### PR TITLE
feat: tool-call chaining + FiestaBoard MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,47 @@ Then go to **http://localhost:4420** — the service starts automatically once t
 
 ---
 
+## MCP Server
+
+FiestaBoard exposes a built-in **MCP (Model Context Protocol) server** at `/api/mcp`. This lets external AI tools — Claude Desktop, Claude Code, or any MCP-compatible client — fully control your FiestaBoard via conversation: install plugins, create pages, manage schedules, and more.
+
+### Connecting Claude Desktop
+
+Add to your `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "fiestaboard": {
+      "type": "http",
+      "url": "http://fiestaboard.local:4420/api/mcp"
+    }
+  }
+}
+```
+
+### Connecting Claude Code
+
+```bash
+/mcp add fiestaboard --transport http --url http://localhost:4420/api/mcp
+```
+
+### Available tools
+
+The MCP server exposes 26+ tools covering the full FiestaBoard API:
+
+| Category | Tools |
+|----------|-------|
+| Plugins | `list_installed_plugins`, `list_registry_plugins`, `install_plugin`, `enable_plugin`, `disable_plugin`, `uninstall_plugin`, `configure_plugin`, `update_plugin`, `get_template_variables` |
+| Pages | `list_pages`, `get_page`, `create_page`, `update_page`, `delete_page` |
+| Schedules | `list_schedules`, `create_schedule`, `update_schedule`, `delete_schedule` |
+| Carousels | `list_carousels`, `create_carousel`, `update_carousel`, `delete_carousel` |
+| System | `get_system_status`, `get_settings_summary`, `set_active_page`, `set_schedule_mode` |
+
+The server is local-only with no authentication. When FiestaBoard gains a login system, Bearer-token auth will be added.
+
+---
+
 ## Documentation
 
 Full documentation is at **[fiestaboard.app](https://fiestaboard.app)**, including:

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,9 @@ recurring-ical-events>=3.8.2
 # Timezone support (used by santa_tracker, visual_clock, stardate, calendar_sub plugins)
 pytz>=2026.2
 
+# MCP (Model Context Protocol) server — exposes FiestaBoard as an MCP tool server
+mcp>=1.8.0
+
 # Optional: Board Python library (alternative to manual implementation)
 # fiesta>=0.1.0
 

--- a/src/ai/chat.py
+++ b/src/ai/chat.py
@@ -76,6 +76,12 @@ uninstall plugins, or change settings. To take ACTION, emit a fenced
 JSON block with the language tag `fiestaboard`. Each block must contain
 exactly one of these operations:
 
+IMPORTANT — TOOL RESULT MESSAGES: When you see a user message starting
+with "[Tool result:", it is an automated result from a tool you
+previously executed — NOT a new human request. Read the result and
+decide whether to take another action or summarise what was
+accomplished. Do NOT re-explain what you did; just continue the task.
+
 PAGE EDITING (use when in the page editor context):
 
 1. Replace the entire page (use when the user asks for a brand-new page

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -761,6 +761,18 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+# Mount the MCP server at /mcp (accessible at /api/mcp via nginx).
+# Gracefully skipped if the mcp package is not installed.
+try:
+    from .mcp_server import mcp_server as _mcp_server_instance
+    if _mcp_server_instance is not None:
+        app.mount("/mcp", _mcp_server_instance.streamable_http_app())
+        logger.info("FiestaBoard MCP server mounted at /mcp (public: /api/mcp)")
+    else:
+        logger.warning("MCP server disabled — mcp package not installed or failed to initialise")
+except Exception as _mcp_mount_err:  # pragma: no cover
+    logger.warning("Failed to mount MCP server: %s", _mcp_mount_err)
+
 
 # Set up log buffer handler
 log_buffer_handler = LogBufferHandler()

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -1,0 +1,818 @@
+"""FiestaBoard MCP Server.
+
+Exposes all FiestaBoard management operations as MCP (Model Context Protocol)
+tools, enabling external LLMs such as Claude Desktop or Claude Code to control
+FiestaBoard via conversation.
+
+Mount point: ``/mcp``  (accessed as ``/api/mcp`` via nginx)
+
+No authentication is required — this server is intended for local / LAN use.
+When FiestaBoard gains a login system, Bearer-token auth should be added here.
+
+Connection example for Claude Desktop (``claude_desktop_config.json``):
+    {
+        "mcpServers": {
+            "fiestaboard": {
+                "type": "http",
+                "url": "http://fiestaboard.local:4420/api/mcp"
+            }
+        }
+    }
+
+Connection example for Claude Code:
+    Add via: /mcp add fiestaboard --transport http --url http://localhost:4420/api/mcp
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Lazy imports — the MCP package is optional; we log a warning if missing
+# rather than crashing the whole API server on import.
+# ---------------------------------------------------------------------------
+
+try:
+    from mcp.server.fastmcp import FastMCP  # type: ignore[import-untyped]
+    _MCP_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    _MCP_AVAILABLE = False
+    FastMCP = None  # type: ignore[assignment,misc]
+    logger.warning(
+        "mcp package not installed — FiestaBoard MCP server is disabled. "
+        "Add `mcp>=1.8.0` to requirements.txt and rebuild the container."
+    )
+
+
+def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
+    """Construct and return the FastMCP server instance.
+
+    Returns ``None`` if the ``mcp`` package is not installed.
+    """
+    if not _MCP_AVAILABLE:
+        return None
+
+    mcp = FastMCP(
+        "FiestaBoard",
+        stateless_http=True,
+        json_response=True,
+        streamable_http_path="/",
+        instructions=(
+            "FiestaBoard is a smart LED matrix display controller. You can:\n"
+            "  • Manage plugins/integrations (weather, stocks, transit, etc.)\n"
+            "  • Create and edit display pages using template variables from plugins\n"
+            "  • Schedule which page shows at which time of day\n"
+            "  • Create carousels that rotate through multiple pages\n\n"
+            "Typical workflow:\n"
+            "  1. list_installed_plugins() — see what's installed & enabled\n"
+            "  2. list_pages() — see current pages\n"
+            "  3. get_template_variables() — see what variables plugins expose\n"
+            "  4. install/configure plugins as needed\n"
+            "  5. create_page() with template_lines using {{plugin_id.variable_name}} syntax\n"
+            "  6. Optionally schedule pages with create_schedule()\n\n"
+            "Template syntax: variables use double-braces like {{weather.temperature}}. "
+            "Color tokens like {{red}}, {{green}} etc. style text inline."
+        ),
+    )
+
+    # -----------------------------------------------------------------------
+    # Plugin tools
+    # -----------------------------------------------------------------------
+
+    @mcp.tool()
+    def list_installed_plugins() -> str:
+        """List all installed FiestaBoard plugins with their status and config schema.
+
+        Returns a JSON array of plugin objects. Each includes:
+        - id: plugin identifier (use this for other plugin tools)
+        - name: display name
+        - enabled: whether the plugin is active
+        - configured: whether required settings have been filled in
+        - description: what the plugin does
+        - settings_schema: JSON Schema describing configurable fields
+        - config: current configuration (sensitive values masked as '***')
+        """
+        try:
+            from .plugins import get_plugin_registry
+            from .config_manager import get_config_manager
+            registry = get_plugin_registry()
+            cm = get_config_manager()
+            plugins = registry.list_plugins()
+            for p in plugins:
+                cfg = cm.get_plugin_config(p["id"])
+                p["config"] = cm._mask_sensitive(cfg) if cfg else {}
+                p["configured"] = bool(cfg)
+            return json.dumps(plugins, default=str)
+        except Exception as exc:
+            return json.dumps({"error": str(exc)})
+
+    @mcp.tool()
+    def list_registry_plugins() -> str:
+        """List all plugins available to install from the FiestaBoard registry.
+
+        Returns a JSON array. Each entry includes:
+        - id: use this as plugin_id when calling install_plugin()
+        - name, description, category
+        - installed: true if already installed
+        """
+        try:
+            from .plugins import get_plugin_registry
+            registry = get_plugin_registry()
+            return json.dumps(registry.get_registry_entries(), default=str)
+        except Exception as exc:
+            return json.dumps({"error": str(exc)})
+
+    @mcp.tool()
+    def install_plugin(plugin_id: str, auto_enable: bool = True) -> str:
+        """Install a plugin from the official FiestaBoard registry and optionally enable it.
+
+        Args:
+            plugin_id: The plugin identifier from list_registry_plugins() (e.g. 'openweather').
+            auto_enable: Whether to enable the plugin after installation (default: True).
+
+        After installing, use configure_plugin() to set API keys and other settings.
+        Use get_template_variables() to discover the variables the plugin exposes.
+        """
+        try:
+            from .plugins import get_plugin_registry
+            registry = get_plugin_registry()
+            registry.install_from_registry(plugin_id)
+            if auto_enable:
+                registry.enable_plugin(plugin_id)
+            status = "installed and enabled" if auto_enable else "installed (disabled)"
+            return f"Plugin '{plugin_id}' {status} successfully."
+        except Exception as exc:
+            return f"Error installing plugin '{plugin_id}': {exc}"
+
+    @mcp.tool()
+    def enable_plugin(plugin_id: str) -> str:
+        """Enable an installed but currently-disabled plugin.
+
+        Args:
+            plugin_id: The plugin identifier (from list_installed_plugins()).
+        """
+        try:
+            from .plugins import get_plugin_registry
+            registry = get_plugin_registry()
+            registry.enable_plugin(plugin_id)
+            return f"Plugin '{plugin_id}' enabled successfully."
+        except Exception as exc:
+            return f"Error enabling plugin '{plugin_id}': {exc}"
+
+    @mcp.tool()
+    def disable_plugin(plugin_id: str) -> str:
+        """Disable an installed plugin without uninstalling it.
+
+        The plugin can be re-enabled later with enable_plugin().
+
+        Args:
+            plugin_id: The plugin identifier (from list_installed_plugins()).
+        """
+        try:
+            from .plugins import get_plugin_registry
+            registry = get_plugin_registry()
+            registry.disable_plugin(plugin_id)
+            return f"Plugin '{plugin_id}' disabled successfully."
+        except Exception as exc:
+            return f"Error disabling plugin '{plugin_id}': {exc}"
+
+    @mcp.tool()
+    def uninstall_plugin(plugin_id: str) -> str:
+        """Permanently remove an installed plugin.
+
+        WARNING: This is irreversible. The plugin and all its configuration
+        will be deleted. Only external/registry plugins can be uninstalled;
+        built-in plugins cannot be removed.
+
+        Args:
+            plugin_id: The plugin identifier (from list_installed_plugins()).
+        """
+        try:
+            from .plugins import get_plugin_registry
+            registry = get_plugin_registry()
+            registry.uninstall_external_plugin(plugin_id)
+            return f"Plugin '{plugin_id}' uninstalled successfully."
+        except Exception as exc:
+            return f"Error uninstalling plugin '{plugin_id}': {exc}"
+
+    @mcp.tool()
+    def configure_plugin(plugin_id: str, config: Dict[str, Any]) -> str:
+        """Update configuration settings for an installed plugin.
+
+        Use list_installed_plugins() to see the settings_schema for a plugin,
+        which shows all valid config keys, their types, and which are required.
+
+        IMPORTANT: Never guess API keys — only set values the user has provided.
+        Sensitive fields (api_key, password, etc.) must be provided explicitly.
+
+        Args:
+            plugin_id: The plugin identifier.
+            config: Dictionary of configuration key-value pairs to update.
+                    Only include keys you want to change.
+        """
+        try:
+            from .plugins import get_plugin_registry
+            from .config_manager import get_config_manager
+            registry = get_plugin_registry()
+            cm = get_config_manager()
+            # Merge with existing config to avoid wiping unchanged fields
+            existing = cm.get_plugin_config(plugin_id) or {}
+            merged = {**existing, **config}
+            registry.set_plugin_config(plugin_id, merged)
+            # Return masked config so sensitive values aren't echoed back
+            updated = cm.get_plugin_config(plugin_id) or {}
+            return json.dumps({
+                "status": "success",
+                "plugin_id": plugin_id,
+                "config": cm._mask_sensitive(updated),
+            }, default=str)
+        except Exception as exc:
+            return f"Error configuring plugin '{plugin_id}': {exc}"
+
+    @mcp.tool()
+    def update_plugin(plugin_id: str) -> str:
+        """Update an installed plugin to its latest registry version.
+
+        Args:
+            plugin_id: The plugin identifier (from list_installed_plugins()).
+        """
+        try:
+            from .plugins import get_plugin_registry
+            registry = get_plugin_registry()
+            registry.reload_plugin(plugin_id)
+            return f"Plugin '{plugin_id}' updated successfully."
+        except Exception as exc:
+            return f"Error updating plugin '{plugin_id}': {exc}"
+
+    @mcp.tool()
+    def get_template_variables() -> str:
+        """Get all template variables available from enabled plugins.
+
+        Returns a nested JSON object: {plugin_id: {variable_name: {description, example, max_length}}}.
+        Use these variables in page templates as {{plugin_id.variable_name}}.
+
+        Example: {{weather.temperature}}, {{stocks.price}}, {{date_time.time_12h}}
+        """
+        try:
+            from .plugins import get_plugin_registry
+            registry = get_plugin_registry()
+            variables = registry.get_all_variables()
+            return json.dumps(variables, default=str)
+        except Exception as exc:
+            return json.dumps({"error": str(exc)})
+
+    # -----------------------------------------------------------------------
+    # Page tools
+    # -----------------------------------------------------------------------
+
+    @mcp.tool()
+    def list_pages() -> str:
+        """List all display pages on this FiestaBoard.
+
+        Returns a JSON array of page objects with:
+        - id: use this for get_page(), update_page(), delete_page(), schedules
+        - name: display name
+        - type: 'template' (dynamic content), 'single', or 'composite'
+        - device_type: 'flagship' or 'note'
+        - duration_seconds: how long to show the page in carousels
+        """
+        try:
+            from .pages.service import get_page_service
+            svc = get_page_service()
+            pages = svc.list_pages()
+            return json.dumps([p.model_dump() for p in pages], default=str)
+        except Exception as exc:
+            return json.dumps({"error": str(exc)})
+
+    @mcp.tool()
+    def get_page(page_id: str) -> str:
+        """Get full details of a specific page including its template content.
+
+        Args:
+            page_id: The page identifier (from list_pages()).
+
+        Returns a JSON object with all page fields including the template array.
+        Each template line can contain {{plugin.variable}} references and
+        {{color}} tokens like {{red}}, {{green}}, {{white}} etc.
+        """
+        try:
+            from .pages.service import get_page_service
+            svc = get_page_service()
+            page = svc.get_page(page_id)
+            if page is None:
+                return json.dumps({"error": f"Page '{page_id}' not found."})
+            return json.dumps(page.model_dump(), default=str)
+        except Exception as exc:
+            return json.dumps({"error": str(exc)})
+
+    @mcp.tool()
+    def create_page(
+        name: str,
+        template_lines: List[str],
+        device_type: str = "flagship",
+        duration_seconds: int = 300,
+    ) -> str:
+        """Create a new template page on FiestaBoard.
+
+        Template lines use {{plugin.variable}} syntax for dynamic data and
+        {{color}} tokens ({{red}}, {{green}}, {{white}}, etc.) for styling.
+
+        Flagship display is 22 columns × 6 rows.
+        Note display is 15 columns × 3 rows.
+
+        Args:
+            name: Display name for the page.
+            template_lines: List of template strings, one per row. Must match
+                            the number of rows for the device_type
+                            (6 for flagship, 3 for note).
+            device_type: 'flagship' (default) or 'note'.
+            duration_seconds: How long to show this page in a carousel (default: 300).
+
+        Example template_lines for a weather page:
+            ["{{white}}{{= UPPER(weather.city)}}", "{{yellow}}{{weather.temperature}}°F",
+             "{{weather.condition}}", "", "{{date_time.time_12h}}", "{{date_time.date_short}}"]
+        """
+        try:
+            from .pages.service import get_page_service
+            from .pages.models import PageCreate
+            svc = get_page_service()
+            data = PageCreate(
+                name=name,
+                type="template",
+                device_type=device_type,  # type: ignore[arg-type]
+                template=template_lines,
+                duration_seconds=duration_seconds,
+            )
+            page = svc.create_page(data)
+            return json.dumps({
+                "status": "success",
+                "page_id": page.id,
+                "name": page.name,
+                "message": f"Page '{name}' created with id '{page.id}'.",
+            }, default=str)
+        except Exception as exc:
+            return f"Error creating page: {exc}"
+
+    @mcp.tool()
+    def update_page(
+        page_id: str,
+        name: Optional[str] = None,
+        template_lines: Optional[List[str]] = None,
+        duration_seconds: Optional[int] = None,
+    ) -> str:
+        """Update an existing page's name, template content, or duration.
+
+        Args:
+            page_id: The page identifier (from list_pages()).
+            name: New display name (optional).
+            template_lines: New template content (optional). Replaces all lines.
+            duration_seconds: New carousel duration in seconds (optional).
+        """
+        try:
+            from .pages.service import get_page_service
+            from .pages.models import PageUpdate
+            svc = get_page_service()
+            data = PageUpdate(
+                name=name,
+                template=template_lines,
+                duration_seconds=duration_seconds,
+            )
+            page = svc.update_page(page_id, data)
+            if page is None:
+                return json.dumps({"error": f"Page '{page_id}' not found."})
+            return json.dumps({"status": "success", "page_id": page.id, "name": page.name}, default=str)
+        except Exception as exc:
+            return f"Error updating page '{page_id}': {exc}"
+
+    @mcp.tool()
+    def delete_page(page_id: str) -> str:
+        """Delete a page permanently.
+
+        WARNING: This cannot be undone. If this is the last page, a default
+        welcome page will be created automatically.
+
+        Args:
+            page_id: The page identifier (from list_pages()).
+        """
+        try:
+            from .pages.service import get_page_service
+            svc = get_page_service()
+            result = svc.delete_page(page_id)
+            if not result.success:
+                return f"Error deleting page: {result.message}"
+            return f"Page '{page_id}' deleted successfully."
+        except Exception as exc:
+            return f"Error deleting page '{page_id}': {exc}"
+
+    # -----------------------------------------------------------------------
+    # Schedule tools
+    # -----------------------------------------------------------------------
+
+    @mcp.tool()
+    def list_schedules() -> str:
+        """List all scheduled time slots for page display.
+
+        Returns a JSON array of schedule entries with:
+        - id: use this for update_schedule(), delete_schedule()
+        - page_id: which page to show
+        - start_time / end_time: HH:MM format (24h). end_time null = runs until next schedule.
+        - day_pattern: 'all', 'weekdays', 'weekends', or 'custom'
+        - enabled: whether the schedule entry is active
+        """
+        try:
+            from .schedules.service import get_schedule_service
+            svc = get_schedule_service()
+            schedules = svc.list_schedules()
+            return json.dumps([s.model_dump() for s in schedules], default=str)
+        except Exception as exc:
+            return json.dumps({"error": str(exc)})
+
+    @mcp.tool()
+    def create_schedule(
+        page_id: str,
+        start_time: str,
+        day_pattern: str = "all",
+        end_time: Optional[str] = None,
+        enabled: bool = True,
+    ) -> str:
+        """Create a new schedule entry to show a specific page at a specific time.
+
+        Args:
+            page_id: Which page (or carousel) to display. Use IDs from list_pages()
+                     or list_carousels().
+            start_time: When to start showing this page in HH:MM format (24h), e.g. "07:00".
+            day_pattern: When this applies — 'all' (every day), 'weekdays', 'weekends',
+                         or 'custom'. Default: 'all'.
+            end_time: When to stop in HH:MM format. Null means open-ended
+                      (runs until the next schedule or end of day). Default: None.
+            enabled: Whether this schedule is active. Default: True.
+        """
+        try:
+            from .schedules.service import get_schedule_service
+            from .schedules.models import ScheduleCreate
+            svc = get_schedule_service()
+            data = ScheduleCreate(
+                page_id=page_id,
+                start_time=start_time,
+                end_time=end_time,
+                day_pattern=day_pattern,  # type: ignore[arg-type]
+                enabled=enabled,
+            )
+            entry = svc.create_schedule(data)
+            return json.dumps({
+                "status": "success",
+                "schedule_id": entry.id,
+                "message": f"Schedule created: page '{page_id}' from {start_time} on {day_pattern} days.",
+            }, default=str)
+        except Exception as exc:
+            return f"Error creating schedule: {exc}"
+
+    @mcp.tool()
+    def update_schedule(
+        schedule_id: str,
+        page_id: Optional[str] = None,
+        start_time: Optional[str] = None,
+        end_time: Optional[str] = None,
+        day_pattern: Optional[str] = None,
+        enabled: Optional[bool] = None,
+    ) -> str:
+        """Update an existing schedule entry.
+
+        Only the fields you provide will be changed.
+
+        Args:
+            schedule_id: The schedule identifier (from list_schedules()).
+            page_id: New page to display (optional).
+            start_time: New start time in HH:MM format (optional).
+            end_time: New end time in HH:MM format, or None to make open-ended (optional).
+            day_pattern: New day pattern: 'all', 'weekdays', 'weekends', 'custom' (optional).
+            enabled: Enable or disable this schedule entry (optional).
+        """
+        try:
+            from .schedules.service import get_schedule_service
+            from .schedules.models import ScheduleUpdate
+            svc = get_schedule_service()
+            data = ScheduleUpdate(
+                page_id=page_id,
+                start_time=start_time,
+                end_time=end_time,
+                day_pattern=day_pattern,  # type: ignore[arg-type]
+                enabled=enabled,
+            )
+            entry = svc.update_schedule(schedule_id, data)
+            if entry is None:
+                return f"Schedule '{schedule_id}' not found."
+            return json.dumps({"status": "success", "schedule_id": entry.id}, default=str)
+        except Exception as exc:
+            return f"Error updating schedule '{schedule_id}': {exc}"
+
+    @mcp.tool()
+    def delete_schedule(schedule_id: str) -> str:
+        """Delete a schedule entry permanently.
+
+        Args:
+            schedule_id: The schedule identifier (from list_schedules()).
+        """
+        try:
+            from .schedules.service import get_schedule_service
+            svc = get_schedule_service()
+            svc.delete_schedule(schedule_id)
+            return f"Schedule '{schedule_id}' deleted successfully."
+        except Exception as exc:
+            return f"Error deleting schedule '{schedule_id}': {exc}"
+
+    # -----------------------------------------------------------------------
+    # Carousel tools
+    # -----------------------------------------------------------------------
+
+    @mcp.tool()
+    def list_carousels() -> str:
+        """List all carousels (playlists that rotate between multiple pages).
+
+        Returns a JSON array with:
+        - id: use this for update_carousel(), delete_carousel(), or as page_id in schedules
+        - name, page_ids, interval_seconds
+        """
+        try:
+            from .carousels.service import get_carousel_service
+            svc = get_carousel_service()
+            carousels = svc.list_carousels()
+            return json.dumps([c.model_dump() for c in carousels], default=str)
+        except Exception as exc:
+            return json.dumps({"error": str(exc)})
+
+    @mcp.tool()
+    def create_carousel(
+        name: str,
+        page_ids: List[str],
+        interval_seconds: int = 30,
+    ) -> str:
+        """Create a carousel that rotates through multiple pages.
+
+        The carousel ID can be used as the page_id in create_schedule() to
+        schedule the whole playlist at a specific time of day.
+
+        Args:
+            name: Display name for the carousel.
+            page_ids: Ordered list of page IDs to rotate through.
+            interval_seconds: How long to show each page (default: 30). Range: 5–3600.
+        """
+        try:
+            from .carousels.service import get_carousel_service
+            from .carousels.models import CarouselCreate
+            svc = get_carousel_service()
+            data = CarouselCreate(
+                name=name,
+                page_ids=page_ids,
+                interval_seconds=interval_seconds,
+            )
+            carousel = svc.create_carousel(data)
+            return json.dumps({
+                "status": "success",
+                "carousel_id": carousel.id,
+                "name": carousel.name,
+                "message": f"Carousel '{name}' created with {len(page_ids)} pages.",
+            }, default=str)
+        except Exception as exc:
+            return f"Error creating carousel: {exc}"
+
+    @mcp.tool()
+    def update_carousel(
+        carousel_id: str,
+        name: Optional[str] = None,
+        page_ids: Optional[List[str]] = None,
+        interval_seconds: Optional[int] = None,
+    ) -> str:
+        """Update an existing carousel's name, page list, or rotation interval.
+
+        Args:
+            carousel_id: The carousel identifier (from list_carousels()).
+            name: New name (optional).
+            page_ids: New ordered list of page IDs (optional). Replaces entire list.
+            interval_seconds: New rotation interval in seconds (optional).
+        """
+        try:
+            from .carousels.service import get_carousel_service
+            from .carousels.models import CarouselUpdate
+            svc = get_carousel_service()
+            data = CarouselUpdate(
+                name=name,
+                page_ids=page_ids,
+                interval_seconds=interval_seconds,
+            )
+            carousel = svc.update_carousel(carousel_id, data)
+            if carousel is None:
+                return f"Carousel '{carousel_id}' not found."
+            return json.dumps({"status": "success", "carousel_id": carousel.id}, default=str)
+        except Exception as exc:
+            return f"Error updating carousel '{carousel_id}': {exc}"
+
+    @mcp.tool()
+    def delete_carousel(carousel_id: str) -> str:
+        """Delete a carousel permanently.
+
+        Args:
+            carousel_id: The carousel identifier (from list_carousels()).
+        """
+        try:
+            from .carousels.service import get_carousel_service
+            svc = get_carousel_service()
+            svc.delete_carousel(carousel_id)
+            return f"Carousel '{carousel_id}' deleted successfully."
+        except Exception as exc:
+            return f"Error deleting carousel '{carousel_id}': {exc}"
+
+    # -----------------------------------------------------------------------
+    # System tools
+    # -----------------------------------------------------------------------
+
+    @mcp.tool()
+    def get_system_status() -> str:
+        """Get the current status of the FiestaBoard system.
+
+        Returns version, whether the display service is running, plugin system
+        status, and the number of installed/enabled plugins.
+        """
+        try:
+            from .api_server import __version__, _service_running, get_service
+            from .plugins import get_plugin_registry
+            registry = get_plugin_registry()
+            plugins = registry.list_plugins()
+            service = get_service()
+            return json.dumps({
+                "version": __version__,
+                "service_running": _service_running and service is not None,
+                "plugin_system_available": True,
+                "plugins_installed": len(plugins),
+                "plugins_enabled": sum(1 for p in plugins if p.get("enabled")),
+            }, default=str)
+        except Exception as exc:
+            return json.dumps({"error": str(exc)})
+
+    @mcp.tool()
+    def get_settings_summary() -> str:
+        """Get a summary of current FiestaBoard settings (non-sensitive fields only).
+
+        Returns display, output, location, and schedule settings.
+        AI provider credentials and board API keys are intentionally excluded.
+        """
+        try:
+            from .settings.service import get_settings_service
+            svc = get_settings_service()
+            summary: Dict[str, Any] = {}
+            try:
+                display = svc.get_display_settings()
+                summary["display"] = display.__dict__ if hasattr(display, "__dict__") else str(display)
+            except Exception:
+                pass
+            try:
+                location = svc.get_location_settings()
+                summary["location"] = location.__dict__ if hasattr(location, "__dict__") else str(location)
+            except Exception:
+                pass
+            try:
+                output = svc.get_output_settings()
+                summary["output"] = output.__dict__ if hasattr(output, "__dict__") else str(output)
+            except Exception:
+                pass
+            return json.dumps(summary, default=str)
+        except Exception as exc:
+            return json.dumps({"error": str(exc)})
+
+    @mcp.tool()
+    def set_active_page(page_id: str) -> str:
+        """Set which page is currently shown on the FiestaBoard display.
+
+        This immediately changes what's visible on the board.
+
+        Args:
+            page_id: The page or carousel ID to display (from list_pages() or list_carousels()).
+        """
+        try:
+            from .config_manager import get_config_manager
+            cm = get_config_manager()
+            cm.set_active_page(page_id)
+            return f"Active page set to '{page_id}'."
+        except Exception as exc:
+            return f"Error setting active page: {exc}"
+
+    @mcp.tool()
+    def set_schedule_mode(enabled: bool) -> str:
+        """Enable or disable schedule mode.
+
+        When enabled, FiestaBoard automatically switches pages according to
+        the schedule you've configured. When disabled, it shows a fixed page.
+
+        Args:
+            enabled: True to enable schedule-based display, False to disable.
+        """
+        try:
+            from .schedules.service import get_schedule_service
+            svc = get_schedule_service()
+            svc.set_schedule_enabled(enabled)
+            state = "enabled" if enabled else "disabled"
+            return f"Schedule mode {state}."
+        except Exception as exc:
+            return f"Error setting schedule mode: {exc}"
+
+    # -----------------------------------------------------------------------
+    # MCP Resources
+    # -----------------------------------------------------------------------
+
+    @mcp.resource("fiestaboard://plugins")
+    def get_plugins_resource() -> str:
+        """Live list of all installed plugins with status."""
+        try:
+            from .plugins import get_plugin_registry
+            registry = get_plugin_registry()
+            plugins = registry.list_plugins()
+            lines = [f"# Installed Plugins ({len(plugins)} total)\n"]
+            for p in plugins:
+                status = "✓ enabled" if p.get("enabled") else "✗ disabled"
+                lines.append(f"- **{p['name']}** (`{p['id']}`) — {status}")
+                if p.get("description"):
+                    lines.append(f"  {p['description']}")
+            return "\n".join(lines)
+        except Exception as exc:
+            return f"Error: {exc}"
+
+    @mcp.resource("fiestaboard://pages")
+    def get_pages_resource() -> str:
+        """Live list of all pages."""
+        try:
+            from .pages.service import get_page_service
+            svc = get_page_service()
+            pages = svc.list_pages()
+            lines = [f"# Pages ({len(pages)} total)\n"]
+            for p in pages:
+                lines.append(f"- **{p.name}** (`{p.id}`) — {p.type}, {p.device_type}")
+            return "\n".join(lines)
+        except Exception as exc:
+            return f"Error: {exc}"
+
+    @mcp.resource("fiestaboard://variables")
+    def get_variables_resource() -> str:
+        """All template variables from enabled plugins."""
+        try:
+            from .plugins import get_plugin_registry
+            registry = get_plugin_registry()
+            variables = registry.get_all_variables()
+            lines = ["# Available Template Variables\n",
+                     "Use these in page templates as `{{plugin.variable}}`.\n"]
+            for plugin_id, vars_dict in variables.items():
+                lines.append(f"\n## {plugin_id}")
+                for var_name, meta in vars_dict.items():
+                    desc = meta.get("description", "")
+                    example = meta.get("example", "")
+                    example_str = f" (e.g. `{example}`)" if example else ""
+                    lines.append(f"- `{{{{{plugin_id}.{var_name}}}}}` — {desc}{example_str}")
+            return "\n".join(lines)
+        except Exception as exc:
+            return f"Error: {exc}"
+
+    # -----------------------------------------------------------------------
+    # MCP Prompts
+    # -----------------------------------------------------------------------
+
+    @mcp.prompt()
+    def setup_fiestaboard() -> str:
+        """Guide for setting up FiestaBoard from scratch."""
+        return (
+            "Help me set up FiestaBoard from scratch. Please:\n"
+            "1. Start by calling list_installed_plugins() to see what's already installed\n"
+            "2. Call list_pages() to see current pages\n"
+            "3. Ask me what kind of information I want to display\n"
+            "4. Suggest and install appropriate plugins\n"
+            "5. Guide me through configuring each plugin with the right API keys / settings\n"
+            "6. Create pages using the plugin variables\n"
+            "7. Optionally set up a schedule or carousel\n\n"
+            "Be conversational and explain what each step does."
+        )
+
+    @mcp.prompt()
+    def create_display_page(topic: str = "weather") -> str:
+        """Create a new display page for a specific topic."""
+        return (
+            f"Help me create a FiestaBoard display page for: {topic}\n\n"
+            "Please:\n"
+            "1. Check list_installed_plugins() for relevant plugins\n"
+            "2. If needed, suggest installing a plugin and guide me through configuration\n"
+            "3. Call get_template_variables() to find the right variable references\n"
+            "4. Create a well-designed page with create_page() using those variables\n"
+            "5. Offer to schedule the page if appropriate\n\n"
+            "Flagship display is 22×6 characters. Use colour tokens like {{yellow}}, "
+            "{{white}}, {{green}} to make it visually clear."
+        )
+
+    return mcp
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton — imported by api_server.py
+# ---------------------------------------------------------------------------
+
+mcp_server = _build_mcp_server()

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -667,18 +667,18 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
             try:
                 display = svc.get_display_settings()
                 summary["display"] = display.__dict__ if hasattr(display, "__dict__") else str(display)
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("get_settings_summary: could not fetch display settings: %s", exc)
             try:
                 location = svc.get_location_settings()
                 summary["location"] = location.__dict__ if hasattr(location, "__dict__") else str(location)
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("get_settings_summary: could not fetch location settings: %s", exc)
             try:
                 output = svc.get_output_settings()
                 summary["output"] = output.__dict__ if hasattr(output, "__dict__") else str(output)
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.debug("get_settings_summary: could not fetch output settings: %s", exc)
             return json.dumps(summary, default=str)
         except Exception as exc:
             return json.dumps({"error": str(exc)})

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -18,7 +18,7 @@ Strategy
 from __future__ import annotations
 
 import json
-from typing import Any, Dict
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,834 @@
+"""Tests for the FiestaBoard MCP server (src/mcp_server.py).
+
+Tools are exercised directly by calling the inner functions returned by
+_build_mcp_server(), bypassing the MCP JSON-RPC layer. Services are mocked
+so no real filesystem/network IO is needed.
+
+Strategy
+--------
+- Import mcp_server._build_mcp_server and call it; the returned FastMCP
+  object exposes the tool functions via its internal registry so we can
+  introspect what tools were registered.
+- For execution testing we call the registered tool functions directly
+  through the FastMCP tool manager.
+- Service singletons are patched at the module level so the lazy-import
+  paths inside the tools resolve to our mocks.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Skip entire module if the mcp package isn't installed
+# ---------------------------------------------------------------------------
+
+pytest.importorskip("mcp", reason="mcp package not installed")
+
+from src.mcp_server import _build_mcp_server, mcp_server, _MCP_AVAILABLE  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _call_tool(mcp_instance: Any, tool_name: str, **kwargs: Any) -> Any:
+    """Synchronously call a registered MCP tool by name.
+
+    FastMCP registers tools in ``_tool_manager``. Each tool's ``fn`` is the
+    original decorated function.  We call it directly, bypassing JSON-RPC.
+    """
+    mgr = mcp_instance._tool_manager
+    tool = mgr._tools.get(tool_name)
+    if tool is None:
+        raise KeyError(f"Tool '{tool_name}' not registered. Available: {list(mgr._tools)}")
+    import asyncio
+    result = tool.fn(**kwargs)
+    if asyncio.iscoroutine(result):
+        result = asyncio.get_event_loop().run_until_complete(result)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def mcp():
+    """Build a fresh MCP server instance for the test module."""
+    instance = _build_mcp_server()
+    assert instance is not None, "MCP package is installed but _build_mcp_server() returned None"
+    return instance
+
+
+@pytest.fixture
+def mock_registry():
+    """Minimal mock plugin registry."""
+    registry = MagicMock()
+    registry.list_plugins.return_value = [
+        {
+            "id": "openweather",
+            "name": "OpenWeather",
+            "enabled": True,
+            "description": "Weather data",
+            "settings_schema": {"type": "object", "properties": {"api_key": {"type": "string"}}},
+        }
+    ]
+    registry.get_registry_entries.return_value = [
+        {"id": "openweather", "name": "OpenWeather", "description": "Weather data", "installed": True},
+        {"id": "stocks", "name": "Stocks", "description": "Stock prices", "installed": False},
+    ]
+    registry.get_all_variables.return_value = {
+        "openweather": {
+            "temperature": {"description": "Current temperature", "example": "72°F"},
+            "condition": {"description": "Weather condition", "example": "Sunny"},
+        }
+    }
+    return registry
+
+
+@pytest.fixture
+def mock_config_manager():
+    """Minimal mock config manager."""
+    cm = MagicMock()
+    cm.get_plugin_config.return_value = {"api_key": "secret123", "units": "imperial"}
+    cm._mask_sensitive.return_value = {"api_key": "***", "units": "imperial"}
+    return cm
+
+
+@pytest.fixture
+def mock_page_service():
+    """Minimal mock page service."""
+    svc = MagicMock()
+    page = MagicMock()
+    page.id = "page-001"
+    page.name = "Weather"
+    page.type = "template"
+    page.device_type = "flagship"
+    page.duration_seconds = 300
+    page.template = ["{{weather.temperature}}", "{{weather.condition}}"]
+    page.model_dump.return_value = {
+        "id": "page-001",
+        "name": "Weather",
+        "type": "template",
+        "device_type": "flagship",
+        "duration_seconds": 300,
+        "template": ["{{weather.temperature}}", "{{weather.condition}}"],
+    }
+    svc.list_pages.return_value = [page]
+    svc.get_page.return_value = page
+    result = MagicMock()
+    result.id = "page-new"
+    result.name = "New Page"
+    svc.create_page.return_value = result
+    svc.update_page.return_value = page
+    delete_result = MagicMock()
+    delete_result.success = True
+    delete_result.message = "Deleted"
+    svc.delete_page.return_value = delete_result
+    return svc
+
+
+@pytest.fixture
+def mock_schedule_service():
+    """Minimal mock schedule service."""
+    svc = MagicMock()
+    entry = MagicMock()
+    entry.id = "sched-001"
+    entry.page_id = "page-001"
+    entry.start_time = "08:00"
+    entry.end_time = None
+    entry.day_pattern = "all"
+    entry.enabled = True
+    entry.model_dump.return_value = {
+        "id": "sched-001",
+        "page_id": "page-001",
+        "start_time": "08:00",
+        "end_time": None,
+        "day_pattern": "all",
+        "enabled": True,
+    }
+    svc.list_schedules.return_value = [entry]
+    svc.create_schedule.return_value = entry
+    svc.update_schedule.return_value = entry
+    return svc
+
+
+@pytest.fixture
+def mock_carousel_service():
+    """Minimal mock carousel service."""
+    svc = MagicMock()
+    c = MagicMock()
+    c.id = "carousel-001"
+    c.name = "Daily"
+    c.page_ids = ["page-001", "page-002"]
+    c.interval_seconds = 30
+    c.model_dump.return_value = {
+        "id": "carousel-001",
+        "name": "Daily",
+        "page_ids": ["page-001", "page-002"],
+        "interval_seconds": 30,
+    }
+    svc.list_carousels.return_value = [c]
+    svc.create_carousel.return_value = c
+    svc.update_carousel.return_value = c
+    return svc
+
+
+@pytest.fixture
+def mock_settings_service():
+    """Minimal mock settings service."""
+    svc = MagicMock()
+    display = MagicMock()
+    display.__dict__ = {"brightness": 80, "refresh_rate": 30}
+    svc.get_display_settings.return_value = display
+    location = MagicMock()
+    location.__dict__ = {"latitude": 40.7128, "longitude": -74.0060, "timezone": "America/New_York"}
+    svc.get_location_settings.return_value = location
+    output = MagicMock()
+    output.__dict__ = {"target": "board"}
+    svc.get_output_settings.return_value = output
+    return svc
+
+
+# ---------------------------------------------------------------------------
+# Module-level guards
+# ---------------------------------------------------------------------------
+
+def test_mcp_available():
+    """_MCP_AVAILABLE is True when the mcp package is installed."""
+    assert _MCP_AVAILABLE is True
+
+
+def test_mcp_server_singleton_not_none():
+    """Module-level mcp_server singleton is not None."""
+    assert mcp_server is not None
+
+
+def test_build_mcp_server_returns_fastmcp(mcp):
+    """_build_mcp_server() returns a FastMCP instance."""
+    from mcp.server.fastmcp import FastMCP
+    assert isinstance(mcp, FastMCP)
+
+
+# ---------------------------------------------------------------------------
+# Tool registration
+# ---------------------------------------------------------------------------
+
+EXPECTED_TOOLS = {
+    # Plugin tools
+    "list_installed_plugins",
+    "list_registry_plugins",
+    "install_plugin",
+    "enable_plugin",
+    "disable_plugin",
+    "uninstall_plugin",
+    "configure_plugin",
+    "update_plugin",
+    "get_template_variables",
+    # Page tools
+    "list_pages",
+    "get_page",
+    "create_page",
+    "update_page",
+    "delete_page",
+    # Schedule tools
+    "list_schedules",
+    "create_schedule",
+    "update_schedule",
+    "delete_schedule",
+    # Carousel tools
+    "list_carousels",
+    "create_carousel",
+    "update_carousel",
+    "delete_carousel",
+    # System tools
+    "get_system_status",
+    "get_settings_summary",
+    "set_active_page",
+    "set_schedule_mode",
+}
+
+
+def test_all_expected_tools_registered(mcp):
+    """All expected tools are registered in the MCP server."""
+    registered = set(mcp._tool_manager._tools.keys())
+    missing = EXPECTED_TOOLS - registered
+    assert not missing, f"Missing tools: {missing}"
+
+
+def test_tool_count(mcp):
+    """MCP server has at least 26 tools registered."""
+    count = len(mcp._tool_manager._tools)
+    assert count >= 26, f"Expected ≥26 tools, found {count}"
+
+
+# ---------------------------------------------------------------------------
+# Plugin tools
+# ---------------------------------------------------------------------------
+
+class TestListInstalledPlugins:
+    def test_returns_json_array(self, mcp, mock_registry, mock_config_manager):
+        with (
+            patch("src.mcp_server.get_plugin_registry", return_value=mock_registry),
+            patch("src.mcp_server.get_config_manager", return_value=mock_config_manager),
+            patch("src.plugins.get_plugin_registry", return_value=mock_registry),
+            patch("src.config_manager.get_config_manager", return_value=mock_config_manager),
+        ):
+            # Call via the tool manager directly
+            result = _call_tool(mcp, "list_installed_plugins")
+        data = json.loads(result)
+        assert isinstance(data, list)
+        assert data[0]["id"] == "openweather"
+
+    def test_includes_config(self, mcp, mock_registry, mock_config_manager):
+        with (
+            patch("src.mcp_server.get_plugin_registry", return_value=mock_registry),
+            patch("src.mcp_server.get_config_manager", return_value=mock_config_manager),
+            patch("src.plugins.get_plugin_registry", return_value=mock_registry),
+            patch("src.config_manager.get_config_manager", return_value=mock_config_manager),
+        ):
+            result = _call_tool(mcp, "list_installed_plugins")
+        data = json.loads(result)
+        assert "config" in data[0]
+
+    def test_error_handling(self, mcp):
+        """Returns JSON error object when service call fails."""
+        with patch("src.plugins.get_plugin_registry", side_effect=RuntimeError("db unavailable")):
+            result = _call_tool(mcp, "list_installed_plugins")
+        data = json.loads(result)
+        assert "error" in data
+
+
+class TestListRegistryPlugins:
+    def test_returns_registry_entries(self, mcp, mock_registry):
+        with patch("src.plugins.get_plugin_registry", return_value=mock_registry):
+            result = _call_tool(mcp, "list_registry_plugins")
+        data = json.loads(result)
+        assert len(data) == 2
+        ids = {d["id"] for d in data}
+        assert "openweather" in ids
+        assert "stocks" in ids
+
+
+class TestInstallPlugin:
+    def test_install_and_enable(self, mcp, mock_registry):
+        with patch("src.plugins.get_plugin_registry", return_value=mock_registry):
+            result = _call_tool(mcp, "install_plugin", plugin_id="stocks")
+        assert "installed and enabled" in result
+        mock_registry.install_from_registry.assert_called_once_with("stocks")
+        mock_registry.enable_plugin.assert_called_once_with("stocks")
+
+    def test_install_without_enable(self, mcp, mock_registry):
+        with patch("src.plugins.get_plugin_registry", return_value=mock_registry):
+            result = _call_tool(mcp, "install_plugin", plugin_id="stocks", auto_enable=False)
+        assert "installed (disabled)" in result
+        mock_registry.enable_plugin.assert_not_called()
+
+    def test_install_error(self, mcp):
+        mock_reg = MagicMock()
+        mock_reg.install_from_registry.side_effect = ValueError("Not in registry")
+        with patch("src.plugins.get_plugin_registry", return_value=mock_reg):
+            result = _call_tool(mcp, "install_plugin", plugin_id="unknown")
+        assert "Error" in result
+        assert "Not in registry" in result
+
+
+class TestEnablePlugin:
+    def test_enable_success(self, mcp, mock_registry):
+        with patch("src.plugins.get_plugin_registry", return_value=mock_registry):
+            result = _call_tool(mcp, "enable_plugin", plugin_id="openweather")
+        assert "enabled successfully" in result
+
+    def test_enable_error(self, mcp):
+        mock_reg = MagicMock()
+        mock_reg.enable_plugin.side_effect = KeyError("openweather not found")
+        with patch("src.plugins.get_plugin_registry", return_value=mock_reg):
+            result = _call_tool(mcp, "enable_plugin", plugin_id="openweather")
+        assert "Error" in result
+
+
+class TestDisablePlugin:
+    def test_disable_success(self, mcp, mock_registry):
+        with patch("src.plugins.get_plugin_registry", return_value=mock_registry):
+            result = _call_tool(mcp, "disable_plugin", plugin_id="openweather")
+        assert "disabled successfully" in result
+
+
+class TestUninstallPlugin:
+    def test_uninstall_success(self, mcp, mock_registry):
+        with patch("src.plugins.get_plugin_registry", return_value=mock_registry):
+            result = _call_tool(mcp, "uninstall_plugin", plugin_id="openweather")
+        assert "uninstalled successfully" in result
+        mock_registry.uninstall_external_plugin.assert_called_once_with("openweather")
+
+
+class TestConfigurePlugin:
+    def test_merges_with_existing_config(self, mcp, mock_registry, mock_config_manager):
+        with (
+            patch("src.plugins.get_plugin_registry", return_value=mock_registry),
+            patch("src.config_manager.get_config_manager", return_value=mock_config_manager),
+        ):
+            result = _call_tool(
+                mcp,
+                "configure_plugin",
+                plugin_id="openweather",
+                config={"api_key": "new-key"},
+            )
+        data = json.loads(result)
+        assert data["status"] == "success"
+        assert data["plugin_id"] == "openweather"
+        # Should have called set_plugin_config with merged dict
+        mock_registry.set_plugin_config.assert_called_once()
+        call_args = mock_registry.set_plugin_config.call_args[0]
+        assert call_args[0] == "openweather"
+        # The merged config should include both existing "units" and new "api_key"
+        merged = call_args[1]
+        assert "api_key" in merged
+
+    def test_returns_masked_config(self, mcp, mock_registry, mock_config_manager):
+        with (
+            patch("src.plugins.get_plugin_registry", return_value=mock_registry),
+            patch("src.config_manager.get_config_manager", return_value=mock_config_manager),
+        ):
+            result = _call_tool(
+                mcp,
+                "configure_plugin",
+                plugin_id="openweather",
+                config={"api_key": "new-key"},
+            )
+        data = json.loads(result)
+        # Sensitive value should be masked
+        assert data["config"]["api_key"] == "***"
+
+    def test_configure_error(self, mcp):
+        mock_reg = MagicMock()
+        mock_cm = MagicMock()
+        mock_cm.get_plugin_config.side_effect = KeyError("plugin not found")
+        with (
+            patch("src.plugins.get_plugin_registry", return_value=mock_reg),
+            patch("src.config_manager.get_config_manager", return_value=mock_cm),
+        ):
+            result = _call_tool(
+                mcp,
+                "configure_plugin",
+                plugin_id="nonexistent",
+                config={"api_key": "x"},
+            )
+        assert "Error" in result
+
+
+class TestGetTemplateVariables:
+    def test_returns_nested_dict(self, mcp, mock_registry):
+        with patch("src.plugins.get_plugin_registry", return_value=mock_registry):
+            result = _call_tool(mcp, "get_template_variables")
+        data = json.loads(result)
+        assert "openweather" in data
+        assert "temperature" in data["openweather"]
+
+
+# ---------------------------------------------------------------------------
+# Page tools
+# ---------------------------------------------------------------------------
+
+class TestListPages:
+    def test_returns_page_list(self, mcp, mock_page_service):
+        with patch("src.pages.service.get_page_service", return_value=mock_page_service):
+            result = _call_tool(mcp, "list_pages")
+        data = json.loads(result)
+        assert isinstance(data, list)
+        assert data[0]["id"] == "page-001"
+
+    def test_error_returns_json_error(self, mcp):
+        mock_svc = MagicMock()
+        mock_svc.list_pages.side_effect = RuntimeError("service down")
+        with patch("src.pages.service.get_page_service", return_value=mock_svc):
+            result = _call_tool(mcp, "list_pages")
+        data = json.loads(result)
+        assert "error" in data
+
+
+class TestGetPage:
+    def test_returns_page_details(self, mcp, mock_page_service):
+        with patch("src.pages.service.get_page_service", return_value=mock_page_service):
+            result = _call_tool(mcp, "get_page", page_id="page-001")
+        data = json.loads(result)
+        assert data["id"] == "page-001"
+        assert "template" in data
+
+    def test_not_found(self, mcp):
+        mock_svc = MagicMock()
+        mock_svc.get_page.return_value = None
+        with patch("src.pages.service.get_page_service", return_value=mock_svc):
+            result = _call_tool(mcp, "get_page", page_id="missing")
+        data = json.loads(result)
+        assert "error" in data
+        assert "not found" in data["error"]
+
+
+class TestCreatePage:
+    def test_creates_page_returns_id(self, mcp, mock_page_service):
+        with patch("src.pages.service.get_page_service", return_value=mock_page_service):
+            result = _call_tool(
+                mcp,
+                "create_page",
+                name="My Page",
+                template_lines=["Line 1", "Line 2", "Line 3", "Line 4", "Line 5", "Line 6"],
+            )
+        data = json.loads(result)
+        assert data["status"] == "success"
+        assert "page_id" in data
+
+    def test_create_page_error(self, mcp):
+        mock_svc = MagicMock()
+        mock_svc.create_page.side_effect = ValueError("invalid template")
+        with patch("src.pages.service.get_page_service", return_value=mock_svc):
+            result = _call_tool(
+                mcp,
+                "create_page",
+                name="Bad Page",
+                template_lines=["only one line"],
+            )
+        assert "Error" in result
+
+
+class TestUpdatePage:
+    def test_update_name(self, mcp, mock_page_service):
+        with patch("src.pages.service.get_page_service", return_value=mock_page_service):
+            result = _call_tool(mcp, "update_page", page_id="page-001", name="New Name")
+        data = json.loads(result)
+        assert data["status"] == "success"
+
+    def test_not_found(self, mcp):
+        mock_svc = MagicMock()
+        mock_svc.update_page.return_value = None
+        with patch("src.pages.service.get_page_service", return_value=mock_svc):
+            result = _call_tool(mcp, "update_page", page_id="missing")
+        data = json.loads(result)
+        assert "error" in data
+
+
+class TestDeletePage:
+    def test_delete_success(self, mcp, mock_page_service):
+        with patch("src.pages.service.get_page_service", return_value=mock_page_service):
+            result = _call_tool(mcp, "delete_page", page_id="page-001")
+        assert "deleted successfully" in result
+
+    def test_delete_failure(self, mcp):
+        mock_svc = MagicMock()
+        fail = MagicMock()
+        fail.success = False
+        fail.message = "Page is in use"
+        mock_svc.delete_page.return_value = fail
+        with patch("src.pages.service.get_page_service", return_value=mock_svc):
+            result = _call_tool(mcp, "delete_page", page_id="page-001")
+        assert "Error" in result or "Page is in use" in result
+
+
+# ---------------------------------------------------------------------------
+# Schedule tools
+# ---------------------------------------------------------------------------
+
+class TestListSchedules:
+    def test_returns_schedule_list(self, mcp, mock_schedule_service):
+        with patch("src.schedules.service.get_schedule_service", return_value=mock_schedule_service):
+            result = _call_tool(mcp, "list_schedules")
+        data = json.loads(result)
+        assert isinstance(data, list)
+        assert data[0]["id"] == "sched-001"
+
+
+class TestCreateSchedule:
+    def test_create_schedule_success(self, mcp, mock_schedule_service):
+        with patch("src.schedules.service.get_schedule_service", return_value=mock_schedule_service):
+            result = _call_tool(
+                mcp,
+                "create_schedule",
+                page_id="page-001",
+                start_time="08:00",
+                day_pattern="weekdays",
+            )
+        data = json.loads(result)
+        assert data["status"] == "success"
+        assert "schedule_id" in data
+
+    def test_create_schedule_error(self, mcp):
+        mock_svc = MagicMock()
+        mock_svc.create_schedule.side_effect = ValueError("invalid time format")
+        with patch("src.schedules.service.get_schedule_service", return_value=mock_svc):
+            result = _call_tool(
+                mcp,
+                "create_schedule",
+                page_id="page-001",
+                start_time="not-a-time",
+            )
+        assert "Error" in result
+
+
+class TestUpdateSchedule:
+    def test_update_success(self, mcp, mock_schedule_service):
+        with patch("src.schedules.service.get_schedule_service", return_value=mock_schedule_service):
+            result = _call_tool(mcp, "update_schedule", schedule_id="sched-001", enabled=False)
+        data = json.loads(result)
+        assert data["status"] == "success"
+
+    def test_not_found(self, mcp):
+        mock_svc = MagicMock()
+        mock_svc.update_schedule.return_value = None
+        with patch("src.schedules.service.get_schedule_service", return_value=mock_svc):
+            result = _call_tool(mcp, "update_schedule", schedule_id="missing")
+        assert "not found" in result
+
+
+class TestDeleteSchedule:
+    def test_delete_success(self, mcp, mock_schedule_service):
+        with patch("src.schedules.service.get_schedule_service", return_value=mock_schedule_service):
+            result = _call_tool(mcp, "delete_schedule", schedule_id="sched-001")
+        assert "deleted successfully" in result
+
+
+# ---------------------------------------------------------------------------
+# Carousel tools
+# ---------------------------------------------------------------------------
+
+class TestListCarousels:
+    def test_returns_carousel_list(self, mcp, mock_carousel_service):
+        with patch("src.carousels.service.get_carousel_service", return_value=mock_carousel_service):
+            result = _call_tool(mcp, "list_carousels")
+        data = json.loads(result)
+        assert data[0]["id"] == "carousel-001"
+        assert len(data[0]["page_ids"]) == 2
+
+
+class TestCreateCarousel:
+    def test_create_success(self, mcp, mock_carousel_service):
+        with patch("src.carousels.service.get_carousel_service", return_value=mock_carousel_service):
+            result = _call_tool(
+                mcp,
+                "create_carousel",
+                name="Morning Show",
+                page_ids=["page-001", "page-002"],
+                interval_seconds=60,
+            )
+        data = json.loads(result)
+        assert data["status"] == "success"
+        assert "carousel_id" in data
+
+
+class TestUpdateCarousel:
+    def test_update_success(self, mcp, mock_carousel_service):
+        with patch("src.carousels.service.get_carousel_service", return_value=mock_carousel_service):
+            result = _call_tool(mcp, "update_carousel", carousel_id="carousel-001", name="Renamed")
+        data = json.loads(result)
+        assert data["status"] == "success"
+
+    def test_not_found(self, mcp):
+        mock_svc = MagicMock()
+        mock_svc.update_carousel.return_value = None
+        with patch("src.carousels.service.get_carousel_service", return_value=mock_svc):
+            result = _call_tool(mcp, "update_carousel", carousel_id="missing")
+        assert "not found" in result
+
+
+class TestDeleteCarousel:
+    def test_delete_success(self, mcp, mock_carousel_service):
+        with patch("src.carousels.service.get_carousel_service", return_value=mock_carousel_service):
+            result = _call_tool(mcp, "delete_carousel", carousel_id="carousel-001")
+        assert "deleted successfully" in result
+
+
+# ---------------------------------------------------------------------------
+# System tools
+# ---------------------------------------------------------------------------
+
+class TestGetSystemStatus:
+    def test_returns_version_and_status(self, mcp, mock_registry):
+        with (
+            patch("src.mcp_server._service_running", False, create=True),
+            patch("src.plugins.get_plugin_registry", return_value=mock_registry),
+        ):
+            # Patch the import inside the tool function
+            import src.api_server as api_mod
+            orig_running = getattr(api_mod, "_service_running", False)
+            try:
+                api_mod._service_running = True
+                with patch("src.api_server.get_service", return_value=MagicMock()):
+                    result = _call_tool(mcp, "get_system_status")
+            finally:
+                api_mod._service_running = orig_running
+        data = json.loads(result)
+        assert "version" in data
+        assert "plugins_installed" in data
+
+    def test_returns_plugin_counts(self, mcp, mock_registry):
+        import src.api_server as api_mod
+        with patch("src.api_server.get_service", return_value=None):
+            result = _call_tool(mcp, "get_system_status")
+        data = json.loads(result)
+        assert isinstance(data.get("plugins_installed"), int)
+
+
+class TestGetSettingsSummary:
+    def test_returns_settings_sections(self, mcp, mock_settings_service):
+        with patch("src.settings.service.get_settings_service", return_value=mock_settings_service):
+            result = _call_tool(mcp, "get_settings_summary")
+        data = json.loads(result)
+        # Should have at least one section
+        assert len(data) > 0
+
+
+class TestSetActivePage:
+    def test_set_active_page(self, mcp):
+        mock_cm = MagicMock()
+        with patch("src.config_manager.get_config_manager", return_value=mock_cm):
+            result = _call_tool(mcp, "set_active_page", page_id="page-001")
+        assert "page-001" in result
+        mock_cm.set_active_page.assert_called_once_with("page-001")
+
+    def test_error_handling(self, mcp):
+        mock_cm = MagicMock()
+        mock_cm.set_active_page.side_effect = ValueError("page not found")
+        with patch("src.config_manager.get_config_manager", return_value=mock_cm):
+            result = _call_tool(mcp, "set_active_page", page_id="bad-id")
+        assert "Error" in result
+
+
+class TestSetScheduleMode:
+    def test_enable(self, mcp, mock_schedule_service):
+        with patch("src.schedules.service.get_schedule_service", return_value=mock_schedule_service):
+            result = _call_tool(mcp, "set_schedule_mode", enabled=True)
+        assert "enabled" in result
+
+    def test_disable(self, mcp, mock_schedule_service):
+        with patch("src.schedules.service.get_schedule_service", return_value=mock_schedule_service):
+            result = _call_tool(mcp, "set_schedule_mode", enabled=False)
+        assert "disabled" in result
+
+
+# ---------------------------------------------------------------------------
+# MCP Resources
+# ---------------------------------------------------------------------------
+
+def _call_resource(mcp_instance: Any, uri: str) -> str:
+    """Call a resource handler directly."""
+    import asyncio
+    mgr = mcp_instance._resource_manager
+    # Resources are keyed by URI template
+    for key, resource in mgr._resources.items():
+        if key == uri or str(key) == uri:
+            result = resource.fn()
+            if asyncio.iscoroutine(result):
+                result = asyncio.get_event_loop().run_until_complete(result)
+            return result
+    raise KeyError(f"Resource '{uri}' not found. Available: {list(mgr._resources.keys())}")
+
+
+class TestMCPResources:
+    def test_plugins_resource(self, mcp, mock_registry):
+        with patch("src.plugins.get_plugin_registry", return_value=mock_registry):
+            result = _call_resource(mcp, "fiestaboard://plugins")
+        assert "OpenWeather" in result
+        assert "openweather" in result
+
+    def test_pages_resource(self, mcp, mock_page_service):
+        with patch("src.pages.service.get_page_service", return_value=mock_page_service):
+            result = _call_resource(mcp, "fiestaboard://pages")
+        assert "Weather" in result
+        assert "page-001" in result
+
+    def test_variables_resource(self, mcp, mock_registry):
+        with patch("src.plugins.get_plugin_registry", return_value=mock_registry):
+            result = _call_resource(mcp, "fiestaboard://variables")
+        assert "temperature" in result
+        assert "openweather" in result
+
+
+# ---------------------------------------------------------------------------
+# MCP Prompts
+# ---------------------------------------------------------------------------
+
+def _call_prompt(mcp_instance: Any, prompt_name: str, **kwargs: Any) -> str:
+    """Call a prompt handler directly."""
+    import asyncio
+    mgr = mcp_instance._prompt_manager
+    prompt = mgr._prompts.get(prompt_name)
+    if prompt is None:
+        raise KeyError(f"Prompt '{prompt_name}' not found. Available: {list(mgr._prompts.keys())}")
+    result = prompt.fn(**kwargs)
+    if asyncio.iscoroutine(result):
+        result = asyncio.get_event_loop().run_until_complete(result)
+    return result
+
+
+class TestMCPPrompts:
+    def test_setup_fiestaboard_prompt(self, mcp):
+        result = _call_prompt(mcp, "setup_fiestaboard")
+        assert "list_installed_plugins" in result
+        assert "list_pages" in result
+
+    def test_create_display_page_prompt_default_topic(self, mcp):
+        result = _call_prompt(mcp, "create_display_page")
+        assert "weather" in result.lower()
+        assert "get_template_variables" in result
+
+    def test_create_display_page_prompt_custom_topic(self, mcp):
+        result = _call_prompt(mcp, "create_display_page", topic="stocks")
+        assert "stocks" in result
+
+
+# ---------------------------------------------------------------------------
+# Error resilience: ensure no tool raises an unhandled exception
+# ---------------------------------------------------------------------------
+
+class TestToolErrorResilience:
+    """All tools should catch exceptions and return an error string / JSON."""
+
+    @pytest.mark.parametrize("tool_name,kwargs", [
+        ("list_installed_plugins", {}),
+        ("list_registry_plugins", {}),
+        ("install_plugin", {"plugin_id": "x"}),
+        ("enable_plugin", {"plugin_id": "x"}),
+        ("disable_plugin", {"plugin_id": "x"}),
+        ("uninstall_plugin", {"plugin_id": "x"}),
+        ("configure_plugin", {"plugin_id": "x", "config": {}}),
+        ("update_plugin", {"plugin_id": "x"}),
+        ("get_template_variables", {}),
+        ("list_pages", {}),
+        ("get_page", {"page_id": "x"}),
+        ("create_page", {"name": "x", "template_lines": []}),
+        ("update_page", {"page_id": "x"}),
+        ("delete_page", {"page_id": "x"}),
+        ("list_schedules", {}),
+        ("create_schedule", {"page_id": "x", "start_time": "08:00"}),
+        ("update_schedule", {"schedule_id": "x"}),
+        ("delete_schedule", {"schedule_id": "x"}),
+        ("list_carousels", {}),
+        ("create_carousel", {"name": "x", "page_ids": []}),
+        ("update_carousel", {"carousel_id": "x"}),
+        ("delete_carousel", {"carousel_id": "x"}),
+        ("get_system_status", {}),
+        ("get_settings_summary", {}),
+        ("set_active_page", {"page_id": "x"}),
+        ("set_schedule_mode", {"enabled": True}),
+    ])
+    def test_tool_does_not_raise(self, mcp, tool_name: str, kwargs: dict):
+        """Each tool returns a string (not raises) even when all services fail."""
+        with (
+            patch("src.plugins.get_plugin_registry", side_effect=RuntimeError("boom")),
+            patch("src.pages.service.get_page_service", side_effect=RuntimeError("boom")),
+            patch("src.schedules.service.get_schedule_service", side_effect=RuntimeError("boom")),
+            patch("src.carousels.service.get_carousel_service", side_effect=RuntimeError("boom")),
+            patch("src.settings.service.get_settings_service", side_effect=RuntimeError("boom")),
+            patch("src.config_manager.get_config_manager", side_effect=RuntimeError("boom")),
+            patch("src.api_server.get_service", side_effect=RuntimeError("boom")),
+        ):
+            result = _call_tool(mcp, tool_name, **kwargs)
+        assert result is not None
+        assert isinstance(result, str)
+        # Must not be empty
+        assert len(result) > 0

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -182,17 +182,18 @@ def mock_carousel_service():
 
 @pytest.fixture
 def mock_settings_service():
-    """Minimal mock settings service."""
+    """Minimal mock settings service.
+
+    Uses SimpleNamespace for return values so Python 3.14's stricter
+    MagicMock.__dict__ handling doesn't interfere.
+    """
+    from types import SimpleNamespace
     svc = MagicMock()
-    display = MagicMock()
-    display.__dict__ = {"brightness": 80, "refresh_rate": 30}
-    svc.get_display_settings.return_value = display
-    location = MagicMock()
-    location.__dict__ = {"latitude": 40.7128, "longitude": -74.0060, "timezone": "America/New_York"}
-    svc.get_location_settings.return_value = location
-    output = MagicMock()
-    output.__dict__ = {"target": "board"}
-    svc.get_output_settings.return_value = output
+    svc.get_display_settings.return_value = SimpleNamespace(brightness=80, refresh_rate=30)
+    svc.get_location_settings.return_value = SimpleNamespace(
+        latitude=40.7128, longitude=-74.0060, timezone="America/New_York"
+    )
+    svc.get_output_settings.return_value = SimpleNamespace(target="board")
     return svc
 
 
@@ -274,13 +275,12 @@ def test_tool_count(mcp):
 
 class TestListInstalledPlugins:
     def test_returns_json_array(self, mcp, mock_registry, mock_config_manager):
+        # The tool uses lazy imports (`from .plugins import get_plugin_registry`)
+        # so we patch the canonical module locations, not src.mcp_server.
         with (
-            patch("src.mcp_server.get_plugin_registry", return_value=mock_registry),
-            patch("src.mcp_server.get_config_manager", return_value=mock_config_manager),
             patch("src.plugins.get_plugin_registry", return_value=mock_registry),
             patch("src.config_manager.get_config_manager", return_value=mock_config_manager),
         ):
-            # Call via the tool manager directly
             result = _call_tool(mcp, "list_installed_plugins")
         data = json.loads(result)
         assert isinstance(data, list)
@@ -288,8 +288,6 @@ class TestListInstalledPlugins:
 
     def test_includes_config(self, mcp, mock_registry, mock_config_manager):
         with (
-            patch("src.mcp_server.get_plugin_registry", return_value=mock_registry),
-            patch("src.mcp_server.get_config_manager", return_value=mock_config_manager),
             patch("src.plugins.get_plugin_registry", return_value=mock_registry),
             patch("src.config_manager.get_config_manager", return_value=mock_config_manager),
         ):

--- a/web/src/__tests__/ai-action-confirmation.test.tsx
+++ b/web/src/__tests__/ai-action-confirmation.test.tsx
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AiActionConfirmation } from "@/components/ai-action-confirmation";
+import type { ToolCall } from "@/lib/ai-chat-types";
+
+// ---------------------------------------------------------------------------
+// Minimal ToolCall fixtures
+// ---------------------------------------------------------------------------
+
+const installCall: ToolCall = {
+  id: "tc1",
+  op: "install_plugin",
+  args: { plugin_id: "openweather", source: "registry" },
+};
+
+const uninstallCall: ToolCall = {
+  id: "tc2",
+  op: "uninstall_plugin",
+  args: { plugin_id: "openweather" },
+};
+
+const enableCall: ToolCall = {
+  id: "tc3",
+  op: "enable_plugin",
+  args: { plugin_id: "stocks" },
+};
+
+describe("AiActionConfirmation", () => {
+  it("renders action label and description", () => {
+    render(
+      <AiActionConfirmation
+        call={installCall}
+        onAllow={vi.fn()}
+        onDeny={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/install plugin: openweather/i)).toBeInTheDocument();
+  });
+
+  it("shows Allow and Deny buttons in pending state", () => {
+    render(
+      <AiActionConfirmation
+        call={installCall}
+        onAllow={vi.fn()}
+        onDeny={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /allow/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /deny/i })).toBeInTheDocument();
+  });
+
+  it("calls onAllow when Allow is clicked and shows Done state", async () => {
+    const onAllow = vi.fn().mockResolvedValue(undefined);
+    const user = userEvent.setup();
+    render(
+      <AiActionConfirmation
+        call={installCall}
+        onAllow={onAllow}
+        onDeny={vi.fn()}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /allow/i }));
+    expect(onAllow).toHaveBeenCalledOnce();
+    await waitFor(() =>
+      expect(screen.getByText(/done/i)).toBeInTheDocument(),
+    );
+  });
+
+  it("calls onDeny when Deny is clicked and shows Denied state", async () => {
+    const onDeny = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <AiActionConfirmation
+        call={installCall}
+        onAllow={vi.fn()}
+        onDeny={onDeny}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /deny/i }));
+    expect(onDeny).toHaveBeenCalledOnce();
+    expect(screen.getByText(/denied/i)).toBeInTheDocument();
+  });
+
+  it("autoAllow=true auto-fires onAllow on mount for non-destructive ops", async () => {
+    const onAllow = vi.fn().mockResolvedValue(undefined);
+    render(
+      <AiActionConfirmation
+        call={enableCall}
+        onAllow={onAllow}
+        onDeny={vi.fn()}
+        autoAllow
+      />,
+    );
+    await waitFor(() => expect(onAllow).toHaveBeenCalledOnce());
+  });
+
+  it("autoAllow=true does NOT auto-fire for destructive ops", async () => {
+    const onAllow = vi.fn().mockResolvedValue(undefined);
+    render(
+      <AiActionConfirmation
+        call={uninstallCall}
+        onAllow={onAllow}
+        onDeny={vi.fn()}
+        autoAllow
+      />,
+    );
+    // Wait a tick to ensure useEffect has run
+    await new Promise((r) => setTimeout(r, 50));
+    expect(onAllow).not.toHaveBeenCalled();
+    // Allow/Deny buttons should still be visible
+    expect(screen.getByRole("button", { name: /allow/i })).toBeInTheDocument();
+  });
+
+  it("autoAllow=false (default) does not auto-fire", async () => {
+    const onAllow = vi.fn().mockResolvedValue(undefined);
+    render(
+      <AiActionConfirmation
+        call={installCall}
+        onAllow={onAllow}
+        onDeny={vi.fn()}
+        autoAllow={false}
+      />,
+    );
+    await new Promise((r) => setTimeout(r, 50));
+    expect(onAllow).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: /allow/i })).toBeInTheDocument();
+  });
+
+  it("resets to pending (not stuck in 'running') if onAllow throws", async () => {
+    const onAllow = vi.fn().mockRejectedValue(new Error("network error"));
+    const user = userEvent.setup();
+    render(
+      <AiActionConfirmation
+        call={installCall}
+        onAllow={onAllow}
+        onDeny={vi.fn()}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /allow/i }));
+    // After error, buttons should reappear (state resets to pending)
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /allow/i })).toBeInTheDocument(),
+    );
+  });
+
+  it("uses destructive button variant for uninstall_plugin", () => {
+    render(
+      <AiActionConfirmation
+        call={uninstallCall}
+        onAllow={vi.fn()}
+        onDeny={vi.fn()}
+      />,
+    );
+    // The Allow button should still be present
+    expect(screen.getByRole("button", { name: /allow/i })).toBeInTheDocument();
+  });
+});

