### PR TITLE
feat(web): board dimensions display as rows × cols app-wide

### DIFF
--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -546,8 +546,8 @@
       "connectedTestAgain": "Verbunden! Erneut testen",
       "thingsToTry": "Tipps:",
       "boardType": "Board-Typ",
-      "flagshipDimensions": "22 × 6 Zeichen",
-      "noteDimensions": "15 × 3 Zeichen",
+      "flagshipDimensions": "6 × 22 Zeichen",
+      "noteDimensions": "3 × 15 Zeichen",
       "boardColor": "Boardfarbe",
       "connectionTestFailed": "Verbindungstest fehlgeschlagen",
       "failedToEnableLocalApi": "Lokale API konnte nicht aktiviert werden"

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -503,8 +503,8 @@
       "connectedTestAgain": "Connected! Test Again",
       "thingsToTry": "Things to try:",
       "boardType": "Board Type",
-      "flagshipDimensions": "22 × 6 characters",
-      "noteDimensions": "15 × 3 characters",
+      "flagshipDimensions": "6 × 22 characters",
+      "noteDimensions": "3 × 15 characters",
       "boardColor": "Board Color",
       "connectionTestFailed": "Connection test failed",
       "failedToEnableLocalApi": "Failed to enable local API"

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -546,8 +546,8 @@
       "connectedTestAgain": "¡Conectado! Probar de nuevo",
       "thingsToTry": "Cosas para probar:",
       "boardType": "Tipo de tablero",
-      "flagshipDimensions": "22 × 6 caracteres",
-      "noteDimensions": "15 × 3 caracteres",
+      "flagshipDimensions": "6 × 22 caracteres",
+      "noteDimensions": "3 × 15 caracteres",
       "boardColor": "Color del tablero",
       "connectionTestFailed": "Prueba de conexión fallida",
       "failedToEnableLocalApi": "Error al habilitar la API local"

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -546,8 +546,8 @@
       "connectedTestAgain": "Connecté ! Retester",
       "thingsToTry": "Choses à essayer :",
       "boardType": "Type de tableau",
-      "flagshipDimensions": "22 × 6 caractères",
-      "noteDimensions": "15 × 3 caractères",
+      "flagshipDimensions": "6 × 22 caractères",
+      "noteDimensions": "3 × 15 caractères",
       "boardColor": "Couleur du tableau",
       "connectionTestFailed": "Échec du test de connexion",
       "failedToEnableLocalApi": "Échec de l'activation de l'API locale"

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -546,8 +546,8 @@
       "connectedTestAgain": "Connesso! Testa di nuovo",
       "thingsToTry": "Cose da provare:",
       "boardType": "Tipo di bacheca",
-      "flagshipDimensions": "22 × 6 caratteri",
-      "noteDimensions": "15 × 3 caratteri",
+      "flagshipDimensions": "6 × 22 caratteri",
+      "noteDimensions": "3 × 15 caratteri",
       "boardColor": "Colore della bacheca",
       "connectionTestFailed": "Test di connessione fallito",
       "failedToEnableLocalApi": "Impossibile abilitare l'API locale"

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -546,8 +546,8 @@
       "connectedTestAgain": "接続完了！再テスト",
       "thingsToTry": "お試しください:",
       "boardType": "ボードタイプ",
-      "flagshipDimensions": "22×6 文字",
-      "noteDimensions": "15×3 文字",
+      "flagshipDimensions": "6×22 文字",
+      "noteDimensions": "3×15 文字",
       "boardColor": "ボードカラー",
       "connectionTestFailed": "接続テストに失敗しました",
       "failedToEnableLocalApi": "ローカルAPIの有効化に失敗しました"

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -546,8 +546,8 @@
       "connectedTestAgain": "연결됨! 다시 테스트",
       "thingsToTry": "시도해 볼 항목:",
       "boardType": "보드 유형",
-      "flagshipDimensions": "22 × 6 문자",
-      "noteDimensions": "15 × 3 문자",
+      "flagshipDimensions": "6 × 22 문자",
+      "noteDimensions": "3 × 15 문자",
       "boardColor": "보드 색상",
       "connectionTestFailed": "연결 테스트 실패",
       "failedToEnableLocalApi": "로컬 API 활성화 실패"

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -546,8 +546,8 @@
       "connectedTestAgain": "Verbonden! Opnieuw testen",
       "thingsToTry": "Dingen om te proberen:",
       "boardType": "Bordtype",
