### PR TITLE
Fix responsive update banner and silence schedule toggle alignment

### DIFF
--- a/web/src/components/general-settings.tsx
+++ b/web/src/components/general-settings.tsx
@@ -276,13 +276,7 @@ export function GeneralSettings() {
               </div>
             ) : (
               <>
-                <div className="flex items-center gap-3">
-                  <Switch
-                    checked={silenceEnabled}
-                    onCheckedChange={handleSilenceToggle}
-                    disabled={isSaving}
-                    id="silence-enabled"
-                  />
+                <div className="flex items-center justify-between gap-3">
                   <div>
                     <label htmlFor="silence-enabled" className="text-sm font-medium cursor-pointer">
                       {t("silenceScheduleLabel")}
@@ -291,10 +285,16 @@ export function GeneralSettings() {
                       {t("silenceScheduleDescription")}
                     </p>
                   </div>
+                  <Switch
+                    checked={silenceEnabled}
+                    onCheckedChange={handleSilenceToggle}
+                    disabled={isSaving}
+                    id="silence-enabled"
+                  />
                 </div>
 
                 {silenceEnabled && (
-                  <div className="mt-4 ml-[52px]">
+                  <div className="mt-4">
                     <div className="grid grid-cols-2 gap-4">
                       <div className="space-y-2">
                         <Label htmlFor="silence-start" className="text-xs">{t("startTimeLabel")}</Label>

--- a/web/src/components/settings/system-update.tsx
+++ b/web/src/components/settings/system-update.tsx
@@ -77,7 +77,7 @@ export function SystemUpdate() {
     <TooltipProvider>
       <Alert className="border-warning/50 bg-warning/10">
         <ArrowUpCircle className="h-4 w-4 text-warning" />
-        <AlertDescription className="flex items-center justify-between gap-4">
+        <AlertDescription className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
           <div className="flex items-center gap-2 flex-wrap">
             <span className="text-sm font-medium">{t("updateAvailable")}</span>
             <Badge variant="secondary" className="text-xs">
@@ -87,7 +87,7 @@ export function SystemUpdate() {
               {t("youAreRunning", { currentVersion: updateCheck.current_version })}
             </span>
           </div>
-          <div className="flex items-center gap-2 flex-shrink-0">
+          <div className="flex items-center gap-2">
             <Button variant="outline" size="sm" asChild>
               <a
                 href={updateCheck.package_url}


### PR DESCRIPTION
## Summary

- Update banner (`system-update.tsx`) now wraps buttons onto a new line on narrow screens instead of overflowing; removed `flex-shrink-0` from the buttons container and added `flex-wrap` to the outer row
- Silence Schedule toggle in general settings moved to the right side to match every other toggle on the Settings page; removed the now-unnecessary `ml-[52px]` left-indent from the expanded config panel

## Test plan

- [ ] Narrow the Settings page window and confirm the update banner wraps the buttons below the version text rather than overflowing
- [ ] Confirm the Silence Schedule toggle appears on the right side, aligned with MQTT and other toggles
- [ ] Enable Silence Schedule and confirm the expanded time/mode pickers render correctly without the old left indent

🤖 Generated with [Claude Code](https://claude.com/claude-code)