### PR TITLE
feat(web): show Raspberry Pi hardware model in Settings → About

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -483,6 +483,7 @@ class VersionResponse(BaseModel):
     package_version: str
     build_version: str
     is_dev: bool
+    hardware_model: Optional[str] = None
 
 
 class UpdateCheckResponse(BaseModel):
@@ -1461,10 +1462,27 @@ def _collect_plugin_demos() -> List[Dict[str, Any]]:
     return demos
 
 
+def _detect_hardware_model() -> Optional[str]:
+    """Return the host hardware model string, or None if undetectable.
+
+    Reads ``/proc/device-tree/model``, which on Raspberry Pi devices contains a
+    null-terminated string such as ``"Raspberry Pi 5 Model B Rev 1.0"``. The
+    file is absent on most non-Pi hosts (generic Docker, macOS, etc.), so the
+    UI suppresses the row when this returns None.
+    """
+    try:
+        with open("/proc/device-tree/model", "rb") as f:
+            raw = f.read(256)
+    except (FileNotFoundError, PermissionError, OSError):
+        return None
+    model = raw.decode("utf-8", errors="replace").rstrip("\x00").strip()
+    return model or None
+
+
 @app.get("/version", response_model=VersionResponse)
 async def version():
     """Get version information.
-    
+
     Returns both the package version (from __version__) and the build version
     (from VERSION environment variable). In production builds, these should match.
     """
@@ -1473,7 +1491,8 @@ async def version():
     return VersionResponse(
         package_version=__version__,
         build_version=build_version,
-        is_dev=build_version == "dev" and not production
+        is_dev=build_version == "dev" and not production,
+        hardware_model=_detect_hardware_model(),
     )
 
 

--- a/tests/test_api_extended.py
+++ b/tests/test_api_extended.py
@@ -331,6 +331,16 @@ class TestRootAndHealth:
         assert "package_version" in data
         assert "build_version" in data
         assert "is_dev" in data
+        assert "hardware_model" in data
+
+    def test_version_includes_detected_hardware_model(self, client):
+        with patch(
+            "src.api_server._detect_hardware_model",
+            return_value="Raspberry Pi 5 Model B Rev 1.0",
+        ):
+            response = client.get("/version")
+        assert response.status_code == 200
+        assert response.json()["hardware_model"] == "Raspberry Pi 5 Model B Rev 1.0"
 
     def test_status_success(self, client, mock_service, mock_settings_service):
         with patch("src.api_server._service_running", True):

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -960,6 +960,7 @@
     "aboutDescription": "Version and service information",
     "version": "Version",
     "buildVersion": "Build",
+    "hardware": "Hardware",
     "status": "Status",
     "statusRunning": "Running",
     "statusStopped": "Stopped",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -960,6 +960,7 @@
     "aboutDescription": "Version and service information",
     "version": "Version",
     "buildVersion": "Build",
+    "hardware": "Hardware",
     "status": "Status",
     "statusRunning": "Running",
     "statusStopped": "Stopped",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -960,6 +960,7 @@
     "aboutDescription": "Version and service information",
     "version": "Version",
     "buildVersion": "Build",
+    "hardware": "Hardware",
     "status": "Status",
     "statusRunning": "Running",
     "statusStopped": "Stopped",

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -960,6 +960,7 @@
     "aboutDescription": "Version and service information",
     "version": "Version",
     "buildVersion": "Build",
+    "hardware": "Hardware",
     "status": "Status",
     "statusRunning": "Running",
     "statusStopped": "Stopped",

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -960,6 +960,7 @@
     "aboutDescription": "Version and service information",
     "version": "Version",
     "buildVersion": "Build",
+    "hardware": "Hardware",
     "status": "Status",
     "statusRunning": "Running",
     "statusStopped": "Stopped",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -960,6 +960,7 @@
     "aboutDescription": "Version and service information",
     "version": "Version",
     "buildVersion": "Build",
+    "hardware": "Hardware",
     "status": "Status",
     "statusRunning": "Running",
     "statusStopped": "Stopped",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -960,6 +960,7 @@
     "aboutDescription": "Version and service information",
     "version": "Version",
     "buildVersion": "Build",
+    "hardware": "Hardware",
     "status": "Status",
     "statusRunning": "Running",
     "statusStopped": "Stopped",

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -960,6 +960,7 @@
     "aboutDescription": "Version and service information",
     "version": "Version",
     "buildVersion": "Build",
