### PR TITLE
fix(auth): unblock /auth/mcp-token when auth is disabled

### DIFF
--- a/src/auth/routes.py
+++ b/src/auth/routes.py
@@ -397,7 +397,19 @@ async def auth_disable(
 
 
 def _require_admin(request: Request) -> str:
-    """Return the logged-in username or raise 401. Shared 1-line gate."""
+    """Return the logged-in username or raise 401. Shared 1-line gate.
+
+    When auth is explicitly *disabled* (``FIESTABOARD_AUTH_ENABLED=0`` or the
+    persisted preference is ``disabled``) there is no admin concept and no
+    session cookie ever gets issued — return a sentinel so MCP token
+    management remains reachable. Without this the Settings → Integrations
+    page hits a 401, the web client redirects to ``/login``, the login page
+    sees auth is disabled and bounces back, and the user is stuck in an
+    infinite reload loop. ``undecided`` mode (first-run, secure-by-default)
+    still requires a session.
+    """
+    if auth_mode() == "disabled":
+        return "anonymous"
     svc = get_auth_service()
     cookie = request.cookies.get(SESSION_COOKIE_NAME)
     username = svc.verify_session(cookie) if cookie else None

--- a/tests/test_auth_mcp_token_routes.py
+++ b/tests/test_auth_mcp_token_routes.py
@@ -38,6 +38,14 @@ def enabled(monkeypatch):
 
 
 @pytest.fixture
+def auth_disabled(monkeypatch):
+    monkeypatch.setenv("FIESTABOARD_AUTH_ENABLED", "false")
+    monkeypatch.delenv("FIESTABOARD_MCP_TOKEN", raising=False)
+    yield
+    monkeypatch.delenv("FIESTABOARD_AUTH_ENABLED", raising=False)
+
+
+@pytest.fixture
 def signed_in(client, enabled):
     r = client.post("/auth/setup", json={"username": "admin", "password": "Password123!"})
     assert r.status_code in (200, 201), r.text
@@ -159,3 +167,50 @@ def test_clear_blocked_when_env_var_pins_the_token(signed_in, client, monkeypatc
     monkeypatch.setenv("FIESTABOARD_MCP_TOKEN", "pinned-by-ops")
     r = client.delete("/auth/mcp-token")
     assert r.status_code == 409
+
+
+# --- Auth-disabled mode (issue #857) --------------------------------------
+#
+# When the install opted out of login, there's no session cookie to send.
+# The mcp-token endpoints must still respond so Settings → Integrations can
+# render. Before the fix these 401s triggered an infinite /login bounce.
+
+
+def test_status_accessible_when_auth_disabled(client, auth_disabled):
+    r = client.get("/auth/mcp-token")
+    assert r.status_code == 200
+    assert r.json() == {"configured": False, "source": "none"}
+
+
+def test_rotate_accessible_when_auth_disabled(client, auth_disabled):
+    r = client.post("/auth/mcp-token")
+    assert r.status_code == 201
+    token = r.json()["token"]
+    assert len(token) >= 32
+    assert client.get("/auth/mcp-token").json() == {
+        "configured": True,
+        "source": "stored",
+    }
+    bare = TestClient(app, raise_server_exceptions=False)
+    assert (
+        bare.get("/mcp/", headers={"Authorization": f"Bearer {token}"}).status_code
+        != 401
+    )
+
+
+def test_clear_accessible_when_auth_disabled(client, auth_disabled):
+    client.post("/auth/mcp-token")
+    r = client.delete("/auth/mcp-token")
+    assert r.status_code == 200
+    assert client.get("/auth/mcp-token").json() == {
+        "configured": False,
+        "source": "none",
+    }
+
+
+def test_undecided_mode_still_requires_auth(client, monkeypatch):
+    monkeypatch.delenv("FIESTABOARD_AUTH_ENABLED", raising=False)
+    monkeypatch.delenv("FIESTABOARD_MCP_TOKEN", raising=False)
+    assert client.get("/auth/mcp-token").status_code == 401
+    assert client.post("/auth/mcp-token").status_code == 401
+    assert client.delete("/auth/mcp-token").status_code == 401


### PR DESCRIPTION
## Summary

- Treat `auth_mode() == "disabled"` as "no admin concept, every caller is authorized" in `_require_admin` so the `/auth/mcp-token` endpoints introduced in #852 remain reachable when the install has opted out of login.
- Adds tests covering status / rotate / clear under disabled mode plus a regression test that `undecided` (first-run, secure-by-default) still 401s.

## Why

When auth is off, no session cookie ever gets issued. The new mcp-token endpoints still required one, so the Settings → Integrations page hit a 401 on mount, the web client redirected to `/login`, the login page saw auth was disabled and `router.replace`d straight back to `/settings?section=integrations`, and the user was stuck in an infinite reload loop (Safari surfaces this as "Can't Open the Page").

Reproduced locally with `FIESTABOARD_AUTH_ENABLED=0` — Safari shows "Can't Open the Page" on the route before the fix and renders the Integrations panel normally after.

Closes #857

## Test plan

- [x] `pytest tests/test_auth_mcp_token_routes.py -v` — 16/16 pass (12 existing + 4 new).
- [x] Manual: with `FIESTABOARD_AUTH_ENABLED=0`, `curl /api/auth/mcp-token` flips from 401 → 200, and Settings → Integrations renders the MCP card.
- [x] Regression: with `FIESTABOARD_AUTH_ENABLED=1` and no session cookie, all three endpoints still 401 (covered by pre-existing tests).
- [x] Regression: undecided mode (no env var, no recorded preference) still 401s (new `test_undecided_mode_still_requires_auth`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)