### PR TITLE
feat(ci): add daily docs-audit cron driven by Claude Sonnet

### DIFF
--- a/.github/docs-audit-state.json
+++ b/.github/docs-audit-state.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": 1,
+  "round": 0,
+  "round_started_at": null,
+  "last_run_at": null,
+  "files_remaining": [],
+  "files_audited": []
+}

--- a/.github/workflows/scheduled-maintenance.yml
+++ b/.github/workflows/scheduled-maintenance.yml
@@ -11,15 +11,22 @@ name: Scheduled Maintenance
 #   - security-scan  : weekly bandit + pip-audit sweep of plugin-registry
 #                      repos, opens/updates an issue on findings
 #                      (was .github/workflows/registry-scan.yml)
+#   - docs-audit     : daily ~4pm America/Los_Angeles sweep of repo docs by
+#                      Claude Sonnet. Opens draft PRs for fixable errors and
+#                      issues for missing/confusing docs. Progress tracked
+#                      in .github/docs-audit-state.json; sweep restarts
+#                      from the top once every file has been audited.
 # =============================================================================
 
 on:
   schedule:
-    # Daily 04:00 UTC for stats refresh; Sunday 00:00 UTC for security scan.
-    # Both crons listed here; each job filters on the resolved schedule
-    # via `github.event.schedule`.
-    - cron: '0 4 * * *'    # plugin stats
-    - cron: '0 0 * * 0'    # security scan (Sundays)
+    # Each job filters on the resolved schedule via `github.event.schedule`.
+    - cron: '0 4 * * *'    # plugin stats (04:00 UTC daily)
+    - cron: '0 0 * * 0'    # security scan (Sun 00:00 UTC)
+    # docs-audit fires twice; only one matches 16:xx America/Los_Angeles
+    # depending on DST. The job gates on the local-hour check below.
+    - cron: '7 23 * * *'   # docs-audit: 4:07pm PDT (summer) / 3:07pm PST
+    - cron: '7 0 * * *'    # docs-audit: 4:07pm PST (winter) / 5:07pm PDT
   workflow_dispatch:
     inputs:
       job:
@@ -27,7 +34,7 @@ on:
         required: true
         default: 'all'
         type: choice
-        options: [all, plugin-stats, security-scan]
+        options: [all, plugin-stats, security-scan, docs-audit]
 
 permissions:
   contents: read
@@ -167,3 +174,219 @@ jobs:
             });
             console.log('Created new security scan issue');
           }
