### PR TITLE
ci: skip docs auto-review on Dependabot PRs

### DIFF
--- a/.github/workflows/claude-docs-review.yml
+++ b/.github/workflows/claude-docs-review.yml
@@ -49,7 +49,13 @@ jobs:
     name: Claude reviews the docs diff
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: github.event.pull_request.draft == false
+    # Skip Dependabot PRs — they only bump dependency versions and never
+    # touch docs in a way this review can usefully critique. The job also
+    # can't post a review on them: Dependabot PRs receive a read-only
+    # GITHUB_TOKEN, so the gh api review POST 403s every time.
+    if: >-
+      github.event.pull_request.draft == false
+      && github.event.pull_request.user.login != 'dependabot[bot]'
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary
- Skip the **Claude: Docs Auto-Review** job on Dependabot PRs by gating the job's `if:` on `github.event.pull_request.user.login != 'dependabot[bot]'`.
- Dependabot PRs don't touch docs in a way this review can usefully critique, and the review can't post anyway — Dependabot PRs receive a read-only `GITHUB_TOKEN`, so the `gh api ... /reviews` POST 403s every run.

## Test plan
- [ ] Next Dependabot PR shows the `Claude: Docs Auto-Review / Claude reviews the docs diff` check as skipped (not failed).
- [ ] A human-authored docs PR still triggers the review normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)