### PR TITLE
fix(a11y): docs-site WCAG 2.2 AA findings

### DIFF
--- a/docs-site/docs/deployment/fiestaupdater.md
+++ b/docs-site/docs/deployment/fiestaupdater.md
@@ -31,7 +31,7 @@ with a `socat`-driven HTTP listener and a single shell handler script.
 
 ## Architecture
 
-```
+```text
 ┌──────────────────────────────────────────────────────┐
 │                    Docker host                        │
 │                                                       │

--- a/docs-site/docs/deployment/fiestaupdater.md
+++ b/docs-site/docs/deployment/fiestaupdater.md
@@ -68,7 +68,7 @@ Key properties:
 | **Docker / manual** | Off by default; opt in via `COMPOSE_PROFILES` | Off — banner shown, user clicks Update Now |
 
 On FiestaPi the `FIESTAUPDATER_TOKEN` is generated automatically on first boot
-by `firstboot.sh`. On Docker installs you generate it yourself (see below).
+by `firstboot.sh`. On Docker installs you generate it yourself (see [Enabling on an existing Docker install](#enabling-on-an-existing-docker-install)).
 
 ## Docker Compose configuration
 

--- a/docs-site/docs/development/plugin-guide.md
+++ b/docs-site/docs/development/plugin-guide.md
@@ -77,7 +77,7 @@ cp -r plugins/_template plugins/my_plugin
 
 This gives you the required directory structure:
 
-```
+```text
 plugins/my_plugin/
 ├── __init__.py          # Plugin class (PluginBase subclass)
 ├── manifest.json        # Plugin metadata and configuration schema
@@ -492,7 +492,7 @@ class DateTimePlugin(PluginBase):
 
 ### Test Structure
 
-```
+```text
 plugins/my_plugin/tests/
 ├── __init__.py       # Required (can be empty)
 ├── conftest.py       # Shared test fixtures
@@ -867,7 +867,7 @@ You can also develop a plugin as a standalone git repository instead of adding i
 
 Your external plugin repository should have the same structure as a built-in plugin, but at the repository root:
 
-```
+```text
 fiestaboard-plugin--my-weather/
 ├── __init__.py          # Plugin class (PluginBase subclass)
 ├── manifest.json        # Plugin metadata and configuration schema
@@ -882,7 +882,7 @@ fiestaboard-plugin--my-weather/
 
 If you want your plugin listed in the official **plugin registry**, your repository **must** follow this naming convention:
 
-```
+```text
 fiestaboard-plugin--{name}
 ```
 

--- a/docs-site/docs/development/plugin-guide.md
+++ b/docs-site/docs/development/plugin-guide.md
@@ -161,7 +161,7 @@ These fields are not enforced by the manifest validator but should be included i
 | `category` | string | `"utility"` | Grouping category. Valid values: `"art"`, `"data"`, `"transit"`, `"weather"`, `"entertainment"`, `"utility"`, `"home"`. |
 | `repository` | string | - | GitHub repository URL. |
 | `documentation` | string | `"README.md"` | Path to documentation file relative to plugin directory. |
-| `env_vars` | array | `[]` | Environment variables the plugin can read (see below). |
+| `env_vars` | array | `[]` | Environment variables the plugin can read (see [Environment Variables](#environment-variables)). |
 | `color_rules_schema` | object | `{}` | Schema for dynamic color rules. |
 
 ### Settings Schema

--- a/docs-site/docs/plugins/air-fog.md
+++ b/docs-site/docs/plugins/air-fog.md
@@ -24,11 +24,11 @@ The Air Quality & Fog plugin provides:
 ### 1. Get API Keys
 
 **PurpleAir (for AQI):**
-1. Sign up at [purpleair.com](https://www.purpleair.com/)
+1. Sign up at [PurpleAir](https://www.purpleair.com/)
 2. Request an API key from the PurpleAir data page
 
 **OpenWeatherMap (for visibility/fog):**
-1. Sign up at [openweathermap.org](https://openweathermap.org/api)
+1. Sign up at [OpenWeatherMap](https://openweathermap.org/api)
 2. Free tier: 1,000 calls/day
 
 Pollen data is fetched from [Open-Meteo](https://open-meteo.com/) automatically and requires no API key.

--- a/docs-site/docs/plugins/configuration.md
+++ b/docs-site/docs/plugins/configuration.md
@@ -41,7 +41,7 @@ Once a plugin is enabled, its data becomes available as **template variables** i
 
 Variables use the format `{{plugin_name.variable_name}}`:
 
-```
+```text
 Temperature: {{weather.temperature}}
 Conditions:  {{weather.condition}}
 ```
@@ -52,7 +52,7 @@ When the page is displayed on your board, these are replaced with live data (e.g
 
 Some plugins provide variables that fill the entire board:
 
-```
+```text
 {{visual_clock.display}}    → Fills all rows with a large clock
 {{sun_art.display}}         → Fills all rows with sun art
 ```
@@ -61,7 +61,7 @@ Some plugins provide variables that fill the entire board:
 
 Some plugins provide array variables that expand into multiple lines:
 
-```
+```text
 {{stocks.prices}}    → Multiple rows of stock data
 {{muni.formatted}}   → Multiple rows of transit arrivals
 ```

--- a/docs-site/docs/plugins/guest-wifi.md
+++ b/docs-site/docs/plugins/guest-wifi.md
@@ -35,7 +35,7 @@ The Guest WiFi plugin provides a simple way to share WiFi credentials:
 
 ## Example Page Layout
 
-```
+```text
 ┌──────────────────────┐
 │                      │
 │  WIFI NETWORK        │

--- a/docs-site/docs/plugins/home-assistant.md
+++ b/docs-site/docs/plugins/home-assistant.md
@@ -61,7 +61,7 @@ The plugin uses colors to indicate state:
 
 ## Example Display
 
-```
+```text
 ┌──────────────────────┐
 │   HOME STATUS        │
 │  FRONT DOOR   CLOSED │

--- a/docs-site/docs/plugins/muni.md
+++ b/docs-site/docs/plugins/muni.md
@@ -22,7 +22,7 @@ The SF Muni plugin provides:
 
 ### 1. Get an API Key
 
-1. Go to [511.org/open-data/token](https://511.org/open-data/token)
+1. Go to [the 511.org Open Data token page](https://511.org/open-data/token)
 2. Register for a free API key
 
 ### 2. Enable in the Web UI

--- a/docs-site/docs/plugins/nearby-aircraft.md
+++ b/docs-site/docs/plugins/nearby-aircraft.md
@@ -28,7 +28,7 @@ The Nearby Aircraft plugin shows:
 5. Click **Save Changes**
 
 :::tip
-No API key is required for basic usage. An optional OpenSky Network account increases rate limits -- register free at [opensky-network.org](https://opensky-network.org/).
+No API key is required for basic usage. An optional OpenSky Network account increases rate limits -- register free at [the OpenSky Network](https://opensky-network.org/).
 :::
 
 ## Available Variables

--- a/docs-site/docs/plugins/overview.md
+++ b/docs-site/docs/plugins/overview.md
@@ -56,8 +56,8 @@ These plugins need a free API key from an external service:
 
 | Plugin | What It Shows | Where to Get the Key |
 |--------|--------------|---------------------|
-| **Weather** | Temperature, UV index, precipitation, high/low, sunset | [weatherapi.com](https://www.weatherapi.com/) (1M calls/month free) or [openweathermap.org](https://openweathermap.org/api) |
-| **Muni Transit** | Real-time SF Muni arrival predictions | [511.org](https://511.org/open-data/token) (free) |
+| **Weather** | Temperature, UV index, precipitation, high/low, sunset | [WeatherAPI](https://www.weatherapi.com/) (1M calls/month free) or [OpenWeatherMap](https://openweathermap.org/api) |
+| **Muni Transit** | Real-time SF Muni arrival predictions | [511.org Open Data token](https://511.org/open-data/token) (free) |
 | **WSDOT Ferries** | WA State ferry schedules, vessel names, car spots, and alerts | [wsdot.wa.gov/traffic/api](https://wsdot.wa.gov/traffic/api/) (free) |
 | **Last.fm Now Playing** | Currently playing music via Last.fm scrobbling | [last.fm/api](https://www.last.fm/api/account/create) (free) |
 
@@ -77,9 +77,9 @@ These plugins work without an API key but offer additional features with one:
 
 | Plugin | Without API Key | With API Key |
 |--------|----------------|-------------|
-| **Stocks** | Monitor stock prices with color-coded indicators | Better symbol search/autocomplete ([finnhub.io](https://finnhub.io/)) |
-| **Sports Scores** | NFL, Soccer, NHL, NBA match scores | Extended data ([thesportsdb.com](https://www.thesportsdb.com/)) |
-| **Nearby Aircraft** | Real-time aircraft info from OpenSky Network | Higher rate limits ([opensky-network.org](https://opensky-network.org/)) |
+| **Stocks** | Monitor stock prices with color-coded indicators | Better symbol search/autocomplete ([Finnhub](https://finnhub.io/)) |
+| **Sports Scores** | NFL, Soccer, NHL, NBA match scores | Extended data ([TheSportsDB](https://www.thesportsdb.com/)) |
+| **Nearby Aircraft** | Real-time aircraft info from OpenSky Network | Higher rate limits ([OpenSky Network](https://opensky-network.org/)) |
 
 ## Using Plugin Data in Pages
 

--- a/docs-site/docs/plugins/sports-scores.md
+++ b/docs-site/docs/plugins/sports-scores.md
@@ -47,7 +47,7 @@ The Sports Scores plugin works **without an API key** using free data from TheSp
 
 ## Example Display
 
-```
+```text
 ┌──────────────────────┐
 │  SPORTS SCORES       │
 │  NFL  CHIEFS 27      │

--- a/docs-site/docs/plugins/sports-scores.md
+++ b/docs-site/docs/plugins/sports-scores.md
@@ -26,7 +26,7 @@ The Sports Scores plugin works **without an API key** using free data from TheSp
 
 ### Enhanced Setup (Optional API Key)
 
-1. Sign up at [thesportsdb.com](https://www.thesportsdb.com/)
+1. Sign up at [TheSportsDB](https://www.thesportsdb.com/)
 2. Get a free API key
 3. In the Web UI, go to **Integrations** > **Sports Scores** and enter the key
 

--- a/docs-site/docs/plugins/stocks.md
+++ b/docs-site/docs/plugins/stocks.md
@@ -29,7 +29,7 @@ The Stock Prices plugin shows:
 6. Click **Save Changes**
 
 :::tip
-No API key is required for stock data. An optional Finnhub API key enables better symbol search -- get one free at [finnhub.io](https://finnhub.io/).
+No API key is required for stock data. An optional Finnhub API key enables better symbol search -- get one free at [Finnhub](https://finnhub.io/).
 :::
 
 ## Available Variables

--- a/docs-site/docs/plugins/weather.md
+++ b/docs-site/docs/plugins/weather.md
@@ -86,7 +86,7 @@ The board uses special characters for weather conditions:
 
 ## Example Page Layout
 
-```
+```text
 ┌──────────────────────┐
 │  SAN FRANCISCO  72*F │
 │  SUNNY     H78  L58  │

--- a/docs-site/docs/plugins/weather.md
+++ b/docs-site/docs/plugins/weather.md
@@ -26,12 +26,12 @@ The Weather plugin provides real-time weather data for your location, including:
 ### 1. Get an API Key
 
 **WeatherAPI.com (Recommended):**
-1. Sign up at [weatherapi.com](https://www.weatherapi.com/)
+1. Sign up at [WeatherAPI](https://www.weatherapi.com/)
 2. Free tier: 1 million calls/month
 3. No credit card required
 
 **OpenWeatherMap (Alternative):**
-1. Sign up at [openweathermap.org](https://openweathermap.org/api)
+1. Sign up at [OpenWeatherMap](https://openweathermap.org/api)
 2. Free tier: 1,000 calls/day
 
 ### 2. Enable and Configure in the Web UI

--- a/docs-site/docs/reference/api-endpoints.md
+++ b/docs-site/docs/reference/api-endpoints.md
@@ -10,7 +10,7 @@ FiestaBoard provides a REST API powered by FastAPI. Interactive API documentatio
 
 ## Base URL
 
-```
+```text
 http://localhost:4420
 ```
 
@@ -167,7 +167,7 @@ curl -X POST http://localhost:4420/api/pages/1/preview
 
 For a complete interactive API explorer with request/response schemas, visit:
 
-```
+```text
 http://localhost:4420/api/docs
 ```
 

--- a/docs-site/docs/setup/api-keys.md
+++ b/docs-site/docs/setup/api-keys.md
@@ -16,7 +16,7 @@ The install wizard asks for this during setup. If you need to find or change you
 
 Faster updates, supports transition animations, requires same-network access.
 
-1. Request a Local API enablement token at [vestaboard.com/local-api](https://www.vestaboard.com/local-api)
+1. Request a Local API enablement token at [the Vestaboard Local API token page](https://www.vestaboard.com/local-api)
 2. After approval, Vestaboard will email you an enablement token
 3. Use the enablement token to enable the Local API on your board — you can do this through FiestaBoard's **Settings** page (select the **Enablement Token** option) or via a `curl` command (see the [Vestaboard Local API docs](https://docs.vestaboard.com/docs/local-api/authentication))
 4. Save the API key returned in the response
@@ -27,7 +27,7 @@ Faster updates, supports transition animations, requires same-network access.
 
 Works from anywhere with internet. No transition animation support.
 
-1. Go to [web.vestaboard.com](https://web.vestaboard.com)
+1. Go to [your Vestaboard account](https://web.vestaboard.com)
 2. Log in with your board account
 3. Navigate to the API section
 4. Enable the **Read/Write API**
@@ -45,11 +45,11 @@ These are optional. Enter them in the **Integrations page** of the web UI as you
 
 | Plugin | Where to Get the Key | Free Tier |
 |--------|---------------------|-----------|
-| Weather | [weatherapi.com](https://www.weatherapi.com/) or [openweathermap.org](https://openweathermap.org/api) | 1M calls/month (WeatherAPI) |
+| Weather | [WeatherAPI](https://www.weatherapi.com/) or [OpenWeatherMap](https://openweathermap.org/api) | 1M calls/month (WeatherAPI) |
 | Traffic | [Google Cloud Console](https://console.cloud.google.com/) (Routes API) | $200/month credit |
 | Home Assistant | Your HA instance → Profile → Long-Lived Access Tokens | Self-hosted |
 | Last.fm | [last.fm/api/account/create](https://www.last.fm/api/account/create) | Unlimited |
-| Muni Transit | [511.org/open-data/token](https://511.org/open-data/token) | Free |
+| Muni Transit | [511.org Open Data token](https://511.org/open-data/token) | Free |
 | WSDOT Ferries | [wsdot.wa.gov/traffic/api](https://wsdot.wa.gov/traffic/api/) | Free |
 | Air Quality | PurpleAir or OpenWeatherMap | Varies |
 
@@ -57,8 +57,8 @@ These are optional. Enter them in the **Integrations page** of the web UI as you
 
 | Plugin | API Key | What It Unlocks |
 |--------|---------|----------------|
-| Stocks | [finnhub.io](https://finnhub.io/) | Better symbol search/autocomplete |
-| Sports Scores | [thesportsdb.com](https://www.thesportsdb.com/) | Extended data |
+| Stocks | [Finnhub](https://finnhub.io/) | Better symbol search/autocomplete |
+| Sports Scores | [TheSportsDB](https://www.thesportsdb.com/) | Extended data |
 | Nearby Aircraft | [OpenSky Network](https://opensky-network.org/) | Higher rate limits |
 
 ### Plugins That Need No API Key

--- a/docs-site/docs/setup/beginners-guide.md
+++ b/docs-site/docs/setup/beginners-guide.md
@@ -15,7 +15,7 @@ Never used Docker or the command line before? No problem. This guide walks throu
 - A split-flap display that's already set up and working with the board's app
 - Your board's API key (Step 2 below shows you where to find it)
 - An internet connection
-- **Either** a Raspberry Pi + microSD card (the easiest path — see below), **or** a computer (Mac, Windows, or Linux) where we'll install Docker
+- **Either** a Raspberry Pi + microSD card (see [The Easiest Path: Flash a Raspberry Pi](#the-easiest-path-flash-a-raspberry-pi)), **or** a computer (Mac, Windows, or Linux) where we'll install Docker
 
 ## The Easiest Path: Flash a Raspberry Pi
 

--- a/docs-site/docs/setup/beginners-guide.md
+++ b/docs-site/docs/setup/beginners-guide.md
@@ -28,7 +28,7 @@ The simplest, most reliable way to run FiestaBoard — even if you've never touc
 If you have (or are willing to buy) a Raspberry Pi, this is by far the easiest route. Here's the whole process:
 
 1. **Get a Raspberry Pi** (3B or newer — the Pi 4, Pi 5, and the inexpensive [Pi Zero 2 W](https://www.raspberrypi.com/products/raspberry-pi-zero-2-w/) all work), plus a microSD card (8 GB minimum, 16 GB+ recommended) and a 5 V power supply.
-2. **Download Raspberry Pi Imager** — a free, official tool from the Raspberry Pi Foundation that flashes images to SD cards. Available for Mac, Windows, and Linux at [raspberrypi.com/software](https://www.raspberrypi.com/software/).
+2. **Download Raspberry Pi Imager** — a free, official tool from the Raspberry Pi Foundation that flashes images to SD cards. Available for Mac, Windows, and Linux on [the Raspberry Pi Imager downloads page](https://www.raspberrypi.com/software/).
 3. **Download the FiestaPi image** from our [GitHub Releases page](https://github.com/Fiestaboard/FiestaBoard/releases/latest) — grab the file named `FiestaPi-<version>-arm64.img.xz`.
 4. **Flash the SD card** with Raspberry Pi Imager:
    - Choose Device → your Pi model
@@ -37,7 +37,7 @@ If you have (or are willing to buy) a Raspberry Pi, this is by far the easiest r
    - Click **Next** and use **Edit Settings** to pre-configure your Wi-Fi network and timezone
    - Click **Write** and wait ~5 minutes
 5. **Insert the SD card into the Pi, plug it in**, and wait 2–3 minutes for first boot.
-6. **Open a browser** on any device on the same network and go to **[http://fiestapi.local:4420](http://fiestapi.local:4420)** — you'll see the FiestaBoard setup wizard.
+6. **Open a browser** on any device on the same network and go to **[the FiestaBoard setup wizard](http://fiestapi.local:4420)** at `http://fiestapi.local:4420`.
 7. **Skip ahead to Step 2** below to grab your board's API key, then enter it in the wizard. You're done.
 
 That's the whole thing. No Docker. No Terminal. No PowerShell. The Pi runs FiestaBoard 24/7 and updates itself with one click in **Settings → System** when new versions release.
@@ -94,7 +94,7 @@ Your board API key is what lets FiestaBoard talk to your display. You can use ei
 
 This is faster and supports transition animations. Your board and computer need to be on the same WiFi network.
 
-1. Go to [vestaboard.com/local-api](https://www.vestaboard.com/local-api) and request a Local API enablement token
+1. Go to [the Vestaboard Local API token page](https://www.vestaboard.com/local-api) and request a Local API enablement token
 2. After approval, Vestaboard will email you the token
 3. Use the token to enable the Local API on your board — FiestaBoard's setup wizard and **Settings** page can do this for you (select the **Enablement Token** option and enter the token), or see the [Vestaboard Local API docs](https://docs.vestaboard.com/docs/local-api/authentication) for how to do it via `curl`
 4. Save the **API key** returned in the response, and note your board's **IP address** (you can find it on your router or use FiestaBoard's network scan)
@@ -103,7 +103,7 @@ This is faster and supports transition animations. Your board and computer need 
 
 Use this if your board and computer are on different networks, or if Local API isn't available for your board.
 
-1. Go to [web.vestaboard.com](https://web.vestaboard.com) and log in
+1. Go to [your Vestaboard account at web.vestaboard.com](https://web.vestaboard.com) and log in
 2. Navigate to the API section
 3. Enable the **Read/Write API**
 4. Copy the API key and save it somewhere safe
@@ -166,7 +166,7 @@ The wizard will:
 
 ### Path C: Download ZIP (No Git, No curl)
 
-1. Go to [github.com/Fiestaboard/FiestaBoard](https://github.com/Fiestaboard/FiestaBoard)
+1. Go to [the FiestaBoard repository on GitHub](https://github.com/Fiestaboard/FiestaBoard)
 2. Click the green **Code** button
 3. Click **Download ZIP**
 4. Extract the ZIP file to a folder you'll remember (like Documents)

--- a/docs-site/docs/setup/cloud-api.md
+++ b/docs-site/docs/setup/cloud-api.md
@@ -29,7 +29,7 @@ By default, FiestaBoard communicates with your board over the local network (Loc
 
 ### Step 1: Get Your Cloud API Key
 
-1. Go to [web.vestaboard.com](https://web.vestaboard.com)
+1. Go to [your Vestaboard account](https://web.vestaboard.com)
 2. Log in to your account
 3. Navigate to the API section
 4. Enable the **Read/Write API**
@@ -69,7 +69,7 @@ The Cloud API has a rate limit of **1 message per 15 seconds**. If you see rate 
 ### 401 Unauthorized
 
 - Double-check your Read/Write API key in Settings
-- Make sure the key is still active at [web.vestaboard.com](https://web.vestaboard.com)
+- Make sure the key is still active in [your Vestaboard account](https://web.vestaboard.com)
 - Verify there are no extra spaces or line breaks in the key
 
 ### Rate Limit Errors

--- a/docs-site/docs/setup/docker-setup.md
+++ b/docs-site/docs/setup/docker-setup.md
@@ -24,7 +24,7 @@ FiestaBoard runs in a single unified container:
 |-----------|---------|------|-------------|
 | `fiestaboard` | Nginx + FastAPI + Next.js | 4420 | Web UI, REST API, display service, plugin system |
 
-```
+```text
 ┌──────────────────────────────────────────────┐
 │                   Browser                     │
 │              http://localhost:4420             │

--- a/docs-site/docs/setup/first-10-minutes.md
+++ b/docs-site/docs/setup/first-10-minutes.md
@@ -74,7 +74,7 @@ Click any variable to insert it into your page at the cursor position. When the 
 
 Here's a page layout you could create using Date & Time and Star Trek Quotes:
 
-```
+```text
   GOOD MORNING
   {date_time.date}
   {date_time.time}

--- a/docs-site/docs/setup/home-assistant-mqtt.md
+++ b/docs-site/docs/setup/home-assistant-mqtt.md
@@ -43,12 +43,12 @@ An MQTT broker is the message relay between FiestaBoard and Home Assistant. You 
 | Situation | What to do |
 |-----------|------------|
 | You use Zigbee2MQTT, Tasmota, ESPHome, or Frigate | You already have a broker. [Skip to Step 2.](#step-2-enable-the-mqtt-integration-in-home-assistant) |
-| You run Home Assistant OS or Supervised | Install the Mosquitto add-on — takes about 2 minutes. See below. |
-| You run Home Assistant Container or Core | Install Mosquitto on your server. See below. |
+| You run Home Assistant OS or Supervised | Install the Mosquitto add-on — takes about 2 minutes. See [Installing the Mosquitto add-on](#installing-the-mosquitto-add-on-haos--supervised). |
+| You run Home Assistant Container or Core | Install Mosquitto on your server. See [Installing Mosquitto standalone](#installing-mosquitto-standalone-container--core--separate-machine). |
 
 ---
 
-### Installing the Mosquitto add-on (HAOS / Supervised)
+### Installing the Mosquitto add-on (HAOS / Supervised) {#installing-the-mosquitto-add-on-haos--supervised}
 
 The Mosquitto broker add-on is a one-click install inside Home Assistant:
 
@@ -72,7 +72,7 @@ If you don't see the **Users** section, go to your Profile and enable **Advanced
 
 ---
 
-### Installing Mosquitto standalone (Container / Core / separate machine)
+### Installing Mosquitto standalone (Container / Core / separate machine) {#installing-mosquitto-standalone-container--core--separate-machine}
 
 If you don't have the HA add-on store, install Mosquitto directly on your server:
 

--- a/docs-site/docs/setup/home-assistant-mqtt.md
+++ b/docs-site/docs/setup/home-assistant-mqtt.md
@@ -18,7 +18,7 @@ FiestaBoard uses [MQTT Discovery](https://www.home-assistant.io/integrations/mqt
 
 The result: a **FiestaBoard device** appears in HA with switches, selects, sensors, and buttons you can use in automations and dashboards.
 
-```
+```text
 FiestaBoard ──────── MQTT broker ──────── Home Assistant
   (publishes state)   (Mosquitto)           (reads state,
   (reads commands)                           sends commands)

--- a/docs-site/docs/setup/local-development.md
+++ b/docs-site/docs/setup/local-development.md
@@ -24,7 +24,7 @@ The development environment uses the **same single-container layout** as product
 
 ## Project Structure
 
-```
+```text
 FiestaBoard/
 ├── plugins/                    # Plugin-based data sources
 │   ├── _template/              # Template for new plugins

--- a/docs-site/docs/setup/quick-start.md
+++ b/docs-site/docs/setup/quick-start.md
@@ -114,7 +114,7 @@ Have your board API key ready before running setup. There are two connection mod
 
 Faster updates, supports transition animations, works over your local network.
 
-1. Request a Local API enablement token at [vestaboard.com/local-api](https://www.vestaboard.com/local-api)
+1. Request a Local API enablement token at [the Vestaboard Local API token page](https://www.vestaboard.com/local-api)
 2. After approval, Vestaboard emails you the token
 3. Use the token to enable the Local API — FiestaBoard's **Settings** page can do this for you, or see the [Vestaboard Local API docs](https://docs.vestaboard.com/docs/local-api/authentication)
 4. Save the API key and note the board's IP address
@@ -123,7 +123,7 @@ Faster updates, supports transition animations, works over your local network.
 
 Works from anywhere with internet. No transition animations. See [Cloud API Setup](/docs/setup/cloud-api) for details.
 
-1. Go to [web.vestaboard.com](https://web.vestaboard.com)
+1. Go to [your Vestaboard account](https://web.vestaboard.com)
 2. Navigate to the API section
 3. Enable **Read/Write API**
 4. Copy your key

--- a/docs-site/docs/setup/raspberry-pi.md
+++ b/docs-site/docs/setup/raspberry-pi.md
@@ -96,7 +96,7 @@ That's it. FiestaBoard starts automatically.
 
 On any device on the same network, open:
 
-**→ [http://fiestapi.local:4420](http://fiestapi.local:4420)**
+**→ [Open FiestaBoard at fiestapi.local:4420](http://fiestapi.local:4420)**
 
 You'll see the FiestaBoard setup wizard. Enter your board API key, choose your board type, and you're running.
 

--- a/docs-site/docs/setup/v2-migration.md
+++ b/docs-site/docs/setup/v2-migration.md
@@ -166,7 +166,7 @@ This is the biggest infrastructure change in V2. FiestaBoard moved from two sepa
 
 **V1 (two containers)**
 
-```
+```text
 Browser → http://localhost:8080 → fiestaboard-ui (Next.js)
                                          ↓ NEXT_PUBLIC_API_URL
 Browser → http://localhost:8000 → fiestaboard-api (FastAPI)
@@ -174,7 +174,7 @@ Browser → http://localhost:8000 → fiestaboard-api (FastAPI)
 
 **V2 (single container)**
 
-```
+```text
 Browser → http://localhost:4420 → nginx
                                     ├── /api/* → FastAPI (internal :8000)
                                     └── /*     → Next.js (internal :3001)

--- a/docs-site/docs/setup/v2-migration.md
+++ b/docs-site/docs/setup/v2-migration.md
@@ -66,7 +66,7 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 
 | Option | Description |
 |--------|-------------|
-| `boards` | Full board instance objects (new format — see below) |
+| `boards` | Full board instance objects (new format — see the [full board instance example](#example-full-board-instance)) |
 | `devices` | List of device type strings: `["flagship"]`, `["flagship", "note"]` |
 | `board_type` | Still accepted for backward compatibility |
 
@@ -75,6 +75,7 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
+<a id="example-full-board-instance"></a>
 **Example — configure a full board instance:**
 ```json
 {

--- a/docs-site/docs/setup/v3-migration.md
+++ b/docs-site/docs/setup/v3-migration.md
@@ -121,7 +121,7 @@ If the same plugin ID exists in both directories, the built-in version is used.
 
 Plugins submitted to the official FiestaBoard plugin registry must follow this repository naming convention:
 
-```
+```text
 fiestaboard-plugin--{name}
 ```
 

--- a/docs-site/docs/troubleshooting.md
+++ b/docs-site/docs/troubleshooting.md
@@ -125,7 +125,7 @@ This is the most common issue. Work through this checklist:
 
 **Fix:**
 - Double-check your API key has no extra spaces or line breaks
-- For Cloud API: verify the key is still active at [web.vestaboard.com](https://web.vestaboard.com)
+- For Cloud API: verify the key is still active in [your Vestaboard account at web.vestaboard.com](https://web.vestaboard.com)
 - Try regenerating the key and entering the new one in Settings
 
 ### Board updates are slow or laggy
@@ -179,7 +179,7 @@ docker-compose restart
 1. Go to **Integrations** and check that the Weather plugin is enabled
 2. Click on the Weather plugin to check your API key is entered
 3. Verify you've entered a valid location
-4. Check if your API key is still active at [weatherapi.com](https://www.weatherapi.com/) or [openweathermap.org](https://openweathermap.org/)
+4. Check if your API key is still active at [WeatherAPI](https://www.weatherapi.com/) or [OpenWeatherMap](https://openweathermap.org/)
 
 ### Traffic plugin returns errors
 


### PR DESCRIPTION
## Summary
Resolves the second round of accessibility findings on the `docs-site/` canonical files. Doc-only changes — no test runs required. `docs-site/versioned_docs/` is intentionally untouched (immutable historical snapshots).

## Findings addressed

### Commit 1 — Descriptive link text (WCAG 2.2 AA 2.4.4 Link Purpose, In Context)
Replaced 30 bare-URL and domain-only link labels with provider/product names or task-oriented phrases so screen-reader users hear the destination, not just a hostname.

- `docs-site/docs/setup/beginners-guide.md` — `raspberrypi.com/software`, `vestaboard.com/local-api`, `web.vestaboard.com`, `github.com/Fiestaboard/FiestaBoard`, bare `http://fiestapi.local:4420`
- `docs-site/docs/setup/raspberry-pi.md` — bare `http://fiestapi.local:4420`
- `docs-site/docs/setup/api-keys.md` — `vestaboard.com/local-api`, `web.vestaboard.com`, `weatherapi.com`, `openweathermap.org`, `511.org/open-data/token`, `finnhub.io`, `thesportsdb.com`
- `docs-site/docs/setup/cloud-api.md` — two `web.vestaboard.com` occurrences
- `docs-site/docs/setup/quick-start.md` — `vestaboard.com/local-api`, `web.vestaboard.com`
- `docs-site/docs/troubleshooting.md` — `web.vestaboard.com`, `weatherapi.com`, `openweathermap.org`
- `docs-site/docs/plugins/overview.md` — `weatherapi.com`, `openweathermap.org`, `511.org`, `finnhub.io`, `thesportsdb.com`, `opensky-network.org`
- `docs-site/docs/plugins/sports-scores.md` — `thesportsdb.com`
- `docs-site/docs/plugins/nearby-aircraft.md` — `opensky-network.org`
- `docs-site/docs/plugins/muni.md` — `511.org/open-data/token`
- `docs-site/docs/plugins/stocks.md` — `finnhub.io`
- `docs-site/docs/plugins/air-fog.md` — `purpleair.com`, `openweathermap.org`
- `docs-site/docs/plugins/weather.md` — `weatherapi.com`, `openweathermap.org`

### Commit 2 — Section-anchor refs (WCAG 2.2 AA 1.3.3 Sensory Characteristics)
Replaced six "see below" direction-only references with explicit links to the target subsection. Added explicit `{#...}` heading IDs (and one inline `<a id>` anchor) where the target was inside a paragraph rather than a heading.

- `docs-site/docs/development/plugin-guide.md:164` → `#environment-variables`
- `docs-site/docs/setup/v2-migration.md:69` → new `#example-full-board-instance` anchor
- `docs-site/docs/setup/home-assistant-mqtt.md:46-47` → new explicit slugs on Mosquitto subsection headings
- `docs-site/docs/setup/beginners-guide.md:18` → `#the-easiest-path-flash-a-raspberry-pi`
- `docs-site/docs/deployment/fiestaupdater.md:71` → `#enabling-on-an-existing-docker-install`

### Commit 3 — Fenced code block language identifiers (WCAG 2.2 AA 1.3.1 Info and Relationships)
Added `text` language identifier to 21 fenced blocks containing ASCII diagrams, directory trees, template snippets, and bare URLs across `docs-site/docs/{development,plugins,setup,deployment,reference}/`.

## Test plan
- [ ] Build the docs site (`docs-site/`) locally and confirm no broken anchor links on the changed pages
- [ ] Re-run `/qa-a11y-docs` against `docs-site/` and confirm the findings table is empty for the targeted criteria
- [ ] Spot-check rendered link text in a screen reader's link-list view to confirm provider names are announced

Builds on the earlier root-docs PR #879; this branch is independent of that one (cut from `main`).

Generated with [Claude Code](https://claude.com/claude-code)