### PR TITLE
feat(mcp): bearer-token auth + unblock dev/https /api/mcp routing

### DIFF
--- a/env.example
+++ b/env.example
@@ -195,6 +195,23 @@ FIESTABOARD_AUTH_ENABLED=
 # FIESTABOARD_SESSION_TTL_SECONDS=604800
 
 # =============================================================================
+# MCP (Model Context Protocol) bearer token
+# =============================================================================
+# When FIESTABOARD_AUTH_ENABLED is on, external MCP clients (Claude Desktop,
+# Claude Code, etc.) can't drive the cookie-based login flow. Set a token
+# here and FiestaBoard's /mcp endpoint will accept it as
+#     Authorization: Bearer <token>
+# instead of a session cookie. A 401 from /mcp will include
+#     WWW-Authenticate: Bearer realm="FiestaBoard MCP"
+# so clients know to send a pre-shared token rather than attempting OAuth.
+#
+# Generate a value with:
+#     python -c "import secrets; print(secrets.token_urlsafe(32))"
+#
+# Leave empty to disable token auth on /mcp (cookie auth still works).
+FIESTABOARD_MCP_TOKEN=
+
+# =============================================================================
 # Secret encryption at rest
 # =============================================================================
 # FiestaBoard can encrypt sensitive values (API keys, board keys, plugin

--- a/nginx-dev.conf
+++ b/nginx-dev.conf
@@ -56,6 +56,27 @@ http {
             internal;
         }
 
