### PR TITLE
fix: apply ruff format to plugins/date_time/__init__.py

### DIFF
--- a/plugins/date_time/__init__.py
+++ b/plugins/date_time/__init__.py
@@ -160,9 +160,7 @@ class DateTimePlugin(PluginBase):
                 # New month formats
                 "month_number": str(now.month),  # 1-12 (unpadded)
                 "month_number_padded": now.strftime("%m"),  # 01-12 (zero-padded)
-                "month_abbr": now.strftime(
-                    "%b"
-                ),  # 3-letter abbreviation (Jan, Feb, etc.)
+                "month_abbr": now.strftime("%b"),  # 3-letter abbreviation (Jan, Feb, etc.)
                 # Additional timezone info
                 "timezone": timezone_str,  # Full timezone name from config
                 # Spoken English time expression


### PR DESCRIPTION
## Summary
- Main has been failing the Platform Tests `ruff format --check` step since #900 merged.
- This is a one-line formatter fix — collapses a three-line `now.strftime("%b")` call into a single line per `ruff format`.
- Unblocks every open PR (CI is currently red on main).

## Test plan
- [x] `ruff format --check src/ plugins/ tests/ scripts/` passes locally
- [ ] Platform Tests passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)