### PR TITLE
fix(web): address CodeQL useless-conditional + unused-var findings from PR #891

### DIFF
--- a/web/src/__tests__/live-output.test.tsx
+++ b/web/src/__tests__/live-output.test.tsx
@@ -623,12 +623,14 @@ describe("Live Output - Cleanup on unmount", () => {
     // shared live-output channel via localStorage. The page builder should
     // observe the storage event and turn off its own toggle so it stops
     // re-establishing live mode.
-    window.dispatchEvent(
-      new StorageEvent("storage", {
-        key: "fiestaboard:liveOutputMessage",
-        newValue: null,
-      }),
-    );
+    // Use Event + defineProperty rather than `new StorageEvent("storage", { ... })`
+    // — CodeQL flags the StorageEvent init-dict overload as superfluous
+    // trailing arguments in the env, and jsdom's StorageEvent constructor
+    // can be unreliable across versions.
+    const storageEvent = new Event("storage");
+    Object.defineProperty(storageEvent, "key", { value: "fiestaboard:liveOutputMessage" });
+    Object.defineProperty(storageEvent, "newValue", { value: null });
+    window.dispatchEvent(storageEvent);
 
     await waitFor(() => {
       expect(toggle).toHaveAttribute("data-state", "unchecked");

--- a/web/src/__tests__/update-intervals-extended.test.tsx
+++ b/web/src/__tests__/update-intervals-extended.test.tsx
@@ -2,7 +2,7 @@
 // The existing general-settings tests cover onChange and board-read blur,
 // but not the polling-interval blur or the requires_restart branch.
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, waitFor } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
 import { ThemeProvider } from "next-themes";
 import { act } from "react";

--- a/web/src/components/page-builder.tsx
+++ b/web/src/components/page-builder.tsx
@@ -1470,7 +1470,7 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
                         const shouldIgnore = shouldIgnoreNextResponse.current;
 
                         if (isTransitioning) return true;
-                        if (preview !== null && !isTransitioning) return false;
+                        if (preview !== null) return false;
                         if (!hasContent) return false;
                         if (shouldIgnore) return false;
                         return isPending && hasContent;

--- a/web/src/components/tiptap-template-editor/TipTapTemplateEditor.tsx
+++ b/web/src/components/tiptap-template-editor/TipTapTemplateEditor.tsx
@@ -408,7 +408,7 @@ export function TipTapTemplateEditor({
 
           // Handle Cut (Ctrl/Cmd + X) - copy to clipboard and delete
           if ((event.ctrlKey || event.metaKey) && event.key === "x") {
-            if (selection && !selection.empty) {
+            if (!selection.empty) {
               try {
                 // Copy selection to clipboard
                 const slice = selection.content();

--- a/web/tests/board-discovery-offline.spec.ts
+++ b/web/tests/board-discovery-offline.spec.ts
@@ -454,7 +454,6 @@ test.describe("Multi-Board — State Independence", () => {
     const boardRes = await fetch(`${API_URL}/settings/board`);
     const boardData = await boardRes.json();
     const board1 = boardData.boards.find((b: Record<string, unknown>) => b.id === board1Id);
-    const board2 = boardData.boards.find((b: Record<string, unknown>) => b.id === board2Id);
 
     // Change board2 from note to flagship
     const updatedBoards = boardData.boards.map((b: Record<string, unknown>) =>


### PR DESCRIPTION
## Summary

Follow-up to #891. Once that PR enabled ESLint in CI, `github-code-quality` (CodeQL) surfaced 5 inline findings on the affected files. All five are real, low-risk to fix, and don't change behavior.

- `page-builder.tsx`: `!isTransitioning` in the `isLoading` IIFE was always true — the prior `if (isTransitioning) return true;` already excluded that state. Dropped the redundant clause.
- `TipTapTemplateEditor.tsx`: `selection &&` in the cut handler was always true — an earlier `if (!selection) return false;` guards it. Dropped the redundant truthiness check.
- `live-output.test.tsx`: replaced `new StorageEvent("storage", {...})` with `new Event("storage")` + `defineProperty` for `key`/`newValue`. CodeQL flags the init-dict overload as superfluous trailing args in this env, and jsdom's `StorageEvent` constructor is unreliable across versions.
- `update-intervals-extended.test.tsx`: removed unused `screen` import from `@testing-library/react`.
- `board-discovery-offline.spec.ts`: removed unused `board2` local in the "changing device type of one board preserves the other" test.

## Test plan

- [x] `npm run lint` → 0 errors, 979 warnings (down 2 from main; the unused-vars fixes drop two warnings too)
- [x] `npm run format:check` → clean
- [x] `npm run test:run` for the touched specs → all green
- [ ] CI's new `lint-web` job stays green
- [ ] CI's `test-ui` job stays green

🤖 Generated with [Claude Code](https://claude.com/claude-code)