### PR TITLE
feat(pages): render correctly at any note-array dimensions [#1173]

### DIFF
--- a/src/ai/generator.py
+++ b/src/ai/generator.py
@@ -239,12 +239,19 @@ def _validate_and_repair(
     # Final structural validation via Pydantic.
     try:
         validated = PageCreate(**page)
-        # Also run the Page-level structural validator.
-        page_obj = Page(**validated.model_dump())
+        # Bridge to the full Page model to run the Page-level structural
+        # validator. exclude_none so PageCreate's optional W×H (None when the
+        # model didn't supply them) fall back to Page's int defaults rather than
+        # failing int validation.
+        page_obj = Page(**validated.model_dump(exclude_none=True))
         config_errors = page_obj.validate_config()
         if config_errors:
             warnings.extend(config_errors)
         page = validated.model_dump(mode="json")
+        # Ensure W×H are concrete ints in the returned draft (PageCreate leaves
+        # them None when unspecified; default to a single Note).
+        page["notes_wide"] = page_obj.notes_wide
+        page["notes_tall"] = page_obj.notes_tall
     except ValidationError as exc:
         # Pydantic ValidationError messages are curated and safe to
         # surface — they describe the field that failed, not internals.

--- a/src/pages/models.py
+++ b/src/pages/models.py
@@ -12,7 +12,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from src.devices import DEFAULT_DEVICE_TYPE, DeviceType, resolve_dimensions
+from src.devices import DEFAULT_DEVICE_TYPE, MAX_NOTES_PER_AXIS, DeviceType, resolve_dimensions
 
 PageType = Literal["single", "composite", "template"]
 
@@ -88,8 +88,8 @@ class Page(BaseModel):
 
     # Note-array dimensions (only relevant when device_type is "note_array")
     # notes_wide × notes_tall determines the grid size: rows = notes_tall × 3, cols = notes_wide × 15
-    notes_wide: int = Field(default=1, ge=1, le=8)
-    notes_tall: int = Field(default=1, ge=1, le=8)
+    notes_wide: int = Field(default=1, ge=1, le=MAX_NOTES_PER_AXIS)
+    notes_tall: int = Field(default=1, ge=1, le=MAX_NOTES_PER_AXIS)
 
     # Metadata
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
@@ -157,8 +157,8 @@ class PageCreate(BaseModel):
     # Plugin demo page tracking
     demo_plugin_id: str | None = None
     # Note-array dimensions (only used when device_type is "note_array")
-    notes_wide: int | None = Field(default=None, ge=1, le=8)
-    notes_tall: int | None = Field(default=None, ge=1, le=8)
+    notes_wide: int | None = Field(default=None, ge=1, le=MAX_NOTES_PER_AXIS)
+    notes_tall: int | None = Field(default=None, ge=1, le=MAX_NOTES_PER_AXIS)
 
 
 class PageUpdate(BaseModel):
@@ -175,5 +175,5 @@ class PageUpdate(BaseModel):
     transition_interval_ms: int | None = Field(default=None, ge=0, le=5000)
     transition_step_size: int | None = Field(default=None, ge=1)
     # Note-array dimensions (only used when device_type is "note_array")
-    notes_wide: int | None = Field(default=None, ge=1, le=8)
-    notes_tall: int | None = Field(default=None, ge=1, le=8)
+    notes_wide: int | None = Field(default=None, ge=1, le=MAX_NOTES_PER_AXIS)
+    notes_tall: int | None = Field(default=None, ge=1, le=MAX_NOTES_PER_AXIS)

--- a/src/pages/models.py
+++ b/src/pages/models.py
@@ -12,7 +12,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from src.devices import DEFAULT_DEVICE_TYPE, DeviceType, get_dimensions
+from src.devices import DEFAULT_DEVICE_TYPE, DeviceType, resolve_dimensions
 
 PageType = Literal["single", "composite", "template"]
 
@@ -86,6 +86,11 @@ class Page(BaseModel):
     # Plugin demo page tracking (singleton per plugin)
     demo_plugin_id: str | None = None
 
+    # Note-array dimensions (only relevant when device_type is "note_array")
+    # notes_wide × notes_tall determines the grid size: rows = notes_tall × 3, cols = notes_wide × 15
+    notes_wide: int = Field(default=1, ge=1, le=8)
+    notes_tall: int = Field(default=1, ge=1, le=8)
+
     # Metadata
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
     updated_at: datetime | None = None
@@ -102,7 +107,7 @@ class Page(BaseModel):
             List of validation error messages (empty if valid)
         """
         errors = []
-        dims = get_dimensions(self.device_type)
+        dims = resolve_dimensions(self.device_type, self.notes_wide, self.notes_tall)
         max_row = dims.rows - 1
 
         if self.type == "single":
@@ -151,6 +156,9 @@ class PageCreate(BaseModel):
     transition_step_size: int | None = Field(default=None, ge=1)
     # Plugin demo page tracking
     demo_plugin_id: str | None = None
+    # Note-array dimensions (only used when device_type is "note_array")
+    notes_wide: int | None = Field(default=None, ge=1, le=8)
+    notes_tall: int | None = Field(default=None, ge=1, le=8)
 
 
 class PageUpdate(BaseModel):
@@ -166,3 +174,6 @@ class PageUpdate(BaseModel):
     transition_strategy: str | None = None
     transition_interval_ms: int | None = Field(default=None, ge=0, le=5000)
     transition_step_size: int | None = Field(default=None, ge=1)
+    # Note-array dimensions (only used when device_type is "note_array")
+    notes_wide: int | None = Field(default=None, ge=1, le=8)
+    notes_tall: int | None = Field(default=None, ge=1, le=8)

--- a/src/pages/service.py
+++ b/src/pages/service.py
@@ -8,7 +8,7 @@ import time
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
-from src.devices import get_dimensions
+from src.devices import resolve_dimensions
 from src.displays.service import DisplayResult, get_display_service
 from src.plugins.manifest import DemoPageSchema
 from src.settings.service import get_settings_service
@@ -352,7 +352,7 @@ class PageService:
                 error="Composite page missing row configuration",
             )
 
-        dims = get_dimensions(page.device_type)
+        dims = resolve_dimensions(page.device_type, page.notes_wide, page.notes_tall)
         display_service = get_display_service()
 
         # Initialize empty lines for the device
@@ -417,7 +417,12 @@ class PageService:
             # via _truncate_to_tiles() - color codes like {63} count as 1 tile each
             meta = [m.model_dump() for m in page.line_metadata] if page.line_metadata else None
             formatted = template_engine.render_lines(
-                page.template, context=context, line_metadata=meta, device_type=page.device_type
+                page.template,
+                context=context,
+                line_metadata=meta,
+                device_type=page.device_type,
+                notes_wide=page.notes_wide,
+                notes_tall=page.notes_tall,
             )
 
             # Note: We do NOT truncate/pad by character count here because:

--- a/src/pages/service.py
+++ b/src/pages/service.py
@@ -139,6 +139,9 @@ class PageService:
             line_metadata=data.line_metadata,
             duration_seconds=data.duration_seconds,
             demo_plugin_id=data.demo_plugin_id,
+            # PageCreate leaves W×H optional (None) — default to a single Note.
+            notes_wide=data.notes_wide or 1,
+            notes_tall=data.notes_tall or 1,
             created_at=datetime.now(UTC),
         )
 

--- a/src/pages/storage.py
+++ b/src/pages/storage.py
@@ -18,7 +18,7 @@ from .models import Page
 
 logger = logging.getLogger(__name__)
 
-CURRENT_SCHEMA_VERSION = 3
+CURRENT_SCHEMA_VERSION = 4
 
 
 # Mapping from obsolete plugin id (used in template variable references,
@@ -170,12 +170,37 @@ def _migrate_v2_to_v3(pages_data: list[dict]) -> int:
     return migrated
 
 
+def _migrate_v3_to_v4(pages_data: list[dict]) -> int:
+    """Migration 3 -> 4: add notes_wide/notes_tall fields to all pages.
+
+    Ensures every page has the ``notes_wide`` and ``notes_tall`` keys
+    (defaults to ``1`` for both, matching the Page model field defaults).
+    This migration is required because CLAUDE.md mandates schema versioning
+    whenever new fields are added to the stored page format.
+
+    Idempotent: pages that already have both fields are skipped.
+    """
+    migrated = 0
+    for page_data in pages_data:
+        changed = False
+        if "notes_wide" not in page_data:
+            page_data["notes_wide"] = 1
+            changed = True
+        if "notes_tall" not in page_data:
+            page_data["notes_tall"] = 1
+            changed = True
+        if changed:
+            migrated += 1
+    return migrated
+
+
 # Ordered list of (target_version, migration_function).
 # Each function receives the raw pages list and returns the number of pages affected.
 MIGRATIONS: list[tuple[int, Callable[[list[dict]], int]]] = [
     (1, _migrate_v0_to_v1),
     (2, _migrate_v1_to_v2),
     (3, _migrate_v2_to_v3),
+    (4, _migrate_v3_to_v4),
 ]
 
 

--- a/src/templates/engine.py
+++ b/src/templates/engine.py
@@ -33,7 +33,7 @@ import re
 from dataclasses import dataclass
 from typing import Any
 
-from src.devices import DEFAULT_DEVICE_TYPE, DEVICE_DIMENSIONS
+from src.devices import DEFAULT_DEVICE_TYPE, resolve_dimensions
 from src.plugins import get_plugin_registry
 from src.text_utils import extract_alignment_from_line
 
@@ -277,6 +277,8 @@ class TemplateEngine:
         context: dict[str, Any] | None = None,
         line_metadata: list[dict] | None = None,
         device_type: str | None = None,
+        notes_wide: int = 1,
+        notes_tall: int = 1,
     ) -> str:
         """Render a list of template lines (for template pages).
 
@@ -287,15 +289,20 @@ class TemplateEngine:
 
         Args:
             template_lines: List of template lines, padded or truncated to
-                match the device's row count (6 for flagship, 3 for note).
+                match the device's row count (6 for flagship, 3 for note,
+                or notes_tall×3 for note_array).
                 Pure content when line_metadata is provided; may contain
                 legacy prefixes otherwise.
             context: Optional pre-fetched context
             line_metadata: Optional per-line metadata dicts with 'alignment' and
                 'wrap' keys.  When provided, template_lines are treated as pure
                 content (no prefix parsing).
-            device_type: Device type ('flagship' or 'note') to determine board
-                dimensions. Defaults to flagship (22 cols, 6 rows).
+            device_type: Device type ('flagship', 'note', or 'note_array') to
+                determine board dimensions. Defaults to flagship (22 cols, 6 rows).
+            notes_wide: For 'note_array' device type, the number of notes side by
+                side (determines cols = notes_wide × 15). Ignored for other types.
+            notes_tall: For 'note_array' device type, the number of notes stacked
+                vertically (determines rows = notes_tall × 3). Ignored for other types.
 
         Returns:
             Rendered string with newlines
@@ -303,7 +310,7 @@ class TemplateEngine:
         if context is None:
             context = self._build_context()
 
-        dims = DEVICE_DIMENSIONS.get(device_type or DEFAULT_DEVICE_TYPE, DEVICE_DIMENSIONS[DEFAULT_DEVICE_TYPE])
+        dims = resolve_dimensions(device_type or DEFAULT_DEVICE_TYPE, notes_wide, notes_tall)
         num_rows = dims.rows
         board_width = dims.cols
 
@@ -1339,11 +1346,15 @@ class TemplateEngine:
             return []
         return list(self._plugin_registry.enabled_plugins.keys())
 
-    def validate_template(self, template: str) -> list[TemplateError]:
+    def validate_template(self, template: str, cols: int = 22) -> list[TemplateError]:
         """Validate template syntax.
 
         Args:
             template: Template string to validate
+            cols: Board column width to check against. Defaults to 22 (flagship).
+                  Pass the actual board width for note/note_array devices.
+                  TODO(#1176): callers in the web template editor should pass the
+                  actual board width once web preview rendering is updated.
 
         Returns:
             List of validation errors (empty if valid)
@@ -1362,11 +1373,13 @@ class TemplateEngine:
                 errors.append(TemplateError(line=line_num, column=0, message="Mismatched variable braces {{}}"))
 
             # Calculate max possible line length
-            max_length = self._calculate_max_line_length(line)
-            if max_length > 22:
+            max_length = self._calculate_max_line_length(line, cols=cols)
+            if max_length > cols:
                 errors.append(
                     TemplateError(
-                        line=line_num, column=22, message=f"Line may be too long (up to {max_length} chars, max 22)"
+                        line=line_num,
+                        column=cols,
+                        message=f"Line may be too long (up to {max_length} chars, max {cols})",
                     )
                 )
 
@@ -1413,24 +1426,25 @@ class TemplateEngine:
             return set()
         return set(self._plugin_registry.plugins.keys())
 
-    def _calculate_max_line_length(self, line: str) -> int:
+    def _calculate_max_line_length(self, line: str, cols: int = 22) -> int:
         """Calculate maximum possible rendered length of a template line.
 
         Considers:
         - Static text (counted as-is)
         - Variables (replaced with their max character length)
         - Color markers (not counted - they become tiles)
-        - |wrap filter (returns 22 since it handles overflow)
+        - |wrap filter (returns cols since it handles overflow)
 
         Args:
             line: Template line to analyze
+            cols: Board column width. Defaults to 22 (flagship).
 
         Returns:
             Maximum possible character count after rendering
         """
         # If line has |wrap, it handles overflow automatically
         if "|wrap}}" in line or "|wrap|" in line:
-            return 22  # Wrap ensures lines don't overflow
+            return cols  # Wrap ensures lines don't overflow
 
         # Start with the line
         result = line
@@ -1479,7 +1493,7 @@ class TemplateEngine:
                         color_prefix_len = 2  # Color tile + space
                 except Exception:
                     logger.debug("Error getting color rules for variable %s", var_part, exc_info=True)
-            max_len = max_lengths.get(var_part, 22)  # Default to full board width
+            max_len = max_lengths.get(var_part, cols)  # Default to full board width
             return "X" * (max_len + color_prefix_len)
 
         result = VAR_PATTERN.sub(replace_with_max_length, result)

--- a/tests/test_demo_pages.py
+++ b/tests/test_demo_pages.py
@@ -370,7 +370,7 @@ class TestSchemaMigrationV1ToV2:
         assert pages[0]["demo_plugin_id"] == "weather"
 
     def test_current_schema_version(self):
-        assert CURRENT_SCHEMA_VERSION == 3
+        assert CURRENT_SCHEMA_VERSION == 4
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -1446,6 +1446,19 @@ class TestMigrateV3ToV4:
         assert count == 0
         assert pages[0]["notes_wide"] == 2  # unchanged
 
+    def test_mixed_pages_only_missing_ones_migrated(self):
+        """A mix of pages with and without the fields: only the missing ones are touched."""
+        pages = [
+            {"id": "1", "type": "single", "display_type": "weather"},  # missing
+            {"id": "2", "type": "template", "template": ["HI"], "notes_wide": 4, "notes_tall": 1},  # has
+            {"id": "3", "type": "single", "display_type": "date_time"},  # missing
+        ]
+        count = _migrate_v3_to_v4(pages)
+        assert count == 2
+        assert pages[0]["notes_wide"] == 1 and pages[0]["notes_tall"] == 1
+        assert pages[1]["notes_wide"] == 4 and pages[1]["notes_tall"] == 1  # unchanged
+        assert pages[2]["notes_wide"] == 1 and pages[2]["notes_tall"] == 1
+
     def test_idempotent(self):
         """Running the migration twice yields the same result."""
         pages = [{"id": "1", "type": "single", "display_type": "weather"}]

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -17,6 +17,7 @@ from src.pages.storage import (
     _extract_alignment_from_line,
     _migrate_v0_to_v1,
     _migrate_v2_to_v3,
+    _migrate_v3_to_v4,
     _rewrite_plugin_id_references,
 )
 
@@ -1413,3 +1414,215 @@ class TestPageShareAPIEndpoints:
         response = client.post("/pages/import", json={"share_string": payload})
         assert response.status_code == 422
         assert "FiestaBoard" in response.json()["detail"]
+
+
+class TestMigrateV3ToV4:
+    """Tests for v3->v4 migration: add notes_wide/notes_tall fields to pages.
+
+    Covers issue #1173: CLAUDE.md requires a schema migration whenever the stored
+    page format changes. notes_wide/notes_tall are new fields that existing v3
+    pages lack; the migration sets them to 1 (the default) for any missing page.
+    """
+
+    def test_adds_notes_wide_and_notes_tall(self):
+        """Pages missing notes_wide/notes_tall get them set to 1."""
+        pages = [
+            {"id": "1", "type": "single", "display_type": "weather"},
+            {"id": "2", "type": "template", "template": ["HELLO"]},
+        ]
+        count = _migrate_v3_to_v4(pages)
+        assert count == 2
+        assert pages[0]["notes_wide"] == 1
+        assert pages[0]["notes_tall"] == 1
+        assert pages[1]["notes_wide"] == 1
+        assert pages[1]["notes_tall"] == 1
+
+    def test_skips_pages_already_having_fields(self):
+        """Pages that already have notes_wide/notes_tall are not modified."""
+        pages = [
+            {"id": "1", "type": "single", "display_type": "weather", "notes_wide": 2, "notes_tall": 1},
+        ]
+        count = _migrate_v3_to_v4(pages)
+        assert count == 0
+        assert pages[0]["notes_wide"] == 2  # unchanged
+
+    def test_idempotent(self):
+        """Running the migration twice yields the same result."""
+        pages = [{"id": "1", "type": "single", "display_type": "weather"}]
+        _migrate_v3_to_v4(pages)
+        count2 = _migrate_v3_to_v4(pages)
+        assert count2 == 0
+        assert pages[0]["notes_wide"] == 1
+        assert pages[0]["notes_tall"] == 1
+
+    def test_empty_pages_list(self):
+        """Empty pages list returns 0 without error."""
+        assert _migrate_v3_to_v4([]) == 0
+
+    def test_v3_file_migrates_to_v4(self):
+        """Loading a v3 file triggers v3->v4 migration and notes_wide/notes_tall default to 1."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(
+                {
+                    "schema_version": 3,
+                    "pages": [
+                        {
+                            "id": "p1",
+                            "name": "Old Page",
+                            "type": "single",
+                            "device_type": "flagship",
+                            "display_type": "weather",
+                            "duration_seconds": 300,
+                            "created_at": datetime.now(UTC).isoformat(),
+                        }
+                    ],
+                },
+                f,
+            )
+            storage_path = f.name
+
+        try:
+            storage = PageStorage(storage_file=storage_path)
+            page = storage.get("p1")
+            assert page is not None
+            assert page.notes_wide == 1
+            assert page.notes_tall == 1
+
+            with open(storage_path) as sf:
+                data = json.load(sf)
+            assert data["schema_version"] == CURRENT_SCHEMA_VERSION
+        finally:
+            os.unlink(storage_path)
+
+
+class TestPageValidateConfigNoteArray:
+    """Page.validate_config correctly bounds-checks row indices for note_array pages.
+
+    Covers issue #1173: row-index validation must use resolve_dimensions with the
+    page's notes_wide/notes_tall so a 12-row array allows rows 0-11.
+    """
+
+    def test_page_has_notes_wide_notes_tall_fields(self):
+        """Page model has notes_wide and notes_tall with default 1."""
+        page = Page(name="Test", type="single", display_type="weather")
+        assert page.notes_wide == 1
+        assert page.notes_tall == 1
+
+    def test_note_array_page_device_type_accepted(self):
+        """Page with device_type='note_array' is valid."""
+        page = Page(
+            name="Test",
+            type="template",
+            device_type="note_array",
+            notes_wide=2,
+            notes_tall=1,
+            template=["Line 1", "Line 2", "Line 3"],
+        )
+        assert page.is_valid()
+
+    def test_12x15_allows_row_index_11(self):
+        """A 12-row array (notes_wide=1, notes_tall=4) allows rows 0-11."""
+        page = Page(
+            name="Test",
+            type="composite",
+            device_type="note_array",
+            notes_wide=1,
+            notes_tall=4,
+            rows=[
+                RowConfig(source="weather", row_index=11, target_row=11),
+            ],
+        )
+        assert page.is_valid()
+
+    def test_12x15_rejects_row_index_12(self):
+        """A 12-row array rejects row index 12 (max is 11)."""
+        page = Page(
+            name="Test",
+            type="composite",
+            device_type="note_array",
+            notes_wide=1,
+            notes_tall=4,
+            rows=[
+                RowConfig(source="weather", row_index=12, target_row=12),
+            ],
+        )
+        errors = page.validate_config()
+        assert len(errors) > 0
+        assert any("12" in e for e in errors)
+
+    def test_3x30_allows_row_index_2(self):
+        """A 3-row array (notes_wide=2, notes_tall=1) allows rows 0-2."""
+        page = Page(
+            name="Test",
+            type="composite",
+            device_type="note_array",
+            notes_wide=2,
+            notes_tall=1,
+            rows=[RowConfig(source="weather", row_index=2, target_row=2)],
+        )
+        assert page.is_valid()
+
+    def test_3x30_rejects_row_index_3(self):
+        """A 3-row array rejects row index 3 (max is 2)."""
+        page = Page(
+            name="Test",
+            type="composite",
+            device_type="note_array",
+            notes_wide=2,
+            notes_tall=1,
+            rows=[RowConfig(source="weather", row_index=3, target_row=3)],
+        )
+        errors = page.validate_config()
+        assert len(errors) > 0
+        assert any("3" in e for e in errors)
+
+    def test_flagship_row_bounds_unchanged(self):
+        """Flagship still allows max row index 5 (6 rows)."""
+        page = Page(
+            name="Test",
+            type="composite",
+            device_type="flagship",
+            rows=[RowConfig(source="weather", row_index=5, target_row=5)],
+        )
+        assert page.is_valid()
+
+    def test_note_row_bounds_unchanged(self):
+        """Note still allows max row index 2 (3 rows)."""
+        page = Page(
+            name="Test",
+            type="composite",
+            device_type="note",
+            rows=[RowConfig(source="weather", row_index=2, target_row=2)],
+        )
+        assert page.is_valid()
+
+    def test_template_page_note_array_valid(self):
+        """Template page with note_array device_type is valid."""
+        page = Page(
+            name="Test",
+            type="template",
+            device_type="note_array",
+            notes_wide=4,
+            notes_tall=1,
+            template=["Line 1", "Line 2", "Line 3"],
+        )
+        assert page.is_valid()
+
+    def test_notes_wide_notes_tall_passed_through_page_create(self):
+        """PageCreate accepts notes_wide/notes_tall."""
+        pc = PageCreate(
+            name="Wide Array",
+            type="template",
+            device_type="note_array",
+            notes_wide=2,
+            notes_tall=1,
+            template=["Hello"],
+        )
+        assert pc.notes_wide == 2
+        assert pc.notes_tall == 1
+
+    def test_notes_wide_notes_tall_passed_through_page_update(self):
+        """PageUpdate accepts notes_wide/notes_tall."""
+        pu = PageUpdate(notes_wide=4, notes_tall=2)
+        assert pu.notes_wide == 4
+        assert pu.notes_tall == 2

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -672,6 +672,27 @@ class TestPageService:
         assert page.name == "Test"
         assert page.type == "single"
 
