### PR TITLE
feat(templates): add zeropad filter and ZEROPAD() formula

### DIFF
--- a/docs-site/docs/reference/template-formulas.md
+++ b/docs-site/docs/reference/template-formulas.md
@@ -170,7 +170,8 @@ Custom user‑defined functions are intentionally **not supported**.
 | `CONTAINS(s, sub)` | `TRUE` if `s` contains `sub`. |
 | `STARTSWITH(s, p)` / `ENDSWITH(s, p)` | Prefix/suffix test. |
 | `PAD(s, w)` | Right‑pad to `w` chars (truncates if longer). |
-| `PADLEFT(s, w)` | Left‑pad to `w` chars. |
+| `PADLEFT(s, w)` | Left‑pad to `w` chars with spaces. |
+| `ZEROPAD(s, w)` | Left‑pad to `w` chars with zeros (e.g. `ZEROPAD(1, 2)` → `"01"`). A leading `-` sign is preserved (`ZEROPAD(-1, 3)` → `"-01"`). Values longer than `w` are returned unchanged. |
 | `CENTER(s, w)` | Center within `w` chars. |
 
 ### Conversion / formatting

--- a/src/templates/engine.py
+++ b/src/templates/engine.py
@@ -7,7 +7,7 @@ Template syntax:
   the user-facing reference docs at ``docs-site/docs/reference/template-formulas.md``.
 - Colors: {{red}}, {{blue}}, etc. - Single colored tile (not text wrapping)
 - Symbols: {sun}, {cloud}, {rain}
-- Formatting: {{value|pad:3}}, {{value|upper}}, {{value|lower}}, {{value|wrap}}
+- Formatting: {{value|pad:3}}, {{value|zeropad:2}}, {{value|upper}}, {{value|lower}}, {{value|wrap}}
 
 Color tiles (each produces one solid color tile):
 - {{red}} or {{63}} - Red tile
@@ -1147,8 +1147,10 @@ class TemplateEngine:
         """Apply a filter to a value.
 
         Supported filters:
-        - pad:N - Pad to N characters
+        - pad:N - Right-pad with spaces to N characters
         - truncate:N - Truncate to N characters
+        - zeropad:N - Left-pad with zeros to N characters (e.g., 1 -> 01).
+          For numeric values, a leading '-' sign is preserved (e.g., -1 -> -01).
         """
         if ":" in filter_expr:
             filter_name, arg = filter_expr.split(":", 1)
@@ -1167,6 +1169,17 @@ class TemplateEngine:
                     return value[:length]
                 except ValueError:
                     return value
+
+            elif filter_name == "zeropad":
+                try:
+                    width = int(arg)
+                except ValueError:
+                    return value
+                if width <= 0:
+                    return value
+                if value.startswith("-"):
+                    return "-" + value[1:].rjust(width - 1, "0")
+                return value.rjust(width, "0")
 
         return value
 

--- a/src/templates/expressions.py
+++ b/src/templates/expressions.py
@@ -13,7 +13,7 @@ Highlights:
       AND, OR, NOT, IFERROR, ISERROR, ISBLANK, DEFAULT, ABS, ROUND, FLOOR,
       CEIL, MIN, MAX, SUM, AVG, MOD, INT, SIGN, UPPER, LOWER, LEN, LEFT,
       RIGHT, MID, TRIM, CONCAT, REPLACE, REPT, CONTAINS, STARTSWITH,
-      ENDSWITH, PAD, PADLEFT, CENTER, TEXT, NUM, FIXED, COLOR.
+      ENDSWITH, PAD, PADLEFT, ZEROPAD, CENTER, TEXT, NUM, FIXED, COLOR.
     * Excel-like error values: ``#REF``, ``#VALUE``, ``#DIV/0``, ``#NAME?``,
       ``#NUM``, ``#SYNTAX`` -- trappable with ``IFERROR``.
 
@@ -1018,6 +1018,20 @@ def _fn_padleft(args: list[Any]) -> Any:
     return s.rjust(width) if len(s) <= width else s[-width:]
 
 
+def _fn_zeropad(args: list[Any]) -> Any:
+    _expect_args("ZEROPAD", args, 2, 2)
+    err = _propagate(*args)
+    if err is not None:
+        return err
+    width = int(_to_number(args[1]))
+    if width <= 0:
+        return _to_string(args[0])
+    s = _to_string(args[0])
+    if s.startswith("-"):
+        return "-" + s[1:].rjust(width - 1, "0")
+    return s.rjust(width, "0")
+
+
 def _fn_center(args: list[Any]) -> Any:
     _expect_args("CENTER", args, 2, 2)
     err = _propagate(*args)
