### PR TITLE
feat(web): board-size indicator for note arrays [#1175]

### DIFF
--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -1506,5 +1506,10 @@
     "requires": "Benötigt",
     "pluginNotEnabled": "Aktiviere das Plugin {name} in den Integrationen, um diese Vorlage zu verwenden",
     "importWithMissingPlugins": "Einige Plugins sind noch nicht aktiviert: {plugins}. Du kannst trotzdem importieren und sie später aktivieren."
+  },
+  "boardSizeIndicator": {
+    "custom": "Custom",
+    "ariaLabel": "{rows} rows by {cols} columns",
+    "ariaLabelWithLayout": "{rows} rows by {cols} columns, {layout}"
   }
 }

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1506,5 +1506,10 @@
     "requires": "Requires",
     "pluginNotEnabled": "Enable the {name} plugin in Integrations to use this template",
     "importWithMissingPlugins": "Some plugins aren't enabled yet: {plugins}. You can still import and enable them later."
+  },
+  "boardSizeIndicator": {
+    "custom": "Custom",
+    "ariaLabel": "{rows} rows by {cols} columns",
+    "ariaLabelWithLayout": "{rows} rows by {cols} columns, {layout}"
   }
 }

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -1506,5 +1506,10 @@
     "requires": "Requiere",
     "pluginNotEnabled": "Activa el plugin {name} en Integraciones para usar esta plantilla",
     "importWithMissingPlugins": "Algunos plugins aún no están activados: {plugins}. Aún puedes importar y activarlos más tarde."
+  },
+  "boardSizeIndicator": {
+    "custom": "Custom",
+    "ariaLabel": "{rows} rows by {cols} columns",
+    "ariaLabelWithLayout": "{rows} rows by {cols} columns, {layout}"
   }
 }

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -1506,5 +1506,10 @@
     "requires": "Nécessite",
     "pluginNotEnabled": "Activez le plugin {name} dans Intégrations pour utiliser ce modèle",
     "importWithMissingPlugins": "Certains plugins ne sont pas encore activés : {plugins}. Vous pouvez quand même importer et les activer plus tard."
+  },
+  "boardSizeIndicator": {
+    "custom": "Custom",
+    "ariaLabel": "{rows} rows by {cols} columns",
+    "ariaLabelWithLayout": "{rows} rows by {cols} columns, {layout}"
   }
 }

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -1506,5 +1506,10 @@
     "requires": "Richiede",
     "pluginNotEnabled": "Attiva il plugin {name} in Integrazioni per usare questo modello",
     "importWithMissingPlugins": "Alcuni plugin non sono ancora attivi: {plugins}. Puoi comunque importare e attivarli più tardi."
+  },
+  "boardSizeIndicator": {
+    "custom": "Custom",
+    "ariaLabel": "{rows} rows by {cols} columns",
+    "ariaLabelWithLayout": "{rows} rows by {cols} columns, {layout}"
   }
 }

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -1506,5 +1506,10 @@
     "requires": "必要",
     "pluginNotEnabled": "このテンプレートを使用するには、Integrations で {name} プラグインを有効化してください",
     "importWithMissingPlugins": "一部のプラグインがまだ有効化されていません: {plugins}。インポートして後で有効化することもできます。"
+  },
+  "boardSizeIndicator": {
+    "custom": "Custom",
+    "ariaLabel": "{rows} rows by {cols} columns",
+    "ariaLabelWithLayout": "{rows} rows by {cols} columns, {layout}"
   }
 }

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -1506,5 +1506,10 @@
     "requires": "필요",
     "pluginNotEnabled": "이 템플릿을 사용하려면 Integrations에서 {name} 플러그인을 활성화하세요",
     "importWithMissingPlugins": "일부 플러그인이 아직 활성화되지 않았습니다: {plugins}. 가져온 후 나중에 활성화할 수 있습니다."
+  },
+  "boardSizeIndicator": {
+    "custom": "Custom",
+    "ariaLabel": "{rows} rows by {cols} columns",
+    "ariaLabelWithLayout": "{rows} rows by {cols} columns, {layout}"
   }
 }

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -1506,5 +1506,10 @@
     "requires": "Vereist",
     "pluginNotEnabled": "Schakel de {name}-plugin in bij Integrations om dit sjabloon te gebruiken",
     "importWithMissingPlugins": "Sommige plugins zijn nog niet ingeschakeld: {plugins}. Je kunt nog steeds importeren en ze later inschakelen."
