### PR TITLE
perf(ci): parallelize platform tests with pytest-xdist (-n auto)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,10 +128,17 @@ jobs:
     
     - name: Run platform tests with coverage
       run: |
-        # Exclude integration tests (network-dependent, run in a separate step)
-        coverage run --source=src --omit='src/utils/*,src/formatters/*,src/main.py,src/system/*,src/text_to_board.py,src/plugins/testing.py' -m pytest tests/ -v -m "not integration"
-        coverage xml
-        coverage report -m --fail-under=80
+        # Exclude integration tests (network-dependent, run in a separate step).
+        # `-n auto` runs tests across all available CPU cores via pytest-xdist.
+        # `--cov` config (source + omit) comes from pyproject.toml
+        # [tool.coverage.run] — pytest-cov handles the per-worker data
+        # collection and combine automatically.
+        pytest tests/ -v -m "not integration" -n auto \
+          --cov=src \
+          --cov-branch \
+          --cov-report=xml:coverage.xml \
+          --cov-report=term-missing \
+          --cov-fail-under=80
       env:
         BOARD_READ_WRITE_KEY: test_key
         WEATHER_API_KEY: test_key

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dev = [
     "pytest>=8.0.0",
     "pytest-cov>=6.0.0",
     "pytest-asyncio>=0.24.0",
+    "pytest-xdist>=3.6.0",
     "coverage>=7.6.0",
     "black>=24.10.0",
     "ruff>=0.9.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@
 pytest>=8.0.0
 pytest-cov>=6.0.0
 pytest-asyncio>=0.24.0
+pytest-xdist>=3.6.0
 coverage>=7.6.0
 
 # Linting


### PR DESCRIPTION
## Summary

Platform Tests currently takes ~3m27s on PRs because pytest runs single-threaded. Add `pytest-xdist` and pass `-n auto` so tests fan out across the runner's CPU cores (`ubuntu-latest` = 2 cores) — expect ~40–50% wall-clock reduction.

Also switch from `coverage run -m pytest` to `pytest --cov` (pytest-cov is already in dev deps). **pytest-cov has built-in xdist integration**: each worker writes its own coverage data file and pytest-cov combines them automatically. The bare `coverage run -m pytest -n auto` pattern only traces the master xdist process, not the workers — which would silently report 0% coverage on parallelized tests.

Coverage source/omit config now lives in `pyproject.toml [tool.coverage.run]` instead of duplicated inline as ci.yml `--omit` flags. **Those flags were stale anyway** — pyproject.toml notes that `src/formatters/*`, `src/system/*`, and `src/text_to_board.py` were removed from omit in issue #505 because they're now tested, but ci.yml was still excluding them.

## Audit for parallel-unsafe patterns

Confirmed safe:
- All file-touching tests use pytest's `tmp_path` fixture (per-test directory).
- No tests start servers / bind ports.
- No tests use `os.chdir` or `pytest.mark.serial`.
- `conftest.py` only adds an autouse `monkeypatch.setenv` (per-test scope).

## Risk

- The new coverage config (pyproject.toml's omit) is stricter than the old inline `--omit` flags. If `src/formatters/*`, `src/system/*`, or `src/text_to_board.py` actually have low coverage despite the #505 comment, `--cov-fail-under=80` will fail. If that happens, easy revert is to add `--cov-config=` with a tmp `.coveragerc` mirroring the old inline list.

## Test plan

- [ ] CI passes; Platform Tests duration drops to ~1m45s–2m
- [ ] Codecov XML still uploads correctly from `coverage.xml`
- [ ] No flake or order-dependent test failures across multiple runs
- [ ] Confirm pytest worker count matches `-n auto` resolution (look for `gw0`, `gw1` markers in test output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)