### PR TITLE
fix(ci): bypass OIDC App exchange on pull_request_target docs reviews

### DIFF
--- a/.github/workflows/claude-docs-review.yml
+++ b/.github/workflows/claude-docs-review.yml
@@ -75,6 +75,16 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Skip the OIDC→claude[bot] App-token exchange and post the
+          # review under the workflow's own GITHUB_TOKEN. On
+          # `pull_request_target` events the App exchange returns
+          # `401 Invalid OIDC token` (the App's trust policy doesn't
+          # admit pull_request_target subs); providing `github_token`
+          # bypasses that exchange entirely, per the action's FAQ. The
+          # cost is the review badge — `github-actions[bot]` instead of
+          # `claude[bot]`. The downstream feedback-capture workflow
+          # already allowlists both bots so the loop is unchanged.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           # Bot-authored PRs (docs-audit cron, issue-triage worker) need
           # to be reviewed too — that's the whole point. Without this the
           # action's anti-bot guard short-circuits the run.


### PR DESCRIPTION
## Summary

- Docs auto-review fired for the first time on PRs #1018 and #1019 and both failed at the same step in `anthropics/claude-code-action@v1`:

  ```
  OIDC token successfully obtained
  Exchanging OIDC token for app token...
  App token exchange failed: 401 Unauthorized - Invalid OIDC token
  ```

- That exchange mints a `claude[bot]` GitHub App installation token. Empirically the Anthropic App's trust policy doesn't admit `pull_request_target` OIDC subs — same action + same secret + same `id-token: write` permission works under `pull_request` (`pr-changelog.yml`) and `workflow_dispatch` (`claude-docs-audit.yml`), so the gap is event-class-specific.

- The action's FAQ documents the bypass: pass `github_token` and the action skips the App exchange entirely. Reviews then post as `github-actions[bot]`. The downstream `docs-audit-feedback.yml` already allowlists both `claude` and `github-actions` so the rejection-capture loop is unchanged.

## Test plan

- [ ] Merge this PR
- [ ] Rebase PR #1018 onto main and confirm the `Claude reviews the docs diff` check now succeeds and a review with inline suggestions is posted
- [ ] Same for PR #1019
- [ ] Verify the review badge reads `github-actions[bot]` and that closing either PR without merging still produces a `rejected-edits.jsonl` line via the feedback workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)