### PR TITLE
refactor: adopt FiestaUI primitives — wave 1 (app root + routes)

### DIFF
--- a/web/app/root.tsx
+++ b/web/app/root.tsx
@@ -14,7 +14,7 @@
  */
 import "./globals.css";
 
-import { PageIconGradientDefs } from "@fiestaboard/ui";
+import { Box, PageIconGradientDefs } from "@fiestaboard/ui";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Links, Meta, Outlet, Scripts, ScrollRestoration } from "react-router";
@@ -195,5 +195,5 @@ function RootBody() {
  * is just the visible body content.
  */
 export function HydrateFallback() {
-  return <div style={{ minHeight: "100vh" }} />;
+  return <Box style={{ minHeight: "100vh" }} />;
 }

--- a/web/app/routes/collections.tsx
+++ b/web/app/routes/collections.tsx
@@ -841,7 +841,7 @@ export default function CollectionsPage() {
                           {i + 1}.
                         </Text>
                       )}
-                      <Text as="span" size="xs" className="truncate">
+                      <Text as="span" size="xs" className="truncate text-secondary-foreground">
                         {getPageName(pid)}
                       </Text>
                     </Badge>

--- a/web/app/routes/collections.tsx
+++ b/web/app/routes/collections.tsx
@@ -8,12 +8,14 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
   Badge,
+  Box,
   Button,
   Card,
   CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
+  Flex,
   Input,
   Label,
   PageHeader,
@@ -30,6 +32,8 @@ import {
   SheetHeader,
   SheetTitle,
   Skeleton,
+  Stack,
+  Text,
 } from "@fiestaboard/ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
@@ -341,9 +345,9 @@ function CollectionForm({ collection, pages, onSubmit, onCancel, onDelete }: Col
       (defaultPageId.length > 0 && rules.every((r) => r.expression.trim().length > 0 && r.page_id.length > 0)));
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-6 mt-4">
+    <Box as="form" onSubmit={handleSubmit} className="space-y-6 mt-4">
       {/* Name */}
-      <div className="space-y-2">
+      <Stack gap="2">
         <Label htmlFor="collection-name">{t("nameLabel")}</Label>
         <Input
           id="collection-name"
@@ -352,49 +356,51 @@ function CollectionForm({ collection, pages, onSubmit, onCancel, onDelete }: Col
           placeholder={t("namePlaceholder")}
           maxLength={100}
         />
-      </div>
+      </Stack>
 
       {/* Selection mode */}
-      <div className="space-y-2">
+      <Stack gap="2">
         <Label htmlFor="collection-mode">{t("selectionModeLabel")}</Label>
-        <p className="text-xs text-muted-foreground">{t("selectionModeDescription")}</p>
+        <Text size="xs" tone="muted">
+          {t("selectionModeDescription")}
+        </Text>
         <Select value={selectionMode} onValueChange={(v) => setSelectionMode(v as CollectionSelectionMode)}>
           <SelectTrigger id="collection-mode">
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="time">
-              <div className="flex items-center gap-2">
+              <Flex align="center" gap="2">
                 <Clock className="h-4 w-4" aria-hidden="true" />
-                <span>{t("modeTimeLabel")}</span>
-              </div>
+                <Text as="span">{t("modeTimeLabel")}</Text>
+              </Flex>
             </SelectItem>
             <SelectItem value="variable">
-              <div className="flex items-center gap-2">
+              <Flex align="center" gap="2">
                 <Sigma className="h-4 w-4" aria-hidden="true" />
-                <span>{t("modeVariableLabel")}</span>
+                <Text as="span">{t("modeVariableLabel")}</Text>
                 <Badge variant="outline" className="text-[10px] uppercase tracking-wide ml-1 py-0">
                   {t("betaBadge")}
                 </Badge>
-              </div>
+              </Flex>
             </SelectItem>
             <SelectItem value="random">
-              <div className="flex items-center gap-2">
+              <Flex align="center" gap="2">
                 <Shuffle className="h-4 w-4" aria-hidden="true" />
-                <span>{t("modeRandomLabel")}</span>
-              </div>
+                <Text as="span">{t("modeRandomLabel")}</Text>
+              </Flex>
             </SelectItem>
           </SelectContent>
         </Select>
-      </div>
+      </Stack>
 
       {/* Page-duration controls (time + random modes) */}
       {(selectionMode === "time" || selectionMode === "random") && (
-        <div className="space-y-2">
+        <Stack gap="2">
           <Label htmlFor="collection-interval">{t("pageDurationLabel")}</Label>
-          <p className="text-xs text-muted-foreground">
+          <Text size="xs" tone="muted">
             {selectionMode === "random" ? t("randomDurationDescription") : t("pageDurationDescription")}
-          </p>
+          </Text>
           <Select value={String(intervalSeconds)} onValueChange={(v) => setIntervalSeconds(Number(v))}>
             <SelectTrigger id="collection-interval">
               <SelectValue />
@@ -407,36 +413,38 @@ function CollectionForm({ collection, pages, onSubmit, onCancel, onDelete }: Col
               ))}
             </SelectContent>
           </Select>
-        </div>
+        </Stack>
       )}
 
       {/* Selected Pages (reorderable) */}
-      <div className="space-y-2">
+      <Stack gap="2">
         <Label>{t("pagesInCollection")}</Label>
-        <p className="text-xs text-muted-foreground">
+        <Text size="xs" tone="muted">
           {selectionMode === "time"
             ? t("dragToReorder")
             : selectionMode === "random"
               ? t("randomMembershipHint")
               : t("variableMembershipHint")}
