### PR TITLE
perf(board-display): gate draw-mode cell metadata behind a prop (#1414)

### DIFF
--- a/web/src/__tests__/board-display-draw-attrs.test.tsx
+++ b/web/src/__tests__/board-display-draw-attrs.test.tsx
@@ -26,8 +26,10 @@ function TestWrapper({ children }: { children: React.ReactNode }) {
 }
 
 describe("BoardDisplay tile coordinates", () => {
-  it("exposes data-row/data-col on static tiles with cell values", () => {
-    const { container } = render(<BoardDisplay message={"A{red}"} isStatic />, { wrapper: TestWrapper });
+  it("exposes data-row/data-col on static tiles with cell values when emitCellMetadata is set", () => {
+    const { container } = render(<BoardDisplay message={"A{red}"} isStatic emitCellMetadata />, {
+      wrapper: TestWrapper,
+    });
     const a = container.querySelector('[data-row="0"][data-col="0"]');
     const red = container.querySelector('[data-row="0"][data-col="1"]');
     expect(a).not.toBeNull();
@@ -37,8 +39,26 @@ describe("BoardDisplay tile coordinates", () => {
     expect(container.querySelector('[data-row="5"][data-col="21"]')).not.toBeNull();
   });
 
-  it("exposes data-row/data-col on animated tiles", () => {
-    const { container } = render(<BoardDisplay message={"HI"} />, { wrapper: TestWrapper });
+  it("exposes data-row/data-col on animated tiles when emitCellMetadata is set", () => {
+    const { container } = render(<BoardDisplay message={"HI"} emitCellMetadata />, { wrapper: TestWrapper });
     expect(container.querySelector('[data-row="0"][data-col="1"]')).not.toBeNull();
+  });
+
+  it("omits cell metadata by default on static tiles (draw mode is the only consumer)", () => {
+    const { container } = render(<BoardDisplay message={"A{red}"} isStatic />, { wrapper: TestWrapper });
+    // Tiles still render (the wrapper hook is unconditional)...
+    expect(container.querySelector("[data-note-tile]")).not.toBeNull();
+    // ...but none carry draw-mode metadata.
+    expect(container.querySelector("[data-row]")).toBeNull();
+    expect(container.querySelector("[data-col]")).toBeNull();
+    expect(container.querySelector("[data-cell-value]")).toBeNull();
+  });
+
+  it("omits cell metadata by default on animated tiles", () => {
+    const { container } = render(<BoardDisplay message={"HI"} />, { wrapper: TestWrapper });
+    expect(container.querySelector("[data-note-tile]")).not.toBeNull();
+    expect(container.querySelector("[data-row]")).toBeNull();
+    expect(container.querySelector("[data-col]")).toBeNull();
+    expect(container.querySelector("[data-cell-value]")).toBeNull();
   });
 });

--- a/web/src/components/board-display.tsx
+++ b/web/src/components/board-display.tsx
@@ -306,6 +306,7 @@ const StaticGridRow = memo(function StaticGridRow({
   showSeams = false,
   isRowSeam = false,
   seamGap = "6px",
+  emitCellMetadata = false,
 }: {
   row: Token[];
   rowIdx: number;
@@ -315,6 +316,7 @@ const StaticGridRow = memo(function StaticGridRow({
   showSeams?: boolean;
   isRowSeam?: boolean;
   seamGap?: string;
+  emitCellMetadata?: boolean;
 }) {
   return (
     <div
@@ -326,14 +328,16 @@ const StaticGridRow = memo(function StaticGridRow({
       {row.map((token, colIdx) => {
         const isColSeam = showSeams && colIdx > 0 && colIdx % NOTE_COLS === 0;
         // Mirror the animated path's wrapper for DOM consistency; hosts the
-        // data-note-tile hook + note-array seam margin.
+        // data-note-tile hook + note-array seam margin. Draw-mode cell
+        // metadata (coordinates + cell value) is opt-in — see
+        // BoardDisplayProps.emitCellMetadata.
         return (
           <div
             key={`col-${rowIdx}-${colIdx}`}
             data-note-tile=""
-            data-row={rowIdx}
-            data-col={colIdx}
-            data-cell-value={getCharFromToken(token)}
+            {...(emitCellMetadata
+              ? { "data-row": rowIdx, "data-col": colIdx, "data-cell-value": getCharFromToken(token) }
+              : {})}
             {...(isColSeam ? { "data-note-col-seam": "true" } : {})}
             style={isColSeam ? { marginLeft: seamGap } : undefined}
           >
@@ -362,6 +366,7 @@ const GridRow = memo(
     showSeams = false,
     isRowSeam = false,
     seamGap = "6px",
+    emitCellMetadata = false,
   }: {
     row: Token[];
     rowIdx: number;
@@ -373,6 +378,7 @@ const GridRow = memo(
     showSeams?: boolean;
     isRowSeam?: boolean;
     seamGap?: string;
+    emitCellMetadata?: boolean;
   }) {
     return (
       <div
@@ -386,12 +392,13 @@ const GridRow = memo(
           // The wrapper is structurally required: CharTile returns a fragment
           // (flap-animation layers), so it needs a single containing flex item.
           // It also hosts the data-note-tile hook + note-array seam margin.
+          // Draw-mode cell coordinates are opt-in — see
+          // BoardDisplayProps.emitCellMetadata.
           return (
             <div
               key={`col-${rowIdx}-${colIdx}`}
               data-note-tile=""
-              data-row={rowIdx}
-              data-col={colIdx}
+              {...(emitCellMetadata ? { "data-row": rowIdx, "data-col": colIdx } : {})}
               {...(isColSeam ? { "data-note-col-seam": "true" } : {})}
               style={isColSeam ? { marginLeft: seamGap } : undefined}
             >
@@ -421,6 +428,7 @@ const GridRow = memo(
     if (prevProps.showSeams !== nextProps.showSeams) return false;
     if (prevProps.isRowSeam !== nextProps.isRowSeam) return false;
     if (prevProps.seamGap !== nextProps.seamGap) return false;
+    if (prevProps.emitCellMetadata !== nextProps.emitCellMetadata) return false;
 
     // Deep compare tokens
     for (let i = 0; i < prevProps.row.length; i++) {
@@ -1150,6 +1158,14 @@ interface BoardDisplayProps {
   notesWide?: number;
   /** Notes tall (for note_array device; ignored otherwise). */
   notesTall?: number;
+  /** Emit data-row / data-col / data-cell-value on every tile wrapper.
+   *  Only the page editor's draw mode consumes these (DrawableBoardPreview
+   *  hit-tests strokes via data-row/data-col and tests read data-cell-value),
+   *  so they are off by default — computing per-tile metadata is wasted work
+   *  for the many static previews (dashboards, lists, chat cards) that never
+   *  draw, and stray data-row/data-col on unrelated previews would force the
+   *  draw surface's hit-testing to reject them one by one. */
+  emitCellMetadata?: boolean;
 }
 
 // Backward compatibility alias
@@ -1166,6 +1182,7 @@ export const BoardDisplay = memo(
     isStatic = false,
     notesWide = 1,
     notesTall = 1,
+    emitCellMetadata = false,
   }: BoardDisplayProps) {
     const t = useTranslations("boardDisplay");
     const animationsEnabled = useBoardAnimationsEnabled();
@@ -1272,6 +1289,7 @@ export const BoardDisplay = memo(
                     showSeams={showSeams}
                     isRowSeam={isRowSeam}
                     seamGap={seamGap}
+                    emitCellMetadata={emitCellMetadata}
                   />
                 ) : (
                   <GridRow
@@ -1286,6 +1304,7 @@ export const BoardDisplay = memo(
                     showSeams={showSeams}
                     isRowSeam={isRowSeam}
                     seamGap={seamGap}
+                    emitCellMetadata={emitCellMetadata}
                   />
                 );
               })}
@@ -1305,7 +1324,8 @@ export const BoardDisplay = memo(
       prevProps.deviceType === nextProps.deviceType &&
       prevProps.notesWide === nextProps.notesWide &&
       prevProps.notesTall === nextProps.notesTall &&
-      prevProps.isStatic === nextProps.isStatic
+      prevProps.isStatic === nextProps.isStatic &&
+      prevProps.emitCellMetadata === nextProps.emitCellMetadata
     );
   },
 );

--- a/web/src/components/page-builder.tsx
+++ b/web/src/components/page-builder.tsx
@@ -1696,6 +1696,10 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
                         deviceType={deviceType}
                         notesWide={notesWide}
                         notesTall={notesTall}
+                        // DrawableBoardPreview hit-tests strokes through the
+                        // tiles' data-row/data-col attributes; only this
+                        // editor preview opts into emitting them.
+                        emitCellMetadata
                       />
                     </DrawableBoardPreview>
                   </div>


### PR DESCRIPTION
Part of #1414.

PR #1413 emitted `data-row`/`data-col` on every tile wrapper (both the static and animated render paths) and `data-cell-value` on every static tile, which means `getCharFromToken` ran for all tiles of every board preview app-wide — dashboards, page lists, chat-drawer previews — even though only the page editor's draw mode consumes these attributes.

## Changes

- `BoardDisplay` gains an `emitCellMetadata?: boolean` prop (default **false**), threaded down to `StaticGridRow` (emits `data-row`/`data-col`/`data-cell-value`) and `GridRow` (emits `data-row`/`data-col`). The memo comparators for `GridRow` and `BoardDisplay` include the new prop.
- The page builder's editor preview — the one wrapped in `DrawableBoardPreview`, which hit-tests strokes via `elementFromPoint` + `data-row`/`data-col` — is the only render site that opts in (`ScaledBoardDisplay` forwards the prop untouched via its `ComponentProps<typeof BoardDisplay>` spread).
- Side benefit: unrelated previews elsewhere on the page no longer carry `data-row`/`data-col` at all, so the draw surface's containment check (`wrapper.contains(tile)`) no longer has to reject their tiles one by one during a drag.

## Tests

`web/src/__tests__/board-display-draw-attrs.test.tsx`:
- attrs present (static + animated) when `emitCellMetadata` is set — including cell values (`"A"`, `"red"`) and the full flagship grid;
- attrs absent by default on both render paths (tiles still render via the unconditional `data-note-tile` hook).

Draw-mode hit-testing still works: `page-builder-draw-mode.test.tsx` round-trips a stroke through the real `PageBuilder` (which now passes the prop), and the draw-mode e2e specs locate tiles inside `[data-draw-surface="true"]`, i.e. the opted-in editor preview.

Validation: `npm test`, `npm run lint`, `npm run format:check` in the dev container — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
