### PR TITLE
test(web): extend timeouts on two CI-flaky UI tests

### DIFF
--- a/web/src/__tests__/active-page-display-multi-board.test.tsx
+++ b/web/src/__tests__/active-page-display-multi-board.test.tsx
@@ -252,9 +252,12 @@ describe("ActivePageDisplay per-board scoping (issue #1247)", () => {
 
     render(<ActivePageDisplay />, { wrapper: TestWrapper });
 
-    await waitFor(() => {
-      expect(previewedPageIds).toContain("page-1");
-    });
+    await waitFor(
+      () => {
+        expect(previewedPageIds).toContain("page-1");
+      },
+      { timeout: 3000 },
+    );
   });
 
   it("single-board installs stay unscoped with no board indicator", async () => {

--- a/web/src/__tests__/schedule-entry-form-select.test.tsx
+++ b/web/src/__tests__/schedule-entry-form-select.test.tsx
@@ -188,7 +188,7 @@ describe("ScheduleEntryForm end-time Select inside Sheet", () => {
     await waitFor(() => {
       expect(endTimeTrigger).toHaveTextContent("18:00");
     });
-  });
+  }, 40000);
 
   it("keyboard: ArrowDown then Enter updates end time", async () => {
     const user = userEvent.setup();


### PR DESCRIPTION
## Summary

Hardens two vitest tests that fail intermittently under CI load — most recently knocking the UI Tests job red on dependabot PR #1444 with no related code change.

- **`schedule-entry-form-select.test.tsx`** — "mouse-click: clicking a time option updates end time" timed out at the global 20s `testTimeout`. The time Select renders 1440 per-minute options in jsdom, so each interaction takes 4–5s even on a fast machine. This gives it the same per-test 40s budget the start-time mouse-click test (line 129) already received for the identical flake.
- **`active-page-display-multi-board.test.tsx`** — "falls back to the active page render when a secondary board has no cached content" failed with `expected [] to include 'page-1'` at ~1.7s: it was the only test in the file using `waitFor`'s default 1s timeout while every sibling passes `{ timeout: 3000 }`. Aligned it.

## Verification

- Both test files pass 6/6 consecutive runs in the `web` test container, under both main's lockfile and the #1444 bumped lockfile (ruling out a dependency regression — see #1444).
- `prettier --check` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)