### PR TITLE
feat(mcp): embed HTML board preview in page tool responses

### DIFF
--- a/src/board_html_renderer.py
+++ b/src/board_html_renderer.py
@@ -1,0 +1,346 @@
+"""HTML renderer for FiestaBoard previews.
+
+Produces a self-contained ``<!DOCTYPE html>`` document that visually mimics
+a Vestaboard / FiestaBoard physical display. Used by the MCP server to
+include an MCP-UI ``EmbeddedResource`` alongside page tool responses, so
+MCP-UI-aware clients (Claude Desktop, etc.) can render a board preview
+inline next to the JSON result.
+
+The renderer is intentionally simple: it parses the rendered template
+text (post template-engine output) into character + colour tokens, then
+emits one ``<div class="tile">`` per cell. A small CSS keyframe plays a
+one-shot flap-in animation on first paint so the preview feels alive
+without requiring any interactivity.
+
+The HTML is fully static — no external assets, no API calls. It is safe
+to embed in a sandboxed iframe.
+"""
+
+from __future__ import annotations
+
+import html
+from typing import Dict, List, Optional, Tuple
+
+# ---------------------------------------------------------------------------
+# Constants — mirrored from web/src/lib/board-colors.ts and
+# web/src/components/board-display.tsx so the preview matches the web UI.
+# ---------------------------------------------------------------------------
+
+DEVICE_DIMS: Dict[str, Tuple[int, int]] = {
+    # device_type -> (rows, cols)
+    "flagship": (6, 22),
+    "note": (3, 15),
+}
+
+# 8-colour board palette (codes 63-71). 71 ("filled") renders as black, same
+# as the web UI.
+COLOR_CODE_MAP: Dict[str, str] = {
+    "63": "#eb4034",  # red
+    "64": "#f5a623",  # orange
+    "65": "#f8e71c",  # yellow
+    "66": "#7ed321",  # green
+    "67": "#4a90d9",  # blue
+    "68": "#9b59b6",  # violet
+    "69": "#ffffff",  # white
+    "70": "#1a1a1a",  # black
+    "71": "#1a1a1a",  # filled
+}
+
+NAMED_COLORS: Dict[str, str] = {
+    "red": COLOR_CODE_MAP["63"],
+    "orange": COLOR_CODE_MAP["64"],
+    "yellow": COLOR_CODE_MAP["65"],
+    "green": COLOR_CODE_MAP["66"],
+    "blue": COLOR_CODE_MAP["67"],
+    "violet": COLOR_CODE_MAP["68"],
+    "purple": COLOR_CODE_MAP["68"],
+    "white": COLOR_CODE_MAP["69"],
+    "black": COLOR_CODE_MAP["70"],
+}
+
+ALL_COLOR_CODES: Dict[str, str] = {**COLOR_CODE_MAP, **NAMED_COLORS}
+
+
+# ---------------------------------------------------------------------------
+# Token parsing — mirrors parseLine() in board-display.tsx
+# ---------------------------------------------------------------------------
+
+class _CharToken:
+    __slots__ = ("value",)
+
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+
+class _ColorToken:
+    __slots__ = ("hex",)
+
+    def __init__(self, hex_value: str) -> None:
+        self.hex = hex_value
+
+
+def _parse_line(line: str) -> List[object]:
+    """Parse a rendered line into a flat list of character/colour tokens.
+
+    Matches the web UI's ``parseLine`` semantics: ``{63}`` / ``{red}`` style
+    single-bracket tokens become colour tiles, ``{/...}`` end tags are
+    dropped, anything else becomes an uppercase character tile.
+    """
+    tokens: List[object] = []
+    i = 0
+    n = len(line)
+    while i < n:
+        if line[i] == "{":
+            close = line.find("}", i)
+            if close != -1:
+                content = line[i + 1 : close]
+                if content.startswith("/"):
+                    i = close + 1
+                    continue
+                hex_value = ALL_COLOR_CODES.get(content) or ALL_COLOR_CODES.get(content.lower())
+                if hex_value is not None:
+                    tokens.append(_ColorToken(hex_value))
+                    i = close + 1
+                    continue
+        tokens.append(_CharToken(line[i].upper()))
+        i += 1
+    return tokens
+
+
+def _grid(formatted: str, rows: int, cols: int, device_type: str) -> List[List[object]]:
+    """Convert a rendered string into a fixed (rows x cols) token grid.
+
+    Lines shorter than ``cols`` are right-padded with blank character
+    tokens; extra lines beyond ``rows`` are ignored. Matches
+    ``messageToGrid`` in the web UI, including the Note-device degree
+    sign -> heart substitution.
+    """
+    is_note = device_type == "note"
+    lines = formatted.split("\n") if formatted else []
+    grid: List[List[object]] = []
+    for r in range(rows):
+        line = lines[r] if r < len(lines) else ""
+        parsed = _parse_line(line)
+        row: List[object] = []
+        for c in range(cols):
+            if c < len(parsed):
+                tok = parsed[c]
+                if is_note and isinstance(tok, _CharToken) and tok.value == "°":
+                    row.append(_CharToken("♥"))
+                else:
+                    row.append(tok)
+            else:
+                row.append(_CharToken(" "))
+        grid.append(row)
+    return grid
+
+
+# ---------------------------------------------------------------------------
+# HTML emission
+# ---------------------------------------------------------------------------
+
+_STYLE = """
+:root {
+  color-scheme: dark;
+  --board-bg: #0c0c0c;
+  --board-frame: #1a1a1a;
+  --tile-bg: #1a1a1a;
+  --tile-text: #f5f0e6;
+  --tile-split: rgba(0, 0, 0, 0.35);
+}
+* { box-sizing: border-box; }
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--board-bg);
+  color: var(--tile-text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  min-height: 100vh;
+}
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  padding: 20px;
+}
+.label {
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.55;
+}
+.label strong { opacity: 0.9; font-weight: 600; }
+.board {
+  background: var(--board-frame);
+  padding: 14px;
+  border-radius: 12px;
+  box-shadow:
+    0 0 0 2px rgba(255, 255, 255, 0.04),
+    0 12px 40px rgba(0, 0, 0, 0.55);
+}
+.row { display: flex; gap: 3px; justify-content: center; }
+.row + .row { margin-top: 3px; }
+.tile {
+  width: 24px;
+  height: 34px;
+  border-radius: 3px;
+  background: var(--tile-bg);
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: flap-in 360ms cubic-bezier(0.2, 0.7, 0.2, 1) both;
+  animation-delay: calc((var(--r, 0) * 18ms) + (var(--c, 0) * 9ms));
+}
+.tile.note { width: 32px; height: 44px; }
+.tile .char {
+  font-family: "SF Mono", "Menlo", "Consolas", monospace;
+  font-weight: 600;
+  font-size: 16px;
+  line-height: 1;
+  color: var(--tile-text);
+  user-select: none;
+}
+.tile.note .char { font-size: 22px; }
+.tile .char.heart { color: #eb4034; }
+.tile .swatch {
+  position: absolute;
+  inset: 5px 2px 6px;
+  border-radius: 2px;
+}
+.tile::after {
+  content: "";
+  position: absolute;
+  left: 0; right: 0;
+  top: 50%;
+  height: 1px;
+  background: var(--tile-split);
+  pointer-events: none;
+}
+@keyframes flap-in {
+  0%   { transform: rotateX(-90deg); opacity: 0; }
+  60%  { transform: rotateX(20deg);  opacity: 1; }
+  100% { transform: rotateX(0deg);   opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .tile { animation: none; }
+}
+"""
+
+
+def _tile_html(token: object, row: int, col: int, is_note: bool) -> str:
+    """Emit the HTML for a single tile."""
+    note_cls = " note" if is_note else ""
+    style = f'style="--r:{row};--c:{col};"'
+    if isinstance(token, _ColorToken):
+        return (
+            f'<div class="tile{note_cls}" {style}>'
+            f'<div class="swatch" style="background:{token.hex};"></div>'
+            f"</div>"
+        )
+    # Character token
+    ch = token.value if isinstance(token, _CharToken) else " "
+    if ch == " ":
+        return f'<div class="tile{note_cls}" {style}></div>'
+    is_heart = ch == "♥"
+    char_cls = " heart" if is_heart else ""
+    return (
+        f'<div class="tile{note_cls}" {style}>'
+        f'<span class="char{char_cls}">{html.escape(ch)}</span>'
+        f"</div>"
+    )
+
+
+def render_board_html(
+    formatted: str,
+    *,
+    device_type: str = "flagship",
+    page_name: Optional[str] = None,
+) -> str:
+    """Render a board preview as a self-contained HTML document.
+
+    Args:
+        formatted: The rendered template text (output of TemplateEngine.render
+            or PageService.preview_page().formatted). May include ``{63}`` /
+            ``{red}`` colour tokens and ``\\n``-separated lines.
+        device_type: ``"flagship"`` (22x6) or ``"note"`` (15x3).
+        page_name: Optional label rendered above the board.
+
+    Returns:
+        A standalone HTML document string (``<!DOCTYPE html>...``).
+    """
+    rows, cols = DEVICE_DIMS.get(device_type, DEVICE_DIMS["flagship"])
+    is_note = device_type == "note"
+    grid = _grid(formatted or "", rows, cols, device_type)
+
+    row_html_parts: List[str] = []
+    for r, row in enumerate(grid):
+        tiles = "".join(_tile_html(tok, r, c, is_note) for c, tok in enumerate(row))
+        row_html_parts.append(f'<div class="row">{tiles}</div>')
+    board_html = "".join(row_html_parts)
+
+    label_html = ""
+    if page_name:
+        safe_name = html.escape(page_name)
+        label_html = (
+            f'<div class="label"><strong>{safe_name}</strong> '
+            f"&middot; {device_type} {cols}&times;{rows}</div>"
+        )
+
+    title = html.escape(page_name or "FiestaBoard Preview")
+    return (
+        "<!DOCTYPE html>"
+        '<html lang="en"><head>'
+        '<meta charset="utf-8">'
+        '<meta name="viewport" content="width=device-width,initial-scale=1">'
+        f"<title>{title}</title>"
+        f"<style>{_STYLE}</style>"
+        "</head><body>"
+        '<div class="wrapper">'
+        f"{label_html}"
+        f'<div class="board" role="img" aria-label="{title}">{board_html}</div>'
+        "</div>"
+        "</body></html>"
+    )
+
+
+def render_page_preview_html(page: object) -> str:
+    """Render an HTML preview for a Page model.
+
+    Uses ``PageService.preview_page`` (which is cached) when available so
+    template variables resolve against live plugin data. Falls back to
+    rendering the raw template lines verbatim if the preview service is
+    unavailable or the page has no template (e.g. composite pages — they
+    are previewed as their stored content).
+
+    Args:
+        page: A ``src.pages.models.Page`` instance.
+
+    Returns:
+        A standalone HTML document string.
+    """
+    device_type = getattr(page, "device_type", "flagship") or "flagship"
+    page_id = getattr(page, "id", None)
+    page_name = getattr(page, "name", None)
+
+    formatted: str = ""
+    if page_id:
+        try:
+            from .pages.service import get_page_service
+
+            svc = get_page_service()
+            result = svc.preview_page(page_id)
+            if result is not None and getattr(result, "formatted", None):
+                formatted = result.formatted
+        except Exception:
+            # Fall through to template fallback below.
+            formatted = ""
+
+    if not formatted:
+        template = getattr(page, "template", None)
+        if template:
+            formatted = "\n".join(template)
+
+    return render_board_html(formatted, device_type=device_type, page_name=page_name)

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -38,14 +38,55 @@ logger = logging.getLogger(__name__)
 
 try:
     from mcp.server.fastmcp import FastMCP  # type: ignore[import-untyped]
