### PR TITLE
ci(claude-review): allow fiestaboard-ci-bot in review allowlists

### DIFF
--- a/.github/workflows/claude-a11y-audit-review.yml
+++ b/.github/workflows/claude-a11y-audit-review.yml
@@ -75,7 +75,9 @@ jobs:
           # feedback-capture allowlists both bots.
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Bot-authored PRs (triage worker) need reviewing too — the point.
-          allowed_bots: 'claude,github-actions'
+          # fiestaboard-ci-bot is the App identity that pushes branch updates,
+          # so synchronize events it fires must clear the anti-bot guard.
+          allowed_bots: 'claude,github-actions,fiestaboard-ci-bot'
           show_full_output: 'true'
           claude_args: >-
             --model claude-sonnet-4-6

--- a/.github/workflows/claude-docs-review.yml
+++ b/.github/workflows/claude-docs-review.yml
@@ -93,8 +93,10 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Bot-authored PRs (docs-audit cron, issue-triage worker) need
           # to be reviewed too — that's the whole point. Without this the
-          # action's anti-bot guard short-circuits the run.
-          allowed_bots: 'claude,github-actions'
+          # action's anti-bot guard short-circuits the run. fiestaboard-ci-bot
+          # is the App identity that pushes branch updates, so the synchronize
+          # events it fires must also clear the guard.
+          allowed_bots: 'claude,github-actions,fiestaboard-ci-bot'
           # Surface the SDK transcript so silent permission denials don't
           # look like a clean success.
           show_full_output: 'true'


### PR DESCRIPTION
## Problem

The **Claude A11y Auto-Review** and **Claude Docs Auto-Review** workflows run on `pull_request_target` and abort via `claude-code-action`'s anti-bot guard when the triggering actor is `fiestaboard-ci-bot` — the GitHub App identity that pushes branch updates. The resulting `synchronize` events leave both review checks red on otherwise-green PRs (e.g. #1288), even though reviewing bot-driven PRs is these workflows' explicit, documented intent.

```
Workflow initiated by non-human actor: fiestaboard-ci-bot (type: Bot).
Add bot to allowed_bots list or use '*' to allow all bots.
```

The action exits before Claude reads the diff, so there are no real code/lint/test/a11y findings — purely a config gate.

## Fix

Add `fiestaboard-ci-bot` to `allowed_bots` in both review workflows:
- `.github/workflows/claude-a11y-audit-review.yml`
- `.github/workflows/claude-docs-review.yml`

The `issues`-triggered `claude-issue-triage.yml` keeps its narrower `'claude'` allowlist — that's a separate triage-policy decision and is not part of any PR's checks.

> Note: because these are `pull_request_target` workflows, the fix only takes effect once it lands on the base branch (`main`). Affected PRs need a fresh `synchronize` event (rebase/push) to re-run against the updated definition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)