### PR TITLE
fix(nginx-dev): kill-switch /sw.js so stale prod SWs self-destruct

### DIFF
--- a/nginx-dev.conf
+++ b/nginx-dev.conf
@@ -94,6 +94,40 @@ http {
             return 503 '{"detail":"Service is starting up, please try again shortly"}';
         }
 
+        # Kill-switch service worker.
+        #
+        # Vite-PWA is configured with devOptions.enabled = false, so the dev
+        # Vite server never emits a sw.js. But any service worker installed
+        # from a prior production-style visit on this origin (someone ran the
+        # built UI against localhost:4420, or ran a different container that
+        # served sw.js) survives in the browser forever. Origin = host:port,
+        # not the container running behind it.
+        #
+        # That stale SW intercepts every dev navigation. Its workbox
+        # NetworkFirst handler has a 10s network timeout, which the cold
+        # macOS-bind-mount Vite dep-pre-bundle blows through, so the SW
+        # falls back to its 7-day-old cached index.html. That HTML
+        # references /assets/<old-hash>.js chunks the dev Vite server
+        # doesn't have → white screen until a hard refresh.
+        #
+        # Without this override the SW also can't self-update: it fetches
+        # /sw.js, the proxy below returns RR7's 404 HTML (Content-Type:
+        # text/html), and the browser rejects that as a SW update. The
+        # stale SW lives forever.
+        #
+        # This block serves a tiny valid SW that, on activate,
+        # unregisters itself, wipes every cache, and reloads every page
+        # it controls. The browser triggers a SW update check on every
+        # SW-intercepted navigation, so the next time a poisoned tab
+        # loads dev, the kill-switch is fetched, installed, activated,
+        # and self-destructs. After that the tab is SW-free for as long
+        # as it points at the dev server.
+        location = /sw.js {
+            default_type application/javascript;
+            add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+            return 200 "self.addEventListener('install',()=>self.skipWaiting());self.addEventListener('activate',e=>e.waitUntil((async()=>{try{await self.registration.unregister()}catch(_){};try{const k=await caches.keys();await Promise.all(k.map(n=>caches.delete(n)))}catch(_){};try{const c=await self.clients.matchAll({type:'window'});c.forEach(x=>x.navigate(x.url))}catch(_){}})()));";
+        }
+
         # Dev: everything else → Vite dev server (HMR over WebSocket).
         # Generous timeouts: Vite pre-bundles dependencies on demand the
         # first time each one is imported, and on macOS the bind-mounted


### PR DESCRIPTION
Any service worker installed from a prior production-style visit at localhost:4420 (SW origin = host:port, not the container) survives in the browser forever. In dev that stale SW intercepts every navigation, NetworkFirst-times-out after 10s (the macOS-bind-mount cold Vite dep-pre-bundle blows past that easily), then falls back to its 7-day-old cached index.html — which references /assets/<old-hash>.js chunks the dev Vite server doesn't have. Result: white screen until the user hard-refreshes, every cold container start.

The SW can't self-update either: vite-plugin-pwa is configured with devOptions.enabled = false so the dev server doesn't emit /sw.js, the SPA-fallback returns RR7's 404 HTML (Content-Type: text/html), and the browser rejects that as a SW update. The stale SW lives forever.

Serve a tiny valid SW at /sw.js that, on activate, unregisters itself, wipes every cache, and reloads every page it controls. The browser triggers a SW update check on every SW-intercepted navigation, so the next time a poisoned tab loads dev, this kill-switch is installed, activated, and self-destructs. Dev tabs are SW-free from then on.

This only addresses the dev-side symptom. The prod vite-plugin-pwa config that produces these dangerous-in-dev SWs (broad NetworkFirst runtime caching, no skipWaiting / clientsClaim, a broken kill-switch in entry.client.tsx) is a separate change.

## Description

Brief description of what this PR does.

## Related Issue

Closes #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] New plugin
- [ ] Documentation update
- [ ] Refactor / maintenance

## Checklist

- [ ] I have tested my changes locally
- [ ] I have added/updated tests where applicable
- [ ] I have updated documentation where applicable
- [ ] My code follows the project's coding standards
