### PR TITLE
feat(schedule): show silence schedule as overlay on calendar

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1168,6 +1168,23 @@
   animation: card-fade-in 1s cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 
+/* Brief highlight when a settings card is jumped to via a hash anchor.
+   Drives the click-to-details flow from the Schedule page → silence card. */
+@keyframes settings-anchor-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 transparent;
+  }
+  20%,
+  60% {
+    box-shadow: 0 0 0 4px color-mix(in oklch, var(--primary) 45%, transparent);
+  }
+}
+
+.settings-anchor-highlight {
+  animation: settings-anchor-pulse 2.2s ease-in-out;
+}
+
 /* Type scale: ratio 1.25; body 1rem (16px). Tailwind text-xs/sm/base/lg/xl/2xl/3xl/4xl align. */
 /* Page typography - consistent titles and descriptions */
 .page-title {

--- a/web/app/routes/schedule.tsx
+++ b/web/app/routes/schedule.tsx
@@ -9,7 +9,7 @@ import {
   Plus,
   Power,
 } from "lucide-react";
-import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { PageHeader } from "@/components/page-header";
@@ -54,8 +54,10 @@ import {
   type ScheduleCreate,
   type ScheduleEntry,
   type ScheduleUpdate,
+  type SilenceMode,
 } from "@/lib/api";
-import { extractTimeFromDate, getDayNameFromDate } from "@/lib/schedule-calendar";
+import { extractTimeFromDate, getDayNameFromDate, type ResolvedSilenceSchedule } from "@/lib/schedule-calendar";
+import { utcToLocalTime } from "@/lib/timezone-utils";
 import { cn } from "@/lib/utils";
 
 // Lazy load ScheduleCalendarView since it includes react-big-calendar (~150KB+)
@@ -203,6 +205,37 @@ export default function SchedulePage() {
     queryFn: () => api.validateSchedules(effectiveBoardId || undefined),
     enabled: (schedulesData?.schedules.length || 0) > 0,
   });
