### PR TITLE
feat(dev): live front-end + local registration for the mock note-array board

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -25,6 +25,10 @@ services:
       - BOARD_API_MODE=local
       - BOARD_HOST=fiestaboard-mock-board
       - BOARD_LOCAL_API_KEY=mock-dev-key
+      # Point note-array (Cloud API) boards at the bundled mock so they can be
+      # registered & exercised by hand in dev — its live board UI is at
+      # http://localhost:19200/ui. Unset this to talk to the real Vestaboard Cloud.
+      - VESTABOARD_CLOUD_API_URL=http://fiestaboard-mock-cloud:9200/
     volumes:
       - ./data:/app/data
       - ./src:/app/src

--- a/docs/reference/NOTE_ARRAYS.md
+++ b/docs/reference/NOTE_ARRAYS.md
@@ -139,9 +139,33 @@ note-array branch, so a single Note never classifies as a 1 × 1 array.
 > `notes_tall` against the preset table to drive the dropdown — it does not rely
 > on the `matched_preset` label string, which is a human-readable hint only.
 
+## Local development — mock Cloud board
+
+Note arrays talk to the Vestaboard **Cloud** API, so there's no local hardware to
+point at. A bundled mock stands in — and it has a live web front-end so you can
+watch and reconfigure a "board" by hand.
+
+- **Server:** `integration-tests/mock-cloud/server.py` — a stdlib HTTP server that
+  faithfully mimics `cloud.vestaboard.com` (token check, dimension + cell-code
+  validation, `currentMessage.layout` reads, request history).
+- **Wired up automatically:** `docker-compose.dev.yml` runs it as
+  `fiestaboard-mock-cloud` and sets `VESTABOARD_CLOUD_API_URL` on the app so
+  note-array boards send/read against the mock. (`BoardClient.CLOUD_NOTE_ARRAY_API_URL`
+  reads that env var; unset it to use the real Cloud API.)
+- **Live front-end:** open **http://localhost:19200/ui** — it renders the current
+  grid as split-flap tiles (characters + color codes), shows the message count /
+  last update, and lets you **Reset** the board or **reconfigure its size** at
+  runtime (the 5 presets, Flagship/Note, or a custom W×H).
+
+Typical loop: `/start` the dev stack → Settings → add a note-array board (any
+token) → build/send a page → watch it land at `/ui`. Control endpoints
+(`GET /mock/state`, `POST /mock/reset`, `POST /mock/configure`) back the UI and
+are handy for scripted/manual testing.
+
 ## See also
 
 - [Note Array setup guide](../setup/NOTE_ARRAYS.md) — user-facing configuration.
 - `src/devices.py` — geometry constants, presets, `resolve_dimensions`,
   `classify_dimensions`.
 - `src/board_client.py` — Cloud API send/read and rate limiting.
+- `integration-tests/mock-cloud/server.py` — the mock Cloud board + its `/ui`.

--- a/env.example
+++ b/env.example
@@ -32,6 +32,12 @@ BOARD_READ_WRITE_KEY=your_read_write_api_key_here  # Used when BOARD_API_MODE=cl
 # - See docs/setup/NOTE_ARRAYS.md for the full walkthrough.
 BOARD_NOTE_ARRAY_TOKEN=your-vestaboard-cloud-token
 
+# Note-array Cloud API base URL (optional). Override to point note-array boards at
+# a mock/local Cloud server instead of the real Vestaboard Cloud. The dev stack
+# (docker-compose.dev.yml) sets this to the bundled mock-cloud service, whose live
+# board UI is at http://localhost:19200/ui. Leave unset in production.
+# VESTABOARD_CLOUD_API_URL=https://cloud.vestaboard.com/
+
 # Board Transition Settings (optional)
 # Control how the board animates when displaying new messages
 # Strategy options: column (Wave), reverse-column (Drift), edges-to-center (Curtain),

