### PR TITLE
ci(pr-label): use pull_request_target so fork PRs can be labeled

### DIFF
--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -1,7 +1,7 @@
 name: PR Auto-Label
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
 permissions:


### PR DESCRIPTION
## Summary
- Switch `.github/workflows/pr-label.yml` from `on: pull_request` to `on: pull_request_target` so the auto-labeler works for PRs opened from forks.

## Why
Surfaced while reviewing #900 (a fork PR). The `label` job failed with:

```
RequestError [HttpError]: Resource not accessible by integration
```

`pull_request` gives fork PRs a read-only `GITHUB_TOKEN`, so the `addLabels` API call fails. `pull_request_target` runs in the base repo's context with the configured `pull-requests: write` permission, which is the standard fix for label / triage workflows.

## Security note
`pull_request_target` is only safe when the workflow does NOT execute code from the PR head. This workflow:
- Reads `context.payload.pull_request.title` and the PR file list via the GitHub API
- Never reads or executes any file from the PR branch
- The `actions/checkout` step defaults to the base ref under `pull_request_target`, so no untrusted code runs with the elevated token

If anyone later adds a step that needs to check out PR contents, it must NOT pass `ref: \${{ github.event.pull_request.head.sha }}` here — that would be the classic `pull_request_target` footgun.

## Test plan
- [ ] Merge and confirm the `label` job passes on the next fork PR (e.g. #900 once it's resynced).
- [ ] Confirm internal PRs still get labeled correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)