### PR TITLE
fix: resolve all 6 open CodeQL security alerts

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -87,6 +87,30 @@ def _validate_request_url(
         raise HTTPException(
             status_code=400, detail="URL must not contain credentials"
         )
+    # Block requests targeting private/loopback/link-local addresses to
+    # prevent SSRF against internal services.
+    import ipaddress as _ipaddress
+    _h = parsed.hostname.lower().rstrip(".")
+    if _h in {"localhost", "localhost.localdomain", "ip6-localhost", "ip6-loopback"}:
+        raise HTTPException(
+            status_code=400,
+            detail="URL must not target internal network resources",
+        )
+    try:
+        _addr = _ipaddress.ip_address(_h)
+        if (
+            _addr.is_private
+            or _addr.is_loopback
+            or _addr.is_link_local
+            or _addr.is_reserved
+            or _addr.is_multicast
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail="URL must not target internal network resources",
+            )
+    except ValueError:
+        pass  # Not an IP literal; hostname-based domains are permitted
 
     host = parsed.hostname.strip().lower()
     if host == "localhost" or host.endswith(".localhost") or host.endswith(".local"):
@@ -1472,7 +1496,15 @@ async def test_board_connection(request: BoardTestRequest):
         api_key = request.local_api_key
         use_cloud = False
         host = request.host
-    
+        try:
+            _validate_board_host(host)
+        except HTTPException as _exc:
+            return {
+                "success": False,
+                "message": "Invalid board host",
+                "error": _exc.detail,
+            }
+
     try:
         # Create temporary client with provided credentials
         client = BoardClient(
@@ -5663,7 +5695,20 @@ async def update_plugin(plugin_id: str):
         )
 
     from pathlib import Path as _Path
+    import os as _os
+    from .plugins.sources import get_external_plugins_dir
     local_path = _Path(source.local_path)
+    # Verify local_path is within the external plugins directory before
+    # passing it to subprocess calls — canonical path-injection barrier.
+    _ext_root = _os.path.realpath(str(get_external_plugins_dir()))
+    _real_local = _os.path.realpath(str(local_path))
+    try:
+        _common = _os.path.commonpath([_ext_root, _real_local])
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid plugin path.")
+    if _common != _ext_root or _real_local == _ext_root:
+        raise HTTPException(status_code=400, detail="Invalid plugin path.")
+    local_path = _Path(_real_local)
 
     if not (local_path / ".git").is_dir():
         raise HTTPException(
@@ -5716,10 +5761,12 @@ async def apply_all_plugin_updates():
         return {"updated": [], "failed": {}, "message": "No updates available."}
 
     from pathlib import Path as _Path
-    from .plugins.sources import clone_or_update_repo
+    import os as _os
+    from .plugins.sources import clone_or_update_repo, get_external_plugins_dir
 
     updated: list = []
     failed: dict = {}
+    _ext_root = _os.path.realpath(str(get_external_plugins_dir()))
 
     for plugin_id in pending:
         source = registry.get_plugin_source(plugin_id)
@@ -5727,7 +5774,16 @@ async def apply_all_plugin_updates():
             failed[plugin_id] = "Plugin source not found."
             continue
 
-        local_path = _Path(source.local_path)
+        _real_local = _os.path.realpath(str(_Path(source.local_path)))
+        try:
+            _common = _os.path.commonpath([_ext_root, _real_local])
+        except ValueError:
+            failed[plugin_id] = "Invalid plugin path."
+            continue
+        if _common != _ext_root or _real_local == _ext_root:
+            failed[plugin_id] = "Invalid plugin path."
+            continue
+        local_path = _Path(_real_local)
         if not (local_path / ".git").is_dir():
             failed[plugin_id] = "Plugin is not a git repository."
             continue

--- a/src/plugins/sources.py
+++ b/src/plugins/sources.py
@@ -395,6 +395,11 @@ def get_remote_head_sha(dest_dir: Path) -> Optional[str]:
         if result.returncode != 0:
             return None
         remote_url = result.stdout.strip()
+        # Validate the URL read from the local git config before passing it
+        # into another subprocess call (prevents command/path injection).
+        ok, _ = _validate_git_url(remote_url)
+        if not ok:
+            return None
 
         # Determine the default branch name tracked locally
         branch_result = subprocess.run(
@@ -402,6 +407,10 @@ def get_remote_head_sha(dest_dir: Path) -> Optional[str]:
             capture_output=True, text=True, timeout=10,
         )
         branch = branch_result.stdout.strip() or "main"
+        # Allow only characters that are legal in git branch names and safe
+        # as subprocess arguments (prevents argument injection).
+        if not re.match(r'^[A-Za-z0-9_./-]+$', branch):
+            return None
 
         # Query the remote for the latest SHA
         ls_result = subprocess.run(

--- a/tests/test_api_coverage_extended.py
+++ b/tests/test_api_coverage_extended.py
@@ -6,6 +6,7 @@ and deprecated compat endpoints.
 """
 
 import pytest
+from pathlib import Path
 from unittest.mock import Mock, patch, AsyncMock
 from fastapi.testclient import TestClient
 from src.api_server import app
@@ -452,6 +453,7 @@ class TestPluginManagement:
         with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
              patch("src.api_server.get_plugin_registry", return_value=mock_registry), \
              patch("pathlib.Path.is_dir", return_value=True), \
+             patch("src.plugins.sources.get_external_plugins_dir", return_value=Path("/fake")), \
              patch("src.plugins.sources.clone_or_update_repo", return_value=(True, None)):
             resp = client.post("/plugins/test_plugin/update")
         assert resp.status_code == 200
@@ -491,6 +493,7 @@ class TestPluginManagement:
         with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
              patch("src.api_server.get_plugin_registry", return_value=mock_registry), \
              patch("pathlib.Path.is_dir", return_value=True), \
+             patch("src.plugins.sources.get_external_plugins_dir", return_value=Path("/fake")), \
              patch("src.plugins.sources.clone_or_update_repo", side_effect=capture_clone):
             resp = client.post("/plugins/test_plugin/update")
         assert resp.status_code == 200
@@ -509,6 +512,7 @@ class TestPluginManagement:
         with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
              patch("src.api_server.get_plugin_registry", return_value=mock_registry), \
              patch("pathlib.Path.is_dir", return_value=True), \
+             patch("src.plugins.sources.get_external_plugins_dir", return_value=Path("/fake")), \
              patch("src.plugins.sources.clone_or_update_repo", return_value=(True, "")):
             resp = client.post("/plugins/updates/apply")
         assert resp.status_code == 200
@@ -549,6 +553,7 @@ class TestPluginManagement:
         with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
              patch("src.api_server.get_plugin_registry", return_value=mock_registry), \
              patch("pathlib.Path.is_dir", return_value=True), \
+             patch("src.plugins.sources.get_external_plugins_dir", return_value=Path("/fake")), \
              patch("src.plugins.sources.clone_or_update_repo", side_effect=fake_clone):
             resp = client.post("/plugins/updates/apply")
         assert resp.status_code == 200


### PR DESCRIPTION
Closes all 6 open alerts from the GitHub code scanning dashboard.

## Changes

### SSRF — alert #22 (`src/api_server.py`)
`POST /config/board/test` in local API mode was making an HTTP request to a user-supplied `host` without first calling `_validate_board_host()`. Added the same validation that the local API enablement endpoint already applies.

### SSRF — alert #23 (`src/api_server.py`)
`_validate_request_url()` (used by `POST /generic-data/test-fetch`) only checked scheme and credentials. Extended it to block requests targeting private/loopback/link-local IP ranges (`127.x`, `10.x`, `192.168.x`, `169.254.x`, `::1`, `fc00::/7`) and `localhost` hostnames to prevent SSRF against internal services.

### Path injection — alerts #24 & #25 (`src/api_server.py`)
Both `POST /plugins/{id}/update` and `POST /plugins/updates/apply` were calling `clone_or_update_repo("", local_path)` with a path read from stored config, bypassing the `_safe_external_dest` containment check used at install time. Added `os.path.realpath` + `os.path.commonpath` containment checks against `get_external_plugins_dir()` before any subprocess call.

### Path injection + command injection — alerts #26 & #2 (`src/plugins/sources.py`)
`get_remote_head_sha()` was reading `remote_url` from `git remote get-url origin` stdout and passing it unsanitised into a second `git ls-remote` subprocess call. Now validates it with `_validate_git_url()`. Also validates the `branch` string against a safe character allowlist (`[A-Za-z0-9_./-]+`) to prevent argument injection.

## Tests
- 202 tests across the five most-affected test files all pass.
- Updated 4 tests in `test_api_coverage_extended.py` to mock `get_external_plugins_dir` so fake `/fake/*` paths pass the new containment check.
- Pre-existing failure (`test_screenshots_entries_reference_existing_files` — missing `random/docs/board-display.png`) is unrelated to these changes.