### PR TITLE
feat(auth): "Keep me logged in" checkbox on the login page

### DIFF
--- a/docs-site/docs/setup/authentication.md
+++ b/docs-site/docs/setup/authentication.md
@@ -31,8 +31,10 @@ a valid session cookie.
    username and password.
 
 3. **Sign in.** You'll be redirected to the dashboard with a session
-   cookie that lasts 7 days. Manage your account (rename, change
-   password, sign out) from the **Profile** page.
+   cookie. Tick **Keep me logged in** (on by default) to stay signed in
+   across browser restarts; clear it on a shared or public computer so the
+   session ends when you close the browser. Manage your account (rename,
+   change password, sign out) from the **Profile** page.
 
 To skip login entirely on a LAN install, click *Continue without login*
 on the first-run picker — the middleware will short-circuit on every
@@ -56,6 +58,13 @@ future request.
 - **Cookies** are `HttpOnly`, `SameSite=Lax`, and `Secure` when the request
   comes in over HTTPS (FiestaBoard trusts the `X-Forwarded-Proto` header
   set by its bundled nginx).
+- **"Keep me logged in"** controls how long the session survives:
+  - **Checked** → a *persistent* cookie with a `Max-Age` (30 days by
+    default) that outlives browser restarts.
+  - **Unchecked** → a *session* cookie (no `Max-Age`) that the browser
+    discards when it closes. The token's signed `expires_at` still caps
+    the server-side lifetime at the normal session TTL (7 days) so a
+    leaked cookie can't live indefinitely on a browser that never closes.
 - **Brute-force protection.** After 10 failed logins from the same client
   IP in 60 seconds the endpoint returns `429 Too Many Requests`.
 - **Stolen-cookie revocation.** Every password or username change bumps
@@ -67,7 +76,8 @@ future request.
 | Variable | Default | Description |
 | --- | --- | --- |
 | `FIESTABOARD_AUTH_ENABLED` | _(unset, first-run picker)_ | `true`/`1`/`yes`/`on` force-enables, `false`/`0`/`no`/`off` force-disables. Unset = use stored preference; if none, show the first-run picker. |
-| `FIESTABOARD_SESSION_TTL_SECONDS` | `604800` (7d) | Session cookie lifetime in seconds. |
+| `FIESTABOARD_SESSION_TTL_SECONDS` | `604800` (7d) | Lifetime for a normal sign-in (without "Keep me logged in"), in seconds. Caps the session-cookie token. |
+| `FIESTABOARD_REMEMBER_ME_TTL_SECONDS` | `2592000` (30d) | Lifetime when "Keep me logged in" is checked, in seconds. Sets both the persistent cookie's `Max-Age` and the token expiry. |
 
 ## Public endpoints
 

--- a/src/auth/routes.py
+++ b/src/auth/routes.py
@@ -15,6 +15,7 @@ from .service import (
     SESSION_COOKIE_NAME,
     SetupRequired,
     _auth_env_override,
+    _remember_me_ttl_seconds,
     auth_mode,
     get_auth_service,
 )
@@ -42,6 +43,10 @@ class StatusResponse(BaseModel):
 class LoginRequest(BaseModel):
     username: str = Field(..., min_length=1, max_length=64)
     password: str = Field(..., min_length=1, max_length=1024)
+    # "Keep me logged in". When true the session is persisted across browser
+    # restarts (long-lived cookie); when false a session cookie is issued that
+    # the browser drops on close. Defaults to false for API clients.
+    remember_me: bool = False
 
 
 class SetupRequest(BaseModel):
@@ -90,7 +95,18 @@ def _is_secure_request(request: Request) -> bool:
     return request.url.scheme == "https"
 
 
-def _set_session_cookie(response: Response, request: Request, token: str) -> None:
+def _set_session_cookie(
+    response: Response, request: Request, token: str, *, persistent: bool = True
+) -> None:
+    """Write the session cookie.
+
+    When *persistent* is true the cookie gets a ``Max-Age`` (the "Keep me
+    logged in" window) so it survives browser restarts. When false we omit
+    ``Max-Age``/``Expires`` entirely, yielding a session cookie that the
+    browser discards when it closes. The token's own ``expires_at`` still caps
+    the server-side lifetime in either case.
+    """
+    max_age = _remember_me_ttl_seconds() if persistent else None
     response.set_cookie(
         key=SESSION_COOKIE_NAME,
         value=token,
@@ -98,7 +114,7 @@ def _set_session_cookie(response: Response, request: Request, token: str) -> Non
         secure=_is_secure_request(request),
         samesite="lax",
         path="/",
-        max_age=7 * 24 * 3600,
+        max_age=max_age,
     )
 
 
