### PR TITLE
ci(claude): grant @claude bot write to push fixes back to PR branches

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,8 +31,13 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
+      # contents/pull-requests are write so the @claude bot can commit and
+      # push fixes back to the PR branch when asked. Without write here, the
+      # action's git push fails 403 — see PR #980 comment 4699425518. Feature
+      # branches aren't protection-gated, so the default GITHUB_TOKEN is
+      # enough (no PAT needed); main is still protected separately.
+      contents: write
+      pull-requests: write
       issues: read
       id-token: write
       actions: read # Required for Claude to read CI results on PRs


### PR DESCRIPTION
## Summary
- Bump `.github/workflows/claude.yml` from `contents: read` / `pull-requests: read` to `write` so the `@claude` comment-triggered action can actually commit and push fixes to the PR branch.
- Comment in the file explains why and points back at PR #980's failure ([comment](https://github.com/Fiestaboard/FiestaBoard/pull/980#issuecomment-4699425518)).

## Why
The `@claude` run on PR #980 produced a good fix but failed at the push step:

> `403 — Permission to Fiestaboard/FiestaBoard.git denied to github-actions[bot]`

Root cause: the workflow gave the injected `GITHUB_TOKEN` read-only `contents` access, so `git push` was rejected even on an unprotected feature branch. `claude-issue-triage.yml` already runs with `contents: write` for the same reason — this just brings `claude.yml` in line.

No PAT needed: feature branches aren't protection-gated; `main` is still protected separately.

## Test plan
- [ ] Merge.
- [ ] Re-trigger `@claude` on PR #980 (after rebase) and confirm the push succeeds and the suggested fix lands on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)