### PR TITLE
fix(pi-image): pin FiestaPi kernel to 6.12 LTS + pre-publish verify gate

### DIFF
--- a/.github/workflows/build-fiestapi.yml
+++ b/.github/workflows/build-fiestapi.yml
@@ -187,6 +187,77 @@ jobs:
           # 30 days — weekly builds rotate frequently; grab the latest.
           retention-days: 30
 
+      - name: Verify image — block known-bad packages before publishing
+        # Pre-publish gate. We build from an unpinned Trixie base, so an
+        # upstream regression can ride into the image silently (it has: the
+        # raspi-firmware #2034 Pi-3 brick, and the 6.18.x kernel that breaks
+        # Pi 3B+ ethernet, #7436). This loop-mounts the freshly built .img and
+        # FAILS the build — before any release attach — if it would ship a
+        # known-bad kernel/firmware or is missing Pi-3 boot files. The artifact
+        # upload above already ran, so a failed image is still downloadable for
+        # debugging; it just never reaches a published release.
+        # Keep the denylist in sync with pi-image/stage-fiestaboard/00-pin-kernel.
+        run: |
+          set -euo pipefail
+          # Reclaim scratch from pi-gen's work dir (build logs already uploaded).
+          sudo rm -rf pi-gen/work || true
+
+          IMG_XZ="${{ steps.out.outputs.img }}"
+          RAW="${IMG_XZ%.xz}"
+          # Keep the .xz — the release-attach steps below still need it.
+          xz -dkf "$IMG_XZ"
+
+          LOOP=$(sudo losetup --show -fP "$RAW")
+          MNT=$(mktemp -d)
+          cleanup() {
+            sudo umount "$MNT/boot/firmware" 2>/dev/null || true
+            sudo umount "$MNT" 2>/dev/null || true
+            sudo losetup -d "$LOOP" 2>/dev/null || true
+            sudo rm -f "$RAW" 2>/dev/null || true
+          }
+          trap cleanup EXIT
+
+          # RPi OS layout: p1 = FAT boot (/boot/firmware), p2 = ext4 root.
+          sudo mount "${LOOP}p2" "$MNT"
+          sudo mount "${LOOP}p1" "$MNT/boot/firmware"
+
+          dq() { sudo dpkg-query --admindir="$MNT/var/lib/dpkg" -W -f="$1" "$2" 2>/dev/null || true; }
+          fail=0
+
+          # (1) raspi-firmware 1:1.20260521-2 bricks Pi 3 boot (raspberrypi/firmware#2034).
+          RF=$(dq '${Version}' raspi-firmware)
+          echo "raspi-firmware: ${RF:-<none>}"
+          if [ "$RF" = "1:1.20260521-2" ]; then
+            echo "::error::Image ships raspi-firmware 1:1.20260521-2 — bricks Pi 3 boot (firmware#2034)."
+            fail=1
+          fi
+
+          # (2) Kernel must be 6.12 LTS, not the 6.18.x that breaks Pi 3B+ ethernet (linux#7436).
+          KERNELS=$(dq '${Package} ${Version}\n' 'linux-image-*' | grep -E 'rpi-(v8|2712)' || true)
+          echo "kernels in image:"; echo "${KERNELS:-<none>}"
+          if printf '%s\n' "$KERNELS" | grep -q 'linux-image-6\.18'; then
+            echo "::error::Image ships a 6.18.x kernel — breaks Pi 3B+ wired ethernet (linux#7436). Kernel pin did not take."
+            fail=1
+          fi
+          if ! printf '%s\n' "$KERNELS" | grep -q 'linux-image-6\.12'; then
+            echo "::error::No 6.12 LTS kernel found in image — kernel pin did not take."
+            fail=1
+          fi
+
+          # (3) Pi-3 boot files must be present (catches firmware#2034-class missing boot files).
+          for f in start.elf kernel8.img bcm2710-rpi-3-b.dtb; do
+            if [ ! -f "$MNT/boot/firmware/$f" ]; then
+              echo "::error::Missing /boot/firmware/$f — Pi 3 would not boot."
+              fail=1
+            fi
+          done
+
+          if [ "$fail" -ne 0 ]; then
+            echo "Image verification FAILED — not publishing this image."
+            exit 1
+          fi
+          echo "Image verification passed."
+
       - name: Resolve target app release tag
         # Skip on workflow_dispatch from non-default branches: a manual
         # build from a feature branch should produce a verifiable artifact

