### PR TITLE
fix(pi): reliable first-boot WiFi via rescan + persistent NM profile

### DIFF
--- a/pi-image/firstboot.sh
+++ b/pi-image/firstboot.sh
@@ -80,17 +80,44 @@ if [ -f "$WIFI_CONFIG_FILE" ]; then
         if command -v rfkill >/dev/null 2>&1; then
             rfkill unblock wifi 2>&1 | logger -t fiestapi-firstboot || true
         fi
+        # Make sure the WiFi radio is on at the NM layer too. rfkill unblock
+        # clears the hard/soft kill switch but NM keeps its own enabled flag.
+        nmcli radio wifi on 2>&1 | logger -t fiestapi-firstboot || true
         logger -t fiestapi-firstboot \
             "WiFi country set to ${WIFI_COUNTRY}; rfkill unblocked"
 
+        # Force a rescan with the new regulatory domain. The first scan
+        # right after rfkill unblock + country change often returns nothing,
+        # so retry a few times before attempting to associate.
+        for _ in 1 2 3 4 5; do
+            if nmcli device wifi rescan 2>/dev/null; then
+                break
+            fi
+            sleep 2
+        done
+        # Give the scan results time to populate before we try to connect.
+        sleep 3
+
+        # Use `connection add` + `up` instead of `device wifi connect` so we
+        # create a persistent profile with autoconnect=yes. `device wifi
+        # connect` depends on the SSID being in the current scan cache and
+        # silently fails if the scan hasn't populated yet; a stored profile
+        # lets NM keep retrying on its own and survives reboots cleanly.
         if [ -n "$WIFI_PASSWORD" ]; then
-            nmcli device wifi connect "$WIFI_SSID" password "$WIFI_PASSWORD" \
+            nmcli connection add type wifi ifname wlan0 \
+                con-name "$WIFI_SSID" ssid "$WIFI_SSID" \
+                wifi-sec.key-mgmt wpa-psk wifi-sec.psk "$WIFI_PASSWORD" \
+                connection.autoconnect yes \
                 2>&1 | logger -t fiestapi-firstboot || true
         else
             # Open network (no password).
-            nmcli device wifi connect "$WIFI_SSID" \
+            nmcli connection add type wifi ifname wlan0 \
+                con-name "$WIFI_SSID" ssid "$WIFI_SSID" \
+                connection.autoconnect yes \
                 2>&1 | logger -t fiestapi-firstboot || true
         fi
+        nmcli connection up "$WIFI_SSID" \
+            2>&1 | logger -t fiestapi-firstboot || true
         logger -t fiestapi-firstboot "WiFi configured for SSID: ${WIFI_SSID}"
     else
         logger -t fiestapi-firstboot \

--- a/pi-image/firstboot.sh
+++ b/pi-image/firstboot.sh
@@ -47,9 +47,10 @@ if [ -f "$WIFI_CONFIG_FILE" ]; then
     WIFI_COUNTRY=""
 
     while IFS='=' read -r key value; do
-        # Strip leading/trailing whitespace and ignore comment lines.
-        key="$(echo "$key" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-        value="$(echo "$value" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+        # Strip CR (in case the file was saved with CRLF line endings on
+        # Windows) and surrounding whitespace, then ignore comment lines.
+        key="$(printf '%s' "$key" | tr -d '\r' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+        value="$(printf '%s' "$value" | tr -d '\r' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
         case "$key" in
             SSID)     WIFI_SSID="$value" ;;
             PASSWORD) WIFI_PASSWORD="$value" ;;
@@ -103,6 +104,12 @@ if [ -f "$WIFI_CONFIG_FILE" ]; then
         # connect` depends on the SSID being in the current scan cache and
         # silently fails if the scan hasn't populated yet; a stored profile
         # lets NM keep retrying on its own and survives reboots cleanly.
+        #
+        # Delete any existing profile of the same name first so this stays
+        # idempotent — otherwise a user dropping a new fiestapi-wifi.txt to
+        # switch networks would silently fail at `connection add` (the pipe
+        # to logger masks the non-zero exit) and be left disconnected.
+        nmcli connection delete "$WIFI_SSID" 2>/dev/null || true
         if [ -n "$WIFI_PASSWORD" ]; then
             nmcli connection add type wifi ifname wlan0 \
                 con-name "$WIFI_SSID" ssid "$WIFI_SSID" \
@@ -116,8 +123,16 @@ if [ -f "$WIFI_CONFIG_FILE" ]; then
                 connection.autoconnect yes \
                 2>&1 | logger -t fiestapi-firstboot || true
         fi
-        nmcli connection up "$WIFI_SSID" \
-            2>&1 | logger -t fiestapi-firstboot || true
+        # Capture the actual exit code of `connection up` (a pipe to logger
+        # would always succeed) so a failed associate is loud in the journal
+        # instead of buried as a stray "Error:" line.
+        if nmcli_out="$(nmcli connection up "$WIFI_SSID" 2>&1)"; then
+            logger -t fiestapi-firstboot "connection up OK: ${nmcli_out}"
+        else
+            nmcli_rc=$?
+            logger -t fiestapi-firstboot \
+                "connection up FAILED (rc=${nmcli_rc}): ${nmcli_out}"
+        fi
         logger -t fiestapi-firstboot "WiFi configured for SSID: ${WIFI_SSID}"
     else
         logger -t fiestapi-firstboot \

