### PR TITLE
fix(a11y): docs — H1 outline and code-block language identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-<p align="center">
+<h1 align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="docs-site/static/img/branding/logo-lockup-dark.png">
     <source media="(prefers-color-scheme: light)" srcset="docs-site/static/img/branding/logo-lockup-light.png">
     <img alt="FiestaBoard" src="docs-site/static/img/branding/logo-lockup-light.png" width="320">
   </picture>
-</p>
+</h1>
 
 <p align="center">
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ docker-compose -f docker-compose.dev.yml up --build
 
 ### Project Structure
 
-```
+```text
 FiestaBoard/
 ├── plugins/          # Plugin-based data sources (weather, stocks, etc.)
 ├── src/              # Platform core (API server, display service, plugin system)

--- a/docs/development/API_MIGRATION.md
+++ b/docs/development/API_MIGRATION.md
@@ -11,12 +11,12 @@ The `/config/vestaboard` endpoints are deprecated. Use `/config/board` instead.
 ### GET - Retrieve board configuration
 
 **Deprecated (returns `Deprecation: true` header):**
-```
+```http
 GET /config/vestaboard
 ```
 
 **Canonical:**
-```
+```http
 GET /config/board
 ```
 
@@ -35,12 +35,12 @@ GET /config/board
 ### PUT - Update board configuration
 
 **Deprecated (returns `Deprecation: true` header):**
-```
+```http
 PUT /config/vestaboard
 ```
 
 **Canonical:**
-```
+```http
 PUT /config/board
 ```
 
@@ -62,19 +62,19 @@ The `/displays/{display_type}/raw` endpoint is deprecated. Use `/plugins/{plugin
 ### GET - Retrieve plugin/display data
 
 **Deprecated (returns `Deprecation: true` header):**
-```
+```http
 GET /displays/{display_type}/raw
 ```
 
 **Canonical:**
-```
+```http
 GET /plugins/{plugin_id}/data
 ```
 
 The `display_type` and `plugin_id` values are the same identifiers (e.g., `weather`, `datetime`, `stocks`).
 
 **Example - old endpoint:**
-```
+```http
 GET /displays/weather/raw
 ```
 ```json
@@ -87,7 +87,7 @@ GET /displays/weather/raw
 ```
 
 **Example - new endpoint:**
-```
+```http
 GET /plugins/weather/data
 ```
 ```json
@@ -108,7 +108,7 @@ GET /plugins/weather/data
 
 Deprecated endpoints include the following HTTP response headers:
 
-```
+```http
 Deprecation: true
 Link: </config/board>; rel="successor-version"
 ```

--- a/docs/development/PLUGIN_DEVELOPMENT.md
+++ b/docs/development/PLUGIN_DEVELOPMENT.md
@@ -51,7 +51,7 @@ class MyPlugin(PluginBase):
 
 Every key in your `data` dictionary becomes a variable:
 
-```
+```jinja
 {{my_plugin.score}}
 {{my_plugin.status}}
 {{my_plugin.label}}
@@ -218,7 +218,7 @@ When a plugin has many variables, groups help users find what they need:
 
 In the editor, variables render under their group headings:
 
-```
+```text
 ▼ Weather
   Current Conditions
     [temperature] [humidity] [condition]
@@ -250,7 +250,7 @@ For plugins that expose lists of items (transit stops, stock tickers, locations)
 
 In templates, arrays are accessed by index:
 
-```
+```jinja
 {{my_plugin.locations.0.name}}: {{my_plugin.locations.0.temperature}}°F
 {{my_plugin.locations.1.name}}: {{my_plugin.locations.1.temperature}}°F
 ```
@@ -279,7 +279,7 @@ For deeply nested data (e.g., transit stops with multiple lines):
 
 Template usage:
 
