### PR TITLE
Fix: countdown plugin instance variables show "???" for mixed-case labels (#774)

### DIFF
--- a/src/plugins/registry.py
+++ b/src/plugins/registry.py
@@ -116,16 +116,23 @@ class PluginRegistry:
         Args:
             plugin_id: Base plugin ID (must already be loaded).
             instance_label: Short alphanumeric label for the instance.
+                Normalized to lowercase so compound keys match the
+                lowercase plugin-id convention used by the template
+                engine's case-insensitive variable lookup.
 
         Returns:
             List of error messages (empty on success).
         """
-        # Validate label
+        # Validate label, then normalize to lowercase.  Plugin IDs are required
+        # to be lowercase (see manifest validation); instance labels follow the
+        # same rule so that `{{plugin:label.field}}` template references — which
+        # are resolved case-insensitively by the engine — match the stored key.
         if not _INSTANCE_LABEL_RE.match(instance_label):
             return [
                 f"Invalid instance label '{instance_label}': must be 1-40 "
                 "alphanumeric characters, underscores, or hyphens."
             ]
+        instance_label = instance_label.lower()
 
         # Base plugin must exist
         if plugin_id not in self._plugins:
@@ -279,6 +286,10 @@ class PluginRegistry:
         Scans *stored_configs* for compound keys (containing the instance
         separator ``:``) and creates the corresponding plugin instances
         with their stored configuration and enabled state.
+
+        Compound keys with a mixed-case instance label (created before
+        labels were normalized to lowercase) are migrated to the lowercase
+        form on disk so subsequent template renders resolve correctly.
         """
         restored = 0
         for config_key, config in stored_configs.items():
@@ -297,8 +308,10 @@ class PluginRegistry:
                 )
                 continue
 
+            normalized_key = self.make_instance_key(base_id, label.lower())
+
             # Skip if already registered (shouldn't happen, but be safe)
-            if config_key in self._plugins:
+            if normalized_key in self._plugins:
                 continue
 
             errors = self.create_instance(base_id, label)
@@ -310,22 +323,40 @@ class PluginRegistry:
 
             # Apply stored config via the proper pipeline so any future
             # side-effects (e.g. validation hooks) are consistently triggered.
-            config_errors = self.set_plugin_config(config_key, config)
+            config_errors = self.set_plugin_config(normalized_key, config)
             if config_errors:
                 logger.warning(
                     "Instance '%s' config failed validation on restore: %s — "
                     "applying raw config to avoid data loss",
-                    config_key, config_errors,
+                    normalized_key, config_errors,
                 )
                 # Fall back to direct assignment so we don't silently discard config
-                self._configs[config_key] = config
-                self._plugins[config_key].config = config
+                self._configs[normalized_key] = config
+                self._plugins[normalized_key].config = config
 
             # Enable via the proper pipeline so any future side-effects are
             # consistently triggered.
             is_enabled = config.get("enabled", False)
             if is_enabled:
-                self.enable_plugin(config_key)
+                self.enable_plugin(normalized_key)
+
+            # If the on-disk key was mixed-case, migrate it to lowercase so
+            # subsequent restarts don't carry a stale duplicate.
+            if config_key != normalized_key:
+                try:
+                    from ..config_manager import get_config_manager
+                    config_manager = get_config_manager()
+                    config_manager.set_plugin_config(normalized_key, config)
+                    config_manager.delete_plugin_config(config_key)
+                    logger.info(
+                        "Migrated instance key '%s' -> '%s' (lowercase normalization)",
+                        config_key, normalized_key,
+                    )
+                except Exception:
+                    logger.exception(
+                        "Failed to migrate instance key '%s' to '%s'",
+                        config_key, normalized_key,
+                    )
 
             restored += 1
 

--- a/tests/test_plugin_instances.py
+++ b/tests/test_plugin_instances.py
@@ -212,6 +212,21 @@ class TestCreateInstance:
         assert "test_plugin:b" in registry_with_plugin._plugins
         assert "test_plugin:c" in registry_with_plugin._plugins
 
+    def test_create_instance_normalizes_mixed_case_label(self, registry_with_plugin):
+        """Mixed-case labels are stored lowercase so the template engine's
+        case-insensitive variable lookup matches the compound key (#774)."""
+        errors = registry_with_plugin.create_instance("test_plugin", "FijiAustralia")
+        assert errors == []
+        assert "test_plugin:fijiaustralia" in registry_with_plugin._plugins
+        assert "test_plugin:FijiAustralia" not in registry_with_plugin._plugins
+
+    def test_create_instance_duplicate_differs_only_in_case(self, registry_with_plugin):
+        """Two labels that differ only in case should collide (both normalize)."""
+        assert registry_with_plugin.create_instance("test_plugin", "Wedding") == []
+        errors = registry_with_plugin.create_instance("test_plugin", "WEDDING")
+        assert len(errors) == 1
+        assert "already exists" in errors[0]
+
 
 # ── delete_instance ─────────────────────────────────────────────────────────
 
