### PR TITLE
ci: prefix Claude workflows + allow manual dispatch

### DIFF
--- a/.github/workflows/claude-docs-audit.yml
+++ b/.github/workflows/claude-docs-audit.yml
@@ -1,0 +1,231 @@
+name: 'Claude: Docs Audit'
+
+# =============================================================================
+# Daily ~4pm America/Los_Angeles sweep of repo docs by Claude Sonnet.
+# Opens draft PRs for fixable errors and issues for missing/confusing docs.
+# Progress tracked in .github/docs-audit-state.json; sweep restarts from the
+# top once every file has been audited.
+#
+# Cron fires twice (paired UTC times) to stay DST-aware; the local-hour
+# gate below picks the correct one. workflow_dispatch always proceeds, so
+# you can kick off a one-off audit from the Actions tab.
+# =============================================================================
+
+on:
+  schedule:
+    # docs-audit fires twice; only one matches 16:xx America/Los_Angeles
+    # depending on DST. The job gates on the local-hour check below.
+    - cron: '7 23 * * *'   # 4:07pm PDT (summer) / 3:07pm PST
+    - cron: '7 0 * * *'    # 4:07pm PST (winter) / 5:07pm PDT
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  docs-audit:
+    name: Audit docs with Claude
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Gate on America/Los_Angeles local hour == 16
+        id: gate
+        # On scheduled runs, only proceed when it is actually 4pm PT.
+        # workflow_dispatch always proceeds.
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "go=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          hour=$(TZ=America/Los_Angeles date +%H)
+          echo "Local hour in America/Los_Angeles: $hour"
+          if [ "$hour" = "16" ]; then
+            echo "go=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "go=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping: not 4pm PT (DST-paired cron firing on the other side)."
+          fi
+
+      - name: Checkout repository
+        if: steps.gate.outputs.go == 'true'
+        uses: actions/checkout@v6
+        with:
+          # RELEASE_PAT so the state-file commit can push to main past
+          # branch protection — same pattern as the plugin-stats job.
+          token: ${{ secrets.RELEASE_PAT }}
+          fetch-depth: 0
+
+      - name: Configure git identity
+        if: steps.gate.outputs.go == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Run Claude docs audit
+        if: steps.gate.outputs.go == 'true'
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Sonnet — the user picked this tier for the recurring audit.
+          claude_args: '--model claude-sonnet-4-6 --max-turns 60'
+          prompt: |
+            You are the FiestaBoard docs auditor. You run unattended once a day
+            at 4pm America/Los_Angeles and audit a small batch of repo docs.
+
+            ## Sweep state
+
+            State file: `.github/docs-audit-state.json`
+            Schema:
+              - `round`           — int, sweep number (starts at 0; bumped each restart)
+              - `round_started_at`— ISO8601 string or null
+              - `last_run_at`     — ISO8601 string or null
+              - `files_remaining` — list of relative paths still to audit this round
+              - `files_audited`   — list of relative paths already audited this round
+
+            ## Sweep logic
+
+            1. Read the state file.
+            2. If `files_remaining` is empty:
+               - Glob the repo for docs files. Include:
+                 `README.md`, `docs/**/*.md`, `plugins/*/README.md`,
+                 `plugins/*/docs/**/*.md`, `web/src/components/README.md`.
+                 Exclude `node_modules/`, `.git/`, `docs-site/node_modules/`,
+                 `web/node_modules/`, `tools/`, and anything under `.claude/`.
+               - Set `files_remaining` to the full glob, sorted.
+               - Set `files_audited` to `[]`.
+               - Bump `round` by 1 and set `round_started_at` to now (ISO8601 UTC).
+            3. Pick the first **8** entries from `files_remaining` as this run's batch.
+               If fewer than 8 remain, use what's there.
+
+            ## For each file in the batch
+
+            Read it carefully. Categorize findings into three buckets:
+
+            **A. Auto-fixable errors** — typos, broken internal links, stale
+                command examples that contradict CLAUDE.md (e.g. mention
+                `npm run dev` directly), wrong file paths, code blocks missing
+                language tags, references to renamed/removed files (verify with
+                `ls` or `grep`), out-of-order section headings vs the canonical
+                plugin doc format described in CLAUDE.md.
+
+            **B. Missing documentation** — a referenced concept, command, env
+                var, or workflow that has no documented home; a plugin without
+                a `docs/SETUP.md` or hero image; a feature in `src/` with no
+                user-facing doc.
+
+            **C. Usability / clarity issues** — instructions that are correct
+                but confusing, redundant, out-of-order, or could be simplified;
+                missing prerequisites; jargon used before definition.
+
+            Be conservative: only flag a finding if you're confident it's real.
+            False positives erode trust. If you're unsure, leave it.
+
+            ## Outputs
+
+            ### If bucket A has any findings across the batch
+
+            Create a branch `docs-audit/round-<round>-batch-<unix-timestamp>`
+            off `main`. Apply ONLY the bucket-A fixes (small, surgical edits).
+            Commit. Open a **draft** PR:
+
+              Title: `docs: auto-audit fixes (round <round>, batch <N> files)`
+              Body:
+                ## Summary
+                Auto-generated by the daily docs-audit cron. Fixes <K> issues
+                across <N> files.
+
+                ## Files touched
+                - `<path>`: <one-line description of fix>
+                - ...
+
+                ## Notes
+                - Round <round> sweep, audited <X>/<Y> files so far.
+                - Review each diff — auto-edits can introduce regressions.
+
+                🤖 Generated by the docs-audit GitHub Action.
+
+            Use `gh pr create --draft`. Never mark ready-for-review.
+
+            ### For each bucket B or C finding
+
+            File a GitHub issue. Dedupe first:
+              `gh issue list --label docs-audit --state open --limit 100 --search "<key phrase>"`
+            If an issue with the same file + topic already exists, skip it.
+
+            Issue title: `docs: <verb> <file> — <one-line summary>`
+              e.g. `docs: clarify weather plugin SETUP.md — API key step ordering`
+                   `docs: add missing docs for src/carousels schema migration flow`
+
+            Issue body:
+              ## File(s)
+              - `<path>`
+
+              ## Category
+              <Missing documentation | Usability / clarity>
+
+              ## Finding
+              <2–5 sentences describing what's missing or confusing>
+
+              ## Suggested improvement
+              <2–5 sentences proposing how to fix it>
+
+              ---
+              _Filed by the docs-audit cron during round <round>._
+
+            Labels: `docs`, `docs-audit`. Create the labels if they don't exist
+            (`gh label create docs-audit --color BFD4F2 --description "Filed by the docs-audit cron" || true`).
+
+            ## State commit
+
+            After processing the batch:
+            1. Move the batch entries from `files_remaining` to `files_audited`.
+            2. Update `last_run_at` to now (ISO8601 UTC).
+            3. Write the JSON back to `.github/docs-audit-state.json`
+               (2-space indent, trailing newline, keys in the same order as the
+               existing file).
+            4. Commit to `main` directly with the message
+               `chore(docs-audit): advance sweep state [skip ci]` and push.
+               This is the ONLY direct-to-main commit you make.
+
+            ## Hard rules
+
+            - Never push to `main` except for the single state-file commit above.
+            - Never force-push, never `--no-verify`, never `--no-gpg-sign`.
+            - Never modify non-docs source code. Edits are restricted to
+              `*.md` files and `.github/docs-audit-state.json`.
+            - Never open more than 1 PR per run.
+            - Never file more than 10 issues per run. If you'd file more,
+              keep the top 10 (most actionable) and discard the rest.
+            - If something looks ambiguous, skip it and move on. Erring on
+              the side of "do nothing" is correct for an unattended job.
+
+            ## Wrap up
+
+            Print a one-screen summary:
+              ROUND: <n> (started <date>)
+              BATCH: <files in this batch>
+              PR opened: <#N or "none">
+              Issues filed: <#A #B ...>
+              Progress: <audited>/<total> files in this round
+              Next batch: <first 3 of files_remaining or "round complete">
+
+      - name: Push state-file changes
+        if: steps.gate.outputs.go == 'true'
+        # Defensive: if the Claude step somehow leaves a staged state change
+        # without pushing (early exit, rate limit, etc.), commit + push it
+        # here. `[skip ci]` keeps this from triggering downstream workflows.
+        run: |
+          if git diff --quiet -- .github/docs-audit-state.json; then
+            echo "State file unchanged."
+            exit 0
+          fi
+          git add .github/docs-audit-state.json
+          git commit -m "chore(docs-audit): advance sweep state [skip ci]"
+          git push origin HEAD:main

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,4 +1,9 @@
-name: Claude Code
+name: 'Claude: Code Assistant'
+
+# Fires when someone mentions `@claude` on an issue, PR, review, or review
+# comment — the action then runs Claude against that context. Also supports
+# manual workflow_dispatch with a `prompt` input for ad-hoc runs (no
+# triggering comment needed).
 
 on:
   issue_comment:
