### PR TITLE
test(draw-mode): second-pointer rejection, toolbar undo/redo click path, e2e cleanup (#1414)

### DIFF
--- a/web/src/__tests__/drawable-board-preview.test.tsx
+++ b/web/src/__tests__/drawable-board-preview.test.tsx
@@ -168,6 +168,43 @@ describe("DrawableBoardPreview", () => {
     ]);
   });
 
+  it("ignores a second concurrent pointer mid-stroke (down, move, and up)", () => {
+    const { surface, onStrokePreview, onStrokeCommit } = setup();
+    const t1 = makeTile(0, 0, surface);
+    const t2 = makeTile(0, 1, surface);
+    const intruderTile = makeTile(3, 3, surface);
+    // Key hit-testing off coordinates rather than call order so the mock
+    // stays valid no matter which handlers consult elementFromPoint.
+    const byPoint: Record<string, HTMLElement> = { "5,5": t1, "6,6": t2, "50,50": intruderTile };
+    document.elementFromPoint = vi.fn((x: number, y: number) => byPoint[`${x},${y}`] ?? null);
+
+    // Pointer 1 starts a stroke.
+    fireEvent.pointerDown(surface, { button: 0, pointerId: 1, clientX: 5, clientY: 5 });
+    expect(onStrokePreview).toHaveBeenLastCalledWith([{ row: 0, col: 0 }]);
+
+    // A second pointer lands mid-stroke on a different tile: its down must
+    // not restart the stroke, its moves must not extend it, and its up must
+    // not commit it.
+    fireEvent.pointerDown(surface, { button: 0, pointerId: 2, clientX: 50, clientY: 50 });
+    fireEvent.pointerMove(surface, { pointerId: 2, clientX: 50, clientY: 50 });
+    fireEvent.pointerUp(surface, { pointerId: 2, clientX: 50, clientY: 50 });
+    expect(onStrokeCommit).not.toHaveBeenCalled();
+
+    // Pointer 1 is still drawing and finishes its stroke normally.
+    fireEvent.pointerMove(surface, { pointerId: 1, clientX: 6, clientY: 6 });
+    fireEvent.pointerUp(surface, { pointerId: 1, clientX: 6, clientY: 6 });
+
+    expect(onStrokeCommit).toHaveBeenCalledTimes(1);
+    expect(onStrokeCommit).toHaveBeenCalledWith([
+      { row: 0, col: 0 },
+      { row: 0, col: 1 },
+    ]);
+    // The intruder's cell never leaked into any preview flush either.
+    for (const call of onStrokePreview.mock.calls) {
+      expect(call[0]).not.toContainEqual({ row: 3, col: 3 });
+    }
+  });
+
   it("ignores hits on tiles outside the draw surface (e.g. another board preview elsewhere on the page)", () => {
     const { surface, onStrokePreview, onStrokeCommit } = setup();
     // Deliberately NOT passed `surface` — this tile lives in document.body,

--- a/web/tests/draw-mode.spec.ts
+++ b/web/tests/draw-mode.spec.ts
@@ -87,7 +87,17 @@ test.beforeEach(async ({ page }) => {
 
 test.afterEach(async () => {
   await deleteAllPages();
+  // Some tests below mutate device config (note-array boards, an extra Note
+  // device) — reset both the board list AND the device list here explicitly
+  // instead of leaning on the next test's beforeEach, so this spec leaves
+  // the shared backend clean even when a mutating test runs last or fails
+  // midway. The devices pin mirrors configureBoard() in helpers.ts.
   await resetToSingleBoard();
+  await fetch(`${API_URL}/settings/board`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json", ...authHeaders() },
+    body: JSON.stringify({ devices: ["flagship"] }),
+  });
   // Some tests enable date_time to get template variables — leave it off.
   await disablePlugin("date_time").catch(() => {});
 });
@@ -156,6 +166,29 @@ test.describe("Draw mode", () => {
     for (const col of [2, 3, 4, 5, 6]) {
       await expect(tile(page, 2, col)).toHaveAttribute("data-cell-value", " ");
     }
+  });
+
+  test("toolbar Undo and Redo buttons revert and re-apply a paint stroke", async ({ page }) => {
+    await gotoNewPage(page);
+    await enterDrawMode(page);
+    await pickBrush(page, "blue");
+
+    await tile(page, 1, 5).click();
+    await expect(tile(page, 1, 5)).toHaveAttribute("data-cell-value", "blue");
+
+    // Same behavior as the Ctrl+Z path above, but through the toolbar's
+    // Undo/Redo buttons (rendered unconditionally, draw mode included) so
+    // the click path stays covered independently of the keyboard shortcut.
+    const undoButton = page.getByRole("button", { name: "Undo", exact: true });
+    const redoButton = page.getByRole("button", { name: "Redo", exact: true });
+
+    await expect(undoButton).toBeEnabled();
+    await undoButton.click();
+    await expect(tile(page, 1, 5)).toHaveAttribute("data-cell-value", " ");
+
+    await expect(redoButton).toBeEnabled();
+    await redoButton.click();
+    await expect(tile(page, 1, 5)).toHaveAttribute("data-cell-value", "blue");
   });
 
   test("eraser clears a painted cell without touching its neighbor", async ({ page }) => {
@@ -264,9 +297,11 @@ test.describe("Draw mode", () => {
   });
 
   test("painting works beyond single-note bounds on a 2×1 note array", async ({ page }) => {
-    // Mirror the note-array setup: size the cloud mock and configure a 2×1
-    // local note-array board whose tiles point at the mock's two listeners.
-    await configureMockCloud(2, 1);
+    // Configure a 2×1 LOCAL-mode note-array board whose tiles point at the
+    // mock board server's two Local-API listeners (7000/7001). No cloud mock
+    // involved: local-mode arrays fan out per-tile local POSTs (see
+    // board_client_from_board_dict), and this test only paints in the editor
+    // and reads data-cell-value — it never sends board output at all.
     const board = {
       name: "Local Array",
       device_type: "note_array",


### PR DESCRIPTION
Part of #1414. Test-only hardening for pencil draw mode — no production code changes.

## 1. Second-pointer rejection unit test

`DrawableBoardPreview` guards against concurrent pointers (`if (strokeRef.current) return` on pointerdown, plus `pointerId` checks on move/up/cancel), but the existing suite only ever fired `pointerId: 1`. New test in `web/src/__tests__/drawable-board-preview.test.tsx`: mid-stroke, a second pointer's down/move/up (different `pointerId`, hitting a different tile) must neither restart, extend, nor commit the stroke — the first pointer's stroke commits exactly once with only its own cells. `elementFromPoint` is mocked by coordinates so the assertion is independent of internal call order.

## 2. Toolbar Undo/Redo click path (e2e)

`web/tests/draw-mode.spec.ts` covered undo only via the Ctrl+Z keyboard path. New test clicks the toolbar buttons (`getByRole("button", { name: "Undo" | "Redo", exact: true })` — matching the toolbar's hardcoded `aria-label`s in `TemplateEditorToolbar.tsx`, which renders the Undo/Redo group unconditionally in draw mode) and asserts a painted cell is reverted and re-applied.

## 3. E2E cleanup

- **Dropped the dead `configureMockCloud(2, 1)` call** in the 2×1 note-array test. Verified dead by code reading: the test's board is `api_mode: "local"` with tiles, so the backend builds a `NoteArrayLocalClient` (`src/board_client.py::board_client_from_board_dict`) that fans out per-tile Local-API POSTs to the mock *board* server's listeners (7000/7001) — the cloud mock (`MOCK_CLOUD_URL`, a separate server) is only used for cloud-mode arrays with a `note_array_token`. The test also never sends or asserts board output (it only paints in the editor and reads `data-cell-value`). The misleading "size the cloud mock" comment is replaced with one explaining why no cloud mock is involved.
- **Explicit devices-config reset**: the 3×15 Note test widens the device list (`devices: ["flagship", "note"]`) and previously leaned on the *next* test's `beforeEach` (`configureBoard()`) to pin it back. The spec's `afterEach` now resets `devices: ["flagship"]` itself (after `resetToSingleBoard()`, mirroring `configureBoard`'s pin), so this spec leaves the shared backend clean even when it is the last to run or a test fails midway.

## Validation

- Unit tests, lint, and format:check run green in the dev container.
- **E2E validation is deferred to CI** — the live Playwright stack could not be run in this session. The spec changes reuse the exact locator patterns, helpers (`tile()`, `enterDrawMode()`, `pickBrush()` and `helpers.ts` fixtures), and wait styles of the neighboring passing tests in the same file, and every locator was verified against the component source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
