### PR TITLE
feat: add Calendar Subscription plugin to registry (closes #545)

### DIFF
--- a/plugin-registry.json
+++ b/plugin-registry.json
@@ -26,6 +26,16 @@
       "category": "transit"
     },
     {
+      "id": "calendar_sub",
+      "name": "Calendar Subscription",
+      "description": "Subscribe to any public iCalendar (.ics) URL and display upcoming events with automatic board alerts before each event starts",
+      "repository": "https://github.com/Fiestaboard/fiestaboard-plugin--calendar-sub",
+      "author": "FiestaBoard Team",
+      "fiestaboard_version": ">=2.10.0",
+      "icon": "calendar",
+      "category": "utility"
+    },
+    {
       "id": "dad_jokes",
       "name": "Dad Jokes",
       "description": "Display random dad jokes from the icanhazdadjoke API",


### PR DESCRIPTION
## Summary

- Adds **Calendar Subscription** (`calendar_sub`) to `plugin-registry.json` — users can now install it from the Integrations page like any other registry plugin
- The plugin lives in its own standalone repo: [Fiestaboard/fiestaboard-plugin--calendar-sub](https://github.com/Fiestaboard/fiestaboard-plugin--calendar-sub)
- Adds `icalendar` and `recurring-ical-events` to `requirements.txt` (required when the plugin is installed)
- Adds plugin listing to main `README.md` Available Plugins table

## What the plugin does

Subscribes to any public `.ics` calendar URL and:
- Exposes upcoming events as template variables (`event_name`, `event_start`, `event_location`, `events[]` array, etc.)
- Fires board **triggers** automatically a configurable number of minutes before each event starts (uses FiestaBoard's `supports_triggers` system)
- Supports `https://` and `webcal://` URL formats
- Fully expands recurring events (RRULE/EXDATE)
- Configurable: `minutes_before`, `display_duration_minutes`, `timezone`, `max_events`, `refresh_seconds`

## Plugin repo

**[github.com/Fiestaboard/fiestaboard-plugin--calendar-sub](https://github.com/Fiestaboard/fiestaboard-plugin--calendar-sub)**
- 48 tests, 99% coverage
- Full docs: README.md + docs/SETUP.md with instructions for Google Calendar, Outlook, Apple Calendar, and school/org calendars

## Test plan

- [ ] Plugin appears in registry and can be installed from the Integrations page
- [ ] Calendar URL field accepts `https://` and `webcal://` formats
- [ ] Events from a public Google Calendar / Outlook / school .ics URL display correctly
- [ ] Board trigger fires `minutes_before` minutes before an event
- [ ] `display_duration_minutes=0` keeps the message up indefinitely
- [ ] Container rebuild picks up new `icalendar` + `recurring-ical-events` packages

Closes #545