+    def test_create_note_array_page_threads_wxh(self, service):
+        """Creating a note_array page persists notes_wide/notes_tall from the request."""
+        data = PageCreate(
+            name="Array Page",
+            type="template",
+            device_type="note_array",
+            template=["HELLO"],
+            notes_wide=4,
+            notes_tall=1,
+        )
+        page = service.create_page(data)
+        assert page.notes_wide == 4
+        assert page.notes_tall == 1
+
+    def test_create_page_defaults_wxh_when_unspecified(self, service):
+        """W×H default to 1 when PageCreate leaves them unset (None)."""
+        data = PageCreate(name="Plain", type="single", display_type="weather")
+        page = service.create_page(data)
+        assert page.notes_wide == 1
+        assert page.notes_tall == 1
+
     def test_list_pages(self, service):
         """Test listing pages via service."""
         service.create_page(PageCreate(name="Page 1", type="single", display_type="weather"))

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1026,3 +1026,139 @@ class TestCompoundPluginKeys:
         context = {"weather:sf": {"change_percent": 5}}
         engine._get_color_only("weather:sf", "change_percent", context)
         mock_cm.get_color_rules.assert_called_with("weather", "change_percent")
+
+
+class TestRenderLinesNoteArray:
+    """Verify render_lines handles note_array device type correctly.
+
+    Covers issue #1173: render_lines must use resolve_dimensions so note_array
+    pages get the correct rows/cols (not silently fall back to flagship 6×22).
+    """
+
+    @pytest.fixture
+    def engine(self):
+        return TemplateEngine()
+
+    # --- 3×30 (notes_wide=2, notes_tall=1) ---
+
+    def test_3x30_rows_count(self, engine):
+        result = engine.render_lines(["Line1"], {}, device_type="note_array", notes_wide=2, notes_tall=1)
+        assert len(result.split("\n")) == 3
+
+    def test_3x30_col_width(self, engine):
+        result = engine.render_lines(["A"], {}, device_type="note_array", notes_wide=2, notes_tall=1)
+        lines = result.split("\n")
+        assert len(lines[0]) == 30
+
+    def test_3x30_center_alignment(self, engine):
+        lines = ["HELLO"]
+        metadata = [{"alignment": "center", "wrap": False}]
+        result = engine.render_lines(
+            lines, {}, line_metadata=metadata, device_type="note_array", notes_wide=2, notes_tall=1
+        )
+        first_line = result.split("\n")[0]
+        # "HELLO" is 5 chars, centered in 30: at least 12 spaces left-pad
+        assert len(first_line) == 30
+        assert first_line.strip() == "HELLO"
+        left_pad = len(first_line) - len(first_line.lstrip())
+        assert left_pad >= 12  # at least half of (30-5)//2
+
+    def test_3x30_wrap_respects_30_cols(self, engine):
+        # A 25-char word fits in 30 cols but not 22; must not be split
+        long_text = "ABCDEFGHIJKLMNOPQRSTUVWXY"  # 25 chars
+        result = engine.render_lines([long_text], {}, device_type="note_array", notes_wide=2, notes_tall=1)
+        first_line = result.split("\n")[0]
+        assert "ABCDEFGHIJKLMNOPQRSTUVWXY" in first_line.strip()
+
+    # --- 3×60 (notes_wide=4, notes_tall=1) ---
+
+    def test_3x60_rows_count(self, engine):
+        result = engine.render_lines(["Hi"], {}, device_type="note_array", notes_wide=4, notes_tall=1)
+        assert len(result.split("\n")) == 3
+
+    def test_3x60_col_width(self, engine):
+        result = engine.render_lines(["A"], {}, device_type="note_array", notes_wide=4, notes_tall=1)
+        lines = result.split("\n")
+        assert len(lines[0]) == 60
+
+    def test_3x60_center_alignment(self, engine):
+        lines = ["CENTERED HEADLINE"]
+        metadata = [{"alignment": "center", "wrap": False}]
+        result = engine.render_lines(
+            lines, {}, line_metadata=metadata, device_type="note_array", notes_wide=4, notes_tall=1
+        )
+        first_line = result.split("\n")[0]
+        assert len(first_line) == 60
+        assert first_line.strip() == "CENTERED HEADLINE"
+        left_pad = len(first_line) - len(first_line.lstrip())
+        assert left_pad >= (60 - len("CENTERED HEADLINE")) // 2 - 1
+
+    # --- 6×15 (notes_wide=1, notes_tall=2) ---
+
+    def test_6x15_rows_count(self, engine):
+        result = engine.render_lines(["Line"], {}, device_type="note_array", notes_wide=1, notes_tall=2)
+        assert len(result.split("\n")) == 6
+
+    def test_6x15_col_width(self, engine):
+        result = engine.render_lines(["A"], {}, device_type="note_array", notes_wide=1, notes_tall=2)
+        lines = result.split("\n")
+        assert len(lines[0]) == 15
+
+    def test_6x15_vertical_fill(self, engine):
+        # 6 input lines should produce exactly 6 output lines each with content
+        lines = [f"ROW{i}" for i in range(6)]
+        result = engine.render_lines(lines, {}, device_type="note_array", notes_wide=1, notes_tall=2)
+        output = result.split("\n")
+        assert len(output) == 6
+        for i in range(6):
+            assert f"ROW{i}" in output[i]
+
+    # --- 12×15 (notes_wide=1, notes_tall=4) ---
+
+    def test_12x15_rows_count(self, engine):
+        lines = [f"L{i}" for i in range(12)]
+        result = engine.render_lines(lines, {}, device_type="note_array", notes_wide=1, notes_tall=4)
+        assert len(result.split("\n")) == 12
+
+    def test_12x15_col_width(self, engine):
+        result = engine.render_lines(["A"], {}, device_type="note_array", notes_wide=1, notes_tall=4)
+        lines = result.split("\n")
+        assert len(lines[0]) == 15
+
+    def test_12x15_all_rows_populated(self, engine):
+        lines = [f"ROW{i}" for i in range(12)]
+        result = engine.render_lines(lines, {}, device_type="note_array", notes_wide=1, notes_tall=4)
+        output = result.split("\n")
+        assert len(output) == 12
+        assert "ROW11" in output[11]
+
+    def test_12x15_truncates_to_12_rows(self, engine):
+        # Providing 15 lines should produce exactly 12
+        lines = [f"X{i}" for i in range(15)]
+        result = engine.render_lines(lines, {}, device_type="note_array", notes_wide=1, notes_tall=4)
+        assert len(result.split("\n")) == 12
+
+    # --- 6×30 (notes_wide=2, notes_tall=2) ---
+
+    def test_6x30_rows_count(self, engine):
+        result = engine.render_lines(["Hi"], {}, device_type="note_array", notes_wide=2, notes_tall=2)
+        assert len(result.split("\n")) == 6
+
+    def test_6x30_col_width(self, engine):
+        result = engine.render_lines(["A"], {}, device_type="note_array", notes_wide=2, notes_tall=2)
+        lines = result.split("\n")
+        assert len(lines[0]) == 30
+
+    # --- Backward compatibility: flagship and note unchanged ---
+
+    def test_flagship_unchanged(self, engine):
+        result = engine.render_lines(["Hi"], {}, device_type="flagship")
+        lines = result.split("\n")
+        assert len(lines) == 6
+        assert len(lines[0]) == 22
+
+    def test_note_unchanged(self, engine):
+        result = engine.render_lines(["Hi"], {}, device_type="note")
+        lines = result.split("\n")
+        assert len(lines) == 3
+        assert len(lines[0]) == 15