+        # MCP traffic must NOT have the /api prefix stripped: the FastAPI
+        # app is configured with root_path="/api", and Starlette's Mount
+        # only computes the sub-app's root_path correctly when the request
+        # path still includes the /api prefix. Stripping it (as the general
+        # /api/ rule below does) makes Starlette compute root_path="/api/mcp"
+        # while scope.path stays "/mcp/", which causes every request to the
+        # MCP sub-app to 404. Must be declared BEFORE `location /api/` so
+        # nginx's longest-prefix match picks it up first.
+        location /api/mcp {
+            error_page 502 503 504 = @api_starting;
+            proxy_pass http://127.0.0.1:8000;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_connect_timeout 10s;
+            proxy_send_timeout 30s;
+            proxy_read_timeout 60s;
+        }
+
         # All API traffic under /api/* → FastAPI backend (path stripped: /api/pages → /pages)
         location /api/ {
             # Return JSON while the API is starting instead of the HTML "please wait" page.

--- a/nginx.https.conf
+++ b/nginx.https.conf
@@ -75,6 +75,27 @@ http {
             internal;
         }
 
+        # MCP traffic must NOT have the /api prefix stripped: the FastAPI
+        # app is configured with root_path="/api", and Starlette's Mount
+        # only computes the sub-app's root_path correctly when the request
+        # path still includes the /api prefix. Stripping it (as the general
+        # /api/ rule below does) makes Starlette compute root_path="/api/mcp"
+        # while scope.path stays "/mcp/", which causes every request to the
+        # MCP sub-app to 404. Must be declared BEFORE `location /api/` so
+        # nginx's longest-prefix match picks it up first.
+        location /api/mcp {
+            error_page 502 503 504 = @api_starting;
+            proxy_pass http://127.0.0.1:8000;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_connect_timeout 10s;
+            proxy_send_timeout 30s;
+            proxy_read_timeout 60s;
+        }
+
         # All API traffic under /api/* → FastAPI backend (path stripped: /api/pages → /pages)
         location /api/ {
             # Return JSON while the API is starting instead of the HTML "please wait" page.

--- a/src/auth/middleware.py
+++ b/src/auth/middleware.py
@@ -60,7 +60,26 @@ def _is_public_path(path: str) -> bool:
 
 
 def _is_mcp_path(path: str) -> bool:
-    return path == "/mcp" or path.startswith("/mcp/")
+    """True for any path that lands on the MCP sub-app.
+
+    The MCP server is mounted at ``/mcp`` inside FastAPI. Behind nginx we
+    have two regimes:
+
+    * Most ``/api/*`` traffic is rewritten to drop the prefix, so the
+      middleware sees ``/mcp/...`` here.
+    * ``/api/mcp/*`` is proxied WITHOUT the rewrite (otherwise Starlette
+      can't compute Mount root_path correctly against FastAPI's
+      ``root_path="/api"``) — so for that path we see ``/api/mcp/...``.
+
+    Both forms point at the same endpoint and should accept the same
+    bearer token.
+    """
+    return (
+        path == "/mcp"
+        or path.startswith("/mcp/")
+        or path == "/api/mcp"
+        or path.startswith("/api/mcp/")
+    )
 
 
 def _bearer_from(request: Request) -> str | None:

--- a/src/auth/middleware.py
+++ b/src/auth/middleware.py
@@ -8,6 +8,14 @@ Public paths (no auth required):
     * ``/auth/*`` — login / setup / status itself
     * ``/openapi.json``, ``/docs``, ``/redoc`` — API docs (still useful)
     * CORS preflight (``OPTIONS``) requests
+
+MCP endpoint (``/mcp/*``):
+    If ``FIESTABOARD_MCP_TOKEN`` is set, the MCP endpoint accepts an
+    ``Authorization: Bearer <token>`` header instead of (or in addition to)
+    the session cookie. This lets external MCP clients (Claude Desktop,
+    Claude Code) connect without needing to drive a browser login flow.
+    A 401 from this endpoint includes ``WWW-Authenticate: Bearer`` so the
+    client knows to send a pre-shared token rather than attempting OAuth.
 """
 
 from __future__ import annotations
@@ -23,6 +31,8 @@ from .service import (
     SESSION_COOKIE_NAME,
     auth_mode,
     get_auth_service,
+    mcp_token,
+    verify_mcp_bearer,
 )
 
 logger = logging.getLogger(__name__)
@@ -49,6 +59,34 @@ def _is_public_path(path: str) -> bool:
     return False
 
 
+def _is_mcp_path(path: str) -> bool:
+    return path == "/mcp" or path.startswith("/mcp/")
+
+
+def _bearer_from(request: Request) -> str | None:
+    """Pull the token from an ``Authorization: Bearer <token>`` header."""
+    header = request.headers.get("authorization", "")
+    scheme, _, token = header.partition(" ")
+    if scheme.lower() == "bearer" and token:
+        return token.strip()
+    return None
+
+
+def _mcp_unauthorized() -> JSONResponse:
+    """401 with a plain Bearer challenge.
+
+    The ``WWW-Authenticate: Bearer`` header signals to MCP clients that
+    this endpoint takes a pre-shared token, not an OAuth flow. We
+    deliberately omit a ``resource_metadata=`` parameter so spec-compliant
+    clients don't attempt OAuth 2.1 dynamic client registration here.
+    """
+    return JSONResponse(
+        {"detail": "Not authenticated"},
+        status_code=401,
+        headers={"WWW-Authenticate": 'Bearer realm="FiestaBoard MCP"'},
+    )
+
+
 class AuthMiddleware(BaseHTTPMiddleware):
     """Enforce a valid session cookie on non-public requests."""
 
@@ -73,6 +111,22 @@ class AuthMiddleware(BaseHTTPMiddleware):
         for extra in self._extra_public:
             if path == extra or path.startswith(extra.rstrip("/") + "/"):
                 return await call_next(request)
+
+        # MCP endpoint: accept a Bearer token if one is configured. Falls
+        # through to cookie auth when no token env var is set so the UI's
+        # own MCP usage (and existing installs) keep working.
+        if _is_mcp_path(path) and mcp_token() is not None:
+            supplied = _bearer_from(request)
+            if supplied is not None:
+                if verify_mcp_bearer(supplied):
+                    request.scope["auth_user"] = "mcp-client"
+                    return await call_next(request)
+                return _mcp_unauthorized()
+            # No Authorization header — challenge the client. We skip the
+            # session-cookie fallback here because Claude/etc. will never
+            # have a cookie, and emitting a 401 with WWW-Authenticate is
+            # exactly the signal it needs.
+            return _mcp_unauthorized()
 
         svc = get_auth_service()
 

--- a/src/auth/service.py
+++ b/src/auth/service.py
@@ -139,6 +139,24 @@ def _auth_env_override() -> str | None:
     return None
 
 
+def mcp_token() -> str | None:
+    """Return the configured MCP bearer token, or ``None`` if none is set.
+
+    Read fresh from the environment on every call so tests / runtime
+    reconfiguration don't have to bust a cache.
+    """
+    raw = os.environ.get("FIESTABOARD_MCP_TOKEN", "").strip()
+    return raw or None
+
+
+def verify_mcp_bearer(supplied: str) -> bool:
+    """Constant-time compare a supplied Bearer token to the configured one."""
+    expected = mcp_token()
+    if expected is None or not supplied:
+        return False
+    return secrets.compare_digest(expected, supplied)
+
+
 # --- Errors ----------------------------------------------------------------
 
 

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -6,21 +6,32 @@ FiestaBoard via conversation.
 
 Mount point: ``/mcp``  (accessed as ``/api/mcp`` via nginx)
 
-No authentication is required — this server is intended for local / LAN use.
-When FiestaBoard gains a login system, Bearer-token auth should be added here.
+Authentication
+--------------
+When ``FIESTABOARD_AUTH_ENABLED`` is on, ``/mcp`` accepts either the
+session cookie (used by the FiestaBoard web UI) or a pre-shared bearer
+token configured via ``FIESTABOARD_MCP_TOKEN`` — set the env var and pass
+the value as ``Authorization: Bearer <token>``. A 401 from ``/mcp``
+includes ``WWW-Authenticate: Bearer realm="FiestaBoard MCP"`` so MCP
+clients send a token rather than attempting OAuth registration.
 
 Connection example for Claude Desktop (``claude_desktop_config.json``):
     {
         "mcpServers": {
             "fiestaboard": {
                 "type": "http",
-                "url": "http://fiestaboard.local:4420/api/mcp"
+                "url": "http://fiestaboard.local:4420/api/mcp",
+                "headers": {
+                    "Authorization": "Bearer <FIESTABOARD_MCP_TOKEN>"
+                }
             }
         }
     }
 
 Connection example for Claude Code:
-    Add via: /mcp add fiestaboard --transport http --url http://localhost:4420/api/mcp
+    /mcp add fiestaboard --transport http \\
+        --url http://localhost:4420/api/mcp \\
+        --header "Authorization: Bearer <FIESTABOARD_MCP_TOKEN>"
 """
 
 from __future__ import annotations

--- a/tests/test_auth_mcp_bearer.py
+++ b/tests/test_auth_mcp_bearer.py
@@ -1,0 +1,131 @@
+"""Tests for MCP bearer-token auth on the ``/mcp`` endpoint.
+
+Verifies:
+  * ``FIESTABOARD_MCP_TOKEN`` unset -> the existing cookie-auth path is
+    unaffected (no behaviour change for installs that don't use MCP).
+  * ``FIESTABOARD_MCP_TOKEN`` set -> a valid ``Authorization: Bearer``
+    header passes the middleware without a session cookie.
+  * Wrong / missing token -> 401 with ``WWW-Authenticate: Bearer realm=...``
+    so MCP clients send a token instead of starting OAuth discovery.
+  * Non-``/mcp`` paths still require the cookie even when the token env
+    var is set (token grants access to MCP only, not the whole API).
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.api_server import app
+from src.auth import routes as auth_routes
+from src.auth import service as auth_service
+
+TOKEN = "test-token-abc123"
+
+
+@pytest.fixture
+def auth_dir(tmp_path, monkeypatch):
+    fresh = auth_service.AuthService(auth_file=tmp_path / "auth.json")
+    monkeypatch.setattr(auth_service, "_service", fresh)
+    auth_routes._FAILED_ATTEMPTS.clear()
+    yield tmp_path
+    monkeypatch.setattr(auth_service, "_service", None)
+
+
+@pytest.fixture
+def client(auth_dir):
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def enabled(monkeypatch):
+    monkeypatch.setenv("FIESTABOARD_AUTH_ENABLED", "true")
+    yield
+    monkeypatch.delenv("FIESTABOARD_AUTH_ENABLED", raising=False)
+
+
+@pytest.fixture
+def with_token(monkeypatch):
+    monkeypatch.setenv("FIESTABOARD_MCP_TOKEN", TOKEN)
+    yield TOKEN
+    monkeypatch.delenv("FIESTABOARD_MCP_TOKEN", raising=False)
+
+
+@pytest.fixture
+def setup_user(client, enabled):
+    """Provision an admin user so middleware doesn't 409 for setup.
+
+    ``/auth/setup`` auto-logs the new user in. We drop the session cookie
+    so subsequent assertions in the test exercise the unauthenticated
+    code path (cookie-less request -> 401) rather than riding on the
+    setup-time session.
+    """
+    r = client.post("/auth/setup", json={"username": "admin", "password": "Password123!"})
+    assert r.status_code in (200, 201), r.text
+    client.cookies.clear()
+
+
+# --- Cookie path is unaffected when no token is configured ----------------
+
+
+def test_mcp_without_token_env_still_requires_cookie(client, setup_user):
+    """No FIESTABOARD_MCP_TOKEN set -> /mcp falls back to cookie auth."""
+    r = client.get("/mcp/")
+    # Cookie missing -> standard 401, no Bearer challenge.
+    assert r.status_code == 401
+    assert "www-authenticate" not in {k.lower() for k in r.headers}
+
+
+# --- Bearer auth path ------------------------------------------------------
+
+
+def test_mcp_with_valid_bearer_passes_middleware(client, setup_user, with_token):
+    """Correct token -> middleware passes through (downstream may still
+    refuse the request for other reasons, but it's not a 401)."""
+    r = client.get("/mcp/", headers={"Authorization": f"Bearer {with_token}"})
+    assert r.status_code != 401
+
+
+def test_mcp_with_wrong_bearer_returns_401_with_challenge(client, setup_user, with_token):
+    r = client.get("/mcp/", headers={"Authorization": "Bearer not-the-real-token"})
+    assert r.status_code == 401
+    assert r.headers.get("WWW-Authenticate", "").startswith("Bearer")
+    assert 'realm="FiestaBoard MCP"' in r.headers["WWW-Authenticate"]
+
+
+def test_mcp_with_no_auth_header_returns_401_with_challenge(client, setup_user, with_token):
+    """When a token is configured, even an un-authenticated request gets
+    the Bearer challenge (no cookie fallback)."""
+    r = client.get("/mcp/")
+    assert r.status_code == 401
+    assert r.headers.get("WWW-Authenticate", "").startswith("Bearer")
+
+
+def test_mcp_bearer_does_not_expose_oauth_resource_metadata(client, setup_user, with_token):
+    """The challenge must NOT advertise OAuth metadata, otherwise spec-
+    compliant MCP clients will try OAuth dynamic client registration."""
+    r = client.get("/mcp/", headers={"Authorization": "Bearer wrong"})
+    assert "resource_metadata" not in r.headers.get("WWW-Authenticate", "")
+
+
+# --- Token scope: MCP only -------------------------------------------------
+
+
+def test_bearer_does_not_grant_access_to_non_mcp_paths(client, setup_user, with_token):
+    """The MCP token must not let a caller bypass cookie auth on the rest
+    of the API. /api/pages should still 401 even with a valid Bearer."""
+    r = client.get("/pages", headers={"Authorization": f"Bearer {with_token}"})
+    # Cookie still required; either standard 401 or a non-Bearer challenge.
+    assert r.status_code == 401
+    assert not r.headers.get("WWW-Authenticate", "").startswith("Bearer")
+
+
+# --- Auth disabled -> token irrelevant -----------------------------------
+
+
+def test_token_irrelevant_when_auth_disabled(client, monkeypatch, with_token):
+    monkeypatch.setenv("FIESTABOARD_AUTH_ENABLED", "false")
+    r = client.get("/mcp/")
+    # No auth means the middleware is a no-op; downstream may 404 or 405
+    # but should not 401.
+    assert r.status_code != 401

--- a/tests/test_auth_mcp_bearer.py
+++ b/tests/test_auth_mcp_bearer.py
@@ -52,6 +52,18 @@ def with_token(monkeypatch):
 
 
 @pytest.fixture
+def no_token(monkeypatch):
+    """Ensure the env var is *unset* even if the dev's local .env had one.
+
+    api_server.py calls ``load_dotenv()`` at import time, which can leak
+    ``FIESTABOARD_MCP_TOKEN`` from the developer's ``.env`` into pytest's
+    process environment. Tests that assert "no token configured" must use
+    this fixture to neutralise that.
+    """
+    monkeypatch.delenv("FIESTABOARD_MCP_TOKEN", raising=False)
+
+
+@pytest.fixture
 def setup_user(client, enabled):
     """Provision an admin user so middleware doesn't 409 for setup.
 
@@ -68,7 +80,7 @@ def setup_user(client, enabled):
 # --- Cookie path is unaffected when no token is configured ----------------
 
 
-def test_mcp_without_token_env_still_requires_cookie(client, setup_user):
+def test_mcp_without_token_env_still_requires_cookie(client, setup_user, no_token):
     """No FIESTABOARD_MCP_TOKEN set -> /mcp falls back to cookie auth."""
     r = client.get("/mcp/")
     # Cookie missing -> standard 401, no Bearer challenge.
@@ -106,6 +118,20 @@ def test_mcp_bearer_does_not_expose_oauth_resource_metadata(client, setup_user, 
     compliant MCP clients will try OAuth dynamic client registration."""
     r = client.get("/mcp/", headers={"Authorization": "Bearer wrong"})
     assert "resource_metadata" not in r.headers.get("WWW-Authenticate", "")
+
+
+def test_bearer_works_for_unstripped_api_mcp_path(client, setup_user, with_token):
+    """Behind nginx the MCP endpoint is reachable at ``/api/mcp/...`` *without*
+    the prefix being stripped (so Starlette's Mount can compute the sub-app's
+    root_path correctly). The middleware must accept the bearer header on
+    that path too, not only on ``/mcp/``."""
+    r = client.get("/api/mcp/", headers={"Authorization": f"Bearer {with_token}"})
+    # Middleware lets us through; downstream MCP may 405 the GET or otherwise
+    # respond, but it must not be the auth-layer 401.
+    assert r.status_code != 401
+    r2 = client.get("/api/mcp/", headers={"Authorization": "Bearer wrong"})
+    assert r2.status_code == 401
+    assert r2.headers.get("WWW-Authenticate", "").startswith("Bearer")
 
 
 # --- Token scope: MCP only -------------------------------------------------


### PR DESCRIPTION
## Summary

Lets external MCP clients (Claude Desktop, Claude Code, etc.) connect to FiestaBoard's `/mcp` endpoint without driving a browser login flow, and fixes the dev / HTTPS nginx configs so the endpoint is actually reachable.

### The problem

When `FIESTABOARD_AUTH_ENABLED=true`, Claude tried to add the server and got:

> Couldn't register with FiestaBoard's sign-in service. You can try again, or add an OAuth Client ID in the connector settings.

Root cause was two stacked issues:

1. **Auth model mismatch.** FiestaBoard auth is cookie-based session auth. Claude's MCP client expects OAuth 2.1 + Dynamic Client Registration on a 401 and tries to discover an Authorization Server. FiestaBoard doesn't speak OAuth — so DCR fails.
2. **MCP route was unreachable in dev / HTTPS.** `nginx.conf` has a dedicated `location /api/mcp` block (added in #?? via `ba66c2d1`) that proxies *without* stripping `/api`, because FastAPI's `root_path="/api"` interacts with Starlette's `Mount` such that `scope["path"]` must keep the `/api/` prefix or the sub-app's root_path is miscomputed → 404. `nginx-dev.conf` and `nginx.https.conf` never got that block, so MCP requests 404'd there even with auth disabled.

### The fix

- **Bearer-token mode.** New `FIESTABOARD_MCP_TOKEN` env var. When set, `/mcp` accepts `Authorization: Bearer <token>` instead of the session cookie. 401s on `/mcp` now include `WWW-Authenticate: Bearer realm="FiestaBoard MCP"` *without* a `resource_metadata=` parameter, so spec-compliant MCP clients send a pre-shared token rather than starting OAuth DCR.
- **Token grants access to `/mcp/*` only.** The rest of the API still requires the session cookie, so leaking the token doesn't expose page/plugin/schedule mutations.
- **Constant-time compare** via `secrets.compare_digest`.
- **Backwards compatible.** When `FIESTABOARD_MCP_TOKEN` is unset, `/mcp` falls back to the existing cookie path. Zero behaviour change for installs that don't use external MCP clients.
- **nginx-dev.conf + nginx.https.conf** get the same `location /api/mcp` un-rewritten proxy block that production already has.
- **Middleware** recognises both `/mcp/...` (TestClient / cookie-stripped traffic) and `/api/mcp/...` (real nginx-proxied traffic) as MCP paths.

### Connection example for Claude Desktop

```json
{
  "mcpServers": {
    "fiestaboard": {
      "type": "http",
      "url": "http://fiestaboard.local:4420/api/mcp",
      "headers": {
        "Authorization": "Bearer <FIESTABOARD_MCP_TOKEN>"
      }
    }
  }
}
```

Generate a token with:

```sh
python -c "import secrets; print(secrets.token_urlsafe(32))"
```

then set it in `.env` as `FIESTABOARD_MCP_TOKEN=…` and restart the container.

## Test plan

- [x] 44 unit tests pass (`tests/test_auth_mcp_bearer.py` x 8, plus `test_auth_routes.py` x 36 to confirm no regressions).
- [x] Live curl against the running dev container:
  - `GET /api/mcp/` no auth → `401 + WWW-Authenticate: Bearer realm="FiestaBoard MCP"` ✓
  - `GET /api/mcp/` wrong bearer → same 401 + challenge ✓
  - `POST /api/mcp/` valid bearer + JSON-RPC `initialize` → real MCP response with FiestaBoard server info + capabilities ✓
  - `/api/health` healthcheck → 200 ✓
  - `/api/auth/status` → 200 (cookie-auth path unaffected) ✓
- [x] Ruff clean.
- [ ] Test from Claude Desktop / Claude Code with a real token (user to verify after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)