### PR TITLE
feat(settings): per-board active page + versioned settings migrations [#1242]

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -222,11 +222,8 @@ class DisplayService:
 
     @staticmethod
     def _get_first_board_id() -> str | None:
-        """Return the ID of the first configured board, or None."""
-        boards = get_settings_service().get_board_settings().boards or []
-        if boards and isinstance(boards[0], dict):
-            return boards[0].get("id")
-        return None
+        """Return the ID of the primary (first) configured board, or None."""
+        return get_settings_service().get_primary_board_id()
 
     def check_and_send_active_page(self) -> bool:
         """Check the active page and send to board if content changed.

--- a/src/schedules/service.py
+++ b/src/schedules/service.py
@@ -61,8 +61,7 @@ class ScheduleService:
         # mode), include those rows so pre-migration and API-created entries still
         # appear for the primary board.
         if board_id:
-            boards = get_settings_service().get_board_settings().boards or []
-            first_id = boards[0].get("id") if boards else None
+            first_id = get_settings_service().get_primary_board_id()
             if first_id and board_id == first_id:
                 legacy = self.storage.list_all(board_id=None)
                 seen = {s.id for s in schedules}

--- a/src/settings/service.py
+++ b/src/settings/service.py
@@ -80,9 +80,12 @@ class ActivePageSettings:
 
     @classmethod
     def from_dict(cls, data: dict) -> "ActivePageSettings":
-        by_board = data.get("by_board") or {}
+        raw_by_board = data.get("by_board") or {}
         # Defensively coerce to a plain str->str dict; ignore malformed entries.
-        clean = {str(k): str(v) for k, v in by_board.items() if isinstance(v, str)} if isinstance(by_board, dict) else {}
+        if isinstance(raw_by_board, dict):
+            clean = {str(k): str(v) for k, v in raw_by_board.items() if isinstance(v, str)}
+        else:
+            clean = {}
         return cls(page_id=data.get("page_id"), by_board=clean)
 
 

--- a/src/settings/service.py
+++ b/src/settings/service.py
@@ -7,6 +7,8 @@ animations and output targets, which can be controlled from the UI.
 import json
 import logging
 import os
+import shutil
+from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -61,16 +63,27 @@ class OutputSettings:
 
 @dataclass
 class ActivePageSettings:
-    """Active page settings for display."""
+    """Active page settings for display.
+
+    The manual active page is stored **per-board** in ``by_board`` (board_id ->
+    page_id). ``page_id`` is kept as a back-compat mirror of the *primary*
+    board's value for one release so older readers (and external tooling) keep
+    working. New code should go through ``SettingsService.get_active_page_id``
+    / ``set_active_page_id`` rather than touching these fields directly.
+    """
 
     page_id: str | None = None
+    by_board: dict[str, str] = field(default_factory=dict)
 
     def to_dict(self) -> dict:
         return asdict(self)
 
     @classmethod
     def from_dict(cls, data: dict) -> "ActivePageSettings":
-        return cls(page_id=data.get("page_id"))
+        by_board = data.get("by_board") or {}
+        # Defensively coerce to a plain str->str dict; ignore malformed entries.
+        clean = {str(k): str(v) for k, v in by_board.items() if isinstance(v, str)} if isinstance(by_board, dict) else {}
+        return cls(page_id=data.get("page_id"), by_board=clean)
 
 
 BOARD_READ_INTERVAL_MIN = 20  # Hard floor: no faster than once every 20 seconds
@@ -252,9 +265,15 @@ class TemporaryOverride:
 
 @dataclass
 class ScheduleSettings:
-    """Schedule system settings."""
+    """Schedule system settings.
 
-    enabled: bool = False  # Schedule mode disabled by default
+    ``enabled`` is **deprecated** as the source of truth: schedule mode is now
+    authoritative per-board via ``boards[i].schedule_enabled``. This flag is
+    retained for one release only as a back-compat mirror of the *primary*
+    board's value. Use ``SettingsService.is_schedule_enabled(board_id)``.
+    """
+
+    enabled: bool = False  # Deprecated mirror of the primary board's schedule_enabled
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -406,6 +425,123 @@ class MQTTSettings:
         )
 
 
+# ==================== Settings schema versioning ====================
+#
+# settings.json carries an integer ``schema_version`` and is migrated through
+# an ordered ``MIGRATIONS`` list on startup (mirrors src/schedules/storage.py).
+# Migrations operate on the **raw dict** before any Pydantic/dataclass parsing,
+# are idempotent, log how many records changed, and a one-time backup of the
+# pre-migration file is written to ``settings.json.v{N}_backup`` before the
+# first migration runs.
+
+CURRENT_SETTINGS_SCHEMA_VERSION = 1
+
+_LEGACY_CAROUSEL_PREFIX = "carousel:"
+_COLLECTION_PREFIX = "collection:"
+
+
+def primary_board_id_from_raw(data: dict) -> str | None:
+    """Return the primary (first) board's id from a raw settings dict.
+
+    The primary board is the first entry in ``board.boards``. Returns None when
+    there are no boards or the first board has no id. This is the migration-safe
+    counterpart to ``SettingsService.get_primary_board_id`` and operates purely
+    on raw JSON so it can be used inside migrations (before parsing).
+    """
+    board = data.get("board")
+    if not isinstance(board, dict):
+        return None
+    boards = board.get("boards")
+    if isinstance(boards, list) and boards and isinstance(boards[0], dict):
+        bid = boards[0].get("id")
+        return bid if isinstance(bid, str) and bid else None
+    return None
+
+
+def _rewrite_carousel_ref(ref: object) -> tuple[object, bool]:
+    """Rewrite a single ``carousel:<uuid>`` reference to ``collection:<uuid>``.
+
+    Returns ``(new_ref, changed)``. Non-carousel and non-str refs pass through.
+    """
+    if isinstance(ref, str) and ref.startswith(_LEGACY_CAROUSEL_PREFIX):
+        return _COLLECTION_PREFIX + ref[len(_LEGACY_CAROUSEL_PREFIX) :], True
+    return ref, False
+
+
+def _migrate_v0_to_v1(data: dict) -> int:
+    """Migration 0 -> 1 (idempotent; operates on the raw settings dict).
+
+    Three independent fix-ups, each counted toward the returned change total:
+
+    1. Rewrite legacy ``carousel:<uuid>`` page references to
+       ``collection:<uuid>`` in ``active_page.page_id`` and
+       ``temporary_override.page_id`` / ``revert_page_id`` (prior behavior of
+       ``_migrate_legacy_carousel_refs``).
+    2. Move the global ``active_page.page_id`` into
+       ``active_page.by_board[primary_id]`` so the manual active page becomes
+       per-board. The ``page_id`` mirror is left in place as a back-compat
+       value for the primary board. Skipped when ``by_board[primary_id]`` is
+       already set. Deferred (mirror left untouched, read-path fallback covers
+       it) when there are no boards yet.
+    3. Reconcile per-board ``schedule_enabled``: when the primary board lacks a
+       ``schedule_enabled`` key and the legacy global ``schedule.enabled`` is
+       True, stamp ``schedule_enabled = True`` on the primary board.
+    """
+    changes = 0
+
+    active = data.get("active_page")
+    if not isinstance(active, dict):
+        active = {}
+
+    # (1) carousel -> collection rewrites
+    new_ref, did = _rewrite_carousel_ref(active.get("page_id"))
+    if did:
+        active["page_id"] = new_ref
+        data["active_page"] = active
+        changes += 1
+
+    override = data.get("temporary_override")
+    if isinstance(override, dict):
+        for key in ("page_id", "revert_page_id"):
+            new_ref, did = _rewrite_carousel_ref(override.get(key))
+            if did:
+                override[key] = new_ref
+                changes += 1
+
+    primary_id = primary_board_id_from_raw(data)
+
+    # (2) global active page -> primary board's by_board slot
+    if primary_id is not None:
+        by_board = active.get("by_board")
+        if not isinstance(by_board, dict):
+            by_board = {}
+        legacy_page_id = active.get("page_id")
+        if legacy_page_id and primary_id not in by_board:
+            by_board[primary_id] = legacy_page_id
+            active["by_board"] = by_board
+            data["active_page"] = active
+            changes += 1
+
+    # (3) reconcile schedule_enabled onto the primary board
+    schedule = data.get("schedule")
+    global_enabled = bool(schedule.get("enabled")) if isinstance(schedule, dict) else False
+    if primary_id is not None and global_enabled:
+        board = data.get("board")
+        boards = board.get("boards") if isinstance(board, dict) else None
+        if isinstance(boards, list) and boards and isinstance(boards[0], dict):
+            primary = boards[0]
+            if "schedule_enabled" not in primary:
+                primary["schedule_enabled"] = True
+                changes += 1
+
+    return changes
+
+
+MIGRATIONS: list[tuple[int, Callable[[dict], int]]] = [
+    (1, _migrate_v0_to_v1),
+]
+
+
 class SettingsService:
     """Service for managing runtime settings.
 
@@ -428,10 +564,11 @@ class SettingsService:
         else:
             self.settings_file = Path(settings_file)
 
-        # One-shot rewrite of any legacy ``carousel:<uuid>`` references in the
-        # settings file to the new ``collection:<uuid>`` prefix. Runs before
-        # any subsystem reads, so every _load_* sees the migrated values.
-        self._migrate_legacy_carousel_refs()
+        # Run ordered schema migrations on the raw settings file BEFORE any
+        # subsystem reads, so every _load_* sees fully migrated values. This
+        # includes the legacy carousel:->collection: rewrite (folded into the
+        # v0->v1 migration) plus per-board active-page / schedule_enabled moves.
+        self._run_migrations()
 
         # Load initial settings from env/file
         self._transition = self._load_transition_settings()
@@ -453,24 +590,19 @@ class SettingsService:
 
         logger.info(f"SettingsService initialized (file: {self.settings_file})")
 
-    def _migrate_legacy_carousel_refs(self) -> None:
-        """Rewrite ``carousel:<uuid>`` references in settings.json once.
+    def _run_migrations(self) -> None:
+        """Run pending settings schema migrations on the raw settings file.
 
-        Touches ``active_page.page_id`` and ``temporary_override.page_id`` /
-        ``temporary_override.revert_page_id``. Writes the file back only if
-        at least one reference changed. No-op when the file does not exist
-        or contains no legacy references.
+        Reads ``settings.json``, runs any migrations whose target version is
+        newer than the file's ``schema_version`` (default 0), and resaves once
+        when anything changed. A one-time backup of the pre-migration file is
+        written to ``settings.json.v{N}_backup`` before the first migration
+        runs. Migrations operate on the raw dict (before dataclass parsing) so
+        every subsequent ``_load_*`` sees migrated values. No-op when the file
+        does not exist or is already at the current version.
         """
         if not self.settings_file.exists():
             return
-
-        legacy_prefix = "carousel:"
-        new_prefix = "collection:"
-
-        def _rewrite(value):
-            if isinstance(value, str) and value.startswith(legacy_prefix):
-                return new_prefix + value[len(legacy_prefix) :], True
-            return value, False
 
         try:
             with open(self.settings_file) as f:  # noqa: PTH123
@@ -479,30 +611,37 @@ class SettingsService:
             logger.warning(f"Could not pre-read settings for migration: {e}")
             return
 
-        changed = 0
-
-        active = data.get("active_page")
-        if isinstance(active, dict):
-            new_ref, did = _rewrite(active.get("page_id"))
-            if did:
-                active["page_id"] = new_ref
-                changed += 1
-
-        override = data.get("temporary_override")
-        if isinstance(override, dict):
-            for key in ("page_id", "revert_page_id"):
-                new_ref, did = _rewrite(override.get(key))
-                if did:
-                    override[key] = new_ref
-                    changed += 1
-
-        if not changed:
+        if not isinstance(data, dict):
             return
+
+        current_version = data.get("schema_version", 0)
+        if not isinstance(current_version, int):
+            current_version = 0
+
+        if current_version >= CURRENT_SETTINGS_SCHEMA_VERSION:
+            return
+
+        backup_path = self.settings_file.with_suffix(f".json.v{current_version}_backup")
+        if not backup_path.exists():
+            try:
+                shutil.copy2(self.settings_file, backup_path)
+                logger.info(f"Created pre-migration settings backup at {backup_path}")
+            except OSError as e:
+                logger.warning(f"Could not create settings backup: {e}")
+
+        for target_version, migrate_fn in MIGRATIONS:
+            if current_version >= target_version:
+                continue
+            count = migrate_fn(data)
+            logger.info(f"Settings schema migration v{current_version}->v{target_version}: {count} change(s) applied")
+            current_version = target_version
+
+        data["schema_version"] = CURRENT_SETTINGS_SCHEMA_VERSION
 
         try:
             with open(self.settings_file, "w") as f:  # noqa: PTH123
                 json.dump(data, f, indent=2)
-            logger.info(f"Migrated {changed} carousel: -> collection: reference(s) in settings.json")
+            logger.info("Saved migrated settings to file")
         except OSError as e:
             logger.warning(f"Could not write migrated settings: {e}")
 
@@ -522,6 +661,7 @@ class SettingsService:
         """Save current settings to JSON file."""
         try:
             data = {
+                "schema_version": CURRENT_SETTINGS_SCHEMA_VERSION,
                 "transitions": self._transition.to_dict(),
                 "output": self._output.to_dict(),
                 "active_page": self._active_page.to_dict(),
@@ -761,27 +901,59 @@ class SettingsService:
         """Determine if message should be sent to UI."""
         return True
 
-    # Active page settings
-    def get_active_page_id(self) -> str | None:
-        """Get the currently active page ID.
-
-        Returns:
-            Active page ID or None if not set
-        """
-        return self._active_page.page_id
-
-    def set_active_page_id(self, page_id: str | None) -> ActivePageSettings:
-        """Set the active page ID.
+    # Active page settings (per-board)
+    def get_active_page_id(self, board_id: str | None = None) -> str | None:
+        """Get the currently active (manual) page ID for a board.
 
         Args:
-            page_id: Page ID to set as active, or None to clear
+            board_id: Board to read. ``None`` resolves to the primary board.
+
+        Returns:
+            The board's active page ID, or None if not set.
+
+        Resolution order:
+          1. ``active_page.by_board[board_id]`` when present.
+          2. For the primary board only, fall back to the legacy
+             ``active_page.page_id`` mirror (covers pre-migration installs and
+             the "no boards yet" deferred-migration case).
+        """
+        bid = board_id if board_id is not None else self.get_primary_board_id()
+        if bid is not None and bid in self._active_page.by_board:
+            return self._active_page.by_board[bid] or None
+        # Legacy mirror fallback for the primary board (or when no board is known).
+        if board_id is None or bid is None or bid == self.get_primary_board_id():
+            return self._active_page.page_id
+        return None
+
+    def set_active_page_id(self, page_id: str | None, board_id: str | None = None) -> ActivePageSettings:
+        """Set the active (manual) page ID for a board.
+
+        Args:
+            page_id: Page ID to set as active, or None to clear.
+            board_id: Board to update. ``None`` resolves to the primary board.
+
+        When the targeted board is the primary board the legacy
+        ``active_page.page_id`` mirror is kept in sync for one release.
 
         Returns:
             Updated ActivePageSettings
         """
-        self._active_page.page_id = page_id
+        primary_id = self.get_primary_board_id()
+        bid = board_id if board_id is not None else primary_id
+
+        if bid is not None:
+            if page_id:
+                self._active_page.by_board[bid] = page_id
+            else:
+                self._active_page.by_board.pop(bid, None)
+
+        # Keep the legacy primary mirror in sync (also covers the no-boards case
+        # where bid is None and we only have the mirror to write to).
+        if board_id is None or bid is None or bid == primary_id:
+            self._active_page.page_id = page_id
+
         self._save_to_file()
-        logger.info(f"Active page set to: {page_id}")
+        logger.info(f"Active page for board {bid!r} set to: {page_id}")
         return self._active_page
 
     def get_active_page_settings(self) -> ActivePageSettings:
@@ -859,6 +1031,20 @@ class SettingsService:
             BoardSettings instance
         """
         return self._board
+
+    def get_primary_board_id(self) -> str | None:
+        """Return the primary (first) configured board's id, or None.
+
+        This is the single source of truth for "which board is the default"
+        and replaces ad-hoc ``boards[0]`` lookups scattered across the codebase
+        (main.py, schedules/service.py). Returns None when no boards exist or
+        the first board has no id.
+        """
+        boards = self._board.boards or []
+        if boards and isinstance(boards[0], dict):
+            bid = boards[0].get("id")
+            return bid if bid else None
+        return None
 
     def set_board_type(self, board_type: Literal["black", "white"] | None) -> BoardSettings:
         """Set the board type for UI rendering.
@@ -1072,33 +1258,47 @@ class SettingsService:
     def is_schedule_enabled(self, board_id: str | None = None) -> bool:
         """Check if schedule mode is enabled for a board.
 
-        When board_id is None, returns the first board's schedule_enabled, or global setting if no boards.
+        Schedule mode is authoritative **per-board** via
+        ``boards[i].schedule_enabled``. ``board_id=None`` resolves to the
+        primary board. An unknown board_id returns False. The legacy global
+        ``schedule.enabled`` mirror is only consulted when there are no
+        configured boards at all (pre-board installs).
         """
-        if board_id:
+        bid = board_id if board_id is not None else self.get_primary_board_id()
+        if bid is not None:
             for b in self._board.boards:
-                if b.get("id") == board_id:
-                    return b.get("schedule_enabled", False)
+                if b.get("id") == bid:
+                    return bool(b.get("schedule_enabled", False))
             return False
-        if self._board.boards:
-            return self._board.boards[0].get("schedule_enabled", self._schedule.enabled)
+        # No boards configured: fall back to the deprecated global mirror.
         return self._schedule.enabled
 
     def set_schedule_enabled(self, enabled: bool, board_id: str | None = None) -> ScheduleSettings:
-        """Enable or disable schedule mode for a board (or globally when board_id is None)."""
-        if board_id:
+        """Enable or disable schedule mode for a board.
+
+        ``board_id=None`` resolves to the primary board. Writing the primary
+        board also updates the deprecated ``schedule.enabled`` mirror for one
+        release.
+        """
+        primary_id = self.get_primary_board_id()
+        bid = board_id if board_id is not None else primary_id
+
+        if bid is not None:
             for b in self._board.boards:
-                if b.get("id") == board_id:
+                if b.get("id") == bid:
                     b["schedule_enabled"] = enabled
+                    if bid == primary_id:
+                        self._schedule.enabled = enabled
                     self._save_to_file()
-                    logger.info(f"Schedule mode for board {board_id}: {'enabled' if enabled else 'disabled'}")
+                    logger.info(f"Schedule mode for board {bid}: {'enabled' if enabled else 'disabled'}")
                     return self._schedule
-            logger.warning(f"Board {board_id} not found for set_schedule_enabled")
+            logger.warning(f"Board {bid} not found for set_schedule_enabled")
             return self._schedule
+
+        # No boards configured: write the deprecated global mirror only.
         self._schedule.enabled = enabled
-        if self._board.boards:
-            self._board.boards[0]["schedule_enabled"] = enabled
         self._save_to_file()
-        logger.info(f"Schedule mode (default): {'enabled' if enabled else 'disabled'}")
+        logger.info(f"Schedule mode (global, no boards): {'enabled' if enabled else 'disabled'}")
         return self._schedule
 
     def get_mqtt_settings(self) -> "MQTTSettings":

--- a/tests/test_schedule_board_id_bug.py
+++ b/tests/test_schedule_board_id_bug.py
@@ -38,6 +38,9 @@ class TestCheckAndSendActivePageBoardId:
             board_settings = Mock()
             board_settings.boards = [{"id": "board-abc-123", "name": "My Board"}]
             settings_service.get_board_settings.return_value = board_settings
+            # get_primary_board_id() is the SSOT the polling loop uses to resolve
+            # the active board (replaces ad-hoc boards[0] lookups).
+            settings_service.get_primary_board_id.return_value = "board-abc-123"
             mock_get_settings.return_value = settings_service
 
             schedule_service = Mock()
@@ -112,6 +115,7 @@ class TestGetActiveRefIdBoardId:
             board_settings = Mock()
             board_settings.boards = [{"id": "board-xyz-789", "name": "Berlin Board"}]
             settings_service.get_board_settings.return_value = board_settings
+            settings_service.get_primary_board_id.return_value = "board-xyz-789"
             mock_get_settings.return_value = settings_service
 
             schedule_service = Mock()

--- a/tests/test_schedules_service.py
+++ b/tests/test_schedules_service.py
@@ -52,6 +52,8 @@ class TestScheduleServiceCRUD:
             {"id": "first-board-uuid", "name": "A"},
             {"id": "second-board-uuid", "name": "B"},
         ]
