### PR TITLE
fix(scheduler): use configured timezone for schedule rotations (#1273)

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -3979,6 +3979,7 @@ async def update_general_config(request: dict):
     general_config = config_manager.get_general()
 
     # Update with provided values
+    timezone_changed = "timezone" in request and request["timezone"] != general_config.get("timezone")
     if "timezone" in request:
         general_config["timezone"] = request["timezone"]
     if "refresh_interval_seconds" in request:
@@ -3999,6 +4000,14 @@ async def update_general_config(request: dict):
 
     if not success:
         raise HTTPException(status_code=500, detail="Failed to update general configuration")
+
+    # The scheduler resolves "now" via the cached TimeService singleton, which
+    # reads Config.GENERAL_TIMEZONE only once at creation. Without rebuilding it
+    # here, a timezone change would update the Date/Time plugin (it re-reads
+    # config every render) but leave schedule rotations firing in the stale
+    # timezone (defaulting to Pacific), so they'd run hours off (issue #1273).
+    if timezone_changed:
+        reset_time_service()
 
     return {"status": "success", "general": general_config}
 

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -653,6 +653,48 @@ class TestUpdateGeneralConfig:
         response = client.put("/config/general", json={"timezone": "X"})
         assert response.status_code == 500
 
+    def test_update_timezone_resets_cached_time_service(self, client, mock_config_manager):
+        """Changing the timezone must rebuild the cached TimeService (issue #1273).
+
+        The Date/Time plugin reads Config.GENERAL_TIMEZONE fresh on every render,
+        so it reflects a timezone change immediately. The scheduler, however, asks
+        the cached TimeService singleton for "now". If the PUT does not reset that
+        singleton, the scheduler keeps firing rotations in the *stale* timezone
+        (defaulting to America/Los_Angeles / Pacific) even though the UI and the
+        Date/Time plugin show the newly configured zone (e.g. America/Chicago).
+
+        This asserts the endpoint rewires the cached TimeService so the scheduler
+        and plugins share one timezone source of truth.
+        """
+        from src import time_service as ts_module
+
+        # Simulate a server that booted before the user configured a timezone:
+        # the cached singleton is anchored to Pacific time.
+        ts_module.reset_time_service()
+        with patch("src.time_service._get_configured_timezone", return_value="America/Los_Angeles"):
+            stale = ts_module.get_time_service()
+        assert stale.default_timezone == "America/Los_Angeles"
+
+        # Before the PUT, the stored config still reports the old timezone
+        # (this is what the endpoint compares against to detect a change).
+        mock_config_manager.get_general.return_value = {
+            "timezone": "America/Los_Angeles",
+            "refresh_interval_seconds": 60,
+        }
+        # User sets America/Chicago in the UI. After the save + reset, the
+        # rebuilt TimeService reads the new configured zone (mirrors how the
+        # Date/Time plugin reads Config.GENERAL_TIMEZONE fresh each render).
+        with patch("src.time_service._get_configured_timezone", return_value="America/Chicago"):
+            response = client.put("/config/general", json={"timezone": "America/Chicago"})
+            assert response.status_code == 200
+
+            # The scheduler resolves "now" via get_time_service(); it must now use
+            # the configured Central time, not the stale Pacific default.
+            current = ts_module.get_time_service()
+            assert current.default_timezone == "America/Chicago"
+
+        ts_module.reset_time_service()
+
 
 class TestBoardScan:
     """Tests for POST /config/board/scan."""


### PR DESCRIPTION
Closes #1273

## Reproduction

A user set the schedule timezone to `America/Chicago` (Central). The Date/Time plugin rendered the correct Central wall-clock time, but schedule rotations fired ~2 hours late — as if the scheduler were on `America/Los_Angeles` (Pacific). A rotation that should start at 8a started at 10a and ended at noon instead of 10a.

## Root cause

The scheduler and the Date/Time plugin resolve "now" from two different timezone sources:

- **Date/Time plugin** reads `Config.GENERAL_TIMEZONE` *fresh on every render* (`Config` re-reads `config.json` on each access), so it reflects a timezone change immediately.
- **Scheduler** computes "now" via `get_time_service()`, a **cached singleton**. `get_time_service()` reads `Config.GENERAL_TIMEZONE` exactly once, at first creation, and bakes it into `TimeService.default_timezone`. The `TimeService` constructor default is `America/Los_Angeles` (Pacific).

`PUT /config/general` — the endpoint the UI calls when the user saves their timezone — persisted the new timezone but **never reset the cached `TimeService`**. So after a timezone change, the plugin showed Central while the scheduler kept evaluating schedules in the stale Pacific zone. The only existing `reset_time_service()` call was in the post-upgrade restore path, not the normal save path.

This is exactly the Central→Pacific 2-hour offset in the report.

## Fix

In `update_general_config()` (`src/api_server.py`), detect when the timezone actually changes and call `reset_time_service()` after a successful save, so the next scheduler tick rebuilds `TimeService` with the configured zone. This makes the scheduler and the plugins share one timezone source of truth, mirroring the existing `reset_time_service()` call in the restore path.

No stored-format change, so no schema migration is needed.

## Tests

- Added regression test `TestUpdateGeneralConfig::test_update_timezone_resets_cached_time_service` in `tests/test_api_coverage.py`. It seeds a cached `TimeService` anchored to Pacific (simulating a server that booted before the timezone was configured), changes the timezone to `America/Chicago` via `PUT /config/general`, and asserts the singleton now reports Central. Confirmed it **fails** without the fix and **passes** with it.
- Full relevant suites pass in the dev container: `test_time_service.py`, all `test_schedules_*`, `test_schedule_board_id_bug.py`, `test_api_coverage.py`, `test_api_extended.py`, `test_silence_schedule_endpoint.py`, `test_post_upgrade_restore.py` (484 tests, 0 failures). `ruff check` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)