### PR TITLE
fix(draw-mode): follow-up sweep — token normalization, guards, picker keyboard nav (#1414)

### DIFF
--- a/web/src/__tests__/draw-char-picker.test.tsx
+++ b/web/src/__tests__/draw-char-picker.test.tsx
@@ -27,6 +27,58 @@ describe("DrawCharPickerContent", () => {
     expect(container.querySelector('[data-draw-char="A"]')).toHaveAttribute("aria-pressed", "false");
   });
 
+  it("keeps exactly one button in the tab order (roving tabindex)", () => {
+    const { container } = render(<DrawCharPickerContent current={{ kind: "eraser" }} onSelect={vi.fn()} />);
+    const buttons = Array.from(container.querySelectorAll<HTMLButtonElement>("[data-draw-char]"));
+    expect(buttons.filter((b) => b.tabIndex === 0)).toHaveLength(1);
+    expect(buttons[0].tabIndex).toBe(0);
+  });
+
+  it("starts the tab order on the currently selected character", () => {
+    const { container } = render(<DrawCharPickerContent current={{ kind: "char", char: "Z" }} onSelect={vi.fn()} />);
+    expect(container.querySelector<HTMLButtonElement>('[data-draw-char="Z"]')!.tabIndex).toBe(0);
+    expect(container.querySelector<HTMLButtonElement>('[data-draw-char="A"]')!.tabIndex).toBe(-1);
+  });
+
+  it("moves focus with arrow keys across the 8-column grid", () => {
+    const { container } = render(<DrawCharPickerContent current={{ kind: "eraser" }} onSelect={vi.fn()} />);
+    const buttons = Array.from(container.querySelectorAll<HTMLButtonElement>("[data-draw-char]"));
+
+    buttons[0].focus();
+    fireEvent.keyDown(buttons[0], { key: "ArrowRight" });
+    expect(document.activeElement).toBe(buttons[1]);
+    expect(buttons[1].tabIndex).toBe(0);
+    expect(buttons[0].tabIndex).toBe(-1);
+
+    fireEvent.keyDown(buttons[1], { key: "ArrowDown" });
+    expect(document.activeElement).toBe(buttons[9]);
+
+    fireEvent.keyDown(buttons[9], { key: "ArrowUp" });
+    expect(document.activeElement).toBe(buttons[1]);
+
+    fireEvent.keyDown(buttons[1], { key: "ArrowLeft" });
+    expect(document.activeElement).toBe(buttons[0]);
+  });
+
+  it("wraps focus at the grid edges and supports Home/End", () => {
+    const { container } = render(<DrawCharPickerContent current={{ kind: "eraser" }} onSelect={vi.fn()} />);
+    const buttons = Array.from(container.querySelectorAll<HTMLButtonElement>("[data-draw-char]"));
+    const last = buttons.length - 1;
+
+    buttons[0].focus();
+    fireEvent.keyDown(buttons[0], { key: "ArrowLeft" });
+    expect(document.activeElement).toBe(buttons[last]);
+
+    fireEvent.keyDown(buttons[last], { key: "ArrowRight" });
+    expect(document.activeElement).toBe(buttons[0]);
+
+    fireEvent.keyDown(buttons[0], { key: "End" });
+    expect(document.activeElement).toBe(buttons[last]);
+
+    fireEvent.keyDown(buttons[last], { key: "Home" });
+    expect(document.activeElement).toBe(buttons[0]);
+  });
+
   it("keeps an explicit width on the wrapper so the dropdown panel cannot shrink-fit", () => {
     // Regression pin: the ToolbarDropdown panel is absolutely positioned in a
     // trigger-sized wrapper; without an explicit width the panel collapses to

--- a/web/src/__tests__/draw-mode-utils.test.ts
+++ b/web/src/__tests__/draw-mode-utils.test.ts
@@ -38,6 +38,12 @@ describe("lineToCells", () => {
   it("does not treat inherited object keys as colors", () => {
     expect(lineToCells("{{constructor}}X")).toEqual(["X"]);
   });
+  it("normalizes the purple alias to the canonical violet cell in every token form", () => {
+    expect(lineToCells("{{purple}}")).toEqual(["{{violet}}"]);
+    expect(lineToCells("{purple}")).toEqual(["{{violet}}"]);
+    expect(lineToCells("{68}")).toEqual(["{{violet}}"]);
+    expect(lineToCells("{{violet}}")).toEqual(["{{violet}}"]);
+  });
 });
 
 describe("cellsToLine", () => {
@@ -61,6 +67,12 @@ describe("isPositionalLine", () => {
   });
   it("is false for inherited object keys", () => {
     expect(isPositionalLine("{{constructor}}")).toBe(false);
+  });
+  it("accepts every color token form lineToCells accepts (shared tokenizer)", () => {
+    // Single-brace named colors and numeric codes are one cell each in
+    // lineToCells, so they must count as positional too.
+    expect(isPositionalLine("{red}{63}{71}AB")).toBe(true);
+    expect(isPositionalLine("{{purple}}{{ RED }}")).toBe(true);
   });
 });
 
@@ -111,6 +123,9 @@ describe("brushToCell", () => {
   it("maps a color brush to a {{color}} cell", () => {
     expect(brushToCell({ kind: "color", color: "red" })).toBe("{{red}}");
     expect(brushToCell({ kind: "color", color: "black" })).toBe("{{black}}");
+  });
+  it("maps a purple brush to the canonical {{violet}} cell", () => {
+    expect(brushToCell({ kind: "color", color: "purple" })).toBe("{{violet}}");
   });
   it("maps the eraser brush to a blank cell", () => {
     expect(brushToCell({ kind: "eraser" })).toBe(" ");
@@ -189,5 +204,8 @@ describe("renderPositionalLine", () => {
   });
   it("passes literals through and drops dynamic tokens", () => {
     expect(renderPositionalLine("HI {{weather.temp}}!")).toBe("HI !");
+  });
+  it("renders the purple alias as the canonical violet marker", () => {
+    expect(renderPositionalLine("{{purple}}")).toBe("{violet}");
   });
 });

--- a/web/src/__tests__/tiptap-editor-apply-stroke.test.tsx
+++ b/web/src/__tests__/tiptap-editor-apply-stroke.test.tsx
@@ -20,7 +20,7 @@ describe("TipTapTemplateEditor applyStroke", () => {
   async function setup(value: string) {
     const ref = createRef<TipTapTemplateEditorHandle>();
     const onChange = vi.fn();
-    render(
+    const { unmount } = render(
       <TipTapTemplateEditor
         ref={ref}
         value={value}
@@ -31,7 +31,7 @@ describe("TipTapTemplateEditor applyStroke", () => {
       />,
     );
     await waitFor(() => expect(ref.current).not.toBeNull());
-    return { ref, onChange };
+    return { ref, onChange, unmount };
   }
 
   it("paints cells into template lines as one change", async () => {
@@ -95,5 +95,18 @@ describe("TipTapTemplateEditor applyStroke", () => {
     await waitFor(() => {
       expect((onChange.mock.calls.at(-1)![0] as string).split("\n")[0]).toBe("");
     });
+  });
+
+  it("undo/redo/applyStroke are safe no-ops once the editor is destroyed", async () => {
+    const { ref, unmount } = await setup("HELLO\n\n\n\n\n");
+    const handle = ref.current!;
+    unmount();
+    // TipTap's useEditor schedules the destroy after unmount — wait until the
+    // guard actually sees a destroyed editor before asserting the no-ops.
+    await waitFor(() => {
+      expect(handle.applyStroke([{ row: 0, col: 0 }], { kind: "eraser" })).toEqual([]);
+    });
+    expect(() => handle.undo()).not.toThrow();
+    expect(() => handle.redo()).not.toThrow();
   });
 });

--- a/web/src/components/tiptap-template-editor/TipTapTemplateEditor.tsx
+++ b/web/src/components/tiptap-template-editor/TipTapTemplateEditor.tsx
@@ -773,10 +773,14 @@ export const TipTapTemplateEditor = forwardRef<TipTapTemplateEditorHandle, TipTa
           return [...byRow.keys()].sort((a, b) => a - b);
         },
         undo() {
-          editorRef.current?.chain().undo().run();
+          const ed = editorRef.current;
+          if (!ed || ed.isDestroyed) return;
+          ed.chain().undo().run();
         },
         redo() {
-          editorRef.current?.chain().redo().run();
+          const ed = editorRef.current;
+          if (!ed || ed.isDestroyed) return;
+          ed.chain().redo().run();
         },
       }),
       [boardLines, boardWidth],
@@ -786,6 +790,10 @@ export const TipTapTemplateEditor = forwardRef<TipTapTemplateEditorHandle, TipTa
     // even when a line's content wraps to multiple visual rows.
     const measureLineHeights = useCallback(() => {
       if (!editor || editor.isDestroyed) return;
+      // In draw mode the editor container is display:none (still connected),
+      // so coordsAtPos would measure a hidden node and produce garbage.
+      // Skip; a measure is scheduled when draw mode exits.
+      if (drawMode) return;
       try {
         const { state, view } = editor;
         if (!view.dom.isConnected) return;
@@ -826,7 +834,7 @@ export const TipTapTemplateEditor = forwardRef<TipTapTemplateEditorHandle, TipTa
       } catch {
         // ignore transient measurement errors
       }
-    }, [editor, boardLines]);
+    }, [editor, boardLines, drawMode]);
 
     const scheduleMeasure = useCallback(() => {
       if (measureScheduledRef.current) return;
@@ -841,6 +849,12 @@ export const TipTapTemplateEditor = forwardRef<TipTapTemplateEditorHandle, TipTa
     useEffect(() => {
       scheduleMeasureRef.current = scheduleMeasure;
     }, [scheduleMeasure]);
+
+    // Measurement is skipped while draw mode hides the editor, so schedule a
+    // fresh measure as soon as draw mode exits (and the editor is visible).
+    useEffect(() => {
+      if (!drawMode) scheduleMeasure();
+    }, [drawMode, scheduleMeasure]);
 
     // Re-measure when the editor container is resized (e.g. window resize)
     useEffect(() => {

--- a/web/src/components/tiptap-template-editor/components/DrawCharPickerContent.tsx
+++ b/web/src/components/tiptap-template-editor/components/DrawCharPickerContent.tsx
@@ -3,6 +3,8 @@
  */
 "use client";
 
+import { useRef, useState } from "react";
+
 import { cn } from "@/lib/utils";
 
 import type { DrawBrush } from "../utils/draw-mode";
@@ -13,8 +15,52 @@ interface DrawCharPickerContentProps {
   onSelect: (brush: DrawBrush) => void;
 }
 
+const GRID_COLS = 8;
+
 export function DrawCharPickerContent({ current, onSelect }: DrawCharPickerContentProps) {
   const selectedChar = current.kind === "char" ? current.char : null;
+  const buttonRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  // Roving tabindex: exactly one button is in the tab order (the selected
+  // character if any, otherwise the first), arrow keys move focus.
+  const [focusedIndex, setFocusedIndex] = useState(() => {
+    const selectedIndex = selectedChar ? DRAW_CHARS.indexOf(selectedChar) : -1;
+    return selectedIndex >= 0 ? selectedIndex : 0;
+  });
+
+  const moveFocus = (index: number) => {
+    const wrapped = ((index % DRAW_CHARS.length) + DRAW_CHARS.length) % DRAW_CHARS.length;
+    setFocusedIndex(wrapped);
+    buttonRefs.current[wrapped]?.focus();
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+    switch (event.key) {
+      case "ArrowRight":
+        event.preventDefault();
+        moveFocus(index + 1);
+        break;
+      case "ArrowLeft":
+        event.preventDefault();
+        moveFocus(index - 1);
+        break;
+      case "ArrowDown":
+        event.preventDefault();
+        moveFocus(index + GRID_COLS);
+        break;
+      case "ArrowUp":
+        event.preventDefault();
+        moveFocus(index - GRID_COLS);
+        break;
+      case "Home":
+        event.preventDefault();
+        moveFocus(0);
+        break;
+      case "End":
+        event.preventDefault();
+        moveFocus(DRAW_CHARS.length - 1);
+        break;
+    }
+  };
 
   return (
     // w-64 matters: the dropdown panel is absolutely positioned inside a
@@ -23,14 +69,20 @@ export function DrawCharPickerContent({ current, onSelect }: DrawCharPickerConte
     // collapse until the glyph buttons overlap.
     <div className="w-64 p-2" data-testid="draw-char-picker">
       <div className="grid grid-cols-8 gap-1">
-        {DRAW_CHARS.map((char) => (
+        {DRAW_CHARS.map((char, index) => (
           <button
             key={char}
+            ref={(el) => {
+              buttonRefs.current[index] = el;
+            }}
             type="button"
             data-draw-char={char}
+            tabIndex={index === focusedIndex ? 0 : -1}
             aria-pressed={selectedChar === char}
             aria-label={char}
             onClick={() => onSelect({ kind: "char", char })}
+            onFocus={() => setFocusedIndex(index)}
+            onKeyDown={(event) => handleKeyDown(event, index)}
             className={cn(
               "flex h-7 w-7 items-center justify-center rounded border font-mono text-sm transition-shadow",
               selectedChar === char ? "ring-2 ring-primary ring-offset-1" : "hover:bg-muted/50",

--- a/web/src/components/tiptap-template-editor/components/ToolbarDropdown.tsx
+++ b/web/src/components/tiptap-template-editor/components/ToolbarDropdown.tsx
@@ -126,7 +126,7 @@ export function ToolbarDropdown({
                 "hover:bg-muted/50 transition-colors",
                 "border border-transparent",
                 isOpen && "bg-muted/70 border-border",
-                disabled && "opacity-50 cursor-not-allowed",
+                disabled && "opacity-60 cursor-not-allowed",
                 className,
               )}
               aria-expanded={isOpen}

--- a/web/src/components/tiptap-template-editor/utils/draw-mode.ts
+++ b/web/src/components/tiptap-template-editor/utils/draw-mode.ts
@@ -71,8 +71,13 @@ const CODE_TO_NAME: Record<number, BoardColorName> = {
   71: "black",
 };
 
+/** Canonical spelling for aliased color names ("purple" is an alias of "violet"). */
+function canonicalColor(color: BoardColorName): BoardColorName {
+  return color === "purple" ? "violet" : color;
+}
+
 function colorCell(color: BoardColorName): Cell {
-  return `{{${color}}}`;
+  return `{{${canonicalColor(color)}}}`;
 }
 
 /** Maps the active brush to the cell content it writes. */
@@ -91,8 +96,13 @@ export function brushToCell(brush: DrawBrush): Cell {
   }
 }
 
-export function lineToCells(line: string): Cell[] {
+/**
+ * Shared tokenizer behind lineToCells and isPositionalLine so their notion of
+ * "what is a color token vs a dynamic token" can never diverge.
+ */
+function tokenizeLine(line: string): { cells: Cell[]; droppedDynamic: boolean } {
   const cells: Cell[] = [];
+  let droppedDynamic = false;
   let remaining = line;
 
   while (remaining.length > 0) {
@@ -101,8 +111,10 @@ export function lineToCells(line: string): Cell[] {
       const content = dbl[1].trim().toLowerCase();
       if (Object.hasOwn(BOARD_COLORS, content)) {
         cells.push(colorCell(content as BoardColorName));
+      } else {
+        // Non-color {{...}} tokens are dynamic — dropped.
+        droppedDynamic = true;
       }
-      // Non-color {{...}} tokens are dynamic — dropped.
       remaining = remaining.slice(dbl[0].length);
       continue;
     }
@@ -128,7 +140,11 @@ export function lineToCells(line: string): Cell[] {
     remaining = remaining.slice(1);
   }
 
-  return cells;
+  return { cells, droppedDynamic };
+}
+
+export function lineToCells(line: string): Cell[] {
+  return tokenizeLine(line).cells;
 }
 
 export function cellsToLine(cells: Cell[]): string {
@@ -138,12 +154,7 @@ export function cellsToLine(cells: Cell[]): string {
 }
 
 export function isPositionalLine(line: string): boolean {
-  const re = /\{\{([^}]+)\}\}/g;
-  let match: RegExpExecArray | null;
-  while ((match = re.exec(line))) {
-    if (!Object.hasOwn(BOARD_COLORS, match[1].trim().toLowerCase())) return false;
-  }
-  return true;
+  return !tokenizeLine(line).droppedDynamic;
 }
 
 export function paintLine(line: string, paints: CellPaint[], cols: number): string {


### PR DESCRIPTION
Part of #1414

Follow-up sweep from the pencil draw mode reviews (PR #1413). This PR lands the small production items; the remaining checklist items (undo metadata restore, row-scoped `applyStroke`, `data-cell-value` gating, and the test-only items) are deliberately deferred to later PRs.

## Checklist items addressed

- [x] Normalize the `{purple}` alias to `violet` — `colorCell` now canonicalizes the alias, so `{{purple}}`, `{purple}`, and `{68}` all produce the single canonical `{{violet}}` cell string (`draw-mode.ts`).
- [x] Unify `isPositionalLine` with `lineToCells` — both now derive from a shared `tokenizeLine` tokenizer, so their notion of color vs dynamic tokens can no longer diverge (single-brace colors and numeric codes included).
- [x] Add `isDestroyed` guard to the editor handle's `undo()`/`redo()` (parity with `applyStroke`).
- [x] Skip the line-height re-measure rAF while the editor is hidden in draw mode — `measureLineHeights` bails while `drawMode` is active (the container is `display:none` but still connected, so `coordsAtPos` measured a hidden node), and a fresh measure is scheduled on draw-mode exit.
- [x] Keyboard navigation parity for the draw character picker — roving tabindex plus Arrow/Home/End handling on the 8-column stamp grid, mirroring `ColorPickerContent`; the tab order starts on the currently selected character.
- [x] Unify disabled styling — `ToolbarDropdown` now uses `opacity-60` like the direct toolbar buttons.

## Tests

- `draw-mode-utils.test.ts`: purple-alias normalization across all token forms (`lineToCells`, `brushToCell`, `renderPositionalLine`) and shared-tokenizer parity for `isPositionalLine`.
- `tiptap-editor-apply-stroke.test.tsx`: `undo`/`redo`/`applyStroke` are safe no-ops on a destroyed editor.
- `draw-char-picker.test.tsx`: roving tabindex, arrow-key grid navigation, edge wrapping, Home/End.

Full web suite, lint, and `format:check` run in the Docker test container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
