### PR TITLE
feat(devices): note-array credentials & board config [#1170]

### DIFF
--- a/env.example
+++ b/env.example
@@ -20,6 +20,12 @@ BOARD_HOST=192.168.0.11  # IP or hostname (e.g., board.local)
 # - No transition support
 # - If using cloud mode, set BOARD_API_MODE=cloud and use BOARD_READ_WRITE_KEY
 BOARD_READ_WRITE_KEY=your_read_write_api_key_here  # Used when BOARD_API_MODE=cloud
+#
+# For Note Array boards (Vestaboard Note Array hardware):
+# - Note Arrays connect exclusively via the Cloud API using a bearer token
+# - Obtain your token from https://web.vestaboard.com (Settings -> API)
+# - Set device_type = "note_array" on the board in FiestaBoard Settings
+BOARD_NOTE_ARRAY_TOKEN=your_note_array_token_here
 
 # Board Transition Settings (optional)
 # Control how the board animates when displaying new messages

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -92,6 +92,7 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "api_mode": "local",
         "local_api_key": "",
         "cloud_key": "",
+        "note_array_token": "",
         "host": "",
         "transition_strategy": None,
         "transition_interval_ms": None,
@@ -294,6 +295,7 @@ SENSITIVE_FIELDS = {
     "api_key",
     "local_api_key",
     "cloud_key",
+    "note_array_token",
     "access_token",
     "password",
     "finnhub_api_key",
@@ -788,6 +790,7 @@ class ConfigManager:
         changed |= apply_str(board_config, "local_api_key", "BOARD_LOCAL_API_KEY", "FB_LOCAL_API_KEY")
         changed |= apply_str(board_config, "host", "BOARD_HOST", "FB_HOST")
         changed |= apply_str(board_config, "cloud_key", "BOARD_READ_WRITE_KEY", "FB_READ_WRITE_KEY")
+        changed |= apply_str(board_config, "note_array_token", "BOARD_NOTE_ARRAY_TOKEN")
         changed |= apply_str(board_config, "transition_strategy", "BOARD_TRANSITION_STRATEGY", "FB_TRANSITION_STRATEGY")
         changed |= apply_int(
             board_config, "transition_interval_ms", "BOARD_TRANSITION_INTERVAL_MS", "FB_TRANSITION_INTERVAL_MS"

--- a/src/devices.py
+++ b/src/devices.py
@@ -100,7 +100,9 @@ class BoardInstance:
     @property
     def is_connection_configured(self) -> bool:
         if is_note_array(self.device_type):
-            return bool(self.note_array_token) and self.notes_wide >= 1 and self.notes_tall >= 1
+            # notes_wide/notes_tall are always >= 1 (clamped in __post_init__),
+            # so configuration hinges solely on having a token.
+            return bool(self.note_array_token)
         if self.api_mode == "cloud":
             return bool(self.cloud_key)
         return bool(self.local_api_key and self.host)
@@ -129,7 +131,7 @@ class BoardInstance:
             port=port if port is not None else 7000,
             local_api_key=data.get("local_api_key", ""),
             cloud_key=data.get("cloud_key", ""),
-            note_array_token=data.get("note_array_token", ""),
+            note_array_token=data.get("note_array_token", "").strip(),
             notes_wide=data.get("notes_wide", 1),
             notes_tall=data.get("notes_tall", 1),
         )

--- a/src/devices.py
+++ b/src/devices.py
@@ -69,6 +69,7 @@ class BoardInstance:
     port: int = 7000  # Local API port (default Vestaboard); used for multi-board mock e2e
     local_api_key: str = ""
     cloud_key: str = ""
+    note_array_token: str = ""  # X-Vestaboard-Token for note-array boards
     notes_wide: int = 1
     notes_tall: int = 1
 
@@ -98,6 +99,8 @@ class BoardInstance:
 
     @property
     def is_connection_configured(self) -> bool:
+        if is_note_array(self.device_type):
+            return bool(self.note_array_token) and self.notes_wide >= 1 and self.notes_tall >= 1
         if self.api_mode == "cloud":
             return bool(self.cloud_key)
         return bool(self.local_api_key and self.host)
@@ -126,6 +129,7 @@ class BoardInstance:
             port=port if port is not None else 7000,
             local_api_key=data.get("local_api_key", ""),
             cloud_key=data.get("cloud_key", ""),
+            note_array_token=data.get("note_array_token", ""),
             notes_wide=data.get("notes_wide", 1),
             notes_tall=data.get("notes_tall", 1),
         )

--- a/src/settings/service.py
+++ b/src/settings/service.py
@@ -105,7 +105,7 @@ class PollingSettings:
         )
 
 
