### PR TITLE
feat: refresh board state after page send + resend button for external updates

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -2549,7 +2549,7 @@ async def refresh_display():
         raise HTTPException(status_code=503, detail="Service not initialized")
     
     try:
-        service.fetch_and_display()
+        service.check_and_send_active_page()
         return {"status": "success", "message": "Display refreshed successfully"}
     except Exception as e:
         logger.error(f"Error refreshing display: {e}")
@@ -2687,6 +2687,7 @@ async def send_message(request: MessageRequest):
         )
         if success:
             if was_sent:
+                service.request_board_refresh()
                 return {"status": "success", "message": "Message sent successfully"}
             else:
                 return {"status": "success", "message": "Message unchanged, no update needed", "skipped": True}
@@ -4848,7 +4849,9 @@ async def set_active_page(request: dict):
             sent_to_board = was_sent
             if not success:
                 logger.warning(f"Failed to send active page to board: {page_id}")
-    
+            elif was_sent:
+                service.request_board_refresh()
+
     return {
         "status": "success",
         "page_id": page_id,
@@ -5978,7 +5981,9 @@ async def send_page(page_id: str, target: Optional[str] = None):
             sent_to_board = was_sent
             if not success:
                 raise HTTPException(status_code=500, detail="Failed to send to board")
-    
+            if was_sent:
+                service.request_board_refresh()
+
     return {
         "status": "success",
         "page_id": page_id,
@@ -6609,12 +6614,12 @@ async def force_refresh():
     if not service:
         raise HTTPException(status_code=503, detail="Service not initialized")
     
-    # Clear cache to force send
+    # Clear cache to force send even if content unchanged
     if service.vb_client:
         service.vb_client.clear_cache()
-    
+
     try:
-        service.fetch_and_display()
+        service.check_and_send_active_page()
         return {"status": "success", "message": "Display force-refreshed successfully"}
     except Exception as e:
         logger.error(f"Error force-refreshing display: {e}")

--- a/src/main.py
+++ b/src/main.py
@@ -48,6 +48,7 @@ class DisplayService:
         self._polled_characters: Optional[List[List[int]]] = None
         self._polled_at: Optional[float] = None
         self._poll_thread: Optional[threading.Thread] = None
+        self._pending_refresh_timer: Optional[threading.Timer] = None
     
     def _build_board_clients(self):
         """Build board clients from settings.boards (first with connection) or Config. Sets self.vb_client."""
@@ -116,6 +117,29 @@ class DisplayService:
             except Exception as e:
                 logger.debug(f"Board state poll failed: {e}")
             time.sleep(interval)
+
+    def request_board_refresh(self, delay_seconds: float = 3.0) -> None:
+        """Schedule a one-shot board-state read shortly after a page is sent.
+
+        Cancels any pending refresh so rapid sends don't stack up timers.
+        """
+        if self._pending_refresh_timer is not None and self._pending_refresh_timer.is_alive():
+            self._pending_refresh_timer.cancel()
+
+        def _do_refresh() -> None:
+            if self.vb_client:
+                try:
+                    chars = self.vb_client.read_current_message()
+                    if chars:
+                        self._polled_characters = chars
+                        self._polled_at = time.time()
+                        logger.debug("Post-send board state refresh completed")
+                except Exception as e:
+                    logger.debug(f"Post-send board state refresh failed: {e}")
+
+        self._pending_refresh_timer = threading.Timer(delay_seconds, _do_refresh)
+        self._pending_refresh_timer.daemon = True
+        self._pending_refresh_timer.start()
 
     def initialize(self) -> bool:
         """Initialize all components."""
@@ -338,6 +362,7 @@ class DisplayService:
 
                 if was_sent:
                     logger.info(f"Active page sent to board: {active_page_id}")
+                    self.request_board_refresh()
                 else:
                     logger.debug("Active page unchanged at board level")
                 return was_sent

--- a/src/mqtt/commands.py
+++ b/src/mqtt/commands.py
@@ -113,12 +113,8 @@ class CommandHandler:
     def _handle_refresh_display(self) -> None:
         from src.api_server import get_service
         service = get_service()
-        if service:
-            # Main DisplayService uses check_and_send_active_page for refresh
-            if hasattr(service, "fetch_and_display"):
-                service.fetch_and_display()
-            elif hasattr(service, "check_and_send_active_page"):
-                service.check_and_send_active_page()
+        if service and hasattr(service, "check_and_send_active_page"):
+            service.check_and_send_active_page()
         self._mark_display_updated()
         self._publish_event("display_updated", "page_refreshed")
 

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -34,7 +34,7 @@ def mock_service():
     service.running = True
     service.initialize.return_value = True
     service.reinitialize_board_client.return_value = None
-    service.fetch_and_display.return_value = None
+    service.check_and_send_active_page.return_value = None
     with patch("src.api_server.get_service", return_value=service):
         yield service
 
@@ -1081,20 +1081,20 @@ class TestForceRefresh:
         response = client.post("/force-refresh")
         assert response.status_code == 200
         mock_service.vb_client.clear_cache.assert_called_once()
-        mock_service.fetch_and_display.assert_called_once()
+        mock_service.check_and_send_active_page.assert_called_once()
 
     def test_force_refresh_no_vb_client(self, client):
         """Force refresh when vb_client is None still works."""
         service = Mock()
         service.vb_client = None
-        service.fetch_and_display.return_value = None
+        service.check_and_send_active_page.return_value = None
         with patch("src.api_server.get_service", return_value=service):
             response = client.post("/force-refresh")
             assert response.status_code == 200
 
     def test_force_refresh_exception(self, client, mock_service):
         """Exception during refresh → 500."""
-        mock_service.fetch_and_display.side_effect = RuntimeError("boom")
+        mock_service.check_and_send_active_page.side_effect = RuntimeError("boom")
         response = client.post("/force-refresh")
         assert response.status_code == 500
 

--- a/tests/test_api_extended.py
+++ b/tests/test_api_extended.py
@@ -1186,7 +1186,7 @@ class TestCacheEndpoints:
         assert response.status_code == 200
 
     def test_force_refresh_error(self, client, mock_service):
-        mock_service.fetch_and_display.side_effect = Exception("Refresh failed")
+        mock_service.check_and_send_active_page.side_effect = Exception("Refresh failed")
         response = client.post("/force-refresh")
         assert response.status_code == 500
 
@@ -1220,7 +1220,7 @@ class TestServiceLifecycle:
         assert response.status_code == 503
 
     def test_refresh_error(self, client, mock_service):
-        mock_service.fetch_and_display.side_effect = Exception("Display error")
+        mock_service.check_and_send_active_page.side_effect = Exception("Display error")
         response = client.post("/refresh")
         assert response.status_code == 500
 

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -460,7 +460,10 @@
     "toastSetDefaultFailed": "Standardseite konnte nicht festgelegt werden",
     "toastSwitchSuccess": "Zur aktiven Seite gewechselt",
     "toastSwitchFailed": "Seitenwechsel fehlgeschlagen",
-    "updatedExternally": "Updated externally"
+    "updatedExternally": "Updated externally",
+    "resendToBoard": "Resend FiestaBoard page",
+    "toastResendSuccess": "Page resent to board",
+    "toastResendFailed": "Failed to resend page"
   },
   "serviceStatus": {
     "disconnectedAriaLabel": "App nicht erreichbar. Netzwerk prüfen oder prüfen, ob FiestaBoard läuft.",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -460,7 +460,10 @@
     "toastSetDefaultFailed": "Failed to set default page",
     "toastSwitchSuccess": "Switched to active page",
     "toastSwitchFailed": "Failed to switch page",
-    "updatedExternally": "Updated externally"
+    "updatedExternally": "Updated externally",
+    "resendToBoard": "Resend FiestaBoard page",
+    "toastResendSuccess": "Page resent to board",
+    "toastResendFailed": "Failed to resend page"
   },
   "serviceStatus": {
     "disconnectedAriaLabel": "Cannot reach the app. Check your network or that FiestaBoard is running.",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -460,7 +460,10 @@
     "toastSetDefaultFailed": "Error al establecer la página predeterminada",
     "toastSwitchSuccess": "Se cambió a la página activa",
     "toastSwitchFailed": "Error al cambiar la página",
-    "updatedExternally": "Updated externally"
+    "updatedExternally": "Updated externally",
+    "resendToBoard": "Resend FiestaBoard page",
+    "toastResendSuccess": "Page resent to board",
+    "toastResendFailed": "Failed to resend page"
   },
   "serviceStatus": {
     "disconnectedAriaLabel": "No se puede conectar con la aplicación. Comprueba tu red o que FiestaBoard esté en ejecución.",

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -460,7 +460,10 @@
     "toastSetDefaultFailed": "Échec de la définition de la page par défaut",
     "toastSwitchSuccess": "Page active changée",
     "toastSwitchFailed": "Échec du changement de page",
-    "updatedExternally": "Updated externally"
+    "updatedExternally": "Updated externally",
+    "resendToBoard": "Resend FiestaBoard page",
+    "toastResendSuccess": "Page resent to board",
+    "toastResendFailed": "Failed to resend page"
   },
   "serviceStatus": {
     "disconnectedAriaLabel": "Application inaccessible. Vérifiez votre réseau ou que FiestaBoard est en cours d'exécution.",

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -460,7 +460,10 @@
     "toastSetDefaultFailed": "Impossibile impostare la pagina predefinita",
     "toastSwitchSuccess": "Passato alla pagina attiva",
     "toastSwitchFailed": "Impossibile cambiare pagina",
-    "updatedExternally": "Updated externally"
+    "updatedExternally": "Updated externally",
+    "resendToBoard": "Resend FiestaBoard page",
+    "toastResendSuccess": "Page resent to board",
+    "toastResendFailed": "Failed to resend page"
   },
   "serviceStatus": {
     "disconnectedAriaLabel": "Impossibile raggiungere l'app. Controlla la rete o che FiestaBoard sia in esecuzione.",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -460,7 +460,10 @@
     "toastSetDefaultFailed": "デフォルトページの設定に失敗しました",
     "toastSwitchSuccess": "アクティブページに切り替えました",
     "toastSwitchFailed": "ページの切り替えに失敗しました",
-    "updatedExternally": "Updated externally"
+    "updatedExternally": "Updated externally",
+    "resendToBoard": "Resend FiestaBoard page",
+    "toastResendSuccess": "Page resent to board",
+    "toastResendFailed": "Failed to resend page"
   },
   "serviceStatus": {
     "disconnectedAriaLabel": "アプリに接続できません。ネットワークまたは FiestaBoard の起動を確認してください。",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -460,7 +460,10 @@
     "toastSetDefaultFailed": "기본 페이지 설정에 실패했습니다",
     "toastSwitchSuccess": "활성 페이지로 전환되었습니다",
     "toastSwitchFailed": "페이지 전환에 실패했습니다",
-    "updatedExternally": "Updated externally"
+    "updatedExternally": "Updated externally",
+    "resendToBoard": "Resend FiestaBoard page",
+    "toastResendSuccess": "Page resent to board",
+    "toastResendFailed": "Failed to resend page"
   },
   "serviceStatus": {
     "disconnectedAriaLabel": "앱에 연결할 수 없습니다. 네트워크 또는 FiestaBoard 실행 여부를 확인하세요.",

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -460,7 +460,10 @@
     "toastSetDefaultFailed": "Standaardpagina instellen mislukt",
     "toastSwitchSuccess": "Gewisseld naar actieve pagina",
     "toastSwitchFailed": "Pagina wisselen mislukt",
-    "updatedExternally": "Updated externally"
+    "updatedExternally": "Updated externally",
+    "resendToBoard": "Resend FiestaBoard page",
+    "toastResendSuccess": "Page resent to board",
+    "toastResendFailed": "Failed to resend page"
   },
   "serviceStatus": {
     "disconnectedAriaLabel": "Kan de app niet bereiken. Controleer je netwerk of of FiestaBoard draait.",

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -460,7 +460,10 @@
     "toastSetDefaultFailed": "Nie udało się ustawić domyślnej strony",
     "toastSwitchSuccess": "Przełączono na aktywną stronę",
     "toastSwitchFailed": "Nie udało się przełączyć strony",
-    "updatedExternally": "Updated externally"
+    "updatedExternally": "Updated externally",
+    "resendToBoard": "Resend FiestaBoard page",
+    "toastResendSuccess": "Page resent to board",
+    "toastResendFailed": "Failed to resend page"
   },
   "serviceStatus": {
     "disconnectedAriaLabel": "Nie można połączyć się z aplikacją. Sprawdź sieć lub czy FiestaBoard jest uruchomiony.",

--- a/web/messages/pt.json
+++ b/web/messages/pt.json
@@ -460,7 +460,10 @@
     "toastSetDefaultFailed": "Falha ao definir página padrão",
     "toastSwitchSuccess": "Página ativa alterada",
     "toastSwitchFailed": "Falha ao trocar de página",
-    "updatedExternally": "Updated externally"
+    "updatedExternally": "Updated externally",
+    "resendToBoard": "Resend FiestaBoard page",
+    "toastResendSuccess": "Page resent to board",
+    "toastResendFailed": "Failed to resend page"
   },
   "serviceStatus": {
     "disconnectedAriaLabel": "Não é possível alcançar o aplicativo. Verifique sua rede ou se o FiestaBoard está em execução.",

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -460,7 +460,10 @@
     "toastSetDefaultFailed": "Не удалось установить страницу по умолчанию",
     "toastSwitchSuccess": "Переключено на активную страницу",
     "toastSwitchFailed": "Не удалось переключить страницу",
-    "updatedExternally": "Updated externally"
+    "updatedExternally": "Updated externally",
+    "resendToBoard": "Resend FiestaBoard page",
+    "toastResendSuccess": "Page resent to board",
+    "toastResendFailed": "Failed to resend page"
   },
   "serviceStatus": {
     "disconnectedAriaLabel": "Не удаётся подключиться к приложению. Проверьте сеть или запущен ли FiestaBoard.",

--- a/web/messages/sv.json
+++ b/web/messages/sv.json
@@ -460,7 +460,10 @@
     "toastSetDefaultFailed": "Kunde inte ställa in standardsida",
     "toastSwitchSuccess": "Bytte till aktiv sida",
     "toastSwitchFailed": "Kunde inte byta sida",
-    "updatedExternally": "Updated externally"
+    "updatedExternally": "Updated externally",
+    "resendToBoard": "Resend FiestaBoard page",
+    "toastResendSuccess": "Page resent to board",
+    "toastResendFailed": "Failed to resend page"
   },
   "serviceStatus": {
     "disconnectedAriaLabel": "Kan inte nå appen. Kontrollera nätverket eller att FiestaBoard körs.",

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -460,7 +460,10 @@
     "toastSetDefaultFailed": "Varsayılan sayfa ayarlanamadı",
     "toastSwitchSuccess": "Aktif sayfaya geçildi",
     "toastSwitchFailed": "Sayfa değiştirilemedi",
-    "updatedExternally": "Updated externally"
+    "updatedExternally": "Updated externally",
+    "resendToBoard": "Resend FiestaBoard page",
+    "toastResendSuccess": "Page resent to board",
+    "toastResendFailed": "Failed to resend page"
   },
   "serviceStatus": {
     "disconnectedAriaLabel": "Uygulamaya ulaşılamıyor. Ağınızı veya FiestaBoard'un çalışıp çalışmadığını kontrol edin.",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -460,7 +460,10 @@
     "toastSetDefaultFailed": "设置默认页面失败",
     "toastSwitchSuccess": "已切换到活跃页面",
     "toastSwitchFailed": "切换页面失败",
-    "updatedExternally": "Updated externally"
+    "updatedExternally": "Updated externally",
+    "resendToBoard": "Resend FiestaBoard page",
+    "toastResendSuccess": "Page resent to board",
+    "toastResendFailed": "Failed to resend page"
   },
   "serviceStatus": {
     "disconnectedAriaLabel": "无法连接应用。请检查网络或 FiestaBoard 是否在运行。",

--- a/web/src/__tests__/general-settings-board-read.test.tsx
+++ b/web/src/__tests__/general-settings-board-read.test.tsx
@@ -169,7 +169,10 @@ describe("GeneralSettings — board read intervals", () => {
 
     const input = document.getElementById("board-read-cloud") as HTMLInputElement;
     fireEvent.change(input, { target: { value: "90" } });
+    // Flush all pending React state updates (including deferred ones) before blur
+    // so the blur handler reads the updated value, not the initial default.
     await waitFor(() => expect(parseInt(input.value, 10)).toBe(90));
+    await act(async () => {});
     fireEvent.blur(input);
 
     await waitFor(() => {

--- a/web/src/__tests__/general-settings-board-read.test.tsx
+++ b/web/src/__tests__/general-settings-board-read.test.tsx
@@ -139,8 +139,10 @@ describe("GeneralSettings — board read intervals", () => {
 
     const input = document.getElementById("board-read-local") as HTMLInputElement;
     fireEvent.change(input, { target: { value: "45" } });
-    // Wait for React state to settle before blur so the handler sees the new value
+    // Flush all pending React state updates (including deferred ones) before blur
+    // so the blur handler reads the updated value, not the initial default.
     await waitFor(() => expect(parseInt(input.value, 10)).toBe(45));
+    await act(async () => {});
     fireEvent.blur(input);
 
     await waitFor(() => {

--- a/web/src/components/active-page-display.tsx
+++ b/web/src/components/active-page-display.tsx
@@ -9,7 +9,7 @@ import { Badge } from "@/components/ui/badge";
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription } from "@/components/ui/sheet";
 import { Skeleton } from "@/components/ui/skeleton";
 import { toast } from "sonner";
-import { Moon, ArrowLeftRight, Calendar, AlertTriangle, GalleryHorizontalEnd, Radio, X, RefreshCw } from "lucide-react";
+import { Moon, ArrowLeftRight, Calendar, AlertTriangle, GalleryHorizontalEnd, Radio, X, RefreshCw, UploadCloud } from "lucide-react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { BoardDisplay } from "@/components/board-display";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -31,6 +31,8 @@ export function ActivePageDisplay() {
   const [shouldPreRender, setShouldPreRender] = useState(false);
   // Show content after animation completes
   const [showSheetContent, setShowSheetContent] = useState(false);
+  // Resend-to-board loading state
+  const [isSyncing, setIsSyncing] = useState(false);
 
   // Start pre-rendering grid in background after component mounts
   useEffect(() => {
@@ -125,6 +127,19 @@ export function ActivePageDisplay() {
     });
     toast.success("Live Mode turned off");
   }, [queryClient]);
+
+  const handleResendToBoard = useCallback(async () => {
+    setIsSyncing(true);
+    try {
+      await api.forceRefresh();
+      await queryClient.invalidateQueries({ queryKey: ["board-current-message"] });
+      toast.success(t("toastResendSuccess"));
+    } catch {
+      toast.error(t("toastResendFailed"));
+    } finally {
+      setIsSyncing(false);
+    }
+  }, [queryClient, t]);
 
   // Fetch board settings for display type
   const { data: boardSettings } = useBoardSettings();
@@ -337,9 +352,19 @@ export function ActivePageDisplay() {
               </div>
             )}
             {isOutOfSync && (
-              <Badge variant="outline" className="text-xs gap-1 border-warning/50 text-warning">
+              <Badge variant="outline" className="text-xs gap-1 border-warning/50 text-warning pr-1">
                 <RefreshCw className="h-3 w-3" />
                 {t("updatedExternally")}
+                <button
+                  type="button"
+                  onClick={handleResendToBoard}
+                  disabled={isSyncing}
+                  aria-label={t("resendToBoard")}
+                  title={t("resendToBoard")}
+                  className="ml-0.5 inline-flex items-center justify-center rounded-sm hover:bg-warning/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+                >
+                  <UploadCloud className={`h-3 w-3 ${isSyncing ? "animate-pulse" : ""}`} aria-hidden="true" />
+                </button>
               </Badge>
             )}
           </div>


### PR DESCRIPTION
## Summary

- **Post-send board refresh**: After any confirmed send to the Vestaboard, a 3-second deferred read is scheduled via `request_board_refresh()` on `DisplayService`. This updates the polled cache (`_polled_characters`) immediately after a page change rather than waiting for the next background poll cycle (30 s local / 3 min cloud). Rapid sends cancel and restart the timer so they don't stack.
- **Resend button on "Updated externally" badge**: When the Active Display shows the board was changed by an external source (Vestaboard app, direct API, etc.), a small `UploadCloud` icon button now appears inside the badge. Clicking it calls `/force-refresh` to push FiestaBoard's active page back to the board, then re-polls the board state.
- **Bug fix**: `/refresh` and `/force-refresh` endpoints were calling the non-existent `fetch_and_display()` method on `DisplayService`; corrected to `check_and_send_active_page()`.

## Test plan

- [ ] Send a page manually — board state on Home screen should update within ~3 seconds instead of waiting for the next poll interval
- [ ] Change active page from the Home screen — same fast update
- [ ] Simulate an external board update; confirm "Updated externally" badge appears with the cloud-upload button
- [ ] Click the cloud-upload button — board should show FiestaBoard's active page again and badge should disappear
- [ ] All 66 web test files pass, all API tests pass (3 pre-existing template plugin failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)