### PR TITLE
feat(bug-hunt): proactive bug-hunting feedback loop (multi-lens + dual learning)

### DIFF
--- a/.github/bug-hunt-state.json
+++ b/.github/bug-hunt-state.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "round": 0,
+  "round_started_at": null,
+  "last_run_at": null,
+  "last_learned_at": null,
+  "areas_remaining": [],
+  "areas_audited": []
+}

--- a/.github/bug-hunt/README.md
+++ b/.github/bug-hunt/README.md
@@ -1,0 +1,69 @@
+# Bug-Hunt Feedback Loop
+
+The bug-hunt cron (`.github/workflows/claude-bug-hunt.yml`) sweeps the codebase
+daily, hunting for real functional bugs with a multi-lens subagent fan-out and
+adversarial verification, then files high-trust issues (`bug`, `bug-hunt`,
+`claude-fix`). The shared triage worker turns each into a **draft** fix PR. A
+human reviews and merges. No bug fix lands without sign-off.
+
+This folder is the loop's **two memories** — one positive, one negative.
+
+## Positive memory: `pattern-memory.md`
+
+What the loop has *learned about where bugs live*. Maintained weekly by
+`.github/workflows/claude-bug-hunt-learn.yml`, which:
+
+1. Runs `gather_fixed_bugs.py` to deterministically collect merged PRs labelled
+   `bug` since the last run (with their linked issues and diffs).
+2. Feeds that to Claude, which distills generalized root-cause patterns,
+   re-ranks the bug-prone modules, and extends the per-lens checklists.
+3. Rewrites `pattern-memory.md` and advances `last_learned_at`.
+
+The hunter reads it each run to bias area selection and to seed each lens with
+the checklist of "things that have actually bitten us." **This raises recall.**
+
+## Negative memory: `rejected-edits.jsonl`
+
+What the loop has *learned not to file*. When a `bug-hunt/issue-*` fix PR is
+closed **without merging**, that's the maintainer saying "this bug report was
+wrong." `.github/workflows/claude-bug-hunt-feedback.yml` triggers on
+`pull_request_target: closed`, runs `build_rejection.py` to bundle the PR's diff
++ every comment/review into one JSONL line, and commits it here.
+
+The hunter reads it each run to (a) never re-propose the same wrong finding and
+(b) generalize the false-positive class. **This raises precision.**
+
+> Closing a bug-hunt fix PR without merging is the teaching action. Add a comment
+> explaining *why* it was wrong — the hunter treats the closer's reasoning as
+> authoritative.
+
+### `rejected-edits.jsonl` schema
+
+One JSON object per line. Primary key is `pr` (re-capture replaces the prior
+line). Fields: `pr`, `title`, `head_ref`, `closed_at`, `author`, `body`,
+`files: [{path, patch}]`, `comments`, `reviews`, `inline_comments`. See
+`build_rejection.py` for details; run it locally with `DRY_RUN=1` to preview:
+
+```bash
+DRY_RUN=1 python3 .github/bug-hunt/build_rejection.py <pr_number>
+```
+
+## Manually clearing a stale entry
+
+Both files are plain text. If a rejection was actually correct, or a learned
+pattern is stale, hand-delete the relevant line/section and commit. The next run
+picks up the change.
+
+## Scripts
+
+- `gather_fixed_bugs.py` — deterministic collector of merged bug-fix PRs for the
+  learner. `--since <ISO8601>` bounds the window. Prints JSON to stdout.
+- `build_rejection.py` — idempotent rejection-log builder for the feedback
+  workflow. Refuses to record merged PRs.
+- `tests/` — pytest for the collector's issue-link parsing.
+
+## Sweep state
+
+Sweep progress lives in `.github/bug-hunt-state.json` (not this folder, by
+convention — it's the hunter's progress, not feedback memory): `round`,
+`areas_remaining`, `areas_audited`, `last_run_at`, `last_learned_at`.

