### PR TITLE
chore: migrate Cursor setup to Claude Code (.claude/)

### DIFF
--- a/.claude/commands/build.md
+++ b/.claude/commands/build.md
@@ -1,0 +1,5 @@
+Rebuild all Docker images using docker-compose.dev.yml. Execute:
+
+docker-compose -f docker-compose.dev.yml build
+
+This rebuilds the images but does not restart the containers. Use /redeploy if you want to rebuild and restart. Show the build results when complete.

--- a/.claude/commands/logs.md
+++ b/.claude/commands/logs.md
@@ -1,0 +1,5 @@
+View and follow the logs from all Docker containers. Execute:
+
+docker-compose -f docker-compose.dev.yml logs -f
+
+Explain to the user that this will stream logs in real-time and they can press Ctrl+C to stop.

--- a/.claude/commands/redeploy-quick.md
+++ b/.claude/commands/redeploy-quick.md
@@ -1,0 +1,7 @@
+Stop, rebuild (using cache), and restart all Docker containers using docker-compose.dev.yml. Run the following commands in sequence:
+
+1. docker-compose -f docker-compose.dev.yml down
+2. docker-compose -f docker-compose.dev.yml build
+3. docker-compose -f docker-compose.dev.yml up -d
+
+This is faster than /redeploy because it uses Docker's build cache. After completion, show the user how to view logs and check container status.

--- a/.claude/commands/redeploy.md
+++ b/.claude/commands/redeploy.md
@@ -1,0 +1,7 @@
+Stop, rebuild (with --no-cache), and restart all Docker containers using docker-compose.dev.yml. Run the following commands in sequence:
+
+1. docker-compose -f docker-compose.dev.yml down
+2. docker-compose -f docker-compose.dev.yml build --no-cache
+3. docker-compose -f docker-compose.dev.yml up -d
+
+After completion, show the user how to view logs and check container status.

--- a/.claude/commands/restart.md
+++ b/.claude/commands/restart.md
@@ -1,0 +1,7 @@
+Stop, rebuild (with --no-cache), and restart all Docker containers using docker-compose.dev.yml. Run the following commands in sequence:
+
+1. docker-compose -f docker-compose.dev.yml down
+2. docker-compose -f docker-compose.dev.yml build --no-cache
+3. docker-compose -f docker-compose.dev.yml up -d
+
+This does a full clean rebuild. Use /build if you just want to rebuild images without restarting, or /start if containers are already built. After completion, show the user how to view logs.

--- a/.claude/commands/setup.md
+++ b/.claude/commands/setup.md
@@ -1,0 +1,81 @@
+Run a comprehensive macOS setup to ensure all prerequisites are installed for FiestaBoard. Execute the following steps in sequence:
+
+## Step 1: Check for Homebrew
+
+Run: `which brew`
+
+- If Homebrew is NOT found, ask the user if they want to install it, then run:
+  ```
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+  ```
+  After installation, remind the user they may need to add Homebrew to their PATH by running the commands shown in the installer output.
+
+- If Homebrew IS found, show the version with `brew --version` and continue.
+
+## Step 2: Check for Docker
+
+Run: `which docker`
+
+- If Docker is NOT found, ask the user if they want to install it via Homebrew, then run:
+  ```
+  brew install --cask docker
+  ```
+  After installation, tell the user to open Docker Desktop from their Applications folder to complete setup.
+
+- If Docker IS found, show the version with `docker --version` and continue.
+
+## Step 3: Check if Docker Desktop is Running
+
+Run: `docker info 2>&1`
+
+- If this command fails with "Cannot connect to the Docker daemon", tell the user:
+  "Docker Desktop is not running. Please open Docker Desktop from your Applications folder and wait for it to start, then run this setup again."
+
+- If successful, Docker is running. Continue to the next step.
+
+## Step 4: Verify Docker Access
+
+Run: `docker run --rm hello-world`
+
+- If this succeeds, Docker is properly configured.
+- If this fails with permission errors, suggest the user may need to add themselves to the docker group or check Docker Desktop settings.
+
+## Step 5: Check for docker-compose
+
+Run: `docker-compose --version`
+
+- Modern Docker Desktop includes docker-compose as a plugin. If the command fails, try `docker compose version` (without hyphen).
+- If neither works, suggest installing docker-compose via: `brew install docker-compose`
+
+## Step 6: Check for Environment File
+
+Run: `ls -la .env 2>/dev/null || echo "NOT_FOUND"`
+
+- If .env is NOT found, copy the example:
+  ```
+  cp env.example .env
+  ```
+  Tell the user: "Created .env from env.example. Please edit .env and add your board API key (BOARD_LOCAL_API_KEY or BOARD_READ_WRITE_KEY) before starting."
+
+- If .env exists, inform the user it's already configured.
+
+## Step 7: Verify Data Directory
+
+Run: `ls -la data/ 2>/dev/null || echo "NOT_FOUND"`
+
+- If data directory doesn't exist, create it:
+  ```
+  mkdir -p data
+  ```
+  Tell the user: "Created data/ directory. FiestaBoard will store its configuration here automatically."
+
+- If data directory exists, inform the user it's already present.
+
+## Summary
+
+After all steps complete, provide a summary:
+- ✅ or ❌ for each component (Homebrew, Docker, Docker running, docker-compose)
+- Status of .env file
+- Next steps: Tell the user to run `/start` to launch the development environment
+
+If any critical component is missing or failed, clearly indicate what needs to be fixed before proceeding.

