### PR TITLE
fix(registry): skip instance keys in V3 orphan detection (#925)

### DIFF
--- a/plugins/countdown/__init__.py
+++ b/plugins/countdown/__init__.py
@@ -5,7 +5,7 @@ Displays the remaining time to an event timestamp in real time.
 
 import logging
 import os
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -84,7 +84,7 @@ class CountdownPlugin(PluginBase):
             # datetimes share the same tzinfo, Python returns the wall-clock
             # delta and silently drops DST transitions — so a "1 day" target
             # straddling spring-forward would report 24h instead of 23h (#926).
-            delta = target.astimezone(timezone.utc) - now.astimezone(timezone.utc)
+            delta = target.astimezone(UTC) - now.astimezone(UTC)
             total_seconds = int(delta.total_seconds())
 
             if total_seconds <= 0:

--- a/src/plugins/registry.py
+++ b/src/plugins/registry.py
@@ -379,7 +379,14 @@ class PluginRegistry:
         ``self._plugins``, so it is skipped on every subsequent startup.
         """
         loaded_ids = set(self._plugins.keys())
-        orphaned = [pid for pid in stored_configs if pid not in loaded_ids]
+        # Instance keys (e.g. "countdown:fijiaustralia") are restored separately
+        # by ``_restore_instances`` and must not be treated as orphaned base
+        # plugins — their base ID is what gets installed from the registry.
+        orphaned = [
+            pid
+            for pid in stored_configs
+            if pid not in loaded_ids and not self.is_instance_key(pid)
+        ]
         if not orphaned:
             return
 

--- a/src/plugins/registry.py
+++ b/src/plugins/registry.py
@@ -382,11 +382,7 @@ class PluginRegistry:
         # Instance keys (e.g. "countdown:fijiaustralia") are restored separately
         # by ``_restore_instances`` and must not be treated as orphaned base
         # plugins — their base ID is what gets installed from the registry.
-        orphaned = [
-            pid
-            for pid in stored_configs
-            if pid not in loaded_ids and not self.is_instance_key(pid)
-        ]
+        orphaned = [pid for pid in stored_configs if pid not in loaded_ids and not self.is_instance_key(pid)]
         if not orphaned:
             return
 

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -1195,6 +1195,38 @@ def test_auto_migrate_skips_already_installed_on_subsequent_boots(
     mock_install.assert_not_called()
 
 
+def test_auto_migrate_ignores_instance_keys_when_base_plugin_is_loaded(
+    registry, mock_loader, mock_plugin, mock_manifest
+):
+    """Instance config keys (e.g. ``countdown:fijiaustralia``) must NOT be flagged
+    as orphaned V3 migration candidates when their base plugin is loaded.
+
+    Regression for https://github.com/Fiestaboard/FiestaBoard/issues/925 — the
+    V3 auto-migration was reporting every plugin instance as missing from the
+    registry because it only checked compound keys against the set of loaded
+    base plugin IDs.
+    """
+    mock_loader.load_all_plugins.return_value = {"countdown": mock_plugin}
+    mock_loader.get_manifest.side_effect = lambda pid: mock_manifest if pid == "countdown" else None
+    mock_manifest.id = "countdown"
+
+    with (
+        patch("src.plugins.registry.load_registry") as mock_load_reg,
+        patch("src.plugins.registry.install_registry_plugin") as mock_install,
+        patch("src.config_manager.get_config_manager") as mock_cm,
+    ):
+        mock_cm.return_value.get_all_plugin_configs.return_value = {
+            "countdown": {"enabled": True},
+            "countdown:fijiaustralia": {"enabled": True, "target_date": "2026-12-25"},
+        }
+        registry.initialize()
+
+    # Instance key has a matching loaded base plugin → no orphans → registry
+    # lookup and install should never be triggered.
+    mock_load_reg.assert_not_called()
+    mock_install.assert_not_called()
+
+
 # --- uninstall_external_plugin ---
 
 


### PR DESCRIPTION
## Summary

Fixes #925 — the V3 plugin auto-migration was incorrectly reporting plugin **instances** (e.g. `countdown:fijiaustralia`) as orphaned configs missing from the registry.

## Root cause

`PluginRegistry._auto_migrate_v2_plugins` (`src/plugins/registry.py`) built its orphan list by comparing every `stored_configs` key against the set of loaded base plugin IDs:

```python
loaded_ids = set(self._plugins.keys())
orphaned = [pid for pid in stored_configs if pid not in loaded_ids]
```

Instance configs are stored under compound keys like `countdown:fijiaustralia`. The base plugin (`countdown`) is in `self._plugins`, but the compound key never is — at this point in startup, instances haven't been restored yet (`_restore_instances` runs immediately after). So every instance key got flagged as an orphan and produced the warning seen in the issue.

## Reproduction

The pre-existing test suite never exercised this path with an instance key. A new regression test in `tests/test_plugin_registry.py` initializes the registry with both `countdown` (loaded) and `countdown:fijiaustralia` (instance config), and asserts that no registry lookup or install is attempted. Without the fix the test fails with:

> AssertionError: Expected 'load_registry' to not have been called. Called 1 times.

plus the exact warning from the issue:

> V3 migration: plugin 'countdown:fijiaustralia' has stored config but is not in the registry.

## Fix

One-line filter on `is_instance_key` in the orphan list comprehension so compound keys are skipped — they are handled by `_restore_instances` later in `initialize()`.

## Test plan

- [x] New regression test fails before the fix and passes after
- [x] Full `tests/test_plugin_registry.py` suite passes (74 tests)
- [x] Broader plugin/migration tests pass (`pytest -k "plugin or registry or migrat"` — 784 passed)

Fixes #925