### PR TITLE
fix(upgrade): auto-restore config lost on upgrade (#1102, #948)

### DIFF
--- a/docs/superpowers/plans/2026-06-18-config-loss-on-upgrade-1102.md
+++ b/docs/superpowers/plans/2026-06-18-config-loss-on-upgrade-1102.md
@@ -1,0 +1,651 @@
+# Config Loss on Upgrade — Self-Healing Auto-Restore Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a FiestaBoard upgrade boot drops user config (timezone, install name, enabled plugins + their secrets), automatically restore the lost keys from the same-boot pre-update snapshot before the service reads them — no manual rollback.
+
+**Architecture:** All three reported casualties live in `data/config.json` (`general.timezone`, `general.instance_name`, `plugins.*`), already captured by the existing #948 pre-update snapshot (`data/update-backups/pre-update-<ts>.json`). We (1) mark when a boot is a genuine version change, (2) compute which config keys regressed vs the newest snapshot, (3) restore only those keys via `ConfigManager` setters early in the API lifespan — before the plugin registry initializes — then refresh the cached time service. Boot-boundary diagnostics ship alongside as the forensic safety net for the "snapshot already empty" blind spot.
+
+**Tech Stack:** Python 3.11, FastAPI, pytest. No new dependencies.
+
+## Global Constraints
+
+- **Spec:** `docs/superpowers/specs/2026-06-18-config-loss-on-upgrade-1102-design.md`. Approach is **detect + restore only** (save-guard and store-unification are deferred, §9).
+- **Tests run in the dev container** (CLAUDE.md): `docker-compose -f docker-compose.dev.yml exec fiestaboard pytest <path>`. The dev container must be running (`/start`).
+- **No new Python deps**; reuse `_resolve_snapshot_name` / `_list_settings_snapshots` already in `src/api_server.py`.
+- **Respect the #937 invariant:** never resurrect a deliberately removed/disabled plugin. Only auto-restore plugins that were **`enabled: True`** in the snapshot.
+- **Only act on a genuine version-change boot** (`seen is not None and seen != current`), gated by an env opt-out (`FIESTABOARD_AUTO_RESTORE`, default on).
+- **Idempotent & non-destructive:** restore only keys whose snapshot value is meaningful and whose live value is empty/default/missing; never overwrite a live value that still holds data.
+- **Branch:** `fix-1102-config-loss-on-upgrade` (already created; spec already committed).
+- `src.__version__` is currently `"7.9.0"`. Tests must monkeypatch it rather than hardcode.
+
+---
+
+## File structure
+
+- `src/config_manager.py` — add a `version_changed_on_load` flag set during load (Task 1).
+- `src/api_server.py` — add the pure restore-set builder (Task 2), the auto-restore routine (Task 3), wire it into `lifespan` (Task 4), and add boot diagnostics (Task 5).
+- `tests/test_config_manager.py` — flag tests (Task 1).
+- `tests/test_post_upgrade_restore.py` — new file: builder + auto-restore tests (Tasks 2–3).
+- `env.example` — document `FIESTABOARD_AUTO_RESTORE` (Task 3).
+
+---
+
+### Task 1: `ConfigManager.version_changed_on_load` flag
+
+**Files:**
+- Modify: `src/config_manager.py` (`__init__` ~line 340, `_maybe_snapshot_on_version_change` ~line 442, add a property)
+- Test: `tests/test_config_manager.py`
+
+**Interfaces:**
+- Produces: `ConfigManager.version_changed_on_load -> bool` — True only when this process loaded an existing config whose recorded `app_version_seen` was a non-None value different from `src.__version__`. False on fresh installs, corrupt-config resets, and same-version restarts.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_config_manager.py` (the autouse `reset_singleton` fixture already isolates the singleton + a tmp settings file):
+
+```python
+def test_version_changed_on_load_true_after_upgrade(tmp_path, monkeypatch):
+    """An existing config with an older app_version_seen flags a version change."""
+    import src
+
+    monkeypatch.setattr(src, "__version__", "9.9.9")
+    cfg = tmp_path / "config.json"
+    cfg.write_text(
+        json.dumps({"app_version_seen": "1.0.0", "plugins": {"weather": {"enabled": True}}})
+    )
+    cm = ConfigManager(config_path=str(cfg))
+    assert cm.version_changed_on_load is True
+
+
+def test_version_changed_on_load_false_same_version(tmp_path, monkeypatch):
+    """Restart on the same version is not a version change."""
+    import src
+
+    monkeypatch.setattr(src, "__version__", "9.9.9")
+    cfg = tmp_path / "config.json"
+    cfg.write_text(json.dumps({"app_version_seen": "9.9.9", "plugins": {}}))
+    cm = ConfigManager(config_path=str(cfg))
+    assert cm.version_changed_on_load is False
+
+
+def test_version_changed_on_load_false_fresh_install(tmp_path, monkeypatch):
+    """A brand-new config (no file) is not a version change."""
+    import src
+
+    monkeypatch.setattr(src, "__version__", "9.9.9")
+    cm = ConfigManager(config_path=str(tmp_path / "config.json"))
+    assert cm.version_changed_on_load is False
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `docker-compose -f docker-compose.dev.yml exec fiestaboard pytest tests/test_config_manager.py -k version_changed_on_load -v`
+Expected: FAIL — `AttributeError: 'ConfigManager' object has no attribute 'version_changed_on_load'`.
+
+- [ ] **Step 3: Initialize the flag in `__init__`**
+
+In `src/config_manager.py`, in `__init__`, add the default immediately before `self._load_or_create()`:
+
+```python
+        self._config: dict[str, Any] = {}
+        self._raw_features: dict[str, Any] = {}
+        self._version_changed_on_load = False
+        self._load_or_create()
+```
+
+- [ ] **Step 4: Set the flag in `_maybe_snapshot_on_version_change`**
+
+In `_maybe_snapshot_on_version_change`, set the flag right after `seen` is read, before the same-version early return:
+
+```python
+        seen = self._config.get(APP_VERSION_SEEN_KEY)
+        self._version_changed_on_load = seen is not None and seen != current_version
+        if seen == current_version:
+            return
+```
+
+- [ ] **Step 5: Add the public property**
+
+Add near the other accessors in `ConfigManager`:
+
+```python
+    @property
+    def version_changed_on_load(self) -> bool:
+        """True if this process loaded an existing config from an older app version.
+
+        False on fresh installs, corrupt-config resets, and same-version restarts.
+        Drives the post-upgrade auto-restore so it only runs on a real upgrade boot.
+        """
+        return self._version_changed_on_load
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `docker-compose -f docker-compose.dev.yml exec fiestaboard pytest tests/test_config_manager.py -k version_changed_on_load -v`
+Expected: PASS (3 passed).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/config_manager.py tests/test_config_manager.py
+git commit -m "feat(config): flag version-change boots for post-upgrade auto-restore (#1102)"
+```
+
+---
+
+### Task 2: Pure restore-set builder
+
+**Files:**
+- Modify: `src/api_server.py` (add function near `_detect_post_upgrade_regression`, ~line 2099)
+- Test: `tests/test_post_upgrade_restore.py` (new)
+
+**Interfaces:**
+- Consumes: `SENSITIVE_FIELDS` and `DEFAULT_CONFIG` from `src.config_manager`.
+- Produces: `_build_post_upgrade_restore_set(snap_config: dict, live_config: dict) -> dict` returning `{"general": {<field>: <snap_value>}, "plugins": {<plugin_id>: <full snap plugin config>}}`. Empty sub-dicts are omitted; an empty result `{}` means nothing regressed.
+
+Rules:
+- `general` — for `timezone` and `instance_name` only: include the snapshot value when it is a non-empty string AND the live value differs AND the live value is empty or equal to the `DEFAULT_CONFIG["general"]` default. (A user legitimately on the default is indistinguishable from a wipe-to-default and is intentionally left alone.)
+- `plugins` — only plugins with `enabled is True` in the snapshot. Include the **full** snapshot plugin config when the live side lost the enablement (missing plugin, or `enabled` not true) OR lost a sensitive field (a `SENSITIVE_FIELDS` key that is non-empty in the snapshot but empty/missing live).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_post_upgrade_restore.py`:
+
+```python
+"""Tests for post-upgrade config auto-restore (#1102 / #948)."""
+
+from src.api_server import _build_post_upgrade_restore_set
+
+
+def test_restore_set_recovers_timezone_lost_to_default():
+    snap = {"general": {"timezone": "America/New_York", "instance_name": "Kitchen"}}
+    live = {"general": {"timezone": "America/Los_Angeles", "instance_name": ""}}
+    result = _build_post_upgrade_restore_set(snap, live)
+    assert result["general"]["timezone"] == "America/New_York"
+    assert result["general"]["instance_name"] == "Kitchen"
+
+
+def test_restore_set_ignores_unchanged_general():
+    snap = {"general": {"timezone": "America/New_York", "instance_name": "Kitchen"}}
+    live = {"general": {"timezone": "America/New_York", "instance_name": "Kitchen"}}
+    result = _build_post_upgrade_restore_set(snap, live)
+    assert "general" not in result
+
+
+def test_restore_set_recovers_disabled_enabled_plugin_with_secrets():
+    snap = {"plugins": {"weather": {"enabled": True, "api_key": "real-key", "location": "NYC"}}}
+    live = {"plugins": {"weather": {"enabled": False}}}
+    result = _build_post_upgrade_restore_set(snap, live)
+    assert result["plugins"]["weather"] == snap["plugins"]["weather"]
+
+
+def test_restore_set_recovers_missing_enabled_plugin():
+    snap = {"plugins": {"stocks": {"enabled": True, "finnhub_api_key": "k"}}}
+    live = {"plugins": {}}
+    result = _build_post_upgrade_restore_set(snap, live)
+    assert "stocks" in result["plugins"]
+
+
+def test_restore_set_recovers_plugin_that_lost_only_its_secret():
+    snap = {"plugins": {"weather": {"enabled": True, "openweathermap_api_key": "real"}}}
+    live = {"plugins": {"weather": {"enabled": True, "openweathermap_api_key": ""}}}
+    result = _build_post_upgrade_restore_set(snap, live)
+    assert result["plugins"]["weather"]["openweathermap_api_key"] == "real"
+
+
+def test_restore_set_does_not_resurrect_disabled_plugin():
+    # User deliberately disabled it under the old version -> snapshot has enabled False.
+    snap = {"plugins": {"weather": {"enabled": False, "api_key": "real-key"}}}
+    live = {"plugins": {}}
+    result = _build_post_upgrade_restore_set(snap, live)
+    assert result.get("plugins", {}) == {}
+
+
+def test_restore_set_empty_when_nothing_regressed():
+    snap = {"general": {"timezone": "America/New_York"}, "plugins": {"weather": {"enabled": True}}}
+    live = {"general": {"timezone": "America/New_York"}, "plugins": {"weather": {"enabled": True}}}
+    assert _build_post_upgrade_restore_set(snap, live) == {}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `docker-compose -f docker-compose.dev.yml exec fiestaboard pytest tests/test_post_upgrade_restore.py -v`
+Expected: FAIL — `ImportError: cannot import name '_build_post_upgrade_restore_set'`.
+
+- [ ] **Step 3: Implement the builder**
+
+In `src/api_server.py`, just above `_detect_post_upgrade_regression` (~line 2099), add:
+
+```python
+# Config fields we know are user-set and safe to auto-restore from a snapshot.
+_RESTORABLE_GENERAL_FIELDS = ("timezone", "instance_name")
+
+
+def _build_post_upgrade_restore_set(
+    snap_config: dict[str, Any], live_config: dict[str, Any]
+) -> dict[str, Any]:
+    """Compute which config.json keys regressed vs a pre-update snapshot.
+
+    Returns ``{"general": {...}, "plugins": {...}}`` with only the keys worth
+    restoring; an empty dict means nothing regressed. See plan Task 2 for rules.
+    """
+    from src.config_manager import DEFAULT_CONFIG, SENSITIVE_FIELDS
+
+    result: dict[str, Any] = {}
+
+    snap_general = snap_config.get("general") or {}
+    live_general = live_config.get("general") or {}
+    default_general = DEFAULT_CONFIG.get("general", {})
+    general: dict[str, Any] = {}
+    for field in _RESTORABLE_GENERAL_FIELDS:
+        snap_val = snap_general.get(field)
+        if not isinstance(snap_val, str) or not snap_val:
+            continue
+        live_val = live_general.get(field)
+        if live_val == snap_val:
+            continue
+        if live_val in ("", None, default_general.get(field)):
+            general[field] = snap_val
+    if general:
+        result["general"] = general
+
+    snap_plugins = snap_config.get("plugins") or {}
+    live_plugins = live_config.get("plugins") or {}
+    plugins: dict[str, Any] = {}
+    for pid, snap_cfg in snap_plugins.items():
+        if not (isinstance(snap_cfg, dict) and snap_cfg.get("enabled") is True):
+            continue  # only auto-restore plugins the user had ENABLED (#937 invariant)
+        live_cfg = live_plugins.get(pid)
+        lost_enable = not (isinstance(live_cfg, dict) and live_cfg.get("enabled") is True)
+        lost_secret = isinstance(live_cfg, dict) and any(
+            key in SENSITIVE_FIELDS and snap_cfg.get(key) and not live_cfg.get(key)
+            for key in snap_cfg
+        )
+        if lost_enable or lost_secret:
+            plugins[pid] = snap_cfg
+    if plugins:
+        result["plugins"] = plugins
+
+    return result
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `docker-compose -f docker-compose.dev.yml exec fiestaboard pytest tests/test_post_upgrade_restore.py -v`
+Expected: PASS (7 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/api_server.py tests/test_post_upgrade_restore.py
+git commit -m "feat(upgrade): detect regressed config keys vs pre-update snapshot (#1102)"
+```
+
+---
+
+### Task 3: Auto-restore routine (apply the restore set)
+
+**Files:**
+- Modify: `src/api_server.py` (new function after `_build_post_upgrade_restore_set`)
+- Modify: `env.example`
+- Test: `tests/test_post_upgrade_restore.py`
+
+**Interfaces:**
+- Consumes: `get_config_manager()`, `_resolve_snapshot_name`, `_build_post_upgrade_restore_set`, `reset_time_service`, `ConfigManager.version_changed_on_load` (Task 1), `ConfigManager.set_general` / `set_plugin_config` / `get_all`.
+- Produces: `_auto_restore_post_upgrade_regression() -> dict[str, Any]` — returns a summary dict (`{"general": [...field names...], "plugins": [...plugin ids...]}`) of what it restored, or `{}` when it did nothing. Side effects: writes restored keys into `config.json` and resets the cached time service.
+
+Gating order: (1) env opt-out, (2) not a version-change boot, (3) no readable newest snapshot, (4) empty restore set → each returns `{}`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_post_upgrade_restore.py`:
+
+```python
+import json
+from unittest.mock import MagicMock
+
+import src.api_server as api_server
+
+
+def _seed_snapshot(tmp_path, config_payload):
+    snap = tmp_path / "pre-update-20260101T000000.000Z.json"
+    snap.write_text(json.dumps({"data": {"config": config_payload}}))
+    return snap
+
+
+def test_auto_restore_applies_general_and_plugins(tmp_path, monkeypatch):
+    snap_path = _seed_snapshot(
+        tmp_path,
+        {
+            "general": {"timezone": "America/New_York", "instance_name": "Kitchen"},
+            "plugins": {"weather": {"enabled": True, "api_key": "real"}},
+        },
+    )
+    cm = MagicMock()
+    cm.version_changed_on_load = True
+    cm.get_all.return_value = {
+        "general": {"timezone": "America/Los_Angeles", "instance_name": ""},
+        "plugins": {"weather": {"enabled": False}},
+    }
+    monkeypatch.setattr(api_server, "get_config_manager", lambda: cm)
+    monkeypatch.setattr(api_server, "_resolve_snapshot_name", lambda name=None: snap_path)
+    reset_called = MagicMock()
+    monkeypatch.setattr(api_server, "reset_time_service", reset_called)
+    monkeypatch.delenv("FIESTABOARD_AUTO_RESTORE", raising=False)
+
+    summary = api_server._auto_restore_post_upgrade_regression()
+
+    cm.set_general.assert_called_once()
+    assert cm.set_general.call_args[0][0] == {
+        "timezone": "America/New_York",
+        "instance_name": "Kitchen",
+    }
+    cm.set_plugin_config.assert_called_once_with("weather", {"enabled": True, "api_key": "real"})
+    reset_called.assert_called_once()
+    # summary lists are sorted() -> alphabetical
+    assert summary == {"general": ["instance_name", "timezone"], "plugins": ["weather"]}
+
+
+def test_auto_restore_noop_when_not_version_change(tmp_path, monkeypatch):
+    cm = MagicMock()
+    cm.version_changed_on_load = False
+    monkeypatch.setattr(api_server, "get_config_manager", lambda: cm)
+    monkeypatch.delenv("FIESTABOARD_AUTO_RESTORE", raising=False)
+    assert api_server._auto_restore_post_upgrade_regression() == {}
+    cm.set_general.assert_not_called()
+
+
+def test_auto_restore_noop_when_disabled_by_env(tmp_path, monkeypatch):
+    cm = MagicMock()
+    cm.version_changed_on_load = True
+    monkeypatch.setattr(api_server, "get_config_manager", lambda: cm)
+    monkeypatch.setenv("FIESTABOARD_AUTO_RESTORE", "0")
+    assert api_server._auto_restore_post_upgrade_regression() == {}
+    cm.set_general.assert_not_called()
+
+
+def test_auto_restore_noop_when_nothing_regressed(tmp_path, monkeypatch):
+    snap_path = _seed_snapshot(
+        tmp_path, {"general": {"timezone": "America/New_York"}, "plugins": {}}
+    )
+    cm = MagicMock()
+    cm.version_changed_on_load = True
+    cm.get_all.return_value = {"general": {"timezone": "America/New_York"}, "plugins": {}}
+    monkeypatch.setattr(api_server, "get_config_manager", lambda: cm)
+    monkeypatch.setattr(api_server, "_resolve_snapshot_name", lambda name=None: snap_path)
+    monkeypatch.setattr(api_server, "reset_time_service", MagicMock())
+    monkeypatch.delenv("FIESTABOARD_AUTO_RESTORE", raising=False)
+    assert api_server._auto_restore_post_upgrade_regression() == {}
+    cm.set_general.assert_not_called()
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `docker-compose -f docker-compose.dev.yml exec fiestaboard pytest tests/test_post_upgrade_restore.py -k auto_restore -v`
+Expected: FAIL — `AttributeError: module 'src.api_server' has no attribute '_auto_restore_post_upgrade_regression'`.
+
+- [ ] **Step 3: Confirm the time-service import is available in `api_server`**
+
+Check that `reset_time_service` is importable in `src/api_server.py`. Run:
+`grep -n "reset_time_service" src/api_server.py`
+If absent, add to the imports near the other `from .time_service` / service imports at the top of the module:
+
+```python
+from .time_service import reset_time_service  # noqa: E402
+```
+
+(The tests monkeypatch `api_server.reset_time_service`, so it must be a module-level name.)
+
+- [ ] **Step 4: Implement the routine**
+
+In `src/api_server.py`, immediately after `_build_post_upgrade_restore_set`, add:
+
+```python
+def _auto_restore_post_upgrade_regression() -> dict[str, Any]:
+    """Restore config keys lost on an upgrade boot from the newest pre-update
+    snapshot, before the service/registry reads config. Returns a summary of
+    what was restored (empty when it did nothing). See issue #1102 / #948.
+    """
+    if os.environ.get("FIESTABOARD_AUTO_RESTORE", "1").strip().lower() in ("0", "false", "no"):
+        return {}
+
+    cm = get_config_manager()
+    if not getattr(cm, "version_changed_on_load", False):
+        return {}
+
+    newest = _resolve_snapshot_name(None)
+    if newest is None:
+        return {}
+    try:
+        snap_doc = json.loads(newest.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    snap_config = (snap_doc.get("data") or {}).get("config") or {}
+    if not snap_config:
+        return {}
+
+    restore_set = _build_post_upgrade_restore_set(snap_config, cm.get_all())
+    if not restore_set:
+        return {}
+
+    summary: dict[str, Any] = {}
+    general = restore_set.get("general")
+    if general:
+        cm.set_general(general)
+        summary["general"] = sorted(general)
+    plugins = restore_set.get("plugins")
+    if plugins:
+        for pid, cfg in plugins.items():
+            cm.set_plugin_config(pid, cfg)
+        summary["plugins"] = sorted(plugins)
+
+    # Restored timezone won't take effect until the cached TimeService is rebuilt.
+    reset_time_service()
+    return summary
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `docker-compose -f docker-compose.dev.yml exec fiestaboard pytest tests/test_post_upgrade_restore.py -v`
+Expected: PASS (11 passed).
+
+- [ ] **Step 6: Document the env var in `env.example`**
+
+Add to `env.example` (near other `FIESTABOARD_*` entries):
+
+```bash
+# Auto-restore config (timezone, install name, enabled plugins + secrets) from the
+# pre-update snapshot when an upgrade boot is detected to have dropped it (#1102/#948).
+# Set to 0 to disable and rely on manual /system/update/rollback instead.
+FIESTABOARD_AUTO_RESTORE=1
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/api_server.py tests/test_post_upgrade_restore.py env.example
+git commit -m "feat(upgrade): auto-restore config lost on upgrade from snapshot (#1102)"
+```
+
+---
+
+### Task 4: Wire auto-restore into the API lifespan
+
+**Files:**
+- Modify: `src/api_server.py` (`lifespan`, ~lines 677–691)
+
+**Interfaces:**
+- Consumes: `_auto_restore_post_upgrade_regression` (Task 3), existing `_detect_post_upgrade_regression`.
+
+The restore must run **before** `get_service()` (~line 694) so the plugin registry reads the restored config. The existing warning-only hint remains as a fallback for when auto-restore is disabled or could not recover (empty snapshot).
+
+- [ ] **Step 1: Insert the auto-restore call before the hint block**
+
+In `src/api_server.py`, directly above the existing `try:`/`_regression_hint = _detect_post_upgrade_regression()` block (~line 677), add:
+
+```python
+    # Auto-heal config dropped on an upgrade boot (#1102/#948) BEFORE the
+    # service + plugin registry read it. No-op unless this is a version-change
+    # boot with a snapshot that still holds the lost data.
+    try:
+        _restored = _auto_restore_post_upgrade_regression()
+        if _restored:
+            logger.warning("Post-upgrade auto-restore applied from snapshot: %s", _restored)
+    except Exception:  # pragma: no cover - safety net must never block boot
+        logger.debug("Post-upgrade auto-restore failed", exc_info=True)
+```
+
+Leave the existing `_detect_post_upgrade_regression` hint block in place immediately after — once auto-restore succeeds it will report no regression, but it still fires when auto-restore is disabled or the snapshot was already empty.
+
+- [ ] **Step 2: Verify the module imports cleanly**
+
+Run: `docker-compose -f docker-compose.dev.yml exec fiestaboard python -c "import src.api_server"`
+Expected: no output, exit 0.
+
+- [ ] **Step 3: Run the full new test file + the config-manager flag tests**
+
+Run: `docker-compose -f docker-compose.dev.yml exec fiestaboard pytest tests/test_post_upgrade_restore.py tests/test_config_manager.py -v`
+Expected: PASS (all).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/api_server.py
+git commit -m "feat(upgrade): run config auto-restore on startup before service init (#1102)"
+```
+
+---
+
+### Task 5: Boot-boundary diagnostics (Track 1 safety net)
+
+**Files:**
+- Modify: `src/api_server.py` (helper + two call sites in `lifespan`)
+
+**Interfaces:**
+- Produces: `_log_config_boot_snapshot(stage: str) -> None` — logs enabled-plugin count, timezone, and install-name presence at a named boot stage. Pure logging; never raises.
+
+Rationale: when the snapshot is already empty (the documented blind spot), auto-restore can't recover and these logs are the only forensic trail. Cheap, no behavioral risk.
+
+- [ ] **Step 1: Implement the diagnostics helper**
+
+In `src/api_server.py`, near the other startup helpers, add:
+
+```python
+def _log_config_boot_snapshot(stage: str) -> None:
+    """Log a one-line config fingerprint at a boot stage (issue #1102 forensics)."""
+    try:
+        cm = get_config_manager()
+        general = cm.get_general()
+        plugins = cm.get_all_plugin_configs()
+        enabled = sum(1 for c in plugins.values() if isinstance(c, dict) and c.get("enabled"))
+        logger.info(
+            "config boot snapshot [%s]: %d plugin(s), %d enabled, timezone=%r, instance_name=%r",
+            stage,
+            len(plugins),
+            enabled,
+            general.get("timezone"),
+            general.get("instance_name"),
+        )
+    except Exception:  # pragma: no cover - diagnostics must never block boot
+        logger.debug("config boot snapshot [%s] failed", stage, exc_info=True)
+```
+
+- [ ] **Step 2: Add call sites in `lifespan`**
+
+Call it once right after the auto-restore block (post-restore state) and once after the service is initialized (`get_service()` returns, ~line 694+):
+
+```python
+    _log_config_boot_snapshot("post-restore")
+```
+
+and, after the auto-start service block:
+
+```python
+    _log_config_boot_snapshot("post-service-init")
+```
+
+- [ ] **Step 3: Verify import + boot log wiring**
+
+Run: `docker-compose -f docker-compose.dev.yml exec fiestaboard python -c "import src.api_server"`
+Expected: exit 0.
+
+- [ ] **Step 4: Restart the dev container and confirm the lines appear**
+
+Run: `docker-compose -f docker-compose.dev.yml restart fiestaboard && docker-compose -f docker-compose.dev.yml logs --since 1m fiestaboard | grep "config boot snapshot"`
+Expected: two `config boot snapshot [post-restore]` / `[post-service-init]` lines.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/api_server.py
+git commit -m "chore(upgrade): log config fingerprint at boot stages for #1102 forensics"
+```
+
+---
+
+### Task 6: End-to-end verification in the dev container
+
+**Files:** none (manual verification + final commit of any notes)
+
+- [ ] **Step 1: Simulate an upgrade that wipes config**
+
+With the dev container running, craft a snapshot + a wiped live config, then restart:
+
+```bash
+# 1. Capture current state, then seed a pre-update snapshot with rich data
+#    and an emptied live config to mimic the upgrade-time loss.
+docker-compose -f docker-compose.dev.yml exec fiestaboard sh -c '
+  mkdir -p data/update-backups
+  cat > data/update-backups/pre-update-20260101T000000.000Z.json <<"EOF"
+{"data":{"config":{"general":{"timezone":"America/New_York","instance_name":"Kitchen"},
+"plugins":{"weather":{"enabled":true,"openweathermap_api_key":"demo-key"}}}}}
+EOF
+  python - <<"EOF"
+import json,sys
+p="data/config.json"
+c=json.load(open(p))
+c["app_version_seen"]="0.0.1"               # force a version-change boot
+c.setdefault("general",{})["timezone"]="America/Los_Angeles"  # wiped to default
+c["general"]["instance_name"]=""
+c["plugins"]={"weather":{"enabled":False}}  # enablement + secret lost
+json.dump(c,open(p,"w"),indent=2)
+print("seeded wiped config")
+EOF'
+```
+
+- [ ] **Step 2: Restart and observe auto-restore**
+
+Run: `docker-compose -f docker-compose.dev.yml restart fiestaboard && docker-compose -f docker-compose.dev.yml logs --since 1m fiestaboard | grep -iE "auto-restore|config boot snapshot"`
+Expected: a `Post-upgrade auto-restore applied from snapshot: {'general': ['instance_name', 'timezone'], 'plugins': ['weather']}` line, and the `post-restore` fingerprint showing 1 enabled plugin + `timezone='America/New_York'` + `instance_name='Kitchen'`.
+
+- [ ] **Step 3: Confirm the restore persisted to disk**
+
+Run: `docker-compose -f docker-compose.dev.yml exec fiestaboard python -c "import json; c=json.load(open('data/config.json')); print(c['general']['timezone'], repr(c['general']['instance_name']), c['plugins']['weather'])"`
+Expected: `America/New_York 'Kitchen' {'enabled': True, 'openweathermap_api_key': 'demo-key'}`.
+
+- [ ] **Step 4: Confirm idempotency on a same-version restart**
+
+Run: `docker-compose -f docker-compose.dev.yml restart fiestaboard && docker-compose -f docker-compose.dev.yml logs --since 1m fiestaboard | grep -i "auto-restore" || echo "no restore on same-version restart (expected)"`
+Expected: no auto-restore line (version unchanged → `version_changed_on_load` False).
+
+- [ ] **Step 5: Run the full affected test suites once more**
+
+Run: `docker-compose -f docker-compose.dev.yml exec fiestaboard pytest tests/test_post_upgrade_restore.py tests/test_config_manager.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Restore your own dev data (cleanup)**
+
+Remove the simulated snapshot so it doesn't shadow real ones:
+
+```bash
+docker-compose -f docker-compose.dev.yml exec fiestaboard rm -f data/update-backups/pre-update-20260101T000000.000Z.json
+```
+
+---
+
+## Notes for the PR
+
+- Closes the reopened half of #1102 (timezone / install name / integrations lost on upgrade); generalizes the #948 mitigation from "warn + manual rollback" to "auto-restore the regressed keys."
+- Deferred (see spec §9): save-boundary write-guard, full `config.json`/`settings.json` store unification, and the heavy local-repro/boot-path root-cause audit (un-defer if diagnostics show a recurrence the snapshot can't recover).
+- `settings.json` board name (`boards[].name`) is NOT auto-restored here — the reported "FiestaBoard name" maps to `config.json` `general.instance_name`, which IS covered. If a recurrence shows the per-board name regressing too, extend `_build_post_upgrade_restore_set` to a `settings` category using the same snapshot (which already captures `settings.json`).

--- a/docs/superpowers/specs/2026-06-18-config-loss-on-upgrade-1102-design.md
+++ b/docs/superpowers/specs/2026-06-18-config-loss-on-upgrade-1102-design.md
@@ -1,0 +1,229 @@
+# Config loss on upgrade (issue #1102, re-run of #948) — design
+
+**Status:** Draft for review
+**Issue:** [#1102](https://github.com/Fiestaboard/FiestaBoard/issues/1102) (reopened), prior art [#948](https://github.com/Fiestaboard/FiestaBoard/issues/948)
+**Date:** 2026-06-18
+
+## 1. Problem
+
+A user running FiestaBoard under Docker + Watchtower (auto-update + restart on every
+new image) loses configuration on each update. The first #1102 fix
+(PR #1103, `1416dbec`) addressed only the *startup validator*: it taught
+`ConfigManager.validate()` to consult the multi-board settings service so the
+backend stops refusing to boot when the legacy `config.json` board block is empty.
+That is why **board credentials and the schedule now survive**.
+
+The reopened report is a **different, deeper bug**: after each update the reporter
+still loses
+
+- the **board / FiestaBoard name**,
+- the **global timezone**, and
+- **integrations (plugin selections + their per-plugin configs and API keys)**.
+
+The user has to re-add these by hand after every update.
+
+## 2. Why the loss is selective (key evidence)
+
+Configuration is split across several JSON files, all under the persisted
+`./data:/app/data` bind mount:
+
+| Store | Owns | Reporter status |
+|---|---|---|
+| `data/settings.json` (`SettingsService`, `src/settings/service.py`) | multi-board `boards[]` incl. creds, schedule, mqtt, display, beta | **survives** |
+| `data/schedules.json`, `data/pages.json`, `data/collections.json` | scheduler / pages / carousels | **survives** |
+| **`data/config.json`** (`ConfigManager`, `src/config_manager.py`) | **`general.timezone`, `plugins.*` (enable + config + secrets), legacy `board` block** | **lost** |
+
+The loss splits **cleanly by file**: everything owned by `config.json` resets;
+everything in the other files survives. This rules out the relative-bind-mount
+footgun (running `docker compose` from a different directory — documented in
+`docker-compose.yml`), which would wipe *all* `data/*.json` files, not just one.
+The failure is specific to **`config.json` contents being emptied/reset on a
+version change.**
+
+> Note on board name: the per-instance name lives in `settings.json`
+> (`boards[].name`), which the reporter says survives. The "name goes blank"
+> symptom therefore needs confirmation — it may be the legacy `config.json`
+> `board.name`, or a display path that reads the legacy block. The forensic /
+> repro step (§5) resolves which store actually owns the blanked name; the
+> self-heal (§6) covers both stores regardless.
+
+## 3. This is issue #948 resurfacing
+
+#948 ("Integrations Lost on Upgrade") is the same symptom. Its fix commit
+(`db821780`) is explicit that the **root cause was never found**:
+
+> "The exact line that resets the enabled flags between boots remains elusive —
+> the 7.0.10..7.1.1 src diff is only ~190 lines and none of it overtly wipes
+> configs — but the damage is real and not limited to one user. Stop the bleed
+> three ways…"
+
+The #948 evidence: last 7.0.10 boot logged `Initialized 19 plugins (7 enabled)`;
+first 7.1.1 boot logged `Initialized 16 plugins (1 enabled)`. Two effects:
+plugins extracted to external repos (19→16, the V3 migration) **and** enabled
+flags reset (7→1, unexplained).
+
+The three #948 "ways" were **mitigations, not a fix**:
+
+1. **Pre-init snapshot** — `ConfigManager._maybe_snapshot_on_version_change()`
+   (`src/config_manager.py:422`) dumps `data/*.json` to
+   `data/update-backups/pre-update-<ts>.json` on a version change, *before* any
+   merge/migration runs. Captures `config.json, settings.json, pages.json,
+   collections.json, schedules.json` (`_PRE_INIT_SNAPSHOT_FILES`, line 414).
+2. **Regression hint** — `_detect_post_upgrade_regression()`
+   (`src/api_server.py:2099`) warns at startup + via `/system/update/status`.
+3. **v2→v3 install retry** — `PluginRegistry._auto_migrate_v2_plugins`.
+
+## 4. The two gaps that matter for #1102
+
+1. **Detection is plugin-only.** `_detect_post_upgrade_regression()` compares
+   only the *enabled plugin ID set* (`src/api_server.py:2127–2138`). It does
+   **not** detect lost `general.timezone`, lost board name, or a plugin that is
+   still "enabled" but lost its API key / config. Two of the three reopened
+   complaints aren't even detected today.
+2. **Recovery is manual and all-or-nothing.** The user must notice the warning
+   and `POST /system/update/rollback` with `restore_settings=true`, which reverts
+   *everything* to the snapshot. Most users never do this — they re-run the
+   wizard, exactly as the reporter describes.
+
+## 5. Track 1 — Boot diagnostics only (deep hunt deferred)
+
+**Decision:** Track 2 (self-heal) is the primary deliverable, so Track 1 is
+scoped to **cheap boundary diagnostics only**. The heavier local-repro harness
+and full boot-path audit (5b/5c below) are **deferred** — pursued only if the
+self-heal proves insufficient in the wild.
+
+**5a. Boot diagnostics (ships with Track 2).** Log enabled-plugin count +
+timezone presence + board-name presence at three boundaries — immediately after
+`ConfigManager` load, after settings-service init, after plugin-registry init.
+Rationale: this is the safety net for Track 2's blind spot (§6, "empty-snapshot"
+case). When the self-heal *can't* recover (the newest snapshot is already
+empty), these logs are the only forensic trail explaining why, and they let us
+spot the loss boundary if a recurrence is reported. A few log lines, no
+behavioral risk.
+
+**5b. (Deferred) Local reproduction harness.** Simulate the upgrade boot in the
+dev container by making the running version disagree with `app_version_seen`
+(seed `config.json` with enabled plugins + non-default timezone + an older
+`app_version_seen`; boot; capture the snapshot, the `Initialized N plugins
+(M enabled)` line, and a before/after `config.json` dump). Determines whether the
+mechanism is **lost** (recreated empty, `config_manager.py:381`), **corrupted**
+(`JSONDecodeError → DEFAULT_CONFIG`, `config_manager.py:374`), or **clobbered in
+memory** (file intact, emptied by a migration/merge/settings write-back).
+
+**5c. (Deferred) Boot-path writer audit** of `_load_or_create` /
+`_merge_with_defaults` (`config_manager.py:350,557`), `_apply_global_connection`
+and settings-service `set_*` during init (`src/settings/service.py:605`), the
+plugin registry V2/V3 migration (`src/plugins/registry.py:386–428`), and any
+startup `_save_internal()` that could persist a partially-initialized config.
+
+**Trigger to un-defer 5b/5c:** a confirmed recurrence where the diagnostics show
+loss but the self-heal could not recover.
+
+## 6. Track 2 — Generalized self-healing auto-restore (PRIMARY)
+
+Take the existing #948 mitigation infrastructure further: **detect a broader
+class of regressions and auto-repair them at boot**, instead of only warning
+about plugins and waiting for a manual full rollback.
+
+**Scope decision:** detect-and-restore only. A save-boundary write-guard (refuse
+to persist a `config.json` materially emptier than what was loaded this boot) was
+considered as a second defensive layer and **deferred to §9** — it requires
+reliably distinguishing boot-time reconciliation from a user-initiated removal,
+which is higher-risk than the restore approach buys us right now.
+
+**Known limitation (the "empty-snapshot" blind spot).** Auto-restore recovers
+data only when the loss happens *on the upgrade boot itself* and the same-boot
+pre-update snapshot still holds the good values — which matches the #948
+evidence and the reported scenario. A user who is **already stuck** (config.json
+emptied on a previous boot) has only empty snapshots and cannot be auto-rescued;
+they need a one-time manual restore or re-setup. Track 1's diagnostics (§5a)
+cover this case forensically. This protects data going *forward* from a good
+state; it does not retroactively rescue an already-wiped install.
+
+**6a. Broaden detection.** Generalize `_detect_post_upgrade_regression` into a
+structured regression report comparing the newest pre-update snapshot against
+live state across:
+- `config.json` → `general.timezone` (snapshot non-empty, live empty/default),
+- `config.json` → `plugins.*`: enabled-in-snapshot-but-not-live (today's check)
+  **plus** plugins that are still enabled but lost config keys (esp.
+  `SENSITIVE_FIELDS`),
+- `settings.json` → board name (snapshot non-empty, live blank).
+
+**6b. Auto-restore the regressed keys.** When a regression is detected on a
+**version-change boot** (i.e. `_maybe_snapshot_on_version_change` fired this
+boot), restore **only the regressed keys** from the newest snapshot into the
+live stores, save once, and log loudly what was restored.
+
+Why this is safe (the #937 invariant — deliberate uninstalls must not
+resurrect): the pre-update snapshot is taken at the **top of this boot's load**,
+before any merge/migration, so it reflects the user's *true last-known-good*
+state as of the previous version's last run. A plugin the user deliberately
+uninstalled under the old version is already absent from that snapshot, so it is
+never resurrected. Restoring from the same-boot snapshot targets exactly the
+data this boot just dropped.
+
+Guardrails:
+- Only run on a detected version change (not on plain restarts).
+- Restore only keys that are **present + non-empty in snapshot and
+  absent/empty/default in live** — never overwrite a value that still has data.
+- Take a fresh backup before writing (reversible), and make it **idempotent**:
+  stamp completion so it can't re-run and fight the user on the next boot.
+- Restore `config.json` data **before** the plugin registry initializes
+  (so enabled flags + configs are in place when `registry.initialize()` reads
+  them), or re-initialize the registry after restoring.
+- Optional `config.json` flag to disable auto-heal for operators who prefer the
+  manual rollback flow.
+
+**6c. Hook point (implementation decision, see §8).** Leading option: perform
+the `config.json` restore early in/after `ConfigManager._load_or_create()` —
+right after `_maybe_snapshot_on_version_change()` — so the two `config.json`
+casualties (timezone, plugins) are healed before any consumer reads them.
+Settings.json-owned data (board name) is reconciled in the settings-service
+load. Keep the heavy plugin-registry recursion concerns noted at
+`config_manager.py:408–440` in mind.
+
+## 7. Testing
+
+- **Track 1 repro** documented as a runnable script/steps (not a committed test
+  that depends on `data/`).
+- **Detection** unit tests: snapshot-vs-live fixtures for each regression class
+  (timezone, plugin enable, plugin config/secret, board name); assert the report
+  is empty when live ≥ snapshot.
+- **Auto-restore** unit tests: regressed boot restores only the missing keys;
+  does **not** resurrect deliberately-removed plugins; does **not** overwrite a
+  live value that still has data; is idempotent across two boots; respects the
+  disable flag.
+- **Guard** the #937 invariant explicitly with a test mirroring the existing
+  v2-retry "deliberate uninstall stays uninstalled" case.
+- Run via the dev container per CLAUDE.md
+  (`docker-compose -f docker-compose.dev.yml exec fiestaboard pytest`).
+
+## 8. Resolved decisions + remaining open items
+
+**Resolved:**
+- **Approach** — detect + restore only; Track 1 reduced to diagnostics (§5a).
+- **Auto-heal default** — automatic, with a `config.json` flag to disable for
+  operators who prefer the manual rollback flow.
+- **Branch** — dedicated `fix-1102-config-loss-on-upgrade` (this worktree is on
+  an unrelated board-size-indicator branch with no diff vs `main`).
+
+**Still open (settle during the implementation plan):**
+- **Restore hook point** — early in `ConfigManager._load_or_create` (simplest
+  for the two `config.json` casualties: timezone + plugins) vs a unified
+  post-init reconciliation in the api_server lifespan (cleaner cross-store for
+  the `settings.json` board name, but must re-init the plugin registry after
+  restoring). Leaning toward the early `config.json` restore + a small
+  settings-service reconciliation for the name.
+
+## 9. Out of scope / deferred layers
+
+- **Save-boundary write-guard** (deferred). A second defensive layer:
+  `ConfigManager._save_internal()` refuses to persist a `config.json` materially
+  emptier than what it loaded this boot unless the change is user-initiated.
+  More "cure than mask," but the user-vs-boot distinction is the hard part;
+  revisit if detect-and-restore proves insufficient.
+- **Full store unification** — collapsing `config.json` (timezone/plugins) into
+  `SettingsService` for a single load/migrate path. Addresses the class at the
+  source but the blast radius (every config reader/writer + a data migration) is
+  too large for this fix. Revisit only if the deferred deep hunt (§5b/5c) shows
+  the two-store split itself is the root cause.

--- a/env.example
+++ b/env.example
@@ -226,3 +226,8 @@ FIESTABOARD_MCP_TOKEN=
 # IMPORTANT: back this key up. Losing it makes existing encrypted secrets
 # unrecoverable.
 FIESTABOARD_SECRET_KEY=
+
+# Auto-restore config (timezone, install name, enabled plugins + secrets) from the
+# pre-update snapshot when an upgrade boot is detected to have dropped it (#1102/#948).
+# Set to 0 to disable and rely on manual /system/update/rollback instead.
+FIESTABOARD_AUTO_RESTORE=1

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -680,6 +680,7 @@ async def lifespan(app: FastAPI):
             logger.warning("Post-upgrade auto-restore applied from snapshot: %s", _restored)
     except Exception:  # pragma: no cover - safety net must never block boot
         logger.debug("Post-upgrade auto-restore failed", exc_info=True)
+    _log_config_boot_snapshot("post-restore")
 
     # If the most recent settings snapshot looks materially richer than the
     # live config (more enabled plugins, etc.), tell the user loudly on
@@ -724,6 +725,7 @@ async def lifespan(app: FastAPI):
             logger.warning("Service can be started manually via /start endpoint after configuration is fixed")
     else:
         logger.warning("Service instance could not be created - check logs for initialization errors")
+    _log_config_boot_snapshot("post-service-init")
 
     # Start mDNS/Bonjour advertisement (fiestaboard.local)
     try:
@@ -2200,6 +2202,25 @@ def _auto_restore_post_upgrade_regression() -> dict[str, Any]:
     # Restored timezone won't take effect until the cached TimeService is rebuilt.
     reset_time_service()
     return summary
+
+
+def _log_config_boot_snapshot(stage: str) -> None:
+    """Log a one-line config fingerprint at a boot stage (issue #1102 forensics)."""
+    try:
+        cm = get_config_manager()
+        general = cm.get_general()
+        plugins = cm.get_all_plugin_configs()
+        enabled = sum(1 for c in plugins.values() if isinstance(c, dict) and c.get("enabled"))
+        logger.info(
+            "config boot snapshot [%s]: %d plugin(s), %d enabled, timezone=%r, instance_name=%r",
+            stage,
+            len(plugins),
+            enabled,
+            general.get("timezone"),
+            general.get("instance_name"),
+        )
+    except Exception:  # pragma: no cover - diagnostics must never block boot
+        logger.debug("config boot snapshot [%s] failed", stage, exc_info=True)
 
 
 def _detect_post_upgrade_regression() -> dict[str, Any] | None:

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -671,6 +671,16 @@ async def lifespan(app: FastAPI):
     # Set up file-based logging
     _setup_file_logging()
 
+    # Auto-heal config dropped on an upgrade boot (#1102/#948) BEFORE the
+    # service + plugin registry read it. No-op unless this is a version-change
+    # boot with a snapshot that still holds the lost data.
+    try:
+        _restored = _auto_restore_post_upgrade_regression()
+        if _restored:
+            logger.warning("Post-upgrade auto-restore applied from snapshot: %s", _restored)
+    except Exception:  # pragma: no cover - safety net must never block boot
+        logger.debug("Post-upgrade auto-restore failed", exc_info=True)
+
     # If the most recent settings snapshot looks materially richer than the
     # live config (more enabled plugins, etc.), tell the user loudly on
     # startup so they don't have to discover the recovery path on their own.

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -47,6 +47,7 @@ from .schedules.models import ScheduleCreate, ScheduleUpdate  # noqa: E402
 from .schedules.service import get_schedule_service  # noqa: E402
 from .settings.service import VALID_OUTPUT_TARGETS, VALID_STRATEGIES, get_settings_service  # noqa: E402
 from .templates.engine import get_template_engine, reset_template_engine  # noqa: E402
+from .time_service import reset_time_service  # noqa: E402
 from .templates.expressions import function_signatures  # noqa: E402
 from .text_to_board import text_to_board_array  # noqa: E402
 
@@ -2146,6 +2147,49 @@ def _build_post_upgrade_restore_set(
         result["plugins"] = plugins
 
     return result
+
+
+def _auto_restore_post_upgrade_regression() -> dict[str, Any]:
+    """Restore config keys lost on an upgrade boot from the newest pre-update
+    snapshot, before the service/registry reads config. Returns a summary of
+    what was restored (empty when it did nothing). See issue #1102 / #948.
+    """
+    if os.environ.get("FIESTABOARD_AUTO_RESTORE", "1").strip().lower() in ("0", "false", "no"):
+        return {}
+
+    cm = get_config_manager()
+    if not getattr(cm, "version_changed_on_load", False):
+        return {}
+
+    newest = _resolve_snapshot_name(None)
+    if newest is None:
+        return {}
+    try:
+        snap_doc = json.loads(newest.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    snap_config = (snap_doc.get("data") or {}).get("config") or {}
+    if not snap_config:
+        return {}
+
+    restore_set = _build_post_upgrade_restore_set(snap_config, cm.get_all())
+    if not restore_set:
+        return {}
+
+    summary: dict[str, Any] = {}
+    general = restore_set.get("general")
+    if general:
+        cm.set_general(general)
+        summary["general"] = sorted(general)
+    plugins = restore_set.get("plugins")
+    if plugins:
+        for pid, cfg in plugins.items():
+            cm.set_plugin_config(pid, cfg)
+        summary["plugins"] = sorted(plugins)
+
+    # Restored timezone won't take effect until the cached TimeService is rebuilt.
+    reset_time_service()
+    return summary
 
 
 def _detect_post_upgrade_regression() -> dict[str, Any] | None:

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -47,9 +47,9 @@ from .schedules.models import ScheduleCreate, ScheduleUpdate  # noqa: E402
 from .schedules.service import get_schedule_service  # noqa: E402
 from .settings.service import VALID_OUTPUT_TARGETS, VALID_STRATEGIES, get_settings_service  # noqa: E402
 from .templates.engine import get_template_engine, reset_template_engine  # noqa: E402
-from .time_service import reset_time_service  # noqa: E402
 from .templates.expressions import function_signatures  # noqa: E402
 from .text_to_board import text_to_board_array  # noqa: E402
+from .time_service import reset_time_service  # noqa: E402
 
 logger = logging.getLogger(__name__)
 

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -2096,6 +2096,58 @@ def _list_settings_snapshots() -> list[dict[str, Any]]:
     return out
 
 
+# Config fields we know are user-set and safe to auto-restore from a snapshot.
+_RESTORABLE_GENERAL_FIELDS = ("timezone", "instance_name")
+
+
+def _build_post_upgrade_restore_set(
+    snap_config: dict[str, Any], live_config: dict[str, Any]
+) -> dict[str, Any]:
+    """Compute which config.json keys regressed vs a pre-update snapshot.
+
+    Returns ``{"general": {...}, "plugins": {...}}`` with only the keys worth
+    restoring; an empty dict means nothing regressed. See plan Task 2 for rules.
+    """
+    from src.config_manager import DEFAULT_CONFIG, SENSITIVE_FIELDS
+
+    result: dict[str, Any] = {}
+
+    snap_general = snap_config.get("general") or {}
+    live_general = live_config.get("general") or {}
+    default_general = DEFAULT_CONFIG.get("general", {})
+    general: dict[str, Any] = {}
+    for field in _RESTORABLE_GENERAL_FIELDS:
+        snap_val = snap_general.get(field)
+        if not isinstance(snap_val, str) or not snap_val:
+            continue
+        live_val = live_general.get(field)
+        if live_val == snap_val:
+            continue
+        if live_val in ("", None, default_general.get(field)):
+            general[field] = snap_val
+    if general:
+        result["general"] = general
+
+    snap_plugins = snap_config.get("plugins") or {}
+    live_plugins = live_config.get("plugins") or {}
+    plugins: dict[str, Any] = {}
+    for pid, snap_cfg in snap_plugins.items():
+        if not (isinstance(snap_cfg, dict) and snap_cfg.get("enabled") is True):
+            continue  # only auto-restore plugins the user had ENABLED (#937 invariant)
+        live_cfg = live_plugins.get(pid)
+        lost_enable = not (isinstance(live_cfg, dict) and live_cfg.get("enabled") is True)
+        lost_secret = isinstance(live_cfg, dict) and any(
+            key in SENSITIVE_FIELDS and snap_cfg.get(key) and not live_cfg.get(key)
+            for key in snap_cfg
+        )
+        if lost_enable or lost_secret:
+            plugins[pid] = snap_cfg
+    if plugins:
+        result["plugins"] = plugins
+
+    return result
+
+
 def _detect_post_upgrade_regression() -> dict[str, Any] | None:
     """Return a hint payload when the live config looks regressed against the
     newest pre-update snapshot.

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -341,6 +341,7 @@ class ConfigManager:
 
         self._config: dict[str, Any] = {}
         self._raw_features: dict[str, Any] = {}
+        self._version_changed_on_load = False
         self._load_or_create()
         self._auto_migrate_features_to_plugins()
         self._migrate_renamed_plugins()
@@ -445,6 +446,7 @@ class ConfigManager:
             return
 
         seen = self._config.get(APP_VERSION_SEEN_KEY)
+        self._version_changed_on_load = seen is not None and seen != current_version
         if seen == current_version:
             return
 
@@ -891,6 +893,15 @@ class ConfigManager:
         self._load_or_create()
         self._apply_env_overrides()
         logger.info("Configuration reloaded from file")
+
+    @property
+    def version_changed_on_load(self) -> bool:
+        """True if this process loaded an existing config from an older app version.
+
+        False on fresh installs, corrupt-config resets, and same-version restarts.
+        Drives the post-upgrade auto-restore so it only runs on a real upgrade boot.
+        """
+        return self._version_changed_on_load
 
     def get_all(self) -> dict[str, Any]:
         """Get full configuration (internal use - includes secrets)."""

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -317,6 +317,14 @@ class ConfigManager:
                 if cls._instance is None:
                     cls._instance = super().__new__(cls)
                     cls._instance._initialized = False
+                    # Initialised once per singleton lifetime (NOT in __init__,
+                    # which can re-run before _initialized flips — see the latch
+                    # in _maybe_snapshot_on_version_change). A re-entrant
+                    # ConfigManager() during the first __init__ (plugin-registry
+                    # init reaches back through get_config_manager) would
+                    # otherwise reset this to False and silently disable the
+                    # post-upgrade auto-restore (#1102).
+                    cls._instance._version_changed_on_load = False
         return cls._instance
 
     def __init__(self, config_path: str | None = None) -> None:
@@ -341,7 +349,6 @@ class ConfigManager:
 
         self._config: dict[str, Any] = {}
         self._raw_features: dict[str, Any] = {}
-        self._version_changed_on_load = False
         self._load_or_create()
         self._auto_migrate_features_to_plugins()
         self._migrate_renamed_plugins()
@@ -446,7 +453,12 @@ class ConfigManager:
             return
 
         seen = self._config.get(APP_VERSION_SEEN_KEY)
-        self._version_changed_on_load = seen is not None and seen != current_version
+        # Latch: once True for this process it stays True. A second load (e.g. a
+        # re-entrant get_config_manager() during plugin-registry init, or an
+        # explicit reload()) runs AFTER _stamp_app_version_seen has rewritten
+        # app_version_seen to the current version — recomputing from scratch
+        # would clear the flag and silently disable the auto-restore (#1102).
+        self._version_changed_on_load = self._version_changed_on_load or (seen is not None and seen != current_version)
         if seen == current_version:
             return
 

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1,5 +1,6 @@
 """Tests for ConfigManager singleton and configuration file management."""
 
+import importlib
 import json
 import threading
 from unittest.mock import MagicMock, patch
@@ -1110,9 +1111,9 @@ def test_no_pre_boot_snapshot_on_brand_new_install(tmp_path):
 
 def test_version_changed_on_load_true_after_upgrade(tmp_path, monkeypatch):
     """An existing config with an older app_version_seen flags a version change."""
-    import src
+    src_module = importlib.import_module("src")
 
-    monkeypatch.setattr(src, "__version__", "9.9.9")
+    monkeypatch.setattr(src_module, "__version__", "9.9.9")
     cfg = tmp_path / "config.json"
     cfg.write_text(json.dumps({"app_version_seen": "1.0.0", "plugins": {"weather": {"enabled": True}}}))
     cm = ConfigManager(config_path=str(cfg))
@@ -1121,9 +1122,9 @@ def test_version_changed_on_load_true_after_upgrade(tmp_path, monkeypatch):
 
 def test_version_changed_on_load_false_same_version(tmp_path, monkeypatch):
     """Restart on the same version is not a version change."""
-    import src
+    src_module = importlib.import_module("src")
 
-    monkeypatch.setattr(src, "__version__", "9.9.9")
+    monkeypatch.setattr(src_module, "__version__", "9.9.9")
     cfg = tmp_path / "config.json"
     cfg.write_text(json.dumps({"app_version_seen": "9.9.9", "plugins": {}}))
     cm = ConfigManager(config_path=str(cfg))
@@ -1132,9 +1133,9 @@ def test_version_changed_on_load_false_same_version(tmp_path, monkeypatch):
 
 def test_version_changed_on_load_false_fresh_install(tmp_path, monkeypatch):
     """A brand-new config (no file) is not a version change."""
-    import src
+    src_module = importlib.import_module("src")
 
-    monkeypatch.setattr(src, "__version__", "9.9.9")
+    monkeypatch.setattr(src_module, "__version__", "9.9.9")
     cm = ConfigManager(config_path=str(tmp_path / "config.json"))
     assert cm.version_changed_on_load is False
 
@@ -1169,9 +1170,9 @@ def test_version_changed_on_load_false_corrupt_config(tmp_path, monkeypatch):
     check, so the flag stays at its __new__ default of False — a corrupt-config
     reset must NOT trigger a restore from a (possibly stale) snapshot.
     """
-    import src
+    src_module = importlib.import_module("src")
 
-    monkeypatch.setattr(src, "__version__", "9.9.9")
+    monkeypatch.setattr(src_module, "__version__", "9.9.9")
     cfg = tmp_path / "config.json"
     cfg.write_text("not valid json {{{")
     cm = ConfigManager(config_path=str(cfg))

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1137,3 +1137,26 @@ def test_version_changed_on_load_false_fresh_install(tmp_path, monkeypatch):
     monkeypatch.setattr(src, "__version__", "9.9.9")
     cm = ConfigManager(config_path=str(tmp_path / "config.json"))
     assert cm.version_changed_on_load is False
+
+
+def test_version_changed_on_load_latches_across_second_load(tmp_path, monkeypatch):
+    """The flag must stay True after a second load that sees the stamped version.
+
+    Regression for #1102: the first load stamps ``app_version_seen`` to the
+    current version and resaves. A second ``_load_or_create`` in the same
+    process — triggered in production by the plugin registry reaching back
+    through ``get_config_manager()`` during the first ``__init__``, reproduced
+    here with an explicit ``reload()`` — then reads the already-stamped config.
+    Recomputing the flag from scratch would clear it to False and silently
+    disable the post-upgrade auto-restore. It must latch True for the process.
+    """
+    import src
+
+    monkeypatch.setattr(src, "__version__", "9.9.9")
+    cfg = tmp_path / "config.json"
+    cfg.write_text(json.dumps({"app_version_seen": "1.0.0", "plugins": {"weather": {"enabled": True}}}))
+    cm = ConfigManager(config_path=str(cfg))
+    assert cm.version_changed_on_load is True
+    # config.json now carries the current version; a second load must not clear it.
+    cm.reload()
+    assert cm.version_changed_on_load is True

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1114,9 +1114,7 @@ def test_version_changed_on_load_true_after_upgrade(tmp_path, monkeypatch):
 
     monkeypatch.setattr(src, "__version__", "9.9.9")
     cfg = tmp_path / "config.json"
-    cfg.write_text(
-        json.dumps({"app_version_seen": "1.0.0", "plugins": {"weather": {"enabled": True}}})
-    )
+    cfg.write_text(json.dumps({"app_version_seen": "1.0.0", "plugins": {"weather": {"enabled": True}}}))
     cm = ConfigManager(config_path=str(cfg))
     assert cm.version_changed_on_load is True
 

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1103,3 +1103,39 @@ def test_no_pre_boot_snapshot_on_brand_new_install(tmp_path):
 
     snapshot_dir = tmp_path / "update-backups"
     assert not snapshot_dir.exists() or not list(snapshot_dir.glob("pre-update-*.json"))
+
+
+# --- version_changed_on_load ---
+
+
+def test_version_changed_on_load_true_after_upgrade(tmp_path, monkeypatch):
+    """An existing config with an older app_version_seen flags a version change."""
+    import src
+
+    monkeypatch.setattr(src, "__version__", "9.9.9")
+    cfg = tmp_path / "config.json"
+    cfg.write_text(
+        json.dumps({"app_version_seen": "1.0.0", "plugins": {"weather": {"enabled": True}}})
+    )
+    cm = ConfigManager(config_path=str(cfg))
+    assert cm.version_changed_on_load is True
+
+
+def test_version_changed_on_load_false_same_version(tmp_path, monkeypatch):
+    """Restart on the same version is not a version change."""
+    import src
+
+    monkeypatch.setattr(src, "__version__", "9.9.9")
+    cfg = tmp_path / "config.json"
+    cfg.write_text(json.dumps({"app_version_seen": "9.9.9", "plugins": {}}))
+    cm = ConfigManager(config_path=str(cfg))
+    assert cm.version_changed_on_load is False
+
+
+def test_version_changed_on_load_false_fresh_install(tmp_path, monkeypatch):
+    """A brand-new config (no file) is not a version change."""
+    import src
+
+    monkeypatch.setattr(src, "__version__", "9.9.9")
+    cm = ConfigManager(config_path=str(tmp_path / "config.json"))
+    assert cm.version_changed_on_load is False

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1160,3 +1160,19 @@ def test_version_changed_on_load_latches_across_second_load(tmp_path, monkeypatc
     # config.json now carries the current version; a second load must not clear it.
     cm.reload()
     assert cm.version_changed_on_load is True
+
+
+def test_version_changed_on_load_false_corrupt_config(tmp_path, monkeypatch):
+    """A corrupt config that resets to defaults is not a version change.
+
+    The JSONDecodeError branch of _load_or_create skips the version-change
+    check, so the flag stays at its __new__ default of False — a corrupt-config
+    reset must NOT trigger a restore from a (possibly stale) snapshot.
+    """
+    import src
+
+    monkeypatch.setattr(src, "__version__", "9.9.9")
+    cfg = tmp_path / "config.json"
+    cfg.write_text("not valid json {{{")
+    cm = ConfigManager(config_path=str(cfg))
+    assert cm.version_changed_on_load is False

--- a/tests/test_post_upgrade_restore.py
+++ b/tests/test_post_upgrade_restore.py
@@ -40,7 +40,8 @@ def test_restore_set_recovers_plugin_that_lost_only_its_secret():
     snap = {"plugins": {"weather": {"enabled": True, "openweathermap_api_key": "real"}}}
     live = {"plugins": {"weather": {"enabled": True, "openweathermap_api_key": ""}}}
     result = _build_post_upgrade_restore_set(snap, live)
-    assert result["plugins"]["weather"]["openweathermap_api_key"] == "real"
+    # the FULL snapshot plugin config is restored, not just the lost secret key
+    assert result["plugins"]["weather"] == snap["plugins"]["weather"]
 
 
 def test_restore_set_does_not_resurrect_disabled_plugin():

--- a/tests/test_post_upgrade_restore.py
+++ b/tests/test_post_upgrade_restore.py
@@ -1,0 +1,53 @@
+"""Tests for post-upgrade config auto-restore (#1102 / #948)."""
+
+from src.api_server import _build_post_upgrade_restore_set
+
+
+def test_restore_set_recovers_timezone_lost_to_default():
+    snap = {"general": {"timezone": "America/New_York", "instance_name": "Kitchen"}}
+    live = {"general": {"timezone": "America/Los_Angeles", "instance_name": ""}}
+    result = _build_post_upgrade_restore_set(snap, live)
+    assert result["general"]["timezone"] == "America/New_York"
+    assert result["general"]["instance_name"] == "Kitchen"
+
+
+def test_restore_set_ignores_unchanged_general():
+    snap = {"general": {"timezone": "America/New_York", "instance_name": "Kitchen"}}
+    live = {"general": {"timezone": "America/New_York", "instance_name": "Kitchen"}}
+    result = _build_post_upgrade_restore_set(snap, live)
+    assert "general" not in result
+
+
+def test_restore_set_recovers_disabled_enabled_plugin_with_secrets():
+    snap = {"plugins": {"weather": {"enabled": True, "api_key": "real-key", "location": "NYC"}}}
+    live = {"plugins": {"weather": {"enabled": False}}}
+    result = _build_post_upgrade_restore_set(snap, live)
+    assert result["plugins"]["weather"] == snap["plugins"]["weather"]
+
+
+def test_restore_set_recovers_missing_enabled_plugin():
+    snap = {"plugins": {"stocks": {"enabled": True, "finnhub_api_key": "k"}}}
+    live = {"plugins": {}}
+    result = _build_post_upgrade_restore_set(snap, live)
+    assert "stocks" in result["plugins"]
+
+
+def test_restore_set_recovers_plugin_that_lost_only_its_secret():
+    snap = {"plugins": {"weather": {"enabled": True, "openweathermap_api_key": "real"}}}
+    live = {"plugins": {"weather": {"enabled": True, "openweathermap_api_key": ""}}}
+    result = _build_post_upgrade_restore_set(snap, live)
+    assert result["plugins"]["weather"]["openweathermap_api_key"] == "real"
+
+
+def test_restore_set_does_not_resurrect_disabled_plugin():
+    # User deliberately disabled it under the old version -> snapshot has enabled False.
+    snap = {"plugins": {"weather": {"enabled": False, "api_key": "real-key"}}}
+    live = {"plugins": {}}
+    result = _build_post_upgrade_restore_set(snap, live)
+    assert result.get("plugins", {}) == {}
+
+
+def test_restore_set_empty_when_nothing_regressed():
+    snap = {"general": {"timezone": "America/New_York"}, "plugins": {"weather": {"enabled": True}}}
+    live = {"general": {"timezone": "America/New_York"}, "plugins": {"weather": {"enabled": True}}}
+    assert _build_post_upgrade_restore_set(snap, live) == {}

--- a/tests/test_post_upgrade_restore.py
+++ b/tests/test_post_upgrade_restore.py
@@ -4,13 +4,12 @@ import json
 from unittest.mock import MagicMock
 
 import src.api_server as api_server
-from src.api_server import _build_post_upgrade_restore_set
 
 
 def test_restore_set_recovers_timezone_lost_to_default():
     snap = {"general": {"timezone": "America/New_York", "instance_name": "Kitchen"}}
     live = {"general": {"timezone": "America/Los_Angeles", "instance_name": ""}}
-    result = _build_post_upgrade_restore_set(snap, live)
+    result = api_server._build_post_upgrade_restore_set(snap, live)
     assert result["general"]["timezone"] == "America/New_York"
     assert result["general"]["instance_name"] == "Kitchen"
 
@@ -18,28 +17,28 @@ def test_restore_set_recovers_timezone_lost_to_default():
 def test_restore_set_ignores_unchanged_general():
     snap = {"general": {"timezone": "America/New_York", "instance_name": "Kitchen"}}
     live = {"general": {"timezone": "America/New_York", "instance_name": "Kitchen"}}
-    result = _build_post_upgrade_restore_set(snap, live)
+    result = api_server._build_post_upgrade_restore_set(snap, live)
     assert "general" not in result
 
 
 def test_restore_set_recovers_disabled_enabled_plugin_with_secrets():
     snap = {"plugins": {"weather": {"enabled": True, "api_key": "real-key", "location": "NYC"}}}
     live = {"plugins": {"weather": {"enabled": False}}}
-    result = _build_post_upgrade_restore_set(snap, live)
+    result = api_server._build_post_upgrade_restore_set(snap, live)
     assert result["plugins"]["weather"] == snap["plugins"]["weather"]
 
 
 def test_restore_set_recovers_missing_enabled_plugin():
     snap = {"plugins": {"stocks": {"enabled": True, "finnhub_api_key": "k"}}}
     live = {"plugins": {}}
-    result = _build_post_upgrade_restore_set(snap, live)
+    result = api_server._build_post_upgrade_restore_set(snap, live)
     assert "stocks" in result["plugins"]
 
 
 def test_restore_set_recovers_plugin_that_lost_only_its_secret():
     snap = {"plugins": {"weather": {"enabled": True, "openweathermap_api_key": "real"}}}
     live = {"plugins": {"weather": {"enabled": True, "openweathermap_api_key": ""}}}
-    result = _build_post_upgrade_restore_set(snap, live)
+    result = api_server._build_post_upgrade_restore_set(snap, live)
     # the FULL snapshot plugin config is restored, not just the lost secret key
     assert result["plugins"]["weather"] == snap["plugins"]["weather"]
 
@@ -48,14 +47,14 @@ def test_restore_set_does_not_resurrect_disabled_plugin():
     # User deliberately disabled it under the old version -> snapshot has enabled False.
     snap = {"plugins": {"weather": {"enabled": False, "api_key": "real-key"}}}
     live = {"plugins": {}}
-    result = _build_post_upgrade_restore_set(snap, live)
+    result = api_server._build_post_upgrade_restore_set(snap, live)
     assert result.get("plugins", {}) == {}
 
 
 def test_restore_set_empty_when_nothing_regressed():
     snap = {"general": {"timezone": "America/New_York"}, "plugins": {"weather": {"enabled": True}}}
     live = {"general": {"timezone": "America/New_York"}, "plugins": {"weather": {"enabled": True}}}
-    assert _build_post_upgrade_restore_set(snap, live) == {}
+    assert api_server._build_post_upgrade_restore_set(snap, live) == {}
 
 
 def _seed_snapshot(tmp_path, config_payload):

--- a/tests/test_post_upgrade_restore.py
+++ b/tests/test_post_upgrade_restore.py
@@ -51,3 +51,81 @@ def test_restore_set_empty_when_nothing_regressed():
     snap = {"general": {"timezone": "America/New_York"}, "plugins": {"weather": {"enabled": True}}}
     live = {"general": {"timezone": "America/New_York"}, "plugins": {"weather": {"enabled": True}}}
     assert _build_post_upgrade_restore_set(snap, live) == {}
+
+
+import json
+from unittest.mock import MagicMock
+
+import src.api_server as api_server
+
+
+def _seed_snapshot(tmp_path, config_payload):
+    snap = tmp_path / "pre-update-20260101T000000.000Z.json"
+    snap.write_text(json.dumps({"data": {"config": config_payload}}))
+    return snap
+
+
+def test_auto_restore_applies_general_and_plugins(tmp_path, monkeypatch):
+    snap_path = _seed_snapshot(
+        tmp_path,
+        {
+            "general": {"timezone": "America/New_York", "instance_name": "Kitchen"},
+            "plugins": {"weather": {"enabled": True, "api_key": "real"}},
+        },
+    )
+    cm = MagicMock()
+    cm.version_changed_on_load = True
+    cm.get_all.return_value = {
+        "general": {"timezone": "America/Los_Angeles", "instance_name": ""},
+        "plugins": {"weather": {"enabled": False}},
+    }
+    monkeypatch.setattr(api_server, "get_config_manager", lambda: cm)
+    monkeypatch.setattr(api_server, "_resolve_snapshot_name", lambda name=None: snap_path)
+    reset_called = MagicMock()
+    monkeypatch.setattr(api_server, "reset_time_service", reset_called)
+    monkeypatch.delenv("FIESTABOARD_AUTO_RESTORE", raising=False)
+
+    summary = api_server._auto_restore_post_upgrade_regression()
+
+    cm.set_general.assert_called_once()
+    assert cm.set_general.call_args[0][0] == {
+        "timezone": "America/New_York",
+        "instance_name": "Kitchen",
+    }
+    cm.set_plugin_config.assert_called_once_with("weather", {"enabled": True, "api_key": "real"})
+    reset_called.assert_called_once()
+    # summary lists are sorted() -> alphabetical
+    assert summary == {"general": ["instance_name", "timezone"], "plugins": ["weather"]}
+
+
+def test_auto_restore_noop_when_not_version_change(tmp_path, monkeypatch):
+    cm = MagicMock()
+    cm.version_changed_on_load = False
+    monkeypatch.setattr(api_server, "get_config_manager", lambda: cm)
+    monkeypatch.delenv("FIESTABOARD_AUTO_RESTORE", raising=False)
+    assert api_server._auto_restore_post_upgrade_regression() == {}
+    cm.set_general.assert_not_called()
+
+
+def test_auto_restore_noop_when_disabled_by_env(tmp_path, monkeypatch):
+    cm = MagicMock()
+    cm.version_changed_on_load = True
+    monkeypatch.setattr(api_server, "get_config_manager", lambda: cm)
+    monkeypatch.setenv("FIESTABOARD_AUTO_RESTORE", "0")
+    assert api_server._auto_restore_post_upgrade_regression() == {}
+    cm.set_general.assert_not_called()
+
+
+def test_auto_restore_noop_when_nothing_regressed(tmp_path, monkeypatch):
+    snap_path = _seed_snapshot(
+        tmp_path, {"general": {"timezone": "America/New_York"}, "plugins": {}}
+    )
+    cm = MagicMock()
+    cm.version_changed_on_load = True
+    cm.get_all.return_value = {"general": {"timezone": "America/New_York"}, "plugins": {}}
+    monkeypatch.setattr(api_server, "get_config_manager", lambda: cm)
+    monkeypatch.setattr(api_server, "_resolve_snapshot_name", lambda name=None: snap_path)
+    monkeypatch.setattr(api_server, "reset_time_service", MagicMock())
+    monkeypatch.delenv("FIESTABOARD_AUTO_RESTORE", raising=False)
+    assert api_server._auto_restore_post_upgrade_regression() == {}
+    cm.set_general.assert_not_called()

--- a/tests/test_post_upgrade_restore.py
+++ b/tests/test_post_upgrade_restore.py
@@ -1,5 +1,9 @@
 """Tests for post-upgrade config auto-restore (#1102 / #948)."""
 
+import json
+from unittest.mock import MagicMock
+
+import src.api_server as api_server
 from src.api_server import _build_post_upgrade_restore_set
 
 
@@ -51,12 +55,6 @@ def test_restore_set_empty_when_nothing_regressed():
     snap = {"general": {"timezone": "America/New_York"}, "plugins": {"weather": {"enabled": True}}}
     live = {"general": {"timezone": "America/New_York"}, "plugins": {"weather": {"enabled": True}}}
     assert _build_post_upgrade_restore_set(snap, live) == {}
-
-
-import json
-from unittest.mock import MagicMock
-
-import src.api_server as api_server
 
 
 def _seed_snapshot(tmp_path, config_payload):
@@ -117,9 +115,7 @@ def test_auto_restore_noop_when_disabled_by_env(tmp_path, monkeypatch):
 
 
 def test_auto_restore_noop_when_nothing_regressed(tmp_path, monkeypatch):
-    snap_path = _seed_snapshot(
-        tmp_path, {"general": {"timezone": "America/New_York"}, "plugins": {}}
-    )
+    snap_path = _seed_snapshot(tmp_path, {"general": {"timezone": "America/New_York"}, "plugins": {}})
     cm = MagicMock()
     cm.version_changed_on_load = True
     cm.get_all.return_value = {"general": {"timezone": "America/New_York"}, "plugins": {}}


### PR DESCRIPTION
## Summary

Self-healing **post-upgrade config auto-restore**, closing the reopened half of #1102 (a re-run of #948, *"integrations lost on upgrade"*).

The first #1102 fix taught the startup validator to consult the multi-board settings service, so board creds + schedule survive Docker auto-updates. But the reporter still loses **board/install name, global timezone, and integrations (plugin selections + their API keys)** on every Watchtower update. Those all live in `data/config.json`, and the loss correlates with version changes. The #948 commit candidly notes the exact line that wipes config "remains elusive" — so three *mitigations* were shipped (pre-update snapshot, a plugin-only regression hint, manual rollback), but the detection never covered timezone/name/plugin-config and recovery was manual + all-or-nothing.

This PR **generalizes that mitigation into an automatic, root-cause-agnostic recovery**: on a version-change boot, it diffs the live config against the newest pre-update snapshot and restores only the regressed keys, before the service/plugin-registry reads config.

## How it works

- **`config_manager.py`** — a latched `version_changed_on_load` flag marking genuine upgrade boots.
- **`api_server.py`**
  - `_build_post_upgrade_restore_set(snap, live)` — pure diff of `general.timezone`, `general.instance_name`, and `plugins.*`.
  - `_auto_restore_post_upgrade_regression()` — gated apply (env opt-out → version-change → snapshot readable → non-empty restore set), persists via existing `ConfigManager` setters, resets the cached time service.
  - `_log_config_boot_snapshot(stage)` — boot-boundary diagnostics (the forensic net for the "snapshot already empty" case).
  - Wired into `lifespan` **before** `get_service()`.
- **`env.example`** — `FIESTABOARD_AUTO_RESTORE` (default on).

## Design guarantees

- **Version-gated** — only acts on a real upgrade boot, never a same-version restart.
- **#937-safe** — only restores plugins that were `enabled: True` in the snapshot, so a deliberately removed/disabled plugin is never resurrected.
- **Non-destructive** — only restores a key whose live value is empty/default; never overwrites live data.
- **Idempotent** and **boot-safe** (failures are swallowed, never block startup).
- **Env opt-out** for operators who prefer manual rollback.

Deferred by design (see spec §9): a save-boundary write-guard, full `config.json`/`settings.json` store unification, and the deeper root-cause hunt (a recurrence the snapshot can't recover un-defers it via the new diagnostics).

## Testing

- New unit tests: regression-set builder + auto-restore gating (`tests/test_post_upgrade_restore.py`), version-flag + **re-entrancy latch** + corrupt-config (`tests/test_config_manager.py`).
- **Full suite: 3823 passed, 11 skipped.** `ruff check` + `ruff format --check` clean.
- A real-file end-to-end run (real `ConfigManager` + real snapshot + real disk write) confirmed restore works **and surfaced a production-breaking bug**: `version_changed_on_load` was reset to `False` by a re-entrant `ConfigManager()` during init (plugin-registry init reaches back through `get_config_manager()` before `_initialized` flips), which would have silently no-opped the whole feature. Fixed by initializing the flag in `__new__` and latching it; pinned by a regression test.

Design spec and implementation plan are included under `docs/superpowers/`.

Closes #1102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
