### PR TITLE
fix: dev container startup crash and wizard skip loop

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,6 +46,12 @@ fi
 # When disabled (or no cert files present):
 #   * Install /app/nginx.http.conf as /etc/nginx/nginx.conf.
 configure_https() {
+    # Skip if nginx.conf is a read-only bind mount (e.g. dev compose).
+    if ! touch /etc/nginx/nginx.conf 2>/dev/null; then
+        echo "[entrypoint] /etc/nginx/nginx.conf is read-only; skipping nginx config setup."
+        return 0
+    fi
+
     HTTPS_ENABLED=$(python -c '
 import json, sys
 try:

--- a/web/src/components/wizard/setup-wizard.tsx
+++ b/web/src/components/wizard/setup-wizard.tsx
@@ -118,10 +118,7 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
     markWizardComplete();
     clearWizardProgress();
     onComplete?.();
-    // Redirect to home dashboard
     router.push("/");
-    // Reload to ensure fresh state
-    window.location.reload();
   }, [onComplete, router]);
 
   // Render step content


### PR DESCRIPTION
## Summary

- **Dev container crash on startup** — `entrypoint.sh` unconditionally copied over `/etc/nginx/nginx.conf`, but `docker-compose.dev.yml` mounts that path as `:ro`. With `set -e`, this killed the container on every start since PR #688 (HTTPS Beta). Fix: skip the nginx config setup when the file is a read-only bind mount.
- **Wizard "Skip for now" reloaded the wizard** — `handleComplete` called `router.push("/")` (async) immediately followed by `window.location.reload()`, which fired before navigation completed and reloaded the wizard URL. Fix: remove the unnecessary `window.location.reload()` — `markWizardComplete()` already persists state to localStorage.

## Test plan

- [ ] Run `/restart` and confirm `fiestaboard-dev` starts cleanly (no `cp: cannot create regular file` errors in logs)
- [ ] Open the setup wizard and click **Skip for now** — should navigate to the dashboard, not reload the wizard

🤖 Generated with [Claude Code](https://claude.com/claude-code)