### PR TITLE
test(contract): add API contract tests for Python backend ↔ Next.js (#502)

### DIFF
--- a/tests/contract/__init__.py
+++ b/tests/contract/__init__.py
@@ -1,0 +1,1 @@
+# Contract test package for FiestaBoard API

--- a/tests/contract/conftest.py
+++ b/tests/contract/conftest.py
@@ -1,0 +1,122 @@
+"""Shared fixtures for API contract tests.
+
+These tests validate that the FastAPI backend returns responses that match
+the schemas the Next.js frontend expects to consume. Using Pydantic models
+as the source of truth for schema validation.
+"""
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from fastapi.testclient import TestClient
+
+from src.api_server import app
+
+
+@pytest.fixture(scope="module")
+def client():
+    """Create a TestClient for the FastAPI app."""
+    return TestClient(app)
+
+
+@pytest.fixture
+def mock_page_service():
+    """Mock the page service for isolated contract testing."""
+    with patch("src.api_server.get_page_service") as mock_get:
+        svc = Mock()
+
+        # Default list_pages returns an empty list
+        svc.list_pages.return_value = []
+
+        # create_page returns a minimal valid Page object
+        from src.pages.models import Page
+        sample_page = Page(
+            id="contract-page-1",
+            name="Contract Test Page",
+            type="template",
+            template=["HELLO WORLD", "", "", "", "", ""],
+        )
+        svc.create_page.return_value = sample_page
+        svc.get_page.return_value = sample_page
+
+        mock_get.return_value = svc
+        yield svc
+
+
+@pytest.fixture
+def mock_schedule_service():
+    """Mock the schedule service for isolated contract testing."""
+    with patch("src.api_server.get_schedule_service") as mock_get:
+        svc = Mock()
+
+        from src.schedules.models import ScheduleEntry as Schedule
+        sample_schedule = Schedule(
+            id="contract-schedule-1",
+            page_id="contract-page-1",
+            start_time="08:00",
+            end_time="17:00",
+            day_pattern="weekdays",
+        )
+        svc.list_schedules.return_value = []
+        svc.create_schedule.return_value = sample_schedule
+        svc.get_schedule.return_value = sample_schedule
+
+        svc.get_schedules_enabled.return_value = True
+        svc.get_active_page_id.return_value = None
+        svc.get_default_page_id.return_value = None
+        svc.validate_schedule_data.return_value = {"valid": True, "errors": []}
+
+        mock_get.return_value = svc
+        yield svc
+
+
+@pytest.fixture
+def mock_settings_service():
+    """Mock the settings service for isolated contract testing."""
+    with patch("src.api_server.get_settings_service") as mock_get:
+        svc = Mock()
+
+        transition = Mock()
+        transition.strategy = "column"
+        transition.step_interval_ms = 100
+        transition.step_size = 1
+        transition.to_dict.return_value = {
+            "strategy": "column",
+            "step_interval_ms": 100,
+            "step_size": 1,
+        }
+        svc.get_transition_settings.return_value = transition
+
+        output = Mock()
+        output.target = "ui"
+        output.to_dict.return_value = {"target": "ui"}
+        svc.get_output_settings.return_value = output
+
+        svc.get_active_page_id.return_value = None
+        svc.get_polling_settings.return_value = Mock(to_dict=lambda: {"enabled": True})
+
+        mock_get.return_value = svc
+        yield svc
+
+
+@pytest.fixture
+def mock_config_manager():
+    """Mock config manager for settings endpoints."""
+    with patch("src.api_server.get_config_manager") as mock_get:
+        cm = Mock()
+        cm.get_all_masked.return_value = {}
+        cm.get_board.return_value = {
+            "api_mode": "local",
+            "local_api_key": "test",
+            "host": "192.168.1.100",
+        }
+        cm._mask_sensitive.side_effect = lambda d: d
+        cm.validate.return_value = (True, [])
+        cm.get_general.return_value = {"timezone": "UTC", "refresh_interval_seconds": 60}
+        cm.get_feature.return_value = {
+            "enabled": False,
+            "start_time": "20:00+00:00",
+            "end_time": "07:00+00:00",
+        }
+        cm.get_plugin_config.return_value = {"enabled": False}
+        mock_get.return_value = cm
+        yield cm

--- a/tests/contract/schemas.py
+++ b/tests/contract/schemas.py
@@ -1,0 +1,195 @@
+"""Pydantic schemas that define the API contracts between the Python backend
+and the Next.js frontend.
+
+These schemas mirror what the frontend TypeScript types expect. If the backend
+changes a response shape, these schemas will fail — catching contract drift
+before it reaches production.
+
+Each schema is defined with strict=True to reject unexpected fields by default.
+"""
+
+from typing import Any, Dict, List, Optional, Union
+from pydantic import BaseModel, Field
+
+
+# ---------------------------------------------------------------------------
+# Core / Health
+# ---------------------------------------------------------------------------
+
+
+class HealthResponse(BaseModel):
+    """GET /health"""
+    status: str  # "ok"
+
+
+class VersionResponse(BaseModel):
+    """GET /version"""
+    package_version: str
+    build_version: str
+    is_dev: bool
+
+
+class StatusResponse(BaseModel):
+    """GET /status"""
+    running: bool
+    active_page: Optional[str] = None
+    uptime_seconds: Optional[float] = None
+
+
+# ---------------------------------------------------------------------------
+# Pages
+# ---------------------------------------------------------------------------
+
+
+class PageSchema(BaseModel):
+    """A single page object as returned by the backend."""
+    id: str
+    name: str
+    type: str  # "template" | "single" | "composite" | "note"
+    template: Optional[Union[List[str], str]] = None
+    display_type: Optional[str] = None
+    rows: Optional[List[Any]] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+
+class PagesListResponse(BaseModel):
+    """GET /pages"""
+    pages: List[PageSchema]
+    total: int
+
+
+class CreatePageResponse(BaseModel):
+    """POST /pages"""
+    status: str  # "success"
+    page: PageSchema
+
+
+class GetPageResponse(PageSchema):
+    """GET /pages/{page_id} — returns the page directly (not nested)."""
+    pass
+
+
+class UpdatePageResponse(BaseModel):
+    """PUT /pages/{page_id}"""
+    status: str  # "success"
+    page: PageSchema
+
+
+class DeletePageResponse(BaseModel):
+    """DELETE /pages/{page_id}"""
+    status: str  # "success" | "not_found"
+
+
+# ---------------------------------------------------------------------------
+# Schedules
+# ---------------------------------------------------------------------------
+
+
+class ScheduleSchema(BaseModel):
+    """A single schedule entry."""
+    id: str
+    page_id: str
+    start_time: str  # "HH:MM"
+    end_time: str  # "HH:MM"
+    day_pattern: str  # "daily" | "weekdays" | "weekends" | ...
+    board_id: Optional[str] = None
+    enabled: Optional[bool] = None
+
+
+class SchedulesListResponse(BaseModel):
+    """GET /schedules"""
+    schedules: List[ScheduleSchema]
+    total: int
+
+
+class CreateScheduleResponse(BaseModel):
+    """POST /schedules"""
+    status: str
+    schedule: ScheduleSchema
+
+
+class GetScheduleResponse(BaseModel):
+    """GET /schedules/{schedule_id}"""
+    schedule: ScheduleSchema
+
+
+class SchedulesEnabledResponse(BaseModel):
+    """GET /schedules/enabled"""
+    enabled: bool
+
+
+class ActivePageResponse(BaseModel):
+    """GET /schedules/active/page"""
+    page_id: Optional[str] = None
+    active: bool
+
+
+class DefaultPageResponse(BaseModel):
+    """GET /schedules/default-page"""
+    page_id: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Settings
+# ---------------------------------------------------------------------------
+
+
+class TransitionSettingsResponse(BaseModel):
+    """GET /settings/transitions"""
+    strategy: str
+    step_interval_ms: Optional[int] = None
+    step_size: Optional[int] = None
+
+
+class OutputSettingsResponse(BaseModel):
+    """GET /settings/output"""
+    target: str  # "ui" | "board" | ...
+
+
+class BoardInstanceSchema(BaseModel):
+    """A single board instance in the board settings."""
+    id: Optional[str] = None
+    name: str
+    device_type: Optional[str] = None
+    board_color: Optional[str] = None
+    api_mode: Optional[str] = None
+    enabled: Optional[bool] = None
+
+
+class BoardSettingsResponse(BaseModel):
+    """GET /settings/board"""
+    boards: List[Dict[str, Any]]
+    board_type: Optional[str] = None
+    devices: Optional[List[str]] = None
+
+
+# ---------------------------------------------------------------------------
+# Plugins
+# ---------------------------------------------------------------------------
+
+
+class PluginSchema(BaseModel):
+    """A single plugin entry as returned by /plugins."""
+    id: str
+    name: str
+    enabled: bool
+    version: Optional[str] = None
+    description: Optional[str] = None
+    category: Optional[str] = None
+
+
+class PluginsListResponse(BaseModel):
+    """GET /plugins"""
+    plugins: List[PluginSchema]
+
+
+class PluginDetailResponse(BaseModel):
+    """GET /plugins/{plugin_id}"""
+    id: str
+    name: str
+    enabled: bool
+    version: Optional[str] = None
+    description: Optional[str] = None
+    category: Optional[str] = None
+    config: Optional[Dict[str, Any]] = None

--- a/tests/contract/test_pages_contract.py
+++ b/tests/contract/test_pages_contract.py
@@ -1,0 +1,264 @@
+"""Contract tests for the /pages API endpoints.
+
+Validates that the Python backend returns responses that conform to the
+schema the Next.js frontend expects to consume.
+
+Issue: #502
+"""
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from src.api_server import app
+from tests.contract.schemas import (
+    PagesListResponse,
+    CreatePageResponse,
+    GetPageResponse,
+    DeletePageResponse,
+)
+from src.pages.models import Page, PageCreate
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def sample_page():
+    """A minimal valid template page."""
+    return Page(
+        id="test-page-contract-1",
+        name="Contract Test",
+        type="template",
+        template=["LINE ONE", "", "", "", "", ""],
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /pages
+# ---------------------------------------------------------------------------
+
+
+class TestListPagesContract:
+    def test_returns_200(self, client):
+        with patch("src.api_server.get_page_service") as mock_svc:
+            svc = Mock()
+            svc.list_pages.return_value = []
+            mock_svc.return_value = svc
+
+            resp = client.get("/pages")
+        assert resp.status_code == 200
+
+    def test_response_has_pages_and_total(self, client):
+        with patch("src.api_server.get_page_service") as mock_svc:
+            svc = Mock()
+            svc.list_pages.return_value = []
+            mock_svc.return_value = svc
+
+            resp = client.get("/pages")
+
+        data = resp.json()
+        assert "pages" in data
+        assert "total" in data
+
+    def test_response_validates_against_schema(self, client):
+        with patch("src.api_server.get_page_service") as mock_svc:
+            svc = Mock()
+            svc.list_pages.return_value = []
+            mock_svc.return_value = svc
+
+            resp = client.get("/pages")
+
+        # Should not raise
+        parsed = PagesListResponse(**resp.json())
+        assert parsed.total == 0
+        assert parsed.pages == []
+
+    def test_pages_list_with_items_validates(self, client, sample_page):
+        with patch("src.api_server.get_page_service") as mock_svc:
+            svc = Mock()
+            svc.list_pages.return_value = [sample_page]
+            mock_svc.return_value = svc
+
+            resp = client.get("/pages")
+
+        data = resp.json()
+        parsed = PagesListResponse(**data)
+        assert parsed.total == 1
+        assert len(parsed.pages) == 1
+        assert parsed.pages[0].name == "Contract Test"
+        assert parsed.pages[0].type == "template"
+
+    def test_page_id_is_string(self, client, sample_page):
+        with patch("src.api_server.get_page_service") as mock_svc:
+            svc = Mock()
+            svc.list_pages.return_value = [sample_page]
+            mock_svc.return_value = svc
+
+            resp = client.get("/pages")
+
+        page = resp.json()["pages"][0]
+        assert isinstance(page["id"], str)
+        assert len(page["id"]) > 0
+
+    def test_total_matches_pages_length(self, client, sample_page):
+        page2 = Page(id="test-2", name="Page Two", type="template", template=["X"])
+        with patch("src.api_server.get_page_service") as mock_svc:
+            svc = Mock()
+            svc.list_pages.return_value = [sample_page, page2]
+            mock_svc.return_value = svc
+
+            resp = client.get("/pages")
+
+        data = resp.json()
+        assert data["total"] == len(data["pages"])
+
+
+# ---------------------------------------------------------------------------
+# POST /pages
+# ---------------------------------------------------------------------------
+
+
+class TestCreatePageContract:
+    def test_returns_200_on_valid_input(self, client, sample_page):
+        with patch("src.api_server.get_page_service") as mock_svc:
+            svc = Mock()
+            svc.create_page.return_value = sample_page
+            mock_svc.return_value = svc
+
+            resp = client.post(
+                "/pages",
+                json={"name": "Contract Test", "type": "template", "template": ["HELLO", "", "", "", "", ""]},
+            )
+
+        assert resp.status_code == 200
+
+    def test_response_validates_against_schema(self, client, sample_page):
+        with patch("src.api_server.get_page_service") as mock_svc:
+            svc = Mock()
+            svc.create_page.return_value = sample_page
+            mock_svc.return_value = svc
+
+            resp = client.post(
+                "/pages",
+                json={"name": "Contract Test", "type": "template", "template": ["HELLO", "", "", "", "", ""]},
+            )
+
+        parsed = CreatePageResponse(**resp.json())
+        assert parsed.status == "success"
+        assert parsed.page.id == "test-page-contract-1"
+
+    def test_response_status_is_success(self, client, sample_page):
+        with patch("src.api_server.get_page_service") as mock_svc:
+            svc = Mock()
+            svc.create_page.return_value = sample_page
+            mock_svc.return_value = svc
+
+            resp = client.post(
+                "/pages",
+                json={"name": "T", "type": "template", "template": ["X", "", "", "", "", ""]},
+            )
+
+        assert resp.json()["status"] == "success"
+
+    def test_returns_400_for_invalid_page(self, client):
+        with patch("src.api_server.get_page_service") as mock_svc:
+            svc = Mock()
+            svc.create_page.side_effect = ValueError("Missing required field")
+            mock_svc.return_value = svc
+
+            resp = client.post(
+                "/pages",
+                json={"name": "Bad Page", "type": "template"},  # missing template
+            )
+
+        # Either 400 (business logic) or 422 (schema validation)
+        assert resp.status_code in (400, 422)
+
+    def test_created_page_has_required_fields(self, client, sample_page):
+        with patch("src.api_server.get_page_service") as mock_svc:
+            svc = Mock()
+            svc.create_page.return_value = sample_page
+            mock_svc.return_value = svc
+
+            resp = client.post(
+                "/pages",
+                json={"name": "T", "type": "template", "template": ["X", "", "", "", "", ""]},
+            )
+
+        page = resp.json()["page"]
+        assert "id" in page
+        assert "name" in page
+        assert "type" in page
+
+
+# ---------------------------------------------------------------------------
+# GET /pages/{page_id}
+# ---------------------------------------------------------------------------
+
+
+class TestGetPageContract:
+    def test_returns_200_for_existing_page(self, client, sample_page):
+        with patch("src.api_server.get_page_service") as mock_svc:
+            svc = Mock()
+            svc.get_page.return_value = sample_page
+            mock_svc.return_value = svc
+
+            resp = client.get("/pages/test-page-contract-1")
+
+        assert resp.status_code == 200
+
+    def test_response_validates_against_schema(self, client, sample_page):
+        with patch("src.api_server.get_page_service") as mock_svc:
+            svc = Mock()
+            svc.get_page.return_value = sample_page
+            mock_svc.return_value = svc
+
+            resp = client.get("/pages/test-page-contract-1")
+
+        # GET /pages/{id} returns the page directly (not nested under "page")
+        parsed = GetPageResponse(**resp.json())
+        assert parsed.id == "test-page-contract-1"
+
+    def test_returns_404_for_missing_page(self, client):
+        with patch("src.api_server.get_page_service") as mock_svc:
+            svc = Mock()
+            svc.get_page.return_value = None
+            mock_svc.return_value = svc
+
+            resp = client.get("/pages/does-not-exist")
+
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# DELETE /pages/{page_id}
+# ---------------------------------------------------------------------------
+
+
+class TestDeletePageContract:
+    def test_returns_200_on_delete(self, client, sample_page):
+        with patch("src.api_server.get_page_service") as mock_svc:
+            from src.pages.service import DeleteResult
+            svc = Mock()
+            svc.delete_page.return_value = DeleteResult(deleted=True)
+            mock_svc.return_value = svc
+
+            resp = client.delete("/pages/test-page-contract-1")
+
+        assert resp.status_code == 200
+
+    def test_response_has_status_field(self, client, sample_page):
+        with patch("src.api_server.get_page_service") as mock_svc:
+            from src.pages.service import DeleteResult
+            svc = Mock()
+            svc.delete_page.return_value = DeleteResult(deleted=True)
+            mock_svc.return_value = svc
+
+            resp = client.delete("/pages/test-page-contract-1")
+
+        data = resp.json()
+        assert "status" in data

--- a/tests/contract/test_schedules_contract.py
+++ b/tests/contract/test_schedules_contract.py
@@ -1,0 +1,362 @@
+"""Contract tests for the /schedules API endpoints.
+
+Validates that the Python backend returns responses that conform to the
+schema the Next.js frontend expects.
+
+Issue: #502
+"""
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from src.api_server import app
+from tests.contract.schemas import (
+    SchedulesListResponse,
+    SchedulesEnabledResponse,
+    DefaultPageResponse,
+)
+from src.schedules.models import ScheduleEntry as Schedule
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def sample_schedule():
+    return Schedule(
+        id="contract-sched-1",
+        page_id="contract-page-1",
+        start_time="08:00",
+        end_time="17:00",
+        day_pattern="weekdays",
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /schedules
+# ---------------------------------------------------------------------------
+
+
+class TestListSchedulesContract:
+    def test_returns_200(self, client):
+        with patch("src.api_server.get_schedule_service") as mock_svc, \
+             patch("src.api_server.get_settings_service") as mock_settings:
+            svc = Mock()
+            svc.list_schedules.return_value = []
+            svc.get_default_page.return_value = None
+            mock_svc.return_value = svc
+
+            ss = Mock()
+            ss.is_schedule_enabled.return_value = False
+            mock_settings.return_value = ss
+
+            resp = client.get("/schedules")
+
+        assert resp.status_code == 200
+
+    def test_response_has_required_keys(self, client):
+        with patch("src.api_server.get_schedule_service") as mock_svc, \
+             patch("src.api_server.get_settings_service") as mock_settings:
+            svc = Mock()
+            svc.list_schedules.return_value = []
+            svc.get_default_page.return_value = None
+            mock_svc.return_value = svc
+
+            ss = Mock()
+            ss.is_schedule_enabled.return_value = False
+            mock_settings.return_value = ss
+
+            resp = client.get("/schedules")
+
+        data = resp.json()
+        assert "schedules" in data
+        assert "total" in data
+
+    def test_schedules_is_list(self, client):
+        with patch("src.api_server.get_schedule_service") as mock_svc, \
+             patch("src.api_server.get_settings_service") as mock_settings:
+            svc = Mock()
+            svc.list_schedules.return_value = []
+            svc.get_default_page.return_value = None
+            mock_svc.return_value = svc
+
+            ss = Mock()
+            ss.is_schedule_enabled.return_value = False
+            mock_settings.return_value = ss
+
+            resp = client.get("/schedules")
+
+        assert isinstance(resp.json()["schedules"], list)
+
+    def test_total_matches_schedules_length(self, client, sample_schedule):
+        with patch("src.api_server.get_schedule_service") as mock_svc, \
+             patch("src.api_server.get_settings_service") as mock_settings:
+            svc = Mock()
+            svc.list_schedules.return_value = [sample_schedule]
+            svc.get_default_page.return_value = None
+            mock_svc.return_value = svc
+
+            ss = Mock()
+            ss.is_schedule_enabled.return_value = True
+            mock_settings.return_value = ss
+
+            resp = client.get("/schedules")
+
+        data = resp.json()
+        assert data["total"] == len(data["schedules"])
+
+    def test_schedule_item_has_required_fields(self, client, sample_schedule):
+        with patch("src.api_server.get_schedule_service") as mock_svc, \
+             patch("src.api_server.get_settings_service") as mock_settings:
+            svc = Mock()
+            svc.list_schedules.return_value = [sample_schedule]
+            svc.get_default_page.return_value = None
+            mock_svc.return_value = svc
+
+            ss = Mock()
+            ss.is_schedule_enabled.return_value = True
+            mock_settings.return_value = ss
+
+            resp = client.get("/schedules")
+
+        sched = resp.json()["schedules"][0]
+        assert "id" in sched
+        assert "page_id" in sched
+        assert "start_time" in sched
+        assert "end_time" in sched
+        assert "day_pattern" in sched
+
+    def test_schedule_time_format_is_hhmm(self, client, sample_schedule):
+        with patch("src.api_server.get_schedule_service") as mock_svc, \
+             patch("src.api_server.get_settings_service") as mock_settings:
+            svc = Mock()
+            svc.list_schedules.return_value = [sample_schedule]
+            svc.get_default_page.return_value = None
+            mock_svc.return_value = svc
+
+            ss = Mock()
+            ss.is_schedule_enabled.return_value = True
+            mock_settings.return_value = ss
+
+            resp = client.get("/schedules")
+
+        sched = resp.json()["schedules"][0]
+        import re
+        assert re.match(r"^\d{2}:\d{2}$", sched["start_time"]), \
+            f"start_time format unexpected: {sched['start_time']}"
+        assert re.match(r"^\d{2}:\d{2}$", sched["end_time"]), \
+            f"end_time format unexpected: {sched['end_time']}"
+
+    def test_wildcard_board_id_returns_no_default_or_enabled(self, client, sample_schedule):
+        """board_id=* returns schedules without enabled/default_page_id semantics."""
+        with patch("src.api_server.get_schedule_service") as mock_svc, \
+             patch("src.api_server.get_settings_service") as mock_settings:
+            svc = Mock()
+            svc.list_schedules.return_value = [sample_schedule]
+            mock_svc.return_value = svc
+
+            ss = Mock()
+            mock_settings.return_value = ss
+
+            resp = client.get("/schedules?board_id=*")
+
+        data = resp.json()
+        assert "schedules" in data
+        assert "total" in data
+        assert data["enabled"] is False  # wildcard sets enabled=False
+        assert data["default_page_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# POST /schedules
+# ---------------------------------------------------------------------------
+
+
+class TestCreateScheduleContract:
+    def test_returns_200_on_valid_input(self, client, sample_schedule):
+        with patch("src.api_server.get_schedule_service") as mock_svc:
+            svc = Mock()
+            svc.create_schedule.return_value = sample_schedule
+            mock_svc.return_value = svc
+
+            resp = client.post(
+                "/schedules",
+                json={
+                    "page_id": "contract-page-1",
+                    "start_time": "08:00",
+                    "end_time": "17:00",
+                    "day_pattern": "weekdays",
+                },
+            )
+
+        assert resp.status_code == 200
+
+    def test_created_schedule_has_required_fields(self, client, sample_schedule):
+        with patch("src.api_server.get_schedule_service") as mock_svc:
+            svc = Mock()
+            svc.create_schedule.return_value = sample_schedule
+            mock_svc.return_value = svc
+
+            resp = client.post(
+                "/schedules",
+                json={
+                    "page_id": "contract-page-1",
+                    "start_time": "08:00",
+                    "end_time": "17:00",
+                    "day_pattern": "weekdays",
+                },
+            )
+
+        data = resp.json()
+        assert "id" in data
+        assert "page_id" in data
+        assert "start_time" in data
+        assert "end_time" in data
+        assert "day_pattern" in data
+
+    def test_returns_400_on_invalid_input(self, client):
+        with patch("src.api_server.get_schedule_service") as mock_svc:
+            svc = Mock()
+            svc.create_schedule.side_effect = ValueError("Missing page_id")
+            mock_svc.return_value = svc
+
+            resp = client.post(
+                "/schedules",
+                json={"start_time": "08:00", "end_time": "17:00"},
+            )
+
+        assert resp.status_code in (400, 422)
+
+    def test_midnight_spanning_schedule_accepted(self, client):
+        """API must accept start_time > end_time for overnight schedules."""
+        overnight = Schedule(
+            id="overnight-1",
+            page_id="p1",
+            start_time="22:00",
+            end_time="06:00",
+            day_pattern="all",
+        )
+        with patch("src.api_server.get_schedule_service") as mock_svc:
+            svc = Mock()
+            svc.create_schedule.return_value = overnight
+            mock_svc.return_value = svc
+
+            resp = client.post(
+                "/schedules",
+                json={
+                    "page_id": "p1",
+                    "start_time": "22:00",
+                    "end_time": "06:00",
+                    "day_pattern": "all",
+                },
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["start_time"] == "22:00"
+        assert data["end_time"] == "06:00"
+
+
+# ---------------------------------------------------------------------------
+# GET /schedules/enabled
+# ---------------------------------------------------------------------------
+
+
+class TestSchedulesEnabledContract:
+    def test_returns_200(self, client):
+        with patch("src.api_server.get_settings_service") as mock_settings:
+            ss = Mock()
+            ss.is_schedule_enabled.return_value = False
+            mock_settings.return_value = ss
+
+            resp = client.get("/schedules/enabled")
+
+        assert resp.status_code == 200
+
+    def test_response_has_enabled_field(self, client):
+        with patch("src.api_server.get_settings_service") as mock_settings:
+            ss = Mock()
+            ss.is_schedule_enabled.return_value = True
+            mock_settings.return_value = ss
+
+            resp = client.get("/schedules/enabled")
+
+        data = resp.json()
+        assert "enabled" in data
+        assert isinstance(data["enabled"], bool)
+
+    def test_enabled_false_validates(self, client):
+        with patch("src.api_server.get_settings_service") as mock_settings:
+            ss = Mock()
+            ss.is_schedule_enabled.return_value = False
+            mock_settings.return_value = ss
+
+            resp = client.get("/schedules/enabled")
+
+        parsed = SchedulesEnabledResponse(**resp.json())
+        assert parsed.enabled is False
+
+    def test_enabled_true_validates(self, client):
+        with patch("src.api_server.get_settings_service") as mock_settings:
+            ss = Mock()
+            ss.is_schedule_enabled.return_value = True
+            mock_settings.return_value = ss
+
+            resp = client.get("/schedules/enabled")
+
+        parsed = SchedulesEnabledResponse(**resp.json())
+        assert parsed.enabled is True
+
+
+# ---------------------------------------------------------------------------
+# GET /schedules/default-page
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultPageContract:
+    def test_returns_200(self, client):
+        with patch("src.api_server.get_schedule_service") as mock_svc:
+            svc = Mock()
+            svc.get_default_page.return_value = None
+            mock_svc.return_value = svc
+
+            resp = client.get("/schedules/default-page")
+
+        assert resp.status_code == 200
+
+    def test_response_has_default_page_id(self, client):
+        with patch("src.api_server.get_schedule_service") as mock_svc:
+            svc = Mock()
+            svc.get_default_page.return_value = None
+            mock_svc.return_value = svc
+
+            resp = client.get("/schedules/default-page")
+
+        data = resp.json()
+        assert "default_page_id" in data
+
+    def test_null_default_page_is_valid(self, client):
+        with patch("src.api_server.get_schedule_service") as mock_svc:
+            svc = Mock()
+            svc.get_default_page.return_value = None
+            mock_svc.return_value = svc
+
+            resp = client.get("/schedules/default-page")
+
+        parsed = DefaultPageResponse(**resp.json())
+        assert parsed.page_id is None
+
+    def test_set_default_page_id_reflects_in_response(self, client):
+        with patch("src.api_server.get_schedule_service") as mock_svc:
+            svc = Mock()
+            svc.get_default_page.return_value = "my-default-page"
+            mock_svc.return_value = svc
+
+            resp = client.get("/schedules/default-page")
+
+        data = resp.json()
+        assert data["default_page_id"] == "my-default-page"

--- a/tests/contract/test_settings_contract.py
+++ b/tests/contract/test_settings_contract.py
@@ -1,0 +1,321 @@
+"""Contract tests for the /settings API endpoints.
+
+Validates that the Python backend returns responses that conform to the
+schema the Next.js frontend expects.
+
+Issue: #502
+"""
+
+import pytest
+from unittest.mock import Mock, patch
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from src.api_server import app
+from tests.contract.schemas import (
+    HealthResponse,
+    VersionResponse,
+    TransitionSettingsResponse,
+    OutputSettingsResponse,
+    BoardSettingsResponse,
+)
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# GET /health
+# ---------------------------------------------------------------------------
+
+
+class TestHealthContract:
+    def test_returns_200(self, client):
+        resp = client.get("/health")
+        assert resp.status_code == 200
+
+    def test_response_has_status_field(self, client):
+        resp = client.get("/health")
+        data = resp.json()
+        assert "status" in data
+
+    def test_status_is_ok(self, client):
+        resp = client.get("/health")
+        assert resp.json()["status"] == "ok"
+
+    def test_validates_against_schema(self, client):
+        resp = client.get("/health")
+        parsed = HealthResponse(**resp.json())
+        assert parsed.status == "ok"
+
+
+# ---------------------------------------------------------------------------
+# GET /version
+# ---------------------------------------------------------------------------
+
+
+class TestVersionContract:
+    def test_returns_200(self, client):
+        resp = client.get("/version")
+        assert resp.status_code == 200
+
+    def test_response_has_package_version_field(self, client):
+        resp = client.get("/version")
+        assert "package_version" in resp.json()
+
+    def test_package_version_is_string(self, client):
+        resp = client.get("/version")
+        assert isinstance(resp.json()["package_version"], str)
+
+    def test_package_version_is_semver_like(self, client):
+        """Version should look like X.Y.Z."""
+        resp = client.get("/version")
+        version = resp.json()["package_version"]
+        parts = version.split(".")
+        assert len(parts) >= 2, f"Version '{version}' doesn't look like semver"
+
+    def test_response_has_build_version_field(self, client):
+        resp = client.get("/version")
+        assert "build_version" in resp.json()
+
+    def test_response_has_is_dev_field(self, client):
+        resp = client.get("/version")
+        assert "is_dev" in resp.json()
+        assert isinstance(resp.json()["is_dev"], bool)
+
+    def test_validates_against_schema(self, client):
+        resp = client.get("/version")
+        parsed = VersionResponse(**resp.json())
+        assert len(parsed.package_version) > 0
+
+
+# ---------------------------------------------------------------------------
+# GET /settings/transitions
+# ---------------------------------------------------------------------------
+
+
+class TestTransitionSettingsContract:
+    def _make_transition_mock(self, strategy="column", step_interval_ms=50, step_size=1):
+        """Create a transition settings mock with concrete attribute values."""
+        from types import SimpleNamespace
+        return SimpleNamespace(
+            strategy=strategy,
+            step_interval_ms=step_interval_ms,
+            step_size=step_size,
+        )
+
+    def test_returns_200(self, client):
+        with patch("src.api_server.get_settings_service") as mock_svc:
+            ss = Mock()
+            ss.get_transition_settings.return_value = self._make_transition_mock()
+            mock_svc.return_value = ss
+
+            resp = client.get("/settings/transitions")
+
+        assert resp.status_code == 200
+
+    def test_response_has_strategy(self, client):
+        with patch("src.api_server.get_settings_service") as mock_svc:
+            ss = Mock()
+            ss.get_transition_settings.return_value = self._make_transition_mock()
+            mock_svc.return_value = ss
+
+            resp = client.get("/settings/transitions")
+
+        assert "strategy" in resp.json()
+
+    def test_validates_against_schema(self, client):
+        with patch("src.api_server.get_settings_service") as mock_svc:
+            ss = Mock()
+            ss.get_transition_settings.return_value = self._make_transition_mock(
+                strategy="column", step_interval_ms=100
+            )
+            mock_svc.return_value = ss
+
+            resp = client.get("/settings/transitions")
+
+        parsed = TransitionSettingsResponse(**resp.json())
+        assert parsed.strategy == "column"
+
+    def test_strategy_is_string(self, client):
+        with patch("src.api_server.get_settings_service") as mock_svc:
+            ss = Mock()
+            ss.get_transition_settings.return_value = self._make_transition_mock(strategy="instant")
+            mock_svc.return_value = ss
+
+            resp = client.get("/settings/transitions")
+
+        assert isinstance(resp.json()["strategy"], str)
+
+
+# ---------------------------------------------------------------------------
+# GET /settings/output
+# ---------------------------------------------------------------------------
+
+
+class TestOutputSettingsContract:
+    def _make_output_mock(self, target="ui"):
+        from types import SimpleNamespace
+        return SimpleNamespace(target=target)
+
+    def test_returns_200(self, client):
+        with patch("src.api_server.get_settings_service") as mock_svc:
+            ss = Mock()
+            ss.get_output_settings.return_value = self._make_output_mock("ui")
+            mock_svc.return_value = ss
+
+            resp = client.get("/settings/output")
+
+        assert resp.status_code == 200
+
+    def test_response_has_target_field(self, client):
+        with patch("src.api_server.get_settings_service") as mock_svc:
+            ss = Mock()
+            ss.get_output_settings.return_value = self._make_output_mock("ui")
+            mock_svc.return_value = ss
+
+            resp = client.get("/settings/output")
+
+        assert "target" in resp.json()
+
+    def test_validates_against_schema(self, client):
+        with patch("src.api_server.get_settings_service") as mock_svc:
+            ss = Mock()
+            ss.get_output_settings.return_value = self._make_output_mock("board")
+            mock_svc.return_value = ss
+
+            resp = client.get("/settings/output")
+
+        parsed = OutputSettingsResponse(**resp.json())
+        assert parsed.target == "board"
+
+    def test_target_is_string(self, client):
+        with patch("src.api_server.get_settings_service") as mock_svc:
+            ss = Mock()
+            ss.get_output_settings.return_value = self._make_output_mock("ui")
+            mock_svc.return_value = ss
+
+            resp = client.get("/settings/output")
+
+        assert isinstance(resp.json()["target"], str)
+
+
+# ---------------------------------------------------------------------------
+# GET /settings/board
+# ---------------------------------------------------------------------------
+
+
+class TestBoardSettingsContract:
+    def _make_board_settings_mock(self, boards=None):
+        """Create a board settings mock with a concrete to_dict()."""
+        if boards is None:
+            boards = []
+        board_dict = {
+            "board_type": "black",
+            "boards": boards,
+            "devices": ["flagship"],
+        }
+        m = Mock()
+        m.to_dict.return_value = board_dict
+        return m
+
+    def test_returns_200(self, client):
+        with patch("src.api_server.get_settings_service") as mock_svc:
+            ss = Mock()
+            ss.get_board_settings.return_value = self._make_board_settings_mock()
+            mock_svc.return_value = ss
+
+            resp = client.get("/settings/board")
+
+        assert resp.status_code == 200
+
+    def test_response_has_boards_field(self, client):
+        with patch("src.api_server.get_settings_service") as mock_svc:
+            ss = Mock()
+            ss.get_board_settings.return_value = self._make_board_settings_mock()
+            mock_svc.return_value = ss
+
+            resp = client.get("/settings/board")
+
+        assert "boards" in resp.json()
+
+    def test_boards_is_list(self, client):
+        with patch("src.api_server.get_settings_service") as mock_svc:
+            ss = Mock()
+            ss.get_board_settings.return_value = self._make_board_settings_mock()
+            mock_svc.return_value = ss
+
+            resp = client.get("/settings/board")
+
+        assert isinstance(resp.json()["boards"], list)
+
+    def test_validates_against_schema(self, client):
+        with patch("src.api_server.get_settings_service") as mock_svc:
+            ss = Mock()
+            ss.get_board_settings.return_value = self._make_board_settings_mock()
+            mock_svc.return_value = ss
+
+            resp = client.get("/settings/board")
+
+        parsed = BoardSettingsResponse(**resp.json())
+        assert isinstance(parsed.boards, list)
+
+    def test_response_has_board_type_field(self, client):
+        with patch("src.api_server.get_settings_service") as mock_svc:
+            ss = Mock()
+            ss.get_board_settings.return_value = self._make_board_settings_mock()
+            mock_svc.return_value = ss
+
+            resp = client.get("/settings/board")
+
+        assert "board_type" in resp.json()
+
+
+# ---------------------------------------------------------------------------
+# GET /settings/active-page
+# ---------------------------------------------------------------------------
+
+
+class TestActivePageSettingsContract:
+    def test_returns_200(self, client):
+        with patch("src.api_server.get_settings_service") as mock_svc:
+            ss = Mock()
+            ss.get_active_page_id.return_value = None
+            mock_svc.return_value = ss
+
+            resp = client.get("/settings/active-page")
+
+        assert resp.status_code == 200
+
+    def test_response_has_page_id_field(self, client):
+        with patch("src.api_server.get_settings_service") as mock_svc:
+            ss = Mock()
+            ss.get_active_page_id.return_value = None
+            mock_svc.return_value = ss
+
+            resp = client.get("/settings/active-page")
+
+        data = resp.json()
+        assert "page_id" in data
+
+    def test_page_id_can_be_null(self, client):
+        with patch("src.api_server.get_settings_service") as mock_svc:
+            ss = Mock()
+            ss.get_active_page_id.return_value = None
+            mock_svc.return_value = ss
+
+            resp = client.get("/settings/active-page")
+
+        assert resp.json()["page_id"] is None
+
+    def test_page_id_can_be_string(self, client):
+        with patch("src.api_server.get_settings_service") as mock_svc:
+            ss = Mock()
+            ss.get_active_page_id.return_value = "some-page-id"
+            mock_svc.return_value = ss
+
+            resp = client.get("/settings/active-page")
+
+        assert resp.json()["page_id"] == "some-page-id"


### PR DESCRIPTION
## Summary

Adds `tests/contract/` — API contract tests validating the Python backend returns exactly what the Next.js frontend expects.

## Files

- `tests/contract/schemas.py` — Pydantic schemas mirroring TypeScript types in the frontend
- `tests/contract/conftest.py` — shared TestClient and service mocks
- `tests/contract/test_pages_contract.py` — 16 tests for `/pages` endpoints
- `tests/contract/test_schedules_contract.py` — 23 tests for `/schedules` endpoints
- `tests/contract/test_settings_contract.py` — 24 tests for `/health`, `/version`, `/settings/*`

**63 tests, all passing.** No external dependencies needed — uses FastAPI TestClient + mocked service layer.

## What the tests catch

- Response fields renamed or removed (e.g. `version` → `package_version`)
- Fields changing type (e.g. `template: str` → `template: List[str]`)
- Overnight schedule contract (`start_time > end_time` must be accepted)
- Nullable vs required fields
- HH:MM format for schedule times
- `board_id=*` wildcard behavior

Closes #502