### PR TITLE
fix(pi): self-heal first-boot pull race + rename image output

### DIFF
--- a/.github/workflows/build-fiestapi.yml
+++ b/.github/workflows/build-fiestapi.yml
@@ -182,9 +182,14 @@ jobs:
           retention-days: 30
 
       - name: Resolve target app release tag
-        # Every build path attaches to an existing app release:
+        # Skip on workflow_dispatch from non-default branches: a manual
+        # build from a feature branch should produce a verifiable artifact
+        # for testing, not pollute a published release page. Dispatch on
+        # main remains attached (maintainer hot-patch path).
+        if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main'
+        # Every release-attaching build path resolves an existing app release:
         #   - Tag builds (refs/tags/vN.0.0) → attach to that tag's release.
-        #   - Weekly cron / manual dispatch → attach to the latest published
+        #   - Weekly cron / dispatch-on-main → attach to the latest published
         #     non-prerelease app release (e.g. v5.1.1).
         # This keeps each app version's release page as the single source
         # of truth for both the code release and its FiestaPi .img.xz.
@@ -207,6 +212,7 @@ jobs:
           echo "Will attach FiestaPi image to release: $TAG"
 
       - name: Attach FiestaPi image to app release
+        if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main'
         # Upload the .img.xz and .sha256 to the resolved release.
         # softprops/action-gh-release@v3 replaces same-named assets in
         # place, so re-running overwrites cleanly. Body is intentionally

--- a/.github/workflows/build-fiestapi.yml
+++ b/.github/workflows/build-fiestapi.yml
@@ -118,7 +118,7 @@ jobs:
             fi
           else
             # Weekly builds labelled by year-week so the filename is
-            # meaningful (e.g. fiestapi-2026-W18-arm64.img.xz).
+            # meaningful (e.g. FiestaPi-2026-W18-arm64.img.xz).
             VERSION="$(date -u +%Y-W%V)"
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
@@ -145,17 +145,24 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
-      - name: Locate output
+      - name: Locate and rename output
         id: out
         run: |
           # build-docker.sh runs as root, so pi-gen/deploy and its contents
           # are root-owned. Reclaim ownership so subsequent steps (checksum,
           # artifact upload, release attach) can read/write without sudo.
           sudo chown -R "$USER:$USER" pi-gen/deploy
-          IMG=$(find pi-gen/deploy -name '*.img.xz' | head -n1)
-          test -n "$IMG"
-          echo "img=$IMG" >> "$GITHUB_OUTPUT"
-          echo "Found image: $IMG"
+          SRC=$(find pi-gen/deploy -name '*.img.xz' | head -n1)
+          test -n "$SRC"
+          # Rename to a stable, user-facing format. pi-gen's default
+          # `image_<date>-fiestapi-lite.img.xz` is ugly and doesn't carry
+          # the FiestaBoard version, so the docs have always lied. Land on
+          # `FiestaPi-<version>-arm64.img.xz` so the release asset matches
+          # what we tell users to download.
+          DEST="pi-gen/deploy/FiestaPi-${{ steps.version.outputs.version }}-arm64.img.xz"
+          mv "$SRC" "$DEST"
+          echo "img=$DEST" >> "$GITHUB_OUTPUT"
+          echo "Renamed: $SRC -> $DEST"
 
       - name: Generate SHA-256 checksum
         id: checksum
@@ -169,7 +176,7 @@ jobs:
       - name: Upload as workflow artifact
         uses: actions/upload-artifact@v7
         with:
