### PR TITLE
perf(docker): use npm ci + add .next/cache mount in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,19 +31,25 @@ WORKDIR /app
 # Install build dependencies for native modules (lightningcss, swc)
 RUN apk add --no-cache python3 make g++
 
-# Copy package files for dependency installation
-COPY web/package.json ./
+# Copy package files for dependency installation. Lockfile is required
+# for `npm ci` reproducibility (matches what CI tests against).
+COPY web/package.json web/package-lock.json ./
 
-# Install ALL dependencies (needed for build)
+# Install ALL dependencies (needed for build). `npm ci` matches the
+# lockfile exactly — same versions CI installed and tested.
 RUN --mount=type=cache,target=/root/.npm \
-    npm install --legacy-peer-deps --no-audit
+    npm ci --legacy-peer-deps --no-audit
 
 # Copy source files
 COPY web/ ./
 
-# Build the Next.js app with standalone output
+# Build the Next.js app with standalone output. The .next/cache mount
+# persists webpack/SWC's incremental compilation cache across builds on
+# the same buildkit instance (helps local devs; no-op in CI where each
+# job gets a fresh runner).
 ENV NODE_OPTIONS="--max-old-space-size=4096"
-RUN npm run build
+RUN --mount=type=cache,target=/app/.next/cache \
+    npm run build
 
 # --- Stage 3: Final unified runtime image ---
 FROM python:3.14-slim


### PR DESCRIPTION
## Summary

Two related improvements to the UI builder stage in the unified Dockerfile.

### 1. `npm install` → `npm ci --legacy-peer-deps`

This now matches what CI tests against — `npm ci` enforces the lockfile exactly. Previously `npm install` could resolve different versions than the lockfile (especially within minor/patch ranges), producing a Docker image that isn't byte-equal to what tests validated.

Required also copying `package-lock.json` into the builder stage (was missing — that's why the previous code used `npm install`).

### 2. Add `.next/cache` BuildKit cache mount

`--mount=type=cache,target=/app/.next/cache` for the `npm run build` step. Webpack/SWC's incremental compilation cache (resolved modules, parse trees) persists across builds on the same buildkit instance — helps local devs iterating on the UI; no-op in CI where every job gets a fresh runner.

Cost: zero. Upside: ~30–60s on warm local rebuilds.

## Risk

- If the lockfile and `package.json` are out of sync (e.g. someone added a dep to `package.json` without running `npm install`), `npm ci` will fail loudly. That's a feature, not a bug — CI's `npm ci` would have caught the same issue.
- `--legacy-peer-deps` is preserved.

## Test plan

- [ ] Docker image builds successfully (CI's E2E jobs / `build-test-image`)
- [ ] No version drift: image installs the same versions CI tested with
- [ ] On a second local `docker build`, observe `.next/cache` hit

🤖 Generated with [Claude Code](https://claude.com/claude-code)