### PR TITLE
fix(note-arrays): size send paths to real dimensions + harden tests [gate for #1185]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,17 @@ jobs:
         pytest -m integration tests/test_plugin_install_integration.py -v
       env:
         BOARD_READ_WRITE_KEY: test_key
-    
+
+    - name: Run note-array Cloud mock contract tests
+      run: |
+        # The mock-cloud Cloud API contract suite lives under integration-tests/,
+        # which is excluded from [tool.pytest.ini_options] testpaths, so the main
+        # test step above never collects it. It is stdlib-only and self-hosts its
+        # mock HTTP servers (no Docker needed), so it can run directly on the host.
+        pytest integration-tests/ -v
+      env:
+        BOARD_READ_WRITE_KEY: test_key
+
     - name: Upload platform coverage
       uses: codecov/codecov-action@v7
       with:

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -36,7 +36,7 @@ from .collections.models import CollectionCreate, CollectionUpdate, is_collectio
 from .collections.service import get_collection_service  # noqa: E402
 from .config import Config  # noqa: E402
 from .config_manager import get_config_manager  # noqa: E402
-from .devices import classify_dimensions, get_dimensions, resolve_dimensions  # noqa: E402
+from .devices import classify_dimensions, resolve_dimensions  # noqa: E402
 from .displays.service import get_display_service, reset_display_service  # noqa: E402
 from .main import DisplayService  # noqa: E402
 from .network.wifi import WiFiError, get_wifi_service  # noqa: E402
@@ -3159,10 +3159,22 @@ async def send_message(request: MessageRequest):
         raise HTTPException(status_code=503, detail="Board client not initialized")
 
     try:
-        # Convert text to board array for proper character/color support
-        board_array = text_to_board_array(request.text)
         settings_service = get_settings_service()
         transition = settings_service.get_transition_settings()
+        # Size the grid to the active (first) board so a manual send to a note
+        # array uses its real geometry instead of a default flagship 22×6.
+        board_settings = settings_service.get_board_settings()
+        device_type = "flagship"
+        notes_wide = 1
+        notes_tall = 1
+        if board_settings.boards:
+            primary_board = board_settings.boards[0]
+            device_type = primary_board.get("device_type", "flagship")
+            notes_wide = primary_board.get("notes_wide", 1)
+            notes_tall = primary_board.get("notes_tall", 1)
+        dims = resolve_dimensions(device_type, notes_wide, notes_tall)
+        # Convert text to board array for proper character/color support
+        board_array = text_to_board_array(request.text, rows=dims.rows, cols=dims.cols)
 
         success, was_sent = service.vb_client.send_characters(
             board_array,
@@ -4376,12 +4388,18 @@ async def send_display(display_type: str, target: str | None = None):
             paused = True
         else:
             transition = settings_service.get_transition_settings()
-            # Use first board's device type for dimensions (flagship vs note)
+            # Size to the first board's device type/dimensions (flagship, note,
+            # or a note array's notes_wide×notes_tall geometry).
             board_settings = settings_service.get_board_settings()
             device_type = "flagship"
+            notes_wide = 1
+            notes_tall = 1
             if board_settings.boards:
-                device_type = board_settings.boards[0].get("device_type", "flagship")
-            dims = get_dimensions(device_type)
+                primary_board = board_settings.boards[0]
+                device_type = primary_board.get("device_type", "flagship")
+                notes_wide = primary_board.get("notes_wide", 1)
+                notes_tall = primary_board.get("notes_tall", 1)
+            dims = resolve_dimensions(device_type, notes_wide, notes_tall)
             board_array = text_to_board_array(result.formatted, rows=dims.rows, cols=dims.cols)
             success, was_sent = service.vb_client.send_characters(
                 board_array,
@@ -5347,7 +5365,7 @@ async def set_active_page(request: dict):
                     page.transition_step_size if page.transition_step_size is not None else system_transition.step_size
                 )
 
-                dims = get_dimensions(page.device_type)
+                dims = resolve_dimensions(page.device_type, page.notes_wide, page.notes_tall)
                 board_array = text_to_board_array(result.formatted, rows=dims.rows, cols=dims.cols)
                 success, was_sent = service.vb_client.send_characters(
                     board_array, strategy=strategy, step_interval_ms=interval_ms, step_size=step_size
@@ -6784,7 +6802,7 @@ async def send_page(page_id: str, target: str | None = None):
             )
 
             # Convert to board array with dimensions for page's device type (flagship vs note)
-            dims = get_dimensions(page.device_type)
+            dims = resolve_dimensions(page.device_type, page.notes_wide, page.notes_tall)
             board_array = text_to_board_array(result.formatted, rows=dims.rows, cols=dims.cols)
             success, was_sent = service.vb_client.send_characters(
                 board_array, strategy=strategy, step_interval_ms=interval_ms, step_size=step_size
@@ -7416,7 +7434,11 @@ async def render_template_live(request: dict):
             client = board_client_from_board_dict(target_board)
             if client:
                 device_type = target_board.get("device_type", "flagship")
-                dims = get_dimensions(device_type)
+                dims = resolve_dimensions(
+                    device_type,
+                    target_board.get("notes_wide", 1),
+                    target_board.get("notes_tall", 1),
+                )
                 board_array = text_to_board_array(rendered, rows=dims.rows, cols=dims.cols)
 
                 transition_settings = settings_service.get_transition_settings()

--- a/src/devices.py
+++ b/src/devices.py
@@ -131,7 +131,7 @@ class BoardInstance:
             port=port if port is not None else 7000,
             local_api_key=data.get("local_api_key", ""),
             cloud_key=data.get("cloud_key", ""),
-            note_array_token=data.get("note_array_token", "").strip(),
+            note_array_token=(data.get("note_array_token") or "").strip(),
             notes_wide=data.get("notes_wide", 1),
             notes_tall=data.get("notes_tall", 1),
         )

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -877,7 +877,7 @@ class TestSetActivePage:
         """Setting an active page also sends to board when enabled."""
         mock_settings_service.should_send_to_board.return_value = True
         with (
-            patch("src.api_server.get_dimensions") as mock_dims,
+            patch("src.api_server.resolve_dimensions") as mock_dims,
             patch("src.api_server.text_to_board_array") as mock_ttba,
         ):
             mock_dims.return_value = Mock(rows=6, cols=22)
@@ -913,7 +913,7 @@ class TestSetActivePage:
         mock_settings_service.should_send_to_board.return_value = True
         mock_service.vb_client.send_characters.return_value = (False, False)
         with (
-            patch("src.api_server.get_dimensions") as mock_dims,
+            patch("src.api_server.resolve_dimensions") as mock_dims,
             patch("src.api_server.text_to_board_array") as mock_ttba,
         ):
             mock_dims.return_value = Mock(rows=6, cols=22)
@@ -1069,7 +1069,7 @@ class TestSendDisplay:
         with (
             patch("src.api_server.get_display_service") as mock_ds,
             patch("src.api_server.text_to_board_array") as mock_ttba,
-            patch("src.api_server.get_dimensions") as mock_dims,
+            patch("src.api_server.resolve_dimensions") as mock_dims,
         ):
             display_service = Mock()
             result = Mock()
@@ -1093,7 +1093,7 @@ class TestSendDisplay:
         with (
             patch("src.api_server.get_display_service") as mock_ds,
             patch("src.api_server.text_to_board_array") as mock_ttba,
-            patch("src.api_server.get_dimensions") as mock_dims,
+            patch("src.api_server.resolve_dimensions") as mock_dims,
         ):
             display_service = Mock()
             result = Mock()
@@ -1173,7 +1173,7 @@ class TestSendPage:
         mock_settings_service.should_send_to_board.return_value = True
         with (
             patch("src.api_server.Config") as mock_config,
-            patch("src.api_server.get_dimensions") as mock_dims,
+            patch("src.api_server.resolve_dimensions") as mock_dims,
             patch("src.api_server.text_to_board_array") as mock_ttba,
         ):
             mock_config.is_silence_mode_active.return_value = False
@@ -1199,7 +1199,7 @@ class TestSendPage:
         mock_service.vb_client.send_characters.return_value = (False, False)
         with (
             patch("src.api_server.Config") as mock_config,
-            patch("src.api_server.get_dimensions") as mock_dims,
+            patch("src.api_server.resolve_dimensions") as mock_dims,
             patch("src.api_server.text_to_board_array") as mock_ttba,
         ):
             mock_config.is_silence_mode_active.return_value = False
@@ -1217,7 +1217,7 @@ class TestSendPage:
         """Explicit target=board sends to board."""
         with (
             patch("src.api_server.Config") as mock_config,
-            patch("src.api_server.get_dimensions") as mock_dims,
+            patch("src.api_server.resolve_dimensions") as mock_dims,
             patch("src.api_server.text_to_board_array") as mock_ttba,
         ):
             mock_config.is_silence_mode_active.return_value = False

--- a/tests/test_api_extended.py
+++ b/tests/test_api_extended.py
@@ -921,6 +921,45 @@ class TestTemplateEndpoints:
         assert "rendered" in data
         assert "sent_to_board" in data
 
+    def test_render_template_live_note_array_sizes_to_real_dimensions(
+        self, client, mock_template_engine, mock_settings_service
+    ):
+        """Regression (note arrays): a live send to a note-array board must size to
+        the array's real geometry (4 side-by-side → 3×60), not crash with HTTP 500.
+
+        The send path previously called get_dimensions(), which only knows flagship
+        and note and raises ValueError on "note_array" → 500. resolve_dimensions is
+        deliberately NOT mocked here so the real note-array geometry runs; only the
+        network send is stubbed, and we assert the grid that reaches the board is the
+        true 3×60 size.
+        """
+        na_board = {
+            "id": "na1",
+            "device_type": "note_array",
+            "notes_wide": 4,
+            "notes_tall": 1,
+            "note_array_token": "tok",
+            "paused": False,
+        }
+        board_settings = Mock()
+        board_settings.boards = [na_board]
+        mock_settings_service.get_board_settings.return_value = board_settings
+
+        with patch("src.api_server.board_client_from_board_dict") as mock_bcfbd:
+            mock_client = Mock()
+            mock_client.send_characters.return_value = (True, True)
+            mock_bcfbd.return_value = mock_client
+            response = client.post(
+                "/templates/render/live",
+                json={"template": "HELLO", "board_id": "na1"},
+            )
+
+        assert response.status_code == 200, response.text
+        assert response.json()["sent_to_board"] is True
+        sent_grid = mock_client.send_characters.call_args.args[0]
+        assert len(sent_grid) == 3, f"expected 3 rows for 4-wide note array, got {len(sent_grid)}"
+        assert all(len(row) == 60 for row in sent_grid), "expected 60 cols (4 notes × 15) per row"
+
     def test_render_template_live_empty(self, client, mock_template_engine, mock_settings_service):
         response = client.post("/templates/render/live", json={"template": ""})
         assert response.status_code == 200

--- a/tests/test_board_client.py
+++ b/tests/test_board_client.py
@@ -793,7 +793,12 @@ class TestSendCharactersNoResponseOnError:
 # Issue #1168 — Note-array Cloud API send/read in BoardClient
 # ---------------------------------------------------------------------------
 
-CLOUD_NOTE_ARRAY_URL = "https://cloud.vestaboard.com/"
+# Hermetic: track the note-array Cloud URL the client is ACTUALLY configured to
+# use. BoardClient.CLOUD_NOTE_ARRAY_API_URL honors VESTABOARD_CLOUD_API_URL, so
+# these URL assertions pass both in CI (env unset → real cloud.vestaboard.com)
+# and inside the dev container (env set → the mock-cloud service), instead of
+# failing whenever the suite runs in the documented `docker exec … pytest` flow.
+CLOUD_NOTE_ARRAY_URL = BoardClient.CLOUD_NOTE_ARRAY_API_URL
 RW_CLOUD_URL = "https://rw.vestaboard.com/"
 
 

--- a/web/src/components/board-size-indicator.tsx
+++ b/web/src/components/board-size-indicator.tsx
@@ -12,17 +12,23 @@ interface BoardSizeIndicatorProps {
   className?: string;
 }
 
-function resolvePresetLabel(notesWide: number, notesTall: number): string | null {
+function resolvePresetId(notesWide: number, notesTall: number): string | null {
   const match = NOTE_ARRAY_PRESETS.find((p) => p.notes_wide === notesWide && p.notes_tall === notesTall);
-  return match ? match.label : null;
+  return match ? match.id : null;
 }
 
 export function BoardSizeIndicator({ deviceType, notesWide = 1, notesTall = 1, className }: BoardSizeIndicatorProps) {
   const t = useTranslations("boardSizeIndicator");
+  // Preset names are localized under the displaySettings namespace so the
+  // indicator shows the SAME translated label as the Settings board-type
+  // selector — not the raw English label baked into board-dimensions.ts (which
+  // previously leaked into both the visible text and the aria-label).
+  const tSettings = useTranslations("displaySettings");
   const { rows, cols } = resolveDimensions(deviceType, notesWide, notesTall);
   const noteArray = isNoteArray(deviceType);
-  // Single fallback point: a matched preset's label, else "Custom".
-  const presetLabel = noteArray ? (resolvePresetLabel(notesWide, notesTall) ?? t("custom")) : null;
+  // Single fallback point: a matched preset's localized label, else "Custom".
+  const presetId = noteArray ? resolvePresetId(notesWide, notesTall) : null;
+  const presetLabel = noteArray ? (presetId ? tSettings(`presets.${presetId}`) : t("custom")) : null;
 
   // aria-label explicitly names each dimension (rows/columns), so screen-reader
   // users get an unambiguous reading regardless of the visual order below.

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -504,8 +504,12 @@ export interface BoardInstance {
   // Per-board pause flag (issue #970). When true FiestaBoard does not
   // push anything to this board from any code path until it is resumed.
   paused?: boolean;
+  /** Per-board schedule mode (issue #1242). Emitted on every GET /settings/board. */
+  schedule_enabled?: boolean;
   api_mode: "local" | "cloud";
   host: string;
+  /** Local API port (default 7000). */
+  port?: number;
   local_api_key: string;
   cloud_key: string;
   /** X-Vestaboard-Token for a Note array (note_array only). Masked as "***" on read. */


### PR DESCRIPTION
## Why this PR

This is the **human-in-the-loop gate** for #1185 (Note Arrays). It targets `next`, so merging it updates #1185. Goal: when this merges, #1185 is actually **100% correct for arrays + multi-board**, with tests you can trust.

I rebuilt the `next` (`04c4f08b`) dev stack from scratch (with the new mock Cloud board on `:19200`) and verified the feature at runtime — not just by reading tests. That surfaced a **ship-blocker** the existing tests hid.

## 🔴 Blocker fixed: note-array boards 500 on every send path

`get_dimensions()` only knows `flagship`/`note` and **raises `ValueError` on `note_array`**. Five send paths called it. Reproduced live:

```
POST /templates/render/live  (note-array board)  ->  HTTP 500
  File "src/api_server.py", line 7419, in render_template_live
    dims = get_dimensions(device_type)
  ValueError: Unknown device type: note_array. ... use resolve_dimensions().
```

A user **cannot send to a note-array board** via the live editor, `/pages/{id}/send`, `/settings/active-page`, or `/displays/{type}/send`. The send-endpoint tests `patch("…get_dimensions")` and hardcode `rows=6, cols=22`, so they could never catch it.

**Fix:** all five send sites use `resolve_dimensions(device_type, notes_wide, notes_tall)`. After the fix the same live send returns **200** and lands a **3×60** grid on the mock.

## What's in this PR (all verified green)

| Change | File |
|---|---|
| 5 send paths size to real note-array dims (was 500) | `src/api_server.py` |
| Guard `from_dict` against a JSON-`null` `note_array_token` (`None.strip()` crash) | `src/devices.py` |
| **New** regression test: live send to note-array board, resolver NOT mocked, asserts 3×60 grid | `tests/test_api_extended.py` |
| Repoint 7 send tests `get_dimensions`→`resolve_dimensions` | `tests/test_api_coverage.py` |
| Make 2 note-array Cloud-URL tests **hermetic** (pass in `docker exec … pytest`, not only CI) | `tests/test_board_client.py` |
| Run the `integration-tests/` mock-cloud contract suite in CI (was never collected) | `.github/workflows/ci.yml` |
| **i18n:** localize size-indicator preset labels (English leaked into visible text **and** aria-label in 13 locales) | `web/src/components/board-size-indicator.tsx` |
| **Type contract:** add `schedule_enabled` + `port` to `BoardInstance` (server emits them; TS type was incomplete) | `web/src/lib/api.ts` |

**Results:** Python `4102 passed / 11 skipped` (was `4099 + 2 failing`), integration `25 passed`, web vitest `1166 passed`, prettier/eslint clean.

## Verification performed against the live `next` build

- **Cloud transport (14/14, real BoardClient → real mock):** URL + `X-Vestaboard-Token`, body exactly `{"characters": grid}` with transitions stripped, 3×60 lands, `read` round-trips, **15s throttle** blocks then allows, **per-board token isolation** holds.
- **Auto-detect (13/13):** every preset + custom 8×8 + flagship + note classify correctly; 404/422 paths; token masked.
- **Web E2E (78 passed):** note-arrays regression, note-pages, multi-board, multi-board-schedule (incl. `board_id` filtering + board-switch isolation), setup wizard, device-mismatch.
- **Pages schema migration** v3→v4: correct, idempotent, no data loss.
- **TS↔Python contract** (full sweep): in sync except the two `BoardInstance` fields fixed here.
- **i18n parity:** all 14 locales carry every note-array key (no missing/orphan); the one real leak is fixed here.

## ✅ Investigated and cleared (were flagged, verified NOT bugs)

- **Settings migration "drops `schedule.enabled`":** not a bug. `is_schedule_enabled()` falls back to the global mirror when there are **no** boards, and the migration stamps per-board `schedule_enabled` when boards exist (and never deletes the global value). No upgrade data loss.
- **"Re-POSTing boards drops `schedule_enabled`/`port`":** not data loss. The Settings UI spreads the received board object (`{...b, ...updates}`), so runtime fields survive even though the TS type omitted them (now added for honesty).

## ⚠️ Still your call (out of scope / not arrays-correctness)

1. **Multi-board driving is primary-only (confirm intended).** The polling loop drives only the first board (`src/main.py:733`) and the dashboard preview ignores the sidebar selection (`active-page-display.tsx`); also `PUT /settings/active-page` is primary-board-scoped (no `board_id`). Looks like later per-board-epic scope, not claimed-broken here.
2. **Unpinned ruff (`ruff>=0.9.0`) → nondeterministic CI format-check.** ruff 0.15 reformats **64 src/ files** of pre-existing code. Can fail `ruff format --check` for any new PR to `next`. Recommend pinning ruff + a one-time reformat (separate PR).
3. **detect-size "unclassifiable" 422 branch is dead** — the read layer pre-filters odd grids to `None`, so users get a misleading "blank or unreachable" message for an unsupported size.
4. **Lower-priority test-quality gaps** (finders, not all verified): `scaled-board-display` fit-mode scaling untested; seam *gap* not asserted; `page-grid-selector` renders note-array thumbnails at 1×1; plugin note-array cache tests assert only `fetch_count`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
