### PR TITLE
feat(silence): tighten boundary race + show imminent-silence banner

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -3811,6 +3811,21 @@ async def get_silence_status():
     # Determine next change time (simplified - just return start or end)
     next_change_utc = end_time if active else start_time
 
+    # Wall-clock seconds until the next active/inactive transition. Lets the
+    # frontend show a "silence starts in N min" warning without re-doing the
+    # UTC + offset math the silence window uses (which has subtle edge cases
+    # around midnight rollover and DST). None when silence is disabled.
+    seconds_until_next_change: int | None = None
+    if enabled:
+        next_change_dt = time_service.parse_iso_time(next_change_utc)
+        if next_change_dt is not None:
+            delta_seconds = int((next_change_dt - current_utc).total_seconds())
+            # next_change_dt is anchored to "today" in UTC, so a negative value
+            # means the boundary already passed today and will recur tomorrow.
+            if delta_seconds < 0:
+                delta_seconds += 86_400
+            seconds_until_next_change = delta_seconds
+
     return {
         "enabled": enabled,
         "active": active,
@@ -3818,6 +3833,7 @@ async def get_silence_status():
         "end_time_utc": end_time,
         "current_time_utc": current_time_utc,
         "next_change_utc": next_change_utc,
+        "seconds_until_next_change": seconds_until_next_change,
         "mode": mode,
         "page_id": page_id,
         "indicator_text": silence_config.get("indicator_text", "SNOOZING"),

--- a/src/main.py
+++ b/src/main.py
@@ -690,6 +690,26 @@ class DisplayService:
         try:
             while self.running:
                 schedule.run_pending()
+
+                # 1-second silence-boundary detector. The schedule library only
+                # fires check_and_send_active_page every polling_interval seconds,
+                # so without this the silence page could appear up to ~15s after
+                # the configured start time (longer if the user raised the poll
+                # interval). A cheap is_silence_mode_active() call each second
+                # lets us catch the transition within ~1s.
+                try:
+                    silence_now = Config.is_silence_mode_active()
+                except Exception as e:
+                    logger.debug(f"Silence boundary check failed: {e}")
+                    silence_now = self._last_silence_mode_active
+                if silence_now != self._last_silence_mode_active:
+                    logger.debug(
+                        "Silence boundary crossed (now=%s, was=%s) - forcing immediate update",
+                        silence_now,
+                        self._last_silence_mode_active,
+                    )
+                    self.check_and_send_active_page()
+
                 # When a collection is active, poll at its mode-specific cadence:
                 # time-mode aligns with the next page boundary; variable-mode uses
                 # the configured poll_seconds.

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -834,9 +834,14 @@ class TestSilenceStatus:
 
     def test_silence_disabled(self, client, mock_config_manager):
         """Silence disabled returns active=False."""
+        from datetime import UTC, datetime
+
         with patch("src.time_service.get_time_service") as mock_ts:
             ts = Mock()
-            ts.get_current_utc.return_value = Mock(strftime=Mock(return_value="12:00+00:00"))
+            # Use a real datetime so the endpoint can subtract from
+            # parse_iso_time(next_change_utc) when computing seconds_until_next_change.
+            ts.get_current_utc.return_value = datetime(2024, 1, 15, 12, 0, tzinfo=UTC)
+            ts.parse_iso_time.return_value = None
             mock_ts.return_value = ts
             response = client.get("/silence-status")
             assert response.status_code == 200
@@ -846,6 +851,8 @@ class TestSilenceStatus:
 
     def test_silence_enabled_active(self, client, mock_config_manager):
         """Silence enabled and currently active."""
+        from datetime import UTC, datetime
+
         mock_config_manager.get_feature.return_value = {
             "enabled": True,
             "start_time": "22:00+00:00",
@@ -854,7 +861,9 @@ class TestSilenceStatus:
         with patch("src.time_service.get_time_service") as mock_ts:
             ts = Mock()
             ts.is_time_in_window.return_value = True
-            ts.get_current_utc.return_value = Mock(strftime=Mock(return_value="23:00+00:00"))
+            ts.get_current_utc.return_value = datetime(2024, 1, 15, 23, 0, tzinfo=UTC)
+            # parse_iso_time of "06:00+00:00" anchored to today.
+            ts.parse_iso_time.return_value = datetime(2024, 1, 15, 6, 0, tzinfo=UTC)
             mock_ts.return_value = ts
             response = client.get("/silence-status")
             data = response.json()
@@ -864,6 +873,8 @@ class TestSilenceStatus:
 
     def test_silence_enabled_inactive(self, client, mock_config_manager):
         """Silence enabled but not currently active."""
+        from datetime import UTC, datetime
+
         mock_config_manager.get_feature.return_value = {
             "enabled": True,
             "start_time": "22:00+00:00",
@@ -872,7 +883,9 @@ class TestSilenceStatus:
         with patch("src.time_service.get_time_service") as mock_ts:
             ts = Mock()
             ts.is_time_in_window.return_value = False
-            ts.get_current_utc.return_value = Mock(strftime=Mock(return_value="12:00+00:00"))
+            ts.get_current_utc.return_value = datetime(2024, 1, 15, 12, 0, tzinfo=UTC)
+            # parse_iso_time of "22:00+00:00" anchored to today.
+            ts.parse_iso_time.return_value = datetime(2024, 1, 15, 22, 0, tzinfo=UTC)
             mock_ts.return_value = ts
             response = client.get("/silence-status")
             data = response.json()

--- a/tests/test_silence_schedule_endpoint.py
+++ b/tests/test_silence_schedule_endpoint.py
@@ -340,3 +340,84 @@ class TestSilenceIndicatorTextAndPosition:
         response = self._put(client, indicator_text=long_text)
         assert response.status_code == 200
         assert response.json()["config"]["indicator_text"] == long_text
+
+
+class TestSilenceStatusSecondsUntilNextChange:
+    """Tests for the seconds_until_next_change field driving the home banner."""
+
+    @staticmethod
+    def _patch_now(monkeypatch, fixed_utc):
+        from datetime import UTC, datetime
+
+        from src import time_service as ts_mod
+
+        ts_mod.reset_time_service()
+        service = ts_mod.get_time_service()
+
+        def fake_now():
+            return datetime.fromisoformat(fixed_utc).replace(tzinfo=UTC)
+
+        monkeypatch.setattr(service, "get_current_utc", fake_now)
+        return service
+
+    def test_returns_none_when_disabled(self, client, mock_config_manager_for_silence, monkeypatch):
+        self._patch_now(monkeypatch, "2024-01-15T12:00:00")
+        # Default fixture has enabled=False
+        response = client.get("/silence-status")
+        assert response.status_code == 200
+        assert response.json()["seconds_until_next_change"] is None
+
+    def test_counts_down_to_silence_start(self, client, mock_config_manager_for_silence, monkeypatch):
+        """When silence is enabled and inactive, count down to start_time."""
+        self._patch_now(monkeypatch, "2024-01-15T11:58:30")
+        client.put(
+            "/settings/silence-schedule",
+            json={
+                "enabled": True,
+                "start_time": "12:00+00:00",  # 1m30s away
+                "end_time": "20:00+00:00",
+            },
+        )
+        response = client.get("/silence-status")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["active"] is False
+        assert data["seconds_until_next_change"] == 90
+
+    def test_counts_down_to_silence_end_when_active(self, client, mock_config_manager_for_silence, monkeypatch):
+        """When already in silence, count down to end_time."""
+        self._patch_now(monkeypatch, "2024-01-15T19:30:00")
+        client.put(
+            "/settings/silence-schedule",
+            json={
+                "enabled": True,
+                "start_time": "12:00+00:00",
+                "end_time": "20:00+00:00",  # 30m away
+            },
+        )
+        response = client.get("/silence-status")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["active"] is True
+        assert data["seconds_until_next_change"] == 30 * 60
+
+    def test_wraps_to_tomorrow_when_boundary_already_passed(
+        self, client, mock_config_manager_for_silence, monkeypatch
+    ):
+        """parse_iso_time anchors to today; if start is earlier than now, add 24h."""
+        self._patch_now(monkeypatch, "2024-01-15T13:00:00")
+        client.put(
+            "/settings/silence-schedule",
+            json={
+                "enabled": True,
+                "start_time": "12:00+00:00",  # earlier today
+                "end_time": "10:00+00:00",  # also earlier today (window wraps midnight)
+            },
+        )
+        response = client.get("/silence-status")
+        assert response.status_code == 200
+        data = response.json()
+        # 13:00 is inside a 12:00->10:00(+1d) window, so silence is active and
+        # we count down to end_time (10:00 tomorrow = 21h away).
+        assert data["active"] is True
+        assert data["seconds_until_next_change"] == 21 * 3600

--- a/tests/test_silence_schedule_endpoint.py
+++ b/tests/test_silence_schedule_endpoint.py
@@ -401,9 +401,7 @@ class TestSilenceStatusSecondsUntilNextChange:
         assert data["active"] is True
         assert data["seconds_until_next_change"] == 30 * 60
 
-    def test_wraps_to_tomorrow_when_boundary_already_passed(
-        self, client, mock_config_manager_for_silence, monkeypatch
-    ):
+    def test_wraps_to_tomorrow_when_boundary_already_passed(self, client, mock_config_manager_for_silence, monkeypatch):
         """parse_iso_time anchors to today; if start is earlier than now, add 24h."""
         self._patch_now(monkeypatch, "2024-01-15T13:00:00")
         client.put(

--- a/web/app/routes/home.tsx
+++ b/web/app/routes/home.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { ActivePageDisplay } from "@/components/active-page-display";
 import { PageHeader } from "@/components/page-header";
 import { PageLayout } from "@/components/page-layout";
+import { SilenceImminentBanner } from "@/components/silence-imminent-banner";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { useWizard } from "@/components/wizard-provider";
@@ -50,6 +51,8 @@ export default function Home() {
           </Alert>
         </div>
       )}
+
+      <SilenceImminentBanner />
 
       <div className="animate-card-fade-in">
         <ActivePageDisplay />

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -126,7 +126,14 @@
     "description": "Überwachen Sie die Anzeige Ihres Boards und die Systemaktivität",
     "noBoardConfigured": "Kein Board konfiguriert",
     "noBoardDescription": "Ihr Board ist noch nicht eingerichtet. Verbinden Sie Ihr Board, um Inhalte anzuzeigen.",
-    "runSetupWizard": "Einrichtungsassistent starten"
+    "runSetupWizard": "Einrichtungsassistent starten",
+    "silenceImminentTitle": "Silence starts in {minutes, plural, =0 {less than a minute} one {# minute} other {# minutes}}",
+    "silenceImminentDescription": "Switch to “{pageName}” now so you don't have to wait for the schedule to catch up.",
+    "silenceImminentDescriptionUnnamed": "Switch to your silence page now so you don't have to wait for the schedule to catch up.",
+    "silenceImminentSwitchNow": "Switch now",
+    "silenceImminentDismiss": "Dismiss",
+    "silenceImminentSwitchSuccess": "Switched to silence page",
+    "silenceImminentSwitchFailed": "Could not switch to silence page"
   },
   "pages": {
     "title": "Seiten",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -83,7 +83,14 @@
     "description": "Monitor your board display and system activity",
     "noBoardConfigured": "No board configured",
     "noBoardDescription": "Your board is not set up yet. Connect your board to start displaying content.",
-    "runSetupWizard": "Run Setup Wizard"
+    "runSetupWizard": "Run Setup Wizard",
+    "silenceImminentTitle": "Silence starts in {minutes, plural, =0 {less than a minute} one {# minute} other {# minutes}}",
+    "silenceImminentDescription": "Switch to “{pageName}” now so you don't have to wait for the schedule to catch up.",
+    "silenceImminentDescriptionUnnamed": "Switch to your silence page now so you don't have to wait for the schedule to catch up.",
+    "silenceImminentSwitchNow": "Switch now",
+    "silenceImminentDismiss": "Dismiss",
+    "silenceImminentSwitchSuccess": "Switched to silence page",
+    "silenceImminentSwitchFailed": "Could not switch to silence page"
   },
   "pages": {
     "title": "Pages",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -126,7 +126,14 @@
     "description": "Supervisa la pantalla de tu tablero y la actividad del sistema",
     "noBoardConfigured": "Ningún tablero configurado",
     "noBoardDescription": "Tu tablero aún no está configurado. Conecta tu tablero para comenzar a mostrar contenido.",
-    "runSetupWizard": "Ejecutar asistente de configuración"
+    "runSetupWizard": "Ejecutar asistente de configuración",
+    "silenceImminentTitle": "Silence starts in {minutes, plural, =0 {less than a minute} one {# minute} other {# minutes}}",
+    "silenceImminentDescription": "Switch to “{pageName}” now so you don't have to wait for the schedule to catch up.",
+    "silenceImminentDescriptionUnnamed": "Switch to your silence page now so you don't have to wait for the schedule to catch up.",
+    "silenceImminentSwitchNow": "Switch now",
+    "silenceImminentDismiss": "Dismiss",
+    "silenceImminentSwitchSuccess": "Switched to silence page",
+    "silenceImminentSwitchFailed": "Could not switch to silence page"
   },
   "pages": {
     "title": "Páginas",

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -126,7 +126,14 @@
     "description": "Surveillez l'affichage de votre tableau et l'activité du système",
     "noBoardConfigured": "Aucun tableau configuré",
     "noBoardDescription": "Votre tableau n'est pas encore configuré. Connectez votre tableau pour commencer à afficher du contenu.",
-    "runSetupWizard": "Lancer l'assistant de configuration"
+    "runSetupWizard": "Lancer l'assistant de configuration",
+    "silenceImminentTitle": "Silence starts in {minutes, plural, =0 {less than a minute} one {# minute} other {# minutes}}",
+    "silenceImminentDescription": "Switch to “{pageName}” now so you don't have to wait for the schedule to catch up.",
+    "silenceImminentDescriptionUnnamed": "Switch to your silence page now so you don't have to wait for the schedule to catch up.",
+    "silenceImminentSwitchNow": "Switch now",
+    "silenceImminentDismiss": "Dismiss",
+    "silenceImminentSwitchSuccess": "Switched to silence page",
+    "silenceImminentSwitchFailed": "Could not switch to silence page"
   },
   "pages": {
     "title": "Pages",

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -126,7 +126,14 @@
     "description": "Monitora la visualizzazione della bacheca e l'attività del sistema",
     "noBoardConfigured": "Nessuna bacheca configurata",
     "noBoardDescription": "La tua bacheca non è ancora configurata. Collega la tua bacheca per iniziare a mostrare contenuti.",
-    "runSetupWizard": "Avvia procedura guidata"
+    "runSetupWizard": "Avvia procedura guidata",
+    "silenceImminentTitle": "Silence starts in {minutes, plural, =0 {less than a minute} one {# minute} other {# minutes}}",
+    "silenceImminentDescription": "Switch to “{pageName}” now so you don't have to wait for the schedule to catch up.",
+    "silenceImminentDescriptionUnnamed": "Switch to your silence page now so you don't have to wait for the schedule to catch up.",
+    "silenceImminentSwitchNow": "Switch now",
+    "silenceImminentDismiss": "Dismiss",
+    "silenceImminentSwitchSuccess": "Switched to silence page",
+    "silenceImminentSwitchFailed": "Could not switch to silence page"
   },
   "pages": {
     "title": "Pagine",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -126,7 +126,14 @@
     "description": "ボードの表示状態とシステムアクティビティを確認できます",
     "noBoardConfigured": "ボードが未設定です",
     "noBoardDescription": "ボードがまだセットアップされていません。ボードを接続してコンテンツの表示を開始しましょう。",
-    "runSetupWizard": "セットアップウィザードを実行"
+    "runSetupWizard": "セットアップウィザードを実行",
+    "silenceImminentTitle": "Silence starts in {minutes, plural, =0 {less than a minute} one {# minute} other {# minutes}}",
+    "silenceImminentDescription": "Switch to “{pageName}” now so you don't have to wait for the schedule to catch up.",
+    "silenceImminentDescriptionUnnamed": "Switch to your silence page now so you don't have to wait for the schedule to catch up.",
+    "silenceImminentSwitchNow": "Switch now",
+    "silenceImminentDismiss": "Dismiss",
+    "silenceImminentSwitchSuccess": "Switched to silence page",
+    "silenceImminentSwitchFailed": "Could not switch to silence page"
   },
   "pages": {
     "title": "ページ",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -126,7 +126,14 @@
     "description": "보드 표시 상태 및 시스템 활동을 모니터링하세요",
     "noBoardConfigured": "보드가 설정되지 않았습니다",
     "noBoardDescription": "보드가 아직 설정되지 않았습니다. 보드를 연결하여 콘텐츠 표시를 시작하세요.",
-    "runSetupWizard": "설정 마법사 실행"
+    "runSetupWizard": "설정 마법사 실행",
+    "silenceImminentTitle": "Silence starts in {minutes, plural, =0 {less than a minute} one {# minute} other {# minutes}}",
+    "silenceImminentDescription": "Switch to “{pageName}” now so you don't have to wait for the schedule to catch up.",
+    "silenceImminentDescriptionUnnamed": "Switch to your silence page now so you don't have to wait for the schedule to catch up.",
+    "silenceImminentSwitchNow": "Switch now",
+    "silenceImminentDismiss": "Dismiss",
+    "silenceImminentSwitchSuccess": "Switched to silence page",
+    "silenceImminentSwitchFailed": "Could not switch to silence page"
   },
   "pages": {
     "title": "페이지",

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -126,7 +126,14 @@
     "description": "Bekijk je bordweergave en systeemactiviteit",
     "noBoardConfigured": "Geen bord geconfigureerd",
     "noBoardDescription": "Je bord is nog niet ingesteld. Verbind je bord om inhoud weer te geven.",
-    "runSetupWizard": "Installatiewizard starten"
+    "runSetupWizard": "Installatiewizard starten",
+    "silenceImminentTitle": "Silence starts in {minutes, plural, =0 {less than a minute} one {# minute} other {# minutes}}",
+    "silenceImminentDescription": "Switch to “{pageName}” now so you don't have to wait for the schedule to catch up.",
+    "silenceImminentDescriptionUnnamed": "Switch to your silence page now so you don't have to wait for the schedule to catch up.",
+    "silenceImminentSwitchNow": "Switch now",
+    "silenceImminentDismiss": "Dismiss",
+    "silenceImminentSwitchSuccess": "Switched to silence page",
+    "silenceImminentSwitchFailed": "Could not switch to silence page"
   },
   "pages": {
     "title": "Pagina's",

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -126,7 +126,14 @@
     "description": "Monitoruj wyświetlacz tablicy i aktywność systemu",
     "noBoardConfigured": "Tablica nie skonfigurowana",
     "noBoardDescription": "Twoja tablica nie jest jeszcze skonfigurowana. Połącz tablicę, aby zacząć wyświetlać treści.",
-    "runSetupWizard": "Uruchom kreator konfiguracji"
+    "runSetupWizard": "Uruchom kreator konfiguracji",
+    "silenceImminentTitle": "Silence starts in {minutes, plural, =0 {less than a minute} one {# minute} other {# minutes}}",
+    "silenceImminentDescription": "Switch to “{pageName}” now so you don't have to wait for the schedule to catch up.",
+    "silenceImminentDescriptionUnnamed": "Switch to your silence page now so you don't have to wait for the schedule to catch up.",
+    "silenceImminentSwitchNow": "Switch now",
+    "silenceImminentDismiss": "Dismiss",
+    "silenceImminentSwitchSuccess": "Switched to silence page",
+    "silenceImminentSwitchFailed": "Could not switch to silence page"
   },
   "pages": {
     "title": "Strony",

--- a/web/messages/pt.json
+++ b/web/messages/pt.json
@@ -126,7 +126,14 @@
     "description": "Monitore a exibição do seu painel e a atividade do sistema",
     "noBoardConfigured": "Nenhum painel configurado",
     "noBoardDescription": "Seu painel ainda não foi configurado. Conecte seu painel para começar a exibir conteúdo.",
-    "runSetupWizard": "Iniciar Assistente de Configuração"
+    "runSetupWizard": "Iniciar Assistente de Configuração",
+    "silenceImminentTitle": "Silence starts in {minutes, plural, =0 {less than a minute} one {# minute} other {# minutes}}",
+    "silenceImminentDescription": "Switch to “{pageName}” now so you don't have to wait for the schedule to catch up.",
+    "silenceImminentDescriptionUnnamed": "Switch to your silence page now so you don't have to wait for the schedule to catch up.",
+    "silenceImminentSwitchNow": "Switch now",
+    "silenceImminentDismiss": "Dismiss",
+    "silenceImminentSwitchSuccess": "Switched to silence page",
+    "silenceImminentSwitchFailed": "Could not switch to silence page"
   },
   "pages": {
     "title": "Páginas",

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -126,7 +126,14 @@
     "description": "Отслеживайте отображение доски и активность системы",
     "noBoardConfigured": "Доска не настроена",
     "noBoardDescription": "Ваша доска ещё не настроена. Подключите доску, чтобы начать отображать контент.",
-    "runSetupWizard": "Запустить мастер настройки"
+    "runSetupWizard": "Запустить мастер настройки",
+    "silenceImminentTitle": "Silence starts in {minutes, plural, =0 {less than a minute} one {# minute} other {# minutes}}",
+    "silenceImminentDescription": "Switch to “{pageName}” now so you don't have to wait for the schedule to catch up.",
+    "silenceImminentDescriptionUnnamed": "Switch to your silence page now so you don't have to wait for the schedule to catch up.",
+    "silenceImminentSwitchNow": "Switch now",
+    "silenceImminentDismiss": "Dismiss",
+    "silenceImminentSwitchSuccess": "Switched to silence page",
+    "silenceImminentSwitchFailed": "Could not switch to silence page"
   },
   "pages": {
     "title": "Страницы",

--- a/web/messages/sv.json
+++ b/web/messages/sv.json
@@ -126,7 +126,14 @@
     "description": "Övervaka din tavlas visning och systemaktivitet",
     "noBoardConfigured": "Ingen tavla konfigurerad",
     "noBoardDescription": "Din tavla är inte inställd ännu. Anslut din tavla för att börja visa innehåll.",
-    "runSetupWizard": "Kör installationsguiden"
+    "runSetupWizard": "Kör installationsguiden",
+    "silenceImminentTitle": "Silence starts in {minutes, plural, =0 {less than a minute} one {# minute} other {# minutes}}",
+    "silenceImminentDescription": "Switch to “{pageName}” now so you don't have to wait for the schedule to catch up.",
+    "silenceImminentDescriptionUnnamed": "Switch to your silence page now so you don't have to wait for the schedule to catch up.",
+    "silenceImminentSwitchNow": "Switch now",
+    "silenceImminentDismiss": "Dismiss",
+    "silenceImminentSwitchSuccess": "Switched to silence page",
+    "silenceImminentSwitchFailed": "Could not switch to silence page"
   },
   "pages": {
     "title": "Sidor",

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -126,7 +126,14 @@
     "description": "Pano ekranınızı ve sistem etkinliğini izleyin",
     "noBoardConfigured": "Pano yapılandırılmadı",
     "noBoardDescription": "Panonuz henüz kurulmadı. İçerik görüntülemeye başlamak için panonuzu bağlayın.",
-    "runSetupWizard": "Kurulum Sihirbazını Çalıştır"
+    "runSetupWizard": "Kurulum Sihirbazını Çalıştır",
+    "silenceImminentTitle": "Silence starts in {minutes, plural, =0 {less than a minute} one {# minute} other {# minutes}}",
+    "silenceImminentDescription": "Switch to “{pageName}” now so you don't have to wait for the schedule to catch up.",
+    "silenceImminentDescriptionUnnamed": "Switch to your silence page now so you don't have to wait for the schedule to catch up.",
+    "silenceImminentSwitchNow": "Switch now",
+    "silenceImminentDismiss": "Dismiss",
+    "silenceImminentSwitchSuccess": "Switched to silence page",
+    "silenceImminentSwitchFailed": "Could not switch to silence page"
   },
   "pages": {
     "title": "Sayfalar",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -126,7 +126,14 @@
     "description": "监控看板显示和系统活动",
     "noBoardConfigured": "未配置看板",
     "noBoardDescription": "您的看板尚未设置。连接看板以开始显示内容。",
-    "runSetupWizard": "运行设置向导"
+    "runSetupWizard": "运行设置向导",
+    "silenceImminentTitle": "Silence starts in {minutes, plural, =0 {less than a minute} one {# minute} other {# minutes}}",
+    "silenceImminentDescription": "Switch to “{pageName}” now so you don't have to wait for the schedule to catch up.",
+    "silenceImminentDescriptionUnnamed": "Switch to your silence page now so you don't have to wait for the schedule to catch up.",
+    "silenceImminentSwitchNow": "Switch now",
+    "silenceImminentDismiss": "Dismiss",
+    "silenceImminentSwitchSuccess": "Switched to silence page",
+    "silenceImminentSwitchFailed": "Could not switch to silence page"
   },
   "pages": {
     "title": "页面",

--- a/web/src/__tests__/silence-imminent-banner.test.tsx
+++ b/web/src/__tests__/silence-imminent-banner.test.tsx
@@ -52,9 +52,7 @@ function setupHandlers(opts: {
         },
       }),
     ),
-    http.get(`${API_BASE}/settings/active-page`, () =>
-      HttpResponse.json({ page_id: opts.manualPageId ?? null }),
-    ),
+    http.get(`${API_BASE}/settings/active-page`, () => HttpResponse.json({ page_id: opts.manualPageId ?? null })),
     http.get(`${API_BASE}/pages`, () =>
       HttpResponse.json({
         pages: opts.pages ?? [{ id: "page-quiet", name: "Quiet" }],

--- a/web/src/__tests__/silence-imminent-banner.test.tsx
+++ b/web/src/__tests__/silence-imminent-banner.test.tsx
@@ -1,0 +1,187 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SilenceImminentBanner } from "@/components/silence-imminent-banner";
+
+import { server } from "./mocks/server";
+
+const API_BASE = "/api";
+
+function silenceStatus(overrides: Record<string, unknown> = {}) {
+  return {
+    enabled: true,
+    active: false,
+    start_time_utc: "04:00+00:00",
+    end_time_utc: "15:00+00:00",
+    current_time_utc: "2025-12-26T03:58:30+00:00",
+    next_change_utc: "04:00+00:00",
+    seconds_until_next_change: 90,
+    mode: "page",
+    page_id: "page-quiet",
+    indicator_text: "SNOOZING",
+    indicator_position: "center",
+    ...overrides,
+  };
+}
+
+function setupHandlers(opts: {
+  silence?: Record<string, unknown>;
+  schedulePageId?: string | null;
+  scheduleEnabled?: boolean;
+  manualPageId?: string | null;
+  pages?: Array<{ id: string; name: string }>;
+  onOverride?: (body: unknown) => void;
+}) {
+  server.use(
+    http.get(`${API_BASE}/silence-status`, () => HttpResponse.json(silenceStatus(opts.silence))),
+    http.get(`${API_BASE}/schedules/active/page`, () =>
+      HttpResponse.json({
+        page_id: opts.schedulePageId ?? null,
+        source: opts.scheduleEnabled ? "schedule" : "manual",
+        schedule_enabled: opts.scheduleEnabled ?? false,
+        temporary_override: {
+          active: false,
+          page_id: null,
+          expires_at: null,
+          remaining_seconds: null,
+          revert_mode: null,
+          revert_page_id: null,
+        },
+      }),
+    ),
+    http.get(`${API_BASE}/settings/active-page`, () =>
+      HttpResponse.json({ page_id: opts.manualPageId ?? null }),
+    ),
+    http.get(`${API_BASE}/pages`, () =>
+      HttpResponse.json({
+        pages: opts.pages ?? [{ id: "page-quiet", name: "Quiet" }],
+        total: (opts.pages ?? [{ id: "page-quiet", name: "Quiet" }]).length,
+      }),
+    ),
+    http.post(`${API_BASE}/settings/temporary-override`, async ({ request }) => {
+      const body = await request.json();
+      opts.onOverride?.(body);
+      return HttpResponse.json({
+        active: true,
+        page_id: (body as { page_id: string }).page_id,
+        expires_at: null,
+        remaining_seconds: 90,
+        revert_mode: "schedule",
+        revert_page_id: null,
+      });
+    }),
+    http.post(`${API_BASE}/force-refresh`, () => HttpResponse.json({ status: "ok" })),
+  );
+}
+
+function TestWrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+describe("SilenceImminentBanner", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows when silence is starting within 2 minutes and the silence page isn't active", async () => {
+    setupHandlers({ manualPageId: "page-home" });
+    render(<SilenceImminentBanner />, { wrapper: TestWrapper });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("silence-imminent-banner")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Silence starts in/)).toBeInTheDocument();
+    expect(screen.getByText(/Quiet/)).toBeInTheDocument();
+  });
+
+  it("does not render when silence is disabled", async () => {
+    setupHandlers({ silence: { enabled: false }, manualPageId: "page-home" });
+    const { container } = render(<SilenceImminentBanner />, { wrapper: TestWrapper });
+    await new Promise((r) => setTimeout(r, 50));
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("does not render when mode is not 'page'", async () => {
+    setupHandlers({
+      silence: { mode: "freeze", page_id: null },
+      manualPageId: "page-home",
+    });
+    const { container } = render(<SilenceImminentBanner />, { wrapper: TestWrapper });
+    await new Promise((r) => setTimeout(r, 50));
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("does not render when silence is already active", async () => {
+    setupHandlers({
+      silence: { active: true, seconds_until_next_change: 600 },
+      manualPageId: "page-home",
+    });
+    const { container } = render(<SilenceImminentBanner />, { wrapper: TestWrapper });
+    await new Promise((r) => setTimeout(r, 50));
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("does not render when the silence page is already showing", async () => {
+    setupHandlers({ manualPageId: "page-quiet" });
+    const { container } = render(<SilenceImminentBanner />, { wrapper: TestWrapper });
+    await new Promise((r) => setTimeout(r, 50));
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("does not render when silence is far away", async () => {
+    setupHandlers({
+      silence: { seconds_until_next_change: 30 * 60 },
+      manualPageId: "page-home",
+    });
+    const { container } = render(<SilenceImminentBanner />, { wrapper: TestWrapper });
+    await new Promise((r) => setTimeout(r, 50));
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("dismiss hides the banner", async () => {
+    setupHandlers({ manualPageId: "page-home" });
+    const user = userEvent.setup();
+    render(<SilenceImminentBanner />, { wrapper: TestWrapper });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("silence-imminent-banner")).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: /Dismiss/i }));
+    expect(screen.queryByTestId("silence-imminent-banner")).not.toBeInTheDocument();
+  });
+
+  it("Switch now calls temporary-override with the silence page id", async () => {
+    const captured: { body?: unknown } = {};
+    setupHandlers({
+      manualPageId: "page-home",
+      onOverride: (body) => {
+        captured.body = body;
+      },
+    });
+    const user = userEvent.setup();
+    render(<SilenceImminentBanner />, { wrapper: TestWrapper });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("silence-imminent-banner")).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: /Switch now/i }));
+
+    await waitFor(() => {
+      expect(captured.body).toBeDefined();
+    });
+    expect(captured.body).toMatchObject({
+      page_id: "page-quiet",
+      revert_mode: "schedule",
+    });
+    expect((captured.body as { duration_minutes: number }).duration_minutes).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/web/src/components/silence-imminent-banner.tsx
+++ b/web/src/components/silence-imminent-banner.tsx
@@ -46,9 +46,7 @@ export function SilenceImminentBanner() {
   });
   const { data: manualActivePage } = useActivePage();
   const scheduleEnabled = activeScheduleData?.schedule_enabled ?? false;
-  const activePageId = scheduleEnabled
-    ? (activeScheduleData?.page_id ?? null)
-    : (manualActivePage?.page_id ?? null);
+  const activePageId = scheduleEnabled ? (activeScheduleData?.page_id ?? null) : (manualActivePage?.page_id ?? null);
 
   const switchNowMutation = useMutation({
     mutationFn: (vars: { pageId: string; durationMinutes: number }) =>

--- a/web/src/components/silence-imminent-banner.tsx
+++ b/web/src/components/silence-imminent-banner.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Moon } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { useActivePage, usePages } from "@/hooks/use-board";
+import { useTranslations } from "@/i18n/translations";
+import type { ActiveScheduleResponse, SilenceStatus } from "@/lib/api";
+import { api } from "@/lib/api";
+
+// Show the banner when silence is imminent within this many seconds.
+const IMMINENT_THRESHOLD_SECONDS = 2 * 60;
+
+export function SilenceImminentBanner() {
+  const t = useTranslations("home");
+  const queryClient = useQueryClient();
+
+  // Track which upcoming boundary the user dismissed, so dismiss applies only
+  // to the current "about to start" window and re-appears for tomorrow.
+  const [dismissedFor, setDismissedFor] = useState<string | null>(null);
+
+  // Local 1s ticker so the countdown decrements between server polls.
+  const [tick, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick((n) => n + 1), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const { data: silenceStatus } = useQuery<SilenceStatus>({
+    queryKey: ["silenceStatus"],
+    queryFn: api.getSilenceStatus,
+    refetchInterval: 30_000,
+  });
+
+  const { data: pagesData } = usePages();
+
+  // Reuse the queries ActivePageDisplay already populates so we don't double-fetch.
+  const { data: activeScheduleData } = useQuery<ActiveScheduleResponse>({
+    queryKey: ["schedules", "active"],
+    queryFn: () => api.getActiveSchedule(),
+    refetchInterval: 60_000,
+  });
+  const { data: manualActivePage } = useActivePage();
+  const scheduleEnabled = activeScheduleData?.schedule_enabled ?? false;
+  const activePageId = scheduleEnabled
+    ? (activeScheduleData?.page_id ?? null)
+    : (manualActivePage?.page_id ?? null);
+
+  const switchNowMutation = useMutation({
+    mutationFn: (vars: { pageId: string; durationMinutes: number }) =>
+      api.setTemporaryOverride({
+        page_id: vars.pageId,
+        duration_minutes: vars.durationMinutes,
+        revert_mode: "schedule",
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["schedules", "active"] });
+      queryClient.invalidateQueries({ queryKey: ["board-current-message"] });
+      api.forceRefresh().catch(() => {});
+      toast.success(t("silenceImminentSwitchSuccess"));
+    },
+    onError: () => {
+      toast.error(t("silenceImminentSwitchFailed"));
+    },
+  });
+
+  // Compute remaining seconds locally, anchored to the server's reading at
+  // fetch time. This keeps the countdown smooth without spamming /silence-status.
+  // useMemo (rather than useEffect+setState) keeps the anchor in sync with the
+  // server snapshot without a cascading re-render.
+  const anchor = useMemo<{ seconds: number; receivedAt: number } | null>(() => {
+    const s = silenceStatus?.seconds_until_next_change;
+    if (typeof s !== "number") return null;
+    return { seconds: s, receivedAt: Date.now() };
+  }, [silenceStatus]);
+
+  if (!silenceStatus?.enabled) return null;
+  if (silenceStatus.active) return null;
+  if (silenceStatus.mode !== "page") return null;
+  const silencePageId = silenceStatus.page_id;
+  if (!silencePageId) return null;
+  if (activePageId === silencePageId) return null;
+
+  if (!anchor) return null;
+  const elapsed = Math.floor((Date.now() - anchor.receivedAt) / 1000);
+  const remaining = anchor.seconds - elapsed;
+  void tick; // keep dependency on the local ticker
+
+  if (remaining <= 0) return null;
+  if (remaining > IMMINENT_THRESHOLD_SECONDS) return null;
+
+  const boundaryKey = silenceStatus.next_change_utc;
+  if (dismissedFor === boundaryKey) return null;
+
+  const silencePage = pagesData?.pages?.find((p) => p.id === silencePageId) ?? null;
+  const minutes = Math.max(0, Math.ceil(remaining / 60));
+
+  const handleSwitchNow = () => {
+    // Override duration must be ≥1 minute and long enough to bridge the gap
+    // until silence naturally starts. Once silence starts, the regular silence
+    // flow takes over (overriding the override) — so we don't need exact
+    // duration math, just enough to span the wait.
+    const durationMinutes = Math.max(1, Math.ceil(remaining / 60) + 1);
+    switchNowMutation.mutate({ pageId: silencePageId, durationMinutes });
+  };
+
+  return (
+    <div className="mb-6">
+      <Alert
+        className="border-info/50 bg-info/10 flex flex-col sm:flex-row sm:items-center sm:gap-4 [&>svg]:static [&>svg]:shrink-0 [&>svg+div]:translate-y-0 [&>svg~*]:pl-3"
+        data-testid="silence-imminent-banner"
+      >
+        <Moon className="h-4 w-4 text-info" />
+        <div className="flex-1 min-w-0">
+          <AlertTitle>{t("silenceImminentTitle", { minutes })}</AlertTitle>
+          <AlertDescription>
+            {silencePage
+              ? t("silenceImminentDescription", { pageName: silencePage.name })
+              : t("silenceImminentDescriptionUnnamed")}
+          </AlertDescription>
+        </div>
+        <div className="flex items-center gap-2 self-center shrink-0">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setDismissedFor(boundaryKey)}
+            disabled={switchNowMutation.isPending}
+          >
+            {t("silenceImminentDismiss")}
+          </Button>
+          <Button
+            variant="brand"
+            size="sm"
+            onClick={handleSwitchNow}
+            disabled={switchNowMutation.isPending}
+            className="w-fit btn-lift"
+          >
+            {t("silenceImminentSwitchNow")}
+          </Button>
+        </div>
+      </Alert>
+    </div>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -470,7 +470,9 @@ export interface SilenceStatus {
   end_time_utc: string;
   current_time_utc: string;
   next_change_utc: string;
+  seconds_until_next_change?: number | null;
   mode?: string;
+  page_id?: string | null;
   indicator_text?: string;
   indicator_position?: string;
 }


### PR DESCRIPTION
## Summary
- **Race fix in `src/main.py`:** added a 1s-granularity silence-boundary detector on top of the existing `schedule.every(N).seconds.do(check_and_send_active_page)` poll. The silence page used to lag the configured boundary by up to `polling_interval` seconds (15s default, longer in cloud mode); now it kicks in within ~1s. No new threads, no config-change re-arming — the loop already runs `time.sleep(1)` between `run_pending()` calls, so adding `Config.is_silence_mode_active()` there is cheap (pure time math).
- **`SilenceImminentBanner` on the home page** for user-controlled remediation: shows when silence is enabled, `mode === "page"`, a `page_id` is set, the silence page isn't already showing, and silence starts within ≤2 min. CTA = "Switch now" → `POST /settings/temporary-override` with `revert_mode: "schedule"`. Dismissible (per upcoming boundary). When silence naturally starts, the normal silence flow takes over.
- **`/silence-status` now returns `seconds_until_next_change`** so the frontend doesn't re-do the UTC + midnight-rollover math the backend already does. `SilenceStatus` TS interface updated to include the new field and the existing `page_id`.

## Test plan
- [x] `pytest tests/test_silence_schedule_endpoint.py tests/test_silence_mode_display.py tests/test_silence_schedule_polling.py tests/test_silence_config_properties.py tests/test_time_service.py` → 127 passed (4 new under `TestSilenceStatusSecondsUntilNextChange`)
- [x] `vitest run src/__tests__/silence-imminent-banner.test.tsx` → 8/8 (renders within window, hides when disabled/active/far/mode-mismatch/already-showing-silence-page, dismiss works, Switch-now POSTs override with correct page id)
- [x] `vitest run src/__tests__/home-page-banner.test.tsx src/__tests__/active-page-display-silence.test.tsx` → no regressions
- [x] `eslint` clean on touched files; `ruff` clean on Python files
- [ ] Manual smoke: configure silence + mode=page + page_id, set start_time ~3 min in future, confirm banner appears at home; click Switch now → board flips to silence page immediately; verify silence kicks in at start_time and stays on that page

🤖 Generated with [Claude Code](https://claude.com/claude-code)