### PR TITLE
feat(web): preview note-array pages at real size in the page editor [#1167]

### DIFF
--- a/web/src/__tests__/page-builder.test.tsx
+++ b/web/src/__tests__/page-builder.test.tsx
@@ -105,3 +105,86 @@ describe("PageBuilder — Sync from Board", () => {
     });
   });
 });
+
+describe("PageBuilder — note-array dimensions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // A 4×1 note array → 4*15 = 60 cols × 1*3 = 3 rows. The BoardSizeIndicator
+  // renders width × height (cols × rows), so a real note-array preview shows
+  // "60 × 3". A 1×1 (flagship/note default) note array would only ever show
+  // "15 × 3", so asserting "60 × 3" proves the real dims were threaded through.
+  function configureNoteArrayBoard(notesWide: number, notesTall: number) {
+    server.use(
+      http.get(`${API_BASE}/settings/board`, () => {
+        return HttpResponse.json({
+          board_type: "black",
+          boards: [
+            {
+              id: "na-1",
+              name: "Note Array",
+              device_type: "note_array",
+              board_color: "black",
+              notes_wide: notesWide,
+              notes_tall: notesTall,
+            },
+          ],
+          devices: ["note_array"],
+        });
+      }),
+    );
+  }
+
+  it("previews a NEW note_array page at the configured board's real size", async () => {
+    // Configured note array is 4 wide × 1 tall → 60 × 3.
+    configureNoteArrayBoard(4, 1);
+
+    render(<PageBuilder deviceType="note_array" onClose={vi.fn()} />, { wrapper: TestWrapper });
+
+    // The size indicator reflects the seeded grid dims (cols × rows), not 1×1.
+    await waitFor(() => {
+      expect(screen.getByRole("img", { name: /3 rows by 60 columns/i })).toBeInTheDocument();
+    });
+    const indicator = screen.getByRole("img", { name: /3 rows by 60 columns/i });
+    expect(indicator).toHaveTextContent("60 × 3");
+  });
+
+  it("seeds dims from an EDITED note_array page", async () => {
+    // Editing a 2×2 note array page (persisted notes_wide/notes_tall) →
+    // 2*15 = 30 cols × 2*3 = 6 rows → "30 × 6".
+    server.use(
+      http.get(`${API_BASE}/pages/:id`, () => {
+        return HttpResponse.json({
+          id: "na-page",
+          name: "My Note Array Page",
+          type: "template",
+          device_type: "note_array",
+          template: ["", "", "", "", "", ""],
+          notes_wide: 2,
+          notes_tall: 2,
+          duration_seconds: 300,
+          created_at: "2024-01-01T00:00:00Z",
+        });
+      }),
+    );
+
+    render(<PageBuilder pageId="na-page" onClose={vi.fn()} />, { wrapper: TestWrapper });
+
+    await waitFor(() => {
+      expect(screen.getByRole("img", { name: /6 rows by 30 columns/i })).toBeInTheDocument();
+    });
+    const indicator = screen.getByRole("img", { name: /6 rows by 30 columns/i });
+    expect(indicator).toHaveTextContent("30 × 6");
+  });
+
+  it("leaves a flagship page at its fixed 22 × 6 size", async () => {
+    render(<PageBuilder deviceType="flagship" onClose={vi.fn()} />, { wrapper: TestWrapper });
+
+    await waitFor(() => {
+      expect(screen.getByRole("img", { name: /6 rows by 22 columns/i })).toBeInTheDocument();
+    });
+    const indicator = screen.getByRole("img", { name: /6 rows by 22 columns/i });
+    expect(indicator).toHaveTextContent("22 × 6");
+  });
+});

--- a/web/src/components/page-builder.tsx
+++ b/web/src/components/page-builder.tsx
@@ -122,10 +122,13 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
 
   // Device type: from prop (new pages) or from existing page (editing)
   const [deviceType, setDeviceType] = useState<DeviceType>(deviceTypeProp);
