### PR TITLE
feat(api): auto-detect board type & size from live layout [#1172]

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -36,7 +36,7 @@ from .collections.models import CollectionCreate, CollectionUpdate, is_collectio
 from .collections.service import get_collection_service  # noqa: E402
 from .config import Config  # noqa: E402
 from .config_manager import get_config_manager  # noqa: E402
-from .devices import get_dimensions, resolve_dimensions  # noqa: E402
+from .devices import classify_dimensions, get_dimensions, resolve_dimensions  # noqa: E402
 from .displays.service import get_display_service, reset_display_service  # noqa: E402
 from .main import DisplayService  # noqa: E402
 from .network.wifi import WiFiError, get_wifi_service  # noqa: E402
@@ -5494,6 +5494,52 @@ async def set_board_paused(board_id: str, request: dict):
         "paused": paused,
         "settings": settings_service.get_board_settings().to_dict(),
     }
+
+
+@app.post("/settings/board/{board_id}/detect-size")
+async def detect_board_size(board_id: str):
+    """Auto-detect a board's device type and dimensions from its live layout.
+
+    Reads the board's current message over its own transport (local / cloud /
+    note-array, via ``board_client_from_board_dict``) and classifies the grid
+    shape with :func:`classify_dimensions`.
+
+    Returns ``device_type``, ``rows``, ``cols`` and — for note arrays —
+    ``notes_wide``, ``notes_tall`` and ``matched_preset``.
+
+    Errors: 404 (unknown board), 400 (board not configured), 422 (board
+    returned no layout, or an unclassifiable grid).
+    """
+    settings_service = get_settings_service()
+    boards = settings_service.get_board_settings().boards or []
+
+    board_dict = next((b for b in boards if b.get("id") == board_id), None)
+    if board_dict is None:
+        raise HTTPException(status_code=404, detail=f"Board {board_id} not found")
+
+    client = board_client_from_board_dict(board_dict)
+    if client is None:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Board {board_id} is not configured (missing credentials)",
+        )
+
+    grid = client.read_current_message()
+    if grid is None:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Board {board_id} returned no layout — board may be blank or unreachable",
+        )
+
+    rows = len(grid)
+    cols = len(grid[0]) if rows > 0 else 0
+    try:
+        return classify_dimensions(rows, cols)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Board {board_id} returned an unclassifiable grid ({rows}×{cols}): {exc}",
+        ) from exc
 
 
 @app.get("/settings/display")