+
+  docs-audit:
+    name: Audit docs with Claude
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Either docs-audit cron fired AND local hour is 16 (4pm PT), OR
+    # explicit workflow_dispatch. The TZ check is what gives us DST-aware
+    # "always 4pm Pacific" behavior — GitHub cron is UTC-only, so we
+    # schedule both 23:07 and 00:07 UTC and let the local hour gate decide.
+    if: |
+      (github.event_name == 'schedule' &&
+        (github.event.schedule == '7 23 * * *' || github.event.schedule == '7 0 * * *')) ||
+      (github.event_name == 'workflow_dispatch' &&
+        (inputs.job == 'all' || inputs.job == 'docs-audit'))
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Gate on America/Los_Angeles local hour == 16
+        id: gate
+        # On scheduled runs, only proceed when it is actually 4pm PT.
+        # workflow_dispatch always proceeds.
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "go=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          hour=$(TZ=America/Los_Angeles date +%H)
+          echo "Local hour in America/Los_Angeles: $hour"
+          if [ "$hour" = "16" ]; then
+            echo "go=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "go=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping: not 4pm PT (DST-paired cron firing on the other side)."
+          fi
+
+      - name: Checkout repository
+        if: steps.gate.outputs.go == 'true'
+        uses: actions/checkout@v6
+        with:
+          # RELEASE_PAT so the state-file commit can push to main past
+          # branch protection — same pattern as the plugin-stats job.
+          token: ${{ secrets.RELEASE_PAT }}
+          fetch-depth: 0
+
+      - name: Configure git identity
+        if: steps.gate.outputs.go == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Run Claude docs audit
+        if: steps.gate.outputs.go == 'true'
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Sonnet — the user picked this tier for the recurring audit.
+          claude_args: '--model claude-sonnet-4-6 --max-turns 60'
+          prompt: |
+            You are the FiestaBoard docs auditor. You run unattended once a day
+            at 4pm America/Los_Angeles and audit a small batch of repo docs.
+
+            ## Sweep state
+
+            State file: `.github/docs-audit-state.json`
+            Schema:
+              - `round`           — int, sweep number (starts at 0; bumped each restart)
+              - `round_started_at`— ISO8601 string or null
+              - `last_run_at`     — ISO8601 string or null
+              - `files_remaining` — list of relative paths still to audit this round
+              - `files_audited`   — list of relative paths already audited this round
+
+            ## Sweep logic
+
+            1. Read the state file.
+            2. If `files_remaining` is empty:
+               - Glob the repo for docs files. Include:
+                 `README.md`, `docs/**/*.md`, `plugins/*/README.md`,
+                 `plugins/*/docs/**/*.md`, `web/src/components/README.md`.
+                 Exclude `node_modules/`, `.git/`, `docs-site/node_modules/`,
+                 `web/node_modules/`, `tools/`, and anything under `.claude/`.
+               - Set `files_remaining` to the full glob, sorted.
+               - Set `files_audited` to `[]`.
+               - Bump `round` by 1 and set `round_started_at` to now (ISO8601 UTC).
+            3. Pick the first **8** entries from `files_remaining` as this run's batch.
+               If fewer than 8 remain, use what's there.
+
+            ## For each file in the batch
+
+            Read it carefully. Categorize findings into three buckets:
+
+            **A. Auto-fixable errors** — typos, broken internal links, stale
+                command examples that contradict CLAUDE.md (e.g. mention
+                `npm run dev` directly), wrong file paths, code blocks missing
+                language tags, references to renamed/removed files (verify with
+                `ls` or `grep`), out-of-order section headings vs the canonical
+                plugin doc format described in CLAUDE.md.
+
+            **B. Missing documentation** — a referenced concept, command, env
+                var, or workflow that has no documented home; a plugin without
+                a `docs/SETUP.md` or hero image; a feature in `src/` with no
+                user-facing doc.
+
+            **C. Usability / clarity issues** — instructions that are correct
+                but confusing, redundant, out-of-order, or could be simplified;
+                missing prerequisites; jargon used before definition.
+
+            Be conservative: only flag a finding if you're confident it's real.
+            False positives erode trust. If you're unsure, leave it.
+
+            ## Outputs
+
+            ### If bucket A has any findings across the batch
+
+            Create a branch `docs-audit/round-<round>-batch-<unix-timestamp>`
+            off `main`. Apply ONLY the bucket-A fixes (small, surgical edits).
+            Commit. Open a **draft** PR:
+
+              Title: `docs: auto-audit fixes (round <round>, batch <N> files)`
+              Body:
+                ## Summary
+                Auto-generated by the daily docs-audit cron. Fixes <K> issues
+                across <N> files.
+
+                ## Files touched
+                - `<path>`: <one-line description of fix>
+                - ...
+
+                ## Notes
+                - Round <round> sweep, audited <X>/<Y> files so far.
+                - Review each diff — auto-edits can introduce regressions.
+
+                🤖 Generated by the docs-audit GitHub Action.
+
+            Use `gh pr create --draft`. Never mark ready-for-review.
+
+            ### For each bucket B or C finding
+
+            File a GitHub issue. Dedupe first:
+              `gh issue list --label docs-audit --state open --limit 100 --search "<key phrase>"`
+            If an issue with the same file + topic already exists, skip it.
+
+            Issue title: `docs: <verb> <file> — <one-line summary>`
+              e.g. `docs: clarify weather plugin SETUP.md — API key step ordering`
+                   `docs: add missing docs for src/carousels schema migration flow`
+
+            Issue body:
+              ## File(s)
+              - `<path>`
+
+              ## Category
+              <Missing documentation | Usability / clarity>
+
+              ## Finding
+              <2–5 sentences describing what's missing or confusing>
+
+              ## Suggested improvement
+              <2–5 sentences proposing how to fix it>
+
+              ---
+              _Filed by the docs-audit cron during round <round>._
+
+            Labels: `docs`, `docs-audit`. Create the labels if they don't exist
+            (`gh label create docs-audit --color BFD4F2 --description "Filed by the docs-audit cron" || true`).
+
+            ## State commit
+
+            After processing the batch:
+            1. Move the batch entries from `files_remaining` to `files_audited`.
+            2. Update `last_run_at` to now (ISO8601 UTC).
+            3. Write the JSON back to `.github/docs-audit-state.json`
+               (2-space indent, trailing newline, keys in the same order as the
+               existing file).
+            4. Commit to `main` directly with the message
+               `chore(docs-audit): advance sweep state [skip ci]` and push.
+               This is the ONLY direct-to-main commit you make.
+
+            ## Hard rules
+
+            - Never push to `main` except for the single state-file commit above.
+            - Never force-push, never `--no-verify`, never `--no-gpg-sign`.
+            - Never modify non-docs source code. Edits are restricted to
+              `*.md` files and `.github/docs-audit-state.json`.
+            - Never open more than 1 PR per run.
+            - Never file more than 10 issues per run. If you'd file more,
+              keep the top 10 (most actionable) and discard the rest.
+            - If something looks ambiguous, skip it and move on. Erring on
+              the side of "do nothing" is correct for an unattended job.
+
+            ## Wrap up
+
+            Print a one-screen summary:
+              ROUND: <n> (started <date>)
+              BATCH: <files in this batch>
+              PR opened: <#N or "none">
+              Issues filed: <#A #B ...>
+              Progress: <audited>/<total> files in this round
+              Next batch: <first 3 of files_remaining or "round complete">
+
+      - name: Push state-file changes
+        if: steps.gate.outputs.go == 'true'
+        # Defensive: if the Claude step somehow leaves a staged state change
+        # without pushing (early exit, rate limit, etc.), commit + push it
+        # here. `[skip ci]` keeps this from triggering downstream workflows.
+        run: |
+          if git diff --quiet -- .github/docs-audit-state.json; then
+            echo "State file unchanged."
+            exit 0
+          fi
+          git add .github/docs-audit-state.json
+          git commit -m "chore(docs-audit): advance sweep state [skip ci]"
+          git push origin HEAD:main


