### PR TITLE
fix: timezone picker sends partial search text to API causing 400 on save

### DIFF
--- a/plugins/date_time/__init__.py
+++ b/plugins/date_time/__init__.py
@@ -32,9 +32,12 @@ class DateTimePlugin(PluginBase):
         errors = []
         
         timezone = config.get("timezone", "America/Los_Angeles")
+        if not isinstance(timezone, str) or not timezone.strip():
+            errors.append(f"Invalid timezone: {timezone!r}")
+            return errors
         try:
             pytz.timezone(timezone)
-        except pytz.exceptions.UnknownTimeZoneError:
+        except (pytz.exceptions.UnknownTimeZoneError, AttributeError, KeyError):
             errors.append(f"Invalid timezone: {timezone}")
         
         return errors

--- a/plugins/date_time/tests/test_plugin.py
+++ b/plugins/date_time/tests/test_plugin.py
@@ -33,6 +33,18 @@ class TestDateTimePlugin:
         errors = plugin.validate_config(config)
         assert len(errors) > 0
         assert any("timezone" in e.lower() for e in errors)
+
+    def test_validate_config_empty_string_timezone(self, sample_manifest):
+        """Test that an empty string timezone is rejected (regression: partial search text)."""
+        plugin = DateTimePlugin(sample_manifest)
+        errors = plugin.validate_config({"timezone": ""})
+        assert len(errors) > 0
+
+    def test_validate_config_none_timezone(self, sample_manifest):
+        """Test that a None timezone value is rejected gracefully."""
+        plugin = DateTimePlugin(sample_manifest)
+        errors = plugin.validate_config({"timezone": None})
+        assert len(errors) > 0
     
     def test_validate_config_default_timezone(self, sample_manifest):
         """Test config validation with default timezone."""

--- a/web/src/__tests__/timezone-picker.test.tsx
+++ b/web/src/__tests__/timezone-picker.test.tsx
@@ -361,4 +361,31 @@ describe("TimezonePicker", () => {
     // Should show at most 50 items plus the message if there are more
     expect(timezoneButtons.length).toBeLessThanOrEqual(50);
   });
+
+  it("does not call onChange with partial/invalid text while typing", async () => {
+    // Regression test for: typing in the search box should NOT propagate invalid
+    // timezone strings to the parent (which would cause a 400 on config save).
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+
+    render(
+      <TimezonePicker
+        value="America/Los_Angeles"
+        onChange={handleChange}
+      />
+    );
+
+    const input = screen.getByPlaceholderText("Search timezone...");
+    await user.click(input);
+
+    // Clear and type partial search text (not a valid IANA timezone)
+    await user.clear(input);
+    await user.type(input, "Los Ang");
+
+    // onChange should NOT have been called with any partial/invalid value
+    const invalidCalls = handleChange.mock.calls.filter(
+      ([v]) => v !== "America/Los_Angeles" && v !== ""
+    );
+    expect(invalidCalls).toHaveLength(0);
+  });
 });

--- a/web/src/components/ui/timezone-picker.tsx
+++ b/web/src/components/ui/timezone-picker.tsx
@@ -111,15 +111,15 @@ export function TimezonePicker({
     setIsOpen(true);
     setHighlightedIndex(-1); // Reset highlight when typing
     
-    // If user types a valid timezone value directly, update it
+    // Only propagate changes when the user types an exact IANA timezone match.
+    // Do NOT call onChange with partial search text — that would store an
+    // invalid timezone in the parent's config state and cause a 400 when saving.
+    // The value is committed via handleSelect when the user picks from the list.
     const exactMatch = ALL_TIMEZONES.find(
       (tz) => tz.value.toLowerCase() === newValue.toLowerCase()
     );
     if (exactMatch) {
       onChange(exactMatch.value);
-    } else {
-      // Allow free-form input for validation
-      onChange(newValue);
     }
   };
 


### PR DESCRIPTION
## Problem

Fixes #602

The `TimezonePicker` component was calling `onChange()` on every keystroke, including partial search strings like `"Los"` or `"New Y"`. When the user clicked **Save** on the Date & Time plugin config, `configValues.timezone` contained that invalid text, and the backend rejected it with a `400 Invalid timezone: Los`.

## Root Cause

In `timezone-picker.tsx`, `handleInputChange` had a fallback `else` branch that called `onChange(newValue)` for any text that wasn't an exact IANA match — intended for "free-form validation" but was actually poisoning the parent state with search garbage.

## Changes

### `web/src/components/ui/timezone-picker.tsx`
- `handleInputChange` no longer calls `onChange` with partial text. `onChange` is only called when the user **selects** from the dropdown (`handleSelect`) or types an **exact** IANA match. Search text stays internal.

### `plugins/date_time/__init__.py`
- `validate_config` now explicitly rejects empty strings and non-string values (`None`) before passing to `pytz.timezone()`, with cleaner error messages.

### `web/src/__tests__/timezone-picker.test.tsx`
- Added regression test: typing partial text does **not** propagate invalid values via `onChange`.

### `plugins/date_time/tests/test_plugin.py`
- Added tests for empty string and `None` timezone values being rejected by backend validation.

## Testing

- All 15 `timezone-picker` frontend tests pass
- All 24 `date_time` plugin tests pass
- Manually verified: saving the Date & Time plugin config no longer returns 400