--- a/integration-tests/mock-cloud/server.py
+++ b/integration-tests/mock-cloud/server.py
@@ -1,16 +1,16 @@
-"""Mock Vestaboard Cloud API server for note-array integration testing.
+"""Mock Vestaboard Cloud API server for note-array development & integration testing.
 
 Simulates the Vestaboard Cloud API (``https://cloud.vestaboard.com/``) used by
-note-array boards, so the FiestaBoard backend can be tested end-to-end without
-a real board or Vestaboard account. Stdlib-only — mirrors ``mock-board/server.py``
-and ``mock-llm/server.py``.
+note-array boards, so the FiestaBoard backend can be tested end-to-end — in CI
+*and* by hand in local dev — without a real board or Vestaboard account.
+Stdlib-only; mirrors ``mock-board/server.py`` and ``mock-llm/server.py``.
 
 The note-array Cloud API (see ``src/board_client.py``) uses:
   * POST ``/`` with header ``X-Vestaboard-Token`` and body ``{"characters": grid}``
     where ``grid`` is a rectangular ``rows×cols`` int array. Success is any 2xx.
   * GET ``/`` with header ``X-Vestaboard-Token`` returning
     ``{"currentMessage": {"layout": "<json-string-grid>", "id": "..."}}`` —
-    note that ``layout`` is a JSON *string* encoding the 2-D int array.
+    ``layout`` is a JSON *string* encoding the 2-D int array.
 
 Endpoints
 ---------
@@ -19,9 +19,22 @@ Cloud API (mimics cloud.vestaboard.com):
     POST /   - Send a note-array message ({"characters": grid})
     GET  /   - Read the current display state (currentMessage.layout)
 
-Mock control:
-    GET  /mock/state   - Return current grid, configured dims, request count, history
-    POST /mock/reset   - Reset the grid to all-zeros (configured/default dims)
+Manual dev tool:
+    GET  /ui            - A live web front-end that renders the current board as
+                          split-flap tiles and lets you reset / reconfigure size.
+
+Mock control (used by /ui and tests):
+    GET  /mock/state     - Current grid, configured dims, request count, history
+    POST /mock/reset     - Reset the grid to all-zeros (configured/default dims)
+    POST /mock/configure - Reconfigure the board size at runtime; body is either
+                           {"rows": R, "cols": C} or {"notes_wide": W, "notes_tall": H}.
+
+Local dev
+---------
+``docker-compose.dev.yml`` runs this as ``fiestaboard-mock-cloud`` (host port
+19200) and points the app at it via ``VESTABOARD_CLOUD_API_URL``. To use it:
+add/select a note-array board in Settings, enter any token, send — then watch it
+land at http://localhost:19200/ui.
 
 Env vars
 --------
@@ -29,8 +42,6 @@ PORT   - listen port (default 9200)
 ROWS   - configured array rows (default 6); when ROWS or COLS is set, incoming
          POSTs are validated against the configured dimensions.
 COLS   - configured array cols (default 30; 6×30 = a 2×2 note array)
-
-The defaults match the ``fiestaboard-mock-cloud`` compose service and the CI job.
 """
 
 from __future__ import annotations
@@ -48,7 +59,7 @@ MAX_CHAR_CODE = 71
 
 # Configured at startup from env. When ROWS or COLS is explicitly set, incoming
 # POSTs are validated against these dimensions; otherwise any valid grid is
-# accepted and stored as-is.
+# accepted and stored as-is. /mock/configure can change these at runtime.
 _ROWS = int(os.environ.get("ROWS", "6"))
 _COLS = int(os.environ.get("COLS", "30"))
 _STRICT_DIMS = bool(os.environ.get("ROWS") or os.environ.get("COLS"))
@@ -67,6 +78,15 @@ class MockCloudState:
         with self._lock:
             self.current_grid = [[0] * self._cols for _ in range(self._rows)]
             self.history: list[dict] = []
+            self.request_count = 0
+
+    def reconfigure(self, rows: int, cols: int) -> None:
+        """Change the configured board size and reset the grid to it."""
+        with self._lock:
+            self._rows = rows
+            self._cols = cols
+            self.current_grid = [[0] * cols for _ in range(rows)]
+            self.history = []
             self.request_count = 0
 
     def set_grid(self, grid: list[list[int]]) -> None:
@@ -114,6 +134,137 @@ def _grid_dimensions(grid) -> tuple[int, int] | None:
     return (len(grid), cols)
 
 
+# Self-contained dev front-end. Static HTML/CSS/JS — all live data is fetched
+# from /mock/state, so nothing here needs server-side templating.
+_FRONTEND_HTML = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Mock Vestaboard — Note Array</title>
+<style>
+  :root { color-scheme: dark; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; padding: 24px; font-family: -apple-system, system-ui, sans-serif;
+    background: #0c0d10; color: #e7e9ee;
+  }
+  h1 { font-size: 16px; font-weight: 600; margin: 0 0 4px; }
+  .sub { color: #8b909c; font-size: 12px; margin-bottom: 18px; }
+  .board-wrap { overflow-x: auto; padding: 14px; background: #000; border-radius: 10px;
+    border: 1px solid #23262e; display: inline-block; max-width: 100%; }
+  .board { display: grid; gap: 3px; }
+  .tile {
+    width: 26px; height: 34px; border-radius: 3px; display: flex; align-items: center;
+    justify-content: center; font-family: "SF Mono", ui-monospace, monospace;
+    font-size: 17px; font-weight: 600; color: #f4f4f6;
+    background: linear-gradient(#1c1f25, #141619); box-shadow: inset 0 -2px 3px #0006, inset 0 1px 0 #ffffff10;
+    border-top: 1px solid #ffffff0d;
+  }
+  .tile.color { color: transparent; }
+  .meta { margin-top: 16px; font-size: 12px; color: #aeb3bd; line-height: 1.7; }
+  .meta b { color: #e7e9ee; font-weight: 600; }
+  .controls { margin-top: 18px; display: flex; gap: 10px; flex-wrap: wrap; align-items: center; }
+  button, select, input {
+    font: inherit; font-size: 13px; background: #1b1e25; color: #e7e9ee;
+    border: 1px solid #2c313b; border-radius: 7px; padding: 7px 12px; cursor: pointer;
+  }
+  button:hover { background: #242832; }
+  input { width: 56px; cursor: text; }
+  label { font-size: 12px; color: #aeb3bd; }
+  .hint { margin-top: 22px; font-size: 11px; color: #6b7280; max-width: 640px; line-height: 1.6; }
+  code { background: #1b1e25; padding: 1px 5px; border-radius: 4px; color: #c8cdd6; }
+</style>
+</head>
+<body>
+  <h1>Mock Vestaboard <span style="color:#6b7280">· Note Array</span></h1>
+  <div class="sub" id="dims">connecting…</div>
+  <div class="board-wrap"><div class="board" id="board"></div></div>
+  <div class="meta">
+    Messages received: <b id="count">0</b> &nbsp;·&nbsp; Last update: <b id="last">—</b>
+  </div>
+  <div class="controls">
+    <label>Size:</label>
+    <select id="preset">
+      <option value="6,22">Flagship (22 × 6)</option>
+      <option value="3,15">Note (15 × 3)</option>
+      <option value="3,30">2 side-by-side (30 × 3)</option>
+      <option value="3,60">4 side-by-side (60 × 3)</option>
+      <option value="6,15">2 stacked (15 × 6)</option>
+      <option value="12,15">4 stacked (15 × 12)</option>
+      <option value="6,30" selected>2×2 grid (30 × 6)</option>
+      <option value="custom">Custom…</option>
+    </select>
+    <span id="customWrap" style="display:none">
+      <input id="cw" type="number" min="1" max="8" value="2" /> ×
+      <input id="ch" type="number" min="1" max="8" value="2" />
+      <label>notes (W × H)</label>
+    </span>
+    <button id="apply">Apply size</button>
+    <button id="reset">Reset board</button>
+  </div>
+  <div class="hint">
+    Point a note-array board at this server (the dev app does this automatically via
+    <code>VESTABOARD_CLOUD_API_URL</code>), enter any token in Settings, and send — the
+    grid below updates live. The Cloud API itself is at <code>POST/GET /</code> with an
+    <code>X-Vestaboard-Token</code> header.
+  </div>
+<script>
+// Vestaboard character codes -> display glyph (or a color tile).
+const PUNCT = {37:"!",38:"@",39:"#",40:"$",41:"(",42:")",44:"-",46:"+",47:"&",48:"=",
+  49:";",50:":",52:"'",53:'"',54:"%",55:",",56:".",59:"/",60:"?",62:"\\u00B0"};
+const COLORS = {63:"#d8112a",64:"#e96d24",65:"#f7d000",66:"#1d8a3f",67:"#2456a6",
+  68:"#7a3b8f",69:"#f3f3f3",70:"#15171a"};
+function glyph(code){
+  if (code === 0) return {ch:""};
+  if (code >= 1 && code <= 26) return {ch:String.fromCharCode(64+code)};      // A-Z
+  if (code >= 27 && code <= 35) return {ch:String(code-26)};                   // 1-9
+  if (code === 36) return {ch:"0"};
+  if (code in PUNCT) return {ch:PUNCT[code]};
+  if (code in COLORS) return {ch:"", color:COLORS[code]};
+  return {ch:""};
+}
+const boardEl = document.getElementById("board");
+function render(state){
+  const g = state.current_grid || [];
+  const rows = g.length, cols = rows ? g[0].length : 0;
+  document.getElementById("dims").textContent =
+    cols + " \\u00D7 " + rows + " characters  (" + (cols/15|0) + "\\u00D7" + (rows/3|0) + " notes)";
+  document.getElementById("count").textContent = state.request_count;
+  const h = state.history || [];
+  document.getElementById("last").textContent = h.length ? new Date(h[h.length-1].timestamp).toLocaleTimeString() : "\\u2014";
+  boardEl.style.gridTemplateColumns = "repeat(" + cols + ", 26px)";
+  const cells = [];
+  for (const row of g) for (const code of row){
+    const gl = glyph(code);
+    const cls = gl.color ? "tile color" : "tile";
+    const style = gl.color ? ' style="background:'+gl.color+'"' : "";
+    cells.push("<div class='"+cls+"'"+style+">"+gl.ch+"</div>");
+  }
+  boardEl.innerHTML = cells.join("");
+}
+async function poll(){
+  try { const r = await fetch("/mock/state"); render(await r.json()); } catch(e){}
+}
+document.getElementById("reset").onclick = async () => { await fetch("/mock/reset",{method:"POST"}); poll(); };
+document.getElementById("preset").onchange = (e) => {
+  document.getElementById("customWrap").style.display = e.target.value === "custom" ? "inline" : "none";
+};
+document.getElementById("apply").onclick = async () => {
+  const v = document.getElementById("preset").value;
+  let body;
+  if (v === "custom"){
+    body = {notes_wide:+document.getElementById("cw").value, notes_tall:+document.getElementById("ch").value};
+  } else { const parts = v.split(",").map(Number); body = {rows:parts[0],cols:parts[1]}; }
+  await fetch("/mock/configure",{method:"POST",headers:{"Content-Type":"application/json"},body:JSON.stringify(body)});
+  poll();
+};
+poll(); setInterval(poll, 1000);
+</script>
+</body>
+</html>"""
+
+
 class Handler(BaseHTTPRequestHandler):
     """HTTP handler that mimics the Vestaboard Cloud API for note arrays."""
 
@@ -123,6 +274,14 @@ class Handler(BaseHTTPRequestHandler):
         body = json.dumps(payload).encode("utf-8")
         self.send_response(status)
         self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_html(self, status: int, html: str) -> None:
+        body = html.encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         self.wfile.write(body)
@@ -158,6 +317,10 @@ class Handler(BaseHTTPRequestHandler):
                     },
                 },
             )
