### PR TITLE
docs: sweep developer-focused docs for accuracy and stale references

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -11,7 +11,7 @@ This document describes the design tokens and usage conventions for the FiestaBo
 
 ## Contrast and accessibility
 
-Semantic colors are chosen for WCAG AA contrast where text is used: primary-foreground on primary, sidebar-accent-foreground on sidebar-accent, brand-foreground on brand. Muted-foreground is used for secondary text on background/card and meets contrast in both light and dark themes. Spot-check new tokens (e.g. after Design Pass 2) in both themes.
+Semantic colors are chosen for WCAG AA contrast where text is used: primary-foreground on primary, sidebar-accent-foreground on sidebar-accent, brand-foreground on brand. Muted-foreground is used for secondary text on background/card and meets contrast in both light and dark themes. Spot-check new tokens in both themes when you add or change one.
 
 ## Semantic colors
 
@@ -120,3 +120,9 @@ Brand warmth continues to come from the orange accent (`--brand`) and board pale
 The Settings page was refactored from custom `bg-muted/20` / `bg-muted/30` rounded sections to standard `Card` components, matching the surface treatment used on all other pages (Pages, Carousels, Integrations, Schedule). Redundant section titles that duplicated titles already inside child Card components were removed.
 
 Hardcoded warm oklch values in `.card-interactive:hover` were replaced with achromatic neutrals.
+
+## Related files
+
+- Theme tokens: [`web/src/app/globals.css`](../web/src/app/globals.css)
+- Empty-state component: [`web/src/components/ui/empty-state.tsx`](../web/src/components/ui/empty-state.tsx)
+- Tailwind config is inline in `globals.css` under `@theme inline { ... }` (Tailwind v4 — no separate `tailwind.config.ts`).

--- a/docs/development/API_MIGRATION.md
+++ b/docs/development/API_MIGRATION.md
@@ -4,57 +4,6 @@ This guide helps developers migrate from deprecated FiestaBoard API endpoints to
 
 ---
 
-## Board Configuration: `/config/vestaboard` → `/config/board`
-
-The `/config/vestaboard` endpoints are deprecated. Use `/config/board` instead.
-
-### GET - Retrieve board configuration
-
-**Deprecated (returns `Deprecation: true` header):**
-```http
-GET /config/vestaboard
-```
-
-**Canonical:**
-```http
-GET /config/board
-```
-
-**Example response (both endpoints return the same shape):**
-```json
-{
-  "config": {
-    "api_mode": "local",
-    "host": "192.168.1.100",
-    "local_api_key": "***"
-  },
-  "api_modes": ["local", "cloud"]
-}
-```
-
-### PUT - Update board configuration
-
-**Deprecated (returns `Deprecation: true` header):**
-```http
-PUT /config/vestaboard
-```
-
-**Canonical:**
-```http
-PUT /config/board
-```
-
-**Example request body:**
-```json
-{
-  "api_mode": "local",
-  "local_api_key": "your-key",
-  "host": "192.168.1.100"
-}
-```
-
----
-
 ## Display Raw Data: `/displays/{type}/raw` → `/plugins/{plugin_id}/data`
 
 The `/displays/{display_type}/raw` endpoint is deprecated. Use `/plugins/{plugin_id}/data` instead.
