### PR TITLE
ci(claude): push @claude fixes via GitHub App token to skip PR approval gate

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -33,25 +33,49 @@ jobs:
     permissions:
       # contents/pull-requests are write so the @claude bot can commit and
       # push fixes back to the PR branch when asked. Without write here, the
-      # action's git push fails 403 — see PR #980 comment 4699425518. Feature
-      # branches aren't protection-gated, so the default GITHUB_TOKEN is
-      # enough (no PAT needed); main is still protected separately.
+      # action's git push fails 403 — see PR #980 comment 4699425518.
+      # id-token: write is no longer needed for git auth (we pass an explicit
+      # github_token below) but is left in place as a harmless no-op.
       contents: write
       pull-requests: write
       issues: read
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
+      # Mint a short-lived token for our own repo-installed GitHub App so that
+      # commits Claude pushes to the PR branch are attributed to a TRUSTED
+      # installed app (e.g. fiestaboard-ci-bot[bot]) rather than the external
+      # claude[bot] identity. On this PUBLIC repo, pushes by claude[bot] are
+      # treated as first-time/external contributions and GitHub parks the
+      # resulting CI in "action_required" (the "Approve workflows" button) on
+      # every push. Pushing under the installed app skips that gate so CI runs
+      # automatically — while random PR contributors stay gated. (Note: the
+      # default GITHUB_TOKEN can't be used instead — its pushes don't trigger
+      # pull_request/push workflows at all.)
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.CLAUDE_BOT_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_BOT_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
+          # Persisted so the subsequent git push uses the app identity.
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # Use the app token for all git/API operations. This also bypasses
+          # the action's default OIDC→claude[bot] exchange, which is what
+          # otherwise triggers the per-push approval gate (see step above).
+          github_token: ${{ steps.app-token.outputs.token }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## Problem

When you tag `@claude` on a PR, `.github/workflows/claude.yml` pushes its fix commit as the **external `claude[bot]`** identity (the action's default OIDC exchange). On this **public** repo, GitHub treats that as a first-time/external contributor and parks the resulting CI run in `action_required` — the **"Approve workflows"** button — re-evaluated on *every* push. That blocks automatic CI and any AI-chaining (push → CI → react).

> Note: just switching to the default `GITHUB_TOKEN` is **not** a fix — its pushes don't trigger `pull_request`/`push` workflows at all, so CI would silently never run.

## Fix

Mint a short-lived token for a **repo-installed, least-privilege GitHub App** via `actions/create-github-app-token@v2`, and route it through both:
- `actions/checkout` → `token:` (so the git push uses the app identity)
- `anthropics/claude-code-action` → `github_token:` (bypasses the OIDC→`claude[bot]` exchange)

Pushes are then attributed to a **trusted installed app**, so CI runs automatically — while random PR contributors stay gated. Public-repo security posture is preserved (the app has no branch-protection bypass).

## ⚠️ Required before merge

The new token step references two secrets that **must exist before this merges**, or `@claude` breaks entirely:

- `CLAUDE_BOT_APP_ID`
- `CLAUDE_BOT_APP_PRIVATE_KEY`

Create a GitHub App on the `Fiestaboard` org with **Contents: RW, Pull requests: RW, Issues: RO, Actions: RO** (no admin / no branch-protection bypass), install it on this repo, then add the App ID + private key as the secrets above.

## Verify

Comment `@claude make a tiny change` on a throwaway PR → the commit should be authored by the `…[bot]` app and **CI starts with no approval banner**:

```
gh api "repos/Fiestaboard/FiestaBoard/actions/runs?event=pull_request&per_page=5" \
  --jq '.workflow_runs[] | {name, status, triggering_actor: .triggering_actor.login}'
```

(should not be `action_required`). Fallback if it still gates: swap both `token:`/`github_token:` to a fine-grained PAT on the `arthurandersonbot` org member.

🤖 Generated with [Claude Code](https://claude.com/claude-code)