### PR TITLE
feat(boards): per-board display engine — BoardRuntime unification (#1243)

### DIFF
--- a/plugins/_template/README.md
+++ b/plugins/_template/README.md
@@ -177,6 +177,7 @@ The `screenshots` array makes plugin images discoverable by the docs site, API, 
 ```python
 from src.plugins.base import PluginBase, PluginResult
 
+
 class MyPlugin(PluginBase):
     @property
     def plugin_id(self) -> str:
@@ -226,12 +227,14 @@ python scripts/run_plugin_tests.py
 
 ```python
 """Tests for the my_plugin plugin."""
+
 import json, pytest
 from pathlib import Path
 from plugins.my_plugin import MyPlugin
 from src.plugins.base import PluginResult
 
 MANIFEST_PATH = Path(__file__).parent.parent / "manifest.json"
+
 
 # PluginBase stores the manifest as a plain dict and calls `.get()` on it,
 # so the fixture must return the parsed dict — exactly what the loader passes
@@ -242,6 +245,7 @@ MANIFEST_PATH = Path(__file__).parent.parent / "manifest.json"
 def manifest():
     with open(MANIFEST_PATH) as f:
         return json.load(f)
+
 
 class TestMyPlugin:
     def test_plugin_id(self, manifest):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,5 +9,5 @@ pytest-xdist>=3.6.0
 coverage>=7.6.0
 
 # Linting
-ruff>=0.9.0
+ruff==0.16.0  # pinned: unpinned ruff made `ruff format --check` in CI nondeterministic across releases
 

--- a/src/main.py
+++ b/src/main.py
@@ -27,130 +27,370 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
+class BoardRuntime:
+    """Client + per-board display state for one configured board.
+
+    Introduced by issue #1243: every board FiestaBoard drives gets its own
+    ``BoardRuntime`` so per-board caches (last-sent content, silence/snooze
+    state, board-read cache) never clobber each other. The ``DisplayService``
+    holds ``runtimes: dict[board_id, BoardRuntime]`` and routes every board
+    through a single unified per-board path (``check_and_send_for_board``).
+
+    ``config_signature`` lets a hot reload keep an unchanged board's runtime
+    (and its caches) instead of rebuilding it — see
+    ``DisplayService.rebuild_board_clients``.
+    """
+
+    def __init__(self, client: BoardClient | None, board_id):
+        self.board_id = board_id
+        self.client = client
+        self.config_signature = None
+
+        # Active-page send cache (dedupes unchanged sends per board).
+        self.last_active_page_content: str | None = None
+        self.last_active_page_id: str | None = None
+
+        # Silence-mode state (global decision, per-board delivery).
+        self.last_silence_mode_active: bool = False
+        self.snoozing_message_sent: bool = False
+
+        # Board-state read cache (populated by the poll thread / adaptive
+        # refresh). Board-state polling stays primary-only (see
+        # ``_board_poll_loop``), but the cache lives on the runtime so a
+        # future per-board poll is a drop-in change.
+        self.polled_characters: list[list[int]] | None = None
+        self.polled_at: float | None = None
+
+        # Adaptive post-send refresh thread + its cancel event.
+        self.refresh_thread: threading.Thread | None = None
+        self.refresh_cancel: threading.Event | None = None
+
+        # Collection cadence gate for the run loop: monotonic-ish epoch time
+        # of the next collection-boundary check for this board. 0.0 means
+        # "check immediately". Only the primary runtime is consulted today.
+        self.next_collection_check: float = 0.0
+
+
 class DisplayService:
     """Main service for displaying information on the board."""
+
+    # Runtime key for the primary board when no board id is available
+    # (legacy single-board Config installs, or tests that set ``vb_client``
+    # directly without a boards list).
+    _PRIMARY_FALLBACK_KEY = "__primary__"
 
     def __init__(self):
         """Initialize the display service."""
         self.running = True
-        self.vb_client: BoardClient | None = None
-        # One client per configured board (keyed by board id). ``vb_client``
-        # stays the first board's client for the many single-board code
-        # paths (manual send, debug, plugins); the update loop uses this map
-        # to drive secondary boards. See issue #1243.
-        self.board_clients: dict[str, BoardClient] = {}
+        # One runtime per configured board (keyed by board id). All per-board
+        # display state lives on the runtime; ``self.vb_client`` and the
+        # ``self._last_*`` / ``self._polled_*`` attributes are back-compat
+        # properties aliasing the PRIMARY board's runtime so untouched callers
+        # (api_server.py, mqtt/commands.py) and existing tests keep working.
+        self.runtimes: dict[str, BoardRuntime] = {}
+        self._primary_board_id = None
 
-        # Active page polling state
-        self._last_active_page_content: str | None = None
-        self._last_active_page_id: str | None = None
-        self._last_silence_mode_active: bool = False
-        self._snoozing_message_sent: bool = False
-        # Per-secondary-board content cache: board_id -> (page_id, content).
-        # Mirrors _last_active_page_* for the primary board.
-        self._secondary_last_sent: dict[str, tuple[str, str]] = {}
-
-        # Board state polling (background thread reads actual board state)
-        self._polled_characters: list[list[int]] | None = None
-        self._polled_at: float | None = None
+        # Board state polling (background thread reads actual board state).
         self._poll_thread: threading.Thread | None = None
-        # Adaptive post-send refresh: a background thread polls the board
-        # on a short ramp after each send and stops early once the read
-        # matches what we just sent. ``_refresh_cancel`` lets a subsequent
-        # call abort an in-flight cycle so rapid sends don't pile up.
-        self._refresh_thread: threading.Thread | None = None
-        self._refresh_cancel: threading.Event | None = None
+
+    # ------------------------------------------------------------------ #
+    # Primary-runtime resolution + back-compat property shims
+    # ------------------------------------------------------------------ #
+
+    def _primary_runtime(self) -> BoardRuntime | None:
+        """Return the primary board's runtime, or None if none exists yet."""
+        if self._primary_board_id is None:
+            return None
+        return self.runtimes.get(self._primary_board_id)
+
+    def _resolve_primary_key(self):
+        """Best-effort key for the primary runtime.
+
+        Prefers the already-established primary id, then the settings SSOT
+        (``get_primary_board_id``), then a stable sentinel so setting
+        ``vb_client`` always has somewhere to live.
+        """
+        if self._primary_board_id is not None:
+            return self._primary_board_id
+        try:
+            bid = get_settings_service().get_primary_board_id()
+        except Exception:
+            bid = None
+        return bid if bid else self._PRIMARY_FALLBACK_KEY
+
+    def _ensure_primary_runtime(self) -> BoardRuntime:
+        """Return the primary runtime, creating an empty one if needed."""
+        rt = self._primary_runtime()
+        if rt is None:
+            key = self._resolve_primary_key()
+            rt = self.runtimes.get(key)
+            if rt is None:
+                rt = BoardRuntime(client=None, board_id=key)
+                self.runtimes[key] = rt
+            self._primary_board_id = key
+        return rt
+
+    @property
+    def vb_client(self) -> BoardClient | None:
+        """The primary board's client (kept for single-board code paths)."""
+        rt = self._primary_runtime()
+        return rt.client if rt is not None else None
+
+    @vb_client.setter
+    def vb_client(self, client: BoardClient | None) -> None:
+        key = self._resolve_primary_key()
+        self._primary_board_id = key
+        rt = self.runtimes.get(key)
+        if rt is None:
+            self.runtimes[key] = BoardRuntime(client=client, board_id=key)
+        else:
+            rt.client = client
+
+    @property
+    def board_clients(self) -> dict:
+        """Read-only view {board_id -> client} for callers that iterate boards."""
+        return {bid: rt.client for bid, rt in self.runtimes.items() if rt.client is not None}
+
+    def get_board_client(self, board_id) -> BoardClient | None:
+        """Return the client for a board id, or None. Seam for per-board send routing (#1244)."""
+        rt = self.runtimes.get(board_id)
+        return rt.client if rt is not None else None
+
+    # Issue-#1243 wording alias for the same seam.
+    get_client = get_board_client
+
+    def get_runtime(self, board_id) -> BoardRuntime | None:
+        """Return the runtime for a board id, or None."""
+        return self.runtimes.get(board_id)
+
+    # -- State shims aliasing the primary runtime (read + write). --------- #
+
+    @property
+    def _last_active_page_content(self):
+        rt = self._primary_runtime()
+        return rt.last_active_page_content if rt is not None else None
+
+    @_last_active_page_content.setter
+    def _last_active_page_content(self, value):
+        self._ensure_primary_runtime().last_active_page_content = value
+
+    @property
+    def _last_active_page_id(self):
+        rt = self._primary_runtime()
+        return rt.last_active_page_id if rt is not None else None
+
+    @_last_active_page_id.setter
+    def _last_active_page_id(self, value):
+        self._ensure_primary_runtime().last_active_page_id = value
+
+    @property
+    def _last_silence_mode_active(self) -> bool:
+        rt = self._primary_runtime()
+        return rt.last_silence_mode_active if rt is not None else False
+
+    @_last_silence_mode_active.setter
+    def _last_silence_mode_active(self, value):
+        self._ensure_primary_runtime().last_silence_mode_active = value
+
+    @property
+    def _snoozing_message_sent(self) -> bool:
+        rt = self._primary_runtime()
+        return rt.snoozing_message_sent if rt is not None else False
+
+    @_snoozing_message_sent.setter
+    def _snoozing_message_sent(self, value):
+        self._ensure_primary_runtime().snoozing_message_sent = value
+
+    @property
+    def _polled_characters(self):
+        rt = self._primary_runtime()
+        return rt.polled_characters if rt is not None else None
+
+    @_polled_characters.setter
+    def _polled_characters(self, value):
+        self._ensure_primary_runtime().polled_characters = value
+
+    @property
+    def _polled_at(self):
+        rt = self._primary_runtime()
+        return rt.polled_at if rt is not None else None
+
+    @_polled_at.setter
+    def _polled_at(self, value):
+        self._ensure_primary_runtime().polled_at = value
+
+    @property
+    def _refresh_thread(self):
+        rt = self._primary_runtime()
+        return rt.refresh_thread if rt is not None else None
+
+    @_refresh_thread.setter
+    def _refresh_thread(self, value):
+        self._ensure_primary_runtime().refresh_thread = value
+
+    @property
+    def _refresh_cancel(self):
+        rt = self._primary_runtime()
+        return rt.refresh_cancel if rt is not None else None
+
+    @_refresh_cancel.setter
+    def _refresh_cancel(self, value):
+        self._ensure_primary_runtime().refresh_cancel = value
+
+    # ------------------------------------------------------------------ #
+    # Building / rebuilding runtimes
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _config_signature(board: dict) -> tuple:
+        """Connection-config signature: unchanged => keep the existing runtime.
+
+        Includes the Local Array Mode tile list (#1399) so editing a tile's
+        host/key/enabled state rebuilds the NoteArrayLocalClient.
+        """
+        tiles = board.get("tiles") or []
+        tiles_sig = tuple(sorted(str(t) for t in tiles)) if isinstance(tiles, list) else ()
+        return (
+            (board.get("api_mode") or "local").lower(),
+            board.get("host") or "",
+            board.get("port"),
+            board.get("local_api_key") or "",
+            board.get("cloud_key") or "",
+            board.get("note_array_token") or "",
+            board.get("device_type") or "flagship",
+            board.get("notes_wide") or 1,
+            board.get("notes_tall") or 1,
+            tiles_sig,
+        )
 
     def _build_board_clients(self, sync_cache: bool = True):
-        """Build one client per configured board (settings.boards) or fall back to Config.
+        """Build one runtime per configured board (settings.boards) or fall back to Config.
 
-        Sets ``self.board_clients`` (board_id -> client for every board with
-        connection credentials) and ``self.vb_client`` (the first board's
-        client, kept for single-board code paths).
+        Populates ``self.runtimes`` (board_id -> BoardRuntime for every board
+        with a usable connection) and ``self._primary_board_id`` (the first
+        board, kept for single-board code paths via the ``vb_client``
+        property). Unchanged boards keep their existing runtime (and caches)
+        so editing one board doesn't reset another's state.
+
+        No credential pre-filter: each device type has its own credential
+        field (local_api_key / cloud_key / note_array_token / per-tile local
+        keys) and ``board_client_from_board_dict`` already returns None for a
+        board without a usable connection. A pre-filter on local/cloud keys
+        silently dropped note-array boards (issue #1243 item 3).
 
         Args:
             sync_cache: read the primary board's current message to seed the
                 skip-unchanged cache. Startup wants this; reinitialization
                 from an API request must NOT block on board I/O (an
-                unreachable board would stall the request), so it skips it —
-                a cold cache just means the next send isn't deduplicated.
+                unreachable board would stall the request), so it skips it.
         """
         settings_service = get_settings_service()
         boards = settings_service.get_board_settings().boards or []
-        clients: dict[str, BoardClient] = {}
+
+        new_runtimes: dict[str, BoardRuntime] = {}
         for board in boards:
-            # No credential pre-filter here: each device type has its own
-            # credential field (local_api_key / cloud_key / note_array_token)
-            # and board_client_from_board_dict already returns None for a
-            # board without a usable connection. A pre-filter on local/cloud
-            # keys silently dropped note-array boards (issue #1243 item 3).
+            if not isinstance(board, dict):
+                continue
+            bid = board.get("id")
+            if not bid:
+                continue
+            sig = self._config_signature(board)
+            existing = self.runtimes.get(bid)
+            if existing is not None and existing.config_signature == sig and existing.client is not None:
+                # Unchanged connection: keep the runtime so its caches survive.
+                new_runtimes[bid] = existing
+                continue
             client = board_client_from_board_dict(board)
-            if client and board.get("id"):
-                clients[board["id"]] = client
-        self.board_clients = clients
-        if boards and boards[0].get("id") in clients:
-            self.vb_client = clients[boards[0]["id"]]
+            if client is None:
+                continue
+            rt = BoardRuntime(client=client, board_id=bid)
+            rt.config_signature = sig
+            new_runtimes[bid] = rt
+
+        self.runtimes = new_runtimes
+
+        if boards and isinstance(boards[0], dict) and boards[0].get("id") in new_runtimes:
+            self._primary_board_id = boards[0]["id"]
         else:
+            # Legacy single-board Config path: no usable settings.boards entry.
             use_cloud = Config.BOARD_API_MODE.lower() == "cloud"
-            self.vb_client = BoardClient(
+            client = BoardClient(
                 api_key=Config.get_board_api_key(),
                 host=Config.BOARD_HOST if not use_cloud else None,
                 use_cloud=use_cloud,
                 skip_unchanged=True,
             )
+            key = self._PRIMARY_FALLBACK_KEY
+            self.runtimes[key] = BoardRuntime(client=client, board_id=key)
+            self._primary_board_id = key
+
         if sync_cache:
-            try:
-                self.vb_client.read_current_message(sync_cache=True)
-            except Exception as e:
-                logger.warning(f"Could not sync cache with board: {e}")
+            rt = self._primary_runtime()
+            if rt is not None and rt.client is not None:
+                try:
+                    rt.client.read_current_message(sync_cache=True)
+                except Exception as e:
+                    logger.warning(f"Could not sync cache with board: {e}")
 
-    def reinitialize_board_client(self) -> bool:
-        """Reinitialize all board clients with current config.
+    def rebuild_board_clients(self) -> bool:
+        """Rebuild runtimes from current config (diff-based, keyed by board id).
 
-        Prefers settings.boards (one client per board with connection);
-        falls back to Config for the primary. Must be called after any
-        boards-list mutation, otherwise sends keep targeting the old
+        Prefers settings.boards (one runtime per board with a connection);
+        falls back to Config for the primary. Unchanged boards keep their
+        runtime + caches; removed/disabled boards are pruned. Must be called
+        after any boards-list mutation, otherwise sends keep targeting the old
         connections (issue: content delivered to a removed board).
         """
-        logger.info("Reinitializing board clients with updated config...")
+        logger.info("Rebuilding board clients with updated config...")
         try:
-            # sync_cache=False: reinit runs inside API request handlers, and a
+            # sync_cache=False: this runs inside API request handlers, and a
             # blocking read against an unreachable board would stall them.
             self._build_board_clients(sync_cache=False)
-            if self.vb_client:
-                # Clear stale polled state from the old config; poll thread will
-                # populate it again on its next iteration using the new client.
-                self._polled_characters = None
-                self._polled_at = None
-                # Drop per-board content caches for boards that no longer exist
-                # (or whose connection may have changed).
-                self._secondary_last_sent = {
-                    board_id: sent
-                    for board_id, sent in self._secondary_last_sent.items()
-                    if board_id in self.board_clients
-                }
-                logger.info(f"Board clients reinitialized successfully ({len(self.board_clients)} board(s))")
+            rt = self._primary_runtime()
+            if rt is not None and rt.client is not None:
+                # Clear stale board-read state from the old config; the poll
+                # thread repopulates it on its next iteration.
+                rt.polled_characters = None
+                rt.polled_at = None
+                logger.info(f"Board clients rebuilt successfully ({len(self.runtimes)} runtime(s))")
                 return True
             return False
         except Exception as e:
-            logger.error(f"Failed to reinitialize board client: {e}")
+            logger.error(f"Failed to rebuild board clients: {e}")
             return False
+
+    # Back-compat alias: external callers + tests use this name.
+    reinitialize_board_client = rebuild_board_clients
 
     def invalidate_board_content(self, board_id: str) -> None:
         """Force the next update cycle to re-send this board's content.
 
-        Clears the display loop's content dedupe for the board (primary or
-        secondary) and the board client's character cache. Used after an
-        out-of-band write to the physical board — e.g. the local-array
-        identify flash — so the real frame is restored on the next poll
-        cycle even though the rendered page content hasn't changed.
+        Clears the board's runtime content dedupe and its client's character
+        cache. Used after an out-of-band write to the physical board — e.g.
+        the local-array identify flash (#1399) — so the real frame is
+        restored on the next poll cycle even though the rendered page
+        content hasn't changed.
         """
-        primary_id = get_settings_service().get_primary_board_id()
-        if board_id == primary_id:
-            self._last_active_page_content = None
-        self._secondary_last_sent.pop(board_id, None)
-        client = self.board_clients.get(board_id)
-        if client is not None:
-            client.clear_cache()
+        rt = self.runtimes.get(board_id)
+        if rt is None:
+            # Legacy installs may key the primary runtime under the fallback
+            # sentinel rather than its settings board id.
+            try:
+                primary_id = get_settings_service().get_primary_board_id()
+            except Exception:
+                primary_id = None
+            if board_id == primary_id:
+                rt = self._primary_runtime()
+        if rt is None:
+            return
+        rt.last_active_page_content = None
+        rt.last_active_page_id = None
+        if rt.client is not None:
+            rt.client.clear_cache()
+
+    # ------------------------------------------------------------------ #
+    # Board-state polling (primary board only; state lives on the runtime)
+    # ------------------------------------------------------------------ #
 
     def _get_board_read_interval(self) -> int:
         """Return the board-state read poll interval in seconds based on API mode."""
@@ -159,15 +399,21 @@ class DisplayService:
         return polling.board_read_interval_cloud if use_cloud else polling.board_read_interval_local
 
     def _board_poll_loop(self) -> None:
-        """Background thread: periodically read actual board state and cache it."""
+        """Background thread: periodically read the primary board's state and cache it.
+
+        Polling stays primary-only (single board-read thread — a thread per
+        board would break the single-threaded send invariant the note-array
+        >=15s throttle relies on). The cache lives on the primary runtime.
+        """
         while self.running:
             interval = self._get_board_read_interval()
             try:
-                if self.vb_client:
-                    chars = self.vb_client.read_current_message()
+                rt = self._primary_runtime()
+                if rt is not None and rt.client is not None:
+                    chars = rt.client.read_current_message()
                     if chars:
-                        self._polled_characters = chars
-                        self._polled_at = time.time()
+                        rt.polled_characters = chars
+                        rt.polled_at = time.time()
                         logger.debug("Board state poll succeeded")
             except Exception as e:
                 logger.debug(f"Board state poll failed: {e}")
@@ -179,29 +425,28 @@ class DisplayService:
         retry_interval_seconds: float = 1.0,
         max_total_seconds: float = 3.0,
     ) -> None:
