### PR TITLE
fix(scheduler): stop pushing active page when schedule disabled (#970)

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -285,20 +285,19 @@ class DisplayService:
                         f"Schedule mode: No matching schedule for {current_day} {current_time.strftime('%H:%M')}"
                     )
             elif active_page_id is None:
-                # Manual mode: Use manual active page setting
-                active_page_id = settings_service.get_active_page_id()
-                logger.debug(f"Manual mode: Using manual active page: {active_page_id}")
-
-            # No active page set - try to default to first page (manual mode only)
-            if not active_page_id and not settings_service.is_schedule_enabled():
-                pages = page_service.list_pages()
-                if pages:
-                    active_page_id = pages[0].id
-                    settings_service.set_active_page_id(active_page_id)
-                    logger.info(f"No active page set, defaulting to first page: {active_page_id}")
-                else:
-                    logger.debug("No active page and no pages available")
-                    return False
+                # Schedule is disabled and no explicit user override is active.
+                # Issue #970: a user toggling the schedule off expects FiestaBoard
+                # to stop pushing to the board so out-of-band content (e.g. a
+                # message composed in the Vestaboard app) isn't overwritten by
+                # the polling loop. Don't auto-push the manually-configured
+                # active page here — explicit user actions (POST
+                # /settings/active-page, POST /settings/temporary-override)
+                # still flow through their own send paths, so the user retains
+                # a way to push when they want to.
+                logger.debug("Schedule disabled - skipping active-page auto-push (issue #970)")
+                self._last_active_page_content = None
+                self._last_active_page_id = None
+                return False
 
             # If schedule mode but no page (gap without default), don't update board
             if not active_page_id:

--- a/tests/test_integration_multi_features.py
+++ b/tests/test_integration_multi_features.py
@@ -251,8 +251,16 @@ class TestScheduleModeIntegration:
 
         return {"page": page_service, "schedule": schedule_service, "settings": settings_service}
 
-    def test_manual_mode_uses_manual_active_page(self, services):
-        """Test that manual mode uses the manual active page setting."""
+    def test_schedule_disabled_does_not_auto_push_active_page(self, services):
+        """Regression for issue #970: schedule off must stop the polling-loop push.
+
+        Pre-fix, toggling the schedule off fell back to "manual mode" and the
+        polling loop kept pushing the manually-set active page (with its live
+        variables, e.g. a clock) — overwriting out-of-band content sent from
+        the Vestaboard app. Now schedule-off means "FiestaBoard stops touching
+        the board" until the user explicitly re-enables the schedule or pushes
+        a page via /settings/active-page or /settings/temporary-override.
+        """
         page_service = services["page"]
         settings_service = services["settings"]
 
@@ -283,11 +291,13 @@ class TestScheduleModeIntegration:
                         service = DisplayService()
                         service.vb_client = mock_client_instance
 
-                        # Check active page (should use manual page1)
-                        service.check_and_send_active_page()
+                        # Tick the polling loop.
+                        sent = service.check_and_send_active_page()
 
-                        # Verify it used page1 (manual), not page2
-                        assert service._last_active_page_id == page1.id
+                        # The polling tick must be a no-op when schedule is off.
+                        assert sent is False
+                        assert service._last_active_page_id is None
+                        mock_client_instance.send_characters.assert_not_called()
 
     def test_schedule_mode_uses_scheduled_page(self, services):
         """Test that schedule mode uses the schedule-based page selection."""

