### PR TITLE
feat(ci): auto-fix failing CI and repair drift on automation PRs

### DIFF
--- a/.github/ci-autofix/README.md
+++ b/.github/ci-autofix/README.md
@@ -1,0 +1,65 @@
+# CI Auto-Fix & Drift Repair
+
+Two Claude-powered workflows that keep **automation-authored PRs**
+(`bug-hunt/*`, `docs/*`, `a11y/*`, `claude/*`) from sitting in a red or stale
+state. Both use the Sonnet model and push under the repo-installed GitHub App
+token so CI re-runs without the "Approve workflows" gate.
+
+| Workflow | Trigger | What it does |
+| --- | --- | --- |
+| [`claude-ci-autofix.yml`](../workflows/claude-ci-autofix.yml) | `workflow_run` — CI completed with `failure` on a PR | Reads the failing logs, attempts a fix, pushes it back to the PR branch. |
+| [`claude-pr-rebase.yml`](../workflows/claude-pr-rebase.yml) | `schedule` (every 3h) + `workflow_dispatch` | Finds bot PRs behind `main` or conflicting, merges `main` in (Claude only for conflicts). |
+
+## How the auto-fixer stays out of an infinite loop
+
+A fix push re-runs CI, which can re-trigger the fixer. Three guards bound it:
+
+1. **Staleness** — if a newer commit superseded the failing SHA, the run
+   bails (a newer CI run will fire for that commit).
+2. **Attempt cap (3)** — "attempts so far" is the count of consecutive
+   `[ci-autofix]` commits at the branch tip. Each fix push adds exactly one
+   such commit, so the counter needs no external state and **resets
+   automatically** when a non-`[ci-autofix]` commit lands (a human push or a
+   drift-repair merge). After 3 attempts the run stops, labels the PR
+   `autofix-exhausted`, flips the sticky comment to "gave up", and
+   @-mentions the maintainer.
+3. **No-push = no loop** — if Claude can't fix it and pushes nothing, CI
+   never re-runs, so the workflow can't re-fire on that SHA.
+
+> The `[ci-autofix]` tag in the commit subject is load-bearing. The prompt
+> requires it; without it the attempt counter breaks.
+
+## The sticky comment
+
+Each PR gets one status comment (marker `<!-- claude-ci-autofix:state -->`).
+The bootstrap step posts it immediately ("🔧 on it, attempt N/3") with an
+unchecked checklist; Claude edits the *same* comment in place, ticking items
+and adding an honest summary of what it changed and verified.
+
+## How drift repair stays cheap
+
+The cron sweep tries a plain `git merge origin/main` first. Clean merges
+push directly with **no Claude run**. Only genuine conflicts spin up Claude,
+which resolves *trivial* conflicts and otherwise aborts + labels the PR
+`needs-human-rebase` (skipped on future sweeps) so it never thrashes.
+
+## Labels
+
+| Label | Meaning |
+| --- | --- |
+| `autofix-exhausted` | The auto-fixer tried 3 times and gave up; needs a human. Push a new commit to reset its budget. |
+| `needs-human-rebase` | Drift repair found non-trivial conflicts; sweeps skip it until a human resolves them. |
+
+## Operating notes
+
+- **Manual dispatch (drift repair):** `gh workflow run claude-pr-rebase.yml`
+- **The auto-fixer can't be dispatched** — `workflow_run` only fires from the
+  workflow file on `main`, so it goes live only after this lands. Validate it
+  with a deliberately-broken automation PR after merge.
+- **Disable quickly:** `gh workflow disable "Claude: CI Auto-Fix"` /
+  `gh workflow disable "Claude: PR Drift Repair"`.
+- **First runs to watch:** check the Actions log for `--allowed-tools` denial
+  messages (they appear because `show_full_output: 'true'`), runaway attempt
+  counts, and false-confidence fixes that don't actually turn CI green.
+- **Scope:** both workflows act only on same-repo automation branches, never
+  on forks or human PRs.