-          name: fiestapi-${{ steps.version.outputs.version }}-arm64
+          name: FiestaPi-${{ steps.version.outputs.version }}-arm64
           path: ${{ steps.out.outputs.img }}
           # 30 days — weekly builds rotate frequently; grab the latest.
           retention-days: 30

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you have (or are willing to buy) a Raspberry Pi 3B or newer, this is by far t
 
 1. A **Raspberry Pi** (3B / 3B+ / Zero 2 W / 4 / 5) with a microSD card and 5 V power supply
 2. **[Raspberry Pi Imager](https://www.raspberrypi.com/software/)** — a free official tool from the Raspberry Pi Foundation that flashes SD cards (works on Mac, Windows, Linux)
-3. The latest **FiestaPi image** from our [Releases page](https://github.com/Fiestaboard/FiestaBoard/releases/latest) (`fiestapi-<version>-arm64.img.xz`)
+3. The latest **FiestaPi image** from our [Releases page](https://github.com/Fiestaboard/FiestaBoard/releases/latest) (`FiestaPi-<version>-arm64.img.xz`)
 
 **The 4-step flow:**
 

--- a/docs-site/docs/setup/beginners-guide.md
+++ b/docs-site/docs/setup/beginners-guide.md
@@ -29,7 +29,7 @@ If you have (or are willing to buy) a Raspberry Pi, this is by far the easiest r
 
 1. **Get a Raspberry Pi** (3B or newer — the Pi 4, Pi 5, and the inexpensive [Pi Zero 2 W](https://www.raspberrypi.com/products/raspberry-pi-zero-2-w/) all work), plus a microSD card (8 GB minimum, 16 GB+ recommended) and a 5 V power supply.
 2. **Download Raspberry Pi Imager** — a free, official tool from the Raspberry Pi Foundation that flashes images to SD cards. Available for Mac, Windows, and Linux at [raspberrypi.com/software](https://www.raspberrypi.com/software/).
-3. **Download the FiestaPi image** from our [GitHub Releases page](https://github.com/Fiestaboard/FiestaBoard/releases/latest) — grab the file named `fiestapi-<version>-arm64.img.xz`.
+3. **Download the FiestaPi image** from our [GitHub Releases page](https://github.com/Fiestaboard/FiestaBoard/releases/latest) — grab the file named `FiestaPi-<version>-arm64.img.xz`.
 4. **Flash the SD card** with Raspberry Pi Imager:
    - Choose Device → your Pi model
    - Choose OS → scroll to the bottom → **Use custom** → pick the `.img.xz` file you downloaded

--- a/docs-site/docs/setup/raspberry-pi.md
+++ b/docs-site/docs/setup/raspberry-pi.md
@@ -26,7 +26,7 @@ FiestaPi is a pre-built Raspberry Pi OS image with FiestaBoard, Docker, and the 
 
 👉 **[Download the latest FiestaPi image](https://github.com/Fiestaboard/FiestaBoard/releases/latest)**
 
-On the Releases page, grab the file named `fiestapi-<version>-arm64.img.xz`.
+On the Releases page, grab the file named `FiestaPi-<version>-arm64.img.xz`.
 
 :::tip Not sure which file to pick?
 Download the `.img.xz` file. It's compressed — Raspberry Pi Imager handles decompression automatically.
@@ -54,8 +54,8 @@ The **Customisation** step in the Imager sidebar is only used during the flash �
 
 Alternative tools: [Balena Etcher](https://etcher.balena.io/) works too. On Linux/macOS with `dd`:
 ```bash
-xz -d fiestapi-<version>-arm64.img.xz
-sudo dd if=fiestapi-<version>-arm64.img of=/dev/<your-sd-card> bs=4M status=progress
+xz -d FiestaPi-<version>-arm64.img.xz
+sudo dd if=FiestaPi-<version>-arm64.img of=/dev/<your-sd-card> bs=4M status=progress
 ```
 
 ### Adding Wi-Fi credentials without Raspberry Pi Imager

--- a/docs/setup/RASPBERRY_PI.md
+++ b/docs/setup/RASPBERRY_PI.md
@@ -12,7 +12,7 @@ The easiest way to run FiestaBoard is to flash a Raspberry Pi with our pre-built
 
 ## 1. Download the image
 
-Grab the latest `fiestapi-<version>-arm64.img.xz` from the [GitHub Releases](https://github.com/Fiestaboard/FiestaBoard/releases) page.
+Grab the latest `FiestaPi-<version>-arm64.img.xz` from the [GitHub Releases](https://github.com/Fiestaboard/FiestaBoard/releases) page.
 
 ## 2. Flash the SD card
 
@@ -32,8 +32,8 @@ The simplest tool is [Raspberry Pi Imager](https://www.raspberrypi.com/software/
 Other tools that work: [Balena Etcher](https://etcher.balena.io/), or `dd` on Linux/macOS:
 
 ```bash
-xz -d fiestapi-<version>-arm64.img.xz
-sudo dd if=fiestapi-<version>-arm64.img of=/dev/<your-sd-card> bs=4M status=progress
+xz -d FiestaPi-<version>-arm64.img.xz
+sudo dd if=FiestaPi-<version>-arm64.img of=/dev/<your-sd-card> bs=4M status=progress
 ```
 
 ### Adding Wi-Fi credentials after flashing

--- a/pi-image/README.md
+++ b/pi-image/README.md
@@ -44,7 +44,7 @@ Built by `.github/workflows/build-fiestapi.yml` on three triggers:
   gh run watch
   ```
 
-Output is uploaded as a workflow artifact (`fiestapi-<version>-arm64`) and, for tag builds, attached to the GitHub Release as `fiestapi-<version>-arm64.img.xz`.
+Output is uploaded as a workflow artifact (`FiestaPi-<version>-arm64`) and, for tag builds, attached to the GitHub Release as `FiestaPi-<version>-arm64.img.xz`.
 
 ## Layout
 

--- a/pi-image/stage-fiestaboard/01-install-fiestaboard/files/fiestaboard.service
+++ b/pi-image/stage-fiestaboard/01-install-fiestaboard/files/fiestaboard.service
@@ -3,15 +3,32 @@ Description=FiestaBoard
 Requires=docker.service
 After=docker.service network-online.target
 Wants=network-online.target
+# First-boot image pulls can race containerd snapshot extraction
+# ("lease does not exist: not found") when compose pulls multiple
+# images in parallel on slow SD-card I/O. Retry up to 10 times in
+# 10 min so the install self-recovers instead of stranding the user
+# with port 4420 closed.
+StartLimitIntervalSec=600
+StartLimitBurst=10
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
 WorkingDirectory=/opt/fiestaboard
+# Serialize image pulls. Parallel layer extraction on slow SD cards
+# triggers the containerd lease race above; one-at-a-time is reliable.
+Environment=COMPOSE_PARALLEL_LIMIT=1
 ExecStartPre=/opt/fiestaboard/firstboot.sh
+# Explicit pull step before `up -d` so transient pull failures are
+# visible in the journal and counted against the retry budget. The
+# `-` prefix tolerates offline boots (we still try `up` with whatever
+# images are cached locally).
+ExecStartPre=-/usr/bin/docker compose pull
 ExecStart=/usr/bin/docker compose up -d
 ExecStop=/usr/bin/docker compose down
 TimeoutStartSec=900
+Restart=on-failure
+RestartSec=30s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

Two related fixes for the FiestaPi image:

- **First-boot pull race**: on fresh SD cards, `docker compose up -d` pulls `fiestaboard` and `fiestaupdater` in parallel, which races containerd's snapshot extraction (`lease does not exist: not found`). With `Type=oneshot` and no `Restart=` policy, the unit dies once and never retries — port 4420 stays closed and the user sees "no login response on a fresh install." Reproduced live on a Pi 4 over Ethernet during this session.
- **Image filename rename**: pi-gen's default output `image_<build-date>-fiestapi-lite.img.xz` is ugly, missing the FiestaBoard version, and inconsistent with the docs (which have always told users to download `fiestapi-<version>-arm64.img.xz`). Rename to `FiestaPi-<version>-arm64.img.xz` and bring all current docs in line.

## Changes

**`pi-image/.../fiestaboard.service`**

- `Environment=COMPOSE_PARALLEL_LIMIT=1` — serializes layer extraction so the containerd snapshot race cannot occur on slow SD-card I/O.
- `ExecStartPre=-/usr/bin/docker compose pull` — explicit pre-pull so transient failures show up in the journal and are counted against the retry budget. The `-` prefix tolerates offline boots.
- `Restart=on-failure`, `RestartSec=30s`, `StartLimitIntervalSec=600`, `StartLimitBurst=10` — any transient pull/extract failure self-heals within ~5 minutes instead of stranding the user.

**`.github/workflows/build-fiestapi.yml`**

- Rename pi-gen's output to `FiestaPi-<version>-arm64.img.xz` before checksum/upload/release-attach. Workflow artifact name follows. Tag builds (`v6.1.1`) yield `FiestaPi-6.1.1-arm64.img.xz`; weekly cron yields `FiestaPi-2026-WNN-arm64.img.xz`.

**Docs** (current versions only — versioned snapshots left as historical record)

- `README.md`, `pi-image/README.md`, `docs/setup/RASPBERRY_PI.md`, `docs-site/docs/setup/{raspberry-pi,beginners-guide}.md` updated to reference `FiestaPi-<version>-arm64.img.xz`.

## Why parallel pulls race

`pull_policy: always` on both services in `pi-image/.../docker-compose.yml` plus `COMPOSE_PROFILES=fiestaupdater` in the .env means every `docker compose up` pulls two images. On a fresh SD card with no cached layers, containerd extracts both image trees concurrently, and intermittently loses track of a lease during snapshot commit. The error surfaces as `failed to commit snapshot extract-<id>-<rnd> sha256:<digest>: NotFound: lease does not exist: not found`. Plenty of disk available (108 GB free on the test Pi) — it's a concurrency bug, not a resource one.

## Recovering existing customers (no reflash)

Already-deployed Pis that hit this can recover by SSHing in and restarting the unit. Once the images are cached locally, subsequent `up` invocations skip the racy pull path:

```
ssh fiesta@fiestapi.local   # password: fiestaboard
sudo systemctl restart fiestaboard
```

## Test plan

- [x] Reproduced the failure live on a fresh Pi 4 (Ethernet, 192.168.0.154) — `docker ps -a` empty, `journalctl -u fiestaboard` shows the containerd lease error, port 4420 closed.
- [x] Deployed the patched unit to the test Pi via scp + `daemon-reload` + manual pull/restart — port 4420 opens, `/api/auth/status` returns `{"setup_required":true,"first_run":true}`.
- [x] Confirmed the unit reloads cleanly with `systemctl restart` after the patch.
- [ ] CI build of `FiestaPi-<version>-arm64.img.xz` succeeds (in progress: https://github.com/Fiestaboard/FiestaBoard/actions/runs/26689164974).
- [ ] Flash the resulting image to a fresh SD card and confirm first boot reaches `setup_required:true` over both Ethernet and Wi-Fi.

## Follow-ups (not in this PR)

- **Pre-pull images during pi-gen build** (largest UX win): use the arm64 CI runner to `docker save` both images into the rootfs and `docker load` them in `firstboot.sh` before `up -d`. Eliminates the first-boot network dependency entirely and drops ~3 min off first boot. Image grows ~600 MB compressed.
- **`docker compose up -d --wait`**: make systemd `active` mean "healthcheck green" instead of "compose returned 0". Honest state for downstream units, ~1–2 min later activation.
- **Verbose `/dev/console` output from `firstboot.sh`** for users debugging with a monitor attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)