### PR TITLE
feat(docs): animated Fiesta gradient on homepage hero

### DIFF
--- a/docs-site/src/css/custom.css
+++ b/docs-site/src/css/custom.css
@@ -58,19 +58,70 @@
   --ifm-link-hover-color: var(--ifm-color-primary-light);
 }
 
-/* Hero section styling */
+/* Hero section: animated Fiesta gradient — mirrors the app sidebar palette */
+@keyframes fiesta-hero-gradient-flow {
+  0%   { background-position: 0% 50%; }
+  100% { background-position: 33.33% 50%; }
+}
+
+/* Light mode: soft pastel coral → peach → lavender, dark text */
 .hero--primary {
-  background: linear-gradient(135deg, #b35900 0%, var(--fiesta-hero-gradient-end) 100%);
-  color: #fff;
+  background: repeating-linear-gradient(
+    135deg,
+    #c98a82 0,
+    #c9a070 33.33%,
+    #9b7bb0 66.66%,
+    #c98a82 100%
+  );
+  background-size: 400% 100%;
+  background-position: 0% 50%;
+  animation: fiesta-hero-gradient-flow 117s linear infinite;
+  color: #000;
 }
 
 .hero--primary .hero__title,
 .hero--primary .hero__subtitle {
+  color: #000;
+}
+
+/* Dark mode: deep Fiesta red → burnt orange → deep purple, white text */
+[data-theme='dark'] .hero--primary {
+  background: repeating-linear-gradient(
+    135deg,
+    #7a2a24 0,
+    #6d5014 33.33%,
+    #4e3070 66.66%,
+    #7a2a24 100%
+  );
+  background-size: 400% 100%;
+  background-position: 0% 50%;
+  animation: fiesta-hero-gradient-flow 117s linear infinite;
   color: #fff;
 }
 
-[data-theme='dark'] .hero--primary {
-  background: linear-gradient(135deg, #8b2d00 0%, #b35900 50%, var(--fiesta-hero-gradient-end) 100%);
+[data-theme='dark'] .hero--primary .hero__title,
+[data-theme='dark'] .hero--primary .hero__subtitle {
+  color: #fff;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero--primary,
+  [data-theme='dark'] .hero--primary {
+    animation: none;
+    background-position: 25% 50%;
+  }
+}
+
+/* Hero outline button: adapts color to match gradient mode */
+:root {
+  --hero-outline-btn-color: #000;
+  --hero-outline-btn-hover-bg: #000;
+  --hero-outline-btn-hover-text: #fff;
+}
+[data-theme='dark'] {
+  --hero-outline-btn-color: #fff;
+  --hero-outline-btn-hover-bg: #fff;
+  --hero-outline-btn-hover-text: #1a1a1a;
 }
 
 /* Align logo with nav: anchor image to bottom so text baseline matches nav links;

--- a/docs-site/src/pages/index.module.css
+++ b/docs-site/src/pages/index.module.css
@@ -26,7 +26,6 @@
   max-width: 700px;
   margin: 1rem auto;
   font-size: 1.2rem;
-  color: rgba(255, 255, 255, 0.95);
 }
 
 .heroDescriptionShort {
@@ -46,7 +45,6 @@
     display: block;
     margin: 0.5rem auto;
     font-size: 1.1rem;
-    color: rgba(255, 255, 255, 0.95);
   }
 }
 
@@ -60,12 +58,12 @@
 }
 
 .githubButton {
-  color: #fff;
-  border-color: #fff;
+  color: var(--hero-outline-btn-color);
+  border-color: var(--hero-outline-btn-color);
 }
 
 .githubButton:hover {
-  color: #1a1a1a;
-  background-color: #fff;
-  border-color: #fff;
+  color: var(--hero-outline-btn-hover-text);
+  background-color: var(--hero-outline-btn-hover-bg);
+  border-color: var(--hero-outline-btn-hover-bg);
 }

--- a/docs-site/src/pages/index.tsx
+++ b/docs-site/src/pages/index.tsx
@@ -2,6 +2,7 @@ import type {ReactNode} from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import { useColorMode } from '@docusaurus/theme-common';
 import Layout from '@theme/Layout';
 import HomepageFeatures from '@site/src/components/HomepageFeatures';
 
@@ -9,11 +10,16 @@ import styles from './index.module.css';
 
 function HomepageHeader() {
   const {siteConfig} = useDocusaurusContext();
+  const { colorMode } = useColorMode();
+  // Dark mode: deep gradient needs the light logo; light mode: pastel gradient needs the dark logo
+  const logoSrc = colorMode === 'dark'
+    ? '/img/branding/logo-lockup-dark.png'
+    : '/img/branding/logo-lockup-light.png';
   return (
     <header className={clsx('hero hero--primary', styles.heroBanner)}>
       <div className="container">
         <img
-          src="/img/branding/logo-lockup-dark.png"
+          src={logoSrc}
           alt="FiestaBoard"
           className={styles.heroLockup}
         />


### PR DESCRIPTION
## Summary

- Replaces the static burnt-orange gradient on the docs homepage hero with the same animated Fiesta brand gradient used by the app sidebar (coral → peach → lavender in light mode; deep red → burnt orange → deep purple in dark mode)
- Same 117 s seamless loop and `prefers-reduced-motion` fallback as the sidebar
- Logo switches between `logo-lockup-light.png` (dark-coloured, for the pastel light gradient) and `logo-lockup-dark.png` (light-coloured, for the dark gradient) via `useColorMode`
- GitHub outline button and description text colours adapt per theme (dark ink in light mode, white in dark mode)

## Test plan

- [ ] Visit the docs homepage in light mode — hero shows animated coral/peach/lavender gradient with dark text and dark logo
- [ ] Visit the docs homepage in dark mode — hero shows animated deep red/orange/purple gradient with white text and light logo
- [ ] Toggle between light and dark mode — gradient, text, and logo all switch correctly
- [ ] Check `prefers-reduced-motion: reduce` — gradient is static (no animation)
- [ ] Verify `npm run build` in `docs-site/` succeeds with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)