--- a/tests/test_schedule_disabled_no_push.py
+++ b/tests/test_schedule_disabled_no_push.py
@@ -70,9 +70,7 @@ class TestScheduleDisabledNoPush:
         live variables) was getting pushed every tick after the user toggled
         the schedule off, overwriting an out-of-band custom message.
         """
-        page_service, settings, config = _patch_common(
-            active_page_id="active-page", schedule_enabled=False
-        )
+        page_service, settings, config = _patch_common(active_page_id="active-page", schedule_enabled=False)
 
         with (
             patch("src.main.get_page_service", return_value=page_service),
@@ -92,9 +90,7 @@ class TestScheduleDisabledNoPush:
 
     def test_schedule_off_subsequent_ticks_stay_silent(self, service):
         """Multiple polling ticks with schedule off should never push."""
-        page_service, settings, config = _patch_common(
-            active_page_id="active-page", schedule_enabled=False
-        )
+        page_service, settings, config = _patch_common(active_page_id="active-page", schedule_enabled=False)
 
         with (
             patch("src.main.get_page_service", return_value=page_service),

--- a/tests/test_schedule_disabled_no_push.py
+++ b/tests/test_schedule_disabled_no_push.py
@@ -1,0 +1,190 @@
+"""Regression test for issue #970: schedule-off must not push to the board.
+
+When a user toggles the schedule off (e.g. so their kid's out-of-band message
+sent from the Vestaboard app stays visible), the polling loop must stop
+auto-pushing the active page. Triggers and explicit user overrides still
+flow through their own paths, so the user retains a way to push when they
+want to — but ``check_and_send_active_page`` itself goes quiet.
+
+See: https://github.com/Fiestaboard/FiestaBoard/issues/970
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from src.main import DisplayService
+
+
+@pytest.fixture
+def service():
+    svc = DisplayService()
+    svc.vb_client = Mock()
+    svc.vb_client.send_characters.return_value = (True, True)
+    return svc
+
+
+def _patch_common(active_page_id="active-page", schedule_enabled=False):
+    """Build the standard set of mocks for a check_and_send_active_page tick.
+
+    Mirrors the pattern used in tests/test_silence_mode_display.py.
+    """
+    page = Mock(
+        id=active_page_id,
+        device_type="note",
+        transition_strategy=None,
+        transition_interval_ms=None,
+        transition_step_size=None,
+    )
+    result = Mock(available=True, formatted="CLOCK\n12:34")
+
+    page_service = Mock()
+    page_service.get_page.return_value = page
+    page_service.preview_page.return_value = result
+    page_service.list_pages.return_value = [page]
+
+    settings = Mock()
+    settings.is_schedule_enabled.return_value = schedule_enabled
+    settings.get_active_page_id.return_value = active_page_id
+    settings.consume_temporary_override.return_value = None
+    settings.get_board_settings.return_value = Mock(boards=[{"device_type": "note"}])
+    settings.get_transition_settings.return_value = Mock(strategy=None, step_interval_ms=500, step_size=1)
+
+    config = Mock()
+    config.is_silence_mode_active.return_value = False
+    config.SILENCE_SCHEDULE_MODE = "indicator"
+    config.SILENCE_SCHEDULE_PAGE_ID = None
+    config.SILENCE_SCHEDULE_INDICATOR_TEXT = "SNOOZING"
+    config.SILENCE_SCHEDULE_INDICATOR_POSITION = "center"
+
+    return page_service, settings, config
+
+
+class TestScheduleDisabledNoPush:
+    """When schedule is off, the polling tick must not touch the board."""
+
+    def test_schedule_off_with_active_page_does_not_send(self, service):
+        """Schedule disabled + manually-set active page → no send.
+
+        This is the literal repro from #970: the active page (e.g. a clock with
+        live variables) was getting pushed every tick after the user toggled
+        the schedule off, overwriting an out-of-band custom message.
+        """
+        page_service, settings, config = _patch_common(
+            active_page_id="active-page", schedule_enabled=False
+        )
+
+        with (
+            patch("src.main.get_page_service", return_value=page_service),
+            patch("src.main.get_settings_service", return_value=settings),
+            patch("src.main.get_schedule_service"),
+            patch("src.main.Config", config),
+            patch.object(service, "_check_trigger_override", return_value=None),
+        ):
+            sent = service.check_and_send_active_page()
+
+        assert sent is False
+        service.vb_client.send_characters.assert_not_called()
+        # The polling render path should also be skipped — no rendering, no
+        # plugin variable refresh — so a clock template isn't being recomputed
+        # every tick when the user expects "off" to mean "off".
+        page_service.preview_page.assert_not_called()
+
+    def test_schedule_off_subsequent_ticks_stay_silent(self, service):
+        """Multiple polling ticks with schedule off should never push."""
+        page_service, settings, config = _patch_common(
+            active_page_id="active-page", schedule_enabled=False
+        )
+
+        with (
+            patch("src.main.get_page_service", return_value=page_service),
+            patch("src.main.get_settings_service", return_value=settings),
+            patch("src.main.get_schedule_service"),
+            patch("src.main.Config", config),
+            patch.object(service, "_check_trigger_override", return_value=None),
+        ):
+            for _ in range(3):
+                assert service.check_and_send_active_page() is False
+
+        service.vb_client.send_characters.assert_not_called()
+
+    def test_schedule_off_with_no_active_page_does_not_default_to_first(self, service):
+        """Schedule off + no manual active page → must not default to first page.
+
+        The pre-fix behavior would call ``set_active_page_id(first_page)`` and
+        push it. After the fix the polling loop must stay quiet.
+        """
+        page_service, settings, config = _patch_common(schedule_enabled=False)
+        settings.get_active_page_id.return_value = None
+
+        with (
+            patch("src.main.get_page_service", return_value=page_service),
+            patch("src.main.get_settings_service", return_value=settings),
+            patch("src.main.get_schedule_service"),
+            patch("src.main.Config", config),
+            patch.object(service, "_check_trigger_override", return_value=None),
+        ):
+            sent = service.check_and_send_active_page()
+
+        assert sent is False
+        service.vb_client.send_characters.assert_not_called()
+        # We must not silently mutate the user's active-page setting either.
+        settings.set_active_page_id.assert_not_called()
+
+    def test_schedule_on_still_pushes_active_page(self, service):
+        """Sanity: schedule-on path is unchanged — the fix is scoped to off."""
+        page_service, settings, config = _patch_common(schedule_enabled=True)
+        schedule_svc = Mock()
+        schedule_svc.get_active_page_id.return_value = "active-page"
+
+        with (
+            patch("src.main.get_page_service", return_value=page_service),
+            patch("src.main.get_settings_service", return_value=settings),
+            patch("src.main.get_schedule_service", return_value=schedule_svc),
+            patch("src.main.Config", config),
+            patch.object(service, "_check_trigger_override", return_value=None),
+            patch("src.main.get_collection_service") as collection_svc,
+        ):
+            collection_svc.return_value.resolve_page_id.return_value = "active-page"
+            service.check_and_send_active_page()
+
+        # The board should have received an update via the normal schedule path.
+        service.vb_client.send_characters.assert_called()
+
+    def test_schedule_off_still_honors_temporary_override(self, service):
+        """A user-initiated temporary override must push even with schedule off.
+
+        ``POST /settings/temporary-override`` is an explicit user action ("show
+        this page now"). The schedule-off guard must not swallow it — that
+        would be the same class of bug, just on a different toggle.
+        """
+        page_service, settings, config = _patch_common(schedule_enabled=False)
+
+        override = Mock()
+        override.is_expired.return_value = False
+        override.page_id = "override-page"
+        settings.consume_temporary_override.return_value = override
+
+        # The override flow asks for the override page via get_page.
+        override_page = Mock(
+            id="override-page",
+            device_type="note",
+            transition_strategy=None,
+            transition_interval_ms=None,
+            transition_step_size=None,
+        )
+        page_service.get_page.return_value = override_page
+
+        with (
+            patch("src.main.get_page_service", return_value=page_service),
+            patch("src.main.get_settings_service", return_value=settings),
+            patch("src.main.get_schedule_service"),
+            patch("src.main.Config", config),
+            patch.object(service, "_check_trigger_override", return_value=None),
+            patch("src.main.get_collection_service") as collection_svc,
+        ):
+            collection_svc.return_value.resolve_page_id.return_value = "override-page"
+            service.check_and_send_active_page()
+
+        # Explicit overrides MUST still reach the board even when schedule is off.
+        service.vb_client.send_characters.assert_called()

