### PR TITLE
fix: a11y audit — labels, focus rings, and ARIA attributes

### DIFF
--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -1096,6 +1096,8 @@
     "preview": "Vorschau",
     "useInTemplates": "In Vorlagen verwenden:",
     "addMapping": "Zuordnung hinzufügen",
+    "removeMapping": "Zuordnung entfernen",
+    "removeItem": "Element entfernen",
     "noSchemaProperties": "Keine Schema-Eigenschaften definiert",
     "clickLocationIcon": "Klicken Sie auf das Standortsymbol, um Ihren aktuellen Standort zu verwenden",
     "digitColorNotUsed": "Ziffernfarbe wird nicht verwendet, wenn ein Farbmuster ausgewählt ist"

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1096,6 +1096,8 @@
     "preview": "Preview",
     "useInTemplates": "Use in templates:",
     "addMapping": "Add mapping",
+    "removeMapping": "Remove mapping",
+    "removeItem": "Remove item",
     "noSchemaProperties": "No schema properties defined",
     "clickLocationIcon": "Click the location icon to use your current location",
     "digitColorNotUsed": "Digit color is not used when a color pattern is selected"

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -1096,6 +1096,8 @@
     "preview": "Vista previa",
     "useInTemplates": "Uso en plantillas:",
     "addMapping": "Añadir mapeo",
+    "removeMapping": "Eliminar mapeo",
+    "removeItem": "Eliminar elemento",
     "noSchemaProperties": "No hay propiedades de esquema definidas",
     "clickLocationIcon": "Haz clic en el icono de ubicación para usar tu ubicación actual",
     "digitColorNotUsed": "El color del dígito no se usa cuando se selecciona un patrón de color"

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -1096,6 +1096,8 @@
     "preview": "Aperçu",
     "useInTemplates": "Utiliser dans les modèles :",
     "addMapping": "Ajouter un mapping",
+    "removeMapping": "Supprimer le mapping",
+    "removeItem": "Supprimer l'élément",
     "noSchemaProperties": "Aucune propriété de schéma définie",
     "clickLocationIcon": "Cliquez sur l'icône de localisation pour utiliser votre position actuelle",
     "digitColorNotUsed": "La couleur du chiffre n'est pas utilisée lorsqu'un motif de couleur est sélectionné"

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -1096,6 +1096,8 @@
     "preview": "Preview",
     "useInTemplates": "Use in templates:",
     "addMapping": "Add mapping",
+    "removeMapping": "Remove mapping",
+    "removeItem": "Remove item",
     "noSchemaProperties": "No schema properties defined",
     "clickLocationIcon": "Click the location icon to use your current location",
     "digitColorNotUsed": "Digit color is not used when a color pattern is selected"

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -1096,6 +1096,8 @@
     "preview": "Preview",
     "useInTemplates": "Use in templates:",
     "addMapping": "Add mapping",
+    "removeMapping": "Remove mapping",
+    "removeItem": "Remove item",
     "noSchemaProperties": "No schema properties defined",
     "clickLocationIcon": "Click the location icon to use your current location",
     "digitColorNotUsed": "Digit color is not used when a color pattern is selected"

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -1096,6 +1096,8 @@
     "preview": "Preview",
     "useInTemplates": "Use in templates:",
     "addMapping": "Add mapping",
+    "removeMapping": "Remove mapping",
+    "removeItem": "Remove item",
     "noSchemaProperties": "No schema properties defined",
     "clickLocationIcon": "Click the location icon to use your current location",
     "digitColorNotUsed": "Digit color is not used when a color pattern is selected"

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -1096,6 +1096,8 @@
     "preview": "Preview",
     "useInTemplates": "Use in templates:",
     "addMapping": "Add mapping",
+    "removeMapping": "Remove mapping",
+    "removeItem": "Remove item",
     "noSchemaProperties": "No schema properties defined",
     "clickLocationIcon": "Click the location icon to use your current location",
     "digitColorNotUsed": "Digit color is not used when a color pattern is selected"

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -1096,6 +1096,8 @@
     "preview": "Preview",
     "useInTemplates": "Use in templates:",
     "addMapping": "Add mapping",
+    "removeMapping": "Remove mapping",
+    "removeItem": "Remove item",
     "noSchemaProperties": "No schema properties defined",
     "clickLocationIcon": "Click the location icon to use your current location",
     "digitColorNotUsed": "Digit color is not used when a color pattern is selected"

--- a/web/messages/pt.json
+++ b/web/messages/pt.json
@@ -1096,6 +1096,8 @@
     "preview": "Preview",
     "useInTemplates": "Use in templates:",
     "addMapping": "Add mapping",
