### PR TITLE
fix: replace out-of-sync badge with alert and fix restore timing

### DIFF
--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -460,10 +460,10 @@
     "toastSetDefaultFailed": "Standardseite konnte nicht festgelegt werden",
     "toastSwitchSuccess": "Zur aktiven Seite gewechselt",
     "toastSwitchFailed": "Seitenwechsel fehlgeschlagen",
-    "updatedExternally": "Updated externally",
-    "resendToBoard": "Resend FiestaBoard page",
-    "toastResendSuccess": "Page resent to board",
-    "toastResendFailed": "Failed to resend page"
+    "updatedExternally": "Board was changed by another app",
+    "resendToBoard": "Restore",
+    "toastResendSuccess": "Board restored",
+    "toastResendFailed": "Failed to restore board"
   },
   "serviceStatus": {
     "disconnectedAriaLabel": "App nicht erreichbar. Netzwerk prüfen oder prüfen, ob FiestaBoard läuft.",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -460,10 +460,10 @@
     "toastSetDefaultFailed": "Failed to set default page",
     "toastSwitchSuccess": "Switched to active page",
     "toastSwitchFailed": "Failed to switch page",
-    "updatedExternally": "Updated externally",
-    "resendToBoard": "Resend FiestaBoard page",
-    "toastResendSuccess": "Page resent to board",
-    "toastResendFailed": "Failed to resend page"
+    "updatedExternally": "Board was changed by another app",
+    "resendToBoard": "Restore",
+    "toastResendSuccess": "Board restored",
+    "toastResendFailed": "Failed to restore board"
   },
   "serviceStatus": {
     "disconnectedAriaLabel": "Cannot reach the app. Check your network or that FiestaBoard is running.",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -460,10 +460,10 @@
     "toastSetDefaultFailed": "Error al establecer la página predeterminada",
     "toastSwitchSuccess": "Se cambió a la página activa",
     "toastSwitchFailed": "Error al cambiar la página",
-    "updatedExternally": "Updated externally",
-    "resendToBoard": "Resend FiestaBoard page",
-    "toastResendSuccess": "Page resent to board",
-    "toastResendFailed": "Failed to resend page"
+    "updatedExternally": "Board was changed by another app",
+    "resendToBoard": "Restore",
+    "toastResendSuccess": "Board restored",
+    "toastResendFailed": "Failed to restore board"
   },
   "serviceStatus": {
     "disconnectedAriaLabel": "No se puede conectar con la aplicación. Comprueba tu red o que FiestaBoard esté en ejecución.",

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -460,10 +460,10 @@
     "toastSetDefaultFailed": "Échec de la définition de la page par défaut",
     "toastSwitchSuccess": "Page active changée",
     "toastSwitchFailed": "Échec du changement de page",
-    "updatedExternally": "Updated externally",
-    "resendToBoard": "Resend FiestaBoard page",
-    "toastResendSuccess": "Page resent to board",
-    "toastResendFailed": "Failed to resend page"
+    "updatedExternally": "Board was changed by another app",
+    "resendToBoard": "Restore",
+    "toastResendSuccess": "Board restored",
+    "toastResendFailed": "Failed to restore board"
   },
   "serviceStatus": {
     "disconnectedAriaLabel": "Application inaccessible. Vérifiez votre réseau ou que FiestaBoard est en cours d'exécution.",

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -460,10 +460,10 @@
     "toastSetDefaultFailed": "Impossibile impostare la pagina predefinita",
     "toastSwitchSuccess": "Passato alla pagina attiva",
     "toastSwitchFailed": "Impossibile cambiare pagina",
-    "updatedExternally": "Updated externally",
-    "resendToBoard": "Resend FiestaBoard page",
-    "toastResendSuccess": "Page resent to board",
-    "toastResendFailed": "Failed to resend page"
+    "updatedExternally": "Board was changed by another app",
+    "resendToBoard": "Restore",
+    "toastResendSuccess": "Board restored",
+    "toastResendFailed": "Failed to restore board"
   },
   "serviceStatus": {
     "disconnectedAriaLabel": "Impossibile raggiungere l'app. Controlla la rete o che FiestaBoard sia in esecuzione.",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -460,10 +460,10 @@
     "toastSetDefaultFailed": "デフォルトページの設定に失敗しました",
     "toastSwitchSuccess": "アクティブページに切り替えました",
     "toastSwitchFailed": "ページの切り替えに失敗しました",
-    "updatedExternally": "Updated externally",
-    "resendToBoard": "Resend FiestaBoard page",
-    "toastResendSuccess": "Page resent to board",
-    "toastResendFailed": "Failed to resend page"
+    "updatedExternally": "Board was changed by another app",
+    "resendToBoard": "Restore",
+    "toastResendSuccess": "Board restored",
+    "toastResendFailed": "Failed to restore board"
   },
   "serviceStatus": {
     "disconnectedAriaLabel": "アプリに接続できません。ネットワークまたは FiestaBoard の起動を確認してください。",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -460,10 +460,10 @@
     "toastSetDefaultFailed": "기본 페이지 설정에 실패했습니다",
     "toastSwitchSuccess": "활성 페이지로 전환되었습니다",
     "toastSwitchFailed": "페이지 전환에 실패했습니다",
-    "updatedExternally": "Updated externally",
-    "resendToBoard": "Resend FiestaBoard page",
-    "toastResendSuccess": "Page resent to board",
-    "toastResendFailed": "Failed to resend page"
+    "updatedExternally": "Board was changed by another app",
+    "resendToBoard": "Restore",
+    "toastResendSuccess": "Board restored",
+    "toastResendFailed": "Failed to restore board"
   },
   "serviceStatus": {
     "disconnectedAriaLabel": "앱에 연결할 수 없습니다. 네트워크 또는 FiestaBoard 실행 여부를 확인하세요.",

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -460,10 +460,10 @@
     "toastSetDefaultFailed": "Standaardpagina instellen mislukt",
     "toastSwitchSuccess": "Gewisseld naar actieve pagina",
     "toastSwitchFailed": "Pagina wisselen mislukt",
-    "updatedExternally": "Updated externally",
-    "resendToBoard": "Resend FiestaBoard page",
-    "toastResendSuccess": "Page resent to board",
-    "toastResendFailed": "Failed to resend page"
+    "updatedExternally": "Board was changed by another app",
+    "resendToBoard": "Restore",
+    "toastResendSuccess": "Board restored",
+    "toastResendFailed": "Failed to restore board"
   },
   "serviceStatus": {
     "disconnectedAriaLabel": "Kan de app niet bereiken. Controleer je netwerk of of FiestaBoard draait.",

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -460,10 +460,10 @@
     "toastSetDefaultFailed": "Nie udało się ustawić domyślnej strony",
     "toastSwitchSuccess": "Przełączono na aktywną stronę",
     "toastSwitchFailed": "Nie udało się przełączyć strony",
-    "updatedExternally": "Updated externally",
-    "resendToBoard": "Resend FiestaBoard page",
-    "toastResendSuccess": "Page resent to board",
-    "toastResendFailed": "Failed to resend page"
+    "updatedExternally": "Board was changed by another app",
+    "resendToBoard": "Restore",
+    "toastResendSuccess": "Board restored",
+    "toastResendFailed": "Failed to restore board"
   },
   "serviceStatus": {
     "disconnectedAriaLabel": "Nie można połączyć się z aplikacją. Sprawdź sieć lub czy FiestaBoard jest uruchomiony.",

--- a/web/messages/pt.json
+++ b/web/messages/pt.json
@@ -460,10 +460,10 @@
     "toastSetDefaultFailed": "Falha ao definir página padrão",
     "toastSwitchSuccess": "Página ativa alterada",
     "toastSwitchFailed": "Falha ao trocar de página",
-    "updatedExternally": "Updated externally",
-    "resendToBoard": "Resend FiestaBoard page",
-    "toastResendSuccess": "Page resent to board",
-    "toastResendFailed": "Failed to resend page"
+    "updatedExternally": "Board was changed by another app",
+    "resendToBoard": "Restore",
+    "toastResendSuccess": "Board restored",
+    "toastResendFailed": "Failed to restore board"
   },
   "serviceStatus": {
     "disconnectedAriaLabel": "Não é possível alcançar o aplicativo. Verifique sua rede ou se o FiestaBoard está em execução.",

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -460,10 +460,10 @@
     "toastSetDefaultFailed": "Не удалось установить страницу по умолчанию",
     "toastSwitchSuccess": "Переключено на активную страницу",
     "toastSwitchFailed": "Не удалось переключить страницу",
-    "updatedExternally": "Updated externally",
-    "resendToBoard": "Resend FiestaBoard page",
-    "toastResendSuccess": "Page resent to board",
-    "toastResendFailed": "Failed to resend page"
+    "updatedExternally": "Board was changed by another app",
+    "resendToBoard": "Restore",
+    "toastResendSuccess": "Board restored",
+    "toastResendFailed": "Failed to restore board"
   },
   "serviceStatus": {
     "disconnectedAriaLabel": "Не удаётся подключиться к приложению. Проверьте сеть или запущен ли FiestaBoard.",

--- a/web/messages/sv.json
+++ b/web/messages/sv.json
@@ -460,10 +460,10 @@
     "toastSetDefaultFailed": "Kunde inte ställa in standardsida",
     "toastSwitchSuccess": "Bytte till aktiv sida",
     "toastSwitchFailed": "Kunde inte byta sida",
-    "updatedExternally": "Updated externally",
-    "resendToBoard": "Resend FiestaBoard page",
-    "toastResendSuccess": "Page resent to board",
-    "toastResendFailed": "Failed to resend page"
+    "updatedExternally": "Board was changed by another app",
+    "resendToBoard": "Restore",
+    "toastResendSuccess": "Board restored",
+    "toastResendFailed": "Failed to restore board"
   },
   "serviceStatus": {
     "disconnectedAriaLabel": "Kan inte nå appen. Kontrollera nätverket eller att FiestaBoard körs.",

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -460,10 +460,10 @@
     "toastSetDefaultFailed": "Varsayılan sayfa ayarlanamadı",
     "toastSwitchSuccess": "Aktif sayfaya geçildi",
     "toastSwitchFailed": "Sayfa değiştirilemedi",
-    "updatedExternally": "Updated externally",
-    "resendToBoard": "Resend FiestaBoard page",
-    "toastResendSuccess": "Page resent to board",
-    "toastResendFailed": "Failed to resend page"
+    "updatedExternally": "Board was changed by another app",
+    "resendToBoard": "Restore",
+    "toastResendSuccess": "Board restored",
+    "toastResendFailed": "Failed to restore board"
   },
   "serviceStatus": {
     "disconnectedAriaLabel": "Uygulamaya ulaşılamıyor. Ağınızı veya FiestaBoard'un çalışıp çalışmadığını kontrol edin.",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -460,10 +460,10 @@
     "toastSetDefaultFailed": "设置默认页面失败",
     "toastSwitchSuccess": "已切换到活跃页面",
     "toastSwitchFailed": "切换页面失败",
-    "updatedExternally": "Updated externally",
-    "resendToBoard": "Resend FiestaBoard page",
-    "toastResendSuccess": "Page resent to board",
-    "toastResendFailed": "Failed to resend page"
+    "updatedExternally": "Board was changed by another app",
+    "resendToBoard": "Restore",
+    "toastResendSuccess": "Board restored",
+    "toastResendFailed": "Failed to restore board"
   },
   "serviceStatus": {
     "disconnectedAriaLabel": "无法连接应用。请检查网络或 FiestaBoard 是否在运行。",

--- a/web/src/__tests__/active-page-display.test.tsx
+++ b/web/src/__tests__/active-page-display.test.tsx
@@ -201,6 +201,65 @@ describe("ActivePageDisplay", () => {
     });
   });
 
