### PR TITLE
feat(schedules): pick the most recently started schedule on conflict

### DIFF
--- a/src/schedules/models.py
+++ b/src/schedules/models.py
@@ -222,6 +222,23 @@ class ScheduleEntry(BaseModel):
         # Normal range: active if start <= time < end
         return start_minutes <= time_minutes < end_minutes
 
+    def minutes_since_start(self, time_str: str) -> int:
+        """Minutes elapsed from this schedule's start_time to the given time.
+
+        Caller must ensure `applies_to_time(time_str)` is True — the result is
+        only meaningful while the schedule's window is active. Handles midnight
+        rollover: for a schedule defined 23:00-03:00 evaluated at 02:00, returns
+        180 (started 3h ago, yesterday), not -1260.
+        """
+        current_minutes = self._time_to_minutes(time_str)
+        start_minutes = self._time_to_minutes(self.start_time)
+        if self.end_time is not None:
+            end_minutes = self._time_to_minutes(self.end_time)
+            if end_minutes <= start_minutes and current_minutes < start_minutes:
+                # Rollover schedule whose window began yesterday
+                return current_minutes + 1440 - start_minutes
+        return current_minutes - start_minutes
+
 
 class ScheduleCreate(BaseModel):
     """Request model for creating a new schedule entry."""

--- a/src/schedules/service.py
+++ b/src/schedules/service.py
@@ -150,7 +150,10 @@ class ScheduleService:
         1. one_off_date matches (most specific — single calendar date or range)
         2. annual_date matches (recurs each year on MM-DD)
         3. weekly matches (existing day-of-week behavior)