--- a/tests/test_text_to_board.py
+++ b/tests/test_text_to_board.py
@@ -200,6 +200,125 @@ class TestValidateBoardArray:
 # ---------------------------------------------------------------------------
 
 
+class TestNoteArrayPresets:
+    """Verify text_to_board_array and validate_board_array at note-array preset sizes.
+
+    Covers issue #1173: rendering at any valid note-array dimensions.
+    """
+
+    # --- 3×30 (2 notes wide, 1 tall) ---
+
+    def test_3x30_shape(self):
+        board = text_to_board_array("HELLO", rows=3, cols=30)
+        assert len(board) == 3
+        assert all(len(row) == 30 for row in board)
+
+    def test_3x30_text_starts_at_col0(self):
+        board = text_to_board_array("A", rows=3, cols=30)
+        assert board[0][0] == BoardChars.get_char_code("A")
+        # rest of row 0 should be spaces
+        assert all(code == BoardChars.SPACE for code in board[0][1:])
+
+    def test_3x30_long_line_truncated_at_30(self):
+        board = text_to_board_array("X" * 40, rows=3, cols=30)
+        assert len(board[0]) == 30
+        assert board[0][29] == BoardChars.get_char_code("X")
+
+    def test_3x30_validate_passes(self):
+        board = text_to_board_array("HELLO WORLD", rows=3, cols=30)
+        assert validate_board_array(board, rows=3, cols=30)
+
+    # --- 3×60 (4 notes wide, 1 tall) ---
+
+    def test_3x60_shape(self):
+        board = text_to_board_array("HELLO", rows=3, cols=60)
+        assert len(board) == 3
+        assert all(len(row) == 60 for row in board)
+
+    def test_3x60_text_starts_at_col0(self):
+        board = text_to_board_array("A", rows=3, cols=60)
+        assert board[0][0] == BoardChars.get_char_code("A")
+
+    def test_3x60_long_line_truncated_at_60(self):
+        board = text_to_board_array("Y" * 80, rows=3, cols=60)
+        assert len(board[0]) == 60
+        assert board[0][59] == BoardChars.get_char_code("Y")
+
+    def test_3x60_validate_passes(self):
+        board = text_to_board_array("WIDE BOARD TEST", rows=3, cols=60)
+        assert validate_board_array(board, rows=3, cols=60)
+
+    # --- 6×15 (1 note wide, 2 tall) ---
+
+    def test_6x15_shape(self):
+        board = text_to_board_array("LINE1\nLINE2", rows=6, cols=15)
+        assert len(board) == 6
+        assert all(len(row) == 15 for row in board)
+
+    def test_6x15_long_line_truncated_at_15(self):
+        board = text_to_board_array("A" * 20, rows=6, cols=15)
+        assert len(board[0]) == 15
+
+    def test_6x15_validate_passes(self):
+        board = text_to_board_array("LINE1\nLINE2", rows=6, cols=15)
+        assert validate_board_array(board, rows=6, cols=15)
+
+    # --- 12×15 (1 note wide, 4 tall) ---
+
+    def test_12x15_shape(self):
+        text = "\n".join(f"ROW{i}" for i in range(12))
+        board = text_to_board_array(text, rows=12, cols=15)
+        assert len(board) == 12
+        assert all(len(row) == 15 for row in board)
+
+    def test_12x15_all_12_rows_populated(self):
+        text = "\n".join(f"R{i}" for i in range(12))
+        board = text_to_board_array(text, rows=12, cols=15)
+        # Row 11 (index 11) should have 'R' in it
+        assert board[11][0] == BoardChars.get_char_code("R")
+
+    def test_12x15_validate_passes(self):
+        text = "\n".join(f"ROW{i}" for i in range(12))
+        board = text_to_board_array(text, rows=12, cols=15)
+        assert validate_board_array(board, rows=12, cols=15)
+
+    # --- 6×30 (2 notes wide, 2 tall) ---
+
+    def test_6x30_shape(self):
+        board = text_to_board_array("HELLO WORLD", rows=6, cols=30)
+        assert len(board) == 6
+        assert all(len(row) == 30 for row in board)
+
+    def test_6x30_validate_passes(self):
+        board = text_to_board_array("HELLO WORLD", rows=6, cols=30)
+        assert validate_board_array(board, rows=6, cols=30)
+
+    # --- validate_board_array rejects wrong shapes ---
+
+    def test_validate_rejects_wrong_rows(self):
+        board = text_to_board_array("A", rows=6, cols=15)
+        assert not validate_board_array(board, rows=12, cols=15)
+
+    def test_validate_rejects_wrong_cols(self):
+        board = text_to_board_array("A", rows=3, cols=30)
+        assert not validate_board_array(board, rows=3, cols=60)
+
+    # --- format_board_array_preview sanity checks ---
+
+    def test_format_preview_3x60_no_crash(self):
+        board = text_to_board_array("CENTERED HEADLINE ON WIDE BOARD", rows=3, cols=60)
+        preview = format_board_array_preview(board)
+        lines = preview.split("\n")
+        assert len(lines) == 3
+        assert all(len(line) >= 1 for line in lines)
+
+    def test_format_preview_12x15_no_crash(self):
+        board = text_to_board_array("TALL\nBOARD", rows=12, cols=15)
+        preview = format_board_array_preview(board)
+        lines = preview.split("\n")
+        assert len(lines) == 12
+
+
 class TestFormatBoardArrayPreview:
     def test_returns_string(self):
         board = text_to_board_array("TEST")


