### PR TITLE
fix(pi): self-heal fiestapi.local when avahi has renamed itself

### DIFF
--- a/pi-image/README.md
+++ b/pi-image/README.md
@@ -11,7 +11,7 @@ A flashable Raspberry Pi OS image with FiestaBoard pre-installed and self-updati
 - FiestaBoard, pre-pulled and configured to start on boot
 - `fiestaupdater` sidecar enabled by default — Settings → Update Now works immediately
 - 1 GB swap file
-- mDNS hostname `fiestapi.local` (with an hourly self-heal timer that reclaims the bare name if avahi has renamed itself to `fiestapi-2.local` after a past flash/conflict)
+- mDNS hostname `fiestapi.local`
 - `FIESTABOARD_PROFILE=pi` env baked in (flips the in-app auto-update toggle to default ON, and seeds the instance name to "FiestaPi" on first boot)
 - First-boot script that generates a unique `FIESTAUPDATER_TOKEN`
 - Post-flash Wi-Fi provisioning: drop `fiestapi-wifi.txt` (with `SSID=`, `PASSWORD=`, optional `COUNTRY=`) on the boot partition — see [RASPBERRY_PI.md](../docs/setup/RASPBERRY_PI.md). The first-boot script sets the wireless regulatory country and unblocks rfkill before connecting, so Wi-Fi works even on a fresh image.

--- a/pi-image/README.md
+++ b/pi-image/README.md
@@ -11,7 +11,7 @@ A flashable Raspberry Pi OS image with FiestaBoard pre-installed and self-updati
 - FiestaBoard, pre-pulled and configured to start on boot
 - `fiestaupdater` sidecar enabled by default — Settings → Update Now works immediately
 - 1 GB swap file
-- mDNS hostname `fiestapi.local`
+- mDNS hostname `fiestapi.local` (with an hourly self-heal timer that reclaims the bare name if avahi has renamed itself to `fiestapi-2.local` after a past flash/conflict)
 - `FIESTABOARD_PROFILE=pi` env baked in (flips the in-app auto-update toggle to default ON, and seeds the instance name to "FiestaPi" on first boot)
 - First-boot script that generates a unique `FIESTAUPDATER_TOKEN`
 - Post-flash Wi-Fi provisioning: drop `fiestapi-wifi.txt` (with `SSID=`, `PASSWORD=`, optional `COUNTRY=`) on the boot partition — see [RASPBERRY_PI.md](../docs/setup/RASPBERRY_PI.md). The first-boot script sets the wireless regulatory country and unblocks rfkill before connecting, so Wi-Fi works even on a fresh image.
@@ -63,5 +63,8 @@ pi-image/
             ├── docker-compose.yml
             ├── env.template
             ├── fiestaboard.service
