### PR TITLE
feat(integrations): edit/delete buttons for plugin demo pages (#943)

### DIFF
--- a/web/app/routes/integrations._index.tsx
+++ b/web/app/routes/integrations._index.tsx
@@ -118,6 +118,7 @@ import {
   Package,
   PartyPopper,
   Pause,
+  Pencil,
   Phone,
   PieChart,
   Pill,
@@ -855,6 +856,8 @@ function PluginCard({
   const [copiedVar, setCopiedVar] = useState<string | null>(null);
   const [isCreatingDemo, setIsCreatingDemo] = useState(false);
   const [showDemoConfirm, setShowDemoConfirm] = useState(false);
+  const [showDeleteDemoConfirm, setShowDeleteDemoConfirm] = useState(false);
+  const [isDeletingDemo, setIsDeletingDemo] = useState(false);
   const [showAddInstance, setShowAddInstance] = useState(false);
   const [instanceLabel, setInstanceLabel] = useState("");
   const [isCreatingInstance, setIsCreatingInstance] = useState(false);
@@ -909,6 +912,24 @@ function PluginCard({
       toast.error(`Failed to create demo page: ${error instanceof Error ? error.message : "Unknown error"}`);
     } finally {
       setIsCreatingDemo(false);
+    }
+  };
+
+  const handleDeleteDemoPage = async () => {
+    const demoPageId = pluginDetails?.demo_page_id;
+    if (!demoPageId) return;
+    setIsDeletingDemo(true);
+    try {
+      await api.deletePage(demoPageId);
+      toast.success(`Demo page deleted for ${plugin.name}`);
+      queryClient.invalidateQueries({ queryKey: ["plugin", plugin.id] });
+      queryClient.invalidateQueries({ queryKey: ["pages"] });
+      queryClient.invalidateQueries({ queryKey: ["pagePreview"] });
+      setShowDeleteDemoConfirm(false);
+    } catch (error) {
+      toast.error(`Failed to delete demo page: ${error instanceof Error ? error.message : "Unknown error"}`);
+    } finally {
+      setIsDeletingDemo(false);
     }
   };
 
@@ -1067,31 +1088,74 @@ function PluginCard({
                       </p>
                     </div>
                     {pluginDetails.demo_page_id ? (
-                      <Dialog open={showDemoConfirm} onOpenChange={setShowDemoConfirm}>
-                        <DialogTrigger asChild>
-                          <Button variant="outline" size="sm" disabled={!areDemoRequirementsMet() || isCreatingDemo}>
-                            <RefreshCw className="h-3.5 w-3.5 mr-1.5" />
-                            Recreate
-                          </Button>
-                        </DialogTrigger>
-                        <DialogContent>
-                          <DialogHeader>
-                            <DialogTitle>Recreate Demo Page?</DialogTitle>
-                            <DialogDescription>
-                              This will delete the existing demo page and create a fresh one with default settings. This
-                              action cannot be undone.
-                            </DialogDescription>
-                          </DialogHeader>
-                          <DialogFooter>
-                            <Button variant="outline" onClick={() => setShowDemoConfirm(false)}>
-                              Cancel
+                      <div className="flex items-center gap-1.5">
+                        <Button variant="outline" size="sm" asChild aria-label="Edit demo page">
+                          <Link href={`/pages/edit/${pluginDetails.demo_page_id}`}>
+                            <Pencil className="h-3.5 w-3.5 mr-1.5" />
+                            Edit
+                          </Link>
+                        </Button>
+                        <Dialog open={showDeleteDemoConfirm} onOpenChange={setShowDeleteDemoConfirm}>
+                          <DialogTrigger asChild>
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              className="text-destructive hover:text-destructive hover:bg-destructive/10"
+                              disabled={isDeletingDemo}
+                              aria-label="Delete demo page"
+                            >
+                              <Trash2 className="h-3.5 w-3.5 mr-1.5" />
+                              Delete
                             </Button>
-                            <Button onClick={handleCreateDemoPage} disabled={isCreatingDemo}>
-                              {isCreatingDemo ? "Creating..." : "Recreate Demo Page"}
+                          </DialogTrigger>
+                          <DialogContent>
+                            <DialogHeader>
+                              <DialogTitle>Delete Demo Page?</DialogTitle>
+                              <DialogDescription>
+                                This will permanently delete the demo page for {plugin.name}. This action cannot be
+                                undone.
+                              </DialogDescription>
+                            </DialogHeader>
+                            <DialogFooter>
+                              <Button variant="outline" onClick={() => setShowDeleteDemoConfirm(false)}>
+                                Cancel
+                              </Button>
+                              <Button
+                                variant="destructive"
+                                onClick={handleDeleteDemoPage}
+                                disabled={isDeletingDemo}
+                              >
+                                {isDeletingDemo ? "Deleting..." : "Delete Demo Page"}
+                              </Button>
+                            </DialogFooter>
+                          </DialogContent>
+                        </Dialog>
+                        <Dialog open={showDemoConfirm} onOpenChange={setShowDemoConfirm}>
+                          <DialogTrigger asChild>
+                            <Button variant="outline" size="sm" disabled={!areDemoRequirementsMet() || isCreatingDemo}>
+                              <RefreshCw className="h-3.5 w-3.5 mr-1.5" />
+                              Recreate
                             </Button>
-                          </DialogFooter>
-                        </DialogContent>
-                      </Dialog>
+                          </DialogTrigger>
+                          <DialogContent>
+                            <DialogHeader>
+                              <DialogTitle>Recreate Demo Page?</DialogTitle>
+                              <DialogDescription>
+                                This will delete the existing demo page and create a fresh one with default settings.
+                                This action cannot be undone.
+                              </DialogDescription>
+                            </DialogHeader>
+                            <DialogFooter>
+                              <Button variant="outline" onClick={() => setShowDemoConfirm(false)}>
+                                Cancel
+                              </Button>
+                              <Button onClick={handleCreateDemoPage} disabled={isCreatingDemo}>
+                                {isCreatingDemo ? "Creating..." : "Recreate Demo Page"}
+                              </Button>
+                            </DialogFooter>
+                          </DialogContent>
+                        </Dialog>
+                      </div>
                     ) : (
                       <Button
                         variant="default"

--- a/web/tests/regression/integrations-plugin-config.spec.ts
+++ b/web/tests/regression/integrations-plugin-config.spec.ts
@@ -315,6 +315,90 @@ test.describe("regression: integrations.plugin (config sheet + lifecycle)", () =
   });
 
   /**
+   * UX node: integrations.plugin.demo-page-edit
+   * Route: /integrations (sheet)
+   * Preconditions: demo-page:already-exists
+   * Interactions: click:edit-demo-page
+   * Expected: navigates to /pages/edit/{demo_page_id} so the user can edit
+   *           the demo page from the same surface that created it (issue #943).
+   * Coverage status: uncovered
+   */
+  test("integrations.plugin.demo-page-edit — Edit button navigates to /pages/edit/{demo_page_id}", async ({ page }) => {
+    // Ensure a demo page exists so the Edit affordance is rendered.
+    const ensureRes = await fetch(`${API_URL}/plugins/${TEST_PLUGIN_ID}/demo-page`, {
+      method: "POST",
+      headers: authHeaders(),
+    });
+    expect(ensureRes.ok).toBeTruthy();
+    const ensured = await ensureRes.json();
+    const demoPageId: string = ensured.page.id;
+    createdDemoPageIds.add(demoPageId);
+
+    await openConfigSheet(page);
+    await expect(page.getByRole("button", { name: "Save Changes" })).toBeEnabled({ timeout: 15_000 });
+
+    const sheet = page.locator('[role="dialog"]').first();
+    const editLink = sheet.getByRole("link", { name: "Edit demo page" });
+    await expect(editLink).toBeVisible({ timeout: 5_000 });
+    await expect(editLink).toHaveAttribute("href", `/pages/edit/${demoPageId}`);
+
+    await editLink.click();
+    await expect(page).toHaveURL(new RegExp(`/pages/edit/${demoPageId}$`), { timeout: 15_000 });
+    await expect(page.getByRole("heading", { name: /Edit Page/i })).toBeVisible({ timeout: 15_000 });
+  });
+
+  /**
+   * UX node: integrations.plugin.demo-page-delete
+   * Route: /integrations (sheet)
+   * Preconditions: demo-page:already-exists
+   * Interactions: click:delete-demo-page → confirm dialog → click:confirm
+   * Expected: confirmation dialog warns about permanence; on confirm the demo
+   *           page is deleted and the section reverts to the "Create Demo Page"
+   *           affordance (issue #943).
+   * Coverage status: uncovered
+   */
+  test("integrations.plugin.demo-page-delete — Delete button removes demo page and toasts success", async ({ page }) => {
+    const ensureRes = await fetch(`${API_URL}/plugins/${TEST_PLUGIN_ID}/demo-page`, {
+      method: "POST",
+      headers: authHeaders(),
+    });
+    expect(ensureRes.ok).toBeTruthy();
+    const ensured = await ensureRes.json();
+    const demoPageId: string = ensured.page.id;
+    // Track for cleanup in case the test fails before deletion runs.
+    createdDemoPageIds.add(demoPageId);
+
+    await openConfigSheet(page);
+    await expect(page.getByRole("button", { name: "Save Changes" })).toBeEnabled({ timeout: 15_000 });
+
+    const sheet = page.locator('[role="dialog"]').first();
+    const deleteBtn = sheet.getByRole("button", { name: "Delete demo page" });
+    await expect(deleteBtn).toBeVisible({ timeout: 5_000 });
+    await deleteBtn.click();
+
+    // Confirmation dialog appears with a clear "cannot be undone" warning.
+    const confirmDialog = page.getByRole("dialog", { name: /Delete Demo Page\?/i });
+    await expect(confirmDialog).toBeVisible({ timeout: 5_000 });
+    await expect(confirmDialog.getByText(/cannot be undone/i)).toBeVisible();
+
+    await confirmDialog.getByRole("button", { name: "Delete Demo Page" }).click();
+
+    // Toast confirms the deletion.
+    await expect(
+      page.getByRole("region", { name: /Notifications/i }).getByText(`Demo page deleted for ${TEST_PLUGIN_NAME}`),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // The section flips back to "Create Demo Page" — Edit/Delete affordances gone.
+    await expect(sheet.getByRole("button", { name: /Create Demo Page/i })).toBeVisible({ timeout: 15_000 });
+    await expect(sheet.getByRole("button", { name: "Delete demo page" })).toHaveCount(0);
+
+    // API confirms the page is actually deleted.
+    const pageRes = await fetch(`${API_URL}/pages/${demoPageId}`, { headers: authHeaders() });
+    expect(pageRes.status).toBe(404);
+    createdDemoPageIds.delete(demoPageId);
+  });
+
+  /**
    * UX node: integrations.plugin.demo-page-recreate-confirm
    * Route: /integrations (sheet)
    * Preconditions: demo-page:already-exists


### PR DESCRIPTION
## Summary

Closes #943.

Adds **Edit** and **Delete** affordances to the *Demo Page* section of the plugin Integrations sheet, alongside the existing *Recreate* button.

The backend already permits `PUT` / `DELETE` on demo pages — and demo pages always appeared in `/pages` where you could edit/delete them — but there was no obvious way to do that from the Integrations sheet where the demo was created. The issue reporter noted this exact gap.

- **Edit** opens `/pages/edit/{demo_page_id}` (re-uses the existing page editor)
- **Delete** opens a confirmation dialog, calls `DELETE /pages/{id}`, invalidates the plugin + pages queries, and the section flips back to *Create Demo Page*

## Test plan

- [x] Manually drove the flow in the dev container against the `date_time` plugin: created a demo → Edit navigates correctly → Delete confirms and removes the page → section reverts to "Create Demo Page".
- [x] New Playwright regression tests in `web/tests/regression/integrations-plugin-config.spec.ts`:
  - `integrations.plugin.demo-page-edit` — Edit link points to `/pages/edit/{id}` and navigates there.
  - `integrations.plugin.demo-page-delete` — Delete button → confirm dialog → page removed (verified via API and UI flips back to *Create Demo Page*).
- [x] Full `integrations-plugin-config.spec.ts` suite runs green (11 passed, 1 pre-existing `test.fixme` skipped).
- [x] `tsc --noEmit` adds no new errors (the one pre-existing `SchemaForm` error is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)