### PR TITLE
fix(ci): allowlist tools for docs-audit so Claude can actually write

### DIFF
--- a/.github/workflows/claude-docs-audit.yml
+++ b/.github/workflows/claude-docs-audit.yml
@@ -73,8 +73,19 @@ jobs:
           GH_TOKEN: ${{ secrets.RELEASE_PAT }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Surface the SDK transcript in the Actions log. Without this the
+          # action prints "full output hidden for security" and silent
+          # permission denials look like a clean success.
+          show_full_output: 'true'
           # Sonnet — the user picked this tier for the recurring audit.
-          claude_args: '--model claude-sonnet-4-6 --max-turns 60'
+          # --allowed-tools: the agent-mode default toolset is read-only, so
+          # without this allowlist every Edit/Write/`git`/`gh` call is denied
+          # and the run completes with 0 PRs + 0 issues + an unchanged state
+          # file. Bash patterns must match what the prompt actually invokes.
+          claude_args: >-
+            --model claude-sonnet-4-6
+            --max-turns 60
+            --allowed-tools "Read,Glob,Grep,Edit,Write,Bash(ls:*),Bash(cat:*),Bash(date:*),Bash(jq:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git branch:*),Bash(git checkout:*),Bash(git switch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git fetch:*),Bash(git rev-parse:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh issue list:*),Bash(gh issue view:*),Bash(gh issue create:*),Bash(gh label list:*),Bash(gh label create:*)"
           prompt: |
             You are the FiestaBoard docs auditor. You run unattended once a day
             at 4pm America/Los_Angeles and audit a small batch of repo docs.


### PR DESCRIPTION
## Summary
- The daily docs-audit cron has been running successfully but doing nothing — no PRs, no issues, no state-file updates.
- Root cause: `claude-code-action@v1` in agent / `workflow_dispatch` mode ships a read-only default toolset. Without an `--allowed-tools` allowlist, every `Edit`/`Write`, `git checkout -b`, `git push`, `gh pr create`, `gh issue create`, and `gh label create` the prompt issues was denied. The 2026-06-11 manual dispatch ([run 27330084308](https://github.com/Fiestaboard/FiestaBoard/actions/runs/27330084308)) burned 40 turns + $2.85 of Sonnet and logged `permission_denials_count: 54`, then exited "successfully".
- Bonus: `show_full_output: true` so the SDK transcript actually lands in the Actions log next time. Without it the action prints "full output hidden for security" and silent denials look like clean successes.

## Changes
- `.github/workflows/claude-docs-audit.yml`
  - Add `--allowed-tools` covering `Read,Glob,Grep,Edit,Write` plus the specific `git` and `gh` subcommands the prompt actually invokes (`git checkout`/`add`/`commit`/`push`, `gh pr create`, `gh issue list`/`view`/`create`, `gh label list`/`create`).
  - Set `show_full_output: 'true'`.

Same allowlist shape as `pr-changelog.yml`, just broader because this job opens PRs and files issues instead of only commenting.

## Test plan
- [ ] Merge, then manually dispatch **Claude: Docs Audit** from the Actions tab.
- [ ] Confirm `permission_denials_count` is `0` (or near-zero) in the SDK result block in the run log.
- [ ] Confirm a `docs-audit/round-1-batch-*` branch + draft PR is opened **and/or** issues with label `docs-audit` are filed.
- [ ] Confirm `.github/docs-audit-state.json` is bumped on `main` with `chore(docs-audit): advance sweep state [skip ci]`.
- [ ] Let the next scheduled 4pm PT run fire and confirm steady-state behavior matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)