--- a/web/src/__tests__/ai-chat-panel.test.tsx
+++ b/web/src/__tests__/ai-chat-panel.test.tsx
@@ -12,6 +12,7 @@ const API_BASE = "/api";
 // Mock the streaming hook so tests don't need a real SSE connection.
 // Each test controls status / messages via `mockHook`.
 const mockSend = vi.fn();
+const mockResume = vi.fn();
 const mockCancel = vi.fn();
 const mockReset = vi.fn();
 const mockRetryLast = vi.fn();
@@ -21,6 +22,7 @@ const defaultHookResult = {
   status: "idle" as const,
   error: null,
   send: mockSend,
+  resume: mockResume,
   cancel: mockCancel,
   retryLast: mockRetryLast,
   reset: mockReset,
@@ -282,5 +284,71 @@ describe("AiChatPanel", () => {
     expect(
       await screen.findByText(/provider timeout after 30s/i),
     ).toBeInTheDocument();
+  });
+
+  it("renders tool-result messages as compact pills, not user bubbles", async () => {
+    server.use(
+      http.get(`${API_BASE}/settings/ai`, () =>
+        HttpResponse.json({
+          enabled: true,
+          providers: [CONFIGURED_PROVIDER],
+          default_provider_id: "p1",
+        }),
+      ),
+    );
+    hookResult = {
+      ...defaultHookResult,
+      messages: [
+        {
+          role: "user",
+          content: "[Tool result: install_plugin for \"openweather\" → Success.]",
+          isToolResult: true,
+        },
+      ],
+    };
+
+    render(<AiChatPanel {...defaultProps} />, { wrapper: Wrapper });
+    // The pill strips the "[Tool result: " prefix when displaying
+    expect(
+      await screen.findByText(/install_plugin for "openweather" → Success/),
+    ).toBeInTheDocument();
+  });
+
+  it("shows ChainingModePicker when onChainingModeChange is provided", async () => {
+    server.use(
+      http.get(`${API_BASE}/settings/ai`, () =>
+        HttpResponse.json({
+          enabled: true,
+          providers: [CONFIGURED_PROVIDER],
+          default_provider_id: "p1",
+        }),
+      ),
+    );
+    const onModeChange = vi.fn();
+    render(
+      <AiChatPanel
+        {...defaultProps}
+        chainingMode="manual"
+        onChainingModeChange={onModeChange}
+      />,
+      { wrapper: Wrapper },
+    );
+    // ChainingModePicker renders a button with the mode name
+    expect(await screen.findByTitle(/ai mode: manual/i)).toBeInTheDocument();
+  });
+
+  it("does not show ChainingModePicker when onChainingModeChange is absent", async () => {
+    server.use(
+      http.get(`${API_BASE}/settings/ai`, () =>
+        HttpResponse.json({
+          enabled: true,
+          providers: [CONFIGURED_PROVIDER],
+          default_provider_id: "p1",
+        }),
+      ),
+    );
+    render(<AiChatPanel {...defaultProps} />, { wrapper: Wrapper });
+    await screen.findByText("FiestaBot (Beta)");
+    expect(screen.queryByTitle(/ai mode:/i)).not.toBeInTheDocument();
   });
 });