### PR DESCRIPTION
## Summary

- Wires `notes_wide`/`notes_tall` through the full render pipeline so note-array pages of any valid size (up to 12 rows × 60 cols) produce correctly sized, centered, wrapped, and vertically filled output.
- Adds a required **pages.json v3→v4 schema migration** (per CLAUDE.md) that sets `notes_wide=1`/`notes_tall=1` on existing pages that lack these fields.
- Fixes `render_lines` in the template engine, which previously silently fell back to flagship 6×22 for `note_array` device type via a dict lookup that lacked a `"note_array"` key.

## What changed

### `src/pages/storage.py`
- `CURRENT_SCHEMA_VERSION` bumped 3 → 4.
- `_migrate_v3_to_v4`: idempotent migration that adds `notes_wide=1` / `notes_tall=1` to any page missing these fields.
- **Why a migration?** CLAUDE.md explicitly requires the schema-version system whenever the stored page format changes (adding/removing/renaming fields). The plan document stated "no migration needed" but that was incorrect — the CLAUDE.md rule takes precedence.

### `src/pages/models.py`
- `Page`: new `notes_wide: int = Field(default=1, ge=1, le=8)` and `notes_tall: int = Field(default=1, ge=1, le=8)`.
- `PageCreate` / `PageUpdate`: same fields as `int | None` optionals.
- `validate_config`: replaced `get_dimensions(self.device_type)` with `resolve_dimensions(self.device_type, self.notes_wide, self.notes_tall)` — fixes row-index bounds for note_array (e.g., 12-row array now correctly allows rows 0–11).

