### PR TITLE
fix(disney_parks_times): abbreviations sort order, uppercase, INDY, BUZZ, settings sort

### DIFF
--- a/plugins/disney_parks_times/__init__.py
+++ b/plugins/disney_parks_times/__init__.py
@@ -28,48 +28,48 @@ COLOR_OPEN = "{66}"   # green - operating normally
 COLOR_CLOSED = "{63}"  # red - closed / not operating
 
 # Known tiny abbreviations (max 5 chars) from common Disney fan usage (wdwmagic, touringplans, etc.).
-# Keys are lowercase substrings to match in ride name; longest match wins.
-# Rise of the Resistance -> "RISE" per common shorthand.
+# Keys are lowercase substrings to match in ride name; longest match wins. Sorted alphabetically by key.
 _KNOWN_TINY_ABBR: List[tuple] = [
-    ("star wars: rise of the resistance", "RISE"),
-    ("rise of the resistance", "RISE"),
-    ("seven dwarfs mine train", "7DMT"),
-    ("big thunder mountain railroad", "BTMRR"),
-    ("millennium falcon", "MFSR"),
-    ("smugglers run", "MFSR"),
-    ("mickey and minnie's runaway railway", "MMRR"),
-    ("runaway railway", "MMRR"),
-    ("haunted mansion", "HM"),
-    ("expedition everest", "EE"),
-    ("frozen ever after", "FEA"),
-    ("flight of passage", "FoP"),
-    ("navi river journey", "NRJ"),
-    ("na'vi river journey", "NRJ"),
-    ("pirates of the caribbean", "PotC"),
-    ("peter pan's flight", "PPF"),
-    ("rock 'n' roller coaster", "RNR"),
-    ("rock n roller coaster", "RNR"),
-    ("tower of terror", "ToT"),
-    ("twilight zone tower of terror", "ToT"),
-    ("toy story midway mania", "TSMM"),
-    ("toy story mania", "TSMM"),
-    ("test track", "TT"),
-    ("spaceship earth", "SE"),
-    ("splash mountain", "SplMt"),
-    ("space mountain", "SM"),
-    ("carousel of progress", "CoP"),
-    ("it's a small world", "SMALL"),
-    ("small world", "SMALL"),
+    ("big thunder mountain railroad", "THUND"),
+    ("buzz lightyear", "BUZZ"),
+    ("carousel of progress", "COP"),
     ("country bear jamboree", "CBJ"),
+    ("expedition everest", "EE"),
+    ("flight of passage", "FOP"),
+    ("frozen ever after", "FRZN"),
+    ("guardians of the galaxy", "GOTG"),
+    ("haunted mansion", "HM"),
+    ("indiana jones", "INDY"),
+    ("it's a small world", "SMALL"),
+    ("jungle cruise", "JUNGL"),
     ("kilimanjaro safaris", "KS"),
-    ("mission: space", "MS"),
+    ("living with the land", "LWTL"),
+    ("mickey and minnie's runaway railway", "MMRR"),
+    ("millennium falcon", "MFSR"),
     ("mission space", "MS"),
-    ("guardians of the galaxy", "GotG"),
+    ("mission: space", "MS"),
+    ("na'vi river journey", "NRJ"),
+    ("navi river journey", "NRJ"),
+    ("peter pan's flight", "PPF"),
+    ("pirates of the caribbean", "POTC"),
+    ("rise of the resistance", "RISE"),
+    ("rock n roller coaster", "RNR"),
+    ("rock 'n' roller coaster", "RNR"),
+    ("runaway railway", "MMRR"),
+    ("seven dwarfs mine train", "7DMT"),
+    ("small world", "SMALL"),
+    ("soarin", "SOARN"),
+    ("soarin'", "SOARN"),
+    ("space mountain", "SMNT"),
+    ("spaceship earth", "SE"),
+    ("splash mountain", "SPLMT"),
     ("star tours", "ST"),
-    ("jungle cruise", "JC"),
-    ("living with the land", "LwtL"),
-    ("soarin'", "Soar"),
-    ("soarin", "Soar"),
+    ("star wars: rise of the resistance", "RISE"),
+    ("test track", "TT"),
+    ("tower of terror", "TOT"),
+    ("toy story mania", "TSMM"),
+    ("toy story midway mania", "TSMM"),
+    ("twilight zone tower of terror", "TOT"),
 ]
 
 
@@ -85,8 +85,8 @@ def _abbreviate_ride_name(name: str, max_len: int = RIDE_ABBR_LEN) -> str:
 
 def _tiny_abbr(name: str, max_len: int = TINY_ABBR_LEN) -> str:
     """Very short ride name (max 5 chars); use known abbreviations when possible.
-    Single-rider lines get a trailing '1' so they differ from the main line (e.g. SM1 vs SM).
-    No spaces in the result so the board doesn't show blank tiles between letters.
+    Single-rider lines get a trailing '1' so they differ from the main line (e.g. SMNT1 vs SMNT).
+    No spaces in the result; always uppercase for board display.
     """
     n = (name or "").strip().lower()
     if not n:
