### PR TITLE
ci(claude): close the docs-audit → triage → draft-PR loop autonomously

### DIFF
--- a/.github/workflows/claude-docs-audit.yml
+++ b/.github/workflows/claude-docs-audit.yml
@@ -137,7 +137,7 @@ jobs:
           claude_args: >-
             --model claude-sonnet-4-6
             --max-turns 60
-            --allowed-tools "Read,Glob,Grep,Edit,Write,Bash(ls:*),Bash(cat:*),Bash(date:*),Bash(jq:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git branch:*),Bash(git checkout:*),Bash(git switch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git fetch:*),Bash(git rev-parse:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh issue list:*),Bash(gh issue view:*),Bash(gh issue create:*),Bash(gh label list:*),Bash(gh label create:*)"
+            --allowed-tools "Read,Glob,Grep,Edit,Write,Bash(ls:*),Bash(cat:*),Bash(date:*),Bash(jq:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git branch:*),Bash(git checkout:*),Bash(git switch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git fetch:*),Bash(git rev-parse:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh issue list:*),Bash(gh issue view:*),Bash(gh issue create:*),Bash(gh issue edit:*),Bash(gh label list:*),Bash(gh label create:*)"
           prompt: |
             You are the FiestaBoard docs auditor. You run unattended once a day
             at 4pm America/Los_Angeles and audit a small batch of repo docs.
@@ -171,12 +171,27 @@ jobs:
 
             Read it carefully. Categorize findings into three buckets:
 
-            **A. Auto-fixable errors** — typos, broken internal links, stale
-                command examples that contradict CLAUDE.md (e.g. mention
-                `npm run dev` directly), wrong file paths, code blocks missing
-                language tags, references to renamed/removed files (verify with
-                `ls` or `grep`), out-of-order section headings vs the canonical
-                plugin doc format described in CLAUDE.md.
+            **A. Auto-fixable errors** — small, surgical edits where the
+                right answer is unambiguous. Includes:
+                  - Typos, spelling, grammar
+                  - Broken internal links (verify the target with `ls`)
+                  - Stale command examples that contradict CLAUDE.md (e.g.
+                    `npm run dev` directly)
+                  - Wrong file paths (verify with `ls`)
+                  - Code blocks missing language tags
+                  - References to renamed/removed files (verify with `grep`)
+                  - Out-of-order section headings vs the canonical plugin
+                    doc format described in CLAUDE.md
+                  - **Broken code inside code blocks** when the breakage is
+                    mechanical and the fix is unambiguous: invalid regex
+                    syntax, malformed JSON, shell commands that won't parse.
+                    Do NOT touch code blocks whose breakage requires runtime
+                    knowledge or design judgment.
+                  - **Outdated external identifiers** (model IDs, API
+                    versions, CLI flags, package names) where you know the
+                    current value from your training OR can verify it from
+                    another up-to-date file in this repo. If the right
+                    replacement isn't unambiguous, file an issue instead.
 
             **B. Missing documentation** — a referenced concept, command, env
                 var, or workflow that has no documented home; a plugin without
@@ -258,6 +273,15 @@ jobs:
 
             Labels: `docs`, `docs-audit`. Create the labels if they don't exist
             (`gh label create docs-audit --color BFD4F2 --description "Filed by the docs-audit cron" || true`).
+
+            After creating each issue, also apply the `claude-fix` label so the
+            issue-triage workflow picks it up and takes a first-pass attempt
+            at a draft PR (issues filed by this bot don't satisfy the triage
+            workflow's author-association gate, so `claude-fix` is what opens
+            that path):
+              `gh issue edit <N> --add-label claude-fix`
+            Create that label first if needed:
+              `gh label create claude-fix --color 0E8A16 --description "Run the Claude issue-triage workflow on this issue" || true`
 
             ## State commit
 

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -2,13 +2,20 @@ name: Claude Issue Triage
 
 # Take a first-pass fix attempt at new issues.
 #
