### PR TITLE
docs: note-array setup, reference, README + env.example [#1182]

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <a href="https://discord.gg/JvN8y6ahaf"><img src="https://img.shields.io/badge/Discord-Join%20us-7289da?logo=discord&logoColor=white" alt="Discord"></a>
 </p>
 
-**FiestaBoard is free, open-source software for Vestaboard and split-flap displays.** It gives you a self-hosted platform with a plugin system to pull in data from the sources that matter to you - weather, stocks, transit, sports, surf conditions, and more - and display it on your board. Compatible with Vestaboard Flagship (22x6) and Note (15x3).
+**FiestaBoard is free, open-source software for Vestaboard and split-flap displays.** It gives you a self-hosted platform with a plugin system to pull in data from the sources that matter to you - weather, stocks, transit, sports, surf conditions, and more - and display it on your board. Compatible with Vestaboard Flagship (22 × 6), Note (15 × 3), and Note arrays (multiple Notes tiled into one larger canvas).
 
 You bring the board. You bring the API keys for the services you care about. FiestaBoard handles the rest.
 
@@ -243,6 +243,24 @@ Works from anywhere with internet. No transition animations.
 4. Copy the key
 
 See [Cloud API Setup](https://fiestaboard.app/docs/setup/cloud-api) for details on choosing between the two modes.
+
+### Note Array
+
+A **Note array** is several Vestaboard Notes tiled into one larger display. FiestaBoard treats the array as a single canvas and renders pages across it. Each Note is 15 × 3 characters, so an array's size is `(notes wide × 15) × (notes tall × 3)` characters.
+
+Five preset sizes are available, plus a custom size up to **8 × 8 Notes**:
+
+| Preset | Notes (W × H) | Characters (W × H) |
+|--------|---------------|--------------------|
+| 2 side-by-side | 2 × 1 | 30 × 3 |
+| 4 side-by-side | 4 × 1 | 60 × 3 |
+| 2 stacked | 1 × 2 | 15 × 6 |
+| 4 stacked | 1 × 4 | 15 × 12 |
+| 2 × 2 grid | 2 × 2 | 30 × 6 |
+
+Note arrays connect through the **Vestaboard Cloud API** using an `X-Vestaboard-Token` (from your Vestaboard Cloud API subscription) — not the Read/Write key. Configure the board type, size, and token in **Settings → Display**, or let FiestaBoard read the array and pick the size for you with **Auto-detect from board**.
+
+**→ [Note Array setup guide](docs/setup/NOTE_ARRAYS.md)** for the full walkthrough, and the [Note Arrays reference](docs/reference/NOTE_ARRAYS.md) for the dimensions model and API details.
 
 ---
 

--- a/docs/reference/NOTE_ARRAYS.md
+++ b/docs/reference/NOTE_ARRAYS.md
@@ -1,0 +1,147 @@
+# Note Arrays reference
+
+This is the technical reference for Note-array support: the dimensions model,
+the built-in presets, custom sizing, the Cloud API transport, and the
+auto-detect endpoint. For a user-facing walkthrough, see the
+[Note Array setup guide](../setup/NOTE_ARRAYS.md).
+
+The source of truth is `src/devices.py` (geometry) and `src/board_client.py`
+(transport). The constants below mirror those modules.
+
+## Dimensions model
+
+A **Note** is the unit of a Note array:
+
+| Constant            | Value | Meaning                              |
+|---------------------|-------|--------------------------------------|
+| `NOTE_COLS`         | 15    | Characters wide per Note             |
+| `NOTE_ROWS`         | 3     | Characters tall per Note             |
+| `MAX_NOTES_PER_AXIS`| 8     | Maximum Notes along either axis      |
+
+An array is a grid of `notes_wide × notes_tall` Notes. Its character
+dimensions are:
+
+```text
+cols = notes_wide × NOTE_COLS   (= notes_wide × 15)
+rows = notes_tall × NOTE_ROWS   (= notes_tall × 3)
+```
+
+`resolve_dimensions(device_type, notes_wide, notes_tall)` returns the
+`(rows, cols)` for any device type — fixed values for `flagship` (6 × 22) and
+`note` (3 × 15), and the computed grid for `note_array`.
+
+Both axes are capped at `MAX_NOTES_PER_AXIS` (8), so the largest supported
+array is 8 × 8 Notes = `120 × 24` characters. The UI clamps **Notes wide** and
+**Notes tall** to the range 1–8, and `BoardInstance.__post_init__` clamps the
+stored values to the same range.
+
+> **Wording:** the app displays sizes as **width × height** in characters (for
+> example `60 × 3` for a 4-wide array). This reference lists Note counts as
+> **W × H** as well.
+
+## Presets
+
+Five presets are defined in `NOTE_ARRAY_PRESETS`:
+
+| Preset id  | Label          | Notes (W × H) | Characters (W × H) |
+|------------|----------------|---------------|--------------------|
+| `2_wide`   | 2 side-by-side | 2 × 1         | 30 × 3             |
+| `4_wide`   | 4 side-by-side | 4 × 1         | 60 × 3             |
+| `2_tall`   | 2 stacked      | 1 × 2         | 15 × 6             |
+| `4_tall`   | 4 stacked      | 1 × 4         | 15 × 12            |
+| `2x2_grid` | 2 × 2 grid     | 2 × 2         | 30 × 6             |
+
+## Custom sizing
+
+Any `notes_wide × notes_tall` from 1 to 8 on each axis is valid, including
+sizes outside the presets (for example `3 × 2` Notes → `45 × 6`).
+
+`is_valid_note_array_grid(rows, cols)` validates a raw character grid:
+
+- `rows > 0` and `cols > 0`
+- `rows` is a multiple of `NOTE_ROWS` (3) and `cols` is a multiple of
+  `NOTE_COLS` (15)
+- `rows // NOTE_ROWS ≤ 8` and `cols // NOTE_COLS ≤ 8`
+
+## Cloud API transport
+
+Note arrays use the **Vestaboard Cloud API**, which is distinct from the older
+Read/Write cloud (`rw.vestaboard.com`) used by single Flagship and Note boards.
+
+| Property    | Value                                                   |
+|-------------|---------------------------------------------------------|
+| Base URL    | `https://cloud.vestaboard.com/`                         |
+| Auth header | `X-Vestaboard-Token: <token>`                           |
+| Send        | `POST` with body `{"characters": <grid>}`               |
+| Read        | `GET`; returns `{"currentMessage": {"layout": <grid>}}` |
+
+The `<grid>` is a `rows × cols` array of Vestaboard character codes sized to the
+array. On read, `layout` may be a JSON-encoded string; FiestaBoard parses it
+(`parse_read_message_payload`) and returns the decoded grid.
+
+### Constraints
+
+- **No transitions.** The Cloud API replaces the whole frame at once. Any
+  transition `strategy` passed to `send_characters()` is stripped and ignored
+  for Note-array boards.
+- **Rate limit: ≥ 15 seconds between sends.** `NOTE_ARRAY_MIN_SEND_INTERVAL` is
+  `15.0` seconds. `BoardClient` tracks the last send per token and silently
+  skips a send that arrives too soon (returning "no change" rather than
+  erroring), so the platform's refresh loop stays well-behaved.
+
+## Auto-detect endpoint
+
+`POST /settings/board/{board_id}/detect-size`
+
+Reads the board's current layout over its own transport
+(`board_client_from_board_dict`) and classifies the grid with
+`classify_dimensions(rows, cols)`.
+
+**Response** — always includes `device_type`, `rows`, `cols`. For note arrays it
+also includes `notes_wide`, `notes_tall`, and `matched_preset`:
+
+```json
+{
+  "device_type": "note_array",
+  "rows": 6,
+  "cols": 30,
+  "notes_wide": 2,
+  "notes_tall": 2,
+  "matched_preset": "2 × 2 grid"
+}
+```
+
+Error responses:
+
+| Status | Cause                                                |
+|--------|------------------------------------------------------|
+| `404`  | Unknown board id.                                    |
+| `400`  | Board is not configured (missing credentials).       |
+| `422`  | Board returned no layout, or an unclassifiable grid. |
+
+### `classify_dimensions` behavior
+
+Given a raw `(rows, cols)`, `classify_dimensions` decides the device type in
+this order:
+
+1. **Flagship** — exactly `6 × 22` → `{"device_type": "flagship", ...}`.
+2. **Note** — exactly `3 × 15` → `{"device_type": "note", ...}`.
+3. **Note array** — passes `is_valid_note_array_grid` → `note_array` with
+   `notes_wide = cols // 15`, `notes_tall = rows // 3`, and `matched_preset` set
+   to a preset **label** when the geometry matches one of the five presets,
+   otherwise `null`.
+4. Otherwise it raises `ValueError` (surfaced as the `422` above).
+
+Order matters: the exact Flagship and Note sizes are checked **before** the
+note-array branch, so a single Note never classifies as a 1 × 1 array.
+
+> **Note for the UI:** the Settings UI matches the detected `notes_wide` /
+> `notes_tall` against the preset table to drive the dropdown — it does not rely
+> on the `matched_preset` label string, which is a human-readable hint only.
+
+## See also
+
+- [Note Array setup guide](../setup/NOTE_ARRAYS.md) — user-facing configuration.
+- `src/devices.py` — geometry constants, presets, `resolve_dimensions`,
+  `classify_dimensions`.
+- `src/board_client.py` — Cloud API send/read and rate limiting.

--- a/docs/setup/NOTE_ARRAYS.md
+++ b/docs/setup/NOTE_ARRAYS.md
@@ -1,0 +1,111 @@
+# Note Array setup
+
+A **Note array** is several Vestaboard Notes tiled together into one larger
+display. FiestaBoard treats the whole array as a single canvas, so your pages,
+plugins, and schedules render across it just like they would on a Flagship or a
+single Note.
+
+This page walks through connecting a Note array, picking its size, and getting
+your Cloud API token.
+
+> **Where to get your token:** Note arrays talk to the **Vestaboard Cloud API**
+> using an `X-Vestaboard-Token`. You get this token from your Vestaboard Cloud
+> API subscription — it is **not** the Read/Write key used by single Flagship
+> and Note boards.
+
+## Overview
+
+Each Note is 15 × 3 characters. An array is a grid of Notes, so its size in
+characters is:
+
+```text
+width  = notes wide × 15
+height = notes tall × 3
+```
+
+Sizes are described as **width × height** throughout the app (for example a
+4-wide array is `60 × 3`).
+
+You'll need:
+
+- A Vestaboard Note array (two or more Notes configured as a single board).
+- A **Vestaboard Cloud API subscription** and its `X-Vestaboard-Token`.
+- A running FiestaBoard instance you can reach in a browser.
+
+## Quick setup
+
+### 1. Add the board
+
+In the FiestaBoard web UI, open **Settings → Display** and add a board (or edit
+an existing one).
+
+### 2. Choose the board type and size
+
+Open the **Board type** dropdown. It is grouped into:
+
+- **Devices** — Flagship and Note (single boards).
+- **Note arrays** — the five presets below, plus **Custom…**.
+
+Pick a preset that matches your hardware:
+
+| Board type        | Notes (W × H) | Characters (W × H) |
+|-------------------|---------------|--------------------|
+| 2 side-by-side    | 2 × 1         | 30 × 3             |
+| 4 side-by-side    | 4 × 1         | 60 × 3             |
+| 2 stacked         | 1 × 2         | 15 × 6             |
+| 4 stacked         | 1 × 4         | 15 × 12            |
+| 2 × 2 grid        | 2 × 2         | 30 × 6             |
+
+If your array isn't one of the presets, choose **Custom…** and set **Notes
+wide** and **Notes tall** (each from 1 to 8). For example, `3 × 2` Notes gives a
+`45 × 6` canvas.
+
+### 3. Paste the Cloud API token
+
+With a Note-array size selected, a **Cloud API Token** field appears. Paste your
+`X-Vestaboard-Token` here. Once saved, the field shows a masked placeholder to
+confirm the token is set.
+
+### 4. (Optional) Auto-detect instead
+
+If you'd rather not look up your array's size by hand, click **Auto-detect from
+board**. FiestaBoard reads the array's current layout over the Cloud API and
+fills in the board type and size for you. (You still need the token saved first,
+since the read uses it.)
+
+### 5. View it
+
+Save your changes. FiestaBoard renders your active page across the full array.
+Open the page editor or preview to confirm the layout looks right at the new
+size.
+
+## Good to know
+
+- **No transition animations.** The Cloud API used by Note arrays sends a full
+  frame at once; FiestaBoard skips transition strategies for these boards.
+- **One send every 15 seconds.** Note-array sends are rate-limited to at least
+  15 seconds apart. FiestaBoard throttles automatically — rapid changes are
+  coalesced rather than rejected — but very fast page rotations may not all
+  reach the board.
+
+## Troubleshooting
+
+**"Could not detect the board configuration."**
+The array returned no layout, or a size FiestaBoard can't classify. Confirm the
+token is correct and the board is reachable, then set the size manually with the
+**Board type** dropdown instead of Auto-detect.
+
+**The board doesn't update.**
+Note arrays only send through the Cloud API. Make sure the **Cloud API Token**
+field is set (it shows a masked placeholder when saved) and that your Vestaboard
+Cloud API subscription is active. Sends are also rate-limited to one every 15
+seconds — see [Good to know](#good-to-know).
+
+**The layout looks cut off or wrong.**
+Check that **Notes wide** and **Notes tall** match your physical hardware. The
+displayed size (for example `30 × 6`) is `width × height` in characters.
+
+## See also
+
+- [Note Arrays reference](../reference/NOTE_ARRAYS.md) — the dimensions model,
+  the presets, custom sizing, and the auto-detect endpoint for contributors.

--- a/env.example
+++ b/env.example
@@ -22,10 +22,15 @@ BOARD_HOST=192.168.0.11  # IP or hostname (e.g., board.local)
 BOARD_READ_WRITE_KEY=your_read_write_api_key_here  # Used when BOARD_API_MODE=cloud
 #
 # For Note Array boards (Vestaboard Note Array hardware):
-# - Note Arrays connect exclusively via the Cloud API using a bearer token
-# - Obtain your token from https://web.vestaboard.com (Settings -> API)
-# - Set device_type = "note_array" on the board in FiestaBoard Settings
-BOARD_NOTE_ARRAY_TOKEN=your_note_array_token_here
+# - Note Arrays connect exclusively via the Vestaboard Cloud API, authenticated
+#   with an X-Vestaboard-Token header (NOT the Read/Write key above).
+# - Obtain the token from your Vestaboard Cloud API subscription.
+# - Constraints: no transition animations, and at least 15 seconds between sends.
+# - This is normally set per-board in the UI (Settings -> Display -> Board type =
+#   a Note-array preset or "Custom…", then paste the Cloud API Token). The value
+#   below is provided for completeness / headless setups.
+# - See docs/setup/NOTE_ARRAYS.md for the full walkthrough.
+BOARD_NOTE_ARRAY_TOKEN=your-vestaboard-cloud-token
 
 # Board Transition Settings (optional)
 # Control how the board animates when displaying new messages


### PR DESCRIPTION
Closes #1182. Part of the Note Arrays epic #1167. Targets `next`.

## What
User- and contributor-facing documentation for note arrays.

- **README.md** — new "Note Array" subsection (under board API setup): what it is, the 5 presets (table, width × height), custom up to 8×8 Notes, the `X-Vestaboard-Token` Cloud API auth, and the Settings/Auto-detect flow; intro updated to mention Note arrays.
- **`docs/setup/NOTE_ARRAYS.md`** (new) — user setup guide: where to get the Cloud API token, a 5-step quick setup (add board → preset/Custom W×H → paste token → optional Auto-detect → view), the no-transitions/15s-rate-limit note, and troubleshooting.
- **`docs/reference/NOTE_ARRAYS.md`** (new — creates `docs/reference/`) — contributor reference: dimensions model (Note = 15×3, 8-per-axis cap), presets table, custom sizing + `is_valid_note_array_grid`, the Cloud API transport (`cloud.vestaboard.com`, `X-Vestaboard-Token`, `{"characters": grid}`, `currentMessage.layout`), constraints, the `detect-size` endpoint, and `classify_dimensions`.
- **`env.example`** — clarified the existing `BOARD_NOTE_ARRAY_TOKEN` block (it's the Cloud API `X-Vestaboard-Token`, not the RW key; no transitions/15s; normally set per-board in the UI); placeholder `your-vestaboard-cloud-token`.

## Verification
- No real personal data / tokens / coordinates — placeholders only (CLAUDE.md privacy rules).
- markdownlint-cli2 (default rules): **0 errors** on both new docs. (Repo enforces no markdownlint config in CI.)
- All relative links resolve; setup ↔ reference cross-link; README links both. Setup steps match the shipped #1178 UI labels.

Docs-only — disjoint from all other PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)