--- a/web/src/__tests__/general-settings-board-read.test.tsx
+++ b/web/src/__tests__/general-settings-board-read.test.tsx
@@ -157,14 +157,15 @@ describe("GeneralSettings — board read intervals", () => {
 
     render(<GeneralSettings />, { wrapper: TestWrapper });
 
-    await waitFor(() =>
-      expect(document.getElementById("board-read-local")).toBeInTheDocument(),
-    );
+    // Wait for the deferred polling settings to fully load and sync to state
+    const input = await waitFor(() => {
+      const el = document.getElementById("board-read-local") as HTMLInputElement;
+      expect(el).toBeInTheDocument();
+      expect(el.value).toBe("30");
+      return el;
+    });
 
-    const input = document.getElementById("board-read-local") as HTMLInputElement;
     fireEvent.change(input, { target: { value: "45" } });
-    // Flush all pending React state updates (including deferred ones) before blur
-    // so the blur handler reads the updated value, not the initial default.
     await waitFor(() => expect(parseInt(input.value, 10)).toBe(45));
     await act(async () => {});
     fireEvent.blur(input);

--- a/web/src/__tests__/general-settings-board-read.test.tsx
+++ b/web/src/__tests__/general-settings-board-read.test.tsx
@@ -108,14 +108,19 @@ describe("GeneralSettings — board read intervals", () => {
   it("shows warning when cloud interval is below 60 seconds", async () => {
     render(<GeneralSettings />, { wrapper: TestWrapper });
 
-    await waitFor(() =>
-      expect(document.getElementById("board-read-cloud")).toBeInTheDocument(),
-    );
+    // Wait for the API value to load (180) before firing the change,
+    // then flush deferred updates so a late React re-render can't overwrite it.
+    await waitFor(() => {
+      const el = document.getElementById("board-read-cloud") as HTMLInputElement;
+      expect(el).toBeInTheDocument();
+      expect(parseInt(el.value, 10)).toBe(180);
+    });
+    // Flush all deferred React state BEFORE the change so the deferred update
+    // from the API doesn't run after our fireEvent and reset cloud back to 180.
+    await act(async () => {});
 
     const input = document.getElementById("board-read-cloud") as HTMLInputElement;
     fireEvent.change(input, { target: { value: "30" } });
-    // Flush deferred React state so the warning renders before asserting.
-    await act(async () => {});
 
     await waitFor(() => {
       expect(

--- a/web/src/__tests__/mocks/handlers.ts
+++ b/web/src/__tests__/mocks/handlers.ts
@@ -1157,7 +1157,9 @@ export const handlers = [
   // Polling settings endpoints
   http.get(`${API_BASE}/settings/polling`, () => {
     return HttpResponse.json({
-      interval_seconds: 300
+      interval_seconds: 300,
+      board_read_interval_local: 30,
+      board_read_interval_cloud: 180
     });
   }),
 

--- a/web/src/__tests__/use-ai-chat.test.ts
+++ b/web/src/__tests__/use-ai-chat.test.ts
@@ -213,6 +213,35 @@ describe("useAiChat", () => {
     expect(last.toolCalls![0].appliedSnapshot?.name).toBe("New Name");
   });
 
+  it("resume() injects a tool-result message with isToolResult=true and starts streaming", () => {
+    const { result } = renderHook(() => useAiChat(makeOpts()));
+    act(() => { result.current.send("install weather"); });
+    // Stream ends
+    act(() => { resolveStream?.(); });
+    // Now chain via resume
+    act(() => {
+      result.current.resume("[Tool result: install_plugin for \"openweather\" → Success.]");
+    });
+    const msgs = result.current.messages;
+    const resultMsg = msgs.find((m) => m.isToolResult);
+    expect(resultMsg).toBeDefined();
+    expect(resultMsg?.role).toBe("user");
+    expect(resultMsg?.isToolResult).toBe(true);
+    expect(resultMsg?.content).toContain("Tool result");
+    // Should be streaming again
+    expect(result.current.status).toBe("streaming");
+  });
+
+  it("resume() without prior send also starts a stream", () => {
+    const { result } = renderHook(() => useAiChat(makeOpts()));
+    act(() => {
+      result.current.resume("[Tool result: enable_plugin for \"stocks\" → Success.]");
+    });
+    expect(result.current.status).toBe("streaming");
+    const resultMsg = result.current.messages.find((m) => m.isToolResult);
+    expect(resultMsg?.isToolResult).toBe(true);
+  });
+
   it("apply_patch without a base snapshot yields no appliedSnapshot", async () => {
     const onToolCall = vi.fn();
     const { result } = renderHook(() =>

--- a/web/src/components/ai-action-confirmation.tsx
+++ b/web/src/components/ai-action-confirmation.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   Calendar,
   CheckCircle,
@@ -43,6 +43,12 @@ interface AiActionConfirmationProps {
   call: ToolCall & { op: ConfirmableOp };
   onAllow: () => Promise<void> | void;
   onDeny: () => void;
+  /**
+   * When true and the action is not destructive, trigger the action
+   * immediately on mount without requiring a user click. Used by
+   * Autonomous chaining mode.
+   */
+  autoAllow?: boolean;
 }
 
 function actionLabel(call: AiActionConfirmationProps["call"]): string {
@@ -177,6 +183,7 @@ export function AiActionConfirmation({
   call,
   onAllow,
   onDeny,
+  autoAllow = false,
 }: AiActionConfirmationProps) {
   const [state, setState] = useState<ActionState>("pending");
 
@@ -201,6 +208,16 @@ export function AiActionConfirmation({
     call.op === "delete_schedule" ||
     call.op === "trigger_system_update" ||
     call.op === "uninstall_plugin";
+
+  // Autonomous mode: auto-fire on mount for non-destructive ops.
+  const hasAutoFired = useRef(false);
+  useEffect(() => {
+    if (autoAllow && !isDestructive && !hasAutoFired.current) {
+      hasAutoFired.current = true;
+      void handleAllow();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <Card className="p-3 text-sm border-border/60 bg-muted/30">

--- a/web/src/components/ai-chat-panel.tsx
+++ b/web/src/components/ai-chat-panel.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
   AlertCircle,
+  CheckCircle2,
   ChevronRight,
   Eye,
   EyeOff,
@@ -40,6 +41,7 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { api, type AISettings } from "@/lib/api";
 import type {
+  ChainingMode,
   ChatMessage,
   ChatTurnContext,
   LineOp,
@@ -47,6 +49,7 @@ import type {
   ToolCallDisplay,
 } from "@/lib/ai-chat-types";
 import { useAiChat } from "@/lib/use-ai-chat";
+import { ChainingModePicker } from "@/components/chaining-mode-picker";
 
 export interface AiChatPanelProps {
   /** Per-turn editor context (device type + current page snapshot). */
@@ -64,6 +67,17 @@ export interface AiChatPanelProps {
    * install_plugin, update_setting, etc.
    */
   renderToolCallSupplement?: (call: ToolCall) => React.ReactNode;
+  /**
+   * Slot ref: parent writes into this ref so sibling components can
+   * call `resume(toolResultText)` after tool execution completes.
+   * The slot is populated from the `resume` function returned by
+   * `useAiChat`, so it always points at the latest closure.
+   */
+  resumeFnRef?: React.MutableRefObject<((text: string) => void) | null>;
+  /** Current AI chaining mode (controlled by parent). */
+  chainingMode?: ChainingMode;
+  /** Called when the user changes the chaining mode via the in-panel picker. */
+  onChainingModeChange?: (mode: ChainingMode) => void;
 }
 
 export function AiChatPanel({
@@ -73,6 +87,9 @@ export function AiChatPanel({
   onUndo = () => {},
   onClose,
   renderToolCallSupplement,
+  resumeFnRef,
+  chainingMode = "manual",
+  onChainingModeChange,
 }: AiChatPanelProps) {
   const [providerId, setProviderId] = useState<string>("");
   const [model, setModel] = useState<string>("");
@@ -100,13 +117,18 @@ export function AiChatPanel({
   const noModels = !!selectedProvider && !effectiveModel;
   const blocked = aiDisabled || noProviders || noModels;
 
-  const { messages, status, error, send, cancel, retryLast, reset } =
+  const { messages, status, error, send, resume, cancel, retryLast, reset } =
     useAiChat({
       getTurnContext,
       onToolCall,
       providerId: effectiveProviderId || undefined,
       model: effectiveModel || undefined,
     });
+
+  // Slot-ref pattern: keep the parent's ref pointed at the latest resume fn.
+  useEffect(() => {
+    if (resumeFnRef) resumeFnRef.current = resume;
+  }, [resumeFnRef, resume]);
 
   // Boards beyond the 3 most recent are collapsed by default.
   // Users can manually expand them; that choice is tracked here.
@@ -169,6 +191,12 @@ export function AiChatPanel({
             )}
           </div>
           <div className="flex items-center gap-1">
+            {onChainingModeChange && (
+              <ChainingModePicker
+                mode={chainingMode}
+                onChange={onChainingModeChange}
+              />
+            )}
             {messages.length > 0 && (
               <Button
                 type="button"
@@ -496,6 +524,20 @@ function MessageBubble({
   }, [isLastAssistant, message.content, message.toolCalls?.length]);
 
   if (message.role === "user") {
+    // Tool-result injection messages get a compact system pill, not a user bubble.
+    if (message.isToolResult) {
+      const displayText = message.content
+        .replace(/^\[Tool result:\s*/, "")
+        .replace(/\]$/, "");
+      return (
+        <div ref={ref} className="flex justify-center py-0.5">
+          <div className="flex items-center gap-1.5 rounded-full border border-border/40 bg-muted/30 px-2.5 py-1 text-[10px] text-muted-foreground max-w-[85%]">
+            <CheckCircle2 className="h-3 w-3 shrink-0 text-green-500" />
+            <span className="truncate font-mono">{displayText}</span>
+          </div>
+        </div>
+      );
+    }
     return (
       <div ref={ref} className="flex justify-end">
         <div className="max-w-[85%] whitespace-pre-wrap break-words rounded-2xl rounded-br-sm bg-brand-emphasis/15 px-3 py-2 text-sm">

--- a/web/src/components/chaining-mode-picker.tsx
+++ b/web/src/components/chaining-mode-picker.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+/**
+ * Compact mode selector for AI tool-call chaining.
+ *
+ * Renders a small icon+label button that opens a dropdown with three modes:
+ *  • Manual        — no auto-chaining (current behaviour)
+ *  • Auto-continue — chain after each user-confirmed Allow
+ *  • Autonomous    — skip confirmations for non-destructive ops, up to 15 steps
+ *
+ * The selected mode is controlled externally; the parent is responsible for
+ * persisting it to `localStorage["fiestaboard:ai-chaining-mode"]`.
+ */
+
+import { Bot, Hand, Zap } from "lucide-react";
+import type { ChainingMode } from "@/lib/ai-chat-types";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+interface ModeConfig {
+  label: string;
+  Icon: React.ComponentType<{ className?: string }>;
+  description: string;
+}
+
+const MODE_CONFIG: Record<ChainingMode, ModeConfig> = {
+  manual: {
+    label: "Manual",
+    Icon: Hand,
+    description: "I'll re-prompt after each action",
+  },
+  "auto-continue": {
+    label: "Auto-continue",
+    Icon: Zap,
+    description: "Chain actions, confirm each step",
+  },
+  autonomous: {
+    label: "Autonomous",
+    Icon: Bot,
+    description: "Run to completion, skip confirmations",
+  },
+};
+
+const MODES: ChainingMode[] = ["manual", "auto-continue", "autonomous"];
+
+interface ChainingModePickerProps {
+  mode: ChainingMode;
+  onChange: (mode: ChainingMode) => void;
+}
+
+export function ChainingModePicker({ mode, onChange }: ChainingModePickerProps) {
+  const { label, Icon, description } = MODE_CONFIG[mode];
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          className="h-7 gap-1 px-2 text-[11px] text-muted-foreground hover:text-foreground"
+          title={`AI mode: ${label} — ${description}`}
+        >
+          <Icon className="h-3.5 w-3.5" />
+          <span className="hidden sm:inline">{label}</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-60">
+        <DropdownMenuLabel className="text-xs font-medium">
+          AI chaining mode
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {MODES.map((key) => {
+          const cfg = MODE_CONFIG[key];
+          const ItemIcon = cfg.Icon;
+          const isActive = key === mode;
+          return (
+            <DropdownMenuItem
+              key={key}
+              onClick={() => onChange(key)}
+              className="flex items-start gap-2.5 py-2 text-xs"
+            >
+              <ItemIcon
+                className={`mt-0.5 h-3.5 w-3.5 shrink-0 ${
+                  isActive ? "text-brand-emphasis" : "text-muted-foreground"
+                }`}
+              />
+              <div className="flex-1 min-w-0">
+                <div
+                  className={`font-medium ${isActive ? "text-brand-emphasis" : ""}`}
+                >
+                  {cfg.label}
+                </div>
+                <div className="text-muted-foreground leading-tight">
+                  {cfg.description}
+                </div>
+              </div>
+              {isActive && (
+                <div className="ml-auto mt-1 h-1.5 w-1.5 shrink-0 rounded-full bg-brand-emphasis" />
+              )}
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/web/src/components/global-ai-chat-drawer.tsx
+++ b/web/src/components/global-ai-chat-drawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
@@ -13,6 +13,7 @@ import { usePageEditorBridge } from "@/components/page-editor-bridge-context";
 import { useScheduleEditorBridge } from "@/components/schedule-editor-bridge-context";
 import { api, type AISettings } from "@/lib/api";
 import type {
+  ChainingMode,
   ChatTurnContext,
   CreateCarouselArgs,
   CreateScheduleArgs,
@@ -29,12 +30,96 @@ import type {
   UpdateSettingArgs,
 } from "@/lib/ai-chat-types";
 
+// ---------------------------------------------------------------------------
+// Helpers for building tool-result chain messages
+// ---------------------------------------------------------------------------
+
+function buildToolResultText(call: ToolCall, success: boolean, errorMsg?: string): string {
+  const status = success ? "Success" : `Failed: ${errorMsg ?? "unknown error"}`;
+  switch (call.op) {
+    case "install_plugin": {
+      const a = call.args as InstallPluginArgs;
+      return `[Tool result: install_plugin for "${a.plugin_id}" → ${status}.${success ? " Plugin installed and enabled. Continue with any remaining steps." : ""}]`;
+    }
+    case "update_plugin_config": {
+      const a = call.args as UpdatePluginConfigArgs;
+      return `[Tool result: update_plugin_config for "${a.plugin_id}" → ${status}.${success ? " Configuration saved. Continue with any remaining steps." : ""}]`;
+    }
+    case "update_plugin": {
+      const a = call.args as UpdatePluginArgs;
+      return `[Tool result: update_plugin for "${a.plugin_id}" → ${status}.]`;
+    }
+    case "enable_plugin": {
+      const a = call.args as EnablePluginArgs;
+      return `[Tool result: enable_plugin for "${a.plugin_id}" → ${status}.]`;
+    }
+    case "disable_plugin": {
+      const a = call.args as DisablePluginArgs;
+      return `[Tool result: disable_plugin for "${a.plugin_id}" → ${status}.]`;
+    }
+    case "uninstall_plugin": {
+      const a = call.args as UninstallPluginArgs;
+      return `[Tool result: uninstall_plugin for "${a.plugin_id}" → ${status}.]`;
+    }
+    case "update_setting": {
+      const a = call.args as UpdateSettingArgs;
+      return `[Tool result: update_setting (${a.category}) → ${status}.${success ? " Setting applied. Continue with any remaining steps." : ""}]`;
+    }
+    case "create_carousel": {
+      const a = call.args as CreateCarouselArgs;
+      return `[Tool result: create_carousel "${a.name}" → ${status}.${success ? " Carousel created. Continue with any remaining steps." : ""}]`;
+    }
+    case "update_carousel":
+      return `[Tool result: update_carousel → ${status}.]`;
+    case "create_schedule": {
+      const a = call.args as CreateScheduleArgs;
+      return `[Tool result: create_schedule at ${a.start_time} → ${status}.${success ? " Schedule created. Continue with any remaining steps." : ""}]`;
+    }
+    case "update_schedule":
+      return `[Tool result: update_schedule → ${status}.]`;
+    case "delete_schedule":
+      return `[Tool result: delete_schedule → ${status}.]`;
+    case "trigger_system_update":
+      return `[Tool result: trigger_system_update → ${status}.]`;
+    default:
+      return `[Tool result: ${(call as ToolCall).op} → ${status}.]`;
+  }
+}
+
+// How many autonomous steps can chain before pausing and asking the user.
+const AUTONOMOUS_STEP_LIMIT = 15;
+
 export function GlobalAiChatDrawer() {
   const { isOpen, close } = useGlobalAiPanel();
   const router = useRouter();
   const queryClient = useQueryClient();
   const { getEditorSnapshot, applyEditorOp, hasEditor, canEditorUndo, editorUndo } = usePageEditorBridge();
   const { hasScheduleEditor, openScheduleForm } = useScheduleEditorBridge();
+
+  // ---------------------------------------------------------------------------
+  // AI chaining mode
+  // ---------------------------------------------------------------------------
+  const [chainingMode, setChainingMode] = useState<ChainingMode>(() => {
+    if (typeof window !== "undefined") {
+      const stored = localStorage.getItem("fiestaboard:ai-chaining-mode");
+      if (stored === "auto-continue" || stored === "autonomous") return stored;
+    }
+    return "manual";
+  });
+
+  useEffect(() => {
+    localStorage.setItem("fiestaboard:ai-chaining-mode", chainingMode);
+  }, [chainingMode]);
+
+  // Slot ref: AiChatPanel writes its resume() fn here so this component can
+  // trigger re-streaming after tool execution without prop-drilling.
+  const resumeFnRef = useRef<((text: string) => void) | null>(null);
+
+  // Count autonomous steps so we can pause after the limit.
+  const autonomousStepsRef = useRef(0);
+  useEffect(() => {
+    autonomousStepsRef.current = 0;
+  }, [chainingMode]);
 
   const { data: aiSettings } = useQuery<AISettings>({
     queryKey: ["ai-settings"],
@@ -266,15 +351,15 @@ export function GlobalAiChatDrawer() {
           break;
 
         case "create_schedule":
-          void handleCreateSchedule(call.args);
+          void chainAfter(call, () => handleCreateSchedule(call.args))();
           break;
 
         case "update_schedule":
-          void handleUpdateSchedule(call.args);
+          void chainAfter(call, () => handleUpdateSchedule(call.args))();
           break;
 
         case "delete_schedule":
-          void handleDeleteSchedule(call.args);
+          void chainAfter(call, () => handleDeleteSchedule(call.args))();
           break;
 
         case "install_plugin":
@@ -283,6 +368,9 @@ export function GlobalAiChatDrawer() {
         case "update_setting":
         case "create_carousel":
         case "update_carousel":
+        case "enable_plugin":
+        case "disable_plugin":
+        case "uninstall_plugin":
         case "trigger_system_update":
           // Handled declaratively via AiActionConfirmation in the chat
           // thread (see renderToolCallSupplement).
@@ -292,7 +380,7 @@ export function GlobalAiChatDrawer() {
           break;
       }
     },
-    [router, close, hasEditor, applyEditorOp, hasScheduleEditor, openScheduleForm, handleCreateSchedule, handleUpdateSchedule, handleDeleteSchedule],
+    [router, close, hasEditor, applyEditorOp, hasScheduleEditor, openScheduleForm, handleCreateSchedule, handleUpdateSchedule, handleDeleteSchedule, chainAfter],
   );
 
   const handleInstallPlugin = useCallback(
@@ -436,17 +524,61 @@ export function GlobalAiChatDrawer() {
     toast.success("System update started. The board will restart shortly.");
   }, []);
 
+  // ---------------------------------------------------------------------------
+  // Chaining: wrap each handler so that on completion (success or failure),
+  // a `[Tool result: ...]` message is injected and the AI re-streams if the
+  // current mode is auto-continue or autonomous.
+  // ---------------------------------------------------------------------------
+  const chainAfter = useCallback(
+    (call: ToolCall, handler: () => Promise<void>): (() => Promise<void>) =>
+      async () => {
+        try {
+          await handler();
+          if (chainingMode === "manual") return;
+          // Autonomous step-limit guard.
+          if (chainingMode === "autonomous") {
+            autonomousStepsRef.current += 1;
+            if (autonomousStepsRef.current >= AUTONOMOUS_STEP_LIMIT) {
+              autonomousStepsRef.current = 0;
+              setChainingMode("manual");
+              resumeFnRef.current?.(
+                `[Tool result: ${call.op} → Success. ` +
+                `Autonomous mode paused after ${AUTONOMOUS_STEP_LIMIT} steps. ` +
+                `Type 'continue' if you want to keep going.]`,
+              );
+              return;
+            }
+          }
+          resumeFnRef.current?.(buildToolResultText(call, true));
+        } catch (e) {
+          if (chainingMode !== "manual") {
+            resumeFnRef.current?.(buildToolResultText(call, false, String(e)));
+          }
+        }
+      },
+    [chainingMode],
+  );
+
   const renderToolCallSupplement = useCallback(
     (call: ToolCall) => {
       if (call.op === "navigate_to_page") return null;
+      if (call.op === "navigate_to_schedule") return null;
       if (call.op === "replace_page" || call.op === "apply_patch" || call.op === "suggest_variables") return null;
+
+      const isDestructive =
+        call.op === "delete_schedule" ||
+        call.op === "trigger_system_update" ||
+        call.op === "uninstall_plugin";
+
+      const autoAllow = chainingMode === "autonomous" && !isDestructive;
 
       if (call.op === "install_plugin") {
         return (
           <AiActionConfirmation
             call={call}
-            onAllow={() => handleInstallPlugin(call.args as InstallPluginArgs)}
+            onAllow={chainAfter(call, () => handleInstallPlugin(call.args as InstallPluginArgs))}
             onDeny={() => {}}
+            autoAllow={autoAllow}
           />
         );
       }
@@ -454,8 +586,9 @@ export function GlobalAiChatDrawer() {
         return (
           <AiActionConfirmation
             call={call}
-            onAllow={() => handleUpdatePluginConfig(call.args as UpdatePluginConfigArgs)}
+            onAllow={chainAfter(call, () => handleUpdatePluginConfig(call.args as UpdatePluginConfigArgs))}
             onDeny={() => {}}
+            autoAllow={autoAllow}
           />
         );
       }
@@ -463,8 +596,9 @@ export function GlobalAiChatDrawer() {
         return (
           <AiActionConfirmation
             call={call}
-            onAllow={() => handleUpdatePlugin(call.args as UpdatePluginArgs)}
+            onAllow={chainAfter(call, () => handleUpdatePlugin(call.args as UpdatePluginArgs))}
             onDeny={() => {}}
+            autoAllow={autoAllow}
           />
         );
       }
@@ -472,8 +606,9 @@ export function GlobalAiChatDrawer() {
         return (
           <AiActionConfirmation
             call={call}
-            onAllow={() => handleEnablePlugin(call.args as EnablePluginArgs)}
+            onAllow={chainAfter(call, () => handleEnablePlugin(call.args as EnablePluginArgs))}
             onDeny={() => {}}
+            autoAllow={autoAllow}
           />
         );
       }
@@ -481,8 +616,9 @@ export function GlobalAiChatDrawer() {
         return (
           <AiActionConfirmation
             call={call}
-            onAllow={() => handleDisablePlugin(call.args as DisablePluginArgs)}
+            onAllow={chainAfter(call, () => handleDisablePlugin(call.args as DisablePluginArgs))}
             onDeny={() => {}}
+            autoAllow={autoAllow}
           />
         );
       }
@@ -490,8 +626,9 @@ export function GlobalAiChatDrawer() {
         return (
           <AiActionConfirmation
             call={call}
-            onAllow={() => handleUninstallPlugin(call.args as UninstallPluginArgs)}
+            onAllow={chainAfter(call, () => handleUninstallPlugin(call.args as UninstallPluginArgs))}
             onDeny={() => {}}
+            autoAllow={autoAllow}
           />
         );
       }
@@ -499,8 +636,9 @@ export function GlobalAiChatDrawer() {
         return (
           <AiActionConfirmation
             call={call}
-            onAllow={() => handleUpdateSetting(call.args as UpdateSettingArgs)}
+            onAllow={chainAfter(call, () => handleUpdateSetting(call.args as UpdateSettingArgs))}
             onDeny={() => {}}
+            autoAllow={autoAllow}
           />
         );
       }
@@ -508,8 +646,9 @@ export function GlobalAiChatDrawer() {
         return (
           <AiActionConfirmation
             call={call}
-            onAllow={() => handleCreateCarousel(call.args as CreateCarouselArgs)}
+            onAllow={chainAfter(call, () => handleCreateCarousel(call.args as CreateCarouselArgs))}
             onDeny={() => {}}
+            autoAllow={autoAllow}
           />
         );
       }
@@ -517,8 +656,9 @@ export function GlobalAiChatDrawer() {
         return (
           <AiActionConfirmation
             call={call}
-            onAllow={() => handleUpdateCarousel(call.args as UpdateCarouselArgs)}
+            onAllow={chainAfter(call, () => handleUpdateCarousel(call.args as UpdateCarouselArgs))}
             onDeny={() => {}}
+            autoAllow={autoAllow}
           />
         );
       }
@@ -529,14 +669,17 @@ export function GlobalAiChatDrawer() {
         return (
           <AiActionConfirmation
             call={call}
-            onAllow={() => handleTriggerSystemUpdate()}
+            onAllow={chainAfter(call, () => handleTriggerSystemUpdate())}
             onDeny={() => {}}
+            autoAllow={autoAllow} // always false because isDestructive
           />
         );
       }
       return null;
     },
     [
+      chainingMode,
+      chainAfter,
       handleInstallPlugin,
       handleUpdatePluginConfig,
       handleUpdatePlugin,
@@ -570,6 +713,9 @@ export function GlobalAiChatDrawer() {
         renderToolCallSupplement={renderToolCallSupplement}
         canUndo={hasEditor && canEditorUndo()}
         onUndo={hasEditor ? editorUndo : undefined}
+        resumeFnRef={resumeFnRef}
+        chainingMode={chainingMode}
+        onChainingModeChange={setChainingMode}
       />
     </div>
   );

--- a/web/src/components/global-ai-chat-drawer.tsx
+++ b/web/src/components/global-ai-chat-drawer.tsx
@@ -309,6 +309,42 @@ export function GlobalAiChatDrawer() {
     [queryClient, schedulesData],
   );
 
+  // ---------------------------------------------------------------------------
+  // Chaining: wrap each handler so that on completion (success or failure),
+  // a `[Tool result: ...]` message is injected and the AI re-streams if the
+  // current mode is auto-continue or autonomous.
+  // Declared before handleToolCall so the callback can reference it directly.
+  // ---------------------------------------------------------------------------
+  const chainAfter = useCallback(
+    (call: ToolCall, handler: () => Promise<void>): (() => Promise<void>) =>
+      async () => {
+        try {
+          await handler();
+          if (chainingMode === "manual") return;
+          // Autonomous step-limit guard.
+          if (chainingMode === "autonomous") {
+            autonomousStepsRef.current += 1;
+            if (autonomousStepsRef.current >= AUTONOMOUS_STEP_LIMIT) {
+              autonomousStepsRef.current = 0;
+              setChainingMode("manual");
+              resumeFnRef.current?.(
+                `[Tool result: ${call.op} → Success. ` +
+                `Autonomous mode paused after ${AUTONOMOUS_STEP_LIMIT} steps. ` +
+                `Type 'continue' if you want to keep going.]`,
+              );
+              return;
+            }
+          }
+          resumeFnRef.current?.(buildToolResultText(call, true));
+        } catch (e) {
+          if (chainingMode !== "manual") {
+            resumeFnRef.current?.(buildToolResultText(call, false, String(e)));
+          }
+        }
+      },
+    [chainingMode],
+  );
+
   const handleToolCall = useCallback(
     (call: ToolCall): void => {
       switch (call.op) {
@@ -523,41 +559,6 @@ export function GlobalAiChatDrawer() {
     await api.applyUpdate();
     toast.success("System update started. The board will restart shortly.");
   }, []);
-
-  // ---------------------------------------------------------------------------
-  // Chaining: wrap each handler so that on completion (success or failure),
-  // a `[Tool result: ...]` message is injected and the AI re-streams if the
-  // current mode is auto-continue or autonomous.
-  // ---------------------------------------------------------------------------
-  const chainAfter = useCallback(
-    (call: ToolCall, handler: () => Promise<void>): (() => Promise<void>) =>
-      async () => {
-        try {
-          await handler();
-          if (chainingMode === "manual") return;
-          // Autonomous step-limit guard.
-          if (chainingMode === "autonomous") {
-            autonomousStepsRef.current += 1;
-            if (autonomousStepsRef.current >= AUTONOMOUS_STEP_LIMIT) {
-              autonomousStepsRef.current = 0;
-              setChainingMode("manual");
-              resumeFnRef.current?.(
-                `[Tool result: ${call.op} → Success. ` +
-                `Autonomous mode paused after ${AUTONOMOUS_STEP_LIMIT} steps. ` +
-                `Type 'continue' if you want to keep going.]`,
-              );
-              return;
-            }
-          }
-          resumeFnRef.current?.(buildToolResultText(call, true));
-        } catch (e) {
-          if (chainingMode !== "manual") {
-            resumeFnRef.current?.(buildToolResultText(call, false, String(e)));
-          }
-        }
-      },
-    [chainingMode],
-  );
 
   const renderToolCallSupplement = useCallback(
     (call: ToolCall) => {

--- a/web/src/lib/ai-chat-types.ts
+++ b/web/src/lib/ai-chat-types.ts
@@ -195,6 +195,8 @@ export type ToolCallDisplay = ToolCall & {
   deviceType?: DeviceType;
 };
 
+export type ChainingMode = "manual" | "auto-continue" | "autonomous";
+
 export interface ChatMessage {
   role: "user" | "assistant";
   content: string;
@@ -206,6 +208,12 @@ export interface ChatMessage {
   warnings?: string[];
   // True while the assistant is still streaming this message.
   pending?: boolean;
+  /**
+   * When true this message is an automated tool-result injection (role: "user"
+   * under the hood) rather than something the human typed. The chat renderer
+   * displays it as a compact system pill instead of a full user bubble.
+   */
+  isToolResult?: boolean;
 }
 
 export interface CurrentPageSnapshot {

--- a/web/src/lib/use-ai-chat.ts
+++ b/web/src/lib/use-ai-chat.ts
@@ -39,6 +39,13 @@ export interface UseAiChatResult {
   status: "idle" | "streaming" | "error";
   error: string | null;
   send: (text: string) => void;
+  /**
+   * Inject an automated tool-result message and immediately re-stream.
+   * Used by the chaining mechanism after a tool call executes: the result
+   * text is prepended with `[Tool result: ...]` so the backend recognises
+   * it as an automated step continuation rather than a human turn.
+   */
+  resume: (toolResultText: string) => void;
   cancel: () => void;
   retryLast: () => void;
   reset: () => void;
@@ -185,6 +192,20 @@ export function useAiChat(opts: UseAiChatOptions): UseAiChatResult {
     [runStream, messages],
   );
 
+  const resume = useCallback(
+    (toolResultText: string) => {
+      const resultMsg: ChatMessage = {
+        role: "user",
+        content: toolResultText,
+        isToolResult: true,
+      };
+      const next = [...messages, resultMsg];
+      setMessages(next);
+      void runStream(next);
+    },
+    [runStream, messages],
+  );
+
   const cancel = useCallback(() => {
     abortRef.current?.abort();
   }, []);
@@ -211,7 +232,7 @@ export function useAiChat(opts: UseAiChatOptions): UseAiChatResult {
     setError(null);
   }, []);
 
-  return { messages, status, error, send, cancel, retryLast, reset };
+  return { messages, status, error, send, resume, cancel, retryLast, reset };
 }
 
 /**


### PR DESCRIPTION
## Summary

Two features that give Fiestabot and external LLMs full, multi-step control over FiestaBoard.

---

## Feature 1 — Tool-call chaining

Fiestabot used to stall after emitting one tool call: the AI would say it's doing something, then nothing would happen unless the user re-prompted. This PR fixes that with three selectable modes:

| Mode | Behaviour |
|------|-----------|
| **Manual** _(default)_ | Current behaviour — no auto-chaining |
| **Auto-continue** | After user clicks Allow, injects a `[Tool result: ...]` message and re-streams automatically |
| **Autonomous** | Non-destructive ops execute without confirmation and chain to completion (max 15 steps) |

The mode picker lives in the FiestaBot panel header. The chosen mode is persisted to `localStorage["fiestaboard:ai-chaining-mode"]`.

**Destructive ops always require confirmation** even in Autonomous mode: `uninstall_plugin`, `delete_schedule`, `trigger_system_update`.

**Autonomous step limit**: after 15 autonomous steps, the AI pauses and shows a message asking the user to type 'continue' to keep going.

### How it works

```
User: "Install the weather plugin, configure it for NYC, and create a morning page"

AI → install_plugin (Allow) → [Tool result: install_plugin → Success. Plugin installed.]
AI → update_plugin_config (Allow) → [Tool result: update_plugin_config → Success. Configuration saved.]
AI → create_page (page created inline) → "Done! Here's your morning weather page."
```

### Files changed (frontend)

- `web/src/lib/ai-chat-types.ts` — add `ChainingMode` type + `isToolResult` flag on `ChatMessage`
- `web/src/lib/use-ai-chat.ts` — add `resume(toolResultText)` function
- `web/src/components/ai-chat-panel.tsx` — slot-ref pattern for `resume`, `ChainingModePicker` in header, tool-result messages render as compact gray pills
- `web/src/components/chaining-mode-picker.tsx` — **new** — 3-mode dropdown with icons
- `web/src/components/ai-action-confirmation.tsx` — add `autoAllow` prop (auto-fires on mount for Autonomous mode)
- `web/src/components/global-ai-chat-drawer.tsx` — `resumeFnRef` slot, `chainAfter()` wrapper, autonomous step counter

### Files changed (backend)

- `src/ai/chat.py` — adds one paragraph to the grammar so the AI recognises `[Tool result: ...]` messages as automated step continuations rather than human turns

---

## Feature 2 — MCP Server

FiestaBoard now ships a built-in **MCP (Model Context Protocol) server** at `/api/mcp`. External AI tools — Claude Desktop, Claude Code, or any MCP-compatible client — can fully control your FiestaBoard via natural language.

### Connecting

**Claude Desktop** (`claude_desktop_config.json`):
```json
{
  "mcpServers": {
    "fiestaboard": {
      "type": "http",
      "url": "http://fiestaboard.local:4420/api/mcp"
    }
  }
}
```

**Claude Code**:
```bash
/mcp add fiestaboard --transport http --url http://localhost:4420/api/mcp
```

### Tools exposed (26 total)

| Category | Tools |
|----------|-------|
| Plugins | `list_installed_plugins`, `list_registry_plugins`, `install_plugin`, `enable_plugin`, `disable_plugin`, `uninstall_plugin`, `configure_plugin`, `update_plugin`, `get_template_variables` |
| Pages | `list_pages`, `get_page`, `create_page`, `update_page`, `delete_page` |
| Schedules | `list_schedules`, `create_schedule`, `update_schedule`, `delete_schedule` |
| Carousels | `list_carousels`, `create_carousel`, `update_carousel`, `delete_carousel` |
| System | `get_system_status`, `get_settings_summary`, `set_active_page`, `set_schedule_mode` |

Also includes 3 resources (`fiestaboard://plugins`, `fiestaboard://pages`, `fiestaboard://variables`) and 2 guided prompts (`setup_fiestaboard`, `create_display_page`).

The server is **local-only with no auth** for now. When FiestaBoard gains a login system, Bearer-token auth will be added.

### Files changed

- `src/mcp_server.py` — **new** — `FastMCP` server with all 26 tools; graceful degradation if `mcp` package not installed
- `src/api_server.py` — mounts the MCP ASGI app at `/mcp` (nginx proxies as `/api/mcp`)
- `requirements.txt` — adds `mcp>=1.8.0`
- `tests/test_mcp_server.py` — **new** — 80 tests covering all tools, resources, prompts, and error resilience
- `README.md` — new "MCP Server" section with connection examples

---

## Test results

```
3438 passed, 11 skipped, 71 warnings (0:01:46)
```
(+80 new MCP tests, all passing)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
