### PR TITLE
feat(docs-audit): learn from closed-without-merge PRs

### DIFF
--- a/.github/docs-audit/README.md
+++ b/.github/docs-audit/README.md
@@ -1,0 +1,59 @@
+# Docs-Audit Feedback Loop
+
+The docs-audit cron (`.github/workflows/claude-docs-audit.yml`) sweeps every
+markdown file in the repo twice a day and opens draft PRs for trivial fixes.
+Sometimes those fixes are wrong — e.g. it tried to rename `Vestaboard`
+(the physical device this software drives) to `FiestaBoard` (the software).
+When that happens, the maintainer closes the PR.
+
+**Closing a docs-audit PR without merging is the teaching action.** This
+folder is the bot's memory of those teaching moments.
+
+## How it works
+
+1. **`docs-audit-feedback.yml`** triggers on `pull_request.closed`. If the
+   PR is unmerged and the head branch starts with `docs-audit/`, it runs
+   `build_rejection.py` to bundle the PR's diff + every comment, review,
+   and inline comment into a single JSON object, then appends that object
+   as one line to `rejected-edits.jsonl` and commits the change to `main`.
+2. **The audit prompt** reads `rejected-edits.jsonl` at the start of every
+   run. The bot is instructed to (a) never re-propose the same `removed →
+   added` swap anywhere in the repo, and (b) generalize from the human's
+   close comment — a Vestaboard rejection becomes a global "never rename
+   Vestaboard" rule, not just a per-file blocklist.
+3. **Re-running capture** is idempotent. If the maintainer adds an
+   explanatory comment after closing, dispatch `docs-audit-feedback.yml`
+   with the PR number and the existing line is replaced.
+
+## File: `rejected-edits.jsonl`
+
+One JSON object per line. Schema:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `pr` | int | PR number. Acts as the primary key — re-capture replaces the prior line. |
+| `title` | string | Original PR title. |
+| `head_ref` | string | `docs-audit/round-<n>-run-<id>`. |
+| `closed_at` | string | ISO 8601. |
+| `author` | string | `github-actions[bot]` for the cron, or whoever pushed. |
+| `body` | string | PR description as opened by the bot. |
+| `files` | array | `[{path, patch}]` — raw unified diff per file. |
+| `comments` | array | Issue-style PR comments: `{author, body, created_at}`. |
+| `reviews` | array | Review-level (cover-letter) comments. |
+| `inline_comments` | array | Per-line review comments: `{author, body, path, created_at, diff_hunk}`. |
+
+## File: `build_rejection.py`
+
+Script the workflow runs. Can be invoked locally with `DRY_RUN=1` to print
+the record to stdout without modifying the log:
+
+```bash
+DRY_RUN=1 python3 .github/docs-audit/build_rejection.py 992
+```
+
+## Manually clearing a stale rejection
+
+If a rejected edit is later determined to have been correct (the close
+was wrong, or the codebase has changed and the swap now makes sense),
+hand-delete that line from `rejected-edits.jsonl` and commit. The file is
+plain JSONL; any text editor can do this.