+  it("shows out-of-sync alert when board was changed externally", async () => {
+    const differentChars = Array.from({ length: 6 }, () => Array(22).fill(1));
+    const expectedChars = Array.from({ length: 6 }, () => Array(22).fill(2));
+    server.use(
+      http.get(`${API_BASE}/board/current-message`, () =>
+        HttpResponse.json({
+          characters: differentChars,
+          message: "",
+          rows: 6,
+          cols: 22,
+          expected_characters: expectedChars,
+          cached_at: null,
+          api_mode: "local",
+        })
+      )
+    );
+
+    render(<ActivePageDisplay />, { wrapper: TestWrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Board was changed by another app")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /Restore/i })).toBeInTheDocument();
+    });
+  });
+
+  it("calls force-refresh and shows success toast when Restore is clicked", async () => {
+    const toastSpy = vi.spyOn((await import("sonner")).toast, "success");
+    const differentChars = Array.from({ length: 6 }, () => Array(22).fill(1));
+    const expectedChars = Array.from({ length: 6 }, () => Array(22).fill(2));
+    server.use(
+      http.get(`${API_BASE}/board/current-message`, () =>
+        HttpResponse.json({
+          characters: differentChars,
+          message: "",
+          rows: 6,
+          cols: 22,
+          expected_characters: expectedChars,
+          cached_at: null,
+          api_mode: "local",
+        })
+      )
+    );
+
+    const user = userEvent.setup();
+    render(<ActivePageDisplay />, { wrapper: TestWrapper });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Restore/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /Restore/i }));
+
+    await waitFor(() => {
+      expect(toastSpy).toHaveBeenCalledWith("Board restored");
+    });
+
+    toastSpy.mockRestore();
+  });
+
   it("handles set active page error", async () => {
     const toastSpy = vi.spyOn((await import("sonner")).toast, "error");
     server.use(

--- a/web/src/__tests__/general-settings-board-read.test.tsx
+++ b/web/src/__tests__/general-settings-board-read.test.tsx
@@ -97,6 +97,8 @@ describe("GeneralSettings — board read intervals", () => {
 
     const input = document.getElementById("board-read-cloud") as HTMLInputElement;
     fireEvent.change(input, { target: { value: "30" } });
+    // Flush deferred React state so the warning renders before asserting.
+    await act(async () => {});
 
     await waitFor(() => {
       expect(

--- a/web/src/components/active-page-display.tsx
+++ b/web/src/components/active-page-display.tsx
@@ -9,12 +9,12 @@ import { Badge } from "@/components/ui/badge";
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription } from "@/components/ui/sheet";
 import { Skeleton } from "@/components/ui/skeleton";
 import { toast } from "sonner";
-import { Moon, ArrowLeftRight, Calendar, AlertTriangle, GalleryHorizontalEnd, Radio, X, RefreshCw, UploadCloud } from "lucide-react";
+import { Moon, ArrowLeftRight, Calendar, AlertTriangle, GalleryHorizontalEnd, Radio, X, UploadCloud, Loader2 } from "lucide-react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { BoardDisplay } from "@/components/board-display";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
-import type { SilenceStatus, Carousel } from "@/lib/api";
+import type { SilenceStatus, Carousel, BoardCurrentMessageResponse } from "@/lib/api";
 import { api, isCarouselId } from "@/lib/api";
 import { PageGridSelector } from "@/components/page-grid-selector";
 import { readLiveOutputMessage, onLiveOutputMessageChange, writeLiveOutputMessage } from "@/lib/live-output-channel";
@@ -132,7 +132,16 @@ export function ActivePageDisplay() {
     setIsSyncing(true);
     try {
       await api.forceRefresh();
-      await queryClient.invalidateQueries({ queryKey: ["board-current-message"] });
+      // Optimistically mark as in-sync so the alert disappears immediately.
+      // The backend schedules a ~3 s deferred board read after each send;
+      // we update the cache now and do a real refetch after 4 s to confirm.
+      queryClient.setQueryData(["board-current-message"], (old: BoardCurrentMessageResponse | undefined) => {
+        if (!old) return old;
+        return { ...old, characters: old.expected_characters ?? old.characters };
+      });
+      setTimeout(() => {
+        queryClient.invalidateQueries({ queryKey: ["board-current-message"] });
+      }, 4000);
       toast.success(t("toastResendSuccess"));
     } catch {
       toast.error(t("toastResendFailed"));
@@ -351,22 +360,6 @@ export function ActivePageDisplay() {
                 <span className="text-info">{t("silenceModeActive")}</span>
               </div>
             )}
-            {isOutOfSync && (
-              <Badge variant="outline" className="text-xs gap-1 border-warning/50 text-warning pr-1">
-                <RefreshCw className="h-3 w-3" />
-                {t("updatedExternally")}
-                <button
-                  type="button"
-                  onClick={handleResendToBoard}
-                  disabled={isSyncing}
-                  aria-label={t("resendToBoard")}
-                  title={t("resendToBoard")}
-                  className="ml-0.5 inline-flex items-center justify-center rounded-sm hover:bg-warning/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
-                >
-                  <UploadCloud className={`h-3 w-3 ${isSyncing ? "animate-pulse" : ""}`} aria-hidden="true" />
-                </button>
-              </Badge>
-            )}
           </div>
         </CardHeader>
 
@@ -384,6 +377,30 @@ export function ActivePageDisplay() {
                   {t("scheduleSettingsLink")}
                 </button>
                 .
+              </AlertDescription>
+            </Alert>
+          )}
+
+          {/* Out-of-sync warning: board was changed by another app */}
+          {isOutOfSync && !liveOutputMessage && (
+            <Alert variant="default" className="border-warning/50 bg-warning/10">
+              <AlertTriangle className="h-4 w-4 text-warning" />
+              <AlertDescription className="flex items-center justify-between gap-3">
+                <span className="text-sm">{t("updatedExternally")}</span>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={handleResendToBoard}
+                  disabled={isSyncing}
+                  className="shrink-0 gap-1.5 border-warning/50 text-warning hover:bg-warning/10 hover:text-warning"
+                >
+                  {isSyncing ? (
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                  ) : (
+                    <UploadCloud className="h-3 w-3" />
+                  )}
+                  {t("resendToBoard")}
+                </Button>
               </AlertDescription>
             </Alert>
           )}


### PR DESCRIPTION
## Summary

- **Design**: Replaces the cramped badge+icon-button in the Active Display header with a proper `Alert` component in the card body (matching the existing schedule gap warning style). The alert shows "Board was changed by another app" with a labeled "Restore" button — much clearer than the previous `UploadCloud` icon embedded in a tiny badge tooltip.
- **Functionality**: Fixes the core timing bug — after clicking Restore, the alert now disappears immediately. The old handler called `invalidateQueries` right after `forceRefresh()`, but the backend's deferred board read takes ~3 s, so the polled `characters` still showed stale out-of-sync state. The new handler optimistically sets `characters = expected_characters` in the cache (the send just succeeded, so we can trust it), then does a real refetch 4 s later to confirm.
- **Copy**: Updates i18n strings across all 14 locales — "Board was changed by another app", "Restore", "Board restored", "Failed to restore board".

## Test plan

- [ ] Verify the "Updated externally" badge no longer appears in the Active Display header badges row
- [ ] Trigger an out-of-sync state (change board via Vestaboard app or another API caller), confirm the amber alert appears below the mode badge and above the board preview
- [ ] Click "Restore" — alert should disappear immediately and a "Board restored" toast should show
- [ ] Confirm a real board poll fires ~4 s later and the state remains in sync
- [ ] Verify alert does not appear when Live Mode is active
- [ ] All 66 web test files pass (887 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)