### PR TITLE
fix(updater): prune old Docker images after successful update

### DIFF
--- a/fiestaupdater/handler.sh
+++ b/fiestaupdater/handler.sh
@@ -371,6 +371,15 @@ handle_update() {
         completed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
         echo "[fiestaupdater] update succeeded; new digest=${after}"
         _write_state "{\"status\":\"success\",\"action\":\"update\",\"service\":\"${FU_SERVICE}\",\"previous_digest\":\"${FU_BEFORE_DIGEST}\",\"previous_image\":\"${FU_BEFORE_IMAGE}\",\"new_digest\":\"${after}\",\"completed_at\":\"${completed_at}\"}"
+        # Remove dangling images left behind by this and previous updates, but
+        # keep the image we just replaced so /rollback can still retag it.
+        echo "[fiestaupdater] pruning old images (keeping rollback target ${FU_BEFORE_DIGEST})..."
+        for img_id in $(docker image ls -q --filter "dangling=true" 2>/dev/null); do
+            full_id=$(docker inspect --format "{{.Id}}" "$img_id" 2>/dev/null || echo "")
+            if [ -n "$full_id" ] && [ "$full_id" != "$FU_BEFORE_DIGEST" ]; then
+                docker image rm "$img_id" 2>/dev/null || true
+            fi
+        done
     ' >>"$logsink" 2>&1 &
 
     respond 202 Accepted "{\"status\":\"queued\",\"action\":\"update\",\"service\":\"${SERVICE}\",\"previous_digest\":\"${before}\",\"previous_image\":\"${before_image}\"}"

--- a/fiestaupdater/tests/handler.bats
+++ b/fiestaupdater/tests/handler.bats
@@ -408,3 +408,58 @@ SH
     grep -q '"status":"in_progress"' "${SANDBOX}/state/last-update.json"
     grep -q '"previous_digest":"sha256:abc123"' "${SANDBOX}/state/last-update.json"
 }
+
+# ---- /update : image pruning ------------------------------------------------
+
+@test "successful update prunes stale dangling images but keeps rollback target" {
+    # Replace the mock docker with one that exposes two dangling images:
+    #   staleimg   → full ID sha256:stale... (older generation, safe to remove)
+    #   rollbackimg → full ID sha256:abc123  (the pre-update image, must be kept)
+    # FU_BEFORE_DIGEST is set from `docker inspect --format '{{.Image}}' fiestaboard`
+    # which the mock returns as sha256:abc123, so rollbackimg must be spared.
+    cat >"${SANDBOX}/docker" <<'SH'
+#!/bin/sh
+echo "$@" >> "${SANDBOX}/docker.calls"
+case "$1" in
+    inspect)
+        case "$3" in
+            *Config.Image*) echo "fiestaboard/fiestaboard:latest" ;;
+            *Id*)
+                case "$4" in
+                    staleimg)    echo "sha256:stalestalestalestaledead000000000000000000000000000000000000000" ;;
+                    rollbackimg) echo "sha256:abc123" ;;
+                    *)           echo "" ;;
+                esac
+                ;;
+            *Image*) echo "sha256:abc123" ;;
+            *)       echo "" ;;
+        esac
+        ;;
+    image)
+        case "$2" in
+            ls) printf 'staleimg\nrollbackimg\n' ;;
+            rm) exit 0 ;;
+        esac
+        ;;
+    compose|tag) exit 0 ;;
+    *) exit 0 ;;
+esac
+SH
+    chmod +x "${SANDBOX}/docker"
+
+    req=$'POST /update HTTP/1.1\r\nHost: x\r\nAuthorization: Bearer test-token-abc\r\nContent-Length: 0\r\n\r\n'
+    send "$req" >/dev/null
+    for _ in 1 2 3 4 5 6 7 8 9 10; do
+        if [ -f "${SANDBOX}/state/last-update.json" ] && \
+           grep -q '"status":"success"' "${SANDBOX}/state/last-update.json"; then
+            break
+        fi
+        sleep 1
+    done
+
+    grep -q '"status":"success"' "${SANDBOX}/state/last-update.json"
+    # Stale image (not the rollback target) must be removed.
+    grep -q 'image rm staleimg' "${SANDBOX}/docker.calls"
+    # Rollback target must NOT be removed.
+    ! grep -q 'image rm rollbackimg' "${SANDBOX}/docker.calls"
+}


### PR DESCRIPTION
## Summary

- Each OTA update pulls a new Docker image but the old one was left on disk as a dangling image with no cleanup
- On a 29GB Raspberry Pi SD card, enough updates eventually fill the filesystem entirely, causing the next update to get stuck mid-pull (the symptom reported in #779)
- After a successful update, the updater now prunes all dangling images **except** the immediately previous one, which must be kept so `/rollback` can retag it locally without re-downloading from the registry

## Test plan

- [x] New bats test `successful update prunes stale dangling images but keeps rollback target` verifies the pruning logic with a custom mock that exposes two dangling images — one older generation (should be removed) and one matching the rollback target (must be kept)
- [x] All 27 handler tests pass

Closes #779

🤖 Generated with [Claude Code](https://claude.com/claude-code)