### PR TITLE
feat(web): page-picker size filtering + size badges (#1249)

### DIFF
--- a/web/app/routes/schedule.tsx
+++ b/web/app/routes/schedule.tsx
@@ -738,7 +738,7 @@ export default function SchedulePage() {
           {pagesData && (
             <ScheduleEntryForm
               schedule={editingSchedule || undefined}
-              pages={pagesData.pages.map((p) => ({ id: p.id, name: p.name }))}
+              pages={pagesData.pages}
               collections={collectionsData?.collections}
               onSubmit={handleSubmit}
               onCancel={handleCloseForm}

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -327,7 +327,9 @@
       "dateOverrideHint": "Overrides any weekly schedule active during this window.",
       "validationAnnualDateRequired": "Please pick a month and day",
       "validationOneOffDateRequired": "Please pick a date",
-      "validationEndDateBeforeStart": "End date must be on or after start date"
+      "validationEndDateBeforeStart": "End date must be on or after start date",
+      "collectionSizeWarning": "{count} von {total} Seiten in dieser Sammlung passen nicht zur Größe dieses Boards und werden übersprungen.",
+      "incompatiblePageWarning": "Diese Seite passt nicht zur Größe dieses Boards und wird möglicherweise nicht richtig angezeigt."
     },
     "descriptionWithTimezone": "Automatisiere die Seitenrotation nach Zeit und Tag · {timezone}",
     "gapDefaultPlaceholder": "Standard für Lücken…",
@@ -628,7 +630,8 @@
     "changeModeOverrideDescription": "Zeige eine Seite für eine festgelegte Dauer und setze dann deinen Zeitplan fort.",
     "changeModeDisableTitle": "Zeitplan-Modus deaktivieren",
     "changeModeDisableDescription": "Deaktiviere den Zeitplan und steuere das Board manuell.",
-    "changeModeDisableSuccess": "Zeitplan-Modus deaktiviert"
+    "changeModeDisableSuccess": "Zeitplan-Modus deaktiviert",
+    "collectionSizeWarning": "{count} von {total} Seiten in dieser Sammlung passen nicht zur Größe dieses Boards und werden übersprungen."
   },
   "forceSetDialog": {
     "title": "Board erzwingen",
@@ -1260,7 +1263,9 @@
     "collectionsTab": "Karussells ({count})",
     "noPagesTitle": "Noch keine Seiten erstellt.",
     "noPagesDescription": "Erstellen Sie Ihre erste Seite, um sie auf dem Board anzuzeigen.",
-    "createFirstPage": "Erste Seite erstellen"
+    "createFirstPage": "Erste Seite erstellen",
+    "noCompatiblePagesTitle": "Keine Seiten passen zur Größe dieses Boards.",
+    "noCompatiblePagesDescription": "Erstelle eine Seite in der Größe dieses Boards, um sie hier zu sehen."
   },
   "profile": {
     "title": "Profil",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -284,7 +284,9 @@
       "dateOverrideHint": "Overrides any weekly schedule active during this window.",
       "validationAnnualDateRequired": "Please pick a month and day",
       "validationOneOffDateRequired": "Please pick a date",
-      "validationEndDateBeforeStart": "End date must be on or after start date"
+      "validationEndDateBeforeStart": "End date must be on or after start date",
+      "collectionSizeWarning": "{count} of {total} pages in this collection don't fit this board's size and will be skipped.",
+      "incompatiblePageWarning": "This page doesn't match this board's size and may not display correctly."
     },
     "descriptionWithTimezone": "Automate page rotation by time and day · {timezone}",
     "gapDefaultPlaceholder": "Gap default…",
@@ -585,7 +587,8 @@
     "changeModeOverrideDescription": "Show a page for a set duration, then resume your schedule.",
     "changeModeDisableTitle": "Turn off schedule mode",
     "changeModeDisableDescription": "Disable the schedule and control the board manually.",
-    "changeModeDisableSuccess": "Schedule mode disabled"
+    "changeModeDisableSuccess": "Schedule mode disabled",
+    "collectionSizeWarning": "{count} of {total} pages in this collection don't fit this board's size and will be skipped."
   },
   "forceSetDialog": {
     "title": "Force Set Board",
@@ -1217,7 +1220,9 @@
     "collectionsTab": "Collections ({count})",
     "noPagesTitle": "No pages created yet.",
     "noPagesDescription": "Create your first page to display on the board.",
-    "createFirstPage": "Create your first page"
+    "createFirstPage": "Create your first page",
+    "noCompatiblePagesTitle": "No pages match this board's size.",
+    "noCompatiblePagesDescription": "Create a page sized for this board to see it here."
   },
   "profile": {
     "title": "Profile",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -327,7 +327,9 @@
       "dateOverrideHint": "Overrides any weekly schedule active during this window.",
       "validationAnnualDateRequired": "Please pick a month and day",
       "validationOneOffDateRequired": "Please pick a date",
-      "validationEndDateBeforeStart": "End date must be on or after start date"
+      "validationEndDateBeforeStart": "End date must be on or after start date",
+      "collectionSizeWarning": "{count} de {total} páginas de esta colección no se ajustan al tamaño de este tablero y se omitirán.",
+      "incompatiblePageWarning": "Esta página no coincide con el tamaño de este tablero y puede no mostrarse correctamente."
     },
     "descriptionWithTimezone": "Automatiza la rotación de páginas por hora y día · {timezone}",
     "gapDefaultPlaceholder": "Predeterminada para huecos…",
@@ -628,7 +630,8 @@
     "changeModeOverrideDescription": "Mostrar una página durante un tiempo determinado y luego reanudar tu programación.",
     "changeModeDisableTitle": "Desactivar modo programado",
     "changeModeDisableDescription": "Desactivar la programación y controlar la pantalla manualmente.",
-    "changeModeDisableSuccess": "Modo programado desactivado"
+    "changeModeDisableSuccess": "Modo programado desactivado",
+    "collectionSizeWarning": "{count} de {total} páginas de esta colección no se ajustan al tamaño de este tablero y se omitirán."
   },
   "forceSetDialog": {
     "title": "Forzar pantalla",
@@ -1260,7 +1263,9 @@
     "collectionsTab": "Carruseles ({count})",
     "noPagesTitle": "Aún no se han creado páginas.",
     "noPagesDescription": "Crea tu primera página para mostrarla en el tablero.",
-    "createFirstPage": "Crear tu primera página"
+    "createFirstPage": "Crear tu primera página",
+    "noCompatiblePagesTitle": "Ninguna página coincide con el tamaño de este tablero.",
+    "noCompatiblePagesDescription": "Crea una página del tamaño de este tablero para verla aquí."
   },
   "profile": {
     "title": "Perfil",

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -327,7 +327,9 @@
       "dateOverrideHint": "Overrides any weekly schedule active during this window.",
       "validationAnnualDateRequired": "Please pick a month and day",
       "validationOneOffDateRequired": "Please pick a date",
-      "validationEndDateBeforeStart": "End date must be on or after start date"
+      "validationEndDateBeforeStart": "End date must be on or after start date",
+      "collectionSizeWarning": "{count} des {total} pages de cette collection ne correspondent pas à la taille de ce tableau et seront ignorées.",
+      "incompatiblePageWarning": "Cette page ne correspond pas à la taille de ce tableau et pourrait ne pas s'afficher correctement."
     },
     "descriptionWithTimezone": "Automatisez la rotation des pages par heure et jour · {timezone}",
     "gapDefaultPlaceholder": "Page par défaut…",
@@ -628,7 +630,8 @@
     "changeModeOverrideDescription": "Affichez une page pendant une durée définie, puis reprenez votre planning.",
     "changeModeDisableTitle": "Désactiver le mode planning",
     "changeModeDisableDescription": "Désactivez le planning et contrôlez le board manuellement.",