+            return
+
+        if self.path in ("/ui", "/ui/"):
+            self._send_html(200, _FRONTEND_HTML)
             return
 
         if self.path == "/mock/state":
@@ -218,7 +381,49 @@ class Handler(BaseHTTPRequestHandler):
             self._send_json(200, {"ok": True, "message": "Mock reset"})
             return
 
+        if self.path == "/mock/configure":
+            self._handle_configure()
+            return
+
         self._send_json(404, {"error": "Not found"})
+
+    def _handle_configure(self) -> None:
+        """Reconfigure the board size at runtime (for the /ui dev tool).
+
+        Body is either ``{"rows": R, "cols": C}`` or ``{"notes_wide": W, "notes_tall": H}``
+        (a note array is notes_wide×15 cols by notes_tall×3 rows). Resets the grid.
+        """
+        global _ROWS, _COLS, _STRICT_DIMS
+        body = self._read_json()
+        if not isinstance(body, dict):
+            self._send_json(400, {"error": "Body must be a JSON object"})
+            return
+
+        if "notes_wide" in body or "notes_tall" in body:
+            try:
+                nw = int(body.get("notes_wide", 1))
+                nt = int(body.get("notes_tall", 1))
+            except (TypeError, ValueError):
+                self._send_json(400, {"error": "notes_wide/notes_tall must be integers"})
+                return
+            if not (1 <= nw <= 8 and 1 <= nt <= 8):
+                self._send_json(400, {"error": "notes_wide/notes_tall must be 1-8"})
+                return
+            rows, cols = nt * 3, nw * 15
+        else:
+            try:
+                rows = int(body["rows"])
+                cols = int(body["cols"])
+            except (KeyError, TypeError, ValueError):
+                self._send_json(400, {"error": "Provide rows+cols or notes_wide+notes_tall"})
+                return
+            if not (1 <= rows <= 24 and 1 <= cols <= 120):
+                self._send_json(400, {"error": "rows must be 1-24, cols 1-120"})
+                return
+
+        _ROWS, _COLS, _STRICT_DIMS = rows, cols, True
+        STATE.reconfigure(rows, cols)
+        self._send_json(200, {"ok": True, "configured_rows": rows, "configured_cols": cols})
 
     def log_message(self, fmt: str, *args) -> None:
         """Suppress default request logging to keep CI output readable."""