-BOARD_SENSITIVE_FIELDS = {"local_api_key", "cloud_key"}
+BOARD_SENSITIVE_FIELDS = {"local_api_key", "cloud_key", "note_array_token"}
 
 
 @dataclass

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1103,3 +1103,95 @@ def test_no_pre_boot_snapshot_on_brand_new_install(tmp_path):
 
     snapshot_dir = tmp_path / "update-backups"
     assert not snapshot_dir.exists() or not list(snapshot_dir.glob("pre-update-*.json"))
+
+
+# ---------------------------------------------------------------------------
+# note_array_token — persistence, masking, and connection-configured check
+# ---------------------------------------------------------------------------
+
+
+def test_note_array_token_persists_through_settings_service_round_trip(tmp_path):
+    """Save a note-array board via SettingsService, reload, confirm token + W×H survive."""
+    import src.settings.service as settings_service_module
+    from src.devices import BoardInstance
+
+    svc = settings_service_module.SettingsService(settings_file=str(tmp_path / "settings.json"))
+
+    board_dict = BoardInstance(
+        device_type="note_array",
+        note_array_token="tok-roundtrip",
+        notes_wide=2,
+        notes_tall=1,
+    ).to_dict()
+    svc.set_boards([board_dict])
+
+    # Reload from disk
+    svc2 = settings_service_module.SettingsService(settings_file=str(tmp_path / "settings.json"))
+    boards = svc2.get_board_settings().boards
+    assert len(boards) == 1
+    b = boards[0]
+    assert b["device_type"] == "note_array"
+    assert b["note_array_token"] == "tok-roundtrip"
+    assert b["notes_wide"] == 2
+    assert b["notes_tall"] == 1
+
+
+def test_note_array_token_masked_in_get_board_settings(tmp_path):
+    """note_array_token is masked to '***' in masked board settings."""
+    import src.settings.service as settings_service_module
+    from src.devices import BoardInstance
+
+    svc = settings_service_module.SettingsService(settings_file=str(tmp_path / "settings.json"))
+    board_dict = BoardInstance(
+        device_type="note_array",
+        note_array_token="tok-secret",
+        notes_wide=2,
+        notes_tall=1,
+    ).to_dict()
+    svc.set_boards([board_dict])
+
+    boards = svc.get_board_settings().to_dict(mask_secrets=True)["boards"]
+    assert boards[0]["note_array_token"] == "***"
+
+
+def test_note_array_token_preserved_when_update_sends_masked_value(tmp_path):
+    """Sending '***' as the token preserves the stored real value (UI round-trip)."""
+    import src.settings.service as settings_service_module
+    from src.devices import BoardInstance
+
+    svc = settings_service_module.SettingsService(settings_file=str(tmp_path / "settings.json"))
+    board_dict = BoardInstance(
+        device_type="note_array",
+        note_array_token="tok-real",
+        notes_wide=2,
+        notes_tall=1,
+    ).to_dict()
+    svc.set_boards([board_dict])
+
+    # Simulate the UI echoing masked value back
+    masked_board = dict(svc.get_board_settings().to_dict(mask_secrets=True)["boards"][0])
+    assert masked_board["note_array_token"] == "***"
+    svc.set_boards([masked_board])
+
+    reloaded = svc.get_board_settings().boards
+    assert reloaded[0]["note_array_token"] == "tok-real"
+
+
+def test_note_array_board_is_connection_configured_via_settings_service(tmp_path, monkeypatch):
+    """_has_configured_board_instance returns True for a note-array board with a token."""
+    import src.settings.service as settings_service_module
+    from src.devices import BoardInstance
+
+    svc = settings_service_module.SettingsService(settings_file=str(tmp_path / "settings.json"))
+    board_dict = BoardInstance(
+        device_type="note_array",
+        note_array_token="tok-abc",
+        notes_wide=2,
+        notes_tall=1,
+    ).to_dict()
+    svc.set_boards([board_dict])
+
+    # Point the global settings service at our tmp instance so ConfigManager sees it
+    monkeypatch.setattr("src.settings.service.get_settings_service", lambda: svc)
+
+    assert ConfigManager._has_configured_board_instance() is True

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -307,6 +307,26 @@ def test_apply_env_overrides_ignores_placeholder_values(monkeypatch, tmp_path):
     assert cm.get_board()["local_api_key"] == ""
 
 
