### PR TITLE
feat(mcp): preview tool, live plugin data, schedule/carousel resources

### DIFF
--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -124,8 +124,15 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
             "  2. list_pages() — see current pages\n"
             "  3. get_template_variables() — see what variables plugins expose\n"
             "  4. install/configure plugins as needed\n"
-            "  5. create_page() with template_lines using {{plugin_id.variable_name}} syntax\n"
-            "  6. Optionally schedule pages with create_schedule()\n\n"
+            "  5. render_page_preview() — iterate on a template until it looks right\n"
+            "  6. create_page() with template_lines using {{plugin_id.variable_name}} syntax\n"
+            "  7. Optionally schedule pages with create_schedule()\n\n"
+            "DEBUGGING TOOLS\n"
+            "  • render_page_preview(template_lines, device_type) — see how a\n"
+            "    template will look WITHOUT creating a page. Use this to iterate.\n"
+            "  • get_plugin_data(plugin_id) — see the LIVE values a plugin is\n"
+            "    currently exposing. Use this when a page renders '???' or wrong\n"
+            "    values; it tells you whether the plugin or the template is at fault.\n\n"
             "DEVICE DIMENSIONS (template_lines length must match exactly)\n"
             "  • flagship: 22 columns × 6 rows\n"
             "  • note:     15 columns × 3 rows\n"
@@ -354,6 +361,35 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
         except Exception as exc:
             return json.dumps({"error": str(exc)})
 
+    @mcp.tool()
+    def get_plugin_data(plugin_id: str) -> str:
+        """Fetch the CURRENT live values a plugin is exposing to template variables.
+
+        Use this when debugging a page that renders unexpectedly — e.g. a value
+        shows as '???' or the wrong number. The returned dict is exactly what
+        the template engine sees when substituting {{plugin_id.variable_name}}.
+
+        Args:
+            plugin_id: The plugin identifier (from list_installed_plugins()).
+
+        Returns a JSON object:
+            {"available": bool, "data": {...}, "error": "..."}
+        If the plugin is disabled or not configured, 'available' is false and
+        'error' explains why; no exception is raised. Cached values may be
+        returned if the plugin's refresh interval hasn't elapsed.
+        """
+        try:
+            from .plugins import get_plugin_registry
+            registry = get_plugin_registry()
+            result = registry.fetch_plugin_data(plugin_id)
+            return json.dumps({
+                "available": result.available,
+                "data": result.data,
+                "error": result.error,
+            }, default=str)
+        except Exception as exc:
+            return json.dumps({"error": str(exc)})
+
     # -----------------------------------------------------------------------
     # Page tools
     # -----------------------------------------------------------------------
@@ -501,6 +537,50 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
             return f"Page '{page_id}' deleted successfully."
         except Exception as exc:
             return f"Error deleting page '{page_id}': {exc}"
+
+    @mcp.tool()
+    def render_page_preview(
+        template_lines: List[str],
+        device_type: str = "flagship",
+    ) -> str:
+        """Render a template to see how it will look BEFORE saving it as a page.
+
+        Use this to iterate on a design without creating (and then having to
+        delete) throwaway pages. Substitutes live plugin values into the
+        template just like the real renderer would, then returns the resulting
+        grid with newlines between rows.
+
+        Args:
+            template_lines: Template strings to render (one per row). Extra
+                            rows are dropped; missing rows are filled with blanks.
+            device_type: 'flagship' (22×6) or 'note' (15×3).
+
+        Returns a JSON object:
+            {
+              "rendered": "<grid string with \\n between rows>",
+              "device_type": "flagship",
+              "context_plugins": ["weather", "date_time", ...]
+            }
+        Unresolved variables render as "???" — that's a sign of a typo or a
+        plugin that's disabled/unconfigured. Lines longer than the board width
+        will appear truncated in the output, matching real-device behavior.
+        """
+        try:
+            from .templates.engine import get_template_engine
+            engine = get_template_engine()
+            context = engine._build_context()
+            rendered = engine.render_lines(
+                template_lines,
+                context=context,
+                device_type=device_type,
+            )
+            return json.dumps({
+                "rendered": rendered,
+                "device_type": device_type,
+                "context_plugins": sorted(context.keys()),
+            }, default=str)
+        except Exception as exc:
+            return json.dumps({"error": str(exc)})
 
     # -----------------------------------------------------------------------
     # Schedule tools
