### PR TITLE
feat(pi): default instance name to "FiestaPi" on FiestaPi image

### DIFF
--- a/pi-image/README.md
+++ b/pi-image/README.md
@@ -12,7 +12,7 @@ A flashable Raspberry Pi OS image with FiestaBoard pre-installed and self-updati
 - `fiestaupdater` sidecar enabled by default — Settings → Update Now works immediately
 - 1 GB swap file
 - mDNS hostname `fiestapi.local`
-- `FIESTABOARD_PROFILE=pi` env baked in (flips the in-app auto-update toggle to default ON)
+- `FIESTABOARD_PROFILE=pi` env baked in (flips the in-app auto-update toggle to default ON, and seeds the instance name to "FiestaPi" on first boot)
 - First-boot script that generates a unique `FIESTAUPDATER_TOKEN`
 - Post-flash Wi-Fi provisioning: drop `fiestapi-wifi.txt` on the boot partition — see [RASPBERRY_PI.md](../docs/setup/RASPBERRY_PI.md)
 

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -300,11 +300,29 @@ class ConfigManager:
                     logger.error(f"Invalid JSON in config file: {e}")
                     logger.info("Creating new config with defaults")
                     self._config = DEFAULT_CONFIG.copy()
+                    self._apply_profile_defaults()
                     self._save_internal()
             else:
                 logger.info(f"Config file not found, creating defaults at {self._config_path}")
                 self._config = self._deep_copy(DEFAULT_CONFIG)
+                self._apply_profile_defaults()
                 self._save_internal()
+
+    def _apply_profile_defaults(self) -> None:
+        """Apply install-profile-specific overrides at fresh-config creation
+        time only.
+
+        On the FiestaPi flashable image (`FIESTABOARD_PROFILE=pi`), default
+        the friendly instance name to "FiestaPi" so the sidebar/browser tab
+        show something meaningful out of the box. Users can rename via
+        Settings; we only set this when creating a brand-new config so a
+        deliberate clear from the UI isn't reset on every restart.
+        """
+        profile = os.getenv("FIESTABOARD_PROFILE", "docker").strip().lower() or "docker"
+        if profile == "pi":
+            general = self._config.setdefault("general", {})
+            if not general.get("instance_name"):
+                general["instance_name"] = "FiestaPi"
 
     def _deep_copy(self, obj: Any) -> Any:
         """Create a deep copy of a nested dict/list structure."""

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -55,6 +55,38 @@ def test_creates_default_config_when_no_file_exists(tmp_path):
     assert loaded["board"]["api_mode"] == "local"
 
 
+def test_pi_profile_defaults_instance_name_on_fresh_config(tmp_path, monkeypatch):
+    """On the FiestaPi image, a brand-new config gets instance_name='FiestaPi'."""
+    monkeypatch.setenv("FIESTABOARD_PROFILE", "pi")
+    config_path = tmp_path / "config.json"
+    cm = ConfigManager(config_path=str(config_path))
+    assert cm.get_general()["instance_name"] == "FiestaPi"
+    # Persisted to disk so the UI sees it without another save round-trip.
+    on_disk = json.loads(config_path.read_text())
+    assert on_disk["general"]["instance_name"] == "FiestaPi"
+
+
+def test_docker_profile_leaves_instance_name_empty(tmp_path, monkeypatch):
+    """Default Docker installs keep instance_name empty (existing behavior)."""
+    monkeypatch.delenv("FIESTABOARD_PROFILE", raising=False)
+    config_path = tmp_path / "config.json"
+    cm = ConfigManager(config_path=str(config_path))
+    assert cm.get_general()["instance_name"] == ""
+
+
+def test_pi_profile_does_not_overwrite_existing_instance_name(tmp_path, monkeypatch):
+    """Existing config (e.g. user renamed) is not stomped on next start."""
+    monkeypatch.setenv("FIESTABOARD_PROFILE", "pi")
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({
+        "board": {"api_mode": "local"},
+        "features": {},
+        "general": {"instance_name": "Kitchen Board"},
+    }))
+    cm = ConfigManager(config_path=str(config_path))
+    assert cm.get_general()["instance_name"] == "Kitchen Board"
+
+
 def test_loads_existing_valid_config_file(tmp_path):
     """Loads existing valid config file."""
     config_path = tmp_path / "config.json"


### PR DESCRIPTION
## Summary

On the FiestaPi flashable image, seed `general.instance_name` to `"FiestaPi"` on first boot so the sidebar and browser tab show something meaningful out of the box. On Docker installs the field stays empty, matching today's behavior.

## How

Piggybacks on the existing `FIESTABOARD_PROFILE=pi` env var that's already baked into [`pi-image/stage-fiestaboard/01-install-fiestaboard/files/docker-compose.yml`](https://github.com/Fiestaboard/FiestaBoard/blob/main/pi-image/stage-fiestaboard/01-install-fiestaboard/files/docker-compose.yml) (also used to flip the auto-update default ON). No new env var, no compose change, no migration.

New `ConfigManager._apply_profile_defaults()` runs **only** at fresh-config creation (both branches: file-missing and invalid-JSON-recovery). When the profile is `pi` and `instance_name` is empty, it's set to `"FiestaPi"` and persisted.

## Why fresh-only

Running this on every load would clobber a user's deliberate rename (or clear). Tied to creation, the user's choice always wins on subsequent restarts.

## Changes

- `src/config_manager.py` — add `_apply_profile_defaults()`, call it in both fresh-config branches of `_load_or_create()`.
- `tests/test_config_manager.py` — 3 new tests:
  - pi profile + fresh config → `instance_name == "FiestaPi"`, persisted to disk
  - docker profile + fresh config → `instance_name == ""` (unchanged)
  - pi profile + existing config with user-set name → not overwritten
- `pi-image/README.md` — note the seeded name alongside the existing auto-update note.

## Test plan

- [x] `pytest tests/test_config_manager.py` — 63 passed (60 existing + 3 new)
- [ ] After merge, on a fresh FiestaPi flash: verify the sidebar shows "FiestaPi" without any user action
- [ ] On an existing FiestaPi install where the user already renamed the instance: verify the rename is preserved across restarts
- [ ] On a Docker install: verify `instance_name` is still empty by default