### PR TITLE
fix(web): scroll the document instead of a nested container

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -284,6 +284,10 @@
   body {
     @apply bg-background text-foreground;
     font-feature-settings: 'ss01';
+    /* Clip horizontal overflow at the document root so the body itself stays the
+     * vertical scroll container. Applying overflow-x to <main> would force its
+     * computed overflow-y to `auto`, recreating a nested scrollbar. */
+    overflow-x: hidden;
   }
   /* Prevent Radix UI Select from removing scrollbar when opened */
   body[data-scroll-locked] {

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -71,7 +71,7 @@ export default async function RootLayout({
         <link rel="apple-touch-icon" href="/icons/apple-touch-icon.png" />
       </head>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased h-dvh overflow-hidden`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <svg width="0" height="0" aria-hidden="true" style={{ position: 'absolute' }}>
           <defs>

--- a/web/src/components/main-content.tsx
+++ b/web/src/components/main-content.tsx
@@ -18,7 +18,7 @@ export function MainContent({ children }: { children: React.ReactNode }) {
     <main
       id="main-content"
       className={cn(
-        "h-dvh flex flex-col overflow-x-hidden overflow-y-auto overscroll-contain w-full mx-auto",
+        "min-h-dvh flex flex-col w-full mx-auto",
         !isAuthScreen && "pt-[72px] lg:pt-0 sidebar-transition",
         !isAuthScreen && (collapsed ? "lg:pl-[76px]" : "lg:pl-[268px]"),
         !isAuthScreen && (aiPanelOpen ? "lg:pr-[384px]" : "lg:pr-0"),

--- a/web/src/components/page-layout.tsx
+++ b/web/src/components/page-layout.tsx
@@ -13,7 +13,11 @@ export function PageLayout({ children, className, outerClassName, fillHeight }: 
   return (
     <div className={cn(
       "bg-background overflow-x-hidden",
-      fillHeight ? "flex-1 min-h-0 flex flex-col overflow-hidden" : "min-h-full",
+      // fillHeight pins the page to the viewport so inner content (e.g. the
+      // calendar grid) can scroll independently. The mobile topbar (`pt-[72px]`
+      // on MainContent) is subtracted on small screens so the wrapper doesn't
+      // extend past the viewport bottom.
+      fillHeight ? "h-[calc(100dvh-72px)] lg:h-dvh flex flex-col overflow-hidden" : "min-h-full",
       outerClassName
     )}>
       <div className={cn(


### PR DESCRIPTION
## Summary
- The shell previously locked `<body>` at `100dvh` + `overflow-hidden` and gave `<main>` its own `h-dvh` + `overflow-y-auto`, producing the inset scrollbar that floats between the page content and the AI-panel column.
- The nav rail and AI drawer are already `position: fixed`, so the document itself can be the scroll container — no inner scrollbar needed.
- Schedule's calendar view (the only `fillHeight` consumer) now pins to viewport height directly so the calendar grid still scrolls internally.

## Changes
- `layout.tsx`: drop `h-dvh` + `overflow-hidden` from `<body>`.
- `main-content.tsx`: drop `h-dvh`, `overflow-y-auto`, `overscroll-contain`, and `overflow-x-hidden` (the last one silently forced computed `overflow-y: auto` on `<main>`, recreating the inner scroll context).
- `globals.css`: move `overflow-x: hidden` onto `<body>` so sidebar/AI panel transitions still can't introduce horizontal scroll, while body overflow propagates to the viewport for vertical scroll.
- `page-layout.tsx`: in `fillHeight` mode, pin to `h-[calc(100dvh-72px)] lg:h-dvh` so Schedule's calendar grid stays viewport-sized and scrolls internally.

## Test plan
- [x] Web test suite passes (`/test-web` — 997 passed, 13 skipped)
- [x] Pages: scrolls naturally at narrow heights; no inset scrollbar
- [x] Home, Carousels, Integrations: scroll the document, no nested scrollbar
- [x] Schedule list view: scrolls naturally
- [x] Schedule calendar view: calendar stays viewport-sized and scrolls internally (no double scrollbar)
- [x] Sidebar (`lg:fixed`) and mobile topbar (`fixed top-2`) stay anchored while scrolling
- [x] No new console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)