### PR TITLE
feat: add stocks monitoring feature

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -84,4 +84,9 @@ When adding a new feature to the project:
 - Document any configuration requirements or setup steps
 - Update relevant sections (Features, Configuration, Usage, etc.) as appropriate
 - Ensure the documentation is clear and accessible to users
+- **MUST document all feature variables (API keys, configuration values, etc.) in `env.example`**
+  - Add environment variable entries with clear descriptions
+  - Include example values where appropriate
+  - Mark optional vs required variables
+  - Follow the existing format and style in `env.example`
 

--- a/env.example
+++ b/env.example
@@ -58,3 +58,12 @@ HOME_ASSISTANT_REFRESH_SECONDS=30
 # Display random Star Trek quotes from TNG, Voyager, and DS9
 STAR_TREK_QUOTES_ENABLED=false
 STAR_TREK_QUOTES_RATIO=3:5:9
+
+# Stocks Configuration
+# Display US stock market prices and percentage changes
+# Get a free Finnhub API key from https://finnhub.io/ (optional - enables better symbol search)
+STOCKS_ENABLED=false
+FINNHUB_API_KEY=your_finnhub_api_key_here  # Optional - enables better symbol search/autocomplete
+STOCKS_SYMBOLS=GOOG  # Comma-separated list of stock symbols (max 5, e.g., "GOOG,AAPL,MSFT,TSLA,NVDA")
+STOCKS_TIME_WINDOW=1 Day  # Options: "1 Day", "5 Days", "1 Month", "3 Months", "6 Months", "1 Year", "2 Years", "5 Years", "ALL"
+STOCKS_REFRESH_SECONDS=300  # How often to fetch stock data (default: 5 minutes)

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,10 @@ pytest>=7.4.0
 pytest-cov>=4.1.0
 httpx>=0.25.0
 
+# Stock market data
+yfinance>=0.2.0
+finnhub-python>=2.4.0
+
 # Optional: Vestaboard Python library (alternative to manual implementation)
 # vesta>=0.1.0
 

--- a/src/config.py
+++ b/src/config.py
@@ -591,6 +591,45 @@ class Config:
             logger.warning(f"Invalid silence schedule time format: {e}")
             return False
     
+    # ==================== Stocks Configuration ====================
+    
+    @classmethod
+    @property
+    def STOCKS_ENABLED(cls) -> bool:
+        """Whether stocks monitoring is enabled."""
+        return cls._get_feature("stocks").get("enabled", False)
+    
+    @classmethod
+    @property
+    def FINNHUB_API_KEY(cls) -> str:
+        """Finnhub API key for stock symbol search (optional)."""
+        return cls._get_feature("stocks").get("finnhub_api_key", "")
+    
+    @classmethod
+    @property
+    def STOCKS_SYMBOLS(cls) -> List[str]:
+        """List of stock symbols to monitor (max 5)."""
+        feature_config = cls._get_feature("stocks")
+        symbols = feature_config.get("symbols", [])
+        if isinstance(symbols, list):
+            # Limit to 5 symbols max
+            return symbols[:5]
+        elif isinstance(symbols, str):
+            return [symbols] if symbols else []
+        return []
+    
+    @classmethod
+    @property
+    def STOCKS_TIME_WINDOW(cls) -> str:
+        """Time window for price comparison (human-readable format)."""
+        return cls._get_feature("stocks").get("time_window", "1 Day")
+    
+    @classmethod
+    @property
+    def STOCKS_REFRESH_SECONDS(cls) -> int:
+        """Stocks data refresh interval in seconds."""
+        return cls._get_feature("stocks").get("refresh_seconds", 300)
+    
     # ==================== Legacy/Unused Configuration ====================
     
     # These are kept for backward compatibility but not actively used
@@ -657,6 +696,7 @@ class Config:
             "surf_enabled": cls.SURF_ENABLED,
             "baywheels_enabled": cls.BAYWHEELS_ENABLED,
             "traffic_enabled": cls.TRAFFIC_ENABLED,
+            "stocks_enabled": cls.STOCKS_ENABLED,
             # Vestaboard config
             "vb_api_mode": cls.VB_API_MODE,
             "vb_host": cls.VB_HOST if cls.VB_API_MODE.lower() == "local" else "cloud",

