### PR TITLE
feat(transitions): selectable without Marketplace enable

### DIFF
--- a/docs/development/TRANSITION_PLUGIN_DEVELOPMENT.md
+++ b/docs/development/TRANSITION_PLUGIN_DEVELOPMENT.md
@@ -128,7 +128,7 @@ Choose conservatively. A transition with `max_frames: 5000` and `min_interval_ms
 
 ## Selecting a transition plugin
 
-Once your plugin is loaded and enabled, users select it from:
+Once your plugin is installed, users select it from (no Marketplace enable step is needed — installing a transition plugin is opting in):
 
 - A specific page's Transition picker in the page editor
 - The global default in Settings → Transitions
@@ -137,7 +137,7 @@ Pages store the choice as `transition_strategy = "plugin:my_transition"`. The ru
 
 ## Visual testing
 
-The **Transition Lab** at `/transitions` lets you preview any enabled transition plugin against arbitrary from/to text without a real board. It uses `POST /transitions/preview` under the hood, which calls your `generate_frames()` and returns the resulting grids as JSON. Use the timeline scrubber to step through frames and verify each intermediate state.
+The **Transition Lab** at `/transitions` lets you preview any installed transition plugin against arbitrary from/to text without a real board. It uses `POST /transitions/preview` under the hood, which calls your `generate_frames()` and returns the resulting grids as JSON. Use the timeline scrubber to step through frames and verify each intermediate state.
 
 ## Performance & rate limits
 

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -5436,12 +5436,14 @@ def _reject_plugin_strategy_when_beta_off(strategy: str | None) -> None:
 
 @app.get("/transitions/plugins")
 async def list_transition_plugins():
-    """List enabled transition plugins available for selection.
+    """List installed transition plugins available for selection.
 
     Each entry includes the plugin id, display name, manifest metadata,
     its ``settings_schema`` (so the UI can render a config form), and the
-    plugin's ``transition_settings`` caps.  Only enabled transition
-    plugins are returned -- disabled ones can't be invoked.
+    plugin's ``transition_settings`` caps.  Every installed transition
+    plugin is listed -- unlike data plugins, transitions don't need to be
+    enabled in the Marketplace to be selectable; installing one is opting
+    in.
 
     Gated behind ``beta.transition_plugins_enabled``.
     """
@@ -5454,8 +5456,6 @@ async def list_transition_plugins():
     out = []
     for plugin_id, plugin in registry._plugins.items():  # noqa: SLF001 - registry is in-process
         if not isinstance(plugin, TransitionPluginBase):
-            continue
-        if not registry.is_enabled(plugin_id):
             continue
         manifest = registry.get_manifest(plugin_id)
         if manifest is None:

--- a/src/plugins/registry.py
+++ b/src/plugins/registry.py
@@ -602,15 +602,14 @@ class PluginRegistry:
         :class:`~src.plugins.base.TransitionPluginBase` and produce
         frame-by-frame board animations; data plugins are filtered out so
         ``board_client.render("plugin:typewriter")`` can never accidentally
-        invoke a data source.  Only plugins that are currently enabled are
-        returned to prevent disabled plugins from running on the board.
+        invoke a data source.  The Marketplace enabled toggle is not
+        consulted: transitions have no polling loop or background cost, so
+        any installed transition plugin may be selected and run.
         """
         from .base import TransitionPluginBase  # local import to avoid cycles
 
         plugin = self._plugins.get(plugin_id)
         if plugin is None or not isinstance(plugin, TransitionPluginBase):
-            return None
-        if not self._enabled.get(plugin_id, False):
             return None
         return plugin
 

--- a/tests/test_transitions_api.py
+++ b/tests/test_transitions_api.py
@@ -142,7 +142,7 @@ def _run(coro):
 # ---------------------------------------------------------------------------
 
 
-def test_list_transition_plugins_returns_enabled(patched_registry):
+def test_list_transition_plugins_returns_installed(patched_registry):
     data = _run(list_transition_plugins())
     ids = {p["id"] for p in data["plugins"]}
     assert {"fake_typewriter", "fake_forever"} <= ids
@@ -157,11 +157,13 @@ def test_list_transition_plugins_includes_settings_schema(patched_registry):
     assert tw["strategy"] == "plugin:fake_typewriter"
 
 
-def test_list_transition_plugins_excludes_disabled(patched_registry):
+def test_list_transition_plugins_includes_disabled(patched_registry):
+    """Transitions don't need the Marketplace enable toggle: installed is
+    enough to be selectable."""
     patched_registry._enabled["fake_typewriter"] = False
     data = _run(list_transition_plugins())
     ids = {p["id"] for p in data["plugins"]}
-    assert "fake_typewriter" not in ids
+    assert "fake_typewriter" in ids
 
 
 def test_list_transition_plugins_omits_data_plugins(patched_registry):


### PR DESCRIPTION
## Summary

Transition plugins currently have to be enabled in the Marketplace before they show up in the transition picker — an awkward extra step for plugins that have no polling loop or background cost. This PR makes every **installed** transition plugin selectable and runnable, while keeping them listed in the Marketplace as before.

- `/transitions/plugins` now returns every installed transition plugin instead of only Marketplace-enabled ones
- `PluginRegistry.get_transition_plugin` no longer consults the enabled toggle, so preview (`/transitions/preview`) and the board runtime work for never-enabled plugins
- The experimental beta gate (`beta.transition_plugins_enabled`, Settings → Beta) is **unchanged** — the feature is still opt-in as a whole
- Updated `docs/development/TRANSITION_PLUGIN_DEVELOPMENT.md` and inverted the enabled-exclusion API test to cover the new behavior

## Test plan

- [x] `tests/test_transitions_api.py`, `tests/test_transition_plugin_base.py`, `tests/test_transitions_runner.py`, `tests/test_plugin_registry.py` — 156 passed in the container
- [x] `ruff check` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)