### PR TITLE
fix(ci): restore FiestaPi image build trigger after release-workflow rename

### DIFF
--- a/.github/workflows/build-fiestapi.yml
+++ b/.github/workflows/build-fiestapi.yml
@@ -4,7 +4,7 @@ name: 'Build: FiestaPi Image'
 # Builds the flashable FiestaPi .img.xz — a slow job (~45-60 min), so we
 # only run it when it matters:
 #
-#   1. After every app release (workflow_run on "Release and Publish") —
+#   1. After every app release (workflow_run on "Release: Publish Image") —
 #      the image is attached to that release's assets automatically.
 #
 #   2. On major-version tags (v5.0.0, v6.0.0, …) — fallback/manual path
@@ -18,7 +18,11 @@ name: 'Build: FiestaPi Image'
 
 on:
   workflow_run:
-    workflows: ["Release and Publish"]
+    # Must exactly match the `name:` of the release workflow (release.yml).
+    # Renamed from "Release and Publish" to "Release: Publish Image" in the
+    # 2026-06-14 Actions-sidebar cleanup; this reference must track that name
+    # or the per-release image build silently never fires.
+    workflows: ["Release: Publish Image"]
     types: [completed]
   push:
     tags:


### PR DESCRIPTION
## Summary

Raspberry Pi image downloads (the `FiestaPi-*.img.xz` release assets) stopped appearing on most release pages. A Discord user reported they couldn't download an image to flash their spare Pi. **Root cause: a broken cross-workflow trigger, not a failing build.**

The 2026-06-14 "Actions sidebar cleanup" (`docs/superpowers/specs/2026-06-14-actions-sidebar-cleanup-design.md`) renamed `release.yml`'s display name:

| File | Old `name:` | New `name:` |
| --- | --- | --- |
| `release.yml` | `Release and Publish` | `Release: Publish Image` |

But `build-fiestapi.yml` triggers off that workflow via `workflow_run`, which matches by the workflow **`name:`** field:

```yaml
on:
  workflow_run:
    workflows: ["Release and Publish"]   # ← old name, no longer exists
```

No workflow is named "Release and Publish" anymore, so the per-release image build **silently never fires**. The cleanup's risk analysis covered required-check job names, external links, and run history — but missed that `workflow_run.workflows` is a name-matched consumer of the renamed workflow.

## Evidence

- **12** successful `Release: Publish Image` runs between Jun 17–21 → **0** triggered FiestaPi builds (`gh run list --workflow build-fiestapi.yml` shows no `workflow_run` events after Jun 14).
- Releases **7.8.2 → 7.10.0** have **no `.img.xz` asset at all**.
- The only recent image (`FiestaPi-2026-W26-arm64.img.xz` on 7.10.1) came from the **weekly cron**, which only attaches to whichever release is latest when it runs — so most release pages are empty.

## Fix

Point the trigger at the current workflow name and add a comment so a future rename keeps this reference in sync:

```yaml
on:
  workflow_run:
    workflows: ["Release: Publish Image"]
    types: [completed]
```

Verified the string now exactly matches `release.yml`'s `name:`. This is the only `workflow_run` reference in the repo, so no other triggers are affected.

## After merge

- The next release will fire the image build and attach `FiestaPi-<version>-arm64.img.xz` automatically.
- The back-catalog releases (7.8.2–7.10.0) will remain asset-less. To backfill any of them, run `build-fiestapi.yml` via `workflow_dispatch` on `main`, or push a `vN.0.0` tag — both resolve to the latest published release. (Out of scope for this PR; happy to follow up.)

### Suggested follow-up (not in this PR)
Add a tiny CI guard that asserts every `workflow_run.workflows:` entry matches an existing workflow `name:`, so this class of rename-drift fails loudly instead of silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)