### PR TITLE
Add Multi-Location Weather Support

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -126,6 +126,30 @@ class Config:
     
     @classmethod
     @property
+    def WEATHER_LOCATIONS(cls) -> List[Dict[str, str]]:
+        """Weather locations to monitor (list of dicts with location and name)."""
+        feature_config = cls._get_feature("weather")
+        
+        # Check for new locations array format
+        locations = feature_config.get("locations")
+        if locations:
+            if isinstance(locations, list):
+                return locations
+            else:
+                return [locations]
+        
+        # Fallback to old single location format
+        location = feature_config.get("location", "")
+        if location:
+            return [{
+                "location": location,
+                "name": "HOME"  # Default name
+            }]
+        
+        return []
+    
+    @classmethod
+    @property
     def WEATHER_ENABLED(cls) -> bool:
         """Whether weather is enabled."""
         return cls._get_feature("weather").get("enabled", False)

--- a/src/data_sources/weather.py
+++ b/src/data_sources/weather.py
@@ -2,7 +2,7 @@
 
 import logging
 import requests
-from typing import Optional, Dict
+from typing import Optional, Dict, List
 from ..config import Config
 
 logger = logging.getLogger(__name__)
@@ -11,40 +11,95 @@ logger = logging.getLogger(__name__)
 class WeatherSource:
     """Fetches current weather data from weather APIs."""
     
-    def __init__(self, provider: str, api_key: str, location: str):
+    def __init__(self, provider: str, api_key: str, locations: List[Dict[str, str]]):
         """
         Initialize weather source.
         
         Args:
             provider: "weatherapi" or "openweathermap"
             api_key: API key for the weather service
-            location: Location string (city name or lat/lon)
+            locations: List of location dicts with keys:
+                      - location: Location string (city name or lat/lon)
+                      - name: Display name (e.g., "HOME", "OFFICE")
         """
         self.provider = provider
         self.api_key = api_key
-        self.location = location
+        # Support both new (list of locations) and old (single location) format
+        if isinstance(locations, list):
+            self.locations = locations if locations else []
+        else:
+            # Backward compatibility - single location dict or string
+            if isinstance(locations, dict):
+                self.locations = [locations]
+            else:
+                # String location (old format)
+                self.locations = [{"location": locations, "name": "HOME"}]
+        
+        # For backward compatibility
+        if self.locations:
+            self.location = self.locations[0].get("location", "")
     
     def fetch_current_weather(self) -> Optional[Dict[str, any]]:
         """
-        Fetch current weather data.
+        Fetch current weather data (backward compatibility - returns first location).
         
+        Returns:
+            Dictionary with weather data for first location, or None if failed
+        """
+        results = self.fetch_multiple_locations()
+        if results and len(results) > 0:
+            return results[0]
+        return None
+    
+    def fetch_multiple_locations(self) -> List[Dict[str, any]]:
+        """
+        Fetch weather for all configured locations.
+        
+        Returns:
+            List of dictionaries with weather data for each location
+        """
+        if not self.locations:
+            return []
+        
+        results = []
+        for loc_config in self.locations:
+            try:
+                data = self._fetch_single_location(
+                    location=loc_config.get("location", ""),
+                    location_name=loc_config.get("name", "LOCATION")
+                )
+                if data:
+                    results.append(data)
+            except Exception as e:
+                logger.error(f"Error fetching weather for {loc_config.get('name', 'unknown')}: {e}")
+        
+        return results
+    
+    def _fetch_single_location(self, location: str, location_name: str) -> Optional[Dict[str, any]]:
+        """
+        Fetch weather for a single location.
+        
+        Args:
+            location: Location string (city name or lat/lon)
+            location_name: Display name for the location
+            
         Returns:
             Dictionary with weather data, or None if failed
         """
         if self.provider == "weatherapi":
-            return self._fetch_weatherapi()
+            return self._fetch_weatherapi_for_location(location, location_name)
         elif self.provider == "openweathermap":