@@ -217,8 +233,9 @@ async def auth_setup(payload: SetupRequest, request: Request, response: Response
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
     # Log them in straight away so the UI can hand control to the dashboard.
-    token = svc.authenticate(payload.username, payload.password)
-    _set_session_cookie(response, request, token)
+    # New admins get a persistent session (matches the prior setup behavior).
+    token = svc.authenticate(payload.username, payload.password, remember=True)
+    _set_session_cookie(response, request, token, persistent=True)
     logger.info("Initial user '%s' created", payload.username)
     return SimpleResponse(status="ok", username=payload.username)
 
@@ -230,7 +247,9 @@ async def auth_login(payload: LoginRequest, request: Request, response: Response
     _check_lockout(ip)
     svc = get_auth_service()
     try:
-        token = svc.authenticate(payload.username, payload.password)
+        token = svc.authenticate(
+            payload.username, payload.password, remember=payload.remember_me
+        )
     except SetupRequired:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -243,7 +262,7 @@ async def auth_login(payload: LoginRequest, request: Request, response: Response
             detail="Invalid username or password",
         )
     _clear_failures(ip)
-    _set_session_cookie(response, request, token)
+    _set_session_cookie(response, request, token, persistent=payload.remember_me)
     return SimpleResponse(status="ok", username=payload.username)
 
 

--- a/src/auth/service.py
+++ b/src/auth/service.py
@@ -50,18 +50,34 @@ _SALT_BYTES = 16
 # want a tighter window without a code change.
 _DEFAULT_SESSION_TTL_SECONDS = 7 * 24 * 3600
 
+# When the user ticks "Keep me logged in" the session is persisted for longer
+# (30 days by default). Also env-overridable for ops who want a different
+# window. This is the upper bound on a remembered cookie's lifetime.
+_DEFAULT_REMEMBER_ME_TTL_SECONDS = 30 * 24 * 3600
 
-def _session_ttl_seconds() -> int:
-    raw = os.environ.get("FIESTABOARD_SESSION_TTL_SECONDS", "").strip()
+
+def _ttl_from_env(var_name: str, default: int) -> int:
+    """Read a positive-int TTL (seconds) from *var_name*, else *default*."""
+    raw = os.environ.get(var_name, "").strip()
     if not raw:
-        return _DEFAULT_SESSION_TTL_SECONDS
+        return default
     try:
         v = int(raw)
         if v <= 0:
-            return _DEFAULT_SESSION_TTL_SECONDS
+            return default
         return v
     except ValueError:
-        return _DEFAULT_SESSION_TTL_SECONDS
+        return default
+
+
+def _session_ttl_seconds() -> int:
+    return _ttl_from_env("FIESTABOARD_SESSION_TTL_SECONDS", _DEFAULT_SESSION_TTL_SECONDS)
+
+
+def _remember_me_ttl_seconds() -> int:
+    return _ttl_from_env(
+        "FIESTABOARD_REMEMBER_ME_TTL_SECONDS", _DEFAULT_REMEMBER_ME_TTL_SECONDS
+    )
 
 
 def is_auth_enabled() -> bool:
@@ -509,8 +525,14 @@ class AuthService:
 
     # -- auth flow ---------------------------------------------------------
 
-    def authenticate(self, username: str, password: str) -> str:
-        """Verify *username*/*password* and return a signed session token."""
+    def authenticate(
+        self, username: str, password: str, *, remember: bool = False
+    ) -> str:
+        """Verify *username*/*password* and return a signed session token.
+
+        When *remember* is true the token is minted with the longer
+        "Keep me logged in" TTL; otherwise it uses the default session TTL.
+        """
         if not self.has_user():
             raise SetupRequired("No user has been provisioned")
         user = self.get_user(username)
@@ -520,10 +542,11 @@ class AuthService:
         if not user or not ok:
             raise InvalidCredentials("Invalid username or password")
         now_ms = self._monotonic_ms()
+        ttl_seconds = _remember_me_ttl_seconds() if remember else _session_ttl_seconds()
         token = SessionToken(
             username=username,
             issued_at=now_ms,
-            expires_at=now_ms + _session_ttl_seconds() * 1000,
+            expires_at=now_ms + ttl_seconds * 1000,
         )
         return self._sign(token.encode())
 

--- a/tests/test_auth_routes.py
+++ b/tests/test_auth_routes.py
@@ -155,6 +155,55 @@ def test_login_brute_force_lockout(client, enabled):
     assert r.status_code == 429
 
 
+def _session_set_cookie(response) -> str:
+    """Return the ``Set-Cookie`` header for the session cookie."""
+    for header in response.headers.get_list("set-cookie"):
+        if header.startswith(f"{auth_service.SESSION_COOKIE_NAME}="):
+            return header
+    raise AssertionError("No session Set-Cookie header found")
+
+
+def test_login_remember_me_sets_persistent_cookie(client, enabled):
+    client.post("/auth/setup", json={"username": "admin", "password": "supersecret"})
+    client.cookies.clear()
+    r = client.post(
+        "/auth/login",
+        json={"username": "admin", "password": "supersecret", "remember_me": True},
+    )
+    assert r.status_code == 200
+    cookie = _session_set_cookie(r)
+    # 30-day default remember-me window.
+    assert "Max-Age=2592000" in cookie
+
+
+def test_login_without_remember_me_sets_session_cookie(client, enabled):
+    client.post("/auth/setup", json={"username": "admin", "password": "supersecret"})
+    client.cookies.clear()
+    r = client.post(
+        "/auth/login",
+        json={"username": "admin", "password": "supersecret", "remember_me": False},
+    )
+    assert r.status_code == 200
+    cookie = _session_set_cookie(r)
+    # A session cookie carries neither Max-Age nor Expires.
+    assert "Max-Age" not in cookie
+    assert "expires" not in cookie.lower()
+
+
+def test_login_remember_me_defaults_to_session_cookie(client, enabled):
+    """Omitting the field behaves like remember_me=False for API clients."""
+    client.post("/auth/setup", json={"username": "admin", "password": "supersecret"})
+    client.cookies.clear()
+    r = client.post(
+        "/auth/login", json={"username": "admin", "password": "supersecret"}
+    )
+    assert r.status_code == 200
+    cookie = _session_set_cookie(r)
+    assert "Max-Age" not in cookie
+    # And the cookie still authenticates subsequent requests.
+    assert client.get("/auth/status").json()["authenticated"] is True
+
+
 # --- /auth/logout ----------------------------------------------------------
 
 

--- a/tests/test_auth_service.py
+++ b/tests/test_auth_service.py
@@ -155,6 +155,52 @@ def test_verify_session_expired(monkeypatch, svc):
     assert svc.verify_session(token) is None
 
 
+def _token_expires_at_ms(token: str) -> int:
+    """Pull the ``expires_at`` (ms) field out of a signed session token.
+
+    Token layout is ``<user_b64>.<issued>.<expires>.<nonce>.<signature>``.
+    """
+    payload, _sig = token.rsplit(".", 1)
+    _user_b64, _issued, expires_s, _nonce = payload.split(".")
+    return int(expires_s)
+
+
+def test_authenticate_remember_extends_ttl(svc):
+    """``remember=True`` mints a token with the longer remember-me TTL."""
+    svc.create_initial_user("admin", "supersecret")
+    short = svc.authenticate("admin", "supersecret", remember=False)
+    long = svc.authenticate("admin", "supersecret", remember=True)
+    # The remembered token outlives the plain session token by roughly the
+    # gap between the 7-day and 30-day defaults.
+    assert _token_expires_at_ms(long) - _token_expires_at_ms(short) > 20 * 24 * 3600 * 1000
+    # Both are still valid sessions for the user.
+    assert svc.verify_session(short) == "admin"
+    assert svc.verify_session(long) == "admin"
+
+
+def test_authenticate_default_uses_session_ttl(monkeypatch, svc):
+    """Default (no remember kwarg) uses the short session TTL window."""
+    svc.create_initial_user("admin", "supersecret")
+    monkeypatch.setenv("FIESTABOARD_SESSION_TTL_SECONDS", "60")
+    monkeypatch.setenv("FIESTABOARD_REMEMBER_ME_TTL_SECONDS", "600")
+    plain = svc.authenticate("admin", "supersecret")
+    remembered = svc.authenticate("admin", "supersecret", remember=True)
+    now_ms = auth_service._now_ms()
+    # Plain token expires ~60s out; remembered ~600s out.
+    assert _token_expires_at_ms(plain) - now_ms < 120 * 1000
+    assert _token_expires_at_ms(remembered) - now_ms > 300 * 1000
+
+
+def test_remember_me_ttl_env_override(monkeypatch):
+    monkeypatch.setenv("FIESTABOARD_REMEMBER_ME_TTL_SECONDS", "12345")
+    assert auth_service._remember_me_ttl_seconds() == 12345
+    # Invalid / non-positive values fall back to the default.
+    monkeypatch.setenv("FIESTABOARD_REMEMBER_ME_TTL_SECONDS", "0")
+    assert auth_service._remember_me_ttl_seconds() == auth_service._DEFAULT_REMEMBER_ME_TTL_SECONDS
+    monkeypatch.setenv("FIESTABOARD_REMEMBER_ME_TTL_SECONDS", "notanumber")
+    assert auth_service._remember_me_ttl_seconds() == auth_service._DEFAULT_REMEMBER_ME_TTL_SECONDS
+
+
 def test_persistence_across_instances(tmp_path):
     p = tmp_path / "auth.json"
     s1 = auth_service.AuthService(auth_file=p)

--- a/web/src/__tests__/login-page.test.tsx
+++ b/web/src/__tests__/login-page.test.tsx
@@ -122,3 +122,82 @@ describe("LoginPage first-run picker", () => {
     ).not.toBeInTheDocument();
   });
 });
