### PR TITLE
fix(web): show setup wizard after first-run auth picker

### DIFF
--- a/web/src/__tests__/wizard-provider.test.tsx
+++ b/web/src/__tests__/wizard-provider.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { server } from "./mocks/server";
+
+// Mock next/navigation. ``currentPathname`` is mutable so individual tests
+// can simulate a route transition (e.g. /login -> /) without remounting the
+// provider — the WizardProvider lives in the root layout, which doesn't
+// remount on client-side navigation, so the bug we're guarding against is
+// "didn't re-check after the auth picker finished".
+let currentPathname = "/";
+vi.mock("next/navigation", () => ({
+  usePathname: () => currentPathname,
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+}));
+
+// Stub the wizard so we don't have to stand up Aurora / WebGL in jsdom.
+vi.mock("@/components/wizard", () => ({
+  SetupWizard: () => <div data-testid="wizard" />,
+}));
+
+import { WizardProvider, useWizard } from "@/components/wizard-provider";
+
+function Probe() {
+  const { isWizardActive } = useWizard();
+  return <div data-testid="probe">{isWizardActive ? "wizard" : "no-wizard"}</div>;
+}
+
+function firstRunValidation() {
+  return http.get("/api/config/validate", () =>
+    HttpResponse.json({
+      valid: false,
+      is_first_run: true,
+      errors: ["missing board"],
+      missing_fields: ["board.host"],
+    }),
+  );
+}
+
+describe("WizardProvider", () => {
+  beforeEach(() => {
+    currentPathname = "/";
+    localStorage.clear();
+  });
+
+  it("does not render the wizard while the user is on /login", async () => {
+    currentPathname = "/login";
+    server.use(firstRunValidation());
+
+    render(
+      <WizardProvider>
+        <Probe />
+      </WizardProvider>,
+    );
+
+    // Children render normally (no wizard) — /login owns its own UI.
+    await screen.findByTestId("probe");
+    expect(screen.getByTestId("probe").textContent).toBe("no-wizard");
+  });
+
+  it("renders the wizard after the user transitions from /login to / on a first-run device", async () => {
+    currentPathname = "/login";
+    server.use(firstRunValidation());
+
+    const { rerender } = render(
+      <WizardProvider>
+        <Probe />
+      </WizardProvider>,
+    );
+
+    await screen.findByTestId("probe");
+    expect(screen.getByTestId("probe").textContent).toBe("no-wizard");
+
+    // Simulate the LoginPage doing router.replace("/") after the
+    // first-run picker resolves (skip or set-up-credentials).
+    currentPathname = "/";
+    rerender(
+      <WizardProvider>
+        <Probe />
+      </WizardProvider>,
+    );
+
+    // The provider must re-run shouldShowWizard now that we're off /login,
+    // and surface the wizard since the server says is_first_run=true.
+    await waitFor(() => {
+      expect(screen.getByTestId("wizard")).toBeInTheDocument();
+    });
+    // Wizard replaces the children entirely, so the probe is gone.
+    expect(screen.queryByTestId("probe")).not.toBeInTheDocument();
+  });
+
+  it("does not render the wizard on / when the device is already configured", async () => {
+    currentPathname = "/";
+    server.use(
+      http.get("/api/config/validate", () =>
+        HttpResponse.json({
+          valid: true,
+          is_first_run: false,
+          errors: [],
+          missing_fields: [],
+        }),
+      ),
+    );
+
+    render(
+      <WizardProvider>
+        <Probe />
+      </WizardProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("probe").textContent).toBe("no-wizard");
+    });
+  });
+});

--- a/web/src/components/wizard-provider.tsx
+++ b/web/src/components/wizard-provider.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, useContext, useState, useEffect, useCallback, ReactNode } from "react";
 import dynamic from "next/dynamic";
+import { usePathname } from "next/navigation";
 import { shouldShowWizard, clearWizardCompletion } from "@/lib/setup-detection";
 import { useTranslations } from "next-intl";
 
