### PR TITLE
docs: sort All Available Plugins table alphabetically

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,22 +119,25 @@ FiestaBoard has **26 built-in plugins** covering weather, finance, transit, spor
 
 ### All Available Plugins
 
+<!-- Sorted alphabetically by plugin name -->
 | Plugin | What It Shows | API Key? |
 |--------|--------------|----------|
-| [Airport Board](https://github.com/Fiestaboard/fiestaboard-plugin--airport-board) | Live flights near a configurable airport | No |
 | [Air Quality & Fog](https://github.com/Fiestaboard/fiestaboard-plugin--air-fog) | AQI and fog conditions | Yes |
+| [Airport Board](https://github.com/Fiestaboard/fiestaboard-plugin--airport-board) | Live flights near a configurable airport | No |
+| [Allergy & Health](https://github.com/Fiestaboard/fiestaboard-plugin--health) | Allergy levels and health risk indicators | No |
 | [Aurora Forecast](https://github.com/Fiestaboard/fiestaboard-plugin--aurora-forecast) | Geomagnetic Kp index and aurora visibility | No |
 | [Bay Wheels](https://github.com/Fiestaboard/fiestaboard-plugin--baywheels) | Bike availability at stations | No |
 | [Calendar Subscription](https://github.com/Fiestaboard/fiestaboard-plugin--calendar-sub) | Upcoming events from any .ics URL | No |
+| [Countdown](./plugins/countdown/README.md) | Time remaining until an event | No |
 | [Currency Exchange](https://github.com/Fiestaboard/fiestaboard-plugin--currency) | Live exchange rates (Frankfurter/ECB) | No |
 | [Dad Jokes](https://github.com/Fiestaboard/fiestaboard-plugin--dad-jokes) | Random dad jokes | No |
+| [Date & Time](./plugins/date_time/README.md) | Current date/time in many formats | No |
 | [Disney Park Queue Times](https://github.com/Fiestaboard/fiestaboard-plugin--disney-parks-times) | Wait times for Disney rides | No |
 | [Earthquake Monitor](https://github.com/Fiestaboard/fiestaboard-plugin--earthquake) | Recent USGS earthquake data | No |
 | [Element of the Day](https://github.com/Fiestaboard/fiestaboard-plugin--element-of-day) | Periodic table element of the day | No |
 | [Generic Data](https://github.com/Fiestaboard/fiestaboard-plugin--generic-data) | Custom data from any JSON/XML URL | No |
 | [Guest WiFi](https://github.com/Fiestaboard/fiestaboard-plugin--guest-wifi) | WiFi credentials for guests | No |
 | [Hacker News](https://github.com/Fiestaboard/fiestaboard-plugin--hacker-news) | Top Hacker News story title and score | No |
-| [Allergy & Health](https://github.com/Fiestaboard/fiestaboard-plugin--health) | Allergy levels and health risk indicators | No |
 | [Home Assistant](https://github.com/Fiestaboard/fiestaboard-plugin--home-assistant) | Smart home status (doors, locks, garage) | Yes (self-hosted) |
 | [ISS Tracker](https://github.com/Fiestaboard/fiestaboard-plugin--iss-tracker) | Real-time ISS position and altitude | No |
 | [Last.fm Now Playing](https://github.com/Fiestaboard/fiestaboard-plugin--last-fm) | Currently playing music | Yes (free) |
@@ -148,6 +151,7 @@ FiestaBoard has **26 built-in plugins** covering weather, finance, transit, spor
 | [Pet Facts](https://github.com/Fiestaboard/fiestaboard-plugin--pet-facts) | Random cat or dog fact | No |
 | [Pi-hole Stats](https://github.com/Fiestaboard/fiestaboard-plugin--pihole) | DNS query stats from local Pi-hole | No |
 | [Quote of the Day](https://github.com/Fiestaboard/fiestaboard-plugin--quote-of-day) | Daily inspirational quote | No |
+| [Random](./plugins/random/README.md) | Randomly selected values from a custom list, coin flip, or board color | No |
 | [Reddit Hot](https://github.com/Fiestaboard/fiestaboard-plugin--reddit-hot) | Top post from any subreddit | No |
 | [River Flow](https://github.com/Fiestaboard/fiestaboard-plugin--river-flow) | Real-time USGS streamflow data | No |
 | [Santa Tracker](https://github.com/Fiestaboard/fiestaboard-plugin--santa-tracker) | Track Santa's journey on Christmas | No |
@@ -170,9 +174,6 @@ FiestaBoard has **26 built-in plugins** covering weather, finance, transit, spor
 | [Wildfire Monitor](https://github.com/Fiestaboard/fiestaboard-plugin--wildfire) | Active wildfires from NIFC | No |
 | [Word of the Day](https://github.com/Fiestaboard/fiestaboard-plugin--word-of-day) | Word, pronunciation, and definition | No |
 | [WSDOT Ferries](https://github.com/Fiestaboard/fiestaboard-plugin--wsdot) | WA State ferry schedules and alerts | Yes (free) |
-| [Countdown](./plugins/countdown/README.md) | Time remaining until an event | No |
-| [Date & Time](./plugins/date_time/README.md) | Current date/time in many formats | No |
-| [Random](./plugins/random/README.md) | Randomly selected values from a custom list, coin flip, or board color | No |
 
 ---
 


### PR DESCRIPTION
## Summary

- Fixes three ordering issues in the "All Available Plugins" table in `README.md`
- Air Quality & Fog and Airport Board were swapped
- Allergy & Health was misplaced after Hacker News instead of in the A's
- Countdown, Date & Time, and Random were stranded at the bottom instead of in alphabetical order
- Adds `<!-- Sorted alphabetically by plugin name -->` comment above the table so future editors know the expected order

## Test plan

- [ ] Verify the table renders correctly on GitHub
- [ ] Confirm all 52 plugins are still present
- [ ] Spot-check alphabetical order throughout the table

🤖 Generated with [Claude Code](https://claude.com/claude-code)