### PR TITLE
ci: rename workflows to consistent Prefix: convention

### DIFF
--- a/.github/workflows/bootstrap-visual-baselines.yml
+++ b/.github/workflows/bootstrap-visual-baselines.yml
@@ -1,4 +1,4 @@
-name: Bootstrap Visual Regression Baselines
+name: 'Manual: Bootstrap Visual Baselines'
 
 # =============================================================================
 # Generates Playwright visual-regression baseline snapshots and opens a PR.

--- a/.github/workflows/build-fiestapi.yml
+++ b/.github/workflows/build-fiestapi.yml
@@ -1,4 +1,4 @@
-name: Build FiestaPi image
+name: 'Build: FiestaPi Image'
 
 # =============================================================================
 # Builds the flashable FiestaPi .img.xz — a slow job (~45-60 min), so we

--- a/.github/workflows/build-fiestaupdater.yml
+++ b/.github/workflows/build-fiestaupdater.yml
@@ -1,4 +1,4 @@
-name: Build & Publish FiestaUpdater
+name: 'Build: FiestaUpdater'
 
 # =============================================================================
 # Builds the `fiestaupdater` sidecar image (multi-arch) and pushes to Docker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: 'CI: Lint, Test & Build'
 
 on:
   push:

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -1,4 +1,4 @@
-name: Claude Issue Triage
+name: 'Claude: Issue Triage'
 
 # Take a first-pass fix attempt at new issues.
 #

--- a/.github/workflows/docs-audit-feedback.yml
+++ b/.github/workflows/docs-audit-feedback.yml
@@ -1,4 +1,4 @@
-name: 'Claude: Docs Audit Feedback Capture'
+name: 'Claude: Docs Audit Feedback'
 
 # =============================================================================
 # Captures rejected docs-pipeline PRs so the cron auditor can learn from them.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@
 #      creates a Docusaurus version snapshot, builds, then deploys.
 #      Patch releases (e.g. 2.5.0 → 2.5.1) share the same docs version
 #      (e.g. "2.5") so the snapshot step is a no-op for them.
-name: Deploy Docs
+name: 'Release: Deploy Docs Site'
 
 on:
   push:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,4 +1,4 @@
-name: Integration Tests
+name: 'CI: Integration Tests'
 
 # Full integration suite runs on merge queue to gate changes before they land on main.
 # A smoke subset also runs on PRs to catch critical breakage early.

--- a/.github/workflows/pr-changelog.yml
+++ b/.github/workflows/pr-changelog.yml
@@ -1,4 +1,4 @@
-name: 'Claude: PR Changelog Summary'
+name: 'Claude: PR Changelog'
 
 # When a PR is merged to main, ask Claude to write a single user-facing
 # changelog one-liner and post it as a PR comment with the marker

--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -1,4 +1,4 @@
-name: PR Auto-Label
+name: 'PR: Auto-Label'
 
 on:
   pull_request_target:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release and Publish
+name: 'Release: Publish Image'
 
 on:
   push:

--- a/.github/workflows/scheduled-maintenance.yml
+++ b/.github/workflows/scheduled-maintenance.yml
@@ -1,4 +1,4 @@
-name: Scheduled Maintenance
+name: 'Scheduled: Maintenance'
 
 # =============================================================================
 # Recurring repo upkeep jobs. Cron-only with a workflow_dispatch fallback

