### PR TITLE
fix(plugins): default to 300s cache when manifest declares no refresh_seconds

### DIFF
--- a/src/plugins/base.py
+++ b/src/plugins/base.py
@@ -226,17 +226,40 @@ class PluginBase(ABC):
         return refresh_schema.get("minimum", MIN_REFRESH_SECONDS)
 
     @property
+    def live_data(self) -> bool:
+        """Whether this plugin opts out of caching and serves fresh data every tick.
+
+        Plugins that genuinely need fresh data on every render (clocks,
+        animations, anything driven by ``now()``) set ``live_data: true``
+        at the top level of ``manifest.json``.  When true, :meth:`get_data`
+        skips the cache entirely and calls :meth:`fetch_data` on every call.
+
+        Defaults to ``False`` -- the safer behavior -- so plugins that
+        don't declare a refresh interval get a sensible default cache
+        instead of hammering their data source on every poll tick.
+        """
+        return bool(self._manifest.get("live_data", False))
+
+    @property
     def refresh_seconds(self) -> int | None:
         """Get the effective refresh interval in seconds.
 
-        Returns the configured value, falling back to the manifest default.
-        The value is clamped to never go below ``min_refresh_seconds`` --
-        even if the stored config contains a lower number.
-        Returns None if the plugin's manifest does not define refresh_seconds.
+        Resolution order:
+
+        1. If the plugin's manifest declares ``live_data: true``, return
+           ``None`` to signal "no cache" to :meth:`get_data`.
+        2. If the manifest declares ``refresh_seconds`` in its
+           ``settings_schema``, return the configured/default value
+           (clamped to ``min_refresh_seconds``).
+        3. Otherwise fall back to :data:`DEFAULT_REFRESH_SECONDS` so a
+           plugin that forgot to declare a refresh interval still gets a
+           reasonable cache instead of fetching fresh data on every tick.
         """
+        if self.live_data:
+            return None
         refresh_schema = self._get_refresh_schema()
         if refresh_schema is None:
-            return None
+            return DEFAULT_REFRESH_SECONDS
         default = refresh_schema.get("default", DEFAULT_REFRESH_SECONDS)
         value = self._config.get("refresh_seconds", default)
         floor = self.min_refresh_seconds
@@ -248,13 +271,24 @@ class PluginBase(ABC):
     def get_data(self) -> PluginResult:
         """Get plugin data with automatic caching based on refresh_seconds.
 
-        If the plugin's manifest defines refresh_seconds in settings_schema,
-        results are cached and reused until the refresh interval expires.
-        Plugins without refresh_seconds in their manifest always fetch fresh.
+        Behavior is controlled by the manifest:
+
+        * ``live_data: true`` -- bypass the cache entirely (every call
+          invokes :meth:`fetch_data`).  Use this for clocks/animations
+          where stale data is wrong by definition.
+        * ``settings_schema.properties.refresh_seconds`` declared -- cache
+          results for the configured interval.
+        * Neither declared -- cache results for
+          :data:`DEFAULT_REFRESH_SECONDS` (5 minutes).  This is the safer
+          default for random/static-ish data sources.
 
         Returns:
             PluginResult with data or error
         """
+        if self.live_data:
+            logger.debug(f"Live data plugin {self.plugin_id}: skipping cache")
+            return self.fetch_data()
+
         interval = self.refresh_seconds
 
         if interval is None:

--- a/tests/test_plugin_base_refresh.py
+++ b/tests/test_plugin_base_refresh.py
@@ -61,6 +61,26 @@ MANIFEST_BARE = {
     "version": "1.0.0",
 }
 
+MANIFEST_LIVE_DATA = {
+    "id": "test_plugin",
+    "name": "Test Plugin",
+    "version": "1.0.0",
+    "live_data": True,
+}
+
+MANIFEST_LIVE_DATA_WITH_SCHEMA = {
+    "id": "test_plugin",
+    "name": "Test Plugin",
+    "version": "1.0.0",
+    "live_data": True,
+    "settings_schema": {
+        "type": "object",
+        "properties": {
+            "refresh_seconds": {"type": "integer", "default": 120, "minimum": 30},
+        },
+    },
+}
+
 
 class ConcretePlugin(PluginBase):
     """Concrete plugin for testing base class behavior."""