@@ -9,10 +14,17 @@ on:
     types: [opened, assigned]
   pull_request_review:
     types: [submitted]
+  workflow_dispatch:
+    inputs:
+      prompt:
+        description: 'Prompt to send to Claude'
+        required: true
+        type: string
 
 jobs:
   claude:
     if: |
+      github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
@@ -40,11 +52,12 @@ jobs:
           additional_permissions: |
             actions: read
 
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
+          # On workflow_dispatch we pass the typed-in prompt explicitly. For
+          # event-driven runs the action picks up the @claude comment itself,
+          # so we leave `prompt` empty.
+          prompt: ${{ github.event_name == 'workflow_dispatch' && inputs.prompt || '' }}
 
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr *)'
-

--- a/.github/workflows/pr-changelog.yml
+++ b/.github/workflows/pr-changelog.yml
@@ -1,21 +1,33 @@
-name: PR Changelog Summary
+name: 'Claude: PR Changelog Summary'
 
 # When a PR is merged to main, ask Claude to write a single user-facing
 # changelog one-liner and post it as a PR comment with the marker
 # `<!-- claude-changelog -->`. The Release workflow later harvests these
 # comments instead of relying on raw PR titles, so the release notes read
 # like a human wrote them.
+#
+# Also supports manual workflow_dispatch with a `pr_number` input — useful
+# for retroactively summarizing a PR that merged before this workflow
+# existed, or for re-running a failed summary.
 
 on:
   pull_request:
     types: [closed]
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to summarize'
+        required: true
+        type: string
 
 jobs:
   summarize:
     name: Summarize merged PR
