### PR TITLE
fix(web): Settings gear icon and Integrations toolbar layout

### DIFF
--- a/web/src/app/integrations/page.tsx
+++ b/web/src/app/integrations/page.tsx
@@ -1758,8 +1758,14 @@ export default function IntegrationsPage() {
 
       {/* Tabs */}
       <Tabs value={activeTab} onValueChange={setActiveTab}>
-        <div className="flex items-center gap-3 mb-4">
-          <TabsList>
+        <div
+          className={
+            activeTab === "marketplace"
+              ? "mb-4 grid grid-cols-1 gap-3 items-center md:grid-cols-[auto_minmax(12rem,1fr)_auto]"
+              : "mb-4 grid grid-cols-1 gap-3 items-center sm:grid-cols-[auto_minmax(0,1fr)]"
+          }
+        >
+          <TabsList className="w-fit">
             <TabsTrigger value="installed">
               Installed
               {data && (
@@ -1777,17 +1783,17 @@ export default function IntegrationsPage() {
               )}
             </TabsTrigger>
           </TabsList>
-          <div className="relative flex-1">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+          <div className="relative min-w-0 w-full">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
             <Input
               placeholder={activeTab === "installed" ? "Search installed plugins..." : "Search available plugins..."}
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="pl-9"
+              className="pl-9 w-full"
             />
           </div>
           {activeTab === "marketplace" && (
-            <div className="flex items-center gap-2 shrink-0">
+            <div className="flex items-center gap-2 shrink-0 md:justify-self-end">
               <div className="flex rounded-md border overflow-hidden">
                 <Button
                   variant={marketplaceView === "card" ? "secondary" : "ghost"}

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -9,7 +9,7 @@ import { GeneralSettings } from "@/components/general-settings";
 import { useWizard } from "@/components/wizard-provider";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Wand2, ChevronDown, SlidersHorizontal } from "lucide-react";
+import { Wand2, ChevronDown, Settings } from "lucide-react";
 import { PageHeader } from "@/components/page-header";
 import { PageLayout } from "@/components/page-layout";
 import {
@@ -27,7 +27,7 @@ export default function SettingsPage() {
 
   return (
     <PageLayout>
-      <PageHeader icon={SlidersHorizontal} title={t("title")} description={t("description")} />
+      <PageHeader icon={Settings} title={t("title")} description={t("description")} />
       <div className="space-y-6">
         <div className="animate-card-fade-in" style={{ animationDelay: "0ms" }}>
           <SystemUpdate />


### PR DESCRIPTION
## Summary
- **Settings:** Use Lucide `Settings` (gear) for the page header icon so it matches the sidebar and reads as settings rather than sliders.
- **Integrations:** Rework the tabs row into a responsive grid so the search field and marketplace view controls align and wrap cleanly.

## Test plan
- [ ] Open `/settings` and confirm the heading card shows the gear icon.
- [ ] Open `/integrations` on narrow and wide viewports; confirm tabs, search, and marketplace controls layout as expected.

Made with [Cursor](https://cursor.com)