### PR TITLE
ci(fiestapi): fix permission denied writing .sha256 next to root-owned image

### DIFF
--- a/.github/workflows/build-fiestapi.yml
+++ b/.github/workflows/build-fiestapi.yml
@@ -148,6 +148,10 @@ jobs:
       - name: Locate output
         id: out
         run: |
+          # build-docker.sh runs as root, so pi-gen/deploy and its contents
+          # are root-owned. Reclaim ownership so subsequent steps (checksum,
+          # artifact upload, release attach) can read/write without sudo.
+          sudo chown -R "$USER:$USER" pi-gen/deploy
           IMG=$(find pi-gen/deploy -name '*.img.xz' | head -n1)
           test -n "$IMG"
           echo "img=$IMG" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem

The FiestaPi build job [failed](https://github.com/Fiestaboard/FiestaBoard/actions/runs/25146856827/job/73708484453) at the `Generate SHA-256 checksum` step:

\`\`\`
/home/runner/work/_temp/....sh: line 2: pi-gen/deploy/image_2026-04-30-fiestapi-lite.img.xz.sha256: Permission denied
\`\`\`

## Cause

\`build-docker.sh\` runs the pi-gen pipeline under \`sudo\`, so \`pi-gen/deploy/\` and the resulting \`.img.xz\` are owned by root. The next step then tries to write \`\${IMG}.sha256\` into that root-owned directory as the unprivileged runner user — denied.

## Fix

Reclaim ownership of \`pi-gen/deploy/\` in the \`Locate output\` step (right after the build) so every downstream step (checksum, artifact upload, release attach) can read/write without sudo.

\`\`\`yaml
sudo chown -R \"\$USER:\$USER\" pi-gen/deploy
\`\`\`

Net diff: +4 lines.

## Test plan

After merge, trigger \`Build FiestaPi image\` via \`workflow_dispatch\` and verify:
- The checksum step succeeds.
- \`.img.xz\` and \`.sha256\` are uploaded as workflow artifacts.
- Both assets are attached to the latest app release.