### PR TITLE
feat(integrations): organize plugin Template Variables by group

### DIFF
--- a/web/app/routes/integrations._index.tsx
+++ b/web/app/routes/integrations._index.tsx
@@ -195,7 +195,7 @@ import {
   Zap,
 } from "lucide-react";
 import type { ReactNode } from "react";
-import { useEffect, useState } from "react";
+import { Fragment, useEffect, useState } from "react";
 import { toast } from "sonner";
 
 import { PageHeader } from "@/components/page-header";
@@ -254,6 +254,13 @@ import type { PluginInfo, RegistryEntry } from "@/lib/api";
 import { api } from "@/lib/api";
 import type { FiestaboardColorName } from "@/lib/board-colors";
 import { ALL_COLOR_CODES, AVAILABLE_COLORS, FIESTABOARD_COLORS } from "@/lib/board-colors";
+import {
+  buildVariablesList,
+  getVariableGroups,
+  groupVariableRows,
+  type PluginVariableRow,
+  type VariablesBlock,
+} from "@/lib/plugin-variables";
 import { cn } from "@/lib/utils";
 
 /**
@@ -1043,58 +1050,74 @@ function PluginCard({
     return required.every((field) => field === "enabled" || Boolean(config[field]));
   };
 
-  // Parse variables from plugin details - handles both array and object formats for variables.simple
-  const getVariablesList = () => {
-    if (!pluginDetails?.variables) return [];
-    const variables = pluginDetails.variables as {
-      simple?:
-        | string[]
-        | Record<string, { description?: string; max_length?: number; group?: string; example?: string }>;
-      arrays?: Record<string, { label_field: string; item_fields: string[] }>;
-    };
-    const list: Array<{ name: string; description: string; maxChars: number }> = [];
+  // Flatten the plugin's manifest variables into table rows, then read the
+  // declared groups so the table can be organized the same way the page-builder
+  // variable picker organizes them.
+  const variablesBlock = pluginDetails?.variables as VariablesBlock | undefined;
+  const variableRows = buildVariablesList(variablesBlock, pluginDetails?.max_lengths);
+  const variableGroups = getVariableGroups(variablesBlock);
+  const hasVariableGroups = Object.keys(variableGroups).length > 0;
 
-    if (variables.simple) {
-      if (Array.isArray(variables.simple)) {
-        variables.simple.forEach((name) => {
-          list.push({
-            name,
-            description: name.replace(/_/g, " "),
-            maxChars: pluginDetails.max_lengths?.[name] ?? 22,
-          });
-        });
-      } else {
-        Object.entries(variables.simple).forEach(([name, meta]) => {
-          list.push({
-            name,
-            description: meta.description ?? name.replace(/_/g, " "),
-            maxChars: pluginDetails.max_lengths?.[name] ?? meta.max_length ?? 22,
-          });
-        });
-      }
-    }
-
-    if (variables.arrays) {
-      Object.entries(variables.arrays).forEach(([arrayName, config]) => {
-        list.push({
-          name: `${arrayName}.{index}.${config.label_field}`,
-          description: `${arrayName} label`,
-          maxChars: pluginDetails.max_lengths?.[`${arrayName}.${config.label_field}`] ?? 22,
-        });
-        // Skip label_field in item_fields to avoid duplicate keys
-        config.item_fields
-          .filter((field) => field !== config.label_field)
-          .forEach((field) => {
-            list.push({
-              name: `${arrayName}.{index}.${field}`,
-              description: `${arrayName} ${field.replace(/_/g, " ")}`,
-              maxChars: pluginDetails.max_lengths?.[`${arrayName}.${field}`] ?? 22,
-            });
-          });
-      });
-    }
-
-    return list;
+  // Render one Template Variables row. Shared by the flat and grouped layouts so
+  // the two stay identical.
+  const renderVariableRow = (variable: PluginVariableRow) => {
+    const resolved = formatCurrentValue(
+      variable.name,
+      rawDisplay?.available ? (rawDisplay.data as Record<string, unknown>) : undefined,
+    );
+    return (
+      <tr
+        key={variable.name}
+        className="hover:bg-muted/30 cursor-pointer transition-colors"
+        onClick={() => handleCopyVar(variable.name)}
+      >
+        <td className="px-3 py-2 align-top">
+          <div className="flex items-center gap-1.5">
+            <code className="text-primary font-mono bg-primary/10 px-1.5 py-0.5 rounded text-[11px]">
+              {plugin.id}.{variable.name}
+            </code>
+            {copiedVar === variable.name ? (
+              <Check className="h-3 w-3 text-success" />
+            ) : (
+              <Copy className="h-3 w-3 text-muted-foreground" />
+            )}
+          </div>
+        </td>
+        <td className="px-3 py-2 text-muted-foreground capitalize align-top">{variable.description}</td>
+        <td className="px-3 py-2 align-top max-w-[200px]" onClick={(e) => e.stopPropagation()}>
+          {!plugin.enabled ? (
+            <span className="text-muted-foreground">—</span>
+          ) : isLoadingRawDisplay ? (
+            <Skeleton className="h-3 w-16" />
+          ) : rawDisplay && rawDisplay.available === false ? (
+            <span className="text-muted-foreground italic">Unavailable</span>
+          ) : resolved && resolved.short !== "" ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="flex items-center gap-1 truncate font-mono text-[11px]">
+                  {renderValueWithColors(resolved.short)}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent
+                side="top"
+                className="max-w-[360px] whitespace-pre-wrap break-words font-mono text-[11px]"
+              >
+                <span className="inline-flex flex-wrap items-center gap-1">
+                  {renderValueWithColors(resolved.full)}
+                </span>
+              </TooltipContent>
+            </Tooltip>
+          ) : (
+            <span className="text-muted-foreground">—</span>
+          )}
+        </td>
+        <td className="px-3 py-2 text-center align-top">
+          <Badge variant="outline" className="text-[10px]">
+            {variable.maxChars}
+          </Badge>
+        </td>
+      </tr>
+    );
   };
 
   // Use icon from plugin manifest, falling back to Puzzle
@@ -1238,7 +1261,7 @@ function PluginCard({
                 )}
 
               {/* Template Variables Section */}
