### PR TITLE
feat(plugins): add Last.fm Now Playing plugin

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -42,7 +42,6 @@ This project uses Docker containers for ALL development, testing, and debugging 
 ### Exceptions
 
 The only code that may run locally:
-- The `macos_helper/` service (macOS-specific Apple Music integration)
 - Utility scripts explicitly marked for local execution
 
 ### Available Cursor Commands
@@ -95,7 +94,8 @@ This project uses a **plugin-based architecture** for data source integrations. 
 ### Plugin Documentation
 
 When creating or modifying a plugin:
-- **DO NOT update the main README.md** for individual plugins
+- **NEW plugins MUST be added** to the main `README.md` "Available Plugins" list (alphabetically)
+- **Modifying existing plugins** does NOT require updating main README.md
 - Plugin documentation goes in the plugin's own directory:
   - `plugins/PLUGIN_NAME/README.md` - Developer documentation (how plugin works)
   - `plugins/PLUGIN_NAME/docs/SETUP.md` - User-facing setup guide (API keys, etc.)
@@ -172,15 +172,25 @@ When creating a new plugin:
 3. Implement `PluginBase` class in `__init__.py`
 4. Create tests in `tests/` directory with >80% coverage
 5. Write user-facing setup guide in `docs/SETUP.md`
+6. **Add screenshot placeholder** to plugin's `README.md`: `![Plugin Name Display](./docs/plugin-name-display.png)`
+7. **Add plugin to project README.md** under "Available Plugins" section (alphabetically ordered)
 
 ### Required Plugin Files
 
 Every plugin MUST have:
 - `__init__.py` - Plugin implementation (PluginBase subclass)
 - `manifest.json` - Plugin metadata, settings schema, variables
-- `README.md` - Plugin documentation (developer-focused)
+- `README.md` - Plugin documentation (developer-focused, **must include screenshot placeholder**)
 - `tests/` - Test directory with test files
 - `docs/SETUP.md` - User-facing setup guide
+
+### Plugin Documentation Checklist
+
+When a new plugin is complete, verify:
+- [ ] Plugin's `README.md` has screenshot placeholder: `![Name Display](./docs/name-display.png)`
+- [ ] Plugin is added to main `README.md` "Available Plugins" list (alphabetically)
+- [ ] Setup guide exists at `docs/SETUP.md`
+- [ ] Tests pass with >80% coverage
 
 ### Plugin Manifest Requirements
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ FiestaBoard uses a **plugin architecture** - each feature is a self-contained pl
 - 📅 **[Date & Time](./plugins/date_time/README.md)**: Current date and time with multiple formats (12h/24h, US dates) and timezone autocomplete
 - 📶 **[Guest WiFi](./plugins/guest_wifi/docs/SETUP.md)**: Display WiFi credentials for guests
 - 🏠 **[Home Assistant](./plugins/home_assistant/docs/SETUP.md)**: House status display (doors, garage, locks, etc.)
+- 🎵 **[Last.fm Now Playing](./plugins/last_fm/docs/SETUP.md)**: Display currently playing music via Last.fm scrobbling
 - 🚇 **[Muni Transit](./plugins/muni/docs/SETUP.md)**: Real-time SF Muni arrival predictions
 - 🛩️ **[Nearby Aircraft](./plugins/nearby_aircraft/docs/SETUP.md)**: Real-time nearby aircraft information from OpenSky Network API
 - 🏆 **[Sports Scores](./plugins/sports_scores/docs/SETUP.md)**: Display recent match scores from NFL, Soccer, NHL, and NBA