--- a/src/devices.py
+++ b/src/devices.py
@@ -206,5 +206,66 @@ def resolve_dimensions(
     raise ValueError(f"Unknown device type: {device_type}. Must be one of {DEVICE_TYPES}")
 
 
+def classify_dimensions(rows: int, cols: int) -> dict:
+    """Classify a grid (rows × cols) into a device type and optional note-array geometry.
+
+    Used to auto-detect a board's type/size from a live layout read.
+
+    Returns a dict with at minimum ``{"device_type", "rows", "cols"}``:
+
+      - flagship / note:
+        ``{"device_type": "flagship"|"note", "rows": int, "cols": int}``
+      - note array (rows a multiple of NOTE_ROWS, cols a multiple of NOTE_COLS,
+        each axis within MAX_NOTES_PER_AXIS, and not the fixed flagship/note size)::
+
+            {
+                "device_type": "note_array",
+                "rows": int,
+                "cols": int,
+                "notes_wide": cols // NOTE_COLS,
+                "notes_tall": rows // NOTE_ROWS,
+                "matched_preset": <preset label> | None,
+            }
+
+    Order matters: an exact 6×22 is a flagship and an exact 3×15 is a Note —
+    both are checked before the note-array branch, so a single Note never
+    classifies as a 1×1 array.
+
+    Raises ValueError for a grid that is neither the flagship size, the Note
+    size, nor a valid note-array grid.
+    """
+    flagship = DEVICE_DIMENSIONS["flagship"]
+    if rows == flagship.rows and cols == flagship.cols:
+        return {"device_type": "flagship", "rows": rows, "cols": cols}
+
+    note = DEVICE_DIMENSIONS["note"]
+    if rows == note.rows and cols == note.cols:
+        return {"device_type": "note", "rows": rows, "cols": cols}
+
+    if is_valid_note_array_grid(rows, cols):
+        notes_wide = cols // NOTE_COLS
+        notes_tall = rows // NOTE_ROWS
+        matched_preset: str | None = None
+        for preset in NOTE_ARRAY_PRESETS:
+            if preset["notes_wide"] == notes_wide and preset["notes_tall"] == notes_tall:
+                matched_preset = preset["label"]
+                break
+        return {
+            "device_type": "note_array",
+            "rows": rows,
+            "cols": cols,
+            "notes_wide": notes_wide,
+            "notes_tall": notes_tall,
+            "matched_preset": matched_preset,
+        }
+
+    raise ValueError(
+        f"Grid {rows}×{cols} is unclassifiable: not a flagship ({flagship.cols}×{flagship.rows}), "
+        f"not a Note ({note.cols}×{note.rows}), and not a valid note-array grid "
+        f"(rows must be a multiple of {NOTE_ROWS}, cols a multiple of {NOTE_COLS}, "
+        f"each axis ≤ {MAX_NOTES_PER_AXIS} notes)."
+    )
+
+
 # Default device type for backward compatibility
 DEFAULT_DEVICE_TYPE: DeviceType = "flagship"

--- a/tests/test_api_server_detect_size.py
+++ b/tests/test_api_server_detect_size.py
@@ -1,0 +1,199 @@
+"""Tests for POST /settings/board/{board_id}/detect-size endpoint."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.api_server import app
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_board_dict(
+    board_id: str = "board-1",
+    device_type: str = "flagship",
+    api_mode: str = "local",
+    local_api_key: str = "lk",
+    host: str = "192.168.0.1",
+    cloud_key: str = "",
+    note_array_token: str = "",
+    notes_wide: int = 1,
+    notes_tall: int = 1,
+) -> dict:
+    return {
+        "id": board_id,
+        "device_type": device_type,
+        "api_mode": api_mode,
+        "local_api_key": local_api_key,
+        "host": host,
+        "port": 7000,
+        "cloud_key": cloud_key,
+        "note_array_token": note_array_token,
+        "notes_wide": notes_wide,
+        "notes_tall": notes_tall,
+    }
+
+
+def _board_settings_mock(boards: list[dict]):
+    """Return a mock BoardSettings exposing the given boards list."""
+    bs = MagicMock()
+    bs.boards = boards
+    return bs
+
+
+# ---------------------------------------------------------------------------
+# Success cases — one per api_mode / device family
+# ---------------------------------------------------------------------------
+
+
+class TestDetectSizeSuccess:
+    """Endpoint returns the classification of the live grid for each transport."""
+
+    @patch("src.api_server.get_settings_service")
+    @patch("src.board_client.BoardClient.read_current_message")
+    def test_local_flagship_6x22(self, mock_read, mock_ss, client):
+        """Local API, flagship 6×22 grid → device_type flagship."""
+        mock_ss.return_value.get_board_settings.return_value = _board_settings_mock(
+            [_make_board_dict(api_mode="local")]
+        )
+        mock_read.return_value = [[0] * 22 for _ in range(6)]
+
+        resp = client.post("/settings/board/board-1/detect-size")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["device_type"] == "flagship"
+        assert data["rows"] == 6
+        assert data["cols"] == 22
+        assert "notes_wide" not in data
+
+    @patch("src.api_server.get_settings_service")
+    @patch("src.board_client.BoardClient.read_current_message")
+    def test_cloud_note_3x15(self, mock_read, mock_ss, client):
+        """Cloud API, Note 3×15 grid → device_type note (classified from the grid)."""
+        mock_ss.return_value.get_board_settings.return_value = _board_settings_mock(
+            [_make_board_dict(api_mode="cloud", cloud_key="ck", local_api_key="", host="")]
+        )
+        mock_read.return_value = [[0] * 15 for _ in range(3)]
+
+        resp = client.post("/settings/board/board-1/detect-size")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["device_type"] == "note"
+        assert data["rows"] == 3
+        assert data["cols"] == 15
+
+    @patch("src.api_server.get_settings_service")
+    @patch("src.board_client.BoardClient.read_current_message")
+    def test_note_array_6x30_2x2_grid(self, mock_read, mock_ss, client):
+        """Note-array board, 6×30 grid → note_array 2×2, preset '2×2 grid'."""
+        mock_ss.return_value.get_board_settings.return_value = _board_settings_mock(
+            [
+                _make_board_dict(
+                    device_type="note_array",
+                    api_mode="cloud",
+                    note_array_token="tok-abc",
+                    notes_wide=2,
+                    notes_tall=2,
+                    local_api_key="tok-abc",
+                    host="",
+                )
+            ]
+        )
+        mock_read.return_value = [[0] * 30 for _ in range(6)]
+
+        resp = client.post("/settings/board/board-1/detect-size")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["device_type"] == "note_array"
+        assert data["notes_wide"] == 2
+        assert data["notes_tall"] == 2
+        assert data["matched_preset"] == "2×2 grid"
+        assert data["rows"] == 6
+        assert data["cols"] == 30
+
+    @patch("src.api_server.get_settings_service")
+    @patch("src.board_client.BoardClient.read_current_message")
+    def test_note_array_3x60_4_side_by_side(self, mock_read, mock_ss, client):
+        """Note-array board, 3×60 grid → note_array 4×1, preset '4 side-by-side'."""
+        mock_ss.return_value.get_board_settings.return_value = _board_settings_mock(
+            [
+                _make_board_dict(
+                    device_type="note_array",
+                    api_mode="cloud",
+                    note_array_token="tok-abc",
+                    notes_wide=4,
+                    notes_tall=1,
+                    local_api_key="tok-abc",
+                    host="",
+                )
+            ]
+        )
+        mock_read.return_value = [[0] * 60 for _ in range(3)]
+
+        resp = client.post("/settings/board/board-1/detect-size")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["device_type"] == "note_array"
+        assert data["notes_wide"] == 4
+        assert data["notes_tall"] == 1
+        assert data["matched_preset"] == "4 side-by-side"
+
+
+# ---------------------------------------------------------------------------
+# Error cases
+# ---------------------------------------------------------------------------
+
+
+class TestDetectSizeErrors:
+    """Endpoint returns structured errors for each failure mode."""
+
+    @patch("src.api_server.get_settings_service")
+    def test_board_not_found_404(self, mock_ss, client):
+        """Unknown board_id → 404."""
+        mock_ss.return_value.get_board_settings.return_value = _board_settings_mock([])
+
+        resp = client.post("/settings/board/nonexistent/detect-size")
+        assert resp.status_code == 404
+        assert "not found" in resp.json()["detail"].lower()
+
+    @patch("src.api_server.get_settings_service")
+    def test_board_not_configured_400(self, mock_ss, client):
+        """Board exists but has no credentials → 400."""
+        mock_ss.return_value.get_board_settings.return_value = _board_settings_mock(
+            [_make_board_dict(local_api_key="", host="")]
+        )
+
+        resp = client.post("/settings/board/board-1/detect-size")
+        assert resp.status_code == 400
+        assert "not configured" in resp.json()["detail"].lower()
+
+    @patch("src.api_server.get_settings_service")
+    @patch("src.board_client.BoardClient.read_current_message")
+    def test_board_unreachable_422(self, mock_read, mock_ss, client):
+        """Board configured but read returns None (unreachable/blank) → 422."""
+        mock_ss.return_value.get_board_settings.return_value = _board_settings_mock([_make_board_dict()])
+        mock_read.return_value = None
+
+        resp = client.post("/settings/board/board-1/detect-size")
+        assert resp.status_code == 422
+        assert "no layout" in resp.json()["detail"].lower()
+
+    @patch("src.api_server.get_settings_service")
+    @patch("src.board_client.BoardClient.read_current_message")
+    def test_unclassifiable_grid_422(self, mock_read, mock_ss, client):
+        """Board returns a 5×15 grid (5 % 3 != 0) → 422 unclassifiable."""
+        mock_ss.return_value.get_board_settings.return_value = _board_settings_mock([_make_board_dict()])
+        mock_read.return_value = [[0] * 15 for _ in range(5)]
+
+        resp = client.post("/settings/board/board-1/detect-size")
+        assert resp.status_code == 422
+        assert "unclassifiable" in resp.json()["detail"].lower()

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -12,6 +12,7 @@ from src.devices import (
     VALID_API_MODES,
     BoardInstance,
     DeviceDimensions,
+    classify_dimensions,
     get_dimensions,
     is_note_array,
     is_valid_note_array_grid,
@@ -597,3 +598,118 @@ class TestBoardInstanceNotesFields:
         """'note_array' is now a valid device_type — not normalized to 'flagship'."""
         board = BoardInstance(device_type="note_array")
         assert board.device_type == "note_array"
+
+
+class TestClassifyDimensions:
+    """Tests for classify_dimensions(rows, cols) — auto-detect from a live grid."""
+
+    # --- Flagship ---
+    def test_flagship_6x22(self):
+        """6×22 → flagship (no note-array keys)."""
+        result = classify_dimensions(6, 22)
+        assert result["device_type"] == "flagship"
+        assert result["rows"] == 6
+        assert result["cols"] == 22
+        assert "notes_wide" not in result
+        assert "notes_tall" not in result
+        assert "matched_preset" not in result
+
+    # --- Note ---
+    def test_note_3x15(self):
+        """3×15 → note (checked before the note-array branch)."""
+        result = classify_dimensions(3, 15)
+        assert result["device_type"] == "note"
+        assert result["rows"] == 3
+        assert result["cols"] == 15
+        assert "notes_wide" not in result
+
+    # --- Note array, preset matches ---
+    def test_note_array_2x2_grid(self):
+        """6×30 → note_array, 2 wide × 2 tall, preset '2×2 grid'."""
+        result = classify_dimensions(6, 30)
+        assert result["device_type"] == "note_array"
+        assert result["notes_wide"] == 2
+        assert result["notes_tall"] == 2
+        assert result["matched_preset"] == "2×2 grid"
+        assert result["rows"] == 6
+        assert result["cols"] == 30
+
+    def test_note_array_4_side_by_side(self):
+        """3×60 → note_array, 4 wide × 1 tall, preset '4 side-by-side'."""
+        result = classify_dimensions(3, 60)
+        assert result["device_type"] == "note_array"
+        assert result["notes_wide"] == 4
+        assert result["notes_tall"] == 1
+        assert result["matched_preset"] == "4 side-by-side"
+
+    def test_note_array_2_side_by_side(self):
+        """3×30 → note_array, 2 wide × 1 tall, preset '2 side-by-side'."""
+        result = classify_dimensions(3, 30)
+        assert result["device_type"] == "note_array"
+        assert result["notes_wide"] == 2
+        assert result["notes_tall"] == 1
+        assert result["matched_preset"] == "2 side-by-side"
+
+    def test_note_array_2_stacked(self):
+        """6×15 → note_array, 1 wide × 2 tall, preset '2 stacked'."""
+        result = classify_dimensions(6, 15)
+        assert result["device_type"] == "note_array"
+        assert result["notes_wide"] == 1
+        assert result["notes_tall"] == 2
+        assert result["matched_preset"] == "2 stacked"
+
+    def test_note_array_4_stacked(self):
+        """12×15 → note_array, 1 wide × 4 tall, preset '4 stacked'."""
+        result = classify_dimensions(12, 15)
+        assert result["device_type"] == "note_array"
+        assert result["notes_wide"] == 1
+        assert result["notes_tall"] == 4
+        assert result["matched_preset"] == "4 stacked"
+
+    # --- Note array, no preset match ---
+    def test_note_array_no_preset_match(self):
+        """9×45 (3 wide × 3 tall) → note_array, matched_preset is None."""
+        result = classify_dimensions(9, 45)
+        assert result["device_type"] == "note_array"
+        assert result["notes_wide"] == 3
+        assert result["notes_tall"] == 3
+        assert result["matched_preset"] is None
+
+    def test_note_array_8x8_at_cap_no_preset(self):
+        """24×120 (8 wide × 8 tall) is at MAX_NOTES_PER_AXIS cap, no preset."""
+        result = classify_dimensions(24, 120)
+        assert result["device_type"] == "note_array"
+        assert result["notes_wide"] == 8
+        assert result["notes_tall"] == 8
+        assert result["matched_preset"] is None
+
+    # --- Unclassifiable ---
+    def test_unclassifiable_5x15_non_multiple_rows(self):
+        """5×15: 5 % 3 != 0 → ValueError."""
+        with pytest.raises(ValueError, match="unclassifiable"):
+            classify_dimensions(5, 15)
+
+    def test_unclassifiable_6x16_non_multiple_cols(self):
+        """6×16: 16 % 15 != 0 → ValueError."""
+        with pytest.raises(ValueError, match="unclassifiable"):
+            classify_dimensions(6, 16)
+
+    def test_unclassifiable_4x4(self):
+        """4×4: not flagship, not note, not valid note-array → ValueError."""
+        with pytest.raises(ValueError, match="unclassifiable"):
+            classify_dimensions(4, 4)
+
+    def test_unclassifiable_over_axis_cap(self):
+        """27×15 (9 notes tall > MAX_NOTES_PER_AXIS=8) → ValueError."""
+        with pytest.raises(ValueError, match="unclassifiable"):
+            classify_dimensions(27, 15)
+
+    def test_unclassifiable_zero_rows(self):
+        """0×15 → ValueError."""
+        with pytest.raises(ValueError):
+            classify_dimensions(0, 15)
+
+    def test_unclassifiable_zero_cols(self):
+        """3×0 → ValueError."""
+        with pytest.raises(ValueError):
+            classify_dimensions(3, 0)


### PR DESCRIPTION
Closes #1172. Part of the Note Arrays epic #1167. Targets `next`.

## What

Adds **auto-detection** of a board's device type and size by reading its live layout:

- **`classify_dimensions(rows, cols)`** in `src/devices.py` — purely additive:
  - `6×22` → `flagship`, `3×15` → `note` (checked before the array branch, so a single Note is never a 1×1 array)
  - valid note-array grids → `note_array` with `notes_wide`, `notes_tall`, and `matched_preset` (one of the 5 presets, else `None`)
  - anything else → `ValueError` ("unclassifiable")
- **`POST /settings/board/{board_id}/detect-size`** — reads the current message via `board_client_from_board_dict` (local / cloud / note-array transport) and classifies the grid. Errors: `404` unknown board, `400` not configured, `422` no layout / unclassifiable grid.

## Tests

- `TestClassifyDimensions` (14 cases): flagship, note, all 5 presets, no-preset (9×45), at-cap 8×8 (24×120), unclassifiable (5×15, 6×16, 4×4, over-cap 27×15), zero dims.
- `tests/test_api_server_detect_size.py` (8 cases): one success per transport (local flagship, cloud note, note-array 2×2 & 4×1) + every error path.

## Verification

- `ruff check` / `ruff format --check`: clean
- targeted pytest: **112 passed**
- broader suite (minus `tests/ai`, which needs API keys locally): **3832 passed, 0 failures**

## Notes

No model, schema, or migration changes. No changes to `board_client.py`, services, or any TypeScript. Disjoint from the other in-flight Wave-3 PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)