### PR TITLE
Fix GitHub plugin install 400 error with no actionable feedback

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -7376,15 +7376,12 @@ async def install_external_plugin(request: ExternalPluginInstallRequest):
             status_code=503, detail="Plugin system is not available."
         )
 
-    # Constrain user-provided branch names to a small safe subset so command
-    # arguments are selected from trusted values at this API boundary.
     safe_branch = request.branch or ""
-    allowed_branches = {"", "main", "master", "develop"}
-    if safe_branch not in allowed_branches:
-        raise HTTPException(
-            status_code=400,
-            detail="branch must be one of: main, master, develop",
-        )
+    if safe_branch:
+        from .plugins.sources import _validate_git_ref
+        _ok, _err = _validate_git_ref(safe_branch)
+        if not _ok:
+            raise HTTPException(status_code=400, detail=_err)
 
     safe_plugin_id = _sanitize_optional_plugin_id(request.plugin_id)
 

--- a/src/plugins/sources.py
+++ b/src/plugins/sources.py
@@ -366,12 +366,10 @@ def clone_or_update_repo(
             )
             logger.info("Updated existing plugin clone at %s", _candidate)
             return True, ""
-        except subprocess.CalledProcessError as exc:
-            stderr = (exc.stderr or "").strip()
+        except subprocess.SubprocessError as exc:
+            stderr = (getattr(exc, "stderr", None) or "").strip()
             msg = f"git fetch/reset failed: {stderr}" if stderr else f"git fetch/reset failed: {exc}"
             return False, msg
-        except subprocess.SubprocessError as exc:
-            return False, f"git fetch/reset failed: {exc}"
 
     # ── Fresh install — validate URL and optional branch ──────────────────────
     ok, err = _validate_git_url(repo_url)
@@ -420,14 +418,11 @@ def clone_or_update_repo(
         )
         logger.info("Installed external plugin repository to %s", _candidate)
         return True, ""
-    except subprocess.CalledProcessError as exc:
-        shutil.rmtree(_candidate, ignore_errors=True)
-        stderr = (exc.stderr or "").strip()
-        msg = f"git clone failed: {stderr}" if stderr else f"git clone failed: {exc}"
-        return False, msg
     except subprocess.SubprocessError as exc:
         shutil.rmtree(_candidate, ignore_errors=True)
-        return False, f"git clone failed: {exc}"
+        stderr = (getattr(exc, "stderr", None) or "").strip()
+        msg = f"git clone failed: {stderr}" if stderr else f"git clone failed: {exc}"
+        return False, msg
     except OSError as exc:
         shutil.rmtree(_candidate, ignore_errors=True)
         return False, f"git clone failed (I/O error): {exc}"

--- a/src/plugins/sources.py
+++ b/src/plugins/sources.py
@@ -366,6 +366,10 @@ def clone_or_update_repo(
             )
             logger.info("Updated existing plugin clone at %s", _candidate)
             return True, ""
+        except subprocess.CalledProcessError as exc:
+            stderr = (exc.stderr or "").strip()
+            msg = f"git fetch/reset failed: {stderr}" if stderr else f"git fetch/reset failed: {exc}"
+            return False, msg
         except subprocess.SubprocessError as exc:
             return False, f"git fetch/reset failed: {exc}"
 
@@ -416,6 +420,11 @@ def clone_or_update_repo(
         )
         logger.info("Installed external plugin repository to %s", _candidate)
         return True, ""
+    except subprocess.CalledProcessError as exc:
+        shutil.rmtree(_candidate, ignore_errors=True)
+        stderr = (exc.stderr or "").strip()
+        msg = f"git clone failed: {stderr}" if stderr else f"git clone failed: {exc}"
+        return False, msg
     except subprocess.SubprocessError as exc:
         shutil.rmtree(_candidate, ignore_errors=True)
         return False, f"git clone failed: {exc}"

--- a/tests/test_api_coverage_extended.py
+++ b/tests/test_api_coverage_extended.py
@@ -585,6 +585,36 @@ class TestPluginManagement:
             resp = client.post("/plugins/install", json={"repository": "https://github.com/example/repo"})
         assert resp.status_code == 503
 
+    def test_install_plugin_arbitrary_branch_accepted(self, client):
+        mock_registry = Mock()
+        mock_registry.install_from_git.return_value = []
+        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
+             patch("src.api_server.get_plugin_registry", return_value=mock_registry), \
+             patch("src.plugins.sources.repo_name_from_url", return_value="repo"), \
+             patch("src.plugins.sources.plugin_id_from_repo_name", return_value="repo"):
+            resp = client.post("/plugins/install", json={
+                "repository": "https://github.com/example/repo",
+                "branch": "release/2.0",
+            })
+        assert resp.status_code == 200
+
+    def test_install_plugin_invalid_branch_rejected(self, client):
+        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True):
+            resp = client.post("/plugins/install", json={
+                "repository": "https://github.com/example/repo",
+                "branch": "-bad-branch",
+            })
+        assert resp.status_code == 400
+
+    def test_install_plugin_error_detail_in_response(self, client):
+        mock_registry = Mock()
+        mock_registry.install_from_git.return_value = ["fatal: repository not found"]
+        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
+             patch("src.api_server.get_plugin_registry", return_value=mock_registry):
+            resp = client.post("/plugins/install", json={"repository": "https://github.com/example/repo"})
+        assert resp.status_code == 400
+        assert "repository not found" in resp.json()["detail"]
+
 
 # ---------------------------------------------------------------------------
 # Generic Data Test Fetch (lines 4985-5055)