--- a/src/data_sources/stocks.py
+++ b/src/data_sources/stocks.py
@@ -1,0 +1,502 @@
+"""Stock market data source using yfinance (Yahoo Finance).
+
+Supports multiple stock symbol monitoring with price and percentage change tracking.
+Optional Finnhub integration for symbol search and autocomplete.
+"""
+
+import logging
+import yfinance as yf
+from typing import Optional, Dict, List, Any
+from datetime import datetime, timedelta
+
+logger = logging.getLogger(__name__)
+
+# Time window mapping: human-readable to yfinance period
+TIME_WINDOW_MAP = {
+    "1 Day": "1d",
+    "5 Days": "5d",
+    "1 Month": "1mo",
+    "3 Months": "3mo",
+    "6 Months": "6mo",
+    "1 Year": "1y",
+    "2 Years": "2y",
+    "5 Years": "5y",
+    "ALL": "max",  # All available history
+}
+
+# Popular US stocks for autocomplete (curated list)
+POPULAR_STOCKS = [
+    {"symbol": "AAPL", "name": "Apple Inc."},
+    {"symbol": "GOOG", "name": "Alphabet Inc."},
+    {"symbol": "GOOGL", "name": "Alphabet Inc. Class A"},
+    {"symbol": "MSFT", "name": "Microsoft Corporation"},
+    {"symbol": "AMZN", "name": "Amazon.com Inc."},
+    {"symbol": "TSLA", "name": "Tesla, Inc."},
+    {"symbol": "META", "name": "Meta Platforms Inc."},
+    {"symbol": "NVDA", "name": "NVIDIA Corporation"},
+    {"symbol": "JPM", "name": "JPMorgan Chase & Co."},
+    {"symbol": "V", "name": "Visa Inc."},
+    {"symbol": "JNJ", "name": "Johnson & Johnson"},
+    {"symbol": "WMT", "name": "Walmart Inc."},
+    {"symbol": "PG", "name": "The Procter & Gamble Company"},
+    {"symbol": "MA", "name": "Mastercard Incorporated"},
+    {"symbol": "UNH", "name": "UnitedHealth Group Incorporated"},
+    {"symbol": "HD", "name": "The Home Depot, Inc."},
+    {"symbol": "DIS", "name": "The Walt Disney Company"},
+    {"symbol": "BAC", "name": "Bank of America Corp."},
+    {"symbol": "ADBE", "name": "Adobe Inc."},
+    {"symbol": "NFLX", "name": "Netflix, Inc."},
+    {"symbol": "CRM", "name": "Salesforce, Inc."},
+    {"symbol": "PYPL", "name": "PayPal Holdings, Inc."},
+    {"symbol": "INTC", "name": "Intel Corporation"},
+    {"symbol": "CMCSA", "name": "Comcast Corporation"},
+    {"symbol": "PFE", "name": "Pfizer Inc."},
+    {"symbol": "CSCO", "name": "Cisco Systems, Inc."},
+    {"symbol": "PEP", "name": "PepsiCo, Inc."},
+    {"symbol": "TMO", "name": "Thermo Fisher Scientific Inc."},
+    {"symbol": "COST", "name": "Costco Wholesale Corporation"},
+    {"symbol": "ABBV", "name": "AbbVie Inc."},
+    {"symbol": "AVGO", "name": "Broadcom Inc."},
+    {"symbol": "TXN", "name": "Texas Instruments Incorporated"},
+    {"symbol": "NKE", "name": "Nike, Inc."},
+    {"symbol": "QCOM", "name": "QUALCOMM Incorporated"},
+    {"symbol": "MDT", "name": "Medtronic plc"},
+    {"symbol": "HON", "name": "Honeywell International Inc."},
+    {"symbol": "AMGN", "name": "Amgen Inc."},
+    {"symbol": "SBUX", "name": "Starbucks Corporation"},
+    {"symbol": "BMY", "name": "Bristol-Myers Squibb Company"},
+    {"symbol": "GILD", "name": "Gilead Sciences, Inc."},
+    {"symbol": "LMT", "name": "Lockheed Martin Corporation"},
+    {"symbol": "RTX", "name": "RTX Corporation"},
+    {"symbol": "DE", "name": "Deere & Company"},
+    {"symbol": "CAT", "name": "Caterpillar Inc."},
+    {"symbol": "GE", "name": "General Electric Company"},
+    {"symbol": "F", "name": "Ford Motor Company"},
+    {"symbol": "GM", "name": "General Motors Company"},
+    {"symbol": "XOM", "name": "Exxon Mobil Corporation"},
+    {"symbol": "CVX", "name": "Chevron Corporation"},
+    {"symbol": "COP", "name": "ConocoPhillips"},
+    {"symbol": "SLB", "name": "Schlumberger Limited"},
+    {"symbol": "EOG", "name": "EOG Resources, Inc."},
+    {"symbol": "MPC", "name": "Marathon Petroleum Corporation"},
+    {"symbol": "VLO", "name": "Valero Energy Corporation"},
+    {"symbol": "PSX", "name": "Phillips 66"},
+    {"symbol": "HES", "name": "Hess Corporation"},
+    {"symbol": "MRO", "name": "Marathon Oil Corporation"},
+    {"symbol": "OXY", "name": "Occidental Petroleum Corporation"},
+    {"symbol": "DVN", "name": "Devon Energy Corporation"},
+    {"symbol": "APA", "name": "APA Corporation"},
+    {"symbol": "FANG", "name": "Diamondback Energy, Inc."},
+    {"symbol": "CTRA", "name": "Coterra Energy Inc."},
+    {"symbol": "PR", "name": "Permian Resources Corporation"},
+    {"symbol": "MTCH", "name": "Match Group, Inc."},
+    {"symbol": "LYFT", "name": "Lyft, Inc."},
+    {"symbol": "UBER", "name": "Uber Technologies, Inc."},
+    {"symbol": "DASH", "name": "DoorDash, Inc."},
+    {"symbol": "GRAB", "name": "Grab Holdings Limited"},
+    {"symbol": "SPOT", "name": "Spotify Technology S.A."},
+    {"symbol": "SNAP", "name": "Snap Inc."},
+    {"symbol": "TWTR", "name": "Twitter, Inc."},
+    {"symbol": "PINS", "name": "Pinterest, Inc."},
+    {"symbol": "ROKU", "name": "Roku, Inc."},
+    {"symbol": "ZM", "name": "Zoom Video Communications, Inc."},
+    {"symbol": "DOCN", "name": "DigitalOcean Holdings, Inc."},
+    {"symbol": "SNOW", "name": "Snowflake Inc."},
+    {"symbol": "NET", "name": "Cloudflare, Inc."},
+    {"symbol": "CRWD", "name": "CrowdStrike Holdings, Inc."},
+    {"symbol": "ZS", "name": "Zscaler, Inc."},
+    {"symbol": "OKTA", "name": "Okta, Inc."},
+    {"symbol": "FTNT", "name": "Fortinet, Inc."},
+    {"symbol": "PANW", "name": "Palo Alto Networks, Inc."},
+    {"symbol": "CHKP", "name": "Check Point Software Technologies Ltd."},
+    {"symbol": "VRSN", "name": "VeriSign, Inc."},
+    {"symbol": "AKAM", "name": "Akamai Technologies, Inc."},
+    {"symbol": "FFIV", "name": "F5, Inc."},
+    {"symbol": "JNPR", "name": "Juniper Networks, Inc."},
+    {"symbol": "ANET", "name": "Arista Networks, Inc."},
+    {"symbol": "NTNX", "name": "Nutanix, Inc."},
+    {"symbol": "VEEV", "name": "Veeva Systems Inc."},
+    {"symbol": "WDAY", "name": "Workday, Inc."},
+    {"symbol": "NOW", "name": "ServiceNow, Inc."},
+    {"symbol": "TEAM", "name": "Atlassian Corporation"},
+    {"symbol": "ASAN", "name": "Asana, Inc."},
+    {"symbol": "MDB", "name": "MongoDB, Inc."},
+    {"symbol": "ESTC", "name": "Elastic N.V."},
+    {"symbol": "SPLK", "name": "Splunk Inc."},
+    {"symbol": "NEWR", "name": "New Relic, Inc."},
+    {"symbol": "DT", "name": "Dynatrace, Inc."},
+    {"symbol": "PD", "name": "PagerDuty, Inc."},
+    {"symbol": "QLYS", "name": "Qualys, Inc."},
+    {"symbol": "RPD", "name": "Rapid7, Inc."},
+    {"symbol": "TENB", "name": "Tenable Holdings, Inc."},
+    {"symbol": "VRRM", "name": "Verra Mobility Corporation"},
+    {"symbol": "ALRM", "name": "Alarm.com Holdings, Inc."},
+]
+
+
+class StocksSource:
+    """Fetches stock market data using yfinance."""
+    
+    def __init__(
+        self,
+        symbols: List[str],
+        time_window: str,
+        finnhub_api_key: Optional[str] = None
+    ):
+        """
+        Initialize stocks source.
+        
+        Args:
+            symbols: List of stock symbols to monitor (max 5)
+            time_window: Human-readable time window (e.g., "1 Day", "ALL")
+            finnhub_api_key: Optional Finnhub API key for symbol search
+        """
+        # Limit to 5 symbols max
+        if isinstance(symbols, list):
+            self.symbols = symbols[:5] if len(symbols) > 5 else symbols
+        elif isinstance(symbols, str):
+            self.symbols = [symbols] if symbols else []
+        else:
+            self.symbols = []
+        
+        self.time_window = time_window
+        self.finnhub_api_key = finnhub_api_key
+    
+    @staticmethod
+    def _map_time_window_to_yfinance(time_window: str) -> str:
+        """
+        Map human-readable time window to yfinance period.
+        
+        Args:
+            time_window: Human-readable format (e.g., "1 Day", "ALL")
+            
+        Returns:
+            yfinance period string (e.g., "1d", "max")
+        """
+        return TIME_WINDOW_MAP.get(time_window, "1d")
+    
+    @staticmethod
+    def _format_price(price: float) -> str:
+        """
+        Format price to always show 2 decimal places.
+        
+        Args:
+            price: Price value
+            
+        Returns:
+            Formatted price string (e.g., "150.25")
+        """
+        return f"{price:.2f}"
+    
+    @staticmethod
+    def _format_percentage(change_percent: float) -> str:
+        """
+        Format percentage change with + or - sign.
+        
+        Args:
+            change_percent: Percentage change (positive or negative)
+            
+        Returns:
+            Formatted percentage string (e.g., "+1.18%" or "-2.34%")
+        """
+        sign = "+" if change_percent >= 0 else ""
+        return f"{sign}{change_percent:.2f}%"
+    
+    def fetch_stocks_data(self) -> List[Dict[str, Any]]:
+        """
+        Fetch stock data for all configured symbols with aligned formatting.
+        
+        Returns:
+            List of dictionaries with stock data for each symbol
+        """
+        if not self.symbols:
+            return []
+        
+        # First pass: fetch all stock data
+        raw_results = []
+        yfinance_period = self._map_time_window_to_yfinance(self.time_window)
+        
+        for symbol in self.symbols:
+            try:
+                stock_data = self._fetch_single_stock(symbol, yfinance_period)
+                if stock_data:
+                    raw_results.append(stock_data)
+            except Exception as e:
+                logger.error(f"Error fetching stock data for {symbol}: {e}")
+                continue
+        
+        if not raw_results:
+            return []
+        
+        # Calculate max widths for alignment
+        max_price_width = 0
+        max_percent_width = 0
+        
+        for stock in raw_results:
+            current_price_str = self._format_price(stock["current_price"])
+            change_percent_str = self._format_percentage(stock["change_percent"])
+            
+            # Price width includes "$" and space: "$ 1234.56" = 8 chars
+            price_width = len(f"${current_price_str}")
+            max_price_width = max(max_price_width, price_width)
+            
+            # Percentage width: "+12.34%" = 7 chars
+            percent_width = len(change_percent_str)
+            max_percent_width = max(max_percent_width, percent_width)
+        
+        # Second pass: apply aligned formatting
+        results = []
+        for stock in raw_results:
+            current_price_str = self._format_price(stock["current_price"])
+            change_percent_str = self._format_percentage(stock["change_percent"])
+            
+            # Right-align price and percentage
+            price_aligned = f"${current_price_str}".rjust(max_price_width)
+            percent_aligned = change_percent_str.rjust(max_percent_width)
+            
+            # Rebuild formatted string with aligned values
+            color_tile = stock.get("color_tile", "{white}")
+            symbol = stock["symbol"]
+            formatted = f"{symbol}{color_tile} {price_aligned} {percent_aligned}"
+            
+            # Update stock data with aligned formatted string
+            stock["formatted"] = formatted
+            results.append(stock)
+        
+        return results
+    
+    def _fetch_single_stock(self, symbol: str, period: str) -> Optional[Dict[str, Any]]:
+        """
+        Fetch data for a single stock symbol.
+        
+        Args:
+            symbol: Stock symbol (e.g., "GOOG")
+            period: yfinance period string (e.g., "1d", "max")
+            
+        Returns:
+            Dictionary with stock data, or None if failed
+        """
+        try:
+            ticker = yf.Ticker(symbol)
+            
+            # Get current price (latest available)
+            info = ticker.info
+            current_price = info.get("regularMarketPrice") or info.get("currentPrice")
+            
+            if current_price is None:
+                logger.warning(f"No current price available for {symbol}")
+                return None
+            
+            # Get historical data for comparison
+            hist = ticker.history(period=period)
+            
+            if hist.empty:
+                logger.warning(f"No historical data available for {symbol} with period {period}")
+                return None
+            
+            # Get previous price (first price in the period)
+            previous_price = float(hist.iloc[0]["Close"])
+            current_price = float(current_price)
+            
+            # Calculate percentage change
+            if previous_price > 0:
+                change_percent = ((current_price - previous_price) / previous_price) * 100
+            else:
+                change_percent = 0.0
+            
+            # Determine direction
+            change_direction = "up" if change_percent >= 0 else "down"
+            
+            # Format values
+            current_price_str = self._format_price(current_price)
+            previous_price_str = self._format_price(previous_price)
+            change_percent_str = self._format_percentage(change_percent)
+            
+            # Determine color based on percentage change
+            if change_percent > 0:
+                color_tile = "{green}"
+            elif change_percent < 0:
+                color_tile = "{red}"
+            else:
+                color_tile = "{white}"
+            
+            # Create initial formatted display string (will be realigned in fetch_stocks_data)
+            # Format: <SYMBOL><COLOR> $<CURRENT_PRICE> <PERCENTAGE_CHANGE_SIGN><PERCENTAGE_CHANGE>
+            # Note: No parentheses around percentage to save 2 tiles for prices > $1000
+            formatted = f"{symbol}{color_tile} ${current_price_str} {change_percent_str}"
+            
+            # Get company name if available
+            company_name = info.get("longName") or info.get("shortName") or symbol
+            
+            return {
+                "symbol": symbol,
+                "current_price": current_price,
+                "previous_price": previous_price,
+                "change_percent": change_percent,  # Raw number (positive or negative)
+                "change_direction": change_direction,
+                "formatted": formatted,  # Will be updated with alignment in fetch_stocks_data
+                "color_tile": color_tile,  # Store color_tile for alignment step
+                "company_name": company_name,
+            }
+            
+        except Exception as e:
+            logger.error(f"Error fetching stock data for {symbol}: {e}", exc_info=True)
+            return None
+    
+    @staticmethod
+    def validate_symbol(symbol: str) -> Dict[str, Any]:
+        """
+        Validate if a stock symbol is valid using yfinance.
+        
+        Args:
+            symbol: Stock symbol to validate
+            
+        Returns:
+            Dictionary with validation result:
+            {
+                "valid": bool,
+                "symbol": str,
+                "name": str (if valid),
+                "error": str (if invalid)
+            }
+        """
+        if not symbol or not symbol.strip():
+            return {
+                "valid": False,
+                "symbol": symbol,
+                "error": "Empty symbol"
+            }
+        
+        symbol = symbol.strip().upper()
+        
+        try:
+            ticker = yf.Ticker(symbol)
+            info = ticker.info
+            
+            # Check if we got valid data (invalid symbols return empty info or error)
+            if not info or "symbol" not in info:
+                return {
+                    "valid": False,
+                    "symbol": symbol,
+                    "error": "Symbol not found"
+                }
+            
+            # Try to get price to confirm it's valid
+            current_price = info.get("regularMarketPrice") or info.get("currentPrice")
+            if current_price is None:
+                return {
+                    "valid": False,
+                    "symbol": symbol,
+                    "error": "No price data available"
+                }
+            
+            # Get company name
+            company_name = info.get("longName") or info.get("shortName") or symbol
+            
+            return {
+                "valid": True,
+                "symbol": symbol,
+                "name": company_name
+            }
+            
+        except Exception as e:
+            logger.debug(f"Symbol validation failed for {symbol}: {e}")
+            return {
+                "valid": False,
+                "symbol": symbol,
+                "error": str(e)
+            }
+    
+    @staticmethod
+    def search_symbols(query: str, limit: int = 10, finnhub_api_key: Optional[str] = None) -> List[Dict[str, str]]:
+        """
+        Search for stock symbols by query.
+        
+        Uses Finnhub API if key is provided, otherwise searches curated list.
+        
+        Args:
+            query: Search query (symbol or company name)
+            limit: Maximum number of results
+            finnhub_api_key: Optional Finnhub API key
+            
+        Returns:
+            List of dictionaries with symbol and name:
+            [{"symbol": "GOOG", "name": "Alphabet Inc."}, ...]
+        """
+        query = query.strip().upper()
+        if not query:
+            return []
+        
+        results = []
+        
+        # Try Finnhub API if key is provided
+        if finnhub_api_key:
+            try:
+                import finnhub
+                # finnhub-python package uses Client class
+                finnhub_client = finnhub.Client(api_key=finnhub_api_key)
+                search_results = finnhub_client.symbol_lookup(query)
+                
+                if search_results and "result" in search_results:
+                    for item in search_results["result"][:limit]:
+                        # Filter to US stocks only (type == "Common Stock" and exchange in US exchanges)
+                        if item.get("type") == "Common Stock":
+                            symbol = item.get("symbol", "")
+                            description = item.get("description", "")
+                            if symbol and description:
+                                results.append({
+                                    "symbol": symbol,
+                                    "name": description
+                                })
+                
+                if results:
+                    return results[:limit]
+            except Exception as e:
+                logger.debug(f"Finnhub search failed, falling back to curated list: {e}")
+        
+        # Fall back to curated list search
+        query_lower = query.lower()
+        for stock in POPULAR_STOCKS:
+            if len(results) >= limit:
+                break
+            
+            symbol = stock["symbol"]
+            name = stock["name"]
+            
+            # Match if query is in symbol or name (case-insensitive)
+            if query_lower in symbol.lower() or query_lower in name.lower():
+                results.append({
+                    "symbol": symbol,
+                    "name": name
+                })
+        
+        return results[:limit]
+
+
+# Singleton instance
+_stocks_source: Optional[StocksSource] = None
+
+
+def get_stocks_source() -> Optional[StocksSource]:
+    """Get or create the stocks source singleton."""
+    global _stocks_source
+    from ..config import Config
+    
+    if not Config.STOCKS_ENABLED:
+        return None
+    
+    if _stocks_source is None:
+        _stocks_source = StocksSource(
+            symbols=Config.STOCKS_SYMBOLS,
+            time_window=Config.STOCKS_TIME_WINDOW,
+            finnhub_api_key=Config.FINNHUB_API_KEY if Config.FINNHUB_API_KEY else None
+        )
+    
+    return _stocks_source
+
+
+def reset_stocks_source() -> None:
+    """Reset the stocks source singleton."""
+    global _stocks_source
+    _stocks_source = None
+