-```
+```jinja
 {{my_plugin.stops.0.lines.N.next_arrival}}
 {{my_plugin.stops.0.lines.KT.is_delayed}}
 ```
@@ -321,7 +321,7 @@ If you want only your declared variables to appear (hiding any extra data keys):
 
 ## Plugin Structure
 
-```
+```text
 plugins/my_plugin/
 ├── __init__.py           # Required: Plugin implementation
 ├── manifest.json         # Required: Plugin metadata + screenshots
@@ -567,7 +567,7 @@ class PluginResult:
 
 ### Test Directory Structure
 
-```
+```text
 plugins/my_plugin/tests/
 ├── __init__.py       # Required (can be empty)
 ├── conftest.py       # Test fixtures

--- a/docs/setup/RASPBERRY_PI.md
+++ b/docs/setup/RASPBERRY_PI.md
@@ -43,7 +43,7 @@ If you flashed with `dd` or Balena Etcher (no Imager customisation), you can sti
 1. Open the `bootfs` drive that appeared when you plugged in the SD card.
 2. Create a file named **`fiestapi-wifi.txt`** with the following content:
 
-   ```
+   ```ini
    SSID=YourNetworkName
    PASSWORD=YourPassword
    COUNTRY=US

--- a/plugins/countdown/README.md
+++ b/plugins/countdown/README.md
@@ -14,7 +14,7 @@ The Countdown plugin shows the remaining days, hours, minutes, and seconds until
 
 ### Event Info
 
-```
+```jinja
 {{countdown.event_name}}       # Name of the event (e.g., "Last Day of School")
 {{countdown.target_datetime}}  # Target datetime string (e.g., "2025-06-15T00:00:00")
 {{countdown.is_expired}}       # "true" if the event has passed, "false" otherwise
@@ -22,7 +22,7 @@ The Countdown plugin shows the remaining days, hours, minutes, and seconds until
 
 ### Countdown Values
 
-```
+```jinja
 {{countdown.days}}             # Remaining days (e.g., "22")
 {{countdown.hours}}            # Remaining hours (0-23) (e.g., "3")
 {{countdown.minutes}}          # Remaining minutes (0-59) (e.g., "10")
@@ -35,7 +35,7 @@ The Countdown plugin shows the remaining days, hours, minutes, and seconds until
 
 ### Classic Countdown (Inspired by Vestaboard)
 
-```
+```jinja
 {center}COUNTDOWN UNTIL
 {{countdown.event_name}}
 
@@ -46,21 +46,21 @@ The Countdown plugin shows the remaining days, hours, minutes, and seconds until
 
 ### Compact Countdown
 
-```
+```jinja
 {center}{{countdown.event_name}}
 {{countdown.days}}D {{countdown.hours}}H {{countdown.minutes}}M
 ```
 
 ### Days Only
 
-```
+```jinja
 {center}{{countdown.days}} DAYS UNTIL
 {{countdown.event_name}}
 ```
 
 ### Full Countdown with Seconds
 
-```
+```jinja
 {center}{{countdown.event_name}}
 {{countdown.days}}D {{countdown.hours}}H
 {{countdown.minutes}}M {{countdown.seconds}}S

--- a/plugins/countdown/docs/SETUP.md
+++ b/plugins/countdown/docs/SETUP.md
@@ -47,7 +47,7 @@ Create or edit a page template to display the countdown:
 
 Example classic countdown template:
 
-```
+```jinja
 {center}COUNTDOWN UNTIL
 {{countdown.event_name}}
 
@@ -82,7 +82,7 @@ Available variables:
 
 ### Classic Countdown
 
-```
+```jinja
 {center}COUNTDOWN UNTIL
 {{countdown.event_name}}
 
@@ -93,7 +93,7 @@ Available variables:
 
 ### Compact Countdown
 
-```
+```jinja
 {center}{{countdown.event_name}}
 {{countdown.days}}D {{countdown.hours}}H {{countdown.minutes}}M
 ```

--- a/plugins/date_time/README.md
+++ b/plugins/date_time/README.md
@@ -14,7 +14,7 @@ The Date & Time plugin provides various date and time variables that update auto
 
 ### Time Variables
 
-```
+```jinja
 {{date_time.time}}          # 24-hour format (e.g., "14:30")
 {{date_time.time_24h}}      # 24-hour format (e.g., "14:30")
 {{date_time.time_12h}}      # 12-hour format with AM/PM (e.g., "2:30 PM")
@@ -24,7 +24,7 @@ The Date & Time plugin provides various date and time variables that update auto
 
 ### Date Variables
 