-    "changeModeDisableSuccess": "Mode planning désactivé"
+    "changeModeDisableSuccess": "Mode planning désactivé",
+    "collectionSizeWarning": "{count} des {total} pages de cette collection ne correspondent pas à la taille de ce tableau et seront ignorées."
   },
   "forceSetDialog": {
     "title": "Forcer l'affichage",
@@ -1260,7 +1263,9 @@
     "collectionsTab": "Carrousels ({count})",
     "noPagesTitle": "Aucune page créée pour le moment.",
     "noPagesDescription": "Créez votre première page à afficher sur le tableau.",
-    "createFirstPage": "Créer votre première page"
+    "createFirstPage": "Créer votre première page",
+    "noCompatiblePagesTitle": "Aucune page ne correspond à la taille de ce tableau.",
+    "noCompatiblePagesDescription": "Créez une page à la taille de ce tableau pour la voir ici."
   },
   "profile": {
     "title": "Profil",

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -327,7 +327,9 @@
       "dateOverrideHint": "Overrides any weekly schedule active during this window.",
       "validationAnnualDateRequired": "Please pick a month and day",
       "validationOneOffDateRequired": "Please pick a date",
-      "validationEndDateBeforeStart": "End date must be on or after start date"
+      "validationEndDateBeforeStart": "End date must be on or after start date",
+      "collectionSizeWarning": "{count} pagine su {total} in questa raccolta non corrispondono alle dimensioni di questa board e verranno saltate.",
+      "incompatiblePageWarning": "Questa pagina non corrisponde alle dimensioni di questa board e potrebbe non essere visualizzata correttamente."
     },
     "descriptionWithTimezone": "Automatizza la rotazione delle pagine per ora e giorno · {timezone}",
     "gapDefaultPlaceholder": "Predefinita per intervalli…",
@@ -628,7 +630,8 @@
     "changeModeOverrideDescription": "Mostra una pagina per una durata definita, poi riprendi la pianificazione.",
     "changeModeDisableTitle": "Disattiva modalità pianificazione",
     "changeModeDisableDescription": "Disattiva la pianificazione e controlla il board manualmente.",
-    "changeModeDisableSuccess": "Modalità pianificazione disattivata"
+    "changeModeDisableSuccess": "Modalità pianificazione disattivata",
+    "collectionSizeWarning": "{count} pagine su {total} in questa raccolta non corrispondono alle dimensioni di questa board e verranno saltate."
   },
   "forceSetDialog": {
     "title": "Forza impostazione board",
@@ -1260,7 +1263,9 @@
     "collectionsTab": "Caroselli ({count})",
     "noPagesTitle": "Nessuna pagina creata.",
     "noPagesDescription": "Crea la tua prima pagina da mostrare sul board.",
-    "createFirstPage": "Crea la tua prima pagina"
+    "createFirstPage": "Crea la tua prima pagina",
+    "noCompatiblePagesTitle": "Nessuna pagina corrisponde alle dimensioni di questa board.",
+    "noCompatiblePagesDescription": "Crea una pagina delle dimensioni di questa board per vederla qui."
   },
   "profile": {
     "title": "Profilo",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -327,7 +327,9 @@
       "dateOverrideHint": "Overrides any weekly schedule active during this window.",
       "validationAnnualDateRequired": "Please pick a month and day",
       "validationOneOffDateRequired": "Please pick a date",
-      "validationEndDateBeforeStart": "End date must be on or after start date"
+      "validationEndDateBeforeStart": "End date must be on or after start date",
+      "collectionSizeWarning": "このコレクションの{total}ページ中{count}ページがこのボードのサイズに合わないため、スキップされます。",
+      "incompatiblePageWarning": "このページはこのボードのサイズに合わないため、正しく表示されない可能性があります。"
     },
     "descriptionWithTimezone": "時刻と曜日でページの切り替えを自動化 · {timezone}",
     "gapDefaultPlaceholder": "空き時間のデフォルト…",
@@ -628,7 +630,8 @@
     "changeModeOverrideDescription": "ページを指定時間だけ表示し、その後スケジュールを再開します。",
     "changeModeDisableTitle": "スケジュールモードをオフ",
     "changeModeDisableDescription": "スケジュールを無効化し、ボードを手動で操作します。",
-    "changeModeDisableSuccess": "スケジュールモードを無効化しました"
+    "changeModeDisableSuccess": "スケジュールモードを無効化しました",
+    "collectionSizeWarning": "このコレクションの{total}ページ中{count}ページがこのボードのサイズに合わないため、スキップされます。"
   },
   "forceSetDialog": {
     "title": "ボードを強制設定",
@@ -1260,7 +1263,9 @@
     "collectionsTab": "カルーセル（{count}）",
     "noPagesTitle": "ページがまだ作成されていません。",
     "noPagesDescription": "ボードに表示する最初のページを作成しましょう。",
-    "createFirstPage": "最初のページを作成"
+    "createFirstPage": "最初のページを作成",
+    "noCompatiblePagesTitle": "このボードのサイズに合うページがありません。",
+    "noCompatiblePagesDescription": "このボードのサイズに合わせたページを作成すると、ここに表示されます。"
   },
   "profile": {
     "title": "プロフィール",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -327,7 +327,9 @@
       "dateOverrideHint": "Overrides any weekly schedule active during this window.",
       "validationAnnualDateRequired": "Please pick a month and day",
       "validationOneOffDateRequired": "Please pick a date",
-      "validationEndDateBeforeStart": "End date must be on or after start date"
+      "validationEndDateBeforeStart": "End date must be on or after start date",
+      "collectionSizeWarning": "이 컬렉션의 {total}개 페이지 중 {count}개가 이 보드의 크기와 맞지 않아 건너뜁니다.",
+      "incompatiblePageWarning": "이 페이지는 이 보드의 크기와 맞지 않아 올바르게 표시되지 않을 수 있습니다."
     },
     "descriptionWithTimezone": "시간과 요일별로 페이지 회전을 자동화 · {timezone}",
     "gapDefaultPlaceholder": "공백 기본…",
@@ -628,7 +630,8 @@
     "changeModeOverrideDescription": "지정된 시간 동안 페이지를 표시한 후 일정을 다시 시작합니다.",
     "changeModeDisableTitle": "일정 모드 끄기",
     "changeModeDisableDescription": "일정을 비활성화하고 보드를 수동으로 제어합니다.",
-    "changeModeDisableSuccess": "일정 모드가 비활성화됨"
+    "changeModeDisableSuccess": "일정 모드가 비활성화됨",
+    "collectionSizeWarning": "이 컬렉션의 {total}개 페이지 중 {count}개가 이 보드의 크기와 맞지 않아 건너뜁니다."
   },
   "forceSetDialog": {
     "title": "보드 강제 설정",
@@ -1260,7 +1263,9 @@
     "collectionsTab": "캐러셀 ({count})",
     "noPagesTitle": "아직 페이지가 만들어지지 않았습니다.",
     "noPagesDescription": "보드에 표시할 첫 페이지를 만드세요.",
-    "createFirstPage": "첫 페이지 만들기"
+    "createFirstPage": "첫 페이지 만들기",
+    "noCompatiblePagesTitle": "이 보드의 크기와 일치하는 페이지가 없습니다.",
+    "noCompatiblePagesDescription": "이 보드 크기에 맞는 페이지를 만들면 여기에 표시됩니다."
   },
   "profile": {
     "title": "프로필",

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -327,7 +327,9 @@
       "dateOverrideHint": "Overrides any weekly schedule active during this window.",
       "validationAnnualDateRequired": "Please pick a month and day",
       "validationOneOffDateRequired": "Please pick a date",
-      "validationEndDateBeforeStart": "End date must be on or after start date"
+      "validationEndDateBeforeStart": "End date must be on or after start date",
+      "collectionSizeWarning": "{count} van de {total} pagina's in deze collectie passen niet bij het formaat van dit bord en worden overgeslagen.",
+      "incompatiblePageWarning": "Deze pagina past niet bij het formaat van dit bord en wordt mogelijk niet correct weergegeven."
     },
     "descriptionWithTimezone": "Automatiseer paginarotatie op tijd en dag · {timezone}",
     "gapDefaultPlaceholder": "Standaard bij gat…",
@@ -628,7 +630,8 @@
     "changeModeOverrideDescription": "Toon een pagina voor een ingestelde duur en hervat daarna je rooster.",
     "changeModeDisableTitle": "Roostermodus uitschakelen",
     "changeModeDisableDescription": "Schakel het rooster uit en bedien het board handmatig.",