--- a/.github/workflows/claude-ci-autofix.yml
+++ b/.github/workflows/claude-ci-autofix.yml
@@ -1,0 +1,287 @@
+name: 'Claude: CI Auto-Fix'
+
+# When CI fails on an automation-authored PR (bug-hunt/*, docs/*, a11y/*,
+# claude/* branches), spin up a Sonnet Claude run that reads the failing CI
+# logs, attempts a fix, and pushes it back to the PR branch — keeping bot
+# PRs out of a permanent red state.
+#
+# Trigger: workflow_run on the CI workflow completing. We act ONLY when the
+# run concluded `failure`, was triggered by a `pull_request` (not push /
+# merge_group), lives on an automation branch, and is NOT from a fork.
+# (workflow_run carries full secrets, so the fork guard is mandatory.)
+#
+# Loop safety — three guards, in order:
+#   1. Staleness: bail if a newer commit superseded the failing SHA (a newer
+#      CI run will fire for it).
+#   2. Attempt cap: the number of attempts so far is the count of consecutive
+#      `[ci-autofix]` commits at the branch tip. Each push adds exactly one
+#      such commit, so the counter is self-contained and survives across runs
+#      with no external state. It resets automatically when a NON-autofix
+#      commit lands (a human push or a drift-repair merge), giving the PR a
+#      fresh budget. After MAX_ATTEMPTS the run stops, flips the sticky
+#      comment to "gave up", labels the PR `autofix-exhausted`, and @-mentions
+#      the maintainer.
+#   3. A "bail without push" can never loop: no new commit means CI never
+#      re-runs, so this workflow can't re-fire on the same SHA.
+#
+# Identity: pushes use a repo-installed GitHub App token so the commit is
+# attributed to a trusted bot and CI re-runs WITHOUT the "Approve workflows"
+# gate (same pattern as claude.yml). The default GITHUB_TOKEN can't be used —
+# its pushes don't trigger the pull_request CI run at all.
+#
+# NOTE: workflow_run only triggers from the workflow file on the DEFAULT
+# branch. This workflow goes live only once merged to main; validate the
+# inner logic via a deliberately-broken test PR after merge.
+
+on:
+  workflow_run:
+    workflows: ['CI: Lint, Test & Build']
+    types: [completed]
+
+# Serialize per branch; don't cancel a fix mid-push. Staleness + the
+# commit-based counter handle superseded runs.
+concurrency:
+  group: claude-ci-autofix-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+  id-token: write
+
+jobs:
+  autofix:
+    # Gate: failed PR-triggered CI run, same-repo (not a fork), on an
+    # automation branch. Author isn't checkable in `if:` for workflow_run
+    # without an API call, but a fork can't push to our automation branches,
+    # so branch prefix + same-repo is a sufficient scope.
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name == github.repository &&
+      (
+        startsWith(github.event.workflow_run.head_branch, 'bug-hunt/') ||
+        startsWith(github.event.workflow_run.head_branch, 'docs/') ||
+        startsWith(github.event.workflow_run.head_branch, 'a11y/') ||
+        startsWith(github.event.workflow_run.head_branch, 'claude/')
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      BRANCH: ${{ github.event.workflow_run.head_branch }}
+      FAILED_RUN_ID: ${{ github.event.workflow_run.id }}
+      FAILED_RUN_URL: ${{ github.event.workflow_run.html_url }}
+      FAILED_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+      MAINTAINER: jeffredodd
+      MAX_ATTEMPTS: '3'
+    steps:
+      # Trusted-bot identity so the fix push skips the approval gate and
+      # re-triggers CI automatically (see header).
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.CLAUDE_BOT_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_BOT_APP_PRIVATE_KEY }}
+
+      - name: Checkout PR branch
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      # Resolve the PR, enforce the staleness + attempt-cap guards, and post
+      # the "on it" sticky comment BEFORE Claude spins up. Plain gh/bash —
+      # this is a normal run step, so no --allowed-tools allowlist applies.
+      - name: Bootstrap — resolve PR, enforce guards, post sticky comment
+        id: bootstrap
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          OWNER_REPO="$GITHUB_REPOSITORY"
+          MARKER="claude-ci-autofix:state"
+
+          # 1. Resolve the open PR for this branch.
+          PR_JSON=$(gh pr list --head "$BRANCH" --state open \
+            --json number,headRefOid --jq '.[0] // empty')
+          if [ -z "$PR_JSON" ]; then
+            echo "No open PR for branch $BRANCH — nothing to do."
+            echo "go=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          PR_NUMBER=$(jq -r '.number' <<<"$PR_JSON")
+          CURRENT_SHA=$(jq -r '.headRefOid' <<<"$PR_JSON")
+
+          # 2. Staleness guard — only act on the latest commit.
+          if [ "$CURRENT_SHA" != "$FAILED_HEAD_SHA" ]; then
+            echo "Failing SHA $FAILED_HEAD_SHA is stale (head is $CURRENT_SHA) — skipping."
+            echo "go=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+
+          # 3. Attempts so far = consecutive [ci-autofix] commits at the tip.
+          PREV=0
+          while IFS= read -r msg; do
+            case "$msg" in
+              *"[ci-autofix]"*) PREV=$((PREV + 1)) ;;
+              *) break ;;
+            esac
+          done < <(git log --format=%s HEAD)
+          ATTEMPT=$((PREV + 1))
+          echo "Prior autofix attempts: $PREV — this would be attempt $ATTEMPT/$MAX_ATTEMPTS."
+
+          # Find the sticky comment (for in-place updates). Body parsing is
+          # NOT used for the counter — purely to locate the comment to edit.
+          COMMENT_ID=$(gh api "repos/$OWNER_REPO/issues/$PR_NUMBER/comments" --paginate \
+            --jq "[.[] | select(.body | contains(\"$MARKER\"))] | .[-1].id // empty")
+
+          # 4. Cap check — escalate instead of attempting.
+          if [ "$ATTEMPT" -gt "$MAX_ATTEMPTS" ]; then
+            echo "Attempt $ATTEMPT exceeds cap $MAX_ATTEMPTS — escalating."
+            gh label create autofix-exhausted --color B60205 \
+              --description "CI auto-fix exhausted its attempts; needs a human" 2>/dev/null || true
+            gh pr edit "$PR_NUMBER" --add-label autofix-exhausted || true
+            read -r -d '' BODY <<EOF || true
+          <!-- $MARKER -->
+          ### ❌ CI auto-fix gave up
+
+          I tried **$MAX_ATTEMPTS times** to get CI green and it's still failing — this one needs a human.
+
+          @$MAINTAINER, over to you. Latest failing run: $FAILED_RUN_URL
+
+          > Push any new (non-autofix) commit to this branch to reset my budget and I'll try again.
+          EOF
+            if [ -n "$COMMENT_ID" ]; then
+              gh api -X PATCH "repos/$OWNER_REPO/issues/comments/$COMMENT_ID" -f body="$BODY" >/dev/null
+            else
+              gh pr comment "$PR_NUMBER" --body "$BODY" >/dev/null
+            fi
+            echo "go=false" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+
+          # A fresh attempt #1 means new non-autofix work landed — clear any
+          # stale exhausted label so the PR isn't visually stuck.
+          if [ "$ATTEMPT" -eq 1 ]; then
+            gh pr edit "$PR_NUMBER" --remove-label autofix-exhausted 2>/dev/null || true
+          fi
+
+          # 5. Post / update the "on it" sticky comment with an unchecked list.
+          read -r -d '' BODY <<EOF || true
+          <!-- $MARKER -->
+          ### 🔧 Auto-fixing CI — attempt $ATTEMPT of $MAX_ATTEMPTS
+
+          CI failed on this automation PR. I'm on it.
+
+          - [ ] Diagnose the failure
+          - [ ] Implement a fix
+          - [ ] Sanity-check the change
+          - [ ] Push the fix
+
+          Failing run: $FAILED_RUN_URL
+          EOF
+          if [ -n "$COMMENT_ID" ]; then
+            gh api -X PATCH "repos/$OWNER_REPO/issues/comments/$COMMENT_ID" -f body="$BODY" >/dev/null
+          else
+            URL=$(gh pr comment "$PR_NUMBER" --body "$BODY")
+            COMMENT_ID="${URL##*issuecomment-}"
+          fi
+
+          {
+            echo "go=true"
+            echo "pr_number=$PR_NUMBER"
+            echo "attempt=$ATTEMPT"
+            echo "comment_id=$COMMENT_ID"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run Claude Code (Sonnet) — attempt the fix
+        if: steps.bootstrap.outputs.go == 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # App token for all git/API ops: trusted-bot push (skips the gate,
+          # re-triggers CI) and bypasses the OIDC→claude[bot] exchange.
+          github_token: ${{ steps.app-token.outputs.token }}
+
+          # The failing CI run was triggered by the bot's push, so the
+          # workflow_run actor is a bot — without this the action's anti-bot
+          # guard rejects the run.
+          allowed_bots: 'claude,github-actions'
+
+          # Surface the transcript — without it, silent permission denials
+          # look like a clean (but no-op) success.
+          show_full_output: 'true'
+
+          additional_permissions: |
+            actions: read
+
+          prompt: |
+            CI just failed on an automation-authored pull request and your job
+            is to get it green. This is **attempt ${{ steps.bootstrap.outputs.attempt }}
+            of ${{ env.MAX_ATTEMPTS }}** — give it a real, full effort.
+
+            - PR: #${{ steps.bootstrap.outputs.pr_number }}
+            - Branch (already checked out): `${{ env.BRANCH }}`
+            - Failed CI run id: `${{ env.FAILED_RUN_ID }}`
+            - Failed CI run URL: ${{ env.FAILED_RUN_URL }}
+            - Status comment to keep updated: issue-comment id
+              `${{ steps.bootstrap.outputs.comment_id }}` on this repo
+
+            ## Steps
+
+            1. **Diagnose.** Read the failing logs:
+               `gh run view ${{ env.FAILED_RUN_ID }} --log-failed`
+               (and `gh run view ${{ env.FAILED_RUN_ID }}` for the job summary).
+               Identify the real root cause, not just the surface error.
+
+            2. **Fix it.** Implement the change that makes CI pass. Attempt a
+               full fix even if the cause is non-trivial — but stay within the
+               PURPOSE of this PR; do not rewrite what the PR is for:
+               - `bug-hunt/*` PRs are TDD'd around a repro test. NEVER delete,
+                 skip, weaken, or `xfail` that test to make CI green — fix the
+                 actual code so the repro passes. The repro staying meaningful
+                 is the whole point.
+               - `docs/*` and `a11y/*` PRs: keep the fix scoped to docs /
+                 accessibility; route any new user-facing string through
+                 next-intl (`web/messages/en.json`), never a hardcoded literal.
+               Follow every rule in CLAUDE.md.
+
+            3. **Sanity-check.** This runner is a bare checkout — full Docker
+               test suites aren't available. Verify what you reasonably can
+               (syntax, imports, a targeted unit test if its deps are present,
+               linters/formatters the failure was about). Do NOT claim a suite
+               passed if you didn't run it — the re-run of CI is the real
+               validation. Be honest about what you verified.
+
+            4. **Commit & push.** Make ONE commit whose subject MUST contain
+               the literal tag `[ci-autofix]` (this is how the attempt counter
+               works — without it the loop guard breaks). Example:
+                   `fix: <what you changed> [ci-autofix]`
+               Then `git push` to the PR branch. The push re-runs CI; if it
+               still fails, I'll fire again for the next attempt.
+
+            5. **Update the status comment.** Edit the sticky comment (do NOT
+               open a new one) to tick the checklist items you completed and
+               add a short, honest summary of what you changed and what you
+               verified. Keep the first line `<!-- claude-ci-autofix:state -->`
+               intact. Update it like:
+                   gh api -X PATCH \
+                     repos/${{ github.repository }}/issues/comments/${{ steps.bootstrap.outputs.comment_id }} \
+                     -f body="<new markdown>"
+
+            6. **If you genuinely cannot fix it:** do NOT push a junk change.
+               Update the sticky comment honestly — what's broken, what you
+               tried, and what a human should check — and stop. (No push means
+               CI won't re-run, so this won't loop.)
+
+            ## Hard rules
+            - Never force-push, never `--no-verify`, never `--no-gpg-sign`.
+            - Never push to `main`. Only push to the PR branch `${{ env.BRANCH }}`.
+            - Never merge or close the PR.
+            - Exactly one commit, and its subject must contain `[ci-autofix]`.
+
+          claude_args: >-
+            --model claude-sonnet-4-6
+            --max-turns 60
+            --allowed-tools "Read,Glob,Grep,Edit,Write,Bash(ls:*),Bash(cat:*),Bash(find:*),Bash(grep:*),Bash(rg:*),Bash(date:*),Bash(jq:*),Bash(python3:*),Bash(node:*),Bash(npm:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git fetch:*),Bash(git rev-parse:*),Bash(gh run view:*),Bash(gh run list:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh pr edit:*),Bash(gh api:*),Bash(gh label list:*),Bash(gh label create:*)"

--- a/.github/workflows/claude-pr-rebase.yml
+++ b/.github/workflows/claude-pr-rebase.yml
@@ -1,0 +1,175 @@
+name: 'Claude: PR Drift Repair'
+
+# Keeps open automation PRs (bug-hunt/*, docs/*, a11y/*, claude/*) current
+# with main so they don't rot in a BEHIND/CONFLICTING state.
+#
+# On a schedule it finds bot PRs that are behind main or have merge
+# conflicts, then for each:
+#   - Cheap path: merge `origin/main` in. If it merges cleanly, push. NO
+#     Claude run is spent on this — it's pure git.
+#   - Conflict path: spin up a Sonnet Claude run that resolves ONLY trivial,
+#     unambiguous conflicts and pushes. If the conflict needs real judgment,
+#     it aborts, labels the PR `needs-human-rebase` (skipped on future
+#     sweeps), comments why, and stops.
+#
+# We MERGE main in rather than literally rebase — history is preserved and
+# no force-push is ever needed. ("rebase" is kept only in the filename.)
+#
+# Composition: a merge push re-runs CI. If the now-current branch then fails
+# CI, claude-ci-autofix.yml picks it up. The merge commit is NOT tagged
+# `[ci-autofix]`, so it correctly resets that workflow's attempt budget.
+#
+# Identity: pushes use the repo-installed GitHub App token so CI re-runs
+# without the "Approve workflows" gate (same pattern as claude.yml). Branch
+# protection on `main` doesn't apply — we only ever push to PR branches.
+
+on:
+  schedule:
+    - cron: '17 */3 * * *' # every 3 hours
+  workflow_dispatch:
+
+# One sweep at a time; a dispatch during a scheduled sweep waits its turn.
+concurrency:
+  group: claude-pr-rebase
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.find.outputs.matrix }}
+      count: ${{ steps.find.outputs.count }}
+    steps:
+      - name: Find behind / conflicting automation PRs
+        id: find
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # mergeStateStatus can be UNKNOWN until GitHub computes mergeability;
+          # such PRs are simply skipped this sweep and caught on the next one.
+          gh pr list --state open --limit 100 \
+            --json number,headRefName,mergeStateStatus,labels > prs.json
+          MATRIX=$(jq -c '
+            [ .[]
+              | select(.headRefName | test("^(bug-hunt|docs|a11y|claude)/"))
+              | select([.labels[].name] | index("needs-human-rebase") | not)
+              | select(.mergeStateStatus == "BEHIND" or .mergeStateStatus == "DIRTY")
+              | {number, headRefName, mergeStateStatus}
+            ] | .[0:10]
+          ' prs.json)
+          COUNT=$(jq 'length' <<<"$MATRIX")
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          echo "matrix={\"include\":$MATRIX}" >> "$GITHUB_OUTPUT"
+          echo "Found $COUNT candidate PR(s) to repair."
+
+  repair:
+    needs: discover
+    if: needs.discover.outputs.count != '0'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      max-parallel: 3
+      fail-fast: false
+      matrix: ${{ fromJson(needs.discover.outputs.matrix) }}
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    env:
+      PR_NUMBER: ${{ matrix.number }}
+      BRANCH: ${{ matrix.headRefName }}
+      STATE: ${{ matrix.mergeStateStatus }}
+      MAINTAINER: jeffredodd
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.CLAUDE_BOT_APP_ID }}
+          private-key: ${{ secrets.CLAUDE_BOT_APP_PRIVATE_KEY }}
+
+      - name: Checkout PR branch
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ matrix.headRefName }}
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      # Cheap path: try a plain merge. Only conflicts fall through to Claude.
+      - name: Attempt clean merge of main
+        id: merge
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin main
+
+          if git merge-base --is-ancestor origin/main HEAD; then
+            echo "Already up to date with main — nothing to do."
+            echo "result=current" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+
+          if git merge --no-edit origin/main; then
+            git push origin "HEAD:$BRANCH"
+            echo "result=merged" >> "$GITHUB_OUTPUT"
+            gh pr comment "$PR_NUMBER" \
+              --body "🔄 Updated this branch with the latest \`main\` (clean merge). CI will re-run." || true
+          else
+            git merge --abort
+            echo "Merge conflicts — handing off to Claude."
+            echo "result=conflict" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run Claude Code (Sonnet) — resolve conflicts
+        if: steps.merge.outputs.result == 'conflict'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
+          allowed_bots: 'claude,github-actions'
+          show_full_output: 'true'
+          prompt: |
+            PR #${{ env.PR_NUMBER }} (branch `${{ env.BRANCH }}`, already
+            checked out) is behind `main` and a plain merge hit conflicts.
+            Bring it up to date — but only if the conflicts are trivial.
+
+            ## Steps
+
+            1. `git fetch origin main` then `git merge --no-edit origin/main`.
+            2. Inspect the conflicts. Resolve them ONLY if they are trivial and
+               unambiguous — e.g. version/changelog bumps, lockfiles, import
+               ordering, or edits to clearly separate regions of a file where
+               the correct resolution is obvious. Preserve BOTH sides' intent.
+            3. **If any conflict needs real judgment** (overlapping logic
+               changes, behaviour you'd have to reason about, anything you're
+               not confident resolving correctly): run `git merge --abort`,
+               then:
+                 - `gh label create needs-human-rebase --color D93F0B --description "Merge conflicts need manual resolution" 2>/dev/null || true`
+                 - `gh pr edit ${{ env.PR_NUMBER }} --add-label needs-human-rebase`
+                 - post a comment naming the conflicting files and why a human
+                   is needed, @-mentioning ${{ env.MAINTAINER }}
+               and STOP. Do not force a risky resolution.
+            4. If you resolved cleanly: confirm no conflict markers remain
+               (`git diff --check`), `git add -A`, `git commit --no-edit`,
+               then `git push` to the PR branch. Post a short comment
+               summarizing what conflicted and how you resolved it. CI will
+               re-run automatically.
+
+            ## Hard rules
+            - Never force-push, never `--no-verify`. Never push to `main`.
+            - Never merge or close the PR itself.
+            - When in doubt, abort and label `needs-human-rebase` — a wrong
+              auto-resolution is worse than asking a human.
+
+          claude_args: >-
+            --model claude-sonnet-4-6
+            --max-turns 40
+            --allowed-tools "Read,Glob,Grep,Edit,Write,Bash(ls:*),Bash(cat:*),Bash(find:*),Bash(grep:*),Bash(rg:*),Bash(date:*),Bash(jq:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git add:*),Bash(git commit:*),Bash(git merge:*),Bash(git push:*),Bash(git fetch:*),Bash(git checkout:*),Bash(git rev-parse:*),Bash(gh pr view:*),Bash(gh pr comment:*),Bash(gh pr edit:*),Bash(gh api:*),Bash(gh label list:*),Bash(gh label create:*)"


