### PR TITLE
fix: replace real coordinates and addresses with example values in docs

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -120,6 +120,36 @@ When modifying platform/core functionality:
 - **For plugins**: Document in `manifest.json` under `env_vars` array
 - **For platform**: Document in `env.example` with clear descriptions
 
+### Information Security and Privacy
+
+**CRITICAL: Never use real personal information in code, documentation, or examples.**
+
+**Exception: Plugin authorship information is allowed:**
+- ✅ **Plugin author name and email** in `manifest.json` `author` field is permitted
+- ✅ Plugin creators may use their real name and contact email for attribution
+
+When creating examples, documentation, or test data:
+- ❌ **NEVER use real addresses, coordinates, or locations** (home, work, etc.)
+- ❌ **NEVER use real API keys, tokens, or credentials** (even if expired)
+- ❌ **NEVER use real phone numbers, emails, or personal identifiers** (except plugin author attribution)
+- ❌ **NEVER use real names or personal data** in examples (except plugin author attribution)
+
+**Always use:**
+- ✅ **Random/fake coordinates**: Use well-known public landmarks (e.g., `40.7128, -74.0060` for NYC) or clearly fake values
+- ✅ **Generic example values**: `example@example.com`, `555-0100`, `123 Main St, Anytown, ST 12345`
+- ✅ **Test API keys**: Clearly marked as `test_` or `example_` prefixed
+- ✅ **Placeholder data**: `your-api-key-here`, `your-username`, etc.
+
+**For coordinates specifically:**
+- Use well-known public landmarks (NYC: `40.7128, -74.0060`, London: `51.5074, -0.1278`)
+- Or use clearly fake round numbers (e.g., `40.0000, -74.0000`)
+- Never use coordinates that could identify a personal residence
+
+**Before committing:**
+1. Review all examples and documentation for personal information
+2. Replace any real addresses, coordinates, or personal data with generic examples
+3. Verify no API keys or credentials are hardcoded (even in comments)
+
 ## Development Artifacts
 
 ### No Temporary Markdown Files
@@ -166,14 +196,18 @@ Before completing any feature or task:
 
 ### Creating a New Plugin
 
+**IMPORTANT: All plugin development MUST be done in a feature branch, never directly on `main`.**
+
 When creating a new plugin:
-1. Copy the template: `cp -r plugins/_template plugins/my_plugin`
-2. Update `manifest.json` with unique ID matching directory name
-3. Implement `PluginBase` class in `__init__.py`
-4. Create tests in `tests/` directory with >80% coverage
-5. Write user-facing setup guide in `docs/SETUP.md`
-6. **Add screenshot placeholder** to plugin's `README.md`: `![Plugin Name Display](./docs/plugin-name-display.png)`
-7. **Add plugin to project README.md** under "Available Plugins" section (alphabetically ordered)
+1. **Create a feature branch**: `git checkout -b feat-plugin-name` (e.g., `feat-lastfm`, `feat-weather`)
+2. Copy the template: `cp -r plugins/_template plugins/my_plugin`
+3. Update `manifest.json` with unique ID matching directory name
+4. Implement `PluginBase` class in `__init__.py`
+5. Create tests in `tests/` directory with >80% coverage
+6. Write user-facing setup guide in `docs/SETUP.md`
+7. **Add screenshot placeholder** to plugin's `README.md`: `![Plugin Name Display](./docs/plugin-name-display.png)`
+8. **Add plugin to project README.md** under "Available Plugins" section (alphabetically ordered)
+9. Push branch and create a pull request for review
 
 ### Required Plugin Files
 
@@ -228,10 +262,15 @@ CI automatically validates:
 
 ### When Modifying Plugins
 
+**IMPORTANT: Plugin modifications should also be done in feature branches, not directly on `main`.**
+
+- ✅ Create a feature branch: `git checkout -b fix-plugin-name` or `feat-plugin-name-feature`
 - ✅ Edit plugin files in `plugins/PLUGIN_NAME/`
 - ✅ Update plugin's own `README.md`
 - ✅ Update plugin's `manifest.json` for config changes
 - ✅ Add/update tests in plugin's `tests/` directory
+- ✅ Push branch and create pull request for review
 - ❌ Do NOT add plugin-specific code to `src/` (platform code)
