### PR TITLE
ci: bootstrap workflow for visual regression baselines (phase 3)

### DIFF
--- a/.github/workflows/bootstrap-visual-baselines.yml
+++ b/.github/workflows/bootstrap-visual-baselines.yml
@@ -1,0 +1,176 @@
+name: Bootstrap Visual Regression Baselines
+
+# =============================================================================
+# Generates Playwright visual-regression baseline snapshots and opens a PR.
+#
+# Manual-only (workflow_dispatch). Run this when:
+#   - Setting up visual regression for the first time
+#   - Intentionally updating baselines after a UI redesign
+#   - A baseline has drifted due to library/font changes
+#
+# The PR opened by this workflow:
+#   1. Commits the generated *.png snapshots under
+#      web/tests/visual-regression.spec.ts-snapshots/
+#   2. Removes `continue-on-error: true` from the visual regression
+#      step in ci.yml — flipping it from advisory to required.
+#
+# Always review the generated screenshots before merging the PR.
+# =============================================================================
+
+on:
+  workflow_dispatch:
+    inputs:
+      enforce:
+        description: 'Also remove continue-on-error: true from ci.yml (make required)'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bootstrap:
+    name: Generate baselines
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up web E2E environment
+        uses: ./.github/actions/setup-web-e2e
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Docker Hub
+        if: github.repository == 'Fiestaboard/FiestaBoard'
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build test image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          push: false
+          load: true
+          tags: fiestaboard:e2e
+          build-args: |
+            VERSION=dev
+          cache-from: |
+            type=gha,scope=build-test
+            type=gha,scope=build-linux/amd64
+
+      - name: Start mock board + FiestaBoard
+        run: |
+          docker run -d --name mock-board \
+            -v ${{ github.workspace }}/integration-tests/mock-board:/app:ro \
+            -w /app \
+            python:3.11-slim python server.py
+
+          docker run -d --name fiestaboard \
+            -e PRODUCTION=false \
+            -e FIESTABOARD_AUTH_ENABLED=false \
+            fiestaboard:e2e
+
+          FB_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' fiestaboard)
+          MOCK_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' mock-board)
+          echo "WORKER_URLS=http://$FB_IP:3000" >> "$GITHUB_ENV"
+          echo "WORKER_MOCK_URLS=http://$MOCK_IP:7000" >> "$GITHUB_ENV"
+          echo "WORKER_MOCK_HOSTS=$MOCK_IP" >> "$GITHUB_ENV"
+
+      - name: Wait for FiestaBoard to be ready
+        timeout-minutes: 3
+        run: |
+          for i in $(seq 1 60); do
+            STATUS=$(curl -s -m 5 -o /dev/null -w "%{http_code}" "${WORKER_URLS}/api/health" 2>/dev/null || echo "000")
+            if [ "$STATUS" = "200" ]; then
+              echo "Ready (attempt $i)"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::FiestaBoard did not become ready"
+          exit 1
+
+      - name: Generate baselines
+        working-directory: web
+        timeout-minutes: 10
+        env:
+          CI: true
+          RUN_VISUAL_REGRESSION: "1"
+          WORKER_URLS: ${{ env.WORKER_URLS }}
+          WORKER_MOCK_URLS: ${{ env.WORKER_MOCK_URLS }}
+          WORKER_MOCK_HOSTS: ${{ env.WORKER_MOCK_HOSTS }}
+        # --update-snapshots writes new baselines on disk. The first run
+        # always "fails" with status 1 (snapshots were updated), so we
+        # accept exit 1 here.
+        run: |
+          set +e
+          npx playwright test visual-regression.spec.ts --update-snapshots --workers=1 --reporter=github
+          code=$?
+          set -e
+          if [ "$code" = "0" ] || [ "$code" = "1" ]; then
+            exit 0
+          fi
+          echo "::error::Playwright crashed with exit $code (not a snapshot update)"
+          exit "$code"
+
+      - name: Stop containers
+        if: always()
+        run: docker rm -f fiestaboard mock-board 2>/dev/null || true
+
+      - name: Flip visual regression to required
+        if: inputs.enforce
+        run: |
+          # Remove `continue-on-error: true` from the visual regression step.
+          # We match the precise context so we don't touch other CoE flags.
+          python3 - <<'PY'
+          import re, sys, pathlib
+          p = pathlib.Path('.github/workflows/ci.yml')
+          src = p.read_text()
+          pattern = re.compile(
+              r'(- name: Run visual regression tests\n'
+              r'        id: visual-regression\n'
+              r'        working-directory: web\n)'
+              r'        continue-on-error: true\n',
+          )
+          new, n = pattern.subn(r'\1', src)
+          if n != 1:
+              print(f"::error::expected exactly 1 match for visual regression CoE, found {n}", file=sys.stderr)
+              sys.exit(1)
+          p.write_text(new)
+          print(f"Removed continue-on-error from {n} visual-regression step.")
+          PY
+
+      - name: Open PR with baselines
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: ci/visual-baselines
+          delete-branch: true
+          commit-message: |
+            ci: refresh visual regression baselines
+
+            Generated by .github/workflows/bootstrap-visual-baselines.yml.
+            Review the screenshots before merging.
+          title: "ci: refresh visual regression baselines"
+          body: |
+            Generated by the **Bootstrap Visual Regression Baselines** workflow.
+
+            ## Review checklist
+
+            - [ ] Inspect each generated `*.png` under `web/tests/visual-regression.spec.ts-snapshots/`
+            - [ ] Verify no unexpected UI changes are baked in
+            - [ ] Confirm CI's `Run visual regression tests` step now passes against the new baselines
+
+            > ⚠️ Once merged, the visual regression step is **required** (no longer
+            > `continue-on-error: true`). Future UI changes must regenerate baselines
+            > via this workflow or `npx playwright test --update-snapshots` locally.
+          labels: |
+            ci
+            visual-regression

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -539,11 +539,12 @@ jobs:
       # ── Visual regression tests ───────────────────────────────────
       # Runs visual-regression.spec.ts against the first worker container
       # only (15 screenshot tests don't benefit from per-worker sharding).
