### PR TITLE
Fix Safari cursor and selection bugs around custom tags

### DIFF
--- a/web/src/components/tiptap-template-editor/TipTapTemplateEditor.tsx
+++ b/web/src/components/tiptap-template-editor/TipTapTemplateEditor.tsx
@@ -288,6 +288,56 @@ export function TipTapTemplateEditor({
           return true;
         }
 
+        // ArrowLeft / ArrowRight: jump over the invisible ZWS anchors that
+        // sandwich every atom node so the cursor doesn't appear to "pause"
+        // on a zero-width position. We take one step in the arrow direction,
+        // then keep skipping while the just-traversed character is ZWS — the
+        // first non-ZWS step is what makes visual progress, so we stop there.
+        // Word/line modifiers (alt/meta on macOS) are left to the browser.
+        if ((event.key === 'ArrowRight' || event.key === 'ArrowLeft') &&
+            !event.altKey && !event.ctrlKey && !event.metaKey) {
+          const { state } = view;
+          const { selection } = state;
+          if (!(selection instanceof TextSelection)) return false;
+
+          const head = selection.$head.pos;
+          const pStart = selection.$head.start();
+          const pEnd = selection.$head.end();
+
+          if (event.key === 'ArrowRight') {
+            if (head >= pEnd) return false;
+            let target = head + 1;
+            while (target < pEnd && state.doc.textBetween(target - 1, target, undefined, OBJ) === ZWS) {
+              target++;
+            }
+            // For non-shift arrow with no ZWS to skip, let the browser handle natively
+            // (preserves IME/composition behavior). For shift+arrow always dispatch —
+            // Safari mis-handles range extension across contenteditable=false atoms.
+            if (target === head + 1 && !event.shiftKey) return false;
+            event.preventDefault();
+            const newSel = event.shiftKey
+              ? TextSelection.create(state.doc, selection.$anchor.pos, target)
+              : TextSelection.create(state.doc, target);
+            view.dispatch(state.tr.setSelection(newSel).scrollIntoView());
+            return true;
+          }
+
+          if (event.key === 'ArrowLeft') {
+            if (head <= pStart) return false;
+            let target = head - 1;
+            while (target > pStart && state.doc.textBetween(target, target + 1, undefined, OBJ) === ZWS) {
+              target--;
+            }
+            if (target === head - 1 && !event.shiftKey) return false;
+            event.preventDefault();
+            const newSel = event.shiftKey
+              ? TextSelection.create(state.doc, selection.$anchor.pos, target)
+              : TextSelection.create(state.doc, target);
+            view.dispatch(state.tr.setSelection(newSel).scrollIntoView());
+            return true;
+          }
+        }
+
         const key = event.key.toLowerCase();
         const isMod = event.ctrlKey || event.metaKey;
         
@@ -450,6 +500,36 @@ export function TipTapTemplateEditor({
         dragstart: (_view, _event) => {
           // Don't prevent - we need the drag to start for drop to work
           return false;
+        },
+        // Click on an atom (variable, color tile, etc.): give visual feedback
+        // by adding the .selected-inline outline directly to the atom's DOM,
+        // and place a collapsed cursor right after the atom in PM state.
+        // We deliberately avoid dispatching a TextSelection that *spans* the
+        // atom — Safari mis-renders such ranges (the visual highlight bleeds
+        // from line-start through the atom). A collapsed cursor is rendered
+        // consistently across browsers, and the explicit class toggle gives
+        // the click feedback that user-select:all used to provide.
+        click: (view, event) => {
+          const target = event.target as HTMLElement;
+          if (target.closest('button')) return false;
+          const coords = view.posAtCoords({ left: event.clientX, top: event.clientY });
+          if (!coords) return false;
+          const node = view.state.doc.nodeAt(coords.pos);
+          if (!node?.isAtom || !node.isInline) return false;
+
+          // Place collapsed cursor immediately after the atom.
+          const after = coords.pos + node.nodeSize;
+          view.dispatch(view.state.tr.setSelection(TextSelection.create(view.state.doc, after)));
+
+          // Visual highlight on the atom's DOM. onSelectionUpdate cleared
+          // .selected-inline above (since the new selection is empty), so
+          // it's safe to set it now.
+          const atomDom = view.nodeDOM(coords.pos);
+          if (atomDom instanceof HTMLElement) {
+            atomDom.classList.add('selected-inline');
+          }
+          event.preventDefault();
+          return true;
         },
       },
       handleDrop: (view, event, _slice, _moved) => {
@@ -1126,18 +1206,12 @@ export function TipTapTemplateEditor({
           content: none;
         }
         
-        /* Selection highlighting for inline atom nodes.
-           user-select: all makes the browser include the whole node in
-           range selections (shift+arrow, click-drag) so they highlight
-           with the native selection color just like regular text. */
-        .ProseMirror [data-node-view-wrapper] {
-          -webkit-user-select: all;
-          user-select: all;
-        }
-        
         /* Range-selection highlight for inline atom nodes (color tiles,
            variables, fill-space).  onSelectionUpdate adds this
-           class to any atom node DOM element inside the selection range. */
+           class to any atom node DOM element inside the selection range,
+           giving shift+arrow and click-drag a visible highlight without
+           needing user-select: all (which made Safari treat clicks on a
+           tag as selecting the entire line). */
         .ProseMirror .selected-inline {
           outline: 2px solid var(--primary);
           outline-offset: 1px;

--- a/web/src/components/tiptap-template-editor/utils/serialization.ts
+++ b/web/src/components/tiptap-template-editor/utils/serialization.ts
@@ -286,15 +286,23 @@ export function parseLineContent(text: string): JSONContent[] {
     }
   }
 
-  // Post-process: insert ZWS between consecutive atom nodes so the cursor
-  // has a text position to render between them (e.g. {{red}}{{blue}}).
+  // Post-process: insert a ZWS text node immediately before AND after every
+  // atom inline node so the caret always has a text-offset anchor adjacent
+  // to the atom. Without this, ProseMirror's domFromPos lands the caret on
+  // a P-element offset between siblings, which Safari mis-renders: the
+  // visual caret falls in the wrong place, arrow keys appear stuck, and
+  // typed input is routed past the atom instead of inserted next to it.
+  // Adjacent text nodes with the same marks merge inside PM, so doubled
+  // ZWS (e.g. preceding text + atom-leading ZWS) collapse into one node.
   const result: JSONContent[] = [];
   for (const node of nodes) {
-    const prev = result[result.length - 1];
-    if (prev && ATOM_NODE_TYPES.has(prev.type!) && ATOM_NODE_TYPES.has(node.type!)) {
+    if (ATOM_NODE_TYPES.has(node.type!)) {
       result.push({ type: 'text', text: '\u200B' });
+      result.push(node);
+      result.push({ type: 'text', text: '\u200B' });
+    } else {
+      result.push(node);
     }
-    result.push(node);
   }
   return result;
 }


### PR DESCRIPTION
## Summary
- Fix caret/selection issues in the rich template editor around inline atom nodes (variables, color tiles, fill-space, formulas) — most severe in Safari but several affected Chrome too.

The bugs the user was chasing: cursor "pausing" near tags, typing being routed past tags into the wrong place, dog-bone caret rendering in the wrong spot vs. its actual position when arrow-keying, click-on-tag highlighting the whole line in Safari, and shift+arrow asymmetry.

Root cause: the parser only emitted ZWS anchors at line boundaries, so positions adjacent to atoms had no text-node anchor. ProseMirror's `domFromPos` then mapped those positions to P-element offsets between siblings — which Safari mis-handles for `contenteditable=false` atom nodes.

## Changes
- **`utils/serialization.ts`**: `parseLineContent` now sandwiches every inline atom with a ZWS text node on both sides. Adjacent same-marked text nodes merge inside PM; the serializer already strips ZWS so saved templates are unchanged.
- **`TipTapTemplateEditor.tsx`**:
  - Added Arrow{Left,Right} handlers that skip the new ZWS anchors, so the cursor doesn't appear to pause at zero-width positions.
  - Shift+arrow now always dispatches through PM rather than falling back to native handling, so range extension is symmetric across atoms in Safari.
  - Removed `-webkit-user-select: all` on node-view-wrappers (it caused Safari to bleed click-selections across the whole line once the ZWS sandwich was in place).
  - Added a `click` handler that places a collapsed cursor after the atom and toggles `.selected-inline` directly on the atom DOM — visual feedback without a DOM Selection range that Safari can mis-render.

## Test plan
- [x] All 772 existing web tests still pass (`tiptap-serialization`, `tiptap-template-editor-enter`, etc.)
- [x] Verified in Chrome: caret advances cleanly past atoms, no extra keystrokes; click-tag selects only the atom (`.selected-inline` outline)
- [ ] Verified in Safari (manual user testing): cursor position now matches caret render, click selects only the tag, shift+arrow symmetric in both directions
- [ ] Existing flows still work: paste of `{{var}}HELLO` creates a real variable atom, drag-and-drop reordering, Backspace/Delete deletes ZWS+atom as one unit

🤖 Generated with [Claude Code](https://claude.com/claude-code)