### PR TITLE
feat(triggers): platform plumbing for plugin trigger ergonomics

### DIFF
--- a/docs/development/PLUGIN_DEVELOPMENT.md
+++ b/docs/development/PLUGIN_DEVELOPMENT.md
@@ -589,9 +589,14 @@ A few real examples of when a trigger is the right tool:
 
 If your plugin just polls and displays steady-state data (weather, transit, stocks), you don't need triggers — return data from `fetch_data()` and let users put it on a page.
 
+There are two ways to surface a trigger:
+
+1. **Poll**: override `check_triggers()` and the display loop evaluates it every tick.
+2. **Push**: call `self.fire_trigger(...)` from `receive_payload()` (or any other event handler) the moment something happens.
+
 ### 1. Declare trigger support in the manifest
 
-Set `supports_triggers: true` at the top level of `manifest.json`. Without this flag the trigger service skips your plugin entirely, even if you override `check_triggers()`.
+Set `supports_triggers: true` at the top level of `manifest.json`. Without this flag the trigger service skips your plugin entirely, even if you override `check_triggers()` or call `fire_trigger()`.
 
 ```json
 {
@@ -602,12 +607,6 @@ Set `supports_triggers: true` at the top level of `manifest.json`. Without this 
   "settings_schema": {
     "type": "object",
     "properties": {
-      "trigger_page_id": {
-        "type": "string",
-        "title": "Page to show when the doorbell rings",
-        "description": "Pick a template page. The trigger's data is exposed as {{doorbell.*}}.",
-        "ui:widget": "page-picker"
-      },
       "refresh_seconds": {
         "type": "integer",
         "default": 60,
@@ -618,7 +617,7 @@ Set `supports_triggers: true` at the top level of `manifest.json`. Without this 
 }
 ```
 
-The `trigger_page_id` field is a convention recognised by the display loop (see step 3). Using `"ui:widget": "page-picker"` makes the FiestaBoard settings UI render a page-chooser dropdown for that field instead of a raw text input.
+When `supports_triggers: true`, the manifest loader **auto-injects** a `trigger_page_id` field into the plugin's effective `settings_schema` so it shows up as a page-picker in the configuration UI. You no longer have to hand-roll the field. If you need a custom title or description, declare `trigger_page_id` explicitly in `settings_schema.properties` — your override wins and the auto-injection is suppressed.
 
 ### 2. Implement `check_triggers()` on your plugin
 
