### PR TITLE
feat(a11y-audit): scaffold Claude accessibility audit feedback loop

### DIFF
--- a/.github/a11y-audit-state.json
+++ b/.github/a11y-audit-state.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": 1,
+  "round": 0,
+  "round_started_at": null,
+  "last_run_at": null,
+  "files_remaining": [],
+  "files_audited": []
+}

--- a/.github/a11y-audit/README.md
+++ b/.github/a11y-audit/README.md
@@ -24,7 +24,7 @@ This folder is the bot's memory of those teaching moments.
 
 ## How it works
 
-1. **`claude-a11y-audit-feedback.yml`** triggers on `pull_request.closed`. If
+1. **`claude-a11y-audit-feedback.yml`** triggers on `pull_request_target.closed`. If
    the PR is unmerged and the head branch starts with `a11y/issue-` (triage
    fix PRs) or `a11y-audit/` (reserved for any future inline-fix PRs), it
    runs `build_rejection.py` to bundle the PR's diff + every comment,

--- a/.github/a11y-audit/README.md
+++ b/.github/a11y-audit/README.md
@@ -1,0 +1,84 @@
+# A11y Audit Feedback Loop
+
+Two finders sweep the FiestaBoard web UI for WCAG 2.2 AA / accessibility
+issues on a recurring schedule and file labeled issues:
+
+- **`.github/workflows/claude-a11y-audit.yml`** — a weekly static sweep that
+  reads `web/src/**/*.tsx` and flags accessibility anti-patterns in the
+  source (missing `aria-label`s, non-semantic interactive elements,
+  hardcoded labels that should go through `next-intl`, heading-order
+  problems, unlabeled form controls, color-only state, focus management).
+- **`.github/workflows/claude-a11y-live-axe.yml`** — a weekly live run that
+  boots the container and runs `axe-core` (via the existing
+  `web/tests/a11y.spec.ts`) against the main routes, then triages the
+  violations into the same issues.
+
+Every finding becomes an issue labeled `a11y` + `a11y-audit` + `claude-fix`.
+The shared **`claude-issue-triage.yml`** worker picks those up by label and
+opens a focused `a11y/issue-*` fix PR. Those PRs are auto-reviewed by
+**`claude-a11y-audit-review.yml`**. Sometimes a fix is wrong — when that
+happens, the maintainer closes the PR without merging.
+
+**Closing an `a11y/issue-*` PR without merging is the teaching action.**
+This folder is the bot's memory of those teaching moments.
+
+## How it works
+
+1. **`claude-a11y-audit-feedback.yml`** triggers on `pull_request.closed`. If
+   the PR is unmerged and the head branch starts with `a11y/issue-` (triage
+   fix PRs) or `a11y-audit/` (reserved for any future inline-fix PRs), it
+   runs `build_rejection.py` to bundle the PR's diff + every comment,
+   review, and inline comment into a single JSON object, appends that object
+   as one line to `rejected-edits.jsonl`, and commits the change to `main`.
+2. **The audit prompt** reads `rejected-edits.jsonl` at the start of every
+   run. The bot is instructed to (a) never re-file the same finding it
+   already proposed and got rejected, and (b) generalize from the human's
+   close comment (e.g. "this element is intentionally decorative" → stop
+   flagging that class of element everywhere).
+3. **Re-running capture** is idempotent. If the maintainer adds an
+   explanatory comment after closing, dispatch
+   `claude-a11y-audit-feedback.yml` with the PR number and the existing line
+   is replaced.
+
+## Why two finders, one label
+
+The static sweep reads source and catches issues that only exist in the code
+(an icon `<button>` with no label, a `<div onClick>` that should be a
+`<button>`, an English `aria-label` literal). The live axe run catches issues
+that only appear at runtime (computed contrast, ARIA wiring after hydration,
+focus order on a real DOM). They overlap deliberately and both file under
+`a11y-audit`, so the dedup, triage, review, and rejection-learning machinery
+is shared — one queue, one memory.
+
+## File: `rejected-edits.jsonl`
+
+One JSON object per line. Schema:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `pr` | int | PR number. Acts as the primary key — re-capture replaces the prior line. |
+| `title` | string | Original PR title. |
+| `head_ref` | string | `a11y/issue-<N>-<slug>` (triage fix PR) or `a11y-audit/round-<n>-run-<id>` (reserved). |
+| `closed_at` | string | ISO 8601. |
+| `author` | string | `github-actions[bot]` / `claude` for the bot, or whoever pushed. |
+| `body` | string | PR description as opened by the bot. |
+| `files` | array | `[{path, patch}]` — raw unified diff per file. |
+| `comments` | array | Issue-style PR comments: `{author, body, created_at}`. |
+| `reviews` | array | Review-level comments. |
+| `inline_comments` | array | Per-line review comments. |
+
+## File: `build_rejection.py`
+
+Script the feedback workflow runs. Can be invoked locally with `DRY_RUN=1`
+to print the record to stdout without modifying the log:
+
+```bash
+DRY_RUN=1 python3 .github/a11y-audit/build_rejection.py 1234
+```
+
+## Manually clearing a stale rejection
+
+If a rejected fix is later determined to have been correct (the close was
+wrong, or the UI changed and the fix now makes sense), hand-delete that line
+from `rejected-edits.jsonl` and commit. The file is plain JSONL; any text
+editor can do this.

