### PR TITLE
chore(deps): ignore react-router/vite major bumps until migration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,17 @@ updates:
       npm-dependencies:
         patterns:
           - "*"
+    ignore:
+      # react-router 8 / vite 8 majors break the /schedule route and need
+      # a dedicated migration — see issue #1381. Drop these once it lands.
+      - dependency-name: "react-router"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@react-router/*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "vite"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@vitejs/plugin-react"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary
Adds Dependabot `ignore` rules for major updates of `react-router`, `@react-router/*`, `vite`, and `@vitejs/plugin-react`.

The v8 majors were backed out of #1366 because react-router 8 breaks the `/schedule` route with an endless reload loop and requires Node ≥ 22.22 (CI runs Node 20 in several jobs). Without these rules, next week's grouped npm PR would re-propose the same broken majors. The migration is tracked in #1381 — remove these entries when it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)