-      "flagshipDimensions": "22 × 6 tekens",
-      "noteDimensions": "15 × 3 tekens",
+      "flagshipDimensions": "6 × 22 tekens",
+      "noteDimensions": "3 × 15 tekens",
       "boardColor": "Bordkleur",
       "connectionTestFailed": "Verbindingstest mislukt",
       "failedToEnableLocalApi": "Lokale API activeren mislukt"

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -546,8 +546,8 @@
       "connectedTestAgain": "Połączono! Testuj ponownie",
       "thingsToTry": "Co możesz wypróbować:",
       "boardType": "Typ tablicy",
-      "flagshipDimensions": "22 × 6 znaków",
-      "noteDimensions": "15 × 3 znaki",
+      "flagshipDimensions": "6 × 22 znaków",
+      "noteDimensions": "3 × 15 znaki",
       "boardColor": "Kolor tablicy",
       "connectionTestFailed": "Test połączenia nie powiódł się",
       "failedToEnableLocalApi": "Nie udało się włączyć lokalnego API"

--- a/web/messages/pt.json
+++ b/web/messages/pt.json
@@ -546,8 +546,8 @@
       "connectedTestAgain": "Conectado! Testar Novamente",
       "thingsToTry": "Coisas para experimentar:",
       "boardType": "Tipo de Painel",
-      "flagshipDimensions": "22 × 6 caracteres",
-      "noteDimensions": "15 × 3 caracteres",
+      "flagshipDimensions": "6 × 22 caracteres",
+      "noteDimensions": "3 × 15 caracteres",
       "boardColor": "Cor do Painel",
       "connectionTestFailed": "Teste de conexão falhou",
       "failedToEnableLocalApi": "Falha ao habilitar a API local"

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -546,8 +546,8 @@
       "connectedTestAgain": "Подключено! Проверить снова",
       "thingsToTry": "Что можно попробовать:",
       "boardType": "Тип доски",
-      "flagshipDimensions": "22 × 6 символов",
-      "noteDimensions": "15 × 3 символов",
+      "flagshipDimensions": "6 × 22 символов",
+      "noteDimensions": "3 × 15 символов",
       "boardColor": "Цвет доски",
       "connectionTestFailed": "Ошибка проверки подключения",
       "failedToEnableLocalApi": "Не удалось включить локальный API"

--- a/web/messages/sv.json
+++ b/web/messages/sv.json
@@ -546,8 +546,8 @@
       "connectedTestAgain": "Ansluten! Testa igen",
       "thingsToTry": "Saker att prova:",
       "boardType": "Tavlans typ",
-      "flagshipDimensions": "22 × 6 tecken",
-      "noteDimensions": "15 × 3 tecken",
+      "flagshipDimensions": "6 × 22 tecken",
+      "noteDimensions": "3 × 15 tecken",
       "boardColor": "Tavlans färg",
       "connectionTestFailed": "Anslutningstest misslyckades",
       "failedToEnableLocalApi": "Kunde inte aktivera lokalt API"

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -546,8 +546,8 @@
       "connectedTestAgain": "Bağlandı! Tekrar Test Et",
       "thingsToTry": "Deneyebilecekleriniz:",
       "boardType": "Pano Türü",
-      "flagshipDimensions": "22 × 6 karakter",
-      "noteDimensions": "15 × 3 karakter",
+      "flagshipDimensions": "6 × 22 karakter",
+      "noteDimensions": "3 × 15 karakter",
       "boardColor": "Pano Rengi",
       "connectionTestFailed": "Bağlantı testi başarısız",
       "failedToEnableLocalApi": "Yerel API etkinleştirilemedi"

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -546,8 +546,8 @@
       "connectedTestAgain": "已连接！再次测试",
       "thingsToTry": "可以尝试：",
       "boardType": "看板类型",
