### PR TITLE
feat(web): hybrid fit/actual-size board preview with horizontal scroll [#1177]

### DIFF
--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -1326,7 +1326,10 @@
     "loading": "Board-Anzeige wird geladen",
     "empty": "Leere Board-Anzeige",
     "preview": "Board-Vorschau",
-    "withMessage": "Board-Anzeige: {message}"
+    "withMessage": "Board-Anzeige: {message}",
+    "previewSizeLabel": "Vorschaugröße",
+    "fitMode": "Anpassen",
+    "actualMode": "Tatsächliche Größe"
   },
   "updateOverlay": {
     "takingLonger": "Aktualisierung dauert länger als erwartet",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1283,7 +1283,10 @@
     "loading": "Loading board display",
     "empty": "Empty board display",
     "preview": "Board preview",
-    "withMessage": "Board display: {message}"
+    "withMessage": "Board display: {message}",
+    "previewSizeLabel": "Preview size",
+    "fitMode": "Fit",
+    "actualMode": "Actual size"
   },
   "updateOverlay": {
     "takingLonger": "Update taking longer than expected",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -1326,7 +1326,10 @@
     "loading": "Cargando visualización del tablero",
     "empty": "Visualización del tablero vacía",
     "preview": "Vista previa del tablero",
-    "withMessage": "Visualización del tablero: {message}"
+    "withMessage": "Visualización del tablero: {message}",
+    "previewSizeLabel": "Tamaño de vista previa",
+    "fitMode": "Ajustar",
+    "actualMode": "Tamaño real"
   },
   "updateOverlay": {
     "takingLonger": "La actualización está tardando más de lo esperado",

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -1326,7 +1326,10 @@
     "loading": "Chargement de l'affichage du tableau",
     "empty": "Affichage du tableau vide",
     "preview": "Aperçu du tableau",
-    "withMessage": "Affichage du tableau : {message}"
+    "withMessage": "Affichage du tableau : {message}",
+    "previewSizeLabel": "Taille de l'aperçu",
+    "fitMode": "Ajuster",
+    "actualMode": "Taille réelle"
   },
   "updateOverlay": {
     "takingLonger": "La mise à jour prend plus de temps que prévu",

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -1326,7 +1326,10 @@
     "loading": "Caricamento display board",
     "empty": "Display board vuoto",
     "preview": "Anteprima board",
-    "withMessage": "Display board: {message}"
+    "withMessage": "Display board: {message}",
+    "previewSizeLabel": "Dimensione anteprima",
+    "fitMode": "Adatta",
+    "actualMode": "Dimensione reale"
   },
   "updateOverlay": {
     "takingLonger": "L'aggiornamento sta impiegando più del previsto",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -1326,7 +1326,10 @@
     "loading": "ボード表示を読み込み中",
     "empty": "ボード表示は空です",
     "preview": "ボードプレビュー",
-    "withMessage": "ボード表示: {message}"
+    "withMessage": "ボード表示: {message}",
+    "previewSizeLabel": "プレビューサイズ",
+    "fitMode": "全体表示",
+    "actualMode": "実寸表示"
   },
   "updateOverlay": {
     "takingLonger": "更新に予想より時間がかかっています",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -1326,7 +1326,10 @@
     "loading": "보드 디스플레이 로드 중",
     "empty": "보드 디스플레이가 비어 있음",
     "preview": "보드 미리보기",
-    "withMessage": "보드 디스플레이: {message}"
+    "withMessage": "보드 디스플레이: {message}",
+    "previewSizeLabel": "미리보기 크기",
+    "fitMode": "맞춤",
+    "actualMode": "실제 크기"
   },
   "updateOverlay": {
     "takingLonger": "업데이트가 예상보다 오래 걸립니다",

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -1326,7 +1326,10 @@
     "loading": "Board-weergave laden",
     "empty": "Lege board-weergave",
     "preview": "Board-preview",
-    "withMessage": "Board-weergave: {message}"
+    "withMessage": "Board-weergave: {message}",
+    "previewSizeLabel": "Voorbeeldgrootte",
+    "fitMode": "Passend",
+    "actualMode": "Werkelijke grootte"
   },
   "updateOverlay": {
     "takingLonger": "Update duurt langer dan verwacht",

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -1326,7 +1326,10 @@
     "loading": "Ładowanie wyświetlacza boarda",
     "empty": "Pusty wyświetlacz boarda",
     "preview": "Podgląd boarda",
-    "withMessage": "Wyświetlacz boarda: {message}"
+    "withMessage": "Wyświetlacz boarda: {message}",
+    "previewSizeLabel": "Rozmiar podglądu",
+    "fitMode": "Dopasuj",
+    "actualMode": "Rzeczywisty rozmiar"
   },
   "updateOverlay": {
     "takingLonger": "Aktualizacja trwa dłużej niż oczekiwano",

--- a/web/messages/pt.json
+++ b/web/messages/pt.json
@@ -1326,7 +1326,10 @@
     "loading": "A carregar visualização do board",
     "empty": "Visualização do board vazia",
     "preview": "Pré-visualização do board",
-    "withMessage": "Visualização do board: {message}"
+    "withMessage": "Visualização do board: {message}",
+    "previewSizeLabel": "Tamanho da pré-visualização",
+    "fitMode": "Ajustar",
+    "actualMode": "Tamanho real"
   },
   "updateOverlay": {
     "takingLonger": "A atualização está a demorar mais do que o esperado",

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -1326,7 +1326,10 @@
     "loading": "Загрузка дисплея board",
     "empty": "Пустой дисплей board",
     "preview": "Предпросмотр board",
-    "withMessage": "Дисплей board: {message}"
+    "withMessage": "Дисплей board: {message}",
+    "previewSizeLabel": "Размер предпросмотра",
+    "fitMode": "По ширине",
+    "actualMode": "Реальный размер"
   },
   "updateOverlay": {
     "takingLonger": "Обновление занимает больше времени, чем ожидалось",

--- a/web/messages/sv.json
+++ b/web/messages/sv.json
@@ -1326,7 +1326,10 @@
     "loading": "Laddar board-display",
     "empty": "Tom board-display",
     "preview": "Board-förhandsgranskning",
-    "withMessage": "Board-display: {message}"
+    "withMessage": "Board-display: {message}",
+    "previewSizeLabel": "Förhandsvisningsstorlek",
+    "fitMode": "Anpassa",
+    "actualMode": "Verklig storlek"
   },
   "updateOverlay": {
     "takingLonger": "Uppdateringen tar längre tid än väntat",

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -1326,7 +1326,10 @@
     "loading": "Board ekranı yükleniyor",
     "empty": "Boş board ekranı",
     "preview": "Board önizlemesi",
-    "withMessage": "Board ekranı: {message}"
+    "withMessage": "Board ekranı: {message}",
+    "previewSizeLabel": "Önizleme boyutu",
+    "fitMode": "Sığdır",
+    "actualMode": "Gerçek boyut"
   },
   "updateOverlay": {
     "takingLonger": "Güncelleme beklenenden uzun sürüyor",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -1326,7 +1326,10 @@
     "loading": "加载 board 显示中",
     "empty": "Board 显示为空",
     "preview": "Board 预览",
-    "withMessage": "Board 显示:{message}"
+    "withMessage": "Board 显示:{message}",
+    "previewSizeLabel": "预览尺寸",
+    "fitMode": "适应",
+    "actualMode": "实际大小"
   },
   "updateOverlay": {
     "takingLonger": "更新比预期时间更长",

--- a/web/src/__tests__/scaled-board-display.test.tsx
+++ b/web/src/__tests__/scaled-board-display.test.tsx
@@ -1,0 +1,118 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen } from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { ScaledBoardDisplay } from "@/components/scaled-board-display";
+import { ConfigOverridesProvider } from "@/hooks/use-config-overrides";
+import { ThemeProvider } from "@/hooks/use-theme";
+
+const MODE_STORAGE_KEY = "fiestaboard:boardPreviewMode";
+
+function TestWrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ConfigOverridesProvider>
+        <ThemeProvider attribute="class" defaultTheme="light">
+          {children}
+        </ThemeProvider>
+      </ConfigOverridesProvider>
+    </QueryClientProvider>
+  );
+}
+
+describe("ScaledBoardDisplay preview-size toggle", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+  });
+  afterEach(() => {
+    window.sessionStorage.clear();
+  });
+
+  it("renders no toggle for a flagship device", () => {
+    render(<ScaledBoardDisplay message="" deviceType="flagship" isStatic />, { wrapper: TestWrapper });
+    expect(screen.queryByRole("button", { name: "Fit" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Actual size" })).toBeNull();
+  });
+
+  it("renders no toggle for a note device", () => {
+    render(<ScaledBoardDisplay message="" deviceType="note" isStatic />, { wrapper: TestWrapper });
+    expect(screen.queryByRole("group", { name: "Preview size" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Fit" })).toBeNull();
+  });
+
+  it("renders the toggle for a note_array device", () => {
+    render(<ScaledBoardDisplay message="" deviceType="note_array" notesWide={4} notesTall={1} isStatic />, {
+      wrapper: TestWrapper,
+    });
+    expect(screen.getByRole("group", { name: "Preview size" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Fit" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Actual size" })).toBeInTheDocument();
+  });
+
+  it("defaults to fit mode (no scroll container) when nothing is persisted", () => {
+    const { container } = render(
+      <ScaledBoardDisplay message="" deviceType="note_array" notesWide={4} notesTall={1} isStatic />,
+      { wrapper: TestWrapper },
+    );
+    expect(container.querySelector("[data-testid='actual-size-scroll']")).toBeNull();
+    expect(screen.getByRole("button", { name: "Fit" })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: "Actual size" })).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("switches to actual mode, shows the scroll container, and persists to sessionStorage", () => {
+    const { container } = render(
+      <ScaledBoardDisplay message="" deviceType="note_array" notesWide={4} notesTall={1} isStatic />,
+      { wrapper: TestWrapper },
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Actual size" }));
+
+    const scroll = container.querySelector("[data-testid='actual-size-scroll']") as HTMLElement | null;
+    expect(scroll).not.toBeNull();
+    // Tailwind `overflow-x-auto` → CSS `overflow-x: auto` on the scroll container.
+    expect(scroll).toHaveClass("overflow-x-auto");
+    expect(screen.getByRole("button", { name: "Actual size" })).toHaveAttribute("aria-pressed", "true");
+    expect(window.sessionStorage.getItem(MODE_STORAGE_KEY)).toBe("actual");
+  });
+
+  it("switches back to fit mode and persists it", () => {
+    const { container } = render(
+      <ScaledBoardDisplay message="" deviceType="note_array" notesWide={4} notesTall={1} isStatic />,
+      { wrapper: TestWrapper },
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Actual size" }));
+    expect(container.querySelector("[data-testid='actual-size-scroll']")).not.toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Fit" }));
+    expect(container.querySelector("[data-testid='actual-size-scroll']")).toBeNull();
+    expect(window.sessionStorage.getItem(MODE_STORAGE_KEY)).toBe("fit");
+  });
+
+  it("reads the persisted mode back on re-mount", () => {
+    window.sessionStorage.setItem(MODE_STORAGE_KEY, "actual");
+    const { container } = render(
+      <ScaledBoardDisplay message="" deviceType="note_array" notesWide={4} notesTall={1} isStatic />,
+      { wrapper: TestWrapper },
+    );
+    expect(container.querySelector("[data-testid='actual-size-scroll']")).not.toBeNull();
+    expect(screen.getByRole("button", { name: "Actual size" })).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("ignores a persisted 'actual' mode for flagship boards (always fit, no toggle)", () => {
+    window.sessionStorage.setItem(MODE_STORAGE_KEY, "actual");
+    const { container } = render(<ScaledBoardDisplay message="" deviceType="flagship" isStatic />, {
+      wrapper: TestWrapper,
+    });
+    // No toggle and no scroll container — flagship rendering is unchanged.
+    expect(screen.queryByRole("group", { name: "Preview size" })).toBeNull();
+    expect(container.querySelector("[data-testid='actual-size-scroll']")).toBeNull();
+  });
+});

--- a/web/src/components/scaled-board-display.tsx
+++ b/web/src/components/scaled-board-display.tsx
@@ -3,8 +3,38 @@
 import { useLayoutEffect, useRef, useState } from "react";
 
 import { BoardDisplay } from "@/components/board-display";
+import { useTranslations } from "@/i18n/translations";
+import { isNoteArray } from "@/lib/board-dimensions";
+import { cn } from "@/lib/utils";
 
 type BoardProps = React.ComponentProps<typeof BoardDisplay>;
+
+type DisplayMode = "fit" | "actual";
+
+/** sessionStorage key persisting the preview mode across re-mounts in a tab. */
+const MODE_STORAGE_KEY = "fiestaboard:boardPreviewMode";
+
+/** Read the persisted preview mode, guarding for SSR / no sessionStorage. */
+function readStoredMode(): DisplayMode {
+  if (typeof window === "undefined") return "fit";
+  try {
+    const stored = window.sessionStorage.getItem(MODE_STORAGE_KEY);
+    return stored === "actual" ? "actual" : "fit";
+  } catch {
+    // sessionStorage can throw (private mode, blocked storage) — fall back.
+    return "fit";
+  }
+}
+
+/** Persist the preview mode, swallowing storage failures. */
+function writeStoredMode(mode: DisplayMode): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.setItem(MODE_STORAGE_KEY, mode);
+  } catch {
+    // Ignore — persistence is best-effort.
+  }
+}
 
 /**
  * Wraps {@link BoardDisplay} so it shrinks to fit a narrow parent.
@@ -14,19 +44,46 @@ type BoardProps = React.ComponentProps<typeof BoardDisplay>;
  * stops responding when the editor pane is squeezed by, say, the
  * resizable AI chat panel — the board overflows or gets clipped.
  *
- * Here we keep the natural tile rendering and just apply
- * `transform: scale()` based on the actual parent width measured at
- * runtime. We never scale UP — full size is always the cap, so the
- * board looks identical in roomy layouts.
+ * In the default **fit** mode we keep the natural tile rendering and just
+ * apply `transform: scale()` based on the actual parent width measured at
+ * runtime. We never scale UP — full size is always the cap, so the board
+ * looks identical in roomy layouts.
+ *
+ * For note-array boards (which can be very wide, e.g. 3×60, or very tall,
+ * e.g. 12×15) a small toggle switches to **actual** mode: tiles render at
+ * their natural readable size inside a horizontally-scrollable container,
+ * with no vertical clipping. The toggle is only rendered for note arrays,
+ * so flagship/note previews are visually unchanged.
  */
 export function ScaledBoardDisplay(props: BoardProps) {
+  const t = useTranslations("boardDisplay");
   const containerRef = useRef<HTMLDivElement>(null);
   const boardRef = useRef<HTMLDivElement>(null);
   const [scale, setScale] = useState(1);
   const [scaledWidth, setScaledWidth] = useState<number | null>(null);
   const [scaledHeight, setScaledHeight] = useState<number | null>(null);
 
+  // The toggle only exists for note arrays; flagship/note always fit.
+  const showToggle = isNoteArray(props.deviceType ?? "flagship");
+
+  // Lazily read the persisted mode on mount (guarded for SSR/no-window).
+  const [displayMode, setDisplayMode] = useState<DisplayMode>(() => readStoredMode());
+
+  // Effective mode: only note arrays can ever be "actual". This keeps the
+  // scaling effect below active for flagship/note even if some other tab
+  // left "actual" in sessionStorage.
+  const mode: DisplayMode = showToggle ? displayMode : "fit";
+
+  const setMode = (next: DisplayMode) => {
+    setDisplayMode(next);
+    writeStoredMode(next);
+  };
+
   useLayoutEffect(() => {
+    // In actual-size mode we render at natural scale with no transform box,
+    // so there's nothing to measure or observe — bail early.
+    if (mode !== "fit") return;
+
     const container = containerRef.current;
     const board = boardRef.current;
     if (!container || !board) return;
@@ -86,35 +143,86 @@ export function ScaledBoardDisplay(props: BoardProps) {
       ro.disconnect();
       if (rafId !== null) cancelAnimationFrame(rafId);
     };
-  }, [props.message, props.size, props.deviceType]);
+  }, [props.message, props.size, props.deviceType, mode]);
+
+  const toggle = showToggle ? (
+    <div className="mb-1 flex w-full justify-center" role="group" aria-label={t("previewSizeLabel")}>
+      <div className="flex gap-1">
+        <button
+          type="button"
+          onClick={() => setMode("fit")}
+          aria-pressed={mode === "fit"}
+          className={cn(
+            "rounded-full border px-2.5 py-1 text-[11px] transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none",
+            mode === "fit"
+              ? "border-primary bg-primary/10 text-foreground"
+              : "border-transparent text-muted-foreground hover:text-foreground",
+          )}
+        >
+          {t("fitMode")}
+        </button>
+        <button
+          type="button"
+          onClick={() => setMode("actual")}
+          aria-pressed={mode === "actual"}
+          className={cn(
+            "rounded-full border px-2.5 py-1 text-[11px] transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none",
+            mode === "actual"
+              ? "border-primary bg-primary/10 text-foreground"
+              : "border-transparent text-muted-foreground hover:text-foreground",
+          )}
+        >
+          {t("actualMode")}
+        </button>
+      </div>
+    </div>
+  ) : null;
+
+  if (mode === "actual") {
+    // Actual size: render at natural scale, scroll horizontally for wide
+    // boards, and let tall boards flow without any vertical clipping.
+    return (
+      <div className="w-full min-w-0">
+        {toggle}
+        <div data-testid="actual-size-scroll" className="w-full overflow-x-auto" style={{ overflowY: "visible" }}>
+          <BoardDisplay {...props} />
+        </div>
+      </div>
+    );
+  }
 
   return (
-    // Outer: full-width, centers the scaled board horizontally.
-    //
-    // Middle: a fixed-size box that matches the *post-scale* dimensions.
-    // This keeps surrounding layout (e.g. preview margin, the live-output
-    // toggle below) honest — without it, the BoardDisplay's natural
-    // 779px-wide layout box would still take that much room and push
-    // siblings around.
-    //
-    // Inner: the BoardDisplay itself, transformed from its top-left so
-    // the visible content lines up with the middle box from x=0.
-    <div ref={containerRef} className="flex w-full min-w-0 justify-center overflow-hidden">
-      <div
-        style={{
-          width: scaledWidth ?? undefined,
-          height: scaledHeight ?? undefined,
-        }}
-      >
+    <div className="w-full min-w-0">
+      {toggle}
+      {/*
+        Outer: full-width, centers the scaled board horizontally.
+
+        Middle: a fixed-size box that matches the *post-scale* dimensions.
+        This keeps surrounding layout (e.g. preview margin, the live-output
+        toggle below) honest — without it, the BoardDisplay's natural
+        779px-wide layout box would still take that much room and push
+        siblings around.
+
+        Inner: the BoardDisplay itself, transformed from its top-left so
+        the visible content lines up with the middle box from x=0.
+      */}
+      <div ref={containerRef} className="flex w-full min-w-0 justify-center overflow-hidden">
         <div
-          ref={boardRef}
           style={{
-            transform: `scale(${scale})`,
-            transformOrigin: "top left",
-            width: "fit-content",
+            width: scaledWidth ?? undefined,
+            height: scaledHeight ?? undefined,
           }}
         >
-          <BoardDisplay {...props} />
+          <div
+            ref={boardRef}
+            style={{
+              transform: `scale(${scale})`,
+              transformOrigin: "top left",
+              width: "fit-content",
+            }}
+          >
+            <BoardDisplay {...props} />
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Closes #1177. Part of the Note Arrays epic #1167. Targets `next`.

## What
Extends `ScaledBoardDisplay` with a **fit-to-width default** + an **"Actual size"** toggle for note-array previews:

- **Fit** (default): existing `transform: scale()` behavior — board shrinks to fill the pane.
- **Actual size**: renders tiles at natural size in an `overflow-x: auto` container so wide configs (3×60) scroll horizontally; height is unclipped so tall configs (12×15) render fully.
- The toggle renders **only for `note_array` boards** (`isNoteArray(deviceType)`), so flagship/note previews are 100% unchanged. Mode is persisted in `sessionStorage` (`fiestaboard:boardPreviewMode`); an effective-mode guard forces flagship/note to fit even if another tab left "actual" stored.
- Compact pill segmented control mirroring the existing toggle style in `settings/display-settings.tsx`; `role="group"` + per-button `aria-pressed`; strings via `useTranslations("boardDisplay")` and added to all 14 locales.

No call-site changes (`page-builder.tsx`, `inline-board-preview.tsx` untouched).

## Tests
`web/src/__tests__/scaled-board-display.test.tsx` (8): no toggle for flagship/note; toggle for note_array; default fit (no scroll container); click → actual shows `overflow-x-auto` + persists; toggle back persists; re-mount reads persisted "actual"; flagship ignores persisted "actual".

## Verification (throwaway `node:26-alpine`, `npm ci --legacy-peer-deps` to match CI)
- targeted vitest: **8 passed**
- full vitest suite: **1116 passed, 13 skipped, 0 failed**
- `prettier --check`: clean · `eslint`: 0 errors

Acceptance criteria (3×60 fits then scrolls; 12×15 no vertical clip; flagship/note unchanged) are covered; live scroll behavior is exercised by CI Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)