### PR TITLE
feat: plugin demo page support (#549)

### DIFF
--- a/plugins/_template/manifest.json
+++ b/plugins/_template/manifest.json
@@ -89,6 +89,27 @@
     }
   },
 
+  "demo": {
+    "name": "My Plugin Demo",
+    "device_type": "flagship",
+    "template": [
+      "",
+      "{{my_plugin.status}}",
+      "Value: {{my_plugin.value}}",
+      "{{my_plugin.formatted}}",
+      "",
+      ""
+    ],
+    "line_metadata": [
+      {"alignment": "center", "wrap": false},
+      {"alignment": "center", "wrap": false},
+      {"alignment": "center", "wrap": false},
+      {"alignment": "center", "wrap": false},
+      {"alignment": "center", "wrap": false},
+      {"alignment": "center", "wrap": false}
+    ]
+  },
+
   "screenshots": [
     {
       "src": "docs/board-display.png",

--- a/plugins/countdown/manifest.json
+++ b/plugins/countdown/manifest.json
@@ -1,14 +1,13 @@
 {
   "id": "countdown",
   "name": "Countdown",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Display the remaining time to an event in real time",
   "author": "FiestaBoard Team",
   "repository": "https://github.com/FiestaBoard/FiestaBoard",
   "documentation": "README.md",
   "icon": "timer",
   "category": "utility",
-
   "settings_schema": {
     "type": "object",
     "properties": {
@@ -37,9 +36,10 @@
         "ui:widget": "timezone"
       }
     },
-    "required": ["target_datetime"]
+    "required": [
+      "target_datetime"
+    ]
   },
-
   "env_vars": [
     {
       "name": "COUNTDOWN_TARGET",
@@ -58,11 +58,14 @@
       "default": "America/Los_Angeles"
     }
   ],
-
   "variables": {
     "groups": {
-      "event": { "label": "Event Info" },
-      "countdown": { "label": "Countdown Values" }
+      "event": {
+        "label": "Event Info"
+      },
+      "countdown": {
+        "label": "Countdown Values"
+      }
     },
     "simple": {
       "event_name": {
@@ -127,7 +130,44 @@
       }
     }
   },
-
+  "demo": {
+    "name": "Countdown Demo",
+    "device_type": "flagship",
+    "template": [
+      "",
+      "{{countdown.event_name}}",
+      "{{countdown.days}} days",
+      "{{countdown.hours}}h {{countdown.minutes}}m",
+      "{{countdown.formatted}}",
+      ""
+    ],
+    "line_metadata": [
+      {
+        "alignment": "center",
+        "wrap": false
+      },
+      {
+        "alignment": "center",
+        "wrap": false
+      },
+      {
+        "alignment": "center",
+        "wrap": false
+      },
+      {
+        "alignment": "center",
+        "wrap": false
+      },
+      {
+        "alignment": "center",
+        "wrap": false
+      },
+      {
+        "alignment": "center",
+        "wrap": false
+      }
+    ]
+  },
   "screenshots": [
     {
       "src": "docs/countdown-display.png",

--- a/plugins/date_time/manifest.json
+++ b/plugins/date_time/manifest.json
@@ -1,14 +1,13 @@
 {
   "id": "date_time",
   "name": "Date & Time",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Display current date and time in configurable formats",
   "author": "FiestaBoard Team",
   "repository": "https://github.com/FiestaBoard/FiestaBoard",
   "documentation": "README.md",
   "icon": "clock",
   "category": "utility",
-
   "settings_schema": {
     "type": "object",
     "properties": {
@@ -26,7 +25,6 @@
       }
     }
   },
-
   "env_vars": [
     {
       "name": "TIMEZONE",
@@ -35,12 +33,17 @@
       "default": "America/Los_Angeles"
     }
   ],
-
   "variables": {
     "groups": {
-      "time": { "label": "Time" },
-      "date": { "label": "Date" },
-      "formatting": { "label": "Formatted" }
+      "time": {
+        "label": "Time"
+      },
+      "date": {
+        "label": "Date"
+      },
+      "formatting": {
+        "label": "Formatted"
+      }
     },
     "simple": {
       "time": {
@@ -158,7 +161,44 @@
       }
     }
   },
-
+  "demo": {
+    "name": "Date & Time Demo",
+    "device_type": "flagship",
+    "template": [
+      "",
+      "{{date_time.day_of_week}}",
+      "{{date_time.month}} {{date_time.day}} {{date_time.year}}",
+      "{{date_time.time_12h}}",
+      "{{date_time.timezone_abbr}}",
+      ""
+    ],
+    "line_metadata": [
+      {
+        "alignment": "center",
+        "wrap": false
+      },
+      {
+        "alignment": "center",
+        "wrap": false
+      },
+      {
+        "alignment": "center",
+        "wrap": false
+      },
+      {
+        "alignment": "center",
+        "wrap": false
+      },
+      {
+        "alignment": "center",
+        "wrap": false
+      },
+      {
+        "alignment": "center",
+        "wrap": false
+      }
+    ]
+  },
   "screenshots": [
     {
       "src": "docs/date-time-display.png",

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -4453,6 +4453,15 @@ async def get_plugin(plugin_id: str):
     config_manager = get_config_manager()
     plugin_config = config_manager.get_plugin_config(plugin_id)
     
+    # Check for demo page
+    has_demo = manifest.demo is not None
+    demo_page_id = None
+    if has_demo:
+        page_service = get_page_service()
+        demo_page = page_service.get_demo_page(plugin_id)
+        if demo_page:
+            demo_page_id = demo_page.id
+
     return {
         "id": plugin_id,
         "name": manifest.name,
@@ -4467,7 +4476,9 @@ async def get_plugin(plugin_id: str):
         "variables": manifest.raw.get("variables", {}),
         "max_lengths": manifest.max_lengths,
         "env_vars": manifest.env_vars,
-        "documentation": manifest.documentation
+        "documentation": manifest.documentation,
+        "has_demo": has_demo,
+        "demo_page_id": demo_page_id,
     }
 
 
@@ -4723,6 +4734,84 @@ async def get_plugin_variables(plugin_id: str):
         "variables": manifest.raw.get("variables", {}),
         "max_lengths": manifest.max_lengths,
         "color_rules_schema": manifest.raw.get("color_rules_schema", {})
+    }
+
+
+# ── Plugin Demo Pages ────────────────────────────────────────────────────────
+
+
+@app.get("/plugins/{plugin_id}/demo-page")
+async def get_plugin_demo_page(plugin_id: str):
+    """
+    Check whether a demo page exists for this plugin.
+
+    Returns ``exists: true`` and the page id when one is found.
+    """
+    if not PLUGIN_SYSTEM_AVAILABLE:
+        raise HTTPException(status_code=503, detail="Plugin system is not available.")
+
+    registry = get_plugin_registry()
+    manifest = registry.get_manifest(plugin_id)
+    if not manifest:
+        raise HTTPException(status_code=404, detail=f"Plugin not found: {plugin_id}")
+
+    if manifest.demo is None:
+        return {"exists": False, "page_id": None, "has_demo_template": False}
+
+    page_service = get_page_service()
+    demo_page = page_service.get_demo_page(plugin_id)
+    return {
+        "exists": demo_page is not None,
+        "page_id": demo_page.id if demo_page else None,
+        "has_demo_template": True,
+    }
+
+
+@app.post("/plugins/{plugin_id}/demo-page")
+async def create_plugin_demo_page(plugin_id: str):
+    """
+    Create (or recreate) the demo page for a plugin.
+
+    The demo page is a singleton per plugin -- calling this endpoint when a
+    demo page already exists will delete the old one and create a fresh copy.
+    """
+    if not PLUGIN_SYSTEM_AVAILABLE:
+        raise HTTPException(status_code=503, detail="Plugin system is not available.")
+
+    registry = get_plugin_registry()
+    manifest = registry.get_manifest(plugin_id)
+    if not manifest:
+        raise HTTPException(status_code=404, detail=f"Plugin not found: {plugin_id}")
+
+    if manifest.demo is None:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Plugin '{plugin_id}' does not include a demo page template.",
+        )
+
+    # Check that required settings are configured
+    settings_schema = manifest.settings_schema
+    required_fields = settings_schema.get("required", [])
+    if required_fields:
+        config_manager = get_config_manager()
+        plugin_config = config_manager.get_plugin_config(plugin_id) or {}
+        missing = [
+            f for f in required_fields
+            if f != "enabled" and not plugin_config.get(f)
+        ]
+        if missing:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Required settings not configured: {', '.join(missing)}. "
+                       f"Configure them first before creating a demo page.",
+            )
+
+    page_service = get_page_service()
+    page, recreated = page_service.create_demo_page(plugin_id, manifest.demo)
+
+    return {
+        "status": "recreated" if recreated else "created",
+        "page": page.model_dump(),
     }
 
 

--- a/src/pages/models.py
+++ b/src/pages/models.py
@@ -80,6 +80,9 @@ class Page(BaseModel):
     transition_interval_ms: Optional[int] = Field(default=None, ge=0, le=5000)
     transition_step_size: Optional[int] = Field(default=None, ge=1)
     
+    # Plugin demo page tracking (singleton per plugin)
+    demo_plugin_id: Optional[str] = None
+
     # Metadata
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: Optional[datetime] = None
@@ -143,6 +146,8 @@ class PageCreate(BaseModel):
     transition_strategy: Optional[str] = None
     transition_interval_ms: Optional[int] = Field(default=None, ge=0, le=5000)
     transition_step_size: Optional[int] = Field(default=None, ge=1)
+    # Plugin demo page tracking
+    demo_plugin_id: Optional[str] = None
 
 
 class PageUpdate(BaseModel):

--- a/src/pages/service.py
+++ b/src/pages/service.py
@@ -9,10 +9,11 @@ from typing import List, Optional, Tuple, Dict
 from datetime import datetime, timezone
 from dataclasses import dataclass
 
-from .models import Page, PageCreate, PageUpdate, RowConfig
+from .models import Page, PageCreate, PageUpdate, LineMetadata, RowConfig
 from .storage import PageStorage
 from ..devices import get_dimensions
 from ..displays.service import get_display_service, DisplayResult
+from ..plugins.manifest import DemoPageSchema
 from ..templates.engine import get_template_engine
 from ..settings.service import get_settings_service
 
@@ -135,6 +136,7 @@ class PageService:
             template=data.template,
             line_metadata=data.line_metadata,
             duration_seconds=data.duration_seconds,
+            demo_plugin_id=data.demo_plugin_id,
             created_at=datetime.now(timezone.utc)
         )
         
@@ -241,6 +243,61 @@ class PageService:
         )
         return self.storage.create(page)
     
+    # Demo page operations
+
+    def get_demo_page(self, plugin_id: str) -> Optional[Page]:
+        """Find the existing demo page for a plugin.
+
+        Returns the page tagged with ``demo_plugin_id == plugin_id``,
+        or None if no demo page exists for this plugin.
+        """
+        for page in self.storage.list_all():
+            if page.demo_plugin_id == plugin_id:
+                return page
+        return None
+
+    def create_demo_page(self, plugin_id: str, demo: DemoPageSchema) -> Tuple[Page, bool]:
+        """Create (or recreate) the demo page for a plugin.
+
+        If a demo page already exists for *plugin_id* it is deleted first,
+        making the demo page a singleton per plugin.
+
+        Returns:
+            Tuple of (created_page, was_recreated)
+        """
+        recreated = False
+        existing = self.get_demo_page(plugin_id)
+        if existing:
+            self.storage.delete(existing.id)
+            self._invalidate_cache(existing.id)
+            recreated = True
+            logger.info(f"Deleted existing demo page {existing.id} for plugin {plugin_id}")
+
+        line_metadata = None
+        if demo.line_metadata:
+            line_metadata = [
+                LineMetadata(
+                    alignment=m.get("alignment", "left"),
+                    wrap=m.get("wrap", False),
+                )
+                for m in demo.line_metadata
+            ]
+
+        page = Page(
+            name=demo.name,
+            type="template",
+            device_type=demo.device_type,
+            template=demo.template,
+            line_metadata=line_metadata,
+            duration_seconds=demo.duration_seconds,
+            demo_plugin_id=plugin_id,
+            created_at=datetime.now(timezone.utc),
+        )
+
+        created = self.storage.create(page)
+        logger.info(f"Created demo page {created.id} for plugin {plugin_id}")
+        return created, recreated
+
     # Rendering
     
     def render_page(self, page: Page, context: Optional[Dict] = None) -> DisplayResult:

--- a/src/pages/storage.py
+++ b/src/pages/storage.py
@@ -16,7 +16,7 @@ from ..text_utils import extract_alignment_from_line as _extract_alignment_from_
 
 logger = logging.getLogger(__name__)
 
-CURRENT_SCHEMA_VERSION = 1
+CURRENT_SCHEMA_VERSION = 2
 
 
 def _migrate_v0_to_v1(pages_data: List[dict]) -> int:
@@ -50,10 +50,24 @@ def _migrate_v0_to_v1(pages_data: List[dict]) -> int:
     return migrated_count
 
 
+def _migrate_v1_to_v2(pages_data: List[dict]) -> int:
+    """Migration 1 -> 2: add demo_plugin_id field to all pages.
+
+    Ensures every page has the ``demo_plugin_id`` key (defaults to ``None``).
+    """
+    migrated = 0
+    for page_data in pages_data:
+        if "demo_plugin_id" not in page_data:
+            page_data["demo_plugin_id"] = None
+            migrated += 1
+    return migrated
+
+
 # Ordered list of (target_version, migration_function).
 # Each function receives the raw pages list and returns the number of pages affected.
 MIGRATIONS: List[Tuple[int, Callable[[List[dict]], int]]] = [
     (1, _migrate_v0_to_v1),
+    (2, _migrate_v1_to_v2),
 ]
 
 

--- a/src/plugins/__init__.py
+++ b/src/plugins/__init__.py
@@ -15,7 +15,7 @@ Plugins can be loaded from three sources:
 from .base import PluginBase, PluginResult, TriggerResult
 from .registry import PluginRegistry, get_plugin_registry
 from .loader import PluginLoader
-from .manifest import PluginManifest, validate_manifest
+from .manifest import PluginManifest, DemoPageSchema, validate_manifest
 from .sources import (
     PluginSource,
     RegistryEntry,
@@ -32,6 +32,7 @@ __all__ = [
     "get_plugin_registry",
     "PluginLoader",
     "PluginManifest",
+    "DemoPageSchema",
     "validate_manifest",
     "PluginSource",
     "RegistryEntry",

--- a/src/plugins/manifest.py
+++ b/src/plugins/manifest.py
@@ -182,6 +182,45 @@ MANIFEST_SCHEMA = {
                 }
             },
             "description": "Screenshots for plugin galleries, docs, and the registry"
+        },
+        "demo": {
+            "type": "object",
+            "required": ["name", "template"],
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Demo page name shown in the pages list"
+                },
+                "device_type": {
+                    "type": "string",
+                    "enum": ["flagship", "note"],
+                    "default": "flagship",
+                    "description": "Target device type for the demo page"
+                },
+                "template": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Template lines with {{plugin_id.var}} placeholders"
+                },
+                "line_metadata": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "alignment": {"type": "string", "enum": ["left", "center", "right"]},
+                            "wrap": {"type": "boolean"}
+                        }
+                    },
+                    "description": "Per-line formatting (alignment, wrap)"
+                },
+                "duration_seconds": {
+                    "type": "integer",
+                    "default": 300,
+                    "minimum": 10,
+                    "description": "Rotation duration in seconds"
+                }
+            },
+            "description": "Demo page template that showcases the plugin's features"
         }
     }
 }