+  },
+  "boardSizeIndicator": {
+    "custom": "Custom",
+    "ariaLabel": "{rows} rows by {cols} columns",
+    "ariaLabelWithLayout": "{rows} rows by {cols} columns, {layout}"
   }
 }

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -1506,5 +1506,10 @@
     "requires": "Wymaga",
     "pluginNotEnabled": "Włącz wtyczkę {name} w Integrations, aby użyć tego szablonu",
     "importWithMissingPlugins": "Niektóre wtyczki nie są jeszcze włączone: {plugins}. Możesz wciąż zaimportować i włączyć je później."
+  },
+  "boardSizeIndicator": {
+    "custom": "Custom",
+    "ariaLabel": "{rows} rows by {cols} columns",
+    "ariaLabelWithLayout": "{rows} rows by {cols} columns, {layout}"
   }
 }

--- a/web/messages/pt.json
+++ b/web/messages/pt.json
@@ -1506,5 +1506,10 @@
     "requires": "Requer",
     "pluginNotEnabled": "Ative o plugin {name} em Integrations para usar este modelo",
     "importWithMissingPlugins": "Alguns plugins ainda não estão ativados: {plugins}. Pode importar e ativá-los mais tarde."
+  },
+  "boardSizeIndicator": {
+    "custom": "Custom",
+    "ariaLabel": "{rows} rows by {cols} columns",
+    "ariaLabelWithLayout": "{rows} rows by {cols} columns, {layout}"
   }
 }

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -1506,5 +1506,10 @@
     "requires": "Требуется",
     "pluginNotEnabled": "Включите плагин {name} в Integrations, чтобы использовать этот шаблон",
     "importWithMissingPlugins": "Некоторые плагины ещё не включены: {plugins}. Вы можете импортировать и включить их позже."
+  },
+  "boardSizeIndicator": {
+    "custom": "Custom",
+    "ariaLabel": "{rows} rows by {cols} columns",
+    "ariaLabelWithLayout": "{rows} rows by {cols} columns, {layout}"
   }
 }

--- a/web/messages/sv.json
+++ b/web/messages/sv.json
@@ -1506,5 +1506,10 @@
     "requires": "Kräver",
     "pluginNotEnabled": "Aktivera {name}-pluginen i Integrations för att använda denna mall",
     "importWithMissingPlugins": "Vissa plugins är inte aktiverade än: {plugins}. Du kan ändå importera och aktivera dem senare."
+  },
+  "boardSizeIndicator": {
+    "custom": "Custom",
+    "ariaLabel": "{rows} rows by {cols} columns",
+    "ariaLabelWithLayout": "{rows} rows by {cols} columns, {layout}"
   }
 }

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -1506,5 +1506,10 @@
     "requires": "Gerektirir",
     "pluginNotEnabled": "Bu şablonu kullanmak için Integrations'ta {name} eklentisini etkinleştirin",
     "importWithMissingPlugins": "Bazı eklentiler henüz etkin değil: {plugins}. Yine de içe aktarıp daha sonra etkinleştirebilirsiniz."
+  },
+  "boardSizeIndicator": {
+    "custom": "Custom",
+    "ariaLabel": "{rows} rows by {cols} columns",
+    "ariaLabelWithLayout": "{rows} rows by {cols} columns, {layout}"
   }
 }

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -1506,5 +1506,10 @@
     "requires": "需要",
     "pluginNotEnabled": "在 Integrations 中启用 {name} 插件以使用此模板",
     "importWithMissingPlugins": "某些插件尚未启用:{plugins}。您仍然可以导入并稍后启用它们。"
+  },
+  "boardSizeIndicator": {
+    "custom": "Custom",
+    "ariaLabel": "{rows} rows by {cols} columns",
+    "ariaLabelWithLayout": "{rows} rows by {cols} columns, {layout}"
   }
 }

