### PR TITLE
feat(date_time): add time_english variable for spoken English time expressions

### DIFF
--- a/plugins/date_time/__init__.py
+++ b/plugins/date_time/__init__.py
@@ -12,6 +12,59 @@ from src.plugins.base import PluginBase, PluginResult
 
 logger = logging.getLogger(__name__)
 
+_HOUR_WORDS = {
+    1: "ONE", 2: "TWO", 3: "THREE", 4: "FOUR", 5: "FIVE", 6: "SIX",
+    7: "SEVEN", 8: "EIGHT", 9: "NINE", 10: "TEN", 11: "ELEVEN", 12: "TWELVE",
+}
+
+_ONES = [
+    "", "ONE", "TWO", "THREE", "FOUR", "FIVE", "SIX", "SEVEN", "EIGHT",
+    "NINE", "TEN", "ELEVEN", "TWELVE", "THIRTEEN", "FOURTEEN", "FIFTEEN",
+    "SIXTEEN", "SEVENTEEN", "EIGHTEEN", "NINETEEN",
+]
+_TENS = ["", "", "TWENTY", "THIRTY", "FORTY", "FIFTY"]
+
+
+def _minute_word(n: int) -> str:
+    """Convert a minute count (1–29) to English words, with A QUARTER for 15."""
+    if n == 15:
+        return "A QUARTER"
+    if n < 20:
+        return _ONES[n]
+    tens = _TENS[n // 10]
+    ones = _ONES[n % 10]
+    return f"{tens}-{ones}" if ones else tens
+
+
+def _time_to_english(hour: int, minute: int) -> str:
+    """Convert hour (0–23) and minute (0–59) to a spoken English expression."""
+    if hour == 0 and minute == 0:
+        return "IT'S MIDNIGHT."
+    if hour == 12 and minute == 0:
+        return "IT'S NOON."
+
+    if 5 <= hour <= 11:
+        period = "IN THE MORNING"
+    elif 12 <= hour <= 17:
+        period = "IN THE AFTERNOON"
+    elif 18 <= hour <= 20:
+        period = "IN THE EVENING"
+    else:
+        period = "AT NIGHT"
+
+    h12 = hour % 12 or 12
+
+    if minute == 0:
+        return f"IT'S {_HOUR_WORDS[h12]} O'CLOCK {period}."
+    elif minute == 30:
+        return f"IT'S HALF PAST {_HOUR_WORDS[h12]} {period}."
+    elif minute < 30:
+        return f"IT'S {_minute_word(minute)} PAST {_HOUR_WORDS[h12]} {period}."
+    else:
+        minutes_to = 60 - minute
+        next_h12 = h12 % 12 + 1
+        return f"IT'S {_minute_word(minutes_to)} TO {_HOUR_WORDS[next_h12]} {period}."
+
 
 class DateTimePlugin(PluginBase):
     """Date and time data plugin.
@@ -77,6 +130,9 @@ class DateTimePlugin(PluginBase):
                 
                 # Additional timezone info
                 "timezone": timezone_str,  # Full timezone name from config
+
+                # Spoken English time expression
+                "time_english": _time_to_english(now.hour, now.minute),
             }
             
             return PluginResult(

--- a/plugins/date_time/manifest.json
+++ b/plugins/date_time/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "date_time",
   "name": "Date & Time",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Display current date and time in configurable formats",
   "author": "FiestaBoard Team",
   "repository": "https://github.com/FiestaBoard/FiestaBoard",
@@ -158,6 +158,12 @@
         "group": "formatting",
         "max_length": 8,
         "example": "3/21/25"
+      },
+      "time_english": {
+        "description": "Current time as a spoken English expression",
+        "group": "formatting",
+        "max_length": 50,
+        "example": "IT'S A QUARTER PAST ONE IN THE AFTERNOON."
       }
     }
   },

--- a/plugins/date_time/tests/test_plugin.py
+++ b/plugins/date_time/tests/test_plugin.py
@@ -435,7 +435,6 @@ class TestTimeToEnglish:
     def sample_manifest(self):
         manifest_path = Path(__file__).parent.parent / "manifest.json"
         with open(manifest_path) as f:
-            import json
             return json.load(f)
 
     @pytest.fixture

--- a/plugins/date_time/tests/test_plugin.py
+++ b/plugins/date_time/tests/test_plugin.py
@@ -6,7 +6,9 @@ import json
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
-from plugins.date_time import DateTimePlugin
+import pytest
+
+from plugins.date_time import DateTimePlugin, _time_to_english
 
 
 class TestDateTimePlugin:
@@ -342,8 +344,8 @@ class TestDateTimeManifestMetadata:
         for group_id, group_def in groups.items():
             assert "label" in group_def, f"Group '{group_id}' missing label"
 
-    def test_all_18_variables_present(self):
-        """All 18 date_time variables are declared in the manifest."""
+    def test_all_19_variables_present(self):
+        """All 19 date_time variables are declared in the manifest."""
         manifest_path = Path(__file__).parent.parent / "manifest.json"
         with open(manifest_path) as f:
             manifest = json.load(f)
@@ -353,7 +355,89 @@ class TestDateTimeManifestMetadata:
             "time", "date", "datetime", "day", "day_of_week", "month",
             "year", "hour", "minute", "timezone_abbr", "time_12h", "time_24h",
             "date_us", "date_us_short", "month_number", "month_number_padded",
-            "month_abbr", "timezone",
+            "month_abbr", "timezone", "time_english",
         ]
         for var in expected:
             assert var in simple, f"Expected variable '{var}' not in manifest"
+
+
+class TestTimeToEnglish:
+    """Unit tests for _time_to_english()."""
+
+    def test_midnight(self):
+        assert _time_to_english(0, 0) == "IT'S MIDNIGHT."
+
+    def test_noon(self):
+        assert _time_to_english(12, 0) == "IT'S NOON."
+
+    def test_on_the_hour_morning(self):
+        assert _time_to_english(9, 0) == "IT'S NINE O'CLOCK IN THE MORNING."
+
+    def test_on_the_hour_afternoon(self):
+        assert _time_to_english(13, 0) == "IT'S ONE O'CLOCK IN THE AFTERNOON."
+
+    def test_on_the_hour_evening(self):
+        assert _time_to_english(19, 0) == "IT'S SEVEN O'CLOCK IN THE EVENING."
+
+    def test_on_the_hour_night(self):
+        assert _time_to_english(22, 0) == "IT'S TEN O'CLOCK AT NIGHT."
+
+    def test_quarter_past(self):
+        assert _time_to_english(12, 15) == "IT'S A QUARTER PAST TWELVE IN THE AFTERNOON."
+
+    def test_half_past(self):
+        assert _time_to_english(8, 30) == "IT'S HALF PAST EIGHT IN THE MORNING."
+
+    def test_quarter_to(self):
+        assert _time_to_english(12, 45) == "IT'S A QUARTER TO ONE IN THE AFTERNOON."
+
+    def test_exact_minutes_past(self):
+        assert _time_to_english(14, 23) == "IT'S TWENTY-THREE PAST TWO IN THE AFTERNOON."
+
+    def test_exact_minutes_to(self):
+        assert _time_to_english(14, 47) == "IT'S THIRTEEN TO THREE IN THE AFTERNOON."
+
+    def test_one_past(self):
+        assert _time_to_english(10, 1) == "IT'S ONE PAST TEN IN THE MORNING."
+
+    def test_one_to(self):
+        assert _time_to_english(10, 59) == "IT'S ONE TO ELEVEN IN THE MORNING."
+
+    def test_twenty_past(self):
+        assert _time_to_english(6, 20) == "IT'S TWENTY PAST SIX IN THE MORNING."
+
+    def test_period_boundaries(self):
+        assert "IN THE MORNING" in _time_to_english(5, 0)
+        assert "IN THE MORNING" in _time_to_english(11, 30)
+        assert "IN THE AFTERNOON" in _time_to_english(12, 1)
+        assert "IN THE AFTERNOON" in _time_to_english(17, 59)
+        assert "IN THE EVENING" in _time_to_english(18, 0)
+        assert "IN THE EVENING" in _time_to_english(20, 59)
+        assert "AT NIGHT" in _time_to_english(21, 0)
+        assert "AT NIGHT" in _time_to_english(23, 59)
+        assert "AT NIGHT" in _time_to_english(0, 1)
+        assert "AT NIGHT" in _time_to_english(4, 59)
+
+    def test_twelve_oclock_night(self):
+        # 12:30 AM — half past twelve at night
+        assert _time_to_english(0, 30) == "IT'S HALF PAST TWELVE AT NIGHT."
+
+    def test_time_english_in_fetch_data(self, sample_manifest, sample_config):
+        """time_english is present in fetch_data output."""
+        plugin = DateTimePlugin(sample_manifest)
+        plugin.config = sample_config
+        result = plugin.fetch_data()
+        assert result.available is True
+        assert "time_english" in result.data
+        assert result.data["time_english"].startswith("IT'S ")
+
+    @pytest.fixture
+    def sample_manifest(self):
+        manifest_path = Path(__file__).parent.parent / "manifest.json"
+        with open(manifest_path) as f:
+            import json
+            return json.load(f)
+
+    @pytest.fixture
+    def sample_config(self):
+        return {"timezone": "America/Los_Angeles", "enabled": True}


### PR DESCRIPTION
## Summary

- Adds a new `time_english` template variable to the `date_time` plugin that renders the current time as a natural spoken English phrase
- Implements the conversion logic entirely in Python (no external dependency) — handles all 60 minute values, four time-of-day periods, and special cases for midnight and noon
- Bumps plugin version `1.1.0` → `1.2.0`

## Example output

| Time | `time_english` |
|------|----------------|
| 12:00 AM | `IT'S MIDNIGHT.` |
| 12:00 PM | `IT'S NOON.` |
| 1:00 PM | `IT'S ONE O'CLOCK IN THE AFTERNOON.` |
| 12:15 PM | `IT'S A QUARTER PAST TWELVE IN THE AFTERNOON.` |
| 8:30 AM | `IT'S HALF PAST EIGHT IN THE MORNING.` |
| 10:45 PM | `IT'S A QUARTER TO ELEVEN AT NIGHT.` |
| 2:23 PM | `IT'S TWENTY-THREE PAST TWO IN THE AFTERNOON.` |

## Usage note

`time_english` can be up to ~46 characters, so use the `|wrap` filter and leave empty lines below for overflow:

```
{{date_time.time_english|wrap}}



```

## Test plan

- [x] 41 tests, 99% coverage (`plugins/date_time/tests/test_plugin.py`)
- [x] All existing tests continue to pass
- [x] `TestTimeToEnglish` covers: midnight, noon, on-the-hour, quarter past/to, half past, exact minutes past/to, all four time-of-day period boundaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)