--- a/tests/test_silence_mode_display.py
+++ b/tests/test_silence_mode_display.py
@@ -108,8 +108,12 @@ class TestSilenceModeDispatch:
         page_service.preview_page.return_value = result
 
         settings = Mock()
-        settings.is_schedule_enabled.return_value = False
+        # Silence-mode dispatch is a sub-feature of the polling loop, so these
+        # tests assume schedule mode is on — the schedule-off guard (#970)
+        # would otherwise short-circuit before silence runs.
+        settings.is_schedule_enabled.return_value = True
         settings.get_active_page_id.return_value = "active-page"
+        settings.consume_temporary_override.return_value = None
         settings.get_board_settings.return_value = Mock(boards=[{"device_type": "note"}])
         settings.get_transition_settings.return_value = Mock(strategy=None, step_interval_ms=500, step_size=1)
 
@@ -127,7 +131,7 @@ class TestSilenceModeDispatch:
         with (
             patch("src.main.get_page_service", return_value=page_service),
             patch("src.main.get_settings_service", return_value=settings),
-            patch("src.main.get_schedule_service"),
+            patch("src.main.get_schedule_service", return_value=Mock(get_active_page_id=Mock(return_value="active-page"))),
             patch("src.main.Config", config),
             patch.object(service, "_check_trigger_override", return_value=None),
         ):
