### PR TITLE
feat: add Pride Month branding for June

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -167,6 +167,13 @@
   --fiesta-red: #c97a72;
   --fiesta-orange: #c99662;
   --fiesta-purple: #9b7bb0;
+  /* Page icon gradient stops — 6 vars so pride month can expand to a full rainbow */
+  --icon-g1: var(--fiesta-red);
+  --icon-g2: var(--fiesta-orange);
+  --icon-g3: var(--fiesta-orange);
+  --icon-g4: var(--fiesta-orange);
+  --icon-g5: var(--fiesta-purple);
+  --icon-g6: var(--fiesta-purple);
   /* Elevation - subtle card and modal shadows */
   --elevation-card: 0 1px 2px 0 rgb(0 0 0 / 0.04), 0 2px 8px -2px rgb(0 0 0 / 0.06);
   --elevation-card-hover: 0 2px 8px -2px rgb(0 0 0 / 0.08), 0 4px 16px -4px rgb(0 0 0 / 0.06);
@@ -231,6 +238,39 @@
   --elevation-card: 0 1px 3px 0 rgb(0 0 0 / 0.20), 0 0 0 1px oklch(1 0 0 / 6%);
   --elevation-card-hover: 0 2px 8px -2px rgb(0 0 0 / 0.30), 0 0 0 1px oklch(1 0 0 / 10%);
   --elevation-modal: 0 8px 24px -4px rgb(0 0 0 / 0.25), 0 4px 8px -4px rgb(0 0 0 / 0.15);
+}
+
+/* Pride month (June) — rainbow page icon gradient + logo text + sidebar */
+.pride-month {
+  --icon-g1: #E40303;
+  --icon-g2: #FF8C00;
+  --icon-g3: #FFED00;
+  --icon-g4: #008026;
+  --icon-g5: #004DFF;
+  --icon-g6: #750787;
+}
+
+.pride-month .logo-fiesta-text {
+  background: linear-gradient(90deg, #E40303, #FF8C00, #FFED00, #008026, #004DFF, #750787);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+/* Sidebar gradient: 3 pride colors spread wide across the spectrum */
+.pride-month .sidebar-gradient,
+.pride-month .sidebar-gradient-horizontal {
+  --sidebar-fiesta-red: #E40303;
+  --sidebar-fiesta-orange: #FFED00;
+  --sidebar-fiesta-purple: #750787;
+}
+
+/* Dark mode sidebar: muted pride colors to stay readable against dark text */
+.pride-month.dark .sidebar-gradient,
+.pride-month.dark .sidebar-gradient-horizontal {
+  --sidebar-fiesta-red: #8a1a10;
+  --sidebar-fiesta-orange: #7a7000;
+  --sidebar-fiesta-purple: #3d1268;
 }
 
 @layer base {

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -59,9 +59,10 @@ export default async function RootLayout({
 }>) {
   const locale = await getLocale();
   const messages = await getMessages();
+  const isPrideMonth = new Date().getMonth() === 5;
 
   return (
-    <html lang={locale} suppressHydrationWarning>
+    <html lang={locale} suppressHydrationWarning className={isPrideMonth ? "pride-month" : undefined}>
       <head>
         <meta name="theme-color" content="#fafafa" media="(prefers-color-scheme: light)" />
         <meta name="theme-color" content="#0a0a0a" media="(prefers-color-scheme: dark)" />
@@ -75,9 +76,12 @@ export default async function RootLayout({
         <svg width="0" height="0" aria-hidden="true" style={{ position: 'absolute' }}>
           <defs>
             <linearGradient id="page-icon-gradient" gradientUnits="userSpaceOnUse" x1="0" y1="0" x2="24" y2="24">
-              <stop offset="0%" stopColor="var(--fiesta-red)" />
-              <stop offset="50%" stopColor="var(--fiesta-orange)" />
-              <stop offset="100%" stopColor="var(--fiesta-purple)" />
+              <stop offset="0%"   stopColor="var(--icon-g1)" />
+              <stop offset="20%"  stopColor="var(--icon-g2)" />
+              <stop offset="40%"  stopColor="var(--icon-g3)" />
+              <stop offset="60%"  stopColor="var(--icon-g4)" />
+              <stop offset="80%"  stopColor="var(--icon-g5)" />
+              <stop offset="100%" stopColor="var(--icon-g6)" />
             </linearGradient>
           </defs>
         </svg>

--- a/web/src/components/fiesta-logo.tsx
+++ b/web/src/components/fiesta-logo.tsx
@@ -16,7 +16,7 @@ export function FiestaLogo({ size = "md", className }: FiestaLogoProps) {
         className,
       )}
     >
-      <span className="font-black text-brand">
+      <span className="font-black text-brand logo-fiesta-text">
         Fiesta
       </span>
       <span className="font-light text-sidebar-foreground">


### PR DESCRIPTION
## Summary

- Adds a rainbow gradient to the **FiestaBoard logo text** ("Fiesta" portion) using CSS `background-clip: text`
- Adds a **full 6-color pride rainbow** to all page header icons via an expanded SVG `linearGradient`
- Adds a **red → yellow → violet sweep** to the navigation sidebar gradient
- All three effects are driven by a single `pride-month` class on `<html>`, set server-side in `layout.tsx` when `new Date().getMonth() === 5` (June). They activate automatically every June and revert on July 1st with no code changes needed.

## Implementation details

- `layout.tsx` — server-side month check; `pride-month` class on `<html>`; SVG gradient expanded from 3 to 6 CSS-variable-driven stops (`--icon-g1`–`--icon-g6`)
- `globals.css` — default `--icon-g*` vars replicate the existing warm gradient; `.pride-month` overrides use the 6 traditional pride flag colors; `.pride-month .logo-fiesta-text` applies the rainbow text gradient; sidebar `--sidebar-fiesta-*` vars overridden for both light and dark mode
- `fiesta-logo.tsx` — `logo-fiesta-text` class added to the "Fiesta" span so the CSS selector can target it

## Test plan

- [x] Load the app in June — confirm rainbow logo text, rainbow page icons, and red→yellow→violet sidebar
- [x] Switch between light and dark mode — confirm sidebar colors remain readable in both
- [x] Verify no visual regression outside of June (change `getMonth() === 5` to a different month locally to test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)