### PR TITLE
feat(integrations): show current value of template variables in plugin config

### DIFF
--- a/web/app/routes/integrations._index.tsx
+++ b/web/app/routes/integrations._index.tsx
@@ -1198,9 +1198,7 @@ function PluginCard({
                       <span className="ml-2 text-xs font-normal">(click to copy)</span>
                     </h4>
                     {!plugin.enabled && (
-                      <p className="text-xs text-muted-foreground italic">
-                        Enable the plugin to see live values.
-                      </p>
+                      <p className="text-xs text-muted-foreground italic">Enable the plugin to see live values.</p>
                     )}
                     {plugin.enabled && rawDisplay && rawDisplay.available === false && (
                       <p className="text-xs text-amber-600 dark:text-amber-400">
@@ -1252,10 +1250,7 @@ function PluginCard({
                                 <td className="px-3 py-2 text-muted-foreground capitalize align-top">
                                   {variable.description}
                                 </td>
-                                <td
-                                  className="px-3 py-2 align-top max-w-[200px]"
-                                  onClick={(e) => e.stopPropagation()}
-                                >
+                                <td className="px-3 py-2 align-top max-w-[200px]" onClick={(e) => e.stopPropagation()}>
                                   {!plugin.enabled ? (
                                     <span className="text-muted-foreground">—</span>
                                   ) : isLoadingRawDisplay ? (

--- a/web/app/routes/integrations._index.tsx
+++ b/web/app/routes/integrations._index.tsx
@@ -828,6 +828,55 @@ const CATEGORY_LABELS: Record<string, string> = {
   weather: "Weather & Environment",
 };
 
+// Resolve the live value of a template variable from a plugin's raw display data.
+// Variable names come in two shapes:
+//   - simple:  "temperature"             → data.temperature
+//   - array:   "forecast.{index}.day"    → data.forecast[i].day for each i
+// Returns null when the variable can't be resolved (missing key, plugin disabled).
+// `short` is what we render in the cell; `full` is what the hover tooltip shows.
+function formatCurrentValue(
+  variable: string,
+  data: Record<string, unknown> | undefined,
+): { short: string; full: string } | null {
+  if (!data) return null;
+
+  const stringify = (v: unknown): string => {
+    if (v == null) return "";
+    if (typeof v === "string") return v;
+    if (typeof v === "number" || typeof v === "boolean") return String(v);
+    try {
+      return JSON.stringify(v);
+    } catch {
+      return String(v);
+    }
+  };
+
+  // Array variable: "<arrayName>.{index}.<field>"
+  const arrayMatch = variable.match(/^([^.]+)\.\{index\}\.(.+)$/);
+  if (arrayMatch) {
+    const [, arrayName, field] = arrayMatch;
+    const arr = data[arrayName];
+    if (!Array.isArray(arr) || arr.length === 0) return null;
+
+    const entries = arr.map((item, i) => {
+      const value = item && typeof item === "object" ? (item as Record<string, unknown>)[field] : undefined;
+      return { i, value: stringify(value) };
+    });
+
+    const fullLines = entries.map(({ i, value }) => `[${i}] ${value || "—"}`);
+    const previewCount = 3;
+    const previewParts = entries.slice(0, previewCount).map(({ i, value }) => `[${i}] ${value || "—"}`);
+    const more = entries.length > previewCount ? `  +${entries.length - previewCount} more` : "";
+
+    return { short: previewParts.join("  ") + more, full: fullLines.join("\n") };
+  }
+
+  // Simple variable: direct key lookup.
+  if (!(variable in data)) return null;
+  const value = stringify(data[variable]);
+  return { short: value, full: value };
+}
+
 interface PluginCardProps {
   plugin: PluginInfo;
   onToggle: (pluginId: string, enabled: boolean) => void;
@@ -872,6 +921,19 @@ function PluginCard({
     enabled: isConfigOpen,
   });
 
+  // Fetch current variable values (raw display data) for the Template Variables table.
+  // Polls while the sheet is open so users can watch values update during troubleshooting.
+  const {
+    data: rawDisplay,
+    isLoading: isLoadingRawDisplay,
+    isFetching: isFetchingRawDisplay,
+  } = useQuery({
+    queryKey: ["plugin-display-raw", plugin.id],
+    queryFn: () => api.getDisplayRaw(plugin.id),
+    enabled: isConfigOpen && plugin.enabled,
+    refetchInterval: 15_000,
+  });
+
   // Initialize config values when plugin details load
   useEffect(() => {
     if (pluginDetails?.config) {
@@ -886,6 +948,7 @@ function PluginCard({
       toast.success(`${plugin.name} configuration saved`);
       onConfigUpdate();
       queryClient.invalidateQueries({ queryKey: ["plugin-displays-batch"] });
+      queryClient.invalidateQueries({ queryKey: ["plugin-display-raw", plugin.id] });
       queryClient.invalidateQueries({ queryKey: ["pagePreview"] });
       setIsConfigOpen(false);
     } catch (error) {
@@ -1128,54 +1191,109 @@ function PluginCard({
 
               {/* Template Variables Section */}
               {getVariablesList().length > 0 && (
-                <div className="space-y-3">
-                  <h4 className="text-sm font-medium text-muted-foreground">
-                    Template Variables
-                    <span className="ml-2 text-xs font-normal">(click to copy)</span>
-                  </h4>
-                  <div className="rounded-md border overflow-hidden">
-                    <table className="w-full text-xs">
-                      <thead className="bg-muted/50">
-                        <tr>
-                          <th className="text-left px-3 py-2 font-medium">Variable</th>
-                          <th className="text-left px-3 py-2 font-medium">Description</th>
-                          <th className="text-center px-3 py-2 font-medium">Max</th>
-                        </tr>
-                      </thead>
-                      <tbody className="divide-y">
-                        {getVariablesList().map((variable) => (
-                          <tr
-                            key={variable.name}
-                            className="hover:bg-muted/30 cursor-pointer transition-colors"
-                            onClick={() => handleCopyVar(variable.name)}
-                          >
-                            <td className="px-3 py-2">
-                              <div className="flex items-center gap-1.5">
-                                <code className="text-primary font-mono bg-primary/10 px-1.5 py-0.5 rounded text-[11px]">
-                                  {plugin.id}.{variable.name}
-                                </code>
-                                {copiedVar === variable.name ? (
-                                  <Check className="h-3 w-3 text-success" />
-                                ) : (
-                                  <Copy className="h-3 w-3 text-muted-foreground" />
-                                )}
-                              </div>
-                            </td>
-                            <td className="px-3 py-2 text-muted-foreground capitalize">{variable.description}</td>
-                            <td className="px-3 py-2 text-center">
-                              <Badge variant="outline" className="text-[10px]">
-                                {variable.maxChars}
-                              </Badge>
-                            </td>
+                <TooltipProvider delayDuration={200}>
+                  <div className="space-y-3">
+                    <h4 className="text-sm font-medium text-muted-foreground">
+                      Template Variables
+                      <span className="ml-2 text-xs font-normal">(click to copy)</span>
+                    </h4>
+                    {!plugin.enabled && (
+                      <p className="text-xs text-muted-foreground italic">
+                        Enable the plugin to see live values.
+                      </p>
+                    )}
+                    {plugin.enabled && rawDisplay && rawDisplay.available === false && (
+                      <p className="text-xs text-amber-600 dark:text-amber-400">
+                        Live values are unavailable
+                        {rawDisplay.error ? `: ${rawDisplay.error}` : "."}
+                      </p>
+                    )}
+                    <div className="rounded-md border overflow-hidden">
+                      <table className="w-full text-xs">
+                        <thead className="bg-muted/50">
+                          <tr>
+                            <th className="text-left px-3 py-2 font-medium">Variable</th>
+                            <th className="text-left px-3 py-2 font-medium">Description</th>
+                            <th className="text-left px-3 py-2 font-medium">
+                              Current Value
+                              {plugin.enabled && isFetchingRawDisplay && !isLoadingRawDisplay && (
+                                <span className="ml-1.5 text-[10px] font-normal text-muted-foreground">
+                                  (refreshing…)
+                                </span>
+                              )}
+                            </th>
+                            <th className="text-center px-3 py-2 font-medium">Max</th>
                           </tr>
-                        ))}
-                      </tbody>
-                    </table>
+                        </thead>
+                        <tbody className="divide-y">
+                          {getVariablesList().map((variable) => {
+                            const resolved = formatCurrentValue(
+                              variable.name,
+                              rawDisplay?.available ? (rawDisplay.data as Record<string, unknown>) : undefined,
+                            );
+                            return (
+                              <tr
+                                key={variable.name}
+                                className="hover:bg-muted/30 cursor-pointer transition-colors"
+                                onClick={() => handleCopyVar(variable.name)}
+                              >
+                                <td className="px-3 py-2 align-top">
+                                  <div className="flex items-center gap-1.5">
+                                    <code className="text-primary font-mono bg-primary/10 px-1.5 py-0.5 rounded text-[11px]">
+                                      {plugin.id}.{variable.name}
+                                    </code>
+                                    {copiedVar === variable.name ? (
+                                      <Check className="h-3 w-3 text-success" />
+                                    ) : (
+                                      <Copy className="h-3 w-3 text-muted-foreground" />
+                                    )}
+                                  </div>
+                                </td>
+                                <td className="px-3 py-2 text-muted-foreground capitalize align-top">
+                                  {variable.description}
+                                </td>
+                                <td
+                                  className="px-3 py-2 align-top max-w-[200px]"
+                                  onClick={(e) => e.stopPropagation()}
+                                >
+                                  {!plugin.enabled ? (
+                                    <span className="text-muted-foreground">—</span>
+                                  ) : isLoadingRawDisplay ? (
+                                    <Skeleton className="h-3 w-16" />
+                                  ) : rawDisplay && rawDisplay.available === false ? (
+                                    <span className="text-muted-foreground italic">Unavailable</span>
+                                  ) : resolved && resolved.short !== "" ? (
+                                    <Tooltip>
+                                      <TooltipTrigger asChild>
+                                        <span className="block truncate font-mono text-[11px]">{resolved.short}</span>
+                                      </TooltipTrigger>
+                                      <TooltipContent
+                                        side="top"
+                                        className="max-w-[360px] whitespace-pre-wrap break-words font-mono text-[11px]"
+                                      >
+                                        {resolved.full}
+                                      </TooltipContent>
+                                    </Tooltip>
+                                  ) : (
+                                    <span className="text-muted-foreground">—</span>
+                                  )}
+                                </td>
+                                <td className="px-3 py-2 text-center align-top">
+                                  <Badge variant="outline" className="text-[10px]">
+                                    {variable.maxChars}
+                                  </Badge>
+                                </td>
+                              </tr>
+                            );
+                          })}
+                        </tbody>
+                      </table>
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      Use in templates as <code className="bg-muted px-1 rounded">{`{{${plugin.id}.variable}}`}</code>
+                    </p>
                   </div>
-                  <p className="text-xs text-muted-foreground">
-                    Use in templates as <code className="bg-muted px-1 rounded">{`{{${plugin.id}.variable}}`}</code>
-                  </p>
-                </div>
+                </TooltipProvider>
               )}
 
               {/* Environment Variables Section */}

--- a/web/tests/regression/integrations-plugin-config.spec.ts
+++ b/web/tests/regression/integrations-plugin-config.spec.ts
@@ -242,6 +242,10 @@ test.describe("regression: integrations.plugin (config sheet + lifecycle)", () =
    * Issue: https://github.com/Fiestaboard/FiestaBoard/issues/936
    */
   test("integrations.plugin.config-sheet.template-vars — Current Value column shows live value", async ({ page }) => {
+    // The raw-display endpoint only refreshes on the plugin scheduler tick,
+    // which on a cold CI container can take >20s for date_time's first cycle.
+    // Triple the default 30s budget so the assertion has room to wait it out.
+    test.slow();
     await openConfigSheet(page);
 
     // Wait for template-vars heading

--- a/web/tests/regression/integrations-plugin-config.spec.ts
+++ b/web/tests/regression/integrations-plugin-config.spec.ts
@@ -258,19 +258,11 @@ test.describe("regression: integrations.plugin (config sheet + lifecycle)", () =
     await expect(timeCode).toBeVisible({ timeout: 5_000 });
     const timeRow = varsTable.locator("tbody tr").filter({ has: timeCode });
 
-    // The "Current Value" cell is the 3rd column. Poll until it renders something
-    // beyond the loading skeleton — the raw display fetch can take a moment.
+    // The "Current Value" cell is the 3rd column. Wait until it renders the live
+    // value — date_time.time always contains a digit (HH:MM). The displays-raw
+    // endpoint can take a moment to warm up on a cold container, so allow 30s.
     const valueCell = timeRow.locator("td").nth(2);
-    await expect
-      .poll(
-        async () => {
-          const text = (await valueCell.textContent())?.trim() ?? "";
-          // Skeleton renders no text; "—" is the empty-state placeholder. Anything else is a live value.
-          return text.length > 0 && text !== "—" ? text : null;
-        },
-        { timeout: 15_000, message: "Current Value cell never populated" },
-      )
-      .not.toBeNull();
+    await expect(valueCell).toContainText(/\d/, { timeout: 30_000 });
   });
 
   /**

--- a/web/tests/regression/integrations-plugin-config.spec.ts
+++ b/web/tests/regression/integrations-plugin-config.spec.ts
@@ -269,6 +269,56 @@ test.describe("regression: integrations.plugin (config sheet + lifecycle)", () =
   });
 
   /**
+   * UX node: integrations.plugin.config-sheet.template-vars.unconfigured
+   * Route: /integrations (sheet)
+   * Preconditions: plugin:enabled, raw-display:unavailable (missing config / fetch error)
+   * Expected:
+   *   - sheet still renders without crashing
+   *   - "Unavailable" message visible above the table
+   *   - every Current Value cell falls back to "—" (no live value)
+   *   - copying a variable still works (rest of the sheet is unaffected)
+   * Issue: https://github.com/Fiestaboard/FiestaBoard/issues/936
+   */
+  test("integrations.plugin.config-sheet.template-vars — handles unconfigured plugin gracefully", async ({ page }) => {
+    // Simulate an unconfigured plugin: the raw-display endpoint reports the
+    // plugin's data isn't available. This is what a plugin like `weather`
+    // returns when its API key isn't set.
+    await page.route(`**/api/displays/${TEST_PLUGIN_ID}/raw`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          display_type: TEST_PLUGIN_ID,
+          data: {},
+          available: false,
+          error: "Plugin not configured",
+        }),
+      });
+    });
+
+    await openConfigSheet(page);
+
+    // Sheet renders, Template Variables section is present (page didn't crash).
+    await expect(page.getByRole("heading", { name: /Template Variables/i })).toBeVisible({ timeout: 15_000 });
+
+    const dialog = page.locator('[role="dialog"]');
+    const varsTable = dialog.locator("table").filter({ hasText: "Current Value" }).filter({ hasText: "Max" });
+    await expect(varsTable).toBeVisible({ timeout: 5_000 });
+
+    // The unavailable hint surfaces the upstream error message.
+    await expect(dialog.getByText(/Plugin not configured/i)).toBeVisible({ timeout: 5_000 });
+
+    // The `time` row's Current Value cell falls back to the "Unavailable"
+    // placeholder rather than a live value or a crashing render.
+    const timeRow = varsTable.getByRole("row", { name: new RegExp(`^${TEST_PLUGIN_ID}\\.time `) });
+    const valueCell = timeRow.locator("td").nth(2);
+    await expect(valueCell).toHaveText("Unavailable", { timeout: 5_000 });
+
+    // Save button is still enabled — the rest of the sheet remains interactive.
+    await expect(page.getByRole("button", { name: "Save Changes" })).toBeEnabled();
+  });
+
+  /**
    * UX node: integrations.plugin.config-sheet.copy-variable
    * Route: /integrations (sheet)
    * Preconditions: plugin:has-template-vars

--- a/web/tests/regression/integrations-plugin-config.spec.ts
+++ b/web/tests/regression/integrations-plugin-config.spec.ts
@@ -252,9 +252,11 @@ test.describe("regression: integrations.plugin (config sheet + lifecycle)", () =
     const varsTable = dialog.locator("table").filter({ hasText: "Current Value" }).filter({ hasText: "Max" });
     await expect(varsTable).toBeVisible({ timeout: 5_000 });
 
-    // Find the row for the `time` variable. date_time exposes a `time` simple variable.
-    const timeRow = varsTable.locator("tbody tr").filter({ hasText: `${TEST_PLUGIN_ID}.time` });
-    await expect(timeRow).toBeVisible({ timeout: 5_000 });
+    // Find the row for the `time` variable via the exact <code> text — bare `hasText`
+    // would also match `time_12h`, `time_24h`, `time_english`, etc.
+    const timeCode = varsTable.locator("tbody tr code", { hasText: new RegExp(`^${TEST_PLUGIN_ID}\\.time$`) });
+    await expect(timeCode).toBeVisible({ timeout: 5_000 });
+    const timeRow = varsTable.locator("tbody tr").filter({ has: timeCode });
 
     // The "Current Value" cell is the 3rd column. Poll until it renders something
     // beyond the loading skeleton — the raw display fetch can take a moment.

--- a/web/tests/regression/integrations-plugin-config.spec.ts
+++ b/web/tests/regression/integrations-plugin-config.spec.ts
@@ -234,6 +234,44 @@ test.describe("regression: integrations.plugin (config sheet + lifecycle)", () =
   });
 
   /**
+   * UX node: integrations.plugin.config-sheet.template-vars.current-value
+   * Route: /integrations (sheet)
+   * Preconditions: plugin:enabled, plugin:exposes-variables
+   * Expected: Template Variables table shows a "Current Value" column populated
+   *   with the live value returned by /displays/{plugin}/raw.
+   * Issue: https://github.com/Fiestaboard/FiestaBoard/issues/936
+   */
+  test("integrations.plugin.config-sheet.template-vars — Current Value column shows live value", async ({ page }) => {
+    await openConfigSheet(page);
+
+    // Wait for template-vars heading
+    await expect(page.getByRole("heading", { name: /Template Variables/i })).toBeVisible({ timeout: 15_000 });
+
+    // Locate the variables table by its column headers (it includes "Current Value" + "Max").
+    const dialog = page.locator('[role="dialog"]');
+    const varsTable = dialog.locator("table").filter({ hasText: "Current Value" }).filter({ hasText: "Max" });
+    await expect(varsTable).toBeVisible({ timeout: 5_000 });
+
+    // Find the row for the `time` variable. date_time exposes a `time` simple variable.
+    const timeRow = varsTable.locator("tbody tr").filter({ hasText: `${TEST_PLUGIN_ID}.time` });
+    await expect(timeRow).toBeVisible({ timeout: 5_000 });
+
+    // The "Current Value" cell is the 3rd column. Poll until it renders something
+    // beyond the loading skeleton — the raw display fetch can take a moment.
+    const valueCell = timeRow.locator("td").nth(2);
+    await expect
+      .poll(
+        async () => {
+          const text = (await valueCell.textContent())?.trim() ?? "";
+          // Skeleton renders no text; "—" is the empty-state placeholder. Anything else is a live value.
+          return text.length > 0 && text !== "—" ? text : null;
+        },
+        { timeout: 15_000, message: "Current Value cell never populated" },
+      )
+      .not.toBeNull();
+  });
+
+  /**
    * UX node: integrations.plugin.config-sheet.copy-variable
    * Route: /integrations (sheet)
    * Preconditions: plugin:has-template-vars

--- a/web/tests/regression/integrations-plugin-config.spec.ts
+++ b/web/tests/regression/integrations-plugin-config.spec.ts
@@ -256,11 +256,10 @@ test.describe("regression: integrations.plugin (config sheet + lifecycle)", () =
     const varsTable = dialog.locator("table").filter({ hasText: "Current Value" }).filter({ hasText: "Max" });
     await expect(varsTable).toBeVisible({ timeout: 5_000 });
 
-    // Find the row for the `time` variable via the exact <code> text — bare `hasText`
-    // would also match `time_12h`, `time_24h`, `time_english`, etc.
-    const timeCode = varsTable.locator("tbody tr code", { hasText: new RegExp(`^${TEST_PLUGIN_ID}\\.time$`) });
-    await expect(timeCode).toBeVisible({ timeout: 5_000 });
-    const timeRow = varsTable.locator("tbody tr").filter({ has: timeCode });
+    // Pin to the `time` row by its accessible name; the trailing space prevents
+    // a substring match against `time_12h`, `time_24h`, `time_english`, etc.
+    const timeRow = varsTable.getByRole("row", { name: new RegExp(`^${TEST_PLUGIN_ID}\\.time `) });
+    await expect(timeRow).toBeVisible({ timeout: 5_000 });
 
     // The "Current Value" cell is the 3rd column. Wait until it renders the live
     // value — date_time.time always contains a digit (HH:MM). The displays-raw


### PR DESCRIPTION
## Summary

- Adds a **Current Value** column to the Template Variables table inside each plugin's Configure sheet on `/integrations`. Values are pulled live from the existing `GET /displays/{plugin}/raw` endpoint and refresh every 15 s while the sheet is open.
- Distinguishes disabled / loading / unavailable / empty states, truncates long values with a tooltip showing the full string, and renders array variables (`name.{index}.field`) as `[0] …  [1] …  +N more` with the full list in the tooltip.
- Closes #936.

## Before / After

| Before | After |
| --- | --- |
| Variable, Description, Max | Variable, Description, **Current Value**, Max |
| Users had to open the Variable Picker on a draft page to see a 12-char preview. | The live value sits next to each variable in the same table the user is already looking at. |

## Test plan
- [x] `npm test` — 1031 passed
- [x] `npm run typecheck` — no new errors introduced (existing `settings_schema` typing error is pre-existing on `main`)
- [x] Manual smoke (Date & Time enabled): table shows live `time`, `hour`, `minute`, `time_12h`, `time_24h`, `timezone_abbr`
- [x] Manual smoke (Date & Time disabled): cells show `—` and "Enable the plugin to see live values." hint appears
- [ ] CI runs the new regression test `integrations.plugin.config-sheet.template-vars — Current Value column shows live value`

🤖 Generated with [Claude Code](https://claude.com/claude-code)