### PR TITLE
fix(docker): include plugin-registry.json in image for Marketplace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,6 +82,8 @@ COPY --from=python-builder /usr/local/bin /usr/local/bin
 COPY src/ ./src/
 COPY plugins/ ./plugins/
 COPY tests/ ./tests/
+# Curated community plugin list for Integrations → Marketplace (API reads /app/plugin-registry.json)
+COPY plugin-registry.json ./plugin-registry.json
 
 # Copy Next.js standalone build from UI builder
 COPY --from=ui-builder /app/.next/standalone ./web/


### PR DESCRIPTION
## Summary

Production Docker images did not copy `plugin-registry.json`. The API loads the curated registry from `/app/plugin-registry.json` (see `src/plugins/sources.py`). Development works because `docker-compose.dev.yml` bind-mounts the file; production `docker-compose.yml` does not, so Hub/prod builds had an empty registry and the Integrations **Marketplace** showed no community plugins.

## Change

- `COPY plugin-registry.json ./plugin-registry.json` in the final Dockerfile stage.

## Verification

- `docker build` succeeds.
- `docker run ... cat /app/plugin-registry.json` shows valid JSON.

Please merge and cut a release image when ready so self-hosted users get the Marketplace list.

Made with [Cursor](https://cursor.com)