### PR TITLE
fix(fiestaupdater): use 127.0.0.1 in healthcheck instead of localhost

### DIFF
--- a/docker-compose.hub.yml
+++ b/docker-compose.hub.yml
@@ -57,7 +57,7 @@ services:
         max-size: "5m"
         max-file: "2"
     healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8765/healthz"]
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://127.0.0.1:8765/healthz"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
         max-size: "5m"
         max-file: "2"
     healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8765/healthz"]
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://127.0.0.1:8765/healthz"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/pi-image/stage-fiestaboard/01-install-fiestaboard/files/docker-compose.yml
+++ b/pi-image/stage-fiestaboard/01-install-fiestaboard/files/docker-compose.yml
@@ -46,7 +46,7 @@ services:
         max-size: "5m"
         max-file: "2"
     healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8765/healthz"]
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://127.0.0.1:8765/healthz"]
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Problem

On Alpine Linux (the `docker:cli` base image), `localhost` resolves to `::1` (IPv6). The `socat TCP-LISTEN:` invocation in `fiestaupdater.sh` listens on IPv4 `0.0.0.0` only. The Docker Compose healthcheck was using `http://localhost:8765/healthz`, which tried the IPv6 address and got "Connection refused" — causing `fiestaupdater` to always report **unhealthy** even though socat was running fine.

The `Dockerfile` `HEALTHCHECK` already used `127.0.0.1` correctly. Only the Compose overrides were wrong.

## Fix

Changed `localhost:8765` → `127.0.0.1:8765` in the healthcheck for all three compose files:

- `docker-compose.yml`
- `docker-compose.hub.yml`
- `pi-image/stage-fiestaboard/01-install-fiestaboard/files/docker-compose.yml`

## Testing

Verified on live Pi after pulling updated images:

```
fiestaupdater   Up 19 seconds (healthy)
```