--- a/docs/superpowers/specs/2026-06-14-actions-sidebar-cleanup-design.md
+++ b/docs/superpowers/specs/2026-06-14-actions-sidebar-cleanup-design.md
@@ -1,0 +1,111 @@
+# GitHub Actions Sidebar Cleanup — Design
+
+## Problem
+
+The GitHub Actions sidebar (left nav at `https://github.com/<repo>/actions`) lists 15
+workflows in alphabetical order by their `name:` field. Today the names are inconsistent —
+some use `Claude:` as a category prefix, some don't; verbs and capitalization vary; manual
+one-off workflows are visually indistinguishable from automatic CI runs. Scanning the
+sidebar to find a specific workflow takes longer than it should.
+
+## Goal
+
+Apply a consistent `Prefix: Title-Case Name` convention across all workflow `name:` fields
+so the sidebar groups related workflows together under shared prefixes. No behavior change,
+no filename change — only the display string each workflow advertises to the Actions UI.
+
+## Non-goals
+
+- Renaming workflow **files** (would invalidate run-history URLs and any external references)
+- Renaming **jobs** inside workflows (would break branch-protection required-check rules)
+- Changing triggers, permissions, secrets, or any logic
+- Reordering jobs or restructuring workflow YAML beyond the single `name:` line
+- Removing the dormant "Notify Arthur" entry in GitHub's UI cache (the workflow file
+  was deleted in PR #512; the leftover sidebar entry must be cleared manually in
+  the GitHub web UI — not in this repo)
+- Removing the `copilot-swe-agent` mention in `.claude/commands/triage.md` (it's a
+  defensive bot-login classifier, not an active Copilot integration)
+
+## Design
+
+### Prefix taxonomy
+
+| Prefix | Meaning | Workflows |
+| --- | --- | --- |
+| `Build:` | Container image builds | FiestaPi Image, FiestaUpdater |
+| `CI:` | Automatic per-PR / per-push validation | Lint, Test & Build; Integration Tests |
+| `Claude:` | Claude-driven automation | Code Assistant, Docs Audit, Docs Audit Feedback, Docs Auto-Review, Issue Triage, PR Changelog |
+| `Manual:` | Human-triggered one-offs (workflow_dispatch only) | Bootstrap Visual Baselines |
+| `PR:` | PR-lifecycle automations not driven by Claude | Auto-Label |
+| `Release:` | Publishes & deploys | Deploy Docs Site, Publish Image |
+| `Scheduled:` | Cron-primary maintenance | Maintenance |
+
+### Rename map
+
+| File | Current `name:` | New `name:` |
+| --- | --- | --- |
+| `bootstrap-visual-baselines.yml` | `Bootstrap Visual Regression Baselines` | `Manual: Bootstrap Visual Baselines` |
+| `build-fiestapi.yml` | `Build FiestaPi image` | `Build: FiestaPi Image` |
+| `build-fiestaupdater.yml` | `Build & Publish FiestaUpdater` | `Build: FiestaUpdater` |
+| `ci.yml` | `CI` | `CI: Lint, Test & Build` |
+| `claude-docs-audit.yml` | `Claude: Docs Audit` | (unchanged) |
+| `claude-docs-review.yml` | `Claude: Docs Auto-Review` | (unchanged) |
+| `claude-issue-triage.yml` | `Claude Issue Triage` | `Claude: Issue Triage` |
+| `claude.yml` | `Claude: Code Assistant` | (unchanged) |
+| `docs-audit-feedback.yml` | `Claude: Docs Audit Feedback Capture` | `Claude: Docs Audit Feedback` |
+| `docs.yml` | `Deploy Docs` | `Release: Deploy Docs Site` |
+| `integration-tests.yml` | `Integration Tests` | `CI: Integration Tests` |
+| `pr-changelog.yml` | `Claude: PR Changelog Summary` | `Claude: PR Changelog` |
+| `pr-label.yml` | `PR Auto-Label` | `PR: Auto-Label` |
+| `release.yml` | `Release and Publish` | `Release: Publish Image` |
+| `scheduled-maintenance.yml` | `Scheduled Maintenance` | `Scheduled: Maintenance` |
+
+12 of 15 files change. 3 (`claude-docs-audit`, `claude-docs-review`, `claude.yml`)
+already conform.
+
+### Resulting sidebar order
+
+```
+Build: FiestaPi Image
+Build: FiestaUpdater
+CI: Integration Tests
+CI: Lint, Test & Build
+Claude: Code Assistant
+Claude: Docs Audit
+Claude: Docs Audit Feedback
+Claude: Docs Auto-Review
+Claude: Issue Triage
+Claude: PR Changelog
+Manual: Bootstrap Visual Baselines
+PR: Auto-Label
+Release: Deploy Docs Site
+Release: Publish Image
+Scheduled: Maintenance
+```
+
+## Risks & mitigations
+
+- **Required status checks break.** Branch-protection rules in GitHub reference the
+  `job` name (e.g. `ci-success`), not the workflow `name:`. This rename does not touch
+  any job IDs, so required checks remain green.
+  *Mitigation:* Diff verification — confirm no `jobs:` block keys are altered.
+- **External links to workflow names rot.** The Actions sidebar URL is
+  `?query=workflow%3A<name>`. Anything bookmarked using the old name will no longer
+  filter. Acceptable cost; URLs that use the workflow file path (`workflows/ci.yml`)
+  still work.
+- **Run history continuity.** GitHub Actions groups runs by workflow **file path**, not
+  `name:`. Renaming only the display field preserves history.
+- **Stale UI entries.** Anyone still seeing "Notify Arthur" in their sidebar must clear
+  it manually via the workflow's three-dot menu. Not in scope.
+
+## Verification
+
+After the edits land:
+
+1. `grep -E "^name:" .github/workflows/*.yml` — confirm every file matches the rename
+   map exactly (15 lines, including the 3 unchanged).
+2. `git diff --stat .github/workflows/` — confirm every changed file is a one-line
+   diff on the `name:` line. Anything larger means an accidental edit.
+3. Branch CI runs to green — proves no required-check name was disturbed.
+4. After merge, open the Actions sidebar in a browser and confirm the new grouping
+   matches the "Resulting sidebar order" section above.


