### PR TITLE
feat(docs): theme-aware plugin cards on homepage

### DIFF
--- a/docs-site/src/components/HomepageFeatures/index.tsx
+++ b/docs-site/src/components/HomepageFeatures/index.tsx
@@ -179,6 +179,14 @@ function deriveThemedPath(src: string, mode: 'light' | 'dark'): string {
   return `${dir}/${mode}/${filename}`;
 }
 
+function deriveBoardPath(src: string, colorMode: 'light' | 'dark'): string {
+  const boardDir = colorMode === 'light' ? 'white' : 'black';
+  const lastSlash = src.lastIndexOf('/');
+  const dir = src.substring(0, lastSlash);
+  const filename = src.substring(lastSlash + 1);
+  return `${dir}/${boardDir}/${filename}`;
+}
+
 function Feature({title, icon, description}: FeatureItem) {
   return (
     <div className={clsx('col col--4')}>
@@ -323,10 +331,13 @@ function FeatureShowcase({title, image, alt, description, link, reverse}: Showca
 }
 
 function PluginCard({title, image, alt, description, link}: ShowcaseItem) {
+  const {colorMode} = useColorMode();
+  const src = deriveBoardPath(image, colorMode);
+
   return (
     <Link to={link} className={styles.pluginCard}>
       <div className={styles.pluginCardImage}>
-        <img src={image} alt={alt} loading="lazy" />
+        <img src={src} alt={alt} loading="lazy" />
       </div>
       <div className={styles.pluginCardBody}>
         <Heading as="h4">


### PR DESCRIPTION
## Summary

- The "23 Plugins and Counting" plugin showcase cards on the homepage now switch between white and black board screenshots based on the Docusaurus site theme
- Light mode shows white board variants (`/img/white/...`), dark mode shows black board variants (`/img/black/...`)
- Uses a new `deriveBoardPath` helper that maps `light` → `white` and `dark` → `black` subdirectories

## Test plan

- [ ] Open docs homepage in light mode — plugin cards should show white board screenshots
- [ ] Toggle to dark mode — plugin cards should switch to black board screenshots
- [ ] Verify all 9 plugin card images load correctly in both modes


Made with [Cursor](https://cursor.com)