### PR TITLE
test(board): comprehensive note-array coverage + end-to-end send/read [#1179]

### DIFF
--- a/tests/test_board_html_renderer.py
+++ b/tests/test_board_html_renderer.py
@@ -48,6 +48,59 @@ class TestDimensions:
         assert _count(html, 'class="row"') == 6
 
 
+class TestNoteArrayPresetRendering:
+    """Each note-array preset renders a grid sized to notes_wide × notes_tall.
+
+    Covers issue #1173's "every preset size renders + validates" requirement at
+    the renderer level: a note_array board is not the Note device, so its tiles
+    use the plain ``.tile`` class (no ``.note`` degree→heart substitution), and
+    the full grid is rows × cols where rows = notes_tall × 3, cols = notes_wide
+    × 15.
+    """
+
+    # (preset_id, notes_wide, notes_tall, expected_rows, expected_cols)
+    PRESETS = [
+        ("2_wide", 2, 1, 3, 30),
+        ("4_wide", 4, 1, 3, 60),
+        ("2_tall", 1, 2, 6, 15),
+        ("4_tall", 1, 4, 12, 15),
+        ("2x2_grid", 2, 2, 6, 30),
+    ]
+
+    def test_each_preset_renders_correct_row_count(self):
+        for preset_id, nw, nt, rows, _cols in self.PRESETS:
+            html = render_board_html("HI", device_type="note_array", notes_wide=nw, notes_tall=nt)
+            assert _count(html, 'class="row"') == rows, preset_id
+
+    def test_each_preset_renders_full_tile_grid(self):
+        for preset_id, nw, nt, rows, cols in self.PRESETS:
+            html = render_board_html("HI", device_type="note_array", notes_wide=nw, notes_tall=nt)
+            # Note arrays use the plain .tile class (not .note), so a total
+            # tile count of rows*cols proves the grid is fully laid out.
+            total = _count(html, 'class="tile"') + _count(html, 'class="tile note"')
+            assert total == rows * cols, preset_id
+            assert resolve_dimensions("note_array", notes_wide=nw, notes_tall=nt) == (rows, cols), preset_id
+
+    def test_note_array_tiles_are_not_note_class(self):
+        """note_array is distinct from the Note device — no .note tile styling."""
+        html = render_board_html("HI", device_type="note_array", notes_wide=2, notes_tall=1)
+        assert _count(html, 'class="tile note"') == 0
+        assert _count(html, 'class="tile"') == 3 * 30
+
+    def test_preset_label_shows_cols_by_rows(self):
+        """The optional label reports the note-array geometry as cols×rows."""
+        html = render_board_html("HI", device_type="note_array", notes_wide=4, notes_tall=1, page_name="Wide Board")
+        # Label format: "<name> · note_array <cols>×<rows>" (× is &times;).
+        assert "note_array 60&times;3" in html
+        assert "Wide Board" in html
+
+    def test_custom_3x3_array_renders(self):
+        """A non-preset 3×3 array (9×45) still renders a full grid."""
+        html = render_board_html("HI", device_type="note_array", notes_wide=3, notes_tall=3)
+        assert _count(html, 'class="row"') == 9
+        assert _count(html, 'class="tile"') == 9 * 45
+
+
 class TestCharacterRendering:
     def test_uppercases_letters(self):
         html = render_board_html("hi", device_type="flagship")

--- a/tests/test_debug_endpoints.py
+++ b/tests/test_debug_endpoints.py
@@ -407,3 +407,72 @@ class TestDebugUtilityFunctions:
             uptime = _get_service_uptime()
             assert uptime is not None
             assert 99 <= uptime <= 101  # Allow small variation
+
+
+class TestGetFirstBoardDims:
+    """Tests for _get_first_board_dims — the note-array geometry helper used by
+    /debug/fill, /debug/blank, /debug/info and the welcome message.
+
+    The debug-endpoint tests above exercise the dict-shaped board path; these
+    cover the object-attribute path, the empty-boards fallback, and the
+    exception fallback (the helper must never raise).
+    """
+
+    def _ss_with_boards(self, boards):
+        ss = Mock()
+        board_settings = Mock()
+        board_settings.boards = boards
+        ss.get_board_settings.return_value = board_settings
+        return ss
+
+    def test_note_array_dict_board_resolves_to_array_dims(self):
+        """A dict note_array board (2 wide × 2 tall) → 6 rows × 30 cols."""
+        from src.api_server import _get_first_board_dims
+
+        ss = self._ss_with_boards([{"device_type": "note_array", "notes_wide": 2, "notes_tall": 2}])
+        with patch("src.api_server.get_settings_service", return_value=ss):
+            dims = _get_first_board_dims()
+        assert (dims.rows, dims.cols) == (6, 30)
+
+    def test_note_array_object_board_resolves_via_getattr(self):
+        """An object-shaped note_array board uses the getattr branch (4 wide × 1 tall → 3×60)."""
+        from types import SimpleNamespace
+
+        from src.api_server import _get_first_board_dims
+
+        board = SimpleNamespace(device_type="note_array", notes_wide=4, notes_tall=1)
+        ss = self._ss_with_boards([board])
+        with patch("src.api_server.get_settings_service", return_value=ss):
+            dims = _get_first_board_dims()
+        assert (dims.rows, dims.cols) == (3, 60)
+
+    def test_flagship_object_board_resolves_via_getattr(self):
+        """A flagship object board (no notes attrs) falls back to 6×22 via getattr defaults."""
+        from types import SimpleNamespace
+
+        from src.api_server import _get_first_board_dims
+
+        board = SimpleNamespace(device_type="flagship")
+        ss = self._ss_with_boards([board])
+        with patch("src.api_server.get_settings_service", return_value=ss):
+            dims = _get_first_board_dims()
+        assert (dims.rows, dims.cols) == (6, 22)
+
+    def test_empty_boards_falls_back_to_flagship(self):
+        """No configured boards → flagship 6×22 default."""
+        from src.api_server import _get_first_board_dims
+
+        ss = self._ss_with_boards([])
+        with patch("src.api_server.get_settings_service", return_value=ss):
+            dims = _get_first_board_dims()
+        assert (dims.rows, dims.cols) == (6, 22)
+
+    def test_settings_error_falls_back_to_flagship(self):
+        """If settings can't be read the helper swallows the error and returns flagship dims."""
+        from src.api_server import _get_first_board_dims
+
+        ss = Mock()
+        ss.get_board_settings.side_effect = RuntimeError("settings unavailable")
+        with patch("src.api_server.get_settings_service", return_value=ss):
+            dims = _get_first_board_dims()
+        assert (dims.rows, dims.cols) == (6, 22)

--- a/tests/test_note_array_e2e.py
+++ b/tests/test_note_array_e2e.py
@@ -1,0 +1,189 @@
+"""End-to-end note-array send -> read round-trip through BoardClient.
+
+This is the cohesive feature test for the note-array epic (#1167, issue #1179).
+The individual merged issues each ship focused unit tests; this module ties the
+whole path together in one deterministic flow:
+
+    1. A ``send_characters`` POST hits the note-array Cloud API URL
+       (``cloud.vestaboard.com``) with the ``X-Vestaboard-Token`` header and a
+       ``{"characters": grid}`` body — never the legacy RW Cloud URL.
+    2. A subsequent ``read_current_message`` parses that exact grid back.
+    3. Transition parameters are absent from the note-array POST body even when
+       a strategy is passed (note arrays do not support transitions).
+    4. A second immediate send is throttled by the 15s client-side rate limit
+       (driven by an injected monotonic clock — no real time/network).
+
+The HTTP layer is mocked with a small **stateful** transport that ties POST and
+GET together (POST stores the grid; GET returns it as a Cloud-shaped
+``currentMessage.layout`` JSON string), mirroring the real Cloud API contract
+and the ``requests``-patching approach used in ``tests/test_board_client.py``.
+"""
+
+import json as _json
+from unittest.mock import Mock, patch
+
+import pytest
+
+from src.board_client import (
+    BoardClient,
+    _note_array_last_send,
+)
+
+# Note-array geometry under test: a 4-wide single row → 3 rows × 60 cols.
+NOTES_WIDE = 4
+NOTES_TALL = 1
+ROWS = NOTES_TALL * 3
+COLS = NOTES_WIDE * 15
+TOKEN = "e2e-note-array-token"
+
+CLOUD_NOTE_ARRAY_URL = BoardClient.CLOUD_NOTE_ARRAY_API_URL
+RW_CLOUD_URL = BoardClient.CLOUD_API_URL
+
+
+@pytest.fixture(autouse=True)
+def _reset_throttle():
+    """Reset the module-level note-array throttle so each test is isolated."""
+    _note_array_last_send.clear()
+    yield
+    _note_array_last_send.clear()
+
+
+def _make_grid(fill: int = 0) -> list[list[int]]:
+    return [[fill] * COLS for _ in range(ROWS)]
+
+
+class _FakeCloud:
+    """Stateful in-memory stand-in for ``cloud.vestaboard.com``.
+
+    POST stores the posted ``characters`` grid; GET returns it in the real
+    Cloud read shape (``{"currentMessage": {"layout": "<json>", "id": ...}}``)
+    so the client's own parser round-trips it back to a grid. Records every
+    request so tests can assert URL, headers, and body.
+    """
+
+    def __init__(self):
+        self.stored_grid: list[list[int]] | None = None
+        self.posts: list[dict] = []
+        self.gets: list[dict] = []
+
+    def post(self, url, headers=None, json=None, timeout=None):
+        # ``json`` mirrors the ``requests.post(..., json=payload)`` kwarg name.
+        body = json
+        self.posts.append({"url": url, "headers": headers, "json": body})
+        # The Cloud API body is {"characters": grid}.
+        self.stored_grid = [row[:] for row in body["characters"]]
+        resp = Mock()
+        resp.raise_for_status = Mock()
+        resp.json = Mock(return_value={"ok": True})
+        return resp
+
+    def get(self, url, headers=None, timeout=None):
+        self.gets.append({"url": url, "headers": headers})
+        grid = self.stored_grid if self.stored_grid is not None else _make_grid()
+        layout = _json.dumps(grid)
+        resp = Mock()
+        resp.raise_for_status = Mock()
+        resp.json = Mock(return_value={"currentMessage": {"layout": layout, "id": "msg-1"}})
+        return resp
+
+
+def _make_client(time_func=None) -> BoardClient:
+    return BoardClient(
+        api_key=TOKEN,
+        use_cloud=True,
+        skip_unchanged=True,
+        note_array_token=TOKEN,
+        notes_wide=NOTES_WIDE,
+        notes_tall=NOTES_TALL,
+        _time_func=time_func,
+    )
+
+
+class TestNoteArrayEndToEnd:
+    """One cohesive send -> read round trip exercising the whole note-array path."""
+
+    def test_full_send_read_roundtrip_with_constraints(self):
+        """Send a grid, read it back, and verify URL/header/body + no transitions + throttle.
+
+        This single flow is the feature's acceptance check:
+          - POST targets cloud.vestaboard.com (not rw.vestaboard.com) with the
+            X-Vestaboard-Token header and a {"characters": grid} body.
+          - GET parses the stored layout back to the identical grid.
+          - The POST body carries no transition params even though a strategy
+            was requested.
+          - A second send 5s later (clock injected) is throttled and never POSTs.
+        """
+        fake = _FakeCloud()
+        # Injected clock: first send at t=0, throttle check on second send at t=5.
+        clock_values = iter([0.0, 5.0])
+        client = _make_client(time_func=lambda: next(clock_values, 5.0))
+
+        sent_grid = _make_grid()
+        sent_grid[0][0] = 1
+        sent_grid[2][59] = 71  # extremes of the 3×60 grid
+
+        with patch("src.board_client.requests.post", side_effect=fake.post):
+            success, was_sent = client.send_characters(sent_grid, strategy="column", step_interval_ms=500, step_size=2)
+
+        # 1. Send succeeded and actually went out.
+        assert (success, was_sent) == (True, True)
+        assert len(fake.posts) == 1
+        post = fake.posts[0]
+
+        # 2. URL is the note-array Cloud API, never the legacy RW Cloud URL.
+        assert post["url"] == CLOUD_NOTE_ARRAY_URL
+        assert post["url"] != RW_CLOUD_URL
+
+        # 3. Token header is present and correct.
+        assert post["headers"]["X-Vestaboard-Token"] == TOKEN
+        assert post["headers"]["Content-Type"] == "application/json"
+
+        # 4. Body is exactly {"characters": grid} — no transition keys.
+        assert post["json"] == {"characters": sent_grid}
+        assert "strategy" not in post["json"]
+        assert "step_interval_ms" not in post["json"]
+        assert "step_size" not in post["json"]
+
+        # 5. Read it back — the parsed layout equals the grid we sent.
+        with patch("src.board_client.requests.get", side_effect=fake.get):
+            read_grid = client.read_current_message()
+
+        assert read_grid == sent_grid
+        assert len(read_grid) == ROWS
+        assert all(len(row) == COLS for row in read_grid)
+
+        # Read used the same note-array URL + token header.
+        assert len(fake.gets) == 1
+        assert fake.gets[0]["url"] == CLOUD_NOTE_ARRAY_URL
+        assert fake.gets[0]["headers"]["X-Vestaboard-Token"] == TOKEN
+
+        # 6. A second, immediate send (t=5 < 15s) is throttled — no new POST.
+        second_grid = _make_grid(fill=2)
+        with patch("src.board_client.requests.post", side_effect=fake.post) as second_post:
+            ok, was_sent2 = client.send_characters(second_grid)
+
+        assert (ok, was_sent2) == (True, False)
+        second_post.assert_not_called()
+        assert len(fake.posts) == 1  # still just the first send
+
+    def test_send_after_throttle_window_goes_through_and_read_reflects_it(self):
+        """After the 15s window elapses a new send lands and a read reflects the latest grid."""
+        fake = _FakeCloud()
+        # t=0 first send, t=20 (>15s) second send.
+        clock_values = iter([0.0, 20.0])
+        client = _make_client(time_func=lambda: next(clock_values, 20.0))
+
+        first = _make_grid(fill=3)
+        second = _make_grid(fill=7)
+
+        with patch("src.board_client.requests.post", side_effect=fake.post):
+            assert client.send_characters(first) == (True, True)
+            assert client.send_characters(second) == (True, True)
+
+        assert len(fake.posts) == 2
+
+        with patch("src.board_client.requests.get", side_effect=fake.get):
+            read_grid = client.read_current_message()
+
+        # The board now reflects the most recent (second) send.
+        assert read_grid == second


### PR DESCRIPTION
Closes #1179. Part of the Note Arrays epic #1167. Targets `next`.

## What
Rounds out backend coverage for the note-array feature as a whole and adds the brief's centerpiece end-to-end test. The feature was already well-covered by the merged sub-issues, so this adds only genuine gaps — no duplication.

- **`tests/test_note_array_e2e.py`** (new) — cohesive end-to-end send→read flow against a stateful in-memory fake Cloud (patches `src.board_client.requests`). Asserts: POST targets `cloud.vestaboard.com` (not `rw.`) with the `X-Vestaboard-Token` header and exactly `{"characters": grid}` body; transition params are stripped even when passed; a read parses the layout back to the identical grid; a second immediate send (t=5s) is throttled `(True, False)` with no POST; a send after the 15s window lands and the read reflects the latest grid.
- **`tests/test_board_html_renderer.py`** — `TestNoteArrayPresetRendering`: renders + validates all 5 presets + a custom 3×3 (row/tile counts, plain `.tile` class, label). Fills the #1173 renderer gap.
- **`tests/test_debug_endpoints.py`** — `TestGetFirstBoardDims`: direct tests for the note-array geometry helper (getattr path, empty-boards fallback, error-swallow fallback) — covering the previously-uncovered `api_server.py` branches `5907→5920` / `5914-5916`.

## Verification
- `ruff check` / `format --check`: clean
- full regression + coverage gate: **3852 passed**, `Required test coverage of 80% reached. Total coverage: 81.65%` (run excludes `tests/ai`, which needs API keys locally; note-array source files are 99–100%).

Tests-only — no `src/` changes. Disjoint from #1178 (web).

🤖 Generated with [Claude Code](https://claude.com/claude-code)