--- a/.claude/commands/start.md
+++ b/.claude/commands/start.md
@@ -1,0 +1,5 @@
+Start all Docker containers using docker-compose.dev.yml. Execute:
+
+docker-compose -f docker-compose.dev.yml up -d
+
+The -d flag runs containers in detached mode (in the background). Show which containers were started and remind the user they can use `docker-compose logs -f` to view logs.

--- a/.claude/commands/status.md
+++ b/.claude/commands/status.md
@@ -1,0 +1,5 @@
+Check the status of all Docker containers. Execute:
+
+docker-compose -f docker-compose.dev.yml ps
+
+Show the container status and explain what each container is doing.

--- a/.claude/commands/stop.md
+++ b/.claude/commands/stop.md
@@ -1,0 +1,5 @@
+Stop all Docker containers using docker-compose.dev.yml. Execute:
+
+docker-compose -f docker-compose.dev.yml down
+
+This stops and removes the containers. Show confirmation when complete.

--- a/.claude/commands/test-api.md
+++ b/.claude/commands/test-api.md
@@ -1,0 +1,5 @@
+Run pytest tests for the API inside the FiestaBoard container. Execute:
+
+docker-compose -f docker-compose.dev.yml exec fiestaboard pytest
+
+Show the test results and explain any failures if they occur.

--- a/.claude/commands/test-prod-local.md
+++ b/.claude/commands/test-prod-local.md
@@ -1,0 +1,15 @@
+Test the production build locally by stopping dev containers, building production images, and starting them with docker-compose.prod.yml. Run the following commands in sequence:
+
+1. docker-compose -f docker-compose.dev.yml down
+2. docker-compose -f docker-compose.prod.yml build --no-cache
+3. docker-compose -f docker-compose.prod.yml up -d
+
+This builds and runs the production images locally for testing before deploying to your NAS. The UI will be available at http://localhost:4420.
+
+After completion, show the user:
+- How to access the UI (http://localhost:4420)
+- How to view logs: `docker-compose -f docker-compose.prod.yml logs -f`
+- How to check status: `docker-compose -f docker-compose.prod.yml ps`
+- Remind them that System Management features will be visible in Settings (production only)
+- How to stop: `docker-compose -f docker-compose.prod.yml down`
+- How to return to dev mode: `/start`

--- a/.claude/commands/test-web.md
+++ b/.claude/commands/test-web.md
@@ -1,0 +1,5 @@
+Run tests for the web UI inside the Docker container. Execute:
+
+docker-compose -f docker-compose.dev.yml run --rm --profile test web sh -c "npm ci && npm test"
+
+Show the test results and explain any failures if they occur.

--- a/.claude/mcp.json
+++ b/.claude/mcp.json
@@ -1,0 +1,32 @@
+{
+  "mcpServers": {
+    "notion": {
+      "url": "https://mcp.notion.com/mcp"
+    },
+    "context7": {
+      "url": "https://mcp.context7.com/mcp"
+    },
+    "memory": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-memory"]
+    },
+    "playwright": {
+      "command": "npx",
+      "args": ["-y", "@playwright/mcp@latest"]
+    },
+    "shadcn": {
+      "command": "npx",
+      "args": ["shadcn@latest", "mcp"]
+    },
+    "github": {
+      "url": "https://api.githubcopilot.com/mcp/",
+      "headers": {
+        "Authorization": "Bearer ${GITHUB_TOKEN}"
+      }
+    },
+    "puppeteer": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-puppeteer"]
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,56 @@
+# FiestaBoard — Claude Code Context
+
+## Page Schema Versioning
+
+> Applies to: `src/pages/**/*.py`
+
+`pages.json` uses a `schema_version` integer for ordered migrations.
+When changing the stored format of pages (adding/removing/renaming fields,
+changing how data is encoded), you MUST use this system instead of ad-hoc
+detection.
+
+### How It Works
+
+- `src/pages/storage.py` has `CURRENT_SCHEMA_VERSION` and a `MIGRATIONS` list
+- Each migration is a `(target_version, function)` tuple
+- On startup `_load()` reads `schema_version` (default 0), runs pending
+  migrations in order, bumps the version, and resaves once
+
+### Adding a New Migration
+
+1. Write a migration function in `storage.py`:
+
+```python
+def _migrate_v1_to_v2(pages_data: List[dict]) -> int:
+    """Migration 1 -> 2: describe what changes."""
+    migrated = 0
+    for page_data in pages_data:
+        # mutate page_data in place
+        migrated += 1
+    return migrated
+```
+
+2. Append to `MIGRATIONS`:
+
+```python
+MIGRATIONS: List[Tuple[int, Callable[[List[dict]], int]]] = [
+    (1, _migrate_v0_to_v1),
+    (2, _migrate_v1_to_v2),  # NEW
+]
+```
+
+3. Bump `CURRENT_SCHEMA_VERSION`:
+
+```python
+CURRENT_SCHEMA_VERSION = 2  # was 1
+```
+
+### Rules
+
+- NEVER use heuristic detection (key presence, string length, etc.) to
+  decide if a page needs migrating — use schema_version
+- NEVER modify the stored format without adding a migration
+- Migrations MUST be idempotent and safe to re-run
+- Migrations operate on raw dicts (before Pydantic validation)
+- Always log how many pages were affected
+- A backup is created automatically before the first migration runs


### PR DESCRIPTION
Adds equivalent Claude Code configuration for all existing .cursor/ setup:
- .claude/mcp.json with all 7 MCP servers (notion, context7, memory, playwright, shadcn, github, puppeteer)
- .claude/commands/ with all 12 slash commands (build, start, stop, logs, status, restart, redeploy, redeploy-quick, setup, test-api, test-web, test-prod-local)
- CLAUDE.md at project root with page schema versioning rules (from .cursor/rules/)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