--- a/plugins/last_fm/README.md
+++ b/plugins/last_fm/README.md
@@ -1,0 +1,135 @@
+# Last.fm Now Playing Plugin
+
+Display what's currently playing on your Vestaboard via Last.fm scrobbling.
+
+![Last.fm Now Playing Display](./docs/last-fm-display.png)
+
+## Overview
+
+This plugin fetches the currently playing or most recently played track from a user's Last.fm profile. It works with any music source that scrobbles to Last.fm, including:
+
+- Apple Music (via scrobbler apps)
+- Spotify (native Last.fm integration)
+- YouTube Music
+- Tidal
+- And many more
+
+## How It Works
+
+```
+Music App → Scrobbler → Last.fm → FiestaBoard → Vestaboard
+```
+
+1. You listen to music on your preferred app
+2. A scrobbler sends the track info to Last.fm
+3. FiestaBoard polls the Last.fm API for your recent tracks
+4. The `@attr.nowplaying` flag indicates if you're actively listening
+5. Track info is displayed on your Vestaboard
+
+## Configuration
+
+### Settings
+
+| Setting | Type | Required | Default | Description |
+|---------|------|----------|---------|-------------|
+| `username` | string | Yes | - | Your Last.fm username |
+| `api_key` | string | Yes | - | Your Last.fm API key |
+| `refresh_seconds` | integer | No | 30 | How often to check for updates (min: 10) |
+| `show_album` | boolean | No | false | Include album name in output |
+| `enabled` | boolean | No | false | Enable the plugin |
+
+### Environment Variables
+
+You can also configure via environment variables:
+
+- `LASTFM_USERNAME` - Last.fm username
+- `LASTFM_API_KEY` - Last.fm API key
+
+## Template Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `{{last_fm.title}}` | Song title | "Bohemian Rhapsody" |
+| `{{last_fm.artist}}` | Artist name | "Queen" |
+| `{{last_fm.album}}` | Album name | "A Night at the Opera" |
+| `{{last_fm.is_playing}}` | Currently playing? | true/false |
+| `{{last_fm.status}}` | Status text | "NOW PLAYING" or "LAST PLAYED" |
+| `{{last_fm.formatted}}` | Formatted string | "Bohemian Rhapsody by Queen" |
+| `{{last_fm.artwork_url}}` | Album artwork URL | https://... |
+| `{{last_fm.track_url}}` | Last.fm track URL | https://... |
+
+## Example Templates
+
+### Simple Now Playing
+
+```
+{{last_fm.status}}
+
+{{last_fm.title}}
+{{last_fm.artist}}
+```
+
+### With Album
+
+```
+NOW PLAYING
+{{last_fm.title}}
+by {{last_fm.artist}}
+{{last_fm.album}}
+```
+
+## API Details
+
+This plugin uses the Last.fm `user.getRecentTracks` endpoint:
+
+- **Endpoint**: `http://ws.audioscrobbler.com/2.0/`
+- **Method**: `user.getRecentTracks`
+- **Rate Limits**: ~5 requests/second (we stay well under this)
+- **Cost**: FREE
+
+The `@attr.nowplaying` attribute in the response indicates if a track is currently being played, providing true real-time status.
+
+## Troubleshooting
+
+### "User not found" error
+
+- Verify your username is correct (case-sensitive)
+- Check your Last.fm profile is public
+
+### "Invalid API key" error
+
+- Regenerate your API key at https://www.last.fm/api/account/create
+- Ensure no extra spaces in the key
+
+### Tracks not showing as "now playing"
+
+- Ensure your scrobbler is running and connected
+- Some scrobblers have a delay before reporting
+- Check that scrobbling is working on your Last.fm profile
+
+## Development
+
+### Running Tests
+
+```bash
+python scripts/run_plugin_tests.py --plugin=last_fm
+```
+
+### API Response Example
+
+```json
+{
+  "recenttracks": {
+    "track": [
+      {
+        "name": "Bohemian Rhapsody",
+        "artist": {"#text": "Queen"},
+        "album": {"#text": "A Night at the Opera"},
+        "image": [{"#text": "https://..."}],
+        "url": "https://www.last.fm/music/Queen/_/Bohemian+Rhapsody",
+        "@attr": {"nowplaying": "true"}
+      }
+    ]
+  }
+}
+```

