### PR TITLE
fix: plugin updates don't stick (wrong FETCH_HEAD branch + 0.0.0 version)

### DIFF
--- a/src/plugins/loader.py
+++ b/src/plugins/loader.py
@@ -5,7 +5,6 @@ as well as external plugin directories (registry and custom git sources).
 """
 
 import importlib.util
-import json
 import logging
 import re
 import sys
@@ -28,25 +27,10 @@ DEFAULT_PLUGINS_DIR = "plugins"
 # FiestaBoard version compatibility helpers
 # ---------------------------------------------------------------------------
 
-_FIESTABOARD_VERSION: Optional[str] = None
-
-
 def _get_fiestaboard_version() -> str:
-    """Return the running FiestaBoard version from package.json."""
-    global _FIESTABOARD_VERSION
-    if _FIESTABOARD_VERSION is not None:
-        return _FIESTABOARD_VERSION
-
-    project_root = Path(__file__).parent.parent.parent
-    pkg_path = project_root / "package.json"
-    try:
-        with open(pkg_path, "r", encoding="utf-8") as f:
-            data = json.load(f)
-        _FIESTABOARD_VERSION = data.get("version", "0.0.0")
-    except Exception:
-        _FIESTABOARD_VERSION = "0.0.0"
-
-    return _FIESTABOARD_VERSION
+    """Return the running FiestaBoard version."""
+    from .. import __version__
+    return __version__
 
 
 def _parse_version(version_str: str) -> Tuple[int, int, int]:

--- a/src/plugins/sources.py
+++ b/src/plugins/sources.py
@@ -295,8 +295,13 @@ def clone_or_update_repo(
     plugins loaded from disk.
 
     Shallow clones (``--depth 1``) are handled correctly: we use
-    ``git fetch --depth=1 origin`` + ``git reset --hard FETCH_HEAD`` instead
-    of ``git pull --ff-only``, which fails on shallow histories.
+    ``git fetch --depth=1 origin HEAD`` + ``git reset --hard FETCH_HEAD``
+    instead of ``git pull --ff-only``, which fails on shallow histories.
+    Fetching the explicit ``HEAD`` refspec is critical: a bare ``git fetch
+    origin`` fetches all branches and sets ``FETCH_HEAD`` to an arbitrary one
+    (often alphabetically first, e.g. ``gh-pages`` before ``main``), causing
+    the subsequent reset to land on the wrong commit.  The next update-check
+    would then always see a SHA mismatch and report a spurious update.
 
     For fresh installs, rather than ``git clone`` (which would require passing
     a user-provided URL as a subprocess argument and trigger
@@ -348,7 +353,7 @@ def clone_or_update_repo(
     if os.path.isdir(os.path.join(_candidate, ".git")):
         try:
             subprocess.run(
-                ["git", "fetch", "--depth=1", "origin"],
+                ["git", "fetch", "--depth=1", "origin", "HEAD"],
                 cwd=_candidate,
                 check=True, capture_output=True, text=True,
                 timeout=120, env=env,
@@ -395,6 +400,8 @@ def clone_or_update_repo(
         _fetch_cmd = ["git", "fetch", "--depth=1", "origin"]
         if branch:
             _fetch_cmd.append(branch)
+        else:
+            _fetch_cmd.append("HEAD")
         subprocess.run(
             _fetch_cmd,
             cwd=_candidate,

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -541,41 +541,9 @@ def test_plugin_sources_returns_loaded_sources(tmp_path):
 # --- _get_fiestaboard_version ---
 
 
-def test_get_fiestaboard_version():
-    """_get_fiestaboard_version reads version from package.json."""
+def test_get_fiestaboard_version_matches_package_version():
+    """_get_fiestaboard_version returns the same value as src.__version__."""
+    import src
     import src.plugins.loader as loader_mod
 
-    old = loader_mod._FIESTABOARD_VERSION
-    try:
-        loader_mod._FIESTABOARD_VERSION = None
-        version = loader_mod._get_fiestaboard_version()
-        assert version != ""
-        assert "." in version
-    finally:
-        loader_mod._FIESTABOARD_VERSION = old
-
-
-def test_get_fiestaboard_version_caches():
-    """_get_fiestaboard_version caches the result."""
-    import src.plugins.loader as loader_mod
-
-    old = loader_mod._FIESTABOARD_VERSION
-    try:
-        loader_mod._FIESTABOARD_VERSION = "1.2.3"
-        assert loader_mod._get_fiestaboard_version() == "1.2.3"
-    finally:
-        loader_mod._FIESTABOARD_VERSION = old
-
-
-def test_get_fiestaboard_version_fallback_on_error():
-    """_get_fiestaboard_version returns 0.0.0 when file can't be read."""
-    import src.plugins.loader as loader_mod
-
-    old = loader_mod._FIESTABOARD_VERSION
-    try:
-        loader_mod._FIESTABOARD_VERSION = None
-        with patch("builtins.open", side_effect=OSError("not found")):
-            version = loader_mod._get_fiestaboard_version()
-        assert version == "0.0.0"
-    finally:
-        loader_mod._FIESTABOARD_VERSION = old
+    assert loader_mod._get_fiestaboard_version() == src.__version__