-    if: github.event.pull_request.merged == true
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -29,6 +41,8 @@ jobs:
 
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: '--model claude-haiku-4-5 --allowed-tools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*)"'
@@ -36,10 +50,10 @@ jobs:
             You are writing one line of a FiestaBoard changelog. FiestaBoard is
             an open-source platform for controlling split-flap displays.
 
-            PR #${{ github.event.pull_request.number }} just merged to main.
+            PR #${{ github.event.pull_request.number || inputs.pr_number }} just merged to main.
 
-            1. Run `gh pr view ${{ github.event.pull_request.number }} --json title,body,labels,files` to read the PR.
-            2. Run `gh pr diff ${{ github.event.pull_request.number }}` to see the actual change (you may pipe to `head -300` if it is huge).
+            1. Run `gh pr view ${{ github.event.pull_request.number || inputs.pr_number }} --json title,body,labels,files` to read the PR.
+            2. Run `gh pr diff ${{ github.event.pull_request.number || inputs.pr_number }}` to see the actual change (you may pipe to `head -300` if it is huge).
             3. Decide if this change is user-facing. Internal-only changes
                include: version bumps, CI tweaks, dependency bumps with no
                behavior change, internal refactors, doc-only typo fixes, test
@@ -72,6 +86,6 @@ jobs:
                    SKIP: <one short reason>
 
                Post the comment with:
-                   gh pr comment ${{ github.event.pull_request.number }} --body "..."
+                   gh pr comment ${{ github.event.pull_request.number || inputs.pr_number }} --body "..."
 
             Do not post anything else. Do not edit files. Do not push.

