### PR TITLE
chore: gitignore supervisord.pid runtime artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ docs-site/.cache-loader/
 
 # Claude Code worktrees (per-user, ephemeral isolated checkouts).
 .claude/worktrees/
+
+# Supervisor runtime PID file (created when supervisord runs locally).
+supervisord.pid


### PR DESCRIPTION
## Summary
- Adds `supervisord.pid` to `.gitignore` so the supervisord runtime PID file isn't accidentally committed when contributors run the dev container locally.

## Context
Came up while reviewing #900 — the PID file got picked up alongside the feature changes. Ignoring it at the repo level prevents the same trip-up for the next contributor.

## Test plan
- [ ] Confirm `supervisord.pid` no longer appears in `git status` after starting the dev container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)