### PR TITLE
fix(ingress): patch Next.js's runtime URL construction so dynamic preloads honor X-Ingress-Path

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -156,21 +156,27 @@ configure_frame_headers() {
 #      payloads; nginx's outer `gzip on` still compresses the rewritten
 #      response before it leaves the box).
 #   2. Adds sub_filter rules that prepend `$http_x_ingress_path` to
-#      absolute `/_next/` and `/api/` references in HTML responses,
-#      covering both `"` and `'` quote styles.
+#      absolute `/_next/` and `/api/` references in HTML and CSS
+#      responses, covering both `"`, `'`, and the unquoted `url()`
+#      form Next.js emits in stylesheets.
+#   3. Injects a runtime URL-patching script as the first child of
+#      `<head>`. The script detects the HA Ingress prefix from
+#      `location.pathname` and patches the DOM property setters
+#      (`HTMLLinkElement.href`, etc.), `Element.prototype.setAttribute`,
+#      `window.fetch`, and `XMLHttpRequest.prototype.open` so URLs the
+#      Next.js client runtime constructs *after* hydration (font
+#      preloads via `ReactDOM.preload`, lazy chunks, etc.) get the
+#      prefix too. Without this last piece, Next.js's build-time
+#      `assetPrefix=""` produces bare `/_next/...` requests that 404
+#      against the host's origin root and break dynamic typography /
+#      lazy assets even though the initial HTML response is correct.
 #
 # When the env var is unset/false the snippet directory stays empty, so
 # direct (non-proxy) deployments incur zero buffering or gzip overhead.
 # Inside the snippet, when X-Ingress-Path is absent the substitutions
-# degenerate to self-substitutions, so toggling the var ON for a direct
-# deployment is also safe (just wasteful).
-#
-# Scope: this handles the initial HTML and its inline asset references,
-# which is what resolves the immediate chunk 404s seen behind HA Ingress.
-# Next.js client-side router navigation uses paths baked at build time
-# and is not yet covered here -- callers that need full SPA navigation
-# under a prefix will additionally need a runtime `assetPrefix` plumbed
-# through next.config.ts.
+# degenerate to self-substitutions and the injected script's regex
+# does not match, so it is a no-op -- toggling the var ON for a direct
+# deployment is safe (just wasteful).
 configure_ingress_path_rewrite() {
     SNIPPET_DIR=/etc/nginx/fiestaboard/location-root
     SNIPPET=$SNIPPET_DIR/base-path-rewrite.conf
@@ -222,6 +228,31 @@ sub_filter '"/api/'    '"$http_x_ingress_path/api/';
 sub_filter "'/api/"    "'$http_x_ingress_path/api/";
 # CSS `url(/_next/...)` -- unquoted is the form Next.js actually emits.
 sub_filter '(/_next/'  '($http_x_ingress_path/_next/';
+# Inject a runtime URL-patching script as the very first child of <head>.
+#
+# Next.js's client runtime constructs dynamic asset URLs (font preloads
+# via ReactDOM.preload, lazy chunk fetches) from a *build-time*
+# `assetPrefix` that's baked into the JS bundles -- empty by default.
+# Server-side sub_filter cannot reach those URLs because they don't
+# exist in the response at all; they're computed on the client after
+# hydration. The result was bare `/_next/static/media/...woff2` font
+# requests against the host's origin root and a broken render under
+# HA Ingress even after #913 and #914 landed.
+#
+# The injected script detects the Ingress prefix from
+# `location.pathname` (only HA Ingress URLs match the regex; any other
+# proxy is a silent no-op), then patches `HTMLLinkElement.prototype.href`,
+# `HTMLScriptElement.prototype.src`, `HTMLImageElement.prototype.src`,
+# `Element.prototype.setAttribute`, `window.fetch`, and
+# `XMLHttpRequest.prototype.open` to prefix any leading-slash URL the
+# Next.js runtime hands them. Running as the first child of <head> means
+# every later script (including hydration) sees the patched versions.
+#
+# Standalone deployments never see this because the env var that gates
+# the snippet (FIESTABOARD_INGRESS_PATH_REWRITE) is off by default;
+# even if an operator turns it on, the script no-ops unless the path
+# matches the HA Ingress shape.
+sub_filter '<head>' '<head><script>(function(){var p=(location.pathname.match(/^\/api\/hassio_ingress\/[^\/]+/)||[])[0];if(!p)return;function f(u){return typeof u==="string"&&u.charCodeAt(0)===47&&u.charCodeAt(1)!==47&&u.indexOf(p)!==0?p+u:u;}function pp(c,k){var d=Object.getOwnPropertyDescriptor(c.prototype,k);if(!d||!d.set)return;Object.defineProperty(c.prototype,k,{set:function(v){d.set.call(this,f(v));},get:d.get,configurable:true});}pp(HTMLLinkElement,"href");pp(HTMLScriptElement,"src");pp(HTMLImageElement,"src");var sa=Element.prototype.setAttribute;Element.prototype.setAttribute=function(n,v){if((n==="href"||n==="src")&&typeof v==="string")v=f(v);return sa.call(this,n,v);};var of=window.fetch;if(typeof of==="function")window.fetch=function(i,o){if(typeof i==="string")i=f(i);return of.call(this,i,o);};var oo=XMLHttpRequest.prototype.open;XMLHttpRequest.prototype.open=function(m,u){if(typeof u==="string")arguments[1]=f(u);return oo.apply(this,arguments);};})();</script>';
 NGINX
 }
 


### PR DESCRIPTION
## Summary
Follow-up to #913 and #914. Those two PRs rewrote `/_next/` and `/api/` URLs in HTML and CSS response bodies. That got the initial wave of assets through HA Supervisor Ingress correctly — but live diagnostics inside the iframe during hydration showed Next.js's client runtime constructing dynamic asset URLs *itself*, from a build-time `assetPrefix` that's empty in our build:

```js
let r = `${t.assetPrefix}/_next/${encodedPath}${suffix}`;
return jsx("link", {href: r, rel: "stylesheet", ...});
```

Every `ReactDOM.preload` call emitted during hydration — including the font preloads for `next/font` — went through this code path, producing bare `/_next/static/media/…woff2` requests against the host's origin root. They 404'd against HA core and the rendered UI lost typography (visible as a near-blank dark layout under HA Ingress).

## Why a runtime patch, not a build-time `assetPrefix`
Next.js does not support runtime `assetPrefix`:
- [#16059 Best way to have basePath as runtime variable](https://github.com/vercel/next.js/discussions/16059)
- [#25368 Make the /_next/ URL prefix configurable](https://github.com/vercel/next.js/discussions/25368)
- [#38142 Dynamic assetPrefix from API](https://github.com/vercel/next.js/discussions/38142)

All three are multi-year unresolved with no Vercel timeline. Of the community workarounds, runtime URL patching has the lowest blast radius for our case: no build-system changes, no second image variant, no placeholder pattern, no per-request `sub_filter` on JS bundles.

## What changes
One nginx `sub_filter` rule in the existing `FIESTABOARD_INGRESS_PATH_REWRITE` snippet that injects a ~25-line minified `<script>` as the **first child of `<head>`**. The script:

1. Detects the HA Ingress prefix from `location.pathname` via a regex that only matches `/api/hassio_ingress/<token>`. **Any other URL path → no-op.**
2. Patches `HTMLLinkElement.prototype.href`, `HTMLScriptElement.prototype.src`, `HTMLImageElement.prototype.src`, `Element.prototype.setAttribute`, `window.fetch`, and `XMLHttpRequest.prototype.open`.
3. Any leading-slash URL the runtime hands these APIs gets prefixed; already-prefixed, protocol-relative, absolute, and relative URLs are left alone.

Running as the first child of `<head>` means every later script (including hydration) sees the patched versions.

## Compatibility / impact on non-HA users
- `FIESTABOARD_INGRESS_PATH_REWRITE` unset (the default for standalone Docker, public preview, etc.) → snippet directory stays empty → no script injection → byte-for-byte identical behavior.
- Env var on but accessed at a non-HA URL path (e.g. someone fronting FiestaBoard with Caddy at `/fiesta/`) → the script's regex doesn't match → early-return → DOM/fetch prototypes untouched.
- Env var on and accessed via HA Ingress → patches active.

## Test plan
- [x] `nginx -t` clean for the rendered snippet (3220 bytes, well within limits).
- [x] Functional test in `nginx:alpine` with a sample upstream: `X-Ingress-Path: /api/hassio_ingress/abc` correctly injects the script as the first child of `<head>` ahead of all other markup; the existing HTML/CSS sub_filters still rewrite link hrefs.
- [x] **jsdom behavioral test** — 9 assertions, all green:
  - `link.href = "/_next/…"` setter (THE bug — React 19 `ReactDOM.preload` uses this directly)
  - `script.src` setter
  - `img.src` setter
  - `link.setAttribute("href", "/api/…")` path
  - Idempotency: already-prefixed URLs not double-prefixed
  - Protocol-relative `//cdn…` left alone
  - Absolute `https://…` left alone
  - Relative `../media/…` left alone
  - `fetch("/api/health")` prefixed
- [x] **jsdom no-op test** — on `http://localhost:4420/` (standalone path), the script early-returns and the DOM/fetch prototypes are not replaced. Confirmed byte-for-byte standalone parity.
- [ ] Live verification under HA Ingress: I'll re-run the in-browser Safari diagnostics on the actual user install once this lands and the add-on bumps. Will leave a comment confirming the font 404s disappear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)