### PR TITLE
ci(triage): grant Edit/Write/git/gh tools + surface SDK output

### DIFF
--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -91,6 +91,13 @@ jobs:
           # the run with "Workflow initiated by non-human actor: claude".
           allowed_bots: 'claude'
 
+          # Surface the SDK transcript in the Actions log. Without this the
+          # action prints "full output hidden for security" and silent
+          # permission denials look like a clean success — exactly what
+          # happened on the first post-#986 triage run for #985: 25 turns
+          # burned, $1 spent, no PR, no comment, conclusion=success.
+          show_full_output: 'true'
+
           additional_permissions: |
             actions: read
 
@@ -153,4 +160,15 @@ jobs:
           # Long ceiling so Claude has room to actually attempt the fix.
           # `timeout-minutes` above is the real backstop on cost.
           # `--model` is picked dynamically by the tier step above.
-          claude_args: '--max-turns 80 --model ${{ steps.tier.outputs.model }}'
+          # `--allowed-tools`: agent-mode default toolset is read-only, so
+          # without this allowlist every Edit/Write/`git`/`gh` call is
+          # denied. Same lesson as claude-docs-audit.yml — the first triage
+          # run on a docs-audit issue did 25 turns of reads and produced no
+          # PR because it couldn't edit or push anything. Includes `find`
+          # and broader `Bash` patterns the triage agent needs to navigate
+          # an unknown codebase (docs-audit's narrower allowlist would
+          # block legitimate work here).
+          claude_args: >-
+            --max-turns 80
+            --model ${{ steps.tier.outputs.model }}
+            --allowed-tools "Read,Glob,Grep,Edit,Write,Bash(ls:*),Bash(cat:*),Bash(find:*),Bash(grep:*),Bash(rg:*),Bash(date:*),Bash(jq:*),Bash(python3:*),Bash(node:*),Bash(npm:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git branch:*),Bash(git checkout:*),Bash(git switch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git fetch:*),Bash(git rev-parse:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr edit:*),Bash(gh pr comment:*),Bash(gh issue list:*),Bash(gh issue view:*),Bash(gh issue comment:*),Bash(gh issue edit:*),Bash(gh label list:*),Bash(gh label create:*),Bash(gh api:*)"


### PR DESCRIPTION
## Summary

Follow-up to #983 and #986 — third (and hopefully final) gate the loop was tripping on.

After #986 let the `claude` bot through, the first real triage run on #985 ran for 25 turns, cost \$1.04, returned `is_error: false`, and produced **nothing** — no PR, no commit, no comment. The action's agent mode defaults to a read-only toolset (`Read`/`Glob`/`Grep`). Without an explicit `--allowed-tools` allowlist, every `Edit`/`Write`/`git`/`gh` call is silently denied; Claude reads the codebase, tries to act, can't, and exits cleanly.

The docs-audit workflow already learned this lesson — its inline comment at `claude-docs-audit.yml:136` says it plainly:

> the agent-mode default toolset is read-only, so without this allowlist every Edit/Write/`git`/`gh` call is denied and the run completes with 0 PRs + 0 issues + an unchanged state file.

## Changes

- `--allowed-tools` allowlist on triage. Intentionally wider than docs-audit's:
  - Triage doesn't know in advance whether the fix is in `src/`, `web/`, a plugin, or a doc. It needs `find`/`grep`/`rg` plus the full `gh issue|pr|api` surface.
  - docs-audit knows it's editing markdown in a known sweep; its narrower allowlist would block legitimate triage work.
- `show_full_output: 'true'`. Surfaces the SDK transcript in the Actions log. Without it, silent permission denials look exactly like clean successes — the failure mode that made debugging the #985 run hard.

## Test plan

- [ ] After merge, re-bounce the `claude-fix` label on #985 and confirm:
  - The Actions log shows actual SDK turns (not "full output hidden")
  - A draft PR opens against `docs/issue-985-…`
  - It correctly updates the countdown plugin examples (the issue's specific ask)

🤖 Generated with [Claude Code](https://claude.com/claude-code)