### PR TITLE
fix(mdns): downgrade EventLoopBlocked failure to friendly info log

### DIFF
--- a/src/system/mdns.py
+++ b/src/system/mdns.py
@@ -101,7 +101,19 @@ class MDNSService:
         except ImportError:
             logger.warning("zeroconf package not installed – mDNS advertisement disabled")
             return False
-        except Exception:
+        except Exception as exc:
+            # zeroconf raises EventLoopBlocked when its internal asyncio loop
+            # can't process the registration within its timeout. On slow
+            # hardware (e.g. Raspberry Pi 3) this happens during a busy
+            # startup. The app is fine — users just lose the .local URL and
+            # can still reach FiestaBoard by IP.
+            if type(exc).__name__ == "EventLoopBlocked":
+                logger.info(
+                    "mDNS registration timed out during startup; "
+                    "%s.local will be unavailable but FiestaBoard is reachable by IP",
+                    self._hostname,
+                )
+                return False
             logger.warning("Failed to start mDNS service", exc_info=True)
             return False
 

--- a/tests/test_mdns.py
+++ b/tests/test_mdns.py
@@ -139,16 +139,51 @@ class TestMDNSServiceLifecycle:
         assert result is False
         assert svc.is_running is False
 
-    def test_start_handles_generic_exception(self):
-        """If zeroconf raises during registration, start returns False."""
+    def test_start_handles_generic_exception(self, caplog):
+        """If zeroconf raises during registration, start returns False and logs a WARNING with traceback."""
+        import logging
+
         from src.system.mdns import MDNSService
 
         with patch("zeroconf.Zeroconf", side_effect=OSError("Network error")):
             svc = MDNSService()
-            result = svc.start()
+            with caplog.at_level(logging.WARNING, logger="src.system.mdns"):
+                result = svc.start()
 
         assert result is False
         assert svc.is_running is False
+        warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("Failed to start mDNS service" in r.getMessage() for r in warning_records)
+        # Unexpected errors should include the traceback for debugging.
+        assert any(r.exc_info is not None for r in warning_records)
+
+    def test_start_handles_event_loop_blocked(self, caplog):
+        """EventLoopBlocked is a benign slow-hardware timeout — log INFO, not WARNING, and no traceback."""
+        import logging
+
+        from src.system.mdns import MDNSService
+
+        class EventLoopBlocked(Exception):
+            """Stand-in for zeroconf._exceptions.EventLoopBlocked."""
+
+        mock_zc = MagicMock()
+        mock_zc.register_service.side_effect = EventLoopBlocked()
+
+        with patch("zeroconf.Zeroconf", return_value=mock_zc), patch("zeroconf.ServiceInfo", MagicMock()):
+            svc = MDNSService(hostname="testboard")
+            with caplog.at_level(logging.INFO, logger="src.system.mdns"):
+                result = svc.start()
+
+        assert result is False
+        assert svc.is_running is False
+
+        mdns_records = [r for r in caplog.records if r.name == "src.system.mdns"]
+        # No scary WARNING/ERROR or traceback for this known-benign case.
+        assert all(r.levelno < logging.WARNING for r in mdns_records)
+        assert all(r.exc_info is None for r in mdns_records)
+        # Friendly explanation names the host and points users at the IP fallback.
+        info_messages = [r.getMessage() for r in mdns_records if r.levelno == logging.INFO]
+        assert any("testboard.local" in msg and "reachable by IP" in msg for msg in info_messages)
 
 
 class TestGetLocalIp:


### PR DESCRIPTION
## Summary
- Fixes #897 — a benign mDNS registration timeout was being logged at `WARNING` with a full traceback, which read as a real failure to users.
- `zeroconf` raises `EventLoopBlocked` when its internal asyncio loop can't process `register_service` within the registration timeout. On slow hardware (the reporter is on a Raspberry Pi 3) during a busy FiestaBoard startup, the call gets starved of cycles and times out before it ever touches the network. The app keeps running fine — users just lose the `fiestaboard.local` URL and can still reach the board by IP.
- Log this known-benign case as a single `INFO` line that names the host and points users at the IP fallback. Keep `WARNING` + traceback for genuinely unexpected failures (e.g. `OSError`, programming errors).
- Add two regression tests:
  - `test_start_handles_event_loop_blocked` — asserts INFO-level message, no traceback, hostname + "reachable by IP" wording.
  - Tightens `test_start_handles_generic_exception` to assert that genuine errors still log at WARNING with `exc_info`.

## Why match by class name
`EventLoopBlocked` lives at `zeroconf._exceptions.EventLoopBlocked`. Matching by `type(exc).__name__` avoids depending on a private import path and stays robust across zeroconf versions.

## Test plan
- [x] `python -m pytest tests/test_mdns.py -v` → 31 passed (including 2 new branches)
- [x] `ruff check src/system/mdns.py tests/test_mdns.py` → clean
- [x] `ruff format --check` → already formatted
- [ ] Manual: verify a real `EventLoopBlocked` on a Pi 3 now produces one INFO line instead of a traceback (cannot reproduce on dev host)

🤖 Generated with [Claude Code](https://claude.com/claude-code)