### PR TITLE
fix(plugins): use self.config.get in plugin template

### DIFF
--- a/plugins/_template/__init__.py
+++ b/plugins/_template/__init__.py
@@ -43,7 +43,7 @@ class MyPlugin(PluginBase):
             - error: Error message if fetch failed
         """
         # Get configuration
-        api_key = self.get_config("api_key")
+        api_key = self.config.get("api_key")
 
         # Can also check environment variable
         if not api_key:


### PR DESCRIPTION
## Summary

- `plugins/_template/__init__.py` called `self.get_config("api_key")`, but `PluginBase` (in `src/plugins/base.py`) exposes no such method. The canonical accessor is the `self.config` dict property with normal `.get()` access — that's what `countdown`, `date_time`, and `random` already use.
- Anyone copying `_template` to bootstrap a new plugin would hit `AttributeError: 'MyPlugin' object has no attribute 'get_config'` on the first `fetch_data()` call. Surfaced by a docs accuracy sweep.
- Fix swaps the one bad call for `self.config.get("api_key")`. One-line diff, no other changes.

## Audit

Grepped `plugins/` and `src/` for `self.get_config(`, `self.get_setting(`, and `self.get_var(`. Only one occurrence existed — the template line fixed here. The three bundled plugins (`countdown`, `date_time`, `random`) already use `self.config.get(...)` correctly, so no other plugins needed changes.

## Test plan

- [x] `plugins/_template/tests/test_plugin.py` — 13/13 pass (including the previously-broken `test_fetch_data_missing_api_key` and the two cases that set `plugin.config = {"api_key": "test_key_123"}`)
- [x] `scripts/run_plugin_tests.py` — countdown / date_time / random all PASS with coverage 98–99%
- [x] Ran inside the dev container per CLAUDE.md (one-shot `docker-compose run --rm fiestaboard` with `requirements-dev` installed for pytest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)