### PR TITLE
ci: allow caniuse-lite in dependency review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,12 @@ jobs:
           allow-licenses: >-
             MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, 0BSD,
             CC0-1.0, Unlicense, Python-2.0, MPL-2.0, Zlib, BlueOak-1.0.0
+          # Per-package exceptions for deps whose license isn't on the
+          # general allow-list but which we've reviewed and accepted.
+          # caniuse-lite ships browser-compat *data* under CC-BY-4.0 (the
+          # code is MIT); it's a transitive dep of browserslist, pulled in
+          # by tooling across the web build.
+          allow-dependencies-licenses: 'pkg:npm/caniuse-lite'
           comment-summary-in-pr: on-failure
 
   test-platform:


### PR DESCRIPTION
## Summary
- The Dependency Review job has been failing fork PRs (e.g. [#900](https://github.com/Fiestaboard/FiestaBoard/pull/900)) because `caniuse-lite` ships its browser-compat data under **CC-BY-4.0**, which isn't on the workflow's license allow-list.
- `caniuse-lite` is a transitive dep of `browserslist`, pulled in by tooling across the web build — contributors can't easily avoid it, so the failure isn't actionable for them.
- This adds a **per-package exception** via `allow-dependencies-licenses` rather than broadly accepting CC-BY-4.0, keeping the existing "do not silently allow all licenses" stance documented in `ci.yml`.

## Context
The failing run on PR #900: https://github.com/Fiestaboard/FiestaBoard/actions/runs/27077523744/job/79922864185

Relevant log line:
```
web/package-lock.json » caniuse-lite@1.0.30001797 – License: CC-BY-4.0
##[error]Dependency review detected incompatible licenses.
```

Note: there's also a `pull-requests: write` warning in the same job log. That's unrelated — GitHub strips write tokens from fork-PR `pull_request` events as a security policy, and it only affects the inline PR comment summary, not the pass/fail status. Not addressed here.

## Test plan
- [ ] Dependency Review job passes on this PR
- [ ] Re-run CI on #900 (or rebase it) and confirm Dependency Review passes for the fork contributor

🤖 Generated with [Claude Code](https://claude.com/claude-code)