### PR TITLE
fix: pass device_type to get_dimensions in _send_trigger_content

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -507,7 +507,7 @@ class DisplayService:
         settings_service = get_settings_service()
         system_transition = settings_service.get_transition_settings()
 
-        dims = get_dimensions()
+        dims = get_dimensions(self._silence_device_type())
         board_array = text_to_board_array(content, rows=dims.rows, cols=dims.cols)
 
         success, was_sent = self.vb_client.send_characters(

--- a/tests/test_silence_mode_display.py
+++ b/tests/test_silence_mode_display.py
@@ -332,3 +332,31 @@ class TestCustomIndicatorTextAndPosition:
 
         assert sent is False
         service.vb_client.send_characters.assert_not_called()
+
+
+class TestSendTriggerContent:
+    """Tests for _send_trigger_content."""
+
+    def test_device_type_passed_to_get_dimensions(self, service):
+        """Regression #748: get_dimensions must receive device_type, not be called bare."""
+        with patch("src.main.get_settings_service") as mock_settings_svc, \
+             patch("src.main.get_dimensions") as mock_get_dims, \
+             patch.object(service, "_silence_device_type", return_value="note"):
+            mock_settings_svc.return_value.get_transition_settings.return_value = Mock(
+                strategy=None, step_interval_ms=500, step_size=1
+            )
+            mock_get_dims.return_value = Mock(rows=3, cols=15)
+
+            service._send_trigger_content("HELLO")
+
+        mock_get_dims.assert_called_once_with("note")
+
+    def test_returns_false_when_no_client(self):
+        svc = DisplayService()
+        svc.vb_client = None
+        assert svc._send_trigger_content("HELLO") is False
+
+    def test_returns_false_when_content_unchanged(self, service):
+        service._last_active_page_content = "SAME"
+        assert service._send_trigger_content("SAME") is False
+        service.vb_client.send_characters.assert_not_called()


### PR DESCRIPTION
## Summary

- Fixes `get_dimensions()` call in `_send_trigger_content` that was missing the required `device_type` argument, causing a crash logged as `Error checking active page`
- Reuses `_silence_device_type()` which reads the device type from the first configured board's settings (falling back to `flagship`) — the same pattern already used by the silence indicator

Closes #748

## Test plan

- [ ] Trigger content sends successfully to the board without an error in logs
- [ ] Falls back to `flagship` dimensions when no board is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)