### PR TITLE
Potential fix for code scanning alert no. 25: Uncontrolled data used in path expression

### DIFF
--- a/src/plugins/sources.py
+++ b/src/plugins/sources.py
@@ -290,6 +290,20 @@ def clone_or_update_repo(
     """
     env = {**os.environ, "GIT_TERMINAL_PROMPT": "0"}
 
+    # Defensive sink-level guard: ensure destination stays inside the
+    # managed external plugins directory before any filesystem access.
+    external_root = os.path.realpath(str(get_external_plugins_dir()))
+    candidate = os.path.realpath(str(dest_dir))
+    try:
+        if os.path.commonpath([external_root, candidate]) != external_root:
+            return False, (
+                f"Refusing to use destination outside external plugins directory: "
+                f"{dest_dir}"
+            )
+    except ValueError:
+        # Different drives / invalid mix of absolute-relative paths.
+        return False, f"Invalid destination path: {dest_dir}"
+
     if dest_dir.exists() and (dest_dir / ".git").is_dir():
         # Already cloned — fetch latest commits and reset to remote HEAD.
         # Works for both full and shallow (--depth 1) clones.

--- a/src/plugins/sources.py
+++ b/src/plugins/sources.py
@@ -287,8 +287,9 @@ def clone_or_update_repo(
         dest_dir: Local directory to clone into.
         branch: Optional branch/tag.  Uses the repo default when empty.
         allowed_root: Trusted root directory that ``dest_dir`` must be contained
-            within.  Defaults to :func:`get_external_plugins_dir`.  High-level
-            callers (e.g. :func:`install_registry_plugin`) should pass the same
+            within.  If not provided, defaults to the result of
+            :func:`get_external_plugins_dir`.  High-level callers (e.g.
+            :func:`install_registry_plugin`) should pass the same
             ``external_dir`` they used when constructing ``dest_dir`` so that
             the containment check uses a consistent boundary.
 

--- a/src/plugins/sources.py
+++ b/src/plugins/sources.py
@@ -267,6 +267,8 @@ def clone_or_update_repo(
     repo_url: str,
     dest_dir: Path,
     branch: str = "",
+    *,
+    allowed_root: Optional[Path] = None,
 ) -> Tuple[bool, str]:
     """Clone a git repository, or fetch/reset if it already exists.
 
@@ -284,6 +286,11 @@ def clone_or_update_repo(
         repo_url: HTTPS URL of the repository (required for fresh clones only).
         dest_dir: Local directory to clone into.
         branch: Optional branch/tag.  Uses the repo default when empty.
+        allowed_root: Trusted root directory that ``dest_dir`` must be contained
+            within.  Defaults to :func:`get_external_plugins_dir`.  High-level
+            callers (e.g. :func:`install_registry_plugin`) should pass the same
+            ``external_dir`` they used when constructing ``dest_dir`` so that
+            the containment check uses a consistent boundary.
 
     Returns:
         ``(True, "")`` on success, ``(False, error_message)`` on failure.
@@ -292,7 +299,8 @@ def clone_or_update_repo(
 
     # Defensive sink-level guard: ensure destination stays inside the
     # managed external plugins directory before any filesystem access.
-    external_root = os.path.realpath(str(get_external_plugins_dir()))
+    root = allowed_root if allowed_root is not None else get_external_plugins_dir()
+    external_root = os.path.realpath(str(root))
     candidate = os.path.realpath(str(dest_dir))
     try:
         if os.path.commonpath([external_root, candidate]) != external_root:
@@ -512,7 +520,7 @@ def install_registry_plugin(
     dest, err = _safe_external_dest(external_dir, entry.plugin_id)
     if dest is None:
         return False, err
-    return clone_or_update_repo(entry.repository, dest, entry.branch)
+    return clone_or_update_repo(entry.repository, dest, entry.branch, allowed_root=external_dir)
 
 
 def install_git_plugin(
@@ -559,4 +567,4 @@ def install_git_plugin(
     dest, err = _safe_external_dest(external_dir, plugin_id)
     if dest is None:
         return False, err
-    return clone_or_update_repo(repo_url, dest, branch)
+    return clone_or_update_repo(repo_url, dest, branch, allowed_root=external_dir)

--- a/tests/test_plugin_install_integration.py
+++ b/tests/test_plugin_install_integration.py
@@ -69,7 +69,7 @@ class TestCloneOrUpdateRepoIntegration:
     def test_fresh_clone(self, tmp_path):
         """Cloning a real repo succeeds and creates expected plugin files."""
         dest = tmp_path / REGISTRY_PLUGIN_ID
-        ok, err = clone_or_update_repo(REGISTRY_REPO_URL, dest)
+        ok, err = clone_or_update_repo(REGISTRY_REPO_URL, dest, allowed_root=tmp_path)
 
         assert ok, f"clone failed: {err}"
         assert err == ""
@@ -80,7 +80,7 @@ class TestCloneOrUpdateRepoIntegration:
     def test_clone_creates_valid_git_repo(self, tmp_path):
         """Cloned directory is a proper git repo with commit history."""
         dest = tmp_path / REGISTRY_PLUGIN_ID
-        clone_or_update_repo(REGISTRY_REPO_URL, dest)
+        clone_or_update_repo(REGISTRY_REPO_URL, dest, allowed_root=tmp_path)
 
         commits = _git_log(dest)
         assert len(commits) >= 1, "expected at least one commit in cloned repo"
@@ -90,12 +90,12 @@ class TestCloneOrUpdateRepoIntegration:
         dest = tmp_path / REGISTRY_PLUGIN_ID
 
         # First clone
-        ok, err = clone_or_update_repo(REGISTRY_REPO_URL, dest)
+        ok, err = clone_or_update_repo(REGISTRY_REPO_URL, dest, allowed_root=tmp_path)
         assert ok, f"initial clone failed: {err}"
         commits_before = _git_log(dest)
 
         # Second call should succeed (pull, already up-to-date is fine)
-        ok, err = clone_or_update_repo(REGISTRY_REPO_URL, dest)
+        ok, err = clone_or_update_repo(REGISTRY_REPO_URL, dest, allowed_root=tmp_path)
         assert ok, f"update (git pull) failed: {err}"
 
         commits_after = _git_log(dest)
@@ -108,6 +108,7 @@ class TestCloneOrUpdateRepoIntegration:
         ok, err = clone_or_update_repo(
             "https://github.com/Fiestaboard/fiestaboard-plugin--does-not-exist-xyz",
             dest,
+            allowed_root=tmp_path,
         )
         assert not ok
         assert err  # some error message present

--- a/tests/test_plugin_sources.py
+++ b/tests/test_plugin_sources.py
@@ -216,7 +216,9 @@ class TestGitUrlValidation:
 
 class TestCloneOrUpdateRepo:
     @mock.patch("src.plugins.sources.subprocess.run")
-    def test_clone_fresh(self, mock_run, tmp_path):
+    @mock.patch("src.plugins.sources.get_external_plugins_dir")
+    def test_clone_fresh(self, mock_ext_dir, mock_run, tmp_path):
+        mock_ext_dir.return_value = tmp_path
         dest = tmp_path / "my_plugin"
         ok, err = clone_or_update_repo("https://github.com/Org/repo", dest)
         assert ok
@@ -226,8 +228,10 @@ class TestCloneOrUpdateRepo:
         assert "clone" in cmd
 
     @mock.patch("src.plugins.sources.subprocess.run")
-    def test_fetch_reset_existing(self, mock_run, tmp_path):
+    @mock.patch("src.plugins.sources.get_external_plugins_dir")
+    def test_fetch_reset_existing(self, mock_ext_dir, mock_run, tmp_path):
         """Update path uses fetch+reset, not pull, and works without a URL."""
+        mock_ext_dir.return_value = tmp_path
         dest = tmp_path / "my_plugin"
         dest.mkdir()
         (dest / ".git").mkdir()  # Simulate existing shallow clone
@@ -244,8 +248,10 @@ class TestCloneOrUpdateRepo:
         assert "FETCH_HEAD" in reset_cmd
 
     @mock.patch("src.plugins.sources.subprocess.run")
-    def test_update_does_not_require_url(self, mock_run, tmp_path):
+    @mock.patch("src.plugins.sources.get_external_plugins_dir")
+    def test_update_does_not_require_url(self, mock_ext_dir, mock_run, tmp_path):
         """Passing an empty or invalid URL is fine when the clone already exists."""
+        mock_ext_dir.return_value = tmp_path
         dest = tmp_path / "my_plugin"
         dest.mkdir()
         (dest / ".git").mkdir()
@@ -256,7 +262,9 @@ class TestCloneOrUpdateRepo:
         "src.plugins.sources.subprocess.run",
         side_effect=subprocess.SubprocessError("network error"),
     )
-    def test_clone_failure(self, mock_run, tmp_path):
+    @mock.patch("src.plugins.sources.get_external_plugins_dir")
+    def test_clone_failure(self, mock_ext_dir, mock_run, tmp_path):
+        mock_ext_dir.return_value = tmp_path
         dest = tmp_path / "fail_plugin"
         ok, err = clone_or_update_repo("https://github.com/Org/repo", dest)
         assert not ok
@@ -266,8 +274,10 @@ class TestCloneOrUpdateRepo:
         "src.plugins.sources.subprocess.run",
         side_effect=subprocess.SubprocessError("fetch failed"),
     )
-    def test_update_failure(self, mock_run, tmp_path):
+    @mock.patch("src.plugins.sources.get_external_plugins_dir")
+    def test_update_failure(self, mock_ext_dir, mock_run, tmp_path):
         """Fetch failure in the update path is surfaced as an error."""
+        mock_ext_dir.return_value = tmp_path
         dest = tmp_path / "my_plugin"
         dest.mkdir()
         (dest / ".git").mkdir()
@@ -275,12 +285,37 @@ class TestCloneOrUpdateRepo:
         assert not ok
         assert "fetch" in err.lower() or "failed" in err.lower()
 
-    def test_rejects_ssh_url_for_fresh_clone(self, tmp_path):
+    @mock.patch("src.plugins.sources.get_external_plugins_dir")
+    def test_rejects_ssh_url_for_fresh_clone(self, mock_ext_dir, tmp_path):
         """SSH URLs are rejected only for fresh clones (URL validation skipped for updates)."""
+        mock_ext_dir.return_value = tmp_path
         dest = tmp_path / "ssh_plugin"
         ok, err = clone_or_update_repo("git@github.com:Org/repo.git", dest)
         assert not ok
         assert "HTTPS" in err
+
+    def test_rejects_dest_outside_external_plugins_dir(self, tmp_path):
+        """Destination outside the external plugins directory is rejected."""
+        other_dir = tmp_path / "other"
+        other_dir.mkdir()
+        ext_dir = tmp_path / "external_plugins"
+        ext_dir.mkdir()
+        dest = other_dir / "my_plugin"
+        with mock.patch("src.plugins.sources.get_external_plugins_dir", return_value=ext_dir):
+            ok, err = clone_or_update_repo("https://github.com/Org/repo", dest)
+        assert not ok
+        assert "outside" in err.lower()
+
+    def test_rejects_path_traversal_via_dest(self, tmp_path):
+        """A dest_dir that escapes via '..' is caught by the containment check."""
+        ext_dir = tmp_path / "external_plugins"
+        ext_dir.mkdir()
+        # Construct a path that appears to be inside external_plugins but resolves outside
+        dest = ext_dir / ".." / "escaped"
+        with mock.patch("src.plugins.sources.get_external_plugins_dir", return_value=ext_dir):
+            ok, err = clone_or_update_repo("https://github.com/Org/repo", dest)
+        assert not ok
+        assert "outside" in err.lower()
 
 
 # ── install helpers ──────────────────────────────────────────────────────────

--- a/tests/test_plugin_sources.py
+++ b/tests/test_plugin_sources.py
@@ -216,11 +216,9 @@ class TestGitUrlValidation:
 
 class TestCloneOrUpdateRepo:
     @mock.patch("src.plugins.sources.subprocess.run")
-    @mock.patch("src.plugins.sources.get_external_plugins_dir")
-    def test_clone_fresh(self, mock_ext_dir, mock_run, tmp_path):
-        mock_ext_dir.return_value = tmp_path
+    def test_clone_fresh(self, mock_run, tmp_path):
         dest = tmp_path / "my_plugin"
-        ok, err = clone_or_update_repo("https://github.com/Org/repo", dest)
+        ok, err = clone_or_update_repo("https://github.com/Org/repo", dest, allowed_root=tmp_path)
         assert ok
         assert err == ""
         mock_run.assert_called_once()
@@ -228,14 +226,12 @@ class TestCloneOrUpdateRepo:
         assert "clone" in cmd
 
     @mock.patch("src.plugins.sources.subprocess.run")
-    @mock.patch("src.plugins.sources.get_external_plugins_dir")
-    def test_fetch_reset_existing(self, mock_ext_dir, mock_run, tmp_path):
+    def test_fetch_reset_existing(self, mock_run, tmp_path):
         """Update path uses fetch+reset, not pull, and works without a URL."""
-        mock_ext_dir.return_value = tmp_path
         dest = tmp_path / "my_plugin"
         dest.mkdir()
         (dest / ".git").mkdir()  # Simulate existing shallow clone
-        ok, err = clone_or_update_repo("", dest)
+        ok, err = clone_or_update_repo("", dest, allowed_root=tmp_path)
         assert ok
         assert err == ""
         # Two subprocess calls: fetch then reset
@@ -248,25 +244,21 @@ class TestCloneOrUpdateRepo:
         assert "FETCH_HEAD" in reset_cmd
 
     @mock.patch("src.plugins.sources.subprocess.run")
-    @mock.patch("src.plugins.sources.get_external_plugins_dir")
-    def test_update_does_not_require_url(self, mock_ext_dir, mock_run, tmp_path):
+    def test_update_does_not_require_url(self, mock_run, tmp_path):
         """Passing an empty or invalid URL is fine when the clone already exists."""
-        mock_ext_dir.return_value = tmp_path
         dest = tmp_path / "my_plugin"
         dest.mkdir()
         (dest / ".git").mkdir()
-        ok, err = clone_or_update_repo("git@github.com:Org/repo.git", dest)
+        ok, err = clone_or_update_repo("git@github.com:Org/repo.git", dest, allowed_root=tmp_path)
         assert ok, "Update path should succeed regardless of URL"
 
     @mock.patch(
         "src.plugins.sources.subprocess.run",
         side_effect=subprocess.SubprocessError("network error"),
     )
-    @mock.patch("src.plugins.sources.get_external_plugins_dir")
-    def test_clone_failure(self, mock_ext_dir, mock_run, tmp_path):
-        mock_ext_dir.return_value = tmp_path
+    def test_clone_failure(self, mock_run, tmp_path):
         dest = tmp_path / "fail_plugin"
-        ok, err = clone_or_update_repo("https://github.com/Org/repo", dest)
+        ok, err = clone_or_update_repo("https://github.com/Org/repo", dest, allowed_root=tmp_path)
         assert not ok
         assert "network error" in err
 
@@ -274,23 +266,19 @@ class TestCloneOrUpdateRepo:
         "src.plugins.sources.subprocess.run",
         side_effect=subprocess.SubprocessError("fetch failed"),
     )
-    @mock.patch("src.plugins.sources.get_external_plugins_dir")
-    def test_update_failure(self, mock_ext_dir, mock_run, tmp_path):
+    def test_update_failure(self, mock_run, tmp_path):
         """Fetch failure in the update path is surfaced as an error."""
-        mock_ext_dir.return_value = tmp_path
         dest = tmp_path / "my_plugin"
         dest.mkdir()
         (dest / ".git").mkdir()
-        ok, err = clone_or_update_repo("", dest)
+        ok, err = clone_or_update_repo("", dest, allowed_root=tmp_path)
         assert not ok
         assert "fetch" in err.lower() or "failed" in err.lower()
 
-    @mock.patch("src.plugins.sources.get_external_plugins_dir")
-    def test_rejects_ssh_url_for_fresh_clone(self, mock_ext_dir, tmp_path):
+    def test_rejects_ssh_url_for_fresh_clone(self, tmp_path):
         """SSH URLs are rejected only for fresh clones (URL validation skipped for updates)."""
-        mock_ext_dir.return_value = tmp_path
         dest = tmp_path / "ssh_plugin"
-        ok, err = clone_or_update_repo("git@github.com:Org/repo.git", dest)
+        ok, err = clone_or_update_repo("git@github.com:Org/repo.git", dest, allowed_root=tmp_path)
         assert not ok
         assert "HTTPS" in err
 
@@ -302,8 +290,7 @@ class TestCloneOrUpdateRepo:
         ext_dir = tmp_path / "external_plugins"
         ext_dir.mkdir()
         dest = other_dir / "my_plugin"
-        with mock.patch("src.plugins.sources.get_external_plugins_dir", return_value=ext_dir):
-            ok, err = clone_or_update_repo("https://github.com/Org/repo", dest)
+        ok, err = clone_or_update_repo("https://github.com/Org/repo", dest, allowed_root=ext_dir)
         assert not ok
         assert "outside" in err.lower()
         mock_run.assert_not_called()
@@ -315,8 +302,7 @@ class TestCloneOrUpdateRepo:
         ext_dir.mkdir()
         # Construct a path that appears to be inside external_plugins but resolves outside
         dest = ext_dir / ".." / "escaped"
-        with mock.patch("src.plugins.sources.get_external_plugins_dir", return_value=ext_dir):
-            ok, err = clone_or_update_repo("https://github.com/Org/repo", dest)
+        ok, err = clone_or_update_repo("https://github.com/Org/repo", dest, allowed_root=ext_dir)
         assert not ok
         assert "outside" in err.lower()
         mock_run.assert_not_called()

--- a/tests/test_plugin_sources.py
+++ b/tests/test_plugin_sources.py
@@ -294,7 +294,8 @@ class TestCloneOrUpdateRepo:
         assert not ok
         assert "HTTPS" in err
 
-    def test_rejects_dest_outside_external_plugins_dir(self, tmp_path):
+    @mock.patch("src.plugins.sources.subprocess.run")
+    def test_rejects_dest_outside_external_plugins_dir(self, mock_run, tmp_path):
         """Destination outside the external plugins directory is rejected."""
         other_dir = tmp_path / "other"
         other_dir.mkdir()
@@ -305,8 +306,10 @@ class TestCloneOrUpdateRepo:
             ok, err = clone_or_update_repo("https://github.com/Org/repo", dest)
         assert not ok
         assert "outside" in err.lower()
+        mock_run.assert_not_called()
 
-    def test_rejects_path_traversal_via_dest(self, tmp_path):
+    @mock.patch("src.plugins.sources.subprocess.run")
+    def test_rejects_path_traversal_via_dest(self, mock_run, tmp_path):
         """A dest_dir that escapes via '..' is caught by the containment check."""
         ext_dir = tmp_path / "external_plugins"
         ext_dir.mkdir()
@@ -316,6 +319,7 @@ class TestCloneOrUpdateRepo:
             ok, err = clone_or_update_repo("https://github.com/Org/repo", dest)
         assert not ok
         assert "outside" in err.lower()
+        mock_run.assert_not_called()
 
 
 # ── install helpers ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Potential fix for [https://github.com/Fiestaboard/FiestaBoard/security/code-scanning/25](https://github.com/Fiestaboard/FiestaBoard/security/code-scanning/25)

The best fix is to enforce a **canonical path containment check inside `clone_or_update_repo`** before any filesystem use of `dest_dir`.  
That means:

- Normalize/resolve `dest_dir` with `os.path.realpath`.
- Resolve the trusted external root (`get_external_plugins_dir()`), also with `realpath`.
- Use `os.path.commonpath([external_root, candidate]) == external_root` to ensure `dest_dir` is inside the allowed directory.
- If not contained, return `(False, "...outside external plugins directory...")` before `dest_dir.exists()` or any git operations.

This is the single best non-breaking hardening because it preserves existing behavior for valid paths, adds defense-in-depth at the sink, and addresses all alert variants in one place.  
Edit only `src/plugins/sources.py` in `clone_or_update_repo(...)` near the start of the function (just after `env = ...` and before line 293 path usage). No new dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
