### PR TITLE
docs(setup): accuracy + clarity sweep across docs/setup/*

### DIFF
--- a/docs/setup/AI_PROVIDERS.md
+++ b/docs/setup/AI_PROVIDERS.md
@@ -39,11 +39,12 @@ section).
 
 ## Quick setup with preset pills
 
-In **Settings → AI Providers**, the **Quick presets** row gives you
-one-click pills for every supported provider, grouped into **Cloud**
-and **Local**. Clicking a pill auto-fills the **Name**, **Base
-URL**, and **Protocol** for that provider — you only have to paste
-your API key and add the model ids you want.
+In **Settings → AI Providers**, the **Quick presets** row gives you one-click pills for every supported provider, grouped into **Cloud** and **Local**. Clicking a pill auto-fills the **Name**, **Base URL**, and **Protocol** for that provider — you only have to paste your API key and add the model ids you want.
+
+The current preset list, sourced from `web/src/components/settings/ai-settings.tsx`:
+
+- **Cloud:** OpenAI, OpenRouter, Anthropic, Groq, DeepSeek, Mistral, Together AI, Fireworks AI.
+- **Local:** Ollama (`http://localhost:11434/v1`), LM Studio (`http://localhost:1234/v1`), llama.cpp (`http://localhost:8080/v1`), vLLM (`http://localhost:8000/v1`).
 
 ## Configuration
 
@@ -72,20 +73,18 @@ using the **Make default** button.
 
 ## Recommended models
 
-These all work well with the FiestaBoard prompt format:
+These all work well with the FiestaBoard prompt format. Any current chat-completion model the provider exposes will work — these are just sensible defaults.
 
 | Provider     | Protocol  | Model                                  | Notes                              |
 | ------------ | --------- | -------------------------------------- | ---------------------------------- |
 | OpenRouter   | OpenAI    | `openai/gpt-4o-mini`                   | Cheap, fast, reliable JSON output. |
-| OpenRouter   | OpenAI    | `anthropic/claude-3.5-sonnet`          | High-quality, slower.              |
+| OpenRouter   | OpenAI    | `anthropic/claude-sonnet-4`            | High-quality, slower.              |
 | OpenAI       | OpenAI    | `gpt-4o-mini`                          | Same as via OpenRouter.            |
-| Anthropic    | Anthropic | `claude-3-5-sonnet-20241022`           | Direct, no OpenRouter markup.      |
-| Anthropic    | Anthropic | `claude-3-5-haiku-20241022`            | Cheaper, fast.                     |
+| Anthropic    | Anthropic | `claude-sonnet-4-20250514`             | Direct, no OpenRouter markup.      |
+| Anthropic    | Anthropic | `claude-haiku-4-20250514`              | Cheaper, fast.                     |
 | Local Ollama | OpenAI    | `qwen2.5:14b-instruct` or larger       | Needs a model that follows JSON.   |
 
-Smaller (≤ 7B) local models often struggle to emit valid JSON for
-the FiestaBoard schema; if you see frequent "Could not parse JSON"
-errors, switch to a larger or instruction-tuned model.
+The Anthropic protocol pins a stable `anthropic-version` header in `src/ai/protocols.py`, so any model ID Anthropic accepts on that version works — earlier IDs like `claude-3-5-sonnet-20241022` are still valid if you've configured them. Smaller (≤ 7B) local models often struggle to emit valid JSON for the FiestaBoard schema; if you see frequent "Could not parse JSON" errors, switch to a larger or instruction-tuned model.
 
 ## Privacy
 

--- a/docs/setup/LOCAL_DEVELOPMENT.md
+++ b/docs/setup/LOCAL_DEVELOPMENT.md
@@ -9,6 +9,8 @@ This guide is for **contributors and plugin developers** who want to work on Fie
 - Docker and Docker Compose installed
 - A `.env` file with your board API key (copy from `env.example`)
 
+> **Important:** Do not run the API (`src/api_server.py`) or the web UI (`npm run dev`) directly on the host. All commands here run **inside** the dev container — no local `pip install` or `npm install` required.
+
 ## Development Workflow
 
 ### Starting Development Environment
@@ -24,6 +26,8 @@ docker-compose -f docker-compose.dev.yml up -d
 docker-compose -f docker-compose.dev.yml logs -f
 ```
 
+If you're working in Claude Code, the project ships matching slash commands: `/start` (up -d), `/stop` (down), and `/restart` (down + `--no-cache` rebuild + up -d).
+
 **Access:**
 - Web UI and API: http://localhost:4420 (single container, same as production)
 - API base path: http://localhost:4420/api/
@@ -31,10 +35,10 @@ docker-compose -f docker-compose.dev.yml logs -f
 
 ### Hot Reload
 
-The development Docker Compose mounts source code as volumes:
+The development Docker Compose mounts source code as volumes (`./src`, `./plugins`, `./web`, `./tests`, `./scripts`, plus `./data`):
 
-- **Python API**: Changes to `src/` and `plugins/` trigger uvicorn auto-reload
-- **Next.js Web UI**: Requires image rebuild to see changes (same unified container as production)
+- **Python API**: Changes to `src/` and `plugins/` trigger uvicorn `--reload` automatically — no restart needed.
+- **Next.js Web UI**: The container serves the production build that was baked into the image, so UI changes need a container rebuild (`docker-compose -f docker-compose.dev.yml up --build` or `/restart`). For interactive UI work, run Storybook with `docker-compose -f docker-compose.dev.yml up fiestaboard-storybook` (port 6006) instead.
 
 ### Stopping Services
 
@@ -65,17 +69,19 @@ docker-compose -f docker-compose.dev.yml run --rm --profile test web sh -c "npm 
 # Health check
 curl http://localhost:4420/api/health
 
-# Status
+# Service status
 curl http://localhost:4420/api/status
 
-# Start service
+# Start the carousel
 curl -X POST http://localhost:4420/api/start
 
-# Send message
+# Send an ad-hoc message
 curl -X POST http://localhost:4420/api/send-message \
   -H "Content-Type: application/json" \
   -d '{"text": "Test message"}'
 ```
+
+For the full schema, open the interactive docs at `http://localhost:4420/api/docs`.
 
 ## Environment Variables
 
@@ -114,11 +120,11 @@ docker-compose -f docker-compose.dev.yml ps
 
 ## VS Code / Dev Container
 
-If using VS Code with Dev Containers:
+The repo ships a `.devcontainer/` with `devcontainer.json`, a build `Dockerfile`, and a `post-create.sh` hook. To use it:
 
-1. The `.devcontainer/devcontainer.json` is configured
-2. Open in container: VS Code → "Reopen in Container"
-3. Dependencies are installed automatically
+1. Install the **Dev Containers** extension in VS Code.
+2. Open the repo folder, then run **Dev Containers: Reopen in Container** from the command palette.
+3. Dependencies install automatically via `post-create.sh`. When the build finishes, VS Code is attached to the container with the same toolchain CI uses.
 
 ## Quick Reference
 
@@ -166,9 +172,9 @@ docker-compose -f docker-compose.dev.yml up --build
 
 ### API Can't Connect to Board
 
-- Check `/status` endpoint for service status
-- Verify `.env` file has valid API keys
-- Check network connectivity to board
+- Check `http://localhost:4420/api/status` for service status.
+- Verify `.env` has valid board credentials (see `env.example`).
+- Confirm the container can reach your board's network. The default dev compose seeds `BOARD_API_MODE=local`, `BOARD_HOST=fiestaboard-mock-board`, and `BOARD_LOCAL_API_KEY=mock-dev-key` so a fresh install talks to the bundled mock board instead of stranding the UI on a spinner. Real-board settings in `data/config.json` always win over those seeds.
 
 ### UI Can't Connect to API
 

--- a/docs/setup/MCP_CLIENTS.md
+++ b/docs/setup/MCP_CLIENTS.md
@@ -11,6 +11,8 @@ This page walks through wiring each client up to a self-hosted FiestaBoard.
 > clients → Generate token** (or **Rotate token**). The plaintext value is
 > shown exactly once — copy it into your client config immediately.
 
+> **Hostname tip:** Docker installs advertise as `fiestaboard.local`; the FiestaPi image advertises as `fiestapi.local`. Use whichever matches your install (or substitute the LAN IP if mDNS doesn't resolve on your network). The examples below use `fiestaboard.local`.
+
 ## Why local hosting makes this awkward
 
 The MCP ecosystem is converging on three transports — stdio, HTTP, and

--- a/docs/setup/RASPBERRY_PI.md
+++ b/docs/setup/RASPBERRY_PI.md
@@ -12,7 +12,7 @@ The easiest way to run FiestaBoard is to flash a Raspberry Pi with our pre-built
 
 ## 1. Download the image
 
-Grab the latest `FiestaPi-<version>-arm64.img.xz` from the [GitHub Releases](https://github.com/Fiestaboard/FiestaBoard/releases) page.
+Grab the latest `FiestaPi-<version>-arm64.img.xz` from the [GitHub Releases](https://github.com/Fiestaboard/FiestaBoard/releases) page. The image is published by the `build-fiestapi.yml` workflow after each app release and typically lands ~45–60 minutes after the release shows up; the release page shows a "Raspberry Pi image is building" banner until it's attached.
 
 ## 2. Flash the SD card
 
@@ -82,6 +82,8 @@ ssh fiesta@fiestapi.local
 cd /opt/fiestaboard
 docker compose pull && docker compose up -d
 ```
+
+The `fiestaupdater` sidecar is enabled by default on FiestaPi (`COMPOSE_PROFILES=fiestaupdater` in `/opt/fiestaboard/.env`) and a unique `FIESTAUPDATER_TOKEN` is generated on first boot — so **Update Now** works out of the box without you having to touch any tokens.
 
 ## Troubleshooting
 

--- a/docs/setup/RELEASE_CHECKLIST.md
+++ b/docs/setup/RELEASE_CHECKLIST.md
@@ -2,6 +2,10 @@
 
 Use this before publishing the repo or cutting a release to avoid leaking secrets or personal data.
 
+> **How releases actually ship:** Day-to-day version bumps are automated. `.github/workflows/release.yml` runs on every push to `main`, picks the bump type from the merged PR's `major` / `minor` / `patch` label (defaults to `patch`), commits `chore: bump version to X.Y.Z [skip ci]`, builds and pushes the multi-arch image, and creates the GitHub Release. The FiestaPi `.img.xz` is attached later by `build-fiestapi.yml` (~45–60 min).
+>
+> **Do not bump versions by hand** in `package.json`, `web/package.json`, or `src/__init__.py`. The checklist below covers the manual gate: making sure no secrets are committed before the first public push.
+
 ## 1. Ensure no secrets are committed
 
 - [ ] **`.env`** – Must not be tracked. Run: `git check-ignore -v .env` (should show `.gitignore`).

--- a/docs/setup/UPDATING.md
+++ b/docs/setup/UPDATING.md
@@ -17,7 +17,7 @@ The updater is opt-in for all non-Pi installs. Two things need to be true:
 1. The `fiestaupdater` Compose profile is enabled.
 2. `FIESTAUPDATER_TOKEN` is set in your `.env`.
 
-The install scripts (`install.sh` / `install.ps1`) ask you about this and configure it for you on a fresh install. To enable it manually after the fact, edit `.env`:
+The install scripts (`scripts/install.sh` / `scripts/install.ps1`) ask you about this and configure it for you on a fresh install. To enable it manually after the fact, edit `.env`:
 
 ```bash
 COMPOSE_PROFILES=fiestaupdater
@@ -92,4 +92,4 @@ If you'd rather not run with the Docker socket exposed at all, leave the `fiesta
 
 **Update kicked off but the page never came back** — Open the URL again after a minute. If it's still down: `docker compose logs fiestaboard` (or `docker logs fiestaboard`). Worst case, manual `docker compose up -d` will bring you back up.
 
-**I want to roll back** — Pin the previous tag in `docker-compose.yml` and `docker compose up -d`. Automated rollback is on the roadmap for 5.1.
+**I want to roll back** — Pin the previous tag in `docker-compose.yml` (replace `fiestaboard/fiestaboard:latest` with `fiestaboard/fiestaboard:<version>`, e.g. `6.10.9`) and run `docker compose up -d`. Available tags are listed on [Docker Hub](https://hub.docker.com/r/fiestaboard/fiestaboard/tags) and the [GitHub Releases](https://github.com/Fiestaboard/FiestaBoard/releases) page. Automated rollback from the UI is still a planned feature.


### PR DESCRIPTION
## Summary

Six-file accuracy and clarity sweep across `docs/setup/` after verifying each doc against the actual codebase (`docker-compose*.yml`, `Dockerfile`, `.github/workflows/*`, `src/ai/protocols.py`, `src/api_server.py`, `pi-image/`, `web/src/components/settings/ai-settings.tsx`). No invented features.

## Per-file change summary

- `LOCAL_DEVELOPMENT.md` — Call out the no-local-pip/npm rule and the `/start /stop /restart` slash commands; clarify that the Next.js UI is the production build (Storybook is the interactive path); correct `/status` → `/api/status` in troubleshooting; document the bundled mock-board defaults seeded by `docker-compose.dev.yml`; replace the stale Dev Container snippet with what's actually shipped under `.devcontainer/`.
- `RASPBERRY_PI.md` — Note that the `.img.xz` asset trails the app release by ~45–60 min (matches `build-fiestapi.yml`); confirm that the `fiestaupdater` sidecar and `FIESTAUPDATER_TOKEN` are pre-configured on FiestaPi so **Update Now** works out of the box.
- `AI_PROVIDERS.md` — Update recommended Anthropic models from `claude-3-5-*` to current 4-series IDs (older IDs still work — called out); list the exact cloud/local preset pills shipped in `ai-settings.tsx` with their default base URLs.
- `MCP_CLIENTS.md` — Add an explicit hostname tip near the top so the `fiestaboard.local` (Docker) vs `fiestapi.local` (FiestaPi) split doesn't trip up Pi users following the examples.
- `RELEASE_CHECKLIST.md` — Frame the file against the automated `release.yml` pipeline (PR-label-driven bumps, multi-arch publish, GitHub Release creation) so contributors know not to bump versions by hand; note the FiestaPi image timing.
- `UPDATING.md` — Correct install script paths (`scripts/install.sh` / `scripts/install.ps1`, not repo root); replace the stale "automated rollback in 5.1" promise (we're on 6.x) with concrete manual-rollback steps that link to Docker Hub tags and GitHub Releases.

## Top accuracy fixes

1. **`docs/setup/UPDATING.md`** — `install.sh`/`install.ps1` paths were wrong (live under `scripts/`, not repo root) and the "automated rollback on the roadmap for 5.1" line was four major versions stale.
2. **`docs/setup/AI_PROVIDERS.md`** — Recommended Anthropic models pointed at year-old `claude-3-5-sonnet-20241022` / `-haiku-20241022`; refreshed to the current 4-series with a note that older IDs still work under the pinned `anthropic-version` header.
3. **`docs/setup/LOCAL_DEVELOPMENT.md`** — Troubleshooting referenced `/status` (no such endpoint via nginx) instead of `/api/status`, and the "API can't connect to board" section never explained the bundled mock-board defaults in `docker-compose.dev.yml`.
4. **`docs/setup/MCP_CLIENTS.md`** — Examples used `fiestaboard.local` exclusively. The Pi advertises `fiestapi.local`, so Pi users would copy-paste a broken URL. Added an upfront hostname tip.
5. **`docs/setup/RELEASE_CHECKLIST.md`** — The page read as a manual release runbook with no mention of `release.yml`. Added a banner explaining version bumps are automated and PR-label driven so nobody tries to hand-bump `package.json`.

## Voice / format checks

- [x] One H1 per file, no skipped heading levels.
- [x] All fenced code blocks have a language tag (`bash`, `yaml`, `ini`, `json`).
- [x] No empty / uninformative image alt text.
- [x] No "click here" / bare-URL links.
- [x] No real API keys, addresses, or PII in examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)