### PR TITLE
docs: add Vestaboard disclaimer to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,4 +340,10 @@ FiestaBoard is free and open source. If you find it useful and want to support c
 <a href="https://www.buymeacoffee.com/fiestaboard" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a>
 
 ---
+
+## Disclaimer
+
+FiestaBoard is an independent, open-source project and is not affiliated with, sponsored by, or endorsed by Vestaboard, Inc. "Vestaboard" is a trademark of Vestaboard, Inc. FiestaBoard simply provides software that is compatible with Vestaboard hardware via their official APIs.
+
+
 Made with ❤️ in San Francisco.


### PR DESCRIPTION
## Summary

- Adds a **Disclaimer** section at the bottom of `README.md` clarifying that FiestaBoard is independent and not affiliated with Vestaboard, Inc.
- Acknowledges "Vestaboard" as a trademark of Vestaboard, Inc.
- Notes that FiestaBoard integrates via their official API, establishing legitimate use.

## Motivation

Proactively addresses any potential trademark or affiliation confusion to avoid legal issues with Vestaboard, Inc.

## Test plan

- [ ] Verify disclaimer renders correctly in GitHub's Markdown preview
- [ ] Confirm no other README content was changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)