### PR TITLE
fix(a11y): localize the Sonner notifications region label

### DIFF
--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -49,7 +49,8 @@
     "savingIndicator": "Wird gespeichert...",
     "pageCount": "{count, plural, one {# Seite} other {# Seiten}}",
     "unknownError": "Unbekannter Fehler",
-    "opensInNewTab": "(wird in einem neuen Tab geöffnet)"
+    "opensInNewTab": "(wird in einem neuen Tab geöffnet)",
+    "notificationsRegionLabel": "Benachrichtigungen"
   },
   "metadata": {
     "appTitle": "FiestaBoard-Steuerung",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -49,7 +49,8 @@
     "savingIndicator": "Saving...",
     "pageCount": "{count, plural, one {# page} other {# pages}}",
     "unknownError": "Unknown error",
-    "opensInNewTab": "(opens in new tab)"
+    "opensInNewTab": "(opens in new tab)",
+    "notificationsRegionLabel": "Notifications"
   },
   "metadata": {
     "appTitle": "FiestaBoard Control",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -49,7 +49,8 @@
     "savingIndicator": "Guardando...",
     "pageCount": "{count, plural, one {# página} other {# páginas}}",
     "unknownError": "Error desconocido",
-    "opensInNewTab": "(se abre en una pestaña nueva)"
+    "opensInNewTab": "(se abre en una pestaña nueva)",
+    "notificationsRegionLabel": "Notificaciones"
   },
   "metadata": {
     "appTitle": "Panel de FiestaBoard",

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -49,7 +49,8 @@
     "savingIndicator": "Enregistrement...",
     "pageCount": "{count, plural, one {# page} other {# pages}}",
     "unknownError": "Erreur inconnue",
-    "opensInNewTab": "(ouvre dans un nouvel onglet)"
+    "opensInNewTab": "(ouvre dans un nouvel onglet)",
+    "notificationsRegionLabel": "Notifications"
   },
   "metadata": {
     "appTitle": "Panneau FiestaBoard",

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -49,7 +49,8 @@
     "savingIndicator": "Salvataggio...",
     "pageCount": "{count, plural, one {# pagina} other {# pagine}}",
     "unknownError": "Errore sconosciuto",
-    "opensInNewTab": "(si apre in una nuova scheda)"
+    "opensInNewTab": "(si apre in una nuova scheda)",
+    "notificationsRegionLabel": "Notifiche"
   },
   "metadata": {
     "appTitle": "Pannello FiestaBoard",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -49,7 +49,8 @@
     "savingIndicator": "保存中...",
     "pageCount": "{count, plural, one {# ページ} other {# ページ}}",
     "unknownError": "不明なエラー",
-    "opensInNewTab": "(新しいタブで開きます)"
+    "opensInNewTab": "(新しいタブで開きます)",
+    "notificationsRegionLabel": "通知"
   },
   "metadata": {
     "appTitle": "FiestaBoard コントロール",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -49,7 +49,8 @@
     "savingIndicator": "저장 중...",
     "pageCount": "{count, plural, one {# 페이지} other {# 페이지}}",
     "unknownError": "알 수 없는 오류",
-    "opensInNewTab": "(새 탭에서 열림)"
+    "opensInNewTab": "(새 탭에서 열림)",
+    "notificationsRegionLabel": "알림"
   },
   "metadata": {
     "appTitle": "FiestaBoard 컨트롤",

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -49,7 +49,8 @@
     "savingIndicator": "Opslaan...",
     "pageCount": "{count, plural, one {# pagina} other {# pagina's}}",
     "unknownError": "Onbekende fout",
-    "opensInNewTab": "(opent in een nieuw tabblad)"
+    "opensInNewTab": "(opent in een nieuw tabblad)",
+    "notificationsRegionLabel": "Meldingen"
   },
   "metadata": {
     "appTitle": "FiestaBoard-bediening",

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -49,7 +49,8 @@
     "savingIndicator": "Zapisywanie...",
     "pageCount": "{count, plural, one {# strona} few {# strony} many {# stron} other {# stron}}",
     "unknownError": "Nieznany błąd",
-    "opensInNewTab": "(otwiera się w nowej karcie)"
+    "opensInNewTab": "(otwiera się w nowej karcie)",
+    "notificationsRegionLabel": "Powiadomienia"
   },
   "metadata": {
     "appTitle": "Panel FiestaBoard",

--- a/web/messages/pt.json
+++ b/web/messages/pt.json
@@ -49,7 +49,8 @@
     "savingIndicator": "Salvando...",
     "pageCount": "{count, plural, one {# página} other {# páginas}}",
     "unknownError": "Erro desconhecido",
-    "opensInNewTab": "(abre numa nova aba)"
+    "opensInNewTab": "(abre numa nova aba)",
+    "notificationsRegionLabel": "Notificações"
   },
   "metadata": {
     "appTitle": "Painel FiestaBoard",

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -49,7 +49,8 @@
     "savingIndicator": "Сохранение...",
     "pageCount": "{count, plural, one {# страница} few {# страницы} many {# страниц} other {# страниц}}",
     "unknownError": "Неизвестная ошибка",
-    "opensInNewTab": "(откроется в новой вкладке)"
+    "opensInNewTab": "(откроется в новой вкладке)",
+    "notificationsRegionLabel": "Уведомления"
   },
   "metadata": {
     "appTitle": "Управление FiestaBoard",

--- a/web/messages/sv.json
+++ b/web/messages/sv.json
@@ -49,7 +49,8 @@
     "savingIndicator": "Sparar...",
     "pageCount": "{count, plural, one {# sida} other {# sidor}}",
     "unknownError": "Okänt fel",
-    "opensInNewTab": "(öppnas i en ny flik)"
+    "opensInNewTab": "(öppnas i en ny flik)",
+    "notificationsRegionLabel": "Aviseringar"
   },
   "metadata": {
     "appTitle": "FiestaBoard-styrning",

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -49,7 +49,8 @@
     "savingIndicator": "Kaydediliyor...",
     "pageCount": "{count, plural, one {# sayfa} other {# sayfa}}",
     "unknownError": "Bilinmeyen hata",
-    "opensInNewTab": "(yeni sekmede açılır)"
+    "opensInNewTab": "(yeni sekmede açılır)",
+    "notificationsRegionLabel": "Bildirimler"
   },
   "metadata": {
     "appTitle": "FiestaBoard Kontrol",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -49,7 +49,8 @@
     "savingIndicator": "保存中...",
     "pageCount": "{count, plural, one {# 个页面} other {# 个页面}}",
     "unknownError": "未知错误",
-    "opensInNewTab": "（在新标签页中打开）"
+    "opensInNewTab": "（在新标签页中打开）",
+    "notificationsRegionLabel": "通知"
   },
   "metadata": {
     "appTitle": "FiestaBoard 控制台",

--- a/web/src/components/ui/sonner.tsx
+++ b/web/src/components/ui/sonner.tsx
@@ -8,15 +8,38 @@ import {
   TriangleAlertIcon,
 } from "lucide-react"
 import { useTheme } from "next-themes"
+import { useTranslations } from "next-intl"
 import { Toaster as Sonner, type ToasterProps } from "sonner"
 
-const Toaster = ({ ...props }: ToasterProps) => {
+/**
+ * App-wide Sonner wrapper.
+ *
+ * Sonner renders a single `<section aria-live="polite" aria-label="…">`
+ * for all toast announcements. By default that label is the English string
+ * "Notifications", which screen readers then announce verbatim under any
+ * `<html lang>` (Spanish, Japanese, etc.). Forward the translated label
+ * through `containerAriaLabel` so the region announcement matches the
+ * active locale.
+ *
+ * Accessibility:
+ *   WCAG 3.1.2 Language of Parts — assistive tech now hears the region
+ *   label in the user's chosen language. Sonner still appends the
+ *   keyboard-shortcut hint ("alt+T") to the label; that suffix is
+ *   universal notation and is left as-is.
+ *
+ * Callers may still override `containerAriaLabel` via props if they need a
+ * more specific label for a particular Toaster instance.
+ */
+const Toaster = ({ containerAriaLabel, ...props }: ToasterProps) => {
   const { theme = "system" } = useTheme()
+  const t = useTranslations("common")
+  const ariaLabel = containerAriaLabel ?? t("notificationsRegionLabel")
 
   return (
     <Sonner
       theme={theme as ToasterProps["theme"]}
       className="toaster group"
+      containerAriaLabel={ariaLabel}
       icons={{
         success: <CircleCheckIcon className="size-4" />,
         info: <InfoIcon className="size-4" />,


### PR DESCRIPTION
## Summary
- The global `<Toaster />` mounted in `app/layout.tsx` was shipping `aria-label="Notifications alt+T"` to every page — including `/login` and the entire authenticated shell — regardless of the active locale. Screen readers in `es`/`ja`/etc. read the English region name verbatim under a non-English `<html lang>`.
- Sonner exposes a `containerAriaLabel` prop for exactly this case; thread it through `useTranslations("common")` so the announced region name tracks the active locale and add a `common.notificationsRegionLabel` key in all 14 catalogs.

## Changes
- `web/src/components/ui/sonner.tsx` — pull a translated label via `useTranslations("common")` and forward it through `containerAriaLabel`. Destructure ahead of the spread so a caller-supplied `containerAriaLabel` prop still wins (escape hatch preserved).
- `web/messages/{en,es,fr,de,it,pt,nl,sv,pl,tr,ru,ja,ko,zh}.json` — add `common.notificationsRegionLabel` with native translations.
- No source-of-truth or behavior changes beyond the aria-label; visual styling and toast props are untouched.

## WCAG 2.2 AA criteria addressed

| Finding (from `/qa-a11y` 2nd pass) | Severity | WCAG SC | Commit |
|---|---|---|---|
| `<section aria-live="polite" aria-label="Notifications alt+T">` rendered globally, label not localized | Moderate | **3.1.2** Language of Parts | `f6cbf3ed` |

The hotkey suffix Sonner appends ("alt+T") stays as-is — that notation is universal and the auditor explicitly carved it out of scope.

## Test plan
- [x] Manual verification on `/login` via Playwright MCP across three locales:
  - `NEXT_LOCALE=en` → `aria-label="Notifications alt+T"`
  - `NEXT_LOCALE=es` → `aria-label="Notificaciones alt+T"`
  - `NEXT_LOCALE=ja` → `aria-label="通知 alt+T"`
- [x] Container TS typecheck on `web/src/components/ui/sonner.tsx`: no new errors.
- [ ] **Reviewer manual smoke:**
  - [ ] NVDA / VoiceOver pass on any signed-in page: the region announcement reads in the active language when first announced.
  - [ ] Hotkey (alt+T on macOS, alt+T on Windows) still focuses the toaster.
  - [ ] Any caller that needs a specific label can still override via `<Toaster containerAriaLabel="…" />` (no callers do today, but the path is open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)