+
+  // Fetch silence schedule + user timezone so we can render the silence window
+  // as a read-only overlay on the calendar/list views. Reuses the same query
+  // key as the settings page so a save there refreshes both pages.
+  const { data: allSettings } = useQuery({
+    queryKey: ["all-settings"],
+    queryFn: api.getAllSettings,
+  });
+
+  const resolvedSilenceSchedule = useMemo<ResolvedSilenceSchedule | null>(() => {
+    const config = allSettings?.silence_schedule?.config;
+    const timezone = allSettings?.general?.timezone ?? "America/Los_Angeles";
+    if (!config || !config.start_time || !config.end_time) return null;
+    const startLocal = utcToLocalTime(config.start_time, timezone);
+    const endLocal = utcToLocalTime(config.end_time, timezone);
+    if (!startLocal || !endLocal) return null;
+    const rawMode = (config.mode as string | undefined) ?? "indicator";
+    const mode: SilenceMode = rawMode === "freeze" || rawMode === "page" ? rawMode : "indicator";
+    return {
+      enabled: !!config.enabled,
+      startTimeLocal: startLocal,
+      endTimeLocal: endLocal,
+      mode,
+      indicatorText: config.indicator_text ?? null,
+      pageId: config.page_id ?? null,
+    };
+  }, [allSettings]);
+
+  const handleSilenceClick = useCallback(() => {
+    router.push("/settings?section=behavior#silence-schedule");
+  }, [router]);
 
   // Toggle schedule (per board when multi-board)
   const toggleSchedule = useMutation({
@@ -652,9 +685,11 @@ export default function SchedulePage() {
           schedules={schedules}
           pages={pages}
           collections={collectionsData?.collections}
+          silenceSchedule={resolvedSilenceSchedule}
           onEdit={handleEdit}
           onDelete={handleDelete}
           onToggleEnabled={handleToggleEnabled}
+          onSilenceClick={handleSilenceClick}
         />
       ) : (
         /* Calendar card: grows to fill remaining space in the pinned layout */
@@ -671,9 +706,11 @@ export default function SchedulePage() {
               pages={pages}
               collections={collectionsData?.collections}
               overlaps={validation?.overlaps}
+              silenceSchedule={resolvedSilenceSchedule}
               onEventClick={handleEventClick}
               onSlotSelect={handleSlotSelect}
               onEventTimeChange={handleEventTimeChange}
+              onSilenceClick={handleSilenceClick}
             />
           </CardContent>
         </Card>

--- a/web/app/routes/settings.tsx
+++ b/web/app/routes/settings.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import type { LucideIcon } from "lucide-react";
 import { Cog, MonitorCog, Plug, Settings, ShieldCheck, User, Wand2, Waves, Wifi, Wrench } from "lucide-react";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 
 import { AccountSection } from "@/components/account-section";
 import { PageHeader } from "@/components/page-header";
@@ -107,6 +107,23 @@ export default function SettingsPage() {
   if (activeSection === "network" && !showNetwork) {
     activeSection = DEFAULT_SECTION;
   }
+
+  // Scroll to a hash anchor (e.g. #silence-schedule) when the active tab
+  // mounts, and pulse the target card so the user can see what they navigated
+  // to. Driven by deep-links like /settings?section=behavior#silence-schedule.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const hash = window.location.hash.replace(/^#/, "");
+    if (!hash) return;
+    const timer = setTimeout(() => {
+      const el = document.getElementById(hash);
+      if (!el) return;
+      el.scrollIntoView({ behavior: "smooth", block: "start" });
+      el.classList.add("settings-anchor-highlight");
+      setTimeout(() => el.classList.remove("settings-anchor-highlight"), 2200);
+    }, 120);
+    return () => clearTimeout(timer);
+  }, [activeSection]);
 
   const handleSectionChange = useCallback(
     (id: string) => {

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -338,6 +338,12 @@
     "editScheduleAriaLabel": "Zeitplan für {pageName} bearbeiten",
     "deleteScheduleAriaLabel": "Zeitplan für {pageName} löschen",
     "openLabel": "offen",
+    "silenceEventTitle": "Silence",
+    "silenceScheduleListTitle": "Silence Schedule",
+    "silenceEventAriaLabel": "Silence schedule, {range}, opens settings",
+    "silenceModeIndicatorSubtitle": "Indicator: {text}",
+    "silenceModeFreezeSubtitle": "Board frozen",
+    "silenceModePageSubtitle": "Page: {name}",
     "dayLabels": {
       "allDays": "Alle Tage",
       "monFri": "Mo-Fr",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -295,6 +295,12 @@
     "editScheduleAriaLabel": "Edit schedule for {pageName}",
     "deleteScheduleAriaLabel": "Delete schedule for {pageName}",
     "openLabel": "open",
+    "silenceEventTitle": "Silence",
+    "silenceScheduleListTitle": "Silence Schedule",
+    "silenceEventAriaLabel": "Silence schedule, {range}, opens settings",
+    "silenceModeIndicatorSubtitle": "Indicator: {text}",
+    "silenceModeFreezeSubtitle": "Board frozen",
+    "silenceModePageSubtitle": "Page: {name}",
     "dayLabels": {
       "allDays": "All days",
       "monFri": "Mon-Fri",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -338,6 +338,12 @@
     "editScheduleAriaLabel": "Editar horario para {pageName}",
     "deleteScheduleAriaLabel": "Eliminar horario para {pageName}",
     "openLabel": "abierto",
+    "silenceEventTitle": "Silence",
+    "silenceScheduleListTitle": "Silence Schedule",
+    "silenceEventAriaLabel": "Silence schedule, {range}, opens settings",
+    "silenceModeIndicatorSubtitle": "Indicator: {text}",
+    "silenceModeFreezeSubtitle": "Board frozen",
+    "silenceModePageSubtitle": "Page: {name}",
     "dayLabels": {
       "allDays": "Todos los días",
       "monFri": "Lun-Vie",

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -338,6 +338,12 @@
     "editScheduleAriaLabel": "Modifier le planning pour {pageName}",
     "deleteScheduleAriaLabel": "Supprimer le planning pour {pageName}",
     "openLabel": "ouvert",
+    "silenceEventTitle": "Silence",
+    "silenceScheduleListTitle": "Silence Schedule",
+    "silenceEventAriaLabel": "Silence schedule, {range}, opens settings",
+    "silenceModeIndicatorSubtitle": "Indicator: {text}",
+    "silenceModeFreezeSubtitle": "Board frozen",
+    "silenceModePageSubtitle": "Page: {name}",
     "dayLabels": {
       "allDays": "Tous les jours",
       "monFri": "Lun-Ven",

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -338,6 +338,12 @@
     "editScheduleAriaLabel": "Modifica pianificazione per {pageName}",
     "deleteScheduleAriaLabel": "Elimina pianificazione per {pageName}",
     "openLabel": "aperto",
+    "silenceEventTitle": "Silence",
+    "silenceScheduleListTitle": "Silence Schedule",
+    "silenceEventAriaLabel": "Silence schedule, {range}, opens settings",
+    "silenceModeIndicatorSubtitle": "Indicator: {text}",
+    "silenceModeFreezeSubtitle": "Board frozen",
+    "silenceModePageSubtitle": "Page: {name}",
     "dayLabels": {
       "allDays": "Tutti i giorni",
       "monFri": "Lun-Ven",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -338,6 +338,12 @@
     "editScheduleAriaLabel": "{pageName} のスケジュールを編集",
     "deleteScheduleAriaLabel": "{pageName} のスケジュールを削除",
     "openLabel": "開く",
+    "silenceEventTitle": "Silence",
+    "silenceScheduleListTitle": "Silence Schedule",
+    "silenceEventAriaLabel": "Silence schedule, {range}, opens settings",
+    "silenceModeIndicatorSubtitle": "Indicator: {text}",
+    "silenceModeFreezeSubtitle": "Board frozen",
+    "silenceModePageSubtitle": "Page: {name}",
     "dayLabels": {
       "allDays": "毎日",
       "monFri": "月-金",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -338,6 +338,12 @@
     "editScheduleAriaLabel": "{pageName}의 일정 편집",
     "deleteScheduleAriaLabel": "{pageName}의 일정 삭제",
     "openLabel": "열림",
+    "silenceEventTitle": "Silence",
+    "silenceScheduleListTitle": "Silence Schedule",
+    "silenceEventAriaLabel": "Silence schedule, {range}, opens settings",
+    "silenceModeIndicatorSubtitle": "Indicator: {text}",
+    "silenceModeFreezeSubtitle": "Board frozen",
+    "silenceModePageSubtitle": "Page: {name}",
     "dayLabels": {
       "allDays": "매일",
       "monFri": "월-금",

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -338,6 +338,12 @@
     "editScheduleAriaLabel": "Rooster voor {pageName} bewerken",
     "deleteScheduleAriaLabel": "Rooster voor {pageName} verwijderen",
     "openLabel": "open",
+    "silenceEventTitle": "Silence",
+    "silenceScheduleListTitle": "Silence Schedule",
+    "silenceEventAriaLabel": "Silence schedule, {range}, opens settings",
+    "silenceModeIndicatorSubtitle": "Indicator: {text}",
+    "silenceModeFreezeSubtitle": "Board frozen",
+    "silenceModePageSubtitle": "Page: {name}",
     "dayLabels": {
       "allDays": "Alle dagen",
       "monFri": "Ma-Vr",

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -338,6 +338,12 @@
     "editScheduleAriaLabel": "Edytuj harmonogram dla {pageName}",
     "deleteScheduleAriaLabel": "Usuń harmonogram dla {pageName}",
     "openLabel": "otwarty",
+    "silenceEventTitle": "Silence",
+    "silenceScheduleListTitle": "Silence Schedule",
+    "silenceEventAriaLabel": "Silence schedule, {range}, opens settings",
+    "silenceModeIndicatorSubtitle": "Indicator: {text}",
+    "silenceModeFreezeSubtitle": "Board frozen",
+    "silenceModePageSubtitle": "Page: {name}",
     "dayLabels": {
       "allDays": "Wszystkie dni",
       "monFri": "Pon-Pt",

--- a/web/messages/pt.json
+++ b/web/messages/pt.json
@@ -338,6 +338,12 @@
     "editScheduleAriaLabel": "Editar agendamento para {pageName}",
     "deleteScheduleAriaLabel": "Eliminar agendamento para {pageName}",
     "openLabel": "aberto",
+    "silenceEventTitle": "Silence",
+    "silenceScheduleListTitle": "Silence Schedule",
+    "silenceEventAriaLabel": "Silence schedule, {range}, opens settings",
+    "silenceModeIndicatorSubtitle": "Indicator: {text}",
+    "silenceModeFreezeSubtitle": "Board frozen",
+    "silenceModePageSubtitle": "Page: {name}",
     "dayLabels": {
       "allDays": "Todos os dias",
       "monFri": "Seg-Sex",

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -338,6 +338,12 @@
     "editScheduleAriaLabel": "Редактировать расписание для {pageName}",
     "deleteScheduleAriaLabel": "Удалить расписание для {pageName}",
     "openLabel": "открыто",
+    "silenceEventTitle": "Silence",
+    "silenceScheduleListTitle": "Silence Schedule",
+    "silenceEventAriaLabel": "Silence schedule, {range}, opens settings",
+    "silenceModeIndicatorSubtitle": "Indicator: {text}",
+    "silenceModeFreezeSubtitle": "Board frozen",
+    "silenceModePageSubtitle": "Page: {name}",
     "dayLabels": {
       "allDays": "Все дни",
       "monFri": "Пн-Пт",

--- a/web/messages/sv.json
+++ b/web/messages/sv.json
@@ -338,6 +338,12 @@
     "editScheduleAriaLabel": "Redigera schema för {pageName}",
     "deleteScheduleAriaLabel": "Ta bort schema för {pageName}",
     "openLabel": "öppet",
+    "silenceEventTitle": "Silence",
+    "silenceScheduleListTitle": "Silence Schedule",
+    "silenceEventAriaLabel": "Silence schedule, {range}, opens settings",
+    "silenceModeIndicatorSubtitle": "Indicator: {text}",
+    "silenceModeFreezeSubtitle": "Board frozen",
+    "silenceModePageSubtitle": "Page: {name}",
     "dayLabels": {
       "allDays": "Alla dagar",
       "monFri": "Mån-Fre",

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -338,6 +338,12 @@
     "editScheduleAriaLabel": "{pageName} için zamanlamayı düzenle",
     "deleteScheduleAriaLabel": "{pageName} için zamanlamayı sil",
     "openLabel": "açık",
+    "silenceEventTitle": "Silence",
+    "silenceScheduleListTitle": "Silence Schedule",
+    "silenceEventAriaLabel": "Silence schedule, {range}, opens settings",
+    "silenceModeIndicatorSubtitle": "Indicator: {text}",
+    "silenceModeFreezeSubtitle": "Board frozen",
+    "silenceModePageSubtitle": "Page: {name}",
     "dayLabels": {
       "allDays": "Tüm günler",
       "monFri": "Pzt-Cum",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -338,6 +338,12 @@
     "editScheduleAriaLabel": "编辑 {pageName} 的计划",
     "deleteScheduleAriaLabel": "删除 {pageName} 的计划",
     "openLabel": "打开",
+    "silenceEventTitle": "Silence",
+    "silenceScheduleListTitle": "Silence Schedule",
+    "silenceEventAriaLabel": "Silence schedule, {range}, opens settings",
+    "silenceModeIndicatorSubtitle": "Indicator: {text}",
+    "silenceModeFreezeSubtitle": "Board frozen",
+    "silenceModePageSubtitle": "Page: {name}",
     "dayLabels": {
       "allDays": "每天",
       "monFri": "周一-周五",

--- a/web/src/__tests__/schedule-calendar-extended.test.ts
+++ b/web/src/__tests__/schedule-calendar-extended.test.ts
@@ -292,6 +292,7 @@ describe("schedule-calendar extended", () => {
         start: new Date(2025, 0, 6, 9, 0),
         end: new Date(2025, 0, 6, 17, 0),
         resource: {
+          kind: "schedule",
           scheduleId: "s1",
           pageId: "p1",
           pageName: "Test",
@@ -310,6 +311,7 @@ describe("schedule-calendar extended", () => {
         start: new Date(2025, 0, 6, 9, 0),
         end: new Date(2025, 0, 6, 17, 0),
         resource: {
+          kind: "schedule",
           scheduleId: "s1",
           pageId: "p1",
           pageName: "Test",

--- a/web/src/__tests__/silence-to-calendar-events.test.ts
+++ b/web/src/__tests__/silence-to-calendar-events.test.ts
@@ -1,0 +1,108 @@
+import { startOfWeek } from "date-fns";
+import { describe, expect, it } from "vitest";
+
+import type { Page } from "@/lib/api";
+import { type ResolvedSilenceSchedule, silenceToCalendarEvents } from "@/lib/schedule-calendar";
+
+// Fixed reference date: a known Sunday
+const WEEK_START = startOfWeek(new Date(2025, 0, 5), { weekStartsOn: 0 }); // Sun Jan 5 2025
+
+const MOCK_PAGES: Page[] = [
+  {
+    id: "page1",
+    name: "Night Page",
+    type: "template",
+    device_type: "flagship",
+    duration_seconds: 30,
+    created_at: "2025-01-01T00:00:00Z",
+  },
+];
+
+function makeSilence(overrides: Partial<ResolvedSilenceSchedule> = {}): ResolvedSilenceSchedule {
+  return {
+    enabled: true,
+    startTimeLocal: "13:00",
+    endTimeLocal: "14:00",
+    mode: "indicator",
+    indicatorText: "SNOOZING",
+    pageId: null,
+    ...overrides,
+  };
+}
+
+describe("silenceToCalendarEvents", () => {
+  it("returns no events when silence is null", () => {
+    expect(silenceToCalendarEvents(null, WEEK_START, MOCK_PAGES)).toEqual([]);
+  });
+
+  it("returns no events when silence is disabled", () => {
+    expect(silenceToCalendarEvents(makeSilence({ enabled: false }), WEEK_START, MOCK_PAGES)).toEqual([]);
+  });
+
+  it("returns no events when start and end are identical (no real window)", () => {
+    const events = silenceToCalendarEvents(
+      makeSilence({ startTimeLocal: "10:00", endTimeLocal: "10:00" }),
+      WEEK_START,
+      MOCK_PAGES,
+    );
+    expect(events).toEqual([]);
+  });
+
+  it("creates one block per day for a same-day window", () => {
+    const events = silenceToCalendarEvents(makeSilence(), WEEK_START, MOCK_PAGES);
+    expect(events).toHaveLength(7);
+    expect(events.every((e) => e.resource.kind === "silence")).toBe(true);
+    expect(events.every((e) => e.title === "Silence")).toBe(true);
+    expect(events.every((e) => !e.resource.isMidnightSplit)).toBe(true);
+  });
+
+  it("splits a midnight-crossing window into evening + morning halves", () => {
+    const silence = makeSilence({ startTimeLocal: "22:00", endTimeLocal: "06:00" });
+    const events = silenceToCalendarEvents(silence, WEEK_START, MOCK_PAGES);
+    // 7 days × 2 halves each = 14 events
+    expect(events).toHaveLength(14);
+    const evening = events.filter(
+      (e) => e.resource.kind === "silence" && e.resource.isMidnightSplit && e.resource.splitPart === "evening",
+    );
+    const morning = events.filter(
+      (e) => e.resource.kind === "silence" && e.resource.isMidnightSplit && e.resource.splitPart === "morning",
+    );
+    expect(evening).toHaveLength(7);
+    expect(morning).toHaveLength(7);
+  });
+
+  it("wraps Saturday's morning continuation back to the same week's Sunday", () => {
+    const silence = makeSilence({ startTimeLocal: "22:00", endTimeLocal: "06:00" });
+    const events = silenceToCalendarEvents(silence, WEEK_START, MOCK_PAGES);
+    // The last morning block (Saturday's continuation) should be on the
+    // week-start (Sunday Jan 5), not the next Sunday (Jan 12).
+    const morningIds = events
+      .filter((e) => e.resource.kind === "silence" && e.resource.splitPart === "morning")
+      .map((e) => e.id);
+    expect(morningIds).toContain("silence-2025-01-05-morning");
+  });
+
+  it("resolves the page name when mode is 'page'", () => {
+    const silence = makeSilence({ mode: "page", pageId: "page1" });
+    const events = silenceToCalendarEvents(silence, WEEK_START, MOCK_PAGES);
+    expect(events[0]?.resource.kind).toBe("silence");
+    if (events[0]?.resource.kind === "silence") {
+      expect(events[0].resource.pageName).toBe("Night Page");
+    }
+  });
+
+  it("falls back to null pageName when the configured page is missing", () => {
+    const silence = makeSilence({ mode: "page", pageId: "missing-id" });
+    const events = silenceToCalendarEvents(silence, WEEK_START, MOCK_PAGES);
+    if (events[0]?.resource.kind === "silence") {
+      expect(events[0].resource.pageName).toBeNull();
+    }
+  });
+
+  it("leaves pageName null for non-page modes", () => {
+    const events = silenceToCalendarEvents(makeSilence({ mode: "freeze" }), WEEK_START, MOCK_PAGES);
+    if (events[0]?.resource.kind === "silence") {
+      expect(events[0].resource.pageName).toBeNull();
+    }
+  });
+});

--- a/web/src/components/schedule/schedule-calendar-view.tsx
+++ b/web/src/components/schedule/schedule-calendar-view.tsx
@@ -14,7 +14,13 @@ import { Slider } from "@/components/ui/slider";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import type { Collection, Overlap, Page, ScheduleEntry } from "@/lib/api";
 import { api } from "@/lib/api";
-import { type CalendarEvent, extractTimeFromDate, schedulesToCalendarEvents } from "@/lib/schedule-calendar";
+import {
+  type CalendarEvent,
+  extractTimeFromDate,
+  type ResolvedSilenceSchedule,
+  schedulesToCalendarEvents,
+  silenceToCalendarEvents,
+} from "@/lib/schedule-calendar";
 
 import { ScheduleEvent } from "./schedule-event";
 
@@ -62,9 +68,11 @@ interface ScheduleCalendarViewProps {
   pages: Page[];
   collections?: Collection[];
   overlaps?: Overlap[];
+  silenceSchedule?: ResolvedSilenceSchedule | null;
   onEventClick: (schedule: ScheduleEntry) => void;
   onSlotSelect: (start: Date, end: Date) => void;
   onEventTimeChange: (scheduleId: string, startTime: string, endTime: string | null) => void;
+  onSilenceClick?: () => void;
 }
 
 export function ScheduleCalendarView({
@@ -72,9 +80,11 @@ export function ScheduleCalendarView({
   pages,
   collections = [],
   overlaps = [],
+  silenceSchedule = null,
   onEventClick,
   onSlotSelect,
   onEventTimeChange,
+  onSilenceClick,
 }: ScheduleCalendarViewProps) {
   // Track mobile state
   const [isMobile, setIsMobile] = useState(false);
@@ -152,10 +162,11 @@ export function ScheduleCalendarView({
   }, [weekStart]);
 
   // Transform schedules to calendar events
-  const events = useMemo(
-    () => schedulesToCalendarEvents(schedules, weekStart, pages, collections, sunTimesMap),
-    [schedules, weekStart, pages, collections, sunTimesMap],
-  );
+  const events = useMemo(() => {
+    const scheduleEvents = schedulesToCalendarEvents(schedules, weekStart, pages, collections, sunTimesMap);
+    const silenceEvents = silenceToCalendarEvents(silenceSchedule, weekStart, pages);
+    return [...scheduleEvents, ...silenceEvents];
+  }, [schedules, weekStart, pages, collections, sunTimesMap, silenceSchedule]);
 
   // Get IDs of schedules that have overlaps
   const overlappingScheduleIds = useMemo(() => {
@@ -170,9 +181,13 @@ export function ScheduleCalendarView({
   // Handle event click
   const handleSelectEvent = useCallback(
     (event: CalendarEvent) => {
+      if (event.resource.kind === "silence") {
+        onSilenceClick?.();
+        return;
+      }
       onEventClick(event.resource.originalSchedule);
     },
-    [onEventClick],
+    [onEventClick, onSilenceClick],
   );
 
   // Handle slot selection (clicking empty time)
@@ -186,6 +201,10 @@ export function ScheduleCalendarView({
   // Handle event drag (move) or resize
   const handleEventDropOrResize = useCallback(
     ({ event, start, end }: EventInteractionArgs<CalendarEvent>) => {
+      // Silence events are read-only — guard even though draggable/resizable
+      // accessors should prevent this from firing.
+      if (event.resource.kind === "silence") return;
+
       const startTime = extractTimeFromDate(start as Date);
       const endTime = extractTimeFromDate(end as Date);
 
@@ -221,6 +240,9 @@ export function ScheduleCalendarView({
   // Custom event prop getter for styling
   const eventPropGetter = useCallback(
     (event: CalendarEvent) => {
+      if (event.resource.kind === "silence") {
+        return { className: "schedule-event schedule-event-silence" };
+      }
       const isOverlapping = overlappingScheduleIds.has(event.resource.scheduleId);
       const isDisabled = !event.resource.enabled;
 
@@ -420,8 +442,10 @@ export function ScheduleCalendarView({
             tooltipAccessor={(event: CalendarEvent) =>
               `${event.title}\n${format(event.start, "h:mm a")} - ${format(event.end, "h:mm a")}`
             }
-            draggableAccessor={(event: CalendarEvent) => !event.resource.isMidnightSplit}
-            resizableAccessor={() => true}
+            draggableAccessor={(event: CalendarEvent) =>
+              event.resource.kind !== "silence" && !event.resource.isMidnightSplit
+            }
+            resizableAccessor={(event: CalendarEvent) => event.resource.kind !== "silence"}
             longPressThreshold={150}
           />
         </div>

--- a/web/src/components/schedule/schedule-event.tsx
+++ b/web/src/components/schedule/schedule-event.tsx
@@ -1,15 +1,35 @@
 import { format } from "date-fns";
+import { Moon } from "lucide-react";
 import { useMemo } from "react";
 import type { EventProps } from "react-big-calendar";
 
 import { Badge } from "@/components/ui/badge";
-import { type CalendarEvent, formatDayPattern, getPageColor, getPageColorLight } from "@/lib/schedule-calendar";
+import { useTranslations } from "@/i18n/translations";
+import {
+  type CalendarEvent,
+  formatDayPattern,
+  getPageColor,
+  getPageColorLight,
+  type ScheduleCalendarEvent,
+  type SilenceCalendarEvent,
+} from "@/lib/schedule-calendar";
 
 interface ScheduleEventProps extends EventProps<CalendarEvent> {
   event: CalendarEvent;
 }
 
+function isSilenceEvent(event: CalendarEvent): event is SilenceCalendarEvent {
+  return event.resource.kind === "silence";
+}
+
 export function ScheduleEvent({ event }: ScheduleEventProps) {
+  if (isSilenceEvent(event)) {
+    return <SilenceEvent event={event} />;
+  }
+  return <RegularScheduleEvent event={event} />;
+}
+
+function RegularScheduleEvent({ event }: { event: ScheduleCalendarEvent }) {
   const { resource } = event;
 
   // Generate consistent color based on schedule ID (so each schedule entry has unique color)
@@ -92,6 +112,64 @@ export function ScheduleEvent({ event }: ScheduleEventProps) {
         {resource.dayPattern !== "all" && (
           <span className="text-[10px] text-muted-foreground truncate">{dayPatternDisplay}</span>
         )}
+      </div>
+    </div>
+  );
+}
+
+function SilenceEvent({ event }: { event: SilenceCalendarEvent }) {
+  const t = useTranslations("schedule");
+  const { resource } = event;
+
+  const { timeRange, continuationHint } = useMemo(() => {
+    const [sH, sM] = resource.startTimeLocal.split(":").map(Number);
+    const [eH, eM] = resource.endTimeLocal.split(":").map(Number);
+    const fullStart = format(new Date(2000, 0, 1, sH, sM), "h:mma").toLowerCase();
+    const fullEnd = format(new Date(2000, 0, 1, eH, eM), "h:mma").toLowerCase();
+    if (resource.isMidnightSplit) {
+      if (resource.splitPart === "evening") {
+        return { timeRange: `${fullStart} - 12:00am`, continuationHint: `→ ${fullEnd}` };
+      }
+      return { timeRange: `12:00am - ${fullEnd}`, continuationHint: `${fullStart} →` };
+    }
+    return { timeRange: `${fullStart} - ${fullEnd}`, continuationHint: null };
+  }, [resource.startTimeLocal, resource.endTimeLocal, resource.isMidnightSplit, resource.splitPart]);
+
+  const subtitle = useMemo(() => {
+    if (resource.mode === "indicator") {
+      return t("silenceModeIndicatorSubtitle", { text: resource.indicatorText || "SNOOZING" });
+    }
+    if (resource.mode === "freeze") {
+      return t("silenceModeFreezeSubtitle");
+    }
+    return t("silenceModePageSubtitle", { name: resource.pageName || "" });
+  }, [t, resource.mode, resource.indicatorText, resource.pageName]);
+
+  const isMorningSplit = resource.isMidnightSplit && resource.splitPart === "morning";
+  const isEveningSplit = resource.isMidnightSplit && resource.splitPart === "evening";
+
+  return (
+    <div
+      className="schedule-event-content h-full w-full overflow-hidden rounded px-1.5 py-1"
+      data-testid="calendar-event-silence"
+      data-split={resource.isMidnightSplit ? resource.splitPart : "none"}
+      role="button"
+      tabIndex={0}
+      aria-label={t("silenceEventAriaLabel", { range: timeRange })}
+    >
+      <div className="flex flex-col gap-0">
+        {isMorningSplit && continuationHint && (
+          <span className="text-[8px] leading-tight truncate opacity-85">{continuationHint}</span>
+        )}
+        <div className="flex items-center gap-1">
+          <Moon className="h-2.5 w-2.5 flex-shrink-0" aria-hidden="true" />
+          <span className="font-medium text-[10px] leading-tight truncate">{t("silenceEventTitle")}</span>
+        </div>
+        <span className="text-[9px] font-medium truncate">{timeRange}</span>
+        {isEveningSplit && continuationHint && (
+          <span className="text-[8px] leading-tight truncate opacity-85">{continuationHint}</span>
+        )}
+        <span className="text-[9px] truncate opacity-80">{subtitle}</span>
       </div>
     </div>
   );

--- a/web/src/components/schedule/schedule-list-view.tsx
+++ b/web/src/components/schedule/schedule-list-view.tsx
@@ -1,4 +1,5 @@
-import { Calendar, Edit, GalleryHorizontalEnd, Trash2 } from "lucide-react";
+import { format } from "date-fns";
+import { Calendar, ChevronRight, Edit, GalleryHorizontalEnd, Moon, Trash2 } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -8,14 +9,17 @@ import { Switch } from "@/components/ui/switch";
 import { useTranslations } from "@/i18n/translations";
 import type { Collection, Page, ScheduleEntry } from "@/lib/api";
 import { isCollectionId } from "@/lib/api";
+import type { ResolvedSilenceSchedule } from "@/lib/schedule-calendar";
 
 interface ScheduleListViewProps {
   schedules: ScheduleEntry[];
   pages: Page[];
   collections?: Collection[];
+  silenceSchedule?: ResolvedSilenceSchedule | null;
   onEdit: (schedule: ScheduleEntry) => void;
   onDelete: (id: string) => void;
   onToggleEnabled?: (schedule: ScheduleEntry, enabled: boolean) => void;
+  onSilenceClick?: () => void;
 }
 
 const DAY_KEYS: Record<string, "monday" | "tuesday" | "wednesday" | "thursday" | "friday" | "saturday" | "sunday"> = {
@@ -98,13 +102,17 @@ export function ScheduleListView({
   schedules,
   pages,
   collections = [],
+  silenceSchedule = null,
   onEdit,
   onDelete,
   onToggleEnabled,
+  onSilenceClick,
 }: ScheduleListViewProps) {
   const t = useTranslations("schedule");
   const tCommon = useTranslations("common");
   const { formatDays, formatTimeDisplay } = useFormatters();
+
+  const showSilenceRow = !!silenceSchedule?.enabled;
 
   const getPageName = (pageId: string): string => {
     if (isCollectionId(pageId)) {
@@ -114,13 +122,52 @@ export function ScheduleListView({
     return pages.find((p) => p.id === pageId)?.name || pageId;
   };
 
+  const renderSilenceRow = () => {
+    if (!showSilenceRow || !silenceSchedule) return null;
+    const [sH, sM] = silenceSchedule.startTimeLocal.split(":").map(Number);
+    const [eH, eM] = silenceSchedule.endTimeLocal.split(":").map(Number);
+    const startLabel = format(new Date(2000, 0, 1, sH, sM), "h:mm a");
+    const endLabel = format(new Date(2000, 0, 1, eH, eM), "h:mm a");
+    const timeRange = `${startLabel} – ${endLabel}`;
+    const subtitle =
+      silenceSchedule.mode === "indicator"
+        ? t("silenceModeIndicatorSubtitle", { text: silenceSchedule.indicatorText || "SNOOZING" })
+        : silenceSchedule.mode === "freeze"
+          ? t("silenceModeFreezeSubtitle")
+          : t("silenceModePageSubtitle", {
+              name:
+                pages.find((p) => p.id === silenceSchedule.pageId)?.name || silenceSchedule.pageId || "",
+            });
+
+    return (
+      <button
+        type="button"
+        onClick={onSilenceClick}
+        aria-label={t("silenceEventAriaLabel", { range: timeRange })}
+        className="w-full text-left flex items-center justify-between p-4 border rounded-lg bg-muted/30 hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring transition-colors"
+        data-testid="schedule-list-silence-row"
+      >
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <Moon className="h-4 w-4 text-muted-foreground flex-shrink-0" aria-hidden="true" />
+            <span className="font-medium">{t("silenceScheduleListTitle")}</span>
+          </div>
+          <div className="text-sm text-muted-foreground truncate">
+            {timeRange} • {subtitle}
+          </div>
+        </div>
+        <ChevronRight className="h-4 w-4 text-muted-foreground flex-shrink-0 ml-2" aria-hidden="true" />
+      </button>
+    );
+  };
+
   return (
     <Card className="mb-6">
       <CardHeader>
         <CardTitle className="text-lg">{t("scheduleEntriesTitle")}</CardTitle>
       </CardHeader>
       <CardContent>
-        {schedules.length === 0 ? (
+        {schedules.length === 0 && !showSilenceRow ? (
           <div className="text-center py-12 text-muted-foreground">
             <Calendar className="h-12 w-12 mx-auto mb-4" />
             <p>{t("noSchedulesCreated")}</p>
@@ -128,6 +175,7 @@ export function ScheduleListView({
           </div>
         ) : (
           <div className="space-y-3">
+            {renderSilenceRow()}
             {schedules.map((schedule) => {
               const pageName = getPageName(schedule.page_id);
               const toggleId = `schedule-enabled-${schedule.id}`;

--- a/web/src/components/schedule/schedule-list-view.tsx
+++ b/web/src/components/schedule/schedule-list-view.tsx
@@ -135,8 +135,7 @@ export function ScheduleListView({
         : silenceSchedule.mode === "freeze"
           ? t("silenceModeFreezeSubtitle")
           : t("silenceModePageSubtitle", {
-              name:
-                pages.find((p) => p.id === silenceSchedule.pageId)?.name || silenceSchedule.pageId || "",
+              name: pages.find((p) => p.id === silenceSchedule.pageId)?.name || silenceSchedule.pageId || "",
             });
 
     return (

--- a/web/src/components/settings/silence-schedule.tsx
+++ b/web/src/components/settings/silence-schedule.tsx
@@ -159,7 +159,7 @@ export function SilenceSchedule() {
   ]);
 
   return (
-    <Card>
+    <Card id="silence-schedule" className="scroll-mt-24">
       <CardHeader>
         <CardTitle className="flex items-center gap-2 text-base">
           <Moon className="h-4 w-4" />

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -746,9 +746,25 @@ export interface SunTimesWeekResponse {
   dates: Record<string, { sunrise: string; sunset: string }>;
 }
 
+export type SilenceMode = "indicator" | "freeze" | "page";
+
+export interface SilenceScheduleConfig {
+  enabled: boolean;
+  start_time: string;
+  end_time: string;
+  mode: SilenceMode;
+  page_id: string | null;
+  indicator_text: string | null;
+  indicator_position: string | null;
+}
+
+export interface SilenceScheduleSettings {
+  config?: Partial<SilenceScheduleConfig>;
+}
+
 export interface AllSettingsResponse {
   general: GeneralConfig;
-  silence_schedule: Record<string, unknown>;
+  silence_schedule: SilenceScheduleSettings;
   polling: PollingSettings;
   transitions: TransitionSettings;
   output: OutputSettings;

--- a/web/src/lib/schedule-calendar.ts
+++ b/web/src/lib/schedule-calendar.ts
@@ -15,30 +15,55 @@ import {
   startOfWeek,
 } from "date-fns";
 
-import type { Collection, Page, ScheduleEntry } from "./api";
+import type { Collection, Page, ScheduleEntry, SilenceMode } from "./api";
 import { isCollectionId } from "./api";
 
-/**
- * Calendar event type for react-big-calendar
- */
-export interface CalendarEvent {
+interface BaseCalendarEvent {
   id: string;
   title: string;
   start: Date;
   end: Date;
-  resource: {
-    scheduleId: string;
-    pageId: string;
-    pageName: string;
-    enabled: boolean;
-    dayPattern: string;
-    originalSchedule: ScheduleEntry;
-    /** True when the event is one half of a midnight-split schedule */
-    isMidnightSplit?: boolean;
-    /** Which half of the split: "evening" ends at 00:00, "morning" starts at 00:00 */
-    splitPart?: "evening" | "morning";
-  };
 }
+
+export interface ScheduleEventResource {
+  kind: "schedule";
+  scheduleId: string;
+  pageId: string;
+  pageName: string;
+  enabled: boolean;
+  dayPattern: string;
+  originalSchedule: ScheduleEntry;
+  /** True when the event is one half of a midnight-split schedule */
+  isMidnightSplit?: boolean;
+  /** Which half of the split: "evening" ends at 00:00, "morning" starts at 00:00 */
+  splitPart?: "evening" | "morning";
+}
+
+export interface SilenceEventResource {
+  kind: "silence";
+  mode: SilenceMode;
+  indicatorText: string | null;
+  /** Page name when mode === "page", otherwise null */
+  pageName: string | null;
+  /** Local-time HH:MM start/end as configured by the user (for display) */
+  startTimeLocal: string;
+  endTimeLocal: string;
+  isMidnightSplit?: boolean;
+  splitPart?: "evening" | "morning";
+}
+
+export interface ScheduleCalendarEvent extends BaseCalendarEvent {
+  resource: ScheduleEventResource;
+}
+
+export interface SilenceCalendarEvent extends BaseCalendarEvent {
+  resource: SilenceEventResource;
+}
+
+/**
+ * Calendar event type for react-big-calendar. Discriminated on resource.kind.
+ */
+export type CalendarEvent = ScheduleCalendarEvent | SilenceCalendarEvent;
 
 /**
  * Map of day names to day-of-week numbers (0 = Sunday, 1 = Monday, etc.)
@@ -177,8 +202,8 @@ export function scheduleToCalendarEvents(
   pages: Page[],
   collections?: Collection[],
   sunTimesMap?: Record<string, { sunrise: string; sunset: string }>,
-): CalendarEvent[] {
-  const events: CalendarEvent[] = [];
+): ScheduleCalendarEvent[] {
+  const events: ScheduleCalendarEvent[] = [];
   const weekEnd = endOfWeek(weekStart, { weekStartsOn: 0 });
   const daysInWeek = eachDayOfInterval({ start: weekStart, end: weekEnd });
 
@@ -232,6 +257,7 @@ export function scheduleToCalendarEvents(
         start: eventStart,
         end: eveningEnd,
         resource: {
+          kind: "schedule",
           scheduleId: schedule.id,
           pageId: schedule.page_id,
           pageName,
@@ -252,6 +278,7 @@ export function scheduleToCalendarEvents(
         start: morningStart,
         end: morningEnd,
         resource: {
+          kind: "schedule",
           scheduleId: schedule.id,
           pageId: schedule.page_id,
           pageName,
@@ -271,6 +298,7 @@ export function scheduleToCalendarEvents(
         start: eventStart,
         end: eventEnd,
         resource: {
+          kind: "schedule",
           scheduleId: schedule.id,
           pageId: schedule.page_id,
           pageName,
@@ -294,8 +322,8 @@ export function schedulesToCalendarEvents(
   pages: Page[],
   collections?: Collection[],
   sunTimesMap?: Record<string, { sunrise: string; sunset: string }>,
-): CalendarEvent[] {
-  const allEvents: CalendarEvent[] = [];
+): ScheduleCalendarEvent[] {
+  const allEvents: ScheduleCalendarEvent[] = [];
 
   for (const schedule of schedules) {
     const events = scheduleToCalendarEvents(schedule, weekStart, pages, collections, sunTimesMap);
@@ -303,6 +331,94 @@ export function schedulesToCalendarEvents(
   }
 
   return allEvents;
+}
+
+/**
+ * Resolved silence-schedule data ready for calendar rendering.
+ * Times are already converted to the user's local timezone as HH:MM.
+ */
+export interface ResolvedSilenceSchedule {
+  enabled: boolean;
+  startTimeLocal: string;
+  endTimeLocal: string;
+  mode: SilenceMode;
+  indicatorText: string | null;
+  pageId: string | null;
+}
+
+/**
+ * Synthesize calendar events for the silence schedule across the visible
+ * week. Mirrors the midnight-split handling used for regular schedules so
+ * a silence window like 22:00 → 06:00 shows as evening + morning halves.
+ */
+export function silenceToCalendarEvents(
+  silence: ResolvedSilenceSchedule | null,
+  weekStart: Date,
+  pages: Page[],
+): SilenceCalendarEvent[] {
+  if (!silence || !silence.enabled) return [];
+  const { hours: sH, minutes: sM } = parseTime(silence.startTimeLocal);
+  const { hours: eH, minutes: eM } = parseTime(silence.endTimeLocal);
+  // Same-time start/end means no silence window — render nothing.
+  if (sH === eH && sM === eM) return [];
+
+  const events: SilenceCalendarEvent[] = [];
+  const weekEnd = endOfWeek(weekStart, { weekStartsOn: 0 });
+  const daysInWeek = eachDayOfInterval({ start: weekStart, end: weekEnd });
+  const isMidnightRollover = eH < sH || (eH === sH && eM <= sM);
+  const pageName = silence.mode === "page" && silence.pageId
+    ? (pages.find((p) => p.id === silence.pageId)?.name ?? null)
+    : null;
+
+  const resourceBase = {
+    kind: "silence" as const,
+    mode: silence.mode,
+    indicatorText: silence.indicatorText,
+    pageName,
+    startTimeLocal: silence.startTimeLocal,
+    endTimeLocal: silence.endTimeLocal,
+  };
+
+  for (const day of daysInWeek) {
+    const dayOfWeek = getDay(day);
+    const eventStart = setMinutes(setHours(day, sH), sM);
+
+    if (isMidnightRollover) {
+      // Saturday's morning continuation wraps to this week's Sunday so the
+      // event stays in the visible template view (same trick as regular
+      // schedule midnight splits).
+      const morningDay = dayOfWeek === 6 ? weekStart : addDays(day, 1);
+
+      events.push({
+        id: `silence-${format(day, "yyyy-MM-dd")}-evening`,
+        title: "Silence",
+        start: eventStart,
+        end: endOfDay(day),
+        resource: { ...resourceBase, isMidnightSplit: true, splitPart: "evening" },
+      });
+
+      const morningStart = setMinutes(setHours(morningDay, 0), 0);
+      const morningEnd = setMinutes(setHours(morningDay, eH), eM);
+      events.push({
+        id: `silence-${format(morningDay, "yyyy-MM-dd")}-morning`,
+        title: "Silence",
+        start: morningStart,
+        end: morningEnd,
+        resource: { ...resourceBase, isMidnightSplit: true, splitPart: "morning" },
+      });
+    } else {
+      const eventEnd = setMinutes(setHours(day, eH), eM);
+      events.push({
+        id: `silence-${format(day, "yyyy-MM-dd")}`,
+        title: "Silence",
+        start: eventStart,
+        end: eventEnd,
+        resource: { ...resourceBase },
+      });
+    }
+  }
+
+  return events;
 }
 
 /**

--- a/web/src/lib/schedule-calendar.ts
+++ b/web/src/lib/schedule-calendar.ts
@@ -366,9 +366,8 @@ export function silenceToCalendarEvents(
   const weekEnd = endOfWeek(weekStart, { weekStartsOn: 0 });
   const daysInWeek = eachDayOfInterval({ start: weekStart, end: weekEnd });
   const isMidnightRollover = eH < sH || (eH === sH && eM <= sM);
-  const pageName = silence.mode === "page" && silence.pageId
-    ? (pages.find((p) => p.id === silence.pageId)?.name ?? null)
-    : null;
+  const pageName =
+    silence.mode === "page" && silence.pageId ? (pages.find((p) => p.id === silence.pageId)?.name ?? null) : null;
 
   const resourceBase = {
     kind: "silence" as const,

--- a/web/src/styles/calendar.css
+++ b/web/src/styles/calendar.css
@@ -303,6 +303,32 @@
   opacity: 0.6;
 }
 
+/* Silence schedule overlay — read-only, visually distinct from real schedules.
+   Diagonal stripe pattern signals "do not disturb / blocked time" without
+   competing with the colored brand events. */
+.schedule-event-silence .schedule-event-content {
+  background-color: color-mix(in oklch, var(--muted-foreground) 8%, transparent);
+  background-image: repeating-linear-gradient(
+    45deg,
+    color-mix(in oklch, var(--muted-foreground) 22%, transparent) 0,
+    color-mix(in oklch, var(--muted-foreground) 22%, transparent) 4px,
+    transparent 4px,
+    transparent 9px
+  );
+  border-left: 2px solid color-mix(in oklch, var(--muted-foreground) 55%, transparent);
+  color: var(--muted-foreground);
+}
+
+.schedule-event-silence .schedule-event-content:hover {
+  background-color: color-mix(in oklch, var(--muted-foreground) 12%, transparent);
+}
+
+/* Silence sits above regular schedule events so the stripe pattern reads
+   clearly when the windows overlap. */
+.schedule-calendar-container .rbc-event.schedule-event-silence {
+  z-index: 2;
+}
+
 /* ===== Events Container ===== */
 .schedule-calendar-container .rbc-day-slot .rbc-events-container {
   margin-right: 2px;


### PR DESCRIPTION
## Summary

- Renders the silence schedule as read-only diagonal-stripe blocks on the Schedule calendar (with midnight-split handling like regular schedules) and as a non-editable row in the list view, so the silence window is visible where users actually plan their day instead of hidden in Settings.
- Clicking the silence block or list row navigates to `/settings?section=behavior#silence-schedule` and pulses the silence card so the destination is obvious.
- Discriminates the existing `CalendarEvent` type into `Schedule | Silence` so the schedule and silence code paths are type-safe and silence events can't be dragged/resized.

## Test plan

- [ ] With silence enabled (non-midnight window, e.g. 13:00–14:00), confirm one striped block per day with Moon icon, "Silence" title, and a mode subtitle (`Indicator: SNOOZING` / `Board frozen` / `Page: {name}`).
- [ ] With a midnight-crossing window (e.g. 22:00–06:00), confirm two striped blocks per day (evening + morning halves) like other midnight-split events.
- [ ] With silence disabled, confirm no silence block on the calendar and no silence row in the list view.
- [ ] Clicking a silence block on the calendar — and the silence row in the list view — navigates to `/settings?section=behavior#silence-schedule`, scrolls to the card, and shows a brief blue ring pulse.
- [ ] Silence blocks can't be dragged or resized; clicking other schedule events still opens the edit sheet.
- [ ] Switch silence modes in Settings (Indicator / Freeze / Page) and confirm the calendar/list subtitles update — `Page: {name}` resolves the page name from the pages query.
- [ ] Keyboard: tab to a silence event/row, press Enter — same navigation; `aria-label` is announced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)