### PR TITLE
fix(web): stop Safari nested-scroll feel on long pages (h-dvh)

### DIFF
--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -70,7 +70,7 @@ export default async function RootLayout({
         <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
       </head>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen overflow-x-hidden`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased h-dvh overflow-hidden`}
       >
         <svg width="0" height="0" aria-hidden="true" style={{ position: 'absolute' }}>
           <defs>

--- a/web/src/components/main-content.tsx
+++ b/web/src/components/main-content.tsx
@@ -18,7 +18,7 @@ export function MainContent({ children }: { children: React.ReactNode }) {
     <main
       id="main-content"
       className={cn(
-        "h-screen flex flex-col overflow-x-hidden overflow-y-auto w-full mx-auto",
+        "h-dvh flex flex-col overflow-x-hidden overflow-y-auto overscroll-contain w-full mx-auto",
         !isAuthScreen && "pt-[72px] lg:pt-0 sidebar-transition",
         !isAuthScreen && (collapsed ? "lg:pl-[76px]" : "lg:pl-[268px]"),
         !isAuthScreen && (aiPanelOpen ? "lg:pr-[384px]" : "lg:pr-0"),


### PR DESCRIPTION
## Summary

On iOS Safari, scrolling a long page (most noticeably **Settings → Integrations**) felt like a "scrolling window inside a scrolling window" — the page would scroll, then bounce/double-scroll as the iOS bottom toolbar (URL bar) collapsed or revealed itself.

**Root cause:** `<main id="main-content">` used Tailwind's `h-screen` (= `100vh`). On iOS Safari, `100vh` is the *largest* viewport — it does **not** shrink when the bottom toolbar is visible. So the inner scroll container stayed taller than the actually-visible area, the body picked up a few pixels of overflow, and every gesture raced between collapsing the toolbar (body scroll) and scrolling `<main>` (inner scroll) → the nested-scroll feel.

What this PR does:

- **`<main>`**: `h-screen` → `h-dvh` (dynamic viewport height, Tailwind v4 native). Now exactly matches the visible viewport, even as the iOS toolbar shows/hides.
- **`<body>`**: `min-h-screen overflow-x-hidden` → `h-dvh overflow-hidden`. The body no longer has a second scrollable layer competing with `<main>`.
- **`<main>` overscroll**: added `overscroll-contain` so nested scrolls (MCP dialog code block, sheets, etc.) don't chain back into the page scroll.

No new components, no padding refactors, no per-page changes — just three class changes on two files.

## Test plan

- [x] Built dev container, served HTML confirms new classes (`h-dvh`, `overscroll-contain`, body `overflow-hidden`).
- [x] In Safari, verified computed styles on `<main>` (`overscroll-behavior: contain`) and `<body>` (`overflow: hidden`).
- [x] Verified `<main>` is the sole scroll surface (`bodyScrollTop` / `htmlScrollTop` stay at 0 even when content overflows).
- [x] Settings page renders normally; sidebar/topbar still positioned correctly.
- [ ] Manual: scroll on real iOS Safari at Settings → Integrations and confirm no nested-scroll bounce.
- [ ] Manual: open the MCP config Dialog and confirm scrolling its `<pre>` block doesn't move the page (overscroll-contain working).
- [ ] Manual: AI chat drawer + Sheet components still scroll internally as expected.
- [ ] Manual: login (auth screen) renders correctly with `overflow-hidden` on body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)