@@ -62,21 +11,25 @@ The `/displays/{display_type}/raw` endpoint is deprecated. Use `/plugins/{plugin
 ### GET - Retrieve plugin/display data
 
 **Deprecated (returns `Deprecation: true` header):**
+
 ```http
 GET /displays/{display_type}/raw
 ```
 
 **Canonical:**
+
 ```http
 GET /plugins/{plugin_id}/data
 ```
 
-The `display_type` and `plugin_id` values are the same identifiers (e.g., `weather`, `datetime`, `stocks`).
+The `display_type` and `plugin_id` values are the same identifiers (e.g., `weather`, `date_time`, `stocks`).
 
-**Example - old endpoint:**
+**Example — old endpoint:**
+
 ```http
 GET /displays/weather/raw
 ```
+
 ```json
 {
   "display_type": "weather",
@@ -86,21 +39,25 @@ GET /displays/weather/raw
 }
 ```
 
-**Example - new endpoint:**
+**Example — new endpoint:**
+
 ```http
 GET /plugins/weather/data
 ```
+
 ```json
 {
   "plugin_id": "weather",
   "available": true,
   "data": { "temperature": 72, "condition": "Sunny" },
-  "formatted": "Sunny, 72°F\nSan Francisco",
+  "formatted_lines": ["Sunny, 72F", "San Francisco", "", "", "", ""],
   "error": null
 }
 ```
 
-> **Note:** The new endpoint also returns a `formatted` field with the pre-formatted display output.
+> **Note:** The new endpoint also returns `formatted_lines` — an array of up to six pre-formatted display lines from the plugin's `PluginResult.formatted_lines`. This is `null` when the plugin does not pre-format its output.
+
+The new endpoint returns **HTTP 503** instead of `"available": false` when plugin data is unavailable (not configured, auth failure, network error). The error detail message comes from `PluginResult.error`. The old endpoint returned a 200 with `available: false`.
 
 ---
 
@@ -110,14 +67,14 @@ Deprecated endpoints include the following HTTP response headers:
 
 ```http
 Deprecation: true
-Link: </config/board>; rel="successor-version"
+Link: </plugins/{plugin_id}/data>; rel="successor-version"
 ```
 
-You can use these headers to detect and log warnings in your integration code.
+The `Link` header value points at the canonical successor for that specific request — e.g. a call to `/displays/weather/raw` returns `Link: </plugins/weather/data>; rel="successor-version"`. Use these headers to detect deprecated calls in your integration code.
 
 ---
 
 ## See Also
 
-- [Technical Debt](./TECHNICAL_DEBT.md) - full list of deprecated endpoints and removal timeline
+- [Technical Debt](./TECHNICAL_DEBT.md) — full list of deprecated endpoints and removal timeline
 - [Plugin Development Guide](./PLUGIN_DEVELOPMENT.md)

--- a/docs/development/PLUGIN_DEVELOPMENT.md
+++ b/docs/development/PLUGIN_DEVELOPMENT.md
@@ -73,12 +73,12 @@ Your plugin shows up in Integrations and your variables appear in the editor.
 
 When your manifest has **no** `variables` section (or it's empty), FiestaBoard automatically:
 
-1. Calls your `fetch_data()` method
-2. Inspects the top-level keys in `data`
+1. Calls your `fetch_data()` method during startup
+2. Inspects the top-level keys in `PluginResult.data`
 3. Exposes every scalar value (strings, numbers, booleans) as a template variable
-4. Uses a default `max_length` of 22 (full board width)
+4. Leaves `max_length` unset, so the template engine truncates to the board width at render time
 
-This means beginners can skip the entire `variables` and `max_lengths` configuration and just focus on returning data.
+This means beginners can skip the entire `variables` and `max_lengths` configuration and just focus on returning data. Lists and dicts in `data` are skipped by auto-discovery — declare them under `variables.arrays` if you need them as template variables.
 
 ### When auto-discovery is active
 
@@ -535,30 +535,46 @@ Your plugin must inherit from `PluginBase`:
 
 | Method | Required | Description |
 |--------|----------|-------------|
-| `plugin_id` | Yes | Property returning plugin ID |
-| `fetch_data()` | Yes | Fetch and return data |
-| `validate_config(config)` | No | Validate configuration |
-| `cleanup()` | No | Clean up when disabled |
+| `plugin_id` | Yes | Property returning the plugin ID; must match `manifest.json` `id` |
+| `fetch_data()` | Yes | Return a `PluginResult` with the data dict for templates |
+| `validate_config(config)` | No | Return a list of error strings; empty list means valid |
+| `on_config_change(old, new)` | No | Hook called after settings are updated |
+| `get_formatted_display()` | No | Return six display lines for "single" page rendering |
+| `cleanup()` | No | Release resources when the plugin is disabled |
+| `check_triggers()` | No | Return a list of `TriggerResult` if `supports_triggers` is set |
+| `receive_payload(payload, headers, raw_body)` | No | Handle inbound webhooks (raise `PermissionError` → 403, `ValueError` → 400) |
 
-### Helper Methods
+### Properties and helpers
 
-| Method | Description |
-|--------|-------------|
-| `get_config(key, default=None)` | Get configuration value |
-| `get_manifest()` | Get plugin manifest |
-| `is_enabled` | Property: plugin enabled state |
+Access settings and metadata through these properties on `PluginBase`:
+
+| Member | Kind | Description |
+|--------|------|-------------|
+| `self.config` | property | Current settings dict (call `.get("key", default)` on it) |
+| `self.manifest` | property | Parsed `manifest.json` as a dict |
+| `self.info` | property | `PluginInfo` dataclass with `id`, `name`, `version`, `author`, etc. |
+| `self.enabled` | property | Whether the plugin is currently enabled |
+| `self.refresh_seconds` | property | Effective refresh interval (clamped to `min_refresh_seconds`) |
+| `self.resolve_config_variables(extra_variables=None, timezone=None)` | method | Resolved copy of config with `{{var}}` strings interpolated |
+| `self.get_resolved_config_value(key, default=None, ...)` | method | One resolved value from the config |
+| `self.get_url(key="url", default="", ...)` | method | Resolved string setting (for HTTP endpoint fields) |
+| `self.get_settings_schema()` | method | The `settings_schema` block from the manifest |
+| `self.get_env_vars()` | method | The `env_vars` array from the manifest |
+| `self.clear_cache()` | method | Force a fresh `fetch_data()` on the next `get_data()` |
+
+> **Heads up:** The base class does **not** expose a `self.get_config(...)` method — call `self.config.get(...)` instead. The bundled `plugins/_template/__init__.py` still calls `self.get_config()` and would raise `AttributeError` at runtime; treat it as pseudo-code until that template is fixed.
 
 ### PluginResult
 
-Return this from `fetch_data()`:
+Return this from `fetch_data()` (see `src/plugins/base.py`):
 
 ```python
 @dataclass
 class PluginResult:
-    available: bool                        # True if data fetched successfully
-    data: Optional[Dict] = None            # Template variables
-    error: Optional[str] = None            # Error message
-    formatted_lines: Optional[List[str]] = None  # Pre-formatted display lines
+    available: bool                              # True if data fetched successfully
+    data: dict[str, Any] | None = None           # Template variables
+    error: str | None = None                     # Error message
+    formatted_lines: list[str] | None = None     # Pre-formatted display (6 lines)
 ```
 
 ## Testing Your Plugin
@@ -627,12 +643,14 @@ def fetch_data(self) -> PluginResult:
 
 ### Configuration
 
-Prefer UI configuration over environment variables:
+Prefer UI configuration over environment variables. Settings live on `self.config`:
 
 ```python
 def fetch_data(self) -> PluginResult:
-    api_key = self.get_config("api_key") or os.getenv("MY_PLUGIN_API_KEY")
+    api_key = self.config.get("api_key") or os.getenv("MY_PLUGIN_API_KEY")
 ```
+
+For settings that contain `{{date}}` / `{{year}}` placeholders (e.g. dynamic URLs), use `self.get_resolved_config_value("api_url")` or the URL-specific shortcut `self.get_url("api_url")`.
 
 ### Logging
 
@@ -645,11 +663,11 @@ logger.error("Failed to fetch data")
 
 ## Plugin Updates
 
-External plugins installed from the registry or a git URL are updated automatically. FiestaBoard checks for new versions every hour and silently pulls the latest commit for any plugin that has changed.
+External plugins installed from the registry or a git URL are updated automatically. A background task in `src/api_server.py` polls every hour, calls `registry.check_for_updates()`, and — when the user's **Auto-update plugins** setting is on — silently pulls the latest commit for any plugin that has changed.
 
-This behaviour is controlled by the **Auto-update plugins** toggle in **Settings → Plugin Updates** (enabled by default). When disabled, users can update plugins manually from the Integrations page using the per-plugin update button or the bulk "Apply all updates" action.
+The behaviour is controlled by **Settings → Plugin Updates**. Users can choose between automatic application and a manual flow that surfaces the available update on the Integrations page (per-plugin update button or the bulk "Apply all updates" action).
 
-For plugin authors this means users will receive fixes and new variables automatically as soon as changes land on the plugin's default branch. Keep the default branch stable — breaking changes should be gated behind a version bump in `manifest.json`.
+For plugin authors this means users on the default settings will receive fixes and new variables shortly after changes land on the plugin's default branch. Keep the default branch stable — breaking changes should be gated behind a version bump in `manifest.json`.
 
 ## Contributing Plugins
 

--- a/docs/development/TECHNICAL_DEBT.md
+++ b/docs/development/TECHNICAL_DEBT.md
@@ -6,29 +6,16 @@ This document tracks known technical debt in FiestaBoard, including deprecated A
 
 ## Deprecated API Endpoints
 
-### 1. Board Configuration Alias
-
-| Type | Path | Status |
-|------|------|--------|
-| **Canonical** | `GET /config/board` | Active |
-| **Canonical** | `PUT /config/board` | Active |
-| **Deprecated** | `GET /config/vestaboard` | Deprecated - returns `Deprecation: true` header |
-| **Deprecated** | `PUT /config/vestaboard` | Deprecated - returns `Deprecation: true` header |
-
-The `/config/vestaboard` paths are backward-compatibility aliases kept after the plugin architecture migration. They redirect to `/config/board` and will be removed in a future major release.
-
-**Migration:** Replace calls to `/config/vestaboard` with `/config/board`. See [API Migration Guide](./API_MIGRATION.md).
-
----
-
-### 2. Display Raw Data
+### Display Raw Data
 
 | Type | Path | Status |
 |------|------|--------|
 | **Canonical** | `GET /plugins/{plugin_id}/data` | Active |
-| **Deprecated** | `GET /displays/{display_type}/raw` | Deprecated - returns `Deprecation: true` header |
+| **Deprecated** | `GET /displays/{display_type}/raw` | Returns `Deprecation: true` header |
 
 After the plugin architecture migration, plugin data should be retrieved via `/plugins/{plugin_id}/data`. The old `/displays/{display_type}/raw` endpoint remains for backward compatibility and will be removed in a future major release.
+
+The new endpoint also changes failure mode: it returns HTTP **503** when plugin data is unavailable instead of `200 {"available": false}`. Callers that rely on the old success-with-flag behaviour need to handle the 503.
 
 **Migration:** Replace calls to `/displays/{type}/raw` with `/plugins/{plugin_id}/data`. See [API Migration Guide](./API_MIGRATION.md).
 
@@ -38,9 +25,17 @@ After the plugin architecture migration, plugin data should be retrieved via `/p
 
 | Endpoint | Deprecated Since | Planned Removal |
 |----------|-----------------|-----------------|
