### PR TITLE
feat: harden Docker data persistence so configs are never lost

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -112,6 +112,11 @@ RUN mkdir -p /app/conf.d
 RUN useradd -m -u 1000 appuser && \
     chown -R appuser:appuser /app /var/log/nginx /var/lib/nginx /run/nginx /etc/nginx
 
+# Declare persistent data volume so Docker always creates a volume for /app/data,
+# even when the container is run without an explicit -v mount (e.g. plain docker run).
+# Compose bind-mounts (./data:/app/data) override this automatically.
+VOLUME /app/data
+
 # Expose single port
 EXPOSE 3000
 

--- a/docker-compose.hub.yml
+++ b/docker-compose.hub.yml
@@ -14,6 +14,8 @@ services:
     volumes:
       # Persist data (including config) to local filesystem
       - ./data:/app/data
+      # Persist marketplace-installed (external) plugins across rebuilds
+      - ./external_plugins:/app/external_plugins
     logging:
       driver: "json-file"
       options:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -16,6 +16,8 @@ services:
     volumes:
       # Persist data (including config) to local filesystem
       - ./data:/app/data
+      # Persist marketplace-installed (external) plugins across rebuilds
+      - ./external_plugins:/app/external_plugins
     logging:
       driver: "json-file"
       options:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ services:
     volumes:
       # Persist data (including config) to local filesystem
       - ./data:/app/data
+      # Persist marketplace-installed (external) plugins across rebuilds
+      - ./external_plugins:/app/external_plugins
       # Docker socket for container management (restart/upgrade from UI)
       # Note: Required for self-update and restart features. Grants container
       # access to the host Docker daemon. Remove this line if you do not need

--- a/docs-site/docs/deployment/production.md
+++ b/docs-site/docs/deployment/production.md
@@ -35,15 +35,43 @@ SILENCE_SCHEDULE_END_TIME=07:00
 
 ### Data Backup
 
-Back up the `data/` directory regularly to preserve your pages, schedules, and settings:
+FiestaBoard stores all persistent state in two directories on the host:
+
+| Directory | Contents |
+|-----------|----------|
+| `data/` | Config, pages, schedules, carousels, settings, logs, and migration backups |
+| `external_plugins/` | Marketplace plugins installed via the Integrations page |
+
+Both directories are automatically bind-mounted by Docker Compose. Back up both to fully preserve your setup:
 
 ```bash
-# Simple backup
-cp -r data/ data-backup-$(date +%Y%m%d)/
+# One-shot backup (run from the directory containing your docker-compose file)
+tar -czf fiestaboard-backup-$(date +%Y%m%d).tar.gz data/ external_plugins/
 
-# Or use a cron job
-0 2 * * * tar -czf /backups/fiestaboard-$(date +\%Y\%m\%d).tar.gz /path/to/FiestaBoard/data/
+# Automated daily backup via cron (runs at 2 AM)
+0 2 * * * tar -czf /backups/fiestaboard-$(date +\%Y\%m\%d).tar.gz /path/to/FiestaBoard/data/ /path/to/FiestaBoard/external_plugins/
 ```
+
+**Restore from backup:**
+
+```bash
+# Stop the container before restoring
+docker-compose down
+
+# Extract the backup (overwrites existing data/ and external_plugins/)
+tar -xzf fiestaboard-backup-20240101.tar.gz
+
+# Start again — all pages, settings, and plugins are restored
+docker-compose up -d
+```
+
+:::tip What each file contains
+- `data/config.json` — Board API key and connection settings
+- `data/settings.json` — Display preferences, active page, schedule
+- `data/pages.json` — All board pages
+- `data/schedules.json` / `data/carousels.json` — Automation rules
+- `data/*.backup` — Automatic pre-migration snapshots (safe to delete after confirming an upgrade works)
+:::
 
 ## Updating
 

--- a/docs-site/docs/setup/docker-setup.md
+++ b/docs-site/docs/setup/docker-setup.md
@@ -104,22 +104,66 @@ See the [API Endpoints](/docs/reference/api-endpoints) reference for the complet
 
 ## Data Persistence
 
