### PR TITLE
Fix Generic Data Test & Preview always returning 400

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -7721,7 +7721,25 @@ async def generic_data_test_fetch(request: dict):
 
     # Validate the URL: scheme must be http(s) and credentials are not allowed
     # (defence against SSRF/credential leaks).
-    _validate_request_url(url)
+    _SSRF_BLOCKED_DETAILS = {
+        "URL must not target internal network resources",
+        "URL host is not allowed",
+        "URL host resolves to a non-public IP",
+    }
+    try:
+        _validate_request_url(url)
+    except HTTPException as _url_exc:
+        if _url_exc.detail in _SSRF_BLOCKED_DETAILS:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Test & Preview can't reach local or private network addresses "
+                    f"({urlparse(url).hostname}). This restriction only applies to the "
+                    "preview feature — your plugin will still fetch this URL normally "
+                    "when your page runs."
+                ),
+            )
+        raise
     # Re-derive url from a strict allowlist regex so the downstream HTTP call is not
     # tracked as tainted by static-analysis tools (py/full-ssrf).
     _safe_url_m = re.fullmatch(

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -7734,12 +7734,10 @@ async def generic_data_test_fetch(request: dict):
 
     host = urlparse(url).hostname or ""
     allowed_hosts = _get_generic_data_allowed_hosts()
-    if not allowed_hosts:
-        raise HTTPException(
-            status_code=400,
-            detail="No allowed hosts configured for generic-data test fetch",
-        )
-    if not _is_host_allowed(host, allowed_hosts):
+    # When GENERIC_DATA_ALLOWED_HOSTS is set, enforce the allowlist.
+    # When it is unset, _validate_request_url above already blocks SSRF
+    # (private IPs, loopback, .local) so we allow any public host.
+    if allowed_hosts and not _is_host_allowed(host, allowed_hosts):
         raise HTTPException(
             status_code=400,
             detail="URL host is not in the allowlist",

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -568,3 +568,27 @@ class TestSSRFProtection:
              patch("requests.request", return_value=mock_resp):
             resp = client.post("/generic-data/test-fetch", json={"url": "https://api.example.com/data"})
         assert resp.status_code == 200
+
+    def test_allows_public_domain_when_no_allowlist_configured(self, client, mock_cm):
+        """When GENERIC_DATA_ALLOWED_HOSTS is unset, any public host should be allowed."""
+        mock_resp = Mock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.content = b'{"ok": true}'
+        mock_resp.json.return_value = {"ok": True}
+        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
+             patch("src.api_server.get_config_manager", return_value=mock_cm), \
+             patch("src.api_server._get_generic_data_allowed_hosts", return_value=[]), \
+             patch("socket.getaddrinfo", return_value=self._PUBLIC_ADDR_INFO), \
+             patch("requests.request", return_value=mock_resp):
+            resp = client.post("/generic-data/test-fetch", json={"url": "https://api.example.com/data"})
+        assert resp.status_code == 200
+
+    def test_rejects_host_not_in_allowlist(self, client, mock_cm):
+        """When GENERIC_DATA_ALLOWED_HOSTS is set, hosts outside the list are rejected."""
+        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
+             patch("src.api_server.get_config_manager", return_value=mock_cm), \
+             patch("src.api_server._get_generic_data_allowed_hosts", return_value=["myapi.com"]), \
+             patch("socket.getaddrinfo", return_value=self._PUBLIC_ADDR_INFO):
+            resp = client.post("/generic-data/test-fetch", json={"url": "https://api.example.com/data"})
+        assert resp.status_code == 400
+        assert "allowlist" in resp.json()["detail"]

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -491,6 +491,10 @@ class TestSSRFProtection:
     def test_rejects_dot_local_domain(self, client, mock_cm):
         resp = self._post(client, "http://mydevice.local/api", mock_cm)
         assert resp.status_code == 400
+        detail = resp.json()["detail"]
+        assert "Test & Preview" in detail
+        assert "mydevice.local" in detail
+        assert "plugin will still fetch" in detail
 
     # --- Blocked: loopback IP ---
 


### PR DESCRIPTION
## Summary

- Fixes #747 — the "Test & Preview" button on the Generic Data plugin always returned `400 Bad Request` for all users who hadn't set the undocumented `GENERIC_DATA_ALLOWED_HOSTS` env var
- Root cause: the `/generic-data/test-fetch` endpoint required `GENERIC_DATA_ALLOWED_HOSTS` to be non-empty, immediately returning 400 with "No allowed hosts configured" when unset (the default for all installations)
- Fix: make the allowlist optional — when unset, any URL that passes the existing SSRF validation (`_validate_request_url`) is allowed through; when set, it still acts as a strict allowlist

The actual page-level data fetch (used when a page renders) calls the plugin's `fetch_data()` directly and was never affected — only the test-fetch endpoint had this gate, which is why the plugin "works" on a page but "Test & Preview" always fails.

## Test plan

- [x] `TestSSRFProtection::test_allows_public_domain_when_no_allowlist_configured` — new test: empty allowlist lets public hosts through
- [x] `TestSSRFProtection::test_rejects_host_not_in_allowlist` — new test: non-empty allowlist still rejects unlisted hosts
- [x] All 25 existing SSRF and generic-data test-fetch tests pass
- [x] Private IPs, loopback, `.local` domains still blocked by `_validate_request_url` regardless of allowlist state

🤖 Generated with [Claude Code](https://claude.com/claude-code)