### PR TITLE
fix(web): chain AI tool calls through navigation and page-edit ops

### DIFF
--- a/web/src/components/global-ai-chat-drawer.tsx
+++ b/web/src/components/global-ai-chat-drawer.tsx
@@ -81,6 +81,21 @@ function buildToolResultText(call: ToolCall, success: boolean, errorMsg?: string
       return `[Tool result: delete_schedule → ${status}.]`;
     case "trigger_system_update":
       return `[Tool result: trigger_system_update → ${status}.]`;
+    case "navigate_to_page": {
+      if (!success) return `[Tool result: navigate_to_page → ${status}.]`;
+      const isNew = call.args.page_id === "new";
+      return `[Tool result: navigate_to_page → Success. ${isNew
+        ? "Blank page editor is now mounted. Surface is 'editor' — use replace_page to ship the template you described, then continue with any remaining steps (schedules, integrations, etc.)."
+        : "Page editor is now mounted. Use apply_patch for incremental edits or replace_page to rewrite, then continue with any remaining steps."}]`;
+    }
+    case "navigate_to_schedule":
+      return `[Tool result: navigate_to_schedule → ${status}.${success ? " Schedule form is open. Continue with create_schedule (or update_schedule) to commit the change." : ""}]`;
+    case "replace_page":
+      return `[Tool result: replace_page → ${status}.${success ? " Page template applied. Continue with any remaining steps." : " Hint: emit navigate_to_page with page_id=\"new\" first if no editor is mounted."}]`;
+    case "apply_patch":
+      return `[Tool result: apply_patch → ${status}.${success ? " Patch applied. Continue with any remaining steps." : " Hint: emit navigate_to_page first if no editor is mounted."}]`;
+    case "suggest_variables":
+      return `[Tool result: suggest_variables → ${status}.${success ? " Suggestions surfaced. Continue with any remaining steps." : ""}]`;
     default:
       return `[Tool result: ${(call as ToolCall).op} → ${status}.]`;
   }