@@ -143,7 +147,7 @@ class TestSilenceModeDispatch:
         with (
             patch("src.main.get_page_service", return_value=page_service),
             patch("src.main.get_settings_service", return_value=settings),
-            patch("src.main.get_schedule_service"),
+            patch("src.main.get_schedule_service", return_value=Mock(get_active_page_id=Mock(return_value="active-page"))),
             patch("src.main.Config", config),
             patch.object(service, "_check_trigger_override", return_value=None),
         ):
@@ -157,7 +161,7 @@ class TestSilenceModeDispatch:
         with (
             patch("src.main.get_page_service", return_value=page_service),
             patch("src.main.get_settings_service", return_value=settings),
-            patch("src.main.get_schedule_service"),
+            patch("src.main.get_schedule_service", return_value=Mock(get_active_page_id=Mock(return_value="active-page"))),
             patch("src.main.Config", config),
             patch.object(service, "_check_trigger_override", return_value=None),
         ):
@@ -203,7 +207,7 @@ class TestSilenceModeDispatch:
         with (
             patch("src.main.get_page_service", return_value=page_service),
             patch("src.main.get_settings_service", return_value=settings),
-            patch("src.main.get_schedule_service"),
+            patch("src.main.get_schedule_service", return_value=Mock(get_active_page_id=Mock(return_value="active-page"))),
             patch("src.main.Config", config),
             patch.object(service, "_check_trigger_override", return_value=None),
         ):
@@ -230,7 +234,7 @@ class TestSilenceModeDispatch:
         with (
             patch("src.main.get_page_service", return_value=page_service),
             patch("src.main.get_settings_service", return_value=settings),
-            patch("src.main.get_schedule_service"),
+            patch("src.main.get_schedule_service", return_value=Mock(get_active_page_id=Mock(return_value="active-page"))),
             patch("src.main.Config", config),
             patch.object(service, "_check_trigger_override", return_value=None),
         ):
@@ -260,8 +264,10 @@ class TestCustomIndicatorTextAndPosition:
         page_service.preview_page.return_value = result
 
         settings = Mock()
-        settings.is_schedule_enabled.return_value = False
+        # Schedule mode on — see comment in TestSilenceModeDispatch._patch_common.
+        settings.is_schedule_enabled.return_value = True
         settings.get_active_page_id.return_value = "active-page"
+        settings.consume_temporary_override.return_value = None
         settings.get_board_settings.return_value = Mock(boards=[{"device_type": "flagship"}])
         settings.get_transition_settings.return_value = Mock(strategy=None, step_interval_ms=500, step_size=1)
 
@@ -278,7 +284,7 @@ class TestCustomIndicatorTextAndPosition:
         with (
             patch("src.main.get_page_service", return_value=page_service),
             patch("src.main.get_settings_service", return_value=settings),
-            patch("src.main.get_schedule_service"),
+            patch("src.main.get_schedule_service", return_value=Mock(get_active_page_id=Mock(return_value="active-page"))),
             patch("src.main.Config", config),
             patch.object(service, "_check_trigger_override", return_value=None),
         ):