--- a/pi-image/stage-fiestaboard/01-install-fiestaboard/files/firstboot.sh
+++ b/pi-image/stage-fiestaboard/01-install-fiestaboard/files/firstboot.sh
@@ -93,17 +93,44 @@ if [ -f "$WIFI_CONFIG_FILE" ]; then
         if command -v rfkill >/dev/null 2>&1; then
             rfkill unblock wifi 2>&1 | logger -t fiestapi-firstboot || true
         fi
+        # Make sure the WiFi radio is on at the NM layer too. rfkill unblock
+        # clears the hard/soft kill switch but NM keeps its own enabled flag.
+        nmcli radio wifi on 2>&1 | logger -t fiestapi-firstboot || true
         logger -t fiestapi-firstboot \
             "WiFi country set to ${WIFI_COUNTRY}; rfkill unblocked"
 
+        # Force a rescan with the new regulatory domain. The first scan
+        # right after rfkill unblock + country change often returns nothing,
+        # so retry a few times before attempting to associate.
+        for _ in 1 2 3 4 5; do
+            if nmcli device wifi rescan 2>/dev/null; then
+                break
+            fi
+            sleep 2
+        done
+        # Give the scan results time to populate before we try to connect.
+        sleep 3
+
+        # Use `connection add` + `up` instead of `device wifi connect` so we
+        # create a persistent profile with autoconnect=yes. `device wifi
+        # connect` depends on the SSID being in the current scan cache and
+        # silently fails if the scan hasn't populated yet; a stored profile
+        # lets NM keep retrying on its own and survives reboots cleanly.
         if [ -n "$WIFI_PASSWORD" ]; then
-            nmcli device wifi connect "$WIFI_SSID" password "$WIFI_PASSWORD" \
+            nmcli connection add type wifi ifname wlan0 \
+                con-name "$WIFI_SSID" ssid "$WIFI_SSID" \
+                wifi-sec.key-mgmt wpa-psk wifi-sec.psk "$WIFI_PASSWORD" \
+                connection.autoconnect yes \
                 2>&1 | logger -t fiestapi-firstboot || true
         else
             # Open network (no password).
-            nmcli device wifi connect "$WIFI_SSID" \
+            nmcli connection add type wifi ifname wlan0 \
+                con-name "$WIFI_SSID" ssid "$WIFI_SSID" \
+                connection.autoconnect yes \
                 2>&1 | logger -t fiestapi-firstboot || true
         fi
+        nmcli connection up "$WIFI_SSID" \
+            2>&1 | logger -t fiestapi-firstboot || true
         logger -t fiestapi-firstboot "WiFi configured for SSID: ${WIFI_SSID}"
     else
         logger -t fiestapi-firstboot \
@@ -122,11 +149,11 @@ if command -v nm-online >/dev/null 2>&1; then
     # Run nm-online standalone (not in a pipe) so its exit code is the one
     # we branch on — piping to logger would mask it and the || would only
     # ever fire on logger's exit, which is effectively never.
-    if nm-online --timeout=60 >/dev/null 2>&1; then
+    if nm-online --timeout=120 >/dev/null 2>&1; then
         logger -t fiestapi-firstboot "nm-online: connectivity confirmed"
     else
         logger -t fiestapi-firstboot \
-            "nm-online timed out after 60s; proceeding without confirmed connectivity"
+            "nm-online timed out after 120s; proceeding without confirmed connectivity"
     fi
 fi
 

--- a/pi-image/stage-fiestaboard/01-install-fiestaboard/files/firstboot.sh
+++ b/pi-image/stage-fiestaboard/01-install-fiestaboard/files/firstboot.sh
@@ -54,9 +54,10 @@ if [ -f "$WIFI_CONFIG_FILE" ]; then
     WIFI_COUNTRY=""
 
     while IFS='=' read -r key value; do
