### PR TITLE
fix(upgrade): snapshot data before init, retry failed v2 installs, surface regression hint (#948)

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -514,6 +514,11 @@ class UpdateStatusResponse(BaseModel):
     # Each entry includes ``previous_digest`` and ``previous_image`` so the
     # UI can offer "revert to the version that was running on <date>".
     settings_snapshots: list[dict[str, Any]] = []
+    # If the most recent snapshot has materially more enabled plugins than
+    # the live config, surface a recovery hint so users hit by issue #948
+    # can roll back with one click instead of discovering the snapshot on
+    # their own. ``None`` when there's no detectable regression.
+    post_upgrade_regression: dict[str, Any] | None = None
 
 
 class UpdateApplyResponse(BaseModel):
@@ -664,6 +669,26 @@ async def lifespan(app: FastAPI):
 
     # Set up file-based logging
     _setup_file_logging()
+
+    # If the most recent settings snapshot looks materially richer than the
+    # live config (more enabled plugins, etc.), tell the user loudly on
+    # startup so they don't have to discover the recovery path on their own.
+    # See issue #948.
+    try:
+        _regression_hint = _detect_post_upgrade_regression()
+        if _regression_hint:
+            logger.warning(
+                "Post-upgrade regression suspected: snapshot '%s' has %d enabled "
+                "plugin(s) but live config has %d. Missing: %s. "
+                "Roll back with POST /system/update/rollback (snapshot=%s, restore_settings=true).",
+                _regression_hint["snapshot_name"],
+                _regression_hint["snapshot_enabled_count"],
+                _regression_hint["current_enabled_count"],
+                _regression_hint["missing_plugin_ids"],
+                _regression_hint["snapshot_name"],
+            )
+    except Exception:  # pragma: no cover - defensive
+        logger.debug("Post-upgrade regression check failed", exc_info=True)
 
     # Initialize and auto-start the service
     service = get_service()
@@ -2056,6 +2081,68 @@ def _list_settings_snapshots() -> list[dict[str, Any]]:
     return out
 
 
+def _detect_post_upgrade_regression() -> dict[str, Any] | None:
+    """Return a hint payload when the live config looks regressed against the
+    newest pre-update snapshot.
+
+    Signals an upgrade is likely to have dropped user state (issue #948 —
+    "integrations lost on upgrade"). We compare the snapshot's enabled
+    plugin set to the current one; if the snapshot enabled strictly more
+    plugins, point the user at /system/update/rollback so they don't have
+    to discover the recovery path on their own.
+
+    Returns ``None`` when:
+      * there are no snapshots,
+      * the newest snapshot is unreadable,
+      * the snapshot has <= 0 enabled plugins (nothing to recover),
+      * the live config has at least as many enabled plugins as the
+        snapshot (no regression detected).
+    """
+    snapshots = _list_settings_snapshots()
+    if not snapshots:
+        return None
+    newest = _resolve_snapshot_name(snapshots[0]["name"])
+    if newest is None:
+        return None
+    try:
+        snap_doc = json.loads(newest.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+    snap_plugins_raw = ((snap_doc.get("data") or {}).get("config") or {}).get("plugins") or {}
+    snap_enabled = {
+        pid
+        for pid, cfg in snap_plugins_raw.items()
+        if isinstance(cfg, dict) and cfg.get("enabled")
+    }
+    if not snap_enabled:
+        return None
+
+    try:
+        live = get_config_manager().get_all_plugin_configs()
+    except Exception:  # pragma: no cover - defensive
+        return None
+    live_enabled = {
+        pid for pid, cfg in live.items() if isinstance(cfg, dict) and cfg.get("enabled")
+    }
+
+    missing = sorted(snap_enabled - live_enabled)
+    if not missing:
+        return None
+
+    return {
+        "snapshot_name": newest.name,
+        "snapshot_enabled_count": len(snap_enabled),
+        "current_enabled_count": len(live_enabled),
+        "missing_plugin_ids": missing,
+        "snapshot_app_version": (snap_doc.get("app_version") if isinstance(snap_doc, dict) else None),
+        "rollback_hint": (
+            "POST /system/update/rollback with snapshot=" + newest.name
+            + " and restore_settings=true to recover."
+        ),
+    }
+
+
 def _prune_settings_snapshots() -> None:
     """Delete all but the ``SETTINGS_SNAPSHOT_RETENTION`` newest snapshots."""
     snapshots = _list_settings_snapshots()
@@ -2116,6 +2203,7 @@ async def system_update_status():
     last = await asyncio.to_thread(_updater_last_update) if available else {}
     interval = _resolve_auto_update_interval(state)
     snapshots = await asyncio.to_thread(_list_settings_snapshots)
+    regression = await asyncio.to_thread(_detect_post_upgrade_regression)
     return UpdateStatusResponse(
         updater_available=available,
         auto_update_enabled=interval != "manual",
@@ -2130,6 +2218,7 @@ async def system_update_status():
         last_update_previous_digest=last.get("previous_digest"),
         last_update_completed_at=last.get("completed_at"),
         settings_snapshots=snapshots,
+        post_upgrade_regression=regression,
     )
 
 

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -12,6 +12,7 @@ import json
 import logging
 import os
 import threading
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Optional
 
@@ -19,6 +20,10 @@ from typing import Any, Optional
 from .time_service import get_time_service
 
 logger = logging.getLogger(__name__)
+
+# Key under which we record the last app version that booted against this
+# config. Used by the boot-time snapshot guard below.
+APP_VERSION_SEEN_KEY = "app_version_seen"
 
 # Mapping from legacy feature keys to plugin IDs.
 # silence_schedule is a system feature and is NOT migrated here.
@@ -351,23 +356,176 @@ class ConfigManager:
                         self._config = json.load(f)
                     logger.info(f"Loaded config from {self._config_path}")
 
+                    # Take a pre-init safety snapshot BEFORE any migration or
+                    # merge touches the loaded data. This covers every upgrade
+                    # path (docker compose pull, FiestaUpdater button, FiestaPi
+                    # button, watchtower, manual swap) — anything that brings
+                    # up a new binary against an existing data dir. See
+                    # issue #948 (integrations lost on upgrade).
+                    self._maybe_snapshot_on_version_change()
+
                     # Snapshot features actually present before merge fills in defaults
                     self._raw_features = self._deep_copy(self._config.get("features", {}))
 
                     # Merge with defaults to handle missing keys
                     self._config = self._merge_with_defaults(self._config)
+                    self._stamp_app_version_seen()
                     self._save_internal()
                 except json.JSONDecodeError as e:
                     logger.error(f"Invalid JSON in config file: {e}")
                     logger.info("Creating new config with defaults")
                     self._config = DEFAULT_CONFIG.copy()
                     self._apply_profile_defaults()
+                    self._stamp_app_version_seen()
                     self._save_internal()
             else:
                 logger.info(f"Config file not found, creating defaults at {self._config_path}")
                 self._config = self._deep_copy(DEFAULT_CONFIG)
                 self._apply_profile_defaults()
+                self._stamp_app_version_seen()
                 self._save_internal()
+
+    # ── boot-time safety snapshot (issue #948) ──────────────────────────
+    #
+    # Whenever the app version on disk differs from the one we just booted,
+    # snapshot data/ to data/update-backups/ BEFORE we touch anything. The
+    # existing /system/update/rollback flow already knows how to list and
+    # restore these files — by reusing the `pre-update-<ts>.json` naming
+    # convention we get rollback for free, regardless of which upgrade
+    # path the user took (compose pull, FiestaUpdater, FiestaPi button…).
+
+    def _stamp_app_version_seen(self) -> None:
+        """Record the running app version into the loaded config dict.
+
+        Caller is responsible for persisting via ``_save_internal``.
+        """
+        try:
+            from src import __version__ as current_version
+        except Exception:  # pragma: no cover - defensive
+            return
+        self._config[APP_VERSION_SEEN_KEY] = current_version
+
+    # Files captured in the pre-init snapshot. Mirrors backup/service.py's
+    # DATA_FILES but is intentionally inlined: BackupService.build_backup()
+    # eagerly initialises the plugin registry, which during ConfigManager
+    # init recurses back through __init__ and corrupts self._config_path.
+    # A flat dict of file payloads is enough for the rollback flow to
+    # restore from.
+    _PRE_INIT_SNAPSHOT_FILES = (
+        "config.json",
+        "settings.json",
+        "pages.json",
+        "collections.json",
+        "schedules.json",
+    )
+
+    def _maybe_snapshot_on_version_change(self) -> None:
+        """If the running version differs from what was last seen, write a
+        pre-init snapshot of ``data/*.json`` to ``update-backups/``.
+
+        No-op when:
+          * the version matches (no upgrade happened),
+          * there is no prior version AND no meaningful user data (fresh
+            install — nothing to back up).
+
+        Failures are swallowed: the snapshot is a safety net, never a
+        gate that could prevent the app from booting.
+
+        Implementation note: we deliberately bypass BackupService here.
+        Its ``build_backup`` calls ``_collect_installed_plugins`` →
+        ``get_plugin_registry`` → ``PluginRegistry.initialize`` →
+        ``get_config_manager`` — which during ``ConfigManager.__init__``
+        re-enters this singleton with the *default* config path and
+        clobbers the one the caller passed in. We hand-roll a minimal
+        snapshot to keep the safety net free of that init-time recursion.
+        """
+        try:
+            from src import __version__ as current_version
+        except Exception:  # pragma: no cover
+            return
+
+        seen = self._config.get(APP_VERSION_SEEN_KEY)
+        if seen == current_version:
+            return
+
+        # Treat as a "first boot" if there's neither a recorded version nor
+        # any user-authored data worth backing up. A fresh install legitimately
+        # has neither, and dumping an empty backup just clutters the rollback
+        # picker.
+        has_user_data = bool(
+            self._config.get("plugins")
+            or self._config.get("features", {}).get("silence_schedule")
+            or self._config.get("board", {}).get("local_api_key")
+            or self._config.get("board", {}).get("cloud_key")
+        )
+        if seen is None and not has_user_data:
+            return
+
+        try:
+            data_dir = self._config_path.parent
+            snapshot_dir = data_dir / "update-backups"
+            snapshot_dir.mkdir(parents=True, exist_ok=True)
+
+            data_payload: dict[str, Any] = {}
+            for filename in self._PRE_INIT_SNAPSHOT_FILES:
+                source = data_dir / filename
+                if not source.is_file():
+                    data_payload[filename[:-5]] = None
+                    continue
+                try:
+                    data_payload[filename[:-5]] = json.loads(source.read_text(encoding="utf-8"))
+                except (OSError, ValueError):
+                    data_payload[filename[:-5]] = None
+
+            doc = {
+                "fiestaboard_backup": True,
+                "schema_version": 1,
+                "exported_at": datetime.now(UTC).isoformat(),
+                "app_version": current_version,
+                "data": data_payload,
+                "installed_plugins": [],
+                "_fiestaupdater": {
+                    "previous_digest": None,
+                    "previous_image": None,
+                    "previous_version": seen or "unknown",
+                    "current_version": current_version,
+                    "trigger": "boot-version-change",
+                },
+            }
+
+            # Match the existing pre-update-<ts>.json shape so the same
+            # rollback endpoint can list and restore these snapshots
+            # without any extra plumbing.
+            now = datetime.now(UTC)
+            ts = now.strftime("%Y%m%dT%H%M%S") + f".{now.microsecond // 1000:03d}Z"
+            target = snapshot_dir / f"pre-update-{ts}.json"
+
+            # Belt-and-braces against same-millisecond collisions when
+            # multiple boot snapshots fire from a tight test/CI loop.
+            for bump in range(1, 1000):
+                if not target.exists():
+                    break
+                ms = (now.microsecond // 1000 + bump) % 1000
+                ts = now.strftime("%Y%m%dT%H%M%S") + f".{ms:03d}Z"
+                target = snapshot_dir / f"pre-update-{ts}.json"
+
+            tmp = target.with_suffix(target.suffix + ".tmp")
+            tmp.write_text(json.dumps(doc, indent=2), encoding="utf-8")
+            tmp.replace(target)
+
+            logger.info(
+                "Version change detected (%s -> %s); pre-init snapshot written to %s",
+                seen or "<unknown>",
+                current_version,
+                target.name,
+            )
+        except Exception:
+            logger.warning(
+                "Could not write pre-init snapshot for version change %s -> %s",
+                seen or "<unknown>",
+                current_version,
+                exc_info=True,
+            )
 
     def _apply_profile_defaults(self) -> None:
         """Apply install-profile-specific overrides at fresh-config creation
@@ -1299,6 +1457,50 @@ class ConfigManager:
             migrations["v2_completed"] = True
             self._save_internal()
         logger.info("v2 plugin migration marked as complete")
+
+    # ── per-plugin retry list (issue #948) ────────────────────────────────────
+    #
+    # If the v2→v3 auto-install fails for a specific plugin (e.g. transient
+    # network during the git clone), we record its id here. On the next boot
+    # the migration retries JUST those ids — provided the user still has a
+    # matching stored config. This keeps the #937 "don't resurrect deliberately
+    # uninstalled plugins" invariant intact while letting a flaky first boot
+    # recover instead of permanently stranding the user.
+
+    def get_v2_plugin_failed_installs(self) -> list[str]:
+        """Return the list of plugin ids that failed to install on a previous
+        v2→v3 migration run."""
+        with self._file_lock:
+            raw = self._config.get("plugin_migrations", {}).get("v2_failed_installs")
+            if not isinstance(raw, list):
+                return []
+            # Defensive filter: only return non-empty string ids.
+            return [pid for pid in raw if isinstance(pid, str) and pid]
+
+    def set_v2_plugin_failed_installs(self, plugin_ids: list[str]) -> None:
+        """Persist the list of plugin ids that should be retried on the next boot.
+
+        Passing an empty list clears the retry queue.
+        """
+        with self._file_lock:
+            migrations = self._config.setdefault("plugin_migrations", {})
+            current = migrations.get("v2_failed_installs") or []
+            normalized = sorted({pid for pid in plugin_ids if isinstance(pid, str) and pid})
+            if current == normalized:
+                return
+            if normalized:
+                migrations["v2_failed_installs"] = normalized
+            else:
+                migrations.pop("v2_failed_installs", None)
+            self._save_internal()
+        if normalized:
+            logger.info("v2 plugin migration: queued %d id(s) for retry: %s", len(normalized), normalized)
+        else:
+            logger.info("v2 plugin migration: retry queue cleared")
+
+    def clear_v2_plugin_failed_installs(self) -> None:
+        """Drop any persisted retry queue. Equivalent to ``set_v2_plugin_failed_installs([])``."""
+        self.set_v2_plugin_failed_installs([])
 
     def migrate_feature_to_plugin(self, feature_name: str, plugin_id: str) -> bool:
         """Migrate a legacy feature configuration to plugin format.

--- a/src/plugins/registry.py
+++ b/src/plugins/registry.py
@@ -410,9 +410,7 @@ class PluginRegistry:
             if not failed:
                 return
             loaded_ids = set(self._plugins.keys())
-            orphan_subset = {
-                pid for pid in failed if pid in stored_configs and pid not in loaded_ids
-            }
+            orphan_subset = {pid for pid in failed if pid in stored_configs and pid not in loaded_ids}
             if not orphan_subset:
                 # Everything that failed has since been resolved (installed
                 # manually, uninstalled deliberately, or otherwise reconciled).

--- a/src/plugins/registry.py
+++ b/src/plugins/registry.py
@@ -375,14 +375,20 @@ class PluginRegistry:
         from the registry, and restores the stored configuration and enabled state
         — giving users a seamless, zero-data-loss upgrade experience.
 
-        One-shot semantics (issue #937): this runs exactly once per install,
-        gated by a persisted flag. After the first run, an "orphaned" config is
-        treated as a deliberate uninstall and is left alone — otherwise the
-        next boot would silently re-clone any plugin the user just deleted.
-        A transient failure (e.g. registry unreachable) still flips the flag;
-        the user can install the missing plugin manually from the Integrations
-        page, which is far better than the alternative of every uninstall
-        being undone the next time the network blips.
+        One-shot semantics with bounded retry (issues #937, #948):
+
+        * The migration sets a persisted ``v2_completed`` flag so an
+          "orphaned" config is treated as a deliberate uninstall on every
+          subsequent boot — not silently re-installed. (Without this the
+          next boot would resurrect any plugin the user just deleted.)
+        * Per-plugin install failures (e.g. transient network blip while
+          cloning from the registry) are recorded in
+          ``plugin_migrations.v2_failed_installs``. On the next boot,
+          if any of those ids still appear as orphaned stored configs,
+          we retry just those — preserving the "stop reinstalling
+          deliberately-deleted plugins" invariant while letting a flaky
+          first boot recover. Once the list is empty the migration goes
+          fully dormant.
         """
         try:
             from src.config_manager import get_config_manager
@@ -392,23 +398,60 @@ class PluginRegistry:
             logger.warning("V3 migration: could not access config manager — skipping: %s", exc)
             return
 
-        if cm.is_v2_plugin_migration_done():
-            return
+        first_run = not cm.is_v2_plugin_migration_done()
+        if first_run:
+            loaded_ids = set(self._plugins.keys())
+            orphan_subset: set[str] | None = None
+        else:
+            # Subsequent boots: only retry plugins that failed on a previous
+            # run AND still have a stored config (i.e. the user hasn't
+            # uninstalled them in the meantime).
+            failed = cm.get_v2_plugin_failed_installs()
+            if not failed:
+                return
+            loaded_ids = set(self._plugins.keys())
+            orphan_subset = {
+                pid for pid in failed if pid in stored_configs and pid not in loaded_ids
+            }
+            if not orphan_subset:
+                # Everything that failed has since been resolved (installed
+                # manually, uninstalled deliberately, or otherwise reconciled).
+                cm.clear_v2_plugin_failed_installs()
+                return
 
-        try:
-            self._run_v2_plugin_migration(stored_configs)
-        finally:
+        failures = self._run_v2_plugin_migration(
+            stored_configs,
+            loaded_ids=loaded_ids,
+            orphan_subset=orphan_subset,
+        )
+
+        if first_run:
             cm.mark_v2_plugin_migration_done()
+        cm.set_v2_plugin_failed_installs(failures)
 
-    def _run_v2_plugin_migration(self, stored_configs: dict[str, dict[str, Any]]) -> None:
-        """Body of the one-shot v2→v3 migration. See `_auto_migrate_v2_plugins`."""
-        loaded_ids = set(self._plugins.keys())
+    def _run_v2_plugin_migration(
+        self,
+        stored_configs: dict[str, dict[str, Any]],
+        *,
+        loaded_ids: set[str] | None = None,
+        orphan_subset: set[str] | None = None,
+    ) -> list[str]:
+        """Body of the v2→v3 migration. See `_auto_migrate_v2_plugins`.
+
+        Returns the list of plugin ids that we attempted to install but
+        could not (registry-clone failure). The caller persists this so
+        we can retry just those on the next boot.
+        """
+        if loaded_ids is None:
+            loaded_ids = set(self._plugins.keys())
         # Instance keys (e.g. "countdown:fijiaustralia") are restored separately
         # by ``_restore_instances`` and must not be treated as orphaned base
         # plugins — their base ID is what gets installed from the registry.
         orphaned = [pid for pid in stored_configs if pid not in loaded_ids and not self.is_instance_key(pid)]
+        if orphan_subset is not None:
+            orphaned = [pid for pid in orphaned if pid in orphan_subset]
         if not orphaned:
-            return
+            return []
 
         logger.info(
             "V3 migration: found %d plugin config(s) with no matching installed plugin: %s",
@@ -420,9 +463,15 @@ class PluginRegistry:
             registry_entries = load_registry()
             registry_map = {e.plugin_id: e for e in registry_entries}
         except Exception as exc:
-            logger.warning("V3 migration: could not load plugin registry — skipping auto-install: %s", exc)
-            return
+            logger.warning(
+                "V3 migration: could not load plugin registry — skipping auto-install: %s",
+                exc,
+            )
+            # Treat as "everything in scope is currently a transient failure"
+            # so we get one more shot at it on the next boot.
+            return list(orphaned)
 
+        failed: list[str] = []
         migrated: list[str] = []
         for plugin_id in orphaned:
             if plugin_id not in registry_map:
@@ -438,10 +487,11 @@ class PluginRegistry:
             if errors:
                 logger.error(
                     "V3 migration: failed to install '%s': %s. "
-                    "Install it manually from the Integrations page if you still want it.",
+                    "Will retry on the next boot if the config is still present.",
                     plugin_id,
                     errors,
                 )
+                failed.append(plugin_id)
                 continue
 
             # install_from_registry() registers the plugin with enabled=False and
@@ -463,6 +513,8 @@ class PluginRegistry:
                 len(migrated),
                 migrated,
             )
+
+        return failed
 
     def get_plugin(self, plugin_id: str) -> PluginBase | None:
         """Get a plugin by ID.

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -870,3 +870,159 @@ def test_v2_plugin_migration_flag_idempotent(tmp_path):
     cm.mark_v2_plugin_migration_done()
     cm.mark_v2_plugin_migration_done()
     assert cm.is_v2_plugin_migration_done() is True
+
+
+# --- v2 plugin migration retry list (issue #948) ---
+#
+# Regression for the upgrade-eats-integrations report: per-plugin install
+# failures must survive across boots so a flaky first attempt can recover,
+# without us giving up the #937 "don't resurrect deliberately-deleted
+# plugins" guarantee.
+
+
+def test_v2_plugin_failed_installs_default_empty(tmp_path):
+    """On a fresh install the retry queue is empty (and stays out of the file)."""
+    config_path = tmp_path / "config.json"
+    cm = ConfigManager(config_path=str(config_path))
+    assert cm.get_v2_plugin_failed_installs() == []
+    saved = json.loads(config_path.read_text())
+    assert "v2_failed_installs" not in saved.get("plugin_migrations", {})
+
+
+def test_v2_plugin_failed_installs_round_trip(tmp_path):
+    """Setting + reloading from disk preserves the queue (deduped + sorted)."""
+    config_path = tmp_path / "config.json"
+    cm = ConfigManager(config_path=str(config_path))
+    cm.set_v2_plugin_failed_installs(["weather", "muni", "weather"])
+    assert cm.get_v2_plugin_failed_installs() == ["muni", "weather"]
+
+    # Reload from disk to confirm persistence.
+    ConfigManager._instance = None
+    cm2 = ConfigManager(config_path=str(config_path))
+    assert cm2.get_v2_plugin_failed_installs() == ["muni", "weather"]
+
+
+def test_v2_plugin_failed_installs_clear_removes_key(tmp_path):
+    """Clearing the queue drops the field entirely so the config stays tidy."""
+    config_path = tmp_path / "config.json"
+    cm = ConfigManager(config_path=str(config_path))
+    cm.set_v2_plugin_failed_installs(["weather"])
+    cm.clear_v2_plugin_failed_installs()
+    assert cm.get_v2_plugin_failed_installs() == []
+    saved = json.loads(config_path.read_text())
+    assert "v2_failed_installs" not in saved.get("plugin_migrations", {})
+
+
+def test_v2_plugin_failed_installs_ignores_non_string_entries(tmp_path):
+    """Defensive: stale on-disk corruption (None, ints, empty strings) is filtered."""
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "plugin_migrations": {
+                    "v2_completed": True,
+                    "v2_failed_installs": ["muni", "", None, 7, "weather"],
+                },
+            }
+        )
+    )
+    cm = ConfigManager(config_path=str(config_path))
+    assert cm.get_v2_plugin_failed_installs() == ["muni", "weather"]
+
+
+# --- app_version_seen stamp + pre-boot snapshot (issue #948) ---
+
+
+def test_app_version_seen_stamped_on_fresh_config(tmp_path):
+    """A brand-new config records the running version so the next boot can
+    detect upgrades without us having to scrape image digests."""
+    from src import __version__
+
+    config_path = tmp_path / "config.json"
+    cm = ConfigManager(config_path=str(config_path))
+    saved = json.loads(config_path.read_text())
+    assert saved.get("app_version_seen") == __version__
+    assert cm._config.get("app_version_seen") == __version__
+
+
+def test_app_version_seen_stamped_on_existing_config(tmp_path):
+    """Loading a config that pre-dates the stamp adds it on first boot."""
+    from src import __version__
+
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"plugins": {"weather": {"enabled": True}}}))
+    ConfigManager(config_path=str(config_path))
+    saved = json.loads(config_path.read_text())
+    assert saved.get("app_version_seen") == __version__
+
+
+def test_pre_boot_snapshot_written_when_version_changes(tmp_path):
+    """When the on-disk version differs from the running one, a pre-init
+    snapshot is dropped into update-backups/ before any migration runs.
+
+    This is the safety net for issue #948: every upgrade path now leaves
+    behind a rollback target, regardless of which mechanism the user used
+    (compose pull, FiestaUpdater button, FiestaPi update, etc.).
+    """
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "app_version_seen": "6.99.0",
+                "plugins": {"weather": {"enabled": True, "api_key": "k"}},
+                "board": {"api_mode": "local", "local_api_key": "x", "host": "h"},
+            }
+        )
+    )
+    # Plant a couple of sibling data files so the snapshot captures them too.
+    (tmp_path / "pages.json").write_text('{"pages": []}')
+
+    ConfigManager(config_path=str(config_path))
+
+    snapshot_dir = tmp_path / "update-backups"
+    assert snapshot_dir.is_dir(), "snapshot dir was not created"
+    snapshots = list(snapshot_dir.glob("pre-update-*.json"))
+    assert len(snapshots) == 1, f"expected exactly one boot snapshot, got {snapshots}"
+
+    doc = json.loads(snapshots[0].read_text())
+    meta = doc.get("_fiestaupdater") or {}
+    assert meta.get("trigger") == "boot-version-change"
+    assert meta.get("previous_version") == "6.99.0"
+    # The captured config payload reflects the pre-merge state — specifically
+    # it still carries the OLD app_version_seen, not the new one that __init__
+    # is about to stamp in.
+    snap_config = (doc.get("data") or {}).get("config") or {}
+    assert snap_config.get("plugins", {}).get("weather", {}).get("enabled") is True
+    assert snap_config.get("app_version_seen") == "6.99.0"
+
+
+def test_no_pre_boot_snapshot_when_versions_match(tmp_path):
+    """A normal restart (same version, same data) is not noisy — no extra
+    snapshot files are dropped into update-backups/."""
+    from src import __version__
+
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "app_version_seen": __version__,
+                "plugins": {"weather": {"enabled": True}},
+                "board": {"api_mode": "local", "local_api_key": "x", "host": "h"},
+            }
+        )
+    )
+    ConfigManager(config_path=str(config_path))
+
+    snapshot_dir = tmp_path / "update-backups"
+    assert not snapshot_dir.exists() or not list(snapshot_dir.glob("pre-update-*.json"))
+
+
+def test_no_pre_boot_snapshot_on_brand_new_install(tmp_path):
+    """A first-ever boot (no config file, no data worth backing up) does not
+    leave a junk snapshot behind."""
+    config_path = tmp_path / "config.json"
+    # No file exists; ConfigManager will create one.
+    ConfigManager(config_path=str(config_path))
+
+    snapshot_dir = tmp_path / "update-backups"
+    assert not snapshot_dir.exists() or not list(snapshot_dir.glob("pre-update-*.json"))

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -1429,9 +1429,7 @@ def test_auto_migrate_no_op_when_retry_queue_resolved(
     with patch("src.config_manager.get_config_manager") as mock_cm:
         mock_cm.return_value.is_v2_plugin_migration_done.return_value = True
         mock_cm.return_value.get_v2_plugin_failed_installs.return_value = ["muni"]
-        mock_cm.return_value.get_all_plugin_configs.return_value = {
-            "muni": {"enabled": True, "stop_code": "15726"}
-        }
+        mock_cm.return_value.get_all_plugin_configs.return_value = {"muni": {"enabled": True, "stop_code": "15726"}}
         registry.initialize()
 
     # No registry lookups, no install attempts.

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -1334,11 +1334,10 @@ def test_auto_migrate_marks_flag_even_when_install_fails(
     mock_load_reg, mock_install, mock_ext_dir, registry, mock_loader, mock_plugin, mock_manifest
 ):
     """If install fails for a transient reason on first boot, we still mark
-    migration as done. Rationale: the alternative (retry on every boot) means
-    that any plugin the user later uninstalls reappears the next time the
-    registry is briefly unreachable — the exact bug from #937. The cost of the
-    chosen tradeoff is small: the user manually installs the failed plugin
-    from the integrations page if needed.
+    migration as done so the user's deliberate uninstalls (#937) are not
+    silently undone on the next boot. But we ALSO record the failed plugin
+    in v2_failed_installs so the next boot can retry just that one plugin
+    (#948 — give upgraders a chance to recover from a flaky first attempt).
     """
     mock_loader.load_all_plugins.return_value = {}
     mock_load_reg.return_value = [
@@ -1355,6 +1354,91 @@ def test_auto_migrate_marks_flag_even_when_install_fails(
         registry.initialize()
 
     mock_cm.return_value.mark_v2_plugin_migration_done.assert_called_once()
+    mock_cm.return_value.set_v2_plugin_failed_installs.assert_called_with(["muni"])
+
+
+@patch("src.plugins.registry.get_external_plugins_dir")
+@patch("src.plugins.registry.install_registry_plugin", return_value=(True, ""))
+@patch("src.plugins.registry.load_registry")
+def test_auto_migrate_retries_only_failed_plugins_on_next_boot(
+    mock_load_reg, mock_install, mock_ext_dir, registry, mock_loader, mock_plugin, mock_manifest
+):
+    """On a subsequent boot (flag already set), the migration retries ONLY
+    the plugin ids in v2_failed_installs that still appear as orphaned
+    stored configs. This recovers from a flaky first attempt without
+    re-running the full migration (which would risk resurrecting plugins
+    the user uninstalled in between — the #937 invariant).
+    """
+    mock_manifest.id = "muni"
+    mock_loader.load_all_plugins.return_value = {}
+    mock_loader.load_plugin.return_value = mock_plugin
+    mock_loader.get_manifest.return_value = mock_manifest
+    mock_load_reg.return_value = [
+        RegistryEntry(
+            plugin_id="muni",
+            name="SF Muni",
+            repository="https://github.com/Org/fiestaboard-plugin--muni",
+        ),
+        RegistryEntry(
+            plugin_id="weather",
+            name="Weather",
+            repository="https://github.com/Org/fiestaboard-plugin--weather",
+        ),
+    ]
+
+    with patch("src.config_manager.get_config_manager") as mock_cm:
+        # Subsequent boot: migration already ran. Only `muni` previously
+        # failed; `weather` was an intentional uninstall (no entry).
+        mock_cm.return_value.is_v2_plugin_migration_done.return_value = True
+        mock_cm.return_value.get_v2_plugin_failed_installs.return_value = ["muni"]
+        # Both still appear in stored configs (the #937 fix would have
+        # purged `weather` if the user had clicked Uninstall, but we
+        # leave both here to prove the retry filter — not the orphan
+        # detector — is what scopes the retry).
+        mock_cm.return_value.get_all_plugin_configs.return_value = {
+            "muni": {"enabled": True, "stop_code": "15726"},
+            "weather": {"enabled": True, "api_key": "k"},
+        }
+        registry.initialize()
+
+    # Only muni was retried; weather was not even attempted.
+    install_calls = [c.args[0].plugin_id for c in mock_install.call_args_list]
+    assert install_calls == ["muni"]
+    # mark_v2_plugin_migration_done is NOT called again (already done).
+    mock_cm.return_value.mark_v2_plugin_migration_done.assert_not_called()
+    # Retry queue is cleared (muni succeeded).
+    mock_cm.return_value.set_v2_plugin_failed_installs.assert_called_with([])
+
+
+@patch("src.plugins.registry.get_external_plugins_dir")
+@patch("src.plugins.registry.install_registry_plugin", return_value=(True, ""))
+@patch("src.plugins.registry.load_registry")
+def test_auto_migrate_no_op_when_retry_queue_resolved(
+    mock_load_reg, mock_install, mock_ext_dir, registry, mock_loader, mock_plugin, mock_manifest
+):
+    """If the retry queue references plugins that the user has since installed
+    or uninstalled manually, the migration is a clean no-op and clears the
+    queue — it must NOT re-run the full first-boot scan.
+    """
+    # Simulate: muni was queued for retry, but the user installed it manually
+    # (so it's now in self._plugins) and the queue is stale.
+    mock_manifest.id = "muni"
+    mock_loader.load_all_plugins.return_value = {"muni": mock_plugin}
+    mock_loader.get_manifest.return_value = mock_manifest
+
+    with patch("src.config_manager.get_config_manager") as mock_cm:
+        mock_cm.return_value.is_v2_plugin_migration_done.return_value = True
+        mock_cm.return_value.get_v2_plugin_failed_installs.return_value = ["muni"]
+        mock_cm.return_value.get_all_plugin_configs.return_value = {
+            "muni": {"enabled": True, "stop_code": "15726"}
+        }
+        registry.initialize()
+
+    # No registry lookups, no install attempts.
+    mock_load_reg.assert_not_called()
+    mock_install.assert_not_called()
+    # Stale queue is cleared so future boots short-circuit immediately.
+    mock_cm.return_value.clear_v2_plugin_failed_installs.assert_called_once()
 
 
 @patch("src.plugins.registry.get_external_plugins_dir")

--- a/tests/test_system_endpoints.py
+++ b/tests/test_system_endpoints.py
@@ -1,9 +1,10 @@
 """Tests for system management endpoints (update check)."""
 
+import json
 import os
 from datetime import UTC
 from typing import Any
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 from urllib.parse import urlparse
 
 import pytest
@@ -689,6 +690,83 @@ class TestSettingsSnapshots:
 
         survivors = api._list_settings_snapshots()
         assert len(survivors) == 5
+
+    def test_detect_regression_flags_missing_enabled_plugins(self, tmp_path, monkeypatch):
+        """When the newest snapshot has more enabled plugins than the live
+        config, the detector returns a recovery hint pointing at the rollback
+        endpoint. This is the visible-to-the-user half of issue #948.
+        """
+        from src import api_server as api
+
+        snap_dir = tmp_path / "update-backups"
+        snap_dir.mkdir()
+        monkeypatch.setattr(api, "SETTINGS_SNAPSHOT_DIR", snap_dir)
+
+        # Plant a snapshot whose recorded config had 3 enabled plugins.
+        snap_doc = {
+            "fiestaboard_backup": True,
+            "schema_version": 1,
+            "app_version": "7.0.10",
+            "data": {
+                "config": {
+                    "plugins": {
+                        "weather": {"enabled": True, "api_key": "k"},
+                        "muni": {"enabled": True, "stop_code": "1"},
+                        "stocks": {"enabled": False, "symbols": []},
+                        "date_time": {"enabled": True},
+                    }
+                }
+            },
+        }
+        target = snap_dir / "pre-update-20260611T030000.000Z.json"
+        target.write_text(json.dumps(snap_doc))
+
+        # Live config currently only has date_time enabled (the post-upgrade
+        # state DarthXoc reported).
+        mock_cm = MagicMock()
+        mock_cm.get_all_plugin_configs.return_value = {
+            "weather": {"enabled": False},
+            "muni": {"enabled": False},
+            "date_time": {"enabled": True},
+        }
+        monkeypatch.setattr(api, "get_config_manager", lambda: mock_cm)
+
+        hint = api._detect_post_upgrade_regression()
+        assert hint is not None
+        assert hint["snapshot_name"] == target.name
+        assert hint["snapshot_enabled_count"] == 3
+        assert hint["current_enabled_count"] == 1
+        assert sorted(hint["missing_plugin_ids"]) == ["muni", "weather"]
+        assert "rollback" in hint["rollback_hint"]
+
+    def test_detect_regression_returns_none_when_caught_up(self, tmp_path, monkeypatch):
+        """A clean upgrade (no plugin loss) does not produce a recovery hint."""
+        from src import api_server as api
+
+        snap_dir = tmp_path / "update-backups"
+        snap_dir.mkdir()
+        monkeypatch.setattr(api, "SETTINGS_SNAPSHOT_DIR", snap_dir)
+
+        snap_doc = {
+            "fiestaboard_backup": True,
+            "data": {"config": {"plugins": {"weather": {"enabled": True}}}},
+        }
+        (snap_dir / "pre-update-20260611T030000.000Z.json").write_text(json.dumps(snap_doc))
+
+        mock_cm = MagicMock()
+        mock_cm.get_all_plugin_configs.return_value = {"weather": {"enabled": True, "api_key": "k"}}
+        monkeypatch.setattr(api, "get_config_manager", lambda: mock_cm)
+
+        assert api._detect_post_upgrade_regression() is None
+
+    def test_detect_regression_returns_none_when_no_snapshots(self, tmp_path, monkeypatch):
+        """No snapshots → nothing to compare against → no hint."""
+        from src import api_server as api
+
+        snap_dir = tmp_path / "update-backups"
+        monkeypatch.setattr(api, "SETTINGS_SNAPSHOT_DIR", snap_dir)
+
+        assert api._detect_post_upgrade_regression() is None
 
     def test_resolve_rejects_path_traversal(self, tmp_path, monkeypatch):
         """``..`` and absolute paths must not escape the snapshot dir."""


### PR DESCRIPTION
## Summary

Stop the bleed for upgrade-eats-integrations (#948). Three layers, smallest first:

- **Boot-time snapshot.** `ConfigManager._load_or_create` now stamps `app_version_seen` and, when the on-disk version disagrees with `src.__version__`, writes a `pre-update-<ts>.json` snapshot of `data/*.json` **before** any merge or migration runs. Matches the existing `/system/update/rollback` filename shape so recovery is one POST away — regardless of upgrade method (compose pull, FiestaUpdater, FiestaPi button, Watchtower, manual swap). Hand-rolled to avoid `BackupService.build_backup → plugin registry → get_config_manager` re-entering during init.
- **Recovery hint.** `/system/update/status` now returns a `post_upgrade_regression` field when the newest snapshot has materially more enabled plugins than the live config; the startup lifespan also logs a loud `WARNING` with the exact rollback command. Users already in the lost state get a one-click recovery path instead of having to discover `update-backups/` themselves.
- **Tighter v2 migration.** Per-plugin install failures are now persisted in `plugin_migrations.v2_failed_installs` and retried on the next boot — but only if the orphan config is still present. Preserves the #937 invariant (deliberate uninstalls don't resurrect) while letting a transient `git clone` blip self-heal instead of permanently locking out auto-install.

**No-override guarantee preserved:** the migration only ever reads/writes plugin ids that are in `stored_configs` AND NOT in `self._plugins`. A loaded plugin with `enabled=True` is never read, never rewritten, never disabled by anything in this PR.

## Root-cause status

Empirically confirmed from DarthXoc's `app.log`: last 7.0.10 boot logged `Initialized 19 plugins (7 enabled)` with 3 instances restored; first 7.1.1 boot logged `Initialized 16 plugins (1 enabled)` with no instances. The exact line that resets the `enabled` flags between boots remains unidentified — the 7.0.10..7.1.1 src diff is only ~190 lines and none of it overtly wipes configs — but the damage is real and not limited to one user. This PR is the safety net so further regressions (this one and any future ones) can't bleed silently again.

## Test plan

- [x] `pytest tests/test_config_manager.py tests/test_plugin_registry.py tests/test_system_endpoints.py` — 226 passed
- [x] Full suite: 3775 passed, 11 skipped, 0 failures
- [ ] Manual: bump `src/__version__` between two boots on a dev install with enabled plugins → confirm `data/update-backups/pre-update-*.json` appears
- [ ] Manual: trigger a `_run_v2_plugin_migration` failure (mock `install_from_registry` to error once), reboot → confirm `v2_failed_installs` set, plugin retried and removed from list on second boot
- [ ] Manual: hit `GET /system/update/status` after a synthetic regression → confirm `post_upgrade_regression` field is populated and startup log shows the WARNING

Closes #948.

🤖 Generated with [Claude Code](https://claude.com/claude-code)