### PR TITLE
docs(blog): remove decorative emoji from post titles and headers

### DIFF
--- a/docs-site/blog/2026-02-15-wysiwyg-editor-scheduling-disney-parks/index.md
+++ b/docs-site/blog/2026-02-15-wysiwyg-editor-scheduling-disney-parks/index.md
@@ -1,5 +1,5 @@
 ---
-title: "Now with a Rich WYSIWYG Editor, Scheduling, and Disney Parks Queue Times 🥳"
+title: "Now with a Rich WYSIWYG Editor, Scheduling, and Disney Parks Queue Times"
 description: "A major FiestaBoard update: a pixel-perfect WYSIWYG editor with live board preview, scheduled messages and layouts, and real-time Disney Parks wait times."
 slug: wysiwyg-editor-scheduling-disney-parks
 authors: [team]
@@ -15,19 +15,19 @@ We've been working on FiestaBoard — the free, open-source web dashboard for Ve
 
 If you're looking for more "pixel-perfect" control or specific automation, here is what's new:
 
-## 🎨 New Rich WYSIWYG Editor
+## New Rich WYSIWYG Editor
 
 No more guessing. The new editor gives you a real-time preview of the Vestaboard grid. You can "paint" individual bits, toggle colors, and align text exactly where you want it before sending it to your board.
 
 ![The rich page editor with live grid preview and the template variable picker open](./rich-editor.png)
 
-## 📅 Scheduling Mode
+## Scheduling Mode
 
 You can now schedule specific messages or layouts to trigger at set times. Perfect for recurring morning greetings, "Meeting in Progress" signs, or daily reminders.
 
 ![The schedule calendar showing pages rotating through a full week](./schedule-calendar.jpg)
 
-## 🏰 Disney Parks Plugin
+## Disney Parks Plugin
 
 By popular request, we've added a plugin that pulls real-time queue times for Disney Parks. You can now turn your board into a live wait-time tracker.
 

--- a/docs-site/blog/2026-05-02-may-2026-update/index.md
+++ b/docs-site/blog/2026-05-02-may-2026-update/index.md
@@ -7,7 +7,7 @@ tags: [release]
 image: ./social-card.png
 ---
 
-Hi friends 👋
+Hi friends,
 
 For anyone who missed the [first](/blog/introducing-fiestaboard) and [second](/blog/wysiwyg-editor-scheduling-disney-parks) posts: FiestaBoard is the free, open-source dashboard for Vestaboard. You self-host it, plug in the data sources you care about (weather, transit, stocks, sports, surf, your calendar, Last.fm, Home Assistant, dad jokes — you name it), and it drives your board. Flagship and Note both supported.
 
@@ -15,7 +15,7 @@ For anyone who missed the [first](/blog/introducing-fiestaboard) and [second](/b
 
 Since the last update, two things have changed that we think genuinely matter for this project:
 
-## 🍓 You no longer need to know Docker — just flash a Raspberry Pi
+## You no longer need to know Docker — just flash a Raspberry Pi
 
 The biggest accessibility unlock: there's now a FiestaPi image you flash onto a microSD card with the official Raspberry Pi Imager. No command line, no docker-compose, no editing config files. Boot the Pi, open `http://fiestapi.local:4420` on any device on your network, and the setup wizard walks you the rest of the way.
 
@@ -23,13 +23,13 @@ While it runs on the Raspberry Pi Zero 2 W, we are testing and using a Pi 3B+ be
 
 Setup guide: [Raspberry Pi setup](/docs/setup/raspberry-pi)
 
-## 🔄 One-click auto-updates
+## One-click auto-updates
 
 The other big quality-of-life change: FiestaBoard now updates itself. There's an in-app "Update available" banner with a single button — click it, you get a full-screen progress overlay, and a minute or two later you're on the latest version. This does require a second "sidecar" docker image that comes automatically with the FiestaPi. For existing users you'll want to pull the new docker compose file to join in on the fun.
 
 Translation: you're not stuck on whatever version you installed six months ago. Bug fixes and new plugins land on your board without you having to think about it.
 
-## 🧩 25+ new plugins since the last post
+## 25+ new plugins since the last post
 
 The plugin registry has roughly doubled. A non-exhaustive sampler of what's new:
 


### PR DESCRIPTION
Cleans up the blog for a more serious tone: removes the 🥳 from the Feb 15 post title, the emoji prefixes from section headers in the Feb 15 and May 2026 posts, and the 👋 greeting.

Kept the ❤️ in "Note device rendering (the heart ❤️ character)" since it refers to the literal board character. Social cards are unaffected — they never included the emoji.

🤖 Generated with [Claude Code](https://claude.com/claude-code)