+
+describe("LoginPage 'Keep me logged in'", () => {
+  beforeEach(() => {
+    replaceMock.mockReset();
+  });
+
+  function mockSignInStatus() {
+    server.use(
+      http.get("/api/auth/status", () =>
+        HttpResponse.json(
+          makeStatus({ mode: "enabled", first_run: false, setup_required: false }),
+        ),
+      ),
+    );
+  }
+
+  /** Wire up the login route and capture its JSON body. */
+  function captureLoginBody(): () => Record<string, unknown> | null {
+    let body: Record<string, unknown> | null = null;
+    server.use(
+      http.post("/api/auth/login", async ({ request }) => {
+        body = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({ status: "ok", username: "admin" });
+      }),
+    );
+    return () => body;
+  }
+
+  it("shows the checkbox checked by default on the sign-in form", async () => {
+    mockSignInStatus();
+    render(<LoginPage />);
+
+    await screen.findByText(/Sign in to FiestaBoard/i);
+    const checkbox = screen.getByRole("checkbox", { name: /Keep me logged in/i });
+    expect(checkbox).toBeInTheDocument();
+    expect(checkbox).toBeChecked();
+  });
+
+  it("submits remember_me=true when the box is left checked", async () => {
+    mockSignInStatus();
+    const getBody = captureLoginBody();
+    render(<LoginPage />);
+
+    await screen.findByText(/Sign in to FiestaBoard/i);
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/Username/i), "admin");
+    await user.type(screen.getByLabelText(/Password/i), "supersecret");
+    await user.click(screen.getByRole("button", { name: /Sign in/i }));
+
+    await waitFor(() => {
+      expect(getBody()).toEqual({
+        username: "admin",
+        password: "supersecret",
+        remember_me: true,
+      });
+    });
+  });
+
+  it("submits remember_me=false when the box is unchecked", async () => {
+    mockSignInStatus();
+    const getBody = captureLoginBody();
+    render(<LoginPage />);
+
+    await screen.findByText(/Sign in to FiestaBoard/i);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("checkbox", { name: /Keep me logged in/i }));
+    await user.type(screen.getByLabelText(/Username/i), "admin");
+    await user.type(screen.getByLabelText(/Password/i), "supersecret");
+    await user.click(screen.getByRole("button", { name: /Sign in/i }));
+
+    await waitFor(() => {
+      expect(getBody()).toEqual({
+        username: "admin",
+        password: "supersecret",
+        remember_me: false,
+      });
+    });
+  });
+});