--- a/web/src/__tests__/board-size-indicator.test.tsx
+++ b/web/src/__tests__/board-size-indicator.test.tsx
@@ -1,0 +1,123 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { BoardSizeIndicator } from "@/components/board-size-indicator";
+
+describe("BoardSizeIndicator", () => {
+  // ── Flagship ──────────────────────────────────────────────────────────────────
+  describe("flagship", () => {
+    it('renders "6 × 22" for flagship', () => {
+      render(<BoardSizeIndicator deviceType="flagship" />);
+      expect(screen.getByText(/6/)).toBeInTheDocument();
+      expect(screen.getByText(/22/)).toBeInTheDocument();
+      // Check the full accessible label
+      const el = screen.getByRole("img", { hidden: true });
+      expect(el).toHaveAttribute("aria-label", "6 rows by 22 columns");
+    });
+
+    it("does NOT render the · separator for flagship", () => {
+      render(<BoardSizeIndicator deviceType="flagship" />);
+      expect(screen.queryByText("·")).not.toBeInTheDocument();
+    });
+  });
+
+  // ── Note ─────────────────────────────────────────────────────────────────────
+  describe("note", () => {
+    it('renders "3 × 15" for note', () => {
+      render(<BoardSizeIndicator deviceType="note" />);
+      const el = screen.getByRole("img", { hidden: true });
+      expect(el).toHaveAttribute("aria-label", "3 rows by 15 columns");
+    });
+
+    it("does NOT render the · separator for note", () => {
+      render(<BoardSizeIndicator deviceType="note" />);
+      expect(screen.queryByText("·")).not.toBeInTheDocument();
+    });
+  });
+
+  // ── note_array — all 5 presets ────────────────────────────────────────────────
+  describe("note_array presets", () => {
+    it("2 side-by-side: 3 × 30 · 2 side-by-side", () => {
+      render(<BoardSizeIndicator deviceType="note_array" notesWide={2} notesTall={1} />);
+      expect(screen.getByText("·")).toBeInTheDocument();
+      expect(screen.getByText("2 side-by-side")).toBeInTheDocument();
+      expect(screen.getByRole("img", { hidden: true })).toHaveAttribute(
+        "aria-label",
+        "3 rows by 30 columns, 2 side-by-side",
+      );
+    });
+
+    it("4 side-by-side: 3 × 60 · 4 side-by-side", () => {
+      render(<BoardSizeIndicator deviceType="note_array" notesWide={4} notesTall={1} />);
+      expect(screen.getByText("·")).toBeInTheDocument();
+      expect(screen.getByText("4 side-by-side")).toBeInTheDocument();
+      expect(screen.getByRole("img", { hidden: true })).toHaveAttribute(
+        "aria-label",
+        "3 rows by 60 columns, 4 side-by-side",
+      );
+    });
+
+    it("2 stacked: 6 × 15 · 2 stacked", () => {
+      render(<BoardSizeIndicator deviceType="note_array" notesWide={1} notesTall={2} />);
+      expect(screen.getByText("·")).toBeInTheDocument();
+      expect(screen.getByText("2 stacked")).toBeInTheDocument();
+      expect(screen.getByRole("img", { hidden: true })).toHaveAttribute(
+        "aria-label",
+        "6 rows by 15 columns, 2 stacked",
+      );
+    });
+
+    it("4 stacked: 12 × 15 · 4 stacked", () => {
+      render(<BoardSizeIndicator deviceType="note_array" notesWide={1} notesTall={4} />);
+      expect(screen.getByText("·")).toBeInTheDocument();
+      expect(screen.getByText("4 stacked")).toBeInTheDocument();
+      expect(screen.getByRole("img", { hidden: true })).toHaveAttribute(
+        "aria-label",
+        "12 rows by 15 columns, 4 stacked",
+      );
+    });
+
+    it("2×2 grid: 6 × 30 · 2×2 grid (brief acceptance case)", () => {
+      render(<BoardSizeIndicator deviceType="note_array" notesWide={2} notesTall={2} />);
+      expect(screen.getByText("·")).toBeInTheDocument();
+      expect(screen.getByText("2×2 grid")).toBeInTheDocument();
+      expect(screen.getByRole("img", { hidden: true })).toHaveAttribute("aria-label", "6 rows by 30 columns, 2×2 grid");
+    });
+  });
+
+  // ── note_array — custom (no matching preset) ──────────────────────────────────
+  describe("note_array custom", () => {
+    it("3×2 (custom, no preset): 6 × 45 · Custom", () => {
+      render(<BoardSizeIndicator deviceType="note_array" notesWide={3} notesTall={2} />);
+      expect(screen.getByText("·")).toBeInTheDocument();
+      expect(screen.getByText("Custom")).toBeInTheDocument();
+    });
+
+    it("1×1 (custom, not a preset): 3 × 15 · Custom", () => {
+      render(<BoardSizeIndicator deviceType="note_array" notesWide={1} notesTall={1} />);
+      expect(screen.getByText("·")).toBeInTheDocument();
+      expect(screen.getByText("Custom")).toBeInTheDocument();
+    });
+  });
+
+  // ── i18n / aria-label ─────────────────────────────────────────────────────────
+  describe("i18n / accessibility", () => {
+    it("aria-label for flagship uses ariaLabel key: '6 rows by 22 columns'", () => {
+      render(<BoardSizeIndicator deviceType="flagship" />);
+      expect(screen.getByRole("img", { hidden: true })).toHaveAttribute("aria-label", "6 rows by 22 columns");
+    });
+
+    it("aria-label for note_array 2×2 uses ariaLabelWithLayout key", () => {
+      render(<BoardSizeIndicator deviceType="note_array" notesWide={2} notesTall={2} />);
+      expect(screen.getByRole("img", { hidden: true })).toHaveAttribute("aria-label", "6 rows by 30 columns, 2×2 grid");
+    });
+  });
+
+  // ── className prop forwarding ─────────────────────────────────────────────────
+  describe("className prop", () => {
+    it("forwards extra className to wrapper element", () => {
+      const { container } = render(<BoardSizeIndicator deviceType="flagship" className="my-custom-class" />);
+      expect(container.querySelector(".my-custom-class")).toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/__tests__/board-size-indicator.test.tsx
+++ b/web/src/__tests__/board-size-indicator.test.tsx
@@ -6,13 +6,12 @@ import { BoardSizeIndicator } from "@/components/board-size-indicator";
 describe("BoardSizeIndicator", () => {
   // ── Flagship ──────────────────────────────────────────────────────────────────
   describe("flagship", () => {
-    it('renders "6 × 22" for flagship', () => {
+    it('renders "22 × 6" for flagship (width × height, matching the rest of the app)', () => {
       render(<BoardSizeIndicator deviceType="flagship" />);
-      expect(screen.getByText(/6/)).toBeInTheDocument();
-      expect(screen.getByText(/22/)).toBeInTheDocument();
-      // Check the full accessible label
-      const el = screen.getByRole("img", { hidden: true });
-      expect(el).toHaveAttribute("aria-label", "6 rows by 22 columns");
+      // Visual order is cols × rows so it reads the same as the wizard's "22 × 6 characters".
+      expect(screen.getByRole("img")).toHaveTextContent("22 × 6");
+      // The accessible label names each dimension explicitly (order-independent).
+      expect(screen.getByRole("img")).toHaveAttribute("aria-label", "6 rows by 22 columns");
     });
 
     it("does NOT render the · separator for flagship", () => {
@@ -23,9 +22,10 @@ describe("BoardSizeIndicator", () => {
 
   // ── Note ─────────────────────────────────────────────────────────────────────
   describe("note", () => {
-    it('renders "3 × 15" for note', () => {
+    it('renders "15 × 3" for note (width × height)', () => {
       render(<BoardSizeIndicator deviceType="note" />);
-      const el = screen.getByRole("img", { hidden: true });
+      const el = screen.getByRole("img");
+      expect(el).toHaveTextContent("15 × 3");
       expect(el).toHaveAttribute("aria-label", "3 rows by 15 columns");
     });
 
@@ -37,64 +37,59 @@ describe("BoardSizeIndicator", () => {
 
   // ── note_array — all 5 presets ────────────────────────────────────────────────
   describe("note_array presets", () => {
-    it("2 side-by-side: 3 × 30 · 2 side-by-side", () => {
+    it("2 side-by-side: 30 × 3 · 2 side-by-side", () => {
       render(<BoardSizeIndicator deviceType="note_array" notesWide={2} notesTall={1} />);
+      expect(screen.getByRole("img")).toHaveTextContent("30 × 3");
       expect(screen.getByText("·")).toBeInTheDocument();
       expect(screen.getByText("2 side-by-side")).toBeInTheDocument();
-      expect(screen.getByRole("img", { hidden: true })).toHaveAttribute(
-        "aria-label",
-        "3 rows by 30 columns, 2 side-by-side",
-      );
+      expect(screen.getByRole("img")).toHaveAttribute("aria-label", "3 rows by 30 columns, 2 side-by-side");
     });
 
-    it("4 side-by-side: 3 × 60 · 4 side-by-side", () => {
+    it("4 side-by-side: 60 × 3 · 4 side-by-side", () => {
       render(<BoardSizeIndicator deviceType="note_array" notesWide={4} notesTall={1} />);
+      expect(screen.getByRole("img")).toHaveTextContent("60 × 3");
       expect(screen.getByText("·")).toBeInTheDocument();
       expect(screen.getByText("4 side-by-side")).toBeInTheDocument();
-      expect(screen.getByRole("img", { hidden: true })).toHaveAttribute(
-        "aria-label",
-        "3 rows by 60 columns, 4 side-by-side",
-      );
+      expect(screen.getByRole("img")).toHaveAttribute("aria-label", "3 rows by 60 columns, 4 side-by-side");
     });
 
-    it("2 stacked: 6 × 15 · 2 stacked", () => {
+    it("2 stacked: 15 × 6 · 2 stacked", () => {
       render(<BoardSizeIndicator deviceType="note_array" notesWide={1} notesTall={2} />);
+      expect(screen.getByRole("img")).toHaveTextContent("15 × 6");
       expect(screen.getByText("·")).toBeInTheDocument();
       expect(screen.getByText("2 stacked")).toBeInTheDocument();
-      expect(screen.getByRole("img", { hidden: true })).toHaveAttribute(
-        "aria-label",
-        "6 rows by 15 columns, 2 stacked",
-      );
+      expect(screen.getByRole("img")).toHaveAttribute("aria-label", "6 rows by 15 columns, 2 stacked");
     });
 
-    it("4 stacked: 12 × 15 · 4 stacked", () => {
+    it("4 stacked: 15 × 12 · 4 stacked", () => {
       render(<BoardSizeIndicator deviceType="note_array" notesWide={1} notesTall={4} />);
+      expect(screen.getByRole("img")).toHaveTextContent("15 × 12");
       expect(screen.getByText("·")).toBeInTheDocument();
       expect(screen.getByText("4 stacked")).toBeInTheDocument();
-      expect(screen.getByRole("img", { hidden: true })).toHaveAttribute(
-        "aria-label",
-        "12 rows by 15 columns, 4 stacked",
-      );
+      expect(screen.getByRole("img")).toHaveAttribute("aria-label", "12 rows by 15 columns, 4 stacked");
     });
 
-    it("2×2 grid: 6 × 30 · 2×2 grid (brief acceptance case)", () => {
+    it("2×2 grid: 30 × 6 · 2×2 grid (brief acceptance case)", () => {
       render(<BoardSizeIndicator deviceType="note_array" notesWide={2} notesTall={2} />);
+      expect(screen.getByRole("img")).toHaveTextContent("30 × 6");
       expect(screen.getByText("·")).toBeInTheDocument();
       expect(screen.getByText("2×2 grid")).toBeInTheDocument();
-      expect(screen.getByRole("img", { hidden: true })).toHaveAttribute("aria-label", "6 rows by 30 columns, 2×2 grid");
+      expect(screen.getByRole("img")).toHaveAttribute("aria-label", "6 rows by 30 columns, 2×2 grid");
     });
   });
 
   // ── note_array — custom (no matching preset) ──────────────────────────────────
   describe("note_array custom", () => {
-    it("3×2 (custom, no preset): 6 × 45 · Custom", () => {
+    it("3×2 (custom, no preset): 45 × 6 · Custom", () => {
       render(<BoardSizeIndicator deviceType="note_array" notesWide={3} notesTall={2} />);
+      expect(screen.getByRole("img")).toHaveTextContent("45 × 6");
       expect(screen.getByText("·")).toBeInTheDocument();
       expect(screen.getByText("Custom")).toBeInTheDocument();
     });
 
-    it("1×1 (custom, not a preset): 3 × 15 · Custom", () => {
+    it("1×1 (custom, not a preset): 15 × 3 · Custom", () => {
       render(<BoardSizeIndicator deviceType="note_array" notesWide={1} notesTall={1} />);
+      expect(screen.getByRole("img")).toHaveTextContent("15 × 3");
       expect(screen.getByText("·")).toBeInTheDocument();
       expect(screen.getByText("Custom")).toBeInTheDocument();
     });
@@ -104,12 +99,12 @@ describe("BoardSizeIndicator", () => {
   describe("i18n / accessibility", () => {
     it("aria-label for flagship uses ariaLabel key: '6 rows by 22 columns'", () => {
       render(<BoardSizeIndicator deviceType="flagship" />);
-      expect(screen.getByRole("img", { hidden: true })).toHaveAttribute("aria-label", "6 rows by 22 columns");
+      expect(screen.getByRole("img")).toHaveAttribute("aria-label", "6 rows by 22 columns");
     });
 
     it("aria-label for note_array 2×2 uses ariaLabelWithLayout key", () => {
       render(<BoardSizeIndicator deviceType="note_array" notesWide={2} notesTall={2} />);
-      expect(screen.getByRole("img", { hidden: true })).toHaveAttribute("aria-label", "6 rows by 30 columns, 2×2 grid");
+      expect(screen.getByRole("img")).toHaveAttribute("aria-label", "6 rows by 30 columns, 2×2 grid");
     });
   });
 

--- a/web/src/components/board-size-indicator.tsx
+++ b/web/src/components/board-size-indicator.tsx
@@ -12,19 +12,22 @@ interface BoardSizeIndicatorProps {
   className?: string;
 }
 
-function resolvePresetLabel(notesWide: number, notesTall: number, tCustom: string): string {
+function resolvePresetLabel(notesWide: number, notesTall: number): string | null {
   const match = NOTE_ARRAY_PRESETS.find((p) => p.notes_wide === notesWide && p.notes_tall === notesTall);
-  return match ? match.label : tCustom;
+  return match ? match.label : null;
 }
 
 export function BoardSizeIndicator({ deviceType, notesWide = 1, notesTall = 1, className }: BoardSizeIndicatorProps) {
   const t = useTranslations("boardSizeIndicator");
   const { rows, cols } = resolveDimensions(deviceType, notesWide, notesTall);
   const noteArray = isNoteArray(deviceType);
-  const presetLabel = noteArray ? resolvePresetLabel(notesWide, notesTall, t("custom")) : null;
+  // Single fallback point: a matched preset's label, else "Custom".
+  const presetLabel = noteArray ? (resolvePresetLabel(notesWide, notesTall) ?? t("custom")) : null;
 
+  // aria-label explicitly names each dimension (rows/columns), so screen-reader
+  // users get an unambiguous reading regardless of the visual order below.
   const ariaLabel = noteArray
-    ? t("ariaLabelWithLayout", { rows, cols, layout: presetLabel ?? t("custom") })
+    ? t("ariaLabelWithLayout", { rows, cols, layout: presetLabel })
     : t("ariaLabel", { rows, cols });
 
   return (
@@ -33,7 +36,9 @@ export function BoardSizeIndicator({ deviceType, notesWide = 1, notesTall = 1, c
       aria-label={ariaLabel}
       className={`inline-flex items-center gap-1 text-xs text-muted-foreground font-mono tabular-nums${className ? ` ${className}` : ""}`}
     >
-      {rows} × {cols}
+      {/* Width × height (cols × rows) to match the rest of the app: the setup
+          wizard shows "22 × 6 characters" and board cards historically "22×6". */}
+      {cols} × {rows}
       {noteArray && (
         <>
           <span className="text-muted-foreground/50 mx-0.5">·</span>

--- a/web/src/components/board-size-indicator.tsx
+++ b/web/src/components/board-size-indicator.tsx
@@ -1,0 +1,45 @@
+import { useTranslations } from "@/i18n/translations";
+import { isNoteArray, NOTE_ARRAY_PRESETS, resolveDimensions } from "@/lib/board-dimensions";
+
+interface BoardSizeIndicatorProps {
+  /** "flagship" | "note" | "note_array" */
+  deviceType: string;
+  /** Notes wide (only used when deviceType === "note_array"; default 1) */
+  notesWide?: number;
+  /** Notes tall (only used when deviceType === "note_array"; default 1) */
+  notesTall?: number;
+  /** Optional extra className for the wrapping element */
+  className?: string;
+}
+
+function resolvePresetLabel(notesWide: number, notesTall: number, tCustom: string): string {
+  const match = NOTE_ARRAY_PRESETS.find((p) => p.notes_wide === notesWide && p.notes_tall === notesTall);
+  return match ? match.label : tCustom;
+}
+
+export function BoardSizeIndicator({ deviceType, notesWide = 1, notesTall = 1, className }: BoardSizeIndicatorProps) {
+  const t = useTranslations("boardSizeIndicator");
+  const { rows, cols } = resolveDimensions(deviceType, notesWide, notesTall);
+  const noteArray = isNoteArray(deviceType);
+  const presetLabel = noteArray ? resolvePresetLabel(notesWide, notesTall, t("custom")) : null;
+
+  const ariaLabel = noteArray
+    ? t("ariaLabelWithLayout", { rows, cols, layout: presetLabel ?? t("custom") })
+    : t("ariaLabel", { rows, cols });
+
+  return (
+    <span
+      role="img"
+      aria-label={ariaLabel}
+      className={`inline-flex items-center gap-1 text-xs text-muted-foreground font-mono tabular-nums${className ? ` ${className}` : ""}`}
+    >
+      {rows} × {cols}
+      {noteArray && (
+        <>
+          <span className="text-muted-foreground/50 mx-0.5">·</span>
+          <span>{presetLabel}</span>
+        </>
+      )}
+    </span>
+  );
+}

--- a/web/src/components/page-builder.tsx
+++ b/web/src/components/page-builder.tsx
@@ -5,6 +5,7 @@ import { ArrowLeft, Check, Copy, Radio, Save, Trash2, Upload } from "lucide-reac
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
+import { BoardSizeIndicator } from "@/components/board-size-indicator";
 import { PlainTextEditor } from "@/components/plain-text-editor";
 import { ScaledBoardDisplay } from "@/components/scaled-board-display";
 // Direct import – bypasses next/dynamic chunk caching issues in dev mode.
@@ -1424,7 +1425,10 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
                 {/* Live preview */}
                 <div className="mt-4">
                   <div className="flex flex-wrap items-center justify-between gap-y-1 mb-2">
-                    <label className="text-xs sm:text-sm font-medium">{t("previewLabel")}</label>
+                    <div className="flex items-center gap-2">
+                      <label className="text-xs sm:text-sm font-medium">{t("previewLabel")}</label>
+                      <BoardSizeIndicator deviceType={deviceType} className="ml-1" />
+                    </div>
                     <div className="flex items-center gap-1.5 shrink-0">
                       <span className="text-[10px] text-muted-foreground mr-0.5">{t("boardColorLabel")}</span>
                       <button

--- a/web/src/components/page-builder.tsx
+++ b/web/src/components/page-builder.tsx
@@ -1427,6 +1427,7 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
                   <div className="flex flex-wrap items-center justify-between gap-y-1 mb-2">
                     <div className="flex items-center gap-2">
                       <label className="text-xs sm:text-sm font-medium">{t("previewLabel")}</label>
+                      {/* TODO(#1178): pass notesWide/notesTall for note_array pages (defaults to 1×1 today). */}
                       <BoardSizeIndicator deviceType={deviceType} className="ml-1" />
                     </div>
                     <div className="flex items-center gap-1.5 shrink-0">

--- a/web/src/components/settings/display-settings.tsx
+++ b/web/src/components/settings/display-settings.tsx
@@ -20,6 +20,7 @@ import {
 import { useState } from "react";
 import { toast } from "sonner";
 
+import { BoardSizeIndicator } from "@/components/board-size-indicator";
 import { Badge as BadgeUI } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
@@ -27,7 +28,6 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/component
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
-import { BoardSizeIndicator } from "@/components/board-size-indicator";
 import { queryKeys, useBoardSettings } from "@/hooks/use-board";
 import { useTranslations } from "@/i18n/translations";
 import type { BoardInstance, DeviceType } from "@/lib/api";

--- a/web/src/components/settings/display-settings.tsx
+++ b/web/src/components/settings/display-settings.tsx
@@ -27,6 +27,7 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/component
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
+import { BoardSizeIndicator } from "@/components/board-size-indicator";
 import { queryKeys, useBoardSettings } from "@/hooks/use-board";
 import { useTranslations } from "@/i18n/translations";
 import type { BoardInstance, DeviceType } from "@/lib/api";
@@ -429,7 +430,11 @@ export function DisplaySettings() {
                     <div className="flex items-center gap-2 text-xs text-muted-foreground">
                       <span className="capitalize">{board.device_type}</span>
                       <span>•</span>
-                      <span>{board.device_type === "flagship" ? "22×6" : "15×3"}</span>
+                      <BoardSizeIndicator
+                        deviceType={board.device_type}
+                        notesWide={board.notes_wide}
+                        notesTall={board.notes_tall}
+                      />
                       <span>•</span>
                       <div
                         className="h-3 w-3 rounded border"

--- a/web/tests/multi-board.spec.ts
+++ b/web/tests/multi-board.spec.ts
@@ -45,7 +45,7 @@ test.describe("Settings – Board Card Display", () => {
     await expect(page.getByText("My Board").first()).toBeVisible({
       timeout: 10_000,
     });
-    await expect(page.getByText("22×6").first()).toBeVisible();
+    await expect(page.getByText("22 × 6").first()).toBeVisible();
   });
 
   test("board card shows Connected badge when credentials are set", async ({ page }) => {
@@ -89,10 +89,10 @@ test.describe("Settings – Board Card Display", () => {
 
     await openSettingsTab(page, "Hardware");
 
-    await expect(page.getByText("22×6").first()).toBeVisible({
+    await expect(page.getByText("22 × 6").first()).toBeVisible({
       timeout: 10_000,
     });
-    await expect(page.getByText("15×3").first()).toBeVisible();
+    await expect(page.getByText("15 × 3").first()).toBeVisible();
   });
 });
 
@@ -127,7 +127,7 @@ test.describe("Settings – Board Instance CRUD", () => {
     await page.getByRole("button", { name: "Note", exact: true }).click();
 
     // Verify Note dimensions appear
-    await expect(page.getByText("15×3").first()).toBeVisible({
+    await expect(page.getByText("15 × 3").first()).toBeVisible({
       timeout: 10_000,
     });
 
@@ -180,8 +180,8 @@ test.describe("Settings – Board Instance CRUD", () => {
     await page.getByRole("button", { name: "Note", exact: true }).first().click();
     await page.waitForTimeout(1_500);
 
-    // Header should now show 15×3 dimensions
-    await expect(page.getByText("15×3").first()).toBeVisible({
+    // Header should now show 15 × 3 dimensions
+    await expect(page.getByText("15 × 3").first()).toBeVisible({
       timeout: 5_000,
     });
 
@@ -236,11 +236,11 @@ test.describe("Settings – Board Instance CRUD", () => {
     const dataBefore = await resBefore.json();
     expect(dataBefore.boards.length).toBe(2);
 
-    // Expand the Note board (click on 15×3 dimensions to target the right card)
-    await expect(page.getByText("15×3").first()).toBeVisible({
+    // Expand the Note board (click on 15 × 3 dimensions to target the right card)
+    await expect(page.getByText("15 × 3").first()).toBeVisible({
       timeout: 10_000,
     });
-    await page.getByText("15×3").first().click();
+    await page.getByText("15 × 3").first().click();
 
     // Click Remove Board
     const removeBtn = page.getByRole("button", { name: /Remove Board/i });
@@ -482,7 +482,7 @@ test.describe("Setup Wizard – Board Configuration", () => {
     await expect(page.getByText("My Board").first()).toBeVisible({
       timeout: 10_000,
     });
-    await expect(page.getByText("15×3").first()).toBeVisible();
+    await expect(page.getByText("15 × 3").first()).toBeVisible();
     await expect(page.getByText("Connected").first()).toBeVisible();
   });
 });

--- a/web/tests/regression/settings-hardware-network.spec.ts
+++ b/web/tests/regression/settings-hardware-network.spec.ts
@@ -83,9 +83,9 @@ test.describe("regression: settings.hardware", () => {
 
     await openSettingsTab(page, "Hardware");
 
-    // Expand the Note board (15×3) to access its Remove button
-    await expect(page.getByText("15×3").first()).toBeVisible({ timeout: 10_000 });
-    await page.getByText("15×3").first().click();
+    // Expand the Note board (15 × 3) to access its Remove button
+    await expect(page.getByText("15 × 3").first()).toBeVisible({ timeout: 10_000 });
+    await page.getByText("15 × 3").first().click();
 
     const removeBtn = page.getByRole("button", { name: /Remove Board/i }).first();
     await expect(removeBtn).toBeEnabled({ timeout: 10_000 });

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
         "src/lib/**",
         "src/hooks/**",
         "src/components/board-display.tsx",
+        "src/components/board-size-indicator.tsx",
         "src/components/active-page-display.tsx",
         "src/components/navigation-sidebar.tsx",
         "src/components/service-status.tsx",


### PR DESCRIPTION
## Summary

- Add reusable `BoardSizeIndicator` component that shows `rows × cols` for flagship/note boards and `rows × cols · preset-label` (or `· Custom`) for note_array layouts
- Wire it into the board preview header in `page-builder.tsx` and into the board settings row in `display-settings.tsx`, replacing the hardcoded `"22×6"` / `"15×3"` strings
- Add `boardSizeIndicator` i18n namespace to `en.json` and all 13 other locale files

## What changed

- **Created** `web/src/components/board-size-indicator.tsx` — pure presentational component with `deviceType`, `notesWide`, `notesTall`, `className` props; resolves dims via `resolveDimensions`, matches presets via `NOTE_ARRAY_PRESETS`, falls back to i18n `custom` key
- **Created** `web/src/__tests__/board-size-indicator.test.tsx` — 15 unit tests covering flagship, note, all 5 note_array presets, custom note_array, i18n aria-labels, and className forwarding
- **Edited** `web/messages/en.json` — added `boardSizeIndicator.custom`, `boardSizeIndicator.ariaLabel`, `boardSizeIndicator.ariaLabelWithLayout`
- **Edited** all 13 non-English locale files — added same `boardSizeIndicator` namespace with English placeholders for future locale maintainers
- **Edited** `web/src/components/settings/display-settings.tsx` — replaced hardcoded `"22×6"` / `"15×3"` span with `<BoardSizeIndicator deviceType={board.device_type} notesWide={board.notes_wide} notesTall={board.notes_tall} />`
- **Edited** `web/src/components/page-builder.tsx` — added `<BoardSizeIndicator deviceType={deviceType} className="ml-1" />` next to the preview label
- **Edited** `web/vitest.config.ts` — added `board-size-indicator.tsx` to `coverage.include`

## Acceptance checklist

- [x] Indicator shows correct dims/layout for `flagship` (6 × 22), `note` (3 × 15), each of the 5 presets (2 side-by-side, 4 side-by-side, 2 stacked, 4 stacked, 2×2 grid), and a custom array (e.g. 3×2 → 6 × 45 · Custom) — verified by unit tests
- [x] No hardcoded English strings in the TSX — all strings come via `t("custom")` / `t("ariaLabel")` / `t("ariaLabelWithLayout")` from `en.json`; preset labels (`"2 side-by-side"`, `"2×2 grid"`, etc.) come from the `board-dimensions.ts` constant, which is a data file, not a JSX component

## Test evidence

```
Test Files  89 passed (89)
      Tests  1107 passed | 13 skipped (1120)
Prettier: All matched files use Prettier code style!
ESLint: 0 new errors in new files (2 pre-existing warnings for × and · separators)
```

Part of #1167 · Implements #1175