-        """Adaptively poll the board after a send so the cached state catches up
-        quickly without waiting for the next full poll interval.
+        """Adaptively poll the primary board after a send so the cached state
+        catches up quickly without waiting for the next full poll interval.
 
         Strategy: sleep ``initial_delay_seconds``, read the board. If the read
         matches what we just sent, update the cache and stop. Otherwise sleep
         ``retry_interval_seconds`` and try again, until ``max_total_seconds``
-        elapses. The latest successful read is always cached, so the display
-        cache improves even when we never observe a match (e.g. during a long
-        transition animation).
+        elapses. The latest successful read is always cached.
 
         A subsequent call cancels any in-flight refresh so rapid sends don't
         stack up threads.
         """
+        rt = self._primary_runtime()
         # Cancel any in-flight refresh from a prior send.
-        if self._refresh_cancel is not None:
-            self._refresh_cancel.set()
+        if rt is not None and rt.refresh_cancel is not None:
+            rt.refresh_cancel.set()
 
-        client = self.vb_client
-        if client is None:
+        if rt is None or rt.client is None:
             return
 
+        client = rt.client
         cancel = threading.Event()
-        self._refresh_cancel = cancel
+        rt.refresh_cancel = cancel
 
         # Snapshot what we just sent so we can detect when the board has
         # caught up. May be None if no send has happened on this client yet.
@@ -216,8 +461,8 @@ class DisplayService:
                 try:
                     chars = client.read_current_message()
                     if chars:
-                        self._polled_characters = chars
-                        self._polled_at = time.time()
+                        rt.polled_characters = chars
+                        rt.polled_at = time.time()
                         if expected is not None and chars == expected:
                             logger.debug("Post-send refresh: board state matches sent content")
                             return
@@ -232,7 +477,7 @@ class DisplayService:
                     return
 
         thread = threading.Thread(target=_do_refresh, daemon=True)
-        self._refresh_thread = thread
+        rt.refresh_thread = thread
         thread.start()
 
     def initialize(self) -> bool:
@@ -244,7 +489,7 @@ class DisplayService:
             logger.error("Configuration validation failed")
             return False
 
-        # Initialize board client from settings.boards (first board) or Config
+        # Initialize board runtimes from settings.boards (all boards) or Config
         try:
             self._build_board_clients()
             if not self.vb_client:
@@ -278,122 +523,70 @@ class DisplayService:
         """Return the ID of the primary (first) configured board, or None."""
         return get_settings_service().get_primary_board_id()
 
-    def check_and_send_active_page(self) -> bool:
-        """Update every configured board from its schedule/active page.
+    # ------------------------------------------------------------------ #
+    # Per-board display engine (single tick loop)
+    # ------------------------------------------------------------------ #
 
