### PR TITLE
Fix color block wrapping bug

### DIFF
--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -563,3 +563,70 @@ class TestTemplateAPIEndpoints:
         # Should treat as empty and return 6 empty lines
         assert all(not line.strip() for line in data["lines"])
 
+
+class TestColorWrapping:
+    """Tests for color marker wrapping behavior."""
+    
+    @pytest.fixture
+    def engine(self):
+        return TemplateEngine()
+    
+    def test_color_blocks_wrap_correctly(self, engine):
+        """Test that color blocks wrap correctly without splitting markers."""
+        # Create a string of 120 color blocks (enough to wrap to 5+ lines)
+        # Each {67} is 4 characters but 1 tile, so 120 tiles = 5.45 lines at 22 tiles/line
+        color_string = "{67}" * 120
+        
+        # Wrap it to 5 lines
+        wrapped = engine._word_wrap_tiles(color_string, first_width=22, subsequent_width=22, max_lines=5)
+        
+        # Verify we got 5 lines
+        assert len(wrapped) == 5
+        
+        # Verify each line contains only valid color markers
+        # No partial markers like {67 or }67} should exist
+        for line in wrapped:
+            # Count opening braces
+            open_braces = line.count("{")
+            # Count closing braces
+            close_braces = line.count("}")
+            # They should be equal (each marker has both)
+            assert open_braces == close_braces, f"Line has mismatched braces: {line}"
+            
+            # Verify no partial markers (opening brace without closing, or closing without opening)
+            # Check that every { is followed by a } before the next {
+            i = 0
+            while i < len(line):
+                if line[i] == "{":
+                    # Find the closing brace
+                    closing = line.find("}", i)
+                    assert closing != -1, f"Unclosed brace at position {i} in line: {line}"
+                    # Verify the content between is valid (digits 63-70 or color name)
+                    content = line[i + 1:closing]
+                    assert content.isdigit() or content.lower() in COLOR_CODES or content.startswith("/"), \
+                        f"Invalid color marker content: {content} in line: {line}"
+                    i = closing + 1
+                elif line[i] == "}":
+                    # Should not have a closing brace without an opening
+                    assert False, f"Closing brace without opening at position {i} in line: {line}"
+                else:
+                    i += 1
+    
+    def test_color_blocks_with_text_wrap(self, engine):
+        """Test wrapping color blocks mixed with text."""
+        # Mix of color blocks and text
+        text = "{67}" * 30 + "HELLO" + "{66}" * 30
+        
+        wrapped = engine._word_wrap_tiles(text, first_width=22, subsequent_width=22, max_lines=5)
+        
+        # Verify all color markers are intact
+        full_text = "".join(wrapped)
+        # Count braces should match
+        assert full_text.count("{") == full_text.count("}")
+        
+        # Verify no partial markers
+        for line in wrapped:
+            open_count = line.count("{")
+            close_count = line.count("}")
+            assert open_count == close_count, f"Line has mismatched braces: {line}"
+


### PR DESCRIPTION
## Problem
When wrapping long strings of color blocks (e.g., `{67}{67}{67}...`), the wrapping logic was splitting color markers character-by-character, which could break markers in the middle (e.g., `{67` or `}67}`). These partial markers were then parsed as regular characters, causing spaces and numbers to appear on the board.

## Solution
- Added `_split_into_tokens()` helper function that splits text into complete tokens (color markers or single characters), ensuring color markers are never split
- Updated `_word_wrap_tiles()` to use token-based splitting instead of character-by-character when breaking long words
- Now takes as many complete tokens as fit on each line, preserving color marker integrity

## Testing
- Added comprehensive tests in `test_templates.py` to verify:
  - Color blocks wrap correctly without splitting markers
  - No partial markers are created
  - Color blocks mixed with text wrap correctly

## Impact
Fixes the bug where wrapping 5+ lines of color blocks would display spaces and numbers on the board instead of just color tiles.