### PR TITLE
Add Airport Departures to plugin registry

### DIFF
--- a/plugin-registry.json
+++ b/plugin-registry.json
@@ -494,6 +494,16 @@
       "category": "utility"
     },
     {
+      "id": "airport_departures",
+      "name": "Airport Departures",
+      "description": "Display upcoming scheduled airline departures with codeshare deduplication, delays, gates, and Note-ready formatting.",
+      "repository": "https://github.com/breedloj/fiestaboard-plugin--airport-departures",
+      "author": "Jonathan Breedlove",
+      "fiestaboard_version": ">=2.10.0",
+      "icon": "plane-takeoff",
+      "category": "transit"
+    },
+    {
       "id": "wsdot",
       "name": "WSDOT",
       "description": "Washington State Ferries: schedules, vessel names, car spots, and alerts",


### PR DESCRIPTION
## Description

Adds Airport Departures to the FiestaBoard plugin registry.

Airport Departures displays upcoming scheduled airline departures for a selected airport using the AirLabs Schedules API. It provides flight numbers, destinations, local departure times, delays, gates, terminals, and operational statuses.

The plugin also:

- Filters out private and non-airline movements
- Deduplicates codeshare listings for the same physical flight
- Prefers the primary marketing flight number
- Uses estimated or actual departure times when available
- Supports configurable handling of recently departed flights
- Includes layouts designed for both Vestaboard Note and Flagship

This complements Airport Board and Nearby Aircraft, which focus on aircraft currently operating near an airport rather than its scheduled airline departures.

Plugin repository: https://github.com/breedloj/fiestaboard-plugin--airport-departures

## Related Issue

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] New plugin
- [ ] Documentation update
- [ ] Refactor / maintenance

## Checklist

- [x] I have tested my changes locally
- [x] I have added/updated tests where applicable
- [x] I have updated documentation where applicable
- [x] My code follows the project's coding standards

### Validation

- FiestaBoard plugin test runner: 23 tests passed
- Branch coverage: 87%
- Strict manifest validation: passed with zero warnings
- Registry repository validation: passed