### PR TITLE
fix(editor): stop caret skipping past hardBreak on click in Safari

### DIFF
--- a/web/src/components/tiptap-template-editor/TipTapTemplateEditor.tsx
+++ b/web/src/components/tiptap-template-editor/TipTapTemplateEditor.tsx
@@ -27,6 +27,10 @@ import { TemplateEditorToolbar } from './components/TemplateEditorToolbar';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useTranslations } from 'next-intl';
 
+/** Inline atom node types that this editor renders as click-targets. Excludes
+ *  hardBreak so a click resolving to a line break doesn't jump the caret past it. */
+const CUSTOM_INLINE_ATOMS = new Set(['variable', 'colorTile', 'fillSpace', 'formula', 'wrappedText']);
+
 /**
  * Serialize a TipTap slice to template string format
  * Used for clipboard operations (copy/paste/cut)
@@ -515,7 +519,13 @@ export function TipTapTemplateEditor({
           const coords = view.posAtCoords({ left: event.clientX, top: event.clientY });
           if (!coords) return false;
           const node = view.state.doc.nodeAt(coords.pos);
-          if (!node?.isAtom || !node.isInline) return false;
+          // hardBreak is also an inline atom in PM, but a click that resolves
+          // onto a hardBreak position is the user trying to put the caret near
+          // a line edge — letting the editor jump the caret *past* the break
+          // (Safari's posAtCoords lands on the break at line boundaries when
+          // adjacent ZWS text nodes are present) reads as the cursor "skipping
+          // ahead a character". Restrict this handler to our content atoms.
+          if (!node || !CUSTOM_INLINE_ATOMS.has(node.type.name)) return false;
 
           // Place collapsed cursor immediately after the atom.
           const after = coords.pos + node.nodeSize;


### PR DESCRIPTION
## Summary
- Restrict the TipTap click handler to the editor's content atoms (`variable`, `colorTile`, `fillSpace`, `formula`, `wrappedText`).
- `hardBreak` is also an inline atom in this schema, so the old `node.isAtom && node.isInline` check was matching it. Safari's \`posAtCoords\` lands on a hardBreak position when clicking near line edges (the layout sandwiches every break with zero-width-space text nodes), and the handler then ran \`coords.pos + node.nodeSize\` and dispatched a selection — jumping the caret past the line break by one position. That's the user-visible "click skips ahead one character" symptom Safari users were hitting; Chrome's hit-testing falls on the adjacent ZWS text instead, which is why arrow keys (which already skip ZWS via a separate keymap) and other browsers were unaffected.

## Test plan
- [x] Existing tiptap tests pass (34/34): `npx vitest run tiptap`.
- [x] Reproduced the original bug in Safari (cursor jumping forward at line-edge clicks) and confirmed the fix lands the caret at the clicked position.
- [ ] Manual smoke in Safari: click around mid-line, line ends, and on color-tile / variable atoms — text clicks should land where you click; atom clicks still place the caret immediately after the atom.
- [ ] Verify Chrome/Firefox behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)