### PR TITLE
fix: date_time plugin respects profile timezone setting (fixes #781)

### DIFF
--- a/plugins/date_time/__init__.py
+++ b/plugins/date_time/__init__.py
@@ -45,7 +45,10 @@ class DateTimePlugin(PluginBase):
     def fetch_data(self) -> PluginResult:
         """Fetch current date and time data."""
         try:
-            timezone_str = self.config.get("timezone", "America/Los_Angeles")
+            timezone_str = self.config.get("timezone")
+            if not timezone_str:
+                from src.config import Config
+                timezone_str = Config.GENERAL_TIMEZONE or "America/Los_Angeles"
             tz = ZoneInfo(timezone_str)
             now = datetime.now(tz)
             

--- a/plugins/date_time/tests/test_plugin.py
+++ b/plugins/date_time/tests/test_plugin.py
@@ -254,15 +254,28 @@ class TestDateTimePlugin:
         assert result.error is not None
     
     def test_fetch_data_default_timezone(self, sample_manifest):
-        """Test fetch_data uses default timezone when not configured."""
-        plugin = DateTimePlugin(sample_manifest)
-        plugin.config = {"enabled": True}  # No timezone in config
-        
-        result = plugin.fetch_data()
-        
+        """Test fetch_data falls back to LA when neither plugin nor general timezone is set."""
+        with patch('src.config.Config') as mock_config:
+            mock_config.GENERAL_TIMEZONE = ""
+            plugin = DateTimePlugin(sample_manifest)
+            plugin.config = {"enabled": True}  # No timezone in config
+            result = plugin.fetch_data()
+
         assert result.available is True
         assert result.data is not None
-        assert result.data["timezone"] == "America/Los_Angeles"  # Default
+        assert result.data["timezone"] == "America/Los_Angeles"  # Final fallback
+
+    def test_fetch_data_uses_general_timezone(self, sample_manifest):
+        """Test fetch_data falls back to general/profile timezone when plugin timezone is not set."""
+        with patch('src.config.Config') as mock_config:
+            mock_config.GENERAL_TIMEZONE = "America/Denver"
+            plugin = DateTimePlugin(sample_manifest)
+            plugin.config = {"enabled": True}  # No plugin-specific timezone
+            result = plugin.fetch_data()
+
+        assert result.available is True
+        assert result.data is not None
+        assert result.data["timezone"] == "America/Denver"
     
     @patch('plugins.date_time.datetime')
     def test_get_formatted_display(self, mock_datetime, sample_manifest, sample_config):


### PR DESCRIPTION
## Summary
- Fixes #781 — date/time variables on Pages ignored the timezone set on the Profile/Settings page
- When no plugin-specific timezone is configured, `fetch_data()` now falls back to `Config.GENERAL_TIMEZONE` before defaulting to `America/Los_Angeles`

## Root cause
`DateTimePlugin.fetch_data()` hardcoded `"America/Los_Angeles"` as the default when no plugin-level timezone was set, with no awareness of the user's profile timezone.

## Fix
Timezone resolution priority:
1. Date & Time plugin's own timezone setting (if explicitly configured)
2. General/profile timezone (`Config.GENERAL_TIMEZONE` — what the user sets on the Profile page)
3. Fallback: `America/Los_Angeles`

## Test plan
- [x] All 25 existing date_time plugin tests pass
- [x] New `test_fetch_data_uses_general_timezone` — verifies profile timezone is used when plugin timezone is unset
- [x] Updated `test_fetch_data_default_timezone` — verifies final LA fallback when neither is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)