### PR TITLE
ci(triage): allow `claude` bot to invoke triage so docs-audit issues actually fire

### DIFF
--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -83,6 +83,14 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
+          # The docs-audit cron files issues as the `claude` bot and applies
+          # the `docs-audit` / `claude-fix` labels itself. Without this the
+          # action's own anti-bot guard short-circuits the run regardless of
+          # our workflow `if:` gate — see PR #983 follow-up where every
+          # docs-audit-filed issue triggered triage but the action rejected
+          # the run with "Workflow initiated by non-human actor: claude".
+          allowed_bots: 'claude'
+
           additional_permissions: |
             actions: read
 


### PR DESCRIPTION
## Summary

Follow-up to #983. The workflow `if:` gate now lets docs-audit-bot-applied labels through (verified — triage fired on #985), but `claude-code-action@v1` has its own anti-bot guard. Default for `allowed_bots` is empty, so every run filed by the docs-audit cron died with:

> Action failed with error: Workflow initiated by non-human actor: claude (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.

This adds `allowed_bots: 'claude'` (not `*`) so only the docs-audit cron's bot identity is trusted to initiate triage. Any future automation that needs to invoke triage has to be added explicitly.

## Evidence

- PR #983 merged → docs-audit dispatched → filed #985 with `docs,docs-audit,claude-fix` labels.
- Triage workflow fired (gate passed) → 3 runs cancelled by `concurrency.cancel-in-progress` → final run failed at the action's bot check, not the workflow gate.
- This change is the minimum fix to close that gap.

## After merge

I'll re-trigger triage on #985 by removing+reapplying the `claude-fix` label, then watch it draft the docs PR for the countdown plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)