### PR TITLE
feat: add POST /plugins/{plugin_id}/receive endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fiestaboard",
-  "version": "5.8.1",
+  "version": "5.9.0",
   "description": "Open-source server that turns your split-flap display into a living dashboard with weather, stocks, sports, transit, and more",
   "keywords": [
     "split-flap",

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 """FiestaBoard Display Service - Main package."""
 
-__version__ = "5.8.1"
+__version__ = "5.9.0"
 

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -7355,6 +7355,53 @@ async def delete_plugin_instance(plugin_id: str, instance_label: str):
     }
 
 
+@app.post("/plugins/{plugin_id}/receive")
+async def receive_plugin_payload(plugin_id: str, request: Request):
+    """
+    Push a JSON payload to a plugin.
+
+    Allows external systems (CI pipelines, automations, etc.) to push data to
+    plugins that support incoming webhooks.  The plugin's ``receive_payload``
+    method is called with the parsed body, the raw request headers, and the
+    raw body bytes (for HMAC verification).
+
+    Returns 404 when the plugin is not found, 400 when it is not enabled or
+    the body is not valid JSON, 403 when the plugin rejects the request due to
+    a signature mismatch, and 405 when the plugin does not support receive.
+    """
+    if not PLUGIN_SYSTEM_AVAILABLE:
+        raise HTTPException(status_code=503, detail="Plugin system is not available.")
+
+    registry = get_plugin_registry()
+    plugin = registry.get_plugin(plugin_id)
+    if not plugin:
+        raise HTTPException(status_code=404, detail=f"Plugin not found: {plugin_id}")
+    if not registry.is_enabled(plugin_id):
+        raise HTTPException(status_code=400, detail=f"Plugin not enabled: {plugin_id}")
+
+    raw_body = await request.body()
+    try:
+        body = json.loads(raw_body)
+    except Exception:
+        raise HTTPException(status_code=400, detail="Request body must be valid JSON")
+
+    headers = dict(request.headers)
+
+    try:
+        plugin.receive_payload(body, headers, raw_body=raw_body)
+    except NotImplementedError:
+        raise HTTPException(
+            status_code=405,
+            detail=f"Plugin '{plugin_id}' does not support receive",
+        )
+    except PermissionError as exc:
+        raise HTTPException(status_code=403, detail=str(exc))
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+    return {"status": "ok"}
+
+
 # ── External Plugin Management ──────────────────────────────────────────────
 
 

--- a/src/plugins/base.py
+++ b/src/plugins/base.py
@@ -456,6 +456,16 @@ class PluginBase(ABC):
         """
         return bool(self._manifest.get("supports_triggers", False))
 
+    def receive_payload(self, payload: Dict[str, Any], headers: Dict[str, str], raw_body: bytes = b"") -> None:
+        """Handle an incoming webhook payload pushed to this plugin.
+
+        Override this in plugins that accept push data from external systems.
+        Raise ``PermissionError`` for signature validation failures (→ HTTP 403),
+        ``ValueError`` for bad request data (→ HTTP 400).
+        The default implementation raises ``NotImplementedError`` (→ HTTP 405).
+        """
+        raise NotImplementedError(f"Plugin {self.plugin_id} does not support receive")
+
     def check_triggers(self) -> List["TriggerResult"]:
         """Check whether any event-based triggers should fire.
 

--- a/tests/test_api_extended.py
+++ b/tests/test_api_extended.py
@@ -751,6 +751,45 @@ class TestPluginEndpoints:
         data = response.json()
         assert data["plugin_system_enabled"] is False
 
+    def test_receive_plugin_payload(self, client, mock_plugin_registry):
+        response = client.post("/plugins/weather/receive", json={"message": "hello"})
+        assert response.status_code == 200
+        assert response.json() == {"status": "ok"}
+        mock_plugin_registry.get_plugin.return_value.receive_payload.assert_called_once()
+
+    def test_receive_plugin_payload_not_found(self, client, mock_plugin_registry):
+        mock_plugin_registry.get_plugin.return_value = None
+        response = client.post("/plugins/nonexistent/receive", json={"message": "hello"})
+        assert response.status_code == 404
+
+    def test_receive_plugin_payload_not_enabled(self, client, mock_plugin_registry):
+        mock_plugin_registry.is_enabled.return_value = False
+        response = client.post("/plugins/weather/receive", json={"message": "hello"})
+        assert response.status_code == 400
+
+    def test_receive_plugin_payload_invalid_json(self, client, mock_plugin_registry):
+        response = client.post(
+            "/plugins/weather/receive",
+            content=b"not json",
+            headers={"Content-Type": "application/json"},
+        )
+        assert response.status_code == 400
+
+    def test_receive_plugin_payload_not_supported(self, client, mock_plugin_registry):
+        mock_plugin_registry.get_plugin.return_value.receive_payload.side_effect = NotImplementedError
+        response = client.post("/plugins/weather/receive", json={"message": "hello"})
+        assert response.status_code == 405
+
+    def test_receive_plugin_payload_bad_signature(self, client, mock_plugin_registry):
+        mock_plugin_registry.get_plugin.return_value.receive_payload.side_effect = PermissionError("Invalid signature")
+        response = client.post("/plugins/weather/receive", json={"message": "hello"})
+        assert response.status_code == 403
+
+    def test_receive_plugin_payload_system_unavailable(self, client):
+        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", False):
+            response = client.post("/plugins/weather/receive", json={"message": "hello"})
+        assert response.status_code == 503
+
 # ============================================================
 # Template Endpoints
 # ============================================================

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "5.8.1",
+  "version": "5.9.0",
   "private": true,
   "scripts": {
     "dev": "next dev --webpack",


### PR DESCRIPTION
## Summary

Fixes #758 — the Webhook plugin's `/api/plugins/webhook/receive` endpoint was returning 404 because no route existed in the core and `PluginBase` had no receive hook.

- Adds `PluginBase.receive_payload(payload, headers, raw_body)` — default raises `NotImplementedError` so all existing plugins are unaffected
- Adds `POST /plugins/{plugin_id}/receive` route that dispatches to the plugin, passing raw body bytes for HMAC verification; maps `PermissionError` → 403, `NotImplementedError` → 405, `ValueError` → 400

## Test plan

- [ ] `test_receive_plugin_payload` — 200 on success
- [ ] `test_receive_plugin_payload_not_found` — 404 when plugin doesn't exist
- [ ] `test_receive_plugin_payload_not_enabled` — 400 when plugin is disabled
- [ ] `test_receive_plugin_payload_invalid_json` — 400 on bad request body
- [ ] `test_receive_plugin_payload_not_supported` — 405 when plugin raises `NotImplementedError`
- [ ] `test_receive_plugin_payload_bad_signature` — 403 when plugin raises `PermissionError`
- [ ] `test_receive_plugin_payload_system_unavailable` — 503 when plugin system is off

Related plugin-side PR: Fiestaboard/fiestaboard-plugin--webhook#2 (or see the webhook plugin repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)