### PR TITLE
docs: FiestaUpdater reference, Raspberry Pi docs, and homepage highlights

### DIFF
--- a/docs-site/docs/deployment/fiestaupdater.md
+++ b/docs-site/docs/deployment/fiestaupdater.md
@@ -1,0 +1,236 @@
+---
+sidebar_position: 2
+description: "Technical reference for the FiestaUpdater sidecar — the companion container that powers FiestaBoard's one-click in-app updates."
+keywords: [FiestaUpdater, fiestaupdater, in-app update, self-update sidecar, Docker socket, FiestaBoard updater]
+---
+
+# FiestaUpdater
+
+`fiestaupdater` is the companion sidecar container that powers FiestaBoard's
+[in-app updates](/docs/features/updating). This page is a technical reference for the
+sidecar itself — its architecture, configuration, HTTP API, and security model.
+
+:::tip Just want the Update Now button?
+If you only want to enable in-app updates, see [In-App Updates](/docs/features/updating)
+for the user-facing guide. This page is for understanding what the sidecar does and how
+to configure it in custom Docker deployments.
+:::
+
+## Why a separate container?
+
+The fiestaboard container can't safely update itself: as soon as
+`docker compose up -d` recreates it, the running process (and any HTTP
+response in flight) is killed. A side process is needed that:
+
+- Has access to the host's Docker socket
+- Survives the recreation of the `fiestaboard` container
+- Is not itself recreated as part of the update
+
+`fiestaupdater` is that process. It's a tiny container based on `docker:cli`
+with a `socat`-driven HTTP listener and a single shell handler script.
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────┐
+│                    Docker host                        │
+│                                                       │
+│   ┌──────────────────┐     internal network          │
+│   │   fiestaboard    │────────►┌────────────────┐   │
+│   │  (port 4420)     │  POST   │  fiestaupdater │   │
+│   │                  │  /update│  (port 8765)   │   │
+│   └──────────────────┘  Bearer └───────┬────────┘   │
+│                                         │            │
+│                                         │ docker.sock │
+│                                         ▼            │
+│                              ┌────────────────────┐  │
+│                              │  Docker daemon     │  │
+│                              │  pull + up -d      │  │
+│                              └────────────────────┘  │
+└──────────────────────────────────────────────────────┘
+```
+
+Key properties:
+
+- **Internal-network only.** The sidecar's port is not published to the host —
+  it's reachable only by other containers on the same Docker Compose network.
+- **Bearer-token authenticated.** Both containers share `FIESTAUPDATER_TOKEN`
+  via `.env`. Tokens are compared by SHA-256 hash to limit timing-attack surface.
+- **Service-name allow-listed.** The compose service the sidecar is willing to
+  act on is validated against `^[a-z0-9_-]+$` before being passed to
+  `docker compose`, so even a compromised env var can't smuggle in shell metacharacters.
+
+## FiestaPi vs. Docker installs
+
+| Install type | Sidecar status | Auto-update default |
+|---|---|---|
+| **[FiestaPi](/docs/setup/raspberry-pi)** | Pre-configured, enabled by default | **On** — applies updates daily |
+| **Docker / manual** | Off by default; opt in via `COMPOSE_PROFILES` | Off — banner shown, user clicks Update Now |
+
+On FiestaPi the `FIESTAUPDATER_TOKEN` is generated automatically on first boot
+by `firstboot.sh`. On Docker installs you generate it yourself (see below).
+
+## Docker Compose configuration
+
+Below is the full `fiestaupdater` service definition used by
+`docker-compose.hub.yml`. To enable in-app updates on a custom deployment,
+add this service to your compose file (or pull it in via
+`COMPOSE_PROFILES=fiestaupdater`):
+
+```yaml
+services:
+  fiestaupdater:
+    image: fiestaboard/fiestaupdater:latest
+    container_name: fiestaupdater
+    profiles: ["fiestaupdater"]
+    restart: unless-stopped
+    pull_policy: always
+    environment:
+      - FIESTAUPDATER_TOKEN=${FIESTAUPDATER_TOKEN}
+      - FIESTAUPDATER_SERVICE=fiestaboard
+      - FIESTAUPDATER_COMPOSE_FILE=/compose/docker-compose.yml
+      - COMPOSE_PROJECT_NAME=fiestaboard
+    cap_add:
+      - SYS_BOOT  # required for POST /shutdown
+    volumes:
+      # Talk to the host Docker daemon to pull images and recreate services.
+      - /var/run/docker.sock:/var/run/docker.sock
+      # Read the same compose file the user deployed with so we update the
+      # exact same service definition.
+      - ./docker-compose.hub.yml:/compose/docker-compose.yml:ro
+      # The compose file references `env_file: .env` for the fiestaboard
+      # service. When the sidecar runs `docker compose -f /compose/...`,
+      # Compose resolves `.env` relative to the compose file's directory.
+      # Without this mount, every pull/up/restart fails with
+      # "env file /compose/.env not found".
+      - ./.env:/compose/.env:ro
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://127.0.0.1:8765/healthz"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
+```
+
+:::warning Three required volume mounts
+All three volumes are required:
+
+1. `docker.sock` — to run `docker compose` against the host daemon
+2. The compose file — so the sidecar updates exactly the service you deployed
+3. `.env` — Compose resolves `env_file` relative to the compose file's directory
+
+Without the `.env` mount, every update silently no-ops with
+`env file /compose/.env not found`.
+:::
+
+### Enabling on an existing Docker install
+
+1. Generate a token and add it (along with `COMPOSE_PROFILES`) to your `.env`:
+
+   ```bash
+   echo "COMPOSE_PROFILES=fiestaupdater" >> .env
+   echo "FIESTAUPDATER_TOKEN=$(head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n')" >> .env
+   ```
+
+2. Make sure your compose file contains the `fiestaupdater` service block above.
+   (`docker-compose.hub.yml` already does.)
+
+3. Bring the stack up:
+
+   ```bash
+   docker compose -f docker-compose.hub.yml up -d
+   ```
+
+4. The Update Now button appears in **Settings → System** once the sidecar
+   passes its healthcheck.
+
+## Environment variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `FIESTAUPDATER_TOKEN` | yes | — | Shared bearer token. The sidecar refuses to start without it. Must match the value the `fiestaboard` container sees so the API can authenticate. |
+| `FIESTAUPDATER_SERVICE` | no | `fiestaboard` | Compose service name to update. Validated against `^[a-z0-9_-]+$`; values that don't match fall back to `fiestaboard`. |
+| `FIESTAUPDATER_COMPOSE_FILE` | no | `/compose/docker-compose.yml` | Path inside the sidecar container to the compose file. Mount your compose file here. |
+| `FIESTAUPDATER_PORT` | no | `8765` | Port the sidecar listens on (internal network only). |
+| `COMPOSE_PROJECT_NAME` | no | derived from compose dir | Must match the project name the main stack uses, so `docker compose` operates on the same containers. Set to `fiestaboard` to match `docker-compose.hub.yml`. |
+
+`COMPOSE_PROFILES=fiestaupdater` is set on the **host** (in your `.env`),
+not inside the sidecar container — it tells Docker Compose to include the
+sidecar service when bringing the stack up.
+
+## HTTP API
+
+All routes are served on port `8765` on the Docker Compose internal network.
+None of them are reachable from the host.
+
+| Method | Path | Auth | Description |
+|---|---|---|---|
+| `GET` | `/healthz` | none | Liveness probe. Returns `{"status":"ok"}`. |
+| `GET` | `/version` | none | Returns the running container's image and digest. Used by the UI to detect when an update has actually landed. |
+| `POST` | `/update` | bearer | `docker compose pull` + `up -d --no-deps` for the configured service. Returns `202 Accepted` immediately; the update runs in the background. |
+| `POST` | `/restart` | bearer | `docker compose restart` for the configured service. Returns `202`. |
+| `POST` | `/shutdown` | bearer | Stops the compose stack and powers off the host. Requires the `SYS_BOOT` capability. Returns `202`. |
+
+Authentication is `Authorization: Bearer <FIESTAUPDATER_TOKEN>`. Failed auth
+returns `401`. Unknown routes return `404`.
+
+`POST /update` and `POST /restart` return `202` before the work starts because
+the action will tear down the `fiestaboard` container that originated the
+HTTP request — the connection would otherwise be cut before any response
+could be flushed.
+
+## Security
+
+- **No host port.** The sidecar's listener is bound to the compose-internal
+  network only. Even on a multi-tenant LAN, no other host can reach `/update`.
+- **Bearer-token auth.** A 64-hex-character random token is required for every
+  state-changing route. SHA-256 hash comparison reduces timing-attack surface.
+- **Service-name allow-list.** The configured service name must match
+  `^[a-z0-9_-]+$` before being passed to `docker compose`. No user input is
+  ever interpolated into a shell command.
+- **Read-only mounts.** The compose file and `.env` are mounted `:ro`.
+- **Limited blast radius.** The sidecar can pull images and recreate the one
+  service named in `FIESTAUPDATER_SERVICE`. It cannot start arbitrary
+  containers or run arbitrary shell commands.
+
+If you're uncomfortable mounting the Docker socket at all, leave the
+`fiestaupdater` profile off and [update manually](/docs/features/updating#updating-manually-always-works).
+
+## Troubleshooting
+
+**The Update Now button doesn't appear.** The web UI probes the sidecar at
+startup. Check:
+
+```bash
+docker compose ps fiestaupdater          # is it running and healthy?
+docker logs fiestaupdater                # any errors?
+docker exec fiestaboard wget -qO- http://fiestaupdater:8765/healthz
+```
+
+The most common cause is `COMPOSE_PROFILES=fiestaupdater` missing from `.env`,
+so the sidecar service is never started.
+
+**Update returns 202 but nothing happens.** Check the sidecar logs for
+`env file /compose/.env not found` — this means the `.env` volume mount is
+missing from your compose file. Add it (see [configuration](#docker-compose-configuration))
+and recreate the sidecar.
+
+**Update started but FiestaBoard never came back.** Wait a minute (the Pi can
+take 60–90s to recreate the container), then reload
+`http://fiestaboard.local:4420`. If still down:
+
+```bash
+docker logs fiestaboard
+docker compose -f docker-compose.hub.yml up -d
+```
+
+**I want to roll back.** Pin the previous image tag (e.g.
+`image: fiestaboard/fiestaboard:5.1.1`) in your compose file, then
+`docker compose up -d`. Automated rollback is planned for a future release.
+
+## See also
+
+- [In-App Updates](/docs/features/updating) — user-facing guide and Update Now flow
+- [FiestaPi Quick Start](/docs/setup/raspberry-pi) — pre-configured Pi image with the sidecar enabled
+- [Raspberry Pi Deployment](/docs/deployment/raspberry-pi) — running on an existing Pi with Docker
+- [Environment Variables](/docs/reference/environment-variables#fiestaupdater) — full env-var reference

--- a/docs-site/docs/deployment/raspberry-pi.md
+++ b/docs-site/docs/deployment/raspberry-pi.md
@@ -60,7 +60,7 @@ COMPOSE_PROFILES=fiestaupdater
 FIESTAUPDATER_TOKEN=$(head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n')
 ```
 
-Then restart: `docker compose -f docker-compose.hub.yml up -d`. See [In-App Updates](/docs/features/updating) for more detail.
+Then restart: `docker compose -f docker-compose.hub.yml up -d`. See [In-App Updates](/docs/features/updating) for more detail, or the [FiestaUpdater reference](/docs/deployment/fiestaupdater) for the full sidecar configuration.
 
 ### Auto-start on boot
 

--- a/docs-site/docs/features/updating.md
+++ b/docs-site/docs/features/updating.md
@@ -36,6 +36,8 @@ FiestaBoard uses a small companion container called `fiestaupdater`. It sits on 
 
 When you click Update Now, the web UI POSTs to the FiestaBoard API, which calls the updater over the internal network. The updater runs `docker compose pull && docker compose up -d` against your compose file. Because it's a separate process, FiestaBoard can update itself without getting cut off mid-response.
 
+**See also:** [FiestaUpdater reference](/docs/deployment/fiestaupdater) for the full sidecar architecture, HTTP API, and security model.
+
 ## Opting in on Docker installs
 
 The updater is opt-in for Docker and manual installs (it's already on for FiestaPi).

--- a/docs-site/docs/reference/environment-variables.md
+++ b/docs-site/docs/reference/environment-variables.md
@@ -106,6 +106,19 @@ Use `BOARD_LOCAL_API_KEY` + `BOARD_HOST` for local mode (default). Use `BOARD_RE
 | `REFRESH_INTERVAL_SECONDS` | Display update interval (seconds) | `300` |
 | `VERSION` | Build version (set automatically during Docker builds -- do not change) | `dev` |
 
+## FiestaUpdater
+
+These variables control the optional [`fiestaupdater`](/docs/deployment/fiestaupdater) sidecar that powers one-click in-app updates. On [FiestaPi](/docs/setup/raspberry-pi) they're configured automatically on first boot.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `COMPOSE_PROFILES` | Set to `fiestaupdater` to enable the updater sidecar in the compose stack. | - |
+| `FIESTAUPDATER_TOKEN` | Shared bearer token (64 hex chars) used to authenticate the FiestaBoard API → sidecar calls. Generate with `head -c 32 /dev/urandom \| od -An -tx1 \| tr -d ' \n'`. | - |
+| `FIESTAUPDATER_SERVICE` | Compose service name the sidecar is allowed to update. Validated against `^[a-z0-9_-]+$`. | `fiestaboard` |
+| `FIESTAUPDATER_COMPOSE_FILE` | Path inside the sidecar container to the mounted compose file. | `/compose/docker-compose.yml` |
+| `FIESTAUPDATER_PORT` | Port the sidecar listens on (Docker internal network only — never published to the host). | `8765` |
+| `COMPOSE_PROJECT_NAME` | Compose project name the sidecar should target. Must match the project the main stack runs under. | `fiestaboard` |
+
 ## Example `.env` File
 
 ```bash

--- a/docs-site/sidebars.ts
+++ b/docs-site/sidebars.ts
@@ -27,6 +27,7 @@ const sidebars: SidebarsConfig = {
         'features/schedule',
         'features/silence-schedule',
         'features/home-assistant-control',
+        'features/updating',
       ],
     },
     {
@@ -72,6 +73,7 @@ const sidebars: SidebarsConfig = {
       items: [
         'deployment/production',
         'deployment/raspberry-pi',
+        'deployment/fiestaupdater',
         'setup/docker-setup',
         'setup/cloud-api',
       ],

--- a/docs-site/src/components/HomepageFeatures/index.tsx
+++ b/docs-site/src/components/HomepageFeatures/index.tsx
@@ -353,6 +353,69 @@ function PluginCard({title, image, alt, description, link}: ShowcaseItem) {
   );
 }
 
+type HighlightItem = {
+  badge: string;
+  icon: string;
+  title: string;
+  description: ReactNode;
+  primary: {label: string; to: string};
+  secondary?: {label: string; to: string};
+};
+
+const HighlightList: HighlightItem[] = [
+  {
+    badge: 'New',
+    icon: '🍓',
+    title: 'FiestaPi — flash a Raspberry Pi, done',
+    description: (
+      <>
+        A pre-built Raspberry Pi OS image with FiestaBoard, Docker, and the self-update
+        sidecar all pre-installed. Flash a microSD card with Raspberry Pi Imager, boot
+        your Pi, open <code>http://fiestapi.local:4420</code> — no Docker setup, no
+        terminal, no config files. Works on Pi 3B, Pi 4, Pi 5, and Pi Zero 2 W.
+      </>
+    ),
+    primary: {label: 'FiestaPi Quick Start', to: '/docs/setup/raspberry-pi'},
+    secondary: {label: 'Download image', to: 'https://github.com/Fiestaboard/FiestaBoard/releases/latest'},
+  },
+  {
+    badge: 'New',
+    icon: '⚡',
+    title: 'One-click in-app updates',
+    description: (
+      <>
+        When a new version ships, a banner appears in <strong>Settings → System</strong>.
+        Click <strong>Update Now</strong> and FiestaBoard updates itself — no SSH, no
+        <code> docker compose pull</code>. On for FiestaPi by default; opt in on Docker
+        installs by enabling the <code>fiestaupdater</code> sidecar.
+      </>
+    ),
+    primary: {label: 'How updates work', to: '/docs/features/updating'},
+    secondary: {label: 'FiestaUpdater reference', to: '/docs/deployment/fiestaupdater'},
+  },
+];
+
+function HighlightCard({badge, icon, title, description, primary, secondary}: HighlightItem) {
+  return (
+    <div className={styles.highlightCard}>
+      <span className={styles.highlightBadge}>{badge}</span>
+      <div className={styles.highlightIcon} aria-hidden="true">{icon}</div>
+      <Heading as="h3">{title}</Heading>
+      <p>{description}</p>
+      <div className={styles.highlightLinks}>
+        <Link className="button button--primary button--sm" to={primary.to}>
+          {primary.label} →
+        </Link>
+        {secondary && (
+          <Link className="button button--outline button--sm" to={secondary.to}>
+            {secondary.label}
+          </Link>
+        )}
+      </div>
+    </div>
+  );
+}
+
 export default function HomepageFeatures(): ReactNode {
   return (
     <>
@@ -362,6 +425,25 @@ export default function HomepageFeatures(): ReactNode {
           <div className="row">
             {FeatureList.map((props, idx) => (
               <Feature key={idx} {...props} />
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* What's New highlights */}
+      <section className={styles.highlights}>
+        <div className="container">
+          <div className="text--center">
+            <Heading as="h2" className={styles.sectionTitle}>
+              What's New
+            </Heading>
+            <p className={styles.sectionSubtitle}>
+              The fastest way to run FiestaBoard, and updates without ever touching a terminal
+            </p>
+          </div>
+          <div className={styles.highlightsGrid}>
+            {HighlightList.map((props) => (
+              <HighlightCard key={props.title} {...props} />
             ))}
           </div>
         </div>

--- a/docs-site/src/components/HomepageFeatures/styles.module.css
+++ b/docs-site/src/components/HomepageFeatures/styles.module.css
@@ -327,3 +327,84 @@
   flex-wrap: wrap;
   gap: 1rem;
 }
+
+/* "What's New" highlights — paired feature cards */
+.highlights {
+  padding: 4rem 0;
+  background: linear-gradient(
+    180deg,
+    var(--ifm-background-color) 0%,
+    var(--ifm-color-emphasis-100) 100%
+  );
+}
+
+.highlightsGrid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 2rem;
+  margin-top: 1.5rem;
+}
+
+@media screen and (max-width: 768px) {
+  .highlightsGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.highlightCard {
+  display: flex;
+  flex-direction: column;
+  padding: 2rem;
+  border-radius: 16px;
+  background: var(--ifm-card-background-color, var(--ifm-background-surface-color));
+  border: 1px solid var(--ifm-color-emphasis-200);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.06);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.highlightCard:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+}
+
+[data-theme='dark'] .highlightCard {
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+.highlightBadge {
+  display: inline-block;
+  align-self: flex-start;
+  padding: 0.2rem 0.7rem;
+  border-radius: 999px;
+  background: var(--ifm-color-primary);
+  color: #fff;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 1rem;
+}
+
+.highlightIcon {
+  font-size: 2.5rem;
+  line-height: 1;
+  margin-bottom: 1rem;
+}
+
+.highlightCard h3 {
+  font-size: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.highlightCard p {
+  font-size: 1.05rem;
+  color: var(--ifm-color-emphasis-700);
+  margin-bottom: 1.25rem;
+  flex: 1;
+}
+
+.highlightLinks {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}

--- a/docs-site/src/pages/index.tsx
+++ b/docs-site/src/pages/index.tsx
@@ -24,7 +24,7 @@ function HomepageHeader() {
           Vestaboard Flagship and Note. All beautifully formatted, endlessly customizable, and running in Docker with zero hassle.
         </p>
         <p className={styles.heroDescriptionShort}>
-          Weather, stocks, sports & more — powered by Docker
+          Weather, stocks, sports & more — flash a Raspberry Pi or run with Docker
         </p>
         <div className={styles.buttons}>
           <Link

--- a/docs-site/versioned_docs/version-5.3/deployment/fiestaupdater.md
+++ b/docs-site/versioned_docs/version-5.3/deployment/fiestaupdater.md
@@ -1,0 +1,236 @@
+---
+sidebar_position: 2
+description: "Technical reference for the FiestaUpdater sidecar — the companion container that powers FiestaBoard's one-click in-app updates."
+keywords: [FiestaUpdater, fiestaupdater, in-app update, self-update sidecar, Docker socket, FiestaBoard updater]
+---
+
+# FiestaUpdater
+
+`fiestaupdater` is the companion sidecar container that powers FiestaBoard's
+[in-app updates](/docs/features/updating). This page is a technical reference for the
+sidecar itself — its architecture, configuration, HTTP API, and security model.
+
+:::tip Just want the Update Now button?
+If you only want to enable in-app updates, see [In-App Updates](/docs/features/updating)
+for the user-facing guide. This page is for understanding what the sidecar does and how
+to configure it in custom Docker deployments.
+:::
+
+## Why a separate container?
+
+The fiestaboard container can't safely update itself: as soon as
+`docker compose up -d` recreates it, the running process (and any HTTP
+response in flight) is killed. A side process is needed that:
+
+- Has access to the host's Docker socket
+- Survives the recreation of the `fiestaboard` container
+- Is not itself recreated as part of the update
+
+`fiestaupdater` is that process. It's a tiny container based on `docker:cli`
+with a `socat`-driven HTTP listener and a single shell handler script.
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────┐
+│                    Docker host                        │
+│                                                       │
+│   ┌──────────────────┐     internal network          │
+│   │   fiestaboard    │────────►┌────────────────┐   │
+│   │  (port 4420)     │  POST   │  fiestaupdater │   │
+│   │                  │  /update│  (port 8765)   │   │
+│   └──────────────────┘  Bearer └───────┬────────┘   │
+│                                         │            │
+│                                         │ docker.sock │
+│                                         ▼            │
+│                              ┌────────────────────┐  │
+│                              │  Docker daemon     │  │
+│                              │  pull + up -d      │  │
+│                              └────────────────────┘  │
+└──────────────────────────────────────────────────────┘
+```
+
+Key properties:
+
+- **Internal-network only.** The sidecar's port is not published to the host —
+  it's reachable only by other containers on the same Docker Compose network.
+- **Bearer-token authenticated.** Both containers share `FIESTAUPDATER_TOKEN`
+  via `.env`. Tokens are compared by SHA-256 hash to limit timing-attack surface.
+- **Service-name allow-listed.** The compose service the sidecar is willing to
+  act on is validated against `^[a-z0-9_-]+$` before being passed to
+  `docker compose`, so even a compromised env var can't smuggle in shell metacharacters.
+
+## FiestaPi vs. Docker installs
+
+| Install type | Sidecar status | Auto-update default |
+|---|---|---|
+| **[FiestaPi](/docs/setup/raspberry-pi)** | Pre-configured, enabled by default | **On** — applies updates daily |
+| **Docker / manual** | Off by default; opt in via `COMPOSE_PROFILES` | Off — banner shown, user clicks Update Now |
+
+On FiestaPi the `FIESTAUPDATER_TOKEN` is generated automatically on first boot
+by `firstboot.sh`. On Docker installs you generate it yourself (see below).
+
+## Docker Compose configuration
+
+Below is the full `fiestaupdater` service definition used by
+`docker-compose.hub.yml`. To enable in-app updates on a custom deployment,
+add this service to your compose file (or pull it in via
+`COMPOSE_PROFILES=fiestaupdater`):
+
+```yaml
+services:
+  fiestaupdater:
+    image: fiestaboard/fiestaupdater:latest
+    container_name: fiestaupdater
+    profiles: ["fiestaupdater"]
+    restart: unless-stopped
+    pull_policy: always
+    environment:
+      - FIESTAUPDATER_TOKEN=${FIESTAUPDATER_TOKEN}
+      - FIESTAUPDATER_SERVICE=fiestaboard
+      - FIESTAUPDATER_COMPOSE_FILE=/compose/docker-compose.yml
+      - COMPOSE_PROJECT_NAME=fiestaboard
+    cap_add:
+      - SYS_BOOT  # required for POST /shutdown
+    volumes:
+      # Talk to the host Docker daemon to pull images and recreate services.
+      - /var/run/docker.sock:/var/run/docker.sock
+      # Read the same compose file the user deployed with so we update the
+      # exact same service definition.
+      - ./docker-compose.hub.yml:/compose/docker-compose.yml:ro
+      # The compose file references `env_file: .env` for the fiestaboard
+      # service. When the sidecar runs `docker compose -f /compose/...`,
+      # Compose resolves `.env` relative to the compose file's directory.
+      # Without this mount, every pull/up/restart fails with
+      # "env file /compose/.env not found".
+      - ./.env:/compose/.env:ro
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://127.0.0.1:8765/healthz"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
+```
+
+:::warning Three required volume mounts
+All three volumes are required:
+
+1. `docker.sock` — to run `docker compose` against the host daemon
+2. The compose file — so the sidecar updates exactly the service you deployed
+3. `.env` — Compose resolves `env_file` relative to the compose file's directory
+
+Without the `.env` mount, every update silently no-ops with
+`env file /compose/.env not found`.
+:::
+
+### Enabling on an existing Docker install
+
+1. Generate a token and add it (along with `COMPOSE_PROFILES`) to your `.env`:
+
+   ```bash
+   echo "COMPOSE_PROFILES=fiestaupdater" >> .env
+   echo "FIESTAUPDATER_TOKEN=$(head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n')" >> .env
+   ```
+
+2. Make sure your compose file contains the `fiestaupdater` service block above.
+   (`docker-compose.hub.yml` already does.)
+
+3. Bring the stack up:
+
+   ```bash
+   docker compose -f docker-compose.hub.yml up -d
+   ```
+
+4. The Update Now button appears in **Settings → System** once the sidecar
+   passes its healthcheck.
+
+## Environment variables
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `FIESTAUPDATER_TOKEN` | yes | — | Shared bearer token. The sidecar refuses to start without it. Must match the value the `fiestaboard` container sees so the API can authenticate. |
+| `FIESTAUPDATER_SERVICE` | no | `fiestaboard` | Compose service name to update. Validated against `^[a-z0-9_-]+$`; values that don't match fall back to `fiestaboard`. |
+| `FIESTAUPDATER_COMPOSE_FILE` | no | `/compose/docker-compose.yml` | Path inside the sidecar container to the compose file. Mount your compose file here. |
+| `FIESTAUPDATER_PORT` | no | `8765` | Port the sidecar listens on (internal network only). |
+| `COMPOSE_PROJECT_NAME` | no | derived from compose dir | Must match the project name the main stack uses, so `docker compose` operates on the same containers. Set to `fiestaboard` to match `docker-compose.hub.yml`. |
+
+`COMPOSE_PROFILES=fiestaupdater` is set on the **host** (in your `.env`),
+not inside the sidecar container — it tells Docker Compose to include the
+sidecar service when bringing the stack up.
+
+## HTTP API
+
+All routes are served on port `8765` on the Docker Compose internal network.
+None of them are reachable from the host.
+
+| Method | Path | Auth | Description |
+|---|---|---|---|
+| `GET` | `/healthz` | none | Liveness probe. Returns `{"status":"ok"}`. |
+| `GET` | `/version` | none | Returns the running container's image and digest. Used by the UI to detect when an update has actually landed. |
+| `POST` | `/update` | bearer | `docker compose pull` + `up -d --no-deps` for the configured service. Returns `202 Accepted` immediately; the update runs in the background. |
+| `POST` | `/restart` | bearer | `docker compose restart` for the configured service. Returns `202`. |
+| `POST` | `/shutdown` | bearer | Stops the compose stack and powers off the host. Requires the `SYS_BOOT` capability. Returns `202`. |
+
+Authentication is `Authorization: Bearer <FIESTAUPDATER_TOKEN>`. Failed auth
+returns `401`. Unknown routes return `404`.
+
+`POST /update` and `POST /restart` return `202` before the work starts because
+the action will tear down the `fiestaboard` container that originated the
+HTTP request — the connection would otherwise be cut before any response
+could be flushed.
+
+## Security
+
+- **No host port.** The sidecar's listener is bound to the compose-internal
+  network only. Even on a multi-tenant LAN, no other host can reach `/update`.
+- **Bearer-token auth.** A 64-hex-character random token is required for every
+  state-changing route. SHA-256 hash comparison reduces timing-attack surface.
+- **Service-name allow-list.** The configured service name must match
+  `^[a-z0-9_-]+$` before being passed to `docker compose`. No user input is
+  ever interpolated into a shell command.
+- **Read-only mounts.** The compose file and `.env` are mounted `:ro`.
+- **Limited blast radius.** The sidecar can pull images and recreate the one
+  service named in `FIESTAUPDATER_SERVICE`. It cannot start arbitrary
+  containers or run arbitrary shell commands.
+
+If you're uncomfortable mounting the Docker socket at all, leave the
+`fiestaupdater` profile off and [update manually](/docs/features/updating#updating-manually-always-works).
+
+## Troubleshooting
+
+**The Update Now button doesn't appear.** The web UI probes the sidecar at
+startup. Check:
+
+```bash
+docker compose ps fiestaupdater          # is it running and healthy?
+docker logs fiestaupdater                # any errors?
+docker exec fiestaboard wget -qO- http://fiestaupdater:8765/healthz
+```
+
+The most common cause is `COMPOSE_PROFILES=fiestaupdater` missing from `.env`,
+so the sidecar service is never started.
+
+**Update returns 202 but nothing happens.** Check the sidecar logs for
+`env file /compose/.env not found` — this means the `.env` volume mount is
+missing from your compose file. Add it (see [configuration](#docker-compose-configuration))
+and recreate the sidecar.
+
+**Update started but FiestaBoard never came back.** Wait a minute (the Pi can
+take 60–90s to recreate the container), then reload
+`http://fiestaboard.local:4420`. If still down:
+
+```bash
+docker logs fiestaboard
+docker compose -f docker-compose.hub.yml up -d
+```
+
+**I want to roll back.** Pin the previous image tag (e.g.
+`image: fiestaboard/fiestaboard:5.1.1`) in your compose file, then
+`docker compose up -d`. Automated rollback is planned for a future release.
+
+## See also
+
+- [In-App Updates](/docs/features/updating) — user-facing guide and Update Now flow
+- [FiestaPi Quick Start](/docs/setup/raspberry-pi) — pre-configured Pi image with the sidecar enabled
+- [Raspberry Pi Deployment](/docs/deployment/raspberry-pi) — running on an existing Pi with Docker
+- [Environment Variables](/docs/reference/environment-variables#fiestaupdater) — full env-var reference

--- a/docs-site/versioned_docs/version-5.3/deployment/raspberry-pi.md
+++ b/docs-site/versioned_docs/version-5.3/deployment/raspberry-pi.md
@@ -60,7 +60,7 @@ COMPOSE_PROFILES=fiestaupdater
 FIESTAUPDATER_TOKEN=$(head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n')
 ```
 
-Then restart: `docker compose -f docker-compose.hub.yml up -d`. See [In-App Updates](/docs/features/updating) for more detail.
+Then restart: `docker compose -f docker-compose.hub.yml up -d`. See [In-App Updates](/docs/features/updating) for more detail, or the [FiestaUpdater reference](/docs/deployment/fiestaupdater) for the full sidecar configuration.
 
 ### Auto-start on boot
 

--- a/docs-site/versioned_docs/version-5.3/features/updating.md
+++ b/docs-site/versioned_docs/version-5.3/features/updating.md
@@ -36,6 +36,8 @@ FiestaBoard uses a small companion container called `fiestaupdater`. It sits on 
 
 When you click Update Now, the web UI POSTs to the FiestaBoard API, which calls the updater over the internal network. The updater runs `docker compose pull && docker compose up -d` against your compose file. Because it's a separate process, FiestaBoard can update itself without getting cut off mid-response.
 
+**See also:** [FiestaUpdater reference](/docs/deployment/fiestaupdater) for the full sidecar architecture, environment variables, and HTTP API.
+
 ## Opting in on Docker installs
 
 The updater is opt-in for Docker and manual installs (it's already on for FiestaPi).

--- a/docs-site/versioned_docs/version-5.3/reference/environment-variables.md
+++ b/docs-site/versioned_docs/version-5.3/reference/environment-variables.md
@@ -106,6 +106,19 @@ Use `BOARD_LOCAL_API_KEY` + `BOARD_HOST` for local mode (default). Use `BOARD_RE
 | `REFRESH_INTERVAL_SECONDS` | Display update interval (seconds) | `300` |
 | `VERSION` | Build version (set automatically during Docker builds -- do not change) | `dev` |
 
+## FiestaUpdater
+
+These variables control the optional [`fiestaupdater`](/docs/deployment/fiestaupdater) sidecar that powers one-click in-app updates. On [FiestaPi](/docs/setup/raspberry-pi) they're configured automatically on first boot.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `COMPOSE_PROFILES` | Set to `fiestaupdater` to enable the updater sidecar in the compose stack. | - |
+| `FIESTAUPDATER_TOKEN` | Shared bearer token (64 hex chars) used to authenticate the FiestaBoard API → sidecar calls. Generate with `head -c 32 /dev/urandom \| od -An -tx1 \| tr -d ' \n'`. | - |
+| `FIESTAUPDATER_SERVICE` | Compose service name the sidecar is allowed to update. Validated against `^[a-z0-9_-]+$`. | `fiestaboard` |
+| `FIESTAUPDATER_COMPOSE_FILE` | Path inside the sidecar container to the mounted compose file. | `/compose/docker-compose.yml` |
+| `FIESTAUPDATER_PORT` | Port the sidecar listens on (Docker internal network only — never published to the host). | `8765` |
+| `COMPOSE_PROJECT_NAME` | Compose project name the sidecar should target. Must match the project the main stack runs under. | `fiestaboard` |
+
 ## Example `.env` File
 
 ```bash

--- a/docs-site/versioned_sidebars/version-5.3-sidebars.json
+++ b/docs-site/versioned_sidebars/version-5.3-sidebars.json
@@ -62,6 +62,7 @@
       "items": [
         "deployment/production",
         "deployment/raspberry-pi",
+        "deployment/fiestaupdater",
         "setup/docker-setup",
         "setup/cloud-api"
       ]


### PR DESCRIPTION
Adds documentation for the FiestaUpdater sidecar and FiestaPi support, plus homepage marketing content surfacing both new features.

## Changes

### New pages
- **`deployment/fiestaupdater.md`** — Full sidecar technical reference: why it's a separate container, FiestaPi vs Docker install comparison, complete `docker-compose.hub.yml` snippet with required volume mounts (`docker.sock`, compose file, `.env`), environment variable table, HTTP API table (`/healthz`, `/version`, `/update`, `/restart`, `/shutdown`), security model, and troubleshooting guide.

### Updated pages
- **`reference/environment-variables.md`** — New "FiestaUpdater" section with table for all six sidecar env vars (`COMPOSE_PROFILES`, `FIESTAUPDATER_TOKEN`, `FIESTAUPDATER_SERVICE`, `FIESTAUPDATER_COMPOSE_FILE`, `FIESTAUPDATER_PORT`, `COMPOSE_PROJECT_NAME`).
- **`features/updating.md`** — Added "See also" cross-link to the FiestaUpdater reference after the technical explanation paragraph.
- **`deployment/raspberry-pi.md`** — Added cross-link to the FiestaUpdater reference alongside the existing updating.md link.

### Sidebar
- Added `deployment/fiestaupdater` entry to the "Deployment" category in both `sidebars.ts` and `versioned_sidebars/version-5.3-sidebars.json`.

### Homepage
- New **"What's New"** highlights section between the feature cards and "See It in Action" showcase — two cards for FiestaPi (🍓) and In-App Updates (⚡), each with a primary docs link and secondary action (release download / sidecar reference).
- Hero subtitle updated: "Weather, stocks, sports & more — flash a Raspberry Pi or run with Docker"
- Matching styles (gradient backdrop, 2-col responsive grid, badge pill, hover lift card).

### Versioned docs
All changes mirrored into `versioned_docs/version-5.3/` — the site has `includeCurrentVersion: false`, so only versioned docs are served.

## Test plan

- `npm run build` passes locally (verified — `[SUCCESS] Generated static files in "build"`).
- New fiestaupdater page renders at `/docs/deployment/fiestaupdater`.
- Sidebar shows "FiestaUpdater" under Deployment.
- Homepage shows "What's New" section with two cards.
- All internal cross-links resolve without broken-link errors.