### PR TITLE
fix(a11y): consolidated WCAG 2.2 AA fixes (9 PRs in one branch)

### DIFF
--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -1506,5 +1506,9 @@
     "requires": "Benötigt",
     "pluginNotEnabled": "Aktiviere das Plugin {name} in den Integrationen, um diese Vorlage zu verwenden",
     "importWithMissingPlugins": "Einige Plugins sind noch nicht aktiviert: {plugins}. Du kannst trotzdem importieren und sie später aktivieren."
+  },
+  "aiChatPanel": {
+    "clearConversationAriaLabel": "Konversation löschen",
+    "closePanelAriaLabel": "FiestaBot (Beta) schließen"
   }
 }

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -1510,5 +1510,8 @@
   "aiChatPanel": {
     "clearConversationAriaLabel": "Konversation löschen",
     "closePanelAriaLabel": "FiestaBot (Beta) schließen"
+  },
+  "aiChat": {
+    "taskProgressAriaLabel": "Fortschritt der KI-Aufgaben"
   }
 }

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -76,7 +76,8 @@
     "primaryNavigation": "Hauptnavigation",
     "secondaryNavigation": "Sekundärnavigation",
     "picks": "Empfehlungen",
-    "skipToMainContent": "Zum Hauptinhalt springen"
+    "skipToMainContent": "Zum Hauptinhalt springen",
+    "prideCelebrationAriaLabel": "Pride Month feiern"
   },
   "network": {
     "title": "WLAN",

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -709,6 +709,7 @@
     "exportFailed": "Freigabezeichenfolge konnte nicht abgerufen werden",
     "exportDialogTitle": "Seite exportieren",
     "exportDialogDescription": "Kopiere diese Freigabezeichenfolge, um deine Seite mit anderen zu teilen.",
+    "exportStringAriaLabel": "Freigabezeichenfolge",
     "exportCopyAriaLabel": "Freigabezeichenfolge kopieren"
   },
   "displaySettings": {

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1510,5 +1510,8 @@
   "aiChatPanel": {
     "clearConversationAriaLabel": "Clear conversation",
     "closePanelAriaLabel": "Close FiestaBot (Beta)"
+  },
+  "aiChat": {
+    "taskProgressAriaLabel": "AI task progress"
   }
 }

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1506,5 +1506,9 @@
     "requires": "Requires",
     "pluginNotEnabled": "Enable the {name} plugin in Integrations to use this template",
     "importWithMissingPlugins": "Some plugins aren't enabled yet: {plugins}. You can still import and enable them later."
+  },
+  "aiChatPanel": {
+    "clearConversationAriaLabel": "Clear conversation",
+    "closePanelAriaLabel": "Close FiestaBot (Beta)"
   }
 }

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -666,6 +666,7 @@
     "exportFailed": "Failed to get share string",
     "exportDialogTitle": "Export Page",
     "exportDialogDescription": "Copy this share string to share your page with others.",
+    "exportStringAriaLabel": "Share string",
     "exportCopyAriaLabel": "Copy share string"
   },
   "displaySettings": {

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -76,7 +76,8 @@
     "primaryNavigation": "Primary navigation",
     "secondaryNavigation": "Secondary navigation",
     "picks": "Staff Picks",
-    "skipToMainContent": "Skip to main content"
+    "skipToMainContent": "Skip to main content",
+    "prideCelebrationAriaLabel": "Celebrate Pride Month"
   },
   "home": {
     "title": "Dashboard",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -1506,5 +1506,9 @@
     "requires": "Requiere",
     "pluginNotEnabled": "Activa el plugin {name} en Integraciones para usar esta plantilla",
     "importWithMissingPlugins": "Algunos plugins aún no están activados: {plugins}. Aún puedes importar y activarlos más tarde."
+  },
+  "aiChatPanel": {
+    "clearConversationAriaLabel": "Borrar conversación",
+    "closePanelAriaLabel": "Cerrar FiestaBot (Beta)"
   }
 }

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -709,6 +709,7 @@
     "exportFailed": "Error al obtener el código compartido",
     "exportDialogTitle": "Exportar página",
     "exportDialogDescription": "Copia este código compartido para compartir tu página con otros.",
+    "exportStringAriaLabel": "Código compartido",
     "exportCopyAriaLabel": "Copiar código compartido"
   },
   "displaySettings": {

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -76,7 +76,8 @@
     "primaryNavigation": "Navegación principal",
     "secondaryNavigation": "Navegación secundaria",
     "picks": "Selecciones del equipo",
-    "skipToMainContent": "Saltar al contenido principal"
+    "skipToMainContent": "Saltar al contenido principal",
+    "prideCelebrationAriaLabel": "Celebrar el Mes del Orgullo"
   },
   "network": {
     "title": "Wi-Fi",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -1510,5 +1510,8 @@
   "aiChatPanel": {
     "clearConversationAriaLabel": "Borrar conversación",
     "closePanelAriaLabel": "Cerrar FiestaBot (Beta)"
+  },
+  "aiChat": {
+    "taskProgressAriaLabel": "Progreso de tareas de IA"
   }
 }

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -709,6 +709,7 @@
     "exportFailed": "Impossible d'obtenir la chaîne de partage",
     "exportDialogTitle": "Exporter la page",
     "exportDialogDescription": "Copiez cette chaîne de partage pour partager votre page avec d'autres.",
+    "exportStringAriaLabel": "Chaîne de partage",
     "exportCopyAriaLabel": "Copier la chaîne de partage"
   },
   "displaySettings": {

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -1506,5 +1506,9 @@
     "requires": "Nécessite",
     "pluginNotEnabled": "Activez le plugin {name} dans Intégrations pour utiliser ce modèle",
     "importWithMissingPlugins": "Certains plugins ne sont pas encore activés : {plugins}. Vous pouvez quand même importer et les activer plus tard."
+  },
+  "aiChatPanel": {
+    "clearConversationAriaLabel": "Effacer la conversation",
+    "closePanelAriaLabel": "Fermer FiestaBot (Beta)"
   }
 }

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -1510,5 +1510,8 @@
   "aiChatPanel": {
     "clearConversationAriaLabel": "Effacer la conversation",
     "closePanelAriaLabel": "Fermer FiestaBot (Beta)"
+  },
+  "aiChat": {
+    "taskProgressAriaLabel": "Progression des tâches IA"
   }
 }

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -76,7 +76,8 @@
     "primaryNavigation": "Navigation principale",
     "secondaryNavigation": "Navigation secondaire",
     "picks": "Sélections de l'équipe",
-    "skipToMainContent": "Aller au contenu principal"
+    "skipToMainContent": "Aller au contenu principal",
+    "prideCelebrationAriaLabel": "Célébrer le Mois des Fiertés"
   },
   "network": {
     "title": "Wi-Fi",

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -76,7 +76,8 @@
     "primaryNavigation": "Navigazione principale",
     "secondaryNavigation": "Navigazione secondaria",
     "picks": "Scelte del team",
-    "skipToMainContent": "Vai al contenuto principale"
+    "skipToMainContent": "Vai al contenuto principale",
+    "prideCelebrationAriaLabel": "Celebra il Mese dell'Orgoglio"
   },
   "network": {
     "title": "Wi-Fi",

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -1506,5 +1506,9 @@
     "requires": "Richiede",
     "pluginNotEnabled": "Attiva il plugin {name} in Integrazioni per usare questo modello",
     "importWithMissingPlugins": "Alcuni plugin non sono ancora attivi: {plugins}. Puoi comunque importare e attivarli più tardi."
+  },
+  "aiChatPanel": {
+    "clearConversationAriaLabel": "Cancella conversazione",
+    "closePanelAriaLabel": "Chiudi FiestaBot (Beta)"
   }
 }

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -1510,5 +1510,8 @@
   "aiChatPanel": {
     "clearConversationAriaLabel": "Cancella conversazione",
     "closePanelAriaLabel": "Chiudi FiestaBot (Beta)"
+  },
+  "aiChat": {
+    "taskProgressAriaLabel": "Avanzamento attività IA"
   }
 }

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -709,6 +709,7 @@
     "exportFailed": "Impossibile ottenere la stringa di condivisione",
     "exportDialogTitle": "Esporta pagina",
     "exportDialogDescription": "Copia questa stringa di condivisione per condividere la tua pagina con altri.",