-    "changeModeDisableSuccess": "Roostermodus uitgeschakeld"
+    "changeModeDisableSuccess": "Roostermodus uitgeschakeld",
+    "collectionSizeWarning": "{count} van de {total} pagina's in deze collectie passen niet bij het formaat van dit bord en worden overgeslagen."
   },
   "forceSetDialog": {
     "title": "Board forceren",
@@ -1260,7 +1263,9 @@
     "collectionsTab": "Carrousels ({count})",
     "noPagesTitle": "Nog geen pagina's gemaakt.",
     "noPagesDescription": "Maak je eerste pagina om op het board te tonen.",
-    "createFirstPage": "Maak je eerste pagina"
+    "createFirstPage": "Maak je eerste pagina",
+    "noCompatiblePagesTitle": "Geen pagina's passen bij het formaat van dit bord.",
+    "noCompatiblePagesDescription": "Maak een pagina in het formaat van dit bord om deze hier te zien."
   },
   "profile": {
     "title": "Profiel",

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -327,7 +327,9 @@
       "dateOverrideHint": "Overrides any weekly schedule active during this window.",
       "validationAnnualDateRequired": "Please pick a month and day",
       "validationOneOffDateRequired": "Please pick a date",
-      "validationEndDateBeforeStart": "End date must be on or after start date"
+      "validationEndDateBeforeStart": "End date must be on or after start date",
+      "collectionSizeWarning": "{count} z {total} stron w tej kolekcji nie pasuje do rozmiaru tej tablicy i zostaną pominięte.",
+      "incompatiblePageWarning": "Ta strona nie pasuje do rozmiaru tej tablicy i może nie wyświetlać się poprawnie."
     },
     "descriptionWithTimezone": "Automatyzuj rotację stron według czasu i dnia · {timezone}",
     "gapDefaultPlaceholder": "Domyślna dla luki…",
@@ -628,7 +630,8 @@
     "changeModeOverrideDescription": "Pokaż stronę przez określony czas, a następnie wznów harmonogram.",
     "changeModeDisableTitle": "Wyłącz tryb harmonogramu",
     "changeModeDisableDescription": "Wyłącz harmonogram i steruj boardem ręcznie.",
-    "changeModeDisableSuccess": "Tryb harmonogramu wyłączony"
+    "changeModeDisableSuccess": "Tryb harmonogramu wyłączony",
+    "collectionSizeWarning": "{count} z {total} stron w tej kolekcji nie pasuje do rozmiaru tej tablicy i zostaną pominięte."
   },
   "forceSetDialog": {
     "title": "Wymuś ustawienie boarda",
@@ -1260,7 +1263,9 @@
     "collectionsTab": "Karuzele ({count})",
     "noPagesTitle": "Nie utworzono jeszcze żadnych stron.",
     "noPagesDescription": "Utwórz pierwszą stronę do wyświetlenia na boardzie.",
-    "createFirstPage": "Utwórz pierwszą stronę"
+    "createFirstPage": "Utwórz pierwszą stronę",
+    "noCompatiblePagesTitle": "Żadna strona nie pasuje do rozmiaru tej tablicy.",
+    "noCompatiblePagesDescription": "Utwórz stronę o rozmiarze tej tablicy, aby zobaczyć ją tutaj."
   },
   "profile": {
     "title": "Profil",

--- a/web/messages/pt.json
+++ b/web/messages/pt.json
@@ -327,7 +327,9 @@
       "dateOverrideHint": "Overrides any weekly schedule active during this window.",
       "validationAnnualDateRequired": "Please pick a month and day",
       "validationOneOffDateRequired": "Please pick a date",
-      "validationEndDateBeforeStart": "End date must be on or after start date"
+      "validationEndDateBeforeStart": "End date must be on or after start date",
+      "collectionSizeWarning": "{count} de {total} páginas desta coleção não se ajustam ao tamanho deste quadro e serão ignoradas.",
+      "incompatiblePageWarning": "Esta página não corresponde ao tamanho deste quadro e pode não ser exibida corretamente."
     },
     "descriptionWithTimezone": "Automatize a rotação de páginas por hora e dia · {timezone}",
     "gapDefaultPlaceholder": "Predefinida para intervalo…",
@@ -628,7 +630,8 @@
     "changeModeOverrideDescription": "Mostrar uma página durante um tempo definido e depois retomar o agendamento.",
     "changeModeDisableTitle": "Desativar modo de agendamento",
     "changeModeDisableDescription": "Desativar o agendamento e controlar o board manualmente.",
-    "changeModeDisableSuccess": "Modo de agendamento desativado"
+    "changeModeDisableSuccess": "Modo de agendamento desativado",
+    "collectionSizeWarning": "{count} de {total} páginas desta coleção não se ajustam ao tamanho deste quadro e serão ignoradas."
   },
   "forceSetDialog": {
     "title": "Forçar board",
@@ -1260,7 +1263,9 @@
     "collectionsTab": "Carrosséis ({count})",
     "noPagesTitle": "Ainda não foram criadas páginas.",
     "noPagesDescription": "Crie a sua primeira página para mostrar no board.",
-    "createFirstPage": "Crie a sua primeira página"
+    "createFirstPage": "Crie a sua primeira página",
+    "noCompatiblePagesTitle": "Nenhuma página corresponde ao tamanho deste quadro.",
+    "noCompatiblePagesDescription": "Crie uma página no tamanho deste quadro para vê-la aqui."
   },
   "profile": {
     "title": "Perfil",

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -327,7 +327,9 @@
       "dateOverrideHint": "Overrides any weekly schedule active during this window.",
       "validationAnnualDateRequired": "Please pick a month and day",
       "validationOneOffDateRequired": "Please pick a date",
-      "validationEndDateBeforeStart": "End date must be on or after start date"
+      "validationEndDateBeforeStart": "End date must be on or after start date",
+      "collectionSizeWarning": "{count} из {total} страниц в этой коллекции не подходят под размер этой доски и будут пропущены.",
+      "incompatiblePageWarning": "Эта страница не подходит под размер этой доски и может отображаться некорректно."
     },
     "descriptionWithTimezone": "Автоматизация смены страниц по времени и дню · {timezone}",
     "gapDefaultPlaceholder": "По умолчанию для пропуска…",
@@ -628,7 +630,8 @@
     "changeModeOverrideDescription": "Показать страницу заданное время, затем продолжить расписание.",
     "changeModeDisableTitle": "Отключить режим расписания",
     "changeModeDisableDescription": "Отключите расписание и управляйте board вручную.",
-    "changeModeDisableSuccess": "Режим расписания отключён"
+    "changeModeDisableSuccess": "Режим расписания отключён",
+    "collectionSizeWarning": "{count} из {total} страниц в этой коллекции не подходят под размер этой доски и будут пропущены."
   },
   "forceSetDialog": {
     "title": "Принудительно установить board",
@@ -1260,7 +1263,9 @@
     "collectionsTab": "Карусели ({count})",
     "noPagesTitle": "Страницы ещё не созданы.",
     "noPagesDescription": "Создайте первую страницу для отображения на board.",
-    "createFirstPage": "Создать первую страницу"
+    "createFirstPage": "Создать первую страницу",
+    "noCompatiblePagesTitle": "Нет страниц, подходящих под размер этой доски.",
+    "noCompatiblePagesDescription": "Создайте страницу под размер этой доски, чтобы увидеть её здесь."
   },
   "profile": {
     "title": "Профиль",

--- a/web/messages/sv.json
+++ b/web/messages/sv.json
@@ -327,7 +327,9 @@
       "dateOverrideHint": "Overrides any weekly schedule active during this window.",
       "validationAnnualDateRequired": "Please pick a month and day",
       "validationOneOffDateRequired": "Please pick a date",
-      "validationEndDateBeforeStart": "End date must be on or after start date"
+      "validationEndDateBeforeStart": "End date must be on or after start date",
+      "collectionSizeWarning": "{count} av {total} sidor i den här samlingen passar inte den här tavlans storlek och hoppas över.",
+      "incompatiblePageWarning": "Den här sidan matchar inte den här tavlans storlek och kanske inte visas korrekt."
     },
     "descriptionWithTimezone": "Automatisera sidrotation efter tid och dag · {timezone}",
     "gapDefaultPlaceholder": "Standard för lucka…",
