### PR TITLE
ci: fire CI on merge_group + tighten integration-tests step timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,17 @@ on:
   pull_request:
     # Run on all PRs regardless of target branch (validate before merge)
     branches: [ '**' ]
+  # Required so the `CI Success` status check reports on the merge-queue
+  # SHA. Without this, GitHub waits `check_response_timeout_minutes` for a
+  # check that never fires and removes the PR with "no response for
+  # status checks". See `dorny/paths-filter` — it diffs the merge SHA
+  # against main, so the existing path filters keep heavy jobs skipped
+  # when the merge commit touches nothing they care about.
+  merge_group:
 
 concurrency:
+  # On merge_group there is no pull_request.number, so this falls back to
+  # the merge SHA — unique per queue entry, so no cross-queue cancels.
   group: ci-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -44,6 +44,7 @@ jobs:
 
       - name: Build production image (same as prod for E2E)
         uses: docker/build-push-action@v7
+        timeout-minutes: 10
         with:
           context: .
           file: ./Dockerfile
@@ -83,6 +84,7 @@ jobs:
 
       - name: Install UI dependencies
         working-directory: web
+        timeout-minutes: 5
         run: |
           if [ -f package-lock.json ]; then
             npm ci --legacy-peer-deps --no-audit
@@ -92,6 +94,7 @@ jobs:
 
       - name: Install Playwright browsers
         working-directory: web
+        timeout-minutes: 5
         run: npx playwright install --with-deps chromium
 
       # ── PR: single container for smoke subset ─────────────────────
@@ -188,6 +191,7 @@ jobs:
 
       - name: Wait for all containers to be ready (full suite)
         if: github.event_name == 'merge_group'
+        timeout-minutes: 3
         run: |
           IFS=',' read -ra URLS <<< "$WORKER_URLS"
           for url in "${URLS[@]}"; do


### PR DESCRIPTION
## Summary

- Add `merge_group:` trigger to `ci.yml` so the required `CI Success` status check actually reports on merge-queue SHAs.
- Add per-step `timeout-minutes` to the heavy steps in `integration-tests.yml` (Docker build, npm ci, Playwright install, container readiness) so a stuck step fails fast.

## Why

Today's merge queue removed PR #956 twice with "no response for status checks":
- added 06:45 → removed 08:10 (1h 25m)
- added 15:25 → removed 16:28 (1h 3m)

Root cause: branch protection requires `CI Success`, but `ci.yml` only ran on `pull_request` / `push` — never on `merge_group`. The merge-queue SHA therefore only ever got `Integration Tests (full)`. After 60 minutes (`check_response_timeout_minutes`) the queue gave up and kicked the PR.

With `merge_group:` added, `dorny/paths-filter` diffs the merge SHA against `main`, so the existing path filters keep heavy jobs skipped when the merge commit touches nothing they care about — the common case. `CI Success` always resolves cleanly.

The per-step timeouts are belt-and-suspenders: today's still-queued integration run was sitting at "in_progress" since 17:26 with no runner pick-up. A stuck `docker buildx` or `npm ci` no longer silently consumes the entire 15-min job budget.

## Follow-ups (not in this PR)

- Consolidate required checks from legacy branch protection into ruleset `12439113`.
- Drop `check_response_timeout_minutes` from 60 → 30 once this lands.

## Test plan

- [ ] CI passes on this PR.
- [ ] When merged into the queue, `CI Success` reports on the merge-group SHA within ~1-2 min (detect-changes only, since `.github/workflows/*.yml` is in the `shared` filter but everything else is unchanged here).
- [ ] PR is not removed from the merge queue with "no response for status checks".

🤖 Generated with [Claude Code](https://claude.com/claude-code)