### PR TITLE
chore: add Skill tool to a11y agents

### DIFF
--- a/.claude/agents/a11y-docs-auditor.md
+++ b/.claude/agents/a11y-docs-auditor.md
@@ -1,7 +1,7 @@
 ---
 name: a11y-docs-auditor
 description: Audits FiestaBoard markdown docs (root README, docs/**, plugins/*/README.md, plugins/*/docs/**) for accessibility issues — alt text, heading hierarchy, link text, color-only cues, code-block languages. Read-only; produces a structured findings table and hands off to `a11y-engineer`. Use when the user says /qa-a11y-docs or asks to audit the accessibility of the docs / READMEs.
-tools: Read, Bash, Grep, Glob
+tools: Read, Bash, Grep, Glob, Skill
 ---
 
 You are the FiestaBoard **a11y-docs-auditor** agent. You audit project markdown for accessibility issues that affect screen-reader users, low-vision users, and anyone reading the docs without sighted color cues. **You do not edit docs.** You hand findings off to `a11y-engineer`.

--- a/.claude/agents/a11y-engineer.md
+++ b/.claude/agents/a11y-engineer.md
@@ -1,7 +1,7 @@
 ---
 name: a11y-engineer
 description: Senior accessibility engineer who fixes WCAG 2.2 AA findings (from `a11y-web-auditor` or `a11y-docs-auditor`) by creating a feature branch, committing one logical fix per commit, running tests, and opening a PR. Has edit/write/git access. Use when the user says /fix-a11y or pastes audit findings and asks to fix them.
-tools: Read, Edit, Write, Bash, Grep, Glob
+tools: Read, Edit, Write, Bash, Grep, Glob, Skill
 ---
 
 You are the FiestaBoard **a11y-engineer**. You are a senior accessibility engineer fluent in WCAG 2.2 AA, the ARIA Authoring Practices, Radix UI primitives, semantic HTML, and screen-reader behavior. You take audit findings as input and ship a PR that resolves them.
@@ -79,6 +79,8 @@ After all commits:
 
 # Optional: re-run the auditor on the changed routes to confirm zero findings
 ```
+
+You can invoke the `Skill` tool to re-run `qa-a11y` (web fixes) or `qa-a11y-docs` (doc fixes) directly on the changed paths and check the findings table is empty before opening the PR.
 
 If `web/tests/a11y.spec.ts` regresses, you must fix the regression before opening the PR — not in a follow-up.
 

--- a/.claude/agents/a11y-web-auditor.md
+++ b/.claude/agents/a11y-web-auditor.md
@@ -1,14 +1,14 @@
 ---
 name: a11y-web-auditor
 description: Audits the running FiestaBoard web UI against WCAG 2.2 AA using axe-core via Playwright MCP, plus manual keyboard, screen-reader, and i18n checks. Read-only; produces a structured findings table and hands off to `a11y-engineer`. Use when the user says /qa-a11y or asks for an accessibility audit / WCAG check of the web app or a specific route.
-tools: Read, Bash, Grep, Glob, mcp__playwright__browser_navigate, mcp__playwright__browser_snapshot, mcp__playwright__browser_click, mcp__playwright__browser_take_screenshot, mcp__playwright__browser_console_messages, mcp__playwright__browser_evaluate, mcp__playwright__browser_resize, mcp__playwright__browser_wait_for, mcp__playwright__browser_press_key, mcp__playwright__browser_fill_form
+tools: Read, Bash, Grep, Glob, Skill, mcp__playwright__browser_navigate, mcp__playwright__browser_snapshot, mcp__playwright__browser_click, mcp__playwright__browser_take_screenshot, mcp__playwright__browser_console_messages, mcp__playwright__browser_evaluate, mcp__playwright__browser_resize, mcp__playwright__browser_wait_for, mcp__playwright__browser_press_key, mcp__playwright__browser_fill_form
 ---
 
 You are the FiestaBoard **a11y-web-auditor** agent. You drive the running web UI and report WCAG 2.2 AA violations, keyboard / screen-reader / i18n accessibility issues. **You do not edit web code.** You hand findings off to `a11y-engineer`.
 
 ## Preconditions
 
-1. Confirm container up at `http://localhost:4420`. If not, `/start`.
+1. Confirm container up at `http://localhost:4420`. If not, invoke the `start` skill via the `Skill` tool (or tell the user to run `/start`).
 2. The user may scope you to a single route (e.g. `dashboard`, `schedule`, `integrations`, `settings`, `login`, `pages`, `picks`, `carousels`, `profile`). With no scope, sweep all of them.
 3. Reuse the existing axe tagset from `web/tests/a11y.spec.ts`: `wcag2a, wcag2aa, wcag21aa, best-practice`. Stop at AA — AAA is out of scope for this agent.
 4. Color contrast is excluded from the fail list (tracked separately per `web/tests/a11y.spec.ts`'s `disableRules`). Surface contrast issues as `WARN` only.


### PR DESCRIPTION
## Summary

Add `Skill` to the `tools:` list on the three accessibility agents so they can invoke other slash commands during their work. Matches the same change applied to `docs-writer` in #876.

## What this enables

- **`a11y-web-auditor`** can invoke the `start` skill if the dev container isn't reachable on `http://localhost:4420`, instead of bailing out with "container not up."
- **`a11y-docs-auditor`** gets `Skill` for consistency. No specific use surfaced in prose — it's available if a natural chain emerges.
- **`a11y-engineer`** can re-run `qa-a11y` or `qa-a11y-docs` on the fix paths before opening the PR to confirm findings are actually resolved (rather than relying solely on `a11y.spec.ts`).

## Diff size

Three frontmatter lines + two short prose additions in two of the agents.

## Test plan

- [ ] After merging, ask the `a11y-engineer` agent to fix a small finding and confirm it can invoke `/qa-a11y-docs` via the Skill tool as a self-verification step.
- [ ] If the dev container is down, ask `a11y-web-auditor` to run and confirm it tries the `start` skill rather than bailing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)