--- a/web/src/app/login/page.tsx
+++ b/web/src/app/login/page.tsx
@@ -19,6 +19,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { Lock, ShieldAlert, ShieldCheck, ShieldQuestion, Loader2 } from "lucide-react";
 import type { AuthStatusResponse } from "@/lib/api";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -83,6 +84,9 @@ export default function LoginPage() {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
+  // "Keep me logged in" — defaults to checked (matches Home Assistant). When
+  // off, the server issues a session cookie that the browser drops on close.
+  const [rememberMe, setRememberMe] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
 
@@ -121,7 +125,11 @@ export default function LoginPage() {
       setFormError(null);
       setSubmitting(true);
       try {
-        const res = await postJson("/auth/login", { username, password });
+        const res = await postJson("/auth/login", {
+          username,
+          password,
+          remember_me: rememberMe,
+        });
         if (res.ok) {
           router.replace(redirectTo);
           return;
@@ -146,7 +154,7 @@ export default function LoginPage() {
         setSubmitting(false);
       }
     },
-    [username, password, router, redirectTo],
+    [username, password, rememberMe, router, redirectTo],
   );
 
   const handleSetup = useCallback(
@@ -404,6 +412,18 @@ export default function LoginPage() {
             onChange={(e) => setPassword(e.target.value)}
             disabled={submitting}
           />
+        </div>
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="remember-me"
+            name="remember-me"
+            checked={rememberMe}
+            onChange={(e) => setRememberMe(e.target.checked)}
+            disabled={submitting}
+          />
+          <Label htmlFor="remember-me" className="cursor-pointer">
+            Keep me logged in
+          </Label>
         </div>
         {formError && (
           <Alert variant="destructive">

--- a/web/src/components/ui/checkbox.tsx
+++ b/web/src/components/ui/checkbox.tsx
@@ -1,0 +1,29 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+export type CheckboxProps = Omit<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  "type"
+>
+
+const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <input
+        type="checkbox"
+        className={cn(
+          "h-4 w-4 shrink-0 rounded-sm border border-input accent-brand",
+          "shadow-sm transition-colors cursor-pointer",
+          "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+          "disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Checkbox.displayName = "Checkbox"
+
+export { Checkbox }


### PR DESCRIPTION
## Summary

Adds a Home Assistant–style **"Keep me logged in"** checkbox to the sign-in form.

FiestaBoard's auth (added in `v6.0.0` / #738) uses **HttpOnly signed cookies**, not localStorage tokens, so the correct analog of HA's checkbox is *cookie persistence*:

- **Checked (default)** → persistent cookie, `Max-Age` 30 days — survives browser restarts.
- **Unchecked** → a **session cookie** (no `Max-Age`) the browser drops on close. The token's signed `expires_at` still caps the server-side lifetime at the 7-day session TTL, so a leaked cookie can't live indefinitely on a never-closed browser.

## Changes

**Backend**
- `src/auth/service.py` — `_remember_me_ttl_seconds()` (30-day default, `FIESTABOARD_REMEMBER_ME_TTL_SECONDS` override); keyword-only `remember` flag on `authenticate()` to pick the TTL.
- `src/auth/routes.py` — `remember_me: bool = False` on `LoginRequest`; `_set_session_cookie(..., persistent=...)` omits `Max-Age` for a session cookie; `auth_login` threads the flag through. Setup keeps its persistent session.

**Frontend**
- `web/src/components/ui/checkbox.tsx` — dependency-free Checkbox primitive matching the existing `ui/` style (no new npm dep / container rebuild).
- `web/src/app/login/page.tsx` — `rememberMe` state (defaults **checked**), checkbox on the sign-in form only, sends `remember_me` in the login body.

**Docs**
- `docs-site/docs/setup/authentication.md` — documents the checkbox, persistent-vs-session behavior, and the new env var.

## Testing

- **Backend:** `68 passed` — route tests assert `remember_me=true` → `Max-Age=2592000`, `false`/omitted → session cookie; service tests assert the extended TTL.
- **Frontend:** full suite `985 passed / 13 skipped (77 files)`; new login-page tests assert default-checked and the submitted `remember_me` value. ESLint + `tsc` clean on changed files.
- **Live smoke:** verified on the real `/login` page — checkbox renders between Password and Sign in, checked by default, toggles correctly.

## Notes

- No Playwright e2e added: the integration harness runs with `FIESTABOARD_AUTH_ENABLED=false`, so an auth-required spec can't run there. The backend route tests (real FastAPI app + middleware + TestClient) cover that integration layer.
- Product decision matching HA: checkbox **defaults to checked**, 30-day remember / 7-day normal (both env-overridable). Easy to flip to default-unchecked if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)