@@ -294,7 +300,7 @@ class TestCustomIndicatorTextAndPosition:
         with (
             patch("src.main.get_page_service", return_value=page_service),
             patch("src.main.get_settings_service", return_value=settings),
-            patch("src.main.get_schedule_service"),
+            patch("src.main.get_schedule_service", return_value=Mock(get_active_page_id=Mock(return_value="active-page"))),
             patch("src.main.Config", config),
             patch.object(service, "_check_trigger_override", return_value=None),
         ):
@@ -322,7 +328,7 @@ class TestCustomIndicatorTextAndPosition:
         with (
             patch("src.main.get_page_service", return_value=page_service),
             patch("src.main.get_settings_service", return_value=settings),
-            patch("src.main.get_schedule_service"),
+            patch("src.main.get_schedule_service", return_value=Mock(get_active_page_id=Mock(return_value="active-page"))),
             patch("src.main.Config", config),
             patch.object(service, "_check_trigger_override", return_value=None),
         ):
@@ -387,7 +393,8 @@ class TestTemporaryOverrideDuringSilence:
         )
 
         settings = Mock()
-        settings.is_schedule_enabled.return_value = False
+        # Schedule mode on — see comment in TestSilenceModeDispatch._patch_common.
+        settings.is_schedule_enabled.return_value = True
         settings.get_active_page_id.return_value = "active-page"
         settings.get_board_settings.return_value = Mock(boards=[{"device_type": "note"}])
         settings.get_transition_settings.return_value = Mock(strategy=None, step_interval_ms=500, step_size=1)
@@ -408,7 +415,7 @@ class TestTemporaryOverrideDuringSilence:
         with (
             patch("src.main.get_page_service", return_value=page_service),
             patch("src.main.get_settings_service", return_value=settings),
-            patch("src.main.get_schedule_service"),
+            patch("src.main.get_schedule_service", return_value=Mock(get_active_page_id=Mock(return_value="active-page"))),
             patch("src.main.Config", config),
             patch.object(service, "_check_trigger_override", return_value=None),
         ):
@@ -426,7 +433,7 @@ class TestTemporaryOverrideDuringSilence:
         with (
             patch("src.main.get_page_service", return_value=page_service),
             patch("src.main.get_settings_service", return_value=settings),
-            patch("src.main.get_schedule_service"),
+            patch("src.main.get_schedule_service", return_value=Mock(get_active_page_id=Mock(return_value="active-page"))),
             patch("src.main.Config", config),
             patch.object(service, "_check_trigger_override", return_value=None),
         ):
@@ -443,7 +450,7 @@ class TestTemporaryOverrideDuringSilence:
         with (
             patch("src.main.get_page_service", return_value=page_service),
             patch("src.main.get_settings_service", return_value=settings),
-            patch("src.main.get_schedule_service"),
+            patch("src.main.get_schedule_service", return_value=Mock(get_active_page_id=Mock(return_value="active-page"))),
             patch("src.main.Config", config),
             patch.object(service, "_check_trigger_override", return_value=None),
         ):

--- a/tests/test_silence_mode_display.py
+++ b/tests/test_silence_mode_display.py
@@ -131,7 +131,9 @@ class TestSilenceModeDispatch:
         with (
             patch("src.main.get_page_service", return_value=page_service),
             patch("src.main.get_settings_service", return_value=settings),
-            patch("src.main.get_schedule_service", return_value=Mock(get_active_page_id=Mock(return_value="active-page"))),
+            patch(
+                "src.main.get_schedule_service", return_value=Mock(get_active_page_id=Mock(return_value="active-page"))
+            ),
             patch("src.main.Config", config),
             patch.object(service, "_check_trigger_override", return_value=None),
         ):
@@ -147,7 +149,9 @@ class TestSilenceModeDispatch:
         with (
             patch("src.main.get_page_service", return_value=page_service),
             patch("src.main.get_settings_service", return_value=settings),
-            patch("src.main.get_schedule_service", return_value=Mock(get_active_page_id=Mock(return_value="active-page"))),
+            patch(
+                "src.main.get_schedule_service", return_value=Mock(get_active_page_id=Mock(return_value="active-page"))
+            ),
             patch("src.main.Config", config),
             patch.object(service, "_check_trigger_override", return_value=None),
         ):