-# Triggers in two ways:
+# Triggers in three ways:
 #   1. Auto: issue opened by the repo owner / a member / a collaborator
 #   2. Manual gate: any issue that gets the `claude-fix` label applied
+#   3. Docs cron: any issue that gets the `docs-audit` label applied
+#      (filed by claude-docs-audit.yml; the bot-authored issues don't
+#      satisfy gate #1, and we want them auto-triaged anyway)
 #
-# This double gate keeps drive-by issues from public reporters out of the
+# This triple gate keeps drive-by issues from public reporters out of the
 # auto-run path while still letting you (or any maintainer) opt one in by
-# adding the label.
+# adding the label, and letting the docs-audit cron close its own loop.
+#
+# Model tier: Sonnet for docs-flavored issues (`docs`/`docs-audit` label),
+# Opus for everything else — code bugs benefit from the harder model, while
+# markdown edits don't. See the "Choose model tier" step below.
 
 on:
   issues:
@@ -34,7 +41,10 @@ jobs:
           github.event.issue.author_association == 'MEMBER' ||
           github.event.issue.author_association == 'COLLABORATOR'
         )) ||
-        (github.event.action == 'labeled' && github.event.label.name == 'claude-fix')
+        (github.event.action == 'labeled' && (
+          github.event.label.name == 'claude-fix' ||
+          github.event.label.name == 'docs-audit'
+        ))
       )
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -50,6 +60,24 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Choose model tier
+        id: tier
+        # Docs-flavored issues are markdown edits — Sonnet handles them and
+        # the docs-audit cron files them in volume, so Opus economics are bad.
+        # Everything else (code bugs, infra, plugin internals) gets Opus,
+        # which is materially better at debugging and codebase navigation.
+        run: |
+          labels='${{ toJSON(github.event.issue.labels.*.name) }}'
+          echo "Labels: $labels"
+          if echo "$labels" | grep -qE '"(docs|docs-audit)"'; then
+            model="claude-sonnet-4-6"
+            echo "Selected Sonnet (docs-flavored issue)"
+          else
+            model="claude-opus-4-7"
+            echo "Selected Opus (default — code/infra issue)"
+          fi
+          echo "model=$model" >> "$GITHUB_OUTPUT"
+
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
         with:
@@ -64,6 +92,8 @@ jobs:
 
             Title: ${{ github.event.issue.title }}
 
+            Labels: ${{ toJSON(github.event.issue.labels.*.name) }}
+
             Body:
             ${{ github.event.issue.body }}
 
@@ -77,18 +107,42 @@ jobs:
                problem if you can, and implement the smallest fix that
                solves it. Follow the rules in CLAUDE.md.
             3. Add or update a test that would have caught the bug.
-            4. Open a DRAFT pull request against `main` from a branch named
-               `claude/issue-${{ github.event.issue.number }}`. Title it
-               `[Claude first-pass] <short summary>` and link the issue with
+               **Docs-only fixes don't need a test** — skip this step if the
+               only files touched are `*.md`.
+            4. Open a DRAFT pull request against `main`.
+               - For docs-flavored issues (labels include `docs` or
+                 `docs-audit`): branch `docs/issue-${{ github.event.issue.number }}-<short-slug>`,
+                 title prefix `docs:` (no `[Claude first-pass]` prefix —
+                 docs PRs go through the normal docs review path).
+               - For everything else: branch
+                 `claude/issue-${{ github.event.issue.number }}`, title
+                 `[Claude first-pass] <short summary>`.
+               In either case link the issue with
                `Closes #${{ github.event.issue.number }}` in the body.
             5. In the PR body, be honest about your confidence: what you
                changed, what you tested, and what a human reviewer should
                double-check before merging.
             6. Never merge the PR. Never force-push. Never bypass hooks.
 