+def test_apply_env_overrides_applies_note_array_token_when_empty(monkeypatch, tmp_path):
+    """BOARD_NOTE_ARRAY_TOKEN bootstraps the note-array token when config is empty."""
+    monkeypatch.setenv("BOARD_NOTE_ARRAY_TOKEN", "env-note-array-token")
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"board": {}, "features": {}, "general": {}}))
+    cm = ConfigManager(config_path=str(config_path))
+    assert cm.get_board()["note_array_token"] == "env-note-array-token"
+
+
+def test_apply_env_overrides_does_not_override_existing_note_array_token(monkeypatch, tmp_path):
+    """A token already stored (e.g. via the UI) is not clobbered by the env var."""
+    monkeypatch.setenv("BOARD_NOTE_ARRAY_TOKEN", "env-token-should-not-win")
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps({"board": {"note_array_token": "ui-stored-token"}, "features": {}, "general": {}})
+    )
+    cm = ConfigManager(config_path=str(config_path))
+    assert cm.get_board()["note_array_token"] == "ui-stored-token"
+
+
 def test_apply_env_overrides_invalid_int_value(monkeypatch, tmp_path):
     """Handles invalid int env var values."""
     monkeypatch.setenv("BOARD_TRANSITION_INTERVAL_MS", "not_a_number")

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -71,14 +71,10 @@ class TestDeviceConstants:
         assert "note_array" in DEVICE_TYPES
 
     def test_valid_api_modes(self):
-        """VALID_API_MODES contains local and cloud."""
+        """VALID_API_MODES contains only local and cloud (no note_array entry)."""
         assert VALID_API_MODES == ("local", "cloud")
         assert "local" in VALID_API_MODES
         assert "cloud" in VALID_API_MODES
-
-    def test_valid_api_modes_unchanged(self):
-        """VALID_API_MODES still only contains 'local' and 'cloud' — no 'note_array' entry."""
-        assert VALID_API_MODES == ("local", "cloud")
         assert "note_array" not in VALID_API_MODES
 
 
@@ -352,6 +348,21 @@ class TestNoteArrayToken:
         """The note_array_token field exists on non-note-array boards too (dataclass symmetry)."""
         board = BoardInstance(device_type="flagship")
         assert board.note_array_token == ""
+
+    def test_note_array_token_whitespace_stripped_on_from_dict(self):
+        """from_dict strips surrounding whitespace (consistent with other credential fields)."""
+        board = BoardInstance.from_dict(
+            {"device_type": "note_array", "note_array_token": "  tok-trim  ", "notes_wide": 2, "notes_tall": 1}
+        )
+        assert board.note_array_token == "tok-trim"
+
+    def test_note_array_whitespace_only_token_not_configured(self):
+        """A whitespace-only token is stripped to empty, so the board is not configured."""
+        board = BoardInstance.from_dict(
+            {"device_type": "note_array", "note_array_token": "   ", "notes_wide": 2, "notes_tall": 1}
+        )
+        assert board.note_array_token == ""
+        assert board.is_connection_configured is False
 
 
 class TestNoteArrayConstants:

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -76,6 +76,11 @@ class TestDeviceConstants:
         assert "local" in VALID_API_MODES
         assert "cloud" in VALID_API_MODES
 