@@ -161,7 +165,9 @@ class TestSilenceModeDispatch:
         with (
             patch("src.main.get_page_service", return_value=page_service),
             patch("src.main.get_settings_service", return_value=settings),
-            patch("src.main.get_schedule_service", return_value=Mock(get_active_page_id=Mock(return_value="active-page"))),
+            patch(
+                "src.main.get_schedule_service", return_value=Mock(get_active_page_id=Mock(return_value="active-page"))
+            ),
             patch("src.main.Config", config),
             patch.object(service, "_check_trigger_override", return_value=None),
         ):
@@ -207,7 +213,9 @@ class TestSilenceModeDispatch:
         with (
             patch("src.main.get_page_service", return_value=page_service),
             patch("src.main.get_settings_service", return_value=settings),
-            patch("src.main.get_schedule_service", return_value=Mock(get_active_page_id=Mock(return_value="active-page"))),
+            patch(
+                "src.main.get_schedule_service", return_value=Mock(get_active_page_id=Mock(return_value="active-page"))
+            ),
             patch("src.main.Config", config),
             patch.object(service, "_check_trigger_override", return_value=None),
         ):
@@ -234,7 +242,9 @@ class TestSilenceModeDispatch:
         with (
             patch("src.main.get_page_service", return_value=page_service),
             patch("src.main.get_settings_service", return_value=settings),
-            patch("src.main.get_schedule_service", return_value=Mock(get_active_page_id=Mock(return_value="active-page"))),
+            patch(
+                "src.main.get_schedule_service", return_value=Mock(get_active_page_id=Mock(return_value="active-page"))
+            ),
             patch("src.main.Config", config),
             patch.object(service, "_check_trigger_override", return_value=None),
         ):
@@ -284,7 +294,9 @@ class TestCustomIndicatorTextAndPosition:
         with (
             patch("src.main.get_page_service", return_value=page_service),
             patch("src.main.get_settings_service", return_value=settings),
-            patch("src.main.get_schedule_service", return_value=Mock(get_active_page_id=Mock(return_value="active-page"))),
+            patch(
+                "src.main.get_schedule_service", return_value=Mock(get_active_page_id=Mock(return_value="active-page"))
+            ),
             patch("src.main.Config", config),
             patch.object(service, "_check_trigger_override", return_value=None),
         ):
@@ -300,7 +312,9 @@ class TestCustomIndicatorTextAndPosition:
         with (
             patch("src.main.get_page_service", return_value=page_service),
             patch("src.main.get_settings_service", return_value=settings),
-            patch("src.main.get_schedule_service", return_value=Mock(get_active_page_id=Mock(return_value="active-page"))),
+            patch(
+                "src.main.get_schedule_service", return_value=Mock(get_active_page_id=Mock(return_value="active-page"))
+            ),
             patch("src.main.Config", config),
             patch.object(service, "_check_trigger_override", return_value=None),
         ):
@@ -328,7 +342,9 @@ class TestCustomIndicatorTextAndPosition:
         with (
             patch("src.main.get_page_service", return_value=page_service),
             patch("src.main.get_settings_service", return_value=settings),
-            patch("src.main.get_schedule_service", return_value=Mock(get_active_page_id=Mock(return_value="active-page"))),
+            patch(
+                "src.main.get_schedule_service", return_value=Mock(get_active_page_id=Mock(return_value="active-page"))
+            ),
             patch("src.main.Config", config),
             patch.object(service, "_check_trigger_override", return_value=None),
         ):
@@ -415,7 +431,9 @@ class TestTemporaryOverrideDuringSilence:
         with (
             patch("src.main.get_page_service", return_value=page_service),
             patch("src.main.get_settings_service", return_value=settings),
-            patch("src.main.get_schedule_service", return_value=Mock(get_active_page_id=Mock(return_value="active-page"))),
+            patch(
+                "src.main.get_schedule_service", return_value=Mock(get_active_page_id=Mock(return_value="active-page"))
+            ),
             patch("src.main.Config", config),
             patch.object(service, "_check_trigger_override", return_value=None),
         ):
