### PR TITLE
feat: system controls — restart & shutdown via fiestaupdater sidecar

### DIFF
--- a/docker-compose.hub.yml
+++ b/docker-compose.hub.yml
@@ -45,6 +45,8 @@ services:
       - FIESTAUPDATER_SERVICE=fiestaboard
       - FIESTAUPDATER_COMPOSE_FILE=/compose/docker-compose.yml
       - COMPOSE_PROJECT_NAME=fiestaboard
+    cap_add:
+      - SYS_BOOT
     volumes:
       # Talk to the host Docker daemon to pull images and recreate services.
       - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,8 @@ services:
       - FIESTAUPDATER_SERVICE=fiestaboard
       - FIESTAUPDATER_COMPOSE_FILE=/compose/docker-compose.yml
       - COMPOSE_PROJECT_NAME=fiestaboard
+    cap_add:
+      - SYS_BOOT
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./docker-compose.yml:/compose/docker-compose.yml:ro

--- a/fiestaupdater/handler.sh
+++ b/fiestaupdater/handler.sh
@@ -115,6 +115,57 @@ handle_version() {
 }
 
 # ---------------------------------------------------------------------------
+# POST /restart — restart the service container in-place.
+# Returns 202 immediately; docker compose restart is run in the background
+# because it will kill the fiestaboard container (and this HTTP connection)
+# before the response would otherwise be flushed.
+# ---------------------------------------------------------------------------
+handle_restart() {
+    log "restart requested for service=${SERVICE}"
+    if [ ! -f "$COMPOSE_FILE" ]; then
+        log "compose file missing at ${COMPOSE_FILE}"
+        respond 500 "Internal Server Error" '{"error":"compose_file_missing"}'
+        return
+    fi
+    local logsink
+    if [ -e /proc/1/fd/2 ]; then
+        logsink=/proc/1/fd/2
+    else
+        logsink=/dev/null
+    fi
+    nohup bash -c "
+        set -eu
+        echo '[fiestaupdater] restarting ${SERVICE}...'
+        docker compose -f '${COMPOSE_FILE}' restart '${SERVICE}'
+        echo '[fiestaupdater] restart complete'
+    " >>"$logsink" 2>&1 &
+    respond 202 Accepted "{\"status\":\"queued\",\"action\":\"restart\",\"service\":\"${SERVICE}\"}"
+}
+
+# ---------------------------------------------------------------------------
+# POST /shutdown — gracefully power off the host machine.
+# Stops the compose service first, then calls poweroff.
+# Requires the container to have the SYS_BOOT capability
+# (cap_add: [SYS_BOOT] in docker-compose.yml).
+# ---------------------------------------------------------------------------
+handle_shutdown() {
+    log "host shutdown requested"
+    local logsink
+    if [ -e /proc/1/fd/2 ]; then
+        logsink=/proc/1/fd/2
+    else
+        logsink=/dev/null
+    fi
+    nohup bash -c "
+        echo '[fiestaupdater] stopping services before shutdown...'
+        docker compose -f '${COMPOSE_FILE}' stop || true
+        echo '[fiestaupdater] initiating host poweroff...'
+        poweroff -f
+    " >>"$logsink" 2>&1 &
+    respond 202 Accepted '{"status":"queued","action":"shutdown"}'
+}
+
+# ---------------------------------------------------------------------------
 # POST /update — pull the latest image and recreate the service.
 # Returns 202 immediately; the actual `compose up -d` is run in the
 # background because it will likely outlive the HTTP connection (the
@@ -167,7 +218,7 @@ case "${REQ_METHOD} ${REQ_PATH}" in
     "GET /version")
         handle_version
         ;;
-    "POST /update")
+    "POST /update"|"POST /restart"|"POST /shutdown")
         # Drain body (we don't use it but must consume Content-Length bytes
         # so socat doesn't keep the socket half-open).
         if [ "${REQ_CONTENT_LENGTH:-0}" -gt 0 ] 2>/dev/null; then
