### PR TITLE
perf(ci): build only latest docs version on PRs (Build Docs 6m → ~2m)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -816,17 +816,26 @@ jobs:
       run: npm ci
 
     - name: Cache Docusaurus build
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           docs-site/.docusaurus
           docs-site/node_modules/.cache
-        key: docusaurus-${{ runner.os }}-${{ hashFiles('docs-site/src/**', 'docs-site/docs/**', 'docs-site/docusaurus.config.ts', 'docs-site/package-lock.json') }}
+        # PR-mode builds skip 40 historical version snapshots, so they
+        # have a different .docusaurus/ shape than full deploy builds.
+        # Keep their caches in separate namespaces to avoid each
+        # poisoning the other on restore.
+        key: docusaurus-pr-${{ runner.os }}-${{ hashFiles('docs-site/src/**', 'docs-site/docs/**', 'docs-site/docusaurus.config.ts', 'docs-site/package-lock.json') }}
         restore-keys: |
-          docusaurus-${{ runner.os }}-
+          docusaurus-pr-${{ runner.os }}-
 
     - name: Build Docusaurus site
       working-directory: docs-site
+      env:
+        # Skip 40 historical versioned_docs snapshots on PR builds —
+        # only build the latest documented version. docs.yml (release
+        # deploy) does not set this and builds the full version matrix.
+        DOCS_PR_MODE: '1'
       run: npm run build
 
   ci-success:

--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -1,8 +1,16 @@
 import {themes as prismThemes} from 'prism-react-renderer';
 import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
+import versions from './versions.json';
 
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
+
+// PR-mode build: only compile the latest documented version. CI uses this on
+// PRs (DOCS_PR_MODE=1) so docs builds don't recompile 40 historical version
+// snapshots that haven't changed. The release-time deploy via docs.yml builds
+// the full set of versions normally.
+const isPRMode = process.env.DOCS_PR_MODE === '1';
+const onlyIncludeVersions = isPRMode && versions.length > 0 ? [versions[0]] : undefined;
 
 const config: Config = {
   clientModules: ['./src/clientModules/versionSession.ts'],
@@ -169,6 +177,7 @@ const config: Config = {
           editUrl:
             'https://github.com/Fiestaboard/FiestaBoard/tree/main/docs-site/',
           includeCurrentVersion: false,
+          ...(onlyIncludeVersions ? {onlyIncludeVersions} : {}),
         },
         blog: false, // Disable blog for now - keep it simple
         theme: {


### PR DESCRIPTION
## Summary

The `Build Docs` job is the longest pole on PR CI at ~6m12s. It rebuilds all **41 versioned_docs/ snapshots** on every PR even though old versions are immutable in practice (they don't change between releases). Recompiling them is the bulk of the wasted work.

This change:

1. **Adds a `DOCS_PR_MODE=1` env-var hook** to `docusaurus.config.ts`. When set, the docs plugin uses `onlyIncludeVersions: [versions[0]]` to compile only the latest documented version. When unset (release deploy via `docs.yml`), the full version matrix is built normally so the live site at docs.fiestaboard.app still serves all history.
2. **Sets `DOCS_PR_MODE=1`** in `ci.yml`'s Build Docs step.
3. **Splits the Docusaurus cache key into a `docusaurus-pr-` namespace** so the PR build's `.docusaurus/` shape doesn't poison the full deploy build's cache (and vice versa).
4. **Bumps `actions/cache@v4` → `v5`** to match the rest of the workflows.

## Expected impact

- **PR Build Docs**: ~6m12s → ~2m (single version build).
- Released docs: **unaffected** — `docs.yml` does not set `DOCS_PR_MODE` and builds the full version matrix as before.

## Risk

- A PR that breaks a link in an *older* versioned doc won't be caught here (only the latest version is built). Old versioned_docs are snapshots and shouldn't be edited in PRs in normal practice; the link-check would catch the issue on the next release deploy.
- The version dropdown in PR previews only shows one version. This is expected and only affects local previews / artifact inspections of PR builds.

## Test plan

- [ ] Build Docs job duration drops to ~2m on this PR
- [ ] PR build still validates the latest version's links (onBrokenLinks: 'throw')
- [ ] Confirm `docs.yml` (run via workflow_dispatch with a tag) still builds all versions
- [ ] Local preview of PR build shows only the latest version in dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)