### PR TITLE
fix: harden collections + sibling JSON stores against data-loss bugs (#1313)

### DIFF
--- a/src/collections/storage.py
+++ b/src/collections/storage.py
@@ -6,6 +6,7 @@ legacy ``data/carousels.json`` file (carousel: prefixed IDs, flat
 ``interval_seconds``) into the new collection format on first run.
 """
 
+import contextlib
 import json
 import logging
 import shutil
@@ -72,6 +73,11 @@ class CollectionStorage:
             self.storage_file = Path(storage_file)
 
         self._collections: dict[str, Collection] = {}
+        # Raw entries (post-migration) that failed Pydantic validation on load.
+        # Round-tripped through _save so a transient parsing failure (e.g. a
+        # bug in a migration, a renamed enum value) never silently deletes a
+        # user's collection from disk. Mirrors src/pages/storage.py (#1305).
+        self._failed_entries: list[dict] = []
         self._load()
 
         logger.info(f"CollectionStorage initialized (file: {self.storage_file}, collections: {len(self._collections)})")
@@ -142,11 +148,21 @@ class CollectionStorage:
         # Hydrate in-memory cache directly from the converted records so the
         # caller does not have to re-read the file we are about to write.
         self._collections = {}
+        self._failed_entries = []
         for record in converted:
+            # Snapshot before datetime coercion so a record that fails Pydantic
+            # validation is round-tripped untouched rather than silently dropped.
+            raw_snapshot = dict(record) if isinstance(record, dict) else record
             try:
                 self._hydrate_record(record)
             except Exception as e:
-                logger.warning(f"Failed to load imported collection: {e}")
+                record_id = raw_snapshot.get("id", "<unknown>") if isinstance(raw_snapshot, dict) else "<unknown>"
+                logger.warning(
+                    "Failed to load imported collection %s; preserving raw entry to avoid data loss: %s",
+                    record_id,
+                    e,
+                )
+                self._failed_entries.append(raw_snapshot)
 
         # Move the legacy file aside so the import is a one-shot operation.
         try:
@@ -177,6 +193,7 @@ class CollectionStorage:
 
         if not self.storage_file.exists():
             self._collections = {}
+            self._failed_entries = []
             return
 
         try:
@@ -185,16 +202,34 @@ class CollectionStorage:
         except (OSError, json.JSONDecodeError) as e:
             logger.warning(f"Failed to load collections file: {e}")
             self._collections = {}
+            self._failed_entries = []
             return
 
         needs_save = self._run_migrations(data)
 
         self._collections = {}
+        self._failed_entries = []
         for record in data.get("collections", []):
+            # Snapshot before datetime coercion so we can round-trip the entry
+            # untouched if Pydantic validation fails below.
+            raw_snapshot = dict(record) if isinstance(record, dict) else record
             try:
                 self._hydrate_record(record)
             except Exception as e:
-                logger.warning(f"Failed to load collection: {e}")
+                record_id = raw_snapshot.get("id", "<unknown>") if isinstance(raw_snapshot, dict) else "<unknown>"
+                logger.error(
+                    "Failed to parse collection %s; preserving raw entry to avoid data loss: %s",
+                    record_id,
+                    e,
+                )
+                self._failed_entries.append(raw_snapshot)
+
+        if self._failed_entries:
+            logger.error(
+                "Collections load preserved %d unparseable entr%s as-is in storage",
+                len(self._failed_entries),
+                "y" if len(self._failed_entries) == 1 else "ies",
+            )
 
         logger.info(f"Loaded {len(self._collections)} collections from storage")
 
@@ -203,6 +238,12 @@ class CollectionStorage:
             logger.info("Saved migrated collections to storage")
 
     def _save(self) -> None:
+        """Save collections to storage file.
+
+        Writes to a sibling ``<file>.tmp`` and ``os.replace``s it into place so
+        a mid-write crash (OOM, SIGKILL, power loss) never leaves a truncated
+        file that would wipe in-memory state on reload (see #1304).
+        """
         try:
             records = []
             for c in self._collections.values():
@@ -213,12 +254,26 @@ class CollectionStorage:
                     record["updated_at"] = record["updated_at"].isoformat()
                 records.append(record)
 
+            # Round-trip any entries that failed to parse on load so a follow-up
+            # save doesn't quietly delete them from disk (see #1305).
+            records.extend(self._failed_entries)
+
             data = {
                 "schema_version": CURRENT_SCHEMA_VERSION,
                 "collections": records,
             }
-            with open(self.storage_file, "w") as f:  # noqa: PTH123
-                json.dump(data, f, indent=2)
+
+            tmp_path = self.storage_file.with_suffix(self.storage_file.suffix + ".tmp")
+            try:
+                with open(tmp_path, "w") as f:  # noqa: PTH123
+                    json.dump(data, f, indent=2)
+                tmp_path.replace(self.storage_file)
+            except BaseException:
+                # Clean up the partial tmp file on any failure so we don't leak
+                # it; the original storage file stays untouched.
+                with contextlib.suppress(OSError):
+                    tmp_path.unlink(missing_ok=True)
+                raise
 
             logger.debug(f"Saved {len(self._collections)} collections to storage")
         except OSError as e:

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -8,6 +8,7 @@ Supports:
 - Plugin system (config.plugins.*) for data source integrations
 """
 
+import contextlib
 import json
 import logging
 import os
@@ -706,10 +707,24 @@ class ConfigManager:
         logger.info(f"Plugin rename migration complete: {len(renamed)} plugin(s) processed")
 
     def _save_internal(self) -> None:
-        """Internal save without acquiring lock (called from locked context)."""
+        """Internal save without acquiring lock (called from locked context).
+
+        Writes to a sibling ``<file>.tmp`` and ``os.replace``s it into place so
+        a mid-write crash (OOM, SIGKILL, power loss) never leaves a truncated
+        config file (see #1304).
+        """
         try:
-            with self._config_path.open("w") as f:
-                json.dump(self._config, f, indent=2)
+            tmp_path = self._config_path.with_suffix(self._config_path.suffix + ".tmp")
+            try:
+                with tmp_path.open("w") as f:
+                    json.dump(self._config, f, indent=2)
+                tmp_path.replace(self._config_path)
+            except BaseException:
+                # Clean up the partial tmp file on any failure so we don't leak
+                # it; the original config file stays untouched.
+                with contextlib.suppress(OSError):
+                    tmp_path.unlink(missing_ok=True)
+                raise
             logger.debug(f"Saved config to {self._config_path}")
         except OSError as e:
             logger.error(f"Failed to save config: {e}")

--- a/src/settings/service.py
+++ b/src/settings/service.py
@@ -4,6 +4,7 @@ This service allows runtime modification of settings like transition
 animations and output targets, which can be controlled from the UI.
 """
 
+import contextlib
 import json
 import logging
 import os
@@ -500,11 +501,28 @@ class SettingsService:
             return
 
         try:
-            with open(self.settings_file, "w") as f:  # noqa: PTH123
-                json.dump(data, f, indent=2)
+            self._atomic_write_json(data)
             logger.info(f"Migrated {changed} carousel: -> collection: reference(s) in settings.json")
         except OSError as e:
             logger.warning(f"Could not write migrated settings: {e}")
+
+    def _atomic_write_json(self, data: dict) -> None:
+        """Write *data* to ``settings_file`` atomically (tmp + os.replace).
+
+        A mid-write crash (OOM, SIGKILL, power loss) never truncates the real
+        file — it stays untouched until the temp file is fully written and
+        renamed over it (see #1304). Uses builtins.open on the tmp path so
+        existing tests can patch builtins.open to inject write errors.
+        """
+        tmp_path = self.settings_file.with_suffix(self.settings_file.suffix + ".tmp")
+        try:
+            with open(tmp_path, "w") as f:  # noqa: PTH123
+                json.dump(data, f, indent=2)
+            tmp_path.replace(self.settings_file)
+        except BaseException:
+            with contextlib.suppress(OSError):
+                tmp_path.unlink(missing_ok=True)
+            raise
 
     def _load_from_file(self) -> dict:
         """Load settings from JSON file."""
@@ -535,10 +553,7 @@ class SettingsService:
                 "plugins": self._plugins.to_dict(),
                 "temporary_override": self._temporary_override.to_dict() if self._temporary_override else None,
             }
-            # Use builtins.open (not Path.open) so existing tests can
-            # patch builtins.open to inject write errors.
-            with open(self.settings_file, "w") as f:  # noqa: PTH123
-                json.dump(data, f, indent=2)
+            self._atomic_write_json(data)
             logger.debug("Settings saved to file")
         except OSError as e:
             logger.error(f"Failed to save settings file: {e}")

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -462,6 +462,89 @@ class TestCollectionStorage:
             data = json.load(f)
         assert data["schema_version"] == 1
 
+    def test_migration_save_preserves_unparseable_entries(self, tmp_path):
+        """Regression for #1313 (mirrors #1305): an entry that fails Pydantic
+        validation during the post-migration save must NOT be silently dropped
+        from the file."""
+        import json
+
+        path = tmp_path / "collections.json"
+        # No schema_version => triggers v0 -> CURRENT migration, which resaves.
+        data = {
+            "collections": [
+                {"id": "collection:good", "name": "Good", "page_ids": ["p1", "p2"]},
+                {"id": "collection:bad", "broken_field": True},  # no name => invalid
+            ],
+        }
+        path.write_text(json.dumps(data))
+
+        storage = CollectionStorage(str(path))
+        assert storage.get("collection:good") is not None
+        assert storage.get("collection:bad") is None  # not in the in-memory cache
+
+        on_disk = json.loads(path.read_text())
+        on_disk_ids = {e["id"] for e in on_disk["collections"] if isinstance(e, dict) and "id" in e}
+        assert "collection:bad" in on_disk_ids, "migration save silently dropped the invalid entry"
+        assert "collection:good" in on_disk_ids
+
+    def test_post_load_save_preserves_unparseable_entries(self, tmp_path):
+        """An ordinary save (create/update/delete) after a load that encountered
+        an unparseable entry must also preserve that entry on disk."""
+        import json
+
+        path = tmp_path / "collections.json"
+        data = {
+            "schema_version": 1,  # already current; no migration
+            "collections": [
+                {"id": "collection:good", "name": "Good", "page_ids": ["p1"]},
+                {"id": "collection:bad", "broken_field": True},  # fails validation
+            ],
+        }
+        path.write_text(json.dumps(data))
+
+        storage = CollectionStorage(str(path))
+        storage.create(Collection(name="New", page_ids=["p3"]))  # triggers a normal save
+
+        on_disk = json.loads(path.read_text())
+        on_disk_ids = {e["id"] for e in on_disk["collections"] if isinstance(e, dict) and "id" in e}
+        assert "collection:bad" in on_disk_ids, "subsequent save dropped the unparseable entry"
+        assert "collection:good" in on_disk_ids
+
+    def test_save_is_atomic_on_mid_write_crash(self, tmp_path, monkeypatch):
+        """Regression for #1313 (mirrors #1304): a crash inside _save() must not
+        corrupt the existing file. The atomic tmp + os.replace pattern keeps the
+        on-disk file intact until the rename succeeds, so reload still finds the
+        original data."""
+        import json
+
+        from src.collections import storage as storage_module
+
+        path = tmp_path / "collections.json"
+        storage = CollectionStorage(str(path))
+        storage.create(Collection(name="KeepMe", page_ids=["p1"]))
+        assert storage.count() == 1
+        original_bytes = path.read_bytes()
+
+        real_dump = json.dump
+
+        def crashing_dump(obj, fh, *args, **kwargs):
+            fh.write('{"collections": [{"id": "abc"')
+            fh.flush()
+            raise OSError("Simulated crash mid-write")
+
+        monkeypatch.setattr(storage_module.json, "dump", crashing_dump)
+        with pytest.raises(OSError):
+            storage._save()
+        monkeypatch.setattr(storage_module.json, "dump", real_dump)
+
+        # The original file must be byte-identical — the crash should have hit a
+        # .tmp file that never got renamed over the real one.
+        assert path.read_bytes() == original_bytes
+
+        reloaded = CollectionStorage(str(path))
+        assert reloaded.count() == 1
+        assert reloaded.list_all()[0].name == "KeepMe"
+
 
 # =============================================================================
 # Legacy carousels.json migration
@@ -520,6 +603,33 @@ class TestLegacyCarouselImport:
         assert not legacy_path.exists()
         assert (tmp_path / "carousels.json.pre-collections-backup").exists()
         assert collections_path.exists()
+
+    def test_legacy_import_preserves_unparseable_entries(self, tmp_path):
+        """Regression for #1313: a legacy carousel that fails to convert/validate
+        must still be round-tripped into collections.json, not silently dropped."""
+        import json
+
+        legacy_path = tmp_path / "carousels.json"
+        collections_path = tmp_path / "collections.json"
+        legacy_path.write_text(
+            json.dumps(
+                {
+                    "carousels": [
+                        {"id": "carousel:good", "name": "Good", "page_ids": ["p1"], "interval_seconds": 20},
+                        {"id": "carousel:bad", "interval_seconds": 30},  # no name => invalid
+                    ]
+                }
+            )
+        )
+
+        storage = CollectionStorage(str(collections_path))
+        assert storage.get("collection:good") is not None
+        assert storage.get("collection:bad") is None
+
+        on_disk = json.loads(collections_path.read_text())
+        on_disk_ids = {e["id"] for e in on_disk["collections"] if isinstance(e, dict) and "id" in e}
+        assert "collection:bad" in on_disk_ids, "legacy import silently dropped the invalid carousel"
+        assert "collection:good" in on_disk_ids
 
 
 # =============================================================================

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1177,3 +1177,33 @@ def test_version_changed_on_load_false_corrupt_config(tmp_path, monkeypatch):
     cfg.write_text("not valid json {{{")
     cm = ConfigManager(config_path=str(cfg))
     assert cm.version_changed_on_load is False
+
+
+def test_save_internal_is_atomic_on_mid_write_crash(tmp_path, monkeypatch):
+    """Regression for #1313 (mirrors #1304): a crash inside _save_internal()
+    must not corrupt the existing config file. The atomic tmp + os.replace
+    pattern keeps the on-disk file intact until the rename succeeds.
+    """
+    from src import config_manager as cm_module
+
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"board": {}, "features": {}, "general": {}}))
+    cm = ConfigManager(config_path=str(config_path))
+    cm._save_internal()  # normalize on-disk content
+    original_bytes = config_path.read_bytes()
+
+    real_dump = json.dump
+
+    def crashing_dump(obj, fh, *args, **kwargs):
+        fh.write('{"board": {')
+        fh.flush()
+        raise OSError("Simulated crash mid-write")
+
+    monkeypatch.setattr(cm_module.json, "dump", crashing_dump)
+    with pytest.raises(OSError):
+        cm._save_internal()
+    monkeypatch.setattr(cm_module.json, "dump", real_dump)
+
+    # The original file must be byte-identical — the crash should have hit a
+    # .tmp file that never got renamed over the real one.
+    assert config_path.read_bytes() == original_bytes

--- a/tests/test_settings_service.py
+++ b/tests/test_settings_service.py
@@ -312,6 +312,28 @@ class TestSettingsServiceInit:
         with patch("builtins.open", side_effect=OSError("write error")):
             settings_service._save_to_file()  # Should not raise
 
+    def test_save_to_file_is_atomic_on_mid_write_crash(self, settings_service, settings_file, monkeypatch):
+        """Regression for #1313 (mirrors #1304): a crash inside _save_to_file()
+        must not corrupt the existing settings file. The atomic tmp + os.replace
+        pattern keeps the on-disk file intact until the rename succeeds."""
+        from src.settings import service as service_module
+
+        settings_service._save_to_file()
+        original_bytes = Path(settings_file).read_bytes()
+
+        real_dump = json.dump
+
+        def crashing_dump(obj, fh, *args, **kwargs):
+            fh.write('{"transitions": {')
+            fh.flush()
+            raise OSError("Simulated crash mid-write")
+
+        monkeypatch.setattr(service_module.json, "dump", crashing_dump)
+        settings_service._save_to_file()  # swallows OSError; must not corrupt file
+        monkeypatch.setattr(service_module.json, "dump", real_dump)
+
+        assert Path(settings_file).read_bytes() == original_bytes
+
 
 class TestSettingsServiceTransitions:
     """Test SettingsService transition settings."""


### PR DESCRIPTION
Fixes #1313.

Follow-up to the pages/schedules hardening (#1304/#1305/#1309/#1311). The two data-loss modes those PRs fixed for `pages`/`schedules` still existed in the sibling JSON stores. This applies the same fixes.

## 1. Silent-drop of unparseable entries on save (mirrors #1305/#1311)

`CollectionStorage._load()` caught per-record Pydantic failures and continued, while `_save()` serialized only `self._collections.values()` — so any migration- or CRUD-triggered save permanently dropped the failed raw record from disk.

Applied the `_failed_entries` pattern from `src/pages/storage.py`:
- snapshot unparseable raw dicts in `_load()` (before datetime coercion),
- reset the list per load,
- re-append them in `_save()` so they round-trip back to disk untouched.

Covered **both** drop sites the issue called out: the normal `_load()` loop **and** the legacy `carousels.json` import path.

## 2. Non-atomic writes (mirrors #1304/#1309)

Converted the direct `open(path, "w") + json.dump` writes to the tmp-file + `os.replace` atomic pattern, so a mid-write crash (OOM/SIGKILL/power loss) leaves the original file intact instead of truncating it:

- `src/collections/storage.py` — `_save()`
- `src/settings/service.py` — carousel-ref migration write **and** `_save_to_file()` (via a new `_atomic_write_json` helper; keeps `builtins.open` so existing IO-error tests still patch correctly)
- `src/config_manager.py` — `_save_internal()`

**Already atomic, left unchanged** (the issue's line refs were stale): `src/auth/service.py::_save` already uses tmp + `fsync` + `replace`, and the `config_manager` pre-update snapshot (~`:527`) already uses tmp + `replace`.

## Tests

New regression tests, mirroring the #1304/#1305 tests for pages/schedules:

- `test_collections.py`: unparseable-entry preservation across **migration save**, **post-load save**, and **legacy import**; plus **mid-write-crash atomicity**.
- `test_settings_service.py`: mid-write-crash atomicity for `_save_to_file`.
- `test_config_manager.py`: mid-write-crash atomicity for `_save_internal`.

All 6 new tests verified RED before the fix and GREEN after. Full runs of `test_collections.py`, `test_settings_service.py`, `test_config_manager.py`, `test_pages.py`, `test_schedules_storage.py` pass (429 passed). `ruff check` and `ruff format --check` clean on all changed files.

## Acceptance

- [x] `CollectionStorage` preserves unparseable records across save (regression test, mirrors #1311)
- [x] All listed JSON stores use atomic tmp+replace writes (regression tests; auth + config snapshot were already atomic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)