+    from mcp.types import (  # type: ignore[import-untyped]
+        EmbeddedResource,
+        TextContent,
+        TextResourceContents,
+    )
     _MCP_AVAILABLE = True
 except ImportError:  # pragma: no cover
     _MCP_AVAILABLE = False
     FastMCP = None  # type: ignore[assignment,misc]
+    TextContent = None  # type: ignore[assignment,misc]
+    EmbeddedResource = None  # type: ignore[assignment,misc]
+    TextResourceContents = None  # type: ignore[assignment,misc]
     logger.warning(
         "mcp package not installed — FiestaBoard MCP server is disabled. "
         "Add `mcp>=1.8.0` to requirements.txt and rebuild the container."
     )
+
+
+def _page_response_with_preview(json_text: str, page: Any) -> List[Any]:
+    """Wrap a page tool's JSON result with an MCP-UI HTML preview block.
+
+    Returns a list of MCP content blocks:
+      1. ``TextContent`` carrying the JSON the tool already returns.
+      2. ``EmbeddedResource`` with ``text/html`` mime under a ``ui://``
+         URI — MCP-UI-aware clients render this inline as a board preview.
+
+    If HTML rendering fails for any reason, falls back to returning just
+    the text block so the tool's primary response is never blocked by
+    preview errors.
+    """
+    blocks: List[Any] = [TextContent(type="text", text=json_text)]
+    try:
+        from .board_html_renderer import render_page_preview_html
+
+        page_id = getattr(page, "id", None) or "unknown"
+        html_text = render_page_preview_html(page)
+        blocks.append(
+            EmbeddedResource(
+                type="resource",
+                resource=TextResourceContents(
+                    uri=f"ui://fiestaboard/page/{page_id}",
+                    mimeType="text/html",
+                    text=html_text,
+                ),
+            )
+        )
+    except Exception as exc:  # pragma: no cover — preview is best-effort
+        logger.warning("Failed to render board HTML preview: %s", exc)
+    return blocks
 
 
 def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