--- a/tests/test_plugin_sources.py
+++ b/tests/test_plugin_sources.py
@@ -234,7 +234,28 @@ class TestCloneOrUpdateRepo:
         calls = [c[0][0] for c in mock_run.call_args_list]
         assert "init" in calls[0]
         assert "fetch" in calls[1]
+        assert calls[1][-1] == "HEAD", "Fresh install without branch must fetch 'HEAD' explicitly"
         assert "reset" in calls[2]
+
+    @mock.patch("src.plugins.sources.subprocess.run")
+    def test_clone_fresh_with_explicit_branch(self, mock_run, tmp_path):
+        """Fresh install with an explicit branch fetches that branch, not HEAD."""
+        plugin_dest = tmp_path / "my_plugin"
+
+        def _fake_run(cmd, **kwargs):
+            if "init" in cmd:
+                plugin_dest.mkdir(parents=True, exist_ok=True)
+                (plugin_dest / ".git").mkdir(exist_ok=True)
+            return mock.MagicMock()
+
+        mock_run.side_effect = _fake_run
+        ok, err = clone_or_update_repo(
+            "https://github.com/Org/repo", "my_plugin", branch="develop", external_dir=tmp_path
+        )
+        assert ok, f"expected ok but got err={err!r}"
+        fetch_cmd = mock_run.call_args_list[1][0][0]
+        assert "fetch" in fetch_cmd
+        assert fetch_cmd[-1] == "develop", "Explicit branch should be the final fetch argument"
 
     @mock.patch("src.plugins.sources.subprocess.run")
     def test_fetch_reset_existing(self, mock_run, tmp_path):
@@ -251,6 +272,10 @@ class TestCloneOrUpdateRepo:
         reset_cmd = mock_run.call_args_list[1][0][0]
         assert "fetch" in fetch_cmd
         assert "--depth=1" in fetch_cmd
+        # Must fetch "HEAD" explicitly so repos with multiple branches (e.g.
+        # gh-pages) don't leave FETCH_HEAD pointing at a non-default branch,
+        # which would cause every subsequent update-check to see a SHA mismatch.
+        assert fetch_cmd[-1] == "HEAD", "Update path must fetch 'origin HEAD', not bare 'origin'"
         assert "reset" in reset_cmd
         assert "FETCH_HEAD" in reset_cmd
 


### PR DESCRIPTION
## Summary

Fixes two bugs that caused "Update All" to report success but leave plugin versions unchanged, with the same updates reappearing on the next check.

- **Root cause (Bug 1):** `git fetch --depth=1 origin` without a refspec fetches all remote branches and sets `FETCH_HEAD` to an arbitrary one — often alphabetically first (e.g. `gh-pages` before `main`). The subsequent `git reset --hard FETCH_HEAD` lands on the wrong commit. The next update-check then always sees a SHA mismatch between the wrong local commit and the remote's real `HEAD`, so updates appear perpetually available. Fixed by passing `HEAD` as an explicit refspec in both the update path and the fresh-install-without-branch path.

- **Secondary (Bug 2):** `_get_fiestaboard_version()` read from `package.json` via a path that doesn't resolve correctly inside the Docker container, silently falling back to `"0.0.0"` and logging a spurious version-incompatibility warning for every plugin with a `fiestaboard_version` constraint. Fixed by importing `__version__` from `src/__init__.py` — the single authoritative source — eliminating the file I/O and the fallback entirely.

Closes #744

## Test plan

- [ ] `tests/test_plugin_sources.py` — `test_fetch_reset_existing` now asserts `fetch_cmd[-1] == "HEAD"`; `test_clone_fresh` asserts the same for fresh installs without a branch; new `test_clone_fresh_with_explicit_branch` confirms an explicit branch still takes priority
- [ ] `tests/test_plugin_loader.py` — three stale `_get_fiestaboard_version` tests (file-read, cache, 0.0.0 fallback) replaced with one that asserts the return value equals `src.__version__`
- [ ] All 103 tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)