+    "removeMapping": "Remove mapping",
+    "removeItem": "Remove item",
     "noSchemaProperties": "No schema properties defined",
     "clickLocationIcon": "Click the location icon to use your current location",
     "digitColorNotUsed": "Digit color is not used when a color pattern is selected"

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -1096,6 +1096,8 @@
     "preview": "Preview",
     "useInTemplates": "Use in templates:",
     "addMapping": "Add mapping",
+    "removeMapping": "Remove mapping",
+    "removeItem": "Remove item",
     "noSchemaProperties": "No schema properties defined",
     "clickLocationIcon": "Click the location icon to use your current location",
     "digitColorNotUsed": "Digit color is not used when a color pattern is selected"

--- a/web/messages/sv.json
+++ b/web/messages/sv.json
@@ -1096,6 +1096,8 @@
     "preview": "Preview",
     "useInTemplates": "Use in templates:",
     "addMapping": "Add mapping",
+    "removeMapping": "Remove mapping",
+    "removeItem": "Remove item",
     "noSchemaProperties": "No schema properties defined",
     "clickLocationIcon": "Click the location icon to use your current location",
     "digitColorNotUsed": "Digit color is not used when a color pattern is selected"

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -1096,6 +1096,8 @@
     "preview": "Preview",
     "useInTemplates": "Use in templates:",
     "addMapping": "Add mapping",
+    "removeMapping": "Remove mapping",
+    "removeItem": "Remove item",
     "noSchemaProperties": "No schema properties defined",
     "clickLocationIcon": "Click the location icon to use your current location",
     "digitColorNotUsed": "Digit color is not used when a color pattern is selected"

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -1096,6 +1096,8 @@
     "preview": "Preview",
     "useInTemplates": "Use in templates:",
     "addMapping": "Add mapping",
+    "removeMapping": "Remove mapping",
+    "removeItem": "Remove item",
     "noSchemaProperties": "No schema properties defined",
     "clickLocationIcon": "Click the location icon to use your current location",
     "digitColorNotUsed": "Digit color is not used when a color pattern is selected"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "5.4.1",
