### PR TITLE
chore: ignore Claude Code lock files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,9 @@ docs-site/.cache-loader/
 # Claude Code worktrees (per-user, ephemeral isolated checkouts).
 .claude/worktrees/
 
+# Claude Code lock files (runtime locks, e.g. scheduled task coordination).
+.claude/*.lock
+
 # Skill-creator eval workspaces (per-iteration test artifacts, not source).
 .claude/skills/*-workspace/
 


### PR DESCRIPTION
## Summary
- Claude Code writes runtime lock files (e.g. `.claude/scheduled_tasks.lock`) that showed up as untracked noise in `git status`. These are per-user runtime artifacts and shouldn't be committed.

## Changes
- Add `.claude/*.lock` to `.gitignore`. Worktrees (`.claude/worktrees/`) were already ignored.

## Test plan
- [x] `git status` no longer reports `.claude/scheduled_tasks.lock` as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)