### PR TITLE
feat(ui): global full-screen overlay for system updates

### DIFF
--- a/web/src/components/providers.tsx
+++ b/web/src/components/providers.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import { ConfigOverridesProvider } from "@/hooks/use-config-overrides";
 import { SidebarProvider } from "@/components/sidebar-context";
 import { FormatPreferencesProvider } from "@/hooks/use-format-preferences";
+import { UpdateProvider } from "@/components/update-context";
 
 export function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(
@@ -39,7 +40,9 @@ export function Providers({ children }: { children: React.ReactNode }) {
       >
         <SidebarProvider>
           <ConfigOverridesProvider>
-            <FormatPreferencesProvider>{children}</FormatPreferencesProvider>
+            <FormatPreferencesProvider>
+              <UpdateProvider>{children}</UpdateProvider>
+            </FormatPreferencesProvider>
           </ConfigOverridesProvider>
         </SidebarProvider>
       </ThemeProvider>

--- a/web/src/components/settings/system-controls.tsx
+++ b/web/src/components/settings/system-controls.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api";
+import { useUpdate } from "@/components/update-context";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -59,17 +60,19 @@ export function SystemControls() {
     "update" | "restart" | "shutdown" | null
   >(null);
   const [activeOverlay, setActiveOverlay] = useState<
-    "restarting" | "shutdown" | null
+    "restart" | "shutdown" | null
   >(null);
+
+  const { startUpdate } = useUpdate();
 
   const updateMutation = useMutation({
     mutationFn: () => api.applyUpdate(),
-    onSuccess: () => setActiveOverlay("restarting"),
+    onSuccess: () => startUpdate(updateCheck?.current_version),
   });
 
   const restartMutation = useMutation({
     mutationFn: () => api.restartSystem(),
-    onSuccess: () => setActiveOverlay("restarting"),
+    onSuccess: () => setActiveOverlay("restart"),
   });
 
   const shutdownMutation = useMutation({
@@ -244,8 +247,8 @@ export function SystemControls() {
         </DialogContent>
       </Dialog>
 
-      {/* Restarting overlay (update or restart) */}
-      {activeOverlay === "restarting" && (
+      {/* Restarting overlay for plain container restart (not update). */}
+      {activeOverlay === "restart" && (
         <RestartingOverlay />
       )}
 
@@ -257,38 +260,101 @@ export function SystemControls() {
   );
 }
 
+// Timeout before showing the "something went wrong" error state.
+const RESTART_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
 /**
- * Full-screen overlay shown while the container restarts.
- * Polls /health every 2 s; once it answers, reloads the page.
+ * Full-screen overlay shown while the container restarts (restart or update).
+ *
+ * For updates the old container keeps running during the image pull, so a
+ * naive "poll until /version responds" would reload the page immediately
+ * against the still-running old container.  Instead we use a two-phase
+ * approach:
+ *
+ *   Phase 1 (restarting): poll every 2 s.  Wait until the API goes DOWN
+ *     (catch) OR until a version change is detected (if currentVersion is
+ *     provided).  Track everWentDown so phase 2 knows a real restart began.
+ *   Phase 2 (back up): poll every 2 s.  Once the API responds successfully
+ *     after having been down, reload.
+ *
+ * A 5-minute timeout surfaces an error state with a manual refresh button
+ * so the user is never stuck in an infinite spinner.
  */
-function RestartingOverlay() {
-  const [phase, setPhase] = useState<"restarting" | "ready">("restarting");
+function RestartingOverlay({
+  currentVersion,
+}: {
+  currentVersion?: string;
+}) {
+  const [phase, setPhase] = useState<"restarting" | "ready" | "error">("restarting");
 
   useEffect(() => {
     let cancelled = false;
+    let everWentDown = false;
+    const deadline = Date.now() + RESTART_TIMEOUT_MS;
 
     const tick = async () => {
       if (cancelled) return;
+      if (Date.now() >= deadline) {
+        setPhase("error");
+        return;
+      }
       try {
-        await api.getVersion();
-        if (!cancelled) {
-          setPhase("ready");
-          setTimeout(() => window.location.reload(), 800);
+        const v = await api.getVersion();
+        if (everWentDown) {
+          // Container came back after a real restart — reload.
+          if (!cancelled) {
+            setPhase("ready");
+            setTimeout(() => window.location.reload(), 800);
+          }
+          return;
+        }
+        // Container is still running.  If a version change is detected
+        // (e.g. image was swapped without a visible down period), reload.
+        if (
+          currentVersion &&
+          v.package_version &&
+          v.package_version !== currentVersion
+        ) {
+          if (!cancelled) {
+            setPhase("ready");
+            setTimeout(() => window.location.reload(), 800);
+          }
           return;
         }
       } catch {
-        // Still coming back up — keep polling.
+        // API is down — the container stopped.  Start watching for it to
+        // come back.
+        everWentDown = true;
       }
       setTimeout(tick, 2000);
     };
 
-    // Short initial delay to let Docker actually stop the container before
-    // we start polling (otherwise we'd immediately see the old instance).
-    setTimeout(tick, 3000);
+    // Brief initial pause before the first poll.  This lets Docker process
+    // the restart/update command so the container has a chance to stop
+    // before we begin checking.
+    setTimeout(tick, 1500);
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [currentVersion]);
+
+  if (phase === "error") {
+    return (
+      <div className="fixed inset-0 z-[100] bg-background/95 backdrop-blur-sm flex items-center justify-center">
+        <div className="text-center space-y-4 max-w-sm mx-auto px-4">
+          <h2 className="text-xl font-semibold">Taking longer than expected</h2>
+          <p className="text-sm text-muted-foreground">
+            FiestaBoard may still be restarting. Check the container logs, then
+            refresh this page.
+          </p>
+          <Button variant="outline" onClick={() => window.location.reload()}>
+            <RefreshCw className="h-4 w-4 mr-2" />
+            Refresh page
+          </Button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="fixed inset-0 z-[100] bg-background/95 backdrop-blur-sm flex items-center justify-center">

--- a/web/src/components/settings/system-update.tsx
+++ b/web/src/components/settings/system-update.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useQuery, useQueryClient, useMutation } from "@tanstack/react-query";
 import { api } from "@/lib/api";
+import { useUpdate } from "@/components/update-context";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -23,7 +24,6 @@ import {
 import {
   ArrowUpCircle,
   ExternalLink,
-  Loader2,
   RefreshCw,
 } from "lucide-react";
 
@@ -43,7 +43,7 @@ import {
 export function SystemUpdate() {
   const queryClient = useQueryClient();
   const [confirmOpen, setConfirmOpen] = useState(false);
-  const [updating, setUpdating] = useState(false);
+  const { startUpdate } = useUpdate();
 
   const { data: updateCheck, isLoading, isError } = useQuery({
     queryKey: ["update-check"],
@@ -61,8 +61,7 @@ export function SystemUpdate() {
 
   const applyMutation = useMutation({
     mutationFn: () => api.applyUpdate(),
-    onMutate: () => setUpdating(true),
-    onError: () => setUpdating(false),
+    onSuccess: () => startUpdate(updateCheck?.current_version),
   });
 
   if (isLoading || isError || !updateCheck || !updateCheck.update_available) {
@@ -100,7 +99,7 @@ export function SystemUpdate() {
               <Button
                 size="sm"
                 onClick={() => setConfirmOpen(true)}
-                disabled={applyMutation.isPending || updating}
+                disabled={applyMutation.isPending}
               >
                 <ArrowUpCircle className="h-4 w-4 mr-2" />
                 Update Now
@@ -163,74 +162,6 @@ export function SystemUpdate() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
-
-      {updating && (
-        <UpdatingOverlay currentVersion={updateCheck.current_version} />
-      )}
     </TooltipProvider>
-  );
-}
-
-/**
- * Full-screen overlay shown while the sidecar recreates the fiestaboard
- * container.  Polls /version every 2s.  Once it reports a different
- * version than we started with, reload the page to pick up the new web
- * bundle.
- */
-function UpdatingOverlay({ currentVersion }: { currentVersion: string }) {
-  const [phase, setPhase] = useState<"pulling" | "restarting" | "ready">(
-    "pulling",
-  );
-
-  useEffect(() => {
-    let cancelled = false;
-    let consecutiveOk = 0;
-
-    const tick = async () => {
-      if (cancelled) return;
-      try {
-        const v = await api.getVersion();
-        if (v.package_version && v.package_version !== currentVersion) {
-          consecutiveOk += 1;
-          if (consecutiveOk >= 2) {
-            setPhase("ready");
-            setTimeout(() => window.location.reload(), 800);
-            return;
-          }
-        }
-      } catch {
-        // Connection refused / timeout while the new container starts up.
-        setPhase("restarting");
-        consecutiveOk = 0;
-      }
-      setTimeout(tick, 2000);
-    };
-
-    tick();
-    return () => {
-      cancelled = true;
-    };
-  }, [currentVersion]);
-
-  const message =
-    phase === "pulling"
-      ? "Pulling the latest image…"
-      : phase === "restarting"
-        ? "Restarting FiestaBoard…"
-        : "Update complete. Reloading…";
-
-  return (
-    <div className="fixed inset-0 z-[100] bg-background/95 backdrop-blur-sm flex items-center justify-center">
-      <div className="text-center space-y-4">
-        <Loader2 className="h-12 w-12 mx-auto animate-spin text-primary" />
-        <h2 className="text-xl font-semibold">Updating FiestaBoard</h2>
-        <p className="text-sm text-muted-foreground max-w-sm mx-auto">
-          {message}
-        </p>
-        <p className="text-xs text-muted-foreground">
-          Don&apos;t close this tab — it will reload automatically.
-        </p>
-      </div>
-    </div>
   );
 }

--- a/web/src/components/update-context.tsx
+++ b/web/src/components/update-context.tsx
@@ -1,0 +1,274 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { api } from "@/lib/api";
+import { Button } from "@/components/ui/button";
+import { Loader2, RefreshCw } from "lucide-react";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type UpdatePhase = "pulling" | "restarting" | "ready" | "error";
+
+interface UpdateContextValue {
+  isUpdating: boolean;
+  startUpdate: (currentVersion?: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+const UpdateContext = createContext<UpdateContextValue>({
+  isUpdating: false,
+  startUpdate: () => {},
+});
+
+// ---------------------------------------------------------------------------
+// localStorage persistence key
+// Stored value: JSON string of { fromVersion?: string; startedAt: number }
+// ---------------------------------------------------------------------------
+
+const LS_KEY = "fb_updating";
+const MAX_AGE_MS = 10 * 60 * 1000; // 10 minutes — matches UPDATE_TIMEOUT_MS
+
+function readPersisted(): { fromVersion?: string; startedAt: number } | null {
+  try {
+    const raw = localStorage.getItem(LS_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as { fromVersion?: string; startedAt: number };
+    if (typeof parsed.startedAt !== "number") return null;
+    if (Date.now() - parsed.startedAt > MAX_AGE_MS) {
+      localStorage.removeItem(LS_KEY);
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function writePersisted(fromVersion?: string) {
+  try {
+    localStorage.setItem(
+      LS_KEY,
+      JSON.stringify({ fromVersion, startedAt: Date.now() }),
+    );
+  } catch {}
+}
+
+function clearPersisted() {
+  try {
+    localStorage.removeItem(LS_KEY);
+  } catch {}
+}
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+export function UpdateProvider({ children }: { children: React.ReactNode }) {
+  const [isUpdating, setIsUpdating] = useState(false);
+  const [currentVersion, setCurrentVersion] = useState<string | undefined>(
+    undefined,
+  );
+
+  // On mount: resume an in-progress update if a recent entry exists in localStorage.
+  useEffect(() => {
+    const persisted = readPersisted();
+    if (persisted) {
+      setCurrentVersion(persisted.fromVersion);
+      setIsUpdating(true);
+    }
+  }, []);
+
+  const startUpdate = useCallback((version?: string) => {
+    writePersisted(version);
+    setCurrentVersion(version);
+    setIsUpdating(true);
+  }, []);
+
+  const handleDone = useCallback(() => {
+    clearPersisted();
+    setIsUpdating(false);
+  }, []);
+
+  return (
+    <UpdateContext.Provider value={{ isUpdating, startUpdate }}>
+      {children}
+      {isUpdating && (
+        <UpdateOverlay currentVersion={currentVersion} onDone={handleDone} />
+      )}
+    </UpdateContext.Provider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useUpdate() {
+  return useContext(UpdateContext);
+}
+
+// ---------------------------------------------------------------------------
+// Overlay
+// ---------------------------------------------------------------------------
+
+const UPDATE_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+
+/**
+ * Full-screen black overlay rendered at the provider level (app layout).
+ * Survives client-side navigation and even a manual browser refresh (via
+ * localStorage).
+ *
+ * Polling strategy — two-phase:
+ *   Phase 1 ("pulling"): poll /version every 2 s.
+ *     - If the API throws (container stopped) → set everWentDown = true.
+ *     - If the API returns a NEW version (without going down first) →
+ *       rare fast swap, treat as done.
+ *   Phase 2 (everWentDown): poll /version every 2 s.
+ *     - Once the API responds successfully → "ready" → reload.
+ *
+ * A 10-minute deadline surfaces an error state with a manual refresh
+ * button so the user can never be stuck in an infinite spinner.
+ */
+function UpdateOverlay({
+  currentVersion,
+  onDone,
+}: {
+  currentVersion?: string;
+  onDone: () => void;
+}) {
+  const [phase, setPhase] = useState<UpdatePhase>("pulling");
+  const [elapsed, setElapsed] = useState(0);
+  const everWentDown = useRef(false);
+
+  // Elapsed-time counter — ticks every second.
+  useEffect(() => {
+    const id = setInterval(() => setElapsed((s) => s + 1), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  // Polling loop.
+  useEffect(() => {
+    let cancelled = false;
+    const deadline = Date.now() + UPDATE_TIMEOUT_MS;
+
+    const tick = async () => {
+      if (cancelled) return;
+      if (Date.now() >= deadline) {
+        setPhase("error");
+        return;
+      }
+
+      try {
+        const v = await api.getVersion();
+        if (everWentDown.current) {
+          // Container came back up after being down — reload.
+          if (!cancelled) {
+            setPhase("ready");
+            clearPersisted();
+            setTimeout(() => window.location.reload(), 800);
+          }
+          return;
+        }
+        // Container still running. Detect version change (fast swap without
+        // a visible down period).
+        if (
+          currentVersion &&
+          v.package_version &&
+          v.package_version !== currentVersion
+        ) {
+          if (!cancelled) {
+            setPhase("ready");
+            clearPersisted();
+            setTimeout(() => window.location.reload(), 800);
+          }
+          return;
+        }
+      } catch {
+        // API is unreachable — the old container stopped.
+        everWentDown.current = true;
+        setPhase("restarting");
+      }
+
+      setTimeout(tick, 2000);
+    };
+
+    // Brief initial pause so Docker has time to begin processing the
+    // update command before we start checking.
+    setTimeout(tick, 1500);
+    return () => {
+      cancelled = true;
+    };
+  }, [currentVersion]);
+
+  // Format elapsed time as M:SS.
+  const minutes = Math.floor(elapsed / 60);
+  const seconds = elapsed % 60;
+  const elapsedLabel = `${minutes}:${String(seconds).padStart(2, "0")} elapsed`;
+
+  if (phase === "error") {
+    return (
+      <div className="fixed inset-0 z-[200] bg-black text-white flex items-center justify-center">
+        <div className="text-center space-y-4 max-w-sm mx-auto px-4">
+          <h2 className="text-xl font-semibold">Update taking longer than expected</h2>
+          <p className="text-sm text-white/70">
+            The update may still be running in the background. Check{" "}
+            <code className="text-xs bg-white/10 px-1 rounded">docker logs fiestaupdater</code>{" "}
+            on the host, then refresh.
+          </p>
+          <Button
+            variant="outline"
+            className="border-white/30 text-white hover:bg-white/10 hover:text-white"
+            onClick={() => {
+              clearPersisted();
+              onDone();
+            }}
+          >
+            <RefreshCw className="h-4 w-4 mr-2" />
+            Dismiss and refresh page
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  const phaseMessage =
+    phase === "pulling" && !everWentDown.current
+      ? "Pulling the latest image from Docker Hub…"
+      : phase === "ready"
+        ? "Update complete. Reloading…"
+        : "Restarting FiestaBoard…";
+
+  return (
+    <div className="fixed inset-0 z-[200] bg-black text-white flex items-center justify-center">
+      <div className="text-center space-y-6 max-w-sm mx-auto px-4">
+        {phase === "ready" ? (
+          <RefreshCw className="h-12 w-12 mx-auto animate-spin text-white" />
+        ) : (
+          <Loader2 className="h-12 w-12 mx-auto animate-spin text-white" />
+        )}
+        <div className="space-y-2">
+          <h2 className="text-2xl font-semibold tracking-tight">Updating FiestaBoard</h2>
+          <p className="text-base text-white/80">{phaseMessage}</p>
+        </div>
+        <div className="space-y-1">
+          <p className="text-sm text-white/50">{elapsedLabel}</p>
+          <p className="text-xs text-white/40">
+            Updates can take a few minutes — please don&apos;t close this tab.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Replaces the per-component update overlays with a single `UpdateProvider` rendered at the app layout level, giving the update UI a solid-black full-screen overlay that survives navigation and manual browser refreshes.

## Problem

The previous `UpdatingOverlay` / `RestartingOverlay` (update path) were mounted inside settings-page components. Navigating away from Settings mid-update unmounted the overlay — the user lost all feedback and the page never auto-reloaded when the new container came up.

Additionally:
- No timeout on the update overlay (infinite spinner if sidecar failed silently)
- The overlay was translucent and showed the app behind it, still allowing accidental interaction

## Solution

### New `UpdateProvider` (`web/src/components/update-context.tsx`)

- Holds update state at the top of the React tree (inside `QueryClientProvider`), rendering `UpdateOverlay` as a fixed child
- **Solid black overlay** (`bg-black text-white`, `z-[200]`) — no scrolling, no sidebar, nothing else visible
- **localStorage persistence** (`fb_updating` key) — a manual browser refresh mid-update re-shows the overlay instead of a blank page. Auto-expires after 10 minutes.
- **Elapsed-time counter** — ticks every second (`M:SS elapsed`) so the user can see things are happening
- **Phase messages**: "Pulling the latest image from Docker Hub…" → "Restarting FiestaBoard…" → "Update complete. Reloading…"
- **Two-phase polling**: waits for API to go DOWN (`everWentDown`), then waits for it to come back UP before reloading. Falls back to version-change detection for fast swaps without a visible down period.
- **10-minute deadline** → error state with a dismissable "Dismiss and refresh page" button — no more infinite spinners
- `useUpdate()` hook exposes `startUpdate(currentVersion?)` to any component

### Updated components

- **`providers.tsx`**: wraps `FormatPreferencesProvider` children in `<UpdateProvider>`
- **`system-controls.tsx`**: `updateMutation.onSuccess` calls `startUpdate()` instead of `setActiveOverlay("update")`; removes update overlay render from JSX
- **`system-update.tsx`**: `applyMutation.onSuccess` calls `startUpdate()`; removes local `UpdatingOverlay` function and all its state

Restart and Shutdown actions keep their existing local overlays (quick ~10 s, no navigation concern).

## Test plan

1. Trigger an update from **Settings → System** (Update Now / Re-pull Latest button)
2. Trigger an update from the **update banner** (Settings → top of page)
3. While the overlay is showing, navigate to the Home page — overlay should still be visible
4. Refresh the browser mid-update — overlay should reappear automatically
5. Verify elapsed timer ticks and phase messages update as the pull progresses
6. After the new container comes up, overlay should dismiss and page reloads
7. Simulate a timeout by disconnecting network for 11 min — error state with dismiss button should appear