+    def test_valid_api_modes_unchanged(self):
+        """VALID_API_MODES still only contains 'local' and 'cloud' — no 'note_array' entry."""
+        assert VALID_API_MODES == ("local", "cloud")
+        assert "note_array" not in VALID_API_MODES
+
 
 class TestBoardInstanceDefaults:
     """Tests for BoardInstance default values."""
@@ -192,6 +197,40 @@ class TestBoardInstanceConnectionConfigured:
         )
         assert board.is_connection_configured is False
 
+    def test_note_array_configured_with_token_and_valid_wh(self):
+        """Note-array board with token and valid W×H is configured."""
+        board = BoardInstance(device_type="note_array", note_array_token="tok-abc", notes_wide=2, notes_tall=1)
+        assert board.is_connection_configured is True
+
+    def test_note_array_not_configured_missing_token(self):
+        """Note-array board without token is not configured."""
+        board = BoardInstance(device_type="note_array", note_array_token="", notes_wide=2, notes_tall=1)
+        assert board.is_connection_configured is False
+
+    def test_note_array_not_configured_empty_token_even_with_cloud_key(self):
+        """cloud_key is irrelevant for note_array boards — token is required."""
+        board = BoardInstance(
+            device_type="note_array", note_array_token="", cloud_key="cloud-k", notes_wide=2, notes_tall=1
+        )
+        assert board.is_connection_configured is False
+
+    def test_note_array_token_does_not_affect_flagship_configured_check(self):
+        """Flagship board with note_array_token set but no local creds is still not configured."""
+        board = BoardInstance(
+            device_type="flagship", note_array_token="tok-abc", api_mode="local", local_api_key="", host=""
+        )
+        assert board.is_connection_configured is False
+
+    def test_cloud_mode_flagship_still_works_unchanged(self):
+        """Cloud mode flagship with cloud_key is configured (unchanged behaviour)."""
+        board = BoardInstance(device_type="flagship", api_mode="cloud", cloud_key="ck-xyz")
+        assert board.is_connection_configured is True
+
+    def test_local_mode_flagship_still_works_unchanged(self):
+        """Local mode flagship with key+host is configured (unchanged behaviour)."""
+        board = BoardInstance(api_mode="local", local_api_key="lk", host="192.168.1.1")
+        assert board.is_connection_configured is True
+
 
 class TestBoardInstanceToDict:
     """Tests for BoardInstance to_dict and from_dict."""
@@ -280,6 +319,39 @@ class TestBoardInstanceToDict:
         data = {"port": None}
         board = BoardInstance.from_dict(data)
         assert board.port == 7000
+
+
+class TestNoteArrayToken:
+    """Tests for the note_array_token field on BoardInstance."""
+
+    def test_note_array_token_default_is_empty_string(self):
+        """BoardInstance() initialises note_array_token to an empty string."""
+        board = BoardInstance()
+        assert board.note_array_token == ""
+
+    def test_note_array_token_explicit_value_preserved(self):
+        """An explicit note_array_token is stored unchanged."""
+        board = BoardInstance(note_array_token="tok-abc123")
+        assert board.note_array_token == "tok-abc123"
+
+    def test_note_array_token_round_trip_to_dict_from_dict(self):
+        """note_array_token survives a to_dict/from_dict round-trip."""
+        original = BoardInstance(device_type="note_array", note_array_token="tok-xyz", notes_wide=2, notes_tall=1)
+        data = original.to_dict()
+        assert data["note_array_token"] == "tok-xyz"
+        restored = BoardInstance.from_dict(data)
+        assert restored.note_array_token == "tok-xyz"
+
+    def test_note_array_token_absent_from_old_json_defaults_to_empty(self):
+        """Old JSON without note_array_token key loads with empty string default."""
+        data = {"id": "x", "device_type": "note_array", "notes_wide": 2, "notes_tall": 1}
+        board = BoardInstance.from_dict(data)
+        assert board.note_array_token == ""
+
+    def test_flagship_board_has_note_array_token_field(self):
+        """The note_array_token field exists on non-note-array boards too (dataclass symmetry)."""
+        board = BoardInstance(device_type="flagship")
+        assert board.note_array_token == ""
 
 
 class TestNoteArrayConstants:


