### PR TITLE
ci(docs-audit-feedback): fire from main via pull_request_target

### DIFF
--- a/.github/workflows/docs-audit-feedback.yml
+++ b/.github/workflows/docs-audit-feedback.yml
@@ -15,10 +15,19 @@ name: 'Claude: Docs Audit Feedback Capture'
 # `workflow_dispatch` re-runs capture for a given PR, which is useful when
 # the maintainer adds an explanatory comment after the original close event.
 # Re-running replaces the prior line for that PR rather than appending.
+#
+# Trigger is `pull_request_target` (not `pull_request`) so GitHub resolves
+# this workflow file from `main` rather than the PR's head ref. Docs-audit
+# branches are cut from `main` at audit time and never updated, so any
+# branch created before this workflow landed would otherwise be invisible
+# to it — exactly what happened with PR #992, which closed one second after
+# the feedback workflow merged and never fired. `pull_request_target` is
+# safe here because the workflow checks out `ref: main` (not PR code) and
+# only reads PR metadata via `gh`; no head-ref code is ever executed.
 # =============================================================================
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
   workflow_dispatch:
     inputs:
@@ -41,9 +50,11 @@ jobs:
     name: Capture rejected docs-audit edit
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # On `pull_request.closed`, only fire for unmerged docs-audit branches.
-    # `workflow_dispatch` always proceeds — the script itself refuses to
-    # log a merged PR, so manual backfill remains safe.
+    # On `pull_request_target.closed`, only fire for unmerged docs-audit
+    # branches. Draft and ready-for-review PRs both fire `closed` — there
+    # is no draft-state gate here. `workflow_dispatch` always proceeds —
+    # the script itself refuses to log a merged PR, so manual backfill
+    # remains safe.
     if: >-
       ${{ github.event_name == 'workflow_dispatch' ||
           (github.event.pull_request.merged == false &&


### PR DESCRIPTION
## Summary
- Switches feedback-capture trigger from \`pull_request\` to \`pull_request_target\` so GitHub resolves the workflow file from \`main\` instead of the PR's head ref.
- Fixes the silent miss on **PR #992**: a draft docs-audit PR closed one second after the feedback workflow merged (#1003) and never fired — its head branch \`docs-audit/round-2-run-70f8fb5b\` was cut from main before the workflow existed, so the file wasn't on the head ref for GitHub to discover. Every in-flight docs-audit branch has the same problem.
- Updates the comment block so the next reader doesn't repeat the \"is it because it's a draft?\" misdiagnosis. Drafts and ready-for-review PRs both fire \`closed\` events; there is no draft gate.

## Why this is safe
- The workflow checks out \`ref: main\` (not the PR head) and only reads PR metadata via \`gh\` — no head-ref code is ever executed.
- The existing \`if:\` gate (\`startsWith(head.ref, 'docs-audit/')\` + \`merged == false\`) still applies; \`pull_request_target\` exposes the same \`github.event.pull_request\` context.

## After merge — backfill the rejection log
\`\`\`
gh workflow run docs-audit-feedback.yml -f pr_number=992
gh workflow run docs-audit-feedback.yml -f pr_number=975
gh workflow run docs-audit-feedback.yml -f pr_number=967
gh workflow run docs-audit-feedback.yml -f pr_number=966
\`\`\`
These are the four closed-without-merge docs-audit drafts that pre-date this fix.

## Test plan
- [ ] Merge to \`main\`.
- [ ] Run the four backfills above; verify \`.github/docs-audit/rejected-edits.jsonl\` gains a line per PR.
- [ ] Wait for the next scheduled docs-audit run (or trigger via \`workflow_dispatch\`) and confirm it reads the log.
- [ ] On the next docs-audit PR you close without merging, confirm a run shows up under the \"Claude: Docs Audit Feedback Capture\" workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)