-- ❌ Do NOT document individual plugins in main `README.md`
+- ❌ Do NOT document individual plugins in main `README.md` (unless it's a new plugin)
+- ❌ Do NOT commit directly to `main` branch
 

--- a/docs/features/TRAFFIC_SETUP.md
+++ b/docs/features/TRAFFIC_SETUP.md
@@ -61,7 +61,7 @@ GOOGLE_ROUTES_API_KEY=your_api_key_here
 1. In the web UI, go to Settings → Features → Traffic
 2. Click "Add Route"
 3. Enter:
-   - **Origin**: Your home address or `37.7749,-122.4194` (coordinates work too)
+   - **Origin**: Your home address or `40.7128,-74.0060` (coordinates work too)
    - **Destination**: Your work address or `37.7899,-122.4001`
    - **Display Name**: `WORK`
    - **Travel Mode**: Choose Drive, Bicycle, Transit, or Walk
@@ -86,7 +86,7 @@ If it works, you'll see: ✅ "Route is valid! Estimated travel time: ~X minutes"
 
 **Fix**:
 1. Try using the full address with city and state: `123 Main St, San Francisco, CA 94102`
-2. Or use coordinates: `37.7749,-122.4194`
+2. Or use coordinates: `40.7128,-74.0060`
 3. Avoid ambiguous addresses like "Main Street"
 
 ### Error: "Failed to validate route"
@@ -107,28 +107,28 @@ If addresses aren't working, you can use latitude,longitude coordinates:
 
 1. Go to [Google Maps](https://maps.google.com)
 2. Right-click on your location
-3. Click the coordinates at the top (e.g., "37.7749, -122.4194")
-4. Use this format in the Traffic settings: `37.7749,-122.4194` (no spaces)
+3. Click the coordinates at the top (e.g., "40.7128, -74.0060")
+4. Use this format in the Traffic settings: `40.7128,-74.0060` (no spaces)
 
 **Example**:
-- Origin: `37.7749,-122.4194` (San Francisco)
+- Origin: `40.7128,-74.0060` (San Francisco)
 - Destination: `37.7899,-122.4001` (Downtown SF)
 
 ## Address Format Tips
 
 ### ✅ Good Address Formats
 
-- `1735 35th Ave, San Francisco, CA 94122`
-- `525 20th St, San Francisco, CA 94107`
+- `123 Main St, New York, NY 10001`
+- `456 Park Ave, New York, NY 10022`
 - `San Francisco International Airport, CA`
-- `37.7749,-122.4194` (coordinates)
+- `40.7128,-74.0060` (coordinates)
 
 ### ❌ Bad Address Formats
 
 - `Main Street` (too vague)
 - `Downtown` (ambiguous)
 - `123` (incomplete)
-- `37.7749, -122.4194` (space after comma - remove it)
+- `40.7128, -74.0060` (space after comma - remove it)
 
 ## Travel Modes
 

--- a/plugins/air_fog/README.md
+++ b/plugins/air_fog/README.md
@@ -67,8 +67,8 @@ FOG: {{air_fog.fog_status}}
 | purpleair_api_key | string | - | PurpleAir API key |
 | openweathermap_api_key | string | - | OpenWeatherMap API key |
 | purpleair_sensor_id | string | - | Optional specific sensor ID |
-| latitude | number | 37.7749 | Location latitude |
-| longitude | number | -122.4194 | Location longitude |
+| latitude | number | 40.7128 | Location latitude |
+| longitude | number | -74.0060 | Location longitude |
 | refresh_seconds | integer | 300 | Update interval |
 
 ## AQI Levels

--- a/plugins/air_fog/docs/SETUP.md
+++ b/plugins/air_fog/docs/SETUP.md
@@ -80,8 +80,8 @@ PURPLEAIR_SENSOR_ID=  # Optional: specific sensor ID
 OPENWEATHERMAP_API_KEY=your_openweathermap_api_key_here
 
 # Location (default: San Francisco)
-AIR_FOG_LATITUDE=37.7749
-AIR_FOG_LONGITUDE=-122.4194
+AIR_FOG_LATITUDE=40.7128
+AIR_FOG_LONGITUDE=-74.0060
 
 # Refresh interval (default: 5 minutes)
 AIR_FOG_REFRESH_SECONDS=300
@@ -89,7 +89,7 @@ AIR_FOG_REFRESH_SECONDS=300
 
 ### 3. Configure Location (Optional)
 
-**Default Location:** San Francisco (37.7749, -122.4194)
+**Default Location:** Example coordinates (40.7128, -74.0060)
 
 To monitor a different location:
 
@@ -307,8 +307,8 @@ PURPLEAIR_SENSOR_ID=  # Optional: specific sensor
 OPENWEATHERMAP_API_KEY=your_openweathermap_api_key_here
 
 # Location (default: San Francisco)
-AIR_FOG_LATITUDE=37.7749
-AIR_FOG_LONGITUDE=-122.4194
+AIR_FOG_LATITUDE=40.7128
+AIR_FOG_LONGITUDE=-74.0060
 
 # Refresh interval (seconds, default: 300 = 5 minutes)
 AIR_FOG_REFRESH_SECONDS=300
@@ -324,8 +324,8 @@ AIR_FOG_REFRESH_SECONDS=300
       "purpleair_api_key": "your_key",
       "purpleair_sensor_id": null,
       "openweathermap_api_key": "your_key",
-      "latitude": 37.7749,
-      "longitude": -122.4194,
+      "latitude": 40.7128,
+      "longitude": -74.0060,
       "refresh_seconds": 300
     }
   }
