### PR TITLE
feat: support per-device-type demo pages in plugin manifests

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -6390,12 +6390,13 @@ async def get_plugin(plugin_id: str):
     config_manager = get_config_manager()
     plugin_config = config_manager.get_plugin_config(plugin_id)
     
-    # Check for demo page
+    # Check for demo page (use flagship as the representative for backwards compat)
     has_demo = manifest.demo is not None
     demo_page_id = None
     if has_demo:
         page_service = get_page_service()
-        demo_page = page_service.get_demo_page(plugin_id)
+        demo_page = page_service.get_demo_page(plugin_id, device_type="flagship") \
+            or page_service.get_demo_page(plugin_id)
         if demo_page:
             demo_page_id = demo_page.id
 
@@ -6685,9 +6686,9 @@ async def get_plugin_variables(plugin_id: str):
 
 
 @app.get("/plugins/{plugin_id}/demo-page")
-async def get_plugin_demo_page(plugin_id: str):
+async def get_plugin_demo_page(plugin_id: str, device_type: str = "flagship"):
     """
-    Check whether a demo page exists for this plugin.
+    Check whether a demo page exists for this plugin and device type.
 
     Returns ``exists: true`` and the page id when one is found.
     """
@@ -6702,22 +6703,24 @@ async def get_plugin_demo_page(plugin_id: str):
     if manifest.demo is None:
         return {"exists": False, "page_id": None, "has_demo_template": False}
 
+    has_demo_template = device_type in manifest.demo
     page_service = get_page_service()
-    demo_page = page_service.get_demo_page(plugin_id)
+    demo_page = page_service.get_demo_page(plugin_id, device_type=device_type)
     return {
         "exists": demo_page is not None,
         "page_id": demo_page.id if demo_page else None,
-        "has_demo_template": True,
+        "has_demo_template": has_demo_template,
     }
 
 
 @app.post("/plugins/{plugin_id}/demo-page")
-async def create_plugin_demo_page(plugin_id: str):
+async def create_plugin_demo_page(plugin_id: str, device_type: str = "flagship"):
     """
-    Create (or recreate) the demo page for a plugin.
+    Create (or recreate) the demo page for a plugin and device type.
 
-    The demo page is a singleton per plugin -- calling this endpoint when a
-    demo page already exists will delete the old one and create a fresh copy.
+    The demo page is a singleton per plugin + device type -- calling this endpoint
+    when a demo page already exists for that device type will delete the old one
+    and create a fresh copy.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
         raise HTTPException(status_code=503, detail="Plugin system is not available.")
@@ -6731,6 +6734,13 @@ async def create_plugin_demo_page(plugin_id: str):
         raise HTTPException(
             status_code=400,
             detail=f"Plugin '{plugin_id}' does not include a demo page template.",
+        )
+
+    demo_schema = manifest.demo.get(device_type)
+    if demo_schema is None:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Plugin '{plugin_id}' has no demo template for device type '{device_type}'.",
         )
 
     # Check that required settings are configured
@@ -6751,7 +6761,7 @@ async def create_plugin_demo_page(plugin_id: str):
             )
 
     page_service = get_page_service()
-    page, recreated = page_service.create_demo_page(plugin_id, manifest.demo)
+    page, recreated = page_service.create_demo_page(plugin_id, demo_schema)
 
     return {
         "status": "recreated" if recreated else "created",

--- a/src/pages/service.py
+++ b/src/pages/service.py
@@ -245,28 +245,29 @@ class PageService:
     
     # Demo page operations
 
-    def get_demo_page(self, plugin_id: str) -> Optional[Page]:
+    def get_demo_page(self, plugin_id: str, device_type: Optional[str] = None) -> Optional[Page]:
         """Find the existing demo page for a plugin.
 
-        Returns the page tagged with ``demo_plugin_id == plugin_id``,
-        or None if no demo page exists for this plugin.
+        Returns the page tagged with ``demo_plugin_id == plugin_id``.
+        If *device_type* is provided, only pages matching that device type are returned.
         """
         for page in self.storage.list_all():
             if page.demo_plugin_id == plugin_id:
-                return page
+                if device_type is None or page.device_type == device_type:
+                    return page
         return None
 
     def create_demo_page(self, plugin_id: str, demo: DemoPageSchema) -> Tuple[Page, bool]:
         """Create (or recreate) the demo page for a plugin.
 