--- a/.github/bug-hunt/build_rejection.py
+++ b/.github/bug-hunt/build_rejection.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Capture why a bug-hunt fix PR was closed without merging.
+
+Run as: build_rejection.py <pr_number>
+
+Reads the PR's metadata, full diff, every comment / review / inline comment
+via `gh`, then writes one JSONL line into
+`.github/bug-hunt/rejected-edits.jsonl`. The next bug-hunt cron run loads that
+file and uses it to avoid re-filing the same wrong bug and to generalize from
+the closer's explanation.
+
+Idempotent: a re-run for the same PR replaces that PR's existing line rather
+than appending a duplicate. This lets the feedback workflow be triggered
+manually (workflow_dispatch) after a user has added a later explanatory
+comment without polluting the log.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+LOG_PATH = Path(".github/bug-hunt/rejected-edits.jsonl")
+
+
+def gh_json(*args: str):
+    out = subprocess.check_output(["gh", *args], text=True)
+    return json.loads(out)
+
+
+def gh_text(*args: str) -> str:
+    return subprocess.check_output(["gh", *args], text=True)
+
+
+def parse_diff(diff: str) -> list[dict]:
+    """Split a unified diff into per-file `{path, patch}` records."""
+    files: list[dict] = []
+    current: dict | None = None
+    for line in diff.splitlines():
+        if line.startswith("diff --git "):
+            if current is not None:
+                current["patch"] = "\n".join(current["patch"])
+                files.append(current)
+            path = line.split(" b/", 1)[-1] if " b/" in line else line
+            current = {"path": path, "patch": [line]}
+        elif current is not None:
+            current["patch"].append(line)
+    if current is not None:
+        current["patch"] = "\n".join(current["patch"])
+        files.append(current)
+    return files
+
+
+def build_record(pr: str) -> dict:
+    meta = gh_json(
+        "pr", "view", pr,
+        "--json", "number,title,headRefName,closedAt,author,body,state",
+    )
+    if meta.get("state") == "MERGED":
+        raise SystemExit(f"PR #{pr} was merged — refusing to record as rejection.")
+
+    diff = gh_text("pr", "diff", pr)
+    files = parse_diff(diff)
+
+    repo = subprocess.check_output(
+        ["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"],
+        text=True,
+    ).strip()
+
+    issue_comments = gh_json(
+        "api", f"repos/{repo}/issues/{pr}/comments",
+        "--jq", "[.[] | {author: .user.login, body: .body, created_at: .created_at}]",
+    )
+    reviews = gh_json(
+        "api", f"repos/{repo}/pulls/{pr}/reviews",
+        "--jq",
+        '[.[] | select((.body // "") != "") | '
+        '{author: .user.login, body: .body, state: .state, submitted_at: .submitted_at}]',
+    )
+    inline = gh_json(
+        "api", f"repos/{repo}/pulls/{pr}/comments",
+        "--jq",
+        "[.[] | {author: .user.login, body: .body, path: .path, "
+        "created_at: .created_at, diff_hunk: .diff_hunk}]",
+    )
+
+    return {
+        "pr": meta["number"],
+        "title": meta["title"],
+        "head_ref": meta["headRefName"],
+        "closed_at": meta["closedAt"],
+        "author": (meta.get("author") or {}).get("login"),
+        "body": meta.get("body") or "",
+        "comments": issue_comments,
+        "reviews": reviews,
+        "inline_comments": inline,
+        "files": files,
+    }
+
+
+def write_log(record: dict, path: Path = LOG_PATH) -> None:
+    """Replace any prior line for this PR; append the new one."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing: list[str] = []
+    if path.exists():
+        existing = [ln for ln in path.read_text().splitlines() if ln.strip()]
+
+    def keep(line: str) -> bool:
+        try:
+            return json.loads(line).get("pr") != record["pr"]
+        except json.JSONDecodeError:
+            return True
+
+    kept = [ln for ln in existing if keep(ln)]
+    kept.append(json.dumps(record, ensure_ascii=False, separators=(",", ":")))
+    path.write_text("\n".join(kept) + "\n")
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        sys.exit("usage: build_rejection.py <pr_number>")
+    pr = sys.argv[1]
+    record = build_record(pr)
+    if os.environ.get("DRY_RUN") == "1":
+        print(json.dumps(record, ensure_ascii=False, indent=2))
+        return
+    write_log(record)
+    print(f"Captured PR #{record['pr']} into {LOG_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/bug-hunt/gather_fixed_bugs.py
+++ b/.github/bug-hunt/gather_fixed_bugs.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Collect fixed-bug records for the bug-hunt learner.
+
+Run as: gather_fixed_bugs.py [--since <ISO8601>]
+
+Deterministically gathers, via `gh`, every CLOSED issue labelled `bug` or
+`bug-hunt` (optionally only those closed at/after `--since`), follows each
+issue's `closedByPullRequestsReferences` to the merged fix PR, and emits a
+record pairing the bug (issue title + body + labels) with the fix (PR title +
+per-file unified diff). Prints a JSON array to stdout.
+
+In this repo the `bug` label lives on issues, not PRs (PRs get
+`python`/`backend`/etc. from the auto-labeler), so the issue is the right
+anchor — and it carries the human description of the bug, which the PR diff
+alone does not.
+
+The point is to keep all data-gathering out of the model: the weekly learner
+(`.github/workflows/claude-bug-hunt-learn.yml`) runs this, then hands the JSON
+to Claude, which only does the distillation into `pattern-memory.md`.
+
+Pure helpers (`parse_linked_issues`, `parse_diff`) are unit-tested in
+`tests/test_gather_fixed_bugs.py`; the `gh`-backed paths are validated via the
+learner workflow.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+
+# `Closes #12`, `fixed #3`, `Resolve #4`, plus a trailing `(#1280)`.
+_LINK_RE = re.compile(r"(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)", re.IGNORECASE)
+_PAREN_RE = re.compile(r"\(#(\d+)\)")
+
+
+def parse_linked_issues(body: str | None) -> list[int]:
+    """Return the deduped, sorted issue numbers referenced by a PR body."""
+    if not body:
+        return []
+    nums = {int(n) for n in _LINK_RE.findall(body)}
+    nums |= {int(n) for n in _PAREN_RE.findall(body)}
+    return sorted(nums)
+
+
+def parse_diff(diff: str) -> list[dict]:
+    """Split a unified diff into per-file `{path, patch}` records."""
+    files: list[dict] = []
+    current: dict | None = None
+    for line in diff.splitlines():
+        if line.startswith("diff --git "):
+            if current is not None:
+                current["patch"] = "\n".join(current["patch"])
+                files.append(current)
+            path = line.split(" b/", 1)[-1] if " b/" in line else line
+            current = {"path": path, "patch": [line]}
+        elif current is not None:
+            current["patch"].append(line)
+    if current is not None:
+        current["patch"] = "\n".join(current["patch"])
+        files.append(current)
+    return files
+
+
+def gh_json(*args: str):
+    return json.loads(subprocess.check_output(["gh", *args], text=True))
+
+
+def gh_text(*args: str) -> str:
+    return subprocess.check_output(["gh", *args], text=True)
+
+
+FIX_LABELS = ("bug", "bug-hunt")
+
+
+def _repo_name_with_owner() -> str:
+    return subprocess.check_output(
+        ["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"],
+        text=True,
+    ).strip()
+
+
+def _closed_issue_numbers(since: str | None) -> list[int]:
+    """Deduped closed-issue numbers carrying any FIX_LABELS, newest first."""
+    seen: dict[int, None] = {}
+    for label in FIX_LABELS:
+        search = f"is:issue is:closed label:{label}"
+        if since:
+            search += f" closed:>={since[:10]}"
+        try:
+            rows = gh_json(
+                "issue", "list",
+                "--search", search,
+                "--limit", "200",
+                "--json", "number",
+            )
+        except subprocess.CalledProcessError:
+            rows = []
+        for r in rows:
+            seen.setdefault(r["number"], None)
+    return list(seen)
+
+
+def collect(since: str | None) -> list[dict]:
+    repo = _repo_name_with_owner()
+    records: list[dict] = []
+    for num in _closed_issue_numbers(since):
+        issue = gh_json(
+            "issue", "view", str(num),
+            "--json",
+            "number,title,body,closedAt,labels,closedByPullRequestsReferences",
+        )
+        # Pick the closing PR in THIS repo (ignore cross-repo references).
+        prs = [
+            ref for ref in (issue.get("closedByPullRequestsReferences") or [])
+            if f"{ref['repository']['owner']['login']}/{ref['repository']['name']}" == repo
+        ]
+        if not prs:
+            continue
+        pr_num = prs[0]["number"]
+        try:
+            diff = gh_text("pr", "diff", str(pr_num), "--patch")
+            pr_title = gh_json("pr", "view", str(pr_num), "--json", "title")["title"]
+        except subprocess.CalledProcessError:
+            diff, pr_title = "", None
+        records.append(
+            {
+                "issue": issue["number"],
+                "issue_title": issue.get("title"),
+                "issue_body": issue.get("body") or "",
+                "labels": [l["name"] for l in issue.get("labels", [])],
+                "closed_at": issue.get("closedAt"),
+                "pr": pr_num,
+                "pr_title": pr_title,
+                "files": parse_diff(diff),
+            }
+        )
+    return records
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Collect merged bug-fix PRs as JSON.")
+    ap.add_argument("--since", default=None, help="ISO8601; only PRs merged at/after this")
+    args = ap.parse_args()
+    since = args.since or None
+    if since in ("", "null", "None"):
+        since = None
+    json.dump(collect(since), sys.stdout, ensure_ascii=False, indent=2)
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/bug-hunt/pattern-memory.md
+++ b/.github/bug-hunt/pattern-memory.md
@@ -1,0 +1,60 @@
+---
+last_learned_at: null
+---
+
+# Bug-Hunt Pattern Memory
+
+This file is the **positive learning** memory for the bug-hunt loop. The weekly
+learner (`.github/workflows/claude-bug-hunt-learn.yml`) mines merged bug-fix PRs
+and distills them into the sections below. The daily hunter
+(`.github/workflows/claude-bug-hunt.yml`) reads this file at the start of every
+run to (a) bias its area selection toward bug-prone modules and (b) seed each
+lens subagent with the class-specific checklist of "things that have actually
+bitten us."
+
+Maintainers may hand-edit this file. Keep it concise — prune stale or duplicate
+patterns. It is the counterpart to `rejected-edits.jsonl` (negative learning):
+this file raises recall where bugs really live; the rejection log raises
+precision by recording false positives.
+
+> The entry below is a seed example so the hunter has a non-empty memory on day
+> one. The learner will replace and extend these as real fixes land.
+
+## Recurring root-cause patterns
+
+Generalized root causes, not one-offs. Each entry: the pattern, where it bit us,
+and what to scrutinize.
+
+- **Naive timezone handling.** Scheduling used server-local time instead of the
+  configured timezone, so rotations fired at the wrong hour for non-Pacific
+  users (issue #1273 → fix #1280). Scrutinize every `datetime.now()` without a
+  tz, every naive/aware datetime mix, and every place a user-configured timezone
+  string must be honored (schedules, carousels, countdown, page rotation).
+  Lens: backend-logic, concurrency-state.
+
+## Bug-prone modules
+
+Areas ranked by how many historical fixes have landed there. The hunter spends
+more budget on the top of this list. (Seeded; the learner re-ranks by fix count.)
+
+1. `src/schedules` — timezone/rotation correctness (#1273/#1280).
+
+## Per-lens checklists
+
+Class-specific checks the learner accumulates. Injected into each lens
+subagent's prompt.
+
+### backend-logic & edge cases
+- Datetime/timezone conversions honor the user-configured TZ, not server local.
+
+### error/exception handling
+- _(none yet)_
+
+### concurrency & shared state
+- _(none yet)_
+
+### Python↔TS API contract drift
+- _(none yet)_
+
+### security & input validation
+- _(none yet)_

--- a/.github/bug-hunt/tests/test_gather_fixed_bugs.py
+++ b/.github/bug-hunt/tests/test_gather_fixed_bugs.py
@@ -1,0 +1,47 @@
+"""Tests for the bug-hunt merged-fix collector's pure helpers.
+
+Only the network-free helpers are exercised here (`parse_linked_issues`,
+`parse_diff`). `main()` shells out to `gh` and is validated manually via the
+learner workflow.
+"""
+
+import importlib.util
+from pathlib import Path
+
+_spec = importlib.util.spec_from_file_location(
+    "gfb", Path(__file__).parent.parent / "gather_fixed_bugs.py"
+)
+gfb = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gfb)
+
+
+def test_parse_closes_fixes_resolves_and_paren():
+    body = "Closes #1273\nalso Fixes #99 and resolves #100\ntitle (#1280)"
+    assert sorted(gfb.parse_linked_issues(body)) == [99, 100, 1273, 1280]
+
+
+def test_parse_dedupes_and_ignores_non_refs():
+    assert gfb.parse_linked_issues("no refs here #notanumber") == []
+    assert gfb.parse_linked_issues("Closes #5 Closes #5") == [5]
+
+
+def test_parse_case_insensitive_and_variants():
+    assert sorted(gfb.parse_linked_issues("CLOSE #1, fixed #2, RESOLVED #3")) == [1, 2, 3]
+
+
+def test_parse_handles_empty_and_none():
+    assert gfb.parse_linked_issues("") == []
+    assert gfb.parse_linked_issues(None) == []
+
+
+def test_parse_diff_splits_per_file():
+    diff = (
+        "diff --git a/foo.py b/foo.py\n"
+        "@@ -1 +1 @@\n-old\n+new\n"
+        "diff --git a/bar.py b/bar.py\n"
+        "@@ -1 +1 @@\n-x\n+y\n"
+    )
+    files = gfb.parse_diff(diff)
+    assert [f["path"] for f in files] == ["foo.py", "bar.py"]
+    assert "+new" in files[0]["patch"]
+    assert "+y" in files[1]["patch"]

--- a/.github/workflows/claude-bug-hunt-feedback.yml
+++ b/.github/workflows/claude-bug-hunt-feedback.yml
@@ -1,0 +1,101 @@
+name: 'Claude: Bug Hunt Feedback Capture'
+
+# =============================================================================
+# Captures rejected bug-hunt fix PRs so the daily hunter can learn from them.
+#
+# The bug-hunt loop is issues-only, so the PRs that feed it come from the triage
+# worker as `bug-hunt/issue-*` draft fixes. When one is closed WITHOUT merging,
+# the maintainer is telling the bot "this fix — or the bug behind it — was
+# wrong." This workflow bundles the PR's diff, close metadata, and every
+# comment/review into a single JSONL line in
+# .github/bug-hunt/rejected-edits.jsonl and commits it to main. The next hunt
+# reads the log and (a) never re-files the rejected finding, and (b)
+# generalizes from the closer's explanation.
+#
+# `workflow_dispatch` re-runs capture for a given PR — useful when a maintainer
+# adds an explanatory comment after the original close. Re-running replaces the
+# prior line for that PR rather than appending.
+#
+# Trigger is `pull_request_target` (not `pull_request`) so GitHub resolves this
+# workflow file from `main` rather than the PR's head ref. Branches cut from
+# `main` before this workflow existed would otherwise be invisible to it. Safe
+# here because the workflow checks out `main` (not PR code) and only reads PR
+# metadata via `gh`; no head-ref code is ever executed.
+# =============================================================================
+
+on:
+  pull_request_target:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to (re)capture into the rejection log'
+        required: true
+        type: number
+
+permissions:
+  contents: read
+
+# Serialize commits to main. Two PRs closed at once would race the same log
+# file and lose a line; cancel-in-progress=false so each capture completes.
+concurrency:
+  group: bug-hunt-feedback
+  cancel-in-progress: false
+
+jobs:
+  capture:
+    name: Capture rejected bug-hunt fix
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # On `pull_request_target.closed`, only fire for unmerged bug-hunt fix
+    # branches. Draft and ready-for-review PRs both fire `closed`. The script
+    # itself refuses to log a merged PR, so manual backfill stays safe.
+    if: >-
+      ${{ github.event_name == 'workflow_dispatch' ||
+          (github.event.pull_request.merged == false &&
+           startsWith(github.event.pull_request.head.ref, 'bug-hunt/issue-')) }}
+    permissions:
+      contents: write
+      pull-requests: read
+      issues: read
+    steps:
+      - name: Determine PR number
+        id: pr
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "number=${{ inputs.pr_number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          # RELEASE_PAT so the log commit can push to main past branch
+          # protection — same pattern as the state-file commit.
+          ref: main
+          token: ${{ secrets.RELEASE_PAT }}
+          fetch-depth: 1
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Capture rejection
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        run: |
+          set -euo pipefail
+          python3 .github/bug-hunt/build_rejection.py "${{ steps.pr.outputs.number }}"
+
+      - name: Commit and push
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- .github/bug-hunt/rejected-edits.jsonl; then
+            echo "Log unchanged — script bailed (merged PR, or no diff)."
+            exit 0
+          fi
+          git add .github/bug-hunt/rejected-edits.jsonl
+          git commit -m "chore(bug-hunt): capture rejection from PR #${{ steps.pr.outputs.number }} [skip ci]"
+          git push origin HEAD:main

--- a/.github/workflows/claude-bug-hunt-feedback.yml
+++ b/.github/workflows/claude-bug-hunt-feedback.yml
@@ -69,7 +69,7 @@ jobs:
           fi
 
       - name: Checkout main
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # RELEASE_PAT so the log commit can push to main past branch
           # protection — same pattern as the state-file commit.

--- a/.github/workflows/claude-bug-hunt-learn.yml
+++ b/.github/workflows/claude-bug-hunt-learn.yml
@@ -1,0 +1,197 @@
+name: 'Claude: Bug Hunt Learner'
+
+# =============================================================================
+# Weekly positive-learning pass for the bug-hunt loop. Mines the bugs we have
+# actually FIXED (closed issues labelled `bug`/`bug-hunt` + their merged fix
+# PRs) and distills them into .github/bug-hunt/pattern-memory.md — recurring
+# root-cause patterns, a ranking of bug-prone modules, and per-lens checklists.
+# The daily hunter reads that file to hunt smarter and prioritize.
+#
+# This is the counterpart to the rejection log: pattern-memory.md raises RECALL
+# (where bugs really live); rejected-edits.jsonl raises PRECISION (what not to
+# file). Data-gathering is a deterministic script (gather_fixed_bugs.py) so the
+# model only does the distillation.
+#
+# Cadence: Monday noon PT. Paired UTC crons absorb DST; the local-hour gate
+# admits exactly the noon window. workflow_dispatch always proceeds.
+# =============================================================================
+
+on:
+  schedule:
+    - cron: '7 19 * * 1'   # 12:07 PDT (summer) Mon / 11:07 PST (gated off)
+    - cron: '7 20 * * 1'   # 12:07 PST (winter) Mon / 13:07 PDT (gated by cooldown)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bug-hunt-learn
+  cancel-in-progress: false
+
+jobs:
+  learn:
+    name: Distill fixed bugs into pattern memory
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+      issues: read
+      pull-requests: read
+      id-token: write
+    steps:
+      - name: Gate on America/Los_Angeles local hour window
+        id: gate
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "go=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          hour=$(TZ=America/Los_Angeles date +%H)
+          minute=$(TZ=America/Los_Angeles date +%M)
+          echo "Local PT: $hour:$minute"
+          in_window=false
+          if [ "$hour" = "12" ] || { [ "$hour" = "13" ] && [ "$minute" -le 30 ]; }; then
+            in_window=true
+          fi
+          if [ "$in_window" = "true" ]; then
+            echo "go=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "go=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping: outside 12:00–13:30 PT window."
+          fi
+
+      - name: Checkout repository
+        if: steps.gate.outputs.go == 'true'
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.RELEASE_PAT }}
+          fetch-depth: 0
+
+      - name: Cooldown (block the paired DST cron)
+        id: dedup
+        if: steps.gate.outputs.go == 'true'
+        # last_learned_at is advanced by the Claude step at the end of a
+        # successful run. A 100h cooldown blocks the second cron in the same
+        # Monday window; the next weekly run is ~168h later. dispatch bypasses.
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "go=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          last=$(jq -r '.last_learned_at // empty' .github/bug-hunt-state.json)
+          if [ -n "$last" ]; then
+            last_epoch=$(date -u -d "$last" +%s 2>/dev/null || echo 0)
+            now_epoch=$(date -u +%s)
+            if [ "$last_epoch" -gt 0 ]; then
+              age_h=$(( (now_epoch - last_epoch) / 3600 ))
+              if [ "$age_h" -lt 100 ]; then
+                echo "Skipping: last learned ${age_h}h ago (<100h cooldown)."
+                echo "go=false" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            fi
+          fi
+          echo "go=true" >> "$GITHUB_OUTPUT"
+
+      - name: Configure git identity
+        if: steps.dedup.outputs.go == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Gather fixed bugs since last learn
+        id: gather
+        if: steps.dedup.outputs.go == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        # gather_fixed_bugs.py is pure stdlib + gh (no project deps). Bound the
+        # window by last_learned_at; on the first run it scans the full history.
+        run: |
+          since=$(jq -r '.last_learned_at // empty' .github/bug-hunt-state.json)
+          echo "Gathering fixed bugs since: ${since:-<all history>}"
+          python3 .github/bug-hunt/gather_fixed_bugs.py --since "$since" > /tmp/fixed-bugs.json
+          count=$(jq 'length' /tmp/fixed-bugs.json)
+          echo "Collected ${count} fixed-bug records."
+          echo "count=${count}" >> "$GITHUB_OUTPUT"
+
+      - name: Distill into pattern memory
+        # Skip the model entirely when there's nothing new to learn.
+        if: steps.dedup.outputs.go == 'true' && steps.gather.outputs.count != '0'
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          show_full_output: 'true'
+          claude_args: >-
+            --model claude-sonnet-4-6
+            --max-turns 60
+            --allowed-tools "Read,Glob,Grep,Edit,Write,Bash(cat:*),Bash(jq:*),Bash(date:*),Bash(git status:*),Bash(git diff:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*)"
+          prompt: |
+            You maintain the FiestaBoard bug-hunt **pattern memory** — the
+            positive-learning file the daily bug hunter reads to hunt smarter.
+
+            ## Inputs
+
+            1. `/tmp/fixed-bugs.json` — a JSON array of bugs we recently FIXED.
+               Each record: `issue`, `issue_title`, `issue_body`, `labels`,
+               `closed_at`, `pr`, `pr_title`, `files` (`{path, patch}` — the
+               actual fix diff). Read it with `cat /tmp/fixed-bugs.json`.
+            2. `.github/bug-hunt/pattern-memory.md` — the current memory.
+
+            ## Your task
+
+            For each fixed bug, study the issue (the symptom) and the fix diff
+            (the root cause + correction). Then UPDATE
+            `.github/bug-hunt/pattern-memory.md`:
+
+            - **Recurring root-cause patterns:** add or refine GENERALIZED
+              patterns — the *class* of mistake, not the one-off. e.g. "naive
+              timezone handling: code reads `datetime.now()` without the
+              configured TZ." Cite the issue/PR numbers. Merge duplicates;
+              prune anything stale or already fully covered.
+            - **Bug-prone modules:** re-rank the list by how many fixes have
+              landed in each area (use the `files` paths). Most-fixed first.
+            - **Per-lens checklists:** under the matching lens
+              (backend-logic / error-handling / concurrency-state /
+              contract-drift / security-input), add concise, concrete checks a
+              future hunter should run, derived from these fixes.
+
+            Keep the file TIGHT and high-signal — it is injected into prompts.
+            Prefer editing existing entries over endless appending. Set the
+            frontmatter `last_learned_at` to the most recent `closed_at` in the
+            input (so the next run only sees newer fixes).
+
+            ## Then advance state and commit
+
+            1. Set `last_learned_at` in `.github/bug-hunt-state.json` to the
+               same value you wrote into the frontmatter (the most recent
+               `closed_at`). Do NOT touch any other field.
+            2. Commit and push to `main`:
+               ```bash
+               git add .github/bug-hunt/pattern-memory.md .github/bug-hunt-state.json
+               git commit -m "chore(bug-hunt): refresh pattern memory [skip ci]" || exit 0
+               git push origin HEAD:main
+               ```
+
+            ## Hard rules
+
+            - The ONLY files you may write are
+              `.github/bug-hunt/pattern-memory.md` and
+              `.github/bug-hunt-state.json`. Never edit source code.
+            - Never force-push, never `--no-verify`. The commit above is your
+              only push to main.
+
+      - name: Push memory changes (fallback)
+        if: steps.dedup.outputs.go == 'true' && steps.gather.outputs.count != '0'
+        # Defensive: if the Claude step exits early with staged-but-unpushed
+        # changes, commit + push them here. [skip ci] avoids retriggering.
+        run: |
+          if git diff --quiet -- .github/bug-hunt/pattern-memory.md .github/bug-hunt-state.json; then
+            echo "Pattern memory unchanged."
+            exit 0
+          fi
+          git add .github/bug-hunt/pattern-memory.md .github/bug-hunt-state.json
+          git commit -m "chore(bug-hunt): refresh pattern memory [skip ci]"
+          git push origin HEAD:main

--- a/.github/workflows/claude-bug-hunt-learn.yml
+++ b/.github/workflows/claude-bug-hunt-learn.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.gate.outputs.go == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           token: ${{ secrets.RELEASE_PAT }}
           fetch-depth: 0

--- a/.github/workflows/claude-bug-hunt-review.yml
+++ b/.github/workflows/claude-bug-hunt-review.yml
@@ -52,7 +52,7 @@ jobs:
       actions: read
     steps:
       - name: Checkout base ref (trusted)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # pull_request_target grants secrets — never check out PR head.
           # Base ref gives Claude trusted CLAUDE.md + the pre-fix code to

--- a/.github/workflows/claude-bug-hunt-review.yml
+++ b/.github/workflows/claude-bug-hunt-review.yml
@@ -1,0 +1,143 @@
+name: 'Claude: Bug Hunt Auto-Review'
+
+# =============================================================================
+# Auto-runs a Claude correctness review on the bug-hunt loop's own fix PRs
+# (head branch `bug-hunt/issue-*`, opened as drafts by the triage worker).
+# Posts ONE review comment focused on whether the fix actually fixes the bug
+# without breaking anything — and whether the repro test genuinely covers it.
+#
+# Gated by the head-branch prefix (NOT by paths alone) so it reviews only this
+# loop's fixes, not every code PR in the repo. Unlike the docs/a11y reviewers
+# it does NOT skip drafts, because bug-hunt fix PRs are draft by design.
+#
+# `pull_request_target` runs from the base ref's workflow definition, so
+# malicious head-branch edits can't fire. We only check out the BASE ref —
+# never the PR head — per the CodeQL `actions/untrusted-checkout` rule. PR head
+# content is read read-only via `gh api .../contents/<path>?ref=<head_sha>`:
+# bytes piped through Claude as data, never executed. `--allowed-tools` is
+# read-only.
+# =============================================================================
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'src/**'
+      - 'plugins/**'
+      - 'web/src/**'
+      - 'tests/**'
+      - 'web/tests/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: claude-bug-hunt-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: Claude reviews the bug-hunt fix
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # Only the loop's own fix PRs (draft or not). Skip Dependabot (read-only
+    # token can't post a review).
+    if: >-
+      github.event.pull_request.user.login != 'dependabot[bot]'
+      && startsWith(github.event.pull_request.head.ref, 'bug-hunt/issue-')
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout base ref (trusted)
+        uses: actions/checkout@v6
+        with:
+          # pull_request_target grants secrets — never check out PR head.
+          # Base ref gives Claude trusted CLAUDE.md + the pre-fix code to
+          # compare against. PR head content is read via
+          # `gh api .../contents/<path>?ref=<head_sha>` — data, never executed.
+          ref: ${{ github.event.pull_request.base.ref }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Run Claude review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Skip the OIDC→claude[bot] App-token exchange (returns 401 on
+          # pull_request_target); post under the workflow's GITHUB_TOKEN. Cost:
+          # the review badge is github-actions[bot], which is why the feedback
+          # capture allowlists that identity.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # The triage worker (claude) opens these PRs; fiestaboard-ci-bot /
+          # github-actions push branch updates whose synchronize events must
+          # clear the anti-bot guard.
+          allowed_bots: 'claude,github-actions,fiestaboard-ci-bot'
+          show_full_output: 'true'
+          claude_args: >-
+            --model claude-sonnet-4-6
+            --max-turns 40
+            --allowed-tools "Read,Glob,Grep,Bash(ls:*),Bash(cat:*),Bash(find:*),Bash(grep:*),Bash(rg:*),Bash(jq:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api:*)"
+          prompt: |
+            You are the FiestaBoard **bug-fix reviewer**. Review PR
+            #${{ github.event.pull_request.number }} — a fix opened by the
+            bug-hunt pipeline for the bug described in its linked issue
+            (`Closes #N` in the PR body). Your focus is **correctness**: does
+            this change actually fix the reported bug, without breaking
+            anything or over-reaching?
+
+            ## Important — workspace is at BASE, not PR head
+
+            The workflow checked out the trusted base ref (CodeQL
+            untrusted-checkout rule), so `cat`/`Read`/`ls` see the PRE-FIX code
+            (useful for CLAUDE.md and for comparing against the fix). Read the
+            PR's version of a file via:
+
+                gh api \
+                  "repos/${{ github.repository }}/contents/<path>?ref=${{ github.event.pull_request.head.sha }}" \
+                  -H "Accept: application/vnd.github.raw"
+
+            That returns raw bytes (data only — never executed). Never
+            `git checkout` the PR head.
+
+            ## How to review
+
+            1. Run `gh pr diff ${{ github.event.pull_request.number }}` for the
+               diff, and `gh pr view ${{ github.event.pull_request.number }}`
+               for the body. Read the linked issue
+               (`gh issue view <N>`) to understand the bug and the intended
+               repro.
+            2. Assess the fix:
+               - **Does it address the root cause** described in the issue, or
+                 just paper over the symptom?
+               - **Repro test.** The issue carried a repro test. Confirm the PR
+                 adds it (or an equivalent) and that it genuinely exercises the
+                 bug — it should FAIL on base and PASS with the fix. A fix
+                 without a guarding test is a finding.
+               - **Regressions / scope.** Does the change risk breaking nearby
+                 behavior? Is it minimal, or does it sprawl beyond the bug?
+               - **Correctness details.** Edge cases, error paths, types,
+                 None/empty handling, and (for contract fixes) that Python and
+                 TS stay in sync.
+               - **CLAUDE.md conventions** (schema migrations for stored
+                 formats, no real PII in examples, plugin rules, etc.).
+            3. If you can't tell whether the repro reproduces, say so and ask
+               the human to verify rather than guessing.
+
+            ## Output — post ONE review
+
+                gh pr review ${{ github.event.pull_request.number }} --comment --body "<markdown>"
+
+            Lead with a one-line **verdict** (e.g. "fix looks correct, test
+            covers it" / "fix is incomplete" / "fix may regress X"), then list
+            findings with `file:line` references. If it's clean, say so briefly
+            — don't manufacture findings.
+
+            ## Hard rules
+
+            - Review only. Never APPROVE / REQUEST_CHANGES — always a plain
+              `--comment`. Sign-off stays human.
+            - No file edits, no pushes, no PR state changes.
+            - One review per run. If you'd post a second, consolidate.

--- a/.github/workflows/claude-bug-hunt.yml
+++ b/.github/workflows/claude-bug-hunt.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Checkout repository
         if: steps.gate.outputs.go == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # RELEASE_PAT so the state-file commit can push to main past branch
           # protection — same pattern as docs-audit / a11y-audit.

--- a/.github/workflows/claude-bug-hunt.yml
+++ b/.github/workflows/claude-bug-hunt.yml
@@ -1,0 +1,455 @@
+name: 'Claude: Bug Hunt'
+
+# =============================================================================
+# Daily America/Los_Angeles proactive bug hunt by Claude Sonnet. Sweeps the
+# codebase one or two SUBSYSTEMS ("areas") at a time and FILES ISSUES for real
+# functional bugs it finds — logic errors, bad edge-case handling, exception
+# mishandling, concurrency/state hazards, Python<->TS API contract drift, and
+# security/input-validation holes. The goal is to find bugs before users do.
+#
+# This loop is ISSUES-ONLY: the hunter NEVER edits source and NEVER opens a PR.
+# Every confirmed bug becomes a `bug` + `bug-hunt` + `claude-fix` labeled issue,
+# and the shared claude-issue-triage.yml worker opens a `bug-hunt/issue-*`
+# DRAFT fix PR for each (using the issue's repro test as the acceptance check).
+# Those PRs are auto-reviewed by claude-bug-hunt-review.yml; rejections feed
+# .github/bug-hunt/rejected-edits.jsonl, which this hunt reads next run.
+#
+# Unlike docs/a11y, the hunt runs a MULTI-LENS SUBAGENT FAN-OUT: it dispatches
+# one read-only lens subagent per bug class (via the Task tool), then runs
+# independent SKEPTIC subagents to adversarially REFUTE each candidate. Only
+# survivors are filed — a trustworthy issue queue is the whole point.
+#
+# A weekly companion (claude-bug-hunt-learn.yml) mines merged bug-fixes into
+# .github/bug-hunt/pattern-memory.md, which this hunt reads to hunt smarter.
+#
+# Cadence: daily, noon PT. Each cron pair fires in UTC to absorb DST drift; the
+# local-hour gate admits exactly the noon window. workflow_dispatch always
+# proceeds.
+#
+# Effort scales with the open `bug-hunt` issue queue (see "Compute dynamic
+# effort"). Drained → thorough (2 areas, cap 12). Hot → conservative (1 area,
+# cap 5). At/above the ceiling the run backs off entirely.
+#
+# Progress tracked in .github/bug-hunt-state.json; the sweep restarts from the
+# top once every area has been hunted.
+# =============================================================================
+
+on:
+  schedule:
+    # One pair of UTC crons for the daily noon PT window. During PDT both fire
+    # inside the gate window and the 3h cooldown drops the second; during PST
+    # the 19:07 cron is gated off and 20:07 is the noon run. dispatch bypasses.
+    - cron: '7 19 * * *'   # 12:07 PDT (summer) / 11:07 PST (gated off)
+    - cron: '7 20 * * *'   # 12:07 PST (winter) / 13:07 PDT (gated by cooldown)
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Print intended issues instead of filing them (no gh issue create, no state commit). Use to eyeball candidate quality.'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+# Serialize every bug-hunt run. Without this, two parallel runs read the same
+# state, pick the same area, and file duplicate issues. cancel-in-progress=false
+# so a workflow_dispatch fired during a scheduled run waits its turn rather than
+# aborting it (which would corrupt the state file).
+concurrency:
+  group: bug-hunt
+  cancel-in-progress: false
+
+jobs:
+  hunt:
+    name: Bug Hunt with Claude
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    # Issues-only loop: no `pull-requests: write` — the hunter opens no PRs.
+    # `contents: write` is for the single state-file commit; `issues: write`
+    # files findings; `id-token: write` for the Claude action's OIDC exchange.
+    permissions:
+      contents: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Gate on America/Los_Angeles local hour window
+        id: gate
+        # Noon window: 12:00–13:30 PT. The 30-minute upper slop absorbs typical
+        # GitHub Actions cron delay (often 10–30 min) without letting a
+        # wrong-DST cron through. workflow_dispatch bypasses the gate.
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "go=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          hour=$(TZ=America/Los_Angeles date +%H)
+          minute=$(TZ=America/Los_Angeles date +%M)
+          echo "Local PT: $hour:$minute"
+          in_window=false
+          if [ "$hour" = "12" ] || { [ "$hour" = "13" ] && [ "$minute" -le 30 ]; }; then
+            in_window=true
+          fi
+          if [ "$in_window" = "true" ]; then
+            echo "go=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "go=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping: outside 12:00–13:30 PT window."
+          fi
+
+      - name: Checkout repository
+        if: steps.gate.outputs.go == 'true'
+        uses: actions/checkout@v6
+        with:
+          # RELEASE_PAT so the state-file commit can push to main past branch
+          # protection — same pattern as docs-audit / a11y-audit.
+          token: ${{ secrets.RELEASE_PAT }}
+          fetch-depth: 0
+
+      - name: Dedup against recent runs and queue ceiling
+        id: dedup
+        if: steps.gate.outputs.go == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        # Daily cadence. The window has a paired UTC cron; a 3h cooldown blocks
+        # the second cron in the same window (next day's run is ~24h later, well
+        # past the cooldown). The open-issue CEILING is the issues-only analog
+        # of the docs draft cap: if the bug queue is saturated, back off so
+        # reviewers aren't drowned. workflow_dispatch bypasses both.
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "go=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          last=$(jq -r '.last_run_at // empty' .github/bug-hunt-state.json)
+          if [ -n "$last" ]; then
+            last_epoch=$(date -u -d "$last" +%s 2>/dev/null || echo 0)
+            now_epoch=$(date -u +%s)
+            if [ "$last_epoch" -gt 0 ]; then
+              age_h=$(( (now_epoch - last_epoch) / 3600 ))
+              if [ "$age_h" -lt 3 ]; then
+                echo "Skipping: last run was ${age_h}h ago (<3h cooldown)."
+                echo "go=false" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            fi
+          fi
+          open_count=$(gh issue list --label bug-hunt --state open --limit 200 --json number --jq 'length')
+          if [ "$open_count" -ge 40 ]; then
+            echo "Skipping: ${open_count} open bug-hunt issues (>=40 ceiling). Triage/close some, or use workflow_dispatch."
+            echo "go=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Open bug-hunt issues: ${open_count} (ceiling 40)."
+          echo "go=true" >> "$GITHUB_OUTPUT"
+
+      - name: Compute dynamic effort
+        id: effort
+        if: steps.dedup.outputs.go == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+        # Effort scales inverse to the open bug-hunt queue. A drained queue
+        # means triage is keeping up and we can hunt more areas / file more; a
+        # warming queue means we narrow the sweep and raise the confidence bar.
+        run: |
+          open_count=$(gh issue list --label bug-hunt --state open --limit 200 --json number --jq 'length')
+          echo "Open bug-hunt issues: ${open_count}"
+          if [ "$open_count" -gt 30 ]; then
+            mode="conservative"; areas=1; cap=5
+          elif [ "$open_count" -gt 15 ]; then
+            mode="balanced";     areas=1; cap=8
+          else
+            mode="thorough";     areas=2; cap=12
+          fi
+          echo "mode=${mode} areas=${areas} cap=${cap}"
+          {
+            echo "mode=${mode}"
+            echo "areas=${areas}"
+            echo "cap=${cap}"
+            echo "open_count=${open_count}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Configure git identity
+        if: steps.dedup.outputs.go == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Run Claude bug-hunt
+        if: steps.dedup.outputs.go == 'true'
+        uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
+          # github.run_id is unique + stable per run. Issue bodies reference it
+          # so a finding traces back to its run. Do NOT compute timestamps in
+          # the prompt — past loops invented stale `date +%s` values from the
+          # model's training cutoff.
+          BRANCH_SUFFIX: ${{ github.run_id }}
+          HUNT_MODE: ${{ steps.effort.outputs.mode }}
+          HUNT_AREAS: ${{ steps.effort.outputs.areas }}
+          HUNT_ISSUE_CAP: ${{ steps.effort.outputs.cap }}
+          HUNT_QUEUE_OPEN: ${{ steps.effort.outputs.open_count }}
+          HUNT_DRY_RUN: ${{ github.event.inputs.dry_run }}
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Surface the SDK transcript in the Actions log. Without this the
+          # action prints "full output hidden for security" and silent
+          # permission denials look like a clean success.
+          show_full_output: 'true'
+          # Sonnet — the hunt is read-heavy "find" work; the per-issue FIX runs
+          # on Opus (in claude-issue-triage.yml).
+          # --allowed-tools: the agent-mode default is read-only, so every
+          # Edit/Write/git/gh call must be allowlisted. This loop is
+          # ISSUES-ONLY, so the allowlist OMITS `gh pr *` and branch-switching
+          # git verbs — the only writes are the state JSON and its commit/push.
+          # `Task` is included so the orchestrator can fan out lens + skeptic
+          # subagents; the subagents inherit the read tools below.
+          claude_args: >-
+            --model claude-sonnet-4-6
+            --max-turns 250
+            --allowed-tools "Task,Read,Glob,Grep,Edit,Write,Bash(ls:*),Bash(cat:*),Bash(find:*),Bash(grep:*),Bash(rg:*),Bash(date:*),Bash(jq:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git rev-parse:*),Bash(gh issue list:*),Bash(gh issue view:*),Bash(gh issue create:*),Bash(gh issue edit:*),Bash(gh label list:*),Bash(gh label create:*)"
+          prompt: |
+            You are the FiestaBoard **bug hunter**. You run unattended once a
+            day and proactively hunt for REAL functional bugs in a batch of the
+            codebase, so we find them before users do. Your job is to **find
+            and confirm** bugs — fixing happens downstream via the issue-triage
+            workflow, which spawns one focused Claude worker per issue you file.
+
+            This loop is **issues-only**: you do **not** open PRs and you do
+            **not** edit any source code. The ONLY file you may write is the
+            sweep state file (see "Hard rules").
+
+            You are NOT a linter or a style/perf/i18n/a11y auditor — those are
+            covered by other tools. Hunt for **functional defects**: code that
+            produces wrong results, crashes, loses data, mishandles errors,
+            races on shared state, drifts between the Python API and the TS
+            client, or exposes a security/input-validation hole.
+
+            ## Effort for this run (computed by the workflow)
+
+            - **Mode:**        ${{ steps.effort.outputs.mode }}
+            - **Areas:**       ${{ steps.effort.outputs.areas }} subsystem(s) this run
+            - **Issue cap:**   ${{ steps.effort.outputs.cap }} per run
+            - **Queue depth:** ${{ steps.effort.outputs.open_count }} open `bug-hunt` issues
+            - **Dry run:**     `$HUNT_DRY_RUN` (if `true`, see Hard rules)
+
+            The mode/areas/cap were chosen by the workflow from the queue depth
+            — don't second-guess them.
+
+            ## Step 1 — Learn from past rejections (do this FIRST)
+
+            **Read `.github/bug-hunt/rejected-edits.jsonl` before anything
+            else.** Each non-empty line is a previous `bug-hunt/issue-*` fix PR
+            that a human closed without merging — i.e. the bug report was a
+            FALSE POSITIVE or the fix was wrong. This is your single most
+            important precision input.
+
+            Each line is JSON: `pr`, `title`, `head_ref`, `closed_at`, `body`,
+            `files` (`{path, patch}`), and `comments`/`reviews`/
+            `inline_comments` (the human's reasoning — authoritative).
+
+            For each rejection: (1) never re-file that same finding — anywhere,
+            not just that file; (2) generalize the *class* of false positive
+            (e.g. "looked like a race but is guarded by lock Y"); (3) cite the
+            PR number in your wrap-up when you skip something because of it.
+
+            If the file is missing or empty, proceed normally.
+
+            ## Step 2 — Read the pattern memory
+
+            **Read `.github/bug-hunt/pattern-memory.md`.** It records recurring
+            root-cause patterns, a ranking of bug-prone modules, and per-lens
+            checklists distilled from bugs we have actually fixed. Use the
+            module ranking to bias which area(s) you pick, and pass each lens
+            its relevant checklist (Step 4).
+
+            ## Step 3 — Sweep state & area selection
+
+            State file: `.github/bug-hunt-state.json`
+            Schema: `schema_version` (int, 1), `round` (int), `round_started_at`
+            (ISO8601|null), `last_run_at` (ISO8601|null), `last_learned_at`
+            (ISO8601|null — owned by the learner, do not touch), `areas_remaining`
+            (list), `areas_audited` (list).
+
+            The sweep unit is a **subsystem**, not a file (functional bugs span
+            files). The canonical area list (each entry is a path scope you
+            glob and read in full):
+
+            1. `src/schedules/`
+            2. `src/pages/`
+            3. `src/collections/` + `src/carousels/`
+            4. board rendering: `src/board_client.py`, `src/board_chars.py`, `src/board_html_renderer.py`, `src/text_to_board.py`, `src/text_utils.py`
+            5. `src/plugins/` (loader/base) + `src/displays/`
+            6. `src/api_server.py` (routes) + `src/auth/` + `src/security/`
+            7. `src/mqtt/` + `src/triggers/`
+            8. `src/settings/` + `src/config_manager.py` + `src/config.py` + `src/backup/`
+            9. `src/ai/` + `src/mcp_server.py`
+            10. `src/system/` + `src/network/` + `src/network_diagnostics.py` + `src/devices.py` + `src/time_service.py`
+            11. `plugins/` (bundled plugins)
+            12. `web/src/routes/`
+            13. `web/src/lib/` (API client + contract drift vs `src/*/models.py`)
+            14. `web/src/components/` (state-heavy components)
+
+            Sweep logic:
+            1. Read the state file.
+            2. If `areas_remaining` is empty: set it to the canonical list above
+               (in order), set `areas_audited` to `[]`, bump `round` by 1, set
+               `round_started_at` to now (ISO8601 UTC).
+            3. Take the first **${{ steps.effort.outputs.areas }}** entries of
+               `areas_remaining` as this run's batch.
+
+            ## Step 4 — Fan out the lens subagents (Task tool)
+
+            For the area batch, dispatch ONE read-only subagent per lens, in
+            parallel, via the Task tool. Each lens subagent: receives the
+            area path scope(s), the rejection lessons (Step 1), and its
+            pattern-memory checklist (Step 2); reads the relevant code deeply
+            (not skimming); and returns candidate bugs as a list of
+            `{area, lens, severity, title, what, trace, repro}`.
+
+            The five lenses:
+            - **backend-logic** — wrong results, off-by-one, bad branch/guard
+              conditions, mishandled None/empty, incorrect state transitions,
+              broken invariants, datetime/timezone mistakes.
+            - **error-handling** — swallowed exceptions, bare `except`, wrong
+              error propagation, missing rollback/cleanup, partial writes on
+              failure, resource leaks.
+            - **concurrency-state** — races on shared/module-global state,
+              non-idempotent operations, cache/singleton staleness, ordering
+              assumptions, unguarded mutation across requests/threads/tasks.
+            - **contract-drift** — mismatches between Python Pydantic models
+              (`src/*/models.py`) and the TS interfaces / fetch wrappers in
+              `web/src/lib/api.ts` (field names, types, optionality, enum
+              values, response shapes).
+            - **security-input** — missing/incorrect input validation,
+              injection, path traversal, unsafe deserialization, authz gaps,
+              secrets handling. (Only flag REAL exploitable issues.)
+
+            Skip a lens whose scope doesn't intersect the area batch (e.g.
+            contract-drift only matters when `web/src/lib` or a `models.py` is
+            in scope).
+
+            ## Step 5 — Dedup candidates
+
+            Pool all lens candidates. For each, dedup against open issues:
+              `gh issue list --label bug-hunt --state open --limit 200 --search "<key phrase>"`
+            Drop candidates that already have an open same-file, same-symptom
+            issue.
+
+            ## Step 6 — Adversarial verification
+
+            For each surviving candidate, dispatch 2–3 INDEPENDENT skeptic
+            subagents (Task tool) whose explicit job is to **REFUTE** it. Each
+            skeptic: re-reads the actual code paths, checks whether a guard /
+            caller / type / framework behavior already prevents the bug, and
+            **defaults to "refuted" under uncertainty**. Where feasible it
+            drafts a minimal failing repro — a `pytest` test for backend bugs
+            that fails against current code.
+
+            **File a candidate ONLY if a majority of its skeptics could not
+            refute it.** This is the precision gate; respect it strictly. In
+            `conservative` mode raise the bar further (only file if NO skeptic
+            refutes).
+
+            ## Step 7 — File issues for survivors
+
+            For each confirmed bug (up to the cap), file a GitHub issue.
+
+            Title: `bug: <area> — <one-line symptom>`
+              e.g. `bug: src/schedules — rotation uses server-local time, not configured TZ`
+
+            Body (this exact structure — a downstream job parses it):
+
+              ## Bug-hunt finding
+
+              - **area:** <area path scope>
+              - **lens:** <backend-logic | error-handling | concurrency-state | contract-drift | security-input>
+              - **severity:** <low | medium | high | critical>
+              - **run:** round <round>, run $BRANCH_SUFFIX
+
+              ### What's wrong
+              <2–5 sentences>
+
+              ### Why it's real (trace)
+              <the code-path trace the skeptics could not refute, with
+              `file:line` references>
+
+              ### Repro
+              ```python
+              # runnable pytest that FAILS against current code (backend bugs).
+              # For frontend/contract bugs with no pytest repro, give precise
+              # numbered reproduction steps instead.
+              def test_...():
+                  ...
+              ```
+
+              ### Suggested direction
+              <2–5 sentences; a direction, NOT a full patch>
+
+            Labels: `bug`, `bug-hunt`. Create them if missing:
+              `gh label create bug-hunt --color B60205 --description "Filed by the bug-hunt cron" || true`
+            (`bug` already exists.) Then apply `claude-fix` so the issue-triage
+            workflow opens a `bug-hunt/issue-*` draft fix PR (bot-filed issues
+            don't satisfy triage's author gate, so `claude-fix` opens that path):
+              `gh issue edit <N> --add-label claude-fix`
+              `gh label create claude-fix --color 0E8A16 --description "Run the Claude issue-triage workflow on this issue" || true`
+
+            ## Step 8 — State commit
+
+            (Skip this ENTIRE section if `$HUNT_DRY_RUN` is `true`.)
+
+            After processing the batch:
+            1. Move the batch entries from `areas_remaining` to `areas_audited`.
+            2. Update `last_run_at` to now (ISO8601 UTC). Do NOT touch
+               `last_learned_at`.
+            3. Write the JSON back to `.github/bug-hunt-state.json` (2-space
+               indent, trailing newline, same key order as the existing file).
+            4. Commit to `main` directly and push:
+               ```bash
+               git add .github/bug-hunt-state.json
+               git commit -m "chore(bug-hunt): advance sweep state [skip ci]" || exit 0
+               git push origin HEAD:main
+               ```
+               This is the ONLY commit you make.
+
+            ## Hard rules
+
+            - **If `$HUNT_DRY_RUN` is `true`:** do NOT run `gh issue create` or
+              `gh issue edit`, and do NOT commit/push state. Instead PRINT the
+              issues you WOULD have filed (title + full body) so a human can
+              eyeball candidate quality. Still do the full hunt + verify.
+            - **Edits are restricted to `.github/bug-hunt-state.json` only.**
+              Never edit, create, or delete any other file. You file issues;
+              the triage worker fixes.
+            - Never open a PR. Never create a branch. (Issues-only.)
+            - Never push to `main` except for the single state-file commit.
+            - Never force-push, never `--no-verify`, never `--no-gpg-sign`.
+            - Never file more than **${{ steps.effort.outputs.cap }}** issues
+              this run. If you'd exceed it, keep the highest-severity, most
+              certain ones and discard the rest.
+            - File a bug ONLY if it survived adversarial verification. When in
+              doubt, do not file — a false positive erodes trust in the queue.
+            - When dedup says skip, skip.
+
+            ## Wrap up
+
+            Print a one-screen summary:
+              ROUND: <n> (started <date>)
+              AREAS: <areas hunted this run>
+              Candidates: <found> / Confirmed: <after verify> / Filed: <#N #N ...>
+              Rejections applied: <PR #s honored, or "none">
+              Progress: <audited>/<total> areas this round
+              Next area(s): <first 2 of areas_remaining or "round complete">
+
+      - name: Push state-file changes (fallback)
+        if: steps.dedup.outputs.go == 'true' && github.event.inputs.dry_run != 'true'
+        # Defensive: if the Claude step exits early (rate limit, allowlist
+        # denial, hallucination) with a staged-but-unpushed state change,
+        # commit + push it here. [skip ci] keeps this from retriggering.
+        run: |
+          if git diff --quiet -- .github/bug-hunt-state.json; then
+            echo "State file unchanged."
+            exit 0
+          fi
+          git add .github/bug-hunt-state.json
+          git commit -m "chore(bug-hunt): advance sweep state [skip ci]"
+          git push origin HEAD:main

--- a/.github/workflows/claude-issue-triage.yml
+++ b/.github/workflows/claude-issue-triage.yml
@@ -2,7 +2,7 @@ name: 'Claude: Issue Triage'
 
 # Take a first-pass fix attempt at new issues.
 #
-# Triggers in three ways:
+# Triggers in several ways:
 #   1. Auto: issue opened by the repo owner / a member / a collaborator
 #   2. Manual gate: any issue that gets the `claude-fix` label applied
 #   3. Docs cron: any issue that gets the `docs-audit` label applied
@@ -11,6 +11,10 @@ name: 'Claude: Issue Triage'
 #   4. A11y cron: any issue that gets the `a11y-audit` label applied
 #      (filed by claude-a11y-audit.yml / claude-a11y-live-axe.yml; same
 #      bot-author reasoning as #3 — these become `a11y/issue-*` fix PRs)
+#   5. Bug-hunt cron: any issue that gets the `bug-hunt` label applied
+#      (filed by claude-bug-hunt.yml; same bot-author reasoning — these
+#      become `bug-hunt/issue-*` DRAFT fix PRs, TDD'd off the issue's
+#      embedded repro test)
 #
 # These gates keep drive-by issues from public reporters out of the
 # auto-run path while still letting you (or any maintainer) opt one in by
@@ -47,7 +51,8 @@ jobs:
         (github.event.action == 'labeled' && (
           github.event.label.name == 'claude-fix' ||
           github.event.label.name == 'docs-audit' ||
-          github.event.label.name == 'a11y-audit'
+          github.event.label.name == 'a11y-audit' ||
+          github.event.label.name == 'bug-hunt'
         ))
       )
     runs-on: ubuntu-latest
@@ -149,6 +154,15 @@ jobs:
                  user-facing string (including `aria-label`) through
                  `next-intl` (`web/messages/en.json` + the 13 sibling
                  locales) — never a hardcoded English literal in JSX.
+               - For bug-hunt issues (labels include `bug-hunt`): branch
+                 `bug-hunt/issue-${{ github.event.issue.number }}-<short-slug>`,
+                 title prefix `fix:`. The issue body contains a fenced
+                 ```python repro``` block — add that repro as a REAL test
+                 FIRST (TDD) and confirm it FAILS on current code, then
+                 implement the smallest fix, confirm the repro PASSES and the
+                 suite stays green, and open as a **draft**
+                 (`gh pr create --draft`) so a human validates the fix before
+                 sign-off. (See "Bug-hunt issues — conventions" below.)
                - For everything else: branch
                  `claude/issue-${{ github.event.issue.number }}`, title
                  `[Claude first-pass] <short summary>`. Open as a draft
@@ -193,6 +207,22 @@ jobs:
                 before opening the PR
               - Scope tightly to the reported finding; cite the WCAG criterion
                 in the PR body
+
+            ## Bug-hunt issues — conventions
+
+            If the issue labels include `bug-hunt`, you are fixing a confirmed
+            functional bug. Work test-first:
+              - Start from the issue's repro block. Turn it into a real test
+                and confirm it FAILS on current code — that proves you've
+                reproduced the bug before you change anything.
+              - Implement the SMALLEST change that makes the repro pass. Do not
+                refactor or fix adjacent things; scope strictly to this bug.
+              - Run the relevant suite (`pytest` for backend, the web tests for
+                frontend) and keep it green. Check callers of any signature you
+                change so the fix doesn't regress them or drift the Python↔TS
+                contract.
+              - In the PR body, state the root cause, what the repro proves,
+                and what a reviewer should double-check. Open as a draft.
 
             If you finish without opening a PR, leave a comment on the issue
             summarizing what you found and why no PR was opened.

--- a/docs/superpowers/plans/2026-06-27-bug-hunt-loop.md
+++ b/docs/superpowers/plans/2026-06-27-bug-hunt-loop.md
@@ -1,0 +1,306 @@
+# Bug-Hunt Loop Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a daily, self-improving GitHub Actions loop that hunts for real functional bugs via a multi-lens subagent fan-out with adversarial verification, files high-trust issues, hands them to the shared triage worker for a human-reviewed draft fix, and learns from both merged fixes (positive) and rejected fixes (negative).
+
+**Architecture:** Third sibling of `docs-audit` / `a11y-audit`, built from the `new-claude-github-actions-flow` skill templates with two departures: (1) the hunter runs lens + skeptic subagents inside one `claude-code-action` run (issues-only output), and (2) a separate weekly learner cron mines merged bug-fix PRs into a `pattern-memory.md`. Option 1 now; the §7 issue schema is designed so a Phase-2 repro-execution job bolts on later.
+
+**Tech Stack:** GitHub Actions, `anthropics/claude-code-action@v1`, Claude (Sonnet 4.6 for hunt/learn/review, Opus 4.7 for triage fixes), Python 3 (`gather_fixed_bugs.py`, `build_rejection.py`), `gh` CLI, `jq`.
+
+## Global Constraints
+
+- Loop slug: `bug-hunt`. Domain label: `bug-hunt`. Reuse existing `bug` + `claude-fix` labels.
+- Hunter branch prefix (fix PRs from triage): `bug-hunt/issue-<N>-<slug>`.
+- Hunter is **issues-only**: permissions `contents: write`, `issues: write`, `id-token: write` — NO `pull-requests: write`. `Edit`/`Write` restricted by hard rule to `.github/bug-hunt-state.json` only.
+- Subagent fan-out requires `Task` in the hunter's `--allowed-tools`.
+- Every Claude step: `show_full_output: 'true'`. Hunter env: `BRANCH_SUFFIX: ${{ github.run_id }}` (never `date +%s`).
+- Commits to `main` from workflows use `RELEASE_PAT` and carry `[skip ci]`.
+- Concurrency: `cancel-in-progress: false` on hunt/learn/feedback; `true` on review.
+- Models are knobs but defaults: hunt/learn/review = `claude-sonnet-4-6`; triage fix = `claude-opus-4-7` (existing default).
+- Source of truth for boilerplate: `.claude/skills/new-claude-github-actions-flow/references/templates/`. Canonical live instances to mirror: `.github/workflows/claude-a11y-audit.yml` (issues-capable audit), `.github/workflows/claude-docs-audit.yml`, `.github/workflows/claude-a11y-audit-review.yml`, `.github/workflows/docs-audit-feedback.yml`.
+- Privacy rules from `CLAUDE.md`: no real PII/keys/coords in any example.
+
+---
+
+### Task 1: Scaffold `.github/bug-hunt/` data + memory skeletons + state file
+
+**Files:**
+- Create: `.github/bug-hunt-state.json`
+- Create: `.github/bug-hunt/pattern-memory.md`
+- Create: `.github/bug-hunt/rejected-edits.jsonl` (empty)
+- Create: `.github/bug-hunt/README.md`
+
+**Interfaces:**
+- Produces: the state schema (`schema_version:1, round:0, round_started_at:null, last_run_at:null, areas_remaining:[], areas_audited:[]`) consumed by Task 4; `pattern-memory.md` consumed by Tasks 4 & 5; `rejected-edits.jsonl` consumed by Task 4 & written by Task 7.
+
+- [ ] **Step 1: Write `.github/bug-hunt-state.json`** — copy `state.json.tmpl` but rename `files_*` → `areas_*`:
+```json
+{
+  "schema_version": 1,
+  "round": 0,
+  "round_started_at": null,
+  "last_run_at": null,
+  "last_learned_at": null,
+  "areas_remaining": [],
+  "areas_audited": []
+}
+```
+
+- [ ] **Step 2: Write `.github/bug-hunt/pattern-memory.md`** — seeded skeleton with frontmatter `last_learned_at: null`, the three sections (Recurring root-cause patterns, Bug-prone modules, Per-lens checklists), and one seeded example entry (the #1273→#1280 timezone pattern) so the hunter has a non-empty memory on day one.
+
+- [ ] **Step 3: Create empty `.github/bug-hunt/rejected-edits.jsonl`** (zero bytes).
+
+- [ ] **Step 4: Write `.github/bug-hunt/README.md`** — adapt `feedback-readme.md.tmpl`, plus a section documenting the SECOND memory (`pattern-memory.md`) and the learner workflow. Explain both memories and how to hand-edit them.
+
+- [ ] **Step 5: Commit**
+```bash
+git add .github/bug-hunt-state.json .github/bug-hunt/
+git commit -m "feat(bug-hunt): scaffold sweep state + dual-memory skeletons"
+```
+
+---
+
+### Task 2: `gather_fixed_bugs.py` + pytest (TDD)
+
+**Files:**
+- Create: `.github/bug-hunt/gather_fixed_bugs.py`
+- Create: `.github/bug-hunt/tests/test_gather_fixed_bugs.py`
+
+**Interfaces:**
+- Produces: `parse_linked_issues(body: str) -> list[int]` (parses `Closes #N`, `Fixes #N`, `Resolves #N`, and trailing `(#N)`), and a `main()` that prints JSON `[{pr, title, closed_at, linked_issues, files:[{path,patch}]}]` for merged PRs labelled `bug` since an optional `--since` ISO timestamp. Consumed by Task 5's learner workflow.
+
+- [ ] **Step 1: Write the failing test** for `parse_linked_issues`:
+```python
+from pathlib import Path
+import importlib.util
+spec = importlib.util.spec_from_file_location(
+    "gfb", Path(__file__).parent.parent / "gather_fixed_bugs.py")
+gfb = importlib.util.module_from_spec(spec); spec.loader.exec_module(gfb)
+
+def test_parse_closes_fixes_resolves_and_paren():
+    body = "Closes #1273\nalso Fixes #99 and resolves #100\ntitle (#1280)"
+    assert sorted(gfb.parse_linked_issues(body)) == [99, 100, 1273, 1280]
+
+def test_parse_dedupes_and_ignores_non_refs():
+    assert gfb.parse_linked_issues("no refs here #notanumber") == []
+    assert gfb.parse_linked_issues("Closes #5 Closes #5") == [5]
+```
+
+- [ ] **Step 2: Run it, verify failure**
+Run: `python3 -m pytest .github/bug-hunt/tests/test_gather_fixed_bugs.py -v`
+Expected: FAIL (module/function missing).
+
+- [ ] **Step 3: Implement `gather_fixed_bugs.py`** — `parse_linked_issues` via regex `(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)` (case-insensitive) plus `\(#(\d+)\)`, deduped. `main()` uses `gh pr list --state merged --search "label:bug" --json number,title,closedAt,body` (+ `--search` date filter when `--since` given), then `gh pr diff <n> --patch` per PR, parsing the unified diff into `{path,patch}` (reuse the `parse_diff` logic from `build_rejection.py.tmpl`). Supports `DRY_RUN`/stdout JSON. No network in the unit test (only `parse_linked_issues` is tested).
+
+- [ ] **Step 4: Run tests, verify pass**
+Run: `python3 -m pytest .github/bug-hunt/tests/test_gather_fixed_bugs.py -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Commit**
+```bash
+git add .github/bug-hunt/gather_fixed_bugs.py .github/bug-hunt/tests/
+git commit -m "feat(bug-hunt): add deterministic merged-bug-fix collector + tests"
+```
+
+---
+
+### Task 3: `build_rejection.py` (negative-learning log builder)
+
+**Files:**
+- Create: `.github/bug-hunt/build_rejection.py`
+
+**Interfaces:**
+- Produces: `build_rejection.py <pr_number>` that writes one idempotent JSONL line to `.github/bug-hunt/rejected-edits.jsonl`; refuses merged PRs; replaces a prior line for the same PR. Consumed by Task 7's feedback workflow.
+
+- [ ] **Step 1: Copy `build_rejection.py.tmpl`** to `.github/bug-hunt/build_rejection.py`, substituting `{{REJECTION_LOG}}` → `.github/bug-hunt/rejected-edits.jsonl`, `{{NAME}}` → `bug-hunt`.
+
+- [ ] **Step 2: Smoke-check it imports**
+Run: `python3 -c "import ast; ast.parse(open('.github/bug-hunt/build_rejection.py').read()); print('ok')"`
+Expected: `ok`.
+
+- [ ] **Step 3: Commit**
+```bash
+git add .github/bug-hunt/build_rejection.py
+git commit -m "feat(bug-hunt): add rejection-log builder (negative learning)"
+```
+
+---
+
+### Task 4: The hunter — `.github/workflows/claude-bug-hunt.yml`
+
+**Files:**
+- Create: `.github/workflows/claude-bug-hunt.yml`
+
+**Interfaces:**
+- Consumes: state file (Task 1), both memories (Tasks 1/5/7).
+- Produces: GitHub issues labelled `bug,bug-hunt,claude-fix` with the §7 schema body; advances the state file.
+
+Base on `audit-cron.yml.tmpl` + `claude-a11y-audit.yml`, then apply **issues-only trims** and the **multi-lens prompt**. Key specifics:
+
+- [ ] **Step 1: Workflow skeleton & triggers** — `on.schedule` one daily PT window via paired UTC crons (e.g. `7 19 * * *` and `7 20 * * *`) + `workflow_dispatch` with a boolean input `dry_run` (default `false`). `concurrency.group: bug-hunt`, `cancel-in-progress: false`. Top-level `permissions: contents: read`.
+
+- [ ] **Step 2: Gate + dedup + effort steps** — copy the gate (local PT hour, `TZ=America/Los_Angeles`, ~30-min slop), the cooldown (`last_run_at` < 20h bounces; `workflow_dispatch` bypasses), and the dynamic-effort step but keyed on **open `bug-hunt` issue count**: drained (≤ `EFFORT_BALANCED_THRESHOLD`=15) → 2 areas + thorough; warm (≤ 30) → 1–2 areas + balanced; hot (> 30) → 1 area + conservative + silence-filing ceiling at 40. Outputs `mode`, `areas`, `cap`.
+
+- [ ] **Step 3: Job permissions (issues-only trim)** —
+```yaml
+permissions:
+  contents: write
+  issues: write
+  id-token: write
+```
+
+- [ ] **Step 4: Claude step env + args** — `GH_TOKEN: ${{ secrets.RELEASE_PAT }}`, `BRANCH_SUFFIX: ${{ github.run_id }}`, effort outputs. `claude_args`:
+```
+--model claude-sonnet-4-6
+--max-turns 250
+--allowed-tools "Task,Read,Glob,Grep,Edit,Write,Bash(ls:*),Bash(cat:*),Bash(find:*),Bash(grep:*),Bash(rg:*),Bash(date:*),Bash(jq:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git rev-parse:*),Bash(gh issue list:*),Bash(gh issue view:*),Bash(gh issue create:*),Bash(gh issue edit:*),Bash(gh label list:*),Bash(gh label create:*)"
+```
+`with: show_full_output: 'true'`, `claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}`. (No `pull-requests` tools, no `git branch/checkout` — issues-only.)
+
+- [ ] **Step 5: The hunter prompt** — bespoke. Sections, in order:
+  1. **Intro:** "You are the FiestaBoard bug hunter. You run daily and hunt for real functional bugs before users hit them. You do NOT edit source — you file issues only."
+  2. **Effort block** (mode/areas/cap from effort outputs).
+  3. **Learning from past rejections** — read `.github/bug-hunt/rejected-edits.jsonl` first (copy the template's rejection section; never re-file a refuted bug; generalize).
+  4. **Pattern memory** — read `.github/bug-hunt/pattern-memory.md`; use bug-prone-module ranking to bias area pick and feed each lens its checklist.
+  5. **Sweep state** — schema with `areas_*`; the enumerated area list (§3 of spec); if `areas_remaining` empty, refill from the enumerated list, bump round.
+  6. **Fan out** — "Dispatch one subagent per lens via the Task tool, in parallel. Each lens is READ-ONLY. Lenses: backend-logic, error-handling, concurrency-state, contract-drift (src/*/models.py ↔ web/src/lib/api.ts), security-input. Give each lens the area(s), the rejection lessons, and its pattern-memory checklist. Each returns candidates {area,lens,severity,trace,proposed_repro}."
+  7. **Dedup** — `gh issue list --label bug-hunt --state open --search "<phrase>"`.
+  8. **Adversarial verify** — "For each candidate, dispatch 2–3 independent skeptic subagents whose job is to REFUTE it: trace the real code paths, default to refuted under uncertainty, and draft a failing repro (pytest for backend). File only if a majority cannot refute."
+  9. **Output / issue schema** — the §7 body verbatim; labels `bug,bug-hunt,claude-fix`; create labels idempotently (`gh label create bug-hunt --color B60205 --description "Filed by the bug-hunt cron" || true`); apply `claude-fix`.
+  10. **State commit** — move audited areas, set `last_run_at`, write back, commit `chore(bug-hunt): advance sweep state [skip ci]`.
+  11. **Hard rules** — only direct-to-main commit is the state file; edits restricted to `.github/bug-hunt-state.json`; never touch source; never exceed `cap` issues; honor dedup; if `dry_run` input is true, PRINT intended issues and do NOT call `gh issue create` or commit state.
+  12. **Wrap-up** summary.
+
+- [ ] **Step 6: Defensive state push step** — copy template's final `Push state-file changes` step (guarded by `dry_run == false`).
+
+- [ ] **Step 7: Validate YAML**
+Run: `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/claude-bug-hunt.yml')); print('ok')"`
+Expected: `ok`. (Plus `actionlint` if available — see Task 9.)
+
+- [ ] **Step 8: Commit**
+```bash
+git add .github/workflows/claude-bug-hunt.yml
+git commit -m "feat(bug-hunt): add daily multi-lens hunter workflow (issues-only)"
+```
+
+---
+
+### Task 5: The learner — `.github/workflows/claude-bug-hunt-learn.yml`
+
+**Files:**
+- Create: `.github/workflows/claude-bug-hunt-learn.yml`
+
+**Interfaces:**
+- Consumes: `gather_fixed_bugs.py` (Task 2), `pattern-memory.md` (Task 1).
+- Produces: rewritten `pattern-memory.md`, committed `[skip ci]`.
+
+- [ ] **Step 1: Triggers & concurrency** — `on.schedule` weekly (e.g. `0 18 * * 1` Mon + DST pair `0 19 * * 1`) + `workflow_dispatch`. `concurrency.group: bug-hunt-learn`, `cancel-in-progress: false`. `permissions: contents: read` top-level.
+
+- [ ] **Step 2: Checkout with RELEASE_PAT** (`fetch-depth: 0`), set up Python via `./.github/actions/setup-python-deps`, configure git identity.
+
+- [ ] **Step 3: Gather step** — `python3 .github/bug-hunt/gather_fixed_bugs.py --since "$(jq -r '.last_learned_at // empty' .github/bug-hunt-state.json)" > /tmp/fixed-bugs.json` (env `GH_TOKEN: RELEASE_PAT`). Echo the count.
+
+- [ ] **Step 4: Job permissions** — `contents: write`, `issues: read`, `pull-requests: read`, `id-token: write`.
+
+- [ ] **Step 5: Claude step** — model `claude-sonnet-4-6`, `--max-turns 60`, `show_full_output: 'true'`, allowlist `Read,Glob,Grep,Edit,Write,Bash(cat:*),Bash(jq:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git status:*),Bash(git diff:*)`. Prompt: "Read `/tmp/fixed-bugs.json` and `.github/bug-hunt/pattern-memory.md`. For each fixed bug, distill the GENERALIZED root-cause (not the one-off), update/extend the three sections, re-rank bug-prone modules by fix count, and set frontmatter `last_learned_at` to now (ISO8601 UTC). Keep it concise — prune stale/duplicate patterns. Write the file back. Also set `last_learned_at` in `.github/bug-hunt-state.json`. Commit `chore(bug-hunt): refresh pattern memory [skip ci]` and push."
+
+- [ ] **Step 6: Defensive push step** for `pattern-memory.md` + state (mirror Task 4 Step 6).
+
+- [ ] **Step 7: Validate YAML + commit**
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/claude-bug-hunt-learn.yml')); print('ok')"
+git add .github/workflows/claude-bug-hunt-learn.yml
+git commit -m "feat(bug-hunt): add weekly learner that mines fixes into pattern memory"
+```
+
+---
+
+### Task 6: Auto-review — `.github/workflows/claude-bug-hunt-review.yml`
+
+**Files:**
+- Create: `.github/workflows/claude-bug-hunt-review.yml`
+
+**Interfaces:**
+- Consumes: nothing internal; reviews PRs whose head branch is `bug-hunt/issue-*`.
+
+- [ ] **Step 1:** Base on `auto-review.yml.tmpl` + `claude-a11y-audit-review.yml`. `on.pull_request_target: types [opened, synchronize, reopened, ready_for_review]`, `paths: ['src/**','plugins/**','web/src/**']`.
+
+- [ ] **Step 2: Job gate** — `if:` requires `github.event.pull_request.draft == false || true` (review drafts too, since fixes open as draft — set the condition to fire on draft bug-hunt PRs) AND `startsWith(github.event.pull_request.head.ref, 'bug-hunt/issue-')`. Note: because triage opens these as DRAFT, do NOT exclude drafts here (unlike the a11y/docs reviewers). Comment this explicitly.
+
+- [ ] **Step 3:** Base-ref checkout (`ref: ${{ github.event.pull_request.base.ref }}`, `persist-credentials: false`, `fetch-depth: 1`). Claude step with `github_token: ${{ secrets.GITHUB_TOKEN }}`, `allowed_bots: 'claude,github-actions'`, read-only allowlist (`Read,Glob,Grep,Bash(cat:*),Bash(find:*),Bash(grep:*),Bash(rg:*),Bash(jq:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr review:*),Bash(gh api:*)`), model `claude-sonnet-4-6`, `--max-turns 40`. Prompt: review the fix's correctness, that the repro test genuinely fails-then-passes and covers the bug, no scope creep, follows CLAUDE.md; post ONE `gh pr review --comment`. `concurrency.group: claude-bug-hunt-review-${{ github.event.pull_request.number }}`, `cancel-in-progress: true`.
+
+- [ ] **Step 4: Validate YAML + commit**
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/claude-bug-hunt-review.yml')); print('ok')"
+git add .github/workflows/claude-bug-hunt-review.yml
+git commit -m "feat(bug-hunt): add auto-review for bug-hunt fix PRs"
+```
+
+---
+
+### Task 7: Feedback capture — `.github/workflows/claude-bug-hunt-feedback.yml`
+
+**Files:**
+- Create: `.github/workflows/claude-bug-hunt-feedback.yml`
+
+**Interfaces:**
+- Consumes: `build_rejection.py` (Task 3). Produces appended `rejected-edits.jsonl`.
+
+- [ ] **Step 1:** Copy `feedback-capture.yml.tmpl`, substitute `{{NAME}}`→`bug-hunt`, `{{REJECTION_LOG}}`→`.github/bug-hunt/rejected-edits.jsonl`, `{{FEEDBACK_DIR}}`→`.github/bug-hunt/`, `{{CONCURRENCY_GROUP_FEEDBACK}}`→`bug-hunt-feedback`. The `if:` startsWith uses ONLY `bug-hunt/issue-` (single source — there are no bucket-A audit branches in issues-only mode).
+
+- [ ] **Step 2: Validate YAML + commit**
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/claude-bug-hunt-feedback.yml')); print('ok')"
+git add .github/workflows/claude-bug-hunt-feedback.yml
+git commit -m "feat(bug-hunt): add rejection-capture feedback workflow"
+```
+
+---
+
+### Task 8: Extend the shared triage worker
+
+**Files:**
+- Modify: `.github/workflows/claude-issue-triage.yml`
+
+**Interfaces:**
+- Consumes: issues labelled `bug-hunt`. Produces: `bug-hunt/issue-<N>-<slug>` draft fix PRs.
+
+- [ ] **Step 1: Add `bug-hunt` to the label gate** (the `github.event.action == 'labeled'` block, alongside `claude-fix`/`docs-audit`/`a11y-audit`).
+
+- [ ] **Step 2: Add a bug-hunt arm to the prompt's step 4** — before the "everything else" fallback: "For bug-hunt issues (labels include `bug-hunt`): branch `bug-hunt/issue-${{ github.event.issue.number }}-<short-slug>`, title prefix `fix:`. The issue body contains a fenced ```python repro``` block — add it as a real failing test FIRST (TDD), confirm it fails, implement the smallest fix, confirm it passes and the suite stays green, then open as a **draft** (`gh pr create --draft`). `Closes #N`."
+
+- [ ] **Step 3: Update the header comment** (the numbered trigger list) to add the bug-hunt cron as trigger #5.
+
+- [ ] **Step 4: Validate YAML + commit**
+```bash
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/claude-issue-triage.yml')); print('ok')"
+git add .github/workflows/claude-issue-triage.yml
+git commit -m "feat(bug-hunt): route bug-hunt issues through triage as draft fix PRs"
+```
+
+---
+
+### Task 9: Final validation + PR
+
+**Files:** none (validation only).
+
+- [ ] **Step 1: Lint all new workflows** — if `actionlint` is available run it on the four new files + the modified triage file; otherwise rely on the per-task `yaml.safe_load` checks. Record any findings and fix.
+
+- [ ] **Step 2: Run the Python test**
+Run: `python3 -m pytest .github/bug-hunt/tests/ -v`
+Expected: PASS.
+
+- [ ] **Step 3: Grep guardrail audit** — confirm: `BRANCH_SUFFIX: ${{ github.run_id }}` present in hunter; `show_full_output: 'true'` in all four; `cancel-in-progress: false` on hunt/learn/feedback and `true` on review; `Task` in hunter allowlist; no `pull-requests: write` on the hunter job; `[skip ci]` on every workflow commit message; `RELEASE_PAT` used for checkout/commit on hunt/learn/feedback.
+
+- [ ] **Step 4: Open the PR** against `main` (title `feat(bug-hunt): scaffold proactive bug-hunting feedback loop`), body listing every file added/modified, calling out deviations from the docs-audit canonical pattern (multi-lens subagents, second learner cron, issues-only hunter), and noting Phase 2 is deferred. Include the manual dispatch + first-cron-tick info.
+
+---
+
+## Self-Review
+
+**Spec coverage:** §3 components → Tasks 1–8 (state/memory T1, scripts T2/T3, hunter T4, learner T5, review T6, feedback T7, triage T8). §4 hunt cycle → T4 Step 5. §5 memories → T1+T5+T7. §6 learner → T5. §7 schema → T4 Step 5.9 (and reserved labels noted). §8 handoff → T6/T7/T8. §9 safety → T4 trims + T9 Step 3 audit. §10 Phase 2 → reserved, not built (correct). §11 testing → T2 (unit), T4 `dry_run` (Step 5.11), T9. §12 prereqs → Global Constraints. No gaps.
+
+**Placeholder scan:** `<N>`, `<slug>`, `<phrase>` are runtime template values, not plan placeholders. The hunter/learner prompts are specified by section content rather than verbatim 300-line transcripts — acceptable because the implementer (this session) holds full template context and the canonical live workflows are cited as the base. No "TBD/handle edge cases" hand-waves.
+
+**Type consistency:** state keys `areas_remaining`/`areas_audited`/`last_run_at`/`last_learned_at` consistent across T1/T4/T5. Branch prefix `bug-hunt/issue-` consistent across T6/T7/T8. Label set `bug,bug-hunt,claude-fix` consistent T4/T8. `parse_linked_issues` signature consistent T2↔T5.

--- a/docs/superpowers/specs/2026-06-27-bug-hunt-loop-design.md
+++ b/docs/superpowers/specs/2026-06-27-bug-hunt-loop-design.md
@@ -1,0 +1,369 @@
+# Bug-Hunt Loop — Design Spec
+
+**Date:** 2026-06-27
+**Status:** Approved design, pre-implementation
+**Author:** Jeffrey Johnson (with Claude)
+
+A Claude-powered, self-improving GitHub Actions loop that proactively hunts for
+real functional bugs in the FiestaBoard codebase — finding them before users do —
+files high-trust issues, hands them to the existing triage worker for a
+human-reviewed draft fix, and gets smarter over time from both the bugs we fix
+and the false positives we reject.
+
+It is the third sibling of the existing `docs-audit` and `a11y-audit` loops,
+built with the `new-claude-github-actions-flow` skill pattern, with two
+deliberate departures: a **multi-lens subagent fan-out with adversarial
+verification**, and a **second positive-learning cron** that mines merged
+bug-fixes into a pattern memory.
+
+---
+
+## 1. Goals & non-goals
+
+### Goals
+- Proactively surface real, functional bugs (logic, edge cases, error handling,
+  concurrency/state, Python↔TS contract drift, security/input-validation)
+  across the ~40k LOC Python + ~64k LOC TS/TSX codebase.
+- **High precision**: only file a bug after independent adversarial verification.
+  A trustworthy queue is the success metric; a noisy one kills the loop.
+- **Learn in both directions**: raise recall where bugs really live (positive
+  learning from merged fixes) and raise precision by never repeating a rejected
+  false positive (negative learning).
+- Reuse the proven loop plumbing and the shared triage worker. No bug fix lands
+  without a human merging a draft PR.
+
+### Non-goals
+- Not a style/lint/perf/i18n/a11y auditor — those are covered by existing
+  read-only finders (`render-perf-auditor`, `i18n-auditor`, `ts-sync-validator`,
+  the a11y loop, etc.). The hunter targets **functional defects** only.
+- The hunter never edits source code. It files issues only.
+- Phase 1 does not *execute* repro tests in CI (that is Phase 2). Phase 1
+  verification is reasoning-based, and the repro test is written into the issue.
+
+---
+
+## 2. Decisions (locked)
+
+| # | Decision | Choice |
+|---|----------|--------|
+| 1 | Hunt scope | **Broad / multi-lens** — 5 specialized lens agents |
+| 2 | Learning | **Both signals** — positive pattern memory + negative rejection log |
+| 3 | Precision | **Adversarial verify** — independent skeptics refute each candidate; repro test where feasible |
+| 4 | Fix handoff | **Issue → draft fix PR** via the shared triage worker; hunter never edits code |
+| 5 | Cadence | Hunter **once daily**; learner **weekly** |
+| 6 | Orchestration | **Option 1, phased to Option 2** — single-job hunter with subagent fan-out, reasoning-verified, issues-only now; designed so a real repro-execution job bolts on as Phase 2 |
+
+---
+
+## 3. Architecture
+
+`bug-hunt` is the loop slug. Domain label `bug-hunt`; reuses existing `bug` and
+`claude-fix` labels.
+
+### Component inventory
+
+| File | Trigger | Role |
+|------|---------|------|
+| `.github/workflows/claude-bug-hunt.yml` | daily cron + dispatch | **Hunter.** One job, fans out lens + skeptic subagents, files issues only. |
+| `.github/workflows/claude-bug-hunt-learn.yml` | weekly cron + dispatch | **Learner.** Mines merged bug-fix PRs → updates pattern memory. |
+| `.github/workflows/claude-bug-hunt-review.yml` | `pull_request_target` | Auto-reviews the loop's fix PRs (gated to `bug-hunt/issue-*` head branches). |
+| `.github/workflows/claude-bug-hunt-feedback.yml` | `pull_request_target: closed` | Captures rejected fix PRs → rejection log. |
+| `.github/bug-hunt-state.json` | data | Sweep progress over **subsystems** (areas), not single files. |
+| `.github/bug-hunt/pattern-memory.md` | data | Positive learning: recurring root causes + bug-prone modules + per-lens checklists. |
+| `.github/bug-hunt/rejected-edits.jsonl` | data | Negative learning: false positives we closed. |
+| `.github/bug-hunt/gather_fixed_bugs.py` | script | Deterministically pulls merged bug-fix PRs + diffs for the learner. |
+| `.github/bug-hunt/build_rejection.py` | script | Rejection-log builder (from skill template). |
+| `.github/bug-hunt/README.md` | docs | Explains both memories. |
+| `.github/bug-hunt/tests/test_gather_fixed_bugs.py` | test | Light pytest for the collector. |
+| `.github/workflows/claude-issue-triage.yml` | **modified** | Add `bug-hunt` to the gate + a bug-hunt fix arm. |
+
+### Why "subsystems," not files
+Multi-lens bugs (a caller/callee mismatch, a contract drift, a race) span files.
+The sweep unit is a curated **area** — an enumerated list of ~12–16 subsystems
+defined in the hunter prompt. The state file tracks `areas_remaining` /
+`areas_audited` and advances one round at a time, same shape as `docs-audit` but
+coarser-grained.
+
+Initial area list (tune during build):
+`src/schedules`, `src/pages`, `src/collections` + `src/carousels`,
+`src/board_client*` + rendering (`board_chars`, `board_html_renderer`,
+`text_to_board`, `text_utils`), `src/plugins` loader/base + `plugins/*`,
+`src/api_server.py` routes, `src/auth` + `src/security`, `src/mqtt`,
+`src/triggers`, `src/displays`, `src/settings` + `config_manager`, `src/ai`,
+`src/backup` + `src/system` + `src/network`, `web/src/routes`, `web/src/lib`
+(API client + contract), `web/src/components` (state-heavy).
+
+---
+
+## 4. The daily hunt cycle (inside one `claude-code-action` run)
+
+```
+read state.json + pattern-memory.md + rejected-edits.jsonl
+        │
+        ▼
+pick this run's area batch (1–2 areas, queue-aware)
+        │
+        ▼
+FAN OUT — lens subagents (Task tool), in parallel, each read-only:
+   ├─ backend-logic & edge cases        (src/**, plugins/**)
+   ├─ error/exception handling
+   ├─ concurrency & shared state
+   ├─ Python↔TS API contract drift      (src/*/models.py ↔ web/src/lib/api.ts)
+   └─ security & input validation
+        │  each returns candidate bugs {area, lens, severity, trace, proposed repro}
+        │  each lens prompt is seeded with the relevant pattern-memory checklist
+        ▼
+DEDUP candidates against open `bug-hunt` issues
+   (gh issue list --label bug-hunt --state open --search "<key phrase>")
+        ▼
+VERIFY — for each candidate, N independent skeptic subagents try to REFUTE it
+   (trace real code paths; default to "refuted" when uncertain;
+    draft a failing repro — pytest for backend)
+        │  keep only survivors (majority cannot refute)
+        ▼
+FILE issues (labels: bug, bug-hunt, claude-fix) with the structured body schema
+   (see §7)
+        ▼
+advance state.json (move area→audited, set last_run_at) → commit [skip ci]
+```
+
+### Models
+Lenses + skeptics + orchestrator: Sonnet 4.6. (All model tiers are knobs.)
+
+### Compute envelope
+Per run: ~5 lens subagents + up to ~2–3 skeptics per surviving candidate, over
+1–2 areas. Bounded by `--max-turns` + `timeout-minutes` (30–45 min). Primary
+cost levers: lens count, areas/run, skeptic count — all tunable.
+
+---
+
+## 5. The two memories
+
+### Memory 1 — `pattern-memory.md` (positive learning)
+Human-readable markdown the learner maintains and the hunter reads. Three living
+sections:
+- **Recurring root-cause patterns** — generalized, not one-offs. e.g.
+  *"Naive timezone handling: schedules used server-local time instead of the
+  configured TZ (#1273 → #1280). Scrutinize every `datetime.now()` and tz
+  conversion."*
+- **Bug-prone modules** — areas ranked by historical fix count; tells the sweep
+  where to spend budget.
+- **Per-lens checklists** — class-specific "things that have actually bitten us,"
+  injected into each lens subagent's prompt.
+
+Carries a `last_learned_at` marker (frontmatter) so the learner's window is
+incremental.
+
+### Memory 2 — `rejected-edits.jsonl` (negative learning)
+The skill's standard mechanism. When a `bug-hunt/issue-*` fix PR is closed
+**unmerged**, the feedback workflow bundles its diff + every comment into one
+JSONL line. The hunter reads it each run: never re-file a refuted bug, and
+generalize the false-positive class (*"looked like a race, but guarded by lock
+Y — stop flagging this shape"*).
+
+**The two memories pull in opposite directions on purpose:** pattern-memory
+raises recall where bugs really live; rejected-edits raises precision by killing
+repeat false positives.
+
+---
+
+## 6. The weekly learner — `claude-bug-hunt-learn.yml`
+
+```
+gather_fixed_bugs.py  (deterministic, no model)
+   gh pr list --state merged --search "label:bug" since last_learned_at
+   → for each: linked issue (Closes #N / (#N)) + fix diff + files touched → JSON
+        │
+        ▼
+Claude (Sonnet) reads that JSON + current pattern-memory.md
+   → distills/updates root-cause patterns, re-ranks bug-prone modules,
+     extends per-lens checklists
+        │
+        ▼
+rewrite pattern-memory.md → commit [skip ci]  (advance last_learned_at)
+```
+
+Data-gathering is a deterministic script so the model only does distillation.
+`last_learned_at` bounds the window — incremental, not a full re-scan each week.
+
+---
+
+## 7. Issue body schema (also the Phase 2 hook)
+
+Every filed issue carries a machine-parseable header and exactly one fenced
+repro block, so Phase 2's executor can parse it with no rework:
+
+```
+## Bug-hunt finding
+
+- **area:** src/schedules
+- **lens:** concurrency
+- **severity:** high
+- **run:** round <N>, run <BRANCH_SUFFIX>
+
+### What's wrong
+<2–5 sentences>
+
+### Why it's real (trace)
+<code-path trace the skeptics could not refute, with file:line refs>
+
+### Repro
+```python
+# runnable pytest that fails against current code
+def test_...():
+    ...
+```
+
+### Suggested direction
+<2–5 sentences; not a full patch>
+```
+
+Labels: `bug`, `bug-hunt`, `claude-fix`. Reserved for Phase 2:
+`repro-confirmed`, `repro-failed`.
+
+---
+
+## 8. Handoff / review / feedback
+
+### Triage (modify existing `claude-issue-triage.yml`)
+- Add `bug-hunt` to the `labeled` gate (alongside `claude-fix`, `docs-audit`,
+  `a11y-audit`).
+- Add a **bug-hunt arm** to the prompt: branch `bug-hunt/issue-<N>-<slug>`,
+  **draft** PR, title `fix: …`. The worker lifts the issue's repro block into a
+  real failing test, implements the smallest fix, makes it pass with the suite
+  green, `Closes #N`.
+- Model tier already defaults to **Opus** for non-docs issues — no tier change
+  needed.
+
+### Review — `claude-bug-hunt-review.yml`
+- `pull_request_target` on code paths, but the **job `if:` is gated to head
+  branch `bug-hunt/issue-*`** so it reviews only the loop's own fix PRs, not
+  every code PR in the repo.
+- Read-only, base-ref checkout, `persist-credentials: false`,
+  `github_token: ${{ secrets.GITHUB_TOKEN }}` to bypass the OIDC App exchange,
+  `allowed_bots: 'claude,github-actions'`, `cancel-in-progress: true`.
+- Reviews the fix's correctness and that the repro test genuinely covers the bug.
+
+### Feedback — `claude-bug-hunt-feedback.yml`
+- `pull_request_target: closed` + `workflow_dispatch` (backfill).
+- Gated on `merged == false` AND `startsWith(head.ref, 'bug-hunt/issue-')`.
+- Runs `build_rejection.py`, commits the JSONL line `[skip ci]`,
+  `cancel-in-progress: false`.
+
+### Full data flow
+```
+        weekly                           daily
+   ┌──────────────┐              ┌──────────────────┐
+   │   LEARNER    │─writes──▶ pattern-memory.md ──read─▶│   HUNTER    │
+   └──────────────┘                                     │ (fan-out +  │
+          ▲                    rejected-edits.jsonl ─read─▶│  verify)   │
+          │ reads                      ▲                 └──────┬──────┘
+   merged bug-fix PRs                  │ writes                 │ files
+          ▲                     ┌──────────────┐         bug + bug-hunt + claude-fix
+          │                     │  FEEDBACK    │                │
+   merge ─┘                     └──────────────┘                ▼
+          ▲                            ▲                  ┌──────────┐
+          │                     close unmerged            │  ISSUE   │
+   ┌──────────────┐                    │                  └────┬─────┘
+   │ human merges │◀─review─┐          │                       │ claude-fix label
+   │   fix PR     │         │          │                       ▼
+   └──────────────┘   ┌─────────────┐  │                ┌──────────────┐
+                      │   REVIEW    │  └────────────────│ TRIAGE WORKER│
+                      └─────────────┘   draft fix PR ◀──│ (Opus, draft)│
+                                        bug-hunt/issue-*└──────────────┘
+```
+
+---
+
+## 9. Safety & error handling (applied from the skill's pitfalls)
+
+- **Concurrency:** `cancel-in-progress: false` on hunt, learn, feedback;
+  `true` on review.
+- **`show_full_output: 'true'`** on every Claude step.
+- **`BRANCH_SUFFIX: ${{ github.run_id }}`** kept even though issues-only (issue
+  bodies cite the run; never `date +%s`).
+- **`RELEASE_PAT`** for state + memory commits past branch protection, and as
+  `GH_TOKEN` for `gh issue create`. **`[skip ci]`** on all commit types.
+  **Defensive state push** as the final hunter step if Claude exits early.
+- **Time-gate** on local PT hour + **cooldown** (`last_run_at`, ~20h for a daily
+  cadence). `workflow_dispatch` bypasses both.
+- **`allowed_bots: 'claude,github-actions'`** on review/feedback;
+  `allowed_bots: 'claude'` already on triage.
+
+### Issues-only trims on the hunter
+- Permissions: `contents: write` (state/memory), `issues: write`,
+  `id-token: write` — **no `pull-requests: write`**.
+- Allowlist drops all `gh pr …` / branch tools and **adds `Task`** for subagent
+  fan-out. `Edit`/`Write` stay but a **hard rule restricts them to
+  `.github/bug-hunt-state.json` only** — the hunter never touches source.
+- Lens subagents are read-only (`Read,Glob,Grep,Bash(cat/find/grep/rg)`); only
+  the orchestrator writes state and calls `gh issue create`.
+
+### Precision governance
+- A candidate is filed only if a **majority of independent skeptics cannot
+  refute it**; skeptics default to "refuted" under uncertainty.
+- **Queue-aware effort:** drained → 2 areas + all 5 lenses + thorough;
+  hot (open `bug-hunt` issues over a ceiling) → 1 area + security/crash lenses +
+  high-confidence bar. A hard **open-issue ceiling silences filing** when the
+  queue is saturated (the issues-only analog of the draft cap).
+- Lenses target real defects, not style; low-severity nitpicks are dropped by
+  design.
+
+---
+
+## 10. Phase 2 (reserved, not built now)
+
+`claude-bug-hunt-verify.yml`: on the `bug-hunt` label, checkout →
+`./.github/actions/setup-python-deps` → parse the issue's repro block → run it
+via pytest. Label `repro-confirmed` (+ failing output comment) or `repro-failed`
+(likely false positive). This both hardens precision and hands the triage worker
+a ready failing test. The §7 schema and the two label names are reserved now so
+Phase 2 needs no rework.
+
+---
+
+## 11. Testing the loop itself
+
+- **Hunter:** a `dry_run` dispatch input that prints intended issues instead of
+  filing them — eyeball candidate quality on one known area before enabling the
+  cron.
+- **Learner acceptance test:** point `gather_fixed_bugs.py` at the known
+  #1273→#1280 timezone fix; confirm `pattern-memory.md` gains a sensible
+  timezone root-cause entry.
+- **Scripts:** `build_rejection.py` exercisable with `DRY_RUN=1` against a real
+  closed PR; `gather_fixed_bugs.py` gets a pytest under `.github/bug-hunt/tests/`
+  confirming it parses `Closes #N` / `(#N)` and emits the expected JSON.
+- **First live run:** watch the Actions log (`show_full_output`) for denials on
+  the new `Task` tool and subagent inheritance; confirm two back-to-back
+  dispatches don't double-file (cooldown + serialized concurrency).
+
+---
+
+## 12. Prerequisites & rollout
+
+- **Secrets:** `RELEASE_PAT`, `CLAUDE_CODE_OAUTH_TOKEN` — already used by the two
+  existing loops, so present.
+- **Rollout order:**
+  1. Land scripts + state + memory skeletons + the triage gate change.
+  2. Land the hunter with `dry_run` default-safe; dispatch once, inspect.
+  3. Enable the daily cron; watch false-positive rate for a week.
+  4. Land the learner; run once; verify pattern-memory updates.
+  5. Land review + feedback.
+  6. Once trusted, build Phase 2 (repro execution).
+
+---
+
+## 13. Open questions / risks
+
+- **`Task` subagent path is unexercised in this repo's workflows.** First run
+  must confirm `claude-code-action` admits the `Task` tool and that subagents
+  inherit read tools. Fallback if not: sequential multi-lens in one context
+  (no fan-out), or Option 3 (matrix of jobs).
+- **Frontend repro tests** are hard to execute in Phase 2 (Python pytest is
+  clean; TS logic bugs lean on reasoning + Playwright). Phase 2 execution
+  initially targets backend bugs only.
+- **Cost.** Daily multi-lens + adversarial verify is the heaviest of the three
+  loops. The queue-aware effort scaler and the lens/area/skeptic knobs are the
+  controls; start conservative.
+- **Area list churn.** As the codebase evolves the enumerated area list needs
+  occasional maintenance; acceptable, and visible in the prompt.


### PR DESCRIPTION
## What this adds

A third self-improving GitHub Actions loop — sibling of `docs-audit` and `a11y-audit` — that **proactively hunts for real functional bugs** so we find them before users do. It files high-trust issues, hands them to the existing triage worker for a human-reviewed **draft** fix, and learns from both the bugs we fix and the false positives we reject.

Design spec: `docs/superpowers/specs/2026-06-27-bug-hunt-loop-design.md`
Implementation plan: `docs/superpowers/plans/2026-06-27-bug-hunt-loop.md`

## How it works

```
daily hunter ─▶ fan out 5 read-only LENS subagents (Task tool)
                  backend-logic · error-handling · concurrency-state
                  · Python↔TS contract-drift · security-input
              ─▶ dedup ─▶ adversarial-verify with independent SKEPTIC subagents
                          (majority-refute gate; draft a failing repro)
              ─▶ file bug + bug-hunt + claude-fix issues (structured repro schema)
                  │
   triage worker ─┴▶ bug-hunt/issue-* DRAFT fix PR (Opus, TDD off the repro)
                  ─▶ auto-review ─▶ human merges  ·  close-unmerged ─▶ rejection log
weekly learner ─▶ mine merged bug-fixes ─▶ pattern-memory.md (where bugs live)
```

Two memories pull in opposite directions: **pattern-memory.md** (positive — raises recall) and **rejected-edits.jsonl** (negative — raises precision).

## Files

**New workflows**
- `claude-bug-hunt.yml` — daily issues-only hunter; multi-lens subagent fan-out + adversarial verify; queue-aware effort; `dry_run` dispatch input
- `claude-bug-hunt-learn.yml` — weekly; mines fixed bugs into pattern memory
- `claude-bug-hunt-review.yml` — auto-review gated to `bug-hunt/issue-*` PRs (reviews drafts)
- `claude-bug-hunt-feedback.yml` — rejection capture on closed-unmerged fix PRs

**Memory + scripts**
- `.github/bug-hunt-state.json` — subsystem ("area") sweep state
- `.github/bug-hunt/pattern-memory.md` — positive learning (seeded with the #1273 timezone pattern)
- `.github/bug-hunt/rejected-edits.jsonl` — negative learning (empty)
- `.github/bug-hunt/gather_fixed_bugs.py` (+ tests) — deterministic merged-fix collector
- `.github/bug-hunt/build_rejection.py` — rejection-log builder
- `.github/bug-hunt/README.md` — explains both memories

**Modified**
- `claude-issue-triage.yml` — adds `bug-hunt` to the label gate + a bug-fix arm (branch `bug-hunt/issue-*`, draft, TDD off the embedded repro). Non-docs issues already select Opus.

## Deviations from the docs-audit canonical pattern

- **Multi-lens subagent fan-out** (`Task` tool) instead of a single-context sweep — first use of subagents in this repo's workflows.
- **Adversarial verification** — skeptic subagents must fail to refute a candidate before it's filed.
- **Second "learner" cron** — positive learning from merged fixes, on top of the standard rejection log.
- **Issues-only hunter, draft fix PRs** — no bug fix lands without human sign-off.
- **Subsystem sweep** ("areas") rather than per-file, since functional bugs span files.

## Phase 2 (deferred, designed-in)

The issue body carries a machine-parseable header + a fenced `python` repro block. A future `claude-bug-hunt-verify.yml` will execute that repro via `setup-python-deps` and label issues `repro-confirmed` / `repro-failed`. Schema + label names are reserved; no rework needed.

## Validation done
- All 5 workflow YAMLs parse; guardrail audit passes (BRANCH_SUFFIX=run_id, show_full_output, cancel-in-progress, Task in allowlist, no `pull-requests:write` on hunter, `[skip ci]` + RELEASE_PAT on state/memory commits).
- `gather_fixed_bugs.py` unit tests pass; validated live against #1273→#1280 + 12 other fixed bugs.
- Confirmed `gh issue list --label bug-hunt` is safe before the label exists.

## First-run watch items
- **`Task` subagent path is unexercised here** — confirm `claude-code-action` admits it (the `show_full_output` log will show any denial). Fallback: sequential lenses in one context.
- Validate false-positive rate via `gh workflow run claude-bug-hunt.yml -f dry_run=true` before trusting the daily cron.
- First cron tick: daily ~12:07 PT. Manual: `gh workflow run claude-bug-hunt.yml`. Learner: `gh workflow run claude-bug-hunt-learn.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)