### PR TITLE
fix: local-array move/swap key pairing + Note Arrays docs (missed the #1399 merge)

### DIFF
--- a/docs-site/docs/setup/note-arrays.md
+++ b/docs-site/docs/setup/note-arrays.md
@@ -1,0 +1,126 @@
+---
+sidebar_position: 6
+description: "Set up a Vestaboard Note array in FiestaBoard — via the Cloud API with a single token, or entirely on your local network with per-Note IPs and keys."
+keywords:
+  [
+    Vestaboard Note array,
+    note array setup,
+    local array mode,
+    X-Vestaboard-Token,
+    local API,
+    multi-board,
+    split-flap wall,
+  ]
+---
+
+# Note Array Setup
+
+A **Note array** is several Vestaboard Notes tiled together into one larger
+display. FiestaBoard treats the whole array as a single canvas, so your pages,
+plugins, and schedules render across it just like they would on a Flagship or
+a single Note.
+
+Each Note is 15 × 3 characters, so an array's size is
+`(notes wide × 15) × (notes tall × 3)` — up to the 8 × 8 maximum
+(120 × 24 characters).
+
+Arrays can be driven two ways:
+
+| | Cloud mode | Local Array Mode |
+|---|---|---|
+| Credentials | One `X-Vestaboard-Token` | Each Note's IP + Local API key |
+| Network | Internet + Vestaboard Cloud | Your LAN only — private |
+| Rate limit | 1 message / 15 seconds | None |
+| Transition animations | Not available | Supported |
+| Subscription | Vestaboard Cloud API | None |
+
+## Add the board
+
+In the FiestaBoard web UI, open **Settings → Hardware**, click **Add Board**,
+and choose **Note Array**. The new board starts as a *2 side-by-side* array in
+Cloud mode. Pick your size with the **Board type** dropdown — five presets
+(2 side-by-side, 4 side-by-side, 2 stacked, 4 stacked, 2×2 grid) plus
+**Custom…** for anything up to 8 × 8 Notes.
+
+## Cloud mode
+
+1. Keep the connection on **Cloud API**.
+2. Paste your `X-Vestaboard-Token` (from your Vestaboard Cloud API
+   subscription — this is **not** the Read/Write key) into the
+   **Cloud API Token** field.
+3. Optionally click **Auto-detect from board** to read the array's size over
+   the Cloud API instead of picking it by hand.
+
+## Local Array Mode
+
+In local mode FiestaBoard slices each rendered frame into 15 × 3 pieces and
+sends every Note its own slice directly over your network — no cloud
+round-trip, no rate limit, and transitions work.
+
+### 1. Switch the connection to Local API
+
+In the board's **Connection** section, select **Local API**. The token field
+is replaced by the **Board tiles** grid: one slot per Note, laid out like your
+wall. (Auto-detect is hidden in local mode — the array's size is defined by
+the tiles you assign.)
+
+### 2. Assign each slot
+
+Click a slot to open its assignment dialog:
+
+- **Scan network for boards** lists Vestaboards found on your network — click
+  one to fill in its IP. Boards already assigned to another slot are labeled.
+- Or type the Note's **IP address** (and port, default `7000`) by hand.
+- Enter the Note's **Local API key** — or switch to **Enablement Token** and
+  exchange it for a key. Each Note has its own key.
+- **Test** checks that FiestaBoard can reach that Note; **Save tile** stores
+  the assignment.
+
+A partially assigned array still works — assigned Notes show their slice,
+unassigned slots stay dark. The badge above the grid tracks progress.
+
+### 3. Verify with Identify
+
+**Identify** works like your computer's monitor-arrangement screen: it flashes
+a slot's position number on the physical board it points at (per-slot, before
+or after saving, or **Identify all** at once). The pattern clears
+automatically on the next update cycle.
+
+### 4. Rearrange with Move
+
+If Identify reveals boards in the wrong order, open either slot and use
+**Move to position** — choosing an empty slot relocates the tile, choosing an
+occupied one swaps the two. Each board keeps its own IP and key; nothing to
+retype. The whole flow is keyboard-accessible: arrow keys move between slots,
+Enter opens a slot, and Move is a standard select.
+
+## Good to know
+
+- **Resizing keeps your keys.** Shrink a 2×2 to 2×1 and back — the hidden
+  tiles' IPs and keys are preserved and reappear.
+- **Local mode: Notes flip independently.** Tiles may start flipping a moment
+  apart; FiestaBoard sends them the same transition to keep the skew small.
+- **Cloud mode: one send every 15 seconds.** FiestaBoard throttles
+  automatically; very fast page rotations may not all reach the board.
+
+## Troubleshooting
+
+**Some Notes update and others don't (local mode).** Open the stale slots'
+dialogs and hit **Test** — an unreachable Note usually means a changed IP
+(give your Notes DHCP reservations) or a wrong key. Failed tiles are retried
+automatically on the next update cycle.
+
+**Two Notes show swapped content (local mode).** Their slots point at each
+other's IPs. **Identify all**, then swap them with **Move to position**.
+
+**The board doesn't update (cloud mode).** Check the **Cloud API Token** is
+set and your Vestaboard Cloud API subscription is active, and remember the
+15-second rate limit.
+
+## See also
+
+- [Local development](./local-development.md) — run FiestaBoard with the
+  bundled mock boards to try arrays without hardware.
+- The in-repo
+  [Note Arrays reference](https://github.com/Fiestaboard/FiestaBoard/blob/main/docs/reference/NOTE_ARRAYS.md)
+  — dimensions model, transports, and endpoints for contributors.

--- a/docs/reference/NOTE_ARRAYS.md
+++ b/docs/reference/NOTE_ARRAYS.md
@@ -105,7 +105,13 @@ one endpoint per Note.
   `normalize_note_array_tiles` / `BoardInstance.configured_tiles`).
   Out-of-range tiles are preserved across W×H resizes and filtered at point of
   use, so shrinking an array never destroys keys. Per-tile `local_api_key` is
