### PR TITLE
feat: add 24 new community plugins to registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,33 +121,58 @@ FiestaBoard has **26 built-in plugins** covering weather, finance, transit, spor
 
 | Plugin | What It Shows | API Key? |
 |--------|--------------|----------|
-| [Weather](https://github.com/Fiestaboard/fiestaboard-plugin--weather) | Temperature, UV, precipitation, high/low | Yes (free) |
-| [Stocks](https://github.com/Fiestaboard/fiestaboard-plugin--stocks) | Stock prices with color indicators | Optional |
-| [Sports Scores](https://github.com/Fiestaboard/fiestaboard-plugin--sports-scores) | NFL, Soccer, NHL, NBA scores | Optional |
-| [Traffic](https://github.com/Fiestaboard/fiestaboard-plugin--traffic) | Travel time with live traffic | Yes (free tier) |
-| [Muni Transit](https://github.com/Fiestaboard/fiestaboard-plugin--muni) | Real-time SF Muni arrivals | Yes (free) |
-| [Home Assistant](https://github.com/Fiestaboard/fiestaboard-plugin--home-assistant) | Smart home status (doors, locks, garage) | Yes (self-hosted) |
-| [Last.fm Now Playing](https://github.com/Fiestaboard/fiestaboard-plugin--last-fm) | Currently playing music | Yes (free) |
-| [Surf Conditions](https://github.com/Fiestaboard/fiestaboard-plugin--surf) | Wave height and quality ratings | No |
+| [Airport Board](https://github.com/Fiestaboard/fiestaboard-plugin--airport-board) | Live flights near a configurable airport | No |
 | [Air Quality & Fog](https://github.com/Fiestaboard/fiestaboard-plugin--air-fog) | AQI and fog conditions | Yes |
-| [Nearby Aircraft](https://github.com/Fiestaboard/fiestaboard-plugin--nearby-aircraft) | Real-time aircraft tracking | Optional |
-| [Disney Park Queue Times](https://github.com/Fiestaboard/fiestaboard-plugin--disney-parks-times) | Wait times for Disney rides | No |
-| [WSDOT Ferries](https://github.com/Fiestaboard/fiestaboard-plugin--wsdot) | WA State ferry schedules and alerts | Yes (free) |
+| [Aurora Forecast](https://github.com/Fiestaboard/fiestaboard-plugin--aurora-forecast) | Geomagnetic Kp index and aurora visibility | No |
 | [Bay Wheels](https://github.com/Fiestaboard/fiestaboard-plugin--baywheels) | Bike availability at stations | No |
+| [Calendar Subscription](https://github.com/Fiestaboard/fiestaboard-plugin--calendar-sub) | Upcoming events from any .ics URL | No |
+| [Currency Exchange](https://github.com/Fiestaboard/fiestaboard-plugin--currency) | Live exchange rates (Frankfurter/ECB) | No |
+| [Dad Jokes](https://github.com/Fiestaboard/fiestaboard-plugin--dad-jokes) | Random dad jokes | No |
+| [Disney Park Queue Times](https://github.com/Fiestaboard/fiestaboard-plugin--disney-parks-times) | Wait times for Disney rides | No |
+| [Earthquake Monitor](https://github.com/Fiestaboard/fiestaboard-plugin--earthquake) | Recent USGS earthquake data | No |
+| [Element of the Day](https://github.com/Fiestaboard/fiestaboard-plugin--element-of-day) | Periodic table element of the day | No |
+| [Generic Data](https://github.com/Fiestaboard/fiestaboard-plugin--generic-data) | Custom data from any JSON/XML URL | No |
+| [Guest WiFi](https://github.com/Fiestaboard/fiestaboard-plugin--guest-wifi) | WiFi credentials for guests | No |
+| [Hacker News](https://github.com/Fiestaboard/fiestaboard-plugin--hacker-news) | Top Hacker News story title and score | No |
+| [Allergy & Health](https://github.com/Fiestaboard/fiestaboard-plugin--health) | Allergy levels and health risk indicators | No |
+| [Home Assistant](https://github.com/Fiestaboard/fiestaboard-plugin--home-assistant) | Smart home status (doors, locks, garage) | Yes (self-hosted) |
+| [ISS Tracker](https://github.com/Fiestaboard/fiestaboard-plugin--iss-tracker) | Real-time ISS position and altitude | No |
+| [Last.fm Now Playing](https://github.com/Fiestaboard/fiestaboard-plugin--last-fm) | Currently playing music | Yes (free) |
+| [Lightning Alerts](https://github.com/Fiestaboard/fiestaboard-plugin--lightning) | Active NWS weather alerts by US state | No |
+| [Moon Phase](https://github.com/Fiestaboard/fiestaboard-plugin--moon-phase) | Current lunar phase and illumination | No |
+| [Muni Transit](https://github.com/Fiestaboard/fiestaboard-plugin--muni) | Real-time SF Muni arrivals | Yes (free) |
+| [National Day](https://github.com/Fiestaboard/fiestaboard-plugin--national-day) | Today's national days and observances | No |
+| [Nearby Aircraft](https://github.com/Fiestaboard/fiestaboard-plugin--nearby-aircraft) | Real-time aircraft tracking | Optional |
+| [Network Speed](https://github.com/Fiestaboard/fiestaboard-plugin--network-speed) | Internet download/upload speed | No |
+| [On This Day](https://github.com/Fiestaboard/fiestaboard-plugin--on-this-day) | Historical event from today's date | No |
+| [Pet Facts](https://github.com/Fiestaboard/fiestaboard-plugin--pet-facts) | Random cat or dog fact | No |
+| [Pi-hole Stats](https://github.com/Fiestaboard/fiestaboard-plugin--pihole) | DNS query stats from local Pi-hole | No |
+| [Quote of the Day](https://github.com/Fiestaboard/fiestaboard-plugin--quote-of-day) | Daily inspirational quote | No |
+| [Reddit Hot](https://github.com/Fiestaboard/fiestaboard-plugin--reddit-hot) | Top post from any subreddit | No |
+| [River Flow](https://github.com/Fiestaboard/fiestaboard-plugin--river-flow) | Real-time USGS streamflow data | No |
+| [Santa Tracker](https://github.com/Fiestaboard/fiestaboard-plugin--santa-tracker) | Track Santa's journey on Christmas | No |
+| [Solar Activity](https://github.com/Fiestaboard/fiestaboard-plugin--solar-activity) | Sunspot count and solar flare data | No |
+| [Spacecraft Launches](https://github.com/Fiestaboard/fiestaboard-plugin--spacecraft-launches) | Upcoming rocket launch countdowns | No |
+| [Sports Scores](https://github.com/Fiestaboard/fiestaboard-plugin--sports-scores) | NFL, Soccer, NHL, NBA scores | Optional |
+| [Star Trek Quotes](https://github.com/Fiestaboard/fiestaboard-plugin--star-trek-quotes) | Quotes from TNG, Voyager, DS9 | No |
+| [Stardate](https://github.com/Fiestaboard/fiestaboard-plugin--stardate) | Current TNG-era stardate | No |
+| [Stocks](https://github.com/Fiestaboard/fiestaboard-plugin--stocks) | Stock prices with color indicators | Optional |
+| [Sun Art](https://github.com/Fiestaboard/fiestaboard-plugin--sun-art) | Art pattern that follows the sun | No |
+| [Surf Conditions](https://github.com/Fiestaboard/fiestaboard-plugin--surf) | Wave height and quality ratings | No |
+| [Tide Times](https://github.com/Fiestaboard/fiestaboard-plugin--tide-times) | NOAA tide predictions by station | No |
+| [Traffic](https://github.com/Fiestaboard/fiestaboard-plugin--traffic) | Travel time with live traffic | Yes (free tier) |
+| [UV Index](https://github.com/Fiestaboard/fiestaboard-plugin--uv-index) | UV index and sun protection advice | No |
+| [Visual Clock](https://github.com/Fiestaboard/fiestaboard-plugin--visual-clock) | Large pixel-art style clock | No |
+| [Volcano Activity](https://github.com/Fiestaboard/fiestaboard-plugin--volcano) | Active volcanoes from Smithsonian GVP | No |
+| [Weather](https://github.com/Fiestaboard/fiestaboard-plugin--weather) | Temperature, UV, precipitation, high/low | Yes (free) |
+| [Webhook](https://github.com/Fiestaboard/fiestaboard-plugin--webhook) | Custom message via HTTP webhook | No |
+| [White Noise](https://github.com/Fiestaboard/fiestaboard-plugin--white-noise) | Ambient rain/white noise effect | No |
+| [Wildfire Monitor](https://github.com/Fiestaboard/fiestaboard-plugin--wildfire) | Active wildfires from NIFC | No |
+| [Word of the Day](https://github.com/Fiestaboard/fiestaboard-plugin--word-of-day) | Word, pronunciation, and definition | No |
+| [WSDOT Ferries](https://github.com/Fiestaboard/fiestaboard-plugin--wsdot) | WA State ferry schedules and alerts | Yes (free) |
 | [Countdown](./plugins/countdown/README.md) | Time remaining until an event | No |
 | [Date & Time](./plugins/date_time/README.md) | Current date/time in many formats | No |
 | [Random](./plugins/random/README.md) | Randomly selected values from a custom list, coin flip, or board color | No |
-| [Generic Data](https://github.com/Fiestaboard/fiestaboard-plugin--generic-data) | Custom data from any JSON/XML URL | No |
-| [Guest WiFi](https://github.com/Fiestaboard/fiestaboard-plugin--guest-wifi) | WiFi credentials for guests | No |
-| [Allergy & Health](https://github.com/Fiestaboard/fiestaboard-plugin--health) | Allergy levels and health risk indicators | No |
-| [Star Trek Quotes](https://github.com/Fiestaboard/fiestaboard-plugin--star-trek-quotes) | Quotes from TNG, Voyager, DS9 | No |
-| [Dad Jokes](https://github.com/Fiestaboard/fiestaboard-plugin--dad-jokes) | Random dad jokes | No |
-| [Santa Tracker](https://github.com/Fiestaboard/fiestaboard-plugin--santa-tracker) | Track Santa's journey on Christmas | No |
-| [Spacecraft Launches](https://github.com/Fiestaboard/fiestaboard-plugin--spacecraft-launches) | Upcoming rocket launch countdowns | No |
-| [Stardate](https://github.com/Fiestaboard/fiestaboard-plugin--stardate) | Current TNG-era stardate | No |
-| [Sun Art](https://github.com/Fiestaboard/fiestaboard-plugin--sun-art) | Art pattern that follows the sun | No |
-| [Visual Clock](https://github.com/Fiestaboard/fiestaboard-plugin--visual-clock) | Large pixel-art style clock | No |
-| [White Noise](https://github.com/Fiestaboard/fiestaboard-plugin--white-noise) | Ambient rain/white noise effect | No |
 
 ---
 

--- a/plugin-registry.json
+++ b/plugin-registry.json
@@ -6,6 +6,16 @@
   "version": "1.0.0",
   "plugins": [
     {
+      "id": "airport_board",
+      "name": "Airport Board",
+      "description": "Display live flight information near a configurable airport.",
+      "repository": "https://github.com/Fiestaboard/fiestaboard-plugin--airport-board",
+      "author": "FiestaBoard Team",
+      "fiestaboard_version": ">=4.2.0",
+      "icon": "plane",
+      "category": "transit"
+    },
+    {
       "id": "air_fog",
       "name": "Air Quality & Fog",
       "description": "Display air quality (AQI), fog/visibility conditions, and pollen/allergen levels",
@@ -14,6 +24,16 @@
       "fiestaboard_version": ">=2.10.0",
       "icon": "wind",
       "category": "weather"
+    },
+    {
+      "id": "aurora_forecast",
+      "name": "Aurora Forecast",
+      "description": "Display the current geomagnetic Kp index and aurora activity forecast.",
+      "repository": "https://github.com/Fiestaboard/fiestaboard-plugin--aurora-forecast",
+      "author": "FiestaBoard Team",
+      "fiestaboard_version": ">=4.2.0",
+      "icon": "zap",
+      "category": "data"
     },
     {
       "id": "baywheels",
@@ -36,6 +56,16 @@
       "category": "utility"
     },
     {
+      "id": "currency",
+      "name": "Currency Exchange",
+      "description": "Display live currency exchange rates using the Frankfurter API.",
+      "repository": "https://github.com/Fiestaboard/fiestaboard-plugin--currency",
+      "author": "FiestaBoard Team",
+      "fiestaboard_version": ">=4.2.0",
+      "icon": "banknote",
+      "category": "data"
+    },
+    {
       "id": "dad_jokes",
       "name": "Dad Jokes",
       "description": "Display random dad jokes from the icanhazdadjoke API",
@@ -54,6 +84,26 @@
       "fiestaboard_version": ">=2.10.0",
       "icon": "landmark",
       "category": "entertainment"
+    },
+    {
+      "id": "earthquake",
+      "name": "Earthquake Monitor",
+      "description": "Display recent earthquake activity from USGS GeoJSON feeds.",
+      "repository": "https://github.com/Fiestaboard/fiestaboard-plugin--earthquake",
+      "author": "FiestaBoard Team",
+      "fiestaboard_version": ">=4.2.0",
+      "icon": "activity",
+      "category": "data"
+    },
+    {
+      "id": "element_of_day",
+      "name": "Element of the Day",
+      "description": "Display a periodic table element that changes daily.",
+      "repository": "https://github.com/Fiestaboard/fiestaboard-plugin--element-of-day",
+      "author": "FiestaBoard Team",
+      "fiestaboard_version": ">=4.2.0",
+      "icon": "atom",
+      "category": "utility"
     },
     {
       "id": "generic_data",
@@ -76,6 +126,16 @@
       "category": "utility"
     },
     {
+      "id": "hacker_news",
+      "name": "Hacker News",
+      "description": "Display the top Hacker News story title and score on your board.",
+      "repository": "https://github.com/Fiestaboard/fiestaboard-plugin--hacker-news",
+      "author": "FiestaBoard Team",
+      "fiestaboard_version": ">=4.2.0",
+      "icon": "newspaper",
+      "category": "data"
+    },
+    {
       "id": "health",
       "name": "Allergy & Health",
       "description": "Display allergy levels (pollen counts) and health risk indicators for your area using Open-Meteo Air Quality data",
@@ -96,6 +156,16 @@
       "category": "home"
     },
     {
+      "id": "iss_tracker",
+      "name": "ISS Tracker",
+      "description": "Display the real-time position and altitude of the ISS.",
+      "repository": "https://github.com/Fiestaboard/fiestaboard-plugin--iss-tracker",
+      "author": "FiestaBoard Team",
+      "fiestaboard_version": ">=4.2.0",
+      "icon": "satellite",
+      "category": "data"
+    },
+    {
       "id": "last_fm",
       "name": "Last.fm Now Playing",
       "description": "Display what's currently playing via Last.fm scrobbling. Works with Apple Music, Spotify, and any scrobbling source.",
@@ -104,6 +174,26 @@
       "fiestaboard_version": ">=2.10.0",
       "icon": "music",
       "category": "entertainment"
+    },
+    {
+      "id": "lightning",
+      "name": "Lightning Alerts",
+      "description": "Display active weather alerts for a US state from the NWS.",
+      "repository": "https://github.com/Fiestaboard/fiestaboard-plugin--lightning",
+      "author": "FiestaBoard Team",
+      "fiestaboard_version": ">=4.2.0",
+      "icon": "cloud-lightning",
+      "category": "data"
+    },
+    {
+      "id": "moon_phase",
+      "name": "Moon Phase",
+      "description": "Display the current lunar phase and illumination.",
+      "repository": "https://github.com/Fiestaboard/fiestaboard-plugin--moon-phase",
+      "author": "FiestaBoard Team",
+      "fiestaboard_version": ">=4.2.0",
+      "icon": "moon",
+      "category": "data"
     },
     {
       "id": "muni",
@@ -116,6 +206,16 @@
       "category": "transit"
     },
     {
+      "id": "national_day",
+      "name": "National Day",
+      "description": "Display today's national days and fun observances.",
+      "repository": "https://github.com/Fiestaboard/fiestaboard-plugin--national-day",
+      "author": "FiestaBoard Team",
+      "fiestaboard_version": ">=4.2.0",
+      "icon": "calendar-heart",
+      "category": "utility"
+    },
+    {
       "id": "nearby_aircraft",
       "name": "Nearby Aircraft",
       "description": "Display real-time nearby aircraft information from OpenSky Network API",
@@ -123,6 +223,76 @@
       "author": "FiestaBoard Team",
       "fiestaboard_version": ">=2.10.0",
       "icon": "plane",
+      "category": "data"
+    },
+    {
+      "id": "network_speed",
+      "name": "Network Speed",
+      "description": "Display your internet connection speed.",
+      "repository": "https://github.com/Fiestaboard/fiestaboard-plugin--network-speed",
+      "author": "FiestaBoard Team",
+      "fiestaboard_version": ">=4.2.0",
+      "icon": "gauge",
+      "category": "utility"
+    },
+    {
+      "id": "on_this_day",
+      "name": "On This Day",
+      "description": "Display a notable historical event that happened on today's date.",
+      "repository": "https://github.com/Fiestaboard/fiestaboard-plugin--on-this-day",
+      "author": "FiestaBoard Team",
+      "fiestaboard_version": ">=4.2.0",
+      "icon": "history",
+      "category": "utility"
+    },
+    {
+      "id": "pet_facts",
+      "name": "Pet Facts",
+      "description": "Display a random fun fact about cats or dogs.",
+      "repository": "https://github.com/Fiestaboard/fiestaboard-plugin--pet-facts",
+      "author": "FiestaBoard Team",
+      "fiestaboard_version": ">=4.2.0",
+      "icon": "paw-print",
+      "category": "entertainment"
+    },
+    {
+      "id": "pihole",
+      "name": "Pi-hole Stats",
+      "description": "Display DNS query statistics from a local Pi-hole ad blocker.",
+      "repository": "https://github.com/Fiestaboard/fiestaboard-plugin--pihole",
+      "author": "FiestaBoard Team",
+      "fiestaboard_version": ">=4.2.0",
+      "icon": "shield",
+      "category": "utility"
+    },
+    {
+      "id": "quote_of_day",
+      "name": "Quote of the Day",
+      "description": "Display a daily inspirational quote from ZenQuotes.",
+      "repository": "https://github.com/Fiestaboard/fiestaboard-plugin--quote-of-day",
+      "author": "FiestaBoard Team",
+      "fiestaboard_version": ">=4.2.0",
+      "icon": "quote",
+      "category": "utility"
+    },
+    {
+      "id": "reddit_hot",
+      "name": "Reddit Hot",
+      "description": "Display the top hot post from any subreddit.",
+      "repository": "https://github.com/Fiestaboard/fiestaboard-plugin--reddit-hot",
+      "author": "FiestaBoard Team",
+      "fiestaboard_version": ">=4.2.0",
+      "icon": "message-circle",
+      "category": "data"
+    },
+    {
+      "id": "river_flow",
+      "name": "River Flow",
+      "description": "Display real-time streamflow data from a USGS monitoring station.",
+      "repository": "https://github.com/Fiestaboard/fiestaboard-plugin--river-flow",
+      "author": "FiestaBoard Team",
+      "fiestaboard_version": ">=4.2.0",
+      "icon": "droplets",
       "category": "data"
     },
     {
@@ -134,6 +304,16 @@
       "fiestaboard_version": ">=2.10.0",
       "icon": "gift",
       "category": "entertainment"
+    },
+    {
+      "id": "solar_activity",
+      "name": "Solar Activity",
+      "description": "Display current solar activity and sunspot data from NOAA.",
+      "repository": "https://github.com/Fiestaboard/fiestaboard-plugin--solar-activity",
+      "author": "FiestaBoard Team",
+      "fiestaboard_version": ">=4.2.0",
+      "icon": "sun",
+      "category": "data"
     },
     {
       "id": "spacecraft_launches",
@@ -206,6 +386,16 @@
       "category": "weather"
     },
     {
+      "id": "tide_times",
+      "name": "Tide Times",
+      "description": "Display NOAA tide predictions for a configured station.",
+      "repository": "https://github.com/Fiestaboard/fiestaboard-plugin--tide-times",
+      "author": "FiestaBoard Team",
+      "fiestaboard_version": ">=4.2.0",
+      "icon": "waves",
+      "category": "data"
+    },
+    {
       "id": "traffic",
       "name": "Traffic",
       "description": "Display commute times and traffic conditions using Google Routes API",
@@ -214,6 +404,16 @@
       "fiestaboard_version": ">=2.10.0",
       "icon": "car",
       "category": "transit"
+    },
+    {
+      "id": "uv_index",
+      "name": "UV Index",
+      "description": "Display the current UV index and protection advice.",
+      "repository": "https://github.com/Fiestaboard/fiestaboard-plugin--uv-index",
+      "author": "FiestaBoard Team",
+      "fiestaboard_version": ">=4.2.0",
+      "icon": "sun-medium",
+      "category": "weather"
     },
     {
       "id": "visual_clock",
@@ -226,6 +426,16 @@
       "category": "art"
     },
     {
+      "id": "volcano",
+      "name": "Volcano Activity",
+      "description": "Display current volcanic activity from the Smithsonian GVP.",
+      "repository": "https://github.com/Fiestaboard/fiestaboard-plugin--volcano",
+      "author": "FiestaBoard Team",
+      "fiestaboard_version": ">=4.2.0",
+      "icon": "flame",
+      "category": "data"
+    },
+    {
       "id": "weather",
       "name": "Weather",
       "description": "Display current weather conditions with temperature, humidity, and wind speed",
@@ -236,6 +446,16 @@
       "category": "weather"
     },
     {
+      "id": "webhook",
+      "name": "Webhook",
+      "description": "Display a custom message pushed via an HTTP webhook.",
+      "repository": "https://github.com/Fiestaboard/fiestaboard-plugin--webhook",
+      "author": "FiestaBoard Team",
+      "fiestaboard_version": ">=4.2.0",
+      "icon": "webhook",
+      "category": "utility"
+    },
+    {
       "id": "white_noise",
       "name": "White Noise",
       "description": "Gentle rain / white noise mode \u2014 softly cascading tiles that create a soothing ambient pitter-patter",
@@ -244,6 +464,26 @@
       "fiestaboard_version": ">=2.10.0",
       "icon": "cloud-rain",
       "category": "art"
+    },
+    {
+      "id": "wildfire",
+      "name": "Wildfire Monitor",
+      "description": "Display active wildfire information from NIFC.",
+      "repository": "https://github.com/Fiestaboard/fiestaboard-plugin--wildfire",
+      "author": "FiestaBoard Team",
+      "fiestaboard_version": ">=4.2.0",
+      "icon": "flame-kindling",
+      "category": "data"
+    },
+    {
+      "id": "word_of_day",
+      "name": "Word of the Day",
+      "description": "Display a word, its pronunciation, and definition.",
+      "repository": "https://github.com/Fiestaboard/fiestaboard-plugin--word-of-day",
+      "author": "FiestaBoard Team",
+      "fiestaboard_version": ">=4.2.0",
+      "icon": "book-open",
+      "category": "utility"
     },
     {
       "id": "wsdot",


### PR DESCRIPTION
## Summary

Adds 24 new community plugins to `plugin-registry.json` and the README plugins table.

## New Plugins

| Plugin ID | Name | Category |
|-----------|------|----------|
| airport_board | Airport Board | transit |
| aurora_forecast | Aurora Forecast | data |
| currency | Currency Exchange | data |
  | earthquake | Earthquake Monitor | data |
| element_of_day | Element of the Day | utility |
| hacker_news | Hacker News | data |
| iss_tracker | ISS Tracker | data |
| lightning | Lightning Alerts | data |
| moon_phase | Moon Phase | data |
| national_day | National Day | utility |
| network_speed | Network Speed | utility |
| on_this_day | On This Day | utility |
| pet_facts | Pet Facts | entertainment |
| pihole | Pi-hole Stats | utility |
| quote_of_day | Quote of the Day | utility |
| reddit_hot | Reddit Hot | data |
| river_flow | River Flow | data |
| solar_activity | Solar Activity | data |
| tide_times | Tide Times | data |
| uv_index | UV Index | weather |
| volcano | Volcano Activity | data |
| webhook | Webhook | utility |
| wildfire | Wildfire Monitor | data |
| word_of_day | Word of the Day | utility |

## Changes
- `plugin-registry.json`: 25 → 49 plugins (24 new entries, alphabetical order maintained)
- `README.md`: All Available Plugins table updated to include all 49 plugins alphabetically

All plugin repos are live under the Fiestaboard GitHub org with passing CI tests.