-        If a demo page already exists for *plugin_id* it is deleted first,
-        making the demo page a singleton per plugin.
+        The singleton constraint is per plugin + device type: creating a demo for
+        "flagship" does not delete an existing "note" demo, and vice versa.
 
         Returns:
             Tuple of (created_page, was_recreated)
         """
         recreated = False
-        existing = self.get_demo_page(plugin_id)
+        existing = self.get_demo_page(plugin_id, device_type=demo.device_type)
         if existing:
             self.storage.delete(existing.id)
             self._invalidate_cache(existing.id)

--- a/src/plugins/manifest.py
+++ b/src/plugins/manifest.py
@@ -345,7 +345,7 @@ class PluginManifest:
     fiestaboard_version: str = ""
     supports_triggers: bool = False
     screenshots: List[Screenshot] = field(default_factory=list)
-    demo: Optional[DemoPageSchema] = None
+    demo: Optional[Dict[str, DemoPageSchema]] = None  # keyed by device_type
     raw: Dict[str, Any] = field(default_factory=dict)
     
     @classmethod
@@ -440,16 +440,33 @@ class PluginManifest:
                 ))
 
         # --- parse demo page schema ---
-        demo: Optional[DemoPageSchema] = None
+        demo: Optional[Dict[str, DemoPageSchema]] = None
         demo_raw = data.get("demo")
-        if isinstance(demo_raw, dict) and "name" in demo_raw and "template" in demo_raw:
-            demo = DemoPageSchema(
-                name=demo_raw["name"],
-                template=demo_raw["template"],
-                device_type=demo_raw.get("device_type", "flagship"),
-                line_metadata=demo_raw.get("line_metadata"),
-                duration_seconds=demo_raw.get("duration_seconds", 300),
-            )
+        if isinstance(demo_raw, dict):
+            if "name" in demo_raw and "template" in demo_raw:
+                # Old flat format — normalise to keyed dict
+                schema = DemoPageSchema(
+                    name=demo_raw["name"],
+                    template=demo_raw["template"],
+                    device_type=demo_raw.get("device_type", "flagship"),
+                    line_metadata=demo_raw.get("line_metadata"),
+                    duration_seconds=demo_raw.get("duration_seconds", 300),
+                )
+                demo = {schema.device_type: schema}
+            else:
+                # New keyed format: {"flagship": {...}, "note": {...}}
+                demo = {}
+                for dt, entry in demo_raw.items():
+                    if isinstance(entry, dict) and "name" in entry and "template" in entry:
+                        demo[dt] = DemoPageSchema(
+                            name=entry["name"],
+                            template=entry["template"],
+                            device_type=dt,
+                            line_metadata=entry.get("line_metadata"),
+                            duration_seconds=entry.get("duration_seconds", 300),
+                        )
+                if not demo:
+                    demo = None
 
         return cls(
             id=data["id"],
@@ -620,7 +637,8 @@ def validate_manifest(data: Dict[str, Any]) -> Tuple[bool, List[str]]:
     if demo is not None:
         if not isinstance(demo, dict):
             errors.append("demo must be an object")
-        else:
+        elif "name" in demo or "template" in demo:
+            # Old flat format
             if "name" not in demo:
                 errors.append("demo missing required field: name")
             if "template" not in demo:
@@ -630,6 +648,21 @@ def validate_manifest(data: Dict[str, Any]) -> Tuple[bool, List[str]]:
             device_type = demo.get("device_type", "flagship")
             if device_type not in ("flagship", "note"):
                 errors.append(f"demo.device_type must be 'flagship' or 'note', got '{device_type}'")
+        else:
+            # New keyed format: keys are device types
+            for key, entry in demo.items():
+                if key not in ("flagship", "note"):
+                    errors.append(f"demo key must be 'flagship' or 'note', got '{key}'")
+                    continue
+                if not isinstance(entry, dict):
+                    errors.append(f"demo.{key} must be an object")
+                    continue
+                if "name" not in entry:
+                    errors.append(f"demo.{key} missing required field: name")
+                if "template" not in entry:
+                    errors.append(f"demo.{key} missing required field: template")
+                elif not isinstance(entry["template"], list):
+                    errors.append(f"demo.{key}.template must be an array of strings")
 
     return len(errors) == 0, errors
 

--- a/tests/test_demo_pages.py
+++ b/tests/test_demo_pages.py
@@ -28,8 +28,8 @@ from src.pages.service import PageService
 
 class TestDemoPageSchema:
 
-    def test_parse_demo_from_manifest(self):
-        """Manifest with a demo section produces a DemoPageSchema."""
+    def test_parse_old_format_from_manifest(self):
+        """Old flat demo format is normalised to a dict keyed by device_type."""
         data = {
             "id": "test_plugin",
             "name": "Test",
@@ -51,36 +51,17 @@ class TestDemoPageSchema:
         }
         manifest = PluginManifest.from_dict(data)
         assert manifest.demo is not None
-        assert manifest.demo.name == "Test Demo"
-        assert manifest.demo.template == ["Line 1", "Line 2", "", "", "", ""]
-        assert manifest.demo.device_type == "flagship"
-        assert manifest.demo.duration_seconds == 600
-        assert len(manifest.demo.line_metadata) == 6
+        assert isinstance(manifest.demo, dict)
+        assert "flagship" in manifest.demo
+        schema = manifest.demo["flagship"]
+        assert schema.name == "Test Demo"
+        assert schema.template == ["Line 1", "Line 2", "", "", "", ""]
+        assert schema.device_type == "flagship"
+        assert schema.duration_seconds == 600
+        assert len(schema.line_metadata) == 6
 
-    def test_manifest_without_demo(self):
-        """Manifest without a demo section sets demo to None."""
-        data = {"id": "test_plugin", "name": "Test", "version": "1.0.0"}
-        manifest = PluginManifest.from_dict(data)
-        assert manifest.demo is None
-
-    def test_demo_defaults(self):
-        """Demo section with minimal fields uses correct defaults."""
-        data = {
-            "id": "test_plugin",
-            "name": "Test",
-            "version": "1.0.0",
-            "demo": {
-                "name": "Minimal Demo",
-                "template": ["Hello"],
-            },
-        }
-        manifest = PluginManifest.from_dict(data)
-        assert manifest.demo.device_type == "flagship"
-        assert manifest.demo.duration_seconds == 300
-        assert manifest.demo.line_metadata is None
-
-    def test_demo_note_device_type(self):
-        """Demo can target the 'note' device type."""
+    def test_parse_old_format_note_device_type(self):
+        """Old flat demo format with device_type=note is stored under 'note' key."""
         data = {
             "id": "test_plugin",
             "name": "Test",
@@ -92,7 +73,97 @@ class TestDemoPageSchema:
             },
         }
         manifest = PluginManifest.from_dict(data)
-        assert manifest.demo.device_type == "note"
+        assert "note" in manifest.demo
+        assert manifest.demo["note"].device_type == "note"
+
+    def test_parse_new_format_single_device(self):
+        """New keyed format with one device type parses correctly."""
+        data = {
+            "id": "test_plugin",
+            "name": "Test",
+            "version": "1.0.0",
+            "demo": {
+                "flagship": {
+                    "name": "Flagship Demo",
+                    "template": ["L1", "L2", "", "", "", ""],
+                    "duration_seconds": 120,
+                }
+            },
+        }
+        manifest = PluginManifest.from_dict(data)
+        assert manifest.demo is not None
+        assert "flagship" in manifest.demo
+        assert "note" not in manifest.demo
+        schema = manifest.demo["flagship"]
+        assert schema.name == "Flagship Demo"
+        assert schema.device_type == "flagship"
+        assert schema.duration_seconds == 120
+
+    def test_parse_new_format_both_devices(self):
+        """New keyed format with both device types parses both schemas."""
+        data = {
+            "id": "test_plugin",
+            "name": "Test",
+            "version": "1.0.0",
+            "demo": {
+                "flagship": {
+                    "name": "Flagship Demo",
+                    "template": ["L1", "L2", "", "", "", ""],
+                },
+                "note": {
+                    "name": "Note Demo",
+                    "template": ["L1", "L2", "L3"],
+                },
+            },
+        }
+        manifest = PluginManifest.from_dict(data)
+        assert "flagship" in manifest.demo
+        assert "note" in manifest.demo
+        assert manifest.demo["flagship"].name == "Flagship Demo"
+        assert manifest.demo["note"].name == "Note Demo"
+        assert manifest.demo["note"].device_type == "note"
+
+    def test_manifest_without_demo(self):
+        """Manifest without a demo section sets demo to None."""
+        data = {"id": "test_plugin", "name": "Test", "version": "1.0.0"}
+        manifest = PluginManifest.from_dict(data)
+        assert manifest.demo is None
+
+    def test_demo_old_format_defaults(self):
+        """Old flat demo with minimal fields uses correct defaults."""
+        data = {
+            "id": "test_plugin",
+            "name": "Test",
+            "version": "1.0.0",
+            "demo": {
+                "name": "Minimal Demo",
+                "template": ["Hello"],
+            },
+        }
+        manifest = PluginManifest.from_dict(data)
+        schema = manifest.demo["flagship"]
+        assert schema.device_type == "flagship"
+        assert schema.duration_seconds == 300
+        assert schema.line_metadata is None
+
+    def test_demo_new_format_defaults(self):
+        """New keyed format with minimal fields uses correct defaults."""
+        data = {
+            "id": "test_plugin",
+            "name": "Test",
+            "version": "1.0.0",
+            "demo": {
+                "note": {
+                    "name": "Note Demo",
+                    "template": ["L1", "L2", "L3"],
+                }
+            },
+        }
+        manifest = PluginManifest.from_dict(data)
+        schema = manifest.demo["note"]
+        assert schema.device_type == "note"
+        assert schema.duration_seconds == 300
+        assert schema.line_metadata is None
 
 
 # ---------------------------------------------------------------------------
@@ -166,6 +237,62 @@ class TestDemoValidation:
         is_valid, errors = validate_manifest(data)
         assert not is_valid
         assert any("demo" in e for e in errors)
+
+    def test_new_format_valid_both_devices(self):
+        """New keyed format with both device types passes validation."""
+        data = {
+            "id": "test_plugin",
+            "name": "Test",
+            "version": "1.0.0",
+            "demo": {
+                "flagship": {"name": "Flagship", "template": ["L1"]},
+                "note": {"name": "Note", "template": ["L1", "L2", "L3"]},
+            },
+        }
+        is_valid, errors = validate_manifest(data)
+        assert is_valid, errors
+
+    def test_new_format_invalid_key(self):
+        """New keyed format with an unknown device type key fails validation."""
+        data = {
+            "id": "test_plugin",
+            "name": "Test",
+            "version": "1.0.0",
+            "demo": {
+                "jumbo": {"name": "Demo", "template": ["L1"]},
+            },
+        }
+        is_valid, errors = validate_manifest(data)
+        assert not is_valid
+        assert any("jumbo" in e for e in errors)
+
+    def test_new_format_missing_name(self):
+        """New keyed format with a missing 'name' in an entry fails validation."""
+        data = {
+            "id": "test_plugin",
+            "name": "Test",
+            "version": "1.0.0",
+            "demo": {
+                "flagship": {"template": ["L1"]},
+            },
+        }
+        is_valid, errors = validate_manifest(data)
+        assert not is_valid
+        assert any("flagship" in e and "name" in e for e in errors)
+
+    def test_new_format_missing_template(self):
+        """New keyed format with a missing 'template' in an entry fails validation."""
+        data = {
+            "id": "test_plugin",
+            "name": "Test",
+            "version": "1.0.0",
+            "demo": {
+                "note": {"name": "Demo"},
+            },
+        }
+        is_valid, errors = validate_manifest(data)
+        assert not is_valid
+        assert any("note" in e and "template" in e for e in errors)
 
 
 # ---------------------------------------------------------------------------
@@ -313,6 +440,56 @@ class TestPageServiceDemo:
         assert service.get_demo_page("plugin_a").name == "Demo A"
         assert service.get_demo_page("plugin_b").name == "Demo B"
         assert service.get_demo_page("plugin_c") is None
+
+    def test_get_demo_page_filters_by_device_type(self, service):
+        """get_demo_page with device_type only returns matching pages."""
+        flagship_schema = self._demo_schema("Flagship Demo")
+        note_schema = DemoPageSchema(
+            name="Note Demo",
+            template=["L1", "L2", "L3"],
+            device_type="note",
+        )
+        service.create_demo_page("test_plugin", flagship_schema)
+        service.create_demo_page("test_plugin", note_schema)
+
+        flagship_page = service.get_demo_page("test_plugin", device_type="flagship")
+        note_page = service.get_demo_page("test_plugin", device_type="note")
+
+        assert flagship_page is not None
+        assert flagship_page.device_type == "flagship"
+        assert note_page is not None
+        assert note_page.device_type == "note"
+
+    def test_singleton_per_device_type(self, service):
+        """Recreating a flagship demo does not delete the note demo, and vice versa."""
+        flagship_schema = self._demo_schema("Flagship Demo")
+        note_schema = DemoPageSchema(
+            name="Note Demo",
+            template=["L1", "L2", "L3"],
+            device_type="note",
+        )
+        service.create_demo_page("test_plugin", flagship_schema)
+        service.create_demo_page("test_plugin", note_schema)
+
+        # Recreate flagship — note should survive
+        _, recreated = service.create_demo_page("test_plugin", self._demo_schema("Flagship Refreshed"))
+        assert recreated
+
+        assert service.get_demo_page("test_plugin", device_type="flagship").name == "Flagship Refreshed"
+        assert service.get_demo_page("test_plugin", device_type="note") is not None
+        assert service.get_demo_page("test_plugin", device_type="note").name == "Note Demo"
+
+    def test_get_demo_page_no_filter_returns_any(self, service):
+        """get_demo_page without device_type returns any demo page for the plugin."""
+        note_schema = DemoPageSchema(
+            name="Note Demo",
+            template=["L1", "L2", "L3"],
+            device_type="note",
+        )
+        service.create_demo_page("test_plugin", note_schema)
+        found = service.get_demo_page("test_plugin")
+        assert found is not None
+        assert found.demo_plugin_id == "test_plugin"
 
     def test_demo_page_persists_to_storage(self, temp_storage_file):
         storage1 = PageStorage(storage_file=temp_storage_file)

--- a/tests/test_silence_mode_display.py
+++ b/tests/test_silence_mode_display.py
@@ -212,15 +212,14 @@ class TestSilenceModeDispatch:
              patch("src.main.Config", config), \
              patch.object(service, "_check_trigger_override", return_value=None):
             sent = service.check_and_send_active_page()
-
-        assert sent is True
-        # The board content should be the silence page, not the active page.
-        args, _ = service.vb_client.send_characters.call_args
-        board_array = args[0]
-        assert "GOOD NIGHT" in _decode_board_text(board_array)
-        # And further ticks must not send again.
-        service.check_and_send_active_page()
-        assert service.vb_client.send_characters.call_count == 1
+            assert sent is True
+            # The board content should be the silence page, not the active page.
+            args, _ = service.vb_client.send_characters.call_args
+            board_array = args[0]
+            assert "GOOD NIGHT" in _decode_board_text(board_array)
+            # And further ticks must not send again.
+            service.check_and_send_active_page()
+            assert service.vb_client.send_characters.call_count == 1
 
     def test_page_mode_falls_back_to_indicator_when_page_missing(self, service):
         active_page, page_service, settings, config = self._patch_common(


### PR DESCRIPTION
## Summary

- Plugin manifests can now define separate demo pages per device type using a new keyed format (`"demo": { "flagship": {...}, "note": {...} }`). The old flat format remains fully supported — existing plugins need no changes.
- `GET` and `POST /plugins/{id}/demo-page` now accept a `?device_type=` query param (defaults to `"flagship"`). Flagship and note demo pages can coexist as independent singletons.
- Fixed a pre-existing test bug in `test_silence_mode_display.py` where the second `check_and_send_active_page()` call was placed outside the `patch` context manager, causing `Config` to be unpatched and the assertion to spuriously fail.

## New manifest format

```json
"demo": {
  "flagship": {
    "name": "My Plugin Demo",
    "template": ["L1", "L2", "", "", "", ""]
  },
  "note": {
    "name": "My Plugin Demo (Note)",
    "template": ["L1", "L2", "L3"]
  }
}
```

The old flat format is still valid and is normalised to `{"flagship": ...}` internally.

## Test plan

- [x] All 33 `tests/test_demo_pages.py` tests pass (7 updated + 9 new)
- [x] All 10 `tests/test_silence_mode_display.py` tests pass
- [x] Full suite: 3072/3072 passing (previously 3071/3072 due to the pre-existing bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)