### PR TITLE
fix(schedules): sunset/sunrise schedules fire ~1h early in DST (#814)

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -5177,9 +5177,12 @@ async def get_location_sun_times(date: Optional[str] = None):
     Returns sunrise and sunset as HH:MM strings, or null values if location is not
     configured or sun times cannot be computed (e.g. polar day/night).
     """
-    from .schedules.sun_times import get_sun_times
+    from .schedules.sun_times import (
+        get_effective_timezone,
+        get_sun_times,
+        get_today_in_timezone,
+    )
     from datetime import date as date_cls
-    import pytz
 
     settings_service = get_settings_service()
     location = settings_service.get_location_settings()
@@ -5187,12 +5190,7 @@ async def get_location_sun_times(date: Optional[str] = None):
     if location.latitude is None or location.longitude is None:
         return {"sunrise": None, "sunset": None, "location_configured": False}
 
-    timezone_str = "UTC"
-    try:
-        from .config import Config
-        timezone_str = Config.TIMEZONE or "UTC"
-    except Exception:
-        logger.debug("Could not get timezone from config, using UTC")
+    timezone_str = get_effective_timezone()
 
     if date:
         try:
@@ -5201,8 +5199,7 @@ async def get_location_sun_times(date: Optional[str] = None):
             from fastapi import HTTPException
             raise HTTPException(status_code=400, detail="Invalid date format. Use YYYY-MM-DD.")
     else:
-        tz = pytz.timezone(timezone_str)
-        target_date = datetime.now(tz).date()
+        target_date = get_today_in_timezone(timezone_str)
 
     times = get_sun_times(location.latitude, location.longitude, target_date, timezone_str)
     if times is None:
@@ -5225,7 +5222,7 @@ async def get_location_sun_times_week(week_start: str):
 
     Returns a map of date strings to { sunrise, sunset } HH:MM values.
     """
-    from .schedules.sun_times import get_sun_times
+    from .schedules.sun_times import get_effective_timezone, get_sun_times
     from datetime import date as date_cls, timedelta
 
     settings_service = get_settings_service()
@@ -5234,12 +5231,7 @@ async def get_location_sun_times_week(week_start: str):
     if location.latitude is None or location.longitude is None:
         return {"location_configured": False, "dates": {}}
 
-    timezone_str = "UTC"
-    try:
-        from .config import Config
-        timezone_str = Config.TIMEZONE or "UTC"
-    except Exception:
-        logger.debug("Could not get timezone from config, using UTC")
+    timezone_str = get_effective_timezone()
 
     try:
         start = date_cls.fromisoformat(week_start)
@@ -6244,17 +6236,15 @@ def _enrich_schedule_with_sun_times(schedule_dict: dict) -> dict:
         schedule_dict["resolved_end_time"] = schedule_dict.get("end_time")
         return schedule_dict
 
-    from datetime import date as date_type
-    from .schedules.sun_times import resolve_schedule_sun_times
+    from .schedules.sun_times import (
+        get_effective_timezone,
+        get_today_in_timezone,
+        resolve_schedule_sun_times,
+    )
 
     settings = get_settings_service()
     loc = settings.get_location_settings()
-    timezone_str = "UTC"
-    try:
-        from .config import Config
-        timezone_str = Config.TIMEZONE or "UTC"
-    except Exception:
-        logger.debug("Could not get timezone from config, using UTC")
+    timezone_str = get_effective_timezone()
 
     resolved_start, resolved_end = resolve_schedule_sun_times(
         start_type=start_type,
@@ -6265,7 +6255,7 @@ def _enrich_schedule_with_sun_times(schedule_dict: dict) -> dict:
         end_time_fallback=schedule_dict.get("end_time"),
         latitude=loc.latitude,
         longitude=loc.longitude,
-        target_date=date_type.today(),
+        target_date=get_today_in_timezone(timezone_str),
         timezone_str=timezone_str,
     )
     schedule_dict["resolved_start_time"] = resolved_start

--- a/src/schedules/service.py
+++ b/src/schedules/service.py
@@ -19,7 +19,11 @@ from .models import (
     DEFAULT_BOARD_ID,
 )
 from .storage import ScheduleStorage
-from .sun_times import resolve_schedule_sun_times
+from .sun_times import (
+    get_effective_timezone,
+    get_today_in_timezone,
+    resolve_schedule_sun_times,
+)
 from ..settings.service import get_settings_service
 
 logger = logging.getLogger(__name__)
@@ -141,9 +145,11 @@ class ScheduleService:
         schedules = [s for s in self.list_schedules(board_id=bid) if s.enabled]
         time_str = current_time.strftime("%H:%M")
 
-        # Pre-fetch location once for sun-time resolution
+        # Pre-fetch location once for sun-time resolution. "today" is computed
+        # in the configured timezone so that schedules anchored to sunset don't
+        # skew when the server clock runs in a different zone than the user.
         location = self._get_location()
-        today = date.today()
+        today = get_today_in_timezone(location[2])
 
         matches = []
         for schedule in schedules:
@@ -171,13 +177,7 @@ class ScheduleService:
         """
         settings = get_settings_service()
         loc = settings.get_location_settings()
-        timezone_str = "UTC"
-        try:
-            from ..config import Config
-            timezone_str = Config.TIMEZONE or "UTC"
-        except Exception:
-            logger.debug("Could not get timezone from config, using UTC")
-        return (loc.latitude, loc.longitude, timezone_str)
+        return (loc.latitude, loc.longitude, get_effective_timezone())
 
     def _resolve_effective_times(
         self,

--- a/src/schedules/sun_times.py
+++ b/src/schedules/sun_times.py
@@ -76,7 +76,7 @@ def get_sun_times(
         try:
             tz = ZoneInfo(timezone_str)
         except (ZoneInfoNotFoundError, ValueError):
-            logger.warning(f"Unknown timezone '{timezone_str}', falling back to UTC")
+            logger.warning("Unknown configured timezone, falling back to UTC")
             tz = ZoneInfo("UTC")
             timezone_str = "UTC"
 

--- a/src/schedules/sun_times.py
+++ b/src/schedules/sun_times.py
@@ -6,13 +6,49 @@ timezone for direct use in schedule evaluation.
 """
 
 import logging
-from datetime import timedelta, date
+from datetime import datetime, timedelta, date
 from typing import Optional, Tuple
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from astral import LocationInfo
 from astral.sun import sun
 
 logger = logging.getLogger(__name__)
+
+
+def get_effective_timezone() -> str:
+    """Return the IANA timezone to use for sun-time resolution.
+
+    Prefers the general (project-wide) timezone used by ``time_service`` so
+    that "what time is it now" and "when is sunset" stay in the same frame.
+    Falls back to the date_time plugin's timezone, then to UTC.
+
+    Without this preference order, a user who configured only the general
+    timezone (or whose date_time plugin TZ is a non-DST equivalent like
+    ``MST``/``America/Phoenix``/``Etc/GMT+7``) sees sunset-based schedules
+    fire ~1 hour early during DST because the sunset is computed without
+    DST while "now" is computed with DST.
+    """
+    try:
+        from ..config import Config
+        return Config.GENERAL_TIMEZONE or Config.TIMEZONE or "UTC"
+    except Exception:
+        logger.debug("Could not read timezone from Config, using UTC", exc_info=True)
+        return "UTC"
+
+
+def get_today_in_timezone(timezone_str: str) -> date:
+    """Return today's date in the given IANA timezone.
+
+    Using the configured timezone (rather than the server's local date) avoids
+    a one-day skew when the server clock runs in a different zone than the
+    user's location.
+    """
+    try:
+        tz = ZoneInfo(timezone_str)
+    except (ZoneInfoNotFoundError, ValueError):
+        tz = ZoneInfo("UTC")
+    return datetime.now(tz).date()
 
 # Sun event types that can be used in schedule start/end
 SUN_EVENT_TYPES = ("sunrise", "sunset")
@@ -37,9 +73,13 @@ def get_sun_times(
         objects, or None if calculation fails (e.g. polar day/night).
     """
     try:
-        import pytz
+        try:
+            tz = ZoneInfo(timezone_str)
+        except (ZoneInfoNotFoundError, ValueError):
+            logger.warning(f"Unknown timezone '{timezone_str}', falling back to UTC")
+            tz = ZoneInfo("UTC")
+            timezone_str = "UTC"
 
-        tz = pytz.timezone(timezone_str)
         location = LocationInfo(
             name="Board",
             region="",

--- a/tests/test_schedules_sun_times.py
+++ b/tests/test_schedules_sun_times.py
@@ -5,6 +5,7 @@ from datetime import date, time
 from unittest.mock import patch, MagicMock
 
 from src.schedules.sun_times import (
+    get_effective_timezone,
     get_sun_times,
     resolve_sun_time,
     resolve_schedule_sun_times,
@@ -413,3 +414,51 @@ class TestStorageSunFields:
         assert entry.start_sun_offset == 0
         assert entry.end_type == "fixed"
         assert entry.end_sun_offset == 0
+
+
+# ---- Effective timezone selection (regression for issue #814) ----
+
+class TestEffectiveTimezone:
+    """Sun-time resolution must share the timezone used by time_service.
+
+    Without this, a user with general timezone set to a DST-aware zone (e.g.
+    America/Denver) but the date_time plugin TZ unset or set to a non-DST
+    equivalent (e.g. MST, America/Phoenix) sees sunset schedules fire ~1 hour
+    early in DST, because "now" applies DST while "sunset" does not.
+    """
+
+    @patch("src.config.Config")
+    def test_prefers_general_timezone_over_plugin_timezone(self, mock_config):
+        mock_config.GENERAL_TIMEZONE = "America/Denver"
+        mock_config.TIMEZONE = "America/Phoenix"
+        assert get_effective_timezone() == "America/Denver"
+
+    @patch("src.config.Config")
+    def test_falls_back_to_plugin_timezone_when_general_empty(self, mock_config):
+        mock_config.GENERAL_TIMEZONE = ""
+        mock_config.TIMEZONE = "America/Denver"
+        assert get_effective_timezone() == "America/Denver"
+
+    @patch("src.config.Config")
+    def test_falls_back_to_utc_when_both_empty(self, mock_config):
+        mock_config.GENERAL_TIMEZONE = ""
+        mock_config.TIMEZONE = ""
+        assert get_effective_timezone() == "UTC"
+
+    def test_dst_aware_sunset_differs_from_non_dst(self):
+        """Sanity check that demonstrates the original bug: Lakewood, CO sunset
+        on a DST day comes out 1 hour later in America/Denver than in MST."""
+        denver = resolve_sun_time(
+            "sunset", 0, 39.7047, -105.0814,
+            date(2026, 5, 30), "America/Denver",
+        )
+        mst = resolve_sun_time(
+            "sunset", 0, 39.7047, -105.0814,
+            date(2026, 5, 30), "MST",
+        )
+        assert denver is not None and mst is not None
+        denver_mins = int(denver[:2]) * 60 + int(denver[3:])
+        mst_mins = int(mst[:2]) * 60 + int(mst[3:])
+        # Denver sunset should be ~60 minutes later than the non-DST MST value
+        # (allow a couple of minutes of slack for astral precision)
+        assert 58 <= (denver_mins - mst_mins) <= 62


### PR DESCRIPTION
## Summary
Fixes #814 — sunset-anchored schedules trigger ~1 hour before actual sunset during DST.

Two separate timezone configs were used inconsistently:
- `time_service` (used for "what time is it now") reads `Config.GENERAL_TIMEZONE`
- `sun_times` (used for sunrise/sunset) read `Config.TIMEZONE` (the date_time plugin's TZ)

When the date_time plugin's timezone is unset (it now defaults to `""`, see #757) or set to a non-DST equivalent like `MST` / `America/Phoenix` / `Etc/GMT+7`, sunset is computed without DST while "now" is computed with DST — schedule fires an hour early.

Reproduced against the reporter's screenshot for Lakewood, CO on 2026-05-30:
- `America/Denver` (DST-aware) → **20:20** ✓ matches iPhone weather
- `MST` (no DST) → **19:20** ✗ matches reporter's "Today: 19:21"

## Changes
- Add `get_effective_timezone()` in `src/schedules/sun_times.py` that prefers `GENERAL_TIMEZONE`, falls back to `TIMEZONE`, then UTC — so sun-time resolution shares the timezone used by `time_service`.
- Add `get_today_in_timezone()` so "today" matches the user's zone rather than the server clock.
- Route the four sun-time callers (`schedules/service.py`, `api_server.py` enrich, `/settings/location/sun-times`, `/settings/location/sun-times-week`) through the helpers.
- Migrate `sun_times.py` from `pytz` to stdlib `zoneinfo`, matching the rest of the project after #605.
- Regression tests covering the timezone preference order and the DST/non-DST divergence.

## Test plan
- [x] `pytest tests/test_schedules_sun_times.py` — 30/30 pass (4 new)
- [x] `pytest tests/ -k 'schedule or sun or location'` — 330 pass
- [ ] Manually verify in the Edit Schedule dialog that "Today: HH:MM" matches local sunset when `general.timezone` is set to an IANA name (e.g. `America/Denver`) and `date_time.timezone` is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)