### PR TITLE
ci: skip Docker Hub login on Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,10 +372,14 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
-        # Skip on fork PRs (no secret access). On internal PRs and main,
-        # fail loudly so we notice credential problems instead of silently
+        # Skip on fork PRs and Dependabot PRs (neither has access to the
+        # DOCKERHUB_* secrets — forks by policy, Dependabot because it uses
+        # a separate secret namespace). On internal PRs and main, fail
+        # loudly so we notice credential problems instead of silently
         # falling back to anonymous pulls with their tiny rate limits.
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: >-
+          (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+          && github.actor != 'dependabot[bot]'
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -416,10 +420,14 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
-        # Skip on fork PRs (no secret access). On internal PRs and main,
-        # fail loudly so we notice credential problems instead of silently
+        # Skip on fork PRs and Dependabot PRs (neither has access to the
+        # DOCKERHUB_* secrets — forks by policy, Dependabot because it uses
+        # a separate secret namespace). On internal PRs and main, fail
+        # loudly so we notice credential problems instead of silently
         # falling back to anonymous pulls with their tiny rate limits.
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: >-
+          (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+          && github.actor != 'dependabot[bot]'
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -587,10 +595,14 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
-        # Skip on fork PRs (no secret access). On internal PRs and main,
-        # fail loudly so we notice credential problems instead of silently
+        # Skip on fork PRs and Dependabot PRs (neither has access to the
+        # DOCKERHUB_* secrets — forks by policy, Dependabot because it uses
+        # a separate secret namespace). On internal PRs and main, fail
+        # loudly so we notice credential problems instead of silently
         # falling back to anonymous pulls with their tiny rate limits.
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: >-
+          (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+          && github.actor != 'dependabot[bot]'
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -732,10 +744,14 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Log in to Docker Hub
-        # Skip on fork PRs (no secret access). On internal PRs and main,
-        # fail loudly so we notice credential problems instead of silently
+        # Skip on fork PRs and Dependabot PRs (neither has access to the
+        # DOCKERHUB_* secrets — forks by policy, Dependabot because it uses
+        # a separate secret namespace). On internal PRs and main, fail
+        # loudly so we notice credential problems instead of silently
         # falling back to anonymous pulls with their tiny rate limits.
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: >-
+          (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+          && github.actor != 'dependabot[bot]'
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
## Summary

- Fixes Dependabot CI failures (e.g. #871) where `build-test-image` fails at the `Log in to Docker Hub` step with `Username and password required`.
- Dependabot PRs run with a restricted token: secrets resolve from the **Dependabot secrets** namespace, not the regular Actions secrets where `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` are configured. The existing guard only skipped the login on **fork PRs**, so internal-but-Dependabot PRs still tried to log in with empty values.
- Extends each of the four `Log in to Docker Hub` guards in `.github/workflows/ci.yml` to also skip when `github.actor == 'dependabot[bot]'`. The Docker build then falls back to anonymous Docker Hub pulls, which is fine for the occasional Dependabot PR.

### Why not add Dependabot secrets instead?

That would also work, but it duplicates the credential out of the org-level Actions secret store and creates another rotation surface. Anonymous pulls are good enough at Dependabot's volume; if we ever see rate-limit hits on Dependabot PRs specifically, we can revisit.

## Test plan

- [ ] CI on this PR passes (this PR is not from Dependabot, so the login path still runs and proves we didn't break the happy path).
- [ ] After merge, comment `@dependabot rebase` on #871 and confirm `build-test-image` no longer fails at the login step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)