@@ -441,6 +456,60 @@ class TestRestoreInstances:
         stored_configs = {"unknown_plugin:inst1": {"enabled": True}}
         registry_with_plugin._restore_instances(stored_configs)
         assert "unknown_plugin:inst1" not in registry_with_plugin._plugins
+
+    def test_restore_migrates_mixed_case_key_to_lowercase(self, registry_with_plugin, mock_loader):
+        """Pre-existing mixed-case instance keys are migrated to lowercase on
+        restore so subsequent template renders resolve correctly (#774).
+
+        The on-disk config is rewritten under the lowercase key and the old
+        mixed-case entry is removed so we don't carry a stale duplicate.
+        """
+        stored_configs = {
+            "test_plugin:FijiAustralia": {"enabled": True, "setting": "v"},
+        }
+        new_plugin = MagicMock(spec=PluginBase)
+        new_plugin.validate_config.return_value = []
+        new_plugin._validate_refresh_seconds.return_value = []
+        new_plugin.enabled = False
+        new_plugin.config = {}
+        mock_loader.create_instance.return_value = new_plugin
+
+        mock_config_manager = MagicMock()
+        with patch("src.config_manager.get_config_manager", return_value=mock_config_manager):
+            registry_with_plugin._restore_instances(stored_configs)
+
+        # Instance is registered under the lowercase compound key
+        assert "test_plugin:fijiaustralia" in registry_with_plugin._plugins
+        assert "test_plugin:FijiAustralia" not in registry_with_plugin._plugins
+        assert registry_with_plugin._enabled["test_plugin:fijiaustralia"] is True
+        assert registry_with_plugin._configs["test_plugin:fijiaustralia"]["setting"] == "v"
+
+        # On-disk config is migrated: new key written, old key deleted
+        mock_config_manager.set_plugin_config.assert_called_with(
+            "test_plugin:fijiaustralia", {"enabled": True, "setting": "v"}
+        )
+        mock_config_manager.delete_plugin_config.assert_called_with(
+            "test_plugin:FijiAustralia"
+        )
+
+    def test_restore_lowercase_key_does_not_trigger_migration(self, registry_with_plugin, mock_loader):
+        """Already-lowercase keys should not re-save or delete config."""
+        stored_configs = {
+            "test_plugin:wedding": {"enabled": True},
+        }
+        new_plugin = MagicMock(spec=PluginBase)
+        new_plugin.validate_config.return_value = []
+        new_plugin._validate_refresh_seconds.return_value = []
+        new_plugin.enabled = False
+        new_plugin.config = {}
+        mock_loader.create_instance.return_value = new_plugin
+
+        mock_config_manager = MagicMock()
+        with patch("src.config_manager.get_config_manager", return_value=mock_config_manager):
+            registry_with_plugin._restore_instances(stored_configs)
+
+        mock_config_manager.set_plugin_config.assert_not_called()
+        mock_config_manager.delete_plugin_config.assert_not_called()
 
 
 # ── edge cases ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #774 — additional plugin instances with mixed-case labels (e.g. `FijiAustralia`) rendered as `???` on the board.

**Root cause:** `_get_variable_value` lowercases the variable source (`parts[0].lower()`) for case-insensitive lookup, but the registry stored compound keys with original casing. So `{{countdown:FijiAustralia.event_name}}` lowercased to `countdown:fijiaustralia` and missed the `countdown:FijiAustralia` context entry.

**Fix:** Normalize instance labels to lowercase in `create_instance`, and migrate any existing mixed-case keys to lowercase on restore so users with broken installs are auto-fixed on next startup. This matches the existing lowercase-only rule for plugin IDs (enforced in manifest validation at src/plugins/manifest.py:549-552).

The lookup itself in src/templates/engine.py is intentionally case-insensitive — that supports users typing variables in the plain-text editor where any case is acceptable — so the right fix is to make storage canonical, not to change the engine.

## Verified manually

Reproduced and confirmed the fix with an end-to-end check (base + mixed-case instance):

```
Render mixed case   : 'Fiji Trip'
Render lowercase    : 'Fiji Trip'
Render all uppercase: 'Fiji Trip'
```

Also verified the on-disk migration of existing mixed-case configs:

```
Before init: countdown:FijiAustralia -> {'event_name': 'Fiji Trip', ...}
After init:  countdown:fijiaustralia -> {'event_name': 'Fiji Trip', ...}  (renamed on disk)
```

## Test plan

- [x] New unit tests cover label normalization, case-collision dedup, and on-disk migration
- [x] Full test suite passes (2972 passed, 11 skipped — no regressions)
- [ ] Manual verification on dev container: create a new countdown instance with a mixed-case label via the UI, build a page referencing its variables, confirm board displays values (not `???`)
- [ ] Upgrade path verification: install with a pre-existing mixed-case instance in config.json, restart, confirm key migrates and template resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)