### PR TITLE
fix(plugins): fix external plugin updates + add Update All bulk action

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -4934,7 +4934,7 @@ async def trigger_plugin_update_check():
 @app.post("/plugins/{plugin_id}/update")
 async def update_plugin(plugin_id: str):
     """
-    Pull the latest version of an external plugin from its remote and reload it.
+    Fetch the latest commits for an external plugin from its remote and reload it.
 
     Built-in plugins cannot be updated via this endpoint.
     """
@@ -4971,7 +4971,8 @@ async def update_plugin(plugin_id: str):
         )
 
     from .plugins.sources import clone_or_update_repo
-    ok, err = clone_or_update_repo(source.repository_url, local_path)
+    # repo_url is not needed for the update path (fetch uses existing origin remote)
+    ok, err = clone_or_update_repo("", local_path)
     if not ok:
         raise HTTPException(status_code=500, detail=f"Update failed: {err}")
 
@@ -4981,13 +4982,74 @@ async def update_plugin(plugin_id: str):
         detail = "; ".join(errors) if errors else "Plugin failed to reload after update."
         raise HTTPException(status_code=500, detail=detail)
 
-    # Clear the update flag for this plugin
     registry._update_status.pop(plugin_id, None)
 
     return {
         "status": "success",
         "plugin_id": plugin_id,
         "message": f"Plugin '{plugin_id}' has been updated and reloaded.",
+    }
+
+
+@app.post("/plugins/updates/apply")
+async def apply_all_plugin_updates():
+    """
+    Fetch and reload all external plugins that have a pending update.
+
+    Uses the cached update status from the last check — call
+    ``POST /plugins/updates/check`` first if you want a fresh scan before
+    applying.  Returns 200 even when some plugins fail so the caller can
+    inspect partial results.
+    """
+    if not PLUGIN_SYSTEM_AVAILABLE:
+        raise HTTPException(
+            status_code=503, detail="Plugin system is not available."
+        )
+
+    registry = get_plugin_registry()
+    pending = [
+        pid for pid, has_update in registry.get_update_status().items() if has_update
+    ]
+
+    if not pending:
+        return {"updated": [], "failed": {}, "message": "No updates available."}
+
+    from pathlib import Path as _Path
+    from .plugins.sources import clone_or_update_repo
+
+    updated: list = []
+    failed: dict = {}
+
+    for plugin_id in pending:
+        source = registry.get_plugin_source(plugin_id)
+        if source is None or not source.local_path:
+            failed[plugin_id] = "Plugin source not found."
+            continue
+
+        local_path = _Path(source.local_path)
+        if not (local_path / ".git").is_dir():
+            failed[plugin_id] = "Plugin is not a git repository."
+            continue
+
+        ok, err = clone_or_update_repo("", local_path)
+        if not ok:
+            failed[plugin_id] = f"git fetch failed: {err}"
+            continue
+
+        reloaded = registry.reload_plugin(plugin_id)
+        if reloaded is None:
+            errors = registry.get_load_errors().get(plugin_id, [])
+            failed[plugin_id] = "; ".join(errors) if errors else "Reload failed."
+            continue
+
+        registry._update_status.pop(plugin_id, None)
+        updated.append(plugin_id)
+        logger.info("Bulk update: applied update for plugin '%s'", plugin_id)
+
+    return {
+        "updated": updated,
+        "failed": failed,
+        "message": f"Updated {len(updated)} plugin(s); {len(failed)} failed.",
     }
 
 

--- a/src/plugins/sources.py
+++ b/src/plugins/sources.py
@@ -220,36 +220,52 @@ def clone_or_update_repo(
     dest_dir: Path,
     branch: str = "",
 ) -> Tuple[bool, str]:
-    """Clone a git repository, or pull updates if it already exists.
+    """Clone a git repository, or fetch/reset if it already exists.
+
+    For existing clones (the update path) the ``repo_url`` is not used —
+    git pulls from whatever remote ``origin`` is already configured.  This
+    means the URL validation is intentionally skipped for that path, which
+    also avoids a bug where the registry stores an empty ``repository_url``
+    for plugins loaded from disk.
+
+    Shallow clones (``--depth 1``) are handled correctly: we use
+    ``git fetch --depth=1 origin`` + ``git reset --hard FETCH_HEAD`` instead
+    of ``git pull --ff-only``, which fails on shallow histories.
 
     Args:
