### PR TITLE
Update plugin links to point to README instead of SETUP

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,22 +62,22 @@ docker-compose down
 FiestaBoard uses a **plugin architecture** - each feature is a self-contained plugin with its own documentation. Browse the `plugins/` directory or use the web UI's **Integrations** page to discover and enable plugins.
 
 ### Available Plugins
-- 💨 **[Air Quality & Fog](./plugins/air_fog/docs/SETUP.md)**: Monitor AQI and fog conditions
-- 🚴 **[Bay Wheels](./plugins/baywheels/docs/SETUP.md)**: Track bike availability at multiple stations
+- 💨 **[Air Quality & Fog](./plugins/air_fog/README.md)**: Monitor AQI and fog conditions
+- 🚴 **[Bay Wheels](./plugins/baywheels/README.md)**: Track bike availability at multiple stations
 - 📅 **[Date & Time](./plugins/date_time/README.md)**: Current date and time with multiple formats (12h/24h, US dates) and timezone autocomplete
-- 📶 **[Guest WiFi](./plugins/guest_wifi/docs/SETUP.md)**: Display WiFi credentials for guests
-- 🏠 **[Home Assistant](./plugins/home_assistant/docs/SETUP.md)**: House status display (doors, garage, locks, etc.)
-- 🎵 **[Last.fm Now Playing](./plugins/last_fm/docs/SETUP.md)**: Display currently playing music via Last.fm scrobbling
-- 🚇 **[Muni Transit](./plugins/muni/docs/SETUP.md)**: Real-time SF Muni arrival predictions
-- 🛩️ **[Nearby Aircraft](./plugins/nearby_aircraft/docs/SETUP.md)**: Real-time nearby aircraft information from OpenSky Network API
-- 🏆 **[Sports Scores](./plugins/sports_scores/docs/SETUP.md)**: Display recent match scores from NFL, Soccer, NHL, and NBA
-- ☀️ **[Sun Art](./plugins/sun_art/docs/SETUP.md)**: Full-screen sun art pattern that changes based on sun position throughout the day
-- 🖖 **[Star Trek Quotes](./plugins/star_trek_quotes/docs/SETUP.md)**: Random quotes from TNG, Voyager, and DS9
-- 📈 **[Stocks](./plugins/stocks/docs/SETUP.md)**: Monitor stock prices with color-coded indicators
-- 🌊 **[Surf Conditions](./plugins/surf/docs/SETUP.md)**: Live surf reports with wave height and quality ratings
-- 🚗 **[Traffic](./plugins/traffic/docs/SETUP.md)**: Travel time to destinations with live traffic
-- 🕐 **[Visual Clock](./plugins/visual_clock/docs/SETUP.md)**: Full-screen clock with large pixel-art style digits
-- 🌤️ **[Weather](./plugins/weather/docs/SETUP.md)**: Current conditions with temperature (F/C), UV index, precipitation chance, daily high/low, and sunset time
+- 📶 **[Guest WiFi](./plugins/guest_wifi/README.md)**: Display WiFi credentials for guests
+- 🏠 **[Home Assistant](./plugins/home_assistant/README.md)**: House status display (doors, garage, locks, etc.)
+- 🎵 **[Last.fm Now Playing](./plugins/last_fm/README.md)**: Display currently playing music via Last.fm scrobbling
+- 🚇 **[Muni Transit](./plugins/muni/README.md)**: Real-time SF Muni arrival predictions
+- 🛩️ **[Nearby Aircraft](./plugins/nearby_aircraft/README.md)**: Real-time nearby aircraft information from OpenSky Network API
+- 🏆 **[Sports Scores](./plugins/sports_scores/README.md)**: Display recent match scores from NFL, Soccer, NHL, and NBA
+- ☀️ **[Sun Art](./plugins/sun_art/README.md)**: Full-screen sun art pattern that changes based on sun position throughout the day
+- 🖖 **[Star Trek Quotes](./plugins/star_trek_quotes/README.md)**: Random quotes from TNG, Voyager, and DS9
+- 📈 **[Stocks](./plugins/stocks/README.md)**: Monitor stock prices with color-coded indicators
+- 🌊 **[Surf Conditions](./plugins/surf/README.md)**: Live surf reports with wave height and quality ratings
+- 🚗 **[Traffic](./plugins/traffic/README.md)**: Travel time to destinations with live traffic
+- 🕐 **[Visual Clock](./plugins/visual_clock/README.md)**: Full-screen clock with large pixel-art style digits
+- 🌤️ **[Weather](./plugins/weather/README.md)**: Current conditions with temperature (F/C), UV index, precipitation chance, daily high/low, and sunset time
 
 **→ [Plugin Development Guide](./docs/development/PLUGIN_DEVELOPMENT.md)** - Create your own plugins!
 