@@ -47,25 +48,43 @@ interface WizardProviderProps {
 
 export function WizardProvider({ children }: WizardProviderProps) {
   const t = useTranslations("wizardProvider");
+  const pathname = usePathname();
+  // ``/login`` owns its own UI (sign-in form, first-run auth picker) and the
+  // ``/config/validate`` request the wizard relies on is unauthenticated-401
+  // there. Treat the auth screen as a "wizard off" surface and re-check the
+  // moment the user leaves it — that's the transition where the first-run
+  // wizard should appear on a freshly provisioned device.
+  const isOnAuthScreen = pathname?.startsWith("/login") ?? false;
   const [isWizardActive, setIsWizardActive] = useState(false);
   const [hasChecked, setHasChecked] = useState(false);
 
-  // Check if wizard should be shown on mount
   useEffect(() => {
+    // Skip the check on /login — ``/config/validate`` would 401 there and
+    // the render branch below renders children directly, so there's nothing
+    // to gate. The effect re-runs (via the ``isOnAuthScreen`` dep) the
+    // moment the user navigates away from /login, which is the transition
+    // where the first-run wizard should appear on a freshly provisioned
+    // device.
+    if (isOnAuthScreen) return;
+
+    let cancelled = false;
     const checkWizard = async () => {
       try {
         const shouldShow = await shouldShowWizard();
-        setIsWizardActive(shouldShow);
+        if (!cancelled) setIsWizardActive(shouldShow);
       } catch (error) {
         console.error("Failed to check wizard status:", error);
-        setIsWizardActive(false);
+        if (!cancelled) setIsWizardActive(false);
       } finally {
-        setHasChecked(true);
+        if (!cancelled) setHasChecked(true);
       }
     };
 
     checkWizard();
-  }, []);
+    return () => {
+      cancelled = true;
+    };
+  }, [isOnAuthScreen]);
 
   const triggerWizard = useCallback(() => {
     // Clear completion status to allow re-running
@@ -76,6 +95,17 @@ export function WizardProvider({ children }: WizardProviderProps) {
   const handleComplete = useCallback(() => {
     setIsWizardActive(false);
   }, []);
+
+  // On /login we never render the wizard: that page owns its own UI and the
+  // wizard's API probe isn't authorized there yet. Hand control back to the
+  // children (the login page) immediately — no loading screen, no wizard.
+  if (isOnAuthScreen) {
+    return (
+      <WizardContext.Provider value={{ isWizardActive: false, triggerWizard }}>
+        {children}
+      </WizardContext.Provider>
+    );
+  }
 
   // Show loading state while checking
   if (!hasChecked) {


### PR DESCRIPTION
## Summary

On a fresh install, completing the /login first-run picker — either **Skip** or **Set up a username & password** — used `router.replace("/")`, a Next.js client-side navigation. The `WizardProvider` lives in the root layout, so the `shouldShowWizard()` check it did on mount (when `/config/validate` was still 401-gated by the missing session) never re-ran. Result: the user landed on the dashboard with the **No board configured** banner instead of the setup wizard.

## Fix

Make `WizardProvider` pathname-aware via `usePathname()`:

- **On `/login`:** render `children` directly. Skip the API probe — that page owns its own UI and `/config/validate` would 401 there anyway.
- **On any other route:** run `shouldShowWizard()`. Critically, re-run it whenever the user transitions *back* from `/login` (the `isOnAuthScreen` dep change does this). That's the moment the first-run wizard should appear on a freshly provisioned device.

Cancellation is wired up via a `cancelled` flag in the effect cleanup so a fast pathname flip can't apply stale state.

## Test plan

- [x] Added `web/src/__tests__/wizard-provider.test.tsx` (TDD: tests written red, then fix written, then green):
  - does not render the wizard while on /login (even if `/config/validate` would say `is_first_run`)
  - **renders the wizard after pathname transitions from /login → / on a first-run device** ← the regression this PR fixes
  - does not render the wizard on / when the device is already configured
- [x] Full suite: 988 tests passing, 0 new lint errors
- [ ] Manual: flash a fresh image, walk through the auth picker (both Skip and Set up paths), verify the wizard appears on `/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)