--- a/plugins/last_fm/__init__.py
+++ b/plugins/last_fm/__init__.py
@@ -1,0 +1,306 @@
+"""Last.fm Now Playing plugin for FiestaBoard.
+
+Displays what's currently playing via Last.fm scrobbling.
+Works with Apple Music, Spotify, and any music source that scrobbles to Last.fm.
+"""
+
+import logging
+import os
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from src.plugins.base import PluginBase, PluginResult
+
+logger = logging.getLogger(__name__)
+
+# Last.fm API endpoint
+LASTFM_API_URL = "http://ws.audioscrobbler.com/2.0/"
+
+
+class LastFmPlugin(PluginBase):
+    """Last.fm Now Playing plugin.
+    
+    Fetches the currently playing or most recently played track
+    from a user's Last.fm scrobbling history.
+    """
+    
+    def __init__(self, manifest: Dict[str, Any]):
+        """Initialize the Last.fm plugin."""
+        super().__init__(manifest)
+        self._cache: Optional[Dict[str, Any]] = None
+        self._cache_time: Optional[datetime] = None
+    
+    @property
+    def plugin_id(self) -> str:
+        """Return plugin identifier."""
+        return "last_fm"
+    
+    def validate_config(self, config: Dict[str, Any]) -> List[str]:
+        """Validate Last.fm configuration."""
+        errors = []
+        
+        username = config.get("username", "").strip()
+        if not username:
+            # Check environment variable
+            username = os.getenv("LASTFM_USERNAME", "").strip()
+            if not username:
+                errors.append("Last.fm username is required")
+        
+        api_key = config.get("api_key", "").strip()
+        if not api_key:
+            # Check environment variable
+            api_key = os.getenv("LASTFM_API_KEY", "").strip()
+            if not api_key:
+                errors.append("Last.fm API key is required")
+        
+        refresh_seconds = config.get("refresh_seconds", 30)
+        if not isinstance(refresh_seconds, int) or refresh_seconds < 10:
+            errors.append("Refresh interval must be at least 10 seconds")
+        
+        return errors
+    
+    def _get_username(self) -> str:
+        """Get username from config or environment."""
+        return (
+            self.config.get("username", "").strip() 
+            or os.getenv("LASTFM_USERNAME", "").strip()
+        )
+    
+    def _get_api_key(self) -> str:
+        """Get API key from config or environment."""
+        return (
+            self.config.get("api_key", "").strip() 
+            or os.getenv("LASTFM_API_KEY", "").strip()
+        )
+    
+    def fetch_data(self) -> PluginResult:
+        """Fetch currently playing or recent track from Last.fm."""
+        username = self._get_username()
+        api_key = self._get_api_key()
+        
+        if not username:
+            return PluginResult(
+                available=False,
+                error="Last.fm username not configured"
+            )
+        
+        if not api_key:
+            return PluginResult(
+                available=False,
+                error="Last.fm API key not configured"
+            )
+        
+        # Check cache
+        refresh_seconds = self.config.get("refresh_seconds", 30)
+        if self._cache and self._cache_time:
+            cache_age = (datetime.now() - self._cache_time).total_seconds()
+            if cache_age < refresh_seconds:
+                logger.debug(f"Using cached data (age: {cache_age:.0f}s)")
+                return PluginResult(available=True, data=self._cache)
+        
+        try:
+            # Call Last.fm API
+            params = {
+                "method": "user.getRecentTracks",
+                "user": username,
+                "api_key": api_key,
+                "format": "json",
+                "limit": 1,
+            }
+            
+            response = requests.get(LASTFM_API_URL, params=params, timeout=10)
+            
+            if response.status_code == 403:
+                return PluginResult(
+                    available=False,
+                    error="Invalid API key"
+                )
+            
+            if response.status_code == 404:
+                return PluginResult(
+                    available=False,
+                    error=f"User '{username}' not found"
+                )
+            
+            if response.status_code != 200:
+                return PluginResult(
+                    available=False,
+                    error=f"Last.fm API error: {response.status_code}"
+                )
+            
+            data = response.json()
+            
+            # Check for API error response
+            if "error" in data:
+                error_msg = data.get("message", "Unknown error")
+                return PluginResult(
+                    available=False,
+                    error=f"Last.fm error: {error_msg}"
+                )
+            
+            # Parse response
+            tracks = data.get("recenttracks", {}).get("track", [])
+            
+            if not tracks:
+                return PluginResult(
+                    available=True,
+                    data=self._empty_data("No recent tracks")
+                )
+            
+            # Handle case where tracks is a single dict instead of list
+            if isinstance(tracks, dict):
+                tracks = [tracks]
+            
+            track = tracks[0]
+            
+            # Check if currently playing (nowplaying attribute)
+            is_playing = track.get("@attr", {}).get("nowplaying") == "true"
+            
+            # Extract track info
+            title = track.get("name", "Unknown")
+            artist = track.get("artist", {})
+            # Artist can be a dict or a string depending on API response
+            if isinstance(artist, dict):
+                artist_name = artist.get("#text", "") or artist.get("name", "Unknown")
+            else:
+                artist_name = str(artist) if artist else "Unknown"
+            
+            album = track.get("album", {})
+            if isinstance(album, dict):
+                album_name = album.get("#text", "") or album.get("name", "")
+            else:
+                album_name = str(album) if album else ""
+            
+            # Get artwork URL (largest available)
+            images = track.get("image", [])
+            artwork_url = ""
+            if images:
+                # Last image is usually the largest
+                for img in reversed(images):
+                    if isinstance(img, dict) and img.get("#text"):
+                        artwork_url = img["#text"]
+                        break
+            
+            # Track URL
+            track_url = track.get("url", "")
+            
+            # Build formatted string
+            show_album = self.config.get("show_album", False)
+            if show_album and album_name:
+                formatted = f"{title} - {artist_name}"
+            else:
+                formatted = f"{title} by {artist_name}"
+            
+            # Status text
+            if is_playing:
+                status = "NOW PLAYING"
+            else:
+                status = "LAST PLAYED"
+            
+            result_data = {
+                "title": title,
+                "artist": artist_name,
+                "album": album_name,
+                "is_playing": is_playing,
+                "artwork_url": artwork_url,
+                "track_url": track_url,
+                "formatted": formatted,
+                "status": status,
+            }
+            
+            # Update cache
+            self._cache = result_data
+            self._cache_time = datetime.now()
+            
+            return PluginResult(available=True, data=result_data)
+            
+        except requests.exceptions.Timeout:
+            logger.warning("Last.fm API request timed out")
+            if self._cache:
+                return PluginResult(available=True, data=self._cache)
+            return PluginResult(
+                available=False,
+                error="Request timed out"
+            )
+        except requests.exceptions.RequestException as e:
+            logger.exception("Error fetching Last.fm data")
+            if self._cache:
+                return PluginResult(available=True, data=self._cache)
+            return PluginResult(
+                available=False,
+                error=f"Network error: {str(e)}"
+            )
+        except Exception as e:
+            logger.exception("Unexpected error fetching Last.fm data")
+            if self._cache:
+                return PluginResult(available=True, data=self._cache)
+            return PluginResult(
+                available=False,
+                error=str(e)
+            )
+    
+    def _empty_data(self, status: str = "Nothing playing") -> Dict[str, Any]:
+        """Return empty data structure when no track is available."""
+        return {
+            "title": "",
+            "artist": "",
+            "album": "",
+            "is_playing": False,
+            "artwork_url": "",
+            "track_url": "",
+            "formatted": "",
+            "status": status,
+        }
+    
+    def get_formatted_display(self) -> Optional[List[str]]:
+        """Return default formatted display for the board."""
+        if not self._cache:
+            result = self.fetch_data()
+            if not result.available:
+                return None
+        
+        data = self._cache
+        if not data or not data.get("title"):
+            return None
+        
+        lines = []
+        
+        # Status line
+        status = data.get("status", "NOW PLAYING")
+        lines.append(status.center(22))
+        
+        # Empty line
+        lines.append("")
+        
+        # Title (may need to truncate/wrap)
+        title = data.get("title", "")[:22]
+        lines.append(title.center(22))
+        
+        # Artist
+        artist = data.get("artist", "")[:22]
+        lines.append(artist.center(22))
+        
+        # Album (if configured and available)
+        album = data.get("album", "")
+        if self.config.get("show_album", False) and album:
+            lines.append(album[:22].center(22))
+        else:
+            lines.append("")
+        
+        # Pad to 6 lines
+        while len(lines) < 6:
+            lines.append("")
+        
+        return lines[:6]
+    
+    def cleanup(self) -> None:
+        """Cleanup when plugin is disabled."""
+        self._cache = None
+        self._cache_time = None
+        logger.info(f"Plugin {self.plugin_id} cleanup")
+
+
+# Export the plugin class
+Plugin = LastFmPlugin