### PR DESCRIPTION
## Summary

Persist the note-array Cloud API token (`note_array_token`) on `BoardInstance`, mask it as a secret everywhere other credentials are, and update `is_connection_configured` to recognise a note-array board as configured when it has a non-empty token.

## What changed

- **`src/devices.py`** — new `note_array_token: str = ""` field on `BoardInstance`; `is_connection_configured` now short-circuits on `is_note_array(device_type)` and requires the token (plus `notes_wide`/`notes_tall` ≥ 1); `from_dict` extracts the field with `""` default for backward-compat; `to_dict` via `asdict` serialises it automatically.
- **`src/settings/service.py`** — added `note_array_token` to `BOARD_SENSITIVE_FIELDS` so it is masked to `"***"` in API responses and preserved when the UI echoes `"***"` back.
- **`src/config_manager.py`** — added `note_array_token` to `SENSITIVE_FIELDS` (masked in `get_all_masked`) and to `DEFAULT_CONFIG["board"]` (enables `set_board` guard); added env-var override `BOARD_NOTE_ARRAY_TOKEN` in `_apply_env_overrides`.
- **`env.example`** — documents `BOARD_NOTE_ARRAY_TOKEN` with a placeholder value (no real token).
- **`tests/test_devices.py`** — new `TestNoteArrayToken` class (5 tests); extended `TestBoardInstanceConnectionConfigured` (6 new tests); `test_valid_api_modes_unchanged` in `TestDeviceConstants`.
- **`tests/test_config_manager.py`** — 4 new round-trip/masking/configured tests via `SettingsService`.

## api_mode locked decision

`VALID_API_MODES` stays `("local", "cloud")`. A note-array board uses `api_mode="cloud"` + the new `note_array_token` field. Routing in **#1168** branches on `is_note_array(device_type)`, not `api_mode`, to pick the correct endpoint and credential. See the plan for full rationale.

## Acceptance criteria

- [x] A board with `device_type=note_array` + `note_array_token` + W×H persists and reports `is_connection_configured == True` — covered by `TestBoardInstanceConnectionConfigured::test_note_array_configured_with_token_and_valid_wh`
- [x] Round-trips through config_manager without losing token or W×H — covered by `test_note_array_token_persists_through_settings_service_round_trip` and `TestNoteArrayToken::test_note_array_token_round_trip_to_dict_from_dict`
- [x] `env.example` documents the token with a placeholder — `BOARD_NOTE_ARRAY_TOKEN=your_note_array_token_here` added

## Test evidence

```
docker-compose -f docker-compose.dev.yml exec -T fiestaboard pytest tests/test_devices.py tests/test_config_manager.py -q
# 169 passed in 0.25s
```

Broader regression (tests/ scope, keyword filter):
```
docker-compose -f docker-compose.dev.yml exec -T fiestaboard pytest tests/ -q -k "device or config or settings or board"
# 1213 passed, 1 skipped (the 1 failure is a pre-existing pytest-asyncio issue in tests/ai/ unrelated to this PR)
```

## Token masking confirmation

- `BOARD_SENSITIVE_FIELDS` in `settings/service.py` masks `note_array_token` → `"***"` in API responses
- `SENSITIVE_FIELDS` in `config_manager.py` masks it in `get_all_masked()`
- `update_boards` (via `set_boards`) preserves real token when UI echoes `"***"` back
- `env.example` uses `your_note_array_token_here` placeholder — no real token

## ruff

```
docker run --rm -v "$(pwd)":/io -w /io ghcr.io/astral-sh/ruff:0.15.17 format src/devices.py src/config_manager.py src/settings/service.py tests/test_devices.py tests/test_config_manager.py
# 1 file reformatted, 4 files left unchanged

docker run --rm -v "$(pwd)":/io -w /io ghcr.io/astral-sh/ruff:0.15.17 check src/devices.py src/config_manager.py src/settings/service.py tests/test_devices.py tests/test_config_manager.py
# All checks passed!
```

---

Part of #1167 · Implements #1170