-  // NOTE: note_array W×H aren't threaded into the page builder yet, so a
-  // note_array page resolves to a single Note (1×1). Configuring note-array
-  // page dimensions in the editor is handled when the settings UI lands (#1178).
-  const dims = resolveDimensions(deviceType);
+  // Note-array grid dimensions. Only meaningful when deviceType === "note_array";
+  // flagship/note always stay 1×1 so they resolve to their fixed device sizes.
+  // Sourced from the existing page (editing), the configured note_array board
+  // (new page), or an AI sync — see the effects below.
+  const [notesWide, setNotesWide] = useState(1);
+  const [notesTall, setNotesTall] = useState(1);
+  const dims = resolveDimensions(deviceType, notesWide, notesTall);
   const numLines = dims.rows;
 
   // Preview board color - defaults to the user's configured board color
@@ -182,6 +185,8 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
   const lineAlignmentsRef = useRef(lineAlignments);
   const lineWrapEnabledRef = useRef(lineWrapEnabled);
   const deviceTypeRef = useRef(deviceType);
+  const notesWideRef = useRef(notesWide);
+  const notesTallRef = useRef(notesTall);
   useEffect(() => {
     nameRef.current = name;
   }, [name]);
@@ -197,6 +202,12 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
   useEffect(() => {
     deviceTypeRef.current = deviceType;
   }, [deviceType]);
+  useEffect(() => {
+    notesWideRef.current = notesWide;
+  }, [notesWide]);
+  useEffect(() => {
+    notesTallRef.current = notesTall;
+  }, [notesTall]);
 
   const hasUnsavedChanges = useMemo(() => {
     if (!savedSnapshot) return true;
@@ -316,12 +327,17 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
             lineAlignmentsRef.current,
             lineWrapEnabledRef.current,
           );
+          const noteArrayDims =
+            deviceTypeRef.current === "note_array"
+              ? { notes_wide: notesWideRef.current, notes_tall: notesTallRef.current }
+              : {};
           let result: { page: { id: string } };
           if (pageId) {
             result = await api.updatePage(pageId, {
               name: nameRef.current,
               template: cleanedLines,
               line_metadata: metadata,
+              ...noteArrayDims,
             });
           } else {
             result = await api.createPage({
@@ -330,6 +346,7 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
               device_type: deviceTypeRef.current,
               template: cleanedLines,
               line_metadata: metadata,
+              ...noteArrayDims,
             });
           }
           // Invalidate the pages list and this page's preview, but don't close.
@@ -501,6 +518,10 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
       if (existingPage.device_type) {
         setDeviceType(existingPage.device_type);
       }
+      // Seed note-array grid dimensions so the preview renders at the page's
+      // real size. Non-note_array pages persist no grid fields → fall back to 1×1.
+      setNotesWide(existingPage.notes_wide ?? 1);
+      setNotesTall(existingPage.notes_tall ?? 1);
 
       const pageName = existingPage.name;
       setName(pageName);
@@ -573,6 +594,19 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
       }
     }
   }, [existingPage, pageId, loadingPage, skipDraft]);
+
+  // Seed note-array grid dimensions for a NEW note_array page from the
+  // configured note_array board, so the editor previews at the board's real
+  // size before the page has ever been saved. Existing pages source their dims
+  // from the load effect above; flagship/note pages never run this branch and
+  // stay 1×1 (which resolves to their fixed device size).
+  useEffect(() => {
+    if (pageId || deviceType !== "note_array" || !boardSettings?.boards) return;
+    const board = boardSettings.boards.find((b) => b.device_type === "note_array");
+    if (!board) return;
+    setNotesWide(board.notes_wide ?? 1);
+    setNotesTall(board.notes_tall ?? 1);
+  }, [pageId, deviceType, boardSettings?.boards]);
 
   useEffect(() => {
     const timeoutId = setTimeout(() => {
@@ -729,6 +763,7 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
           name,
           template: cleanedLines,
           line_metadata: metadata,
+          ...(deviceType === "note_array" ? { notes_wide: notesWide, notes_tall: notesTall } : {}),
         };
         return api.updatePage(pageId, payload);
       } else {
@@ -738,6 +773,7 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
           device_type: deviceType,
           template: cleanedLines,
           line_metadata: metadata,
+          ...(deviceType === "note_array" ? { notes_wide: notesWide, notes_tall: notesTall } : {}),
         };
         return api.createPage(payload);
       }
@@ -851,6 +887,12 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
       if (data.device_type) {
         setDeviceType(data.device_type);
       }
+      // Mirror any note-array grid dimensions the synced page carries so the
+      // preview matches the source board. Read defensively — the current
+      // CurrentDisplayResponse type doesn't yet declare these fields.
+      const synced = data as { notes_wide?: number; notes_tall?: number };
+      if (synced.notes_wide != null) setNotesWide(synced.notes_wide);
+      if (synced.notes_tall != null) setNotesTall(synced.notes_tall);
 
       toast.success(t("toastSyncedFrom", { name: data.page_name }));
     },
