### PR TITLE
feat(ai): AI todo list for multi-step task tracking

### DIFF
--- a/src/ai/chat.py
+++ b/src/ai/chat.py
@@ -363,13 +363,38 @@ SYSTEM:
     will restart briefly during the update. The user will be asked to
     confirm before it runs.
 
+TASK TRACKING (for multi-step sequences of 3 or more actions):
+
+16. Announce and update a running todo list across sequential steps:
+
+    ```fiestaboard
+    {"op": "update_task_list", "args": {
+      "tasks": [
+        {"id": "1", "label": "Create morning page", "status": "done"},
+        {"id": "2", "label": "Schedule 07:00-09:00", "status": "in_progress"},
+        {"id": "3", "label": "Schedule 09:00-12:00", "status": "pending"}
+      ]
+    }}
+    ```
+
+    Use this when performing 3 or more sequential steps:
+    - Emit at the BEGINNING of your plan with all tasks as "pending"
+    - Re-emit BEFORE each step: mark the current task "in_progress", completed
+      tasks "done", remaining tasks "pending"
+    - Use "failed" if a step fails; leave the rest "pending"
+    - Keep `id` values stable across updates (same id = same task)
+    - `update_task_list` does NOT count toward the one-block-per-response
+      limit — you may emit it in the SAME response as one action block
+
 RULES
 - Only emit ops the user actually asked for. If they ask a question or
   want an explanation, just answer in prose — do not emit a tool block.
 - Prefer `apply_patch` over `replace_page` when the user is iterating
   on an existing page. `replace_page` is destructive.
-- You may emit at most one tool block per response. Put any explanation
-  text before or after the block.
+- You may emit at most one ACTION tool block per response. `update_task_list`
+  is a status-only block and does not count as an action — you may emit it
+  in the same response alongside one action block. Put any explanation text
+  before or after the block(s).
 - If you emit a tool block, it must be valid JSON parseable on its own.
   Do not put comments inside the block.
 - Always explain what you are about to do before emitting any block that

