### PR TITLE
chore: replace pytz with stdlib zoneinfo

### DIFF
--- a/docs-site/docs/development/plugin-guide.md
+++ b/docs-site/docs/development/plugin-guide.md
@@ -442,7 +442,7 @@ from typing import Any, Dict, List, Optional
 import logging
 from datetime import datetime
 
-import pytz
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from src.plugins.base import PluginBase, PluginResult
 
@@ -460,14 +460,14 @@ class DateTimePlugin(PluginBase):
         errors = []
         timezone = config.get("timezone", "America/Los_Angeles")
         try:
-            pytz.timezone(timezone)
-        except pytz.exceptions.UnknownTimeZoneError:
+            ZoneInfo(timezone)
+        except (ZoneInfoNotFoundError, ValueError):
             errors.append(f"Invalid timezone: {timezone}")
         return errors
 
     def fetch_data(self) -> PluginResult:
         try:
-            tz = pytz.timezone(self.config.get("timezone", "America/Los_Angeles"))
+            tz = ZoneInfo(self.config.get("timezone", "America/Los_Angeles"))
             now = datetime.now(tz)
             return PluginResult(
                 available=True,

--- a/docs-site/versioned_docs/version-2.10/development/plugin-guide.md
+++ b/docs-site/versioned_docs/version-2.10/development/plugin-guide.md
@@ -417,7 +417,7 @@ from typing import Any, Dict, List, Optional
 import logging
 from datetime import datetime
 
-import pytz
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from src.plugins.base import PluginBase, PluginResult
 
@@ -435,14 +435,14 @@ class DateTimePlugin(PluginBase):
         errors = []
         timezone = config.get("timezone", "America/Los_Angeles")
         try:
-            pytz.timezone(timezone)
-        except pytz.exceptions.UnknownTimeZoneError:
+            ZoneInfo(timezone)
+        except (ZoneInfoNotFoundError, ValueError):
             errors.append(f"Invalid timezone: {timezone}")
         return errors
 
     def fetch_data(self) -> PluginResult:
         try:
-            tz = pytz.timezone(self.config.get("timezone", "America/Los_Angeles"))
+            tz = ZoneInfo(self.config.get("timezone", "America/Los_Angeles"))
             now = datetime.now(tz)
             return PluginResult(
                 available=True,

--- a/docs-site/versioned_docs/version-2.11/development/plugin-guide.md
+++ b/docs-site/versioned_docs/version-2.11/development/plugin-guide.md
@@ -417,7 +417,7 @@ from typing import Any, Dict, List, Optional
 import logging
 from datetime import datetime
 
-import pytz
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from src.plugins.base import PluginBase, PluginResult
 
@@ -435,14 +435,14 @@ class DateTimePlugin(PluginBase):
         errors = []
         timezone = config.get("timezone", "America/Los_Angeles")
         try:
-            pytz.timezone(timezone)
-        except pytz.exceptions.UnknownTimeZoneError:
+            ZoneInfo(timezone)
+        except (ZoneInfoNotFoundError, ValueError):
             errors.append(f"Invalid timezone: {timezone}")
         return errors
 
     def fetch_data(self) -> PluginResult:
         try:
-            tz = pytz.timezone(self.config.get("timezone", "America/Los_Angeles"))
+            tz = ZoneInfo(self.config.get("timezone", "America/Los_Angeles"))
             now = datetime.now(tz)
             return PluginResult(
                 available=True,

--- a/docs-site/versioned_docs/version-2.5/development/plugin-guide.md
+++ b/docs-site/versioned_docs/version-2.5/development/plugin-guide.md
@@ -417,7 +417,7 @@ from typing import Any, Dict, List, Optional
 import logging
 from datetime import datetime
 
-import pytz
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from src.plugins.base import PluginBase, PluginResult
 
@@ -435,14 +435,14 @@ class DateTimePlugin(PluginBase):
         errors = []
         timezone = config.get("timezone", "America/Los_Angeles")
         try:
-            pytz.timezone(timezone)
-        except pytz.exceptions.UnknownTimeZoneError:
+            ZoneInfo(timezone)
+        except (ZoneInfoNotFoundError, ValueError):
             errors.append(f"Invalid timezone: {timezone}")
         return errors
 
     def fetch_data(self) -> PluginResult:
         try:
-            tz = pytz.timezone(self.config.get("timezone", "America/Los_Angeles"))
+            tz = ZoneInfo(self.config.get("timezone", "America/Los_Angeles"))
             now = datetime.now(tz)
             return PluginResult(
                 available=True,

--- a/docs-site/versioned_docs/version-2.6/development/plugin-guide.md
+++ b/docs-site/versioned_docs/version-2.6/development/plugin-guide.md
@@ -417,7 +417,7 @@ from typing import Any, Dict, List, Optional
 import logging
 from datetime import datetime
 
-import pytz
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from src.plugins.base import PluginBase, PluginResult
 
@@ -435,14 +435,14 @@ class DateTimePlugin(PluginBase):
         errors = []
         timezone = config.get("timezone", "America/Los_Angeles")
         try:
-            pytz.timezone(timezone)
-        except pytz.exceptions.UnknownTimeZoneError:
+            ZoneInfo(timezone)
+        except (ZoneInfoNotFoundError, ValueError):
             errors.append(f"Invalid timezone: {timezone}")
         return errors
 
     def fetch_data(self) -> PluginResult:
         try:
-            tz = pytz.timezone(self.config.get("timezone", "America/Los_Angeles"))
+            tz = ZoneInfo(self.config.get("timezone", "America/Los_Angeles"))
             now = datetime.now(tz)
             return PluginResult(
                 available=True,

--- a/docs-site/versioned_docs/version-2.7/development/plugin-guide.md
+++ b/docs-site/versioned_docs/version-2.7/development/plugin-guide.md
@@ -417,7 +417,7 @@ from typing import Any, Dict, List, Optional
 import logging
 from datetime import datetime
 
-import pytz
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from src.plugins.base import PluginBase, PluginResult
 
@@ -435,14 +435,14 @@ class DateTimePlugin(PluginBase):
         errors = []
         timezone = config.get("timezone", "America/Los_Angeles")
         try:
-            pytz.timezone(timezone)
-        except pytz.exceptions.UnknownTimeZoneError:
+            ZoneInfo(timezone)
+        except (ZoneInfoNotFoundError, ValueError):
             errors.append(f"Invalid timezone: {timezone}")
         return errors
 
     def fetch_data(self) -> PluginResult:
         try:
-            tz = pytz.timezone(self.config.get("timezone", "America/Los_Angeles"))
+            tz = ZoneInfo(self.config.get("timezone", "America/Los_Angeles"))
             now = datetime.now(tz)
             return PluginResult(
                 available=True,

--- a/docs-site/versioned_docs/version-2.8/development/plugin-guide.md
+++ b/docs-site/versioned_docs/version-2.8/development/plugin-guide.md
@@ -417,7 +417,7 @@ from typing import Any, Dict, List, Optional
 import logging
 from datetime import datetime
 
-import pytz
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from src.plugins.base import PluginBase, PluginResult
 
@@ -435,14 +435,14 @@ class DateTimePlugin(PluginBase):
         errors = []
         timezone = config.get("timezone", "America/Los_Angeles")
         try:
-            pytz.timezone(timezone)
-        except pytz.exceptions.UnknownTimeZoneError:
+            ZoneInfo(timezone)
+        except (ZoneInfoNotFoundError, ValueError):
             errors.append(f"Invalid timezone: {timezone}")
         return errors
 
     def fetch_data(self) -> PluginResult:
         try:
-            tz = pytz.timezone(self.config.get("timezone", "America/Los_Angeles"))
+            tz = ZoneInfo(self.config.get("timezone", "America/Los_Angeles"))
             now = datetime.now(tz)
             return PluginResult(
                 available=True,

--- a/docs-site/versioned_docs/version-2.9/development/plugin-guide.md
+++ b/docs-site/versioned_docs/version-2.9/development/plugin-guide.md
@@ -417,7 +417,7 @@ from typing import Any, Dict, List, Optional
 import logging
 from datetime import datetime
 
-import pytz
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from src.plugins.base import PluginBase, PluginResult
 
@@ -435,14 +435,14 @@ class DateTimePlugin(PluginBase):
         errors = []
         timezone = config.get("timezone", "America/Los_Angeles")
         try:
-            pytz.timezone(timezone)
-        except pytz.exceptions.UnknownTimeZoneError:
+            ZoneInfo(timezone)
+        except (ZoneInfoNotFoundError, ValueError):
             errors.append(f"Invalid timezone: {timezone}")
         return errors
 
     def fetch_data(self) -> PluginResult:
         try:
-            tz = pytz.timezone(self.config.get("timezone", "America/Los_Angeles"))
+            tz = ZoneInfo(self.config.get("timezone", "America/Los_Angeles"))
             now = datetime.now(tz)
             return PluginResult(
                 available=True,

--- a/docs-site/versioned_docs/version-4.0/development/plugin-guide.md
+++ b/docs-site/versioned_docs/version-4.0/development/plugin-guide.md
@@ -442,7 +442,7 @@ from typing import Any, Dict, List, Optional
 import logging
 from datetime import datetime
 
-import pytz
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from src.plugins.base import PluginBase, PluginResult
 
@@ -460,14 +460,14 @@ class DateTimePlugin(PluginBase):
         errors = []
         timezone = config.get("timezone", "America/Los_Angeles")
         try:
-            pytz.timezone(timezone)
-        except pytz.exceptions.UnknownTimeZoneError:
+            ZoneInfo(timezone)
+        except (ZoneInfoNotFoundError, ValueError):
             errors.append(f"Invalid timezone: {timezone}")
         return errors
 
     def fetch_data(self) -> PluginResult:
         try:
-            tz = pytz.timezone(self.config.get("timezone", "America/Los_Angeles"))
+            tz = ZoneInfo(self.config.get("timezone", "America/Los_Angeles"))
             now = datetime.now(tz)
             return PluginResult(
                 available=True,

--- a/docs-site/versioned_docs/version-4.1/development/plugin-guide.md
+++ b/docs-site/versioned_docs/version-4.1/development/plugin-guide.md
@@ -442,7 +442,7 @@ from typing import Any, Dict, List, Optional
 import logging
 from datetime import datetime
 
-import pytz
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from src.plugins.base import PluginBase, PluginResult
 
@@ -460,14 +460,14 @@ class DateTimePlugin(PluginBase):
         errors = []
         timezone = config.get("timezone", "America/Los_Angeles")
         try:
-            pytz.timezone(timezone)
-        except pytz.exceptions.UnknownTimeZoneError:
+            ZoneInfo(timezone)
+        except (ZoneInfoNotFoundError, ValueError):
             errors.append(f"Invalid timezone: {timezone}")
         return errors
 
     def fetch_data(self) -> PluginResult:
         try:
-            tz = pytz.timezone(self.config.get("timezone", "America/Los_Angeles"))
+            tz = ZoneInfo(self.config.get("timezone", "America/Los_Angeles"))
             now = datetime.now(tz)
             return PluginResult(
                 available=True,

--- a/docs-site/versioned_docs/version-4.2/development/plugin-guide.md
+++ b/docs-site/versioned_docs/version-4.2/development/plugin-guide.md
@@ -442,7 +442,7 @@ from typing import Any, Dict, List, Optional
 import logging
 from datetime import datetime
 
-import pytz
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from src.plugins.base import PluginBase, PluginResult
 
@@ -460,14 +460,14 @@ class DateTimePlugin(PluginBase):
         errors = []
         timezone = config.get("timezone", "America/Los_Angeles")
         try:
-            pytz.timezone(timezone)
-        except pytz.exceptions.UnknownTimeZoneError:
+            ZoneInfo(timezone)
+        except (ZoneInfoNotFoundError, ValueError):
             errors.append(f"Invalid timezone: {timezone}")
         return errors
 
     def fetch_data(self) -> PluginResult:
         try:
-            tz = pytz.timezone(self.config.get("timezone", "America/Los_Angeles"))
+            tz = ZoneInfo(self.config.get("timezone", "America/Los_Angeles"))
             now = datetime.now(tz)
             return PluginResult(
                 available=True,

--- a/docs-site/versioned_docs/version-4.3/development/plugin-guide.md
+++ b/docs-site/versioned_docs/version-4.3/development/plugin-guide.md
@@ -442,7 +442,7 @@ from typing import Any, Dict, List, Optional
 import logging
 from datetime import datetime
 
-import pytz
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from src.plugins.base import PluginBase, PluginResult
 
@@ -460,14 +460,14 @@ class DateTimePlugin(PluginBase):
         errors = []
         timezone = config.get("timezone", "America/Los_Angeles")
         try:
-            pytz.timezone(timezone)
-        except pytz.exceptions.UnknownTimeZoneError:
+            ZoneInfo(timezone)
+        except (ZoneInfoNotFoundError, ValueError):
             errors.append(f"Invalid timezone: {timezone}")
         return errors
 
     def fetch_data(self) -> PluginResult:
         try:
-            tz = pytz.timezone(self.config.get("timezone", "America/Los_Angeles"))
+            tz = ZoneInfo(self.config.get("timezone", "America/Los_Angeles"))
             now = datetime.now(tz)
             return PluginResult(
                 available=True,

--- a/docs-site/versioned_docs/version-4.4/development/plugin-guide.md
+++ b/docs-site/versioned_docs/version-4.4/development/plugin-guide.md
@@ -442,7 +442,7 @@ from typing import Any, Dict, List, Optional
 import logging
 from datetime import datetime
 
-import pytz
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from src.plugins.base import PluginBase, PluginResult
 
@@ -460,14 +460,14 @@ class DateTimePlugin(PluginBase):
         errors = []
         timezone = config.get("timezone", "America/Los_Angeles")
         try:
-            pytz.timezone(timezone)
-        except pytz.exceptions.UnknownTimeZoneError:
+            ZoneInfo(timezone)
+        except (ZoneInfoNotFoundError, ValueError):
             errors.append(f"Invalid timezone: {timezone}")
         return errors
 
     def fetch_data(self) -> PluginResult:
         try:
-            tz = pytz.timezone(self.config.get("timezone", "America/Los_Angeles"))
+            tz = ZoneInfo(self.config.get("timezone", "America/Los_Angeles"))
             now = datetime.now(tz)
             return PluginResult(
                 available=True,

--- a/docs-site/versioned_docs/version-4.5/development/plugin-guide.md
+++ b/docs-site/versioned_docs/version-4.5/development/plugin-guide.md
@@ -442,7 +442,7 @@ from typing import Any, Dict, List, Optional
 import logging
 from datetime import datetime
 
-import pytz
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from src.plugins.base import PluginBase, PluginResult
 
@@ -460,14 +460,14 @@ class DateTimePlugin(PluginBase):
         errors = []
         timezone = config.get("timezone", "America/Los_Angeles")
         try:
-            pytz.timezone(timezone)
-        except pytz.exceptions.UnknownTimeZoneError:
+            ZoneInfo(timezone)
+        except (ZoneInfoNotFoundError, ValueError):
             errors.append(f"Invalid timezone: {timezone}")
         return errors
 
     def fetch_data(self) -> PluginResult:
         try:
-            tz = pytz.timezone(self.config.get("timezone", "America/Los_Angeles"))
+            tz = ZoneInfo(self.config.get("timezone", "America/Los_Angeles"))
             now = datetime.now(tz)
             return PluginResult(
                 available=True,

--- a/docs-site/versioned_docs/version-4.6/development/plugin-guide.md
+++ b/docs-site/versioned_docs/version-4.6/development/plugin-guide.md
@@ -442,7 +442,7 @@ from typing import Any, Dict, List, Optional
 import logging
 from datetime import datetime
 
-import pytz
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from src.plugins.base import PluginBase, PluginResult
 
@@ -460,14 +460,14 @@ class DateTimePlugin(PluginBase):
         errors = []
         timezone = config.get("timezone", "America/Los_Angeles")
         try:
-            pytz.timezone(timezone)
-        except pytz.exceptions.UnknownTimeZoneError:
+            ZoneInfo(timezone)
+        except (ZoneInfoNotFoundError, ValueError):
             errors.append(f"Invalid timezone: {timezone}")
         return errors
 
     def fetch_data(self) -> PluginResult:
         try:
-            tz = pytz.timezone(self.config.get("timezone", "America/Los_Angeles"))
+            tz = ZoneInfo(self.config.get("timezone", "America/Los_Angeles"))
             now = datetime.now(tz)
             return PluginResult(
                 available=True,

--- a/plugins/countdown/__init__.py
+++ b/plugins/countdown/__init__.py
@@ -7,8 +7,7 @@ import logging
 import os
 from datetime import datetime
 from typing import Any, Dict, List, Optional
-
-import pytz
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from src.plugins.base import PluginBase, PluginResult
 
@@ -36,8 +35,8 @@ class CountdownPlugin(PluginBase):
 
         timezone = config.get("timezone", "America/Los_Angeles")
         try:
-            pytz.timezone(timezone)
-        except pytz.exceptions.UnknownTimeZoneError:
+            ZoneInfo(timezone)
+        except (ZoneInfoNotFoundError, ValueError):
             errors.append(f"Invalid timezone: {timezone}")
 
         target = config.get("target_datetime") or os.getenv("COUNTDOWN_TARGET")
@@ -58,7 +57,7 @@ class CountdownPlugin(PluginBase):
         """Fetch countdown data."""
         try:
             timezone_str = self.config.get("timezone", "America/Los_Angeles")
-            tz = pytz.timezone(timezone_str)
+            tz = ZoneInfo(timezone_str)
             now = datetime.now(tz)
 
             target_str = self.config.get("target_datetime") or os.getenv(
@@ -78,9 +77,9 @@ class CountdownPlugin(PluginBase):
                     error=f"Invalid target datetime: {target_str}",
                 )
 
-            # Localize the target if it has no timezone info
+            # Attach timezone info if the target is naive (zoneinfo uses replace).
             if target_naive.tzinfo is None:
-                target = tz.localize(target_naive)
+                target = target_naive.replace(tzinfo=tz)
             else:
                 target = target_naive
 

--- a/plugins/countdown/tests/test_plugin.py
+++ b/plugins/countdown/tests/test_plugin.py
@@ -5,7 +5,7 @@ from unittest.mock import patch, MagicMock
 from datetime import datetime
 import json
 from pathlib import Path
-import pytz
+from zoneinfo import ZoneInfo
 
 from plugins.countdown import CountdownPlugin
 from src.plugins.base import PluginResult
@@ -67,8 +67,8 @@ class TestCountdownPlugin:
     @patch("plugins.countdown.datetime")
     def test_fetch_data_future_event(self, mock_datetime, sample_manifest, sample_config):
         """Test fetch_data with a future target date."""
-        tz = pytz.timezone("America/Los_Angeles")
-        mock_now = tz.localize(datetime(2025, 5, 24, 20, 50, 0))
+        tz = ZoneInfo("America/Los_Angeles")
+        mock_now = datetime(2025, 5, 24, 20, 50, 0, tzinfo=tz)
         mock_datetime.now.return_value = mock_now
         mock_datetime.fromisoformat = datetime.fromisoformat
 
@@ -92,9 +92,9 @@ class TestCountdownPlugin:
     @patch("plugins.countdown.datetime")
     def test_fetch_data_exact_values(self, mock_datetime, sample_manifest, sample_config):
         """Test fetch_data returns correct countdown values."""
-        tz = pytz.timezone("America/Los_Angeles")
+        tz = ZoneInfo("America/Los_Angeles")
         # 21 days, 3 hours, 10 minutes before target
-        mock_now = tz.localize(datetime(2025, 5, 24, 20, 50, 0))
+        mock_now = datetime(2025, 5, 24, 20, 50, 0, tzinfo=tz)
         mock_datetime.now.return_value = mock_now
         mock_datetime.fromisoformat = datetime.fromisoformat
 
@@ -111,8 +111,8 @@ class TestCountdownPlugin:
     @patch("plugins.countdown.datetime")
     def test_fetch_data_expired_event(self, mock_datetime, sample_manifest, sample_config):
         """Test fetch_data when the event has already passed."""
-        tz = pytz.timezone("America/Los_Angeles")
-        mock_now = tz.localize(datetime(2025, 7, 1, 0, 0, 0))
+        tz = ZoneInfo("America/Los_Angeles")
+        mock_now = datetime(2025, 7, 1, 0, 0, 0, tzinfo=tz)
         mock_datetime.now.return_value = mock_now
         mock_datetime.fromisoformat = datetime.fromisoformat
 
@@ -163,8 +163,8 @@ class TestCountdownPlugin:
     @patch("plugins.countdown.datetime")
     def test_fetch_data_all_variables(self, mock_datetime, sample_manifest, sample_config):
         """Test fetch_data returns all expected variables from manifest."""
-        tz = pytz.timezone("America/Los_Angeles")
-        mock_now = tz.localize(datetime(2025, 5, 24, 20, 50, 0))
+        tz = ZoneInfo("America/Los_Angeles")
+        mock_now = datetime(2025, 5, 24, 20, 50, 0, tzinfo=tz)
         mock_datetime.now.return_value = mock_now
         mock_datetime.fromisoformat = datetime.fromisoformat
 
@@ -187,8 +187,8 @@ class TestCountdownPlugin:
     @patch("plugins.countdown.datetime")
     def test_fetch_data_formatted_lines(self, mock_datetime, sample_manifest, sample_config):
         """Test fetch_data returns formatted lines for the board."""
-        tz = pytz.timezone("America/Los_Angeles")
-        mock_now = tz.localize(datetime(2025, 5, 24, 20, 50, 0))
+        tz = ZoneInfo("America/Los_Angeles")
+        mock_now = datetime(2025, 5, 24, 20, 50, 0, tzinfo=tz)
         mock_datetime.now.return_value = mock_now
         mock_datetime.fromisoformat = datetime.fromisoformat
 
@@ -202,8 +202,8 @@ class TestCountdownPlugin:
     @patch("plugins.countdown.datetime")
     def test_get_formatted_display(self, mock_datetime, sample_manifest, sample_config):
         """Test get_formatted_display returns 6 lines."""
-        tz = pytz.timezone("America/Los_Angeles")
-        mock_now = tz.localize(datetime(2025, 5, 24, 20, 50, 0))
+        tz = ZoneInfo("America/Los_Angeles")
+        mock_now = datetime(2025, 5, 24, 20, 50, 0, tzinfo=tz)
         mock_datetime.now.return_value = mock_now
         mock_datetime.fromisoformat = datetime.fromisoformat
 
@@ -221,8 +221,8 @@ class TestCountdownPlugin:
     @patch("plugins.countdown.datetime")
     def test_get_formatted_display_expired(self, mock_datetime, sample_manifest, sample_config):
         """Test formatted display when event has passed."""
-        tz = pytz.timezone("America/Los_Angeles")
-        mock_now = tz.localize(datetime(2025, 7, 1, 0, 0, 0))
+        tz = ZoneInfo("America/Los_Angeles")
+        mock_now = datetime(2025, 7, 1, 0, 0, 0, tzinfo=tz)
         mock_datetime.now.return_value = mock_now
         mock_datetime.fromisoformat = datetime.fromisoformat
 
@@ -245,8 +245,8 @@ class TestCountdownPlugin:
     @patch("plugins.countdown.datetime")
     def test_fetch_data_formatted_string(self, mock_datetime, sample_manifest, sample_config):
         """Test the formatted countdown string."""
-        tz = pytz.timezone("America/Los_Angeles")
-        mock_now = tz.localize(datetime(2025, 5, 24, 20, 50, 0))
+        tz = ZoneInfo("America/Los_Angeles")
+        mock_now = datetime(2025, 5, 24, 20, 50, 0, tzinfo=tz)
         mock_datetime.now.return_value = mock_now
         mock_datetime.fromisoformat = datetime.fromisoformat
 
@@ -259,8 +259,8 @@ class TestCountdownPlugin:
     @patch("plugins.countdown.datetime")
     def test_fetch_data_default_event_name(self, mock_datetime, sample_manifest):
         """Test default event name when not configured."""
-        tz = pytz.timezone("America/Los_Angeles")
-        mock_now = tz.localize(datetime(2025, 5, 24, 20, 50, 0))
+        tz = ZoneInfo("America/Los_Angeles")
+        mock_now = datetime(2025, 5, 24, 20, 50, 0, tzinfo=tz)
         mock_datetime.now.return_value = mock_now
         mock_datetime.fromisoformat = datetime.fromisoformat
 

--- a/plugins/date_time/__init__.py
+++ b/plugins/date_time/__init__.py
@@ -6,7 +6,7 @@ Displays current date and time in various formats.
 from typing import Any, Dict, List, Optional
 import logging
 from datetime import datetime
-import pytz
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from src.plugins.base import PluginBase, PluginResult
 
@@ -36,8 +36,8 @@ class DateTimePlugin(PluginBase):
             errors.append(f"Invalid timezone: {timezone!r}")
             return errors
         try:
-            pytz.timezone(timezone)
-        except (pytz.exceptions.UnknownTimeZoneError, AttributeError, KeyError):
+            ZoneInfo(timezone)
+        except (ZoneInfoNotFoundError, ValueError, AttributeError, KeyError):
             errors.append(f"Invalid timezone: {timezone}")
         
         return errors
@@ -46,7 +46,7 @@ class DateTimePlugin(PluginBase):
         """Fetch current date and time data."""
         try:
             timezone_str = self.config.get("timezone", "America/Los_Angeles")
-            tz = pytz.timezone(timezone_str)
+            tz = ZoneInfo(timezone_str)
             now = datetime.now(tz)
             
             data = {

--- a/plugins/date_time/tests/test_plugin.py
+++ b/plugins/date_time/tests/test_plugin.py
@@ -5,7 +5,7 @@ from unittest.mock import patch, MagicMock
 from datetime import datetime
 import json
 from pathlib import Path
-import pytz
+from zoneinfo import ZoneInfo
 
 from plugins.date_time import DateTimePlugin
 from src.plugins.base import PluginResult
@@ -59,8 +59,8 @@ class TestDateTimePlugin:
         """Test fetch_data returns all expected variables."""
         # Mock datetime to return a specific date/time
         mock_now = datetime(2025, 1, 15, 14, 30, 0)  # Wednesday, Jan 15, 2025, 2:30 PM
-        tz = pytz.timezone("America/Los_Angeles")
-        mock_now = tz.localize(mock_now)
+        tz = ZoneInfo("America/Los_Angeles")
+        mock_now = mock_now.replace(tzinfo=tz)
         mock_datetime.now.return_value = mock_now
         
         plugin = DateTimePlugin(sample_manifest)
@@ -100,8 +100,8 @@ class TestDateTimePlugin:
         """Test time format variables."""
         # Test at 2:30 PM (14:30)
         mock_now = datetime(2025, 1, 15, 14, 30, 0)
-        tz = pytz.timezone("America/Los_Angeles")
-        mock_now = tz.localize(mock_now)
+        tz = ZoneInfo("America/Los_Angeles")
+        mock_now = mock_now.replace(tzinfo=tz)
         mock_datetime.now.return_value = mock_now
         
         plugin = DateTimePlugin(sample_manifest)
@@ -116,8 +116,8 @@ class TestDateTimePlugin:
     def test_fetch_data_time_formats_midnight(self, mock_datetime, sample_manifest, sample_config):
         """Test time formats at midnight (12:00 AM)."""
         mock_now = datetime(2025, 1, 15, 0, 0, 0)
-        tz = pytz.timezone("America/Los_Angeles")
-        mock_now = tz.localize(mock_now)
+        tz = ZoneInfo("America/Los_Angeles")
+        mock_now = mock_now.replace(tzinfo=tz)
         mock_datetime.now.return_value = mock_now
         
         plugin = DateTimePlugin(sample_manifest)
@@ -131,8 +131,8 @@ class TestDateTimePlugin:
     def test_fetch_data_time_formats_noon(self, mock_datetime, sample_manifest, sample_config):
         """Test time formats at noon (12:00 PM)."""
         mock_now = datetime(2025, 1, 15, 12, 0, 0)
-        tz = pytz.timezone("America/Los_Angeles")
-        mock_now = tz.localize(mock_now)
+        tz = ZoneInfo("America/Los_Angeles")
+        mock_now = mock_now.replace(tzinfo=tz)
         mock_datetime.now.return_value = mock_now
         
         plugin = DateTimePlugin(sample_manifest)
@@ -146,8 +146,8 @@ class TestDateTimePlugin:
     def test_fetch_data_date_formats(self, mock_datetime, sample_manifest, sample_config):
         """Test US date format variables."""
         mock_now = datetime(2025, 1, 15, 14, 30, 0)
-        tz = pytz.timezone("America/Los_Angeles")
-        mock_now = tz.localize(mock_now)
+        tz = ZoneInfo("America/Los_Angeles")
+        mock_now = mock_now.replace(tzinfo=tz)
         mock_datetime.now.return_value = mock_now
         
         plugin = DateTimePlugin(sample_manifest)
@@ -163,8 +163,8 @@ class TestDateTimePlugin:
         """Test month format variables."""
         # Test January (month 1)
         mock_now = datetime(2025, 1, 15, 14, 30, 0)
-        tz = pytz.timezone("America/Los_Angeles")
-        mock_now = tz.localize(mock_now)
+        tz = ZoneInfo("America/Los_Angeles")
+        mock_now = mock_now.replace(tzinfo=tz)
         mock_datetime.now.return_value = mock_now
         
         plugin = DateTimePlugin(sample_manifest)
@@ -178,7 +178,7 @@ class TestDateTimePlugin:
         
         # Test December (month 12)
         mock_now = datetime(2025, 12, 25, 14, 30, 0)
-        mock_now = tz.localize(mock_now)
+        mock_now = mock_now.replace(tzinfo=tz)
         mock_datetime.now.return_value = mock_now
         
         result = plugin.fetch_data()
@@ -191,8 +191,8 @@ class TestDateTimePlugin:
     def test_fetch_data_timezone_info(self, mock_datetime, sample_manifest, sample_config):
         """Test timezone-related variables."""
         mock_now = datetime(2025, 1, 15, 14, 30, 0)
-        tz = pytz.timezone("America/New_York")
-        mock_now = tz.localize(mock_now)
+        tz = ZoneInfo("America/New_York")
+        mock_now = mock_now.replace(tzinfo=tz)
         mock_datetime.now.return_value = mock_now
         
         config = sample_config.copy()
@@ -210,8 +210,8 @@ class TestDateTimePlugin:
         """Test day of week variable."""
         # Wednesday
         mock_now = datetime(2025, 1, 15, 14, 30, 0)  # Jan 15, 2025 is a Wednesday
-        tz = pytz.timezone("America/Los_Angeles")
-        mock_now = tz.localize(mock_now)
+        tz = ZoneInfo("America/Los_Angeles")
+        mock_now = mock_now.replace(tzinfo=tz)
         mock_datetime.now.return_value = mock_now
         
         plugin = DateTimePlugin(sample_manifest)
@@ -226,8 +226,8 @@ class TestDateTimePlugin:
     def test_fetch_data_variables_match_manifest(self, mock_datetime, sample_manifest, sample_config):
         """Test that fetch_data() output keys match the manifest-declared variables."""
         mock_now = datetime(2025, 1, 15, 14, 30, 0)
-        tz = pytz.timezone("America/Los_Angeles")
-        mock_now = tz.localize(mock_now)
+        tz = ZoneInfo("America/Los_Angeles")
+        mock_now = mock_now.replace(tzinfo=tz)
         mock_datetime.now.return_value = mock_now
 
         plugin = DateTimePlugin(sample_manifest)
@@ -270,8 +270,8 @@ class TestDateTimePlugin:
     def test_get_formatted_display(self, mock_datetime, sample_manifest, sample_config):
         """Test formatted display output."""
         mock_now = datetime(2025, 1, 15, 14, 30, 0)
-        tz = pytz.timezone("America/Los_Angeles")
-        mock_now = tz.localize(mock_now)
+        tz = ZoneInfo("America/Los_Angeles")
+        mock_now = mock_now.replace(tzinfo=tz)
         mock_datetime.now.return_value = mock_now
         
         plugin = DateTimePlugin(sample_manifest)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ classifiers = [
 dependencies = [
     "requests>=2.32.0",
     "python-dateutil>=2.9.0",
-    "pytz>=2024.2",
     "fastapi>=0.125.0",
     "uvicorn[standard]>=0.34.0",
     "pydantic>=2.10.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ requests>=2.32.0
 pyyaml>=6.0.2
 python-dotenv>=1.0.1
 schedule>=1.2.2
-pytz>=2024.2
 defusedxml>=0.7.1
 
 # API Server dependencies

--- a/scripts/generate_sun_art_images.py
+++ b/scripts/generate_sun_art_images.py
@@ -31,7 +31,6 @@ with open(manifest_path, 'r') as f:
     manifest = json.load(f)
 from src.board_chars import BoardChars
 from datetime import datetime
-import pytz
 
 # Official FiestaBoard color hex values (from web/src/lib/board-colors.ts)
 COLOR_HEX = {

--- a/src/time_service.py
+++ b/src/time_service.py
@@ -8,15 +8,32 @@ in the application, including:
 - Timestamp generation and formatting for logs
 
 All time-sensitive code should use this service instead of directly using
-datetime or pytz to ensure consistency and testability.
+datetime or zoneinfo to ensure consistency and testability.
 """
 
 import logging
-from datetime import datetime, time
+from datetime import datetime, time, timezone as _dt_timezone
 from typing import Optional
-import pytz
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 logger = logging.getLogger(__name__)
+
+# Public UTC singleton used throughout the service. Using datetime.timezone.utc
+# (rather than ZoneInfo("UTC")) keeps equality checks simple and avoids the
+# need for tzdata on any target platform.
+UTC = _dt_timezone.utc
+
+
+def _resolve_timezone(name: str):
+    """Resolve an IANA timezone name to a ZoneInfo, falling back to UTC.
+
+    Returns a tuple ``(tzinfo, ok)`` where ``ok`` is ``False`` when the name
+    could not be resolved (the caller can decide how to log/respond).
+    """
+    try:
+        return ZoneInfo(name), True
+    except (ZoneInfoNotFoundError, ValueError):
+        return UTC, False
 
 
 class TimeService:
@@ -29,11 +46,10 @@ class TimeService:
             default_timezone: Default IANA timezone name (e.g., "America/Los_Angeles")
         """
         self.default_timezone = default_timezone
-        try:
-            self._default_tz = pytz.timezone(default_timezone)
-        except pytz.exceptions.UnknownTimeZoneError:
+        tz, ok = _resolve_timezone(default_timezone)
+        if not ok:
             logger.warning(f"Unknown default timezone: {default_timezone}, using UTC")
-            self._default_tz = pytz.UTC
+        self._default_tz = tz
     
     # Core time operations
     
@@ -43,7 +59,7 @@ class TimeService:
         Returns:
             Current datetime in UTC timezone
         """
-        return datetime.now(pytz.UTC)
+        return datetime.now(UTC)
     
     def get_current_time(self, timezone: Optional[str] = None) -> datetime:
         """Get current time in specified timezone.
@@ -57,9 +73,8 @@ class TimeService:
         if timezone is None:
             tz = self._default_tz
         else:
-            try:
-                tz = pytz.timezone(timezone)
-            except pytz.exceptions.UnknownTimeZoneError:
+            tz, ok = _resolve_timezone(timezone)
+            if not ok:
                 logger.warning(f"Unknown timezone: {timezone}, using default")
                 tz = self._default_tz
         
@@ -111,7 +126,7 @@ class TimeService:
             utc_dt = naive_dt - timedelta(minutes=offset_total_minutes)
             
             # Make it timezone aware (UTC)
-            utc_dt = pytz.UTC.localize(utc_dt)
+            utc_dt = utc_dt.replace(tzinfo=UTC)
             
             return utc_dt
             
@@ -167,11 +182,9 @@ class TimeService:
             logger.error("local_time and timezone are required")
             return "00:00+00:00"
         
-        try:
-            tz = pytz.timezone(timezone)
-        except pytz.exceptions.UnknownTimeZoneError:
+        tz, ok = _resolve_timezone(timezone)
+        if not ok:
             logger.warning(f"Unknown timezone: {timezone}, using UTC")
-            tz = pytz.UTC
         
         try:
             # Parse local time
@@ -192,13 +205,11 @@ class TimeService:
             
             # Create datetime for today at this time in the specified timezone
             now_utc = self.get_current_utc()
-            naive_dt = datetime(now_utc.year, now_utc.month, now_utc.day, hour, minute)
-            
-            # Localize to the specified timezone
-            local_dt = tz.localize(naive_dt)
-            
+            # Attach timezone directly; zoneinfo handles DST via fold semantics
+            local_dt = datetime(now_utc.year, now_utc.month, now_utc.day, hour, minute, tzinfo=tz)
+
             # Convert to UTC
-            utc_dt = local_dt.astimezone(pytz.UTC)
+            utc_dt = local_dt.astimezone(UTC)
             
             # Format as ISO time string
             return utc_dt.strftime("%H:%M+00:00")
@@ -221,11 +232,9 @@ class TimeService:
             logger.error("utc_iso and timezone are required")
             return "00:00"
         
-        try:
-            tz = pytz.timezone(timezone)
-        except pytz.exceptions.UnknownTimeZoneError:
+        tz, ok = _resolve_timezone(timezone)
+        if not ok:
             logger.warning(f"Unknown timezone: {timezone}, using UTC")
-            tz = pytz.UTC
         
         utc_dt = self.parse_iso_time(utc_iso)
         if utc_dt is None:
@@ -267,14 +276,12 @@ class TimeService:
             
             # Ensure it's UTC-aware
             if utc_dt.tzinfo is None:
-                utc_dt = pytz.UTC.localize(utc_dt)
+                utc_dt = utc_dt.replace(tzinfo=UTC)
             
             # Convert to target timezone
-            try:
-                tz = pytz.timezone(timezone)
-            except pytz.exceptions.UnknownTimeZoneError:
+            tz, ok = _resolve_timezone(timezone)
+            if not ok:
                 logger.warning(f"Unknown timezone: {timezone}, using UTC")
-                tz = pytz.UTC
             
             local_dt = utc_dt.astimezone(tz)
             
@@ -323,4 +330,3 @@ def reset_time_service():
     """Reset the time service singleton (primarily for testing)."""
     global _time_service
     _time_service = None
-

--- a/tests/test_integration_multi_features.py
+++ b/tests/test_integration_multi_features.py
@@ -2,9 +2,8 @@
 
 import pytest
 import tempfile
-import pytz
 from pathlib import Path
-from datetime import datetime, time
+from datetime import datetime, time, timezone
 from unittest.mock import Mock, patch
 from src.templates.engine import TemplateEngine
 from src.main import DisplayService
@@ -363,7 +362,7 @@ class TestScheduleModeIntegration:
                             # Mock TimeService to return Monday 12:00 (within schedule)
                             # Create a mock datetime for Monday 12:00
                             mock_datetime_obj = datetime(2025, 1, 13, 12, 0, 0)  # Monday Jan 13, 2025 at 12:00
-                            mock_datetime_obj = pytz.UTC.localize(mock_datetime_obj)
+                            mock_datetime_obj = mock_datetime_obj.replace(tzinfo=timezone.utc)
                             
                             mock_time_service = Mock()
                             mock_time_service.get_current_time.return_value = mock_datetime_obj
@@ -426,7 +425,7 @@ class TestScheduleModeIntegration:
                             # Mock TimeService to return Monday 20:00 (outside schedule, should use default)
                             # Create a mock datetime for Monday 20:00
                             mock_datetime_obj = datetime(2025, 1, 13, 20, 0, 0)  # Monday Jan 13, 2025 at 20:00
-                            mock_datetime_obj = pytz.UTC.localize(mock_datetime_obj)
+                            mock_datetime_obj = mock_datetime_obj.replace(tzinfo=timezone.utc)
                             
                             mock_time_service = Mock()
                             mock_time_service.get_current_time.return_value = mock_datetime_obj
@@ -482,7 +481,7 @@ class TestScheduleModeIntegration:
                             # Mock TimeService to return Tuesday 12:00 (no schedule for Tuesday)
                             # Create a mock datetime for Tuesday 12:00
                             mock_datetime_obj = datetime(2025, 1, 14, 12, 0, 0)  # Tuesday Jan 14, 2025 at 12:00
-                            mock_datetime_obj = pytz.UTC.localize(mock_datetime_obj)
+                            mock_datetime_obj = mock_datetime_obj.replace(tzinfo=timezone.utc)
                             
                             mock_time_service = Mock()
                             mock_time_service.get_current_time.return_value = mock_datetime_obj

--- a/tests/test_schedule_board_id_bug.py
+++ b/tests/test_schedule_board_id_bug.py
@@ -7,9 +7,8 @@ silently ignored because the polling loop only looked for board_id="".
 """
 
 import pytest
-from datetime import datetime, time
+from datetime import datetime, time, timezone
 from unittest.mock import Mock, patch, MagicMock
-import pytz
 
 
 class TestCheckAndSendActivePageBoardId:
@@ -68,7 +67,7 @@ class TestCheckAndSendActivePageBoardId:
         """check_and_send_active_page must pass the first board's ID to get_active_page_id."""
         svc, schedule_service = service_with_board
 
-        mock_now = datetime(2025, 6, 15, 12, 0, tzinfo=pytz.timezone("UTC"))
+        mock_now = datetime(2025, 6, 15, 12, 0, tzinfo=timezone.utc)
         mock_time_service = Mock()
         mock_time_service.get_current_time.return_value = mock_now
 
@@ -120,7 +119,7 @@ class TestGetActiveRefIdBoardId:
         """_get_active_ref_id must pass the first board's ID to get_active_page_id."""
         svc, schedule_service = service_with_board
 
-        mock_now = datetime(2025, 6, 15, 14, 0, tzinfo=pytz.timezone("UTC"))
+        mock_now = datetime(2025, 6, 15, 14, 0, tzinfo=timezone.utc)
         mock_time_service = Mock()
         mock_time_service.get_current_time.return_value = mock_now
 

--- a/tests/test_time_service.py
+++ b/tests/test_time_service.py
@@ -1,11 +1,13 @@
 """Tests for TimeService."""
 
 import pytest
-from datetime import datetime, time
+from datetime import datetime, time, timezone
+
 from unittest.mock import Mock, patch
-import pytz
 
 from src.time_service import TimeService, get_time_service, reset_time_service
+
+UTC = timezone.utc
 
 
 class TestTimeServiceCore:
@@ -16,7 +18,7 @@ class TestTimeServiceCore:
         service = TimeService()
         utc_now = service.get_current_utc()
         
-        assert utc_now.tzinfo == pytz.UTC
+        assert utc_now.tzinfo == UTC
         assert isinstance(utc_now, datetime)
     
     def test_get_current_time_default_timezone(self):
@@ -52,7 +54,7 @@ class TestTimeServiceSilenceMode:
         
         # Mock get_current_utc to return 12:00 UTC
         with patch.object(service, 'get_current_utc') as mock_get_utc:
-            mock_get_utc.return_value = datetime(2024, 1, 15, 12, 0, tzinfo=pytz.UTC)
+            mock_get_utc.return_value = datetime(2024, 1, 15, 12, 0, tzinfo=UTC)
             
             # Window: 10:00 UTC to 14:00 UTC
             result = service.is_time_in_window("10:00+00:00", "14:00+00:00")
@@ -65,7 +67,7 @@ class TestTimeServiceSilenceMode:
         
         # Mock get_current_utc to return 15:00 UTC
         with patch.object(service, 'get_current_utc') as mock_get_utc:
-            mock_get_utc.return_value = datetime(2024, 1, 15, 15, 0, tzinfo=pytz.UTC)
+            mock_get_utc.return_value = datetime(2024, 1, 15, 15, 0, tzinfo=UTC)
             
             # Window: 10:00 UTC to 14:00 UTC
             result = service.is_time_in_window("10:00+00:00", "14:00+00:00")
@@ -78,7 +80,7 @@ class TestTimeServiceSilenceMode:
         
         # Mock get_current_utc to return 22:00 UTC
         with patch.object(service, 'get_current_utc') as mock_get_utc:
-            mock_get_utc.return_value = datetime(2024, 1, 15, 22, 0, tzinfo=pytz.UTC)
+            mock_get_utc.return_value = datetime(2024, 1, 15, 22, 0, tzinfo=UTC)
             
             # Window: 20:00 UTC to 08:00 UTC (spans midnight)
             result = service.is_time_in_window("20:00+00:00", "08:00+00:00")
@@ -91,7 +93,7 @@ class TestTimeServiceSilenceMode:
         
         # Mock get_current_utc to return 06:00 UTC
         with patch.object(service, 'get_current_utc') as mock_get_utc:
-            mock_get_utc.return_value = datetime(2024, 1, 15, 6, 0, tzinfo=pytz.UTC)
+            mock_get_utc.return_value = datetime(2024, 1, 15, 6, 0, tzinfo=UTC)
             
             # Window: 20:00 UTC to 08:00 UTC (spans midnight)
             result = service.is_time_in_window("20:00+00:00", "08:00+00:00")
@@ -104,7 +106,7 @@ class TestTimeServiceSilenceMode:
         
         # Mock get_current_utc to return 12:00 UTC
         with patch.object(service, 'get_current_utc') as mock_get_utc:
-            mock_get_utc.return_value = datetime(2024, 1, 15, 12, 0, tzinfo=pytz.UTC)
+            mock_get_utc.return_value = datetime(2024, 1, 15, 12, 0, tzinfo=UTC)
             
             # Window: 20:00 UTC to 08:00 UTC (spans midnight)
             result = service.is_time_in_window("20:00+00:00", "08:00+00:00")
@@ -222,7 +224,7 @@ class TestTimeServiceParseIsoTime:
         
         assert result is not None
         assert isinstance(result, datetime)
-        assert result.tzinfo == pytz.UTC
+        assert result.tzinfo == UTC
     
     def test_parse_iso_time_with_negative_offset(self):
         """Test parsing time with negative offset (e.g., PST)."""
@@ -307,7 +309,7 @@ class TestTimeServiceInitialization:
         service = TimeService(default_timezone="Invalid/Timezone")
         
         # Should still initialize, using UTC as fallback
-        assert service._default_tz == pytz.UTC
+        assert service._default_tz == UTC
 
 
 class TestParseIsoTimeErrorHandling:


### PR DESCRIPTION
pytz was causing intermittent errors (see #602). Python 3.9+ ships `zoneinfo` (IANA time zone support) in the standard library, so we can drop the third-party dependency entirely.

Replacements applied across src, plugins, tests, and docs:
- `pytz.UTC` / `pytz.timezone("UTC")` -> `datetime.timezone.utc`
- `pytz.timezone(name)` -> `zoneinfo.ZoneInfo(name)`
- `pytz.exceptions.UnknownTimeZoneError` -> `(ZoneInfoNotFoundError, ValueError)`
- `tz.localize(naive_dt)` -> `naive_dt.replace(tzinfo=tz)` (zoneinfo is DST-aware natively and has no `.localize()`)

Also removes `pytz` from requirements.txt and pyproject.toml, and cleans up an unused `import pytz` in scripts/generate_sun_art_images.py.

Verified: full pytest suite green for all touched modules (time_service, date_time, countdown, integration + schedule tests). The 3 pre-existing failures in plugins/_template are unrelated (missing `get_config` from the V3 plugin base refactor).

Fixes #602 