### PR TITLE
Update baywheels plugin to Lyft Bike Share

### DIFF
--- a/plugin-registry.json
+++ b/plugin-registry.json
@@ -36,10 +36,10 @@
       "category": "data"
     },
     {
-      "id": "baywheels",
-      "name": "Bay Wheels",
-      "description": "Display Bay Wheels bike share availability with electric and classic bike counts",
-      "repository": "https://github.com/Fiestaboard/fiestaboard-plugin--baywheels",
+      "id": "lyft_bikeshare",
+      "name": "Lyft Bike Share",
+      "description": "Display Lyft bike share availability with electric and classic bike counts. Works with Bay Wheels, CitiBike, Capital Bikeshare, Biketown, Divvy, and other Lyft-operated systems.",
+      "repository": "https://github.com/Fiestaboard/fiestaboard-plugin--lyft-bike-share",
       "author": "FiestaBoard Team",
       "fiestaboard_version": ">=2.10.0",
       "icon": "bike",

--- a/plugin-registry.json
+++ b/plugin-registry.json
@@ -36,7 +36,7 @@
       "category": "data"
     },
     {
-      "id": "lyft_bikeshare",
+      "id": "lyft_bike_share",
       "name": "Lyft Bike Share",
       "description": "Display Lyft bike share availability with electric and classic bike counts. Works with Bay Wheels, CitiBike, Capital Bikeshare, Biketown, Divvy, and other Lyft-operated systems.",
       "repository": "https://github.com/Fiestaboard/fiestaboard-plugin--lyft-bike-share",

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -46,15 +46,15 @@ PLUGIN_ID_RENAMES: Dict[str, str] = {
     # v2.0.0 of the bike share plugin generalised to all Lyft-operated
     # GBFS systems (Bay Wheels, CitiBike, Capital Bikeshare, Biketown,
     # Divvy, ...) and renamed the plugin id.
-    "baywheels": "lyft_bikeshare",
+    "baywheels": "lyft_bike_share",
 }
 
 # Per-rename adjustments to the migrated settings dict. Each handler
 # receives a deep-copied settings dict and returns the adjusted dict
 # that will be written under the new plugin id. Used to drop fields
 # that no longer exist in the new manifest and seed new defaults.
-def _adjust_baywheels_to_lyft_bikeshare(cfg: Dict[str, Any]) -> Dict[str, Any]:
-    """Adjust a v1 baywheels config to fit the v2 lyft_bikeshare schema.
+def _adjust_baywheels_to_lyft_bike_share(cfg: Dict[str, Any]) -> Dict[str, Any]:
+    """Adjust a v1 baywheels config to fit the v2 lyft_bike_share schema.
 
     - Promotes the legacy singular ``station_id`` into ``station_ids`` if
       the list is empty (so users with the old single-station setup
@@ -77,7 +77,7 @@ def _adjust_baywheels_to_lyft_bikeshare(cfg: Dict[str, Any]) -> Dict[str, Any]:
 
 
 PLUGIN_RENAME_ADJUSTERS: Dict[str, Any] = {
-    "baywheels": _adjust_baywheels_to_lyft_bikeshare,
+    "baywheels": _adjust_baywheels_to_lyft_bike_share,
 }
 
 # Default configuration schema

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -39,6 +39,47 @@ FEATURE_TO_PLUGIN_MAP = {
 # Fields excluded from feature-to-plugin migration (handled by manifest defaults)
 MIGRATION_EXCLUDED_FIELDS = {"color_rules"}
 
+# Plugin renames applied on startup. Maps an obsolete plugin id to its
+# replacement id. Each entry is a one-shot, idempotent rename of the
+# `plugins.<old_id>` config block to `plugins.<new_id>`.
+PLUGIN_ID_RENAMES: Dict[str, str] = {
+    # v2.0.0 of the bike share plugin generalised to all Lyft-operated
+    # GBFS systems (Bay Wheels, CitiBike, Capital Bikeshare, Biketown,
+    # Divvy, ...) and renamed the plugin id.
+    "baywheels": "lyft_bikeshare",
+}
+
+# Per-rename adjustments to the migrated settings dict. Each handler
+# receives a deep-copied settings dict and returns the adjusted dict
+# that will be written under the new plugin id. Used to drop fields
+# that no longer exist in the new manifest and seed new defaults.
+def _adjust_baywheels_to_lyft_bikeshare(cfg: Dict[str, Any]) -> Dict[str, Any]:
+    """Adjust a v1 baywheels config to fit the v2 lyft_bikeshare schema.
+
+    - Promotes the legacy singular ``station_id`` into ``station_ids`` if
+      the list is empty (so users with the old single-station setup
+      keep monitoring the same station).
+    - Drops the deprecated singular ``station_id`` and ``station_name``
+      fields, which were removed in v2.0.0.
+    - Seeds a default ``gbfs_base_url`` (Bay Wheels) if not present, so
+      existing users keep pointing at the same feed without manual
+      reconfiguration.
+    """
+    legacy_id = cfg.pop("station_id", None)
+    cfg.pop("station_name", None)
+
+    station_ids = cfg.get("station_ids")
+    if not station_ids and legacy_id:
+        cfg["station_ids"] = [legacy_id]
+
+    cfg.setdefault("gbfs_base_url", "https://gbfs.baywheels.com/gbfs/en")
+    return cfg
+
+
+PLUGIN_RENAME_ADJUSTERS: Dict[str, Any] = {
+    "baywheels": _adjust_baywheels_to_lyft_bikeshare,
+}
+
 # Default configuration schema
 DEFAULT_CONFIG: Dict[str, Any] = {
     "board": {
@@ -276,6 +317,7 @@ class ConfigManager:
         self._raw_features: Dict[str, Any] = {}
         self._load_or_create()
         self._auto_migrate_features_to_plugins()
+        self._migrate_renamed_plugins()
         self._apply_env_overrides()
         self._initialized = True
 
@@ -416,6 +458,70 @@ class ConfigManager:
 
         logger.info(
             f"Auto-migration complete: {len(to_migrate)} feature(s) migrated to plugins"
+        )
+
+    def _migrate_renamed_plugins(self) -> None:
+        """Apply one-shot plugin id renames defined in PLUGIN_ID_RENAMES.
+
+        For each ``old_id -> new_id`` entry, if ``plugins.<old_id>`` exists
+        and ``plugins.<new_id>`` does not, the old block is moved under the
+        new id (running an optional adjuster to drop/rename fields). If
+        both exist, the old block is dropped to avoid leaking stale
+        settings. The pass is naturally idempotent — once the rename has
+        run, ``plugins.<old_id>`` no longer exists and the loop is a
+        no-op.
+        """
+        plugins = self._config.get("plugins")
+        if not isinstance(plugins, dict) or not plugins:
+            return
+
+        renamed: List[tuple] = []
+        for old_id, new_id in PLUGIN_ID_RENAMES.items():
+            if old_id not in plugins:
+                continue
+
+            old_cfg = plugins[old_id]
+            if not isinstance(old_cfg, dict):
+                # Unexpected shape; drop it silently rather than raise.
+                plugins.pop(old_id, None)
+                continue
+
+            if new_id in plugins:
+                # User already has the new plugin configured; drop the
+                # stale old entry without overwriting their config.
+                plugins.pop(old_id, None)
+                logger.info(
+                    f"Plugin rename '{old_id}' -> '{new_id}': new id already "
+                    f"present, dropping stale old config"
+                )
+                renamed.append((old_id, new_id, False))
+                continue
+
+            adjuster = PLUGIN_RENAME_ADJUSTERS.get(old_id)
+            new_cfg = self._deep_copy(old_cfg)
+            if adjuster is not None:
+                try:
+                    new_cfg = adjuster(new_cfg)
+                except Exception as e:  # pragma: no cover - defensive
+                    logger.warning(
+                        f"Adjuster for plugin rename '{old_id}' -> '{new_id}' "
+                        f"failed ({e}); falling back to a plain rename"
+                    )
+                    new_cfg = self._deep_copy(old_cfg)
+
+            plugins[new_id] = new_cfg
+            plugins.pop(old_id, None)
+            renamed.append((old_id, new_id, True))
+            logger.info(f"Renamed plugin config '{old_id}' -> '{new_id}'")
+
+        if not renamed:
+            return
+
+        with self._file_lock:
+            self._save_internal()
+
+        logger.info(
+            f"Plugin rename migration complete: {len(renamed)} plugin(s) processed"
         )
 
     def _save_internal(self) -> None:

--- a/src/pages/storage.py
+++ b/src/pages/storage.py
@@ -6,6 +6,7 @@ Includes schema versioning and automatic migration on startup.
 
 import json
 import logging
+import re
 import shutil
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Tuple
@@ -16,7 +17,17 @@ from ..text_utils import extract_alignment_from_line as _extract_alignment_from_
 
 logger = logging.getLogger(__name__)
 
-CURRENT_SCHEMA_VERSION = 2
+CURRENT_SCHEMA_VERSION = 3
+
+
+# Mapping from obsolete plugin id (used in template variable references,
+# `display_type` for single pages, and `rows[].source` for composite
+# pages) to its replacement id. Driven by the same renames in
+# `src/config_manager.py:PLUGIN_ID_RENAMES`; kept local here to avoid a
+# cross-module import from a low-level storage layer.
+_PLUGIN_ID_RENAMES: Dict[str, str] = {
+    "baywheels": "lyft_bikeshare",
+}
 
 
 def _migrate_v0_to_v1(pages_data: List[dict]) -> int:
@@ -63,11 +74,107 @@ def _migrate_v1_to_v2(pages_data: List[dict]) -> int:
     return migrated
 
 
+def _build_plugin_id_rename_pattern() -> re.Pattern:
+    """Build a single regex matching any obsolete plugin id from
+    ``_PLUGIN_ID_RENAMES`` followed by a ``.`` (variable accessor).
+
+    The negative lookbehind on ``[A-Za-z0-9_]`` ensures we don't match
+    an id that's the suffix of a longer identifier (e.g. ``mybaywheels.``).
+    """
+    alternation = "|".join(re.escape(old_id) for old_id in _PLUGIN_ID_RENAMES)
+    return re.compile(rf"(?<![A-Za-z0-9_])({alternation})\.")
+
+
+_PLUGIN_ID_RENAME_PATTERN = _build_plugin_id_rename_pattern()
+
+
+def _rewrite_plugin_id_references(text: str) -> Tuple[str, int]:
+    """Rewrite obsolete plugin id references in *text*.
+
+    Replaces any occurrence of ``<old_id>.`` (where ``<old_id>`` is a key
+    of ``_PLUGIN_ID_RENAMES``) that is not part of a longer identifier
+    with ``<new_id>.``. Returns the rewritten string and the number of
+    substitutions made. Catches both plain ``{{baywheels.x}}`` references
+    and formula references like ``{{= baywheels.x + 1 }}``.
+    """
+    if not text or "." not in text:
+        return text, 0
+
+    def _sub(match: re.Match) -> str:
+        return _PLUGIN_ID_RENAMES[match.group(1)] + "."
+
+    new_text, n = _PLUGIN_ID_RENAME_PATTERN.subn(_sub, text)
+    return new_text, n
+
+
+def _migrate_v2_to_v3(pages_data: List[dict]) -> int:
+    """Migration 2 -> 3: rewrite obsolete plugin id references.
+
+    Updates pages that reference plugin ids listed in
+    ``_PLUGIN_ID_RENAMES`` (e.g. ``baywheels`` → ``lyft_bikeshare``):
+
+    * Template strings: rewrites every ``<old_id>.<field>`` reference,
+      including those inside ``{{ ... }}`` and ``{{= ... }}`` formulas.
+    * Single pages: rewrites ``display_type`` if it equals an old id.
+    * Composite pages: rewrites ``rows[].source`` if it equals an old id.
+    * Demo-page tracking: rewrites ``demo_plugin_id`` if it equals an old id.
+
+    Returns the number of pages that were modified.
+    """
+    migrated = 0
+    for page_data in pages_data:
+        page_changed = False
+
+        # Template strings (template-type pages)
+        template = page_data.get("template")
+        if isinstance(template, list):
+            new_template: List = []
+            for line in template:
+                if isinstance(line, str):
+                    rewritten, count = _rewrite_plugin_id_references(line)
+                    if count:
+                        page_changed = True
+                    new_template.append(rewritten)
+                else:
+                    new_template.append(line)
+            if page_changed:
+                page_data["template"] = new_template
+
+        # Single-page display_type
+        display_type = page_data.get("display_type")
+        if isinstance(display_type, str) and display_type in _PLUGIN_ID_RENAMES:
+            page_data["display_type"] = _PLUGIN_ID_RENAMES[display_type]
+            page_changed = True
+
+        # Composite-page row sources
+        rows = page_data.get("rows")
+        if isinstance(rows, list):
+            for row in rows:
+                if not isinstance(row, dict):
+                    continue
+                source = row.get("source")
+                if isinstance(source, str) and source in _PLUGIN_ID_RENAMES:
+                    row["source"] = _PLUGIN_ID_RENAMES[source]
+                    page_changed = True
+
+        # Demo-page tracking field
+        demo_plugin_id = page_data.get("demo_plugin_id")
+        if isinstance(demo_plugin_id, str) and demo_plugin_id in _PLUGIN_ID_RENAMES:
+            page_data["demo_plugin_id"] = _PLUGIN_ID_RENAMES[demo_plugin_id]
+            page_changed = True
+
+        if page_changed:
+            migrated += 1
+
+    return migrated
+
+
 # Ordered list of (target_version, migration_function).
 # Each function receives the raw pages list and returns the number of pages affected.
 MIGRATIONS: List[Tuple[int, Callable[[List[dict]], int]]] = [
     (1, _migrate_v0_to_v1),
     (2, _migrate_v1_to_v2),
+    (3, _migrate_v2_to_v3),
 ]
 
 

--- a/src/pages/storage.py
+++ b/src/pages/storage.py
@@ -26,7 +26,7 @@ CURRENT_SCHEMA_VERSION = 3
 # `src/config_manager.py:PLUGIN_ID_RENAMES`; kept local here to avoid a
 # cross-module import from a low-level storage layer.
 _PLUGIN_ID_RENAMES: Dict[str, str] = {
-    "baywheels": "lyft_bikeshare",
+    "baywheels": "lyft_bike_share",
 }
 
 
@@ -111,7 +111,7 @@ def _migrate_v2_to_v3(pages_data: List[dict]) -> int:
     """Migration 2 -> 3: rewrite obsolete plugin id references.
 
     Updates pages that reference plugin ids listed in
-    ``_PLUGIN_ID_RENAMES`` (e.g. ``baywheels`` → ``lyft_bikeshare``):
+    ``_PLUGIN_ID_RENAMES`` (e.g. ``baywheels`` → ``lyft_bike_share``):
 
     * Template strings: rewrites every ``<old_id>.<field>`` reference,
       including those inside ``{{ ... }}`` and ``{{= ... }}`` formulas.

--- a/tests/test_config_migration.py
+++ b/tests/test_config_migration.py
@@ -363,3 +363,151 @@ class TestConfigPersistence:
         cm2 = ConfigManager(config_path=v1_config_path)
         assert cm2.get_plugin_config("weather") is not None
         assert cm2.get_plugin_config("muni") is not None
+
+
+class TestPluginIdRename:
+    """Tests for one-shot plugin id renames (e.g. baywheels -> lyft_bikeshare)."""
+
+    def test_baywheels_renamed_to_lyft_bikeshare(self, tmp_path):
+        """plugins.baywheels should be renamed to plugins.lyft_bikeshare."""
+        config = {
+            "plugins": {
+                "baywheels": {
+                    "enabled": True,
+                    "station_ids": ["123", "456"],
+                    "refresh_seconds": 90,
+                },
+            },
+        }
+        cfg_path = tmp_path / "config.json"
+        cfg_path.write_text(json.dumps(config))
+
+        cm = ConfigManager(config_path=str(cfg_path))
+
+        assert cm.get_plugin_config("baywheels") is None
+        lyft = cm.get_plugin_config("lyft_bikeshare")
+        assert lyft is not None
+        assert lyft["enabled"] is True
+        assert lyft["station_ids"] == ["123", "456"]
+        assert lyft["refresh_seconds"] == 90
+        # gbfs_base_url default should be seeded
+        assert lyft["gbfs_base_url"] == "https://gbfs.baywheels.com/gbfs/en"
+
+    def test_baywheels_legacy_station_id_promoted(self, tmp_path):
+        """A user with only the legacy singular station_id should keep that station."""
+        config = {
+            "plugins": {
+                "baywheels": {
+                    "enabled": True,
+                    "station_id": "abc-1",
+                    "station_name": "Market St",
+                    "station_ids": [],
+                    "refresh_seconds": 60,
+                },
+            },
+        }
+        cfg_path = tmp_path / "config.json"
+        cfg_path.write_text(json.dumps(config))
+
+        cm = ConfigManager(config_path=str(cfg_path))
+
+        lyft = cm.get_plugin_config("lyft_bikeshare")
+        assert lyft is not None
+        assert lyft["station_ids"] == ["abc-1"]
+        # Deprecated singular fields removed
+        assert "station_id" not in lyft
+        assert "station_name" not in lyft
+
+    def test_baywheels_rename_preserves_existing_lyft_bikeshare(self, tmp_path):
+        """If both ids exist, the new id wins and the old one is dropped."""
+        config = {
+            "plugins": {
+                "baywheels": {
+                    "enabled": True,
+                    "station_ids": ["old"],
+                    "refresh_seconds": 60,
+                },
+                "lyft_bikeshare": {
+                    "enabled": True,
+                    "station_ids": ["new"],
+                    "refresh_seconds": 120,
+                    "gbfs_base_url": "https://gbfs.citibikenyc.com/gbfs/en",
+                },
+            },
+        }
+        cfg_path = tmp_path / "config.json"
+        cfg_path.write_text(json.dumps(config))
+
+        cm = ConfigManager(config_path=str(cfg_path))
+
+        assert cm.get_plugin_config("baywheels") is None
+        lyft = cm.get_plugin_config("lyft_bikeshare")
+        assert lyft["station_ids"] == ["new"]
+        assert lyft["refresh_seconds"] == 120
+        assert lyft["gbfs_base_url"] == "https://gbfs.citibikenyc.com/gbfs/en"
+
+    def test_baywheels_rename_idempotent(self, tmp_path):
+        """A second startup must not recreate or alter the renamed entry."""
+        config = {
+            "plugins": {
+                "baywheels": {
+                    "enabled": True,
+                    "station_ids": ["123"],
+                    "refresh_seconds": 60,
+                },
+            },
+        }
+        cfg_path = tmp_path / "config.json"
+        cfg_path.write_text(json.dumps(config))
+
+        cm = ConfigManager(config_path=str(cfg_path))
+        first = cm.get_plugin_config("lyft_bikeshare")
+
+        _reset_singleton()
+        cm2 = ConfigManager(config_path=str(cfg_path))
+        second = cm2.get_plugin_config("lyft_bikeshare")
+
+        assert first == second
+        assert cm2.get_plugin_config("baywheels") is None
+
+    def test_no_rename_when_old_id_absent(self, tmp_path):
+        """Configs with no obsolete plugin id should be left untouched."""
+        config = {
+            "plugins": {
+                "weather": {"enabled": True, "api_key": "x"},
+            },
+        }
+        cfg_path = tmp_path / "config.json"
+        cfg_path.write_text(json.dumps(config))
+
+        cm = ConfigManager(config_path=str(cfg_path))
+
+        assert cm.get_plugin_config("baywheels") is None
+        assert cm.get_plugin_config("lyft_bikeshare") is None
+        assert cm.get_plugin_config("weather")["api_key"] == "x"
+
+    def test_baywheels_feature_then_rename_chain(self, tmp_path):
+        """v1 features.baywheels should migrate to plugins, then rename to lyft_bikeshare."""
+        config = _make_v1_config()
+        config["features"]["baywheels"] = {
+            "enabled": True,
+            "station_id": "xyz",
+            "station_name": "Embarcadero",
+            "station_ids": [],
+            "refresh_seconds": 75,
+            "color_rules": {},
+        }
+        cfg_path = tmp_path / "config.json"
+        cfg_path.write_text(json.dumps(config))
+
+        cm = ConfigManager(config_path=str(cfg_path))
+
+        # Old id should not exist; new one should, with promoted station id
+        assert cm.get_plugin_config("baywheels") is None
+        lyft = cm.get_plugin_config("lyft_bikeshare")
+        assert lyft is not None
+        assert lyft["enabled"] is True
+        assert lyft["station_ids"] == ["xyz"]
+        assert lyft["refresh_seconds"] == 75
+        assert "station_id" not in lyft
+        assert "station_name" not in lyft

--- a/tests/test_config_migration.py
+++ b/tests/test_config_migration.py
@@ -366,10 +366,10 @@ class TestConfigPersistence:
 
 
 class TestPluginIdRename:
-    """Tests for one-shot plugin id renames (e.g. baywheels -> lyft_bikeshare)."""
+    """Tests for one-shot plugin id renames (e.g. baywheels -> lyft_bike_share)."""
 
-    def test_baywheels_renamed_to_lyft_bikeshare(self, tmp_path):
-        """plugins.baywheels should be renamed to plugins.lyft_bikeshare."""
+    def test_baywheels_renamed_to_lyft_bike_share(self, tmp_path):
+        """plugins.baywheels should be renamed to plugins.lyft_bike_share."""
         config = {
             "plugins": {
                 "baywheels": {
@@ -385,7 +385,7 @@ class TestPluginIdRename:
         cm = ConfigManager(config_path=str(cfg_path))
 
         assert cm.get_plugin_config("baywheels") is None
-        lyft = cm.get_plugin_config("lyft_bikeshare")
+        lyft = cm.get_plugin_config("lyft_bike_share")
         assert lyft is not None
         assert lyft["enabled"] is True
         assert lyft["station_ids"] == ["123", "456"]
@@ -411,14 +411,14 @@ class TestPluginIdRename:
 
         cm = ConfigManager(config_path=str(cfg_path))
 
-        lyft = cm.get_plugin_config("lyft_bikeshare")
+        lyft = cm.get_plugin_config("lyft_bike_share")
         assert lyft is not None
         assert lyft["station_ids"] == ["abc-1"]
         # Deprecated singular fields removed
         assert "station_id" not in lyft
         assert "station_name" not in lyft
 
-    def test_baywheels_rename_preserves_existing_lyft_bikeshare(self, tmp_path):
+    def test_baywheels_rename_preserves_existing_lyft_bike_share(self, tmp_path):
         """If both ids exist, the new id wins and the old one is dropped."""
         config = {
             "plugins": {
@@ -427,7 +427,7 @@ class TestPluginIdRename:
                     "station_ids": ["old"],
                     "refresh_seconds": 60,
                 },
-                "lyft_bikeshare": {
+                "lyft_bike_share": {
                     "enabled": True,
                     "station_ids": ["new"],
                     "refresh_seconds": 120,
@@ -441,7 +441,7 @@ class TestPluginIdRename:
         cm = ConfigManager(config_path=str(cfg_path))
 
         assert cm.get_plugin_config("baywheels") is None
-        lyft = cm.get_plugin_config("lyft_bikeshare")
+        lyft = cm.get_plugin_config("lyft_bike_share")
         assert lyft["station_ids"] == ["new"]
         assert lyft["refresh_seconds"] == 120
         assert lyft["gbfs_base_url"] == "https://gbfs.citibikenyc.com/gbfs/en"
@@ -461,11 +461,11 @@ class TestPluginIdRename:
         cfg_path.write_text(json.dumps(config))
 
         cm = ConfigManager(config_path=str(cfg_path))
-        first = cm.get_plugin_config("lyft_bikeshare")
+        first = cm.get_plugin_config("lyft_bike_share")
 
         _reset_singleton()
         cm2 = ConfigManager(config_path=str(cfg_path))
-        second = cm2.get_plugin_config("lyft_bikeshare")
+        second = cm2.get_plugin_config("lyft_bike_share")
 
         assert first == second
         assert cm2.get_plugin_config("baywheels") is None
@@ -483,11 +483,11 @@ class TestPluginIdRename:
         cm = ConfigManager(config_path=str(cfg_path))
 
         assert cm.get_plugin_config("baywheels") is None
-        assert cm.get_plugin_config("lyft_bikeshare") is None
+        assert cm.get_plugin_config("lyft_bike_share") is None
         assert cm.get_plugin_config("weather")["api_key"] == "x"
 
     def test_baywheels_feature_then_rename_chain(self, tmp_path):
-        """v1 features.baywheels should migrate to plugins, then rename to lyft_bikeshare."""
+        """v1 features.baywheels should migrate to plugins, then rename to lyft_bike_share."""
         config = _make_v1_config()
         config["features"]["baywheels"] = {
             "enabled": True,
@@ -504,7 +504,7 @@ class TestPluginIdRename:
 
         # Old id should not exist; new one should, with promoted station id
         assert cm.get_plugin_config("baywheels") is None
-        lyft = cm.get_plugin_config("lyft_bikeshare")
+        lyft = cm.get_plugin_config("lyft_bike_share")
         assert lyft is not None
         assert lyft["enabled"] is True
         assert lyft["station_ids"] == ["xyz"]

--- a/tests/test_demo_pages.py
+++ b/tests/test_demo_pages.py
@@ -240,7 +240,7 @@ class TestSchemaMigrationV1ToV2:
         assert pages[0]["demo_plugin_id"] == "weather"
 
     def test_current_schema_version(self):
-        assert CURRENT_SCHEMA_VERSION == 2
+        assert CURRENT_SCHEMA_VERSION == 3
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -488,9 +488,9 @@ class TestMigrateV2ToV3:
         count = _migrate_v2_to_v3(pages)
         assert count == 1
         assert pages[0]["template"] == [
-            "{{lyft_bikeshare.station_name}}",
-            "E:{{lyft_bikeshare.electric_bikes}} C:{{lyft_bikeshare.classic_bikes}}",
-            "{{lyft_bikeshare.stations.0.electric_bikes}}",
+            "{{lyft_bike_share.station_name}}",
+            "E:{{lyft_bike_share.electric_bikes}} C:{{lyft_bike_share.classic_bikes}}",
+            "{{lyft_bike_share.stations.0.electric_bikes}}",
             "no vars here",
         ]
 
@@ -507,14 +507,14 @@ class TestMigrateV2ToV3:
         count = _migrate_v2_to_v3(pages)
         assert count == 1
         assert pages[0]["template"] == [
-            "{{= IF(lyft_bikeshare.electric_bikes > 0, lyft_bikeshare.electric_bikes, 'NO') }}",
+            "{{= IF(lyft_bike_share.electric_bikes > 0, lyft_bike_share.electric_bikes, 'NO') }}",
         ]
 
     def test_single_page_display_type_rewritten(self):
         pages = [{"id": "1", "type": "single", "display_type": "baywheels"}]
         count = _migrate_v2_to_v3(pages)
         assert count == 1
-        assert pages[0]["display_type"] == "lyft_bikeshare"
+        assert pages[0]["display_type"] == "lyft_bike_share"
 
     def test_composite_row_source_rewritten(self):
         pages = [
@@ -529,7 +529,7 @@ class TestMigrateV2ToV3:
         ]
         count = _migrate_v2_to_v3(pages)
         assert count == 1
-        assert pages[0]["rows"][0]["source"] == "lyft_bikeshare"
+        assert pages[0]["rows"][0]["source"] == "lyft_bike_share"
         assert pages[0]["rows"][1]["source"] == "weather"
 
     def test_demo_plugin_id_rewritten(self):
@@ -537,13 +537,13 @@ class TestMigrateV2ToV3:
             {
                 "id": "1",
                 "type": "single",
-                "display_type": "lyft_bikeshare",
+                "display_type": "lyft_bike_share",
                 "demo_plugin_id": "baywheels",
             }
         ]
         count = _migrate_v2_to_v3(pages)
         assert count == 1
-        assert pages[0]["demo_plugin_id"] == "lyft_bikeshare"
+        assert pages[0]["demo_plugin_id"] == "lyft_bike_share"
 
     def test_unrelated_pages_not_modified(self):
         pages = [
@@ -581,7 +581,7 @@ class TestMigrateV2ToV3:
             {
                 "id": "1",
                 "type": "template",
-                "template": ["{{lyft_bikeshare.station_name}}"],
+                "template": ["{{lyft_bike_share.station_name}}"],
             }
         ]
         count = _migrate_v2_to_v3(pages)
@@ -592,7 +592,7 @@ class TestMigrateV2ToV3:
             "{{baywheels.x}} and {{baywheels.y}} but not {{weather.t}}"
         )
         assert n == 2
-        assert out == "{{lyft_bikeshare.x}} and {{lyft_bikeshare.y}} but not {{weather.t}}"
+        assert out == "{{lyft_bike_share.x}} and {{lyft_bike_share.y}} but not {{weather.t}}"
 
     def test_rewrite_helper_empty_input(self):
         assert _rewrite_plugin_id_references("") == ("", 0)
@@ -648,8 +648,8 @@ class TestPageStorageV2ToV3Integration:
         storage = PageStorage(storage_file=temp_storage_file)
         page = storage.get("p1")
         assert page is not None
-        assert page.template[0] == "{{lyft_bikeshare.station_name}}"
-        assert page.template[1] == "E:{{lyft_bikeshare.electric_bikes}}"
+        assert page.template[0] == "{{lyft_bike_share.station_name}}"
+        assert page.template[1] == "E:{{lyft_bike_share.electric_bikes}}"
 
         with open(temp_storage_file) as f:
             data = json.load(f)

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -604,13 +604,15 @@ class TestPageStorageV2ToV3Integration:
 
     @pytest.fixture
     def temp_storage_file(self):
+        import glob
         with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
             yield f.name
         os.unlink(f.name)
-        for suffix in (".v0_backup", ".v1_backup", ".v2_backup"):
-            backup = f.name + suffix
-            if os.path.exists(backup):
-                os.unlink(backup)
+        # Migration may create per-source-version backup files (.vN_backup)
+        # alongside the storage file; sweep them all so the suite stays tidy
+        # as CURRENT_SCHEMA_VERSION grows.
+        for backup in glob.glob(f.name + ".v*_backup"):
+            os.unlink(backup)
 
     def test_v2_file_migrated_to_v3(self, temp_storage_file):
         with open(temp_storage_file, "w") as f:

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -13,6 +13,8 @@ from src.pages.storage import (
     PageStorage,
     _extract_alignment_from_line,
     _migrate_v0_to_v1,
+    _migrate_v2_to_v3,
+    _rewrite_plugin_id_references,
 )
 from src.pages.service import PageService, DeleteResult
 from src.displays.service import DisplayResult
@@ -465,6 +467,191 @@ class TestSchemaVersioning:
         page = storage.get("p1")
         assert page.template == ["HELLO", "", "", "", "", ""]
         assert page.line_metadata[0].alignment == "center"
+
+
+class TestMigrateV2ToV3:
+    """Tests for v2->v3 plugin id rename migration."""
+
+    def test_template_variable_references_rewritten(self):
+        pages = [
+            {
+                "id": "1",
+                "type": "template",
+                "template": [
+                    "{{baywheels.station_name}}",
+                    "E:{{baywheels.electric_bikes}} C:{{baywheels.classic_bikes}}",
+                    "{{baywheels.stations.0.electric_bikes}}",
+                    "no vars here",
+                ],
+            }
+        ]
+        count = _migrate_v2_to_v3(pages)
+        assert count == 1
+        assert pages[0]["template"] == [
+            "{{lyft_bikeshare.station_name}}",
+            "E:{{lyft_bikeshare.electric_bikes}} C:{{lyft_bikeshare.classic_bikes}}",
+            "{{lyft_bikeshare.stations.0.electric_bikes}}",
+            "no vars here",
+        ]
+
+    def test_formula_references_rewritten(self):
+        pages = [
+            {
+                "id": "1",
+                "type": "template",
+                "template": [
+                    "{{= IF(baywheels.electric_bikes > 0, baywheels.electric_bikes, 'NO') }}",
+                ],
+            }
+        ]
+        count = _migrate_v2_to_v3(pages)
+        assert count == 1
+        assert pages[0]["template"] == [
+            "{{= IF(lyft_bikeshare.electric_bikes > 0, lyft_bikeshare.electric_bikes, 'NO') }}",
+        ]
+
+    def test_single_page_display_type_rewritten(self):
+        pages = [{"id": "1", "type": "single", "display_type": "baywheels"}]
+        count = _migrate_v2_to_v3(pages)
+        assert count == 1
+        assert pages[0]["display_type"] == "lyft_bikeshare"
+
+    def test_composite_row_source_rewritten(self):
+        pages = [
+            {
+                "id": "1",
+                "type": "composite",
+                "rows": [
+                    {"source": "baywheels", "row_index": 0, "target_row": 0},
+                    {"source": "weather", "row_index": 0, "target_row": 1},
+                ],
+            }
+        ]
+        count = _migrate_v2_to_v3(pages)
+        assert count == 1
+        assert pages[0]["rows"][0]["source"] == "lyft_bikeshare"
+        assert pages[0]["rows"][1]["source"] == "weather"
+
+    def test_demo_plugin_id_rewritten(self):
+        pages = [
+            {
+                "id": "1",
+                "type": "single",
+                "display_type": "lyft_bikeshare",
+                "demo_plugin_id": "baywheels",
+            }
+        ]
+        count = _migrate_v2_to_v3(pages)
+        assert count == 1
+        assert pages[0]["demo_plugin_id"] == "lyft_bikeshare"
+
+    def test_unrelated_pages_not_modified(self):
+        pages = [
+            {
+                "id": "1",
+                "type": "template",
+                "template": ["{{weather.temperature}}", "static text"],
+            },
+            {
+                "id": "2",
+                "type": "single",
+                "display_type": "weather",
+            },
+        ]
+        count = _migrate_v2_to_v3(pages)
+        assert count == 0
+        assert pages[0]["template"] == ["{{weather.temperature}}", "static text"]
+        assert pages[1]["display_type"] == "weather"
+
+    def test_does_not_match_id_suffix(self):
+        """An identifier that merely *ends* with an old id must not be rewritten."""
+        pages = [
+            {
+                "id": "1",
+                "type": "template",
+                "template": ["{{mybaywheels.foo}}", "{{baywheelsx.foo}}"],
+            }
+        ]
+        count = _migrate_v2_to_v3(pages)
+        assert count == 0
+        assert pages[0]["template"] == ["{{mybaywheels.foo}}", "{{baywheelsx.foo}}"]
+
+    def test_idempotent(self):
+        pages = [
+            {
+                "id": "1",
+                "type": "template",
+                "template": ["{{lyft_bikeshare.station_name}}"],
+            }
+        ]
+        count = _migrate_v2_to_v3(pages)
+        assert count == 0
+
+    def test_rewrite_helper_returns_count(self):
+        out, n = _rewrite_plugin_id_references(
+            "{{baywheels.x}} and {{baywheels.y}} but not {{weather.t}}"
+        )
+        assert n == 2
+        assert out == "{{lyft_bikeshare.x}} and {{lyft_bikeshare.y}} but not {{weather.t}}"
+
+    def test_rewrite_helper_empty_input(self):
+        assert _rewrite_plugin_id_references("") == ("", 0)
+        assert _rewrite_plugin_id_references("no dots no rename") == ("no dots no rename", 0)
+
+
+class TestPageStorageV2ToV3Integration:
+    """End-to-end test that a v2 pages file is migrated on load."""
+
+    @pytest.fixture
+    def temp_storage_file(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            yield f.name
+        os.unlink(f.name)
+        for suffix in (".v0_backup", ".v1_backup", ".v2_backup"):
+            backup = f.name + suffix
+            if os.path.exists(backup):
+                os.unlink(backup)
+
+    def test_v2_file_migrated_to_v3(self, temp_storage_file):
+        with open(temp_storage_file, "w") as f:
+            json.dump(
+                {
+                    "schema_version": 2,
+                    "pages": [
+                        {
+                            "id": "p1",
+                            "name": "Bikes",
+                            "type": "template",
+                            "device_type": "flagship",
+                            "template": [
+                                "{{baywheels.station_name}}",
+                                "E:{{baywheels.electric_bikes}}",
+                                "",
+                                "",
+                                "",
+                                "",
+                            ],
+                            "line_metadata": [
+                                {"alignment": "center", "wrap": False}
+                            ] * 6,
+                            "duration_seconds": 300,
+                            "demo_plugin_id": None,
+                            "created_at": datetime.now(timezone.utc).isoformat(),
+                        }
+                    ],
+                },
+                f,
+            )
+
+        storage = PageStorage(storage_file=temp_storage_file)
+        page = storage.get("p1")
+        assert page is not None
+        assert page.template[0] == "{{lyft_bikeshare.station_name}}"
+        assert page.template[1] == "E:{{lyft_bikeshare.electric_bikes}}"
+
+        with open(temp_storage_file) as f:
+            data = json.load(f)
+        assert data["schema_version"] == CURRENT_SCHEMA_VERSION
 
 
 class TestPageService:


### PR DESCRIPTION
Updates the plugin registry to reflect the rename of the Bay Wheels plugin to Lyft Bike Share:

- Plugin ID: `baywheels` → `lyft_bikeshare`
- Plugin name: "Bay Wheels" → "Lyft Bike Share"
- Repository: `fiestaboard-plugin--baywheels` → `fiestaboard-plugin--lyft-bike-share`
- Updated description to reflect support for multiple Lyft-operated bike share systems

Related to the v2.0.0 release of the plugin which includes breaking variable name changes.