### PR TITLE
fix(web): remove nested scroll containers on mobile

### DIFF
--- a/web/src/components/home-assistant-entity-picker.tsx
+++ b/web/src/components/home-assistant-entity-picker.tsx
@@ -80,9 +80,9 @@ export function HomeAssistantEntityPicker({ open, onClose, onSelect }: Props) {
             <div className="text-sm text-muted-foreground">{t("loadingEntities")}</div>
           </div>
         ) : (
-          <div className="space-y-3 flex-1 overflow-y-auto">
+          <div className="space-y-3 flex-1 min-h-0 flex flex-col">
             {!selectedEntity ? (
-              <div className="space-y-2">
+              <div className="space-y-2 flex-1 min-h-0 flex flex-col">
                 <Input
                   placeholder={t("searchPlaceholder")}
                   value={searchQuery}
@@ -90,7 +90,7 @@ export function HomeAssistantEntityPicker({ open, onClose, onSelect }: Props) {
                   autoFocus
                   className="h-9"
                 />
-                <ScrollArea className="h-[400px] border rounded-md">
+                <ScrollArea className="flex-1 min-h-[200px] border rounded-md">
                   <div className="p-1">
                     {filteredEntities.length === 0 ? (
                       <div className="text-sm text-muted-foreground text-center py-3">

--- a/web/src/components/plugin-settings/schema-form.tsx
+++ b/web/src/components/plugin-settings/schema-form.tsx
@@ -982,7 +982,7 @@ function GenericDataMappingHelper({ name: _name, property: _property, value, onC
 
       {/* Response tree browser */}
       {previewData && (
-        <div className="border rounded-lg p-3 bg-muted/20 max-h-64 overflow-auto">
+        <div className="border rounded-lg p-3 bg-muted/20 sm:max-h-64 sm:overflow-auto">
           <div className="text-xs font-medium text-muted-foreground mb-2">
             {t("responseClickToAdd")}
           </div>

--- a/web/src/components/tiptap-template-editor/components/FormulaEditorPanel.tsx
+++ b/web/src/components/tiptap-template-editor/components/FormulaEditorPanel.tsx
@@ -466,8 +466,8 @@ export function FormulaEditorPanel({
               {loadingFns && (
                 <p className="text-xs text-muted-foreground px-3 py-2">{t("loading") ?? "Loading…"}</p>
               )}
-              {/* max-h only on mobile — desktop lets the column scroll */}
-              <div className="overflow-y-auto max-h-[240px] sm:max-h-none px-2 pb-2 space-y-1">
+              {/* Parent column (desktop) or modal (mobile) scrolls — don't nest a scroll here. */}
+              <div className="px-2 pb-2 space-y-1">
                 {CATEGORY_ORDER.filter((cat) => grouped[cat]?.length).map((cat) => {
                   const isCollapsed = collapsedCategories.has(cat);
                   const fns = grouped[cat] ?? [];
@@ -547,8 +547,8 @@ export function FormulaEditorPanel({
         {/* ── RIGHT COLUMN (desktop) / TOP (mobile): Expression editor + action buttons ── */}
         <div className="order-1 sm:order-2 flex flex-col flex-1 min-w-0 sm:overflow-hidden">
 
-          {/* Scrollable expression area — grows to fill available height */}
-          <div className="flex-1 overflow-y-auto px-3 pt-3 pb-2.5 space-y-1.5 sm:flex sm:flex-col sm:overflow-hidden">
+          {/* Desktop: flex column fills, editor sizes within. Mobile: parent modal scrolls — no nested scroll. */}
+          <div className="px-3 pt-3 pb-2.5 space-y-1.5 sm:flex-1 sm:flex sm:flex-col sm:overflow-hidden">
             <label className="text-[10px] font-semibold text-muted-foreground uppercase tracking-widest">
               {t("formulaExpression")}
             </label>


### PR DESCRIPTION
## Summary

In mobile mode several screens had multiple nested scroll containers competing for touch input, which made scrolling janky and intercepted gestures intended for the page (or the sheet/modal) viewport. This PR audits the pattern and fixes the three most impactful offenders.

### The pattern

A child component adds its own `overflow-y-auto` (often with `max-h-*`) inside a parent that is *already* the natural scroll viewport (the `<main>` element, a `SheetContent`, an `AlertDialogContent`, or a portal modal). On desktop the inner scroll is mostly invisible; on mobile, where the parent fills the viewport, the user ends up with 2–3 stacked scroll regions on one screen.

**Rule of thumb:** only introduce a scroll if you *are* the intended scroll region (chat thread, virtualized list, fixed-height picker). Otherwise flow and let the nearest viewport / sheet / modal scroll.

### Fixes

- **`home-assistant-entity-picker.tsx`** — `AlertDialogContent[max-h-[80vh] flex flex-col]` → wrapper `flex-1 overflow-y-auto` → `ScrollArea h-[400px]` was three nested scrolls. Drop the middle wrapper; let the `ScrollArea` (now `flex-1 min-h-[200px]`) be the single scroll inside the dialog.
- **`FormulaEditorPanel.tsx`** — The formula modal already has `max-h-[90vh] overflow-y-auto`. The panel was adding mobile-only inner `overflow-y-auto` to *both* the function list and the expression column, giving three nested scrolls on mobile. Removed; desktop side-by-side columns still scroll independently as before.
- **`plugin-settings/schema-form.tsx`** — Response tree had `max-h-64 overflow-auto` nested inside the integrations `SheetContent` that already scrolls. Gated behind `sm:` so the tree flows naturally on mobile while keeping the bounded preview on desktop.

### Notes on what was *not* changed

The audit also flagged several false positives that turned out to be intentional single-scroll regions: the `SheetContent` wrappers on the Schedule / Carousels / Integrations pages, the mobile navigation menu (`overflow-hidden` parent + scrolling `<nav>` child = one scroll layer), the AI chat panel's `ScrollArea` inside a sized `Card`, the page editor canvas, and the portaled `TimePicker` / `TimezonePicker` dropdowns. Leaving those alone.

## Test plan

- [ ] Open the Integrations sheet on a phone-sized viewport, expand a plugin that uses the generic data-mapping helper, verify the response tree no longer creates its own scroll region.
- [ ] Insert a formula in the rich-text editor on mobile (`{{= ... }}`); confirm only the modal scrolls and you can reach the function list, editor, and action buttons.
- [ ] Open the Home Assistant entity picker on mobile; verify a single scroll inside the dialog covers both the search list and (after selecting an entity) the attribute list.
- [ ] Spot-check desktop layouts for the same three components — should be visually identical aside from the inner-scroll behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)