### PR TITLE
ci: stop hiding failures (phase 1)

### DIFF
--- a/.github/workflows/build-fiestapi.yml
+++ b/.github/workflows/build-fiestapi.yml
@@ -57,10 +57,12 @@ jobs:
 
       - name: Free up disk space
         # pi-gen needs ~4 GB of scratch; ubuntu-latest is tight by default.
+        # If cleanup fails, fail fast — the alternative is a confusing
+        # out-of-disk error later in the build.
         run: |
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
-                      /opt/hostedtoolcache/CodeQL /usr/local/share/boost || true
-          sudo docker image prune -af || true
+                      /opt/hostedtoolcache/CodeQL /usr/local/share/boost
+          sudo docker image prune -af
           df -h /
 
       - name: Set up QEMU (arm64 emulation for pi-gen)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,9 +232,10 @@ jobs:
       if: steps.discover.outputs.has_plugins == 'true'
       run: |
         python scripts/run_plugin_tests.py --verbose
-        # Combine per-plugin coverage data and generate XML for Codecov
-        coverage combine || true
-        coverage xml -o coverage-plugins.xml || true
+        # Combine per-plugin coverage data and generate XML for Codecov.
+        # Failures here mean the test setup is broken — surface them.
+        coverage combine
+        coverage xml -o coverage-plugins.xml
       env:
         BOARD_READ_WRITE_KEY: test_key
         WEATHER_API_KEY: test_key
@@ -243,18 +244,9 @@ jobs:
       if: always() && steps.discover.outputs.has_plugins == 'true'
       run: |
         if [ -f coverage-plugins.xml ]; then
-          python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
-        import xml.etree.ElementTree as ET
-        root = ET.parse('coverage-plugins.xml').getroot()
-        line = float(root.attrib.get('line-rate', '0')) * 100
-        branch = float(root.attrib.get('branch-rate', '0')) * 100
-        print('## Plugin Tests')
-        print()
-        print('| Metric | Value |')
-        print('|---|---|')
-        print(f'| Line coverage | {line:.1f}% |')
-        print(f'| Branch coverage | {branch:.1f}% |')
-        PY
+          python3 scripts/ci/coverage_summary.py \
+            --cobertura coverage-plugins.xml \
+            --title "Plugin Tests" >> "$GITHUB_STEP_SUMMARY"
         fi
 
     - name: Upload plugin coverage
@@ -295,27 +287,11 @@ jobs:
 
     - name: Write coverage summary
       if: always()
-      working-directory: web
       run: |
-        if [ -f coverage/lcov.info ]; then
-          python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
-        # Parse lcov.info: sum LF (lines found) and LH (lines hit) across files.
-        lf = lh = brf = brh = 0
-        with open('coverage/lcov.info') as f:
-            for line in f:
-                if line.startswith('LF:'): lf += int(line[3:])
-                elif line.startswith('LH:'): lh += int(line[3:])
-                elif line.startswith('BRF:'): brf += int(line[4:])
-                elif line.startswith('BRH:'): brh += int(line[4:])
-        line_pct = (lh / lf * 100) if lf else 0
-        branch_pct = (brh / brf * 100) if brf else 0
-        print('## UI Tests')
-        print()
-        print('| Metric | Value |')
-        print('|---|---|')
-        print(f'| Line coverage | {line_pct:.1f}% |')
-        print(f'| Branch coverage | {branch_pct:.1f}% |')
-        PY
+        if [ -f web/coverage/lcov.info ]; then
+          python3 scripts/ci/coverage_summary.py \
+            --lcov web/coverage/lcov.info \
+            --title "UI Tests" >> "$GITHUB_STEP_SUMMARY"
         fi
 
     - name: Upload UI coverage
@@ -405,8 +381,11 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
+        # Skip on fork PRs (no secret access). On internal PRs and main,
+        # fail loudly so we notice credential problems instead of silently
+        # falling back to anonymous pulls with their tiny rate limits.
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@v4
-        continue-on-error: true
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -446,8 +425,11 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
+        # Skip on fork PRs (no secret access). On internal PRs and main,
+        # fail loudly so we notice credential problems instead of silently
+        # falling back to anonymous pulls with their tiny rate limits.
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@v4
-        continue-on-error: true
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -609,8 +591,11 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
+        # Skip on fork PRs (no secret access). On internal PRs and main,
+        # fail loudly so we notice credential problems instead of silently
+        # falling back to anonymous pulls with their tiny rate limits.
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@v4
-        continue-on-error: true
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -748,8 +733,11 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
+        # Skip on fork PRs (no secret access). On internal PRs and main,
+        # fail loudly so we notice credential problems instead of silently
+        # falling back to anonymous pulls with their tiny rate limits.
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@v4
-        continue-on-error: true
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/registry-scan.yml
+++ b/.github/workflows/registry-scan.yml
@@ -31,8 +31,21 @@ jobs:
 
     - name: Scan all registry plugins
       id: scan