@@ -209,6 +248,16 @@ class Screenshot:
     alt: str
     caption: str = ""
     primary: bool = False
+
+
+@dataclass
+class DemoPageSchema:
+    """Bundled demo page template that showcases a plugin's features."""
+    name: str
+    template: List[str]
+    device_type: str = "flagship"
+    line_metadata: Optional[List[Dict[str, Any]]] = None
+    duration_seconds: int = 300
 
 
 @dataclass
@@ -296,6 +345,7 @@ class PluginManifest:
     fiestaboard_version: str = ""
     supports_triggers: bool = False
     screenshots: List[Screenshot] = field(default_factory=list)
+    demo: Optional[DemoPageSchema] = None
     raw: Dict[str, Any] = field(default_factory=dict)
     
     @classmethod
@@ -389,6 +439,18 @@ class PluginManifest:
                     primary=bool(entry.get("primary", False)),
                 ))
 
+        # --- parse demo page schema ---
+        demo: Optional[DemoPageSchema] = None
+        demo_raw = data.get("demo")
+        if isinstance(demo_raw, dict) and "name" in demo_raw and "template" in demo_raw:
+            demo = DemoPageSchema(
+                name=demo_raw["name"],
+                template=demo_raw["template"],
+                device_type=demo_raw.get("device_type", "flagship"),
+                line_metadata=demo_raw.get("line_metadata"),
+                duration_seconds=demo_raw.get("duration_seconds", 300),
+            )
+
         return cls(
             id=data["id"],
             name=data["name"],
@@ -407,6 +469,7 @@ class PluginManifest:
             fiestaboard_version=data.get("fiestaboard_version", ""),
             supports_triggers=bool(data.get("supports_triggers", False)),
             screenshots=screenshots,
+            demo=demo,
             raw=data,
         )
     
