### PR TITLE
ci(fiestapi): build on native arm64 runner; trim shared path filter

### DIFF
--- a/.github/workflows/build-fiestapi.yml
+++ b/.github/workflows/build-fiestapi.yml
@@ -30,7 +30,10 @@ permissions:
 jobs:
   build:
     name: Build .img.xz with pi-gen
-    runs-on: ubuntu-latest
+    # Native arm64 runner — pi-gen's arm64 branch builds the image directly
+    # without qemu/binfmt emulation, which is both faster and avoids the
+    # flaky qemu setup that previously failed on ubuntu-latest (amd64).
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 90
     steps:
       - name: Checkout FiestaBoard

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,17 @@ jobs:
               - 'plugins/**'
             shared:
               - 'docker-compose*.yml'
+              # Workflow changes can affect any job, but exclude workflows
+              # that build artifacts unrelated to the app (pi-gen image,
+              # fiestaupdater container, docs site, registry scan, PR
+              # labelling). Those have their own pipelines and don't need
+              # to retrigger Platform/Web tests when edited in isolation.
               - '.github/workflows/**'
+              - '!.github/workflows/build-fiestapi.yml'
+              - '!.github/workflows/build-fiestaupdater.yml'
+              - '!.github/workflows/docs.yml'
+              - '!.github/workflows/registry-scan.yml'
+              - '!.github/workflows/pr-label.yml'
               - 'package.json'
               - 'scripts/version-sync.js'
             docs:


### PR DESCRIPTION
## Why

The `Build FiestaPi image` workflow was failing because it ran on `ubuntu-latest` (amd64) and pi-gen's `arm64` branch needed qemu/binfmt to cross-build — the qemu setup was flaky.

We don't need emulation: GitHub provides free native arm64 runners for public repos, and `release.yml` already uses one for arm64 image builds.

## Changes

### 1. `build-fiestapi.yml` → native arm64 runner
Switch `runs-on` from `ubuntu-latest` to `ubuntu-24.04-arm`. pi-gen runs natively, no qemu, and the build should be considerably faster than emulated.

### 2. `ci.yml` → trim the \`shared\` path filter
Previously *any* change under `.github/workflows/**` triggered Platform Tests + Web Tests. That included pi-gen image builds, the fiestaupdater container build, docs, registry-scan, and pr-label — none of which touch the app.

Excluded those workflows from `shared` so editing the pi build (or any of those other ancillary workflows) no longer runs the full app test suite. They each have their own pipelines.

> Answering the question \"if I edit pi build, do we need to build the whole app?\" — no, and now we don't.

## Test plan

- After merge, trigger `Build FiestaPi image` via `workflow_dispatch` to confirm a green run on arm64.
- This PR itself should *not* trigger Platform/Web tests (since the only workflow change is to `build-fiestapi.yml` — which is now excluded — plus `ci.yml` itself, which still matches `shared`). Realistically `ci.yml` will still trigger because it's in `shared`, which is correct: a CI config change should be validated.