@@ -156,12 +156,12 @@ FiestaBoard uses a **plugin architecture** - each feature is a self-contained pl
 
 ### Advanced Setup
 
-For detailed setup instructions for specific plugins, see each plugin's `docs/SETUP.md`:
-- **Home Assistant**: [plugins/home_assistant/docs/SETUP.md](./plugins/home_assistant/docs/SETUP.md)
-- **Weather**: [plugins/weather/docs/SETUP.md](./plugins/weather/docs/SETUP.md)
-- **Stocks**: [plugins/stocks/docs/SETUP.md](./plugins/stocks/docs/SETUP.md)
+For detailed setup instructions for specific plugins, see each plugin's README:
+- **Home Assistant**: [plugins/home_assistant/README.md](./plugins/home_assistant/README.md)
+- **Weather**: [plugins/weather/README.md](./plugins/weather/README.md)
+- **Stocks**: [plugins/stocks/README.md](./plugins/stocks/README.md)
 
-Browse `plugins/*/docs/SETUP.md` for all plugin setup guides.
+Browse `plugins/*/README.md` for all plugin documentation. Each plugin's README includes a link to its setup guide.
 
 ## Configuration
 
@@ -183,21 +183,21 @@ All configuration is done via environment variables in `.env`:
 
 All plugins can be configured via the web UI (**Integrations** page) or environment variables. Each plugin has its own setup documentation in `plugins/<plugin_name>/docs/SETUP.md`.
 
-| Plugin | API Key Required | Setup Guide |
+| Plugin | API Key Required | Documentation |
 |--------|-----------------|-------------|
-| Air/Fog | Yes (PurpleAir/OWM) | [plugins/air_fog/docs/SETUP.md](./plugins/air_fog/docs/SETUP.md) |
-| Bay Wheels | No | [plugins/baywheels/docs/SETUP.md](./plugins/baywheels/docs/SETUP.md) |
-| Date & Time | No | [plugins/date_time/docs/SETUP.md](./plugins/date_time/docs/SETUP.md) |
-| Guest WiFi | No | [plugins/guest_wifi/docs/SETUP.md](./plugins/guest_wifi/docs/SETUP.md) |
-| Home Assistant | Yes (HA token) | [plugins/home_assistant/docs/SETUP.md](./plugins/home_assistant/docs/SETUP.md) |
-| Muni Transit | Yes (free 511.org) | [plugins/muni/docs/SETUP.md](./plugins/muni/docs/SETUP.md) |
-| Nearby Aircraft | No (optional OpenSky) | [plugins/nearby_aircraft/docs/SETUP.md](./plugins/nearby_aircraft/docs/SETUP.md) |
-| Sports Scores | No (optional TheSportsDB) | [plugins/sports_scores/docs/SETUP.md](./plugins/sports_scores/docs/SETUP.md) |
-| Star Trek Quotes | No | [plugins/star_trek_quotes/docs/SETUP.md](./plugins/star_trek_quotes/docs/SETUP.md) |
-| Stocks | No (optional Finnhub) | [plugins/stocks/docs/SETUP.md](./plugins/stocks/docs/SETUP.md) |
-| Surf | No | [plugins/surf/docs/SETUP.md](./plugins/surf/docs/SETUP.md) |
-| Traffic | Yes (Google Routes) | [plugins/traffic/docs/SETUP.md](./plugins/traffic/docs/SETUP.md) |
-| Weather | Yes (OpenWeatherMap) | [plugins/weather/docs/SETUP.md](./plugins/weather/docs/SETUP.md) |
+| Air/Fog | Yes (PurpleAir/OWM) | [plugins/air_fog/README.md](./plugins/air_fog/README.md) |
+| Bay Wheels | No | [plugins/baywheels/README.md](./plugins/baywheels/README.md) |
+| Date & Time | No | [plugins/date_time/README.md](./plugins/date_time/README.md) |
+| Guest WiFi | No | [plugins/guest_wifi/README.md](./plugins/guest_wifi/README.md) |
+| Home Assistant | Yes (HA token) | [plugins/home_assistant/README.md](./plugins/home_assistant/README.md) |
+| Muni Transit | Yes (free 511.org) | [plugins/muni/README.md](./plugins/muni/README.md) |
+| Nearby Aircraft | No (optional OpenSky) | [plugins/nearby_aircraft/README.md](./plugins/nearby_aircraft/README.md) |
+| Sports Scores | No (optional TheSportsDB) | [plugins/sports_scores/README.md](./plugins/sports_scores/README.md) |
+| Star Trek Quotes | No | [plugins/star_trek_quotes/README.md](./plugins/star_trek_quotes/README.md) |
+| Stocks | No (optional Finnhub) | [plugins/stocks/README.md](./plugins/stocks/README.md) |
+| Surf | No | [plugins/surf/README.md](./plugins/surf/README.md) |
+| Traffic | Yes (Google Routes) | [plugins/traffic/README.md](./plugins/traffic/README.md) |
+| Weather | Yes (OpenWeatherMap) | [plugins/weather/README.md](./plugins/weather/README.md) |
 
 See `env.example` for all available environment variables.
 

