### PR TITLE
fix: unbreak docs-site deploys (OOM) and let daily stats refresh deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -105,6 +105,11 @@ jobs:
       - name: Build Docusaurus site
         working-directory: docs-site
         run: npm run build
+        env:
+          # Headroom above Node's ~4GB default; the version-capped build fits
+          # comfortably, but a single version's docs growing shouldn't brick
+          # deploys again (they OOMed 2026-06-16 → 2026-07-18).
+          NODE_OPTIONS: --max-old-space-size=8192
 
       # --- Push version snapshot to main (after successful build) ---
 

--- a/.github/workflows/scheduled-maintenance.yml
+++ b/.github/workflows/scheduled-maintenance.yml
@@ -64,9 +64,11 @@ jobs:
           if git diff --staged --quiet; then
             echo "No changes."
           else
-            # [skip ci] so the daily stats refresh doesn't trigger
-            # docs.yml (6-min Docusaurus build) on every cron run.
-            git commit -m "chore: refresh plugin stats [skip ci]"
+            # No [skip ci]: this push must trigger docs.yml so the refreshed
+            # stats actually deploy to fiestaboard.app. (With [skip ci] the
+            # live site served a stale plugin-stats.json for weeks — the
+            # daily commit landed but the site never rebuilt.)
+            git commit -m "chore: refresh plugin stats"
             git push
           fi
 

--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -6,11 +6,18 @@ import versions from "./versions.json";
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
 // PR-mode build: only compile the latest documented version. CI uses this on
-// PRs (DOCS_PR_MODE=1) so docs builds don't recompile 40 historical version
-// snapshots that haven't changed. The release-time deploy via docs.yml builds
-// the full set of versions normally.
+// PRs (DOCS_PR_MODE=1) so docs builds don't recompile historical version
+// snapshots that haven't changed.
+//
+// Deploy builds are capped to the most recent minors: one snapshot exists per
+// minor release, so the full set grows without bound (57 as of 7.3) and
+// building all of them exhausts the Node heap — deploys OOMed from
+// 2026-06-16 to 2026-07-18. Older snapshots stay in versioned_docs/ but are
+// not built or served.
 const isPRMode = process.env.DOCS_PR_MODE === "1";
-const onlyIncludeVersions = isPRMode && versions.length > 0 ? [versions[0]] : undefined;
+const DEPLOY_VERSION_CAP = 12;
+const onlyIncludeVersions =
+  versions.length > 0 ? (isPRMode ? [versions[0]] : versions.slice(0, DEPLOY_VERSION_CAP)) : undefined;
 
 const config: Config = {
   clientModules: ["./src/clientModules/versionSession.ts"],


### PR DESCRIPTION
## Problem

**"Release: Deploy Docs Site" has failed 47 consecutive times since 2026-06-11**, so fiestaboard.app is serving stale content — including a `plugin-stats.json` generated **2026-06-10** (which is why the stats page numbers looked frozen/wrong).

Two independent causes:

1. **OOM**: the deploy build compiles *every* versioned docs snapshot — 57 as of 7.3, one per minor release, growing ~2/month — and dies with `FATAL ERROR: Reached heap limit` (Node's ~4GB default) during the client webpack compile. The bulk of the versioned tree landed 2026-06-16 (#1110), right after the last successful deploy. Side effect: version snapshots froze at 7.3 because the snapshot-commit step runs *after* the build.
2. **Stats never deploy anyway**: the daily 04:00 UTC stats refresh commits with `[skip ci]`, deliberately skipping the docs build — so fresh stats only ever shipped by piggybacking on unrelated docs changes.

## Fix

- **`docusaurus.config.ts`** — cap non-PR builds to the **12 most recent** versioned snapshots (`DEPLOY_VERSION_CAP`). Older snapshots stay in `versioned_docs/` but are no longer built or served (their URLs will 404; the version dropdown shrinks accordingly). PR builds still build only the latest version via `DOCS_PR_MODE=1`, unchanged.
- **`docs.yml`** — `NODE_OPTIONS=--max-old-space-size=8192` on the build step as headroom, so a single version's docs growing can't brick deploys again.
- **`scheduled-maintenance.yml`** — drop `[skip ci]` from the daily stats commit. The push (made with `RELEASE_PAT`) triggers `docs.yml` via its `docs-site/**` paths filter, so the site redeploys with fresh stats every day.

## Verification

- Full non-PR-mode build run locally with the cap: **succeeds** (previously OOMed), builds exactly 12 versions (7.3 at `/docs/` root + 7.2→6.10), 81M output. Remaining "broken anchor" warnings are pre-existing.
- `prettier --check` passes on the config change; CI's PR docs build path (`DOCS_PR_MODE=1`) is unaffected.

## Notes / follow-ups

- After merge, the next deploy publishes the current `plugin-stats.json` (July data) and future daily refreshes deploy automatically.
- Version snapshots 7.4–7.11 were never created (build failed before the snapshot-commit step); the next tagged release resumes snapshotting at the current minor.
- Separate observation from the investigation, not addressed here: plugin "unique cloners" stats largely measure the fleet's auto-update git traffic (~250 active installs re-fetching the ex-builtin plugins), not organic installs — and the July 16 release burst showed ~140 installs re-cloning all plugins in one day, i.e. installs still losing `external_plugins/` across upgrades (the #948/#1301 mechanism). Worth its own issue if we want the stats page to reflect deliberate installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)