### PR TITLE
docs: add screenshot references to plugin SETUP.md files

### DIFF
--- a/plugins/air_fog/docs/SETUP.md
+++ b/plugins/air_fog/docs/SETUP.md
@@ -227,6 +227,8 @@ Triggered when:
 
 ## Example Templates
 
+![Air Quality and Fog Display](./air-fog-display.png)
+
 ### Compact Alert
 
 ```

--- a/plugins/baywheels/docs/SETUP.md
+++ b/plugins/baywheels/docs/SETUP.md
@@ -136,6 +136,8 @@ Total across all configured stations:
 
 ## Example Templates
 
+![Bay Wheels Display](./baywheels-display.png)
+
 ### Simple Single Station
 
 ```

--- a/plugins/guest_wifi/docs/SETUP.md
+++ b/plugins/guest_wifi/docs/SETUP.md
@@ -47,6 +47,8 @@ docker-compose restart
 
 ## Display Format
 
+![Guest WiFi Display](./guest-wifi-display.png)
+
 When enabled, the board will show:
 
 ```

--- a/plugins/home_assistant/docs/SETUP.md
+++ b/plugins/home_assistant/docs/SETUP.md
@@ -131,6 +131,8 @@ docker-compose logs -f | grep -i "home\|assistant"
 
 ## Display Format
 
+![Home Assistant Display](./home-assistant-display.png)
+
 The board will show:
 
 ```

--- a/plugins/muni/docs/SETUP.md
+++ b/plugins/muni/docs/SETUP.md
@@ -145,6 +145,8 @@ Access individual stops using index (0-3):
 
 ## Example Templates
 
+![Muni Transit Display](./muni-display.png)
+
 ### Simple Single Stop
 
 ```

--- a/plugins/sports_scores/docs/SETUP.md
+++ b/plugins/sports_scores/docs/SETUP.md
@@ -164,6 +164,8 @@ Access the first game directly (without array index):
 
 ## Example Templates
 
+![Sports Scores Display](./sports-scores-display.png)
+
 ### Simple List
 
 ```

--- a/plugins/stocks/docs/SETUP.md
+++ b/plugins/stocks/docs/SETUP.md
@@ -156,6 +156,8 @@ Access specific stocks using index (0-4):
 
 ## Example Templates
 
+![Stock Prices Display](./stocks-display.png)
+
 ### Simple List
 
 ```

--- a/plugins/surf/docs/SETUP.md
+++ b/plugins/surf/docs/SETUP.md
@@ -157,6 +157,8 @@ Surf quality is automatically calculated based on swell period and wind conditio
 
 ## Example Templates
 
+![Surf Conditions Display](./surf-display.png)
+
 ### Compact Report
 
 ```

--- a/plugins/traffic/docs/SETUP.md
+++ b/plugins/traffic/docs/SETUP.md
@@ -163,6 +163,8 @@ Each mode returns different routes optimized for that transportation type.
 
 ## Example Configuration
 
+![Traffic Display](./traffic-display.png)
+
 Here's a complete example for a morning commute:
 
 **Route 1: Home to Work (Drive)**


### PR DESCRIPTION
## Summary

- Adds display screenshot references to `SETUP.md` for 9 plugins following the pattern established in `plugins/nearby_aircraft/docs/SETUP.md`
- Screenshot PNG files already existed in each plugin's `docs/` directory; this PR simply wires them into the documentation
- Closes the duplicate air_fog issue (#74) alongside the primary one (#75)
- Closes the last_fm issue (#124) as the screenshot and README reference were already in place

## Changes

| Plugin | Section Added Under |
|--------|---------------------|
| `air_fog` | `## Example Templates` |
| `baywheels` | `## Example Templates` |
| `muni` | `## Example Templates` |
| `sports_scores` | `## Example Templates` |
| `stocks` | `## Example Templates` |
| `surf` | `## Example Templates` |
| `guest_wifi` | `## Display Format` |
| `home_assistant` | `## Display Format` |
| `traffic` | `## Example Configuration` |

## Closes

Closes #74
Closes #75
Closes #76
Closes #78
Closes #79
Closes #80
Closes #81
Closes #83
Closes #84
Closes #85
Closes #124

Made with [Cursor](https://cursor.com)