### PR TITLE
feat(web): per-board sidebar selector + CurrentBoardProvider [#1246]

### DIFF
--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -77,7 +77,10 @@
     "secondaryNavigation": "Sekundärnavigation",
     "picks": "Empfehlungen",
     "skipToMainContent": "Zum Hauptinhalt springen",
-    "prideCelebrationAriaLabel": "Pride Month feiern"
+    "prideCelebrationAriaLabel": "Pride Month feiern",
+    "boardSelector": "Zu verwaltendes Board auswählen",
+    "selectBoard": "Board auswählen",
+    "unnamedBoard": "Unbenanntes Board"
   },
   "network": {
     "title": "WLAN",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -77,7 +77,10 @@
     "secondaryNavigation": "Secondary navigation",
     "picks": "Staff Picks",
     "skipToMainContent": "Skip to main content",
-    "prideCelebrationAriaLabel": "Celebrate Pride Month"
+    "prideCelebrationAriaLabel": "Celebrate Pride Month",
+    "boardSelector": "Select board to manage",
+    "selectBoard": "Select board",
+    "unnamedBoard": "Unnamed board"
   },
   "home": {
     "title": "Dashboard",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -77,7 +77,10 @@
     "secondaryNavigation": "Navegación secundaria",
     "picks": "Selecciones del equipo",
     "skipToMainContent": "Saltar al contenido principal",
-    "prideCelebrationAriaLabel": "Celebrar el Mes del Orgullo"
+    "prideCelebrationAriaLabel": "Celebrar el Mes del Orgullo",
+    "boardSelector": "Seleccionar tablero a gestionar",
+    "selectBoard": "Seleccionar tablero",
+    "unnamedBoard": "Tablero sin nombre"
   },
   "network": {
     "title": "Wi-Fi",

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -77,7 +77,10 @@
     "secondaryNavigation": "Navigation secondaire",
     "picks": "Sélections de l'équipe",
     "skipToMainContent": "Aller au contenu principal",
-    "prideCelebrationAriaLabel": "Célébrer le Mois des Fiertés"
+    "prideCelebrationAriaLabel": "Célébrer le Mois des Fiertés",
+    "boardSelector": "Sélectionner le tableau à gérer",
+    "selectBoard": "Sélectionner un tableau",
+    "unnamedBoard": "Tableau sans nom"
   },
   "network": {
     "title": "Wi-Fi",

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -77,7 +77,10 @@
     "secondaryNavigation": "Navigazione secondaria",
     "picks": "Scelte del team",
     "skipToMainContent": "Vai al contenuto principale",
-    "prideCelebrationAriaLabel": "Celebra il Mese dell'Orgoglio"
+    "prideCelebrationAriaLabel": "Celebra il Mese dell'Orgoglio",
+    "boardSelector": "Seleziona la bacheca da gestire",
+    "selectBoard": "Seleziona bacheca",
+    "unnamedBoard": "Bacheca senza nome"
   },
   "network": {
     "title": "Wi-Fi",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -77,7 +77,10 @@
     "secondaryNavigation": "サブナビゲーション",
     "picks": "スタッフのおすすめ",
     "skipToMainContent": "メインコンテンツへスキップ",
-    "prideCelebrationAriaLabel": "プライド月間を祝う"
+    "prideCelebrationAriaLabel": "プライド月間を祝う",
+    "boardSelector": "管理するボードを選択",
+    "selectBoard": "ボードを選択",
+    "unnamedBoard": "名前のないボード"
   },
   "network": {
     "title": "Wi-Fi",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -77,7 +77,10 @@
     "secondaryNavigation": "보조 탐색",
     "picks": "스태프 추천",
     "skipToMainContent": "본문으로 건너뛰기",
-    "prideCelebrationAriaLabel": "프라이드의 달 축하하기"
+    "prideCelebrationAriaLabel": "프라이드의 달 축하하기",
+    "boardSelector": "관리할 보드 선택",
+    "selectBoard": "보드 선택",
+    "unnamedBoard": "이름 없는 보드"
   },
   "network": {
     "title": "Wi-Fi",

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -77,7 +77,10 @@
     "secondaryNavigation": "Subnavigatie",
     "picks": "Aanbevolen",
     "skipToMainContent": "Naar hoofdinhoud",
-    "prideCelebrationAriaLabel": "Vier Pride Month"
+    "prideCelebrationAriaLabel": "Vier Pride Month",
+    "boardSelector": "Te beheren board selecteren",
+    "selectBoard": "Board selecteren",
+    "unnamedBoard": "Naamloos board"
   },
   "network": {
     "title": "Wi-Fi",

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -77,7 +77,10 @@
     "secondaryNavigation": "Nawigacja drugorzędna",
     "picks": "Polecane",
     "skipToMainContent": "Przejdź do treści głównej",
-    "prideCelebrationAriaLabel": "Świętuj Miesiąc Dumy"
+    "prideCelebrationAriaLabel": "Świętuj Miesiąc Dumy",
+    "boardSelector": "Wybierz tablicę do zarządzania",
+    "selectBoard": "Wybierz tablicę",
+    "unnamedBoard": "Tablica bez nazwy"
   },
   "network": {
     "title": "Wi-Fi",

--- a/web/messages/pt.json
+++ b/web/messages/pt.json
@@ -77,7 +77,10 @@
     "secondaryNavigation": "Navegação secundária",
     "picks": "Seleções da equipa",
     "skipToMainContent": "Pular para o conteúdo principal",
-    "prideCelebrationAriaLabel": "Celebrar o Mês do Orgulho"
+    "prideCelebrationAriaLabel": "Celebrar o Mês do Orgulho",
+    "boardSelector": "Selecionar quadro a gerir",
+    "selectBoard": "Selecionar quadro",
+    "unnamedBoard": "Quadro sem nome"
   },
   "network": {
     "title": "Wi-Fi",

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -77,7 +77,10 @@
     "secondaryNavigation": "Дополнительная навигация",
     "picks": "Подборка команды",
     "skipToMainContent": "Перейти к основному содержимому",
-    "prideCelebrationAriaLabel": "Отпраздновать месяц гордости"
+    "prideCelebrationAriaLabel": "Отпраздновать месяц гордости",
+    "boardSelector": "Выберите доску для управления",
+    "selectBoard": "Выберите доску",
+    "unnamedBoard": "Доска без названия"
   },
   "network": {
     "title": "Wi-Fi",

--- a/web/messages/sv.json
+++ b/web/messages/sv.json
@@ -77,7 +77,10 @@
     "secondaryNavigation": "Sekundär navigering",
     "picks": "Personalens val",
     "skipToMainContent": "Hoppa till huvudinnehållet",
-    "prideCelebrationAriaLabel": "Fira Pride-månaden"
+    "prideCelebrationAriaLabel": "Fira Pride-månaden",
+    "boardSelector": "Välj tavla att hantera",
+    "selectBoard": "Välj tavla",
+    "unnamedBoard": "Namnlös tavla"
   },
   "network": {
     "title": "Wi-Fi",

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -77,7 +77,10 @@
     "secondaryNavigation": "İkincil gezinme",
     "picks": "Ekip Seçimleri",
     "skipToMainContent": "Ana içeriğe geç",
-    "prideCelebrationAriaLabel": "Onur Ayı'nı kutla"
+    "prideCelebrationAriaLabel": "Onur Ayı'nı kutla",
+    "boardSelector": "Yönetilecek panoyu seçin",
+    "selectBoard": "Pano seçin",
+    "unnamedBoard": "Adsız pano"
   },
   "network": {
     "title": "Wi-Fi",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -77,7 +77,10 @@
     "secondaryNavigation": "次导航",
     "picks": "团队精选",
     "skipToMainContent": "跳到主要内容",
-    "prideCelebrationAriaLabel": "庆祝骄傲月"
+    "prideCelebrationAriaLabel": "庆祝骄傲月",
+    "boardSelector": "选择要管理的板",
+    "selectBoard": "选择板",
+    "unnamedBoard": "未命名的板"
   },
   "network": {
     "title": "Wi-Fi",

--- a/web/src/__tests__/current-board-context.test.tsx
+++ b/web/src/__tests__/current-board-context.test.tsx
@@ -1,0 +1,123 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { CurrentBoardProvider, useCurrentBoard } from "@/components/current-board-context";
+
+import { server } from "./mocks/server";
+
+const API_BASE = "/api";
+const STORAGE_KEY = "fiestaboard_current_board";
+
+function boardsResponse(boards: Array<{ id: string; name: string }>) {
+  return HttpResponse.json({
+    board_type: "black",
+    boards: boards.map((b) => ({
+      ...b,
+      device_type: "flagship",
+      board_color: "black",
+    })),
+    devices: ["flagship"],
+  });
+}
+
+function Probe() {
+  const { currentBoardId, currentBoard, boards, setCurrentBoardId } = useCurrentBoard();
+  return (
+    <div>
+      <span data-testid="current-id">{currentBoardId}</span>
+      <span data-testid="current-name">{currentBoard?.name ?? ""}</span>
+      <span data-testid="board-count">{boards.length}</span>
+      <button data-testid="select-two" onClick={() => setCurrentBoardId("two")} />
+    </div>
+  );
+}
+
+function renderProbe() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <CurrentBoardProvider>
+        <Probe />
+      </CurrentBoardProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("CurrentBoardProvider", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("defaults to the primary board when nothing is stored", async () => {
+    server.use(
+      http.get(`${API_BASE}/settings/board`, () =>
+        boardsResponse([
+          { id: "one", name: "Kitchen" },
+          { id: "two", name: "Office" },
+        ]),
+      ),
+    );
+
+    renderProbe();
+
+    await waitFor(() => expect(screen.getByTestId("current-id")).toHaveTextContent("one"));
+    expect(screen.getByTestId("current-name")).toHaveTextContent("Kitchen");
+  });
+
+  it("restores a valid stored board id from localStorage", async () => {
+    localStorage.setItem(STORAGE_KEY, "two");
+    server.use(
+      http.get(`${API_BASE}/settings/board`, () =>
+        boardsResponse([
+          { id: "one", name: "Kitchen" },
+          { id: "two", name: "Office" },
+        ]),
+      ),
+    );
+
+    renderProbe();
+
+    await waitFor(() => expect(screen.getByTestId("current-id")).toHaveTextContent("two"));
+    expect(screen.getByTestId("current-name")).toHaveTextContent("Office");
+  });
+
+  it("drops a stale stored id and falls back to the primary board", async () => {
+    localStorage.setItem(STORAGE_KEY, "deleted-board");
+    server.use(
+      http.get(`${API_BASE}/settings/board`, () =>
+        boardsResponse([
+          { id: "one", name: "Kitchen" },
+          { id: "two", name: "Office" },
+        ]),
+      ),
+    );
+
+    renderProbe();
+
+    await waitFor(() => expect(screen.getByTestId("current-id")).toHaveTextContent("one"));
+  });
+
+  it("persists a new selection to localStorage", async () => {
+    server.use(
+      http.get(`${API_BASE}/settings/board`, () =>
+        boardsResponse([
+          { id: "one", name: "Kitchen" },
+          { id: "two", name: "Office" },
+        ]),
+      ),
+    );
+
+    renderProbe();
+
+    await waitFor(() => expect(screen.getByTestId("current-id")).toHaveTextContent("one"));
+
+    fireEvent.click(screen.getByTestId("select-two"));
+
+    await waitFor(() => expect(screen.getByTestId("current-id")).toHaveTextContent("two"));
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("two");
+  });
+});

