### PR TITLE
security: fix remaining 3 py/command-line-injection CodeQL taint chains

### DIFF
--- a/scripts/scan_registry.py
+++ b/scripts/scan_registry.py
@@ -21,6 +21,7 @@ Exit codes:
 import argparse
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -78,6 +79,15 @@ def load_registry() -> List[Dict]:
 
 def clone_repo(repo_url: str, target_dir: str, verbose: bool) -> Optional[str]:
     """Shallow-clone a repository. Returns error message or None on success."""
+    # Validate the URL from the registry JSON before passing to subprocess
+    # (py/command-line-injection). Only HTTPS URLs are permitted; re-derive
+    # from a regex match so CodeQL does not track the value as tainted.
+    if not isinstance(repo_url, str) or not repo_url.startswith("https://"):
+        return f"git clone rejected: only HTTPS URLs are supported (got {repo_url!r})"
+    _url_m = re.fullmatch(r"https://[^\x00-\x1f\s\"'<>\\]+", repo_url)
+    if not _url_m:
+        return f"git clone rejected: URL contains invalid characters: {repo_url!r}"
+    repo_url = _url_m.group(0)
     try:
         result = subprocess.run(
             ["git", "clone", "--depth", "1", f"{repo_url}.git", target_dir],
@@ -202,7 +212,16 @@ def scan_plugin(entry: Dict, workspace: str, verbose: bool) -> PluginScanResult:
     repo_url = entry.get("repository", "")
 
     result = PluginScanResult(plugin_id, name, repo_url)
-    plugin_dir = os.path.join(workspace, plugin_id)
+
+    # Validate plugin_id before using it as a path component to prevent
+    # path injection in downstream subprocess calls (py/path-injection).
+    # Re-derive from a regex match so CodeQL treats it as sanitised.
+    _id_m = re.fullmatch(r"[a-z][a-z0-9_]{0,63}", plugin_id)
+    if not _id_m:
+        result.clone_error = f"Invalid plugin id {plugin_id!r}"
+        return result
+    safe_plugin_id = _id_m.group(0)
+    plugin_dir = os.path.join(workspace, safe_plugin_id)
 
     # Clone
     clone_error = clone_repo(repo_url, plugin_dir, verbose)

--- a/scripts/validate_plugins.py
+++ b/scripts/validate_plugins.py
@@ -346,9 +346,24 @@ def validate_registry_entry(entry: Dict, verbose: bool) -> List[str]:
     # 4. Repo reachability via git ls-remote
     if verbose:
         print(f"  Checking {repo_url} ...", end=" ", flush=True)
+    # Validate the URL from the registry JSON before passing to subprocess
+    # (py/command-line-injection). Only HTTPS URLs are permitted; re-derive
+    # from a regex match so CodeQL does not track the value as tainted.
+    if not repo_url.startswith("https://"):
+        errors.append(f"[{plugin_id}] Only HTTPS repository URLs are supported")
+        if verbose:
+            print("REJECTED")
+        return errors
+    _url_m = re.fullmatch(r"https://[^\x00-\x1f\s\"'<>\\]+", repo_url)
+    if not _url_m:
+        errors.append(f"[{plugin_id}] Repository URL contains invalid characters: {repo_url!r}")
+        if verbose:
+            print("REJECTED")
+        return errors
+    _safe_repo_url = _url_m.group(0)
     try:
         result = subprocess.run(
-            ["git", "ls-remote", "--heads", repo_url],
+            ["git", "ls-remote", "--heads", _safe_repo_url],
             capture_output=True,
             text=True,
             timeout=30,

--- a/src/plugins/sources.py
+++ b/src/plugins/sources.py
@@ -410,6 +410,12 @@ def get_remote_head_sha(dest_dir: Path) -> Optional[str]:
         ok, _ = _validate_git_url(remote_url)
         if not ok:
             return None
+        # Re-derive remote_url from a regex match so the subprocess sink
+        # does not see it as tainted (CodeQL py/command-line-injection).
+        _url_m = re.fullmatch(r"https://[^\x00-\x1f\s\"'<>\\]+", remote_url)
+        if not _url_m:
+            return None
+        remote_url = _url_m.group(0)
 
         # Determine the default branch name tracked locally
         branch_result = subprocess.run(
@@ -419,8 +425,12 @@ def get_remote_head_sha(dest_dir: Path) -> Optional[str]:
         branch = branch_result.stdout.strip() or "main"
         # Allow only characters that are legal in git branch names and safe
         # as subprocess arguments (prevents argument injection).
-        if not re.match(r'^[A-Za-z0-9_./-]+$', branch):
+        # Re-derive branch from the match result so the subprocess sink
+        # does not see it as tainted (CodeQL py/command-line-injection).
+        _branch_m = re.match(r'^[A-Za-z0-9_./-]+$', branch)
+        if not _branch_m:
             return None
+        branch = _branch_m.group(0)
 
         # Query the remote for the latest SHA
         ls_result = subprocess.run(


### PR DESCRIPTION
## Summary

Closes the remaining 3 CodeQL `py/command-line-injection` alerts by applying the same re-derivation pattern used in the earlier `clone_or_update_repo` fix (#632).

## Root Cause

CodeQL only clears taint when a value is **reassigned** from a recognised sanitiser pattern — `re.fullmatch(pattern, val).group(0)` is the canonical barrier. Calling a validation function (even one that raises on bad input) and then using the original variable at the subprocess sink is not sufficient to break the taint chain.

## Changes

### `src/plugins/sources.py` — `get_remote_head_sha` (2 taint chains)

**`remote_url`** (tainted: subprocess stdout from `git remote get-url`)
- `_validate_git_url(remote_url)` was already called, but the original variable still reached the `git ls-remote` sink
- After validation, re-derive: `_url_m = re.fullmatch(r'https://...', remote_url); remote_url = _url_m.group(0)`

**`branch`** (tainted: subprocess stdout from `git rev-parse --abbrev-ref HEAD`)
- The `re.match(...)` result was discarded (bare `if not re.match` check), so `branch` remained tainted
- Changed to `_branch_m = re.match(...); branch = _branch_m.group(0)` so the re-derived value reaches the sink

### `scripts/scan_registry.py` — `clone_repo` / `scan_plugin` (1 taint chain)

**`repo_url`** (tainted: `json.load` → `entry.get('repository')`)
- No validation at all before `git clone ${repo_url}.git`
- Added HTTPS-only check + `re.fullmatch` re-derivation before the subprocess call

**`plugin_id`** (tainted: `json.load` → `entry.get('id')`)
- Flowed into `os.path.join(workspace, plugin_id)` → `bandit -r plugin_dir` with no sanitisation
- Added `re.fullmatch(r'[a-z][a-z0-9_]{0,63}', plugin_id)` re-derivation to `safe_plugin_id`

### `scripts/validate_plugins.py` — `validate_registry_entry` (1 taint chain)

**`repo_url`** (tainted: `json.load`)
- Flowed directly to `git ls-remote --heads ${repo_url}` with only a repo-name fragment check (which did not block execution on failure)
- Added HTTPS-only check + `re.fullmatch` re-derivation to `_safe_repo_url` before the subprocess call

## Testing

- `pytest tests/test_plugin_sources.py` — 67 passed ✅
- Full platform suite `pytest tests/ -m 'not integration'` — **2635 passed, 11 skipped** ✅