@@ -433,7 +451,9 @@ class TestTemporaryOverrideDuringSilence:
         with (
             patch("src.main.get_page_service", return_value=page_service),
             patch("src.main.get_settings_service", return_value=settings),
-            patch("src.main.get_schedule_service", return_value=Mock(get_active_page_id=Mock(return_value="active-page"))),
+            patch(
+                "src.main.get_schedule_service", return_value=Mock(get_active_page_id=Mock(return_value="active-page"))
+            ),
             patch("src.main.Config", config),
             patch.object(service, "_check_trigger_override", return_value=None),
         ):
@@ -450,7 +470,9 @@ class TestTemporaryOverrideDuringSilence:
         with (
             patch("src.main.get_page_service", return_value=page_service),
             patch("src.main.get_settings_service", return_value=settings),
-            patch("src.main.get_schedule_service", return_value=Mock(get_active_page_id=Mock(return_value="active-page"))),
+            patch(
+                "src.main.get_schedule_service", return_value=Mock(get_active_page_id=Mock(return_value="active-page"))
+            ),
             patch("src.main.Config", config),
             patch.object(service, "_check_trigger_override", return_value=None),
         ):

--- a/tests/test_silence_schedule_polling.py
+++ b/tests/test_silence_schedule_polling.py
@@ -43,8 +43,22 @@ def service_factory():
         mocks["config"].SILENCE_SCHEDULE_INDICATOR_POSITION = "center"
         mocks["config"].SILENCE_SCHEDULE_PAGE_ID = None
 
+        # Schedule mode is enabled (see settings mock below), so the schedule
+        # service must yield a concrete page id when consulted.
+        schedule_service = Mock()
+        schedule_service.get_active_page_id.return_value = "page-1"
+        mocks["schedule"].return_value = schedule_service
+
+        # Collection resolution is a passthrough — return the page id unchanged.
+        collection_service = Mock()
+        collection_service.resolve_page_id.side_effect = lambda pid: pid
+        mocks["collection"].return_value = collection_service
+
         settings_service = Mock()
-        settings_service.is_schedule_enabled.return_value = False
+        # Silence-mode is a sub-feature of the polling loop, so these tests
+        # assume the schedule is enabled — otherwise the schedule-off guard
+        # (issue #970) short-circuits before silence dispatch can run.
+        settings_service.is_schedule_enabled.return_value = True
         settings_service.get_active_page_id.return_value = "page-1"
         settings_service.get_polling_interval.return_value = 60
         board_settings = Mock()


### PR DESCRIPTION
Closes #970

## Repro

1. Toggle the schedule off on the Schedule page (so out-of-band content sent from the Vestaboard app should be preserved).
2. Observe the polling loop continuing to push the manually-set active page (e.g. a clock page) to the board every tick, overwriting the custom message.

Pre-fix, ``DisplayService.check_and_send_active_page`` fell back to "manual mode" when ``is_schedule_enabled()`` returned False: it loaded the manually-set active page (or defaulted to the first page) and pushed it. There was no way to tell FiestaBoard "stop touching the board."

## Fix

When schedule mode is off and no explicit user override is active, the polling-loop branch now returns early. The board is left alone.

Explicit user actions are unchanged:
- ``POST /settings/active-page`` immediately pushes via its own send path
- ``POST /settings/temporary-override`` flows through ``consume_temporary_override`` above the new guard, so "show this page now" still works
- Plugin trigger overrides above the guard are also unaffected

Scope is the minimal interpretation of the bug — making "schedule off" honest. The reporter's larger ask (on-demand silence timer, post-schedule-off behavior controls) is deliberately out of scope for this fix.

## Tests

- New ``tests/test_schedule_disabled_no_push.py`` regression suite: 5 tests covering single tick, multiple ticks, no-manual-page, schedule-on-still-pushes sanity, and temporary-override-still-works.
- Updated existing silence-mode and integration tests that implicitly relied on the old manual-mode behavior to assert schedule-on (silence is a sub-feature of an active polling loop).
- Full ``pytest tests/`` run: 3721 passed, 11 skipped.

## Test plan

- [ ] Toggle the schedule off in the UI and confirm a custom message sent from the Vestaboard app stays on the board.
- [ ] Toggle the schedule back on and confirm scheduled/active pages start updating again.
- [ ] With schedule off, push a page via the active-page UI and confirm it lands on the board.
- [ ] With schedule off, push a temporary override and confirm it lands and reverts as configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)