### PR DESCRIPTION
## What & why

Automation-authored PRs (`bug-hunt/*`, `docs/*`, `a11y/*`, `claude/*`) too often sit in a **red CI** state or rot **behind `main`**, needing manual nudges. This adds two Sonnet-powered workflows that close that loop automatically, scoped strictly to same-repo automation branches.

## `claude-ci-autofix.yml` — event-driven fixer

- **Trigger:** `workflow_run` on `CI: Lint, Test & Build` completing with `failure`, gated to a `pull_request`-triggered, **same-repo** (fork-guarded) automation branch. This is exactly "all CI jobs stopped and the `CI Success` gate failed."
- **Flow:** a plain bootstrap step posts an *"on it"* sticky comment **immediately** with a checklist, then Claude reads the failing logs (`gh run view --log-failed`), fixes, and pushes to the PR branch. It edits the *same* comment as it works (ticking the checklist) and adds an honest summary.
- **Identity:** pushes under the repo-installed GitHub App token, so CI re-runs **without** the "Approve workflows" gate (same pattern as `claude.yml`).

### Loop safety (the important part)
1. **Staleness** — bail if a newer commit superseded the failing SHA.
2. **Attempt cap = 3** — "attempts so far" is the count of consecutive `[ci-autofix]` commits at the branch tip. No external state; **auto-resets** when a non-autofix commit lands (human push or a drift-repair merge). After 3 → label `autofix-exhausted`, flip the comment to "gave up", `@`-mention `@jeffredodd`.
3. **No push can't loop** — if Claude can't fix it and pushes nothing, CI never re-runs, so the workflow can't re-fire on that SHA.