-              {getVariablesList().length > 0 && (
+              {variableRows.length > 0 && (
                 <TooltipProvider delayDuration={200}>
                   <div className="space-y-3">
                     <h4 className="text-sm font-medium text-muted-foreground">
@@ -1272,67 +1295,22 @@ function PluginCard({
                           </tr>
                         </thead>
                         <tbody className="divide-y">
-                          {getVariablesList().map((variable) => {
-                            const resolved = formatCurrentValue(
-                              variable.name,
-                              rawDisplay?.available ? (rawDisplay.data as Record<string, unknown>) : undefined,
-                            );
-                            return (
-                              <tr
-                                key={variable.name}
-                                className="hover:bg-muted/30 cursor-pointer transition-colors"
-                                onClick={() => handleCopyVar(variable.name)}
-                              >
-                                <td className="px-3 py-2 align-top">
-                                  <div className="flex items-center gap-1.5">
-                                    <code className="text-primary font-mono bg-primary/10 px-1.5 py-0.5 rounded text-[11px]">
-                                      {plugin.id}.{variable.name}
-                                    </code>
-                                    {copiedVar === variable.name ? (
-                                      <Check className="h-3 w-3 text-success" />
-                                    ) : (
-                                      <Copy className="h-3 w-3 text-muted-foreground" />
-                                    )}
-                                  </div>
-                                </td>
-                                <td className="px-3 py-2 text-muted-foreground capitalize align-top">
-                                  {variable.description}
-                                </td>
-                                <td className="px-3 py-2 align-top max-w-[200px]" onClick={(e) => e.stopPropagation()}>
-                                  {!plugin.enabled ? (
-                                    <span className="text-muted-foreground">—</span>
-                                  ) : isLoadingRawDisplay ? (
-                                    <Skeleton className="h-3 w-16" />
-                                  ) : rawDisplay && rawDisplay.available === false ? (
-                                    <span className="text-muted-foreground italic">Unavailable</span>
-                                  ) : resolved && resolved.short !== "" ? (
-                                    <Tooltip>
-                                      <TooltipTrigger asChild>
-                                        <span className="flex items-center gap-1 truncate font-mono text-[11px]">
-                                          {renderValueWithColors(resolved.short)}
-                                        </span>
-                                      </TooltipTrigger>
-                                      <TooltipContent
-                                        side="top"
-                                        className="max-w-[360px] whitespace-pre-wrap break-words font-mono text-[11px]"
-                                      >
-                                        <span className="inline-flex flex-wrap items-center gap-1">
-                                          {renderValueWithColors(resolved.full)}
-                                        </span>
-                                      </TooltipContent>
-                                    </Tooltip>
-                                  ) : (
-                                    <span className="text-muted-foreground">—</span>
-                                  )}
-                                </td>
-                                <td className="px-3 py-2 text-center align-top">
-                                  <Badge variant="outline" className="text-[10px]">
-                                    {variable.maxChars}
-                                  </Badge>
-                                </td>
-                              </tr>
-                            );
-                          })}
+                          {hasVariableGroups
+                            ? groupVariableRows(variableRows, variableGroups, "General").map((section) => (
+                                <Fragment key={section.groupId ?? "__general__"}>
+                                  <tr className="bg-muted/40">
+                                    <th
+                                      scope="colgroup"
+                                      colSpan={4}
+                                      className="text-left px-3 py-1.5 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground"
+                                    >
+                                      {section.label}
+                                    </th>
+                                  </tr>
+                                  {section.rows.map(renderVariableRow)}
+                                </Fragment>
+                              ))
+                            : variableRows.map(renderVariableRow)}
                         </tbody>
                       </table>
                     </div>
@@ -1398,7 +1376,7 @@ function PluginCard({
               {/* No config message */}
               {(!pluginDetails?.settings_schema ||
                 Object.keys(pluginDetails.settings_schema.properties || {}).length === 0) &&
-                getVariablesList().length === 0 && (
+                variableRows.length === 0 && (
                   <p className="text-sm text-muted-foreground">No configuration options available for this plugin.</p>
                 )}
             </>

--- a/web/app/routes/integrations._index.tsx
+++ b/web/app/routes/integrations._index.tsx
@@ -1102,9 +1102,7 @@ function PluginCard({
                 side="top"
                 className="max-w-[360px] whitespace-pre-wrap break-words font-mono text-[11px]"
               >
-                <span className="inline-flex flex-wrap items-center gap-1">
-                  {renderValueWithColors(resolved.full)}
-                </span>
+                <span className="inline-flex flex-wrap items-center gap-1">{renderValueWithColors(resolved.full)}</span>
               </TooltipContent>
             </Tooltip>
           ) : (

--- a/web/src/__tests__/plugin-variables.test.ts
+++ b/web/src/__tests__/plugin-variables.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildVariablesList,
+  getVariableGroups,
+  groupVariableRows,
+  type PluginVariableRow,
+  type VariablesBlock,
+} from "@/lib/plugin-variables";
+
+describe("buildVariablesList", () => {
+  it("returns an empty list when variables are undefined", () => {
+    expect(buildVariablesList(undefined, undefined)).toEqual([]);
+  });
+
+  it("handles simple variables expressed as a string array (no group)", () => {
+    const variables: VariablesBlock = { simple: ["temp_high", "temp_low"] };
+
+    const rows = buildVariablesList(variables, undefined);
+
+    expect(rows).toEqual([
+      { name: "temp_high", description: "temp high", maxChars: 22, group: undefined },
+      { name: "temp_low", description: "temp low", maxChars: 22, group: undefined },
+    ]);
+  });
+
+  it("carries the group and description from object-form simple variables", () => {
+    const variables: VariablesBlock = {
+      groups: { time: { label: "Time" }, date: { label: "Date" } },
+      simple: {
+        time: { description: "Current time", group: "time", max_length: 5 },
+        weekday: { description: "Day of week", group: "date" },
+      },
+    };
+
+    const rows = buildVariablesList(variables, undefined);
+
+    expect(rows).toEqual([
+      { name: "time", description: "Current time", maxChars: 5, group: "time" },
+      { name: "weekday", description: "Day of week", maxChars: 22, group: "date" },
+    ]);
+  });
+
+  it("prefers max_lengths over meta.max_length over the 22 default", () => {
+    const variables: VariablesBlock = {
+      simple: {
+        a: { description: "A", max_length: 10 },
+        b: { description: "B", max_length: 10 },
+        c: { description: "C" },
+      },
+    };
+
+    const rows = buildVariablesList(variables, { a: 30 });
+
+    expect(rows.find((r) => r.name === "a")?.maxChars).toBe(30); // from max_lengths
+    expect(rows.find((r) => r.name === "b")?.maxChars).toBe(10); // from meta.max_length
+    expect(rows.find((r) => r.name === "c")?.maxChars).toBe(22); // default
+  });
+
+  it("expands array variables into label + item-field rows without a group", () => {
+    const variables: VariablesBlock = {
+      arrays: {
+        forecast: { label_field: "day", item_fields: ["day", "high", "low"] },
+      },
+    };
+
+    const rows = buildVariablesList(variables, { "forecast.high": 4 });
+
+    expect(rows).toEqual([
+      { name: "forecast.{index}.day", description: "forecast label", maxChars: 22, group: undefined },
+      { name: "forecast.{index}.high", description: "forecast high", maxChars: 4, group: undefined },
+      { name: "forecast.{index}.low", description: "forecast low", maxChars: 22, group: undefined },
+    ]);
+  });
+});
+
+describe("getVariableGroups", () => {
+  it("returns the groups map when present", () => {
+    const groups = { time: { label: "Time" } };
+    expect(getVariableGroups({ groups })).toEqual(groups);
+  });
+
+  it("returns an empty object when groups are absent or variables undefined", () => {
+    expect(getVariableGroups({})).toEqual({});
+    expect(getVariableGroups(undefined)).toEqual({});
+  });
+});
+
+describe("groupVariableRows", () => {
+  const rows: PluginVariableRow[] = [
+    { name: "time", description: "Current time", maxChars: 5, group: "time" },
+    { name: "hour", description: "Hour", maxChars: 2, group: "time" },
+    { name: "weekday", description: "Weekday", maxChars: 9, group: "date" },
+    { name: "raw", description: "Raw", maxChars: 22, group: undefined },
+  ];
+
+  it("orders sections by the manifest group order and appends ungrouped under the general label", () => {
+    const groups = { date: { label: "Date" }, time: { label: "Time" } };
+
+    const sections = groupVariableRows(rows, groups, "General");
+
+    expect(sections.map((s) => s.label)).toEqual(["Date", "Time", "General"]);
+    expect(sections[0].rows.map((r) => r.name)).toEqual(["weekday"]);
+    expect(sections[1].rows.map((r) => r.name)).toEqual(["time", "hour"]);
+    expect(sections[2]).toMatchObject({ groupId: null, label: "General" });
+    expect(sections[2].rows.map((r) => r.name)).toEqual(["raw"]);
+  });
+
+  it("skips groups that have no matching variables", () => {
+    const groups = { time: { label: "Time" }, empty: { label: "Empty" } };
+
+    const sections = groupVariableRows(rows, groups, "General");
+
+    expect(sections.map((s) => s.label)).not.toContain("Empty");
+  });
+
+  it("treats a variable whose group is not defined as ungrouped", () => {
+    const orphan: PluginVariableRow[] = [{ name: "x", description: "x", maxChars: 1, group: "missing" }];
+
+    const sections = groupVariableRows(orphan, { time: { label: "Time" } }, "General");
+
+    expect(sections).toEqual([{ groupId: null, label: "General", rows: orphan }]);
+  });
+
+  it("puts every row under the general section when no groups are defined", () => {
+    const sections = groupVariableRows(rows, {}, "General");
+
+    expect(sections).toHaveLength(1);
+    expect(sections[0]).toMatchObject({ groupId: null, label: "General" });
+    expect(sections[0].rows).toEqual(rows);
+  });
+
+  it("omits the general section when every row belongs to a defined group", () => {
+    const grouped: PluginVariableRow[] = [{ name: "time", description: "t", maxChars: 5, group: "time" }];
+
+    const sections = groupVariableRows(grouped, { time: { label: "Time" } }, "General");
+
+    expect(sections.map((s) => s.label)).toEqual(["Time"]);
+  });
+});

--- a/web/src/lib/plugin-variables.ts
+++ b/web/src/lib/plugin-variables.ts
@@ -1,0 +1,156 @@
+// Helpers for turning a plugin's manifest `variables` block into the rows shown
+// in the Integrations config sheet's "Template Variables" table, and for
+// organizing those rows by their declared groups — mirroring how the page
+// builder variable picker (VariablePickerContent) groups them.
+
+/** A single declared group, e.g. `{ label: "Time" }`. */
+export interface VariableGroupDef {
+  label: string;
+}
+
+/** Per-variable metadata as declared in the manifest's `variables.simple` map. */
+export interface SimpleVariableMeta {
+  description?: string;
+  type?: string;
+  max_length?: number;
+  group?: string;
+  example?: string;
+}
+
+/** Shape of a plugin's manifest `variables` block (as returned by /plugins/{id}). */
+export interface VariablesBlock {
+  groups?: Record<string, VariableGroupDef>;
+  simple?: string[] | Record<string, SimpleVariableMeta>;
+  arrays?: Record<string, { label_field: string; item_fields: string[] }>;
+}
+
+/** A row in the Template Variables table. */
+export interface PluginVariableRow {
+  name: string;
+  description: string;
+  maxChars: number;
+  /** Group id from the manifest, when declared. Array-derived rows are ungrouped. */
+  group?: string;
+}
+
+/** A contiguous section of the table: a declared group, or the ungrouped bucket. */
+export interface VariableGroupSection {
+  /** Group id, or `null` for the ungrouped ("General") bucket. */
+  groupId: string | null;
+  label: string;
+  rows: PluginVariableRow[];
+}
+
+const DEFAULT_MAX_CHARS = 22;
+
+const humanize = (s: string): string => s.replace(/_/g, " ");
+
+/**
+ * Flatten a plugin's `variables` block into table rows.
+ *
+ * Handles both shapes of `variables.simple` (a plain `string[]` or a metadata
+ * map) and expands `variables.arrays` into `name.{index}.field` rows. Simple
+ * variables carry their declared `group`; array-derived rows have none.
+ */
+export function buildVariablesList(
+  variables: VariablesBlock | undefined,
+  maxLengths: Record<string, number> | undefined,
+): PluginVariableRow[] {
+  if (!variables) return [];
+
+  const rows: PluginVariableRow[] = [];
+  const maxFor = (key: string, fallback: number): number => maxLengths?.[key] ?? fallback;
+
+  const { simple, arrays } = variables;
+
+  if (simple) {
+    if (Array.isArray(simple)) {
+      for (const name of simple) {
+        rows.push({
+          name,
+          description: humanize(name),
+          maxChars: maxFor(name, DEFAULT_MAX_CHARS),
+          group: undefined,
+        });
+      }
+    } else {
+      for (const [name, meta] of Object.entries(simple)) {
+        rows.push({
+          name,
+          description: meta.description ?? humanize(name),
+          maxChars: maxFor(name, meta.max_length ?? DEFAULT_MAX_CHARS),
+          group: meta.group,
+        });
+      }
+    }
+  }
+
+  if (arrays) {
+    for (const [arrayName, config] of Object.entries(arrays)) {
+      rows.push({
+        name: `${arrayName}.{index}.${config.label_field}`,
+        description: `${arrayName} label`,
+        maxChars: maxFor(`${arrayName}.${config.label_field}`, DEFAULT_MAX_CHARS),
+        group: undefined,
+      });
+      // Skip the label field in item_fields to avoid duplicate keys.
+      for (const field of config.item_fields.filter((f) => f !== config.label_field)) {
+        rows.push({
+          name: `${arrayName}.{index}.${field}`,
+          description: `${arrayName} ${humanize(field)}`,
+          maxChars: maxFor(`${arrayName}.${field}`, DEFAULT_MAX_CHARS),
+          group: undefined,
+        });
+      }
+    }
+  }
+
+  return rows;
+}
+
+/** The declared groups for a plugin, or an empty object when none are declared. */
+export function getVariableGroups(variables: VariablesBlock | undefined): Record<string, VariableGroupDef> {
+  return variables?.groups ?? {};
+}
+
+/**
+ * Organize rows into sections following the manifest's group order, dropping
+ * groups with no matching rows. Rows with no group (or a group not declared in
+ * `groups`) are collected into a trailing "General" section labelled
+ * `generalLabel`. When no groups are declared, every row lands in that single
+ * General section.
+ */
+export function groupVariableRows(
+  rows: PluginVariableRow[],
+  groups: Record<string, VariableGroupDef>,
+  generalLabel: string,
+): VariableGroupSection[] {
+  const byGroup = new Map<string, PluginVariableRow[]>();
+  const ungrouped: PluginVariableRow[] = [];
+
+  for (const row of rows) {
+    if (row.group && groups[row.group]) {
+      const bucket = byGroup.get(row.group);
+      if (bucket) {
+        bucket.push(row);
+      } else {
+        byGroup.set(row.group, [row]);
+      }
+    } else {
+      ungrouped.push(row);
+    }
+  }
+
+  const sections: VariableGroupSection[] = [];
+  for (const [groupId, def] of Object.entries(groups)) {
+    const groupRows = byGroup.get(groupId);
+    if (groupRows && groupRows.length > 0) {
+      sections.push({ groupId, label: def.label, rows: groupRows });
+    }
+  }
+  if (ungrouped.length > 0) {
+    sections.push({ groupId: null, label: generalLabel, rows: ungrouped });
+  }
+
+  return sections;
+}

--- a/web/tests/regression/integrations-plugin-config.spec.ts
+++ b/web/tests/regression/integrations-plugin-config.spec.ts
@@ -269,6 +269,35 @@ test.describe("regression: integrations.plugin (config sheet + lifecycle)", () =
   });
 
   /**
+   * UX node: integrations.plugin.config-sheet.template-vars.grouped
+   * Route: /integrations (sheet)
+   * Preconditions: plugin:enabled, plugin:exposes-variables, manifest declares variables.groups
+   * Expected: the Template Variables table is organized under the plugin's
+   *   declared group labels (mirroring the page-builder variable picker), and
+   *   grouped variables still render as copyable rows beneath their group.
+   * Issue: https://github.com/Fiestaboard/FiestaBoard/issues/1104
+   */
+  test("integrations.plugin.config-sheet.template-vars — organized by manifest group", async ({ page }) => {
+    await openConfigSheet(page);
+
+    await expect(page.getByRole("heading", { name: /Template Variables/i })).toBeVisible({ timeout: 15_000 });
+
+    const dialog = page.locator('[role="dialog"]');
+    const varsTable = dialog.locator("table").filter({ hasText: "Current Value" }).filter({ hasText: "Max" });
+    await expect(varsTable).toBeVisible({ timeout: 5_000 });
+
+    // date_time's manifest declares variables.groups = Time / Date / Formatted.
+    // Each non-empty group becomes a sub-header (a colgroup header cell) in the table.
+    for (const label of ["Time", "Date", "Formatted"]) {
+      await expect(varsTable.getByRole("columnheader", { name: label, exact: true })).toBeVisible();
+    }
+
+    // A grouped variable still renders as a copyable row beneath its group header.
+    const timeRow = varsTable.getByRole("row", { name: new RegExp(`^${TEST_PLUGIN_ID}\\.time `) });
+    await expect(timeRow).toBeVisible({ timeout: 5_000 });
+  });
+
+  /**
    * UX node: integrations.plugin.config-sheet.template-vars.unconfigured
    * Route: /integrations (sheet)
    * Preconditions: plugin:enabled, raw-display:unavailable (missing config / fetch error)


### PR DESCRIPTION
Closes #1104.

## Summary

The plugin **Configuration sheet** (Integrations → Configure) listed Template Variables as one flat table. The Page Builder's variable picker already organizes those same variables under their declared `variables.groups` labels — this brings the identical organization to the config sheet.

| Before | After |
|--------|-------|
| One flat list of every variable | Variables grouped under their manifest group labels (e.g. **Time / Date / Formatted**), in manifest order |

## What changed

- **Extracted the variable logic into a pure, testable module** — `web/src/lib/plugin-variables.ts`:
  - `buildVariablesList()` — flattens the manifest `variables` block into table rows (same logic as before) and now carries each variable's `group`.
  - `getVariableGroups()` — reads the declared `variables.groups`.
  - `groupVariableRows()` — orders sections by manifest group order, drops empty groups, and collects ungrouped / unknown-group rows into a trailing **General** section.
- **Rendering** (`web/app/routes/integrations._index.tsx`): group sub-headers are rendered as `colgroup` header rows *inside the existing table*, so column alignment is preserved and the live "Current Value" / "Max" columns keep working. The per-row JSX was lifted into a shared `renderVariableRow` helper used by both layouts.
- **Backward compatible**: plugins that declare no groups render flat exactly as before. No array plugin declares groups; array-derived variables fall under **General** when groups exist.

No backend change was needed — `/plugins/{id}` already returns the full manifest `variables` block (including `groups`).

## Testing

- ✅ 12 new unit tests for the grouping helpers (`web/src/__tests__/plugin-variables.test.ts`)
- ✅ Full web unit suite green (1065 passed, 0 failed)
- ✅ `typecheck` introduces no new errors; `lint` exits 0
- ✅ Added a regression assertion that the `date_time` config sheet shows its **Time / Date / Formatted** group headers (`web/tests/regression/integrations-plugin-config.spec.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)