### PR TITLE
fix: remove fiestaboard-core/plugins from CI PYTHONPATH

### DIFF
--- a/scripts/ci-workflow-template.yml
+++ b/scripts/ci-workflow-template.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Run tests
         env:
-          PYTHONPATH: "fiestaboard-core:${{ github.workspace }}:fiestaboard-core/plugins"
+          PYTHONPATH: "${{ github.workspace }}:fiestaboard-core"
           BOARD_READ_WRITE_KEY: test_key
         run: |
           cat > .coveragerc << 'RCEOF'


### PR DESCRIPTION
The `fiestaboard-core/plugins/random/__init__.py` (FiestaBoard's internal "random" plugin) was shadowing Python's stdlib `random` module because `fiestaboard-core/plugins` was included in PYTHONPATH.

This caused all 49 external plugin repos to fail CI with:
```
ImportError: cannot import name 'choice' from partially initialized module 'random'
(most likely due to a circular import) (.../fiestaboard-core/plugins/random/__init__.py)
```

The `fiestaboard-core/plugins` path entry was never necessary — plugins are resolved via the workspace-first PYTHONPATH (`${{ github.workspace }}`) and the symlink/`__init__.py` setup step. Only `${{ github.workspace }}` and `fiestaboard-core` are needed.

All 49 external plugin repos have been updated with the same fix in a separate batch commit.