--- a/plugins/air_fog/README.md
+++ b/plugins/air_fog/README.md
@@ -2,6 +2,8 @@
 
 Display air quality index (AQI) and fog/visibility conditions.
 
+**→ [Setup Guide](./docs/SETUP.md)** - API key registration and configuration
+
 ## Overview
 
 The Air Quality & Fog plugin combines data from PurpleAir (air quality) and OpenWeatherMap (visibility) to give you a complete picture of outdoor conditions.
@@ -45,19 +47,9 @@ FOG: {{air_fog.fog_status}}
 {{air_fog.fog_color}} FOG: {{air_fog.fog_status}}
 ```
 
-## Setup
+## Quick Setup
 
-### PurpleAir API Key
-
-1. Go to [PurpleAir](https://www.purpleair.com/)
-2. Create an account and request API access
-3. Get your API key from the dashboard
-
-### OpenWeatherMap API Key
-
-1. Go to [OpenWeatherMap](https://openweathermap.org/)
-2. Sign up for a free account
-3. Get your API key
+For detailed setup instructions including API key registration, see the **[Setup Guide](./docs/SETUP.md)**.
 
 ## Configuration
 

--- a/plugins/baywheels/README.md
+++ b/plugins/baywheels/README.md
@@ -2,6 +2,8 @@
 
 Display Bay Wheels bike share availability with electric and classic bike counts.
 
+**→ [Setup Guide](./docs/SETUP.md)** - Configuration and station setup
+
 ## Overview
 
 The Bay Wheels plugin fetches real-time bike availability from the Bay Wheels GBFS feed, showing electric and classic bike counts at your selected stations.

--- a/plugins/date_time/README.md
+++ b/plugins/date_time/README.md
@@ -4,6 +4,8 @@ Display current date and time on your board with comprehensive formatting option
 
 ![Date & Time Display](./docs/date-time-display.png)
 
+**→ [Setup Guide](./docs/SETUP.md)** - Configuration and setup instructions
+
 ## Overview
 
 The Date & Time plugin provides various date and time variables that update automatically based on your configured timezone. It supports multiple time formats (12-hour and 24-hour), US date formats, and flexible month representations.

--- a/plugins/guest_wifi/README.md
+++ b/plugins/guest_wifi/README.md
@@ -2,6 +2,8 @@
 
 Display guest WiFi credentials on your board.
 
+**→ [Setup Guide](./docs/SETUP.md)** - Configuration instructions
+
 ## Overview
 
 The Guest WiFi plugin displays your guest network name and password, making it easy for visitors to connect.

--- a/plugins/home_assistant/README.md
+++ b/plugins/home_assistant/README.md
@@ -2,6 +2,8 @@
 
 Display entity states from your Home Assistant instance.
 
+**→ [Setup Guide](./docs/SETUP.md)** - Access token setup and configuration
+
 ## Overview
 
 The Home Assistant plugin connects to your Home Assistant instance and allows you to display any entity state on your board. It supports dynamic entity access, so you can reference any entity by its ID.
@@ -14,15 +16,9 @@ The Home Assistant plugin connects to your Home Assistant instance and allows yo
 - Support for sensors, binary sensors, switches, and more
 - Configurable entity list
 
-## Setup
+## Quick Setup
 
-### Get Long-Lived Access Token
-
-1. Open Home Assistant
-2. Click your profile (bottom left)
-3. Scroll to "Long-Lived Access Tokens"
-4. Create a new token
-5. Copy the token (you won't see it again)
+For detailed setup instructions including access token creation, see the **[Setup Guide](./docs/SETUP.md)**.
 
 ## Template Variables
 

--- a/plugins/last_fm/README.md
+++ b/plugins/last_fm/README.md
@@ -4,6 +4,8 @@ Display what's currently playing on your Vestaboard via Last.fm scrobbling.
 
 ![Last.fm Now Playing Display](./docs/last-fm-display.png)
 
+**→ [Setup Guide](./docs/SETUP.md)** - API key registration and configuration
+
 ## Overview
 
 This plugin fetches the currently playing or most recently played track from a user's Last.fm profile. It works with any music source that scrobbles to Last.fm, including:

--- a/plugins/muni/README.md
+++ b/plugins/muni/README.md
@@ -2,6 +2,8 @@
 
 Display San Francisco Muni transit arrival times with multi-stop and multi-line support.
 
+**→ [Setup Guide](./docs/SETUP.md)** - API key registration and stop configuration
+
 ## Overview
 
 The SF Muni plugin fetches real-time arrival predictions from 511.org and displays them for your selected stops. It supports multiple stops and shows arrivals for all lines at each stop.
@@ -14,13 +16,9 @@ The SF Muni plugin fetches real-time arrival predictions from 511.org and displa
 - Delay indicators
 - Color-coded status
 
-## Setup
+## Quick Setup
 
-### Get 511.org API Key
-
-1. Go to [511.org/developers](https://511.org/developers)
-2. Create a free account
-3. Get your API key
+For detailed setup instructions including API key registration, see the **[Setup Guide](./docs/SETUP.md)**.
 
 ## Template Variables
 

--- a/plugins/nearby_aircraft/README.md
+++ b/plugins/nearby_aircraft/README.md
@@ -4,6 +4,8 @@ Display real-time nearby aircraft information from the OpenSky Network API.
 
 ![Nearby Aircraft Display](./docs/nearby-aircraft-display.png)
 
+**→ [Setup Guide](./docs/SETUP.md)** - Configuration and optional OAuth setup
+
 ## Overview
 
 The Nearby Aircraft plugin fetches live aircraft state vectors from the OpenSky Network API and displays aircraft within a user-defined radius. It shows call sign, altitude (feet), ground speed (knots), and squawk code for each aircraft. The plugin includes column alignment formatting to ensure consistent display across all aircraft rows.

--- a/plugins/sports_scores/README.md
+++ b/plugins/sports_scores/README.md
@@ -2,6 +2,8 @@
 
 Display recent sports match scores from NFL, Soccer, NHL, and NBA using TheSportsDB API.
 
+**→ [Setup Guide](./docs/SETUP.md)** - Configuration and optional API key setup
+
 ## Overview
 
 The Sports Scores plugin fetches recent sports match scores from TheSportsDB API and exposes them as template variables for use in FiestaBoard displays. The plugin supports multiple sports simultaneously and can work with the free tier API or an optional premium API key.

--- a/plugins/star_trek_quotes/README.md
+++ b/plugins/star_trek_quotes/README.md
@@ -2,6 +2,8 @@
 
 Display random Star Trek quotes from TNG, Voyager, and DS9.
 
+**→ [Setup Guide](./docs/SETUP.md)** - Configuration instructions
+
 ## Overview
 
 The Star Trek Quotes plugin displays inspirational and memorable quotes from Star Trek: The Next Generation, Voyager, and Deep Space Nine.

--- a/plugins/stocks/README.md
+++ b/plugins/stocks/README.md
@@ -2,6 +2,8 @@
 
 Display real-time stock prices and percentage changes.
 
+**→ [Setup Guide](./docs/SETUP.md)** - Configuration and optional API key setup
+
 ## Overview
 
 The Stock Prices plugin fetches live stock data from Yahoo Finance and displays prices with color-coded percentage changes.

--- a/plugins/sun_art/README.md
+++ b/plugins/sun_art/README.md
@@ -4,6 +4,8 @@ Display a full-screen 6x22 bit image pattern that changes based on the sun's pos
 
 ![Sun Art Display](./docs/sun-art-noon.png)
 
+**→ [Setup Guide](./docs/SETUP.md)** - Location configuration
+
 ## Overview
 
 The Sun Art plugin generates visual patterns representing the sun's position using latitude/longitude coordinates. It calculates accurate sun positions using the `astral` library and creates 12 distinct patterns showing the sun's progression throughout the day.

--- a/plugins/surf/README.md
+++ b/plugins/surf/README.md
@@ -2,6 +2,8 @@
 
 Display surf conditions including wave height, swell period, and quality rating.
 
+**→ [Setup Guide](./docs/SETUP.md)** - Location configuration
+
 ## Overview
 
 The Surf plugin fetches real-time marine data from Open-Meteo (free, no API key required) to display surf conditions at your favorite spot.

--- a/plugins/traffic/README.md
+++ b/plugins/traffic/README.md
@@ -2,6 +2,8 @@
 
 Display commute times and traffic conditions using Google Routes API.
 
+**→ [Setup Guide](./docs/SETUP.md)** - API key registration and route configuration
+
 ## Overview
 
 The Traffic plugin fetches real-time commute times from Google Routes API, showing drive times with traffic delays for multiple routes.
@@ -13,15 +15,9 @@ The Traffic plugin fetches real-time commute times from Google Routes API, showi
 - Multiple route monitoring
 - Color-coded traffic status
 
-## Setup
+## Quick Setup
 
-### Get Google Routes API Key
-
-1. Go to [Google Cloud Console](https://console.cloud.google.com/)
-2. Create a new project or select existing
-3. Enable the Routes API
-4. Create an API key
-5. Restrict the key to Routes API
+For detailed setup instructions including API key registration, see the **[Setup Guide](./docs/SETUP.md)**.
 
 ## Template Variables
 

--- a/plugins/visual_clock/README.md
+++ b/plugins/visual_clock/README.md
@@ -4,6 +4,8 @@ Displays a full-screen clock with large pixel-art style digits that span the ent
 
 ![Visual Clock Display](./docs/visual-clock-display.png)
 
+**→ [Setup Guide](./docs/SETUP.md)** - Configuration and API key setup
+
 ## Features
 
 - Full-screen display using colored tiles

--- a/plugins/weather/README.md
+++ b/plugins/weather/README.md
@@ -2,6 +2,8 @@
 
 Display current weather conditions with temperature, humidity, and wind speed.
 
+**→ [Setup Guide](./docs/SETUP.md)** - API key registration and configuration
+
 ## Overview
 
 The Weather plugin fetches real-time weather data from WeatherAPI.com or OpenWeatherMap and makes it available as template variables for your board.
@@ -19,27 +21,9 @@ The Weather plugin fetches real-time weather data from WeatherAPI.com or OpenWea
 - Support for multiple locations
 - Choice of weather providers
 
-## Setup
+## Quick Setup
 
-### 1. Get an API Key
-
-**WeatherAPI.com (Recommended)**
-- Free tier: 1 million calls/month
-- Sign up at [weatherapi.com](https://www.weatherapi.com/)
-
-**OpenWeatherMap**
-- Free tier: 1,000 calls/day
-- Sign up at [openweathermap.org](https://openweathermap.org/)
-
-### 2. Configure the Plugin
-
-Via the Integrations page:
-1. Go to **Integrations** → **Weather**
-2. Enable the plugin
-3. Select your provider
-4. Enter your API key
-5. Add one or more locations
-6. Save
+For detailed setup instructions, see the **[Setup Guide](./docs/SETUP.md)**.
 
 ## Template Variables
 


### PR DESCRIPTION
- Changed all plugin links in main README.md to point to plugin README.md files
- Added SETUP.md links to all plugin README.md files for easy navigation
- Updated configuration table header from 'Setup Guide' to 'Documentation'
- Creates clear navigation path: Main README → Plugin README → Plugin SETUP