### PR TITLE
chore: gitignore .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ docs-site/.cache-loader/
 # Team-shared config lives in .claude/settings.json; this file is for individual
 # overrides that should never be committed.
 .claude/settings.local.json
+
+# Claude Code worktrees (per-user, ephemeral isolated checkouts).
+.claude/worktrees/


### PR DESCRIPTION
## Summary
- Ignore `.claude/worktrees/`, the per-user ephemeral directory Claude Code creates for isolated-worktree mode, so it doesn't show up as untracked.

## Test plan
- [x] `git status` no longer lists `.claude/worktrees/`