-        Within a priority tier, the most recently created entry wins.
+        Within a priority tier, the schedule whose window started most
+        recently relative to the current time wins (so a 10:00 schedule
+        beats an 8:00 schedule at 10:30). If two schedules share the same
+        start_time, the most recently created entry wins.
         """
         bid = board_id or DEFAULT_BOARD_ID
         schedules = [s for s in self.list_schedules(board_id=bid) if s.enabled]
@@ -175,12 +178,14 @@ class ScheduleService:
                 continue
             if not effective_schedule.applies_to_time(time_str):
                 continue
-            tiers[schedule.recurrence_type].append(schedule)
+            tiers[schedule.recurrence_type].append(effective_schedule)
 
         for tier_name in ("one_off_date", "annual_date", "weekly"):
             tier_matches = tiers[tier_name]
             if tier_matches:
-                tier_matches.sort(key=lambda s: s.created_at, reverse=True)
+                tier_matches.sort(
+                    key=lambda s: (s.minutes_since_start(time_str), -s.created_at.timestamp())
+                )
                 logger.debug(
                     f"Active schedule: {tier_matches[0].id} ({tier_name}) "
                     f"for {today.isoformat()} {time_str} (board={bid})"

--- a/src/schedules/service.py
+++ b/src/schedules/service.py
@@ -183,9 +183,7 @@ class ScheduleService:
         for tier_name in ("one_off_date", "annual_date", "weekly"):
             tier_matches = tiers[tier_name]
             if tier_matches:
-                tier_matches.sort(
-                    key=lambda s: (s.minutes_since_start(time_str), -s.created_at.timestamp())
-                )
+                tier_matches.sort(key=lambda s: (s.minutes_since_start(time_str), -s.created_at.timestamp()))
                 logger.debug(
                     f"Active schedule: {tier_matches[0].id} ({tier_name}) "
                     f"for {today.isoformat()} {time_str} (board={bid})"

--- a/tests/test_schedules_service.py
+++ b/tests/test_schedules_service.py
@@ -1,7 +1,7 @@
 """Tests for schedule service."""
 
 import tempfile
-from datetime import time
+from datetime import time, timedelta
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -271,6 +271,102 @@ class TestActivePageResolution:
         # Wednesday - should match
         page_id = service.get_active_page_id(time(12, 0), "wednesday")
         assert page_id == "custom-page"
+
+
+class TestWeeklyConflictTiebreaker:
+    """Within the weekly tier, the schedule that started most recently wins."""
+
+    def test_later_start_time_wins_over_earlier(self, service):
+        # 08:00–13:00 and 10:00–13:00 both cover Monday at 10:30. The 10:00
+        # window began more recently, so its page should display.
+        service.create_schedule(
+            ScheduleCreate(
+                page_id="morning-page",
+                start_time="08:00",
+                end_time="13:00",
+                day_pattern="all",
+            )
+        )
+        service.create_schedule(
+            ScheduleCreate(
+                page_id="late-morning-page",
+                start_time="10:00",
+                end_time="13:00",
+                day_pattern="all",
+            )
+        )
+        assert service.get_active_page_id(time(10, 30), "monday") == "late-morning-page"
+
+    def test_later_start_wins_regardless_of_created_at_order(self, service):
+        # Create the later-starting schedule first, then the earlier-starting
+        # one. The later start_time must still win even though it is older.
+        later = service.create_schedule(
+            ScheduleCreate(
+                page_id="late-morning-page",
+                start_time="10:00",
+                end_time="13:00",
+                day_pattern="all",
+            )
+        )
+        later.created_at = later.created_at - timedelta(hours=1)
+        service.storage._schedules[later.id] = later
+
+        service.create_schedule(
+            ScheduleCreate(
+                page_id="morning-page",
+                start_time="08:00",
+                end_time="13:00",
+                day_pattern="all",
+            )
+        )
+        assert service.get_active_page_id(time(10, 30), "monday") == "late-morning-page"
+
+    def test_identical_start_time_falls_back_to_created_at(self, service):
+        # Two schedules with the same start_time tie on the primary key, so the
+        # more recently created one wins.
+        first = service.create_schedule(
+            ScheduleCreate(
+                page_id="first-page",
+                start_time="09:00",
+                end_time="17:00",
+                day_pattern="all",
+            )
+        )
+        first.created_at = first.created_at - timedelta(seconds=5)
+        service.storage._schedules[first.id] = first
+
+        service.create_schedule(
+            ScheduleCreate(
+                page_id="second-page",
+                start_time="09:00",
+                end_time="17:00",
+                day_pattern="all",
+            )
+        )
+        assert service.get_active_page_id(time(12, 0), "monday") == "second-page"
+
+    def test_midnight_rollover_respects_actual_elapsed(self, service):
+        # Two overnight schedules both active at 02:00:
+        #   23:00–04:00 started 3h ago (yesterday at 23:00)
+        #   01:00–04:00 started 1h ago (today at 01:00)
+        # The 01:00 one started more recently and must win.
+        service.create_schedule(
+            ScheduleCreate(
+                page_id="late-night-page",
+                start_time="23:00",
+                end_time="04:00",
+                day_pattern="all",
+            )
+        )
+        service.create_schedule(
+            ScheduleCreate(
+                page_id="early-morning-page",
+                start_time="01:00",
+                end_time="04:00",
+                day_pattern="all",
+            )
+        )
+        assert service.get_active_page_id(time(2, 0), "monday") == "early-morning-page"
 
 
 class TestValidation:


### PR DESCRIPTION
## Summary
- When two same-tier schedules both match the current moment, the resolver picks the one whose window began most recently — so at 10:30, a 10:00-13:00 schedule beats an 08:00-13:00 schedule regardless of which was added first.
- Midnight rollover is handled by a new `ScheduleEntry.minutes_since_start` helper, so a 23:00-04:00 schedule at 02:00 reports 180 elapsed minutes (not -1260) and a 01:00-04:00 schedule still wins.
- Exact ties on `start_time` fall back to the previous "most recently created wins" rule, which preserves the existing annual / one-off tier behavior.

## Test plan
- [x] `pytest tests/test_schedules_service.py tests/test_schedules_date_overrides.py tests/test_schedules_models.py tests/test_schedules_midnight_rollover.py` — 111 passed in dev container
- [ ] Manually verify with two overlapping weekly schedules in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)