### PR TITLE
docs: refresh Anthropic model IDs in AI_PROVIDERS.md

### DIFF
--- a/docs/setup/AI_PROVIDERS.md
+++ b/docs/setup/AI_PROVIDERS.md
@@ -78,11 +78,13 @@ These all work well with the FiestaBoard prompt format. Any current chat-complet
 | Provider     | Protocol  | Model                                  | Notes                              |
 | ------------ | --------- | -------------------------------------- | ---------------------------------- |
 | OpenRouter   | OpenAI    | `openai/gpt-4o-mini`                   | Cheap, fast, reliable JSON output. |
-| OpenRouter   | OpenAI    | `anthropic/claude-sonnet-4`            | High-quality, slower.              |
+| OpenRouter   | OpenAI    | `anthropic/claude-sonnet-4.6`          | High-quality, slower.              |
 | OpenAI       | OpenAI    | `gpt-4o-mini`                          | Same as via OpenRouter.            |
-| Anthropic    | Anthropic | `claude-sonnet-4-20250514`             | Direct, no OpenRouter markup.      |
-| Anthropic    | Anthropic | `claude-haiku-4-20250514`              | Cheaper, fast.                     |
+| Anthropic    | Anthropic | `claude-sonnet-4-6`                    | Direct, no OpenRouter markup.      |
+| Anthropic    | Anthropic | `claude-haiku-4-5-20251001`            | Cheaper, fast.                     |
 | Local Ollama | OpenAI    | `qwen2.5:14b-instruct` or larger       | Needs a model that follows JSON.   |
+
+> **Note:** Model IDs are versioned and providers periodically rotate them. This table is updated periodically, but the authoritative list of current Claude model IDs lives at [docs.anthropic.com](https://docs.anthropic.com/). If a suggested ID returns an "unknown model" error, check there for the current name.
 
 The Anthropic protocol pins a stable `anthropic-version` header in `src/ai/protocols.py`, so any model ID Anthropic accepts on that version works — earlier IDs like `claude-3-5-sonnet-20241022` are still valid if you've configured them. Smaller (≤ 7B) local models often struggle to emit valid JSON for the FiestaBoard schema; if you see frequent "Could not parse JSON" errors, switch to a larger or instruction-tuned model.
 


### PR DESCRIPTION
## Summary

The Recommended models table in `docs/setup/AI_PROVIDERS.md` listed the original May 2025 Claude 4.0 release IDs (`claude-sonnet-4-20250514`, `claude-haiku-4-20250514`) and a generic OpenRouter alias (`anthropic/claude-sonnet-4`). Users who copy these verbatim today may hit an "unknown model" error or get an older, less capable version.

This PR updates the Anthropic direct-API rows to current Claude 4.x IDs (`claude-sonnet-4-6`, `claude-haiku-4-5-20251001`) and the OpenRouter row to the Sonnet 4.6 alias (`anthropic/claude-sonnet-4.6`). A short block-quote note now points readers to [docs.anthropic.com](https://docs.anthropic.com/) as the authoritative source whenever a suggested ID stops resolving.

## Files
- `docs/setup/AI_PROVIDERS.md` — updated 3 model IDs in the Recommended models table and added a versioning note

## Voice / format checks
- [x] No real PII in examples
- [x] Voice matches the rest of the doc (concise, no marketing fluff)
- [x] Note is brief (one block-quote, two sentences) — does not over-elaborate
- [x] Existing surrounding paragraph about `claude-3-5-sonnet-20241022` being a still-valid older ID was preserved
- [x] Docs a11y audit on the changed file — no findings (one H1, no images, descriptive link text, no color/direction cues)

## Scope notes
- `grep` confirms no other files in the repo reference the outdated `claude-*-20250514` IDs.
- `docs-site/docs/setup/ai-providers.md` is a separate, older Docusaurus copy that still lists Claude 3.5 IDs (not the IDs called out by the issues), so it was left alone — out of scope for these two issues.
- `docs-site/versioned_docs/**` are historical version snapshots and were intentionally not modified.

Closes #965
Closes #977

🤖 Generated with [Claude Code](https://claude.com/claude-code)