### PR TITLE
Docs splash page emojis

### DIFF
--- a/docs-site/src/components/HomepageFeatures/index.tsx
+++ b/docs-site/src/components/HomepageFeatures/index.tsx
@@ -85,7 +85,7 @@ type ShowcaseItem = {
 const FeatureShowcaseList: ShowcaseItem[] = [
   {
     title: 'Dashboard & Web UI',
-    emoji: '🖥️',
+    emoji: '',
     image: '/img/web-ui-home.png',
     alt: 'FiestaBoard web dashboard showing active display with stock ticker data',
     description: 'Monitor your display, manage pages, and configure plugins from a modern web interface.',
@@ -93,7 +93,7 @@ const FeatureShowcaseList: ShowcaseItem[] = [
   },
   {
     title: 'WYSIWYG Page Editor',
-    emoji: '✏️',
+    emoji: '',
     image: '/img/page-editor-wysiwyg.png',
     alt: 'FiestaBoard WYSIWYG page editor with visual board preview',
     description: 'Design your board layouts visually—see exactly how content will appear before sending it to your display.',
@@ -101,7 +101,7 @@ const FeatureShowcaseList: ShowcaseItem[] = [
   },
   {
     title: 'Visual Scheduling',
-    emoji: '📅',
+    emoji: '',
     image: '/img/schedule-calendar.png',
     alt: 'FiestaBoard schedule calendar view with time-based page scheduling',
     description: 'Schedule different pages for different times and days with an intuitive calendar interface.',
@@ -182,7 +182,7 @@ function FeatureShowcase({title, emoji, image, alt, description, link, reverse}:
       </div>
       <div className={styles.showcaseContent}>
         <Heading as="h3">
-          <span className={styles.showcaseEmoji}>{emoji}</span> {title}
+          {emoji && <span className={styles.showcaseEmoji}>{emoji}</span>}{emoji && ' '}{title}
         </Heading>
         <p>{description}</p>
         <Link className="button button--primary button--sm" to={link}>
@@ -212,7 +212,7 @@ function PluginCard({title, emoji, image, alt, description, link}: ShowcaseItem)
 export default function HomepageFeatures(): ReactNode {
   return (
     <>
-      {/* Feature cards with emojis */}
+      {/* Feature cards */}
       <section className={styles.features}>
         <div className="container">
           <div className="row">
@@ -245,7 +245,7 @@ export default function HomepageFeatures(): ReactNode {
         <div className="container">
           <div className="text--center margin-bottom--lg">
             <Heading as="h2" className={styles.sectionTitle}>
-              🎉 18 Plugins and Counting
+              18 Plugins and Counting
             </Heading>
             <p className={styles.sectionSubtitle}>
               From weather and stocks to Disney park wait times—there's a plugin for everything
@@ -260,7 +260,7 @@ export default function HomepageFeatures(): ReactNode {
             <Link
               className="button button--primary button--lg"
               to="/docs/plugins/overview">
-              🔌 Explore All Plugins
+              Explore All Plugins
             </Link>
           </div>
         </div>
@@ -270,7 +270,7 @@ export default function HomepageFeatures(): ReactNode {
       <section className={styles.ctaSection}>
         <div className="container text--center">
           <Heading as="h2" className={styles.ctaTitle}>
-            Ready to Get Started? 🚀
+            Ready to Get Started?
           </Heading>
           <p className={styles.ctaSubtitle}>
             FiestaBoard is free, open source, and runs anywhere Docker does.
@@ -280,12 +280,12 @@ export default function HomepageFeatures(): ReactNode {
             <Link
               className="button button--primary button--lg"
               to="/docs/setup/beginners-guide">
-              📖 Beginner's Guide
+              Beginner's Guide
             </Link>
             <Link
               className="button button--outline button--primary button--lg"
               to="/docs/development/plugin-guide">
-              🛠️ Build a Plugin
+              Build a Plugin
             </Link>
           </div>
         </div>

--- a/docs-site/src/components/HomepageFeatures/styles.module.css
+++ b/docs-site/src/components/HomepageFeatures/styles.module.css
@@ -6,7 +6,7 @@
 }
 
 .featureEmoji {
-  font-size: 4rem;
+  font-size: 3rem;
   display: block;
   margin-bottom: 1rem;
 }

--- a/docs-site/src/pages/index.tsx
+++ b/docs-site/src/pages/index.tsx
@@ -28,18 +28,18 @@ function HomepageHeader() {
           endlessly customizable, and running in Docker with zero hassle.
         </p>
         <p className={styles.heroDescriptionShort}>
-          Weather, stocks, sports & more — in Docker 🐳
+          Weather, stocks, sports & more — powered by Docker
         </p>
         <div className={styles.buttons}>
           <Link
             className="button button--secondary button--lg"
             to="/docs/intro">
-            🚀 Get Started
+            Get Started
           </Link>
           <Link
             className={clsx('button button--outline button--lg', styles.githubButton)}
             href="https://github.com/Fiestaboard/FiestaBoard">
-            ⭐ View on GitHub
+            View on GitHub
           </Link>
         </div>
       </div>


### PR DESCRIPTION
## Description

This PR cleans up the docs splash page by reducing emoji usage to create a more professional and less cluttered appearance. Emojis have been removed from buttons, section titles, showcase headings, and the CTA, while being retained where they serve as meaningful visual icons (e.g., feature cards, plugin identifiers, footer). The size of feature card emojis was also slightly reduced for a more restrained feel.

## Related Issue

Closes #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] New plugin
- [ ] Documentation update
- [x] Refactor / maintenance

## Checklist

- [x] I have tested my changes locally
- [ ] I have added/updated tests where applicable
- [ ] I have updated documentation where applicable
- [x] My code follows the project's coding standards

---
<p><a href="https://cursor.com/agents?id=bc-5f010111-1a05-42c0-bd8a-33296c743030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5f010111-1a05-42c0-bd8a-33296c743030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