@@ -90,6 +110,28 @@ class FailingPlugin(PluginBase):
 
     def fetch_data(self) -> PluginResult:
         return PluginResult(available=False, error="always fails")
+
+
+# --- live_data property ---
+
+
+class TestLiveDataProperty:
+    def test_defaults_to_false(self):
+        plugin = ConcretePlugin(MANIFEST_BARE)
+        assert plugin.live_data is False
+
+    def test_false_when_not_declared(self):
+        plugin = ConcretePlugin(MANIFEST_WITH_REFRESH)
+        assert plugin.live_data is False
+
+    def test_true_when_manifest_opts_in(self):
+        plugin = ConcretePlugin(MANIFEST_LIVE_DATA)
+        assert plugin.live_data is True
+
+    def test_explicit_false(self):
+        manifest = {**MANIFEST_BARE, "live_data": False}
+        plugin = ConcretePlugin(manifest)
+        assert plugin.live_data is False
 
 
 # --- _get_refresh_schema ---
@@ -126,12 +168,28 @@ class TestRefreshSecondsProperty:
         plugin._config = {"refresh_seconds": 60}
         assert plugin.refresh_seconds == 60
 
-    def test_returns_none_without_schema(self):
+    def test_defaults_to_300s_without_schema(self):
+        """Plugins without a refresh_seconds schema get a safe 5-minute cache by default.
+
+        Before this fix the property returned ``None`` (meaning "no cache"),
+        which caused random-data plugins like Star Trek Quotes to re-fetch
+        on every poll tick and flip the board every ~14 seconds.
+        """
         plugin = ConcretePlugin(MANIFEST_WITHOUT_REFRESH)
+        assert plugin.refresh_seconds == DEFAULT_REFRESH_SECONDS
+
+    def test_defaults_to_300s_for_bare_manifest(self):
+        plugin = ConcretePlugin(MANIFEST_BARE)
+        assert plugin.refresh_seconds == DEFAULT_REFRESH_SECONDS
+
+    def test_returns_none_when_live_data_true(self):
+        """``live_data: true`` opts out of caching and signals "always fresh"."""
+        plugin = ConcretePlugin(MANIFEST_LIVE_DATA)
         assert plugin.refresh_seconds is None
 
-    def test_returns_none_for_bare_manifest(self):
-        plugin = ConcretePlugin(MANIFEST_BARE)
+    def test_live_data_overrides_explicit_schema(self):
+        """``live_data: true`` wins even when refresh_seconds is declared in the schema."""
+        plugin = ConcretePlugin(MANIFEST_LIVE_DATA_WITH_SCHEMA)
         assert plugin.refresh_seconds is None
 
     def test_falls_back_to_global_default_when_schema_missing_default(self):
@@ -174,19 +232,52 @@ class TestGetDataCaching:
         plugin.get_data()
         assert plugin.fetch_call_count == 2
 
-    def test_no_caching_without_schema(self):
+    def test_caches_with_default_300s_when_no_schema(self):
+        """Plugins without a refresh_seconds schema should still cache.
+
+        Regression test for the board-flipping bug: previously a plugin
+        with no ``refresh_seconds`` in its manifest fell through to
+        ``fetch_data()`` on every call, causing random-data plugins to
+        pick a fresh value every poll tick.
+        """
         plugin = ConcretePlugin(MANIFEST_WITHOUT_REFRESH)
 
         plugin.get_data()
         plugin.get_data()
-        assert plugin.fetch_call_count == 2
+        assert plugin.fetch_call_count == 1
 
-    def test_no_caching_for_bare_manifest(self):
+    def test_caches_with_default_300s_for_bare_manifest(self):
         plugin = ConcretePlugin(MANIFEST_BARE)
 
         plugin.get_data()
         plugin.get_data()
+        assert plugin.fetch_call_count == 1
+
+    def test_default_cache_expires_after_300s(self):
+        plugin = ConcretePlugin(MANIFEST_BARE)
+
+        plugin.get_data()
+        assert plugin.fetch_call_count == 1
+
+        plugin._last_fetch_time = datetime.now() - timedelta(seconds=DEFAULT_REFRESH_SECONDS + 1)
+        plugin.get_data()
         assert plugin.fetch_call_count == 2
