### PR TITLE
Potential fix for code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -1504,11 +1504,11 @@ async def test_board_connection(request: BoardTestRequest):
             
     except ValueError as e:
         # Invalid configuration (missing required fields)
-        logger.warning(f"Board connection test failed - invalid config: {e}")
+        logger.warning("Board connection test failed - invalid config", exc_info=True)
         return {
             "success": False,
-            "message": str(e),
-            "error": f"Configuration error: {str(e)}"
+            "message": "Board connection configuration is invalid.",
+            "error": "Configuration error"
         }
     except requests.exceptions.ConnectionError as e:
         logger.error(f"Board connection test error: {e}")


### PR DESCRIPTION
Potential fix for [https://github.com/Fiestaboard/FiestaBoard/security/code-scanning/3](https://github.com/Fiestaboard/FiestaBoard/security/code-scanning/3)

To fix this without changing functionality, keep the same success/failure behavior and response shape, but stop returning raw exception text to API clients.

Best fix in `src/api_server.py` around the `except ValueError as e:` block:
- Keep logging for diagnostics, but log with traceback on the server (`logger.warning(..., exc_info=True)`).
- Replace `str(e)` in response fields with a generic, non-sensitive message.
- Preserve keys (`success`, `message`, `error`) so clients are not broken structurally.

This single change addresses all listed alert variants because they all point to the same tainted flow (`e` into returned JSON).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