--- a/pi-image/README.md
+++ b/pi-image/README.md
@@ -6,7 +6,12 @@ A flashable Raspberry Pi OS image with FiestaBoard pre-installed and self-updati
 
 ## What's in the image
 
-- Raspberry Pi OS Lite (64-bit, latest stable release)
+- Raspberry Pi OS Lite (64-bit, Trixie)
+- **Kernel pinned to the 6.12 LTS series.** Trixie's default 6.18.x kernel regressed the
+  lan78xx driver and breaks wired ethernet on the Pi 3B+ ([raspberrypi/linux#7436](https://github.com/raspberrypi/linux/issues/7436)).
+  FiestaPi holds the last-known-good `6.12.75` until that's fixed upstream — see
+  `stage-fiestaboard/00-pin-kernel/`. Remove that stage (and the apt pin it writes) once
+  #7436 is resolved.
 - Docker + Docker Compose (apt + convenience repo)
 - FiestaBoard, pre-pulled and configured to start on boot
 - `fiestaupdater` sidecar enabled by default — Settings → Update Now works immediately
@@ -46,6 +51,16 @@ Built by `.github/workflows/build-fiestapi.yml` on three triggers:
 
 Output is uploaded as a workflow artifact (`FiestaPi-<version>-arm64`) and, for tag builds, attached to the GitHub Release as `FiestaPi-<version>-arm64.img.xz`.
 
+**Pre-publish verification gate.** Because the image is built from a moving Trixie base
+(`apt` pulls live packages on every build), an upstream regression can ride into the image
+silently — it has before (the raspi-firmware [#2034](https://github.com/raspberrypi/firmware/issues/2034)
+Pi-3 boot brick, the 6.18.x [#7436](https://github.com/raspberrypi/linux/issues/7436) Pi 3B+
+ethernet break). The workflow now loop-mounts the freshly built `.img` and **fails before any
+release attach** if it ships a known-bad kernel/firmware version or is missing the Pi-3 boot
+files (`start.elf`, `kernel8.img`, `bcm2710-rpi-3-b.dtb`). The debug artifact is still uploaded
+on failure; only the *published* release is gated. Update the denylist alongside
+`stage-fiestaboard/00-pin-kernel/` as upstream issues open and close.
+
 ## Layout
 
 ```
@@ -56,6 +71,8 @@ pi-image/
 └── stage-fiestaboard/     ← custom pi-gen stage
     ├── prerun.sh
     ├── EXPORT_IMAGE       ← marks this stage as the one to export
+    ├── 00-pin-kernel/
+    │   └── 00-run.sh      ← pins kernel to 6.12 LTS (linux#7436 workaround)
     └── 01-install-fiestaboard/
         ├── 00-packages    ← apt packages installed in the chroot
         ├── 00-run.sh      ← installs docker-ce + FiestaBoard in chroot

--- a/pi-image/stage-fiestaboard/00-pin-kernel/00-run.sh
+++ b/pi-image/stage-fiestaboard/00-pin-kernel/00-run.sh
@@ -1,0 +1,76 @@
+#!/bin/bash -e
+# Pin the Raspberry Pi kernel to the 6.12 LTS series.
+#
+# WHY: Raspberry Pi OS Trixie's default kernel moved to the 6.18.x series,
+# which regressed the lan78xx driver (EEE / TX-LPI behaviour changed when
+# lan78xx was converted to phylink in 6.17). On the Pi 3B+ this kills wired
+# ethernet — the link flaps and never carries traffic:
+#   lan78xx ... eth0: kevent 0 may have been dropped
+#   lan78xx ... eth0: Link is Down
+# See raspberrypi/linux#7436 (OPEN). The last-known-good kernel from that
+# thread is 6.12.75, and the whole 6.12 LTS line is still in the Trixie
+# archive. We hold the image there until #7436 is fixed upstream.
+#
+# The base pi-gen stages already installed the 6.18.x kernel + metapackages,
+# so this script installs the 6.12 LTS kernels, removes the 6.18.x ones (so
+# raspi-firmware regenerates /boot/firmware/kernel8.img from 6.12), holds the
+# 6.12 packages, and pins the 6.18 line / metapackages to never reinstall.
+#
+# ⚠️  UNVERIFIED ON HARDWARE in this commit — must boot on a real Pi 3B and
+#     Pi 3B+ (wired) before merge. The pre-publish CI gate in
+#     build-fiestapi.yml asserts the pin took (no 6.18 kernel, 6.12 present,
+#     Pi-3 boot files exist) but cannot prove the board actually networks.
+
+# Last-known-good LTS kernel per raspberrypi/linux#7436. Bump within the 6.12
+# line only; do NOT advance to 6.18.x until that issue is resolved.
+KVER="6.12.75+rpt"
+
+on_chroot <<EOF
+set -eu
+
+# 1. Block the 6.18.x kernel line and the metapackages that drag it back in.
+cat > /etc/apt/preferences.d/fiestapi-pin-kernel <<'PIN'
+# FiestaPi: hold the kernel at the 6.12 LTS line. The 6.18.x series breaks
+# Pi 3B+ wired ethernet (raspberrypi/linux#7436). Priority -1 = never install.
+# Remove this file + unhold the 6.12 packages once #7436 is fixed upstream.
+Package: linux-image-6.18.* linux-headers-6.18.* linux-image-rpi-v8 linux-image-rpi-2712 linux-headers-rpi-v8 linux-headers-rpi-2712
+Pin: release *
+Pin-Priority: -1
+PIN
+
+apt-get update -qq
+
+# 2. Install the explicit 6.12 LTS kernels (both flavours: v8 = Pi 2/3/Zero2,
+#    2712 = Pi 4/5) so every supported board boots a known-good kernel.
+apt-get install -y --no-install-recommends \
+    "linux-image-${KVER}-rpi-v8" \
+    "linux-image-${KVER}-rpi-2712"
+
+# 3. Remove the 6.18.x kernels and the metapackages depending on them, so
+#    raspi-firmware picks the 6.12 kernel as the highest installed version
+#    for each flavour when it regenerates the boot partition.
+apt-get purge -y 'linux-image-6.18.*' linux-image-rpi-v8 linux-image-rpi-2712 || true
+apt-get autoremove -y --purge || true
+
+# 4. Force raspi-firmware to regenerate /boot/firmware/kernel*.img + initramfs
+#    from the now-only 6.12 kernel.
+apt-get install --reinstall -y raspi-firmware
+
+# 5. Hold the 6.12 kernels so a stray apt upgrade can't move them.
+apt-mark hold "linux-image-${KVER}-rpi-v8" "linux-image-${KVER}-rpi-2712"
+
+# 6. Fail the build loudly if the pin didn't take — better a failed image
+#    build than a silently-shipped broken-ethernet image.
+if dpkg-query -W -f='\${Package}\n' 'linux-image-6.18*' 2>/dev/null | grep -q .; then
+    echo "pin-kernel: ERROR — a 6.18.x kernel is still installed after pinning" >&2
+    exit 1
+fi
+if ! dpkg-query -W -f='\${Package}\n' "linux-image-${KVER}-rpi-v8" 2>/dev/null | grep -q .; then
+    echo "pin-kernel: ERROR — 6.12 v8 kernel not installed" >&2
+    exit 1
+fi
+test -f /boot/firmware/kernel8.img \
+    || { echo "pin-kernel: ERROR — /boot/firmware/kernel8.img missing (Pi 3 won't boot)" >&2; exit 1; }
+
+echo "pin-kernel: kernel held at ${KVER} (v8 + 2712); 6.18.x removed."
+EOF


### PR DESCRIPTION
## Why

FiestaPi builds from a **moving Trixie base** — `build-fiestapi.yml` checks out pi-gen at the `arm64` branch HEAD and `apt`-pulls live packages on **every release + a weekly cron**, then auto-attaches the `.img.xz` to the latest GitHub Release **with no boot/network smoke test**. Our advertised-minimum hardware is the Pi 3B, so any upstream Trixie regression ships straight to the most fragile boards, undetected.

Two have already shipped, surfaced by a user report (Pi 3B, "ethernet blinks then dies, never on the network"):

| Issue | Effect | Status |
|---|---|---|
| [raspberrypi/firmware#2034](https://github.com/raspberrypi/firmware/issues/2034) | `raspi-firmware 1:1.20260521-2` **bricks Pi 3 boot** (3× ACT-LED blink, `start.elf` not placed) | Fixed upstream in `-3`; current images carry the fix (~June 8–18 exposure window) |
| [raspberrypi/linux#7436](https://github.com/raspberrypi/linux/issues/7436) | Trixie's default **6.18.x kernel breaks wired ethernet on the Pi 3B+** (lan78xx EEE/TX-LPI regression from the 6.17 phylink conversion) | **OPEN** — and `FiestaPi-7.11.7` ships `6.18.34`, so **we are shipping broken 3B+ ethernet right now** |

Verified by reading the actual build logs (`pi-gen-build-logs-*` artifacts): current images install `linux-image-rpi-v8 = 1:6.18.34-1+rpt1`. The `6.12.75` LTS kernel (the last-known-good per #7436) is still in the Trixie archive, so the pin below is buildable.

## What

1. **Kernel pin — `pi-image/stage-fiestaboard/00-pin-kernel/00-run.sh`** (new pi-gen sub-stage, runs before the FiestaBoard install): installs `linux-image-6.12.75+rpt-rpi-v8` + `-rpi-2712`, removes the 6.18.x kernels and the metapackages that pull them, reinstalls `raspi-firmware` to regenerate `/boot/firmware/kernel*.img`, `apt-mark hold`s the 6.12 kernels, and writes an apt preference pinning the 6.18 line to `-1` so it can't creep back. Self-checks fail the build if the pin doesn't take.

2. **Pre-publish verify gate — `build-fiestapi.yml`**: after the artifact upload and before any release attach, loop-mounts the freshly built `.img` and **fails the build** if it ships a known-bad `raspi-firmware`/kernel version or is missing Pi-3 boot files (`start.elf`, `kernel8.img`, `bcm2710-rpi-3-b.dtb`). The debug artifact still uploads on failure — only the *published* release is gated. This is the durable safeguard so this class of regression can't silently ship again.

3. **Docs** — `pi-image/README.md` documents both and notes to remove the pin once #7436 closes.

## ⚠️ Not yet verified on hardware

The CI gate proves the pin *took* (no 6.18 kernel, 6.12 present, boot files exist) but **cannot prove the board actually networks**. Before merge this must be built and booted on:

- [ ] a real **Pi 3B** (wired) — boots, reaches the UI
- [ ] a real **Pi 3B+** (wired) — boots **and ethernet carries traffic** (the actual #7436 regression)

Suggested: `gh workflow run build-fiestapi.yml --ref fix-fiestapi-pin-kernel-6.12`, flash the artifact, confirm on both boards.

## Validation done here
- `build-fiestapi.yml` parses (YAML) and the embedded gate script passes `bash -n`; step ordered after artifact upload, before release attach.
- `00-pin-kernel/00-run.sh` passes `bash -n`; `6.12.75` confirmed present in `archive.raspberrypi.com/debian trixie`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
