### PR TITLE
fix(web): make sheet close button visible on mobile

### DIFF
--- a/web/src/components/ui/sheet.tsx
+++ b/web/src/components/ui/sheet.tsx
@@ -21,7 +21,7 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 bg-black/80",
+      "fixed inset-0 z-[110] bg-black/80",
       className
     )}
     style={{
@@ -34,7 +34,7 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
 
 const sheetVariants = cva(
-  "fixed z-50 gap-4 bg-background p-6 shadow-lg",
+  "fixed z-[110] gap-4 bg-background p-6 shadow-lg",
   {
     variants: {
       side: {
@@ -89,8 +89,8 @@ const SheetContent = React.forwardRef<
         {...props}
       >
         {children}
-        <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-          <X className="h-4 w-4" />
+        <SheetPrimitive.Close className="absolute right-4 top-4 h-10 w-10 flex items-center justify-center rounded-full bg-muted/80 hover:bg-muted ring-offset-background transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
+          <X className="h-5 w-5" />
           <span className="sr-only">Close</span>
         </SheetPrimitive.Close>
       </SheetPrimitive.Content>


### PR DESCRIPTION
## Summary
- Fixed the close (X) button on the page selector sheet being hidden behind the mobile navigation header
- Increased z-index from `z-50` to `z-[110]` so sheets render above the mobile nav header (`z-[100]`)
- Enlarged close button to 40x40px with a visible circular background for better touch target and visibility
- Increased icon size from 16px to 20px

## Test plan
- [ ] Open the app on mobile (or use responsive mode in dev tools)
- [ ] Tap "Change Page" to open the page selector sheet
- [ ] Verify the X close button is visible in the top-right corner
- [ ] Verify tapping the X closes the sheet
- [ ] Verify the sheet still works correctly on desktop