### PR TITLE
fix(nginx): rewrite CSS bodies and unquoted url() under X-Ingress-Path

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -209,10 +209,19 @@ configure_ingress_path_rewrite() {
     cat > "$SNIPPET" <<'NGINX'
 proxy_set_header Accept-Encoding "";
 sub_filter_once off;
+# Also rewrite CSS bodies, not just HTML. Next.js emits @font-face
+# declarations like `src: url(/_next/static/media/...woff2)` inside its
+# generated stylesheets; those URLs are unquoted and live in a text/css
+# response, so the default HTML-only sub_filter never sees them, fonts
+# 404 against the host's origin root, and the rendered UI loses its
+# typography (typically appearing as a near-blank dark layout).
+sub_filter_types text/css;
 sub_filter '"/_next/'  '"$http_x_ingress_path/_next/';
 sub_filter "'/_next/"  "'$http_x_ingress_path/_next/";
 sub_filter '"/api/'    '"$http_x_ingress_path/api/';
 sub_filter "'/api/"    "'$http_x_ingress_path/api/";
+# CSS `url(/_next/...)` -- unquoted is the form Next.js actually emits.
+sub_filter '(/_next/'  '($http_x_ingress_path/_next/';
 NGINX
 }
 

--- a/nginx-dev.conf
+++ b/nginx-dev.conf
@@ -125,6 +125,10 @@ http {
             proxy_http_version 1.1;
             add_header Cache-Control "no-cache, no-store, must-revalidate";
             expires off;
+
+            # See nginx.conf; CSS at /_next/static/css/* needs the same
+            # Ingress prefix rewriting as HTML.
+            include /etc/nginx/fiestaboard/location-root/*.conf;
         }
 
         # Dev: no caching on images

--- a/nginx.conf
+++ b/nginx.conf
@@ -130,6 +130,14 @@ http {
             proxy_cache_valid 200 60m;
             expires 1y;
             add_header Cache-Control "public, immutable";
+
+            # CSS at /_next/static/css/* references fonts/images via
+            # `url(/_next/static/media/...)` which need the same Ingress
+            # prefix rewriting as HTML. The snippet is the same one
+            # included in `location /`; nginx applies each directive in
+            # whichever scope it's valid (sub_filter on text/css, Accept-
+            # Encoding override on the proxy_pass).
+            include /etc/nginx/fiestaboard/location-root/*.conf;
         }
 
         # Cache images

--- a/nginx.https.conf
+++ b/nginx.https.conf
@@ -145,6 +145,10 @@ http {
             proxy_cache_valid 200 60m;
             expires 1y;
             add_header Cache-Control "public, immutable";
+
+            # See nginx.conf; CSS at /_next/static/css/* needs the same
+            # Ingress prefix rewriting as HTML.
+            include /etc/nginx/fiestaboard/location-root/*.conf;
         }
 
         # Cache images


### PR DESCRIPTION
## Summary
Follow-up to #913. The first cut rewrote HTML responses (which fixed JS-chunk 404s behind HA Ingress) but missed CSS bodies. Next.js emits `@font-face { src: url(/_next/static/media/…woff2) }` inside its stylesheets — an **unquoted** URL inside a **`text/css`** response — so neither the default HTML-only `sub_filter` scope nor the existing `"/_next/` / `'/_next/` patterns caught those references.

For HA Ingress users that meant: HTML loaded ✅, JS chunks loaded ✅, but stylesheets pulled the wrong-origin font URLs that 404'd. The visible result is a near-blank dark UI with two woff2 errors in the console — what an HA user reported as "still a black screen."

## What changed
- `sub_filter_types text/css;` so CSS responses get processed.
- `sub_filter '(/_next/' '($http_x_ingress_path/_next/'` for the unquoted `url(/_next/…)` form.
- Include the snippet in **`location /_next/static`** too (nginx.conf, nginx.https.conf, nginx-dev.conf). Stylesheets at `/_next/static/css/*` are served by that location, and the original PR only attached the snippet to `location /`, so CSS bodies skipped the rewrite entirely.

## Compatibility
`FIESTABOARD_INGRESS_PATH_REWRITE` unset → snippet directory stays empty → both `include` directives silently no-op → byte-for-byte identical behavior for standalone Docker / public preview.

## Test plan
- [x] `nginx -t` clean for all three configs with the snippet present.
- [x] End-to-end test in `nginx:alpine` with a sample Next.js-shaped CSS file:
  - HTML link href: rewritten under header, unchanged without.
  - CSS `url(/_next/…)` (unquoted, the font case): rewritten under header, unchanged without.
  - CSS `url("/_next/…")` and `url('/_next/…')`: rewritten under header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)