### PR TITLE
fix(docs-site): prevent spotlight image from collapsing ranking column

### DIFF
--- a/docs-site/src/pages/stats.module.css
+++ b/docs-site/src/pages/stats.module.css
@@ -27,7 +27,7 @@
 
 .dashboard {
   display: grid;
-  grid-template-columns: auto 1fr;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
   gap: 2.5rem;
   align-items: start;
   margin-bottom: 3rem;


### PR DESCRIPTION
## Summary

The stats page dashboard uses a two-column grid. With `auto 1fr`, the left column (the top plugin's board image) claimed its full natural width, leaving almost no space for the Popularity ranking section on the right — it was squished to a sliver and the heading was showing rotated vertically.

Changed `auto 1fr` → `minmax(0, 1fr) minmax(0, 1fr)` so both columns share available space equally. The spotlight image already carries `max-width: 100%` so it scales down cleanly. The existing 768px breakpoint that collapses to a single column is unchanged.

## Test plan

- [ ] Visit `/stats` on a wide viewport — spotlight and ranking should sit side by side with equal width
- [ ] Resize below 768px — layout should collapse to a single column (unchanged behaviour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)