### PR TITLE
feat(board): note-array send constraints — no transitions, 15s throttle [#1169]

### DIFF
--- a/src/board_client.py
+++ b/src/board_client.py
@@ -16,6 +16,8 @@ Cloud API Reference:
 import json
 import logging
 import re
+import time as _time_module
+from collections.abc import Callable
 from typing import Any, Literal, Optional
 
 import requests
@@ -62,6 +64,13 @@ TransitionStrategy = Literal[
 ]
 
 VALID_STRATEGIES = ["column", "reverse-column", "edges-to-center", "row", "diagonal", "random"]
+
+# Minimum interval (seconds) between note-array sends enforced client-side.
+NOTE_ARRAY_MIN_SEND_INTERVAL: float = 15.0
+
+# Module-level per-board throttle state. Key = note_array_token (board id proxy).
+# Persists across BoardClient recreations within a process.
+_note_array_last_send: dict[str, float] = {}
 
 
 def _valid_grid_dimensions() -> set:
@@ -150,6 +159,7 @@ class BoardClient:
         note_array_token: str | None = None,
         notes_wide: int = 1,
         notes_tall: int = 1,
+        _time_func: Callable[[], float] | None = None,
     ):
         """
         Initialize board API client.
@@ -163,6 +173,8 @@ class BoardClient:
             note_array_token: X-Vestaboard-Token for note-array boards; non-empty enables note-array mode.
             notes_wide: Number of Notes side-by-side (columns = notes_wide * 15).
             notes_tall: Number of Notes stacked (rows = notes_tall * 3).
+            _time_func: Injectable monotonic clock for note-array throttle tests.
+                Defaults to ``time.monotonic``.
         """
         if not api_key:
             raise ValueError("api_key is required")
@@ -202,6 +214,8 @@ class BoardClient:
         self._notes_wide: int = notes_wide
         self._notes_tall: int = notes_tall
         self._is_note_array: bool = bool(note_array_token)
+        # Injectable monotonic clock for the note-array send throttle (tests).
+        self._time_func: Callable[[], float] = _time_func if _time_func is not None else _time_module.monotonic
 
     @property
     def _note_array_headers(self) -> dict[str, str]:
@@ -303,6 +317,28 @@ class BoardClient:
             logger.error(f"Invalid strategy: {strategy}. Must be one of {VALID_STRATEGIES}")
             return (False, False)
 
+        # Note-array boards do not support transitions; strip and warn.
+        if self._is_note_array and strategy is not None:
+            logger.debug("Note-array board: transition strategy %r is not supported and will be ignored.", strategy)
+            strategy = None
+            step_interval_ms = None
+            step_size = None
+
+        # Rate-limit note-array sends to >= NOTE_ARRAY_MIN_SEND_INTERVAL seconds.
+        # Read the clock once and reuse it for the success-path timestamp below.
+        now = self._time_func() if self._is_note_array else None
+        if self._is_note_array:
+            last = _note_array_last_send.get(self._note_array_token)
+            if last is not None:
+                elapsed = now - last
+                if elapsed < NOTE_ARRAY_MIN_SEND_INTERVAL:
+                    logger.warning(
+                        "Note-array send throttled: %.1fs since last send (min %.0fs); skipping.",
+                        elapsed,
+                        NOTE_ARRAY_MIN_SEND_INTERVAL,
+                    )
+                    return (True, False)
+
         # Check if characters have changed (client-side caching)
         if self.skip_unchanged and not force and self._last_characters == characters:
             logger.debug("Character array unchanged, skipping send")
@@ -337,6 +373,9 @@ class BoardClient:
 
             self._last_characters = [row[:] for row in characters]
             self._last_text = None
+
+            if self._is_note_array:
+                _note_array_last_send[self._note_array_token] = now
 
             transition_info = ""
             if strategy:

--- a/tests/test_board_client.py
+++ b/tests/test_board_client.py
@@ -10,11 +10,25 @@ from src.board_client import (
     VALID_STRATEGIES,
     BoardClient,
     _is_valid_character_grid,
+    _note_array_last_send,
     board_client_from_board_dict,
     is_successful_board_read_response,
     parse_read_message_payload,
     strip_color_markers,
 )