@@ -300,13 +341,15 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
             return json.dumps({"error": str(exc)})
 
     @mcp.tool()
-    def get_page(page_id: str) -> str:
+    def get_page(page_id: str) -> Any:
         """Get full details of a specific page including its template content.
 
         Args:
             page_id: The page identifier (from list_pages()).
 
-        Returns a JSON object with all page fields including the template array.
+        Returns the page JSON plus an MCP-UI ``text/html`` board preview
+        embedded resource (``ui://fiestaboard/page/{id}``). MCP-UI-aware
+        clients render the preview inline; others see the JSON only.
         Each template line can contain {{plugin.variable}} references and
         {{color}} tokens like {{red}}, {{green}}, {{white}} etc.
         """
@@ -316,7 +359,8 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
             page = svc.get_page(page_id)
             if page is None:
                 return json.dumps({"error": f"Page '{page_id}' not found."})
-            return json.dumps(page.model_dump(), default=str)
+            json_text = json.dumps(page.model_dump(), default=str)
+            return _page_response_with_preview(json_text, page)
         except Exception as exc:
             return json.dumps({"error": str(exc)})
 
@@ -359,12 +403,13 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
                 duration_seconds=duration_seconds,
             )
             page = svc.create_page(data)
-            return json.dumps({
+            json_text = json.dumps({
                 "status": "success",
                 "page_id": page.id,
                 "name": page.name,
                 "message": f"Page '{name}' created with id '{page.id}'.",
             }, default=str)
+            return _page_response_with_preview(json_text, page)
         except Exception as exc:
             return f"Error creating page: {exc}"
 
@@ -395,7 +440,8 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
             page = svc.update_page(page_id, data)
             if page is None:
                 return json.dumps({"error": f"Page '{page_id}' not found."})
-            return json.dumps({"status": "success", "page_id": page.id, "name": page.name}, default=str)
+            json_text = json.dumps({"status": "success", "page_id": page.id, "name": page.name}, default=str)
+            return _page_response_with_preview(json_text, page)
         except Exception as exc:
             return f"Error updating page '{page_id}': {exc}"
 
@@ -764,6 +810,27 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
             return "\n".join(lines)
         except Exception as exc:
             return f"Error: {exc}"
+
+    @mcp.resource("fiestaboard://page/{page_id}/preview.html", mime_type="text/html")
+    def get_page_preview_html(page_id: str) -> str:
+        """Self-contained HTML preview of a page rendered as a board.
+
+        Useful for MCP-UI clients that want to fetch a board preview by
+        page id without going through the page tools.
+        """
+        try:
+            from .pages.service import get_page_service
+            from .board_html_renderer import render_page_preview_html
+            svc = get_page_service()
+            page = svc.get_page(page_id)
+            if page is None:
+                return (
+                    "<!DOCTYPE html><html><body><p>Page "
+                    f"<code>{page_id}</code> not found.</p></body></html>"
+                )
+            return render_page_preview_html(page)
+        except Exception as exc:
+            return f"<!DOCTYPE html><html><body><p>Error: {exc}</p></body></html>"
 
     @mcp.resource("fiestaboard://variables")
     def get_variables_resource() -> str:

--- a/tests/test_board_html_renderer.py
+++ b/tests/test_board_html_renderer.py
@@ -1,0 +1,201 @@
+"""Tests for src/board_html_renderer.py.
+
+The renderer is pure — it has no service dependencies for the
+``render_board_html`` path — so these tests poke at the string output
+directly. The ``render_page_preview_html`` path mocks ``get_page_service``
+to verify it falls back gracefully when the preview cache is unavailable.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.board_html_renderer import (
+    DEVICE_DIMS,
+    render_board_html,
+    render_page_preview_html,
+)
+
+
+def _count(html: str, needle: str) -> int:
+    return html.count(needle)
+
+
+class TestDimensions:
+    def test_flagship_renders_6_rows(self):
+        html = render_board_html("HELLO", device_type="flagship")
+        assert _count(html, 'class="row"') == 6
+
+    def test_flagship_renders_22_cols_per_row(self):
+        html = render_board_html("HELLO", device_type="flagship")
+        rows, cols = DEVICE_DIMS["flagship"]
+        # 6 rows * 22 cols = 132 tiles
+        assert _count(html, 'class="tile"') + _count(html, 'class="tile note"') == rows * cols
+
+    def test_note_renders_3_rows(self):
+        html = render_board_html("HI", device_type="note")
+        assert _count(html, 'class="row"') == 3
+
+    def test_note_renders_15_cols_per_row(self):
+        html = render_board_html("HI", device_type="note")
+        rows, cols = DEVICE_DIMS["note"]
+        # Note tiles carry the .note class.
+        assert _count(html, 'class="tile note"') == rows * cols
+
+    def test_unknown_device_falls_back_to_flagship(self):
+        html = render_board_html("HI", device_type="zigzag")
+        assert _count(html, 'class="row"') == 6
+
+
+class TestCharacterRendering:
+    def test_uppercases_letters(self):
+        html = render_board_html("hi", device_type="flagship")
+        # Letters are emitted inside <span class="char">…</span>
+        assert ">H</span>" in html
+        assert ">I</span>" in html
+
+    def test_blank_lines_render_empty_tiles(self):
+        html = render_board_html("", device_type="flagship")
+        # No characters — every tile must be empty (no <span class="char">)
+        assert 'class="char"' not in html
+        # But the grid must still be 132 tiles.
+        assert _count(html, 'class="tile"') == 6 * 22
+
+    def test_note_substitutes_degree_with_heart(self):
+        html = render_board_html("72°", device_type="note")
+        # Heart glyph appears with the heart styling class.
+        assert "heart" in html
+        # The literal degree sign should not be rendered for a Note.
+        # (It may appear inside CSS comments only — we check span content.)
+        assert ">°</span>" not in html
+
+    def test_flagship_keeps_degree_sign(self):
+        html = render_board_html("72°", device_type="flagship")
+        assert ">°</span>" in html
+
+
+class TestColorTokens:
+    def test_numeric_color_code_renders_swatch(self):
+        html = render_board_html("{63}A", device_type="flagship")
+        # Red hex appears as background of a swatch div.
+        assert "background:#eb4034" in html
+
+    def test_named_color_renders_swatch(self):
+        html = render_board_html("{blue}A", device_type="flagship")
+        assert "background:#4a90d9" in html
+
+    def test_uppercase_named_color_works(self):
+        html = render_board_html("{RED}A", device_type="flagship")
+        assert "background:#eb4034" in html
+
+    def test_end_tags_are_dropped(self):
+        html = render_board_html("{red}A{/red}B", device_type="flagship")
+        # Both letters present; no stray "/red" leakage.
+        assert ">A</span>" in html
+        assert ">B</span>" in html
+        assert "/red" not in html
+
+    def test_unknown_brace_token_falls_through_as_chars(self):
+        html = render_board_html("{xy}", device_type="flagship")
+        # Renders as literal characters '{','X','Y','}' since it's not a colour.
+        assert ">{</span>" in html
+        assert ">X</span>" in html
+        assert ">Y</span>" in html
+        assert ">}</span>" in html
+
+
+class TestHtmlEscaping:
+    def test_page_name_is_escaped(self):
+        html = render_board_html(
+            "HI", device_type="flagship", page_name="<script>x</script>"
+        )
+        assert "<script>x</script>" not in html
+        assert "&lt;script&gt;" in html
+
+    def test_character_special_chars_escaped(self):
+        # '&' is character code 47 on the board, parses as a char token.
+        html = render_board_html("&", device_type="flagship")
+        assert ">&amp;</span>" in html
+        # Make sure we never emit a bare ampersand-letter inside a span body.
+        assert ">&<" not in html
+
+
+class TestDocumentShell:
+    def test_doctype_present(self):
+        html = render_board_html("HI", device_type="flagship")
+        assert html.startswith("<!DOCTYPE html>")
+        assert "</html>" in html
+
+    def test_includes_inline_style(self):
+        html = render_board_html("HI", device_type="flagship")
+        assert "<style>" in html
+        assert "flap-in" in html
+
+    def test_page_name_appears_in_label(self):
+        html = render_board_html(
+            "HI", device_type="flagship", page_name="Weather Today"
+        )
+        assert "Weather Today" in html
+
+
+class TestRenderPagePreviewHtml:
+    def _fake_page(self, **overrides):
+        return SimpleNamespace(
+            id=overrides.get("id", "page-1"),
+            name=overrides.get("name", "My Page"),
+            device_type=overrides.get("device_type", "flagship"),
+            template=overrides.get("template", ["HELLO", "WORLD"]),
+        )
+
+    def test_uses_preview_service_formatted_text(self):
+        page = self._fake_page(template=["IGNORED"])
+        svc = MagicMock()
+        svc.preview_page.return_value = SimpleNamespace(formatted="LIVE\nDATA")
+        with patch("src.pages.service.get_page_service", return_value=svc):
+            html = render_page_preview_html(page)
+        assert ">L</span>" in html
+        assert ">I</span>" in html
+        assert ">V</span>" in html
+        assert ">E</span>" in html
+        # template content was not used
+        assert html.count(">I</span>") >= 1
+
+    def test_falls_back_to_template_when_preview_unavailable(self):
+        page = self._fake_page(template=["FALLBACK"])
+        svc = MagicMock()
+        svc.preview_page.return_value = None
+        with patch("src.pages.service.get_page_service", return_value=svc):
+            html = render_page_preview_html(page)
+        for ch in "FALLBACK":
+            assert f">{ch}</span>" in html
+
+    def test_falls_back_when_preview_raises(self):
+        page = self._fake_page(template=["BOOM"])
+        svc = MagicMock()
+        svc.preview_page.side_effect = RuntimeError("kaboom")
+        with patch("src.pages.service.get_page_service", return_value=svc):
+            html = render_page_preview_html(page)
+        for ch in "BOOM":
+            assert f">{ch}</span>" in html
+
+    def test_page_without_template_renders_blank_board(self):
+        page = self._fake_page(template=None)
+        svc = MagicMock()
+        svc.preview_page.return_value = None
+        with patch("src.pages.service.get_page_service", return_value=svc):
+            html = render_page_preview_html(page)
+        # Blank board: no character spans, still 132 tiles.
+        assert 'class="char"' not in html
+        assert html.count('class="tile"') == 6 * 22
+
+    def test_note_device_renders_note_dimensions(self):
+        page = self._fake_page(device_type="note", template=["HI"])
+        svc = MagicMock()
+        svc.preview_page.return_value = None
+        with patch("src.pages.service.get_page_service", return_value=svc):
+            html = render_page_preview_html(page)
+        assert html.count('class="row"') == 3
+        assert html.count('class="tile note"') == 3 * 15

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -42,12 +42,36 @@ def _call_tool(mcp_instance: Any, tool_name: str, **kwargs: Any) -> Any:
 
     FastMCP registers tools in ``_tool_manager``. Each tool's ``fn`` is the
     original decorated function.  We call it directly, bypassing JSON-RPC.
+
+    Page tools that emit an MCP-UI HTML preview return a list of content
+    blocks (``[TextContent, EmbeddedResource]``). For backward-compat with
+    existing assertions that ``json.loads(result)``, this helper unwraps
+    the first ``TextContent`` block to its raw ``.text`` string. Callers
+    that need the embedded HTML resource should use ``_call_tool_blocks``.
     """
+    import asyncio
     mgr = mcp_instance._tool_manager
     tool = mgr._tools.get(tool_name)
     if tool is None:
         raise KeyError(f"Tool '{tool_name}' not registered. Available: {list(mgr._tools)}")
+    result = tool.fn(**kwargs)
+    if asyncio.iscoroutine(result):
+        result = asyncio.get_event_loop().run_until_complete(result)
+    if isinstance(result, list) and result:
+        first = result[0]
+        if hasattr(first, "text"):
+            return first.text
+    return result
+
+
+def _call_tool_blocks(mcp_instance: Any, tool_name: str, **kwargs: Any) -> Any:
+    """Like ``_call_tool`` but returns the raw tool return value (list of
+    content blocks for page tools, or a string otherwise)."""
     import asyncio
+    mgr = mcp_instance._tool_manager
+    tool = mgr._tools.get(tool_name)
+    if tool is None:
+        raise KeyError(f"Tool '{tool_name}' not registered. Available: {list(mgr._tools)}")
     result = tool.fn(**kwargs)
     if asyncio.iscoroutine(result):
         result = asyncio.get_event_loop().run_until_complete(result)
@@ -509,6 +533,55 @@ class TestUpdatePage:
             result = _call_tool(mcp, "update_page", page_id="missing")
         data = json.loads(result)
         assert "error" in data
+
+
+class TestPageToolsEmbedHtmlPreview:
+    """Page tools attach a ``ui://`` text/html EmbeddedResource as the
+    second content block so MCP-UI clients can render a board preview."""
+
+    @staticmethod
+    def _assert_html_block(blocks):
+        from mcp.types import EmbeddedResource, TextContent
+        assert isinstance(blocks, list), f"expected list, got {type(blocks).__name__}"
+        assert len(blocks) >= 2, "expected text + html resource blocks"
+        assert isinstance(blocks[0], TextContent)
+        embedded = blocks[1]
+        assert isinstance(embedded, EmbeddedResource)
+        assert embedded.resource.mimeType == "text/html"
+        assert str(embedded.resource.uri).startswith("ui://fiestaboard/page/")
+        html_text = embedded.resource.text
+        assert "<!DOCTYPE html>" in html_text
+        return html_text
+
+    def test_get_page_embeds_html_preview(self, mcp, mock_page_service):
+        # preview_page returns None -> renderer falls back to template lines
+        mock_page_service.preview_page.return_value = None
+        with patch("src.pages.service.get_page_service", return_value=mock_page_service):
+            blocks = _call_tool_blocks(mcp, "get_page", page_id="page-001")
+        self._assert_html_block(blocks)
+
+    def test_create_page_embeds_html_preview(self, mcp, mock_page_service):
+        mock_page_service.preview_page.return_value = None
+        # create_page returns a result MagicMock; give it the attrs the renderer reads.
+        result = mock_page_service.create_page.return_value
+        result.device_type = "flagship"
+        result.template = ["{{red}}HELLO", "WORLD"]
+        with patch("src.pages.service.get_page_service", return_value=mock_page_service):
+            blocks = _call_tool_blocks(
+                mcp,
+                "create_page",
+                name="My Page",
+                template_lines=["Line 1", "Line 2", "Line 3", "Line 4", "Line 5", "Line 6"],
+            )
+        html_text = self._assert_html_block(blocks)
+        # Fallback path uses template lines verbatim, so the red swatch appears.
+        assert "#eb4034" in html_text
+
+    def test_update_page_embeds_html_preview(self, mcp, mock_page_service):
+        mock_page_service.preview_page.return_value = None
+        with patch("src.pages.service.get_page_service", return_value=mock_page_service):
+            blocks = _call_tool_blocks(mcp, "update_page", page_id="page-001", name="New Name")
+        self._assert_html_block(blocks)
 
 
 class TestDeletePage:


### PR DESCRIPTION
## Summary

- Adds `src/board_html_renderer.py` — a pure renderer that turns a page's rendered template text + `device_type` into a self-contained `<!DOCTYPE html>` doc visually mimicking a Vestaboard. Inline CSS, no external assets, no client fetches; safe to embed in a sandboxed iframe. Uses the same 8-colour palette as `web/src/lib/board-colors.ts` and mirrors `parseLine` / `messageToGrid` semantics from `web/src/components/board-display.tsx` (including the Note-device `°→♥` substitution).
- Wires the renderer into the MCP server so MCP-UI-aware clients (Claude Desktop, Claude Code) render a board preview inline alongside the JSON result. Affects `get_page`, `create_page`, `update_page` — each now returns `[TextContent(json), EmbeddedResource(text/html, ui://fiestaboard/page/{id})]`. Preview rendering is best-effort: any error falls back to the text block alone so previews never break the primary tool response.
- Adds a new MCP resource `fiestaboard://page/{page_id}/preview.html` (mime `text/html`) so clients can also fetch a board preview by id on demand.
- Renderer prefers `PageService.preview_page()` (cached, resolves live plugin variables) and falls back to the raw template lines if the service is unavailable or returns nothing.

## What it looks like

Each preview is a 22×6 (flagship) or 15×3 (note) grid of tiles. Characters render in monospace on the tile face; `{63}` / `{red}` style colour tokens render as coloured swatches inset in a tile. A one-shot `flap-in` CSS keyframe plays on first paint (respects `prefers-reduced-motion`).

## Test plan

- [x] `pytest tests/test_board_html_renderer.py` — 24 tests covering flagship/note dimensions, colour tokens (numeric + named + uppercase), `{/...}` end-tag stripping, blank lines, HTML escaping, `°→♥` Note substitution, document shell, and the `render_page_preview_html` fallback paths (preview returns None, preview raises, no template).
- [x] `pytest tests/test_mcp_server.py` — 83 tests pass; 3 new tests assert `get_page` / `create_page` / `update_page` attach an `EmbeddedResource` with `ui://fiestaboard/page/{id}` URI and `text/html` mime.
- [x] Full suite: `pytest tests/` — 3351 passed.
- [ ] Manual smoke in an MCP-UI-aware client: call `get_page` and confirm the board preview renders inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)