--- a/src/formatters/message_formatter.py
+++ b/src/formatters/message_formatter.py
@@ -469,6 +469,35 @@ class MessageFormatter:
         return "\n".join(lines[:self.MAX_ROWS])
 
 
+    def format_stocks(self, stocks_data: Dict) -> str:
+        """
+        Format stocks data for display.
+        
+        Args:
+            stocks_data: Dictionary with stocks information
+            
+        Returns:
+            Formatted string (max 6 lines)
+        """
+        if not stocks_data:
+            return "Stocks: Unavailable"
+        
+        stocks = stocks_data.get("stocks", [])
+        if not stocks:
+            return "Stocks: No data available"
+        
+        lines = []
+        
+        # Display up to 4 stocks (one per line, or combine if space allows)
+        for stock in stocks[:4]:
+            formatted = stock.get("formatted", "")
+            if formatted:
+                lines.append(formatted)
+        
+        # Ensure we don't exceed 6 rows
+        return "\n".join(lines[:self.MAX_ROWS])
+
+
 def get_message_formatter() -> MessageFormatter:
     """Get message formatter instance."""
     return MessageFormatter()

--- a/src/templates/engine.py
+++ b/src/templates/engine.py
@@ -81,6 +81,10 @@ AVAILABLE_VARIABLES = {
         "duration_minutes", "delay_minutes", "traffic_status", "traffic_color", "destination_name", "formatted",
         "route_count", "worst_delay", "routes"
     ],
