### PR TITLE
fix:plugin update-check blocking event loop and system update-check perf on slow networks

### DIFF
--- a/nginx-dev.conf
+++ b/nginx-dev.conf
@@ -67,6 +67,9 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_connect_timeout 10s;
+            proxy_send_timeout 30s;
+            proxy_read_timeout 60s;
         }
 
         location @api_starting {

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -651,7 +651,9 @@ async def lifespan(app: FastAPI):
                 try:
                     if PLUGIN_SYSTEM_AVAILABLE:
                         registry = get_plugin_registry()
-                        results = registry.check_for_updates()
+                        results = await _asyncio.get_event_loop().run_in_executor(
+                            None, registry.check_for_updates
+                        )
                         updates = [p for p, v in results.items() if v]
                         if updates:
                             auto_update = get_settings_service().get_plugin_settings().auto_update
@@ -1454,7 +1456,7 @@ def _check_dockerhub_for_latest() -> Optional[str]:
     """
     try:
         # Query Docker Hub tags endpoint
-        resp = requests.get(DOCKERHUB_TAGS_URL, timeout=10)
+        resp = requests.get(DOCKERHUB_TAGS_URL, timeout=4)
         resp.raise_for_status()
         data = resp.json()
         
@@ -1488,7 +1490,7 @@ def _check_github_releases_for_latest() -> Optional[str]:
         resp = requests.get(
             GITHUB_RELEASES_API,
             headers={"Accept": "application/vnd.github.v3+json"},
-            timeout=10,
+            timeout=4,
         )
         resp.raise_for_status()
         tag_name = resp.json().get("tag_name", "")
@@ -1511,32 +1513,61 @@ async def system_update_check():
     return await _perform_update_check()
 
 
+_UPDATE_CHECK_CACHE_TTL = 3600  # seconds
+
+
 async def _perform_update_check() -> "UpdateCheckResponse":
     """Run the actual update check against Docker Hub / GitHub Releases.
 
     Extracted from the HTTP handler so the background scheduler (auto-update
     interval) can reuse it without going through the network stack.  Records
     ``last_check`` in the system update state file on every successful query.
+
+    Server-side result cache (TTL: 1 hour) prevents repeated network calls when
+    the frontend refreshes quickly or the Pi has slow/no outbound internet.
+    Both source checks run in parallel to halve worst-case latency.
     """
     is_production = os.getenv("PRODUCTION", "false").lower() == "true"
 
+    # --- Server-side cache: return the stored result if it is still fresh ----
     try:
-        # Try Docker Hub first (checks actual container registry), fall back to GitHub Releases
-        # Run in a thread so the blocking HTTP call doesn't stall the event loop
-        latest_version = await asyncio.to_thread(_check_dockerhub_for_latest)
+        _cached_state = _system_update_state_load()
+        _cached_result = _cached_state.get("cached_result")
+        _last_check_raw = _cached_state.get("last_check")
+        if _cached_result and _last_check_raw:
+            _last_check_dt = datetime.fromisoformat(_last_check_raw)
+            if _last_check_dt.tzinfo is None:
+                _last_check_dt = _last_check_dt.replace(tzinfo=timezone.utc)
+            _age = (datetime.now(timezone.utc) - _last_check_dt).total_seconds()
+            if _age < _UPDATE_CHECK_CACHE_TTL:
+                logger.debug("system/update-check: returning cached result (age=%.0fs)", _age)
+                return UpdateCheckResponse(**_cached_result)
+    except Exception as _ce:
+        logger.debug("Could not read update-check cache (non-fatal): %s", _ce)
 
-        if not latest_version:
-            latest_version = await asyncio.to_thread(_check_github_releases_for_latest)
+    try:
+        # Run both source checks in parallel; prefer Docker Hub, fall back to GitHub.
+        dh_version, gh_version = await asyncio.gather(
+            asyncio.to_thread(_check_dockerhub_for_latest),
+            asyncio.to_thread(_check_github_releases_for_latest),
+        )
+        latest_version = dh_version or gh_version
 
         if latest_version:
             update_available = _is_newer_version(latest_version, __version__)
-            # Record this check so the UI can show "last checked".  Best-effort.
             try:
                 _state = _system_update_state_load()
                 _state["last_check"] = datetime.now(timezone.utc).isoformat()
+                _state["cached_result"] = {
+                    "current_version": __version__,
+                    "latest_version": latest_version,
+                    "update_available": update_available,
+                    "package_url": GITHUB_PACKAGE_URL,
+                    "is_production": is_production,
+                }
                 _system_update_state_save(_state)
             except Exception as e:
-                logger.debug("Could not persist update-check timestamp (non-fatal): %s", e, exc_info=True)
+                logger.debug("Could not persist update-check result (non-fatal): %s", e, exc_info=True)
             return UpdateCheckResponse(
                 current_version=__version__,
                 latest_version=latest_version,
@@ -7451,8 +7482,8 @@ async def trigger_plugin_update_check():
     """
     Trigger an immediate update check for all external plugins.
 
-    This runs synchronously and may take a few seconds per plugin
-    (one ``git ls-remote`` per installed external plugin).
+    Runs ``git ls-remote`` against each external plugin's origin in a thread
+    pool so the event loop is not blocked.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
         raise HTTPException(
@@ -7460,7 +7491,8 @@ async def trigger_plugin_update_check():
         )
 
     registry = get_plugin_registry()
-    results = registry.check_for_updates()
+    loop = asyncio.get_event_loop()
+    results = await loop.run_in_executor(None, registry.check_for_updates)
     plugins_with_updates = [pid for pid, has_update in results.items() if has_update]
     return {
         "checked": len(results),

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -7885,4 +7885,3 @@ async def import_backup(
 if __name__ == "__main__":
     import uvicorn
     uvicorn.run(app, host="0.0.0.0", port=8000)
-

--- a/tests/test_system_endpoints.py
+++ b/tests/test_system_endpoints.py
@@ -28,15 +28,17 @@ def client():
 
 
 @pytest.fixture(autouse=True)
-def clear_update_check_cache():
-    """Prevent the server-side update-check cache from leaking between tests.
+def _isolate_state_file(tmp_path):
+    """Give every test its own state file so cached update-check results cannot
+    leak between tests.
 
     Each test that exercises _perform_update_check needs a clean slate so the
     cached_result from a previous test doesn't short-circuit network calls that
-    the test has mocked.
+    the test has mocked.  Tests that need to verify file persistence (e.g.
+    TestSystemUpdateAutoToggle) use monkeypatch.setattr to redirect
+    SYSTEM_UPDATE_STATE_FILE to their own path, which overrides this fixture.
     """
-    with patch("src.api_server._system_update_state_load", return_value={}), \
-         patch("src.api_server._system_update_state_save"):
+    with patch("src.api_server.SYSTEM_UPDATE_STATE_FILE", tmp_path / "update_state.json"):
         yield
 
 

--- a/tests/test_system_endpoints.py
+++ b/tests/test_system_endpoints.py
@@ -27,6 +27,19 @@ def client():
     return TestClient(app)
 
 
+@pytest.fixture(autouse=True)
+def clear_update_check_cache():
+    """Prevent the server-side update-check cache from leaking between tests.
+
+    Each test that exercises _perform_update_check needs a clean slate so the
+    cached_result from a previous test doesn't short-circuit network calls that
+    the test has mocked.
+    """
+    with patch("src.api_server._system_update_state_load", return_value={}), \
+         patch("src.api_server._system_update_state_save"):
+        yield
+
+
 class TestUpdateCheck:
     """Tests for /system/update-check endpoint."""
 
@@ -175,8 +188,10 @@ class TestDockerHubCheck:
         assert result is None
 
     def test_update_check_uses_dockerhub_first(self, client):
-        """Test that update-check tries Docker Hub before falling back to GitHub Releases."""
+        """Test that Docker Hub is queried and its result takes priority over GitHub Releases.
 
+        Both sources are checked in parallel; Docker Hub's version wins when it succeeds.
+        """
         call_order = []
 
         tags_resp = Mock()
@@ -189,21 +204,25 @@ class TestDockerHubCheck:
         }
         tags_resp.raise_for_status = Mock()
 
+        github_resp = Mock()
+        github_resp.status_code = 200
+        github_resp.json.return_value = {"tag_name": "v1.0.0"}  # lower — should not win
+        github_resp.raise_for_status = Mock()
+
         def mock_get(url, **kwargs):
             call_order.append(url)
             if _host_is(url, "hub.docker.com"):
                 return tags_resp
-            # GitHub Releases should NOT be called
-            raise AssertionError("Should not reach GitHub Releases API")
+            return github_resp
 
         with patch("src.api_server.requests.get", side_effect=mock_get):
             response = client.get("/system/update-check")
 
         assert response.status_code == 200
         data = response.json()
+        # Docker Hub's version (99.0.0) wins over GitHub's (1.0.0)
         assert data["latest_version"] == "99.0.0"
         assert data["update_available"] is True
-        # Verify Docker Hub was called
         assert any(_host_is(url, "hub.docker.com") for url in call_order)
 
     def test_update_check_falls_back_to_github_releases(self, client):


### PR DESCRIPTION
## Summary

- **Plugin update check spins forever:** `POST /plugins/updates/check` was calling `registry.check_for_updates()` (which shells out `git ls-remote` per plugin) directly inside an `async def` endpoint, blocking the asyncio event loop for the entire duration. Same issue existed in the hourly background loop. Both are now dispatched via `run_in_executor` so the event loop stays free.

- **Dev nginx missing proxy timeouts:** `nginx-dev.conf` had no `proxy_read_timeout` set, silently relying on nginx's implicit 60s default. Added the same explicit `proxy_connect_timeout 10s` / `proxy_send_timeout 30s` / `proxy_read_timeout 60s` block that production already had.

- **System update-check causes ~10s TTFB spikes on Pi:** Profiled a Raspberry Pi instance and found that `/api/system/update-check` was firing fresh requests to Docker Hub *and* GitHub on every page load, with no server-side cache. The two checks ran sequentially with 10s timeouts each — worst case 20s of blocking threads. On a Pi with slow/no outbound internet this backed up the asyncio thread pool enough to delay unrelated endpoints (`/api/pages`, `/api/config/validate`, page previews) by ~10s. Fixed with:
  - **Server-side 1-hour cache** stored in the existing state file — subsequent calls return instantly without any network I/O
  - **Parallel checks** via `asyncio.gather` instead of sequential awaits — halves worst-case latency on a cache miss
  - **4s timeouts** instead of 10s — failures fail fast on restricted networks

## Test plan

- [ ] Click "Check for updates" on the Integrations page — button should stop spinning and show a toast (previously spun forever when external plugins were installed)
- [ ] Reload the UI on a slow/Pi host — page load should no longer show ~10s TTFB on `/api/system/update-check` after the first successful check
- [ ] Confirm `nginx-dev.conf` proxy timeout block matches `nginx.conf`
- [ ] Verify background hourly plugin update loop still runs correctly (`docker-compose logs -f` — should see "Plugin update check: all plugins up to date" every hour without errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)