### PR TITLE
docs: sweep root community docs for accuracy and broken pointers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,16 +59,16 @@ All tests run inside Docker:
 docker-compose -f docker-compose.dev.yml up -d
 
 # Platform/API tests
-docker-compose exec fiestaboard pytest
+docker-compose -f docker-compose.dev.yml exec fiestaboard pytest
 
-# Web UI tests
-docker-compose exec fiestaboard npm run test:run
+# Web UI tests (runs in a one-shot container with the test profile)
+docker-compose -f docker-compose.dev.yml run --rm --profile test web sh -c "npm ci && npm test"
 
 # Plugin validation (if you changed plugins)
-docker-compose exec fiestaboard python scripts/validate_plugins.py --verbose
+docker-compose -f docker-compose.dev.yml exec fiestaboard python scripts/validate_plugins.py --verbose
 
 # Plugin tests (if you changed a specific plugin)
-docker-compose exec fiestaboard python scripts/run_plugin_tests.py --plugin=my_plugin
+docker-compose -f docker-compose.dev.yml exec fiestaboard python scripts/run_plugin_tests.py --plugin=my_plugin
 ```
 
 CI runs on push/PR; make sure the same commands (or their CI equivalents) pass locally.
@@ -140,7 +140,7 @@ If you discover a security issue, do **not** open a public issue. See [SECURITY.
 
 ## Questions?
 
-- Open a GitHub Discussion or issue for general questions (use the project’s repository URL once it’s public or shared).
-- For bugs or feature ideas, use the issue tracker and try to keep one topic per issue.
+- Open a [GitHub issue](https://github.com/Fiestaboard/FiestaBoard/issues) or chat in [Discord](https://discord.gg/JvN8y6ahaf) for general questions.
+- For bugs or feature ideas, use the issue tracker and keep one topic per issue.
 
 Thanks for contributing.

--- a/DOCKERHUB_README.md
+++ b/DOCKERHUB_README.md
@@ -53,7 +53,7 @@ Then open **http://localhost:4420** to connect your board and start the service.
 
 ## What You Can Display
 
-FiestaBoard includes **26 built-in plugins**. Many work without any API key at all:
+FiestaBoard has a catalog of **50+ plugins**. Many work without any API key at all:
 
 | Plugin | Description | API Key? |
 |--------|-------------|----------|
@@ -64,11 +64,11 @@ FiestaBoard includes **26 built-in plugins**. Many work without any API key at a
 | Home Assistant | Smart home status display | Yes (self-hosted) |
 | Surf Conditions | Wave height and quality | No |
 | Date & Time | Multiple formats with timezone support | No |
-| Disney Parks | Wait times from Queue-Times.com | No |
+| Disney Park Queue Times | Wait times from Queue-Times.com | No |
 | Last.fm | Currently playing music | Yes (free) |
 | Visual Clock | Large pixel-art clock | No |
 | Star Trek Quotes | Quotes from TNG, Voyager, DS9 | No |
-| And 15 more... | Transit, aircraft, ferries, WiFi, sun art, countdown, etc. | Varies |
+| And 40+ more... | Transit, aircraft, ferries, WiFi, sun art, countdown, etc. | Varies |
 
 ## Key Features
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The wizard collects your board API key, starts the server, and opens the setup p
 
 ## What Can You Display?
 
-FiestaBoard has **26 built-in plugins** covering weather, finance, transit, sports, entertainment, and home automation. Here's what they look like:
+FiestaBoard has a catalog of **50+ plugins** covering weather, finance, transit, sports, entertainment, and home automation. Here's what they look like:
 
 **Weather** - Temperature, UV index, precipitation, high/low, sunset time
 
@@ -246,6 +246,8 @@ If you'd rather run Docker on a Pi you've already set up, the pre-built Docker i
 
 ## Stopping and Restarting
 
+Run these from the folder you originally started FiestaBoard in (the one with your `docker-compose.hub.yml` or cloned `docker-compose.yml` and your `./data` directory).
+
 ```bash
 # Stop FiestaBoard
 docker-compose down
