### PR TITLE
fix: validate startup config against multi-board settings (#1102)

### DIFF
--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -1196,6 +1196,18 @@ class ConfigManager:
             if not board.get("host"):
                 errors.append("Board host is required when api_mode is 'local'")
 
+        # If the legacy board config is empty but any board instance configured
+        # via the multi-board settings service has connection credentials, the
+        # service can start fine — _build_board_clients() prefers settings.boards
+        # over Config when present. Without this, users who set up their board
+        # through Settings (rather than the first-run wizard) get stuck in a
+        # startup retry loop with the legacy-config validation errors above,
+        # even though the UI's /config/validate endpoint considers them
+        # configured. (issue #1102)
+        if errors and self._has_configured_board_instance():
+            board_error_prefixes = ("Board cloud_key", "Board local_api_key", "Board host")
+            errors = [e for e in errors if not e.startswith(board_error_prefixes)]
+
         # Validate features that are enabled
         features = config.get("features", {})
 
@@ -1217,6 +1229,26 @@ class ConfigManager:
                 errors.append("Guest WiFi password is required when enabled")
 
         return (len(errors) == 0, errors)
+
+    @staticmethod
+    def _has_configured_board_instance() -> bool:
+        """Return True if any board in the multi-board settings service has connection creds."""
+        try:
+            from .devices import BoardInstance
+            from .settings.service import get_settings_service
+
+            board_settings = get_settings_service().get_board_settings()
+        except Exception:
+            return False
+
+        for board_dict in board_settings.boards or []:
+            try:
+                instance = BoardInstance.from_dict(board_dict)
+            except Exception:
+                continue
+            if instance.is_connection_configured:
+                return True
+        return False
 
     def migrate_silence_schedule_to_utc(self) -> bool:
         """Migrate silence_schedule times from old HH:MM format to UTC ISO format.

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -660,14 +660,10 @@ def test_validate_local_config_passes_when_only_multi_board_configured(tmp_path,
     cm = ConfigManager(config_path=str(config_path))
 
     fake_board_settings = MagicMock()
-    fake_board_settings.boards = [
-        {"api_mode": "local", "local_api_key": "real-key", "host": "10.0.0.5"}
-    ]
+    fake_board_settings.boards = [{"api_mode": "local", "local_api_key": "real-key", "host": "10.0.0.5"}]
     fake_service = MagicMock()
     fake_service.get_board_settings.return_value = fake_board_settings
-    monkeypatch.setattr(
-        "src.settings.service.get_settings_service", lambda: fake_service
-    )
+    monkeypatch.setattr("src.settings.service.get_settings_service", lambda: fake_service)
 
     valid, errors = cm.validate()
     assert valid is True, f"expected valid config, got errors: {errors}"
@@ -686,14 +682,10 @@ def test_validate_local_config_fails_when_multi_board_also_empty(tmp_path, monke
     cm = ConfigManager(config_path=str(config_path))
 
     fake_board_settings = MagicMock()
-    fake_board_settings.boards = [
-        {"api_mode": "local", "local_api_key": "", "host": ""}
-    ]
+    fake_board_settings.boards = [{"api_mode": "local", "local_api_key": "", "host": ""}]
     fake_service = MagicMock()
     fake_service.get_board_settings.return_value = fake_board_settings
-    monkeypatch.setattr(
-        "src.settings.service.get_settings_service", lambda: fake_service
-    )
+    monkeypatch.setattr("src.settings.service.get_settings_service", lambda: fake_service)
 
     valid, errors = cm.validate()
     assert valid is False

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -23,7 +23,7 @@ def mock_time_service():
 
 @pytest.fixture(autouse=True)
 def reset_singleton(tmp_path, monkeypatch):
-    """Reset ConfigManager singleton between tests and clear env vars."""
+    """Reset ConfigManager + SettingsService singletons and clear env vars."""
     # Clear environment variables that could interfere with validation tests
     monkeypatch.delenv("BOARD_READ_WRITE_KEY", raising=False)
     monkeypatch.delenv("FB_READ_WRITE_KEY", raising=False)
@@ -35,8 +35,32 @@ def reset_singleton(tmp_path, monkeypatch):
 
     ConfigManager._instance = None
     ConfigManager._lock = threading.Lock()
-    yield tmp_path
+
+    # Pre-seed ConfigManager singleton with an empty tmp config so that
+    # SettingsService._apply_global_connection() doesn't migrate the real
+    # global config from data/config.json into the fresh settings instance.
+    empty_config_path = tmp_path / "_empty_config.json"
+    empty_config_path.write_text('{"board": {}, "features": {}, "general": {}}')
+    ConfigManager(config_path=str(empty_config_path))
+
+    # Reset SettingsService singleton and point it at an empty tmp settings
+    # file so validate() doesn't pick up a real configured board from data/
+    # (e.g. when tests run inside a populated dev container).
+    import src.settings.service as settings_service_module
+
+    settings_service_module._settings_service = settings_service_module.SettingsService(
+        settings_file=str(tmp_path / "settings.json")
+    )
+
+    # Now clear the ConfigManager singleton so each test can pin its own
+    # config_path via ConfigManager(config_path=...).
     ConfigManager._instance = None
+    ConfigManager._lock = threading.Lock()
+
+    yield tmp_path
+
+    ConfigManager._instance = None
+    settings_service_module._settings_service = None
 
 
 # --- __init__ and _load_or_create ---
@@ -614,6 +638,67 @@ def test_validate_invalid_local_config_missing_key_or_host(tmp_path):
     valid, errors = cm.validate()
     assert valid is False
     assert any("local_api_key" in e or "host" in e for e in errors)
+
+
+def test_validate_local_config_passes_when_only_multi_board_configured(tmp_path, monkeypatch):
+    """Empty legacy board config still validates if a multi-board instance has creds.
+
+    Regression for issue #1102: users who configured their board through the
+    multi-board Settings flow (not the first-run wizard) ended up with an empty
+    legacy ``config["board"]`` block. ``Config.validate()`` at startup would
+    fail with ``Board local_api_key/host is required``, even though the
+    multi-board settings service had a fully configured board. The service
+    would then sit in a 60s retry loop refusing to initialize.
+    """
+    config_path = tmp_path / "config.json"
+    config_data = {
+        "board": {"api_mode": "local", "local_api_key": "", "host": ""},
+        "features": {},
+        "general": {},
+    }
+    config_path.write_text(json.dumps(config_data))
+    cm = ConfigManager(config_path=str(config_path))
+
+    fake_board_settings = MagicMock()
+    fake_board_settings.boards = [
+        {"api_mode": "local", "local_api_key": "real-key", "host": "10.0.0.5"}
+    ]
+    fake_service = MagicMock()
+    fake_service.get_board_settings.return_value = fake_board_settings
+    monkeypatch.setattr(
+        "src.settings.service.get_settings_service", lambda: fake_service
+    )
+
+    valid, errors = cm.validate()
+    assert valid is True, f"expected valid config, got errors: {errors}"
+    assert not any("local_api_key" in e or "host" in e for e in errors)
+
+
+def test_validate_local_config_fails_when_multi_board_also_empty(tmp_path, monkeypatch):
+    """Legacy and multi-board both empty: validation still reports board errors."""
+    config_path = tmp_path / "config.json"
+    config_data = {
+        "board": {"api_mode": "local", "local_api_key": "", "host": ""},
+        "features": {},
+        "general": {},
+    }
+    config_path.write_text(json.dumps(config_data))
+    cm = ConfigManager(config_path=str(config_path))
+
+    fake_board_settings = MagicMock()
+    fake_board_settings.boards = [
+        {"api_mode": "local", "local_api_key": "", "host": ""}
+    ]
+    fake_service = MagicMock()
+    fake_service.get_board_settings.return_value = fake_board_settings
+    monkeypatch.setattr(
+        "src.settings.service.get_settings_service", lambda: fake_service
+    )
+
+    valid, errors = cm.validate()
+    assert valid is False
+    assert any("local_api_key" in e for e in errors)
+    assert any("host" in e for e in errors)
 
 
 def test_validate_enabled_weather_without_api_key(tmp_path):


### PR DESCRIPTION
## Summary

Fixes #1102 — backend service refused to start after every Watchtower upgrade unless the user re-ran the Setup Wizard.

**Root cause:** the startup-time validator (`Config.validate()` in `src/main.py` → `ConfigManager.validate()`) only checked the legacy single-board config block at `config["board"]`. Users who configured their board through the multi-board **Settings** flow (rather than the first-run wizard) had an empty legacy block, so the validator failed with:

```
Board local_api_key is required when api_mode is 'local'
Board host is required when api_mode is 'local'
```

Meanwhile the UI was happy because `/config/validate` (in `src/api_server.py`) *did* know to consult `settings.boards`, and `_build_board_clients()` in `src/main.py` also prefers `settings.boards` over the legacy `Config` block — so the service would actually run fine, if only it got past validation. Re-running the wizard repopulated the legacy block and broke the loop temporarily.

## Fix

`ConfigManager.validate()` now drops board-related errors when any board instance in the multi-board settings service has connection credentials — matching the behaviour `/config/validate` already implements. Single source of truth for "is a board configured": the same check the endpoint uses.

The autouse fixture in `tests/test_config_manager.py` is also extended to isolate the `SettingsService` singleton (and pre-seed an empty `ConfigManager`) so validation tests no longer depend on whatever board lives in the dev container's `data/` directory.

## Test plan

- [x] New `test_validate_local_config_passes_when_only_multi_board_configured` — empty legacy, multi-board has creds → valid
- [x] New `test_validate_local_config_fails_when_multi_board_also_empty` — both empty → still reports board errors
- [x] All 77 existing `test_config_manager.py` tests still pass
- [x] All 441 tests across `test_config*.py` + `test_api_*.py` still pass
- [ ] CI green (Python lint + tests, UI lint + tests, Playwright, Docker build)
- [ ] Manual: spin up a container with an empty `config.json` but a configured `settings.json` board → service starts without re-running the wizard

🤖 Generated with [Claude Code](https://claude.com/claude-code)