--- a/src/ai/chat_ops.py
+++ b/src/ai/chat_ops.py
@@ -437,6 +437,36 @@ class TriggerSystemUpdateOp(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# update_task_list — frontend-only task tracker (no API call).
+# The model emits this to announce and update a running todo list so the
+# user can see progress across multi-step autonomous sessions.
+# ---------------------------------------------------------------------------
+
+TaskStatus = Literal["pending", "in_progress", "done", "failed"]
+
+
+class TaskItem(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    id: str = Field(..., min_length=1, max_length=50)
+    label: str = Field(..., min_length=1, max_length=200)
+    status: TaskStatus = "pending"
+
+
+class UpdateTaskListArgs(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    tasks: List[TaskItem] = Field(default_factory=list)
+
+
+class UpdateTaskListOp(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    op: Literal["update_task_list"]
+    args: UpdateTaskListArgs
+
+
+# ---------------------------------------------------------------------------
 # Discriminated union + helper.
 # ---------------------------------------------------------------------------
 
@@ -460,6 +490,7 @@ ToolCall = Union[
     DeleteScheduleOp,
     UpdatePluginOp,
     TriggerSystemUpdateOp,
+    UpdateTaskListOp,
 ]
 
 
@@ -482,6 +513,7 @@ _OP_REGISTRY = {
     "delete_schedule": DeleteScheduleOp,
     "update_plugin": UpdatePluginOp,
     "trigger_system_update": TriggerSystemUpdateOp,
+    "update_task_list": UpdateTaskListOp,
 }
 
 

--- a/web/src/components/ai-chat-panel.tsx
+++ b/web/src/components/ai-chat-panel.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import {
   AlertCircle,
   CheckCircle2,
   ChevronRight,
+  Circle,
   Eye,
   EyeOff,
   Loader2,
@@ -16,6 +17,7 @@ import {
   Trash2,
   Undo2,
   X,
+  XCircle,
 } from "lucide-react";
 
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -45,6 +47,8 @@ import type {
   ChatMessage,
   ChatTurnContext,
   LineOp,
+  TaskItem,
+  TaskStatus,
   ToolCall,
   ToolCallDisplay,
 } from "@/lib/ai-chat-types";
@@ -78,6 +82,10 @@ export interface AiChatPanelProps {
   chainingMode?: ChainingMode;
   /** Called when the user changes the chaining mode via the in-panel picker. */
   onChainingModeChange?: (mode: ChainingMode) => void;
+  /** Running task list emitted by the AI for multi-step sequences. */
+  taskList?: TaskItem[];
+  /** Called when the user clears the conversation so the parent can reset task state. */
+  onConversationReset?: () => void;
 }
 
 export function AiChatPanel({
@@ -90,6 +98,8 @@ export function AiChatPanel({
   resumeFnRef,
   chainingMode = "manual",
   onChainingModeChange,
+  taskList,
+  onConversationReset,
 }: AiChatPanelProps) {
   const [providerId, setProviderId] = useState<string>("");
   const [model, setModel] = useState<string>("");
@@ -129,6 +139,12 @@ export function AiChatPanel({
   useEffect(() => {
     if (resumeFnRef) resumeFnRef.current = resume;
   }, [resumeFnRef, resume]);
+
+  // Wrap reset to also notify parent (so it can clear the task list etc.)
+  const handleReset = useCallback(() => {
+    reset();
+    onConversationReset?.();
+  }, [reset, onConversationReset]);
 
   // Boards beyond the 3 most recent are collapsed by default.
   // Users can manually expand them; that choice is tracked here.
@@ -198,7 +214,7 @@ export function AiChatPanel({
                 size="icon"
                 variant="ghost"
                 className="h-7 w-7"
-                onClick={reset}
+                onClick={handleReset}
                 title="Clear conversation"
                 aria-label="Clear conversation"
               >
@@ -219,9 +235,14 @@ export function AiChatPanel({
           </div>
         </div>
 
+        {/* Task list panel — shown when the AI has an active task list */}
+        {(taskList?.length ?? 0) > 0 && (
+          <TaskListPanel tasks={taskList!} />
+        )}
+
         {/* Messages — scrollable middle section */}
         <ScrollArea className="min-h-0 flex-1 overflow-x-hidden">
-          <div className="space-y-3 px-4 py-4">
+          <div className="min-w-0 max-w-full overflow-x-hidden space-y-3 px-4 py-4">
             {messages.length === 0 && (
               <EmptyState blocked={blocked} aiDisabled={aiDisabled} />
             )}
@@ -336,6 +357,72 @@ export function AiChatPanel({
 // ---------------------------------------------------------------------------
 // Sub-components
 // ---------------------------------------------------------------------------
+
+function TaskStatusIcon({ status }: { status: TaskStatus }) {
+  switch (status) {
+    case "done":
+      return <CheckCircle2 className="h-3 w-3 shrink-0 text-green-500" />;
+    case "failed":
+      return <XCircle className="h-3 w-3 shrink-0 text-destructive" />;
+    case "in_progress":
+      return <Loader2 className="h-3 w-3 shrink-0 animate-spin text-brand-emphasis" />;
+    case "pending":
+      return <Circle className="h-3 w-3 shrink-0 text-muted-foreground/50" />;
+  }
+}
+
+function TaskListPanel({ tasks }: { tasks: TaskItem[] }) {
+  const allDone =
+    tasks.length > 0 &&
+    tasks.every((t) => t.status === "done" || t.status === "failed");
+  const doneCount = tasks.filter((t) => t.status === "done").length;
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    if (allDone) {
+      const timer = setTimeout(() => setVisible(false), 3000);
+      return () => clearTimeout(timer);
+    } else {
+      setVisible(true);
+    }
+  }, [allDone]);
+
+  if (!visible) return null;
+
+  const pct = tasks.length > 0 ? (doneCount / tasks.length) * 100 : 0;
+
+  return (
+    <div className="border-b px-4 py-2 bg-muted/30 flex-shrink-0">
+      <div className="flex items-center justify-between mb-1.5">
+        <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+          Tasks ({doneCount}/{tasks.length})
+        </span>
+        <div className="h-1 w-20 rounded-full bg-muted overflow-hidden">
+          <div
+            className="h-full bg-brand-emphasis transition-all duration-300"
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+      </div>
+      <ul className="space-y-0.5 max-h-28 overflow-y-auto">
+        {tasks.map((task) => (
+          <li key={task.id} className="flex items-center gap-1.5 text-[11px]">
+            <TaskStatusIcon status={task.status} />
+            <span
+              className={cn(
+                "truncate",
+                task.status === "done" ? "text-muted-foreground line-through" : "",
+                task.status === "failed" ? "text-destructive" : "",
+              )}
+            >
+              {task.label}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
 
 function GradientSparkles({ className }: { className?: string }) {
   return (
@@ -558,18 +645,22 @@ function MessageBubble({
           <ChatMarkdown>{message.content}</ChatMarkdown>
         </div>
       )}
-      {message.toolCalls?.map((call) => (
-        <div key={call.id} className="space-y-1.5">
-          <ToolCallCard
-            call={call}
-            showUndo={isLastAssistant && canUndo}
-            onUndo={onUndo}
-            boardVisible={isBoardVisible(call.id)}
-            onToggleBoard={() => onToggleBoard(call.id)}
-          />
-          {renderToolCallSupplement?.(call)}
-        </div>
-      ))}
+      {message.toolCalls
+        // update_task_list is a status-only op shown in the task panel above —
+        // suppress it from the chat thread to avoid redundant cards.
+        ?.filter((call) => call.op !== "update_task_list")
+        .map((call) => (
+          <div key={call.id} className="space-y-1.5">
+            <ToolCallCard
+              call={call}
+              showUndo={isLastAssistant && canUndo}
+              onUndo={onUndo}
+              boardVisible={isBoardVisible(call.id)}
+              onToggleBoard={() => onToggleBoard(call.id)}
+            />
+            {renderToolCallSupplement?.(call)}
+          </div>
+        ))}
       {message.warnings && message.warnings.length > 0 && (
         <div className="space-y-1">
           {message.warnings.map((w, i) => (
@@ -687,6 +778,8 @@ function labelFor(call: ToolCall): string {
       return "Delete schedule";
     case "trigger_system_update":
       return "System update";
+    case "update_task_list":
+      return "Task list update";
   }
 }
 

--- a/web/src/components/global-ai-chat-drawer.tsx
+++ b/web/src/components/global-ai-chat-drawer.tsx
@@ -21,6 +21,7 @@ import type {
   DisablePluginArgs,
   EnablePluginArgs,
   InstallPluginArgs,
+  TaskItem,
   ToolCall,
   UninstallPluginArgs,
   UpdateCarouselArgs,
@@ -135,6 +136,8 @@ export function GlobalAiChatDrawer() {
   // trigger re-streaming after tool execution without prop-drilling.
   const resumeFnRef = useRef<((text: string) => void) | null>(null);
 
+  // Task list state — updated by update_task_list ops from the AI.
+  const [taskList, setTaskList] = useState<TaskItem[]>([]);
 
   const { data: aiSettings } = useQuery<AISettings>({
     queryKey: ["ai-settings"],
@@ -391,6 +394,11 @@ export function GlobalAiChatDrawer() {
           })();
           break;
         }
+
+        case "update_task_list":
+          // Status-only op — update the task panel, do NOT chain or call resume.
+          setTaskList(call.args.tasks);
+          break;
 
         case "replace_page":
         case "apply_patch":
@@ -750,6 +758,8 @@ export function GlobalAiChatDrawer() {
         resumeFnRef={resumeFnRef}
         chainingMode={chainingMode}
         onChainingModeChange={setChainingMode}
+        taskList={taskList}
+        onConversationReset={() => setTaskList([])}
       />
     </div>
   );

--- a/web/src/lib/ai-chat-types.ts
+++ b/web/src/lib/ai-chat-types.ts
@@ -158,6 +158,18 @@ export interface UninstallPluginArgs {
   plugin_id: string;
 }
 
+export type TaskStatus = "pending" | "in_progress" | "done" | "failed";
+
+export interface TaskItem {
+  id: string;
+  label: string;
+  status: TaskStatus;
+}
+
+export interface UpdateTaskListArgs {
+  tasks: TaskItem[];
+}
+
 export type ToolCall =
   | { id: string; op: "replace_page"; args: ReplacePageArgs }
   | { id: string; op: "apply_patch"; args: ApplyPatchArgs }
@@ -176,7 +188,8 @@ export type ToolCall =
   | { id: string; op: "enable_plugin"; args: EnablePluginArgs }
   | { id: string; op: "disable_plugin"; args: DisablePluginArgs }
   | { id: string; op: "uninstall_plugin"; args: UninstallPluginArgs }
-  | { id: string; op: "trigger_system_update"; args: Record<string, never> };
+  | { id: string; op: "trigger_system_update"; args: Record<string, never> }
+  | { id: string; op: "update_task_list"; args: UpdateTaskListArgs };
 
 /**
  * Tool call as displayed in the chat thread. Adds an optional


### PR DESCRIPTION
## What

Adds an `update_task_list` tool op so the AI can track and display progress across long multi-step sessions — the root cause of "AI just stops sometimes".

## Changes

### Backend
- **`src/ai/chat_ops.py`** — New `update_task_list` op with `TaskItem` (id, label, status: pending/in_progress/done/failed)
- **`src/ai/chat.py`** — TASK TRACKING section added to the tool grammar. For 3+ sequential actions the AI emits a task list upfront and re-emits before each step to mark progress. `update_task_list` is explicitly allowed alongside one action block per turn (doesn't count toward the one-block limit).

### Frontend
- **`ai-chat-types.ts`** — `TaskStatus`, `TaskItem`, `UpdateTaskListArgs` types; extended `ToolCall` union
- **`global-ai-chat-drawer.tsx`** — Handles `update_task_list` (stores in state, no chaining). Removed the 15-step autonomous cap. Mobile width fixed (`w-full sm:w-96` + `border-l`).
- **`ai-chat-panel.tsx`** — New `TaskListPanel` between header and messages: task icons (⚪/🔄/✅/❌), progress bar, auto-dismisses 3s after all done. `update_task_list` op cards suppressed from the chat thread (shown in the panel instead).

## How it works

When the AI handles "create 13 schedule entries":
1. Emits a task list upfront (all pending) — panel appears showing 0/13
2. Before each entry: re-emits with current task `in_progress`, past ones `done`
3. User sees live progress bar ticking up to 13/13
4. Panel auto-dismisses 3 seconds after completion

Without a step cap, the AI now chains through the entire list autonomously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)