-        </p>
+        </Text>
 
         {selectedPageIds.length === 0 ? (
-          <div className="border border-dashed rounded-lg p-4 text-center text-sm text-muted-foreground">
+          <Text tone="muted" className="border border-dashed rounded-lg p-4 text-center">
             {t("noPagesAdded")}
-          </div>
+          </Text>
         ) : (
-          <div className="space-y-1">
+          <Stack gap="1">
             {selectedPageIds.map((pid, index) => {
               const page = pages.find((p) => p.id === pid);
               return (
-                <div
+                <Flex
                   key={pid}
+                  align="center"
+                  gap="2"
                   draggable={selectionMode === "time"}
                   onDragStart={() => handleDragStart(index)}
                   onDragOver={(e) => handleDragOver(e, index)}
                   onDragEnd={handleDragEnd}
-                  className={`flex items-center gap-2 rounded-lg border p-2.5 bg-background ${
+                  className={`rounded-lg border p-2.5 bg-background ${
                     selectionMode === "time" ? "cursor-grab active:cursor-grabbing" : ""
                   } ${dragIndex === index ? "opacity-50" : ""}`}
                 >
@@ -447,7 +455,9 @@ function CollectionForm({ collection, pages, onSubmit, onCancel, onDelete }: Col
                     </Badge>
                   )}
                   <FileText className="h-4 w-4 text-muted-foreground flex-shrink-0" />
-                  <span className="text-sm truncate flex-1">{page?.name || pid}</span>
+                  <Text as="span" className="truncate flex-1">
+                    {page?.name || pid}
+                  </Text>
                   <Button
                     type="button"
                     variant="ghost"
@@ -457,10 +467,10 @@ function CollectionForm({ collection, pages, onSubmit, onCancel, onDelete }: Col
                   >
                     <Trash2 className="h-3.5 w-3.5 text-muted-foreground" />
                   </Button>
-                </div>
+                </Flex>
               );
             })}
-          </div>
+          </Stack>
         )}
 
         {availablePages.length > 0 && (
@@ -477,20 +487,28 @@ function CollectionForm({ collection, pages, onSubmit, onCancel, onDelete }: Col
             </SelectContent>
           </Select>
         )}
-      </div>
+      </Stack>
 
       {/* Variable-mode controls */}
       {selectionMode === "variable" && (
-        <div className="space-y-4 border-t pt-4">
-          <div className="flex items-start gap-2 rounded-md border border-dashed bg-muted/40 p-2.5 text-xs text-muted-foreground">
+        <Stack gap="4" className="border-t pt-4">
+          <Flex
+            align="start"
+            gap="2"
+            className="rounded-md border border-dashed bg-muted/40 p-2.5 text-xs text-muted-foreground"
+          >
             <Badge variant="outline" className="text-[10px] uppercase tracking-wide py-0">
               {t("betaBadge")}
             </Badge>
-            <span>{t("variableModeBetaNote")}</span>
-          </div>
-          <div className="space-y-2">
+            <Text as="span" size="xs" tone="muted">
+              {t("variableModeBetaNote")}
+            </Text>
+          </Flex>
+          <Stack gap="2">
             <Label htmlFor="collection-default">{t("variableDefaultLabel")}</Label>
-            <p className="text-xs text-muted-foreground">{t("variableDefaultDescription")}</p>
+            <Text size="xs" tone="muted">
+              {t("variableDefaultDescription")}
+            </Text>
             <Select value={defaultPageId} onValueChange={setDefaultPageId} disabled={selectedPageIds.length === 0}>
               <SelectTrigger id="collection-default">
                 <SelectValue placeholder={t("variableDefaultPlaceholder")} />
@@ -506,18 +524,20 @@ function CollectionForm({ collection, pages, onSubmit, onCancel, onDelete }: Col
                 })}
               </SelectContent>
             </Select>
-          </div>
+          </Stack>
 
-          <div className="space-y-2">
+          <Stack gap="2">
             <Label>{t("variableRulesLabel")}</Label>
-            <p className="text-xs text-muted-foreground">{t("variableRulesDescription")}</p>
+            <Text size="xs" tone="muted">
+              {t("variableRulesDescription")}
+            </Text>
 
             {rules.length === 0 ? (
-              <div className="border border-dashed rounded-lg p-4 text-center text-sm text-muted-foreground">
+              <Text tone="muted" className="border border-dashed rounded-lg p-4 text-center">
                 {t("variableNoRules")}
-              </div>
+              </Text>
             ) : (
-              <div className="space-y-2">
+              <Stack gap="2">
                 {rules.map((rule, index) => (
                   <VariableRuleRow
                     key={index}
@@ -540,7 +560,7 @@ function CollectionForm({ collection, pages, onSubmit, onCancel, onDelete }: Col
                     t={t}
                   />
                 ))}
-              </div>
+              </Stack>
             )}
 
             <Button
@@ -572,11 +592,13 @@ function CollectionForm({ collection, pages, onSubmit, onCancel, onDelete }: Col
                 </AlertDialogFooter>
               </AlertDialogContent>
             </AlertDialog>
-          </div>
+          </Stack>
 
-          <div className="space-y-2">
+          <Stack gap="2">
             <Label htmlFor="collection-poll">{t("variablePollLabel")}</Label>
-            <p className="text-xs text-muted-foreground">{t("variablePollDescription")}</p>
+            <Text size="xs" tone="muted">
+              {t("variablePollDescription")}
+            </Text>
             <Select value={String(pollSeconds)} onValueChange={(v) => setPollSeconds(Number(v))}>
               <SelectTrigger id="collection-poll">
                 <SelectValue />
@@ -589,21 +611,21 @@ function CollectionForm({ collection, pages, onSubmit, onCancel, onDelete }: Col
                 ))}
               </SelectContent>
             </Select>
-          </div>
-        </div>
+          </Stack>
+        </Stack>
       )}
 
       {/* Actions */}
-      <div className="flex justify-between gap-2 pt-2">
-        <div>
+      <Flex justify="between" gap="2" className="pt-2">
+        <Box>
           {isEdit && onDelete && (
             <Button type="button" variant="destructive" onClick={onDelete} disabled={isSubmitting}>
               <Trash2 className="mr-2 h-4 w-4" />
               {tc("delete")}
             </Button>
           )}
-        </div>
-        <div className="flex gap-2">
+        </Box>
+        <Flex gap="2">
           <Button type="button" variant="outline" onClick={onCancel} disabled={isSubmitting}>
             {tc("cancel")}
           </Button>
@@ -611,9 +633,9 @@ function CollectionForm({ collection, pages, onSubmit, onCancel, onDelete }: Col
             {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
             {isEdit ? t("updateCollection") : t("createCollection")}
           </Button>
-        </div>
-      </div>
-    </form>
+        </Flex>
+      </Flex>
+    </Box>
   );
 }
 
@@ -745,8 +767,12 @@ export default function CollectionsPage() {
         <Card>
           <CardContent className="py-12 text-center">
             <GalleryHorizontalEnd className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
-            <p className="text-muted-foreground mb-2">{t("noCollectionsTitle")}</p>
-            <p className="text-sm text-muted-foreground mb-4">{t("noCollectionsDescription")}</p>
+            <Text tone="muted" size="base" className="mb-2">
+              {t("noCollectionsTitle")}
+            </Text>
+            <Text tone="muted" className="mb-4">
+              {t("noCollectionsDescription")}
+            </Text>
             <Button
               variant="brand"
               onClick={() => {
@@ -761,7 +787,7 @@ export default function CollectionsPage() {
           </CardContent>
         </Card>
       ) : (
-        <div className="space-y-4">
+        <Stack gap="4">
           {collections.map((collection, idx) => (
             <Card
               key={collection.id}
@@ -771,12 +797,14 @@ export default function CollectionsPage() {
               <CardHeader className="pb-3">
                 {/* min-w-0: CardHeader is a grid; without it this grid item
                     sizes to min-content and long names inflate the row. */}
-                <div className="flex items-start justify-between gap-2 min-w-0">
-                  <div className="flex items-center gap-2 min-w-0">
+                <Flex align="start" justify="between" gap="2" className="min-w-0">
+                  <Flex align="center" gap="2" className="min-w-0">
                     <GalleryHorizontalEnd className="h-5 w-5 text-primary flex-shrink-0" />
-                    <div className="min-w-0">
+                    <Box className="min-w-0">
                       <CardTitle className="text-base flex items-center gap-2 min-w-0">
-                        <span className="truncate">{collection.name}</span>
+                        <Text as="span" size="base" weight="semibold" className="truncate">
+                          {collection.name}
+                        </Text>
                         <Badge variant="outline" className="text-[10px] uppercase tracking-wide flex-shrink-0">
                           {collection.selection_mode === "time" ? (
                             <Clock className="h-3 w-3 mr-1" aria-hidden="true" />
@@ -797,28 +825,32 @@ export default function CollectionsPage() {
                         {collection.page_ids.length} page
                         {collection.page_ids.length !== 1 ? "s" : ""} &middot; {describeMode(collection)}
                       </CardDescription>
-                    </div>
-                  </div>
+                    </Box>
+                  </Flex>
                   <Button variant="ghost" size="sm" className="flex-shrink-0" onClick={() => handleEdit(collection)}>
                     <Pencil className="h-4 w-4" />
                   </Button>
-                </div>
+                </Flex>
               </CardHeader>
               <CardContent className="pt-0">
-                <div className="flex flex-wrap gap-1.5">
+                <Flex wrap gap="1.5">
                   {collection.page_ids.map((pid, i) => (
                     <Badge key={pid} variant="secondary" className="text-xs max-w-full">
                       {collection.selection_mode === "time" && (
-                        <span className="text-muted-foreground mr-1 flex-shrink-0">{i + 1}.</span>
+                        <Text as="span" size="xs" tone="muted" className="mr-1 flex-shrink-0">
+                          {i + 1}.
+                        </Text>
                       )}
-                      <span className="truncate">{getPageName(pid)}</span>
+                      <Text as="span" size="xs" className="truncate">
+                        {getPageName(pid)}
+                      </Text>
                     </Badge>
                   ))}
-                </div>
+                </Flex>
               </CardContent>
             </Card>
           ))}
-        </div>
+        </Stack>
       )}
 
       {/* Form Sheet */}

--- a/web/app/routes/debug.tsx
+++ b/web/app/routes/debug.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, PageLayout } from "@fiestaboard/ui";
+import { Card, CardContent, Code, Heading, PageLayout, Text } from "@fiestaboard/ui";
 import { Activity } from "lucide-react";
 
 import { useTranslations } from "@/i18n/translations";
@@ -10,11 +10,12 @@ export default function DebugMonitorPage() {
       <Card>
         <CardContent className="py-12 text-center">
           <Activity className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
-          <h2 className="text-lg font-semibold mb-2">{t("monitoringRemovedTitle")}</h2>
-          <p className="text-sm text-muted-foreground max-w-lg mx-auto">
-            {t("monitoringRemovedDescription")}{" "}
-            <code className="px-1.5 py-0.5 rounded bg-muted font-mono text-xs">docker logs fiestaboard</code>
-          </p>
+          <Heading level={2} size="lg" className="mb-2">
+            {t("monitoringRemovedTitle")}
+          </Heading>
+          <Text tone="muted" className="max-w-lg mx-auto">
+            {t("monitoringRemovedDescription")} <Code>docker logs fiestaboard</Code>
+          </Text>
         </CardContent>
       </Card>
     </PageLayout>

--- a/web/app/routes/home.tsx
+++ b/web/app/routes/home.tsx
@@ -1,4 +1,4 @@
-import { Alert, AlertDescription, AlertTitle, Button, PageHeader, PageLayout } from "@fiestaboard/ui";
+import { Alert, AlertDescription, AlertTitle, Box, Button, PageHeader, PageLayout } from "@fiestaboard/ui";
 import { Home as HomeIcon, Info } from "lucide-react";
 import { useEffect, useState } from "react";
 
@@ -30,13 +30,13 @@ export default function Home() {
       <PageHeader icon={HomeIcon} title={t("title")} description={t("description")} />
 
       {boardNotConfigured && (
-        <div className="mb-6">
+        <Box className="mb-6">
           <Alert className="border-info/50 bg-info/10 flex flex-col sm:flex-row sm:items-center sm:gap-4 [&>svg]:static [&>svg]:shrink-0 [&>svg+div]:translate-y-0 [&>svg~*]:pl-3">
             <Info className="h-4 w-4 text-info" />
-            <div className="flex-1 min-w-0">
+            <Box className="flex-1 min-w-0">
               <AlertTitle>{t("noBoardConfigured")}</AlertTitle>
               <AlertDescription>{t("noBoardDescription")}</AlertDescription>
-            </div>
+            </Box>
             <Button
               variant="brand"
               size="sm"
@@ -46,14 +46,14 @@ export default function Home() {
               {t("runSetupWizard")}
             </Button>
           </Alert>
-        </div>
+        </Box>
       )}
 
       <SilenceImminentBanner />
 
-      <div className="animate-card-fade-in">
+      <Box className="animate-card-fade-in">
         <ActivePageDisplay />
-      </div>
+      </Box>
     </PageLayout>
   );
 }

--- a/web/app/routes/integrations.$pluginId.tsx
+++ b/web/app/routes/integrations.$pluginId.tsx
@@ -1,16 +1,30 @@
 import {
   Badge,
+  Box,
   Button,
+  Code,
   Dialog,
   DialogContent,
   DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  Flex,
+  Heading,
   Input,
   Label,
+  List,
   PageLayout,
   Skeleton,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  Text,
+  TextLink,
 } from "@fiestaboard/ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowDownToLine, ArrowLeft, CopyPlus, ExternalLink, Puzzle } from "lucide-react";
@@ -120,24 +134,24 @@ export default function PluginDetailPage() {
   return (
     <PageLayout>
       {/* Back navigation */}
-      <div className="mb-4">
+      <Box className="mb-4">
         <Button variant="ghost" size="sm" className="gap-1.5 -ml-2 text-muted-foreground hover:text-foreground" asChild>
           <Link href="/integrations?tab=marketplace">
             <ArrowLeft className="h-4 w-4" />
             {t("backToMarketplace")}
           </Link>
         </Button>
-      </div>
+      </Box>
 
-      <div className="max-w-3xl mx-auto space-y-6 animate-card-fade-in">
+      <Stack gap="6" className="max-w-3xl mx-auto animate-card-fade-in">
         {/* Plugin header card */}
-        <div className="rounded-xl border bg-card px-6 py-5">
-          <div className="flex items-start justify-between gap-4">
-            <div className="flex items-start gap-4 min-w-0">
-              <div className="p-2.5 rounded-lg bg-muted text-muted-foreground shrink-0 mt-0.5">
+        <Box className="rounded-xl border bg-card px-6 py-5">
+          <Flex align="start" justify="between" gap="4">
+            <Flex align="start" gap="4" className="min-w-0">
+              <Box className="p-2.5 rounded-lg bg-muted text-muted-foreground shrink-0 mt-0.5">
                 <Puzzle className="h-5 w-5" />
-              </div>
-              <div className="min-w-0">
+              </Box>
+              <Box className="min-w-0">
                 {isLoading ? (
                   <>
                     <Skeleton className="h-6 w-48 mb-2" />
@@ -145,29 +159,39 @@ export default function PluginDetailPage() {
                   </>
                 ) : (
                   <>
-                    <div className="flex items-center gap-2 flex-wrap mb-1">
+                    <Flex align="center" gap="2" wrap className="mb-1">
+                      {/* Custom card header (icon + badge + trailing actions) doesn't
+                          match PageHeader's shape, so the page h1 stays raw here
+                          (couldn't snap — see wave 1 report). */}
                       <h1 className="text-xl font-semibold">{entry?.name ?? pluginId}</h1>
                       <Badge variant="secondary" className="text-xs">
                         {categoryLabel}
                       </Badge>
-                    </div>
-                    <p className="text-sm text-muted-foreground">
-                      {entry?.author && <span className="mr-3">{t("byAuthor", { author: entry.author })}</span>}
-                      {entry?.fiestaboard_version && (
-                        <span className="text-xs">
-                          {t("requiresFiestaboard", { version: entry.fiestaboard_version })}
-                        </span>
+                    </Flex>
+                    <Text tone="muted">
+                      {entry?.author && (
+                        <Text as="span" tone="muted" className="mr-3">
+                          {t("byAuthor", { author: entry.author })}
+                        </Text>
                       )}
-                    </p>
+                      {entry?.fiestaboard_version && (
+                        <Text as="span" size="xs" tone="muted">
+                          {t("requiresFiestaboard", { version: entry.fiestaboard_version })}
+                        </Text>
+                      )}
+                    </Text>
                   </>
                 )}
-              </div>
-            </div>
+              </Box>
+            </Flex>
 
             {/* Actions */}
-            <div className="flex items-center gap-2 shrink-0">
+            <Flex align="center" gap="2" className="shrink-0">
               {entry?.repository && (
                 <Button variant="outline" size="sm" asChild>
+                  {/* asChild hands this anchor Button's own chrome (border/bg/text) — TextLink's
+                      underline+text-primary styling would clash with that, so it stays raw
+                      (couldn't snap — see wave 1 report). */}
                   <a href={entry.repository} target="_blank" rel="noopener noreferrer">
                     <ExternalLink className="h-3.5 w-3.5 mr-1.5" />
                     GitHub
@@ -188,19 +212,21 @@ export default function PluginDetailPage() {
                     {installMutation.isPending ? t("installing") : t("install")}
                   </Button>
                 ))}
-            </div>
-          </div>
+            </Flex>
+          </Flex>
 
           {/* Description */}
           {entry?.description && (
-            <p className="mt-4 text-sm text-muted-foreground leading-relaxed border-t pt-4">{entry.description}</p>
+            <Text tone="muted" className="mt-4 leading-relaxed border-t pt-4">
+              {entry.description}
+            </Text>
           )}
-        </div>
+        </Box>
 
         {/* README */}
-        <div className="rounded-xl border bg-card px-6 py-5">
+        <Box className="rounded-xl border bg-card px-6 py-5">
           {isLoadingReadme ? (
-            <div className="space-y-3">
+            <Stack gap="3">
               <Skeleton className="h-5 w-1/3" />
               <Skeleton className="h-4 w-full" />
               <Skeleton className="h-4 w-5/6" />
@@ -209,16 +235,16 @@ export default function PluginDetailPage() {
               <Skeleton className="h-4 w-full" />
               <Skeleton className="h-4 w-3/4" />
               <Skeleton className="h-4 w-5/6" />
-            </div>
+            </Stack>
           ) : readme ? (
-            <div className="plugin-readme">
+            <Box className="plugin-readme">
               <ReactMarkdown
                 remarkPlugins={[remarkGfm]}
                 components={{
                   a: ({ href, children, ...props }) => (
-                    <a href={href} target="_blank" rel="noopener noreferrer" {...props}>
+                    <TextLink href={href} target="_blank" rel="noopener noreferrer" {...props}>
                       {children}
-                    </a>
+                    </TextLink>
                   ),
                   img: ({ src, alt, ...props }) => (
                     <img src={src} alt={alt ?? ""} className="rounded-lg max-h-64 w-auto my-3" {...props} />
@@ -235,62 +261,68 @@ export default function PluginDetailPage() {
                         {children}
                       </code>
                     ) : (
-                      <code className="bg-muted px-1.5 py-0.5 rounded text-xs font-mono" {...props}>
-                        {children}
-                      </code>
+                      <Code {...props}>{children}</Code>
                     );
                   },
                   table: ({ children, ...props }) => (
-                    <div className="overflow-x-auto my-4">
-                      <table className="w-full text-xs border-collapse" {...props}>
-                        {children}
-                      </table>
-                    </div>
+                    <Table className="text-xs border-collapse my-4" {...props}>
+                      {children}
+                    </Table>
                   ),
                   thead: ({ children, ...props }) => (
-                    <thead className="bg-muted/50" {...props}>
+                    <TableHeader className="bg-muted/50" {...props}>
                       {children}
-                    </thead>
+                    </TableHeader>
                   ),
+                  tbody: ({ children, ...props }) => <TableBody {...props}>{children}</TableBody>,
+                  tr: ({ children, ...props }) => <TableRow {...props}>{children}</TableRow>,
                   th: ({ children, ...props }) => (
-                    <th className="border border-border px-3 py-2 text-left font-medium" {...props}>
+                    <TableHead className="border border-border text-left" {...props}>
                       {children}
-                    </th>
+                    </TableHead>
                   ),
                   td: ({ children, ...props }) => (
-                    <td className="border border-border px-3 py-2" {...props}>
+                    <TableCell className="border border-border" {...props}>
                       {children}
-                    </td>
+                    </TableCell>
                   ),
                   h1: ({ children, ...props }) => (
+                    // Markdown README content — h1 here is document structure, not the app
+                    // page's own title, so PageHeader doesn't fit; stays raw (couldn't snap).
                     <h1 className="text-xl font-bold mt-0 mb-4 pb-2 border-b" {...props}>
                       {children}
                     </h1>
                   ),
                   h2: ({ children, ...props }) => (
-                    <h2 className="text-base font-semibold mt-6 mb-2 text-foreground" {...props}>
+                    <Heading level={2} className="mt-6 mb-2" {...props}>
                       {children}
-                    </h2>
+                    </Heading>
                   ),
                   h3: ({ children, ...props }) => (
-                    <h3 className="text-sm font-semibold mt-4 mb-1.5 text-foreground" {...props}>
+                    <Heading level={3} size="sm" className="mt-4 mb-1.5" {...props}>
                       {children}
-                    </h3>
+                    </Heading>
                   ),
                   p: ({ children, ...props }) => (
-                    <p className="text-sm leading-relaxed mb-3 text-muted-foreground" {...props}>
+                    <Text tone="muted" className="leading-relaxed mb-3" {...props}>
                       {children}
-                    </p>
+                    </Text>
                   ),
                   ul: ({ children, ...props }) => (
-                    <ul className="list-disc list-inside space-y-1 mb-3 text-sm text-muted-foreground" {...props}>
+                    <List marker="disc" gap="1" className="list-inside mb-3 text-sm text-muted-foreground" {...props}>
                       {children}
-                    </ul>
+                    </List>
                   ),
                   ol: ({ children, ...props }) => (
-                    <ol className="list-decimal list-inside space-y-1 mb-3 text-sm text-muted-foreground" {...props}>
+                    <List
+                      as="ol"
+                      marker="decimal"
+                      gap="1"
+                      className="list-inside mb-3 text-sm text-muted-foreground"
+                      {...props}
+                    >
                       {children}
-                    </ol>
+                    </List>
                   ),
                   blockquote: ({ children, ...props }) => (
                     <blockquote
@@ -302,20 +334,22 @@ export default function PluginDetailPage() {
                   ),
                   hr: () => <hr className="border-border my-5" />,
                   strong: ({ children, ...props }) => (
-                    <strong className="font-semibold text-foreground" {...props}>
+                    <Text as="span" weight="semibold" {...props}>
                       {children}
-                    </strong>
+                    </Text>
                   ),
                 }}
               >
                 {readme}
               </ReactMarkdown>
-            </div>
+            </Box>
           ) : (
-            <p className="text-sm text-muted-foreground italic">{t("documentationNotAvailable")}</p>
+            <Text tone="muted" className="italic">
+              {t("documentationNotAvailable")}
+            </Text>
           )}
-        </div>
-      </div>
+        </Box>
+      </Stack>
 
       <Dialog open={addInstanceOpen} onOpenChange={setAddInstanceOpen}>
         <DialogContent>
@@ -325,7 +359,7 @@ export default function PluginDetailPage() {
             </DialogTitle>
             <DialogDescription>{t("addInstanceDescription")}</DialogDescription>
           </DialogHeader>
-          <div className="space-y-2 py-2">
+          <Stack gap="2" className="py-2">
             <Label htmlFor="detail-instance-label">{t("instanceNameLabel")}</Label>
             <Input
               id="detail-instance-label"
@@ -338,8 +372,10 @@ export default function PluginDetailPage() {
               }}
               autoFocus
             />
-            <p className="text-xs text-muted-foreground">{t("instanceNameHelp")}</p>
-          </div>
+            <Text size="xs" tone="muted">
+              {t("instanceNameHelp")}
+            </Text>
+          </Stack>
           <DialogFooter>
             <Button variant="outline" onClick={() => setAddInstanceOpen(false)} disabled={isCreatingInstance}>
               {tCommon("cancel")}

--- a/web/app/routes/integrations._index.tsx
+++ b/web/app/routes/integrations._index.tsx
@@ -11,12 +11,14 @@ import {
   AlertDialogTitle,
   AlertTitle,
   Badge,
+  Box,
   Button,
   Card,
   CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
+  Code as CodeChip,
   Dialog,
   DialogContent,
   DialogDescription,
@@ -29,6 +31,9 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
+  Flex,
+  Grid,
+  Heading,
   Input,
   Label,
   PageHeader,
@@ -42,11 +47,19 @@ import {
   SheetTitle,
   SheetTrigger,
   Skeleton,
+  Stack,
   Switch,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
   Tabs,
   TabsContent,
   TabsList,
   TabsTrigger,
+  Text,
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -77,7 +90,7 @@ import {
   Bookmark,
   BookOpen,
   Bot,
-  Box,
+  Box as BoxIcon,
   Bug,
   Building,
   Building2,
@@ -641,21 +654,23 @@ function ColorRulesEditor({
 
   return (
     <TooltipProvider>
-      <div className="space-y-3">
-        <div className="flex items-center justify-between">
-          <h4 className="text-sm font-medium text-muted-foreground">
+      <Stack gap="3">
+        <Flex align="center" justify="between">
+          <Heading level={4} size="sm" className="font-medium text-muted-foreground">
             {t("colorRules.title")}
-            <span className="ml-2 text-xs font-normal">({t("colorRules.firstMatchWins")})</span>
-          </h4>
+            <Text as="span" size="xs" tone="muted" className="ml-2">
+              ({t("colorRules.firstMatchWins")})
+            </Text>
+          </Heading>
           <Button variant="outline" size="sm" className="h-7 text-xs" onClick={() => setShowAddField(!showAddField)}>
             <Plus className="h-3 w-3 mr-1" />
             {t("colorRules.addField")}
           </Button>
-        </div>
+        </Flex>
 
         {/* Add new field input */}
         {showAddField && (
-          <div className="flex gap-2 p-2 rounded-md border bg-muted/30">
+          <Flex gap="2" className="p-2 rounded-md border bg-muted/30">
             <input
               type="text"
               value={newFieldName}
@@ -669,28 +684,30 @@ function ColorRulesEditor({
             <Button size="sm" variant="ghost" className="h-8 text-xs" onClick={() => setShowAddField(false)}>
               {tCommon("cancel")}
             </Button>
-          </div>
+          </Flex>
         )}
 
         {fieldNames.length === 0 ? (
-          <p className="text-xs text-muted-foreground py-2">
+          <Text size="xs" tone="muted" className="py-2">
             No color rules configured. Add a field to create dynamic colors.
-          </p>
+          </Text>
         ) : (
-          <div className="space-y-3">
+          <Stack gap="3">
             {fieldNames.map((fieldName) => {
               const rules = colorRules[fieldName];
               return (
-                <div key={fieldName} className="rounded-md border overflow-hidden">
+                <Box key={fieldName} className="rounded-md border overflow-hidden">
                   {/* Field header */}
-                  <div className="bg-muted/50 px-3 py-2 flex items-center justify-between">
-                    <div className="flex items-center gap-2">
-                      <code className="text-xs font-mono text-primary bg-primary/10 px-1.5 py-0.5 rounded">
+                  <Flex align="center" justify="between" className="bg-muted/50 px-3 py-2">
+                    <Flex align="center" gap="2">
+                      <CodeChip className="text-primary bg-primary/10">
                         {pluginId}.{fieldName}
-                      </code>
-                      <span className="text-xs text-muted-foreground">→ color based on value</span>
-                    </div>
-                    <div className="flex items-center gap-1">
+                      </CodeChip>
+                      <Text as="span" size="xs" tone="muted">
+                        → color based on value
+                      </Text>
+                    </Flex>
+                    <Flex align="center" gap="1">
                       <button
                         onClick={() => onCopyVar(`${fieldName}_color`)}
                         className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1 px-2 py-1 rounded hover:bg-muted"
@@ -700,7 +717,7 @@ function ColorRulesEditor({
                         ) : (
                           <Copy className="h-3 w-3" />
                         )}
-                        <code className="font-mono text-[10px]">{fieldName}_color</code>
+                        <CodeChip className="bg-transparent px-0 py-0 rounded-none">{fieldName}_color</CodeChip>
                       </button>
                       <Tooltip>
                         <TooltipTrigger asChild>
@@ -712,14 +729,14 @@ function ColorRulesEditor({
                           </button>
                         </TooltipTrigger>
                         <TooltipContent>
-                          <p>{t("colorRules.deleteFieldTooltip")}</p>
+                          <Text>{t("colorRules.deleteFieldTooltip")}</Text>
                         </TooltipContent>
                       </Tooltip>
-                    </div>
-                  </div>
+                    </Flex>
+                  </Flex>
 
                   {/* Rules */}
-                  <div className="divide-y">
+                  <Box className="divide-y">
                     {rules.map((rule, idx) => {
                       const colorStyle = COLOR_DISPLAY[rule.color as FiestaboardColorName] || {
                         bg: "bg-muted",
@@ -727,9 +744,9 @@ function ColorRulesEditor({
                         hex: "#6b7280",
                       };
                       return (
-                        <div key={idx} className="px-3 py-2 flex items-center gap-2 text-xs">
+                        <Flex key={idx} align="center" gap="2" className="px-3 py-2 text-xs">
                           {/* Reorder buttons */}
-                          <div className="flex flex-col gap-0.5">
+                          <Flex direction="col" gap="0.5">
                             <button
                               onClick={() => handleMoveRule(fieldName, idx, "up")}
                               disabled={idx === 0}
@@ -744,7 +761,7 @@ function ColorRulesEditor({
                             >
                               <ArrowDown className="h-3 w-3" />
                             </button>
-                          </div>
+                          </Flex>
 
                           {/* Color picker */}
                           <select
@@ -763,7 +780,9 @@ function ColorRulesEditor({
                             ))}
                           </select>
 
-                          <span className="text-muted-foreground shrink-0">when</span>
+                          <Text as="span" size="xs" tone="muted" className="shrink-0">
+                            when
+                          </Text>
 
                           {/* Condition picker */}
                           <select
@@ -801,13 +820,13 @@ function ColorRulesEditor({
                           >
                             <Trash2 className="h-3 w-3" />
                           </button>
-                        </div>
+                        </Flex>
                       );
                     })}
-                  </div>
+                  </Box>
 
                   {/* Add rule button */}
-                  <div className="px-3 py-2 border-t bg-muted/20">
+                  <Box className="px-3 py-2 border-t bg-muted/20">
                     <button
                       onClick={() => handleAddRule(fieldName)}
                       className="text-xs text-muted-foreground hover:text-foreground flex items-center gap-1"
@@ -815,17 +834,17 @@ function ColorRulesEditor({
                       <Plus className="h-3 w-3" />
                       {t("colorRules.addRule")}
                     </button>
-                  </div>
-                </div>
+                  </Box>
+                </Box>
               );
             })}
-          </div>
+          </Stack>
         )}
 
-        <p className="text-xs text-muted-foreground">
+        <Text size="xs" tone="muted">
           {t("colorRules.ruleDescription", { example: `{{${pluginId}.field_color}}` })}
-        </p>
-      </div>
+        </Text>
+      </Stack>
     </TooltipProvider>
   );
 }
@@ -902,6 +921,9 @@ function renderValueWithColors(value: string): ReactNode[] {
   let textBuf = "";
   const flushText = () => {
     if (textBuf) {
+      // Rendered inline into caller-supplied text contexts with varying ambient
+      // size/color (font-mono chips, tooltip content, table cells) — Text's fixed
+      // defaults would override whichever context this lands in, so this stays raw.
       nodes.push(<span key={`t${key++}`}>{textBuf}</span>);
       textBuf = "";
     }
@@ -919,7 +941,7 @@ function renderValueWithColors(value: string): ReactNode[] {
         if (hex) {
           flushText();
           nodes.push(
-            <span
+            <Box
               key={`c${key++}`}
               aria-label={`color ${content}`}
               className="inline-block align-middle h-3 w-3 rounded-sm border border-border/40"
@@ -1081,55 +1103,63 @@ function PluginCard({
       rawDisplay?.available ? (rawDisplay.data as Record<string, unknown>) : undefined,
     );
     return (
-      <tr
+      <TableRow
         key={variable.name}
         className="hover:bg-muted/30 cursor-pointer transition-colors"
         onClick={() => handleCopyVar(variable.name)}
       >
-        <td className="px-3 py-2 align-top">
-          <div className="flex items-center gap-1.5">
-            <code className="text-primary font-mono bg-primary/10 px-1.5 py-0.5 rounded text-[11px]">
+        <TableCell className="px-3 py-2 align-top">
+          <Flex align="center" gap="1.5">
+            <CodeChip className="text-primary bg-primary/10">
               {plugin.id}.{variable.name}
-            </code>
+            </CodeChip>
             {copiedVar === variable.name ? (
               <Check className="h-3 w-3 text-success" />
             ) : (
               <Copy className="h-3 w-3 text-muted-foreground" />
             )}
-          </div>
-        </td>
-        <td className="px-3 py-2 text-muted-foreground capitalize align-top">{variable.description}</td>
-        <td className="px-3 py-2 align-top max-w-[200px]" onClick={(e) => e.stopPropagation()}>
+          </Flex>
+        </TableCell>
+        <TableCell className="px-3 py-2 text-muted-foreground capitalize align-top">{variable.description}</TableCell>
+        <TableCell className="px-3 py-2 align-top max-w-[200px]" onClick={(e) => e.stopPropagation()}>
           {!plugin.enabled ? (
-            <span className="text-muted-foreground">—</span>
+            <Text as="span" tone="muted">
+              —
+            </Text>
           ) : isLoadingRawDisplay ? (
             <Skeleton className="h-3 w-16" />
           ) : rawDisplay && rawDisplay.available === false ? (
-            <span className="text-muted-foreground italic">Unavailable</span>
+            <Text as="span" tone="muted" className="italic">
+              Unavailable
+            </Text>
           ) : resolved && resolved.short !== "" ? (
             <Tooltip>
               <TooltipTrigger asChild>
-                <span className="flex items-center gap-1 truncate font-mono text-[11px]">
+                <Flex align="center" gap="1" className="truncate font-mono text-[11px]">
                   {renderValueWithColors(resolved.short)}
-                </span>
+                </Flex>
               </TooltipTrigger>
               <TooltipContent
                 side="top"
                 className="max-w-[360px] whitespace-pre-wrap break-words font-mono text-[11px]"
               >
-                <span className="inline-flex flex-wrap items-center gap-1">{renderValueWithColors(resolved.full)}</span>
+                <Flex inline wrap align="center" gap="1">
+                  {renderValueWithColors(resolved.full)}
+                </Flex>
               </TooltipContent>
             </Tooltip>
           ) : (
-            <span className="text-muted-foreground">—</span>
+            <Text as="span" tone="muted">
+              —
+            </Text>
           )}
-        </td>
-        <td className="px-3 py-2 text-center align-top">
+        </TableCell>
+        <TableCell className="px-3 py-2 text-center align-top">
           <Badge variant="outline" className="text-[10px]">
             {variable.maxChars}
           </Badge>
-        </td>
-      </tr>
+        </TableCell>
+      </TableRow>
     );
   };
 
@@ -1192,27 +1222,29 @@ function PluginCard({
           </SheetTitle>
           <SheetDescription>Configure settings for this integration</SheetDescription>
         </SheetHeader>
-        <div className="py-6 space-y-6">
+        <Stack gap="6" className="py-6">
           {isLoadingDetails ? (
-            <div className="space-y-4">
+            <Stack gap="4">
               <Skeleton className="h-10 w-full" />
               <Skeleton className="h-10 w-full" />
               <Skeleton className="h-10 w-full" />
-            </div>
+            </Stack>
           ) : (
             <>
               {/* Demo Page Section */}
               {pluginDetails?.has_demo && (
-                <div className="rounded-lg border bg-muted/30 p-4 space-y-3">
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <h4 className="text-sm font-medium">Demo Page</h4>
-                      <p className="text-xs text-muted-foreground mt-0.5">
+                <Stack gap="3" className="rounded-lg border bg-muted/30 p-4">
+                  <Flex align="center" justify="between">
+                    <Box>
+                      <Heading level={4} size="sm" className="font-medium">
+                        Demo Page
+                      </Heading>
+                      <Text size="xs" tone="muted" className="mt-0.5">
                         {pluginDetails.demo_page_id
                           ? "A demo page already exists for this plugin."
                           : "Create a ready-to-use page that showcases this plugin."}
-                      </p>
-                    </div>
+                      </Text>
+                    </Box>
                     {pluginDetails.demo_page_id ? (
                       <Dialog open={showDemoConfirm} onOpenChange={setShowDemoConfirm}>
                         <DialogTrigger asChild>
@@ -1250,113 +1282,119 @@ function PluginCard({
                         {isCreatingDemo ? "Creating..." : "Create Demo Page"}
                       </Button>
                     )}
-                  </div>
+                  </Flex>
                   {!areDemoRequirementsMet() && (
-                    <p className="text-xs text-amber-600 dark:text-amber-400">
+                    <Text size="xs" tone="warning">
                       Configure the required settings below before creating a demo page.
-                    </p>
+                    </Text>
                   )}
-                </div>
+                </Stack>
               )}
 
               {/* Settings Section */}
               {pluginDetails?.settings_schema &&
                 Object.keys(pluginDetails.settings_schema.properties || {}).length > 0 && (
-                  <div className="space-y-4">
-                    <h4 className="text-sm font-medium text-muted-foreground">Settings</h4>
+                  <Stack gap="4">
+                    <Heading level={4} size="sm" className="font-medium text-muted-foreground">
+                      Settings
+                    </Heading>
                     <SchemaForm
                       schema={pluginDetails.settings_schema}
                       values={configValues}
                       onChange={setConfigValues}
                       disabled={isSaving}
                     />
-                  </div>
+                  </Stack>
                 )}
 
               {/* Template Variables Section */}
               {variableRows.length > 0 && (
                 <TooltipProvider delayDuration={200}>
-                  <div className="space-y-3">
-                    <h4 className="text-sm font-medium text-muted-foreground">
+                  <Stack gap="3">
+                    <Heading level={4} size="sm" className="font-medium text-muted-foreground">
                       Template Variables
-                      <span className="ml-2 text-xs font-normal">(click to copy)</span>
-                    </h4>
+                      <Text as="span" size="xs" tone="muted" className="ml-2">
+                        (click to copy)
+                      </Text>
+                    </Heading>
                     {!plugin.enabled && (
-                      <p className="text-xs text-muted-foreground italic">Enable the plugin to see live values.</p>
+                      <Text size="xs" tone="muted" className="italic">
+                        Enable the plugin to see live values.
+                      </Text>
                     )}
                     {plugin.enabled && rawDisplay && rawDisplay.available === false && (
-                      <p className="text-xs text-amber-600 dark:text-amber-400">
+                      <Text size="xs" tone="warning">
                         Live values are unavailable
                         {rawDisplay.error ? `: ${rawDisplay.error}` : "."}
-                      </p>
+                      </Text>
                     )}
-                    <div className="rounded-md border overflow-hidden">
-                      <table className="w-full text-xs">
-                        <thead className="bg-muted/50">
-                          <tr>
-                            <th className="text-left px-3 py-2 font-medium">Variable</th>
-                            <th className="text-left px-3 py-2 font-medium">Description</th>
-                            <th className="text-left px-3 py-2 font-medium">
+                    <Box className="rounded-md border overflow-hidden">
+                      <Table className="text-xs">
+                        <TableHeader className="bg-muted/50">
+                          <TableRow>
+                            <TableHead className="text-left px-3 py-2 font-medium h-auto">Variable</TableHead>
+                            <TableHead className="text-left px-3 py-2 font-medium h-auto">Description</TableHead>
+                            <TableHead className="text-left px-3 py-2 font-medium h-auto">
                               Current Value
                               {plugin.enabled && isFetchingRawDisplay && !isLoadingRawDisplay && (
-                                <span className="ml-1.5 text-[10px] font-normal text-muted-foreground">
+                                <Text as="span" size="xs" tone="muted" className="ml-1.5 text-[10px] font-normal">
                                   (refreshing…)
-                                </span>
+                                </Text>
                               )}
-                            </th>
-                            <th className="text-center px-3 py-2 font-medium">Max</th>
-                          </tr>
-                        </thead>
-                        <tbody className="divide-y">
+                            </TableHead>
+                            <TableHead className="text-center px-3 py-2 font-medium h-auto">Max</TableHead>
+                          </TableRow>
+                        </TableHeader>
+                        <TableBody className="divide-y">
                           {hasVariableGroups
                             ? groupVariableRows(variableRows, variableGroups, "General").map((section) => (
                                 <Fragment key={section.groupId ?? "__general__"}>
-                                  <tr className="bg-muted/40">
-                                    <th
+                                  <TableRow className="bg-muted/40">
+                                    <TableHead
                                       scope="colgroup"
                                       colSpan={4}
-                                      className="text-left px-3 py-1.5 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground"
+                                      className="text-left px-3 py-1.5 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground h-auto"
                                     >
                                       {section.label}
-                                    </th>
-                                  </tr>
+                                    </TableHead>
+                                  </TableRow>
                                   {section.rows.map(renderVariableRow)}
                                 </Fragment>
                               ))
                             : variableRows.map(renderVariableRow)}
-                        </tbody>
-                      </table>
-                    </div>
-                    <p className="text-xs text-muted-foreground">
-                      Use in templates as <code className="bg-muted px-1 rounded">{`{{${plugin.id}.variable}}`}</code>
-                    </p>
-                  </div>
+                        </TableBody>
+                      </Table>
+                    </Box>
+                    <Text size="xs" tone="muted">
+                      Use in templates as <CodeChip className="bg-muted px-1 py-0 rounded">{`{{${plugin.id}.variable}}`}</CodeChip>
+                    </Text>
+                  </Stack>
                 </TooltipProvider>
               )}
 
               {/* Environment Variables Section */}
               {pluginDetails?.env_vars && pluginDetails.env_vars.length > 0 && (
-                <div className="space-y-3">
-                  <h4 className="text-sm font-medium text-muted-foreground">Environment Variables</h4>
-                  <div className="rounded-md border overflow-hidden">
-                    <table className="w-full text-xs">
-                      <thead className="bg-muted/50">
-                        <tr>
-                          <th className="text-left px-3 py-2 font-medium">Variable</th>
-                          <th className="text-left px-3 py-2 font-medium">Description</th>
-                          <th className="text-center px-3 py-2 font-medium">Required</th>
-                        </tr>
-                      </thead>
-                      <tbody className="divide-y">
+                <Stack gap="3">
+                  <Heading level={4} size="sm" className="font-medium text-muted-foreground">
+                    Environment Variables
+                  </Heading>
+                  <Box className="rounded-md border overflow-hidden">
+                    <Table className="text-xs">
+                      <TableHeader className="bg-muted/50">
+                        <TableRow>
+                          <TableHead className="text-left px-3 py-2 font-medium h-auto">Variable</TableHead>
+                          <TableHead className="text-left px-3 py-2 font-medium h-auto">Description</TableHead>
+                          <TableHead className="text-center px-3 py-2 font-medium h-auto">Required</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody className="divide-y">
                         {pluginDetails.env_vars.map((envVar) => (
-                          <tr key={envVar.name} className="hover:bg-muted/30">
-                            <td className="px-3 py-2">
-                              <code className="font-mono bg-muted px-1.5 py-0.5 rounded text-[11px]">
-                                {envVar.name}
-                              </code>
-                            </td>
-                            <td className="px-3 py-2 text-muted-foreground">{envVar.description}</td>
-                            <td className="px-3 py-2 text-center">
+                          <TableRow key={envVar.name} className="hover:bg-muted/30">
+                            <TableCell className="px-3 py-2">
+                              <CodeChip>{envVar.name}</CodeChip>
+                            </TableCell>
+                            <TableCell className="px-3 py-2 text-muted-foreground">{envVar.description}</TableCell>
+                            <TableCell className="px-3 py-2 text-center">
                               {envVar.required ? (
                                 <Badge variant="destructive" className="text-[10px]">
                                   Required
@@ -1366,13 +1404,13 @@ function PluginCard({
                                   Optional
                                 </Badge>
                               )}
-                            </td>
-                          </tr>
+                            </TableCell>
+                          </TableRow>
                         ))}
-                      </tbody>
-                    </table>
-                  </div>
-                </div>
+                      </TableBody>
+                    </Table>
+                  </Box>
+                </Stack>
               )}
 
               {/* Color Rules Section */}
@@ -1390,11 +1428,11 @@ function PluginCard({
               {(!pluginDetails?.settings_schema ||
                 Object.keys(pluginDetails.settings_schema.properties || {}).length === 0) &&
                 variableRows.length === 0 && (
-                  <p className="text-sm text-muted-foreground">No configuration options available for this plugin.</p>
+                  <Text tone="muted">No configuration options available for this plugin.</Text>
                 )}
             </>
           )}
-        </div>
+        </Stack>
         <SheetFooter className="flex-col gap-2 sm:flex-row">
           {isExternal && onUninstall && (
             <Button
@@ -1426,25 +1464,27 @@ function PluginCard({
 
   const rows = (
     <>
-      <tr
+      <TableRow
         className={cn(
           "border-b last:border-b-0 transition-colors",
           plugin.enabled ? "hover:bg-muted/30" : "opacity-60 hover:opacity-80 hover:bg-muted/20",
         )}
       >
         {/* Name column: icon + name + version + source badges */}
-        <td className="px-4 py-2.5">
-          <div className="flex items-center gap-3">
-            <div
+        <TableCell className="px-4 py-2.5">
+          <Flex align="center" gap="3">
+            <Box
               className={cn(
                 "p-1.5 rounded-md shrink-0",
                 plugin.enabled ? "bg-primary/10 text-primary" : "bg-muted text-muted-foreground",
               )}
             >
               <Icon className="h-4 w-4" />
-            </div>
-            <div className="flex items-center gap-1.5 flex-wrap min-w-0">
-              <span className="font-medium text-sm whitespace-nowrap">{plugin.name}</span>
+            </Box>
+            <Flex align="center" gap="1.5" wrap className="min-w-0">
+              <Text as="span" weight="medium" className="whitespace-nowrap">
+                {plugin.name}
+              </Text>
               <Badge variant="outline" className="text-[10px] font-normal px-1.5 py-0 h-4 shrink-0">
                 v{plugin.version}
               </Badge>
@@ -1453,7 +1493,7 @@ function PluginCard({
                   variant="outline"
                   className="text-[10px] gap-1 font-normal px-1.5 py-0 h-4 shrink-0 border-orange-300 text-orange-600 dark:text-orange-400 dark:border-orange-700"
                 >
-                  <Box className="h-2.5 w-2.5" />
+                  <BoxIcon className="h-2.5 w-2.5" />
                   Core
                 </Badge>
               )}
@@ -1484,17 +1524,17 @@ function PluginCard({
                   Update
                 </Badge>
               )}
-            </div>
-          </div>
-        </td>
+            </Flex>
+          </Flex>
+        </TableCell>
 
         {/* Category column */}
-        <td className="px-4 py-2.5 text-sm text-muted-foreground whitespace-nowrap hidden sm:table-cell">
+        <TableCell className="px-4 py-2.5 text-sm text-muted-foreground whitespace-nowrap hidden sm:table-cell">
           {categoryLabel}
-        </td>
+        </TableCell>
 
         {/* Status column */}
-        <td className="px-4 py-2.5 whitespace-nowrap hidden md:table-cell">
+        <TableCell className="px-4 py-2.5 whitespace-nowrap hidden md:table-cell">
           {plugin.enabled ? (
             plugin.configured ? (
               <Badge variant="default" className="text-[10px] gap-1 px-1.5 py-0 h-5">
@@ -1513,11 +1553,11 @@ function PluginCard({
               Disabled
             </Badge>
           )}
-        </td>
+        </TableCell>
 
         {/* Actions column: toggle + configure + overflow */}
-        <td className="px-4 py-2.5">
-          <div className="flex items-center justify-end gap-0.5">
+        <TableCell className="px-4 py-2.5">
+          <Flex align="center" justify="end" gap="0.5">
             <Switch
               checked={plugin.enabled}
               onCheckedChange={(checked) => onToggle(plugin.id, checked)}
@@ -1586,13 +1626,13 @@ function PluginCard({
                 )}
               </DropdownMenuContent>
             </DropdownMenu>
-          </div>
-        </td>
-      </tr>
+          </Flex>
+        </TableCell>
+      </TableRow>
       {showAddInstance && (
-        <tr className="border-b last:border-b-0">
-          <td colSpan={4} className="px-4 py-3">
-            <div className="flex items-center gap-3 max-w-md">
+        <TableRow className="border-b last:border-b-0">
+          <TableCell colSpan={4} className="px-4 py-3">
+            <Flex align="center" gap="3" className="max-w-md">
               <Label htmlFor={`instance-label-${plugin.id}`} className="text-sm whitespace-nowrap">
                 Instance name:
               </Label>
@@ -1632,13 +1672,13 @@ function PluginCard({
               >
                 Cancel
               </Button>
-            </div>
-            <p className="text-xs text-muted-foreground mt-1.5">
+            </Flex>
+            <Text size="xs" tone="muted" className="mt-1.5">
               Creates a new independent instance of this plugin with its own configuration. Use alphanumeric characters,
               hyphens, or underscores (1-40 chars).
-            </p>
-          </td>
-        </tr>
+            </Text>
+          </TableCell>
+        </TableRow>
       )}
     </>
   );
@@ -1702,20 +1742,20 @@ function RegistryPluginCard({
 }) {
   const Icon = getPluginIcon(entry.icon);
   return (
-    <div className="rounded-xl animate-card-fade-in h-full" style={{ animationDelay: `${index * 60}ms` }}>
+    <Box className="rounded-xl animate-card-fade-in h-full" style={{ animationDelay: `${index * 60}ms` }}>
       <Link href={`/integrations/${entry.id}`} className="block h-full group">
         <Card className="h-full flex flex-col group-hover:bg-muted/20 transition-colors">
           <CardHeader className="pb-3">
-            <div className="flex items-start justify-between gap-4">
-              <div className="flex items-center gap-3">
-                <div className="p-2 rounded-lg bg-muted text-muted-foreground shrink-0">
+            <Flex align="start" justify="between" gap="4">
+              <Flex align="center" gap="3">
+                <Box className="p-2 rounded-lg bg-muted text-muted-foreground shrink-0">
                   <Icon className="h-5 w-5" />
-                </div>
-                <div>
+                </Box>
+                <Box>
                   <CardTitle className="text-base">{entry.name}</CardTitle>
                   <CardDescription className="text-xs mt-0.5">by {entry.author}</CardDescription>
-                </div>
-              </div>
+                </Box>
+              </Flex>
               {isInstalled ? (
                 <Badge variant="secondary" className="text-xs gap-1 shrink-0 self-start mt-0.5">
                   <CheckCircle className="h-3 w-3" />
@@ -1737,17 +1777,19 @@ function RegistryPluginCard({
                   {isInstalling ? "Installing..." : "Install"}
                 </Button>
               )}
-            </div>
+            </Flex>
           </CardHeader>
           <CardContent className="pt-0 flex flex-col flex-1">
-            <p className="text-sm text-muted-foreground mb-3 line-clamp-2 flex-1">{entry.description}</p>
+            <Text tone="muted" className="mb-3 line-clamp-2 flex-1">
+              {entry.description}
+            </Text>
             <Badge variant="secondary" className="text-xs gap-1 self-start">
               {CATEGORY_LABELS[entry.category || "utility"] || entry.category || "Utility"}
             </Badge>
           </CardContent>
         </Card>
       </Link>
-    </div>
+    </Box>
   );
 }
 
@@ -1764,33 +1806,37 @@ function RegistryPluginRow({
 }) {
   const Icon = getPluginIcon(entry.icon);
   return (
-    <tr className="border-b last:border-b-0 hover:bg-muted/30 transition-colors">
-      <td className="px-4 py-2.5">
+    <TableRow className="border-b last:border-b-0 hover:bg-muted/30 transition-colors">
+      <TableCell className="px-4 py-2.5">
         <Link href={`/integrations/${entry.id}`} className="flex items-center gap-3 group">
-          <div className="p-1.5 rounded-md bg-muted text-muted-foreground shrink-0">
+          <Box className="p-1.5 rounded-md bg-muted text-muted-foreground shrink-0">
             <Icon className="h-4 w-4" />
-          </div>
-          <div>
-            <div className="flex items-center gap-2">
-              <span className="font-medium text-sm group-hover:underline underline-offset-2">{entry.name}</span>
+          </Box>
+          <Box>
+            <Flex align="center" gap="2">
+              <Text as="span" weight="medium" className="group-hover:underline underline-offset-2">
+                {entry.name}
+              </Text>
               {isInstalled && (
                 <Badge variant="secondary" className="text-[10px] gap-1 px-1.5 py-0 h-5">
                   <CheckCircle className="h-2.5 w-2.5" />
                   Installed
                 </Badge>
               )}
-            </div>
+            </Flex>
             {entry.description && (
-              <p className="text-xs text-muted-foreground truncate max-w-xs">{entry.description}</p>
+              <Text size="xs" tone="muted" className="truncate max-w-xs">
+                {entry.description}
+              </Text>
             )}
-          </div>
+          </Box>
         </Link>
-      </td>
-      <td className="px-4 py-2.5 text-sm text-muted-foreground whitespace-nowrap">
+      </TableCell>
+      <TableCell className="px-4 py-2.5 text-sm text-muted-foreground whitespace-nowrap">
         {CATEGORY_LABELS[entry.category || "utility"] || entry.category || "Utility"}
-      </td>
-      <td className="px-4 py-2.5 text-sm text-muted-foreground whitespace-nowrap">{entry.author}</td>
-      <td className="px-4 py-2.5 text-right">
+      </TableCell>
+      <TableCell className="px-4 py-2.5 text-sm text-muted-foreground whitespace-nowrap">{entry.author}</TableCell>
+      <TableCell className="px-4 py-2.5 text-right">
         {!isInstalled && (
           <Button
             size="sm"
@@ -1803,8 +1849,8 @@ function RegistryPluginRow({
             {isInstalling ? "Installing..." : "Install"}
           </Button>
         )}
-      </td>
-    </tr>
+      </TableCell>
+    </TableRow>
   );
 }
 
@@ -2119,8 +2165,8 @@ export default function IntegrationsPage() {
           <AlertTitle>{t("securityWarningTitle")}</AlertTitle>
           <AlertDescription>{t("securityWarning")}</AlertDescription>
         </Alert>
-        <div className="space-y-4 py-2">
-          <div className="space-y-2">
+        <Stack gap="4" className="py-2">
+          <Stack gap="2">
             <Label htmlFor="git-url">{t("repoUrl")}</Label>
             <Input
               id="git-url"
@@ -2129,9 +2175,9 @@ export default function IntegrationsPage() {
               onChange={(e) => setGitUrl(e.target.value)}
               disabled={isInstallingGit}
             />
-          </div>
-          <div className="grid grid-cols-2 gap-4">
-            <div className="space-y-2">
+          </Stack>
+          <Grid cols="2" gap="4">
+            <Stack gap="2">
               <Label htmlFor="git-plugin-id">{t("pluginIdOptional")}</Label>
               <Input
                 id="git-plugin-id"
@@ -2140,8 +2186,8 @@ export default function IntegrationsPage() {
                 onChange={(e) => setGitPluginId(e.target.value)}
                 disabled={isInstallingGit}
               />
-            </div>
-            <div className="space-y-2">
+            </Stack>
+            <Stack gap="2">
               <Label htmlFor="git-branch">{t("branchOptional")}</Label>
               <Input
                 id="git-branch"
@@ -2150,9 +2196,9 @@ export default function IntegrationsPage() {
                 onChange={(e) => setGitBranch(e.target.value)}
                 disabled={isInstallingGit}
               />
-            </div>
-          </div>
-        </div>
+            </Stack>
+          </Grid>
+        </Stack>
         <DialogFooter>
           <Button variant="outline" onClick={() => setGitDialogOpen(false)} disabled={isInstallingGit}>
             {tCommon("cancel")}
@@ -2178,7 +2224,7 @@ export default function IntegrationsPage() {
   return (
     <PageLayout>
       <PageHeader icon={Puzzle} title={t("title")} description={t("description")}>
-        <div className="mt-3 flex justify-start sm:justify-end">
+        <Flex className="mt-3 justify-start sm:justify-end">
           <Button
             variant="outline"
             size="sm"
@@ -2189,12 +2235,12 @@ export default function IntegrationsPage() {
             <RefreshCw className={cn("h-3.5 w-3.5", isCheckingForUpdates && "animate-spin")} />
             {isCheckingForUpdates ? t("checking") : t("checkForUpdates")}
           </Button>
-        </div>
+        </Flex>
       </PageHeader>
 
       {/* Tabs */}
       <Tabs value={activeTab} onValueChange={setActiveTab}>
-        <div
+        <Box
           className={
             activeTab === "marketplace"
               ? "mb-4 grid grid-cols-1 gap-3 items-center md:grid-cols-[auto_minmax(12rem,1fr)_auto]"
@@ -2219,7 +2265,7 @@ export default function IntegrationsPage() {
               )}
             </TabsTrigger>
           </TabsList>
-          <div className="relative min-w-0 w-full">
+          <Box className="relative min-w-0 w-full">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
             <Input
               placeholder={
@@ -2229,10 +2275,10 @@ export default function IntegrationsPage() {
               onChange={(e) => setSearchQuery(e.target.value)}
               className="pl-9 w-full"
             />
-          </div>
+          </Box>
           {activeTab === "marketplace" && (
-            <div className="flex items-center gap-2 shrink-0 md:justify-self-end">
-              <div className="flex rounded-md border overflow-hidden">
+            <Flex align="center" gap="2" className="shrink-0 md:justify-self-end">
+              <Flex className="rounded-md border overflow-hidden">
                 <Button
                   variant={marketplaceView === "card" ? "secondary" : "ghost"}
                   size="icon"
@@ -2251,98 +2297,104 @@ export default function IntegrationsPage() {
                 >
                   <LayoutList className="h-4 w-4" />
                 </Button>
-              </div>
+              </Flex>
               <Button variant="outline" className="gap-2" onClick={() => setGitDialogOpen(true)}>
                 <GitBranch className="h-4 w-4" />
                 {t("addFromGit")}
               </Button>
-            </div>
+            </Flex>
           )}
-        </div>
+        </Box>
 
         {/* ── Installed Tab ── */}
         <TabsContent value="installed" className="mt-0">
           {isLoading ? (
             <Card className="overflow-hidden">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="border-b bg-muted/40">
-                    <th className="px-4 py-2.5 text-left font-medium text-muted-foreground text-xs">
+              <Table>
+                <TableHeader>
+                  <TableRow className="border-b bg-muted/40">
+                    <TableHead className="px-4 py-2.5 text-left font-medium text-muted-foreground text-xs h-auto">
                       {t("nameColumn")}
-                    </th>
-                    <th className="px-4 py-2.5 text-left font-medium text-muted-foreground text-xs hidden sm:table-cell">
+                    </TableHead>
+                    <TableHead className="px-4 py-2.5 text-left font-medium text-muted-foreground text-xs hidden sm:table-cell h-auto">
                       {t("categoryColumn")}
-                    </th>
-                    <th className="px-4 py-2.5 text-left font-medium text-muted-foreground text-xs hidden md:table-cell">
+                    </TableHead>
+                    <TableHead className="px-4 py-2.5 text-left font-medium text-muted-foreground text-xs hidden md:table-cell h-auto">
                       {t("statusColumn")}
-                    </th>
-                    <th className="px-4 py-2.5 w-32" />
-                  </tr>
-                </thead>
-                <tbody>
+                    </TableHead>
+                    <TableHead className="px-4 py-2.5 w-32 h-auto" />
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
                   {[...Array(5)].map((_, i) => (
-                    <tr key={i} className="border-b last:border-b-0">
-                      <td className="px-4 py-2.5">
-                        <div className="flex items-center gap-3">
+                    <TableRow key={i} className="border-b last:border-b-0">
+                      <TableCell className="px-4 py-2.5">
+                        <Flex align="center" gap="3">
                           <Skeleton className="h-7 w-7 rounded-md shrink-0" />
-                          <div className="flex items-center gap-2">
+                          <Flex align="center" gap="2">
                             <Skeleton className="h-4 w-32" />
                             <Skeleton className="h-4 w-10" />
-                          </div>
-                        </div>
-                      </td>
-                      <td className="px-4 py-2.5 hidden sm:table-cell">
+                          </Flex>
+                        </Flex>
+                      </TableCell>
+                      <TableCell className="px-4 py-2.5 hidden sm:table-cell">
                         <Skeleton className="h-4 w-20" />
-                      </td>
-                      <td className="px-4 py-2.5 hidden md:table-cell">
+                      </TableCell>
+                      <TableCell className="px-4 py-2.5 hidden md:table-cell">
                         <Skeleton className="h-5 w-24 rounded-full" />
-                      </td>
-                      <td className="px-4 py-2.5">
-                        <div className="flex items-center justify-end gap-1">
+                      </TableCell>
+                      <TableCell className="px-4 py-2.5">
+                        <Flex align="center" justify="end" gap="1">
                           <Skeleton className="h-5 w-9 rounded-full" />
                           <Skeleton className="h-7 w-7 rounded" />
                           <Skeleton className="h-7 w-7 rounded" />
-                        </div>
-                      </td>
-                    </tr>
+                        </Flex>
+                      </TableCell>
+                    </TableRow>
                   ))}
-                </tbody>
-              </table>
+                </TableBody>
+              </Table>
             </Card>
           ) : error ? (
             <Card className="border-destructive">
               <CardContent className="flex items-center gap-3 py-6">
                 <AlertCircle className="h-5 w-5 text-destructive" />
-                <p className="text-sm text-destructive">
+                <Text tone="destructive">
                   {t("loadPluginsError", { error: error instanceof Error ? error.message : tCommon("error") })}
-                </p>
+                </Text>
               </CardContent>
             </Card>
           ) : filteredInstalled.length === 0 ? (
-            <div className="text-center py-16">
+            <Box className="text-center py-16">
               {query ? (
                 <>
                   <Search className="h-10 w-10 text-muted-foreground mx-auto mb-3" />
-                  <p className="text-muted-foreground">{t("noInstalledMatch", { query: searchQuery })}</p>
+                  <Text tone="muted">{t("noInstalledMatch", { query: searchQuery })}</Text>
                 </>
               ) : (
                 <>
                   <Puzzle className="h-10 w-10 text-muted-foreground mx-auto mb-3" />
-                  <p className="font-medium mb-1">{t("noPluginsInstalled")}</p>
-                  <p className="text-sm text-muted-foreground mb-4">{t("headToMarketplace")}</p>
+                  <Text weight="medium" className="mb-1">
+                    {t("noPluginsInstalled")}
+                  </Text>
+                  <Text tone="muted" className="mb-4">
+                    {t("headToMarketplace")}
+                  </Text>
                   <Button variant="outline" onClick={() => setActiveTab("marketplace")}>
                     {t("browseMarketplace")}
                   </Button>
                 </>
               )}
-            </div>
+            </Box>
           ) : (
-            <div className="space-y-3">
+            <Stack gap="3">
               {updatesAvailableCount > 0 && (
-                <div className="flex items-center justify-between rounded-lg border border-amber-200 bg-amber-50 px-4 py-2.5 dark:border-amber-800 dark:bg-amber-950/40">
-                  <p className="text-sm text-amber-700 dark:text-amber-400">
-                    {t("pluginUpdatesAvailable", { count: updatesAvailableCount })}
-                  </p>
+                <Flex
+                  align="center"
+                  justify="between"
+                  className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-2.5 dark:border-amber-800 dark:bg-amber-950/40"
+                >
+                  <Text tone="warning">{t("pluginUpdatesAvailable", { count: updatesAvailableCount })}</Text>
                   <Button
                     size="sm"
                     variant="outline"
@@ -2353,12 +2405,12 @@ export default function IntegrationsPage() {
                     <RefreshCw className={cn("h-3.5 w-3.5 mr-1.5", isUpdatingAll && "animate-spin")} />
                     {isUpdatingAll ? t("updating") : t("updateAllCount", { count: updatesAvailableCount })}
                   </Button>
-                </div>
+                </Flex>
               )}
               <Card className="overflow-hidden animate-card-fade-in">
-                <table className="w-full text-sm">
-                  <thead>
-                    <tr className="border-b bg-muted/40">
+                <Table>
+                  <TableHeader>
+                    <TableRow className="border-b bg-muted/40">
                       {(["name", "category", "status"] as const).map((col) => {
                         const labels: Record<string, string> = {
                           name: t("nameColumn"),
@@ -2367,16 +2419,16 @@ export default function IntegrationsPage() {
                         };
                         const active = installedSort.key === col;
                         return (
-                          <th
+                          <TableHead
                             key={col}
                             className={cn(
-                              "px-4 py-2.5 text-left font-medium text-muted-foreground text-xs cursor-pointer select-none hover:text-foreground transition-colors",
+                              "px-4 py-2.5 text-left font-medium text-muted-foreground text-xs cursor-pointer select-none hover:text-foreground transition-colors h-auto",
                               col === "category" && "hidden sm:table-cell",
                               col === "status" && "hidden md:table-cell",
                             )}
                             onClick={() => handleInstalledSort(col)}
                           >
-                            <span className="flex items-center gap-1">
+                            <Flex align="center" gap="1">
                               {labels[col]}
                               {active ? (
                                 installedSort.dir === "asc" ? (
@@ -2387,14 +2439,14 @@ export default function IntegrationsPage() {
                               ) : (
                                 <ChevronsUp className="h-3 w-3 opacity-30" />
                               )}
-                            </span>
-                          </th>
+                            </Flex>
+                          </TableHead>
                         );
                       })}
-                      <th className="px-4 py-2.5 w-32" />
-                    </tr>
-                  </thead>
-                  <tbody>
+                      <TableHead className="px-4 py-2.5 w-32 h-auto" />
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
                     {sortedInstalled.map((plugin) => (
                       <PluginCard
                         key={plugin.id}
@@ -2408,44 +2460,52 @@ export default function IntegrationsPage() {
                         isUpdating={updatingId === plugin.id}
                       />
                     ))}
-                  </tbody>
-                </table>
+                  </TableBody>
+                </Table>
               </Card>
-            </div>
+            </Stack>
           )}
         </TabsContent>
 
         {/* ── Marketplace Tab ── */}
         <TabsContent value="marketplace" className="mt-0">
           {filteredRegistry.length === 0 ? (
-            <div className="text-center py-16">
+            <Box className="text-center py-16">
               {query ? (
                 <>
                   <Search className="h-10 w-10 text-muted-foreground mx-auto mb-3" />
-                  <p className="text-muted-foreground">{t("noPluginsMatch", { query: searchQuery })}</p>
+                  <Text tone="muted">{t("noPluginsMatch", { query: searchQuery })}</Text>
                 </>
               ) : (
                 <>
                   <Puzzle className="h-10 w-10 text-muted-foreground mx-auto mb-3" />
-                  <p className="font-medium mb-1">{t("noRegistryPluginsFound")}</p>
-                  <p className="text-sm text-muted-foreground">{t("canInstallCustomGitDescription")}</p>
+                  <Text weight="medium" className="mb-1">
+                    {t("noRegistryPluginsFound")}
+                  </Text>
+                  <Text tone="muted">{t("canInstallCustomGitDescription")}</Text>
                 </>
               )}
-            </div>
+            </Box>
           ) : marketplaceView === "card" ? (
-            <div className="space-y-6 animate-card-fade-in">
+            <Stack gap="6" className="animate-card-fade-in">
               {(() => {
                 let globalIndex = 0;
                 return marketplaceCategories.map((category) => {
                   const entries = groupedRegistry[category] ?? [];
                   if (entries.length === 0) return null;
                   return (
-                    <section key={category}>
-                      <h2 className="text-sm font-medium text-muted-foreground uppercase tracking-wide mb-3 flex items-center gap-2">
+                    <Box as="section" key={category}>
+                      <Heading
+                        level={2}
+                        size="sm"
+                        className="font-medium text-muted-foreground uppercase tracking-wide mb-3 flex items-center gap-2"
+                      >
                         {CATEGORY_LABELS[category] || category}
-                        <span className="text-xs font-normal normal-case tracking-normal">({entries.length})</span>
-                      </h2>
-                      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3 items-stretch">
+                        <Text as="span" size="xs" tone="muted" className="normal-case tracking-normal">
+                          ({entries.length})
+                        </Text>
+                      </Heading>
+                      <Grid cols="1" md="2" gap="4" className="xl:grid-cols-3 items-stretch">
                         {entries.map((entry) => {
                           const cardIndex = globalIndex++;
                           return (
@@ -2459,18 +2519,18 @@ export default function IntegrationsPage() {
                             />
                           );
                         })}
-                      </div>
-                    </section>
+                      </Grid>
+                    </Box>
                   );
                 });
               })()}
-            </div>
+            </Stack>
           ) : (
             /* List view */
             <Card className="overflow-hidden animate-card-fade-in">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="border-b bg-muted/40">
+              <Table>
+                <TableHeader>
+                  <TableRow className="border-b bg-muted/40">
                     {(["name", "category", "author"] as const).map((col) => {
                       const labels: Record<string, string> = {
                         name: t("nameColumn"),
@@ -2479,12 +2539,12 @@ export default function IntegrationsPage() {
                       };
                       const active = marketplaceSort.key === col;
                       return (
-                        <th
+                        <TableHead
                           key={col}
-                          className="px-4 py-2.5 text-left font-medium text-muted-foreground text-xs cursor-pointer select-none hover:text-foreground transition-colors"
+                          className="px-4 py-2.5 text-left font-medium text-muted-foreground text-xs cursor-pointer select-none hover:text-foreground transition-colors h-auto"
                           onClick={() => handleMarketplaceSort(col)}
                         >
-                          <span className="flex items-center gap-1">
+                          <Flex align="center" gap="1">
                             {labels[col]}
                             {active ? (
                               marketplaceSort.dir === "asc" ? (
@@ -2495,14 +2555,14 @@ export default function IntegrationsPage() {
                             ) : (
                               <ChevronsUp className="h-3 w-3 opacity-30" />
                             )}
-                          </span>
-                        </th>
+                          </Flex>
+                        </TableHead>
                       );
                     })}
-                    <th className="px-4 py-2.5 w-24" />
-                  </tr>
-                </thead>
-                <tbody>
+                    <TableHead className="px-4 py-2.5 w-24 h-auto" />
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
                   {sortedRegistry.map((entry) => (
                     <RegistryPluginRow
                       key={entry.id}
@@ -2512,8 +2572,8 @@ export default function IntegrationsPage() {
                       isInstalled={installedIds.has(entry.id)}
                     />
                   ))}
-                </tbody>
-              </table>
+                </TableBody>
+              </Table>
             </Card>
           )}
         </TabsContent>

--- a/web/app/routes/integrations._index.tsx
+++ b/web/app/routes/integrations._index.tsx
@@ -2375,7 +2375,7 @@ export default function IntegrationsPage() {
               ) : (
                 <>
                   <Puzzle className="h-10 w-10 text-muted-foreground mx-auto mb-3" />
-                  <Text weight="medium" className="mb-1">
+                  <Text size="base" weight="medium" className="mb-1">
                     {t("noPluginsInstalled")}
                   </Text>
                   <Text tone="muted" className="mb-4">
@@ -2480,7 +2480,7 @@ export default function IntegrationsPage() {
               ) : (
                 <>
                   <Puzzle className="h-10 w-10 text-muted-foreground mx-auto mb-3" />
-                  <Text weight="medium" className="mb-1">
+                  <Text size="base" weight="medium" className="mb-1">
                     {t("noRegistryPluginsFound")}
                   </Text>
                   <Text tone="muted">{t("canInstallCustomGitDescription")}</Text>

--- a/web/app/routes/integrations._index.tsx
+++ b/web/app/routes/integrations._index.tsx
@@ -1366,7 +1366,8 @@ function PluginCard({
                       </Table>
                     </Box>
                     <Text size="xs" tone="muted">
-                      Use in templates as <CodeChip className="bg-muted px-1 py-0 rounded">{`{{${plugin.id}.variable}}`}</CodeChip>
+                      Use in templates as{" "}
+                      <CodeChip className="bg-muted px-1 py-0 rounded">{`{{${plugin.id}.variable}}`}</CodeChip>
                     </Text>
                   </Stack>
                 </TooltipProvider>

--- a/web/app/routes/login.tsx
+++ b/web/app/routes/login.tsx
@@ -25,6 +25,7 @@
 import {
   Alert,
   AlertDescription,
+  Box,
   Button,
   Card,
   CardContent,
@@ -34,8 +35,12 @@ import {
   CardTitle,
   Checkbox,
   FiestaLogo,
+  Flex,
   Input,
   Label,
+  Stack,
+  Text,
+  TextLink,
 } from "@fiestaboard/ui";
 import { Loader2, Lock, ShieldAlert, ShieldCheck, ShieldQuestion } from "lucide-react";
 import { type FormEvent, useCallback, useEffect, useRef, useState } from "react";
@@ -264,7 +269,7 @@ export default function LoginPage() {
   if (!status) {
     return (
       <CenteredCard tCommon={tCommon} icon={<Loader2 className="h-6 w-6 animate-spin" />} title={t("loadingTitle")}>
-        <p className="text-sm text-muted-foreground">{t("loadingDescription")}</p>
+        <Text tone="muted">{t("loadingDescription")}</Text>
       </CenteredCard>
     );
   }
@@ -273,7 +278,7 @@ export default function LoginPage() {
   if (!status.enabled || status.authenticated) {
     return (
       <CenteredCard tCommon={tCommon} icon={<Loader2 className="h-6 w-6 animate-spin" />} title={t("redirectingTitle")}>
-        <p className="text-sm text-muted-foreground">{t("redirectingDescription")}</p>
+        <Text tone="muted">{t("redirectingDescription")}</Text>
       </CenteredCard>
     );
   }
@@ -288,7 +293,7 @@ export default function LoginPage() {
         title={t("protectTitle")}
         description={t("protectDescription")}
       >
-        <div className="space-y-3">
+        <Stack gap="3">
           <Button
             type="button"
             variant="brand"
@@ -312,8 +317,10 @@ export default function LoginPage() {
               <AlertDescription>{formError}</AlertDescription>
             </Alert>
           )}
-          <p className="text-xs text-muted-foreground">{t("protectFootnote")}</p>
-        </div>
+          <Text size="xs" tone="muted">
+            {t("protectFootnote")}
+          </Text>
+        </Stack>
       </CenteredCard>
     );
   }
@@ -326,8 +333,8 @@ export default function LoginPage() {
         title={t("setupTitle")}
         description={t("setupDescription")}
       >
-        <form className="space-y-4" onSubmit={handleSetup}>
-          <div className="space-y-2">
+        <Box as="form" className="space-y-4" onSubmit={handleSetup}>
+          <Stack gap="2">
             <Label htmlFor="username">{t("usernameLabel")}</Label>
             <Input
               id="username"
@@ -340,8 +347,8 @@ export default function LoginPage() {
               onChange={(e) => setUsername(e.target.value)}
               disabled={submitting}
             />
-          </div>
-          <div className="space-y-2">
+          </Stack>
+          <Stack gap="2">
             <Label htmlFor="password">{t("passwordLabel")}</Label>
             <Input
               id="password"
@@ -355,9 +362,11 @@ export default function LoginPage() {
               onChange={(e) => setPassword(e.target.value)}
               disabled={submitting}
             />
-            <p className="text-xs text-muted-foreground">{t("passwordMinHint")}</p>
-          </div>
-          <div className="space-y-2">
+            <Text size="xs" tone="muted">
+              {t("passwordMinHint")}
+            </Text>
+          </Stack>
+          <Stack gap="2">
             <Label htmlFor="confirm-password">{t("confirmPasswordLabel")}</Label>
             <Input
               id="confirm-password"
@@ -370,7 +379,7 @@ export default function LoginPage() {
               onChange={(e) => setConfirmPassword(e.target.value)}
               disabled={submitting}
             />
-          </div>
+          </Stack>
           {formError && (
             <Alert variant="destructive">
               <AlertDescription>{formError}</AlertDescription>
@@ -385,7 +394,7 @@ export default function LoginPage() {
               t("createButton")
             )}
           </Button>
-        </form>
+        </Box>
       </CenteredCard>
     );
   }
@@ -397,8 +406,8 @@ export default function LoginPage() {
       title={t("signInTitle")}
       description={t("signInDescription")}
     >
-      <form className="space-y-4" onSubmit={handleLogin}>
-        <div className="space-y-2">
+      <Box as="form" className="space-y-4" onSubmit={handleLogin}>
+        <Stack gap="2">
           <Label htmlFor="username">{t("usernameLabel")}</Label>
           <Input
             id="username"
@@ -411,8 +420,8 @@ export default function LoginPage() {
             onChange={(e) => setUsername(e.target.value)}
             disabled={submitting}
           />
-        </div>
-        <div className="space-y-2">
+        </Stack>
+        <Stack gap="2">
           <Label htmlFor="password">{t("passwordLabel")}</Label>
           <Input
             id="password"
@@ -425,8 +434,8 @@ export default function LoginPage() {
             onChange={(e) => setPassword(e.target.value)}
             disabled={submitting}
           />
-        </div>
-        <div className="flex items-center gap-2">
+        </Stack>
+        <Flex align="center" gap="2">
           <Checkbox
             id="remember-me"
             name="remember-me"
@@ -437,7 +446,7 @@ export default function LoginPage() {
           <Label htmlFor="remember-me" className="cursor-pointer">
             {t("rememberMeLabel")}
           </Label>
-        </div>
+        </Flex>
         {formError && (
           <Alert variant="destructive">
             <AlertDescription>{formError}</AlertDescription>
@@ -452,7 +461,7 @@ export default function LoginPage() {
             t("submitButton")
           )}
         </Button>
-      </form>
+      </Box>
     </CenteredCard>
   );
 }
@@ -474,38 +483,36 @@ function CenteredCard({
 }) {
   const t = useTranslations("login");
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-background p-4">
-      <div className="mb-6 flex items-center gap-3">
+    <Flex direction="col" align="center" justify="center" className="min-h-screen bg-background p-4">
+      <Flex align="center" gap="3" className="mb-6">
         <img src={appUrl("/icons/favicon-32x32.png")} alt="" width={36} height={36} className="flex-shrink-0" />
         <FiestaLogo className="text-2xl" />
-      </div>
+      </Flex>
       <Card className="w-full max-w-md">
         <CardHeader className="space-y-1">
-          <div className="flex items-center gap-2">
+          <Flex align="center" gap="2">
             {icon}
             <CardTitle as="h1">{title}</CardTitle>
-          </div>
+          </Flex>
           {description && <CardDescription>{description}</CardDescription>}
         </CardHeader>
         <CardContent>{children}</CardContent>
         <CardFooter className="text-xs text-muted-foreground">
           {t.rich("changeLater", {
             link: (chunks) => (
-              <a
-                href="https://fiestaboard.app/docs/setup/authentication"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="underline hover:text-foreground"
-              >
+              <TextLink href="https://fiestaboard.app/docs/setup/authentication" target="_blank" rel="noopener noreferrer">
                 {chunks}
                 {/* sr-only cue lets screen-reader users know this link
                     leaves the app (WCAG 2.4.4 / 3.2.5). */}
-                <span className="sr-only"> {tCommon("opensInNewTab")}</span>
-              </a>
+                <Text as="span" className="sr-only">
+                  {" "}
+                  {tCommon("opensInNewTab")}
+                </Text>
+              </TextLink>
             ),
           })}
         </CardFooter>
       </Card>
-    </div>
+    </Flex>
   );
 }

--- a/web/app/routes/login.tsx
+++ b/web/app/routes/login.tsx
@@ -500,7 +500,11 @@ function CenteredCard({
         <CardFooter className="text-xs text-muted-foreground">
           {t.rich("changeLater", {
             link: (chunks) => (
-              <TextLink href="https://fiestaboard.app/docs/setup/authentication" target="_blank" rel="noopener noreferrer">
+              <TextLink
+                href="https://fiestaboard.app/docs/setup/authentication"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
                 {chunks}
                 {/* sr-only cue lets screen-reader users know this link
                     leaves the app (WCAG 2.4.4 / 3.2.5). */}

--- a/web/app/routes/offline.tsx
+++ b/web/app/routes/offline.tsx
@@ -1,3 +1,4 @@
+import { Box, Flex, List, ListItem, Stack, Text } from "@fiestaboard/ui";
 import { RefreshCw, WifiOff } from "lucide-react";
 import { useEffect, useState } from "react";
 
@@ -40,21 +41,23 @@ export default function OfflinePage() {
   }, [isOnline]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-background p-4">
-      <div className="max-w-md w-full text-center space-y-6">
-        <div className="flex justify-center">
-          <div className="rounded-full bg-muted p-6">
+    <Flex align="center" justify="center" className="min-h-screen bg-background p-4">
+      <Stack gap="6" className="max-w-md w-full text-center">
+        <Flex justify="center">
+          <Box className="rounded-full bg-muted p-6">
             <WifiOff className="h-12 w-12 text-muted-foreground" />
-          </div>
-        </div>
+          </Box>
+        </Flex>
 
-        <div className="space-y-2">
+        <Stack gap="2">
+          {/* Reserved for PageHeader elsewhere; this standalone offline splash has no icon/description
+              card to match, so the h1 stays raw here (couldn't snap — see wave 1 report). */}
           <h1 className="text-3xl font-bold tracking-tight">{isOnline ? t("reconnecting") : t("youreOffline")}</h1>
-          <p className="text-muted-foreground">{isOnline ? t("connectionRestored") : t("offlineDescription")}</p>
-        </div>
+          <Text tone="muted">{isOnline ? t("connectionRestored") : t("offlineDescription")}</Text>
+        </Stack>
 
         {!isOnline && (
-          <div className="space-y-4">
+          <Stack gap="4">
             <button
               onClick={handleRetry}
               className="inline-flex items-center justify-center gap-2 rounded-md bg-primary px-6 py-3 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
@@ -63,23 +66,23 @@ export default function OfflinePage() {
               {t("tryAgain")}
             </button>
 
-            <div className="text-sm text-muted-foreground">
-              <p>{t("whileOffline")}</p>
-              <ul className="mt-2 space-y-1">
-                <li>• {t("viewPreviouslyLoaded")}</li>
-                <li>• {t("accessCached")}</li>
-                <li>• {t("browseSaved")}</li>
-              </ul>
-            </div>
-          </div>
+            <Box className="text-sm text-muted-foreground">
+              <Text tone="muted">{t("whileOffline")}</Text>
+              <List gap="1" className="mt-2">
+                <ListItem>• {t("viewPreviouslyLoaded")}</ListItem>
+                <ListItem>• {t("accessCached")}</ListItem>
+                <ListItem>• {t("browseSaved")}</ListItem>
+              </List>
+            </Box>
+          </Stack>
         )}
 
         {isOnline && (
-          <div className="flex justify-center">
-            <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
-          </div>
+          <Flex justify="center">
+            <Box className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></Box>
+          </Flex>
         )}
-      </div>
-    </div>
+      </Stack>
+    </Flex>
   );
 }

--- a/web/app/routes/pages._index.tsx
+++ b/web/app/routes/pages._index.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Button,
   Dialog,
   DialogContent,
@@ -6,6 +7,8 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  Flex,
+  Grid,
   PageHeader,
   PageLayout,
   PageToolbar,
@@ -38,11 +41,11 @@ function PageGridSelector(props: React.ComponentProps<typeof PageGridSelectorLaz
   return (
     <Suspense
       fallback={
-        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
+        <Grid cols="2" sm="3" lg="4" gap="4" className="xl:grid-cols-5">
           {Array.from({ length: 6 }).map((_, i) => (
             <Skeleton key={i} className="aspect-[9/16] w-full rounded-lg" />
           ))}
-        </div>
+        </Grid>
       }
     >
       <PageGridSelectorLazy {...props} />
@@ -176,7 +179,7 @@ export default function PagesPage() {
       <PageHeader icon={FileText} title={t("title")} description={t("description")} />
       <PageToolbar
         left={
-          <div className="flex items-center border rounded-md" role="group" aria-label={t("viewModeLabel")}>
+          <Flex align="center" className="border rounded-md" role="group" aria-label={t("viewModeLabel")}>
             <Button
               size="sm"
               variant={viewMode === "grid" ? "secondary" : "ghost"}
@@ -197,10 +200,10 @@ export default function PagesPage() {
             >
               <List className="h-4 w-4" />
             </Button>
-          </div>
+          </Flex>
         }
         right={
-          <div className="flex items-center gap-2">
+          <Flex align="center" gap="2">
             <Button variant="brand" size="sm" onClick={handleCreateNew} className="h-9 sm:h-8 px-3 text-xs btn-lift">
               <Plus className="h-4 w-4 sm:h-3 sm:w-3 mr-1" />
               {t("newPage")}
@@ -214,11 +217,11 @@ export default function PagesPage() {
               <Download className="h-4 w-4 sm:h-3 sm:w-3 mr-1" />
               {t("importPage")}
             </Button>
-          </div>
+          </Flex>
         }
       />
 
-      <div className="animate-card-fade-in" style={{ animationDelay: "150ms" }}>
+      <Box className="animate-card-fade-in" style={{ animationDelay: "150ms" }}>
         {hasMultipleDevices ? (
           <Tabs value={activeTab ?? availableDevices[0]} onValueChange={(v) => setActiveTab(v as DeviceType)}>
             <TabsList className="mb-5">
@@ -271,7 +274,7 @@ export default function PagesPage() {
             viewMode={viewMode}
           />
         )}
-      </div>
+      </Box>
       <ImportPageDialog open={importOpen} onOpenChange={setImportOpen} />
     </PageLayout>
   );

--- a/web/app/routes/pages.edit._index.tsx
+++ b/web/app/routes/pages.edit._index.tsx
@@ -1,4 +1,4 @@
-import { PageLayout } from "@fiestaboard/ui";
+import { PageLayout, Text } from "@fiestaboard/ui";
 import { useEffect, useState } from "react";
 
 import { PageBuilder } from "@/components/page-builder";
@@ -33,7 +33,9 @@ export default function EditPage() {
   if (!pageId) {
     return (
       <PageLayout>
-        <div className="text-center text-muted-foreground">Loading...</div>
+        <Text tone="muted" className="text-center">
+          Loading...
+        </Text>
       </PageLayout>
     );
   }

--- a/web/app/routes/picks.tsx
+++ b/web/app/routes/picks.tsx
@@ -153,7 +153,9 @@ function PickCard({ pick, enabledPluginIds }: { pick: StaffPick; enabledPluginId
               </TooltipTrigger>
               {hasMissingPlugins && (
                 <TooltipContent side="top" className="max-w-xs">
-                  <Text>{t("importWithMissingPlugins", { plugins: missingPlugins.map((p) => p.name).join(", ") })}</Text>
+                  <Text>
+                    {t("importWithMissingPlugins", { plugins: missingPlugins.map((p) => p.name).join(", ") })}
+                  </Text>
                 </TooltipContent>
               )}
             </Tooltip>

--- a/web/app/routes/picks.tsx
+++ b/web/app/routes/picks.tsx
@@ -1,13 +1,19 @@
 import {
   Badge,
+  Box,
   Button,
+  Flex,
+  Grid,
+  Heading,
   PageHeader,
   PageLayout,
   Skeleton,
+  Stack,
   Tabs,
   TabsContent,
   TabsList,
   TabsTrigger,
+  Text,
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -56,81 +62,83 @@ function PickCard({ pick, enabledPluginIds }: { pick: StaffPick; enabledPluginId
 
   return (
     <TooltipProvider>
-      <div className="group flex flex-col rounded-xl border bg-card overflow-hidden shadow-sm hover:shadow-md transition-shadow">
+      <Flex
+        direction="col"
+        className="group rounded-xl border bg-card overflow-hidden shadow-sm hover:shadow-md transition-shadow"
+      >
         {/* Preview — padded dark well so the full board screenshot breathes */}
-        <div className="relative w-full aspect-[17/8] bg-zinc-950 flex items-center justify-center p-4">
+        <Flex align="center" justify="center" className="relative w-full aspect-[17/8] bg-zinc-950 p-4">
           {showImage ? (
-            <div className="relative w-full h-full">
+            <Box className="relative w-full h-full">
               <img
                 src={pick.image!}
                 alt={pick.name}
                 className="object-contain drop-shadow-xl"
                 onError={() => setImgError(true)}
               />
-            </div>
+            </Box>
           ) : (
-            <div className="w-full h-full flex items-center justify-center">
-              <div className="grid gap-1 opacity-20 w-full" style={{ gridTemplateColumns: "repeat(22, 1fr)" }}>
+            <Flex align="center" justify="center" className="w-full h-full">
+              <Box className="grid gap-1 opacity-20 w-full" style={{ gridTemplateColumns: "repeat(22, 1fr)" }}>
                 {Array.from({ length: 132 }).map((_, i) => (
-                  <div key={i} className="aspect-square rounded-sm bg-white/60" />
+                  <Box key={i} className="aspect-square rounded-sm bg-white/60" />
                 ))}
-              </div>
-            </div>
+              </Box>
+            </Flex>
           )}
-        </div>
+        </Flex>
 
         {/* Card body */}
-        <div className="flex flex-col gap-3 p-5 flex-1">
-          <div className="flex flex-col gap-1.5">
-            <h3 className="font-semibold leading-tight">{pick.name}</h3>
-            <p className="text-sm text-muted-foreground leading-snug">{pick.description}</p>
-          </div>
+        <Stack gap="3" className="p-5 flex-1">
+          <Stack gap="1.5">
+            <Heading level={3}>{pick.name}</Heading>
+            <Text tone="muted" className="leading-snug">
+              {pick.description}
+            </Text>
+          </Stack>
 
           {/* Required plugins */}
           {pick.required_plugins.length > 0 && (
-            <div className="flex flex-wrap items-center gap-1.5">
-              <span className="text-[10px] text-muted-foreground uppercase tracking-wide font-medium">
+            <Flex align="center" wrap gap="1.5">
+              <Text as="span" size="xs" tone="muted" weight="medium" className="uppercase tracking-wide">
                 {t("requires")}
-              </span>
+              </Text>
               {pick.required_plugins.map((plugin) => {
                 const enabled = enabledPluginIds.has(plugin.id);
                 return enabled ? (
-                  <span
-                    key={plugin.id}
-                    className="inline-flex items-center gap-1 text-[10px] text-green-700 dark:text-green-400"
-                  >
+                  <Flex key={plugin.id} inline align="center" gap="1" className="text-xs text-success">
                     <CircleCheck className="h-3 w-3" />
                     {plugin.name}
-                  </span>
+                  </Flex>
                 ) : (
                   <Tooltip key={plugin.id}>
                     <TooltipTrigger asChild>
                       <Link
                         href="/integrations"
-                        className="inline-flex items-center gap-1 text-[10px] text-amber-600 dark:text-amber-400 hover:underline"
+                        className="inline-flex items-center gap-1 text-xs text-warning hover:underline"
                       >
                         <CircleAlert className="h-3 w-3" />
                         {plugin.name}
                       </Link>
                     </TooltipTrigger>
                     <TooltipContent side="top">
-                      <p>{t("pluginNotEnabled", { name: plugin.name })}</p>
+                      <Text>{t("pluginNotEnabled", { name: plugin.name })}</Text>
                     </TooltipContent>
                   </Tooltip>
                 );
               })}
-            </div>
+            </Flex>
           )}
 
           {/* Tags + Import */}
-          <div className="flex items-center justify-between gap-2 mt-auto pt-1">
-            <div className="flex flex-wrap gap-1">
+          <Flex align="center" justify="between" gap="2" className="mt-auto pt-1">
+            <Flex wrap gap="1">
               {pick.tags.map((tag) => (
                 <Badge key={tag} variant="secondary" className="text-[10px] px-1.5 py-0 h-4 font-normal">
                   {tag}
                 </Badge>
               ))}
-            </div>
+            </Flex>
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button
@@ -145,13 +153,13 @@ function PickCard({ pick, enabledPluginIds }: { pick: StaffPick; enabledPluginId
               </TooltipTrigger>
               {hasMissingPlugins && (
                 <TooltipContent side="top" className="max-w-xs">
-                  <p>{t("importWithMissingPlugins", { plugins: missingPlugins.map((p) => p.name).join(", ") })}</p>
+                  <Text>{t("importWithMissingPlugins", { plugins: missingPlugins.map((p) => p.name).join(", ") })}</Text>
                 </TooltipContent>
               )}
             </Tooltip>
-          </div>
-        </div>
-      </div>
+          </Flex>
+        </Stack>
+      </Flex>
     </TooltipProvider>
   );
 }
@@ -184,31 +192,35 @@ function PicksGrid({ deviceType }: { deviceType: DeviceType }) {
 
   if (picksLoading) {
     return (
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+      <Grid cols="1" lg="2" gap="8">
         {[1, 2].map((i) => (
-          <div key={i} className="rounded-xl border overflow-hidden">
+          <Box key={i} className="rounded-xl border overflow-hidden">
             <Skeleton className="w-full aspect-[17/8]" />
-            <div className="p-4 flex flex-col gap-2">
+            <Stack gap="2" className="p-4">
               <Skeleton className="h-4 w-1/2" />
               <Skeleton className="h-3 w-3/4" />
               <Skeleton className="h-8 w-20 self-end mt-2" />
-            </div>
-          </div>
+            </Stack>
+          </Box>
         ))}
-      </div>
+      </Grid>
     );
   }
 
   if (filtered.length === 0) {
-    return <p className="text-sm text-muted-foreground text-center py-16">{t("empty")}</p>;
+    return (
+      <Text tone="muted" className="text-center py-16">
+        {t("empty")}
+      </Text>
+    );
   }
 
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+    <Grid cols="1" lg="2" gap="8">
       {filtered.map((pick) => (
         <PickCard key={pick.id} pick={pick} enabledPluginIds={enabledPluginIds} />
       ))}
-    </div>
+    </Grid>
   );
 }
 
@@ -227,9 +239,11 @@ export default function PicksPage() {
     <PageLayout>
       <PageHeader icon={Sparkles} title={t("title")} description={t("description")} />
 
-      <div className="flex items-center gap-2 mb-6 -mt-2">
-        <span className="text-xs text-muted-foreground italic">{t("byline")}</span>
-      </div>
+      <Flex align="center" gap="2" className="mb-6 -mt-2">
+        <Text as="span" size="xs" tone="muted" className="italic">
+          {t("byline")}
+        </Text>
+      </Flex>
 
       {hasMultipleDevices ? (
         <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as DeviceType)}>

--- a/web/app/routes/schedule.tsx
+++ b/web/app/routes/schedule.tsx
@@ -698,7 +698,7 @@ export default function SchedulePage() {
                 <Plus className="h-4 w-4 mr-1" />
                 {t("addSchedule")}
               </Button>
-            </div>
+            </Flex>
           }
         />
       </TooltipProvider>

--- a/web/app/routes/schedule.tsx
+++ b/web/app/routes/schedule.tsx
@@ -8,6 +8,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
   BoardIcon,
+  Box,
   Button,
   Card,
   CardContent,
@@ -19,6 +20,7 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
+  Flex,
   PageHeader,
   PageLayout,
   PageToolbar,
@@ -33,6 +35,8 @@ import {
   SheetHeader,
   SheetTitle,
   Skeleton,
+  Stack,
+  Text,
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -82,9 +86,9 @@ function ScheduleCalendarView(props: React.ComponentProps<typeof ScheduleCalenda
   return (
     <Suspense
       fallback={
-        <div className="space-y-4">
+        <Stack gap="4">
           <Skeleton className="h-96 w-full" />
-        </div>
+        </Stack>
       }
     >
       <ScheduleCalendarViewLazy {...props} />
@@ -490,7 +494,7 @@ export default function SchedulePage() {
           className="flex-shrink-0"
           left={
             /* View toggle */
-            <div className="flex items-center gap-1 bg-muted p-1 rounded-md">
+            <Flex align="center" gap="1" className="bg-muted p-1 rounded-md">
               <Button
                 variant={viewMode === "list" ? "secondary" : "ghost"}
                 size="sm"
@@ -509,22 +513,24 @@ export default function SchedulePage() {
                 <CalendarDays className="h-4 w-4 mr-1.5" />
                 {t("calendarView")}
               </Button>
-            </div>
+            </Flex>
           }
           right={
-            <div className="flex items-center gap-2 flex-wrap justify-end">
+            <Flex align="center" justify="end" gap="2" wrap>
               {/* Active board indicator (multi-board only). Read-only: switching
                   boards happens via the shared sidebar selector (#1248). */}
               {boards.length > 1 && (
-                <span
+                <Flex
                   data-testid="active-board-indicator"
-                  className="flex items-center gap-1.5 h-8 px-2.5 rounded-md border bg-muted/40 text-xs text-muted-foreground max-w-[150px]"
+                  align="center"
+                  gap="1.5"
+                  className="h-8 px-2.5 rounded-md border bg-muted/40 text-xs text-muted-foreground max-w-[150px]"
                 >
                   <BoardIcon className="h-3.5 w-3.5 shrink-0" />
-                  <span className="truncate">
+                  <Text as="span" size="xs" tone="muted" className="truncate">
                     {currentBoard?.name || t("boardFallback", { id: currentBoardId.slice(0, 8) })}
-                  </span>
-                </span>
+                  </Text>
+                </Flex>
               )}
 
               {/* Schedule on/off toggle */}
@@ -541,22 +547,26 @@ export default function SchedulePage() {
                     className="flex items-center gap-1.5 border rounded-md px-2.5 h-8 cursor-pointer bg-transparent text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60"
                   >
                     <Power className={`h-3.5 w-3.5 ${scheduleEnabled ? "text-green-500" : "text-muted-foreground"}`} />
-                    <span className="text-xs font-medium">{scheduleEnabled ? tCommon("on") : tCommon("off")}</span>
-                    <span
+                    <Text as="span" size="xs" weight="medium">
+                      {scheduleEnabled ? tCommon("on") : tCommon("off")}
+                    </Text>
+                    <Flex
                       aria-hidden="true"
+                      align="center"
+                      inline
                       className={cn(
-                        "inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent transition-all",
+                        "h-[1.15rem] w-8 shrink-0 rounded-full border border-transparent transition-all",
                         scheduleEnabled ? "bg-primary" : "bg-input/80 dark:bg-input/80",
                         "scale-75",
                       )}
                     >
-                      <span
+                      <Box
                         className={cn(
                           "pointer-events-none block size-4 rounded-full bg-background ring-0 transition-transform",
                           scheduleEnabled ? "translate-x-[calc(100%-3px)]" : "translate-x-px",
                         )}
                       />
-                    </span>
+                    </Flex>
                   </button>
                 </TooltipTrigger>
                 <TooltipContent side="bottom">
@@ -608,11 +618,17 @@ export default function SchedulePage() {
                           className={`relative h-8 w-8 p-0 ${hasOverlaps ? "text-destructive hover:text-destructive" : "text-yellow-500 hover:text-yellow-500"}`}
                         >
                           {hasOverlaps ? <AlertCircle className="h-4 w-4" /> : <AlertTriangle className="h-4 w-4" />}
-                          <span
-                            className={`absolute -top-1 -right-1 h-4 min-w-4 px-0.5 text-[9px] font-bold rounded-full flex items-center justify-center text-white ${hasOverlaps ? "bg-destructive" : "bg-yellow-500"}`}
+                          <Flex
+                            align="center"
+                            justify="center"
+                            inline
+                            className={cn(
+                              "absolute -top-1 -right-1 h-4 min-w-4 px-0.5 text-xs font-bold rounded-full text-white",
+                              hasOverlaps ? "bg-destructive" : "bg-yellow-500",
+                            )}
                           >
                             {issueCount}
-                          </span>
+                          </Flex>
                         </Button>
                       </DropdownMenuTrigger>
                     </TooltipTrigger>
@@ -645,10 +661,15 @@ export default function SchedulePage() {
                           {t("gapsInSchedule", { count: issueCount })}{" "}
                           {defaultPageId ? (
                             <>
-                              {t("defaultLabel")} <span className="font-medium">{getPageName(defaultPageId)}</span>
+                              {t("defaultLabel")}{" "}
+                              <Text as="span" size="xs" weight="medium">
+                                {getPageName(defaultPageId)}
+                              </Text>
                             </>
                           ) : (
-                            <span className="text-muted-foreground">{t("noDefaultPageSet")}</span>
+                            <Text as="span" size="xs" tone="muted">
+                              {t("noDefaultPageSet")}
+                            </Text>
                           )}
                         </DropdownMenuItem>
                         {validation?.gaps && validation.gaps.length > 0 && (
@@ -658,7 +679,9 @@ export default function SchedulePage() {
                               if (!gap?.days || !gap?.start_time || !gap?.end_time) return null;
                               return (
                                 <DropdownMenuItem key={i} className="text-xs cursor-default focus:bg-transparent">
-                                  <span className="text-muted-foreground mr-2">{formatDaysCompact(gap.days)}</span>
+                                  <Text as="span" size="xs" tone="muted" className="mr-2">
+                                    {formatDaysCompact(gap.days)}
+                                  </Text>
                                   {gap.start_time} – {gap.end_time}
                                 </DropdownMenuItem>
                               );
@@ -682,16 +705,20 @@ export default function SchedulePage() {
 
       {/* ── Location warning (sun schedules without location configured) ── */}
       {hasSunSchedules && !locationConfigured && (
-        <div className="flex items-start gap-2.5 rounded-md border border-amber-300 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/30 px-3.5 py-2.5 text-sm text-amber-800 dark:text-amber-300 flex-shrink-0">
+        <Flex
+          align="start"
+          gap="2.5"
+          className="rounded-md border border-amber-300 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/30 px-3.5 py-2.5 text-sm text-amber-800 dark:text-amber-300 flex-shrink-0"
+        >
           <MapPin className="h-4 w-4 mt-0.5 shrink-0" />
-          <span>
+          <Text as="span" tone="warning">
             {t("locationWarning")}{" "}
             <Link href="/settings" className="font-medium underline underline-offset-2 hover:no-underline">
               {t("configureLocationLink")}
             </Link>
             .
-          </span>
-        </div>
+          </Text>
+        </Flex>
       )}
 
       {/* ── Schedule View ── */}

--- a/web/app/routes/settings.tsx
+++ b/web/app/routes/settings.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Button,
   Card,
   CardContent,
@@ -166,21 +167,23 @@ export default function SettingsPage() {
     <PageLayout>
       <PageHeader icon={Settings} title={t("title")} description={t("description")} />
 
-      <div className="mb-5">
+      <Box className="mb-5">
         <SystemUpdate />
-      </div>
+      </Box>
 
       <Tabs value={activeSection} onValueChange={handleSectionChange}>
-        <div className="mb-5 -mx-3 sm:-mx-4 md:mx-0 overflow-x-auto px-3 sm:px-4 md:px-0">
+        <Box className="mb-5 -mx-3 sm:-mx-4 md:mx-0 overflow-x-auto px-3 sm:px-4 md:px-0">
           <TabsList className="w-fit h-auto p-1">
             {sections.map(({ id, label, icon: Icon }) => (
               <TabsTrigger key={id} value={id} className="gap-1.5 px-3 py-1.5 data-[state=active]:shadow-sm">
                 <Icon className="h-4 w-4 flex-shrink-0" />
+                {/* Inherits size/weight/color from TabsTrigger's data-active state — Text's fixed
+                    tone/weight defaults would break the active/inactive styling, so this stays raw. */}
                 <span className="whitespace-nowrap">{label}</span>
               </TabsTrigger>
             ))}
           </TabsList>
-        </div>
+        </Box>
 
         <TabsContent value="general" className="mt-0 space-y-6">
           <InstanceNameCard />

--- a/web/app/routes/transitions.tsx
+++ b/web/app/routes/transitions.tsx
@@ -16,12 +16,15 @@
 
 import {
   Badge,
+  Box,
   Button,
   Card,
   CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
+  Flex,
+  Grid,
   Label,
   PageHeader,
   PageLayout,
@@ -31,6 +34,8 @@ import {
   SelectTrigger,
   SelectValue,
   Slider,
+  Stack,
+  Text,
   Textarea,
 } from "@fiestaboard/ui";
 import { useQuery } from "@tanstack/react-query";
@@ -305,14 +310,14 @@ export default function TransitionsLabPage() {
     <PageLayout>
       <PageHeader icon={FlaskConical} title={t("title")} description={t("description")} />
 
-      <div className="grid gap-6 lg:grid-cols-[400px_1fr]">
+      <Box className="grid gap-6 lg:grid-cols-[400px_1fr]">
         <Card>
           <CardHeader>
             <CardTitle>{t("setupTitle")}</CardTitle>
             <CardDescription>{t("setupDescription")}</CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
-            <div className="space-y-2">
+            <Stack gap="2">
               <Label htmlFor="plugin-picker">{t("pluginLabel")}</Label>
               <Select value={selectedPluginId} onValueChange={(val: string) => setSelectedPluginId(val)}>
                 <SelectTrigger id="plugin-picker">
@@ -326,16 +331,20 @@ export default function TransitionsLabPage() {
                   ))}
                 </SelectContent>
               </Select>
-              {selectedPlugin && <p className="text-xs text-muted-foreground">{selectedPlugin.description}</p>}
+              {selectedPlugin && (
+                <Text size="xs" tone="muted">
+                  {selectedPlugin.description}
+                </Text>
+              )}
               {pluginsQuery.isSuccess && plugins.length === 0 && (
-                <p className="text-xs text-muted-foreground flex items-center gap-1">
+                <Text size="xs" tone="muted" className="flex items-center gap-1">
                   <Wand2 className="h-3 w-3" />
                   {t("noPlugins")}
-                </p>
+                </Text>
               )}
-            </div>
+            </Stack>
 
-            <div className="space-y-2">
+            <Stack gap="2">
               <Label htmlFor="device-picker">{t("deviceLabel")}</Label>
               <Select value={deviceType} onValueChange={(val: string) => setDeviceType(val as DeviceType)}>
                 <SelectTrigger id="device-picker">
@@ -347,11 +356,11 @@ export default function TransitionsLabPage() {
                   <SelectItem value="note_array">{t("deviceNoteArray")}</SelectItem>
                 </SelectContent>
               </Select>
-            </div>
+            </Stack>
 
             {deviceType === "note_array" && (
-              <div className="grid grid-cols-2 gap-3">
-                <div className="space-y-2">
+              <Grid cols="2" gap="3">
+                <Stack gap="2">
                   <Label htmlFor="notes-wide">{t("notesWideLabel")}</Label>
                   <Select value={String(notesWide)} onValueChange={(val: string) => setNotesWide(Number(val))}>
                     <SelectTrigger id="notes-wide">
@@ -365,8 +374,8 @@ export default function TransitionsLabPage() {
                       ))}
                     </SelectContent>
                   </Select>
-                </div>
-                <div className="space-y-2">
+                </Stack>
+                <Stack gap="2">
                   <Label htmlFor="notes-tall">{t("notesTallLabel")}</Label>
                   <Select value={String(notesTall)} onValueChange={(val: string) => setNotesTall(Number(val))}>
                     <SelectTrigger id="notes-tall">
@@ -380,11 +389,11 @@ export default function TransitionsLabPage() {
                       ))}
                     </SelectContent>
                   </Select>
-                </div>
-              </div>
+                </Stack>
+              </Grid>
             )}
 
-            <div className="space-y-2">
+            <Stack gap="2">
               <Label htmlFor="from-page">{t("fromPageLabel")}</Label>
               <Select value={fromPageId} onValueChange={(val: string) => setFromPageId(val)}>
                 <SelectTrigger id="from-page">
@@ -398,9 +407,9 @@ export default function TransitionsLabPage() {
                   ))}
                 </SelectContent>
               </Select>
-            </div>
+            </Stack>
 
-            <div className="space-y-2">
+            <Stack gap="2">
               <Label htmlFor="to-page">{t("toPageLabel")}</Label>
               <Select value={toPageId} onValueChange={(val: string) => setToPageId(val)}>
                 <SelectTrigger id="to-page">
@@ -415,11 +424,13 @@ export default function TransitionsLabPage() {
                 </SelectContent>
               </Select>
               {pagesQuery.isSuccess && pages.length === 0 && (
-                <p className="text-xs text-muted-foreground">{t("noPages")}</p>
+                <Text size="xs" tone="muted">
+                  {t("noPages")}
+                </Text>
               )}
-            </div>
+            </Stack>
 
-            <div className="space-y-2">
+            <Stack gap="2">
               <Label htmlFor="config-json">{t("configLabel")}</Label>
               <Textarea
                 id="config-json"
@@ -429,7 +440,7 @@ export default function TransitionsLabPage() {
                 className="font-mono text-xs"
                 spellCheck={false}
               />
-            </div>
+            </Stack>
 
             <Button
               onClick={runPreview}
@@ -439,11 +450,13 @@ export default function TransitionsLabPage() {
               {previewing ? t("generating") : t("runPreview")}
             </Button>
 
-            {previewError && <p className="text-sm text-destructive">{previewError}</p>}
+            {previewError && <Text tone="destructive">{previewError}</Text>}
 
-            <div className="space-y-2 border-t pt-4">
-              <p className="text-xs text-muted-foreground">{t("liveHint")}</p>
-              <div className="flex gap-2">
+            <Stack gap="2" className="border-t pt-4">
+              <Text size="xs" tone="muted">
+                {t("liveHint")}
+              </Text>
+              <Flex gap="2">
                 <Button
                   variant="outline"
                   className="flex-1"
@@ -464,10 +477,10 @@ export default function TransitionsLabPage() {
                     {restoring ? t("restoring") : t("restoreBoard")}
                   </Button>
                 )}
-              </div>
-              {liveStatus && <p className="text-sm text-muted-foreground">{liveStatus}</p>}
-              {liveError && <p className="text-sm text-destructive">{liveError}</p>}
-            </div>
+              </Flex>
+              {liveStatus && <Text tone="muted">{liveStatus}</Text>}
+              {liveError && <Text tone="destructive">{liveError}</Text>}
+            </Stack>
           </CardContent>
         </Card>
 
@@ -487,14 +500,14 @@ export default function TransitionsLabPage() {
             {displayGrid ? (
               <TransitionGridDisplay grid={displayGrid} size={gridSize} />
             ) : (
-              <div className="rounded-lg border-2 border-dashed p-12 text-center text-muted-foreground">
+              <Box className="rounded-lg border-2 border-dashed p-12 text-center text-muted-foreground">
                 {t("previewEmpty")}
-              </div>
+              </Box>
             )}
 
             {preview && preview.frames.length > 0 && (
               <>
-                <div className="flex items-center gap-2">
+                <Flex align="center" gap="2">
                   <Button
                     size="icon"
                     variant="outline"
@@ -536,12 +549,12 @@ export default function TransitionsLabPage() {
                   >
                     <SkipForward className="h-4 w-4" />
                   </Button>
-                  <span className="text-sm text-muted-foreground tabular-nums">
+                  <Text as="span" tone="muted" className="tabular-nums">
                     {t("frameCounter", { current: frameIdx + 1, total: preview.frames.length })}
-                  </span>
-                </div>
+                  </Text>
+                </Flex>
 
-                <div className="space-y-2">
+                <Stack gap="2">
                   <Label>{t("scrubLabel")}</Label>
                   <Slider
                     value={[frameIdx]}
@@ -553,18 +566,18 @@ export default function TransitionsLabPage() {
                     max={Math.max(0, preview.frames.length - 1)}
                     step={1}
                   />
-                </div>
+                </Stack>
 
                 {preview.frames[frameIdx] && (
-                  <p className="text-xs text-muted-foreground">
+                  <Text size="xs" tone="muted">
                     {t("frameDelay", { ms: preview.frames[frameIdx].delay_ms })}
-                  </p>
+                  </Text>
                 )}
               </>
             )}
           </CardContent>
         </Card>
-      </div>
+      </Box>
     </PageLayout>
   );
 }


### PR DESCRIPTION
Wave 1 of 6 for epic #1474: migrates `app/root.tsx` + all 13 route files from raw HTML to `@fiestaboard/ui` primitives per the plan recipe (`docs/superpowers/plans/2026-08-02-fiestaui-primitives-migration.md`).

## What changed
- Layout `div`s → `Flex`/`Stack`/`Grid` (variant props for layout; board-geometry and arbitrary classes preserved verbatim in `className`)
- Typography → `Text`/`Heading`; inline spans in colored/sized contexts carry matching `size`/`tone`/`weight` props
- `code` → `Code`, plain anchors → `TextLink`, lists → `List`/`ListItem`, debug tables → `Table` set, `form`/`section` → `Box as=…`
- Router `Link`s untouched; `svg`/`img`/`dl`-family stay raw (allowlisted)
- **7 raw tags intentionally remain** across 3 files, each with an in-code rationale comment (ReactMarkdown overrides, offline h1, inherit-only spans)

## Verification
- ESLint 0 errors, prettier clean, vitest **1353 passed / 0 failed** (node 24, CI parity, in Docker)
- Task-reviewed (spec + quality: Approved); two review nits fixed in the last commit
- Screenshots of all 13 routes captured from the branch's prod image — gallery link in comments
- Intentional visual diffs (normalization): `text-[9px]/[10px]` → `text-xs` on two tiny badges, login footer link now carries the canonical `TextLink` treatment

No ESLint enforcement rule yet — that lands with wave 6.

Part of #1474

🤖 Generated with [Claude Code](https://claude.com/claude-code)