### PR TITLE
docs: remove Fable 5 from AI_PROVIDERS recommended models

### DIFF
--- a/docs/setup/AI_PROVIDERS.md
+++ b/docs/setup/AI_PROVIDERS.md
@@ -64,8 +64,8 @@ The current preset list, sourced from `web/src/components/settings/ai-settings.t
      `data/config.json` and is masked (`***`) on read.
    - **Models** — type each model id and press Enter or click `+`.
      The format depends on your provider:
-     - OpenRouter: `openai/gpt-4o-mini`, `anthropic/claude-opus-4-8`, `anthropic/claude-fable-5`, `anthropic/claude-sonnet-4-6`, `anthropic/claude-haiku-4-5-20251001`
-     - Anthropic direct: `claude-fable-5`, `claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5-20251001`
+     - OpenRouter: `openai/gpt-4o-mini`, `anthropic/claude-opus-4-8`, `anthropic/claude-sonnet-4-6`, `anthropic/claude-haiku-4-5-20251001`
+     - Anthropic direct: `claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5-20251001`
      - OpenAI direct: `gpt-4o-mini`, `gpt-4o`
 
      See the **Recommended models** table below for a full list.
@@ -86,12 +86,10 @@ These all work well with the FiestaBoard prompt format. Any current chat-complet
 | ------------ | --------- | -------------------------------------- | --------------------------------------- |
 | OpenRouter   | OpenAI    | `openai/gpt-4o-mini`                   | Cheap, fast, reliable JSON output.      |
 | OpenRouter   | OpenAI    | `anthropic/claude-opus-4-8`            | Best quality, higher cost.              |
-| OpenRouter   | OpenAI    | `anthropic/claude-fable-5`             | High quality, higher cost.              |
 | OpenRouter   | OpenAI    | `anthropic/claude-sonnet-4-6`          | High-quality, moderate cost.            |
 | OpenRouter   | OpenAI    | `anthropic/claude-haiku-4-5-20251001`  | Cheap, fast Claude via OpenRouter.      |
 | OpenAI       | OpenAI    | `gpt-4o-mini`                          | Same as via OpenRouter.                 |
 | Anthropic    | Anthropic | `claude-opus-4-8`                      | Best quality; direct, no markup.        |
-| Anthropic    | Anthropic | `claude-fable-5`                       | High quality; direct, no markup.        |
 | Anthropic    | Anthropic | `claude-sonnet-4-6`                    | High-quality; direct, no markup.        |
 | Anthropic    | Anthropic | `claude-haiku-4-5-20251001`            | Cheaper, fast.                          |
 | Local Ollama | OpenAI    | `qwen2.5:14b-instruct` or larger       | Needs a model that follows JSON.        |


### PR DESCRIPTION
## Summary

We shouldn't be recommending Claude Fable 5 yet. This removes it from `docs/setup/AI_PROVIDERS.md`:

- Inline model examples (OpenRouter + Anthropic direct)
- The **Recommended models** table (OpenRouter + Anthropic rows)

No replacement needed — **Opus 4.8** is already listed adjacent in every location, so the recommendations still cover the top-quality tier.

This walks back the Fable 5 rows added in #1128 while keeping the Opus 4.8 additions intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)