### PR TITLE
test(auth): add E2E coverage for login, setup, and logout flows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -498,6 +498,118 @@ jobs:
           retention-days: 30
           if-no-files-found: ignore
 
+  auth-e2e-tests:
+    name: Auth E2E Tests
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: github.event_name == 'pull_request' && (needs.detect-changes.outputs.api == 'true' || needs.detect-changes.outputs.ui == 'true' || needs.detect-changes.outputs.shared == 'true')
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+
+      - name: Install deps (parallel)
+        run: |
+          (cd web && npm ci && echo "✅ npm ci complete") &
+          NPM_PID=$!
+          cd web
+          npx playwright install-deps chromium > /dev/null
+          wait $NPM_PID || { echo "❌ npm ci failed"; exit 1; }
+          npx playwright install chromium
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        continue-on-error: true
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build test image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          push: false
+          load: true
+          tags: fiestaboard:auth-e2e
+          build-args: |
+            VERSION=dev
+          # Reuse the cache the main e2e job warms up.
+          cache-from: |
+            type=gha,scope=build-linux/amd64
+            type=gha,scope=build-test
+
+      - name: Start FiestaBoard with auth enabled
+        run: |
+          docker run -d --name fiestaboard-auth \
+            -e PRODUCTION=false \
+            -e FIESTABOARD_AUTH_ENABLED=true \
+            fiestaboard:auth-e2e
+
+          FB_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' fiestaboard-auth)
+          echo "BASE_URL=http://$FB_IP:3000" >> $GITHUB_ENV
+          echo "FiestaBoard IP: $FB_IP"
+
+      - name: Wait for container ready
+        run: |
+          for i in $(seq 1 60); do
+            STATUS=$(curl -s -m 5 -o /dev/null -w "%{http_code}" "$BASE_URL/api/health" 2>/dev/null || echo "000")
+            if [ "$STATUS" = "200" ]; then
+              echo "✅ Ready (attempt $i)"
+              break
+            fi
+            if [ "$i" = "60" ]; then
+              echo "❌ Failed to become ready"
+              docker logs fiestaboard-auth | tail -50
+              exit 1
+            fi
+            sleep 1
+          done
+
+      - name: Confirm auth is enabled
+        # Sanity check: if the container started with auth disabled we'd
+        # get false positives from the spec's skip guard.
+        run: |
+          MODE=$(curl -s "$BASE_URL/api/auth/status" | python3 -c "import json,sys; print(json.load(sys.stdin)['mode'])")
+          echo "auth mode = $MODE"
+          if [ "$MODE" != "enabled" ]; then
+            echo "❌ Expected auth mode 'enabled', got '$MODE'"
+            exit 1
+          fi
+
+      - name: Run auth E2E tests
+        working-directory: web
+        run: npx playwright test auth.spec.ts --reporter=github --workers=1
+        env:
+          CI: true
+          RUN_AUTH_TESTS: "1"
+          BASE_URL: ${{ env.BASE_URL }}
+
+      - name: Dump container logs on failure
+        if: failure()
+        run: docker logs fiestaboard-auth | tail -200
+
+      - name: Stop container
+        if: always()
+        run: docker rm -f fiestaboard-auth 2>/dev/null || true
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-auth-results
+          path: web/playwright-test-results/
+          retention-days: 7
+
   build:
     name: Build Verification
     runs-on: ubuntu-latest
@@ -561,7 +673,7 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [detect-changes, test-platform, test-plugins, test-ui, a11y-tests, e2e-tests, build, build-docs]
+    needs: [detect-changes, test-platform, test-plugins, test-ui, a11y-tests, e2e-tests, auth-e2e-tests, build, build-docs]
     if: always()
     steps:
       - name: Check all jobs passed or were skipped

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -20,6 +20,13 @@ const ciIgnore = ["**/generate-screenshots.spec.ts"];
 if (!process.env.RUN_VISUAL_REGRESSION) {
   ciIgnore.push("**/visual-regression.spec.ts");
 }
