### PR TITLE
docs: document the plugin trigger system

### DIFF
--- a/docs/development/PLUGIN_DEVELOPMENT.md
+++ b/docs/development/PLUGIN_DEVELOPMENT.md
@@ -561,6 +561,176 @@ class PluginResult:
     formatted_lines: Optional[List[str]] = None  # Pre-formatted display lines
 ```
 
+## Triggering Pages from a Plugin
+
+Most plugins are passive — they provide template variables that get rendered on a schedule. **Triggers** let a plugin push a page to the board the moment something happens: a doorbell ring, a weather alert, a flight landing, the dryer finishing. The trigger wins over the scheduled or manually-selected page until it expires (or the user changes the page).
+
+A few real examples of when a trigger is the right tool:
+
+- A doorbell plugin fires a `"Someone at the door"` page when its webhook receives a press.
+- A weather plugin fires a severe-storm alert whenever a new NWS warning lands.
+- A countdown plugin fires a `"T-minus 60 seconds"` page in the final minute before zero.
+
+If your plugin just polls and displays steady-state data (weather, transit, stocks), you don't need triggers — return data from `fetch_data()` and let users put it on a page.
+
+### 1. Declare trigger support in the manifest
+
+Set `supports_triggers: true` at the top level of `manifest.json`. Without this flag the trigger service skips your plugin entirely, even if you override `check_triggers()`.
+
+```json
+{
+  "id": "doorbell",
+  "name": "Doorbell",
+  "version": "1.0.0",
+  "supports_triggers": true,
+  "settings_schema": {
+    "type": "object",
+    "properties": {
+      "trigger_page_id": {
+        "type": "string",
+        "title": "Page to show when the doorbell rings",
+        "description": "Pick a template page. The trigger's data is exposed as {{doorbell.*}}.",
+        "ui:widget": "page-picker"
+      },
+      "refresh_seconds": {
+        "type": "integer",
+        "default": 60,
+        "minimum": 10
+      }
+    }
+  }
+}
+```
+
+The `trigger_page_id` field is a convention recognised by the display loop (see step 3). Using `"ui:widget": "page-picker"` makes the FiestaBoard settings UI render a page-chooser dropdown for that field instead of a raw text input.
+
+### 2. Implement `check_triggers()` on your plugin
+
+`PluginBase` defines `check_triggers()` with a no-op default. Override it to evaluate your conditions and return a list of `TriggerResult` objects. Only entries with `triggered=True` activate; `triggered=False` entries are ignored (returning a non-firing result is fine — handy for state-machine clarity).
+
+```python
+from src.plugins.base import PluginBase, PluginResult, TriggerResult
+
+
+class DoorbellPlugin(PluginBase):
+    @property
+    def plugin_id(self) -> str:
+        return "doorbell"
+
+    def fetch_data(self) -> PluginResult:
+        # Passive data — used when no trigger is active.
+        return PluginResult(available=True, data={"last_ring": self._last_ring_iso()})
+
+    def check_triggers(self) -> list[TriggerResult]:
+        ring = self._pending_ring()  # your own state, e.g. from receive_payload()
+        if ring is None:
+            return []
+
+        return [
+            TriggerResult(
+                triggered=True,
+                trigger_id=f"doorbell_ring_{ring.id}",   # stable per event — see dedup notes
+                priority=80,                              # higher beats lower; default 0
+                duration_seconds=45,                      # auto-expires after this
+                data={
+                    "visitor": ring.visitor_label,        # available as {{doorbell.visitor}}
+                    "timestamp": ring.timestamp_iso,
+                },
+                message="Someone at the door",            # fallback if no trigger_page_id
+            )
+        ]
+```
+
+The `TriggerResult` fields are defined in `src/plugins/base.py`:
+
+| Field | Type | Default | Purpose |
+|-------|------|---------|---------|
+| `triggered` | bool | (required) | Whether the trigger fires. `False` entries are ignored. |
+| `trigger_id` | str | `""` | Stable identifier. Same id replaces the prior trigger (dedup). |
+| `priority` | int | `0` | Higher wins when multiple triggers are active simultaneously. |
+| `duration_seconds` | int | `30` | How long the trigger stays active before auto-expiring. |
+| `data` | dict \| None | `None` | Template context exposed as `{{<plugin_id>.*}}` when rendering `trigger_page_id`. |
+| `message` | str \| None | `None` | Plain-text fallback sent to the board if no `trigger_page_id` is configured. |
+| `formatted_lines` | list[str] \| None | `None` | Pre-formatted 6-line board content; takes precedence over `message`. |
+
+### 3. Lifecycle: when triggers fire and what they replace
+
+The display loop ticks at the configured polling interval (see `src/main.py:683`). Each tick, **before** evaluating the scheduled or manual page, it calls `check_triggers()` on every enabled plugin where `supports_triggers` is `true`. The order of operations:
+
+1. **Silence mode wins.** If the board is in silence mode, triggers are *not* evaluated — no plugin code runs at all. The silence indicator stays on the board.
+2. **Each trigger-capable plugin is asked.** `check_triggers()` is called; any returned `triggered=True` results are recorded in the `TriggerService`.
+3. **Highest-priority non-expired trigger is selected.** Ties are broken by insertion order. Expired triggers (older than their `duration_seconds`) are dropped first.
+4. **The page is chosen.** In priority order:
+   - If the plugin's config has `trigger_page_id` set and that page exists and is a `template` page, it is rendered with `{plugin_id: trigger.data}` as template context — so a doorbell trigger with `data={"visitor": "UPS"}` makes `{{doorbell.visitor}}` resolve to `"UPS"` in that page.
+   - Else, if the `TriggerResult` has `formatted_lines`, those are sent as-is.
+   - Else, if it has `message`, that text is sent.
+   - Else, fall through to the normal scheduled/manual page.
+5. **The previously-displayed page is replaced.** When the trigger expires (or is dismissed), the next tick falls through to the scheduled/manual page automatically — no special handling needed.
+
+#### Dedup
+
+Re-emitting a `TriggerResult` with the same `trigger_id` *replaces* the existing active trigger (same id, refreshed `activated_at` and `duration_seconds`). This means it's safe — and expected — to keep returning the same trigger every tick while the underlying condition holds. The board doesn't flicker because the `TriggerService` only sends content to the board when the rendered content actually changes (`src/main.py:630-633`).
+
+Pick `trigger_id` values that are **stable per event** (e.g. `"doorbell_ring_<event_uuid>"`, `"storm_alert_<nws_id>"`). Using a fixed string like `"doorbell"` works too, but means a second ring within the duration window can't visibly re-fire — it just refreshes the existing trigger's clock.
+
+#### User override
+
+If the user manually changes the page (e.g. via the "Change Page" button on the home screen), every active trigger is dismissed *and* suppressed for the remainder of its natural duration (`src/triggers/service.py:186-203`). A plugin can keep returning the same `TriggerResult` every tick — it won't re-activate until the suppression window lapses. This is what makes manual page changes "stick" against a chatty plugin.
+
+#### Rate limiting
+
+The trigger service does not rate-limit firing — that's your plugin's job. The simplest pattern is to track the last-fired timestamp per condition and return `[]` until enough time has passed.
+
+### 4. Inspecting and controlling triggers via the API
+
+The platform exposes triggers over HTTP for the UI and external systems:
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/triggers` | List all active triggers (sorted by priority desc). |
+| `GET` | `/triggers/active` | Return the single highest-priority active trigger, or `null`. |
+| `POST` | `/triggers/{trigger_id}/dismiss` | Remove a specific trigger. |
+| `POST` | `/triggers/clear` | Remove all active triggers. |
+| `POST` | `/triggers/check` | Force an immediate evaluation of every trigger-capable plugin. |
+
+`POST /triggers/check` is useful in tests and when wiring up webhook-driven plugins — call it from `receive_payload()` after queueing a new event so the trigger fires without waiting for the next polling tick.
+
+### 5. Common patterns
+
+**Event-on-state-change.** Compare the latest fetched state against the previous one and fire when something crosses a boundary. Don't fire on every tick the condition is true — track the transition.
+
+```python
+def check_triggers(self) -> list[TriggerResult]:
+    current = self._read_sensor()
+    if current == self._last_state:
+        return []
+    self._last_state = current
+    if current != "alert":
+        return []
+    return [TriggerResult(
+        triggered=True,
+        trigger_id=f"sensor_alert_{current.event_id}",
+        priority=50,
+        duration_seconds=120,
+        data={"reading": current.value},
+    )]
+```
+
+**Threshold alert.** Fire when a numeric value crosses a configured threshold and stay active until it recovers.
+
+**Webhook-driven.** Override `receive_payload()` (see `src/plugins/base.py:458`) to enqueue an event when an external system pushes to your plugin's webhook endpoint. Then `check_triggers()` consumes the queue. Hit `POST /triggers/check` from `receive_payload()` to fire immediately rather than waiting for the next tick.
+
+**Scheduled interrupt.** A countdown plugin can fire a high-priority trigger in the final minute before an event so the board interrupts whatever else is showing.
+
+### Gotchas
+
+- ❌ **Don't fire on every tick without a stable `trigger_id`.** Without an id the trigger replaces itself anyway, but using event-derived ids makes dedup, dismiss, and API inspection sane.
+- ❌ **Don't return `triggered=True` for steady-state data.** Triggers preempt the user's scheduled page. Reserve them for genuine events.
+- ❌ **Don't raise from `check_triggers()` and assume the loop handles it gracefully.** It does (`src/triggers/service.py:240-244`), but the error is silently logged — your trigger just stops firing. Catch and log inside the method if you need visibility.
+- ❌ **Don't store secrets or PII in `TriggerResult.data`.** It's exposed via `GET /triggers` and the page template engine.
+- ❌ **Don't expect triggers to fire during silence mode.** They're explicitly suppressed.
+- ⚠️ **`priority` is plugin-author choice.** There's no global scale, so coordinate with other trigger-capable plugins if you ship a registry plugin. As a rough convention so far: ambient/informational ~10, notable ~50, urgent/safety ~80+.
+
 ## Testing Your Plugin
 
 **All plugins must include tests with a minimum of 80% code coverage.** CI will fail if coverage is below this threshold.

