### PR TITLE
fix(countdown): compute delta via UTC to honor DST transitions (#926)

### DIFF
--- a/plugins/countdown/__init__.py
+++ b/plugins/countdown/__init__.py
@@ -5,7 +5,7 @@ Displays the remaining time to an event timestamp in real time.
 
 import logging
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -80,7 +80,11 @@ class CountdownPlugin(PluginBase):
 
             event_name = self.config.get("event_name") or os.getenv("COUNTDOWN_EVENT_NAME") or "Event"
 
-            delta = target - now
+            # Convert both sides to UTC before subtracting. When two aware
+            # datetimes share the same tzinfo, Python returns the wall-clock
+            # delta and silently drops DST transitions — so a "1 day" target
+            # straddling spring-forward would report 24h instead of 23h (#926).
+            delta = target.astimezone(timezone.utc) - now.astimezone(timezone.utc)
             total_seconds = int(delta.total_seconds())
 
             if total_seconds <= 0:

--- a/plugins/countdown/manifest.json
+++ b/plugins/countdown/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "countdown",
   "name": "Countdown",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Display the remaining time to an event in real time",
   "author": "FiestaBoard Team",
   "repository": "https://github.com/FiestaBoard/FiestaBoard",

--- a/plugins/countdown/tests/test_plugin.py
+++ b/plugins/countdown/tests/test_plugin.py
@@ -255,6 +255,61 @@ class TestCountdownPlugin:
         assert result.data["formatted"] == "21D 3H 10M"
 
     @patch("plugins.countdown.datetime")
+    def test_fetch_data_dst_spring_forward(self, mock_datetime, sample_manifest):
+        """Countdown across the DST spring-forward boundary loses an hour (#926).
+
+        When both ``now`` and ``target`` share the same ``ZoneInfo`` reference,
+        Python's ``datetime`` subtraction ignores ``tzinfo`` and returns wall-clock
+        delta — which is wrong across DST transitions where wall-clock and elapsed
+        seconds disagree by an hour.
+        """
+        tz = ZoneInfo("America/Los_Angeles")
+        # PST 20:00 on 2025-03-08 -> PDT 20:00 on 2025-03-09.
+        # DST springs forward at 02:00 local on 2025-03-09, so the real elapsed
+        # time is 23 hours, not 24 wall-clock hours.
+        mock_now = datetime(2025, 3, 8, 20, 0, 0, tzinfo=tz)
+        mock_datetime.now.return_value = mock_now
+        mock_datetime.fromisoformat = datetime.fromisoformat
+
+        plugin = CountdownPlugin(sample_manifest)
+        plugin.config = {
+            "target_datetime": "2025-03-09T20:00:00",
+            "timezone": "America/Los_Angeles",
+        }
+        result = plugin.fetch_data()
+
+        assert result.available is True
+        data = result.data
+        # 23 hours of real elapsed time => 0 days, 23 hours.
+        assert data["days"] == "0"
+        assert data["hours"] == "23"
+        assert data["total_seconds"] == "82800"
+
+    @patch("plugins.countdown.datetime")
+    def test_fetch_data_dst_fall_back(self, mock_datetime, sample_manifest):
+        """Countdown across the DST fall-back boundary gains an hour (#926)."""
+        tz = ZoneInfo("America/Los_Angeles")
+        # PDT 20:00 on 2025-11-01 -> PST 20:00 on 2025-11-02.
+        # DST falls back at 02:00 local on 2025-11-02, so the real elapsed
+        # time is 25 hours, not 24 wall-clock hours.
+        mock_now = datetime(2025, 11, 1, 20, 0, 0, tzinfo=tz)
+        mock_datetime.now.return_value = mock_now
+        mock_datetime.fromisoformat = datetime.fromisoformat
+
+        plugin = CountdownPlugin(sample_manifest)
+        plugin.config = {
+            "target_datetime": "2025-11-02T20:00:00",
+            "timezone": "America/Los_Angeles",
+        }
+        result = plugin.fetch_data()
+
+        assert result.available is True
+        data = result.data
+        assert data["days"] == "1"
+        assert data["hours"] == "1"
+        assert data["total_seconds"] == "90000"
+
+    @patch("plugins.countdown.datetime")
     def test_fetch_data_default_event_name(self, mock_datetime, sample_manifest):
         """Test default event name when not configured."""
         tz = ZoneInfo("America/Los_Angeles")


### PR DESCRIPTION
## Summary

Fixes #926 — countdown calculation of T-0 was offset by one hour across DST transitions.

When two aware datetimes share the same `tzinfo` instance, Python's `datetime` subtraction ignores the `tzinfo` and returns a wall-clock delta. Across a DST boundary the wall-clock delta and the real elapsed time disagree by an hour — so a 1-day countdown straddling spring-forward reported 24h remaining instead of 23h, and 24h instead of 25h across fall-back.

Fix: convert both `target` and `now` to UTC before subtracting, so the delta always reflects real elapsed time regardless of DST.

```python
delta = target.astimezone(timezone.utc) - now.astimezone(timezone.utc)
```

## Test plan

- [x] New regression test `test_fetch_data_dst_spring_forward` — PDT 20:00 minus PST 20:00 (24h wall-clock, 23h real) returns 0d 23h
- [x] New regression test `test_fetch_data_dst_fall_back` — PST 20:00 minus PDT 20:00 (24h wall-clock, 25h real) returns 1d 1h
- [x] All 25 countdown tests pass (`pytest plugins/countdown/tests/`)
- [ ] Verify end-to-end in dev container: create a countdown with target spanning the next DST transition and confirm hour value updates correctly across the boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)