### PR TITLE
fix: plugin auto-updates never triggered due to local/remote branch name mismatch

### DIFF
--- a/src/plugins/sources.py
+++ b/src/plugins/sources.py
@@ -468,12 +468,23 @@ def get_remote_head_sha(dest_dir: Path) -> Optional[str]:
             capture_output=True, text=True, timeout=30,
             env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
         )
+        if ls_result.returncode == 0 and ls_result.stdout.strip():
+            # Output format: "<sha>\trefs/heads/<branch>"
+            return ls_result.stdout.strip().split()[0]
+
+        # The local branch name (e.g. "master") does not exist on the remote
+        # (e.g. remote default is "main").  This happens because git init
+        # creates "master" by default but most plugin repos use "main".
+        # Fall back to the remote's advertised HEAD ref so updates are still
+        # detected correctly regardless of local/remote branch name mismatch.
+        ls_result = subprocess.run(
+            ["git", "ls-remote", remote_url, "HEAD"],
+            capture_output=True, text=True, timeout=30,
+            env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
+        )
         if ls_result.returncode != 0 or not ls_result.stdout.strip():
             return None
-
-        # Output format: "<sha>\trefs/heads/<branch>"
-        sha = ls_result.stdout.strip().split()[0]
-        return sha
+        return ls_result.stdout.strip().split()[0]
     except (subprocess.SubprocessError, IndexError, OSError):
         return None
 

--- a/tests/test_plugin_sources.py
+++ b/tests/test_plugin_sources.py
@@ -564,6 +564,36 @@ class TestGetRemoteHeadSha:
         sha = get_remote_head_sha(d)
         assert sha == "deadbeef"
 
+    @mock.patch("src.plugins.sources.subprocess.run")
+    def test_falls_back_to_remote_head_on_branch_mismatch(self, mock_run, tmp_path):
+        """When local branch (e.g. 'master') doesn't exist on remote (e.g. 'main'),
+        fall back to querying remote HEAD so updates are still detected."""
+        d = tmp_path / "plugin"
+        d.mkdir()
+        (d / ".git").mkdir()
+
+        def side_effect(cmd, **kwargs):
+            m = mock.Mock()
+            if "remote" in cmd:
+                m.returncode = 0
+                m.stdout = "https://github.com/Org/repo\n"
+            elif "rev-parse" in cmd:
+                m.returncode = 0
+                m.stdout = "master\n"  # local branch is "master"
+            elif "ls-remote" in cmd and "--heads" in cmd:
+                # remote has no "master" branch
+                m.returncode = 0
+                m.stdout = ""
+            elif "ls-remote" in cmd:
+                # fallback: remote HEAD
+                m.returncode = 0
+                m.stdout = "deadbeef\tHEAD\n"
+            return m
+
+        mock_run.side_effect = side_effect
+        sha = get_remote_head_sha(d)
+        assert sha == "deadbeef"
+
 
 class TestCheckPluginUpdateAvailable:
     @mock.patch("src.plugins.sources.get_local_head_sha", return_value="abc")


### PR DESCRIPTION
## Root cause

PR #632 replaced `git clone --depth 1` with `git init + git fetch + git reset --hard FETCH_HEAD` to fix a CodeQL command-injection taint chain. The problem: `git clone` mirrors the remote's default branch name locally; `git init` does not — it creates whatever `init.defaultBranch` is configured for, which defaults to **`master`** in the `python:3.14-slim` container (git 2.47.3, no global config).

Most FiestaBoard plugin repos use **`main`** as their default branch. After install, the local clone sits on `master` but the remote has no `master` ref.

Failure path in `get_remote_head_sha`:
1. `git rev-parse --abbrev-ref HEAD` → `"master"`
2. `git ls-remote --heads <url> master` → empty (remote has no `master`)
3. Returns `None` → `check_plugin_update_available` returns `False`
4. Auto-update loop never fires

Users observed that plugins only updated after an uninstall + reinstall (which fetches the latest HEAD from scratch).

## Fix

- **`src/plugins/sources.py`** — When `git ls-remote --heads <url> <branch>` returns nothing, fall back to `git ls-remote <url> HEAD` to obtain the remote's advertised HEAD SHA. This resolves the update check correctly regardless of local/remote branch name mismatch, and also covers the detached HEAD edge case.
- **`tests/test_plugin_sources.py`** — New test `test_falls_back_to_remote_head_on_branch_mismatch` that mocks a local `master` branch against a remote that has no `master`, confirms the fallback returns the remote HEAD SHA.

## Test plan

- [x] `TestGetRemoteHeadSha` — all 4 tests pass (including new mismatch test)
- [x] Full `test_plugin_sources.py` + `test_plugin_registry.py` — 140 tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)