### PR TITLE
chore(web): bump @fiestaboard/ui to 0.4.0

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "web",
-  "version": "8.14.0",
+  "version": "8.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "8.14.0",
+      "version": "8.15.0",
       "dependencies": {
         "@codemirror/commands": "^6.10.4",
         "@codemirror/language": "^6.12.4",
         "@codemirror/state": "^6.7.1",
         "@codemirror/view": "^6.43.7",
-        "@fiestaboard/ui": "^0.3.0",
+        "@fiestaboard/ui": "^0.4.0",
         "@lezer/highlight": "^1.2.3",
         "@microsoft/fetch-event-source": "^2.0.1",
         "@react-router/fs-routes": "^8.3.0",
@@ -2973,9 +2973,9 @@
       }
     },
     "node_modules/@fiestaboard/ui": {
-      "version": "0.3.0",
-      "resolved": "https://npm.pkg.github.com/download/@fiestaboard/ui/0.3.0/c3dd006a5135aad6413c6d04ce5dc433b8b51268",
-      "integrity": "sha512-C1nUjGpr4EDxlQLqTT1QZv9HJ3p4JWMD5YGrtooZ6dwdSdb8SbqwXvFlpFd0X67tO8xiiJhnzrd2Z08IHCrRfg==",
+      "version": "0.4.0",
+      "resolved": "https://npm.pkg.github.com/download/@fiestaboard/ui/0.4.0/b320f040f9f22b01b62e54f0f516767d72dd8a05",
+      "integrity": "sha512-irxvkYrbmuyHpZcHa9K/ULRt7wDGIlcPoXTPZze4Y2fsXfliHl+WD6ua1HHJj9EZk6fkfZ80BbRPHN5LmREXvg==",
       "license": "MIT",
       "dependencies": {
         "@base-ui/react": "^1.6.0",

--- a/web/package.json
+++ b/web/package.json
@@ -27,7 +27,7 @@
     "@codemirror/language": "^6.12.4",
     "@codemirror/state": "^6.7.1",
     "@codemirror/view": "^6.43.7",
-    "@fiestaboard/ui": "^0.3.0",
+    "@fiestaboard/ui": "^0.4.0",
     "@lezer/highlight": "^1.2.3",
     "@microsoft/fetch-event-source": "^2.0.1",
     "@react-router/fs-routes": "^8.3.0",


### PR DESCRIPTION
Routine design-system bump: [FiestaUI v0.4.0](https://github.com/Fiestaboard/FiestaUI/releases/tag/v0.4.0).

- **Interactive Storybook catalog** — 275 stories with full controls (Sidebar Playground, Seasons preview gallery)
- **DRAFT_SEASONS registry** — 7 designed seasonal themes (Halloween, Thanksgiving, Christmas, New Year, Easter, Mother's Day, Father's Day) that are **Storybook-preview only**: `getActiveSeason()` consults only `SEASONS`, so the app still activates Pride alone and there are no runtime or visual changes
- **Packaging fix** — seasonal CSS files now ship in `dist/` so `theme.css` imports resolve

Verified: lockfile regenerated in-container against GitHub Packages; production web build succeeds with the new version (CSS import resolution exercised).

🤖 Generated with [Claude Code](https://claude.com/claude-code)