### PR TITLE
fix(plugins): demo page now matches configured board size (#942)

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -8212,6 +8212,7 @@ async def generic_data_test_fetch(request: dict):
     # (scheme is one of {"http","https"}; host already passed the
     # IpAddressSanitizer above).
     from urllib.parse import urlunsplit as _urlunsplit
+
     _safe_scheme = "https" if _parsed_url.scheme == "https" else "http"
     _safe_netloc = _host_for_check
     if _parsed_url.port:

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -7480,6 +7480,32 @@ async def get_plugin_variables(plugin_id: str):
 # ── Plugin Demo Pages ────────────────────────────────────────────────────────
 
 
+def _resolve_demo_device_type(demo: dict) -> str:
+    """Pick the demo device_type that matches the configured board.
+
+    Walks the user's configured boards in order and returns the first
+    device_type that the plugin actually ships a demo for. Falls back to
+    any device_type the plugin supports, then to "flagship" as a last
+    resort. See issue #942.
+    """
+    configured: list[str] = []
+    try:
+        board_settings = get_settings_service().get_board_settings()
+        for board in getattr(board_settings, "boards", []) or []:
+            dt = board.get("device_type") if isinstance(board, dict) else None
+            if dt and dt not in configured:
+                configured.append(dt)
+    except Exception:  # noqa: BLE001 — settings access must never break demo creation
+        logger.debug("Could not resolve configured device_type; using plugin default", exc_info=True)
+
+    for dt in configured:
+        if dt in demo:
+            return dt
+    if demo:
+        return next(iter(demo))
+    return "flagship"
+
+
 @app.get("/plugins/{plugin_id}/demo-page")
 async def get_plugin_demo_page(plugin_id: str, device_type: str = "flagship"):
     """
@@ -7509,9 +7535,15 @@ async def get_plugin_demo_page(plugin_id: str, device_type: str = "flagship"):
 
 
 @app.post("/plugins/{plugin_id}/demo-page")
-async def create_plugin_demo_page(plugin_id: str, device_type: str = "flagship"):
+async def create_plugin_demo_page(plugin_id: str, device_type: str | None = None):
     """
     Create (or recreate) the demo page for a plugin and device type.
+
+    When *device_type* is omitted, it is resolved from the configured board
+    settings (the first device type listed under Settings → Hardware), so a
+    Note board does not silently get a Flagship-sized demo page (issue #942).
+    If the plugin does not ship a demo template for the configured device,
+    we fall back to any device type it does support.
 
     The demo page is a singleton per plugin + device type -- calling this endpoint
     when a demo page already exists for that device type will delete the old one
@@ -7531,11 +7563,13 @@ async def create_plugin_demo_page(plugin_id: str, device_type: str = "flagship")
             detail=f"Plugin '{plugin_id}' does not include a demo page template.",
         )
 
-    demo_schema = manifest.demo.get(device_type)
+    resolved_device_type = device_type or _resolve_demo_device_type(manifest.demo)
+
+    demo_schema = manifest.demo.get(resolved_device_type)
     if demo_schema is None:
         raise HTTPException(
             status_code=400,
-            detail=f"Plugin '{plugin_id}' has no demo template for device type '{device_type}'.",
+            detail=f"Plugin '{plugin_id}' has no demo template for device type '{resolved_device_type}'.",
         )
 
     # Check that required settings are configured

--- a/tests/test_demo_pages.py
+++ b/tests/test_demo_pages.py
@@ -6,12 +6,15 @@ Covers:
 - Schema migration v1 -> v2
 - PageService.get_demo_page() and create_demo_page()
 - Manifest validation of the demo section
+- POST /plugins/{plugin_id}/demo-page endpoint device_type resolution
 """
 
 import os
 import tempfile
+from unittest.mock import Mock, patch
 
 import pytest
+from fastapi.testclient import TestClient
 
 from src.pages.models import Page, PageCreate
 from src.pages.service import PageService
@@ -502,3 +505,144 @@ class TestPageServiceDemo:
         assert found is not None
         assert found.id == page.id
         assert found.demo_plugin_id == "test_plugin"
+
+
+# ---------------------------------------------------------------------------
+# POST /plugins/{plugin_id}/demo-page – endpoint behaviour
+#
+# Regression coverage for issue #942: when no device_type query param is
+# supplied, the endpoint must honour the configured board's device_type
+# instead of defaulting to "flagship".
+# ---------------------------------------------------------------------------
+
+
+class TestCreateDemoPageEndpoint:
+    @pytest.fixture
+    def client(self):
+        from src.api_server import app
+
+        return TestClient(app)
+
+    @pytest.fixture
+    def flagship_demo_schema(self):
+        return DemoPageSchema(
+            name="Flagship Demo",
+            template=["F1", "F2", "F3", "F4", "F5", "F6"],
+            device_type="flagship",
+        )
+
+    @pytest.fixture
+    def note_demo_schema(self):
+        return DemoPageSchema(
+            name="Note Demo",
+            template=["N1", "N2", "N3"],
+            device_type="note",
+        )
+
+    @pytest.fixture
+    def manifest_with_both_demos(self, flagship_demo_schema, note_demo_schema):
+        manifest = Mock()
+        manifest.demo = {"flagship": flagship_demo_schema, "note": note_demo_schema}
+        manifest.settings_schema = {"required": []}
+        return manifest
+
+    @pytest.fixture
+    def board_settings_with_device(self):
+        def _make(device_type: str):
+            bs = Mock()
+            bs.boards = [{"id": "b1", "device_type": device_type}]
+            bs.devices = [device_type]
+            return bs
+
+        return _make
+
+    def _patch_dependencies(self, manifest, board_settings):
+        """Patch the registry, settings service, and page service."""
+        registry = Mock()
+        registry.get_manifest.return_value = manifest
+
+        settings_service = Mock()
+        settings_service.get_board_settings.return_value = board_settings
+
+        created_page = Mock()
+        created_page.model_dump.return_value = {"id": "p1", "name": "demo"}
+        page_service = Mock()
+        page_service.create_demo_page.return_value = (created_page, False)
+
+        return (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_plugin_registry", return_value=registry),
+            patch("src.api_server.get_settings_service", return_value=settings_service),
+            patch("src.api_server.get_page_service", return_value=page_service),
+            patch("src.api_server.get_config_manager", return_value=Mock(get_plugin_config=Mock(return_value={}))),
+            page_service,
+        )
+
+    def test_defaults_to_configured_board_device_type_note(
+        self, client, manifest_with_both_demos, board_settings_with_device
+    ):
+        """When the only configured board is a Note, the demo must use the note schema."""
+        bs = board_settings_with_device("note")
+        p_avail, p_reg, p_ss, p_ps, p_cm, page_service = self._patch_dependencies(
+            manifest_with_both_demos, bs
+        )
+
+        with p_avail, p_reg, p_ss, p_ps, p_cm:
+            response = client.post("/plugins/test_plugin/demo-page")
+
+        assert response.status_code == 200, response.text
+        page_service.create_demo_page.assert_called_once()
+        passed_schema = page_service.create_demo_page.call_args[0][1]
+        assert passed_schema.device_type == "note", (
+            "Endpoint should resolve device_type from configured board settings, "
+            "not hard-code 'flagship'."
+        )
+
+    def test_defaults_to_configured_board_device_type_flagship(
+        self, client, manifest_with_both_demos, board_settings_with_device
+    ):
+        """When the only configured board is a Flagship, the demo uses the flagship schema."""
+        bs = board_settings_with_device("flagship")
+        p_avail, p_reg, p_ss, p_ps, p_cm, page_service = self._patch_dependencies(
+            manifest_with_both_demos, bs
+        )
+
+        with p_avail, p_reg, p_ss, p_ps, p_cm:
+            response = client.post("/plugins/test_plugin/demo-page")
+
+        assert response.status_code == 200, response.text
+        passed_schema = page_service.create_demo_page.call_args[0][1]
+        assert passed_schema.device_type == "flagship"
+
+    def test_explicit_device_type_query_overrides_settings(
+        self, client, manifest_with_both_demos, board_settings_with_device
+    ):
+        """An explicit ?device_type=flagship still wins over a Note-only configuration."""
+        bs = board_settings_with_device("note")
+        p_avail, p_reg, p_ss, p_ps, p_cm, page_service = self._patch_dependencies(
+            manifest_with_both_demos, bs
+        )
+
+        with p_avail, p_reg, p_ss, p_ps, p_cm:
+            response = client.post("/plugins/test_plugin/demo-page?device_type=flagship")
+
+        assert response.status_code == 200, response.text
+        passed_schema = page_service.create_demo_page.call_args[0][1]
+        assert passed_schema.device_type == "flagship"
+
+    def test_falls_back_to_flagship_when_note_template_missing(
+        self, client, flagship_demo_schema, board_settings_with_device
+    ):
+        """If the plugin only ships a flagship demo, a Note board still gets *something*."""
+        manifest = Mock()
+        manifest.demo = {"flagship": flagship_demo_schema}
+        manifest.settings_schema = {"required": []}
+        bs = board_settings_with_device("note")
+        p_avail, p_reg, p_ss, p_ps, p_cm, page_service = self._patch_dependencies(manifest, bs)
+
+        with p_avail, p_reg, p_ss, p_ps, p_cm:
+            response = client.post("/plugins/test_plugin/demo-page")
+
+        assert response.status_code == 200, response.text
+        passed_schema = page_service.create_demo_page.call_args[0][1]
+        assert passed_schema.device_type == "flagship"

--- a/tests/test_demo_pages.py
+++ b/tests/test_demo_pages.py
@@ -583,9 +583,7 @@ class TestCreateDemoPageEndpoint:
     ):
         """When the only configured board is a Note, the demo must use the note schema."""
         bs = board_settings_with_device("note")
-        p_avail, p_reg, p_ss, p_ps, p_cm, page_service = self._patch_dependencies(
-            manifest_with_both_demos, bs
-        )
+        p_avail, p_reg, p_ss, p_ps, p_cm, page_service = self._patch_dependencies(manifest_with_both_demos, bs)
 
         with p_avail, p_reg, p_ss, p_ps, p_cm:
             response = client.post("/plugins/test_plugin/demo-page")
@@ -594,8 +592,7 @@ class TestCreateDemoPageEndpoint:
         page_service.create_demo_page.assert_called_once()
         passed_schema = page_service.create_demo_page.call_args[0][1]
         assert passed_schema.device_type == "note", (
-            "Endpoint should resolve device_type from configured board settings, "
-            "not hard-code 'flagship'."
+            "Endpoint should resolve device_type from configured board settings, not hard-code 'flagship'."
         )
 
     def test_defaults_to_configured_board_device_type_flagship(
@@ -603,9 +600,7 @@ class TestCreateDemoPageEndpoint:
     ):
         """When the only configured board is a Flagship, the demo uses the flagship schema."""
         bs = board_settings_with_device("flagship")
-        p_avail, p_reg, p_ss, p_ps, p_cm, page_service = self._patch_dependencies(
-            manifest_with_both_demos, bs
-        )
+        p_avail, p_reg, p_ss, p_ps, p_cm, page_service = self._patch_dependencies(manifest_with_both_demos, bs)
 
         with p_avail, p_reg, p_ss, p_ps, p_cm:
             response = client.post("/plugins/test_plugin/demo-page")
@@ -619,9 +614,7 @@ class TestCreateDemoPageEndpoint:
     ):
         """An explicit ?device_type=flagship still wins over a Note-only configuration."""
         bs = board_settings_with_device("note")
-        p_avail, p_reg, p_ss, p_ps, p_cm, page_service = self._patch_dependencies(
-            manifest_with_both_demos, bs
-        )
+        p_avail, p_reg, p_ss, p_ps, p_cm, page_service = self._patch_dependencies(manifest_with_both_demos, bs)
 
         with p_avail, p_reg, p_ss, p_ps, p_cm:
             response = client.post("/plugins/test_plugin/demo-page?device_type=flagship")


### PR DESCRIPTION
## Summary
- Closes #942. `POST /plugins/{id}/demo-page` used to default `device_type` to `"flagship"`, so a Note-only deployment got a 6×22 demo page that clipped on the 3×15 Note display.
- The UI calls this endpoint with no parameters, so the hardcoded default always won regardless of the device configured under Settings → Hardware.
- The endpoint now resolves `device_type` from `BoardSettings.boards` when the query parameter is omitted, falling back to any device type the plugin ships if its preferred one is unsupported. Explicit `?device_type=` still wins.

## TDD
Added four endpoint tests in `tests/test_demo_pages.py::TestCreateDemoPageEndpoint`:
- Note-configured board → demo created with `device_type="note"` (the failing-first regression).
- Flagship-configured board → demo created with `device_type="flagship"`.
- Explicit `?device_type=flagship` overrides a Note configuration.
- Plugin only ships a flagship demo → Note board still receives a usable demo instead of a 400.

## Test plan
- [x] `pytest tests/test_demo_pages.py -v` → 37 passed (4 new).
- [x] `pytest tests/test_api_extended.py tests/test_api_coverage.py tests/test_api_coverage_extended.py` → 373 passed, no regressions.
- [x] `ruff check src/api_server.py tests/test_demo_pages.py` → clean.
- [ ] Manual: with a Note board configured, create a Demo Page for Date & Time and confirm the rendered page fits 3×15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)