### PR TITLE
feat(docs-site): generate llms.txt and llms-full.txt for AI assistants

### DIFF
--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -190,6 +190,36 @@ const config: Config = {
 
   plugins: [
     [
+      "@sablier/docusaurus-plugin-llms",
+      {
+        // Generate from the snapshot that /docs/ actually serves — the
+        // working docs/ dir can describe unreleased features between
+        // releases. versions[0] keeps this on the latest snapshot as
+        // releases ship.
+        docsDir: `versioned_docs/version-${versions[0]}`,
+        pathTransformation: {
+          ignorePaths: ["versioned_docs", `version-${versions[0]}`],
+        },
+        title: "FiestaBoard",
+        description:
+          "Open-source software for split-flap displays (Vestaboard Flagship and Note). Plugins, scheduling, and a visual page editor for your board.",
+        version: versions[0],
+        generateLLMsTxt: true,
+        generateLLMsFullTxt: true,
+        includeOrder: [
+          "**/intro.md",
+          "**/setup/**",
+          "**/plugins/overview.md",
+          "**/plugins/configuration.md",
+          "**/plugins/**",
+          "**/features/**",
+          "**/deployment/**",
+          "**/reference/**",
+          "**/troubleshooting.md",
+        ],
+      },
+    ],
+    [
       "@docusaurus/plugin-client-redirects",
       {
         // Pages that were deleted outright (not just moved off the version

--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -5577,25 +5577,37 @@
         "@docusaurus/core": "^3.0.0"
       }
     },
+    "node_modules/@sablier/docusaurus-plugin-llms/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/@sablier/docusaurus-plugin-llms/node_modules/brace-expansion": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
-      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@sablier/docusaurus-plugin-llms/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "license": "ISC",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^2.0.2"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -6486,26 +6498,26 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -7368,6 +7380,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
@@ -7496,6 +7509,7 @@
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
       "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -8131,6 +8145,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/config-chain": {
@@ -15413,6 +15428,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -19093,6 +19109,42 @@
         "path-is-inside": "1.0.2",
         "path-to-regexp": "3.3.0",
         "range-parser": "1.2.0"
+      }
+    },
+    "node_modules/serve-handler/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/serve-handler/node_modules/brace-expansion": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/serve-handler/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/serve-handler/node_modules/path-to-regexp": {

--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -13,6 +13,7 @@
         "@docusaurus/preset-classic": "3.9.2",
         "@easyops-cn/docusaurus-search-local": "^0.55.1",
         "@mdx-js/react": "^3.0.0",
+        "@sablier/docusaurus-plugin-llms": "0.3.1",
         "clsx": "^2.0.0",
         "lucide-react": "^1.17.0",
         "prism-react-renderer": "^2.3.0",
@@ -5558,6 +5559,47 @@
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
       "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
       "license": "MIT"
+    },
+    "node_modules/@sablier/docusaurus-plugin-llms": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@sablier/docusaurus-plugin-llms/-/docusaurus-plugin-llms-0.3.1.tgz",
+      "integrity": "sha512-9XYZHG3lHIg0ccPZpEBGVyG6oH9FIZnKeYw2WKpMcSYvv3V98rM4VCCdP2uBLDChlrnjgBY0h/NKCHVNKaLMXg==",
+      "license": "MIT",
+      "dependencies": {
+        "gray-matter": "^4.0.3",
+        "minimatch": "^9.0.3",
+        "yaml": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "@docusaurus/core": "^3.0.0"
+      }
+    },
+    "node_modules/@sablier/docusaurus-plugin-llms/node_modules/brace-expansion": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@sablier/docusaurus-plugin-llms/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.10",
@@ -21619,6 +21661,21 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "1.2.2",

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -25,6 +25,7 @@
     "@docusaurus/preset-classic": "3.9.2",
     "@easyops-cn/docusaurus-search-local": "^0.55.1",
     "@mdx-js/react": "^3.0.0",
+    "@sablier/docusaurus-plugin-llms": "0.3.1",
     "clsx": "^2.0.0",
     "lucide-react": "^1.17.0",
     "prism-react-renderer": "^2.3.0",

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -38,7 +38,11 @@
     "serialize-javascript": ">=7.0.5",
     "uuid": ">=14.0.0",
     "joi": ">=17.13.4",
-    "ws": ">=8.20.1"
+    "ws": ">=8.20.1",
+    "@sablier/docusaurus-plugin-llms": {
+      "minimatch": "^10.2.5"
+    },
+    "brace-expansion@^5.0.0": "^5.0.8"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.9.2",


### PR DESCRIPTION
## Why

Follow-up to #1461. With classic-search 404s fixed, this covers the AI-assistant side of discoverability (GEO). Research findings that shaped the scope:

- **Google explicitly does not use llms.txt** and isn't planning to (Gary Illyes, Jul 2025) — this PR is **not** a Google-SEO play.
- **Anthropic has confirmed Claude respects llms.txt in retrieval workflows; Perplexity confirmed it uses it to prioritize page selection**; IDE agents (Cursor, Continue, Cline) consume it. That's precisely how FiestaBoard's audience asks setup questions ("how do I set up FiestaBoard on my Pi" in Claude/Cursor).
- Classic-SEO fundamentals (JSON-LD SoftwareApplication + FAQPage schema, per-page metas/og, sitemap, allow-all robots.txt that lets AI crawlers in) are already in place — no changes needed there.

## What

Adds `@sablier/docusaurus-plugin-llms` (maintained fork of `docusaurus-plugin-llms`) emitting at build time:

- **`/llms.txt`** — llmstxt.org index: title, description, and a per-page link list with frontmatter descriptions, ordered docs-journey-style (intro → setup → plugins → features → deployment → reference → troubleshooting)
- **`/llms-full.txt`** — full docs corpus (~315 KB) for agents that want everything in one fetch

Content is generated from `versioned_docs/version-${versions[0]}` — the snapshot `/docs/` actually serves — rather than the working `docs/` dir, which can describe unreleased features between releases. Follows the latest snapshot automatically as releases ship.

## Verification

- All 62 `llms.txt` links resolve to real built pages (scripted check, 62/62)
- `llms-full.txt` contains real page content (spot-checked)
- #1461's redirect stubs unaffected
- PR-mode build green, prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)