### PR TITLE
fix: support package layout (plugins/<id>/) in plugin loader

### DIFF
--- a/src/plugins/loader.py
+++ b/src/plugins/loader.py
@@ -291,11 +291,19 @@ class PluginLoader:
                 )
 
         # Load Python module
+        # Support two repo layouts:
+        #   1. Root layout:    <plugin_dir>/__init__.py                     (older repos)
+        #   2. Package layout: <plugin_dir>/plugins/<id>/__init__.py        (newer repos)
         init_path = plugin_dir / "__init__.py"
         if not init_path.exists():
-            errors.append(f"Plugin __init__.py not found: {init_path}")
-            self._load_errors[plugin_name] = errors
-            return None
+            subdir_path = plugin_dir / "plugins" / plugin_name / "__init__.py"
+            if subdir_path.exists():
+                init_path = subdir_path
+                logger.debug("Using package layout for plugin %s: %s", plugin_name, init_path)
+            else:
+                errors.append(f"Plugin __init__.py not found: {init_path}")
+                self._load_errors[plugin_name] = errors
+                return None
         
         try:
             # Import the plugin module dynamically

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -217,6 +217,39 @@ def test_load_plugin_handles_missing_init(tmp_path):
     assert any("__init__.py" in e for e in loader.load_errors["no_init"])
 
 
+def test_load_plugin_loads_package_layout(tmp_path):
+    """load_plugin finds __init__.py in plugins/<id>/ subdirectory (newer repo layout)."""
+    plugin_id = "pkg_layout"
+    plugin_dir = tmp_path / plugin_id
+    plugin_dir.mkdir()
+    (plugin_dir / "manifest.json").write_text(
+        '{"id":"pkg_layout","name":"Test","version":"1.0.0","description":"","author":"","variables":{"simple":["var1"]},"max_lengths":{}}'
+    )
+    # Create package layout: plugins/pkg_layout/__init__.py (no root __init__.py)
+    sub_pkg = plugin_dir / "plugins" / plugin_id
+    sub_pkg.mkdir(parents=True)
+    (plugin_dir / "plugins" / "__init__.py").write_text("")
+    plugin_code = f'''
+"""Test plugin with package layout."""
+from src.plugins.base import PluginBase, PluginResult
+
+class PkgLayoutPlugin(PluginBase):
+    @property
+    def plugin_id(self) -> str:
+        return "{plugin_id}"
+
+    def fetch_data(self) -> PluginResult:
+        return PluginResult(available=True, data={{"value": "test"}})
+'''
+    (sub_pkg / "__init__.py").write_text(plugin_code)
+
+    loader = _loader_for_tests(tmp_path)
+    plugin = loader.load_plugin(plugin_id)
+    assert plugin is not None
+    assert plugin.plugin_id == plugin_id
+    assert plugin_id in loader.loaded_plugins
+
+
 def test_load_plugin_handles_import_errors(tmp_path):
     """load_plugin handles import errors in __init__.py."""
     plugin_dir = tmp_path / "import_error"


### PR DESCRIPTION
## Problem

Installing 24 git-repo plugins via the plugin install API returned HTTP 400 errors. The root cause was a directory structure mismatch:

- **26 repos (working):** root `__init__.py` at repo root
- **24 repos (broken):** plugin class lives at `plugins/<plugin_id>/__init__.py` with no root `__init__.py`

The loader only checked for root `__init__.py` and failed immediately if it wasn't present.

## Solution

### Loader fix (`src/plugins/loader.py`)
Added a fallback: when root `__init__.py` is missing, the loader now also checks `plugins/<id>/__init__.py` before returning an error. This handles both layouts transparently.

### Root shim files (24 plugin repos)
Added backward-compatible `__init__.py` shim files to all 24 affected plugin repos. Each shim dynamically re-exports from the package subdirectory, so older FiestaBoard installations (without this loader fix) will also work correctly.

Affected repos: airport_board, aurora_forecast, currency, earthquake, element_of_day, hacker_news, iss_tracker, lightning, moon_phase, national_day, network_speed, on_this_day, pet_facts, pihole, quote_of_day, reddit_hot, river_flow, solar_activity, tide_times, uv_index, volcano, webhook, wildfire, word_of_day

## Changes

- `src/plugins/loader.py` — fallback path detection for package layout
- `tests/test_plugin_loader.py` — new test `test_load_plugin_loads_package_layout`