### PR DESCRIPTION
## Summary

Adds a `docs-audit` job to the existing `scheduled-maintenance.yml` workflow. It runs once a day at **~4:07pm America/Los_Angeles** year-round and sends **Claude Sonnet 4.6** off to sweep the repo's markdown docs.

Each run:

- Reads progress from `.github/docs-audit-state.json` (`round`, `files_remaining`, `files_audited`)
- Picks the next **8 files** from `files_remaining`
- Opens **one draft PR** with auto-fixable errors (typos, broken links, stale commands, wrong paths, ordering vs canonical plugin doc format)
- Files **labeled issues** (`docs`, `docs-audit`) for missing docs and usability/clarity findings, with dedupe via `gh issue list --label docs-audit`
- Commits the advanced state back to `main` with `[skip ci]`
- When `files_remaining` empties, regenerates from a docs glob and bumps `round` — so the sweep loops indefinitely

## How DST is handled

GitHub Actions cron is UTC-only with no timezone support. The workflow registers two crons (`7 23 * * *` and `7 0 * * *`) and the job's first step gates on `TZ=America/Los_Angeles date +%H == 16`. Exactly one fires per day at 4pm Pacific regardless of DST. Minute `:07` keeps us off the fleet-thundering `:00` mark and out of the Sunday-midnight security-scan slot.

## Hard safety rules in the prompt

- Never push to `main` except the single state-file commit
- Never force-push, never `--no-verify`, never `--no-gpg-sign`
- Edits restricted to `*.md` + the state file
- Max 1 PR + 10 issues per run
- Draft PRs only — human reviews before merge

## Test plan

- [ ] Verify `gh workflow run scheduled-maintenance.yml -f job=docs-audit` triggers the job (workflow_dispatch path bypasses the TZ gate)
- [ ] Confirm `RELEASE_PAT` and `CLAUDE_CODE_OAUTH_TOKEN` secrets are populated (existing jobs already use both)
- [ ] First scheduled run: confirm state file initializes (round 0 → round 1), a batch of 8 files is processed, and the next day's run picks up where this one left off
- [ ] Spot-check the first auto-PR for false positives — if Claude is too aggressive, tighten the prompt's "be conservative" guidance
- [ ] Verify `docs-audit` label gets created on first issue filing

🤖 Generated with [Claude Code](https://claude.com/claude-code)