### PR TITLE
fix: add pytz dependency for plugin timezone support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,9 @@ paho-mqtt>=2.1.0
 icalendar>=7.0.3
 recurring-ical-events>=3.8.1
 
+# Timezone support (used by santa_tracker, visual_clock, stardate, calendar_sub plugins)
+pytz>=2024.0
+
 # Optional: Board Python library (alternative to manual implementation)
 # fiesta>=0.1.0
 


### PR DESCRIPTION
Several external plugins (`santa_tracker`, `visual_clock`, `stardate`, `calendar_sub`) import `pytz` at module level. `pytz` was previously available as a transitive dependency but is no longer guaranteed after dependency updates.

Adding it explicitly ensures CI can install all plugin dependencies correctly when running plugin tests against the FiestaBoard core.

**Affected plugins:** santa-tracker, visual-clock, stardate, calendar-sub, sun-art