### PR TITLE
feat(mcp): UI-managed bearer token in Settings → Integrations

### DIFF
--- a/src/auth/routes.py
+++ b/src/auth/routes.py
@@ -16,7 +16,9 @@ from .service import (
     _auth_env_override,
     _remember_me_ttl_seconds,
     auth_mode,
+    generate_mcp_token,
     get_auth_service,
+    mcp_token_source,
 )
 
 logger = logging.getLogger(__name__)
@@ -76,6 +78,25 @@ class PreferenceRequest(BaseModel):
 class SimpleResponse(BaseModel):
     status: str
     username: str | None = None
+
+
+class McpTokenStatusResponse(BaseModel):
+    # Whether the MCP endpoint will accept *any* bearer token right now.
+    configured: bool
+    # ``"env"``  -> ``FIESTABOARD_MCP_TOKEN`` is set; the UI must show
+    #               "managed by ops" and hide rotate/clear controls.
+    # ``"stored"`` -> token lives in ``auth.json`` and is UI-managed.
+    # ``"none"`` -> nothing configured; ``/mcp`` still requires the
+    #               session cookie (legacy behaviour).
+    source: str
+
+
+class McpTokenRotateResponse(BaseModel):
+    # Returned ONCE on rotation. The plaintext token is never readable
+    # again after this response — the client must show it to the user
+    # immediately. The server stores it verbatim (auth.json is 0600) so
+    # ``verify_mcp_bearer`` can constant-time-compare future requests.
+    token: str
 
 
 # --- Cookie helpers --------------------------------------------------------
@@ -363,4 +384,82 @@ async def auth_disable(
         ) from None
     _clear_session_cookie(response)
     logger.info("Auth disabled by user '%s'", username)
+    return SimpleResponse(status="ok")
+
+
+# --- MCP bearer-token management ------------------------------------------
+#
+# These endpoints let an authenticated admin generate / rotate / revoke the
+# pre-shared bearer token that external MCP clients (Claude Desktop, Claude
+# Code) use to authenticate. The plaintext token is only returned by
+# ``POST /auth/mcp-token`` and never read back — the UI is responsible for
+# showing it to the user at rotation time.
+
+
+def _require_admin(request: Request) -> str:
+    """Return the logged-in username or raise 401. Shared 1-line gate."""
+    svc = get_auth_service()
+    cookie = request.cookies.get(SESSION_COOKIE_NAME)
+    username = svc.verify_session(cookie) if cookie else None
+    if not username:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated"
+        )
+    return username
+
+
+@router.get("/mcp-token", response_model=McpTokenStatusResponse)
+async def auth_mcp_token_status(request: Request) -> McpTokenStatusResponse:
+    """Report whether an MCP bearer token is configured, and from where."""
+    _require_admin(request)
+    source = mcp_token_source()
+    return McpTokenStatusResponse(configured=source != "none", source=source)
+
+
+@router.post(
+    "/mcp-token",
+    response_model=McpTokenRotateResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def auth_mcp_token_rotate(request: Request) -> McpTokenRotateResponse:
+    """Generate a fresh MCP bearer token, persist it, and return it ONCE.
+
+    Refuses if ``FIESTABOARD_MCP_TOKEN`` is set, because the env var wins
+    in :func:`~src.auth.service.mcp_token` resolution — a UI rotation
+    would silently have no effect and confuse the admin.
+    """
+    username = _require_admin(request)
+    if mcp_token_source() == "env":
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "MCP token is pinned by FIESTABOARD_MCP_TOKEN environment "
+                "variable. Unset it before managing the token from the UI."
+            ),
+        )
+    token = generate_mcp_token()
+    get_auth_service().set_stored_mcp_token(token)
+    logger.info("MCP token rotated by user '%s'", username)
+    return McpTokenRotateResponse(token=token)
+
+
+@router.delete("/mcp-token", response_model=SimpleResponse)
+async def auth_mcp_token_clear(request: Request) -> SimpleResponse:
+    """Revoke the stored MCP bearer token.
+
+    External MCP clients will start receiving 401 + Bearer challenge on
+    their next request. (If ``FIESTABOARD_MCP_TOKEN`` is set, this only
+    clears the stored fallback — the env var continues to be active.)
+    """
+    username = _require_admin(request)
+    if mcp_token_source() == "env":
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "MCP token is pinned by FIESTABOARD_MCP_TOKEN environment "
+                "variable. Unset it before managing the token from the UI."
+            ),
+        )
+    get_auth_service().set_stored_mcp_token(None)
+    logger.info("MCP token revoked by user '%s'", username)
     return SimpleResponse(status="ok")