-        repo_url: HTTPS URL of the repository.
+        repo_url: HTTPS URL of the repository (required for fresh clones only).
         dest_dir: Local directory to clone into.
         branch: Optional branch/tag.  Uses the repo default when empty.
 
     Returns:
         ``(True, "")`` on success, ``(False, error_message)`` on failure.
     """
-    ok, err = _validate_git_url(repo_url)
-    if not ok:
-        return False, err
-
     env = {**os.environ, "GIT_TERMINAL_PROMPT": "0"}
 
     if dest_dir.exists() and (dest_dir / ".git").is_dir():
-        # Already cloned – pull latest
+        # Already cloned — fetch latest commits and reset to remote HEAD.
+        # Works for both full and shallow (--depth 1) clones.
         try:
-            cmd = ["git", "-C", str(dest_dir), "pull", "--ff-only"]
             subprocess.run(
-                cmd, check=True, capture_output=True, text=True,
+                ["git", "-C", str(dest_dir), "fetch", "--depth=1", "origin"],
+                check=True, capture_output=True, text=True,
                 timeout=120, env=env,
+            )
+            subprocess.run(
+                ["git", "-C", str(dest_dir), "reset", "--hard", "FETCH_HEAD"],
+                check=True, capture_output=True, text=True,
+                timeout=30, env=env,
             )
             logger.info("Updated existing clone at %s", dest_dir)
             return True, ""
         except subprocess.SubprocessError as exc:
-            return False, f"git pull failed for {repo_url}: {exc}"
+            return False, f"git fetch/reset failed at {dest_dir}: {exc}"
 
-    # Fresh clone
+    # Fresh clone — URL is required and must be validated.
+    ok, err = _validate_git_url(repo_url)
+    if not ok:
+        return False, err
+
     dest_dir.parent.mkdir(parents=True, exist_ok=True)
     try:
         cmd = ["git", "clone", "--depth", "1"]

--- a/tests/test_api_coverage_extended.py
+++ b/tests/test_api_coverage_extended.py
@@ -473,6 +473,94 @@ class TestPluginManagement:
             resp = client.post("/plugins/weather/update")
         assert resp.status_code == 400
 
+    def test_update_plugin_no_url_required(self, client):
+        """Endpoint passes empty URL to clone_or_update_repo (URL not needed for update path)."""
+        # source has no repository_url (as happens for disk-loaded external plugins)
+        mock_source = Mock(source_type="external", local_path="/fake/path", repository_url="")
+        mock_registry = Mock()
+        mock_registry.get_plugin_source.return_value = mock_source
+        mock_registry.reload_plugin.return_value = Mock()
+        mock_registry._update_status = {}
+
+        captured_url = []
+
+        def capture_clone(url, *args, **kwargs):
+            captured_url.append(url)
+            return (True, "")
+
+        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
+             patch("src.api_server.get_plugin_registry", return_value=mock_registry), \
+             patch("pathlib.Path.is_dir", return_value=True), \
+             patch("src.plugins.sources.clone_or_update_repo", side_effect=capture_clone):
+            resp = client.post("/plugins/test_plugin/update")
+        assert resp.status_code == 200
+        # The endpoint must pass "" not source.repository_url
+        assert captured_url == [""]
+
+    def test_apply_all_updates_success(self, client):
+        """Bulk update applies all pending updates and returns results."""
+        mock_source = Mock(source_type="external", local_path="/fake/path")
+        mock_registry = Mock()
+        mock_registry.get_update_status.return_value = {"plugin_a": True, "plugin_b": False}
+        mock_registry.get_plugin_source.return_value = mock_source
+        mock_registry.reload_plugin.return_value = Mock()
+        mock_registry._update_status = {"plugin_a": True}
+
+        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
+             patch("src.api_server.get_plugin_registry", return_value=mock_registry), \
+             patch("pathlib.Path.is_dir", return_value=True), \
+             patch("src.plugins.sources.clone_or_update_repo", return_value=(True, "")):
+            resp = client.post("/plugins/updates/apply")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "plugin_a" in data["updated"]
+        assert data["failed"] == {}
+
+    def test_apply_all_updates_no_updates(self, client):
+        """Returns 200 with empty lists when nothing needs updating."""
+        mock_registry = Mock()
+        mock_registry.get_update_status.return_value = {}
+        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
+             patch("src.api_server.get_plugin_registry", return_value=mock_registry):
+            resp = client.post("/plugins/updates/apply")
+        assert resp.status_code == 200
+        assert resp.json()["updated"] == []
+        assert resp.json()["failed"] == {}
+
+    def test_apply_all_updates_partial_failure(self, client):
+        """Partial failures are reported in 'failed' dict while successes are in 'updated'."""
+        mock_source_ok = Mock(source_type="external", local_path="/fake/ok")
+        mock_source_fail = Mock(source_type="external", local_path="/fake/fail")
+
+        def get_source(pid):
+            return mock_source_ok if pid == "good_plugin" else mock_source_fail
+
+        mock_registry = Mock()
+        mock_registry.get_update_status.return_value = {"good_plugin": True, "bad_plugin": True}
+        mock_registry.get_plugin_source.side_effect = get_source
+        mock_registry.reload_plugin.return_value = Mock()
+        mock_registry._update_status = {"good_plugin": True, "bad_plugin": True}
+
+        def fake_clone(url, path, *args, **kwargs):
+            if "fail" in str(path):
+                return (False, "git fetch error")
+            return (True, "")
+
+        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
+             patch("src.api_server.get_plugin_registry", return_value=mock_registry), \
+             patch("pathlib.Path.is_dir", return_value=True), \
+             patch("src.plugins.sources.clone_or_update_repo", side_effect=fake_clone):
+            resp = client.post("/plugins/updates/apply")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "good_plugin" in data["updated"]
+        assert "bad_plugin" in data["failed"]
+
+    def test_apply_all_updates_unavailable(self, client):
+        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", False):
+            resp = client.post("/plugins/updates/apply")
+        assert resp.status_code == 503
+
     def test_install_plugin_success(self, client):
         mock_registry = Mock()
         mock_registry.install_from_git.return_value = []

--- a/tests/test_plugin_sources.py
+++ b/tests/test_plugin_sources.py
@@ -231,14 +231,31 @@ class TestCloneOrUpdateRepo:
         assert "clone" in cmd
 
     @mock.patch("src.plugins.sources.subprocess.run")
-    def test_pull_existing(self, mock_run, tmp_path):
+    def test_fetch_reset_existing(self, mock_run, tmp_path):
+        """Update path uses fetch+reset, not pull, and works without a URL."""
         dest = tmp_path / "my_plugin"
         dest.mkdir()
-        (dest / ".git").mkdir()  # Simulate existing clone
-        ok, err = clone_or_update_repo("https://github.com/Org/repo", dest)
+        (dest / ".git").mkdir()  # Simulate existing shallow clone
+        ok, err = clone_or_update_repo("", dest)
         assert ok
-        cmd = mock_run.call_args[0][0]
-        assert "pull" in cmd
+        assert err == ""
+        # Two subprocess calls: fetch then reset
+        assert mock_run.call_count == 2
+        fetch_cmd = mock_run.call_args_list[0][0][0]
+        reset_cmd = mock_run.call_args_list[1][0][0]
+        assert "fetch" in fetch_cmd
+        assert "--depth=1" in fetch_cmd
+        assert "reset" in reset_cmd
+        assert "FETCH_HEAD" in reset_cmd
+
+    @mock.patch("src.plugins.sources.subprocess.run")
+    def test_update_does_not_require_url(self, mock_run, tmp_path):
+        """Passing an empty or invalid URL is fine when the clone already exists."""
+        dest = tmp_path / "my_plugin"
+        dest.mkdir()
+        (dest / ".git").mkdir()
+        ok, err = clone_or_update_repo("git@github.com:Org/repo.git", dest)
+        assert ok, "Update path should succeed regardless of URL"
 
     @mock.patch(
         "src.plugins.sources.subprocess.run",
@@ -250,7 +267,21 @@ class TestCloneOrUpdateRepo:
         assert not ok
         assert "network error" in err
 
-    def test_rejects_ssh_url(self, tmp_path):
+    @mock.patch(
+        "src.plugins.sources.subprocess.run",
+        side_effect=subprocess.SubprocessError("fetch failed"),
+    )
+    def test_update_failure(self, mock_run, tmp_path):
+        """Fetch failure in the update path is surfaced as an error."""
+        dest = tmp_path / "my_plugin"
+        dest.mkdir()
+        (dest / ".git").mkdir()
+        ok, err = clone_or_update_repo("", dest)
+        assert not ok
+        assert "fetch" in err.lower() or "failed" in err.lower()
+
+    def test_rejects_ssh_url_for_fresh_clone(self, tmp_path):
+        """SSH URLs are rejected only for fresh clones (URL validation skipped for updates)."""
         dest = tmp_path / "ssh_plugin"
         ok, err = clone_or_update_repo("git@github.com:Org/repo.git", dest)
         assert not ok

--- a/web/src/app/integrations/page.tsx
+++ b/web/src/app/integrations/page.tsx
@@ -1574,6 +1574,7 @@ export default function IntegrationsPage() {
   const [installingId, setInstallingId] = useState<string | null>(null);
   const [uninstallingId, setUninstallingId] = useState<string | null>(null);
   const [updatingId, setUpdatingId] = useState<string | null>(null);
+  const [isUpdatingAll, setIsUpdatingAll] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [gitDialogOpen, setGitDialogOpen] = useState(false);
   const [gitUrl, setGitUrl] = useState("");
@@ -1683,6 +1684,26 @@ export default function IntegrationsPage() {
     }
   };
 
+  const handleUpdateAll = async () => {
+    setIsUpdatingAll(true);
+    try {
+      const result = await api.applyAllPluginUpdates();
+      if (result.updated.length > 0) {
+        toast.success(`Updated ${result.updated.length} plugin(s)`);
+      }
+      const failedIds = Object.keys(result.failed);
+      if (failedIds.length > 0) {
+        toast.error(`${failedIds.length} plugin(s) failed to update: ${failedIds.join(", ")}`);
+      }
+      queryClient.invalidateQueries({ queryKey: ["plugins"] });
+      queryClient.invalidateQueries({ queryKey: ["plugin-registry"] });
+    } catch (err) {
+      toast.error(`Update all failed: ${err instanceof Error ? err.message : 'Unknown error'}`);
+    } finally {
+      setIsUpdatingAll(false);
+    }
+  };
+
   const handleInstallFromGit = async () => {
     if (!gitUrl.trim()) return;
     setIsInstallingGit(true);
@@ -1786,6 +1807,8 @@ export default function IntegrationsPage() {
     }
     return installedSort.dir === "asc" ? valA.localeCompare(valB) : valB.localeCompare(valA);
   });
+
+  const updatesAvailableCount = (data?.plugins ?? []).filter((p) => p.update_available === true).length;
 
   // Git install dialog (shared, used in Marketplace tab)
   const gitInstallDialog = (
@@ -2007,6 +2030,24 @@ export default function IntegrationsPage() {
               )}
             </div>
           ) : (
+            <div className="space-y-3">
+              {updatesAvailableCount > 0 && (
+                <div className="flex items-center justify-between rounded-lg border border-amber-200 bg-amber-50 px-4 py-2.5 dark:border-amber-800 dark:bg-amber-950/40">
+                  <p className="text-sm text-amber-700 dark:text-amber-400">
+                    {updatesAvailableCount} plugin update{updatesAvailableCount !== 1 ? "s" : ""} available
+                  </p>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-7 border-amber-300 text-amber-700 hover:bg-amber-100 dark:border-amber-700 dark:text-amber-400 dark:hover:bg-amber-900"
+                    onClick={handleUpdateAll}
+                    disabled={isUpdatingAll || !!updatingId}
+                  >
+                    <RefreshCw className={cn("h-3.5 w-3.5 mr-1.5", isUpdatingAll && "animate-spin")} />
+                    {isUpdatingAll ? "Updating…" : `Update All (${updatesAvailableCount})`}
+                  </Button>
+                </div>
+              )}
             <Card className="overflow-hidden animate-card-fade-in">
               <table className="w-full text-sm">
                 <thead>
@@ -2057,6 +2098,7 @@ export default function IntegrationsPage() {
                 </tbody>
               </table>
             </Card>
+            </div>
           )}
         </TabsContent>
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -817,6 +817,12 @@ export interface PluginUpdateCheckResponse {
   updates_available: string[];
 }
 
+export interface PluginApplyUpdatesResponse {
+  updated: string[];
+  failed: Record<string, string>;
+  message: string;
+}
+
 export interface VersionResponse {
   package_version: string;
   build_version: string;
@@ -1312,6 +1318,11 @@ export const api = {
 
   triggerPluginUpdateCheck: () =>
     fetchApi<PluginUpdateCheckResponse>("/plugins/updates/check", {
+      method: "POST",
+    }),
+
+  applyAllPluginUpdates: () =>
+    fetchApi<PluginApplyUpdatesResponse>("/plugins/updates/apply", {
       method: "POST",
     }),
 


### PR DESCRIPTION
## Summary

- **Fixes 500 errors on external plugin updates** caused by two stacked bugs in `clone_or_update_repo`:
  1. `repository_url` is always `""` for disk-loaded external plugins (the loader never reads the git remote URL). The old code validated this empty URL before doing anything → immediate failure.
  2. `git pull --ff-only` fails on shallow clones (`--depth 1`). Replaced with `git fetch --depth=1 origin` + `git reset --hard FETCH_HEAD` which works correctly for shallow histories.
- **Adds `POST /plugins/updates/apply`** — bulk endpoint that fetches and reloads all external plugins with pending updates, returning `{ updated, failed, message }` with partial-failure support.
- **Adds "Update All" banner** to the Integrations page that appears when any external plugins have available updates.

## Test plan

- [ ] Install an external plugin from a git URL
- [ ] Verify single-plugin update (dropdown → Update) no longer returns 500
- [ ] Verify the amber "Update All (N)" banner appears in the Installed tab when updates are available
- [ ] Click "Update All" and verify plugins update and banner disappears
- [ ] Verify partial failures are shown as error toasts while successes are shown as success toasts
- [ ] All 19 targeted tests pass (`tests/test_plugin_sources.py::TestCloneOrUpdateRepo`, `tests/test_api_coverage_extended.py::TestPluginManagement`)


Made with [Cursor](https://cursor.com)