### PR TITLE
ci(fiestapi): fix stage symlink + attach image to latest app release

### DIFF
--- a/.github/workflows/build-fiestapi.yml
+++ b/.github/workflows/build-fiestapi.yml
@@ -68,7 +68,11 @@ jobs:
       - name: Wire FiestaBoard stage into pi-gen
         run: |
           cd pi-gen
-          ln -s "$GITHUB_WORKSPACE/FiestaBoard/pi-image/stage-fiestaboard" stage-fiestaboard
+          # Copy (don't symlink) — pi-gen's build-docker.sh runs inside a
+          # container that only bind-mounts the pi-gen directory itself,
+          # so a symlink to $GITHUB_WORKSPACE/FiestaBoard/... is dangling
+          # inside the container and `realpath stage-fiestaboard` fails.
+          cp -r "$GITHUB_WORKSPACE/FiestaBoard/pi-image/stage-fiestaboard" stage-fiestaboard
           cp "$GITHUB_WORKSPACE/FiestaBoard/pi-image/config" config
           # Skip stages we don't ship. stage2/SKIP_IMAGES prevents a second
           # image from being exported (we export from stage-fiestaboard via

--- a/.github/workflows/build-fiestapi.yml
+++ b/.github/workflows/build-fiestapi.yml
@@ -153,7 +153,7 @@ jobs:
           # 30 days — weekly builds rotate frequently; grab the latest.
           retention-days: 30
 
-      - name: Attach to release (major-version tag builds only)
+      - name: Attach to major-version release (tag builds only)
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
@@ -190,6 +190,30 @@ jobs:
           files: |
             ${{ steps.out.outputs.img }}
             ${{ steps.checksum.outputs.sha256 }}
+
+      - name: Publish weekly/manual build as prerelease
+        # Weekly cron and manual dispatch builds — create/update a
+        # prerelease tagged 'fiestapi-<version>' (e.g. fiestapi-2026-W18)
+        # so the .img.xz is preserved beyond the 30-day artifact window
+        # and can be linked from docs / shared with testers.
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: fiestapi-${{ steps.version.outputs.version }}
+          name: FiestaPi ${{ steps.version.outputs.version }}
+          prerelease: true
+          # Replace the asset if the same tag is rebuilt (e.g. manual reruns).
+          files: |
+            ${{ steps.out.outputs.img }}
+            ${{ steps.checksum.outputs.sha256 }}
+          body: |
+            Automated FiestaPi image build.
+
+            - Trigger: `${{ github.event_name }}`
+            - Commit: ${{ github.sha }}
+            - Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+            Flash the attached `.img.xz` to a Raspberry Pi using Raspberry Pi Imager.
 
       - name: Update latest-version file in docs (tag builds only)
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
Follow-up to #654.

## Why

Two issues with the FiestaPi image build, surfaced after #654 merged and we did a real run:

### 1. Build still failing at end of stage2
\`\`\`
realpath: stage-fiestaboard: No such file or directory
[05:34:21] Build failed
\`\`\`

pi-gen's `build-docker.sh` runs the build inside a container that only bind-mounts the `pi-gen/` directory itself. The symlink we used to wire in `stage-fiestaboard` points at `\$GITHUB_WORKSPACE/FiestaBoard/...` — that path is dangling inside the container, so `realpath stage-fiestaboard` fails after stage2 completes.

### 2. Where should non-major builds publish to?
The 30-day workflow artifact disappears, so weekly + manual builds had no permanent home. Initial draft of this PR created a separate \`fiestapi-<version>\` prerelease, but per review that's duplicative — each app version's release page (e.g. \`v5.1.1\`) should be the single home for both the code release and the matching FiestaPi \`.img.xz\`.

## Changes (\`build-fiestapi.yml\`)

1. **Copy `stage-fiestaboard` into pi-gen instead of symlinking.** `cp -r` survives pi-gen's container bind-mount.

2. **Attach FiestaPi image to the latest app release instead of a separate prerelease.**
   - New \`Resolve latest app release tag\` step (non-tag builds) finds the most recent non-draft, non-prerelease \`v*\` tag via \`gh release list\`.
   - \`Attach FiestaPi image to latest app release\` uploads the \`.img.xz\` and \`.sha256\` to that release without touching its existing body.
   - \`softprops/action-gh-release@v2\` replaces same-named assets in place, so weekly + manual reruns overwrite cleanly. Each app release ends up with exactly one current FiestaPi image.

3. **Make checksum generation unconditional** — it's now needed for every build path (was tag-only).

4. **Major-tag builds (vN.0.0) unchanged** — still create + populate their own release with the full FiestaPi description and Wi-Fi setup notes.

## Test plan

- After merge, trigger \`Build FiestaPi image\` via \`workflow_dispatch\`. Verify:
  - Build completes (the `cp -r` change should fix the realpath failure).
  - The \`.img.xz\` + \`.sha256\` show up as assets on the latest app release (currently https://github.com/Fiestaboard/FiestaBoard/releases/tag/v5.1.1).
  - Re-triggering replaces the assets in place rather than appending duplicates.
- The existing https://github.com/Fiestaboard/FiestaBoard/releases/tag/fiestapi-2026-W18 prerelease (created by the earlier validation run) can be deleted manually — won't recur.

## Notes

- Workflow artifact upload (30-day) is unchanged — still useful for grabbing the image directly from the run page.
- \`GITHUB_TOKEN\` already has \`contents: write\`, sufficient for both reading release list and uploading assets.