### PR TITLE
fix(ui): replace Staff Picks sparkles icon with Award

### DIFF
--- a/web/src/components/navigation-sidebar.tsx
+++ b/web/src/components/navigation-sidebar.tsx
@@ -5,7 +5,7 @@ import Image from "next/image";
 import { usePathname } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useQuery } from "@tanstack/react-query";
-import { Home, FileText, Settings, Calendar, Menu, Puzzle, GalleryHorizontalEnd, ChevronLeft, ChevronRight, HelpCircle, Sparkles } from "lucide-react";
+import { Home, FileText, Settings, Calendar, Menu, Puzzle, GalleryHorizontalEnd, ChevronLeft, ChevronRight, HelpCircle, Sparkles, Award } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { MAX_APP_WIDTH, SIDEBAR_INSET } from "@/lib/layout-constants";
 import { ThemeToggle } from "@/components/theme-toggle";
@@ -35,7 +35,7 @@ const primaryItems: NavItem[] = [
 ];
 
 const secondaryItems: NavItem[] = [
-  { key: "picks", href: "/picks", icon: Sparkles },
+  { key: "picks", href: "/picks", icon: Award },
   { key: "helpDocs", href: "https://fiestaboard.app/docs/intro", icon: HelpCircle, external: true },
   { key: "settings", href: "/settings", icon: Settings },
 ];


### PR DESCRIPTION
## Summary

Staff Picks was using the same `Sparkles` icon as the AI Assistant button, making the two sidebar entries visually indistinguishable.

Replaced the Staff Picks icon with `Award` (ribbon/medal shape from lucide-react), which better conveys a curated gallery without the AI connotation. The AI Assistant button retains `Sparkles`.

## Changes

- `web/src/components/navigation-sidebar.tsx` — import `Award`, swap `picks` nav item icon from `Sparkles` → `Award`

🤖 Generated with [Claude Code](https://claude.com/claude-code)