### PR TITLE
fix(ci): pin ruff to 0.16.0 and format README code fences

### DIFF
--- a/plugins/_template/README.md
+++ b/plugins/_template/README.md
@@ -177,6 +177,7 @@ The `screenshots` array makes plugin images discoverable by the docs site, API, 
 ```python
 from src.plugins.base import PluginBase, PluginResult
 
+
 class MyPlugin(PluginBase):
     @property
     def plugin_id(self) -> str:
@@ -226,12 +227,14 @@ python scripts/run_plugin_tests.py
 
 ```python
 """Tests for the my_plugin plugin."""
+
 import json, pytest
 from pathlib import Path
 from plugins.my_plugin import MyPlugin
 from src.plugins.base import PluginResult
 
 MANIFEST_PATH = Path(__file__).parent.parent / "manifest.json"
+
 
 # PluginBase stores the manifest as a plain dict and calls `.get()` on it,
 # so the fixture must return the parsed dict — exactly what the loader passes
@@ -242,6 +245,7 @@ MANIFEST_PATH = Path(__file__).parent.parent / "manifest.json"
 def manifest():
     with open(MANIFEST_PATH) as f:
         return json.load(f)
+
 
 class TestMyPlugin:
     def test_plugin_id(self, manifest):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,5 +9,5 @@ pytest-xdist>=3.6.0
 coverage>=7.6.0
 
 # Linting
-ruff>=0.9.0
+ruff==0.16.0  # pinned: unpinned ruff made `ruff format --check` in CI nondeterministic across releases
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -18,6 +18,7 @@ This directory contains shared test infrastructure to reduce boilerplate and imp
 ```python
 from tests import sample_page, mock_board_client
 
+
 def test_something(sample_page, mock_board_client):
     # Use fixtures directly
     pass


### PR DESCRIPTION
Every Python-touching PR currently fails Platform Tests on `ruff format --check`: CI installs unpinned `ruff>=0.9.0`, and the just-released **ruff 0.16.0** format-checks Markdown code fences, flagging `plugins/_template/README.md` and `tests/README.md` — files no open PR touches (see e.g. the failures on #1424/#1425/#1426/#1431).

- Pin `ruff==0.16.0` in `requirements-dev.txt` so format checks are deterministic; bumps become deliberate.
- Apply 0.16.0's formatting to the two drifting READMEs (blank-line normalization inside code fences only).

Verified in a clean container: `ruff format --check src/ plugins/ tests/ scripts/` → 238 files already formatted.

**Merge this first** — the four failing PRs go green once their branches/bases pick it up (I'll handle the branch updates and re-runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)