### PR TITLE
fix: rebuild named plugin instances after a plugin reload

### DIFF
--- a/src/plugins/registry.py
+++ b/src/plugins/registry.py
@@ -879,7 +879,7 @@ class PluginRegistry:
         return plugins
 
     def reload_plugin(self, plugin_id: str) -> PluginBase | None:
-        """Reload a plugin.
+        """Reload a plugin and rebuild all of its named instances.
 
         Args:
             plugin_id: Plugin identifier
@@ -905,6 +905,7 @@ class PluginRegistry:
             if manifest:
                 self._plugins[plugin_id] = plugin
                 self._manifests[plugin_id] = manifest
+                self.clear_discovered_cache(plugin_id)
 
                 # Restore state
                 if was_enabled:
@@ -925,9 +926,60 @@ class PluginRegistry:
                         self._configs[plugin_id] = config
                         plugin.config = config
 
+                self._rebuild_instances(plugin_id, manifest)
+
                 return plugin
 
         return None
+
+    def _rebuild_instances(self, plugin_id: str, manifest: PluginManifest) -> None:
+        """Recreate all named instances of *plugin_id* after a base reload.
+
+        Named instances (compound ``plugin_id:label`` keys) hold their own
+        plugin object and manifest reference, so a base reload alone would
+        leave them running the old code with a stale manifest (issue #1390).
+        Each instance is rebuilt from the freshly loaded class and has its
+        enabled state and config restored.
+
+        If a rebuild fails, the old instance is kept running rather than
+        being torn down.
+        """
+        prefix = f"{plugin_id}{INSTANCE_SEPARATOR}"
+        for compound_key in [k for k in self._plugins if k.startswith(prefix)]:
+            new_instance = self._loader.create_instance(plugin_id)
+            if new_instance is None:
+                logger.warning(
+                    "Failed to rebuild instance '%s' after reload — keeping the old instance",
+                    compound_key,
+                )
+                continue
+
+            old_instance = self._plugins[compound_key]
+            try:
+                old_instance.cleanup()
+            except Exception:
+                logger.exception("Error cleaning up old instance '%s'", compound_key)
+
+            self._plugins[compound_key] = new_instance
+            self._manifests[compound_key] = manifest
+            self.clear_discovered_cache(compound_key)
+
+            # Restore state (mirrors the base-plugin restore above)
+            if self._enabled.get(compound_key, False):
+                self.enable_plugin(compound_key)
+            instance_config = self._configs.get(compound_key, {})
+            if instance_config:
+                errors = self.set_plugin_config(compound_key, instance_config)
+                if errors:
+                    logger.warning(
+                        "Config validation failed after reload for '%s': %s — applying raw config to avoid data loss",
+                        compound_key,
+                        errors,
+                    )
+                    self._configs[compound_key] = instance_config
+                    new_instance.config = instance_config
+
+            logger.info("Rebuilt plugin instance after reload: %s", compound_key)
 
     def get_load_errors(self) -> dict[str, list[str]]:
         """Get plugin load errors.

--- a/tests/test_plugin_instances.py
+++ b/tests/test_plugin_instances.py
@@ -510,6 +510,158 @@ class TestRestoreInstances:
         mock_config_manager.delete_plugin_config.assert_not_called()
 
 
+# ── reload rebuilds instances (issue #1390) ─────────────────────────────────
+
+
+class TestReloadRebuildsInstances:
+    """reload_plugin() must rebuild named instances, not just the base plugin.
+
+    Regression tests for issue #1390: after a plugin update, compound-key
+    instances kept running the old code with a stale manifest reference
+    until a full service restart.
+    """
+
+    def _configure_reload(self, mock_loader):
+        """Set up loader mocks simulating a successful base reload."""
+        reloaded_base = MagicMock(spec=PluginBase)
+        reloaded_base.plugin_id = "test_plugin"
+        reloaded_base.validate_config.return_value = []
+        reloaded_base._validate_refresh_seconds.return_value = []
+        reloaded_base.enabled = False
+        reloaded_base.config = {}
+
+        new_manifest = MagicMock(spec=PluginManifest)
+        new_manifest.id = "test_plugin"
+        new_manifest.raw = {"variables": {"simple": ["var1", "var2", "sunrise"]}}
+
+        rebuilt = MagicMock(spec=PluginBase)
+        rebuilt.plugin_id = "test_plugin"
+        rebuilt.validate_config.return_value = []
+        rebuilt._validate_refresh_seconds.return_value = []
+        rebuilt.enabled = False
+        rebuilt.config = {}
+
+        mock_loader.reload_plugin.return_value = reloaded_base
+        mock_loader.get_manifest.return_value = new_manifest
+        mock_loader.create_instance.return_value = rebuilt
+        return reloaded_base, new_manifest, rebuilt
+
+    def test_reload_rebuilds_named_instance(self, registry_with_plugin, mock_loader):
+        registry_with_plugin.create_instance("test_plugin", "sf")
+        old_instance = registry_with_plugin._plugins["test_plugin:sf"]
+        reloaded_base, _, rebuilt = self._configure_reload(mock_loader)
+
+        result = registry_with_plugin.reload_plugin("test_plugin")
+
+        assert result is reloaded_base
+        assert registry_with_plugin._plugins["test_plugin:sf"] is rebuilt
+        assert registry_with_plugin._plugins["test_plugin:sf"] is not old_instance
+
+    def test_reload_repoints_instance_manifest(self, registry_with_plugin, mock_loader):
+        registry_with_plugin.create_instance("test_plugin", "sf")
+        old_manifest = registry_with_plugin._manifests["test_plugin:sf"]
+        _, new_manifest, _ = self._configure_reload(mock_loader)
+
+        registry_with_plugin.reload_plugin("test_plugin")
+
+        assert registry_with_plugin._manifests["test_plugin:sf"] is new_manifest
+        assert registry_with_plugin._manifests["test_plugin:sf"] is not old_manifest
+
+    def test_reload_restores_instance_enabled_and_config(self, registry_with_plugin, mock_loader):
+        registry_with_plugin.create_instance("test_plugin", "sf")
+        registry_with_plugin.set_plugin_config("test_plugin:sf", {"api_key": "inst_key"})
+        registry_with_plugin.enable_plugin("test_plugin:sf")
+        _, _, rebuilt = self._configure_reload(mock_loader)
+
+        registry_with_plugin.reload_plugin("test_plugin")
+
+        assert registry_with_plugin._enabled["test_plugin:sf"] is True
+        assert rebuilt.enabled is True
+        assert registry_with_plugin._configs["test_plugin:sf"]["api_key"] == "inst_key"
+        assert rebuilt.config["api_key"] == "inst_key"
+
+    def test_reload_keeps_disabled_instance_disabled(self, registry_with_plugin, mock_loader):
+        registry_with_plugin.create_instance("test_plugin", "sf")
+        _, _, rebuilt = self._configure_reload(mock_loader)
+
+        registry_with_plugin.reload_plugin("test_plugin")
+
+        assert registry_with_plugin._enabled["test_plugin:sf"] is False
+        assert rebuilt.enabled is False
+
+    def test_reload_instance_config_fallback_when_validation_fails(self, registry_with_plugin, mock_loader):
+        """If the new version rejects the old config, apply it raw (no data loss)."""
+        registry_with_plugin.create_instance("test_plugin", "sf")
+        registry_with_plugin.set_plugin_config("test_plugin:sf", {"api_key": "inst_key"})
+        _, _, rebuilt = self._configure_reload(mock_loader)
+        rebuilt.validate_config.return_value = ["required field 'new_field' missing"]
+
+        registry_with_plugin.reload_plugin("test_plugin")
+
+        assert registry_with_plugin._configs["test_plugin:sf"]["api_key"] == "inst_key"
+        assert rebuilt.config["api_key"] == "inst_key"
+
+    def test_reload_cleans_up_old_instance(self, registry_with_plugin, mock_loader):
+        registry_with_plugin.create_instance("test_plugin", "sf")
+        old_instance = registry_with_plugin._plugins["test_plugin:sf"]
+        self._configure_reload(mock_loader)
+
+        registry_with_plugin.reload_plugin("test_plugin")
+
+        old_instance.cleanup.assert_called_once()
+
+    def test_reload_keeps_old_instance_when_rebuild_fails(self, registry_with_plugin, mock_loader):
+        """A failed instance rebuild must not kill the running old instance."""
+        registry_with_plugin.create_instance("test_plugin", "sf")
+        old_instance = registry_with_plugin._plugins["test_plugin:sf"]
+        old_manifest = registry_with_plugin._manifests["test_plugin:sf"]
+        self._configure_reload(mock_loader)
+        mock_loader.create_instance.return_value = None
+
+        registry_with_plugin.reload_plugin("test_plugin")
+
+        assert registry_with_plugin._plugins["test_plugin:sf"] is old_instance
+        assert registry_with_plugin._manifests["test_plugin:sf"] is old_manifest
+        old_instance.cleanup.assert_not_called()
+
+    def test_reload_rebuilds_multiple_instances(self, registry_with_plugin, mock_loader):
+        registry_with_plugin.create_instance("test_plugin", "sf")
+        registry_with_plugin.create_instance("test_plugin", "nyc")
+        _, new_manifest, rebuilt = self._configure_reload(mock_loader)
+
+        registry_with_plugin.reload_plugin("test_plugin")
+
+        assert registry_with_plugin._plugins["test_plugin:sf"] is rebuilt
+        assert registry_with_plugin._plugins["test_plugin:nyc"] is rebuilt
+        assert registry_with_plugin._manifests["test_plugin:sf"] is new_manifest
+        assert registry_with_plugin._manifests["test_plugin:nyc"] is new_manifest
+
+    def test_reload_clears_discovered_vars(self, registry_with_plugin, mock_loader):
+        """Auto-discovery cache must not survive a reload for base or instances."""
+        registry_with_plugin.create_instance("test_plugin", "sf")
+        registry_with_plugin._discovered_vars["test_plugin"] = ["old_var"]
+        registry_with_plugin._discovered_vars["test_plugin:sf"] = ["old_var"]
+        self._configure_reload(mock_loader)
+
+        registry_with_plugin.reload_plugin("test_plugin")
+
+        assert "test_plugin" not in registry_with_plugin._discovered_vars
+        assert "test_plugin:sf" not in registry_with_plugin._discovered_vars
+
+    def test_reload_base_failure_leaves_instances_running(self, registry_with_plugin, mock_loader):
+        """If the base reload fails, existing instances keep running old code."""
+        registry_with_plugin.create_instance("test_plugin", "sf")
+        old_instance = registry_with_plugin._plugins["test_plugin:sf"]
+        mock_loader.reload_plugin.return_value = None
+        mock_loader.get_manifest.return_value = None
+
+        result = registry_with_plugin.reload_plugin("test_plugin")
+
+        assert result is None
+        assert registry_with_plugin._plugins["test_plugin:sf"] is old_instance
+        old_instance.cleanup.assert_not_called()
+
+
 # ── edge cases ──────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Fixes #1390 — after a plugin update, named instances (`plugin_id:label` compound keys) kept running the pre-update code with a stale manifest reference until a full service restart.

`PluginRegistry.reload_plugin()` now:

- Rebuilds every compound-key instance via `loader.create_instance()` (the loader refreshes `_plugin_classes` on reload, so rebuilt instances run the new code)
- Repoints each instance's `_manifests` entry at the freshly loaded manifest (previously it kept referencing the manifest object captured at `create_instance()` time)
- Restores each instance's enabled state and config through the normal `enable_plugin` / `set_plugin_config` pipeline, with the same raw-config fallback the base plugin uses when the new version's `validate_config` rejects the old config
- Clears the `_discovered_vars` auto-discovery cache for the base plugin **and** its instances — an extra staleness gap found while validating the issue: the cache is documented as "once per plugin lifecycle" but previously survived reloads even for the base plugin
- Keeps the old instance running (no cleanup) if an instance rebuild fails, and leaves instances untouched if the base reload itself fails

Since the manual update endpoint, bulk apply, and the 6-hour auto-update loop all funnel through `reload_plugin()`, one fix covers all update paths.

## Validation

Confirmed the bug end-to-end with the real loader (no mocks): created a plugin with a named instance, updated its files on disk to add a `sunrise` variable, called `reload_plugin()`. Before the fix the instance kept emitting only the old data (`{'greeting': 'hello'}`); after the fix it emits the new variable and its variable list includes it, with enabled state and config preserved.

## Tests

New `TestReloadRebuildsInstances` class (10 tests, written first and watched fail) covering: instance rebuild, manifest repointing, enabled/config restore, disabled-stays-disabled, raw-config fallback, old-instance cleanup, rebuild-failure keeps old instance, multiple instances, discovery-cache clearing, and base-reload failure leaving instances running.

`ruff check`, `ruff format --check`, and the plugin registry/instance/loader/settings/API test files (290 tests) all pass in the Docker container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)