### PR TITLE
feat(plugin-settings): page-picker widget + numeric enum + /data 500 fix

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -5087,6 +5087,14 @@ async def set_active_page(request: dict):
             if not page:
                 raise HTTPException(status_code=404, detail=f"Page not found: {page_id}")
 
+    # Dismiss any active plugin triggers so the user's explicit page change
+    # actually sticks. Without this, a plugin re-emitting the same trigger
+    # every display loop tick (e.g. calendar_sub during a countdown window)
+    # would silently overwrite the user's selection. See issue #856.
+    if PLUGIN_SYSTEM_AVAILABLE:
+        from .triggers.service import get_trigger_service
+        get_trigger_service().dismiss_active_for_user_override()
+
     # Set the active page (stores the carousel ID or page ID as-is)
     settings_service.set_active_page_id(page_id)
 

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -7570,7 +7570,7 @@ async def get_plugin_data(plugin_id: str):
         "plugin_id": plugin_id,
         "available": result.available,
         "data": result.data,
-        "formatted": result.formatted,
+        "formatted_lines": result.formatted_lines,
         "error": result.error
     }
 

--- a/src/triggers/service.py
+++ b/src/triggers/service.py
@@ -9,7 +9,7 @@ display loop can override the normal schedule/manual page.
 
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any
 
 from ..plugins.base import PluginBase, TriggerResult
@@ -79,12 +79,37 @@ class TriggerService:
 
     def __init__(self) -> None:
         self._active_triggers: dict[str, ActiveTrigger] = {}
+        # Triggers the user has explicitly dismissed (typically via a manual
+        # "Change Page" action). Each entry maps a trigger_id to the time at
+        # which the suppression expires, after which the trigger is allowed
+        # to re-fire. Without this, a plugin re-emitting the trigger every
+        # display loop tick would silently overwrite the user's choice
+        # (see issue #856 — manual page change blocked by active trigger).
+        self._suppressed_until: dict[str, datetime] = {}
         logger.info("TriggerService initialized")
 
     # -- public API --------------------------------------------------------
 
     def activate_trigger(self, plugin_id: str, trigger: TriggerResult) -> None:
-        """Record a fired trigger (replaces any existing trigger with same id)."""
+        """Record a fired trigger (replaces any existing trigger with same id).
+
+        Triggers that were recently dismissed by the user are suppressed: a
+        plugin can keep returning the same TriggerResult every loop tick, but
+        it won't show on the board until the suppression entry expires (or
+        a new trigger fires with a different ``trigger_id``).
+        """
+        suppressed_until = self._suppressed_until.get(trigger.trigger_id)
+        if suppressed_until is not None:
+            if datetime.now() < suppressed_until:
+                logger.debug(
+                    "Trigger %s is user-suppressed until %s — not activating",
+                    trigger.trigger_id,
+                    suppressed_until.isoformat(),
+                )
+                return
+            # Suppression has lapsed; drop the entry and fall through.
+            del self._suppressed_until[trigger.trigger_id]
+
         active = ActiveTrigger(
             trigger_id=trigger.trigger_id,
             plugin_id=plugin_id,
@@ -123,16 +148,59 @@ class TriggerService:
             reverse=True,
         )
 
-    def dismiss_trigger(self, trigger_id: str) -> bool:
+    def dismiss_trigger(self, trigger_id: str, suppress: bool = False) -> bool:
         """Dismiss (remove) a trigger by its id.
+
+        Args:
+            trigger_id: The trigger to dismiss.
+            suppress: When True, also blacklist this ``trigger_id`` from
+                re-activating until its natural duration would have ended.
+                This is what makes a user's manual page change stick when a
+                plugin keeps re-emitting the same trigger.
 
         Returns True if the trigger existed and was removed.
         """
-        if trigger_id in self._active_triggers:
-            del self._active_triggers[trigger_id]
+        active = self._active_triggers.get(trigger_id)
+        if active is None:
+            return False
+
+        if suppress:
+            # Suppress for whatever was left of the trigger's natural duration,
+            # not the full duration — once that window passes, the underlying
+            # condition (e.g. "event happening soon") should be gone, and any
+            # new trigger from the plugin is a fresh signal worth honoring.
+            self._suppressed_until[trigger_id] = (
+                active.activated_at + timedelta(seconds=active.duration_seconds)
+            )
+            logger.info(
+                "Trigger dismissed + suppressed: %s (until %s)",
+                trigger_id,
+                self._suppressed_until[trigger_id].isoformat(),
+            )
+        else:
             logger.info("Trigger dismissed: %s", trigger_id)