@@ -626,6 +625,7 @@ The `trigger_page_id` field is a convention recognised by the display loop (see 
 
 ```python
 from src.plugins.base import PluginBase, PluginResult, TriggerResult
+from src.triggers import TriggerPriority
 
 
 class DoorbellPlugin(PluginBase):
@@ -646,7 +646,7 @@ class DoorbellPlugin(PluginBase):
             TriggerResult(
                 triggered=True,
                 trigger_id=f"doorbell_ring_{ring.id}",   # stable per event — see dedup notes
-                priority=80,                              # higher beats lower; default 0
+                priority=TriggerPriority.URGENT,         # see priority scale below
                 duration_seconds=45,                      # auto-expires after this
                 data={
                     "visitor": ring.visitor_label,        # available as {{doorbell.visitor}}
@@ -662,14 +662,65 @@ The `TriggerResult` fields are defined in `src/plugins/base.py`:
 | Field | Type | Default | Purpose |
 |-------|------|---------|---------|
 | `triggered` | bool | (required) | Whether the trigger fires. `False` entries are ignored. |
-| `trigger_id` | str | `""` | Stable identifier. Same id replaces the prior trigger (dedup). |
-| `priority` | int | `0` | Higher wins when multiple triggers are active simultaneously. |
+| `trigger_id` | str | `""` | Stable identifier. Same id replaces the prior trigger (dedup). Defaults to the plugin id when omitted on a `fire_trigger()` call. |
+| `priority` | int \| `TriggerPriority` | `0` | Higher wins when multiple triggers are active simultaneously. Prefer the `TriggerPriority` enum (see below). |
 | `duration_seconds` | int | `30` | How long the trigger stays active before auto-expiring. |
 | `data` | dict \| None | `None` | Template context exposed as `{{<plugin_id>.*}}` when rendering `trigger_page_id`. |
 | `message` | str \| None | `None` | Plain-text fallback sent to the board if no `trigger_page_id` is configured. |
 | `formatted_lines` | list[str] \| None | `None` | Pre-formatted 6-line board content; takes precedence over `message`. |
 
-### 3. Lifecycle: when triggers fire and what they replace
+#### Priority scale: `TriggerPriority`
+
+Use the published `TriggerPriority` enum (`src/triggers/priority.py`) so triggers from different plugins compose predictably:
+
+| Tier       | Value | When to use                                                    |
+|------------|------:|----------------------------------------------------------------|
+| `AMBIENT`  |    10 | Passive surfacing (e.g. "now playing" updates).                |
+| `NOTABLE`  |    50 | Worth interrupting the current page (e.g. weather alert).      |
+| `URGENT`   |    80 | Must surface immediately (e.g. doorbell, garage left open).    |
+| `CRITICAL` |   100 | Safety / security override (e.g. smoke alarm, severe weather). |
+
+Raw integers still work for backwards compatibility (`priority=42`), but plugins **should prefer the enum** so the ecosystem stays predictable.
+
+### 3. Push pattern — `fire_trigger()` from `receive_payload`
+
+Webhook-driven plugins shouldn't have to wait for the next polling tick. Call `self.fire_trigger(...)` directly from `receive_payload`:
+
+```python
+from src.plugins.base import PluginBase, PluginResult, TriggerResult
+from src.triggers import TriggerPriority
+
+
+class WebhookDoorbellPlugin(PluginBase):
+    @property
+    def plugin_id(self) -> str:
+        return "doorbell"
+
+    def fetch_data(self) -> PluginResult:
+        return PluginResult(available=True, data={})
+
+    def receive_payload(self, payload, headers, raw_body=b""):
+        self.fire_trigger(
+            TriggerResult(
+                triggered=True,
+                trigger_id=f"ring_{payload['event_id']}",
+                message="DOORBELL",
+                priority=TriggerPriority.URGENT,
+                duration_seconds=60,
+                data={"who": payload.get("visitor")},
+            )
+        )
+```
+
+`fire_trigger()` resolves the active `TriggerService` singleton (the same one the display loop uses), so the board reflects the event on the next render — no waiting for the next polling tick. It is a no-op when:
+
+- the plugin's manifest doesn't set `supports_triggers: true`,
+- the passed `TriggerResult.triggered` is `False`, or
+- the trigger id has been user-dismissed (suppression is honoured exactly like `check_triggers()`).
+
+If `trigger_id` is omitted it defaults to the plugin id so simple fire-and-forget handlers don't collide on an empty key.
+
+### 4. Lifecycle: when triggers fire and what they replace
 
 The display loop ticks at the configured polling interval (see `src/main.py:683`). Each tick, **before** evaluating the scheduled or manual page, it calls `check_triggers()` on every enabled plugin where `supports_triggers` is `true`. The order of operations:
 
@@ -697,7 +748,7 @@ If the user manually changes the page (e.g. via the "Change Page" button on the 
 
 The trigger service does not rate-limit firing — that's your plugin's job. The simplest pattern is to track the last-fired timestamp per condition and return `[]` until enough time has passed.
 
-### 4. Inspecting and controlling triggers via the API
+### 5. Inspecting and controlling triggers via the API
 
 The platform exposes triggers over HTTP for the UI and external systems:
 
@@ -709,9 +760,9 @@ The platform exposes triggers over HTTP for the UI and external systems:
 | `POST` | `/triggers/clear` | Remove all active triggers. |
 | `POST` | `/triggers/check` | Force an immediate evaluation of every trigger-capable plugin. |
 
-`POST /triggers/check` is useful in tests and when wiring up webhook-driven plugins — call it from `receive_payload()` after queueing a new event so the trigger fires without waiting for the next polling tick.
+`POST /triggers/check` is useful in tests and for external systems that want to force an evaluation pass. For webhook-driven plugins, prefer `self.fire_trigger(...)` from `receive_payload()` — it's a direct in-process call and avoids the HTTP round-trip.
 
-### 5. Common patterns
+### 6. Common patterns
 
 **Event-on-state-change.** Compare the latest fetched state against the previous one and fire when something crosses a boundary. Don't fire on every tick the condition is true — track the transition.
 
@@ -734,7 +785,7 @@ def check_triggers(self) -> list[TriggerResult]:
 
 **Threshold alert.** Fire when a numeric value crosses a configured threshold and stay active until it recovers.
 
-**Webhook-driven.** Override `receive_payload()` (see `src/plugins/base.py:458`) to enqueue an event when an external system pushes to your plugin's webhook endpoint. Then `check_triggers()` consumes the queue. Hit `POST /triggers/check` from `receive_payload()` to fire immediately rather than waiting for the next tick.
+**Webhook-driven.** Override `receive_payload()` (see `src/plugins/base.py:458`) to handle an incoming webhook and call `self.fire_trigger(...)` directly — no need to wait for the next polling tick or hit `POST /triggers/check`.
 
 **Scheduled interrupt.** A countdown plugin can fire a high-priority trigger in the final minute before an event so the board interrupts whatever else is showing.
 
@@ -745,7 +796,7 @@ def check_triggers(self) -> list[TriggerResult]:
 - ❌ **Don't raise from `check_triggers()` and assume the loop handles it gracefully.** It does (`src/triggers/service.py:240-244`), but the error is silently logged — your trigger just stops firing. Catch and log inside the method if you need visibility.
 - ❌ **Don't store secrets or PII in `TriggerResult.data`.** It's exposed via `GET /triggers` and the page template engine.
 - ❌ **Don't expect triggers to fire during silence mode.** They're explicitly suppressed.
-- ⚠️ **`priority` is plugin-author choice.** There's no global scale, so coordinate with other trigger-capable plugins if you ship a registry plugin. As a rough convention so far: ambient/informational ~10, notable ~50, urgent/safety ~80+.
+- ⚠️ **Prefer `TriggerPriority` over raw integers.** Raw `priority=42` still works, but the enum (`AMBIENT`/`NOTABLE`/`URGENT`/`CRITICAL`) is the published scale and keeps triggers from different plugins composing predictably.
 
 ## Testing Your Plugin
 

--- a/src/plugins/base.py
+++ b/src/plugins/base.py
@@ -479,6 +479,67 @@ class PluginBase(ABC):
         """
         return []
 
+    def fire_trigger(self, trigger: "TriggerResult") -> None:
+        """Immediately submit a trigger to the active :class:`TriggerService`.
+
+        Intended for **push-driven** plugins -- typically those overriding
+        :meth:`receive_payload` -- that need to surface an event as soon as
+        a webhook arrives instead of waiting for the next polling tick or
+        re-implementing ``check_triggers``.
+
+        The method is a no-op when:
+
+        * the plugin's manifest does not declare ``supports_triggers: true``
+          (the trigger system is intentionally opt-in), or
+        * the supplied :class:`TriggerResult` has ``triggered=False`` (matches
+          the behaviour of :meth:`TriggerService.check_plugin_triggers`).
+
+        Triggers that the user has dismissed are still suppressed by the
+        :class:`TriggerService`; ``fire_trigger`` simply delegates and does
+        not bypass user overrides.
+
+        Args:
+            trigger: The :class:`TriggerResult` to enqueue.  When ``trigger_id``
+                is omitted the plugin id is used as a fallback so simple
+                webhook handlers can fire-and-forget.
+        """
+        if not self.supports_triggers:
+            logger.debug(
+                "fire_trigger called on plugin %s which does not declare "
+                "supports_triggers; ignoring",
+                self.plugin_id,
+            )
+            return
+
+        if not getattr(trigger, "triggered", False):
+            logger.debug(
+                "fire_trigger received a non-fired TriggerResult from %s; "
+                "ignoring",
+                self.plugin_id,
+            )
+            return
+
+        # Default trigger_id to the plugin id so naive callers
+        # (``self.fire_trigger(TriggerResult(triggered=True, message="..."))``)
+        # don't end up colliding on an empty string in the service dict.
+        if not trigger.trigger_id:
+            trigger.trigger_id = self.plugin_id
+
+        try:
+            # Local import keeps the plugin base independent of the triggers
+            # subpackage at import time (avoids a circular import — the
+            # service module imports PluginBase).
+            from ..triggers.service import get_trigger_service
+        except Exception:
+            logger.exception(
+                "fire_trigger could not import TriggerService for plugin %s",
+                self.plugin_id,
+            )
+            return
+
+        service = get_trigger_service()
+        service.activate_trigger(self.plugin_id, trigger)
+
     def get_env_vars(self) -> list[dict[str, Any]]:
         """Return required/optional environment variables from manifest.
 

--- a/src/plugins/manifest.py
+++ b/src/plugins/manifest.py
@@ -9,6 +9,7 @@ The manifest.json file is the heart of each plugin, defining:
 - Color rules schema
 """
 
+import copy
 import json
 import logging
 from dataclasses import dataclass, field
@@ -16,6 +17,38 @@ from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+
+# Canonical settings-schema entry auto-injected for any plugin whose manifest
+# declares ``supports_triggers: true``.  Plugin authors can still override the
+# field by declaring their own ``trigger_page_id`` property — the override
+# wins, so they keep full control of label/description/default behaviour.
+TRIGGER_PAGE_ID_PROPERTY: dict[str, Any] = {
+    "type": "string",
+    "title": "Trigger Page",
+    "description": (
+        "Page rendered when this plugin fires a trigger. The trigger's "
+        "data is exposed to the template as the plugin's variables."
+    ),
+    "ui:widget": "page-picker",
+    "default": "",
+}
+
+
+def _inject_trigger_page_id(settings_schema: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of *settings_schema* with the canonical ``trigger_page_id``
+    field injected when the author has not declared their own.
+
+    The on-disk manifest is never mutated; the loader uses this enriched
+    schema so the configuration UI surfaces a page picker automatically for
+    every plugin that declares ``supports_triggers: true``.
+    """
+    enriched = copy.deepcopy(settings_schema) if settings_schema else {}
+    enriched.setdefault("type", "object")
+    properties = enriched.setdefault("properties", {})
+    if "trigger_page_id" not in properties:
+        properties["trigger_page_id"] = copy.deepcopy(TRIGGER_PAGE_ID_PROPERTY)
+    return enriched
 
 # JSON Schema for validating manifest.json files
 MANIFEST_SCHEMA = {
@@ -468,6 +501,22 @@ class PluginManifest:
                 if not demo:
                     demo = None
 
+        # Auto-inject `trigger_page_id` into the effective settings_schema
+        # for any plugin that declares `supports_triggers: true`.  This frees
+        # plugin authors from having to hand-roll the field while still
+        # letting them override it by declaring their own property.  The
+        # on-disk manifest is left untouched — only the in-memory copy used
+        # by the loader (and forwarded into `raw` so the plugin instance
+        # sees the same schema) is enriched.
+        supports_triggers = bool(data.get("supports_triggers", False))
+        settings_schema = data.get("settings_schema", {})
+        if supports_triggers:
+            settings_schema = _inject_trigger_page_id(settings_schema)
+            raw = dict(data)
+            raw["settings_schema"] = settings_schema
+        else:
+            raw = data
+
         return cls(
             id=data["id"],
             name=data["name"],
@@ -476,7 +525,7 @@ class PluginManifest:
             author=data.get("author", "Unknown"),
             repository=data.get("repository", ""),
             documentation=data.get("documentation", "README.md"),
-            settings_schema=data.get("settings_schema", {}),
+            settings_schema=settings_schema,
             env_vars=data.get("env_vars", []),
             variables=variables,
             max_lengths=top_max_lengths,
@@ -484,10 +533,10 @@ class PluginManifest:
             icon=data.get("icon", "puzzle"),
             category=data.get("category", "utility"),
             fiestaboard_version=data.get("fiestaboard_version", ""),
-            supports_triggers=bool(data.get("supports_triggers", False)),
+            supports_triggers=supports_triggers,
             screenshots=screenshots,
             demo=demo,
-            raw=data,
+            raw=raw,
         )
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/triggers/__init__.py
+++ b/src/triggers/__init__.py
@@ -1,5 +1,6 @@
 """Trigger system for event-based plugin messages."""
 
+from .priority import TriggerPriority
 from .service import (
     ActiveTrigger,
     TriggerService,
@@ -9,6 +10,7 @@ from .service import (
 
 __all__ = [
     "ActiveTrigger",
+    "TriggerPriority",
     "TriggerService",
     "get_trigger_service",
     "reset_trigger_service",

--- a/src/triggers/priority.py
+++ b/src/triggers/priority.py
@@ -1,0 +1,44 @@
+"""Standard priority tiers for plugin triggers.
+
+``TriggerResult.priority`` is an open integer to preserve flexibility, but
+plugins should prefer these published tiers so the relative ordering across
+the ecosystem stays predictable.  Higher numbers win when multiple triggers
+are active at the same time.
+
+Tiers
+-----
+
+* :attr:`TriggerPriority.AMBIENT`  (10) — passive surfacing.  The board
+  drifts to this content when nothing else is going on (e.g. "now playing"
+  scrobble updates).
+* :attr:`TriggerPriority.NOTABLE`  (50) — something worth interrupting the
+  current page for (e.g. weather alert, score change).
+* :attr:`TriggerPriority.URGENT`   (80) — must surface now (e.g. doorbell,
+  garage door left open).
+* :attr:`TriggerPriority.CRITICAL` (100) — safety / security override
+  (e.g. smoke alarm, severe weather warning).
+
+Existing integer literals continue to work — ``priority=42`` is still valid.
+The enum subclasses :class:`int` so values can be passed directly into the
+``TriggerResult.priority`` integer field.
+"""
+
+from enum import IntEnum
+
+
+class TriggerPriority(IntEnum):
+    """Documented priority tiers for plugin triggers.
+
+    Plugins are encouraged to use these values rather than raw integers so
+    that triggers from different plugins compose predictably.  Custom values
+    in between tiers (e.g. ``NOTABLE + 5``) are allowed when a plugin needs
+    to outrank another plugin's same-tier trigger.
+    """
+
+    AMBIENT = 10
+    NOTABLE = 50
+    URGENT = 80
+    CRITICAL = 100
+
+
+__all__ = ["TriggerPriority"]

--- a/tests/test_plugin_validation.py
+++ b/tests/test_plugin_validation.py
@@ -1061,7 +1061,19 @@ class TestToDictSerialization:
         assert result["author"] == "Tester"
         assert result["repository"] == "https://example.com"
         assert result["documentation"] == "DOCS.md"
-        assert result["settings_schema"] == {"type": "object"}
+        # When supports_triggers is True the loader auto-injects a
+        # canonical `trigger_page_id` field — verify it's present and that
+        # the original `type: object` marker is preserved.
+        assert result["settings_schema"]["type"] == "object"
+        assert "trigger_page_id" in result["settings_schema"].get(
+            "properties", {}
+        )
+        assert (
+            result["settings_schema"]["properties"]["trigger_page_id"][
+                "ui:widget"
+            ]
+            == "page-picker"
+        )
         assert result["env_vars"] == [{"name": "API_KEY"}]
         assert result["max_lengths"] == {"temp": 5}
         assert result["icon"] == "thermometer"

--- a/tests/test_trigger_platform_plumbing.py
+++ b/tests/test_trigger_platform_plumbing.py
@@ -1,0 +1,353 @@
+"""Tests for the platform-level trigger plumbing additions.
+
+Covers the three platform improvements introduced for plugin authors:
+
+1. Auto-injection of ``trigger_page_id`` into the effective settings_schema
+   for plugins that declare ``supports_triggers: true``.
+2. The :meth:`PluginBase.fire_trigger` synchronous helper used by webhook-
+   driven plugins to submit a trigger immediately.
+3. The :class:`TriggerPriority` published priority scale.
+"""
+
+from typing import List
+
+import pytest
+
+from src.plugins.base import PluginBase, PluginResult, TriggerResult
+from src.plugins.manifest import (
+    TRIGGER_PAGE_ID_PROPERTY,
+    PluginManifest,
+    _inject_trigger_page_id,
+)
+from src.triggers import TriggerPriority
+from src.triggers.service import (
+    TriggerService,
+    get_trigger_service,
+    reset_trigger_service,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _TriggerPlugin(PluginBase):
+    """Minimal trigger-capable plugin used across tests."""
+
+    @property
+    def plugin_id(self) -> str:
+        return "fire_plugin"
+
+    def fetch_data(self) -> PluginResult:
+        return PluginResult(available=True, data={})
+
+    def check_triggers(self) -> List[TriggerResult]:
+        return []
+
+
+def _make_manifest(
+    *,
+    supports_triggers: bool = True,
+    extra_properties: dict | None = None,
+    plugin_id: str = "fire_plugin",
+) -> dict:
+    schema_properties: dict = {
+        "api_key": {"type": "string", "title": "API Key"},
+    }
+    if extra_properties:
+        schema_properties.update(extra_properties)
+    return {
+        "id": plugin_id,
+        "name": "Fire Plugin",
+        "version": "1.0.0",
+        "supports_triggers": supports_triggers,
+        "settings_schema": {
+            "type": "object",
+            "properties": schema_properties,
+        },
+    }
+
+
+@pytest.fixture(autouse=True)
+def _reset_singleton():
+    """Each test runs with a clean TriggerService singleton."""
+    reset_trigger_service()
+    yield
+    reset_trigger_service()
+
+
+# ---------------------------------------------------------------------------
+# Gap 1 — auto-inject trigger_page_id into the effective settings_schema
+# ---------------------------------------------------------------------------
+
+
+class TestTriggerPageIdInjection:
+    """``trigger_page_id`` should appear on every trigger-capable plugin."""
+
+    def test_field_injected_when_supports_triggers_true(self):
+        data = _make_manifest(supports_triggers=True)
+        manifest = PluginManifest.from_dict(data)
+
+        props = manifest.settings_schema["properties"]
+        assert "trigger_page_id" in props
+        field = props["trigger_page_id"]
+        assert field["type"] == "string"
+        # The page-picker widget marker is what surfaces the picker in the UI.
+        assert field["ui:widget"] == "page-picker"
+
+    def test_field_not_injected_when_supports_triggers_false(self):
+        data = _make_manifest(supports_triggers=False)
+        manifest = PluginManifest.from_dict(data)
+        assert "trigger_page_id" not in manifest.settings_schema.get(
+            "properties", {}
+        )
+
+    def test_author_override_wins(self):
+        """If a plugin author declares ``trigger_page_id`` themselves, keep it."""
+        custom = {
+            "type": "string",
+            "title": "Custom Picker Title",
+            "description": "Where I want this thing rendered",
+            "ui:widget": "page-picker",
+            "default": "page-foo",
+        }
+        data = _make_manifest(extra_properties={"trigger_page_id": custom})
+        manifest = PluginManifest.from_dict(data)
+        assert manifest.settings_schema["properties"]["trigger_page_id"] == custom
+
+    def test_injection_does_not_mutate_input_dict(self):
+        """The on-disk manifest dict must remain untouched."""
+        data = _make_manifest(supports_triggers=True)
+        original_props = dict(data["settings_schema"]["properties"])
+        PluginManifest.from_dict(data)
+        assert data["settings_schema"]["properties"] == original_props
+        assert "trigger_page_id" not in data["settings_schema"]["properties"]
+
+    def test_inject_helper_handles_missing_schema(self):
+        """The injector must cope with manifests that omit settings_schema."""
+        enriched = _inject_trigger_page_id({})
+        assert enriched["type"] == "object"
+        assert "trigger_page_id" in enriched["properties"]
+
+    def test_raw_settings_schema_carries_injected_field(self):
+        """The plugin instance reads from ``manifest.raw`` — that copy must
+        carry the injected field so ``plugin.get_settings_schema`` returns it."""
+        data = _make_manifest(supports_triggers=True)
+        manifest = PluginManifest.from_dict(data)
+        raw_props = manifest.raw["settings_schema"]["properties"]
+        assert "trigger_page_id" in raw_props
+
+    def test_canonical_property_marker_constant_exposed(self):
+        """``TRIGGER_PAGE_ID_PROPERTY`` is exported so other modules
+        (e.g. the registry serialiser) can reference the canonical shape."""
+        assert TRIGGER_PAGE_ID_PROPERTY["ui:widget"] == "page-picker"
+        assert TRIGGER_PAGE_ID_PROPERTY["type"] == "string"
+
+
+# ---------------------------------------------------------------------------
+# Gap 2 — PluginBase.fire_trigger helper
+# ---------------------------------------------------------------------------
+
+
+class TestFireTrigger:
+    def test_fire_trigger_enqueues_to_active_service(self):
+        plugin = _TriggerPlugin(_make_manifest(supports_triggers=True))
+        plugin.enabled = True
+
+        plugin.fire_trigger(
+            TriggerResult(
+                triggered=True,
+                trigger_id="webhook_event",
+                message="Doorbell rang",
+                priority=TriggerPriority.URGENT,
+                duration_seconds=60,
+            )
+        )
+
+        service = get_trigger_service()
+        active = service.list_active_triggers()
+        assert len(active) == 1
+        assert active[0].trigger_id == "webhook_event"
+        assert active[0].plugin_id == "fire_plugin"
+        assert active[0].message == "Doorbell rang"
+
+    def test_fire_trigger_works_from_receive_payload(self):
+        """Push-driven plugins should be able to fire from receive_payload."""
+
+        class WebhookPlugin(PluginBase):
+            @property
+            def plugin_id(self) -> str:
+                return "fire_plugin"
+
+            def fetch_data(self) -> PluginResult:
+                return PluginResult(available=True, data={})
+
+            def receive_payload(self, payload, headers, raw_body=b""):
+                self.fire_trigger(
+                    TriggerResult(
+                        triggered=True,
+                        trigger_id=f"event_{payload['event_id']}",
+                        message=payload["message"],
+                        priority=TriggerPriority.NOTABLE,
+                        duration_seconds=30,
+                        data=payload,
+                    )
+                )
+
+        plugin = WebhookPlugin(_make_manifest(supports_triggers=True))
+        plugin.enabled = True
+        plugin.receive_payload(
+            {"event_id": "abc123", "message": "Build failed"},
+            headers={},
+        )
+
+        service = get_trigger_service()
+        active = service.get_active_trigger()
+        assert active is not None
+        assert active.trigger_id == "event_abc123"
+        assert active.data["event_id"] == "abc123"
+
+    def test_fire_trigger_noop_when_plugin_does_not_support_triggers(self):
+        """Calling fire_trigger on a non-trigger plugin must be a safe no-op."""
+        plugin = _TriggerPlugin(_make_manifest(supports_triggers=False))
+        plugin.enabled = True
+        plugin.fire_trigger(
+            TriggerResult(
+                triggered=True,
+                trigger_id="dropped",
+                message="Should not surface",
+            )
+        )
+        service = get_trigger_service()
+        assert service.list_active_triggers() == []
+
+    def test_fire_trigger_noop_when_not_triggered(self):
+        """A TriggerResult with triggered=False must be ignored."""
+        plugin = _TriggerPlugin(_make_manifest(supports_triggers=True))
+        plugin.enabled = True
+        plugin.fire_trigger(
+            TriggerResult(triggered=False, trigger_id="not_yet")
+        )
+        assert get_trigger_service().list_active_triggers() == []
+
+    def test_fire_trigger_defaults_trigger_id_to_plugin_id(self):
+        """If the caller omits trigger_id we fall back to the plugin id so
+        the service dict key stays stable (rather than ``""``)."""
+        plugin = _TriggerPlugin(_make_manifest(supports_triggers=True))
+        plugin.enabled = True
+        plugin.fire_trigger(
+            TriggerResult(triggered=True, message="No ID supplied")
+        )
+        service = get_trigger_service()
+        active = service.list_active_triggers()
+        assert len(active) == 1
+        assert active[0].trigger_id == "fire_plugin"
+
+    def test_fire_trigger_respects_user_suppression(self):
+        """User-dismissed triggers stay suppressed even when re-fired by a
+        webhook — fire_trigger delegates to ``activate_trigger`` which
+        already honours the suppression list."""
+        plugin = _TriggerPlugin(_make_manifest(supports_triggers=True))
+        plugin.enabled = True
+
+        trigger = TriggerResult(
+            triggered=True,
+            trigger_id="muted",
+            message="Should be suppressed",
+            priority=TriggerPriority.NOTABLE,
+            duration_seconds=600,
+        )
+        plugin.fire_trigger(trigger)
+
+        service = get_trigger_service()
+        service.dismiss_trigger("muted", suppress=True)
+        assert service.get_active_trigger() is None
+
+        # Webhook arrives again — must remain suppressed.
+        plugin.fire_trigger(trigger)
+        assert service.get_active_trigger() is None
+
+
+# ---------------------------------------------------------------------------
+# Gap 3 — TriggerPriority published scale
+# ---------------------------------------------------------------------------
+
+
+class TestTriggerPriority:
+    def test_documented_tiers(self):
+        assert TriggerPriority.AMBIENT == 10
+        assert TriggerPriority.NOTABLE == 50
+        assert TriggerPriority.URGENT == 80
+        assert TriggerPriority.CRITICAL == 100
+
+    def test_ordering_holds(self):
+        ordered = sorted(
+            [
+                TriggerPriority.URGENT,
+                TriggerPriority.AMBIENT,
+                TriggerPriority.CRITICAL,
+                TriggerPriority.NOTABLE,
+            ]
+        )
+        assert ordered == [
+            TriggerPriority.AMBIENT,
+            TriggerPriority.NOTABLE,
+            TriggerPriority.URGENT,
+            TriggerPriority.CRITICAL,
+        ]
+
+    def test_integer_priorities_still_supported(self):
+        """The enum is a label on top of an int — raw integer ``priority``
+        values continue to work for backwards compatibility."""
+        trigger = TriggerResult(
+            triggered=True,
+            trigger_id="raw_int",
+            priority=42,
+            duration_seconds=30,
+        )
+        assert trigger.priority == 42
+
+    def test_enum_value_usable_as_priority(self):
+        """Enum values pass straight into TriggerResult.priority."""
+        trigger = TriggerResult(
+            triggered=True,
+            trigger_id="urgent",
+            priority=TriggerPriority.URGENT,
+            duration_seconds=30,
+        )
+        # IntEnum compares equal to its integer value.
+        assert trigger.priority == 80
+        assert int(trigger.priority) == 80
+
+    def test_higher_priority_wins_in_trigger_service(self):
+        svc = TriggerService()
+        svc.activate_trigger(
+            "p1",
+            TriggerResult(
+                triggered=True,
+                trigger_id="ambient",
+                priority=TriggerPriority.AMBIENT,
+                duration_seconds=60,
+                message="Now playing",
+            ),
+        )
+        svc.activate_trigger(
+            "p2",
+            TriggerResult(
+                triggered=True,
+                trigger_id="critical",
+                priority=TriggerPriority.CRITICAL,
+                duration_seconds=60,
+                message="Smoke alarm",
+            ),
+        )
+        active = svc.get_active_trigger()
+        assert active is not None
+        assert active.trigger_id == "critical"
+
+    def test_exported_from_triggers_package(self):
+        """Authors import directly from ``src.triggers``."""
+        from src.triggers import TriggerPriority as Exported
+
+        assert Exported is TriggerPriority


### PR DESCRIPTION
## Summary

Three platform-level improvements to FiestaBoard's plugin trigger system so plugin authors stop having to hand-roll the same boilerplate.

> **Docs note:** the new `## Triggering Pages from a Plugin` section in `docs/development/PLUGIN_DEVELOPMENT.md` is written as if PR #892 (`docs/plugin-triggers`) is already merged. If #892 lands first the section reads as a natural extension; if this PR merges first the section stands on its own as the canonical docs for the trigger system.

### Gap 1 — Auto-inject `trigger_page_id` into the effective settings schema

`PluginManifest.from_dict` now adds a canonical `trigger_page_id` field (string + `ui:widget: page-picker`) to the effective `settings_schema` whenever a manifest sets `supports_triggers: true`. The on-disk manifest is never mutated — the loader builds an enriched copy that is both stored on `PluginManifest.settings_schema` and forwarded into `manifest.raw` so the plugin instance and the registry serialiser see the same schema. Authors can override by declaring their own `trigger_page_id` property; the override wins.

Touched: `src/plugins/manifest.py`, `tests/test_plugin_validation.py` (one assertion rewritten — see notes below), new tests in `tests/test_trigger_platform_plumbing.py`.

### Gap 2 — `PluginBase.fire_trigger(...)`

Webhook-driven plugins can now call `self.fire_trigger(TriggerResult(...))` directly from `receive_payload` instead of mutating internal state and waiting for the next polling tick. The helper:

- Resolves the active `TriggerService` via `get_trigger_service()` (the same singleton accessor the display loop uses in `src/main.py`).
- No-ops when the plugin doesn't declare `supports_triggers: true` or when the supplied `TriggerResult.triggered` is `False`.
- Defaults `trigger_id` to the plugin id so naive fire-and-forget handlers don't collide on `""`.
- Honours user suppression — `TriggerService.activate_trigger` already drops user-dismissed ids, and `fire_trigger` simply delegates.

Touched: `src/plugins/base.py`, tests in `tests/test_trigger_platform_plumbing.py`.

### Gap 3 — Publish a `TriggerPriority` scale

New `src/triggers/priority.py` exposes a documented IntEnum:

| Tier       | Value | Use case                                              |
|------------|------:|-------------------------------------------------------|
| `AMBIENT`  |    10 | Passive surfacing (now playing, scrobbles).           |
| `NOTABLE`  |    50 | Worth interrupting the current page (weather alert).  |
| `URGENT`   |    80 | Must surface (doorbell, garage left open).            |
| `CRITICAL` |   100 | Safety / security (smoke alarm, severe weather).      |

Re-exported from `src.triggers`. Raw integers still work (`priority=42`).

## Design tradeoffs

- **TriggerService singleton access**: the helper uses the existing `get_trigger_service()` module-level singleton accessor in `src/triggers/service.py` (which is what the display loop uses too). I considered injecting the service into `PluginBase.__init__`, but that would have widened the plugin constructor signature and forced every existing plugin to thread the dependency through. The module singleton is the same accessor the platform already uses, and the test suite uses `reset_trigger_service()` to keep tests hermetic.
- **Schema mutation**: I deliberately do not mutate `data` in `from_dict`. The loader passes the enriched schema both to `PluginManifest.settings_schema` and into `raw` (a shallow `dict(data)` copy with `settings_schema` replaced), so `manifest.to_dict()` and the runtime instance see the same effective schema.
- **`fire_trigger` no-op semantics**: `TriggerService` has no global "triggers disabled" flag today. The closest matching behaviour is the existing per-plugin gate (`supports_triggers`), so I gate `fire_trigger` on that and on `TriggerResult.triggered`. Both paths log at debug level rather than raising — matches `check_plugin_triggers` which silently skips disabled plugins.
- **No template-stub changes**: `plugins/_template/` has no commented trigger stub today, so per the task instructions I left it alone.

## Files touched

- `src/plugins/manifest.py` — auto-injection of `trigger_page_id`, new `TRIGGER_PAGE_ID_PROPERTY` constant and `_inject_trigger_page_id` helper.
- `src/plugins/base.py` — `PluginBase.fire_trigger`.
- `src/triggers/priority.py` — new module with `TriggerPriority` enum.
- `src/triggers/__init__.py` — re-export `TriggerPriority`.
- `tests/test_trigger_platform_plumbing.py` — new (19 tests).
- `tests/test_plugin_validation.py` — one assertion updated to reflect the auto-injected field.
- `docs/development/PLUGIN_DEVELOPMENT.md` — new "Triggering Pages from a Plugin" section.

## Test plan

Run in the dev container:

```
docker-compose -f docker-compose.dev.yml run --rm --no-deps fiestaboard sh -c "pip install -q pytest pytest-asyncio && pytest tests/test_plugin_triggers.py tests/test_trigger_platform_plumbing.py -x"
```

- [x] 19 new tests in `tests/test_trigger_platform_plumbing.py` all pass.
- [x] Existing 43 tests in `tests/test_plugin_triggers.py` still pass.
- [x] Full plugin-test sweep (`tests/test_plugin_*.py`, `tests/test_trigger_platform_plumbing.py`) — 354 passed, 0 failed.
- [x] No shipped plugin currently declares `supports_triggers: true`, so the auto-injection has zero behavioural blast radius on the existing plugin set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)