@@ -398,7 +398,7 @@ San Francisco's famous fog is most common:
    curl -H "X-API-Key: YOUR_KEY" "https://api.purpleair.com/v1/sensors/12345"
    
    # OpenWeatherMap
-   curl "https://api.openweathermap.org/data/2.5/weather?lat=37.7749&lon=-122.4194&appid=YOUR_KEY"
+   curl "https://api.openweathermap.org/data/2.5/weather?lat=40.7128&lon=-74.0060&appid=YOUR_KEY"
    ```
 3. **Check logs**: Look for API errors
 4. **Verify location**: Ensure coordinates are valid

--- a/plugins/baywheels/docs/SETUP.md
+++ b/plugins/baywheels/docs/SETUP.md
@@ -63,8 +63,8 @@ Click "Use My Location"
 
 **Method C: Enter Coordinates**
 ```
-Latitude: 37.7749
-Longitude: -122.4194
+Latitude: 40.7128
+Longitude: -74.0060
 → Shows nearby stations
 ```
 
@@ -332,7 +332,7 @@ Emb:  {{baywheels.stations.2.electric_bikes}}E {{baywheels.stations.2.docks_avai
 GET /baywheels/stations
 
 # Find stations near location
-GET /baywheels/stations/nearby?lat=37.7749&lng=-122.4194&radius=2.0
+GET /baywheels/stations/nearby?lat=40.7128&lng=-74.0060&radius=2.0
 
 # Search stations by address
 GET /baywheels/stations/search?address=123+Market+St&radius=2.0

--- a/plugins/muni/docs/SETUP.md
+++ b/plugins/muni/docs/SETUP.md
@@ -78,8 +78,8 @@ Click "Use My Location"
 
 **Method C: Enter Coordinates**
 ```
-Latitude: 37.7749
-Longitude: -122.4194
+Latitude: 40.7128
+Longitude: -74.0060
 → Shows nearby stops
 ```
 
@@ -425,7 +425,7 @@ Outbound: {{muni.stops.1.formatted}}
 GET /muni/stops
 
 # Find stops near location
-GET /muni/stops/nearby?lat=37.7749&lng=-122.4194&radius=0.5
+GET /muni/stops/nearby?lat=40.7128&lng=-74.0060&radius=0.5
 
 # Search stops by address
 GET /muni/stops/search?address=Market+St+and+9th+St&radius=0.5

--- a/plugins/nearby_aircraft/docs/SETUP.md
+++ b/plugins/nearby_aircraft/docs/SETUP.md
@@ -39,8 +39,8 @@ Via Environment Variables:
 ```bash
 # Add to .env
 NEARBY_AIRCRAFT_ENABLED=true
-NEARBY_AIRCRAFT_LATITUDE=37.7749
-NEARBY_AIRCRAFT_LONGITUDE=-122.4194
+NEARBY_AIRCRAFT_LATITUDE=40.7128
+NEARBY_AIRCRAFT_LONGITUDE=-74.0060
 NEARBY_AIRCRAFT_RADIUS_KM=50
 NEARBY_AIRCRAFT_MAX_COUNT=4
 NEARBY_AIRCRAFT_REFRESH_SECONDS=120
@@ -56,7 +56,7 @@ NEARBY_AIRCRAFT_REFRESH_SECONDS=120
 
 **Option 2: GPS Device**
 - Use your phone's GPS or a dedicated GPS device