@@ -1427,8 +1469,12 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
                   <div className="flex flex-wrap items-center justify-between gap-y-1 mb-2">
                     <div className="flex items-center gap-2">
                       <label className="text-xs sm:text-sm font-medium">{t("previewLabel")}</label>
-                      {/* TODO(#1178): pass notesWide/notesTall for note_array pages (defaults to 1×1 today). */}
-                      <BoardSizeIndicator deviceType={deviceType} className="ml-1" />
+                      <BoardSizeIndicator
+                        deviceType={deviceType}
+                        notesWide={notesWide}
+                        notesTall={notesTall}
+                        className="ml-1"
+                      />
                     </div>
                     <div className="flex items-center gap-1.5 shrink-0">
                       <span className="text-[10px] text-muted-foreground mr-0.5">{t("boardColorLabel")}</span>
@@ -1486,6 +1532,8 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
                       size="md"
                       boardType={effectiveBoardColor}
                       deviceType={deviceType}
+                      notesWide={notesWide}
+                      notesTall={notesTall}
                     />
                   </div>
 

--- a/web/src/components/scaled-board-display.tsx
+++ b/web/src/components/scaled-board-display.tsx
@@ -143,7 +143,7 @@ export function ScaledBoardDisplay(props: BoardProps) {
       ro.disconnect();
       if (rafId !== null) cancelAnimationFrame(rafId);
     };
-  }, [props.message, props.size, props.deviceType, mode]);
+  }, [props.message, props.size, props.deviceType, props.notesWide, props.notesTall, mode]);
 
   const toggle = showToggle ? (
     <div className="mb-1 flex w-full justify-center" role="group" aria-label={t("previewSizeLabel")}>


### PR DESCRIPTION
Closes the editor-preview gap discovered while scoping the epic: a configured note-array board previewed as a single 1×1 Note in the page editor, because `page-builder.tsx` passed only `deviceType` (not the board's `notes_wide`/`notes_tall`) to the preview. The variable-size preview (#1176) and fit/Actual-size toggle + horizontal scroll (#1177) only needed real dims to render.

## What
- **`page-builder.tsx`** — adds `notesWide`/`notesTall` state (+ refs mirroring `deviceTypeRef` for the imperative `save()`):
  - **Editing** a page seeds dims from `existingPage.notes_wide`/`notes_tall`.
  - **New** `note_array` page seeds from the configured note-array board in `boardSettings`.
  - AI-sync seeds from the synced page.
  - `resolveDimensions(deviceType, notesWide, notesTall)`; dims passed to `<BoardSizeIndicator>` and `<ScaledBoardDisplay>`; both create/update payloads persist `notes_wide`/`notes_tall` for note arrays.
- **`scaled-board-display.tsx`** — `notesWide`/`notesTall` added to the fit-scaling `useLayoutEffect` deps.

Flagship/Note are byte-identical (dims stay 1×1, ignored by `resolveDimensions`; no grid fields persisted).

## Tests
`page-builder.test.tsx` — new block (3): new note_array seeds from board → "60 × 3"; edited note_array → "30 × 6"; flagship stays "22 × 6".

## Verification (throwaway node:26-alpine)
targeted **7 passed**; full vitest **1158 passed / 13 skipped / 0 failed**; eslint 0 errors; prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)