@@ -93,7 +108,14 @@ export function GlobalAiChatDrawer() {
   const { isOpen, close } = useGlobalAiPanel();
   const router = useRouter();
   const queryClient = useQueryClient();
-  const { getEditorSnapshot, applyEditorOp, hasEditor, canEditorUndo, editorUndo } = usePageEditorBridge();
+  const {
+    getEditorSnapshot,
+    applyEditorOp,
+    hasEditor,
+    canEditorUndo,
+    editorUndo,
+    waitForEditor,
+  } = usePageEditorBridge();
   const { hasScheduleEditor, openScheduleForm } = useScheduleEditorBridge();
 
   // ---------------------------------------------------------------------------
@@ -349,41 +371,61 @@ export function GlobalAiChatDrawer() {
     (call: ToolCall): void => {
       switch (call.op) {
         case "navigate_to_page": {
-          const { page_id, device_type } = call.args;
-          if (page_id === "new") {
-            const params = new URLSearchParams();
-            if (device_type) params.set("device", device_type);
-            params.set("fresh", "1");
-            router.push(`/pages/new?${params.toString()}`);
-          } else {
-            router.push(`/pages/edit/${page_id}`);
-          }
+          void chainAfter(call, async () => {
+            const { page_id, device_type } = call.args;
+            if (page_id === "new") {
+              const params = new URLSearchParams();
+              if (device_type) params.set("device", device_type);
+              params.set("fresh", "1");
+              router.push(`/pages/new?${params.toString()}`);
+            } else {
+              router.push(`/pages/edit/${page_id}`);
+            }
+            // Wait out the route transition so the destination editor is
+            // mounted before the chain resumes; otherwise a follow-up
+            // replace_page would race the mount and silently no-op.
+            await waitForEditor();
+          })();
           break;
         }
 
         case "navigate_to_schedule": {
-          const { prefill } = call.args;
-          if (hasScheduleEditor) {
-            openScheduleForm(prefill ?? undefined);
-          } else {
-            const params = new URLSearchParams();
-            if (prefill?.page_id) params.set("prefill_page_id", prefill.page_id);
-            if (prefill?.start_time) params.set("prefill_start", prefill.start_time);
-            if (prefill?.end_time) params.set("prefill_end", prefill.end_time);
-            if (prefill?.day_pattern) params.set("prefill_days", prefill.day_pattern);
-            const qs = params.size ? `?${params.toString()}` : "";
-            router.push(`/schedule${qs}`);
-          }
+          void chainAfter(call, async () => {
+            const { prefill } = call.args;
+            if (hasScheduleEditor) {
+              openScheduleForm(prefill ?? undefined);
+            } else {
+              const params = new URLSearchParams();
+              if (prefill?.page_id) params.set("prefill_page_id", prefill.page_id);
+              if (prefill?.start_time) params.set("prefill_start", prefill.start_time);
+              if (prefill?.end_time) params.set("prefill_end", prefill.end_time);
+              if (prefill?.day_pattern) params.set("prefill_days", prefill.day_pattern);
+              const qs = params.size ? `?${params.toString()}` : "";
+              router.push(`/schedule${qs}`);
+            }
+          })();
           break;
         }
 
         case "replace_page":
         case "apply_patch":
         case "suggest_variables":
-          // Delegate to the page editor if one is mounted.
-          if (hasEditor) {
+          void chainAfter(call, async () => {
+            // Wait on the live handlersRef rather than the closure-captured
+            // `hasEditor` state. When the model emits navigate_to_page and
+            // replace_page in the same stream turn, both handlers share the
+            // pre-navigation closure (hasEditor === false). waitForEditor
+            // resolves as soon as the new editor registers, regardless of
+            // when the React state catches up.
+            const ready = await waitForEditor();
+            if (!ready) {
+              // Surface the missing editor so the AI can recover (e.g. by
+              // first emitting navigate_to_page) instead of the call being
+              // silently dropped.
+              throw new Error("no page editor mounted");
+            }
             applyEditorOp(call);
-          }
+          })();
           break;
 
         case "create_schedule":
@@ -416,7 +458,7 @@ export function GlobalAiChatDrawer() {
           break;
       }
     },
-    [router, close, hasEditor, applyEditorOp, hasScheduleEditor, openScheduleForm, handleCreateSchedule, handleUpdateSchedule, handleDeleteSchedule, chainAfter],
+    [router, close, hasEditor, applyEditorOp, waitForEditor, hasScheduleEditor, openScheduleForm, handleCreateSchedule, handleUpdateSchedule, handleDeleteSchedule, chainAfter],
   );
 
   const handleInstallPlugin = useCallback(

--- a/web/src/components/page-editor-bridge-context.tsx
+++ b/web/src/components/page-editor-bridge-context.tsx
@@ -27,6 +27,13 @@ interface PageEditorBridgeContextValue {
   canEditorUndo: () => boolean;
   /** Trigger undo in the editor. */
   editorUndo: () => void;
+  /**
+   * Resolves once a page editor is mounted (either already, or after the next
+   * `register()` call). Resolves `true` on success and `false` on timeout so
+   * the chaining loop never stalls. Used by `navigate_to_page` to wait out the
+   * route transition before resuming the AI.
+   */
+  waitForEditor: (timeoutMs?: number) => Promise<boolean>;
   /** Called by the page editor to register itself. */
   register: (handlers: EditorHandlers) => void;
   /** Called by the page editor when it unmounts. */
@@ -41,10 +48,18 @@ export function PageEditorBridgeProvider({ children }: { children: React.ReactNo
   // re-read canUndo() reactively after each change.
   const [mutationPulse, setMutationPulse] = useState(0);
   const handlersRef = useRef<EditorHandlers | null>(null);
+  // Pending waiters resolved when the next editor registers. The AI chaining
+  // loop uses these to wait out the route transition after navigate_to_page.
+  const pendingWaitersRef = useRef<Array<(ok: boolean) => void>>([]);
 
   const register = useCallback((handlers: EditorHandlers) => {
     handlersRef.current = handlers;
     setHasEditor(true);
+    if (pendingWaitersRef.current.length > 0) {
+      const waiters = pendingWaitersRef.current;
+      pendingWaitersRef.current = [];
+      for (const resolve of waiters) resolve(true);
+    }
   }, []);
 
   const unregister = useCallback(() => {
@@ -52,6 +67,30 @@ export function PageEditorBridgeProvider({ children }: { children: React.ReactNo
     setHasEditor(false);
     setMutationPulse(0);
   }, []);
+
+  const waitForEditor = useCallback(
+    (timeoutMs: number = 3000): Promise<boolean> => {
+      if (handlersRef.current) return Promise.resolve(true);
+      return new Promise<boolean>((resolve) => {
+        let settled = false;
+        const onReady = (ok: boolean) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          resolve(ok);
+        };
+        const timer = setTimeout(() => {
+          // Remove this waiter so a late register() doesn't double-resolve.
+          pendingWaitersRef.current = pendingWaitersRef.current.filter(
+            (w) => w !== onReady,
+          );
+          onReady(false);
+        }, timeoutMs);
+        pendingWaitersRef.current.push(onReady);
+      });
+    },
+    [],
+  );
 
   const getEditorSnapshot = useCallback(
     () => handlersRef.current?.getSnapshot() ?? null,
@@ -85,6 +124,7 @@ export function PageEditorBridgeProvider({ children }: { children: React.ReactNo
         applyEditorOp,
         canEditorUndo,
         editorUndo,
+        waitForEditor,
         register,
         unregister,
       }}


### PR DESCRIPTION
## Summary

- Auto-continue and Autonomous chaining modes (added in #786) hung after the first tool call whenever the model emitted `navigate_to_page`, `navigate_to_schedule`, `replace_page`, `apply_patch`, or `suggest_variables`. `handleToolCall` only wrapped the schedule and plugin branches in `chainAfter`, so `resumeFnRef` never fired and the conversation stalled on the new page.
- Wire every executable tool op through `chainAfter` in `web/src/components/global-ai-chat-drawer.tsx`. `buildToolResultText` now produces informative `[Tool result: …]` strings for the newly-chained ops so the model knows the next legal step.
- Add `waitForEditor(timeoutMs): Promise<boolean>` on `PageEditorBridge` in `web/src/components/page-editor-bridge-context.tsx`. `navigate_to_page` awaits it so the chain resumes only after the destination editor has registered. `replace_page` / `apply_patch` / `suggest_variables` also gate on `waitForEditor` (which reads the live `handlersRef`) instead of the closure-captured `hasEditor` — when the model emits navigate + replace in the same stream turn, both handlers otherwise share the pre-navigation closure and `replace_page` would race the mount.

## How it was broken

```
AI: "I'll create a new weather page"
  ↓
emit navigate_to_page { page_id: "new" }
  ↓
handleToolCall does router.push(…) — NO chainAfter wrapper
  ↓
resumeFnRef.current?.(…) is never called
  ↓
chain dies; UI appears to hang on /pages/new
```

## How it's fixed

`navigate_to_page` now:
1. Routes to the destination.
2. `await waitForEditor()` — resolves on the next `register()` call or after a 3 s timeout.
3. `chainAfter` injects `[Tool result: navigate_to_page → Success. Blank page editor is now mounted. …]` and re-streams.

`replace_page` / `apply_patch` / `suggest_variables` now:
1. `await waitForEditor()` (gates on the live `handlersRef`, not stale React state).
2. Throw `no page editor mounted` on timeout so `chainAfter` reports failure to the model (lets it self-correct by emitting `navigate_to_page` first).
3. Otherwise call `applyEditorOp(call)`.

## Test plan

- [x] `npm run test:run -- src/__tests__/ai-chat-panel.test.tsx src/__tests__/use-ai-chat.test.ts` — 37/37 green
- [x] ESLint clean on the two touched files (0 errors)
- [x] Playwright MCP end-to-end on the local dev container in Autonomous mode:
  ```
  prompt: "Create a new page titled \"Hello World\" with HELLO WORLD on line 1, the current
           date variable on line 2. Navigate to a new page and replace the template directly.
           Then create a schedule that shows this page every weekday at 7am."
  → navigate_to_page → Success
  → replace_page    → Success
  → navigate_to_schedule → Success
  ```
  No hang; URL transitions `/` → `/pages/new?fresh=1` → `/schedule` as the chain progresses.
- [x] Manual mode unchanged — `chainAfter` early-returns when `chainingMode === "manual"`, so the only behavioural delta is for `auto-continue` and `autonomous`.

## Out of scope

- Backend (`src/ai/chat.py`) tool grammar / system prompt — already correct.
- Adding new tool ops or new chaining modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)