+
+
+@pytest.fixture(autouse=True)
+def _reset_note_array_throttle():
+    """Clear the module-level note-array throttle state before each test.
+
+    ``_note_array_last_send`` persists for the process lifetime by design, so
+    without this reset a timestamp left by one test would throttle the first
+    send of an unrelated test that reuses the same token.
+    """
+    _note_array_last_send.clear()
+    yield
+    _note_array_last_send.clear()
 
 
 class TestStripColorMarkers:
@@ -1041,3 +1055,170 @@ class TestBoardClientFactoryNoteArray:
         client = board_client_from_board_dict(board)
         assert client is not None
         assert client._is_note_array is False
+
+
+# ---------------------------------------------------------------------------
+# Issue #1169 — Note-array send constraints (no transitions, 15s rate limit)
+# ---------------------------------------------------------------------------
+
+
+def _clock(*values):
+    """Return a callable that yields the given values in order, then repeats the last."""
+    seq = list(values)
+
+    def _next():
+        return seq.pop(0) if len(seq) > 1 else seq[0]
+
+    return _next
+
+
+class TestNoteArrayConstraints:
+    """Note-array sends strip transitions and enforce a 15s rate limit."""
+
+    @pytest.fixture
+    def note_array_client_with_clock(self):
+        """Factory: call with (time_func, token) to get a throttle-testable client."""
+
+        def _make(time_func, token):
+            return BoardClient(
+                api_key=token,
+                use_cloud=True,
+                note_array_token=token,
+                notes_wide=4,
+                notes_tall=1,
+                _time_func=time_func,
+            )
+
+        return _make
+
+    @pytest.fixture
+    def note_array_client(self):
+        return BoardClient(
+            api_key="na-tok",
+            use_cloud=True,
+            note_array_token="na-strip-tok",
+            notes_wide=4,
+            notes_tall=1,
+        )
+
+    @pytest.fixture
+    def valid_3x60_grid(self):
+        return [[0] * 60 for _ in range(3)]
+
+    @pytest.fixture
+    def other_3x60_grid(self):
+        # A distinct grid to bypass the content-unchanged cache on a second send.
+        return [[1] * 60 for _ in range(3)]
+
+    # --- transition stripping -------------------------------------------------
+
+    @patch("src.board_client.requests.post")
+    def test_note_array_send_omits_strategy_even_when_passed(self, mock_post, note_array_client, valid_3x60_grid):
+        mock_post.return_value.raise_for_status = Mock()
+
+        result = note_array_client.send_characters(
+            valid_3x60_grid, strategy="column", step_interval_ms=500, step_size=2
+        )
+
+        body = mock_post.call_args.kwargs["json"]
+        assert "strategy" not in body
+        assert "step_interval_ms" not in body
+        assert "step_size" not in body
+        assert result == (True, True)
+
+    @patch("src.board_client.requests.post")
+    def test_note_array_send_omits_strategy_none_also_fine(self, mock_post, note_array_client, valid_3x60_grid):
+        mock_post.return_value.raise_for_status = Mock()
+
+        note_array_client.send_characters(valid_3x60_grid, strategy=None)
+
+        body = mock_post.call_args.kwargs["json"]
+        assert body == {"characters": valid_3x60_grid}
+
+    # --- throttle -------------------------------------------------------------
+
+    @patch("src.board_client.requests.post")
+    def test_note_array_second_send_within_15s_is_throttled(
+        self, mock_post, note_array_client_with_clock, valid_3x60_grid, other_3x60_grid, caplog
+    ):
+        mock_post.return_value.raise_for_status = Mock()
+        # First send at t=0, throttle-check on second send at t=10 (<15s).
+        client = note_array_client_with_clock(_clock(0.0, 10.0), "na-throttle-within")
+
+        first = client.send_characters(valid_3x60_grid)
+        assert first == (True, True)
+        assert mock_post.call_count == 1
+
+        with caplog.at_level("WARNING"):
+            second = client.send_characters(other_3x60_grid)
+
+        assert second == (True, False)
+        assert mock_post.call_count == 1  # not sent again
+        assert any(record.levelname == "WARNING" and "throttled" in record.message for record in caplog.records)
+
+    @patch("src.board_client.requests.post")
+    def test_note_array_second_send_at_exactly_15s_goes_through(
+        self, mock_post, note_array_client_with_clock, valid_3x60_grid, other_3x60_grid
+    ):
+        mock_post.return_value.raise_for_status = Mock()
+        client = note_array_client_with_clock(_clock(0.0, 15.0), "na-throttle-exact")
+
+        assert client.send_characters(valid_3x60_grid) == (True, True)
+        assert client.send_characters(other_3x60_grid) == (True, True)
+        assert mock_post.call_count == 2
+
+    @patch("src.board_client.requests.post")
+    def test_note_array_second_send_after_15s_goes_through(
+        self, mock_post, note_array_client_with_clock, valid_3x60_grid, other_3x60_grid
+    ):
+        mock_post.return_value.raise_for_status = Mock()
+        client = note_array_client_with_clock(_clock(0.0, 16.0), "na-throttle-after")
+
+        assert client.send_characters(valid_3x60_grid) == (True, True)
+        assert client.send_characters(other_3x60_grid) == (True, True)
+        assert mock_post.call_count == 2
+
+    @patch("src.board_client.requests.post")
+    def test_note_array_first_send_always_goes_through(self, mock_post, note_array_client_with_clock, valid_3x60_grid):
+        mock_post.return_value.raise_for_status = Mock()
+        # Token never previously seen in _note_array_last_send.
+        client = note_array_client_with_clock(_clock(100.0), "na-throttle-first")
+
+        assert client.send_characters(valid_3x60_grid) == (True, True)
+        assert mock_post.call_count == 1
+
+    @patch("src.board_client.requests.post")
+    def test_note_array_throttle_state_persists_across_client_recreation(
+        self, mock_post, note_array_client_with_clock, valid_3x60_grid, other_3x60_grid
+    ):
+        """A new BoardClient with the same token still sees the prior send's timestamp."""
+        mock_post.return_value.raise_for_status = Mock()
+        token = "na-throttle-persist"
+
+        first_client = note_array_client_with_clock(_clock(0.0), token)
+        assert first_client.send_characters(valid_3x60_grid) == (True, True)
+        assert mock_post.call_count == 1
+
+        # New instance (simulating reinitialize_board_client), clock at t=5 (<15s).
+        second_client = note_array_client_with_clock(_clock(5.0), token)
+        result = second_client.send_characters(other_3x60_grid)
+
+        assert result == (True, False)
+        assert mock_post.call_count == 1  # second instance's send was throttled
+
+    # --- regression -----------------------------------------------------------
+
+    @patch("src.board_client.requests.post")
+    def test_flagship_transitions_unchanged(self, mock_post):
+        """Flagship local sends still carry transition params."""
+        client = BoardClient(api_key="local-key", host="192.168.0.11")
+        grid = [[0] * 22 for _ in range(6)]
+        mock_post.return_value.raise_for_status = Mock()
+
+        result = client.send_characters(grid, strategy="column", step_interval_ms=500, step_size=2)
+
+        body = mock_post.call_args.kwargs["json"]
+        assert body["strategy"] == "column"
+        assert body["step_interval_ms"] == 500
+        assert body["step_size"] == 2
+        assert result == (True, True)


