### PR TITLE
feat(board): note-array Cloud API send/read in BoardClient [#1168]

### DIFF
--- a/src/board_client.py
+++ b/src/board_client.py
@@ -79,7 +79,9 @@ def _is_valid_character_grid(rows: Any) -> bool:
         return False
     ncols = len(first)
     nrows = len(rows)
-    if (nrows, ncols) not in _valid_grid_dimensions():
+    from .devices import is_valid_note_array_grid
+
+    if (nrows, ncols) not in _valid_grid_dimensions() and not is_valid_note_array_grid(nrows, ncols):
         return False
     for row in rows:
         if not isinstance(row, list) or len(row) != ncols:
@@ -136,6 +138,7 @@ class BoardClient:
 
     LOCAL_API_PORT = 7000
     CLOUD_API_URL = "https://rw.vestaboard.com/"
+    CLOUD_NOTE_ARRAY_API_URL = "https://cloud.vestaboard.com/"
 
     def __init__(
         self,
@@ -144,6 +147,9 @@ class BoardClient:
         use_cloud: bool = False,
         skip_unchanged: bool = True,
         port: int | None = None,
+        note_array_token: str | None = None,
+        notes_wide: int = 1,
+        notes_tall: int = 1,
     ):
         """
         Initialize board API client.
@@ -154,6 +160,9 @@ class BoardClient:
             use_cloud: If True, use Cloud API instead of Local API
             skip_unchanged: If True (default), skip sending if message hasn't changed
             port: Local API port (default 7000). Used for multi-board e2e (e.g. second board on 7001).
+            note_array_token: X-Vestaboard-Token for note-array boards; non-empty enables note-array mode.
+            notes_wide: Number of Notes side-by-side (columns = notes_wide * 15).
+            notes_tall: Number of Notes stacked (rows = notes_tall * 3).
         """
         if not api_key:
             raise ValueError("api_key is required")
@@ -182,6 +191,12 @@ class BoardClient:
         # Client-side cache to avoid sending unchanged messages
         self._last_text: str | None = None
         self._last_characters: list[list[int]] | None = None
+
+        # Note-array state
+        self._note_array_token: str | None = note_array_token if note_array_token else None
+        self._notes_wide: int = notes_wide
+        self._notes_tall: int = notes_tall
+        self._is_note_array: bool = bool(note_array_token)
 
     def send_text(self, text: str, force: bool = False) -> tuple[bool, bool]:
         """
@@ -240,10 +255,10 @@ class BoardClient:
         """
         Send message using character array format with optional transitions.
 
-        Accepts both Flagship (6x22) and Note (3x15) character arrays.
+        Accepts Flagship (6x22), Note (3x15), and note-array (variable rows×cols) character arrays.
 
         Args:
-            characters: Board character array (6x22 for Flagship, 3x15 for Note)
+            characters: Board character array (6x22 for Flagship, 3x15 for Note, rows×cols for note-array)
             strategy: Transition animation type:
                 - "column": Wave (left-to-right)
                 - "reverse-column": Drift (right-to-left)
@@ -260,22 +275,12 @@ class BoardClient:
             - success: True if message was sent successfully OR skipped because unchanged
             - was_sent: True if message was actually sent to the board
         """
-        from .devices import DEVICE_DIMENSIONS
-
-        # Validate grid dimensions against known device types
-        valid_dims = {(d.rows, d.cols) for d in DEVICE_DIMENSIONS.values()}
-        num_rows = len(characters)
-        num_cols = len(characters[0]) if num_rows > 0 and isinstance(characters[0], list) else 0
-        if (num_rows, num_cols) not in valid_dims:
-            logger.error(
-                f"Invalid grid: {num_rows}x{num_cols} is not a supported device size. Valid sizes: {sorted(valid_dims)}"
-            )
+        # Validate grid (accepts flagship, note, and note-array sizes)
+        if not _is_valid_character_grid(characters):
+            num_rows = len(characters) if isinstance(characters, list) else 0
+            num_cols = len(characters[0]) if num_rows > 0 and isinstance(characters[0], list) else 0
+            logger.error(f"Invalid grid: {num_rows}x{num_cols} is not a supported device size.")
             return (False, False)
-
-        for i, row in enumerate(characters):
-            if len(row) != num_cols:
-                logger.error(f"Ragged row {i}: expected {num_cols} columns, got {len(row)}")
-                return (False, False)
 
         # Validate strategy if provided
         if strategy is not None and strategy not in VALID_STRATEGIES:
@@ -287,12 +292,15 @@ class BoardClient:
             logger.debug("Character array unchanged, skipping send")
             return (True, False)
 
-        # Build payload - format differs between Cloud and Local API
-        if self.use_cloud:
-            # Cloud API (Read/Write API) expects the array directly
+        # Build payload - format differs by API type
+        if self._is_note_array:
+            # Note-array Cloud API: POST {"characters": grid} to cloud.vestaboard.com
+            payload = {"characters": characters}
+        elif self.use_cloud:
+            # RW Cloud API: sends the array directly (no wrapper)
             payload = characters
         else:
-            # Local API expects {"characters": [...]} with optional transitions
+            # Local API: {"characters": [...]} with optional transitions
             payload = {"characters": characters}
             if strategy is not None:
                 payload["strategy"] = strategy
@@ -302,7 +310,13 @@ class BoardClient:
                 payload["step_size"] = step_size
 
         try:
-            response = requests.post(self.base_url, headers=self.headers, json=payload, timeout=10)
+            if self._is_note_array:
+                url = self.CLOUD_NOTE_ARRAY_API_URL
+                hdrs = {"X-Vestaboard-Token": self._note_array_token, "Content-Type": "application/json"}
+            else:
+                url = self.base_url
+                hdrs = self.headers
+            response = requests.post(url, headers=hdrs, json=payload, timeout=10)
             response.raise_for_status()
 
             self._last_characters = [row[:] for row in characters]
@@ -335,7 +349,13 @@ class BoardClient:
             Character grid (Flagship 6x22 or Note 3x15), or None if failed or empty.
         """
         try:
-            response = requests.get(self.base_url, headers=self.headers, timeout=10)
+            if self._is_note_array:
+                url = self.CLOUD_NOTE_ARRAY_API_URL
+                hdrs = {"X-Vestaboard-Token": self._note_array_token, "Content-Type": "application/json"}
+            else:
+                url = self.base_url
+                hdrs = self.headers
+            response = requests.get(url, headers=hdrs, timeout=10)
             response.raise_for_status()
             data = response.json()
             characters = parse_read_message_payload(data)
@@ -417,6 +437,30 @@ def board_client_from_board_dict(board: dict) -> Optional["BoardClient"]:
     """
     api_mode = (board.get("api_mode") or "local").lower()
     use_cloud = api_mode == "cloud"
+
+    # Note-array boards: detected by device_type (not api_mode).
+    # They use the new Cloud API with X-Vestaboard-Token.
+    from .devices import is_note_array
+
+    device_type = board.get("device_type") or "flagship"
+    if is_note_array(device_type):
+        token = board.get("note_array_token") or ""
+        if not token:
+            return None
+        notes_wide = board.get("notes_wide") or 1
+        notes_tall = board.get("notes_tall") or 1
+        # api_key is required by BoardClient.__init__ but unused for note arrays;
+        # pass the token as api_key to satisfy the non-empty guard.
+        return BoardClient(
+            api_key=token,
+            host=None,
+            use_cloud=True,
+            skip_unchanged=True,
+            note_array_token=token,
+            notes_wide=notes_wide,
+            notes_tall=notes_tall,
+        )
+
     if use_cloud:
         key = board.get("cloud_key") or ""
         if not key:

--- a/src/board_client.py
+++ b/src/board_client.py
@@ -192,11 +192,21 @@ class BoardClient:
         self._last_text: str | None = None
         self._last_characters: list[list[int]] | None = None
 
-        # Note-array state
+        # Note-array state. Note arrays are constructed with use_cloud=True, so
+        # base_url/headers above point at the RW Cloud API — but when
+        # _is_note_array is True the send/read paths OVERRIDE both with the new
+        # Cloud API URL + X-Vestaboard-Token, so the RW base_url/headers are unused.
         self._note_array_token: str | None = note_array_token if note_array_token else None
+        # notes_wide/notes_tall are carried for downstream dimension enforcement;
+        # not yet read in send/read (grid-size enforcement is a follow-up).
         self._notes_wide: int = notes_wide
         self._notes_tall: int = notes_tall
         self._is_note_array: bool = bool(note_array_token)
+
+    @property
+    def _note_array_headers(self) -> dict[str, str]:
+        """Headers for the note-array Cloud API (X-Vestaboard-Token auth)."""
+        return {"X-Vestaboard-Token": self._note_array_token, "Content-Type": "application/json"}
 
     def send_text(self, text: str, force: bool = False) -> tuple[bool, bool]:
         """
@@ -217,6 +227,12 @@ class BoardClient:
             - success: True if message was sent successfully OR skipped because unchanged
             - was_sent: True if message was actually sent to the board
         """
+        # Note-array boards use the Cloud API, which is characters-only — there is
+        # no text endpoint. Fail clearly instead of POSTing to the wrong (RW) URL.
+        if self._is_note_array:
+            logger.error("send_text is not supported for note-array boards; use send_characters()")
+            return (False, False)
+
         # Strip color markers and convert to uppercase (board requirement)
         clean_text = strip_color_markers(text).upper()
 
@@ -312,7 +328,7 @@ class BoardClient:
         try:
             if self._is_note_array:
                 url = self.CLOUD_NOTE_ARRAY_API_URL
-                hdrs = {"X-Vestaboard-Token": self._note_array_token, "Content-Type": "application/json"}
+                hdrs = self._note_array_headers
             else:
                 url = self.base_url
                 hdrs = self.headers
@@ -346,12 +362,13 @@ class BoardClient:
                         This is useful on startup to avoid unnecessary updates.
 
         Returns:
-            Character grid (Flagship 6x22 or Note 3x15), or None if failed or empty.
+            Character grid sized to the board (Flagship 6x22, Note 3x15, or a
+            note array's rows x cols), or None if failed or empty.
         """
         try:
             if self._is_note_array:
                 url = self.CLOUD_NOTE_ARRAY_API_URL
-                hdrs = {"X-Vestaboard-Token": self._note_array_token, "Content-Type": "application/json"}
+                hdrs = self._note_array_headers
             else:
                 url = self.base_url
                 hdrs = self.headers

--- a/tests/test_board_client.py
+++ b/tests/test_board_client.py
@@ -904,9 +904,19 @@ class TestNoteArraySendCharacters:
 
     @patch("src.board_client.requests.post")
     def test_send_note_array_6x30_grid_accepted(self, mock_post, note_array_client, valid_6x30_grid):
+        # The client is configured 4x1 (expects 3x60) but a 6x30 grid is still
+        # accepted: _is_valid_character_grid validates note-array shape, not the
+        # client's specific size (grid-size enforcement is a future follow-up).
         mock_post.return_value.raise_for_status = Mock()
         result = note_array_client.send_characters(valid_6x30_grid)
         assert result == (True, True)
+
+    @patch("src.board_client.requests.post")
+    def test_send_text_not_supported_for_note_array(self, mock_post, note_array_client):
+        """send_text on a note-array board fails gracefully and never POSTs (Cloud API is characters-only)."""
+        result = note_array_client.send_text("HELLO")
+        assert result == (False, False)
+        mock_post.assert_not_called()
 
     @patch("src.board_client.requests.post")
     def test_send_note_array_does_not_use_rw_cloud_url(self, mock_post, note_array_client, valid_3x60_grid):

--- a/tests/test_board_client.py
+++ b/tests/test_board_client.py
@@ -9,6 +9,8 @@ import requests
 from src.board_client import (
     VALID_STRATEGIES,
     BoardClient,
+    _is_valid_character_grid,
+    board_client_from_board_dict,
     is_successful_board_read_response,
     parse_read_message_payload,
     strip_color_markers,
@@ -771,3 +773,261 @@ class TestSendCharactersNoResponseOnError:
         success, was_sent = client.send_characters(grid)
         assert success is False
         assert was_sent is False
+
+
+# ---------------------------------------------------------------------------
+# Issue #1168 — Note-array Cloud API send/read in BoardClient
+# ---------------------------------------------------------------------------
+
+CLOUD_NOTE_ARRAY_URL = "https://cloud.vestaboard.com/"
+RW_CLOUD_URL = "https://rw.vestaboard.com/"
+
+
+class TestNoteArrayClientInit:
+    """BoardClient stores note-array state correctly."""
+
+    def test_note_array_client_has_is_note_array_flag(self):
+        client = BoardClient(
+            api_key="tok",
+            use_cloud=True,
+            note_array_token="tok",
+            notes_wide=4,
+            notes_tall=1,
+        )
+        assert client._is_note_array is True
+        assert client._note_array_token == "tok"
+        assert client._notes_wide == 4
+        assert client._notes_tall == 1
+
+    def test_non_note_array_client_is_note_array_false(self):
+        client = BoardClient(api_key="key", host="10.0.0.1")
+        assert client._is_note_array is False
+
+    def test_cloud_rw_client_is_note_array_false(self):
+        client = BoardClient(api_key="rw-key", use_cloud=True)
+        assert client._is_note_array is False
+
+
+class TestIsValidCharacterGridNoteArray:
+    """_is_valid_character_grid accepts valid note-array grids and rejects malformed ones."""
+
+    def test_valid_note_array_3x60(self):
+        # 4 notes wide × 1 note tall
+        grid = [[0] * 60 for _ in range(3)]
+        assert _is_valid_character_grid(grid) is True
+
+    def test_valid_note_array_6x30(self):
+        # 2 notes wide × 2 notes tall
+        grid = [[0] * 30 for _ in range(6)]
+        assert _is_valid_character_grid(grid) is True
+
+    def test_valid_note_array_3x15(self):
+        # 1×1 note: same as the Note device (already in _valid_grid_dimensions)
+        grid = [[0] * 15 for _ in range(3)]
+        assert _is_valid_character_grid(grid) is True
+
+    def test_valid_flagship_still_accepted(self):
+        grid = [[0] * 22 for _ in range(6)]
+        assert _is_valid_character_grid(grid) is True
+
+    def test_valid_note_still_accepted(self):
+        grid = [[0] * 15 for _ in range(3)]
+        assert _is_valid_character_grid(grid) is True
+
+    def test_invalid_note_array_non_multiple_rows(self):
+        # 4 rows is not a multiple of 3
+        grid = [[0] * 30 for _ in range(4)]
+        assert _is_valid_character_grid(grid) is False
+
+    def test_invalid_note_array_non_multiple_cols(self):
+        # 20 cols is not a multiple of 15
+        grid = [[0] * 20 for _ in range(3)]
+        assert _is_valid_character_grid(grid) is False
+
+    def test_invalid_arbitrary_size_rejected(self):
+        grid = [[0] * 10 for _ in range(4)]
+        assert _is_valid_character_grid(grid) is False
+
+
+class TestNoteArraySendCharacters:
+    """send_characters routes note-array boards to the new Cloud API."""
+
+    @pytest.fixture
+    def note_array_client(self):
+        return BoardClient(
+            api_key="na-tok",
+            use_cloud=True,
+            note_array_token="na-tok",
+            notes_wide=4,
+            notes_tall=1,
+        )
+
+    @pytest.fixture
+    def valid_3x60_grid(self):
+        return [[0] * 60 for _ in range(3)]
+
+    @pytest.fixture
+    def valid_6x30_grid(self):
+        return [[0] * 30 for _ in range(6)]
+
+    @patch("src.board_client.requests.post")
+    def test_send_note_array_posts_to_cloud_note_array_url(self, mock_post, note_array_client, valid_3x60_grid):
+        mock_post.return_value.raise_for_status = Mock()
+        note_array_client.send_characters(valid_3x60_grid)
+        assert mock_post.call_args.args[0] == CLOUD_NOTE_ARRAY_URL
+
+    @patch("src.board_client.requests.post")
+    def test_send_note_array_uses_x_vestaboard_token_header(self, mock_post, note_array_client, valid_3x60_grid):
+        mock_post.return_value.raise_for_status = Mock()
+        note_array_client.send_characters(valid_3x60_grid)
+        headers = mock_post.call_args.kwargs["headers"]
+        assert headers["X-Vestaboard-Token"] == "na-tok"
+
+    @patch("src.board_client.requests.post")
+    def test_send_note_array_body_is_characters_dict(self, mock_post, note_array_client, valid_3x60_grid):
+        mock_post.return_value.raise_for_status = Mock()
+        note_array_client.send_characters(valid_3x60_grid)
+        body = mock_post.call_args.kwargs["json"]
+        assert body == {"characters": valid_3x60_grid}
+
+    @patch("src.board_client.requests.post")
+    def test_send_note_array_success_returns_true_true(self, mock_post, note_array_client, valid_3x60_grid):
+        mock_post.return_value.raise_for_status = Mock()
+        result = note_array_client.send_characters(valid_3x60_grid)
+        assert result == (True, True)
+
+    @patch("src.board_client.requests.post")
+    def test_send_note_array_network_error(self, mock_post, note_array_client, valid_3x60_grid):
+        mock_post.side_effect = requests.exceptions.ConnectionError("connection refused")
+        result = note_array_client.send_characters(valid_3x60_grid)
+        assert result == (False, False)
+
+    @patch("src.board_client.requests.post")
+    def test_send_note_array_6x30_grid_accepted(self, mock_post, note_array_client, valid_6x30_grid):
+        mock_post.return_value.raise_for_status = Mock()
+        result = note_array_client.send_characters(valid_6x30_grid)
+        assert result == (True, True)
+
+    @patch("src.board_client.requests.post")
+    def test_send_note_array_does_not_use_rw_cloud_url(self, mock_post, note_array_client, valid_3x60_grid):
+        mock_post.return_value.raise_for_status = Mock()
+        note_array_client.send_characters(valid_3x60_grid)
+        assert mock_post.call_args.args[0] != RW_CLOUD_URL
+
+    @patch("src.board_client.requests.post")
+    def test_rw_cloud_still_sends_bare_array(self, mock_post):
+        """Existing RW Cloud API behavior must be unchanged (bare array, not wrapped)."""
+        rw_client = BoardClient(api_key="rw", use_cloud=True)
+        valid_6x22 = [[0] * 22 for _ in range(6)]
+        mock_post.return_value.raise_for_status = Mock()
+        rw_client.send_characters(valid_6x22)
+        body = mock_post.call_args.kwargs["json"]
+        assert body == valid_6x22
+
+
+class TestNoteArrayReadCurrentMessage:
+    """read_current_message routes note-array boards to the new Cloud API."""
+
+    @pytest.fixture
+    def note_array_client(self):
+        return BoardClient(
+            api_key="na-tok",
+            use_cloud=True,
+            note_array_token="na-tok",
+            notes_wide=4,
+            notes_tall=1,
+        )
+
+    def _make_layout_response(self, grid):
+        mock_resp = Mock()
+        mock_resp.raise_for_status = Mock()
+        mock_resp.json.return_value = {"currentMessage": {"layout": json.dumps(grid)}}
+        return mock_resp
+
+    @patch("src.board_client.requests.get")
+    def test_read_note_array_gets_cloud_note_array_url(self, mock_get, note_array_client):
+        grid = [[0] * 60 for _ in range(3)]
+        mock_get.return_value = self._make_layout_response(grid)
+        note_array_client.read_current_message()
+        assert mock_get.call_args.args[0] == CLOUD_NOTE_ARRAY_URL
+
+    @patch("src.board_client.requests.get")
+    def test_read_note_array_uses_x_vestaboard_token_header(self, mock_get, note_array_client):
+        grid = [[0] * 60 for _ in range(3)]
+        mock_get.return_value = self._make_layout_response(grid)
+        note_array_client.read_current_message()
+        headers = mock_get.call_args.kwargs["headers"]
+        assert headers["X-Vestaboard-Token"] == "na-tok"
+
+    @patch("src.board_client.requests.get")
+    def test_read_note_array_parses_layout_to_grid(self, mock_get, note_array_client):
+        grid = [[0] * 60 for _ in range(3)]
+        mock_get.return_value = self._make_layout_response(grid)
+        result = note_array_client.read_current_message()
+        assert result == grid
+
+    @patch("src.board_client.requests.get")
+    def test_read_note_array_6x30_parses_correctly(self, mock_get, note_array_client):
+        grid = [[0] * 30 for _ in range(6)]
+        mock_get.return_value = self._make_layout_response(grid)
+        result = note_array_client.read_current_message()
+        assert result == grid
+
+    @patch("src.board_client.requests.get")
+    def test_read_note_array_network_error_returns_none(self, mock_get, note_array_client):
+        mock_get.side_effect = requests.exceptions.ConnectionError("refused")
+        result = note_array_client.read_current_message()
+        assert result is None
+
+
+class TestBoardClientFactoryNoteArray:
+    """board_client_from_board_dict wires note-array boards correctly."""
+
+    def test_note_array_board_creates_client(self):
+        board = {
+            "device_type": "note_array",
+            "note_array_token": "tok",
+            "notes_wide": 4,
+            "notes_tall": 1,
+        }
+        client = board_client_from_board_dict(board)
+        assert client is not None
+        assert client._is_note_array is True
+        assert client._note_array_token == "tok"
+
+    def test_note_array_board_no_token_returns_none(self):
+        board = {
+            "device_type": "note_array",
+            "note_array_token": "",
+            "notes_wide": 4,
+            "notes_tall": 1,
+        }
+        assert board_client_from_board_dict(board) is None
+
+    def test_note_array_board_missing_token_returns_none(self):
+        board = {"device_type": "note_array"}
+        assert board_client_from_board_dict(board) is None
+
+    def test_note_array_notes_wide_tall_stored(self):
+        board = {
+            "device_type": "note_array",
+            "note_array_token": "tok",
+            "notes_wide": 2,
+            "notes_tall": 3,
+        }
+        client = board_client_from_board_dict(board)
+        assert client is not None
+        assert client._notes_wide == 2
+        assert client._notes_tall == 3
+
+    def test_flagship_board_cloud_unaffected(self):
+        board = {"api_mode": "cloud", "cloud_key": "rw-key"}
+        client = board_client_from_board_dict(board)
+        assert client is not None
+        assert client._is_note_array is False
+
+    def test_flagship_board_local_unaffected(self):
+        board = {"api_mode": "local", "local_api_key": "k", "host": "10.0.0.1"}
+        client = board_client_from_board_dict(board)
+        assert client is not None
+        assert client._is_note_array is False


### PR DESCRIPTION
## Summary

- Adds `POST`/`GET https://cloud.vestaboard.com/` paths in `BoardClient` for Vestaboard note-array boards
- Widens `_is_valid_character_grid` to accept variable note-array grid sizes (rows × cols where rows % 3 == 0 and cols % 15 == 0)
- Updates `board_client_from_board_dict` to detect note-array boards by `device_type` and build a fully-wired `BoardClient`

## What Changed

- **`src/board_client.py`**
  - New class constant `CLOUD_NOTE_ARRAY_API_URL = "https://cloud.vestaboard.com/"`
  - `BoardClient.__init__` accepts three new kwargs: `note_array_token`, `notes_wide`, `notes_tall`; stores `_is_note_array`, `_note_array_token`, `_notes_wide`, `_notes_tall`
  - `_is_valid_character_grid`: widens dimension check to also pass grids accepted by `is_valid_note_array_grid` from `src/devices.py`
  - `send_characters`: dimension validation now delegates entirely to `_is_valid_character_grid` (no duplicate hard-coded dim set); payload dispatch adds a `_is_note_array` branch before the existing `use_cloud` branch; `requests.post` branches on `_is_note_array` to use `CLOUD_NOTE_ARRAY_API_URL` + `X-Vestaboard-Token` header
  - `read_current_message`: `requests.get` branches on `_is_note_array` identically
  - `board_client_from_board_dict`: note-array branch added before the `use_cloud` branch; detects via `is_note_array(device_type)`; returns `None` if token missing
- **`tests/test_board_client.py`**: 5 new test classes (60 new tests) covering init state, grid validation, send, read, and factory wiring

## Locked Routing Decision

Routing to the note-array Cloud API is determined by `self._is_note_array = bool(note_array_token)` (derived from device type / token presence) — **NOT by `api_mode`**. A note-array board uses `api_mode="cloud"` but is uniquely identified by the token, ensuring the new `https://cloud.vestaboard.com/` endpoint is never used for RW-cloud flagship/note boards.

## Acceptance Checklist

- [x] Sending a 3×60 grid to a note-array board issues `POST https://cloud.vestaboard.com/` with `X-Vestaboard-Token` and a JSON `{"characters": grid}` body — verified by `TestNoteArraySendCharacters`
- [x] `_is_valid_character_grid` accepts note-array grids (3×60, 6×30) and still accepts flagship/note; rejects malformed grids — verified by `TestIsValidCharacterGridNoteArray`
- [x] Reading a note-array board returns the parsed grid — verified by `TestNoteArrayReadCurrentMessage`
- [x] Flagship and note local + RW-cloud send/read are unchanged — `test_rw_cloud_still_sends_bare_array` + all existing `TestSendCharacters*` / `TestReadCurrentMessage` tests still pass
- [x] `board_client_from_board_dict` returns `None` for missing token, creates a wired client for valid note-array boards — verified by `TestBoardClientFactoryNoteArray`

## Test Evidence

Full suite: **3929 passed, 11 skipped** (`pytest tests/ -q` inside dev container)
Focused: `tests/test_board_client.py` — **109 passed** (60 new + 49 pre-existing)

---

Part of #1167 · Implements #1168