### PR TITLE
feat(skill): scaffold and tune Claude GitHub Actions feedback loops

### DIFF
--- a/.claude/skills/new-claude-github-actions-flow/SKILL.md
+++ b/.claude/skills/new-claude-github-actions-flow/SKILL.md
@@ -1,0 +1,260 @@
+---
+name: new-claude-github-actions-flow
+description: Scaffold or tune a Claude-powered GitHub Actions feedback loop — the docs-audit pattern (scheduled cron → audit → file issues → open PRs → auto-review → capture rejections to learn from). Use this skill whenever the user wants to create a new automated Claude workflow for a domain (tests, perf, i18n, plugins, security, infra, accessibility, schema migrations, etc.), mirror the docs-audit pattern, set up a recurring audit-and-fix loop, add a scheduled Claude job to GitHub Actions, build a "Claude workflow" or "Claude feedback loop", or tune knobs on an existing claude-*.yml workflow (cron schedule, model tier, batch size, queue thresholds, file globs, draft caps, allowed-tools allowlists, time-window gates). Trigger eagerly on phrases like "set up an automation", "Claude cron", "recurring Claude job", "audit loop", "feedback loop", "scan repeatedly for X", "automate fixing X", "fan out Claude on X", "add a workflow that runs every day", or any request to tune cron / effort / model on an existing `.github/workflows/claude-*.yml` file. Use this skill even when the user does not say "skill" or "scaffold" — if the intent is "make Claude do this on a schedule and open PRs", that is this skill.
+---
+
+# new-claude-github-actions-flow
+
+## What this skill does
+
+Scaffolds (or tunes) a Claude-powered, self-improving audit-and-fix loop on GitHub Actions. The canonical example is the FiestaBoard `docs-audit` system: a cron-driven Claude run sweeps a domain (markdown files), opens trivial fixes inline as ready-for-review PRs, files issues for everything else, fans out per-issue triage workers, auto-reviews docs PRs, and captures rejection feedback so the next sweep doesn't repeat mistakes.
+
+This skill lets you create the same shape of loop for **any domain** — tests, performance, i18n, plugin manifests, schema migrations, security findings, broken images, dead links — with the knobs (schedule, model tier, batch size, file globs) tuned for that domain.
+
+## When NOT to use this skill
+
+- The user wants a **one-off** Claude task, not a recurring loop → use a regular slash command or the `Agent` tool.
+- The user wants to **manually run** an existing workflow once → just `gh workflow run …`.
+- The user wants to **author the prompt logic** for an existing loop's Claude run → edit the prompt directly; you don't need scaffolding.
+
+## The shape of a loop
+
+Every loop produced by this skill has up to four GitHub Actions workflows plus a state file. Components are independently optional, but the recommended default is all four:
+
+| File | Trigger | Purpose |
+| --- | --- | --- |
+| `.github/workflows/claude-<name>.yml` | `schedule` + `workflow_dispatch` | Main audit cron. Sweeps the domain in batches, opens trivial fixes inline, files issues for the rest. |
+| `.github/workflows/claude-issue-triage.yml` (one shared, not per-loop) | `issues: [opened, labeled]` | Per-issue worker. When the audit files an issue with the loop's label, this opens a focused fix PR. |
+| `.github/workflows/claude-<name>-review.yml` | `pull_request_target` on paths | Auto-reviews every PR touching the domain, before merge. |
+| `.github/workflows/claude-<name>-feedback.yml` | `pull_request_target: [closed]` | Captures closed-without-merge PRs into a JSONL rejection log the next audit reads. |
+| `.github/<name>-state.json` | (file, not a workflow) | Sweep progress: round, files_remaining, files_audited, last_run_at. |
+| `.github/<name>/build_rejection.py` | (script) | Builds one JSONL line per rejected PR with full diff + every comment. |
+| `.github/<name>/rejected-edits.jsonl` | (data) | Append-only learning log the audit prompt reads at the start of every run. |
+| `.github/<name>/README.md` | (docs) | Explains the loop's feedback memory for human maintainers. |
+
+The canonical reference instance is `docs-audit`. Read `.github/workflows/claude-docs-audit.yml`, `.github/workflows/docs-audit-feedback.yml`, `.github/workflows/claude-docs-review.yml`, `.github/workflows/claude-issue-triage.yml`, and `.github/docs-audit/` end-to-end before you scaffold a new loop. They are the source of truth for the pattern — these templates copy from them, not the other way around.
+
+## Detecting mode: CREATE vs TUNE
+
+Read the user's message. If they want to **make a new loop**, go to [CREATE flow](#create-flow). If they want to **change knobs on an existing loop** (schedule, model, batch size, etc.), go to [TUNE flow](#tune-flow). If unclear, ask.
+
+Examples of CREATE intent: "set up an audit loop for tests", "I want a Claude cron that scans plugins", "mirror docs-audit but for accessibility", "automate fixing broken images in screenshots".
+
+Examples of TUNE intent: "make the docs-audit run every 4 hours instead of 2", "bump batch size", "switch the docs review to Haiku", "I want the audit to skip files under `web/messages/`", "drop the cap when queue is hot".
+
+## CREATE flow
+
+### Step 1 — Gather variables
+
+Ask the user these questions in order. Suggest a sensible default and let them confirm or override. Use one `AskUserQuestion` batch if you're in Claude Code; otherwise go inline.
+
+**Required:**
+
+1. **Loop name (slug)** — kebab-case, used in filenames, labels, branch prefixes. Example: `tests-audit`, `perf-audit`, `i18n-audit`, `plugin-audit`. Must not collide with an existing `claude-*.yml` workflow.
+2. **What is this loop auditing?** — one paragraph describing the domain. The user's words go into the audit prompt verbatim. Examples: "the Python test suite for flaky tests, slow tests, and missing coverage" / "plugin manifests for missing fields, stale screenshots, and category drift".
+3. **File globs to sweep** — include + exclude patterns. Default exclude list: `node_modules/`, `.git/`, `**/node_modules/`, `tools/`, `.claude/`. Example for tests: include `tests/**/*.py`, `plugins/*/tests/**/*.py`; exclude `**/__pycache__/`.
+
+**Optional (use the defaults unless the user objects):**
+
+4. **Components** — default all four. Sub-options:
+   - Triage worker reuse — if `.github/workflows/claude-issue-triage.yml` already exists, reuse it; just add the new label to its `if:` gate. Don't create a per-loop triage worker.
+   - Skip the auto-review if PRs touching this domain don't need a separate Claude review pass.
+   - Skip the feedback capture if the loop is read-only (no PRs to learn from).
+   - **Issues-only mode** (no inline PRs at all): if the loop only files issues — no bucket-A inline fixes — apply the trims in [Issues-only trims](#issues-only-trims) below. This is a real variant; the docs-audit default opens inline PRs, but `manifest-audit`-style loops where every finding needs a thinking pass don't.
+5. **Cadence** — default: twice daily, noon + 4pm PT. Other patterns: daily, weekly, on push to main, weekdays-only.
+6. **Model tier** — default for audit: Sonnet 4.6. Default for triage: Opus 4.7 (code) / Sonnet 4.6 (docs). Default for review: Sonnet 4.6.
+7. **Effort thresholds** — default mirrors docs-audit: queue ≤ 40 → thorough; 40–80 → balanced; > 80 → conservative. Batch sizes 32/24/12, caps 100/60/32.
+8. **Branch prefix** — default `<name>/round-<n>-run-<id>` for inline PRs, `<short-name>/issue-<N>-<slug>` for triage PRs.
+9. **Issue labels** — default: domain label + `<name>` + `claude-fix` (for triage handoff).
+
+### Step 2 — Confirm the file plan
+
+List the files you'll create with their exact paths. Show the user before writing anything. Example:
+
+```
+Will create:
+  .github/workflows/claude-tests-audit.yml          (audit cron)
+  .github/workflows/claude-tests-audit-review.yml   (PR auto-review)
+  .github/workflows/claude-tests-audit-feedback.yml (rejection capture)
+  .github/tests-audit-state.json                    (sweep state)
+  .github/tests-audit/README.md                     (folder doc)
+  .github/tests-audit/build_rejection.py            (script)
+  .github/tests-audit/rejected-edits.jsonl          (empty)
+
+Will modify:
+  .github/workflows/claude-issue-triage.yml         (add `tests-audit` to label gate)
+```
+
+### Step 3 — Render the templates
+
+Read each template from `references/templates/`. Each template uses `{{TOKEN}}` placeholders documented in `references/variables.md`. Substitute the variables per the user's choices. Write the rendered file to its target path on a feature branch.
+
+Template files to read:
+- `references/templates/audit-cron.yml.tmpl` → main audit workflow
+- `references/templates/auto-review.yml.tmpl` → PR auto-review (skip if user opted out)
+- `references/templates/feedback-capture.yml.tmpl` → rejection capture (skip if opted out)
+- `references/templates/state.json.tmpl` → initial sweep state
+- `references/templates/build_rejection.py.tmpl` → rejection log builder
+- `references/templates/feedback-readme.md.tmpl` → human-readable folder docs
+
+For the **audit prompt body** — the long `prompt:` block in the audit workflow — synthesize it from the user's domain description. Use the docs-audit prompt as the structural template (sweep logic, batch picking, bucket A/B/C definitions, rejection-log learning, hard rules, wrap-up summary) but rewrite the domain-specific paragraphs:
+- "You are the FiestaBoard X auditor." — substitute X.
+- The categorization section (what counts as bucket A / B / C for this domain).
+- Glob patterns for file discovery.
+- Hard rules around which files Claude may edit.
+
+If the loop has no triage worker, drop the "After creating each issue, also apply the `claude-fix` label" instruction.
+
+### Step 4 — Read the pitfalls before writing
+
+**Before you write any workflow file, read `references/pitfalls.md` end-to-end.** Every gotcha in there has cost real PRs and real debugging time. The biggest ones:
+
+- `BRANCH_SUFFIX=${{ github.run_id }}` — never `date +%s` (the model invents stale 2025 timestamps).
+- `pull_request_target` for feedback capture, NOT `pull_request` — branches don't carry the workflow forward.
+- `--allowed-tools` allowlist must match every Bash pattern the prompt invokes — missing patterns silently fail.
+- `show_full_output: 'true'` — without it, permission denials look like clean successes.
+- `allowed_bots: 'claude'` — required when bot-authored issues should trigger the workflow.
+- Auto-review uses `github_token: ${{ secrets.GITHUB_TOKEN }}` to bypass the OIDC App exchange on `pull_request_target`.
+- Auto-review checks out the **base ref**, never the PR head (CodeQL `actions/untrusted-checkout`).
+- Concurrency group + `cancel-in-progress: false` — without it, parallel runs open duplicate PRs.
+- Cron pairs in UTC to absorb DST — one pair per intended PT window.
+
+### Step 5 — Branch, commit, PR
+
+Per `CLAUDE.md`, never push directly to `main`. Cut a feature branch (`feat-<name>-loop`), commit the rendered files with conventional commit messages, push, and open a PR with `gh pr create`. Title: `feat(<name>-audit): scaffold Claude feedback loop`. In the PR body, list every file added and call out any deviation from the docs-audit canonical pattern.
+
+If the canonical docs-audit triage worker already exists, edit `.github/workflows/claude-issue-triage.yml` to extend the `labeled` condition with the new loop's label and bump the model-tier selection if appropriate.
+
+### Step 6 — Tell the user what's next
+
+After the PR opens, tell the user explicitly:
+- The first cron tick — when the loop will fire on its own.
+- How to manual-dispatch it now: `gh workflow run claude-<name>.yml`.
+- Where to find the state file and rejection log.
+- The labels to apply to issues that should trigger the triage worker (if any).
+- How to disable the loop quickly (delete the schedule, or `gh workflow disable`).
+
+## Issues-only trims
+
+When the loop only files issues — no inline bucket-A PRs, no auto-review, no feedback capture — the audit workflow's surface area shrinks. Apply *every* trim below; leaving any one in place is dead permission or dead instruction that future-you will have to reason about. The state-file commit still happens, so a few write capabilities stay.
+
+**Permissions block (audit job).** Drop `pull-requests: write`. Keep `contents: write` (state-file commit), `issues: write`, `id-token: write`. Result:
+
+```yaml
+permissions:
+  contents: write
+  issues: write
+  id-token: write
+```
+
+**`--allowed-tools` allowlist.** Drop these (the audit never invokes them):
+
+- `Bash(gh pr create:*)`
+- `Bash(gh pr view:*)`
+- `Bash(gh pr list:*)` *(or keep only if dedup still wants it — see below)*
+- `Bash(gh pr edit:*)`
+- `Bash(git branch:*)`, `Bash(git checkout:*)`, `Bash(git switch:*)`, `Bash(git fetch:*)`
+
+**Keep** these — they're still needed for the state-file commit and for issue work:
+
+- `Read`, `Glob`, `Grep`, `Edit`, `Write` (Edit/Write are how Claude rewrites the state JSON)
+- `Bash(git add:*)`, `Bash(git commit:*)`, `Bash(git push:*)`, `Bash(git status:*)`, `Bash(git diff:*)`, `Bash(git log:*)`, `Bash(git show:*)`, `Bash(git rev-parse:*)`
+- `Bash(gh issue list:*)`, `Bash(gh issue view:*)`, `Bash(gh issue create:*)`, `Bash(gh issue edit:*)`
+- `Bash(gh label list:*)`, `Bash(gh label create:*)`
+- `Bash(ls:*)`, `Bash(cat:*)`, `Bash(find:*)`, `Bash(date:*)`, `Bash(jq:*)`
+
+**Prompt body.** Strip these sections:
+
+- Bucket A (the trivial-mechanical-fixes case). Every finding is an issue; there's no bucket A.
+- "Create a branch named exactly … Branch off `main`. Apply ONLY the bucket-A fixes. Commit. Open a … PR." — gone.
+- The draft-cap dedup check (no drafts exist when no PRs are opened). The cooldown check stays.
+- "After creating each issue, also apply the `claude-fix` label" — drop unless a triage worker exists.
+
+**Hard rules.** Replace "Edits are restricted to `<editable globs>`" with "Edits are restricted to `<STATE_FILE>` only". The audit must not modify source code outside the state file.
+
+**What stays.**
+- The full sweep/state logic (state file, batches, rounds).
+- The dedup cooldown check.
+- The dynamic-effort step (queue depth → batch/cap).
+- The wrap-up summary.
+- The defensive state-file push at the end.
+- All the pitfall guards: `BRANCH_SUFFIX`, `show_full_output`, `concurrency.cancel-in-progress: false`, `RELEASE_PAT` for checkout, `TZ=…` gate, `[skip ci]` on the state commit.
+
+**`BRANCH_SUFFIX` in issues-only mode.** Even though no PR branches are created, keep the env var. It's cheap, it lets issue bodies reference the run (`round <N>, run $BRANCH_SUFFIX`), and it preserves the pattern so future-you can re-enable bucket A without re-engineering.
+
+## TUNE flow
+
+The audit loop's behaviour is controlled by a handful of knobs. Most live in the workflow YAML; a few live in the prompt block.
+
+### Step 1 — Identify the loop
+
+If the user says "the docs audit", look at `.github/workflows/claude-docs-audit.yml`. If they reference another loop, find it by `ls .github/workflows/claude-*.yml`. If ambiguous, ask.
+
+### Step 2 — Identify the knob
+
+Read `references/variables.md`. Every knob is catalogued there with:
+- What it controls
+- Where in the workflow file it lives (step name, env var, or interpolation token)
+- The trade-offs (lower batch = more PRs per day; higher cap = noisier reviewer queue; etc.)
+- Cross-references — some knobs need updates in multiple places.
+
+Common tuning requests and where they land:
+
+| Request | File(s) | Knob |
+| --- | --- | --- |
+| "Run every 4 hours" | audit workflow | `on.schedule.cron` pairs + the local-time gate |
+| "Use Opus instead of Sonnet" | audit workflow | `--model` in `claude_args` |
+| "Bump batch / cap" | audit workflow | "Compute dynamic effort" step's branches |
+| "Add a file pattern to skip" | audit workflow | Prompt's glob-discovery section |
+| "Hold off when N drafts open" | audit workflow | "Dedup against recent runs" step's `draft_count` cap |
+| "Allow another Bash command" | audit workflow | `--allowed-tools` allowlist |
+| "Auto-review more file types" | review workflow | `on.pull_request_target.paths` |
+| "Capture rejections from new branch prefix" | feedback workflow | `if:` startsWith condition |
+
+### Step 3 — Make the change
+
+For straight YAML edits, use `Edit`. For prompt-body changes, edit the multiline `prompt: |` block carefully — the indentation matters; YAML block scalars are sensitive.
+
+If a knob is referenced in multiple places (e.g., model tier appears in both `env:` for visibility and `claude_args:` for execution), update both. `references/variables.md` flags these.
+
+### Step 4 — Test before opening the PR
+
+GitHub Actions cron triggers can't be locally simulated, but `workflow_dispatch` runs as soon as you push. If the user wants to validate, suggest opening the PR, merging, and then dispatching the workflow once to see the effect.
+
+For dry-running: the `prompt:` block can be lifted into a local Claude run with the same inputs to sanity-check the new logic.
+
+### Step 5 — Branch, commit, PR
+
+Same as CREATE step 5. PR title: `chore(<name>-audit): <what you tuned>`. PR body should call out before/after for every knob you changed, and explain why (queue too hot, reviewer fatigue, missed findings, etc.).
+
+## Key references
+
+Read these before making decisions:
+- `references/pitfalls.md` — every hard-won lesson, with the PR that taught it.
+- `references/variables.md` — full knob catalogue for tuning.
+- `references/architecture.md` — how the four workflows interlock and why.
+- `references/templates/` — the parameterized YAML and Python templates.
+- `.github/workflows/claude-docs-audit.yml` (in the repo) — the canonical instance.
+
+## Hard rules
+
+These apply to every loop you scaffold:
+
+- **Never commit directly to `main`.** Feature branch + PR. This skill is meant to follow `CLAUDE.md`.
+- **Never skip `show_full_output: 'true'`.** Without it, silent permission denials masquerade as clean successes.
+- **Never use `date +%s` for branch suffixes.** Use `github.run_id` via `BRANCH_SUFFIX` env var.
+- **Never use `pull_request` for feedback capture.** Use `pull_request_target` so the workflow is resolved from `main`, not the PR head.
+- **Never check out the PR head ref in an auto-review workflow.** Always the base ref. PR content is read via `gh api .../contents` from inside the prompt.
+- **Never widen `--allowed-tools` beyond what the prompt actually invokes.** Each pattern is a foot-gun.
+- **Never set `cancel-in-progress: true` on the audit workflow.** Parallel runs racing the state file open duplicate PRs.
+- **Always copy the dedup + cooldown logic** from docs-audit. Without it, reviewer queues blow up.
+- **Always seed the state file** to `schema_version: 1, round: 0, files_remaining: [], files_audited: []`. The first cron run computes the file list.
+
+## Wrap-up
+
+After scaffolding or tuning, give the user:
+- A one-line summary of what landed.
+- The PR URL.
+- The first scheduled trigger time.
+- The manual dispatch command.
+- A heads-up about anything they should monitor on the first few runs (queue depth, false-positive rate, allowed-tools denial errors in the action log).

--- a/.claude/skills/new-claude-github-actions-flow/evals/evals.json
+++ b/.claude/skills/new-claude-github-actions-flow/evals/evals.json
@@ -1,0 +1,26 @@
+{
+  "skill_name": "new-claude-github-actions-flow",
+  "evals": [
+    {
+      "id": 1,
+      "name": "create-tests-audit-from-scratch",
+      "prompt": "I want to set up a Claude feedback loop for my Python tests, similar to the docs-audit I already have. It should scan tests/**/*.py and plugins/*/tests/**/*.py twice a day and find flaky tests (tests that use real time/network without mocking), slow tests (anything over 2 seconds), and tests that don't actually assert anything. Open inline PRs for trivial fixes (typos, dead code, missing assertions where the intent is obvious) and file issues for everything else. Use Sonnet for the audit. Include the rejection-feedback capture so the loop learns from closed PRs. Name it tests-audit. Scaffold the full thing on a feature branch and tell me what to do next.",
+      "expected_output": "A feature branch with: claude-tests-audit.yml (audit workflow), claude-tests-audit-review.yml (auto-review), claude-tests-audit-feedback.yml (rejection capture), .github/tests-audit-state.json (initial state), .github/tests-audit/build_rejection.py, .github/tests-audit/README.md, .github/tests-audit/rejected-edits.jsonl (empty). The triage workflow at .github/workflows/claude-issue-triage.yml should be updated to add 'tests-audit' to its labeled gate. All the pitfalls should be observed: BRANCH_SUFFIX=github.run_id, show_full_output, --allowed-tools allowlist with Edit/Write/git/gh, UTC cron pairs for DST, cancel-in-progress: false, RELEASE_PAT for state-file push, pull_request_target for feedback. A PR should be opened.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "name": "tune-docs-audit-knobs",
+      "prompt": "The docs-audit is being too aggressive. Reviewer queue keeps getting drowned. Bump the conservative threshold so it kicks in at 40 open issues instead of 80, and drop the conservative batch size to 8 (from 12) and cap to 20 (from 32). Also extend the cooldown from 3h to 6h. Open a PR with the change.",
+      "expected_output": "An Edit to .github/workflows/claude-docs-audit.yml that changes: EFFORT_HOT_THRESHOLD 80→40 in the 'Compute dynamic effort' step, batch=12 → batch=8 in the conservative branch, cap=32 → cap=20 in the conservative branch, and the cooldown check (age_h -lt 3) → (age_h -lt 6) in the 'Dedup' step. Other knobs preserved. PR opened on a feature branch with a descriptive title and body that explains before/after for each knob and why.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "name": "create-minimal-audit-only-loop",
+      "prompt": "Set up a minimal Claude loop that just audits plugin manifests (plugins/*/manifest.json) once a week (Mondays at 10am Pacific). It should only file issues — no inline PRs, no auto-review, no feedback capture. Just the auditor. Call it manifest-audit. Use Sonnet. The audit should look for: missing required fields (id, name, version, settings_schema, variables), screenshots that don't exist on disk, plugin id not matching directory name, and invalid category (must be one of: art, data, entertainment, home, transit, utility, weather). File one issue per problem.",
+      "expected_output": "Just two files: .github/workflows/claude-manifest-audit.yml and .github/manifest-audit-state.json. The audit YAML has a weekly cron (with PT gate), Sonnet model, write permissions only for issues (no PR creation), allowlist without git push or gh pr create, and a domain-specific prompt that covers the four checks. Skip the auto-review, feedback, triage modifications. PR opened with a feature branch.",
+      "files": []
+    }
+  ]
+}

--- a/.claude/skills/new-claude-github-actions-flow/evals/grade.py
+++ b/.claude/skills/new-claude-github-actions-flow/evals/grade.py
@@ -1,0 +1,557 @@
+#!/usr/bin/env python3
+"""Programmatic grader for new-claude-github-actions-flow evals.
+
+Reads an iteration directory, runs each eval's assertions against its
+outputs, writes grading.json per run with {text, passed, evidence}.
+
+Usage:
+    python3 grade.py <iteration_dir>
+    e.g. python3 grade.py .../iteration-1/
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+def read(p: Path) -> str:
+    try:
+        return p.read_text()
+    except (FileNotFoundError, UnicodeDecodeError):
+        return ""
+
+
+def strip_yaml_comments(text: str) -> str:
+    """Strip lines that are pure YAML comments so checks like 'pull-requests: write'
+    don't match comment text that merely mentions the literal."""
+    return "\n".join(ln for ln in text.splitlines() if not re.match(r"^\s*#", ln))
+
+
+def files_under(d: Path) -> list[Path]:
+    return [p for p in d.rglob("*") if p.is_file()]
+
+
+# -----------------------------------------------------------------------------
+# Generic checks shared across evals
+# -----------------------------------------------------------------------------
+
+def grep(pattern: str, text: str, flags: int = 0) -> tuple[bool, str]:
+    """Return (matched, snippet around first match or empty)."""
+    m = re.search(pattern, text, flags)
+    if not m:
+        return False, ""
+    start = max(0, m.start() - 60)
+    end = min(len(text), m.end() + 60)
+    snippet = text[start:end].replace("\n", "\\n")
+    return True, f"…{snippet}…"
+
+
+def all_grep(patterns: list[str], text: str, flags: int = 0) -> tuple[bool, str]:
+    misses = [p for p in patterns if not re.search(p, text, flags)]
+    if misses:
+        return False, f"missing: {misses}"
+    return True, f"all {len(patterns)} patterns matched"
+
+
+# -----------------------------------------------------------------------------
+# Eval 1 — create tests-audit
+# -----------------------------------------------------------------------------
+
+def grade_eval_1(outputs: Path) -> list[dict]:
+    """Grade the create-tests-audit-from-scratch eval."""
+    audit = read(outputs / ".github/workflows/claude-tests-audit.yml")
+    review = read(outputs / ".github/workflows/claude-tests-audit-review.yml")
+    feedback = read(outputs / ".github/workflows/claude-tests-audit-feedback.yml")
+    state = read(outputs / ".github/tests-audit-state.json")
+    rejection = read(outputs / ".github/tests-audit/build_rejection.py")
+    feedback_readme = read(outputs / ".github/tests-audit/README.md")
+    triage = read(outputs / ".github/workflows/claude-issue-triage.yml")
+
+    def check(text: str, fn) -> tuple[bool, str]:
+        return fn(text)
+
+    results = []
+
+    def add(text: str, passed: bool, evidence: str):
+        results.append({"text": text, "passed": passed, "evidence": evidence[:300]})
+
+    # --- audit workflow ---
+    if not audit:
+        for t in [
+            "audit workflow uses BRANCH_SUFFIX env var bound to github.run_id (not date +%s)",
+            "audit workflow sets show_full_output: 'true' on the claude-code-action",
+            "audit workflow's --allowed-tools includes Edit, Write, Bash(git push:*), and Bash(gh pr create:*)",
+            "audit workflow has at least 4 cron entries arranged as UTC pairs for DST absorption",
+            "audit workflow declares concurrency group with cancel-in-progress: false",
+            "audit workflow uses RELEASE_PAT for the checkout token to push past branch protection",
+            "audit workflow includes Compute dynamic effort step with three modes (thorough/balanced/conservative)",
+            "audit workflow's Dedup step has both cooldown-hours and draft-cap checks",
+            "audit workflow has a local-hour time gate (TZ=America/Los_Angeles) before checkout",
+            "audit workflow's prompt instructs Claude to read the rejection log before doing anything else",
+            "audit workflow's hard rules section restricts editable files to tests-only globs",
+            "audit workflow's prompt covers all three user-specified checks: flaky tests, slow tests, no-assertion tests",
+        ]:
+            add(t, False, "audit workflow file missing")
+    else:
+        ok, ev = grep(r"BRANCH_SUFFIX:\s*\$\{\{\s*github\.run_id\s*\}\}", audit)
+        add("audit workflow uses BRANCH_SUFFIX env var bound to github.run_id (not date +%s)", ok, ev)
+
+        ok, ev = grep(r"show_full_output:\s*['\"]?true['\"]?", audit)
+        add("audit workflow sets show_full_output: 'true' on the claude-code-action", ok, ev)
+
+        ok, ev = all_grep([r"Edit", r"Write", r"Bash\(git push", r"Bash\(gh pr create"], audit)
+        add("audit workflow's --allowed-tools includes Edit, Write, Bash(git push:*), and Bash(gh pr create:*)", ok, ev)
+
+        cron_count = len(re.findall(r"^\s*-\s*cron:", audit, re.MULTILINE))
+        add(
+            "audit workflow has at least 4 cron entries arranged as UTC pairs for DST absorption",
+            cron_count >= 4,
+            f"cron count = {cron_count}",
+        )
+
+        ok, ev = grep(r"cancel-in-progress:\s*false", audit)
+        add("audit workflow declares concurrency group with cancel-in-progress: false", ok, ev)
+
+        ok, ev = grep(r"RELEASE_PAT", audit)
+        add("audit workflow uses RELEASE_PAT for the checkout token to push past branch protection", ok, ev)
+
+        ok, ev = all_grep([r"thorough", r"balanced", r"conservative"], audit)
+        add("audit workflow includes Compute dynamic effort step with three modes (thorough/balanced/conservative)", ok, ev)
+
+        ok, ev = all_grep([r"cooldown", r"draft_count"], audit, re.IGNORECASE)
+        add("audit workflow's Dedup step has both cooldown-hours and draft-cap checks", ok, ev)
+
+        ok, ev = grep(r"TZ=America/Los_Angeles", audit)
+        add("audit workflow has a local-hour time gate (TZ=America/Los_Angeles) before checkout", ok, ev)
+
+        ok, ev = grep(r"rejected-edits\.jsonl", audit)
+        add("audit workflow's prompt instructs Claude to read the rejection log before doing anything else", ok, ev)
+
+        ok, ev = grep(r"tests/.*\.py|\*\.py", audit)
+        add("audit workflow's hard rules section restricts editable files to tests-only globs", ok, ev)
+
+        ok, ev = all_grep([r"flak", r"slow", r"assert"], audit, re.IGNORECASE)
+        add("audit workflow's prompt covers all three user-specified checks: flaky tests, slow tests, no-assertion tests", ok, ev)
+
+    # --- review workflow ---
+    if not review:
+        for t in [
+            "auto-review workflow uses pull_request_target (not pull_request)",
+            "auto-review workflow checks out base.ref (never head.ref) with persist-credentials: false",
+            "auto-review workflow passes github_token: secrets.GITHUB_TOKEN to bypass OIDC App exchange",
+            "auto-review workflow's allowed_bots includes both claude and github-actions",
+            "auto-review workflow's --allowed-tools is read-only (no Edit, no Write, no git push, no gh pr create)",
+        ]:
+            add(t, False, "review workflow file missing")
+    else:
+        ok, ev = grep(r"pull_request_target", review)
+        add("auto-review workflow uses pull_request_target (not pull_request)", ok, ev)
+
+        base_ok, _ = grep(r"github\.event\.pull_request\.base\.ref", review)
+        head_used, _ = grep(r"head\.sha\s*\}\}\s*\n.*ref:\s*\$\{\{\s*github\.event\.pull_request\.head", review)
+        persist, _ = grep(r"persist-credentials:\s*false", review)
+        add(
+            "auto-review workflow checks out base.ref (never head.ref) with persist-credentials: false",
+            base_ok and persist and not head_used,
+            f"base.ref ok={base_ok}, persist-credentials:false={persist}, head.ref used in checkout={head_used}",
+        )
+
+        ok, ev = grep(r"github_token:\s*\$\{\{\s*secrets\.GITHUB_TOKEN", review)
+        add("auto-review workflow passes github_token: secrets.GITHUB_TOKEN to bypass OIDC App exchange", ok, ev)
+
+        ok, ev = grep(r"allowed_bots:.*claude.*github-actions|allowed_bots:.*github-actions.*claude", review)
+        add("auto-review workflow's allowed_bots includes both claude and github-actions", ok, ev)
+
+        # The allowlist string for review must not contain write-y patterns
+        m = re.search(r"--allowed-tools\s+\"([^\"]+)\"", review)
+        if m:
+            tools = m.group(1)
+            forbidden = [w for w in [r"\bEdit\b", r"\bWrite\b", r"git push", r"gh pr create"] if re.search(w, tools)]
+            add(
+                "auto-review workflow's --allowed-tools is read-only (no Edit, no Write, no git push, no gh pr create)",
+                not forbidden,
+                f"forbidden found: {forbidden}; tools={tools[:200]}",
+            )
+        else:
+            add(
+                "auto-review workflow's --allowed-tools is read-only (no Edit, no Write, no git push, no gh pr create)",
+                False,
+                "no --allowed-tools found in review workflow",
+            )
+
+    # --- feedback workflow ---
+    if not feedback:
+        for t in [
+            "feedback workflow uses pull_request_target on closed event (not pull_request)",
+            "feedback workflow's if-condition checks startsWith for BOTH the audit branch prefix and the triage branch prefix",
+            "feedback workflow's concurrency has cancel-in-progress: false to serialize log writes",
+        ]:
+            add(t, False, "feedback workflow file missing")
+    else:
+        ok, ev = grep(r"pull_request_target:[^\n]*\n\s*types:\s*\[closed\]", feedback)
+        add("feedback workflow uses pull_request_target on closed event (not pull_request)", ok, ev)
+
+        starts = re.findall(r"startsWith\(github\.event\.pull_request\.head\.ref,\s*'([^']+)'\)", feedback)
+        add(
+            "feedback workflow's if-condition checks startsWith for BOTH the audit branch prefix and the triage branch prefix",
+            len(starts) >= 2,
+            f"startsWith prefixes found: {starts}",
+        )
+
+        ok, ev = grep(r"cancel-in-progress:\s*false", feedback)
+        add("feedback workflow's concurrency has cancel-in-progress: false to serialize log writes", ok, ev)
+
+    # --- build_rejection.py ---
+    if not rejection:
+        add(
+            "build_rejection.py present, idempotent (replaces prior line for same PR), refuses to log merged PRs",
+            False, "build_rejection.py missing",
+        )
+    else:
+        ok, ev = all_grep([r"keep", r"MERGED", r"def\s+build_record"], rejection)
+        add(
+            "build_rejection.py present, idempotent (replaces prior line for same PR), refuses to log merged PRs",
+            ok, ev,
+        )
+
+    # --- state json ---
+    if not state:
+        add("state JSON file initialized with schema_version: 1, round: 0, empty files arrays", False, "state file missing")
+    else:
+        try:
+            j = json.loads(state)
+            ok = (
+                j.get("schema_version") == 1
+                and j.get("round") == 0
+                and j.get("files_remaining") == []
+                and j.get("files_audited") == []
+            )
+            add(
+                "state JSON file initialized with schema_version: 1, round: 0, empty files arrays",
+                ok,
+                f"schema_version={j.get('schema_version')} round={j.get('round')} remaining_len={len(j.get('files_remaining', []))} audited_len={len(j.get('files_audited', []))}",
+            )
+        except json.JSONDecodeError:
+            add("state JSON file initialized with schema_version: 1, round: 0, empty files arrays", False, "invalid JSON")
+
+    # --- feedback README ---
+    if not feedback_readme:
+        add("feedback dir has a README explaining the rejection log schema and DRY_RUN usage", False, "README missing")
+    else:
+        ok, ev = all_grep([r"rejected-edits\.jsonl", r"DRY_RUN", r"head_ref"], feedback_readme)
+        add("feedback dir has a README explaining the rejection log schema and DRY_RUN usage", ok, ev)
+
+    # --- triage workflow modified ---
+    if not triage:
+        add("triage workflow modified to add tests-audit label to the labeled-gate if-condition", False, "triage workflow not in outputs")
+    else:
+        ok, ev = grep(r"['\"]tests-audit['\"]", triage)
+        add("triage workflow modified to add tests-audit label to the labeled-gate if-condition", ok, ev)
+
+    return results
+
+
+# -----------------------------------------------------------------------------
+# Eval 2 — tune docs-audit
+# -----------------------------------------------------------------------------
+
+def grade_eval_2(outputs: Path) -> list[dict]:
+    audit = read(outputs / ".github/workflows/claude-docs-audit.yml")
+    summary = read(outputs / "summary.md")
+    results = []
+
+    def add(text: str, passed: bool, evidence: str):
+        results.append({"text": text, "passed": passed, "evidence": evidence[:300]})
+
+    if not audit:
+        for t in [
+            "claude-docs-audit.yml's conservative branch threshold changed from 80 to 40 (i.e., open_count -gt 40 triggers conservative)",
+            "claude-docs-audit.yml's conservative batch is now 8 (was 12)",
+            "claude-docs-audit.yml's conservative cap is now 20 (was 32)",
+            "claude-docs-audit.yml's cooldown check is now `age_h -lt 6` (was 3)",
+            "claude-docs-audit.yml's balanced and thorough branches were NOT changed (batches stay 24 and 32, caps stay 60 and 100)",
+            "claude-docs-audit.yml's structure outside the 'Compute dynamic effort' and 'Dedup' steps was preserved (no incidental rewrites)",
+        ]:
+            add(t, False, "claude-docs-audit.yml missing from outputs")
+    else:
+        # Conservative threshold: looking for `if [ "$open_count" -gt 40 ];` as the first branch (replacing 80)
+        # The pattern in the existing file is: `if [ "$open_count" -gt 80 ]; then\n    mode="conservative"`
+        m = re.search(r'open_count"?\s*-gt\s+(\d+)\s*\]?\s*;\s*then\s*\n\s*mode="conservative"', audit)
+        thresh = int(m.group(1)) if m else None
+        add(
+            "claude-docs-audit.yml's conservative branch threshold changed from 80 to 40 (i.e., open_count -gt 40 triggers conservative)",
+            thresh == 40, f"conservative threshold = {thresh}",
+        )
+
+        m = re.search(r'mode="conservative";\s*batch=(\d+);\s*cap=(\d+)', audit)
+        batch_c, cap_c = (int(m.group(1)), int(m.group(2))) if m else (None, None)
+        add("claude-docs-audit.yml's conservative batch is now 8 (was 12)", batch_c == 8, f"conservative batch = {batch_c}")
+        add("claude-docs-audit.yml's conservative cap is now 20 (was 32)", cap_c == 20, f"conservative cap = {cap_c}")
+
+        m = re.search(r'age_h["\'\]\s]*-lt\s+(\d+)', audit)
+        cool = int(m.group(1)) if m else None
+        add(
+            "claude-docs-audit.yml's cooldown check is now `age_h -lt 6` (was 3)",
+            cool == 6, f"cooldown hours = {cool}",
+        )
+
+        # Balanced/thorough unchanged
+        m_b = re.search(r'mode="balanced";\s*batch=(\d+);\s*cap=(\d+)', audit)
+        m_t = re.search(r'mode="thorough";\s*batch=(\d+);\s*cap=(\d+)', audit)
+        batch_b, cap_b = (int(m_b.group(1)), int(m_b.group(2))) if m_b else (None, None)
+        batch_t, cap_t = (int(m_t.group(1)), int(m_t.group(2))) if m_t else (None, None)
+        ok = batch_b == 24 and cap_b == 60 and batch_t == 32 and cap_t == 100
+        add(
+            "claude-docs-audit.yml's balanced and thorough branches were NOT changed (batches stay 24 and 32, caps stay 60 and 100)",
+            ok, f"balanced=({batch_b},{cap_b}) thorough=({batch_t},{cap_t})",
+        )
+
+        # Structure preserved — check a few invariant phrases survive
+        invariants = [
+            "Gate on America/Los_Angeles local hour window",
+            "Run Claude docs audit",
+            "BRANCH_SUFFIX:",
+            "show_full_output:",
+            "anthropics/claude-code-action@v1",
+            "concurrency:",
+        ]
+        misses = [p for p in invariants if p not in audit]
+        add(
+            "claude-docs-audit.yml's structure outside the 'Compute dynamic effort' and 'Dedup' steps was preserved (no incidental rewrites)",
+            not misses, f"missing invariants: {misses}",
+        )
+
+    # Summary
+    if not summary:
+        add("summary.md describes before/after for each of the four knobs explicitly", False, "summary.md missing")
+        add("summary.md includes a PR title and body draft", False, "summary.md missing")
+    else:
+        beforeAfter = sum(1 for tok in ["80", "40", "12", "8", "32", "20", " 3", " 6"] if tok in summary)
+        add(
+            "summary.md describes before/after for each of the four knobs explicitly",
+            beforeAfter >= 6,
+            f"matched {beforeAfter}/8 knob tokens",
+        )
+
+        ok, ev = grep(r"(?i)PR (title|body)", summary)
+        add("summary.md includes a PR title and body draft", ok, ev)
+
+    return results
+
+
+# -----------------------------------------------------------------------------
+# Eval 3 — minimal audit-only
+# -----------------------------------------------------------------------------
+
+def grade_eval_3(outputs: Path) -> list[dict]:
+    audit = read(outputs / ".github/workflows/claude-manifest-audit.yml")
+    state = read(outputs / ".github/manifest-audit-state.json")
+    results = []
+
+    def add(text: str, passed: bool, evidence: str):
+        results.append({"text": text, "passed": passed, "evidence": evidence[:300]})
+
+    all_files = files_under(outputs)
+    rel = [str(p.relative_to(outputs)) for p in all_files]
+
+    # exactly one workflow + one state json (ignoring summary.md)
+    workflow_files = [p for p in rel if p.endswith(".yml") and "workflows/" in p]
+    state_files = [p for p in rel if "state.json" in p]
+
+    add(
+        "exactly one workflow file created: .github/workflows/claude-manifest-audit.yml",
+        workflow_files == [".github/workflows/claude-manifest-audit.yml"],
+        f"workflow files: {workflow_files}",
+    )
+    add(
+        "exactly one state file created: .github/manifest-audit-state.json",
+        state_files == [".github/manifest-audit-state.json"],
+        f"state files: {state_files}",
+    )
+    add(
+        "NO review workflow file (claude-manifest-audit-review.yml) was created",
+        ".github/workflows/claude-manifest-audit-review.yml" not in rel,
+        "absent" if ".github/workflows/claude-manifest-audit-review.yml" not in rel else "present (should be absent)",
+    )
+    add(
+        "NO feedback workflow file (claude-manifest-audit-feedback.yml) was created",
+        ".github/workflows/claude-manifest-audit-feedback.yml" not in rel,
+        "absent" if ".github/workflows/claude-manifest-audit-feedback.yml" not in rel else "present (should be absent)",
+    )
+    has_buildrejection = any("build_rejection" in p for p in rel)
+    add(
+        "NO build_rejection.py was created",
+        not has_buildrejection,
+        "absent" if not has_buildrejection else "present (should be absent)",
+    )
+    has_triage = any("issue-triage" in p for p in rel)
+    add(
+        "NO modifications were made to claude-issue-triage.yml",
+        not has_triage,
+        "absent" if not has_triage else "present (should be absent)",
+    )
+
+    if not audit:
+        for t in [
+            "audit workflow's --allowed-tools does NOT include Bash(gh pr create:*) (no PRs are opened)",
+            "audit workflow's --allowed-tools does NOT include Bash(git branch:*) or Bash(git checkout:*) (no feature branches are cut)",
+            "audit workflow's permissions block does NOT include pull-requests: write (only contents: write + issues: write + id-token: write)",
+            "audit workflow has a weekly cron firing Mondays at 10am PT (with local-time gate)",
+            "audit workflow uses claude-sonnet-4-6 as the model",
+            "audit workflow sets show_full_output: true",
+            "audit workflow's prompt covers all 4 manifest checks: missing required fields, missing screenshots, id-vs-dir mismatch, invalid category",
+            "audit workflow's prompt instructs Claude to list valid categories explicitly (art, data, entertainment, home, transit, utility, weather)",
+            "audit workflow's prompt does NOT reference a rejection log (feedback capture opted out)",
+            "audit prompt's wrap-up section is preserved (round/batch/progress summary)",
+            "audit workflow's prompt does NOT include bucket-A inline-PR instructions (issues-only mode)",
+        ]:
+            add(t, False, "audit workflow missing")
+    else:
+        m = re.search(r"--allowed-tools\s+\"([^\"]+)\"", audit)
+        tools = m.group(1) if m else ""
+
+        pr_tools = [w for w in ["gh pr create", "gh pr edit"] if w in tools]
+        add(
+            "audit workflow's --allowed-tools does NOT include Bash(gh pr create:*) (no PRs are opened)",
+            not pr_tools,
+            f"found PR tools: {pr_tools}",
+        )
+
+        branch_tools = [w for w in ["git branch", "git checkout", "git switch"] if w in tools]
+        add(
+            "audit workflow's --allowed-tools does NOT include Bash(git branch:*) or Bash(git checkout:*) (no feature branches are cut)",
+            not branch_tools,
+            f"found branch tools: {branch_tools}",
+        )
+
+        # permissions block — `pull-requests: write` should NOT appear in the audit job's permissions block.
+        # Strip comment lines so a "# Issues-only loop: no pull-requests: write" comment doesn't trigger.
+        audit_no_comments = strip_yaml_comments(audit)
+        ok = not re.search(r"pull-requests:\s*write", audit_no_comments)
+        add(
+            "audit workflow's permissions block does NOT include pull-requests: write (only contents: write + issues: write + id-token: write)",
+            ok, "pull-requests:write found" if not ok else "absent",
+        )
+
+        # weekly Mon 10am PT — single cron pair, gate on Monday + hour 10
+        mon_ok, _ = grep(r"(?i)mon|^\s*-\s*cron:\s*['\"]?\d+\s+\d+\s+\*\s+\*\s+[01]", audit)
+        ten_ok, _ = grep(r"(?i)10:|hour.*10", audit)
+        add(
+            "audit workflow has a weekly cron firing Mondays at 10am PT (with local-time gate)",
+            mon_ok and ten_ok,
+            f"monday-pattern={mon_ok}, hour-10={ten_ok}",
+        )
+
+        ok, ev = grep(r"claude-sonnet-4", audit)
+        add("audit workflow uses claude-sonnet-4-6 as the model", ok, ev)
+
+        ok, ev = grep(r"show_full_output:\s*['\"]?true['\"]?", audit)
+        add("audit workflow sets show_full_output: true", ok, ev)
+
+        ok, ev = all_grep([r"required field", r"screenshot", r"id.*directory|directory.*id|id.*match", r"category|invalid category"], audit, re.IGNORECASE)
+        add(
+            "audit workflow's prompt covers all 4 manifest checks: missing required fields, missing screenshots, id-vs-dir mismatch, invalid category",
+            ok, ev,
+        )
+
+        ok, ev = all_grep([r"\bart\b", r"\bdata\b", r"\bentertainment\b", r"\bhome\b", r"\btransit\b", r"\butility\b", r"\bweather\b"], audit)
+        add(
+            "audit workflow's prompt instructs Claude to list valid categories explicitly (art, data, entertainment, home, transit, utility, weather)",
+            ok, ev,
+        )
+
+        has_rej = "rejected-edits.jsonl" in audit or "rejection log" in audit.lower()
+        add("audit workflow's prompt does NOT reference a rejection log (feedback capture opted out)", not has_rej, "rejection log referenced" if has_rej else "absent")
+
+        ok, ev = grep(r"(?i)wrap.up|round:|progress", audit)
+        add("audit prompt's wrap-up section is preserved (round/batch/progress summary)", ok, ev)
+
+        # No bucket A → no "Create a branch named exactly" / "Apply ONLY the bucket-A fixes" / "Open a … PR" in prompt
+        # Strip YAML comments first so explanatory comments don't trigger.
+        audit_no_comments = strip_yaml_comments(audit)
+        bucket_a_signals = sum(1 for p in [
+            r"(?i)bucket\s*a\b",
+            r"(?i)Create a branch named",
+            r"(?i)Apply ONLY the bucket",
+            r"(?i)gh pr create",
+        ] if re.search(p, audit_no_comments))
+        add(
+            "audit workflow's prompt does NOT include bucket-A inline-PR instructions (issues-only mode)",
+            bucket_a_signals == 0,
+            f"bucket-A signals matched: {bucket_a_signals} (want 0)",
+        )
+
+    if not state:
+        pass  # handled by file-count assertion above
+    else:
+        try:
+            j = json.loads(state)
+            if not (j.get("schema_version") == 1 and j.get("round") == 0):
+                # add diagnostic, not a separate assertion
+                pass
+        except json.JSONDecodeError:
+            pass
+
+    return results
+
+
+# -----------------------------------------------------------------------------
+# Dispatcher
+# -----------------------------------------------------------------------------
+
+GRADERS = {
+    "eval-1-create-tests-audit": grade_eval_1,
+    "eval-2-tune-docs-audit": grade_eval_2,
+    "eval-3-minimal-audit-only": grade_eval_3,
+}
+
+
+def main():
+    if len(sys.argv) != 2:
+        sys.exit("usage: grade.py <iteration_dir>")
+    iter_dir = Path(sys.argv[1]).resolve()
+
+    for eval_dir in sorted(iter_dir.iterdir()):
+        if not eval_dir.is_dir():
+            continue
+        grader = GRADERS.get(eval_dir.name)
+        if grader is None:
+            print(f"[skip] no grader for {eval_dir.name}")
+            continue
+        for variant_dir in sorted(eval_dir.iterdir()):
+            if not variant_dir.is_dir():
+                continue
+            # Look for outputs/ either directly under variant_dir (legacy)
+            # or under variant_dir/run-1/ (aggregator-compatible layout).
+            for candidate in [variant_dir / "outputs", variant_dir / "run-1" / "outputs"]:
+                if candidate.exists():
+                    outputs = candidate
+                    break
+            else:
+                print(f"[skip] {variant_dir} — no outputs/")
+                continue
+
+            results = grader(outputs)
+            total = len(results)
+            passed = sum(1 for r in results if r["passed"])
+            run_dir = outputs.parent
+            grading_path = run_dir / "grading.json"
+            grading_path.write_text(json.dumps({
+                "eval_id": eval_dir.name,
+                "variant": variant_dir.name,
+                "summary": {
+                    "pass_rate": passed / total if total else 0,
+                    "passed": passed,
+                    "failed": total - passed,
+                    "total": total,
+                },
+                "expectations": results,
+            }, indent=2) + "\n")
+            print(f"{eval_dir.name}/{variant_dir.name}: {passed}/{total} passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/new-claude-github-actions-flow/references/architecture.md
+++ b/.claude/skills/new-claude-github-actions-flow/references/architecture.md
@@ -1,0 +1,187 @@
+# Architecture
+
+How the four workflow files interlock and why each one exists. Read this once before scaffolding your first loop; you won't need to re-read it for routine tuning.
+
+## The loop, in one picture
+
+```
+                ┌──────────────────────────────────────────┐
+                │            scheduled cron                │
+                │  (twice daily, gated to local PT window) │
+                └──────────────────┬───────────────────────┘
+                                   │
+                  reads state.json │ reads rejected-edits.jsonl
+                                   ▼
+                  ┌────────────────────────────────┐
+                  │     claude-<name>.yml          │
+                  │  (the AUDITOR — Claude run)    │
+                  └─────┬────────────────┬─────────┘
+                        │                │
+       trivial fixes    │                │  everything else
+                        ▼                ▼
+                ┌──────────────┐    ┌─────────────────┐
+                │  inline PR   │    │ files an ISSUE  │
+                │ ready-for-rev│    │ label: <name>   │
+                └──────┬───────┘    └────────┬────────┘
+                       │                     │
+                       │                     ▼
+                       │       ┌────────────────────────────────┐
+                       │       │  claude-issue-triage.yml       │
+                       │       │  (PER-ISSUE WORKER — Claude)   │
+                       │       └──────────────┬─────────────────┘
+                       │                      │
+                       │                      ▼
+                       │              ┌──────────────┐
+                       │              │ per-issue PR │
+                       │              └──────┬───────┘
+                       │                     │
+                       └───────┬─────────────┘
+                               ▼
+              ┌───────────────────────────────────────┐
+              │  claude-<name>-review.yml             │
+              │  (REVIEWER — Claude posts one review) │
+              └───────────────────┬───────────────────┘
+                                  │
+              if PR is closed     │       if PR is merged → done
+              without merging     ▼
+              ┌────────────────────────────────────┐
+              │  claude-<name>-feedback.yml        │
+              │  (captures rejection → JSONL log)  │
+              └────────────────────┬───────────────┘
+                                   │
+                                   ▼
+                       rejected-edits.jsonl
+                                   │
+                                   │ (next cron run reads it)
+                                   ▼
+                         (back to top — auditor learns)
+```
+
+## Why four workflows?
+
+Each one has a different trigger, different permissions, and a different blast radius. Splitting them apart is the safest separation of concerns.
+
+### `claude-<name>.yml` — the auditor
+
+- **Trigger:** scheduled cron (twice-daily) + manual dispatch.
+- **What it does:** sweeps the domain in batches, files issues for non-trivial findings, opens one ready-for-review inline PR per run for trivial fixes, advances the sweep state.
+- **Permissions:** `contents: write` (to push the state-file commit + open PR), `pull-requests: write`, `issues: write`, `id-token: write`.
+- **State:** `.github/<name>-state.json` (sweep progress) + `.github/<name>/rejected-edits.jsonl` (learning input).
+- **Failure modes:** allowlist denials silent without `show_full_output`; duplicate PRs from parallel runs without serialized concurrency; DST drift without paired UTC crons.
+
+### `claude-issue-triage.yml` — the per-issue worker
+
+- **Trigger:** `issues: [opened, labeled]`.
+- **What it does:** when an issue is opened by a trusted author OR the `claude-fix` label is applied OR an audit-loop label is applied (e.g., `docs-audit`), takes a first-pass fix attempt and opens a focused PR.
+- **Permissions:** `contents: write`, `pull-requests: write`, `issues: write`, `id-token: write`, `actions: read`.
+- **Why shared (not per-loop):** triage is the same job regardless of which audit filed the issue. The only per-loop branch is the label check in the `if:` condition. Multiple audits feed one triage worker.
+- **Failure modes:** bot-filed issues blocked unless `allowed_bots: 'claude'`; `@claude` mention double-fires with `claude.yml` unless excluded; wrong model tier (Opus on a markdown edit) wastes budget.
+
+### `claude-<name>-review.yml` — the auto-reviewer
+
+- **Trigger:** `pull_request_target` on paths matching the domain, types `[opened, synchronize, reopened, ready_for_review]`.
+- **What it does:** reads the PR diff and posts one Claude review comment. Read-only — never edits, never merges.
+- **Permissions:** `contents: read`, `pull-requests: write`, `id-token: write`, `actions: read`.
+- **Safety:** checks out the **base ref**, never the PR head. Reads PR head content via `gh api .../contents` (data, not code). `--allowed-tools` is read-only.
+- **Failure modes:** OIDC App exchange returns `401` on `pull_request_target` unless `github_token` provided; pwn-request if you check out the head ref.
+
+### `claude-<name>-feedback.yml` — the rejection capture
+
+- **Trigger:** `pull_request_target: [closed]` + manual dispatch (for backfill).
+- **What it does:** when a docs-pipeline PR is closed without merging, runs `build_rejection.py` to bundle the diff + every comment into one JSONL line and commits to `main`. The auditor reads this log next run.
+- **Permissions:** `contents: write` (for the log commit), `pull-requests: read`, `issues: read`.
+- **Why `pull_request_target` (not `pull_request`):** branches were cut from `main` before the workflow existed; `pull_request` resolves the workflow from the PR's head ref and never fires. `pull_request_target` resolves from `main`.
+- **Failure modes:** silently appends duplicates (without idempotent `build_rejection.py`); races the log file (without serialized concurrency).
+
+## What lives in `.github/<name>/`
+
+The folder is the loop's persistent memory.
+
+| File | Lifetime | Owner |
+| --- | --- | --- |
+| `<name>-state.json` (in `.github/`, not `.github/<name>/`) | mutated by the auditor every run | the audit cron |
+| `<name>/rejected-edits.jsonl` | append-only learning log | the feedback workflow |
+| `<name>/build_rejection.py` | static; tweaked when the schema evolves | maintainer |
+| `<name>/README.md` | human-readable docs for the folder | maintainer |
+
+The state file goes in `.github/` (not the loop's subfolder) because it's the audit's progress, not feedback memory. The rejection log and its companion script go in `.github/<name>/` so future loops follow the same convention.
+
+## Why the auditor and triage worker are separated
+
+The audit's job is **finding**. The triage worker's job is **fixing**. Splitting them has several payoffs:
+
+1. **Bounded effort per PR.** A single triage run focuses on one issue. The audit can spread its attention across the full repo without burning the per-PR budget.
+2. **Parallelism for free.** Multiple triage workers can run in parallel (one per issue), while the audit is serialized to its single concurrency group.
+3. **Different model tiers.** The audit is volume-heavy (Sonnet); triage is depth-heavy for code (Opus). Mixing them in one run forces a bad compromise.
+4. **Failure isolation.** A triage worker hitting an allowlist denial doesn't corrupt the audit's state file.
+5. **Audit can pre-screen.** The audit applies labels and prefixes so the triage worker enters with context (`label: docs-audit` → use Sonnet) instead of guessing.
+
+## Why the auto-review is a separate workflow
+
+The auto-review fires on **every** PR touching the domain — not just bot-authored ones. It's a quality gate for human contributions too. Making it a separate workflow:
+
+1. Lets it run on `pull_request_target` (which the audit and triage can't, because they write code).
+2. Lets the allowed-tools allowlist be read-only.
+3. Lets it use `cancel-in-progress: true` (the latest diff supersedes prior reviews).
+4. Lets it be disabled independently if the review pass becomes noisy.
+
+## Why the feedback capture is a separate workflow
+
+The feedback workflow fires on **every PR close** matching the audit's branch prefix. Co-locating it with the auditor would tangle `on.schedule` with `on.pull_request_target` and make permissions harder to scope. Separating it:
+
+1. Lets it run on `pull_request_target.closed` exclusively.
+2. Lets the `if:` condition gate precisely on `merged == false` AND branch prefix.
+3. Lets the `workflow_dispatch` re-run path be a clean separate entry point for backfill after late comments.
+
+## How rejections close the loop
+
+The rejection log is the most important non-obvious mechanism. Without it, the audit re-proposes the same wrong edit forever. The flow:
+
+1. Audit opens a PR proposing some edit.
+2. Reviewer (human) closes the PR without merging — sometimes with a comment explaining why.
+3. Feedback workflow fires, captures the PR + the explanatory comments, appends one JSONL line.
+4. Next audit run reads the log:
+   - Extracts every `-/+` swap from the patches → never re-proposes the literal swap.
+   - Reads the close comments → generalizes the lesson (e.g., "Vestaboard is the hardware, never rename it").
+5. Audit's wrap-up summary cites the PRs whose lessons it applied.
+
+The auditor's prompt explicitly instructs:
+- "Treat the close commenter's reasoning as authoritative."
+- "Generalize — most rejections expose a class of false positive."
+- "Cite when relevant — mention the PR number in your wrap-up summary."
+
+The maintainer can hand-delete a JSONL line if a rejection was wrong (the file is plain text).
+
+## When components are optional
+
+The minimal loop is:
+- `claude-<name>.yml` (auditor)
+- `.github/<name>-state.json` (sweep state)
+
+The auditor still runs without any of: triage, review, feedback. It just won't fan out to per-issue fix PRs and won't learn from rejections.
+
+You can add components incrementally:
+- Just the auditor → sweeps + opens inline PRs.
+- Auditor + triage → also fans out to per-issue fix PRs.
+- Auditor + triage + review → adds a quality gate on PRs touching the domain.
+- Auditor + triage + review + feedback → closes the learning loop. Recommended.
+
+## Comparison: this skill vs. one-off audits
+
+A one-off audit is a `gh workflow run` (or just `Agent` from a Claude Code session). It's faster to set up but:
+- No state file → can't sweep large domains in batches.
+- No rejection log → repeats wrong findings.
+- No dedup → opens duplicate PRs.
+- No queue-aware effort scaling → drowns the reviewer.
+
+Use this skill when the domain is large enough that one pass can't cover it, recurring enough that learning matters, and the team wants the audit to throttle itself.
+
+## Comparison: this skill vs. a Linear automation
+
+Linear / Jira automations sit outside the codebase and report findings via API. They can be more flexible (custom dashboards, SLAs, cross-repo) but lose:
+- Direct PR fan-out (Linear doesn't open PRs against your repo).
+- Bytes-level diff capture for the rejection log.
+- Free hosting on GitHub Actions.
+- Co-location with the code being audited.
+
+This skill is the right answer when the loop's outputs are PRs and the loop's input is the repo itself.

--- a/.claude/skills/new-claude-github-actions-flow/references/pitfalls.md
+++ b/.claude/skills/new-claude-github-actions-flow/references/pitfalls.md
@@ -1,0 +1,413 @@
+# Pitfalls
+
+Every entry here cost a real PR, a real silent failure, or a real CI debugging session. Read this end-to-end before scaffolding or tuning a loop. The PR numbers refer to the FiestaBoard history — `git log -- .github/workflows/claude-*.yml` will give you the full context.
+
+## Branch naming — never `date +%s`
+
+**Symptom:** branches like `docs-audit/round-3-run-1758049200` with the unix timestamp from a year ago.
+
+**Cause:** the audit prompt asked Claude to pick a unique branch suffix and Claude invented `$(date +%s)` — except the model's "now" was its training cutoff, not the actual run time. PR #967 was the first time this happened.
+
+**Fix:** the workflow sets `BRANCH_SUFFIX: ${{ github.run_id }}` in `env:`, and the prompt instructs Claude to read that env var (`echo "$BRANCH_SUFFIX"`) instead of computing a timestamp. `github.run_id` is unique per run and stable.
+
+```yaml
+env:
+  BRANCH_SUFFIX: ${{ github.run_id }}
+```
+
+```
+prompt: |
+  ...
+  Create a branch named exactly:
+      docs-audit/round-<round>-run-$BRANCH_SUFFIX
+
+  where $BRANCH_SUFFIX is the BRANCH_SUFFIX env var. Do NOT use `date +%s`.
+  Verify with `echo "$BRANCH_SUFFIX"` first.
+```
+
+## Concurrency — `cancel-in-progress: false`
+
+**Symptom:** two PRs touching the same files, opened seconds apart, both saying "round 3 batch 8–16".
+
+**Cause:** PRs #966/#967 — two cron triggers fired in the same window (e.g., the second of a UTC cron pair), both read the same `files_remaining` from the state file, both picked the same batch, both opened a PR.
+
+**Fix:**
+
+```yaml
+concurrency:
+  group: <name>-audit
+  cancel-in-progress: false
+```
+
+`cancel-in-progress: false` is critical. A `workflow_dispatch` fired during a scheduled run should *wait its turn*, not abort the scheduled run. With `true` you'd lose the scheduled run mid-way and corrupt the state file.
+
+The feedback-capture workflow also needs serialization — two PRs closed at once would race the JSONL log:
+
+```yaml
+concurrency:
+  group: <name>-audit-feedback
+  cancel-in-progress: false
+```
+
+The review workflow is the *opposite* — there you want `cancel-in-progress: true` because only the latest diff matters.
+
+## DST and cron — UTC pairs per intended PT window
+
+GitHub Actions only accepts UTC crons. America/Los_Angeles is UTC-8 (PST) in winter and UTC-7 (PDT) in summer. A single cron line will drift by one hour twice a year.
+
+**Symptom:** the audit fires at 11am instead of noon for half the year.
+
+**Fix:** declare **two crons per intended local window** and gate them with a local-hour check.
+
+```yaml
+on:
+  schedule:
+    - cron: '7 19 * * *'   # 12:07 PDT (summer) — winter cron gated off
+    - cron: '7 20 * * *'   # 12:07 PST (winter) — summer cron gated by cooldown
+    - cron: '7 23 * * *'   # 16:07 PDT (summer)
+    - cron: '7 0 * * *'    # 16:07 PST (winter)
+```
+
+The gate step bounces the run if the local PT hour is outside the intended windows:
+
+```bash
+hour=$(TZ=America/Los_Angeles date +%H)
+minute=$(TZ=America/Los_Angeles date +%M)
+in_window=false
+if [ "$hour" = "12" ] || { [ "$hour" = "13" ] && [ "$minute" -le 30 ]; }; then
+  in_window=true
+fi
+# ... etc
+```
+
+The 30-minute slop on the upper bound absorbs typical GitHub Actions cron delay (often 10–30 min). Without it, a delayed run misses its window.
+
+`workflow_dispatch` always bypasses the gate.
+
+## Cooldown — block paired UTC crons in the same window
+
+**Symptom:** the audit runs twice in 15 minutes (e.g., 12:07 PDT and 13:07 PDT both fire on the same day if both UTC crons are admitted by the gate).
+
+**Cause:** during DST one of the paired UTC crons falls inside the gate window of the *next* window.
+
+**Fix:** add a `last_run_at` check that bounces runs younger than ~3 hours.
+
+```bash
+last=$(jq -r '.last_run_at // empty' .github/<name>-state.json)
+if [ -n "$last" ]; then
+  age_h=$(( ($(date -u +%s) - $(date -u -d "$last" +%s)) / 3600 ))
+  if [ "$age_h" -lt 3 ]; then
+    echo "Skipping: last run was ${age_h}h ago."
+    exit 0
+  fi
+fi
+```
+
+`workflow_dispatch` bypasses this check too.
+
+## Open-draft cap — prevent unbounded stacking
+
+**Symptom:** five docs-audit drafts open, reviewer stops reviewing them, the audit keeps opening new ones for weeks.
+
+**Fix:** cap how many open drafts the audit tolerates before silencing itself:
+
+```bash
+draft_count=$(gh pr list --search "head:<name>/" --state open --json number --jq 'length')
+if [ "$draft_count" -ge 5 ]; then
+  echo "Skipping: ${draft_count} open audit draft(s)."
+  exit 0
+fi
+```
+
+5 is the docs-audit value. Tune per domain: a high-volume domain with patient reviewers can run higher; a low-volume domain wants a smaller cap. The previous version of this check used "any draft open" and the audit silenced itself for weeks at a time — a hard ceiling without a relief valve is too strict.
+
+## Dynamic effort — scale with queue depth
+
+The audit batch size and issue cap should scale **inverse** to open issue count. A drained queue means triage is keeping up; a hot queue means reviewers are drowning.
+
+```bash
+open_count=$(gh issue list --label <name> --state open --limit 200 --json number --jq 'length')
+if [ "$open_count" -gt 80 ]; then
+  mode="conservative"; batch=12; cap=32
+elif [ "$open_count" -gt 40 ]; then
+  mode="balanced";     batch=24; cap=60
+else
+  mode="thorough";     batch=32; cap=100
+fi
+```
+
+The mode threads into the prompt via `${{ steps.effort.outputs.mode }}` interpolation. The prompt's "Aggressiveness" section uses it to decide how confident a finding needs to be before filing.
+
+Don't make this a static knob — the whole point is self-balancing.
+
+## `--allowed-tools` allowlist — read-only by default
+
+**Symptom:** 25 turns burned, $1 spent, no PR, no comment, conclusion=success in the Actions log.
+
+**Cause:** the `anthropics/claude-code-action` agent-mode default toolset is **read-only**. Every `Edit`, `Write`, `git push`, or `gh pr create` is denied. Without `show_full_output: 'true'`, the denial messages are hidden and the run looks like a clean success.
+
+**Fix:** explicit allowlist that matches **every Bash pattern the prompt actually invokes**:
+
+```yaml
+claude_args: >-
+  --model claude-sonnet-4-6
+  --max-turns 250
+  --allowed-tools "Read,Glob,Grep,Edit,Write,Bash(ls:*),Bash(cat:*),Bash(find:*),Bash(date:*),Bash(jq:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git branch:*),Bash(git checkout:*),Bash(git switch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git fetch:*),Bash(git rev-parse:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh issue list:*),Bash(gh issue view:*),Bash(gh issue create:*),Bash(gh issue edit:*),Bash(gh label list:*),Bash(gh label create:*)"
+```
+
+Audit and triage workflows need write access. Review workflows are read-only and the allowlist should reflect that — no `Edit`/`Write`, no `git push`, no `gh pr create`.
+
+If you add a new Bash invocation to a prompt, the allowlist must grow too.
+
+## `show_full_output: 'true'` — always
+
+Without this, the action prints `full output hidden for security`. Silent permission denials, hallucinated tool calls, and stuck-in-a-loop conditions all look like green checkmarks.
+
+```yaml
+with:
+  show_full_output: 'true'
+```
+
+If you ever wonder "why did this run cost $X and produce nothing?" — this is the answer 80% of the time.
+
+## `allowed_bots: 'claude'` — for bot-filed issues
+
+**Symptom:** the audit cron files issues with `gh issue create` (so the author is the `claude` bot). The triage workflow sees the new issue, the `if:` condition admits it… and the `anthropics/claude-code-action` rejects the run with "Workflow initiated by non-human actor: claude".
+
+**Fix:**
+
+```yaml
+with:
+  allowed_bots: 'claude'
+```
+
+For the auto-review workflow, both bot identities show up — bot-authored PRs come from `claude` or `github-actions`:
+
+```yaml
+with:
+  allowed_bots: 'claude,github-actions'
+```
+
+This is independent of the workflow's own `if:` gate. The action has its own anti-bot guard layered on top.
+
+## `pull_request_target` vs `pull_request` for feedback capture
+
+**Symptom:** PR #992 closed one second after the feedback workflow merged. The capture workflow never fired. The branch was already created from `main` *before* the capture workflow existed — and `pull_request` resolves workflow definitions from the **PR's head ref**.
+
+**Fix:** use `pull_request_target` so GitHub resolves the workflow from `main`:
+
+```yaml
+on:
+  pull_request_target:
+    types: [closed]
+```
+
+Branches cut from `main` before the workflow was added would otherwise be invisible to it forever. With `pull_request_target` the workflow runs against `main`'s definition regardless of head-ref age.
+
+**Safety:** `pull_request_target` grants secrets to the workflow. Two musts:
+1. Check out the **base ref** (or no checkout at all), never the PR head.
+2. Read PR head content via `gh api .../contents/<path>?ref=<head_sha>` — bytes piped through Claude as *data*, never materialized in a path a later step could execute.
+
+The action's `--allowed-tools` is your last line of defense. Keep it read-only for `pull_request_target` workflows.
+
+## Auto-review workflow checkout — base ref only
+
+**Symptom:** none yet — but CodeQL's `actions/untrusted-checkout` rule flags this pattern. It's called "pwn-request": a malicious PR head edits `.github/workflows/foo.yml` to leak secrets, and if you check out the head with `actions/checkout`, the malicious workflow runs against your secrets.
+
+**Fix:**
+
+```yaml
+- uses: actions/checkout@v6
+  with:
+    ref: ${{ github.event.pull_request.base.ref }}
+    fetch-depth: 1
+    persist-credentials: false
+```
+
+`persist-credentials: false` prevents the workflow's `GITHUB_TOKEN` from leaking into the working tree where the prompt might accidentally surface it.
+
+## OIDC App exchange fails on `pull_request_target` — bypass it
+
+**Symptom:** the auto-review workflow logs `401 Invalid OIDC token` when the action tries to exchange the OIDC token for a `claude[bot]` App token.
+
+**Cause:** the App's trust policy doesn't admit `pull_request_target` subjects.
+
+**Fix:** provide `github_token` to skip the OIDC exchange:
+
+```yaml
+with:
+  claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+  github_token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+The cost: review comments are posted under `github-actions[bot]` instead of `claude[bot]`. The feedback-capture workflow's `allowed_bots` allowlist must include `github-actions` because the review badge is now from that identity.
+
+## State file must commit with `[skip ci]`
+
+**Symptom:** every audit run triggers the audit again because the state-file commit fired `push` on `main`.
+
+**Fix:** include `[skip ci]` in the commit message:
+
+```
+chore(<name>-audit): advance sweep state [skip ci]
+```
+
+The audit workflow doesn't currently listen on push-to-main, but if the repo ever adds `on.push` to anything, the audit's own commit shouldn't be the trigger.
+
+## Hard rules in the prompt — bound the blast radius
+
+The audit prompt has explicit guardrails so Claude can't go off-roading:
+
+```
+## Hard rules
+- Never push to `main` except for the single state-file commit above.
+- Never force-push, never `--no-verify`, never `--no-gpg-sign`.
+- Never modify non-docs source code. Edits are restricted to *.md and the state file.
+- Never open more than 1 PR per run.
+- Never file more than <CAP> issues per run.
+- When dedup says skip, skip — don't refile the same finding.
+```
+
+The "Edits are restricted to" rule is the most important. Without it Claude has carte blanche over the repo for the duration of the run. State the *exact* file types editable and the *exact* paths writable.
+
+## RELEASE_PAT for state-file pushes past branch protection
+
+**Symptom:** the state-file commit fails with "GH006: Protected branch update failed for refs/heads/main".
+
+**Cause:** `main` is branch-protected; the default `GITHUB_TOKEN` can't bypass.
+
+**Fix:** use a personal access token stored as `RELEASE_PAT`:
+
+```yaml
+- uses: actions/checkout@v6
+  with:
+    token: ${{ secrets.RELEASE_PAT }}
+    fetch-depth: 0
+```
+
+The same `RELEASE_PAT` is also needed for `gh pr create` calls that the action makes — pass it as `GH_TOKEN` in `env:`.
+
+## Defensive state-file push at the end
+
+If the Claude step exits early (rate limit, allowlist denial, hallucination), the state file may be staged but not pushed. A defensive final step catches this:
+
+```yaml
+- name: Push state-file changes
+  if: steps.dedup.outputs.go == 'true'
+  run: |
+    if git diff --quiet -- .github/<name>-state.json; then
+      echo "State file unchanged."
+      exit 0
+    fi
+    git add .github/<name>-state.json
+    git commit -m "chore(<name>-audit): advance sweep state [skip ci]"
+    git push origin HEAD:main
+```
+
+This isn't ideal — Claude exited mid-run, so the round counter may be inconsistent — but it's better than a state file that says "round 3, 50 files remaining" forever.
+
+## Rejection log learning — feed it back in the prompt
+
+The feedback-capture workflow appends rejected PRs to `.github/<name>/rejected-edits.jsonl`. The audit prompt **must** read that file at the top of every run:
+
+```
+Read `.github/<name>/rejected-edits.jsonl` before doing anything else.
+Each non-empty line is a previous audit PR that a human closed without
+merging — i.e. the proposed edit was wrong. The log is your single most
+important input.
+
+For each rejection:
+1. Never repeat the exact swap (extract -/+ lines from each file's patch).
+2. Read every comment — the closer's reasoning is authoritative.
+3. Generalize — most rejections expose a class of false positive.
+4. Cite when relevant — mention the PR number when you skip a finding.
+```
+
+Without this section in the prompt, the audit will re-propose the same wrong edit forever.
+
+## Idempotent rejection capture
+
+`build_rejection.py` must replace a prior line for the same PR rather than append a duplicate. The `workflow_dispatch` re-run path exists specifically for backfilling after a late explanatory comment.
+
+```python
+def keep(line: str) -> bool:
+    try:
+        return json.loads(line).get("pr") != record["pr"]
+    except json.JSONDecodeError:
+        return True  # preserve hand-edited lines
+```
+
+The script also refuses to log merged PRs:
+
+```python
+if meta.get("state") == "MERGED":
+    raise SystemExit(f"PR #{pr} was merged — refusing to record as rejection.")
+```
+
+## Triage worker — triple trigger and bot allowlist
+
+The shared triage worker (`claude-issue-triage.yml`) is gated three ways:
+1. Issue opened by trusted author (OWNER / MEMBER / COLLABORATOR)
+2. `claude-fix` label applied manually
+3. Audit's domain label applied (e.g., `docs-audit`, `tests-audit`)
+
+Without gate 3, audit-filed issues won't trigger triage because the bot author doesn't satisfy gate 1.
+
+Gate 3 must be reflected in two places:
+1. The workflow's `if:` condition (`github.event.label.name == 'docs-audit'`)
+2. The action's `allowed_bots: 'claude'` (so the run isn't rejected post-gate)
+
+When you add a new loop, **edit the triage workflow** to add the new label to its `if:` condition, and update the model-tier selection step if the new loop should prefer Sonnet (docs-flavored) or Opus (code-flavored).
+
+## Branch prefix → PR style mapping
+
+Inline audit PRs are **ready-for-review** (no `--draft` flag). Triage-worker PRs may be draft or ready depending on flavor:
+
+- Docs-flavored: ready-for-review (PRs go through normal docs review path)
+- Code-flavored: draft (human validates the first-pass code fix)
+
+Branch naming carries the flavor:
+- `<name>/round-<n>-run-<id>` — audit inline PR (always ready-for-review)
+- `<short>/issue-<N>-<slug>` — triage PR (flavor-dependent draft state)
+
+The feedback capture's `if:` condition must match both prefixes if both flavors should feed the rejection log.
+
+## Don't widen permissions speculatively
+
+`permissions: contents: read` at the top of the workflow, then `contents: write` only on the job that needs it. The least-privilege baseline matters because `pull_request_target` workflows have secrets attached.
+
+For the audit job:
+```yaml
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+```
+
+For the review job:
+```yaml
+permissions:
+  contents: read
+  pull-requests: write   # to post the review
+  id-token: write
+  actions: read
+```
+
+For the feedback capture:
+```yaml
+permissions:
+  contents: write        # to commit the JSONL log
+  pull-requests: read
+  issues: read
+```
+
+## Summary — the five most painful
+
+If you only remember five things:
+
+1. **`BRANCH_SUFFIX: ${{ github.run_id }}`** — never `date +%s`.
+2. **`show_full_output: 'true'`** — silent denials look like success without it.
+3. **`--allowed-tools`** — the action's default is read-only; every write needs allowlisting.
+4. **`pull_request_target`** (with base-ref checkout) for feedback capture and auto-review.
+5. **`concurrency: cancel-in-progress: false`** on the audit and feedback workflows.

--- a/.claude/skills/new-claude-github-actions-flow/references/templates/audit-cron.yml.tmpl
+++ b/.claude/skills/new-claude-github-actions-flow/references/templates/audit-cron.yml.tmpl
@@ -1,0 +1,341 @@
+name: 'Claude: {{DISPLAY_NAME}}'
+
+# =============================================================================
+# {{DESCRIPTION}}
+#
+# Cadence: {{CADENCE_SUMMARY}}. Each cron pair fires twice in UTC to absorb DST
+# drift; the local-hour gate below admits exactly the intended window.
+# workflow_dispatch always proceeds.
+#
+# Effort scales with the open `{{ISSUE_LABEL_AUDIT}}` issue queue (see "Compute
+# dynamic effort" step). Drained queue → thorough mode (batch {{BATCH_THOROUGH}},
+# cap {{CAP_THOROUGH}}). Hot queue → conservative mode (batch {{BATCH_CONSERVATIVE}},
+# cap {{CAP_CONSERVATIVE}}). The audit self-throttles without manual tuning.
+#
+# Progress tracked in {{STATE_FILE}}; sweep restarts from the top once every
+# file has been audited.
+# =============================================================================
+
+on:
+  schedule:
+{{CRONS}}
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Serialize every {{NAME}} run. Without this, two parallel runs read the
+# same state, pick the same batch, and open duplicate PRs touching the same
+# files. cancel-in-progress=false so a workflow_dispatch fired during a
+# scheduled run waits its turn rather than aborting it.
+concurrency:
+  group: {{CONCURRENCY_GROUP_AUDIT}}
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    name: {{DISPLAY_NAME}} with Claude
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Gate on {{TIMEZONE}} local hour window
+        id: gate
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "go=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          hour=$(TZ={{TIMEZONE}} date +%H)
+          minute=$(TZ={{TIMEZONE}} date +%M)
+          echo "Local: $hour:$minute"
+{{TIME_GATE_BODY}}
+
+      - name: Checkout repository
+        if: steps.gate.outputs.go == 'true'
+        uses: actions/checkout@v6
+        with:
+          # RELEASE_PAT so the state-file commit can push to main past
+          # branch protection.
+          token: ${{ secrets.RELEASE_PAT }}
+          fetch-depth: 0
+
+      - name: Dedup against recent runs and open drafts
+        id: dedup
+        if: steps.gate.outputs.go == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "go=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          last=$(jq -r '.last_run_at // empty' {{STATE_FILE}})
+          if [ -n "$last" ]; then
+            last_epoch=$(date -u -d "$last" +%s 2>/dev/null || echo 0)
+            now_epoch=$(date -u +%s)
+            if [ "$last_epoch" -gt 0 ]; then
+              age_h=$(( (now_epoch - last_epoch) / 3600 ))
+              if [ "$age_h" -lt {{COOLDOWN_HOURS}} ]; then
+                echo "Skipping: last run was ${age_h}h ago (<{{COOLDOWN_HOURS}}h cooldown)."
+                echo "go=false" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            fi
+          fi
+          draft_count=$(gh pr list --search "head:{{BRANCH_PREFIX_AUDIT}}" --state open --json number --jq 'length')
+          if [ "$draft_count" -ge {{DRAFT_CAP}} ]; then
+            drafts=$(gh pr list --search "head:{{BRANCH_PREFIX_AUDIT}}" --state open --json number --jq '[.[].number | tostring] | join(", #")')
+            echo "Skipping: ${draft_count} open {{NAME}} draft(s) (#${drafts}). Merge/close some, or use workflow_dispatch."
+            echo "go=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Open audit drafts: ${draft_count} (cap {{DRAFT_CAP}})."
+          echo "go=true" >> "$GITHUB_OUTPUT"
+
+      - name: Compute dynamic effort
+        id: effort
+        if: steps.dedup.outputs.go == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        run: |
+          open_count=$(gh issue list --label {{ISSUE_LABEL_AUDIT}} --state open --limit 200 --json number --jq 'length')
+          echo "Open {{ISSUE_LABEL_AUDIT}} issues: ${open_count}"
+          if [ "$open_count" -gt {{EFFORT_HOT_THRESHOLD}} ]; then
+            mode="conservative"; batch={{BATCH_CONSERVATIVE}}; cap={{CAP_CONSERVATIVE}}
+          elif [ "$open_count" -gt {{EFFORT_BALANCED_THRESHOLD}} ]; then
+            mode="balanced";     batch={{BATCH_BALANCED}};     cap={{CAP_BALANCED}}
+          else
+            mode="thorough";     batch={{BATCH_THOROUGH}};     cap={{CAP_THOROUGH}}
+          fi
+          echo "mode=${mode} batch=${batch} cap=${cap}"
+          {
+            echo "mode=${mode}"
+            echo "batch=${batch}"
+            echo "cap=${cap}"
+            echo "open_count=${open_count}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Configure git identity
+        if: steps.dedup.outputs.go == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Run Claude {{NAME}}
+        if: steps.dedup.outputs.go == 'true'
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          BRANCH_SUFFIX: ${{ github.run_id }}
+          AUDIT_MODE: ${{ steps.effort.outputs.mode }}
+          AUDIT_BATCH_SIZE: ${{ steps.effort.outputs.batch }}
+          AUDIT_ISSUE_CAP: ${{ steps.effort.outputs.cap }}
+          AUDIT_QUEUE_OPEN: ${{ steps.effort.outputs.open_count }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          show_full_output: 'true'
+          claude_args: >-
+            --model {{MODEL_AUDIT}}
+            --max-turns {{MAX_TURNS_AUDIT}}
+            --allowed-tools "{{ALLOWED_TOOLS_AUDIT}}"
+          prompt: |
+            {{DOMAIN_INTRO}}
+
+            ## Effort for this run (computed by the workflow)
+
+            - **Mode:**       ${{ steps.effort.outputs.mode }}
+            - **Batch size:** ${{ steps.effort.outputs.batch }} files
+            - **Issue cap:**  ${{ steps.effort.outputs.cap }} per run
+            - **Queue depth:** ${{ steps.effort.outputs.open_count }} open `{{ISSUE_LABEL_AUDIT}}` issues
+
+            The mode/batch/cap were chosen by the workflow based on the
+            queue depth — you don't need to second-guess them.
+
+            ## Learning from past rejections
+
+            **Read `{{REJECTION_LOG}}` before doing anything else.** Each
+            non-empty line is a previous PR (from this cron or from a
+            triage worker) that a human closed without merging — i.e. the
+            proposed edit was wrong. The log is your single most important
+            input; it is how this loop gets better over time.
+
+            Each line is a JSON object with:
+              - `pr`, `title`, `head_ref`, `closed_at`
+              - `body` — the PR description you originally wrote
+              - `files` — list of `{path, patch}` for every file changed
+              - `comments`, `reviews`, `inline_comments` — every human
+                comment on the PR. These contain the *reason* for the close.
+
+            For each rejection:
+
+            1. **Never repeat the exact swap.** Extract `-` / `+` lines
+               from each `patch`. If you would propose the same swap
+               again — anywhere in the repo, not just in the same file —
+               do not.
+            2. **Read every comment.** Treat the closer's reasoning as
+               authoritative. Generalize beyond the specific case.
+            3. **Cite when relevant.** If you skip a finding because a
+               past rejection covers it, mention the PR number in the
+               wrap-up summary.
+
+            If the file does not exist or is empty, proceed normally.
+
+            ## Sweep state
+
+            State file: `{{STATE_FILE}}`
+            Schema:
+              - `schema_version`  — int, currently 1
+              - `round`           — int, sweep number (starts at 0; bumped each restart)
+              - `round_started_at`— ISO8601 string or null
+              - `last_run_at`     — ISO8601 string or null
+              - `files_remaining` — list of relative paths still to audit this round
+              - `files_audited`   — list of relative paths already audited this round
+
+            ## Sweep logic
+
+            1. Read the state file.
+            2. If `files_remaining` is empty:
+               - Glob the repo for files matching:
+{{FILE_GLOB_INCLUDES_LIST}}
+                 Exclude:
+{{FILE_GLOB_EXCLUDES_LIST}}
+               - Set `files_remaining` to the full glob, sorted.
+               - Set `files_audited` to `[]`.
+               - Bump `round` by 1 and set `round_started_at` to now (ISO8601 UTC).
+            3. Pick the first **${{ steps.effort.outputs.batch }}** entries from
+               `files_remaining` as this run's batch. If fewer remain, use
+               what's there.
+
+            ## For each file in the batch
+
+            Read it carefully and deeply — don't skim. Spend real budget
+            understanding what the file contains, then verify against
+            ground truth (does this command actually work? does this
+            path exist? does this symbol exist? does this match the
+            schema?).
+
+            Categorize findings into three buckets:
+
+            **A. Trivial mechanical fixes ONLY** — single-token or
+                single-line edits with no ambiguity:
+{{BUCKET_A_DEFINITION}}
+
+                Anything bigger than a one-line edit, anything requiring
+                surrounding context to fix, anything involving a choice
+                between reasonable rewrites — is NOT bucket A. Push it to
+                B or C so a triage worker handles it.
+
+            **B. Missing things** — referenced concept, command, env var,
+                or workflow with no existing implementation or doc:
+{{BUCKET_B_DEFINITION}}
+
+            **C. Quality / clarity issues** — present but confusing,
+                redundant, out-of-order, or simplifiable:
+{{BUCKET_C_DEFINITION}}
+
+            ## Aggressiveness
+
+            Mode for this run: **${{ steps.effort.outputs.mode }}**.
+
+            - `thorough` (queue ≤ {{EFFORT_BALANCED_THRESHOLD}}): file any
+              defensible finding. False positives are cheap.
+            - `balanced` (between thresholds): file findings you're
+              moderately confident about. Skim past minor preferences.
+            - `conservative` (queue > {{EFFORT_HOT_THRESHOLD}}): only flag
+              high-confidence findings. Reviewer queue is hot.
+
+            Always: dedup against open `{{ISSUE_LABEL_AUDIT}}` issues before
+            filing:
+              `gh issue list --label {{ISSUE_LABEL_AUDIT}} --state open --limit 200 --search "<key phrase>"`
+            Skip if a same-file, same-topic issue already exists open.
+
+            ## Outputs
+
+            ### If bucket A has any findings across the batch
+
+            Create a branch named exactly:
+
+                {{BRANCH_PREFIX_AUDIT}}round-<round>-run-$BRANCH_SUFFIX
+
+            where `$BRANCH_SUFFIX` is the value of the `BRANCH_SUFFIX`
+            environment variable (set to `github.run_id`). Do NOT use
+            `date +%s` — past runs invented stale timestamps that way.
+            Verify with `echo "$BRANCH_SUFFIX"` first.
+
+            Branch off `main`. Apply ONLY the bucket-A fixes. Commit.
+            Open a **ready-for-review** PR (no `--draft`):
+
+              Title: `{{NAME}}: auto-audit — round <round>, files <X+1>–<Y> of <T>`
+              Body: includes summary, files touched, notes about the round.
+
+            Use `gh pr create` with NO `--draft` flag.
+
+            ### For each bucket B or C finding
+
+            File a GitHub issue. Dedupe first.
+
+            Issue title: `{{ISSUE_TITLE_TEMPLATE}}`
+
+            Issue body should include: file path(s), category, finding
+            description (2-5 sentences), suggested improvement (2-5
+            sentences), and footer noting which round filed it.
+
+            Labels: `{{ISSUE_LABEL_DOMAIN}}`, `{{ISSUE_LABEL_AUDIT}}`. Create
+            labels if needed:
+              `gh label create {{ISSUE_LABEL_AUDIT}} --color BFD4F2 --description "Filed by the {{NAME}} cron" || true`
+
+            After creating each issue, also apply the `{{TRIAGE_LABEL}}` label
+            so the issue-triage workflow picks it up:
+              `gh issue edit <N> --add-label {{TRIAGE_LABEL}}`
+            Create that label first if needed:
+              `gh label create {{TRIAGE_LABEL}} --color 0E8A16 --description "Run the Claude issue-triage workflow on this issue" || true`
+
+            ## State commit
+
+            After processing the batch:
+            1. Move the batch entries from `files_remaining` to `files_audited`.
+            2. Update `last_run_at` to now (ISO8601 UTC).
+            3. Write the JSON back to `{{STATE_FILE}}` (2-space indent, trailing
+               newline, keys in the same order as the existing file).
+            4. Commit to `main` directly with the message
+               `chore({{NAME}}): advance sweep state [skip ci]` and push.
+               This is the ONLY direct-to-main commit you make.
+
+            ## Hard rules
+
+            - Never push to `main` except for the single state-file commit above.
+            - Never force-push, never `--no-verify`, never `--no-gpg-sign`.
+            - Never modify files outside: {{HARD_RULES_FILE_RESTRICTION}}.
+            - Never open more than 1 PR per run.
+            - Never file more than **${{ steps.effort.outputs.cap }}** issues per run.
+            - When dedup says skip, skip — don't refile.
+            - When mode is `thorough`, lean toward filing; when
+              `conservative`, lean toward skipping.
+
+            ## Wrap up
+
+            Print a one-screen summary:
+              ROUND: <n> (started <date>)
+              BATCH: <files in this batch>
+              PR opened: <#N or "none">
+              Issues filed: <#A #B ...>
+              Progress: <audited>/<total> files in this round
+              Next batch: <first 3 of files_remaining or "round complete">
+
+      - name: Push state-file changes
+        if: steps.dedup.outputs.go == 'true'
+        # Defensive: if the Claude step exits early, commit + push the
+        # state file here. [skip ci] keeps this from retriggering.
+        run: |
+          if git diff --quiet -- {{STATE_FILE}}; then
+            echo "State file unchanged."
+            exit 0
+          fi
+          git add {{STATE_FILE}}
+          git commit -m "chore({{NAME}}): advance sweep state [skip ci]"
+          git push origin HEAD:main

--- a/.claude/skills/new-claude-github-actions-flow/references/templates/auto-review.yml.tmpl
+++ b/.claude/skills/new-claude-github-actions-flow/references/templates/auto-review.yml.tmpl
@@ -1,0 +1,98 @@
+name: 'Claude: {{DISPLAY_NAME}} Auto-Review'
+
+# =============================================================================
+# Auto-runs a Claude code review on any PR touching {{DOMAIN_DESCRIPTION_SHORT}}.
+# Posts ONE review comment. Read-only on contents — only pull-requests:write
+# so the action can leave its review.
+#
+# `pull_request_target` runs from the base ref's workflow definition, so
+# malicious head-branch edits can't fire. We only check out the BASE ref —
+# never the PR head — per the CodeQL `actions/untrusted-checkout` rule
+# (the "pwn-request" pattern). PR head content is read read-only via
+# `gh api .../contents/<path>?ref=<head_sha>` from inside the prompt:
+# bytes piped through Claude as data, never materialized in a location a
+# later step could execute. Belt and braces: `--allowed-tools` is read-only.
+#
+# Draft PRs are skipped — a draft signals "not ready for review yet."
+# The trigger includes `ready_for_review` so the review fires when the
+# author flips draft → ready.
+# =============================================================================
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+{{REVIEW_PATHS}}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: claude-{{NAME}}-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: Claude reviews the {{NAME}} diff
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    if: github.event.pull_request.draft == false
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout base ref (trusted)
+        uses: actions/checkout@v6
+        with:
+          # pull_request_target grants secrets — never check out PR head.
+          # Base ref gives Claude the trusted CLAUDE.md / canonical refs.
+          # PR head content is read via `gh api .../contents/<path>?ref=<head_sha>`
+          # from inside the prompt — data piped through Claude, never executed.
+          ref: ${{ github.event.pull_request.base.ref }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Run Claude review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Skip the OIDC→claude[bot] App-token exchange. On
+          # pull_request_target events the App exchange returns
+          # `401 Invalid OIDC token`; providing github_token bypasses
+          # that exchange entirely.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Bot-authored PRs need to be reviewed too — that's the point.
+          allowed_bots: 'claude,github-actions'
+          show_full_output: 'true'
+          claude_args: >-
+            --model {{MODEL_REVIEW}}
+            --max-turns {{MAX_TURNS_REVIEW}}
+            --allowed-tools "{{ALLOWED_TOOLS_REVIEW}}"
+          prompt: |
+            You are the FiestaBoard {{NAME}} reviewer. Review PR
+            #${{ github.event.pull_request.number }}: {{ github.event.pull_request.title }}
+
+            ## What to review
+
+            {{REVIEW_PROMPT_BODY}}
+
+            ## How to access PR content
+
+            Use `gh pr diff ${{ github.event.pull_request.number }}` for the diff.
+            Use `gh api repos/${{ github.repository }}/contents/<path>?ref=${{ github.event.pull_request.head.sha }}`
+            for full file contents. Never `git checkout` the PR head.
+
+            ## Output
+
+            Post ONE review comment via `gh pr review --comment`. Be specific
+            with file:line references. If everything looks good, say so
+            briefly — a thumbs-up is fine.
+
+            ## Hard rules
+
+            - Read-only: never Edit, Write, or push.
+            - One review comment per run.
+            - Reference the canonical patterns in CLAUDE.md and the {{NAME}}
+              folder's docs as the source of truth.

--- a/.claude/skills/new-claude-github-actions-flow/references/templates/build_rejection.py.tmpl
+++ b/.claude/skills/new-claude-github-actions-flow/references/templates/build_rejection.py.tmpl
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Capture why a {{NAME}} PR was closed without merging.
+
+Run as: build_rejection.py <pr_number>
+
+Reads the PR's metadata, full diff, every comment / review / inline comment
+via `gh`, then writes one JSONL line into `{{REJECTION_LOG}}`. The next
+{{NAME}} cron run loads that file and uses it to avoid repeating the same
+wrong edit and to generalize from the closer's explanation.
+
+Idempotent: a re-run for the same PR replaces that PR's existing line
+rather than appending a duplicate. This lets the GitHub Action be
+triggered manually (workflow_dispatch) after a user has added a later
+explanatory comment without polluting the log.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+LOG_PATH = Path("{{REJECTION_LOG}}")
+
+
+def gh_json(*args: str):
+    out = subprocess.check_output(["gh", *args], text=True)
+    return json.loads(out)
+
+
+def gh_text(*args: str) -> str:
+    return subprocess.check_output(["gh", *args], text=True)
+
+
+def parse_diff(diff: str) -> list[dict]:
+    """Split a unified diff into per-file `{path, patch}` records."""
+    files: list[dict] = []
+    current: dict | None = None
+    for line in diff.splitlines():
+        if line.startswith("diff --git "):
+            if current is not None:
+                current["patch"] = "\n".join(current["patch"])
+                files.append(current)
+            path = line.split(" b/", 1)[-1] if " b/" in line else line
+            current = {"path": path, "patch": [line]}
+        elif current is not None:
+            current["patch"].append(line)
+    if current is not None:
+        current["patch"] = "\n".join(current["patch"])
+        files.append(current)
+    return files
+
+
+def build_record(pr: str) -> dict:
+    meta = gh_json(
+        "pr", "view", pr,
+        "--json", "number,title,headRefName,closedAt,author,body,state",
+    )
+    if meta.get("state") == "MERGED":
+        raise SystemExit(f"PR #{pr} was merged — refusing to record as rejection.")
+
+    diff = gh_text("pr", "diff", pr)
+    files = parse_diff(diff)
+
+    repo = subprocess.check_output(
+        ["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"],
+        text=True,
+    ).strip()
+
+    issue_comments = gh_json(
+        "api", f"repos/{repo}/issues/{pr}/comments",
+        "--jq", "[.[] | {author: .user.login, body: .body, created_at: .created_at}]",
+    )
+    reviews = gh_json(
+        "api", f"repos/{repo}/pulls/{pr}/reviews",
+        "--jq",
+        '[.[] | select((.body // "") != "") | '
+        '{author: .user.login, body: .body, state: .state, submitted_at: .submitted_at}]',
+    )
+    inline = gh_json(
+        "api", f"repos/{repo}/pulls/{pr}/comments",
+        "--jq",
+        "[.[] | {author: .user.login, body: .body, path: .path, "
+        "created_at: .created_at, diff_hunk: .diff_hunk}]",
+    )
+
+    return {
+        "pr": meta["number"],
+        "title": meta["title"],
+        "head_ref": meta["headRefName"],
+        "closed_at": meta["closedAt"],
+        "author": (meta.get("author") or {}).get("login"),
+        "body": meta.get("body") or "",
+        "comments": issue_comments,
+        "reviews": reviews,
+        "inline_comments": inline,
+        "files": files,
+    }
+
+
+def write_log(record: dict, path: Path = LOG_PATH) -> None:
+    """Replace any prior line for this PR; append the new one."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing: list[str] = []
+    if path.exists():
+        existing = [ln for ln in path.read_text().splitlines() if ln.strip()]
+
+    def keep(line: str) -> bool:
+        try:
+            return json.loads(line).get("pr") != record["pr"]
+        except json.JSONDecodeError:
+            return True
+
+    kept = [ln for ln in existing if keep(ln)]
+    kept.append(json.dumps(record, ensure_ascii=False, separators=(",", ":")))
+    path.write_text("\n".join(kept) + "\n")
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        sys.exit("usage: build_rejection.py <pr_number>")
+    pr = sys.argv[1]
+    record = build_record(pr)
+    if os.environ.get("DRY_RUN") == "1":
+        print(json.dumps(record, ensure_ascii=False, indent=2))
+        return
+    write_log(record)
+    print(f"Captured PR #{record['pr']} into {LOG_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/new-claude-github-actions-flow/references/templates/feedback-capture.yml.tmpl
+++ b/.claude/skills/new-claude-github-actions-flow/references/templates/feedback-capture.yml.tmpl
@@ -1,0 +1,100 @@
+name: 'Claude: {{DISPLAY_NAME}} Feedback Capture'
+
+# =============================================================================
+# Captures rejected {{NAME}} PRs so the cron auditor can learn from them.
+#
+# Two PR sources feed this pipeline, and both must be captured:
+#   - `{{BRANCH_PREFIX_AUDIT}}*` — bucket-A inline PRs from the audit cron itself
+#   - `{{BRANCH_PREFIX_TRIAGE}}*` — per-issue fixes from the triage worker
+#
+# When either is closed without merging, the maintainer is telling the bot
+# "this edit was wrong." This workflow bundles the PR's diff, close metadata,
+# and every comment/review into a single JSONL line in {{REJECTION_LOG}}
+# and commits that file to main. The next audit run reads the log and uses
+# it to (a) never re-propose the same exact swap, and (b) generalize from
+# the closer's explanation.
+#
+# `workflow_dispatch` re-runs capture for a given PR — useful when a
+# maintainer adds an explanatory comment after the original close.
+# Re-running replaces the prior line for that PR rather than appending.
+#
+# Trigger is `pull_request_target` (not `pull_request`) so GitHub resolves
+# this workflow file from `main` rather than the PR's head ref. Branches
+# cut from `main` at audit time and never updated would otherwise be
+# invisible to it. `pull_request_target` is safe here because the workflow
+# checks out `main` (not PR code) and only reads PR metadata via `gh`;
+# no head-ref code is ever executed.
+# =============================================================================
+
+on:
+  pull_request_target:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to (re)capture into the rejection log'
+        required: true
+        type: number
+
+permissions:
+  contents: read
+
+concurrency:
+  group: {{CONCURRENCY_GROUP_FEEDBACK}}
+  cancel-in-progress: false
+
+jobs:
+  capture:
+    name: Capture rejected {{NAME}} edit
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: >-
+      ${{ github.event_name == 'workflow_dispatch' ||
+          (github.event.pull_request.merged == false &&
+           (startsWith(github.event.pull_request.head.ref, '{{BRANCH_PREFIX_AUDIT}}') ||
+            startsWith(github.event.pull_request.head.ref, '{{BRANCH_PREFIX_TRIAGE}}'))) }}
+    permissions:
+      contents: write
+      pull-requests: read
+      issues: read
+    steps:
+      - name: Determine PR number
+        id: pr
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "number=${{ inputs.pr_number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          # RELEASE_PAT so the log commit can push to main past branch
+          # protection.
+          ref: main
+          token: ${{ secrets.RELEASE_PAT }}
+          fetch-depth: 1
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Capture rejection
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        run: |
+          set -euo pipefail
+          python3 {{FEEDBACK_DIR}}build_rejection.py "${{ steps.pr.outputs.number }}"
+
+      - name: Commit and push
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- {{REJECTION_LOG}}; then
+            echo "Log unchanged — script bailed (merged PR, or no diff)."
+            exit 0
+          fi
+          git add {{REJECTION_LOG}}
+          git commit -m "chore({{NAME}}): capture rejection from PR #${{ steps.pr.outputs.number }} [skip ci]"
+          git push origin HEAD:main

--- a/.claude/skills/new-claude-github-actions-flow/references/templates/feedback-readme.md.tmpl
+++ b/.claude/skills/new-claude-github-actions-flow/references/templates/feedback-readme.md.tmpl
@@ -1,0 +1,58 @@
+# {{DISPLAY_NAME}} Feedback Loop
+
+The {{NAME}} cron (`.github/workflows/claude-{{NAME}}.yml`) sweeps {{DOMAIN_DESCRIPTION_SHORT}}
+on a recurring schedule and opens ready-for-review PRs for trivial fixes
+and issues for everything else. Sometimes those fixes are wrong. When that
+happens, the maintainer closes the PR.
+
+**Closing a {{NAME}} PR without merging is the teaching action.** This
+folder is the bot's memory of those teaching moments.
+
+## How it works
+
+1. **`claude-{{NAME}}-feedback.yml`** triggers on `pull_request.closed`. If
+   the PR is unmerged and the head branch starts with
+   `{{BRANCH_PREFIX_AUDIT}}` or `{{BRANCH_PREFIX_TRIAGE}}`, it runs
+   `build_rejection.py` to bundle the PR's diff + every comment, review,
+   and inline comment into a single JSON object, then appends that object
+   as one line to `rejected-edits.jsonl` and commits the change to `main`.
+2. **The audit prompt** reads `rejected-edits.jsonl` at the start of every
+   run. The bot is instructed to (a) never re-propose the same `removed →
+   added` swap anywhere in the repo, and (b) generalize from the human's
+   close comment.
+3. **Re-running capture** is idempotent. If the maintainer adds an
+   explanatory comment after closing, dispatch `claude-{{NAME}}-feedback.yml`
+   with the PR number and the existing line is replaced.
+
+## File: `rejected-edits.jsonl`
+
+One JSON object per line. Schema:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `pr` | int | PR number. Acts as the primary key — re-capture replaces the prior line. |
+| `title` | string | Original PR title. |
+| `head_ref` | string | `{{BRANCH_PREFIX_AUDIT}}round-<n>-run-<id>` or `{{BRANCH_PREFIX_TRIAGE}}<N>-<slug>`. |
+| `closed_at` | string | ISO 8601. |
+| `author` | string | `github-actions[bot]` for the cron, or whoever pushed. |
+| `body` | string | PR description as opened by the bot. |
+| `files` | array | `[{path, patch}]` — raw unified diff per file. |
+| `comments` | array | Issue-style PR comments: `{author, body, created_at}`. |
+| `reviews` | array | Review-level comments. |
+| `inline_comments` | array | Per-line review comments. |
+
+## File: `build_rejection.py`
+
+Script the workflow runs. Can be invoked locally with `DRY_RUN=1` to print
+the record to stdout without modifying the log:
+
+```bash
+DRY_RUN=1 python3 {{FEEDBACK_DIR}}build_rejection.py 992
+```
+
+## Manually clearing a stale rejection
+
+If a rejected edit is later determined to have been correct (the close
+was wrong, or the codebase has changed and the swap now makes sense),
+hand-delete that line from `rejected-edits.jsonl` and commit. The file is
+plain JSONL; any text editor can do this.

--- a/.claude/skills/new-claude-github-actions-flow/references/templates/state.json.tmpl
+++ b/.claude/skills/new-claude-github-actions-flow/references/templates/state.json.tmpl
@@ -1,0 +1,8 @@
+{
+  "schema_version": 1,
+  "round": 0,
+  "round_started_at": null,
+  "last_run_at": null,
+  "files_remaining": [],
+  "files_audited": []
+}

--- a/.claude/skills/new-claude-github-actions-flow/references/variables.md
+++ b/.claude/skills/new-claude-github-actions-flow/references/variables.md
@@ -1,0 +1,143 @@
+# Variable catalogue
+
+Every knob a loop exposes, what it controls, where it lives in the rendered files, and the trade-offs. Use this when **tuning** an existing loop or when **rendering** a new one.
+
+Tokens are written as `{{TOKEN_NAME}}` in templates. The substitution is literal text; no Jinja, no nesting.
+
+## Identity & naming
+
+| Token | Example | Used in | Notes |
+| --- | --- | --- | --- |
+| `{{NAME}}` | `tests-audit` | filenames, branch prefix, issue label, state file path, concurrency group | kebab-case; must not collide with existing `claude-*.yml` |
+| `{{SHORT_NAME}}` | `tests` | triage branch prefix (`<short>/issue-*`) | typically the first segment of `{{NAME}}` |
+| `{{DISPLAY_NAME}}` | `Tests Audit` | workflow `name:` field, PR/issue titles | Title Case |
+| `{{DESCRIPTION}}` | `Sweep of the Python test suite for flaky tests, slow tests, and missing coverage.` | header comment block | one paragraph |
+
+## Schedule & gating
+
+| Token | Default | Used in | Notes |
+| --- | --- | --- | --- |
+| `{{CRONS}}` | 4 UTC entries for noon + 4pm PT | `on.schedule` | pairs per intended local window; see [pitfalls.md](pitfalls.md#dst-and-cron) |
+| `{{TIME_GATE_WINDOWS}}` | `12:00-13:30` and `16:00-17:30` PT | "Gate on local hour" step bash | upper bound includes 30 min slop for GHA delay |
+| `{{COOLDOWN_HOURS}}` | `3` | "Dedup" step's `age_h < N` check | between 2 and 4 is sensible for ≤twice-daily |
+| `{{DRAFT_CAP}}` | `5` | "Dedup" step's `draft_count -ge N` check | raise for high-volume domains, lower for slow reviewer queues |
+| `{{TIMEZONE}}` | `America/Los_Angeles` | gate step's `TZ=` | change for non-US-PT teams |
+
+## Effort scaling
+
+The audit's batch size and issue cap scale **inversely** with the open issue queue. Higher queue → lower batch/cap. Three modes:
+
+| Token | Default | Notes |
+| --- | --- | --- |
+| `{{EFFORT_HOT_THRESHOLD}}` | `80` | open issues above this → conservative |
+| `{{EFFORT_BALANCED_THRESHOLD}}` | `40` | open issues above this → balanced |
+| `{{BATCH_CONSERVATIVE}}` | `12` | files audited per run when queue is hot |
+| `{{BATCH_BALANCED}}` | `24` | files audited per run when queue is warm |
+| `{{BATCH_THOROUGH}}` | `32` | files audited per run when queue is drained |
+| `{{CAP_CONSERVATIVE}}` | `32` | max issues filed per run when queue is hot |
+| `{{CAP_BALANCED}}` | `60` | max issues filed per run when queue is warm |
+| `{{CAP_THOROUGH}}` | `100` | max issues filed per run when queue is drained |
+
+The three caps thread into the prompt via `${{ steps.effort.outputs.cap }}` interpolation.
+
+## Files & paths
+
+| Token | Example | Used in | Notes |
+| --- | --- | --- | --- |
+| `{{STATE_FILE}}` | `.github/tests-audit-state.json` | state file path, prompt | always `.github/{{NAME}}-state.json` by convention |
+| `{{REJECTION_LOG}}` | `.github/tests-audit/rejected-edits.jsonl` | feedback workflow, prompt | always `.github/{{NAME}}/rejected-edits.jsonl` |
+| `{{FEEDBACK_DIR}}` | `.github/tests-audit/` | feedback README, `build_rejection.py` | folder for the rejection log and its docs |
+| `{{FILE_GLOB_INCLUDES}}` | `tests/**/*.py`, `plugins/*/tests/**/*.py` | prompt's "Glob the repo" section | domain-specific |
+| `{{FILE_GLOB_EXCLUDES}}` | `node_modules/`, `.git/`, `**/__pycache__/`, `tools/`, `.claude/` | prompt's glob exclusions | always exclude `.claude/` and `node_modules` |
+| `{{EDITABLE_FILE_TYPES}}` | `*.md` or `tests/**/*.py` | "Hard rules" section of prompt | hard ceiling on what Claude is allowed to edit |
+
+## Branch & label conventions
+
+| Token | Example | Used in | Notes |
+| --- | --- | --- | --- |
+| `{{BRANCH_PREFIX_AUDIT}}` | `tests-audit/` | audit prompt, feedback `if:` condition | inline PRs from the cron use `<prefix>round-<n>-run-<id>` |
+| `{{BRANCH_PREFIX_TRIAGE}}` | `tests/issue-` | triage prompt, feedback `if:` condition | per-issue PRs from the triage worker |
+| `{{ISSUE_LABEL_DOMAIN}}` | `tests` | issue creation, dedup | broad domain tag, e.g., `docs`, `tests`, `perf` |
+| `{{ISSUE_LABEL_AUDIT}}` | `tests-audit` | issue creation, dedup, triage `if:` gate | same as `{{NAME}}`; flags the issue as audit-filed |
+| `{{TRIAGE_LABEL}}` | `claude-fix` | issue post-create label application | shared across all loops |
+
+## Model tiers
+
+| Token | Default | Used in | Notes |
+| --- | --- | --- | --- |
+| `{{MODEL_AUDIT}}` | `claude-sonnet-4-6` | audit `claude_args.--model` | Sonnet handles audits in volume; Opus only if findings are deeply analytical |
+| `{{MODEL_REVIEW}}` | `claude-sonnet-4-6` | review `claude_args.--model` | Sonnet is fine for reviews; Haiku is too brief |
+| `{{MODEL_TRIAGE_DOCS}}` | `claude-sonnet-4-6` | triage tier-step output (docs branch) | docs-flavored issues |
+| `{{MODEL_TRIAGE_CODE}}` | `claude-opus-4-7` | triage tier-step output (default branch) | code/infra issues benefit from Opus |
+| `{{MAX_TURNS_AUDIT}}` | `250` | audit `claude_args.--max-turns` | high ceiling; `timeout-minutes` is the real cost backstop |
+| `{{MAX_TURNS_TRIAGE}}` | `80` | triage `claude_args.--max-turns` | enough to investigate + write tests + open PR |
+| `{{MAX_TURNS_REVIEW}}` | `40` | review `claude_args.--max-turns` | a review run shouldn't need more |
+
+## Tool allowlists
+
+The action's agent-mode default is read-only. Every Edit/Write/git push/gh action must be allowlisted. **Match every Bash pattern the prompt invokes** — see [pitfalls.md](pitfalls.md#-allowed-tools-allowlist--read-only-by-default).
+
+| Token | Used in | Notes |
+| --- | --- | --- |
+| `{{ALLOWED_TOOLS_AUDIT}}` | audit `claude_args.--allowed-tools` | Read/Glob/Grep/Edit/Write + git + gh issue create + gh pr create + gh label create + jq/date/cat/ls/find |
+| `{{ALLOWED_TOOLS_TRIAGE}}` | triage `claude_args.--allowed-tools` | broader than audit — adds `find`, `grep`, `rg`, `python3`, `node`, `npm` for codebase navigation |
+| `{{ALLOWED_TOOLS_REVIEW}}` | review `claude_args.--allowed-tools` | read-only — no Edit/Write/git push/gh pr create |
+
+## Prompt body — domain-specific
+
+This is the only token that requires bespoke composition. The rest are mechanical substitutions; this one is the audit's *thinking*.
+
+| Token | Used in | What goes here |
+| --- | --- | --- |
+| `{{DOMAIN_INTRO}}` | first line of prompt | `"You are the FiestaBoard <domain> auditor. You run unattended <cadence> and audit a batch of <thing>."` |
+| `{{BUCKET_A_DEFINITION}}` | "Categorize findings" section | what counts as a trivial mechanical fix in this domain (single-token edit, no ambiguity) |
+| `{{BUCKET_B_DEFINITION}}` | "Categorize findings" section | what counts as a missing-thing-to-document/fix issue |
+| `{{BUCKET_C_DEFINITION}}` | "Categorize findings" section | what counts as a clarity/quality finding |
+| `{{ISSUE_TITLE_TEMPLATE}}` | "For each bucket B or C finding" | e.g., `"tests: <verb> <file> — <one-line summary>"` |
+| `{{HARD_RULES_FILE_RESTRICTION}}` | "Hard rules" section | exact glob of files Claude may edit |
+
+When composing these, the prompt's structural skeleton (sweep state, dedup, output format, hard rules, wrap-up) stays unchanged — only the domain-flavored paragraphs change.
+
+## Concurrency
+
+| Token | Example | Notes |
+| --- | --- | --- |
+| `{{CONCURRENCY_GROUP_AUDIT}}` | `tests-audit` | single global group; not keyed by anything |
+| `{{CONCURRENCY_GROUP_FEEDBACK}}` | `tests-audit-feedback` | serialize JSONL log writes |
+| `{{CONCURRENCY_GROUP_REVIEW}}` | `claude-tests-audit-review-${{ github.event.pull_request.number }}` | per-PR, with `cancel-in-progress: true` so a new push cancels the prior review |
+| `{{CONCURRENCY_GROUP_TRIAGE}}` | `claude-issue-triage-${{ github.event.issue.number }}` | per-issue, with `cancel-in-progress: true` |
+
+## Review workflow path filter
+
+The auto-review workflow is gated on file paths so it doesn't fire for unrelated PRs.
+
+| Token | Example | Used in |
+| --- | --- | --- |
+| `{{REVIEW_PATHS}}` | `'**.md', 'plugins/*/docs/**', 'docs/**'` (docs case) or `'tests/**/*.py', 'plugins/*/tests/**'` (tests case) | review workflow's `on.pull_request_target.paths` |
+
+## Tuning quick-reference
+
+When the user asks to change …
+
+| Request | Token(s) to change | File(s) |
+| --- | --- | --- |
+| "Run every 4 hours" | `{{CRONS}}`, `{{TIME_GATE_WINDOWS}}`, `{{COOLDOWN_HOURS}}` | audit workflow |
+| "Use Opus" | `{{MODEL_AUDIT}}` | audit workflow |
+| "Bump batch size" | `{{BATCH_THOROUGH}}` (and possibly `_BALANCED` / `_CONSERVATIVE`) | audit workflow |
+| "Bump issue cap" | `{{CAP_THOROUGH}}` (and others) | audit workflow |
+| "Hold off when 3 drafts open" | `{{DRAFT_CAP}}` | audit workflow |
+| "Add a Bash command Claude can run" | `{{ALLOWED_TOOLS_AUDIT}}` (or triage / review) | the relevant workflow |
+| "Skip files under X" | `{{FILE_GLOB_EXCLUDES}}` | audit workflow's prompt |
+| "Auto-review more file types" | `{{REVIEW_PATHS}}` | review workflow |
+| "Triage code issues with Sonnet" | `{{MODEL_TRIAGE_CODE}}` | triage workflow |
+| "Stop the loop temporarily" | (no token — `gh workflow disable claude-<name>.yml`) | — |
+
+## Cross-references
+
+Some tokens live in multiple places. When tuning, update all of them.
+
+- `{{NAME}}` — audit filename, audit `concurrency.group`, audit prompt's `<name>`, feedback workflow filename, feedback `concurrency.group`, review workflow filename, state file path, rejection log path, feedback dir.
+- `{{BRANCH_PREFIX_AUDIT}}` — audit prompt's "Create a branch named …", feedback `if:` `startsWith(...)`, feedback README.
+- `{{BRANCH_PREFIX_TRIAGE}}` — triage prompt's "branch <triage-prefix>-<N>-…", feedback `if:` `startsWith(...)`, feedback README.
+- `{{ISSUE_LABEL_AUDIT}}` — audit prompt's `gh issue create --label`, audit prompt's `gh issue list --label` (dedup), triage workflow's `if:` `github.event.label.name ==`, triage workflow's `Choose model tier` step's grep.
+- `{{MODEL_AUDIT}}` — audit's `claude_args.--model`, audit's `env.AUDIT_MODEL` (if you add visibility), header comment.

--- a/.gitignore
+++ b/.gitignore
@@ -110,5 +110,8 @@ docs-site/.cache-loader/
 # Claude Code worktrees (per-user, ephemeral isolated checkouts).
 .claude/worktrees/
 
+# Skill-creator eval workspaces (per-iteration test artifacts, not source).
+.claude/skills/*-workspace/
+
 # Supervisor runtime PID file (created when supervisord runs locally).
 supervisord.pid


### PR DESCRIPTION
## Summary

Adds a project-local skill at `.claude/skills/new-claude-github-actions-flow/` that codifies the **docs-audit pattern** (scheduled cron → audit → file issues → open PRs → auto-review → capture rejections to learn from) so the same shape can be applied to new domains (tests, perf, i18n, plugins, security, etc.) without re-discovering its pitfalls.

Two flows:
- **CREATE** — scaffold a new audit loop given a domain description, with optional issues-only / no-feedback / no-review variants
- **TUNE** — adjust knobs (schedule, model tier, batch size, queue thresholds, file globs, draft caps) on existing `claude-*.yml` workflows

## What's in the skill

- `SKILL.md` — main flow with `Issues-only trims` section for minimal variants
- `references/pitfalls.md` — every hard-won lesson with the PR that taught it
- `references/variables.md` — every tunable knob, where it lives, the trade-offs, and cross-references for tuning
- `references/architecture.md` — how the four workflows interlock and why
- `references/templates/` — parameterized YAML/Python/JSON templates for `audit-cron`, `auto-review`, `feedback-capture`, `build_rejection.py`, state seed, feedback-folder README
- `evals/evals.json` + `evals/grade.py` — three regression test cases (create new loop, tune existing, minimal issues-only) with 49 programmatic assertions

## Pitfalls encoded

Every guard in the canonical `claude-docs-audit.yml` is captured with the reason it exists:

- `BRANCH_SUFFIX: ${{ github.run_id }}` (never `date +%s` — fixes #967-class stale-timestamp branches)
- `show_full_output: 'true'` everywhere (silent permission denials look like clean successes without it)
- `--allowed-tools` allowlist matched per prompt, with read-only slice for review jobs
- `pull_request_target` on feedback capture (so branches cut from `main` before the workflow existed still fire — fixes the PR #992 miss)
- Base-ref-only checkout on auto-review (CodeQL pwn-request guard, `persist-credentials: false`)
- `github_token: ${{ secrets.GITHUB_TOKEN }}` to bypass the OIDC App-token 401 on `pull_request_target` (PR #1020)
- Paired UTC crons + local-PT gate to absorb DST without drifting
- `concurrency.cancel-in-progress: false` on audit/feedback so parallel runs don't race the state file (fixes PR #966/#967-class duplicate PRs)
- Issues-only-variant trim list (drop `pull-requests: write`, PR-creation tools, bucket-A prompt sections) for audits like `manifest-audit` that never open PRs

## Eval results

Iteration-2 (with the new minimal-variant guidance and isolation fixes):

| Eval | With skill | Without skill |
| --- | --- | --- |
| eval-1 (create `tests-audit`) | 24/24 | 24/24 |
| eval-2 (tune `docs-audit` knobs) | 6/8 ¹ | 8/8 |
| eval-3 (minimal `manifest-audit`) | 17/17 | 16/17 |

¹ Two with-skill misses on eval-2 are `summary.md` not landing on disk because the subagent harness blocked the Write tool for "report files"; the agent inlined the summary in its response. Not a skill issue.

The baseline ties or wins on evals 1–2 because both prompts explicitly reference the existing `docs-audit` pattern — a baseline agent told to mirror it produces ~the same correctness. The skill's value is sharpest on eval-3 (issues-only variant, where the right trims aren't obvious without explicit guidance).

## Files

13 files, all under `.claude/skills/new-claude-github-actions-flow/` plus a `.gitignore` entry for the per-iteration eval workspace (`.claude/skills/*-workspace/`).

## Test plan

- [ ] Type `/new-claude-github-actions-flow` in a fresh Claude Code session and confirm the skill loads
- [ ] Ask "set up a Claude cron that audits X" — confirm the description triggers the skill without an explicit slash command
- [ ] Run the eval grader against the workspace dir to confirm the regression tests still pass: `python3 .claude/skills/new-claude-github-actions-flow/evals/grade.py <workspace>`