--- a/plugins/_template/README.md
+++ b/plugins/_template/README.md
@@ -113,6 +113,7 @@ plugins/my_plugin/
 | `documentation` | string | Path to documentation file |
 | `env_vars` | array | Environment variables the plugin can use |
 | `color_rules_schema` | object | Schema for dynamic color rules |
+| `supports_triggers` | boolean | Enable event-based triggers (see [Triggering Pages from a Plugin](../../docs/development/PLUGIN_DEVELOPMENT.md#triggering-pages-from-a-plugin)) |
 
 #### Screenshots Field
 
@@ -167,6 +168,8 @@ class MyPlugin(PluginBase):
 | `validate_config(config)` | Validate configuration. Return list of errors |
 | `cleanup()` | Called when plugin is disabled. Clean up resources |
 | `on_config_change(old, new)` | Called when configuration is updated |
+| `check_triggers()` | Return event-based `TriggerResult` list (requires `supports_triggers: true` — see [Triggering Pages from a Plugin](../../docs/development/PLUGIN_DEVELOPMENT.md#triggering-pages-from-a-plugin)) |
+| `receive_payload(payload, headers, raw_body)` | Handle a pushed webhook payload (raise `PermissionError` / `ValueError` for 403 / 400) |
 | `config` | Property. The current configuration dictionary |
 | `manifest` | Property. The raw manifest dictionary |
 

--- a/plugins/_template/__init__.py
+++ b/plugins/_template/__init__.py
@@ -13,6 +13,9 @@ from typing import Any
 
 from src.plugins.base import PluginBase, PluginResult
 
+# Uncomment when adding event-based triggers (see check_triggers stub below):
+# from src.plugins.base import TriggerResult
+
 logger = logging.getLogger(__name__)
 
 
@@ -141,4 +144,33 @@ class MyPlugin(PluginBase):
         Override this to clean up any resources (close connections, etc.)
         """
         logger.info(f"Plugin {self.plugin_id} cleanup")
+
+    # ------------------------------------------------------------------
+    # Optional: event-based triggers
+    # ------------------------------------------------------------------
+    # Uncomment and adapt the block below if your plugin needs to push a
+    # specific page to the board in response to an event (doorbell ring,
+    # weather alert, threshold crossed, etc.). You must also set
+    # `"supports_triggers": true` in manifest.json — without that flag
+    # this method is never called.
+    #
+    # Full docs: docs/development/PLUGIN_DEVELOPMENT.md
+    # ("Triggering Pages from a Plugin")
+    #
+    # def check_triggers(self) -> list["TriggerResult"]:
+    #     """Return a list of TriggerResult; entries with triggered=True activate."""
+    #     event = self._pending_event()  # your own state
+    #     if event is None:
+    #         return []
+    #     return [
+    #         TriggerResult(
+    #             triggered=True,
+    #             trigger_id=f"my_plugin_event_{event.id}",  # stable per event
+    #             priority=50,                                # higher = more important
+    #             duration_seconds=30,                        # auto-expires after this
+    #             data={"label": event.label},                # → {{my_plugin.label}}
+    #             message="Event fired",                      # fallback when no
+    #                                                         # trigger_page_id is set
+    #         )
+    #     ]
 


### PR DESCRIPTION
## Summary

Users have been asking how a plugin can push a page to the board in response to an event — a doorbell ring, a weather alert, a countdown hitting zero. The trigger system already exists end-to-end in code (`src/triggers/`, `PluginBase.check_triggers()`, the `trigger_page_id` convention in `src/main.py`, the `/triggers` REST API) but there was no developer-facing documentation. This branch adds it.

## What's in here

- **New "Triggering Pages from a Plugin" section** in `docs/development/PLUGIN_DEVELOPMENT.md` covering:
  - When to use triggers vs. passive `fetch_data()`
  - Declaring `supports_triggers: true` in the manifest, with a real doorbell example
  - Implementing `check_triggers()` and the full `TriggerResult` field table
  - Lifecycle: silence-mode short-circuit, per-tick evaluation, priority selection, `trigger_page_id` page rendering with `{plugin_id: trigger.data}` as template context, fallback to `formatted_lines` / `message`
  - Dedup via stable `trigger_id`, user-override suppression (the manual "Change Page" interaction)
  - The `/triggers` REST endpoints (`GET /triggers`, `GET /triggers/active`, `POST /triggers/{id}/dismiss`, `POST /triggers/clear`, `POST /triggers/check`)
  - Common patterns: event-on-state-change, threshold alert, webhook-driven (`receive_payload()`), scheduled interrupt
  - Gotchas — what not to do, including PII in `data`, raising silently, ignoring silence mode
- **`plugins/_template/__init__.py`** — commented-out copy-pasteable `check_triggers()` stub
- **`plugins/_template/README.md`** — adds `supports_triggers`, `check_triggers()`, and `receive_payload()` rows to the manifest / `PluginBase` reference tables, each linking to the new section

All code references are pinned to actual `src/` paths (`src/plugins/base.py:44,468`, `src/triggers/service.py:186,240-244`, `src/main.py:589-609,683`) so the docs stay anchored to behaviour, not paraphrase.

## Voice / format checks

- [x] Examples-first (doorbell visitor, weather alert, countdown T-minus 60s) rather than abstract placeholders
- [x] Real, runnable code anchored to actual `PluginBase` / `TriggerResult` signatures
- [x] No real PII in examples — visitor labels, IDs, etc. are all generic
- [x] Block-quote / table / short-paragraph cadence matches the rest of `PLUGIN_DEVELOPMENT.md`
- [x] Scope limited to the four files in the brief: no other plugin docs touched
- [x] `python3 scripts/validate_plugins.py` passes (3/3)
- [x] No new a11y findings introduced by this branch (pre-existing untagged code fences in `_template/README.md` and `PLUGIN_DEVELOPMENT.md` are out of scope — they predate these commits)

## How the trigger system actually works (short version for reviewers)

1. Plugin declares `"supports_triggers": true` in `manifest.json` → `PluginBase.supports_triggers` returns `True`.
2. Plugin overrides `check_triggers() -> list[TriggerResult]`.
3. Every active-page polling tick (`src/main.py:683`), before evaluating the scheduled/manual page, `_check_trigger_override()` walks `registry.trigger_plugins`, calls `check_triggers()` on each, and records any `triggered=True` results in the `TriggerService`.
4. `TriggerService.get_active_trigger()` returns the highest-priority non-expired trigger.
5. If the producing plugin's config has `trigger_page_id`, that page is rendered with `{plugin_id: trigger.data}` as context. Otherwise `formatted_lines` or `message` is sent raw.
6. On manual page change, `dismiss_active_for_user_override()` clears all active triggers and suppresses re-firing of the same `trigger_id` for the rest of its natural duration.
7. Triggers are entirely skipped while silence mode is active.

## Code-side gaps worth followups

These are real holes I noticed but did not address in this branch:

- **No bundled plugin uses triggers yet.** All current trigger coverage lives in `tests/test_plugin_triggers.py` with synthetic plugins. A real reference implementation (e.g. a webhook-driven plugin in `plugins/`) would make the docs land harder.
- **`trigger_page_id` is an undocumented config convention.** The display loop hardcodes `plugin.config.get("trigger_page_id")` (`src/main.py:600`) but the manifest schema does not formalise it. Plugins have to know to add it to their `settings_schema` themselves (with `"ui:widget": "page-picker"` for the picker UI). Worth lifting into the platform — either as a manifest-level field auto-injected into settings, or as a top-level `trigger_page_id_schema` flag.
- **No public helper to fire triggers from `receive_payload()`.** Webhook plugins currently have to mutate internal state and rely on the next tick — or call `POST /triggers/check` over HTTP. A `self.fire_trigger(TriggerResult(...))` shortcut on `PluginBase` would be cleaner.
- **`priority` has no defined scale.** I documented an ad-hoc convention (10 ambient / 50 notable / 80+ urgent) but the platform should publish one to avoid registry-plugin collisions.
- **No tests cover the `trigger_page_id` render path in `src/main.py:596-609`.** Worth backfilling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)