### PR TITLE
docs: spec — FiestaUI primitive adoption (zero raw HTML in web app)

### DIFF
--- a/docs/superpowers/plans/2026-08-02-fiestaui-primitives-migration.md
+++ b/docs/superpowers/plans/2026-08-02-fiestaui-primitives-migration.md
@@ -1,0 +1,199 @@
+# FiestaUI Primitives Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace essentially all raw HTML in `web/app/**` and `web/src/**` with `@fiestaboard/ui` components, then make it permanent with an ESLint rule.
+
+**Architecture:** Six independent wave PRs into `main`, each applying the same mechanical recipe to a fixed file list, verified by the existing CI suites plus before/after screenshots. The final wave flips on `react/forbid-elements`. Spec: `docs/superpowers/specs/2026-08-02-fiestaui-primitives-adoption-design.md`.
+
+**Tech Stack:** React 19, React Router v7, `@fiestaboard/ui` (needs the minor release from the companion FiestaUI plan `docs/superpowers/plans/2026-08-02-primitives-for-zero-raw-html.md` in the FiestaUI repo), ESLint 9 flat config with `eslint-plugin-react`.
+
+## Global Constraints
+
+- **Prerequisite:** `web/package.json` must be on the `@fiestaboard/ui` minor that ships `Text`/`Heading`/`Code`/`TextLink`/`List`/`Table`/`Box` (delivered by the evergreen upgrade PR #1471 pipeline). Waves 1–6 cannot start before it lands on `main`.
+- Never run `npm install`/`npm run dev` on the host (CLAUDE.md). All checks run in Docker: `docker compose -f docker-compose.dev.yml run --rm --profile test web sh -c "npm ci && npm run typecheck && npm run lint && npm run format:check && npm test"`.
+- Each wave: its own feature branch off fresh `main` (`feat-primitives-wave-N`), own PR, straight to `main`. Use an isolated worktree (concurrent sessions share the main checkout).
+- Prettier runs in CI (`lint-web` fails on `prettier --check`) — run `npm run format` in the container before pushing.
+- Normalization is bounded to the blessed variant scales (table below). Anything that cannot snap cleanly: keep the exact classes via `className` on the primitive, and log the pattern as a comment on the epic issue — recurring patterns get promoted to FiestaUI variants instead of repeated one-offs.
+- Visual evidence per wave: run the branch's prod image on `:4499` (`docker build -t fiestaboard-wave-test . && docker run --rm -d -p 4499:3000 --name fiestaboard-wave-test fiestaboard-wave-test`), screenshot each affected screen before/after, attach to the PR.
+- Do not migrate: `**/__tests__/**`, `*.stories.tsx`, anything under `web/tests/`.
+
+## The Migration Recipe (applies to every wave)
+
+Work file-by-file. For each raw element, pick the first matching row:
+
+| Raw pattern | Replacement (`@fiestaboard/ui`) |
+|---|---|
+| `<div className="flex items-center justify-between gap-4">` | `<Flex align="center" justify="between" gap="4">` |
+| `<div className="flex flex-col gap-2">` or `<div className="space-y-2">` | `<Stack gap="2">` |
+| `<div className="grid grid-cols-2 gap-4">` | `<Grid cols="2" gap="4">` |
+| `<div className="flex ...">` with extra classes (borders, padding, colors) | `Flex`/`Stack` variant props for layout + keep the rest in `className` |
+| any other `div` (positioned overlays, portal/canvas hosts, plain wrappers) | `<Box className="...">` (or `<Box as="section">` etc. for semantic elements) |
+| `<p className="text-sm text-muted-foreground">` | `<Text tone="muted">` |
+| `<p>` / `<p className="text-sm">` | `<Text>` (Text defaults to `size="sm"`) |
+| `<span className="text-xs ...">` | `<Text as="span" size="xs">` |
+| `<h2>`/`<h3>`/`<h4>` with title styling | `<Heading level={3} size="...">` (level = same element as before; `h1` stays `PageHeader`) |
+| `<code className="...">` (inline) | `<Code>` |
+| `<a href ...>` (plain anchor) | `<TextLink href ...>` — react-router `<Link>`/`<NavLink>` stay as they are |
+| `<ul className="space-y-1">` + `<li>` | `<List gap="1">` + `<ListItem>` |
+| `<ol className="list-decimal ...">` | `<List as="ol" marker="decimal">` |
+| `<table>`/`<thead>`/`<tbody>`/`<tr>`/`<th>`/`<td>` | `Table`/`TableHeader`/`TableBody`/`TableRow`/`TableHead`/`TableCell` (drop any hand-rolled `overflow-x-auto` wrapper div — `Table` brings its own) |
+| `<form>` | `<Box as="form">` |
+| `<section>`/`<main>`/`<header>`/`<footer>`/`<nav>` | `<Box as="section">` etc. (unless a chrome component like `MainContent` already covers it) |
+| `<strong>` | `<Text as="span" weight="semibold">` |
+| `svg`, `canvas`, `iframe`, `img`, `br`, `em`, `small`, `kbd`, `pre`, `figure`, `dl`, `dt`, `dd` | **leave raw** (allowlisted) |
+
+**Normalization snapping (intentional visual diffs, reviewed via screenshots):**
+
+- Gap/spacing snaps to the enumerated scale `0, 0.5, 1, 1.5, 2, 2.5, 3, 4, 5, 6, 8, 12`: `gap-7`→`gap="6"`, `space-y-10`→`gap="8"` (nearest step; ties round down).
+- Arbitrary font sizes snap to `xs/sm/base/lg`: `text-[13px]`→`size="sm"`, `text-[11px]`→`size="xs"`.
+- Muted/status text colors snap to `tone` values instead of hand-picked grays.
+- Title-ish font styling on headings snaps to `Heading`'s built-in recipe (`font-semibold leading-none tracking-tight`).
+
+**Worked example** (real code, `src/components/settings/about-card.tsx`):
+
+Before:
+
+```tsx
+<dl className="space-y-3 text-sm">
+  <div className="flex items-center justify-between gap-4">
+    <dt className="text-muted-foreground">{t("status")}</dt>
+    <dd>
+      {isLoadingStatus ? <Skeleton className="h-5 w-16" /> : statusBadge}
+    </dd>
+  </div>
+</dl>
+```
+
+After (`dl`/`dt`/`dd` are allowlisted and stay raw; the layout `div` becomes `Flex`):
+
+```tsx
+<dl className="space-y-3 text-sm">
+  <Flex align="center" justify="between" gap="4">
+    <dt className="text-muted-foreground">{t("status")}</dt>
+    <dd>
+      {isLoadingStatus ? <Skeleton className="h-5 w-16" /> : statusBadge}
+    </dd>
+  </Flex>
+</dl>
+```
+
+**Import style:** extend the existing `import { ... } from "@fiestaboard/ui";` line in each file (98 files already have one).
+
+**Per-file definition of done:** `grep -nE '<(div|span|p|h[1-6]|ul|ol|li|section|main|header|footer|nav|form|table|thead|tbody|tr|td|th|a|code|strong)\b' <file>` returns only react-router `Link` false-positives or nothing.
+
+## Wave Task Template (Tasks 1–5 all follow this shape)
+
+- [ ] **Step 1:** Create worktree + branch: `git worktree add .claude/worktrees/feat-primitives-wave-N -b feat-primitives-wave-N origin/main`
+- [ ] **Step 2:** Apply the recipe to every file in the wave's list (below). Commit in chunks of 5–8 files: `git commit -m "refactor: migrate <area> to @fiestaboard/ui primitives (wave N)"`
+- [ ] **Step 3:** Verify in Docker (from repo root): `docker compose -f docker-compose.dev.yml run --rm --profile test web sh -c "npm ci && npm run typecheck && npm run lint && npm run format:check && npm test"` → all PASS (run `npm run format` in-container and re-commit if format:check fails)
+- [ ] **Step 4:** Build + run the branch image on `:4499`, screenshot every affected screen (before = same screens on `main`'s image), eyeball for unintended drift beyond the snapping table
+- [ ] **Step 5:** Push, open PR titled `refactor: adopt FiestaUI primitives — wave N (<area>)`, attach screenshots, link the epic
+- [ ] **Step 6:** After merge, delete the worktree: `git worktree remove .claude/worktrees/feat-primitives-wave-N`
+
+### Task 1: Wave 1 — app root + routes (14 files)
+
+**Files (Modify):** `web/app/root.tsx`, `web/app/routes/collections.tsx`, `web/app/routes/debug.tsx`, `web/app/routes/home.tsx`, `web/app/routes/integrations._index.tsx`, `web/app/routes/integrations.$pluginId.tsx`, `web/app/routes/login.tsx`, `web/app/routes/offline.tsx`, `web/app/routes/pages._index.tsx`, `web/app/routes/pages.edit._index.tsx`, `web/app/routes/picks.tsx`, `web/app/routes/schedule.tsx`, `web/app/routes/settings.tsx`, `web/app/routes/transitions.tsx`
+
+Steps: template above. Screens to screenshot: `/`, `/login`, `/pages`, `/pages/edit`, `/integrations`, `/integrations/date_time`, `/schedule`, `/collections`, `/transitions`, `/picks`, `/settings`, `/debug`, `/offline`.
+Note: `app/routes/debug.tsx` contains tables → `Table` set. `app/root.tsx` layout scaffolding that isn't covered by `MainContent`/`SkipToContent` chrome becomes `Box`.
+
+### Task 2: Wave 2 — src/components top-level, A–O (20 files)
+
+**Files (Modify):** `web/src/components/account-section.tsx`, `active-page-display.tsx`, `ai-action-confirmation.tsx`, `ai-chat-panel.tsx`, `board-display.tsx`, `board-size-indicator.tsx`, `boot-gate.tsx`, `chaining-mode-picker.tsx`, `chat-markdown.tsx`, `config-display.tsx`, `day-selector.tsx`, `drawable-board-preview.tsx`, `force-set-dialog.tsx`, `general-settings.tsx`, `global-ai-chat-drawer.tsx`, `home-assistant-entity-picker.tsx`, `inline-board-preview.tsx`, `install-prompt.tsx`, `navigation-sidebar.tsx`, `output-target-selector.tsx` (all under `web/src/components/`)
+
+Steps: template above. Screens: dashboard, AI chat drawer, board preview states, navigation sidebar (desktop + mobile).
+Note: board-display/drawable-board-preview have canvas/positioned hosts → `Box`, keep exact classes; do NOT snap board-geometry pixel values.
+
+### Task 3: Wave 3 — src/components top-level, P–Z + i18n (20 files)
+
+**Files (Modify):** `web/src/components/page-builder.tsx`, `page-editor-shell.tsx`, `page-grid-selector.tsx`, `page-picker-dialog.tsx`, `plain-text-editor.tsx`, `scaled-board-display.tsx`, `schedule-entry-form.tsx`, `service-controls.tsx`, `service-status.tsx`, `sidebar-account.tsx`, `silence-imminent-banner.tsx`, `silence-mode-status.tsx`, `smart-link.tsx`, `static-board-display.tsx`, `update-context.tsx`, `variable-autocomplete-textarea.tsx`, `variable-rule-row.tsx`, `version-display.tsx`, `wizard-provider.tsx` (under `web/src/components/`) plus `web/src/i18n/translations.tsx`
+
+Steps: template above. Screens: page editor, schedule entry form, service status/controls (settings), account section.
+Note: `smart-link.tsx` wraps router links — router `Link` stays; only plain `<a>` branches become `TextLink`.
+
+### Task 4: Wave 4 — settings components (25 files)
+
+**Files (Modify):** all 25 `web/src/components/settings/*.tsx`: `about-card.tsx`, `accessibility-settings.tsx`, `ai-settings.tsx`, `animation-settings.tsx`, `appearance-settings.tsx`, `auto-update-interval.tsx`, `backup-settings.tsx`, `beta-settings.tsx`, `board-settings.tsx`, `debug-settings.tsx`, `display-settings.tsx`, `festive-months-settings.tsx`, `instance-name.tsx`, `location-settings.tsx`, `mcp-settings.tsx`, `mqtt-settings.tsx`, `network-settings.tsx`, `plugin-settings.tsx`, `silence-schedule.tsx`, `system-controls.tsx`, `system-update.tsx`, `tile-grid-assignment.tsx`, `time-and-date.tsx`, `transition-settings.tsx`, `update-intervals.tsx`
+
+Steps: template above. Screens: every `/settings` tab, light + dark.
+Note: settings tables (backup list, debug info) → `Table` set; `about-card.tsx`'s `dl/dt/dd` stay raw per allowlist (worked example above).
+
+### Task 5: Wave 5 — tiptap template editor (14 files)
+
+**Files (Modify):** `web/src/components/tiptap-template-editor/TipTapTemplateEditor.tsx`, `components/ColorPickerContent.tsx`, `components/DrawCharPickerContent.tsx`, `components/FilterPickerContent.tsx`, `components/FormattingPickerContent.tsx`, `components/FormulaEditorPanel.tsx`, `components/TemplateEditorToolbar.tsx`, `components/ToolbarDropdown.tsx`, `components/VariablePickerContent.tsx`, `node-views/ColorTileNodeView.tsx`, `node-views/FillSpaceNodeView.tsx`, `node-views/FormulaNodeView.tsx`, `node-views/VariableNodeView.tsx`, `node-views/WrappedTextView.tsx`
+
+Steps: template above. Screens: template editor with variables, formulas, color tiles, all toolbar pickers open; run draw-mode e2e specs.
+Note: NodeViews render inside TipTap's contentEditable — character-grid geometry is pixel-load-bearing. Layout `div`s here that carry grid metrics keep exact classes via `Box className` (no snapping); only chrome around the editor normalizes.
+
+### Task 6: Wave 6 — remainder + ESLint flip
+
+**Files:**
+- Modify: `web/src/components/wizard/setup-wizard.tsx`, `step-board-setup.tsx`, `step-easy-plugins.tsx`, `step-welcome.tsx`; `web/src/components/schedule/schedule-calendar-view.tsx`, `schedule-event.tsx`, `schedule-list-view.tsx`; `web/src/components/transitions/transition-grid-display.tsx`; `web/src/components/plugin-settings/schema-form.tsx`; `web/src/components/ui/sonner.tsx`, `time-picker.tsx`, `timezone-picker.tsx`
+- Modify: `web/eslint.config.mjs`
+
+- [ ] **Step 1–2:** Worktree + apply recipe to the 12 files (template above)
+- [ ] **Step 3: Add the enforcement rule** — in `web/eslint.config.mjs`, append a new config object after the existing main block:
+
+```js
+// Design-system enforcement: app code renders @fiestaboard/ui components,
+// not raw HTML. Allowlisted leaves (svg, canvas, iframe, img, br, em,
+// small, kbd, pre, figure, dl, dt, dd) are simply not listed here.
+{
+  files: ["app/**/*.tsx", "src/**/*.tsx"],
+  ignores: ["src/**/__tests__/**", "**/*.stories.tsx"],
+  rules: {
+    "react/forbid-elements": [
+      "error",
+      {
+        forbid: [
+          { element: "div", message: "Use Flex/Stack/Grid for layout, or Box (@fiestaboard/ui)" },
+          { element: "span", message: 'Use Text as="span" (@fiestaboard/ui)' },
+          { element: "p", message: "Use Text (@fiestaboard/ui)" },
+          { element: "h1", message: "Use PageHeader (@fiestaboard/ui)" },
+          { element: "h2", message: "Use Heading level={2} (@fiestaboard/ui)" },
+          { element: "h3", message: "Use Heading level={3} (@fiestaboard/ui)" },
+          { element: "h4", message: "Use Heading level={4} (@fiestaboard/ui)" },
+          { element: "h5", message: "Use Heading (@fiestaboard/ui)" },
+          { element: "h6", message: "Use Heading (@fiestaboard/ui)" },
+          { element: "ul", message: "Use List (@fiestaboard/ui)" },
+          { element: "ol", message: 'Use List as="ol" (@fiestaboard/ui)' },
+          { element: "li", message: "Use ListItem (@fiestaboard/ui)" },
+          { element: "section", message: 'Use Box as="section" (@fiestaboard/ui)' },
+          { element: "main", message: 'Use MainContent or Box as="main" (@fiestaboard/ui)' },
+          { element: "header", message: 'Use Box as="header" (@fiestaboard/ui)' },
+          { element: "footer", message: 'Use Box as="footer" (@fiestaboard/ui)' },
+          { element: "nav", message: 'Use Box as="nav" (@fiestaboard/ui)' },
+          { element: "form", message: 'Use Box as="form" (@fiestaboard/ui)' },
+          { element: "table", message: "Use Table (@fiestaboard/ui)" },
+          { element: "thead", message: "Use TableHeader (@fiestaboard/ui)" },
+          { element: "tbody", message: "Use TableBody (@fiestaboard/ui)" },
+          { element: "tr", message: "Use TableRow (@fiestaboard/ui)" },
+          { element: "th", message: "Use TableHead (@fiestaboard/ui)" },
+          { element: "td", message: "Use TableCell (@fiestaboard/ui)" },
+          { element: "a", message: "Use TextLink, or the router Link for navigation (@fiestaboard/ui)" },
+          { element: "code", message: "Use Code (@fiestaboard/ui)" },
+          { element: "strong", message: 'Use Text as="span" weight="semibold" (@fiestaboard/ui)' },
+        ],
+      },
+    ],
+  },
+},
+```
+
+- [ ] **Step 4: Run lint expecting zero violations** — `docker compose -f docker-compose.dev.yml run --rm --profile test web sh -c "npm ci && npm run lint"`. Every hit is either a file missed by an earlier wave (fix it now, this is the sweep-up gate) or a legitimate `Box`/allowlist case.
+- [ ] **Step 5:** Full Docker verify + screenshots (wizard, schedule views, transitions picker, toasts, time/timezone pickers)
+- [ ] **Step 6:** Push, PR `refactor: adopt FiestaUI primitives — wave 6 (remainder) + forbid-elements rule`, link epic, note in the body that this closes the epic
+
+---
+
+## Epic Bookkeeping
+
+Create the epic issue before Wave 1 (after the FiestaUI minor lands): title `Epic: adopt FiestaUI primitives — zero raw HTML in web app`, body = link to the spec + this plan + a checklist of the 6 waves. Each wave PR references it. Patterns that couldn't snap cleanly are logged as comments; recurring ones become FiestaUI issues.
+
+## Self-Review Notes
+
+- All 105 files from the raw-tag sweep are assigned to exactly one wave (14 + 20 + 20 + 25 + 14 + 12 = 105). Re-run the sweep grep at execution time and slot any newly-added files into the matching wave.
+- The recipe table covers every element the lint rule bans; the allowlist matches the spec exactly.
+- Interfaces: primitive names/props used in the recipe match the FiestaUI plan's Produces blocks (`Text` defaults `size="sm"`; `Heading` takes `level={2|3|4}`; `List` takes `as/marker/gap`; `Box` takes `as`).
+- Known risk carried from the spec: if the evergreen upgrade PR mislabels `upgrade-blocked` (flaky baseline check), verify FiestaBoard CI directly and merge manually.

--- a/docs/superpowers/plans/2026-08-02-fiestaui-primitives-migration.md
+++ b/docs/superpowers/plans/2026-08-02-fiestaui-primitives-migration.md
@@ -43,6 +43,8 @@ Work file-by-file. For each raw element, pick the first matching row:
 | `<strong>` | `<Text as="span" weight="semibold">` |
 | `svg`, `canvas`, `iframe`, `img`, `br`, `em`, `small`, `kbd`, `pre`, `figure`, `dl`, `dt`, `dd` | **leave raw** (allowlisted) |
 
+**⚠️ Inline-span sharp edge (from FiestaUI's final review):** a raw `<span>` inherits size/color/weight from its context; `<Text as="span">` resets all three to its defaults (`text-sm text-foreground font-normal`). Do NOT mechanically swap spans inside colored/sized contexts (badges, alerts, buttons, headings) — either pass matching `size`/`tone`/`weight` props, or if the span exists purely for semantics/hooks with fully inherited styling, leave it raw only if allowlisted; otherwise carry the context explicitly. Same for bare `<ul>` → `List`: `gap` defaults to `"1"`, so pass `gap="0"` when the original had no spacing.
+
 **Normalization snapping (intentional visual diffs, reviewed via screenshots):**
 
 - Gap/spacing snaps to the enumerated scale `0, 0.5, 1, 1.5, 2, 2.5, 3, 4, 5, 6, 8, 12`: `gap-7`→`gap="6"`, `space-y-10`→`gap="8"` (nearest step; ties round down).

--- a/docs/superpowers/specs/2026-08-02-fiestaui-primitives-adoption-design.md
+++ b/docs/superpowers/specs/2026-08-02-fiestaui-primitives-adoption-design.md
@@ -1,0 +1,80 @@
+# FiestaUI Primitive Adoption — Design
+
+**Date:** 2026-08-02
+**Status:** Approved
+**Scope:** Two repos — `Fiestaboard/FiestaUI` (new primitives) and `Fiestaboard/FiestaBoard` (full migration + enforcement)
+
+## Goal
+
+Eliminate essentially all raw HTML from FiestaBoard's web app code (`web/app/**`, `web/src/**`). Every element the app renders comes from `@fiestaboard/ui` — either an existing component, a new primitive added by this project, or the typed `Box` escape hatch. An ESLint rule makes the state permanent.
+
+## Current state (measured on `fiestaui-upgrade` @ v1.0.1, 2026-08-02)
+
+- 98 files already import `@fiestaboard/ui`; the local `web/src/components/ui/` dir is down to three app-specific components (`sonner`, `time-picker`, `timezone-picker`).
+- FiestaUI v1.0.x already exports layout primitives `Flex`, `Stack`, `Grid` (cva variants, enumerated gap scale) plus the `Page*` chrome, used in ~10 routes.
+- Remaining raw HTML in app code (excluding tests/stories): ~1,119 `div`, ~297 `span`, ~242 `p`, then a tail: 32 `code`, 20 `a`, 14 `li`, 11 `strong`, 11 `h3`, 10 `ul`, 9 `h2`, 8 `form`, 7 `table` (+ scattered `section`, `img`, `dl`, `ol`, `h4`, `nav`). Spread over ~100 files: 38 `src/components` top-level, 25 `src/components/settings`, 13 `app/routes`, 14 tiptap editor, ~10 misc (wizard, schedule, transitions, plugin-settings).
+
+## Decisions (with rationale)
+
+1. **Full sweep, upstream-first.** Extend FiestaUI with the missing primitives, then migrate everything. Layout-only was rejected: typography is a third of the surface and the user wants ~zero custom HTML.
+2. **Normalize while migrating.** Primitives expose a small set of blessed variants; near-miss styles snap to the nearest variant (e.g. `space-y-3` → `Stack gap="3"`, `text-[13px]` → `size="sm"`). Small intentional visual diffs are reviewed per wave. Strict pixel parity was rejected — it would encode today's inconsistencies into the design system.
+3. **ESLint ban + allowlist**, error severity, landing with the final wave. Convention-only drifts, especially with agent-written PRs.
+4. **Epic + wave PRs via agents**, straight into `main` (no integration branch — waves are independent and individually green).
+5. **Semantic primitive set + Box** (rejected: one polymorphic Box for everything — weaker semantics, harder to lint, off-style for this codebase).
+
+## Part 1 — FiestaUI additions
+
+New components in `src/components/ui/`, matching the existing cva-variant house style (enumerated variants so every emitted class is statically visible to the Tailwind v4 scanner). Each ships with a Storybook story and VRT baseline. Released as a **minor**; the Downstream Upgrade pipeline delivers it to FiestaBoard automatically.
+
+| Primitive | Renders | Variants | Replaces |
+|---|---|---|---|
+| `Text` | `p` or `span` via `as` (default `p`) | `size` xs/sm/base/lg · `tone` default/muted/destructive/success · `weight` normal/medium/semibold | ~540 `p`/`span` |
+| `Heading` | `h2`–`h4` via `level` | `size` decoupled from level, default = v1.0.0 unified title typography | ~20 headings (`h1` remains `PageHeader`'s job) |
+| `Code` | `code` | inline chip style | 32 uses |
+| `TextLink` | `a` | canonical link + focus-ring recipe | 20 uses |
+| `List` / `ListItem` | `ul`/`ol` via `as` | `marker` none/disc/decimal · `gap` scale | ~25 uses |
+| `Table`, `TableHeader`, `TableBody`, `TableRow`, `TableHead`, `TableCell` | table elements | house table style | 7 tables (settings/debug) |
+| `Box` | `div`/`section`/`main`/`nav`/`header`/`footer`/`form` via `as` | none — unstyled, `className` pass-through | genuinely custom layout: positioned overlays, portal hosts, canvas wrappers |
+
+`Box` is what keeps "zero raw HTML" honest: anything that fits no styled primitive uses `Box` rather than a lint-disable comment.
+
+Suggested PR slicing upstream: ① `Text`/`Heading`/`Code`/`TextLink` ② `List`/`Table` set ③ `Box` (+ export barrel, stories, VRT).
+
+## Part 2 — FiestaBoard migration
+
+- Layout `div`s → `Flex`/`Stack`/`Grid`; typography → `Text`/`Heading`; tail → `Code`/`TextLink`/`List`/`Table`; remainder → `Box`.
+- Semantics preserved: primitives render real `p`/`ul`/`table` elements, so the accessibility tree is unchanged where intended; the a11y (light/dark) and Playwright suites are the regression net.
+- Each wave PR includes before/after screenshots of affected screens (normalization diffs are intentional and reviewed).
+- Recurring patterns that fit no primitive get logged on the epic; if a pattern recurs, it becomes a FiestaUI variant, not a repeated one-off `className`.
+
+### Enforcement
+
+`react/forbid-elements` (severity **error**) in `web/eslint` config, scoped to `app/**` and `src/**` (tests/stories excluded), banning: `div span p h1 h2 h3 h4 h5 h6 ul ol li section main header footer nav form table thead tbody tr td th a code strong`. Each entry's message names the replacement (e.g. `div → Flex/Stack/Grid/Box`, `strong → Text weight="semibold"`). Allowlist (stays raw, semantic leaves with no primitive counterpart): `svg` and children, `canvas`, `iframe`, `img`, `br`, `em`, `small`, `kbd`, `pre`, `figure`, `dl`, `dt`, `dd`. The three local ui components migrate like everything else. The rule lands **with the final wave** so CI never lies red mid-migration.
+
+## Part 3 — Delivery
+
+GitHub epic in FiestaBoard with sub-issues:
+
+| # | Wave | Files (approx) |
+|---|---|---|
+| 0 | FiestaUI primitives (3 upstream PRs → minor release → evergreen PR delivers) | — |
+| 1 | `app/routes` + app root | 13 |
+| 2 | `src/components` top-level, half A | ~19 |
+| 3 | `src/components` top-level, half B | ~19 |
+| 4 | `src/components/settings` | 25 |
+| 5 | tiptap template editor | 14 |
+| 6 | wizard/schedule/transitions/plugin-settings/misc + local ui trio + **ESLint rule flip** | ~12 |
+
+One agent per wave, each PR runs full web CI plus screenshot review by the maintainer. Waves 1–6 depend on wave 0 having landed in FiestaBoard via the upgrade PR.
+
+## Error handling / risks
+
+- **Tailwind class scanning:** primitives use enumerated cva variants only — no dynamic class construction — so the `@source` contract with the package keeps working.
+- **Visual drift beyond intent:** normalization is bounded to the blessed variant scales; anything that can't snap cleanly is escalated on the epic rather than eyeballed.
+- **Downstream pipeline coupling:** wave 0 rides the evergreen upgrade PR (`fiestaui-upgrade`); if its fix-loop mislabels (`upgrade-blocked` false positives from the flaky baseline check — known issue, see below), the bump can be verified and merged manually.
+- **Known follow-up (out of scope):** the Downstream Upgrade workflow's baseline validation intermittently fails on main's full-suite vitest flakes and skips fix attempts / mislabels the PR; it should filter known flakes or rerun-failed. Tracked separately in FiestaUI.
+
+## Testing
+
+- FiestaUI: unit/story coverage per primitive + VRT baselines; `npm run lint/typecheck/build/build-storybook` gates.
+- FiestaBoard: existing vitest + Playwright + a11y suites per wave; no new test infrastructure required. The ESLint rule is itself the permanent regression test for the "no raw HTML" invariant.


### PR DESCRIPTION
Approved design spec for extending FiestaUI with Text/Heading/Code/TextLink/List/Table/Box primitives and migrating all raw HTML in `web/app`+`web/src` to design-system components, enforced by an ESLint `forbid-elements` rule. Delivery: epic + 6 agent wave PRs, upstream primitives first via the evergreen upgrade pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)