-            return self._fetch_openweathermap()
+            return self._fetch_openweathermap_for_location(location, location_name)
         else:
             logger.error(f"Unknown weather provider: {self.provider}")
             return None
     
-    def _fetch_weatherapi(self) -> Optional[Dict[str, any]]:
-        """Fetch weather from WeatherAPI.com."""
+    def _fetch_weatherapi_for_location(self, location: str, location_name: str) -> Optional[Dict[str, any]]:
+        """Fetch weather from WeatherAPI.com for a specific location."""
         url = "http://api.weatherapi.com/v1/current.json"
         params = {
             "key": self.api_key,
-            "q": self.location,
+            "q": location,
             "aqi": "no"
         }
         
@@ -60,21 +115,22 @@ class WeatherSource:
                 "humidity": data["current"]["humidity"],
                 "wind_mph": data["current"]["wind_mph"],
                 "wind_speed": data["current"]["wind_mph"],  # Alias for template compatibility
-                "location": data["location"]["name"]
+                "location": data["location"]["name"],
+                "location_name": location_name  # Add display name
             }
             
         except requests.exceptions.RequestException as e:
-            logger.error(f"Failed to fetch weather from WeatherAPI: {e}")
+            logger.error(f"Failed to fetch weather from WeatherAPI for {location_name}: {e}")
             return None
         except KeyError as e:
-            logger.error(f"Unexpected response format from WeatherAPI: {e}")
+            logger.error(f"Unexpected response format from WeatherAPI for {location_name}: {e}")
             return None
     
-    def _fetch_openweathermap(self) -> Optional[Dict[str, any]]:
-        """Fetch weather from OpenWeatherMap."""
+    def _fetch_openweathermap_for_location(self, location: str, location_name: str) -> Optional[Dict[str, any]]:
+        """Fetch weather from OpenWeatherMap for a specific location."""
         url = "https://api.openweathermap.org/data/2.5/weather"
         params = {
-            "q": self.location,
+            "q": location,
             "appid": self.api_key,
             "units": "imperial"
         }
@@ -91,14 +147,15 @@ class WeatherSource:
                 "description": data["weather"][0]["description"],
                 "humidity": data["main"]["humidity"],
                 "wind_mph": data["wind"]["speed"],
-                "wind_speed": data["wind"]["speed"]  # Alias for template compatibility
+                "wind_speed": data["wind"]["speed"],  # Alias for template compatibility
+                "location_name": location_name  # Add display name
             }
             
         except requests.exceptions.RequestException as e:
-            logger.error(f"Failed to fetch weather from OpenWeatherMap: {e}")
+            logger.error(f"Failed to fetch weather from OpenWeatherMap for {location_name}: {e}")
             return None
         except KeyError as e:
-            logger.error(f"Unexpected response format from OpenWeatherMap: {e}")
+            logger.error(f"Unexpected response format from OpenWeatherMap for {location_name}: {e}")
             return None
 
 
@@ -108,9 +165,23 @@ def get_weather_source() -> Optional[WeatherSource]:
         logger.warning("Weather API key not configured")
         return None
     
+    # Support both new (WEATHER_LOCATIONS list) and old (WEATHER_LOCATION) config
+    locations = getattr(Config, 'WEATHER_LOCATIONS', None)
+    
+    if not locations:
+        # Fall back to single location (backward compatibility)
+        location = Config.WEATHER_LOCATION
+        if location:
+            locations = [{
+                "location": location,
+                "name": "HOME"
+            }]
+        else:
+            locations = []
+    
     return WeatherSource(
         provider=Config.WEATHER_PROVIDER,
         api_key=Config.WEATHER_API_KEY,
-        location=Config.WEATHER_LOCATION
+        locations=locations
     )
 