Per your call, it attempts a **full** fix on every failure (incl. `bug-hunt/*`), with one guardrail in the prompt: never neuter a bug-hunt repro test to force green — fix the actual code.

## `claude-pr-rebase.yml` — cron drift repair

- **Trigger:** every 3h + `workflow_dispatch`.
- **Flow:** discover open automation PRs that are `BEHIND`/`DIRTY` (skip `needs-human-rebase`) → for each, try a plain `git merge origin/main` (**no Claude** on clean merges) → only real conflicts spin up Claude, which resolves *trivial* conflicts and otherwise aborts + labels `needs-human-rebase` + comments.
- **Merges, never rebases** — history preserved, no force-push. A merge push re-runs CI; if it then fails, the auto-fixer above picks it up. The merge commit isn't `[ci-autofix]`-tagged, so it correctly hands a fresh attempt budget to the fixer.

## New labels
- `autofix-exhausted` — fixer gave up after 3 tries; push any commit to reset.
- `needs-human-rebase` — conflicts need a human; sweeps skip it.

## Validation done
- Both workflows parse as YAML (Ruby Psych).
- Every embedded `run:` block extracted via the YAML parser and passes `bash -n` (heredoc dedent verified).
- Unit-tested the consecutive-`[ci-autofix]` attempt counter (fresh=0, 2 prior=2, merge breaks the chain, non-autofix tip=0).
- Validated the `discover` jq filter + matrix shape against a mock PR list (correctly includes only in-scope BEHIND/DIRTY, excludes labeled / human / CLEAN / UNKNOWN).

## ⚠️ Activation note
`workflow_run` only triggers from the workflow file **on `main`**, so the auto-fixer goes live **only after this merges**. Recommended: after merge, open a deliberately-broken automation PR to watch one full attempt cycle. The drift-repair workflow can be exercised immediately via `gh workflow run claude-pr-rebase.yml`.

Maintainer docs: `.github/ci-autofix/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)