+
+    def test_live_data_skips_cache_entirely(self):
+        """``live_data: true`` calls ``fetch_data()`` every time."""
+        plugin = ConcretePlugin(MANIFEST_LIVE_DATA)
+
+        plugin.get_data()
+        plugin.get_data()
+        plugin.get_data()
+        assert plugin.fetch_call_count == 3
+
+    def test_live_data_does_not_populate_cache(self):
+        plugin = ConcretePlugin(MANIFEST_LIVE_DATA)
+
+        plugin.get_data()
+        assert plugin._cached_result is None
+        assert plugin._last_fetch_time is None
 
     def test_does_not_cache_failed_result(self):
         plugin = FailingPlugin(MANIFEST_WITH_REFRESH)
@@ -463,6 +554,11 @@ class TestRuntimeClamping:
         assert plugin.fetch_call_count == 1
 
     def test_no_clamping_without_floor(self):
+        """When the manifest declares no refresh_seconds schema there's no floor
+        to clamp against, but the property now returns the safe 300s default
+        rather than None (and ignores stray config values for refresh_seconds
+        since the schema doesn't acknowledge the field).
+        """
         plugin = ConcretePlugin(MANIFEST_WITHOUT_REFRESH)
         plugin._config = {"refresh_seconds": 1}
-        assert plugin.refresh_seconds is None
+        assert plugin.refresh_seconds == DEFAULT_REFRESH_SECONDS


### PR DESCRIPTION
## Summary

`PluginBase.get_data()` previously fell through to `fetch_data()` on every call when a plugin's `manifest.json` did not declare `refresh_seconds` in `settings_schema.properties`. On a live Pi running 6.11.5 / current `main`, with the default `polling.interval_seconds = 14`, this caused random-data plugins (Star Trek Quotes, etc.) to pick a fresh random value every poll tick and the Vestaboard to physically flip every ~14 seconds.

This PR flips the default so the safer behavior wins:

- **300s default cache** when `manifest.json` declares no `refresh_seconds` — `PluginBase.refresh_seconds` now returns `DEFAULT_REFRESH_SECONDS` instead of `None`, so `get_data()` caches the result for 5 minutes.
- **Opt-out for live data**: a new top-level `"live_data": true` manifest field tells the platform to skip the cache entirely (use this for clocks, animations, anything driven by `now()`).
- **Unchanged behavior** for plugins that already declare `refresh_seconds` in `settings_schema` — that's 47 of 53 in-tree plugins, so the blast radius of this change is limited to the handful of plugins that were already misbehaving.

## What changed

- `src/plugins/base.py`
  - New `live_data` property that reads the top-level manifest bool.
  - `refresh_seconds` now resolves to `DEFAULT_REFRESH_SECONDS` (300) when no schema is declared, or `None` when `live_data: true`.
  - `get_data()` short-circuits to `fetch_data()` when `live_data` is true, and logs the resolved behavior at debug level.
- `tests/test_plugin_base_refresh.py`
  - Updated the two "no schema -> no cache" tests to assert the new caching behavior.
  - Added a `TestLiveDataProperty` class.
  - Added regression tests for: (a) manifest with no `refresh_seconds` -> 300s cache used, (b) manifest with `live_data: true` -> no cache, (c) explicit `refresh_seconds` -> unchanged.
  - Added an explicit cache-expiry test at the 300s boundary.

## Migration notes for plugin authors

If your plugin needs always-fresh data on every render (clock, ticker, animation), add this to your `manifest.json`:

```json
{
  "live_data": true
}
```

Otherwise, do nothing — your plugin will now be cached for 5 minutes by default, which is almost certainly what you wanted.

## Test plan

- [x] `tests/test_plugin_base_refresh.py` — 53 tests pass (includes new coverage for the three branches).
- [x] Wider plugin suite — `tests/test_plugin_*` + `tests/test_config*` + `tests/test_security.py` — 547 tests pass.
- [ ] Manual: deploy to the Pi, verify Star Trek Quotes no longer flips the board every 14s.
- [ ] Manual: verify a `live_data: true` plugin (if any are added) still refreshes on every poll tick.

## Caveats

This is a behavior-change PR that touches the plugin contract. Leaving the merge decision to a human.