-| `GET /config/vestaboard` | v1.x | v2.0 |
-| `PUT /config/vestaboard` | v1.x | v2.0 |
 | `GET /displays/{type}/raw` | v1.x | v2.0 |
+
+---
+
+## Dead Code
+
+### Unregistered `/config/vestaboard` compat shims
+
+`src/api_server.py` defines `get_board_config_compat()` and `update_board_config_compat()` to redirect callers from the historical `/config/vestaboard` paths to `/config/board`, but neither function is registered as a FastAPI route — there's no `@app.get("/config/vestaboard")` or `@app.put(...)` binding. The functions are unreachable.
+
+**Cleanup:** Delete both functions. The historical paths already return 404 to clients, so no migration window is needed.
 
 ---
 

--- a/docs/development/VISUAL_REGRESSION.md
+++ b/docs/development/VISUAL_REGRESSION.md
@@ -1,17 +1,29 @@
 # Visual Regression Tests
 
-FiestaBoard's web UI ships with Playwright visual regression tests
-(`web/tests/visual-regression.spec.ts`). Each test renders a critical
-UI state and compares it pixel-by-pixel against a committed baseline
-PNG, using a 0.3 % pixel-diff ratio to tolerate sub-pixel rendering
-differences between runs.
+FiestaBoard's web UI ships with Playwright visual regression tests in
+`web/tests/visual-regression.spec.ts`. Each test renders a critical UI
+state and compares it pixel-by-pixel against a committed baseline PNG.
+The suite uses `maxDiffPixelRatio: 0.003` (0.3 %) with a per-pixel
+`threshold: 0.2` to tolerate sub-pixel rendering differences between
+runs.
+
+There are 15 screenshot tests covering Dashboard (default / dark /
+light), Page Editor (empty / with content / with template variables),
+Schedule (empty / with entries), Settings (general / board config),
+Plugin Integrations (installed / marketplace), Pages list (empty /
+with pages), and Navigation (sidebar default).
 
 ## When CI runs them
 
 The `Run visual regression tests` step lives inside the `E2E Tests`
 job in `.github/workflows/ci.yml`. It runs on every PR (and pushes to
 `main`) when web-relevant paths change. The step uses `--workers=1`
