### PR TITLE
Fix "Check for updates" aborting early and not refreshing plugin list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fiestaboard",
-  "version": "5.6.22",
+  "version": "5.6.23",
   "description": "Open-source server that turns your split-flap display into a living dashboard with weather, stocks, sports, transit, and more",
   "keywords": [
     "split-flap",

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """FiestaBoard Display Service - Main package."""
 
-__version__ = "5.6.22"
+__version__ = "5.6.23"
 

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "5.6.22",
+  "version": "5.6.23",
   "private": true,
   "scripts": {
     "dev": "next dev --webpack",

--- a/web/src/app/integrations/page.tsx
+++ b/web/src/app/integrations/page.tsx
@@ -1780,12 +1780,11 @@ export default function IntegrationsPage() {
       } else {
         toast.success(t("toastNoUpdates"));
       }
-      queryClient.invalidateQueries({ queryKey: ["plugins"] });
-      queryClient.invalidateQueries({ queryKey: ["plugin-updates"] });
     } catch (err) {
       toast.error(t("toastCheckFailed", { error: err instanceof Error ? err.message : tCommon("error") }));
     } finally {
       setIsCheckingForUpdates(false);
+      queryClient.invalidateQueries({ queryKey: ["plugins"] });
     }
   };
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1014,20 +1014,21 @@ export interface SystemActionResponse {
 // API client with typed methods
 const DEFAULT_TIMEOUT_MS = 30000;
 
-async function fetchApi<T>(path: string, options?: RequestInit): Promise<T> {
-  const timeoutSignal = AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
-  const signal = options?.signal
-    ? AbortSignal.any([options.signal, timeoutSignal])
+async function fetchApi<T>(path: string, options?: RequestInit & { timeoutMs?: number }): Promise<T> {
+  const { timeoutMs = DEFAULT_TIMEOUT_MS, ...fetchOptions } = options ?? {};
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  const signal = fetchOptions.signal
+    ? AbortSignal.any([fetchOptions.signal, timeoutSignal])
     : timeoutSignal;
 
   let res: globalThis.Response;
   try {
     res = await fetch(`${API_BASE}${path}`, {
-      ...options,
+      ...fetchOptions,
       signal,
       headers: {
         "Content-Type": "application/json",
-        ...options?.headers,
+        ...fetchOptions.headers,
       },
     });
   } catch (err) {
@@ -1579,6 +1580,7 @@ export const api = {
   triggerPluginUpdateCheck: () =>
     fetchApi<PluginUpdateCheckResponse>("/plugins/updates/check", {
       method: "POST",
+      timeoutMs: 120000,
     }),
 
   applyAllPluginUpdates: () =>

--- a/web/tests/integrations.spec.ts
+++ b/web/tests/integrations.spec.ts
@@ -139,3 +139,103 @@ test.describe("Integrations Page", () => {
     await expect(page.getByRole("dialog")).not.toBeVisible({ timeout: 3_000 });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Check for Updates
+// ---------------------------------------------------------------------------
+
+test.describe("Check for Updates", () => {
+  test("shows the Check for Updates button on the Installed tab", async ({ page }) => {
+    await page.goto("/integrations");
+    await expect(
+      page.getByRole("heading", { name: /integrations/i })
+    ).toBeVisible({ timeout: 15_000 });
+
+    await expect(
+      page.getByRole("button", { name: /check for updates/i })
+    ).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("shows all-up-to-date toast when no updates are found", async ({ page }) => {
+    await page.route("**/api/plugins/updates/check", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ checked: 3, updates_available: [] }),
+      });
+    });
+
+    await page.goto("/integrations");
+    await expect(
+      page.getByRole("heading", { name: /integrations/i })
+    ).toBeVisible({ timeout: 15_000 });
+
+    await page.getByRole("button", { name: /check for updates/i }).click();
+
+    await expect(
+      page.getByText("All plugins are up to date")
+    ).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("shows update count toast when updates are found", async ({ page }) => {
+    await page.route("**/api/plugins/updates/check", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ checked: 2, updates_available: ["some_plugin"] }),
+      });
+    });
+
+    await page.goto("/integrations");
+    await expect(
+      page.getByRole("heading", { name: /integrations/i })
+    ).toBeVisible({ timeout: 15_000 });
+
+    await page.getByRole("button", { name: /check for updates/i }).click();
+
+    await expect(
+      page.getByText("1 plugin update available")
+    ).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("shows error toast and still refreshes plugin list when check fails", async ({ page }) => {
+    let pluginsRequestCount = 0;
+
+    await page.route("**/api/plugins/updates/check", async (route) => {
+      await route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ detail: "Internal Server Error" }),
+      });
+    });
+
+    // Count GET /api/plugins requests (excludes sub-paths like /plugins/updates)
+    await page.route(/\/api\/plugins(\?.*)?$/, async (route) => {
+      if (route.request().method() === "GET") {
+        pluginsRequestCount++;
+      }
+      await route.continue();
+    });
+
+    await page.goto("/integrations");
+    await expect(
+      page.getByRole("heading", { name: /integrations/i })
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Wait for the initial plugin list load to complete
+    await page.waitForLoadState("networkidle").catch(() => {});
+    const countAfterLoad = pluginsRequestCount;
+
+    await page.getByRole("button", { name: /check for updates/i }).click();
+
+    // Error toast should appear
+    await expect(
+      page.getByText(/Couldn't check for updates/)
+    ).toBeVisible({ timeout: 5_000 });
+
+    // The finally block must trigger a plugin list refresh even on error
+    await expect
+      .poll(() => pluginsRequestCount, { timeout: 5_000 })
+      .toBeGreaterThan(countAfterLoad);
+  });
+});


### PR DESCRIPTION
## Summary

- **30-second abort**: `fetchApi` applies `AbortSignal.timeout(30000)` to every request. For users with several external plugins, the sequential `git ls-remote` calls in `/plugins/updates/check` can exceed 30 s, causing the frontend to abort the fetch and show _"Couldn't check for updates: Fetch is aborted"_ — even though the backend eventually completes and caches the results.
- **Updates missing until reload**: `queryClient.invalidateQueries` was inside the `try` block, so an aborted request skipped the refresh entirely, leaving stale (no-update) data in the UI until the user reloaded.

## Changes

- Added a `timeoutMs` option to `fetchApi` (defaults to 30 s) so individual calls can override the global timeout without changing other endpoints.
- Set `timeoutMs: 120000` on `triggerPluginUpdateCheck` — 2 minutes is enough headroom for any practical number of external plugins.
- Moved `queryClient.invalidateQueries({ queryKey: ["plugins"] })` into the `finally` block of `handleCheckForUpdates` so the plugin list always refreshes regardless of outcome.
- Removed the no-op `["plugin-updates"]` invalidation — no `useQuery` ever used that key; plugin update state is carried by the `["plugins"]` query.

## Tests

Four new Playwright tests added to `integrations.spec.ts`:

- [ ] "Check for Updates" button is visible on the Installed tab
- [ ] Shows _"All plugins are up to date"_ toast when the API reports no updates
- [ ] Shows _"1 plugin update available"_ toast when updates are found (mocked response)
- [ ] Shows error toast **and** triggers a `GET /api/plugins` refresh when the check endpoint returns 500 (verifies the `finally`-block fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)