### PR TITLE
fix(web): eliminate page-transition flicker on first paint after route swap

### DIFF
--- a/web/src/components/ui/react-bits/fade-content.tsx
+++ b/web/src/components/ui/react-bits/fade-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 
 interface FadeContentProps {
   children: React.ReactNode;
@@ -24,9 +24,27 @@ export default function FadeContent({
   const ref = useRef<HTMLDivElement>(null);
   const [inView, setInView] = useState(false);
 
-  useEffect(() => {
+  // If the element is already on-screen at mount, kick the animation off on
+  // the next frame — IntersectionObserver fires asynchronously and would leave
+  // a ~20-30ms gap of invisible content between mount and animation start
+  // (perceived as a flicker right after a route transition, since the new
+  // PageFadeWrapper mounts with opacity:0 and stays there until the observer
+  // catches up). Off-screen mounts still fall back to the observer so this
+  // keeps working as a scroll-into-view effect elsewhere.
+  useLayoutEffect(() => {
     const el = ref.current;
     if (!el) return;
+
+    const rect = el.getBoundingClientRect();
+    const vh = window.innerHeight || document.documentElement.clientHeight;
+    const vw = window.innerWidth || document.documentElement.clientWidth;
+    const onScreen = rect.bottom > 0 && rect.right > 0 && rect.top < vh && rect.left < vw;
+
+    if (onScreen) {
+      const raf = requestAnimationFrame(() => setInView(true));
+      return () => cancelAnimationFrame(raf);
+    }
+
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting) {


### PR DESCRIPTION
## Summary

After the React Router v7 SPA migration (#919), the first paint of a freshly mounted route would sit at `opacity: 0` for 20-30ms before the fade-in started. The result was a brief blank gap stamped between the old page disappearing and the new page animating in — perceived as a flicker on every first-time route load.

### Root cause

`FadeContent` (the wrapper inside `PageFadeWrapper`) sets up an `IntersectionObserver` in a `useEffect`. `useEffect` runs *after* paint, and the observer's callback fires asynchronously on a later microtask — so on every route mount:

1. Mount → DOM committed with `opacity: 0`
2. Browser paints `opacity: 0` (page invisible, no transition declared yet)
3. `useEffect` runs → `observer.observe(el)`
4. ~20-30ms later, observer callback fires → `setInView(true)`
5. Re-render → `opacity: 1` → CSS transition finally begins

Steps 2-4 are the flicker.

Frame-by-frame capture (before):

| t (ms) | inline opacity | computed opacity |
|-------:|---------------:|-----------------:|
| 33 | 1 *(old route)* | 1 |
| 40 | 0 *(new mounted)* | 0 *(blank, no animation)* |
| 61 | 1 *(IO fires)* | 0 → animation begins |

### Fix

Switch to `useLayoutEffect` and, when the element is already on-screen at mount (true for every page transition), schedule `setInView(true)` via a single `requestAnimationFrame`. The initial `opacity: 0` paint still commits, and the flip to `opacity: 1` lands on the very next frame so the CSS transition actually fires. Off-screen mounts still fall back to `IntersectionObserver`, preserving the scroll-into-view behavior for any other use of this primitive.

After:

| t (ms) | inline opacity | computed opacity |
|-------:|---------------:|-----------------:|
| 15 | 1 *(old route)* | 1 |
| 23 | 0 *(new mounted)* | 0 |
| 32 | 1 *(rAF fires)* | 0 → animation begins immediately |

The 20-30ms blank gap collapses to a single frame.

## Test plan

- [x] Reproduced via Playwright instrumentation of `#main-content > div` style/opacity over rAF on `/pages → /schedule`
- [x] Rebuilt prod image, verified the same instrumentation shows a single-frame gap with the fix in place
- [ ] Verify on iOS Safari (where transitions can be more sensitive to commit-order timing)
- [ ] Verify with `prefers-reduced-motion: reduce` still skips the transform/opacity transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)