+        # list_schedules() resolves the primary board via get_primary_board_id().
+        mock_gs.get_primary_board_id.return_value = "first-board-uuid"
         monkeypatch.setattr(
             "src.schedules.service.get_settings_service",
             lambda: mock_gs,

--- a/tests/test_settings_per_board.py
+++ b/tests/test_settings_per_board.py
@@ -60,6 +60,11 @@ def _two_board_raw(active_page=None, schedule=None, schema_version=None):
     return data
 
 
+def _write_raw(settings_file, raw):
+    """Write a raw settings dict to the given file path."""
+    Path(settings_file).write_text(json.dumps(raw))
+
+
 # ==================== ActivePageSettings dataclass ====================
 
 
@@ -95,7 +100,7 @@ class TestPrimaryBoardHelpers:
         assert primary_board_id_from_raw({"board": {"boards": [{"name": "no id"}]}}) is None
 
     def test_get_primary_board_id_matches_first_board(self, settings_file, mock_config):
-        Path(settings_file).write_text(json.dumps(_two_board_raw()))
+        _write_raw(settings_file, _two_board_raw())
         svc = SettingsService(settings_file=settings_file)
         assert svc.get_primary_board_id() == "board-1"
 
@@ -110,22 +115,14 @@ class TestPrimaryBoardHelpers:
 
 class TestCarouselMigration:
     def test_rewrites_active_page_and_override_refs(self, settings_file, mock_config):
-        Path(settings_file).write_text(
-            json.dumps(
-                _two_board_raw(
-                    active_page={"page_id": "carousel:abc"},
-                    schedule={"enabled": False},
-                )
-                | {
-                    "temporary_override": {
-                        "page_id": "carousel:def",
-                        "expires_at": "2999-01-01T00:00:00+00:00",
-                        "revert_mode": "page",
-                        "revert_page_id": "carousel:ghi",
-                    }
-                }
-            )
-        )
+        raw = _two_board_raw(active_page={"page_id": "carousel:abc"}, schedule={"enabled": False})
+        raw["temporary_override"] = {
+            "page_id": "carousel:def",
+            "expires_at": "2999-01-01T00:00:00+00:00",
+            "revert_mode": "page",
+            "revert_page_id": "carousel:ghi",
+        }
+        _write_raw(settings_file, raw)
         SettingsService(settings_file=settings_file)
         data = json.loads(Path(settings_file).read_text())
         # active_page.page_id rewritten and moved to by_board for primary
@@ -140,9 +137,7 @@ class TestCarouselMigration:
 
 class TestActivePageMigration:
     def test_global_active_page_moves_to_primary_board(self, settings_file, mock_config):
-        Path(settings_file).write_text(
-            json.dumps(_two_board_raw(active_page={"page_id": "page-1"}))
-        )
+        _write_raw(settings_file, _two_board_raw(active_page={"page_id": "page-1"}))
         svc = SettingsService(settings_file=settings_file)
 
         data = json.loads(Path(settings_file).read_text())
@@ -158,19 +153,14 @@ class TestActivePageMigration:
         assert svc.get_active_page_id(board_id="board-2") is None
 
     def test_skips_when_by_board_already_set(self, settings_file, mock_config):
-        Path(settings_file).write_text(
-            json.dumps(
-                _two_board_raw(active_page={"page_id": "page-1", "by_board": {"board-1": "already"}})
-            )
-        )
+        raw = _two_board_raw(active_page={"page_id": "page-1", "by_board": {"board-1": "already"}})
+        _write_raw(settings_file, raw)
         svc = SettingsService(settings_file=settings_file)
         assert svc.get_active_page_id(board_id="board-1") == "already"
 
     def test_deferred_when_no_boards(self, settings_file, mock_config):
         # No boards configured yet: leave the mirror, read-path fallback covers it.
-        Path(settings_file).write_text(
-            json.dumps({"active_page": {"page_id": "page-1"}, "board": {"boards": []}})
-        )
+        _write_raw(settings_file, {"active_page": {"page_id": "page-1"}, "board": {"boards": []}})
         svc = SettingsService(settings_file=settings_file)
         # A default board is created on load; read with no board_id still returns
         # the mirror value (no by_board entry was written by the migration).
@@ -182,17 +172,13 @@ class TestActivePageMigration:
 
 class TestScheduleEnabledMigration:
     def test_global_schedule_enabled_moves_to_primary(self, settings_file, mock_config):
-        Path(settings_file).write_text(
-            json.dumps(_two_board_raw(schedule={"enabled": True}))
-        )
+        _write_raw(settings_file, _two_board_raw(schedule={"enabled": True}))
         svc = SettingsService(settings_file=settings_file)
 
         data = json.loads(Path(settings_file).read_text())
         assert data["board"]["boards"][0]["schedule_enabled"] is True
         # Second board untouched.
-        assert "schedule_enabled" not in data["board"]["boards"][1] or (
-            data["board"]["boards"][1].get("schedule_enabled") is False
-        )
+        assert data["board"]["boards"][1].get("schedule_enabled", False) is False
 
         assert svc.is_schedule_enabled() is True
         assert svc.is_schedule_enabled(board_id="board-1") is True
@@ -201,14 +187,12 @@ class TestScheduleEnabledMigration:
     def test_does_not_override_existing_primary_flag(self, settings_file, mock_config):
         raw = _two_board_raw(schedule={"enabled": True})
         raw["board"]["boards"][0]["schedule_enabled"] = False
-        Path(settings_file).write_text(json.dumps(raw))
+        _write_raw(settings_file, raw)
         svc = SettingsService(settings_file=settings_file)
         assert svc.is_schedule_enabled(board_id="board-1") is False
 
     def test_global_disabled_no_change(self, settings_file, mock_config):
-        Path(settings_file).write_text(
-            json.dumps(_two_board_raw(schedule={"enabled": False}))
-        )
+        _write_raw(settings_file, _two_board_raw(schedule={"enabled": False}))
         svc = SettingsService(settings_file=settings_file)
         assert svc.is_schedule_enabled(board_id="board-1") is False
 
@@ -218,9 +202,8 @@ class TestScheduleEnabledMigration:
 
 class TestMigrationMechanics:
     def test_idempotent_rerun_is_noop(self, settings_file, mock_config):
-        Path(settings_file).write_text(
-            json.dumps(_two_board_raw(active_page={"page_id": "page-1"}, schedule={"enabled": True}))
-        )
+        raw = _two_board_raw(active_page={"page_id": "page-1"}, schedule={"enabled": True})
+        _write_raw(settings_file, raw)
         SettingsService(settings_file=settings_file)
         first = Path(settings_file).read_text()
 
@@ -231,9 +214,7 @@ class TestMigrationMechanics:
         assert json.loads(second)["schema_version"] == CURRENT_SETTINGS_SCHEMA_VERSION
 
     def test_backup_created_before_migration(self, settings_file, mock_config):
-        Path(settings_file).write_text(
-            json.dumps(_two_board_raw(active_page={"page_id": "page-1"}))
-        )
+        _write_raw(settings_file, _two_board_raw(active_page={"page_id": "page-1"}))
         SettingsService(settings_file=settings_file)
         backup = Path(settings_file).with_suffix(".json.v0_backup")
         assert backup.exists()
@@ -247,7 +228,7 @@ class TestMigrationMechanics:
             active_page={"page_id": "page-1", "by_board": {"board-1": "page-1"}},
             schema_version=CURRENT_SETTINGS_SCHEMA_VERSION,
         )
