### PR TITLE
docs: document the Home Assistant Supervisor add-on (beta)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ That's it — FiestaBoard starts on every boot and updates itself with one click
 
 > **Why we recommend this path:** The Pi is inexpensive, low-power, runs 24/7, and is purpose-built to be a reliable always-on display controller. Even users who have never touched a Raspberry Pi before can complete this in under 15 minutes.
 
+### Already running Home Assistant? Use the HA add-on (beta)
+
+If you have **Home Assistant OS** or **Home Assistant Supervised**, you can install FiestaBoard from the HA Add-on Store. You get sidebar Ingress, MQTT auto-discovery with the Mosquitto add-on, HA-managed backups of all your settings, and updates through HA's UI.
+
+[![Open your Home Assistant instance and show the app store with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_store.svg)](https://my.home-assistant.io/redirect/supervisor_store/?repository_url=https%3A%2F%2Fgithub.com%2FFiestaboard%2FFiestaBoard-Home-Assistant-App)
+
+**→ [Home Assistant Add-on setup guide](https://fiestaboard.app/docs/setup/home-assistant-addon)** — currently in beta; report issues at the [add-on repo](https://github.com/Fiestaboard/FiestaBoard-Home-Assistant-App/issues).
+
 ### Alternative: Run on a computer with Docker
 
 Already have a laptop, desktop, NAS, or home server? FiestaBoard runs anywhere Docker runs. **All you need:** Your board's API key + [Docker](https://docs.docker.com/get-started/get-docker/) installed.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ If you have **Home Assistant OS** or **Home Assistant Supervised**, you can inst
 
 [![Open your Home Assistant instance and show the app store with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_store.svg)](https://my.home-assistant.io/redirect/supervisor_store/?repository_url=https%3A%2F%2Fgithub.com%2FFiestaboard%2FFiestaBoard-Home-Assistant-App)
 
-**→ [Home Assistant Add-on setup guide](https://fiestaboard.app/docs/setup/home-assistant-addon)** — currently in beta; report issues at the [add-on repo](https://github.com/Fiestaboard/FiestaBoard-Home-Assistant-App/issues).
+**→ [Home Assistant Add-on setup guide](https://fiestaboard.app/docs/setup/home-assistant-addon)**
+
+> 🧪 **The HA add-on is in beta and we want your feedback.** Report bugs or feature requests at the [add-on repo issues](https://github.com/Fiestaboard/FiestaBoard-Home-Assistant-App/issues), or come say hi on [Discord](https://discord.gg/JvN8y6ahaf) — even "it just worked" reports help us stabilize the beta.
 
 ### Alternative: Run on a computer with Docker
 

--- a/docs-site/docs/intro.md
+++ b/docs-site/docs/intro.md
@@ -57,10 +57,10 @@ If you don't have a Pi yet, any model from the Raspberry Pi 3B onwards works. Th
 
 ## Other Ways to Run FiestaBoard
 
-Don't have a Pi, or already have a home server? FiestaBoard runs anywhere Docker runs — and if you already use **Home Assistant OS** or **Supervised**, you can install it from the HA Add-on Store ([beta](/docs/setup/home-assistant-addon)).
+Don't have a Pi, or already have a home server? FiestaBoard runs anywhere Docker runs — and if you already use Home Assistant OS or Supervised, you can install it from the HA Add-on Store.
 
 <div className="row">
-<div className="col col--6">
+<div className="col col--4">
 
 ### I'm new to all this
 
@@ -69,13 +69,22 @@ Never used Docker or the command line? No problem.
 **[Beginner's Guide](/docs/setup/beginners-guide)** walks you through every step with clear instructions — including the easy Pi-flash path and a Docker fallback.
 
 </div>
-<div className="col col--6">
+<div className="col col--4">
 
 ### I'm comfortable with Docker
 
 Know your way around `docker-compose`? Run FiestaBoard on a laptop, NAS, or home server.
 
 **[Docker Quick Start](/docs/setup/quick-start)** gets you running in under 5 minutes.
+
+</div>
+<div className="col col--4">
+
+### I run Home Assistant 🏠
+
+On Home Assistant OS or Supervised? Install FiestaBoard from the **HA Add-on Store** with one click — Ingress, MQTT auto-discovery, and HA backups all wired up.
+
+**[Home Assistant Add-on](/docs/setup/home-assistant-addon)** — currently in beta, feedback welcome via [GitHub issues](https://github.com/Fiestaboard/FiestaBoard-Home-Assistant-App/issues) or [Discord](https://discord.gg/JvN8y6ahaf).
 
 </div>
 </div>

--- a/docs-site/docs/intro.md
+++ b/docs-site/docs/intro.md
@@ -57,7 +57,7 @@ If you don't have a Pi yet, any model from the Raspberry Pi 3B onwards works. Th
 
 ## Other Ways to Run FiestaBoard
 
-Don't have a Pi, or already have a home server? FiestaBoard runs anywhere Docker runs.
+Don't have a Pi, or already have a home server? FiestaBoard runs anywhere Docker runs — and if you already use **Home Assistant OS** or **Supervised**, you can install it from the HA Add-on Store ([beta](/docs/setup/home-assistant-addon)).
 
 <div className="row">
 <div className="col col--6">
@@ -92,6 +92,7 @@ If you've already got FiestaBoard installed and running, check out **[Your First
 |---------|---------------|
 | **[FiestaPi Quick Start](/docs/setup/raspberry-pi)** | Flash a Pi image and be running in minutes |
 | **[Quick Start](/docs/setup/quick-start)** | Installation and first run (Docker) |
+| **[Home Assistant Add-on](/docs/setup/home-assistant-addon)** | Install from the HA Add-on Store (beta) — Ingress, MQTT auto-discovery, HA backups |
 | **[Beginner's Guide](/docs/setup/beginners-guide)** | Step-by-step for non-technical users |
 | **[Your First 10 Minutes](/docs/setup/first-10-minutes)** | What to do right after setup |
 | **[Plugins Overview](/docs/plugins/overview)** | All 26 plugins and what they do |

--- a/docs-site/docs/setup/home-assistant-addon.md
+++ b/docs-site/docs/setup/home-assistant-addon.md
@@ -6,8 +6,13 @@ keywords: [FiestaBoard Home Assistant add-on, HAOS, Home Assistant Supervisor, V
 
 # Home Assistant Add-on (Beta)
 
-:::warning Beta
-The Home Assistant add-on is in **beta**. End-to-end install works (Ingress, MQTT auto-discovery, HA core API, backups, updates through the add-on store), but the wrapper is still maturing — please [file issues](https://github.com/Fiestaboard/FiestaBoard-Home-Assistant-App/issues) if anything misbehaves.
+:::warning Beta — feedback wanted
+The Home Assistant add-on is in **beta**. End-to-end install works (Ingress, MQTT auto-discovery, HA core API, backups, updates through the add-on store), but the wrapper is still maturing and we'd love to hear from you:
+
+- 🐛 **Found a bug or have a suggestion?** [Open an issue](https://github.com/Fiestaboard/FiestaBoard-Home-Assistant-App/issues) on the add-on repo.
+- 💬 **Want to chat or get help?** [Join us on Discord](https://discord.gg/JvN8y6ahaf) — there's a community of FiestaBoard users (including Home Assistant power users) happy to help.
+
+Even "it just worked" reports are useful while we're stabilizing the beta — let us know what HA install type you're on (OS / Supervised) and which features you tried.
 :::
 
 If you already run **Home Assistant OS** or **Home Assistant Supervised**, you can install FiestaBoard from the HA Add-on Store. The add-on wraps the standard `fiestaboard/fiestaboard` image and adds the integration glue HA expects:
@@ -66,12 +71,18 @@ A couple of things work differently under the add-on compared to a standalone Do
 - **The in-app "Update Now" button is hidden.** Updates flow through HA's add-on store, not FiestaBoard's own [in-app updater](/docs/features/updating). The companion [fiestaupdater](/docs/deployment/fiestaupdater) sidecar would race HA Supervisor's update flow and isn't safe under HA, so the shim disables it.
 - **MQTT is auto-wired.** Install the Mosquitto broker add-on first; FiestaBoard picks up the broker host and credentials through the HA services API with no manual config.
 
-## Reporting issues
+## Help us shape the beta
 
-The add-on lives in its own repository:
+This integration is new and we want your feedback — what works, what doesn't, what's confusing, what's missing. Two ways to reach us:
 
-- **Source and issues**: <https://github.com/Fiestaboard/FiestaBoard-Home-Assistant-App>
-- **Add-on documentation**: <https://github.com/Fiestaboard/FiestaBoard-Home-Assistant-App/blob/main/fiestaboard/DOCS.md>
-- **FiestaBoard core (not specific to HA)**: <https://github.com/Fiestaboard/FiestaBoard/issues>
+- 🐛 **[Open an issue on the add-on repo](https://github.com/Fiestaboard/FiestaBoard-Home-Assistant-App/issues)** for bugs, feature requests, or anything reproducible. Please include your HA installation type (OS / Supervised), the add-on version, and the relevant snippet from the add-on **Log** tab.
+- 💬 **[Join our Discord](https://discord.gg/JvN8y6ahaf)** to chat, ask questions, share what you've built, or just say hi. There's a community of FiestaBoard users (including Home Assistant folks) happy to help.
 
-When filing an HA-add-on issue, please include your HA installation type (OS / Supervised), the add-on version, and the relevant snippet from the add-on **Log** tab.
+### Where things live
+
+| Concern | Repo / link |
+| --- | --- |
+| Add-on bugs, feature requests, install issues | [`FiestaBoard-Home-Assistant-App` issues](https://github.com/Fiestaboard/FiestaBoard-Home-Assistant-App/issues) |
+| Add-on source and config docs | [`FiestaBoard-Home-Assistant-App`](https://github.com/Fiestaboard/FiestaBoard-Home-Assistant-App) ([DOCS.md](https://github.com/Fiestaboard/FiestaBoard-Home-Assistant-App/blob/main/fiestaboard/DOCS.md)) |
+| FiestaBoard core (everything not HA-specific) | [`FiestaBoard` issues](https://github.com/Fiestaboard/FiestaBoard/issues) |
+| Chat, help, show-and-tell | [Discord](https://discord.gg/JvN8y6ahaf) |

--- a/docs-site/docs/setup/home-assistant-addon.md
+++ b/docs-site/docs/setup/home-assistant-addon.md
@@ -1,0 +1,77 @@
+---
+sidebar_position: 4
+description: "Install FiestaBoard as a Home Assistant Supervisor add-on. Sidebar Ingress, auto MQTT discovery, HA-managed backups — all from the HA Add-on Store. Currently in beta."
+keywords: [FiestaBoard Home Assistant add-on, HAOS, Home Assistant Supervisor, Vestaboard Home Assistant, FiestaBoard HA app, supervised add-on, ingress]
+---
+
+# Home Assistant Add-on (Beta)
+
+:::warning Beta
+The Home Assistant add-on is in **beta**. End-to-end install works (Ingress, MQTT auto-discovery, HA core API, backups, updates through the add-on store), but the wrapper is still maturing — please [file issues](https://github.com/Fiestaboard/FiestaBoard-Home-Assistant-App/issues) if anything misbehaves.
+:::
+
+If you already run **Home Assistant OS** or **Home Assistant Supervised**, you can install FiestaBoard from the HA Add-on Store. The add-on wraps the standard `fiestaboard/fiestaboard` image and adds the integration glue HA expects:
+
+- **Sidebar entry via Ingress** — one-click web access from the HA sidebar, authenticated by HA itself.
+- **Auto MQTT discovery** — works zero-config with the official **Mosquitto broker** add-on.
+- **HA core API** — FiestaBoard's [Home Assistant plugin](/docs/plugins/home-assistant) talks to HA via the Supervisor proxy with no long-lived access token to create.
+- **HA-managed backups** — FiestaBoard's `/app/data` (settings, plugin state, marketplace plugins) is mounted from HA's persistent `addon_config` volume, so HA snapshots capture everything.
+- **Updates through the add-on store** — a weekly workflow in the add-on repo polls this repo for new releases and opens a sync PR. Once merged and tagged, HA Supervisor offers the update like any other add-on.
+
+This is a different install path than [FiestaPi](/docs/setup/raspberry-pi) (a standalone Pi image) or [Docker Compose](/docs/setup/quick-start). Use the add-on if:
+
+- You already have a Home Assistant OS / Supervised install.
+- You want FiestaBoard updates to come through HA's UI alongside the rest of your add-ons.
+- You want FiestaBoard's HA plugin and MQTT setup to be zero-config.
+
+## What you'll need
+
+- A working **Home Assistant OS** or **Home Assistant Supervised** install (the Add-on Store isn't available on Container or Core).
+- Your **Vestaboard** and its API key ([how to find it](/docs/setup/api-keys)).
+- A **Mosquitto broker** add-on installed (optional, but required for MQTT auto-discovery).
+
+## Install
+
+1. In Home Assistant, navigate to **Settings → Add-ons → Add-on Store**.
+2. Click the **⋮** menu (top-right) → **Repositories**.
+3. Add the repository URL:
+
+   ```text
+   https://github.com/Fiestaboard/FiestaBoard-Home-Assistant-App
+   ```
+
+4. The **FiestaBoard** add-on appears in the store. Click **Install**.
+
+Or use the one-click badge in the add-on repo's [README](https://github.com/Fiestaboard/FiestaBoard-Home-Assistant-App):
+
+[![Open your Home Assistant instance and show the app store with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_store.svg)](https://my.home-assistant.io/redirect/supervisor_store/?repository_url=https%3A%2F%2Fgithub.com%2FFiestaboard%2FFiestaBoard-Home-Assistant-App)
+
+## Configure and start
+
+Open the add-on's **Configuration** tab and set, at minimum:
+
+- `board_api_mode`: `local` (recommended) or `cloud`.
+- For local mode: `board_host` (your board's IP) and `board_local_api_key`.
+- For cloud mode: `board_read_write_key`.
+- `weather_api_key` and `weather_location` if you'll use the weather plugin.
+- `timezone` (e.g. `America/Los_Angeles`).
+
+Click **Start**, then **Open Web UI** when the add-on goes green. The remaining FiestaBoard plugins (transit, sports, surf, AI art, etc.) are configured from inside FiestaBoard's own web UI — the Configuration tab intentionally only surfaces the bootstrap-critical fields.
+
+## How HA-specific behavior is handled
+
+A couple of things work differently under the add-on compared to a standalone Docker install. The full reference lives in the add-on repo's [DOCS.md](https://github.com/Fiestaboard/FiestaBoard-Home-Assistant-App/blob/main/fiestaboard/DOCS.md); the highlights:
+
+- **Auth defaults to off.** [FiestaBoard 6.0+ auth](/docs/setup/authentication) is gated behind HA Ingress, which already authenticates web access. Set the `fiestaboard_auth_enabled` option to `true` if you publish the LAN port (`4420`) to the internet or share it with people without HA logins.
+- **The in-app "Update Now" button is hidden.** Updates flow through HA's add-on store, not FiestaBoard's own [in-app updater](/docs/features/updating). The companion [fiestaupdater](/docs/deployment/fiestaupdater) sidecar would race HA Supervisor's update flow and isn't safe under HA, so the shim disables it.
+- **MQTT is auto-wired.** Install the Mosquitto broker add-on first; FiestaBoard picks up the broker host and credentials through the HA services API with no manual config.
+
+## Reporting issues
+
+The add-on lives in its own repository:
+
+- **Source and issues**: <https://github.com/Fiestaboard/FiestaBoard-Home-Assistant-App>
+- **Add-on documentation**: <https://github.com/Fiestaboard/FiestaBoard-Home-Assistant-App/blob/main/fiestaboard/DOCS.md>
+- **FiestaBoard core (not specific to HA)**: <https://github.com/Fiestaboard/FiestaBoard/issues>
+
+When filing an HA-add-on issue, please include your HA installation type (OS / Supervised), the add-on version, and the relevant snippet from the add-on **Log** tab.


### PR DESCRIPTION
## Summary

Adds a setup guide for the [FiestaBoard Home Assistant add-on](https://github.com/Fiestaboard/FiestaBoard-Home-Assistant-App), linked from `intro.md` and `README.md`. Calls out beta status and the HA-specific defaults the wrapper configures (auth off because Ingress already authenticates, in-app updater hidden so HA Supervisor owns updates, MQTT auto-wired through the HA services API).

### Files

- `docs-site/docs/setup/home-assistant-addon.md` — new beta install guide
- `docs-site/docs/intro.md` — adds an entry to the "All Documentation" table and mentions the path under "Other Ways to Run FiestaBoard"
- `README.md` — adds a third "Get Started" path between FiestaPi and Docker for users who already run HAOS/Supervised

### Why

Right now there's no path from `fiestaboard.app` to the HA add-on — HA users searching for a Home Assistant integration find only the [MQTT integration page](https://fiestaboard.app/docs/setup/home-assistant-mqtt) (which is a different thing — it gates the *device-in-HA* surface, not a self-hosting path). This closes that gap and labels the add-on as beta so users have the right expectation.

## Test plan

- [ ] Render `docs-site` locally and visit `/docs/setup/home-assistant-addon` to confirm formatting renders.
- [ ] Confirm sidebar position 4 lands where intended (alongside `api-keys` and `docker-setup`).
- [ ] Verify all outbound links work (add-on repo, DOCS.md, my.home-assistant.io badge).