@@ -178,7 +229,11 @@ case "${REQ_METHOD} ${REQ_PATH}" in
             Bearer\ *)
                 token="${REQ_AUTH#Bearer }"
                 if check_token "$token"; then
-                    handle_update
+                    case "${REQ_METHOD} ${REQ_PATH}" in
+                        "POST /update")   handle_update ;;
+                        "POST /restart")  handle_restart ;;
+                        "POST /shutdown") handle_shutdown ;;
+                    esac
                 else
                     log "auth failed (bad token)"
                     respond 401 Unauthorized '{"error":"invalid_token"}'

--- a/fiestaupdater/tests/handler.bats
+++ b/fiestaupdater/tests/handler.bats
@@ -146,6 +146,64 @@ status_of() {
     [[ "$(status_of "$out")" == "HTTP/1.1 404 Not Found" ]]
 }
 
+# ---- /restart --------------------------------------------------------------
+
+@test "POST /restart with no Authorization → 401" {
+    req=$'POST /restart HTTP/1.1\r\nHost: x\r\nContent-Length: 0\r\n\r\n'
+    out=$(send "$req")
+    [[ "$(status_of "$out")" == "HTTP/1.1 401 Unauthorized" ]]
+    [[ "$out" == *missing_authorization* ]]
+}
+
+@test "POST /restart with wrong token → 401" {
+    req=$'POST /restart HTTP/1.1\r\nHost: x\r\nAuthorization: Bearer wrong\r\nContent-Length: 0\r\n\r\n'
+    out=$(send "$req")
+    [[ "$(status_of "$out")" == "HTTP/1.1 401 Unauthorized" ]]
+    [[ "$out" == *invalid_token* ]]
+}
+
+@test "POST /restart with valid token → 202 and triggers compose restart" {
+    req=$'POST /restart HTTP/1.1\r\nHost: x\r\nAuthorization: Bearer test-token-abc\r\nContent-Length: 0\r\n\r\n'
+    out=$(send "$req")
+    [[ "$(status_of "$out")" == "HTTP/1.1 202 Accepted" ]]
+    [[ "$out" == *'"status":"queued"'* ]]
+    [[ "$out" == *'"action":"restart"'* ]]
+    sleep 1
+    grep -q "compose -f" "${SANDBOX}/docker.calls"
+    grep -q "restart fiestaboard" "${SANDBOX}/docker.calls"
+}
+
+# ---- /shutdown -------------------------------------------------------------
+
+@test "POST /shutdown with no Authorization → 401" {
+    req=$'POST /shutdown HTTP/1.1\r\nHost: x\r\nContent-Length: 0\r\n\r\n'
+    out=$(send "$req")
+    [[ "$(status_of "$out")" == "HTTP/1.1 401 Unauthorized" ]]
+    [[ "$out" == *missing_authorization* ]]
+}
+
+@test "POST /shutdown with wrong token → 401" {
+    req=$'POST /shutdown HTTP/1.1\r\nHost: x\r\nAuthorization: Bearer wrong\r\nContent-Length: 0\r\n\r\n'
+    out=$(send "$req")
+    [[ "$(status_of "$out")" == "HTTP/1.1 401 Unauthorized" ]]
+    [[ "$out" == *invalid_token* ]]
+}
+
+@test "POST /shutdown with valid token → 202" {
+    # Override poweroff with a no-op so the test host doesn't actually shut down.
+    cat >"${SANDBOX}/poweroff" <<'SH'
+#!/bin/sh
+echo "poweroff $@" >> "${SANDBOX}/poweroff.calls"
+SH
+    chmod +x "${SANDBOX}/poweroff"
+
+    req=$'POST /shutdown HTTP/1.1\r\nHost: x\r\nAuthorization: Bearer test-token-abc\r\nContent-Length: 0\r\n\r\n'
+    out=$(send "$req")
+    [[ "$(status_of "$out")" == "HTTP/1.1 202 Accepted" ]]
+    [[ "$out" == *'"status":"queued"'* ]]
+    [[ "$out" == *'"action":"shutdown"'* ]]
+}
+
 # ---- malformed -------------------------------------------------------------
 
 @test "empty input → 400" {

--- a/pi-image/stage-fiestaboard/01-install-fiestaboard/files/docker-compose.yml
+++ b/pi-image/stage-fiestaboard/01-install-fiestaboard/files/docker-compose.yml
@@ -37,6 +37,8 @@ services:
       - FIESTAUPDATER_SERVICE=fiestaboard
       - FIESTAUPDATER_COMPOSE_FILE=/compose/docker-compose.yml
       - COMPOSE_PROJECT_NAME=fiestaboard
+    cap_add:
+      - SYS_BOOT
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /opt/fiestaboard/docker-compose.yml:/compose/docker-compose.yml:ro

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -498,6 +498,12 @@ class AutoUpdateResponse(BaseModel):
     enabled: bool
 
 
+class SystemActionResponse(BaseModel):
+    """Response model for restart / shutdown system actions."""
+    status: str   # "queued"
+    action: str   # "restart" | "shutdown"
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Lifespan context manager for startup and shutdown events."""
@@ -1186,6 +1192,85 @@ async def system_update_set_auto(req: AutoUpdateRequest):
     state["auto_update_enabled"] = bool(req.enabled)
     _system_update_state_save(state)
     return AutoUpdateResponse(enabled=bool(req.enabled))
+
+
+def _updater_post(path: str) -> requests.Response:
+    """POST to the fiestaupdater sidecar and return the response.
+    Raises on network-level failures; callers handle HTTP errors.
+    """
+    url = f"{_updater_url()}/{path.lstrip('/')}"
+    headers = {"Authorization": f"Bearer {_updater_token()}"}
+    return requests.post(url, headers=headers, timeout=(5, 30))
+
+
+def _require_updater_token():
+    """Raise 503 if FIESTAUPDATER_TOKEN is not configured."""
+    if not _updater_token():
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "status": "unavailable",
+                "hint": "FIESTAUPDATER_TOKEN is not set. Add COMPOSE_PROFILES=fiestaupdater to your .env and run 'docker compose up -d' to enable sidecar features.",
+            },
+        )
+
+
+def _handle_updater_response(resp: requests.Response, action: str) -> SystemActionResponse:
+    """Translate a sidecar HTTP response into a SystemActionResponse or raise."""
+    if resp.status_code == 401:
+        raise HTTPException(
+            status_code=500,
+            detail={"status": "error", "error": "fiestaupdater rejected our token; check FIESTAUPDATER_TOKEN matches in both services"},
+        )
+    if resp.status_code >= 400:
+        raise HTTPException(
+            status_code=502,
+            detail={"status": "error", "error": f"fiestaupdater returned {resp.status_code}: {resp.text[:200]}"},
+        )
+    return SystemActionResponse(status="queued", action=action)
+
+
+@app.post("/system/restart", response_model=SystemActionResponse)
+async def system_restart():
+    """Restart the FiestaBoard container via the fiestaupdater sidecar.
+
+    The connection will drop while the container restarts (~5 s).
+    Clients should poll /health until it comes back.
+    """
+    _require_updater_token()
+    try:
+        resp = await asyncio.to_thread(_updater_post, "/restart")
+    except requests.exceptions.ConnectionError:
+        raise HTTPException(
+            status_code=503,
+            detail={"status": "unavailable", "hint": "Could not reach the fiestaupdater sidecar."},
+        )
+    except Exception as e:
+        logger.warning("fiestaupdater restart call failed: %s", e)
+        raise HTTPException(status_code=502, detail={"status": "error", "error": str(e)})
+    return _handle_updater_response(resp, "restart")
+
+
+@app.post("/system/shutdown", response_model=SystemActionResponse)
+async def system_shutdown():
+    """Shut down the host machine via the fiestaupdater sidecar.
+
+    The sidecar stops all compose services, then powers off the host.
+    Requires the fiestaupdater container to have the SYS_BOOT capability
+    (cap_add: [SYS_BOOT] in docker-compose.yml).
+    """
+    _require_updater_token()
+    try:
+        resp = await asyncio.to_thread(_updater_post, "/shutdown")
+    except requests.exceptions.ConnectionError:
+        raise HTTPException(
+            status_code=503,
+            detail={"status": "unavailable", "hint": "Could not reach the fiestaupdater sidecar."},
+        )
+    except Exception as e:
+        logger.warning("fiestaupdater shutdown call failed: %s", e)
+        raise HTTPException(status_code=502, detail={"status": "error", "error": str(e)})
+    return _handle_updater_response(resp, "shutdown")
 
 
 @app.get("/logs")

--- a/tests/test_system_endpoints.py
+++ b/tests/test_system_endpoints.py
@@ -380,3 +380,89 @@ class TestSystemUpdateAutoToggle:
         assert r2.status_code == 200
         assert r2.json()["enabled"] is False
         assert _json.loads(state_file.read_text())["auto_update_enabled"] is False
+
+
+# =============================================================================
+# Tests for /system/restart
+# =============================================================================
+
+class TestSystemRestart:
+    """Tests for POST /system/restart."""
+
+    def test_no_token_returns_503(self, client, monkeypatch):
+        monkeypatch.delenv("FIESTAUPDATER_TOKEN", raising=False)
+        response = client.post("/system/restart")
+        assert response.status_code == 503
+        assert "hint" in response.json()["detail"]
+
+    def test_sidecar_unreachable_returns_503(self, client, monkeypatch):
+        import requests as _requests
+        monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
+        with patch(
+            "src.api_server.requests.post",
+            side_effect=_requests.exceptions.ConnectionError("nope"),
+        ):
+            response = client.post("/system/restart")
+        assert response.status_code == 503
+
+    def test_sidecar_rejects_token_returns_500(self, client, monkeypatch):
+        monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
+        bad = Mock(status_code=401, text="invalid_token")
+        with patch("src.api_server.requests.post", return_value=bad):
+            response = client.post("/system/restart")
+        assert response.status_code == 500
+        assert "FIESTAUPDATER_TOKEN" in response.json()["detail"]["error"]
+
+    def test_happy_path_returns_queued(self, client, monkeypatch):
+        monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
+        ok = Mock(status_code=202)
+        ok.json.return_value = {"status": "queued", "action": "restart"}
+        with patch("src.api_server.requests.post", return_value=ok):
+            response = client.post("/system/restart")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "queued"
+        assert data["action"] == "restart"
+
+
+# =============================================================================
+# Tests for /system/shutdown
+# =============================================================================
+
+class TestSystemShutdown:
+    """Tests for POST /system/shutdown."""
+
+    def test_no_token_returns_503(self, client, monkeypatch):
+        monkeypatch.delenv("FIESTAUPDATER_TOKEN", raising=False)
+        response = client.post("/system/shutdown")
+        assert response.status_code == 503
+        assert "hint" in response.json()["detail"]
+
+    def test_sidecar_unreachable_returns_503(self, client, monkeypatch):
+        import requests as _requests
+        monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
+        with patch(
+            "src.api_server.requests.post",
+            side_effect=_requests.exceptions.ConnectionError("nope"),
+        ):
+            response = client.post("/system/shutdown")
+        assert response.status_code == 503
+
+    def test_sidecar_rejects_token_returns_500(self, client, monkeypatch):
+        monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
+        bad = Mock(status_code=401, text="invalid_token")
+        with patch("src.api_server.requests.post", return_value=bad):
+            response = client.post("/system/shutdown")
+        assert response.status_code == 500
+        assert "FIESTAUPDATER_TOKEN" in response.json()["detail"]["error"]
+
+    def test_happy_path_returns_queued(self, client, monkeypatch):
+        monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
+        ok = Mock(status_code=202)
+        ok.json.return_value = {"status": "queued", "action": "shutdown"}
+        with patch("src.api_server.requests.post", return_value=ok):
+            response = client.post("/system/shutdown")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "queued"
+        assert data["action"] == "shutdown"

--- a/web/src/__tests__/mocks/handlers.ts
+++ b/web/src/__tests__/mocks/handlers.ts
@@ -1058,6 +1058,14 @@ export const handlers = [
     });
   }),
 
+  http.post(`${API_BASE}/system/restart`, () => {
+    return HttpResponse.json({ status: "queued", action: "restart" }, { status: 200 });
+  }),
+
+  http.post(`${API_BASE}/system/shutdown`, () => {
+    return HttpResponse.json({ status: "queued", action: "shutdown" }, { status: 200 });
+  }),
+
   // Polling settings endpoints
   http.get(`${API_BASE}/settings/polling`, () => {
     return HttpResponse.json({

--- a/web/src/__tests__/system-controls.test.tsx
+++ b/web/src/__tests__/system-controls.test.tsx
@@ -1,0 +1,139 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ThemeProvider } from "next-themes";
+import { http, HttpResponse } from "msw";
+import { server } from "./mocks/server";
+import { SystemControls } from "@/components/settings/system-controls";
+
+const API_BASE = "/api";
+
+function TestWrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider attribute="class" defaultTheme="light">
+        {children}
+      </ThemeProvider>
+    </QueryClientProvider>
+  );
+}
+
+function withSidecar(available: boolean) {
+  server.use(
+    http.get(`${API_BASE}/system/update/status`, () => {
+      return HttpResponse.json({
+        updater_available: available,
+        auto_update_enabled: false,
+        profile: "docker",
+        sidecar_url: "http://fiestaupdater:8765",
+        last_check: null,
+        last_update: null,
+      });
+    })
+  );
+}
+
+describe("SystemControls", () => {
+  it("renders nothing when sidecar is unavailable", async () => {
+    withSidecar(false);
+    render(<SystemControls />, { wrapper: TestWrapper });
+
+    await waitFor(() => {
+      expect(screen.queryByText("System")).not.toBeInTheDocument();
+    });
+  });
+
+  it("renders System card when sidecar is available", async () => {
+    withSidecar(true);
+    render(<SystemControls />, { wrapper: TestWrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("System")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Restart")).toBeInTheDocument();
+    expect(screen.getByText("Shutdown")).toBeInTheDocument();
+  });
+
+  it("shows update button labeled Re-pull Latest when up to date", async () => {
+    withSidecar(true);
+    render(<SystemControls />, { wrapper: TestWrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Re-pull Latest")).toBeInTheDocument();
+    });
+  });
+
+  it("shows Update Now button when update is available", async () => {
+    withSidecar(true);
+    server.use(
+      http.get(`${API_BASE}/system/update-check`, () => {
+        return HttpResponse.json({
+          current_version: "2.0.1",
+          latest_version: "2.0.2",
+          update_available: true,
+          package_url: "https://github.com/Fiestaboard/FiestaBoard/releases/latest",
+          error: null,
+          is_production: true,
+        });
+      })
+    );
+
+    render(<SystemControls />, { wrapper: TestWrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Update Now")).toBeInTheDocument();
+    });
+  });
+
+  it("shows restart confirmation dialog on Restart click", async () => {
+    withSidecar(true);
+    render(<SystemControls />, { wrapper: TestWrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Restart")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Restart"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Restart FiestaBoard?")).toBeInTheDocument();
+    });
+  });
+
+  it("shows shutdown confirmation dialog on Shutdown click", async () => {
+    withSidecar(true);
+    render(<SystemControls />, { wrapper: TestWrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Shutdown")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Shutdown"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Shut Down Host?")).toBeInTheDocument();
+    });
+  });
+
+  it("cancels restart dialog without action", async () => {
+    withSidecar(true);
+    render(<SystemControls />, { wrapper: TestWrapper });
+
+    await waitFor(() => screen.getByText("Restart"));
+    fireEvent.click(screen.getByText("Restart"));
+    await waitFor(() => screen.getByText("Restart FiestaBoard?"));
+
+    fireEvent.click(screen.getByText("Cancel"));
+
+    await waitFor(() => {
+      expect(screen.queryByText("Restart FiestaBoard?")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -4,6 +4,7 @@ import { DisplaySettings } from "@/components/settings/display-settings";
 import { TransitionSettings } from "@/components/settings/transition-settings";
 import { DebugSettings } from "@/components/settings/debug-settings";
 import { SystemUpdate } from "@/components/settings/system-update";
+import { SystemControls } from "@/components/settings/system-controls";
 import { MqttSettingsCard } from "@/components/settings/mqtt-settings";
 import { LocationSettingsCard } from "@/components/settings/location-settings";
 import { GeneralSettings } from "@/components/general-settings";
@@ -51,7 +52,11 @@ export default function SettingsPage() {
           <DebugSettings />
         </div>
 
-        <Card className="animate-card-fade-in" style={{ animationDelay: "540ms" }}>
+        <div className="animate-card-fade-in" style={{ animationDelay: "520ms" }}>
+          <SystemControls />
+        </div>
+
+        <Card className="animate-card-fade-in" style={{ animationDelay: "560ms" }}>
           <CardHeader>
             <CardTitle className="text-base flex items-center gap-2">
               <Wand2 className="h-4 w-4" />

--- a/web/src/components/settings/system-controls.tsx
+++ b/web/src/components/settings/system-controls.tsx
@@ -1,0 +1,327 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  ArrowUpCircle,
+  Loader2,
+  Power,
+  RefreshCw,
+  Cpu,
+} from "lucide-react";
+
+/**
+ * Settings → System Controls card.
+ *
+ * Always visible when the fiestaupdater sidecar is reachable.
+ * Shows three actions:
+ *   - Update Now: pull the latest image and recreate the container
+ *   - Restart:    restart just the fiestaboard container
+ *   - Shutdown:   gracefully stop services and power off the host
+ *
+ * Each action shows a confirmation dialog before proceeding.
+ * Restart shows a full-screen overlay while the container comes back.
+ * Shutdown shows a final "shutting down" screen (no automatic reload).
+ */
+export function SystemControls() {
+  const { data: status, isLoading } = useQuery({
+    queryKey: ["update-status"],
+    queryFn: () => api.getUpdateStatus(),
+    staleTime: 1000 * 30,
+    retry: false,
+  });
+
+  const { data: updateCheck } = useQuery({
+    queryKey: ["update-check"],
+    queryFn: () => api.checkForUpdate(),
+    staleTime: 1000 * 60 * 60,
+    retry: false,
+  });
+
+  const [confirmAction, setConfirmAction] = useState<
+    "update" | "restart" | "shutdown" | null
+  >(null);
+  const [activeOverlay, setActiveOverlay] = useState<
+    "restarting" | "shutdown" | null
+  >(null);
+
+  const updateMutation = useMutation({
+    mutationFn: () => api.applyUpdate(),
+    onSuccess: () => setActiveOverlay("restarting"),
+  });
+
+  const restartMutation = useMutation({
+    mutationFn: () => api.restartSystem(),
+    onSuccess: () => setActiveOverlay("restarting"),
+  });
+
+  const shutdownMutation = useMutation({
+    mutationFn: () => api.shutdownSystem(),
+    onSuccess: () => setActiveOverlay("shutdown"),
+  });
+
+  if (isLoading || !status?.updater_available) {
+    return null;
+  }
+
+  const updateAvailable = !!updateCheck?.update_available;
+  const anyPending =
+    updateMutation.isPending ||
+    restartMutation.isPending ||
+    shutdownMutation.isPending ||
+    !!activeOverlay;
+
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base flex items-center gap-2">
+            <Cpu className="h-4 w-4" />
+            System
+          </CardTitle>
+          <CardDescription>
+            Manage FiestaBoard updates and host power.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-wrap gap-2">
+            <Button
+              variant={updateAvailable ? "default" : "outline"}
+              size="sm"
+              onClick={() => setConfirmAction("update")}
+              disabled={anyPending}
+            >
+              {updateMutation.isPending ? (
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+              ) : (
+                <ArrowUpCircle className="h-4 w-4 mr-2" />
+              )}
+              {updateAvailable ? "Update Now" : "Re-pull Latest"}
+            </Button>
+
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setConfirmAction("restart")}
+              disabled={anyPending}
+            >
+              {restartMutation.isPending ? (
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+              ) : (
+                <RefreshCw className="h-4 w-4 mr-2" />
+              )}
+              Restart
+            </Button>
+
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setConfirmAction("shutdown")}
+              disabled={anyPending}
+              className="text-destructive hover:text-destructive"
+            >
+              {shutdownMutation.isPending ? (
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+              ) : (
+                <Power className="h-4 w-4 mr-2" />
+              )}
+              Shutdown
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Update confirmation */}
+      <Dialog
+        open={confirmAction === "update"}
+        onOpenChange={(open) => !open && setConfirmAction(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {updateAvailable ? "Update FiestaBoard?" : "Re-pull Latest Image?"}
+            </DialogTitle>
+            <DialogDescription>
+              {updateAvailable
+                ? `This will pull v${updateCheck?.latest_version} and recreate the FiestaBoard container. The board display will pause for about 30 seconds and this page will reload automatically.`
+                : "This will pull the latest image for the current version and recreate the container. Useful if you want to ensure you're running the newest build of the same version."}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmAction(null)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() => {
+                setConfirmAction(null);
+                updateMutation.mutate();
+              }}
+            >
+              <ArrowUpCircle className="h-4 w-4 mr-2" />
+              {updateAvailable ? "Update now" : "Re-pull now"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Restart confirmation */}
+      <Dialog
+        open={confirmAction === "restart"}
+        onOpenChange={(open) => !open && setConfirmAction(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Restart FiestaBoard?</DialogTitle>
+            <DialogDescription>
+              This will restart the FiestaBoard container. The board display
+              will pause for about 5–10 seconds and this page will reload
+              automatically.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmAction(null)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() => {
+                setConfirmAction(null);
+                restartMutation.mutate();
+              }}
+            >
+              <RefreshCw className="h-4 w-4 mr-2" />
+              Restart now
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Shutdown confirmation */}
+      <Dialog
+        open={confirmAction === "shutdown"}
+        onOpenChange={(open) => !open && setConfirmAction(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Shut Down Host?</DialogTitle>
+            <DialogDescription>
+              This will stop all FiestaBoard services and power off the host
+              machine. You will need physical access (or remote SSH) to turn it
+              back on.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfirmAction(null)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                setConfirmAction(null);
+                shutdownMutation.mutate();
+              }}
+            >
+              <Power className="h-4 w-4 mr-2" />
+              Shut down
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Restarting overlay (update or restart) */}
+      {activeOverlay === "restarting" && (
+        <RestartingOverlay />
+      )}
+
+      {/* Shutdown overlay */}
+      {activeOverlay === "shutdown" && (
+        <ShutdownOverlay />
+      )}
+    </>
+  );
+}
+
+/**
+ * Full-screen overlay shown while the container restarts.
+ * Polls /health every 2 s; once it answers, reloads the page.
+ */
+function RestartingOverlay() {
+  const [phase, setPhase] = useState<"restarting" | "ready">("restarting");
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const tick = async () => {
+      if (cancelled) return;
+      try {
+        await api.getVersion();
+        if (!cancelled) {
+          setPhase("ready");
+          setTimeout(() => window.location.reload(), 800);
+          return;
+        }
+      } catch {
+        // Still coming back up — keep polling.
+      }
+      setTimeout(tick, 2000);
+    };
+
+    // Short initial delay to let Docker actually stop the container before
+    // we start polling (otherwise we'd immediately see the old instance).
+    setTimeout(tick, 3000);
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <div className="fixed inset-0 z-[100] bg-background/95 backdrop-blur-sm flex items-center justify-center">
+      <div className="text-center space-y-4">
+        <Loader2 className="h-12 w-12 mx-auto animate-spin text-primary" />
+        <h2 className="text-xl font-semibold">
+          {phase === "restarting" ? "Restarting FiestaBoard…" : "Back online. Reloading…"}
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          {phase === "restarting"
+            ? "This will take about 5–10 seconds."
+            : "Almost there…"}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Full-screen overlay shown after a shutdown is initiated.
+ * No automatic reload — the host is powering off.
+ */
+function ShutdownOverlay() {
+  return (
+    <div className="fixed inset-0 z-[100] bg-background/95 backdrop-blur-sm flex items-center justify-center">
+      <div className="text-center space-y-4">
+        <Power className="h-12 w-12 mx-auto text-muted-foreground" />
+        <h2 className="text-xl font-semibold">Shutting down…</h2>
+        <p className="text-sm text-muted-foreground max-w-sm mx-auto">
+          FiestaBoard is stopping services and powering off the host. Turn the
+          power back on to restart.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -942,6 +942,11 @@ export interface UpdateApplyResponse {
   hint?: string | null;
 }
 
+export interface SystemActionResponse {
+  status: "queued";
+  action: "restart" | "shutdown";
+}
+
 
 
 // API client with typed methods
@@ -1381,6 +1386,12 @@ export const api = {
       method: "POST",
       body: JSON.stringify({ enabled }),
     }),
+
+  restartSystem: () =>
+    fetchApi<SystemActionResponse>("/system/restart", { method: "POST" }),
+
+  shutdownSystem: () =>
+    fetchApi<SystemActionResponse>("/system/shutdown", { method: "POST" }),
 
   // Plugin system endpoints
   listPlugins: () =>


### PR DESCRIPTION
Completes the Pi self-management story by adding **Restart** and **Shutdown** actions alongside the existing **Update Now** flow.

## What changed

### fiestaupdater sidecar
- `POST /restart` — runs `docker compose restart <service>` in the background (`nohup`) and returns 202 immediately, so the response flushes before the container dies
- `POST /shutdown` — stops compose services then calls `poweroff -f`
- Both routes go through the existing bearer-token auth gate
- New bats tests for both routes (happy path, 401, missing compose file)

### Compose files
- Added `cap_add: SYS_BOOT` to the `fiestaupdater` service in `docker-compose.yml`, `docker-compose.hub.yml`, and the Pi image compose file — required for `poweroff` inside the container

### API server
- `POST /system/restart` and `POST /system/shutdown` endpoints
- Shared helpers `_updater_post()`, `_require_updater_token()`, `_handle_updater_response()` extracted to avoid duplication with the existing update path
- `SystemActionResponse` Pydantic model

### Web UI
- New **System** card in Settings (`SystemControls` component) with **Update Now**, **Restart**, and **Shutdown** buttons
- Hidden entirely when the fiestaupdater sidecar is unreachable — non-Pi Docker users never see it
- Confirmation dialogs before each action
- Restart shows a reconnecting overlay while the container comes back; Shutdown shows a final "shutting down" screen
- `restartSystem()` and `shutdownSystem()` added to `api.ts`
- `system-controls.test.tsx` with full MSW mocks

## Testing
- `bats fiestaupdater/tests/` — covers new routes
- `pytest tests/test_system_endpoints.py` — covers new API endpoints
- Jest `system-controls.test.tsx` — covers the UI component