### PR TITLE
feat(plugins): add note-array support to Device Size Support (#1232) BoardContext

### DIFF
--- a/src/devices.py
+++ b/src/devices.py
@@ -315,3 +315,20 @@ def classify_dimensions(rows: int, cols: int) -> dict:
 
 # Default device type for backward compatibility
 DEFAULT_DEVICE_TYPE: DeviceType = "flagship"
+
+
+def board_context_for(device_type: str, notes_wide: int = 1, notes_tall: int = 1) -> BoardContext:
+    """Build a :class:`BoardContext` for any device type, including note arrays.
+
+    Unlike :meth:`BoardContext.from_device_type` (flagship/note only), this
+    resolves note-array geometry from ``notes_wide``/``notes_tall`` via
+    :func:`resolve_dimensions`, so plugins receive the board's true size. Falls
+    back to the default device for an unrecognized type so a bad value never
+    crashes a render.
+    """
+    try:
+        dims = resolve_dimensions(device_type, notes_wide, notes_tall)
+    except ValueError:
+        device_type = DEFAULT_DEVICE_TYPE
+        dims = resolve_dimensions(device_type, notes_wide, notes_tall)
+    return BoardContext(device_type=device_type, rows=dims.rows, cols=dims.cols)

--- a/src/pages/service.py
+++ b/src/pages/service.py
@@ -12,6 +12,8 @@ from src.devices import (
     DEFAULT_DEVICE_TYPE,
     DEVICE_DIMENSIONS,
     BoardContext,
+    board_context_for,
+    is_note_array,
     resolve_dimensions,
 )
 from src.displays.service import DisplayResult, get_display_service
@@ -328,9 +330,23 @@ class PageService:
 
     @staticmethod
     def _board_for_page(page: Page) -> BoardContext:
-        """Build a BoardContext for a page, falling back to the default device."""
-        device_type = page.device_type if page.device_type in DEVICE_DIMENSIONS else DEFAULT_DEVICE_TYPE
-        return BoardContext.from_device_type(device_type)
+        """Build a BoardContext for a page (note-array aware).
+
+        Resolves note-array geometry from the page's notes_wide/notes_tall so a
+        note-array page's plugins receive the board's true size, not flagship's.
+        """
+        return board_context_for(page.device_type, page.notes_wide, page.notes_tall)
+
+    @staticmethod
+    def _board_key(page: Page) -> str:
+        """Stable key identifying a page's board *size* for batch context sharing.
+
+        Flagship/Note have fixed sizes (keyed by device_type); note arrays vary,
+        so their dimensions are folded in — matching :meth:`PluginBase._cache_key`.
+        """
+        if is_note_array(page.device_type):
+            return f"note_array:{page.notes_wide}x{page.notes_tall}"
+        return page.device_type if page.device_type in DEVICE_DIMENSIONS else DEFAULT_DEVICE_TYPE
 
     def _render_single(self, page: Page) -> DisplayResult:
         """Render a single-source page."""
@@ -537,30 +553,31 @@ class PageService:
 
             pages_to_render.append((page_id, page))
 
-        # Build shared template context once per distinct device type. Plugins
+        # Build shared template context once per distinct board *size*. Plugins
         # may emit different data per board size, so a single shared context
-        # would be wrong when pages target different devices; fanning out once
-        # per device type (not per page) keeps the efficiency win.
-        contexts_by_device: dict[str, dict] = {}
-        template_device_types = {
-            (p.device_type if p.device_type in DEVICE_DIMENSIONS else DEFAULT_DEVICE_TYPE)
-            for _, p in pages_to_render
-            if p.type == "template"
-        }
-        if template_device_types:
+        # would be wrong when pages target different sizes; fanning out once per
+        # distinct board (not per page) keeps the efficiency win. Note arrays of
+        # different sizes are distinct boards (see _board_key).
+        contexts_by_board: dict[str, dict] = {}
+        boards: dict[str, BoardContext] = {}
+        for _, p in pages_to_render:
+            if p.type != "template":
+                continue
+            key = self._board_key(p)
+            if key not in boards:
+                boards[key] = board_context_for(p.device_type, p.notes_wide, p.notes_tall)
+        if boards:
             try:
                 from src.plugins.registry import get_plugin_registry
 
-                boards = {dt: BoardContext.from_device_type(dt) for dt in template_device_types}
-                contexts_by_device = get_plugin_registry().build_template_contexts_for(boards)
+                contexts_by_board = get_plugin_registry().build_template_contexts_for(boards)
             except Exception as e:
                 logger.error(f"Failed to build shared template context: {e}")
 
         # Second pass: render pages that missed cache
         for page_id, page in pages_to_render:
             try:
-                page_device = page.device_type if page.device_type in DEVICE_DIMENSIONS else DEFAULT_DEVICE_TYPE
-                result = self.render_page(page, context=contexts_by_device.get(page_device))
+                result = self.render_page(page, context=contexts_by_board.get(self._board_key(page)))
 
                 # Cache the result
                 self._preview_cache[page_id] = CachedPreview(

--- a/src/plugins/base.py
+++ b/src/plugins/base.py
@@ -371,12 +371,20 @@ class PluginBase(ABC):
 
     @staticmethod
     def _cache_key(board: BoardContext | None) -> str:
-        """Cache key for a board: its device_type, or the default sentinel.
+        """Cache key for a board: keyed on its size, or the default sentinel.
 
-        Keyed on ``device_type`` only (not color/name) so the cache holds at
-        most one entry per board size, not per physical board.
+        Keyed on board *size* (not color/name) so the cache holds at most one
+        entry per distinct board geometry, not per physical board. Flagship and
+        Note have fixed sizes, so their ``device_type`` is a sufficient key; note
+        arrays all share ``device_type`` ``"note_array"`` but vary in size, so
+        their dimensions are folded in to avoid collisions between, e.g., a
+        60×3 and a 6×30 array.
         """
-        return board.device_type if board else _DEFAULT_CACHE_KEY
+        if board is None:
+            return _DEFAULT_CACHE_KEY
+        if board.device_type == "note_array":
+            return f"note_array:{board.cols}x{board.rows}"
+        return board.device_type
 
     def clear_cache(self) -> None:
         """Clear all cached data, forcing a fresh fetch on the next get_data() call.

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -13,6 +13,7 @@ from src.devices import (
     BoardContext,
     BoardInstance,
     DeviceDimensions,
+    board_context_for,
     classify_dimensions,
     get_dimensions,
     is_note_array,
@@ -749,3 +750,36 @@ class TestClassifyDimensions:
         """3×0 → ValueError."""
         with pytest.raises(ValueError):
             classify_dimensions(3, 0)
+
+
+class TestBoardContextFor:
+    """Tests for board_context_for() — note-array-aware BoardContext factory."""
+
+    def test_flagship(self):
+        b = board_context_for("flagship")
+        assert (b.device_type, b.rows, b.cols) == ("flagship", 6, 22)
+        assert (b.width, b.height) == (22, 6)
+
+    def test_note(self):
+        b = board_context_for("note")
+        assert (b.device_type, b.rows, b.cols) == ("note", 3, 15)
+
+    def test_note_array_4_wide(self):
+        """4 side-by-side → 3 rows × 60 cols (the case from_device_type cannot build)."""
+        b = board_context_for("note_array", notes_wide=4, notes_tall=1)
+        assert (b.device_type, b.rows, b.cols) == ("note_array", 3, 60)
+
+    def test_note_array_2x2(self):
+        b = board_context_for("note_array", notes_wide=2, notes_tall=2)
+        assert (b.device_type, b.rows, b.cols) == ("note_array", 6, 30)
+
+    def test_note_array_distinct_sizes_distinct_dims(self):
+        """Two note arrays of different sizes produce different contexts."""
+        wide = board_context_for("note_array", notes_wide=4, notes_tall=1)
+        tall = board_context_for("note_array", notes_wide=1, notes_tall=4)
+        assert (wide.rows, wide.cols) != (tall.rows, tall.cols)
+
+    def test_unknown_falls_back_to_default(self):
+        """An unrecognized device type falls back to the default (flagship)."""
+        b = board_context_for("nonsense")
+        assert (b.device_type, b.rows, b.cols) == ("flagship", 6, 22)

--- a/tests/test_plugin_board_context.py
+++ b/tests/test_plugin_board_context.py
@@ -88,6 +88,23 @@ class TestPerBoardCaching:
         assert plugin.get_data(BoardContext.from_device_type("flagship")).data["device"] == "flagship"
         assert plugin.fetch_count == 2
 
+    def test_note_arrays_of_different_sizes_cache_independently(self):
+        """Note arrays share device_type 'note_array' but differ in size — they
+        must not collide in the per-board cache (would serve wrong-sized data)."""
+        plugin = BoardProbePlugin()
+        plugin.get_data(BoardContext("note_array", rows=3, cols=60))  # 4 side-by-side
+        plugin.get_data(BoardContext("note_array", rows=6, cols=30))  # 2×2 grid
+        assert plugin.fetch_count == 2
+        # Re-fetching the first size within TTL is served from cache (no new fetch).
+        plugin.get_data(BoardContext("note_array", rows=3, cols=60))
+        assert plugin.fetch_count == 2
+
+    def test_same_note_array_size_served_from_cache(self):
+        plugin = BoardProbePlugin()
+        plugin.get_data(BoardContext("note_array", rows=3, cols=60))
+        plugin.get_data(BoardContext("note_array", rows=3, cols=60))
+        assert plugin.fetch_count == 1
+
     def test_clear_cache_wipes_all_boards(self):
         plugin = BoardProbePlugin()
         plugin.get_data(BoardContext.from_device_type("flagship"))


### PR DESCRIPTION
Wires **note arrays** into the plugin `BoardContext` that #1232 (Device Size Support, @DarthXoc) introduced. #1232 lets plugins read a board's width/height to adapt content, but only knew Flagship/Note — note arrays were collapsing to a 1×1 Note for plugins.

## What
- **`src/devices.py`** — `board_context_for(device_type, notes_wide, notes_tall)` builds a `BoardContext` for **any** type via `resolve_dimensions` (note arrays included), falling back to the default for an unknown type. (`BoardContext.from_device_type` stays flagship/note-only.)
- **`src/pages/service.py`** — `_board_for_page` now uses it, so a note-array page's plugins receive the board's **true size**; the batch render path groups shared contexts by board *size* (`_board_key`) instead of `device_type`, so two note-array pages of different sizes don't share one context.
- **`src/plugins/base.py`** — `_cache_key` folds dimensions in for note arrays (they all share `device_type "note_array"`) so a 60×3 and a 6×30 board don't collide in the per-board plugin cache. Flagship/Note keys unchanged.

## Tests
`TestBoardContextFor` (devices) + note-array cache-disambiguation (plugin board context). Verified against the real merged base: ruff clean, targeted **247 passed** (incl. #1232's `test_plugin_board_context.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)