--- a/.github/docs-audit/build_rejection.py
+++ b/.github/docs-audit/build_rejection.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Capture why a docs-audit PR was closed without merging.
+
+Run as: build_rejection.py <pr_number>
+
+Reads the PR's metadata, full diff, every comment / review / inline comment
+via `gh`, then writes one JSONL line into
+`.github/docs-audit/rejected-edits.jsonl`. The next docs-audit cron run
+loads that file and uses it to avoid repeating the same wrong edit and to
+generalize from the closer's explanation.
+
+Idempotent: a re-run for the same PR replaces that PR's existing line
+rather than appending a duplicate. This lets the GitHub Action be
+triggered manually (workflow_dispatch) after a user has added a later
+explanatory comment without polluting the log.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+LOG_PATH = Path(".github/docs-audit/rejected-edits.jsonl")
+
+
+def gh_json(*args: str):
+    out = subprocess.check_output(["gh", *args], text=True)
+    return json.loads(out)
+
+
+def gh_text(*args: str) -> str:
+    return subprocess.check_output(["gh", *args], text=True)
+
+
+def parse_diff(diff: str) -> list[dict]:
+    """Split a unified diff into per-file `{path, patch}` records."""
+    files: list[dict] = []
+    current: dict | None = None
+    for line in diff.splitlines():
+        if line.startswith("diff --git "):
+            if current is not None:
+                current["patch"] = "\n".join(current["patch"])
+                files.append(current)
+            # `diff --git a/path b/path` — take everything after ` b/`.
+            path = line.split(" b/", 1)[-1] if " b/" in line else line
+            current = {"path": path, "patch": [line]}
+        elif current is not None:
+            current["patch"].append(line)
+    if current is not None:
+        current["patch"] = "\n".join(current["patch"])
+        files.append(current)
+    return files
+
+
+def build_record(pr: str) -> dict:
+    meta = gh_json(
+        "pr", "view", pr,
+        "--json", "number,title,headRefName,closedAt,author,body,state",
+    )
+    if meta.get("state") == "MERGED":
+        raise SystemExit(f"PR #{pr} was merged — refusing to record as rejection.")
+
+    diff = gh_text("pr", "diff", pr)
+    files = parse_diff(diff)
+
+    repo = subprocess.check_output(
+        ["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"],
+        text=True,
+    ).strip()
+
+    issue_comments = gh_json(
+        "api", f"repos/{repo}/issues/{pr}/comments",
+        "--jq", "[.[] | {author: .user.login, body: .body, created_at: .created_at}]",
+    )
+    reviews = gh_json(
+        "api", f"repos/{repo}/pulls/{pr}/reviews",
+        "--jq",
+        '[.[] | select((.body // "") != "") | '
+        '{author: .user.login, body: .body, state: .state, submitted_at: .submitted_at}]',
+    )
+    inline = gh_json(
+        "api", f"repos/{repo}/pulls/{pr}/comments",
+        "--jq",
+        "[.[] | {author: .user.login, body: .body, path: .path, "
+        "created_at: .created_at, diff_hunk: .diff_hunk}]",
+    )
+
+    return {
+        "pr": meta["number"],
+        "title": meta["title"],
+        "head_ref": meta["headRefName"],
+        "closed_at": meta["closedAt"],
+        "author": (meta.get("author") or {}).get("login"),
+        "body": meta.get("body") or "",
+        "comments": issue_comments,
+        "reviews": reviews,
+        "inline_comments": inline,
+        "files": files,
+    }
+
+
+def write_log(record: dict, path: Path = LOG_PATH) -> None:
+    """Replace any prior line for this PR; append the new one."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing: list[str] = []
+    if path.exists():
+        existing = [ln for ln in path.read_text().splitlines() if ln.strip()]
+
+    def keep(line: str) -> bool:
+        try:
+            return json.loads(line).get("pr") != record["pr"]
+        except json.JSONDecodeError:
+            # Preserve hand-edited / malformed lines rather than silently dropping.
+            return True
+
+    kept = [ln for ln in existing if keep(ln)]
+    kept.append(json.dumps(record, ensure_ascii=False, separators=(",", ":")))
+    path.write_text("\n".join(kept) + "\n")
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        sys.exit("usage: build_rejection.py <pr_number>")
+    pr = sys.argv[1]
+    record = build_record(pr)
+    if os.environ.get("DRY_RUN") == "1":
+        print(json.dumps(record, ensure_ascii=False, indent=2))
+        return
+    write_log(record)
+    print(f"Captured PR #{record['pr']} into {LOG_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/claude-docs-audit.yml
+++ b/.github/workflows/claude-docs-audit.yml
@@ -216,6 +216,45 @@ jobs:
             queue depth — you don't need to second-guess them. Just use
             them.
 
+            ## Learning from past rejections
+
+            **Read `.github/docs-audit/rejected-edits.jsonl` before doing
+            anything else.** Each non-empty line is one of your previous
+            draft PRs that a human closed without merging — i.e. the
+            proposed edit was wrong. The log is your single most important
+            input; it is how this audit gets better over time.
+
+            Each line is a JSON object with:
+              - `pr`, `title`, `head_ref`, `closed_at`
+              - `body` — the PR description you originally wrote
+              - `files` — list of `{path, patch}` for every file changed,
+                where `patch` is the raw unified diff
+              - `comments`, `reviews`, `inline_comments` — every human
+                comment on the PR (issue-style, review-level, and inline).
+                These usually contain the *reason* the close happened.
+
+            For each rejection:
+
+            1. **Never repeat the exact swap.** Extract the `-` / `+`
+               lines from each file's `patch`. If you would propose the
+               same `-old → +new` change again — anywhere in the repo,
+               not just in the same file — do not.
+            2. **Read every comment.** Treat the close commenter's
+               reasoning as authoritative. If they wrote "Vestaboard is
+               the physical device this software drives, don't rename
+               it" then "Vestaboard" is a protected term *everywhere* —
+               not just in the file that PR touched.
+            3. **Generalize.** Most rejections expose a class of false
+               positive (proper nouns, intentional jargon, deliberate
+               examples, links that look broken but aren't). Carry the
+               class forward, not just the literal string.
+            4. **Cite when relevant.** If you skip a finding because a
+               past rejection covers it, mention the PR number in your
+               wrap-up summary so the maintainer can see the loop
+               working.
+
+            If the file does not exist or is empty, proceed normally.
+
             ## Sweep state
 
             State file: `.github/docs-audit-state.json`

--- a/.github/workflows/docs-audit-feedback.yml
+++ b/.github/workflows/docs-audit-feedback.yml
@@ -1,0 +1,95 @@
+name: 'Claude: Docs Audit Feedback Capture'
+
+# =============================================================================
+# Captures rejected docs-audit PRs so the cron auditor can learn from them.
+#
+# When a draft PR opened by claude-docs-audit.yml is closed without merging,
+# the maintainer is telling the bot "this edit was wrong." This workflow
+# bundles the PR's diff, the close metadata, and every comment/review on it
+# into a single JSONL line in `.github/docs-audit/rejected-edits.jsonl` and
+# commits that file to main. The next audit run reads the log and uses it to
+# (a) never re-propose the same exact swap, and (b) generalize from the
+# closer's explanation (e.g., "Vestaboard is a product name, do not rename"
+# → never rename Vestaboard in any doc).
+#
+# `workflow_dispatch` re-runs capture for a given PR, which is useful when
+# the maintainer adds an explanatory comment after the original close event.
+# Re-running replaces the prior line for that PR rather than appending.
+# =============================================================================
+
+on:
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to (re)capture into the rejection log'
+        required: true
+        type: number
+
+permissions:
+  contents: read
+
+# Serialize commits to main. Two PRs closed at once would race the same log
+# file and lose a line; cancel-in-progress=false so each capture completes.
+concurrency:
+  group: docs-audit-feedback
+  cancel-in-progress: false
+
+jobs:
+  capture:
+    name: Capture rejected docs-audit edit
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # On `pull_request.closed`, only fire for unmerged docs-audit branches.
+    # `workflow_dispatch` always proceeds — the script itself refuses to
+    # log a merged PR, so manual backfill remains safe.
+    if: >-
+      ${{ github.event_name == 'workflow_dispatch' ||
+          (github.event.pull_request.merged == false &&
+           startsWith(github.event.pull_request.head.ref, 'docs-audit/')) }}
+    permissions:
+      contents: write
+      pull-requests: read
+      issues: read
+    steps:
+      - name: Determine PR number
+        id: pr
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "number=${{ inputs.pr_number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          # RELEASE_PAT so the log commit can push to main past branch
+          # protection — same pattern as the docs-audit state-file commit.
+          ref: main
+          token: ${{ secrets.RELEASE_PAT }}
+          fetch-depth: 1
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Capture rejection
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        run: |
+          set -euo pipefail
+          python3 .github/docs-audit/build_rejection.py "${{ steps.pr.outputs.number }}"
+
+      - name: Commit and push
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- .github/docs-audit/rejected-edits.jsonl; then
+            echo "Log unchanged — script bailed (merged PR, or no diff)."
+            exit 0
+          fi
+          git add .github/docs-audit/rejected-edits.jsonl
+          git commit -m "chore(docs-audit): capture rejection from PR #${{ steps.pr.outputs.number }} [skip ci]"
+          git push origin HEAD:main


### PR DESCRIPTION
## Summary

Adds a feedback loop so the docs-audit cron learns from rejected PRs instead of repeating the same wrong edit. Closing a docs-audit draft PR without merging is the teaching action — and any comment left at close is captured along with the diff.

Motivated by #992, where the bot proposed renaming **Vestaboard** (the physical device this software drives) to **FiestaBoard** (the software) in `plugins/random/docs/SETUP.md`. That's a class of false positive — proper nouns the maintainer wants preserved — that no static glossary will ever fully enumerate.

## How it works

1. **`docs-audit-feedback.yml`** fires on `pull_request.closed`. If `merged == false` and the head branch is `docs-audit/*`, it runs `build_rejection.py` to bundle the PR's full diff + every issue comment, review, and inline review comment into a single JSON object and append it as one line to `.github/docs-audit/rejected-edits.jsonl`. The commit goes straight to `main` (using `RELEASE_PAT`, same pattern as the existing state-file commit) with `[skip ci]`.
2. **`build_rejection.py`** is the extraction. Idempotent on PR number — re-running replaces that PR's prior line, so adding an explanatory comment after the close and re-dispatching the workflow refreshes the entry instead of duplicating it.
3. **The audit prompt** now reads `rejected-edits.jsonl` before anything else and is instructed to: (a) never re-propose the same `removed → added` swap anywhere in the repo, (b) treat each closer's comment as authoritative on *why*, (c) generalize to a class of false positive (proper nouns, intentional jargon, deliberate examples), and (d) cite the relevant PR# when it skips a finding so the loop is visible.

## What's in this PR

- `.github/workflows/docs-audit-feedback.yml` — new workflow (49 lines)
- `.github/docs-audit/build_rejection.py` — extraction script (~125 lines)
- `.github/docs-audit/rejected-edits.jsonl` — empty seed file
- `.github/docs-audit/README.md` — schema + loop docs
- `.github/workflows/claude-docs-audit.yml` — prompt now reads the log

## After this merges

1. Close #992 (with a comment like `Vestaboard is the physical device this software drives — do not rename it`).
2. The new workflow fires, runs `build_rejection.py 992`, appends one JSONL line, commits to main.
3. Next docs-audit cron run reads the log → won't re-propose the Vestaboard rename, and won't propose renaming Vestaboard anywhere else either.

## Test plan

- [x] Dry-ran `DRY_RUN=1 python3 .github/docs-audit/build_rejection.py 992` locally — JSONL shape matches schema; the Vestaboard swap and PR body are captured cleanly.
- [ ] Merge this PR.
- [ ] Close #992 with an explanatory comment; verify the feedback workflow runs and commits a new line to `rejected-edits.jsonl`.
- [ ] Watch the next scheduled docs-audit run; confirm it doesn't re-propose the Vestaboard rename, and verify the wrap-up summary cites the rejection.
- [ ] Manually `workflow_dispatch` the feedback workflow against the same PR# after adding a follow-up comment; verify the JSONL line is replaced, not duplicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)