### PR TITLE
docs(mcp): correct local-client setup walkthrough + fix Desktop snippet

### DIFF
--- a/docs/setup/MCP_CLIENTS.md
+++ b/docs/setup/MCP_CLIENTS.md
@@ -1,0 +1,153 @@
+# MCP clients
+
+FiestaBoard exposes a [Model Context Protocol](https://modelcontextprotocol.io)
+server at `/api/mcp/`, so an AI assistant like Claude Desktop or Claude Code
+can read your pages, render template previews, configure plugins, and manage
+schedules through conversation rather than the web UI.
+
+This page walks through wiring each client up to a self-hosted FiestaBoard.
+
+> **Where to get your token:** **Settings → Integrations → MCP / external
+> clients → Generate token** (or **Rotate token**). The plaintext value is
+> shown exactly once — copy it into your client config immediately.
+
+## Why local hosting makes this awkward
+
+The MCP ecosystem is converging on three transports — stdio, HTTP, and
+SSE — and three auth styles — bearer tokens, OAuth 2.1 with dynamic client
+registration, and "trust the parent process." Different clients support
+different combinations:
+
+| Client | Transport | Auth it expects | Works against FiestaBoard? |
+|---|---|---|---|
+| Claude Desktop | stdio only | parent-process trust | ✅ via the `mcp-remote` proxy |
+| Claude Code (CLI) | HTTP, stdio, SSE | bearer tokens, OAuth | ✅ HTTP + bearer, directly |
+| claude.ai web (Connectors) | HTTP | OAuth 2.1 + DCR + public HTTPS | ❌ requires public hosting |
+| ChatGPT (Apps SDK) | HTTP | OAuth 2.1 + DCR + public HTTPS | ❌ requires public hosting |
+
+FiestaBoard is a **LAN appliance** — no public hostname, no TLS cert, no
+OAuth authorization server. That eliminates the web-based clients
+automatically. Desktop apps can still reach it because they run on the same
+network as you, but they need a small shim to bridge their stdio assumption
+to FiestaBoard's HTTP endpoint.
+
+That shim is [`mcp-remote`](https://www.npmjs.com/package/mcp-remote), a
+tiny Node program that pretends to be a stdio MCP server to Desktop and
+forwards everything as HTTP to FiestaBoard.
+
+## Claude Desktop
+
+**Prerequisites:** Node 18 or newer, with `npx` reachable from Claude
+Desktop's launch environment. On macOS with Homebrew Node that usually
+"just works"; with `nvm` you may need to use the absolute path (see
+[Troubleshooting](#troubleshooting)).
+
+1. In FiestaBoard's web UI, open **Settings → Integrations → MCP / external
+   clients** and click **Generate token** (or **Rotate token**). Keep the
+   reveal dialog open — it shows the token and a Desktop config snippet.
+2. Open `~/Library/Application Support/Claude/claude_desktop_config.json`
+   (create it if it doesn't exist) and merge in the `fiestaboard` entry
+   from the reveal dialog. It looks like this:
+
+   ```json
+   {
+     "mcpServers": {
+       "fiestaboard": {
+         "command": "npx",
+         "args": [
+           "-y",
+           "mcp-remote",
+           "http://fiestaboard.local:4420/api/mcp/",
+           "--allow-http",
+           "--header",
+           "Authorization: Bearer <YOUR_TOKEN>"
+         ]
+       }
+     }
+   }
+   ```
+
+3. **Fully quit** Claude Desktop (⌘Q — closing the window isn't enough)
+   and relaunch. The `fiestaboard` server should appear under the MCP
+   indicator with tools available.
+
+### What's going on under the hood
+
+- Claude Desktop's `mcpServers` config only accepts stdio entries (a
+  `command` plus `args`). It does not honour `"type": "http"`,
+  `"url"`, or `"headers"` — if you try those, Desktop will pop a "Some
+  MCP servers could not be loaded" dialog and skip the entry.
+- `npx -y mcp-remote ...` downloads and runs the proxy on first launch,
+  then caches it. It speaks stdio to Desktop and HTTP to FiestaBoard.
+- `--allow-http` is mandatory because `mcp-remote` refuses plaintext
+  targets by default. We're on a LAN, so http is fine — but the flag
+  has to be explicit.
+- The **trailing slash** on the URL is load-bearing. Hitting
+  `/api/mcp` triggers a FastAPI 307 redirect to `/api/mcp/` that
+  rewrites the Location header to drop the `:4420` port. `curl` won't
+  follow the redirect by default; Node's `fetch` does, then times out
+  on port 80. Always end the URL with `/`.
+
+## Claude Code (CLI)
+
+Claude Code speaks HTTP and bearer tokens directly, so no proxy is needed:
+
+```bash
+claude mcp add fiestaboard --transport http \
+    --url http://fiestaboard.local:4420/api/mcp/ \
+    --header "Authorization: Bearer <YOUR_TOKEN>"
+```
+
+Verify with `claude mcp list`. Inside a Claude Code session, the
+`fiestaboard` server's tools (`list_pages`, `render_page_preview`, etc.)
+become callable just like any built-in tool.
+
+## claude.ai web — not supported
+
+The Connectors flow at **claude.ai → Settings → Connectors → Add custom
+connector** is for *public* MCP servers. It performs OAuth 2.1 dynamic
+client registration against `/.well-known/oauth-protected-resource` and
+`/.well-known/oauth-authorization-server`, neither of which FiestaBoard
+exposes, and it requires HTTPS with a publicly-trusted certificate.
+
+If you add a LAN URL there, you'll see:
+
+> Couldn't register with FiestaBoard's sign-in service. You can try
+> again, or add an OAuth Client ID in the connector settings.
+
+There is no workaround short of putting FiestaBoard behind a public
+HTTPS reverse proxy *and* implementing an OAuth authorization server.
+That's well out of scope for a home LED display. **Use Claude Desktop
+or Claude Code instead.**
+
+## Troubleshooting
+
+**"Some MCP servers could not be loaded… skipped: fiestaboard"** — your
+`claude_desktop_config.json` entry is using the HTTP form (`"type":
+"http"`, `"url"`, `"headers"`). Desktop rejects that. Switch to the
+`mcp-remote` stdio form shown above.
+
+**`Connection error: fetch failed … ETIMEDOUT`** in the Desktop MCP
+log — almost always the missing trailing slash on the URL. Use
+`/api/mcp/`, not `/api/mcp`.
+
+**`command not found: npx`** in the Desktop MCP log — Claude Desktop
+launches from `launchd` and may not inherit your shell's PATH. Replace
+`"npx"` in the config with the absolute path from `which npx` (e.g.
+`/opt/homebrew/bin/npx` on Apple Silicon Homebrew). `nvm`-managed Node
+installs put `npx` under `~/.nvm/versions/node/<version>/bin/npx`,
+which changes on every upgrade — installing Node via Homebrew (`brew
+install node`) is more stable for this use case.
+
+**`401 Unauthorized`** — the token is wrong or was rotated. Generate a
+new one in **Settings → Integrations** and update the `Authorization`
+header.
+
+**Tools call succeeds but the page-preview image doesn't render
+inline** — that's expected for now. Claude Desktop renders text and
+images from tool results inline, but doesn't iframe HTML resources.
+FiestaBoard exposes a self-contained HTML preview at the MCP resource
+`fiestaboard://page/{page_id}/preview.html`, which renders inline in
+[MCP-UI](https://mcpui.dev)-aware clients but not in Desktop today.
+For now, use `render_page_preview()` for an ASCII view or open the
+FiestaBoard web UI for the pixel preview.

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -15,23 +15,34 @@ the value as ``Authorization: Bearer <token>``. A 401 from ``/mcp``
 includes ``WWW-Authenticate: Bearer realm="FiestaBoard MCP"`` so MCP
 clients send a token rather than attempting OAuth registration.
 
-Connection example for Claude Desktop (``claude_desktop_config.json``):
+Connection example for Claude Desktop (``claude_desktop_config.json``).
+Desktop only supports stdio servers, so we proxy through ``mcp-remote``.
+The trailing slash on the URL avoids a 307 from FastAPI that drops the port::
+
     {
         "mcpServers": {
             "fiestaboard": {
-                "type": "http",
-                "url": "http://fiestaboard.local:4420/api/mcp",
-                "headers": {
-                    "Authorization": "Bearer <FIESTABOARD_MCP_TOKEN>"
-                }
+                "command": "npx",
+                "args": [
+                    "-y",
+                    "mcp-remote",
+                    "http://fiestaboard.local:4420/api/mcp/",
+                    "--allow-http",
+                    "--header",
+                    "Authorization: Bearer <FIESTABOARD_MCP_TOKEN>"
+                ]
             }
         }
     }
 
-Connection example for Claude Code:
-    /mcp add fiestaboard --transport http \\
-        --url http://localhost:4420/api/mcp \\
+Connection example for Claude Code (talks HTTP directly, no proxy)::
+
+    claude mcp add fiestaboard --transport http \\
+        --url http://localhost:4420/api/mcp/ \\
         --header "Authorization: Bearer <FIESTABOARD_MCP_TOKEN>"
+
+See ``docs/setup/MCP_CLIENTS.md`` for the full setup walkthrough,
+including why claude.ai web Connectors can't reach a LAN host.
 """
 
 from __future__ import annotations

--- a/web/src/components/settings/mcp-settings.tsx
+++ b/web/src/components/settings/mcp-settings.tsx
@@ -41,9 +41,17 @@ import { Skeleton } from "@/components/ui/skeleton";
 /**
  * Build the Claude Desktop config snippet the user will paste into
  * ``~/Library/Application Support/Claude/claude_desktop_config.json``.
- * We compute the URL from the browser's own ``window.location`` so the
- * snippet matches however the user is currently reaching FiestaBoard
- * (``localhost``, ``fiestaboard.local``, a LAN IP, etc.).
+ *
+ * Claude Desktop's ``mcpServers`` only accepts **stdio** entries, so for a
+ * remote HTTP MCP server like FiestaBoard we wrap it with the ``mcp-remote``
+ * Node proxy. The trailing slash on the URL matters: hitting ``/api/mcp``
+ * triggers a FastAPI 307 to ``/api/mcp/`` that drops the ``:4420`` port,
+ * which Node's fetch follows and times out on. ``--allow-http`` is required
+ * because the proxy refuses plaintext targets by default.
+ *
+ * URL host/protocol come from ``window.location`` so the snippet matches
+ * however the user is currently reaching FiestaBoard (``localhost``,
+ * ``fiestaboard.local``, a LAN IP, etc.).
  */
 function buildClaudeDesktopConfig(token: string): string {
   let host = "fiestaboard.local:4420";
@@ -54,12 +62,15 @@ function buildClaudeDesktopConfig(token: string): string {
     typeof window !== "undefined" && window.location?.protocol === "https:"
       ? "https"
       : "http";
+  const url = `${proto}://${host}/api/mcp/`;
+  const args = ["-y", "mcp-remote", url];
+  if (proto === "http") args.push("--allow-http");
+  args.push("--header", `Authorization: Bearer ${token}`);
   const config = {
     mcpServers: {
       fiestaboard: {
-        type: "http",
-        url: `${proto}://${host}/api/mcp`,
-        headers: { Authorization: `Bearer ${token}` },
+        command: "npx",
+        args,
       },
     },
   };
@@ -146,7 +157,18 @@ export function McpSettings() {
             A pre-shared token that lets Claude Desktop, Claude Code, and other MCP
             clients talk to this FiestaBoard. The token authenticates as a single
             principal — scoped to the <code className="font-mono text-xs">/api/mcp</code>{" "}
-            endpoint only — so it can&apos;t edit pages or other settings.
+            endpoint only — so it can&apos;t edit pages or other settings. See{" "}
+            <a
+              href="https://github.com/Fiestaboard/FiestaBoard/blob/main/docs/setup/MCP_CLIENTS.md"
+              target="_blank"
+              rel="noreferrer"
+              className="underline underline-offset-2"
+            >
+              MCP client setup
+            </a>{" "}
+            for client-specific quirks (Desktop needs an stdio proxy; claude.ai web
+            Connectors require public HTTPS and OAuth, so they won&apos;t reach a LAN
+            host).
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
@@ -358,6 +380,22 @@ export function McpSettings() {
                 </code>
                 , merging with anything that&apos;s already there, then fully quit and
                 relaunch Claude Desktop (⌘Q — closing the window isn&apos;t enough).
+                Claude Desktop only supports stdio MCP servers, so this snippet shells
+                out to{" "}
+                <a
+                  href="https://www.npmjs.com/package/mcp-remote"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="underline underline-offset-2"
+                >
+                  mcp-remote
+                </a>{" "}
+                via <code className="font-mono">npx</code> as a proxy — Node 18+ must
+                be installed and <code className="font-mono">npx</code> reachable from
+                Claude Desktop&apos;s PATH. If it errors with{" "}
+                <code className="font-mono">command not found</code>, replace{" "}
+                <code className="font-mono">&quot;npx&quot;</code> with the absolute
+                path from <code className="font-mono">which npx</code>.
               </p>
               <pre className="max-h-64 overflow-auto rounded bg-muted px-3 py-2 font-mono text-xs">
                 {configSnippet}
@@ -365,14 +403,21 @@ export function McpSettings() {
             </div>
 
             <p className="text-xs text-muted-foreground">
-              <strong>Claude Code (CLI):</strong>{" "}
+              <strong>Claude Code (CLI):</strong> talks HTTP directly — no proxy needed.
+              <br />
               <code className="font-mono">
                 claude mcp add fiestaboard --transport http --url{" "}
                 {typeof window !== "undefined"
                   ? `${window.location.protocol}//${window.location.host}`
                   : "http://fiestaboard.local:4420"}
-                /api/mcp --header &quot;Authorization: Bearer &lt;token&gt;&quot;
+                /api/mcp/ --header &quot;Authorization: Bearer &lt;token&gt;&quot;
               </code>
+            </p>
+            <p className="text-xs text-muted-foreground">
+              <strong>claude.ai web (Connectors):</strong> not supported for self-hosted
+              FiestaBoard. The Connectors flow requires a public HTTPS URL and OAuth
+              2.1 dynamic client registration, neither of which a LAN host can provide.
+              Use Desktop or Code instead.
             </p>
           </div>
 


### PR DESCRIPTION
## Summary

- Switches the **Claude Desktop config snippet** generated by Settings → Integrations from the broken HTTP form (`"type": "http"`, `"url"`, `"headers"`) to the stdio-via-`mcp-remote` form Desktop actually accepts. Desktop was popping *"Some MCP servers could not be loaded… skipped: fiestaboard"* on launch with the old snippet.
- Adds a trailing `/` on the generated MCP URL so Node's `fetch` (inside `mcp-remote`) doesn't follow FastAPI's 307 redirect — that redirect drops the `:4420` port when proxied through nginx and the client times out on port 80.
- Rewrites the helper copy in `mcp-settings.tsx` (`CardDescription`, reveal-dialog instructions, Claude Code line) to reflect what each client actually supports, and adds an explicit "not supported" note for claude.ai web Connectors (they need public HTTPS + OAuth 2.1 DCR — a LAN host can't satisfy either).
- Adds `docs/setup/MCP_CLIENTS.md` with the full walkthrough for Claude Desktop, Claude Code, and why the web Connectors flow won't work for self-hosted FiestaBoard. Includes a troubleshooting section for the failure modes hit during testing: `ETIMEDOUT` (missing trailing slash), `command not found: npx` (Desktop PATH), `401 Unauthorized` (rotated token), and the visual-HTML-preview rendering caveat (Desktop doesn't iframe HTML MCP resources).
- Updates the stale config example in `src/mcp_server.py`'s module docstring to match the new snippet.

## Out of scope (separate issue)

The underlying `/api/mcp` → `/api/mcp/` redirect that drops the port is an nginx + FastAPI proxy-headers interaction worth fixing server-side (either by setting `redirect_slashes=False` on the MCP mount or by forwarding `X-Forwarded-Port`). Leaving for a focused follow-up; users get a working setup via the trailing slash now.

## Test plan

- [ ] Generate a fresh token in Settings → Integrations and verify the copied snippet uses `"command": "npx"` with `mcp-remote` args and a URL ending in `/api/mcp/`.
- [ ] Paste the snippet into `~/Library/Application Support/Claude/claude_desktop_config.json`, ⌘Q + relaunch Claude Desktop, confirm the `fiestaboard` server appears with tools (no "could not be loaded" dialog).
- [ ] Run `claude mcp add fiestaboard --transport http --url http://<host>:4420/api/mcp/ --header "Authorization: Bearer <token>"` and confirm `claude mcp list` shows it healthy.
- [ ] Read `docs/setup/MCP_CLIENTS.md` end-to-end and confirm the troubleshooting entries match the actual error strings users will see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)