--- a/.github/a11y-audit/build_rejection.py
+++ b/.github/a11y-audit/build_rejection.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Capture why an a11y-audit PR was closed without merging.
+
+Run as: build_rejection.py <pr_number>
+
+Reads the PR's metadata, full diff, every comment / review / inline comment
+via `gh`, then writes one JSONL line into
+`.github/a11y-audit/rejected-edits.jsonl`. The next a11y-audit cron run
+loads that file and uses it to avoid re-filing the same false-positive
+finding and to generalize from the closer's explanation (e.g. "this <div>
+is intentionally non-interactive — don't keep flagging it as needing a
+button role").
+
+Idempotent: a re-run for the same PR replaces that PR's existing line
+rather than appending a duplicate. This lets the GitHub Action be
+triggered manually (workflow_dispatch) after a user has added a later
+explanatory comment without polluting the log.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+LOG_PATH = Path(".github/a11y-audit/rejected-edits.jsonl")
+
+
+def gh_json(*args: str):
+    out = subprocess.check_output(["gh", *args], text=True)
+    return json.loads(out)
+
+
+def gh_text(*args: str) -> str:
+    return subprocess.check_output(["gh", *args], text=True)
+
+
+def parse_diff(diff: str) -> list[dict]:
+    """Split a unified diff into per-file `{path, patch}` records."""
+    files: list[dict] = []
+    current: dict | None = None
+    for line in diff.splitlines():
+        if line.startswith("diff --git "):
+            if current is not None:
+                current["patch"] = "\n".join(current["patch"])
+                files.append(current)
+            # `diff --git a/path b/path` — take everything after ` b/`.
+            path = line.split(" b/", 1)[-1] if " b/" in line else line
+            current = {"path": path, "patch": [line]}
+        elif current is not None:
+            current["patch"].append(line)
+    if current is not None:
+        current["patch"] = "\n".join(current["patch"])
+        files.append(current)
+    return files
+
+
+def build_record(pr: str) -> dict:
+    meta = gh_json(
+        "pr", "view", pr,
+        "--json", "number,title,headRefName,closedAt,author,body,state",
+    )
+    if meta.get("state") == "MERGED":
+        raise SystemExit(f"PR #{pr} was merged — refusing to record as rejection.")
+
+    diff = gh_text("pr", "diff", pr)
+    files = parse_diff(diff)
+
+    repo = subprocess.check_output(
+        ["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"],
+        text=True,
+    ).strip()
+
+    issue_comments = gh_json(
+        "api", f"repos/{repo}/issues/{pr}/comments",
+        "--jq", "[.[] | {author: .user.login, body: .body, created_at: .created_at}]",
+    )
+    reviews = gh_json(
+        "api", f"repos/{repo}/pulls/{pr}/reviews",
+        "--jq",
+        '[.[] | select((.body // "") != "") | '
+        '{author: .user.login, body: .body, state: .state, submitted_at: .submitted_at}]',
+    )
+    inline = gh_json(
+        "api", f"repos/{repo}/pulls/{pr}/comments",
+        "--jq",
+        "[.[] | {author: .user.login, body: .body, path: .path, "
+        "created_at: .created_at, diff_hunk: .diff_hunk}]",
+    )
+
+    return {
+        "pr": meta["number"],
+        "title": meta["title"],
+        "head_ref": meta["headRefName"],
+        "closed_at": meta["closedAt"],
+        "author": (meta.get("author") or {}).get("login"),
+        "body": meta.get("body") or "",
+        "comments": issue_comments,
+        "reviews": reviews,
+        "inline_comments": inline,
+        "files": files,
+    }
+
+
+def write_log(record: dict, path: Path = LOG_PATH) -> None:
+    """Replace any prior line for this PR; append the new one."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing: list[str] = []
+    if path.exists():
+        existing = [ln for ln in path.read_text().splitlines() if ln.strip()]
+
+    def keep(line: str) -> bool:
+        try:
+            return json.loads(line).get("pr") != record["pr"]
+        except json.JSONDecodeError:
+            # Preserve hand-edited / malformed lines rather than silently dropping.
+            return True
+
+    kept = [ln for ln in existing if keep(ln)]
+    kept.append(json.dumps(record, ensure_ascii=False, separators=(",", ":")))
+    path.write_text("\n".join(kept) + "\n")
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        sys.exit("usage: build_rejection.py <pr_number>")
+    pr = sys.argv[1]
+    record = build_record(pr)
+    if os.environ.get("DRY_RUN") == "1":
+        print(json.dumps(record, ensure_ascii=False, indent=2))
+        return
+    write_log(record)
+    print(f"Captured PR #{record['pr']} into {LOG_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/claude-a11y-audit-feedback.yml
+++ b/.github/workflows/claude-a11y-audit-feedback.yml
@@ -1,0 +1,107 @@
+name: 'Claude: A11y Audit Feedback Capture'
+
+# =============================================================================
+# Captures rejected a11y-pipeline PRs so the cron auditor can learn from them.
+#
+# The a11y loop is issues-only, so the PRs that feed it come from the triage
+# worker:
+#   - `a11y/issue-*` — per-issue fix PRs from claude-issue-triage.yml (which
+#     fixes the issues the a11y-audit / a11y-live-axe sweeps file)
+#   - `a11y-audit/*` — reserved for any future inline-fix PRs from the sweep
+#     itself (none today; kept so the loop survives re-enabling bucket A)
+#
+# When either is closed without merging, the maintainer is telling the bot
+# "this fix (or the finding behind it) was wrong." This workflow bundles the
+# PR's diff, close metadata, and every comment/review into a single JSONL
+# line in .github/a11y-audit/rejected-edits.jsonl and commits it to main. The
+# next sweep reads the log and (a) never re-files the rejected finding, and
+# (b) generalizes from the closer's explanation.
+#
+# `workflow_dispatch` re-runs capture for a given PR — useful when a
+# maintainer adds an explanatory comment after the original close. Re-running
+# replaces the prior line for that PR rather than appending.
+#
+# Trigger is `pull_request_target` (not `pull_request`) so GitHub resolves
+# this workflow file from `main` rather than the PR's head ref. Branches cut
+# from `main` before this workflow existed would otherwise be invisible to
+# it. Safe here because the workflow checks out `main` (not PR code) and only
+# reads PR metadata via `gh`; no head-ref code is ever executed.
+# =============================================================================
+
+on:
+  pull_request_target:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to (re)capture into the rejection log'
+        required: true
+        type: number
+
+permissions:
+  contents: read
+
+# Serialize commits to main. Two PRs closed at once would race the same log
+# file and lose a line; cancel-in-progress=false so each capture completes.
+concurrency:
+  group: a11y-audit-feedback
+  cancel-in-progress: false
+
+jobs:
+  capture:
+    name: Capture rejected a11y edit
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # On `pull_request_target.closed`, only fire for unmerged a11y-pipeline
+    # branches. Draft and ready-for-review PRs both fire `closed`. The script
+    # itself refuses to log a merged PR, so manual backfill stays safe.
+    if: >-
+      ${{ github.event_name == 'workflow_dispatch' ||
+          (github.event.pull_request.merged == false &&
+           (startsWith(github.event.pull_request.head.ref, 'a11y/issue-') ||
+            startsWith(github.event.pull_request.head.ref, 'a11y-audit/'))) }}
+    permissions:
+      contents: write
+      pull-requests: read
+      issues: read
+    steps:
+      - name: Determine PR number
+        id: pr
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "number=${{ inputs.pr_number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          # RELEASE_PAT so the log commit can push to main past branch
+          # protection — same pattern as the state-file commit.
+          ref: main
+          token: ${{ secrets.RELEASE_PAT }}
+          fetch-depth: 1
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Capture rejection
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        run: |
+          set -euo pipefail
+          python3 .github/a11y-audit/build_rejection.py "${{ steps.pr.outputs.number }}"
+
+      - name: Commit and push
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- .github/a11y-audit/rejected-edits.jsonl; then
+            echo "Log unchanged — script bailed (merged PR, or no diff)."
+            exit 0
+          fi
+          git add .github/a11y-audit/rejected-edits.jsonl
+          git commit -m "chore(a11y-audit): capture rejection from PR #${{ steps.pr.outputs.number }} [skip ci]"
+          git push origin HEAD:main

--- a/.github/workflows/claude-a11y-audit-review.yml
+++ b/.github/workflows/claude-a11y-audit-review.yml
@@ -1,0 +1,155 @@
+name: 'Claude: A11y Auto-Review'
+
+# =============================================================================
+# Auto-runs a Claude ACCESSIBILITY review on any PR that touches the web UI
+# (`web/src/**/*.tsx`) or its translations (`web/messages/**`). Posts ONE
+# review comment focused only on the a11y dimension — general code review is
+# handled by other workflows. This is the quality gate on the a11y-fix
+# pipeline (triage-worker `a11y/issue-*` PRs) and on human UI PRs alike.
+#
+# `pull_request_target` runs from the base ref's workflow definition, so
+# malicious head-branch edits to this workflow file can't fire. We only check
+# out the BASE ref — never the PR head — per the CodeQL
+# `actions/untrusted-checkout` rule (the "pwn-request" pattern). PR head
+# content is read read-only via `gh api .../contents/<path>?ref=<head_sha>`
+# from inside the prompt: bytes piped through Claude as data, never
+# materialized where a later step could execute them. Belt and braces:
+# `--allowed-tools` is read-only (no Edit/Write, no git push, no PR state
+# changes).
+#
+# Draft PRs are skipped; the trigger includes `ready_for_review` so the
+# review fires when the author flips draft → ready.
+# =============================================================================
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'web/src/**/*.tsx'
+      - 'web/messages/**'
+
+permissions:
+  contents: read
+
+# Cancel a prior review for the same PR when a new push comes in — only the
+# latest diff matters and we don't want two reviews racing the same comment.
+concurrency:
+  group: claude-a11y-audit-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: Claude reviews the a11y diff
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Skip drafts and Dependabot (its read-only token can't post a review).
+    if: >-
+      github.event.pull_request.draft == false
+      && github.event.pull_request.user.login != 'dependabot[bot]'
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout base ref (trusted)
+        uses: actions/checkout@v6
+        with:
+          # pull_request_target grants secrets — never check out PR head.
+          # Base ref gives Claude the trusted CLAUDE.md / a11y conventions /
+          # en.json reference. PR head content is read via
+          # `gh api .../contents/<path>?ref=<head_sha>` from inside the
+          # prompt — data piped through Claude, never executed.
+          ref: ${{ github.event.pull_request.base.ref }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Run Claude review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Skip the OIDC→claude[bot] App-token exchange and post under the
+          # workflow's own GITHUB_TOKEN. On pull_request_target the App
+          # exchange returns `401 Invalid OIDC token`; github_token bypasses
+          # it. Cost: review badge is `github-actions[bot]` — which is why the
+          # feedback-capture allowlists both bots.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Bot-authored PRs (triage worker) need reviewing too — the point.
+          allowed_bots: 'claude,github-actions'
+          show_full_output: 'true'
+          claude_args: >-
+            --model claude-sonnet-4-6
+            --max-turns 40
+            --allowed-tools "Read,Glob,Grep,Bash(ls:*),Bash(cat:*),Bash(find:*),Bash(grep:*),Bash(rg:*),Bash(jq:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api:*)"
+          prompt: |
+            You are the FiestaBoard **accessibility reviewer**. Review PR
+            #${{ github.event.pull_request.number }} — only the ACCESSIBILITY
+            of the web UI changes it makes. Skim non-a11y aspects for context
+            but don't review them; other workflows handle general code review.
+
+            ## Important — workspace is at BASE, not PR head
+
+            The workflow checked out the trusted base ref (CodeQL
+            untrusted-checkout rule), so `cat`/`Read`/`ls` see BASE content
+            (useful for CLAUDE.md, the a11y conventions, and the baseline
+            `web/messages/en.json`). Read the PR's version of a file via:
+
+                gh api \
+                  "repos/${{ github.repository }}/contents/<path>?ref=${{ github.event.pull_request.head.sha }}" \
+                  -H "Accept: application/vnd.github.raw"
+
+            That returns raw bytes (data only — never executed). Never
+            `git checkout` the PR head.
+
+            ## How to review
+
+            1. Run `gh pr diff ${{ github.event.pull_request.number }}` to see
+               the diff. Focus on `web/src/**/*.tsx` and `web/messages/**`.
+            2. For the changed TSX, check the a11y dimension against
+               FiestaBoard conventions (the axe baseline is
+               `web/tests/a11y.spec.ts`; WCAG bar is 2.2 AA):
+               - **Accessible names.** Every interactive element has one —
+                 icon-only `<button>`s need an `aria-label`; form controls
+                 need an associated label. (WCAG 4.1.2 / 1.3.1)
+               - **Semantics.** `<button>`/`<a href>` over
+                 `<div role="button">`; no `onClick` on a non-interactive
+                 element without role + keyboard support. (WCAG 2.1.1 / 4.1.2)
+               - **Strings via next-intl.** Any new user-facing string —
+                 including `aria-label`, `title`, `alt`, placeholders — must
+                 come from a `next-intl` key, NOT a hardcoded English literal.
+                 If the PR adds a key, confirm it exists in
+                 `web/messages/en.json` (fetch the PR's version via the
+                 `gh api` contents call). Flag a hardcoded literal loudly.
+               - **Headings & landmarks.** No skipped heading levels, single
+                 `<h1>`, headings not used purely for styling. (WCAG 1.3.1)
+               - **Images / icons.** Meaningful images have `alt`; decorative
+                 ones are `aria-hidden`. (WCAG 1.1.1)
+               - **Focus & dynamic regions.** Custom widgets move/trap/restore
+                 focus; toasts / async results announce via `role="status"` or
+                 `aria-live`. (WCAG 2.4.3 / 4.1.3)
+               - **Don't fail on color-contrast** — it's excluded from the
+                 axe gate; mention as a low-priority note only.
+            3. For `web/messages/**` changes, sanity-check that a11y-relevant
+               keys (labels) read naturally and aren't left as raw English in
+               non-English locale files.
+
+            ## Output — post ONE review
+
+            Post a single review via `gh pr review`:
+
+                gh pr review ${{ github.event.pull_request.number }} --comment --body "<markdown>"
+
+            Lead the body with a one-line **verdict** (e.g. "no a11y concerns"
+            / "small a11y fixes" / "a11y blockers"), then list findings with
+            `file:line` references and the WCAG criterion for each. For a
+            single-line fix with an obvious replacement you may include a
+            ```` ```suggestion ```` block. If the PR is clean from an a11y
+            standpoint, say so briefly — don't manufacture findings.
+
+            ## Hard rules
+
+            - Review only. Never APPROVE / REQUEST_CHANGES — always a plain
+              `--comment`. Sign-off stays human.
+            - No file edits, no pushes, no PR state changes.
+            - One review per run. If you'd post a second, consolidate.
+            - Stay on the a11y dimension. Don't review unrelated code.

--- a/.github/workflows/claude-a11y-audit.yml
+++ b/.github/workflows/claude-a11y-audit.yml
@@ -1,0 +1,482 @@
+name: 'Claude: A11y Audit'
+
+# =============================================================================
+# Weekly America/Los_Angeles static accessibility sweep of the web UI source
+# by Claude Sonnet. Reads `web/src/**/*.tsx` in batches and FILES ISSUES for
+# WCAG 2.2 AA / accessibility problems it finds in the source — missing
+# `aria-label`s, non-semantic interactive elements, hardcoded user-facing
+# strings that should go through next-intl, heading-order problems, unlabeled
+# form controls, color-only state, focus-management gaps.
+#
+# This loop is ISSUES-ONLY: the sweep does NOT open code PRs itself (an a11y
+# fix nearly always touches TSX + 14 i18n locale files, so it's never a true
+# one-line mechanical edit). Every finding becomes a `a11y` + `a11y-audit` +
+# `claude-fix` labeled issue, and the shared claude-issue-triage.yml worker
+# opens a focused `a11y/issue-*` fix PR for each. Those PRs are auto-reviewed
+# by claude-a11y-audit-review.yml; rejections feed
+# .github/a11y-audit/rejected-edits.jsonl, which this sweep reads next run.
+#
+# A companion workflow (claude-a11y-live-axe.yml) catches RUNTIME a11y issues
+# by booting the app and running axe-core; it files into the same labels so
+# the dedup / triage / review / learning machinery is shared.
+#
+# Cadence: Monday noon PT. Each cron pair fires in UTC to absorb DST drift;
+# the local-hour gate below admits exactly the noon window. workflow_dispatch
+# always proceeds.
+#
+# Effort scales with the open `a11y-audit` issue queue (see "Compute dynamic
+# effort" step). Drained queue → thorough mode (batch 32, cap 100). Hot queue
+# → conservative mode (batch 12, cap 32). The audit self-throttles.
+#
+# Progress tracked in .github/a11y-audit-state.json; sweep restarts from the
+# top once every file has been audited.
+# =============================================================================
+
+on:
+  schedule:
+    # One pair of UTC crons for the Monday-noon PT window. Only one matches
+    # the local-hour gate depending on DST; the other is blocked by the gate
+    # or the short cooldown. workflow_dispatch bypasses both.
+    - cron: '7 19 * * 1'   # 12:07 PDT (summer) Mon / 11:07 PST (gated off)
+    - cron: '7 20 * * 1'   # 12:07 PST (winter) Mon / 13:07 PDT (gated by cooldown)
+  workflow_dispatch:
+    inputs:
+      focus:
+        description: 'Optional steering hint — narrow the sweep to a topic (e.g. "wizard", "schedule", "settings dialogs"). Leave blank for the default sweep. Focus runs do not advance sweep state.'
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+# Serialize every a11y-audit run. Without this, two parallel runs read the
+# same state, pick the same batch, and file duplicate issues.
+# cancel-in-progress=false so a workflow_dispatch fired during a scheduled
+# run waits its turn rather than aborting it.
+concurrency:
+  group: a11y-audit
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    name: A11y Audit with Claude
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Issues-only loop: no `pull-requests: write` — the sweep never opens PRs.
+    # `contents: write` is for the single state-file commit; `issues: write`
+    # files findings; `id-token: write` for the Claude action's OIDC exchange.
+    permissions:
+      contents: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Gate on America/Los_Angeles local hour window
+        id: gate
+        # Noon window: 12:00–13:30 PT. The 30-minute upper slop absorbs
+        # typical GitHub Actions cron delay (often 10–30 min) without letting
+        # a wrong-DST cron through. workflow_dispatch bypasses the gate.
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "go=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          hour=$(TZ=America/Los_Angeles date +%H)
+          minute=$(TZ=America/Los_Angeles date +%M)
+          echo "Local PT: $hour:$minute"
+          in_window=false
+          if [ "$hour" = "12" ] || { [ "$hour" = "13" ] && [ "$minute" -le 30 ]; }; then
+            in_window=true
+          fi
+          if [ "$in_window" = "true" ]; then
+            echo "go=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "go=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping: outside 12:00–13:30 PT window."
+          fi
+
+      - name: Checkout repository
+        if: steps.gate.outputs.go == 'true'
+        uses: actions/checkout@v6
+        with:
+          # RELEASE_PAT so the state-file commit can push to main past branch
+          # protection — same pattern as the docs-audit state-file commit.
+          token: ${{ secrets.RELEASE_PAT }}
+          fetch-depth: 0
+
+      - name: Dedup against recent runs
+        id: dedup
+        if: steps.gate.outputs.go == 'true'
+        # Weekly cadence (Monday noon PT). The window has a paired UTC cron; a
+        # 3h cooldown blocks the second cron in the same window. There is no
+        # open-draft cap here — this loop opens no PRs of its own (issues
+        # only). workflow_dispatch bypasses the cooldown.
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "go=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          last=$(jq -r '.last_run_at // empty' .github/a11y-audit-state.json)
+          if [ -n "$last" ]; then
+            last_epoch=$(date -u -d "$last" +%s 2>/dev/null || echo 0)
+            now_epoch=$(date -u +%s)
+            if [ "$last_epoch" -gt 0 ]; then
+              age_h=$(( (now_epoch - last_epoch) / 3600 ))
+              if [ "$age_h" -lt 3 ]; then
+                echo "Skipping: last run was ${age_h}h ago (<3h cooldown)."
+                echo "go=false" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            fi
+          fi
+          echo "go=true" >> "$GITHUB_OUTPUT"
+
+      - name: Compute dynamic effort
+        id: effort
+        if: steps.dedup.outputs.go == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        # Effort scales inverse to the open a11y-audit issue queue. A drained
+        # queue means triage is keeping up and the UI can absorb more
+        # findings; a hot queue means we back off so reviewers don't drown.
+        run: |
+          open_count=$(gh issue list --label a11y-audit --state open --limit 200 --json number --jq 'length')
+          echo "Open a11y-audit issues: ${open_count}"
+          if [ "$open_count" -gt 80 ]; then
+            mode="conservative"; batch=12; cap=32
+          elif [ "$open_count" -gt 40 ]; then
+            mode="balanced";     batch=24; cap=60
+          else
+            mode="thorough";     batch=32; cap=100
+          fi
+          echo "mode=${mode} batch=${batch} cap=${cap}"
+          {
+            echo "mode=${mode}"
+            echo "batch=${batch}"
+            echo "cap=${cap}"
+            echo "open_count=${open_count}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Configure git identity
+        if: steps.dedup.outputs.go == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Run Claude a11y-audit
+        if: steps.dedup.outputs.go == 'true'
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          # github.run_id is unique + stable per run. Issue bodies reference
+          # it so a finding can be traced back to the run that filed it. Do
+          # NOT compute timestamps in the prompt — past loops invented stale
+          # `date +%s` values from the model's training cutoff.
+          BRANCH_SUFFIX: ${{ github.run_id }}
+          AUDIT_MODE: ${{ steps.effort.outputs.mode }}
+          AUDIT_BATCH_SIZE: ${{ steps.effort.outputs.batch }}
+          AUDIT_ISSUE_CAP: ${{ steps.effort.outputs.cap }}
+          AUDIT_QUEUE_OPEN: ${{ steps.effort.outputs.open_count }}
+          AUDIT_FOCUS: ${{ github.event.inputs.focus }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Surface the SDK transcript in the Actions log. Without this the
+          # action prints "full output hidden for security" and silent
+          # permission denials look like a clean success.
+          show_full_output: 'true'
+          # Sonnet — the sweep is read-heavy "find" work; the per-issue FIX
+          # is what runs on Opus (in claude-issue-triage.yml).
+          # --allowed-tools: the agent-mode default is read-only, so every
+          # Edit/Write/git/gh call must be allowlisted. This loop is
+          # ISSUES-ONLY, so the allowlist deliberately OMITS `gh pr *` and
+          # the branch-switching git verbs — the only writes are the state
+          # JSON (Edit/Write) and the single state commit/push.
+          claude_args: >-
+            --model claude-sonnet-4-6
+            --max-turns 250
+            --allowed-tools "Read,Glob,Grep,Edit,Write,Bash(ls:*),Bash(cat:*),Bash(find:*),Bash(date:*),Bash(jq:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git rev-parse:*),Bash(gh issue list:*),Bash(gh issue view:*),Bash(gh issue create:*),Bash(gh issue edit:*),Bash(gh label list:*),Bash(gh label create:*)"
+          prompt: |
+            You are the FiestaBoard **accessibility (a11y) auditor**. You run
+            unattended once a week and statically audit a batch of web UI
+            source files (`web/src/**/*.tsx`) for WCAG 2.2 AA and general
+            accessibility problems. Your job is to **find** problems — fixing
+            happens downstream via the issue-triage workflow, which spawns one
+            focused Claude worker per issue you file. Lean into filing issues;
+            each one becomes a short, scoped, high-success-rate fix task.
+
+            This loop is **issues-only**: you do **not** open PRs and you do
+            **not** edit any source code. The ONLY file you may write is the
+            sweep state file (see "Hard rules").
+
+            ## Effort for this run (computed by the workflow)
+
+            - **Mode:**       ${{ steps.effort.outputs.mode }}
+            - **Batch size:** ${{ steps.effort.outputs.batch }} files
+            - **Issue cap:**  ${{ steps.effort.outputs.cap }} per run
+            - **Queue depth:** ${{ steps.effort.outputs.open_count }} open `a11y-audit` issues
+
+            The mode/batch/cap were chosen by the workflow based on the queue
+            depth — you don't need to second-guess them. Just use them.
+
+            ## Focus directive (optional)
+
+            Maintainer-supplied focus for this run: `$AUDIT_FOCUS`
+
+            Verify by echoing `"$AUDIT_FOCUS"` before doing anything else.
+
+            **If `$AUDIT_FOCUS` is empty**, follow the default sweep logic
+            below — pick the next batch from `files_remaining`, audit it,
+            advance state.
+
+            **If `$AUDIT_FOCUS` is non-empty**, this is a targeted probe, not
+            a sweep tick:
+            - Ignore `files_remaining`/`files_audited`. Glob the same corpus
+              the round-restart step would (see "Sweep logic" step 2), then
+              filter to files matching the focus hint (substring on path plus
+              topical judgment — e.g. focus "wizard" includes
+              `web/src/components/wizard/**`).
+            - Take the first `${{ steps.effort.outputs.batch }}` of the
+              filtered list as your batch.
+            - Tag issues: add a line `_Focus: <AUDIT_FOCUS>._` under the
+              "Filed by" footer.
+            - Do **NOT** advance sweep state. Skip the entire "State commit"
+              section. The next scheduled sweep still covers these files in
+              the normal rotation.
+
+            ## Learning from past rejections
+
+            **Read `.github/a11y-audit/rejected-edits.jsonl` before doing
+            anything else.** Each non-empty line is a previous a11y fix PR
+            (opened by a triage worker for an issue you filed) that a human
+            closed without merging — i.e. the proposed fix was wrong, OR the
+            underlying finding was a false positive. The log is your single
+            most important input; it is how this audit gets better over time.
+
+            Each line is a JSON object with:
+              - `pr`, `title`, `head_ref`, `closed_at`
+              - `body` — the PR description
+              - `files` — list of `{path, patch}` for every file changed
+              - `comments`, `reviews`, `inline_comments` — every human
+                comment. These usually contain the *reason* for the close.
+
+            For each rejection:
+
+            1. **Don't re-file the rejected finding.** If the close comments
+               say the finding itself was wrong ("this `<div>` is decorative,
+               it shouldn't be a button"; "this label is set via
+               `aria-labelledby` on the parent, it's fine"), do not file that
+               same finding again — anywhere in the repo, not just that file.
+            2. **Read every comment.** Treat the closer's reasoning as
+               authoritative. Generalize: most rejections expose a *class* of
+               false positive (intentional decorative elements, labels
+               provided indirectly, Radix primitives that already handle
+               keyboard/focus, deliberately non-translated technical tokens).
+               Carry the class forward, not just the literal case.
+            3. **Cite when relevant.** If you skip a finding because a past
+               rejection covers it, mention the PR number in your wrap-up.
+
+            If the file does not exist or is empty, proceed normally.
+
+            ## Sweep state
+
+            State file: `.github/a11y-audit-state.json`
+            Schema:
+              - `schema_version`  — int, currently 1
+              - `round`           — int, sweep number (starts at 0; bumped each restart)
+              - `round_started_at`— ISO8601 string or null
+              - `last_run_at`     — ISO8601 string or null
+              - `files_remaining` — list of relative paths still to audit this round
+              - `files_audited`   — list of relative paths already audited this round
+
+            ## Sweep logic
+
+            1. Read the state file.
+            2. If `files_remaining` is empty:
+               - Glob the repo for web UI source. Include:
+                 `web/src/**/*.tsx`.
+                 Exclude: `web/src/**/*.test.tsx`, `web/src/**/*.stories.tsx`,
+                 `web/src/__tests__/**`, `web/src/stories/**`, and anything
+                 under `node_modules/`, `.git/`, or `.claude/`.
+               - Set `files_remaining` to the full glob, sorted.
+               - Set `files_audited` to `[]`.
+               - Bump `round` by 1 and set `round_started_at` to now (ISO8601 UTC).
+            3. Pick the first **${{ steps.effort.outputs.batch }}** entries
+               from `files_remaining` as this run's batch. If fewer remain,
+               use what's there.
+
+            ## For each file in the batch
+
+            Read it **carefully** — don't skim. Understand what renders, what's
+            interactive, and which strings reach the user. Then look for WCAG
+            2.2 AA / accessibility problems. FiestaBoard conventions you must
+            apply:
+
+            - **Strings go through next-intl.** Any user-facing string —
+              including `aria-label`, `title`, `alt`, placeholder, and visible
+              text — must come from a `next-intl` key in `web/messages/en.json`
+              (and its 13 sibling locales), NOT a hardcoded English literal in
+              JSX. A hardcoded English `aria-label="Delete"` is a finding.
+            - **Prefer semantic HTML / Radix.** `<button>` over
+              `<div role="button">`; `<a href>` for navigation. Radix / shadcn
+              primitives in `web/src/components/ui/` already provide keyboard
+              and focus behavior — re-implementing it by hand (or NOT using it
+              for a custom interactive widget) is a finding. Custom widgets in
+              `web/src/components/wizard/` and
+              `web/src/components/tiptap-template-editor/` get extra scrutiny.
+            - **The axe baseline** lives at `web/tests/a11y.spec.ts` (tags
+              `wcag2a, wcag2aa, wcag21a, wcag21aa, best-practice`). Color
+              contrast is intentionally excluded there and tracked separately
+              — so report contrast concerns as low-priority quality findings
+              (bucket C), never as the headline.
+
+            Categorize findings into two buckets (this loop has no
+            trivial-inline-fix bucket — everything is an issue):
+
+            **B. Accessibility defects / WCAG violations** — concrete barriers:
+                - Icon-only `<button>` / clickable with no accessible name
+                  (no text, no `aria-label`, no `aria-labelledby`) — WCAG
+                  4.1.2.
+                - Non-semantic interactive element: `<div>`/`<span>` with
+                  `onClick` but no `role`, `tabIndex`, or keyboard handler —
+                  WCAG 2.1.1 / 4.1.2.
+                - `<img>` (or meaningful icon) with no `alt` / not marked
+                  `aria-hidden` when decorative — WCAG 1.1.1.
+                - Form control with no associated `<label>` / `aria-label` /
+                  `aria-labelledby` — WCAG 1.3.1 / 4.1.2.
+                - Hardcoded user-facing string (incl. `aria-label`) instead of
+                  a next-intl key — a11y + i18n defect.
+                - Heading hierarchy: skipped levels, more than one `<h1>`,
+                  headings used for styling — WCAG 1.3.1.
+                - Non-descriptive link/button text ("click here", "read
+                  more", bare URL) — WCAG 2.4.4.
+                - Color/shape used as the ONLY signal for state (error,
+                  selected, online) with no text or icon — WCAG 1.4.1.
+                - Dialog / menu / disclosure with missing or wrong ARIA, or a
+                  custom one that doesn't move/trap/restore focus — WCAG
+                  4.1.2 / 2.4.3.
+                - Dynamic region (toast, async result, live status) with no
+                  `role="status"` / `aria-live` — WCAG 4.1.3.
+
+            **C. Accessibility quality / clarity** — present but improvable:
+                - Redundant or conflicting ARIA (e.g. `role="button"` on a
+                  `<button>`, `aria-label` duplicating visible text).
+                - Focus order that won't match visual order; missing visible
+                  focus affordance on a custom control.
+                - Overly verbose / unhelpful alt text or labels.
+                - Suspected color-contrast issues (low priority — contrast is
+                  excluded from the axe gate; mention but don't lead with it).
+
+            ## Aggressiveness
+
+            Mode for this run: **${{ steps.effort.outputs.mode }}**.
+
+            - `thorough` (queue ≤ 40): file any defensible finding. False
+              positives are cheap — the triage worker validates or comments.
+            - `balanced` (40 < queue ≤ 80): file findings you're moderately
+              confident about. Skim past minor preferences.
+            - `conservative` (queue > 80): only flag high-confidence findings.
+              The reviewer queue is hot; don't add noise.
+
+            Always: dedup against open `a11y-audit` issues before filing:
+              `gh issue list --label a11y-audit --state open --limit 200 --search "<key phrase>"`
+            Skip if a same-file, same-topic issue already exists open.
+
+            ## Outputs — file a GitHub issue for each finding
+
+            Dedupe first (see above). Then:
+
+            Issue title: `a11y: <verb> <file> — <one-line summary>`
+              e.g. `a11y: label icon-only buttons in schedule list (WCAG 2.2 AA 4.1.2)`
+                   `a11y: route Settings tab labels through next-intl`
+
+            Issue body:
+              ## File(s)
+              - `<path>` (cite the component / approximate line)
+
+              ## Category
+              <Accessibility defect / WCAG violation | Accessibility quality>
+
+              ## WCAG
+              <criterion, e.g. 4.1.2 Name, Role, Value — or "general a11y">
+
+              ## Finding
+              <2–5 sentences: what's wrong and who it affects (keyboard,
+              screen-reader, low-vision, etc.)>
+
+              ## Suggested fix
+              <2–5 sentences. If a new string is needed, say "add a next-intl
+              key" — do not invent an English literal. Prefer semantic
+              HTML / existing Radix primitives.>
+
+              ---
+              _Filed by the a11y-audit cron during round <round> (run $BRANCH_SUFFIX)._
+
+            Labels: `a11y`, `a11y-audit`. Create them if missing:
+              `gh label create a11y --color 5319E7 --description "Accessibility / WCAG" || true`
+              `gh label create a11y-audit --color BFD4F2 --description "Filed by the a11y-audit cron" || true`
+
+            After creating each issue, also apply the `claude-fix` label so the
+            issue-triage workflow picks it up and opens an `a11y/issue-*` fix
+            PR (issues filed by this bot don't satisfy the triage workflow's
+            author-association gate, so `claude-fix` / `a11y-audit` is what
+            opens that path):
+              `gh issue edit <N> --add-label claude-fix`
+            Create that label first if needed:
+              `gh label create claude-fix --color 0E8A16 --description "Run the Claude issue-triage workflow on this issue" || true`
+
+            ## State commit
+
+            (Skip this whole section if `$AUDIT_FOCUS` is non-empty.)
+
+            After processing the batch:
+            1. Move the batch entries from `files_remaining` to `files_audited`.
+            2. Update `last_run_at` to now (ISO8601 UTC).
+            3. Write the JSON back to `.github/a11y-audit-state.json` (2-space
+               indent, trailing newline, keys in the same order as the
+               existing file).
+            4. Commit to `main` directly and push:
+               ```bash
+               git add .github/a11y-audit-state.json
+               git commit -m "chore(a11y-audit): advance sweep state [skip ci]" || exit 0
+               git push origin HEAD:main
+               ```
+               This is the ONLY commit you make.
+
+            ## Hard rules
+
+            - **Edits are restricted to `.github/a11y-audit-state.json` only.**
+              Never edit, create, or delete any other file. You do not fix
+              code — you file issues. The triage worker fixes.
+            - Never open a PR. Never create a branch. (This loop is issues-only.)
+            - Never push to `main` except for the single state-file commit above.
+            - Never force-push, never `--no-verify`, never `--no-gpg-sign`.
+            - Never file more than **${{ steps.effort.outputs.cap }}** issues
+              this run. If you'd file more, keep the top
+              ${{ steps.effort.outputs.cap }} (most actionable) and discard
+              the rest.
+            - When dedup says skip, skip — don't refile. When mode is
+              `thorough`, lean toward filing; when `conservative`, lean toward
+              skipping.
+
+            ## Wrap up
+
+            Print a one-screen summary:
+              ROUND: <n> (started <date>)
+              BATCH: <files in this batch>
+              Issues filed: <#A #B ...>
+              Rejections applied: <PR #s you honored, or "none">
+              Progress: <audited>/<total> files in this round
+              Next batch: <first 3 of files_remaining or "round complete">
+
+      - name: Push state-file changes (fallback)
+        if: steps.dedup.outputs.go == 'true'
+        # Defensive: if the Claude step exits early (rate limit, allowlist
+        # denial, hallucination) with a staged-but-unpushed state change,
+        # commit + push it here. [skip ci] keeps this from retriggering.
+        run: |
+          if git diff --quiet -- .github/a11y-audit-state.json; then
+            echo "State file unchanged."
+            exit 0
+          fi
+          git add .github/a11y-audit-state.json
+          git commit -m "chore(a11y-audit): advance sweep state [skip ci]"
+          git push origin HEAD:main

--- a/.github/workflows/claude-a11y-live-axe.yml
+++ b/.github/workflows/claude-a11y-live-axe.yml
@@ -1,0 +1,302 @@
+name: 'Claude: A11y Live Axe'
+
+# =============================================================================
+# Weekly America/Los_Angeles RUNTIME accessibility sweep. Boots the unified
+# container (same way the CI e2e job does), runs axe-core against the main
+# routes via the existing web/tests/a11y.spec.ts (in DEBUG_A11Y full-findings
+# mode), then a Claude step triages the violations into GitHub issues.
+#
+# This is the live companion to claude-a11y-audit.yml (the static TSX source
+# sweep). The static sweep catches issues visible in the source; this catches
+# issues that only appear at runtime (computed ARIA after hydration, focus
+# order on a real DOM, axe rules that need a rendered page). Both file under
+# the SAME labels (`a11y` + `a11y-audit` + `claude-fix`) so the dedup,
+# triage, auto-review, and rejection-learning machinery is shared — one
+# queue, one memory.
+#
+# Findings → issues → claude-issue-triage.yml opens `a11y/issue-*` fix PRs.
+#
+# Cadence: Thursday noon PT (offset from the Monday static sweep to spread
+# reviewer load). The two UTC crons cover DST; the local-hour gate admits
+# only the noon hour so exactly one fires (no state file here, so the gate is
+# the dedup — no cooldown needed). workflow_dispatch always proceeds.
+#
+# NOTE: this job builds the Docker image and runs containers, so it is much
+# heavier than the static sweep. axe color-contrast is excluded (it's
+# excluded in a11y.spec.ts too — tracked separately).
+# =============================================================================
+
+on:
+  schedule:
+    - cron: '7 19 * * 4'   # 12:07 PDT (summer) Thu / 11:07 PST (gated off)
+    - cron: '7 20 * * 4'   # 12:07 PST (winter) Thu / 13:07 PDT (gated off)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Serialize runs; don't let a dispatch abort a scheduled run mid-build.
+concurrency:
+  group: a11y-live-axe
+  cancel-in-progress: false
+
+jobs:
+  axe:
+    name: Boot app, run axe, file a11y issues
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
+    steps:
+      - name: Gate on America/Los_Angeles local hour window
+        id: gate
+        # Noon hour only (12:00–12:59 PT). With no state file there is no
+        # cooldown, so the gate must admit exactly ONE of the two paired UTC
+        # crons. Gating on hour==12 does that: only the in-DST noon cron
+        # lands on local hour 12. The :07 cron start tolerates ~50 min of
+        # GitHub Actions delay before slipping out of the hour.
+        # workflow_dispatch bypasses the gate.
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "go=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          hour=$(TZ=America/Los_Angeles date +%H)
+          minute=$(TZ=America/Los_Angeles date +%M)
+          echo "Local PT: $hour:$minute"
+          if [ "$hour" = "12" ]; then
+            echo "go=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "go=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping: outside the noon PT hour."
+          fi
+
+      - name: Checkout repository
+        if: steps.gate.outputs.go == 'true'
+        uses: actions/checkout@v6
+
+      - name: Set up web E2E environment
+        if: steps.gate.outputs.go == 'true'
+        uses: ./.github/actions/setup-web-e2e
+
+      - name: Set up Docker Buildx
+        if: steps.gate.outputs.go == 'true'
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Docker Hub
+        # Avoid anonymous-pull rate limits when warming base layers. Scheduled
+        # and dispatch runs always have the secrets (not a fork PR).
+        if: steps.gate.outputs.go == 'true' && github.actor != 'dependabot[bot]'
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build test image
+        if: steps.gate.outputs.go == 'true'
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          push: false
+          load: true
+          tags: fiestaboard:a11y
+          build-args: |
+            VERSION=dev
+          # Read whatever the CI build jobs already warmed; cold cache just
+          # means a full build.
+          cache-from: |
+            type=gha,scope=build-linux/amd64
+            type=gha,scope=build-test
+
+      - name: Start 1 mock board + FiestaBoard container
+        id: boot
+        if: steps.gate.outputs.go == 'true'
+        # Single worker is enough for an a11y sweep. Mirrors the CI e2e job's
+        # boot (mock-board + fiestaboard), wiring the same WORKER_* env the
+        # axe spec's helpers read.
+        run: |
+          docker run -d --name mock-board-0 \
+            -v ${{ github.workspace }}/integration-tests/mock-board:/app:ro \
+            -w /app \
+            python:3.11-slim python server.py
+
+          docker run -d --name fiestaboard-0 \
+            -e PRODUCTION=false \
+            -e FIESTABOARD_AUTH_ENABLED=false \
+            fiestaboard:a11y
+
+          FB_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' fiestaboard-0)
+          MOCK_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' mock-board-0)
+          echo "FiestaBoard=$FB_IP  MockBoard=$MOCK_IP"
+
+          {
+            echo "WORKER_URLS=http://$FB_IP:3000"
+            echo "WORKER_MOCK_URLS=http://$MOCK_IP:7000"
+            echo "WORKER_MOCK_HOSTS=$MOCK_IP"
+          } >> "$GITHUB_ENV"
+
+      - name: Wait for container to be ready
+        if: steps.gate.outputs.go == 'true'
+        timeout-minutes: 3
+        run: |
+          IFS=',' read -ra URLS <<< "$WORKER_URLS"
+          for url in "${URLS[@]}"; do
+            echo "Waiting for $url..."
+            for i in $(seq 1 60); do
+              STATUS=$(curl -s -m 5 -o /dev/null -w "%{http_code}" "$url/api/health" 2>/dev/null || echo "000")
+              if [ "$STATUS" = "200" ]; then
+                echo "  Ready (attempt $i)"
+                break
+              fi
+              if [ "$i" = "60" ]; then
+                echo "  ❌ Failed to become ready"
+                exit 1
+              fi
+              sleep 1
+            done
+          done
+
+      - name: Run axe sweep (full findings)
+        if: steps.gate.outputs.go == 'true'
+        working-directory: web
+        # `continue-on-error` because a11y.spec.ts ASSERTS no critical/serious
+        # violations and we WANT it to surface them, not fail the workflow.
+        # DEBUG_A11Y=1 makes the spec log every finding (all impacts) as
+        # `[a11y] <route>: <json>`; we tee that to a log the Claude step
+        # parses. retries=0 keeps the log from double-printing on retry.
+        continue-on-error: true
+        env:
+          CI: 'true'
+          DEBUG_A11Y: '1'
+        run: |
+          set -o pipefail || true
+          npx playwright test a11y.spec.ts --workers=1 --retries=0 --reporter=list 2>&1 \
+            | tee a11y-run.log
+          echo "Axe sweep finished (exit code masked by continue-on-error)."
+
+      - name: Stop containers
+        if: always()
+        run: |
+          docker rm -f fiestaboard-0 mock-board-0 2>/dev/null || true
+
+      - name: Triage axe findings into issues
+        if: steps.gate.outputs.go == 'true'
+        uses: anthropics/claude-code-action@v1
+        env:
+          # RELEASE_PAT (a PAT, not GITHUB_TOKEN) so the issues + labels this
+          # step creates actually TRIGGER claude-issue-triage.yml. Events
+          # raised by the default GITHUB_TOKEN do not trigger other workflows.
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          RUN_ID: ${{ github.run_id }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          show_full_output: 'true'
+          # Read-only on the repo (no Edit/Write/git). Only `gh issue` /
+          # `gh label` are write actions, and they go through RELEASE_PAT.
+          claude_args: >-
+            --model claude-sonnet-4-6
+            --max-turns 120
+            --allowed-tools "Read,Glob,Grep,Bash(ls:*),Bash(cat:*),Bash(find:*),Bash(date:*),Bash(jq:*),Bash(gh issue list:*),Bash(gh issue view:*),Bash(gh issue create:*),Bash(gh issue edit:*),Bash(gh label list:*),Bash(gh label create:*)"
+          prompt: |
+            You are the FiestaBoard **live accessibility triager**. The
+            workflow just booted the app and ran axe-core against the main
+            routes (via `web/tests/a11y.spec.ts` in `DEBUG_A11Y=1` mode). Your
+            job is to turn the axe output into well-scoped GitHub issues that
+            feed the shared a11y-fix pipeline. You do NOT edit code and you do
+            NOT open PRs — you file issues; a triage worker fixes them.
+
+            ## Step 1 — read the axe output
+
+            Read `web/a11y-run.log`. It contains, for each audited route, a
+            block of the form:
+
+                [a11y] /schedule: [
+                  { "id": "button-name", "impact": "serious", "help": "...",
+                    "helpUrl": "...", "nodes": 3, "sample": [["button.x"], ...] },
+                  ...
+                ]
+
+            Parse every `[a11y] <route>:` block. Each array element is one axe
+            rule violation on that route, with `id`, `impact`
+            (critical/serious/moderate/minor), `help`, `helpUrl`, `nodes`
+            (count), and `sample` (up to 3 CSS-selector targets). If the log
+            is missing, empty, or shows no `[a11y]` blocks (e.g. the app
+            failed to boot), file NO issues — print a short note saying the
+            sweep produced no parseable findings and stop.
+
+            ## Step 2 — prioritize
+
+            Group violations by `(route, rule id)`. Rank by impact:
+            **critical > serious > moderate > minor**. Skip `color-contrast`
+            (it's intentionally excluded from FiestaBoard's axe gate and
+            tracked separately) unless nothing else surfaced — and even then
+            file it as low priority. Lead with critical/serious.
+
+            ## Step 3 — learn from past rejections
+
+            Read `.github/a11y-audit/rejected-edits.jsonl` if it exists. Each
+            line is a previously-closed a11y fix PR. If the close comments
+            establish that a given finding is a false positive (e.g. axe flags
+            something the team has deliberately accepted), do not re-file that
+            same finding. Generalize the lesson.
+
+            ## Step 4 — dedup, then file issues
+
+            Before filing, dedup against open issues:
+              `gh issue list --label a11y-audit --state open --limit 200 --search "<rule id> <route>"`
+            Skip any `(route, rule id)` that already has an open issue.
+
+            For each surviving violation group, file ONE issue:
+
+            Title: `a11y: <rule id> on <route> — <short help> (<impact>)`
+              e.g. `a11y: button-name on /schedule — buttons must have discernible text (serious)`
+
+            Body:
+              ## Route
+              `<route>`
+
+              ## Axe rule
+              `<rule id>` (<impact>) — <help>
+              <helpUrl>
+
+              ## Affected elements (sample)
+              - `<selector>`
+              - ...
+              (<nodes> total node(s) flagged)
+
+              ## Suggested fix
+              <2–4 sentences. Any new user-facing string (incl. `aria-label`)
+              must be added as a `next-intl` key in `web/messages/en.json` —
+              do not hardcode English. Prefer semantic HTML / existing Radix
+              primitives in `web/src/components/ui/`.>
+
+              ---
+              _Filed by the a11y live-axe sweep (run $RUN_ID)._
+
+            Labels: `a11y`, `a11y-audit`. Create if missing:
+              `gh label create a11y --color 5319E7 --description "Accessibility / WCAG" || true`
+              `gh label create a11y-audit --color BFD4F2 --description "Filed by the a11y-audit cron" || true`
+
+            After creating each issue, apply `claude-fix` so the triage
+            worker picks it up:
+              `gh issue edit <N> --add-label claude-fix`
+              `gh label create claude-fix --color 0E8A16 --description "Run the Claude issue-triage workflow on this issue" || true`
+
+            ## Hard rules
+
+            - Read-only on the repo: never Edit, Write, create branches, or
+              open PRs. Filing issues + creating labels is the only output.
+            - Cap at **40** issues this run. If axe surfaced more, file the
+              top 40 by impact and note the rest in your wrap-up.
+            - When dedup says skip, skip.
+
+            ## Wrap up
+
+            Print:
+              Routes parsed: <list>
+              Violations found: <by impact>
+              Issues filed: <#N ...>
+              Skipped (dedup / rejection log): <count>

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -8,8 +8,11 @@ name: 'Claude: Issue Triage'
 #   3. Docs cron: any issue that gets the `docs-audit` label applied
 #      (filed by claude-docs-audit.yml; the bot-authored issues don't
 #      satisfy gate #1, and we want them auto-triaged anyway)
+#   4. A11y cron: any issue that gets the `a11y-audit` label applied
+#      (filed by claude-a11y-audit.yml / claude-a11y-live-axe.yml; same
+#      bot-author reasoning as #3 — these become `a11y/issue-*` fix PRs)
 #
-# This triple gate keeps drive-by issues from public reporters out of the
+# These gates keep drive-by issues from public reporters out of the
 # auto-run path while still letting you (or any maintainer) opt one in by
 # adding the label, and letting the docs-audit cron close its own loop.
 #
@@ -43,7 +46,8 @@ jobs:
         )) ||
         (github.event.action == 'labeled' && (
           github.event.label.name == 'claude-fix' ||
-          github.event.label.name == 'docs-audit'
+          github.event.label.name == 'docs-audit' ||
+          github.event.label.name == 'a11y-audit'
         ))
       )
     runs-on: ubuntu-latest
@@ -133,6 +137,18 @@ jobs:
                  **ready-for-review** — use `gh pr create` with NO
                  `--draft` flag — so the docs auto-review workflow fires
                  and the PR lands in the maintainer's normal review queue.
+               - For a11y-flavored issues (labels include `a11y` or
+                 `a11y-audit`): branch
+                 `a11y/issue-${{ github.event.issue.number }}-<short-slug>`,
+                 title prefix `fix(a11y):` (no `[Claude first-pass]` prefix).
+                 Open **ready-for-review** — `gh pr create` with NO `--draft`
+                 flag — so the a11y auto-review workflow
+                 (`claude-a11y-audit-review.yml`) fires. These are code
+                 fixes: add or update a test when practical, keep
+                 `web/tests/a11y.spec.ts` green, and route every new
+                 user-facing string (including `aria-label`) through
+                 `next-intl` (`web/messages/en.json` + the 13 sibling
+                 locales) — never a hardcoded English literal in JSX.
                - For everything else: branch
                  `claude/issue-${{ github.event.issue.number }}`, title
                  `[Claude first-pass] <short summary>`. Open as a draft
@@ -159,6 +175,24 @@ jobs:
               - Canonical README / SETUP section orders for plugin docs
                 (see `CLAUDE.md` and the existing `plugins/date_time/`,
                 `plugins/random/` docs as voice references)
+
+            ## A11y issues — conventions
+
+            If the issue labels include `a11y` or `a11y-audit`, you are
+            shipping an accessibility fix. Before editing, read
+            `.claude/agents/a11y-engineer.md` and apply its rules:
+              - Prefer semantic HTML over ARIA (`<button>` over
+                `<div role="button">`); use the Radix/shadcn primitives in
+                `web/src/components/ui/` rather than re-implementing keyboard
+                and focus behavior
+              - Every new user-facing string (including `aria-label`, `title`,
+                `alt`) goes through `next-intl` — add the key to
+                `web/messages/en.json`; never ship an English literal in JSX
+              - WCAG 2.2 AA is the bar; don't roll AAA-tier changes into the fix
+              - `web/tests/a11y.spec.ts` must still pass — run the web tests
+                before opening the PR
+              - Scope tightly to the reported finding; cite the WCAG criterion
+                in the PR body
 
             If you finish without opening a PR, leave a comment on the issue
             summarizing what you found and why no PR was opened.


### PR DESCRIPTION
## Summary

Adds a Claude-powered, self-improving **accessibility audit loop** modeled on the canonical `docs-audit` system. Two finders sweep the web UI for WCAG 2.2 AA / a11y issues and feed **one** shared label → **one** triage worker → **one** auto-review + rejection-learning pipeline.

This complements the existing interactive tooling (`/qa-a11y` live audit, `/qa-a11y-docs`, the `a11y-engineer` fixer) by making the audit **recurring, batched, queue-aware, and self-correcting** — exactly the gap a one-off command can't fill.

## What the loop does

1. **Static sweep** (`claude-a11y-audit.yml`, weekly Mon noon PT) reads `web/src/**/*.tsx` in batches and files issues for source-visible a11y problems (missing `aria-label`, non-semantic interactive elements, hardcoded strings that should use next-intl, heading order, unlabeled inputs, color-only state, focus gaps). **Issues-only** — the sweep opens no PRs of its own.
2. **Live axe sweep** (`claude-a11y-live-axe.yml`, weekly Thu noon PT) boots the container (mirrors the CI e2e job) and runs `axe-core` via the existing `web/tests/a11y.spec.ts`, then triages runtime violations into the same issues.
3. Every finding → `a11y` + `a11y-audit` + `claude-fix` issue → **`claude-issue-triage.yml` opens a focused `a11y/issue-*` fix PR** (your "label picks it up and an agent fixes it" request).
4. **Auto-review** (`claude-a11y-audit-review.yml`) reviews the a11y dimension of any PR touching `web/src/**/*.tsx` or `web/messages/**`.
5. **Feedback capture** (`claude-a11y-audit-feedback.yml`) records rejected `a11y/issue-*` PRs into `rejected-edits.jsonl`; the next sweep reads it and stops re-filing false positives.

## Files added

| File | Role |
| --- | --- |
| `.github/workflows/claude-a11y-audit.yml` | Static TSX sweep cron (issues-only) |
| `.github/workflows/claude-a11y-live-axe.yml` | Live axe-core cron (boots app, triages into issues) |
| `.github/workflows/claude-a11y-audit-review.yml` | A11y auto-review on UI PRs |
| `.github/workflows/claude-a11y-audit-feedback.yml` | Rejection capture |
| `.github/a11y-audit-state.json` | Sweep state (seeded round 0) |
| `.github/a11y-audit/build_rejection.py` | Rejection-log builder |
| `.github/a11y-audit/rejected-edits.jsonl` | Empty learning log |
| `.github/a11y-audit/README.md` | Folder docs |

## Files modified

- `.github/workflows/claude-issue-triage.yml` — added `a11y-audit` to the label gate + an `a11y/issue-*` ready-for-review fix flavor pointing at `.claude/agents/a11y-engineer.md`.

## Deviations from the canonical docs-audit pattern

- **Issues-only** (skill's issues-only trims applied): an a11y fix nearly always touches TSX + 14 i18n locales, so it's never a true one-line inline fix. The audit job drops `pull-requests: write` and all `gh pr`/branch-switch tools; hard rules restrict edits to the state file only.
- **Two finders, one label**: a static source sweep plus a live runtime axe sweep, deliberately overlapping, sharing the dedup/triage/review/learning machinery.
- **Weekly cadence** (Mon static, Thu live) instead of twice-daily — a11y churn is slower than docs, and the offset spreads reviewer load.

## Guardrails carried over from the skill's pitfalls

`BRANCH_SUFFIX=github.run_id` · `show_full_output: 'true'` · scoped `--allowed-tools` · `pull_request_target` + base-ref checkout + `github_token` OIDC bypass for review/feedback · `concurrency cancel-in-progress: false` on audit/feedback · DST-paired UTC crons + local-hour gate · `RELEASE_PAT` for state/log pushes (and so bot-filed issues trigger triage) · `[skip ci]` on state/log commits.

## Notes for reviewers

- The **live axe** job builds the Docker image and runs containers, so it's heavier than the static sweep; watch its first run for boot/health-gate behavior.
- The first scheduled static sweep computes the file list (~245 TSX files) and works through it in batches of 12–32 depending on queue depth, so a full round spans several weeks by design.
- Requires the existing repo secrets `CLAUDE_CODE_OAUTH_TOKEN`, `RELEASE_PAT`, and (for live axe) `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)