### PR TITLE
fix: Vestaboard Cloud currentMessage layout for board setup (#461)

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -1318,8 +1318,8 @@ async def test_board_connection(request: BoardTestRequest):
         message: Human-readable status message
         error: Detailed error message if failed
     """
-    from .board_client import BoardClient
-    
+    from .board_client import BoardClient, is_successful_board_read_response
+
     api_mode = request.api_mode.lower()
     
     # Validate required fields based on mode
@@ -1369,30 +1369,30 @@ async def test_board_connection(request: BoardTestRequest):
             # Parse the response to verify it's valid board data
             try:
                 data = response.json()
-                characters = None
-                if isinstance(data, list) and len(data) > 0:
-                    characters = data
-                elif isinstance(data, dict) and "message" in data:
-                    characters = data.get("message")
-                
-                if characters is not None:
+                if is_successful_board_read_response(data):
                     logger.info(f"Board connection test successful ({api_mode} mode)")
                     return {
                         "success": True,
                         "message": "Successfully connected to your board!",
-                        "api_mode": api_mode
+                        "api_mode": api_mode,
                     }
-                else:
-                    logger.warning(f"Board connection test: HTTP 200 but unexpected response format ({api_mode} mode)")
-                    return {
-                        "success": False,
-                        "message": "Connected to the board but received an unexpected response. Your board's firmware may need to be updated.",
-                        "error": f"Unexpected response format: {type(data).__name__}",
-                        "troubleshooting": [
-                            "Check for firmware updates in the Vestaboard app.",
-                            "Make sure you're using the latest version of FiestaBoard.",
-                        ]
-                    }
+                detail = (
+                    f"JSON keys: {', '.join(sorted(data))}"
+                    if isinstance(data, dict)
+                    else f"body type: {type(data).__name__}"
+                )
+                logger.warning(
+                    f"Board connection test: HTTP 200 but unrecognized response ({api_mode} mode): {detail}"
+                )
+                return {
+                    "success": False,
+                    "message": "Connected to Vestaboard but the response shape was not recognized.",
+                    "error": f"Unrecognized read response ({detail}).",
+                    "troubleshooting": [
+                        "Update FiestaBoard to the latest version.",
+                        "If this persists, file an issue with the response keys shown above (no API keys).",
+                    ],
+                }
             except ValueError:
                 logger.warning(f"Board connection test: HTTP 200 but invalid JSON ({api_mode} mode)")
                 return {

--- a/src/board_client.py
+++ b/src/board_client.py
@@ -13,10 +13,11 @@ Cloud API Reference:
 - GET https://rw.vestaboard.com/ - Read current display
 """
 
+import json
 import logging
 import re
 import requests
-from typing import Optional, List, Tuple, Literal
+from typing import Any, List, Literal, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -62,6 +63,68 @@ VALID_STRATEGIES = [
     "column", "reverse-column", "edges-to-center", 
     "row", "diagonal", "random"
 ]
+
+
+def _valid_grid_dimensions() -> set:
+    from .devices import DEVICE_DIMENSIONS
+
+    return {(d.rows, d.cols) for d in DEVICE_DIMENSIONS.values()}
+
+
+def _is_valid_character_grid(rows: Any) -> bool:
+    """True if rows is a rectangular int grid matching a known device size."""
+    if not isinstance(rows, list) or not rows:
+        return False
+    first = rows[0]
+    if not isinstance(first, list):
+        return False
+    ncols = len(first)
+    nrows = len(rows)
+    if (nrows, ncols) not in _valid_grid_dimensions():
+        return False
+    for row in rows:
+        if not isinstance(row, list) or len(row) != ncols:
+            return False
+        if not all(isinstance(c, int) for c in row):
+            return False
+    return True
+
+
+def parse_read_message_payload(data: Any) -> Optional[List[List[int]]]:
+    """Extract character grid from Local or Cloud GET /message (or cloud root) JSON.
+
+    Cloud API returns ``{"currentMessage": {"layout": "<json string>", "id": ...}}``.
+    Local API may return a raw grid list or ``{"message": ...}``.
+    """
+    if isinstance(data, list):
+        return data if _is_valid_character_grid(data) else None
+    if not isinstance(data, dict):
+        return None
+    if "message" in data:
+        m = data.get("message")
+        return m if isinstance(m, list) and _is_valid_character_grid(m) else None
+    cm = data.get("currentMessage")
+    if isinstance(cm, dict) and "layout" in cm:
+        layout = cm.get("layout")
+        if layout is None or layout == "":
+            return None
+        if isinstance(layout, str):
+            try:
+                layout = json.loads(layout)
+            except (json.JSONDecodeError, TypeError):
+                return None
+        if isinstance(layout, list) and _is_valid_character_grid(layout):
+            return layout
+    return None
+
+
+def is_successful_board_read_response(data: Any) -> bool:
+    """True if GET body indicates a working read (grid or explicit empty state)."""
+    if parse_read_message_payload(data) is not None:
+        return True
+    if isinstance(data, dict) and "currentMessage" in data and data.get("currentMessage") is None:
+        return True
+    return False
 
 
 class BoardClient:
@@ -291,7 +354,7 @@ class BoardClient:
                         This is useful on startup to avoid unnecessary updates.
         
         Returns:
-            6x22 character array, or None if failed
+            Character grid (Flagship 6x22 or Note 3x15), or None if failed or empty.
         """
         try:
             response = requests.get(
@@ -301,13 +364,7 @@ class BoardClient:
             )
             response.raise_for_status()
             data = response.json()
-            
-            # Local API returns the character array directly
-            characters = None
-            if isinstance(data, list) and len(data) == 6:
-                characters = data
-            elif isinstance(data, dict) and "message" in data:
-                characters = data.get("message")
+            characters = parse_read_message_payload(data)
             
             # Optionally sync the cache with current board state
             if sync_cache and characters:

--- a/tests/test_board_client.py
+++ b/tests/test_board_client.py
@@ -1,10 +1,18 @@
 """Tests for Board Local API client."""
 
+import json
+
 import pytest
 from unittest.mock import Mock, patch, MagicMock
 import requests
 
-from src.board_client import BoardClient, VALID_STRATEGIES, strip_color_markers
+from src.board_client import (
+    BoardClient,
+    VALID_STRATEGIES,
+    is_successful_board_read_response,
+    parse_read_message_payload,
+    strip_color_markers,
+)
 
 
 class TestStripColorMarkers:
@@ -256,6 +264,35 @@ class TestSendCharacters:
         assert mock_post.call_count == 1
 
 
+class TestParseReadMessagePayload:
+    """Vestaboard Cloud vs Local GET body shapes."""
+
+    def test_cloud_current_message_layout_string_note(self):
+        grid = [[0] * 15 for _ in range(3)]
+        body = {"currentMessage": {"layout": json.dumps(grid), "id": "x"}}
+        assert parse_read_message_payload(body) == grid
+
+    def test_cloud_current_message_layout_list_flagship(self):
+        grid = [[0] * 22 for _ in range(6)]
+        body = {"currentMessage": {"layout": grid, "id": "x"}}
+        assert parse_read_message_payload(body) == grid
+
+    def test_legacy_message_key(self):
+        grid = [[0] * 22 for _ in range(6)]
+        assert parse_read_message_payload({"message": grid}) == grid
+
+    def test_local_raw_list_note(self):
+        grid = [[1] * 15 for _ in range(3)]
+        assert parse_read_message_payload(grid) == grid
+
+    def test_invalid_dimensions_rejected(self):
+        grid = [[0] * 10 for _ in range(4)]
+        assert parse_read_message_payload(grid) is None
+
+    def test_is_successful_empty_current_message(self):
+        assert is_successful_board_read_response({"currentMessage": None}) is True
+
+
 class TestReadCurrentMessage:
     """Tests for read_current_message method."""
     
@@ -295,6 +332,17 @@ class TestReadCurrentMessage:
         result = client.read_current_message()
         
         assert result is None
+
+    @patch('src.board_client.requests.get')
+    def test_read_current_message_cloud_current_message_shape(self, mock_get):
+        """Cloud API returns currentMessage.layout (stringified JSON)."""
+        grid = [[0] * 15 for _ in range(3)]
+        client = BoardClient(api_key="rw-key", use_cloud=True)
+        mock_get.return_value.raise_for_status = Mock()
+        mock_get.return_value.json.return_value = {
+            "currentMessage": {"layout": json.dumps(grid), "id": "u"},
+        }
+        assert client.read_current_message() == grid
 
 
 class TestCacheManagement:

--- a/tests/test_board_connection_test.py
+++ b/tests/test_board_connection_test.py
@@ -5,6 +5,8 @@ specific, actionable error messages with troubleshooting steps for
 every failure mode instead of a generic error.
 """
 
+import json
+
 from unittest.mock import Mock, patch
 
 import pytest
@@ -357,8 +359,58 @@ class TestBoardTestUnexpectedResponse:
 
         data = response.json()
         assert data["success"] is False
-        assert "unexpected" in data["message"].lower()
+        assert "recognized" in data["message"].lower()
+        assert "status" in data.get("error", "").lower() or "keys" in data.get("error", "").lower()
         assert "troubleshooting" in data
+
+    @patch("src.api_server.requests.get")
+    @patch("src.board_client.BoardClient")
+    def test_cloud_200_current_message_note_layout(self, mock_client_cls, mock_get, client):
+        """Cloud GET returns Vestaboard currentMessage.layout string (Note 3x15)."""
+        note_grid = [[0] * 15 for _ in range(3)]
+        mock_client = Mock()
+        mock_client.base_url = "https://rw.vestaboard.com/"
+        mock_client.headers = {}
+        mock_client_cls.return_value = mock_client
+
+        mock_resp = Mock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "currentMessage": {
+                "layout": json.dumps(note_grid),
+                "id": "test-uuid",
+                "appeared": 1,
+            }
+        }
+        mock_get.return_value = mock_resp
+
+        response = client.post(
+            "/config/board/test",
+            json={"api_mode": "cloud", "cloud_key": "rw-key"},
+        )
+        data = response.json()
+        assert data["success"] is True
+        assert data["api_mode"] == "cloud"
+
+    @patch("src.api_server.requests.get")
+    @patch("src.board_client.BoardClient")
+    def test_cloud_200_current_message_null(self, mock_client_cls, mock_get, client):
+        """Cloud GET with empty board (currentMessage null) still counts as connected."""
+        mock_client = Mock()
+        mock_client.base_url = "https://rw.vestaboard.com/"
+        mock_client.headers = {}
+        mock_client_cls.return_value = mock_client
+
+        mock_resp = Mock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"currentMessage": None}
+        mock_get.return_value = mock_resp
+
+        response = client.post(
+            "/config/board/test",
+            json={"api_mode": "cloud", "cloud_key": "rw-key"},
+        )
+        assert response.json()["success"] is True
 
     @patch("src.api_server.requests.get")
     @patch("src.board_client.BoardClient")


### PR DESCRIPTION
## Summary
Vestaboard Cloud `GET` returns `{ "currentMessage": { "layout": "<json string>", ... } }` (documented for Flagship and Note). FiestaBoard only accepted a raw grid list or `{"message": ...}`, so the setup wizard reported **Unexpected response format: dict** even with a valid Read/Write key.

## Changes
- Parse `currentMessage.layout` (string or list) in `board_client` alongside legacy shapes.
- Treat `currentMessage: null` as a successful connection test (empty board).
- `/config/board/test`: clearer errors when shape is still unknown (JSON keys in message).
- Tests for Cloud Note layout + parser coverage.

Fixes #461

Made with [Cursor](https://cursor.com)