@@ -628,7 +630,8 @@
     "changeModeOverrideDescription": "Visa en sida under en bestämd tid och återuppta sedan ditt schema.",
     "changeModeDisableTitle": "Stäng av schemaläge",
     "changeModeDisableDescription": "Inaktivera schemat och styr board manuellt.",
-    "changeModeDisableSuccess": "Schemaläge inaktiverat"
+    "changeModeDisableSuccess": "Schemaläge inaktiverat",
+    "collectionSizeWarning": "{count} av {total} sidor i den här samlingen passar inte den här tavlans storlek och hoppas över."
   },
   "forceSetDialog": {
     "title": "Tvinga inställning av board",
@@ -1260,7 +1263,9 @@
     "collectionsTab": "Karuseller ({count})",
     "noPagesTitle": "Inga sidor har skapats än.",
     "noPagesDescription": "Skapa din första sida för att visa på board.",
-    "createFirstPage": "Skapa din första sida"
+    "createFirstPage": "Skapa din första sida",
+    "noCompatiblePagesTitle": "Inga sidor matchar den här tavlans storlek.",
+    "noCompatiblePagesDescription": "Skapa en sida i den här tavlans storlek för att se den här."
   },
   "profile": {
     "title": "Profil",

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -327,7 +327,9 @@
       "dateOverrideHint": "Overrides any weekly schedule active during this window.",
       "validationAnnualDateRequired": "Please pick a month and day",
       "validationOneOffDateRequired": "Please pick a date",
-      "validationEndDateBeforeStart": "End date must be on or after start date"
+      "validationEndDateBeforeStart": "End date must be on or after start date",
+      "collectionSizeWarning": "Bu koleksiyondaki {total} sayfadan {count} tanesi bu panonun boyutuna uymuyor ve atlanacak.",
+      "incompatiblePageWarning": "Bu sayfa bu panonun boyutuyla eşleşmiyor ve doğru görüntülenmeyebilir."
     },
     "descriptionWithTimezone": "Sayfa rotasyonunu saat ve güne göre otomatikleştir · {timezone}",
     "gapDefaultPlaceholder": "Boşluk varsayılanı…",
@@ -628,7 +630,8 @@
     "changeModeOverrideDescription": "Belirli bir süre için bir sayfa gösterip zamanlamanıza devam edin.",
     "changeModeDisableTitle": "Zamanlama modunu kapat",
     "changeModeDisableDescription": "Zamanlamayı devre dışı bırakıp board'u manuel olarak kontrol edin.",
-    "changeModeDisableSuccess": "Zamanlama modu devre dışı bırakıldı"
+    "changeModeDisableSuccess": "Zamanlama modu devre dışı bırakıldı",
+    "collectionSizeWarning": "Bu koleksiyondaki {total} sayfadan {count} tanesi bu panonun boyutuna uymuyor ve atlanacak."
   },
   "forceSetDialog": {
     "title": "Board'u Zorla Ayarla",
@@ -1260,7 +1263,9 @@
     "collectionsTab": "Döngüler ({count})",
     "noPagesTitle": "Henüz sayfa oluşturulmadı.",
     "noPagesDescription": "Board'da görüntülemek için ilk sayfanızı oluşturun.",
-    "createFirstPage": "İlk sayfanızı oluşturun"
+    "createFirstPage": "İlk sayfanızı oluşturun",
+    "noCompatiblePagesTitle": "Bu panonun boyutuyla eşleşen sayfa yok.",
+    "noCompatiblePagesDescription": "Burada görmek için bu pano boyutunda bir sayfa oluşturun."
   },
   "profile": {
     "title": "Profil",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -327,7 +327,9 @@
       "dateOverrideHint": "Overrides any weekly schedule active during this window.",
       "validationAnnualDateRequired": "Please pick a month and day",
       "validationOneOffDateRequired": "Please pick a date",
-      "validationEndDateBeforeStart": "End date must be on or after start date"
+      "validationEndDateBeforeStart": "End date must be on or after start date",
+      "collectionSizeWarning": "此合集中的 {total} 个页面中有 {count} 个不适合此板的尺寸，将被跳过。",
+      "incompatiblePageWarning": "此页面与此板的尺寸不匹配，可能无法正确显示。"
     },
     "descriptionWithTimezone": "按时间和日期自动轮换页面 · {timezone}",
     "gapDefaultPlaceholder": "空隙默认…",
@@ -628,7 +630,8 @@
     "changeModeOverrideDescription": "显示一个页面一段时间,然后恢复您的计划。",
     "changeModeDisableTitle": "关闭计划模式",
     "changeModeDisableDescription": "禁用计划并手动控制 board。",
