### PR TITLE
fix: remove server-side update-check cache that caused stale results after restart

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -1513,37 +1513,15 @@ async def system_update_check():
     return await _perform_update_check()
 
 
-_UPDATE_CHECK_CACHE_TTL = 3600  # seconds
-
-
 async def _perform_update_check() -> "UpdateCheckResponse":
     """Run the actual update check against Docker Hub / GitHub Releases.
 
     Extracted from the HTTP handler so the background scheduler (auto-update
     interval) can reuse it without going through the network stack.  Records
     ``last_check`` in the system update state file on every successful query.
-
-    Server-side result cache (TTL: 1 hour) prevents repeated network calls when
-    the frontend refreshes quickly or the Pi has slow/no outbound internet.
     Both source checks run in parallel to halve worst-case latency.
     """
     is_production = os.getenv("PRODUCTION", "false").lower() == "true"
-
-    # --- Server-side cache: return the stored result if it is still fresh ----
-    try:
-        _cached_state = _system_update_state_load()
-        _cached_result = _cached_state.get("cached_result")
-        _last_check_raw = _cached_state.get("last_check")
-        if _cached_result and _last_check_raw:
-            _last_check_dt = datetime.fromisoformat(_last_check_raw)
-            if _last_check_dt.tzinfo is None:
-                _last_check_dt = _last_check_dt.replace(tzinfo=timezone.utc)
-            _age = (datetime.now(timezone.utc) - _last_check_dt).total_seconds()
-            if _age < _UPDATE_CHECK_CACHE_TTL:
-                logger.debug("system/update-check: returning cached result (age=%.0fs)", _age)
-                return UpdateCheckResponse(**_cached_result)
-    except Exception as _ce:
-        logger.debug("Could not read update-check cache (non-fatal): %s", _ce)
 
     try:
         # Run both source checks in parallel; prefer Docker Hub, fall back to GitHub.
@@ -1558,13 +1536,6 @@ async def _perform_update_check() -> "UpdateCheckResponse":
             try:
                 _state = _system_update_state_load()
                 _state["last_check"] = datetime.now(timezone.utc).isoformat()
-                _state["cached_result"] = {
-                    "current_version": __version__,
-                    "latest_version": latest_version,
-                    "update_available": update_available,
-                    "package_url": GITHUB_PACKAGE_URL,
-                    "is_production": is_production,
-                }
                 _system_update_state_save(_state)
             except Exception as e:
                 logger.debug("Could not persist update-check result (non-fatal): %s", e, exc_info=True)

--- a/tests/test_system_endpoints.py
+++ b/tests/test_system_endpoints.py
@@ -29,15 +29,7 @@ def client():
 
 @pytest.fixture(autouse=True)
 def _isolate_state_file(tmp_path):
-    """Give every test its own state file so cached update-check results cannot
-    leak between tests.
-
-    Each test that exercises _perform_update_check needs a clean slate so the
-    cached_result from a previous test doesn't short-circuit network calls that
-    the test has mocked.  Tests that need to verify file persistence (e.g.
-    TestSystemUpdateAutoToggle) use monkeypatch.setattr to redirect
-    SYSTEM_UPDATE_STATE_FILE to their own path, which overrides this fixture.
-    """
+    """Give every test its own state file to prevent state leaking between tests."""
     with patch("src.api_server.SYSTEM_UPDATE_STATE_FILE", tmp_path / "update_state.json"):
         yield
 


### PR DESCRIPTION
## Summary

- Removes the 1-hour server-side result cache from `_perform_update_check()` that was persisted to `data/.system-update.json`
- The cached `update_available: false` result survived container restarts (the `data/` dir is volume-mounted), so after an OS upgrade the device would return stale results and never surface the update notification
- The client-side `staleTime: 1h` in react-query already prevents the browser from hammering the endpoint on every render, so the server-side cache provided minimal additional protection
- `last_check` is still written on every successful check so the auto-update interval scheduler continues to work correctly

## Root cause

Introduced in #746 (May 11) alongside the Pi event-loop fix. The cache TTL is 1 hour but persists across process restarts — so an OS upgrade that takes less than an hour would leave the device returning a stale `update_available: false` from before 5.7.9 shipped.

## Test plan

- [ ] Verify `/system/update-check` returns a live result on every call (no `cached_result` key written to state file)
- [ ] Verify auto-update interval scheduler (`_is_update_check_due`) still reads `last_check` correctly
- [ ] Run `/test-api` to confirm existing update-check tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)