@@ -257,7 +259,9 @@ docker-compose up -d
 docker-compose logs -f
 ```
 
-Then go to **http://localhost:4420** — the service starts automatically once the container is running.
+If you pulled the image with `docker-compose.hub.yml`, add `-f docker-compose.hub.yml` to each command (for example `docker-compose -f docker-compose.hub.yml down`).
+
+Then open **http://localhost:4420** — the service starts automatically once the container is running.
 
 ---
 
@@ -274,7 +278,7 @@ Then go to **http://localhost:4420** — the service starts automatically once t
 
 - Make sure Docker Desktop is running (look for the whale icon)
 - Check if the container is running: `docker ps`
-- Port conflict? Change the host port in `docker-compose.yml` (left side of `4420:3000`)
+- Port conflict? Change the host port in your compose file (left side of `4420:3000`)
 
 ### Plugin Issues
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,21 +2,25 @@
 
 ## Reporting a vulnerability
 
-If you believe you've found a security issue, please report it responsibly:
+If you believe you've found a security issue, please report it privately:
 
-- **Do not** open a public GitHub issue.
-- Email the maintainers (see [README](./README.md) for contact) or report via GitHub Security Advisories if the repo has that enabled.
+- **Do not** open a public GitHub issue or post in Discord.
+- File a private report via [GitHub Security Advisories](https://github.com/Fiestaboard/FiestaBoard/security/advisories/new).
 
-We will acknowledge your report and work with you to understand and address it.
+We will acknowledge your report, work with you to understand it, and coordinate a fix and disclosure timeline. Please do not publicly share details of the issue until a fix is released.
+
+## Supported versions
+
+We provide security fixes for the latest released version on the `main` branch and the `latest` Docker tag. Older versions are best-effort.
 
 ## Sensitive data handling
 
 - **Secrets** (API keys, tokens, passwords) are never logged or returned in API responses. Plugin and board configs are masked (sensitive fields replaced with `***`) when returned by the API.
-- **Configuration** is loaded from the `data/` directory and from environment variables. Never commit `.env` or `data/config.json` / `data/settings.json`; they are listed in `.gitignore`.
+- **Configuration** is loaded from the `data/` directory and from environment variables. Never commit `.env` or files under `data/` (such as `data/config.json` or `data/settings.json`) — they are listed in `.gitignore`.
 - **Docker** Compose files reference `env_file: .env` so secrets stay on the host; no secrets are baked into images.
 
 ## Deployment
 
-- Run the API and UI in Docker; use a reverse proxy (e.g. nginx) with TLS in front if exposed to the internet.
-- Restrict access to the API and UI (e.g. VPN, firewall, or auth proxy) when possible.
+- Run the API and UI in Docker; put a reverse proxy (for example nginx) with TLS in front if you expose FiestaBoard to the internet.
+- Restrict access to the API and UI when possible (VPN, firewall, or auth proxy). FiestaBoard's HTTP API has no built-in authentication today.
 - Use strong, unique API keys for your Vestaboard and any third-party services (weather, transit, etc.).


### PR DESCRIPTION
## Summary

Cross-referenced the root-level community docs against the actual codebase (Dockerfile, `docker-compose*.yml`, `plugins/`, `scripts/`, CLAUDE.md) and fixed accuracy bugs that would mislead new contributors and users. Voice / structure are otherwise preserved.

## Files changed

- **`README.md`** — Replaced stale "26 built-in plugins" claim with "50+ plugins" (the Available Plugins table actually lists 52). Clarified that the Stopping and Restarting commands must run from the original install folder, and added a `-f docker-compose.hub.yml` hint for hub-install users whose folder has no plain `docker-compose.yml`. Softened the port-conflict tip accordingly.
- **`CONTRIBUTING.md`** — Added the missing `-f docker-compose.dev.yml` flag to the pytest / plugin-validation / plugin-test commands so they actually target the dev stack, and replaced the broken `docker-compose exec fiestaboard npm run test:run` with the canonical web-test invocation from CLAUDE.md (`docker-compose -f docker-compose.dev.yml run --rm --profile test web sh -c "npm ci && npm test"`). Replaced the placeholder "use the project's repository URL once it's public" line with real Issues + Discord links.
- **`SECURITY.md`** — The previous "email the maintainers (see README for contact)" pointer was a dead end (README has no maintainer email). Replaced with a direct link to file a private [GitHub Security Advisory](https://github.com/Fiestaboard/FiestaBoard/security/advisories/new), matching how `CODE_OF_CONDUCT.md` already routes incident reports. Added a brief Supported Versions section and noted that the HTTP API has no built-in auth today.
- **`DOCKERHUB_README.md`** — Same `26 → 50+` plugin count fix as the main README, with the trailing "And 15 more..." row updated to "And 40+ more..." so the math (11 listed + 40+ = 50+) actually balances. Renamed "Disney Parks" to "Disney Park Queue Times" to match the canonical name in README.md.
- **`CODE_OF_CONDUCT.md`** — No changes. Standard Contributor Covenant 2.0, the GitHub Security Advisories enforcement channel is consistent with the SECURITY.md update, and no broken references.

## Biggest accuracy fixes

The headline "26 built-in plugins" figure was off by roughly 2x in both README.md and DOCKERHUB_README.md — the Available Plugins table actually lists 52 entries. The CONTRIBUTING.md test commands were broken in two ways (missing dev compose flag, and a web-test command that does not exist in the unified container). The SECURITY.md vuln-report path pointed at a non-existent maintainer email. These are the kinds of errors a brand-new contributor would hit on day one.

## Voice / format checks

- [x] Voice matches existing tone — no marketing fluff added
- [x] Every code fence has a language tag
- [x] No placeholder URLs or `<your-value>` substitutions
- [x] All link targets verified to exist (`docs/setup/LOCAL_DEVELOPMENT.md`, `docs/setup/RASPBERRY_PI.md`, `docs/setup/AI_PROVIDERS.md`, `docs/development/PLUGIN_DEVELOPMENT.md`)
- [x] No real PII added
- [x] Scope: strictly the 5 root-level community MD files — no edits under `docs/`, `plugins/`, or `web/`

## Test plan

- [ ] Sanity-check rendered Markdown on GitHub (especially the README plugin table and the new SECURITY advisories link)
- [ ] Verify the corrected `docker-compose -f docker-compose.dev.yml run --rm --profile test web sh -c "npm ci && npm test"` command actually runs locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)