### PR TITLE
docs: fix MD038 in RELEASE_CHECKLIST blocking the merge queue

### DIFF
--- a/docs/setup/RELEASE_CHECKLIST.md
+++ b/docs/setup/RELEASE_CHECKLIST.md
@@ -33,7 +33,7 @@ git grep -E 'api_key|password|secret|token' -- '*.py' '*.ts' '*.tsx' '*.json' '*
 git grep -E 'api_key|password|secret|token' -- '*.md' | grep -v -E 'your_|your-|<[^>]+>|example|placeholder|`[a-z_]+`|\$\{' || true
 ```
 
-> **What to look for:** lines containing long hex or base64 strings, keys starting with `sk-`, `Bearer ` followed by a real-looking value, or any string that looks like a real credential rather than a placeholder. Hits on words like "your API key" or "token configuration" are expected and can be ignored.
+> **What to look for:** lines containing long hex or base64 strings, keys starting with `sk-`, `Bearer` followed by a real-looking value, or any string that looks like a real credential rather than a placeholder. Hits on words like "your API key" or "token configuration" are expected and can be ignored.
 
 - [ ] No real credential values appear in documentation files.
 - [ ] Docs and examples use placeholders like `your_api_key_here`, `your-weather-api-key`, etc.


### PR DESCRIPTION
## What

Removes a trailing space inside the `` `Bearer ` `` code span on line 36 of `docs/setup/RELEASE_CHECKLIST.md`, which violated markdownlint `MD038/no-space-in-code`.

## Why

The **Lint Markdown** CI job lints *all* repository markdown. This pre-existing error (introduced in #1264, merged 06-25) wasn't caught on that PR's own CI run, but it fails for **every PR that enters the merge queue** — the queue rebuilds the branch on top of latest `main` and runs the full lint suite, so the broken file on `main` backs the PR out.

That's why #1271 kept getting backed out despite rebasing: the failure was never in #1271's changes (a GitHub Actions deps bump) — it was this file on `main`. Any PR was going to hit it.

```
docs/setup/RELEASE_CHECKLIST.md:36:103 MD038/no-space-in-code Spaces inside code span elements [Context: "`***"]
```

The surrounding prose already reads "followed by a real-looking value", so the trailing space inside the backticks was redundant.

## Verification

`markdownlint-cli2` with the repo config (`.markdownlint-cli2.jsonc`): **0 errors** across all 85 linted files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)