-      # `continue-on-error: true` keeps PRs unblocked while baseline
-      # snapshots are being bootstrapped — generated snapshots are
-      # uploaded as artifacts so maintainers can download and commit
-      # them. Once committed, this step compares against the baseline
-      # using the 0.3% pixel threshold defined in the spec file.
+      # `continue-on-error: true` is in place until baseline snapshots are
+      # committed. To bootstrap (or refresh) baselines, run:
+      #   gh workflow run bootstrap-visual-baselines.yml
+      # That workflow opens a PR with the new PNGs and removes this
+      # `continue-on-error: true` line, making the step required.
+      # See docs/development/VISUAL_REGRESSION.md for the full workflow.
       - name: Run visual regression tests
         id: visual-regression
         working-directory: web

--- a/docs/development/VISUAL_REGRESSION.md
+++ b/docs/development/VISUAL_REGRESSION.md
@@ -1,0 +1,83 @@
+# Visual Regression Tests
+
+FiestaBoard's web UI ships with Playwright visual regression tests
+(`web/tests/visual-regression.spec.ts`). Each test renders a critical
+UI state and compares it pixel-by-pixel against a committed baseline
+PNG, using a 0.3 % pixel-diff ratio to tolerate sub-pixel rendering
+differences between runs.
+
+## When CI runs them
+
+The `Run visual regression tests` step lives inside the `E2E Tests`
+job in `.github/workflows/ci.yml`. It runs on every PR (and pushes to
+`main`) when web-relevant paths change. The step uses `--workers=1`
+because the 15-ish screenshot tests don't benefit from sharding.
+
+## Updating baselines
+
+You'll need new baselines when:
+
+- You **intentionally redesigned** a UI surface that one of the tests
+  exercises.
+- A **library or font upgrade** caused acceptable rendering drift.
+- You're **bootstrapping** the test suite for the first time.
+
+There are two supported workflows. Pick whichever fits.
+
+### Option A — locally (faster iteration)
+
+Run the dev stack and regenerate from your laptop:
+
+```bash
+# 1. Start the dev container (per CLAUDE.md, never run npm/python on host).
+docker-compose -f docker-compose.dev.yml up -d
+
+# 2. Wait for the API to be ready.
+curl --retry 30 --retry-delay 1 --retry-connrefused http://localhost:4420/api/health
+
+# 3. Regenerate snapshots inside the container.
+docker-compose -f docker-compose.dev.yml run --rm --profile test web sh -c "
+  cd /web && npx playwright test visual-regression.spec.ts --update-snapshots --workers=1
+"
+
+# 4. Inspect the diff before committing.
+git status web/tests/visual-regression.spec.ts-snapshots/
+git diff --stat web/tests/visual-regression.spec.ts-snapshots/
+git add web/tests/visual-regression.spec.ts-snapshots/
+git commit -m "ci: refresh visual regression baselines"
+```
+
+Different local fonts can produce snapshots that disagree with CI. If
+the resulting PR fails CI visual regression, fall back to Option B.
+
+### Option B — via the bootstrap workflow (matches CI exactly)
+
+```bash
+gh workflow run bootstrap-visual-baselines.yml
+```
+
+The `Bootstrap Visual Regression Baselines` workflow:
+
+1. Builds the production Docker image with the same arguments CI uses.
+2. Boots a single `fiestaboard` + `mock-board` pair.
+3. Runs Playwright with `--update-snapshots`.
+4. Opens a PR titled **"ci: refresh visual regression baselines"** with
+   the new PNGs.
+
+Review the screenshots in the PR before merging. The workflow also
+removes `continue-on-error: true` from the visual regression step on
+first run — once merged, the step is **required**.
+
+## Adding a new screenshot test
+
+1. Add the test to `web/tests/visual-regression.spec.ts` using
+   `expect(page).toHaveScreenshot(snap('your-name'), SCREENSHOT_OPTIONS)`.
+2. Run Option A or B above to generate the baseline.
+3. Commit the new `.png` alongside your test code.
+
+## Why we hide the cursor / today highlight
+
+`maskEditorCursor` and `maskCalendarToday` in the spec file neutralise
+sources of non-determinism (blinking cursors, today highlighting).
+Add similar masks if a new test surface has its own time-varying or
+animation-driven state.


