### PR TITLE
fix(weather): display UV index 0-11+ when API returns normalized 0-1 scale

### DIFF
--- a/plugins/weather/source.py
+++ b/plugins/weather/source.py
@@ -15,19 +15,21 @@ logger = logging.getLogger(__name__)
 def _uv_to_display_index(uv: Any) -> Optional[int]:
     """Convert API UV value to display index 0-11+.
 
-    Some APIs return UV on a normalized 0-1 scale; others use 0-11+.
-    Values in (0, 1] are treated as normalized and scaled to 0-11.
+    Uses type to distinguish scales: integers are treated as standard
+    0-11+ (e.g. 1 means UV index 1). Floats in (0, 1) are treated as
+    normalized 0-1 and scaled to 0-11; other floats are standard scale.
     """
     if uv is None:
         return None
+    if isinstance(uv, int):
+        return max(0, uv)
     try:
         v = float(uv)
     except (TypeError, ValueError):
         return None
     if v < 0:
         return 0
-    if 0 <= v <= 1:
-        # Normalized 0-1 scale: 0 -> 0, 1 -> 11
+    if 0 < v < 1:
         return round(v * 11)
     return round(v)
 

--- a/plugins/weather/tests/test_plugin.py
+++ b/plugins/weather/tests/test_plugin.py
@@ -16,23 +16,27 @@ class TestUvToDisplayIndex:
         assert _uv_to_display_index(0) == 0
         assert _uv_to_display_index(0.0) == 0
 
-    def test_uv_standard_scale_rounded(self):
-        """Values > 1 are treated as 0-11+ and rounded."""
-        assert _uv_to_display_index(2.1) == 2
-        assert _uv_to_display_index(3.8) == 4
+    def test_uv_integer_standard_scale(self):
+        """Integers are always standard 0-11+ (type-based)."""
+        assert _uv_to_display_index(1) == 1
         assert _uv_to_display_index(5) == 5
         assert _uv_to_display_index(10) == 10
         assert _uv_to_display_index(11) == 11
 
-    def test_uv_normalized_0_1_scale(self):
-        """Values in (0, 1] are scaled to 0-11 (fixes APIs that return 0-1)."""
-        assert _uv_to_display_index(0.1) == 1   # round(1.1)
-        assert _uv_to_display_index(0.5) == 6   # round(5.5)
-        assert _uv_to_display_index(0.9) == 10  # round(9.9)
-        assert _uv_to_display_index(1.0) == 11  # round(11)
+    def test_uv_float_standard_scale_rounded(self):
+        """Floats outside (0, 1) are standard scale and rounded."""
+        assert _uv_to_display_index(2.1) == 2
+        assert _uv_to_display_index(3.8) == 4
+        assert _uv_to_display_index(1.0) == 1
 
-    def test_uv_string_coerced(self):
-        """String values are coerced to float then processed."""
+    def test_uv_float_normalized_between_0_and_1(self):
+        """Floats in (0, 1) are treated as normalized and scaled to 0-11."""
+        assert _uv_to_display_index(0.1) == 1
+        assert _uv_to_display_index(0.5) == 6
+        assert _uv_to_display_index(0.9) == 10
+
+    def test_uv_string_coerced_to_float(self):
+        """String values are coerced to float then processed (so "1" -> 1, "0.5" -> 6)."""
         assert _uv_to_display_index("7") == 7
         assert _uv_to_display_index("0.5") == 6
 


### PR DESCRIPTION
Changes:

- Add _uv_to_display_index() to normalize UV: values in (0,1] scaled to 0-11
- Use helper for current and forecast UV so Vestaboard shows correct range
- Add tests for normalized scale, standard scale, and edge cases

Tested:
Locally in my board