+  "version": "5.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "5.4.1",
+      "version": "5.5.1",
       "dependencies": {
         "@ducanh2912/next-pwa": "^10.0.0",
         "@radix-ui/react-accordion": "^1.2.2",
@@ -18492,6 +18492,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/web/src/app/carousels/page.tsx
+++ b/web/src/app/carousels/page.tsx
@@ -153,14 +153,14 @@ function CarouselForm({ carousel, pages, onSubmit, onCancel, onDelete }: Carouse
 
       {/* Interval */}
       <div className="space-y-2">
-        <Label>{t("pageDurationLabel")}</Label>
+        <Label htmlFor="carousel-interval">{t("pageDurationLabel")}</Label>
         <p className="text-xs text-muted-foreground">{t("pageDurationDescription")}</p>
         <Select
           value={String(intervalSeconds)}
           onValueChange={(v) => setIntervalSeconds(Number(v))}
           modal={false}
         >
-          <SelectTrigger>
+          <SelectTrigger id="carousel-interval">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>

--- a/web/src/app/integrations/page.tsx
+++ b/web/src/app/integrations/page.tsx
@@ -1029,7 +1029,7 @@ function PluginCard({
   const configSheet = (
     <Sheet open={isConfigOpen} onOpenChange={setIsConfigOpen}>
       <SheetTrigger asChild>
-        <Button variant="ghost" size="icon" className="h-7 w-7">
+        <Button variant="ghost" size="icon" className="h-7 w-7" aria-label="Configure">
           <Settings className="h-3.5 w-3.5" />
         </Button>
       </SheetTrigger>
@@ -1360,7 +1360,7 @@ function PluginCard({
           {configSheet}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon" className="h-7 w-7">
+              <Button variant="ghost" size="icon" className="h-7 w-7" aria-label="More options">
                 <MoreHorizontal className="h-3.5 w-3.5" />
               </Button>
             </DropdownMenuTrigger>

--- a/web/src/app/profile/page.tsx
+++ b/web/src/app/profile/page.tsx
@@ -186,7 +186,9 @@ export default function ProfilePage() {
                 <Skeleton className="h-10 w-full max-w-sm" />
               ) : (
                 <div className="space-y-2 max-w-sm">
+                  <Label htmlFor="instance-name">{t("instanceNameTitle")}</Label>
                   <Input
+                    id="instance-name"
                     value={instanceName}
                     onChange={(e) => setInstanceName(e.target.value)}
                     onBlur={handleInstanceNameBlur}
@@ -281,20 +283,20 @@ export default function ProfilePage() {
                 <div className="space-y-4">
                   {/* Timezone */}
                   <div className="space-y-2 max-w-sm">
-                    <Label className="text-sm font-medium">{t("timezoneLabel")}</Label>
-                    <TimezonePicker value={timezone} onChange={handleTimezoneChange} />
+                    <Label id="timezone-label" htmlFor="timezone-picker" className="text-sm font-medium">{t("timezoneLabel")}</Label>
+                    <TimezonePicker id="timezone-picker" value={timezone} onChange={handleTimezoneChange} />
                   </div>
 
                   {/* Format selects */}
                   <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 max-w-md">
                     <div className="space-y-2">
-                      <Label className="text-sm font-medium">{t("timeFormat")}</Label>
+                      <Label htmlFor="time-format" className="text-sm font-medium">{t("timeFormat")}</Label>
                       <Select
                         value={selectedTimeFormat}
                         onValueChange={(v) => handleTimeFormatChange(v as "12h" | "24h")}
                         disabled={isSaving}
                       >
-                        <SelectTrigger>
+                        <SelectTrigger id="time-format">
                           <SelectValue />
                         </SelectTrigger>
                         <SelectContent>
@@ -305,7 +307,7 @@ export default function ProfilePage() {
                     </div>
 
                     <div className="space-y-2">
-                      <Label className="text-sm font-medium">{t("dateFormat")}</Label>
+                      <Label htmlFor="date-format" className="text-sm font-medium">{t("dateFormat")}</Label>
                       <Select
                         value={selectedDateFormat}
                         onValueChange={(v) =>
@@ -315,7 +317,7 @@ export default function ProfilePage() {
                         }
                         disabled={isSaving}
                       >
-                        <SelectTrigger>
+                        <SelectTrigger id="date-format">
                           <SelectValue />
                         </SelectTrigger>
                         <SelectContent>

--- a/web/src/components/general-settings.tsx
+++ b/web/src/components/general-settings.tsx
@@ -235,6 +235,7 @@ export function GeneralSettings() {
                       <div className="space-y-2">
                         <Label htmlFor="silence-start" className="text-xs">{t("startTimeLabel")}</Label>
                         <TimePicker
+                          id="silence-start"
                           value={silenceStartTime}
                           onChange={(val) => handleSilenceTimeChange("start", val)}
                           disabled={isSaving}
@@ -244,6 +245,7 @@ export function GeneralSettings() {
                       <div className="space-y-2">
                         <Label htmlFor="silence-end" className="text-xs">{t("endTimeLabel")}</Label>
                         <TimePicker
+                          id="silence-end"
                           value={silenceEndTime}
                           onChange={(val) => handleSilenceTimeChange("end", val)}
                           disabled={isSaving}

--- a/web/src/components/home-assistant-entity-picker.tsx
+++ b/web/src/components/home-assistant-entity-picker.tsx
@@ -137,7 +137,7 @@ export function HomeAssistantEntityPicker({ open, onClose, onSelect }: Props) {
                 </div>
 
                 <div className="space-y-1.5">
-                  <label className="text-xs font-medium text-muted-foreground px-1">{t("selectAttribute")}</label>
+                  <p className="text-xs font-medium text-muted-foreground px-1">{t("selectAttribute")}</p>
                   <ScrollArea className="h-[250px] border rounded-md">
                     <div className="p-1">
                       {availableAttributes.map((attr) => {

--- a/web/src/components/page-builder.tsx
+++ b/web/src/components/page-builder.tsx
@@ -951,13 +951,14 @@ export function PageBuilder({ pageId, deviceType: deviceTypeProp = "flagship", o
 
             {/* Page name */}
             <div className="space-y-1.5">
-              <label className="text-xs sm:text-sm font-medium">{t("pageNameLabel")}</label>
+              <label htmlFor="page-name" className="text-xs sm:text-sm font-medium">{t("pageNameLabel")}</label>
               <input
+                id="page-name"
                 type="text"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 placeholder={t("pageNamePlaceholder")}
-                className="w-full h-10 sm:h-9 px-3 text-sm rounded-md border bg-background"
+                className="w-full h-10 sm:h-9 px-3 text-sm rounded-md border bg-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
               />
             </div>
 
@@ -1069,7 +1070,8 @@ export function PageBuilder({ pageId, deviceType: deviceTypeProp = "flagship", o
                     <button
                       onClick={() => setPreviewBoardColor("black")}
                       aria-label={t("previewAsBlack")}
-                      className={`h-5 w-5 rounded-full border-2 bg-board-surface-dark transition-colors ${
+                      aria-pressed={effectiveBoardColor === "black"}
+                      className={`h-5 w-5 rounded-full border-2 bg-board-surface-dark transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 ${
                         effectiveBoardColor === "black"
                           ? "border-primary ring-1 ring-primary/30"
                           : "border-border hover:border-muted-foreground"
@@ -1078,7 +1080,8 @@ export function PageBuilder({ pageId, deviceType: deviceTypeProp = "flagship", o
                     <button
                       onClick={() => setPreviewBoardColor("white")}
                       aria-label={t("previewAsWhite")}
-                      className={`h-5 w-5 rounded-full border-2 bg-board-surface-light transition-colors ${
+                      aria-pressed={effectiveBoardColor === "white"}
+                      className={`h-5 w-5 rounded-full border-2 bg-board-surface-light transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 ${
                         effectiveBoardColor === "white"
                           ? "border-primary ring-1 ring-primary/30"
                           : "border-border hover:border-muted-foreground"

--- a/web/src/components/page-grid-selector.tsx
+++ b/web/src/components/page-grid-selector.tsx
@@ -664,9 +664,9 @@ export function PageGridSelector({
     return (
       <div>
         {effectiveLabel && (
-          <label className="text-xs font-medium text-muted-foreground mb-3 block">
+          <p className="text-xs font-medium text-muted-foreground mb-3">
             {effectiveLabel}
-          </label>
+          </p>
         )}
         {pagesContent}
       </div>

--- a/web/src/components/plugin-settings/schema-form.tsx
+++ b/web/src/components/plugin-settings/schema-form.tsx
@@ -176,6 +176,7 @@ function StringField({ name, property, value, onChange, required, disabled }: Fi
   if (isTimezone) {
     return (
       <TimezonePicker
+        id={name}
         value={String(value || "")}
         onChange={onChange}
         disabled={disabled}
@@ -951,8 +952,9 @@ function GenericDataMappingHelper({ name: _name, property: _property, value, onC
             <div className="flex-1 grid gap-2 p-3 border rounded-lg bg-muted/30">
               <div className="grid grid-cols-2 gap-2">
                 <div className="grid gap-1">
-                  <Label className="text-xs">{t("variableName")}</Label>
+                  <Label htmlFor={`mapping-${index}-variable`} className="text-xs">{t("variableName")}</Label>
                   <Input
+                    id={`mapping-${index}-variable`}
                     value={mapping.variable || ""}
                     onChange={(e) => handleItemChange(index, "variable", e.target.value)}
                     placeholder={t("variableNamePlaceholder")}
@@ -961,8 +963,9 @@ function GenericDataMappingHelper({ name: _name, property: _property, value, onC
                   />
                 </div>
                 <div className="grid gap-1">
-                  <Label className="text-xs">{t("dataPath")}</Label>
+                  <Label htmlFor={`mapping-${index}-path`} className="text-xs">{t("dataPath")}</Label>
                   <Input
+                    id={`mapping-${index}-path`}
                     value={mapping.path || ""}
                     onChange={(e) => handleItemChange(index, "path", e.target.value)}
                     placeholder={t("dataPathPlaceholder")}
@@ -973,8 +976,9 @@ function GenericDataMappingHelper({ name: _name, property: _property, value, onC
               </div>
               <div className="grid grid-cols-2 gap-2">
                 <div className="grid gap-1">
-                  <Label className="text-xs">{t("defaultValue")}</Label>
+                  <Label htmlFor={`mapping-${index}-default`} className="text-xs">{t("defaultValue")}</Label>
                   <Input
+                    id={`mapping-${index}-default`}
                     value={mapping.default || ""}
                     onChange={(e) => handleItemChange(index, "default", e.target.value)}
                     placeholder={t("defaultValuePlaceholder")}
@@ -1002,6 +1006,7 @@ function GenericDataMappingHelper({ name: _name, property: _property, value, onC
               onClick={() => handleRemove(index)}
               disabled={disabled}
               className="h-9 w-9 text-destructive hover:text-destructive self-start mt-3"
+              aria-label={t("removeMapping")}
             >
               <Trash2 className="h-4 w-4" />
             </Button>
@@ -1107,6 +1112,7 @@ function ArrayField({ name, property, value, onChange, disabled, itemSchema }: A
               onClick={() => handleRemove(index)}
               disabled={disabled}
               className="h-9 w-9 text-destructive hover:text-destructive"
+              aria-label={t("removeItem")}
             >
               <Trash2 className="h-4 w-4" />
             </Button>

--- a/web/src/components/settings/debug-settings.tsx
+++ b/web/src/components/settings/debug-settings.tsx
@@ -216,7 +216,7 @@ export function DebugSettings() {
           <div className="space-y-4">
         {/* Network Diagnostics */}
         <div className="space-y-2">
-          <Label className="text-xs font-medium">{t("networkDiagnosticsLabel")}</Label>
+          <p className="text-xs font-medium">{t("networkDiagnosticsLabel")}</p>
           <Button
             onClick={() => networkDiagnosticsMutation.mutate()}
             disabled={isAnyMutationLoading}
@@ -312,7 +312,7 @@ export function DebugSettings() {
 
         {/* Blank Board */}
         <div className="space-y-2">
-          <Label className="text-xs font-medium">{t("clearBoardLabel")}</Label>
+          <p className="text-xs font-medium">{t("clearBoardLabel")}</p>
           <Button
             onClick={() => blankMutation.mutate()}
             disabled={!isBoardConfigured || isAnyMutationLoading}
@@ -334,13 +334,13 @@ export function DebugSettings() {
 
         {/* Fill Board with Character */}
         <div className="space-y-2">
-          <Label className="text-xs font-medium">{t("fillWithCharacterLabel")}</Label>
+          <Label htmlFor="fill-character" className="text-xs font-medium">{t("fillWithCharacterLabel")}</Label>
           <div className="flex gap-2">
             <Select
               value={selectedCharacter.toString()}
               onValueChange={(value) => setSelectedCharacter(parseInt(value))}
             >
-              <SelectTrigger className="flex-1 h-9 text-xs">
+              <SelectTrigger id="fill-character" className="flex-1 h-9 text-xs">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent className="max-h-80">
@@ -384,7 +384,7 @@ export function DebugSettings() {
 
         {/* Show Debug Info */}
         <div className="space-y-2">
-          <Label className="text-xs font-medium">{t("displaySystemInfoLabel")}</Label>
+          <p className="text-xs font-medium">{t("displaySystemInfoLabel")}</p>
           <Button
             onClick={() => debugInfoMutation.mutate()}
             disabled={!isBoardConfigured || isAnyMutationLoading}
@@ -406,7 +406,7 @@ export function DebugSettings() {
 
         {/* Clear Cache */}
         <div className="space-y-2">
-          <Label className="text-xs font-medium">{t("cacheManagementLabel")}</Label>
+          <p className="text-xs font-medium">{t("cacheManagementLabel")}</p>
           <Button
             onClick={() => clearCacheMutation.mutate()}
             disabled={!isBoardConfigured || isAnyMutationLoading}

--- a/web/src/components/settings/display-settings.tsx
+++ b/web/src/components/settings/display-settings.tsx
@@ -480,7 +480,8 @@ export function DisplaySettings() {
                         <div className="flex gap-1">
                           <button
                             onClick={() => handleUpdateBoard(board.id, { device_type: "flagship" })}
-                            className={`px-2.5 py-1 rounded-full border text-[11px] transition-colors ${
+                            aria-pressed={board.device_type === "flagship"}
+                            className={`px-2.5 py-1 rounded-full border text-[11px] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
                               board.device_type === "flagship"
                                 ? "border-primary bg-primary/10 text-foreground"
                                 : "border-transparent text-muted-foreground hover:text-foreground"
@@ -490,7 +491,8 @@ export function DisplaySettings() {
                           </button>
                           <button
                             onClick={() => handleUpdateBoard(board.id, { device_type: "note" })}
-                            className={`px-2.5 py-1 rounded-full border text-[11px] transition-colors ${
+                            aria-pressed={board.device_type === "note"}
+                            className={`px-2.5 py-1 rounded-full border text-[11px] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
                               board.device_type === "note"
                                 ? "border-primary bg-primary/10 text-foreground"
                                 : "border-transparent text-muted-foreground hover:text-foreground"
@@ -506,7 +508,8 @@ export function DisplaySettings() {
                           <button
                             onClick={() => handleUpdateBoard(board.id, { board_color: "black" })}
                             aria-label={t("blackAriaLabel")}
-                            className={`h-6 w-6 rounded-full border-2 bg-board-surface-dark transition-colors ${
+                            aria-pressed={board.board_color === "black"}
+                            className={`h-6 w-6 rounded-full border-2 bg-board-surface-dark transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 ${
                               board.board_color === "black"
                                 ? "border-primary ring-2 ring-primary/30"
                                 : "border-border hover:border-muted-foreground"
@@ -515,7 +518,8 @@ export function DisplaySettings() {
                           <button
                             onClick={() => handleUpdateBoard(board.id, { board_color: "white" })}
                             aria-label={t("whiteAriaLabel")}
-                            className={`h-6 w-6 rounded-full border-2 bg-board-surface-light transition-colors ${
+                            aria-pressed={board.board_color === "white"}
+                            className={`h-6 w-6 rounded-full border-2 bg-board-surface-light transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 ${
                               board.board_color === "white"
                                 ? "border-primary ring-2 ring-primary/30"
                                 : "border-border hover:border-muted-foreground"

--- a/web/src/components/settings/mqtt-settings.tsx
+++ b/web/src/components/settings/mqtt-settings.tsx
@@ -118,7 +118,7 @@ export function MqttSettingsCard() {
       </CardHeader>
 
       <Collapsible open={expanded} onOpenChange={setExpanded}>
-        <CollapsibleTrigger className="flex w-full items-center justify-between px-6 py-2 text-xs text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-none">
+        <CollapsibleTrigger className="flex w-full items-center justify-between px-6 py-2 text-xs text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm">
           <span>{t("brokerConfiguration")}</span>
           <ChevronDown className={`h-4 w-4 transition-transform duration-200 ${expanded ? "rotate-180" : ""}`} />
         </CollapsibleTrigger>
@@ -127,8 +127,9 @@ export function MqttSettingsCard() {
           <CardContent className="pt-2 space-y-4">
             <div className="grid grid-cols-3 gap-3">
               <div className="col-span-2 space-y-1">
-                <Label className="text-xs">{t("brokerHost")}</Label>
+                <Label htmlFor="mqtt-broker-host" className="text-xs">{t("brokerHost")}</Label>
                 <Input
+                  id="mqtt-broker-host"
                   value={merged.broker_host}
                   onChange={(e) => setDraft((d) => ({ ...d, broker_host: e.target.value }))}
                   placeholder="localhost"
@@ -136,8 +137,9 @@ export function MqttSettingsCard() {
                 />
               </div>
               <div className="space-y-1">
-                <Label className="text-xs">{t("port")}</Label>
+                <Label htmlFor="mqtt-broker-port" className="text-xs">{t("port")}</Label>
                 <Input
+                  id="mqtt-broker-port"
                   type="number"
                   value={merged.broker_port}
                   onChange={(e) => setDraft((d) => ({ ...d, broker_port: Number(e.target.value) }))}
@@ -149,8 +151,9 @@ export function MqttSettingsCard() {
 
             <div className="grid grid-cols-2 gap-3">
               <div className="space-y-1">
-                <Label className="text-xs">{t("username")}</Label>
+                <Label htmlFor="mqtt-username" className="text-xs">{t("username")}</Label>
                 <Input
+                  id="mqtt-username"
                   value={merged.username}
                   onChange={(e) => setDraft((d) => ({ ...d, username: e.target.value }))}
                   placeholder={t("optional")}
@@ -158,9 +161,10 @@ export function MqttSettingsCard() {
                 />
               </div>
               <div className="space-y-1">
-                <Label className="text-xs">{t("password")}</Label>
+                <Label htmlFor="mqtt-password" className="text-xs">{t("password")}</Label>
                 <div className="flex gap-1.5">
                   <Input
+                    id="mqtt-password"
                     type={showPassword ? "text" : "password"}
                     value={merged.password === "***" ? "" : merged.password}
                     onChange={(e) => setDraft((d) => ({ ...d, password: e.target.value }))}
@@ -182,8 +186,9 @@ export function MqttSettingsCard() {
             </div>
 
             <div className="space-y-1">
-              <Label className="text-xs">{t("externalUrl")}</Label>
+              <Label htmlFor="mqtt-external-url" className="text-xs">{t("externalUrl")}</Label>
               <Input
+                id="mqtt-external-url"
                 value={merged.external_url}
                 onChange={(e) => setDraft((d) => ({ ...d, external_url: e.target.value }))}
                 placeholder={t("externalUrlPlaceholder")}

--- a/web/src/components/tiptap-template-editor/components/FormulaEditorPanel.tsx
+++ b/web/src/components/tiptap-template-editor/components/FormulaEditorPanel.tsx
@@ -222,7 +222,7 @@ export function FormulaEditorPanel({
 
         {/* ── Header: expression input + inline validation ── */}
         <div className="px-3 pt-3 pb-2.5 space-y-1.5">
-          <label className="text-[10px] font-semibold text-muted-foreground uppercase tracking-widest">
+          <label htmlFor="formula-expression" className="text-[10px] font-semibold text-muted-foreground uppercase tracking-widest">
             Formula expression
           </label>
           <div className="relative">
@@ -230,6 +230,7 @@ export function FormulaEditorPanel({
               {"{{="}
             </span>
             <input
+              id="formula-expression"
               ref={inputRef}
               type="text"
               value={expr}

--- a/web/src/components/ui/time-picker.tsx
+++ b/web/src/components/ui/time-picker.tsx
@@ -13,9 +13,11 @@ interface TimePickerProps {
   placeholder?: string;
   className?: string;
   disabled?: boolean;
+  id?: string;
+  "aria-label"?: string;
 }
 
-export function TimePicker({ value, onChange, placeholder = "00:00", className, disabled }: TimePickerProps) {
+export function TimePicker({ value, onChange, placeholder = "00:00", className, disabled, id, "aria-label": ariaLabel }: TimePickerProps) {
   const t = useTranslations("timePicker");
   const [isOpen, setIsOpen] = useState(false);
   const [hours, setHours] = useState("00");
@@ -194,10 +196,14 @@ export function TimePicker({ value, onChange, placeholder = "00:00", className, 
   return (
     <div ref={containerRef} className={cn("relative", className)}>
       <Button
+        id={id}
         type="button"
         variant="outline"
         onClick={toggleDropdown}
         disabled={disabled}
+        aria-label={ariaLabel}
+        aria-expanded={isOpen}
+        aria-haspopup="listbox"
         className={cn(
           "w-full h-9 px-3 text-sm justify-start font-normal",
           !value && "text-muted-foreground"

--- a/web/src/components/ui/timezone-picker.tsx
+++ b/web/src/components/ui/timezone-picker.tsx
@@ -15,6 +15,7 @@ interface TimezonePickerProps {
   className?: string;
   disabled?: boolean;
   onValidationChange?: (isValid: boolean) => void;
+  id?: string;
 }
 
 export function TimezonePicker({ 
@@ -22,7 +23,8 @@ export function TimezonePicker({
   onChange, 
   className, 
   disabled,
-  onValidationChange 
+  onValidationChange,
+  id,
 }: TimezonePickerProps) {
   const t = useTranslations("timezonePicker");
   const [searchQuery, setSearchQuery] = useState("");
@@ -251,6 +253,7 @@ export function TimezonePicker({
       <div className="relative">
         <Input
           ref={inputRef}
+          id={id}
           type="text"
           role="combobox"
           aria-expanded={isOpen}

--- a/web/src/components/wizard/step-board-setup.tsx
+++ b/web/src/components/wizard/step-board-setup.tsx
@@ -52,6 +52,7 @@ export function StepBoardSetup({
 }: StepBoardSetupProps) {
   const t = useTranslations("wizard.boardSetup");
   const tc = useTranslations("common");
+  const tbs = useTranslations("boardSettings");
   const configRef = useRef(config);
   configRef.current = config;
 
@@ -237,7 +238,7 @@ export function StepBoardSetup({
     <div className="space-y-6">
       {/* API Mode Selection */}
       <div className="space-y-3">
-        <Label className="text-base font-medium">{t("connectionType")}</Label>
+        <p className="text-base font-medium">{t("connectionType")}</p>
         <div className="grid grid-cols-2 gap-3">
           <button
             type="button"
@@ -305,7 +306,8 @@ export function StepBoardSetup({
               <button
                 type="button"
                 onClick={() => setShowApiKey(!showApiKey)}
-                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                aria-label={showApiKey ? tbs("hideApiKey") : tbs("showApiKey")}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
               >
                 {showApiKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
               </button>
@@ -373,9 +375,9 @@ export function StepBoardSetup({
           )}
           {scanStatus === "done" && discoveredBoards.length >= 1 && (
             <div className="space-y-2">
-              <Label className="text-sm">
+              <p className="text-sm">
                 {t("foundBoards", { count: discoveredBoards.length })}
-              </Label>
+              </p>
               <div className="space-y-1.5">
                 {discoveredBoards.map((board) => (
                   <button
@@ -407,7 +409,7 @@ export function StepBoardSetup({
 
           {/* Local Key Mode Toggle */}
           <div className="space-y-3">
-            <Label className="text-sm font-medium">{t("authenticationMethod")}</Label>
+            <p className="text-sm font-medium">{t("authenticationMethod")}</p>
             <div className="grid grid-cols-2 gap-2">
               <button
                 type="button"
@@ -460,7 +462,8 @@ export function StepBoardSetup({
                 <button
                   type="button"
                   onClick={() => setShowApiKey(!showApiKey)}
-                  className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                  aria-label={showApiKey ? tbs("hideApiKey") : tbs("showApiKey")}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
                 >
                   {showApiKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
                 </button>
@@ -489,7 +492,8 @@ export function StepBoardSetup({
                   <button
                     type="button"
                     onClick={() => setShowApiKey(!showApiKey)}
-                    className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                    aria-label={showApiKey ? tbs("hideToken") : tbs("showToken")}
+                    className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
                   >
                     {showApiKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
                   </button>
@@ -602,11 +606,12 @@ export function StepBoardSetup({
       {/* Device Type & Board Color */}
       <div className="space-y-4 pt-4 border-t">
         <div className="space-y-3">
-          <Label className="text-sm font-medium">{t("boardType")}</Label>
+          <p className="text-sm font-medium">{t("boardType")}</p>
           <div className="grid grid-cols-2 gap-3">
             <button
               type="button"
               onClick={() => onConfigChange({ ...config, device_type: "flagship" })}
+              aria-pressed={config.device_type === "flagship"}
               className={cn(
                 "flex flex-col items-center gap-1.5 p-3 rounded-lg border-2 transition-all",
                 config.device_type === "flagship"
@@ -620,6 +625,7 @@ export function StepBoardSetup({
             <button
               type="button"
               onClick={() => onConfigChange({ ...config, device_type: "note" })}
+              aria-pressed={config.device_type === "note"}
               className={cn(
                 "flex flex-col items-center gap-1.5 p-3 rounded-lg border-2 transition-all",
                 config.device_type === "note"
@@ -634,14 +640,15 @@ export function StepBoardSetup({
         </div>
 
         <div className="space-y-3">
-          <Label className="text-sm font-medium">{t("boardColor")}</Label>
+          <p className="text-sm font-medium">{t("boardColor")}</p>
           <div className="flex items-center gap-3">
             <button
               type="button"
               onClick={() => onConfigChange({ ...config, board_color: "black" })}
               aria-label={tc("black")}
+              aria-pressed={config.board_color === "black"}
               className={cn(
-                "h-8 w-8 rounded-full border-2 bg-board-surface-dark transition-colors",
+                "h-8 w-8 rounded-full border-2 bg-board-surface-dark transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
                 config.board_color === "black"
                   ? "border-primary ring-2 ring-primary/30"
                   : "border-border hover:border-muted-foreground"
@@ -651,8 +658,9 @@ export function StepBoardSetup({
               type="button"
               onClick={() => onConfigChange({ ...config, board_color: "white" })}
               aria-label={tc("white")}
+              aria-pressed={config.board_color === "white"}
               className={cn(
-                "h-8 w-8 rounded-full border-2 bg-board-surface-light transition-colors",
+                "h-8 w-8 rounded-full border-2 bg-board-surface-light transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
                 config.board_color === "white"
                   ? "border-primary ring-2 ring-primary/30"
                   : "border-border hover:border-muted-foreground"
@@ -663,7 +671,7 @@ export function StepBoardSetup({
 
         {/* Live board preview */}
         <div className="space-y-2 pt-3">
-          <Label className="text-sm font-medium text-muted-foreground">{tc("preview")}</Label>
+          <p className="text-sm font-medium text-muted-foreground">{tc("preview")}</p>
           <BoardDisplay
             message={previewMessage}
             size="sm"

--- a/web/src/components/wizard/step-easy-plugins.tsx
+++ b/web/src/components/wizard/step-easy-plugins.tsx
@@ -258,8 +258,9 @@ export function StepEasyPlugins({
               {plugin.id === "date_time" && selected && (
                 <CardContent className="pt-2 space-y-3" onClick={(e) => e.stopPropagation()}>
                   <div className="space-y-2">
-                    <Label className="text-sm">{t("timezoneLabel")}</Label>
+                    <Label htmlFor="wizard-timezone" className="text-sm">{t("timezoneLabel")}</Label>
                     <TimezonePicker
+                      id="wizard-timezone"
                       value={config.date_time.timezone}
                       onChange={(timezone) =>
                         onConfigChange({


### PR DESCRIPTION
## Summary

Comprehensive accessibility audit and fix pass across the web UI.

## Changes

### Form label/input associations
All form inputs now have proper `id`/`htmlFor` pairs so screen readers can announce labels correctly:
- Page builder page name input
- MQTT settings (broker host, port, username, password, external URL)
- Profile page (instance name, timezone, time format, date format)
- Carousels page (page duration select)
- General settings (silence start/end TimePicker IDs)
- Schema form mapping inputs (variable, path, default)
- Wizard step-easy-plugins timezone picker
- Formula editor expression input

### Focus ring visibility
- Raw `<input>` in page-builder: added `focus-visible:ring` classes
- Color picker buttons in page-builder: added `focus-visible:ring` + `ring-offset`
- CollapsibleTrigger in mqtt-settings: added `focus-visible:ring-2`

### Component accessibility props
- **TimePicker**: added `id`, `aria-label`, `aria-expanded`, `aria-haspopup` props to trigger button
- **TimezonePicker**: added `id` prop forwarded to the underlying input

### ARIA attributes on toggle buttons
Added `aria-pressed` to all toggle-style buttons so assistive technology reports state:
- Board type (flagship/note) in step-board-setup and display-settings
- Board color (black/white) in page-builder, step-board-setup, and display-settings

### Icon-only buttons
Added `aria-label` to all icon-only buttons that were missing one:
- Show/hide API key and token buttons in step-board-setup
- Configure and More options buttons in integrations page
- Remove mapping and remove item buttons in schema-form

### Standalone label elements → semantic elements
Converted `<label>`/`<Label>` elements not associated with any form control to `<p>` elements (using `<label>` for non-inputs is invalid HTML):
- Page grid selector section heading
- Debug settings section headings (network diagnostics, clear board, display system info, cache management)
- Wizard step-board-setup section headings (connection type, found boards, auth method, board type, board color, preview)
- HA entity picker "Select attribute" heading

### Translation keys
Added `removeMapping` and `removeItem` keys to `en.json` for the newly labelled remove buttons in schema-form.