### PR TITLE
fix(nginx): no-cache index.html in prod, no-store in dev

### DIFF
--- a/nginx-dev.conf
+++ b/nginx-dev.conf
@@ -115,6 +115,12 @@ http {
             proxy_connect_timeout 10s;
             proxy_send_timeout 300s;
             proxy_read_timeout 300s;
+            # Never cache dev assets. Vite re-optimizes deps on demand and
+            # stamps every dep chunk URL with a fresh ?v=<hash>. If the
+            # browser caches index.html, it keeps pulling stale chunk
+            # hashes that Vite already invalidated → instant 504s and a
+            # white screen until a hard-refresh. no-store kills that path.
+            add_header Cache-Control "no-store" always;
             include /etc/nginx/fiestaboard/location-root/*.conf;
         }
     }

--- a/nginx.conf
+++ b/nginx.conf
@@ -159,9 +159,17 @@ http {
         # routing can take over. The `<base href>` injected by the
         # location-root snippet ensures relative asset URLs resolve
         # correctly under reverse-proxy prefixes (e.g. HA Ingress).
+        #
+        # index.html must revalidate on every request: it references the
+        # current build's hashed /assets/*.js bundles, so a cached entry
+        # point pins the user to a stale chunk graph and they miss the
+        # new release until they hard-refresh. no-cache (not no-store)
+        # still lets nginx return 304 Not Modified when the file is
+        # unchanged, so the wire cost is just a conditional GET.
         location / {
             root /app/web/build/client;
             try_files $uri $uri/ /index.html;
+            add_header Cache-Control "no-cache, must-revalidate" always;
             include /etc/nginx/fiestaboard/location-root/*.conf;
         }
     }


### PR DESCRIPTION
## Summary

- **Prod `nginx.conf`**: `location /` (SPA fallback) now sends `Cache-Control: no-cache, must-revalidate`. Browsers will revalidate `index.html` on every load but can still get a `304 Not Modified` when nothing changed. Hashed bundles in `/assets/` already have the correct year-long `immutable` cache, so this only adds a single conditional GET per page load.
- **Dev `nginx-dev.conf`**: `location /` (rr7 proxy) now sends `Cache-Control: no-store`. Vite stamps a fresh `?v=<hash>` on every dep chunk after each re-optimization, and caching `index.html` in dev pins the browser to stale chunk hashes — instant 504s and a white screen until a hard-refresh.

## Why

Repro on the dev server today:
1. Load `http://localhost:4420/` — browser caches `index.html`.
2. Vite discovers a new dep, re-optimizes, bumps the dep-cache version.
3. Browser reloads but still has the old `index.html` cached → requests `/node_modules/.vite/deps/chunk-XXXX.js?v=oldhash`.
4. rr7 returns `504` instantly for the stale hash.
5. Bundle never loads → white screen.

Same shape on prod: after a deploy, users hit a cached `index.html` that asks for `/assets/app-OLDHASH.js` (404 since the new build replaced it with NEWHASH).

## Caveat (worth a follow-up)

nginx's `add_header` directive does **not** inherit from the parent context when a `location` block has its own `add_header`. The `X-Content-Type-Options` and `X-XSS-Protection` headers set at the `server` level are already lost in `/assets/`, `/sw.js`, `/registerSW.js`, `/manifest.json` — this change extends that pattern, it does not introduce it. A separate header-inheritance audit (or moving to `more_set_headers` from `nginx-extras` / `headers-more`) would fix all of them at once.

## Test plan

- [ ] Dev container: load `http://localhost:4420/`, then `curl -I` — `Cache-Control: no-store` on `/`.
- [ ] Dev container: trigger a Vite re-optimization (touch a file that pulls a new dep), reload browser without hard-refresh — UI loads cleanly, no 504 chunks.
- [ ] Prod build: `docker compose up`, hit `/` — `Cache-Control: no-cache, must-revalidate` on the response; `/assets/*.js` still `public, immutable`.
- [ ] Prod build: second load returns `304 Not Modified` on `index.html` (no body re-fetched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)