### PR TITLE
fix: route silence schedule saves to the feature endpoint (#597)

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -1649,6 +1649,50 @@ async def get_silence_status():
     }
 
 
+class SilenceScheduleRequest(BaseModel):
+    """Request body for updating the silence schedule feature."""
+    enabled: bool
+    start_time: str
+    end_time: str
+
+
+@app.put("/settings/silence-schedule")
+async def update_silence_schedule(request: SilenceScheduleRequest):
+    """
+    Update the silence schedule configuration.
+
+    `silence_schedule` is a system feature (not a plugin). Times must be in
+    UTC ISO format (e.g. "04:00+00:00"); the UI converts local time to UTC
+    before calling this endpoint.
+    """
+    config_manager = get_config_manager()
+
+    updated = {
+        "enabled": request.enabled,
+        "start_time": request.start_time,
+        "end_time": request.end_time,
+    }
+
+    success = config_manager.set_feature("silence_schedule", updated)
+    if not success:
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to persist silence schedule configuration",
+        )
+
+    logger.info(
+        "Silence schedule updated: enabled=%s, start=%s, end=%s",
+        request.enabled,
+        request.start_time,
+        request.end_time,
+    )
+
+    return {
+        "status": "success",
+        "config": config_manager.get_feature("silence_schedule") or updated,
+    }
+
+
 # =============================================================================
 # Display Source Endpoints
 # =============================================================================
@@ -3004,9 +3048,9 @@ async def get_all_settings():
     settings_service = get_settings_service()
     config_manager = get_config_manager()
     
-    # Get silence schedule config
-    silence_config = config_manager.get_plugin_config("silence_schedule")
-    
+    # Get silence schedule config (stored under features, not plugins)
+    silence_feature = config_manager.get_feature("silence_schedule") or {}
+
     # Get all other settings
     general = config_manager.get_general()
     polling = settings_service.get_polling_settings()
@@ -3015,10 +3059,10 @@ async def get_all_settings():
     board = settings_service.get_board_settings()
     mqtt = settings_service.get_mqtt_settings()
     display = settings_service.get_display_settings()