-        # Strip leading/trailing whitespace and ignore comment lines.
-        key="$(echo "$key" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
-        value="$(echo "$value" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+        # Strip CR (in case the file was saved with CRLF line endings on
+        # Windows) and surrounding whitespace, then ignore comment lines.
+        key="$(printf '%s' "$key" | tr -d '\r' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+        value="$(printf '%s' "$value" | tr -d '\r' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
         [[ -z "$key" && -z "$value" ]] && continue
         [[ -z "$key" || "$key" =~ ^# ]] && continue
         case "$key" in
@@ -116,6 +117,12 @@ if [ -f "$WIFI_CONFIG_FILE" ]; then
         # connect` depends on the SSID being in the current scan cache and
         # silently fails if the scan hasn't populated yet; a stored profile
         # lets NM keep retrying on its own and survives reboots cleanly.
+        #
+        # Delete any existing profile of the same name first so this stays
+        # idempotent — otherwise a user dropping a new fiestapi-wifi.txt to
+        # switch networks would silently fail at `connection add` (the pipe
+        # to logger masks the non-zero exit) and be left disconnected.
+        nmcli connection delete "$WIFI_SSID" 2>/dev/null || true
         if [ -n "$WIFI_PASSWORD" ]; then
             nmcli connection add type wifi ifname wlan0 \
                 con-name "$WIFI_SSID" ssid "$WIFI_SSID" \
@@ -129,8 +136,16 @@ if [ -f "$WIFI_CONFIG_FILE" ]; then
                 connection.autoconnect yes \
                 2>&1 | logger -t fiestapi-firstboot || true
         fi
-        nmcli connection up "$WIFI_SSID" \
-            2>&1 | logger -t fiestapi-firstboot || true
+        # Capture the actual exit code of `connection up` (a pipe to logger
+        # would always succeed) so a failed associate is loud in the journal
+        # instead of buried as a stray "Error:" line.
+        if nmcli_out="$(nmcli connection up "$WIFI_SSID" 2>&1)"; then
+            logger -t fiestapi-firstboot "connection up OK: ${nmcli_out}"
+        else
+            nmcli_rc=$?
+            logger -t fiestapi-firstboot \
+                "connection up FAILED (rc=${nmcli_rc}): ${nmcli_out}"
+        fi
         logger -t fiestapi-firstboot "WiFi configured for SSID: ${WIFI_SSID}"
     else
         logger -t fiestapi-firstboot \


### PR DESCRIPTION
## Summary

First-boot WiFi provisioning via `/boot/firmware/fiestapi-wifi.txt` was intermittently failing or stalling on fresh Pi setups. Root cause: `nmcli device wifi connect` ran immediately after the regulatory domain was set, before NetworkManager had a populated scan cache for the new domain — so it would silently return "No network with SSID 'X' found" (errors were swallowed by `|| true`), leaving the Pi offline. The 60 s `nm-online` budget then ran out and `docker compose pull` ran offline.

### Reliability fixes
- Turn the radio on at the NM layer (`nmcli radio wifi on`) on top of `rfkill unblock`.
- Force a rescan with up to 5 retries (handles "scan throttled"), then a short sleep, before associating.
- Replace `nmcli device wifi connect` with `nmcli connection add` + `nmcli connection up` so we register a persistent profile with `autoconnect=yes`. The profile doesn't depend on the scan cache and NM will retry on its own across reboots — important if the regulatory domain doesn't fully apply until reboot on some Pi OS versions.
- Bump `nm-online --timeout` from 60 s → 120 s to absorb the extra scan/associate latency on a cold boot.

### Robustness / debuggability follow-ups (from self-review)
- **Idempotent re-provisioning**: `nmcli connection delete "$SSID"` before `add`, so a user dropping a *new* `fiestapi-wifi.txt` to switch networks isn't silently broken by the "connection already exists" error.
- **CRLF-safe parsing**: explicit `tr -d '\r'` on parsed values (GNU sed's `[[:space:]]` already covered it, but making this defensive prevents regressions if anyone touches the trim later).
- **Real connect exit code in journal**: capture `nmcli connection up`'s actual exit code instead of piping to `logger` (which always exits 0 and masks failure). A failed associate now logs `connection up FAILED (rc=N): <output>` so `journalctl -t fiestapi-firstboot` shows the problem at a glance.

Applied to both `pi-image/firstboot.sh` and `pi-image/stage-fiestaboard/01-install-fiestaboard/files/firstboot.sh` (the latter is what actually ships in the image).

### Intentionally not in this PR
- Writing the NM keyfile directly to `/etc/NetworkManager/system-connections/`. Equivalent to what `nmcli connection add` does internally; would churn the code without fixing a different failure mode.
- Hidden-SSID support (`wifi.hidden yes`) — out of scope; can be added behind a `HIDDEN=true` option in the txt file if a user actually needs it.
- `set -o pipefail` for the whole script — broader semantic change; every other `|| true` in the script would need re-auditing.

## Test plan

- [ ] Flash a fresh FiestaPi image to an SD card
- [ ] Drop a `fiestapi-wifi.txt` with `SSID=` / `PASSWORD=` / `COUNTRY=US` onto the FAT32 boot partition
- [ ] Boot WiFi-only (no Ethernet), confirm Pi associates to the AP within ~1–2 min
- [ ] `journalctl -t fiestapi-firstboot` shows the rescan, `connection up OK`, and `nm-online: connectivity confirmed`
- [ ] Reboot once, confirm the stored profile auto-reconnects without needing the txt file (which is wiped after first use)
- [ ] Re-provision: drop a *second* `fiestapi-wifi.txt` with a different SSID, reboot, confirm the old profile is deleted and the new one comes up cleanly
- [ ] Repeat first-boot test with an open (no-password) network to exercise the second `connection add` branch
- [ ] Save `fiestapi-wifi.txt` from Windows Notepad (CRLF) and confirm parsing still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)