--- a/plugins/last_fm/docs/SETUP.md
+++ b/plugins/last_fm/docs/SETUP.md
@@ -1,0 +1,148 @@
+# Last.fm Now Playing Setup Guide
+
+This guide will help you set up the Last.fm Now Playing plugin for FiestaBoard.
+
+## Prerequisites
+
+- A Last.fm account (free)
+- A Last.fm API key (free)
+- A scrobbler app for your music player
+
+## Step 1: Create a Last.fm Account
+
+If you don't already have a Last.fm account:
+
+1. Go to [https://www.last.fm/join](https://www.last.fm/join)
+2. Create a free account
+3. Note your **username** (visible in your profile URL: `last.fm/user/YOUR_USERNAME`)
+
+## Step 2: Get a Free API Key
+
+1. Go to [https://www.last.fm/api/account/create](https://www.last.fm/api/account/create)
+2. Fill in the application form:
+   - **Application name**: FiestaBoard (or any name you prefer)
+   - **Application description**: Personal music display
+   - **Callback URL**: Leave blank
+   - **Application homepage**: Leave blank or enter your FiestaBoard URL
+3. Click "Submit"
+4. Copy your **API Key** (you don't need the Shared Secret for this plugin)
+
+## Step 3: Set Up a Scrobbler
+
+A scrobbler is an app that sends your "now playing" info to Last.fm. Choose the setup for your music player:
+
+### For Apple Music (macOS/iOS)
+
+**Recommended: Scrobbles for Last.fm**
+
+1. Download from the [Mac App Store](https://apps.apple.com/app/scrobbles-for-last-fm/id1344679160) or [iOS App Store](https://apps.apple.com/app/scrobbles-for-last-fm/id1344679160)
+2. Open the app and sign in with your Last.fm account
+3. Grant permission to access your music
+4. The app runs in the background and scrobbles automatically
+
+**Alternative: Marvis Pro (iOS)**
+- Has built-in Last.fm scrobbling
+- Premium app with additional features
+
+### For Spotify
+
+Spotify has built-in Last.fm integration:
+
+1. Go to your Last.fm settings: [https://www.last.fm/settings/applications](https://www.last.fm/settings/applications)
+2. Scroll down to "Spotify Scrobbling"
+3. Click "Connect" and authorize Spotify
+4. Scrobbling happens automatically when you play music on Spotify
+
+### For Other Music Players
+
+- **YouTube Music**: Use Web Scrobbler browser extension
+- **Tidal**: Use the Tidal app's built-in scrobbling or a third-party scrobbler
+- **Plex/Plexamp**: Enable scrobbling in Plex settings
+- **Desktop (any player)**: Try [Web Scrobbler](https://web-scrobbler.com/) browser extension
+
+## Step 4: Configure FiestaBoard
+
+### Option A: Via Web UI
+
+1. Open FiestaBoard web interface
+2. Go to **Integrations**
+3. Find **Last.fm Now Playing** and click to configure
+4. Enter your **Last.fm username**
+5. Enter your **API key**
+6. Adjust refresh interval if desired (default: 30 seconds)
+7. Enable the plugin
+
+### Option B: Via Environment Variables
+
+Add to your `.env` file or Docker environment:
+
+```env
+LASTFM_USERNAME=your_username
+LASTFM_API_KEY=your_api_key_here
+```
+
+Then enable the plugin in the UI.
+
+## Step 5: Verify It's Working
+
+1. Play a song on your music player
+2. Check your Last.fm profile to confirm scrobbling is working
+3. Wait a few seconds for FiestaBoard to pick up the track
+4. Your Vestaboard should display the currently playing song!
+
+## Using in Templates
+
+Once configured, you can use these variables in your templates:
+
+```
+{{last_fm.title}}       - Song title
+{{last_fm.artist}}      - Artist name
+{{last_fm.album}}       - Album name
+{{last_fm.is_playing}}  - true if currently playing
+{{last_fm.status}}      - "NOW PLAYING" or "LAST PLAYED"
+{{last_fm.formatted}}   - "Song Title by Artist"
+```
+
+### Example Template
+
+```
+{{last_fm.status}}
+
+{{last_fm.title}}
+by {{last_fm.artist}}
+```
+
+## Troubleshooting
+
+### Nothing appears on the board
+
+1. **Check scrobbling is working**: Visit your Last.fm profile and verify recent tracks appear
+2. **Verify credentials**: Double-check your username and API key
+3. **Check plugin is enabled**: Go to Integrations and ensure the plugin is toggled on
+
+### Shows "LAST PLAYED" instead of "NOW PLAYING"
+
+This means the scrobbler isn't sending the "now playing" notification. Try:
+
+1. Restart your scrobbler app
+2. Check scrobbler settings for "send now playing" option
+3. Some scrobblers have a delay - wait a few seconds after starting a song
+
+### API key errors
+
+1. Visit [https://www.last.fm/api/accounts](https://www.last.fm/api/accounts) to view your API keys
+2. Create a new key if needed
+3. Make sure there are no extra spaces when copying the key
+
+### Rate limiting
+
+The Last.fm API allows ~5 requests per second. FiestaBoard's default 30-second refresh interval stays well under this limit. If you've set a very low refresh interval, consider increasing it.
+
+## Privacy Note
+
+This plugin only reads your public scrobbling data. It does not:
+- Access your Last.fm password
+- Modify your Last.fm account
+- Share your listening data with anyone
+
+Your API key is stored locally in your FiestaBoard configuration.

--- a/plugins/last_fm/manifest.json
+++ b/plugins/last_fm/manifest.json
@@ -1,0 +1,77 @@
+{
+  "id": "last_fm",
+  "name": "Last.fm Now Playing",
+  "version": "1.0.0",
+  "description": "Display what's currently playing via Last.fm scrobbling. Works with Apple Music, Spotify, and any scrobbling source.",
+  "author": "FiestaBoard",
+  "icon": "music",
+  "category": "entertainment",
+  "repository": "https://github.com/roblesi/FiestaBoard",
+  "documentation": "README.md",
+  "settings_schema": {
+    "type": "object",
+    "properties": {
+      "username": {
+        "type": "string",
+        "title": "Last.fm Username",
+        "description": "Your Last.fm username (from your profile URL: last.fm/user/USERNAME)"
+      },
+      "api_key": {
+        "type": "string",
+        "title": "API Key",
+        "description": "Your Last.fm API key (get one free at last.fm/api/account/create)",
+        "ui:widget": "password"
+      },
+      "refresh_seconds": {
+        "type": "integer",
+        "title": "Refresh Interval (seconds)",
+        "description": "How often to check for now playing updates. Lower values = more real-time but more API calls.",
+        "default": 30,
+        "minimum": 10
+      },
+      "show_album": {
+        "type": "boolean",
+        "title": "Show Album Name",
+        "description": "Include album name in the formatted output",
+        "default": false
+      },
+      "enabled": {
+        "type": "boolean",
+        "title": "Enabled",
+        "default": false
+      }
+    },
+    "required": ["username", "api_key"]
+  },
+  "env_vars": [
+    {
+      "name": "LASTFM_USERNAME",
+      "required": false,
+      "description": "Last.fm username (can also be set in UI)"
+    },
+    {
+      "name": "LASTFM_API_KEY",
+      "required": false,
+      "description": "Last.fm API key (can also be set in UI)"
+    }
+  ],
+  "variables": {
+    "simple": [
+      "title",
+      "artist",
+      "album",
+      "is_playing",
+      "artwork_url",
+      "track_url",
+      "formatted",
+      "status"
+    ]
+  },
+  "max_lengths": {
+    "title": 22,
+    "artist": 22,
+    "album": 22,
+    "formatted": 22,
+    "status": 22
+  }
+}

--- a/plugins/last_fm/tests/__init__.py
+++ b/plugins/last_fm/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Last.fm plugin tests."""

--- a/plugins/last_fm/tests/conftest.py
+++ b/plugins/last_fm/tests/conftest.py
@@ -1,0 +1,128 @@
+"""Plugin test fixtures and configuration for Last.fm."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from src.plugins.testing import PluginTestCase, create_mock_response
+
+
+@pytest.fixture(autouse=True)
+def reset_plugin_singletons():
+    """Reset plugin singletons before each test."""
+    yield
+
+
+@pytest.fixture
+def mock_api_response():
+    """Fixture to create mock API responses."""
+    return create_mock_response
+
+
+@pytest.fixture
+def sample_manifest():
+    """Return sample manifest for testing."""
+    return {
+        "id": "last_fm",
+        "name": "Last.fm Now Playing",
+        "version": "1.0.0",
+        "settings_schema": {
+            "type": "object",
+            "properties": {
+                "username": {"type": "string"},
+                "api_key": {"type": "string"},
+                "refresh_seconds": {"type": "integer", "default": 30},
+                "show_album": {"type": "boolean", "default": False},
+            },
+            "required": ["username", "api_key"]
+        }
+    }
+
+
+@pytest.fixture
+def sample_config():
+    """Return sample configuration for testing."""
+    return {
+        "username": "testuser",
+        "api_key": "test_api_key_12345",
+        "refresh_seconds": 30,
+        "show_album": False,
+        "enabled": True
+    }
+
+
+@pytest.fixture
+def nowplaying_response():
+    """Return a sample Last.fm API response with nowplaying track."""
+    return {
+        "recenttracks": {
+            "track": [
+                {
+                    "name": "Test Song",
+                    "artist": {"#text": "Test Artist"},
+                    "album": {"#text": "Test Album"},
+                    "image": [
+                        {"#text": "https://example.com/small.jpg", "size": "small"},
+                        {"#text": "https://example.com/medium.jpg", "size": "medium"},
+                        {"#text": "https://example.com/large.jpg", "size": "large"},
+                        {"#text": "https://example.com/extralarge.jpg", "size": "extralarge"}
+                    ],
+                    "url": "https://www.last.fm/music/Test+Artist/_/Test+Song",
+                    "@attr": {"nowplaying": "true"}
+                }
+            ],
+            "@attr": {
+                "user": "testuser",
+                "totalPages": "1",
+                "page": "1",
+                "perPage": "1",
+                "total": "1"
+            }
+        }
+    }
+
+
+@pytest.fixture
+def recent_track_response():
+    """Return a sample Last.fm API response without nowplaying (just recent)."""
+    return {
+        "recenttracks": {
+            "track": [
+                {
+                    "name": "Recent Song",
+                    "artist": {"#text": "Recent Artist"},
+                    "album": {"#text": "Recent Album"},
+                    "image": [
+                        {"#text": "https://example.com/artwork.jpg", "size": "extralarge"}
+                    ],
+                    "url": "https://www.last.fm/music/Recent+Artist/_/Recent+Song",
+                    "date": {"uts": "1704067200", "#text": "01 Jan 2024, 00:00"}
+                }
+            ]
+        }
+    }
+
+
+@pytest.fixture
+def empty_tracks_response():
+    """Return a sample Last.fm API response with no tracks."""
+    return {
+        "recenttracks": {
+            "track": [],
+            "@attr": {
+                "user": "testuser",
+                "totalPages": "0",
+                "page": "1",
+                "perPage": "1",
+                "total": "0"
+            }
+        }
+    }
+
+
+@pytest.fixture
+def error_response():
+    """Return a sample Last.fm API error response."""
+    return {
+        "error": 6,
+        "message": "User not found"
+    }

--- a/plugins/last_fm/tests/test_plugin.py
+++ b/plugins/last_fm/tests/test_plugin.py
@@ -1,0 +1,417 @@
+"""Unit tests for Last.fm Now Playing plugin."""
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from datetime import datetime, timedelta
+
+from plugins.last_fm import LastFmPlugin, LASTFM_API_URL
+
+
+class TestLastFmPlugin:
+    """Test Last.fm plugin."""
+    
+    def test_plugin_id(self, sample_manifest):
+        """Test plugin ID matches manifest."""
+        plugin = LastFmPlugin(sample_manifest)
+        assert plugin.plugin_id == "last_fm"
+    
+    def test_init(self, sample_manifest):
+        """Test plugin initialization."""
+        plugin = LastFmPlugin(sample_manifest)
+        assert plugin._cache is None
+        assert plugin._cache_time is None
+    
+    def test_validate_config_valid(self, sample_manifest, sample_config):
+        """Test config validation with valid config."""
+        plugin = LastFmPlugin(sample_manifest)
+        errors = plugin.validate_config(sample_config)
+        assert errors == []
+    
+    def test_validate_config_missing_username(self, sample_manifest):
+        """Test config validation with missing username."""
+        plugin = LastFmPlugin(sample_manifest)
+        config = {"api_key": "test_key", "refresh_seconds": 30}
+        errors = plugin.validate_config(config)
+        assert any("username" in e.lower() for e in errors)
+    
+    def test_validate_config_missing_api_key(self, sample_manifest):
+        """Test config validation with missing API key."""
+        plugin = LastFmPlugin(sample_manifest)
+        config = {"username": "testuser", "refresh_seconds": 30}
+        errors = plugin.validate_config(config)
+        assert any("api key" in e.lower() for e in errors)
+    
+    def test_validate_config_invalid_refresh(self, sample_manifest):
+        """Test config validation with invalid refresh interval."""
+        plugin = LastFmPlugin(sample_manifest)
+        config = {"username": "testuser", "api_key": "key", "refresh_seconds": 5}
+        errors = plugin.validate_config(config)
+        assert any("refresh" in e.lower() or "10 seconds" in e.lower() for e in errors)
+    
+    @patch.dict('os.environ', {'LASTFM_USERNAME': 'envuser', 'LASTFM_API_KEY': 'envkey'})
+    def test_validate_config_from_env(self, sample_manifest):
+        """Test config validation uses environment variables as fallback."""
+        plugin = LastFmPlugin(sample_manifest)
+        config = {}  # Empty config, should use env vars
+        errors = plugin.validate_config(config)
+        assert errors == []
+    
+    @patch('plugins.last_fm.requests.get')
+    def test_fetch_data_nowplaying(self, mock_get, sample_manifest, sample_config, nowplaying_response):
+        """Test fetch_data with currently playing track."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = nowplaying_response
+        mock_get.return_value = mock_response
+        
+        plugin = LastFmPlugin(sample_manifest)
+        plugin.config = sample_config
+        
+        result = plugin.fetch_data()
+        
+        assert result.available is True
+        assert result.data["title"] == "Test Song"
+        assert result.data["artist"] == "Test Artist"
+        assert result.data["album"] == "Test Album"
+        assert result.data["is_playing"] is True
+        assert result.data["status"] == "NOW PLAYING"
+        assert "extralarge" in result.data["artwork_url"]
+        assert "Test Song by Test Artist" in result.data["formatted"]
+    
+    @patch('plugins.last_fm.requests.get')
+    def test_fetch_data_recent_track(self, mock_get, sample_manifest, sample_config, recent_track_response):
+        """Test fetch_data with recently played track (not currently playing)."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = recent_track_response
+        mock_get.return_value = mock_response
+        
+        plugin = LastFmPlugin(sample_manifest)
+        plugin.config = sample_config
+        
+        result = plugin.fetch_data()
+        
+        assert result.available is True
+        assert result.data["title"] == "Recent Song"
+        assert result.data["artist"] == "Recent Artist"
+        assert result.data["is_playing"] is False
+        assert result.data["status"] == "LAST PLAYED"
+    
+    @patch('plugins.last_fm.requests.get')
+    def test_fetch_data_no_tracks(self, mock_get, sample_manifest, sample_config, empty_tracks_response):
+        """Test fetch_data with no recent tracks."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = empty_tracks_response
+        mock_get.return_value = mock_response
+        
+        plugin = LastFmPlugin(sample_manifest)
+        plugin.config = sample_config
+        
+        result = plugin.fetch_data()
+        
+        assert result.available is True
+        assert result.data["title"] == ""
+        assert result.data["is_playing"] is False
+        assert "No recent tracks" in result.data["status"]
+    
+    @patch('plugins.last_fm.requests.get')
+    def test_fetch_data_api_error(self, mock_get, sample_manifest, sample_config, error_response):
+        """Test fetch_data handles API error response."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = error_response
+        mock_get.return_value = mock_response
+        
+        plugin = LastFmPlugin(sample_manifest)
+        plugin.config = sample_config
+        
+        result = plugin.fetch_data()
+        
+        assert result.available is False
+        assert "User not found" in result.error
+    
+    @patch('plugins.last_fm.requests.get')
+    def test_fetch_data_invalid_api_key(self, mock_get, sample_manifest, sample_config):
+        """Test fetch_data handles 403 invalid API key."""
+        mock_response = Mock()
+        mock_response.status_code = 403
+        mock_get.return_value = mock_response
+        
+        plugin = LastFmPlugin(sample_manifest)
+        plugin.config = sample_config
+        
+        result = plugin.fetch_data()
+        
+        assert result.available is False
+        assert "Invalid API key" in result.error
+    
+    @patch('plugins.last_fm.requests.get')
+    def test_fetch_data_user_not_found(self, mock_get, sample_manifest, sample_config):
+        """Test fetch_data handles 404 user not found."""
+        mock_response = Mock()
+        mock_response.status_code = 404
+        mock_get.return_value = mock_response
+        
+        plugin = LastFmPlugin(sample_manifest)
+        plugin.config = sample_config
+        
+        result = plugin.fetch_data()
+        
+        assert result.available is False
+        assert "not found" in result.error.lower()
+    
+    @patch('plugins.last_fm.requests.get')
+    def test_fetch_data_network_error(self, mock_get, sample_manifest, sample_config):
+        """Test fetch_data handles network errors."""
+        import requests
+        mock_get.side_effect = requests.exceptions.ConnectionError("Network error")
+        
+        plugin = LastFmPlugin(sample_manifest)
+        plugin.config = sample_config
+        
+        result = plugin.fetch_data()
+        
+        assert result.available is False
+        assert "Network error" in result.error
+    
+    @patch('plugins.last_fm.requests.get')
+    def test_fetch_data_timeout(self, mock_get, sample_manifest, sample_config):
+        """Test fetch_data handles timeout."""
+        import requests
+        mock_get.side_effect = requests.exceptions.Timeout("Request timed out")
+        
+        plugin = LastFmPlugin(sample_manifest)
+        plugin.config = sample_config
+        
+        result = plugin.fetch_data()
+        
+        assert result.available is False
+        assert "timed out" in result.error.lower()
+    
+    @patch('plugins.last_fm.requests.get')
+    def test_fetch_data_uses_cache(self, mock_get, sample_manifest, sample_config, nowplaying_response):
+        """Test fetch_data uses cache within refresh interval."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = nowplaying_response
+        mock_get.return_value = mock_response
+        
+        plugin = LastFmPlugin(sample_manifest)
+        plugin.config = sample_config
+        
+        # First call
+        result1 = plugin.fetch_data()
+        assert result1.available is True
+        assert mock_get.call_count == 1
+        
+        # Second call (should use cache)
+        result2 = plugin.fetch_data()
+        assert result2.available is True
+        assert mock_get.call_count == 1  # No additional API call
+        assert result2.data["title"] == result1.data["title"]
+    
+    @patch('plugins.last_fm.requests.get')
+    def test_fetch_data_cache_expires(self, mock_get, sample_manifest, sample_config, nowplaying_response):
+        """Test fetch_data refreshes cache after interval."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = nowplaying_response
+        mock_get.return_value = mock_response
+        
+        plugin = LastFmPlugin(sample_manifest)
+        plugin.config = sample_config
+        
+        # First call
+        plugin.fetch_data()
+        assert mock_get.call_count == 1
+        
+        # Simulate cache expiration
+        plugin._cache_time = datetime.now() - timedelta(seconds=60)
+        
+        # Second call (should refresh)
+        plugin.fetch_data()
+        assert mock_get.call_count == 2
+    
+    @patch('plugins.last_fm.requests.get')
+    def test_fetch_data_fallback_to_cache_on_error(self, mock_get, sample_manifest, sample_config, nowplaying_response):
+        """Test fetch_data falls back to cache on network error."""
+        # First successful call
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = nowplaying_response
+        mock_get.return_value = mock_response
+        
+        plugin = LastFmPlugin(sample_manifest)
+        plugin.config = sample_config
+        
+        result1 = plugin.fetch_data()
+        assert result1.available is True
+        
+        # Simulate cache expiration
+        plugin._cache_time = datetime.now() - timedelta(seconds=60)
+        
+        # Second call fails
+        import requests
+        mock_get.side_effect = requests.exceptions.ConnectionError("Network error")
+        
+        result2 = plugin.fetch_data()
+        
+        # Should return cached data
+        assert result2.available is True
+        assert result2.data["title"] == "Test Song"
+    
+    def test_fetch_data_missing_username(self, sample_manifest):
+        """Test fetch_data returns error when username missing."""
+        plugin = LastFmPlugin(sample_manifest)
+        plugin.config = {"api_key": "test_key"}
+        
+        result = plugin.fetch_data()
+        
+        assert result.available is False
+        assert "username" in result.error.lower()
+    
+    def test_fetch_data_missing_api_key(self, sample_manifest):
+        """Test fetch_data returns error when API key missing."""
+        plugin = LastFmPlugin(sample_manifest)
+        plugin.config = {"username": "testuser"}
+        
+        result = plugin.fetch_data()
+        
+        assert result.available is False
+        assert "api key" in result.error.lower()
+    
+    @patch('plugins.last_fm.requests.get')
+    def test_fetch_data_artist_as_string(self, mock_get, sample_manifest, sample_config):
+        """Test fetch_data handles artist as string (not dict)."""
+        response = {
+            "recenttracks": {
+                "track": [
+                    {
+                        "name": "Test Song",
+                        "artist": "String Artist",  # Artist as string, not dict
+                        "album": {"#text": "Test Album"},
+                        "image": [],
+                        "url": "https://example.com"
+                    }
+                ]
+            }
+        }
+        
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = response
+        mock_get.return_value = mock_response
+        
+        plugin = LastFmPlugin(sample_manifest)
+        plugin.config = sample_config
+        
+        result = plugin.fetch_data()
+        
+        assert result.available is True
+        assert result.data["artist"] == "String Artist"
+    
+    @patch('plugins.last_fm.requests.get')
+    def test_fetch_data_single_track_dict(self, mock_get, sample_manifest, sample_config):
+        """Test fetch_data handles single track as dict (not list)."""
+        response = {
+            "recenttracks": {
+                "track": {  # Single track as dict, not list
+                    "name": "Single Song",
+                    "artist": {"#text": "Single Artist"},
+                    "album": {"#text": "Single Album"},
+                    "image": [],
+                    "url": "https://example.com"
+                }
+            }
+        }
+        
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = response
+        mock_get.return_value = mock_response
+        
+        plugin = LastFmPlugin(sample_manifest)
+        plugin.config = sample_config
+        
+        result = plugin.fetch_data()
+        
+        assert result.available is True
+        assert result.data["title"] == "Single Song"
+    
+    @patch('plugins.last_fm.requests.get')
+    def test_get_formatted_display(self, mock_get, sample_manifest, sample_config, nowplaying_response):
+        """Test get_formatted_display returns 6 lines."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = nowplaying_response
+        mock_get.return_value = mock_response
+        
+        plugin = LastFmPlugin(sample_manifest)
+        plugin.config = sample_config
+        
+        lines = plugin.get_formatted_display()
+        
+        assert lines is not None
+        assert len(lines) == 6
+        assert "NOW PLAYING" in lines[0]
+        assert "Test Song" in lines[2]
+        assert "Test Artist" in lines[3]
+    
+    @patch('plugins.last_fm.requests.get')
+    def test_get_formatted_display_with_album(self, mock_get, sample_manifest, nowplaying_response):
+        """Test get_formatted_display includes album when configured."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = nowplaying_response
+        mock_get.return_value = mock_response
+        
+        plugin = LastFmPlugin(sample_manifest)
+        plugin.config = {
+            "username": "testuser",
+            "api_key": "test_key",
+            "show_album": True
+        }
+        
+        lines = plugin.get_formatted_display()
+        
+        assert lines is not None
+        assert len(lines) == 6
+        # Album should be in one of the lines
+        assert any("Test Album" in line for line in lines)
+    
+    def test_cleanup(self, sample_manifest):
+        """Test cleanup clears cache."""
+        plugin = LastFmPlugin(sample_manifest)
+        plugin._cache = {"title": "cached"}
+        plugin._cache_time = datetime.now()
+        
+        plugin.cleanup()
+        
+        assert plugin._cache is None
+        assert plugin._cache_time is None
+    
+    @patch('plugins.last_fm.requests.get')
+    def test_api_request_params(self, mock_get, sample_manifest, sample_config, nowplaying_response):
+        """Test correct API parameters are sent."""
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = nowplaying_response
+        mock_get.return_value = mock_response
+        
+        plugin = LastFmPlugin(sample_manifest)
+        plugin.config = sample_config
+        
+        plugin.fetch_data()
+        
+        # Check API was called with correct params
+        mock_get.assert_called_once()
+        call_args = mock_get.call_args
+        
+        assert call_args[0][0] == LASTFM_API_URL
+        params = call_args[1]["params"]
+        assert params["method"] == "user.getRecentTracks"
+        assert params["user"] == "testuser"
+        assert params["api_key"] == "test_api_key_12345"
+        assert params["format"] == "json"
+        assert params["limit"] == 1


### PR DESCRIPTION
Add new plugin that displays currently playing music via Last.fm scrobbling. Works with any music source (Apple Music, Spotify, etc.) that scrobbles to Last.fm.

- Polls Last.fm user.getRecentTracks API for real-time now playing status
- Exposes template variables: title, artist, album, is_playing, status
- Includes comprehensive tests with 97% coverage
- Updates .cursorrules with plugin creation checklist

Closes #117