@@ -98,10 +98,10 @@ def _tiny_abbr(name: str, max_len: int = TINY_ABBR_LEN) -> str:
         if key_phrase in n and len(key_phrase) > len(match):
             match, abbr = key_phrase, known
     if abbr:
-        base = abbr[:max_len]
+        base = abbr[:max_len].upper()
     else:
-        # Fallback: first max_len chars of name, with any spaces removed then truncate
-        base = "".join((name or "").strip().split())[:max_len]
+        # Fallback: first max_len chars of name, spaces removed, then uppercase for board
+        base = "".join((name or "").strip().split())[:max_len].upper()
     if is_single_rider:
         if len(base) < max_len:
             base = (base + "1")[:max_len]

--- a/plugins/disney_parks_times/tests/test_plugin.py
+++ b/plugins/disney_parks_times/tests/test_plugin.py
@@ -82,7 +82,7 @@ class TestDisneyParksTimesPlugin:
         assert rides[0]["is_open"] is True
         # Formatted has no space between color and abbreviation (board shows one tile, not blank then abbr)
         formatted = rides[0]["formatted"]
-        assert formatted.startswith("{66}SM"), f"formatted should be color then abbr with no space: {formatted!r}"
+        assert formatted.startswith("{66}SMNT"), f"formatted should be color then abbr with no space: {formatted!r}"
         assert result.formatted_lines is not None
         assert len(result.formatted_lines) <= 6
 
@@ -235,22 +235,24 @@ class TestTinyAbbr:
 
     def test_other_known_abbreviations(self):
         """Other Disney rides use common fan abbreviations."""
-        assert _tiny_abbr("Space Mountain") == "SM"
+        assert _tiny_abbr("Space Mountain") == "SMNT"
         assert _tiny_abbr("Haunted Mansion") == "HM"
-        assert _tiny_abbr("Big Thunder Mountain Railroad") == "BTMRR"
+        assert _tiny_abbr("Big Thunder Mountain Railroad") == "THUND"
         assert _tiny_abbr("Seven Dwarfs Mine Train") == "7DMT"
-        assert _tiny_abbr("Jungle Cruise") == "JC"
+        assert _tiny_abbr("Jungle Cruise") == "JUNGL"
         assert _tiny_abbr("It's a Small World") == "SMALL"
+        assert _tiny_abbr("Indiana Jones Adventure") == "INDY"
+        assert _tiny_abbr("Buzz Lightyear Astro Blasters") == "BUZZ"
 
     def test_unknown_ride_fallback(self):
         """Unknown ride name falls back to first 5 chars (spaces removed)."""
-        assert _tiny_abbr("Some Other Ride") == "SomeO"
+        assert _tiny_abbr("Some Other Ride") == "SOMEO"
 
     def test_single_rider_gets_trailing_one(self):
         """Single-rider lines get '1' suffix so they differ from main line."""
-        assert _tiny_abbr("Space Mountain - Single Rider") == "SM1"
+        assert _tiny_abbr("Space Mountain - Single Rider") == "SMNT1"
         assert _tiny_abbr("Haunted Mansion Single Rider") == "HM1"
-        assert _tiny_abbr("Big Thunder Mountain Railroad - Single Rider") == "BTMR1"  # 5 chars: trim one, add 1
+        assert _tiny_abbr("Big Thunder Mountain Railroad - Single Rider") == "THUN1"  # 5 chars: trim one, add 1
         assert _tiny_abbr("Seven Dwarfs Mine Train - Single Rider") == "7DMT1"
 
     def test_no_spaces_in_abbreviations(self):

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -1604,7 +1604,9 @@ async def list_disney_parks():
         for group in data:
             if group.get("id") == DISNEY_GROUP_ID:
                 parks = group.get("parks", [])
-                return [{"id": p["id"], "name": p["name"], "country": p.get("country"), "timezone": p.get("timezone")} for p in parks]
+                out = [{"id": p["id"], "name": p["name"], "country": p.get("country"), "timezone": p.get("timezone")} for p in parks]
+                out.sort(key=lambda x: (x.get("name") or "").lower())
+                return out
         return []
     except Exception as e:
         logger.error(f"Error listing Disney parks: {e}", exc_info=True)
@@ -1623,6 +1625,7 @@ async def list_park_rides(park_id: int):
         for land in data.get("lands", []):
             for ride in land.get("rides", []):
                 rides.append({"id": ride["id"], "name": ride["name"]})
+        rides.sort(key=lambda x: (x.get("name") or "").lower())
         return rides
     except HTTPException:
         raise


### PR DESCRIPTION
Changes:
- Sort known abbreviations alphabetically by key phrase
- Sort parks and rides alphabetically in Queue-Times API (settings picker)
- Use uppercase for all tiny abbreviations (board displays uppercase only)
- Add Indiana Jones -> INDY, Buzz Lightyear -> BUZZ
- Update tests for current abbreviations (THUND, JUNGL, etc.) and add INDY/BUZZ