--- a/.github/workflows/scheduled-maintenance.yml
+++ b/.github/workflows/scheduled-maintenance.yml
@@ -11,11 +11,10 @@ name: Scheduled Maintenance
 #   - security-scan  : weekly bandit + pip-audit sweep of plugin-registry
 #                      repos, opens/updates an issue on findings
 #                      (was .github/workflows/registry-scan.yml)
-#   - docs-audit     : daily ~4pm America/Los_Angeles sweep of repo docs by
-#                      Claude Sonnet. Opens draft PRs for fixable errors and
-#                      issues for missing/confusing docs. Progress tracked
-#                      in .github/docs-audit-state.json; sweep restarts
-#                      from the top once every file has been audited.
+#
+# Note: the Claude-driven docs audit lives in its own workflow
+# (.github/workflows/claude-docs-audit.yml) so it surfaces independently
+# in the Actions sidebar.
 # =============================================================================
 
 on:
@@ -23,10 +22,6 @@ on:
     # Each job filters on the resolved schedule via `github.event.schedule`.
     - cron: '0 4 * * *'    # plugin stats (04:00 UTC daily)
     - cron: '0 0 * * 0'    # security scan (Sun 00:00 UTC)
-    # docs-audit fires twice; only one matches 16:xx America/Los_Angeles
-    # depending on DST. The job gates on the local-hour check below.
-    - cron: '7 23 * * *'   # docs-audit: 4:07pm PDT (summer) / 3:07pm PST
-    - cron: '7 0 * * *'    # docs-audit: 4:07pm PST (winter) / 5:07pm PDT
   workflow_dispatch:
     inputs:
       job:
@@ -34,7 +29,7 @@ on:
         required: true
         default: 'all'
         type: choice
-        options: [all, plugin-stats, security-scan, docs-audit]
+        options: [all, plugin-stats, security-scan]
 
 permissions:
   contents: read
@@ -174,219 +169,3 @@ jobs:
             });
             console.log('Created new security scan issue');
           }
