### PR TITLE
test(e2e): fix flaky theme toggle class assertion

### DIFF
--- a/web/tests/navigation.spec.ts
+++ b/web/tests/navigation.spec.ts
@@ -95,8 +95,10 @@ test.describe("Navigation", () => {
       await page.waitForTimeout(500);
 
       const restoredClass = await htmlEl.getAttribute("class");
-      // Should be back to (roughly) the initial state
-      expect(restoredClass).toBe(initialClass);
+      // Should be back to (roughly) the initial state. Adding then removing
+      // the "dark" class leaves an empty class attribute, so treat a missing
+      // attribute and an empty one as equivalent.
+      expect(restoredClass ?? "").toBe(initialClass ?? "");
     }
   });
 


### PR DESCRIPTION
## Summary
The E2E test `navigation.spec.ts › theme toggle switches between light and dark mode` fails deterministically on current CI runs (seen on Dependabot PRs #1337, #1366, #1378) even though no web code has changed on main.

Root cause: the test reads the `<html>` `class` attribute before toggling (`null` when absent), toggles the theme twice, and expects the attribute to return to its exact initial value. But `use-theme.tsx` uses `classList.add("dark")` / `classList.remove("dark")`, and removing the last class leaves an **empty** `class=""` attribute rather than removing it — so the comparison is `"" !== null` and the test fails whenever the page starts with no class on `<html>` (light/system-light initial theme).

Fix: normalize `null` and `""` on both sides of the assertion so it compares actual class content.

## Testing
One-line test-only change; verified logic against `web/src/hooks/use-theme.tsx` (`applyClass`). CI on this PR runs the E2E suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)