-            return True
-        return False
+
+        del self._active_triggers[trigger_id]
+        return True
+
+    def dismiss_active_for_user_override(self) -> int:
+        """Dismiss every currently-active trigger and suppress re-firing.
+
+        Called when the user explicitly takes control of what's on the board
+        (e.g. via "Change Page" on the Home screen). Returns the number of
+        triggers dismissed.
+        """
+        # Snapshot keys first because dismiss_trigger mutates the dict.
+        ids = list(self._active_triggers.keys())
+        for tid in ids:
+            self.dismiss_trigger(tid, suppress=True)
+        if ids:
+            logger.info(
+                "Dismissed %d trigger(s) for user override; suppressed: %s",
+                len(ids),
+                ", ".join(ids),
+            )
+        return len(ids)
 
     def clear_expired(self) -> None:
         """Remove all triggers that have exceeded their duration."""
@@ -143,9 +211,17 @@ class TriggerService:
             del self._active_triggers[tid]
             logger.debug("Trigger expired and removed: %s", tid)
 
+        # Garbage-collect lapsed suppression entries so the dict doesn't
+        # grow without bound.
+        now = datetime.now()
+        lapsed = [tid for tid, until in self._suppressed_until.items() if now >= until]
+        for tid in lapsed:
+            del self._suppressed_until[tid]
+
     def clear_all(self) -> None:
         """Remove all active triggers."""
         self._active_triggers.clear()
+        self._suppressed_until.clear()
         logger.info("All triggers cleared")
 
     def check_plugin_triggers(self, plugin: PluginBase) -> None:

--- a/tests/test_api_coverage_extended.py
+++ b/tests/test_api_coverage_extended.py
@@ -374,7 +374,15 @@ class TestTrafficEndpoints:
 
 class TestPluginData:
     def test_get_plugin_data_success(self, client):
-        mock_result = Mock(available=True, data={"key": "val"}, formatted="formatted", error=None)
+        # ``formatted_lines`` mirrors the field on PluginResult after the
+        # ``/plugins/{id}/data`` endpoint was fixed to stop referencing the
+        # non-existent ``formatted`` attribute (issue surfaced as a 500).
+        mock_result = Mock(
+            available=True,
+            data={"key": "val"},
+            formatted_lines=["line1", "line2"],
+            error=None,
+        )
         mock_registry = Mock()
         mock_registry.get_plugin.return_value = Mock()
         mock_registry.is_enabled.return_value = True
@@ -383,7 +391,9 @@ class TestPluginData:
              patch("src.api_server.get_plugin_registry", return_value=mock_registry):
             resp = client.get("/plugins/test_plugin/data")
         assert resp.status_code == 200
-        assert resp.json()["available"] is True
+        body = resp.json()
+        assert body["available"] is True
+        assert body["formatted_lines"] == ["line1", "line2"]
 
     def test_get_plugin_data_not_available(self, client):
         mock_result = Mock(available=False, error="auth failed")

--- a/tests/test_plugin_triggers.py
+++ b/tests/test_plugin_triggers.py
@@ -289,6 +289,119 @@ class TestTriggerService:
         result = trigger_service.dismiss_trigger("does_not_exist")
         assert result is False
 