-        Path(settings_file).write_text(json.dumps(raw))
+        _write_raw(settings_file, raw)
         SettingsService(settings_file=settings_file)
         backup = Path(settings_file).with_suffix(f".json.v{CURRENT_SETTINGS_SCHEMA_VERSION}_backup")
         assert not backup.exists()
@@ -264,11 +245,10 @@ class TestMigrationMechanics:
                 "boards": [{"id": "only-board", "name": "My Board", "device_type": "flagship"}],
             },
         }
-        Path(settings_file).write_text(json.dumps(raw))
+        _write_raw(settings_file, raw)
         svc = SettingsService(settings_file=settings_file)
 
         # Reads with no board_id behave exactly as before migration.
-        assert svc.get_active_page_id() is None or svc.get_active_page_id() == "my-page"
         assert svc.get_active_page_id() == "my-page"
         assert svc.is_schedule_enabled() is True
         # And these resolve to the single board.
@@ -282,7 +262,7 @@ class TestMigrationMechanics:
 class TestPerBoardActivePage:
     @pytest.fixture
     def two_board_service(self, settings_file, mock_config):
-        Path(settings_file).write_text(json.dumps(_two_board_raw()))
+        _write_raw(settings_file, _two_board_raw())
         return SettingsService(settings_file=settings_file)
 
     def test_set_get_independent_per_board(self, two_board_service):
