### PR TITLE
feat: Implement board settings API and fix useBoardSettings hook

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -1822,6 +1822,40 @@ async def update_polling_settings(request: dict):
         raise HTTPException(status_code=400, detail=str(e))
 
 
+@app.get("/settings/board")
+async def get_board_settings():
+    """Get current board display settings."""
+    settings_service = get_settings_service()
+    board = settings_service.get_board_settings()
+    return {
+        "board_type": board.board_type
+    }
+
+
+@app.put("/settings/board")
+async def update_board_settings(request: dict):
+    """
+    Update board display settings.
+    
+    Body should include:
+    - board_type: "black", "white", or null for default
+    """
+    if "board_type" not in request:
+        raise HTTPException(status_code=400, detail="board_type parameter required")
+    
+    settings_service = get_settings_service()
+    
+    try:
+        board_type = request["board_type"]
+        board = settings_service.set_board_type(board_type)
+        return {
+            "status": "success",
+            "settings": board.to_dict()
+        }
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
 # =============================================================================
 # Pages Endpoints
 # =============================================================================

--- a/web/src/components/active-page-display.tsx
+++ b/web/src/components/active-page-display.tsx
@@ -262,7 +262,7 @@ export function ActivePageDisplay() {
             message={displayMessage} 
             isLoading={isLoadingPreview || (!!activePageId && !previewData)}
             size="md"
-            boardType={boardSettings?.board_type || "black"}
+            boardType={boardSettings?.board_type ?? "black"}
           />
         </CardContent>
       </Card>

--- a/web/src/components/page-builder.tsx
+++ b/web/src/components/page-builder.tsx
@@ -41,6 +41,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { api, PageCreate, PageUpdate, PageType } from "@/lib/api";
 import { cn } from "@/lib/utils";
+import { useBoardSettings } from "@/hooks/use-vestaboard";
 
 // Transition strategy display names
 const STRATEGY_LABELS: Record<string, string> = {
@@ -144,6 +145,9 @@ interface PageBuilderProps {
 
 export function PageBuilder({ pageId, onClose, onSave }: PageBuilderProps) {
   const queryClient = useQueryClient();
+
+  // Fetch board settings for display type
+  const { data: boardSettings } = useBoardSettings();
 
   // Form state
   const [name, setName] = useState("");
@@ -575,6 +579,7 @@ export function PageBuilder({ pageId, onClose, onSave }: PageBuilderProps) {
                   message={preview} 
                   isLoading={previewMutation.isPending}
                   size="md"
+                  boardType={boardSettings?.board_type ?? "black"}
                 />
               </div>
 

--- a/web/src/hooks/use-vestaboard.ts
+++ b/web/src/hooks/use-vestaboard.ts
@@ -10,6 +10,7 @@ export const queryKeys = {
   activePage: ["activePage"] as const,
   pages: ["pages"] as const,
   pagePreview: (pageId: string) => ["pagePreview", pageId] as const,
+  boardSettings: ["boardSettings"] as const,
 };
 
 // Status query - refetches every 5 seconds
@@ -105,5 +106,15 @@ export function usePagePreview(pageId: string | null, options?: { enabled?: bool
     enabled: !!pageId && (options?.enabled !== false),
     retry: 1,
     refetchInterval: options?.refetchInterval,
+  });
+}
+
+// Board settings query - for UI display preferences
+export function useBoardSettings() {
+  return useQuery({
+    queryKey: queryKeys.boardSettings,
+    queryFn: api.getBoardSettings,
+    retry: 1,
+    staleTime: 5 * 60 * 1000, // Consider data fresh for 5 minutes
   });
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -422,6 +422,10 @@ export interface PollingSettings {
   interval_seconds: number;
 }
 
+export interface BoardSettings {
+  board_type: "black" | "white" | null;
+}
+
 export interface FullConfig {
   vestaboard: VestaboardConfig;
   features: FeaturesConfig;
@@ -722,6 +726,15 @@ export const api = {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ interval_seconds }),
+    }),
+
+  // Board settings
+  getBoardSettings: () => fetchApi<BoardSettings>("/settings/board"),
+  updateBoardSettings: (board_type: "black" | "white" | null) =>
+    fetchApi<{ status: string; settings: BoardSettings }>("/settings/board", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ board_type }),
     }),
 
   // Home Assistant endpoints


### PR DESCRIPTION
## Problem
The NAS deployment was experiencing a runtime error:
`TypeError: (0,i.useBoardSettings) is not a function. (In '(0,i.useBoardSettings)()', '(0,i.useBoardSettings)' is undefined)`

This was caused by the `useBoardSettings` hook being called in components but never actually implemented in the codebase.

## Solution
Implemented a complete board settings feature across the full stack:

### Backend Changes
- Added `BoardSettings` dataclass to settings service with `board_type` field supporting `"black"`, `"white"`, or `null`
- Created `GET /settings/board` and `PUT /settings/board` API endpoints
- Integrated board settings persistence into `data/settings.json`

### Frontend Changes
- Added `BoardSettings` TypeScript interface to API client
- Implemented `useBoardSettings()` React hook with proper React Query caching
- Updated all components using `VestaboardDisplay` to respect board_type:
  - `active-page-display.tsx` (main display)
  - `page-grid-selector.tsx` (page selection grid)
  - `page-builder.tsx` (page template builder)
- Proper null-safe handling with fallback to `"black"` board type

## Testing
- No linter errors
- All TypeScript types are properly defined
- Null values are safely handled throughout the stack

## Impact
- Fixes the NAS deployment error
- Adds user-configurable board display type setting
- Maintains backward compatibility with default `"black"` board type