### PR TITLE
fix(web): mobile overflow sweep — dropdowns, board previews, selects, long-name layouts

### DIFF
--- a/web/app/routes/collections.tsx
+++ b/web/app/routes/collections.tsx
@@ -757,13 +757,15 @@ export default function CollectionsPage() {
               style={{ animationDelay: `${idx * 50}ms` }}
             >
               <CardHeader className="pb-3">
-                <div className="flex items-start justify-between gap-2">
+                {/* min-w-0: CardHeader is a grid; without it this grid item
+                    sizes to min-content and long names inflate the row. */}
+                <div className="flex items-start justify-between gap-2 min-w-0">
                   <div className="flex items-center gap-2 min-w-0">
                     <GalleryHorizontalEnd className="h-5 w-5 text-primary flex-shrink-0" />
                     <div className="min-w-0">
-                      <CardTitle className="text-base truncate flex items-center gap-2">
-                        {collection.name}
-                        <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
+                      <CardTitle className="text-base flex items-center gap-2 min-w-0">
+                        <span className="truncate">{collection.name}</span>
+                        <Badge variant="outline" className="text-[10px] uppercase tracking-wide flex-shrink-0">
                           {collection.selection_mode === "time" ? (
                             <Clock className="h-3 w-3 mr-1" aria-hidden="true" />
                           ) : collection.selection_mode === "random" ? (
@@ -774,7 +776,7 @@ export default function CollectionsPage() {
                           {collection.selection_mode}
                         </Badge>
                         {collection.selection_mode === "variable" && (
-                          <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
+                          <Badge variant="outline" className="text-[10px] uppercase tracking-wide flex-shrink-0">
                             {t("betaBadge")}
                           </Badge>
                         )}
@@ -793,11 +795,11 @@ export default function CollectionsPage() {
               <CardContent className="pt-0">
                 <div className="flex flex-wrap gap-1.5">
                   {collection.page_ids.map((pid, i) => (
-                    <Badge key={pid} variant="secondary" className="text-xs">
+                    <Badge key={pid} variant="secondary" className="text-xs max-w-full">
                       {collection.selection_mode === "time" && (
-                        <span className="text-muted-foreground mr-1">{i + 1}.</span>
+                        <span className="text-muted-foreground mr-1 flex-shrink-0">{i + 1}.</span>
                       )}
-                      {getPageName(pid)}
+                      <span className="truncate">{getPageName(pid)}</span>
                     </Badge>
                   ))}
                 </div>

--- a/web/src/components/active-page-display.tsx
+++ b/web/src/components/active-page-display.tsx
@@ -18,9 +18,9 @@ import {
 import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState, useTransition } from "react";
 import { toast } from "sonner";
 
-import { BoardDisplay } from "@/components/board-display";
 import { ForceSetDialog } from "@/components/force-set-dialog";
 import { PageGridSelector } from "@/components/page-grid-selector";
+import { ScaledBoardDisplay } from "@/components/scaled-board-display";
 import Link from "@/components/smart-link";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
@@ -505,9 +505,11 @@ export function ActivePageDisplay() {
           )}
 
           {/* Board Frame — contain: layout style paint isolates the tile grid from
-              any layout changes in ancestor elements (e.g. sidebar padding snap). */}
+              any layout changes in ancestor elements (e.g. sidebar padding snap).
+              ScaledBoardDisplay shrinks the board to fit narrow (mobile) cards —
+              BoardDisplay's breakpoint tile sizes alone overflow phone widths. */}
           <div className="flex justify-center overflow-x-hidden px-2" style={{ contain: "layout style paint" }}>
-            <BoardDisplay
+            <ScaledBoardDisplay
               message={displayMessage}
               isLoading={!boardState && !liveOutputMessage}
               size="md"

--- a/web/src/components/day-selector.tsx
+++ b/web/src/components/day-selector.tsx
@@ -20,6 +20,9 @@ const WEEKDAYS = ["monday", "tuesday", "wednesday", "thursday", "friday"];
 const WEEKENDS = ["saturday", "sunday"];
 const ALL_DAYS = [...WEEKDAYS, ...WEEKENDS];
 
+// Chip rows wrap so trailing chips aren't clipped at phone widths.
+const CHIP_ROW_CLASS = "ml-auto flex flex-wrap justify-end gap-1 min-w-0";
+
 export function DaySelector({ value, customDays = [], onChange, className }: DaySelectorProps) {
   const t = useTranslations("daySelector");
   const dayLabels = t.raw("dayLabels") as Record<string, string>;
@@ -111,7 +114,7 @@ export function DaySelector({ value, customDays = [], onChange, className }: Day
             {value === "all" && <div className="h-2 w-2 rounded-full bg-primary" />}
           </div>
           <span className="text-sm font-medium">{t("allDays")}</span>
-          <div className="ml-auto flex flex-wrap justify-end gap-1 min-w-0">
+          <div data-testid="day-pattern-chips" className={CHIP_ROW_CLASS}>
             {ALL_DAYS.map((day) => (
               <Badge key={day} variant="secondary" className="text-xs">
                 {dayLabels[day]}
@@ -143,7 +146,7 @@ export function DaySelector({ value, customDays = [], onChange, className }: Day
             {value === "weekdays" && <div className="h-2 w-2 rounded-full bg-primary" />}
           </div>
           <span className="text-sm font-medium">{t("weekdays")}</span>
-          <div className="ml-auto flex flex-wrap justify-end gap-1 min-w-0">
+          <div data-testid="day-pattern-chips" className={CHIP_ROW_CLASS}>
             {WEEKDAYS.map((day) => (
               <Badge key={day} variant="secondary" className="text-xs">
                 {dayLabels[day]}
@@ -175,7 +178,7 @@ export function DaySelector({ value, customDays = [], onChange, className }: Day
             {value === "weekends" && <div className="h-2 w-2 rounded-full bg-primary" />}
           </div>
           <span className="text-sm font-medium">{t("weekends")}</span>
-          <div className="ml-auto flex flex-wrap justify-end gap-1 min-w-0">
+          <div data-testid="day-pattern-chips" className={CHIP_ROW_CLASS}>
             {WEEKENDS.map((day) => (
               <Badge key={day} variant="secondary" className="text-xs">
                 {dayLabels[day]}

--- a/web/src/components/day-selector.tsx
+++ b/web/src/components/day-selector.tsx
@@ -111,7 +111,7 @@ export function DaySelector({ value, customDays = [], onChange, className }: Day
             {value === "all" && <div className="h-2 w-2 rounded-full bg-primary" />}
           </div>
           <span className="text-sm font-medium">{t("allDays")}</span>
-          <div className="ml-auto flex gap-1">
+          <div className="ml-auto flex flex-wrap justify-end gap-1 min-w-0">
             {ALL_DAYS.map((day) => (
               <Badge key={day} variant="secondary" className="text-xs">
                 {dayLabels[day]}
@@ -143,7 +143,7 @@ export function DaySelector({ value, customDays = [], onChange, className }: Day
             {value === "weekdays" && <div className="h-2 w-2 rounded-full bg-primary" />}
           </div>
           <span className="text-sm font-medium">{t("weekdays")}</span>
-          <div className="ml-auto flex gap-1">
+          <div className="ml-auto flex flex-wrap justify-end gap-1 min-w-0">
             {WEEKDAYS.map((day) => (
               <Badge key={day} variant="secondary" className="text-xs">
                 {dayLabels[day]}
@@ -175,7 +175,7 @@ export function DaySelector({ value, customDays = [], onChange, className }: Day
             {value === "weekends" && <div className="h-2 w-2 rounded-full bg-primary" />}
           </div>
           <span className="text-sm font-medium">{t("weekends")}</span>
-          <div className="ml-auto flex gap-1">
+          <div className="ml-auto flex flex-wrap justify-end gap-1 min-w-0">
             {WEEKENDS.map((day) => (
               <Badge key={day} variant="secondary" className="text-xs">
                 {dayLabels[day]}

--- a/web/src/components/scaled-board-display.tsx
+++ b/web/src/components/scaled-board-display.tsx
@@ -111,9 +111,20 @@ export function ScaledBoardDisplay(props: BoardProps) {
     const compute = () => {
       rafId = null;
       const constraint = findConstraint();
-      // The constraint's clientWidth excludes its own padding, which
-      // is the visible content area we have to fit.
-      const cw = constraint.clientWidth;
+      // clientWidth INCLUDES padding, but overflow clips at the padding
+      // edge while the visible slot for content is the content box —
+      // subtract the constraint's own padding or the board renders
+      // padding-width too wide and gets clipped at the edges.
+      const constraintStyle = getComputedStyle(constraint);
+      const constraintContentWidth =
+        constraint.clientWidth - parseFloat(constraintStyle.paddingLeft) - parseFloat(constraintStyle.paddingRight);
+      // The overflow-x ancestor can be far wider than our actual slot
+      // (e.g. the setup wizard's fullscreen overflow-y-auto scroller,
+      // whose computed overflow-x is "auto"). Our own container is
+      // w-full, so its clientWidth is the real slot — never scale to
+      // more room than the narrower of the two.
+      const cw =
+        container.clientWidth > 0 ? Math.min(constraintContentWidth, container.clientWidth) : constraintContentWidth;
       // Board's natural (un-transformed) width — read offsetWidth on
       // the actual rendered board so the current transform doesn't
       // skew the measurement.
@@ -138,6 +149,7 @@ export function ScaledBoardDisplay(props: BoardProps) {
     compute();
     const ro = new ResizeObserver(recompute);
     ro.observe(findConstraint());
+    ro.observe(container);
     ro.observe(board);
     return () => {
       ro.disconnect();

--- a/web/src/components/schedule/schedule-calendar-view.tsx
+++ b/web/src/components/schedule/schedule-calendar-view.tsx
@@ -319,8 +319,11 @@ export function ScheduleCalendarView({
   return (
     <TooltipProvider>
       <div className="schedule-calendar-wrapper flex flex-col sm:h-full">
-        {/* Top bar: mobile day navigation (left) + zoom slider (right) */}
-        <div className="flex items-center justify-between mb-2 px-1">
+        {/* Top bar: mobile day navigation (left) + zoom slider (right).
+            flex-wrap: day nav + zoom together exceed narrow phone widths;
+            wrapping drops the zoom control to its own line instead of
+            pushing it off-screen. */}
+        <div className="flex flex-wrap items-center justify-between gap-y-1 mb-2 px-1">
           {/* Mobile day navigation */}
           {isMobile ? (
             <div className="flex items-center gap-1">
@@ -365,7 +368,7 @@ export function ScheduleCalendarView({
           {/* Zoom slider */}
           <Tooltip>
             <TooltipTrigger asChild>
-              <div className="flex items-center gap-2">
+              <div className="ml-auto flex items-center gap-2">
                 <Button
                   variant="ghost"
                   size="sm"

--- a/web/src/components/tiptap-template-editor/components/ToolbarDropdown.tsx
+++ b/web/src/components/tiptap-template-editor/components/ToolbarDropdown.tsx
@@ -136,7 +136,8 @@ export function ToolbarDropdown({
         {isOpen && (
           <div
             ref={panelRef}
-            className="absolute top-full left-0 mt-1 z-50 bg-popover border border-border rounded-md shadow-lg max-w-[calc(100vw-16px)]"
+            data-testid="toolbar-dropdown-panel"
+            className="absolute top-full left-0 mt-1 z-50 bg-popover border border-border rounded-md shadow-lg max-w-[calc(100vw-16px)] overflow-x-auto"
             style={{ transform: panelShift ? `translateX(${panelShift}px)` : undefined }}
           >
             {typeof children === "function" ? children(handleClose) : children}

--- a/web/src/components/tiptap-template-editor/components/ToolbarDropdown.tsx
+++ b/web/src/components/tiptap-template-editor/components/ToolbarDropdown.tsx
@@ -3,7 +3,7 @@
  */
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
@@ -28,6 +28,48 @@ export function ToolbarDropdown({
 }: ToolbarDropdownProps) {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  const [panelShift, setPanelShift] = useState(0);
+
+  // The panel is plain `absolute top-full left-0` with no collision handling,
+  // so a wide picker anchored to a right-side toolbar button runs off narrow
+  // (mobile) viewports. Measure after open/content changes and shift it back
+  // into view.
+  useLayoutEffect(() => {
+    if (!isOpen) {
+      setPanelShift(0);
+      return;
+    }
+    const clamp = () => {
+      const panel = panelRef.current;
+      if (!panel) return;
+      // Measure the untransformed position so repeated clamps don't compound.
+      const prevTransform = panel.style.transform;
+      panel.style.transform = "none";
+      const rect = panel.getBoundingClientRect();
+      panel.style.transform = prevTransform;
+      const viewportWidth = document.documentElement.clientWidth;
+      const margin = 8;
+      let shift = 0;
+      if (rect.right > viewportWidth - margin) {
+        shift = viewportWidth - margin - rect.right;
+      }
+      if (rect.left + shift < margin) {
+        shift = margin - rect.left;
+      }
+      setPanelShift(shift);
+    };
+    clamp();
+    // Pickers change width as the user switches tabs or filters, and rotation
+    // changes the viewport — re-clamp on both.
+    const observer = new ResizeObserver(clamp);
+    if (panelRef.current) observer.observe(panelRef.current);
+    window.addEventListener("resize", clamp);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", clamp);
+    };
+  }, [isOpen]);
 
   const handleClose = () => {
     setIsOpen(false);
@@ -92,7 +134,11 @@ export function ToolbarDropdown({
         </Tooltip>
 
         {isOpen && (
-          <div className="absolute top-full left-0 mt-1 z-50 bg-popover border border-border rounded-md shadow-lg">
+          <div
+            ref={panelRef}
+            className="absolute top-full left-0 mt-1 z-50 bg-popover border border-border rounded-md shadow-lg max-w-[calc(100vw-16px)]"
+            style={{ transform: panelShift ? `translateX(${panelShift}px)` : undefined }}
+          >
             {typeof children === "function" ? children(handleClose) : children}
           </div>
         )}

--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -71,7 +71,10 @@ const SelectContent = React.forwardRef<
       <SelectPrimitive.Content
         ref={ref}
         className={cn(
-          "relative z-[120] max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md",
+          // max-w: Radix clamps popper *position* but not width, so content
+          // sized by a long item (e.g. page names) would run off narrow
+          // viewports. Clamping here makes long item text wrap instead.
+          "relative z-[120] max-h-96 min-w-[8rem] max-w-[calc(100vw-16px)] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className,

--- a/web/src/components/wizard/step-board-setup.tsx
+++ b/web/src/components/wizard/step-board-setup.tsx
@@ -15,7 +15,7 @@ import {
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
-import { BoardDisplay } from "@/components/board-display";
+import { ScaledBoardDisplay } from "@/components/scaled-board-display";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -637,7 +637,7 @@ export function StepBoardSetup({
         {/* Live board preview */}
         <div className="space-y-2 pt-3">
           <p className="text-sm font-medium text-muted-foreground">{tc("preview")}</p>
-          <BoardDisplay
+          <ScaledBoardDisplay
             message={previewMessage}
             size="sm"
             boardType={config.board_color}

--- a/web/tests/mobile-critical-flows.spec.ts
+++ b/web/tests/mobile-critical-flows.spec.ts
@@ -6,7 +6,16 @@
  *
  * Issue: #500 — E2E: add Playwright tests for critical user flows
  */
-import { API_URL, configureBoard, createPage, deleteAllPages, expect, suppressWizard, test } from "./helpers";
+import {
+  API_URL,
+  authHeaders,
+  configureBoard,
+  createPage,
+  deleteAllPages,
+  expect,
+  suppressWizard,
+  test,
+} from "./helpers";
 
 const MOBILE_VIEWPORT = { width: 375, height: 812 };
 
@@ -191,6 +200,92 @@ test.describe("Mobile — Board preview fits viewport", () => {
     expect(geometry).not.toBeNull();
     expect(geometry?.frameInViewport).toBe(true);
     expect(geometry?.tilesInsideFrame).toBe(true);
+  });
+});
+
+test.describe("Mobile — Long names stay inside the viewport", () => {
+  const LONG_NAME = "An Extremely Long Page Name That Someone Might Actually Type On Their Phone 2026 Edition";
+
+  test("schedule form select and day chips fit with long page names", async ({ page }) => {
+    await createPage(LONG_NAME);
+
+    await page.goto("/schedule");
+    await page.getByRole("button", { name: /add schedule/i }).click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible({ timeout: 10_000 });
+
+    // Radix Select sizes its content to the widest item; long page names
+    // used to blow the panel past the viewport (position is clamped by
+    // Radix, width is not — ui/select.tsx now caps it).
+    await dialog.getByRole("combobox").first().click();
+    const panel = page.locator("[data-radix-popper-content-wrapper]");
+    await expect(panel).toBeVisible({ timeout: 5_000 });
+    const panelBox = await panel.boundingBox();
+    expect(panelBox).not.toBeNull();
+    if (panelBox) {
+      expect(panelBox.x).toBeGreaterThanOrEqual(0);
+      expect(panelBox.x + panelBox.width).toBeLessThanOrEqual(MOBILE_VIEWPORT.width);
+    }
+    await page.keyboard.press("Escape");
+
+    // Day-pattern chip rows (All Days / Weekdays / Weekends) must wrap
+    // rather than clip their trailing chips at phone width.
+    const chipOverflow = await page.evaluate((vw) => {
+      const rows = document.querySelectorAll('[role="dialog"] .ml-auto.flex');
+      return [...rows].filter((el) => el.getBoundingClientRect().right > vw + 2).length;
+    }, MOBILE_VIEWPORT.width);
+    expect(chipOverflow).toBe(0);
+  });
+
+  test("collections card truncates long collection and page names", async ({ page }) => {
+    const pageId = await createPage(LONG_NAME);
+    const res = await fetch(`${API_URL}/collections`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...authHeaders() },
+      body: JSON.stringify({
+        name: "A Collection With An Unreasonably Long Name For Mobile Testing Purposes",
+        page_ids: [pageId],
+        interval_seconds: 60,
+      }),
+    });
+    const created = await res.json();
+    const collectionId: string | undefined = created?.collection?.id;
+
+    try {
+      await page.goto("/collections");
+      await expect(page.getByText(/unreasonably long name/i).first()).toBeVisible({ timeout: 10_000 });
+
+      const overflowing = await page.evaluate((vw) => {
+        return [...document.querySelectorAll("main *")].filter((el) => {
+          const r = el.getBoundingClientRect();
+          return r.width > 0 && r.height > 0 && r.right > vw + 2 && r.left < vw;
+        }).length;
+      }, MOBILE_VIEWPORT.width);
+      expect(overflowing).toBe(0);
+    } finally {
+      if (collectionId) {
+        await fetch(`${API_URL}/collections/${encodeURIComponent(collectionId)}`, {
+          method: "DELETE",
+          headers: authHeaders(),
+        }).catch(() => {});
+      }
+    }
+  });
+
+  test("schedule calendar zoom control stays on screen", async ({ page }) => {
+    await page.goto("/schedule");
+    await page.getByRole("button", { name: /calendar/i }).click();
+
+    const zoomControls = page.locator(".ml-auto.flex.items-center").first();
+    await expect(zoomControls).toBeVisible({ timeout: 10_000 });
+
+    const box = await zoomControls.boundingBox();
+    expect(box).not.toBeNull();
+    if (box) {
+      expect(box.x).toBeGreaterThanOrEqual(0);
+      expect(box.x + box.width).toBeLessThanOrEqual(MOBILE_VIEWPORT.width);
+    }
   });
 });
 

--- a/web/tests/mobile-critical-flows.spec.ts
+++ b/web/tests/mobile-critical-flows.spec.ts
@@ -7,10 +7,10 @@
  * Issue: #500 — E2E: add Playwright tests for critical user flows
  */
 import {
-  API_URL,
-  authHeaders,
   configureBoard,
+  createCollection,
   createPage,
+  deleteAllCollections,
   deleteAllPages,
   expect,
   suppressWizard,
@@ -231,45 +231,36 @@ test.describe("Mobile — Long names stay inside the viewport", () => {
 
     // Day-pattern chip rows (All Days / Weekdays / Weekends) must wrap
     // rather than clip their trailing chips at phone width.
-    const chipOverflow = await page.evaluate((vw) => {
-      const rows = document.querySelectorAll('[role="dialog"] .ml-auto.flex');
-      return [...rows].filter((el) => el.getBoundingClientRect().right > vw + 2).length;
+    const chipRows = await page.evaluate((vw) => {
+      const rows = document.querySelectorAll('[role="dialog"] [data-testid="day-pattern-chips"]');
+      return {
+        count: rows.length,
+        overflowing: [...rows].filter((el) => el.getBoundingClientRect().right > vw + 2).length,
+      };
     }, MOBILE_VIEWPORT.width);
-    expect(chipOverflow).toBe(0);
+    expect(chipRows.count).toBeGreaterThan(0); // guard against a vacuous pass
+    expect(chipRows.overflowing).toBe(0);
   });
 
   test("collections card truncates long collection and page names", async ({ page }) => {
     const pageId = await createPage(LONG_NAME);
-    const res = await fetch(`${API_URL}/collections`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json", ...authHeaders() },
-      body: JSON.stringify({
-        name: "A Collection With An Unreasonably Long Name For Mobile Testing Purposes",
-        page_ids: [pageId],
-        interval_seconds: 60,
-      }),
-    });
-    const created = await res.json();
-    const collectionId: string | undefined = created?.collection?.id;
+    await createCollection("A Collection With An Unreasonably Long Name For Mobile Testing Purposes", [pageId], 60);
 
     try {
       await page.goto("/collections");
       await expect(page.getByText(/unreasonably long name/i).first()).toBeVisible({ timeout: 10_000 });
 
+      // No left-bound condition: an element pushed ENTIRELY past the right
+      // edge (r.left >= viewport) is just as broken as a partly-clipped one.
       const overflowing = await page.evaluate((vw) => {
         return [...document.querySelectorAll("main *")].filter((el) => {
           const r = el.getBoundingClientRect();
-          return r.width > 0 && r.height > 0 && r.right > vw + 2 && r.left < vw;
+          return r.width > 0 && r.height > 0 && r.right > vw + 2;
         }).length;
       }, MOBILE_VIEWPORT.width);
       expect(overflowing).toBe(0);
     } finally {
-      if (collectionId) {
-        await fetch(`${API_URL}/collections/${encodeURIComponent(collectionId)}`, {
-          method: "DELETE",
-          headers: authHeaders(),
-        }).catch(() => {});
-      }
+      await deleteAllCollections().catch(() => {});
     }
   });
 
@@ -302,7 +293,7 @@ test.describe("Mobile — Editor toolbar dropdowns", () => {
     await expect(colorsButton).toBeVisible({ timeout: 10_000 });
     await colorsButton.click();
 
-    const panel = page.locator(".absolute.top-full");
+    const panel = page.getByTestId("toolbar-dropdown-panel");
     await expect(panel).toBeVisible({ timeout: 5_000 });
 
     const box = await panel.boundingBox();

--- a/web/tests/mobile-critical-flows.spec.ts
+++ b/web/tests/mobile-critical-flows.spec.ts
@@ -164,3 +164,57 @@ test.describe("Mobile — Integrations", () => {
     }
   });
 });
+
+test.describe("Mobile — Board preview fits viewport", () => {
+  test("dashboard board preview stays inside its frame at phone width", async ({ page }) => {
+    await page.goto("/");
+    const firstTile = page.getByTestId("char-tile-0-0");
+    await expect(firstTile).toBeVisible({ timeout: 15_000 });
+    // Let ScaledBoardDisplay's measure + rAF scale pass settle
+    await page.waitForTimeout(500);
+
+    const geometry = await page.evaluate(() => {
+      const t0 = document.querySelector('[data-testid="char-tile-0-0"]');
+      const t21 = document.querySelector('[data-testid="char-tile-0-21"]');
+      if (!t0 || !t21) return null;
+      const frame = t0.closest('[class*="border-["]');
+      if (!frame) return null;
+      const fr = frame.getBoundingClientRect();
+      const r0 = t0.getBoundingClientRect();
+      const r21 = t21.getBoundingClientRect();
+      return {
+        frameInViewport: fr.left >= 0 && fr.right <= window.innerWidth,
+        tilesInsideFrame: r0.left >= fr.left - 0.5 && r21.right <= fr.right + 0.5,
+      };
+    });
+
+    expect(geometry).not.toBeNull();
+    expect(geometry?.frameInViewport).toBe(true);
+    expect(geometry?.tilesInsideFrame).toBe(true);
+  });
+});
+
+test.describe("Mobile — Editor toolbar dropdowns", () => {
+  test("colors picker stays inside the viewport at phone width", async ({ page }) => {
+    await page.goto("/pages/new?device=flagship");
+
+    // The editor persists rich/plain mode per browser — make sure we're in Rich
+    const richTab = page.getByRole("button", { name: /rich/i }).first();
+    await expect(richTab).toBeVisible({ timeout: 15_000 });
+    await richTab.click();
+
+    const colorsButton = page.getByRole("button", { name: "Colors" });
+    await expect(colorsButton).toBeVisible({ timeout: 10_000 });
+    await colorsButton.click();
+
+    const panel = page.locator(".absolute.top-full");
+    await expect(panel).toBeVisible({ timeout: 5_000 });
+
+    const box = await panel.boundingBox();
+    expect(box).not.toBeNull();
+    if (box) {
+      expect(box.x).toBeGreaterThanOrEqual(0);
+      expect(box.x + box.width).toBeLessThanOrEqual(MOBILE_VIEWPORT.width);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes six mobile-only overflow/rendering bugs, found via the original iPhone bug report plus a full app sweep (static audit of six overflow-prone pattern classes + dynamic 393px sweep of all 27 route states, seeded long-name data, and every interactive popup surface). All reproduced and re-verified in both Chromium and WebKit (iPhone emulation).

### Commit 1 — original report
1. **Editor toolbar pickers ran off-screen.** The tiptap `ToolbarDropdown` (Variables / Colors / Formatting / Formula) is anchored `absolute left-0` with no collision handling; a 274px panel opened at x=275 on a 393px viewport. It now measures the open panel and shifts it into view (re-clamping on panel/window resize), capped at `100vw - 16px`.
2. **Board previews overflowed their frame ("overlapping colors").** The dashboard Active Display and setup wizard rendered raw `BoardDisplay` (needs ~372px; the dashboard card offers ~320px on phones), clipping the first column and spilling color chips over the frame. Both now use `ScaledBoardDisplay`.

### Commit 2 — sweep findings
3. **Select dropdowns blew out with long item names (app-wide).** `SelectContent` had no max-width; Radix sizes the panel to the widest item and only clamps *position*, so a long page name produced a **659px-wide** dropdown on a 393px screen. Capped at `calc(100vw-16px)` in `ui/select.tsx` — long items now wrap. Covers the schedule form, gap-default select, plugin page pickers, etc.
4. **Collections cards never truncated.** The CardHeader grid item lacked `min-w-0`, so long names inflated the header row to ~755px via min-content propagation (Badge is `whitespace-nowrap`). Fixed with `min-w-0` at the grid item + truncating spans for the title and page chips.
5. **Schedule calendar zoom slider rendered off-screen** on phones (top bar needs ~500px). The bar now wraps, dropping the zoom control to its own right-aligned line.
6. **Schedule form day chips clipped** (Sun/Fri half-cut). Chip rows now wrap.

Everything else swept came back clean: settings tab strip scrolls, all tables have scroll/clip wrappers with responsive column hiding, timezone/time-picker portals stay in-viewport, Radix dropdown width overrides are ≤320px (collision-safe), media/canvas elements are fluid.

## Test plan

- [x] Reproduced all six at 393×852 before fixing (Chromium + WebKit); re-verified fixed in both engines
- [x] Desktop (1280px) spot-checked unchanged for calendar, collections, selects
- [x] 5 new Playwright regression tests in `web/tests/mobile-critical-flows.spec.ts` — each verified to fail on the unfixed code; full mobile spec: 16/16 passing
- [x] Full web unit suite green in the dev container (95 files, 1186 passed)
- [x] `eslint` (0 errors) and `prettier --check` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)