### PR TITLE
fix: load plugin board images from GitHub raw URLs instead of local static files

### DIFF
--- a/docs-site/src/pages/plugins/detail.tsx
+++ b/docs-site/src/pages/plugins/detail.tsx
@@ -167,7 +167,7 @@ function DetailContent() {
   }
 
   const categoryLabel = CATEGORY_LABELS[plugin.category] ?? plugin.category;
-  const heroImage = pluginBoardImagePath(plugin.id, boardColor === 'white' ? 'light' : 'dark');
+  const heroImage = pluginBoardImagePath(plugin, boardColor === 'white' ? 'light' : 'dark');
 
   return (
     <>

--- a/docs-site/src/pages/plugins/index.tsx
+++ b/docs-site/src/pages/plugins/index.tsx
@@ -18,7 +18,7 @@ function CategoryBadge({category}: {category: string}) {
 }
 
 function PluginCard({plugin, boardColor}: {plugin: PluginEntry; boardColor: 'black' | 'white'}) {
-  const imgSrc = pluginBoardImagePath(plugin.id, boardColor === 'white' ? 'light' : 'dark');
+  const imgSrc = pluginBoardImagePath(plugin, boardColor === 'white' ? 'light' : 'dark');
 
   return (
     <Link to={`/plugins/detail?id=${plugin.id}`} className={styles.pluginCard}>

--- a/docs-site/src/plugin-data.ts
+++ b/docs-site/src/plugin-data.ts
@@ -40,10 +40,24 @@ export function pluginImagePath(id: string): string {
 }
 
 /**
- * Converts a plugin ID to its board display image path for a specific board colour.
- * e.g. pluginBoardImagePath("air_fog", "dark") → "/img/black/air-fog-display.png"
+ * Derives the raw GitHub content URL for a plugin's board-display screenshot.
+ * e.g. pluginBoardImagePath(plugin, "dark")
+ *   → "https://raw.githubusercontent.com/Fiestaboard/fiestaboard-plugin--air-fog/main/docs/black/board-display.png"
+ *
+ * Falls back to the legacy local static path if no repository is available.
  */
-export function pluginBoardImagePath(id: string, colorMode: 'light' | 'dark'): string {
+export function pluginBoardImagePath(plugin: PluginEntry, colorMode: 'light' | 'dark'): string {
   const boardDir = colorMode === 'light' ? 'white' : 'black';
-  return `/img/${boardDir}/${id.replace(/_/g, '-')}-display.png`;
+
+  if (plugin.repository) {
+    const cleaned = plugin.repository.replace(/\.git$/, '').replace(/\/$/, '');
+    const match = cleaned.match(/github\.com\/(.+)/);
+    if (match) {
+      const branch = plugin.branch?.trim() || 'main';
+      return `https://raw.githubusercontent.com/${match[1]}/${branch}/docs/${boardDir}/board-display.png`;
+    }
+  }
+
+  // Fallback for plugins without an external repository
+  return `/img/${boardDir}/${plugin.id.replace(/_/g, '-')}-display.png`;
 }


### PR DESCRIPTION
## Problem

25 of 49 plugins on the `/plugins` directory page were showing blank image cards with 404 errors. The `pluginBoardImagePath()` function in `docs-site/src/plugin-data.ts` was hardcoded to return local static file paths (`/img/black/{id}-display.png`), meaning images only appeared if they had been manually copied into `docs-site/static/img/`. The 25 newer external plugins (airport-board, aurora-forecast, currency, etc.) were never given local copies.

## Root Cause

The image path function didn't know about each plugin's GitHub repository — it only had the plugin ID. So there was no way to derive the source-of-truth location (each plugin repo's `docs/black/board-display.png`).

## Fix

`pluginBoardImagePath()` now accepts a full `PluginEntry` (instead of just the `id`) and derives the `raw.githubusercontent.com` URL directly from the `repository` field in `plugin-registry.json`:

```
https://raw.githubusercontent.com/Fiestaboard/fiestaboard-plugin--{name}/main/docs/{black|white}/board-display.png
```

It also respects the `branch` field for plugins pinned to a non-`main` branch. A local static path fallback is kept for any plugin without an external repository.

## Impact

- **Existing plugins** (baywheels, air_fog, weather, etc.) now load images live from their GitHub repos — no more stale local copies needed
- **New plugins** just need `docs/black/board-display.png` and `docs/white/board-display.png` in their repo and they appear automatically — zero changes to this repo required
- **25 scaffold-only plugins** will still show blank until their screenshots are generated and pushed, which is the correct behaviour

## Files Changed

- `docs-site/src/plugin-data.ts` — rewrote `pluginBoardImagePath()` signature + implementation
- `docs-site/src/pages/plugins/index.tsx` — pass `plugin` instead of `plugin.id`
- `docs-site/src/pages/plugins/detail.tsx` — pass `plugin` instead of `plugin.id`