### PR TITLE
fix: make HA Ingress asset URLs base-path aware at runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -971,6 +971,121 @@ jobs:
           path: web/playwright-test-results/
           retention-days: 7
 
+  ingress-e2e-tests:
+    name: HA Ingress E2E Tests
+    runs-on: ubuntu-latest
+    needs: [detect-changes, build-test-image]
+    if: github.event_name == 'pull_request' && (needs.detect-changes.outputs.api == 'true' || needs.detect-changes.outputs.ui == 'true' || needs.detect-changes.outputs.shared == 'true')
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up web E2E environment
+        uses: ./.github/actions/setup-web-e2e
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to Docker Hub
+        # Skip on fork PRs and Dependabot PRs (neither has access to the
+        # DOCKERHUB_* secrets — forks by policy, Dependabot because it uses
+        # a separate secret namespace). On internal PRs and main, fail
+        # loudly so we notice credential problems instead of silently
+        # falling back to anonymous pulls with their tiny rate limits.
+        if: >-
+          (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+          && github.actor != 'dependabot[bot]'
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build test image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          target: runtime
+          push: false
+          load: true
+          tags: fiestaboard:ingress-e2e
+          build-args: |
+            VERSION=dev
+          # Reuse the cache the main e2e job warms up.
+          cache-from: |
+            type=gha,scope=build-linux/amd64
+            type=gha,scope=build-test
+
+      - name: Start FiestaBoard behind the HA Ingress simulator
+        # The simulator conf (infra/ha-ingress-proxy.conf) proxies to
+        # `http://fiestaboard:3000`, so the app container must be named
+        # `fiestaboard` on a shared network. The prod bundle matters here:
+        # the ingress-escape bugs this job guards against (runtime-built
+        # chunk URLs, minifier quote styles) only exist in minified output.
+        run: |
+          docker network create ingress-net
+
+          docker run -d --name fiestaboard --network ingress-net \
+            -e PRODUCTION=false \
+            -e FIESTABOARD_AUTH_ENABLED=false \
+            -e FIESTABOARD_INGRESS_PATH_REWRITE=true \
+            -e FIESTABOARD_X_FRAME_OPTIONS=OFF \
+            fiestaboard:ingress-e2e
+
+          docker run -d --name ha-ingress-proxy --network ingress-net \
+            -v ${{ github.workspace }}/infra/ha-ingress-proxy.conf:/etc/nginx/conf.d/default.conf:ro \
+            -p 5050:80 \
+            nginx:alpine
+
+          echo "BASE_URL=http://localhost:5050" >> $GITHUB_ENV
+
+      - name: Wait for container ready (through the simulator)
+        timeout-minutes: 2
+        run: |
+          for i in $(seq 1 60); do
+            STATUS=$(curl -s -m 5 -o /dev/null -w "%{http_code}" "$BASE_URL/api/hassio_ingress/test-token/api/health" 2>/dev/null || echo "000")
+            if [ "$STATUS" = "200" ]; then
+              echo "✅ Ready (attempt $i)"
+              break
+            fi
+            if [ "$i" = "60" ]; then
+              echo "❌ Failed to become ready"
+              docker logs fiestaboard | tail -50
+              docker logs ha-ingress-proxy | tail -20
+              exit 1
+            fi
+            sleep 1
+          done
+
+      - name: Run ingress E2E tests
+        working-directory: web
+        timeout-minutes: 5
+        run: npx playwright test ingress.spec.ts --reporter=github --workers=1
+        env:
+          CI: true
+          RUN_INGRESS_TESTS: "1"
+          BASE_URL: ${{ env.BASE_URL }}
+
+      - name: Dump container logs on failure
+        if: failure()
+        run: |
+          docker logs fiestaboard | tail -200
+          docker logs ha-ingress-proxy | tail -50
+
+      - name: Stop containers
+        if: always()
+        run: docker rm -f fiestaboard ha-ingress-proxy 2>/dev/null || true; docker network rm ingress-net 2>/dev/null || true
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-ingress-results
+          path: web/playwright-test-results/
+          retention-days: 7
+
   build:
     name: Build Verification
     runs-on: ubuntu-latest
@@ -1129,7 +1244,7 @@ jobs:
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [detect-changes, dependency-review, test-platform, test-plugins, lint-web, lint-docs, test-ui, a11y-tests, build-test-image, e2e-tests, ai-mcp-e2e-tests, auth-e2e-tests, build, build-docs, lint-markdown, link-check]
+    needs: [detect-changes, dependency-review, test-platform, test-plugins, lint-web, lint-docs, test-ui, a11y-tests, build-test-image, e2e-tests, ai-mcp-e2e-tests, auth-e2e-tests, ingress-e2e-tests, build, build-docs, lint-markdown, link-check]
     if: always()
     steps:
       - name: Check all jobs passed or were skipped
@@ -1150,6 +1265,7 @@ jobs:
             e2e-tests
             ai-mcp-e2e-tests
             auth-e2e-tests
+            ingress-e2e-tests
             build
             build-docs
             lint-markdown

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -247,6 +247,21 @@ sub_filter '"/manifest.json' '"$http_x_ingress_path/manifest.json';
 sub_filter "'/manifest.json" "'$http_x_ingress_path/manifest.json";
 sub_filter '"/favicon.ico' '"$http_x_ingress_path/favicon.ico';
 sub_filter "'/favicon.ico" "'$http_x_ingress_path/favicon.ico";
+# Backtick-quoted variants: the Vite 8 toolchain's oxc minifier emits
+# template-literal strings (`/assets/...`) where older builds used
+# double quotes. Defense-in-depth for third-party code — first-party
+# asset references go through the runtime base path instead
+# (renderBuiltUrl -> window.__fbAssetUrl, and appUrl() for JSX srcs).
+#
+# Deliberately NO backtick variants for /icons/, /manifest.json, or
+# /favicon.ico: every first-party reference to those is wrapped in
+# appUrl() (enforced by eslint no-restricted-syntax), so a body-level
+# rewrite would prefix the literal INSIDE the appUrl() call and the
+# runtime would prefix it again — double prefix, broken image.
+sub_filter '`/assets/' '`$http_x_ingress_path/assets/';
+sub_filter '`/sw.js' '`$http_x_ingress_path/sw.js';
+sub_filter '`/registerSW.js' '`$http_x_ingress_path/registerSW.js';
+sub_filter '`/api/' '`$http_x_ingress_path/api/';
 # React Router v7 SPA hydration context. The Vite build inlines
 #   window.__reactRouterContext = {"basename":"/", ...}
 # into the served HTML. HydratedRouter strips `basename` from

--- a/nginx-dev.conf
+++ b/nginx-dev.conf
@@ -50,10 +50,14 @@ http {
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-XSS-Protection "1; mode=block" always;
 
-        # Intercept upstream errors so we can serve the "please wait" page instead of
-        # a raw 502 Bad Gateway while the API or UI are still starting up.
+        # Intercept CONNECTION-LEVEL upstream errors (502 refused / 504 timeout) so we
+        # can serve the "please wait" page instead of a raw gateway error while the
+        # API is still starting. 503 is deliberately NOT intercepted: the API uses it
+        # for real conditions ("board unreachable", "client not initialized") whose
+        # JSON detail must reach the UI — intercepting it masked every app-level
+        # error as "starting up" forever.
         proxy_intercept_errors on;
-        error_page 502 503 504 /starting.html;
+        error_page 502 504 /starting.html;
 
         location = /starting.html {
             root /app/static;
@@ -62,7 +66,7 @@ http {
 
         # MCP — same precedence rule as production.
         location /api/mcp {
-            error_page 502 503 504 = @api_starting;
+            error_page 502 504 = @api_starting;
             proxy_pass http://127.0.0.1:8000;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
@@ -75,7 +79,7 @@ http {
         }
 
         location /api/ {
-            error_page 502 503 504 = @api_starting;
+            error_page 502 504 = @api_starting;
             rewrite ^/api(.*)$ $1 break;
             proxy_pass http://127.0.0.1:8000;
             proxy_http_version 1.1;

--- a/nginx.conf
+++ b/nginx.conf
@@ -62,10 +62,14 @@ http {
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-XSS-Protection "1; mode=block" always;
 
-        # Intercept upstream errors so we can serve the "please wait" page instead of
-        # a raw 502 Bad Gateway while the API is still starting up.
+        # Intercept CONNECTION-LEVEL upstream errors (502 refused / 504 timeout) so we
+        # can serve the "please wait" page instead of a raw gateway error while the
+        # API is still starting. 503 is deliberately NOT intercepted: the API uses it
+        # for real conditions ("board unreachable", "client not initialized") whose
+        # JSON detail must reach the UI — intercepting it masked every app-level
+        # error as "starting up" forever.
         proxy_intercept_errors on;
-        error_page 502 503 504 /starting.html;
+        error_page 502 504 /starting.html;
 
         location = /starting.html {
             root /app/static;
@@ -81,7 +85,7 @@ http {
         # MCP sub-app to 404. Must be declared BEFORE `location /api/` so
         # nginx's longest-prefix match picks it up first.
         location /api/mcp {
-            error_page 502 503 504 = @api_starting;
+            error_page 502 504 = @api_starting;
             proxy_pass http://127.0.0.1:8000;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
@@ -96,7 +100,7 @@ http {
         # All API traffic under /api/* → FastAPI backend (path stripped: /api/pages → /pages)
         location /api/ {
             # Return JSON while the API is starting instead of the HTML "please wait" page.
-            error_page 502 503 504 = @api_starting;
+            error_page 502 504 = @api_starting;
             rewrite ^/api(.*)$ $1 break;
             proxy_pass http://127.0.0.1:8000;
             proxy_http_version 1.1;

--- a/nginx.https.conf
+++ b/nginx.https.conf
@@ -59,8 +59,14 @@ http {
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-XSS-Protection "1; mode=block" always;
 
+        # Intercept CONNECTION-LEVEL upstream errors (502 refused / 504 timeout) so we
+        # can serve the "please wait" page instead of a raw gateway error while the
+        # API is still starting. 503 is deliberately NOT intercepted: the API uses it
+        # for real conditions ("board unreachable", "client not initialized") whose
+        # JSON detail must reach the UI — intercepting it masked every app-level
+        # error as "starting up" forever.
         proxy_intercept_errors on;
-        error_page 502 503 504 /starting.html;
+        error_page 502 504 /starting.html;
 
         location = /starting.html {
             root /app/static;
@@ -68,7 +74,7 @@ http {
         }
 
         location /api/mcp {
-            error_page 502 503 504 = @api_starting;
+            error_page 502 504 = @api_starting;
             proxy_pass http://127.0.0.1:8000;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
@@ -81,7 +87,7 @@ http {
         }
 
         location /api/ {
-            error_page 502 503 504 = @api_starting;
+            error_page 502 504 = @api_starting;
             rewrite ^/api(.*)$ $1 break;
             proxy_pass http://127.0.0.1:8000;
             proxy_http_version 1.1;

--- a/web/app/root.tsx
+++ b/web/app/root.tsx
@@ -36,6 +36,7 @@ import { ThemeColorMeta } from "@/components/theme-color-meta";
 import { Toaster } from "@/components/ui/sonner";
 import { WizardProvider } from "@/components/wizard-provider";
 import i18n from "@/i18n/i18next";
+import { appUrl } from "@/lib/base-path";
 import { readCookieString, shouldShowPride } from "@/lib/pride";
 
 import type { Route } from "./+types/root";
@@ -44,11 +45,29 @@ import type { Route } from "./+types/root";
 // `useTranslation` runs anywhere in the tree.
 void i18n;
 
+// Classic <script> injected into <head> so it executes during document
+// parsing, before the deferred module bundle. vite.config.ts's
+// `experimental.renderBuiltUrl` routes every JS-hosted asset URL through
+// this global, which prepends the React Router basename under HA Ingress
+// (nginx rewrites the inlined `"basename":"/"` hydration literal — see
+// web/src/lib/base-path.ts). The basename global is read lazily at call
+// time, so script ordering relative to the hydration context script
+// doesn't matter. Filenames arrive relative ("assets/chunk.js").
+const ASSET_URL_HELPER = `window.__fbAssetUrl=function(f){var c=window.__reactRouterContext,b=c&&c.basename;return((!b||b==="/")?"":b.replace(/\\/+$/,""))+"/"+f};`;
+
+// appUrl() wrapping matters for the CLIENT-side <Links /> re-render: at
+// prerender time `window` is undefined so these emit the plain absolute
+// paths into the HTML (which nginx sub_filter rewrites under Ingress),
+// but when React re-renders Links in the browser the hrefs are computed
+// fresh — without the runtime prefix they'd revert to the host root and
+// 404 inside Home Assistant. (There is deliberately no body-level
+// backtick sub_filter for /icons/ etc. — see entrypoint.sh — because it
+// would double-prefix these appUrl() literals.)
 export const links: Route.LinksFunction = () => [
-  { rel: "icon", href: "/favicon.ico", sizes: "any" },
-  { rel: "icon", href: "/icons/favicon-32x32.png", type: "image/png", sizes: "32x32" },
-  { rel: "apple-touch-icon", href: "/icons/apple-touch-icon.png" },
-  { rel: "manifest", href: "/manifest.json" },
+  { rel: "icon", href: appUrl("/favicon.ico"), sizes: "any" },
+  { rel: "icon", href: appUrl("/icons/favicon-32x32.png"), type: "image/png", sizes: "32x32" },
+  { rel: "apple-touch-icon", href: appUrl("/icons/apple-touch-icon.png") },
+  { rel: "manifest", href: appUrl("/manifest.json") },
 ];
 
 export const meta: Route.MetaFunction = () => [
@@ -91,6 +110,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className={initialIsPrideMonth ? "pride-month" : undefined} suppressHydrationWarning>
       <head>
+        <script dangerouslySetInnerHTML={{ __html: ASSET_URL_HELPER }} />
         <Meta />
         <Links />
       </head>

--- a/web/app/routes/login.tsx
+++ b/web/app/routes/login.tsx
@@ -35,7 +35,7 @@ import { Label } from "@/components/ui/label";
 import { useRouter, useSearchParams } from "@/hooks/use-router";
 import { useTranslations } from "@/i18n/translations";
 import type { AuthStatusResponse } from "@/lib/api";
-import { apiUrl } from "@/lib/base-path";
+import { apiUrl, appUrl } from "@/lib/base-path";
 
 type AuthStatus = AuthStatusResponse;
 
@@ -468,7 +468,7 @@ function CenteredCard({
   return (
     <div className="min-h-screen flex flex-col items-center justify-center bg-background p-4">
       <div className="mb-6 flex items-center gap-3">
-        <img src="/icons/favicon-32x32.png" alt="" width={36} height={36} className="flex-shrink-0" />
+        <img src={appUrl("/icons/favicon-32x32.png")} alt="" width={36} height={36} className="flex-shrink-0" />
         <FiestaLogo className="text-2xl" />
       </div>
       <Card className="w-full max-w-md">

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -163,6 +163,33 @@ const eslintConfig = [
           message:
             'Root-relative hard navigations break HA Ingress (issue #48). Wrap the path with appUrl() from "@/lib/base-path".',
         },
+        // Static-asset literals in JSX `src` attributes land in the JS
+        // bundle, where the minifier's quote style (oxc emits backticks)
+        // makes nginx sub_filter rewriting unreliable — route them through
+        // appUrl() so the runtime basename is applied instead. (root.tsx's
+        // links()/meta() output is exempt by shape: those are object `href`
+        // properties rendered into the HTML document, which sub_filter
+        // rewrites reliably — not JSX `src` attributes.)
+        // Child (not descendant) combinators: a literal already wrapped in
+        // appUrl(...) sits inside a CallExpression and must not match.
+        {
+          selector:
+            "JSXAttribute[name.name='src'] > Literal[value=/^\\u002F(icons\\u002F|favicon\\.ico$|manifest\\.json$)/]",
+          message:
+            'Absolute asset URLs in JSX bypass the HA Ingress base path. Wrap the path with appUrl() from "@/lib/base-path".',
+        },
+        {
+          selector:
+            "JSXAttribute[name.name='src'] > JSXExpressionContainer > Literal[value=/^\\u002F(icons\\u002F|favicon\\.ico$|manifest\\.json$)/]",
+          message:
+            'Absolute asset URLs in JSX bypass the HA Ingress base path. Wrap the path with appUrl() from "@/lib/base-path".',
+        },
+        {
+          selector:
+            "JSXAttribute[name.name='src'] > JSXExpressionContainer > TemplateLiteral > TemplateElement[value.raw=/^\\u002F(icons\\u002F|favicon\\.ico$|manifest\\.json$)/]",
+          message:
+            'Absolute asset URLs in JSX bypass the HA Ingress base path. Wrap the path with appUrl() from "@/lib/base-path".',
+        },
       ],
     },
   },

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -25,6 +25,12 @@ if (!process.env.RUN_AI_TESTS) {
 if (!process.env.RUN_AUTH_TESTS) {
   ciIgnore.push("**/auth.spec.ts");
 }
+// Ingress specs need the HA Ingress simulator sidecar in front of a
+// production-bundle container (see tests/ingress.spec.ts); the main e2e
+// matrix talks to the container directly.
+if (!process.env.RUN_INGRESS_TESTS) {
+  ciIgnore.push("**/ingress.spec.ts");
+}
 
 export default defineConfig({
   testDir: "./tests",

--- a/web/src/components/boot-gate.tsx
+++ b/web/src/components/boot-gate.tsx
@@ -6,7 +6,7 @@ import { useEffect, useState } from "react";
 
 import { FiestaLogo } from "@/components/fiesta-logo";
 import { useTranslations } from "@/i18n/translations";
-import { apiUrl } from "@/lib/base-path";
+import { apiUrl, appUrl } from "@/lib/base-path";
 
 /** How long to wait before showing the splash (avoids a flash for fast startups). */
 const SHOW_SPLASH_DELAY_MS = 600;
@@ -83,7 +83,7 @@ export function BootGate({ children }: { children: React.ReactNode }) {
       >
         {/* Branding */}
         <div className="flex items-center gap-3">
-          <img src="/icons/favicon-32x32.png" alt="" width={36} height={36} className="flex-shrink-0" />
+          <img src={appUrl("/icons/favicon-32x32.png")} alt="" width={36} height={36} className="flex-shrink-0" />
           <FiestaLogo className="text-2xl" />
         </div>
 

--- a/web/src/components/navigation-sidebar.tsx
+++ b/web/src/components/navigation-sidebar.tsx
@@ -38,6 +38,7 @@ import { usePrideActive } from "@/hooks/use-pride-active";
 import { usePathname } from "@/hooks/use-router";
 import { useTranslations } from "@/i18n/translations";
 import { type AISettings, api } from "@/lib/api";
+import { appUrl } from "@/lib/base-path";
 import { MAX_APP_WIDTH, SIDEBAR_INSET } from "@/lib/layout-constants";
 import { cn } from "@/lib/utils";
 
@@ -367,12 +368,12 @@ export function NavigationSidebar() {
               aria-label={t("prideCelebrationAriaLabel")}
               className="flex items-center gap-3 min-w-0 flex-1 ml-2 cursor-pointer text-left"
             >
-              <img src="/icons/favicon-32x32.png" alt="" width={32} height={32} className="flex-shrink-0" />
+              <img src={appUrl("/icons/favicon-32x32.png")} alt="" width={32} height={32} className="flex-shrink-0" />
               <FiestaLogo size="sm" className="logo-on-gradient whitespace-nowrap" />
             </button>
           ) : (
             <div className="flex items-center gap-3 min-w-0 flex-1 ml-2">
-              <img src="/icons/favicon-32x32.png" alt="" width={32} height={32} className="flex-shrink-0" />
+              <img src={appUrl("/icons/favicon-32x32.png")} alt="" width={32} height={32} className="flex-shrink-0" />
               <FiestaLogo size="sm" className="logo-on-gradient whitespace-nowrap" />
             </div>
           )}
@@ -485,7 +486,7 @@ export function NavigationSidebar() {
                 aria-label={t("prideCelebrationAriaLabel")}
                 className="flex items-center gap-2 overflow-hidden px-4 py-4 cursor-pointer text-left w-full"
               >
-                <img src="/icons/favicon-32x32.png" alt="" width={32} height={32} className="flex-shrink-0" />
+                <img src={appUrl("/icons/favicon-32x32.png")} alt="" width={32} height={32} className="flex-shrink-0" />
                 <FiestaLogo
                   className={cn(
                     "logo-on-gradient whitespace-nowrap overflow-hidden transition-opacity duration-100",
@@ -495,7 +496,7 @@ export function NavigationSidebar() {
               </button>
             ) : (
               <div className="flex items-center gap-2 overflow-hidden px-4 py-4">
-                <img src="/icons/favicon-32x32.png" alt="" width={32} height={32} className="flex-shrink-0" />
+                <img src={appUrl("/icons/favicon-32x32.png")} alt="" width={32} height={32} className="flex-shrink-0" />
                 <FiestaLogo
                   className={cn(
                     "logo-on-gradient whitespace-nowrap overflow-hidden transition-opacity duration-100",

--- a/web/src/components/wizard/setup-wizard.tsx
+++ b/web/src/components/wizard/setup-wizard.tsx
@@ -173,7 +173,13 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
             <div className="flex items-center justify-between mb-4">
               <div />
               <div className="inline-flex items-center justify-center w-14 h-14 sm:w-16 sm:h-16 rounded-2xl bg-primary/10 overflow-hidden">
-                <img src={appUrl("/icons/icon-96x96.png")} alt="" width={48} height={48} className="w-10 h-10 sm:w-12 sm:h-12" />
+                <img
+                  src={appUrl("/icons/icon-96x96.png")}
+                  alt=""
+                  width={48}
+                  height={48}
+                  className="w-10 h-10 sm:w-12 sm:h-12"
+                />
               </div>
               <LanguageSelector />
             </div>

--- a/web/src/components/wizard/setup-wizard.tsx
+++ b/web/src/components/wizard/setup-wizard.tsx
@@ -8,6 +8,7 @@ import { Aurora } from "@/components/ui/aurora";
 import { Button } from "@/components/ui/button";
 import { useRouter } from "@/hooks/use-router";
 import { useTranslations } from "@/i18n/translations";
+import { appUrl } from "@/lib/base-path";
 import type { WizardProgress } from "@/lib/setup-detection";
 import { clearWizardProgress, getWizardProgress, markWizardComplete, saveWizardProgress } from "@/lib/setup-detection";
 import { cn } from "@/lib/utils";
@@ -172,7 +173,7 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
             <div className="flex items-center justify-between mb-4">
               <div />
               <div className="inline-flex items-center justify-center w-14 h-14 sm:w-16 sm:h-16 rounded-2xl bg-primary/10 overflow-hidden">
-                <img src="/icons/icon-96x96.png" alt="" width={48} height={48} className="w-10 h-10 sm:w-12 sm:h-12" />
+                <img src={appUrl("/icons/icon-96x96.png")} alt="" width={48} height={48} className="w-10 h-10 sm:w-12 sm:h-12" />
               </div>
               <LanguageSelector />
             </div>

--- a/web/tests/ingress.spec.ts
+++ b/web/tests/ingress.spec.ts
@@ -1,0 +1,160 @@
+/**
+ * HA Ingress E2E regression tests.
+ *
+ * Runs against the HA Ingress simulator (infra/ha-ingress-proxy.conf),
+ * which mimics HA Supervisor's Ingress flow: strips the per-install
+ * prefix `/api/hassio_ingress/test-token` from incoming requests,
+ * forwards to FiestaBoard's nginx with an `X-Ingress-Path` header, and
+ * 404s anything that arrives WITHOUT the prefix — so any URL the SPA
+ * builds that escapes the prefix fails loudly here, exactly like it
+ * does inside Home Assistant.
+ *
+ * The FiestaBoard container must run the PRODUCTION bundle
+ * (`docker build --target runtime`) with
+ * `FIESTABOARD_INGRESS_PATH_REWRITE=true`: the historical escapes were
+ * artifacts of the minified output (rolldown's `__vite__mapDeps`
+ * relative deps resolved by a runtime `"/" + file` helper; backtick
+ * string literals that nginx sub_filter patterns didn't match), which
+ * `vite dev` never exhibits.
+ *
+ * Gated behind RUN_INGRESS_TESTS (mirrors RUN_AUTH_TESTS): the main e2e
+ * matrix talks to the container directly, without the simulator.
+ *
+ * Env:
+ *   BASE_URL        — the simulator origin (e.g. http://localhost:5050)
+ *   INGRESS_PREFIX  — override for the simulated prefix (defaults to
+ *                     the token baked into infra/ha-ingress-proxy.conf)
+ */
+import { expect, type Page, test } from "@playwright/test";
+
+const PREFIX = process.env.INGRESS_PREFIX || "/api/hassio_ingress/test-token";
+// The simulator origin. Everything the SPA requests from this origin must
+// carry the prefix — the simulator 404s anything that doesn't, exactly
+// like Home Assistant would.
+const SIMULATOR_ORIGIN = process.env.BASE_URL ? new URL(process.env.BASE_URL).origin : "";
+
+test.skip(!process.env.RUN_INGRESS_TESTS, "RUN_INGRESS_TESTS not set — ingress simulator not running");
+
+/** Requests that escaped the ingress prefix, and prefixed static assets that 404'd. */
+function trackIngressViolations(page: Page) {
+  const escapes: string[] = [];
+  const notFound: string[] = [];
+
+  page.on("request", (request) => {
+    if (!/^https?:/.test(request.url())) return; // data:/blob: are out of scope
+    const url = new URL(request.url());
+    // Cross-origin URLs (none expected — fonts ship locally) don't go
+    // through the simulator.
+    if (url.origin !== SIMULATOR_ORIGIN) return;
+    if (!url.pathname.startsWith(`${PREFIX}/`) && url.pathname !== PREFIX) {
+      escapes.push(`${request.method()} ${url.pathname}`);
+    }
+  });
+
+  page.on("response", (response) => {
+    if (!/^https?:/.test(response.url())) return;
+    const url = new URL(response.url());
+    if (url.origin !== SIMULATOR_ORIGIN) return;
+    // API endpoints may legitimately return errors on a fresh install
+    // (e.g. 503 "Board client not initialized"); static assets must not.
+    const isStatic = /^\/(assets|icons)\/|\/(favicon\.ico|manifest\.json|sw\.js|registerSW\.js)$/.test(
+      url.pathname.replace(PREFIX, ""),
+    );
+    if (isStatic && response.status() >= 400) {
+      notFound.push(`${response.status()} ${url.pathname}`);
+    }
+  });
+
+  return { escapes, notFound };
+}
+
+function suppressWizard(page: Page) {
+  return page.addInitScript(() => {
+    localStorage.setItem("fiestaboard_wizard_complete", "true");
+  });
+}
+
+test.describe("HA Ingress", () => {
+  test.beforeAll(async ({ request }) => {
+    // Take the fresh container out of first-run mode so routes render
+    // instead of the setup wizard. Going through the prefixed API is
+    // deliberate — it exercises PUT requests through the simulator. The
+    // board host is a placeholder; nothing here reads from the board.
+    await request.put(`${PREFIX}/api/config/board`, {
+      data: { api_mode: "local", local_api_key: "test-key", host: "mock-board" },
+    });
+    await request.put(`${PREFIX}/api/settings/board`, {
+      data: { devices: ["flagship"] },
+    });
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await suppressWizard(page);
+  });
+
+  test("dashboard loads under the prefix with zero escaping requests", async ({ page }) => {
+    const { escapes, notFound } = trackIngressViolations(page);
+
+    await page.goto(`${PREFIX}/`);
+    await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible({ timeout: 15_000 });
+
+    expect(escapes, "requests must stay under the ingress prefix").toEqual([]);
+    expect(notFound, "prefixed static assets must resolve").toEqual([]);
+  });
+
+  test("lazy-route navigation stays under the prefix", async ({ page }) => {
+    // THE historical failure mode: the first route was fine (its chunks
+    // are <link modulepreload> in the sub_filter-rewritten HTML), but
+    // client-side navigation lazy-loads route chunks through Vite's
+    // runtime preload helper, which used to build root-absolute
+    // `/assets/...` URLs that bypassed the prefix and 404'd against the
+    // Home Assistant origin.
+    const { escapes, notFound } = trackIngressViolations(page);
+
+    await page.goto(`${PREFIX}/`);
+    await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible({ timeout: 15_000 });
+
+    for (const [link, heading] of [
+      ["Pages", "Pages"],
+      ["Settings", "Settings"],
+    ] as const) {
+      await page.getByRole("link", { name: link }).first().click();
+      await expect(page.getByRole("heading", { name: heading, exact: true })).toBeVisible({ timeout: 10_000 });
+    }
+
+    expect(escapes, "lazy-route requests must stay under the ingress prefix").toEqual([]);
+    expect(notFound, "lazy-route chunks and icons must resolve").toEqual([]);
+  });
+
+  test("in-app logo icon renders (not just requested)", async ({ page }) => {
+    // The sidebar logo is a JSX `<img src>` that lands in the JS bundle,
+    // where sub_filter can't reliably reach it — it must go through the
+    // runtime base path (appUrl) instead.
+    await page.goto(`${PREFIX}/`);
+    await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible({ timeout: 15_000 });
+
+    // The sidebar renders several logo copies (desktop expanded/collapsed,
+    // mobile) — assert on the one that's actually visible.
+    const logo = page.locator('img[src*="/icons/favicon-32x32.png"]').filter({ visible: true }).first();
+    await expect(logo).toBeVisible({ timeout: 10_000 });
+    expect(await logo.getAttribute("src"), "logo src must carry the ingress prefix").toContain(PREFIX);
+    await expect
+      .poll(async () => logo.evaluate((el: HTMLImageElement) => el.naturalWidth), {
+        message: "logo image bytes must actually load",
+      })
+      .toBeGreaterThan(0);
+  });
+
+  test("deep-route document load resolves under the prefix", async ({ page }) => {
+    // Covers the HTML + React Router basename path for a non-root
+    // document URL (HA reloads the iframe at the panel root, but users
+    // can land on deep links via browser history/bookmarks).
+    const { escapes, notFound } = trackIngressViolations(page);
+
+    await page.goto(`${PREFIX}/pages`);
+    await expect(page.getByRole("heading", { name: "Pages", exact: true })).toBeVisible({ timeout: 15_000 });
+
+    expect(escapes, "deep-route requests must stay under the ingress prefix").toEqual([]);
+    expect(notFound, "deep-route assets must resolve").toEqual([]);
+  });
+});

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -19,19 +19,47 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  * loaded from `/assets/index-X.js` would dynamic-import `./assets/foo.js`
  * which resolves to `/assets/assets/foo.js` (double prefix) → 404.
  *
- * For HA Ingress, the runtime prefix is injected by nginx's sub_filter
- * rewriting `/assets/`, `/sw.js`, `/icons/`, `/manifest.json` in both
- * HTML and JS response bodies (see entrypoint.sh::configure_ingress_path_rewrite).
- * Every asset URL Vite emits lives as a string literal in the build
- * output — nginx can rewrite them all at request time. API request URLs
- * are runtime-concatenated (not literals), so the SPA prefixes them
- * itself via src/lib/base-path.ts instead of relying on sub_filter.
+ * For HA Ingress, the runtime prefix is applied in two complementary ways:
  *
- * Direct deployments (`X-Ingress-Path` absent) get the snippet expanded
- * to no-op substitutions and incur only the gzip-pass-through overhead.
+ * 1. HTML and CSS bodies: nginx sub_filter rewrites `/assets/`, `/sw.js`,
+ *    `/icons/`, `/manifest.json` literals at request time
+ *    (see entrypoint.sh::configure_ingress_path_rewrite).
+ *
+ * 2. JS-hosted asset references: `experimental.renderBuiltUrl` below.
+ *    Since the Vite 8 (rolldown) toolchain, chunk URLs no longer exist as
+ *    `"/assets/..."` string literals in the JS output — `__vite__mapDeps`
+ *    stores RELATIVE `"assets/..."` strings and the preload helper
+ *    concatenates the base at runtime (`assetsURL = f => "/" + f`), and the
+ *    oxc minifier emits backtick-quoted strings sub_filter patterns don't
+ *    match. Both make body rewriting unreliable for JS, so JS-hosted URLs
+ *    are instead routed through `window.__fbAssetUrl`, a classic-script
+ *    global defined in app/root.tsx that prepends the React Router
+ *    basename (the same source of truth src/lib/base-path.ts uses for
+ *    API URLs).
+ *
+ * Direct deployments (`X-Ingress-Path` absent) keep basename "/" so the
+ * runtime helper degrades to the plain absolute path, and the sub_filter
+ * snippet expands to no-op substitutions.
  */
 export default defineConfig({
   base: "/",
+  experimental: {
+    renderBuiltUrl(filename, { hostType }) {
+      if (hostType === "js") {
+        // SSR/prerender never loads assets through this expression, but
+        // guard on `window` anyway so evaluating it outside a browser
+        // (e.g. jsdom without the root.tsx inline script) still yields a
+        // usable root-absolute URL.
+        const file = JSON.stringify(filename);
+        return {
+          runtime: `typeof window!=="undefined"&&window.__fbAssetUrl?window.__fbAssetUrl(${file}):"/"+${file}`,
+        };
+      }
+      // HTML and CSS keep the default absolute `base: "/"` emission,
+      // which nginx sub_filter rewrites under HA Ingress.
+      return undefined;
+    },
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## Problem

Live debugging against a real Home Assistant instance (add-on 8.13.1) showed the app under Ingress fires a ~22-request **404 storm to the HA origin root on every lazy-route navigation**, plus 404s for the in-app logo/favicon, and every backend error reads "Service is starting up, please try again shortly" forever.

Root causes (all verified against the shipped bundle):

1. **The sub_filter assumption is stale since the Vite 8 / rolldown migration.** Chunk URLs no longer exist as `"/assets/..."` literals: `__vite__mapDeps` stores relative `"assets/..."` strings and the preload helper builds the URL at runtime (``assetsURL = e => `/` + e``). No response body ever contains a rewritable literal, so nginx can't fix it.
2. **The oxc minifier emits backtick-quoted strings** (`` `/icons/favicon-32x32.png` ``) which the quote-anchored sub_filter patterns don't match → broken logo/icons under Ingress.
3. **nginx intercepted app-level 503s** (`error_page 502 503 504`), masking real errors like "Failed to read current board message" as eternal "starting up".

## Fix

- `experimental.renderBuiltUrl` routes every JS-hosted asset URL through `window.__fbAssetUrl` — a classic-script global inlined in `root.tsx` `<head>` that prepends the React Router basename, the same source of truth `base-path.ts` already uses for API URLs (#1412). HTML/CSS keep the absolute base + sub_filter path.
- All first-party `/icons/…` JSX srcs and `root.tsx` `links()` hrefs go through `appUrl()`; new eslint `no-restricted-syntax` selectors ban bare absolute asset literals in JSX `src` (probe-tested: catches literal, template, and `{"..."}` forms; ignores `appUrl(...)`-wrapped).
- Backtick sub_filter variants for `/assets/`, `/sw.js`, `/registerSW.js`, `/api/` as third-party defense-in-depth. Deliberately **none** for `/icons/` etc.: those are `appUrl()`-wrapped, so a body rewrite would double-prefix (observed while testing).
- `error_page` narrowed to `502 504` in all three nginx confs so genuine API 503 JSON reaches the UI.

## Regression proofing

New `web/tests/ingress.spec.ts` + `ingress-e2e-tests` CI job: runs the **production** (`--target runtime`) image behind the HA Ingress simulator (`infra/ha-ingress-proxy.conf`, which 404s any un-prefixed request exactly like HA does) and fails on any request that escapes the prefix, any 404ing static asset, and a non-rendering logo. This is the test that would have caught both regressions.

## Verification

- Local harness run against the runtime image: **4/4 ingress tests pass, zero prefix escapes** (previously: 22+ escapes per navigation).
- `/api/board/current-message` with unreachable board now returns `{"detail":"Failed to read current board message"}` through the proxy instead of the masked "starting up" message.
- eslint: 0 errors; tsc: 146 errors (identical to main); vitest: only the pre-existing `language-selector` failure that also fails on pristine `origin/main`.

Fixes the remaining Fiestaboard/FiestaBoard-Home-Assistant-App#48 fallout on 8.13.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)