### PR TITLE
fix(ui): remove wobble from boot and update spinners

### DIFF
--- a/web/src/components/boot-gate.tsx
+++ b/web/src/components/boot-gate.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { Loader2, WifiOff } from "lucide-react";
+import { WifiOff } from "lucide-react";
 import Image from "next/image";
 import { useEffect, useState } from "react";
 
@@ -100,7 +100,7 @@ export function BootGate({ children }: { children: React.ReactNode }) {
         ) : (
           /* ── Waiting state ── */
           <>
-            <Loader2 className="h-8 w-8 text-muted-foreground animate-spin" strokeWidth={1.5} />
+            <div className="h-8 w-8 rounded-full border-[2.5px] border-muted-foreground/25 border-t-muted-foreground animate-spin" />
             <p className="text-sm text-muted-foreground">Waiting to start…</p>
           </>
         )}

--- a/web/src/components/update-context.tsx
+++ b/web/src/components/update-context.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { RefreshCw } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { createContext, Fragment, useCallback, useContext, useEffect, useRef, useState } from "react";
 

--- a/web/src/components/update-context.tsx
+++ b/web/src/components/update-context.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { RefreshCw } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { createContext, Fragment, useCallback, useContext, useEffect, useRef, useState } from "react";
 
@@ -229,11 +228,7 @@ function UpdateOverlay({ currentVersion, onDone }: { currentVersion?: string; on
     <div className="fixed inset-0 z-[200] bg-black text-white flex items-center justify-center">
       <div className="text-center space-y-6 max-w-xs mx-auto px-4">
         {/* Spinner */}
-        {phase === "ready" ? (
-          <RefreshCw className="h-12 w-12 mx-auto animate-spin text-white" />
-        ) : (
-          <div className="h-12 w-12 mx-auto rounded-full border-[3px] border-white/20 border-t-white animate-spin" />
-        )}
+        <div className="h-12 w-12 mx-auto rounded-full border-[3px] border-white/20 border-t-white animate-spin" />
 
         {/* Title + current phase message */}
         <div className="space-y-2">


### PR DESCRIPTION
## Summary
- Replace lucide-react `Loader2` (boot splash) and `RefreshCw` (update "ready" phase) with the same symmetric CSS border-ring spinner already used by the update screen's other phases.
- The lucide icons' asymmetric paths and rounded stroke caps push their visual mass off the SVG rotation center, producing a faint wobble during `animate-spin`. The border-ring is a perfect circle, so it rotates cleanly.

## Test plan
- [ ] `/restart` the dev container, watch the boot splash — spinner is steady, no wobble.
- [ ] Trigger an update, watch all phases (`pulling`, `restarting`, `ready`) — spinner is steady throughout, no visual change between phases beyond text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)