### PR DESCRIPTION
## Summary

- Renames all 15 GitHub Actions workflow `name:` fields to a consistent `Prefix: Title-Case Name` convention so the Actions sidebar groups related workflows together (GitHub sorts alphabetically).
- 12 of 15 workflows change; 3 (`claude-docs-audit`, `claude-docs-review`, `claude.yml`) already conformed.
- Only the display `name:` field changes — filenames, jobs, triggers, permissions, and secrets are untouched, so run history (keyed by file path) and branch-protection required checks (keyed by job ID) are preserved.

## Prefix taxonomy

| Prefix | Meaning |
| --- | --- |
| `Build:` | Container image builds |
| `CI:` | Automatic per-PR / per-push validation |
| `Claude:` | Claude-driven automation |
| `Manual:` | Human-triggered one-offs (workflow_dispatch only) |
| `PR:` | PR-lifecycle automations not driven by Claude |
| `Release:` | Publishes & deploys |
| `Scheduled:` | Cron-primary maintenance |

## Resulting sidebar

```
Build: FiestaPi Image
Build: FiestaUpdater
CI: Integration Tests
CI: Lint, Test & Build
Claude: Code Assistant
Claude: Docs Audit
Claude: Docs Audit Feedback
Claude: Docs Auto-Review
Claude: Issue Triage
Claude: PR Changelog
Manual: Bootstrap Visual Baselines
PR: Auto-Label
Release: Deploy Docs Site
Release: Publish Image
Scheduled: Maintenance
```

Full design notes in `docs/superpowers/specs/2026-06-14-actions-sidebar-cleanup-design.md`.

## Notes

- The dormant "Notify Arthur" entry that may still appear in the Actions sidebar is a stale UI artifact — the workflow file was already removed in #512. Clear it manually in the GitHub web UI (open the entry → "..." → Delete workflow).
- No Copilot workflows exist in the repo; the only `copilot` mention is `copilot-swe-agent` in `.claude/commands/triage.md`, which is a defensive bot-login classifier and stays put.

## Test plan

- [ ] CI runs green on this branch (proves no required-check job name was disturbed)
- [ ] After merge, open the Actions sidebar and confirm grouping matches the listing above
- [ ] Confirm no orphaned run history (Actions tab still shows past runs under each renamed workflow)