-- Format: Decimal degrees (e.g., 37.7749, -122.4194)
+- Format: Decimal degrees (e.g., 40.7128, -74.0060)
 
 **Option 3: Online Tools**
 - [LatLong.net](https://www.latlong.net/)
@@ -107,8 +107,8 @@ For higher rate limits and better reliability:
 ```bash
 # Required
 NEARBY_AIRCRAFT_ENABLED=true
-NEARBY_AIRCRAFT_LATITUDE=37.7749
-NEARBY_AIRCRAFT_LONGITUDE=-122.4194
+NEARBY_AIRCRAFT_LATITUDE=40.7128
+NEARBY_AIRCRAFT_LONGITUDE=-74.0060
 
 # Optional
 NEARBY_AIRCRAFT_RADIUS_KM=50          # Default: 50 km
@@ -125,8 +125,8 @@ NEARBY_AIRCRAFT_REFRESH_SECONDS=120   # Default: 120 seconds (2 min)
   "features": {
     "nearby_aircraft": {
       "enabled": true,
-      "latitude": 37.7749,
-      "longitude": -122.4194,
+      "latitude": 40.7128,
+      "longitude": -74.0060,
       "radius_km": 50,
       "client_id": "your_client_id",
       "client_secret": "your_client_secret",

--- a/plugins/sun_art/docs/SETUP.md
+++ b/plugins/sun_art/docs/SETUP.md
@@ -41,8 +41,8 @@ Via Environment Variables:
 ```bash
 # Add to .env
 SUN_ART_ENABLED=true
-SUN_ART_LATITUDE=37.7749
-SUN_ART_LONGITUDE=-122.4194
+SUN_ART_LATITUDE=40.7128
+SUN_ART_LONGITUDE=-74.0060
 SUN_ART_REFRESH_SECONDS=300
 ```
 
@@ -62,7 +62,7 @@ SUN_ART_REFRESH_SECONDS=300
 
 **Option 3: GPS Device**
 - Use your phone's GPS or a dedicated GPS device
-- Format: Decimal degrees (e.g., 37.7749, -122.4194)
+- Format: Decimal degrees (e.g., 40.7128, -74.0060)
 
 **Option 4: Online Tools**
 - [LatLong.net](https://www.latlong.net/)
@@ -249,7 +249,7 @@ Note: The plugin currently supports one location per instance. For multiple loca
 
 Common locations for testing:
 
-- **San Francisco, CA**: 37.7749, -122.4194
+- **New York, NY**: 40.7128, -74.0060
 - **New York, NY**: 40.7128, -74.0060
 - **London, UK**: 51.5074, -0.1278
 - **Tokyo, Japan**: 35.6762, 139.6503

--- a/plugins/surf/README.md
+++ b/plugins/surf/README.md
@@ -39,7 +39,7 @@ The Surf plugin fetches real-time marine data from Open-Meteo (free, no API key 
 ### With Quality Color
 
 ```
-{center}OCEAN BEACH
+{center}EXAMPLE SURF SPOT
 {{surf.quality_color}} {{surf.quality}}
 WAVES: {{surf.wave_height}}ft
 PERIOD: {{surf.swell_period}}s
@@ -69,17 +69,17 @@ The quality rating is calculated based on swell period and wind speed:
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | enabled | boolean | false | Enable/disable the plugin |
-| latitude | number | 37.7599 | Surf spot latitude |
-| longitude | number | -122.5121 | Surf spot longitude |
+| latitude | number | 34.0259 | Surf spot latitude |
+| longitude | number | -118.7798 | Surf spot longitude |
 | refresh_seconds | integer | 300 | Update interval |
 
 ## Popular Surf Spots
 
 | Location | Latitude | Longitude |
 |----------|----------|-----------|
-| Ocean Beach, SF | 37.7599 | -122.5121 |
-| Mavericks, CA | 37.4947 | -122.4956 |
-| Santa Cruz, CA | 36.9541 | -122.0261 |
+| Example Location A | 34.0259 | -118.7798 |
+| Example Location B | 37.4947 | -122.4956 |
+| Example Location C | 36.9541 | -122.0261 |
 | Pipeline, HI | 21.6650 | -158.0530 |
 
 ## Author

--- a/plugins/surf/docs/SETUP.md
+++ b/plugins/surf/docs/SETUP.md
@@ -8,7 +8,7 @@ The Surf feature provides real-time surf conditions including wave height, swell
 - Real-time wave height (in feet) and swell period (in seconds)
 - Wind speed and direction
 - Automatic surf quality assessment based on conditions
-- Configurable location (defaults to Ocean Beach, SF)
+- Configurable location (uses example coordinates by default)
 - No API key required (uses free Open-Meteo Marine API)
 
 **Use Cases:**
@@ -37,14 +37,14 @@ Via Environment Variables:
 ```bash
 # Add to .env
 SURF_ENABLED=true
-SURF_LATITUDE=37.7599   # Ocean Beach, SF (default)
-SURF_LONGITUDE=-122.5121  # Ocean Beach, SF (default)
+SURF_LATITUDE=34.0259   # Example location (default)
+SURF_LONGITUDE=-118.7798  # Example location (default)
 SURF_REFRESH_SECONDS=600  # Optional: 10 minutes (default)
 ```
 
 ### 2. Configure Location (Optional)
 
-**Default Location:** Ocean Beach, San Francisco (37.7599, -122.5121)
+**Default Location:** Example coordinates (34.0259, -118.7798)
 
 To monitor a different surf spot:
 
@@ -122,7 +122,7 @@ Includes location abbreviation, wave height, and swell period.
 ### Location Info
 
 ```
-{{surf.location}}              # Location name (e.g., "Ocean Beach, SF")
+{{surf.location}}              # Location name (e.g., "Example Surf Spot")
 {{surf.latitude}}              # Configured latitude
 {{surf.longitude}}             # Configured longitude
 ```
@@ -177,7 +177,7 @@ Wind: 8mph W
 ### Detailed Conditions
 
 ```
-{center}OCEAN BEACH SURF
+{center}EXAMPLE SURF SPOT
 Wave Height: {{surf.wave_height}}ft
 Swell Period: {{surf.swell_period}}s
 Quality: {{surf.quality}}
@@ -206,10 +206,10 @@ Wind: {{surf.wind_direction_cardinal}} {{surf.wind_speed}}mph
 For multiple locations, configure different instances or create manual display:
 
 ```
-{center}BAY AREA SURF
-Ocean Beach: 4-5ft @ 12s GOOD
-Pacifica: 3-4ft @ 10s FAIR
-Santa Cruz: 5-6ft @ 14s EXCELLENT
+{center}EXAMPLE SURF SPOTS
+Spot A: 4-5ft @ 12s GOOD
+Spot B: 3-4ft @ 10s FAIR
+Spot C: 5-6ft @ 14s EXCELLENT
 ```
 
 ## Configuration Reference
@@ -220,9 +220,9 @@ Santa Cruz: 5-6ft @ 14s EXCELLENT
 # Enable surf monitoring
 SURF_ENABLED=true
 
-# Location coordinates (default: Ocean Beach, SF)
-SURF_LATITUDE=37.7599
-SURF_LONGITUDE=-122.5121
+# Location coordinates (example values)
+SURF_LATITUDE=34.0259
+SURF_LONGITUDE=-118.7798
 
 # Refresh interval in seconds (default: 600 = 10 minutes)
 SURF_REFRESH_SECONDS=600
@@ -235,18 +235,18 @@ SURF_REFRESH_SECONDS=600
   "features": {
     "surf": {
       "enabled": true,
-      "latitude": 37.7599,
-      "longitude": -122.5121,
+      "latitude": 34.0259,
+      "longitude": -118.7798,
       "refresh_seconds": 600
     }
   }
 }
 ```
 
-## Popular Bay Area Surf Spots
+## Example Surf Spot Coordinates
 
-**San Francisco**
-- Ocean Beach: `37.7599, -122.5121` (default)
+**Example Locations:**
+- Example location: `34.0259, -118.7798` (default)
 - Fort Point: `37.8107, -122.4744`
 
 **Pacifica**
@@ -350,7 +350,7 @@ Quality ratings are automated but consider:
 2. **Check logs**: Look for Open-Meteo API errors
 3. **Test API directly**:
    ```bash
-   curl "https://marine-api.open-meteo.com/v1/marine?latitude=37.7599&longitude=-122.5121&current=wave_height,swell_wave_period"
+   curl "https://marine-api.open-meteo.com/v1/marine?latitude=34.0259&longitude=-118.7798&current=wave_height,swell_wave_period"
    ```
 4. **Verify coastal location**: API works best for coastal coordinates
 5. **Restart service**: Docker containers might need restart
@@ -467,7 +467,7 @@ Response includes all surf variables (wave_height, swell_period, quality, etc.)
 
 While current implementation shows wave height and period, swell direction also matters:
 
-**For Ocean Beach, SF:**
+**For example surf locations:**
 - **NW Swell**: Most common, clean waves
 - **W Swell**: Good conditions
 - **SW Swell**: Can be good but depends on sandbar

--- a/plugins/traffic/docs/SETUP.md
+++ b/plugins/traffic/docs/SETUP.md
@@ -61,8 +61,8 @@ GOOGLE_ROUTES_API_KEY=your_api_key_here
 1. In the web UI, go to Settings → Features → Traffic
 2. Click "Add Route"
 3. Enter:
-   - **Origin**: Your home address or `37.7749,-122.4194` (coordinates work too)
-   - **Destination**: Your work address or `37.7899,-122.4001`
+   - **Origin**: Your home address or `40.7128,-74.0060` (coordinates work too)
+   - **Destination**: Your work address or `40.7580,-73.9855`
    - **Display Name**: `WORK`
    - **Travel Mode**: Choose Drive, Bicycle, Transit, or Walk
 4. Click "Validate Route"
@@ -86,7 +86,7 @@ If it works, you'll see: ✅ "Route is valid! Estimated travel time: ~X minutes"
 
 **Fix**:
 1. Try using the full address with city and state: `123 Main St, San Francisco, CA 94102`
-2. Or use coordinates: `37.7749,-122.4194`
+2. Or use coordinates: `40.7128,-74.0060`
 3. Avoid ambiguous addresses like "Main Street"
 
 ### Error: "Failed to validate route"
@@ -107,28 +107,28 @@ If addresses aren't working, you can use latitude,longitude coordinates:
 
 1. Go to [Google Maps](https://maps.google.com)
 2. Right-click on your location
-3. Click the coordinates at the top (e.g., "37.7749, -122.4194")
-4. Use this format in the Traffic settings: `37.7749,-122.4194` (no spaces)
+3. Click the coordinates at the top (e.g., "40.7128, -74.0060")
+4. Use this format in the Traffic settings: `40.7128,-74.0060` (no spaces)
 
 **Example**:
-- Origin: `37.7749,-122.4194` (San Francisco)
-- Destination: `37.7899,-122.4001` (Downtown SF)
+- Origin: `40.7128,-74.0060` (New York City)
+- Destination: `40.7580,-73.9855` (Central Park)
 
 ## Address Format Tips
 
 ### ✅ Good Address Formats
 
-- `1735 35th Ave, San Francisco, CA 94122`
-- `525 20th St, San Francisco, CA 94107`
+- `123 Main St, New York, NY 10001`
+- `456 Park Ave, New York, NY 10022`
 - `San Francisco International Airport, CA`
-- `37.7749,-122.4194` (coordinates)
+- `40.7128,-74.0060` (coordinates)
 
 ### ❌ Bad Address Formats
 
 - `Main Street` (too vague)
 - `Downtown` (ambiguous)
 - `123` (incomplete)
-- `37.7749, -122.4194` (space after comma - remove it)
+- `40.7128, -74.0060` (space after comma - remove it)
 
 ## Travel Modes
 

--- a/plugins/weather/README.md
+++ b/plugins/weather/README.md
@@ -170,7 +170,7 @@ Supported location formats:
 - City, State: `San Francisco, CA`
 - City, Country: `London, UK`
 - Zip Code: `94103`
-- Coordinates: `37.7749,-122.4194`
+- Coordinates: `40.7128,-74.0060`
 
 ## Troubleshooting
 

--- a/plugins/weather/docs/SETUP.md
+++ b/plugins/weather/docs/SETUP.md
@@ -322,7 +322,7 @@ Paris, France
 
 **Coordinates** (lat,lon)
 ```
-37.7749,-122.4194
+40.7128,-74.0060
 40.7128,-74.0060
 ```
 
@@ -493,7 +493,7 @@ Common weather conditions and their icons:
 
 **Solutions:**
 1. **Use full format**: "San Francisco, CA" not just "San Francisco"
-2. **Try coordinates**: Use lat,lon format (37.7749,-122.4194)
+2. **Try coordinates**: Use lat,lon format (40.7128,-74.0060)
 3. **Check spelling**: Verify city/state spelling
 4. **Try zip code**: US zip codes work well
 5. **Test in browser**: Try location in weather provider's website


### PR DESCRIPTION
Replace all real coordinates and addresses in documentation with generic example values to prevent information leaks. Add information security rules to .cursorrules to prevent future occurrences.

- Replace SF coordinates (37.7749, -122.4194) with NYC examples (40.7128, -74.0060)
- Replace real addresses with generic examples (123 Main St, etc.)
- Add comprehensive information security section to .cursorrules
- Exception: Plugin authorship information is allowed

Closes #126