-FiestaBoard stores its data in a `data/` directory that is mounted as a Docker volume:
+FiestaBoard stores all runtime state on disk so that configuration, pages, and schedules survive container restarts and image upgrades.
+
+### What is persisted
+
+Two host directories are bind-mounted into the container:
+
+| Host path | Container path | Contents |
+|-----------|---------------|----------|
+| `./data/` | `/app/data/` | All application state (see table below) |
+| `./external_plugins/` | `/app/external_plugins/` | Marketplace plugins installed via the Integrations page |
+
+Files inside `data/`:
+
+| File | Description |
+|------|-------------|
+| `config.json` | Board connection settings, API keys, plugin configuration |
+| `settings.json` | Display preferences, transitions, schedule, MQTT, active page |
+| `pages.json` | All board pages you have created |
+| `schedules.json` | Time-based scheduling rules |
+| `carousels.json` | Carousel display settings |
+| `logs/` | Application, API, and nginx log files |
+| `*.backup` | Pre-migration backups created automatically before schema upgrades |
+
+This is configured in every Docker Compose file:
 
 ```yaml
 volumes:
   - ./data:/app/data
+  - ./external_plugins:/app/external_plugins
 ```
 
-This includes:
-- Page configurations
-- Schedule entries
-- Plugin settings
-- Service configuration
+### Running with plain `docker run`
 
-:::tip
-Back up the `data/` directory to preserve your configuration when updating FiestaBoard.
+If you start the container directly without Docker Compose, pass the volume flags explicitly — otherwise data is lost when the container is removed:
+
+```bash
+docker run -d \
+  --name fiestaboard \
+  -p 4420:3000 \
+  -v "$(pwd)/data:/app/data" \
+  -v "$(pwd)/external_plugins:/app/external_plugins" \
+  fiestaboard/fiestaboard:latest
+```
+
+:::warning Data loss without volume mounts
+If you run `docker run` without `-v` flags, Docker creates an anonymous volume for `/app/data` (from the `VOLUME` directive in the image). The data still persists between restarts of the **same container**, but is permanently lost when you run `docker rm`. Always use explicit bind-mounts or named volumes for anything you want to keep.
 :::
+
+### Backup and restore
+
+```bash
+# Backup (from the directory containing your docker-compose file)
+tar -czf fiestaboard-backup-$(date +%Y%m%d).tar.gz data/ external_plugins/
+
+# Restore
+tar -xzf fiestaboard-backup-20240101.tar.gz
+docker-compose up -d
+```
+
+All configuration, pages, schedules, and installed plugins are captured in a single archive.
 
 ## Updating FiestaBoard
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,14 @@
 #!/bin/sh
 set -e
 
-# Ensure log directory exists
+# Ensure data and log directories exist and are owned by the app user.
+# This handles bind-mounted host directories that may be owned by root (common on Linux).
 mkdir -p /app/data/logs
-chown appuser:appuser /app/data/logs 2>/dev/null || true
+chown -R appuser:appuser /app/data 2>/dev/null || true
+
+# Ensure external_plugins directory exists and is writable for marketplace installs.
+mkdir -p /app/external_plugins
+chown appuser:appuser /app/external_plugins 2>/dev/null || true
 
 # ---------------------------------------------------------------------------
 # If the container is already running as a non-root user (e.g. Docker


### PR DESCRIPTION
## Summary

- **`VOLUME /app/data` in Dockerfile** — ensures plain `docker run` without `-v` gets an auto-created anonymous volume instead of writing to the ephemeral container layer (data persists across restarts of the same container, with a clear callout that explicit mounts are needed for long-term safety)
- **`./external_plugins` mount in all production compose files** (`docker-compose.yml`, `docker-compose.prod.yml`, `docker-compose.hub.yml`) — marketplace-installed plugins were previously lost on every container rebuild
- **Expanded `entrypoint.sh` ownership fixup** — now covers all of `/app/data` (not just `/app/data/logs`) and `/app/external_plugins`, preventing write-permission failures on Linux where Docker creates bind-mount directories as root

## Documentation

- `docs-site/docs/setup/docker-setup.md` — new "What is persisted" table covering every file, `docker run` example with correct `-v` flags, data-loss warning callout, and backup/restore commands
- `docs-site/docs/deployment/production.md` — expanded Data Backup section with restore instructions, `external_plugins` coverage, and per-file tip callout

## Test plan

- [ ] `docker-compose up -d --build` — verify `./data` and `./external_plugins` directories are created on the host
- [ ] Stop and remove the container (`docker-compose down`), restart — verify config/pages are still present in `data/`
- [ ] Install a marketplace plugin, rebuild the container — verify the plugin is still available
- [ ] On Linux: create `data/` as root before starting, verify the app starts without permission errors
- [ ] Run `docker run -d -p 4420:3000 fiestaboard/fiestaboard:latest` (no `-v`) and confirm `docker inspect` shows an anonymous volume for `/app/data`

Made with [Cursor](https://cursor.com)