@@ -885,6 +965,44 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
                     example = meta.get("example", "")
                     example_str = f" (e.g. `{example}`)" if example else ""
                     lines.append(f"- `{{{{{plugin_id}.{var_name}}}}}` — {desc}{example_str}")
+            return "\n".join(lines)
+        except Exception as exc:
+            return f"Error: {exc}"
+
+    @mcp.resource("fiestaboard://schedules")
+    def get_schedules_resource() -> str:
+        """Live list of all scheduled time slots."""
+        try:
+            from .schedules.service import get_schedule_service
+            svc = get_schedule_service()
+            schedules = svc.list_schedules()
+            lines = [f"# Schedules ({len(schedules)} total)\n"]
+            for s in schedules:
+                status = "✓ enabled" if getattr(s, "enabled", True) else "✗ disabled"
+                end = getattr(s, "end_time", None) or "open"
+                lines.append(
+                    f"- **{s.start_time}–{end}** on {s.day_pattern} "
+                    f"→ page `{s.page_id}` ({status}) [`{s.id}`]"
+                )
+            return "\n".join(lines)
+        except Exception as exc:
+            return f"Error: {exc}"
+
+    @mcp.resource("fiestaboard://carousels")
+    def get_carousels_resource() -> str:
+        """Live list of all carousels (page playlists)."""
+        try:
+            from .carousels.service import get_carousel_service
+            svc = get_carousel_service()
+            carousels = svc.list_carousels()
+            lines = [f"# Carousels ({len(carousels)} total)\n"]
+            for c in carousels:
+                page_count = len(getattr(c, "page_ids", []) or [])
+                interval = getattr(c, "interval_seconds", "?")
+                lines.append(
+                    f"- **{c.name}** (`{c.id}`) — {page_count} pages, "
+                    f"{interval}s per page"
+                )
             return "\n".join(lines)
         except Exception as exc:
             return f"Error: {exc}"

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -454,6 +454,35 @@ class TestGetTemplateVariables:
         assert "temperature" in data["openweather"]
 
 
+class TestGetPluginData:
+    def test_returns_live_values(self, mcp):
+        from src.plugins.base import PluginResult
+        mock_reg = MagicMock()
+        mock_reg.fetch_plugin_data.return_value = PluginResult(
+            available=True,
+            data={"temperature": "72°F", "condition": "Sunny"},
+        )
+        with patch("src.plugins.get_plugin_registry", return_value=mock_reg):
+            result = _call_tool(mcp, "get_plugin_data", plugin_id="openweather")
+        data = json.loads(result)
+        assert data["available"] is True
+        assert data["data"]["temperature"] == "72°F"
+        assert data["error"] is None
+
+    def test_disabled_plugin_returns_error_field(self, mcp):
+        from src.plugins.base import PluginResult
+        mock_reg = MagicMock()
+        mock_reg.fetch_plugin_data.return_value = PluginResult(
+            available=False,
+            error="Plugin not enabled: openweather",
+        )
+        with patch("src.plugins.get_plugin_registry", return_value=mock_reg):
+            result = _call_tool(mcp, "get_plugin_data", plugin_id="openweather")
+        data = json.loads(result)
+        assert data["available"] is False
+        assert "not enabled" in data["error"]
+
+
 # ---------------------------------------------------------------------------
 # Page tools
 # ---------------------------------------------------------------------------
@@ -599,6 +628,34 @@ class TestDeletePage:
         with patch("src.pages.service.get_page_service", return_value=mock_svc):
             result = _call_tool(mcp, "delete_page", page_id="page-001")
         assert "Error" in result or "Page is in use" in result
