### PR TITLE
refactor: adopt FiestaUI primitives — wave 2 (components A–O)

### DIFF
--- a/web/src/components/account-section.tsx
+++ b/web/src/components/account-section.tsx
@@ -22,6 +22,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
   AlertDialogTrigger,
+  Box,
   Button,
   Card,
   CardContent,
@@ -31,6 +32,8 @@ import {
   Input,
   Label,
   Skeleton,
+  Stack,
+  Text,
 } from "@fiestaboard/ui";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { KeyRound, LogOut, ShieldAlert, ShieldCheck, ShieldOff, UserCircle2, UserCog } from "lucide-react";
@@ -104,7 +107,11 @@ export function AccountSection() {
           </CardTitle>
           <CardDescription>
             {t.rich("signedIn.description", {
-              name: () => <span className="font-mono text-foreground">{username}</span>,
+              name: () => (
+                <Text as="span" className="font-mono text-foreground">
+                  {username}
+                </Text>
+              ),
             })}
           </CardDescription>
         </CardHeader>
@@ -193,8 +200,8 @@ function ChangeUsernameForm({ currentUsername }: { currentUsername: string }) {
   const unchanged = newUsername.trim() === currentUsername;
 
   return (
-    <form className="space-y-4 max-w-sm" onSubmit={onSubmit} aria-label={t("changeUsername.formAriaLabel")}>
-      <div className="space-y-2">
+    <Box as="form" className="space-y-4 max-w-sm" onSubmit={onSubmit} aria-label={t("changeUsername.formAriaLabel")}>
+      <Stack gap="2">
         <Label htmlFor="account-username">{t("changeUsername.newUsernameLabel")}</Label>
         <Input
           id="account-username"
@@ -205,8 +212,8 @@ function ChangeUsernameForm({ currentUsername }: { currentUsername: string }) {
           required
           maxLength={64}
         />
-      </div>
-      <div className="space-y-2">
+      </Stack>
+      <Stack gap="2">
         <Label htmlFor="account-username-password">{t("changeUsername.currentPasswordLabel")}</Label>
         <Input
           id="account-username-password"
@@ -217,11 +224,11 @@ function ChangeUsernameForm({ currentUsername }: { currentUsername: string }) {
           disabled={submitting}
           required
         />
-      </div>
+      </Stack>
       <Button type="submit" disabled={submitting || unchanged || !password}>
         {submitting ? t("changeUsername.submitting") : t("changeUsername.submit")}
       </Button>
-    </form>
+    </Box>
   );
 }
 
@@ -259,8 +266,8 @@ function ChangePasswordForm() {
   };
 
   return (
-    <form className="space-y-4 max-w-sm" onSubmit={onSubmit} aria-label={t("changePassword.formAriaLabel")}>
-      <div className="space-y-2">
+    <Box as="form" className="space-y-4 max-w-sm" onSubmit={onSubmit} aria-label={t("changePassword.formAriaLabel")}>
+      <Stack gap="2">
         <Label htmlFor="account-current-password">{t("changePassword.currentPasswordLabel")}</Label>
         <Input
           id="account-current-password"
@@ -271,8 +278,8 @@ function ChangePasswordForm() {
           disabled={submitting}
           required
         />
-      </div>
-      <div className="space-y-2">
+      </Stack>
+      <Stack gap="2">
         <Label htmlFor="account-new-password">{t("changePassword.newPasswordLabel")}</Label>
         <Input
           id="account-new-password"
@@ -284,9 +291,11 @@ function ChangePasswordForm() {
           required
           minLength={8}
         />
-        <p className="text-xs text-muted-foreground">{t("changePassword.newPasswordHint")}</p>
-      </div>
-      <div className="space-y-2">
+        <Text size="xs" tone="muted">
+          {t("changePassword.newPasswordHint")}
+        </Text>
+      </Stack>
+      <Stack gap="2">
         <Label htmlFor="account-confirm-password">{t("changePassword.confirmPasswordLabel")}</Label>
         <Input
           id="account-confirm-password"
@@ -298,16 +307,16 @@ function ChangePasswordForm() {
           required
           minLength={8}
         />
-      </div>
+      </Stack>
       {error && (
-        <p className="text-sm text-destructive" role="alert">
+        <Text tone="destructive" role="alert">
           {error}
-        </p>
+        </Text>
       )}
       <Button type="submit" disabled={submitting || !currentPassword || !newPassword}>
         {submitting ? t("changePassword.submitting") : t("changePassword.submit")}
       </Button>
-    </form>
+    </Box>
   );
 }
 
@@ -365,23 +374,31 @@ function DisableAuthDialog({ username }: { username: string }) {
             {t("disableLogin.dialogTitle")}
           </AlertDialogTitle>
           <AlertDialogDescription asChild>
-            <div className="space-y-3 text-sm">
-              <p>
+            <Stack gap="3" className="text-sm">
+              <Text tone="muted">
                 {t.rich("disableLogin.dialogBody1", {
-                  name: () => <span className="font-mono">{username}</span>,
+                  name: () => (
+                    <Text as="span" tone="muted" className="font-mono">
+                      {username}
+                    </Text>
+                  ),
                 })}
-              </p>
-              <p>
+              </Text>
+              <Text tone="muted">
                 {t.rich("disableLogin.dialogBody2", {
-                  strong: (chunks: ReactNode) => <strong>{chunks}</strong>,
+                  strong: (chunks: ReactNode) => (
+                    <Text as="span" weight="semibold" tone="muted">
+                      {chunks}
+                    </Text>
+                  ),
                 })}
-              </p>
-              <p>{t("disableLogin.dialogBody3")}</p>
-            </div>
+              </Text>
+              <Text tone="muted">{t("disableLogin.dialogBody3")}</Text>
+            </Stack>
           </AlertDialogDescription>
         </AlertDialogHeader>
-        <form onSubmit={onConfirm} className="space-y-3">
-          <div className="space-y-2">
+        <Box as="form" onSubmit={onConfirm} className="space-y-3">
+          <Stack gap="2">
             <Label htmlFor="disable-auth-password">{t("disableLogin.confirmPasswordLabel")}</Label>
             <Input
               id="disable-auth-password"
@@ -393,11 +410,11 @@ function DisableAuthDialog({ username }: { username: string }) {
               required
               autoFocus
             />
-          </div>
+          </Stack>
           {error && (
-            <p className="text-sm text-destructive" role="alert">
+            <Text tone="destructive" role="alert">
               {error}
-            </p>
+            </Text>
           )}
           <AlertDialogFooter>
             {/* Plain buttons rather than AlertDialogCancel /
@@ -410,7 +427,7 @@ function DisableAuthDialog({ username }: { username: string }) {
               {submitting ? t("disableLogin.confirming") : t("disableLogin.confirm")}
             </Button>
           </AlertDialogFooter>
-        </form>
+        </Box>
       </AlertDialogContent>
     </AlertDialog>
   );
@@ -446,12 +463,16 @@ function EnableLoginCard() {
         </CardTitle>
         <CardDescription>
           {t.rich("enableLogin.description", {
-            strong: (chunks: ReactNode) => <strong>{chunks}</strong>,
+            strong: (chunks: ReactNode) => (
+              <Text as="span" weight="semibold" tone="muted">
+                {chunks}
+              </Text>
+            ),
           })}
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        <p className="text-sm text-muted-foreground">{t("enableLogin.body")}</p>
+        <Text tone="muted">{t("enableLogin.body")}</Text>
         <Button type="button" variant="brand" onClick={onEnable} disabled={submitting}>
           <ShieldCheck className="h-4 w-4" />
           {submitting ? t("enableLogin.submitting") : t("enableLogin.button")}

--- a/web/src/components/active-page-display.tsx
+++ b/web/src/components/active-page-display.tsx
@@ -4,6 +4,7 @@ import {
   Alert,
   AlertDescription,
   Badge,
+  Box,
   Button,
   Card,
   CardContent,
@@ -15,12 +16,16 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  Flex,
+  Grid,
   Sheet,
   SheetContent,
   SheetDescription,
   SheetHeader,
   SheetTitle,
   Skeleton,
+  Stack,
+  Text,
 } from "@fiestaboard/ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
@@ -426,16 +431,22 @@ export function ActivePageDisplay() {
     <>
       <Card className="card-interactive">
         <CardHeader className="pb-4">
-          <div className="flex items-center justify-between">
-            <div className="flex items-baseline gap-2 min-w-0">
+          <Flex align="center" justify="between">
+            <Flex align="baseline" gap="2" className="min-w-0">
               <CardTitle className="text-lg">{t("title")}</CardTitle>
               {isMultiBoard && currentBoard && (
-                <span className="text-xs text-muted-foreground truncate" data-testid="active-display-board-name">
+                <Text
+                  as="span"
+                  size="xs"
+                  tone="muted"
+                  className="truncate"
+                  data-testid="active-display-board-name"
+                >
                   {t("boardIndicator", { boardName: currentBoard.name })}
-                </span>
+                </Text>
               )}
-            </div>
-            <div className="flex items-center gap-2">
+            </Flex>
+            <Flex align="center" gap="2">
               {scheduleEnabled && (
                 <Link
                   href="/schedule"
@@ -453,14 +464,16 @@ export function ActivePageDisplay() {
                 <ArrowLeftRight className="h-4 w-4" />
                 {t("changePage")}
               </Button>
-            </div>
-          </div>
+            </Flex>
+          </Flex>
 
           {/* Active page name and status */}
-          <div className="flex items-center gap-4 text-xs text-muted-foreground mt-3 flex-wrap">
-            <div className="flex items-center gap-1.5">
-              <span className="font-medium text-foreground">{activePageName}</span>
-            </div>
+          <Flex align="center" gap="4" wrap className="text-xs text-muted-foreground mt-3">
+            <Flex align="center" gap="1.5">
+              <Text as="span" size="xs" weight="medium">
+                {activePageName}
+              </Text>
+            </Flex>
             {liveMessageForBoard ? (
               <Badge
                 variant="destructive"
@@ -514,10 +527,12 @@ export function ActivePageDisplay() {
               </Badge>
             )}
             {silenceStatus?.active && (
-              <div className="flex items-center gap-1.5">
+              <Flex align="center" gap="1.5">
                 <Moon className="h-3 w-3 text-info" aria-hidden="true" />
-                <span className="text-info">{t("silenceModeActive")}</span>
-              </div>
+                <Text as="span" size="xs" tone="info">
+                  {t("silenceModeActive")}
+                </Text>
+              </Flex>
             )}
             {pausedBoards.map((board) => (
               <Badge
@@ -531,7 +546,7 @@ export function ActivePageDisplay() {
                 {showBoardNameOnPauseBadge ? `${tPause("badge")}: ${board.name}` : tPause("badge")}
               </Badge>
             ))}
-          </div>
+          </Flex>
         </CardHeader>
 
         <CardContent className="space-y-4">
@@ -557,7 +572,9 @@ export function ActivePageDisplay() {
             <Alert variant="default" className="border-warning/50 bg-warning/10">
               <AlertTriangle className="h-4 w-4 text-warning" />
               <AlertDescription className="flex items-center justify-between gap-3">
-                <span className="text-sm">{t("updatedExternally")}</span>
+                <Text as="span" size="sm">
+                  {t("updatedExternally")}
+                </Text>
                 <Button
                   size="sm"
                   variant="outline"
@@ -576,7 +593,7 @@ export function ActivePageDisplay() {
               any layout changes in ancestor elements (e.g. sidebar padding snap).
               ScaledBoardDisplay shrinks the board to fit narrow (mobile) cards —
               BoardDisplay's breakpoint tile sizes alone overflow phone widths. */}
-          <div className="flex justify-center overflow-x-hidden px-2" style={{ contain: "layout style paint" }}>
+          <Flex justify="center" className="overflow-x-hidden px-2" style={{ contain: "layout style paint" }}>
             <ScaledBoardDisplay
               message={displayMessage}
               isLoading={!boardState && !liveMessageForBoard}
@@ -584,13 +601,13 @@ export function ActivePageDisplay() {
               boardType={currentBoard?.board_color ?? getEffectiveBoardColor(boardSettings)}
               deviceType={activeDeviceType}
             />
-          </div>
+          </Flex>
         </CardContent>
       </Card>
 
       {/* Pre-render grid in background (hidden) to warm up cache */}
       {shouldPreRender && !isSheetOpen && (
-        <div className="hidden">
+        <Box className="hidden">
           <PageGridSelector
             activePageId={deferredActivePageId}
             onSelectPage={handleSelectPage}
@@ -599,7 +616,7 @@ export function ActivePageDisplay() {
             label=""
             filterByCurrentBoardSize
           />
-        </div>
+        </Box>
       )}
 
       {/* Page Selector Sheet - grid is already cached so opens instantly */}
@@ -616,15 +633,15 @@ export function ActivePageDisplay() {
             <SheetDescription>{t("selectPageDescription")}</SheetDescription>
           </SheetHeader>
 
-          <div className="mt-6">
+          <Box className="mt-6">
             {!showSheetContent ? (
               // Show lightweight skeleton during animation for smooth 60fps
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <Grid cols="1" sm="2" gap="3">
                 <Skeleton className="h-32 w-full" />
                 <Skeleton className="h-32 w-full" />
                 <Skeleton className="h-32 w-full" />
                 <Skeleton className="h-32 w-full" />
-              </div>
+              </Grid>
             ) : shouldPreRender ? (
               <PageGridSelector
                 activePageId={deferredActivePageId}
@@ -635,9 +652,11 @@ export function ActivePageDisplay() {
                 filterByCurrentBoardSize
               />
             ) : (
-              <div className="text-center text-sm text-muted-foreground py-8">{t("loadingPages")}</div>
+              <Text tone="muted" className="text-center py-8">
+                {t("loadingPages")}
+              </Text>
             )}
-          </div>
+          </Box>
         </SheetContent>
       </Sheet>
 
@@ -657,7 +676,7 @@ export function ActivePageDisplay() {
             <DialogDescription>{t("changeModeDescription")}</DialogDescription>
           </DialogHeader>
 
-          <div className="flex flex-col gap-3 py-2">
+          <Stack gap="3" className="py-2">
             {/* Override temporarily */}
             <button
               type="button"
@@ -667,15 +686,21 @@ export function ActivePageDisplay() {
               }}
               className="flex items-start gap-4 p-4 rounded-xl border border-border hover:border-primary/50 hover:bg-primary/5 text-left transition-colors group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
-              <div className="h-10 w-10 rounded-full bg-primary/10 flex items-center justify-center flex-shrink-0 group-hover:bg-primary/20 transition-colors">
+              <Flex
+                align="center"
+                justify="center"
+                className="h-10 w-10 rounded-full bg-primary/10 flex-shrink-0 group-hover:bg-primary/20 transition-colors"
+              >
                 <Timer className="h-5 w-5 text-primary" />
-              </div>
-              <div className="min-w-0">
-                <div className="font-semibold text-sm text-foreground">{t("changeModeOverrideTitle")}</div>
-                <div className="text-xs text-muted-foreground mt-0.5 leading-relaxed">
+              </Flex>
+              <Box className="min-w-0">
+                <Text size="sm" weight="semibold">
+                  {t("changeModeOverrideTitle")}
+                </Text>
+                <Text size="xs" tone="muted" className="mt-0.5 leading-relaxed">
                   {t("changeModeOverrideDescription")}
-                </div>
-              </div>
+                </Text>
+              </Box>
             </button>
 
             {/* Turn off schedule */}
@@ -685,21 +710,27 @@ export function ActivePageDisplay() {
               disabled={disableScheduleMutation.isPending}
               className="flex items-start gap-4 p-4 rounded-xl border border-border hover:border-muted-foreground/40 hover:bg-muted/40 text-left transition-colors group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              <div className="h-10 w-10 rounded-full bg-muted flex items-center justify-center flex-shrink-0 group-hover:bg-muted/80 transition-colors">
+              <Flex
+                align="center"
+                justify="center"
+                className="h-10 w-10 rounded-full bg-muted flex-shrink-0 group-hover:bg-muted/80 transition-colors"
+              >
                 {disableScheduleMutation.isPending ? (
                   <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
                 ) : (
                   <CalendarOff className="h-5 w-5 text-muted-foreground" />
                 )}
-              </div>
-              <div className="min-w-0">
-                <div className="font-semibold text-sm text-foreground">{t("changeModeDisableTitle")}</div>
-                <div className="text-xs text-muted-foreground mt-0.5 leading-relaxed">
+              </Flex>
+              <Box className="min-w-0">
+                <Text size="sm" weight="semibold">
+                  {t("changeModeDisableTitle")}
+                </Text>
+                <Text size="xs" tone="muted" className="mt-0.5 leading-relaxed">
                   {t("changeModeDisableDescription")}
-                </div>
-              </div>
+                </Text>
+              </Box>
             </button>
-          </div>
+          </Stack>
 
           <DialogFooter>
             <Button variant="ghost" size="sm" onClick={() => setChangeModeOpen(false)}>

--- a/web/src/components/active-page-display.tsx
+++ b/web/src/components/active-page-display.tsx
@@ -435,13 +435,7 @@ export function ActivePageDisplay() {
             <Flex align="baseline" gap="2" className="min-w-0">
               <CardTitle className="text-lg">{t("title")}</CardTitle>
               {isMultiBoard && currentBoard && (
-                <Text
-                  as="span"
-                  size="xs"
-                  tone="muted"
-                  className="truncate"
-                  data-testid="active-display-board-name"
-                >
+                <Text as="span" size="xs" tone="muted" className="truncate" data-testid="active-display-board-name">
                   {t("boardIndicator", { boardName: currentBoard.name })}
                 </Text>
               )}

--- a/web/src/components/ai-action-confirmation.tsx
+++ b/web/src/components/ai-action-confirmation.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Button, Card } from "@fiestaboard/ui";
+import { Box, Button, Card, Flex, Text } from "@fiestaboard/ui";
 import {
   Calendar,
   CheckCircle,
@@ -217,16 +217,20 @@ export function AiActionConfirmation({ call, onAllow, onDeny, autoAllow = false 
 
   return (
     <Card className="p-3 text-sm border-border/60 bg-muted/30">
-      <div className="flex items-start gap-2">
+      <Flex align="start" gap="2">
         <ActionIcon op={call.op} />
-        <div className="flex-1 min-w-0">
-          <p className="font-medium leading-tight">{actionLabel(call, t)}</p>
-          <p className="text-muted-foreground mt-0.5 leading-snug">{actionDescription(call, t)}</p>
-        </div>
-      </div>
+        <Box className="flex-1 min-w-0">
+          <Text weight="medium" className="leading-tight">
+            {actionLabel(call, t)}
+          </Text>
+          <Text tone="muted" className="mt-0.5 leading-snug">
+            {actionDescription(call, t)}
+          </Text>
+        </Box>
+      </Flex>
 
       {!isSettled && (
-        <div className="flex gap-2 mt-3 justify-end">
+        <Flex gap="2" justify="end" className="mt-3">
           <Button
             variant="outline"
             size="sm"
@@ -245,21 +249,21 @@ export function AiActionConfirmation({ call, onAllow, onDeny, autoAllow = false 
           >
             {state === "running" ? t("working") : t("allow")}
           </Button>
-        </div>
+        </Flex>
       )}
 
       {state === "done" && (
-        <div className="flex items-center gap-1.5 mt-2 text-xs text-green-600 dark:text-green-400">
+        <Flex align="center" gap="1.5" className="mt-2 text-xs text-green-600 dark:text-green-400">
           <CheckCircle className="h-3.5 w-3.5" aria-hidden="true" />
           {t("done")}
-        </div>
+        </Flex>
       )}
 
       {state === "denied" && (
-        <div className="flex items-center gap-1.5 mt-2 text-xs text-muted-foreground">
+        <Flex align="center" gap="1.5" className="mt-2 text-xs text-muted-foreground">
           <XCircle className="h-3.5 w-3.5" aria-hidden="true" />
           {t("denied")}
-        </div>
+        </Flex>
       )}
     </Card>
   );

--- a/web/src/components/ai-chat-panel.tsx
+++ b/web/src/components/ai-chat-panel.tsx
@@ -4,18 +4,25 @@ import {
   Alert,
   AlertDescription,
   Badge,
+  Box,
   Button,
   Card,
+  Code,
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
+  Flex,
   Label,
+  List,
+  ListItem,
   ScrollArea,
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
+  Stack,
+  Text,
   Textarea,
 } from "@fiestaboard/ui";
 import { useQuery } from "@tanstack/react-query";
@@ -187,16 +194,18 @@ export function AiChatPanel({
   };
 
   return (
-    <div className="flex h-full min-h-0 w-full flex-col">
+    <Flex direction="col" className="h-full min-h-0 w-full">
       <Card className="flex flex-1 min-h-0 w-full flex-col gap-0 overflow-hidden rounded-none border-0 py-0 shadow-none">
         {/* Header */}
-        <div className="flex flex-shrink-0 items-center justify-between gap-2 border-b px-4 py-3">
-          <div className="flex min-w-0 items-center gap-2">
+        <Flex align="center" justify="between" gap="2" className="flex-shrink-0 border-b px-4 py-3">
+          <Flex align="center" gap="2" className="min-w-0">
             <Sparkles className="h-4 w-4 shrink-0 text-brand-emphasis" />
-            <span className="truncate text-sm font-semibold">FiestaBot (Beta)</span>
+            <Text as="span" size="sm" weight="semibold" className="truncate">
+              FiestaBot (Beta)
+            </Text>
             {status === "streaming" && <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />}
-          </div>
-          <div className="flex items-center gap-1">
+          </Flex>
+          <Flex align="center" gap="1">
             {onChainingModeChange && <ChainingModePicker mode={chainingMode} onChange={onChainingModeChange} />}
             {messages.length > 0 && (
               <Button
@@ -222,8 +231,8 @@ export function AiChatPanel({
             >
               <X className="h-4 w-4" />
             </Button>
-          </div>
-        </div>
+          </Flex>
+        </Flex>
 
         {/* Task list panel — shown when the AI has an active task list */}
         {(taskList?.length ?? 0) > 0 && <TaskListPanel tasks={taskList!} />}
@@ -233,8 +242,9 @@ export function AiChatPanel({
             to screen-reader users as they arrive (additions + text
             changes), without re-reading the entire transcript. */}
         <ScrollArea className="min-h-0 flex-1 overflow-x-hidden">
-          <div
-            className="min-w-0 max-w-full overflow-x-hidden space-y-3 px-4 py-4"
+          <Stack
+            gap="3"
+            className="min-w-0 max-w-full overflow-x-hidden px-4 py-4"
             aria-live="polite"
             aria-atomic="false"
             aria-relevant="additions text"
@@ -258,16 +268,16 @@ export function AiChatPanel({
                 <AlertCircle className="h-3.5 w-3.5" />
                 <AlertDescription className="break-words">
                   {error}
-                  <div className="mt-1.5">
+                  <Box className="mt-1.5">
                     <Button size="sm" variant="outline" className="h-7 text-xs" onClick={retryLast}>
                       <RotateCcw className="mr-1 h-3 w-3" />
                       Retry
                     </Button>
-                  </div>
+                  </Box>
                 </AlertDescription>
               </Alert>
             )}
-          </div>
+          </Stack>
         </ScrollArea>
 
         {/* Sticky composer at the bottom of the Card.
@@ -276,7 +286,7 @@ export function AiChatPanel({
          *  the model is a property of the next turn, not chrome at the
          *  top of the panel. This also frees vertical space and works
          *  well in narrow chat-pane widths. */}
-        <div className="flex flex-shrink-0 flex-col gap-2 border-t bg-card px-4 py-4">
+        <Flex direction="col" gap="2" className="flex-shrink-0 border-t bg-card px-4 py-4">
           <Label htmlFor="ai-chat-input" className="sr-only">
             Message
           </Label>
@@ -294,8 +304,8 @@ export function AiChatPanel({
             disabled={blocked}
             className="resize-none px-3 py-3 text-sm"
           />
-          <div className="flex flex-wrap items-center justify-between gap-2">
-            <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+          <Flex wrap align="center" justify="between" gap="2">
+            <Flex wrap align="center" gap="1.5" className="min-w-0">
               <ModelPill
                 providers={providers}
                 providerId={effectiveProviderId}
@@ -307,8 +317,10 @@ export function AiChatPanel({
                 model={effectiveModel}
                 onModelChange={setModel}
               />
-              <span className="text-[10px] text-muted-foreground">⌘/Ctrl+Enter</span>
-            </div>
+              <Text as="span" tone="muted" className="text-[10px]">
+                ⌘/Ctrl+Enter
+              </Text>
+            </Flex>
             {status === "streaming" ? (
               <Button type="button" size="sm" variant="outline" className="h-7 gap-1 text-xs" onClick={cancel}>
                 <Square className="h-3 w-3" />
@@ -327,10 +339,10 @@ export function AiChatPanel({
                 Send
               </Button>
             )}
-          </div>
-        </div>
+          </Flex>
+        </Flex>
       </Card>
-    </div>
+    </Flex>
   );
 }
 
@@ -371,18 +383,18 @@ function TaskListPanel({ tasks }: { tasks: TaskItem[] }) {
   const pct = tasks.length > 0 ? (doneCount / tasks.length) * 100 : 0;
 
   return (
-    <div
+    <Box
       className="border-b px-4 py-2 bg-muted/30 flex-shrink-0"
       role="status"
       aria-live="polite"
       aria-atomic="false"
       aria-label={t("taskStatusAriaLabel")}
     >
-      <div className="flex items-center justify-between mb-1.5">
-        <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+      <Flex align="center" justify="between" className="mb-1.5">
+        <Text as="span" weight="medium" tone="muted" className="text-[10px] uppercase tracking-wide">
           Tasks ({doneCount}/{tasks.length})
-        </span>
-        <div
+        </Text>
+        <Box
           role="progressbar"
           aria-valuenow={pct}
           aria-valuemin={0}
@@ -390,34 +402,35 @@ function TaskListPanel({ tasks }: { tasks: TaskItem[] }) {
           aria-label={t("taskProgressAriaLabel")}
           className="h-1 w-20 rounded-full bg-muted overflow-hidden"
         >
-          <div className="h-full bg-brand-emphasis transition-all duration-300" style={{ width: `${pct}%` }} />
-        </div>
-      </div>
-      <ul className="space-y-0.5 max-h-28 overflow-y-auto">
+          <Box className="h-full bg-brand-emphasis transition-all duration-300" style={{ width: `${pct}%` }} />
+        </Box>
+      </Flex>
+      <List gap="0" className="space-y-0.5 max-h-28 overflow-y-auto">
         {tasks.map((task) => (
-          <li key={task.id} className="flex items-center gap-1.5 text-[11px]">
+          <ListItem key={task.id} className="flex items-center gap-1.5 text-[11px]">
             <TaskStatusIcon status={task.status} />
-            <span
+            <Text
+              as="span"
               className={cn(
-                "truncate",
+                "truncate text-[11px]",
                 task.status === "done" ? "text-muted-foreground line-through" : "",
                 task.status === "failed" ? "text-destructive" : "",
               )}
             >
               {task.label}
-            </span>
-          </li>
+            </Text>
+          </ListItem>
         ))}
-      </ul>
-    </div>
+      </List>
+    </Box>
   );
 }
 
 function GradientSparkles({ className }: { className?: string }) {
   return (
-    <span className={`relative inline-block shrink-0 ${className ?? ""}`} aria-hidden="true">
+    <Text as="span" className={`relative inline-block shrink-0 ${className ?? ""}`} aria-hidden="true">
       {/* Big central star — gradient sweep via CSS mask */}
-      <span className="ai-sparkle-icon absolute inset-0 h-full w-full" />
+      <Text as="span" className="ai-sparkle-icon absolute inset-0 h-full w-full" />
       {/* Small elements — pulse independently from their own centers */}
       <svg
         viewBox="0 0 24 24"
@@ -441,7 +454,7 @@ function GradientSparkles({ className }: { className?: string }) {
         </g>
         <circle className="sparkle-circ" cx={4} cy={20} r={2} stroke="url(#ai-sg)" />
       </svg>
-    </span>
+    </Text>
   );
 }
 
@@ -459,25 +472,29 @@ function EmptyState({ blocked, aiDisabled }: { blocked: boolean; aiDisabled: boo
     );
   }
   return (
-    <div className="flex flex-col items-center gap-5 px-2 py-6 text-center">
+    <Flex direction="col" align="center" gap="5" className="px-2 py-6 text-center">
       <GradientSparkles className="h-8 w-8" />
-      <div>
-        <p className="text-sm font-medium">How can I help?</p>
-        <p className="mt-1 text-xs text-muted-foreground">Describe what you&apos;d like to build or change.</p>
-      </div>
-      <div className="w-full space-y-2 text-left text-xs">
+      <Box>
+        <Text weight="medium">How can I help?</Text>
+        <Text size="xs" tone="muted" className="mt-1">
+          Describe what you&apos;d like to build or change.
+        </Text>
+      </Box>
+      <Stack gap="2" className="w-full text-left text-xs">
         {[
           "Build a weather + transit page for my morning commute",
           "Replace line 2 with today’s date",
           "What plugin variables can I use on this page?",
         ].map((s) => (
-          <div key={s} className="flex items-start gap-2 text-muted-foreground">
+          <Flex key={s} align="start" gap="2" className="text-muted-foreground">
             <ChevronRight className="mt-0.5 h-3 w-3 shrink-0 text-muted-foreground/50" />
-            <span>&ldquo;{s}&rdquo;</span>
-          </div>
+            <Text as="span" size="xs" tone="muted">
+              &ldquo;{s}&rdquo;
+            </Text>
+          </Flex>
         ))}
-      </div>
-    </div>
+      </Stack>
+    </Flex>
   );
 }
 
@@ -506,7 +523,7 @@ function ModelPill({
   const onlyOneProvider = providers.length <= 1;
   const shortModel = model ? model.split("/").slice(-1)[0] || model : "Default";
   return (
-    <div className="flex items-center gap-1">
+    <Flex align="center" gap="1">
       {!onlyOneProvider && (
         <Select value={providerId} onValueChange={onProviderChange}>
           <SelectTrigger
@@ -531,6 +548,8 @@ function ModelPill({
           title={model}
         >
           <SelectValue>
+            {/* Inherit-only span: relies on SelectTrigger's font-mono text-[11px];
+                Text as="span" would reset size/family, so this stays raw. */}
             <span className="truncate">{shortModel}</span>
           </SelectValue>
         </SelectTrigger>
@@ -542,7 +561,7 @@ function ModelPill({
           ))}
         </SelectContent>
       </Select>
-    </div>
+    </Flex>
   );
 }
 
@@ -576,41 +595,49 @@ function MessageBubble({
     if (message.isToolResult) {
       const displayText = message.content.replace(/^\[Tool result:\s*/, "").replace(/\]$/, "");
       return (
-        <div ref={ref} className="flex justify-center py-0.5">
-          <div className="flex items-center gap-1.5 overflow-hidden rounded-full border border-border/40 bg-muted/30 px-2.5 py-1 text-[10px] text-muted-foreground max-w-[85%]">
+        <Flex ref={ref} justify="center" className="py-0.5">
+          <Flex
+            align="center"
+            gap="1.5"
+            className="overflow-hidden rounded-full border border-border/40 bg-muted/30 px-2.5 py-1 text-[10px] text-muted-foreground max-w-[85%]"
+          >
             <CheckCircle2 className="h-3 w-3 shrink-0 text-green-500" />
-            <span className="min-w-0 truncate font-mono">{displayText}</span>
-          </div>
-        </div>
+            <Text as="span" tone="muted" className="min-w-0 truncate font-mono text-[10px]">
+              {displayText}
+            </Text>
+          </Flex>
+        </Flex>
       );
     }
     return (
-      <div ref={ref} className="flex justify-end">
-        <div className="max-w-[85%] whitespace-pre-wrap break-words rounded-2xl rounded-br-sm bg-brand-emphasis/15 px-3 py-2 text-sm">
+      <Flex ref={ref} justify="end">
+        <Box className="max-w-[85%] whitespace-pre-wrap break-words rounded-2xl rounded-br-sm bg-brand-emphasis/15 px-3 py-2 text-sm">
           {message.content}
-        </div>
-      </div>
+        </Box>
+      </Flex>
     );
   }
 
   return (
-    <div ref={ref} className="flex flex-col gap-1.5">
-      <div className="flex items-center gap-1.5">
+    <Flex ref={ref} direction="col" gap="1.5">
+      <Flex align="center" gap="1.5">
         <Sparkles className="h-3 w-3 text-brand-emphasis" />
-        <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">AI</span>
+        <Text as="span" weight="medium" tone="muted" className="text-[10px] uppercase tracking-wide">
+          AI
+        </Text>
         {message.pending && <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />}
-      </div>
+      </Flex>
       {message.content && (
-        <div className="break-words text-sm">
+        <Box className="break-words text-sm">
           <ChatMarkdown>{message.content}</ChatMarkdown>
-        </div>
+        </Box>
       )}
       {message.toolCalls
         // update_task_list is a status-only op shown in the task panel above —
         // suppress it from the chat thread to avoid redundant cards.
         ?.filter((call) => call.op !== "update_task_list")
         .map((call) => (
-          <div key={call.id} className="space-y-1.5">
+          <Stack key={call.id} gap="1.5">
             <ToolCallCard
               call={call}
               showUndo={isLastAssistant && canUndo}
@@ -619,19 +646,19 @@ function MessageBubble({
               onToggleBoard={() => onToggleBoard(call.id)}
             />
             {renderToolCallSupplement?.(call)}
-          </div>
+          </Stack>
         ))}
       {message.warnings && message.warnings.length > 0 && (
-        <div className="space-y-1">
+        <Stack gap="1">
           {message.warnings.map((w, i) => (
             <Alert key={i} className="py-1.5 text-xs">
               <AlertCircle className="h-3 w-3" />
               <AlertDescription>{w}</AlertDescription>
             </Alert>
           ))}
-        </div>
+        </Stack>
       )}
-    </div>
+    </Flex>
   );
 }
 
@@ -651,12 +678,12 @@ function ToolCallCard({
   const deviceType = call.deviceType ?? "flagship";
   const hasBoard = !!call.appliedSnapshot;
   return (
-    <div className="space-y-2 overflow-hidden rounded-lg border bg-muted/40 p-2.5">
-      <div className="flex items-center justify-between gap-2">
+    <Stack gap="2" className="overflow-hidden rounded-lg border bg-muted/40 p-2.5">
+      <Flex align="center" justify="between" gap="2">
         <Badge variant="secondary" className="font-mono text-[10px]">
           {labelFor(call)}
         </Badge>
-        <div className="flex items-center gap-1">
+        <Flex align="center" gap="1">
           {hasBoard && !boardVisible && (
             <Button
               type="button"
@@ -695,11 +722,11 @@ function ToolCallCard({
               Undo
             </Button>
           )}
-        </div>
-      </div>
+        </Flex>
+      </Flex>
       {hasBoard && boardVisible && <InlineBoardPreview snapshot={call.appliedSnapshot!} deviceType={deviceType} />}
       <ToolCallSummary call={call} />
-    </div>
+    </Stack>
   );
 }
 
@@ -753,27 +780,34 @@ function ToolCallSummary({ call }: { call: ToolCall }) {
       // the main thing the user sees, with the patch detail
       // available for anyone who wants to inspect it.
       <PatchDetailDisclosure count={count}>
-        <ul className="space-y-0.5 px-1 pt-1 text-[11px] text-muted-foreground">
+        <List gap="0" className="space-y-0.5 px-1 pt-1 text-[11px] text-muted-foreground">
           {call.args.changes.map((c, i) => (
-            <li key={i} className="break-all font-mono">
+            <ListItem key={i} className="break-all font-mono">
               {summarizeLineOp(c)}
-            </li>
+            </ListItem>
           ))}
-          {call.args.rename && <li className="break-all font-mono">→ rename to &quot;{call.args.rename}&quot;</li>}
-        </ul>
+          {call.args.rename && (
+            <ListItem className="break-all font-mono">→ rename to &quot;{call.args.rename}&quot;</ListItem>
+          )}
+        </List>
       </PatchDetailDisclosure>
     );
   }
   if (call.op === "suggest_variables") {
     return (
-      <ul className="space-y-0.5 text-[11px]">
+      <List gap="0" className="space-y-0.5 text-[11px]">
         {call.args.suggestions.map((s, i) => (
-          <li key={i}>
-            <code className="font-mono text-[10px]">{`{{${s.ref}}}`}</code>
-            {s.description && <span className="text-muted-foreground"> — {s.description}</span>}
-          </li>
+          <ListItem key={i}>
+            <Code className="font-mono text-[10px]">{`{{${s.ref}}}`}</Code>
+            {s.description && (
+              <Text as="span" tone="muted" className="text-[11px]">
+                {" "}
+                — {s.description}
+              </Text>
+            )}
+          </ListItem>
         ))}
-      </ul>
+      </List>
     );
   }
   // navigate_to_page, install_plugin, update_plugin_config, update_setting:
@@ -790,6 +824,9 @@ function PatchDetailDisclosure({ count, children }: { count: number; children: R
           className="group/disclose flex w-full items-center gap-1 rounded text-[10px] text-muted-foreground transition-colors hover:text-foreground"
         >
           <ChevronRight className="h-3 w-3 transition-transform group-data-[panel-open]/disclose:rotate-90" />
+          {/* Inherit-only span: the button's color flips on hover
+              (text-muted-foreground → text-foreground); a Text tone would pin
+              the color and defeat that transition, so this stays raw. */}
           <span>{count === 1 ? "View change" : `View ${count} changes`}</span>
         </button>
       </CollapsibleTrigger>

--- a/web/src/components/board-display.tsx
+++ b/web/src/components/board-display.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Box, Text } from "@fiestaboard/ui";
 import { memo, useEffect, useMemo, useRef, useState } from "react";
 
 import { useBoardAnimationsEnabled } from "@/hooks/use-board-animations";
@@ -262,17 +263,17 @@ const StaticTile = memo(function StaticTile({
         : "text-[10px] sm:text-[13px] md:text-[16px] lg:text-[20px]";
 
   const splitLine = (
-    <div className={`absolute top-1/2 left-0 right-0 h-[1px] ${isWhiteBoard ? "bg-black/10" : "bg-black/30"}`} />
+    <Box className={`absolute top-1/2 left-0 right-0 h-[1px] ${isWhiteBoard ? "bg-black/10" : "bg-black/30"}`} />
   );
 
   if (token.type === "color") {
     const bgColor = resolveColorCode(token.code, isWhiteBoard);
     const inset = size === "sm" ? "3px 1px 4px" : size === "md" ? "4px 2px 5px" : "5px 2px 6px";
     return (
-      <div className={`${sizeClass} relative rounded-[3px] overflow-hidden`} style={{ backgroundColor: tileBg }}>
-        <div className="absolute rounded-[2px]" style={{ inset, backgroundColor: bgColor }} />
+      <Box className={`${sizeClass} relative rounded-[3px] overflow-hidden`} style={{ backgroundColor: tileBg }}>
+        <Box className="absolute rounded-[2px]" style={{ inset, backgroundColor: bgColor }} />
         {splitLine}
-      </div>
+      </Box>
     );
   }
 
@@ -280,20 +281,20 @@ const StaticTile = memo(function StaticTile({
   const isBlank = displayChar === " ";
 
   return (
-    <div
+    <Box
       className={`${sizeClass} relative rounded-[3px] overflow-hidden flex items-center justify-center`}
       style={{ backgroundColor: tileBg }}
     >
       {!isBlank && (
-        <span
+        <Text as="span"
           className={`${textSizeClass} font-mono font-semibold select-none leading-none`}
           style={{ color: token.value === "♥" ? "#eb4034" : textColor }}
         >
           {displayChar}
-        </span>
+        </Text>
       )}
       {splitLine}
-    </div>
+    </Box>
   );
 });
 
@@ -319,7 +320,7 @@ const StaticGridRow = memo(function StaticGridRow({
   emitCellMetadata?: boolean;
 }) {
   return (
-    <div
+    <Box
       data-note-row=""
       {...(isRowSeam ? { "data-note-row-seam": "true" } : {})}
       className={`flex ${gapClass} justify-center`}
@@ -332,7 +333,7 @@ const StaticGridRow = memo(function StaticGridRow({
         // metadata (coordinates + cell value) is opt-in — see
         // BoardDisplayProps.emitCellMetadata.
         return (
-          <div
+          <Box
             key={`col-${rowIdx}-${colIdx}`}
             data-note-tile=""
             {...(emitCellMetadata
@@ -342,10 +343,10 @@ const StaticGridRow = memo(function StaticGridRow({
             style={isColSeam ? { marginLeft: seamGap } : undefined}
           >
             <StaticTile token={token} size={size} boardType={boardType} />
-          </div>
+          </Box>
         );
       })}
-    </div>
+    </Box>
   );
 });
 
@@ -381,7 +382,7 @@ const GridRow = memo(
     emitCellMetadata?: boolean;
   }) {
     return (
-      <div
+      <Box
         data-note-row=""
         {...(isRowSeam ? { "data-note-row-seam": "true" } : {})}
         className={`flex ${gapClass} justify-center`}
@@ -395,7 +396,7 @@ const GridRow = memo(
           // Draw-mode cell coordinates are opt-in — see
           // BoardDisplayProps.emitCellMetadata.
           return (
-            <div
+            <Box
               key={`col-${rowIdx}-${colIdx}`}
               data-note-tile=""
               {...(emitCellMetadata ? { "data-row": rowIdx, "data-col": colIdx } : {})}
@@ -411,10 +412,10 @@ const GridRow = memo(
                 rowIdx={rowIdx}
                 colIdx={colIdx}
               />
-            </div>
+            </Box>
           );
         })}
-      </div>
+      </Box>
     );
   },
   (prevProps, nextProps) => {
@@ -823,7 +824,7 @@ const CharTile = memo(
 
     return (
       <>
-        <div
+        <Box
           className={`relative ${sizeClasses[size]} rounded-[3px] overflow-hidden`}
           data-testid={`char-tile-${rowIdx}-${colIdx}`}
           data-current-char={currentChar}
@@ -852,12 +853,12 @@ const CharTile = memo(
                       : "[--color-margin-top:4px] sm:[--color-margin-top:5px] md:[--color-margin-top:6px] lg:[--color-margin-top:8px] [--color-margin-bottom:5px] sm:[--color-margin-bottom:7px] md:[--color-margin-bottom:8px] lg:[--color-margin-bottom:10px] [--color-margin-h:2px] md:[--color-margin-h:3px]";
 
                 return (
-                  <div
+                  <Box
                     key={`static-color-${token.code}`}
                     className={`absolute inset-0 ${marginClasses} flex items-center justify-center`}
                     style={{ zIndex: 2 }}
                   >
-                    <div
+                    <Box
                       className="relative rounded-[3px] overflow-hidden"
                       style={{
                         marginTop: "var(--color-margin-top)",
@@ -876,9 +877,9 @@ const CharTile = memo(
                     `,
                       }}
                     >
-                      <div className="absolute top-1/2 left-0 right-0 h-[1px] bg-black/10" />
-                    </div>
-                  </div>
+                      <Box className="absolute top-1/2 left-0 right-0 h-[1px] bg-black/10" />
+                    </Box>
+                  </Box>
                 );
               }
 
@@ -893,7 +894,7 @@ const CharTile = memo(
               const charColor = isHeart ? "#eb4034" : textColor;
 
               return (
-                <div
+                <Box
                   key={`static-char-${targetCharIndex}`}
                   className="absolute inset-0 flex items-center justify-center overflow-hidden"
                   style={{
@@ -904,25 +905,25 @@ const CharTile = memo(
                   }}
                 >
                   {!isColor && targetChar !== " " && (
-                    <span
+                    <Text as="span"
                       className={`${textSizeClasses[size]} font-mono font-semibold select-none leading-none relative z-10`}
                       style={{ color: charColor }}
                     >
                       {targetChar}
-                    </span>
+                    </Text>
                   )}
                   {/* Blank/space character - render as empty but maintain layout */}
                   {!isColor && targetChar === " " && (
-                    <span
+                    <Text as="span"
                       className={`${textSizeClasses[size]} font-mono font-semibold select-none leading-none relative z-10`}
                       style={{ color: textColor, visibility: "hidden" }}
                       aria-hidden="true"
                     >
                       {" "}
-                    </span>
+                    </Text>
                   )}
                   {isColor && (
-                    <div
+                    <Box
                       className="absolute inset-0 rounded-[3px]"
                       style={{
                         backgroundColor: charBg,
@@ -936,7 +937,7 @@ const CharTile = memo(
                       }}
                     />
                   )}
-                </div>
+                </Box>
               );
             })()}
 
@@ -958,7 +959,7 @@ const CharTile = memo(
                 const bg = isColor ? resolveColorCode(char, isWhiteBoard) : tileBg;
                 const isHeart = char === "♥";
                 return (
-                  <div
+                  <Box
                     style={{
                       position: "absolute" as const,
                       ...(isTop ? { top: 0 } : { bottom: 0 }),
@@ -972,21 +973,21 @@ const CharTile = memo(
                     }}
                   >
                     {!isColor && char !== " " && (
-                      <span
+                      <Text as="span"
                         className={`${textSizeClasses[size]} font-mono font-semibold select-none leading-none`}
                         style={{ color: isHeart ? "#eb4034" : textColor }}
                       >
                         {char}
-                      </span>
+                      </Text>
                     )}
-                  </div>
+                  </Box>
                 );
               };
 
               return (
                 <>
                   {/* Layer 1: new char top half — sits behind falling top flap */}
-                  <div
+                  <Box
                     style={{
                       position: "absolute",
                       top: 0,
@@ -998,10 +999,10 @@ const CharTile = memo(
                     }}
                   >
                     {renderHalf(newChar, true)}
-                  </div>
+                  </Box>
 
                   {/* Layer 2: old char bottom half — sits behind unfolding bottom flap */}
-                  <div
+                  <Box
                     style={{
                       position: "absolute",
                       top: "50%",
@@ -1013,10 +1014,10 @@ const CharTile = memo(
                     }}
                   >
                     {renderHalf(prevChar, false)}
-                  </div>
+                  </Box>
 
                   {/* Layer 3: top flap — old char top half, folds DOWN (hinged at midpoint) */}
-                  <div
+                  <Box
                     key={`ft-${currentCharIndex}`}
                     style={{
                       position: "absolute",
@@ -1034,7 +1035,7 @@ const CharTile = memo(
                   >
                     {renderHalf(prevChar, true)}
                     {/* Hinge shadow at bottom edge of flap */}
-                    <div
+                    <Box
                       style={{
                         position: "absolute",
                         bottom: 0,
@@ -1045,10 +1046,10 @@ const CharTile = memo(
                         pointerEvents: "none",
                       }}
                     />
-                  </div>
+                  </Box>
 
                   {/* Layer 4: bottom flap — new char bottom half, UNFOLDS into place */}
-                  <div
+                  <Box
                     key={`fb-${currentCharIndex}`}
                     style={{
                       position: "absolute",
@@ -1067,7 +1068,7 @@ const CharTile = memo(
                   >
                     {renderHalf(newChar, false)}
                     {/* Hinge highlight at top edge of flap */}
-                    <div
+                    <Box
                       style={{
                         position: "absolute",
                         top: 0,
@@ -1080,10 +1081,10 @@ const CharTile = memo(
                         pointerEvents: "none",
                       }}
                     />
-                  </div>
+                  </Box>
 
                   {/* Shadow cast by falling flap onto bottom half */}
-                  <div
+                  <Box
                     key={`fs-${currentCharIndex}`}
                     style={{
                       position: "absolute",
@@ -1102,7 +1103,7 @@ const CharTile = memo(
                   />
 
                   {/* Split line at midpoint */}
-                  <div
+                  <Box
                     className={`absolute top-1/2 left-0 right-0 h-[1px] ${isWhiteBoard ? "bg-black/10" : "bg-black/30"}`}
                     style={{ zIndex: 5 }}
                   />
@@ -1114,11 +1115,11 @@ const CharTile = memo(
           {/* Character is shown via pre-rendered layer above, just add styling */}
           {!isAnimating && !isTransitioning && currentCharIndex === targetCharIndex && (
             <>
-              <div
+              <Box
                 className={`absolute top-1/2 left-0 right-0 h-[1px] ${isWhiteBoard ? "bg-black/10" : "bg-black/30"}`}
                 style={{ zIndex: 3 }}
               />
-              <div
+              <Box
                 className="absolute inset-0 pointer-events-none"
                 style={{
                   zIndex: 1,
@@ -1129,7 +1130,7 @@ const CharTile = memo(
               />
             </>
           )}
-        </div>
+        </Box>
       </>
     );
   },
@@ -1252,8 +1253,8 @@ export const BoardDisplay = memo(
     }, [message, isLoading, t]);
 
     return (
-      <div className={`w-full flex justify-center`}>
-        <div
+      <Box className={`w-full flex justify-center`}>
+        <Box
           role="img"
           aria-label={boardText}
           data-board-preview=""
@@ -1266,7 +1267,7 @@ export const BoardDisplay = memo(
           }}
         >
           {/* Inner bezel border */}
-          <div
+          <Box
             className={`${paddingClasses[size]} relative`}
             aria-hidden="true"
             style={{
@@ -1275,7 +1276,7 @@ export const BoardDisplay = memo(
                 : "linear-gradient(135deg, var(--color-board-surface-dark) 0%, var(--color-board-black) 100%)",
             }}
           >
-            <div className={`flex flex-col ${gapClasses[size]}`}>
+            <Box className={`flex flex-col ${gapClasses[size]}`}>
               {grid.map((row, rowIdx) => {
                 const isRowSeam = showSeams && rowIdx > 0 && rowIdx % NOTE_ROWS === 0;
                 return isStatic ? (
@@ -1308,10 +1309,10 @@ export const BoardDisplay = memo(
                   />
                 );
               })}
-            </div>
-          </div>
-        </div>
-      </div>
+            </Box>
+          </Box>
+        </Box>
+      </Box>
     );
   },
   (prevProps, nextProps) => {

--- a/web/src/components/board-display.tsx
+++ b/web/src/components/board-display.tsx
@@ -286,7 +286,8 @@ const StaticTile = memo(function StaticTile({
       style={{ backgroundColor: tileBg }}
     >
       {!isBlank && (
-        <Text as="span"
+        <Text
+          as="span"
           className={`${textSizeClass} font-mono font-semibold select-none leading-none`}
           style={{ color: token.value === "♥" ? "#eb4034" : textColor }}
         >
@@ -905,7 +906,8 @@ const CharTile = memo(
                   }}
                 >
                   {!isColor && targetChar !== " " && (
-                    <Text as="span"
+                    <Text
+                      as="span"
                       className={`${textSizeClasses[size]} font-mono font-semibold select-none leading-none relative z-10`}
                       style={{ color: charColor }}
                     >
@@ -914,7 +916,8 @@ const CharTile = memo(
                   )}
                   {/* Blank/space character - render as empty but maintain layout */}
                   {!isColor && targetChar === " " && (
-                    <Text as="span"
+                    <Text
+                      as="span"
                       className={`${textSizeClasses[size]} font-mono font-semibold select-none leading-none relative z-10`}
                       style={{ color: textColor, visibility: "hidden" }}
                       aria-hidden="true"
@@ -973,7 +976,8 @@ const CharTile = memo(
                     }}
                   >
                     {!isColor && char !== " " && (
-                      <Text as="span"
+                      <Text
+                        as="span"
                         className={`${textSizeClasses[size]} font-mono font-semibold select-none leading-none`}
                         style={{ color: isHeart ? "#eb4034" : textColor }}
                       >

--- a/web/src/components/board-size-indicator.tsx
+++ b/web/src/components/board-size-indicator.tsx
@@ -1,3 +1,5 @@
+import { Text } from "@fiestaboard/ui";
+
 import { useTranslations } from "@/i18n/translations";
 import { isNoteArray, NOTE_ARRAY_PRESETS, resolveDimensions } from "@/lib/board-dimensions";
 
@@ -37,20 +39,27 @@ export function BoardSizeIndicator({ deviceType, notesWide = 1, notesTall = 1, c
     : t("ariaLabel", { rows, cols });
 
   return (
-    <span
+    <Text
+      as="span"
+      size="xs"
+      tone="muted"
       role="img"
       aria-label={ariaLabel}
-      className={`inline-flex items-center gap-1 text-xs text-muted-foreground font-mono tabular-nums${className ? ` ${className}` : ""}`}
+      className={`inline-flex items-center gap-1 font-mono tabular-nums${className ? ` ${className}` : ""}`}
     >
       {/* Rows × cols (height × width) per the note-array epic convention; the
           wizard "characters" strings and tests use the same rows × cols order. */}
       {rows} × {cols}
       {noteArray && (
         <>
-          <span className="text-muted-foreground/50 mx-0.5">·</span>
-          <span>{presetLabel}</span>
+          <Text as="span" size="xs" className="text-muted-foreground/50 mx-0.5">
+            ·
+          </Text>
+          <Text as="span" size="xs" tone="muted">
+            {presetLabel}
+          </Text>
         </>
       )}
-    </span>
+    </Text>
   );
 }

--- a/web/src/components/boot-gate.tsx
+++ b/web/src/components/boot-gate.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FiestaLogo } from "@fiestaboard/ui";
+import { Box, FiestaLogo, Flex, Stack, Text } from "@fiestaboard/ui";
 import { useQuery } from "@tanstack/react-query";
 import { WifiOff } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -74,27 +74,32 @@ export function BootGate({ children }: { children: React.ReactNode }) {
   if (!showSplash) return null;
 
   return (
-    <div className="fixed inset-0 z-[200] flex flex-col items-center justify-center bg-background">
-      <div
-        className="flex flex-col items-center gap-6 text-center px-6 max-w-sm"
+    <Flex direction="col" align="center" justify="center" className="fixed inset-0 z-[200] bg-background">
+      <Flex
+        direction="col"
+        align="center"
+        gap="6"
+        className="text-center px-6 max-w-sm"
         role="status"
         aria-live="polite"
         aria-atomic="true"
       >
         {/* Branding */}
-        <div className="flex items-center gap-3">
+        <Flex align="center" gap="3">
           <img src={appUrl("/icons/favicon-32x32.png")} alt="" width={36} height={36} className="flex-shrink-0" />
           <FiestaLogo className="text-2xl" />
-        </div>
+        </Flex>
 
         {timedOut ? (
           /* ── Error state ── */
           <>
             <WifiOff className="h-10 w-10 text-muted-foreground" strokeWidth={1.5} aria-hidden="true" />
-            <div className="space-y-1.5">
-              <p className="text-base font-semibold">{t("errorHeading")}</p>
-              <p className="text-sm text-muted-foreground">{t("errorDescription")}</p>
-            </div>
+            <Stack gap="1.5">
+              <Text size="base" weight="semibold">
+                {t("errorHeading")}
+              </Text>
+              <Text tone="muted">{t("errorDescription")}</Text>
+            </Stack>
             <button
               onClick={() => window.location.reload()}
               className="px-4 py-2 text-sm font-medium rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
@@ -105,14 +110,14 @@ export function BootGate({ children }: { children: React.ReactNode }) {
         ) : (
           /* ── Waiting state ── */
           <>
-            <div
+            <Box
               className="h-8 w-8 rounded-full border-[2.5px] border-muted-foreground/25 border-t-muted-foreground animate-spin"
               aria-hidden="true"
             />
-            <p className="text-sm text-muted-foreground">{t("waiting")}</p>
+            <Text tone="muted">{t("waiting")}</Text>
           </>
         )}
-      </div>
-    </div>
+      </Flex>
+    </Flex>
   );
 }

--- a/web/src/components/chaining-mode-picker.tsx
+++ b/web/src/components/chaining-mode-picker.tsx
@@ -13,6 +13,7 @@
  */
 
 import {
+  Box,
   Button,
   DropdownMenu,
   DropdownMenuContent,
@@ -20,6 +21,7 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
+  Text,
 } from "@fiestaboard/ui";
 import { Bot, Hand, Zap } from "lucide-react";
 
@@ -62,9 +64,9 @@ export function ChainingModePicker({ mode, onChange }: ChainingModePickerProps) 
           aria-label={t("triggerAriaLabel", { mode: label })}
         >
           <Icon className="h-3.5 w-3.5" aria-hidden="true" />
-          <span className="hidden sm:inline" aria-hidden="true">
+          <Text as="span" size="xs" tone="muted" className="hidden sm:inline" aria-hidden="true">
             {label}
-          </span>
+          </Text>
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-60">
@@ -79,13 +81,15 @@ export function ChainingModePicker({ mode, onChange }: ChainingModePickerProps) 
                 aria-hidden="true"
                 className={`mt-0.5 h-3.5 w-3.5 shrink-0 ${isActive ? "text-brand-emphasis" : "text-muted-foreground"}`}
               />
-              <div className="flex-1 min-w-0">
-                <div className={`font-medium ${isActive ? "text-brand-emphasis" : ""}`}>
+              <Box className="flex-1 min-w-0">
+                <Text size="xs" weight="medium" className={isActive ? "text-brand-emphasis" : undefined}>
                   {t(`modes.${MODE_KEY[key]}.label`)}
-                </div>
-                <div className="text-muted-foreground leading-tight">{t(`modes.${MODE_KEY[key]}.description`)}</div>
-              </div>
-              {isActive && <div className="ml-auto mt-1 h-1.5 w-1.5 shrink-0 rounded-full bg-brand-emphasis" />}
+                </Text>
+                <Text size="xs" tone="muted" className="leading-tight">
+                  {t(`modes.${MODE_KEY[key]}.description`)}
+                </Text>
+              </Box>
+              {isActive && <Box className="ml-auto mt-1 h-1.5 w-1.5 shrink-0 rounded-full bg-brand-emphasis" />}
             </DropdownMenuItem>
           );
         })}

--- a/web/src/components/chat-markdown.tsx
+++ b/web/src/components/chat-markdown.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Box } from "@fiestaboard/ui";
 import React, { useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -41,6 +42,10 @@ const COLOR_SWATCHES: Record<string, string> = {
   black: "#1a1a1a",
 };
 
+// NOTE (FiestaUI primitives migration): VarChip/ColorChip intentionally render
+// raw <code>/<span>. These are bespoke inline token chips (brand-tinted variable
+// pills, color swatch labels), not semantic code — the <Code> primitive's own
+// recipe (padding/bg/size) would fight this hand-tuned styling. Kept raw.
 function VarChip({ plugin, field }: { plugin: string; field: string }) {
   return (
     <code
@@ -149,6 +154,12 @@ function splitWithTokens(text: string): React.ReactNode[] {
 export function ChatMarkdown({ children, className }: ChatMarkdownProps) {
   // The components map is stable per render; memoize to avoid React's
   // markdown reconciler re-creating component identities mid-stream.
+  // NOTE (FiestaUI primitives migration): every entry below is a react-markdown
+  // element override — react-markdown maps each markdown AST node type to these
+  // renderers, which MUST return the corresponding native HTML tag (p, strong,
+  // em, headings, ul/ol/li, a, code, pre, blockquote, table parts). Swapping in
+  // @fiestaboard/ui primitives here would break that AST-to-DOM contract, so
+  // these stay raw by design (documented exception).
   const components = useMemo(
     () =>
       ({
@@ -275,10 +286,10 @@ export function ChatMarkdown({ children, className }: ChatMarkdownProps) {
   );
 
   return (
-    <div className={cn("space-y-0", className)}>
+    <Box className={cn("space-y-0", className)}>
       <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
         {children}
       </ReactMarkdown>
-    </div>
+    </Box>
   );
 }

--- a/web/src/components/config-display.tsx
+++ b/web/src/components/config-display.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Badge, Card, CardContent, CardHeader, CardTitle, Skeleton } from "@fiestaboard/ui";
+import { Badge, Card, CardContent, CardHeader, CardTitle, Grid, Skeleton, Text } from "@fiestaboard/ui";
 import { Calendar, Cloud, Home, RotateCw, Wifi } from "lucide-react";
 import type { ComponentType } from "react";
 
@@ -23,7 +23,8 @@ const VulcanSalute = ({ className }: { className?: string }) => {
     : "grayscale(100%) brightness(0)"; // Black for primary/enabled state
 
   return (
-    <span
+    <Text
+      as="span"
       aria-hidden="true"
       className={className}
       style={{
@@ -42,7 +43,7 @@ const VulcanSalute = ({ className }: { className?: string }) => {
       }}
     >
       🖖
-    </span>
+    </Text>
   );
 };
 
@@ -87,11 +88,11 @@ export function ConfigDisplay() {
           <CardTitle className="text-lg">{t("title")}</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="grid grid-cols-2 gap-2">
+          <Grid cols="2" gap="2">
             {Array.from({ length: 6 }).map((_, i) => (
               <Skeleton key={i} className="h-9 w-full" />
             ))}
-          </div>
+          </Grid>
         </CardContent>
       </Card>
     );
@@ -102,11 +103,13 @@ export function ConfigDisplay() {
       <CardHeader>
         <CardTitle className="text-lg flex items-center gap-2">
           {t("title")}
-          <span className="text-xs font-normal text-muted-foreground">({t("clickToToggle")})</span>
+          <Text as="span" size="xs" tone="muted" className="font-normal">
+            ({t("clickToToggle")})
+          </Text>
         </CardTitle>
       </CardHeader>
       <CardContent>
-        <div className="grid grid-cols-2 gap-2">
+        <Grid cols="2" gap="2">
           {configItems.map(({ key, labelKey, icon: Icon }) => {
             const backendValue = (data?.[key] ?? false) as boolean;
             const enabled = getEffectiveValue(key, backendValue);
@@ -127,13 +130,13 @@ export function ConfigDisplay() {
                 <Icon
                   className={`h-4 w-4 shrink-0 transition-colors ${enabled ? "text-primary" : "text-muted-foreground"}`}
                 />
-                <span
-                  className={`text-xs truncate transition-colors ${
-                    enabled ? "text-foreground" : "text-muted-foreground"
-                  }`}
+                <Text
+                  as="span"
+                  size="xs"
+                  className={`truncate transition-colors ${enabled ? "text-foreground" : "text-muted-foreground"}`}
                 >
                   {label}
-                </span>
+                </Text>
                 <Badge
                   variant={enabled ? "default" : "secondary"}
                   className={`ml-auto shrink-0 text-[10px] px-1.5 py-0.5 transition-all ${
@@ -145,7 +148,7 @@ export function ConfigDisplay() {
               </button>
             );
           })}
-        </div>
+        </Grid>
       </CardContent>
     </Card>
   );

--- a/web/src/components/day-selector.tsx
+++ b/web/src/components/day-selector.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Badge } from "@fiestaboard/ui";
+import { Badge, Box, Flex, Text } from "@fiestaboard/ui";
 import { type KeyboardEvent, useEffect, useRef, useState } from "react";
 
 import { useTranslations } from "@/i18n/translations";
@@ -21,7 +21,8 @@ const WEEKENDS = ["saturday", "sunday"];
 const ALL_DAYS = [...WEEKDAYS, ...WEEKENDS];
 
 // Chip rows wrap so trailing chips aren't clipped at phone widths.
-const CHIP_ROW_CLASS = "ml-auto flex flex-wrap justify-end gap-1 min-w-0";
+// (Flex layout via <Flex wrap justify="end" gap="1"> at each usage.)
+const CHIP_ROW_CLASS = "ml-auto min-w-0";
 
 export function DaySelector({ value, customDays = [], onChange, className }: DaySelectorProps) {
   const t = useTranslations("daySelector");
@@ -85,8 +86,9 @@ export function DaySelector({ value, customDays = [], onChange, className }: Day
       <legend className="text-sm font-medium leading-none">{t("daysLegend")}</legend>
 
       {/* Pattern Radio Buttons */}
-      <div
-        className="flex flex-col gap-2"
+      <Flex
+        direction="col"
+        gap="2"
         role="radiogroup"
         aria-label={t("dayPatternAriaLabel")}
         onKeyDown={handleRadioKeyDown}
@@ -105,22 +107,26 @@ export function DaySelector({ value, customDays = [], onChange, className }: Day
             value === "all" ? "border-primary bg-primary/5 text-primary" : "border-border hover:bg-accent",
           )}
         >
-          <div
+          <Flex
+            align="center"
+            justify="center"
             className={cn(
-              "h-4 w-4 rounded-full border-2 flex items-center justify-center",
+              "h-4 w-4 rounded-full border-2",
               value === "all" ? "border-primary" : "border-muted-foreground",
             )}
           >
-            {value === "all" && <div className="h-2 w-2 rounded-full bg-primary" />}
-          </div>
-          <span className="text-sm font-medium">{t("allDays")}</span>
-          <div data-testid="day-pattern-chips" className={CHIP_ROW_CLASS}>
+            {value === "all" && <Box className="h-2 w-2 rounded-full bg-primary" />}
+          </Flex>
+          <Text as="span" size="sm" weight="medium" className={value === "all" ? "text-primary" : undefined}>
+            {t("allDays")}
+          </Text>
+          <Flex wrap justify="end" gap="1" data-testid="day-pattern-chips" className={CHIP_ROW_CLASS}>
             {ALL_DAYS.map((day) => (
               <Badge key={day} variant="secondary" className="text-xs">
                 {dayLabels[day]}
               </Badge>
             ))}
-          </div>
+          </Flex>
         </button>
 
         <button
@@ -137,22 +143,26 @@ export function DaySelector({ value, customDays = [], onChange, className }: Day
             value === "weekdays" ? "border-primary bg-primary/5 text-primary" : "border-border hover:bg-accent",
           )}
         >
-          <div
+          <Flex
+            align="center"
+            justify="center"
             className={cn(
-              "h-4 w-4 rounded-full border-2 flex items-center justify-center",
+              "h-4 w-4 rounded-full border-2",
               value === "weekdays" ? "border-primary" : "border-muted-foreground",
             )}
           >
-            {value === "weekdays" && <div className="h-2 w-2 rounded-full bg-primary" />}
-          </div>
-          <span className="text-sm font-medium">{t("weekdays")}</span>
-          <div data-testid="day-pattern-chips" className={CHIP_ROW_CLASS}>
+            {value === "weekdays" && <Box className="h-2 w-2 rounded-full bg-primary" />}
+          </Flex>
+          <Text as="span" size="sm" weight="medium" className={value === "weekdays" ? "text-primary" : undefined}>
+            {t("weekdays")}
+          </Text>
+          <Flex wrap justify="end" gap="1" data-testid="day-pattern-chips" className={CHIP_ROW_CLASS}>
             {WEEKDAYS.map((day) => (
               <Badge key={day} variant="secondary" className="text-xs">
                 {dayLabels[day]}
               </Badge>
             ))}
-          </div>
+          </Flex>
         </button>
 
         <button
@@ -169,22 +179,26 @@ export function DaySelector({ value, customDays = [], onChange, className }: Day
             value === "weekends" ? "border-primary bg-primary/5 text-primary" : "border-border hover:bg-accent",
           )}
         >
-          <div
+          <Flex
+            align="center"
+            justify="center"
             className={cn(
-              "h-4 w-4 rounded-full border-2 flex items-center justify-center",
+              "h-4 w-4 rounded-full border-2",
               value === "weekends" ? "border-primary" : "border-muted-foreground",
             )}
           >
-            {value === "weekends" && <div className="h-2 w-2 rounded-full bg-primary" />}
-          </div>
-          <span className="text-sm font-medium">{t("weekends")}</span>
-          <div data-testid="day-pattern-chips" className={CHIP_ROW_CLASS}>
+            {value === "weekends" && <Box className="h-2 w-2 rounded-full bg-primary" />}
+          </Flex>
+          <Text as="span" size="sm" weight="medium" className={value === "weekends" ? "text-primary" : undefined}>
+            {t("weekends")}
+          </Text>
+          <Flex wrap justify="end" gap="1" data-testid="day-pattern-chips" className={CHIP_ROW_CLASS}>
             {WEEKENDS.map((day) => (
               <Badge key={day} variant="secondary" className="text-xs">
                 {dayLabels[day]}
               </Badge>
             ))}
-          </div>
+          </Flex>
         </button>
 
         <button
@@ -202,20 +216,26 @@ export function DaySelector({ value, customDays = [], onChange, className }: Day
             value === "custom" && "rounded-b-none border-b-0",
           )}
         >
-          <div
+          <Flex
+            align="center"
+            justify="center"
             className={cn(
-              "h-4 w-4 rounded-full border-2 flex items-center justify-center",
+              "h-4 w-4 rounded-full border-2",
               value === "custom" ? "border-primary" : "border-muted-foreground",
             )}
           >
-            {value === "custom" && <div className="h-2 w-2 rounded-full bg-primary" />}
-          </div>
-          <span className="text-sm font-medium">{t("customDays")}</span>
+            {value === "custom" && <Box className="h-2 w-2 rounded-full bg-primary" />}
+          </Flex>
+          <Text as="span" size="sm" weight="medium" className={value === "custom" ? "text-primary" : undefined}>
+            {t("customDays")}
+          </Text>
         </button>
 
         {value === "custom" && (
-          <div
-            className="ml-6 flex flex-wrap gap-2 px-4 pb-3 pt-2 border border-t-0 border-primary bg-primary/5 rounded-b-lg"
+          <Flex
+            wrap
+            gap="2"
+            className="ml-6 px-4 pb-3 pt-2 border border-t-0 border-primary bg-primary/5 rounded-b-lg"
             role="group"
             aria-label={t("selectCustomDaysAriaLabel")}
           >
@@ -239,9 +259,9 @@ export function DaySelector({ value, customDays = [], onChange, className }: Day
                 {dayLabels[day]}
               </label>
             ))}
-          </div>
+          </Flex>
         )}
-      </div>
+      </Flex>
     </fieldset>
   );
 }

--- a/web/src/components/drawable-board-preview.tsx
+++ b/web/src/components/drawable-board-preview.tsx
@@ -7,6 +7,7 @@
  * ScaledBoardDisplay's CSS transform never enters coordinate math.
  */
 
+import { Box } from "@fiestaboard/ui";
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useRef } from "react";
 
@@ -115,7 +116,7 @@ export function DrawableBoardPreview({ active, onStrokePreview, onStrokeCommit, 
   };
 
   return (
-    <div
+    <Box
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}
       onPointerUp={handlePointerUp}
@@ -127,6 +128,6 @@ export function DrawableBoardPreview({ active, onStrokePreview, onStrokeCommit, 
       data-draw-surface={active ? "true" : undefined}
     >
       {children}
-    </div>
+    </Box>
   );
 }

--- a/web/src/components/force-set-dialog.tsx
+++ b/web/src/components/force-set-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  Box,
   Button,
   Dialog,
   DialogContent,
@@ -8,8 +9,11 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  Flex,
   Input,
   Label,
+  Stack,
+  Text,
 } from "@fiestaboard/ui";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Timer } from "lucide-react";
@@ -93,10 +97,10 @@ export function ForceSetDialog({ open, onOpenChange, pageId, pageName }: ForceSe
           <DialogDescription>{t("description", { pageName })}</DialogDescription>
         </DialogHeader>
 
-        <div className="py-2">
-          <div className="space-y-2">
+        <Box className="py-2">
+          <Stack gap="2">
             <Label className="text-sm font-medium">{t("showFor")}</Label>
-            <div className="flex flex-wrap gap-2">
+            <Flex wrap gap="2">
               {DURATION_PRESETS.map((preset) => (
                 <button
                   key={preset.minutes}
@@ -125,9 +129,9 @@ export function ForceSetDialog({ open, onOpenChange, pageId, pageName }: ForceSe
               >
                 {t("custom")}
               </button>
-            </div>
+            </Flex>
             {isCustom && (
-              <div className="flex items-center gap-2">
+              <Flex align="center" gap="2">
                 <Input
                   type="number"
                   min={1}
@@ -138,11 +142,13 @@ export function ForceSetDialog({ open, onOpenChange, pageId, pageName }: ForceSe
                   className="w-24"
                   autoFocus
                 />
-                <span className="text-sm text-muted-foreground">{t("minutes")}</span>
-              </div>
+                <Text as="span" size="sm" tone="muted">
+                  {t("minutes")}
+                </Text>
+              </Flex>
             )}
-          </div>
-        </div>
+          </Stack>
+        </Box>
 
         <DialogFooter>
           <Button variant="outline" onClick={() => onOpenChange(false)} disabled={setOverrideMutation.isPending}>

--- a/web/src/components/general-settings.tsx
+++ b/web/src/components/general-settings.tsx
@@ -1,13 +1,15 @@
 "use client";
 
+import { Stack } from "@fiestaboard/ui";
+
 import { SilenceSchedule } from "@/components/settings/silence-schedule";
 import { UpdateIntervals } from "@/components/settings/update-intervals";
 
 export function GeneralSettings() {
   return (
-    <div className="space-y-6">
+    <Stack gap="6">
       <UpdateIntervals />
       <SilenceSchedule />
-    </div>
+    </Stack>
   );
 }

--- a/web/src/components/global-ai-chat-drawer.tsx
+++ b/web/src/components/global-ai-chat-drawer.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Box } from "@fiestaboard/ui";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -816,7 +817,7 @@ export function GlobalAiChatDrawer() {
   if (!hasProviders) return null;
 
   return (
-    <div
+    <Box
       ref={panelRef}
       role="dialog"
       aria-modal="true"
@@ -842,6 +843,6 @@ export function GlobalAiChatDrawer() {
         taskList={taskList}
         onConversationReset={() => setTaskList([])}
       />
-    </div>
+    </Box>
   );
 }

--- a/web/src/components/home-assistant-entity-picker.tsx
+++ b/web/src/components/home-assistant-entity-picker.tsx
@@ -8,9 +8,14 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
+  Box,
   Button,
+  Code,
+  Flex,
   Input,
   ScrollArea,
+  Stack,
+  Text,
 } from "@fiestaboard/ui";
 import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
@@ -80,13 +85,13 @@ export function HomeAssistantEntityPicker({ open, onClose, onSelect }: Props) {
         </AlertDialogHeader>
 
         {isLoading ? (
-          <div className="flex items-center justify-center py-8">
-            <div className="text-sm text-muted-foreground">{t("loadingEntities")}</div>
-          </div>
+          <Flex align="center" justify="center" className="py-8">
+            <Text tone="muted">{t("loadingEntities")}</Text>
+          </Flex>
         ) : (
-          <div className="space-y-3 flex-1 min-h-0 flex flex-col">
+          <Flex direction="col" gap="3" className="flex-1 min-h-0">
             {!selectedEntity ? (
-              <div className="space-y-2 flex-1 min-h-0 flex flex-col">
+              <Flex direction="col" gap="2" className="flex-1 min-h-0">
                 <Input
                   placeholder={t("searchPlaceholder")}
                   aria-label={t("searchAriaLabel")}
@@ -96,9 +101,11 @@ export function HomeAssistantEntityPicker({ open, onClose, onSelect }: Props) {
                   className="h-9"
                 />
                 <ScrollArea className="flex-1 min-h-[200px] border rounded-md">
-                  <div className="p-1">
+                  <Box className="p-1">
                     {filteredEntities.length === 0 ? (
-                      <div className="text-sm text-muted-foreground text-center py-3">{t("noEntities")}</div>
+                      <Text tone="muted" className="text-center py-3">
+                        {t("noEntities")}
+                      </Text>
                     ) : (
                       filteredEntities.map((entity) => (
                         <button
@@ -109,21 +116,25 @@ export function HomeAssistantEntityPicker({ open, onClose, onSelect }: Props) {
                           }}
                           className="w-full text-left px-3 py-1.5 rounded hover:bg-muted transition-colors flex items-center gap-2"
                         >
-                          <span className="font-mono text-sm flex-1">{entity.entity_id}</span>
-                          <span className="text-xs text-muted-foreground truncate max-w-[200px]">
+                          <Text as="span" size="sm" className="font-mono flex-1">
+                            {entity.entity_id}
+                          </Text>
+                          <Text as="span" size="xs" tone="muted" className="truncate max-w-[200px]">
                             {entity.friendly_name !== entity.entity_id ? entity.friendly_name : ""}
-                          </span>
+                          </Text>
                         </button>
                       ))
                     )}
-                  </div>
+                  </Box>
                 </ScrollArea>
-              </div>
+              </Flex>
             ) : (
               <>
-                <div className="space-y-1.5">
-                  <div className="px-2 py-1.5 bg-muted rounded flex items-center justify-between gap-2">
-                    <span className="font-mono text-sm flex-1 truncate">{selectedEntity.entity_id}</span>
+                <Stack gap="1.5">
+                  <Flex align="center" justify="between" gap="2" className="px-2 py-1.5 bg-muted rounded">
+                    <Text as="span" size="sm" className="font-mono flex-1 truncate">
+                      {selectedEntity.entity_id}
+                    </Text>
                     <Button
                       variant="ghost"
                       size="sm"
@@ -136,13 +147,15 @@ export function HomeAssistantEntityPicker({ open, onClose, onSelect }: Props) {
                     >
                       {t("change")}
                     </Button>
-                  </div>
-                </div>
+                  </Flex>
+                </Stack>
 
-                <div className="space-y-1.5">
-                  <p className="text-xs font-medium text-muted-foreground px-1">{t("selectAttribute")}</p>
+                <Stack gap="1.5">
+                  <Text size="xs" weight="medium" tone="muted" className="px-1">
+                    {t("selectAttribute")}
+                  </Text>
                   <ScrollArea className="h-[250px] border rounded-md">
-                    <div className="p-1">
+                    <Box className="p-1">
                       {availableAttributes.map((attr) => {
                         const value = attr === "state" ? selectedEntity.state : selectedEntity.attributes[attr];
                         const displayValue =
@@ -157,37 +170,39 @@ export function HomeAssistantEntityPicker({ open, onClose, onSelect }: Props) {
                               selectedAttribute === attr && "bg-primary/10 border border-primary",
                             )}
                           >
-                            <div className="flex items-center justify-between gap-2">
-                              <span className="font-mono text-xs font-medium">{attr}</span>
+                            <Flex align="center" justify="between" gap="2">
+                              <Text as="span" size="xs" weight="medium" className="font-mono">
+                                {attr}
+                              </Text>
                               {displayValue && (
-                                <span className="text-xs text-muted-foreground truncate max-w-[150px]">
+                                <Text as="span" size="xs" tone="muted" className="truncate max-w-[150px]">
                                   {displayValue}
-                                </span>
+                                </Text>
                               )}
-                            </div>
+                            </Flex>
                           </button>
                         );
                       })}
-                    </div>
+                    </Box>
                   </ScrollArea>
-                </div>
+                </Stack>
               </>
             )}
 
             {selectedEntity && selectedAttribute && (
-              <div className="px-2 py-1.5 bg-muted rounded space-y-1">
-                <code className="text-xs font-mono block">
+              <Stack gap="1" className="px-2 py-1.5 bg-muted rounded">
+                <Code className="text-xs font-mono block">
                   {`{{home_assistant.${selectedEntity.entity_id.replace(/\./g, "_")}.${selectedAttribute}}}`}
-                </code>
-                <div className="text-xs text-muted-foreground">
+                </Code>
+                <Text size="xs" tone="muted">
                   {t("valueLabel")}:{" "}
                   {selectedAttribute === "state"
                     ? selectedEntity.state
                     : String(selectedEntity.attributes[selectedAttribute] || "N/A")}
-                </div>
-              </div>
+                </Text>
+              </Stack>
             )}
-          </div>
+          </Flex>
         )}
 
         <AlertDialogFooter>

--- a/web/src/components/inline-board-preview.tsx
+++ b/web/src/components/inline-board-preview.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Box, Text } from "@fiestaboard/ui";
 import { useQuery } from "@tanstack/react-query";
 
 import { ScaledBoardDisplay } from "@/components/scaled-board-display";
@@ -53,7 +54,11 @@ export function InlineBoardPreview({ snapshot, deviceType, size = "sm", classNam
   if (isError) {
     // Don't crash the chat panel if the render API hiccups — fall
     // back to a quiet hint. The card still has a useful summary.
-    return <div className="text-[10px] text-muted-foreground italic">(preview unavailable)</div>;
+    return (
+      <Text tone="muted" className="text-[10px] italic">
+        (preview unavailable)
+      </Text>
+    );
   }
 
   // Pass `null` while loading so BoardDisplay shows its empty grid
@@ -61,7 +66,7 @@ export function InlineBoardPreview({ snapshot, deviceType, size = "sm", classNam
   // string — BoardDisplay's tile components init to that target on
   // mount, so no flip animation runs.
   return (
-    <div className={className}>
+    <Box className={className}>
       <ScaledBoardDisplay
         message={isLoading ? null : (data?.rendered ?? "")}
         deviceType={deviceType}
@@ -69,6 +74,6 @@ export function InlineBoardPreview({ snapshot, deviceType, size = "sm", classNam
         boardType="black"
         isStatic
       />
-    </div>
+    </Box>
   );
 }

--- a/web/src/components/install-prompt.tsx
+++ b/web/src/components/install-prompt.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Box, Flex, Heading, Text } from "@fiestaboard/ui";
 import { Download, X } from "lucide-react";
 import { useEffect, useState } from "react";
 
@@ -95,22 +96,26 @@ export function InstallPrompt() {
   }
 
   return (
-    <div
+    <Box
       role="status"
       aria-live="polite"
       className="fixed bottom-4 left-4 right-4 lg:left-auto lg:right-4 lg:w-96 z-50 animate-in slide-in-from-bottom-5"
     >
-      <div className="bg-card border border-border rounded-lg shadow-lg p-4">
-        <div className="flex items-start gap-3">
-          <div className="flex-shrink-0 rounded-full bg-primary/10 p-2">
+      <Box className="bg-card border border-border rounded-lg shadow-lg p-4">
+        <Flex align="start" gap="3">
+          <Box className="flex-shrink-0 rounded-full bg-primary/10 p-2">
             <Download className="h-5 w-5 text-primary" />
-          </div>
+          </Box>
 
-          <div className="flex-1 min-w-0">
-            <h3 className="font-semibold text-sm mb-1">{t("title")}</h3>
-            <p className="text-xs text-muted-foreground mb-3">{t("description")}</p>
+          <Box className="flex-1 min-w-0">
+            <Heading level={3} size="sm" className="mb-1">
+              {t("title")}
+            </Heading>
+            <Text size="xs" tone="muted" className="mb-3">
+              {t("description")}
+            </Text>
 
-            <div className="flex gap-2">
+            <Flex gap="2">
               <button
                 onClick={handleInstallClick}
                 className="flex-1 inline-flex items-center justify-center gap-2 rounded-md bg-primary px-3 py-2 text-xs font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
@@ -124,8 +129,8 @@ export function InstallPrompt() {
               >
                 {t("notNow")}
               </button>
-            </div>
-          </div>
+            </Flex>
+          </Box>
 
           <button
             onClick={handleDismiss}
@@ -134,8 +139,8 @@ export function InstallPrompt() {
           >
             <X className="h-4 w-4" />
           </button>
-        </div>
-      </div>
-    </div>
+        </Flex>
+      </Box>
+    </Box>
   );
 }

--- a/web/src/components/navigation-sidebar.tsx
+++ b/web/src/components/navigation-sidebar.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { BoardSelector, fireSeasonBurst, Sidebar, type SidebarLinkProps, type SidebarNavItem } from "@fiestaboard/ui";
+import {
+  BoardSelector,
+  fireSeasonBurst,
+  Flex,
+  Sidebar,
+  type SidebarLinkProps,
+  type SidebarNavItem,
+  Text,
+} from "@fiestaboard/ui";
 import { useQuery } from "@tanstack/react-query";
 import {
   Award,
@@ -77,8 +85,15 @@ export function NavigationSidebar() {
       if (!season) return;
       fireSeasonBurst(e, season.colors);
       toast.custom(() => (
-        <div className="flex items-center gap-2 rounded-full border border-white/10 bg-[#111] px-5 py-2.5 text-[15px] font-bold shadow-xl">
-          <span
+        <Flex
+          align="center"
+          gap="2"
+          className="rounded-full border border-white/10 bg-[#111] px-5 py-2.5 text-[15px] font-bold shadow-xl"
+        >
+          <Text
+            as="span"
+            weight="bold"
+            className="text-[15px]"
             style={{
               background: "linear-gradient(90deg, #e40303, #ff8c00, #ffed00, #008026, #004dff, #750787)",
               WebkitBackgroundClip: "text",
@@ -87,9 +102,9 @@ export function NavigationSidebar() {
             }}
           >
             Happy Pride!
-          </span>{" "}
+          </Text>{" "}
           🏳️‍🌈
-        </div>
+        </Flex>
       ));
     },
     [season],

--- a/web/src/components/navigation-sidebar.tsx
+++ b/web/src/components/navigation-sidebar.tsx
@@ -92,8 +92,7 @@ export function NavigationSidebar() {
         >
           <Text
             as="span"
-            weight="bold"
-            className="text-[15px]"
+            className="text-[15px] font-bold"
             style={{
               background: "linear-gradient(90deg, #e40303, #ff8c00, #ffed00, #008026, #004dff, #750787)",
               WebkitBackgroundClip: "text",

--- a/web/src/components/output-target-selector.tsx
+++ b/web/src/components/output-target-selector.tsx
@@ -1,6 +1,17 @@
 "use client";
 
-import { Badge, Card, CardContent, CardDescription, CardHeader, CardTitle, Skeleton } from "@fiestaboard/ui";
+import {
+  Badge,
+  Box,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Flex,
+  Skeleton,
+  Text,
+} from "@fiestaboard/ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Monitor, Smartphone, Zap } from "lucide-react";
 import { toast } from "sonner";
@@ -100,17 +111,19 @@ export function OutputTargetSelector() {
                 isActive ? "border-brand bg-brand/5" : "border-muted hover:border-brand/50 active:bg-muted/50"
               }`}
             >
-              <div className="flex items-start gap-3">
-                <div
+              <Flex align="start" gap="3">
+                <Box
                   className={`p-2 rounded-md shrink-0 ${
                     isActive ? "bg-brand-emphasis text-brand-foreground" : "bg-muted"
                   }`}
                 >
                   <Icon className="h-5 w-5" />
-                </div>
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2 flex-wrap">
-                    <span className="font-medium text-sm sm:text-base">{getOptionLabel(option.value)}</span>
+                </Box>
+                <Box className="flex-1 min-w-0">
+                  <Flex align="center" gap="2" wrap>
+                    <Text as="span" size="sm" weight="medium" className="sm:text-base">
+                      {getOptionLabel(option.value)}
+                    </Text>
                     {isActive && (
                       <Badge variant="default" className="text-[10px] sm:text-xs">
                         {tc("active")}
@@ -121,10 +134,12 @@ export function OutputTargetSelector() {
                         {tc("effective")}
                       </Badge>
                     )}
-                  </div>
-                  <p className="text-xs text-muted-foreground mt-1">{getOptionDescription(option.value)}</p>
-                </div>
-              </div>
+                  </Flex>
+                  <Text size="xs" tone="muted" className="mt-1">
+                    {getOptionDescription(option.value)}
+                  </Text>
+                </Box>
+              </Flex>
             </button>
           );
         })}


### PR DESCRIPTION
Wave 2 of 6 for epic #1474: migrates 20 top-level `web/src/components/` files (account-section → output-target-selector) to `@fiestaboard/ui` primitives per the plan recipe.

## Highlights
- Board-geometry preserved verbatim: board-display / drawable-board-preview / inline-board-preview keep exact pixel classes on `Box` (no gap-prop snapping); all test hooks (`data-note-tile`, `data-draw-surface`, …) retained
- Inline spans in colored contexts carry matching `size`/`tone`/`weight`; invalid `weight="bold"` caught and replaced with `font-bold` className (Text's scale is normal/medium/semibold)
- Documented raw-tag exceptions (with in-code rationale): chat-markdown's ReactMarkdown renderer map + VarChip/ColorChip, two inherit-only spans in ai-chat-panel
- aria/roles/forms preserved (`role="radiogroup"`, `aria-modal`, form `onSubmit`, …)

## Verification
- ESLint 0 errors, prettier clean (in Docker; `npm test` locally blocked by the pre-existing node:20 dev-image worker bug — CI runs node 24)
- Task-reviewed (Approved); reviewer independently verified every variant value against FiestaUI's cva sources
- ⚠️ Screenshot gap: dashboard/sidebar/AI-panel are gated behind a configured board on a fresh instance — only the wizard was capturable. Please eyeball those screens on your live instance; the one intentional visible snap is chaining-mode-picker's trigger label `text-[11px]`→`text-xs`

No ESLint enforcement rule yet — wave 6.

Part of #1474

🤖 Generated with [Claude Code](https://claude.com/claude-code)