### PR TITLE
Potential fix for code scanning alert no. 22: Full server-side request forgery

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -129,6 +129,53 @@ def _validate_board_host(host: str) -> None:
         )
 
 
+def _validate_board_host_is_local_network(host: str) -> None:
+    """Ensure ``host`` resolves only to private/local IPv4 addresses.
+
+    Prevents SSRF to arbitrary internet hosts while still allowing local
+    network boards.
+    """
+    import ipaddress
+    import socket
+
+    def _is_allowed_ipv4(addr: ipaddress.IPv4Address) -> bool:
+        return (
+            addr.is_private
+            or addr.is_loopback
+            or addr.is_link_local
+        )
+
+    try:
+        ip = ipaddress.IPv4Address(host)
+        if not _is_allowed_ipv4(ip):
+            raise HTTPException(
+                status_code=400,
+                detail="host must resolve to a local/private IPv4 address",
+            )
+        return
+    except ValueError:
+        pass
+
+    try:
+        addrinfo = socket.getaddrinfo(host, None, family=socket.AF_INET, type=socket.SOCK_STREAM)
+    except socket.gaierror:
+        raise HTTPException(status_code=400, detail="host could not be resolved")
+
+    resolved_ips = {
+        ipaddress.IPv4Address(info[4][0])
+        for info in addrinfo
+        if info and len(info) >= 5 and info[4]
+    }
+    if not resolved_ips:
+        raise HTTPException(status_code=400, detail="host did not resolve to an IPv4 address")
+
+    if not all(_is_allowed_ipv4(ip) for ip in resolved_ips):
+        raise HTTPException(
+            status_code=400,
+            detail="host must resolve only to local/private IPv4 addresses",
+        )
+
+
 # Global service instance
 _service: Optional[DisplayService] = None
 _service_lock = threading.Lock()
@@ -1623,6 +1670,7 @@ async def enable_local_api(request: EnablementTokenRequest):
     # redirect this request away from the local board (SSRF).
     try:
         _validate_board_host(request.host)
+        _validate_board_host_is_local_network(request.host)
     except HTTPException as exc:
         return {
             "success": False,


### PR DESCRIPTION
Potential fix for [https://github.com/Fiestaboard/FiestaBoard/security/code-scanning/22](https://github.com/Fiestaboard/FiestaBoard/security/code-scanning/22)

General fix: do not allow arbitrary user-selected request destinations. Instead, validate the host and enforce that it resolves to an expected/trusted network scope before making the outbound request.

Best fix here (without changing endpoint behavior): keep existing `_validate_board_host` checks, and add a second validator that only permits private/local IPv4 addresses (or hostnames that resolve exclusively to private/local IPv4 addresses). Then call this validator in `enable_local_api` before constructing `url`. This preserves the current API shape (`host` still provided by user) while blocking internet SSRF destinations.

Changes needed in `src/api_server.py`:
1. Add a helper function (near `_validate_board_host`) to resolve/validate destination addresses against private/local ranges.
2. In `enable_local_api`, call the new helper right after `_validate_board_host`.
3. Add only standard-library imports inside the helper (`ipaddress`, `socket`) so no global import churn is required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