-      "flagshipDimensions": "22 × 6 个字符",
-      "noteDimensions": "15 × 3 个字符",
+      "flagshipDimensions": "6 × 22 个字符",
+      "noteDimensions": "3 × 15 个字符",
       "boardColor": "看板颜色",
       "connectionTestFailed": "连接测试失败",
       "failedToEnableLocalApi": "启用本地API失败"

--- a/web/src/__tests__/board-size-indicator.test.tsx
+++ b/web/src/__tests__/board-size-indicator.test.tsx
@@ -6,10 +6,10 @@ import { BoardSizeIndicator } from "@/components/board-size-indicator";
 describe("BoardSizeIndicator", () => {
   // ── Flagship ──────────────────────────────────────────────────────────────────
   describe("flagship", () => {
-    it('renders "22 × 6" for flagship (width × height, matching the rest of the app)', () => {
+    it('renders "6 × 22" for flagship (rows × cols)', () => {
       render(<BoardSizeIndicator deviceType="flagship" />);
-      // Visual order is cols × rows so it reads the same as the wizard's "22 × 6 characters".
-      expect(screen.getByRole("img")).toHaveTextContent("22 × 6");
+      // Visual order is rows × cols, matching the wizard's "6 × 22 characters".
+      expect(screen.getByRole("img")).toHaveTextContent("6 × 22");
       // The accessible label names each dimension explicitly (order-independent).
       expect(screen.getByRole("img")).toHaveAttribute("aria-label", "6 rows by 22 columns");
     });
@@ -22,10 +22,10 @@ describe("BoardSizeIndicator", () => {
 
   // ── Note ─────────────────────────────────────────────────────────────────────
   describe("note", () => {
-    it('renders "15 × 3" for note (width × height)', () => {
+    it('renders "3 × 15" for note (rows × cols)', () => {
       render(<BoardSizeIndicator deviceType="note" />);
       const el = screen.getByRole("img");
-      expect(el).toHaveTextContent("15 × 3");
+      expect(el).toHaveTextContent("3 × 15");
       expect(el).toHaveAttribute("aria-label", "3 rows by 15 columns");
     });
 
@@ -37,41 +37,41 @@ describe("BoardSizeIndicator", () => {
 
   // ── note_array — all 5 presets ────────────────────────────────────────────────
   describe("note_array presets", () => {
-    it("2 side-by-side: 30 × 3 · 2 side-by-side", () => {
+    it("2 side-by-side: 3 × 30 · 2 side-by-side", () => {
       render(<BoardSizeIndicator deviceType="note_array" notesWide={2} notesTall={1} />);
-      expect(screen.getByRole("img")).toHaveTextContent("30 × 3");
+      expect(screen.getByRole("img")).toHaveTextContent("3 × 30");
       expect(screen.getByText("·")).toBeInTheDocument();
       expect(screen.getByText("2 side-by-side")).toBeInTheDocument();
       expect(screen.getByRole("img")).toHaveAttribute("aria-label", "3 rows by 30 columns, 2 side-by-side");
     });
 
-    it("4 side-by-side: 60 × 3 · 4 side-by-side", () => {
+    it("4 side-by-side: 3 × 60 · 4 side-by-side", () => {
       render(<BoardSizeIndicator deviceType="note_array" notesWide={4} notesTall={1} />);
-      expect(screen.getByRole("img")).toHaveTextContent("60 × 3");
+      expect(screen.getByRole("img")).toHaveTextContent("3 × 60");
       expect(screen.getByText("·")).toBeInTheDocument();
       expect(screen.getByText("4 side-by-side")).toBeInTheDocument();
       expect(screen.getByRole("img")).toHaveAttribute("aria-label", "3 rows by 60 columns, 4 side-by-side");
     });
 
-    it("2 stacked: 15 × 6 · 2 stacked", () => {
+    it("2 stacked: 6 × 15 · 2 stacked", () => {
       render(<BoardSizeIndicator deviceType="note_array" notesWide={1} notesTall={2} />);
-      expect(screen.getByRole("img")).toHaveTextContent("15 × 6");
+      expect(screen.getByRole("img")).toHaveTextContent("6 × 15");
       expect(screen.getByText("·")).toBeInTheDocument();
       expect(screen.getByText("2 stacked")).toBeInTheDocument();
       expect(screen.getByRole("img")).toHaveAttribute("aria-label", "6 rows by 15 columns, 2 stacked");
     });
 
-    it("4 stacked: 15 × 12 · 4 stacked", () => {
+    it("4 stacked: 12 × 15 · 4 stacked", () => {
       render(<BoardSizeIndicator deviceType="note_array" notesWide={1} notesTall={4} />);
-      expect(screen.getByRole("img")).toHaveTextContent("15 × 12");
+      expect(screen.getByRole("img")).toHaveTextContent("12 × 15");
       expect(screen.getByText("·")).toBeInTheDocument();
       expect(screen.getByText("4 stacked")).toBeInTheDocument();
       expect(screen.getByRole("img")).toHaveAttribute("aria-label", "12 rows by 15 columns, 4 stacked");
     });
 
-    it("2×2 grid: 30 × 6 · 2×2 grid (brief acceptance case)", () => {
+    it("2×2 grid: 6 × 30 · 2×2 grid (brief acceptance case)", () => {
       render(<BoardSizeIndicator deviceType="note_array" notesWide={2} notesTall={2} />);
-      expect(screen.getByRole("img")).toHaveTextContent("30 × 6");
+      expect(screen.getByRole("img")).toHaveTextContent("6 × 30");
       expect(screen.getByText("·")).toBeInTheDocument();
       expect(screen.getByText("2×2 grid")).toBeInTheDocument();
       expect(screen.getByRole("img")).toHaveAttribute("aria-label", "6 rows by 30 columns, 2×2 grid");
@@ -80,16 +80,16 @@ describe("BoardSizeIndicator", () => {
 
   // ── note_array — custom (no matching preset) ──────────────────────────────────
   describe("note_array custom", () => {
-    it("3×2 (custom, no preset): 45 × 6 · Custom", () => {
+    it("3×2 (custom, no preset): 6 × 45 · Custom", () => {
       render(<BoardSizeIndicator deviceType="note_array" notesWide={3} notesTall={2} />);
-      expect(screen.getByRole("img")).toHaveTextContent("45 × 6");
+      expect(screen.getByRole("img")).toHaveTextContent("6 × 45");
       expect(screen.getByText("·")).toBeInTheDocument();
       expect(screen.getByText("Custom")).toBeInTheDocument();
     });
 
-    it("1×1 (custom, not a preset): 15 × 3 · Custom", () => {
+    it("1×1 (custom, not a preset): 3 × 15 · Custom", () => {
       render(<BoardSizeIndicator deviceType="note_array" notesWide={1} notesTall={1} />);
-      expect(screen.getByRole("img")).toHaveTextContent("15 × 3");
+      expect(screen.getByRole("img")).toHaveTextContent("3 × 15");
       expect(screen.getByText("·")).toBeInTheDocument();
       expect(screen.getByText("Custom")).toBeInTheDocument();
     });

--- a/web/src/__tests__/page-builder.test.tsx
+++ b/web/src/__tests__/page-builder.test.tsx
@@ -111,10 +111,10 @@ describe("PageBuilder — note-array dimensions", () => {
     vi.clearAllMocks();
   });
 
-  // A 4×1 note array → 4*15 = 60 cols × 1*3 = 3 rows. The BoardSizeIndicator
-  // renders width × height (cols × rows), so a real note-array preview shows
-  // "60 × 3". A 1×1 (flagship/note default) note array would only ever show
-  // "15 × 3", so asserting "60 × 3" proves the real dims were threaded through.
+  // A 4×1 note array → 4*15 = 60 cols, 1*3 = 3 rows. The BoardSizeIndicator
+  // renders rows × cols, so a real note-array preview shows
+  // "3 × 60". A 1×1 (flagship/note default) note array would only ever show
+  // "3 × 15", so asserting "3 × 60" proves the real dims were threaded through.
   function configureNoteArrayBoard(notesWide: number, notesTall: number) {
     server.use(
       http.get(`${API_BASE}/settings/board`, () => {
@@ -137,22 +137,22 @@ describe("PageBuilder — note-array dimensions", () => {
   }
 
   it("previews a NEW note_array page at the configured board's real size", async () => {
-    // Configured note array is 4 wide × 1 tall → 60 × 3.
+    // Configured note array is 4 wide × 1 tall → 3 × 60.
     configureNoteArrayBoard(4, 1);
 
     render(<PageBuilder deviceType="note_array" onClose={vi.fn()} />, { wrapper: TestWrapper });
 
-    // The size indicator reflects the seeded grid dims (cols × rows), not 1×1.
+    // The size indicator reflects the seeded grid dims (rows × cols), not 1×1.
     await waitFor(() => {
       expect(screen.getByRole("img", { name: /3 rows by 60 columns/i })).toBeInTheDocument();
     });
     const indicator = screen.getByRole("img", { name: /3 rows by 60 columns/i });
-    expect(indicator).toHaveTextContent("60 × 3");
+    expect(indicator).toHaveTextContent("3 × 60");
   });
 
   it("seeds dims from an EDITED note_array page", async () => {
     // Editing a 2×2 note array page (persisted notes_wide/notes_tall) →
-    // 2*15 = 30 cols × 2*3 = 6 rows → "30 × 6".
+    // 2*15 = 30 cols × 2*3 = 6 rows → "6 × 30".
     server.use(
       http.get(`${API_BASE}/pages/:id`, () => {
         return HttpResponse.json({
@@ -175,16 +175,16 @@ describe("PageBuilder — note-array dimensions", () => {
       expect(screen.getByRole("img", { name: /6 rows by 30 columns/i })).toBeInTheDocument();
     });
     const indicator = screen.getByRole("img", { name: /6 rows by 30 columns/i });
-    expect(indicator).toHaveTextContent("30 × 6");
+    expect(indicator).toHaveTextContent("6 × 30");
   });
 
-  it("leaves a flagship page at its fixed 22 × 6 size", async () => {
+  it("leaves a flagship page at its fixed 6 × 22 size", async () => {
     render(<PageBuilder deviceType="flagship" onClose={vi.fn()} />, { wrapper: TestWrapper });
 
     await waitFor(() => {
       expect(screen.getByRole("img", { name: /6 rows by 22 columns/i })).toBeInTheDocument();
     });
     const indicator = screen.getByRole("img", { name: /6 rows by 22 columns/i });
-    expect(indicator).toHaveTextContent("22 × 6");
+    expect(indicator).toHaveTextContent("6 × 22");
   });
 });

--- a/web/src/components/board-size-indicator.tsx
+++ b/web/src/components/board-size-indicator.tsx
@@ -36,9 +36,9 @@ export function BoardSizeIndicator({ deviceType, notesWide = 1, notesTall = 1, c
       aria-label={ariaLabel}
       className={`inline-flex items-center gap-1 text-xs text-muted-foreground font-mono tabular-nums${className ? ` ${className}` : ""}`}
     >
-      {/* Width × height (cols × rows) to match the rest of the app: the setup
-          wizard shows "22 × 6 characters" and board cards historically "22×6". */}
-      {cols} × {rows}
+      {/* Rows × cols (height × width) per the note-array epic convention; the
+          wizard "characters" strings and tests use the same rows × cols order. */}
+      {rows} × {cols}
       {noteArray && (
         <>
           <span className="text-muted-foreground/50 mx-0.5">·</span>

--- a/web/tests/multi-board.spec.ts
+++ b/web/tests/multi-board.spec.ts
@@ -45,7 +45,7 @@ test.describe("Settings – Board Card Display", () => {
     await expect(page.getByText("My Board").first()).toBeVisible({
       timeout: 10_000,
     });
-    await expect(page.getByText("22 × 6").first()).toBeVisible();
+    await expect(page.getByText("6 × 22").first()).toBeVisible();
   });
 
   test("board card shows Connected badge when credentials are set", async ({ page }) => {
@@ -89,10 +89,10 @@ test.describe("Settings – Board Card Display", () => {
 
     await openSettingsTab(page, "Hardware");
 
-    await expect(page.getByText("22 × 6").first()).toBeVisible({
+    await expect(page.getByText("6 × 22").first()).toBeVisible({
       timeout: 10_000,
     });
-    await expect(page.getByText("15 × 3").first()).toBeVisible();
+    await expect(page.getByText("3 × 15").first()).toBeVisible();
   });
 });
 
@@ -127,7 +127,7 @@ test.describe("Settings – Board Instance CRUD", () => {
     await page.getByRole("button", { name: "Note", exact: true }).click();
 
     // Verify Note dimensions appear
-    await expect(page.getByText("15 × 3").first()).toBeVisible({
+    await expect(page.getByText("3 × 15").first()).toBeVisible({
       timeout: 10_000,
     });
 
@@ -182,8 +182,8 @@ test.describe("Settings – Board Instance CRUD", () => {
     await page.getByRole("option", { name: "Note", exact: true }).click();
     await page.waitForTimeout(1_500);
 
-    // Header should now show 15 × 3 dimensions
-    await expect(page.getByText("15 × 3").first()).toBeVisible({
+    // Header should now show 3 × 15 dimensions
+    await expect(page.getByText("3 × 15").first()).toBeVisible({
       timeout: 5_000,
     });
 
@@ -208,8 +208,8 @@ test.describe("Settings – Board Instance CRUD", () => {
     await page.getByRole("option", { name: "4 side-by-side" }).click();
     await page.waitForTimeout(1_500);
 
-    // 4×1 notes → 60 × 3 characters
-    await expect(page.getByText("60 × 3").first()).toBeVisible({ timeout: 5_000 });
+    // 4×1 notes → 3 × 60 characters
+    await expect(page.getByText("3 × 60").first()).toBeVisible({ timeout: 5_000 });
 
     let res = await fetch(`${API_URL}/settings/board`);
     let data = await res.json();
@@ -227,7 +227,7 @@ test.describe("Settings – Board Instance CRUD", () => {
     await page.reload();
     await expect(page.getByRole("heading", { name: "Settings", exact: true })).toBeVisible({ timeout: 15_000 });
     await openSettingsTab(page, "Hardware");
-    await expect(page.getByText("60 × 3").first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText("3 × 60").first()).toBeVisible({ timeout: 10_000 });
 
     res = await fetch(`${API_URL}/settings/board`);
     data = await res.json();
@@ -263,8 +263,8 @@ test.describe("Settings – Board Instance CRUD", () => {
     await expect(detectBtn).toBeVisible({ timeout: 5_000 });
     await detectBtn.click();
 
-    // The selector lands on the 2×2 grid preset → 30 × 6 characters.
-    await expect(page.getByText("30 × 6").first()).toBeVisible({ timeout: 10_000 });
+    // The selector lands on the 2×2 grid preset → 6 × 30 characters.
+    await expect(page.getByText("6 × 30").first()).toBeVisible({ timeout: 10_000 });
 
     const res = await fetch(`${API_URL}/settings/board`);
     const data = await res.json();
@@ -319,11 +319,11 @@ test.describe("Settings – Board Instance CRUD", () => {
     const dataBefore = await resBefore.json();
     expect(dataBefore.boards.length).toBe(2);
 
-    // Expand the Note board (click on 15 × 3 dimensions to target the right card)
-    await expect(page.getByText("15 × 3").first()).toBeVisible({
+    // Expand the Note board (click on 3 × 15 dimensions to target the right card)
+    await expect(page.getByText("3 × 15").first()).toBeVisible({
       timeout: 10_000,
     });
-    await page.getByText("15 × 3").first().click();
+    await page.getByText("3 × 15").first().click();
 
     // Click Remove Board
     const removeBtn = page.getByRole("button", { name: /Remove Board/i });
@@ -412,9 +412,9 @@ test.describe("Setup Wizard – Board Configuration", () => {
 
     await expect(page.getByText("Board Type")).toBeVisible({ timeout: 5_000 });
     await expect(page.getByText("Flagship")).toBeVisible();
-    await expect(page.getByText("22 × 6 characters")).toBeVisible();
+    await expect(page.getByText("6 × 22 characters")).toBeVisible();
     await expect(page.getByText("Note")).toBeVisible();
-    await expect(page.getByText("15 × 3 characters")).toBeVisible();
+    await expect(page.getByText("3 × 15 characters")).toBeVisible();
   });
 
   test("wizard shows Board Color swatches with Black and White options", async ({ page }) => {
@@ -448,7 +448,7 @@ test.describe("Setup Wizard – Board Configuration", () => {
     // Select Note type and White color LAST (right before Test Connection)
     // so these are the most recent React state changes in the closure
     const noteTypeBtn = page.locator("button", {
-      hasText: "15 × 3 characters",
+      hasText: "3 × 15 characters",
     });
     await noteTypeBtn.scrollIntoViewIfNeeded();
     await expect(noteTypeBtn).toBeVisible({ timeout: 5_000 });
@@ -522,7 +522,7 @@ test.describe("Setup Wizard – Board Configuration", () => {
 
     // Select Note type first — scroll to Board Type section
     const noteTypeBtn = page.locator("button", {
-      hasText: "15 × 3 characters",
+      hasText: "3 × 15 characters",
     });
     await noteTypeBtn.scrollIntoViewIfNeeded();
     await expect(noteTypeBtn).toBeVisible({ timeout: 5_000 });
@@ -565,7 +565,7 @@ test.describe("Setup Wizard – Board Configuration", () => {
     await expect(page.getByText("My Board").first()).toBeVisible({
       timeout: 10_000,
     });
-    await expect(page.getByText("15 × 3").first()).toBeVisible();
+    await expect(page.getByText("3 × 15").first()).toBeVisible();
     await expect(page.getByText("Connected").first()).toBeVisible();
   });
 });

--- a/web/tests/regression/note-arrays.spec.ts
+++ b/web/tests/regression/note-arrays.spec.ts
@@ -40,14 +40,14 @@ const TYPE_SELECT_LABEL = "Board type and size";
 
 // Preset labels come straight from messages/en.json displaySettings.presets.*
 // and the dimensions from src/lib/board-dimensions.ts NOTE_ARRAY_PRESETS.
-// charLabel is the BoardSizeIndicator text: `{cols} × {rows}` (cols = w*15,
-// rows = h*3). All five presets except "4 side-by-side" go beyond #1178.
+// charLabel is the BoardSizeIndicator text: `{rows} × {cols}` (rows = h*3,
+// cols = w*15). All five presets except "4 side-by-side" go beyond #1178.
 const PRESETS = [
-  { label: "2 side-by-side", notesWide: 2, notesTall: 1, charLabel: "30 × 3" },
-  { label: "4 side-by-side", notesWide: 4, notesTall: 1, charLabel: "60 × 3" },
-  { label: "2 stacked", notesWide: 1, notesTall: 2, charLabel: "15 × 6" },
-  { label: "4 stacked", notesWide: 1, notesTall: 4, charLabel: "15 × 12" },
-  { label: "2×2 grid", notesWide: 2, notesTall: 2, charLabel: "30 × 6" },
+  { label: "2 side-by-side", notesWide: 2, notesTall: 1, charLabel: "3 × 30" },
+  { label: "4 side-by-side", notesWide: 4, notesTall: 1, charLabel: "3 × 60" },
+  { label: "2 stacked", notesWide: 1, notesTall: 2, charLabel: "6 × 15" },
+  { label: "4 stacked", notesWide: 1, notesTall: 4, charLabel: "12 × 15" },
+  { label: "2×2 grid", notesWide: 2, notesTall: 2, charLabel: "6 × 30" },
 ] as const;
 
 test.beforeEach(async ({ context, page }) => {
@@ -113,7 +113,7 @@ test.describe("regression: note-arrays — presets", () => {
 // ---------------------------------------------------------------------------
 
 test.describe("regression: note-arrays — custom W×H", () => {
-  test("Custom… with 3 × 2 persists notes_wide:3, notes_tall:2", async ({ page }) => {
+  test("Custom… with 2 × 3 persists notes_wide:3, notes_tall:2", async ({ page }) => {
     await openHardwareAndExpand(page);
 
     // Pick "Custom…" (displaySettings.customLabel → display-settings.tsx:645).
@@ -179,7 +179,7 @@ test.describe("regression: note-arrays — custom W×H", () => {
 // ---------------------------------------------------------------------------
 
 test.describe("regression: note-arrays — size indicator", () => {
-  test('configured 4 side-by-side board shows "60 × 3 · 4 side-by-side"', async ({ page }) => {
+  test('configured 4 side-by-side board shows "3 × 60 · 4 side-by-side"', async ({ page }) => {
     // Configure the single board as a 4-side-by-side note array directly via API.
     await fetch(`${API_URL}/settings/board`, {
       method: "PUT",
@@ -212,7 +212,7 @@ test.describe("regression: note-arrays — size indicator", () => {
     await expect(indicator).toBeVisible({ timeout: 10_000 });
 
     // Visible text is `{cols} × {rows} · {preset}` (board-size-indicator.tsx:41-46).
-    await expect(indicator).toContainText("60 × 3");
+    await expect(indicator).toContainText("3 × 60");
     await expect(indicator).toContainText("4 side-by-side");
   });
 
@@ -241,10 +241,10 @@ test.describe("regression: note-arrays — size indicator", () => {
     await expect(page.getByRole("heading", { name: "Settings", exact: true })).toBeVisible({ timeout: 15_000 });
     await openSettingsTab(page, "Hardware");
 
-    // 3×2 notes → 45 × 6 chars; no preset matches → boardSizeIndicator.custom ("Custom").
+    // 3×2 notes → 6 × 45 chars; no preset matches → boardSizeIndicator.custom ("Custom").
     const indicator = page.getByRole("img", { name: "6 rows by 45 columns, Custom" });
     await expect(indicator).toBeVisible({ timeout: 10_000 });
-    await expect(indicator).toContainText("45 × 6");
+    await expect(indicator).toContainText("6 × 45");
     await expect(indicator).toContainText("Custom");
   });
 });
@@ -294,8 +294,8 @@ test.describe("regression: note-arrays — auto-detect", () => {
     // Click Auto-detect (displaySettings.autoDetect → display-settings.tsx:725).
     await page.getByRole("button", { name: "Auto-detect from board" }).first().click();
 
-    // Header now shows flagship dimensions (22 × 6) and persists flagship.
-    await expect(page.getByText("22 × 6").first()).toBeVisible({ timeout: 10_000 });
+    // Header now shows flagship dimensions (6 × 22) and persists flagship.
+    await expect(page.getByText("6 × 22").first()).toBeVisible({ timeout: 10_000 });
     // The Cloud API Token field is hidden once the board is no longer a note array.
     await expect(page.getByText("Cloud API Token")).toHaveCount(0, { timeout: 5_000 });
 

--- a/web/tests/regression/settings-hardware-network.spec.ts
+++ b/web/tests/regression/settings-hardware-network.spec.ts
@@ -83,9 +83,9 @@ test.describe("regression: settings.hardware", () => {
 
     await openSettingsTab(page, "Hardware");
 
-    // Expand the Note board (15 × 3) to access its Remove button
-    await expect(page.getByText("15 × 3").first()).toBeVisible({ timeout: 10_000 });
-    await page.getByText("15 × 3").first().click();
+    // Expand the Note board (3 × 15) to access its Remove button
+    await expect(page.getByText("3 × 15").first()).toBeVisible({ timeout: 10_000 });
+    await page.getByText("3 × 15").first().click();
 
     const removeBtn = page.getByRole("button", { name: /Remove Board/i }).first();
     await expect(removeBtn).toBeEnabled({ timeout: 10_000 });


### PR DESCRIPTION
Flips the board-dimension **display** convention from width×height (cols × rows) to **rows × cols** app-wide, per maintainer decision (resolves the open UX-consistency question on #1175).

**Why:** the #1175 brief specified rows × cols ("3 × 60 · 4 Notes side-by-side") and the epic uses rows × cols throughout. The epic had shipped width×height to match the legacy wizard; this flips the whole app to rows × cols so the convention is consistent in the new direction.

**Changed (display only):**
- `BoardSizeIndicator` renders `{rows} × {cols}` (board cards + preview).
- Wizard `flagshipDimensions`/`noteDimensions` → "6 × 22"/"3 × 15 characters" across all 14 locales.
- UI display assertions updated in `board-size-indicator.test.tsx`, `multi-board.spec.ts`, `regression/note-arrays.spec.ts`.

**Deliberately unchanged:** backend grid descriptions ("3×15 array"), notes W×H / preset names ("4×1", "2×2 grid"), and aria-labels (already name rows/columns explicitly).

Verified: vitest indicator test 14 passed; all 14 locale JSON valid + prettier-clean; eslint 0 errors. Playwright E2E validated by CI.

Part of #1167.