### PR TITLE
feat(web): note-array TypeScript types + shared dimension helpers [#1174]

### DIFF
--- a/src/board_html_renderer.py
+++ b/src/board_html_renderer.py
@@ -27,12 +27,6 @@ from .devices import resolve_dimensions as _resolve_dimensions
 # web/src/lib/board-dimensions.ts so the preview matches the web UI.
 # ---------------------------------------------------------------------------
 
-# _STATIC_DEVICE_DIMS kept for reference; use _resolve_dimensions() in render functions.
-_STATIC_DEVICE_DIMS: dict[str, tuple[int, int]] = {
-    "flagship": (6, 22),
-    "note": (3, 15),
-}
-
 # 8-colour board palette (codes 63-71). 71 ("filled") renders as black, same
 # as the web UI.
 COLOR_CODE_MAP: dict[str, str] = {
@@ -274,7 +268,8 @@ def render_board_html(
         _dims = _resolve_dimensions(device_type, notes_wide=notes_wide, notes_tall=notes_tall)
         rows, cols = _dims.rows, _dims.cols
     except ValueError:
-        rows, cols = _STATIC_DEVICE_DIMS["flagship"]
+        # Unknown/corrupt device_type — fall back to flagship 6×22 rather than crash.
+        rows, cols = 6, 22
     is_note = device_type == "note"
     grid = _grid(formatted or "", rows, cols, device_type)
 

--- a/src/board_html_renderer.py
+++ b/src/board_html_renderer.py
@@ -20,13 +20,15 @@ from __future__ import annotations
 
 import html
 
+from .devices import resolve_dimensions as _resolve_dimensions
+
 # ---------------------------------------------------------------------------
 # Constants — mirrored from web/src/lib/board-colors.ts and
-# web/src/components/board-display.tsx so the preview matches the web UI.
+# web/src/lib/board-dimensions.ts so the preview matches the web UI.
 # ---------------------------------------------------------------------------
 
-DEVICE_DIMS: dict[str, tuple[int, int]] = {
-    # device_type -> (rows, cols)
+# _STATIC_DEVICE_DIMS kept for reference; use _resolve_dimensions() in render functions.
+_STATIC_DEVICE_DIMS: dict[str, tuple[int, int]] = {
     "flagship": (6, 22),
     "note": (3, 15),
 }
@@ -249,6 +251,8 @@ def render_board_html(
     formatted: str,
     *,
     device_type: str = "flagship",
+    notes_wide: int = 1,
+    notes_tall: int = 1,
     page_name: str | None = None,
 ) -> str:
     """Render a board preview as a self-contained HTML document.
@@ -257,13 +261,20 @@ def render_board_html(
         formatted: The rendered template text (output of TemplateEngine.render
             or PageService.preview_page().formatted). May include ``{63}`` /
             ``{red}`` colour tokens and ``\\n``-separated lines.
-        device_type: ``"flagship"`` (22x6) or ``"note"`` (15x3).
+        device_type: ``"flagship"`` (22×6), ``"note"`` (15×3), or
+            ``"note_array"`` (dimensions computed from notes_wide/notes_tall).
+        notes_wide: Number of Notes wide (only used for ``"note_array"``).
+        notes_tall: Number of Notes tall (only used for ``"note_array"``).
         page_name: Optional label rendered above the board.
 
     Returns:
         A standalone HTML document string (``<!DOCTYPE html>...``).
     """
-    rows, cols = DEVICE_DIMS.get(device_type, DEVICE_DIMS["flagship"])
+    try:
+        _dims = _resolve_dimensions(device_type, notes_wide=notes_wide, notes_tall=notes_tall)
+        rows, cols = _dims.rows, _dims.cols
+    except ValueError:
+        rows, cols = _STATIC_DEVICE_DIMS["flagship"]
     is_note = device_type == "note"
     grid = _grid(formatted or "", rows, cols, device_type)
 
@@ -311,6 +322,8 @@ def render_page_preview_html(page: object) -> str:
         A standalone HTML document string.
     """
     device_type = getattr(page, "device_type", "flagship") or "flagship"
+    notes_wide = getattr(page, "notes_wide", 1) or 1
+    notes_tall = getattr(page, "notes_tall", 1) or 1
     page_id = getattr(page, "id", None)
     page_name = getattr(page, "name", None)
 
@@ -332,4 +345,10 @@ def render_page_preview_html(page: object) -> str:
         if template:
             formatted = "\n".join(template)
 
-    return render_board_html(formatted, device_type=device_type, page_name=page_name)
+    return render_board_html(
+        formatted,
+        device_type=device_type,
+        notes_wide=notes_wide,
+        notes_tall=notes_tall,
+        page_name=page_name,
+    )

--- a/tests/test_board_html_renderer.py
+++ b/tests/test_board_html_renderer.py
@@ -12,10 +12,10 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from src.board_html_renderer import (
-    DEVICE_DIMS,
     render_board_html,
     render_page_preview_html,
 )
+from src.devices import resolve_dimensions
 
 
 def _count(html: str, needle: str) -> int:
@@ -29,7 +29,7 @@ class TestDimensions:
 
     def test_flagship_renders_22_cols_per_row(self):
         html = render_board_html("HELLO", device_type="flagship")
-        rows, cols = DEVICE_DIMS["flagship"]
+        rows, cols = resolve_dimensions("flagship")
         # 6 rows * 22 cols = 132 tiles
         assert _count(html, 'class="tile"') + _count(html, 'class="tile note"') == rows * cols
 
@@ -39,7 +39,7 @@ class TestDimensions:
 
     def test_note_renders_15_cols_per_row(self):
         html = render_board_html("HI", device_type="note")
-        rows, cols = DEVICE_DIMS["note"]
+        rows, cols = resolve_dimensions("note")
         # Note tiles carry the .note class.
         assert _count(html, 'class="tile note"') == rows * cols
 

--- a/web/src/__tests__/board-dimensions.test.ts
+++ b/web/src/__tests__/board-dimensions.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isNoteArray,
+  MAX_NOTES_PER_AXIS,
+  NOTE_ARRAY_PRESETS,
+  NOTE_COLS,
+  NOTE_ROWS,
+  noteArrayDimensions,
+  resolveDimensions,
+} from "@/lib/board-dimensions";
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+describe("constants", () => {
+  it("NOTE_ROWS equals 3", () => {
+    expect(NOTE_ROWS).toBe(3);
+  });
+
+  it("NOTE_COLS equals 15", () => {
+    expect(NOTE_COLS).toBe(15);
+  });
+
+  it("MAX_NOTES_PER_AXIS equals 8", () => {
+    expect(MAX_NOTES_PER_AXIS).toBe(8);
+  });
+});
+
+// =============================================================================
+// NOTE_ARRAY_PRESETS — preset math for all 5 presets
+// =============================================================================
+
+describe("NOTE_ARRAY_PRESETS", () => {
+  it('preset "2_wide" has correct values and computed dims', () => {
+    const p = NOTE_ARRAY_PRESETS.find((x) => x.id === "2_wide");
+    expect(p).toBeDefined();
+    expect(p!.notes_wide).toBe(2);
+    expect(p!.notes_tall).toBe(1);
+    expect(noteArrayDimensions(p!.notes_wide, p!.notes_tall)).toEqual({ rows: 3, cols: 30 });
+  });
+
+  it('preset "4_wide" has correct values and computed dims', () => {
+    const p = NOTE_ARRAY_PRESETS.find((x) => x.id === "4_wide");
+    expect(p).toBeDefined();
+    expect(p!.notes_wide).toBe(4);
+    expect(p!.notes_tall).toBe(1);
+    expect(noteArrayDimensions(p!.notes_wide, p!.notes_tall)).toEqual({ rows: 3, cols: 60 });
+  });
+
+  it('preset "2_tall" has correct values and computed dims', () => {
+    const p = NOTE_ARRAY_PRESETS.find((x) => x.id === "2_tall");
+    expect(p).toBeDefined();
+    expect(p!.notes_wide).toBe(1);
+    expect(p!.notes_tall).toBe(2);
+    expect(noteArrayDimensions(p!.notes_wide, p!.notes_tall)).toEqual({ rows: 6, cols: 15 });
+  });
+
+  it('preset "4_tall" has correct values and computed dims', () => {
+    const p = NOTE_ARRAY_PRESETS.find((x) => x.id === "4_tall");
+    expect(p).toBeDefined();
+    expect(p!.notes_wide).toBe(1);
+    expect(p!.notes_tall).toBe(4);
+    expect(noteArrayDimensions(p!.notes_wide, p!.notes_tall)).toEqual({ rows: 12, cols: 15 });
+  });
+
+  it('preset "2x2_grid" has correct values and computed dims', () => {
+    const p = NOTE_ARRAY_PRESETS.find((x) => x.id === "2x2_grid");
+    expect(p).toBeDefined();
+    expect(p!.notes_wide).toBe(2);
+    expect(p!.notes_tall).toBe(2);
+    expect(noteArrayDimensions(p!.notes_wide, p!.notes_tall)).toEqual({ rows: 6, cols: 30 });
+  });
+
+  it("all 5 preset IDs exist and are unique", () => {
+    expect(NOTE_ARRAY_PRESETS).toHaveLength(5);
+    const ids = NOTE_ARRAY_PRESETS.map((p) => p.id);
+    const uniqueIds = new Set(ids);
+    expect(uniqueIds.size).toBe(5);
+    expect(ids).toContain("2_wide");
+    expect(ids).toContain("4_wide");
+    expect(ids).toContain("2_tall");
+    expect(ids).toContain("4_tall");
+    expect(ids).toContain("2x2_grid");
+  });
+
+  it("preset labels are non-empty strings", () => {
+    for (const p of NOTE_ARRAY_PRESETS) {
+      expect(typeof p.label).toBe("string");
+      expect(p.label.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// =============================================================================
+// noteArrayDimensions — custom W×H
+// =============================================================================
+
+describe("noteArrayDimensions", () => {
+  it("noteArrayDimensions(1, 1) → { rows: 3, cols: 15 }", () => {
+    expect(noteArrayDimensions(1, 1)).toEqual({ rows: 3, cols: 15 });
+  });
+
+  it("noteArrayDimensions(3, 2) → { rows: 6, cols: 45 }", () => {
+    expect(noteArrayDimensions(3, 2)).toEqual({ rows: 6, cols: 45 });
+  });
+
+  it("noteArrayDimensions(8, 8) → { rows: 24, cols: 120 } (max axis)", () => {
+    expect(noteArrayDimensions(8, 8)).toEqual({ rows: 24, cols: 120 });
+  });
+
+  it("noteArrayDimensions(4, 1) → { rows: 3, cols: 60 }", () => {
+    expect(noteArrayDimensions(4, 1)).toEqual({ rows: 3, cols: 60 });
+  });
+});
+
+// =============================================================================
+// resolveDimensions — flagship
+// =============================================================================
+
+describe("resolveDimensions — flagship", () => {
+  it('resolveDimensions("flagship") → { rows: 6, cols: 22 }', () => {
+    expect(resolveDimensions("flagship")).toEqual({ rows: 6, cols: 22 });
+  });
+
+  it('resolveDimensions("flagship", 4, 2) → { rows: 6, cols: 22 } (w/h ignored)', () => {
+    expect(resolveDimensions("flagship", 4, 2)).toEqual({ rows: 6, cols: 22 });
+  });
+});
+
+// =============================================================================
+// resolveDimensions — note
+// =============================================================================
+
+describe("resolveDimensions — note", () => {
+  it('resolveDimensions("note") → { rows: 3, cols: 15 }', () => {
+    expect(resolveDimensions("note")).toEqual({ rows: 3, cols: 15 });
+  });
+
+  it('resolveDimensions("note", 3, 3) → { rows: 3, cols: 15 } (w/h ignored)', () => {
+    expect(resolveDimensions("note", 3, 3)).toEqual({ rows: 3, cols: 15 });
+  });
+});
+
+// =============================================================================
+// resolveDimensions — note_array (key acceptance-criteria case)
+// =============================================================================
+
+describe("resolveDimensions — note_array", () => {
+  it('resolveDimensions("note_array", 4, 1) → { rows: 3, cols: 60 } (acceptance-criteria case)', () => {
+    expect(resolveDimensions("note_array", 4, 1)).toEqual({ rows: 3, cols: 60 });
+  });
+
+  it('resolveDimensions("note_array", 2, 2) → { rows: 6, cols: 30 }', () => {
+    expect(resolveDimensions("note_array", 2, 2)).toEqual({ rows: 6, cols: 30 });
+  });
+
+  it('resolveDimensions("note_array", 1, 4) → { rows: 12, cols: 15 }', () => {
+    expect(resolveDimensions("note_array", 1, 4)).toEqual({ rows: 12, cols: 15 });
+  });
+
+  it('resolveDimensions("note_array") defaults → { rows: 3, cols: 15 } (1×1)', () => {
+    expect(resolveDimensions("note_array")).toEqual({ rows: 3, cols: 15 });
+  });
+});
+
+// =============================================================================
+// resolveDimensions — unknown device type fallback
+// =============================================================================
+
+describe("resolveDimensions — unknown device type fallback", () => {
+  it('resolveDimensions("unknown_device") → { rows: 6, cols: 22 } (flagship fallback)', () => {
+    expect(resolveDimensions("unknown_device")).toEqual({ rows: 6, cols: 22 });
+  });
+});
+
+// =============================================================================
+// isNoteArray
+// =============================================================================
+
+describe("isNoteArray", () => {
+  it('isNoteArray("note_array") → true', () => {
+    expect(isNoteArray("note_array")).toBe(true);
+  });
+
+  it('isNoteArray("flagship") → false', () => {
+    expect(isNoteArray("flagship")).toBe(false);
+  });
+
+  it('isNoteArray("note") → false', () => {
+    expect(isNoteArray("note")).toBe(false);
+  });
+
+  it('isNoteArray("") → false', () => {
+    expect(isNoteArray("")).toBe(false);
+  });
+
+  it('isNoteArray("NOTE_ARRAY") → false (case-sensitive)', () => {
+    expect(isNoteArray("NOTE_ARRAY")).toBe(false);
+  });
+});

--- a/web/src/components/board-display.tsx
+++ b/web/src/components/board-display.tsx
@@ -6,15 +6,7 @@ import { useBoardAnimationsEnabled } from "@/hooks/use-board-animations";
 import { useTranslations } from "@/i18n/translations";
 import type { DeviceType } from "@/lib/api";
 import { ALL_COLOR_CODES, BOARD_COLORS } from "@/lib/board-colors";
-
-const ROWS = 6;
-const COLS = 22;
-
-// Device dimensions lookup
-const DEVICE_DIMS: Record<string, { rows: number; cols: number }> = {
-  flagship: { rows: 6, cols: 22 },
-  note: { rows: 3, cols: 15 },
-};
+import { resolveDimensions } from "@/lib/board-dimensions";
 
 // All displayable board characters indexed by character code (0-71).
 // Undefined codes (43, 45, 51, 57, 58, 61) use ' ' as placeholder so
@@ -192,8 +184,8 @@ function parseLine(line: string): Token[] {
 // Convert message string to grid of tokens with configurable dimensions
 function messageToGrid(
   message: string,
-  rows: number = ROWS,
-  cols: number = COLS,
+  rows: number = 6,
+  cols: number = 22,
   deviceType: string = "flagship",
 ): Token[][] {
   const lines = message.split("\n");
@@ -1105,6 +1097,10 @@ interface BoardDisplayProps {
   /** Skip animation infrastructure and render plain divs per tile. Much
    *  cheaper for static previews that never animate. */
   isStatic?: boolean;
+  /** Notes wide (for note_array device; ignored otherwise). */
+  notesWide?: number;
+  /** Notes tall (for note_array device; ignored otherwise). */
+  notesTall?: number;
 }
 
 // Backward compatibility alias
@@ -1119,11 +1115,13 @@ export const BoardDisplay = memo(
     boardType = "black",
     deviceType = "flagship",
     isStatic = false,
+    notesWide = 1,
+    notesTall = 1,
   }: BoardDisplayProps) {
     const t = useTranslations("boardDisplay");
     const animationsEnabled = useBoardAnimationsEnabled();
     // Get dimensions for the device type
-    const dims = DEVICE_DIMS[deviceType] || DEVICE_DIMS.flagship;
+    const dims = resolveDimensions(deviceType, notesWide, notesTall);
 
     // Memoize grid calculation to avoid recalculating on every render
     const grid = useMemo(() => {

--- a/web/src/components/board-display.tsx
+++ b/web/src/components/board-display.tsx
@@ -1248,6 +1248,8 @@ export const BoardDisplay = memo(
       prevProps.className === nextProps.className &&
       prevProps.boardType === nextProps.boardType &&
       prevProps.deviceType === nextProps.deviceType &&
+      prevProps.notesWide === nextProps.notesWide &&
+      prevProps.notesTall === nextProps.notesTall &&
       prevProps.isStatic === nextProps.isStatic
     );
   },

--- a/web/src/components/page-builder.tsx
+++ b/web/src/components/page-builder.tsx
@@ -10,7 +10,6 @@ import { ScaledBoardDisplay } from "@/components/scaled-board-display";
 // Direct import – bypasses next/dynamic chunk caching issues in dev mode.
 // TipTap's useEditor({ immediatelyRender: false }) handles SSR safely.
 import { TipTapTemplateEditor } from "@/components/tiptap-template-editor/TipTapTemplateEditor";
-import { DEVICE_DIMENSIONS } from "@/components/tiptap-template-editor/utils/constants";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import {
   AlertDialog,
@@ -45,6 +44,7 @@ import type {
   PageUpdate,
 } from "@/lib/api";
 import { api } from "@/lib/api";
+import { resolveDimensions } from "@/lib/board-dimensions";
 import { applyLineOpInPlace } from "@/lib/line-ops";
 import { onLiveOutputMessageChange, writeLiveOutputMessage } from "@/lib/live-output-channel";
 import { clearPreviewCacheForPage } from "@/lib/preview-cache";
@@ -121,7 +121,7 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
 
   // Device type: from prop (new pages) or from existing page (editing)
   const [deviceType, setDeviceType] = useState<DeviceType>(deviceTypeProp);
-  const dims = DEVICE_DIMENSIONS[deviceType] || DEVICE_DIMENSIONS.flagship;
+  const dims = resolveDimensions(deviceType);
   const numLines = dims.rows;
 
   // Preview board color - defaults to the user's configured board color

--- a/web/src/components/page-builder.tsx
+++ b/web/src/components/page-builder.tsx
@@ -121,6 +121,9 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
 
   // Device type: from prop (new pages) or from existing page (editing)
   const [deviceType, setDeviceType] = useState<DeviceType>(deviceTypeProp);
+  // NOTE: note_array W×H aren't threaded into the page builder yet, so a
+  // note_array page resolves to a single Note (1×1). Configuring note-array
+  // page dimensions in the editor is handled when the settings UI lands (#1178).
   const dims = resolveDimensions(deviceType);
   const numLines = dims.rows;
 

--- a/web/src/components/page-grid-selector.tsx
+++ b/web/src/components/page-grid-selector.tsx
@@ -13,7 +13,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { getEffectiveBoardColor, useBoardSettings, useCollections, usePages } from "@/hooks/use-board";
 import { useTranslations } from "@/i18n/translations";
-import type { Collection, Page, PagePreviewResponse } from "@/lib/api";
+import type { Collection, DeviceType, Page, PagePreviewResponse } from "@/lib/api";
 import { api, isCollectionId } from "@/lib/api";
 
 // Cache key for batch previews in localStorage
@@ -461,7 +461,7 @@ export interface PageGridSelectorProps {
   /** Label text above the grid */
   label?: string;
   /** Filter pages by device type */
-  deviceTypeFilter?: "flagship" | "note";
+  deviceTypeFilter?: DeviceType;
   /** View mode: "grid" shows previews, "list" shows compact list */
   viewMode?: ViewMode;
   /** Whether to include collections in the grid */

--- a/web/src/components/page-grid-selector.tsx
+++ b/web/src/components/page-grid-selector.tsx
@@ -222,7 +222,7 @@ const PageButton = memo(
             preview={preview}
             isLoading={isLoadingPreview}
             boardType={boardType}
-            deviceType={(page.device_type as "flagship" | "note") || "flagship"}
+            deviceType={(page.device_type as DeviceType) || "flagship"}
           />
         </div>
 
@@ -399,7 +399,7 @@ const CollectionButton = memo(
           ) : (
             <div className="absolute inset-0">
               {stackPages.map(({ pageId, page, preview }, idx) => {
-                const deviceType = (page?.device_type as "flagship" | "note") || "flagship";
+                const deviceType = (page?.device_type as DeviceType) || "flagship";
                 return (
                   <div
                     key={pageId}

--- a/web/src/components/static-board-display.tsx
+++ b/web/src/components/static-board-display.tsx
@@ -5,11 +5,7 @@ import { memo, useMemo } from "react";
 import { useTranslations } from "@/i18n/translations";
 import type { DeviceType } from "@/lib/api";
 import { ALL_COLOR_CODES, BOARD_COLORS } from "@/lib/board-colors";
-
-const DEVICE_DIMS: Record<string, { rows: number; cols: number }> = {
-  flagship: { rows: 6, cols: 22 },
-  note: { rows: 3, cols: 15 },
-};
+import { resolveDimensions } from "@/lib/board-dimensions";
 
 const _BOARD_CHARS = [
   " ",
@@ -163,15 +159,21 @@ export const StaticBoardDisplay = memo(function StaticBoardDisplay({
   boardType = "black",
   deviceType = "flagship",
   className = "",
+  notesWide = 1,
+  notesTall = 1,
 }: {
   message: string | null;
   size?: "sm" | "md" | "lg";
   boardType?: "black" | "white";
   deviceType?: DeviceType;
   className?: string;
+  /** Notes wide (for note_array device; ignored otherwise). */
+  notesWide?: number;
+  /** Notes tall (for note_array device; ignored otherwise). */
+  notesTall?: number;
 }) {
   const t = useTranslations("boardDisplay");
-  const dims = DEVICE_DIMS[deviceType] || DEVICE_DIMS.flagship;
+  const dims = resolveDimensions(deviceType, notesWide, notesTall);
   const isWhiteBoard = boardType === "white";
   const tileBg = isWhiteBoard ? "var(--color-board-surface-light)" : "var(--color-board-surface-dark)";
   const textColor = isWhiteBoard ? "var(--color-board-text-on-light)" : "var(--color-board-text-on-dark)";

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -196,7 +196,7 @@ export interface SetActivePageResponse {
 export type PageType = "single" | "composite" | "template";
 
 // Device types
-export type DeviceType = "flagship" | "note";
+export type DeviceType = "flagship" | "note" | "note_array";
 
 export interface RowConfig {
   source: string;
@@ -227,6 +227,10 @@ export interface Page {
   transition_step_size?: number | null;
   created_at: string;
   updated_at?: string;
+  /** Number of Notes wide (note_array device_type only). */
+  notes_wide?: number;
+  /** Number of Notes tall (note_array device_type only). */
+  notes_tall?: number;
 }
 
 export interface PageCreate {
@@ -242,6 +246,10 @@ export interface PageCreate {
   transition_strategy?: string | null;
   transition_interval_ms?: number | null;
   transition_step_size?: number | null;
+  /** Number of Notes wide (note_array device_type only). */
+  notes_wide?: number;
+  /** Number of Notes tall (note_array device_type only). */
+  notes_tall?: number;
 }
 
 export interface PageUpdate {
@@ -255,6 +263,10 @@ export interface PageUpdate {
   transition_strategy?: string | null;
   transition_interval_ms?: number | null;
   transition_step_size?: number | null;
+  /** Number of Notes wide (note_array device_type only). */
+  notes_wide?: number;
+  /** Number of Notes tall (note_array device_type only). */
+  notes_tall?: number;
 }
 
 export interface PagesResponse {
@@ -496,6 +508,10 @@ export interface BoardInstance {
   host: string;
   local_api_key: string;
   cloud_key: string;
+  /** Number of Notes arranged horizontally (note_array only; default 1). */
+  notes_wide?: number;
+  /** Number of Notes arranged vertically (note_array only; default 1). */
+  notes_tall?: number;
 }
 
 export interface BoardSettings {

--- a/web/src/lib/board-dimensions.ts
+++ b/web/src/lib/board-dimensions.ts
@@ -59,7 +59,8 @@ export function isNoteArray(deviceType: string): boolean {
  * - "note_array"         → computes from notes_wide × notes_tall
  * - unknown              → falls back to flagship (matches Python board_html_renderer.py)
  *
- * Mirrors Python resolve_dimensions().
+ * Mirrors Python resolve_dimensions(), except unknown device types fall back
+ * to flagship (matching board_html_renderer.py) rather than raising.
  *
  * @param deviceType  "flagship" | "note" | "note_array"
  * @param notes_wide  Number of notes wide (only used for "note_array"; default 1)

--- a/web/src/lib/board-dimensions.ts
+++ b/web/src/lib/board-dimensions.ts
@@ -1,0 +1,78 @@
+// ── Constants (mirror Python src/devices.py) ─────────────────────────────────
+export const NOTE_ROWS = 3;
+export const NOTE_COLS = 15;
+export const MAX_NOTES_PER_AXIS = 8;
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+export interface BoardDimensions {
+  rows: number;
+  cols: number;
+}
+
+export interface NoteArrayPreset {
+  id: string;
+  label: string;
+  notes_wide: number;
+  notes_tall: number;
+}
+
+// ── Static device dimensions (flagship + note) ────────────────────────────────
+export const DEVICE_DIMENSIONS: Record<string, BoardDimensions> = {
+  flagship: { rows: 6, cols: 22 },
+  note: { rows: NOTE_ROWS, cols: NOTE_COLS },
+};
+
+// ── 5 presets (exact ids/labels/values matching Python NOTE_ARRAY_PRESETS) ────
+export const NOTE_ARRAY_PRESETS: NoteArrayPreset[] = [
+  { id: "2_wide", label: "2 side-by-side", notes_wide: 2, notes_tall: 1 },
+  { id: "4_wide", label: "4 side-by-side", notes_wide: 4, notes_tall: 1 },
+  { id: "2_tall", label: "2 stacked", notes_wide: 1, notes_tall: 2 },
+  { id: "4_tall", label: "4 stacked", notes_wide: 1, notes_tall: 4 },
+  { id: "2x2_grid", label: "2×2 grid", notes_wide: 2, notes_tall: 2 },
+];
+
+// ── Core helpers ──────────────────────────────────────────────────────────────
+
+/**
+ * Compute dimensions for a note-array grid.
+ * Does NOT validate inputs (mirrors Python note_array_dimensions()).
+ */
+export function noteArrayDimensions(notes_wide: number, notes_tall: number): BoardDimensions {
+  return {
+    rows: notes_tall * NOTE_ROWS,
+    cols: notes_wide * NOTE_COLS,
+  };
+}
+
+/**
+ * Return true if device_type is "note_array".
+ * Mirrors Python is_note_array().
+ */
+export function isNoteArray(deviceType: string): boolean {
+  return deviceType === "note_array";
+}
+
+/**
+ * Resolve board dimensions for any device type.
+ *
+ * - "flagship" | "note"  → looks up DEVICE_DIMENSIONS (w/h ignored)
+ * - "note_array"         → computes from notes_wide × notes_tall
+ * - unknown              → falls back to flagship (matches Python board_html_renderer.py)
+ *
+ * Mirrors Python resolve_dimensions().
+ *
+ * @param deviceType  "flagship" | "note" | "note_array"
+ * @param notes_wide  Number of notes wide (only used for "note_array"; default 1)
+ * @param notes_tall  Number of notes tall (only used for "note_array"; default 1)
+ * @returns           { rows, cols }
+ */
+export function resolveDimensions(deviceType: string, notes_wide = 1, notes_tall = 1): BoardDimensions {
+  if (deviceType in DEVICE_DIMENSIONS) {
+    return DEVICE_DIMENSIONS[deviceType];
+  }
+  if (deviceType === "note_array") {
+    return noteArrayDimensions(notes_wide, notes_tall);
+  }
+  // Unknown: fall back to flagship (matches Python fallback in board_html_renderer.py)
+  return DEVICE_DIMENSIONS.flagship;
+}


### PR DESCRIPTION
## Summary

- Introduces `web/src/lib/board-dimensions.ts` as a single TypeScript source of truth for board geometry, mirroring `src/devices.py`
- Extends `DeviceType` in `api.ts` to include `"note_array"` and adds `notes_wide`/`notes_tall` to `BoardInstance`, `Page`, `PageCreate`, and `PageUpdate` — resolving the TS Page-type drift flagged on #1173
- Removes duplicated `DEVICE_DIMS` literals from `board-display.tsx`, `static-board-display.tsx`, `page-builder.tsx`, and `src/board_html_renderer.py`

## What changed

- **New:** `web/src/lib/board-dimensions.ts` — exports `NOTE_ROWS` (3), `NOTE_COLS` (15), `MAX_NOTES_PER_AXIS` (8), 5 presets (`2_wide`/`4_wide`/`2_tall`/`4_tall`/`2x2_grid`) with exact ids/labels/values matching Python, `noteArrayDimensions(w, h)`, `isNoteArray(deviceType)`, `resolveDimensions(deviceType, notesWide?, notesTall?)`
- **New:** `web/src/__tests__/board-dimensions.test.ts` — 28 vitest tests covering all presets, custom W×H, `resolveDimensions` for flagship/note/note_array/unknown, and `isNoteArray`
- **`web/src/lib/api.ts`** — `DeviceType` now includes `"note_array"`; `BoardInstance`, `Page`, `PageCreate`, `PageUpdate` gain optional `notes_wide?`/`notes_tall?`
- **`web/src/components/board-display.tsx`** — imports `resolveDimensions`; removes module-level `DEVICE_DIMS` and standalone `ROWS`/`COLS` constants; adds `notesWide`/`notesTall` props
- **`web/src/components/static-board-display.tsx`** — same refactor; adds `notesWide`/`notesTall` props
- **`web/src/components/page-builder.tsx`** — replaces tiptap `DEVICE_DIMENSIONS` import (flagship/note only) with `resolveDimensions`
- **`web/src/components/page-grid-selector.tsx`** — `deviceTypeFilter` prop widened from `"flagship" | "note"` to `DeviceType`
- **`src/board_html_renderer.py`** — replaces hardcoded `DEVICE_DIMS` dict with `resolve_dimensions()` from `src/devices.py`; `render_board_html()` accepts `notes_wide`/`notes_tall` kwargs; `render_page_preview_html()` reads them from the page object

## Acceptance checklist

| Criterion | Met |
|---|---|
| `DeviceType` includes `note_array`; presets + helpers exported from one module | ✅ `web/src/lib/board-dimensions.ts` |
| All former `DEVICE_DIMS` consumers use the shared helper (no duplicated literals) | ✅ board-display, static-board-display, page-builder, board_html_renderer |
| `resolveDimensions("note_array", 4, 1)` → `{ rows: 3, cols: 60 }` | ✅ Test #19 in board-dimensions.test.ts |
| `npm run` type-check / lint passes (for changed files) | ✅ eslint + prettier clean on all changed files |
| 28-test vitest suite | ✅ All pass |

## Test evidence

- **Web tests:** 88 test files, 1093 passed, 13 skipped — including `board-dimensions.test.ts` (28/28 ✅)
- **Prettier:** All changed `.ts`/`.tsx` files formatted — `All matched files use Prettier code style!`
- **ESLint:** 0 errors on all changed source files
- **ruff:** `src/board_html_renderer.py` — `All checks passed!`

Note: `npm run typecheck` has pre-existing failures on origin/next (unrelated to this PR: tiptap extensions, schedule/settings routes, storybook, api.ts duplicate `board` identifier, etc.) — none introduced by this PR.

---

Part of #1167 · Implements #1174