-            └── firstboot.sh
+            ├── fiestapi-heal-mdns.service
+            ├── fiestapi-heal-mdns.timer
+            ├── firstboot.sh
+            └── heal-mdns.sh
 ```

--- a/pi-image/stage-fiestaboard/01-install-fiestaboard/00-run.sh
+++ b/pi-image/stage-fiestaboard/01-install-fiestaboard/00-run.sh
@@ -9,10 +9,15 @@ mkdir -p "$INSTALL_DIR"
 install -m 0644 files/docker-compose.yml "${INSTALL_DIR}/docker-compose.yml"
 install -m 0644 files/env.template       "${INSTALL_DIR}/env.template"
 install -m 0755 files/firstboot.sh       "${INSTALL_DIR}/firstboot.sh"
+install -m 0755 files/heal-mdns.sh       "${INSTALL_DIR}/heal-mdns.sh"
 
-# systemd unit
+# systemd units
 install -m 0644 files/fiestaboard.service \
     "${ROOTFS_DIR}/etc/systemd/system/fiestaboard.service"
+install -m 0644 files/fiestapi-heal-mdns.service \
+    "${ROOTFS_DIR}/etc/systemd/system/fiestapi-heal-mdns.service"
+install -m 0644 files/fiestapi-heal-mdns.timer \
+    "${ROOTFS_DIR}/etc/systemd/system/fiestapi-heal-mdns.timer"
 
 on_chroot <<'EOF'
 # ── Docker installation ───────────────────────────────────────────────────
@@ -32,6 +37,10 @@ apt-get install -y --no-install-recommends \
 # Enable Docker and FiestaBoard to start on boot.
 systemctl enable docker
 systemctl enable fiestaboard.service
+
+# Periodic self-heal for the fiestapi.local mDNS hostname.  See heal-mdns.sh
+# for why this is needed (avahi never retries the bare name after a rename).
+systemctl enable fiestapi-heal-mdns.timer
 
 # Add the default user (uid 1000) to the docker group.
 FIRST_USER="$(getent passwd 1000 | cut -d: -f1)"

--- a/pi-image/stage-fiestaboard/01-install-fiestaboard/files/fiestapi-heal-mdns.service
+++ b/pi-image/stage-fiestaboard/01-install-fiestaboard/files/fiestapi-heal-mdns.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Reclaim fiestapi.local if avahi has renamed itself after a past mDNS conflict
+After=avahi-daemon.service network-online.target
+Wants=network-online.target
+Requires=avahi-daemon.service
+
+[Service]
+Type=oneshot
+ExecStart=/opt/fiestaboard/heal-mdns.sh

--- a/pi-image/stage-fiestaboard/01-install-fiestaboard/files/fiestapi-heal-mdns.timer
+++ b/pi-image/stage-fiestaboard/01-install-fiestaboard/files/fiestapi-heal-mdns.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Periodically heal fiestapi.local mDNS hostname
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=1h
+Persistent=true
+Unit=fiestapi-heal-mdns.service
+
+[Install]
+WantedBy=timers.target

--- a/pi-image/stage-fiestaboard/01-install-fiestaboard/files/heal-mdns.sh
+++ b/pi-image/stage-fiestaboard/01-install-fiestaboard/files/heal-mdns.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Reclaim our base mDNS hostname if avahi-daemon has renamed itself due to a
+# past conflict (e.g. advertising as fiestapi-2.local instead of fiestapi.local).
+#
+# Why this exists: avahi auto-renames on hostname collision (common when a
+# previously-flashed FiestaPi held the name and then disappeared, or during
+# a brief network blip).  Once renamed, avahi NEVER retries the bare name on
+# its own — even after the conflict is long gone.  A restart makes it try
+# again; if the conflict is still active it simply renames itself again, so
+# this is safe to run repeatedly.
+
+set -eu
+
+EXPECTED="$(hostname).local"
+
+# Ask avahi over D-Bus what FQDN it's currently advertising.  This is more
+# reliable than parsing `systemctl status` output and avoids needing
+# avahi-utils (avahi-resolve) on the image.
+CURRENT="$(dbus-send --system --print-reply --reply-timeout=5000 \
+    --dest=org.freedesktop.Avahi / \
+    org.freedesktop.Avahi.Server.GetHostNameFqdn 2>/dev/null \
+    | awk -F'"' '/string/ {print $2; exit}')"
+
+# If we couldn't read avahi's state, do nothing rather than restart blindly.
+if [ -z "$CURRENT" ] || [ "$CURRENT" = "$EXPECTED" ]; then
+    exit 0
+fi
+
+logger -t fiestapi-heal-mdns \
+    "avahi advertising as ${CURRENT}, expected ${EXPECTED} — restarting to reclaim"
+systemctl restart avahi-daemon


### PR DESCRIPTION
## Summary

- **Symptom**: A FiestaPi that's been running for a while stops responding at `http://fiestapi.local:4420/` even though it's healthy and reachable by IP. SSH by IP works, the container is up, nginx returns 200 — but `.local` resolution fails on every client on the LAN.
- **Root cause**: `avahi-daemon` auto-renames on mDNS hostname conflict (e.g. to `fiestapi-2.local`, `fiestapi-3.local`). This typically gets triggered when an earlier flash of the same image briefly held the name on the LAN. Once renamed, **avahi never retries the bare name on its own** — so the Pi stays stuck on `fiestapi-3.local` forever, even after the conflicting device is long gone.
- **Fix**: A tiny healer script driven by an hourly systemd timer that asks avahi (via D-Bus) what FQDN it's advertising, and `systemctl restart avahi-daemon`s it only when the advertised name doesn't match `$(hostname).local`. If a real conflict still exists, avahi just renames itself again — safe to run repeatedly.

### Timing

- Fires 2 minutes after boot (catches the post-flash race where another Pi briefly held the name)
- Re-fires every 1 hour
- `Persistent=true` so a missed run catches up on next boot

The check is essentially free (one D-Bus call + string compare). The restart only happens on a real mismatch.

### Reproduction (before this fix)

On a Pi where the bug was active:

```
$ systemctl status avahi-daemon | grep 'running \['
 └─537 "avahi-daemon: running [fiestapi-3.local]"
$ hostname
fiestapi
```

After `systemctl restart avahi-daemon`, avahi reclaimed `fiestapi.local` cleanly. This PR makes that healing automatic.

### Why not just on first-boot?

The failure mode specifically happens on *long-running* Pis after the original conflict goes away — a first-boot script would miss exactly the case this PR fixes.

## Test plan

- [x] `shellcheck` clean on `heal-mdns.sh`
- [x] `systemd-analyze verify` clean on both unit files (tested on a live Pi 5 running Raspberry Pi OS Lite trixie)
- [x] D-Bus call returns the expected FQDN string and parses correctly (verified live)
- [x] Dry-run of `heal-mdns.sh` against a Pi whose advertised name matches `hostname.local` exits 0 with no log entry
- [ ] Next FiestaPi image build (`build-fiestapi.yml`) succeeds with the new units installed
- [ ] On a freshly-flashed image: `systemctl list-timers | grep heal-mdns` shows the timer scheduled
- [ ] Manually induce a rename (e.g. temporarily set hostname to something else, restart avahi twice while another box claims `fiestapi.local`, then remove the conflict) and confirm the healer reclaims the name within the next timer cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)