### PR DESCRIPTION
Closes #1169. Part of the Note Arrays epic #1167. Targets `next`.

## What
Enforces the two Cloud-API constraints for note-array boards in `BoardClient.send_characters`:

- **No transitions** — note-array sends strip any `strategy` / `step_interval_ms` / `step_size` (forced to `None`) and log a debug note; the payload + transition-info log can never re-introduce them.
- **≥15s rate limit** — a module-level `_note_array_last_send` dict keyed by the board's `note_array_token` throttles re-sends within `NOTE_ARRAY_MIN_SEND_INTERVAL` (15s), returning `(True, False)` and warning. The dict is module-scoped so it survives `BoardClient` recreation (clients are rebuilt on reinit / per-call), matching the server-side, per-board nature of the limit. Time is injectable (`_time_func`, defaults to `time.monotonic`) for deterministic tests.

## Tests
`TestNoteArrayConstraints` in `tests/test_board_client.py`: transition-strip, throttle within/at/after 15s, first-send pass-through, persistence across client recreation, and a flagship-still-has-transitions regression. An autouse fixture resets the throttle dict between tests.

## Verification
- `ruff check` / `format`: clean
- targeted `tests/test_board_client.py`: **118 passed**
- broader suite (minus `tests/ai`): **3817 passed, 0 failures**

Disjoint from the other in-flight Wave-3 PRs (#1172, #1181).

🤖 Generated with [Claude Code](https://claude.com/claude-code)