-```
+```jinja
 {{date_time.date}}          # ISO format (e.g., "2025-01-15")
 {{date_time.date_us}}       # US format MM/DD/YYYY (e.g., "01/15/2025")
 {{date_time.date_us_short}} # US format MM/DD/YY (e.g., "01/15/25")
@@ -33,14 +33,14 @@ The Date & Time plugin provides various date and time variables that update auto
 
 ### Day Variables
 
-```
+```jinja
 {{date_time.day_of_week}}   # Full day name (e.g., "Wednesday")
 {{date_time.day}}           # Day of month 1-31 (e.g., "15")
 ```
 
 ### Month Variables
 
-```
+```jinja
 {{date_time.month}}              # Full month name (e.g., "January")
 {{date_time.month_abbr}}         # 3-letter abbreviation (e.g., "Jan")
 {{date_time.month_number}}        # Month number 1-12 (e.g., "1")
@@ -49,13 +49,13 @@ The Date & Time plugin provides various date and time variables that update auto
 
 ### Year Variables
 
-```
+```jinja
 {{date_time.year}}          # Year (e.g., "2025")
 ```
 
 ### Timezone Variables
 
-```
+```jinja
 {{date_time.timezone}}      # Full timezone name (e.g., "America/Los_Angeles")
 {{date_time.timezone_abbr}} # Timezone abbreviation (e.g., "PST")
 ```
@@ -64,19 +64,19 @@ The Date & Time plugin provides various date and time variables that update auto
 
 ### Simple 24-Hour Clock
 
-```
+```jinja
 {center}{{date_time.time_24h}}
 ```
 
 ### Simple 12-Hour Clock
 
-```
+```jinja
 {center}{{date_time.time_12h}}
 ```
 
 ### Full Date Display
 
-```
+```jinja
 {center}{{date_time.day_of_week}}
 {{date_time.date}}
 {{date_time.time_12h}}
@@ -84,28 +84,28 @@ The Date & Time plugin provides various date and time variables that update auto
 
 ### US Date Format
 
-```
+```jinja
 {center}{{date_time.date_us}}
 {{date_time.time_12h}} {{date_time.timezone_abbr}}
 ```
 
 ### Classic Format
 
-```
+```jinja
 {center}{{date_time.month}} {{date_time.day}}, {{date_time.year}}
 {{date_time.time_12h}} {{date_time.timezone_abbr}}
 ```
 
 ### Compact Format
 
-```
+```jinja
 {center}{{date_time.month_abbr}} {{date_time.day}}
 {{date_time.time_12h}}
 ```
 
 ### Date Components
 
-```
+```jinja
 {center}{{date_time.month_number_padded}}/{{date_time.day}}/{{date_time.year}}
 {{date_time.day_of_week}}
 ```

--- a/plugins/date_time/docs/SETUP.md
+++ b/plugins/date_time/docs/SETUP.md
@@ -102,19 +102,19 @@ The plugin provides a comprehensive set of template variables:
 
 ### Simple 24-Hour Clock
 
-```
+```jinja
 {center}{{date_time.time_24h}}
 ```
 
 ### Simple 12-Hour Clock
 
-```
+```jinja
 {center}{{date_time.time_12h}}
 ```
 
 ### Full Date Display
 
-```
+```jinja
 {center}{{date_time.day_of_week}}
 {{date_time.date}}
 {{date_time.time_12h}}
@@ -122,28 +122,28 @@ The plugin provides a comprehensive set of template variables:
 
 ### US Date Format
 
-```
+```jinja
 {center}{{date_time.date_us}}
 {{date_time.time_12h}} {{date_time.timezone_abbr}}
 ```
 
 ### Classic Format
 
-```
+```jinja
 {center}{{date_time.month}} {{date_time.day}}, {{date_time.year}}
 {{date_time.time_12h}} {{date_time.timezone_abbr}}
 ```
 
 ### Compact Format
 
-```
+```jinja
 {center}{{date_time.month_abbr}} {{date_time.day}}
 {{date_time.time_12h}}
 ```
 
 ### Date Components
 
