### PR TITLE
ci(release): show "Pi image building" banner until image is attached

### DIFF
--- a/.github/workflows/build-fiestapi.yml
+++ b/.github/workflows/build-fiestapi.yml
@@ -224,6 +224,31 @@ jobs:
             ${{ steps.out.outputs.img }}
             ${{ steps.checksum.outputs.sha256 }}
 
+      - name: Clear "image pending" banner from release notes
+        if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main'
+        # release.yml inserts a "Raspberry Pi image is building" banner wrapped
+        # in <!-- pi-image-pending-start --> / <!-- pi-image-pending-end -->
+        # markers when the release is first created. Now that the .img.xz is
+        # attached, strip that block so users don't see a stale "pending" notice
+        # next to a release that already has the asset.
+        #
+        # No-ops cleanly when the banner is missing (weekly cron builds, tag
+        # builds against older releases, re-runs after a prior success).
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.target_release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          BODY=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json body --jq .body)
+          NEW_BODY=$(BODY="$BODY" python3 -c 'import os, re, sys; sys.stdout.write(re.sub(r"<!-- pi-image-pending-start -->.*?<!-- pi-image-pending-end -->\n*", "", os.environ["BODY"], flags=re.DOTALL))')
+          if [ "$BODY" = "$NEW_BODY" ]; then
+            echo "No pending banner found on release $TAG — nothing to clear."
+            exit 0
+          fi
+          printf '%s' "$NEW_BODY" > /tmp/release-body.md
+          gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --notes-file /tmp/release-body.md
+          echo "Cleared pending banner from release $TAG."
+
       - name: Update latest-version file in docs (tag builds only)
         if: startsWith(github.ref, 'refs/tags/')
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -456,7 +456,22 @@ jobs:
 
             // Build final release notes
             let releaseNotes = '';
-            
+
+            // Pi image is built by a separate workflow (build-fiestapi.yml) that
+            // runs after this release is published and takes ~45-60 min. Mark the
+            // release with a banner so users know the .img.xz is on its way; the
+            // Pi workflow strips this block once the image has been attached.
+            // Markers are HTML comments so the regex-strip in build-fiestapi.yml
+            // can find this exact span no matter how the body is edited later.
+            const piPendingBanner =
+              `<!-- pi-image-pending-start -->\n` +
+              `> 🍓 **Raspberry Pi image is building** — the \`FiestaPi-${version}-arm64.img.xz\` ` +
+              `asset will appear in the **Assets** section below once the build completes ` +
+              `(~45-60 min). ` +
+              `[Watch progress](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/workflows/build-fiestapi.yml)\n` +
+              `<!-- pi-image-pending-end -->\n\n`;
+            releaseNotes += piPendingBanner;
+
             if (aiSummary) {
               releaseNotes += `## Summary\n\n${aiSummary}\n\n`;
             }


### PR DESCRIPTION
## Summary

- When `release.yml` creates a new GitHub release, prepend a marked banner to the release body announcing that the Raspberry Pi `.img.xz` is still building (~45–60 min) with a link to the Pi build workflow.
- Once `build-fiestapi.yml` uploads the `.img.xz` + `.sha256` to that release, a new step strips the banner from the release body so it no longer shows "pending" next to an already-attached asset.

## Why

Today there's a ~45–60 min window after a release publishes where the GitHub Releases page advertises a Pi image (in the "Raspberry Pi" section of the body) but the **Assets** section doesn't actually contain it yet — the Pi build runs separately via `workflow_run`. Users who refresh during that window think the image is missing. This banner makes the in-flight state explicit and self-clears.

## How it works

- The banner is wrapped in `<!-- pi-image-pending-start -->` / `<!-- pi-image-pending-end -->` HTML-comment markers (invisible in rendered markdown but easy to find via regex), so the removal step can target exactly that span no matter how the body is edited later.
- The removal step uses `gh release view --json body` → Python regex strip → `gh release edit --notes-file`. If no markers are present (weekly cron builds, tag builds attaching to older releases, re-runs after success) the step exits 0 with a "nothing to clear" log line — no-op, no error.
- Removal step is gated by the same `if:` as the asset-attach step (skip dispatch from non-default branches), so feature-branch dispatches don't touch published release bodies.

## Test plan

- [ ] Cut a normal release on `main`; verify the new release body shows the Pi-pending banner above the Summary section while `build-fiestapi.yml` is still running.
- [ ] When `build-fiestapi.yml` finishes and attaches `FiestaPi-<version>-arm64.img.xz`, verify the banner is removed automatically from the same release.
- [ ] Trigger `build-fiestapi.yml` via the weekly cron / `workflow_dispatch` on `main` against a release that already has no banner; verify the "nothing to clear" log line and that the release body is left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)