### PR TITLE
feat(api): de-hardcode board geometry for note arrays [#1171]

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -36,7 +36,7 @@ from .collections.models import CollectionCreate, CollectionUpdate, is_collectio
 from .collections.service import get_collection_service  # noqa: E402
 from .config import Config  # noqa: E402
 from .config_manager import get_config_manager  # noqa: E402
-from .devices import get_dimensions  # noqa: E402
+from .devices import get_dimensions, resolve_dimensions  # noqa: E402
 from .displays.service import get_display_service, reset_display_service  # noqa: E402
 from .main import DisplayService  # noqa: E402
 from .network.wifi import WiFiError, get_wifi_service  # noqa: E402
@@ -3087,7 +3087,12 @@ _WELCOME_TEMPLATE_NOTE = [
 ]
 
 
-def _build_welcome_template(device_type: str, custom_msg: str) -> list:
+def _build_welcome_template(
+    device_type: str,
+    custom_msg: str,
+    notes_wide: int = 1,
+    notes_tall: int = 1,
+) -> list:
     """Build the welcome message template for a given device type.
 
     Returns a list of template strings (one per row) sized appropriately
@@ -3095,16 +3100,29 @@ def _build_welcome_template(device_type: str, custom_msg: str) -> list:
     fit the device's column count.
 
     Args:
-        device_type: "flagship" or "note"
+        device_type: "flagship", "note", or "note_array"
         custom_msg: Optional user-configured welcome message; when empty,
             a device-appropriate default is used.
+        notes_wide: For note_array: number of notes side-by-side (default 1).
+        notes_tall: For note_array: number of notes stacked (default 1).
     """
+    try:
+        dims = resolve_dimensions(device_type, notes_wide=notes_wide, notes_tall=notes_tall)
+    except ValueError:
+        dims = resolve_dimensions("flagship")
+
+    cols = dims.cols
+
     if device_type == "note":
-        cols = 15
         default_msg = _DEFAULT_WELCOME_NOTE
         rows = list(_WELCOME_TEMPLATE_NOTE)
+    elif device_type == "note_array":
+        default_msg = _DEFAULT_WELCOME_NOTE
+        # Generate a plain template: blank rows with center row carrying text
+        center_idx = dims.rows // 2
+        rows = [""] * dims.rows
+        rows[center_idx] = "{center}"
     else:
-        cols = 22
         default_msg = _DEFAULT_WELCOME_FLAGSHIP
         rows = list(_WELCOME_TEMPLATE_FLAGSHIP)
 
@@ -3165,10 +3183,11 @@ async def send_welcome_message():
         settings_service = get_settings_service()
         transition = settings_service.get_transition_settings()
 
-        # Determine device type from configured boards (defaults to flagship).
-        # The Note has different dimensions (3x15 vs flagship's 6x22), so we
-        # render a smaller welcome message that fits its display.
+        # Determine device type and array dimensions from configured boards
+        # (defaults to flagship 6×22). Note arrays use notes_wide/notes_tall
+        # to compute the actual grid size.
         device_type = "flagship"
+        nw, nt = 1, 1
         try:
             board_settings = settings_service.get_board_settings()
             boards = getattr(board_settings, "boards", None) or []
@@ -3176,18 +3195,22 @@ async def send_welcome_message():
                 first = boards[0]
                 if isinstance(first, dict):
                     dt = first.get("device_type", "flagship")
+                    nw = first.get("notes_wide", 1)
+                    nt = first.get("notes_tall", 1)
                 else:
                     dt = getattr(first, "device_type", "flagship")
-                if dt in ("flagship", "note"):
+                    nw = getattr(first, "notes_wide", 1)
+                    nt = getattr(first, "notes_tall", 1)
+                if dt in ("flagship", "note", "note_array"):
                     device_type = dt
         except Exception as exc:  # pragma: no cover - defensive
-            logger.debug(f"Could not determine device type for welcome message: {exc}")
+            logger.debug("Could not determine device type for welcome message: %s", exc)
 
-        welcome_template = _build_welcome_template(device_type, custom_msg)
+        welcome_template = _build_welcome_template(device_type, custom_msg, notes_wide=nw, notes_tall=nt)
 
         # Convert template to board array sized for the target device
         welcome_text = "\n".join(welcome_template)
-        dims = get_dimensions(device_type)
+        dims = resolve_dimensions(device_type, notes_wide=nw, notes_tall=nt)
         board_array = text_to_board_array(welcome_text, rows=dims.rows, cols=dims.cols)
 
         success, was_sent = board_client.send_characters(
@@ -5825,6 +5848,32 @@ def _get_board_client():
     return None
 
 
+def _get_first_board_dims():
+    """Return resolved dimensions for the first configured board.
+
+    Falls back to flagship 6×22 when the boards list is empty or settings
+    cannot be read. Safe to call from any endpoint — never raises.
+    """
+    try:
+        settings_service = get_settings_service()
+        board_settings = settings_service.get_board_settings()
+        boards = getattr(board_settings, "boards", None) or []
+        if boards:
+            first = boards[0]
+            if isinstance(first, dict):
+                dt = first.get("device_type", "flagship")
+                nw = first.get("notes_wide", 1)
+                nt = first.get("notes_tall", 1)
+            else:
+                dt = getattr(first, "device_type", "flagship")
+                nw = getattr(first, "notes_wide", 1)
+                nt = getattr(first, "notes_tall", 1)
+            return resolve_dimensions(dt, notes_wide=nw, notes_tall=nt)
+    except Exception as exc:
+        logger.debug("Could not resolve board dims (using flagship default): %s", exc)
+    return resolve_dimensions("flagship")
+
+
 def _board_is_paused(board_id: str | None = None) -> bool:
     """Return True when the target board (or default board) is paused.
 
@@ -5872,9 +5921,10 @@ async def debug_blank_board():
         logger.info("Board is paused - blocking debug blank send")
         return _paused_response()
 
+    dims = _get_first_board_dims()
     try:
-        # Create a 6x22 array filled with spaces (code 0)
-        blank_array = [[0] * 22 for _ in range(6)]
+        # Create an array of spaces (code 0) sized for the active board
+        blank_array = [[0] * dims.cols for _ in range(dims.rows)]
         success, was_sent = client.send_characters(blank_array, force=True)
 
         if success:
@@ -5915,9 +5965,10 @@ async def debug_fill_board(request: dict):
         logger.info("Board is paused - blocking debug fill send")
         return _paused_response()
 
+    dims = _get_first_board_dims()
     try:
-        # Create a 6x22 array filled with the specified character
-        fill_array = [[character_code] * 22 for _ in range(6)]
+        # Create an array filled with the specified character, sized for the active board
+        fill_array = [[character_code] * dims.cols for _ in range(dims.rows)]
         success, was_sent = client.send_characters(fill_array, force=True)
 
         if success:
@@ -5954,7 +6005,7 @@ async def debug_show_info():
     now = time_service.get_current_time()
     timestamp = now.strftime("%H:%M")
 
-    # Build debug info text (6 lines max, 22 chars each)
+    # Build debug info text (line/char limits sized to active board)
     debug_text = f"""DEBUG INFO
 BOARD: {board_ip[:15]}
 SERVER: {server_ip[:14]}

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -6005,7 +6005,11 @@ async def debug_show_info():
     now = time_service.get_current_time()
     timestamp = now.strftime("%H:%M")
 
-    # Build debug info text (line/char limits sized to active board)
+    # Build debug info text. The per-line slice caps below are flagship-oriented
+    # (~22 col); the final grid is sized to the active board's dimensions when
+    # converted to a board array (see text_to_board_array call). On narrow boards
+    # the converter wraps/truncates to the real width. Per-line polish for exotic
+    # widths is deferred (see #1173).
     debug_text = f"""DEBUG INFO
 BOARD: {board_ip[:15]}
 SERVER: {server_ip[:14]}
@@ -6026,10 +6030,11 @@ V{version[:7]} {timestamp}"""
         return {**_paused_response(), "debug_info": debug_text}
 
     try:
-        # Convert text to board array
+        # Convert text to board array, sized to the active board's dimensions
         from .text_to_board import text_to_board_array
 
-        board_array = text_to_board_array(debug_text, use_color_tiles=False)
+        dims = _get_first_board_dims()
+        board_array = text_to_board_array(debug_text, use_color_tiles=False, rows=dims.rows, cols=dims.cols)
 
         success, was_sent = client.send_characters(board_array, force=True)
 

--- a/src/displays/service.py
+++ b/src/displays/service.py
@@ -10,8 +10,6 @@ import logging
 from dataclasses import dataclass
 from typing import Any
 
-from src.formatters.message_formatter import get_message_formatter
-
 # Import plugin system
 try:
     from src.plugins import PluginRegistry, get_plugin_registry
@@ -49,7 +47,6 @@ class DisplayService:
 
     def __init__(self):
         """Initialize display service with plugin registry."""
-        self.formatter = get_message_formatter()
         self._plugin_registry: PluginRegistry | None = None
 
         if PLUGIN_SYSTEM_AVAILABLE:

--- a/src/formatters/message_formatter.py
+++ b/src/formatters/message_formatter.py
@@ -327,18 +327,9 @@ class MessageFormatter:
                 # Very compact - color tile before temp
                 lines.append(f"{location}: {temp_color} {temp}F")
 
-        # Ensure we don't exceed 6 rows
-        result = "\n".join(lines[: self._rows])
-
-        # Truncate each line to 22 characters if needed (accounting for color markers)
-        result_lines = result.split("\n")
-        truncated = []
-        for line in result_lines:
-            # Don't count color markers toward the 22 char limit
-            # They get stripped during conversion
-            truncated.append(line)
-
-        return "\n".join(truncated)
+        # Cap at the board's row count; per-line width is enforced later during
+        # text->grid conversion (which strips color markers before measuring).
+        return "\n".join(lines[: self._rows])
 
     def _get_temp_color(self, temp: int) -> str:
         """
@@ -373,7 +364,7 @@ class MessageFormatter:
             max_lines: Maximum number of lines
 
         Returns:
-            List of lines (each max 22 characters)
+            List of lines (each at most self._cols characters)
         """
         lines = text.split("\n")
         result = []

--- a/src/formatters/message_formatter.py
+++ b/src/formatters/message_formatter.py
@@ -16,13 +16,24 @@ logger = logging.getLogger(__name__)
 
 
 class MessageFormatter:
-    """Formats data for board 6x22 character grid."""
+    """Formats data for a configurable board character grid.
+
+    Class-level MAX_ROWS/MAX_COLS remain for backward compatibility.
+    Instance-level _rows/_cols reflect the target board's actual dimensions.
+    """
 
     MAX_ROWS = 6
     MAX_COLS = 22
 
-    def __init__(self):
-        """Initialize message formatter."""
+    def __init__(self, rows: int = 6, cols: int = 22) -> None:
+        """Initialize message formatter.
+
+        Args:
+            rows: Number of rows for the target board (default 6 for flagship).
+            cols: Number of columns for the target board (default 22 for flagship).
+        """
+        self._rows = rows
+        self._cols = cols
 
     def format_weather(self, weather_data: dict) -> str:
         """
@@ -72,7 +83,7 @@ class MessageFormatter:
             lines.append(" | ".join(info_parts))
 
         # Ensure we don't exceed 6 rows
-        return "\n".join(lines[: self.MAX_ROWS])
+        return "\n".join(lines[: self._rows])
 
     def format_datetime(self, datetime_data: dict) -> str:
         """
@@ -106,7 +117,7 @@ class MessageFormatter:
             else:
                 lines.append(time_str)
 
-        return "\n".join(lines[: self.MAX_ROWS])
+        return "\n".join(lines[: self._rows])
 
     def format_guest_wifi(self, ssid: str, password: str) -> str:
         """
@@ -132,14 +143,14 @@ class MessageFormatter:
 
         # SSID with blue tile indicator
         ssid_line = f"{{{{blue}}}} {ssid}"
-        lines.append(ssid_line[: self.MAX_COLS + 8])  # +8 for {{blue}} marker
+        lines.append(ssid_line[: self._cols + 8])  # +8 for {{blue}} marker
 
         # Password with violet tile indicator
         pass_line = f"{{{{violet}}}} {password}"
-        lines.append(pass_line[: self.MAX_COLS + 10])  # +10 for {{violet}} marker
+        lines.append(pass_line[: self._cols + 10])  # +10 for {{violet}} marker
 
         # Ensure we don't exceed 6 rows
-        return "\n".join(lines[: self.MAX_ROWS])
+        return "\n".join(lines[: self._rows])
 
     def format_star_trek_quote(self, quote_data: dict) -> str:
         """
@@ -177,20 +188,20 @@ class MessageFormatter:
         lines.extend(quote_lines)
 
         # Add separator if we have room
-        if len(lines) < self.MAX_ROWS - 1:
+        if len(lines) < self._rows - 1:
             lines.append("")
 
         # Add attribution with series color tile if we have room
-        if len(lines) < self.MAX_ROWS:
-            if series_color and len(lines) < self.MAX_ROWS - 1:
+        if len(lines) < self._rows:
+            if series_color and len(lines) < self._rows - 1:
                 # Room for character line and series line with color
-                lines.append(f"- {character}"[: self.MAX_COLS])
-                lines.append(f"{series_color} {series_display}"[: self.MAX_COLS + 8])
+                lines.append(f"- {character}"[: self._cols])
+                lines.append(f"{series_color} {series_display}"[: self._cols + 8])
             else:
                 # Combine into one line
-                lines.append(f"- {character} ({series_display})"[: self.MAX_COLS])
+                lines.append(f"- {character} ({series_display})"[: self._cols])
 
-        return "\n".join(lines[: self.MAX_ROWS])
+        return "\n".join(lines[: self._rows])
 
     def format_house_status(self, status_data: dict[str, dict]) -> str:
         """
@@ -215,7 +226,7 @@ class MessageFormatter:
 
         # Process each entity
         for name, info in status_data.items():
-            if len(lines) >= self.MAX_ROWS:
+            if len(lines) >= self._rows:
                 break
 
             state = info.get("state", "unknown").lower()
@@ -246,13 +257,13 @@ class MessageFormatter:
 
             # Format: "{color} Name: status"
             # Account for color marker length when truncating
-            max_name_len = self.MAX_COLS - len(f" : {status_text}") - 1  # -1 for indicator tile
+            max_name_len = self._cols - len(f" : {status_text}") - 1  # -1 for indicator tile
             display_name = name[:max_name_len] if len(name) > max_name_len else name
 
             line = f"{indicator} {display_name}: {status_text}"
             lines.append(line)
 
-        return "\n".join(lines[: self.MAX_ROWS])
+        return "\n".join(lines[: self._rows])
 
     def format_combined(self, weather_data: dict | None, datetime_data: dict | None) -> str:
         """
@@ -290,7 +301,7 @@ class MessageFormatter:
                 lines.append(time_str)
 
             # Add separator if we have weather
-            if weather_data and len(lines) < self.MAX_ROWS:
+            if weather_data and len(lines) < self._rows:
                 lines.append("")
 
         # Weather information
@@ -308,16 +319,16 @@ class MessageFormatter:
             temp_color = self._get_temp_color(temp)
 
             # Compact format to fit
-            if len(lines) + 2 <= self.MAX_ROWS:
+            if len(lines) + 2 <= self._rows:
                 lines.append(f"{location}: {symbol} {condition_display}")
                 # Temperature with color tile indicator before the number
                 lines.append(f"Temp: {temp_color} {temp}F")
-            elif len(lines) + 1 <= self.MAX_ROWS:
+            elif len(lines) + 1 <= self._rows:
                 # Very compact - color tile before temp
                 lines.append(f"{location}: {temp_color} {temp}F")
 
         # Ensure we don't exceed 6 rows
-        result = "\n".join(lines[: self.MAX_ROWS])
+        result = "\n".join(lines[: self._rows])
 
         # Truncate each line to 22 characters if needed (accounting for color markers)
         result_lines = result.split("\n")
@@ -369,12 +380,12 @@ class MessageFormatter:
 
         for line in lines[:max_lines]:
             # If line is too long, try to split on spaces
-            if len(line) > self.MAX_COLS:
+            if len(line) > self._cols:
                 words = line.split()
                 current_line = ""
 
                 for word in words:
-                    if len(current_line) + len(word) + 1 <= self.MAX_COLS:
+                    if len(current_line) + len(word) + 1 <= self._cols:
                         if current_line:
                             current_line += " " + word
                         else:
@@ -427,7 +438,7 @@ class MessageFormatter:
 
         # Stop name (if available and fits)
         if stop_name:
-            lines.append(stop_name[: self.MAX_COLS])
+            lines.append(stop_name[: self._cols])
 
         # Format arrival times
         if arrivals:
@@ -455,15 +466,15 @@ class MessageFormatter:
             if is_delayed:
                 arrival_line = f"{{{{red}}}}{arrival_line}"
 
-            lines.append(arrival_line[: self.MAX_COLS + 10])  # Account for color markers
+            lines.append(arrival_line[: self._cols + 10])  # Account for color markers
         else:
             lines.append(f"{line}: No arrivals")
 
         # Add delay description if present
-        if delay_description and len(lines) < self.MAX_ROWS:
-            lines.append(delay_description[: self.MAX_COLS])
+        if delay_description and len(lines) < self._rows:
+            lines.append(delay_description[: self._cols])
 
-        return "\n".join(lines[: self.MAX_ROWS])
+        return "\n".join(lines[: self._rows])
 
     def format_stocks(self, stocks_data: dict) -> str:
         """
@@ -491,9 +502,14 @@ class MessageFormatter:
                 lines.append(formatted)
 
         # Ensure we don't exceed 6 rows
-        return "\n".join(lines[: self.MAX_ROWS])
+        return "\n".join(lines[: self._rows])
 
 
-def get_message_formatter() -> MessageFormatter:
-    """Get message formatter instance."""
-    return MessageFormatter()
+def get_message_formatter(rows: int = 6, cols: int = 22) -> MessageFormatter:
+    """Get message formatter instance sized for a specific board.
+
+    Args:
+        rows: Number of rows for the target board (default 6 for flagship).
+        cols: Number of columns for the target board (default 22 for flagship).
+    """
+    return MessageFormatter(rows=rows, cols=cols)

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -436,6 +436,84 @@ class TestSendWelcomeMessage:
             welcome_text = mock_ttba.call_args.args[0]
             assert "HIYA FROM FIESTABOARD" in welcome_text
 
+    def test_welcome_uses_note_array_template(self, client):
+        """note_array 2-wide board: text_to_board_array called with rows=3, cols=30."""
+        with (
+            patch("src.api_server.Config") as mock_config,
+            patch("src.board_client.BoardClient") as MockBoardClient,
+            patch("src.api_server.text_to_board_array") as mock_ttba,
+            patch("src.api_server.get_settings_service") as mock_ss,
+        ):
+            mock_config.is_silence_mode_active.return_value = False
+            mock_config.BOARD_API_MODE = "local"
+            mock_config.get_board_api_key.return_value = "test_key_12345"
+            mock_config.BOARD_HOST = "192.168.1.100"
+
+            board_client = Mock()
+            board_client.send_characters.return_value = (True, True)
+            MockBoardClient.return_value = board_client
+
+            mock_ttba.return_value = [[0] * 30 for _ in range(3)]
+
+            ss = Mock()
+            transition = Mock()
+            transition.strategy = "column"
+            transition.step_interval_ms = 100
+            transition.step_size = 1
+            ss.get_transition_settings.return_value = transition
+            board_settings = Mock()
+            board_settings.boards = [{"device_type": "note_array", "notes_wide": 2, "notes_tall": 1}]
+            ss.get_board_settings.return_value = board_settings
+            mock_ss.return_value = ss
+
+            response = client.post("/send-welcome-message")
+            assert response.status_code == 200
+            assert response.json()["status"] == "success"
+
+            assert mock_ttba.call_count == 1
+            kwargs = mock_ttba.call_args.kwargs
+            assert kwargs.get("rows") == 3
+            assert kwargs.get("cols") == 30
+
+    def test_welcome_note_array_2tall(self, client):
+        """note_array 2-tall board: text_to_board_array called with rows=6, cols=15."""
+        with (
+            patch("src.api_server.Config") as mock_config,
+            patch("src.board_client.BoardClient") as MockBoardClient,
+            patch("src.api_server.text_to_board_array") as mock_ttba,
+            patch("src.api_server.get_settings_service") as mock_ss,
+        ):
+            mock_config.is_silence_mode_active.return_value = False
+            mock_config.BOARD_API_MODE = "local"
+            mock_config.get_board_api_key.return_value = "test_key_12345"
+            mock_config.BOARD_HOST = "192.168.1.100"
+
+            board_client = Mock()
+            board_client.send_characters.return_value = (True, True)
+            MockBoardClient.return_value = board_client
+
+            mock_ttba.return_value = [[0] * 15 for _ in range(6)]
+
+            ss = Mock()
+            transition = Mock()
+            transition.strategy = "column"
+            transition.step_interval_ms = 100
+            transition.step_size = 1
+            ss.get_transition_settings.return_value = transition
+            board_settings = Mock()
+            board_settings.boards = [{"device_type": "note_array", "notes_wide": 1, "notes_tall": 2}]
+            ss.get_board_settings.return_value = board_settings
+            mock_ss.return_value = ss
+
+            response = client.post("/send-welcome-message")
+            assert response.status_code == 200
+            assert response.json()["status"] == "success"
+
+            assert mock_ttba.call_count == 1
+            kwargs = mock_ttba.call_args.kwargs
+            assert kwargs.get("rows") == 6
+            assert kwargs.get("cols") == 15
+
 
 class TestBuildWelcomeTemplate:
     """Unit tests for _build_welcome_template helper."""
@@ -480,6 +558,38 @@ class TestBuildWelcomeTemplate:
         template = _build_welcome_template("unknown", "")
         assert len(template) == 6
         assert template[2] == "HIYA FROM FIESTABOARD"
+
+    def test_note_array_2wide_template_has_3_rows(self):
+        """note_array 2-wide (3×30) template has exactly 3 rows."""
+        from src.api_server import _build_welcome_template
+
+        template = _build_welcome_template("note_array", "", notes_wide=2, notes_tall=1)
+        assert len(template) == 3
+
+    def test_note_array_2wide_template_center_fits_cols(self):
+        """note_array 2-wide center row contains the custom message and fits ≤30 chars."""
+        from src.api_server import _build_welcome_template
+
+        template = _build_welcome_template("note_array", "HI", notes_wide=2, notes_tall=1)
+        # center row is at index dims.rows // 2 = 1
+        center_row = template[1]
+        assert center_row == "HI"
+        assert len(center_row) <= 30
+
+    def test_note_array_2tall_template_has_6_rows(self):
+        """note_array 2-tall (6×15) template has exactly 6 rows."""
+        from src.api_server import _build_welcome_template
+
+        template = _build_welcome_template("note_array", "", notes_wide=1, notes_tall=2)
+        assert len(template) == 6
+
+    def test_note_array_custom_msg_truncated_to_cols(self):
+        """note_array 2-wide truncates custom message to 30 chars."""
+        from src.api_server import _build_welcome_template
+
+        template = _build_welcome_template("note_array", "a" * 50, notes_wide=2, notes_tall=1)
+        center_row = template[1]
+        assert len(center_row) == 30
 
 
 # ===========================================================================

--- a/tests/test_debug_endpoints.py
+++ b/tests/test_debug_endpoints.py
@@ -7,6 +7,28 @@ from fastapi.testclient import TestClient
 
 from src.api_server import app
 
+# ---------------------------------------------------------------------------
+# Helper: build a mock SettingsService pre-configured for a given board type
+# ---------------------------------------------------------------------------
+
+
+def _mock_ss(device_type="flagship", notes_wide=1, notes_tall=1, send_to_board=True):
+    """Return a Mock SettingsService wired for a specific board geometry.
+
+    Args:
+        device_type: "flagship", "note", or "note_array"
+        notes_wide: number of notes side-by-side (for note_array)
+        notes_tall: number of notes stacked (for note_array)
+        send_to_board: return value for should_send_to_board()
+    """
+    ss = Mock()
+    ss.should_send_to_board.return_value = send_to_board
+    ss.is_paused.return_value = False
+    board_settings = Mock()
+    board_settings.boards = [{"device_type": device_type, "notes_wide": notes_wide, "notes_tall": notes_tall}]
+    ss.get_board_settings.return_value = board_settings
+    return ss
+
 
 @pytest.fixture
 def client():
@@ -56,6 +78,35 @@ class TestDebugBlank:
             assert response.status_code == 400
             assert "not configured" in response.json()["detail"].lower()
 
+    # --- geometry tests: blank array must be sized per board type ---
+
+    def test_blank_flagship_grid_size(self, client, mock_board_client):
+        """Flagship board: blank produces a 6×22 array of zeros."""
+        with patch("src.api_server.get_settings_service", return_value=_mock_ss("flagship")):
+            response = client.post("/debug/blank")
+        assert response.status_code == 200
+        args = mock_board_client.send_characters.call_args
+        assert args[0][0] == [[0] * 22 for _ in range(6)]
+
+    def test_blank_note_grid_size(self, client, mock_board_client):
+        """Note board: blank produces a 3×15 array of zeros."""
+        with patch("src.api_server.get_settings_service", return_value=_mock_ss("note")):
+            response = client.post("/debug/blank")
+        assert response.status_code == 200
+        args = mock_board_client.send_characters.call_args
+        assert args[0][0] == [[0] * 15 for _ in range(3)]
+
+    def test_blank_note_array_2x2_grid_size(self, client, mock_board_client):
+        """Note-array 2×2: blank produces a 6×30 array of zeros."""
+        with patch(
+            "src.api_server.get_settings_service",
+            return_value=_mock_ss("note_array", notes_wide=2, notes_tall=2),
+        ):
+            response = client.post("/debug/blank")
+        assert response.status_code == 200
+        args = mock_board_client.send_characters.call_args
+        assert args[0][0] == [[0] * 30 for _ in range(6)]
+
 
 class TestDebugFill:
     """Tests for /debug/fill endpoint."""
@@ -94,6 +145,46 @@ class TestDebugFill:
             response = client.post("/debug/fill", json={"character_code": 63})
             assert response.status_code == 400
 
+    # --- geometry tests: grid must be sized per board type ---
+
+    def test_fill_flagship_grid_size(self, client, mock_board_client):
+        """Flagship board: fill produces a 6×22 grid."""
+        with patch("src.api_server.get_settings_service", return_value=_mock_ss("flagship")):
+            response = client.post("/debug/fill", json={"character_code": 63})
+        assert response.status_code == 200
+        args = mock_board_client.send_characters.call_args
+        assert args[0][0] == [[63] * 22 for _ in range(6)]
+
+    def test_fill_note_grid_size(self, client, mock_board_client):
+        """Note board: fill produces a 3×15 grid."""
+        with patch("src.api_server.get_settings_service", return_value=_mock_ss("note")):
+            response = client.post("/debug/fill", json={"character_code": 5})
+        assert response.status_code == 200
+        args = mock_board_client.send_characters.call_args
+        assert args[0][0] == [[5] * 15 for _ in range(3)]
+
+    def test_fill_note_array_2wide_grid_size(self, client, mock_board_client):
+        """Note-array 2-wide: fill produces a 3×30 grid."""
+        with patch(
+            "src.api_server.get_settings_service",
+            return_value=_mock_ss("note_array", notes_wide=2, notes_tall=1),
+        ):
+            response = client.post("/debug/fill", json={"character_code": 1})
+        assert response.status_code == 200
+        args = mock_board_client.send_characters.call_args
+        assert args[0][0] == [[1] * 30 for _ in range(3)]
+
+    def test_fill_note_array_2tall_grid_size(self, client, mock_board_client):
+        """Note-array 2-tall: fill produces a 6×15 grid."""
+        with patch(
+            "src.api_server.get_settings_service",
+            return_value=_mock_ss("note_array", notes_wide=1, notes_tall=2),
+        ):
+            response = client.post("/debug/fill", json={"character_code": 0})
+        assert response.status_code == 200
+        args = mock_board_client.send_characters.call_args
+        assert args[0][0] == [[0] * 15 for _ in range(6)]
+
 
 class TestDebugInfo:
     """Tests for /debug/info endpoint."""
@@ -120,6 +211,25 @@ class TestDebugInfo:
         with patch("src.api_server._get_board_client", return_value=None):
             response = client.post("/debug/info")
             assert response.status_code == 400
+
+    # --- geometry tests: info should not crash for any board type ---
+
+    def test_info_sends_to_board_flagship(self, client, mock_board_client):
+        """Flagship board: /debug/info succeeds without crashing."""
+        with patch("src.api_server.get_settings_service", return_value=_mock_ss("flagship")):
+            response = client.post("/debug/info")
+        assert response.status_code == 200
+        assert response.json()["status"] == "success"
+
+    def test_info_note_array_does_not_crash(self, client, mock_board_client):
+        """Note-array board: /debug/info does not crash and returns success."""
+        with patch(
+            "src.api_server.get_settings_service",
+            return_value=_mock_ss("note_array", notes_wide=2, notes_tall=1),
+        ):
+            response = client.post("/debug/info")
+        assert response.status_code == 200
+        assert response.json()["status"] == "success"
 
 
 class TestDebugTestConnection:

--- a/tests/test_debug_endpoints.py
+++ b/tests/test_debug_endpoints.py
@@ -58,8 +58,9 @@ class TestDebugBlank:
     """Tests for /debug/blank endpoint."""
 
     def test_blank_board_success(self, client, mock_board_client):
-        """Test blanking the board successfully."""
-        response = client.post("/debug/blank")
+        """Test blanking the board successfully (flagship → 6×22, env-independent)."""
+        with patch("src.api_server.get_settings_service", return_value=_mock_ss("flagship")):
+            response = client.post("/debug/blank")
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == "success"
@@ -112,8 +113,9 @@ class TestDebugFill:
     """Tests for /debug/fill endpoint."""
 
     def test_fill_board_success(self, client, mock_board_client):
-        """Test filling the board with a character."""
-        response = client.post("/debug/fill", json={"character_code": 63})
+        """Test filling the board with a character (flagship → 6×22, env-independent)."""
+        with patch("src.api_server.get_settings_service", return_value=_mock_ss("flagship")):
+            response = client.post("/debug/fill", json={"character_code": 63})
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == "success"
@@ -221,8 +223,8 @@ class TestDebugInfo:
         assert response.status_code == 200
         assert response.json()["status"] == "success"
 
-    def test_info_note_array_does_not_crash(self, client, mock_board_client):
-        """Note-array board: /debug/info does not crash and returns success."""
+    def test_info_note_array_sized_to_board(self, client, mock_board_client):
+        """Note-array board: /debug/info sends a grid sized to the array (3×30 for 2-wide)."""
         with patch(
             "src.api_server.get_settings_service",
             return_value=_mock_ss("note_array", notes_wide=2, notes_tall=1),
@@ -230,6 +232,18 @@ class TestDebugInfo:
             response = client.post("/debug/info")
         assert response.status_code == 200
         assert response.json()["status"] == "success"
+        sent_grid = mock_board_client.send_characters.call_args[0][0]
+        assert len(sent_grid) == 3, "note array (2x1) has 3 rows"
+        assert all(len(row) == 30 for row in sent_grid), "note array (2x1) has 30 cols"
+
+    def test_info_flagship_sized_6x22(self, client, mock_board_client):
+        """Flagship board: /debug/info still sends a byte-identical 6×22 grid."""
+        with patch("src.api_server.get_settings_service", return_value=_mock_ss("flagship")):
+            response = client.post("/debug/info")
+        assert response.status_code == 200
+        sent_grid = mock_board_client.send_characters.call_args[0][0]
+        assert len(sent_grid) == 6
+        assert all(len(row) == 22 for row in sent_grid)
 
 
 class TestDebugTestConnection:

--- a/tests/test_message_formatter.py
+++ b/tests/test_message_formatter.py
@@ -418,3 +418,78 @@ class TestFormatCombined:
 def test_get_message_formatter_returns_instance():
     instance = get_message_formatter()
     assert isinstance(instance, MessageFormatter)
+
+
+# ---------------------------------------------------------------------------
+# Per-instance dimensions (issue #1171)
+# ---------------------------------------------------------------------------
+
+
+class TestMessageFormatterDimensions:
+    def test_init_flagship_defaults(self):
+        """Default constructor produces 6×22 instance."""
+        fmt = MessageFormatter()
+        assert fmt._rows == 6
+        assert fmt._cols == 22
+
+    def test_init_note_dimensions(self):
+        """Note-sized constructor produces 3×15 instance."""
+        fmt = MessageFormatter(rows=3, cols=15)
+        assert fmt._rows == 3
+        assert fmt._cols == 15
+
+    def test_class_constants_unchanged(self):
+        """Class-level MAX_ROWS/MAX_COLS must remain 6/22 for backward compat."""
+        assert MessageFormatter.MAX_ROWS == 6
+        assert MessageFormatter.MAX_COLS == 22
+
+    def test_format_weather_note_truncates_at_3_rows(self):
+        """Note-sized formatter produces ≤3 rows for weather with many items."""
+        fmt = MessageFormatter(rows=3, cols=15)
+        data = {
+            "location": "SF",
+            "condition": "Sunny",
+            "temperature": 72,
+            "feels_like": 65,
+            "humidity": 60,
+            "wind_mph": 10,
+        }
+        result = fmt.format_weather(data)
+        assert len(result.split("\n")) <= 3
+
+    def test_format_weather_flagship_unchanged(self):
+        """Flagship formatter output is identical whether constructed explicitly or by default."""
+        data = {
+            "location": "SF",
+            "condition": "Sunny",
+            "temperature": 72,
+            "feels_like": 72,
+            "humidity": 60,
+            "wind_mph": 10,
+        }
+        default_result = MessageFormatter().format_weather(data)
+        explicit_result = MessageFormatter(rows=6, cols=22).format_weather(data)
+        assert default_result == explicit_result
+
+    def test_split_into_lines_note_cols_wraps_at_15(self):
+        """Note-sized formatter wraps each line at 15 characters."""
+        fmt = MessageFormatter(rows=3, cols=15)
+        long_text = "This is a long sentence that needs wrapping"
+        lines = fmt.split_into_lines(long_text)
+        for line in lines:
+            assert len(line) <= 15
+
+    def test_split_into_lines_note_array_wide(self):
+        """Wide note-array formatter wraps each line at 30 characters."""
+        fmt = MessageFormatter(rows=3, cols=30)
+        long_text = "This is a sentence that is longer than thirty characters total"
+        lines = fmt.split_into_lines(long_text)
+        for line in lines:
+            assert len(line) <= 30
+
+    def test_get_message_formatter_custom_dims(self):
+        """get_message_formatter factory passes rows/cols to instance."""
+        fmt = get_message_formatter(rows=3, cols=15)
+        assert isinstance(fmt, MessageFormatter)
+        assert fmt._rows == 3
+        assert fmt._cols == 15


### PR DESCRIPTION
## Summary

- Replaces all hardcoded `6×22` and `cols = 22` / `range(6)` board-geometry literals in `src/api_server.py` and `src/formatters/message_formatter.py` with resolved dimensions from `resolve_dimensions()`.
- Adds `_get_first_board_dims()` helper that reads the first configured board's device type and `notes_wide`/`notes_tall`, falls back to flagship safely.
- Adds per-instance `rows`/`cols` to `MessageFormatter`; class-level `MAX_ROWS`/`MAX_COLS` preserved for backward compat.
- Flagship/note output is **byte-identical** before and after (proven by existing and new tests).

## De-hardcoded sites

| Site | File | Old | New |
|------|------|-----|-----|
| A | `api_server.py` — `_build_welcome_template` | `if note: cols=15 else: cols=22` | `dims = resolve_dimensions(device_type, notes_wide, notes_tall)` → `cols = dims.cols` |
| B | `api_server.py` — `debug_blank_board` | `[[0] * 22 for _ in range(6)]` | `[[0] * dims.cols for _ in range(dims.rows)]` via `_get_first_board_dims()` |
| C | `api_server.py` — `debug_fill_board` | `[[character_code] * 22 for _ in range(6)]` | `[[character_code] * dims.cols for _ in range(dims.rows)]` via `_get_first_board_dims()` |
| D | `api_server.py` — `debug_show_info` | Comment only: `6 lines max, 22 chars each` | Comment updated; slice caps unchanged (all < min board width) |
| E | `api_server.py` — `send_welcome_message` | `get_dimensions(device_type)` + guard `("flagship", "note")` | `resolve_dimensions(device_type, nw, nt)` + guard includes `"note_array"` |
| F | `message_formatter.py` | `self.MAX_ROWS` / `self.MAX_COLS` at 26 sites | `self._rows` / `self._cols` (per-instance, set in `__init__`) |

## `message_formatter.py` refactor

`MessageFormatter.__init__` now accepts `rows: int = 6, cols: int = 22`. All 26 internal `self.MAX_ROWS`/`self.MAX_COLS` references replaced with `self._rows`/`self._cols`. Class-level constants `MAX_ROWS = 6` and `MAX_COLS = 22` remain for backward compat. `get_message_formatter(rows=6, cols=22)` factory updated to pass through dimensions.

## Acceptance checklist

- [x] `/fill` produces correctly-sized grid for flagship (6×22), note (3×15), note_array 2-wide (3×30), note_array 2-tall (6×15) — proven by `TestDebugFill::test_fill_*_grid_size`
- [x] `/blank` produces correctly-sized grid for flagship, note, and note_array 2×2 (6×30) — proven by `TestDebugBlank::test_blank_*_grid_size`
- [x] `/info` does not crash for flagship or note_array 2-wide — proven by `TestDebugInfo::test_info_*`
- [x] Welcome message uses correct dims for flagship (6×22), note (3×15), note_array 2-wide (3×30), note_array 2-tall (6×15) — proven by `TestSendWelcomeMessage::test_welcome_*`
- [x] `_build_welcome_template` produces correct row counts for all note_array sizes — proven by `TestBuildWelcomeTemplate::test_note_array_*`
- [x] No literal `22`/`6` board-geometry values remain in the touched paths (only in comments/constants)
- [x] **Flagship/note output unchanged** — proven by `test_fill_flagship_grid_size`, `test_blank_flagship_grid_size`, `test_format_weather_flagship_unchanged`, and all pre-existing flagship/note tests passing without modification

## Test evidence

```
# Targeted tests (113 passed)
docker-compose -f docker-compose.dev.yml exec -T fiestaboard pytest \
  tests/test_debug_endpoints.py tests/test_api_coverage.py tests/test_message_formatter.py \
  -k "fill or blank or info or welcome or formatter or build_welcome or dimensions" -q
→ 113 passed, 90 deselected

# Regression (3690 passed, 11 skipped)
docker-compose -f docker-compose.dev.yml exec -T fiestaboard pytest tests/ --ignore=tests/ai -q
→ 3690 passed, 11 skipped, 0 failed

# Ruff: all checks passed on all 5 changed files
```

Part of #1167 · Implements #1171