### PR TITLE
perf(ci): cache Docusaurus webpack build in PR Build Docs job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -554,6 +554,16 @@ jobs:
       working-directory: docs-site
       run: npm ci
 
+    - name: Cache Docusaurus build
+      uses: actions/cache@v4
+      with:
+        path: |
+          docs-site/.docusaurus
+          docs-site/node_modules/.cache
+        key: docusaurus-${{ runner.os }}-${{ hashFiles('docs-site/src/**', 'docs-site/docs/**', 'docs-site/docusaurus.config.ts', 'docs-site/package-lock.json') }}
+        restore-keys: |
+          docusaurus-${{ runner.os }}-
+
     - name: Build Docusaurus site
       working-directory: docs-site
       run: npm run build


### PR DESCRIPTION
## Summary

- The PR-facing **Build Docs** job in `ci.yml` was taking ~8.5 min on every PR (observed 509–522s for the "Build Docusaurus site" step in recent runs).
- PR #831 (plugin stats dashboard) added a webpack incremental cache to `docs.yml` (Deploy Docs) that drops the build to ~1 min on cache hits, but the same step was never added to `ci.yml`.
- This PR mirrors that exact cache config into the `build-docs` job in `ci.yml`.

## Why this is the fix

The "new stats" feature itself doesn't run during build:
- `plugin-stats.json` is generated by a separate nightly cron (`plugin-stats.yml`).
- `stats.tsx` fetches it at runtime in the browser (`useEffect`), not at build time.

The slowness is just cold Docusaurus/webpack builds — which the same author already solved for `docs.yml` and we just need to apply to `ci.yml`.

## Expected impact

| Run | Before | After (cache hit) |
|---|---|---|
| PR Build Docs | ~8.5 min | ~1–2 min |

Cache key matches `docs.yml` (src/docs/config/lockfile hash), with `restore-keys` fallback so even partial hits give incremental benefit.

## Test plan

- [ ] First run on this PR will populate cache (still ~8 min).
- [ ] Subsequent push to this branch should hit the cache and complete in ~1–2 min.
- [ ] Other PRs that don't touch docs-site won't run this job at all (existing `detect-changes` filter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)