-  masked (`"***"`) in API responses and resolved by `(row, col)` on write.
+  masked (`"***"`) in API responses; on write, a masked key is resolved against
+  the stored tiles **host:port-first** (so credentials follow the physical
+  board when the UI's Move/swap re-keys tiles to new grid positions), falling
+  back to `(row, col)` for the change-the-IP-keep-the-key flow.
+- **Rearranging.** The UI's "Move to position" is a plain tiles update over
+  `PUT /settings/board` — it rewrites `row`/`col` on the moved (or swapped)
+  tile dicts; there is no dedicated endpoint.
 - **Send path.** `NoteArrayLocalClient` (`src/note_array_local_client.py`)
   slices the full frame with `slice_note_array_grid()` into 15 × 3 subgrids
   and fans them out concurrently, one plain local `BoardClient` per tile.

--- a/docs/setup/NOTE_ARRAYS.md
+++ b/docs/setup/NOTE_ARRAYS.md
@@ -141,8 +141,18 @@ screen:
 The identify pattern clears automatically on the next update cycle (within the
 polling interval). If the board is paused, the pattern stays until you resume.
 
-If two boards are swapped, open either slot, point it at the other IP (rescan
-or edit the host), and save.
+### 4. Rearrange with Move — no retyping
+
+If Identify reveals boards in the wrong order, you don't have to re-enter
+anything. Open either slot's dialog and use **Move to position**:
+
+- Choosing an **empty** slot relocates the tile there.
+- Choosing an **occupied** slot swaps the two tiles — each board keeps its own
+  IP and Local API key.
+
+The whole flow works without a mouse: the slot grid supports **arrow-key
+navigation**, Enter opens a slot's dialog, and Move to position is a standard
+select. Run Identify all again afterwards to confirm the new arrangement.
 
 ## Good to know
 
@@ -181,7 +191,8 @@ Notes that succeeded aren't re-sent.
 
 **Two Notes show swapped content (local mode).**
 Their slots point at each other's IPs. Use **Identify all** to see which board
-answers for which position, then reassign the two slots.
+answers for which position, then open either slot and use **Move to position**
+to swap them — see [Rearrange with Move](#4-rearrange-with-move--no-retyping).
 
 **The layout looks cut off or wrong.**
 Check that **Notes wide** and **Notes tall** match your physical hardware. The

--- a/src/settings/service.py
+++ b/src/settings/service.py
@@ -1177,16 +1177,25 @@ class SettingsService:
             for key in BOARD_SENSITIVE_FIELDS:
                 if b.get(key) == "***":
                     b[key] = existing.get(key, "")
-            # Preserve masked per-tile credentials, matched by (row, col)
+            # Preserve masked per-tile credentials. Match by host:port FIRST so
+            # the key follows the physical board when tiles are moved/swapped
+            # to new grid positions (the UI's "Move to position" sends masked
+            # keys at the NEW coordinates — a position-only match would pair
+            # each host with the OTHER board's key). Fall back to (row, col)
+            # for the change-the-IP-keep-the-key flow.
             incoming_tiles = b.get("tiles")
             if isinstance(incoming_tiles, list):
-                existing_tiles_by_pos = {
-                    (t.get("row"), t.get("col")): t for t in existing.get("tiles") or [] if isinstance(t, dict)
-                }
+                existing_tiles = [t for t in existing.get("tiles") or [] if isinstance(t, dict)]
+                existing_tiles_by_pos = {(t.get("row"), t.get("col")): t for t in existing_tiles}
+                existing_tiles_by_endpoint: dict = {}
+                for t in existing_tiles:
+                    existing_tiles_by_endpoint.setdefault((t.get("host"), t.get("port")), t)
                 for tile in incoming_tiles:
                     if not isinstance(tile, dict):
                         continue
-                    existing_tile = existing_tiles_by_pos.get((tile.get("row"), tile.get("col")), {})
+                    existing_tile = existing_tiles_by_endpoint.get(
+                        (tile.get("host"), tile.get("port"))
+                    ) or existing_tiles_by_pos.get((tile.get("row"), tile.get("col")), {})
                     for key in TILE_SENSITIVE_FIELDS:
                         if tile.get(key) == "***":
                             tile[key] = existing_tile.get(key, "")

--- a/tests/test_settings_service.py
+++ b/tests/test_settings_service.py
@@ -861,3 +861,39 @@ class TestLocalArrayTileMasking:
         settings_service.set_boards([update])
         tiles = {(t["row"], t["col"]): t for t in settings_service._board.boards[0]["tiles"]}
         assert tiles[(0, 0)]["local_api_key"] == "rotated"
+
+    def test_set_boards_swap_keeps_key_with_its_board(self, settings_service):
+        """Moving/swapping tiles sends masked keys at NEW positions — each key
+        must follow its physical board (host), not the grid position."""
+        board = self._array_board()
+        board["tiles"][0]["local_api_key"] = "key-for-host-1"
+        board["tiles"][1]["local_api_key"] = "key-for-host-2"
+        settings_service.set_boards([board])
+        board_id = settings_service._board.boards[0]["id"]
+
+        # The UI's swap: hosts trade places, keys are masked, positions are new.
+        update = self._array_board(id=board_id)
+        update["tiles"] = [
+            {"row": 0, "col": 0, "host": "10.0.0.2", "port": 7000, "local_api_key": "***", "enabled": True},
+            {"row": 0, "col": 1, "host": "10.0.0.1", "port": 7000, "local_api_key": "***", "enabled": True},
+        ]
+        settings_service.set_boards([update])
+
+        by_host = {t["host"]: t["local_api_key"] for t in settings_service._board.boards[0]["tiles"]}
+        assert by_host["10.0.0.1"] == "key-for-host-1"
+        assert by_host["10.0.0.2"] == "key-for-host-2"
+
+    def test_set_boards_host_edit_at_same_position_keeps_key(self, settings_service):
+        """Changing a tile's IP (same slot, masked key) keeps the stored key —
+        the (row, col) fallback when no host matches."""
+        settings_service.set_boards([self._array_board()])
+        board_id = settings_service._board.boards[0]["id"]
+
+        update = self._array_board(id=board_id)
+        update["tiles"][0]["host"] = "10.0.0.77"  # new IP, no existing tile has it
+        update["tiles"][0]["local_api_key"] = "***"
+        settings_service.set_boards([update])
+
+        tiles = {(t["row"], t["col"]): t for t in settings_service._board.boards[0]["tiles"]}
+        assert tiles[(0, 0)]["host"] == "10.0.0.77"
+        assert tiles[(0, 0)]["local_api_key"] == "secret-a"


### PR DESCRIPTION
## Summary

PR #1399 was enqueued at `9f6f2f5d` and merged at that snapshot, so the last two `localnext` commits didn't land. This PR carries them onto `main`:

**🐛 Fix (worth a patch release): move/swap mispairs tile credentials**
The tile-assignment UI's "Move to position" sends masked (`"***"`) keys at their NEW grid positions, but `set_boards` restored masked keys by `(row, col)`. Swapping two tiles whose Notes have *different* Local API keys silently paired each board's IP with the *other* board's key — both tiles then fail to auth. Masked keys now resolve **host:port-first** (credentials follow the physical board), with the `(row, col)` fallback preserving the change-the-IP-keep-the-key flow. Regression tests cover both paths.

This shipped in 8.2.0, so a `8.2.1` with this fix is recommended before users build multi-key local arrays.

**📝 Docs the feature was missing**
- Setup guide: new "Rearrange with Move" section (incl. keyboard navigation); the stale "point it at the other IP" troubleshooting advice now points at Move.
- Reference: host-first masked-key resolution; rearranging rides `PUT /settings/board`.
- **New docs-site page** `docs-site/docs/setup/note-arrays.md` → `fiestaboard.app/docs/setup/note-arrays`: the site previously had **no** Note Arrays page at all (cloud or local). Covers both modes with a comparison table, assignment/identify/move flows, and troubleshooting. (Note: the page goes live only once the docs-site deploy OOM issue is resolved — the live site has served stale content since June 11.)

## Verification

- `pytest tests/test_settings_service.py tests/test_devices.py` — 263 passed (includes the new swap-keeps-key-with-board and host-edit-keeps-key regression tests)
- ruff check + format clean; markdownlint + cspell clean across all three docs files

🤖 Generated with [Claude Code](https://claude.com/claude-code)