### PR TITLE
fix(e2e): use parallelIndex for per-worker backend pool

### DIFF
--- a/web/tests/helpers.ts
+++ b/web/tests/helpers.ts
@@ -42,9 +42,14 @@ export const MOCK_BOARD_PORT_2 = parseInt(process.env.MOCK_BOARD_PORT_2 || "1700
 export const BOARD_2_LOCAL_API_PORT = 7001;
 export let MOCK_BOARD_URL_2 = process.env.MOCK_BOARD_URL_2 || `http://localhost:${MOCK_BOARD_PORT_2}`;
 
-function _configureWorker(workerIndex: number) {
+// Backend-pool slot MUST come from parallelIndex, not workerIndex: when a
+// worker restarts after a failure the replacement gets a new unique
+// workerIndex, so `workerIndex % N` wraps onto a backend still owned by a
+// live worker and the two stomp each other's board config. parallelIndex is
+// stable per slot (always 0..workers-1, reused across restarts).
+function _configureWorker(parallelIndex: number) {
   if (_workerUrls.length > 0) {
-    const idx = workerIndex % _workerUrls.length;
+    const idx = parallelIndex % _workerUrls.length;
     API_URL = `${_workerUrls[idx]}/api`;
     MOCK_BOARD_URL = _workerMockUrls[idx] || DEFAULT_MOCK_BOARD_URL;
     BOARD_HOST = _workerMockHosts[idx] || DEFAULT_BOARD_HOST;
@@ -63,7 +68,7 @@ function _configureWorker(workerIndex: number) {
 export const test = base.extend<{ resetBackend: void }, { workerBackend: void }>({
   workerBackend: [
     async ({}, use, workerInfo) => {
-      _configureWorker(workerInfo.workerIndex);
+      _configureWorker(workerInfo.parallelIndex);
       await use();
     },
     { scope: "worker", auto: true },
@@ -71,7 +76,7 @@ export const test = base.extend<{ resetBackend: void }, { workerBackend: void }>
 
   baseURL: async ({}, use, workerInfo) => {
     if (_workerUrls.length > 0) {
-      const idx = workerInfo.workerIndex % _workerUrls.length;
+      const idx = workerInfo.parallelIndex % _workerUrls.length;
       // eslint-disable-next-line react-hooks/rules-of-hooks -- Playwright fixture `use` callback, not a React hook
       await use(_workerUrls[idx]);
     } else {


### PR DESCRIPTION
## Problem

The E2E helpers assign each Playwright worker an isolated backend with `workerInfo.workerIndex % WORKER_URLS.length`. Per the [Playwright docs](https://playwright.dev/docs/api/class-workerinfo), a worker restarted after a test failure gets a **new unique `workerIndex`**, while `parallelIndex` is the stable slot number (always `0..workers-1`, reused across restarts).

So the suite is only isolated until the first failure: the retry runs in a fresh worker with `workerIndex >= 4`, `% 4` wraps it onto a backend still owned by a live worker, and the two stomp each other's board config. One genuine flake cascades into mirror-image failures across unrelated specs.

Seen in [run 29896316641](https://github.com/Fiestaboard/FiestaBoard/actions/runs/29896316641) (PR #1402, a dep bump that touches no product code): `multi-board.spec.ts` saw a Note tab it never created at the same moment `regression/note-arrays.spec.ts` saw the note_array it had just saved come back as `flagship` — and every retry allocated yet another colliding index, so the retry failed too. This also explains the long-standing "rerun clears it" flake pattern: a clean rerun has no restarts, hence no collisions.

## Fix

Use `workerInfo.parallelIndex` for the backend/mock/cloud URL pool (both in `_configureWorker` and the `baseURL` fixture), with a comment explaining why `workerIndex` is wrong here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)