@@ -1147,6 +1161,7 @@ _BUILTINS: dict[str, Callable[[list[Any]], Any]] = {
     "ENDSWITH": _fn_endswith,
     "PAD": _fn_pad,
     "PADLEFT": _fn_padleft,
+    "ZEROPAD": _fn_zeropad,
     "CENTER": _fn_center,
     # Conversion / format
     "TEXT": _fn_text,
@@ -1211,6 +1226,7 @@ _SIGNATURES: dict[str, tuple[str, str, str]] = {
     "ENDSWITH": ("text", "ENDSWITH(s, suffix)", "True if s ends with suffix"),
     "PAD": ("text", "PAD(s, width)", "Right-pad to width"),
     "PADLEFT": ("text", "PADLEFT(s, width)", "Left-pad to width"),
+    "ZEROPAD": ("text", "ZEROPAD(s, width)", "Left-pad with zeros to width (e.g. 1 -> 01)"),
     "CENTER": ("text", "CENTER(s, width)", "Center within width"),
     # Conversion
     "TEXT": ("convert", "TEXT(x)", "Convert to string"),
@@ -1542,6 +1558,7 @@ _ARITY: dict[str, tuple[int, int | None]] = {
     "ENDSWITH": (2, 2),
     "PAD": (2, 2),
     "PADLEFT": (2, 2),
+    "ZEROPAD": (2, 2),
     "CENTER": (2, 2),
     "TEXT": (1, 1),
     "NUM": (1, 1),

--- a/tests/test_template_expressions.py
+++ b/tests/test_template_expressions.py
@@ -108,6 +108,12 @@ class TestStringOps:
     def test_padleft(self):
         assert evaluate('PADLEFT("7", 3)') == "  7"
 
+    def test_zeropad(self):
+        assert evaluate("ZEROPAD(1, 2)") == "01"
+        assert evaluate("ZEROPAD(12, 2)") == "12"
+        assert evaluate("ZEROPAD(123, 2)") == "123"
+        assert evaluate("ZEROPAD(-1, 3)") == "-01"
+
     def test_center(self):
         assert evaluate('CENTER("hi", 6)') == "  hi  "
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -100,6 +100,36 @@ class TestFilters:
         result = engine.render("{{weather.condition|truncate:6}}", context)
         assert result == "Partly"
 
+    def test_zeropad_filter_single_digit(self, engine):
+        """|zeropad:2 turns 1 into 01."""
+        context = {"date_time": {"month": 1}}
+        result = engine.render("{{date_time.month|zeropad:2}}", context)
+        assert result == "01"
+
+    def test_zeropad_filter_no_padding_needed(self, engine):
+        """|zeropad:2 leaves 12 unchanged."""
+        context = {"date_time": {"month": 12}}
+        result = engine.render("{{date_time.month|zeropad:2}}", context)
+        assert result == "12"
+
+    def test_zeropad_filter_value_longer_than_width(self, engine):
+        """|zeropad:N leaves longer values alone (no truncation)."""
+        context = {"x": {"v": 123}}
+        result = engine.render("{{x.v|zeropad:2}}", context)
+        assert result == "123"
+
+    def test_zeropad_filter_preserves_negative_sign(self, engine):
+        """Negative numbers keep the sign and zero-pad the digits."""
+        context = {"x": {"v": -1}}
+        result = engine.render("{{x.v|zeropad:3}}", context)
+        assert result == "-01"
+
+    def test_zeropad_filter_invalid_arg(self, engine):
+        """Non-integer width falls back to the raw value."""
+        context = {"x": {"v": 1}}
+        result = engine.render("{{x.v|zeropad:abc}}", context)
+        assert result == "1"
+
 
 class TestColors:
     """Tests for color code handling."""


### PR DESCRIPTION
## Summary
- Adds a `|zeropad:N` filter so template authors can zero-pad numeric values to a fixed width (e.g. `{{date_time.month|zeropad:2}}` renders `01` through `12`).
- Adds a matching `ZEROPAD(s, w)` formula function for use inside `{{= ... }}` expressions, alongside the existing `PAD` / `PADLEFT` / `CENTER`.
- Preserves a leading `-` sign on negative numbers (`ZEROPAD(-1, 3)` → `-01`); values already wider than `w` are returned unchanged (no truncation).
- Updates the engine docstring and `docs-site/docs/reference/template-formulas.md` to mention the new filter/function.

## Motivation
There was no built-in way to format single-digit months/days/hours as `01`, `02`, … without an `IF` expression. `|pad:N` right-pads with spaces, so it doesn't help here. This fills the gap with a small, focused addition that mirrors the shape of the existing filters/functions.

## Test plan
- [x] `pytest tests/test_templates.py tests/test_templates_extended.py tests/test_template_expressions.py` — 399 passed locally in the dev container.
- New tests cover: single digit, no padding needed, value longer than width, negative sign preserved, invalid width arg, and the formula form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)