+    "exportStringAriaLabel": "Stringa di condivisione",
     "exportCopyAriaLabel": "Copia stringa di condivisione"
   },
   "displaySettings": {

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -1506,5 +1506,9 @@
     "requires": "必要",
     "pluginNotEnabled": "このテンプレートを使用するには、Integrations で {name} プラグインを有効化してください",
     "importWithMissingPlugins": "一部のプラグインがまだ有効化されていません: {plugins}。インポートして後で有効化することもできます。"
+  },
+  "aiChatPanel": {
+    "clearConversationAriaLabel": "会話をクリア",
+    "closePanelAriaLabel": "FiestaBot (Beta) を閉じる"
   }
 }

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -1510,5 +1510,8 @@
   "aiChatPanel": {
     "clearConversationAriaLabel": "会話をクリア",
     "closePanelAriaLabel": "FiestaBot (Beta) を閉じる"
+  },
+  "aiChat": {
+    "taskProgressAriaLabel": "AI タスクの進行状況"
   }
 }

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -709,6 +709,7 @@
     "exportFailed": "共有文字列の取得に失敗",
     "exportDialogTitle": "ページをエクスポート",
     "exportDialogDescription": "この共有文字列をコピーしてページを他の人と共有します。",
+    "exportStringAriaLabel": "共有文字列",
     "exportCopyAriaLabel": "共有文字列をコピー"
   },
   "displaySettings": {

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -76,7 +76,8 @@
     "primaryNavigation": "メインナビゲーション",
     "secondaryNavigation": "サブナビゲーション",
     "picks": "スタッフのおすすめ",
-    "skipToMainContent": "メインコンテンツへスキップ"
+    "skipToMainContent": "メインコンテンツへスキップ",
+    "prideCelebrationAriaLabel": "プライド月間を祝う"
   },
   "network": {
     "title": "Wi-Fi",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -76,7 +76,8 @@
     "primaryNavigation": "기본 탐색",
     "secondaryNavigation": "보조 탐색",
     "picks": "스태프 추천",
-    "skipToMainContent": "본문으로 건너뛰기"
+    "skipToMainContent": "본문으로 건너뛰기",
+    "prideCelebrationAriaLabel": "프라이드의 달 축하하기"
   },
   "network": {
     "title": "Wi-Fi",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -1506,5 +1506,9 @@
     "requires": "필요",
     "pluginNotEnabled": "이 템플릿을 사용하려면 Integrations에서 {name} 플러그인을 활성화하세요",
     "importWithMissingPlugins": "일부 플러그인이 아직 활성화되지 않았습니다: {plugins}. 가져온 후 나중에 활성화할 수 있습니다."
+  },
+  "aiChatPanel": {
+    "clearConversationAriaLabel": "대화 지우기",
+    "closePanelAriaLabel": "FiestaBot (Beta) 닫기"
   }
 }

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -1510,5 +1510,8 @@
   "aiChatPanel": {
     "clearConversationAriaLabel": "대화 지우기",
     "closePanelAriaLabel": "FiestaBot (Beta) 닫기"
+  },
+  "aiChat": {
+    "taskProgressAriaLabel": "AI 작업 진행률"
   }
 }

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -709,6 +709,7 @@
     "exportFailed": "공유 문자열 가져오기 실패",
     "exportDialogTitle": "페이지 내보내기",
     "exportDialogDescription": "이 공유 문자열을 복사하여 다른 사람과 페이지를 공유하세요.",
+    "exportStringAriaLabel": "공유 문자열",
     "exportCopyAriaLabel": "공유 문자열 복사"
   },
   "displaySettings": {

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -1506,5 +1506,9 @@
     "requires": "Vereist",
     "pluginNotEnabled": "Schakel de {name}-plugin in bij Integrations om dit sjabloon te gebruiken",
     "importWithMissingPlugins": "Sommige plugins zijn nog niet ingeschakeld: {plugins}. Je kunt nog steeds importeren en ze later inschakelen."
+  },
+  "aiChatPanel": {
+    "clearConversationAriaLabel": "Gesprek wissen",
+    "closePanelAriaLabel": "FiestaBot (Beta) sluiten"
   }
 }

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -1510,5 +1510,8 @@
   "aiChatPanel": {
     "clearConversationAriaLabel": "Gesprek wissen",
     "closePanelAriaLabel": "FiestaBot (Beta) sluiten"
+  },
+  "aiChat": {
+    "taskProgressAriaLabel": "Voortgang AI-taken"
   }
 }

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -709,6 +709,7 @@
     "exportFailed": "Deelreeks ophalen mislukt",
     "exportDialogTitle": "Pagina exporteren",
     "exportDialogDescription": "Kopieer deze deelreeks om je pagina met anderen te delen.",
+    "exportStringAriaLabel": "Deelreeks",
     "exportCopyAriaLabel": "Deelreeks kopiëren"
   },
   "displaySettings": {

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -76,7 +76,8 @@
     "primaryNavigation": "Hoofdnavigatie",
     "secondaryNavigation": "Subnavigatie",
     "picks": "Aanbevolen",
-    "skipToMainContent": "Naar hoofdinhoud"
+    "skipToMainContent": "Naar hoofdinhoud",
+    "prideCelebrationAriaLabel": "Vier Pride Month"
   },
   "network": {
     "title": "Wi-Fi",

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -709,6 +709,7 @@
     "exportFailed": "Nie udało się pobrać ciągu udostępniania",
     "exportDialogTitle": "Eksportuj stronę",
     "exportDialogDescription": "Skopiuj ten ciąg udostępniania, aby udostępnić stronę innym.",
+    "exportStringAriaLabel": "Ciąg udostępniania",
     "exportCopyAriaLabel": "Skopiuj ciąg udostępniania"
   },
   "displaySettings": {

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -76,7 +76,8 @@
     "primaryNavigation": "Nawigacja główna",
     "secondaryNavigation": "Nawigacja drugorzędna",
     "picks": "Polecane",
-    "skipToMainContent": "Przejdź do treści głównej"
+    "skipToMainContent": "Przejdź do treści głównej",
+    "prideCelebrationAriaLabel": "Świętuj Miesiąc Dumy"
   },
   "network": {
     "title": "Wi-Fi",

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -1510,5 +1510,8 @@
   "aiChatPanel": {
     "clearConversationAriaLabel": "Wyczyść rozmowę",
     "closePanelAriaLabel": "Zamknij FiestaBot (Beta)"
+  },
+  "aiChat": {
+    "taskProgressAriaLabel": "Postęp zadań AI"
   }
 }

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -1506,5 +1506,9 @@
     "requires": "Wymaga",
     "pluginNotEnabled": "Włącz wtyczkę {name} w Integrations, aby użyć tego szablonu",
     "importWithMissingPlugins": "Niektóre wtyczki nie są jeszcze włączone: {plugins}. Możesz wciąż zaimportować i włączyć je później."
+  },
+  "aiChatPanel": {
+    "clearConversationAriaLabel": "Wyczyść rozmowę",
+    "closePanelAriaLabel": "Zamknij FiestaBot (Beta)"
   }
 }

--- a/web/messages/pt.json
+++ b/web/messages/pt.json
@@ -709,6 +709,7 @@
     "exportFailed": "Falha ao obter string de partilha",
     "exportDialogTitle": "Exportar página",
     "exportDialogDescription": "Copie esta string de partilha para partilhar a sua página com outros.",
+    "exportStringAriaLabel": "String de partilha",
     "exportCopyAriaLabel": "Copiar string de partilha"
   },
   "displaySettings": {

--- a/web/messages/pt.json
+++ b/web/messages/pt.json
@@ -1510,5 +1510,8 @@
   "aiChatPanel": {
     "clearConversationAriaLabel": "Limpar conversa",
     "closePanelAriaLabel": "Fechar FiestaBot (Beta)"
+  },
+  "aiChat": {
+    "taskProgressAriaLabel": "Progresso das tarefas de IA"
   }
 }

