### PR TITLE
Potential fix for code scanning alert no. 23: Full server-side request forgery

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -57,11 +57,13 @@ def _validate_request_url(
 ) -> None:
     """Validate a user-supplied URL before using it in an HTTP request.
 
-    Blocks credentialed URLs (``user:pass@host``) and unsupported schemes
-    so the URL can't be abused for SSRF/credential leaks.  Raises
-    :class:`HTTPException` (status 400) when the URL is rejected.
+    Blocks credentialed URLs (``user:pass@host``), unsupported schemes and
+    non-public destinations (loopback/private/link-local/etc.) to reduce SSRF
+    risk. Raises :class:`HTTPException` (status 400) when the URL is rejected.
     """
     from urllib.parse import urlparse
+    import ipaddress
+    import socket
 
     if not isinstance(url, str) or not url:
         raise HTTPException(status_code=400, detail="URL is required")
@@ -85,6 +87,35 @@ def _validate_request_url(
         raise HTTPException(
             status_code=400, detail="URL must not contain credentials"
         )
+
+    host = parsed.hostname.strip().lower()
+    if host == "localhost" or host.endswith(".localhost") or host.endswith(".local"):
+        raise HTTPException(status_code=400, detail="URL host is not allowed")
+
+    def _is_non_public_ip(ip_str: str) -> bool:
+        ip_obj = ipaddress.ip_address(ip_str)
+        return (
+            ip_obj.is_private
+            or ip_obj.is_loopback
+            or ip_obj.is_link_local
+            or ip_obj.is_multicast
+            or ip_obj.is_reserved
+            or ip_obj.is_unspecified
+        )
+
+    try:
+        if _is_non_public_ip(host):
+            raise HTTPException(status_code=400, detail="URL host resolves to a non-public IP")
+    except ValueError:
+        try:
+            infos = socket.getaddrinfo(host, parsed.port or (443 if parsed.scheme == "https" else 80))
+        except socket.gaierror:
+            raise HTTPException(status_code=400, detail="URL host could not be resolved")
+
+        for info in infos:
+            resolved_ip = info[4][0]
+            if _is_non_public_ip(resolved_ip):
+                raise HTTPException(status_code=400, detail="URL host resolves to a non-public IP")
 
 
 # Hostnames are restricted to RFC 1123 labels (letters, digits, hyphens) and

--- a/tests/test_api_coverage_extended.py
+++ b/tests/test_api_coverage_extended.py
@@ -590,6 +590,9 @@ class TestPluginManagement:
 # ---------------------------------------------------------------------------
 
 class TestGenericDataTestFetch:
+    # Public IP returned by the mocked DNS resolver (93.184.216.34 = example.com)
+    _PUBLIC_ADDR_INFO = [(None, None, None, None, ("93.184.216.34", 443))]
+
     def test_fetch_json_success(self, client):
         mock_resp = Mock()
         mock_resp.raise_for_status.return_value = None
@@ -599,6 +602,7 @@ class TestGenericDataTestFetch:
         mock_cm.get_general.return_value = {"timezone": "UTC"}
         with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
              patch("src.api_server.get_config_manager", return_value=mock_cm), \
+             patch("socket.getaddrinfo", return_value=self._PUBLIC_ADDR_INFO), \
              patch("requests.request", return_value=mock_resp):
             resp = client.post("/generic-data/test-fetch", json={"url": "https://api.example.com/data", "format": "json"})
         assert resp.status_code == 200
@@ -626,6 +630,7 @@ class TestGenericDataTestFetch:
         mock_cm.get_general.return_value = {}
         with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
              patch("src.api_server.get_config_manager", return_value=mock_cm), \
+             patch("socket.getaddrinfo", return_value=self._PUBLIC_ADDR_INFO), \
              patch("requests.request", side_effect=req.exceptions.Timeout("timeout")):
             resp = client.post("/generic-data/test-fetch", json={"url": "https://api.example.com/slow"})
         assert resp.status_code == 504
@@ -636,6 +641,7 @@ class TestGenericDataTestFetch:
         mock_cm.get_general.return_value = {}
         with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
              patch("src.api_server.get_config_manager", return_value=mock_cm), \
+             patch("socket.getaddrinfo", return_value=self._PUBLIC_ADDR_INFO), \
              patch("requests.request", side_effect=req.exceptions.ConnectionError("conn")):
             resp = client.post("/generic-data/test-fetch", json={"url": "https://api.example.com/bad"})
         assert resp.status_code == 502
@@ -648,6 +654,7 @@ class TestGenericDataTestFetch:
         mock_cm.get_general.return_value = {}
         with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
              patch("src.api_server.get_config_manager", return_value=mock_cm), \
+             patch("socket.getaddrinfo", return_value=self._PUBLIC_ADDR_INFO), \
              patch("requests.request", return_value=mock_resp):
             resp = client.post("/generic-data/test-fetch", json={"url": "https://api.example.com/big"})
         assert resp.status_code == 400
@@ -661,6 +668,7 @@ class TestGenericDataTestFetch:
         mock_cm.get_general.return_value = {}
         with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
              patch("src.api_server.get_config_manager", return_value=mock_cm), \
+             patch("socket.getaddrinfo", return_value=self._PUBLIC_ADDR_INFO), \
              patch("requests.request", return_value=mock_resp):
             resp = client.post("/generic-data/test-fetch", json={
                 "url": "https://api.example.com/data",

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -9,6 +9,8 @@ Covers:
 - refresh_seconds rate-limit bypass attempts
 """
 
+import socket
+
 import pytest
 from unittest.mock import Mock, patch
 from fastapi.testclient import TestClient
@@ -432,3 +434,129 @@ class TestRefreshSecondsBypass:
                 json={"config": {"refresh_seconds": 60}},
             )
             assert response.status_code == 200
+
+
+# ===========================================================================
+# SSRF Protection Tests
+# ===========================================================================
+
+class TestSSRFProtection:
+    """Tests that _validate_request_url blocks SSRF targets via /generic-data/test-fetch."""
+
+    # Public IP used in DNS mocks: 93.184.216.34 is the well-known example.com address
+    _PUBLIC_ADDR_INFO = [(None, None, None, None, ("93.184.216.34", 443))]
+
+    @pytest.fixture
+    def mock_cm(self):
+        cm = Mock()
+        cm.get_general.return_value = {}
+        return cm
+
+    def _post(self, client, url: str, mock_cm):
+        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
+             patch("src.api_server.get_config_manager", return_value=mock_cm):
+            return client.post("/generic-data/test-fetch", json={"url": url})
+
+    # --- Blocked: non-http(s) schemes ---
+
+    def test_rejects_ftp_scheme(self, client, mock_cm):
+        resp = self._post(client, "ftp://example.com/file", mock_cm)
+        assert resp.status_code == 400
+
+    def test_rejects_file_scheme(self, client, mock_cm):
+        resp = self._post(client, "file:///etc/passwd", mock_cm)
+        assert resp.status_code == 400
+
+    # --- Blocked: credentials in URL ---
+
+    def test_rejects_url_with_credentials(self, client, mock_cm):
+        resp = self._post(client, "https://user:pass@example.com/data", mock_cm)
+        assert resp.status_code == 400
+
+    # --- Blocked: localhost-like names ---
+
+    def test_rejects_localhost(self, client, mock_cm):
+        resp = self._post(client, "http://localhost/api", mock_cm)
+        assert resp.status_code == 400
+
+    def test_rejects_localhost_subdomain(self, client, mock_cm):
+        resp = self._post(client, "http://anything.localhost/api", mock_cm)
+        assert resp.status_code == 400
+
+    def test_rejects_dot_local_domain(self, client, mock_cm):
+        resp = self._post(client, "http://mydevice.local/api", mock_cm)
+        assert resp.status_code == 400
+
+    # --- Blocked: loopback IP ---
+
+    def test_rejects_loopback_ipv4(self, client, mock_cm):
+        resp = self._post(client, "http://127.0.0.1/api", mock_cm)
+        assert resp.status_code == 400
+
+    def test_rejects_loopback_127_x(self, client, mock_cm):
+        resp = self._post(client, "http://127.1.2.3/api", mock_cm)
+        assert resp.status_code == 400
+
+    # --- Blocked: private/RFC-1918 IPs ---
+
+    def test_rejects_private_10_x(self, client, mock_cm):
+        resp = self._post(client, "http://10.0.0.1/api", mock_cm)
+        assert resp.status_code == 400
+
+    def test_rejects_private_192_168(self, client, mock_cm):
+        resp = self._post(client, "http://192.168.1.1/api", mock_cm)
+        assert resp.status_code == 400
+
+    def test_rejects_private_172_16(self, client, mock_cm):
+        resp = self._post(client, "http://172.16.0.1/api", mock_cm)
+        assert resp.status_code == 400
+
+    # --- Blocked: link-local ---
+
+    def test_rejects_link_local_169_254(self, client, mock_cm):
+        resp = self._post(client, "http://169.254.169.254/latest/meta-data/", mock_cm)
+        assert resp.status_code == 400
+
+    # --- Blocked: DNS resolves to private IP ---
+
+    def test_rejects_domain_resolving_to_private_ip(self, client, mock_cm):
+        private_addr_info = [(None, None, None, None, ("10.0.0.5", 80))]
+        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
+             patch("src.api_server.get_config_manager", return_value=mock_cm), \
+             patch("socket.getaddrinfo", return_value=private_addr_info):
+            resp = client.post("/generic-data/test-fetch", json={"url": "https://internal.corp/api"})
+        assert resp.status_code == 400
+
+    # --- Blocked: DNS failure ---
+
+    def test_rejects_unresolvable_domain(self, client, mock_cm):
+        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
+             patch("src.api_server.get_config_manager", return_value=mock_cm), \
+             patch("socket.getaddrinfo", side_effect=socket.gaierror("no such host")):
+            resp = client.post("/generic-data/test-fetch", json={"url": "https://no-such-host.invalid/api"})
+        assert resp.status_code == 400
+
+    # --- Allowed: public IP and domain ---
+
+    def test_allows_public_ip(self, client, mock_cm):
+        mock_resp = Mock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.content = b'{"ok": true}'
+        mock_resp.json.return_value = {"ok": True}
+        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
+             patch("src.api_server.get_config_manager", return_value=mock_cm), \
+             patch("requests.request", return_value=mock_resp):
+            resp = client.post("/generic-data/test-fetch", json={"url": "https://93.184.216.34/api"})
+        assert resp.status_code == 200
+
+    def test_allows_public_domain(self, client, mock_cm):
+        mock_resp = Mock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.content = b'{"ok": true}'
+        mock_resp.json.return_value = {"ok": True}
+        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
+             patch("src.api_server.get_config_manager", return_value=mock_cm), \
+             patch("socket.getaddrinfo", return_value=self._PUBLIC_ADDR_INFO), \
+             patch("requests.request", return_value=mock_resp):
+            resp = client.post("/generic-data/test-fetch", json={"url": "https://api.example.com/data"})
+        assert resp.status_code == 200


### PR DESCRIPTION
Potential fix for [https://github.com/Fiestaboard/FiestaBoard/security/code-scanning/23](https://github.com/Fiestaboard/FiestaBoard/security/code-scanning/23)

The safest fix without changing intended functionality too much is to strengthen `_validate_request_url` so it rejects URLs resolving to loopback, private, link-local, multicast, reserved/unspecified IPs, and localhost-like names. Then keep using this validator in `generic_data_test_fetch` (already called), so all current call sites benefit.

Concretely in `src/api_server.py`:
1. Extend `_validate_request_url` after hostname/scheme/credential checks.
2. Parse hostname and:
   - reject obvious local names (`localhost`, `.localhost`, `.local`).
   - if hostname is an IP literal, block non-public IP ranges.
   - if hostname is a domain, resolve with `socket.getaddrinfo` and ensure all resolved IPs are public; reject on DNS failure.
3. Keep existing behavior (http/https only, no credentials) unchanged otherwise.

No changes are required in `src/plugins/config_interpolation.py`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
