### PR TITLE
fix(fiestaupdater): mount .env into sidecar so in-app updates actually run

### DIFF
--- a/docker-compose.hub.yml
+++ b/docker-compose.hub.yml
@@ -53,6 +53,13 @@ services:
       # Read the same compose file the user deployed with so we update the
       # exact same service definition.
       - ./docker-compose.hub.yml:/compose/docker-compose.yml:ro
+      # The compose file references `env_file: .env` for the fiestaboard
+      # service.  When the sidecar runs `docker compose -f /compose/...`,
+      # Compose resolves `.env` relative to the compose file's directory.
+      # Without this mount, every pull/up/restart fails with
+      # "env file /compose/.env not found" and the in-app updater silently
+      # no-ops.
+      - ./.env:/compose/.env:ro
     logging:
       driver: "json-file"
       options:

--- a/pi-image/stage-fiestaboard/01-install-fiestaboard/files/docker-compose.yml
+++ b/pi-image/stage-fiestaboard/01-install-fiestaboard/files/docker-compose.yml
@@ -42,6 +42,13 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - /opt/fiestaboard/docker-compose.yml:/compose/docker-compose.yml:ro
+      # The compose file references `env_file: .env` for the fiestaboard
+      # service.  When the sidecar runs `docker compose -f /compose/...`,
+      # Compose resolves `.env` relative to the compose file's directory.
+      # Without this mount, every pull/up/restart fails with
+      # "env file /compose/.env not found" and the in-app updater silently
+      # no-ops.
+      - /opt/fiestaboard/.env:/compose/.env:ro
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
## Problem

Clicking **Update Now** in Settings → System spins forever. The API records \`last_update\` based on the sidecar's \`202 Accepted\` ack, but the fiestaboard container is never actually recreated, so \`/api/version\` keeps reporting the old version and \`UpdatingOverlay\` polls indefinitely.

Reproduced on a 5.0.1 → 5.1.0 update on a flashed FiestaPi (192.168.0.247).

## Root cause

The fiestaupdater sidecar runs \`docker compose -f /compose/docker-compose.yml pull/up/restart\` against a bind-mounted compose file. That compose file declares:

\`\`\`yaml
fiestaboard:
  env_file:
    - .env
\`\`\`

Compose resolves \`.env\` **relative to the compose file's directory**, i.e. \`/compose/.env\` inside the sidecar. We never mounted the host \`.env\` there, so every \`pull\` / \`up -d\` / \`restart\` aborts with \`env file /compose/.env not found\`. Because the sidecar runs the update via \`nohup bash -c '...' &\`, the failure happens after the \`202\` is sent to the client and is only visible in \`docker logs fiestaupdater\`.

## Fix

Mount the host \`.env\` at \`/compose/.env\` (read-only) in both compose files used by the sidecar:

- \`docker-compose.hub.yml\` — Docker Hub installs
- \`pi-image/stage-fiestaboard/01-install-fiestaboard/files/docker-compose.yml\` — FiestaPi flashable image

## Existing installs

This change only fixes **new** flashes / fresh \`docker compose up -d\` runs. Existing FiestaPi devices need to manually add the volume and recreate the sidecar:

\`\`\`bash
cd /opt/fiestaboard
sudo cp docker-compose.yml docker-compose.yml.bak
# Add under fiestaupdater: volumes:
#   - /opt/fiestaboard/.env:/compose/.env:ro
docker compose --profile fiestaupdater up -d fiestaupdater
\`\`\`

We may want a release note / migration step for this.

## Follow-ups (not in this PR)

- \`UpdatingOverlay\` has no timeout — it should surface a "still updating after N minutes? check \`docker logs fiestaupdater\`" branch instead of spinning forever.
- Consider having the sidecar tail its own update output and expose it via a status endpoint so the UI can show progress / failure.