### PR TITLE
Potential fix for code scanning alert no. 12: Information exposure through an exception

### DIFF
--- a/src/utils/stocks.py
+++ b/src/utils/stocks.py
@@ -433,12 +433,12 @@ class StocksSource:
                 "name": company_name
             }
             
-        except Exception as e:
-            logger.debug(f"Symbol validation failed for {symbol}: {e}")
+        except Exception:
+            logger.error("Symbol validation failed for %s", symbol, exc_info=True)
             return {
                 "valid": False,
                 "symbol": symbol,
-                "error": str(e)
+                "error": "Unable to validate symbol at this time"
             }
     
     @staticmethod


### PR DESCRIPTION
Potential fix for [https://github.com/Fiestaboard/FiestaBoard/security/code-scanning/12](https://github.com/Fiestaboard/FiestaBoard/security/code-scanning/12)

To fix this safely without changing intended behavior, stop returning raw exception text from `StocksSource.validate_symbol`. Keep the return schema the same (`valid/symbol/error`), but replace `str(e)` with a generic client-safe message. Log full exception details server-side with `exc_info=True` so diagnostics remain available to developers.

Best single change:
- **File:** `src/utils/stocks.py`
- **Region:** `StocksSource.validate_symbol`, `except Exception as e:` block (around lines 436–442 in the snippet)
- Replace debug log without traceback with an error log including traceback.
- Replace `"error": str(e)` with a generic string like `"Unable to validate symbol at this time"`.

No functional API contract change (still returns invalid result with an `error` field), only sanitization of sensitive content.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