-    "changeModeDisableSuccess": "计划模式已禁用"
+    "changeModeDisableSuccess": "计划模式已禁用",
+    "collectionSizeWarning": "此合集中的 {total} 个页面中有 {count} 个不适合此板的尺寸，将被跳过。"
   },
   "forceSetDialog": {
     "title": "强制设置 Board",
@@ -1260,7 +1263,9 @@
     "collectionsTab": "轮播（{count}）",
     "noPagesTitle": "尚未创建页面。",
     "noPagesDescription": "创建您的第一个页面以在 board 上显示。",
-    "createFirstPage": "创建您的第一个页面"
+    "createFirstPage": "创建您的第一个页面",
+    "noCompatiblePagesTitle": "没有与此板尺寸匹配的页面。",
+    "noCompatiblePagesDescription": "创建适合此板尺寸的页面后将显示在这里。"
   },
   "profile": {
     "title": "个人资料",

--- a/web/src/__tests__/board-dimensions-compat.test.ts
+++ b/web/src/__tests__/board-dimensions-compat.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for the page<->board size-compatibility helpers (issue #1249).
+ *
+ * These mirror the Python predicate in src/devices.py exactly — see
+ * tests/test_devices.py (TestSizeKey / TestPagesCompatibleWithBoard) for the
+ * backend truth table this must stay in sync with.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { classifyDimensions, pagesCompatibleWithBoard, sizeKey } from "@/lib/board-dimensions";
+
+describe("sizeKey", () => {
+  it("flagship resolves to flagship:6x22", () => {
+    expect(sizeKey("flagship")).toBe("flagship:6x22");
+  });
+
+  it("note resolves to note:3x15", () => {
+    expect(sizeKey("note")).toBe("note:3x15");
+  });
+
+  it("note_array folds in resolved dimensions", () => {
+    expect(sizeKey("note_array", 2, 2)).toBe("note_array:6x30");
+    expect(sizeKey("note_array", 2, 1)).toBe("note_array:3x30");
+    expect(sizeKey("note_array", 1, 4)).toBe("note_array:12x15");
+    expect(sizeKey("note_array")).toBe("note_array:3x15");
+  });
+
+  it("flagship ignores note counts", () => {
+    expect(sizeKey("flagship", 3, 2)).toBe("flagship:6x22");
+  });
+
+  it("unknown device type falls back to flagship (family and dims)", () => {
+    expect(sizeKey("mystery")).toBe("flagship:6x22");
+  });
+});
+
+describe("pagesCompatibleWithBoard", () => {
+  const board = (device_type: string, notes_wide = 1, notes_tall = 1) => ({
+    device_type,
+    notes_wide,
+    notes_tall,
+  });
+
+  it("flagship page fits flagship board", () => {
+    expect(pagesCompatibleWithBoard(board("flagship"), board("flagship"))).toBe(true);
+  });
+
+  it("flagship page does not fit note board", () => {
+    expect(pagesCompatibleWithBoard(board("flagship"), board("note"))).toBe(false);
+  });
+
+  it("note page fits note board", () => {
+    expect(pagesCompatibleWithBoard(board("note"), board("note"))).toBe(true);
+  });
+
+  it("note page does not fit a 1x1 note array (family mismatch at same dims)", () => {
+    expect(pagesCompatibleWithBoard(board("note"), board("note_array", 1, 1))).toBe(false);
+  });
+
+  it("note arrays must match the W×H grid exactly", () => {
+    expect(pagesCompatibleWithBoard(board("note_array", 2, 2), board("note_array", 2, 2))).toBe(true);
+    expect(pagesCompatibleWithBoard(board("note_array", 2, 2), board("note_array", 2, 1))).toBe(false);
+    expect(pagesCompatibleWithBoard(board("note_array", 2, 2), board("note_array", 4, 1))).toBe(false);
+  });
+
+  it("missing geometry defaults to a flagship", () => {
+    expect(pagesCompatibleWithBoard({}, board("flagship"))).toBe(true);
+    expect(pagesCompatibleWithBoard({ device_type: "note" }, {})).toBe(false);
+  });
+});
+
+describe("classifyDimensions", () => {
+  it("classifies the flagship size", () => {
+    expect(classifyDimensions(6, 22)).toEqual({ device_type: "flagship", rows: 6, cols: 22 });
+  });
+
+  it("classifies the note size (never a 1x1 array)", () => {
+    expect(classifyDimensions(3, 15)).toEqual({ device_type: "note", rows: 3, cols: 15 });
+  });
+
+  it("classifies note-array grids with preset matching", () => {
+    expect(classifyDimensions(6, 30)).toEqual({
+      device_type: "note_array",
+      rows: 6,
+      cols: 30,
+      notes_wide: 2,
+      notes_tall: 2,
+      matched_preset: "2×2 grid",
+    });
+    expect(classifyDimensions(9, 45)).toMatchObject({
+      device_type: "note_array",
+      notes_wide: 3,
+      notes_tall: 3,
+      matched_preset: null,
+    });
+  });
+
+  it("throws for unclassifiable grids", () => {
+    expect(() => classifyDimensions(5, 20)).toThrow(/unclassifiable/);
+    expect(() => classifyDimensions(0, 15)).toThrow(/unclassifiable/);
+    // 9 notes on an axis exceeds MAX_NOTES_PER_AXIS
+    expect(() => classifyDimensions(3, 135)).toThrow(/unclassifiable/);
+  });
+});

--- a/web/src/__tests__/schedule-entry-form-size-filter.test.tsx
+++ b/web/src/__tests__/schedule-entry-form-size-filter.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * Tests for page<->board size filtering in ScheduleEntryForm (issue #1249).
+ *
+ * The form should only offer pages whose size matches the current board
+ * (from useCurrentBoard), keep the already-selected page visible when
+ * editing, and surface a non-fatal warning when a selected collection only
+ * partially fits the board. With no current board (single-board installs
+ * before boards load, and all existing tests) the behavior is unchanged.
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ScheduleEntryForm } from "@/components/schedule-entry-form";
+import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import type { Collection } from "@/lib/api";
+
+const mockUseCurrentBoard = vi.fn();
+
+vi.mock("@/components/current-board-context", () => ({
+  useCurrentBoard: () => mockUseCurrentBoard(),
+}));
+
+const FLAGSHIP_BOARD = {
+  id: "board-1",
+  name: "Big Board",
+  device_type: "flagship",
+  notes_wide: 1,
+  notes_tall: 1,
+};
+
+const PAGES = [
+  { id: "page-flag", name: "Flagship Page", device_type: "flagship" },
+  { id: "page-note", name: "Note Page", device_type: "note" },
+];
+
+const MIXED_COLLECTION = {
+  id: "collection:mixed",
+  name: "Mixed Sizes",
+  page_ids: ["page-flag", "page-note"],
+  selection_mode: "time",
+} as unknown as Collection;
+
+function renderInSheet(props: Parameters<typeof ScheduleEntryForm>[0]) {
+  return render(
+    <Sheet open={true}>
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle>Add Schedule</SheetTitle>
+          <SheetDescription>Configure schedule entry</SheetDescription>
+        </SheetHeader>
+        <ScheduleEntryForm {...props} />
+      </SheetContent>
+    </Sheet>,
+  );
+}
+
+beforeEach(() => {
+  mockUseCurrentBoard.mockReturnValue({
+    currentBoardId: FLAGSHIP_BOARD.id,
+    currentBoard: FLAGSHIP_BOARD,
+    boards: [FLAGSHIP_BOARD],
+    setCurrentBoardId: vi.fn(),
+  });
+});
+
+describe("ScheduleEntryForm size filtering", () => {
+  it("only offers pages compatible with the current board", async () => {
+    const user = userEvent.setup();
+    renderInSheet({ pages: PAGES, onSubmit: vi.fn(), onCancel: vi.fn() });
+
+    await user.click(screen.getByLabelText("Page or Collection"));
+    await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument());
+
+    expect(screen.getByRole("option", { name: /Flagship Page/ })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: /Note Page/ })).not.toBeInTheDocument();
+  });
+
+  it("shows all pages when no current board is resolved (unchanged behavior)", async () => {
+    mockUseCurrentBoard.mockReturnValue({
+      currentBoardId: "",
+      currentBoard: undefined,
+      boards: [],
+      setCurrentBoardId: vi.fn(),
+    });
+    const user = userEvent.setup();
+    renderInSheet({ pages: PAGES, onSubmit: vi.fn(), onCancel: vi.fn() });
+
+    await user.click(screen.getByLabelText("Page or Collection"));
+    await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument());
+
+    expect(screen.getByRole("option", { name: /Flagship Page/ })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: /Note Page/ })).toBeInTheDocument();
+  });
+
+  it("keeps the selected page visible when editing an incompatible entry", async () => {
+    const user = userEvent.setup();
+    renderInSheet({
+      pages: PAGES,
+      onSubmit: vi.fn(),
+      onCancel: vi.fn(),
+      prefillPageId: "page-note",
+    });
+
+    // The incompatible-but-selected page stays selectable and a warning shows.
+    expect(screen.getByLabelText("Page or Collection")).toHaveTextContent("Note Page");
+    expect(screen.getByText(/doesn't match this board's size/)).toBeInTheDocument();
+
+    await user.click(screen.getByLabelText("Page or Collection"));
+    await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument());
+    expect(screen.getByRole("option", { name: /Note Page/ })).toBeInTheDocument();
+  });
+
+  it("warns when a selected collection only partially fits the board", () => {
+    renderInSheet({
+      pages: PAGES,
+      collections: [MIXED_COLLECTION],
+      onSubmit: vi.fn(),
+      onCancel: vi.fn(),
+      prefillPageId: MIXED_COLLECTION.id,
+    });
+
+    expect(screen.getByText(/1 of 2 pages in this collection don't fit/)).toBeInTheDocument();
+  });
+
+  it("does not warn for a fully compatible selection", () => {
+    renderInSheet({
+      pages: PAGES,
+      onSubmit: vi.fn(),
+      onCancel: vi.fn(),
+      prefillPageId: "page-flag",
+    });
+
+    expect(screen.queryByText(/doesn't match this board's size/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/will be skipped/)).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/active-page-display.tsx
+++ b/web/src/components/active-page-display.tsx
@@ -18,6 +18,7 @@ import {
 import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState, useTransition } from "react";
 import { toast } from "sonner";
 
+import { useCurrentBoard } from "@/components/current-board-context";
 import { ForceSetDialog } from "@/components/force-set-dialog";
 import { PageGridSelector } from "@/components/page-grid-selector";
 import { ScaledBoardDisplay } from "@/components/scaled-board-display";
@@ -47,6 +48,7 @@ import {
 import { useTranslations } from "@/i18n/translations";
 import type { BoardCurrentMessageResponse, Collection, SilenceStatus } from "@/lib/api";
 import { api, isCollectionId } from "@/lib/api";
+import { pagesCompatibleWithBoard } from "@/lib/board-dimensions";
 import { onLiveOutputMessageChange, readLiveOutputMessage, writeLiveOutputMessage } from "@/lib/live-output-channel";
 
 export function ActivePageDisplay() {
@@ -235,6 +237,11 @@ export function ActivePageDisplay() {
   // Set active page mutation
   const setActivePageMutation = useSetActivePage();
 
+  // Board currently managed in the sidebar selector — used to filter the page
+  // picker to size-compatible pages and to warn about partially-fitting
+  // collections (issue #1249).
+  const { currentBoard } = useCurrentBoard();
+
   // Get the active page ID based on mode
   const activePageId = scheduleEnabled ? activeScheduleData?.page_id || null : activePageData?.page_id || null;
 
@@ -299,6 +306,19 @@ export function ActivePageDisplay() {
         return;
       }
 
+      // Non-fatal size warning when a collection only partially fits the
+      // current board — mirrors the backend `warnings` from #1245.
+      if (currentBoard && isCollectionId(pageId)) {
+        const collection = collectionsData?.collections?.find((c: Collection) => c.id === pageId);
+        const members = (collection?.page_ids ?? [])
+          .map((pid) => pages.find((p) => p.id === pid))
+          .filter((p): p is (typeof pages)[number] => Boolean(p));
+        const misfits = members.filter((p) => !pagesCompatibleWithBoard(p, currentBoard));
+        if (members.length > 0 && misfits.length > 0) {
+          toast.warning(t("collectionSizeWarning", { count: misfits.length, total: members.length }));
+        }
+      }
+
       // Manual mode (or after the user chose to disable schedule): switch immediately.
       setOpenSheetAsManual(false);
       setActivePageMutation.mutate(pageId, {
@@ -313,7 +333,17 @@ export function ActivePageDisplay() {
         },
       });
     },
-    [activePageId, scheduleEnabled, overrideActive, openSheetAsManual, setActivePageMutation],
+    [
+      activePageId,
+      scheduleEnabled,
+      overrideActive,
+      openSheetAsManual,
+      setActivePageMutation,
+      currentBoard,
+      collectionsData,
+      pages,
+      t,
+    ],
   );
 
   // Get the active page for name resolution
@@ -529,6 +559,7 @@ export function ActivePageDisplay() {
             isPending={isPending || setActivePageMutation.isPending}
             showActiveIndicator={true}
             label=""
+            filterByCurrentBoardSize
           />
         </div>
       )}
@@ -563,6 +594,7 @@ export function ActivePageDisplay() {
                 isPending={isPending || setActivePageMutation.isPending}
                 showActiveIndicator={true}
                 label=""
+                filterByCurrentBoardSize
               />
             ) : (
               <div className="text-center text-sm text-muted-foreground py-8">{t("loadingPages")}</div>

--- a/web/src/components/page-grid-selector.tsx
+++ b/web/src/components/page-grid-selector.tsx
@@ -3,6 +3,8 @@
 import { Clock, FilePlus, GalleryHorizontalEnd, LayoutTemplate } from "lucide-react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import { BoardSizeIndicator } from "@/components/board-size-indicator";
+import { useCurrentBoard } from "@/components/current-board-context";
 import Link from "@/components/smart-link";
 import { StaticBoardDisplay } from "@/components/static-board-display";
 import { Badge } from "@/components/ui/badge";
@@ -15,6 +17,7 @@ import { getEffectiveBoardColor, useBoardSettings, useCollections, usePages } fr
 import { useTranslations } from "@/i18n/translations";
 import type { Collection, DeviceType, Page, PagePreviewResponse } from "@/lib/api";
 import { api, isCollectionId } from "@/lib/api";
+import { pagesCompatibleWithBoard } from "@/lib/board-dimensions";
 
 // Cache key for batch previews in localStorage
 const BATCH_CACHE_KEY = "fiestaboard_previews_batch";
@@ -215,6 +218,12 @@ const PageButton = memo(
         <div className="flex items-center gap-2.5 min-w-0">
           <TypeIcon className={iconClassName} aria-hidden="true" />
           <span className={nameClassName}>{page.name}</span>
+          <BoardSizeIndicator
+            deviceType={page.device_type || "flagship"}
+            notesWide={page.notes_wide}
+            notesTall={page.notes_tall}
+            className="ml-auto shrink-0"
+          />
         </div>
 
         <div className="hover-stable">
@@ -304,6 +313,12 @@ const PageListItem = memo(
       >
         <LayoutTemplate className={iconClassName} aria-hidden="true" />
         <span className={nameClassName}>{page.name}</span>
+        <BoardSizeIndicator
+          deviceType={page.device_type || "flagship"}
+          notesWide={page.notes_wide}
+          notesTall={page.notes_tall}
+          className="ml-auto shrink-0"
+        />
         {formattedDate && (
           <span className="ml-auto flex items-center gap-1 text-xs text-muted-foreground shrink-0">
             <Clock className="h-3 w-3" aria-hidden="true" />
@@ -472,6 +487,12 @@ export interface PageGridSelectorProps {
   viewMode?: ViewMode;
   /** Whether to include collections in the grid */
   showCollections?: boolean;
+  /**
+   * Show only pages whose size matches the current board (issue #1249).
+   * Used by pickers that ASSIGN a page to a board (e.g. Change Page); the
+   * global Pages library keeps showing everything.
+   */
+  filterByCurrentBoardSize?: boolean;
 }
 
 export function PageGridSelector({
@@ -483,6 +504,7 @@ export function PageGridSelector({
   deviceTypeFilter,
   viewMode = "grid",
   showCollections = true,
+  filterByCurrentBoardSize = false,
 }: PageGridSelectorProps) {
   const t = useTranslations("pageGridSelector");
   const effectiveLabel = label === undefined ? t("selectPageLabel") : label;
@@ -496,12 +518,22 @@ export function PageGridSelector({
   // Fetch board settings for display type
   const { data: boardSettings } = useBoardSettings();
 
+  // Current board for size-compatibility filtering (issue #1249). Single-board
+  // installs see no change: their pages match the only board by construction.
+  const { currentBoard } = useCurrentBoard();
+
   // Memoize pages array to prevent unnecessary re-renders, with optional device type filter
   const allPages = useMemo(() => pagesData?.pages || [], [pagesData]);
   const pages = useMemo(() => {
-    if (!deviceTypeFilter) return allPages;
-    return allPages.filter((p) => (p.device_type || "flagship") === deviceTypeFilter);
-  }, [allPages, deviceTypeFilter]);
+    let result = allPages;
+    if (deviceTypeFilter) {
+      result = result.filter((p) => (p.device_type || "flagship") === deviceTypeFilter);
+    }
+    if (filterByCurrentBoardSize && currentBoard) {
+      result = result.filter((p) => pagesCompatibleWithBoard(p, currentBoard));
+    }
+    return result;
+  }, [allPages, deviceTypeFilter, filterByCurrentBoardSize, currentBoard]);
 
   // State for batch preview data
   const [previews, setPreviews] = useState<Record<string, PagePreviewResponse>>({});
@@ -608,6 +640,27 @@ export function PageGridSelector({
           </div>
         )}
       </div>
+    );
+  }
+
+  // All pages exist but none match the current board's size: explain the
+  // filter instead of claiming no pages were created (issue #1249).
+  if (pages.length === 0 && allPages.length > 0 && filterByCurrentBoardSize && currentBoard) {
+    return (
+      <Card>
+        <CardContent className="py-6">
+          <EmptyState
+            icon={FilePlus}
+            title={t("noCompatiblePagesTitle")}
+            description={t("noCompatiblePagesDescription")}
+            action={
+              <Button asChild variant="brand" size="sm" className="btn-lift">
+                <Link href="/pages/new">{t("createFirstPage")}</Link>
+              </Button>
+            }
+          />
+        </CardContent>
+      </Card>
     );
   }
 

--- a/web/src/components/page-picker-dialog.tsx
+++ b/web/src/components/page-picker-dialog.tsx
@@ -2,17 +2,24 @@
 
 import { Check, FileText, GalleryHorizontalEnd, LayoutTemplate } from "lucide-react";
 
+import { BoardSizeIndicator } from "@/components/board-size-indicator";
+import { useCurrentBoard } from "@/components/current-board-context";
 import { Badge } from "@/components/ui/badge";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useTranslations } from "@/i18n/translations";
 import type { Collection } from "@/lib/api";
 import { isCollectionId } from "@/lib/api";
+import { pagesCompatibleWithBoard } from "@/lib/board-dimensions";
 
 interface Page {
   id: string;
   name: string;
   type?: string;
+  /** Board geometry for size badges/filtering; pages without it act as flagship. */
+  device_type?: string;
+  notes_wide?: number;
+  notes_tall?: number;
 }
 
 interface PagePickerDialogProps {
@@ -21,6 +28,8 @@ interface PagePickerDialogProps {
   selectedPageId: string | null;
   onSelect: (pageId: string | null) => void;
   allowNone?: boolean;
+  /** Show only pages whose size matches the current board (issue #1249). */
+  filterByCurrentBoardSize?: boolean;
 }
 
 /**
@@ -33,8 +42,16 @@ export function PagePickerDialog({
   selectedPageId,
   onSelect,
   allowNone = false,
+  filterByCurrentBoardSize = false,
 }: PagePickerDialogProps) {
   const t = useTranslations("pagePickerDialog");
+  const { currentBoard } = useCurrentBoard();
+  // Size filter (issue #1249): keep the current selection visible even when it
+  // no longer fits, so an existing choice never silently disappears.
+  const visiblePages =
+    filterByCurrentBoardSize && currentBoard
+      ? pages.filter((p) => p.id === selectedPageId || pagesCompatibleWithBoard(p, currentBoard))
+      : pages;
   const hasCollections = collections.length > 0;
   const defaultTab = selectedPageId && isCollectionId(selectedPageId) ? "collections" : "pages";
 
@@ -53,7 +70,7 @@ export function PagePickerDialog({
 
   const pagesList = (
     <div className="space-y-2" role="listbox" aria-label={t("pagesAriaLabel")}>
-      {pages.map((page) => (
+      {visiblePages.map((page) => (
         <button
           key={page.id}
           role="option"
@@ -69,6 +86,13 @@ export function PagePickerDialog({
               <Badge variant="secondary" className="text-[10px]">
                 {page.type}
               </Badge>
+            )}
+            {page.device_type && (
+              <BoardSizeIndicator
+                deviceType={page.device_type}
+                notesWide={page.notes_wide}
+                notesTall={page.notes_tall}
+              />
             )}
           </div>
           {selectedPageId === page.id && <Check className="h-4 w-4 text-brand" aria-hidden="true" />}
@@ -106,7 +130,7 @@ export function PagePickerDialog({
     return (
       <div className="space-y-2">
         {noneOption}
-        {pages.length === 0 ? (
+        {visiblePages.length === 0 ? (
           <EmptyState icon={FileText} title={t("noPagesTitle")} description={t("noPagesDescription")} />
         ) : (
           pagesList
@@ -122,7 +146,7 @@ export function PagePickerDialog({
         <TabsList className="w-full">
           <TabsTrigger value="pages" className="flex-1 gap-1.5">
             <LayoutTemplate className="h-4 w-4" aria-hidden="true" />
-            {t("pagesTab", { count: pages.length })}
+            {t("pagesTab", { count: visiblePages.length })}
           </TabsTrigger>
           <TabsTrigger value="collections" className="flex-1 gap-1.5">
             <GalleryHorizontalEnd className="h-4 w-4" aria-hidden="true" />
@@ -130,7 +154,7 @@ export function PagePickerDialog({
           </TabsTrigger>
         </TabsList>
         <TabsContent value="pages">
-          {pages.length === 0 ? (
+          {visiblePages.length === 0 ? (
             <EmptyState icon={FileText} title={t("noPagesTitle")} description={t("noPagesDescription")} />
           ) : (
             pagesList

--- a/web/src/components/schedule-entry-form.tsx
+++ b/web/src/components/schedule-entry-form.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { AlertCircle, GalleryHorizontalEnd, Loader2, Sunrise, Sunset, Trash2 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { AlertCircle, AlertTriangle, GalleryHorizontalEnd, Loader2, Sunrise, Sunset, Trash2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 
+import { BoardSizeIndicator } from "@/components/board-size-indicator";
+import { useCurrentBoard } from "@/components/current-board-context";
 import { DaySelector } from "@/components/day-selector";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -20,10 +22,21 @@ import type {
   ScheduleUpdate,
   TimeType,
 } from "@/lib/api";
+import { isCollectionId } from "@/lib/api";
+import { pagesCompatibleWithBoard } from "@/lib/board-dimensions";
+
+interface SchedulePageOption {
+  id: string;
+  name: string;
+  /** Board geometry for size filtering; pages without it act as flagship. */
+  device_type?: string;
+  notes_wide?: number;
+  notes_tall?: number;
+}
 
 interface ScheduleEntryFormProps {
   schedule?: ScheduleEntry;
-  pages: Array<{ id: string; name: string }>;
+  pages: SchedulePageOption[];
   collections?: Collection[];
   onSubmit: (data: ScheduleCreate | ScheduleUpdate) => Promise<void>;
   onCancel: () => void;
@@ -100,6 +113,10 @@ export function ScheduleEntryForm({
   const tc = useTranslations("common");
   const isEdit = Boolean(schedule);
 
+  // Board the schedule targets: the app-wide current board (issue #1249).
+  // Single-board installs see no change — every page for that board matches.
+  const { currentBoard } = useCurrentBoard();
+
   // Use schedule values if editing, prefill values if creating from calendar, or defaults
   const [pageId, setPageId] = useState(schedule?.page_id || prefillPageId || "");
   const [startTime, setStartTime] = useState(schedule?.start_time || prefillStartTime || "09:00");
@@ -130,6 +147,38 @@ export function ScheduleEntryForm({
 
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // Only pages whose size matches the current board are offered (issue #1249).
+  // The currently selected page is always kept so editing an existing entry
+  // never renders an empty Select.
+  const visiblePages = useMemo(() => {
+    if (!currentBoard) return pages;
+    return pages.filter((p) => p.id === pageId || pagesCompatibleWithBoard(p, currentBoard));
+  }, [pages, currentBoard, pageId]);
+
+  // Non-fatal size warning for the current selection: a collection with some
+  // members that don't fit the board, or a plain page that doesn't fit
+  // (possible when editing a pre-existing entry). Mirrors the backend
+  // `warnings` from #1245.
+  const sizeWarning = useMemo(() => {
+    if (!currentBoard || !pageId) return null;
+    if (isCollectionId(pageId)) {
+      const collection = collections.find((c) => c.id === pageId);
+      if (!collection) return null;
+      const members = collection.page_ids
+        .map((pid) => pages.find((p) => p.id === pid))
+        .filter((p): p is SchedulePageOption => Boolean(p));
+      if (members.length === 0) return null;
+      const misfits = members.filter((p) => !pagesCompatibleWithBoard(p, currentBoard));
+      if (misfits.length === 0) return null;
+      return t("scheduleEntryForm.collectionSizeWarning", { count: misfits.length, total: members.length });
+    }
+    const page = pages.find((p) => p.id === pageId);
+    if (page && !pagesCompatibleWithBoard(page, currentBoard)) {
+      return t("scheduleEntryForm.incompatiblePageWarning");
+    }
+    return null;
+  }, [currentBoard, pageId, collections, pages, t]);
 
   // Validation
   const [validationErrors, setValidationErrors] = useState<string[]>([]);
@@ -320,13 +369,28 @@ export function ScheduleEntryForm({
                 </div>
               </>
             )}
-            {pages.map((page) => (
+            {visiblePages.map((page) => (
               <SelectItem key={page.id} value={page.id}>
-                {page.name}
+                <span className="flex items-center gap-2">
+                  {page.name}
+                  {page.device_type && (
+                    <BoardSizeIndicator
+                      deviceType={page.device_type}
+                      notesWide={page.notes_wide}
+                      notesTall={page.notes_tall}
+                    />
+                  )}
+                </span>
               </SelectItem>
             ))}
           </SelectContent>
         </Select>
+        {sizeWarning && (
+          <Alert variant="default" className="border-warning/50 bg-warning/10">
+            <AlertTriangle className="h-4 w-4 text-warning" />
+            <AlertDescription className="text-sm">{sizeWarning}</AlertDescription>
+          </Alert>
+        )}
       </div>
 
       {/* Time Selection */}

--- a/web/src/lib/board-dimensions.ts
+++ b/web/src/lib/board-dimensions.ts
@@ -77,3 +77,97 @@ export function resolveDimensions(deviceType: string, notes_wide = 1, notes_tall
   // Unknown: fall back to flagship (matches Python fallback in board_html_renderer.py)
   return DEVICE_DIMENSIONS.flagship;
 }
+
+/**
+ * Return true if (rows, cols) is a valid note-array size.
+ * Mirrors Python is_valid_note_array_grid().
+ */
+export function isValidNoteArrayGrid(rows: number, cols: number): boolean {
+  if (rows <= 0 || cols <= 0) return false;
+  if (rows % NOTE_ROWS !== 0 || cols % NOTE_COLS !== 0) return false;
+  return rows / NOTE_ROWS <= MAX_NOTES_PER_AXIS && cols / NOTE_COLS <= MAX_NOTES_PER_AXIS;
+}
+
+export interface ClassifiedDimensions {
+  device_type: "flagship" | "note" | "note_array";
+  rows: number;
+  cols: number;
+  notes_wide?: number;
+  notes_tall?: number;
+  matched_preset?: string | null;
+}
+
+/**
+ * Classify a grid (rows × cols) into a device type and optional note-array
+ * geometry. Mirrors Python classify_dimensions(): an exact 6×22 is a flagship
+ * and an exact 3×15 is a Note — both are checked BEFORE the note-array branch,
+ * so a single Note never classifies as a 1×1 array.
+ *
+ * Throws for a grid that is neither the flagship size, the Note size, nor a
+ * valid note-array grid.
+ */
+export function classifyDimensions(rows: number, cols: number): ClassifiedDimensions {
+  const flagship = DEVICE_DIMENSIONS.flagship;
+  if (rows === flagship.rows && cols === flagship.cols) {
+    return { device_type: "flagship", rows, cols };
+  }
+  const note = DEVICE_DIMENSIONS.note;
+  if (rows === note.rows && cols === note.cols) {
+    return { device_type: "note", rows, cols };
+  }
+  if (isValidNoteArrayGrid(rows, cols)) {
+    const notes_wide = cols / NOTE_COLS;
+    const notes_tall = rows / NOTE_ROWS;
+    const preset = NOTE_ARRAY_PRESETS.find((p) => p.notes_wide === notes_wide && p.notes_tall === notes_tall);
+    return {
+      device_type: "note_array",
+      rows,
+      cols,
+      notes_wide,
+      notes_tall,
+      matched_preset: preset ? preset.label : null,
+    };
+  }
+  throw new Error(
+    `Grid ${rows}x${cols} is unclassifiable: not a flagship (${flagship.rows}x${flagship.cols}), ` +
+      `not a Note (${note.rows}x${note.cols}), and not a valid note-array grid ` +
+      `(rows must be a multiple of ${NOTE_ROWS}, cols a multiple of ${NOTE_COLS}, ` +
+      `each axis <= ${MAX_NOTES_PER_AXIS} notes).`,
+  );
+}
+
+// ── Page <-> board size compatibility (issue #1249, mirrors src/devices.py) ──
+
+/** Anything carrying board geometry: a Page, a BoardInstance, or a raw dict. */
+export interface SizedEntity {
+  device_type?: string | null;
+  notes_wide?: number | null;
+  notes_tall?: number | null;
+}
+
+/**
+ * Canonical family + resolved-size key for page<->board compatibility.
+ * Mirrors Python size_key(): e.g. "flagship:6x22", "note:3x15",
+ * "note_array:6x30" (a 2×2 note grid). The device family is part of the key
+ * on purpose — a Note page is NOT compatible with a 1×1 note array even
+ * though both resolve to 3×15. Unknown device types fall back to flagship
+ * (family AND dimensions), matching the Python fallback.
+ */
+export function sizeKey(deviceType: string, notesWide = 1, notesTall = 1): string {
+  const family = deviceType in DEVICE_DIMENSIONS || isNoteArray(deviceType) ? deviceType : "flagship";
+  const { rows, cols } = resolveDimensions(family, notesWide, notesTall);
+  return `${family}:${rows}x${cols}`;
+}
+
+/**
+ * True when a page renders 1:1 on a board: EXACT sizeKey() match.
+ * Mirrors Python pages_compatible_with_board(). Family-aware: flagship ≠ note
+ * even at identical dimensions, and note arrays must match the resolved W×H
+ * grid exactly.
+ */
+export function pagesCompatibleWithBoard(page: SizedEntity, board: SizedEntity): boolean {
+  return (
+    sizeKey(page.device_type || "flagship", page.notes_wide || 1, page.notes_tall || 1) ===
+    sizeKey(board.device_type || "flagship", board.notes_wide || 1, board.notes_tall || 1)
+  );
+}


### PR DESCRIPTION
Closes #1249

Pairs with the backend enforcement PR for #1245 (#1426) — this is the independent client-side half: pickers that assign a page to a board only offer size-compatible pages, and pages carry a size badge everywhere they're listed.

## What

### TS helpers (`web/src/lib/board-dimensions.ts`)

Ports the Python predicate from `src/devices.py` 1:1:

- `sizeKey(deviceType, notesWide = 1, notesTall = 1)` — family + resolved-dimension key (`"flagship:6x22"`, `"note:3x15"`, `"note_array:6x30"`). Family is part of the key on purpose: a Note page ≠ a 1×1 note array even though both resolve to 3×15. Unknown device types fall back to flagship (family and dims), matching Python.
- `pagesCompatibleWithBoard(page, board)` — EXACT `sizeKey` match; accepts any object carrying `device_type`/`notes_wide`/`notes_tall`.
- `classifyDimensions(rows, cols)` (+ `isValidNoteArrayGrid`) — previously missing on the TS side; same ordering rules as Python (exact flagship/note checked before the array branch), throws for unclassifiable grids.

### Picker filtering (client-side, no new endpoint)

- **Schedule entry form** (`schedule-entry-form.tsx`): the Page/Collection select only lists pages compatible with `useCurrentBoard()`'s board. The currently selected page is always kept so editing an existing entry never renders an empty select. The schedule route now passes full page objects (geometry included).
- **Change Page picker** (`PageGridSelector`, used by `ActivePageDisplay`): new opt-in `filterByCurrentBoardSize` prop; enabled for the Change Page sheet. When every page is filtered out, a dedicated "no pages match this board's size" empty state replaces the misleading "no pages created yet" one. The global Pages library keeps showing everything.
- **`PagePickerDialog`**: same optional filter prop for future board-scoped callers.

### Collection warnings (non-fatal)

- Schedule form: selecting a collection whose members only partially fit shows an inline warning ("{count} of {total} pages … will be skipped"); an existing entry whose plain page no longer fits warns too.
- Change Page: selecting a partially fitting collection raises a warning toast. Mirrors the backend `warnings` array from #1245.

### Size badges

Every page row/card in the Pages list and the pickers now shows its size via the existing `BoardSizeIndicator` (e.g. `6 × 22`, or `6 × 30 · 2×2 grid` for note arrays), including inside the schedule form's select options.

### i18n

5 new strings (`pageGridSelector.noCompatiblePagesTitle`/`noCompatiblePagesDescription`, `schedule.scheduleEntryForm.collectionSizeWarning`/`incompatiblePageWarning`, `activeDisplay.collectionSizeWarning`) added to `en.json` and machine-translated into all 13 other locales (de, es, fr, it, ja, ko, nl, pl, pt, ru, sv, tr, zh).

### Back-compat

Single-board installs see no change: every page for that board matches it, and with no resolved current board (default context) all filtering is bypassed — existing component tests pass unchanged.

## Tests

- `src/__tests__/board-dimensions-compat.test.ts` — `sizeKey` / `pagesCompatibleWithBoard` / `classifyDimensions` truth table kept in sync with the backend's `tests/test_devices.py`.
- `src/__tests__/schedule-entry-form-size-filter.test.tsx` — filtering, unchanged behavior without a current board, selected-page retention on edit, collection partial-fit warning, no-warning happy path.

In Docker: vitest **106 files / 1306 passed (13 skipped)**; `eslint` 0 errors; `prettier --check` clean. (`npm run typecheck` has pre-existing failures on main unrelated to this diff; CI does not gate on it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)