-    
+
     return {
         "general": general,
-        "silence_schedule": silence_config or {},
+        "silence_schedule": {"config": silence_feature},
         "polling": {
             "interval_seconds": polling.interval_seconds
         },

--- a/tests/test_settings_all.py
+++ b/tests/test_settings_all.py
@@ -91,13 +91,24 @@ def test_settings_all_status_structure():
 
 
 def test_settings_all_silence_schedule_structure():
-    """Test silence schedule structure."""
+    """Test silence schedule structure.
+
+    The UI expects the feature config wrapped as `{ "config": {...} }` so that
+    `allSettings.silence_schedule.config.{enabled,start_time,end_time}` is
+    accessible. See web/src/components/general-settings.tsx.
+    """
     response = client.get("/settings/all")
     data = response.json()
-    
+
     silence = data["silence_schedule"]
     assert isinstance(silence, dict)
-    # Silence schedule may be empty dict if not configured
+    assert "config" in silence
+    config = silence["config"]
+    assert isinstance(config, dict)
+    assert "enabled" in config
+    assert "start_time" in config
+    assert "end_time" in config
+    assert isinstance(config["enabled"], bool)
 
 
 def test_settings_all_consistency():

--- a/tests/test_silence_schedule_endpoint.py
+++ b/tests/test_silence_schedule_endpoint.py
@@ -1,0 +1,145 @@
+"""Tests for the dedicated silence schedule settings endpoint.
+
+`silence_schedule` is a system feature (not a plugin), so it has its own
+endpoint at `PUT /settings/silence-schedule` backed by
+`config_manager.set_feature("silence_schedule", ...)`. These tests cover the
+happy path, validation errors, round-trip via `get_feature`, and that
+`/silence-status` reflects writes made through this endpoint.
+"""
+from unittest.mock import Mock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.api_server import app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def mock_config_manager_for_silence():
+    """Mock config manager with a working silence_schedule feature."""
+    with patch("src.api_server.get_config_manager") as mock_get:
+        cm = Mock()
+        store = {"enabled": False, "start_time": "04:00+00:00", "end_time": "15:00+00:00"}
+
+        def _get_feature(name):
+            if name == "silence_schedule":
+                return dict(store)
+            return {}
+
+        def _set_feature(name, value):
+            if name == "silence_schedule":
+                store.clear()
+                store.update(value)
+                return True
+            return False
+
+        cm.get_feature.side_effect = _get_feature
+        cm.set_feature.side_effect = _set_feature
+        cm.migrate_silence_schedule_to_utc.return_value = False
+        mock_get.return_value = cm
+        yield cm, store
+
+
+class TestUpdateSilenceScheduleEndpoint:
+    def test_update_success(self, client, mock_config_manager_for_silence):
+        cm, store = mock_config_manager_for_silence
+        response = client.put(
+            "/settings/silence-schedule",
+            json={
+                "enabled": True,
+                "start_time": "04:00+00:00",
+                "end_time": "15:00+00:00",
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "success"
+        assert data["config"]["enabled"] is True
+        assert data["config"]["start_time"] == "04:00+00:00"
+        assert data["config"]["end_time"] == "15:00+00:00"
+
+        cm.set_feature.assert_called_once_with(
+            "silence_schedule",
+            {
+                "enabled": True,
+                "start_time": "04:00+00:00",
+                "end_time": "15:00+00:00",
+            },
+        )
+
+    def test_update_roundtrip_via_get_feature(self, client, mock_config_manager_for_silence):
+        cm, store = mock_config_manager_for_silence
+        client.put(
+            "/settings/silence-schedule",
+            json={
+                "enabled": True,
+                "start_time": "05:30+00:00",
+                "end_time": "13:15+00:00",
+            },
+        )
+
+        # Feature dict should reflect the write
+        assert store == {
+            "enabled": True,
+            "start_time": "05:30+00:00",
+            "end_time": "13:15+00:00",
+        }
+
+    def test_update_missing_fields_returns_422(self, client, mock_config_manager_for_silence):
+        response = client.put(
+            "/settings/silence-schedule",
+            json={"enabled": True},
+        )
+        assert response.status_code == 422
+
+    def test_update_wrong_types_returns_422(self, client, mock_config_manager_for_silence):
+        response = client.put(
+            "/settings/silence-schedule",
+            json={
+                "enabled": "yes",
+                "start_time": 0,
+                "end_time": None,
+            },
+        )
+        assert response.status_code == 422
+
+    def test_update_persist_failure_returns_500(self, client):
+        with patch("src.api_server.get_config_manager") as mock_get:
+            cm = Mock()
+            cm.set_feature.return_value = False
+            cm.get_feature.return_value = {}
+            mock_get.return_value = cm
+
+            response = client.put(
+                "/settings/silence-schedule",
+                json={
+                    "enabled": True,
+                    "start_time": "04:00+00:00",
+                    "end_time": "15:00+00:00",
+                },
+            )
+            assert response.status_code == 500
+
+    def test_silence_status_reflects_write(self, client, mock_config_manager_for_silence):
+        """After writing via the endpoint, /silence-status should see the new values."""
+        client.put(
+            "/settings/silence-schedule",
+            json={
+                "enabled": True,
+                "start_time": "04:00+00:00",
+                "end_time": "15:00+00:00",
+            },
+        )
+
+        response = client.get("/silence-status")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["enabled"] is True
+        assert data["start_time_utc"] == "04:00+00:00"
+        assert data["end_time_utc"] == "15:00+00:00"

--- a/web/src/__tests__/api-extended.test.ts
+++ b/web/src/__tests__/api-extended.test.ts
@@ -708,6 +708,33 @@ describe("API Extended Tests", () => {
       expect(result.status).toBe("success");
       expect(result.settings.interval_seconds).toBe(600);
     });
+
+    it("updateSilenceSchedule PUTs to /settings/silence-schedule", async () => {
+      let capturedPath: string | undefined;
+      let capturedBody: unknown;
+      server.use(
+        http.put(`${API_BASE}/settings/silence-schedule`, async ({ request }) => {
+          capturedPath = new URL(request.url).pathname;
+          capturedBody = await request.json();
+          return HttpResponse.json({
+            status: "success",
+            config: capturedBody,
+          });
+        })
+      );
+      const result = await api.updateSilenceSchedule({
+        enabled: true,
+        start_time: "04:00+00:00",
+        end_time: "15:00+00:00",
+      });
+      expect(capturedPath).toBe("/api/settings/silence-schedule");
+      expect(capturedBody).toEqual({
+        enabled: true,
+        start_time: "04:00+00:00",
+        end_time: "15:00+00:00",
+      });
+      expect(result.status).toBe("success");
+    });
   });
 
   describe("Board settings endpoints", () => {

--- a/web/src/__tests__/mocks/handlers.ts
+++ b/web/src/__tests__/mocks/handlers.ts
@@ -865,6 +865,19 @@ export const handlers = [
     return HttpResponse.json(mockSilenceStatus);
   }),
 
+  // Silence schedule update endpoint (system feature, not a plugin)
+  http.put(`${API_BASE}/settings/silence-schedule`, async ({ request }) => {
+    const body = await request.json() as {
+      enabled: boolean;
+      start_time: string;
+      end_time: string;
+    };
+    return HttpResponse.json({
+      status: "success",
+      config: body,
+    });
+  }),
+
   // Carousel endpoints
   http.get(`${API_BASE}/carousels`, () => {
     return HttpResponse.json({

--- a/web/src/components/general-settings.tsx
+++ b/web/src/components/general-settings.tsx
@@ -73,16 +73,13 @@ export function GeneralSettings() {
     }
   }, [deferredPollingSettings]);
 
-  // Update silence schedule mutation (now uses plugin API)
+  // Update silence schedule mutation (system feature endpoint, not plugin API)
   const updateSilenceMutation = useMutation({
-    mutationFn: (data: Record<string, unknown>) => 
-      api.updatePluginConfig("silence_schedule", data),
+    mutationFn: (data: { enabled: boolean; start_time: string; end_time: string }) =>
+      api.updateSilenceSchedule(data),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["plugin", "silence_schedule"], refetchType: 'active' });
-      queryClient.invalidateQueries({ queryKey: ["plugins"], refetchType: 'active' });
-      queryClient.invalidateQueries({ queryKey: ["config"], refetchType: 'active' });
-      // Invalidate template variables since plugin config may affect available variables
-      queryClient.invalidateQueries({ queryKey: ["template-variables"], refetchType: 'active' });
+      queryClient.invalidateQueries({ queryKey: ["all-settings"], refetchType: 'active' });
+      queryClient.invalidateQueries({ queryKey: ["silence-status"], refetchType: 'active' });
       toast.success(t("toastSettingsSaved"));
     },
     onError: (error: Error) => {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1190,6 +1190,14 @@ export const api = {
   // Silence mode status
   getSilenceStatus: () => fetchApi<SilenceStatus>("/silence-status"),
 
+  // Silence schedule (system feature, not a plugin)
+  updateSilenceSchedule: (data: { enabled: boolean; start_time: string; end_time: string }) =>
+    fetchApi<{ status: string; config: Record<string, unknown> }>("/settings/silence-schedule", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    }),
+
   // Polling settings
   getPollingSettings: () => fetchApi<PollingSettings>("/settings/polling"),
   updatePollingSettings: (interval_seconds: number) =>

--- a/web/tests/settings-full.spec.ts
+++ b/web/tests/settings-full.spec.ts
@@ -167,6 +167,61 @@ test.describe("Settings – Full Coverage", () => {
     expect(data).toHaveProperty("end_time_utc");
   });
 
+  test("toggling silence schedule saves without 404 (regression: #597)", async ({
+    page,
+  }) => {
+    // Snapshot original state so we can restore it at the end
+    const originalRes = await fetch(`${API_URL}/silence-status`);
+    const original = await originalRes.json();
+    const originalEnabled: boolean = original.enabled;
+
+    await page.goto("/settings");
+    await expect(
+      page.getByRole("heading", { name: "Settings", exact: true }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const silenceToggle = page.locator("#silence-enabled");
+    await expect(silenceToggle).toBeVisible({ timeout: 10_000 });
+
+    // Wait for the debounced PUT triggered by the toggle. The regression
+    // (#597) was that this request 404'd because the UI was calling the
+    // plugin config endpoint instead of the dedicated feature endpoint.
+    const savePromise = page.waitForResponse(
+      (resp) =>
+        resp.url().includes("/settings/silence-schedule") &&
+        resp.request().method() === "PUT",
+      { timeout: 10_000 },
+    );
+
+    await silenceToggle.click();
+
+    const saveResponse = await savePromise;
+    expect(saveResponse.status()).toBe(200);
+
+    // Confirm the write landed: /silence-status should now reflect the flip
+    await expect
+      .poll(
+        async () => {
+          const res = await fetch(`${API_URL}/silence-status`);
+          const data = await res.json();
+          return data.enabled as boolean;
+        },
+        { timeout: 5_000 },
+      )
+      .toBe(!originalEnabled);
+
+    // Restore original state via the same endpoint the UI uses
+    await fetch(`${API_URL}/settings/silence-schedule`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        enabled: originalEnabled,
+        start_time: original.start_time_utc,
+        end_time: original.end_time_utc,
+      }),
+    });
+  });
+
   test("silence status endpoint returns current time info", async () => {
     const res = await fetch(`${API_URL}/silence-status`);
     expect(res.ok).toBe(true);


### PR DESCRIPTION
The Silence Schedule toggle in Settings was 404-ing because the UI saved via the plugin config endpoint, but `silence_schedule` is a system feature, not a plugin. Add a dedicated `PUT /settings/silence-schedule` backed by `config_manager.set_feature()`, fix `/settings/all` to read from the correct location, and point the UI at the new endpoint.

Also update the CI tests. Now the fix is defended at three layers: the FastAPI route exists (pytest), the UI calls it with the correct shape (Vitest), and a real browser toggle round-trips end to end (Playwright).

Fixes #597