--- a/web/messages/pt.json
+++ b/web/messages/pt.json
@@ -1506,5 +1506,9 @@
     "requires": "Requer",
     "pluginNotEnabled": "Ative o plugin {name} em Integrations para usar este modelo",
     "importWithMissingPlugins": "Alguns plugins ainda não estão ativados: {plugins}. Pode importar e ativá-los mais tarde."
+  },
+  "aiChatPanel": {
+    "clearConversationAriaLabel": "Limpar conversa",
+    "closePanelAriaLabel": "Fechar FiestaBot (Beta)"
   }
 }

--- a/web/messages/pt.json
+++ b/web/messages/pt.json
@@ -76,7 +76,8 @@
     "primaryNavigation": "Navegação principal",
     "secondaryNavigation": "Navegação secundária",
     "picks": "Seleções da equipa",
-    "skipToMainContent": "Pular para o conteúdo principal"
+    "skipToMainContent": "Pular para o conteúdo principal",
+    "prideCelebrationAriaLabel": "Celebrar o Mês do Orgulho"
   },
   "network": {
     "title": "Wi-Fi",

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -1510,5 +1510,8 @@
   "aiChatPanel": {
     "clearConversationAriaLabel": "Очистить разговор",
     "closePanelAriaLabel": "Закрыть FiestaBot (Beta)"
+  },
+  "aiChat": {
+    "taskProgressAriaLabel": "Прогресс задач ИИ"
   }
 }

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -76,7 +76,8 @@
     "primaryNavigation": "Основная навигация",
     "secondaryNavigation": "Дополнительная навигация",
     "picks": "Подборка команды",
-    "skipToMainContent": "Перейти к основному содержимому"
+    "skipToMainContent": "Перейти к основному содержимому",
+    "prideCelebrationAriaLabel": "Отпраздновать месяц гордости"
   },
   "network": {
     "title": "Wi-Fi",

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -709,6 +709,7 @@
     "exportFailed": "Не удалось получить строку обмена",
     "exportDialogTitle": "Экспорт страницы",
     "exportDialogDescription": "Скопируйте эту строку обмена, чтобы поделиться страницей с другими.",
+    "exportStringAriaLabel": "Строка обмена",
     "exportCopyAriaLabel": "Скопировать строку обмена"
   },
   "displaySettings": {

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -1506,5 +1506,9 @@
     "requires": "Требуется",
     "pluginNotEnabled": "Включите плагин {name} в Integrations, чтобы использовать этот шаблон",
     "importWithMissingPlugins": "Некоторые плагины ещё не включены: {plugins}. Вы можете импортировать и включить их позже."
+  },
+  "aiChatPanel": {
+    "clearConversationAriaLabel": "Очистить разговор",
+    "closePanelAriaLabel": "Закрыть FiestaBot (Beta)"
   }
 }

--- a/web/messages/sv.json
+++ b/web/messages/sv.json
@@ -76,7 +76,8 @@
     "primaryNavigation": "Huvudnavigering",
     "secondaryNavigation": "Sekundär navigering",
     "picks": "Personalens val",
-    "skipToMainContent": "Hoppa till huvudinnehållet"
+    "skipToMainContent": "Hoppa till huvudinnehållet",
+    "prideCelebrationAriaLabel": "Fira Pride-månaden"
   },
   "network": {
     "title": "Wi-Fi",

--- a/web/messages/sv.json
+++ b/web/messages/sv.json
@@ -709,6 +709,7 @@
     "exportFailed": "Kunde inte hämta delningssträng",
     "exportDialogTitle": "Exportera sida",
     "exportDialogDescription": "Kopiera denna delningssträng för att dela din sida med andra.",
+    "exportStringAriaLabel": "Delningssträng",
     "exportCopyAriaLabel": "Kopiera delningssträng"
   },
   "displaySettings": {

--- a/web/messages/sv.json
+++ b/web/messages/sv.json
@@ -1510,5 +1510,8 @@
   "aiChatPanel": {
     "clearConversationAriaLabel": "Rensa konversation",
     "closePanelAriaLabel": "Stäng FiestaBot (Beta)"
+  },
+  "aiChat": {
+    "taskProgressAriaLabel": "AI-uppgifters förlopp"
   }
 }

--- a/web/messages/sv.json
+++ b/web/messages/sv.json
@@ -1506,5 +1506,9 @@
     "requires": "Kräver",
     "pluginNotEnabled": "Aktivera {name}-pluginen i Integrations för att använda denna mall",
     "importWithMissingPlugins": "Vissa plugins är inte aktiverade än: {plugins}. Du kan ändå importera och aktivera dem senare."
+  },
+  "aiChatPanel": {
+    "clearConversationAriaLabel": "Rensa konversation",
+    "closePanelAriaLabel": "Stäng FiestaBot (Beta)"
   }
 }

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -709,6 +709,7 @@
     "exportFailed": "Paylaşım dizgesi alınamadı",
     "exportDialogTitle": "Sayfayı Dışa Aktar",
     "exportDialogDescription": "Sayfanızı başkalarıyla paylaşmak için bu paylaşım dizgesini kopyalayın.",
+    "exportStringAriaLabel": "Paylaşım dizgesi",
     "exportCopyAriaLabel": "Paylaşım dizgesini kopyala"
   },
   "displaySettings": {

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -1510,5 +1510,8 @@
   "aiChatPanel": {
     "clearConversationAriaLabel": "Konuşmayı temizle",
     "closePanelAriaLabel": "FiestaBot (Beta)'yı kapat"
+  },
+  "aiChat": {
+    "taskProgressAriaLabel": "AI görev ilerlemesi"
   }
 }

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -1506,5 +1506,9 @@
     "requires": "Gerektirir",
     "pluginNotEnabled": "Bu şablonu kullanmak için Integrations'ta {name} eklentisini etkinleştirin",
     "importWithMissingPlugins": "Bazı eklentiler henüz etkin değil: {plugins}. Yine de içe aktarıp daha sonra etkinleştirebilirsiniz."
+  },
+  "aiChatPanel": {
+    "clearConversationAriaLabel": "Konuşmayı temizle",
+    "closePanelAriaLabel": "FiestaBot (Beta)'yı kapat"
   }
 }

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -76,7 +76,8 @@
     "primaryNavigation": "Ana gezinme",
     "secondaryNavigation": "İkincil gezinme",
     "picks": "Ekip Seçimleri",
-    "skipToMainContent": "Ana içeriğe geç"
+    "skipToMainContent": "Ana içeriğe geç",
+    "prideCelebrationAriaLabel": "Onur Ayı'nı kutla"
   },
   "network": {
     "title": "Wi-Fi",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -76,7 +76,8 @@
     "primaryNavigation": "主导航",
     "secondaryNavigation": "次导航",
     "picks": "团队精选",
-    "skipToMainContent": "跳到主要内容"
+    "skipToMainContent": "跳到主要内容",
+    "prideCelebrationAriaLabel": "庆祝骄傲月"
   },
   "network": {
     "title": "Wi-Fi",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -1510,5 +1510,8 @@
   "aiChatPanel": {
     "clearConversationAriaLabel": "清除对话",
     "closePanelAriaLabel": "关闭 FiestaBot (Beta)"
+  },
+  "aiChat": {
+    "taskProgressAriaLabel": "AI 任务进度"
   }
 }

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -1506,5 +1506,9 @@
     "requires": "需要",
     "pluginNotEnabled": "在 Integrations 中启用 {name} 插件以使用此模板",
     "importWithMissingPlugins": "某些插件尚未启用:{plugins}。您仍然可以导入并稍后启用它们。"