@@ -232,7 +437,7 @@ def main() -> None:
     port = int(os.environ.get("PORT", "9200"))
     server = HTTPServer(("0.0.0.0", port), Handler)
     logger.info(
-        "Mock Cloud API listening on 0.0.0.0:%d (rows=%d, cols=%d, strict_dims=%s)",
+        "Mock Cloud API on 0.0.0.0:%d (rows=%d, cols=%d, strict_dims=%s) — front-end at /ui",
         port,
         _ROWS,
         _COLS,

--- a/integration-tests/test_cloud_mock.py
+++ b/integration-tests/test_cloud_mock.py
@@ -263,3 +263,62 @@ class TestBoardClientIntegrationWithMock:
                 notes_wide=2,
                 notes_tall=2,
             )
+
+
+class TestMockCloudDevTools:
+    """The /ui front-end and /mock/configure runtime-reconfigure (manual dev tool)."""
+
+    def test_ui_serves_html(self, client: httpx.Client) -> None:
+        resp = client.get("/ui")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/html")
+        assert "Mock Vestaboard" in resp.text
+        assert 'id="board"' in resp.text  # the live grid container
+
+    def test_configure_by_notes_reconfigures_and_resets(self, client: httpx.Client) -> None:
+        resp = client.post("/mock/configure", json={"notes_wide": 4, "notes_tall": 1})
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True, "configured_rows": 3, "configured_cols": 60}
+        state = client.get("/mock/state").json()
+        assert state["configured_rows"] == 3
+        assert state["configured_cols"] == 60
+        assert len(state["current_grid"]) == 3 and len(state["current_grid"][0]) == 60
+        assert state["request_count"] == 0  # grid reset
+
+    def test_configure_by_rows_cols(self, client: httpx.Client) -> None:
+        resp = client.post("/mock/configure", json={"rows": 12, "cols": 15})
+        assert resp.status_code == 200
+        assert resp.json()["configured_rows"] == 12
+        assert client.get("/mock/state").json()["configured_cols"] == 15
+
+    def test_send_at_reconfigured_size_succeeds(self, client: httpx.Client) -> None:
+        """After reconfiguring to 3×60, a 3×60 send is accepted (strict dims follow)."""
+        client.post("/mock/configure", json={"notes_wide": 4, "notes_tall": 1})
+        grid = _grid(3, 60, fill=66)
+        resp = client.post("/", json={"characters": grid}, headers=_TOKEN_HEADERS)
+        assert resp.status_code == 200
+        assert client.get("/mock/state").json()["current_grid"] == grid
+
+    def test_configure_rejects_out_of_range_notes(self, client: httpx.Client) -> None:
+        resp = client.post("/mock/configure", json={"notes_wide": 9, "notes_tall": 1})
+        assert resp.status_code == 400
+
+    def test_configure_rejects_bad_body(self, client: httpx.Client) -> None:
+        resp = client.post("/mock/configure", json={"foo": "bar"})
+        assert resp.status_code == 400
+
+
+def test_board_client_cloud_url_env_override() -> None:
+    """VESTABOARD_CLOUD_API_URL overrides the note-array Cloud API base URL.
+
+    Verified in a subprocess so the module-level read of the env var happens
+    at a fresh import (and doesn't pollute the suite's already-imported module).
+    """
+    import os
+    import subprocess
+    import sys
+
+    env = {**os.environ, "VESTABOARD_CLOUD_API_URL": "http://mock-host:9200/", "PYTHONPATH": str(_PROJECT_ROOT)}
+    code = "from src.board_client import BoardClient; print(BoardClient.CLOUD_NOTE_ARRAY_API_URL)"
+    out = subprocess.check_output([sys.executable, "-c", code], env=env, text=True).strip()
+    assert out == "http://mock-host:9200/"