--- a/src/auth/service.py
+++ b/src/auth/service.py
@@ -140,13 +140,42 @@ def _auth_env_override() -> str | None:
 
 
 def mcp_token() -> str | None:
-    """Return the configured MCP bearer token, or ``None`` if none is set.
+    """Return the active MCP bearer token, or ``None`` if none is set.
 
-    Read fresh from the environment on every call so tests / runtime
-    reconfiguration don't have to bust a cache.
+    Resolution order (first match wins):
+
+    1. ``FIESTABOARD_MCP_TOKEN`` environment variable — lets ops pin a
+       value out-of-band without touching ``auth.json``.
+    2. ``mcp_token`` field in ``auth.json`` — managed by the Settings UI.
+
+    Read fresh on every call so tests / runtime reconfiguration don't
+    have to bust a cache.
     """
-    raw = os.environ.get("FIESTABOARD_MCP_TOKEN", "").strip()
-    return raw or None
+    env = os.environ.get("FIESTABOARD_MCP_TOKEN", "").strip()
+    if env:
+        return env
+    try:
+        return get_auth_service().get_stored_mcp_token()
+    except Exception:
+        # Auth store unreachable — fail closed so we don't grant access
+        # we can't reason about.
+        return None
+
+
+def mcp_token_source() -> str:
+    """Where the active MCP token comes from: ``"env"``, ``"stored"``, or ``"none"``.
+
+    Used by the Settings API so the UI can show "managed by ops" when
+    the env var is set and hide the rotate/clear controls.
+    """
+    if os.environ.get("FIESTABOARD_MCP_TOKEN", "").strip():
+        return "env"
+    try:
+        if get_auth_service().get_stored_mcp_token():
+            return "stored"
+    except Exception:
+        return "none"
+    return "none"
 
 
 def verify_mcp_bearer(supplied: str) -> bool:
@@ -155,6 +184,11 @@ def verify_mcp_bearer(supplied: str) -> bool:
     if expected is None or not supplied:
         return False
     return secrets.compare_digest(expected, supplied)
+
+
+def generate_mcp_token() -> str:
+    """Return a fresh 32-byte URL-safe token suitable for the MCP endpoint."""
+    return secrets.token_urlsafe(32)
 
 
 # --- Errors ----------------------------------------------------------------
@@ -430,6 +464,36 @@ class AuthService:
                 self._data.pop("auth_pref", None)
             else:
                 self._data["auth_pref"] = preference
+            self._save()
+
+    # -- MCP bearer token --------------------------------------------------
+
+    def get_stored_mcp_token(self) -> str | None:
+        """Return the persisted MCP bearer token, or ``None`` if unset.
+
+        This is the UI-managed value. The runtime ``mcp_token()`` helper
+        in this module also consults ``FIESTABOARD_MCP_TOKEN``; the env
+        var wins so ops can pin a value out-of-band.
+        """
+        with self._lock:
+            tok = self._data.get("mcp_token")
+        if isinstance(tok, str) and tok:
+            return tok
+        return None
+
+    def set_stored_mcp_token(self, token: str | None) -> None:
+        """Persist (or clear) the UI-managed MCP bearer token.
+
+        Pass ``None`` to remove it. Stored in ``auth.json`` (file mode
+        0600 alongside the password hash), so no extra encryption layer.
+        """
+        if token is not None and (not isinstance(token, str) or not token.strip()):
+            raise ValueError("token must be a non-empty string or None")
+        with self._lock:
+            if token is None:
+                self._data.pop("mcp_token", None)
+            else:
+                self._data["mcp_token"] = token.strip()
             self._save()
 
     # -- mutations ---------------------------------------------------------

--- a/tests/test_auth_mcp_token_routes.py
+++ b/tests/test_auth_mcp_token_routes.py
@@ -1,0 +1,161 @@
+"""Tests for the ``/auth/mcp-token`` admin endpoints.
+
+Covers status, rotation, revocation, env-var override, and the
+end-to-end "rotate a token → use it against /mcp/" path so we know
+the UI's button maps to a token that the middleware actually accepts.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.api_server import app
+from src.auth import routes as auth_routes
+from src.auth import service as auth_service
+
+
+@pytest.fixture
+def auth_dir(tmp_path, monkeypatch):
+    fresh = auth_service.AuthService(auth_file=tmp_path / "auth.json")
+    monkeypatch.setattr(auth_service, "_service", fresh)
+    auth_routes._FAILED_ATTEMPTS.clear()
+    yield tmp_path
+    monkeypatch.setattr(auth_service, "_service", None)
+
+
+@pytest.fixture
+def client(auth_dir):
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def enabled(monkeypatch):
+    monkeypatch.setenv("FIESTABOARD_AUTH_ENABLED", "true")
+    monkeypatch.delenv("FIESTABOARD_MCP_TOKEN", raising=False)
+    yield
+    monkeypatch.delenv("FIESTABOARD_AUTH_ENABLED", raising=False)
+
+
+@pytest.fixture
+def signed_in(client, enabled):
+    r = client.post("/auth/setup", json={"username": "admin", "password": "Password123!"})
+    assert r.status_code in (200, 201), r.text
+    # ``/auth/setup`` returns a fresh session cookie; subsequent requests
+    # in this client will carry it.
+
+
+# --- Status ----------------------------------------------------------------
+
+
+def test_status_requires_auth(client, enabled):
+    client.post("/auth/setup", json={"username": "admin", "password": "Password123!"})
+    client.cookies.clear()
+    r = client.get("/auth/mcp-token")
+    assert r.status_code == 401
+
+
+def test_status_reports_none_when_nothing_set(signed_in, client):
+    r = client.get("/auth/mcp-token")
+    assert r.status_code == 200
+    body = r.json()
+    assert body == {"configured": False, "source": "none"}
+
+
+def test_status_reports_env_when_env_var_set(signed_in, client, monkeypatch):
+    monkeypatch.setenv("FIESTABOARD_MCP_TOKEN", "from-env")
+    r = client.get("/auth/mcp-token")
+    body = r.json()
+    assert body == {"configured": True, "source": "env"}
+
+
+def test_status_reports_stored_when_rotated(signed_in, client):
+    rotate = client.post("/auth/mcp-token")
+    assert rotate.status_code == 201
+    r = client.get("/auth/mcp-token")
+    assert r.json() == {"configured": True, "source": "stored"}
+
+
+# --- Rotate ---------------------------------------------------------------
+
+
+def test_rotate_requires_auth(client, enabled):
+    client.post("/auth/setup", json={"username": "admin", "password": "Password123!"})
+    client.cookies.clear()
+    r = client.post("/auth/mcp-token")
+    assert r.status_code == 401
+
+
+def test_rotate_returns_token_and_persists(signed_in, client):
+    r = client.post("/auth/mcp-token")
+    assert r.status_code == 201
+    token = r.json()["token"]
+    # secrets.token_urlsafe(32) -> 43 chars of url-safe base64. Defensive
+    # bound check rather than exact length so we don't break if the helper
+    # gets bumped to a longer entropy size.
+    assert len(token) >= 32
+    # Status now reports it's stored.
+    s = client.get("/auth/mcp-token")
+    assert s.json() == {"configured": True, "source": "stored"}
+
+
+def test_rotate_replaces_previous_token(signed_in, client):
+    a = client.post("/auth/mcp-token").json()["token"]
+    b = client.post("/auth/mcp-token").json()["token"]
+    assert a != b
+    # The current stored token is the second one; the first must no
+    # longer authenticate against /mcp/.
+    r_old = client.get("/mcp/", headers={"Authorization": f"Bearer {a}"})
+    assert r_old.status_code == 401
+    r_new = client.get("/mcp/", headers={"Authorization": f"Bearer {b}"})
+    assert r_new.status_code != 401
+
+
+def test_rotate_blocked_when_env_var_pins_the_token(signed_in, client, monkeypatch):
+    monkeypatch.setenv("FIESTABOARD_MCP_TOKEN", "pinned-by-ops")
+    r = client.post("/auth/mcp-token")
+    assert r.status_code == 409
+    # And the env-managed token still wins.
+    assert client.get("/auth/mcp-token").json()["source"] == "env"
+
+
+# --- End-to-end: rotated token actually authenticates ---------------------
+
+
+def test_rotated_token_passes_mcp_middleware(signed_in, client):
+    token = client.post("/auth/mcp-token").json()["token"]
+    # Fresh client without the admin session cookie so we're exercising
+    # the bearer path, not riding on the rotation call's cookie.
+    bare = TestClient(app, raise_server_exceptions=False)
+    r = bare.get("/mcp/", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code != 401
+    r_bad = bare.get("/mcp/", headers={"Authorization": "Bearer not-it"})
+    assert r_bad.status_code == 401
+    assert r_bad.headers.get("WWW-Authenticate", "").startswith("Bearer")
+
+
+# --- Clear ----------------------------------------------------------------
+
+
+def test_clear_requires_auth(client, enabled):
+    client.post("/auth/setup", json={"username": "admin", "password": "Password123!"})
+    client.cookies.clear()
+    r = client.delete("/auth/mcp-token")
+    assert r.status_code == 401
+
+
+def test_clear_revokes_stored_token(signed_in, client):
+    token = client.post("/auth/mcp-token").json()["token"]
+    r = client.delete("/auth/mcp-token")
+    assert r.status_code == 200
+    assert client.get("/auth/mcp-token").json() == {"configured": False, "source": "none"}
+    # Old token no longer accepted.
+    bare = TestClient(app, raise_server_exceptions=False)
+    r2 = bare.get("/mcp/", headers={"Authorization": f"Bearer {token}"})
+    assert r2.status_code == 401
+
+
+def test_clear_blocked_when_env_var_pins_the_token(signed_in, client, monkeypatch):
+    monkeypatch.setenv("FIESTABOARD_MCP_TOKEN", "pinned-by-ops")
+    r = client.delete("/auth/mcp-token")
+    assert r.status_code == 409

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -40,6 +40,7 @@ import { DisplaySettings } from "@/components/settings/display-settings";
 import { InstanceNameCard } from "@/components/settings/instance-name";
 import { LanguageSettingsCard } from "@/components/settings/language-settings";
 import { LocationSettingsCard } from "@/components/settings/location-settings";
+import { McpSettings } from "@/components/settings/mcp-settings";
 import { MqttSettingsCard } from "@/components/settings/mqtt-settings";
 import { NetworkSettings } from "@/components/settings/network-settings";
 import { PluginSettingsCard } from "@/components/settings/plugin-settings";
@@ -222,6 +223,7 @@ export default function SettingsPage() {
 
         <TabsContent value="integrations" className="mt-0 space-y-6">
           <AiSettings />
+          <McpSettings />
           <MqttSettingsCard />
           <PluginSettingsCard />
         </TabsContent>

--- a/web/src/components/settings/mcp-settings.tsx
+++ b/web/src/components/settings/mcp-settings.tsx
@@ -1,0 +1,386 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  AlertTriangle,
+  Bot,
+  Check,
+  Copy,
+  KeyRound,
+  Loader2,
+  RefreshCw,
+  Trash2,
+} from "lucide-react";
+import { toast } from "sonner";
+
+import { api } from "@/lib/api";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Skeleton } from "@/components/ui/skeleton";
+
+/**
+ * Build the Claude Desktop config snippet the user will paste into
+ * ``~/Library/Application Support/Claude/claude_desktop_config.json``.
+ * We compute the URL from the browser's own ``window.location`` so the
+ * snippet matches however the user is currently reaching FiestaBoard
+ * (``localhost``, ``fiestaboard.local``, a LAN IP, etc.).
+ */
+function buildClaudeDesktopConfig(token: string): string {
+  let host = "fiestaboard.local:4420";
+  if (typeof window !== "undefined" && window.location?.host) {
+    host = window.location.host;
+  }
+  const proto =
+    typeof window !== "undefined" && window.location?.protocol === "https:"
+      ? "https"
+      : "http";
+  const config = {
+    mcpServers: {
+      fiestaboard: {
+        type: "http",
+        url: `${proto}://${host}/api/mcp`,
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    },
+  };
+  return JSON.stringify(config, null, 2);
+}
+
+export function McpSettings() {
+  const queryClient = useQueryClient();
+  const [revealedToken, setRevealedToken] = useState<string | null>(null);
+  const [confirmingRotate, setConfirmingRotate] = useState(false);
+  const [confirmingClear, setConfirmingClear] = useState(false);
+  const [copied, setCopied] = useState<"token" | "config" | null>(null);
+
+  const { data: status, isLoading } = useQuery({
+    queryKey: ["mcp-token-status"],
+    queryFn: () => api.getMcpTokenStatus(),
+  });
+
+  const rotateMutation = useMutation({
+    mutationFn: () => api.rotateMcpToken(),
+    onSuccess: ({ token }) => {
+      setRevealedToken(token);
+      setConfirmingRotate(false);
+      queryClient.invalidateQueries({ queryKey: ["mcp-token-status"] });
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+      setConfirmingRotate(false);
+    },
+  });
+
+  const clearMutation = useMutation({
+    mutationFn: () => api.clearMcpToken(),
+    onSuccess: () => {
+      toast.success("MCP token revoked");
+      setConfirmingClear(false);
+      queryClient.invalidateQueries({ queryKey: ["mcp-token-status"] });
+    },
+    onError: (err: Error) => {
+      toast.error(err.message);
+      setConfirmingClear(false);
+    },
+  });
+
+  const handleCopy = async (text: string, which: "token" | "config") => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(which);
+      setTimeout(() => setCopied(null), 1500);
+    } catch {
+      toast.error("Couldn't copy to clipboard");
+    }
+  };
+
+  const configSnippet = useMemo(
+    () => (revealedToken ? buildClaudeDesktopConfig(revealedToken) : ""),
+    [revealedToken],
+  );
+
+  if (isLoading || !status) {
+    return (
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-5 w-44" />
+          <Skeleton className="h-4 w-72" />
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  const isPinnedByEnv = status.source === "env";
+  const hasToken = status.configured;
+  const rotateLabel = hasToken ? "Rotate token" : "Generate token";
+
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Bot className="h-4 w-4" />
+            MCP / external clients
+          </CardTitle>
+          <CardDescription>
+            A pre-shared token that lets Claude Desktop, Claude Code, and other MCP
+            clients talk to this FiestaBoard. The token authenticates as a single
+            principal — scoped to the <code className="font-mono text-xs">/api/mcp</code>{" "}
+            endpoint only — so it can&apos;t edit pages or other settings.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium">Status:</span>
+            {isPinnedByEnv ? (
+              <Badge variant="secondary" className="gap-1.5">
+                <KeyRound className="h-3 w-3" />
+                Pinned by FIESTABOARD_MCP_TOKEN
+              </Badge>
+            ) : hasToken ? (
+              <Badge variant="default" className="gap-1.5 bg-emerald-600 hover:bg-emerald-600">
+                <Check className="h-3 w-3" />
+                Configured
+              </Badge>
+            ) : (
+              <Badge variant="outline">Not configured</Badge>
+            )}
+          </div>
+
+          {isPinnedByEnv && (
+            <p className="text-sm text-muted-foreground">
+              The active token is set by the{" "}
+              <code className="font-mono text-xs">FIESTABOARD_MCP_TOKEN</code> environment
+              variable. Unset it in your{" "}
+              <code className="font-mono text-xs">.env</code> and restart the container
+              before managing the token from this UI.
+            </p>
+          )}
+
+          {!isPinnedByEnv && !hasToken && (
+            <p className="text-sm text-muted-foreground">
+              No token is configured. External MCP clients will fall back to cookie auth,
+              which Claude Desktop / Claude Code don&apos;t support — they&apos;ll fail
+              registration with an opaque error. Generate a token to unblock them.
+            </p>
+          )}
+
+          {!isPinnedByEnv && hasToken && (
+            <p className="text-sm text-muted-foreground">
+              A token is configured and active. Rotate it to invalidate the previous one
+              (any client still using the old token will start receiving 401), or revoke
+              it entirely to fall back to cookie-only auth.
+            </p>
+          )}
+
+          {!isPinnedByEnv && (
+            <div className="flex flex-wrap gap-2">
+              <Button
+                onClick={() => setConfirmingRotate(true)}
+                disabled={rotateMutation.isPending}
+                variant="default"
+                className="gap-2"
+              >
+                {rotateMutation.isPending ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <RefreshCw className="h-4 w-4" />
+                )}
+                {rotateLabel}
+              </Button>
+              {hasToken && (
+                <Button
+                  onClick={() => setConfirmingClear(true)}
+                  disabled={clearMutation.isPending}
+                  variant="outline"
+                  className="gap-2"
+                >
+                  {clearMutation.isPending ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Trash2 className="h-4 w-4" />
+                  )}
+                  Revoke token
+                </Button>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* "Are you sure you want to rotate?" — only shown when there's an
+          existing token whose rotation would invalidate something. */}
+      <AlertDialog
+        open={confirmingRotate}
+        onOpenChange={(open) => !open && setConfirmingRotate(false)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {hasToken ? "Rotate MCP token?" : "Generate MCP token?"}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {hasToken
+                ? "Any client still using the previous token will be denied with a 401 + Bearer challenge on its next request. You'll see the new token once — store it somewhere safe (it's not readable from the UI again)."
+                : "You'll see the token once — store it somewhere safe (it's not readable from the UI again). External MCP clients will use it to authenticate to /api/mcp."}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={rotateMutation.isPending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => rotateMutation.mutate()}
+              disabled={rotateMutation.isPending}
+            >
+              {rotateMutation.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : null}
+              {hasToken ? "Rotate" : "Generate"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog
+        open={confirmingClear}
+        onOpenChange={(open) => !open && setConfirmingClear(false)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Revoke MCP token?</AlertDialogTitle>
+            <AlertDialogDescription>
+              External MCP clients will start receiving 401 on their next request. You
+              can always generate a new token later.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={clearMutation.isPending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => clearMutation.mutate()}
+              disabled={clearMutation.isPending}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {clearMutation.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : null}
+              Revoke
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Reveal-once dialog. Stays open until the user dismisses it, so we
+          don't auto-close on an accidental click outside. */}
+      <Dialog
+        open={revealedToken !== null}
+        onOpenChange={(open) => {
+          if (!open) setRevealedToken(null);
+        }}
+      >
+        <DialogContent className="sm:max-w-xl">
+          <DialogHeader>
+            <DialogTitle>Save this token</DialogTitle>
+            <DialogDescription className="flex items-start gap-2">
+              <AlertTriangle className="h-4 w-4 mt-0.5 flex-shrink-0 text-amber-500" />
+              <span>
+                FiestaBoard stores only what&apos;s needed to verify future requests —
+                this is the only time the plaintext value is shown. Copy it into your MCP
+                client now.
+              </span>
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4">
+            <div>
+              <div className="mb-1.5 flex items-center justify-between">
+                <span className="text-sm font-medium">Token</span>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => revealedToken && handleCopy(revealedToken, "token")}
+                  className="h-7 gap-1.5"
+                >
+                  {copied === "token" ? (
+                    <Check className="h-3.5 w-3.5" />
+                  ) : (
+                    <Copy className="h-3.5 w-3.5" />
+                  )}
+                  {copied === "token" ? "Copied" : "Copy"}
+                </Button>
+              </div>
+              <code className="block w-full break-all rounded bg-muted px-3 py-2 font-mono text-xs">
+                {revealedToken}
+              </code>
+            </div>
+
+            <div>
+              <div className="mb-1.5 flex items-center justify-between">
+                <span className="text-sm font-medium">
+                  Claude Desktop config snippet
+                </span>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => handleCopy(configSnippet, "config")}
+                  className="h-7 gap-1.5"
+                >
+                  {copied === "config" ? (
+                    <Check className="h-3.5 w-3.5" />
+                  ) : (
+                    <Copy className="h-3.5 w-3.5" />
+                  )}
+                  {copied === "config" ? "Copied" : "Copy"}
+                </Button>
+              </div>
+              <p className="mb-2 text-xs text-muted-foreground">
+                Paste this into{" "}
+                <code className="font-mono">
+                  ~/Library/Application Support/Claude/claude_desktop_config.json
+                </code>
+                , merging with anything that&apos;s already there, then fully quit and
+                relaunch Claude Desktop (⌘Q — closing the window isn&apos;t enough).
+              </p>
+              <pre className="max-h-64 overflow-auto rounded bg-muted px-3 py-2 font-mono text-xs">
+                {configSnippet}
+              </pre>
+            </div>
+
+            <p className="text-xs text-muted-foreground">
+              <strong>Claude Code (CLI):</strong>{" "}
+              <code className="font-mono">
+                claude mcp add fiestaboard --transport http --url{" "}
+                {typeof window !== "undefined"
+                  ? `${window.location.protocol}//${window.location.host}`
+                  : "http://fiestaboard.local:4420"}
+                /api/mcp --header &quot;Authorization: Bearer &lt;token&gt;&quot;
+              </code>
+            </p>
+          </div>
+
+          <DialogFooter>
+            <Button onClick={() => setRevealedToken(null)}>I&apos;ve saved it</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1203,6 +1203,17 @@ export type AuthStatusResponse = {
   first_run: boolean;
 };
 
+/**
+ * Status of the pre-shared bearer token used by external MCP clients.
+ * ``source: "env"`` means ``FIESTABOARD_MCP_TOKEN`` is pinned by ops and
+ * the UI must hide rotate/clear actions; ``"stored"`` means it's
+ * UI-managed; ``"none"`` means no token is configured (cookie auth only).
+ */
+export type McpTokenStatus = {
+  configured: boolean;
+  source: "env" | "stored" | "none";
+};
+
 // ── WiFi (FiestaPi only) ──────────────────────────────────────────────────
 export interface WifiCapability {
   available: boolean;
@@ -2092,6 +2103,24 @@ export const api = {
     }
     return (await res.json()) as { status: string };
   },
+
+  // ── MCP bearer token (admin only) ───────────────────────────────────────
+  // Lets external MCP clients (Claude Desktop, Claude Code) connect by
+  // pasting a one-time-shown token into their connector config instead
+  // of editing FIESTABOARD_MCP_TOKEN in .env. See src/auth/routes.py.
+
+  getMcpTokenStatus: () => fetchApi<McpTokenStatus>("/auth/mcp-token"),
+
+  /**
+   * Generate a fresh token, persist it server-side, and return the
+   * plaintext value ONCE. The caller is responsible for showing it to
+   * the user immediately — it can't be read back after this response.
+   */
+  rotateMcpToken: () =>
+    fetchApi<{ token: string }>("/auth/mcp-token", { method: "POST" }),
+
+  clearMcpToken: () =>
+    fetchApi<{ status: string }>("/auth/mcp-token", { method: "DELETE" }),
 
   // ── WiFi (FiestaPi only) ────────────────────────────────────────────────
   getWifiCapability: () => fetchApi<WifiCapability>("/network/wifi/capability"),


### PR DESCRIPTION
## Summary

Re-lands PR #850, which was merged into `feat-mcp-bearer-token` *after* that branch had already shipped to `main` (PR #849), so the UI work never made it onto `main`. This brings the MCP token Settings UI to `main` as a clean cherry-pick of `fc290c01` — no conflicts.

## What lands

**Backend** (`src/auth/`)
- `auth.json`-persisted MCP token (env var still wins for ops pinning)
- Admin-only routes: `GET / POST / DELETE /auth/mcp-token`
- `mcp_token_source()` → `"env" | "stored" | "none"` for the UI badge

**Frontend** (`web/src/components/settings/mcp-settings.tsx`)
- New `McpSettings` card in Settings → Integrations alongside AI / MQTT / Plugins
- Status badge: *Pinned by FIESTABOARD_MCP_TOKEN* / *Configured* / *Not configured*
- Rotate / revoke with `AlertDialog` confirmation
- On rotate, a reveal-once `Dialog` shows the plaintext token plus:
  - A ready-to-paste **Claude Desktop** JSON config snippet
  - A **Claude Code CLI** one-liner
  - URLs are built from `window.location` so they match however the user reaches the board
  - Both have copy buttons

**Tests** (`tests/test_auth_mcp_token_routes.py`)
- 12 new tests covering status / rotate / clear, auth gating, env-var precedence, and an end-to-end auth check against `/mcp/`

## Test plan

- [x] `pytest tests/test_auth_mcp_token_routes.py` — 12 / 12 pass in container
- [x] Broader auth+mcp suite — 187 / 187 pass
- [ ] Manual: Settings → Integrations → Generate, confirm reveal-once dialog shows snippets, copy buttons work
- [ ] Manual: Rotate while `FIESTABOARD_MCP_TOKEN` is set → returns 409, UI hides controls
- [ ] Manual: Use copied Claude Code CLI snippet to connect a real MCP client

🤖 Generated with [Claude Code](https://claude.com/claude-code)