### PR DESCRIPTION
## Summary

Phase 3 of the CI repair series. Adds the missing tooling so visual regression can finally graduate from advisory to required.

- **New workflow:** \`.github/workflows/bootstrap-visual-baselines.yml\` (workflow_dispatch only). Spins up the same Docker test image + mock board as CI, runs Playwright with \`--update-snapshots\`, and opens a PR with the new PNGs. When the \`enforce\` input is true (default), the same PR also removes \`continue-on-error: true\` from the visual regression step.
- **New docs:** \`docs/development/VISUAL_REGRESSION.md\` walks through both regeneration paths (local Docker, vs the bootstrap workflow that matches CI exactly).
- **ci.yml comment refresh** on the visual regression step — points maintainers at the bootstrap workflow instead of the artifact-download dance nobody ever did.

## Why this is a separate PR

The existing \`continue-on-error: true\` is intentionally **kept** in this PR. Removing it without baselines would break CI on this very PR. The follow-up PR opened by the bootstrap workflow is what flips the step to required.

## Test plan

- [ ] Merge this PR
- [ ] Run \`gh workflow run bootstrap-visual-baselines.yml\`
- [ ] Review the auto-opened "ci: refresh visual regression baselines" PR — confirm screenshots look right
- [ ] Confirm that auto-PR's CI run now treats visual regression as required (no green-with-failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)