--- a/src/board_client.py
+++ b/src/board_client.py
@@ -15,6 +15,7 @@ Cloud API Reference:
 
 import json
 import logging
+import os
 import re
 import time as _time_module
 from collections.abc import Callable
@@ -147,7 +148,11 @@ class BoardClient:
 
     LOCAL_API_PORT = 7000
     CLOUD_API_URL = "https://rw.vestaboard.com/"
-    CLOUD_NOTE_ARRAY_API_URL = "https://cloud.vestaboard.com/"
+    # Note-array Cloud API base URL. Overridable via VESTABOARD_CLOUD_API_URL so a
+    # local dev environment can point note-array boards at the mock Cloud server
+    # (docker-compose.dev.yml sets it to the fiestaboard-mock-cloud service);
+    # defaults to the real Vestaboard Cloud API in production.
+    CLOUD_NOTE_ARRAY_API_URL = os.environ.get("VESTABOARD_CLOUD_API_URL") or "https://cloud.vestaboard.com/"
 
     def __init__(
         self,


### PR DESCRIPTION
Closes the early requirement that the note-array mock be a **real, registerable local-dev tool with its own front-end** — not just a headless CI fixture.

## What
- **Register against it in dev.** `BoardClient.CLOUD_NOTE_ARRAY_API_URL` is now overridable via `VESTABOARD_CLOUD_API_URL` (defaults to the real Cloud API in prod). `docker-compose.dev.yml` sets it to the bundled `fiestaboard-mock-cloud` service, so a note-array board added in Settings sends/reads against the mock automatically.
- **Live front-end — `GET /ui`** (http://localhost:19200/ui in dev): renders the current board as split-flap tiles (A–Z, digits, punctuation, and the 7 Vestaboard color codes), shows message count + last-update time, and lets you **Reset** the board or **reconfigure its size at runtime** — the 5 note-array presets, Flagship/Note, or a custom W×H — via a new `POST /mock/configure` control endpoint.
- Docs + `env.example` updated; `docs/reference/NOTE_ARRAYS.md` has a "Local development — mock Cloud board" section.

## Manual loop
`/start` → Settings → add a note-array board (any token) → build/send a page → watch it land live at `/ui`, and flip the board size from the UI to test each preset.

## Verification
- `integration-tests/test_cloud_mock.py`: **25 passed** (the 18 existing + new `/ui`, `/mock/configure` by notes & by rows/cols, reset, send-at-reconfigured-size, validation, and the env-override test).
- ruff clean on changed files; `docker-compose.dev.yml` YAML valid; `test_board_client.py` 118 passed (env override is backward-compatible).
- Smoke-tested end to end: started the server, fetched `/ui`, reconfigured to 3×60, sent an all-green grid, confirmed it stored + read back.

Note: CI's ruff lints `src/ tests/ plugins/ scripts/` (not `integration-tests/`), consistent with the existing mock servers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)