-because the 15-ish screenshot tests don't benefit from sharding.
+because the 15 screenshot tests don't benefit from sharding.
+
+The step is currently `continue-on-error: true` — see the comment block
+in `ci.yml`. Once `bootstrap-visual-baselines.yml` has been run and the
+generated baselines are merged, that line is removed and the step
+becomes required.
 
 ## Updating baselines
 
@@ -35,9 +47,10 @@ docker-compose -f docker-compose.dev.yml up -d
 # 2. Wait for the API to be ready.
 curl --retry 30 --retry-delay 1 --retry-connrefused http://localhost:4420/api/health
 
-# 3. Regenerate snapshots inside the container.
-docker-compose -f docker-compose.dev.yml run --rm --profile test web sh -c "
-  cd /web && npx playwright test visual-regression.spec.ts --update-snapshots --workers=1
+# 3. Regenerate snapshots inside the web test container.
+#    Working dir inside the container is /app (mounted from ./web).
+docker-compose -f docker-compose.dev.yml --profile test run --rm web sh -c "
+  npm ci && npx playwright test visual-regression.spec.ts --update-snapshots --workers=1
 "
 
 # 4. Inspect the diff before committing.
@@ -64,20 +77,30 @@ The `Bootstrap Visual Regression Baselines` workflow:
 4. Opens a PR titled **"ci: refresh visual regression baselines"** with
    the new PNGs.
 
-Review the screenshots in the PR before merging. The workflow also
-removes `continue-on-error: true` from the visual regression step on
-first run — once merged, the step is **required**.
+Review the screenshots in the PR before merging. Flipping the CI step
+from advisory (`continue-on-error: true`) to required is a separate
+one-line PR — the bot token in `bootstrap-visual-baselines.yml` lacks
+the `workflow` scope needed to modify `ci.yml`.
 
 ## Adding a new screenshot test
 
 1. Add the test to `web/tests/visual-regression.spec.ts` using
-   `expect(page).toHaveScreenshot(snap('your-name'), SCREENSHOT_OPTIONS)`.
+   `expect(page).toHaveScreenshot(snap("your-name"), SCREENSHOT_OPTIONS)`.
+   Use the existing `snap()` helper so snapshot filenames stay consistent.
 2. Run Option A or B above to generate the baseline.
-3. Commit the new `.png` alongside your test code.
+3. Commit the new `.png` alongside your test code under
+   `web/tests/visual-regression.spec.ts-snapshots/`.
 
 ## Why we hide the cursor / today highlight
 
 `maskEditorCursor` and `maskCalendarToday` in the spec file neutralise
-sources of non-determinism (blinking cursors, today highlighting).
-Add similar masks if a new test surface has its own time-varying or
-animation-driven state.
+sources of non-determinism (blinking caret, selection highlights, the
+calendar "today" tile that changes daily). Add similar masks if a new
+test surface has its own time-varying or animation-driven state.
+
+## Related files
+
+- Spec: `web/tests/visual-regression.spec.ts`
+- Baselines: `web/tests/visual-regression.spec.ts-snapshots/`
+- CI step: `.github/workflows/ci.yml` (search for `Run visual regression tests`)
+- Bootstrap workflow: `.github/workflows/bootstrap-visual-baselines.yml`


