### PR TITLE
Register generative-ai-art plugin

### DIFF
--- a/plugin-registry.json
+++ b/plugin-registry.json
@@ -115,8 +115,16 @@
       "icon": "database",
       "category": "data"
     },
-    {
-      "id": "guest_wifi",
+    {      "id": "generative_ai_art",
+      "name": "Generative AI Art",
+      "description": "Generate full-screen abstract art for your split-flap display using an LLM. Each piece is a unique, thought-out composition using the board's 8-color palette.",
+      "repository": "https://github.com/Fiestaboard/fiestaboard-plugin--generative-ai-art",
+      "author": "FiestaBoard Team",
+      "fiestaboard_version": ">=2.10.0",
+      "icon": "palette",
+      "category": "art"
+    },
+    {      "id": "guest_wifi",
       "name": "Guest WiFi",
       "description": "Display guest WiFi credentials on your board",
       "repository": "https://github.com/Fiestaboard/fiestaboard-plugin--guest-wifi",


### PR DESCRIPTION
Adds the `generative_ai_art` plugin to the plugin registry.

**Plugin:** [fiestaboard-plugin--generative-ai-art](https://github.com/Fiestaboard/fiestaboard-plugin--generative-ai-art)

Each refresh the plugin asks any OpenAI-compatible LLM to compose a unique full-screen abstract art piece using the board's 8-colour palette, chosen from a pool of 63 artistic themes (concentric rings, aurora borealis, Mondrian-style blocks, Rothko colour fields, herringbone weaves, and more).

**Features:**
- Works with OpenAI, OpenRouter, Ollama, LM Studio, or any OpenAI v1-compatible endpoint
- Supports Flagship (6×22) and Note (3×15) display sizes
- Graceful fallback — board keeps showing the last piece if the LLM call fails
- Custom theme list, extra prompt instructions, and full system prompt override via `custom_system_prompt`

**Version:** 1.3.0  
**Minimum FiestaBoard version:** 2.10.0