### PR TITLE
fix(schedules): resolve sun-based times before conflict detection (#924)

### DIFF
--- a/plugins/countdown/__init__.py
+++ b/plugins/countdown/__init__.py
@@ -5,7 +5,7 @@ Displays the remaining time to an event timestamp in real time.
 
 import logging
 import os
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -84,7 +84,7 @@ class CountdownPlugin(PluginBase):
             # datetimes share the same tzinfo, Python returns the wall-clock
             # delta and silently drops DST transitions — so a "1 day" target
             # straddling spring-forward would report 24h instead of 23h (#926).
-            delta = target.astimezone(timezone.utc) - now.astimezone(timezone.utc)
+            delta = target.astimezone(UTC) - now.astimezone(UTC)
             total_seconds = int(delta.total_seconds())
 
             if total_seconds <= 0:

--- a/src/schedules/service.py
+++ b/src/schedules/service.py
@@ -264,8 +264,19 @@ class ScheduleService:
             s for s in self.list_schedules(board_id=board_id) if s.enabled and s.recurrence_type == "weekly"
         ]
 
-        overlaps = self._detect_overlaps(weekly_schedules)
-        gaps = self._detect_gaps(weekly_schedules)
+        # Resolve sun-based start/end times before checking for overlaps and
+        # gaps so validation reflects what the user actually scheduled (e.g.
+        # "sunset until 22:00") rather than the placeholder fallback HH:MM
+        # values stored on disk (see #924).
+        location = self._get_location()
+        today = get_today_in_timezone(location[2])
+        resolved_schedules = [self._resolve_effective_times(s, today, location) for s in weekly_schedules]
+
+        # Preserve original schedule IDs on overlaps so the UI can highlight
+        # the right rows; _resolve_effective_times copies the entry so ids
+        # already round-trip, but we pass resolved copies explicitly here.
+        overlaps = self._detect_overlaps(resolved_schedules)
+        gaps = self._detect_gaps(resolved_schedules)
 
         return ScheduleValidationResult(valid=len(overlaps) == 0, overlaps=overlaps, gaps=gaps)
 

--- a/tests/test_schedules_service.py
+++ b/tests/test_schedules_service.py
@@ -421,6 +421,69 @@ class TestValidation:
         assert "saturday" in gap_days
         assert "sunday" in gap_days
 
+    def test_validate_uses_resolved_sun_times_not_fallbacks(self, service, monkeypatch):
+        """Regression test for #924: validation must resolve sun-based times
+        before checking for overlaps. Otherwise two non-overlapping sunset
+        schedules with shared placeholder fallbacks are wrongly reported as
+        conflicts."""
+        # Configure a location so sun resolution runs
+        mock_settings = MagicMock()
+        mock_settings.get_location_settings.return_value.latitude = 40.7128
+        mock_settings.get_location_settings.return_value.longitude = -74.0060
+        mock_settings.get_board_settings.return_value.boards = []
+        monkeypatch.setattr(
+            "src.schedules.service.get_settings_service",
+            lambda: mock_settings,
+        )
+        monkeypatch.setattr(
+            "src.schedules.service.get_effective_timezone",
+            lambda: "America/New_York",
+        )
+
+        # Stub the sun-time resolver so the test is deterministic. The two
+        # schedules below both have stored fallback start_time="00:00", but
+        # after sun resolution one runs sunset to 22:00 and the other runs
+        # 06:00 until sunset — so they do not actually overlap.
+        def fake_resolver(*, start_type, end_type, start_time_fallback, end_time_fallback, **kwargs):
+            start = "20:00" if start_type == "sunset" else start_time_fallback
+            end = "20:00" if end_type == "sunset" else end_time_fallback
+            return start, end
+
+        monkeypatch.setattr(
+            "src.schedules.service.resolve_schedule_sun_times",
+            fake_resolver,
+        )
+
+        # Schedule A: sunset (~20:00) until 22:00
+        service.create_schedule(
+            ScheduleCreate(
+                page_id="evening-page",
+                start_time="00:00",  # placeholder fallback for sunset
+                end_time="22:00",
+                day_pattern="all",
+                enabled=True,
+                start_type="sunset",
+            )
+        )
+        # Schedule B: 06:00 until sunset (~20:00)
+        service.create_schedule(
+            ScheduleCreate(
+                page_id="daytime-page",
+                start_time="06:00",
+                end_time="00:00",  # placeholder fallback for sunset
+                day_pattern="all",
+                enabled=True,
+                end_type="sunset",
+            )
+        )
+
+        result = service.validate_schedules()
+        assert result.valid is True, (
+            f"Sun-based schedules should not conflict once resolved, "
+            f"got overlaps: {[o.conflict_description for o in result.overlaps]}"
+        )
+        assert len(result.overlaps) == 0
+
 
 class TestHelpers:
     """Tests for internal helper methods and module-level utilities."""


### PR DESCRIPTION
## Summary

Fixes #924. Schedule "conflict" warnings were inaccurate for sun-based schedules because validation compared the raw stored `start_time`/`end_time` HH:MM strings — which for sunrise/sunset schedules are placeholder fallback values (often `00:00`) — instead of the resolved sun times for today.

## Root cause

`ScheduleService.validate_schedules` passed weekly schedules straight into `_detect_overlaps` and `_detect_gaps`. Those helpers read `schedule.start_time` and `schedule.end_time` literally. For schedules with `start_type` or `end_type` set to `"sunrise"`/`"sunset"`, those fields are placeholder fallbacks that don't represent the actual run window. Two sunset-anchored schedules with the same `"00:00"` placeholder were therefore reported as overlapping even when their real (resolved) windows didn't intersect.

This is why the issue reporter saw a "Schedule Conflict" they couldn't make sense of — the fixed-vs-sunset schedules genuinely don't conflict, but the validator never resolved sunset to its real HH:MM before comparing.

## Reproduction

Schedules used: one `06:00 → sunset`, another `sunset → 22:00`, both daily. They don't overlap in practice (sunset is the boundary), but the validator reported a conflict on every weekday. The new regression test in `tests/test_schedules_service.py::TestValidation::test_validate_uses_resolved_sun_times_not_fallbacks` reproduces this exactly using a stubbed sun resolver that returns `20:00` for sunset; before the fix the schedules produce an `Overlap`, after the fix they do not.

## Fix

In `src/schedules/service.py`, `validate_schedules` now resolves effective sun-based start/end times for today (using `_resolve_effective_times`, the same helper used by `get_active_page_id`) before passing the schedules into the overlap and gap detectors. Disabled schedules are still excluded as before. The fix is one focused change in `validate_schedules`; `_detect_overlaps`, `_detect_gaps`, and time helpers are untouched.

## Test plan

- [x] New regression test `test_validate_uses_resolved_sun_times_not_fallbacks` fails on `main`, passes with the fix
- [x] Existing 32 tests in `tests/test_schedules_service.py` continue to pass
- [x] Full schedule-related suite (`pytest tests/ -k schedule`) — 351 passed, 0 failed
- [ ] Manual sanity check in the dev UI with a sunset-based schedule + a fixed schedule that meets at sunset (no "Schedule Conflicts" banner)

Fixes #924