-      run: python scripts/scan_registry.py --verbose --output scan-results
-      continue-on-error: true
+      # scan_registry.py exits 0 (clean), 1 (vulns found — sets
+      # has_vulnerabilities output for the issue-creator step), or 2
+      # (setup/config error). Allow 1 but surface 2 — a crashing scan
+      # silently skipping issue creation is the exact failure mode we
+      # had before this change.
+      run: |
+        set +e
+        python scripts/scan_registry.py --verbose --output scan-results
+        code=$?
+        set -e
+        if [ "$code" = "0" ] || [ "$code" = "1" ]; then
+          exit 0
+        fi
+        echo "::error::scan_registry.py crashed with exit code $code"
+        exit "$code"
 
     - name: Upload scan results
       if: always()

--- a/scripts/ci/coverage_summary.py
+++ b/scripts/ci/coverage_summary.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Emit a Markdown coverage summary table for GitHub Actions step summaries.
+
+Parses either lcov.info (web) or Cobertura XML (Python) and writes a
+Markdown table to stdout. Designed to be piped into $GITHUB_STEP_SUMMARY.
+
+This replaces inline `python3 - <<'PY'` heredocs in workflow YAML, which
+are brittle (indentation, $ expansion, set -e propagation) and have
+broken CI runs in the past.
+
+Usage:
+    python3 scripts/ci/coverage_summary.py --lcov web/coverage/lcov.info --title "UI Tests"
+    python3 scripts/ci/coverage_summary.py --cobertura coverage-plugins.xml --title "Plugin Tests"
+
+Exits 0 on success, 1 if the input file is missing or cannot be parsed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+def parse_lcov(path: Path) -> tuple[float, float]:
+    lf = lh = brf = brh = 0
+    for line in path.read_text().splitlines():
+        if line.startswith("LF:"):
+            lf += int(line[3:])
+        elif line.startswith("LH:"):
+            lh += int(line[3:])
+        elif line.startswith("BRF:"):
+            brf += int(line[4:])
+        elif line.startswith("BRH:"):
+            brh += int(line[4:])
+    line_pct = (lh / lf * 100) if lf else 0.0
+    branch_pct = (brh / brf * 100) if brf else 0.0
+    return line_pct, branch_pct
+
+
+def parse_cobertura(path: Path) -> tuple[float, float]:
+    root = ET.parse(path).getroot()
+    line_pct = float(root.attrib.get("line-rate", "0")) * 100
+    branch_pct = float(root.attrib.get("branch-rate", "0")) * 100
+    return line_pct, branch_pct
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--lcov", type=Path, help="Path to an lcov.info file")
+    group.add_argument("--cobertura", type=Path, help="Path to a Cobertura XML file")
+    parser.add_argument("--title", required=True, help="Section title for the summary")
+    args = parser.parse_args()
+
+    path: Path = args.lcov or args.cobertura
+    if not path.is_file():
+        print(f"coverage_summary: {path} not found", file=sys.stderr)
+        return 1
+
+    try:
+        if args.lcov:
+            line_pct, branch_pct = parse_lcov(path)
+        else:
+            line_pct, branch_pct = parse_cobertura(path)
+    except Exception as exc:
+        print(f"coverage_summary: failed to parse {path}: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"## {args.title}")
+    print()
+    print("| Metric | Value |")
+    print("|---|---|")
+    print(f"| Line coverage | {line_pct:.1f}% |")
+    print(f"| Branch coverage | {branch_pct:.1f}% |")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Part 1 of a CI repair series. Surfaces failures the CI was silently swallowing.

- **Fix recurring \`UI Tests\` failure.** The \`npm run test:coverage\` step passes, but the *next* step — an inline \`python3 - <<'PY'\` heredoc that parses lcov.info — has been crashing intermittently. Heredocs in workflow \`run:\` blocks are brittle (indentation, \`$\` expansion, \`set -e\` propagation). Replaced with a standalone \`scripts/ci/coverage_summary.py\` that takes \`--lcov\` or \`--cobertura\` and emits the same Markdown table.
- **Remove \`|| true\` masks** from \`coverage combine\`, \`coverage xml\`, and \`build-fiestapi\` disk-cleanup. Real failures should fail.
- **DockerHub login: fork-aware instead of \`continue-on-error: true\`.** Forks (no secret access) skip cleanly; internal PRs and main now fail loudly when credentials break instead of silently using anonymous pulls that hit rate limits.
- **registry-scan: handle exit codes explicitly.** \`scan_registry.py\` exits 0/1/2 (clean/vulns/config-error). The blanket \`continue-on-error: true\` swallowed all three. Now allows 1 but surfaces 2.

Visual-regression's \`continue-on-error: true\` is intentionally preserved — addressed separately in a follow-up that bootstraps baseline snapshots.

## Test plan

- [ ] CI passes on this PR (validates UI Tests no longer trip the heredoc step)
- [ ] Manually trigger registry-scan via \`workflow_dispatch\` post-merge; confirm exit-code handling
- [ ] Confirm a fork PR still passes (no DockerHub credentials available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)