### PR TITLE
chore(deps): ignore TypeScript major updates in dependabot npm group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,12 @@ updates:
       npm-dependencies:
         patterns:
           - "*"
+    ignore:
+      # TS 7 (native compiler) breaks typescript-eslint (hard-refuses TS >= 7,
+      # typescript-eslint#10940) and Storybook's react-docgen-typescript plugin.
+      # Remove once both support TS 7, then migrate deliberately.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Summary

The weekly npm group bump (#1442) pulled in the **TypeScript 6 → 7 major**, which broke three CI jobs with one root cause:

- **Lint UI (web)**: eslint exits 2 at startup — `typescript-eslint does not support TS 7.0` (typescript-eslint#10940)
- **Accessibility Tests (dark + light)**: Storybook build crashes in `vite-plugin-react-docgen-typescript` (`Cannot read properties of undefined (reading 'fileExists')`) — the TS 7 native-compiler rewrite changed the compiler API it calls

Neither tool supports TS 7 yet, so this adds a dependabot `ignore` for TypeScript **majors only** (minors/patches still flow). Once typescript-eslint and the Storybook docgen plugin ship TS 7 support, drop the rule and migrate deliberately.

After this merges, `@dependabot recreate` on #1442 rebuilds the group PR without TS 7, keeping the other 41 updates.

## Test plan
- [x] `yaml.safe_load` parses the file
- [x] Rule scoped to the npm ecosystem entry only

🤖 Generated with [Claude Code](https://claude.com/claude-code)