@@ -331,7 +311,7 @@ class TestPerBoardActivePage:
 class TestPerBoardScheduleEnabled:
     @pytest.fixture
     def two_board_service(self, settings_file, mock_config):
-        Path(settings_file).write_text(json.dumps(_two_board_raw()))
+        _write_raw(settings_file, _two_board_raw())
         return SettingsService(settings_file=settings_file)
 
     def test_independent_per_board(self, two_board_service):

--- a/tests/test_settings_per_board.py
+++ b/tests/test_settings_per_board.py
@@ -1,0 +1,370 @@
+"""Tests for the per-board settings foundation (issue #1242).
+
+Covers:
+  - settings.json schema_version + ordered migrations (v0->v1):
+      * carousel:->collection: rewrite (folded from the old one-shot migration)
+      * global active_page.page_id -> active_page.by_board[primary_id]
+      * global schedule.enabled -> primary board schedule_enabled
+      * idempotency, single-board no-op, and pre-migration backup
+  - per-board active-page get/set for two boards (with primary mirror)
+  - get_primary_board_id() / primary_board_id_from_raw()
+  - per-board schedule_enabled authority
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.settings.service import (
+    CURRENT_SETTINGS_SCHEMA_VERSION,
+    ActivePageSettings,
+    SettingsService,
+    primary_board_id_from_raw,
+)
+
+
+@pytest.fixture
+def settings_file(tmp_path):
+    return str(tmp_path / "settings.json")
+
+
+@pytest.fixture
+def mock_config():
+    with patch("src.config.Config") as mock:
+        mock.FB_TRANSITION_STRATEGY = "column"
+        mock.FB_TRANSITION_INTERVAL_MS = 100
+        mock.FB_TRANSITION_STEP_SIZE = 2
+        mock.OUTPUT_TARGET = "board"
+        yield mock
+
+
+def _two_board_raw(active_page=None, schedule=None, schema_version=None):
+    """Build a minimal raw settings dict with two boards (ids board-1/board-2)."""
+    data = {
+        "board": {
+            "board_type": "black",
+            "boards": [
+                {"id": "board-1", "name": "Primary", "device_type": "flagship", "board_color": "black"},
+                {"id": "board-2", "name": "Second", "device_type": "flagship", "board_color": "white"},
+            ],
+        },
+    }
+    if active_page is not None:
+        data["active_page"] = active_page
+    if schedule is not None:
+        data["schedule"] = schedule
+    if schema_version is not None:
+        data["schema_version"] = schema_version
+    return data
+
+
+# ==================== ActivePageSettings dataclass ====================
+
+
+class TestActivePageSettingsByBoard:
+    def test_from_dict_parses_by_board(self):
+        aps = ActivePageSettings.from_dict({"page_id": "p1", "by_board": {"b1": "p1", "b2": "p2"}})
+        assert aps.page_id == "p1"
+        assert aps.by_board == {"b1": "p1", "b2": "p2"}
+
+    def test_from_dict_defaults_empty_by_board(self):
+        aps = ActivePageSettings.from_dict({"page_id": "p1"})
+        assert aps.by_board == {}
+
+    def test_from_dict_ignores_malformed_by_board(self):
+        aps = ActivePageSettings.from_dict({"by_board": {"b1": None, "b2": 5, "b3": "ok"}})
+        assert aps.by_board == {"b3": "ok"}
+
+    def test_to_dict_roundtrips(self):
+        aps = ActivePageSettings(page_id="p1", by_board={"b1": "p1"})
+        assert aps.to_dict() == {"page_id": "p1", "by_board": {"b1": "p1"}}
+
+
+# ==================== primary board helper ====================
+
+
+class TestPrimaryBoardHelpers:
+    def test_primary_board_id_from_raw(self):
+        assert primary_board_id_from_raw(_two_board_raw()) == "board-1"
+
+    def test_primary_board_id_from_raw_empty(self):
+        assert primary_board_id_from_raw({"board": {"boards": []}}) is None
+        assert primary_board_id_from_raw({}) is None
+        assert primary_board_id_from_raw({"board": {"boards": [{"name": "no id"}]}}) is None
+
+    def test_get_primary_board_id_matches_first_board(self, settings_file, mock_config):
+        Path(settings_file).write_text(json.dumps(_two_board_raw()))
+        svc = SettingsService(settings_file=settings_file)
+        assert svc.get_primary_board_id() == "board-1"
+
+    def test_get_primary_board_id_default_board(self, settings_file, mock_config):
+        # Fresh service auto-creates a default board with a generated id.
+        svc = SettingsService(settings_file=settings_file)
+        assert svc.get_primary_board_id() == svc._board.boards[0]["id"]
+
+
+# ==================== migration: carousel rewrite ====================
+
+
+class TestCarouselMigration:
+    def test_rewrites_active_page_and_override_refs(self, settings_file, mock_config):
+        Path(settings_file).write_text(
+            json.dumps(
+                _two_board_raw(
+                    active_page={"page_id": "carousel:abc"},
+                    schedule={"enabled": False},
+                )
+                | {
+                    "temporary_override": {
+                        "page_id": "carousel:def",
+                        "expires_at": "2999-01-01T00:00:00+00:00",
+                        "revert_mode": "page",
+                        "revert_page_id": "carousel:ghi",
+                    }
+                }
+            )
+        )
+        SettingsService(settings_file=settings_file)
+        data = json.loads(Path(settings_file).read_text())
+        # active_page.page_id rewritten and moved to by_board for primary
+        assert data["active_page"]["page_id"] == "collection:abc"
+        assert data["active_page"]["by_board"]["board-1"] == "collection:abc"
+        assert data["temporary_override"]["page_id"] == "collection:def"
+        assert data["temporary_override"]["revert_page_id"] == "collection:ghi"
+
+
+# ==================== migration: global active page -> primary board ====================
+
+
+class TestActivePageMigration:
+    def test_global_active_page_moves_to_primary_board(self, settings_file, mock_config):
+        Path(settings_file).write_text(
+            json.dumps(_two_board_raw(active_page={"page_id": "page-1"}))
+        )
+        svc = SettingsService(settings_file=settings_file)
+
+        data = json.loads(Path(settings_file).read_text())
+        assert data["active_page"]["by_board"]["board-1"] == "page-1"
+        # Legacy mirror kept for back-compat.
+        assert data["active_page"]["page_id"] == "page-1"
+        assert data["schema_version"] == CURRENT_SETTINGS_SCHEMA_VERSION
+
+        # Reading with no board_id returns the same value as before (primary).
+        assert svc.get_active_page_id() == "page-1"
+        assert svc.get_active_page_id(board_id="board-1") == "page-1"
+        # The second board did not inherit the global active page.
+        assert svc.get_active_page_id(board_id="board-2") is None
+
+    def test_skips_when_by_board_already_set(self, settings_file, mock_config):
+        Path(settings_file).write_text(
+            json.dumps(
+                _two_board_raw(active_page={"page_id": "page-1", "by_board": {"board-1": "already"}})
+            )
+        )
+        svc = SettingsService(settings_file=settings_file)
+        assert svc.get_active_page_id(board_id="board-1") == "already"
+
+    def test_deferred_when_no_boards(self, settings_file, mock_config):
+        # No boards configured yet: leave the mirror, read-path fallback covers it.
+        Path(settings_file).write_text(
+            json.dumps({"active_page": {"page_id": "page-1"}, "board": {"boards": []}})
+        )
+        svc = SettingsService(settings_file=settings_file)
+        # A default board is created on load; read with no board_id still returns
+        # the mirror value (no by_board entry was written by the migration).
+        assert svc.get_active_page_id() == "page-1"
+
+
+# ==================== migration: schedule_enabled -> primary board ====================
+
+
+class TestScheduleEnabledMigration:
+    def test_global_schedule_enabled_moves_to_primary(self, settings_file, mock_config):
+        Path(settings_file).write_text(
+            json.dumps(_two_board_raw(schedule={"enabled": True}))
+        )
+        svc = SettingsService(settings_file=settings_file)
+
+        data = json.loads(Path(settings_file).read_text())
+        assert data["board"]["boards"][0]["schedule_enabled"] is True
+        # Second board untouched.
+        assert "schedule_enabled" not in data["board"]["boards"][1] or (
+            data["board"]["boards"][1].get("schedule_enabled") is False
+        )
+
+        assert svc.is_schedule_enabled() is True
+        assert svc.is_schedule_enabled(board_id="board-1") is True
+        assert svc.is_schedule_enabled(board_id="board-2") is False
+
+    def test_does_not_override_existing_primary_flag(self, settings_file, mock_config):
+        raw = _two_board_raw(schedule={"enabled": True})
+        raw["board"]["boards"][0]["schedule_enabled"] = False
+        Path(settings_file).write_text(json.dumps(raw))
+        svc = SettingsService(settings_file=settings_file)
+        assert svc.is_schedule_enabled(board_id="board-1") is False
+
+    def test_global_disabled_no_change(self, settings_file, mock_config):
+        Path(settings_file).write_text(
+            json.dumps(_two_board_raw(schedule={"enabled": False}))
+        )
+        svc = SettingsService(settings_file=settings_file)
+        assert svc.is_schedule_enabled(board_id="board-1") is False
+
+
+# ==================== migration: idempotency, backup, single-board no-op ====================
+
+
+class TestMigrationMechanics:
+    def test_idempotent_rerun_is_noop(self, settings_file, mock_config):
+        Path(settings_file).write_text(
+            json.dumps(_two_board_raw(active_page={"page_id": "page-1"}, schedule={"enabled": True}))
+        )
+        SettingsService(settings_file=settings_file)
+        first = Path(settings_file).read_text()
+
+        # Re-instantiating runs migrations again; already-current file is a no-op.
+        SettingsService(settings_file=settings_file)
+        second = Path(settings_file).read_text()
+        assert json.loads(first)["active_page"] == json.loads(second)["active_page"]
+        assert json.loads(second)["schema_version"] == CURRENT_SETTINGS_SCHEMA_VERSION
+
+    def test_backup_created_before_migration(self, settings_file, mock_config):
+        Path(settings_file).write_text(
+            json.dumps(_two_board_raw(active_page={"page_id": "page-1"}))
+        )
+        SettingsService(settings_file=settings_file)
+        backup = Path(settings_file).with_suffix(".json.v0_backup")
+        assert backup.exists()
+        # Backup preserves the pre-migration content (no schema_version, no by_board).
+        backup_data = json.loads(backup.read_text())
+        assert "schema_version" not in backup_data
+        assert "by_board" not in backup_data.get("active_page", {})
+
+    def test_no_backup_when_already_current(self, settings_file, mock_config):
+        raw = _two_board_raw(
+            active_page={"page_id": "page-1", "by_board": {"board-1": "page-1"}},
+            schema_version=CURRENT_SETTINGS_SCHEMA_VERSION,
+        )
+        Path(settings_file).write_text(json.dumps(raw))
+        SettingsService(settings_file=settings_file)
+        backup = Path(settings_file).with_suffix(f".json.v{CURRENT_SETTINGS_SCHEMA_VERSION}_backup")
+        assert not backup.exists()
+
+    def test_single_board_zero_behavior_change(self, settings_file, mock_config):
+        """The #1 acceptance criterion: a single-board install migrates with no
+        observable behavior change. Global active page -> primary board; reading
+        with no board_id returns the same value; schedule flag preserved."""
+        raw = {
+            "active_page": {"page_id": "my-page"},
+            "schedule": {"enabled": True},
+            "board": {
+                "board_type": "black",
+                "boards": [{"id": "only-board", "name": "My Board", "device_type": "flagship"}],
+            },
+        }
+        Path(settings_file).write_text(json.dumps(raw))
+        svc = SettingsService(settings_file=settings_file)
+
+        # Reads with no board_id behave exactly as before migration.
+        assert svc.get_active_page_id() is None or svc.get_active_page_id() == "my-page"
+        assert svc.get_active_page_id() == "my-page"
+        assert svc.is_schedule_enabled() is True
+        # And these resolve to the single board.
+        assert svc.get_active_page_id(board_id="only-board") == "my-page"
+        assert svc.is_schedule_enabled(board_id="only-board") is True
+
+
+# ==================== per-board active page get/set ====================
+
+
+class TestPerBoardActivePage:
+    @pytest.fixture
+    def two_board_service(self, settings_file, mock_config):
+        Path(settings_file).write_text(json.dumps(_two_board_raw()))
+        return SettingsService(settings_file=settings_file)
+
+    def test_set_get_independent_per_board(self, two_board_service):
+        svc = two_board_service
+        svc.set_active_page_id("page-A", board_id="board-1")
+        svc.set_active_page_id("page-B", board_id="board-2")
+        assert svc.get_active_page_id(board_id="board-1") == "page-A"
+        assert svc.get_active_page_id(board_id="board-2") == "page-B"
+        # Default (None) resolves to the primary board.
+        assert svc.get_active_page_id() == "page-A"
+
+    def test_set_primary_updates_mirror(self, two_board_service):
+        svc = two_board_service
+        svc.set_active_page_id("page-A")  # None -> primary (board-1)
+        assert svc._active_page.page_id == "page-A"
+        assert svc._active_page.by_board["board-1"] == "page-A"
+
+    def test_set_secondary_does_not_touch_mirror(self, two_board_service):
+        svc = two_board_service
+        svc.set_active_page_id("page-B", board_id="board-2")
+        assert svc._active_page.page_id is None
+        assert "board-1" not in svc._active_page.by_board
+
+    def test_clear_per_board(self, two_board_service):
+        svc = two_board_service
+        svc.set_active_page_id("page-A", board_id="board-1")
+        svc.set_active_page_id(None, board_id="board-1")
+        assert svc.get_active_page_id(board_id="board-1") is None
+        assert "board-1" not in svc._active_page.by_board
+
+    def test_unknown_board_returns_none(self, two_board_service):
+        assert two_board_service.get_active_page_id(board_id="does-not-exist") is None
+
+    def test_persists_across_reload(self, settings_file, two_board_service):
+        svc = two_board_service
+        svc.set_active_page_id("page-A", board_id="board-1")
+        svc.set_active_page_id("page-B", board_id="board-2")
+        reloaded = SettingsService(settings_file=settings_file)
+        assert reloaded.get_active_page_id(board_id="board-1") == "page-A"
+        assert reloaded.get_active_page_id(board_id="board-2") == "page-B"
+
+
+# ==================== per-board schedule_enabled ====================
+
+
+class TestPerBoardScheduleEnabled:
+    @pytest.fixture
+    def two_board_service(self, settings_file, mock_config):
+        Path(settings_file).write_text(json.dumps(_two_board_raw()))
+        return SettingsService(settings_file=settings_file)
+
+    def test_independent_per_board(self, two_board_service):
+        svc = two_board_service
+        svc.set_schedule_enabled(True, board_id="board-2")
+        assert svc.is_schedule_enabled(board_id="board-1") is False
+        assert svc.is_schedule_enabled(board_id="board-2") is True
+
+    def test_set_none_writes_primary_and_mirror(self, two_board_service):
+        svc = two_board_service
+        svc.set_schedule_enabled(True)  # None -> primary
+        assert svc.is_schedule_enabled(board_id="board-1") is True
+        assert svc.is_schedule_enabled() is True
+        # Deprecated mirror kept in sync for the primary board.
+        assert svc._schedule.enabled is True
+
+    def test_set_secondary_does_not_touch_mirror(self, two_board_service):
+        svc = two_board_service
+        svc.set_schedule_enabled(True, board_id="board-2")
+        assert svc._schedule.enabled is False
+
+    def test_unknown_board_returns_false(self, two_board_service):
+        assert two_board_service.is_schedule_enabled(board_id="nope") is False
+
+    def test_no_boards_falls_back_to_global_mirror(self, settings_file, mock_config):
+        svc = SettingsService(settings_file=settings_file)
+        svc._board.boards = []
+        svc._schedule.enabled = True
+        assert svc.is_schedule_enabled() is True
+
+    def test_set_with_no_boards_writes_global_mirror(self, settings_file, mock_config):
+        svc = SettingsService(settings_file=settings_file)
+        svc._board.boards = []
+        result = svc.set_schedule_enabled(True)
+        assert result.enabled is True
+        assert svc.is_schedule_enabled() is True

--- a/tests/test_settings_service.py
+++ b/tests/test_settings_service.py
@@ -97,7 +97,9 @@ class TestActivePageSettings:
 
     def test_to_dict(self):
         aps = ActivePageSettings(page_id="abc")
-        assert aps.to_dict() == {"page_id": "abc"}
+        # by_board holds the per-board active page map (page_id is the
+        # back-compat mirror of the primary board's value).
+        assert aps.to_dict() == {"page_id": "abc", "by_board": {}}
 
 
 # ==================== PollingSettings ====================


### PR DESCRIPTION
Closes #1242

Backend data-model foundation for per-board support. No display-loop or endpoint behavior change beyond the new method signatures and the one-time `settings.json` migration (those land in #1243 / the follow-ups).

## What changed

**Per-board active page** (`src/settings/service.py`)
- `ActivePageSettings` gains `by_board: dict[str, str]` (board_id → page_id). `page_id` is kept as a back-compat **mirror of the primary board's** value for one release.
- New signatures:
  - `get_active_page_id(board_id: str | None = None)` — `None` → primary board; falls back to the legacy `page_id` mirror for the primary when `by_board` is empty.
  - `set_active_page_id(page_id, board_id: str | None = None)` — `None` → primary; keeps the mirror in sync when writing the primary board.

**Versioned settings migrations** (ported from `src/schedules/storage.py`)
- Real `schema_version` + module-level `MIGRATIONS` list + `_run_migrations(raw_dict)` + one-time backup to `settings.json.v{N}_backup`.
- Migrations run in `SettingsService.__init__` **before** the `_load_*` calls and operate on the raw dict (before dataclass parsing).
- `_save_to_file` now stamps `schema_version`.

**Migration `v0→v1`** (idempotent, logs counts):
1. Folds the old `carousel:` → `collection:` rewrite (replaces `_migrate_legacy_carousel_refs`).
2. Moves global `active_page.page_id` → `active_page.by_board[primary_id]` (skips if already set; **deferred** when there are no boards yet — the read-path mirror fallback covers it).
3. Stamps `schedule_enabled = True` on the primary board when the primary lacks the key and the legacy global `schedule.enabled` is True.

**Per-board `schedule_enabled` authority**
- `is_schedule_enabled(board_id)` reads `boards[i].schedule_enabled` (`None` → primary); the global `schedule.enabled` mirror is only consulted when there are no boards. `set_schedule_enabled(None)` writes the primary board (and its mirror). `ScheduleSettings.enabled` is now a documented deprecated mirror.

**Primary-board helper**
- `SettingsService.get_primary_board_id()` + module-level `primary_board_id_from_raw(data)` (for migrations).
- Routed the duplicated `boards[0]` id reads in `src/main.py` (`_get_first_board_id`) and `src/schedules/service.py` through the helper. The display loop itself is untouched (that's #1243). Schedules `board_id=""` ↔ primary aliasing in `src/schedules/service.py` is intentionally **kept**; `schedules.json` is not bulk-rewritten.

## Migration safety

Single-board installs migrate with **zero behavior change**: the global active page moves to the primary board, and reading with no `board_id` returns the same value as before. The migration is idempotent (re-running on a current-version file is a no-op), backs up the pre-migration file once, and logs how many records changed.

## Tests

`tests/test_settings_per_board.py`: migration idempotency + backup + single-board no-op; per-board active-page get/set across two boards (with primary mirror); `get_primary_board_id` / `primary_board_id_from_raw`; per-board `schedule_enabled` and its migration.

## New public signatures other issues depend on

- `get_active_page_id(board_id: str | None = None) -> str | None`
- `set_active_page_id(page_id: str | None, board_id: str | None = None) -> ActivePageSettings`
- `get_primary_board_id() -> str | None`
- `primary_board_id_from_raw(data: dict) -> str | None`

🤖 Generated with [Claude Code](https://claude.com/claude-code)