+    "hardware": "Hardware",
     "status": "Status",
     "statusRunning": "Running",
     "statusStopped": "Stopped",

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -960,6 +960,7 @@
     "aboutDescription": "Version and service information",
     "version": "Version",
     "buildVersion": "Build",
+    "hardware": "Hardware",
     "status": "Status",
     "statusRunning": "Running",
     "statusStopped": "Stopped",

--- a/web/messages/pt.json
+++ b/web/messages/pt.json
@@ -960,6 +960,7 @@
     "aboutDescription": "Version and service information",
     "version": "Version",
     "buildVersion": "Build",
+    "hardware": "Hardware",
     "status": "Status",
     "statusRunning": "Running",
     "statusStopped": "Stopped",

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -960,6 +960,7 @@
     "aboutDescription": "Version and service information",
     "version": "Version",
     "buildVersion": "Build",
+    "hardware": "Hardware",
     "status": "Status",
     "statusRunning": "Running",
     "statusStopped": "Stopped",

--- a/web/messages/sv.json
+++ b/web/messages/sv.json
@@ -960,6 +960,7 @@
     "aboutDescription": "Version and service information",
     "version": "Version",
     "buildVersion": "Build",
+    "hardware": "Hardware",
     "status": "Status",
     "statusRunning": "Running",
     "statusStopped": "Stopped",

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -960,6 +960,7 @@
     "aboutDescription": "Version and service information",
     "version": "Version",
     "buildVersion": "Build",
+    "hardware": "Hardware",
     "status": "Status",
     "statusRunning": "Running",
     "statusStopped": "Stopped",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -960,6 +960,7 @@
     "aboutDescription": "Version and service information",
     "version": "Version",
     "buildVersion": "Build",
+    "hardware": "Hardware",
     "status": "Status",
     "statusRunning": "Running",
     "statusStopped": "Stopped",

--- a/web/src/components/settings/about-card.tsx
+++ b/web/src/components/settings/about-card.tsx
@@ -2,7 +2,7 @@
 
 import { useTranslations } from "next-intl";
 import { useQuery } from "@tanstack/react-query";
-import { ExternalLink, Info, Package } from "lucide-react";
+import { Cpu, ExternalLink, Info, Package } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -108,6 +108,16 @@ export function AboutCard() {
               <dt className="text-muted-foreground">{t("buildVersion")}</dt>
               <dd className="font-mono text-xs text-muted-foreground tabular-nums">
                 {versionData.build_version}
+              </dd>
+            </div>
+          )}
+
+          {versionData?.hardware_model && (
+            <div className="flex items-center justify-between gap-4">
+              <dt className="text-muted-foreground">{t("hardware")}</dt>
+              <dd className="flex items-center gap-2">
+                <Cpu className="h-3.5 w-3.5 text-muted-foreground" />
+                <span className="text-xs">{versionData.hardware_model}</span>
               </dd>
             </div>
           )}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1052,6 +1052,7 @@ export interface VersionResponse {
   package_version: string;
   build_version: string;
   is_dev: boolean;
+  hardware_model: string | null;
 }
 
 export interface UpdateCheckResponse {


### PR DESCRIPTION
## Summary

- Adds an optional `hardware_model` field to the `/version` API, read from `/proc/device-tree/model` (e.g. `"Raspberry Pi 5 Model B Rev 1.0"`).
- Renders a new **Hardware** row in Settings → System → About, gated on the value being non-null — so generic Docker installs are unaffected and don't show an empty/awkward row.
- One new translation key (`profile.hardware`) added across all 14 locale files (English string only; existing untranslated entries follow the same pattern in this repo).

The detection deliberately avoids the `FIESTABOARD_PROFILE` env var: any host that exposes a device-tree model string gets it surfaced, including non-FiestaPi Pi setups running our Docker image with `/proc` available.

## Test plan

- [x] `pytest tests/test_api_extended.py::TestRootAndHealth::test_version{,_includes_detected_hardware_model}` — both pass in dev container
- [ ] Manual: load `/settings` → System tab on a Pi install, confirm "Hardware" row appears with the model string
- [ ] Manual: load on Docker/macOS install, confirm "Hardware" row is hidden (no empty row, no `—`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)