### PR TITLE
ci: use RELEASE_PAT in bootstrap-visual-baselines

### DIFF
--- a/.github/workflows/bootstrap-visual-baselines.yml
+++ b/.github/workflows/bootstrap-visual-baselines.yml
@@ -151,6 +151,11 @@ jobs:
       - name: Open PR with baselines
         uses: peter-evans/create-pull-request@v7
         with:
+          # GITHUB_TOKEN can't modify workflow files
+          # (`refusing to allow a GitHub App to ... without 'workflows'
+          # permission`). The PR includes a change to ci.yml, so use
+          # the PAT that's already wired for release pushes.
+          token: ${{ secrets.RELEASE_PAT }}
           branch: ci/visual-baselines
           delete-branch: true
           commit-message: |


### PR DESCRIPTION
First live run of the bootstrap workflow failed at the \`create-pull-request\` step:

\`\`\`
remote rejected ci/visual-baselines -> ci/visual-baselines
(refusing to allow a GitHub App to create or update workflow
.github/workflows/ci.yml without 'workflows' permission)
\`\`\`

\`GITHUB_TOKEN\` intentionally cannot modify workflow files. The auto-PR includes a ci.yml change (the \`continue-on-error: true\` removal), so swap to \`RELEASE_PAT\` — the same secret \`release.yml\` already uses for push-to-main.

Five-line targeted fix; baselines were generated successfully, only the PR-opening step needed this token swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)