### PR TITLE
test(integration): note-array Cloud API mock for integration tests [#1181]

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -108,6 +108,18 @@ jobs:
           sleep 2
           echo "Mock board started on port 7000"
 
+      - name: Start mock Vestaboard Cloud API (smoke)
+        if: github.event_name == 'pull_request'
+        env:
+          PORT: 9200
+          ROWS: 6
+          COLS: 30
+        run: |
+          # mock-cloud/server.py is stdlib-only too — no pip install needed.
+          python3 integration-tests/mock-cloud/server.py &
+          sleep 2
+          echo "Mock Cloud API started on port 9200"
+
       - name: Start FiestaBoard container (smoke)
         if: github.event_name == 'pull_request'
         run: |
@@ -144,23 +156,34 @@ jobs:
           # mock server running on the GitHub Actions runner host. From inside Docker,
           # the host is reachable at host.docker.internal, not localhost.
           MOCK_BOARD_HOST: host.docker.internal
+          # MOCK_CLOUD_URL is reachable from the runner host (Playwright) at
+          # localhost; the mock Cloud API listens on the runner, not in Docker.
+          MOCK_CLOUD_URL: http://localhost:9200/
 
       # ── Merge queue: 4 isolated containers for full suite ─────────
       # The full suite uses workers=4 (playwright.config.ts). Without per-worker
       # backend isolation, all workers share a single backend and race conditions
       # cause spurious failures. We start 4 FiestaBoard + 4 mock-board containers
       # and pass WORKER_URLS so each Playwright worker gets its own isolated backend.
-      - name: Start 4 mock board + FiestaBoard containers (full suite)
+      - name: Start 4 mock board + mock cloud + FiestaBoard containers (full suite)
         if: github.event_name == 'merge_group'
         run: |
           WORKER_COUNT=4
           WORKER_URLS=""
           WORKER_MOCK_URLS=""
           WORKER_MOCK_HOSTS=""
+          MOCK_CLOUD_URLS=""
 
           for i in $(seq 0 $((WORKER_COUNT - 1))); do
             docker run -d --name mock-board-$i \
               -v ${{ github.workspace }}/integration-tests/mock-board:/app:ro \
+              -w /app \
+              python:3.11-slim python server.py
+
+            # Note-array Cloud API mock (stdlib-only); one per worker for isolation.
+            docker run -d --name mock-cloud-$i \
+              -e PORT=9200 -e ROWS=6 -e COLS=30 \
+              -v ${{ github.workspace }}/integration-tests/mock-cloud:/app:ro \
               -w /app \
               python:3.11-slim python server.py
 
@@ -173,21 +196,25 @@ jobs:
           for i in $(seq 0 $((WORKER_COUNT - 1))); do
             FB_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' fiestaboard-int-$i)
             MOCK_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' mock-board-$i)
+            CLOUD_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' mock-cloud-$i)
 
             [ -n "$WORKER_URLS" ] && WORKER_URLS="$WORKER_URLS,"
             [ -n "$WORKER_MOCK_URLS" ] && WORKER_MOCK_URLS="$WORKER_MOCK_URLS,"
             [ -n "$WORKER_MOCK_HOSTS" ] && WORKER_MOCK_HOSTS="$WORKER_MOCK_HOSTS,"
+            [ -n "$MOCK_CLOUD_URLS" ] && MOCK_CLOUD_URLS="$MOCK_CLOUD_URLS,"
 
             WORKER_URLS="${WORKER_URLS}http://$FB_IP:3000"
             WORKER_MOCK_URLS="${WORKER_MOCK_URLS}http://$MOCK_IP:7000"
             WORKER_MOCK_HOSTS="${WORKER_MOCK_HOSTS}$MOCK_IP"
+            MOCK_CLOUD_URLS="${MOCK_CLOUD_URLS}http://$CLOUD_IP:9200"
 
-            echo "Worker $i: FiestaBoard=$FB_IP, MockBoard=$MOCK_IP"
+            echo "Worker $i: FiestaBoard=$FB_IP, MockBoard=$MOCK_IP, MockCloud=$CLOUD_IP"
           done
 
           echo "WORKER_URLS=$WORKER_URLS" >> $GITHUB_ENV
           echo "WORKER_MOCK_URLS=$WORKER_MOCK_URLS" >> $GITHUB_ENV
           echo "WORKER_MOCK_HOSTS=$WORKER_MOCK_HOSTS" >> $GITHUB_ENV
+          echo "MOCK_CLOUD_URLS=$MOCK_CLOUD_URLS" >> $GITHUB_ENV
 
       - name: Wait for all containers to be ready (full suite)
         if: github.event_name == 'merge_group'
@@ -221,13 +248,14 @@ jobs:
           WORKER_URLS: ${{ env.WORKER_URLS }}
           WORKER_MOCK_URLS: ${{ env.WORKER_MOCK_URLS }}
           WORKER_MOCK_HOSTS: ${{ env.WORKER_MOCK_HOSTS }}
+          MOCK_CLOUD_URLS: ${{ env.MOCK_CLOUD_URLS }}
 
       - name: Stop containers
         if: always()
         run: |
           docker rm -f fiestaboard-integration 2>/dev/null || true
           for i in 0 1 2 3; do
-            docker rm -f fiestaboard-int-$i mock-board-$i 2>/dev/null || true
+            docker rm -f fiestaboard-int-$i mock-board-$i mock-cloud-$i 2>/dev/null || true
           done
 
       - name: Upload test results

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -85,6 +85,29 @@ services:
         max-size: "10m"
         max-file: "3"
 
+  # Mock Vestaboard Cloud API (cloud.vestaboard.com) - for note-array integration tests
+  fiestaboard-mock-cloud:
+    image: python:3.11-alpine
+    container_name: fiestaboard-mock-cloud
+    volumes:
+      - ./integration-tests/mock-cloud/server.py:/server.py:ro
+    # Host port avoids collisions with the Local API mock (17000/17001).
+    # Inside the container the mock listens on 9200 (Vestaboard Cloud API).
+    ports:
+      - "19200:9200"
+    environment:
+      - PORT=9200
+      - ROWS=6
+      - COLS=30
+    command: python /server.py
+    networks:
+      - fiestaboard-dev
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
   # Storybook - Component development and testing (opt-in via profile)
   fiestaboard-storybook:
     image: node:20-alpine

--- a/integration-tests/mock-cloud/server.py
+++ b/integration-tests/mock-cloud/server.py
@@ -1,0 +1,248 @@
+"""Mock Vestaboard Cloud API server for note-array integration testing.
+
+Simulates the Vestaboard Cloud API (``https://cloud.vestaboard.com/``) used by
+note-array boards, so the FiestaBoard backend can be tested end-to-end without
+a real board or Vestaboard account. Stdlib-only — mirrors ``mock-board/server.py``
+and ``mock-llm/server.py``.
+
+The note-array Cloud API (see ``src/board_client.py``) uses:
+  * POST ``/`` with header ``X-Vestaboard-Token`` and body ``{"characters": grid}``
+    where ``grid`` is a rectangular ``rows×cols`` int array. Success is any 2xx.
+  * GET ``/`` with header ``X-Vestaboard-Token`` returning
+    ``{"currentMessage": {"layout": "<json-string-grid>", "id": "..."}}`` —
+    note that ``layout`` is a JSON *string* encoding the 2-D int array.
+
+Endpoints
+---------
+
+Cloud API (mimics cloud.vestaboard.com):
+    POST /   - Send a note-array message ({"characters": grid})
+    GET  /   - Read the current display state (currentMessage.layout)
+
+Mock control:
+    GET  /mock/state   - Return current grid, configured dims, request count, history
+    POST /mock/reset   - Reset the grid to all-zeros (configured/default dims)
+
+Env vars
+--------
+PORT   - listen port (default 9200)
+ROWS   - configured array rows (default 6); when ROWS or COLS is set, incoming
+         POSTs are validated against the configured dimensions.
+COLS   - configured array cols (default 30; 6×30 = a 2×2 note array)
+
+The defaults match the ``fiestaboard-mock-cloud`` compose service and the CI job.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import UTC, datetime
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from threading import Lock
+
+logger = logging.getLogger(__name__)
+
+MAX_CHAR_CODE = 71
+
+# Configured at startup from env. When ROWS or COLS is explicitly set, incoming
+# POSTs are validated against these dimensions; otherwise any valid grid is
+# accepted and stored as-is.
+_ROWS = int(os.environ.get("ROWS", "6"))
+_COLS = int(os.environ.get("COLS", "30"))
+_STRICT_DIMS = bool(os.environ.get("ROWS") or os.environ.get("COLS"))
+
+
+class MockCloudState:
+    """Thread-safe state container for the mock Cloud API."""
+
+    def __init__(self, rows: int, cols: int) -> None:
+        self._lock = Lock()
+        self._rows = rows
+        self._cols = cols
+        self.reset()
+
+    def reset(self) -> None:
+        with self._lock:
+            self.current_grid = [[0] * self._cols for _ in range(self._rows)]
+            self.history: list[dict] = []
+            self.request_count = 0
+
+    def set_grid(self, grid: list[list[int]]) -> None:
+        with self._lock:
+            self.current_grid = [row[:] for row in grid]
+            # Update internal dims to match the stored grid.
+            self._rows = len(grid)
+            self._cols = len(grid[0]) if grid else self._cols
+            self.history.append(
+                {
+                    "grid_dims": [self._rows, self._cols],
+                    "timestamp": datetime.now(UTC).isoformat(),
+                }
+            )
+            self.request_count += 1
+
+    def get_grid(self) -> list[list[int]]:
+        with self._lock:
+            return [row[:] for row in self.current_grid]
+
+    def get_state(self) -> dict:
+        with self._lock:
+            return {
+                "current_grid": self.current_grid,
+                "configured_rows": self._rows,
+                "configured_cols": self._cols,
+                "request_count": self.request_count,
+                "history": self.history[-10:],
+            }
+
+
+STATE = MockCloudState(_ROWS, _COLS)
+
+
+def _grid_dimensions(grid) -> tuple[int, int] | None:
+    """Return (rows, cols) for a rectangular int grid, or None if malformed."""
+    if not isinstance(grid, list) or len(grid) == 0:
+        return None
+    if not isinstance(grid[0], list):
+        return None
+    cols = len(grid[0])
+    for row in grid:
+        if not isinstance(row, list) or len(row) != cols:
+            return None
+    return (len(grid), cols)
+
+
+class Handler(BaseHTTPRequestHandler):
+    """HTTP handler that mimics the Vestaboard Cloud API for note arrays."""
+
+    # ----- helpers ---------------------------------------------------------
+
+    def _send_json(self, status: int, payload: dict) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _read_json(self) -> dict | None:
+        length = int(self.headers.get("Content-Length") or 0)
+        if length == 0:
+            return None
+        raw = self.rfile.read(length)
+        try:
+            return json.loads(raw.decode("utf-8"))
+        except json.JSONDecodeError:
+            return None
+
+    def _token(self) -> str | None:
+        """Return the X-Vestaboard-Token header value, or None if absent/empty."""
+        return self.headers.get("X-Vestaboard-Token") or None
+
+    # ----- routes ----------------------------------------------------------
+
+    def do_GET(self) -> None:
+        if self.path == "/":
+            if self._token() is None:
+                self._send_json(401, {"error": "Missing or invalid X-Vestaboard-Token"})
+                return
+            grid = STATE.get_grid()
+            self._send_json(
+                200,
+                {
+                    "currentMessage": {
+                        "layout": json.dumps(grid),
+                        "id": "mock-layout-id",
+                    },
+                },
+            )
+            return
+
+        if self.path == "/mock/state":
+            self._send_json(200, STATE.get_state())
+            return
+
+        self._send_json(404, {"error": "Not found"})
+
+    def do_POST(self) -> None:
+        if self.path == "/":
+            if self._token() is None:
+                self._send_json(401, {"error": "Missing or invalid X-Vestaboard-Token"})
+                return
+
+            body = self._read_json()
+            if not isinstance(body, dict) or not isinstance(body.get("characters"), list):
+                self._send_json(400, {"error": "Request must include 'characters'"})
+                return
+
+            grid = body["characters"]
+            dims = _grid_dimensions(grid)
+            if dims is None:
+                self._send_json(400, {"error": "Request must include 'characters'"})
+                return
+
+            rows, cols = dims
+            if _STRICT_DIMS and (rows != _ROWS or cols != _COLS):
+                self._send_json(
+                    400,
+                    {
+                        "error": (f"Grid dimensions {rows}x{cols} do not match configured array size {_ROWS}x{_COLS}"),
+                    },
+                )
+                return
+
+            for r_idx, row in enumerate(grid):
+                for c_idx, code in enumerate(row):
+                    if not isinstance(code, int) or isinstance(code, bool) or code < 0 or code > MAX_CHAR_CODE:
+                        self._send_json(
+                            400,
+                            {
+                                "error": (
+                                    f"Invalid character code {code} at row {r_idx}, "
+                                    f"col {c_idx}. Must be 0-{MAX_CHAR_CODE}."
+                                ),
+                            },
+                        )
+                        return
+
+            STATE.set_grid(grid)
+            self._send_json(200, {"ok": True})
+            return
+
+        if self.path == "/mock/reset":
+            STATE.reset()
+            self._send_json(200, {"ok": True, "message": "Mock reset"})
+            return
+
+        self._send_json(404, {"error": "Not found"})
+
+    def log_message(self, fmt: str, *args) -> None:
+        """Suppress default request logging to keep CI output readable."""
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s mock-cloud %(levelname)s %(message)s",
+    )
+    port = int(os.environ.get("PORT", "9200"))
+    server = HTTPServer(("0.0.0.0", port), Handler)
+    logger.info(
+        "Mock Cloud API listening on 0.0.0.0:%d (rows=%d, cols=%d, strict_dims=%s)",
+        port,
+        _ROWS,
+        _COLS,
+        _STRICT_DIMS,
+    )
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        logger.info("KeyboardInterrupt received, shutting down mock Cloud API server.")
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/integration-tests/test_cloud_mock.py
+++ b/integration-tests/test_cloud_mock.py
@@ -1,0 +1,259 @@
+"""Integration tests for the note-array Cloud API mock server.
+
+Exercises ``integration-tests/mock-cloud/server.py`` (the stdlib-only mock of
+``https://cloud.vestaboard.com/``) and the round-trip behaviour of
+``src.board_client.BoardClient`` against it.
+
+The mock server is started in-process on an ephemeral port via a pytest
+fixture, so these tests run standalone (``pytest integration-tests/test_cloud_mock.py``)
+with only ``pytest`` + ``httpx`` installed — no Docker, no real network.
+
+``BoardClient`` is pointed at the mock by monkeypatching its class-level
+``CLOUD_NOTE_ARRAY_API_URL`` constant, mirroring the established integration
+pattern (real HTTP to a local mock instead of ``requests`` patching).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from collections.abc import Iterator
+from http.server import HTTPServer
+from pathlib import Path
+from threading import Thread
+
+import httpx
+import pytest
+
+_HERE = Path(__file__).resolve().parent
+_PROJECT_ROOT = _HERE.parent
+
+# Default note-array geometry used by the mock + these tests (a 2×2 grid).
+ROWS = 6
+COLS = 30
+
+
+def _load_mock_module():
+    """Import mock-cloud/server.py as a module (the dir name isn't importable)."""
+    server_path = _HERE / "mock-cloud" / "server.py"
+    spec = importlib.util.spec_from_file_location("mock_cloud_server", server_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+_mock = _load_mock_module()
+
+
+def _grid(rows: int = ROWS, cols: int = COLS, fill: int = 0) -> list[list[int]]:
+    return [[fill] * cols for _ in range(rows)]
+
+
+@pytest.fixture
+def mock_server(monkeypatch: pytest.MonkeyPatch) -> Iterator[str]:
+    """Start the in-process mock Cloud API on an ephemeral port.
+
+    Yields the base URL (``http://127.0.0.1:<port>/``). The mock is configured
+    in strict 6×30 mode (matching the compose/CI ``ROWS``/``COLS`` env) so
+    dimension validation is exercised deterministically. State is reset before
+    each test via the mock's own ``reset()`` so tests stay isolated.
+    """
+    monkeypatch.setattr(_mock, "_ROWS", ROWS)
+    monkeypatch.setattr(_mock, "_COLS", COLS)
+    monkeypatch.setattr(_mock, "_STRICT_DIMS", True)
+    monkeypatch.setattr(_mock, "STATE", _mock.MockCloudState(ROWS, COLS))
+    server = HTTPServer(("127.0.0.1", 0), _mock.Handler)
+    port = server.server_address[1]
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{port}/"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+@pytest.fixture
+def client(mock_server: str) -> httpx.Client:
+    with httpx.Client(base_url=mock_server, timeout=5.0) as c:
+        yield c
+
+
+_TOKEN_HEADERS = {"X-Vestaboard-Token": "test-tok", "Content-Type": "application/json"}
+
+
+class TestMockCloudServerPOST:
+    def test_post_valid_6x30_grid_returns_200(self, client: httpx.Client) -> None:
+        resp = client.post("/", json={"characters": _grid()}, headers=_TOKEN_HEADERS)
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True}
+
+    def test_post_stores_grid_readable_via_mock_state(self, client: httpx.Client) -> None:
+        grid = _grid()
+        grid[0][0] = 1
+        grid[5][29] = 71
+        resp = client.post("/", json={"characters": grid}, headers=_TOKEN_HEADERS)
+        assert resp.status_code == 200
+
+        state = client.get("/mock/state").json()
+        assert state["current_grid"] == grid
+        assert state["request_count"] == 1
+
+    def test_post_missing_token_returns_401(self, client: httpx.Client) -> None:
+        resp = client.post(
+            "/",
+            json={"characters": _grid()},
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code == 401
+
+    def test_post_wrong_token_still_accepted(self, client: httpx.Client) -> None:
+        # The mock validates header *presence*, not the token *value* — value
+        # correctness is an app-level concern.
+        resp = client.post(
+            "/",
+            json={"characters": _grid()},
+            headers={"X-Vestaboard-Token": "wrong-tok", "Content-Type": "application/json"},
+        )
+        assert resp.status_code == 200
+
+    def test_post_missing_characters_key_returns_400(self, client: httpx.Client) -> None:
+        resp = client.post("/", json={"text": "hello"}, headers=_TOKEN_HEADERS)
+        assert resp.status_code == 400
+
+    def test_post_invalid_grid_wrong_dimensions_returns_400(self, client: httpx.Client) -> None:
+        # Mock defaults to strict 6×30; a 6×22 grid must be rejected.
+        resp = client.post("/", json={"characters": _grid(6, 22)}, headers=_TOKEN_HEADERS)
+        assert resp.status_code == 400
+
+    def test_post_invalid_cell_value_returns_400(self, client: httpx.Client) -> None:
+        grid = _grid()
+        grid[2][7] = 999
+        resp = client.post("/", json={"characters": grid}, headers=_TOKEN_HEADERS)
+        assert resp.status_code == 400
+
+
+class TestMockCloudServerGET:
+    def test_get_after_post_returns_layout_with_correct_dimensions(self, client: httpx.Client) -> None:
+        client.post("/", json={"characters": _grid()}, headers=_TOKEN_HEADERS)
+        resp = client.get("/", headers=_TOKEN_HEADERS)
+        assert resp.status_code == 200
+        layout = json.loads(resp.json()["currentMessage"]["layout"])
+        assert len(layout) == ROWS
+        assert all(len(row) == COLS for row in layout)
+
+    def test_get_layout_value_matches_posted_grid(self, client: httpx.Client) -> None:
+        grid = _grid()
+        grid[1][3] = 5
+        grid[4][20] = 63
+        client.post("/", json={"characters": grid}, headers=_TOKEN_HEADERS)
+        resp = client.get("/", headers=_TOKEN_HEADERS)
+        layout = json.loads(resp.json()["currentMessage"]["layout"])
+        assert layout == grid
+
+    def test_get_missing_token_returns_401(self, client: httpx.Client) -> None:
+        resp = client.get("/")
+        assert resp.status_code == 401
+
+    def test_get_returns_id_field(self, client: httpx.Client) -> None:
+        resp = client.get("/", headers=_TOKEN_HEADERS)
+        message_id = resp.json()["currentMessage"]["id"]
+        assert isinstance(message_id, str)
+        assert message_id
+
+    def test_get_before_any_post_returns_blank_grid(self, client: httpx.Client) -> None:
+        client.post("/mock/reset")
+        resp = client.get("/", headers=_TOKEN_HEADERS)
+        layout = json.loads(resp.json()["currentMessage"]["layout"])
+        assert all(cell == 0 for row in layout for cell in row)
+
+
+class TestMockCloudServerReset:
+    def test_reset_clears_grid(self, client: httpx.Client) -> None:
+        grid = _grid(fill=10)
+        client.post("/", json={"characters": grid}, headers=_TOKEN_HEADERS)
+        client.post("/mock/reset")
+        resp = client.get("/", headers=_TOKEN_HEADERS)
+        layout = json.loads(resp.json()["currentMessage"]["layout"])
+        assert all(cell == 0 for row in layout for cell in row)
+
+    def test_reset_resets_request_count(self, client: httpx.Client) -> None:
+        client.post("/", json={"characters": _grid(fill=1)}, headers=_TOKEN_HEADERS)
+        client.post("/", json={"characters": _grid(fill=2)}, headers=_TOKEN_HEADERS)
+        client.post("/mock/reset")
+        state = client.get("/mock/state").json()
+        assert state["request_count"] == 0
+
+
+@pytest.fixture
+def board_client_module(monkeypatch: pytest.MonkeyPatch, mock_server: str):
+    """Import ``src.board_client`` with its Cloud URL redirected to the mock."""
+    if str(_PROJECT_ROOT) not in sys.path:
+        sys.path.insert(0, str(_PROJECT_ROOT))
+    from src import board_client
+
+    monkeypatch.setattr(board_client.BoardClient, "CLOUD_NOTE_ARRAY_API_URL", mock_server)
+    return board_client
+
+
+class TestBoardClientIntegrationWithMock:
+    def test_board_client_send_characters_to_mock_succeeds(self, board_client_module) -> None:
+        client = board_client_module.BoardClient(
+            api_key="tok",
+            use_cloud=True,
+            note_array_token="tok",
+            notes_wide=2,
+            notes_tall=2,
+        )
+        success, was_sent = client.send_characters(_grid(fill=4))
+        assert (success, was_sent) == (True, True)
+
+    def test_board_client_read_current_message_from_mock(self, board_client_module, client: httpx.Client) -> None:
+        grid = _grid()
+        grid[0][0] = 9
+        grid[5][29] = 50
+        client.post("/", json={"characters": grid}, headers=_TOKEN_HEADERS)
+
+        board = board_client_module.BoardClient(
+            api_key="tok",
+            use_cloud=True,
+            note_array_token="tok",
+            notes_wide=2,
+            notes_tall=2,
+        )
+        result = board.read_current_message()
+        assert result is not None
+        assert len(result) == ROWS
+        assert all(len(row) == COLS for row in result)
+        assert result == grid
+
+    def test_board_client_send_then_read_roundtrip(self, board_client_module) -> None:
+        grid = _grid()
+        grid[2][10] = 33
+        grid[3][15] = 17
+
+        board = board_client_module.BoardClient(
+            api_key="tok",
+            use_cloud=True,
+            note_array_token="tok",
+            notes_wide=2,
+            notes_tall=2,
+        )
+        success, _ = board.send_characters(grid)
+        assert success is True
+
+        result = board.read_current_message()
+        assert result == grid
+
+    def test_board_client_missing_token_raises(self, board_client_module) -> None:
+        # An empty api_key is rejected end-to-end, confirming token enforcement.
+        with pytest.raises(ValueError, match="api_key is required"):
+            board_client_module.BoardClient(
+                api_key="",
+                use_cloud=True,
+                note_array_token="",
+                notes_wide=2,
+                notes_tall=2,
+            )


### PR DESCRIPTION
Closes #1181. Part of the Note Arrays epic #1167. Targets `next`.

## What
A mock of the note-array Cloud API (`https://cloud.vestaboard.com/`) so integration/E2E tests can exercise note-array send/read without hitting the real service. Blocks #1179.

- **NEW `integration-tests/mock-cloud/server.py`** — stdlib-only server. `POST /` validates `X-Vestaboard-Token` (401 if absent), requires `{"characters": grid}` (400 otherwise), enforces configured `ROWS`/`COLS` and cell codes 0–71; `GET /` returns `{"currentMessage": {"layout": "<json grid>", "id": ...}}`. Control endpoints `GET /mock/state`, `POST /mock/reset`. Configurable via `PORT`/`ROWS`/`COLS` (default 9200 / 6×30 = a 2×2 array). Mirrors `mock-llm/server.py` + `mock-board/server.py`.
- **NEW `integration-tests/test_cloud_mock.py`** — 18 pytest cases (POST, GET, reset, and `BoardClient` round-trip) running the mock in-process on an ephemeral port.
- **EDIT `docker-compose.dev.yml`** — `fiestaboard-mock-cloud` service (host 19200→9200), a direct copy of `fiestaboard-mock-board`.
- **EDIT `.github/workflows/integration-tests.yml`** — start mock-cloud alongside mock-board in both the PR smoke path and the merge-queue full-suite path; pass `MOCK_CLOUD_URL`(S) to Playwright; add to cleanup.

## Verification
- `integration-tests/test_cloud_mock.py`: **18 passed**
- `ruff check` / `format`: clean
- `yaml.safe_load` of both edited YAML files: OK

The compose service + CI wiring are syntactically valid and faithful to the existing mock-board pattern; their runtime behavior is validated by CI. Disjoint from the other in-flight Wave-3 PRs (#1172, #1169).

🤖 Generated with [Claude Code](https://claude.com/claude-code)