### PR TITLE
docs: fix MD038 trailing space blocking merge queue (unblocks #1271)

### DIFF
--- a/docs/setup/RELEASE_CHECKLIST.md
+++ b/docs/setup/RELEASE_CHECKLIST.md
@@ -33,7 +33,7 @@ git grep -E 'api_key|password|secret|token' -- '*.py' '*.ts' '*.tsx' '*.json' '*
 git grep -E 'api_key|password|secret|token' -- '*.md' | grep -v -E 'your_|your-|<[^>]+>|example|placeholder|`[a-z_]+`|\$\{' || true
 ```
 
-> **What to look for:** lines containing long hex or base64 strings, keys starting with `sk-`, `Bearer ` followed by a real-looking value, or any string that looks like a real credential rather than a placeholder. Hits on words like "your API key" or "token configuration" are expected and can be ignored.
+> **What to look for:** lines containing long hex or base64 strings, keys starting with `sk-`, `Bearer` followed by a real-looking value, or any string that looks like a real credential rather than a placeholder. Hits on words like "your API key" or "token configuration" are expected and can be ignored.
 
 - [ ] No real credential values appear in documentation files.
 - [ ] Docs and examples use placeholders like `your_api_key_here`, `your-weather-api-key`, etc.


### PR DESCRIPTION
## Problem

PR #1271 (and any PR touching `.github/workflows/ci.yml` / `integration-tests.yml` or markdown) **keeps failing the merge queue** on the `Lint Markdown` job, even though its own PR-branch checks pass.

## Root cause

`docs/setup/RELEASE_CHECKLIST.md:36` contains a code span with a trailing space inside the backticks — `` `Bearer ` `` — which trips **markdownlint MD038 (no-space-in-code)**. It was introduced in #1264 (commit `4c2a1362`) and has been sitting on `main` ever since.

Why it only bites in the merge queue:

- The repo-wide `Lint Markdown` job runs only when the `markdown` **or** `shared` path filter matches (`ci.yml:1066`).
- `shared` includes `.github/workflows/ci.yml` and `integration-tests.yml` (`ci.yml:76-80`).
- Most PRs touch neither, so the job is **skipped** and the latent error never surfaces.
- #1271 (Dependabot GitHub-Actions bump) modifies `ci.yml` → `shared == true` → the job runs in the merge queue against current `main`, lints **all** markdown, and fails.
- #1271's own branch checks passed because they ran against a **stale base** from before #1264 landed.

## Fix

Remove the trailing space: `` `Bearer ` `` → `` `Bearer` ``. Reads identically ("`Bearer` followed by a real-looking value").

Verified with the repo's own config:

```
$ npx markdownlint-cli2 ...
Linting: 85 file(s)
Summary: 0 error(s)
```

Once this lands on `main`, #1271 will pass the merge queue on its next attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)