-
-  docs-audit:
-    name: Audit docs with Claude
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    # Either docs-audit cron fired AND local hour is 16 (4pm PT), OR
-    # explicit workflow_dispatch. The TZ check is what gives us DST-aware
-    # "always 4pm Pacific" behavior — GitHub cron is UTC-only, so we
-    # schedule both 23:07 and 00:07 UTC and let the local hour gate decide.
-    if: |
-      (github.event_name == 'schedule' &&
-        (github.event.schedule == '7 23 * * *' || github.event.schedule == '7 0 * * *')) ||
-      (github.event_name == 'workflow_dispatch' &&
-        (inputs.job == 'all' || inputs.job == 'docs-audit'))
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-      id-token: write
-    steps:
-      - name: Gate on America/Los_Angeles local hour == 16
-        id: gate
-        # On scheduled runs, only proceed when it is actually 4pm PT.
-        # workflow_dispatch always proceeds.
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "go=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          hour=$(TZ=America/Los_Angeles date +%H)
-          echo "Local hour in America/Los_Angeles: $hour"
-          if [ "$hour" = "16" ]; then
-            echo "go=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "go=false" >> "$GITHUB_OUTPUT"
-            echo "Skipping: not 4pm PT (DST-paired cron firing on the other side)."
-          fi
-
-      - name: Checkout repository
-        if: steps.gate.outputs.go == 'true'
-        uses: actions/checkout@v6
-        with:
-          # RELEASE_PAT so the state-file commit can push to main past
-          # branch protection — same pattern as the plugin-stats job.
-          token: ${{ secrets.RELEASE_PAT }}
-          fetch-depth: 0
-
-      - name: Configure git identity
-        if: steps.gate.outputs.go == 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Run Claude docs audit
-        if: steps.gate.outputs.go == 'true'
-        uses: anthropics/claude-code-action@v1
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # Sonnet — the user picked this tier for the recurring audit.
-          claude_args: '--model claude-sonnet-4-6 --max-turns 60'
-          prompt: |
-            You are the FiestaBoard docs auditor. You run unattended once a day
-            at 4pm America/Los_Angeles and audit a small batch of repo docs.
-
-            ## Sweep state
-
-            State file: `.github/docs-audit-state.json`
-            Schema:
-              - `round`           — int, sweep number (starts at 0; bumped each restart)
-              - `round_started_at`— ISO8601 string or null
-              - `last_run_at`     — ISO8601 string or null
-              - `files_remaining` — list of relative paths still to audit this round
-              - `files_audited`   — list of relative paths already audited this round
-
-            ## Sweep logic
-
-            1. Read the state file.
-            2. If `files_remaining` is empty:
-               - Glob the repo for docs files. Include:
-                 `README.md`, `docs/**/*.md`, `plugins/*/README.md`,
-                 `plugins/*/docs/**/*.md`, `web/src/components/README.md`.
-                 Exclude `node_modules/`, `.git/`, `docs-site/node_modules/`,
-                 `web/node_modules/`, `tools/`, and anything under `.claude/`.
-               - Set `files_remaining` to the full glob, sorted.
-               - Set `files_audited` to `[]`.
-               - Bump `round` by 1 and set `round_started_at` to now (ISO8601 UTC).
-            3. Pick the first **8** entries from `files_remaining` as this run's batch.
-               If fewer than 8 remain, use what's there.
-
-            ## For each file in the batch
-
-            Read it carefully. Categorize findings into three buckets:
-
-            **A. Auto-fixable errors** — typos, broken internal links, stale
-                command examples that contradict CLAUDE.md (e.g. mention
-                `npm run dev` directly), wrong file paths, code blocks missing
-                language tags, references to renamed/removed files (verify with
-                `ls` or `grep`), out-of-order section headings vs the canonical
-                plugin doc format described in CLAUDE.md.
-
-            **B. Missing documentation** — a referenced concept, command, env
-                var, or workflow that has no documented home; a plugin without
-                a `docs/SETUP.md` or hero image; a feature in `src/` with no
-                user-facing doc.
-
-            **C. Usability / clarity issues** — instructions that are correct
-                but confusing, redundant, out-of-order, or could be simplified;
-                missing prerequisites; jargon used before definition.
-
-            Be conservative: only flag a finding if you're confident it's real.
-            False positives erode trust. If you're unsure, leave it.
-
-            ## Outputs
-
-            ### If bucket A has any findings across the batch
-
-            Create a branch `docs-audit/round-<round>-batch-<unix-timestamp>`
-            off `main`. Apply ONLY the bucket-A fixes (small, surgical edits).
-            Commit. Open a **draft** PR:
-
-              Title: `docs: auto-audit fixes (round <round>, batch <N> files)`
-              Body:
-                ## Summary
-                Auto-generated by the daily docs-audit cron. Fixes <K> issues
-                across <N> files.
-
-                ## Files touched
-                - `<path>`: <one-line description of fix>
-                - ...
-
-                ## Notes
-                - Round <round> sweep, audited <X>/<Y> files so far.
-                - Review each diff — auto-edits can introduce regressions.
-
-                🤖 Generated by the docs-audit GitHub Action.
-
-            Use `gh pr create --draft`. Never mark ready-for-review.
-
-            ### For each bucket B or C finding
-
-            File a GitHub issue. Dedupe first:
-              `gh issue list --label docs-audit --state open --limit 100 --search "<key phrase>"`
-            If an issue with the same file + topic already exists, skip it.
-
-            Issue title: `docs: <verb> <file> — <one-line summary>`
-              e.g. `docs: clarify weather plugin SETUP.md — API key step ordering`
-                   `docs: add missing docs for src/carousels schema migration flow`
-
-            Issue body:
-              ## File(s)
-              - `<path>`
-
-              ## Category
-              <Missing documentation | Usability / clarity>
-
-              ## Finding
-              <2–5 sentences describing what's missing or confusing>
-
-              ## Suggested improvement
-              <2–5 sentences proposing how to fix it>
-
-              ---
-              _Filed by the docs-audit cron during round <round>._
-
-            Labels: `docs`, `docs-audit`. Create the labels if they don't exist
-            (`gh label create docs-audit --color BFD4F2 --description "Filed by the docs-audit cron" || true`).
-
-            ## State commit
-
-            After processing the batch:
-            1. Move the batch entries from `files_remaining` to `files_audited`.
-            2. Update `last_run_at` to now (ISO8601 UTC).
-            3. Write the JSON back to `.github/docs-audit-state.json`
-               (2-space indent, trailing newline, keys in the same order as the
-               existing file).
-            4. Commit to `main` directly with the message
-               `chore(docs-audit): advance sweep state [skip ci]` and push.
-               This is the ONLY direct-to-main commit you make.
-
-            ## Hard rules
-
-            - Never push to `main` except for the single state-file commit above.
-            - Never force-push, never `--no-verify`, never `--no-gpg-sign`.
-            - Never modify non-docs source code. Edits are restricted to
-              `*.md` files and `.github/docs-audit-state.json`.
-            - Never open more than 1 PR per run.
-            - Never file more than 10 issues per run. If you'd file more,
-              keep the top 10 (most actionable) and discard the rest.
-            - If something looks ambiguous, skip it and move on. Erring on
-              the side of "do nothing" is correct for an unattended job.
-
-            ## Wrap up
-
-            Print a one-screen summary:
-              ROUND: <n> (started <date>)
-              BATCH: <files in this batch>
-              PR opened: <#N or "none">
-              Issues filed: <#A #B ...>
-              Progress: <audited>/<total> files in this round
-              Next batch: <first 3 of files_remaining or "round complete">
-
-      - name: Push state-file changes
-        if: steps.gate.outputs.go == 'true'
-        # Defensive: if the Claude step somehow leaves a staged state change
-        # without pushing (early exit, rate limit, etc.), commit + push it
-        # here. `[skip ci]` keeps this from triggering downstream workflows.
-        run: |
-          if git diff --quiet -- .github/docs-audit-state.json; then
-            echo "State file unchanged."
-            exit 0
-          fi
-          git add .github/docs-audit-state.json
-          git commit -m "chore(docs-audit): advance sweep state [skip ci]"
-          git push origin HEAD:main