+    def test_dismiss_with_suppress_blocks_reactivation(self, trigger_service):
+        """Regression for #856.
+
+        A plugin that re-emits the same trigger every loop tick (e.g.
+        calendar_sub during a countdown window) used to silently overwrite
+        the user's manual "Change Page" selection. Dismissing with
+        suppress=True blacklists the trigger_id until its natural duration
+        would have ended, so subsequent activations are dropped.
+        """
+        trigger = TriggerResult(
+            triggered=True,
+            trigger_id="sticky_event",
+            message="UPCOMING",
+            priority=5,
+            duration_seconds=900,  # 15 min — typical countdown horizon
+        )
+        trigger_service.activate_trigger("calendar_sub", trigger)
+        assert trigger_service.get_active_trigger() is not None
+
+        # User clicks "Change Page" — backend dismisses + suppresses.
+        dismissed = trigger_service.dismiss_trigger("sticky_event", suppress=True)
+        assert dismissed is True
+        assert trigger_service.get_active_trigger() is None
+
+        # Plugin re-emits the same trigger on the next display loop tick.
+        # Without suppression this would re-activate and clobber the user's
+        # page choice; with suppression it must be ignored.
+        trigger_service.activate_trigger("calendar_sub", trigger)
+        assert trigger_service.get_active_trigger() is None
+
+    def test_suppression_allows_new_trigger_ids_through(self, trigger_service):
+        """Suppressing one trigger_id must not block other events from firing.
+
+        Calendar_sub uses a per-event trigger_id (different ID per upcoming
+        event), so dismissing today's standup must not block tomorrow's
+        design review.
+        """
+        first = TriggerResult(
+            triggered=True, trigger_id="event_a", message="Event A",
+            priority=5, duration_seconds=900,
+        )
+        second = TriggerResult(
+            triggered=True, trigger_id="event_b", message="Event B",
+            priority=5, duration_seconds=900,
+        )
+        trigger_service.activate_trigger("calendar_sub", first)
+        trigger_service.dismiss_trigger("event_a", suppress=True)
+
+        # A different event fires — should activate normally.
+        trigger_service.activate_trigger("calendar_sub", second)
+        active = trigger_service.get_active_trigger()
+        assert active is not None
+        assert active.trigger_id == "event_b"
+
+    def test_suppression_lapses_after_duration(self, trigger_service):
+        """Suppression entries must expire so trigger_ids can fire again later."""
+        from datetime import datetime, timedelta
+
+        trigger = TriggerResult(
+            triggered=True, trigger_id="lapsing", message="X",
+            priority=1, duration_seconds=60,
+        )
+        trigger_service.activate_trigger("plugin", trigger)
+        trigger_service.dismiss_trigger("lapsing", suppress=True)
+
+        # Rewind suppression entry into the past.
+        trigger_service._suppressed_until["lapsing"] = (
+            datetime.now() - timedelta(seconds=1)
+        )
+
+        trigger_service.activate_trigger("plugin", trigger)
+        assert trigger_service.get_active_trigger() is not None
+
+    def test_dismiss_active_for_user_override_clears_all(self, trigger_service):
+        """Helper used by PUT /settings/active-page to clear + suppress in one go."""
+        for tid in ("a", "b", "c"):
+            trigger_service.activate_trigger(
+                "plugin",
+                TriggerResult(
+                    triggered=True, trigger_id=tid, message=tid,
+                    priority=1, duration_seconds=300,
+                ),
+            )
+        assert len(trigger_service.list_active_triggers()) == 3
+
+        count = trigger_service.dismiss_active_for_user_override()
+        assert count == 3
+        assert trigger_service.get_active_trigger() is None
+
+        # Re-firing any of the suppressed IDs must be a no-op.
+        for tid in ("a", "b", "c"):
+            trigger_service.activate_trigger(
+                "plugin",
+                TriggerResult(
+                    triggered=True, trigger_id=tid, message=tid,
+                    priority=1, duration_seconds=300,
+                ),
+            )
+        assert trigger_service.get_active_trigger() is None
+
+    def test_clear_all_resets_suppressions_too(self, trigger_service):
+        """clear_all must wipe suppression entries so post-clear triggers fire normally."""
+        trigger = TriggerResult(
+            triggered=True, trigger_id="cleared", message="X",
+            priority=1, duration_seconds=60,
+        )
+        trigger_service.activate_trigger("plugin", trigger)
+        trigger_service.dismiss_trigger("cleared", suppress=True)
+        trigger_service.clear_all()
+
+        trigger_service.activate_trigger("plugin", trigger)
+        assert trigger_service.get_active_trigger() is not None
+
     def test_expired_triggers_cleared(self, trigger_service):
         trigger = TriggerResult(
             triggered=True,

--- a/web/src/__tests__/schema-form.test.tsx
+++ b/web/src/__tests__/schema-form.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from "vitest";
 import { useState } from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { SchemaForm, type JSONSchema } from "@/components/plugin-settings";
 
 /**
@@ -243,5 +244,139 @@ describe("SchemaForm - editing fields with schema defaults", () => {
     await user.keyboard("{Control>}a{/Control}{Backspace}");
 
     expect(input.value).toBe("");
+  });
+});
+
+/**
+ * page-picker widget: a plugin can declare `"ui:widget": "page-picker"` on a
+ * string field to get a button that opens the existing PagePickerDialog and
+ * writes back the chosen page UUID, instead of a raw text input.
+ */
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      getPages: vi.fn().mockResolvedValue({
+        pages: [
+          { id: "page-uuid-1", name: "Welcome", type: "template" },
+          { id: "page-uuid-2", name: "Stocks", type: "template" },
+        ],
+        total: 2,
+      }),
+    },
+  };
+});
+
+function QueryHarness({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+describe("SchemaForm - page-picker widget", () => {
+  const pageSchema: JSONSchema = {
+    type: "object",
+    properties: {
+      trigger_page_id: {
+        type: "string",
+        title: "Trigger Page",
+        "ui:widget": "page-picker",
+      },
+    },
+  };
+
+  function Harness({ initial }: { initial: Record<string, unknown> }) {
+    const [values, setValues] = useState<Record<string, unknown>>(initial);
+    return (
+      <QueryHarness>
+        <SchemaForm schema={pageSchema} values={values} onChange={setValues} />
+      </QueryHarness>
+    );
+  }
+
+  it("renders a Select trigger (not a raw text input) for ui:widget: page-picker", async () => {
+    render(<Harness initial={{ trigger_page_id: "" }} />);
+
+    // The picker is a Radix Select trigger, exposing role=combobox.
+    expect(await screen.findByRole("combobox")).toBeInTheDocument();
+    // The raw text input fallback must NOT be rendered.
+    expect(screen.queryByRole("textbox", { name: /trigger page/i })).not.toBeInTheDocument();
+    // With no value, the dropdown's trigger surfaces the "None (no override)"
+    // option, which maps to "" in the form state.
+    expect(await screen.findByText(/none \(no override\)/i)).toBeInTheDocument();
+  });
+
+  it("shows the selected page's name once the pages have loaded", async () => {
+    render(<Harness initial={{ trigger_page_id: "page-uuid-2" }} />);
+
+    expect(await screen.findByText("Stocks")).toBeInTheDocument();
+  });
+});
+
+describe("SchemaForm - numeric enum (integer Select)", () => {
+  const enumSchema: JSONSchema = {
+    type: "object",
+    properties: {
+      minutes_before: {
+        type: "integer",
+        title: "Lead Time",
+        default: 5,
+        enum: [1, 2, 3, 5, 10],
+      },
+    },
+  };
+
+  function Harness({
+    initial,
+    onChange,
+  }: {
+    initial: Record<string, unknown>;
+    onChange?: (v: Record<string, unknown>) => void;
+  }) {
+    const [values, setValues] = useState<Record<string, unknown>>(initial);
+    return (
+      <SchemaForm
+        schema={enumSchema}
+        values={values}
+        onChange={(v) => {
+          setValues(v);
+          onChange?.(v);
+        }}
+      />
+    );
+  }
+
+  it("renders as a Select trigger (combobox), not a number input", () => {
+    render(<Harness initial={{ minutes_before: 5 }} />);
+
+    // The combobox role identifies a Radix Select trigger.
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+    expect(screen.queryByRole("spinbutton")).not.toBeInTheDocument();
+  });
+
+  it("uses enumNames as friendly labels when provided", () => {
+    const labeledSchema: JSONSchema = {
+      type: "object",
+      properties: {
+        stay_minutes: {
+          type: "integer",
+          title: "Stay On Board",
+          default: 0,
+          enum: [0, 5, 15],
+          enumNames: ["Until next page", "5 min", "15 min"],
+        },
+      },
+    };
+    function Local() {
+      const [values, setValues] = useState<Record<string, unknown>>({ stay_minutes: 0 });
+      return <SchemaForm schema={labeledSchema} values={values} onChange={setValues} />;
+    }
+    render(<Local />);
+
+    // The Select trigger displays the friendly label for the current value.
+    expect(screen.getByText("Until next page")).toBeInTheDocument();
   });
 });

--- a/web/src/components/plugin-settings/page-picker-field.stories.tsx
+++ b/web/src/components/plugin-settings/page-picker-field.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { PagePickerField } from "./page-picker-field";
+
+const mockPages = {
+  pages: [
+    {
+      id: "page-uuid-1",
+      name: "Weather Dashboard",
+      type: "template" as const,
+      device_type: "flagship" as const,
+      duration_seconds: 300,
+      created_at: "2026-01-01T00:00:00Z",
+    },
+    {
+      id: "page-uuid-2",
+      name: "Morning Briefing",
+      type: "template" as const,
+      device_type: "flagship" as const,
+      duration_seconds: 300,
+      created_at: "2026-01-01T00:00:00Z",
+    },
+    {
+      id: "page-uuid-3",
+      name: "Static Welcome",
+      type: "single" as const,
+      device_type: "flagship" as const,
+      duration_seconds: 300,
+      created_at: "2026-01-01T00:00:00Z",
+    },
+  ],
+  total: 3,
+};
+
+function withMockedPages(initialValue: string) {
+  return function Wrapper() {
+    const [value, setValue] = useState(initialValue);
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { staleTime: Infinity } },
+    });
+    queryClient.setQueryData(["pages"], mockPages);
+
+    return (
+      <QueryClientProvider client={queryClient}>
+        <div className="max-w-md space-y-3">
+          <div className="text-xs text-muted-foreground">
+            Selected: <code>{value || "(none)"}</code>
+          </div>
+          <PagePickerField
+            id="trigger_page_id"
+            value={value}
+            onChange={(v) => setValue(String(v ?? ""))}
+          />
+        </div>
+      </QueryClientProvider>
+    );
+  };
+}
+
+const meta = {
+  title: "PluginSettings/PagePickerField",
+  parameters: { layout: "padded" },
+  tags: ["autodocs"],
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Empty: Story = {
+  render: withMockedPages(""),
+};
+
+export const PreSelected: Story = {
+  render: withMockedPages("page-uuid-2"),
+};

--- a/web/src/components/plugin-settings/page-picker-field.stories.tsx
+++ b/web/src/components/plugin-settings/page-picker-field.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { Label } from "@/components/ui/label";
 import { PagePickerField } from "./page-picker-field";
 
 const mockPages = {
@@ -47,6 +48,11 @@ function withMockedPages(initialValue: string) {
           <div className="text-xs text-muted-foreground">
             Selected: <code>{value || "(none)"}</code>
           </div>
+          {/* The Label is what gives the Radix Select trigger its accessible
+              name; the SchemaForm renders one in production, so we mirror that
+              here to keep the story representative and pass axe-core's
+              button-name rule. */}
+          <Label htmlFor="trigger_page_id">Trigger Page</Label>
           <PagePickerField
             id="trigger_page_id"
             value={value}

--- a/web/src/components/plugin-settings/page-picker-field.tsx
+++ b/web/src/components/plugin-settings/page-picker-field.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { api } from "@/lib/api";
+
+interface PagePickerFieldProps {
+  id: string;
+  value: string;
+  onChange: (value: unknown) => void;
+  disabled?: boolean;
+}
+
+// Radix Select doesn't accept empty-string item values, so the "None" option
+// uses this sentinel and is translated back to "" when written to the form.
+const NONE_VALUE = "__none__";
+
+export function PagePickerField({ id, value, onChange, disabled }: PagePickerFieldProps) {
+  const { data: pagesData, isLoading } = useQuery({
+    queryKey: ["pages"],
+    queryFn: api.getPages,
+  });
+
+  const pages = pagesData?.pages ?? [];
+  const selectValue = value && value.length > 0 ? value : NONE_VALUE;
+
+  return (
+    <Select
+      value={selectValue}
+      onValueChange={(v) => onChange(v === NONE_VALUE ? "" : v)}
+      disabled={disabled || isLoading}
+      modal={false}
+    >
+      <SelectTrigger id={id}>
+        <SelectValue placeholder={isLoading ? "Loading pages…" : "Choose a page…"} />
+      </SelectTrigger>
+      <SelectContent className="max-h-[300px] z-[120]">
+        <SelectItem value={NONE_VALUE}>None (no override)</SelectItem>
+        {pages.map((page) => (
+          <SelectItem key={page.id} value={page.id}>
+            {page.name}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}

--- a/web/src/components/plugin-settings/schema-form.tsx
+++ b/web/src/components/plugin-settings/schema-form.tsx
@@ -14,6 +14,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { TimezonePicker } from "@/components/ui/timezone-picker";
+import { PagePickerField } from "./page-picker-field";
 import { cn } from "@/lib/utils";
 import { api, type QueueTimesPark, type QueueTimesRide } from "@/lib/api";
 import { Plus, Trash2, Eye, EyeOff, MapPin, Loader2, ChevronRight, ChevronDown, Zap, Copy, Check } from "lucide-react";
@@ -25,7 +26,8 @@ interface SchemaProperty {
   title?: string;
   description?: string;
   default?: unknown;
-  enum?: string[];
+  enum?: unknown[];
+  enumNames?: string[];
   minimum?: number;
   maximum?: number;
   minItems?: number;
@@ -67,6 +69,7 @@ function StringField({ name, property, value, onChange, required, disabled }: Fi
   const isPassword = property["ui:widget"] === "password";
   const isTextarea = property["ui:widget"] === "textarea";
   const isTimezone = property["ui:widget"] === "timezone";
+  const isPagePicker = property["ui:widget"] === "page-picker";
   
   if (property.enum) {
     // Normalize enum to array of strings - handle all possible formats
@@ -114,19 +117,30 @@ function StringField({ name, property, value, onChange, required, disabled }: Fi
       };
       
       // Render all enum options
+      const enumNames = property.enumNames;
       const selectItems = React.useMemo(() => {
         return allOptions.map((option, idx) => {
           const itemKey = `${name}-option-${idx}-${option}`;
+          // Look up custom label from enumNames if provided. Use the
+          // original enum index (not the deduped one) so labels stay
+          // aligned with their values.
+          let displayLabel = capitalizeDisplay(option);
+          if (enumNames && Array.isArray(enumNames)) {
+            const originalIdx = enumArray.indexOf(option);
+            if (originalIdx >= 0 && enumNames[originalIdx]) {
+              displayLabel = enumNames[originalIdx];
+            }
+          }
           return (
-            <SelectItem 
+            <SelectItem
               key={itemKey}
               value={option}
             >
-              {capitalizeDisplay(option)}
+              {displayLabel}
             </SelectItem>
           );
         });
-      }, [name, allOptions]);
+      }, [name, allOptions, enumNames, enumArray]);
       
       // Stable onChange handler to prevent re-renders
       const handleValueChange = React.useCallback((newValue: string) => {
@@ -185,6 +199,17 @@ function StringField({ name, property, value, onChange, required, disabled }: Fi
     );
   }
 
+  if (isPagePicker) {
+    return (
+      <PagePickerField
+        id={name}
+        value={String(value || "")}
+        onChange={onChange}
+        disabled={disabled}
+      />
+    );
+  }
+
   return (
     <div className="relative">
       <Input
@@ -223,9 +248,59 @@ interface NumberFieldProps extends FieldProps {
   isLocationLoading?: boolean;
 }
 
-function NumberField({ name, property, value, onChange, required, disabled, onLocationRequest, showLocationButton, isLocationLoading }: NumberFieldProps) {
+function NumberEnumField({ name, property, value, onChange, disabled }: FieldProps) {
+  const rawEnum = property.enum as unknown[];
+  const numericEnum = rawEnum
+    .map((opt) => Number(opt))
+    .filter((n) => Number.isFinite(n));
+  const enumNames = property.enumNames;
+  const defaultNum =
+    property.default !== undefined && Number.isFinite(Number(property.default))
+      ? Number(property.default)
+      : numericEnum[0];
+  const currentNum =
+    value !== undefined && value !== null && Number.isFinite(Number(value))
+      ? Number(value)
+      : defaultNum;
+  const selectValue = numericEnum.includes(currentNum)
+    ? String(currentNum)
+    : String(defaultNum);
+  return (
+    <Select
+      value={selectValue}
+      onValueChange={(v) => onChange(Number(v))}
+      disabled={disabled}
+      modal={false}
+    >
+      <SelectTrigger id={name}>
+        <SelectValue
+          placeholder={property["ui:placeholder"] || `Select ${property.title || name}`}
+        />
+      </SelectTrigger>
+      <SelectContent className="max-h-[300px] z-[120]">
+        {numericEnum.map((option, idx) => (
+          <SelectItem key={`${name}-num-${idx}-${option}`} value={String(option)}>
+            {enumNames && enumNames[idx] ? enumNames[idx] : String(option)}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+function NumberField(props: NumberFieldProps) {
+  const { name, property, value, onChange, required, disabled, onLocationRequest, showLocationButton, isLocationLoading } = props;
   const t = useTranslations("schemaForm");
   const [isGettingLocation, setIsGettingLocation] = useState(false);
+
+  // Numeric enum → Select. Honors optional enumNames for friendly labels
+  // (e.g. {enum: [0, 5], enumNames: ["Until next page", "5 min"]}).
+  // Delegated to a sub-component so the hook order is stable when a field
+  // switches between enum and free-number variants.
+  const hasNumericEnum =
+    property.enum &&
+    Array.isArray(property.enum) &&
+    property.enum.some((opt) => Number.isFinite(Number(opt)));
 
   // Local text buffer so the user can freely edit the field (delete the
   // existing value, paste a new one, type intermediate states like "-" or
@@ -245,6 +320,10 @@ function NumberField({ name, property, value, onChange, required, disabled, onLo
       setText(value !== undefined && value !== null ? String(value) : "");
     }
   }, [value, isFocused]);
+
+  if (hasNumericEnum) {
+    return <NumberEnumField {...props} />;
+  }
 
   // Helper function to get user-friendly error message
   const getErrorMessage = (error: GeolocationPositionError | null | undefined): string => {


### PR DESCRIPTION
## Summary

Closes a few related plugin-settings + trigger gaps surfaced while testing the new Calendar Subscription plugin's `trigger_page_id` field:

- **`page-picker` widget** — `schema-form.tsx` now renders fields with `"ui:widget": "page-picker"` as a Radix Select dropdown listing pages by name and saving the page UUID. The calendar-sub plugin's manifest already declared this widget (the field used to silently fall back to a raw UUID text input, which led to user confusion — pasting the page share-string blob didn't work).
- **Numeric enum + `enumNames`** — `NumberField` now renders a `Select` when an integer field declares `enum: [...]`, with optional `enumNames: [...]` for friendly labels (e.g. `{enum: [0, 5], enumNames: ["Until next page", "5 min"]}`). Saved values stay typed as integers. Unblocks the calendar plugin's preset Lead Time / Stay-On-Board fields ([calendar-sub PR](https://github.com/Fiestaboard/fiestaboard-plugin--calendar-sub/pull/8)) and benefits any plugin that wants integer presets.
- **`/api/plugins/{id}/data` 500 fix** — `api_server.py` referenced `result.formatted` but `PluginResult` only has `formatted_lines`. Now returns `formatted_lines` (matches the dataclass + nearby endpoints).
- **fix(triggers): user override beats re-emitted plugin trigger (closes #856)** — when a plugin re-emits the same trigger every loop tick (e.g. calendar_sub during a countdown), `PUT /settings/active-page` now dismisses + suppresses the active trigger's `trigger_id` until its natural duration would have ended. The user's manual "Change Page" choice sticks. Different events (different `trigger_id`s) still fire normally; suppression is per-id.

## Test plan

- [x] `npm test` in `web/` — 1001 tests pass, including new schema-form coverage for the picker widget and numeric enum/enumNames branches
- [x] `pytest tests/test_plugin_triggers.py` — 43 tests pass, 5 new for trigger suppression
- [x] Manual: open Integrations → Calendar Subscription → Configure → Trigger Page is a dropdown listing pages with the current selection checked
- [x] Manual: select a page, Save, reopen — selection persists; backend config has the UUID
- [x] Manual: `curl /api/plugins/calendar_sub/data` returns 200 with `formatted_lines`
- [x] Manual (regression for #856): with a countdown trigger active, `PUT /settings/active-page` → trigger dismissed → `POST /triggers/check` runs → trigger stays suppressed → board keeps showing the user's page (decoded from mock board character grid)
- [ ] Reviewer: confirm Storybook entry renders (PluginSettings/PagePickerField)

🤖 Generated with [Claude Code](https://claude.com/claude-code)