### PR TITLE
docs(setup): fix invalid regex in RELEASE_CHECKLIST.md secret-scan command

### DIFF
--- a/docs/setup/RELEASE_CHECKLIST.md
+++ b/docs/setup/RELEASE_CHECKLIST.md
@@ -18,7 +18,7 @@ From repo root:
 
 ```bash
 # Should return no matches (or only test/example placeholders like "test_key", "your_*_here")
-git grep -E 'api_key|password|secret|token' -- '*.py' '*.ts' '*.tsx' '*.json' '*.yml' '*.md' | grep -v -E 'example|test_key|your_|placeholder|***|_mask_sensitive|SENSITIVE' || true
+git grep -E 'api_key|password|secret|token' -- '*.py' '*.ts' '*.tsx' '*.json' '*.yml' '*.md' | grep -v -E 'example|test_key|your_|placeholder|_mask_sensitive|SENSITIVE' || true
 ```
 
 - [ ] No real API keys, tokens, or passwords in code, docs, or committed config.


### PR DESCRIPTION
## Summary

Fixes the `grep -v -E` pattern on line 21 of `docs/setup/RELEASE_CHECKLIST.md`, which included `***` as one of the pipe-delimited alternatives. `***` is an invalid quantifier in ERE syntax (multiple `*` on an empty atom), so the command errored out for anyone running the checklist verbatim — breaking a security-oriented step right before a release.

Drops `***` from the alternation; the remaining literals (`example`, `test_key`, `your_`, `placeholder`, `_mask_sensitive`, `SENSITIVE`) already cover the intended placeholder cases, so this is the minimal change matching the issue's suggested fix.

Closes #968

## Verification

Before:
```
$ echo "foo" | grep -v -E 'example|test_key|your_|placeholder|***|_mask_sensitive|SENSITIVE'
ugrep: error: error at position 39
(?m)example|test_key|your_|placeholder|***|_mask_sensitive|SENSITIVE
              empty (sub)expression___/
exit=2
```

After:
```
$ echo "foo" | grep -v -E 'example|test_key|your_|placeholder|_mask_sensitive|SENSITIVE'
foo
exit=0
```

Also `git grep`ed the rest of the repo for the same broken pattern in case it had been copy-pasted elsewhere — only the one occurrence in `RELEASE_CHECKLIST.md`.

## Test plan

- [ ] Copy the corrected command from line 21 of `docs/setup/RELEASE_CHECKLIST.md` and run it from repo root; confirm it exits 0 (and lists any non-placeholder hits, or none).

🤖 Generated with [Claude Code](https://claude.com/claude-code)