### PR TITLE
fix(web): use userSpaceOnUse gradient so all icon paths render correctly

### DIFF
--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -68,7 +68,7 @@ export default async function RootLayout({
       >
         <svg width="0" height="0" aria-hidden="true" style={{ position: 'absolute' }}>
           <defs>
-            <linearGradient id="page-icon-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+            <linearGradient id="page-icon-gradient" gradientUnits="userSpaceOnUse" x1="0" y1="0" x2="24" y2="24">
               <stop offset="0%" stopColor="var(--fiesta-red)" />
               <stop offset="50%" stopColor="var(--fiesta-orange)" />
               <stop offset="100%" stopColor="var(--fiesta-purple)" />


### PR DESCRIPTION
## Problem

Page header icons for **Carousels** and **Schedule** were rendering as plain hollow squares/rectangles instead of their full icon shapes.

## Root Cause

The SVG `linearGradient` used `gradientUnits="objectBoundingBox"` (the SVG default). This mode computes the gradient relative to each element's own bounding box — which is **degenerate (zero-dimensional) for perfectly horizontal or vertical paths**.

- `Calendar` icon inner paths: `M3 10h18` (horizontal, height = 0) and `M8 2v4`/`M16 2v4` (vertical, width = 0)
- `GalleryHorizontalEnd` icon inner paths: `M2 7v10` and `M6 5v14` (vertical, width = 0)

When a gradient bounding box has a zero dimension, SVG rendering is undefined and browsers apply no color to those paths. Only the outer `rect` element (which has a well-defined bounding box) received color, making the icon look like a plain square outline.

Icons with complex, non-axis-aligned paths (like `Home`) were unaffected.

## Fix

Switch to `gradientUnits="userSpaceOnUse"` with coordinates `(0,0)→(24,24)`, mapping the gradient to Lucide's 24×24 viewBox coordinate space. Every child element is painted based on its position within the icon's coordinate system, regardless of whether its own bounding box is degenerate.

## Change

One line in `web/src/app/layout.tsx`:

```diff
- <linearGradient id="page-icon-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+ <linearGradient id="page-icon-gradient" gradientUnits="userSpaceOnUse" x1="0" y1="0" x2="24" y2="24">
```

No icon or component changes required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)