### PR TITLE
test(e2e): multi-board regression through the real UI + per-board docs

### DIFF
--- a/docs-site/docs/reference/api-endpoints.md
+++ b/docs-site/docs/reference/api-endpoints.md
@@ -107,11 +107,24 @@ When creating or updating a page, the following fields are available:
 
 ### Board Management
 
+Installs with more than one board follow a **per-board** model: each board
+has its own active page, schedule, and send routing, addressed by a
+`board_id` query param (or body field) on the relevant endpoints below.
+Omitting `board_id` always falls back to the primary board (`boards[0]`),
+which keeps single-board installs behaving exactly as before. **Pages** and
+**Collections** are not per-board — they're one shared library, and their
+pickers filter to the boards they're compatible with (see
+[Board Instance Fields](#board-instance-fields) for the size model).
+
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | `PUT` | `/settings/board` | Update board configuration (devices, connection) |
 | `POST` | `/settings/board/add` | Add a new board instance |
 | `DELETE` | `/settings/board/{id}` | Remove a board instance |
+| `GET` | `/settings/active-page` | Get a board's active page id (`?board_id=`) |
+| `PUT` | `/settings/active-page` | Set a board's active page (renders and sends immediately) |
+| `POST` | `/pages/{id}/send` | Send a page (`?target=board&board_id=`) |
+| `GET` | `/board/current-message` | Read a board's current display (`?board_id=`) |
 
 #### `PUT /settings/board` — request body fields
 
@@ -121,19 +134,30 @@ When creating or updating a page, the following fields are available:
 | `devices` | string[] | Device type list e.g. `["flagship", "note"]` (backward-compatible) |
 | `board_type` | string | Legacy field — still accepted |
 
+#### `PUT /settings/active-page` — request body fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `page_id` | string \| null | Page (or collection) id to activate, or `null` to clear |
+| `board_id` | string | Optional. Omitted → primary board (legacy behavior) |
+
 #### Board Instance Fields
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `id` | string | UUID (auto-generated on create) |
 | `name` | string | Display name for this board |
-| `device_type` | string | `"flagship"` (22×6) or `"note"` (15×3) |
+| `device_type` | string | `"flagship"` (22×6), `"note"` (15×3), or `"note_array"` (variable W×H) |
 | `board_color` | string | `"black"` or `"white"` |
 | `api_mode` | string | `"local"` or `"cloud"` |
 | `host` | string | Board IP address (local mode) |
 | `local_api_key` | string | Local API key |
 | `cloud_key` | string | Cloud Read/Write key |
+| `note_array_token` | string | Cloud API token (note-array boards in cloud mode) |
+| `notes_wide` / `notes_tall` | number | Note-array grid dimensions — resolves to `(notes_wide × 15) × (notes_tall × 3)` characters |
 | `enabled` | boolean | Whether this board is active |
+| `schedule_enabled` | boolean | Whether this board follows its schedule (vs. manual mode) |
+| `paused` | boolean | Whether this board's output is paused |
 
 ## Example Requests
 

--- a/docs-site/docs/setup/note-arrays.md
+++ b/docs-site/docs/setup/note-arrays.md
@@ -42,6 +42,23 @@ Cloud mode. Pick your size with the **Board type** dropdown — five presets
 (2 side-by-side, 4 side-by-side, 2 stacked, 4 stacked, 2×2 grid) plus
 **Custom…** for anything up to 8 × 8 Notes.
 
+## Multiple boards
+
+Adding a Note array alongside another board (or a second array) puts your
+install in FiestaBoard's per-board model:
+
+- A **board selector** appears in the sidebar once you have more than one
+  board. It picks which board the **Dashboard** and **Schedule** pages
+  manage — each board keeps its own active page and schedule, independent of
+  the others.
+- **Pages and Collections stay global.** There's one shared library, not one
+  per board; when you're managing a board, its page pickers filter to pages
+  sized for that board (an array's W×H, a Flagship's 22×6, a Note's 15×3) so
+  you only see pages that will render 1:1.
+- Manual sends and scheduled rotations are routed to whichever board is
+  selected — a Flagship board is never affected by an array's schedule, or
+  vice versa.
+
 ## Cloud mode
 
 1. Keep the connection on **Cloud API**.

--- a/docs/reference/NOTE_ARRAYS.md
+++ b/docs/reference/NOTE_ARRAYS.md
@@ -184,6 +184,35 @@ note-array branch, so a single Note never classifies as a 1 × 1 array.
 > `notes_tall` against the preset table to drive the dropdown — it does not rely
 > on the `matched_preset` label string, which is a human-readable hint only.
 
+## Multi-board model (per-board scheduling, driving, and the sidebar selector)
+
+Arrays motivated generalizing FiestaBoard from one implicit "primary board"
+to N independently-driven boards (epic #1241, issues #1242-#1251):
+
+- **Per-board:** display engine (`DisplayService` → `runtimes` in
+  `src/main.py`), active page (`settings_service.get_active_page_id(board_id=)`),
+  schedule + `schedule_enabled`, send routing (`board_id` query param on
+  `/settings/active-page`, `/pages/{id}/send`, `/board/current-message`),
+  MQTT/trigger delivery, pause, board-state polling.
+- **Global:** Pages and Collections — one shared library, never duplicated
+  per board. Their pickers filter by the current board's size
+  (`web/src/lib/board-dimensions.ts` `pagesCompatibleWithBoard`,
+  mirrored in `src/devices.py`).
+- **Current board:** a persisted sidebar selector
+  (`web/src/components/current-board-context.tsx` `CurrentBoardProvider`,
+  `web/src/components/navigation-sidebar.tsx` `BoardSelector`) sets which
+  board the Dashboard and Schedule pages manage — frontend-only state
+  (`localStorage`, default primary board, shown only when
+  `boards.length > 1`), reconciled against the live board list on every
+  render so a stale/removed board id falls back to the primary.
+
+The end-to-end regression for this — a Flagship + a Note Array driven
+through the sidebar selector, Dashboard, Schedule, page-picker filtering, and
+the editor's stale-reference warning — lives in
+`web/tests/regression/multi-board-e2e.spec.ts`. Backend send→read coverage
+for a mixed fleet against both stdlib mocks is in the "mixed fleet" test of
+`web/tests/note-array-output.spec.ts`.
+
 ## Local development — mock Cloud board
 
 Note arrays talk to the Vestaboard **Cloud** API, so there's no local hardware to

--- a/web/tests/regression/multi-board-e2e.spec.ts
+++ b/web/tests/regression/multi-board-e2e.spec.ts
@@ -1,0 +1,296 @@
+/**
+ * Multi-board E2E regression. [#1251, final issue of the per-board epic #1241]
+ *
+ * Exercises the per-board model through the actual UI with a MIXED fleet —
+ * a Flagship board (Local API, mocked by integration-tests/mock-board) and a
+ * Vestaboard Note Array board (Cloud API, mocked by integration-tests/mock-cloud)
+ * — which no earlier spec drives through the sidebar/Dashboard/Schedule/page-picker
+ * UI together:
+ *
+ *  - multi-board-output.spec.ts and note-array-output.spec.ts assert at the
+ *    API/hardware layer (fetch calls straight to /pages/{id}/send etc.), and
+ *    note-array-output.spec.ts's "mixed fleet" test already covers the
+ *    backend send->read assertion per board against both stdlib mocks.
+ *  - board-switch-ux.spec.ts and multi-board-output.spec.ts drive the sidebar
+ *    selector UI, but only ever with two Flagship boards.
+ *
+ * This spec is the missing combination: sidebar board selector -> Dashboard
+ * + Schedule -> page-picker size filtering -> editor retarget warning, all
+ * with one Flagship + one Note Array board.
+ */
+import {
+  API_URL,
+  authHeaders,
+  BOARD_HOST,
+  configureBoard,
+  configureMockCloud,
+  deleteAllPages,
+  deleteAllSchedules,
+  deletePagesByDevice,
+  ensureAuthForFetch,
+  expect,
+  getMockBoardState,
+  getMockCloudState,
+  getToastsRegion,
+  gridToText,
+  loginIfNeeded,
+  resetMockBoard,
+  resetMockCloud,
+  resetToSingleBoard,
+  suppressWizard,
+  test,
+} from "../helpers";
+
+const ARRAY_NOTES_WIDE = 2;
+const ARRAY_NOTES_TALL = 1;
+const ARRAY_ROWS = ARRAY_NOTES_TALL * 3; // 3
+const ARRAY_COLS = ARRAY_NOTES_WIDE * 15; // 30
+
+function uniq(prefix: string): string {
+  return `${prefix}${Date.now() % 1_000_000}`;
+}
+
+/** Create a Flagship (6x22) page and return its id. */
+async function createFlagshipPage(name: string, token: string): Promise<string> {
+  const template = ["", token, "", "", "", ""];
+  const res = await fetch(`${API_URL}/pages`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...authHeaders() },
+    body: JSON.stringify({ name, type: "template", template }),
+  });
+  if (!res.ok) throw new Error(`createFlagshipPage failed: ${res.status} ${await res.text()}`);
+  const data = await res.json();
+  return data.page.id;
+}
+
+/** Create a note_array page sized to ARRAY_NOTES_WIDE x ARRAY_NOTES_TALL and return its id. */
+async function createArrayPage(name: string, token: string): Promise<string> {
+  const template = Array.from({ length: ARRAY_ROWS }, (_, i) => (i === 0 ? token : ""));
+  const res = await fetch(`${API_URL}/pages`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...authHeaders() },
+    body: JSON.stringify({
+      name,
+      type: "template",
+      template,
+      device_type: "note_array",
+      notes_wide: ARRAY_NOTES_WIDE,
+      notes_tall: ARRAY_NOTES_TALL,
+    }),
+  });
+  if (!res.ok) throw new Error(`createArrayPage failed: ${res.status} ${await res.text()}`);
+  const data = await res.json();
+  return data.page.id;
+}
+
+/** Configure a Flagship board ("Kitchen") + a Note Array board ("Office"), both manual mode. */
+async function configureMixedFleet(): Promise<{ kitchenId: string; officeId: string }> {
+  const res = await fetch(`${API_URL}/settings/board`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json", ...authHeaders() },
+    body: JSON.stringify({
+      boards: [
+        {
+          name: "Kitchen",
+          device_type: "flagship",
+          board_color: "black",
+          enabled: true,
+          api_mode: "local",
+          host: BOARD_HOST,
+          port: 7000,
+          local_api_key: "test-key",
+        },
+        {
+          name: "Office",
+          device_type: "note_array",
+          board_color: "white",
+          enabled: true,
+          api_mode: "cloud",
+          notes_wide: ARRAY_NOTES_WIDE,
+          notes_tall: ARRAY_NOTES_TALL,
+          // Unique per run: the backend throttles note-array sends per token.
+          note_array_token: `test-array-token-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        },
+      ],
+    }),
+  });
+  if (!res.ok) throw new Error(`configureMixedFleet failed: ${res.status} ${await res.text()}`);
+  const data = await res.json();
+  const boards = data.settings?.boards ?? [];
+  if (boards.length < 2) throw new Error("configureMixedFleet: expected 2 boards");
+  return { kitchenId: boards[0].id, officeId: boards[1].id };
+}
+
+async function setActivePage(pageId: string, boardId: string): Promise<void> {
+  const res = await fetch(`${API_URL}/settings/active-page`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json", ...authHeaders() },
+    body: JSON.stringify({ page_id: pageId, board_id: boardId }),
+  });
+  if (!res.ok) throw new Error(`setActivePage failed: ${res.status} ${await res.text()}`);
+}
+
+function boardText(state: { current_message?: number[][] }): string {
+  return gridToText(state.current_message).join("\n");
+}
+
+function cloudText(state: { current_grid?: number[][] }): string {
+  return gridToText(state.current_grid).join("\n");
+}
+
+test.describe("regression: multi-board — mixed fleet through the real UI", () => {
+  let kitchenId: string;
+  let officeId: string;
+
+  test.beforeEach(async ({ context, page }) => {
+    await ensureAuthForFetch();
+    await loginIfNeeded(context);
+    await configureBoard();
+    await deleteAllSchedules();
+    await deleteAllPages();
+    await resetMockBoard();
+    await resetMockCloud();
+    await configureMockCloud(ARRAY_NOTES_WIDE, ARRAY_NOTES_TALL);
+    ({ kitchenId, officeId } = await configureMixedFleet());
+    // No need to clear a stale `fiestaboard_current_board`: each test creates
+    // fresh boards with new ids, and CurrentBoardProvider falls back to the
+    // primary board whenever the stored id doesn't match a live board.
+    await suppressWizard(page);
+  });
+
+  test.afterAll(async () => {
+    await deleteAllSchedules();
+    await deletePagesByDevice("note_array");
+    await deleteAllPages();
+    await resetToSingleBoard();
+  });
+
+  test("sidebar board selector switches the Dashboard and Schedule to the selected board's own state", async ({
+    page,
+  }) => {
+    const kitchenPage = await createFlagshipPage("Kitchen Active", uniq("KIT"));
+    const officePage = await createArrayPage("Office Active", uniq("OFF"));
+    await setActivePage(kitchenPage, kitchenId);
+    await setActivePage(officePage, officeId);
+
+    await page.goto("/");
+    await expect(page.getByRole("heading", { level: 1 }).first()).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId("active-display-board-name")).toContainText("Kitchen", { timeout: 10_000 });
+
+    await page.locator("aside").getByLabel("Select board to manage").click();
+    await page.getByRole("option", { name: "Office" }).click();
+    await expect(page.getByTestId("active-display-board-name")).toContainText("Office", { timeout: 10_000 });
+
+    // The current-board selection is shared context: Schedule reflects it too.
+    await page.goto("/schedule");
+    await expect(page.getByRole("heading", { name: "Schedule", exact: true })).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByTestId("active-board-indicator")).toContainText("Office", { timeout: 10_000 });
+
+    await page.locator("aside").getByLabel("Select board to manage").click();
+    await page.getByRole("option", { name: "Kitchen" }).click();
+    await expect(page.getByTestId("active-board-indicator")).toContainText("Kitchen", { timeout: 10_000 });
+  });
+
+  test("Change Page on the selected board sends to that board's own mock, at that board's own size", async ({
+    page,
+  }) => {
+    // Note-array sends are throttled >=15s per board token (src/board_client.py
+    // NOTE_ARRAY_MIN_SEND_INTERVAL); this test sends to Office twice.
+    test.setTimeout(45_000);
+    const kitchenToken = uniq("KIT");
+    const officeToken = uniq("OFF");
+    await createFlagshipPage("Kitchen Send", kitchenToken);
+    await createArrayPage("Office Send", officeToken);
+    // Seed Office with a placeholder active page before switching to it: a
+    // board with no active page yet triggers a (separate, transient)
+    // auto-assign-default attempt that can race with an immediate UI click.
+    const officePlaceholder = await createArrayPage("Office Placeholder", uniq("PLC"));
+    await setActivePage(officePlaceholder, officeId);
+
+    await page.goto("/");
+    await expect(page.getByRole("heading", { level: 1 }).first()).toBeVisible({ timeout: 15_000 });
+
+    // Kitchen (default board) -> Change Page -> pick the Kitchen page.
+    await page.getByRole("button", { name: /Change Page/i }).click();
+    await page.getByText("Kitchen Send", { exact: true }).click();
+
+    await expect.poll(async () => boardText(await getMockBoardState()), { timeout: 10_000 }).toContain(kitchenToken);
+    const boardStateAfterKitchen = await getMockBoardState();
+    expect(boardStateAfterKitchen.current_message?.length).toBe(6);
+
+    // Switch to Office -> Change Page -> pick the Office (array) page.
+    await page.locator("aside").getByLabel("Select board to manage").click();
+    await page.getByRole("option", { name: "Office" }).click();
+    await expect(page.getByTestId("active-display-board-name")).toContainText("Office", { timeout: 10_000 });
+
+    // Clear the throttle window opened by the placeholder's send above.
+    await page.waitForTimeout(16_000);
+
+    await page.getByRole("button", { name: /Change Page/i }).click();
+    await page.getByText("Office Send", { exact: true }).click();
+
+    await expect.poll(async () => cloudText(await getMockCloudState()), { timeout: 10_000 }).toContain(officeToken);
+    const cloudState = await getMockCloudState();
+    expect(cloudState.current_grid?.length).toBe(ARRAY_ROWS);
+    expect(cloudState.current_grid?.[0]?.length).toBe(ARRAY_COLS);
+
+    // The array's content never reached the flagship's hardware.
+    const finalBoardState = await getMockBoardState();
+    expect(boardText(finalBoardState)).not.toContain(officeToken);
+  });
+
+  test("the page picker filters out pages that don't match the selected board's size", async ({ page }) => {
+    const kitchenPage = await createFlagshipPage("Kitchen Only", uniq("KIT"));
+    const officePage = await createArrayPage("Office Only", uniq("OFF"));
+    // Give each board an active page so switching boards doesn't also trigger
+    // the (unrelated) "no active page yet" auto-assign path.
+    await setActivePage(kitchenPage, kitchenId);
+    await setActivePage(officePage, officeId);
+
+    await page.goto("/");
+    await expect(page.getByRole("heading", { level: 1 }).first()).toBeVisible({ timeout: 15_000 });
+
+    // Kitchen (Flagship) selected: only the Flagship-sized page is offered.
+    await page.getByRole("button", { name: /Change Page/i }).click();
+    const kitchenDialog = page.getByRole("dialog");
+    await expect(kitchenDialog.getByText("Kitchen Only", { exact: true })).toBeVisible({ timeout: 10_000 });
+    await expect(kitchenDialog.getByText("Office Only", { exact: true })).toHaveCount(0);
+    await page.keyboard.press("Escape");
+
+    // Switch to Office (Note Array): only the array-sized page is offered.
+    await page.locator("aside").getByLabel("Select board to manage").click();
+    await page.getByRole("option", { name: "Office" }).click();
+    await expect(page.getByTestId("active-display-board-name")).toContainText("Office", { timeout: 10_000 });
+
+    await page.getByRole("button", { name: /Change Page/i }).click();
+    const officeDialog = page.getByRole("dialog");
+    await expect(officeDialog.getByText("Office Only", { exact: true })).toBeVisible({ timeout: 10_000 });
+    await expect(officeDialog.getByText("Kitchen Only", { exact: true })).toHaveCount(0);
+  });
+
+  test("retargeting a board's active page to an incompatible size surfaces the stale-reference warning", async ({
+    page,
+  }) => {
+    const pageId = await createFlagshipPage("Retarget Active Page", uniq("KIT"));
+    await setActivePage(pageId, kitchenId);
+
+    await page.goto(`/pages/edit/${pageId}`);
+    await expect(page.getByText("6 × 22").first()).toBeVisible({ timeout: 15_000 });
+
+    // Flagship (6x22) -> Note (3x15): a shrinking retarget confirms first.
+    await page.getByLabel("Change board size").click();
+    await page.getByRole("option", { name: "Note", exact: true }).click();
+    await expect(page.getByText("3 × 15").first()).toBeVisible({ timeout: 10_000 });
+
+    await page.getByRole("button", { name: "Save" }).first().click();
+    await expect(page.getByRole("heading", { name: "Change board size?" })).toBeVisible({ timeout: 10_000 });
+    await page.getByRole("button", { name: "Resize and save" }).click();
+
+    // The toast names the board and the "active page" surface (issue #1250),
+    // proving the per-board active-page reference (not just a schedule) is tracked.
+    const toast = getToastsRegion(page);
+    await expect(toast).toContainText("This page no longer fits", { timeout: 10_000 });
+    await expect(toast).toContainText("Kitchen");
+    await expect(toast).toContainText("active page");
+  });
+});


### PR DESCRIPTION
Closes #1251

**Per-board #10 — final issue of epic #1241.** All of #1242-#1250 are merged, so this fills the one remaining gap: an E2E regression that exercises a **mixed fleet** (Flagship + Note Array) through the actual UI, plus docs describing the per-board model.

## What changed

### `web/tests/regression/multi-board-e2e.spec.ts` (new)

Configures a Flagship board ("Kitchen", Local API → mock-board) and a Note Array board ("Office", Cloud API → mock-cloud) and drives them together — something no earlier spec did (existing specs either assert at the API/hardware layer directly, or drive the sidebar selector with two Flagship boards only):

1. **Sidebar selector → Dashboard + Schedule** — switching boards updates the Dashboard's Active Display and the Schedule page's board indicator to that board's own active page, and the selection persists across a full navigation.
2. **Change Page → correct mock, correct size** — a manual send from each board lands on that board's own mock (mock-board vs. mock-cloud) at that board's own geometry, and never cross-contaminates the other board's hardware.
3. **Page picker size filtering** — the "Change Page" picker only offers pages sized for the currently-selected board (Flagship-sized pages are hidden when Office is selected, and vice versa).
4. **Editor stale-reference warning** — retargeting a page that's a board's active page to an incompatible size surfaces the "This page no longer fits" toast naming that board and the "active page" surface (issue #1250), proving per-board active-page references (not just schedules) are tracked.

Backend send→read coverage for a mixed fleet against both stdlib mocks already exists in `note-array-output.spec.ts`'s "mixed fleet" test, so this spec deliberately doesn't duplicate it.

Verified: 4/4 passing, repeated back-to-back to check for flakiness, run against an isolated dev stack (separate compose project/ports) with prettier + eslint clean.

### Docs

- `docs-site/docs/setup/note-arrays.md` — new "Multiple boards" section: sidebar selector, global Pages/Collections, size-filtered pickers.
- `docs-site/docs/reference/api-endpoints.md` — `board_id` params on the active-page/send/current-message endpoints, `note_array` device fields.
- `docs/reference/NOTE_ARRAYS.md` — contributor-facing summary of the per-board model with pointers to the key files and this spec.

## Test plan

- [x] New Playwright spec passes locally (4/4, repeated)
- [x] `eslint` / `prettier --check` clean on the new spec
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)