+
+
+class TestRenderPagePreview:
+    def test_renders_plain_text(self, mcp):
+        result = _call_tool(
+            mcp,
+            "render_page_preview",
+            template_lines=["HELLO", "WORLD"],
+            device_type="flagship",
+        )
+        data = json.loads(result)
+        assert "rendered" in data
+        assert "HELLO" in data["rendered"]
+        assert "WORLD" in data["rendered"]
+        assert data["device_type"] == "flagship"
+        assert isinstance(data["context_plugins"], list)
+
+    def test_returns_error_json_on_bad_device_type(self, mcp):
+        # Bad device_type falls back to flagship in the engine, so this
+        # should still produce a valid 'rendered' field rather than crash.
+        result = _call_tool(
+            mcp,
+            "render_page_preview",
+            template_lines=["X"],
+            device_type="not-a-device",
+        )
+        data = json.loads(result)
+        assert "rendered" in data or "error" in data
 
 
 # ---------------------------------------------------------------------------
@@ -818,6 +875,19 @@ class TestMCPResources:
         assert "temperature" in result
         assert "openweather" in result
 
+    def test_schedules_resource(self, mcp, mock_schedule_service):
+        with patch("src.schedules.service.get_schedule_service", return_value=mock_schedule_service):
+            result = _call_resource(mcp, "fiestaboard://schedules")
+        assert "sched-001" in result
+        assert "page-001" in result
+        assert "08:00" in result
+
+    def test_carousels_resource(self, mcp, mock_carousel_service):
+        with patch("src.carousels.service.get_carousel_service", return_value=mock_carousel_service):
+            result = _call_resource(mcp, "fiestaboard://carousels")
+        assert "Daily" in result
+        assert "carousel-001" in result
+
 
 # ---------------------------------------------------------------------------
 # MCP Prompts
@@ -884,11 +954,13 @@ class TestToolErrorResilience:
         ("configure_plugin", {"plugin_id": "x", "config": {}}),
         ("update_plugin", {"plugin_id": "x"}),
         ("get_template_variables", {}),
+        ("get_plugin_data", {"plugin_id": "x"}),
         ("list_pages", {}),
         ("get_page", {"page_id": "x"}),
         ("create_page", {"name": "x", "template_lines": []}),
         ("update_page", {"page_id": "x"}),
         ("delete_page", {"page_id": "x"}),
+        ("render_page_preview", {"template_lines": ["{{x.y}}"]}),
         ("list_schedules", {}),
         ("create_schedule", {"page_id": "x", "start_time": "08:00"}),
         ("update_schedule", {"schedule_id": "x"}),


### PR DESCRIPTION
_(Reopened — original PR #837 auto-closed when base branch `feat-mcp-improved-guidance` was deleted on merge of #835. Retargeted to `main`.)_

## Summary

Adds three capabilities so external MCP clients can debug FiestaBoard the same way we do internally, rather than guessing or creating throwaway pages.

**Stacked on top of #835** — once that merges, this rebases cleanly onto main.

### New tools
- **`render_page_preview(template_lines, device_type)`** — render a template WITHOUT creating a page; returns the final grid plus the plugin context that was substituted in. Lets the LLM iterate on a design and catch typos / wrong variable names before persisting.
- **`get_plugin_data(plugin_id)`** — return the live values a plugin is currently exposing to template variables. Distinguishes "the template is wrong" from "the plugin isn't returning data" when debugging. Pairs naturally with the `troubleshoot_display` prompt from #835.

### New resources
- **`fiestaboard://schedules`** and **`fiestaboard://carousels`** — symmetry with existing `plugins` / `pages` / `variables` resources.

### Instructions update
Connection-time `instructions=` block now references both new debugging tools and slots `render_page_preview` into the TYPICAL WORKFLOW.

## Test plan

- [x] `pytest tests/test_mcp_server.py` — 91 passed
- [x] New tests cover: render_page_preview happy path + bad device_type, get_plugin_data success + disabled-plugin error, both new resources
- [x] Error-resilience parametrize list extended to cover both new tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)
