### PR TITLE
fix: resolve pointer-events and scroll issues for dropdowns inside Sheet sidebars

### DIFF
--- a/web/src/__tests__/schedule-entry-form-select.test.tsx
+++ b/web/src/__tests__/schedule-entry-form-select.test.tsx
@@ -1,0 +1,223 @@
+/**
+ * Tests for Select dropdown interactions (mouse and keyboard) inside a Sheet.
+ *
+ * Root cause of the original bug: Radix UI Dialog (Sheet) sets
+ * `document.body.style.pointerEvents = "none"` in modal mode. Radix Select
+ * portals its content into document.body, which then inherits that rule —
+ * so mouse clicks on Select options are silently swallowed. Keyboard events
+ * still work because they dispatch directly to the focused element.
+ *
+ * Fix: `modal={false}` on each Select nested inside a Sheet. The Sheet
+ * already handles modal behavior; the Select doesn't need to participate.
+ *
+ * These tests render ScheduleEntryForm inside an open Sheet to replicate
+ * the real usage context and assert that both mouse-click and keyboard
+ * interactions work correctly.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ScheduleEntryForm } from "@/components/schedule-entry-form";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+
+const mockPages = [
+  { id: "page-1", name: "Morning Dashboard" },
+  { id: "page-2", name: "Evening Dashboard" },
+];
+
+/** Wrap the form in an open Sheet, matching the real schedule page context. */
+function renderInSheet(props: Parameters<typeof ScheduleEntryForm>[0]) {
+  return render(
+    <Sheet open={true}>
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle>Add Schedule</SheetTitle>
+          <SheetDescription>Configure schedule entry</SheetDescription>
+        </SheetHeader>
+        <ScheduleEntryForm {...props} />
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Page / Carousel Select
+// ---------------------------------------------------------------------------
+describe("ScheduleEntryForm page Select inside Sheet", () => {
+  it("mouse-click: clicking a page option selects it", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    const onCancel = vi.fn();
+
+    renderInSheet({ pages: mockPages, onSubmit, onCancel });
+
+    // Use label association to find the page combobox specifically
+    const trigger = screen.getByLabelText("Page or Carousel");
+    await user.click(trigger);
+
+    // Wait for the Select listbox to appear
+    await waitFor(() => {
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+    });
+
+    // Click an option with mouse
+    const option = screen.getByRole("option", { name: "Morning Dashboard" });
+    await user.click(option);
+
+    // The combobox should now display the selected page name
+    await waitFor(() => {
+      expect(trigger).toHaveTextContent("Morning Dashboard");
+    });
+  });
+
+  it("keyboard: ArrowDown then Enter selects a page option", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    const onCancel = vi.fn();
+
+    renderInSheet({ pages: mockPages, onSubmit, onCancel });
+
+    const trigger = screen.getByLabelText("Page or Carousel");
+    await user.click(trigger);
+
+    await waitFor(() => {
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+    });
+
+    // Navigate down and confirm
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => {
+      // Should have selected one of the pages (first highlighted)
+      expect(trigger).not.toHaveTextContent(/select page/i);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Start-time Select
+// ---------------------------------------------------------------------------
+describe("ScheduleEntryForm start-time Select inside Sheet", () => {
+  it("mouse-click: clicking a time option updates start time", async () => {
+    const user = userEvent.setup();
+
+    renderInSheet({
+      pages: mockPages,
+      prefillStartTime: "09:00",
+      prefillEndTime: "17:00",
+      onSubmit: vi.fn(),
+      onCancel: vi.fn(),
+    });
+
+    const startTimeTrigger = screen.getByLabelText("Start Time");
+    await user.click(startTimeTrigger);
+
+    await waitFor(() => {
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+    });
+
+    // Click the 10:00 option
+    const option = screen.getByRole("option", { name: "10:00" });
+    await user.click(option);
+
+    await waitFor(() => {
+      expect(startTimeTrigger).toHaveTextContent("10:00");
+    });
+  });
+
+  it("keyboard: ArrowDown then Enter updates start time", async () => {
+    const user = userEvent.setup();
+
+    renderInSheet({
+      pages: mockPages,
+      prefillStartTime: "09:00",
+      prefillEndTime: "17:00",
+      onSubmit: vi.fn(),
+      onCancel: vi.fn(),
+    });
+
+    const startTimeTrigger = screen.getByLabelText("Start Time");
+
+    // Open via Space key (Radix Select standard keyboard trigger)
+    await user.click(startTimeTrigger);
+
+    await waitFor(() => {
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+    });
+
+    // Move to next option and select
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{Enter}");
+
+    // The trigger should show a different time (next minute after 09:00)
+    await waitFor(() => {
+      expect(startTimeTrigger).toHaveTextContent("09:01");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-time Select
+// ---------------------------------------------------------------------------
+describe("ScheduleEntryForm end-time Select inside Sheet", () => {
+  it("mouse-click: clicking a time option updates end time", async () => {
+    const user = userEvent.setup();
+
+    renderInSheet({
+      pages: mockPages,
+      prefillStartTime: "09:00",
+      prefillEndTime: "17:00",
+      onSubmit: vi.fn(),
+      onCancel: vi.fn(),
+    });
+
+    const endTimeTrigger = screen.getByLabelText("End Time");
+    await user.click(endTimeTrigger);
+
+    await waitFor(() => {
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+    });
+
+    // Click the 18:00 option
+    const option = screen.getByRole("option", { name: "18:00" });
+    await user.click(option);
+
+    await waitFor(() => {
+      expect(endTimeTrigger).toHaveTextContent("18:00");
+    });
+  });
+
+  it("keyboard: ArrowDown then Enter updates end time", async () => {
+    const user = userEvent.setup();
+
+    renderInSheet({
+      pages: mockPages,
+      prefillStartTime: "09:00",
+      prefillEndTime: "17:00",
+      onSubmit: vi.fn(),
+      onCancel: vi.fn(),
+    });
+
+    const endTimeTrigger = screen.getByLabelText("End Time");
+    await user.click(endTimeTrigger);
+
+    await waitFor(() => {
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+    });
+
+    await user.keyboard("{ArrowDown}");
+    await user.keyboard("{Enter}");
+
+    await waitFor(() => {
+      expect(endTimeTrigger).toHaveTextContent("17:01");
+    });
+  });
+});

--- a/web/src/app/carousels/page.tsx
+++ b/web/src/app/carousels/page.tsx
@@ -158,6 +158,7 @@ function CarouselForm({ carousel, pages, onSubmit, onCancel, onDelete }: Carouse
         <Select
           value={String(intervalSeconds)}
           onValueChange={(v) => setIntervalSeconds(Number(v))}
+          modal={false}
         >
           <SelectTrigger>
             <SelectValue />

--- a/web/src/components/plugin-settings/schema-form.tsx
+++ b/web/src/components/plugin-settings/schema-form.tsx
@@ -137,12 +137,13 @@ function StringField({ name, property, value, onChange, required, disabled }: Fi
           value={selectValue}
           onValueChange={handleValueChange}
           disabled={disabled}
+          modal={false}
         >
           <SelectTrigger id={name}>
             <SelectValue placeholder={property["ui:placeholder"] || `Select ${property.title || name}`} />
           </SelectTrigger>
           <SelectContent 
-            className="max-h-[300px] z-[120] pointer-events-auto"
+            className="max-h-[300px] z-[120]"
             disableHeightConstraint={allOptions.length > 1}
           >
             {selectItems}

--- a/web/src/components/schedule-entry-form.tsx
+++ b/web/src/components/schedule-entry-form.tsx
@@ -158,7 +158,7 @@ export function ScheduleEntryForm({
       {/* Page / Carousel Selection */}
       <div className="space-y-2">
         <Label htmlFor="page">{t("scheduleEntryForm.pageOrCarousel")}</Label>
-        <Select value={pageId} onValueChange={setPageId}>
+        <Select value={pageId} onValueChange={setPageId} modal={false}>
           <SelectTrigger id="page">
             <SelectValue placeholder={t("scheduleEntryForm.selectPageOrCarousel")} />
           </SelectTrigger>
@@ -191,7 +191,7 @@ export function ScheduleEntryForm({
         <div className="grid grid-cols-2 gap-4">
           <div className="space-y-2">
             <Label htmlFor="start-time">{t("scheduleEntryForm.startTime")}</Label>
-            <Select value={startTime} onValueChange={setStartTime}>
+            <Select value={startTime} onValueChange={setStartTime} modal={false}>
               <SelectTrigger id="start-time">
                 <SelectValue />
               </SelectTrigger>
@@ -208,7 +208,7 @@ export function ScheduleEntryForm({
           {hasEndTime && (
             <div className="space-y-2">
               <Label htmlFor="end-time">{t("scheduleEntryForm.endTime")}</Label>
-              <Select value={endTime} onValueChange={setEndTime}>
+              <Select value={endTime} onValueChange={setEndTime} modal={false}>
                 <SelectTrigger id="end-time">
                   <SelectValue />
                 </SelectTrigger>

--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -84,6 +84,7 @@ const SelectContent = React.forwardRef<
           className
         )}
         position={position}
+        style={{ pointerEvents: "auto" }}
         {...props}
       >
         <SelectScrollUpButton />

--- a/web/src/components/ui/timezone-picker.tsx
+++ b/web/src/components/ui/timezone-picker.tsx
@@ -94,11 +94,54 @@ export function TimezonePicker({
       }
     };
 
+    const handleScroll = (event: Event) => {
+      // Don't reposition when the scroll is happening inside the dropdown list itself
+      if (listRef.current?.contains(event.target as Node)) {
+        return;
+      }
+      if (containerRef.current) {
+        const rect = containerRef.current.getBoundingClientRect();
+        const dropdownMaxHeight = 240;
+        const spaceBelow = window.innerHeight - rect.bottom;
+        const top = spaceBelow >= dropdownMaxHeight || spaceBelow >= rect.top
+          ? rect.bottom + 4
+          : rect.top - dropdownMaxHeight - 4;
+        setDropdownStyle({
+          position: "fixed",
+          top,
+          left: rect.left,
+          width: rect.width,
+          zIndex: 9999,
+          pointerEvents: "auto",
+        });
+      }
+    };
+
     if (isOpen) {
       document.addEventListener("mousedown", handleClickOutside);
-      return () => document.removeEventListener("mousedown", handleClickOutside);
+      // Reposition dropdown when any ancestor scrolls (e.g. Sheet with overflow-y-auto)
+      document.addEventListener("scroll", handleScroll, true);
+      return () => {
+        document.removeEventListener("mousedown", handleClickOutside);
+        document.removeEventListener("scroll", handleScroll, true);
+      };
     }
   }, [isOpen, value]);
+
+  // Prevent Radix scroll-lock (react-remove-scroll) from blocking wheel events inside
+  // the portal dropdown. The Sheet/Dialog modal adds a document-level wheel listener
+  // that calls preventDefault() on events outside the modal DOM tree. Our portal is
+  // appended to document.body, so react-remove-scroll treats it as "outside".
+  // Stopping propagation on the list element prevents the event from reaching document.
+  useEffect(() => {
+    const el = listRef.current;
+    if (!el || !isOpen) return;
+    const handleWheel = (e: WheelEvent) => {
+      e.stopPropagation();
+    };
+    el.addEventListener("wheel", handleWheel);
+    return () => el.removeEventListener("wheel", handleWheel);
+  }, [isOpen]);
 
   const handleSelect = (timezoneValue: string) => {
     onChange(timezoneValue);
@@ -139,6 +182,7 @@ export function TimezonePicker({
         left: rect.left,
         width: rect.width,
         zIndex: 9999,
+        pointerEvents: "auto",
       });
     }
   };


### PR DESCRIPTION
## Problem

Several dropdown components were broken when used inside Sheet (slide-out sidebar) components:

1. **Select dropdowns were unclickable** — Radix Dialog/Sheet sets `document.body { pointer-events: none }` when open. Portaled Select dropdowns inherit this and swallow all mouse clicks. Keyboard navigation still worked since key events go directly to focused elements.

2. **TimezonePicker dropdown was unclickable** — Same body pointer-events issue. The custom `createPortal` dropdown rendered in `document.body` also had no mouse events.

3. **TimezonePicker dropdown mis-positioned on scroll** — When the Sheet content scrolled, the fixed-position portal dropdown stayed at its original coordinates rather than tracking the trigger element.

4. **TimezonePicker dropdown unscrollable via mouse wheel** — Radix's `react-remove-scroll` (used by Sheet) adds a document-level `wheel` listener that calls `preventDefault()` on events outside the modal DOM tree. Since the portal is in `document.body` (outside Sheet's React tree), wheel events were blocked. Dragging the scrollbar still worked.

## Solution

### Radix Select inside Sheet
- Add `style={{ pointerEvents: "auto" }}` to `SelectPrimitive.Content` in the shared `select.tsx` component — directly overrides the body's rule for all portaled Select dropdowns
- Add `modal={false}` to Select components in `schedule-entry-form.tsx`, `carousels/page.tsx`, and `plugin-settings/schema-form.tsx` to prevent `DismissableLayer` from fighting over pointer-events

### TimezonePicker custom portal
- Add `pointerEvents: "auto"` to the portal `dropdownStyle` so mouse clicks register
- Add a capture-phase `scroll` listener to reposition the dropdown when any ancestor scrolls (e.g. Sheet), skipping repositioning when the scroll originates inside the dropdown itself
- Add a `wheel` event `stopPropagation()` listener on the portal element to prevent `react-remove-scroll` from blocking mouse wheel scroll inside the dropdown list

## Tests

Added `web/src/__tests__/schedule-entry-form-select.test.tsx` with 6 tests covering both mouse-click and keyboard interaction for all three Select components (page picker, start time, end time) inside a Sheet.

All 678 existing tests continue to pass (48 test files).