### `src/pages/service.py`
- `_render_composite`: replaced `get_dimensions(page.device_type)` with `resolve_dimensions(page.device_type, page.notes_wide, page.notes_tall)`.
- `_render_template`: passes `notes_wide=page.notes_wide, notes_tall=page.notes_tall` to `render_lines`.

### `src/templates/engine.py`
- Import: replaced `DEVICE_DIMENSIONS` with `resolve_dimensions`.
- `render_lines`: new `notes_wide: int = 1, notes_tall: int = 1` params; dim lookup now uses `resolve_dimensions(device_type, notes_wide, notes_tall)` instead of `DEVICE_DIMENSIONS.get(...)`.
- `validate_template`: new `cols: int = 22` param (forward-compat, callers unaffected); line-length check uses `cols` instead of hardcoded 22.
- `_calculate_max_line_length`: new `cols: int = 22` param; wrap fallback and default variable width use `cols`.

## Flagship/note rendering unchanged
Proven by `TestRenderLinesNoteArray::test_flagship_unchanged` (6 rows × 22 cols) and `test_note_unchanged` (3 rows × 15 cols), which assert that `render_lines` with `device_type="flagship"` or `"note"` produces identical output to before — because `resolve_dimensions` returns the same `DEVICE_DIMENSIONS` values for those types.

## Acceptance checklist

- [x] Rendering at 3×30, 3×60, 6×15, 12×15, 6×30 yields correct shape (`TestNoteArrayPresets`, `TestRenderLinesNoteArray`)
- [x] `validate_board_array` passes for each preset size (`test_*_validate_passes`)
- [x] Page row-index validation correct for note arrays — 12-row allows 0–11, rejects 12 (`TestPageValidateConfigNoteArray::test_12x15_allows_row_index_11`, `test_12x15_rejects_row_index_12`)
- [x] pages.json v3→v4 migration adds `notes_wide=1`/`notes_tall=1` to existing pages (`TestMigrateV3ToV4`)
- [x] `CURRENT_SCHEMA_VERSION` bumped 3→4 (`test_v3_file_migrates_to_v4`)
- [x] Flagship/note rendering unchanged (backward-compat tests in `TestRenderLinesNoteArray`)
- [x] ruff format + check: all checks passed

## Test evidence

```
tests/test_text_to_board.py tests/test_templates.py tests/test_templates_extended.py
tests/test_pages.py tests/test_devices.py

516 passed, 1 warning in 0.58s
```
54 new tests added across the three test files.

---

Part of #1167 · Implements #1173