### PR TITLE
feat(board): adaptive post-send refresh — UI catches up in <1s, not 30s

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -45,7 +45,12 @@ class DisplayService:
         self._polled_characters: list[list[int]] | None = None
         self._polled_at: float | None = None
         self._poll_thread: threading.Thread | None = None
-        self._pending_refresh_timer: threading.Timer | None = None
+        # Adaptive post-send refresh: a background thread polls the board
+        # on a short ramp after each send and stops early once the read
+        # matches what we just sent. ``_refresh_cancel`` lets a subsequent
+        # call abort an in-flight cycle so rapid sends don't pile up.
+        self._refresh_thread: threading.Thread | None = None
+        self._refresh_cancel: threading.Event | None = None
 
     def _build_board_clients(self):
         """Build board clients from settings.boards (first with connection) or Config. Sets self.vb_client."""
@@ -115,28 +120,67 @@ class DisplayService:
                 logger.debug(f"Board state poll failed: {e}")
             time.sleep(interval)
 
-    def request_board_refresh(self, delay_seconds: float = 3.0) -> None:
-        """Schedule a one-shot board-state read shortly after a page is sent.
+    def request_board_refresh(
+        self,
+        initial_delay_seconds: float = 0.5,
+        retry_interval_seconds: float = 1.0,
+        max_total_seconds: float = 3.0,
+    ) -> None:
+        """Adaptively poll the board after a send so the cached state catches up
+        quickly without waiting for the next full poll interval.
 