--- a/tests/test_plugin_sources.py
+++ b/tests/test_plugin_sources.py
@@ -370,6 +370,40 @@ class TestCloneOrUpdateRepoPathSafety:
         assert err == ""
 
 
+class TestCloneOrUpdateRepoErrorMessages:
+    """Stderr from CalledProcessError should appear in the returned error string."""
+
+    @mock.patch("src.plugins.sources.subprocess.run")
+    def test_fresh_clone_includes_stderr(self, mock_run, tmp_path):
+        exc = subprocess.CalledProcessError(128, ["git", "fetch"])
+        exc.stderr = "fatal: repository 'https://github.com/x/y' not found"
+        mock_run.side_effect = exc
+        ok, err = clone_or_update_repo("https://github.com/x/y", "my_plugin", external_dir=tmp_path)
+        assert not ok
+        assert "not found" in err
+
+    @mock.patch("src.plugins.sources.subprocess.run")
+    def test_update_includes_stderr(self, mock_run, tmp_path):
+        dest = tmp_path / "my_plugin"
+        dest.mkdir()
+        (dest / ".git").mkdir()
+        exc = subprocess.CalledProcessError(128, ["git", "fetch"])
+        exc.stderr = "fatal: unable to access"
+        mock_run.side_effect = exc
+        ok, err = clone_or_update_repo("", "my_plugin", external_dir=tmp_path)
+        assert not ok
+        assert "unable to access" in err
+
+    @mock.patch("src.plugins.sources.subprocess.run")
+    def test_empty_stderr_falls_back_to_exc_str(self, mock_run, tmp_path):
+        exc = subprocess.CalledProcessError(128, ["git", "fetch"])
+        exc.stderr = ""
+        mock_run.side_effect = exc
+        ok, err = clone_or_update_repo("https://github.com/x/y", "my_plugin", external_dir=tmp_path)
+        assert not ok
+        assert "clone" in err and "failed" in err
+
+
 # ── install helpers ──────────────────────────────────────────────────────────
 
 

--- a/web/src/__tests__/plugin-instances.test.ts
+++ b/web/src/__tests__/plugin-instances.test.ts
@@ -89,7 +89,7 @@ describe("Plugin Instance API", () => {
           })
         )
       );
-      await expect(api.createPluginInstance("weather", "sf")).rejects.toThrow("400");
+      await expect(api.createPluginInstance("weather", "sf")).rejects.toThrow("Label already exists");
     });
 
     it("throws when plugin system unavailable (503)", async () => {
@@ -140,7 +140,7 @@ describe("Plugin Instance API", () => {
           })
         )
       );
-      await expect(api.deletePluginInstance("weather", "sf")).rejects.toThrow("400");
+      await expect(api.deletePluginInstance("weather", "sf")).rejects.toThrow("Instance not found");
     });
 
     it("throws when plugin system unavailable (503)", async () => {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1083,7 +1083,16 @@ async function fetchApi<T>(path: string, options?: RequestInit & { timeoutMs?: n
     throw err;
   }
   if (!res.ok) {
-    throw new Error(`API error: ${res.status} ${res.statusText}`);
+    let detail = `${res.status} ${res.statusText}`;
+    try {
+      const body = await res.json();
+      if (body?.detail) {
+        detail = typeof body.detail === "string" ? body.detail : JSON.stringify(body.detail);
+      }
+    } catch {
+      // ignore JSON parse errors; use status text fallback
+    }
+    throw new Error(detail);
   }
   return res.json();
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1083,7 +1083,7 @@ async function fetchApi<T>(path: string, options?: RequestInit & { timeoutMs?: n
     throw err;
   }
   if (!res.ok) {
-    let detail = `${res.status} ${res.statusText}`;
+    let detail = `API error: ${res.status} ${res.statusText}`;
     try {
       const body = await res.json();
       if (body?.detail) {


### PR DESCRIPTION
Fixes #760

## Summary

- **`web/src/lib/api.ts`** — `fetchApi` now reads the response body on non-OK responses and surfaces the `detail` field. Users previously saw `"API error: 400 Bad Request"`; they now see the actual reason (e.g. `"fatal: repository 'https://...' not found"`).
- **`src/api_server.py`** — Replaced the hardcoded branch whitelist `{main, master, develop}` on `/plugins/install` with a call to `_validate_git_ref()`. Any branch with valid git ref characters (e.g. `release/2.0`, `v1.0`) now works.
- **`src/plugins/sources.py`** — `CalledProcessError` is now caught before the generic `SubprocessError` in both the fresh-clone and update paths, so git's `stderr` (e.g. `"fatal: repository not found"`) is included in the returned error string.

## Test plan

- [ ] New `TestCloneOrUpdateRepoErrorMessages` tests verify stderr is surfaced for both fresh-clone and update failures
- [ ] `test_install_plugin_arbitrary_branch_accepted` — `release/2.0` now returns 200
- [ ] `test_install_plugin_invalid_branch_rejected` — ref starting with `-` still returns 400
- [ ] `test_install_plugin_error_detail_in_response` — 400 body `detail` contains the actual git error
- [ ] All 70 pre-existing `test_plugin_sources.py` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)