### PR DESCRIPTION
## Summary

Cross-referenced five developer-focused docs against the running codebase (`src/api_server.py`, `src/plugins/base.py`, `plugins/_template/`, `web/tests/visual-regression.spec.ts`, `web/src/app/globals.css`) and fixed the inaccuracies that had drifted. No new features documented, no aspirational content added.

## Files

- `docs/development/API_MIGRATION.md` — removed the `/config/vestaboard` section (those routes are no longer registered); corrected the `/plugins/{plugin_id}/data` response shape (`formatted_lines`, not `formatted`) and noted the 503-vs-200 behaviour change.
- `docs/development/TECHNICAL_DEBT.md` — dropped the matching `/config/vestaboard` deprecation entry; moved the unregistered compat shims to a new "Dead Code" section flagging them for deletion.
- `docs/development/PLUGIN_DEVELOPMENT.md` — rewrote the Properties/helpers table to match `src/plugins/base.py` (the doc claimed `self.get_config(...)` and `self.get_manifest()`, neither of which exists on `PluginBase`); fixed the "default `max_length` of 22" claim (actually `None`); added `on_config_change` / `get_formatted_display` / `check_triggers` / `receive_payload` to the methods list; tightened the Plugin Updates description.
- `docs/development/VISUAL_REGRESSION.md` — corrected the local Option A command (working dir is `/app`, not `/web`); replaced "15-ish" with the actual list of 15 covered surfaces; added a Related files block.
- `docs/design.md` — small polish: dropped the stale "Design Pass 2" reference in the contrast section; added a Related files block.

## Top 5 accuracy fixes

1. **`/config/vestaboard` endpoints don't exist as routes.** The helper functions `get_board_config_compat()` and `update_board_config_compat()` are defined in `src/api_server.py` but never bound with `@app.get/put` decorators. Both `API_MIGRATION.md` and `TECHNICAL_DEBT.md` claimed those paths were live and deprecated — they actually return 404. Removed from migration guide; flagged as dead code in TECHNICAL_DEBT.md.
2. **`PluginBase.get_config()` doesn't exist.** `PLUGIN_DEVELOPMENT.md` listed it as the canonical helper, but `PluginBase` only exposes `self.config` (property). Real plugins (e.g. `plugins/date_time/__init__.py`) use `self.config.get("timezone")`. The bundled `plugins/_template/__init__.py` calls `self.get_config(...)` and would `AttributeError` at runtime — called this out as a followup.
3. **`/plugins/{plugin_id}/data` returns `formatted_lines`, not `formatted`.** The API_MIGRATION example showed a `"formatted": "Sunny, 72°F\nSan Francisco"` string field; the actual response carries `formatted_lines: list[str] | None` from `PluginResult.formatted_lines`. Also documented that the new endpoint switches to HTTP 503 when data is unavailable.
4. **Auto-discovery does not set `max_length = 22`.** `VariableMetadata.max_length` defaults to `None`; truncation happens against the live board width at render time. Removed the "default 22" claim from the auto-discovery section.
5. **Visual regression local command was broken.** The dev `web` container's `working_dir` is `/app` (`docker-compose.dev.yml`), but the doc told users to `cd /web` inside the container. Replaced with a single `npm ci && npx playwright test` invocation from `/app`.

## Verify

- `scripts/validate_plugins.py` — N/A (no plugin docs touched)
- Manual a11y heuristics on all five files: one H1 each, no skipped heading levels, no bare opening fences, no empty/uninformative alt text, no color-only or "see above"-style cues.

## Followups (not in this PR)

- `plugins/_template/__init__.py` still calls `self.get_config("api_key")` — a code fix is needed; flagged in PLUGIN_DEVELOPMENT.md.
- The unregistered `/config/vestaboard` compat shims in `src/api_server.py` should be deleted; flagged in TECHNICAL_DEBT.md's new "Dead Code" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)