-```
+```jinja
 {center}{{date_time.month_number_padded}}/{{date_time.day}}/{{date_time.year}}
 {{date_time.day_of_week}}
 ```

--- a/plugins/random/README.md
+++ b/plugins/random/README.md
@@ -31,29 +31,29 @@ The Random plugin generates fresh random values on a schedule you control. It ex
 ## Example Templates
 
 **Coin flip:**
-```
+```jinja
 COIN FLIP
 {{random.coin_flip}}
 ```
 
 **Pick from a custom list:**
-```
+```jinja
 TONIGHT'S DINNER
 {{random.choice}}
 ```
 
 **Random color tile:**
-```
+```jinja
 {{random.color}}
 ```
 
 **Color tile with name:**
-```
+```jinja
 {{random.color}} {{random.color_name}}
 ```
 
 **Combined:**
-```
+```jinja
 
 FLIP: {{random.coin_flip}}
 PICK: {{random.choice}}


### PR DESCRIPTION
## Summary

Resolves accessibility findings from `/qa-a11y-docs` on the FiestaBoard markdown documentation. One serious finding (missing H1 in root README) plus a batch of minor code-block language-identifier fixes across platform and plugin docs.

## Findings addressed

### Serious
- **[WCAG 2.2 AA 1.3.1 Info and Relationships, 2.4.6 Headings and Labels]** `README.md:1-7` — The document outline started at H2 (`## Get Started in 5 Minutes`). The centered logo `<picture>` lockup is now wrapped in an `<h1>` element (instead of `<p>`), giving the document a proper top-level heading. The existing `alt="FiestaBoard"` on the inner `<img>` provides the heading's accessible name; visual presentation is unchanged.

### Minor — code blocks now have language identifiers

All of the following programmatically identify the language of fenced code blocks so assistive tech and tooling can convey the content type accurately and renderers can apply syntax highlighting. WCAG criteria: **1.3.1 Info and Relationships**, and **3.1.1 Language of Page** (analogous principle applied to code content).

- `README.md:362` — project-structure ASCII tree → ` ```text `
- `docs/development/API_MIGRATION.md:14,19,38,43,65,70,77,90,111` — HTTP request/response examples → ` ```http `
- `docs/development/PLUGIN_DEVELOPMENT.md:54,253,282` — Jinja template variable usage → ` ```jinja `
- `docs/development/PLUGIN_DEVELOPMENT.md:221,324,570` — editor variable picker tree + plugin/test directory trees → ` ```text `
- `docs/setup/RASPBERRY_PI.md:46` — `fiestapi-wifi.txt` key=value Wi-Fi config → ` ```ini `
- `plugins/countdown/README.md:17,25,38,49,56,63` — template variable refs + example templates → ` ```jinja `
- `plugins/countdown/docs/SETUP.md:50,85,96` — example countdown templates → ` ```jinja `
- `plugins/date_time/README.md:17,27,36,43,52,58,67,73,79,87,94,101,108` — template variable groups + examples → ` ```jinja `
- `plugins/date_time/docs/SETUP.md:105,111,117,125,132,139,146` — example templates → ` ```jinja `
- `plugins/random/README.md:34,40,46,51,56` — example template snippets → ` ```jinja `

## Commits

1. `fix(a11y): add H1 to root README for document outline`
2. `fix(a11y): label HTTP request code blocks in API_MIGRATION.md`
3. `fix(a11y): label code blocks in PLUGIN_DEVELOPMENT.md`
4. `fix(a11y): label code blocks in plugin docs`
5. `fix(a11y): label remaining code blocks`

## Test plan

Doc-only PR — no application code or test changes; `web/tests/a11y.spec.ts` is unaffected. Manual verification:

- [ ] Render `README.md` on GitHub and confirm the FiestaBoard logo lockup is now the document's H1 (visible in the GitHub document outline / "Outline" pane).
- [ ] Render each touched doc on GitHub and confirm code blocks display with the expected syntax highlighting (HTTP coloring on API_MIGRATION examples, Jinja/Mustache-style highlighting on template snippets, plain text for ASCII trees, INI coloring for the Wi-Fi config).
- [ ] Re-run `/qa-a11y-docs` on the changed files and confirm zero remaining findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)