+    "stocks": [
+        "symbol", "current_price", "previous_price", "change_percent", "change_direction", "formatted", "company_name",
+        "symbol_count", "stocks"
+    ],
 }
 
 # Maximum character lengths for each variable (for validation)
@@ -218,6 +222,34 @@ VARIABLE_MAX_LENGTHS = {
     "traffic.routes.3.duration_minutes": 3,
     "traffic.routes.3.destination_name": 10,
     "traffic.routes.3.formatted": 22,
+    "stocks.symbol": 5,
+    "stocks.current_price": 8,
+    "stocks.previous_price": 8,
+    "stocks.change_percent": 6,
+    "stocks.change_direction": 4,
+    "stocks.formatted": 22,
+    "stocks.company_name": 20,
+    "stocks.symbol_count": 1,
+    "stocks.stocks.0.symbol": 5,
+    "stocks.stocks.0.current_price": 8,
+    "stocks.stocks.0.change_percent": 6,
+    "stocks.stocks.0.formatted": 22,
+    "stocks.stocks.1.symbol": 5,
+    "stocks.stocks.1.current_price": 8,
+    "stocks.stocks.1.change_percent": 6,
+    "stocks.stocks.1.formatted": 22,
+    "stocks.stocks.2.symbol": 5,
+    "stocks.stocks.2.current_price": 8,
+    "stocks.stocks.2.change_percent": 6,
+    "stocks.stocks.2.formatted": 22,
+    "stocks.stocks.3.symbol": 5,
+    "stocks.stocks.3.current_price": 8,
+    "stocks.stocks.3.change_percent": 6,
+    "stocks.stocks.3.formatted": 22,
+    "stocks.stocks.4.symbol": 5,
+    "stocks.stocks.4.current_price": 8,
+    "stocks.stocks.4.change_percent": 6,
+    "stocks.stocks.4.formatted": 22,
 }
 
 # Regex patterns
@@ -585,7 +617,7 @@ class TemplateEngine:
         context = {}
         
         # Fetch from each source
-        sources = ["weather", "datetime", "home_assistant", "star_trek", "guest_wifi", "air_fog", "muni", "surf", "baywheels", "traffic"]
+        sources = ["weather", "datetime", "home_assistant", "star_trek", "guest_wifi", "air_fog", "muni", "surf", "baywheels", "traffic", "stocks"]
         
         for source in sources:
             try:
@@ -666,6 +698,7 @@ class TemplateEngine:
             "surf": "surf",
             "baywheels": "baywheels",
             "traffic": "traffic",
+            "stocks": "stocks",
         }
         
         feature_name = feature_map.get(source)
@@ -928,6 +961,7 @@ class TemplateEngine:
             "surf": "surf",
             "baywheels": "baywheels",
             "traffic": "traffic",
+            "stocks": "stocks",
         }
         
         feature_name = feature_map.get(source)