-        Cancels any pending refresh so rapid sends don't stack up timers.
+        Strategy: sleep ``initial_delay_seconds``, read the board. If the read
+        matches what we just sent, update the cache and stop. Otherwise sleep
+        ``retry_interval_seconds`` and try again, until ``max_total_seconds``
+        elapses. The latest successful read is always cached, so the display
+        cache improves even when we never observe a match (e.g. during a long
+        transition animation).
+
+        A subsequent call cancels any in-flight refresh so rapid sends don't
+        stack up threads.
         """
-        if self._pending_refresh_timer is not None and self._pending_refresh_timer.is_alive():
-            self._pending_refresh_timer.cancel()
+        # Cancel any in-flight refresh from a prior send.
+        if self._refresh_cancel is not None:
+            self._refresh_cancel.set()
+
+        client = self.vb_client
+        if client is None:
+            return
+
+        cancel = threading.Event()
+        self._refresh_cancel = cancel
+
+        # Snapshot what we just sent so we can detect when the board has
+        # caught up. May be None if no send has happened on this client yet.
+        last_sent = getattr(client, "_last_characters", None)
+        expected = [row[:] for row in last_sent] if isinstance(last_sent, list) and last_sent else None
 
         def _do_refresh() -> None:
-            if self.vb_client:
+            start = time.monotonic()
+            if cancel.wait(initial_delay_seconds):
+                return
+            while True:
                 try:
-                    chars = self.vb_client.read_current_message()
+                    chars = client.read_current_message()
                     if chars:
                         self._polled_characters = chars
                         self._polled_at = time.time()
-                        logger.debug("Post-send board state refresh completed")
+                        if expected is not None and chars == expected:
+                            logger.debug("Post-send refresh: board state matches sent content")
+                            return
                 except Exception as e:
                     logger.debug(f"Post-send board state refresh failed: {e}")
 
-        self._pending_refresh_timer = threading.Timer(delay_seconds, _do_refresh)
-        self._pending_refresh_timer.daemon = True
-        self._pending_refresh_timer.start()
+                elapsed = time.monotonic() - start
+                if elapsed >= max_total_seconds:
+                    return
+                wait_secs = min(retry_interval_seconds, max_total_seconds - elapsed)
+                if cancel.wait(wait_secs):
+                    return
+
+        thread = threading.Thread(target=_do_refresh, daemon=True)
+        self._refresh_thread = thread
+        thread.start()
 
     def initialize(self) -> bool:
         """Initialize all components."""

--- a/tests/test_adaptive_board_refresh.py
+++ b/tests/test_adaptive_board_refresh.py
@@ -1,0 +1,212 @@
+"""Tests for adaptive post-send board state refresh.
+
+After a send, ``DisplayService.request_board_refresh`` should poll the
+board on a short ramp (initial small delay, then short retry intervals,
+capped at a max total) and stop as soon as the read result matches the
+characters that were just sent. The latest read is always cached so the
+display cache improves even when we never see a match.
+"""
+
+import time
+from unittest.mock import Mock
+
+from src.main import DisplayService
+
+# Short timings so tests don't sleep for real seconds. The behavior
+# under test is the *shape* of the retry loop — initial delay, retry
+# cadence, total budget, early-stop on match — not the exact production
+# constants.
+INITIAL = 0.02
+RETRY = 0.02
+MAX_TOTAL = 0.20
+
+
+def _make_service_with_last(last_chars):
+    svc = DisplayService()
+    client = Mock()
+    client._last_characters = last_chars
+    svc.vb_client = client
+    return svc, client
+
+
+def _wait_for_thread(svc, timeout=2.0):
+    """Wait for the post-send refresh thread to finish."""
+    thread = svc._refresh_thread
+    assert thread is not None, "request_board_refresh should have started a thread"
+    thread.join(timeout=timeout)
+    assert not thread.is_alive(), "refresh thread should complete within timeout"
+
+
+class TestAdaptiveRefresh:
+    def test_stops_when_first_read_matches_sent(self):
+        """If the first read matches what we sent, no retries — one call."""
+        sent = [[1, 2, 3]]
+        svc, client = _make_service_with_last(sent)
+        client.read_current_message.return_value = sent
+
+        svc.request_board_refresh(
+            initial_delay_seconds=INITIAL,
+            retry_interval_seconds=RETRY,
+            max_total_seconds=MAX_TOTAL,
+        )
+        _wait_for_thread(svc)
+
+        assert client.read_current_message.call_count == 1
+        assert svc._polled_characters == sent
+
+    def test_retries_until_match(self):
+        """If first read is stale, keep polling until it matches sent state."""
+        sent = [[9, 9, 9]]
+        stale = [[0, 0, 0]]
+        svc, client = _make_service_with_last(sent)
+        # Return stale twice, then the real (matching) state.
+        client.read_current_message.side_effect = [stale, stale, sent, sent]
+
+        svc.request_board_refresh(
+            initial_delay_seconds=INITIAL,
+            retry_interval_seconds=RETRY,
+            max_total_seconds=MAX_TOTAL,
+        )
+        _wait_for_thread(svc)
+
+        assert client.read_current_message.call_count == 3
+        assert svc._polled_characters == sent
+
+    def test_caches_latest_read_on_timeout(self):
+        """When the board never matches, we still keep the freshest read."""
+        sent = [[5, 5, 5]]
+        latest = [[7, 7, 7]]
+        svc, client = _make_service_with_last(sent)
+        client.read_current_message.return_value = latest
+
+        svc.request_board_refresh(
+            initial_delay_seconds=INITIAL,
+            retry_interval_seconds=RETRY,
+            max_total_seconds=MAX_TOTAL,
+        )
+        _wait_for_thread(svc)
+
+        # At least one retry must have happened (timeout window > initial).
+        assert client.read_current_message.call_count >= 2
+        # Even without a match, the latest read wins the cache.
+        assert svc._polled_characters == latest
+
+    def test_total_time_bounded_by_max_total(self):
+        """The refresh thread must respect max_total_seconds, even on no-match."""
+        sent = [[1]]
+        not_sent = [[2]]
+        svc, client = _make_service_with_last(sent)
+        client.read_current_message.return_value = not_sent
+
+        start = time.monotonic()
+        svc.request_board_refresh(
+            initial_delay_seconds=INITIAL,
+            retry_interval_seconds=RETRY,
+            max_total_seconds=MAX_TOTAL,
+        )
+        _wait_for_thread(svc, timeout=MAX_TOTAL + 1.0)
+        elapsed = time.monotonic() - start
+
+        # Allow a small fudge for thread scheduling, but not more than 2x.
+        assert elapsed < MAX_TOTAL * 2, f"refresh exceeded budget: {elapsed:.3f}s"
+
+    def test_cancels_previous_refresh(self):
+        """A second request_board_refresh aborts the first in-flight cycle."""
+        sent_a = [[10]]
+        sent_b = [[20]]
+        svc, client = _make_service_with_last(sent_a)
+        client.read_current_message.return_value = sent_b
+
+        svc.request_board_refresh(
+            initial_delay_seconds=0.10,
+            retry_interval_seconds=0.10,
+            max_total_seconds=1.0,
+        )
+        first_thread = svc._refresh_thread
+
+        # Immediately update the client's last-sent and trigger a new refresh.
+        client._last_characters = sent_b
+        time.sleep(0.01)  # let the first thread start sleeping
+        svc.request_board_refresh(
+            initial_delay_seconds=INITIAL,
+            retry_interval_seconds=RETRY,
+            max_total_seconds=MAX_TOTAL,
+        )
+        second_thread = svc._refresh_thread
+
+        # First thread should be cancelled and exit promptly without running
+        # its retry loop to completion.
+        first_thread.join(timeout=0.5)
+        assert not first_thread.is_alive(), "previous refresh should have been cancelled"
+
+        # Second cycle should still complete normally and leave a fresh cache.
+        second_thread.join(timeout=2.0)
+        assert not second_thread.is_alive()
+        assert svc._polled_characters == sent_b
+
+    def test_handles_read_returning_none(self):
+        """``read_current_message`` returning None must not crash the loop."""
+        sent = [[1]]
+        svc, client = _make_service_with_last(sent)
+        client.read_current_message.return_value = None
+
+        svc.request_board_refresh(
+            initial_delay_seconds=INITIAL,
+            retry_interval_seconds=RETRY,
+            max_total_seconds=MAX_TOTAL,
+        )
+        _wait_for_thread(svc)
+
+        # We retried — None never matches "sent" so we keep going.
+        assert client.read_current_message.call_count >= 2
+        # No fresh state was successfully read; cache stays unchanged.
+        assert svc._polled_characters is None
+
+    def test_handles_read_exception(self):
+        """A raised exception during read must not kill the loop."""
+        sent = [[1]]
+        svc, client = _make_service_with_last(sent)
+        client.read_current_message.side_effect = RuntimeError("boom")
+
+        svc.request_board_refresh(
+            initial_delay_seconds=INITIAL,
+            retry_interval_seconds=RETRY,
+            max_total_seconds=MAX_TOTAL,
+        )
+        _wait_for_thread(svc)
+
+        # Multiple attempts despite raising.
+        assert client.read_current_message.call_count >= 2
+
+    def test_handles_no_last_characters(self):
+        """If we have no record of what we sent, still refresh — just no early stop."""
+        svc, client = _make_service_with_last(None)
+        latest = [[42]]
+        client.read_current_message.return_value = latest
+
+        svc.request_board_refresh(
+            initial_delay_seconds=INITIAL,
+            retry_interval_seconds=RETRY,
+            max_total_seconds=MAX_TOTAL,
+        )
+        _wait_for_thread(svc)
+
+        # Without a target, we run the full window.
+        assert client.read_current_message.call_count >= 2
+        assert svc._polled_characters == latest
+
+    def test_no_vb_client_is_noop(self):
+        """No board client → no thread crash; call returns cleanly."""
+        svc = DisplayService()
+        svc.vb_client = None
+        # Should not raise.
+        svc.request_board_refresh(
+            initial_delay_seconds=INITIAL,
+            retry_interval_seconds=RETRY,
+            max_total_seconds=MAX_TOTAL,
+        )
+        # Either no thread was started or it exits quickly.
+        thread = svc._refresh_thread
+        if thread is not None:
+            thread.join(timeout=0.5)
+            assert not thread.is_alive()

--- a/web/src/__tests__/hooks-extended.test.ts
+++ b/web/src/__tests__/hooks-extended.test.ts
@@ -92,7 +92,9 @@ describe("use-board extended", () => {
         await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
         const boardKeyCalls = () =>
-          spy.mock.calls.filter(([opts]) => Array.isArray(opts?.queryKey) && opts.queryKey[0] === "board-current-message");
+          spy.mock.calls.filter(
+            ([opts]) => Array.isArray(opts?.queryKey) && opts.queryKey[0] === "board-current-message",
+          );
 
         // Before the first scheduled tick, no board-state invalidations yet.
         expect(boardKeyCalls()).toHaveLength(0);

--- a/web/src/__tests__/hooks-extended.test.ts
+++ b/web/src/__tests__/hooks-extended.test.ts
@@ -64,6 +64,54 @@ describe("use-board extended", () => {
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(result.current.data?.page_id).toBeNull();
     });
+
+    it("invalidates board-current-message shortly after success and again as a safety net", async () => {
+      // The backend's post-send adaptive refresh updates its cache within ~3s.
+      // We invalidate twice from the client: once at ~750ms to catch the
+      // fast local-API case, and once at ~3500ms after the backend's window
+      // closes. Otherwise the user waits up to 30s for the next poll tick.
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      try {
+        const queryClient = new QueryClient({
+          defaultOptions: {
+            queries: { retry: false },
+            mutations: { retry: false },
+          },
+        });
+        const spy = vi.spyOn(queryClient, "invalidateQueries");
+
+        function Wrapper({ children }: { children: React.ReactNode }) {
+          return React.createElement(QueryClientProvider, { client: queryClient }, children);
+        }
+
+        const { result } = renderHook(() => useSetActivePage(), { wrapper: Wrapper });
+
+        await act(async () => {
+          result.current.mutate("page-1");
+        });
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+        const boardKeyCalls = () =>
+          spy.mock.calls.filter(([opts]) => Array.isArray(opts?.queryKey) && opts.queryKey[0] === "board-current-message");
+
+        // Before the first scheduled tick, no board-state invalidations yet.
+        expect(boardKeyCalls()).toHaveLength(0);
+
+        // After ~750ms, the first invalidate should have fired.
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(800);
+        });
+        expect(boardKeyCalls().length).toBeGreaterThanOrEqual(1);
+
+        // After ~3500ms total, the second (safety-net) invalidate should have fired.
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(3000);
+        });
+        expect(boardKeyCalls().length).toBeGreaterThanOrEqual(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 
   describe("usePagePreview", () => {

--- a/web/src/hooks/use-board.ts
+++ b/web/src/hooks/use-board.ts
@@ -17,6 +17,16 @@ export const queryKeys = {
   schedules: (boardId: string) => ["schedules", boardId] as const,
 };
 
+// Pair with the backend's adaptive post-send refresh (max ~3s). Early tick
+// catches the fast local-API case; late tick is the safety net once the
+// backend's window closes. Without this, the UI would wait up to 30s for
+// the next board-current-message refetch tick.
+function scheduleBoardStateInvalidations(queryClient: ReturnType<typeof useQueryClient>) {
+  const key = ["board-current-message"];
+  setTimeout(() => queryClient.invalidateQueries({ queryKey: key }), 750);
+  setTimeout(() => queryClient.invalidateQueries({ queryKey: key }), 3500);
+}
+
 // Status query - refetches every 15 seconds
 export function useStatus() {
   return useQuery({
@@ -78,6 +88,7 @@ export function useSetActivePage() {
     onSuccess: () => {
       // Only invalidate status, not activePage (we already updated it optimistically)
       queryClient.invalidateQueries({ queryKey: queryKeys.status });
+      scheduleBoardStateInvalidations(queryClient);
     },
     onSettled: () => {
       // Always refetch after error or success to ensure consistency


### PR DESCRIPTION
## Summary
- **Backend** (`src/main.py`): `DisplayService.request_board_refresh()` now adaptively polls the Vestaboard after a send instead of a single shot 3s later. Initial 500ms delay, then retries every 1s, capped at 3s total. Stops early as soon as the read matches what we sent. Every successful read still updates the cache, so even a timeout improves freshness over the old behavior. A subsequent call cancels the in-flight cycle via `threading.Event` so rapid sends don't stack threads.
- **Frontend** (`web/src/hooks/use-board.ts`): on successful `useSetActivePage`, schedule `board-current-message` invalidations at 750ms and 3500ms. The early tick catches the fast local-API case; the late tick is the safety net after the backend's adaptive window closes.

## Why
Switching active pages felt slow: the backend scheduled one read 3s after a send, and the React Query that drives the board display polls every 30s. So the UI could lag 0–30s behind the physical board after every change. With these two changes the UI typically reflects the new board state within ~1s.

## Test plan
- [x] New backend tests: `tests/test_adaptive_board_refresh.py` (9 cases: early stop on match, retries until match, cache on timeout, time budget enforced, cancellation, None / exception handling, no `_last_characters`, no `vb_client`).
- [x] New frontend test in `web/src/__tests__/hooks-extended.test.ts` verifying `useSetActivePage` invalidates `board-current-message` at ~750ms and ~3500ms.
- [x] Full backend suite: 3789 passed, 11 skipped.
- [x] Full frontend suite: 1053 passed, 13 skipped.
- [x] Ruff lint + format on touched Python files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)