--- a/web/src/__tests__/navigation-sidebar.test.tsx
+++ b/web/src/__tests__/navigation-sidebar.test.tsx
@@ -1,8 +1,10 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { CurrentBoardProvider } from "@/components/current-board-context";
 import { GlobalAiPanelProvider } from "@/components/global-ai-panel-context";
 import { SidebarProvider } from "@/components/sidebar-context";
 import { ConfigOverridesProvider } from "@/hooks/use-config-overrides";
@@ -45,11 +47,13 @@ function TestWrapper({ children }: { children: React.ReactNode }) {
     <QueryClientProvider client={queryClient}>
       <GlobalAiPanelProvider>
         <SidebarProvider>
-          <ConfigOverridesProvider>
-            <ThemeProvider attribute="class" defaultTheme="light">
-              {children}
-            </ThemeProvider>
-          </ConfigOverridesProvider>
+          <CurrentBoardProvider>
+            <ConfigOverridesProvider>
+              <ThemeProvider attribute="class" defaultTheme="light">
+                {children}
+              </ThemeProvider>
+            </ConfigOverridesProvider>
+          </CurrentBoardProvider>
         </SidebarProvider>
       </GlobalAiPanelProvider>
     </QueryClientProvider>
@@ -326,5 +330,92 @@ describe("NavigationSidebar AI Assistant visibility (issue #806)", () => {
     await waitFor(() => {
       expect(screen.queryByText("AI Assistant")).not.toBeInTheDocument();
     });
+  });
+});
+
+describe("NavigationSidebar board selector (issue #1246)", () => {
+  const API_BASE = "/api";
+
+  beforeEach(() => {
+    mockPathname.mockReturnValue("/");
+    localStorage.clear();
+  });
+
+  function mockBoards(boards: Array<{ id: string; name: string }>) {
+    server.use(
+      http.get(`${API_BASE}/settings/board`, () =>
+        HttpResponse.json({
+          board_type: "black",
+          boards: boards.map((b) => ({ ...b, device_type: "flagship", board_color: "black" })),
+          devices: ["flagship"],
+        }),
+      ),
+    );
+  }
+
+  it("hides the selector for single-board installs", async () => {
+    mockBoards([{ id: "default", name: "Flagship" }]);
+
+    render(<NavigationSidebar />, { wrapper: TestWrapper });
+
+    // Give the board-settings query time to resolve, then assert absence.
+    await waitFor(() => {
+      expect(screen.getAllByLabelText("Primary navigation").length).toBeGreaterThan(0);
+    });
+    expect(screen.queryByLabelText("Select board to manage")).not.toBeInTheDocument();
+  });
+
+  it("shows the selector when more than one board is configured", async () => {
+    mockBoards([
+      { id: "one", name: "Kitchen" },
+      { id: "two", name: "Office" },
+    ]);
+
+    render(<NavigationSidebar />, { wrapper: TestWrapper });
+
+    // Desktop sidebar + mobile drawer each render a trigger.
+    await waitFor(() => {
+      expect(screen.getAllByLabelText("Select board to manage").length).toBeGreaterThan(0);
+    });
+  });
+
+  it("opens the dropdown and lists all configured boards", async () => {
+    const user = userEvent.setup();
+    mockBoards([
+      { id: "one", name: "Kitchen" },
+      { id: "two", name: "Office" },
+    ]);
+
+    render(<NavigationSidebar />, { wrapper: TestWrapper });
+
+    const triggers = await screen.findAllByLabelText("Select board to manage");
+    await user.click(triggers[0]);
+
+    await waitFor(() => {
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+    });
+    expect(screen.getByRole("option", { name: "Kitchen" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Office" })).toBeInTheDocument();
+  });
+
+  it("restores the persisted board selection across reloads", async () => {
+    const user = userEvent.setup();
+    localStorage.setItem("fiestaboard_current_board", "two");
+    mockBoards([
+      { id: "one", name: "Kitchen" },
+      { id: "two", name: "Office" },
+    ]);
+
+    render(<NavigationSidebar />, { wrapper: TestWrapper });
+
+    const triggers = await screen.findAllByLabelText("Select board to manage");
+    await user.click(triggers[0]);
+
+    await waitFor(() => {
+      expect(screen.getByRole("listbox")).toBeInTheDocument();
+    });
+    // The persisted board ("Office") is the selected option when the menu opens.
+    expect(screen.getByRole("option", { name: "Office" })).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("option", { name: "Kitchen" })).toHaveAttribute("aria-selected", "false");
   });
 });

--- a/web/src/components/current-board-context.tsx
+++ b/web/src/components/current-board-context.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+
+import { useBoardSettings } from "@/hooks/use-board";
+import type { BoardInstance } from "@/lib/api";
+
+const STORAGE_KEY = "fiestaboard_current_board";
+
+interface CurrentBoardContextValue {
+  /** ID of the board the user is currently managing. Empty string until boards load. */
+  currentBoardId: string;
+  /** Select a board to manage; persists the choice to localStorage. */
+  setCurrentBoardId: (boardId: string) => void;
+  /** The resolved board instance for `currentBoardId`, or undefined while loading. */
+  currentBoard: BoardInstance | undefined;
+  /** The live list of board instances from board settings. */
+  boards: BoardInstance[];
+}
+
+const CurrentBoardContext = createContext<CurrentBoardContextValue>({
+  currentBoardId: "",
+  setCurrentBoardId: () => {},
+  currentBoard: undefined,
+  boards: [],
+});
+
+function readStoredBoardId(): string | null {
+  try {
+    return localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function CurrentBoardProvider({ children }: { children: React.ReactNode }) {
+  const { data: boardSettings } = useBoardSettings();
+
+  // Memoize so the boards array identity is stable between renders when the
+  // query data is unchanged; downstream effects depend on it.
+  const boards = useMemo(() => boardSettings?.boards ?? [], [boardSettings?.boards]);
+
+  const [currentBoardId, setCurrentBoardIdState] = useState<string>("");
+
+  // Reconcile the selected board against the live board list. The default is
+  // the PRIMARY board (boards[0]); a stored id is honored only if it still
+  // maps to an existing board, otherwise it's dropped in favor of the primary.
+  useEffect(() => {
+    if (boards.length === 0) return;
+    const primaryId = boards[0].id;
+
+    setCurrentBoardIdState((prev) => {
+      // Prefer the in-memory selection if it's still valid.
+      if (prev && boards.some((b) => b.id === prev)) return prev;
+
+      const stored = readStoredBoardId();
+      if (stored && boards.some((b) => b.id === stored)) return stored;
+
+      return primaryId;
+    });
+  }, [boards]);
+
+  const setCurrentBoardId = useCallback((boardId: string) => {
+    setCurrentBoardIdState(boardId);
+    try {
+      localStorage.setItem(STORAGE_KEY, boardId);
+    } catch {}
+  }, []);
+
+  const currentBoard = useMemo(() => boards.find((b) => b.id === currentBoardId), [boards, currentBoardId]);
+
+  const value = useMemo(
+    () => ({ currentBoardId, setCurrentBoardId, currentBoard, boards }),
+    [currentBoardId, setCurrentBoardId, currentBoard, boards],
+  );
+
+  return <CurrentBoardContext.Provider value={value}>{children}</CurrentBoardContext.Provider>;
+}
+
+export function useCurrentBoard() {
+  return useContext(CurrentBoardContext);
+}

--- a/web/src/components/navigation-sidebar.tsx
+++ b/web/src/components/navigation-sidebar.tsx
@@ -11,6 +11,7 @@ import {
   HelpCircle,
   Home,
   Menu,
+  Monitor,
   Puzzle,
   Settings,
   Sparkles,
@@ -18,6 +19,7 @@ import {
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 
+import { useCurrentBoard } from "@/components/current-board-context";
 import { FiestaLogo } from "@/components/fiesta-logo";
 import { useGlobalAiPanel } from "@/components/global-ai-panel-context";
 import { SidebarAccount } from "@/components/sidebar-account";
@@ -26,6 +28,7 @@ import { SidebarAuroraHorizontal } from "@/components/sidebar-aurora-horizontal"
 import { useSidebar } from "@/components/sidebar-context";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { Button } from "@/components/ui/button";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { VersionDisplay } from "@/components/version-display";
 import { ViewTransitionLink } from "@/components/view-transition-link";
@@ -60,6 +63,64 @@ const secondaryItems: NavItem[] = [
 
 const PRIDE_COLORS = ["#e40303", "#ff8c00", "#ffed00", "#008026", "#004dff", "#750787"];
 
+/**
+ * Board picker for the sidebar. Selects the board the rest of the app manages
+ * (Dashboard/Schedule consume `useCurrentBoard()`). Renders only for multi-board
+ * installs; single-board users never see it. In the collapsed desktop sidebar it
+ * shrinks to an icon-only trigger with a tooltip showing the current board name,
+ * mirroring the collapsed nav-item pattern (`opacity-0 max-w-0` on the label).
+ */
+function BoardSelector({ collapsed = false }: { collapsed?: boolean }) {
+  const { boards, currentBoardId, setCurrentBoardId, currentBoard } = useCurrentBoard();
+  const t = useTranslations("navigation");
+
+  if (boards.length <= 1) return null;
+
+  const currentName = currentBoard?.name || t("unnamedBoard");
+
+  const trigger = (
+    <SelectTrigger
+      aria-label={t("boardSelector")}
+      className={cn(
+        "h-9 gap-2 transition-[width,padding] duration-100",
+        collapsed ? "w-9 justify-center px-0 [&>svg:last-child]:hidden" : "w-full",
+      )}
+    >
+      <Monitor className="h-5 w-5 flex-shrink-0 text-muted-foreground" />
+      <span
+        className={cn(
+          "min-w-0 flex-1 overflow-hidden whitespace-nowrap text-left transition-opacity duration-100",
+          collapsed ? "max-w-0 opacity-0" : "max-w-48 opacity-100 delay-150",
+        )}
+      >
+        <SelectValue placeholder={t("selectBoard")} />
+      </span>
+    </SelectTrigger>
+  );
+
+  return (
+    <Select value={currentBoardId} onValueChange={setCurrentBoardId}>
+      {collapsed ? (
+        <Tooltip>
+          <TooltipTrigger asChild>{trigger}</TooltipTrigger>
+          <TooltipContent side="right" className="font-medium">
+            {currentName}
+          </TooltipContent>
+        </Tooltip>
+      ) : (
+        trigger
+      )}
+      <SelectContent>
+        {boards.map((board) => (
+          <SelectItem key={board.id} value={board.id}>
+            {board.name || t("unnamedBoard")}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
 export function NavigationSidebar() {
   const pathname = usePathname();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
@@ -68,6 +129,7 @@ export function NavigationSidebar() {
   const { collapsed, transitioning, toggle, onTransitionEnd } = useSidebar();
   const t = useTranslations("navigation");
   const { isOpen: aiPanelOpen, open: openAiPanel } = useGlobalAiPanel();
+  const { boards } = useCurrentBoard();
 
   const isPrideMonth = usePrideActive();
 
@@ -339,6 +401,11 @@ export function NavigationSidebar() {
             </button>
           )}
         </nav>
+        {boards.length > 1 && (
+          <div className="shrink-0 border-t border-sidebar-border mx-3 px-3 py-3">
+            <BoardSelector />
+          </div>
+        )}
         <div className="shrink-0 border-t border-sidebar-border mx-3" />
         <div className="shrink-0 px-3 py-3 text-sidebar-foreground">
           <nav aria-label={t("secondaryNavigation")} className="space-y-1">
@@ -418,6 +485,15 @@ export function NavigationSidebar() {
             <nav aria-label={t("primaryNavigation")} className="min-h-0 flex-1 space-y-1 overflow-y-auto py-4 px-2">
               {primaryItems.map(renderDesktopNavItem)}
             </nav>
+
+            {boards.length > 1 && (
+              <>
+                <div className="mx-2 border-t border-sidebar-border" />
+                <div className="shrink-0 px-2 py-2">
+                  <BoardSelector collapsed={collapsed} />
+                </div>
+              </>
+            )}
 
             {hasAiProviders && (
               <>

--- a/web/src/components/providers.tsx
+++ b/web/src/components/providers.tsx
@@ -3,6 +3,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useState } from "react";
 
+import { CurrentBoardProvider } from "@/components/current-board-context";
 import { SidebarProvider } from "@/components/sidebar-context";
 import { UpdateProvider } from "@/components/update-context";
 import { ConfigOverridesProvider } from "@/hooks/use-config-overrides";
@@ -35,11 +36,13 @@ export function Providers({ children }: { children: React.ReactNode }) {
     <QueryClientProvider client={queryClient}>
       <ThemeProvider>
         <SidebarProvider>
-          <ConfigOverridesProvider>
-            <FormatPreferencesProvider>
-              <UpdateProvider>{children}</UpdateProvider>
-            </FormatPreferencesProvider>
-          </ConfigOverridesProvider>
+          <CurrentBoardProvider>
+            <ConfigOverridesProvider>
+              <FormatPreferencesProvider>
+                <UpdateProvider>{children}</UpdateProvider>
+              </FormatPreferencesProvider>
+            </ConfigOverridesProvider>
+          </CurrentBoardProvider>
         </SidebarProvider>
       </ThemeProvider>
     </QueryClientProvider>


### PR DESCRIPTION
Closes #1246

Part of the per-board epic (#1241). Adds the frontend foundation that the Dashboard (#1247) and Schedule (#1248) will consume to become board-aware. This PR is provider + selector + i18n only — it intentionally does **not** wire the Dashboard or Schedule to the current board yet.

## What's included

### `CurrentBoardProvider` (new)
`web/src/components/current-board-context.tsx`, mirroring the `SidebarProvider` localStorage+context pattern:
- Holds `currentBoardId`, persisted to `localStorage` (`fiestaboard_current_board`).
- Defaults to the **primary board** (`boards[0].id`).
- Reconciles against the live board list on every board-settings change: an in-memory or stored id is honored only if it still maps to an existing board; otherwise it falls back to the primary (drops a stale id).
- Exposes `useCurrentBoard()` -> `{ currentBoardId, setCurrentBoardId, currentBoard, boards }`.
- Mounted in `web/src/components/providers.tsx` inside `QueryClientProvider` (so `useBoardSettings` resolves) and `SidebarProvider`.

### Sidebar board selector
`web/src/components/navigation-sidebar.tsx`:
- Renders **only when `boards.length > 1`** — single-board installs never see it.
- Reuses the existing `ui/select` primitives, with board options from `useBoardSettings()` via the provider.
- **Collapsed desktop mode:** icon-only trigger (`Monitor`) wrapped in `ui/tooltip` showing the board name; the label fades via the existing `opacity-0 max-w-0` collapsed-nav pattern.
- Placed between the primary nav and the secondary/footer block; also wired into the **mobile drawer**.

### i18n + a11y
- New keys `navigation.boardSelector`, `navigation.selectBoard`, `navigation.unnamedBoard` added to `en.json` and **all 14 locales** (de, es, fr, it, ja, ko, nl, pl, pt, ru, sv, tr, zh) with proper translations — key parity preserved at 1490 keys across all 15 files.
- `aria-label` on the trigger (`navigation.boardSelector`), following existing nav a11y conventions.

## Tests (vitest)
- `current-board-context.test.tsx`: defaults to primary, restores a valid stored id, drops a stale id, persists a new selection.
- `navigation-sidebar.test.tsx`: hidden with 1 board, shown with >1, lists all boards on open, restores the persisted selection.

## `useCurrentBoard()` API (for #1247 / #1248 / #1249)
```ts
const { currentBoardId, setCurrentBoardId, currentBoard, boards } = useCurrentBoard();
// currentBoardId: string        - selected board id ("" until boards load)
// setCurrentBoardId: (id) => void - select + persist to localStorage
// currentBoard: BoardInstance | undefined
// boards: BoardInstance[]       - live list from board settings
```

## Validation
Verified statically (no host dev stack): prettier `--check` clean, eslint clean (0 errors), tsc clean for the changed files, and i18n key parity confirmed across all 15 message files. CI ("CI Success") is the executable gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)