--- a/src/templates/engine.py
+++ b/src/templates/engine.py
@@ -60,7 +60,7 @@ SYMBOL_CHARS = {
 # Available data sources and their fields
 # Fields ending in _color return just the color tile based on color rules
 AVAILABLE_VARIABLES = {
-    "weather": ["temperature", "condition", "humidity", "location", "wind_speed", "temperature_color"],
+    "weather": ["temperature", "condition", "humidity", "location", "wind_speed", "temperature_color", "location_count", "locations"],
     "datetime": ["time", "date", "day", "day_of_week", "month", "year", "hour", "minute"],
     "home_assistant": ["state_color"],  # Dynamic based on entities
     "star_trek": ["quote", "character", "series", "series_color"],
@@ -92,6 +92,27 @@ VARIABLE_MAX_LENGTHS = {
     "weather.location": 15,
     "weather.wind_speed": 3,
     "weather.temperature_color": 4,  # Color tile like {65}
+    # Multi-location weather fields
+    "weather.location_count": 1,
+    "weather.locations.0.temperature": 3,
+    "weather.locations.0.condition": 12,
+    "weather.locations.0.location": 15,
+    "weather.locations.0.location_name": 10,
+    "weather.locations.0.wind_speed": 3,
+    "weather.locations.0.humidity": 3,
+    "weather.locations.0.feels_like": 3,
+    "weather.locations.1.temperature": 3,
+    "weather.locations.1.condition": 12,
+    "weather.locations.1.location": 15,
+    "weather.locations.1.location_name": 10,
+    "weather.locations.1.wind_speed": 3,
+    "weather.locations.1.humidity": 3,
+    "weather.locations.1.feels_like": 3,
+    "weather.locations.2.temperature": 3,
+    "weather.locations.2.condition": 12,
+    "weather.locations.2.location_name": 10,
+    "weather.locations.3.temperature": 3,
+    "weather.locations.3.location_name": 10,
     "datetime.time": 5,
     "datetime.date": 10,
     "datetime.day": 2,

--- a/web/src/components/feature-settings/weather-location-manager.tsx
+++ b/web/src/components/feature-settings/weather-location-manager.tsx
@@ -1,0 +1,150 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { MapPin, Plus, X } from "lucide-react";
+
+interface WeatherLocation {
+  location: string;
+  name: string;
+}
+
+interface WeatherLocationManagerProps {
+  selectedLocations: WeatherLocation[];
+  onLocationsSelected: (locations: WeatherLocation[]) => void;
+  maxLocations?: number;
+}
+
+export function WeatherLocationManager({
+  selectedLocations,
+  onLocationsSelected,
+  maxLocations = 10,
+}: WeatherLocationManagerProps) {
+  const [newLocation, setNewLocation] = useState("");
+  const [newName, setNewName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const handleAdd = () => {
+    if (!newLocation.trim()) {
+      setError("Location is required");
+      return;
+    }
+    if (!newName.trim()) {
+      setError("Name is required");
+      return;
+    }
+    if (selectedLocations.length >= maxLocations) {
+      setError(`Maximum ${maxLocations} locations allowed`);
+      return;
+    }
+
+    const updatedLocations = [
+      ...selectedLocations,
+      { location: newLocation.trim(), name: newName.trim() },
+    ];
+    onLocationsSelected(updatedLocations);
+    setNewLocation("");
+    setNewName("");
+    setError(null);
+  };
+
+  const handleRemove = (index: number) => {
+    const updatedLocations = selectedLocations.filter((_, i) => i !== index);
+    onLocationsSelected(updatedLocations);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-3">
+        <Label className="text-xs font-medium">Add Location</Label>
+        <div className="grid gap-3">
+          <div className="space-y-1.5">
+            <Label className="text-xs text-muted-foreground">
+              Location (City or Coordinates)
+            </Label>
+            <Input
+              type="text"
+              value={newLocation}
+              onChange={(e) => setNewLocation(e.target.value)}
+              placeholder="San Francisco, CA or 37.7749,-122.4194"
+              className="h-9 text-sm"
+            />
+            <p className="text-xs text-muted-foreground">
+              Enter a city name or coordinates in lat,lng format
+            </p>
+          </div>
+          <div className="space-y-1.5">
+            <Label className="text-xs text-muted-foreground">
+              Display Name
+            </Label>
+            <Input
+              type="text"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              placeholder="HOME, OFFICE, etc."
+              className="h-9 text-sm"
+              maxLength={15}
+            />
+            <p className="text-xs text-muted-foreground">
+              Short name for templates (max 15 chars)
+            </p>
+          </div>
+          {error && (
+            <p className="text-xs text-destructive">{error}</p>
+          )}
+          <Button
+            type="button"
+            onClick={handleAdd}
+            variant="outline"
+            size="sm"
+            className="w-full"
+          >
+            <Plus className="h-4 w-4 mr-2" />
+            Add Location
+          </Button>
+        </div>
+      </div>
+
+      {selectedLocations.length > 0 && (
+        <div className="space-y-2">
+          <Label className="text-xs font-medium">
+            Selected Locations ({selectedLocations.length}/{maxLocations})
+          </Label>
+          <div className="space-y-2">
+            {selectedLocations.map((loc, index) => (
+              <div
+                key={index}
+                className="flex items-center justify-between p-2 bg-muted/30 rounded-lg"
+              >
+                <div className="flex items-center gap-2 flex-1 min-w-0">
+                  <Badge variant="outline" className="text-[10px] font-mono px-1.5 shrink-0">
+                    [{index}]
+                  </Badge>
+                  <MapPin className="h-3 w-3 text-muted-foreground shrink-0" />
+                  <div className="flex-1 min-w-0">
+                    <p className="text-xs font-medium truncate">{loc.name}</p>
+                    <p className="text-xs text-muted-foreground truncate" title={loc.location}>
+                      {loc.location}
+                    </p>
+                  </div>
+                </div>
+                <button
+                  onClick={() => handleRemove(index)}
+                  className="ml-2 hover:text-destructive shrink-0"
+                  title="Remove location"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
+            ))}
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Use <code className="bg-muted px-1 rounded">weather.locations.{"{index}"}.temperature</code> in templates (e.g., locations.0, locations.1)
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -273,7 +273,12 @@ export interface WeatherFeatureConfig {
   enabled: boolean;
   api_key: string;
   provider: "weatherapi" | "openweathermap";
-  location: string;
+  location: string;  // Keep for backward compat
+  locations?: Array<{
+    location: string;
+    name: string;
+  }>;
+  refresh_seconds?: number;
 }
 
 export interface DateTimeFeatureConfig {


### PR DESCRIPTION
## Overview
This PR adds support for multiple weather locations, following the same pattern as Baywheels stations and Traffic routes.

## Changes
- **Backend:**
  - Added `locations` array to weather config (backward compatible)
  - Updated `WeatherSource` to fetch multiple locations
  - Modified `DisplayService` to expose location data
  - Added template variables: `weather.locations.N.*`
  
- **Frontend:**
  - Updated TypeScript types for weather config
  - Added locations management UI in feature settings
  - Updated variable picker to show location-specific variables

## Backward Compatibility
- Existing single `location` configs continue to work
- Existing templates using `{{weather.temperature}}` unchanged (uses first location)
- New configs can use `locations` array for multiple locations

## Template Usage
```
{center}WEATHER
HOME: {{weather.locations.0.temperature}}°F
OFFICE: {{weather.locations.1.temperature}}°F
{{weather.locations.0.condition}}
{{weather.locations.1.condition}}
```

## Testing
- [x] Single location (old format) still works
- [x] Multiple locations (new format) works
- [x] Template access to indexed locations
- [x] Backward compatibility of existing templates
- [x] UI for adding/removing locations
- [x] Color rules apply correctly to each location