@@ -1167,7 +1201,7 @@ class TemplateEngine:
             List of source names that are configured
         """
         available = []
-        sources = ["weather", "datetime", "home_assistant", "star_trek", "guest_wifi", "air_fog", "muni", "surf", "baywheels", "traffic"]
+        sources = ["weather", "datetime", "home_assistant", "star_trek", "guest_wifi", "air_fog", "muni", "surf", "baywheels", "traffic", "stocks"]
         
         for source in sources:
             try:
@@ -1281,6 +1315,7 @@ class TemplateEngine:
                     "surf": "surf",
                     "baywheels": "baywheels",
                     "traffic": "traffic",
+                    "stocks": "stocks",
                 }
                 feature = feature_map.get(source)
                 if feature:

--- a/tests/test_stocks.py
+++ b/tests/test_stocks.py
@@ -1,0 +1,389 @@
+"""Unit tests for Stocks data source."""
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from src.data_sources.stocks import StocksSource, TIME_WINDOW_MAP, POPULAR_STOCKS
+
+
+class TestStocksSource:
+    """Test Stocks data source."""
+    
+    def test_init(self):
+        """Test source initialization."""
+        source = StocksSource(
+            symbols=["GOOG", "AAPL"],
+            time_window="1 Day",
+            finnhub_api_key=""
+        )
+        assert source.symbols == ["GOOG", "AAPL"]
+        assert source.time_window == "1 Day"
+        assert source.finnhub_api_key == ""
+    
+    def test_init_single_symbol(self):
+        """Test initialization with single symbol string."""
+        source = StocksSource(
+            symbols="GOOG",
+            time_window="1 Day"
+        )
+        assert source.symbols == ["GOOG"]
+    
+    def test_init_max_symbols(self):
+        """Test that symbols are limited to 5 max."""
+        source = StocksSource(
+            symbols=["GOOG", "AAPL", "MSFT", "TSLA", "AMZN", "META"],  # 6 symbols
+            time_window="1 Day"
+        )
+        assert len(source.symbols) == 5
+        assert source.symbols == ["GOOG", "AAPL", "MSFT", "TSLA", "AMZN"]
+    
+    def test_init_empty_symbols(self):
+        """Test initialization with empty symbols."""
+        source = StocksSource(symbols=[], time_window="1 Day")
+        assert source.symbols == []
+    
+    def test_time_window_mapping(self):
+        """Test time window to yfinance period mapping."""
+        source = StocksSource(symbols=["GOOG"], time_window="1 Day")
+        assert source._map_time_window_to_yfinance("1 Day") == "1d"
+        assert source._map_time_window_to_yfinance("5 Days") == "5d"
+        assert source._map_time_window_to_yfinance("1 Month") == "1mo"
+        assert source._map_time_window_to_yfinance("ALL") == "max"
+        assert source._map_time_window_to_yfinance("Unknown") == "1d"  # Default
+    
+    def test_format_price(self):
+        """Test price formatting to 2 decimal places."""
+        assert StocksSource._format_price(150.25) == "150.25"
+        assert StocksSource._format_price(1234.567) == "1234.57"  # Rounded
+        assert StocksSource._format_price(0.99) == "0.99"
+        assert StocksSource._format_price(1000.0) == "1000.00"
+    
+    def test_format_percentage(self):
+        """Test percentage formatting with + or - sign."""
+        assert StocksSource._format_percentage(1.18) == "+1.18%"
+        assert StocksSource._format_percentage(-2.34) == "-2.34%"
+        assert StocksSource._format_percentage(0.0) == "+0.00%"
+        assert StocksSource._format_percentage(12.5) == "+12.50%"
+        assert StocksSource._format_percentage(-0.01) == "-0.01%"
+    
+    @patch('src.data_sources.stocks.yf.Ticker')
+    def test_fetch_single_stock_success(self, mock_ticker_class):
+        """Test successful single stock data fetch."""
+        # Mock yfinance Ticker
+        mock_ticker = MagicMock()
+        mock_ticker.info = {
+            "regularMarketPrice": 150.25,
+            "longName": "Alphabet Inc."
+        }
+        
+        # Mock historical data
+        import pandas as pd
+        mock_hist = pd.DataFrame({
+            "Close": [148.07, 149.50, 150.25]
+        })
+        mock_ticker.history.return_value = mock_hist
+        
+        mock_ticker_class.return_value = mock_ticker
+        
+        source = StocksSource(symbols=["GOOG"], time_window="1 Day")
+        result = source._fetch_single_stock("GOOG", "1d")
+        
+        assert result is not None
+        assert result["symbol"] == "GOOG"
+        assert result["current_price"] == 150.25
+        assert result["previous_price"] == 148.07
+        assert result["change_percent"] == pytest.approx(1.47, abs=0.01)  # (150.25 - 148.07) / 148.07 * 100
+        assert result["change_direction"] == "up"
+        assert result["company_name"] == "Alphabet Inc."
+        assert "{green}" in result["formatted"]  # Positive change = green
+        assert "GOOG" in result["formatted"]
+        assert "150.25" in result["formatted"]
+    
+    @patch('src.data_sources.stocks.yf.Ticker')
+    def test_fetch_single_stock_negative_change(self, mock_ticker_class):
+        """Test stock with negative change (red color)."""
+        mock_ticker = MagicMock()
+        mock_ticker.info = {
+            "regularMarketPrice": 100.0,
+            "longName": "Test Corp"
+        }
+        
+        import pandas as pd
+        mock_hist = pd.DataFrame({
+            "Close": [110.0, 105.0, 100.0]
+        })
+        mock_ticker.history.return_value = mock_hist
+        mock_ticker_class.return_value = mock_ticker
+        
+        source = StocksSource(symbols=["TEST"], time_window="1 Day")
+        result = source._fetch_single_stock("TEST", "1d")
+        
+        assert result is not None
+        assert result["change_percent"] < 0
+        assert result["change_direction"] == "down"
+        assert "{red}" in result["formatted"]
+    
+    @patch('src.data_sources.stocks.yf.Ticker')
+    def test_fetch_single_stock_zero_change(self, mock_ticker_class):
+        """Test stock with zero change (white color)."""
+        mock_ticker = MagicMock()
+        mock_ticker.info = {
+            "regularMarketPrice": 100.0,
+            "longName": "Test Corp"
+        }
+        
+        import pandas as pd
+        mock_hist = pd.DataFrame({
+            "Close": [100.0, 100.0, 100.0]
+        })
+        mock_ticker.history.return_value = mock_hist
+        mock_ticker_class.return_value = mock_ticker
+        
+        source = StocksSource(symbols=["TEST"], time_window="1 Day")
+        result = source._fetch_single_stock("TEST", "1d")
+        
+        assert result is not None
+        assert result["change_percent"] == pytest.approx(0.0, abs=0.01)
+        assert result["change_direction"] == "up"  # 0 is considered "up"
+        assert "{white}" in result["formatted"]
+    
+    @patch('src.data_sources.stocks.yf.Ticker')
+    def test_fetch_single_stock_no_price(self, mock_ticker_class):
+        """Test stock with no current price available."""
+        mock_ticker = MagicMock()
+        mock_ticker.info = {}  # No price info
+        mock_ticker_class.return_value = mock_ticker
+        
+        source = StocksSource(symbols=["INVALID"], time_window="1 Day")
+        result = source._fetch_single_stock("INVALID", "1d")
+        
+        assert result is None
+    
+    @patch('src.data_sources.stocks.yf.Ticker')
+    def test_fetch_single_stock_no_history(self, mock_ticker_class):
+        """Test stock with no historical data."""
+        mock_ticker = MagicMock()
+        mock_ticker.info = {"regularMarketPrice": 100.0}
+        
+        import pandas as pd
+        mock_ticker.history.return_value = pd.DataFrame()  # Empty DataFrame
+        mock_ticker_class.return_value = mock_ticker
+        
+        source = StocksSource(symbols=["TEST"], time_window="1 Day")
+        result = source._fetch_single_stock("TEST", "1d")
+        
+        assert result is None
+    
+    @patch('src.data_sources.stocks.yf.Ticker')
+    def test_fetch_stocks_data_alignment(self, mock_ticker_class):
+        """Test that multiple stocks are aligned in columns."""
+        # Mock different stocks with different price ranges
+        def create_mock_ticker(symbol, current_price, previous_price):
+            mock_ticker = MagicMock()
+            mock_ticker.info = {
+                "regularMarketPrice": current_price,
+                "longName": f"{symbol} Corp"
+            }
+            
+            import pandas as pd
+            mock_hist = pd.DataFrame({
+                "Close": [previous_price, current_price * 0.99, current_price]
+            })
+            mock_ticker.history.return_value = mock_hist
+            return mock_ticker
+        
+        # Setup mocks for different price ranges
+        mock_ticker_class.side_effect = [
+            create_mock_ticker("GOOG", 1234.56, 1200.0),  # High price
+            create_mock_ticker("AAPL", 273.08, 270.0),   # Medium price
+            create_mock_ticker("TSLA", 45.43, 44.0),     # Lower price
+        ]
+        
+        source = StocksSource(
+            symbols=["GOOG", "AAPL", "TSLA"],
+            time_window="1 Day"
+        )
+        
+        results = source.fetch_stocks_data()
+        
+        assert len(results) == 3
+        
+        # Check that all formatted strings have aligned prices and percentages
+        formatted_strings = [r["formatted"] for r in results]
+        
+        # Format: SYMBOL{color} $PRICE PERCENTAGE
+        # After alignment with rjust, prices and percentages should have consistent widths
+        # The rjust adds leading spaces, so we need to extract the full aligned sections
+        
+        price_widths = []
+        percent_widths = []
+        
+        for fmt in formatted_strings:
+            # Format: SYMBOL{color} $PRICE PERCENTAGE
+            # Find the closing brace of color tile (e.g., {green} ends at })
+            color_end = fmt.find("}")
+            if color_end == -1:
+                continue
+            
+            # The space after color tile is right after the }
+            space_after_color = color_end + 1
+            if space_after_color >= len(fmt) or fmt[space_after_color] != " ":
+                continue
+            
+            # Find $ which marks where the actual price starts (may have leading spaces before it from rjust)
+            dollar_idx = fmt.find("$", space_after_color)
+            if dollar_idx == -1:
+                continue
+            
+            # Find the space after the price (before percentage)
+            space_after_price = fmt.find(" ", dollar_idx)
+            if space_after_price == -1:
+                continue
+            
+            # Extract the full price section (from space after color to space after price)
+            # This includes any leading spaces from rjust padding
+            price_section = fmt[space_after_color + 1:space_after_price]
+            price_widths.append(len(price_section))
+            
+            # Find % to get percentage section
+            percent_idx = fmt.find("%", space_after_price)
+            if percent_idx != -1:
+                # Extract percentage section (from space after price to %)
+                # This may also include leading spaces from rjust
+                percent_section = fmt[space_after_price + 1:percent_idx + 1]
+                percent_widths.append(len(percent_section))
+        
+        # Debug: print the actual strings to verify alignment
+        # All prices should have the same width (right-aligned with rjust padding)
+        assert len(set(price_widths)) == 1, (
+            f"Prices should be aligned (widths: {price_widths}, "
+            f"formatted strings: {formatted_strings})"
+        )
+        
+        # All percentages should have the same width (right-aligned with rjust padding)
+        assert len(set(percent_widths)) == 1, (
+            f"Percentages should be aligned (widths: {percent_widths}, "
+            f"formatted strings: {formatted_strings})"
+        )
+        
+        # Verify the formatted strings contain expected elements
+        assert any("GOOG" in f for f in formatted_strings)
+        assert any("AAPL" in f for f in formatted_strings)
+        assert any("TSLA" in f for f in formatted_strings)
+    
+    @patch('src.data_sources.stocks.yf.Ticker')
+    def test_fetch_stocks_data_empty_symbols(self, mock_ticker_class):
+        """Test fetch with empty symbols list."""
+        source = StocksSource(symbols=[], time_window="1 Day")
+        results = source.fetch_stocks_data()
+        
+        assert results == []
+        mock_ticker_class.assert_not_called()
+    
+    @patch('src.data_sources.stocks.yf.Ticker')
+    def test_fetch_stocks_data_partial_failure(self, mock_ticker_class):
+        """Test fetch when some symbols fail."""
+        def create_mock_ticker(symbol, current_price, previous_price, has_price=True, has_history=True):
+            mock_ticker = MagicMock()
+            if has_price:
+                mock_ticker.info = {
+                    "regularMarketPrice": current_price,
+                    "longName": f"{symbol} Corp"
+                }
+            else:
+                mock_ticker.info = {}
+            
+            import pandas as pd
+            if has_history:
+                mock_hist = pd.DataFrame({
+                    "Close": [previous_price, current_price * 0.99, current_price]
+                })
+            else:
+                mock_hist = pd.DataFrame()
+            mock_ticker.history.return_value = mock_hist
+            return mock_ticker
+        
+        mock_ticker_class.side_effect = [
+            create_mock_ticker("GOOG", 150.0, 148.0, has_price=True, has_history=True),
+            create_mock_ticker("INVALID", 0, 0, has_price=False, has_history=False),  # Fails
+            create_mock_ticker("AAPL", 200.0, 198.0, has_price=True, has_history=True),
+        ]
+        
+        source = StocksSource(
+            symbols=["GOOG", "INVALID", "AAPL"],
+            time_window="1 Day"
+        )
+        
+        results = source.fetch_stocks_data()
+        
+        # Should return 2 successful results, skipping the invalid one
+        assert len(results) == 2
+        assert results[0]["symbol"] == "GOOG"
+        assert results[1]["symbol"] == "AAPL"
+    
+    def test_validate_symbol_success(self):
+        """Test symbol validation with valid symbol."""
+        with patch('src.data_sources.stocks.yf.Ticker') as mock_ticker_class:
+            mock_ticker = MagicMock()
+            mock_ticker.info = {
+                "symbol": "GOOG",
+                "longName": "Alphabet Inc.",
+                "regularMarketPrice": 150.25  # Need price for validation
+            }
+            mock_ticker_class.return_value = mock_ticker
+            
+            result = StocksSource.validate_symbol("GOOG")
+            
+            assert result["valid"] is True
+            assert result["symbol"] == "GOOG"
+            assert "Alphabet" in result.get("name", "")
+    
+    def test_validate_symbol_invalid(self):
+        """Test symbol validation with invalid symbol."""
+        with patch('src.data_sources.stocks.yf.Ticker') as mock_ticker_class:
+            mock_ticker = MagicMock()
+            mock_ticker.info = {}  # Empty info = invalid
+            mock_ticker_class.return_value = mock_ticker
+            
+            result = StocksSource.validate_symbol("INVALID")
+            
+            assert result["valid"] is False
+            assert result["symbol"] == "INVALID"
+    
+    def test_search_symbols_curated_list(self):
+        """Test symbol search using curated list (no Finnhub)."""
+        source = StocksSource(
+            symbols=[],
+            time_window="1 Day",
+            finnhub_api_key=""  # No API key
+        )
+        
+        results = source.search_symbols("AAP")
+        
+        # Should find AAPL in curated list
+        assert len(results) > 0
+        assert any(r["symbol"] == "AAPL" for r in results)
+        assert any("Apple" in r.get("name", "") for r in results)
+    
+    def test_search_symbols_no_results(self):
+        """Test symbol search with no matches."""
+        source = StocksSource(
+            symbols=[],
+            time_window="1 Day",
+            finnhub_api_key=""
+        )
+        
+        results = source.search_symbols("ZZZZZZZ")
+        
+        assert results == []
+    
+    def test_search_symbols_with_finnhub_skipped(self):
+        """Test symbol search with Finnhub API - skipped due to complex mocking."""
+        # Note: Finnhub integration is tested via integration tests
+        # Unit tests focus on curated list functionality
+        pass
+    
+    def test_search_symbols_finnhub_fallback_skipped(self):
+        """Test that search falls back to curated list if Finnhub fails - skipped."""
+        # Note: Finnhub fallback is tested via integration tests
+        pass
+

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "dependencies": {
         "@radix-ui/react-accordion": "^1.2.2",
         "@radix-ui/react-alert-dialog": "^1.1.4",
@@ -164,7 +164,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2047,7 +2046,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2091,7 +2089,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5661,7 +5658,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -5799,7 +5797,6 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5810,7 +5807,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -5881,7 +5877,6 @@
       "integrity": "sha512-3xP4XzzDNQOIqBMWogftkwxhg5oMKApqY0BAflmLZiFYHqyhSOxv/cd/zPQLTcCXr4AkaKb25joocY0BD1WC6A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.51.0",
         "@typescript-eslint/types": "8.51.0",
@@ -6761,7 +6756,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6837,7 +6831,6 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -7698,7 +7691,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -8403,18 +8395,29 @@
       }
     },
     "node_modules/cssstyle": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.5.tgz",
-      "integrity": "sha512-GlsEptulso7Jg0VaOZ8BXQi3AkYM5BOJKEO/rjMidSCq70FkIC5y0eawrCXeYzxgt3OCf4Ls+eoxN+/05vN0Ag==",
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.6.tgz",
+      "integrity": "sha512-legscpSpgSAeGEe0TNcai97DKt9Vd9AsAdOL7Uoetb52Ar/8eJm3LIa39qpv8wWzLFlNG4vVvppQM+teaMPj3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/css-color": "^4.1.1",
         "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
-        "css-tree": "^3.1.0"
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/csstype": {
@@ -8504,7 +8507,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -8731,7 +8733,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
@@ -9222,7 +9225,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9396,7 +9398,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -11338,7 +11339,6 @@
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -11884,6 +11884,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -12102,7 +12103,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@inquirer/confirm": "^5.0.0",
         "@mswjs/interceptors": "^0.40.0",
@@ -12139,22 +12139,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/msw/node_modules/type-fest": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.3.1.tgz",
-      "integrity": "sha512-VCn+LMHbd4t6sF3wfU/+HKT63C9OoyrSIf4b+vtWHpt2U7/4InZG467YDNMFMR70DdHjAdpPWmw2lzRdg0Xqqg==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "dependencies": {
-        "tagged-tag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mute-stream": {
@@ -13003,7 +12987,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -13183,6 +13166,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -13198,6 +13182,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -13355,7 +13340,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13410,7 +13394,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -13423,7 +13406,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.14.2",
@@ -13431,7 +13415,6 @@
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14186,7 +14169,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -14590,7 +14572,6 @@
       "integrity": "sha512-pKP5jXJYM4OjvNklGuHKO53wOCAwfx79KvZyOWHoi9zXUH5WVMFUe/ZfWyxXG/GTcj0maRgHGUjq/0I43r0dDQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@storybook/icons": "^2.0.0",
@@ -15133,7 +15114,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -15325,6 +15305,22 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-fest": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.3.1.tgz",
+      "integrity": "sha512-VCn+LMHbd4t6sF3wfU/+HKT63C9OoyrSIf4b+vtWHpt2U7/4InZG467YDNMFMR70DdHjAdpPWmw2lzRdg0Xqqg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
@@ -15409,7 +15405,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15692,7 +15687,6 @@
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -15786,7 +15780,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16037,7 +16030,6 @@
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -16116,7 +16108,6 @@
       "integrity": "sha512-khZGfAeJx6I8K9zKohEWWYN6KDlVw2DHownoe+6Vtwj1LP9WFgegXnVMSkZ/dBEBtXFwrkkydsaPFlB7f8wU2A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-html-community": "0.0.8",
         "html-entities": "^2.1.0",

--- a/web/src/components/feature-settings/feature-card.tsx
+++ b/web/src/components/feature-settings/feature-card.tsx
@@ -19,12 +19,13 @@ import { BayWheelsStationFinder } from "./baywheels-station-finder";
 import { MuniStopFinder } from "./muni-stop-finder";
 import { TrafficRoutePlanner } from "./traffic-route-planner";
 import { WeatherLocationManager } from "./weather-location-manager";
+import { StockSymbolInput } from "./stock-symbol-input";
 import { utcToLocalTime, localTimeToUTC } from "@/lib/timezone-utils";
 
 export interface FeatureField {
   key: string;
   label: string;
-  type: "text" | "password" | "select" | "number" | "location" | "time";
+  type: "text" | "password" | "select" | "number" | "location" | "time" | "stocks";
   placeholder?: string;
   options?: { value: string; label: string }[];
   required?: boolean;
@@ -1124,6 +1125,12 @@ export function FeatureCard({
                       onChange={(value) => handleChange(field.key, value)}
                       placeholder={field.placeholder}
                     />
+                  ) : field.type === "stocks" ? (
+                    <StockSymbolInput
+                      selectedSymbols={(formData[field.key] as string[]) ?? []}
+                      onSymbolsChange={(symbols) => handleChange(field.key, symbols)}
+                      maxSymbols={5}
+                    />
                   ) : (
                     <input
                       type="text"
@@ -1227,6 +1234,10 @@ export function FeatureCard({
             // For password fields, "***" indicates a value is set
             if (f.type === "password") {
               return !hasSecretValue(f.key);
+            }
+            // For array fields (like stocks symbols), check if array is empty
+            if (f.type === "stocks" || Array.isArray(value)) {
+              return !value || (Array.isArray(value) && value.length === 0);
             }
             // For other fields, check if value is empty
             return !value || (typeof value === "string" && value.trim() === "");

--- a/web/src/components/feature-settings/index.tsx
+++ b/web/src/components/feature-settings/index.tsx
@@ -16,6 +16,7 @@ import {
   Bike,
   Car,
   Moon,
+  TrendingUp,
 } from "lucide-react";
 import { LucideIcon } from "lucide-react";
 
@@ -447,6 +448,70 @@ const FEATURE_DEFINITIONS: Record<
       { name: "routes.1.duration_minutes", description: "Travel time for second route", example: "35", maxChars: 3, typical: "1-3 digits" },
       { name: "routes.2.duration_minutes", description: "Travel time for third route", example: "45", maxChars: 3, typical: "1-3 digits" },
       { name: "routes.3.duration_minutes", description: "Travel time for fourth route", example: "20", maxChars: 3, typical: "1-3 digits" },
+    ],
+  },
+  stocks: {
+    title: "Stocks",
+    description: "Display US stock market prices and percentage changes",
+    icon: TrendingUp,
+    hasRefreshInterval: true,
+    defaultRefreshSeconds: 300,
+    fields: [
+      {
+        key: "finnhub_api_key",
+        label: "Finnhub API Key (Optional)",
+        type: "password",
+        placeholder: "Enter Finnhub API key for better symbol search",
+        required: false,
+        description: "Optional - enables better symbol search/autocomplete. Get free key at finnhub.io",
+      },
+      {
+        key: "symbols",
+        label: "Stock Symbols",
+        type: "stocks",  // Custom type for stock symbol input
+        placeholder: "Search and select stock symbols",
+        required: true,
+        description: "Select up to 5 stock symbols to monitor",
+      },
+      {
+        key: "time_window",
+        label: "Time Window",
+        type: "select",
+        options: [
+          { value: "1 Day", label: "1 Day" },
+          { value: "5 Days", label: "5 Days" },
+          { value: "1 Month", label: "1 Month" },
+          { value: "3 Months", label: "3 Months" },
+          { value: "6 Months", label: "6 Months" },
+          { value: "1 Year", label: "1 Year" },
+          { value: "2 Years", label: "2 Years" },
+          { value: "5 Years", label: "5 Years" },
+          { value: "ALL", label: "All Time" },
+        ],
+        description: "Compare current price to price from this time period",
+      },
+      {
+        key: "refresh_seconds",
+        label: "Refresh Interval (seconds)",
+        type: "number",
+        placeholder: "300",
+        description: "How often to fetch new stock data (min: 60, default: 5 min)",
+      },
+    ],
+    outputs: [
+      { name: "symbol", description: "Stock symbol (first stock)", example: "GOOG", maxChars: 5, typical: "1-5 chars" },
+      { name: "current_price", description: "Current price (first stock)", example: "150.25", maxChars: 8, typical: "6-8 chars" },
+      { name: "change_percent", description: "Percentage change (first stock)", example: "+1.18", maxChars: 6, typical: "4-6 chars" },
+      { name: "formatted", description: "Pre-formatted display (first stock)", example: "GOOG{green} $150.25 +1.18%", maxChars: 22, typical: "15-22 chars" },
+      { name: "symbol_count", description: "Number of tracked symbols", example: "3", maxChars: 1, typical: "1 digit" },
+      { name: "stocks.0.symbol", description: "Symbol of first stock", example: "GOOG", maxChars: 5, typical: "1-5 chars" },
+      { name: "stocks.0.current_price", description: "Current price of first stock", example: "150.25", maxChars: 8, typical: "6-8 chars" },
+      { name: "stocks.0.change_percent", description: "Percentage change of first stock", example: "+1.18", maxChars: 6, typical: "4-6 chars" },
+      { name: "stocks.0.formatted", description: "Formatted display of first stock", example: "GOOG{green} $150.25 +1.18%", maxChars: 22, typical: "15-22 chars" },
+      { name: "stocks.1.symbol", description: "Symbol of second stock", example: "AAPL", maxChars: 5, typical: "1-5 chars" },
+      { name: "stocks.1.current_price", description: "Current price of second stock", example: "175.50", maxChars: 8, typical: "6-8 chars" },
+      { name: "stocks.2.symbol", description: "Symbol of third stock", example: "MSFT", maxChars: 5, typical: "1-5 chars" },
+      { name: "stocks.3.symbol", description: "Symbol of fourth stock", example: "TSLA", maxChars: 5, typical: "1-5 chars" },
     ],
   },
 };

--- a/web/src/components/feature-settings/stock-symbol-input.tsx
+++ b/web/src/components/feature-settings/stock-symbol-input.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Search, X, Loader2, CheckCircle2, AlertCircle, TrendingUp } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { cn } from "@/lib/utils";
+import { api, StockSymbol, StockSymbolValidation } from "@/lib/api";
+
+interface StockSymbolInputProps {
+  selectedSymbols: string[];
+  onSymbolsChange: (symbols: string[]) => void;
+  maxSymbols?: number;
+}
+
+export function StockSymbolInput({
+  selectedSymbols,
+  onSymbolsChange,
+  maxSymbols = 5,
+}: StockSymbolInputProps) {
+  const [query, setQuery] = useState("");
+  const [suggestions, setSuggestions] = useState<StockSymbol[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [validating, setValidating] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [showSuggestions, setShowSuggestions] = useState(false);
+
+  // Debounced search
+  useEffect(() => {
+    if (!query.trim()) {
+      setSuggestions([]);
+      setShowSuggestions(false);
+      return;
+    }
+
+    const timeoutId = setTimeout(async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const result = await api.searchStockSymbols(query.trim(), 10);
+        setSuggestions(result.symbols);
+        setShowSuggestions(true);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to search symbols");
+        setSuggestions([]);
+      } finally {
+        setLoading(false);
+      }
+    }, 300); // 300ms debounce
+
+    return () => clearTimeout(timeoutId);
+  }, [query]);
+
+  const handleAddSymbol = useCallback(async (symbol: StockSymbol) => {
+    // Check if already selected
+    if (selectedSymbols.includes(symbol.symbol)) {
+      setError(`${symbol.symbol} is already selected`);
+      return;
+    }
+
+    // Check if at max
+    if (selectedSymbols.length >= maxSymbols) {
+      setError(`Maximum ${maxSymbols} symbols allowed`);
+      return;
+    }
+
+    // Validate symbol before adding
+    setValidating(symbol.symbol);
+    setError(null);
+
+    try {
+      const validation = await api.validateStockSymbol(symbol.symbol);
+      
+      if (validation.valid) {
+        onSymbolsChange([...selectedSymbols, symbol.symbol]);
+        setQuery("");
+        setSuggestions([]);
+        setShowSuggestions(false);
+        setError(null);
+      } else {
+        setError(validation.error || `Invalid symbol: ${symbol.symbol}`);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to validate symbol");
+    } finally {
+      setValidating(null);
+    }
+  }, [selectedSymbols, maxSymbols, onSymbolsChange]);
+
+  const handleRemoveSymbol = (symbol: string) => {
+    onSymbolsChange(selectedSymbols.filter(s => s !== symbol));
+  };
+
+  const handleManualAdd = async () => {
+    const symbol = query.trim().toUpperCase();
+    if (!symbol) {
+      setError("Please enter a symbol");
+      return;
+    }
+
+    if (selectedSymbols.includes(symbol)) {
+      setError(`${symbol} is already selected`);
+      return;
+    }
+
+    if (selectedSymbols.length >= maxSymbols) {
+      setError(`Maximum ${maxSymbols} symbols allowed`);
+      return;
+    }
+
+    // Validate before adding
+    setValidating(symbol);
+    setError(null);
+
+    try {
+      const validation = await api.validateStockSymbol(symbol);
+      
+      if (validation.valid) {
+        onSymbolsChange([...selectedSymbols, symbol]);
+        setQuery("");
+        setSuggestions([]);
+        setShowSuggestions(false);
+        setError(null);
+      } else {
+        setError(validation.error || `Invalid symbol: ${symbol}`);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to validate symbol");
+    } finally {
+      setValidating(null);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Selected symbols */}
+      {selectedSymbols.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {selectedSymbols.map((symbol) => (
+            <Badge
+              key={symbol}
+              variant="secondary"
+              className="flex items-center gap-2 px-3 py-1.5"
+            >
+              <TrendingUp className="h-3 w-3" />
+              <span className="font-mono">{symbol}</span>
+              <button
+                type="button"
+                onClick={() => handleRemoveSymbol(symbol)}
+                className="ml-1 rounded-full hover:bg-destructive/20 p-0.5"
+                aria-label={`Remove ${symbol}`}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </Badge>
+          ))}
+        </div>
+      )}
+
+      {/* Search input */}
+      <div className="relative">
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <Input
+            type="text"
+            placeholder="Search for stock symbol (e.g., GOOG, AAPL)..."
+            value={query}
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setError(null);
+            }}
+            onFocus={() => {
+              if (suggestions.length > 0) {
+                setShowSuggestions(true);
+              }
+            }}
+            onBlur={() => {
+              // Delay to allow click on suggestion
+              setTimeout(() => setShowSuggestions(false), 200);
+            }}
+            className="pl-9 pr-20"
+            disabled={selectedSymbols.length >= maxSymbols}
+          />
+          {loading && (
+            <Loader2 className="absolute right-12 top-1/2 -translate-y-1/2 h-4 w-4 animate-spin text-muted-foreground" />
+          )}
+          {validating && (
+            <Loader2 className="absolute right-12 top-1/2 -translate-y-1/2 h-4 w-4 animate-spin text-muted-foreground" />
+          )}
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            onClick={handleManualAdd}
+            disabled={!query.trim() || loading || validating || selectedSymbols.length >= maxSymbols}
+            className="absolute right-1 top-1/2 -translate-y-1/2 h-7 px-3 text-xs"
+          >
+            Add
+          </Button>
+        </div>
+
+        {/* Suggestions dropdown */}
+        {showSuggestions && suggestions.length > 0 && (
+          <div className="absolute z-50 w-full mt-1 bg-popover border rounded-md shadow-lg max-h-60 overflow-auto">
+            {suggestions.map((suggestion) => (
+              <button
+                key={suggestion.symbol}
+                type="button"
+                onClick={() => handleAddSymbol(suggestion)}
+                disabled={selectedSymbols.includes(suggestion.symbol) || selectedSymbols.length >= maxSymbols}
+                className={cn(
+                  "w-full text-left px-4 py-2 hover:bg-accent hover:text-accent-foreground transition-colors",
+                  "flex items-center justify-between",
+                  (selectedSymbols.includes(suggestion.symbol) || selectedSymbols.length >= maxSymbols) && "opacity-50 cursor-not-allowed"
+                )}
+              >
+                <div className="flex items-center gap-2">
+                  <TrendingUp className="h-4 w-4 text-muted-foreground" />
+                  <span className="font-mono font-semibold">{suggestion.symbol}</span>
+                  <span className="text-sm text-muted-foreground">{suggestion.name}</span>
+                </div>
+                {selectedSymbols.includes(suggestion.symbol) && (
+                  <CheckCircle2 className="h-4 w-4 text-green-500" />
+                )}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Error message */}
+      {error && (
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {/* Help text */}
+      <p className="text-sm text-muted-foreground">
+        {selectedSymbols.length >= maxSymbols
+          ? `Maximum ${maxSymbols} symbols selected`
+          : `Search and select up to ${maxSymbols} stock symbols. Symbols are validated before being added.`}
+      </p>
+    </div>
+  );
+}
+

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -389,6 +389,33 @@ export interface SilenceScheduleFeatureConfig {
   end_time: string;   // UTC ISO format (e.g., "15:00+00:00")
 }
 
+export interface StocksFeatureConfig {
+  enabled: boolean;
+  finnhub_api_key?: string;  // Optional - enables better symbol search
+  symbols: string[];  // List of stock symbols (max 5)
+  time_window: string;  // "1 Day", "5 Days", "1 Month", "3 Months", "6 Months", "1 Year", "2 Years", "5 Years", "ALL"
+  refresh_seconds: number;
+  color_rules?: {
+    change_percent?: Array<{
+      condition: string;
+      value: number;
+      color: string;
+    }>;
+  };
+}
+
+export interface StockSymbol {
+  symbol: string;
+  name: string;
+}
+
+export interface StockSymbolValidation {
+  valid: boolean;
+  symbol: string;
+  name?: string;
+  error?: string;
+}
+
 export interface FeaturesConfig {
   weather: WeatherFeatureConfig;
   datetime: DateTimeFeatureConfig;
@@ -401,6 +428,7 @@ export interface FeaturesConfig {
   baywheels: BayWheelsFeatureConfig;
   traffic: TrafficFeatureConfig;
   silence_schedule: SilenceScheduleFeatureConfig;
+  stocks: StocksFeatureConfig;
 }
 
 export interface GeneralConfig {
@@ -705,6 +733,24 @@ export const api = {
     }>("/traffic/routes/validate", {
       method: "POST",
       body: JSON.stringify({ origin, destination, destination_name, travel_mode }),
+    }),
+  
+  // Stocks endpoints
+  searchStockSymbols: (query: string, limit?: number) => {
+    const params = new URLSearchParams({
+      query,
+      ...(limit !== undefined && { limit: limit.toString() }),
+    });
+    return fetchApi<{
+      symbols: StockSymbol[];
+      count: number;
+      query: string;
+    }>(`/stocks/search?${params}`);
+  },
+  validateStockSymbol: (symbol: string) =>
+    fetchApi<StockSymbolValidation>("/stocks/validate", {
+      method: "POST",
+      body: JSON.stringify({ symbol }),
     }),
   
   // General configuration


### PR DESCRIPTION
- Implement stocks monitoring with endpoints for searching and validating stock symbols.
- Add configuration options for enabling stocks, setting a Finnhub API key, selecting stock symbols, and defining refresh intervals.
- Update the display service to include stocks data and integrate it into the UI.
- Enhance the variable picker to support live stocks data and display stock information.
- Document new environment variables and update the README accordingly.

<img width="884" height="398" alt="Screenshot 2025-12-31 at 1 57 04 AM" src="https://github.com/user-attachments/assets/ca42467f-b056-45d8-b1ed-1296cab8c7b8" />