-        The primary board (boards[0]) keeps the full feature set — triggers,
-        temporary overrides, silence indicator, manual active page. Secondary
-        boards are schedule-driven (issue #1243): each enabled, unpaused,
-        schedule-enabled board resolves its own active page and receives it
-        via its own client.
+    def check_and_send_active_page(self) -> bool:
+        """Drive every configured board from its schedule/active page.
+
+        Back-compat entry point (retained for /refresh, /force-refresh, MQTT,
+        the run loop, and existing tests). It drives the PRIMARY board through
+        the full feature set (triggers, temporary override, silence indicator,
+        per-board active page) and then each secondary board through the same
+        unified per-board path. Every board keeps its own state on its runtime.
 
         Returns:
-            True if content was sent to the primary board, False otherwise
+            True if content was sent to the PRIMARY board, False otherwise.
         """
-        sent = self._update_primary_board()
+        primary_id = self._get_first_board_id()
+        rt = self._ensure_primary_runtime()
+        sent = self.check_and_send_for_board(primary_id, rt, is_primary=True)
         try:
-            self._update_secondary_boards()
+            self._drive_secondary_boards()
         except Exception as e:  # secondaries must never break the primary loop
             logger.error(f"Error updating secondary boards: {e}")
         return sent
 
-    def _update_secondary_boards(self) -> None:
-        """Drive every board after the first from its own schedule.
+    def _drive_secondary_boards(self) -> None:
+        """Drive every board after the first through the unified per-board path.
 
-        Scope (first slice of #1243): schedule + per-board default page,
-        per-board pause and schedule_enabled, collections, per-page
-        transitions. Global silence mode silences secondaries entirely
-        (freeze semantics — the SNOOZING indicator stays a primary-board
-        feature). Triggers, temporary overrides and the manual active page
-        remain primary-only.
+        Each board raising is isolated so one failure never blocks the others.
         """
         settings_service = get_settings_service()
         boards = settings_service.get_board_settings().boards or []
         if len(boards) <= 1:
             return
-        if Config.is_silence_mode_active():
-            return
-
-        page_service = get_page_service()
-        schedule_service = get_schedule_service()
-        collection_service = get_collection_service()
-        from .time_service import get_time_service
-
-        now = get_time_service().get_current_time()
-        current_time = now.time()
-        current_day = now.strftime("%A").lower()
 
         for board in boards[1:]:
+            if not isinstance(board, dict):
+                continue
             board_id = board.get("id")
             if not board_id:
                 continue
-            client = self.board_clients.get(board_id)
-            if client is None:
+            rt = self.runtimes.get(board_id)
+            if rt is None:
                 continue
             if not board.get("enabled", True):
                 continue
-            if settings_service.is_paused(board_id=board_id) is True:
-                continue
-            if not settings_service.is_schedule_enabled(board_id=board_id):
-                continue
-
-            active_page_id = schedule_service.get_active_page_id(current_time, current_day, board_id=board_id)
-            if not active_page_id:
-                continue
-            if is_collection_id(active_page_id):
-                active_page_id = collection_service.resolve_page_id(active_page_id)
-                if not active_page_id:
-                    continue
-
-            page = page_service.get_page(active_page_id)
-            if not page:
-                logger.warning(f"Board {board_id}: active page not found: {active_page_id}")
-                continue
-            result = page_service.preview_page(active_page_id, force_refresh=True)
-            if not result or not result.available:
-                logger.warning(f"Board {board_id}: failed to render active page: {active_page_id}")
-                continue
-
-            content = result.formatted
-            if self._secondary_last_sent.get(board_id) == (active_page_id, content):
-                continue
-
-            system_transition = settings_service.get_transition_settings()
-            strategy = page.transition_strategy if page.transition_strategy else system_transition.strategy
-            interval_ms = (
-                page.transition_interval_ms
-                if page.transition_interval_ms is not None
-                else system_transition.step_interval_ms
-            )
-            step_size = (
-                page.transition_step_size if page.transition_step_size is not None else system_transition.step_size
-            )
-
-            dims = resolve_dimensions(page.device_type, page.notes_wide, page.notes_tall)
-            board_array = text_to_board_array(content, rows=dims.rows, cols=dims.cols)
             try:
-                success, was_sent = client.send_characters(
-                    board_array, strategy=strategy, step_interval_ms=interval_ms, step_size=step_size
-                )
-            except Exception as e:
-                logger.error(f"Board {board_id}: send failed: {e}")
-                continue
-            if success:
-                self._secondary_last_sent[board_id] = (active_page_id, content)
-                if was_sent:
-                    logger.info(f"Board {board_id}: active page sent: {active_page_id}")
-            else:
-                logger.error(f"Board {board_id}: failed to send active page: {active_page_id}")
+                self.check_and_send_for_board(board_id, rt, is_primary=False, board=board)
+            except Exception as e:  # partial-failure isolation
+                logger.error(f"Board {board_id}: update failed: {e}")
 
-    def _update_primary_board(self) -> bool:
-        """Check the primary board's active page and send if content changed.
+    def check_and_send_for_board(
+        self, board_id, rt: BoardRuntime, *, is_primary: bool, board: dict | None = None
+    ) -> bool:
+        """Resolve and send one board's active page. Unified per-board path.
 
-        Respects schedule mode - uses schedule-based page selection when enabled,
-        otherwise falls back to manual active page setting.
-        Active triggers take priority over scheduled/manual pages.
+        Respects schedule mode (per board) - uses schedule-based page selection
+        when that board's schedule is enabled, otherwise the board's manual
+        active page. Triggers and temporary overrides are the PRIMARY board's
+        feature set (locked epic decision); silence is a global decision with
+        per-board delivery. All state reads/writes go through ``rt``.
 
         Returns:
-            True if content was sent to board, False otherwise
+            True if content was sent to this board, False otherwise.
         """
         try:
             settings_service = get_settings_service()
@@ -401,122 +594,102 @@ class DisplayService:
             schedule_service = get_schedule_service()
 
             # --- Pause short-circuit (issue #970) ---
-            # When the board is paused the user wants FiestaBoard to be
-            # completely hands-off: no scheduled rotation, no silence
+            # A paused board is completely hands-off: no rotation, no silence
             # indicator, no trigger overrides, no override revert. Evaluate
-            # this BEFORE silence so a paused board doesn't even emit the
-            # one-shot SNOOZING indicator on entering silence.
-            board_id = self._get_first_board_id()
-            # Only treat a strict ``True`` as paused — guards against Mock
-            # returns from older fixtures that pre-date the pause feature.
+            # this BEFORE silence. Only a strict ``True`` counts as paused
+            # (guards against Mock returns from older fixtures).
             if settings_service.is_paused(board_id=board_id) is True:
                 logger.debug("Board %s is paused - skipping update", board_id or "(default)")
                 return False
 
-            # --- Silence mode short-circuit (evaluated FIRST) ---
-            # Important: we evaluate silence before doing ANY plugin/API work
-            # (trigger evaluation, page rendering, collection resolution) so a
-            # "snoozed" board doesn't cause weather/transit/stocks/etc. APIs
-            # to be hit on every poll. We send exactly one update when entering
-            # silence (with the SNOOZING indicator) and then go quiet until
-            # the silence window ends.
+            # --- Silence mode short-circuit (global decision, per-board state) ---
+            # Evaluate silence before any plugin/API work so a snoozed board
+            # doesn't hit weather/transit/stocks APIs on every poll. We send
+            # exactly one update on entering silence, then go quiet.
             silence_mode_active = Config.is_silence_mode_active()
-            entering_silence_mode = silence_mode_active and not self._last_silence_mode_active
-            exiting_silence_mode = not silence_mode_active and self._last_silence_mode_active
+            entering_silence_mode = silence_mode_active and not rt.last_silence_mode_active
+            exiting_silence_mode = not silence_mode_active and rt.last_silence_mode_active
 
-            if silence_mode_active and self._snoozing_message_sent:
-                # Steady-state silence: indicator is already on the board.
-                # Do nothing — no rendering, no plugin fetches, no trigger
-                # evaluation, no board send.
-                # (If we are here, _snoozing_message_sent=True implies a prior
-                # successful silence-mode send, which set _last_silence_mode_active
-                # to True, so this is necessarily not the entering-silence tick.)
-                logger.debug("Silence mode active - skipping update (board already snoozing)")
-                self._last_silence_mode_active = True
+            if silence_mode_active and rt.snoozing_message_sent:
+                # Steady-state silence: indicator is already on this board.
+                logger.debug(
+                    "Silence mode active - skipping update (board %s already snoozing)", board_id or "(default)"
+                )
+                rt.last_silence_mode_active = True
                 return False
 
             if exiting_silence_mode:
                 logger.info("▶️  Exiting silence mode - resuming normal updates")
-                self._snoozing_message_sent = False
-                # The board currently shows the SNOOZING indicator on top of
-                # whatever content was last rendered. Clear the content cache
-                # so the next render is unconditionally pushed to the board,
-                # otherwise we'd see "content unchanged, skipping send" and
-                # leave the indicator stuck on the board.
-                self._last_active_page_content = None
+                rt.snoozing_message_sent = False
+                # The board still shows the SNOOZING indicator on top of the
+                # last-rendered content. Clear the content cache so the next
+                # render is unconditionally pushed, otherwise "content
+                # unchanged, skipping send" leaves the indicator stuck.
+                rt.last_active_page_content = None
 
-            # --- Check for active triggers (highest priority, but suppressed during silence) ---
-            if not silence_mode_active:
+            # --- Triggers (PRIMARY only; suppressed during silence) ---
+            if is_primary and not silence_mode_active:
                 trigger_content = self._check_trigger_override()
                 if trigger_content is not None:
-                    return self._send_trigger_content(trigger_content)
+                    return self._send_trigger_content(trigger_content, rt)
 
-            # --- Temporary override check (user-initiated, time-limited; below triggers) ---
-            # Issue #949: an explicit user override (POST /settings/temporary-override)
-            # must win over the silence schedule. The user pressed "show this page
-            # now" — honoring silence here would silently swallow that intent.
-            # Plugin-driven trigger overrides above DO still defer to silence;
-            # only this user-initiated path bypasses it.
+            # --- Temporary override (PRIMARY only; global consume-once store) ---
+            # Issue #949: an explicit user override wins over the silence
+            # schedule. Plugin-driven trigger overrides above still defer to
+            # silence; only this user-initiated path bypasses it.
             active_page_id = None
             override_active = False
-            override = settings_service.consume_temporary_override()
-            if override is not None:
-                if not override.is_expired():
-                    active_page_id = override.page_id
-                    override_active = True
-                    logger.debug(f"Temporary override active: using page {active_page_id}")
-                elif not silence_mode_active:
-                    # Override just expired — apply revert before resuming normal flow.
-                    # Skip during silence: the silence-mode dispatch below will own
-                    # the board until the silence window ends.
-                    logger.info(f"Temporary override expired, applying revert: {override.revert_mode}")
-                    if override.revert_mode == "blank":
-                        return self._send_blank_board()
-                    if override.revert_mode == "page" and override.revert_page_id:
-                        settings_service.set_active_page_id(override.revert_page_id)
-                    # "schedule" (and fallback): clear content cache so next tick rerenders
-                    self._last_active_page_content = None
+            if is_primary:
+                override = settings_service.consume_temporary_override()
+                if override is not None:
+                    if not override.is_expired():
+                        active_page_id = override.page_id
+                        override_active = True
+                        logger.debug(f"Temporary override active: using page {active_page_id}")
+                    elif not silence_mode_active:
+                        # Override just expired — apply revert before resuming.
+                        # Skip during silence: the silence dispatch owns the
+                        # board until the window ends.
+                        logger.info(f"Temporary override expired, applying revert: {override.revert_mode}")
+                        if override.revert_mode == "blank":
+                            return self._send_blank_board(rt)
+                        if override.revert_mode == "page" and override.revert_page_id:
+                            settings_service.set_active_page_id(override.revert_page_id, board_id=board_id)
+                        # "schedule" (and fallback): clear cache so next tick rerenders.
+                        rt.last_active_page_content = None
 
-            # Determine active page based on schedule mode (skipped when override is active)
-            if active_page_id is None and settings_service.is_schedule_enabled():
-                # Schedule mode: Use schedule service to determine page
-                # Use TimeService to get current time in configured timezone
+            # --- Determine this board's active page (schedule vs manual) ---
+            if active_page_id is None and settings_service.is_schedule_enabled(board_id=board_id):
                 from .time_service import get_time_service
 
-                time_service = get_time_service()
-                now = time_service.get_current_time()
+                now = get_time_service().get_current_time()
                 current_time = now.time()
                 current_day = now.strftime("%A").lower()  # monday, tuesday, etc.
-
-                # Pass the first board's ID so schedules scoped to that board are found
-                board_id = self._get_first_board_id()
                 active_page_id = schedule_service.get_active_page_id(current_time, current_day, board_id=board_id)
-
                 if active_page_id:
-                    logger.debug(f"Schedule mode: Active page determined by schedule: {active_page_id}")
+                    logger.debug(f"Board {board_id}: schedule active page: {active_page_id}")
                 else:
                     logger.debug(
-                        f"Schedule mode: No matching schedule for {current_day} {current_time.strftime('%H:%M')}"
+                        f"Board {board_id}: no matching schedule for {current_day} {current_time.strftime('%H:%M')}"
                     )
             elif active_page_id is None:
-                # Manual mode: Use manual active page setting
-                active_page_id = settings_service.get_active_page_id()
-                logger.debug(f"Manual mode: Using manual active page: {active_page_id}")
+                active_page_id = settings_service.get_active_page_id(board_id=board_id)
+                logger.debug(f"Board {board_id}: manual active page: {active_page_id}")
 
-            # No active page set - try to default to first page (manual mode only)
-            if not active_page_id and not settings_service.is_schedule_enabled():
+            # Primary never goes dark: default to first page in manual mode.
+            # Secondary boards do NOT default (they go dark when no page is set).
+            if not active_page_id and is_primary and not settings_service.is_schedule_enabled(board_id=board_id):
                 pages = page_service.list_pages()
                 if pages:
                     active_page_id = pages[0].id
-                    settings_service.set_active_page_id(active_page_id)
+                    settings_service.set_active_page_id(active_page_id, board_id=board_id)
                     logger.info(f"No active page set, defaulting to first page: {active_page_id}")
                 else:
                     logger.debug("No active page and no pages available")
                     return False
 
-            # If schedule mode but no page (gap without default), don't update board
             if not active_page_id:
-                logger.debug("No active page available (schedule gap with no default)")
+                logger.debug("Board %s: no active page available", board_id or "(default)")
                 return False
 
             # Resolve collections: if the active ref is a collection, determine
@@ -530,60 +703,54 @@ class DisplayService:
                 logger.debug(f"Collection {active_page_id} resolved to page {resolved}")
                 active_page_id = resolved
 
-            # Get the page for transition settings
             page = page_service.get_page(active_page_id)
             if not page:
                 logger.warning(f"Active page not found: {active_page_id}")
                 return False
 
-            # Render the page with fresh data — force_refresh bypasses the preview
-            # cache so template variables (weather, time, stocks, etc.) are current.
+            # Render with fresh data — force_refresh bypasses the preview cache
+            # so template variables (weather, time, stocks, etc.) are current.
             result = page_service.preview_page(active_page_id, force_refresh=True)
             if not result or not result.available:
                 logger.warning(f"Failed to render active page: {active_page_id}")
                 return False
 
-            # Silence-mode state was already evaluated at the top of this method.
-            # If we get here while silence is active, it means we are entering
-            # silence (or recovering from a missing indicator after restart /
-            # power outage) and need to send exactly one update with the
-            # silence-mode display, or suppress updates entirely (freeze mode).
-            #
-            # Exception (issue #949): a user-initiated temporary override wins
-            # over silence. The user explicitly asked to see this page now, so
-            # we render it and skip the silence dispatch. Once the override
-            # expires, normal silence behavior resumes on the next tick.
+            # --- Silence dispatch (per-board delivery, sized to this board) ---
+            # A user-initiated temporary override (primary only) wins over
+            # silence (issue #949); everything else is silenced.
             if silence_mode_active and not override_active:
                 silence_mode = Config.SILENCE_SCHEDULE_MODE
+                if is_primary:
+                    silence_dt = self._silence_device_type()
+                    silence_nw = silence_nt = 1
+                else:
+                    silence_dt = (board or {}).get("device_type") or "flagship"
+                    silence_nw = (board or {}).get("notes_wide", 1) or 1
+                    silence_nt = (board or {}).get("notes_tall", 1) or 1
                 if silence_mode == "freeze":
                     if entering_silence_mode:
                         logger.info("⏸️  Entering silence mode (freeze) - leaving board untouched")
                     else:
                         logger.debug("Silence mode active (freeze) - blocking update")
-                    self._last_silence_mode_active = True
-                    self._snoozing_message_sent = True
+                    rt.last_silence_mode_active = True
+                    rt.snoozing_message_sent = True
                     return False
                 if silence_mode == "page":
-                    return self._send_silence_page()
-                return self._send_silence_indicator(page.device_type)
+                    return self._send_silence_page(rt)
+                return self._send_silence_indicator(silence_dt, rt, silence_nw, silence_nt)
 
-            # Get base content
+            # --- Normal send (content changed) ---
             current_content = result.formatted
-            content_to_send = current_content
-
-            # Normal mode (not in silence) - check if content changed
-            if current_content == self._last_active_page_content and active_page_id == self._last_active_page_id:
-                logger.debug("Active page content unchanged, skipping send")
+            if current_content == rt.last_active_page_content and active_page_id == rt.last_active_page_id:
+                logger.debug("Board %s: content unchanged, skipping send", board_id or "(default)")
                 return False
-            logger.info(f"Active page content changed, sending to board: {active_page_id}")
+            logger.info(f"Board {board_id}: active page content changed, sending: {active_page_id}")
 
-            # At this point, we're going to send an update
-
-            if not self.vb_client:
+            if not rt.client:
                 logger.warning("Board client not initialized")
                 return False
 
-            # Get transition settings - use page-level if set, otherwise system defaults
+            # Transition settings — page-level if set, otherwise system defaults.
             system_transition = settings_service.get_transition_settings()
             strategy = page.transition_strategy if page.transition_strategy else system_transition.strategy
             interval_ms = (
@@ -595,39 +762,44 @@ class DisplayService:
                 page.transition_step_size if page.transition_step_size is not None else system_transition.step_size
             )
 
-            # Send to board
+            # resolve_dimensions (never get_dimensions, which raises for
+            # note_array) so a note-array page renders at its true size.
             dims = resolve_dimensions(page.device_type, page.notes_wide, page.notes_tall)
-            board_array = text_to_board_array(content_to_send, rows=dims.rows, cols=dims.cols)
+            board_array = text_to_board_array(current_content, rows=dims.rows, cols=dims.cols)
 
-            success, was_sent = self.vb_client.send_characters(
+            success, was_sent = rt.client.send_characters(
                 board_array, strategy=strategy, step_interval_ms=interval_ms, step_size=step_size
             )
 
             if success:
-                self._last_active_page_content = content_to_send
-                self._last_active_page_id = active_page_id
-                self._last_silence_mode_active = silence_mode_active
-
+                rt.last_active_page_content = current_content
+                rt.last_active_page_id = active_page_id
+                rt.last_silence_mode_active = silence_mode_active
                 if was_sent:
-                    logger.info(f"Active page sent to board: {active_page_id}")
-                    self.request_board_refresh()
+                    logger.info(f"Board {board_id}: active page sent: {active_page_id}")
+                    # Board-state adaptive refresh is primary-only (see
+                    # _board_poll_loop). Secondary boards don't feed the
+                    # board-read cache the Active Display UI shows.
+                    if is_primary:
+                        self.request_board_refresh()
                 else:
                     logger.debug("Active page unchanged at board level")
                 return was_sent
-            logger.error(f"Failed to send active page to board: {active_page_id}")
+            logger.error(f"Board {board_id}: failed to send active page: {active_page_id}")
             return False
 
         except Exception as e:
-            logger.error(f"Error checking active page: {e}")
+            logger.error(f"Error checking active page for board {board_id}: {e}")
             return False
 
     # ------------------------------------------------------------------ #
     # Temporary override helpers
     # ------------------------------------------------------------------ #
 
-    def _send_blank_board(self) -> bool:
+    def _send_blank_board(self, rt: BoardRuntime | None = None) -> bool:
         """Send a fully blank board when a temporary override expires with revert_mode='blank'."""
-        if not self.vb_client:
+        rt = rt if rt is not None else self._ensure_primary_runtime()
+        if rt is None or rt.client is None:
             logger.warning("Board client not initialized")
             return False
 
@@ -638,7 +810,7 @@ class DisplayService:
         settings_service = get_settings_service()
         system_transition = settings_service.get_transition_settings()
 
-        success, was_sent = self.vb_client.send_characters(
+        success, was_sent = rt.client.send_characters(
             board_array,
             strategy=system_transition.strategy,
             step_interval_ms=system_transition.step_interval_ms,
@@ -646,8 +818,8 @@ class DisplayService:
         )
 
         if success:
-            self._last_active_page_content = None
-            self._last_active_page_id = None
+            rt.last_active_page_content = None
+            rt.last_active_page_id = None
             logger.info("Temporary override expired (blank) - board cleared")
             if was_sent:
                 self.request_board_refresh()
@@ -660,7 +832,7 @@ class DisplayService:
     # ------------------------------------------------------------------ #
 
     def _silence_device_type(self) -> str:
-        """Pick a device type for the silence display.
+        """Pick a device type for the primary board's silence display.
 
         Prefers the first configured board's device type so the silence
         display is sized for the actual hardware (Note vs Flagship). Falls
@@ -676,13 +848,13 @@ class DisplayService:
             logger.warning("Could not determine device type from board settings: %s", e)
         return "flagship"
 
-    def _build_silence_indicator_array(self, device_type: str):
+    def _build_silence_indicator_array(self, device_type: str, notes_wide: int = 1, notes_tall: int = 1):
         """Build a clean board array with 'SNOOZING' centered.
 
-        Sized for the given device so the message fits the Note (15 cols)
-        as well as the Flagship (22 cols) without overlaying other content.
+        Sized via resolve_dimensions so it fits the Note (15 cols), the
+        Flagship (22 cols), and any note-array grid without overlaying content.
         """
-        dims = get_dimensions(device_type)
+        dims = resolve_dimensions(device_type, notes_wide, notes_tall)
         board_array = [[BoardChars.SPACE] * dims.cols for _ in range(dims.rows)]
 
         indicator = Config.SILENCE_SCHEDULE_INDICATOR_TEXT
@@ -707,20 +879,28 @@ class DisplayService:
                 board_array[row][start_col + i] = char_code
         return board_array
 
-    def _send_silence_indicator(self, page_device_type: str) -> bool:
+    def _send_silence_indicator(
+        self, page_device_type: str, rt: BoardRuntime | None = None, notes_wide: int = 1, notes_tall: int = 1
+    ) -> bool:
         """Send a clean SNOOZING-only board sized for the device."""
-        if not self.vb_client:
+        rt = rt if rt is not None else self._ensure_primary_runtime()
+        if rt is None or rt.client is None:
             logger.warning("Board client not initialized")
             return False
 
-        device_type = self._silence_device_type() or page_device_type
+        # Primary board: prefer the first configured board's device type
+        # (legacy behavior). Secondary boards pass their own resolved geometry.
+        if rt.board_id == self._primary_board_id:
+            device_type = self._silence_device_type() or page_device_type
+        else:
+            device_type = page_device_type
         logger.info(f"⏸️  Entering silence mode (indicator) - displaying SNOOZING for {device_type}")
 
         settings_service = get_settings_service()
         system_transition = settings_service.get_transition_settings()
-        board_array = self._build_silence_indicator_array(device_type)
+        board_array = self._build_silence_indicator_array(device_type, notes_wide, notes_tall)
 
-        success, was_sent = self.vb_client.send_characters(
+        success, was_sent = rt.client.send_characters(
             board_array,
             strategy=system_transition.strategy,
             step_interval_ms=system_transition.step_interval_ms,
@@ -728,23 +908,24 @@ class DisplayService:
         )
 
         if success:
-            self._last_active_page_content = "snoozing"
-            self._last_active_page_id = "__silence__"
-            self._last_silence_mode_active = True
-            self._snoozing_message_sent = True
+            rt.last_active_page_content = "snoozing"
+            rt.last_active_page_id = "__silence__"
+            rt.last_silence_mode_active = True
+            rt.snoozing_message_sent = True
             logger.info("🔇 Silence mode active - further updates blocked until silence ends")
             return was_sent
 
         logger.error("Failed to send silence indicator to board")
         return False
 
-    def _send_silence_page(self) -> bool:
+    def _send_silence_page(self, rt: BoardRuntime | None = None) -> bool:
         """Render the configured silence page once and freeze it on the board.
 
         Variables in the page are rendered with the values present at the
         moment silence begins; the board is not refreshed afterwards.
         """
-        if not self.vb_client:
+        rt = rt if rt is not None else self._ensure_primary_runtime()
+        if rt is None or rt.client is None:
             logger.warning("Board client not initialized")
             return False
 
@@ -757,14 +938,14 @@ class DisplayService:
                 "Silence mode 'page' selected but page %r not found - falling back to indicator",
                 page_id,
             )
-            return self._send_silence_indicator(self._silence_device_type())
+            return self._send_silence_indicator(self._silence_device_type(), rt)
 
         logger.info(f"⏸️  Entering silence mode (page) - displaying {page.id}")
 
         result = page_service.preview_page(page.id, force_refresh=True)
         if not result or not result.available:
             logger.warning("Silence page %s could not be rendered - falling back to indicator", page.id)
-            return self._send_silence_indicator(page.device_type)
+            return self._send_silence_indicator(page.device_type, rt)
 
         settings_service = get_settings_service()
         system_transition = settings_service.get_transition_settings()
@@ -779,7 +960,7 @@ class DisplayService:
         dims = resolve_dimensions(page.device_type, page.notes_wide, page.notes_tall)
         board_array = text_to_board_array(result.formatted, rows=dims.rows, cols=dims.cols)
 
-        success, was_sent = self.vb_client.send_characters(
+        success, was_sent = rt.client.send_characters(
             board_array,
             strategy=strategy,
             step_interval_ms=interval_ms,
@@ -787,10 +968,10 @@ class DisplayService:
         )
 
         if success:
-            self._last_active_page_content = result.formatted
-            self._last_active_page_id = f"__silence_page__:{page.id}"
-            self._last_silence_mode_active = True
-            self._snoozing_message_sent = True
+            rt.last_active_page_content = result.formatted
+            rt.last_active_page_id = f"__silence_page__:{page.id}"
+            rt.last_silence_mode_active = True
+            rt.snoozing_message_sent = True
             logger.info("🔇 Silence page sent - further updates blocked until silence ends")
             return was_sent
 
@@ -844,16 +1025,17 @@ class DisplayService:
             logger.error(f"Error checking triggers: {e}")
             return None
 
-    def _send_trigger_content(self, content: str) -> bool:
-        """Send trigger content to the board.
+    def _send_trigger_content(self, content: str, rt: BoardRuntime | None = None) -> bool:
+        """Send trigger content to the board (primary board).
 
         Returns True if the content was sent successfully.
         """
-        if not self.vb_client:
+        rt = rt if rt is not None else self._ensure_primary_runtime()
+        if rt is None or rt.client is None:
             logger.warning("Board client not initialized")
             return False
 
-        if content == self._last_active_page_content:
+        if content == rt.last_active_page_content:
             logger.debug("Trigger content unchanged, skipping send")
             return False
 
@@ -864,7 +1046,7 @@ class DisplayService:
         dims = get_dimensions(self._silence_device_type())
         board_array = text_to_board_array(content, rows=dims.rows, cols=dims.cols)
 
-        success, was_sent = self.vb_client.send_characters(
+        success, was_sent = rt.client.send_characters(
             board_array,
             strategy=system_transition.strategy,
             step_interval_ms=system_transition.step_interval_ms,
@@ -872,8 +1054,8 @@ class DisplayService:
         )
 
         if success:
-            self._last_active_page_content = content
-            self._last_active_page_id = "__trigger__"
+            rt.last_active_page_content = content
+            rt.last_active_page_id = "__trigger__"
             if was_sent:
                 logger.info("Triggered message sent to board")
             return was_sent
@@ -913,7 +1095,6 @@ class DisplayService:
         self.check_and_send_active_page()
 
         logger.info("Service started, waiting for scheduled updates...")
-        _next_collection_check: float = time.time()
         try:
             while self.running:
                 schedule.run_pending()
@@ -939,20 +1120,22 @@ class DisplayService:
 
                 # When a collection is active, poll at its mode-specific cadence:
                 # time-mode aligns with the next page boundary; variable-mode uses
-                # the configured poll_seconds.
+                # the configured poll_seconds. The gate lives on the primary
+                # runtime (issue #1243) so a runtime rebuild resets it cleanly.
                 now = time.time()
-                if now >= _next_collection_check:
+                primary_rt = self._ensure_primary_runtime()
+                if now >= primary_rt.next_collection_check:
                     ref_id = self._get_active_ref_id()
                     if ref_id and is_collection_id(ref_id):
                         collection_service = get_collection_service()
                         secs = collection_service.seconds_until_next_check(ref_id, now)
                         if secs is not None:
                             self.check_and_send_active_page()
-                            _next_collection_check = now + max(1, secs)
+                            primary_rt.next_collection_check = now + max(1, secs)
                         else:
-                            _next_collection_check = now + polling_interval
+                            primary_rt.next_collection_check = now + polling_interval
                     else:
-                        _next_collection_check = now + polling_interval
+                        primary_rt.next_collection_check = now + polling_interval
                 time.sleep(1)
         except KeyboardInterrupt:
             logger.info("Keyboard interrupt received")

--- a/tests/README.md
+++ b/tests/README.md
@@ -18,6 +18,7 @@ This directory contains shared test infrastructure to reduce boilerplate and imp
 ```python
 from tests import sample_page, mock_board_client
 
+
 def test_something(sample_page, mock_board_client):
     # Use fixtures directly
     pass

--- a/tests/test_multi_board_driving.py
+++ b/tests/test_multi_board_driving.py
@@ -1,27 +1,24 @@
-"""Tests for per-board display driving (issue #1243).
+"""Tests for building/rebuilding per-board runtimes (issue #1243).
 
-Covers:
-  - _build_board_clients builds one client per configured board and keeps
-    vb_client pointing at the primary
-  - reinitialize_board_client prunes caches for removed boards
-  - _update_secondary_boards sends each secondary board its own scheduled
-    page via its own client, and skips paused / disabled / schedule-off
-    boards, silence mode, and unchanged content
+Covers ``DisplayService._build_board_clients`` / ``rebuild_board_clients``:
+  - one runtime per configured board, ``vb_client`` pointing at the primary
+  - note-array boards (token auth) are not filtered out
+  - boards without a usable connection get no runtime
+  - a rebuild prunes runtimes for removed boards
+  - ``invalidate_board_content`` clears a runtime's dedupe + client cache
+    (the local-array identify flash depends on this)
+
+The per-board *driving* behaviour (routing, pause/schedule/silence isolation,
+per-board caches) is covered by ``tests/test_per_board_engine.py``, which
+exercises the unified ``check_and_send_for_board`` path.
 """
 
-from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from src.main import DisplayService
-
-
-def _time_service():
-    svc = MagicMock()
-    svc.get_current_time.return_value = datetime(2026, 7, 15, 12, 0, 0)
-    return svc
+from src.main import BoardRuntime, DisplayService
 
 
 def _board(board_id: str, name: str, **overrides) -> dict:
@@ -42,37 +39,10 @@ def _board(board_id: str, name: str, **overrides) -> dict:
     return board
 
 
-TRANSITIONS = SimpleNamespace(strategy="instant", step_interval_ms=0, step_size=1)
-
-
-def _settings_service(boards, paused_ids=(), schedule_off_ids=()):
+def _settings_service(boards):
     svc = MagicMock()
     svc.get_board_settings.return_value = SimpleNamespace(boards=boards)
-    svc.is_paused.side_effect = lambda board_id=None: board_id in paused_ids
-    svc.is_schedule_enabled.side_effect = lambda board_id=None: board_id not in schedule_off_ids
-    svc.get_transition_settings.return_value = TRANSITIONS
-    return svc
-
-
-def _page_service(page_id: str, content: str):
-    svc = MagicMock()
-    page = SimpleNamespace(
-        id=page_id,
-        device_type="flagship",
-        notes_wide=1,
-        notes_tall=1,
-        transition_strategy=None,
-        transition_interval_ms=None,
-        transition_step_size=None,
-    )
-    svc.get_page.return_value = page
-    svc.preview_page.return_value = SimpleNamespace(available=True, formatted=content, error=None)
-    return svc
-
-
-def _schedule_service(active_by_board: dict):
-    svc = MagicMock()
-    svc.get_active_page_id.side_effect = lambda t, d, board_id=None: active_by_board.get(board_id)
+    svc.get_primary_board_id.return_value = boards[0]["id"] if boards else None
     return svc
 
 
@@ -82,7 +52,7 @@ def service():
 
 
 class TestBuildBoardClients:
-    def test_builds_one_client_per_board_with_credentials(self, service):
+    def test_builds_one_runtime_per_board_with_credentials(self, service):
         boards = [_board("b1", "One"), _board("b2", "Two", port=7001)]
         clients = {"b1": MagicMock(), "b2": MagicMock()}
         with (
@@ -93,11 +63,13 @@ class TestBuildBoardClients:
 
         assert service.board_clients == clients
         assert service.vb_client is clients["b1"]
+        assert set(service.runtimes) == {"b1", "b2"}
+        assert service._primary_board_id == "b1"
         clients["b1"].read_current_message.assert_called_once_with(sync_cache=True)
 
-    def test_note_array_board_with_only_a_token_gets_a_client(self, service):
+    def test_note_array_board_with_only_a_token_gets_a_runtime(self, service):
         """Note arrays authenticate with note_array_token, not local/cloud keys —
-        the client-map build must not filter them out (issue #1243 item 3)."""
+        the runtime build must not filter them out (issue #1243 item 3)."""
         boards = [
             _board("b1", "One"),
             _board(
@@ -120,146 +92,107 @@ class TestBuildBoardClients:
         ):
             service._build_board_clients()
 
-        assert set(service.board_clients) == {"b1", "b2"}
+        assert set(service.runtimes) == {"b1", "b2"}
 
-    def test_board_without_credentials_gets_no_client(self, service):
+    def test_local_array_board_with_tiles_gets_a_runtime(self, service):
+        """Local Array Mode (#1399): a local-mode note array with saved tiles
+        must get a runtime via the real client factory (NoteArrayLocalClient)."""
+        boards = [
+            _board(
+                "b1",
+                "LocalArray",
+                device_type="note_array",
+                api_mode="local",
+                host="",
+                local_api_key="",
+                cloud_key="",
+                notes_wide=2,
+                notes_tall=1,
+                tiles=[
+                    {"row": 0, "col": 0, "host": "192.0.2.10", "port": 7000, "local_api_key": "test-k1"},
+                    {"row": 0, "col": 1, "host": "192.0.2.11", "port": 7000, "local_api_key": "test-k2"},
+                ],
+            ),
+        ]
+        with patch("src.main.get_settings_service", return_value=_settings_service(boards)):
+            service._build_board_clients(sync_cache=False)
+
+        assert set(service.runtimes) == {"b1"}
+        assert type(service.runtimes["b1"].client).__name__ == "NoteArrayLocalClient"
+
+    def test_board_without_credentials_gets_no_runtime(self, service):
         """Uses the REAL client factory: a board with no usable credential
-        (no local key, cloud key, or note-array token) must yield no client."""
+        (no local key, cloud key, or note-array token) must yield no runtime."""
         boards = [_board("b1", "One"), _board("b2", "Two", local_api_key="", cloud_key="")]
         with patch("src.main.get_settings_service", return_value=_settings_service(boards)):
             service._build_board_clients(sync_cache=False)
 
-        assert set(service.board_clients) == {"b1"}
+        assert set(service.runtimes) == {"b1"}
 
-    def test_reinitialize_prunes_caches_of_removed_boards(self, service):
+    def test_unchanged_board_keeps_its_runtime_and_caches(self, service):
+        """A diff-based rebuild must keep an unchanged board's runtime so its
+        caches (last-sent content, silence state) survive editing another board."""
+        boards = [_board("b1", "One")]
+        original_client = MagicMock()
+
+        with (
+            patch("src.main.get_settings_service", return_value=_settings_service(boards)),
+            patch("src.main.board_client_from_board_dict", return_value=original_client),
+        ):
+            service._build_board_clients(sync_cache=False)
+            service.runtimes["b1"].last_active_page_content = "REMEMBER ME"
+
+            # Rebuild with the same board config — runtime + cache must survive.
+            service._build_board_clients(sync_cache=False)
+
+        assert service.runtimes["b1"].client is original_client
+        assert service.runtimes["b1"].last_active_page_content == "REMEMBER ME"
+
+    def test_rebuild_prunes_removed_boards(self, service):
+        service.runtimes = {"b-gone": BoardRuntime(client=MagicMock(), board_id="b-gone")}
+        service._primary_board_id = "b-gone"
         boards = [_board("b2", "Two", port=7001)]
-        service._secondary_last_sent = {"b2": ("p", "c"), "b-gone": ("p", "c")}
         with (
             patch("src.main.get_settings_service", return_value=_settings_service(boards)),
             patch("src.main.board_client_from_board_dict", side_effect=lambda b: MagicMock()),
         ):
             assert service.reinitialize_board_client() is True
 
-        assert set(service.board_clients) == {"b2"}
-        assert set(service._secondary_last_sent) == {"b2"}
+        assert set(service.runtimes) == {"b2"}
+        assert service._primary_board_id == "b2"
 
 
-class TestUpdateSecondaryBoards:
-    def _run(self, service, boards, *, paused=(), schedule_off=(), active=None, content="HELLO BOARD TWO"):
-        active = active if active is not None else {"b2": "page-2"}
-        with (
-            patch("src.main.get_settings_service", return_value=_settings_service(boards, paused, schedule_off)),
-            patch("src.main.get_page_service", return_value=_page_service("page-2", content)),
-            patch("src.main.get_schedule_service", return_value=_schedule_service(active)),
-            patch("src.main.get_collection_service", return_value=MagicMock()),
-            patch("src.time_service.get_time_service", return_value=_time_service()),
-            patch("src.main.Config") as mock_config,
-        ):
-            mock_config.is_silence_mode_active.return_value = False
-            service._update_secondary_boards()
+class TestInvalidateBoardContent:
+    """invalidate_board_content is the Local Array Mode hook (#1399): after an
+    out-of-band board write (identify flash) the next tick must re-send."""
 
-    def test_secondary_board_receives_its_scheduled_page(self, service):
-        boards = [_board("b1", "One"), _board("b2", "Two", port=7001)]
+    def test_clears_runtime_dedupe_and_client_cache(self, service):
         client = MagicMock()
-        client.send_characters.return_value = (True, True)
-        service.board_clients = {"b1": MagicMock(), "b2": client}
+        rt = BoardRuntime(client=client, board_id="b2")
+        rt.last_active_page_content = "CACHED"
+        rt.last_active_page_id = "p1"
+        service.runtimes = {"b2": rt}
 
-        self._run(service, boards)
+        with patch("src.main.get_settings_service", return_value=_settings_service([_board("b1", "One")])):
+            service.invalidate_board_content("b2")
 
-        client.send_characters.assert_called_once()
-        rows = client.send_characters.call_args.args[0]
-        assert len(rows) == 6 and len(rows[0]) == 22  # flagship dimensions
-        assert service._secondary_last_sent["b2"] == ("page-2", "HELLO BOARD TWO")
+        assert rt.last_active_page_content is None
+        assert rt.last_active_page_id is None
+        client.clear_cache.assert_called_once()
 
-    def test_primary_client_is_never_used_for_secondary_content(self, service):
-        boards = [_board("b1", "One"), _board("b2", "Two", port=7001)]
-        primary = MagicMock()
-        secondary = MagicMock()
-        secondary.send_characters.return_value = (True, True)
-        service.board_clients = {"b1": primary, "b2": secondary}
+    def test_unknown_board_is_a_noop(self, service):
+        with patch("src.main.get_settings_service", return_value=_settings_service([_board("b1", "One")])):
+            service.invalidate_board_content("nope")  # must not raise
 
-        self._run(service, boards)
-
-        primary.send_characters.assert_not_called()
-
-    def test_unchanged_content_is_not_resent(self, service):
-        boards = [_board("b1", "One"), _board("b2", "Two", port=7001)]
+    def test_primary_fallback_runtime_is_invalidated_by_primary_id(self, service):
+        """Legacy installs key the primary runtime under the fallback sentinel;
+        invalidating by the settings primary id must still find it."""
         client = MagicMock()
-        client.send_characters.return_value = (True, True)
-        service.board_clients = {"b2": client}
+        service.vb_client = client  # creates the primary runtime
+        service._last_active_page_content = "CACHED"
 
-        self._run(service, boards)
-        self._run(service, boards)
+        with patch("src.main.get_settings_service", return_value=_settings_service([_board("b1", "One")])):
+            service.invalidate_board_content("b1")
 
-        assert client.send_characters.call_count == 1
-
-    def test_paused_secondary_board_is_skipped(self, service):
-        boards = [_board("b1", "One"), _board("b2", "Two", port=7001)]
-        client = MagicMock()
-        service.board_clients = {"b2": client}
-
-        self._run(service, boards, paused=("b2",))
-
-        client.send_characters.assert_not_called()
-
-    def test_schedule_disabled_secondary_board_is_skipped(self, service):
-        boards = [_board("b1", "One"), _board("b2", "Two", port=7001)]
-        client = MagicMock()
-        service.board_clients = {"b2": client}
-
-        self._run(service, boards, schedule_off=("b2",))
-
-        client.send_characters.assert_not_called()
-
-    def test_disabled_secondary_board_is_skipped(self, service):
-        boards = [_board("b1", "One"), _board("b2", "Two", port=7001, enabled=False)]
-        client = MagicMock()
-        service.board_clients = {"b2": client}
-
-        self._run(service, boards)
-
-        client.send_characters.assert_not_called()
-
-    def test_no_matching_schedule_sends_nothing(self, service):
-        boards = [_board("b1", "One"), _board("b2", "Two", port=7001)]
-        client = MagicMock()
-        service.board_clients = {"b2": client}
-
-        self._run(service, boards, active={"b2": None})
-
-        client.send_characters.assert_not_called()
-
-    def test_silence_mode_silences_secondary_boards(self, service):
-        boards = [_board("b1", "One"), _board("b2", "Two", port=7001)]
-        client = MagicMock()
-        service.board_clients = {"b2": client}
-        with (
-            patch("src.main.get_settings_service", return_value=_settings_service(boards)),
-            patch("src.main.get_page_service", return_value=_page_service("page-2", "X")),
-            patch("src.main.get_schedule_service", return_value=_schedule_service({"b2": "page-2"})),
-            patch("src.time_service.get_time_service", return_value=_time_service()),
-            patch("src.main.Config") as mock_config,
-        ):
-            mock_config.is_silence_mode_active.return_value = True
-            service._update_secondary_boards()
-
-        client.send_characters.assert_not_called()
-
-    def test_single_board_is_a_noop(self, service):
-        boards = [_board("b1", "One")]
-        client = MagicMock()
-        service.board_clients = {"b1": client}
-
-        self._run(service, boards)
-
-        client.send_characters.assert_not_called()
-
-    def test_send_failure_does_not_cache_content(self, service):
-        boards = [_board("b1", "One"), _board("b2", "Two", port=7001)]
-        client = MagicMock()
-        client.send_characters.return_value = (False, False)
-        service.board_clients = {"b2": client}
-
-        self._run(service, boards)
-
-        assert "b2" not in service._secondary_last_sent
+        assert service._last_active_page_content is None
+        client.clear_cache.assert_called_once()

--- a/tests/test_per_board_engine.py
+++ b/tests/test_per_board_engine.py
@@ -1,0 +1,387 @@
+"""Unit tests for the per-board display engine (issue #1243 remainder).
+
+These exercise the ``BoardRuntime`` refactor: every configured board is
+driven through one unified per-board path (``check_and_send_for_board``)
+with its own cached state living on its runtime, so boards never clobber
+each other's caches. Covers:
+
+  - per-board routing / state isolation (flagship + note-array in one tick)
+  - primary "never goes dark" fallback vs. secondary go-dark semantics
+  - per-board manual active page (schedule mode off -> that board's page)
+  - partial-failure isolation (one board raising never blocks others)
+  - temporary_override evaluated for the primary board only
+  - silence as a global decision with per-board delivery + per-board state
+  - the note-array send routes through its own client at its own size
+"""
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from src.main import BoardRuntime, DisplayService
+
+TRANSITIONS = SimpleNamespace(strategy="instant", step_interval_ms=0, step_size=1)
+
+
+def _board(board_id: str, name: str, **overrides) -> dict:
+    board = {
+        "id": board_id,
+        "name": name,
+        "device_type": "flagship",
+        "board_color": "black",
+        "enabled": True,
+        "paused": False,
+        "api_mode": "local",
+        "host": "mock-host",
+        "port": 7000,
+        "local_api_key": "test-key",
+        "schedule_enabled": True,
+    }
+    board.update(overrides)
+    return board
+
+
+def _note_array_board(board_id: str, name: str, notes_wide: int, notes_tall: int, **overrides) -> dict:
+    return _board(
+        board_id,
+        name,
+        device_type="note_array",
+        api_mode="cloud",
+        host="",
+        local_api_key="",
+        cloud_key="",
+        note_array_token="test-token",
+        notes_wide=notes_wide,
+        notes_tall=notes_tall,
+        **overrides,
+    )
+
+
+def _time_service():
+    svc = MagicMock()
+    svc.get_current_time.return_value = datetime(2026, 7, 15, 12, 0, 0)
+    return svc
+
+
+def _settings_service(boards, *, paused=(), schedule_off=(), manual=None, override=None):
+    """A settings service mock with per-board resolution.
+
+    ``manual`` maps board_id -> manual active page id (used when that
+    board's schedule mode is off). ``override`` is the consume result.
+    """
+    manual = manual or {}
+    svc = MagicMock()
+    svc.get_board_settings.return_value = SimpleNamespace(boards=boards)
+    svc.get_primary_board_id.return_value = boards[0]["id"] if boards else None
+    svc.is_paused.side_effect = lambda board_id=None: board_id in paused
+    svc.is_schedule_enabled.side_effect = lambda board_id=None: board_id not in schedule_off
+    svc.get_active_page_id.side_effect = lambda board_id=None: manual.get(board_id)
+    svc.get_transition_settings.return_value = TRANSITIONS
+    svc.consume_temporary_override.return_value = override
+    return svc
+
+
+def _page(page_id, device_type="flagship", notes_wide=1, notes_tall=1):
+    return SimpleNamespace(
+        id=page_id,
+        device_type=device_type,
+        notes_wide=notes_wide,
+        notes_tall=notes_tall,
+        transition_strategy=None,
+        transition_interval_ms=None,
+        transition_step_size=None,
+    )
+
+
+def _page_service(specs):
+    """specs: dict page_id -> {"content", "device_type", "notes_wide", "notes_tall"}."""
+    svc = MagicMock()
+
+    def _get_page(pid):
+        spec = specs.get(pid)
+        if spec is None:
+            return None
+        return _page(pid, spec.get("device_type", "flagship"), spec.get("notes_wide", 1), spec.get("notes_tall", 1))
+
+    def _preview(pid, force_refresh=False):
+        spec = specs.get(pid)
+        if spec is None:
+            return SimpleNamespace(available=False, formatted="", error="missing")
+        return SimpleNamespace(available=True, formatted=spec["content"], error=None)
+
+    svc.get_page.side_effect = _get_page
+    svc.preview_page.side_effect = _preview
+    svc.list_pages.return_value = [_page(pid) for pid in specs]
+    return svc
+
+
+def _schedule_service(active_by_board):
+    svc = MagicMock()
+    svc.get_active_page_id.side_effect = lambda t, d, board_id=None: active_by_board.get(board_id)
+    return svc
+
+
+def _service_with_runtimes(boards):
+    """Build a DisplayService with a mock-client runtime per board."""
+    svc = DisplayService()
+    runtimes = {}
+    clients = {}
+    for board in boards:
+        client = MagicMock()
+        client.send_characters.return_value = (True, True)
+        client._last_characters = None
+        clients[board["id"]] = client
+        runtimes[board["id"]] = BoardRuntime(client=client, board_id=board["id"])
+    svc.runtimes = runtimes
+    svc._primary_board_id = boards[0]["id"] if boards else None
+    return svc, clients
+
+
+def _drive(svc, boards, *, settings=None, pages=None, schedule=None, silence=False):
+    settings = settings if settings is not None else _settings_service(boards)
+    pages = pages if pages is not None else _page_service({})
+    schedule = schedule if schedule is not None else _schedule_service({})
+    with (
+        patch("src.main.get_settings_service", return_value=settings),
+        patch("src.main.get_page_service", return_value=pages),
+        patch("src.main.get_schedule_service", return_value=schedule),
+        patch("src.main.get_collection_service", return_value=MagicMock()),
+        patch("src.time_service.get_time_service", return_value=_time_service()),
+        patch("src.main.Config") as cfg,
+        patch.object(svc, "_check_trigger_override", return_value=None),
+        patch.object(svc, "request_board_refresh"),
+    ):
+        cfg.is_silence_mode_active.return_value = silence
+        cfg.SILENCE_SCHEDULE_MODE = "indicator"
+        cfg.SILENCE_SCHEDULE_INDICATOR_TEXT = "SNOOZING"
+        cfg.SILENCE_SCHEDULE_INDICATOR_POSITION = "center"
+        cfg.SILENCE_SCHEDULE_PAGE_ID = None
+        return svc.check_and_send_active_page()
+
+
+class TestPerBoardRouting:
+    def test_flagship_and_note_array_each_get_their_own_page_at_their_own_size(self):
+        boards = [_board("b1", "One"), _note_array_board("b2", "Two", notes_wide=2, notes_tall=2)]
+        svc, clients = _service_with_runtimes(boards)
+        pages = _page_service(
+            {
+                "pA": {"content": "ALPHA", "device_type": "flagship"},
+                "pB": {"content": "BETA", "device_type": "note_array", "notes_wide": 2, "notes_tall": 2},
+            }
+        )
+        schedule = _schedule_service({"b1": "pA", "b2": "pB"})
+
+        _drive(svc, boards, pages=pages, schedule=schedule)
+
+        clients["b1"].send_characters.assert_called_once()
+        rows1 = clients["b1"].send_characters.call_args.args[0]
+        assert len(rows1) == 6 and len(rows1[0]) == 22  # flagship
+
+        clients["b2"].send_characters.assert_called_once()
+        rows2 = clients["b2"].send_characters.call_args.args[0]
+        assert len(rows2) == 6 and len(rows2[0]) == 30  # note-array 2x2 -> 6x30
+
+        assert svc.runtimes["b1"].last_active_page_id == "pA"
+        assert svc.runtimes["b2"].last_active_page_id == "pB"
+
+    def test_state_is_isolated_between_runtimes(self):
+        """Editing the primary's cache must not affect a secondary's."""
+        boards = [_board("b1", "One"), _board("b2", "Two", port=7001)]
+        svc, _clients = _service_with_runtimes(boards)
+        pages = _page_service({"pA": {"content": "ALPHA"}, "pB": {"content": "BETA"}})
+        schedule = _schedule_service({"b1": "pA", "b2": "pB"})
+
+        _drive(svc, boards, pages=pages, schedule=schedule)
+
+        assert svc.runtimes["b1"].last_active_page_content == "ALPHA"
+        assert svc.runtimes["b2"].last_active_page_content == "BETA"
+
+    def test_primary_client_never_receives_secondary_content(self):
+        boards = [_board("b1", "One"), _board("b2", "Two", port=7001)]
+        svc, clients = _service_with_runtimes(boards)
+        pages = _page_service({"pB": {"content": "BETA"}})
+        schedule = _schedule_service({"b1": None, "b2": "pB"})
+
+        _drive(svc, boards, pages=pages, schedule=schedule)
+
+        # Primary had no scheduled page and no manual page -> no send.
+        clients["b1"].send_characters.assert_not_called()
+        clients["b2"].send_characters.assert_called_once()
+
+    def test_unchanged_content_is_not_resent(self):
+        boards = [_board("b1", "One"), _board("b2", "Two", port=7001)]
+        svc, clients = _service_with_runtimes(boards)
+        pages = _page_service({"pB": {"content": "BETA"}})
+        schedule = _schedule_service({"b2": "pB"})
+
+        _drive(svc, boards, pages=pages, schedule=schedule)
+        _drive(svc, boards, pages=pages, schedule=schedule)
+
+        assert clients["b2"].send_characters.call_count == 1
+
+
+class TestSkips:
+    def test_paused_board_is_skipped(self):
+        boards = [_board("b1", "One"), _board("b2", "Two", port=7001)]
+        svc, clients = _service_with_runtimes(boards)
+        pages = _page_service({"pB": {"content": "BETA"}})
+        schedule = _schedule_service({"b2": "pB"})
+        settings = _settings_service(boards, paused=("b2",))
+
+        _drive(svc, boards, settings=settings, pages=pages, schedule=schedule)
+
+        clients["b2"].send_characters.assert_not_called()
+
+    def test_schedule_disabled_board_uses_manual_page(self):
+        """Schedule off for a secondary -> its manual by_board page is shown."""
+        boards = [_board("b1", "One"), _board("b2", "Two", port=7001)]
+        svc, clients = _service_with_runtimes(boards)
+        pages = _page_service({"pManual": {"content": "MANUAL2"}})
+        settings = _settings_service(boards, schedule_off=("b2",), manual={"b2": "pManual"})
+
+        _drive(svc, boards, settings=settings, pages=pages)
+
+        clients["b2"].send_characters.assert_called_once()
+        assert svc.runtimes["b2"].last_active_page_id == "pManual"
+
+    def test_secondary_with_no_active_page_goes_dark(self):
+        """Unlike the primary, a secondary does NOT default to pages[0]."""
+        boards = [_board("b1", "One"), _board("b2", "Two", port=7001)]
+        svc, clients = _service_with_runtimes(boards)
+        pages = _page_service({"pDefault": {"content": "DEFAULT"}})
+        settings = _settings_service(boards, schedule_off=("b2",), manual={})
+
+        _drive(svc, boards, settings=settings, pages=pages)
+
+        clients["b2"].send_characters.assert_not_called()
+
+    def test_disabled_board_is_skipped(self):
+        boards = [_board("b1", "One"), _board("b2", "Two", port=7001, enabled=False)]
+        svc, clients = _service_with_runtimes(boards)
+        pages = _page_service({"pB": {"content": "BETA"}})
+        schedule = _schedule_service({"b2": "pB"})
+
+        _drive(svc, boards, pages=pages, schedule=schedule)
+
+        clients["b2"].send_characters.assert_not_called()
+
+
+class TestPrimaryFallback:
+    def test_primary_defaults_to_first_page_when_no_active_page(self):
+        """The primary never goes dark: manual mode with no active page -> pages[0]."""
+        boards = [_board("b1", "One", schedule_enabled=False)]
+        svc, clients = _service_with_runtimes(boards)
+        pages = _page_service({"pFirst": {"content": "FIRST"}})
+        settings = _settings_service(boards, schedule_off=("b1",), manual={})
+
+        _drive(svc, boards, settings=settings, pages=pages)
+
+        clients["b1"].send_characters.assert_called_once()
+        settings.set_active_page_id.assert_called_once()
+        assert svc.runtimes["b1"].last_active_page_id == "pFirst"
+
+
+class TestPartialFailureIsolation:
+    def test_secondary_raising_does_not_block_primary(self):
+        boards = [_board("b1", "One"), _board("b2", "Two", port=7001)]
+        svc, clients = _service_with_runtimes(boards)
+        clients["b2"].send_characters.side_effect = RuntimeError("board 2 exploded")
+        pages = _page_service({"pA": {"content": "ALPHA"}, "pB": {"content": "BETA"}})
+        schedule = _schedule_service({"b1": "pA", "b2": "pB"})
+
+        result = _drive(svc, boards, pages=pages, schedule=schedule)
+
+        assert result is True  # primary still sent
+        clients["b1"].send_characters.assert_called_once()
+
+    def test_primary_error_isolated_from_secondary(self):
+        boards = [_board("b1", "One"), _board("b2", "Two", port=7001)]
+        svc, clients = _service_with_runtimes(boards)
+        clients["b1"].send_characters.side_effect = RuntimeError("board 1 exploded")
+        pages = _page_service({"pA": {"content": "ALPHA"}, "pB": {"content": "BETA"}})
+        schedule = _schedule_service({"b1": "pA", "b2": "pB"})
+
+        result = _drive(svc, boards, pages=pages, schedule=schedule)
+
+        assert result is False  # primary failed gracefully
+        clients["b2"].send_characters.assert_called_once()  # secondary unaffected
+
+
+class TestTemporaryOverridePrimaryOnly:
+    def test_override_consumed_only_for_primary(self):
+        boards = [_board("b1", "One"), _board("b2", "Two", port=7001)]
+        svc, _clients = _service_with_runtimes(boards)
+        pages = _page_service({"pA": {"content": "ALPHA"}, "pB": {"content": "BETA"}})
+        schedule = _schedule_service({"b1": "pA", "b2": "pB"})
+        settings = _settings_service(boards)
+
+        _drive(svc, boards, settings=settings, pages=pages, schedule=schedule)
+
+        # The override store is a global consume-once resource: it must be
+        # consumed exactly once (for the primary), never per-secondary.
+        settings.consume_temporary_override.assert_called_once()
+
+
+class TestPerBoardSilenceDelivery:
+    def test_each_board_gets_its_own_snoozing_indicator_sized_to_its_device(self):
+        boards = [_board("b1", "One"), _note_array_board("b2", "Two", notes_wide=2, notes_tall=1)]
+        svc, clients = _service_with_runtimes(boards)
+        pages = _page_service(
+            {
+                "pA": {"content": "ALPHA"},
+                "pB": {"content": "BETA", "device_type": "note_array", "notes_wide": 2, "notes_tall": 1},
+            }
+        )
+        schedule = _schedule_service({"b1": "pA", "b2": "pB"})
+
+        _drive(svc, boards, pages=pages, schedule=schedule, silence=True)
+
+        # Both boards receive a SNOOZING indicator on entering silence, each
+        # sized to its own geometry (flagship 6x22, note-array 2x1 -> 3x30).
+        rows1 = clients["b1"].send_characters.call_args.args[0]
+        assert len(rows1) == 6 and len(rows1[0]) == 22
+        rows2 = clients["b2"].send_characters.call_args.args[0]
+        assert len(rows2) == 3 and len(rows2[0]) == 30
+
+        # Silence state is tracked per runtime.
+        assert svc.runtimes["b1"].snoozing_message_sent is True
+        assert svc.runtimes["b2"].snoozing_message_sent is True
+
+    def test_steady_silence_does_not_resend_per_board(self):
+        boards = [_board("b1", "One"), _board("b2", "Two", port=7001)]
+        svc, clients = _service_with_runtimes(boards)
+        pages = _page_service({"pA": {"content": "ALPHA"}, "pB": {"content": "BETA"}})
+        schedule = _schedule_service({"b1": "pA", "b2": "pB"})
+
+        _drive(svc, boards, pages=pages, schedule=schedule, silence=True)
+        _drive(svc, boards, pages=pages, schedule=schedule, silence=True)
+
+        # Exactly one send per board (the entering-silence indicator).
+        assert clients["b1"].send_characters.call_count == 1
+        assert clients["b2"].send_characters.call_count == 1
+
+
+class TestSeams:
+    def test_get_board_client_and_get_runtime(self):
+        boards = [_board("b1", "One"), _board("b2", "Two", port=7001)]
+        svc, clients = _service_with_runtimes(boards)
+
+        assert svc.get_board_client("b2") is clients["b2"]
+        assert svc.get_runtime("b1").board_id == "b1"
+        assert svc.get_board_client("nope") is None
+        assert svc.get_runtime("nope") is None
+
+
+class TestBoardRuntime:
+    def test_defaults(self):
+        rt = BoardRuntime(client=None, board_id="b1")
+        assert rt.board_id == "b1"
+        assert rt.client is None
+        assert rt.last_active_page_content is None
+        assert rt.last_active_page_id is None
+        assert rt.last_silence_mode_active is False
+        assert rt.snoozing_message_sent is False
+        assert rt.polled_characters is None
+        assert rt.polled_at is None
+        assert rt.refresh_thread is None
+        assert rt.refresh_cancel is None


### PR DESCRIPTION
Closes #1243

Reimplements the `BoardRuntime` design from the abandoned `next` integration branch (PR #1410, commit b6445459) on top of current `main`, preserving all Local Array Mode (#1399/#1409) behavior that `next` predates.

## Design

- **`BoardRuntime`** — one per configured board: client + all per-board cached state (`last_active_page_content`/`_id`, `last_silence_mode_active`, `snoozing_message_sent`, `polled_characters`/`_at`, adaptive-refresh thread + cancel event, collection cadence gate). Held in `DisplayService.runtimes: dict[board_id, BoardRuntime]` with `self._primary_board_id` naming the primary.
- **Unified per-board path** — `check_and_send_for_board(board_id, rt, is_primary=...)` drives every board: per-board pause, per-board schedule vs. manual active page (`ActivePageSettings.by_board`), collections, per-page transitions, and per-board sizing via `resolve_dimensions`. The primary keeps the full feature set (triggers, temporary override, never-goes-dark default); secondaries go dark when no page is set. Silence is a global decision with per-board delivery and per-board state. Failures are isolated per board.
- **Back-compat shims** — `vb_client` and `_last_active_page_content`/`_id`, `_last_silence_mode_active`, `_snoozing_message_sent`, `_polled_characters`/`_at`, `_refresh_thread`/`_cancel` are read/write properties aliasing the primary runtime, so untouched callers (`api_server.py`, `mqtt/commands.py`) and existing tests keep working. `service.vb_client = X` creates/replaces the primary runtime (fallback sentinel key for legacy Config-only installs). `check_and_send_active_page()` is now a thin wrapper: primary via `check_and_send_for_board(primary)`, then each secondary through the same path.
- **Seams for #1244** — `get_board_client(board_id)` (+ `get_client` alias) and `get_runtime(board_id)`.
- **Diff-based rebuild** — `rebuild_board_clients()` (aliased as `reinitialize_board_client`) rebuilds from `settings.boards` keyed by board id; a connection-config signature lets unchanged boards keep their runtime and caches, so editing one board no longer resets another's state.

## Local Array Mode preservation

- `_build_board_clients()` still routes every board through `board_client_from_board_dict()` with **no credential pre-filter**, so local-tile note arrays (`NoteArrayLocalClient`) and token-auth note arrays both get runtimes (the #1243-item-3 gating fix on main is kept).
- `invalidate_board_content(board_id)` (the identify-flash hook from #1399) is reimplemented on runtimes: clears the board's runtime dedupe and its client cache, with a fallback lookup for legacy primary keys.
- The rebuild config signature includes the `tiles` list, so editing a tile's host/key/enabled state rebuilds that board's `NoteArrayLocalClient` instead of keeping a stale one.
- `src/devices.py` / `src/board_client.py` (tiles, `uses_local_tiles`, `configured_tiles`, `normalize_note_array_tiles`) are untouched.

## Tests

- `tests/test_multi_board_driving.py` — rewritten to next's simplified build/rebuild coverage, plus new cases for a local-tile array getting a `NoteArrayLocalClient` runtime and for `invalidate_board_content` under the runtime design.
- `tests/test_per_board_engine.py` — ported from next: per-board routing/sizing (flagship + note array in one tick), state isolation, skips (paused/disabled/dark), primary fallback, partial-failure isolation, primary-only override consumption, per-board silence delivery, seams, runtime defaults.
- Targeted run in the dev container: **692 passed** across all 22 test files that import `src.main` or exercise the touched API surface (per-board, adaptive refresh, silence, triggers, pause, MQTT, api_server identify/output/coverage/extended, note-array clients). `ruff check` + `ruff format --check` clean on the touched files.

## Deviations from the issue text

- Branch is `feat-1243-board-runtime-main` (the name `feat-1243-board-runtime` is taken by the merged-to-`next` PR #1410 branch).
- Board-state polling stays primary-only (as in the reference implementation): the read cache lives on the runtime, so a per-board poll is a drop-in later. The collection cadence gate now lives on the primary `BoardRuntime` (`next_collection_check`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
