### PR TITLE
Page editor: show active state on wrap and alignment toolbar buttons

### DIFF
--- a/web/src/components/tiptap-template-editor/components/TemplateEditorToolbar.tsx
+++ b/web/src/components/tiptap-template-editor/components/TemplateEditorToolbar.tsx
@@ -35,7 +35,7 @@ interface TemplateEditorToolbarProps {
 
 export function TemplateEditorToolbar({
   editor,
-  _currentAlignment = 'left',
+  currentAlignment = 'left',
   currentWrapEnabled = false,
   onAlignmentChange,
   onWrapToggle,
@@ -409,14 +409,15 @@ export function TemplateEditorToolbar({
               type="button"
               onClick={onWrapToggle}
               className={cn(
-                "flex items-center justify-center p-1.5 rounded-md",
-                "hover:bg-muted/50 transition-colors",
+                "flex items-center justify-center p-1.5 rounded-md transition-colors",
                 "border border-transparent",
-                currentWrapEnabled && "bg-muted/70 border-border"
+                currentWrapEnabled
+                  ? "bg-primary text-primary-foreground"
+                  : "hover:bg-muted/50"
               )}
               aria-label={t("toggleWrap")}
             >
-              <WrapText className={cn("w-4 h-4", currentWrapEnabled && "text-primary")} />
+              <WrapText className="w-4 h-4" />
             </button>
           </TooltipTrigger>
           <TooltipContent>
@@ -436,7 +437,12 @@ export function TemplateEditorToolbar({
               <button
                 type="button"
                 onClick={() => handleAlignmentClick('left')}
-                className="px-2 py-1.5 transition-colors hover:bg-muted/50"
+                className={cn(
+                  "px-2 py-1.5 transition-colors",
+                  currentAlignment === 'left'
+                    ? "bg-primary text-primary-foreground"
+                    : "hover:bg-muted/50"
+                )}
                 aria-label={t("alignLeft")}
               >
                 <AlignLeft className="w-4 h-4" />
@@ -450,7 +456,12 @@ export function TemplateEditorToolbar({
               <button
                 type="button"
                 onClick={() => handleAlignmentClick('center')}
-                className="px-2 py-1.5 border-x border-border transition-colors hover:bg-muted/50"
+                className={cn(
+                  "px-2 py-1.5 border-x border-border transition-colors",
+                  currentAlignment === 'center'
+                    ? "bg-primary text-primary-foreground"
+                    : "hover:bg-muted/50"
+                )}
                 aria-label={t("alignCenter")}
               >
                 <AlignCenter className="w-4 h-4" />
@@ -464,7 +475,12 @@ export function TemplateEditorToolbar({
               <button
                 type="button"
                 onClick={() => handleAlignmentClick('right')}
-                className="px-2 py-1.5 transition-colors hover:bg-muted/50"
+                className={cn(
+                  "px-2 py-1.5 transition-colors",
+                  currentAlignment === 'right'
+                    ? "bg-primary text-primary-foreground"
+                    : "hover:bg-muted/50"
+                )}
                 aria-label={t("alignRight")}
               >
                 <AlignRight className="w-4 h-4" />


### PR DESCRIPTION
## Summary

- Wire `currentAlignment` through to the TipTap toolbar (it was destructured as `_currentAlignment` and silently dropped), so the left/center/right buttons reflect the current line's alignment. The "left" button now lights up on default lines, since `currentAlignment` defaults to `'left'`.
- Strengthen the wrap button's active treatment to match — it had an active style but the subtle `bg-muted/70` + recolored icon read as inactive next to the unstyled alignment buttons.
- Both controls now use `bg-primary text-primary-foreground` when active, matching the fallback alignment controls already rendered below the editor.

No data-model, prop, or upstream changes. Only `TemplateEditorToolbar.tsx` is touched.

## Test plan

- [ ] Open the Page editor on a fresh line — the **left** alignment button is active.
- [ ] Center- or right-align the line — the corresponding button activates and the others deactivate; cursor moves between lines update the active button.
- [ ] Toggle wrap on a line — the wrap button shows the prominent active state; moving the cursor to a non-wrapped line returns it to inactive.
- [ ] Multi-line selection still applies alignment to the full range.
- [ ] Save and reload — active states reflect the persisted per-line metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)