+            ## Docs issues — voice and format
+
+            If the issue labels include `docs` or `docs-audit`, your output
+            is community-facing documentation. Before drafting, read
+            `.claude/agents/docs-writer.md` and apply its rules:
+              - Examples-first, abstractions second
+              - Short paragraphs (2–3 sentences)
+              - Block-quote notes for caveats
+              - No marketing fluff ("powerful", "seamless", "easily")
+              - Privacy rules: no real PII, addresses, API keys; coords use
+                public landmarks (NYC `40.7128, -74.0060`) or round fakes
+              - Canonical README / SETUP section orders for plugin docs
+                (see `CLAUDE.md` and the existing `plugins/date_time/`,
+                `plugins/random/` docs as voice references)
+
             If you finish without opening a PR, leave a comment on the issue
             summarizing what you found and why no PR was opened.
 
           # Long ceiling so Claude has room to actually attempt the fix.
           # `timeout-minutes` above is the real backstop on cost.
-          claude_args: '--max-turns 80'
+          # `--model` is picked dynamically by the tier step above.
+          claude_args: '--max-turns 80 --model ${{ steps.tier.outputs.model }}'


### PR DESCRIPTION
## Summary

The docs-audit cron files quality issues (`#965`, `#968`, `#977`) but they never produced draft PRs. Traced it to one specific handoff: the triage workflow's author-association gate rejects bot-authored issues (`app/claude` → `author_association: NONE`), and no label opened the second gate either. Every triage run for those three issues shows `conclusion: skipped`.

This PR closes the loop end-to-end, with model-tier routing on the way.

## Changes

**`claude-issue-triage.yml`**
- **Triple-branch gate.** `docs-audit` label now opens triage alongside `claude-fix`. Bot-authored docs-audit issues flow through automatically; the manual `claude-fix` path stays untouched.
- **Dynamic model tier.** New "Choose model tier" step inspects issue labels and selects `claude-sonnet-4-6` for `docs`/`docs-audit` issues, `claude-opus-4-7` for everything else. Markdown edits don't need Opus; code debugging does.
- **Docs voice routing.** When the issue is docs-flavored, prompt tells triage to branch as `docs/issue-<N>-<slug>` (not `claude/issue-<N>`), use the `docs:` title prefix, and read `.claude/agents/docs-writer.md` for voice/format/privacy rules before drafting.
- **Test-skip for docs.** `*.md`-only fixes don't need a test (was forcing test changes onto every docs PR).

**`claude-docs-audit.yml`**
- **Bucket A expanded.** Two categories that drove #968 and #965 into the issue path are now explicitly auto-fixable: broken code inside code blocks (invalid regex syntax, malformed JSON, unparseable shell) and outdated external identifiers (model IDs, API versions, CLI flags) where the right replacement is unambiguous.
- **`claude-fix` auto-apply.** After filing each issue, also apply `claude-fix` as a belt-and-suspenders unlock for triage (parallel safety net to the gate change above). Adds `gh issue edit` to the allowed-tools list.

## What this changes operationally

Before: audit files an issue → triage skipped → human has to read the issue, write the fix, open the PR.

After: audit either fixes inline in its own draft PR (most cases now), or files an issue → triage fires automatically → Sonnet drafts a docs PR with the right voice and links `Closes #N`. Human only reviews PRs.

## Test plan

- [x] `actionlint` clean on both workflow files
- [ ] Merge → manually `workflow_dispatch` the docs-audit GHA → confirm any new issue gets `claude-fix` applied → confirm triage fires (not skipped) → confirm a draft PR opens against the docs file
- [ ] Confirm the model-tier step picks Sonnet on a docs issue and Opus on a non-docs issue (visible in the run log)

## Out of scope

- `claude.yml` (the `@claude`-mention handler) intentionally not changed — it's user-initiated and the model is already implicit.
- The `docs-writer` agent file itself is the source of truth; we point at it rather than inlining the rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)