### PR DESCRIPTION
## Summary

- Group all Claude-driven workflows under a `Claude:` name prefix so they cluster together in the Actions sidebar.
- Add `workflow_dispatch` to every Claude workflow so any of them can be fired manually from the UI.
- Extract the docs-audit job out of `Scheduled Maintenance` into its own `Claude: Docs Audit` workflow so it surfaces independently in the sidebar (and can be dispatched without dropdown-spelunking).

## Workflow changes

| File | New name | Manual trigger |
| --- | --- | --- |
| `claude.yml` | `Claude: Code Assistant` | `workflow_dispatch` with a `prompt` input (for ad-hoc runs without an @claude comment) |
| `pr-changelog.yml` | `Claude: PR Changelog Summary` | `workflow_dispatch` with a `pr_number` input (retro-summarize or rerun a failed summary) |
| `claude-docs-audit.yml` *(new)* | `Claude: Docs Audit` | `workflow_dispatch` (no inputs); DST-paired crons + local-hour gate preserved verbatim |
| `scheduled-maintenance.yml` | unchanged | docs-audit job + its crons + the `docs-audit` dispatch option removed |

## Test plan

- [ ] Confirm Actions sidebar now shows three `Claude: …` entries grouped together
- [ ] Run `Claude: Docs Audit` manually from Actions → expect the same behavior as the prior bundled job
- [ ] Run `Claude: PR Changelog Summary` manually with a known PR number → expect a `<!-- claude-changelog -->` comment on that PR
- [ ] Run `Claude: Code Assistant` manually with a test prompt → expect Claude to act on the supplied prompt
- [ ] Verify the next scheduled `Scheduled Maintenance` run no longer attempts docs-audit
- [ ] Verify the next scheduled docs-audit (4pm PT) fires from the new workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)