### PR TITLE
fix(board): note-array review rollup + cross-issue throttle test fix

### DIFF
--- a/integration-tests/mock-cloud/server.py
+++ b/integration-tests/mock-cloud/server.py
@@ -180,7 +180,9 @@ class Handler(BaseHTTPRequestHandler):
             grid = body["characters"]
             dims = _grid_dimensions(grid)
             if dims is None:
-                self._send_json(400, {"error": "Request must include 'characters'"})
+                # Distinct from the missing-key error above: the key is present but
+                # the value isn't a non-empty rectangular 2-D int grid.
+                self._send_json(400, {"error": "'characters' must be a non-empty rectangular 2-D int array"})
                 return
 
             rows, cols = dims

--- a/integration-tests/test_cloud_mock.py
+++ b/integration-tests/test_cloud_mock.py
@@ -195,6 +195,12 @@ def board_client_module(monkeypatch: pytest.MonkeyPatch, mock_server: str):
     from src import board_client
 
     monkeypatch.setattr(board_client.BoardClient, "CLOUD_NOTE_ARRAY_API_URL", mock_server)
+    # Reset the module-level note-array send throttle so each test starts clean.
+    # Without this, a send in one test leaves a timestamp keyed by note_array_token
+    # that throttles the next test's send within the 15s window (the send→read
+    # roundtrip would then read a stale grid). Mirrors the autouse reset in
+    # tests/test_board_client.py.
+    board_client._note_array_last_send.clear()
     return board_client
 
 

--- a/src/board_client.py
+++ b/src/board_client.py
@@ -317,15 +317,27 @@ class BoardClient:
             logger.error(f"Invalid strategy: {strategy}. Must be one of {VALID_STRATEGIES}")
             return (False, False)
 
-        # Note-array boards do not support transitions; strip and warn.
-        if self._is_note_array and strategy is not None:
-            logger.debug("Note-array board: transition strategy %r is not supported and will be ignored.", strategy)
+        # Note-array boards do not support transitions; strip and warn. Guard on
+        # ANY transition param (not just strategy) so a caller passing only
+        # step_interval_ms/step_size still gets the debug breadcrumb explaining
+        # why their animation param was dropped.
+        if self._is_note_array and any(p is not None for p in (strategy, step_interval_ms, step_size)):
+            logger.debug(
+                "Note-array board: transition params (strategy=%r, step_interval_ms=%r, step_size=%r) "
+                "are not supported and will be ignored.",
+                strategy,
+                step_interval_ms,
+                step_size,
+            )
             strategy = None
             step_interval_ms = None
             step_size = None
 
         # Rate-limit note-array sends to >= NOTE_ARRAY_MIN_SEND_INTERVAL seconds.
         # Read the clock once and reuse it for the success-path timestamp below.
+        # The check+update below is not locked: FiestaBoard's send paths run on a
+        # single-threaded main loop, so the TOCTOU window is unreachable in
+        # practice. If sends ever become concurrent, guard this with a per-token lock.
         now = self._time_func() if self._is_note_array else None
         if self._is_note_array:
             last = _note_array_last_send.get(self._note_array_token)

--- a/src/devices.py
+++ b/src/devices.py
@@ -259,9 +259,11 @@ def classify_dimensions(rows: int, cols: int) -> dict:
             "matched_preset": matched_preset,
         }
 
+    # All dimensions in this message are rows×cols (matching the "{rows}×{cols}"
+    # grid description) so the comparison sizes read consistently.
     raise ValueError(
-        f"Grid {rows}×{cols} is unclassifiable: not a flagship ({flagship.cols}×{flagship.rows}), "
-        f"not a Note ({note.cols}×{note.rows}), and not a valid note-array grid "
+        f"Grid {rows}×{cols} is unclassifiable: not a flagship ({flagship.rows}×{flagship.cols}), "
+        f"not a Note ({note.rows}×{note.cols}), and not a valid note-array grid "
         f"(rows must be a multiple of {NOTE_ROWS}, cols a multiple of {NOTE_COLS}, "
         f"each axis ≤ {MAX_NOTES_PER_AXIS} notes)."
     )


### PR DESCRIPTION
Part of the Note Arrays epic #1167. Targets `next`. Post-merge follow-up addressing @claude review findings on the Wave-3 PRs **plus a real integration bug**.

## 🐞 Integration bug (most important)
`integration-tests/test_cloud_mock.py::test_board_client_send_then_read_roundtrip` **fails on the current `next`**. #1169 added a 15s note-array send throttle; #1181's roundtrip test sends twice within 15s (after an earlier test in the class) without resetting the module-level `_note_array_last_send` dict, so the second send is throttled and the read sees a stale grid. Each PR passed its own CI independently (strict=false → not tested together); the conflict is semantic, not textual. **Fix:** clear the throttle dict in the `board_client_module` fixture (mirrors the autouse reset #1169 added to `tests/test_board_client.py`). This would otherwise fail the `next→main` integration run.

## @claude review polish
- **[#1172] `src/devices.py`** — `classify_dimensions` unclassifiable error mixed orders: grid described `{rows}×{cols}` ("5×15") but comparisons `{cols}×{rows}` ("22×6"). Both rows×cols now.
- **[#1169] `src/board_client.py`** — broaden the transition-strip guard to fire on any of `strategy`/`step_interval_ms`/`step_size` (lone step params now log why they were dropped); comment the throttle check+update's single-threaded-safe TOCTOU.
- **[#1181] `integration-tests/mock-cloud/server.py`** — distinct 400 message for a jagged/non-rectangular grid vs the missing-key case.

## Verification
`ruff check`/`format --check`: clean · `tests/` (minus `tests/ai`) + `integration-tests/test_cloud_mock.py`: **3858 passed, 0 failures** (was 1 failed on `next`).

Disjoint from #1178 (web) and #1179 (adds test files; this touches different ones).

🤖 Generated with [Claude Code](https://claude.com/claude-code)