### PR TITLE
fix(ui): hide AI Assistant button when AI is disabled, auto-close open panel

### DIFF
--- a/web/src/__tests__/navigation-sidebar.test.tsx
+++ b/web/src/__tests__/navigation-sidebar.test.tsx
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ThemeProvider } from "next-themes";
+import { http, HttpResponse } from "msw";
+import { server } from "./mocks/server";
 import { ConfigOverridesProvider } from "@/hooks/use-config-overrides";
 import { SidebarProvider } from "@/components/sidebar-context";
 import { GlobalAiPanelProvider } from "@/components/global-ai-panel-context";
@@ -209,5 +211,85 @@ describe("NavigationSidebar carousels link", () => {
     const carouselsLink = carouselsLinks[0].closest("a");
     expect(carouselsLink).toBeInTheDocument();
     expect(carouselsLink).toHaveAttribute("href", "/carousels");
+  });
+});
+
+describe("NavigationSidebar AI Assistant visibility (issue #806)", () => {
+  const API_BASE = "/api";
+
+  beforeEach(() => {
+    mockPathname.mockReturnValue("/");
+  });
+
+  it("hides AI Assistant button when AI is disabled, even with providers configured", async () => {
+    server.use(
+      http.get(`${API_BASE}/settings/ai`, () =>
+        HttpResponse.json({
+          enabled: false,
+          providers: [
+            {
+              id: "p1",
+              name: "OpenRouter",
+              base_url: "https://openrouter.ai/api/v1",
+              api_key: "sk-test",
+              models: ["openai/gpt-4o-mini"],
+              default_model: "openai/gpt-4o-mini",
+            },
+          ],
+          default_provider_id: "p1",
+        }),
+      ),
+    );
+
+    render(<NavigationSidebar />, { wrapper: TestWrapper });
+
+    await waitFor(() => {
+      expect(screen.queryByText("AI Assistant")).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows AI Assistant button when AI is enabled with providers", async () => {
+    server.use(
+      http.get(`${API_BASE}/settings/ai`, () =>
+        HttpResponse.json({
+          enabled: true,
+          providers: [
+            {
+              id: "p1",
+              name: "OpenRouter",
+              base_url: "https://openrouter.ai/api/v1",
+              api_key: "sk-test",
+              models: ["openai/gpt-4o-mini"],
+              default_model: "openai/gpt-4o-mini",
+            },
+          ],
+          default_provider_id: "p1",
+        }),
+      ),
+    );
+
+    render(<NavigationSidebar />, { wrapper: TestWrapper });
+
+    await waitFor(() => {
+      expect(screen.getAllByText("AI Assistant").length).toBeGreaterThan(0);
+    });
+  });
+
+  it("hides AI Assistant button when AI is enabled but no providers configured", async () => {
+    server.use(
+      http.get(`${API_BASE}/settings/ai`, () =>
+        HttpResponse.json({
+          enabled: true,
+          providers: [],
+          default_provider_id: null,
+        }),
+      ),
+    );
+
+    render(<NavigationSidebar />, { wrapper: TestWrapper });
+
+    await waitFor(() => {
+      expect(screen.queryByText("AI Assistant")).not.toBeInTheDocument();
+    });
   });
 });

--- a/web/src/components/global-ai-chat-drawer.tsx
+++ b/web/src/components/global-ai-chat-drawer.tsx
@@ -184,6 +184,14 @@ export function GlobalAiChatDrawer() {
     return () => window.removeEventListener("keydown", handler);
   }, [isOpen, close]);
 
+  // Auto-close when AI is disabled so the drawer doesn't trap users who
+  // navigate to the AI panel and then toggle AI off in Settings (issue #806).
+  useEffect(() => {
+    if (isOpen && aiSettings && !aiSettings.enabled) {
+      close();
+    }
+  }, [isOpen, aiSettings, close]);
+
   const getTurnContext = useCallback((): ChatTurnContext => {
     const pages = pagesData?.pages?.map((p) => ({ id: p.id, name: p.name }));
     const plugins = pluginsData?.plugins?.map((p) => ({

--- a/web/src/components/navigation-sidebar.tsx
+++ b/web/src/components/navigation-sidebar.tsx
@@ -52,7 +52,7 @@ export function NavigationSidebar() {
     queryKey: ["ai-settings"],
     queryFn: () => api.getAiSettings(),
   });
-  const hasAiProviders = (aiSettings?.providers?.length ?? 0) > 0;
+  const hasAiProviders = (aiSettings?.enabled ?? false) && (aiSettings?.providers?.length ?? 0) > 0;
 
   useEffect(() => {
     setMobileMenuOpen(false);


### PR DESCRIPTION
## Summary
- Closes #806
- The AI Assistant button in the navigation sidebar was visible even when AI was disabled in Settings (as long as providers were configured), allowing users to open a panel that covered the mobile screen with no obvious escape
- When AI was toggled off mid-session, an already-open panel would remain stuck open

## Changes
- **navigation-sidebar.tsx**: `hasAiProviders` now checks `enabled` in addition to `providers.length` — button only appears when AI is both enabled and has providers configured
- **global-ai-chat-drawer.tsx**: Added effect to auto-close the drawer when AI settings change to `enabled: false`
- **navigation-sidebar.test.tsx**: 3 new tests covering disabled/enabled/no-providers scenarios

## Test plan
- [ ] Verify AI Assistant button disappears from nav when AI is toggled off in Settings → AI Providers
- [ ] Verify AI Assistant button reappears when AI is toggled back on
- [ ] Verify that if the panel was open and AI is disabled in another tab, the panel closes automatically
- [ ] All 19 navigation-sidebar tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)