### PR TITLE
feat: Add editor tabs for rich and plain text editing modes

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "1.15.4",
+  "version": "1.16.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "1.15.4",
+      "version": "1.16.3",
       "dependencies": {
         "@ducanh2912/next-pwa": "^10.0.0",
         "@radix-ui/react-accordion": "^1.2.2",
@@ -16,6 +16,7 @@
         "@radix-ui/react-select": "^2.1.4",
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-switch": "^1.2.6",
+        "@radix-ui/react-tabs": "^1.1.1",
         "@radix-ui/react-tooltip": "^1.1.8",
         "@tanstack/react-query": "^5.90.12",
         "@tiptap/extension-paragraph": "^3.15.3",
@@ -2804,6 +2805,37 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-scroll-area": {
       "version": "1.2.10",
       "license": "MIT",
@@ -2917,6 +2949,36 @@
         "@radix-ui/react-use-controllable-state": "1.2.2",
         "@radix-ui/react-use-previous": "1.1.1",
         "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/web/package.json
+++ b/web/package.json
@@ -21,6 +21,7 @@
     "@radix-ui/react-select": "^2.1.4",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-switch": "^1.2.6",
+    "@radix-ui/react-tabs": "^1.1.1",
     "@radix-ui/react-tooltip": "^1.1.8",
     "@tanstack/react-query": "^5.90.12",
     "@tiptap/extension-paragraph": "^3.15.3",

--- a/web/src/components/plain-text-editor.tsx
+++ b/web/src/components/plain-text-editor.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useRef, useEffect } from "react";
+import { cn } from "@/lib/utils";
+
+interface PlainTextEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  onFocus?: () => void;
+  placeholder?: string;
+  className?: string;
+}
+
+/**
+ * Plain text code editor for template editing
+ * Provides a simple textarea with code editor styling
+ */
+export function PlainTextEditor({
+  value,
+  onChange,
+  onFocus,
+  placeholder = "Type your template text...",
+  className,
+}: PlainTextEditorProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Auto-resize textarea to fit content
+  useEffect(() => {
+    const textarea = textareaRef.current;
+    if (textarea) {
+      textarea.style.height = 'auto';
+      textarea.style.height = `${Math.max(textarea.scrollHeight, 144)}px`; // Minimum 6 lines (~144px)
+    }
+  }, [value]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const newValue = e.target.value;
+    
+    // Split by newlines and limit to 6 lines
+    const lines = newValue.split('\n');
+    if (lines.length > 6) {
+      // Prevent adding more than 6 lines
+      return;
+    }
+    
+    // Convert to uppercase
+    const uppercased = newValue.toUpperCase();
+    onChange(uppercased);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    // Prevent adding more than 6 lines
+    if (e.key === 'Enter') {
+      const currentLines = value.split('\n');
+      if (currentLines.length >= 6) {
+        e.preventDefault();
+        return;
+      }
+    }
+    
+    // Convert lowercase to uppercase on the fly
+    if (e.key.length === 1 && /[a-z]/.test(e.key) && !e.ctrlKey && !e.metaKey && !e.altKey) {
+      e.preventDefault();
+      const start = e.currentTarget.selectionStart;
+      const end = e.currentTarget.selectionEnd;
+      const before = value.substring(0, start);
+      const after = value.substring(end);
+      const newValue = before + e.key.toUpperCase() + after;
+      onChange(newValue);
+      
+      // Move cursor after inserted character
+      setTimeout(() => {
+        if (textareaRef.current) {
+          textareaRef.current.selectionStart = start + 1;
+          textareaRef.current.selectionEnd = start + 1;
+        }
+      }, 0);
+    }
+  };
+
+  return (
+    <div className={cn("relative", className)}>
+      <textarea
+        ref={textareaRef}
+        value={value}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        onFocus={onFocus}
+        placeholder={placeholder}
+        className={cn(
+          "w-full p-3 rounded-md border bg-background",
+          "font-mono text-sm resize-none",
+          "focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+          "placeholder:text-muted-foreground",
+          "overflow-y-auto"
+        )}
+        rows={6}
+        style={{
+          minHeight: '9rem', // 6 lines minimum
+          lineHeight: '1.5rem',
+        }}
+      />
+      
+      {/* Line counter */}
+      <div className="mt-1 text-xs text-muted-foreground">
+        {value.split('\n').length} / 6 lines
+      </div>
+      
+      {/* Helper text */}
+      <div className="mt-2 text-xs text-muted-foreground space-y-1">
+        <p>• Maximum 6 lines (22 characters per line recommended)</p>
+        <p>• Use template syntax: {'{{variable}}'}, {'{{red}}'}, {'{{fill_space}}'}</p>
+        <p>• Alignment prefixes: {'{left}'}, {'{center}'}, {'{right}'}</p>
+        <p>• Wrap prefix: {'{wrap}'}</p>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/ui/tabs.tsx
+++ b/web/src/components/ui/tabs.tsx
@@ -1,0 +1,55 @@
+"use client"
+
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@/lib/utils"
+
+const Tabs = TabsPrimitive.Root
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+))
+TabsList.displayName = TabsPrimitive.List.displayName
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      className
+    )}
+    {...props}
+  />
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      className
+    )}
+    {...props}
+  />
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }


### PR DESCRIPTION
## Summary

- Add tabbed interface to toggle between Rich Editor and Plain Text modes
- Create new PlainTextEditor component with code editor styling
- Add Tabs UI component from Radix UI
- Ensure alignment prefixes are properly handled when switching modes

## Changes

### New Components
- `web/src/components/ui/tabs.tsx` - Radix UI tabs component
- `web/src/components/plain-text-editor.tsx` - Plain text code editor component

### Modified Components
- `web/src/components/page-builder.tsx` - Added tab switching UI and mode management
- `web/package.json` - Added `@radix-ui/react-tabs` dependency

### Features
- **Rich Editor Tab**: Visual TipTap editor with toolbar and inline rendering of variables, colors, and special nodes
- **Plain Text Tab**: Code editor-style textarea for direct template syntax editing with alignment prefixes visible

### Bug Fixes
- Alignment prefixes (`{center}`, `{right}`, `{wrap}`) are properly stripped when switching from plain text to rich editor
- Both editors maintain proper state synchronization

## Test Plan

- [x] Switch between Rich Editor and Plain Text tabs
- [x] Edit content in Rich Editor and verify it appears correctly in Plain Text
- [x] Edit content in Plain Text with alignment prefixes and verify they're parsed correctly in Rich Editor
- [x] Verify alignment prefixes don't appear as literal text in Rich Editor
- [x] Verify preview updates correctly regardless of active tab
- [x] Test with existing pages and new pages

## Screenshots

The editor now includes tabs above the editing area allowing users to choose their preferred editing experience.