### PR TITLE
fix(ingress): rewrite React Router basename so SPA matches routes under HA Ingress

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -231,9 +231,19 @@ sub_filter '"/manifest.json' '"$http_x_ingress_path/manifest.json';
 sub_filter "'/manifest.json" "'$http_x_ingress_path/manifest.json";
 sub_filter '"/favicon.ico' '"$http_x_ingress_path/favicon.ico';
 sub_filter "'/favicon.ico" "'$http_x_ingress_path/favicon.ico";
+# React Router v7 SPA hydration context. The Vite build inlines
+#   window.__reactRouterContext = {"basename":"/", ...}
+# into the served HTML. HydratedRouter strips `basename` from
+# `location.pathname` before matching, so under an Ingress proxy the
+# request lands on `<ingress-path>/`, RR strips "/" (a no-op), and
+# the resulting path (still `<ingress-path>/`) has no matching route —
+# every page renders the SPA's 404 boundary. Rewriting the literal so
+# basename equals the Ingress prefix makes RR strip the prefix and
+# match the bare routes (`/`, `/login`, `/integrations/:id`, ...).
+sub_filter '"basename":"/"' '"basename":"$http_x_ingress_path/"';
 # href="/..." in the SPA's <Link to="/..."> renders are not rewritten —
 # React Router resolves them through its history API which honors the
-# document base. If we ever need to surface them through templates,
+# basename above. If we ever need to surface them through templates,
 # add explicit substitutions here.
 NGINX
 }


### PR DESCRIPTION
## Summary

- PR #919 / #920 / #922 migrated the web UI from Next.js to a React Router v7 static SPA, and the runtime URL-patching script chain (#913 → #918) collapsed into a single nginx `sub_filter` set over `/assets/`, `/sw.js`, `/api/`, `/icons/`, `/manifest.json`, `/favicon.ico`. The PR description claimed the rewrite was exhaustive because every asset URL is a string literal in the Vite build output.
- **It missed one literal.** Vite emits an inline `__reactRouterContext` `<script>` at the top of the served HTML:
  ```js
  window.__reactRouterContext = {"basename":"/", ..., "isSpaMode":true};
  ```
  React Router's `HydratedRouter` strips `basename` from `location.pathname` before matching. Under HA Ingress the request lands on `/api/hassio_ingress/<token>/`, RR strips `"/"` (a no-op), and the resulting path has no matching route — every page renders the SPA's 404 boundary instead of the app.

## Repro

Confirmed live against `fiestaboard/fiestaboard:7.0.1` via the Fiestaboard Home Assistant add-on (7.0.1-ha.1) on a HAOS install:

- Sidebar iframe URL: `http://192.168.0.52:8123/api/hassio_ingress/o01HnAewinfDpspXbYgjA0ShJKp4Rcg1Tw5YrA7caMI/`
- Assets all load fine (the existing `sub_filter` rewrites work — `entry.client-CEmM1Z0l.js`, `root-CwNHM9KC.css`, manifest chunks).
- React Router boots, then throws inside its own error boundary:
  ```
  Error: No route matches URL
  "/api/hassio_ingress/o01HnAewinfDpspXbYgjA0ShJKp4Rcg1Tw5YrA7caMI/"
  ```
- DOM inspection confirms `window.__reactRouterContext.basename === "/"` while `location.pathname` is the full Ingress URL.

## Fix

One sub_filter line that rewrites the basename literal in the HTML response:

```nginx
sub_filter '"basename":"/"' '"basename":"$http_x_ingress_path/"';
```

- Same shape as the rewrites that #913/#914/#919 already use for asset paths.
- Direct deployments (no `X-Ingress-Path` header): `$http_x_ingress_path` expands to `""`, so the substitution rewrites `"basename":"/"` to `"basename":"/"` — a self-rewrite no-op. Standalone Docker keeps working unchanged.
- Updated the trailing comment block: `<Link to="...">` paths really are fine on their own now (RR resolves them through the basename above), so the "if we ever need to surface them" caveat is the only thing left there.

## Test plan

- [ ] **Standalone Docker** (no Ingress): build, run `docker run -p 4420:4420 fiestaboard/fiestaboard`, open `http://localhost:4420` — UI loads, `basename` stays `"/"`, no regression vs 7.0.1.
- [ ] **HA Ingress** (Fiestaboard add-on, this fix backported): sidebar iframe renders the FiestaBoard UI (no React Router 404), `<Link>` navigation works between `/`, `/login`, `/integrations/:id` under the Ingress prefix, lazy route chunks resolve.
- [ ] **Existing 200-test regression suite**: still passes (no app-side changes).

Labeling `patch` so `release.yml` cuts `v7.0.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)