+// Auth specs need a container booted with FIESTABOARD_AUTH_ENABLED=true.
+// The main e2e job runs with auth disabled, so opt these in via env var
+// (mirrors the visual-regression pattern above) and let a dedicated job
+// flip the switch.
+if (!process.env.RUN_AUTH_TESTS) {
+  ciIgnore.push("**/auth.spec.ts");
+}
 
 export default defineConfig({
   testDir: "./tests",

--- a/web/tests/COVERAGE.md
+++ b/web/tests/COVERAGE.md
@@ -13,12 +13,13 @@ Tests exercise the full stack:
 Playwright browser → Next.js UI → FastAPI backend → Mock Vestaboard API
 ```
 
-### Playwright Spec Files (27 files)
+### Playwright Spec Files (28 files)
 
 | File | Area | What's Covered |
 |------|------|----------------|
 | `api.spec.ts` | Backend API | Core endpoint contracts: version, config, settings CRUD, pages CRUD, schedules CRUD, plugins, template validation, displays, debug |
 | `api-extended.spec.ts` | Backend API | Deeper API coverage: full config, board config test, page preview/send/batch, schedule active/validate/default/enable, plugin config/variables, settings transitions/active-page/board, template render, service start/stop |
+| `auth.spec.ts` | Authentication | First-run setup form, sign-in form (valid + invalid creds), remember-me cookie behavior, logout, protected-route 401 / 409 setup-required, `/profile` redirect, `redirect=` query param. Gated behind `RUN_AUTH_TESTS=1` because it requires a container booted with `FIESTABOARD_AUTH_ENABLED=true`. Runs in its own CI job (`auth-e2e-tests`); the main e2e job runs with auth disabled. |
 | `board-discovery-offline.spec.ts` | Board discovery & offline | Board scan/discovery endpoint, connection test (online/offline/missing creds), per-board schedule active page resolution, per-board schedule enable/disable independence, Note template rendering dimensions, offline board send handling, multi-board state independence |
 | `calendar-alignment.spec.ts` | Schedule UI | Time gutter label alignment with hour grid, desktop + mobile viewports |
 | `dashboard.spec.ts` | Dashboard | Board display visible, active page name, manual mode badge |
@@ -63,6 +64,8 @@ Playwright browser → Next.js UI → FastAPI backend → Mock Vestaboard API
 | `/integrations/[pluginId]` | `plugin-detail.spec.ts` |
 | `/settings` | `settings.spec.ts`, `settings-full.spec.ts`, `visual-regression.spec.ts` |
 | `/debug` | `settings-full.spec.ts` (debug tools section) |
+| `/login` | `auth.spec.ts` (setup + sign-in forms) |
+| `/profile` | `auth.spec.ts` (redirects to `/settings`) |
 
 ---
 

--- a/web/tests/auth.spec.ts
+++ b/web/tests/auth.spec.ts
@@ -18,7 +18,8 @@ import { test, expect, type APIRequestContext, type Page } from "@playwright/tes
 
 const BASE_URL = process.env.BASE_URL || "http://localhost:4420";
 const API_URL = `${BASE_URL}/api`;
-const SESSION_COOKIE_NAME = "fb_session";
+// Must match SESSION_COOKIE_NAME in src/auth/service.py.
+const SESSION_COOKIE_NAME = "fiestaboard_session";
 
 const ADMIN_USERNAME = "e2e-admin";
 const ADMIN_PASSWORD = "e2e-password-12345";
@@ -244,6 +245,12 @@ test.describe("Authentication", () => {
 
     test("/profile redirects to /settings while authenticated", async ({ page }) => {
       await signIn(page);
+      // The WizardProvider gates every non-/login route behind /config/validate
+      // and renders a full-screen loader (then the SetupWizard) when
+      // `is_first_run` is true — children never mount, so /profile's
+      // redirect useEffect never fires. Configure a stub board so
+      // is_first_run flips to false and the page actually loads.
+      await ensureBoardConfigured(page);
       await page.goto("/profile");
       // Profile is a thin redirect to /settings?section=general.
       await page.waitForURL(/\/settings/, { timeout: 5_000 });
@@ -289,5 +296,30 @@ async function signIn(page: Page): Promise<void> {
   });
   if (!res.ok()) {
     throw new Error(`signIn failed: ${res.status()} ${await res.text()}`);
+  }
+}
+
+/**
+ * PUT a stub board config so `/api/config/validate` reports
+ * `is_first_run: false`. Without this, the WizardProvider holds the page
+ * on a loading screen / setup wizard and any UI test that needs the real
+ * page to mount (and run its useEffects) hangs.
+ *
+ * Idempotent — the values aren't checked against a real board here.
+ * Caller must already be authenticated; the session cookie on page.request
+ * carries through.
+ */
+async function ensureBoardConfigured(page: Page): Promise<void> {
+  const res = await page.request.put(`${API_URL}/config/board`, {
+    data: {
+      api_mode: "local",
+      local_api_key: "auth-e2e-stub-key",
+      host: "127.0.0.1",
+    },
+  });
+  if (!res.ok()) {
+    throw new Error(
+      `ensureBoardConfigured failed: ${res.status()} ${await res.text()}`,
+    );
   }
 }

--- a/web/tests/auth.spec.ts
+++ b/web/tests/auth.spec.ts
@@ -72,7 +72,7 @@ test.describe("Authentication", () => {
     test("protected API endpoint returns 409 setup_required when no user exists", async ({
       request,
     }) => {
-      const res = await request.get(`${API_URL}/settings`);
+      const res = await request.get(`${API_URL}/pages`);
       expect(res.status()).toBe(409);
       const body = await res.json();
       expect(body.setup_required).toBe(true);
@@ -128,7 +128,7 @@ test.describe("Authentication", () => {
           data: { username: ADMIN_USERNAME, password: ADMIN_PASSWORD, remember_me: true },
         });
         expect(login.ok()).toBe(true);
-        const res = await ctx.get(`${API_URL}/settings`);
+        const res = await ctx.get(`${API_URL}/pages`);
         expect(res.ok()).toBe(true);
       } finally {
         await ctx.dispose();
@@ -151,7 +151,7 @@ test.describe("Authentication", () => {
         expect(out.headers()["set-cookie"] || "").toContain(SESSION_COOKIE_NAME);
 
         // A protected endpoint must now 401 (user exists, no valid cookie).
-        const protectedRes = await ctx.get(`${API_URL}/settings`);
+        const protectedRes = await ctx.get(`${API_URL}/pages`);
         expect(protectedRes.status()).toBe(401);
       } finally {
         await ctx.dispose();

--- a/web/tests/auth.spec.ts
+++ b/web/tests/auth.spec.ts
@@ -1,0 +1,293 @@
+/**
+ * Authentication E2E tests.
+ *
+ * Exercises the FastAPI `/auth/*` router and the `/login` UI against a
+ * container booted with `FIESTABOARD_AUTH_ENABLED=true`.
+ *
+ * These specs are gated behind `RUN_AUTH_TESTS` in `playwright.config.ts`
+ * because the default e2e job runs with auth disabled — running them there
+ * would fail since the middleware short-circuits and the login page bounces
+ * straight home.
+ *
+ * The tests inside the serial block share state on purpose: the first one
+ * provisions the admin via `/auth/setup`, and the rest log in / log out
+ * against that user. Running them in parallel against the same container
+ * would race on the user store.
+ */
+import { test, expect, type APIRequestContext, type Page } from "@playwright/test";
+
+const BASE_URL = process.env.BASE_URL || "http://localhost:4420";
+const API_URL = `${BASE_URL}/api`;
+const SESSION_COOKIE_NAME = "fb_session";
+
+const ADMIN_USERNAME = "e2e-admin";
+const ADMIN_PASSWORD = "e2e-password-12345";
+const WRONG_PASSWORD = "definitely-not-it";
+
+type AuthStatus = {
+  enabled: boolean;
+  setup_required: boolean;
+  authenticated: boolean;
+  username?: string | null;
+  mode: string;
+  first_run: boolean;
+};
+
+async function fetchAuthStatus(request: APIRequestContext): Promise<AuthStatus> {
+  const res = await request.get(`${API_URL}/auth/status`);
+  expect(res.ok()).toBe(true);
+  return (await res.json()) as AuthStatus;
+}
+
+/** Convenience: assert the response carries a Set-Cookie for the session. */
+function expectSessionCookieSet(headers: Record<string, string>): void {
+  const setCookie = headers["set-cookie"] || "";
+  expect(setCookie).toContain(`${SESSION_COOKIE_NAME}=`);
+}
+
+test.describe("Authentication", () => {
+  test.beforeAll(async ({ request }) => {
+    // If somebody runs this file against an auth-disabled container by
+    // accident, skip with a clear message instead of failing every test.
+    const status = await fetchAuthStatus(request);
+    test.skip(
+      !status.enabled,
+      "Container has FIESTABOARD_AUTH_ENABLED=false; auth specs require it on.",
+    );
+  });
+
+  test.describe.serial("setup, login, and logout flow", () => {
+    test("status reports setup_required before any user exists", async ({ request }) => {
+      const status = await fetchAuthStatus(request);
+      expect(status.enabled).toBe(true);
+      expect(status.setup_required).toBe(true);
+      expect(status.authenticated).toBe(false);
+      // Env override pins mode to "enabled", so first_run is false even
+      // though no user has been provisioned yet.
+      expect(status.mode).toBe("enabled");
+      expect(status.first_run).toBe(false);
+    });
+
+    test("protected API endpoint returns 409 setup_required when no user exists", async ({
+      request,
+    }) => {
+      const res = await request.get(`${API_URL}/settings`);
+      expect(res.status()).toBe(409);
+      const body = await res.json();
+      expect(body.setup_required).toBe(true);
+    });
+
+    test("/login renders the create-administrator form on first run", async ({ page }) => {
+      await page.goto("/login");
+      await expect(page.getByRole("heading", { name: "Create administrator" })).toBeVisible();
+      // The setup form has a confirm-password field; the regular sign-in form
+      // does not. This is the cheapest tell that we're in setup mode.
+      await expect(page.getByLabel("Confirm password")).toBeVisible();
+    });
+
+    test("setup form rejects mismatched passwords client-side", async ({ page }) => {
+      await page.goto("/login");
+      await page.getByLabel("Username").fill(ADMIN_USERNAME);
+      await page.getByLabel("Password", { exact: true }).fill(ADMIN_PASSWORD);
+      await page.getByLabel("Confirm password").fill("something-else-entirely");
+      await page.getByRole("button", { name: "Create account" }).click();
+      await expect(page.getByText("Passwords do not match.")).toBeVisible();
+      // We should still be on /login — no admin should have been created.
+      await expect(page).toHaveURL(/\/login/);
+    });
+
+    test("setup form creates admin and redirects to dashboard", async ({ page }) => {
+      await page.goto("/login");
+      await page.getByLabel("Username").fill(ADMIN_USERNAME);
+      await page.getByLabel("Password", { exact: true }).fill(ADMIN_PASSWORD);
+      await page.getByLabel("Confirm password").fill(ADMIN_PASSWORD);
+      await page.getByRole("button", { name: "Create account" }).click();
+
+      // Setup endpoint logs the new admin in and the page replaces to "/".
+      await page.waitForURL((url) => !url.pathname.startsWith("/login"), { timeout: 10_000 });
+
+      // Session cookie must be present on the page context.
+      const cookies = await page.context().cookies();
+      const session = cookies.find((c) => c.name === SESSION_COOKIE_NAME);
+      expect(session).toBeTruthy();
+      expect(session?.httpOnly).toBe(true);
+
+      // /auth/status should now confirm authentication.
+      const after = await fetchAuthStatus(page.request);
+      expect(after.authenticated).toBe(true);
+      expect(after.setup_required).toBe(false);
+      expect(after.username).toBe(ADMIN_USERNAME);
+    });
+
+    test("a protected endpoint succeeds with an authenticated session", async ({ playwright }) => {
+      // Each test gets a fresh request context, so re-authenticate by hand.
+      const ctx = await playwright.request.newContext({ baseURL: BASE_URL });
+      try {
+        const login = await ctx.post(`${API_URL}/auth/login`, {
+          data: { username: ADMIN_USERNAME, password: ADMIN_PASSWORD, remember_me: true },
+        });
+        expect(login.ok()).toBe(true);
+        const res = await ctx.get(`${API_URL}/settings`);
+        expect(res.ok()).toBe(true);
+      } finally {
+        await ctx.dispose();
+      }
+    });
+
+    test("logout clears the session cookie and protects the API again", async ({
+      playwright,
+    }) => {
+      const ctx = await playwright.request.newContext({ baseURL: BASE_URL });
+      try {
+        const login = await ctx.post(`${API_URL}/auth/login`, {
+          data: { username: ADMIN_USERNAME, password: ADMIN_PASSWORD },
+        });
+        expect(login.ok()).toBe(true);
+
+        const out = await ctx.post(`${API_URL}/auth/logout`);
+        expect(out.ok()).toBe(true);
+        // Logout should expire the session cookie.
+        expect(out.headers()["set-cookie"] || "").toContain(SESSION_COOKIE_NAME);
+
+        // A protected endpoint must now 401 (user exists, no valid cookie).
+        const protectedRes = await ctx.get(`${API_URL}/settings`);
+        expect(protectedRes.status()).toBe(401);
+      } finally {
+        await ctx.dispose();
+      }
+    });
+  });
+
+  test.describe("post-setup sign-in", () => {
+    // Each test in this block runs in a fresh browser context, so previous
+    // sessions don't bleed in. We sign in / out as needed.
+
+    test("/auth/login rejects wrong password with 401", async ({ request }) => {
+      const res = await request.post(`${API_URL}/auth/login`, {
+        data: { username: ADMIN_USERNAME, password: WRONG_PASSWORD },
+      });
+      expect(res.status()).toBe(401);
+      const body = await res.json();
+      expect(body.detail).toMatch(/invalid/i);
+    });
+
+    test("/auth/login accepts valid credentials and sets session cookie", async ({ request }) => {
+      const res = await request.post(`${API_URL}/auth/login`, {
+        data: {
+          username: ADMIN_USERNAME,
+          password: ADMIN_PASSWORD,
+          remember_me: true,
+        },
+      });
+      expect(res.ok()).toBe(true);
+      expectSessionCookieSet(res.headers());
+      // The "remember_me=true" branch attaches a Max-Age so the cookie
+      // survives a browser restart.
+      expect(res.headers()["set-cookie"]).toMatch(/max-age=\d+/i);
+    });
+
+    test("/auth/login without remember_me yields a session-only cookie", async ({ request }) => {
+      const res = await request.post(`${API_URL}/auth/login`, {
+        data: {
+          username: ADMIN_USERNAME,
+          password: ADMIN_PASSWORD,
+          remember_me: false,
+        },
+      });
+      expect(res.ok()).toBe(true);
+      // No Max-Age / Expires == browser drops the cookie on close.
+      const setCookie = res.headers()["set-cookie"] || "";
+      expect(setCookie).not.toMatch(/max-age=/i);
+      expect(setCookie).not.toMatch(/expires=/i);
+    });
+
+    test("login form: invalid creds show an inline error and stay on /login", async ({ page }) => {
+      await page.goto("/login");
+      await expect(page.getByRole("heading", { name: "Sign in to FiestaBoard" })).toBeVisible();
+
+      await page.getByLabel("Username").fill(ADMIN_USERNAME);
+      await page.getByLabel("Password", { exact: true }).fill(WRONG_PASSWORD);
+      await page.getByRole("button", { name: "Sign in" }).click();
+
+      await expect(page.getByText(/invalid username or password/i)).toBeVisible();
+      await expect(page).toHaveURL(/\/login/);
+    });
+
+    test("login form: valid creds redirect to dashboard", async ({ page }) => {
+      await page.goto("/login");
+      await page.getByLabel("Username").fill(ADMIN_USERNAME);
+      await page.getByLabel("Password", { exact: true }).fill(ADMIN_PASSWORD);
+      await page.getByRole("button", { name: "Sign in" }).click();
+
+      await page.waitForURL((url) => !url.pathname.startsWith("/login"), { timeout: 10_000 });
+      const status = await fetchAuthStatus(page.request);
+      expect(status.authenticated).toBe(true);
+    });
+
+    test("authenticated session persists across reload", async ({ page }) => {
+      await signIn(page);
+      // Land on settings (something other than /), reload, expect to still be there.
+      await page.goto("/settings");
+      await page.reload();
+      await expect(page).toHaveURL(/\/settings/);
+      const status = await fetchAuthStatus(page.request);
+      expect(status.authenticated).toBe(true);
+    });
+
+    test("redirect=... preserves intent through the sign-in form", async ({ page }) => {
+      await page.goto("/login?redirect=%2Fsettings");
+      await page.getByLabel("Username").fill(ADMIN_USERNAME);
+      await page.getByLabel("Password", { exact: true }).fill(ADMIN_PASSWORD);
+      await page.getByRole("button", { name: "Sign in" }).click();
+      await page.waitForURL(/\/settings/, { timeout: 10_000 });
+    });
+
+    test("/profile redirects to /settings while authenticated", async ({ page }) => {
+      await signIn(page);
+      await page.goto("/profile");
+      // Profile is a thin redirect to /settings?section=general.
+      await page.waitForURL(/\/settings/, { timeout: 5_000 });
+    });
+
+    test("validation: /auth/login with empty username is rejected (422)", async ({ request }) => {
+      const res = await request.post(`${API_URL}/auth/login`, {
+        data: { username: "", password: ADMIN_PASSWORD },
+      });
+      expect(res.status()).toBe(422);
+    });
+
+    test("validation: /auth/setup with short password is rejected (422)", async ({ request }) => {
+      const res = await request.post(`${API_URL}/auth/setup`, {
+        data: { username: "newadmin", password: "short" },
+      });
+      // Either 422 (pydantic min_length=8) or 409 (user already exists) is acceptable —
+      // both prove the endpoint enforces a rule. We assert it's NOT a 2xx.
+      expect(res.ok()).toBe(false);
+      expect([409, 422]).toContain(res.status());
+    });
+
+    test("/auth/setup is rejected once an admin exists (409)", async ({ request }) => {
+      const res = await request.post(`${API_URL}/auth/setup`, {
+        data: { username: "second-admin", password: "another-password" },
+      });
+      expect(res.status()).toBe(409);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+async function signIn(page: Page): Promise<void> {
+  const res = await page.request.post(`${API_URL}/auth/login`, {
+    data: {
+      username: ADMIN_USERNAME,
+      password: ADMIN_PASSWORD,
+      remember_me: true,
+    },
+  });
+  if (!res.ok()) {
+    throw new Error(`signIn failed: ${res.status()} ${await res.text()}`);
+  }
+}


### PR DESCRIPTION
## Summary

- The main e2e job runs every container with `FIESTABOARD_AUTH_ENABLED=false`, leaving the `/auth/*` router, the `/login` UI, the `/profile` redirect, and authenticated request gating **completely uncovered by e2e tests** despite being a security boundary.
- This PR adds a dedicated `auth.spec.ts` plus a new `auth-e2e-tests` CI job that boots a single container with auth enabled and runs only that spec. The main e2e job is unchanged.
- Pattern mirrors the existing `RUN_VISUAL_REGRESSION` opt-in so the spec is skipped by default and the gating is local to `playwright.config.ts`.

## What's covered

- `GET /auth/status` shape pre- and post-setup.
- Protected API returns 409 `setup_required` before any admin exists.
- `/login` renders the **Create administrator** form on first run; mismatched-password client-side validation.
- Setup form provisions the admin via `/auth/setup`, sets the session cookie (HttpOnly), and redirects to the dashboard.
- Logout via `/auth/logout` expires the cookie and protected endpoints flip back to 401.
- Sign-in form: invalid creds show an inline error and stay on `/login`; valid creds redirect to the dashboard.
- `remember_me=true` issues a long-lived cookie (Max-Age present); `remember_me=false` issues a session cookie (no Max-Age/Expires).
- `?redirect=/settings` query param preserved through login.
- `/profile` redirects to `/settings?section=general` while authenticated.
- Pydantic validation: empty username → 422; short password on setup → 409/422.
- `/auth/setup` is rejected with 409 once an admin exists.

## How the CI job runs it

- Builds the same image as the main e2e job, reusing the build cache.
- Starts **one** FiestaBoard container with `FIESTABOARD_AUTH_ENABLED=true`, picks up the container IP, sets `BASE_URL=http://<ip>:3000`.
- Sanity-checks `/auth/status` reports `mode=enabled` before running the spec (so a misconfigured container can't silently make all tests skip).
- Runs `npx playwright test auth.spec.ts --workers=1` with `RUN_AUTH_TESTS=1`.
- Uploads container logs on failure for debugging.
- Added to the `ci-success` `needs:` aggregator so it gates the merge.

## What I deliberately did NOT do

- Did not change the existing `e2e-tests` job. Its 4-worker fan-out with auth disabled stays exactly as it was.
- Did not add per-test auth toggling — the env var is read at container startup, so a separate container is the right boundary.
- Did not extend `helpers.ts`; the spec talks to the API directly so it doesn't pull in the multi-board mock fixtures it doesn't need.

## Test plan

- [ ] `auth-e2e-tests` job is green on this PR
- [ ] Main `e2e-tests` job still green (sanity: I haven't perturbed it)
- [ ] Visually scan job logs to confirm the auth container actually booted with `mode=enabled`

🤖 Generated with [Claude Code](https://claude.com/claude-code)