### PR TITLE
refactor: adopt FiestaUI primitives — wave 3 (components P–Z + i18n)

### DIFF
--- a/web/src/components/page-builder.tsx
+++ b/web/src/components/page-builder.tsx
@@ -12,6 +12,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
   AlertDialogTrigger,
+  Box,
   Button,
   Card,
   CardContent,
@@ -22,6 +23,7 @@ import {
   DialogDescription,
   DialogHeader,
   DialogTitle,
+  Flex,
   ScrollArea,
   Select,
   SelectContent,
@@ -29,7 +31,9 @@ import {
   SelectTrigger,
   SelectValue,
   Skeleton,
+  Stack,
   Switch,
+  Text,
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -1407,12 +1411,12 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
 
   return (
     <>
-      <div className="flex-1 min-h-0 w-full max-w-full overflow-x-hidden">
+      <Box className="flex-1 min-h-0 w-full max-w-full overflow-x-hidden">
         {/* Main Editor */}
         <Card className="flex flex-col min-h-0 w-full max-w-full overflow-x-hidden">
           <CardHeader className="pb-1 flex-shrink-0 px-4 sm:px-6">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-2 min-w-0">
+            <Flex align="center" justify="between">
+              <Flex align="center" gap="2" className="min-w-0">
                 <Button
                   variant="ghost"
                   size="icon"
@@ -1425,7 +1429,7 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
                 <CardTitle className="text-base sm:text-lg truncate">
                   {pageId ? t("editPage") : t("createPage")}
                 </CardTitle>
-              </div>
+              </Flex>
               {/* `skipDelayDuration={0}` disables Radix's "skip the
                *  hover delay when moving between tooltips" behavior.
                *  Without it, clicking the AI toggle and triggering a
@@ -1435,7 +1439,7 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
                *  time to settle on the new layout before any new
                *  tooltip pops. */}
               <TooltipProvider skipDelayDuration={0}>
-                <div className="flex items-center gap-1.5">
+                <Flex align="center" gap="1.5">
                   {/* Delete button - only show when editing */}
                   {pageId && (
                     <AlertDialog>
@@ -1453,7 +1457,7 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
                           </AlertDialogTrigger>
                         </TooltipTrigger>
                         <TooltipContent>
-                          <p>{t("deletePageTooltip")}</p>
+                          <Text>{t("deletePageTooltip")}</Text>
                         </TooltipContent>
                       </Tooltip>
                       <AlertDialogContent>
@@ -1483,7 +1487,7 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
                       <Button
                         variant="brand"
                         size="sm"
-                        className="h-8 gap-1.5 px-3"
+                        className="h-8 gap-1.5 px-3 text-xs"
                         onClick={() => {
                           // A shrinking retarget loses content — confirm first.
                           if (isShrinkingRetarget) {
@@ -1496,11 +1500,11 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
                         aria-label={t("savePageAriaLabel")}
                       >
                         <Save className="h-3.5 w-3.5" />
-                        <span className="text-xs">{saveMutation.isPending ? tCommon("saving") : t("savePage")}</span>
+                        {saveMutation.isPending ? tCommon("saving") : t("savePage")}
                       </Button>
                     </TooltipTrigger>
                     <TooltipContent>
-                      <p>{t("savePageTooltip")}</p>
+                      <Text>{t("savePageTooltip")}</Text>
                     </TooltipContent>
                   </Tooltip>
                   {/* Export button — only on existing pages */}
@@ -1510,7 +1514,7 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
                         <Button
                           variant="secondary"
                           size="sm"
-                          className="h-8 gap-1.5 px-3"
+                          className="h-8 gap-1.5 px-3 text-xs"
                           disabled={hasUnsavedChanges}
                           onClick={async () => {
                             try {
@@ -1525,17 +1529,17 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
                           aria-label={t("exportPageAriaLabel")}
                         >
                           <Upload className="h-3.5 w-3.5" />
-                          <span className="text-xs">{t("exportPage")}</span>
+                          {t("exportPage")}
                         </Button>
                       </TooltipTrigger>
                       <TooltipContent>
-                        <p>{hasUnsavedChanges ? t("exportDisabledTooltip") : t("exportPageTooltip")}</p>
+                        <Text>{hasUnsavedChanges ? t("exportDisabledTooltip") : t("exportPageTooltip")}</Text>
                       </TooltipContent>
                     </Tooltip>
                   )}
-                </div>
+                </Flex>
               </TooltipProvider>
-            </div>
+            </Flex>
           </CardHeader>
 
           <CardContent className="flex flex-col flex-1 min-h-0 px-3 sm:px-4 md:px-6 pt-2">
@@ -1548,7 +1552,7 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
               )}
 
               {/* Page name */}
-              <div className="space-y-1.5">
+              <Stack gap="1.5">
                 <label htmlFor="page-name" className="text-xs sm:text-sm font-medium">
                   {t("pageNameLabel")}
                 </label>
@@ -1560,17 +1564,13 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
                   placeholder={t("pageNamePlaceholder")}
                   className="w-full h-10 sm:h-9 px-3 text-sm rounded-md border bg-background focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                 />
-              </div>
+              </Stack>
 
               {/* Template line editors */}
-              <div className="space-y-3">
-                <div className="flex items-center justify-between">
+              <Stack gap="3">
+                <Flex align="center" justify="between">
                   <label className="text-xs sm:text-sm font-medium">{t("templateLabel")}</label>
-                  <div
-                    className="flex items-center border rounded-md overflow-hidden"
-                    role="group"
-                    aria-label={t("editorModeAriaLabel")}
-                  >
+                  <Flex align="center" role="group" aria-label={t("editorModeAriaLabel")} className="border rounded-md overflow-hidden">
                     <Button
                       size="sm"
                       variant="ghost"
@@ -1591,10 +1591,10 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
                     >
                       {t("plainEditor")}
                     </Button>
-                  </div>
-                </div>
+                  </Flex>
+                </Flex>
                 {editorMode === "rich" ? (
-                  <div>
+                  <Box>
                     {/* Template editor with device-specific dimensions */}
                     <TipTapTemplateEditor
                       ref={tipTapRef}
@@ -1680,9 +1680,9 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
                       onDrawBrushChange={setDrawBrush}
                       onDrawHistoryEvent={handleDrawHistoryEvent}
                     />
-                  </div>
+                  </Box>
                 ) : (
-                  <div>
+                  <Box>
                     <PlainTextEditor
                       value={templateLines.join("\n")}
                       onChange={(newValue) => {
@@ -1692,32 +1692,46 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
                       boardLines={numLines}
                       boardWidth={dims.cols}
                     />
-                  </div>
+                  </Box>
                 )}
 
                 {/* Line count validation warning */}
                 {lineCount > numLines && (
-                  <div className="flex items-start gap-2 rounded-md border border-warning/50 bg-warning/10 px-3 py-2 text-xs text-warning">
-                    <span className="font-medium shrink-0">{t("warningLabel")}</span>
-                    <span>{t("lineCountWarning", { lineCount, maxLines: numLines })}</span>
-                  </div>
+                  <Flex
+                    align="start"
+                    gap="2"
+                    className="rounded-md border border-warning/50 bg-warning/10 px-3 py-2 text-xs text-warning"
+                  >
+                    <Text as="span" size="xs" weight="medium" tone="warning" className="shrink-0">
+                      {t("warningLabel")}
+                    </Text>
+                    <Text as="span" size="xs" tone="warning">
+                      {t("lineCountWarning", { lineCount, maxLines: numLines })}
+                    </Text>
+                  </Flex>
                 )}
 
                 {/* Wrap budget warnings */}
                 {wrapBudgetWarnings.map((lineNumber) => (
-                  <div
+                  <Flex
                     key={`wrap-budget-${lineNumber}`}
-                    className="flex items-start gap-2 rounded-md border border-warning/50 bg-warning/10 px-3 py-2 text-xs text-warning"
+                    align="start"
+                    gap="2"
+                    className="rounded-md border border-warning/50 bg-warning/10 px-3 py-2 text-xs text-warning"
                   >
-                    <span className="font-medium shrink-0">{t("warningLabel")}</span>
-                    <span>{t("wrapBudgetWarning", { lineNumber })}</span>
-                  </div>
+                    <Text as="span" size="xs" weight="medium" tone="warning" className="shrink-0">
+                      {t("warningLabel")}
+                    </Text>
+                    <Text as="span" size="xs" tone="warning">
+                      {t("wrapBudgetWarning", { lineNumber })}
+                    </Text>
+                  </Flex>
                 ))}
 
                 {/* Live preview */}
-                <div className="mt-4">
-                  <div className="flex flex-wrap items-center justify-between gap-y-1 mb-2">
-                    <div className="flex items-center gap-2">
+                <Box className="mt-4">
+                  <Flex align="center" justify="between" className="flex-wrap gap-y-1 mb-2">
+                    <Flex align="center" gap="2">
                       <label className="text-xs sm:text-sm font-medium">{t("previewLabel")}</label>
                       <BoardSizeIndicator
                         deviceType={deviceType}
@@ -1788,9 +1802,11 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
                           </Select>
                         </>
                       )}
-                    </div>
-                    <div className="flex items-center gap-1.5 shrink-0">
-                      <span className="text-[10px] text-muted-foreground mr-0.5">{t("boardColorLabel")}</span>
+                    </Flex>
+                    <Flex align="center" gap="1.5" className="shrink-0">
+                      <Text as="span" size="xs" tone="muted" className="mr-0.5">
+                        {t("boardColorLabel")}
+                      </Text>
                       <button
                         onClick={() => setPreviewBoardColor("black")}
                         aria-label={t("previewAsBlack")}
@@ -1811,9 +1827,9 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
                             : "border-border hover:border-muted-foreground"
                         }`}
                       />
-                    </div>
-                  </div>
-                  <div className="flex justify-center">
+                    </Flex>
+                  </Flex>
+                  <Flex justify="center">
                     <DrawableBoardPreview
                       active={drawMode}
                       onStrokePreview={setStrokePreviewCells}
@@ -1867,12 +1883,16 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
                         emitCellMetadata
                       />
                     </DrawableBoardPreview>
-                  </div>
-                  {drawMode && <p className="mt-1 text-center text-xs text-muted-foreground">{t("drawModeHint")}</p>}
+                  </Flex>
+                  {drawMode && (
+                    <Text tone="muted" size="xs" className="mt-1 text-center">
+                      {t("drawModeHint")}
+                    </Text>
+                  )}
 
                   {/* Live output controls */}
-                  <div className="mt-3 flex items-center justify-between gap-3 rounded-lg border px-3 py-2">
-                    <div className="flex items-center gap-2">
+                  <Flex align="center" justify="between" gap="3" className="mt-3 rounded-lg border px-3 py-2">
+                    <Flex align="center" gap="2">
                       <Switch
                         id="live-output-toggle"
                         checked={liveOutputEnabled}
@@ -1889,9 +1909,11 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
                         {t("liveOutput")}
                       </label>
                       {liveSendMutation.isPending && (
-                        <span className="text-[10px] text-muted-foreground">{tCommon("sending")}</span>
+                        <Text as="span" size="xs" tone="muted">
+                          {tCommon("sending")}
+                        </Text>
                       )}
-                    </div>
+                    </Flex>
 
                     {boardSettings?.boards && boardSettings.boards.length > 1 && (
                       <Select value={selectedBoardId} onValueChange={setSelectedBoardId}>
@@ -1907,13 +1929,13 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
                         </SelectContent>
                       </Select>
                     )}
-                  </div>
-                </div>
-              </div>
+                  </Flex>
+                </Box>
+              </Stack>
             </ScrollArea>
           </CardContent>
         </Card>
-      </div>
+      </Box>
 
       {/* Export dialog */}
       <Dialog open={exportOpen} onOpenChange={setExportOpen}>
@@ -1922,7 +1944,7 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
             <DialogTitle>{t("exportDialogTitle")}</DialogTitle>
             <DialogDescription>{t("exportDialogDescription")}</DialogDescription>
           </DialogHeader>
-          <div className="relative">
+          <Box className="relative">
             <textarea
               readOnly
               value={exportShareString}
@@ -1941,7 +1963,7 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
             >
               {exportCopied ? <Check className="h-4 w-4 text-green-600" /> : <Copy className="h-4 w-4" />}
             </button>
-          </div>
+          </Box>
         </DialogContent>
       </Dialog>
 

--- a/web/src/components/page-builder.tsx
+++ b/web/src/components/page-builder.tsx
@@ -1570,7 +1570,12 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
               <Stack gap="3">
                 <Flex align="center" justify="between">
                   <label className="text-xs sm:text-sm font-medium">{t("templateLabel")}</label>
-                  <Flex align="center" role="group" aria-label={t("editorModeAriaLabel")} className="border rounded-md overflow-hidden">
+                  <Flex
+                    align="center"
+                    role="group"
+                    aria-label={t("editorModeAriaLabel")}
+                    className="border rounded-md overflow-hidden"
+                  >
                     <Button
                       size="sm"
                       variant="ghost"

--- a/web/src/components/page-editor-shell.tsx
+++ b/web/src/components/page-editor-shell.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Flex, Stack } from "@fiestaboard/ui";
 import { useCallback, useEffect, useRef } from "react";
 
 import { PageBuilder, type PageBuilderHandle } from "@/components/page-builder";
@@ -45,8 +46,8 @@ export function PageEditorShell({ pageId, deviceType, skipDraft, onClose, onSave
   }, [register, unregister, getSnapshot, applyOp, save, getCanUndo, undo]);
 
   return (
-    <div className="flex flex-1 min-h-0 w-full overflow-hidden bg-background">
-      <div className="flex h-full w-full min-w-0 flex-1 flex-col overflow-y-auto bg-background px-3 sm:px-4 md:px-6 py-4 sm:py-6 md:py-8 lg:py-3">
+    <Flex className="flex-1 min-h-0 w-full overflow-hidden bg-background">
+      <Stack className="h-full w-full min-w-0 flex-1 overflow-y-auto bg-background px-3 sm:px-4 md:px-6 py-4 sm:py-6 md:py-8 lg:py-3">
         <PageBuilder
           ref={builderRef}
           pageId={pageId}
@@ -55,7 +56,7 @@ export function PageEditorShell({ pageId, deviceType, skipDraft, onClose, onSave
           onClose={onClose}
           onSave={onSave}
         />
-      </div>
-    </div>
+      </Stack>
+    </Flex>
   );
 }

--- a/web/src/components/page-grid-selector.tsx
+++ b/web/src/components/page-grid-selector.tsx
@@ -2,15 +2,20 @@
 
 import {
   Badge,
+  Box,
   Button,
   Card,
   CardContent,
   EmptyState,
+  Flex,
+  Grid,
   Skeleton,
+  Stack,
   Tabs,
   TabsContent,
   TabsList,
   TabsTrigger,
+  Text,
 } from "@fiestaboard/ui";
 import { Clock, FilePlus, GalleryHorizontalEnd, LayoutTemplate } from "lucide-react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -129,14 +134,14 @@ const PageButtonPreview = memo(
 
     if (isLoading && !preview) {
       return (
-        <div ref={ref} className="w-full py-4" role="status" aria-label={t("loadingPreviewAriaLabel")}>
+        <Box ref={ref} className="w-full py-4" role="status" aria-label={t("loadingPreviewAriaLabel")}>
           <Skeleton className="h-20 w-full rounded-md" />
-        </div>
+        </Box>
       );
     }
 
     return (
-      <div
+      <Box
         ref={ref}
         className="w-full hover-stable overflow-hidden -mr-3"
         style={{
@@ -152,9 +157,9 @@ const PageButtonPreview = memo(
             deviceType={deviceType}
           />
         ) : (
-          <div className="w-full" style={{ height: deviceType === "note" ? 90 : 168 }} />
+          <Box className="w-full" style={{ height: deviceType === "note" ? 90 : 168 }} />
         )}
-      </div>
+      </Box>
     );
   },
   (prevProps, nextProps) => {
@@ -221,28 +226,30 @@ const PageButton = memo(
         type="button"
         aria-pressed={isActive}
       >
-        <div className="flex items-center gap-2.5 min-w-0">
+        <Flex align="center" gap="2.5" className="min-w-0">
           <TypeIcon className={iconClassName} aria-hidden="true" />
-          <span className={nameClassName}>{page.name}</span>
+          <Text as="span" className={nameClassName}>
+            {page.name}
+          </Text>
           <BoardSizeIndicator
             deviceType={page.device_type || "flagship"}
             notesWide={page.notes_wide}
             notesTall={page.notes_tall}
             className="ml-auto shrink-0"
           />
-        </div>
+        </Flex>
 
-        <div className="hover-stable">
+        <Box className="hover-stable">
           <PageButtonPreview
             preview={preview}
             isLoading={isLoadingPreview}
             boardType={boardType}
             deviceType={(page.device_type as DeviceType) || "flagship"}
           />
-        </div>
+        </Box>
 
         {showActiveIndicator && isActive && (
-          <div className="absolute -bottom-0.5 left-1/2 -translate-x-1/2 w-12 h-0.5 bg-brand rounded-full" />
+          <Box className="absolute -bottom-0.5 left-1/2 -translate-x-1/2 w-12 h-0.5 bg-brand rounded-full" />
         )}
       </button>
     );
@@ -318,7 +325,9 @@ const PageListItem = memo(
         aria-pressed={isActive}
       >
         <LayoutTemplate className={iconClassName} aria-hidden="true" />
-        <span className={nameClassName}>{page.name}</span>
+        <Text as="span" className={nameClassName}>
+          {page.name}
+        </Text>
         <BoardSizeIndicator
           deviceType={page.device_type || "flagship"}
           notesWide={page.notes_wide}
@@ -326,10 +335,10 @@ const PageListItem = memo(
           className="ml-auto shrink-0"
         />
         {formattedDate && (
-          <span className="ml-auto flex items-center gap-1 text-xs text-muted-foreground shrink-0">
+          <Text as="span" size="xs" tone="muted" className="ml-auto flex items-center gap-1 shrink-0">
             <Clock className="h-3 w-3" aria-hidden="true" />
             {formattedDate}
-          </span>
+          </Text>
         )}
       </button>
     );
@@ -407,28 +416,30 @@ const CollectionButton = memo(
         type="button"
         aria-pressed={isActive}
       >
-        <div className="flex items-center gap-2.5 min-w-0">
+        <Flex align="center" gap="2.5" className="min-w-0">
           <GalleryHorizontalEnd className={iconClassName} aria-hidden="true" />
-          <span className={nameClassName}>{collection.name}</span>
+          <Text as="span" className={nameClassName}>
+            {collection.name}
+          </Text>
           <Badge variant="secondary" className="text-[10px] ml-auto flex-shrink-0">
             {tCommon("pageCount", { count: collection.page_ids.length })}
           </Badge>
-        </div>
+        </Flex>
 
         {/* Cascading stack of board previews */}
-        <div className="relative h-[160px] w-full overflow-hidden hover-stable">
+        <Box className="relative h-[160px] w-full overflow-hidden hover-stable">
           {loadingPreviews && stackPages.every((sp) => !sp.preview) ? (
-            <div className="flex gap-2 items-end h-full p-2" role="status" aria-label={t("loadingPreviewsAriaLabel")}>
+            <Flex gap="2" align="end" className="h-full p-2" role="status" aria-label={t("loadingPreviewsAriaLabel")}>
               <Skeleton className="h-24 flex-1 max-w-[80px] rounded-md" />
               <Skeleton className="h-28 flex-1 max-w-[80px] rounded-md" />
               <Skeleton className="h-24 flex-1 max-w-[80px] rounded-md" />
-            </div>
+            </Flex>
           ) : (
-            <div className="absolute inset-0">
+            <Box className="absolute inset-0">
               {stackPages.map(({ pageId, page, preview }, idx) => {
                 const deviceType = (page?.device_type as DeviceType) || "flagship";
                 return (
-                  <div
+                  <Box
                     key={pageId}
                     className="absolute"
                     style={{
@@ -447,15 +458,15 @@ const CollectionButton = memo(
                       boardType={boardType ?? "black"}
                       deviceType={deviceType}
                     />
-                  </div>
+                  </Box>
                 );
               })}
-            </div>
+            </Box>
           )}
-        </div>
+        </Box>
 
         {showActiveIndicator && isActive && (
-          <div className="absolute -bottom-0.5 left-1/2 -translate-x-1/2 w-12 h-0.5 bg-brand rounded-full" />
+          <Box className="absolute -bottom-0.5 left-1/2 -translate-x-1/2 w-12 h-0.5 bg-brand rounded-full" />
         )}
       </button>
     );
@@ -626,26 +637,28 @@ export function PageGridSelector({
 
   if (isLoadingPages) {
     return (
-      <div aria-busy="true">
+      <Box aria-busy="true">
         {effectiveLabel && (
-          <span className="text-xs font-medium text-muted-foreground mb-3 block">{effectiveLabel}</span>
+          <Text as="span" size="xs" weight="medium" tone="muted" className="mb-3 block">
+            {effectiveLabel}
+          </Text>
         )}
         {viewMode === "list" ? (
-          <div className="flex flex-col gap-3">
+          <Stack gap="3">
             <Skeleton className="h-14 w-full rounded-lg" />
             <Skeleton className="h-14 w-full rounded-lg" />
             <Skeleton className="h-14 w-full rounded-lg" />
             <Skeleton className="h-14 w-full rounded-lg" />
-          </div>
+          </Stack>
         ) : (
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <Grid cols="1" gap="4" className="sm:grid-cols-2">
             <Skeleton className="h-40 w-full rounded-lg" />
             <Skeleton className="h-40 w-full rounded-lg" />
             <Skeleton className="h-40 w-full rounded-lg" />
             <Skeleton className="h-40 w-full rounded-lg" />
-          </div>
+          </Grid>
         )}
-      </div>
+      </Box>
     );
   }
 
@@ -716,7 +729,7 @@ export function PageGridSelector({
 
   const pagesContent =
     viewMode === "list" ? (
-      <div className="flex flex-col gap-3" role="group" aria-label={t("pagesAriaLabel")}>
+      <Stack gap="3" role="group" aria-label={t("pagesAriaLabel")}>
         {pages.map((page) => (
           <PageListItem
             key={page.id}
@@ -726,9 +739,9 @@ export function PageGridSelector({
             onSelect={onSelectPage}
           />
         ))}
-      </div>
+      </Stack>
     ) : (
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4" role="group" aria-label={t("pagesAriaLabel")}>
+      <Grid cols="1" gap="4" className="sm:grid-cols-2" role="group" aria-label={t("pagesAriaLabel")}>
         {pages.map((page) => (
           <PageButton
             key={page.id}
@@ -742,11 +755,11 @@ export function PageGridSelector({
             boardType={getEffectiveBoardColor(boardSettings)}
           />
         ))}
-      </div>
+      </Grid>
     );
 
   const collectionsGrid = (
-    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4" role="group" aria-label={t("collectionsAriaLabel")}>
+    <Grid cols="1" gap="4" className="sm:grid-cols-2" role="group" aria-label={t("collectionsAriaLabel")}>
       {collections.map((collection) => (
         <CollectionButton
           key={collection.id}
@@ -761,20 +774,24 @@ export function PageGridSelector({
           boardType={getEffectiveBoardColor(boardSettings)}
         />
       ))}
-    </div>
+    </Grid>
   );
 
   if (!showCollectionItems) {
     return (
-      <div>
-        {effectiveLabel && <p className="text-xs font-medium text-muted-foreground mb-3">{effectiveLabel}</p>}
+      <Box>
+        {effectiveLabel && (
+          <Text size="xs" weight="medium" tone="muted" className="mb-3">
+            {effectiveLabel}
+          </Text>
+        )}
         {pagesContent}
-      </div>
+      </Box>
     );
   }
 
   return (
-    <div>
+    <Box>
       <Tabs defaultValue={defaultTab}>
         <TabsList className="w-full">
           <TabsTrigger value="pages" className="flex-1 gap-1.5">
@@ -789,6 +806,6 @@ export function PageGridSelector({
         <TabsContent value="pages">{pagesContent}</TabsContent>
         <TabsContent value="collections">{collectionsGrid}</TabsContent>
       </Tabs>
-    </div>
+    </Box>
   );
 }

--- a/web/src/components/page-picker-dialog.tsx
+++ b/web/src/components/page-picker-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Badge, EmptyState, Tabs, TabsContent, TabsList, TabsTrigger } from "@fiestaboard/ui";
+import { Badge, EmptyState, Flex, Stack, Tabs, TabsContent, TabsList, TabsTrigger, Text } from "@fiestaboard/ui";
 import { Check, FileText, GalleryHorizontalEnd, LayoutTemplate } from "lucide-react";
 
 import { BoardSizeIndicator } from "@/components/board-size-indicator";
@@ -61,13 +61,15 @@ export function PagePickerDialog({
         selectedPageId === null ? "border-brand bg-muted/50" : ""
       }`}
     >
-      <span className="text-sm font-medium">{t("noneNoDefault")}</span>
+      <Text as="span" weight="medium">
+        {t("noneNoDefault")}
+      </Text>
       {selectedPageId === null && <Check className="h-4 w-4 text-brand" aria-hidden="true" />}
     </button>
   );
 
   const pagesList = (
-    <div className="space-y-2" role="listbox" aria-label={t("pagesAriaLabel")}>
+    <Stack gap="2" role="listbox" aria-label={t("pagesAriaLabel")}>
       {visiblePages.map((page) => (
         <button
           key={page.id}
@@ -78,8 +80,10 @@ export function PagePickerDialog({
             selectedPageId === page.id ? "border-brand bg-muted/50" : ""
           }`}
         >
-          <div className="flex items-center gap-2">
-            <span className="text-sm font-medium">{page.name}</span>
+          <Flex align="center" gap="2">
+            <Text as="span" weight="medium">
+              {page.name}
+            </Text>
             {page.type && (
               <Badge variant="secondary" className="text-[10px]">
                 {page.type}
@@ -92,15 +96,15 @@ export function PagePickerDialog({
                 notesTall={page.notes_tall}
               />
             )}
-          </div>
+          </Flex>
           {selectedPageId === page.id && <Check className="h-4 w-4 text-brand" aria-hidden="true" />}
         </button>
       ))}
-    </div>
+    </Stack>
   );
 
   const collectionsList = (
-    <div className="space-y-2" role="listbox" aria-label={t("collectionsAriaLabel")}>
+    <Stack gap="2" role="listbox" aria-label={t("collectionsAriaLabel")}>
       {collections.map((collection) => (
         <button
           key={collection.id}
@@ -111,34 +115,36 @@ export function PagePickerDialog({
             selectedPageId === collection.id ? "border-brand bg-muted/50" : ""
           }`}
         >
-          <div className="flex items-center gap-2">
+          <Flex align="center" gap="2">
             <GalleryHorizontalEnd className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-            <span className="text-sm font-medium">{collection.name}</span>
+            <Text as="span" weight="medium">
+              {collection.name}
+            </Text>
             <Badge variant="secondary" className="text-[10px]">
               {t("pageCount", { count: collection.page_ids.length })}
             </Badge>
-          </div>
+          </Flex>
           {selectedPageId === collection.id && <Check className="h-4 w-4 text-brand" aria-hidden="true" />}
         </button>
       ))}
-    </div>
+    </Stack>
   );
 
   if (!hasCollections) {
     return (
-      <div className="space-y-2">
+      <Stack gap="2">
         {noneOption}
         {visiblePages.length === 0 ? (
           <EmptyState icon={FileText} title={t("noPagesTitle")} description={t("noPagesDescription")} />
         ) : (
           pagesList
         )}
-      </div>
+      </Stack>
     );
   }
 
   return (
-    <div className="space-y-2">
+    <Stack gap="2">
       {noneOption}
       <Tabs defaultValue={defaultTab}>
         <TabsList className="w-full">
@@ -160,6 +166,6 @@ export function PagePickerDialog({
         </TabsContent>
         <TabsContent value="collections">{collectionsList}</TabsContent>
       </Tabs>
-    </div>
+    </Stack>
   );
 }

--- a/web/src/components/plain-text-editor.tsx
+++ b/web/src/components/plain-text-editor.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Textarea } from "@fiestaboard/ui";
+import { Box, Stack, Text, Textarea } from "@fiestaboard/ui";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { useTranslations } from "@/i18n/translations";
@@ -107,9 +107,9 @@ export function PlainTextEditor({
       : Array.from({ length: lineCount }, (_, i) => ({ height: 24, label: i + 1 }));
 
   return (
-    <div className={cn("relative", className)}>
+    <Box className={cn("relative", className)}>
       {/* Hidden mirror div — measures actual wrapped height of each logical line */}
-      <div
+      <Box
         ref={mirrorRef}
         aria-hidden="true"
         style={{
@@ -126,7 +126,7 @@ export function PlainTextEditor({
       />
 
       {/* Editor with line numbers */}
-      <div
+      <Box
         className={cn(
           "flex rounded-md border overflow-hidden bg-background",
           "focus-within:outline-none focus-within:ring-1 focus-within:ring-ring",
@@ -134,7 +134,7 @@ export function PlainTextEditor({
         )}
       >
         {/* Line numbers gutter */}
-        <div
+        <Box
           ref={lineNumbersRef}
           className="select-none overflow-hidden bg-muted/40 border-r shrink-0 text-right"
           style={{
@@ -151,7 +151,7 @@ export function PlainTextEditor({
           aria-hidden="true"
         >
           {gutterNumbers.map(({ height, label }) => (
-            <div
+            <Box
               key={label}
               style={{
                 height: `${height}px`,
@@ -162,9 +162,9 @@ export function PlainTextEditor({
               }}
             >
               {label}
-            </div>
+            </Box>
           ))}
-        </div>
+        </Box>
 
         {/* Textarea — border handled by wrapper above */}
         <Textarea
@@ -185,27 +185,32 @@ export function PlainTextEditor({
             lineHeight: "1.5rem",
           }}
         />
-      </div>
+      </Box>
 
       {/* Line counter */}
-      <div className={cn("mt-1 text-xs", isOverLimit ? "text-warning font-medium" : "text-muted-foreground")}>
+      <Text
+        size="xs"
+        className={cn("mt-1", isOverLimit ? "text-warning font-medium" : "text-muted-foreground")}
+      >
         {t("lineCount", { current: lineCount, total: boardLines })}
         {isOverLimit && ` ${t("exceedsLimit", { limit: boardLines })}`}
-      </div>
+      </Text>
 
       {/* Helper text */}
-      <div className="mt-2 text-xs text-muted-foreground space-y-1">
-        <p>• {t("charsPerLine", { width: boardWidth })}</p>
-        <p>
+      <Stack gap="1" className="mt-2">
+        <Text size="xs" tone="muted">
+          • {t("charsPerLine", { width: boardWidth })}
+        </Text>
+        <Text size="xs" tone="muted">
           • {t("templateSyntaxIntro")} {"{{variable}}"}, {"{{red}}"}, {"{{fill_space}}"}
-        </p>
-        <p>
+        </Text>
+        <Text size="xs" tone="muted">
           • {t("alignmentPrefixesIntro")} {"{left}"}, {"{center}"}, {"{right}"}
-        </p>
-        <p>
+        </Text>
+        <Text size="xs" tone="muted">
           • {t("wrapPrefixIntro")} {"{wrap}"}
-        </p>
-      </div>
-    </div>
+        </Text>
+      </Stack>
+    </Box>
   );
 }

--- a/web/src/components/plain-text-editor.tsx
+++ b/web/src/components/plain-text-editor.tsx
@@ -188,10 +188,7 @@ export function PlainTextEditor({
       </Box>
 
       {/* Line counter */}
-      <Text
-        size="xs"
-        className={cn("mt-1", isOverLimit ? "text-warning font-medium" : "text-muted-foreground")}
-      >
+      <Text size="xs" className={cn("mt-1", isOverLimit ? "text-warning font-medium" : "text-muted-foreground")}>
         {t("lineCount", { current: lineCount, total: boardLines })}
         {isOverLimit && ` ${t("exceedsLimit", { limit: boardLines })}`}
       </Text>

--- a/web/src/components/scaled-board-display.tsx
+++ b/web/src/components/scaled-board-display.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Box, Flex } from "@fiestaboard/ui";
 import { useLayoutEffect, useRef, useState } from "react";
 
 import { BoardDisplay } from "@/components/board-display";
@@ -158,8 +159,8 @@ export function ScaledBoardDisplay(props: BoardProps) {
   }, [props.message, props.size, props.deviceType, props.notesWide, props.notesTall, mode]);
 
   const toggle = showToggle ? (
-    <div className="mb-1 flex w-full justify-center" role="group" aria-label={t("previewSizeLabel")}>
-      <div className="flex gap-1">
+    <Flex justify="center" className="mb-1 w-full" role="group" aria-label={t("previewSizeLabel")}>
+      <Flex gap="1">
         <button
           type="button"
           onClick={() => setMode("fit")}
@@ -186,25 +187,25 @@ export function ScaledBoardDisplay(props: BoardProps) {
         >
           {t("actualMode")}
         </button>
-      </div>
-    </div>
+      </Flex>
+    </Flex>
   ) : null;
 
   if (mode === "actual") {
     // Actual size: render at natural scale, scroll horizontally for wide
     // boards, and let tall boards flow without any vertical clipping.
     return (
-      <div className="w-full min-w-0">
+      <Box className="w-full min-w-0">
         {toggle}
-        <div data-testid="actual-size-scroll" className="w-full overflow-x-auto" style={{ overflowY: "visible" }}>
+        <Box data-testid="actual-size-scroll" className="w-full overflow-x-auto" style={{ overflowY: "visible" }}>
           <BoardDisplay {...props} />
-        </div>
-      </div>
+        </Box>
+      </Box>
     );
   }
 
   return (
-    <div className="w-full min-w-0">
+    <Box className="w-full min-w-0">
       {toggle}
       {/*
         Outer: full-width, centers the scaled board horizontally.
@@ -218,14 +219,14 @@ export function ScaledBoardDisplay(props: BoardProps) {
         Inner: the BoardDisplay itself, transformed from its top-left so
         the visible content lines up with the middle box from x=0.
       */}
-      <div ref={containerRef} className="flex w-full min-w-0 justify-center overflow-hidden">
-        <div
+      <Flex ref={containerRef} justify="center" className="w-full min-w-0 overflow-hidden">
+        <Box
           style={{
             width: scaledWidth ?? undefined,
             height: scaledHeight ?? undefined,
           }}
         >
-          <div
+          <Box
             ref={boardRef}
             style={{
               transform: `scale(${scale})`,
@@ -234,9 +235,9 @@ export function ScaledBoardDisplay(props: BoardProps) {
             }}
           >
             <BoardDisplay {...props} />
-          </div>
-        </div>
-      </div>
-    </div>
+          </Box>
+        </Box>
+      </Flex>
+    </Box>
   );
 }

--- a/web/src/components/schedule-entry-form.tsx
+++ b/web/src/components/schedule-entry-form.tsx
@@ -3,15 +3,21 @@
 import {
   Alert,
   AlertDescription,
+  Box,
   Button,
+  Flex,
   Input,
   Label,
+  List,
+  ListItem,
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
+  Stack,
   Switch,
+  Text,
 } from "@fiestaboard/ui";
 import { AlertCircle, AlertTriangle, GalleryHorizontalEnd, Loader2, Sunrise, Sunset, Trash2 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
@@ -342,7 +348,7 @@ export function ScheduleEntryForm({
   };
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-6">
+    <Box as="form" onSubmit={handleSubmit} className="space-y-6">
       {error && (
         <Alert variant="destructive">
           <AlertCircle className="h-4 w-4" />
@@ -351,7 +357,7 @@ export function ScheduleEntryForm({
       )}
 
       {/* Page / Collection Selection */}
-      <div className="space-y-2">
+      <Stack gap="2">
         <Label htmlFor="page">{t("scheduleEntryForm.pageOrCollection")}</Label>
         <Select value={pageId} onValueChange={setPageId} modal={false}>
           <SelectTrigger id="page">
@@ -360,25 +366,25 @@ export function ScheduleEntryForm({
           <SelectContent>
             {collections.length > 0 && (
               <>
-                <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground">
+                <Box className="px-2 py-1.5 text-xs font-medium text-muted-foreground">
                   {t("scheduleEntryForm.collectionsGroup")}
-                </div>
+                </Box>
                 {collections.map((collection) => (
                   <SelectItem key={collection.id} value={collection.id}>
-                    <span className="flex items-center gap-2">
+                    <Flex align="center" gap="2">
                       <GalleryHorizontalEnd className="h-3.5 w-3.5" />
                       {collection.name}
-                    </span>
+                    </Flex>
                   </SelectItem>
                 ))}
-                <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground">
+                <Box className="px-2 py-1.5 text-xs font-medium text-muted-foreground">
                   {t("scheduleEntryForm.pagesGroup")}
-                </div>
+                </Box>
               </>
             )}
             {visiblePages.map((page) => (
               <SelectItem key={page.id} value={page.id}>
-                <span className="flex items-center gap-2">
+                <Flex align="center" gap="2">
                   {page.name}
                   {page.device_type && (
                     <BoardSizeIndicator
@@ -387,7 +393,7 @@ export function ScheduleEntryForm({
                       notesTall={page.notes_tall}
                     />
                   )}
-                </span>
+                </Flex>
               </SelectItem>
             ))}
           </SelectContent>
@@ -398,14 +404,14 @@ export function ScheduleEntryForm({
             <AlertDescription className="text-sm">{sizeWarning}</AlertDescription>
           </Alert>
         )}
-      </div>
+      </Stack>
 
       {/* Time Selection */}
-      <div className="space-y-4">
+      <Stack gap="4">
         {/* Start Time */}
-        <div className="space-y-2">
+        <Stack gap="2">
           <Label htmlFor="start-time">{t("scheduleEntryForm.startTime")}</Label>
-          <div className="flex gap-2">
+          <Flex gap="2">
             <Select value={startType} onValueChange={(v) => setStartType(v as TimeType)}>
               <SelectTrigger className="w-[140px]" aria-label={t("scheduleEntryForm.startTimeType")}>
                 <SelectValue />
@@ -413,11 +419,11 @@ export function ScheduleEntryForm({
               <SelectContent>
                 {TIME_TYPE_OPTIONS.map((type) => (
                   <SelectItem key={`start-type-${type}`} value={type}>
-                    <span className="flex items-center gap-1.5">
+                    <Flex align="center" gap="1.5">
                       {type === "sunrise" && <Sunrise className="h-3.5 w-3.5" />}
                       {type === "sunset" && <Sunset className="h-3.5 w-3.5" />}
                       {getTimeTypeLabel(type)}
-                    </span>
+                    </Flex>
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -436,7 +442,7 @@ export function ScheduleEntryForm({
                 </SelectContent>
               </Select>
             ) : (
-              <div className="flex items-center gap-2 flex-1">
+              <Flex align="center" gap="2" className="flex-1">
                 <Input
                   type="number"
                   value={startSunOffset}
@@ -447,25 +453,25 @@ export function ScheduleEntryForm({
                   className="w-20"
                   aria-label={t("scheduleEntryForm.sunOffset")}
                 />
-                <span className="text-xs text-muted-foreground whitespace-nowrap">
+                <Text as="span" size="xs" tone="muted" className="whitespace-nowrap">
                   {t("scheduleEntryForm.sunOffsetHint")}
-                </span>
-              </div>
+                </Text>
+              </Flex>
             )}
-          </div>
+          </Flex>
           {startType !== "fixed" && schedule?.resolved_start_time && (
-            <p className="text-xs text-muted-foreground flex items-center gap-1">
+            <Text tone="muted" size="xs" className="flex items-center gap-1">
               {startType === "sunrise" ? <Sunrise className="h-3 w-3" /> : <Sunset className="h-3 w-3" />}
               {t("scheduleEntryForm.resolvedTime", { time: schedule.resolved_start_time })}
-            </p>
+            </Text>
           )}
-        </div>
+        </Stack>
 
         {/* End Time */}
         {hasEndTime && (
-          <div className="space-y-2">
+          <Stack gap="2">
             <Label htmlFor="end-time">{t("scheduleEntryForm.endTime")}</Label>
-            <div className="flex gap-2">
+            <Flex gap="2">
               <Select value={endType} onValueChange={(v) => setEndType(v as TimeType)}>
                 <SelectTrigger className="w-[140px]" aria-label={t("scheduleEntryForm.endTimeType")}>
                   <SelectValue />
@@ -473,11 +479,11 @@ export function ScheduleEntryForm({
                 <SelectContent>
                   {TIME_TYPE_OPTIONS.map((type) => (
                     <SelectItem key={`end-type-${type}`} value={type}>
-                      <span className="flex items-center gap-1.5">
+                      <Flex align="center" gap="1.5">
                         {type === "sunrise" && <Sunrise className="h-3.5 w-3.5" />}
                         {type === "sunset" && <Sunset className="h-3.5 w-3.5" />}
                         {getTimeTypeLabel(type)}
-                      </span>
+                      </Flex>
                     </SelectItem>
                   ))}
                 </SelectContent>
@@ -496,7 +502,7 @@ export function ScheduleEntryForm({
                   </SelectContent>
                 </Select>
               ) : (
-                <div className="flex items-center gap-2 flex-1">
+                <Flex align="center" gap="2" className="flex-1">
                   <Input
                     type="number"
                     value={endSunOffset}
@@ -507,35 +513,37 @@ export function ScheduleEntryForm({
                     className="w-20"
                     aria-label={t("scheduleEntryForm.sunOffset")}
                   />
-                  <span className="text-xs text-muted-foreground whitespace-nowrap">
+                  <Text as="span" size="xs" tone="muted" className="whitespace-nowrap">
                     {t("scheduleEntryForm.sunOffsetHint")}
-                  </span>
-                </div>
+                  </Text>
+                </Flex>
               )}
-            </div>
+            </Flex>
             {endType !== "fixed" && schedule?.resolved_end_time && (
-              <p className="text-xs text-muted-foreground flex items-center gap-1">
+              <Text tone="muted" size="xs" className="flex items-center gap-1">
                 {endType === "sunrise" ? <Sunrise className="h-3 w-3" /> : <Sunset className="h-3 w-3" />}
                 {t("scheduleEntryForm.resolvedTime", { time: schedule.resolved_end_time })}
-              </p>
+              </Text>
             )}
-          </div>
+          </Stack>
         )}
 
         {/* End time toggle */}
-        <div className="flex items-center gap-2">
+        <Flex align="center" gap="2">
           <Switch id="has-end-time" checked={hasEndTime} onCheckedChange={setHasEndTime} />
           <Label htmlFor="has-end-time" className="text-sm text-muted-foreground">
             {t("scheduleEntryForm.setEndTime")}
           </Label>
           {!hasEndTime && (
-            <span className="text-xs text-muted-foreground">({t("scheduleEntryForm.openEndedHint")})</span>
+            <Text as="span" size="xs" tone="muted">
+              ({t("scheduleEntryForm.openEndedHint")})
+            </Text>
           )}
-        </div>
-      </div>
+        </Flex>
+      </Stack>
 
       {/* Recurrence Selection */}
-      <div className="space-y-2">
+      <Stack gap="2">
         <Label htmlFor="recurrence">{t("scheduleEntryForm.recurrenceLabel")}</Label>
         <Select value={recurrenceType} onValueChange={(v) => setRecurrenceType(v as RecurrenceType)}>
           <SelectTrigger id="recurrence">
@@ -547,24 +555,24 @@ export function ScheduleEntryForm({
             <SelectItem value="one_off_date">{t("scheduleEntryForm.recurrenceOneOff")}</SelectItem>
           </SelectContent>
         </Select>
-        <p className="text-xs text-muted-foreground">
+        <Text size="xs" tone="muted">
           {recurrenceType === "weekly"
             ? t("scheduleEntryForm.recurrenceWeeklyDescription")
             : recurrenceType === "annual_date"
               ? t("scheduleEntryForm.recurrenceAnnualDescription")
               : t("scheduleEntryForm.recurrenceOneOffDescription")}
-        </p>
-      </div>
+        </Text>
+      </Stack>
 
       {recurrenceType === "weekly" && (
         <DaySelector value={dayPattern} customDays={customDays} onChange={handleDayChange} />
       )}
 
       {recurrenceType === "annual_date" && (
-        <div className="space-y-3 rounded-lg border p-4">
-          <div className="space-y-2">
+        <Stack gap="3" className="rounded-lg border p-4">
+          <Stack gap="2">
             <Label>{t("scheduleEntryForm.annualDateLabel")}</Label>
-            <div className="flex gap-2">
+            <Flex gap="2">
               <Select value={annualMonth} onValueChange={setAnnualMonth}>
                 <SelectTrigger className="flex-1" aria-label="Month">
                   <SelectValue placeholder="MM" />
@@ -591,18 +599,18 @@ export function ScheduleEntryForm({
                   ))}
                 </SelectContent>
               </Select>
-            </div>
-          </div>
-          <div className="flex items-center gap-2">
+            </Flex>
+          </Stack>
+          <Flex align="center" gap="2">
             <Switch id="annual-has-range" checked={annualHasRange} onCheckedChange={setAnnualHasRange} />
             <Label htmlFor="annual-has-range" className="text-sm text-muted-foreground">
               {t("scheduleEntryForm.useDateRange")}
             </Label>
-          </div>
+          </Flex>
           {annualHasRange && (
-            <div className="space-y-2">
+            <Stack gap="2">
               <Label>{t("scheduleEntryForm.annualEndDateLabel")}</Label>
-              <div className="flex gap-2">
+              <Flex gap="2">
                 <Select value={annualEndMonth} onValueChange={setAnnualEndMonth}>
                   <SelectTrigger className="flex-1" aria-label="End month">
                     <SelectValue placeholder="MM" />
@@ -629,16 +637,18 @@ export function ScheduleEntryForm({
                     ))}
                   </SelectContent>
                 </Select>
-              </div>
-            </div>
+              </Flex>
+            </Stack>
           )}
-          <p className="text-xs text-muted-foreground">{t("scheduleEntryForm.dateOverrideHint")}</p>
-        </div>
+          <Text size="xs" tone="muted">
+            {t("scheduleEntryForm.dateOverrideHint")}
+          </Text>
+        </Stack>
       )}
 
       {recurrenceType === "one_off_date" && (
-        <div className="space-y-3 rounded-lg border p-4">
-          <div className="space-y-2">
+        <Stack gap="3" className="rounded-lg border p-4">
+          <Stack gap="2">
             <Label htmlFor="one-off-date">{t("scheduleEntryForm.oneOffDateLabel")}</Label>
             <Input
               id="one-off-date"
@@ -647,15 +657,15 @@ export function ScheduleEntryForm({
               min={todayISO()}
               onChange={(e) => setOneOffDate(e.target.value)}
             />
-          </div>
-          <div className="flex items-center gap-2">
+          </Stack>
+          <Flex align="center" gap="2">
             <Switch id="one-off-has-range" checked={oneOffHasRange} onCheckedChange={setOneOffHasRange} />
             <Label htmlFor="one-off-has-range" className="text-sm text-muted-foreground">
               {t("scheduleEntryForm.useDateRange")}
             </Label>
-          </div>
+          </Flex>
           {oneOffHasRange && (
-            <div className="space-y-2">
+            <Stack gap="2">
               <Label htmlFor="one-off-end-date">{t("scheduleEntryForm.oneOffEndDateLabel")}</Label>
               <Input
                 id="one-off-end-date"
@@ -664,48 +674,50 @@ export function ScheduleEntryForm({
                 min={oneOffDate || undefined}
                 onChange={(e) => setOneOffEndDate(e.target.value)}
               />
-            </div>
+            </Stack>
           )}
-          <p className="text-xs text-muted-foreground">{t("scheduleEntryForm.dateOverrideHint")}</p>
-        </div>
+          <Text size="xs" tone="muted">
+            {t("scheduleEntryForm.dateOverrideHint")}
+          </Text>
+        </Stack>
       )}
 
       {/* Enabled Toggle */}
-      <div className="flex items-center justify-between rounded-lg border p-4">
-        <div className="space-y-0.5">
+      <Flex align="center" justify="between" className="rounded-lg border p-4">
+        <Stack gap="0.5">
           <Label htmlFor="enabled" className="text-base">
             Enabled
           </Label>
-          <div className="text-sm text-muted-foreground">Schedule will be active when enabled</div>
-        </div>
+          <Text tone="muted">Schedule will be active when enabled</Text>
+        </Stack>
         <Switch id="enabled" checked={enabled} onCheckedChange={setEnabled} />
-      </div>
+      </Flex>
 
       {/* Validation Errors */}
       {validationErrors.length > 0 && (
         <Alert>
           <AlertCircle className="h-4 w-4" />
           <AlertDescription>
-            <ul className="list-disc list-inside space-y-1">
+            <List marker="disc" gap="1" className="list-inside">
               {validationErrors.map((err, i) => (
-                <li key={i}>{err}</li>
+                <ListItem key={i}>{err}</ListItem>
               ))}
-            </ul>
+            </List>
           </AlertDescription>
         </Alert>
       )}
 
       {/* Actions */}
-      <div className="flex justify-between gap-2">
-        <div>
+      <Flex justify="between" gap="2">
+        <Box>
           {isEdit && onDelete && (
             <Button type="button" variant="destructive" onClick={onDelete} disabled={isSubmitting}>
               <Trash2 className="mr-2 h-4 w-4" />
               {tc("delete")}
             </Button>
           )}
-        </div>
-        <div className="flex gap-2">
+        </Box>
+        <Flex gap="2">
           <Button type="button" variant="outline" onClick={onCancel} disabled={isSubmitting}>
             {tc("cancel")}
           </Button>
@@ -713,8 +725,8 @@ export function ScheduleEntryForm({
             {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
             {isEdit ? t("scheduleEntryForm.updateSchedule") : t("scheduleEntryForm.createSchedule")}
           </Button>
-        </div>
-      </div>
-    </form>
+        </Flex>
+      </Flex>
+    </Box>
   );
 }

--- a/web/src/components/schedule-entry-form.tsx
+++ b/web/src/components/schedule-entry-form.tsx
@@ -698,7 +698,7 @@ export function ScheduleEntryForm({
         <Alert>
           <AlertCircle className="h-4 w-4" />
           <AlertDescription>
-            <List marker="disc" gap="1" className="list-inside">
+            <List marker="disc" gap="1" className="list-inside pl-0">
               {validationErrors.map((err, i) => (
                 <ListItem key={i}>{err}</ListItem>
               ))}

--- a/web/src/components/service-controls.tsx
+++ b/web/src/components/service-controls.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Badge, Card, CardContent, CardHeader, CardTitle, Skeleton } from "@fiestaboard/ui";
+import { Badge, Card, CardContent, CardHeader, CardTitle, Flex, Skeleton, Text } from "@fiestaboard/ui";
 
 import { useStatus } from "@/hooks/use-board";
 import { useTranslations } from "@/i18n/translations";
@@ -28,7 +28,7 @@ export function ServiceControls() {
   return (
     <Card>
       <CardHeader className="px-4 sm:px-6">
-        <div className="flex items-center justify-between">
+        <Flex align="center" justify="between">
           <CardTitle className="text-base sm:text-lg">{t("title")}</CardTitle>
           <Badge
             variant={isRunning ? "default" : "secondary"}
@@ -36,10 +36,12 @@ export function ServiceControls() {
           >
             {isRunning ? tc("running") : tc("stopped")}
           </Badge>
-        </div>
+        </Flex>
       </CardHeader>
       <CardContent className="space-y-4 px-4 sm:px-6">
-        <p className="text-[10px] text-muted-foreground">{t("contentAutoSent")}</p>
+        <Text tone="muted" size="xs">
+          {t("contentAutoSent")}
+        </Text>
       </CardContent>
     </Card>
   );

--- a/web/src/components/service-status.tsx
+++ b/web/src/components/service-status.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Skeleton, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@fiestaboard/ui";
+import { Skeleton, Text, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@fiestaboard/ui";
 
 import { useStatus } from "@/hooks/use-board";
 import { useTranslations } from "@/i18n/translations";
@@ -37,11 +37,15 @@ export function ServiceStatus() {
             className="relative h-6 w-6 flex items-center justify-center cursor-default rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             aria-label={ariaLabel}
           >
-            <span className={`h-3 w-3 rounded-full ${statusClass} transition-all`} style={glowStyle} />
+            <Text
+              as="span"
+              className={`h-3 w-3 rounded-full ${statusClass} transition-all`}
+              style={glowStyle}
+            />
           </button>
         </TooltipTrigger>
         <TooltipContent>
-          <p>{statusText}</p>
+          <Text>{statusText}</Text>
         </TooltipContent>
       </Tooltip>
     </TooltipProvider>

--- a/web/src/components/service-status.tsx
+++ b/web/src/components/service-status.tsx
@@ -37,11 +37,7 @@ export function ServiceStatus() {
             className="relative h-6 w-6 flex items-center justify-center cursor-default rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             aria-label={ariaLabel}
           >
-            <Text
-              as="span"
-              className={`h-3 w-3 rounded-full ${statusClass} transition-all`}
-              style={glowStyle}
-            />
+            <Text as="span" className={`h-3 w-3 rounded-full ${statusClass} transition-all`} style={glowStyle} />
           </button>
         </TooltipTrigger>
         <TooltipContent>

--- a/web/src/components/sidebar-account.tsx
+++ b/web/src/components/sidebar-account.tsx
@@ -67,7 +67,7 @@ export function SidebarAccount({ collapsed = false, variant = "desktop" }: Sideb
         weight="medium"
         size={variant === "mobile" ? "base" : "sm"}
         className={cn(
-          "whitespace-nowrap overflow-hidden transition-opacity duration-100",
+          "text-sidebar-foreground whitespace-nowrap overflow-hidden transition-opacity duration-100",
           collapsed ? "opacity-0 max-w-0" : "opacity-100 max-w-48 delay-150",
         )}
       >

--- a/web/src/components/sidebar-account.tsx
+++ b/web/src/components/sidebar-account.tsx
@@ -9,7 +9,7 @@
  * Account — this is just the always-visible escape hatch.
  */
 
-import { Tooltip, TooltipContent, TooltipTrigger } from "@fiestaboard/ui";
+import { Text, Tooltip, TooltipContent, TooltipTrigger } from "@fiestaboard/ui";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { LogOut } from "lucide-react";
 
@@ -62,14 +62,17 @@ export function SidebarAccount({ collapsed = false, variant = "desktop" }: Sideb
   const button = (
     <button type="button" onClick={handleSignOut} aria-label="Sign out" className={className}>
       <LogOut className="h-5 w-5 flex-shrink-0" />
-      <span
+      <Text
+        as="span"
+        weight="medium"
+        size={variant === "mobile" ? "base" : "sm"}
         className={cn(
           "whitespace-nowrap overflow-hidden transition-opacity duration-100",
           collapsed ? "opacity-0 max-w-0" : "opacity-100 max-w-48 delay-150",
         )}
       >
         Sign out
-      </span>
+      </Text>
     </button>
   );
 

--- a/web/src/components/silence-imminent-banner.tsx
+++ b/web/src/components/silence-imminent-banner.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Alert, AlertDescription, AlertTitle, Button } from "@fiestaboard/ui";
+import { Alert, AlertDescription, AlertTitle, Box, Button, Flex } from "@fiestaboard/ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Moon } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
@@ -106,21 +106,21 @@ export function SilenceImminentBanner() {
   };
 
   return (
-    <div className="mb-6">
+    <Box className="mb-6">
       <Alert
         className="border-info/50 bg-info/10 flex flex-col sm:flex-row sm:items-center sm:gap-4 [&>svg]:static [&>svg]:shrink-0 [&>svg+div]:translate-y-0 [&>svg~*]:pl-3"
         data-testid="silence-imminent-banner"
       >
         <Moon className="h-4 w-4 text-info" />
-        <div className="flex-1 min-w-0">
+        <Box className="flex-1 min-w-0">
           <AlertTitle>{t("silenceImminentTitle", { minutes })}</AlertTitle>
           <AlertDescription>
             {silencePage
               ? t("silenceImminentDescription", { pageName: silencePage.name })
               : t("silenceImminentDescriptionUnnamed")}
           </AlertDescription>
-        </div>
-        <div className="flex items-center gap-2 self-center shrink-0">
+        </Box>
+        <Flex align="center" gap="2" className="self-center shrink-0">
           <Button
             variant="ghost"
             size="sm"
@@ -138,8 +138,8 @@ export function SilenceImminentBanner() {
           >
             {t("silenceImminentSwitchNow")}
           </Button>
-        </div>
+        </Flex>
       </Alert>
-    </div>
+    </Box>
   );
 }

--- a/web/src/components/silence-mode-status.tsx
+++ b/web/src/components/silence-mode-status.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Badge } from "@fiestaboard/ui";
+import { Badge, Box, Text } from "@fiestaboard/ui";
 import { useQuery } from "@tanstack/react-query";
 import { Clock, Loader2, Moon, Sun } from "lucide-react";
 
@@ -31,23 +31,23 @@ export function SilenceModeStatus({ className, showDetails = true }: SilenceMode
 
   if (isLoading || !silenceStatus || !generalConfig) {
     return (
-      <div className={className}>
+      <Box className={className}>
         <Badge variant="secondary" className="gap-1.5">
           <Loader2 className="h-3 w-3 animate-spin" />
           {t("loading")}
         </Badge>
-      </div>
+      </Box>
     );
   }
 
   if (!silenceStatus.enabled) {
     return (
-      <div className={className}>
+      <Box className={className}>
         <Badge variant="outline" className="gap-1.5">
           <Moon className="h-3 w-3" />
           {t("disabled")}
         </Badge>
-      </div>
+      </Box>
     );
   }
 
@@ -61,34 +61,34 @@ export function SilenceModeStatus({ className, showDetails = true }: SilenceMode
 
   if (silenceStatus.active) {
     return (
-      <div className={className}>
+      <Box className={className}>
         <Badge variant="destructive" className="gap-1.5">
           <Moon className="h-3 w-3" />
-          <span>{t("active")}</span>
+          {t("active")}
         </Badge>
         {showDetails && (
-          <p className="text-xs text-muted-foreground mt-1">
+          <Text tone="muted" size="xs" className="mt-1">
             <Clock className="h-3 w-3 inline mr-1" />
             {t("until", { time: nextChangeLocal, timezone: timezoneAbbr })}
-          </p>
+          </Text>
         )}
-      </div>
+      </Box>
     );
   }
 
   return (
-    <div className={className}>
+    <Box className={className}>
       <Badge variant="secondary" className="gap-1.5">
         <Sun className="h-3 w-3" />
-        <span>{t("inactive")}</span>
+        {t("inactive")}
       </Badge>
       {showDetails && (
-        <p className="text-xs text-muted-foreground mt-1">
+        <Text tone="muted" size="xs" className="mt-1">
           <Clock className="h-3 w-3 inline mr-1" />
           {t("startsAt", { time: nextChangeLocal, timezone: timezoneAbbr })}
-        </p>
+        </Text>
       )}
-    </div>
+    </Box>
   );
 }
 

--- a/web/src/components/smart-link.tsx
+++ b/web/src/components/smart-link.tsx
@@ -1,3 +1,4 @@
+import { TextLink } from "@fiestaboard/ui";
 import type { AnchorHTMLAttributes, ReactNode } from "react";
 import { Link as RRLink } from "react-router";
 
@@ -33,9 +34,9 @@ export default function SmartLink({
 }: SmartLinkProps) {
   if (EXTERNAL.test(href)) {
     return (
-      <a href={href} {...rest}>
+      <TextLink href={href} {...rest}>
         {children}
-      </a>
+      </TextLink>
     );
   }
   return (

--- a/web/src/components/static-board-display.tsx
+++ b/web/src/components/static-board-display.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Box, Text } from "@fiestaboard/ui";
 import { memo, useMemo } from "react";
 
 import { useTranslations } from "@/i18n/translations";
@@ -233,14 +234,14 @@ export const StaticBoardDisplay = memo(function StaticBoardDisplay({
     size === "sm" ? "rounded-lg border-[3px]" : "rounded-lg sm:rounded-xl border-[3px] sm:border-[4px] lg:border-[5px]";
 
   return (
-    <div className="w-full flex justify-center">
-      <div
+    <Box className="w-full flex justify-center">
+      <Box
         role="img"
         aria-label={message ? t("preview") : t("empty")}
         className={`${borderClasses} ${className} max-w-full`}
         style={{ backgroundColor: bezelBg, borderColor, boxShadow, width: "fit-content" }}
       >
-        <div
+        <Box
           className={`${paddingClasses[size]} relative`}
           aria-hidden="true"
           style={{
@@ -249,11 +250,11 @@ export const StaticBoardDisplay = memo(function StaticBoardDisplay({
               : "linear-gradient(135deg, var(--color-board-surface-dark) 0%, var(--color-board-black) 100%)",
           }}
         >
-          <div className={`flex flex-col ${gapClasses[size]}`}>
+          <Box className={`flex flex-col ${gapClasses[size]}`}>
             {grid.map((row, rowIdx) => {
               const isRowSeam = showSeams && rowIdx > 0 && rowIdx % NOTE_ROWS === 0;
               return (
-                <div
+                <Box
                   key={rowIdx}
                   data-note-row=""
                   {...(isRowSeam ? { "data-note-row-seam": "true" } : {})}
@@ -271,7 +272,7 @@ export const StaticBoardDisplay = memo(function StaticBoardDisplay({
                       // (inner shadow, separator line) are invisible at 14×18px.
                       if (size === "sm") {
                         return (
-                          <div
+                          <Box
                             key={colIdx}
                             data-note-tile=""
                             {...seamProps}
@@ -286,7 +287,7 @@ export const StaticBoardDisplay = memo(function StaticBoardDisplay({
                         );
                       }
                       return (
-                        <div
+                        <Box
                           key={colIdx}
                           data-note-tile=""
                           {...seamProps}
@@ -298,7 +299,7 @@ export const StaticBoardDisplay = memo(function StaticBoardDisplay({
                             ...tileSeamStyle,
                           }}
                         >
-                          <div
+                          <Box
                             className="absolute rounded-[3px] overflow-hidden"
                             style={{
                               top: "3px",
@@ -310,9 +311,9 @@ export const StaticBoardDisplay = memo(function StaticBoardDisplay({
                                 "0 2px 4px rgba(0,0,0,0.3), inset 0 1px 1px rgba(255,255,255,0.15), inset 0 -1px 1px rgba(0,0,0,0.25)",
                             }}
                           >
-                            <div className="absolute top-1/2 left-0 right-0 h-[1px] bg-black/10" />
-                          </div>
-                        </div>
+                            <Box className="absolute top-1/2 left-0 right-0 h-[1px] bg-black/10" />
+                          </Box>
+                        </Box>
                       );
                     }
 
@@ -325,7 +326,7 @@ export const StaticBoardDisplay = memo(function StaticBoardDisplay({
                     // per flagship board).
                     if (size === "sm") {
                       return (
-                        <div
+                        <Box
                           key={colIdx}
                           data-note-tile=""
                           {...seamProps}
@@ -338,19 +339,20 @@ export const StaticBoardDisplay = memo(function StaticBoardDisplay({
                           }}
                         >
                           {char !== " " && (
-                            <span
+                            <Text
+                              as="span"
                               className={`${textSizeClasses[size]} font-mono font-semibold select-none leading-none`}
                               style={{ color: isHeart ? "#eb4034" : textColor }}
                             >
                               {char}
-                            </span>
+                            </Text>
                           )}
-                        </div>
+                        </Box>
                       );
                     }
 
                     return (
-                      <div
+                      <Box
                         key={colIdx}
                         data-note-tile=""
                         {...seamProps}
@@ -362,21 +364,22 @@ export const StaticBoardDisplay = memo(function StaticBoardDisplay({
                           ...tileSeamStyle,
                         }}
                       >
-                        <div className="absolute inset-0 flex items-center justify-center" style={{ zIndex: 2 }}>
+                        <Box className="absolute inset-0 flex items-center justify-center" style={{ zIndex: 2 }}>
                           {char !== " " && (
-                            <span
+                            <Text
+                              as="span"
                               className={`${textSizeClasses[size]} font-mono font-semibold select-none leading-none`}
                               style={{ color: isHeart ? "#eb4034" : textColor }}
                             >
                               {char}
-                            </span>
+                            </Text>
                           )}
-                        </div>
-                        <div
+                        </Box>
+                        <Box
                           className={`absolute top-1/2 left-0 right-0 h-[1px] ${isWhiteBoard ? "bg-black/10" : "bg-black/30"}`}
                           style={{ zIndex: 3 }}
                         />
-                        <div
+                        <Box
                           className="absolute inset-0 pointer-events-none"
                           style={{
                             zIndex: 1,
@@ -385,15 +388,15 @@ export const StaticBoardDisplay = memo(function StaticBoardDisplay({
                               : "linear-gradient(180deg, rgba(255,255,255,0.05) 0%, transparent 50%, rgba(0,0,0,0.2) 100%)",
                           }}
                         />
-                      </div>
+                      </Box>
                     );
                   })}
-                </div>
+                </Box>
               );
             })}
-          </div>
-        </div>
-      </div>
-    </div>
+          </Box>
+        </Box>
+      </Box>
+    </Box>
   );
 });

--- a/web/src/components/update-context.tsx
+++ b/web/src/components/update-context.tsx
@@ -280,7 +280,7 @@ function UpdateOverlay({ currentVersion, onDone }: { currentVersion?: string; on
               </Fragment>
             );
           })}
-        </div>
+        </Flex>
 
         <Text size="xs" className="text-white/40">
           {t("dontCloseTab")}

--- a/web/src/components/update-context.tsx
+++ b/web/src/components/update-context.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Button } from "@fiestaboard/ui";
+import { Box, Button, Code, Flex, Heading, Stack, Text } from "@fiestaboard/ui";
 import { RefreshCw } from "lucide-react";
 import { createContext, Fragment, useCallback, useContext, useEffect, useRef, useState } from "react";
 
@@ -187,14 +187,16 @@ function UpdateOverlay({ currentVersion, onDone }: { currentVersion?: string; on
 
   if (phase === "error") {
     return (
-      <div className="fixed inset-0 z-[200] bg-black text-white flex items-center justify-center">
-        <div className="text-center space-y-4 max-w-sm mx-auto px-4">
-          <h2 className="text-xl font-semibold">{t("takingLonger")}</h2>
-          <p className="text-sm text-white/70">
+      <Flex align="center" justify="center" className="fixed inset-0 z-[200] bg-black text-white">
+        <Stack gap="4" className="text-center max-w-sm mx-auto px-4">
+          <Heading level={2} className="text-xl">
+            {t("takingLonger")}
+          </Heading>
+          <Text className="text-white/70">
             {t.rich("takingLongerDescription", {
-              code: (chunks) => <code className="text-xs bg-white/10 px-1 rounded">{chunks}</code>,
+              code: (chunks) => <Code className="text-xs bg-white/10 px-1 rounded">{chunks}</Code>,
             })}
-          </p>
+          </Text>
           <Button
             variant="outline"
             className="border-white/30 text-white hover:bg-white/10 hover:text-white"
@@ -206,8 +208,8 @@ function UpdateOverlay({ currentVersion, onDone }: { currentVersion?: string; on
             <RefreshCw className="h-4 w-4 mr-2" />
             {t("dismissAndRefresh")}
           </Button>
-        </div>
-      </div>
+        </Stack>
+      </Flex>
     );
   }
 
@@ -226,43 +228,49 @@ function UpdateOverlay({ currentVersion, onDone }: { currentVersion?: string; on
         : t("phaseRestarting");
 
   return (
-    <div className="fixed inset-0 z-[200] bg-black text-white flex items-center justify-center">
-      <div className="text-center space-y-6 max-w-xs mx-auto px-4">
+    <Flex align="center" justify="center" className="fixed inset-0 z-[200] bg-black text-white">
+      <Stack gap="6" className="text-center max-w-xs mx-auto px-4">
         {/* Spinner */}
-        <div className="h-12 w-12 mx-auto rounded-full border-[3px] border-white/20 border-t-white animate-spin" />
+        <Box className="h-12 w-12 mx-auto rounded-full border-[3px] border-white/20 border-t-white animate-spin" />
 
         {/* Title + current phase message */}
-        <div className="space-y-2">
-          <h2 className="text-2xl font-semibold tracking-tight">{t("updatingFiestaboard")}</h2>
-          <p className="text-base text-white/80">{phaseMessage}</p>
-        </div>
+        <Stack gap="2">
+          <Heading level={2} className="text-2xl">
+            {t("updatingFiestaboard")}
+          </Heading>
+          <Text size="base" className="text-white/80">
+            {phaseMessage}
+          </Text>
+        </Stack>
 
         {/* Step dots */}
-        <div className="flex items-start w-full">
+        <Flex align="start" className="w-full">
           {steps.map((step, i) => {
             const isCompleted = i < stepIndex;
             const isActive = i === stepIndex;
             return (
               <Fragment key={step.key}>
-                <div className="flex flex-col items-center gap-1.5 flex-shrink-0">
-                  <div
+                <Stack align="center" gap="1.5" className="flex-shrink-0">
+                  <Box
                     className={cn(
                       "h-2.5 w-2.5 rounded-full transition-all duration-500",
                       isCompleted || isActive ? "bg-white" : "bg-white/25",
                       isActive && "ring-2 ring-white/40 ring-offset-2 ring-offset-black",
                     )}
                   />
-                  <span
+                  <Text
+                    as="span"
+                    size="xs"
                     className={cn(
-                      "text-xs leading-none transition-colors duration-500",
+                      "leading-none transition-colors duration-500",
                       isActive ? "text-white" : isCompleted ? "text-white/50" : "text-white/25",
                     )}
                   >
                     {step.label}
-                  </span>
-                </div>
+                  </Text>
+                </Stack>
                 {i < steps.length - 1 && (
-                  <div
+                  <Box
                     className={cn(
                       "flex-1 h-px mt-[5px] mx-2 transition-all duration-500",
                       isCompleted ? "bg-white/50" : "bg-white/15",
@@ -274,8 +282,10 @@ function UpdateOverlay({ currentVersion, onDone }: { currentVersion?: string; on
           })}
         </div>
 
-        <p className="text-xs text-white/40">{t("dontCloseTab")}</p>
-      </div>
-    </div>
+        <Text size="xs" className="text-white/40">
+          {t("dontCloseTab")}
+        </Text>
+      </Stack>
+    </Flex>
   );
 }

--- a/web/src/components/variable-autocomplete-textarea.tsx
+++ b/web/src/components/variable-autocomplete-textarea.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Textarea } from "@fiestaboard/ui";
+import { Box, Text, Textarea } from "@fiestaboard/ui";
 import { useQuery } from "@tanstack/react-query";
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 
@@ -180,7 +180,7 @@ export const VariableAutocompleteTextarea = forwardRef<HTMLTextAreaElement, Vari
     );
 
     return (
-      <div className="relative">
+      <Box className="relative">
         <Textarea
           ref={innerRef}
           id={id}
@@ -204,7 +204,7 @@ export const VariableAutocompleteTextarea = forwardRef<HTMLTextAreaElement, Vari
           disabled={disabled}
         />
         {open && filtered.length > 0 && (
-          <div
+          <Box
             role="listbox"
             className="absolute left-0 right-0 z-30 mt-1 max-h-64 overflow-auto rounded-md border bg-popover p-1 shadow-md"
           >
@@ -224,17 +224,23 @@ export const VariableAutocompleteTextarea = forwardRef<HTMLTextAreaElement, Vari
                   idx === activeIndex ? "bg-accent text-accent-foreground" : "hover:bg-accent/50",
                 )}
               >
-                <span className="font-mono text-xs">{s.token}</span>
+                <Text
+                  as="span"
+                  size="xs"
+                  className={cn("font-mono", idx === activeIndex && "text-accent-foreground")}
+                >
+                  {s.token}
+                </Text>
                 {s.preview && (
-                  <span className="truncate text-xs text-muted-foreground">
+                  <Text as="span" size="xs" tone="muted" className="truncate">
                     {s.preview.length > 20 ? `${s.preview.slice(0, 20)}…` : s.preview}
-                  </span>
+                  </Text>
                 )}
               </button>
             ))}
-          </div>
+          </Box>
         )}
-      </div>
+      </Box>
     );
   },
 );

--- a/web/src/components/variable-autocomplete-textarea.tsx
+++ b/web/src/components/variable-autocomplete-textarea.tsx
@@ -224,11 +224,7 @@ export const VariableAutocompleteTextarea = forwardRef<HTMLTextAreaElement, Vari
                   idx === activeIndex ? "bg-accent text-accent-foreground" : "hover:bg-accent/50",
                 )}
               >
-                <Text
-                  as="span"
-                  size="xs"
-                  className={cn("font-mono", idx === activeIndex && "text-accent-foreground")}
-                >
+                <Text as="span" size="xs" className={cn("font-mono", idx === activeIndex && "text-accent-foreground")}>
                   {s.token}
                 </Text>
                 {s.preview && (

--- a/web/src/components/variable-rule-row.tsx
+++ b/web/src/components/variable-rule-row.tsx
@@ -1,6 +1,18 @@
 "use client";
 
-import { Badge, Button, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@fiestaboard/ui";
+import {
+  Badge,
+  Box,
+  Button,
+  Flex,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Stack,
+  Text,
+} from "@fiestaboard/ui";
 import { AlertCircle, Check, GripVertical, HelpCircle, Pencil, Sparkles, Trash2, X } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 
@@ -101,7 +113,7 @@ export function VariableRuleRow({
   };
 
   return (
-    <div
+    <Box
       draggable={!isEditing}
       onDragStart={onDragStart}
       onDragOver={onDragOver}
@@ -115,11 +127,11 @@ export function VariableRuleRow({
     >
       {isEditing ? (
         <>
-          <div className="flex items-center justify-between gap-2">
-            <div className="flex items-center gap-1">
-              <span className="text-xs text-muted-foreground">
+          <Flex align="center" justify="between" gap="2">
+            <Flex align="center" gap="1">
+              <Text as="span" size="xs" tone="muted">
                 {t("variableRuleEditingLabel", { index: index + 1 })}
-              </span>
+              </Text>
               <Button
                 type="button"
                 variant="ghost"
@@ -131,8 +143,8 @@ export function VariableRuleRow({
               >
                 <HelpCircle className="h-3.5 w-3.5 text-muted-foreground" />
               </Button>
-            </div>
-            <div className="flex items-center gap-1">
+            </Flex>
+            <Flex align="center" gap="1">
               <Button type="button" variant="ghost" size="sm" className="h-7 px-2 text-xs" onClick={onCancelEdit}>
                 <X className="h-3.5 w-3.5 mr-1" />
                 {t("variableRuleCancel")}
@@ -148,25 +160,31 @@ export function VariableRuleRow({
                 <Check className="h-3.5 w-3.5 mr-1" />
                 {t("variableRuleSave")}
               </Button>
-            </div>
-          </div>
+            </Flex>
+          </Flex>
           {helpOpen && (
-            <div className="rounded-md border border-dashed bg-muted/40 p-2.5 space-y-2 text-xs">
-              <div>
-                <div className="font-medium mb-1">{t("variableRuleHelpOperatorsTitle")}</div>
-                <div className="text-muted-foreground font-mono">
+            <Stack gap="2" className="rounded-md border border-dashed bg-muted/40 p-2.5 text-xs">
+              <Box>
+                <Text size="xs" weight="medium" className="mb-1">
+                  {t("variableRuleHelpOperatorsTitle")}
+                </Text>
+                <Text size="xs" tone="muted" className="font-mono">
                   ==, =, !=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;= · AND OR NOT (or &amp;&amp; || !) · + - * / %
-                </div>
-              </div>
-              <div>
-                <div className="font-medium mb-1">{t("variableRuleHelpFunctionsTitle")}</div>
-                <div className="text-muted-foreground font-mono">
+                </Text>
+              </Box>
+              <Box>
+                <Text size="xs" weight="medium" className="mb-1">
+                  {t("variableRuleHelpFunctionsTitle")}
+                </Text>
+                <Text size="xs" tone="muted" className="font-mono">
                   IF(cond, then, else) · AND(a, b) · OR(a, b) · CONTAINS(s, sub) · STARTSWITH · LEN · UPPER · LOWER
-                </div>
-              </div>
-              <div>
-                <div className="font-medium mb-1">{t("variableRuleHelpExamplesTitle")}</div>
-                <div className="flex flex-wrap gap-1.5">
+                </Text>
+              </Box>
+              <Box>
+                <Text size="xs" weight="medium" className="mb-1">
+                  {t("variableRuleHelpExamplesTitle")}
+                </Text>
+                <Flex gap="1.5" className="flex-wrap">
                   {EXAMPLE_EXPRESSIONS.map((ex) => (
                     <button
                       type="button"
@@ -177,9 +195,9 @@ export function VariableRuleRow({
                       {ex}
                     </button>
                   ))}
-                </div>
-              </div>
-            </div>
+                </Flex>
+              </Box>
+            </Stack>
           )}
           <VariableAutocompleteTextarea
             value={draft.expression}
@@ -189,9 +207,11 @@ export function VariableRuleRow({
             ariaLabel={t("variableExpressionAriaLabel", { index: index + 1 })}
           />
           {lintFindings.map((f) => (
-            <div key={f.kind} className="flex items-start gap-1.5 text-xs text-amber-600 dark:text-amber-400">
+            <Flex key={f.kind} align="start" gap="1.5" className="text-xs text-amber-600 dark:text-amber-400">
               <AlertCircle className="h-3.5 w-3.5 mt-0.5 flex-shrink-0" />
-              <span className="flex-1">{f.message}</span>
+              <Text as="span" size="xs" className="flex-1 text-amber-600 dark:text-amber-400">
+                {f.message}
+              </Text>
               {f.autoFix && (
                 <Button
                   type="button"
@@ -204,13 +224,15 @@ export function VariableRuleRow({
                   {t("variableRuleApplyFix")}
                 </Button>
               )}
-            </div>
+            </Flex>
           ))}
           {hasUnknownVars && (
-            <div className="flex items-start gap-1.5 text-xs text-amber-600 dark:text-amber-400">
+            <Flex align="start" gap="1.5" className="text-xs text-amber-600 dark:text-amber-400">
               <AlertCircle className="h-3.5 w-3.5 mt-0.5 flex-shrink-0" />
-              <span>{t("variableRuleUnknownVars", { vars: unknownVars.slice(0, 3).join(", ") })}</span>
-            </div>
+              <Text as="span" size="xs" className="text-amber-600 dark:text-amber-400">
+                {t("variableRuleUnknownVars", { vars: unknownVars.slice(0, 3).join(", ") })}
+              </Text>
+            </Flex>
           )}
           <Select value={draft.page_id} onValueChange={(v) => setDraft((d) => ({ ...d, page_id: v }))}>
             <SelectTrigger>
@@ -226,17 +248,19 @@ export function VariableRuleRow({
           </Select>
         </>
       ) : (
-        <div className="flex items-center gap-2">
+        <Flex align="center" gap="2">
           <GripVertical className="h-4 w-4 text-muted-foreground flex-shrink-0" aria-hidden />
           <Badge variant="outline" className="text-xs tabular-nums flex-shrink-0">
             {index + 1}
           </Badge>
-          <div className="flex-1 min-w-0">
-            <div className="font-mono text-xs truncate">{summaryExpression}</div>
-            <div className="text-xs text-muted-foreground truncate">
+          <Box className="flex-1 min-w-0">
+            <Text size="xs" className="font-mono truncate">
+              {summaryExpression}
+            </Text>
+            <Text size="xs" tone="muted" className="truncate">
               {t("variableRuleSummaryArrow", { target: summaryTarget })}
-            </div>
-          </div>
+            </Text>
+          </Box>
           <Button
             type="button"
             variant="ghost"
@@ -257,8 +281,8 @@ export function VariableRuleRow({
           >
             <Trash2 className="h-3.5 w-3.5 text-muted-foreground" />
           </Button>
-        </div>
+        </Flex>
       )}
-    </div>
+    </Box>
   );
 }

--- a/web/src/components/version-display.tsx
+++ b/web/src/components/version-display.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@fiestaboard/ui";
+import { Flex, Text, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@fiestaboard/ui";
 import { useQuery } from "@tanstack/react-query";
 import { ArrowUpCircle, Package } from "lucide-react";
 
@@ -26,12 +26,12 @@ export function VersionDisplay() {
   if (!version) return null;
 
   return (
-    <div className="flex items-center gap-2 text-xs text-muted-foreground">
+    <Flex align="center" gap="2" className="text-xs text-muted-foreground">
       <Package className="h-3 w-3" />
-      <span suppressHydrationWarning>
+      <Text as="span" size="xs" tone="muted" suppressHydrationWarning>
         v{version.package_version}
         {version.is_dev && ` ${t("devSuffix")}`}
-      </span>
+      </Text>
       {updateCheck?.update_available && (
         <TooltipProvider>
           <Tooltip>
@@ -45,11 +45,11 @@ export function VersionDisplay() {
               </button>
             </TooltipTrigger>
             <TooltipContent>
-              <p>{t("updateAvailableTooltip", { version: updateCheck.latest_version ?? "" })}</p>
+              <Text>{t("updateAvailableTooltip", { version: updateCheck.latest_version ?? "" })}</Text>
             </TooltipContent>
           </Tooltip>
         </TooltipProvider>
       )}
-    </div>
+    </Flex>
   );
 }

--- a/web/src/components/wizard-provider.tsx
+++ b/web/src/components/wizard-provider.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Box, Flex, Text } from "@fiestaboard/ui";
 import type { ReactNode } from "react";
 import { createContext, lazy, Suspense, useCallback, useContext, useEffect, useState } from "react";
 
@@ -10,12 +11,14 @@ import { clearWizardCompletion, shouldShowWizard } from "@/lib/setup-detection";
 function WizardLoadingFallback() {
   const t = useTranslations("wizardProvider");
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-background">
-      <div className="text-center">
-        <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
-        <p className="mt-4 text-muted-foreground">{t("loadingSetupWizard")}</p>
-      </div>
-    </div>
+    <Flex align="center" justify="center" className="fixed inset-0 bg-background">
+      <Box className="text-center">
+        <Box className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+        <Text tone="muted" className="mt-4">
+          {t("loadingSetupWizard")}
+        </Text>
+      </Box>
+    </Flex>
   );
 }
 
@@ -108,12 +111,14 @@ export function WizardProvider({ children }: WizardProviderProps) {
   // Show loading state while checking
   if (!hasChecked) {
     return (
-      <div className="fixed inset-0 flex items-center justify-center bg-background">
-        <div className="text-center">
-          <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
-          <p className="mt-4 text-muted-foreground">{t("loading")}</p>
-        </div>
-      </div>
+      <Flex align="center" justify="center" className="fixed inset-0 bg-background">
+        <Box className="text-center">
+          <Box className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+          <Text tone="muted" className="mt-4">
+            {t("loading")}
+          </Text>
+        </Box>
+      </Flex>
     );
   }
 

--- a/web/src/i18n/translations.tsx
+++ b/web/src/i18n/translations.tsx
@@ -4,7 +4,7 @@
  * Exposes the shape the codebase has been using for ~2 years:
  *   const t = useTranslations("namespace");
  *   t("key", {count: 3});            // ICU plural via inline regex
- *   t.rich("key", { strong: (c) => <strong>{c}</strong> });
+ *   t.rich("key", { strong: (c) => <Text as="span" weight="semibold">{c}</Text> });
  *   t.raw("key");                    // raw object / array / string
  *
  * react-i18next's `t` returns the resolved string for plain keys; we


### PR DESCRIPTION
Wave 3 of 6 for epic #1474: migrates 20 files (`src/components` P–Z + `src/i18n/translations.tsx`) to `@fiestaboard/ui` primitives per the plan recipe.

## What changed
- Same recipe as waves 1–2; **all 20 files fully converted** — no rationale-kept exceptions this wave
- `scaled-board-display` / `static-board-display`: pixel-load-bearing wrappers → `Box` (emits zero classes), tile classes + inline styles byte-identical
- `smart-link.tsx`: only the external-`<a>` branch → `TextLink`; the router branch untouched
- Judgment calls (review-verified as style-neutral): redundant bare spans inside `Badge`s removed; `text-xs` hoisted onto Save/Export `Button`s instead of introducing a color-resetting `Text as="span"`

## Verification
- Docker: ESLint 0 errors, prettier clean; tsc adds zero new errors in wave files (repo-wide tsc red is pre-existing, not a CI gate)
- Task review: Approved; both minors fixed in the final commit (sidebar label carries `text-sidebar-foreground` intent explicitly; validation list keeps its original indent)
- Process improvement from this wave: the definition-of-done grep now sweeps **closing** tags too — a stray `</div>` passes an opening-only grep but breaks the parse

No ESLint rule yet — wave 6.

Part of #1474

🤖 Generated with [Claude Code](https://claude.com/claude-code)