+  },
+  "aiChatPanel": {
+    "clearConversationAriaLabel": "清除对话",
+    "closePanelAriaLabel": "关闭 FiestaBot (Beta)"
   }
 }

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -709,6 +709,7 @@
     "exportFailed": "获取分享字符串失败",
     "exportDialogTitle": "导出页面",
     "exportDialogDescription": "复制此分享字符串以与他人分享您的页面。",
+    "exportStringAriaLabel": "分享字符串",
     "exportCopyAriaLabel": "复制分享字符串"
   },
   "displaySettings": {

--- a/web/src/__tests__/active-page-display-override.test.tsx
+++ b/web/src/__tests__/active-page-display-override.test.tsx
@@ -25,6 +25,14 @@ vi.mock("@/hooks/use-router", () => ({
   }),
 }));
 
+vi.mock("@/components/smart-link", () => ({
+  default: ({ children, href, ...rest }: { children: React.ReactNode; href: string }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
 import { ActivePageDisplay } from "@/components/active-page-display";
 
 function TestWrapper({ children }: { children: React.ReactNode }) {

--- a/web/src/__tests__/active-page-display-silence.test.tsx
+++ b/web/src/__tests__/active-page-display-silence.test.tsx
@@ -22,6 +22,14 @@ vi.mock("@/hooks/use-router", () => ({
   }),
 }));
 
+vi.mock("@/components/smart-link", () => ({
+  default: ({ children, href, ...rest }: { children: React.ReactNode; href: string }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
 import { ActivePageDisplay } from "@/components/active-page-display";
 
 function TestWrapper({ children }: { children: React.ReactNode }) {

--- a/web/src/__tests__/active-page-display.test.tsx
+++ b/web/src/__tests__/active-page-display.test.tsx
@@ -12,14 +12,21 @@ import { server } from "./mocks/server";
 const API_BASE = "/api";
 import { ActivePageDisplay } from "@/components/active-page-display";
 
-const mockPush = vi.fn();
 vi.mock("@/hooks/use-router", () => ({
   useRouter: () => ({
-    push: mockPush,
+    push: vi.fn(),
     replace: vi.fn(),
     prefetch: vi.fn(),
     back: vi.fn(),
   }),
+}));
+
+vi.mock("@/components/smart-link", () => ({
+  default: ({ children, href, ...rest }: { children: React.ReactNode; href: string }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
 }));
 
 function TestWrapper({ children }: { children: React.ReactNode }) {
@@ -108,7 +115,10 @@ describe("ActivePageDisplay", () => {
     });
   });
 
-  it("shows View Schedule button when schedule is enabled", async () => {
+  it("renders View Schedule as a link (not a button) when schedule is enabled", async () => {
+    // Regression: navigation actions must be <a href> so screen reader users
+    // hear "link" (navigation) rather than "button" (in-page action).
+    // See issue #1197 / WCAG 2.4.4.
     server.use(
       http.get(`${API_BASE}/schedules/active/page`, () =>
         HttpResponse.json({
@@ -122,14 +132,36 @@ describe("ActivePageDisplay", () => {
     render(<ActivePageDisplay />, { wrapper: TestWrapper });
 
     await waitFor(() => {
-      const viewScheduleBtn = screen.getByRole("button", { name: /View Schedule/i });
-      expect(viewScheduleBtn).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: /View Schedule/i })).toBeInTheDocument();
     });
 
-    const viewScheduleBtn = screen.getByRole("button", { name: /View Schedule/i });
-    await userEvent.click(viewScheduleBtn);
+    const viewScheduleLink = screen.getByRole("link", { name: /View Schedule/i });
+    expect(viewScheduleLink).toHaveAttribute("href", "/schedule");
+    // It must NOT be exposed to assistive tech as a button.
+    expect(screen.queryByRole("button", { name: /View Schedule/i })).not.toBeInTheDocument();
+  });
 
-    expect(mockPush).toHaveBeenCalledWith("/schedule");
+  it("renders schedule gap link as a link (not a button)", async () => {
+    // Regression: the "Schedule settings" affordance inside the schedule-gap
+    // warning navigates to /schedule, so it must be an anchor too. See #1197.
+    server.use(
+      http.get(`${API_BASE}/schedules/active/page`, () =>
+        HttpResponse.json({
+          page_id: null,
+          source: "schedule",
+          schedule_enabled: true,
+        }),
+      ),
+    );
+
+    render(<ActivePageDisplay />, { wrapper: TestWrapper });
+
+    await waitFor(() => {
+      expect(screen.getByRole("link", { name: /Schedule settings/i })).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole("link", { name: /Schedule settings/i })).toHaveAttribute("href", "/schedule");
+    expect(screen.queryByRole("button", { name: /Schedule settings/i })).not.toBeInTheDocument();
   });
 
   it("derives schedule mode from active schedule endpoint without fetching full schedule list", async () => {
@@ -151,7 +183,7 @@ describe("ActivePageDisplay", () => {
     render(<ActivePageDisplay />, { wrapper: TestWrapper });
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: /View Schedule/i })).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: /View Schedule/i })).toBeInTheDocument();
     });
   });
 

--- a/web/src/__tests__/ai-chat-panel.test.tsx
+++ b/web/src/__tests__/ai-chat-panel.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import enMessages from "../../messages/en.json";
 import { AiChatPanel } from "@/components/ai-chat-panel";
 
 import { server } from "./mocks/server";
@@ -313,6 +314,41 @@ describe("AiChatPanel", () => {
     });
     // ChainingModePicker renders a button with the mode name
     expect(await screen.findByTitle(/ai mode: manual/i)).toBeInTheDocument();
+  });
+
+  it("header buttons resolve their aria-label through next-intl (no hardcoded English)", async () => {
+    // Regression test for issue #1190: the close + clear-conversation
+    // buttons must read their accessible name from the `aiChatPanel`
+    // namespace in `web/messages/*.json`, not from a hardcoded literal
+    // in JSX. We assert the rendered aria-label matches the en bundle
+    // exactly — if anyone reverts to a literal that drifts from the
+    // translation key, this test fails.
+    server.use(
+      http.get(`${API_BASE}/settings/ai`, () =>
+        HttpResponse.json({
+          enabled: true,
+          providers: [CONFIGURED_PROVIDER],
+          default_provider_id: "p1",
+        }),
+      ),
+    );
+    hookResult = {
+      ...defaultHookResult,
+      messages: [{ role: "user", content: "hi" }],
+    };
+
+    render(<AiChatPanel {...defaultProps} />, { wrapper: Wrapper });
+
+    expect(
+      await screen.findByRole("button", {
+        name: enMessages.aiChatPanel.clearConversationAriaLabel,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("button", {
+        name: enMessages.aiChatPanel.closePanelAriaLabel,
+      }),
+    ).toBeInTheDocument();
   });
 
   it("does not show ChainingModePicker when onChainingModeChange is absent", async () => {

--- a/web/src/__tests__/ai-chat-panel.test.tsx
+++ b/web/src/__tests__/ai-chat-panel.test.tsx
@@ -4,9 +4,9 @@ import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import enMessages from "../../messages/en.json";
 import { AiChatPanel } from "@/components/ai-chat-panel";
 
+import enMessages from "../../messages/en.json";
 import { server } from "./mocks/server";
 
 const API_BASE = "/api";

--- a/web/src/__tests__/ai-chat-panel.test.tsx
+++ b/web/src/__tests__/ai-chat-panel.test.tsx
@@ -365,4 +365,29 @@ describe("AiChatPanel", () => {
     await screen.findByText("FiestaBot (Beta)");
     expect(screen.queryByTitle(/ai mode:/i)).not.toBeInTheDocument();
   });
+
+  it("task progress bar exposes role=progressbar with ARIA value attributes", async () => {
+    server.use(
+      http.get(`${API_BASE}/settings/ai`, () =>
+        HttpResponse.json({
+          enabled: true,
+          providers: [CONFIGURED_PROVIDER],
+          default_provider_id: "p1",
+        }),
+      ),
+    );
+    const taskList = [
+      { id: "1", label: "Read docs", status: "done" as const },
+      { id: "2", label: "Patch component", status: "in_progress" as const },
+      { id: "3", label: "Run tests", status: "pending" as const },
+      { id: "4", label: "Open PR", status: "pending" as const },
+    ];
+    render(<AiChatPanel {...defaultProps} taskList={taskList} />, { wrapper: Wrapper });
+
+    const progressbar = await screen.findByRole("progressbar");
+    expect(progressbar).toHaveAttribute("aria-valuenow", "25");
+    expect(progressbar).toHaveAttribute("aria-valuemin", "0");
+    expect(progressbar).toHaveAttribute("aria-valuemax", "100");
+    expect(progressbar).toHaveAccessibleName();
+  });
 });

--- a/web/src/__tests__/install-prompt.test.tsx
+++ b/web/src/__tests__/install-prompt.test.tsx
@@ -1,0 +1,37 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { InstallPrompt } from "@/components/install-prompt";
+
+describe("InstallPrompt", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("announces the install banner with a polite aria-live region", async () => {
+    render(<InstallPrompt />);
+
+    const beforeInstall = new Event("beforeinstallprompt") as Event & {
+      prompt?: () => Promise<void>;
+      userChoice?: Promise<{ outcome: "accepted" | "dismissed" }>;
+    };
+    beforeInstall.prompt = vi.fn().mockResolvedValue(undefined);
+    beforeInstall.userChoice = Promise.resolve({ outcome: "dismissed" as const });
+
+    act(() => {
+      window.dispatchEvent(beforeInstall);
+    });
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    const banner = screen.getByRole("status");
+    expect(banner).toHaveAttribute("aria-live", "polite");
+    expect(banner).toHaveTextContent(/install/i);
+  });
+});

--- a/web/src/__tests__/language-selector.test.tsx
+++ b/web/src/__tests__/language-selector.test.tsx
@@ -61,4 +61,15 @@ describe("LanguageSelector", () => {
     const trigger = screen.getByRole("combobox", { name: /language/i });
     expect(trigger).toHaveAttribute("aria-label", "Language");
   });
+
+  it("marks the decorative Globe icon as aria-hidden so it is not announced", () => {
+    render(<LanguageSelector />);
+    // The Globe icon is decorative — it sits next to a visible label
+    // inside the trigger, so it must be hidden from assistive tech
+    // (WCAG 2.2 AA 1.1.1 Non-text Content).
+    const trigger = screen.getByRole("combobox", { name: /language/i });
+    const svg = trigger.querySelector("svg");
+    expect(svg).not.toBeNull();
+    expect(svg).toHaveAttribute("aria-hidden", "true");
+  });
 });

--- a/web/src/__tests__/live-output-home-sync.test.tsx
+++ b/web/src/__tests__/live-output-home-sync.test.tsx
@@ -35,6 +35,14 @@ vi.mock("@/hooks/use-router", () => ({
   }),
 }));
 
+vi.mock("@/components/smart-link", () => ({
+  default: ({ children, href, ...rest }: { children: React.ReactNode; href: string }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
 // ──────────────────────────────────────────────────────────────────────────────
 // Unit-level: verify the React Query cache sharing mechanism directly
 // ──────────────────────────────────────────────────────────────────────────────

--- a/web/src/__tests__/navigation-sidebar.test.tsx
+++ b/web/src/__tests__/navigation-sidebar.test.tsx
@@ -22,6 +22,14 @@ vi.mock("@/hooks/use-router", () => ({
   }),
 }));
 
+// Mock usePrideActive so tests can toggle the pride-month logo state
+// without colliding with the calendar. Defaults to false to match the
+// non-pride code path used by the existing suite.
+const mockPrideActive = vi.fn(() => false);
+vi.mock("@/hooks/use-pride-active", () => ({
+  usePrideActive: () => mockPrideActive(),
+}));
+
 // Must import after mocking
 import { NavigationSidebar } from "@/components/navigation-sidebar";
 
@@ -211,6 +219,33 @@ describe("NavigationSidebar collections link", () => {
     const collectionsLink = collectionsLinks[0].closest("a");
     expect(collectionsLink).toBeInTheDocument();
     expect(collectionsLink).toHaveAttribute("href", "/collections");
+  });
+});
+
+describe("NavigationSidebar pride logo accessibility (issue #1204)", () => {
+  beforeEach(() => {
+    mockPathname.mockReturnValue("/");
+    mockPrideActive.mockReturnValue(false);
+  });
+
+  it("renders the logo area as a non-interactive div when Pride Month is inactive", () => {
+    mockPrideActive.mockReturnValue(false);
+    render(<NavigationSidebar />, { wrapper: TestWrapper });
+
+    expect(screen.queryByRole("button", { name: "Celebrate Pride Month" })).not.toBeInTheDocument();
+  });
+
+  it("renders the logo area as a keyboard-accessible button during Pride Month", () => {
+    mockPrideActive.mockReturnValue(true);
+    render(<NavigationSidebar />, { wrapper: TestWrapper });
+
+    // Both the mobile header and the desktop sidebar render a celebrate button.
+    const celebrateButtons = screen.getAllByRole("button", { name: "Celebrate Pride Month" });
+    expect(celebrateButtons.length).toBeGreaterThanOrEqual(2);
+    celebrateButtons.forEach((button) => {
+      expect(button.tagName).toBe("BUTTON");
+      expect(button).toHaveAttribute("type", "button");
+    });
   });
 });
 

--- a/web/src/__tests__/output-target-selector.test.tsx
+++ b/web/src/__tests__/output-target-selector.test.tsx
@@ -55,6 +55,19 @@ describe("OutputTargetSelector", () => {
     });
   });
 
+  it("exposes selection state via aria-pressed", async () => {
+    render(<OutputTargetSelector />, { wrapper: TestWrapper });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Board Only/ })).toBeInTheDocument();
+    });
+
+    // mockOutputSettings.target === "board"
+    expect(screen.getByRole("button", { name: /Board Only/ })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: /UI Only/ })).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByRole("button", { name: /UI \+ Board/ })).toHaveAttribute("aria-pressed", "false");
+  });
+
   it("handles selection changes", async () => {
     const user = userEvent.setup();
     render(<OutputTargetSelector />, { wrapper: TestWrapper });

--- a/web/src/__tests__/page-grid-selector.test.tsx
+++ b/web/src/__tests__/page-grid-selector.test.tsx
@@ -435,6 +435,45 @@ describe("PageGridSelector", () => {
     expect(onSelectPage).toHaveBeenCalledWith("collection:c1");
   });
 
+  it("sets aria-pressed on collection buttons to reflect selection state", async () => {
+    vi.mocked(api.getCollections).mockResolvedValue({
+      collections: [
+        {
+          id: "collection:c1",
+          name: "Selected Collection",
+          page_ids: ["page-1"],
+          selection_mode: "time",
+
+          time: { interval_seconds: 30 },
+
+          variable: null,
+          created_at: "2025-01-01T00:00:00Z",
+        },
+        {
+          id: "collection:c2",
+          name: "Unselected Collection",
+          page_ids: ["page-2"],
+          selection_mode: "time",
+
+          time: { interval_seconds: 60 },
+
+          variable: null,
+          created_at: "2025-01-01T00:00:00Z",
+        },
+      ],
+      total: 2,
+    });
+
+    render(<PageGridSelector activePageId="collection:c1" onSelectPage={vi.fn()} />, { wrapper: TestWrapper });
+
+    await waitFor(() => {
+      const selected = screen.getByText("Selected Collection").closest("button");
+      const unselected = screen.getByText("Unselected Collection").closest("button");
+      expect(selected).toHaveAttribute("aria-pressed", "true");
+      expect(unselected).toHaveAttribute("aria-pressed", "false");
+    });
+  });
+
   describe("list view mode", () => {
     it("renders page names in list view without calling previewPagesBatch", async () => {
       render(<PageGridSelector activePageId={null} onSelectPage={vi.fn()} viewMode="list" />, { wrapper: TestWrapper });

--- a/web/src/__tests__/page-grid-selector.test.tsx
+++ b/web/src/__tests__/page-grid-selector.test.tsx
@@ -404,6 +404,37 @@ describe("PageGridSelector", () => {
     expect(screen.getByText("1 page")).toBeInTheDocument();
   });
 
+  it("marks decorative tab icons as aria-hidden so screen readers don't announce them", async () => {
+    vi.mocked(api.getCollections).mockResolvedValue({
+      collections: [
+        {
+          id: "collection:c1",
+          name: "My Collection",
+          page_ids: ["page-1"],
+          selection_mode: "time",
+          time: { interval_seconds: 30 },
+          variable: null,
+          created_at: "2025-01-01T00:00:00Z",
+        },
+      ],
+      total: 1,
+    });
+
+    render(<PageGridSelector activePageId={null} onSelectPage={vi.fn()} />, { wrapper: TestWrapper });
+
+    // Tabs already have visible text labels, so the Lucide icons inside
+    // them are decorative — they must be hidden from AT (WCAG 2.2 AA 1.1.1).
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /Pages/i })).toBeInTheDocument();
+    });
+    for (const tabName of [/Pages/i, /Collections/i]) {
+      const tab = screen.getByRole("tab", { name: tabName });
+      const svg = tab.querySelector("svg");
+      expect(svg).not.toBeNull();
+      expect(svg).toHaveAttribute("aria-hidden", "true");
+    }
+  });
+
   it("highlights active collection and handles click", async () => {
     vi.mocked(api.getCollections).mockResolvedValue({
       collections: [

--- a/web/src/__tests__/page-picker-dialog.test.tsx
+++ b/web/src/__tests__/page-picker-dialog.test.tsx
@@ -124,6 +124,30 @@ describe("PagePickerDialog", () => {
     expect(collectionsTab).toHaveTextContent("1");
   });
 
+  it("marks decorative tab icons as aria-hidden so screen readers don't announce them", () => {
+    const collections = [
+      {
+        id: COLLECTION_ID,
+        name: "Rotating Display",
+        page_ids: ["page-1", "page-2"],
+        selection_mode: "time" as const,
+        time: { interval_seconds: 30 },
+        variable: null,
+        created_at: "2025-01-01T00:00:00Z",
+      },
+    ];
+    render(<PagePickerDialog pages={PAGES} collections={collections} selectedPageId={null} onSelect={vi.fn()} />);
+
+    // Tabs already have visible text labels, so the Lucide icons inside
+    // them are decorative — they must be hidden from AT (WCAG 2.2 AA 1.1.1).
+    for (const tabName of [/pages/i, /collections/i]) {
+      const tab = screen.getByRole("tab", { name: tabName });
+      const svg = tab.querySelector("svg");
+      expect(svg).not.toBeNull();
+      expect(svg).toHaveAttribute("aria-hidden", "true");
+    }
+  });
+
   it("defaults to collections tab when a collection id is selected", () => {
     const collections = [
       {

--- a/web/src/components/active-page-display.tsx
+++ b/web/src/components/active-page-display.tsx
@@ -21,6 +21,7 @@ import { toast } from "sonner";
 import { BoardDisplay } from "@/components/board-display";
 import { ForceSetDialog } from "@/components/force-set-dialog";
 import { PageGridSelector } from "@/components/page-grid-selector";
+import Link from "@/components/smart-link";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -43,7 +44,6 @@ import {
   usePages,
   useSetActivePage,
 } from "@/hooks/use-board";
-import { useRouter } from "@/hooks/use-router";
 import { useTranslations } from "@/i18n/translations";
 import type { BoardCurrentMessageResponse, Collection, SilenceStatus } from "@/lib/api";
 import { api, isCollectionId } from "@/lib/api";
@@ -53,7 +53,6 @@ export function ActivePageDisplay() {
   const t = useTranslations("activeDisplay");
   const _tc = useTranslations("common");
   const tPause = useTranslations("displaySettings.pause");
-  const router = useRouter();
 
   // Sheet open state
   const [isSheetOpen, setIsSheetOpen] = useState(false);
@@ -370,13 +369,12 @@ export function ActivePageDisplay() {
             <CardTitle className="text-lg">{t("title")}</CardTitle>
             <div className="flex items-center gap-2">
               {scheduleEnabled && (
-                <button
-                  type="button"
-                  onClick={() => router.push("/schedule")}
+                <Link
+                  href="/schedule"
                   className="text-xs text-muted-foreground underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
                 >
                   {t("viewSchedule")} →
-                </button>
+                </Link>
               )}
               <Button
                 variant="outline"
@@ -475,12 +473,12 @@ export function ActivePageDisplay() {
               <AlertTriangle className="h-4 w-4 text-warning" />
               <AlertDescription className="text-sm">
                 {t("noPageScheduled")}{" "}
-                <button
-                  onClick={() => router.push("/schedule")}
+                <Link
+                  href="/schedule"
                   className="underline font-medium hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
                 >
                   {t("scheduleSettingsLink")}
-                </button>
+                </Link>
                 .
               </AlertDescription>
             </Alert>

--- a/web/src/components/ai-chat-panel.tsx
+++ b/web/src/components/ai-chat-panel.tsx
@@ -333,6 +333,7 @@ function TaskStatusIcon({ status }: { status: TaskStatus }) {
 }
 
 function TaskListPanel({ tasks }: { tasks: TaskItem[] }) {
+  const t = useTranslations("aiChat");
   const allDone = tasks.length > 0 && tasks.every((t) => t.status === "done" || t.status === "failed");
   const doneCount = tasks.filter((t) => t.status === "done").length;
   const [visible, setVisible] = useState(true);
@@ -356,7 +357,14 @@ function TaskListPanel({ tasks }: { tasks: TaskItem[] }) {
         <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
           Tasks ({doneCount}/{tasks.length})
         </span>
-        <div className="h-1 w-20 rounded-full bg-muted overflow-hidden">
+        <div
+          role="progressbar"
+          aria-valuenow={pct}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={t("taskProgressAriaLabel")}
+          className="h-1 w-20 rounded-full bg-muted overflow-hidden"
+        >
           <div className="h-full bg-brand-emphasis transition-all duration-300" style={{ width: `${pct}%` }} />
         </div>
       </div>

--- a/web/src/components/ai-chat-panel.tsx
+++ b/web/src/components/ai-chat-panel.tsx
@@ -45,6 +45,7 @@ import type {
 } from "@/lib/ai-chat-types";
 import { type AISettings, api } from "@/lib/api";
 import { useAiChat } from "@/lib/use-ai-chat";
+import { cn } from "@/lib/utils";
 
 export interface AiChatPanelProps {
   /** Per-turn editor context (device type + current page snapshot). */

--- a/web/src/components/ai-chat-panel.tsx
+++ b/web/src/components/ai-chat-panel.tsx
@@ -32,6 +32,7 @@ import { Label } from "@/components/ui/label";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
+import { useTranslations } from "@/i18n/translations";
 import type {
   ChainingMode,
   ChatMessage,
@@ -91,6 +92,7 @@ export function AiChatPanel({
   taskList,
   onConversationReset,
 }: AiChatPanelProps) {
+  const t = useTranslations("aiChatPanel");
   const [providerId, setProviderId] = useState<string>("");
   const [model, setModel] = useState<string>("");
   const [draft, setDraft] = useState("");
@@ -193,8 +195,8 @@ export function AiChatPanel({
                 variant="ghost"
                 className="h-7 w-7"
                 onClick={handleReset}
-                title="Clear conversation"
-                aria-label="Clear conversation"
+                title={t("clearConversationAriaLabel")}
+                aria-label={t("clearConversationAriaLabel")}
               >
                 <Trash2 className="h-3.5 w-3.5" />
               </Button>
@@ -205,8 +207,8 @@ export function AiChatPanel({
               variant="ghost"
               className="h-7 w-7"
               onClick={onClose}
-              title="Close FiestaBot (Beta)"
-              aria-label="Close FiestaBot (Beta)"
+              title={t("closePanelAriaLabel")}
+              aria-label={t("closePanelAriaLabel")}
             >
               <X className="h-4 w-4" />
             </Button>

--- a/web/src/components/ai-chat-panel.tsx
+++ b/web/src/components/ai-chat-panel.tsx
@@ -320,13 +320,13 @@ export function AiChatPanel({
 function TaskStatusIcon({ status }: { status: TaskStatus }) {
   switch (status) {
     case "done":
-      return <CheckCircle2 className="h-3 w-3 shrink-0 text-green-500" />;
+      return <CheckCircle2 className="h-3 w-3 shrink-0 text-green-500" aria-hidden="true" />;
     case "failed":
-      return <XCircle className="h-3 w-3 shrink-0 text-destructive" />;
+      return <XCircle className="h-3 w-3 shrink-0 text-destructive" aria-hidden="true" />;
     case "in_progress":
-      return <Loader2 className="h-3 w-3 shrink-0 animate-spin text-brand-emphasis" />;
+      return <Loader2 className="h-3 w-3 shrink-0 animate-spin text-brand-emphasis" aria-hidden="true" />;
     case "pending":
-      return <Circle className="h-3 w-3 shrink-0 text-muted-foreground/50" />;
+      return <Circle className="h-3 w-3 shrink-0 text-muted-foreground/50" aria-hidden="true" />;
   }
 }
 

--- a/web/src/components/install-prompt.tsx
+++ b/web/src/components/install-prompt.tsx
@@ -95,7 +95,11 @@ export function InstallPrompt() {
   }
 
   return (
-    <div className="fixed bottom-4 left-4 right-4 lg:left-auto lg:right-4 lg:w-96 z-50 animate-in slide-in-from-bottom-5">
+    <div
+      role="status"
+      aria-live="polite"
+      className="fixed bottom-4 left-4 right-4 lg:left-auto lg:right-4 lg:w-96 z-50 animate-in slide-in-from-bottom-5"
+    >
       <div className="bg-card border border-border rounded-lg shadow-lg p-4">
         <div className="flex items-start gap-3">
           <div className="flex-shrink-0 rounded-full bg-primary/10 p-2">

--- a/web/src/components/language-selector.tsx
+++ b/web/src/components/language-selector.tsx
@@ -32,7 +32,7 @@ export function LanguageSelector() {
   return (
     <Select value={locale} onValueChange={handleChange} disabled={isPending}>
       <SelectTrigger className="h-8 w-[130px] text-xs gap-1" aria-label={t("language")}>
-        <Globe className="h-3.5 w-3.5 flex-shrink-0" />
+        <Globe className="h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />
         <SelectValue />
       </SelectTrigger>
       <SelectContent>

--- a/web/src/components/navigation-sidebar.tsx
+++ b/web/src/components/navigation-sidebar.tsx
@@ -274,13 +274,22 @@ export function NavigationSidebar() {
               <Menu className="h-6 w-6" />
             )}
           </Button>
-          <div
-            className={cn("flex items-center gap-3 min-w-0 flex-1 ml-2", isPrideMonth && "cursor-pointer")}
-            onClick={isPrideMonth ? firePrideCelebration : undefined}
-          >
-            <img src="/icons/favicon-32x32.png" alt="" width={32} height={32} className="flex-shrink-0" />
-            <FiestaLogo size="sm" className="logo-on-gradient whitespace-nowrap" />
-          </div>
+          {isPrideMonth ? (
+            <button
+              type="button"
+              onClick={firePrideCelebration}
+              aria-label={t("prideCelebrationAriaLabel")}
+              className="flex items-center gap-3 min-w-0 flex-1 ml-2 cursor-pointer text-left"
+            >
+              <img src="/icons/favicon-32x32.png" alt="" width={32} height={32} className="flex-shrink-0" />
+              <FiestaLogo size="sm" className="logo-on-gradient whitespace-nowrap" />
+            </button>
+          ) : (
+            <div className="flex items-center gap-3 min-w-0 flex-1 ml-2">
+              <img src="/icons/favicon-32x32.png" alt="" width={32} height={32} className="flex-shrink-0" />
+              <FiestaLogo size="sm" className="logo-on-gradient whitespace-nowrap" />
+            </div>
+          )}
         </div>
       </header>
 
@@ -376,18 +385,32 @@ export function NavigationSidebar() {
 
           <div className="relative z-[1] flex h-full flex-col overflow-hidden">
             {/* Header */}
-            <div
-              className={cn("flex items-center gap-2 overflow-hidden px-4 py-4", isPrideMonth && "cursor-pointer")}
-              onClick={isPrideMonth ? firePrideCelebration : undefined}
-            >
-              <img src="/icons/favicon-32x32.png" alt="" width={32} height={32} className="flex-shrink-0" />
-              <FiestaLogo
-                className={cn(
-                  "logo-on-gradient whitespace-nowrap overflow-hidden transition-opacity duration-100",
-                  collapsed ? "opacity-0 max-w-0" : "opacity-100 max-w-48 delay-150",
-                )}
-              />
-            </div>
+            {isPrideMonth ? (
+              <button
+                type="button"
+                onClick={firePrideCelebration}
+                aria-label={t("prideCelebrationAriaLabel")}
+                className="flex items-center gap-2 overflow-hidden px-4 py-4 cursor-pointer text-left w-full"
+              >
+                <img src="/icons/favicon-32x32.png" alt="" width={32} height={32} className="flex-shrink-0" />
+                <FiestaLogo
+                  className={cn(
+                    "logo-on-gradient whitespace-nowrap overflow-hidden transition-opacity duration-100",
+                    collapsed ? "opacity-0 max-w-0" : "opacity-100 max-w-48 delay-150",
+                  )}
+                />
+              </button>
+            ) : (
+              <div className="flex items-center gap-2 overflow-hidden px-4 py-4">
+                <img src="/icons/favicon-32x32.png" alt="" width={32} height={32} className="flex-shrink-0" />
+                <FiestaLogo
+                  className={cn(
+                    "logo-on-gradient whitespace-nowrap overflow-hidden transition-opacity duration-100",
+                    collapsed ? "opacity-0 max-w-0" : "opacity-100 max-w-48 delay-150",
+                  )}
+                />
+              </div>
+            )}
 
             <div className="mx-2 border-t border-sidebar-border" />
 

--- a/web/src/components/output-target-selector.tsx
+++ b/web/src/components/output-target-selector.tsx
@@ -97,6 +97,7 @@ export function OutputTargetSelector() {
               key={option.value}
               onClick={() => updateMutation.mutate(option.value)}
               disabled={updateMutation.isPending}
+              aria-pressed={isActive}
               className={`w-full p-4 rounded-lg border-2 text-left transition-all active:scale-[0.98] min-h-[64px] ${
                 isActive ? "border-brand bg-brand/5" : "border-muted hover:border-brand/50 active:bg-muted/50"
               }`}

--- a/web/src/components/page-builder.tsx
+++ b/web/src/components/page-builder.tsx
@@ -1537,6 +1537,7 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
             <textarea
               readOnly
               value={exportShareString}
+              aria-label={t("exportStringAriaLabel")}
               className="w-full h-28 px-3 py-2 pr-10 text-xs font-mono rounded-md border bg-muted resize-none focus-visible:outline-none"
               onFocus={(e) => e.target.select()}
             />

--- a/web/src/components/page-grid-selector.tsx
+++ b/web/src/components/page-grid-selector.tsx
@@ -379,7 +379,13 @@ const CollectionButton = memo(
     const count = stackPages.length;
 
     return (
-      <button onClick={handleClick} disabled={isPending} className={buttonClassName} type="button">
+      <button
+        onClick={handleClick}
+        disabled={isPending}
+        className={buttonClassName}
+        type="button"
+        aria-pressed={isActive}
+      >
         <div className="flex items-center gap-2.5 min-w-0">
           <GalleryHorizontalEnd className={iconClassName} />
           <span className={nameClassName}>{collection.name}</span>

--- a/web/src/components/page-grid-selector.tsx
+++ b/web/src/components/page-grid-selector.tsx
@@ -213,7 +213,7 @@ const PageButton = memo(
         aria-pressed={isActive}
       >
         <div className="flex items-center gap-2.5 min-w-0">
-          <TypeIcon className={iconClassName} />
+          <TypeIcon className={iconClassName} aria-hidden="true" />
           <span className={nameClassName}>{page.name}</span>
         </div>
 
@@ -302,11 +302,11 @@ const PageListItem = memo(
         type="button"
         aria-pressed={isActive}
       >
-        <LayoutTemplate className={iconClassName} />
+        <LayoutTemplate className={iconClassName} aria-hidden="true" />
         <span className={nameClassName}>{page.name}</span>
         {formattedDate && (
           <span className="ml-auto flex items-center gap-1 text-xs text-muted-foreground shrink-0">
-            <Clock className="h-3 w-3" />
+            <Clock className="h-3 w-3" aria-hidden="true" />
             {formattedDate}
           </span>
         )}
@@ -387,7 +387,7 @@ const CollectionButton = memo(
         aria-pressed={isActive}
       >
         <div className="flex items-center gap-2.5 min-w-0">
-          <GalleryHorizontalEnd className={iconClassName} />
+          <GalleryHorizontalEnd className={iconClassName} aria-hidden="true" />
           <span className={nameClassName}>{collection.name}</span>
           <Badge variant="secondary" className="text-[10px] ml-auto flex-shrink-0">
             {tCommon("pageCount", { count: collection.page_ids.length })}
@@ -719,11 +719,11 @@ export function PageGridSelector({
       <Tabs defaultValue={defaultTab}>
         <TabsList className="w-full">
           <TabsTrigger value="pages" className="flex-1 gap-1.5">
-            <LayoutTemplate className="h-4 w-4" />
+            <LayoutTemplate className="h-4 w-4" aria-hidden="true" />
             {t("pagesTab", { count: pages.length })}
           </TabsTrigger>
           <TabsTrigger value="collections" className="flex-1 gap-1.5">
-            <GalleryHorizontalEnd className="h-4 w-4" />
+            <GalleryHorizontalEnd className="h-4 w-4" aria-hidden="true" />
             {t("collectionsTab", { count: collections.length })}
           </TabsTrigger>
         </TabsList>

--- a/web/src/components/page-header.tsx
+++ b/web/src/components/page-header.tsx
@@ -26,7 +26,7 @@ export function PageHeader({
     >
       <div className="min-w-0">
         <h1 className="page-title flex items-center gap-3">
-          <Icon className="h-5 w-5 flex-shrink-0" style={{ stroke: "url(#page-icon-gradient)" }} />
+          <Icon className="h-5 w-5 flex-shrink-0" style={{ stroke: "url(#page-icon-gradient)" }} aria-hidden="true" />
           {title}
         </h1>
         <p className="page-description">{description}</p>

--- a/web/src/components/page-picker-dialog.tsx
+++ b/web/src/components/page-picker-dialog.tsx
@@ -90,7 +90,7 @@ export function PagePickerDialog({
           }`}
         >
           <div className="flex items-center gap-2">
-            <GalleryHorizontalEnd className="h-4 w-4 text-muted-foreground" />
+            <GalleryHorizontalEnd className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
             <span className="text-sm font-medium">{collection.name}</span>
             <Badge variant="secondary" className="text-[10px]">
               {t("pageCount", { count: collection.page_ids.length })}
@@ -121,11 +121,11 @@ export function PagePickerDialog({
       <Tabs defaultValue={defaultTab}>
         <TabsList className="w-full">
           <TabsTrigger value="pages" className="flex-1 gap-1.5">
-            <LayoutTemplate className="h-4 w-4" />
+            <LayoutTemplate className="h-4 w-4" aria-hidden="true" />
             {t("pagesTab", { count: pages.length })}
           </TabsTrigger>
           <TabsTrigger value="collections" className="flex-1 gap-1.5">
-            <GalleryHorizontalEnd className="h-4 w-4" />
+            <GalleryHorizontalEnd className="h-4 w-4" aria-hidden="true" />
             {t("collectionsTab", { count: collections.length })}
           </TabsTrigger>
         </TabsList>

--- a/web/tests/regression/pages-edit.spec.ts
+++ b/web/tests/regression/pages-edit.spec.ts
@@ -36,7 +36,9 @@ test.describe("regression: pages.edit", () => {
     const dialog = page.getByRole("dialog");
     await expect(dialog).toBeVisible({ timeout: 10_000 });
     await expect(dialog.getByText("Export Page", { exact: true })).toBeVisible();
-    const textarea = dialog.locator("textarea");
+    // The share-string textarea must be reachable by its accessible name
+    // (WCAG 2.2 AA 4.1.2 Name, Role, Value / 1.3.1 Info and Relationships).
+    const textarea = dialog.getByRole("textbox", { name: "Share string" });
     await expect(textarea).toBeVisible();
     await expect(textarea).not.toHaveValue("");
     await page.keyboard.press("Escape");


### PR DESCRIPTION
## Summary

Consolidates **9 separate `fix(a11y)` PRs** into one branch so the overlapping changes can be resolved, fixed, and reviewed in a single place. Each fix is preserved as its own commit (original messages intact); a final commit resolves the issues that only surfaced once the changes were combined.

Supersedes and closes: #1207, #1208, #1209, #1210, #1211, #1212, #1213, #1214, #1215.

## Fixes included (one commit each)

| Commit | Was PR | Issue | Fix |
|--------|--------|-------|-----|
| `d86906df` | #1208 | Closes #1203 | output-target selection exposed via `aria-pressed` |
| `6997a160` | #1213 | Closes #1205 | install-prompt banner announced via `aria-live` |
| `b78fd471` | #1215 | Closes #1197 | `<Link>` for /schedule navigation in ActivePageDisplay |
| `bb702316` | #1207 | Closes #1200 | `aria-pressed` on CollectionButton in page-grid-selector |
| `d0024eb9` | #1209 | Closes #1206 | decorative Lucide icons hidden from assistive tech |
| `34b23d9f` | #1210 | Closes #1190 | ai-chat-panel button aria-labels routed through next-intl |
| `f43e96bc` | #1212 | Closes #1191 | AI task list progress bar exposed as `role=progressbar` |
| `3ba76f56` | #1211 | Closes #1195 | export dialog textarea labelled in page builder |
| `c78d0d46` | #1214 | Closes #1204 | pride month logo made keyboard-accessible |

## Consolidation work (final commit `a3c9d357`)

Three of the source PRs were red and several overlapped on the same files (`ai-chat-panel.tsx`, `page-grid-selector.tsx`, all 14 `web/messages/*.json`). Resolved here:

- **#1212 UI Tests** (`ReferenceError: cn is not defined`) — `TaskListPanel` used `cn()` without importing it. Added the canonical `import { cn } from "@/lib/utils"`.
- **#1210 Lint UI** (`simple-import-sort/imports`) — the merged `ai-chat-panel.test.tsx` import block was unsorted. Re-sorted via `eslint --fix`.
- **Message-file conflicts** — #1210 and #1212 both appended namespaces at end-of-file in all 14 locales. Both blocks kept.

## Verification (in container)

- `eslint src` → **0 errors** (882 pre-existing i18next warnings unchanged)
- `prettier --check` on all changed files → clean
- `vitest run` → **88 files / 1076 tests passing**, 13 skipped

## Notes for reviewer

- **Namespace inconsistency (intentional, left as-is):** #1210 added the `aiChatPanel` message namespace and #1212 added `aiChat`, both for the same component. Preserved both to keep each original fix's behavior; collapsing them into one namespace is an optional follow-up cleanup.
- **#1215's E2E red was unrelated:** the failing `multi-board-schedule.spec.ts › board-selector` test exercises the /schedule page itself, which the ActivePageDisplay link change does not touch (the same run also had an `error-recovery` flake that passed on retry). Expecting it to clear on fresh CI here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)