@@ -551,7 +614,23 @@ def validate_manifest(data: Dict[str, Any]) -> Tuple[bool, List[str]]:
         for key, value in max_lengths.items():
             if not isinstance(value, int) or value < 1:
                 errors.append(f"max_lengths.{key} must be a positive integer")
-    
+
+    # Validate demo section if present
+    demo = data.get("demo")
+    if demo is not None:
+        if not isinstance(demo, dict):
+            errors.append("demo must be an object")
+        else:
+            if "name" not in demo:
+                errors.append("demo missing required field: name")
+            if "template" not in demo:
+                errors.append("demo missing required field: template")
+            elif not isinstance(demo["template"], list):
+                errors.append("demo.template must be an array of strings")
+            device_type = demo.get("device_type", "flagship")
+            if device_type not in ("flagship", "note"):
+                errors.append(f"demo.device_type must be 'flagship' or 'note', got '{device_type}'")
+
     return len(errors) == 0, errors
 
 

--- a/tests/test_demo_pages.py
+++ b/tests/test_demo_pages.py
@@ -1,0 +1,330 @@
+"""Tests for the plugin demo page feature.
+
+Covers:
+- DemoPageSchema parsing from manifest
+- Page model demo_plugin_id field
+- Schema migration v1 -> v2
+- PageService.get_demo_page() and create_demo_page()
+- Manifest validation of the demo section
+"""
+
+import json
+import pytest
+import tempfile
+import os
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+from src.plugins.manifest import (
+    DemoPageSchema,
+    PluginManifest,
+    validate_manifest,
+)
+from src.pages.models import Page, PageCreate, LineMetadata
+from src.pages.storage import PageStorage, _migrate_v1_to_v2, CURRENT_SCHEMA_VERSION
+from src.pages.service import PageService
+
+
+# ---------------------------------------------------------------------------
+# DemoPageSchema + manifest parsing
+# ---------------------------------------------------------------------------
+
+class TestDemoPageSchema:
+
+    def test_parse_demo_from_manifest(self):
+        """Manifest with a demo section produces a DemoPageSchema."""
+        data = {
+            "id": "test_plugin",
+            "name": "Test",
+            "version": "1.0.0",
+            "demo": {
+                "name": "Test Demo",
+                "template": ["Line 1", "Line 2", "", "", "", ""],
+                "device_type": "flagship",
+                "line_metadata": [
+                    {"alignment": "center", "wrap": False},
+                    {"alignment": "left", "wrap": False},
+                    {"alignment": "left", "wrap": False},
+                    {"alignment": "left", "wrap": False},
+                    {"alignment": "left", "wrap": False},
+                    {"alignment": "left", "wrap": False},
+                ],
+                "duration_seconds": 600,
+            },
+        }
+        manifest = PluginManifest.from_dict(data)
+        assert manifest.demo is not None
+        assert manifest.demo.name == "Test Demo"
+        assert manifest.demo.template == ["Line 1", "Line 2", "", "", "", ""]
+        assert manifest.demo.device_type == "flagship"
+        assert manifest.demo.duration_seconds == 600
+        assert len(manifest.demo.line_metadata) == 6
+
+    def test_manifest_without_demo(self):
+        """Manifest without a demo section sets demo to None."""
+        data = {"id": "test_plugin", "name": "Test", "version": "1.0.0"}
+        manifest = PluginManifest.from_dict(data)
+        assert manifest.demo is None
+
+    def test_demo_defaults(self):
+        """Demo section with minimal fields uses correct defaults."""
+        data = {
+            "id": "test_plugin",
+            "name": "Test",
+            "version": "1.0.0",
+            "demo": {
+                "name": "Minimal Demo",
+                "template": ["Hello"],
+            },
+        }
+        manifest = PluginManifest.from_dict(data)
+        assert manifest.demo.device_type == "flagship"
+        assert manifest.demo.duration_seconds == 300
+        assert manifest.demo.line_metadata is None
+
+    def test_demo_note_device_type(self):
+        """Demo can target the 'note' device type."""
+        data = {
+            "id": "test_plugin",
+            "name": "Test",
+            "version": "1.0.0",
+            "demo": {
+                "name": "Note Demo",
+                "template": ["L1", "L2", "L3"],
+                "device_type": "note",
+            },
+        }
+        manifest = PluginManifest.from_dict(data)
+        assert manifest.demo.device_type == "note"
+
+
+# ---------------------------------------------------------------------------
+# Manifest validation
+# ---------------------------------------------------------------------------
+
+class TestDemoValidation:
+
+    def test_valid_demo_section(self):
+        """A well-formed demo section passes validation."""
+        data = {
+            "id": "test_plugin",
+            "name": "Test",
+            "version": "1.0.0",
+            "demo": {
+                "name": "Demo",
+                "template": ["{{test_plugin.value}}"],
+            },
+        }
+        is_valid, errors = validate_manifest(data)
+        assert is_valid, errors
+
+    def test_demo_missing_name(self):
+        """Demo section missing 'name' fails validation."""
+        data = {
+            "id": "test_plugin",
+            "name": "Test",
+            "version": "1.0.0",
+            "demo": {"template": ["line"]},
+        }
+        is_valid, errors = validate_manifest(data)
+        assert not is_valid
+        assert any("demo" in e and "name" in e for e in errors)
+
+    def test_demo_missing_template(self):
+        """Demo section missing 'template' fails validation."""
+        data = {
+            "id": "test_plugin",
+            "name": "Test",
+            "version": "1.0.0",
+            "demo": {"name": "Demo"},
+        }
+        is_valid, errors = validate_manifest(data)
+        assert not is_valid
+        assert any("demo" in e and "template" in e for e in errors)
+
+    def test_demo_invalid_device_type(self):
+        """Demo with bad device_type fails validation."""
+        data = {
+            "id": "test_plugin",
+            "name": "Test",
+            "version": "1.0.0",
+            "demo": {
+                "name": "Demo",
+                "template": ["line"],
+                "device_type": "jumbo",
+            },
+        }
+        is_valid, errors = validate_manifest(data)
+        assert not is_valid
+        assert any("device_type" in e for e in errors)
+
+    def test_demo_not_dict_fails(self):
+        """Non-object demo value fails validation."""
+        data = {
+            "id": "test_plugin",
+            "name": "Test",
+            "version": "1.0.0",
+            "demo": "not an object",
+        }
+        is_valid, errors = validate_manifest(data)
+        assert not is_valid
+        assert any("demo" in e for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# Page model – demo_plugin_id
+# ---------------------------------------------------------------------------
+
+class TestPageDemoField:
+
+    def test_page_has_demo_plugin_id(self):
+        page = Page(
+            name="Test",
+            type="template",
+            template=["L1"],
+            demo_plugin_id="weather",
+        )
+        assert page.demo_plugin_id == "weather"
+        assert page.is_valid()
+
+    def test_page_demo_plugin_id_defaults_none(self):
+        page = Page(name="Test", type="template", template=["L1"])
+        assert page.demo_plugin_id is None
+
+    def test_page_create_includes_demo_plugin_id(self):
+        pc = PageCreate(
+            name="Demo",
+            type="template",
+            template=["L1"],
+            demo_plugin_id="weather",
+        )
+        assert pc.demo_plugin_id == "weather"
+
+    def test_page_serialization_includes_demo_plugin_id(self):
+        page = Page(
+            name="Test",
+            type="template",
+            template=["L1"],
+            demo_plugin_id="stocks",
+        )
+        data = page.model_dump()
+        assert data["demo_plugin_id"] == "stocks"
+
+
+# ---------------------------------------------------------------------------
+# Schema migration v1 -> v2
+# ---------------------------------------------------------------------------
+
+class TestSchemaMigrationV1ToV2:
+
+    def test_adds_demo_plugin_id(self):
+        pages = [
+            {"id": "1", "name": "A", "type": "template", "template": ["X"]},
+            {"id": "2", "name": "B", "type": "single", "display_type": "weather"},
+        ]
+        count = _migrate_v1_to_v2(pages)
+        assert count == 2
+        assert pages[0]["demo_plugin_id"] is None
+        assert pages[1]["demo_plugin_id"] is None
+
+    def test_idempotent(self):
+        pages = [
+            {"id": "1", "name": "A", "type": "template", "template": ["X"], "demo_plugin_id": None},
+        ]
+        count = _migrate_v1_to_v2(pages)
+        assert count == 0
+
+    def test_preserves_existing_value(self):
+        pages = [
+            {"id": "1", "name": "A", "type": "template", "template": ["X"], "demo_plugin_id": "weather"},
+        ]
+        count = _migrate_v1_to_v2(pages)
+        assert count == 0
+        assert pages[0]["demo_plugin_id"] == "weather"
+
+    def test_current_schema_version(self):
+        assert CURRENT_SCHEMA_VERSION == 2
+
+
+# ---------------------------------------------------------------------------
+# PageService – demo page operations
+# ---------------------------------------------------------------------------
+
+class TestPageServiceDemo:
+
+    @pytest.fixture
+    def temp_storage_file(self):
+        fd, path = tempfile.mkstemp(suffix=".json")
+        os.close(fd)
+        yield path
+        if os.path.exists(path):
+            os.unlink(path)
+
+    @pytest.fixture
+    def service(self, temp_storage_file):
+        storage = PageStorage(storage_file=temp_storage_file)
+        return PageService(storage=storage)
+
+    def _demo_schema(self, name="Test Demo"):
+        return DemoPageSchema(
+            name=name,
+            template=["Line 1", "{{test.var}}", "", "", "", ""],
+            device_type="flagship",
+            line_metadata=[
+                {"alignment": "center", "wrap": False},
+                {"alignment": "left", "wrap": False},
+                {"alignment": "left", "wrap": False},
+                {"alignment": "left", "wrap": False},
+                {"alignment": "left", "wrap": False},
+                {"alignment": "left", "wrap": False},
+            ],
+            duration_seconds=300,
+        )
+
+    def test_get_demo_page_none_when_empty(self, service):
+        assert service.get_demo_page("test_plugin") is None
+
+    def test_create_demo_page(self, service):
+        page, recreated = service.create_demo_page("test_plugin", self._demo_schema())
+        assert not recreated
+        assert page.demo_plugin_id == "test_plugin"
+        assert page.name == "Test Demo"
+        assert page.type == "template"
+        assert page.device_type == "flagship"
+        assert page.template == ["Line 1", "{{test.var}}", "", "", "", ""]
+        assert len(page.line_metadata) == 6
+        assert page.line_metadata[0].alignment == "center"
+
+    def test_get_demo_page_after_create(self, service):
+        page, _ = service.create_demo_page("test_plugin", self._demo_schema())
+        found = service.get_demo_page("test_plugin")
+        assert found is not None
+        assert found.id == page.id
+
+    def test_recreate_demo_page(self, service):
+        page1, _ = service.create_demo_page("test_plugin", self._demo_schema())
+        page2, recreated = service.create_demo_page("test_plugin", self._demo_schema("Refreshed"))
+        assert recreated
+        assert page2.id != page1.id
+        assert page2.name == "Refreshed"
+        assert service.get_demo_page("test_plugin").id == page2.id
+
+    def test_demo_page_singleton_per_plugin(self, service):
+        service.create_demo_page("plugin_a", self._demo_schema("Demo A"))
+        service.create_demo_page("plugin_b", self._demo_schema("Demo B"))
+
+        assert service.get_demo_page("plugin_a").name == "Demo A"
+        assert service.get_demo_page("plugin_b").name == "Demo B"
+        assert service.get_demo_page("plugin_c") is None
+
+    def test_demo_page_persists_to_storage(self, temp_storage_file):
+        storage1 = PageStorage(storage_file=temp_storage_file)
+        svc1 = PageService(storage=storage1)
+        page, _ = svc1.create_demo_page("test_plugin", self._demo_schema())
+
+        storage2 = PageStorage(storage_file=temp_storage_file)
+        svc2 = PageService(storage=storage2)
+        found = svc2.get_demo_page("test_plugin")
+        assert found is not None
+        assert found.id == page.id
+        assert found.demo_plugin_id == "test_plugin"

--- a/web/src/app/integrations/page.tsx
+++ b/web/src/app/integrations/page.tsx
@@ -944,6 +944,8 @@ function PluginCard({
   const [configValues, setConfigValues] = useState<Record<string, unknown>>({});
   const [isSaving, setIsSaving] = useState(false);
   const [copiedVar, setCopiedVar] = useState<string | null>(null);
+  const [isCreatingDemo, setIsCreatingDemo] = useState(false);
+  const [showDemoConfirm, setShowDemoConfirm] = useState(false);
 
   const isExternal = plugin.source?.source_type !== "builtin";
   const hasUpdate = plugin.update_available === true;
@@ -976,6 +978,26 @@ function PluginCard({
     }
   };
 
+  const queryClient = useQueryClient();
+
+  const handleCreateDemoPage = async () => {
+    setIsCreatingDemo(true);
+    try {
+      const result = await api.createPluginDemoPage(plugin.id);
+      const verb = result.status === "recreated" ? "recreated" : "created";
+      toast.success(`Demo page ${verb} for ${plugin.name}`);
+      queryClient.invalidateQueries({ queryKey: ["plugin", plugin.id] });
+      queryClient.invalidateQueries({ queryKey: ["pages"] });
+      setShowDemoConfirm(false);
+    } catch (error) {
+      toast.error(
+        `Failed to create demo page: ${error instanceof Error ? error.message : "Unknown error"}`
+      );
+    } finally {
+      setIsCreatingDemo(false);
+    }
+  };
+
   // Copy template variable
   const handleCopyVar = (varName: string) => {
     const templateVar = `{{${plugin.id}.${varName}}}`;
@@ -983,6 +1005,19 @@ function PluginCard({
     setCopiedVar(varName);
     setTimeout(() => setCopiedVar(null), 2000);
     toast.success(`Copied ${templateVar}`);
+  };
+
+  const areDemoRequirementsMet = (): boolean => {
+    if (!pluginDetails?.settings_schema) return true;
+    const schema = pluginDetails.settings_schema as {
+      required?: string[];
+      properties?: Record<string, { type?: string }>;
+    };
+    const required = schema.required ?? [];
+    const config = pluginDetails.config ?? {};
+    return required.every(
+      (field) => field === "enabled" || Boolean(config[field])
+    );
   };
 
   // Parse variables from plugin details - handles both array and object formats for variables.simple
@@ -1073,6 +1108,75 @@ function PluginCard({
             </div>
           ) : (
             <>
+              {/* Demo Page Section */}
+              {pluginDetails?.has_demo && (
+                <div className="rounded-lg border bg-muted/30 p-4 space-y-3">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <h4 className="text-sm font-medium">Demo Page</h4>
+                      <p className="text-xs text-muted-foreground mt-0.5">
+                        {pluginDetails.demo_page_id
+                          ? "A demo page already exists for this plugin."
+                          : "Create a ready-to-use page that showcases this plugin."}
+                      </p>
+                    </div>
+                    {pluginDetails.demo_page_id ? (
+                      <Dialog open={showDemoConfirm} onOpenChange={setShowDemoConfirm}>
+                        <DialogTrigger asChild>
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            disabled={!areDemoRequirementsMet() || isCreatingDemo}
+                          >
+                            <RefreshCw className="h-3.5 w-3.5 mr-1.5" />
+                            Recreate
+                          </Button>
+                        </DialogTrigger>
+                        <DialogContent>
+                          <DialogHeader>
+                            <DialogTitle>Recreate Demo Page?</DialogTitle>
+                            <DialogDescription>
+                              This will delete the existing demo page and create a
+                              fresh one with default settings. This action cannot be
+                              undone.
+                            </DialogDescription>
+                          </DialogHeader>
+                          <DialogFooter>
+                            <Button
+                              variant="outline"
+                              onClick={() => setShowDemoConfirm(false)}
+                            >
+                              Cancel
+                            </Button>
+                            <Button
+                              onClick={handleCreateDemoPage}
+                              disabled={isCreatingDemo}
+                            >
+                              {isCreatingDemo ? "Creating..." : "Recreate Demo Page"}
+                            </Button>
+                          </DialogFooter>
+                        </DialogContent>
+                      </Dialog>
+                    ) : (
+                      <Button
+                        variant="default"
+                        size="sm"
+                        onClick={handleCreateDemoPage}
+                        disabled={!areDemoRequirementsMet() || isCreatingDemo}
+                      >
+                        <Play className="h-3.5 w-3.5 mr-1.5" />
+                        {isCreatingDemo ? "Creating..." : "Create Demo Page"}
+                      </Button>
+                    )}
+                  </div>
+                  {!areDemoRequirementsMet() && (
+                    <p className="text-xs text-amber-600 dark:text-amber-400">
+                      Configure the required settings below before creating a demo page.
+                    </p>
+                  )}
+                </div>
+              )}
+
               {/* Settings Section */}
               {pluginDetails?.settings_schema && Object.keys(pluginDetails.settings_schema.properties || {}).length > 0 && (
                 <div className="space-y-4">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -726,6 +726,19 @@ export interface PluginDetailResponse {
     description: string;
   }>;
   documentation: string;
+  has_demo: boolean;
+  demo_page_id: string | null;
+}
+
+export interface PluginDemoPageResponse {
+  exists: boolean;
+  page_id: string | null;
+  has_demo_template: boolean;
+}
+
+export interface PluginDemoPageCreateResponse {
+  status: "created" | "recreated";
+  page: Page;
 }
 
 export interface PluginConfigUpdateResponse {
@@ -1254,7 +1267,15 @@ export const api = {
   
   getPluginVariables: (pluginId: string) =>
     fetchApi<PluginVariablesResponse>(`/plugins/${pluginId}/variables`),
-  
+
+  getPluginDemoPage: (pluginId: string) =>
+    fetchApi<PluginDemoPageResponse>(`/plugins/${pluginId}/demo-page`),
+
+  createPluginDemoPage: (pluginId: string) =>
+    fetchApi<PluginDemoPageCreateResponse>(`/plugins/${pluginId}/demo-page`, {
+      method: "POST",
+    }),
+
   getAllPluginVariables: () =>
     fetchApi<AllPluginVariablesResponse>("/plugins/variables/all"),
   


### PR DESCRIPTION
## Summary

Implements [#549](https://github.com/Fiestaboard/FiestaBoard/issues/549) -- a "Create Demo Page" button on each plugin's config sheet that creates a ready-to-use showcase page with one click.

- Plugins bundle a `demo` section in their `manifest.json` with a pre-built template
- Demo pages are singletons per plugin (one demo page per plugin, recreatable)
- Button is disabled until required settings (API keys, etc.) are configured
- Confirmation dialog before recreating an existing demo page

### Platform changes

| Area | Files | What |
|------|-------|------|
| Manifest schema | `src/plugins/manifest.py` | `DemoPageSchema` dataclass, `demo` in `MANIFEST_SCHEMA`, parsing + validation |
| Page model | `src/pages/models.py`, `src/pages/storage.py` | `demo_plugin_id` field, schema migration v1 -> v2 |
| Page service | `src/pages/service.py` | `get_demo_page()`, `create_demo_page()` |
| API | `src/api_server.py` | `GET/POST /plugins/{id}/demo-page`, updated `GET /plugins/{id}` |
| Web types | `web/src/lib/api.ts` | New interfaces + API methods |
| Web UI | `web/src/app/integrations/page.tsx` | Demo Page section in plugin config sheet |
| Built-in plugins | `plugins/date_time/`, `plugins/countdown/` | Demo templates + version bump to 1.1.0 |
| Template | `plugins/_template/manifest.json` | Example demo section |
| Tests | `tests/test_demo_pages.py` | 20 unit tests |

### External plugin PRs

All 25 external plugin repos have corresponding PRs on `feat/demo-page` branches adding their own demo templates.

## Test plan

- [ ] API tests pass for demo page endpoints (create, recreate, 404 for missing demo, 400 for missing required settings)
- [ ] Schema migration v1->v2 correctly adds `demo_plugin_id` to existing pages
- [ ] UI button states: hidden when no demo, disabled when required settings missing, create vs recreate
- [ ] Demo page is a singleton per plugin (recreating deletes old page)
- [ ] Built-in plugins (date_time, countdown) demo pages render correctly

Made with [Cursor](https://cursor.com)