### PR TITLE
refactor: adopt FiestaUI primitives — wave 4 (settings)

### DIFF
--- a/web/src/components/settings/about-card.tsx
+++ b/web/src/components/settings/about-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Badge, Card, CardContent, CardDescription, CardHeader, CardTitle, Skeleton } from "@fiestaboard/ui";
+import { Badge, Box, Card, CardContent, CardDescription, CardHeader, CardTitle, Flex, Skeleton, Text, TextLink } from "@fiestaboard/ui";
 import { useQuery } from "@tanstack/react-query";
 import { Cpu, ExternalLink, Info, Package } from "lucide-react";
 
@@ -40,14 +40,15 @@ export function AboutCard() {
       </CardHeader>
       <CardContent>
         <dl className="space-y-3 text-sm">
-          <div className="flex items-center justify-between gap-4">
+          <Flex align="center" justify="between" gap="4">
             <dt className="text-muted-foreground">{t("status")}</dt>
             <dd>
               {isLoadingStatus ? (
                 <Skeleton className="h-5 w-16" />
               ) : (
-                <div className="flex items-center gap-2">
-                  <span
+                <Flex align="center" gap="2">
+                  <Text
+                    as="span"
                     className={cn("h-2 w-2 rounded-full", isRunning ? "bg-board-green" : "bg-muted-foreground")}
                     style={
                       isRunning
@@ -63,20 +64,22 @@ export function AboutCard() {
                   >
                     {isRunning ? t("statusRunning") : t("statusStopped")}
                   </Badge>
-                </div>
+                </Flex>
               )}
             </dd>
-          </div>
+          </Flex>
 
-          <div className="flex items-center justify-between gap-4">
+          <Flex align="center" justify="between" gap="4">
             <dt className="text-muted-foreground">{t("version")}</dt>
             <dd>
               {isLoadingVersion ? (
                 <Skeleton className="h-5 w-16" />
               ) : versionData ? (
-                <div className="flex items-center gap-2">
+                <Flex align="center" gap="2">
                   <Package className="h-3.5 w-3.5 text-muted-foreground" />
-                  <span className="font-mono tabular-nums">v{versionData.package_version}</span>
+                  <Text as="span" className="font-mono tabular-nums">
+                    v{versionData.package_version}
+                  </Text>
                   {versionData.is_dev && (
                     <Badge variant="secondary" className="text-xs">
                       {t("devBuild")}
@@ -87,41 +90,45 @@ export function AboutCard() {
                       v{updateCheck.latest_version} available
                     </Badge>
                   )}
-                </div>
+                </Flex>
               ) : (
-                <span className="text-muted-foreground">—</span>
+                <Text as="span" tone="muted">
+                  —
+                </Text>
               )}
             </dd>
-          </div>
+          </Flex>
 
           {versionData?.build_version && (
-            <div className="flex items-center justify-between gap-4">
+            <Flex align="center" justify="between" gap="4">
               <dt className="text-muted-foreground">{t("buildVersion")}</dt>
               <dd className="font-mono text-xs text-muted-foreground tabular-nums">{versionData.build_version}</dd>
-            </div>
+            </Flex>
           )}
 
           {versionData?.hardware_model && (
-            <div className="flex items-center justify-between gap-4">
+            <Flex align="center" justify="between" gap="4">
               <dt className="text-muted-foreground">{t("hardware")}</dt>
               <dd className="flex items-center gap-2">
                 <Cpu className="h-3.5 w-3.5 text-muted-foreground" />
-                <span className="text-xs">{versionData.hardware_model}</span>
+                <Text as="span" size="xs">
+                  {versionData.hardware_model}
+                </Text>
               </dd>
-            </div>
+            </Flex>
           )}
 
-          <div className="pt-2 border-t">
-            <a
+          <Box className="pt-2 border-t">
+            <TextLink
               href="https://fiestaboard.app/docs/intro"
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center gap-1.5 text-sm text-primary hover:underline"
+              className="inline-flex items-center gap-1.5 text-sm text-primary no-underline hover:underline"
             >
               {t("viewDocs")}
               <ExternalLink className="h-3.5 w-3.5" />
-            </a>
-          </div>
+            </TextLink>
+          </Box>
         </dl>
       </CardContent>
     </Card>

--- a/web/src/components/settings/about-card.tsx
+++ b/web/src/components/settings/about-card.tsx
@@ -1,6 +1,18 @@
 "use client";
 
-import { Badge, Box, Card, CardContent, CardDescription, CardHeader, CardTitle, Flex, Skeleton, Text, TextLink } from "@fiestaboard/ui";
+import {
+  Badge,
+  Box,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Flex,
+  Skeleton,
+  Text,
+  TextLink,
+} from "@fiestaboard/ui";
 import { useQuery } from "@tanstack/react-query";
 import { Cpu, ExternalLink, Info, Package } from "lucide-react";
 

--- a/web/src/components/settings/accessibility-settings.tsx
+++ b/web/src/components/settings/accessibility-settings.tsx
@@ -1,6 +1,17 @@
 "use client";
 
-import { Box, Card, CardContent, CardDescription, CardHeader, CardTitle, Flex, Skeleton, Switch, Text } from "@fiestaboard/ui";
+import {
+  Box,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Flex,
+  Skeleton,
+  Switch,
+  Text,
+} from "@fiestaboard/ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Accessibility } from "lucide-react";
 import { useEffect, useState } from "react";

--- a/web/src/components/settings/accessibility-settings.tsx
+++ b/web/src/components/settings/accessibility-settings.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Card, CardContent, CardDescription, CardHeader, CardTitle, Skeleton, Switch } from "@fiestaboard/ui";
+import { Box, Card, CardContent, CardDescription, CardHeader, CardTitle, Flex, Skeleton, Switch, Text } from "@fiestaboard/ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Accessibility } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -49,20 +49,22 @@ export function AccessibilitySettings() {
         {isLoading ? (
           <Skeleton className="h-6 w-48" />
         ) : (
-          <div className="flex items-center gap-3">
+          <Flex align="center" gap="3">
             <Switch
               id="reduce-motion"
               checked={reduceMotion}
               onCheckedChange={handleReduceMotionToggle}
               disabled={updateDisplayMutation.isPending}
             />
-            <div>
+            <Box>
               <label htmlFor="reduce-motion" className="text-sm font-medium cursor-pointer">
                 {t("reduceMotion")}
               </label>
-              <p className="text-xs text-muted-foreground mt-0.5">{t("reduceMotionHint")}</p>
-            </div>
-          </div>
+              <Text size="xs" tone="muted" className="mt-0.5">
+                {t("reduceMotionHint")}
+              </Text>
+            </Box>
+          </Flex>
         )}
       </CardContent>
     </Card>

--- a/web/src/components/settings/ai-settings.tsx
+++ b/web/src/components/settings/ai-settings.tsx
@@ -13,6 +13,8 @@ import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
+  Box,
+  Flex,
   Input,
   Label,
   Select,
@@ -21,7 +23,9 @@ import {
   SelectTrigger,
   SelectValue,
   Skeleton,
+  Stack,
   Switch,
+  Text,
 } from "@fiestaboard/ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
@@ -159,14 +163,16 @@ function ProviderRow({
 
   return (
     <Collapsible open={expanded} onOpenChange={onToggleExpanded} className="rounded-md border">
-      <div className="flex items-center justify-between gap-2 p-2">
+      <Flex align="center" justify="between" gap="2" className="p-2">
         <CollapsibleTrigger className="flex flex-1 items-center gap-2 min-w-0 text-left rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
           <ChevronDown
             className={`h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200 ${
               expanded ? "rotate-180" : ""
             }`}
           />
-          <span className="text-sm font-medium truncate">{summaryName}</span>
+          <Text as="span" size="sm" weight="medium" className="truncate">
+            {summaryName}
+          </Text>
           {isDefault && (
             <Badge variant="default" className="h-5 text-[10px] shrink-0">
               Default
@@ -177,11 +183,11 @@ function ProviderRow({
               Anthropic
             </Badge>
           )}
-          <span className="text-[11px] text-muted-foreground shrink-0">
+          <Text as="span" tone="muted" className="text-[11px] shrink-0">
             {modelCount === 0 ? "no models" : `${modelCount} model${modelCount === 1 ? "" : "s"}`}
-          </span>
+          </Text>
         </CollapsibleTrigger>
-        <div className="flex items-center gap-1.5 shrink-0">
+        <Flex align="center" gap="1.5" className="shrink-0">
           {!isDefault && (
             <Button
               type="button"
@@ -205,12 +211,12 @@ function ProviderRow({
           >
             <Trash2 className="h-3.5 w-3.5" />
           </Button>
-        </div>
-      </div>
+        </Flex>
+      </Flex>
 
       <CollapsibleContent>
-        <div className="space-y-3 border-t p-3">
-          <div className="space-y-1.5">
+        <Stack gap="3" className="border-t p-3">
+          <Stack gap="1.5">
             <Label htmlFor={`name-${provider.id}`} className="text-xs">
               Name
             </Label>
@@ -221,9 +227,9 @@ function ProviderRow({
               placeholder="OpenRouter"
               className="h-8"
             />
-          </div>
+          </Stack>
 
-          <div className="space-y-1.5">
+          <Stack gap="1.5">
             <Label htmlFor={`protocol-${provider.id}`} className="text-xs">
               Protocol
             </Label>
@@ -247,9 +253,9 @@ function ProviderRow({
                 <SelectItem value="anthropic">Anthropic (Messages API)</SelectItem>
               </SelectContent>
             </Select>
-          </div>
+          </Stack>
 
-          <div className="space-y-1.5">
+          <Stack gap="1.5">
             <Label htmlFor={`url-${provider.id}`} className="text-xs">
               Base URL
             </Label>
@@ -260,15 +266,17 @@ function ProviderRow({
               placeholder="https://openrouter.ai/api/v1"
               className="h-8 font-mono text-xs"
             />
-            <div className="rounded-md border border-dashed bg-muted/30 p-2 space-y-1">
-              <div className="text-[10px] uppercase tracking-wide text-muted-foreground font-medium">Quick presets</div>
+            <Stack gap="1" className="rounded-md border border-dashed bg-muted/30 p-2">
+              <Text weight="medium" tone="muted" className="text-[10px] uppercase tracking-wide">
+                Quick presets
+              </Text>
               {(["cloud", "local"] as const).map((group) => {
                 const presets = PROVIDER_PRESETS.filter((p) => p.group === group);
                 return (
-                  <div key={group} className="flex flex-wrap items-center gap-1">
-                    <span className="text-[10px] uppercase tracking-wide text-muted-foreground pr-1 w-10">
+                  <Flex key={group} wrap align="center" gap="1">
+                    <Text as="span" tone="muted" className="text-[10px] uppercase tracking-wide pr-1 w-10">
                       {group === "cloud" ? "Cloud" : "Local"}
-                    </span>
+                    </Text>
                     {presets.map((preset) => (
                       <Button
                         key={preset.label}
@@ -290,17 +298,17 @@ function ProviderRow({
                         {preset.label}
                       </Button>
                     ))}
-                  </div>
+                  </Flex>
                 );
               })}
-            </div>
-          </div>
+            </Stack>
+          </Stack>
 
-          <div className="space-y-1.5">
+          <Stack gap="1.5">
             <Label htmlFor={`key-${provider.id}`} className="text-xs">
               API Key
             </Label>
-            <div className="relative">
+            <Box className="relative">
               <KeyRound className="pointer-events-none absolute left-2 top-2 h-3.5 w-3.5 text-muted-foreground" />
               <Input
                 id={`key-${provider.id}`}
@@ -320,12 +328,12 @@ function ProviderRow({
               >
                 {showKey ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
               </Button>
-            </div>
-          </div>
+            </Box>
+          </Stack>
 
-          <div className="space-y-1.5">
+          <Stack gap="1.5">
             <Label className="text-xs">Models</Label>
-            <div className="flex gap-1.5">
+            <Flex gap="1.5">
               <Input
                 value={modelInput}
                 onChange={(e) => setModelInput(e.target.value)}
@@ -342,9 +350,9 @@ function ProviderRow({
               <Button type="button" size="sm" variant="outline" className="h-8" onClick={addModel}>
                 <Plus className="h-3.5 w-3.5" />
               </Button>
-            </div>
+            </Flex>
             {provider.models.length > 0 && (
-              <div className="flex flex-wrap gap-1 pt-1">
+              <Flex wrap gap="1" className="pt-1">
                 {provider.models.map((m) => (
                   <Badge key={m} variant="secondary" className="font-mono text-[11px] gap-1">
                     {m}
@@ -358,12 +366,12 @@ function ProviderRow({
                     </button>
                   </Badge>
                 ))}
-              </div>
+              </Flex>
             )}
-          </div>
+          </Stack>
 
           {provider.models.length > 0 && (
-            <div className="space-y-1.5">
+            <Stack gap="1.5">
               <Label htmlFor={`default-${provider.id}`} className="text-xs">
                 Default model
               </Label>
@@ -382,10 +390,10 @@ function ProviderRow({
                   ))}
                 </SelectContent>
               </Select>
-            </div>
+            </Stack>
           )}
 
-          <div className="flex items-center justify-between gap-2 pt-1">
+          <Flex align="center" justify="between" gap="2" className="pt-1">
             <Button
               type="button"
               size="sm"
@@ -395,16 +403,24 @@ function ProviderRow({
               disabled={testing || provider.models.length === 0 || !provider.base_url}
             >
               {testing ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Sparkles className="h-3.5 w-3.5" />}
-              <span className="text-xs">Test connection</span>
+              <Text as="span" size="xs">
+                Test connection
+              </Text>
             </Button>
             {testResult && (
-              <div className={`flex items-center gap-1 text-xs ${testResult.ok ? "text-success" : "text-destructive"}`}>
+              <Flex
+                align="center"
+                gap="1"
+                className={`text-xs ${testResult.ok ? "text-success" : "text-destructive"}`}
+              >
                 {testResult.ok ? <CheckCircle2 className="h-3.5 w-3.5" /> : <XCircle className="h-3.5 w-3.5" />}
-                <span className="line-clamp-2">{testResult.message}</span>
-              </div>
+                <Text as="span" size="xs" tone={testResult.ok ? "success" : "destructive"} className="line-clamp-2">
+                  {testResult.message}
+                </Text>
+              </Flex>
             )}
-          </div>
-        </div>
+          </Flex>
+        </Stack>
       </CollapsibleContent>
     </Collapsible>
   );
@@ -501,8 +517,8 @@ export function AiSettings() {
   return (
     <Card>
       <CardHeader>
-        <div className="flex items-start justify-between gap-2">
-          <div>
+        <Flex align="start" justify="between" gap="2">
+          <Box>
             <CardTitle className="text-base flex items-center gap-2">
               <Sparkles className="h-4 w-4" />
               AI Providers
@@ -511,8 +527,8 @@ export function AiSettings() {
               Configure OpenAI-compatible LLMs for the &ldquo;Gen AI&rdquo; page generator. BYO-LLM: FiestaBoard never
               bundles a key.
             </CardDescription>
-          </div>
-          <div className="flex items-center gap-2 pt-1">
+          </Box>
+          <Flex align="center" gap="2" className="pt-1">
             <Label htmlFor="ai-enabled" className="text-xs">
               {current.enabled ? "Enabled" : "Disabled"}
             </Label>
@@ -522,8 +538,8 @@ export function AiSettings() {
               onCheckedChange={toggleEnabled}
               disabled={saveMutation.isPending}
             />
-          </div>
-        </div>
+          </Flex>
+        </Flex>
       </CardHeader>
       <CardContent className="space-y-3">
         <Alert>
@@ -534,11 +550,11 @@ export function AiSettings() {
         </Alert>
 
         {current.providers.length === 0 ? (
-          <div className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
+          <Text tone="muted" className="rounded-md border border-dashed p-6 text-center">
             No providers configured yet.
-          </div>
+          </Text>
         ) : (
-          <div className="space-y-3">
+          <Stack gap="3">
             {current.providers.map((p, idx) => (
               <ProviderRow
                 key={p.id}
@@ -551,16 +567,16 @@ export function AiSettings() {
                 onMakeDefault={() => makeDefault(idx)}
               />
             ))}
-          </div>
+          </Stack>
         )}
 
-        <div className="flex flex-wrap items-center justify-between gap-2 pt-1">
+        <Flex wrap align="center" justify="between" gap="2" className="pt-1">
           <Button type="button" variant="outline" size="sm" className="gap-1.5" onClick={addProvider}>
             <Plus className="h-3.5 w-3.5" />
             Add provider
           </Button>
           {hasDraft && (
-            <div className="flex gap-2">
+            <Flex gap="2">
               <Button type="button" variant="ghost" size="sm" onClick={() => setDraft(null)}>
                 Discard
               </Button>
@@ -573,9 +589,9 @@ export function AiSettings() {
               >
                 {saveMutation.isPending ? "Saving..." : "Save changes"}
               </Button>
-            </div>
+            </Flex>
           )}
-        </div>
+        </Flex>
       </CardContent>
     </Card>
   );

--- a/web/src/components/settings/ai-settings.tsx
+++ b/web/src/components/settings/ai-settings.tsx
@@ -4,6 +4,7 @@ import {
   Alert,
   AlertDescription,
   Badge,
+  Box,
   Button,
   Card,
   CardContent,
@@ -13,7 +14,6 @@ import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
-  Box,
   Flex,
   Input,
   Label,
@@ -408,11 +408,7 @@ function ProviderRow({
               </Text>
             </Button>
             {testResult && (
-              <Flex
-                align="center"
-                gap="1"
-                className={`text-xs ${testResult.ok ? "text-success" : "text-destructive"}`}
-              >
+              <Flex align="center" gap="1" className={`text-xs ${testResult.ok ? "text-success" : "text-destructive"}`}>
                 {testResult.ok ? <CheckCircle2 className="h-3.5 w-3.5" /> : <XCircle className="h-3.5 w-3.5" />}
                 <Text as="span" size="xs" tone={testResult.ok ? "success" : "destructive"} className="line-clamp-2">
                   {testResult.message}

--- a/web/src/components/settings/animation-settings.tsx
+++ b/web/src/components/settings/animation-settings.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Card, CardContent, CardDescription, CardHeader, CardTitle, Label, Skeleton } from "@fiestaboard/ui";
+import { Box, Card, CardContent, CardDescription, CardHeader, CardTitle, Flex, Label, Skeleton, Stack, Text } from "@fiestaboard/ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Sparkles } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -81,12 +81,14 @@ export function AnimationSettings() {
           <Skeleton className="h-20 w-full" />
         ) : (
           <>
-            <div className="space-y-2">
-              <div>
+            <Stack gap="2">
+              <Box>
                 <Label className="text-sm font-medium">{t("boardAnimationsLabel")}</Label>
-                <p className="text-xs text-muted-foreground mt-0.5">{t("boardAnimationsHint")}</p>
-              </div>
-              <div role="radiogroup" aria-label={t("boardAnimationsLabel")} className="flex flex-wrap gap-2">
+                <Text size="xs" tone="muted" className="mt-0.5">
+                  {t("boardAnimationsHint")}
+                </Text>
+              </Box>
+              <Flex wrap gap="2" role="radiogroup" aria-label={t("boardAnimationsLabel")}>
                 {BOARD_OPTIONS.map((option) => {
                   const selected = boardMode === option;
                   return (
@@ -107,16 +109,20 @@ export function AnimationSettings() {
                     </button>
                   );
                 })}
-              </div>
-              <p className="text-xs text-muted-foreground">{t(BOARD_HINT_KEY[boardMode])}</p>
-            </div>
+              </Flex>
+              <Text size="xs" tone="muted">
+                {t(BOARD_HINT_KEY[boardMode])}
+              </Text>
+            </Stack>
 
-            <div className="space-y-2 pt-2 border-t">
-              <div>
+            <Stack gap="2" className="pt-2 border-t">
+              <Box>
                 <Label className="text-sm font-medium">{t("siteAnimationsLabel")}</Label>
-                <p className="text-xs text-muted-foreground mt-0.5">{t("siteAnimationsHint")}</p>
-              </div>
-              <div role="radiogroup" aria-label={t("siteAnimationsLabel")} className="flex flex-wrap gap-2">
+                <Text size="xs" tone="muted" className="mt-0.5">
+                  {t("siteAnimationsHint")}
+                </Text>
+              </Box>
+              <Flex wrap gap="2" role="radiogroup" aria-label={t("siteAnimationsLabel")}>
                 {SITE_OPTIONS.map((option) => {
                   const selected = siteMode === option;
                   return (
@@ -137,11 +143,13 @@ export function AnimationSettings() {
                     </button>
                   );
                 })}
-              </div>
-            </div>
+              </Flex>
+            </Stack>
 
             {reduceMotion && (
-              <p className="text-xs text-muted-foreground italic">{t("animationsReduceMotionOverride")}</p>
+              <Text size="xs" tone="muted" className="italic">
+                {t("animationsReduceMotionOverride")}
+              </Text>
             )}
           </>
         )}

--- a/web/src/components/settings/animation-settings.tsx
+++ b/web/src/components/settings/animation-settings.tsx
@@ -1,6 +1,18 @@
 "use client";
 
-import { Box, Card, CardContent, CardDescription, CardHeader, CardTitle, Flex, Label, Skeleton, Stack, Text } from "@fiestaboard/ui";
+import {
+  Box,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Flex,
+  Label,
+  Skeleton,
+  Stack,
+  Text,
+} from "@fiestaboard/ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Sparkles } from "lucide-react";
 import { useEffect, useState } from "react";

--- a/web/src/components/settings/appearance-settings.tsx
+++ b/web/src/components/settings/appearance-settings.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@fiestaboard/ui";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle, Grid, Text } from "@fiestaboard/ui";
 import { Check, Monitor, Moon, Sun } from "lucide-react";
 
 import { useTheme } from "@/hooks/use-theme";
@@ -21,7 +21,7 @@ export function AppearanceSettings() {
         <CardDescription>{t("appearanceDescription")}</CardDescription>
       </CardHeader>
       <CardContent>
-        <div className="grid grid-cols-3 gap-3 max-w-sm">
+        <Grid cols="3" gap="3" className="max-w-sm">
           {(
             [
               { value: "light", label: t("lightMode"), Icon: Sun },
@@ -44,16 +44,16 @@ export function AppearanceSettings() {
                 )}
               >
                 {isActive && (
-                  <span className="absolute right-1.5 top-1.5">
+                  <Text as="span" className="absolute right-1.5 top-1.5">
                     <Check className="h-3 w-3 text-primary" />
-                  </span>
+                  </Text>
                 )}
                 <Icon className="h-5 w-5" />
                 {label}
               </button>
             );
           })}
-        </div>
+        </Grid>
       </CardContent>
     </Card>
   );

--- a/web/src/components/settings/auto-update-interval.tsx
+++ b/web/src/components/settings/auto-update-interval.tsx
@@ -7,11 +7,13 @@ import {
   CardDescription,
   CardHeader,
   CardTitle,
+  Flex,
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
+  Text,
 } from "@fiestaboard/ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { CalendarClock, RefreshCw } from "lucide-react";
@@ -121,7 +123,7 @@ export function AutoUpdateIntervalCard() {
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-3">
-        <div className="flex flex-wrap items-center gap-3">
+        <Flex wrap align="center" gap="3">
           <Select
             value={current}
             onValueChange={(v) => mutation.mutate(v as AutoUpdateInterval)}
@@ -138,7 +140,9 @@ export function AutoUpdateIntervalCard() {
               ))}
             </SelectContent>
           </Select>
-          <span className="text-xs text-muted-foreground">Last checked: {formatLastCheck(status.last_check)}</span>
+          <Text as="span" size="xs" tone="muted">
+            Last checked: {formatLastCheck(status.last_check)}
+          </Text>
           <Button
             variant="outline"
             size="sm"
@@ -149,8 +153,8 @@ export function AutoUpdateIntervalCard() {
             <RefreshCw className={`h-4 w-4 mr-2 ${checkNowMutation.isPending ? "animate-spin" : ""}`} />
             {checkNowMutation.isPending ? t("checkingForUpdates") : t("checkNow")}
           </Button>
-        </div>
-        <p className="text-sm text-muted-foreground">{INTERVAL_DESCRIPTIONS[current]}</p>
+        </Flex>
+        <Text tone="muted">{INTERVAL_DESCRIPTIONS[current]}</Text>
       </CardContent>
     </Card>
   );

--- a/web/src/components/settings/backup-settings.tsx
+++ b/web/src/components/settings/backup-settings.tsx
@@ -200,9 +200,8 @@ export function BackupSettings() {
               <Text as="span" weight="medium" tone="muted">
                 {pending?.fileName}
               </Text>
-              . Your existing pages,
-              collections, schedules and configuration will be overwritten. A timestamped copy of each existing file is
-              kept alongside the new one so you can roll back manually if needed.
+              . Your existing pages, collections, schedules and configuration will be overwritten. A timestamped copy of
+              each existing file is kept alongside the new one so you can roll back manually if needed.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/web/src/components/settings/backup-settings.tsx
+++ b/web/src/components/settings/backup-settings.tsx
@@ -15,8 +15,11 @@ import {
   CardDescription,
   CardHeader,
   CardTitle,
+  Flex,
   Label,
+  Stack,
   Switch,
+  Text,
 } from "@fiestaboard/ui";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { AlertTriangle, Database, Download, Loader2, Upload } from "lucide-react";
@@ -137,7 +140,7 @@ export function BackupSettings() {
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-6">
-          <div className="flex flex-col sm:flex-row gap-3">
+          <Flex direction="col" gap="3" className="sm:flex-row">
             <Button variant="default" className="gap-2" onClick={handleExport} disabled={importMutation.isPending}>
               <Download className="h-4 w-4" />
               Export backup
@@ -158,25 +161,25 @@ export function BackupSettings() {
               className="hidden"
               onChange={handleFileSelected}
             />
-          </div>
+          </Flex>
 
-          <div className="flex items-start gap-3 rounded-md border border-border/60 bg-muted/40 p-3">
+          <Flex align="start" gap="3" className="rounded-md border border-border/60 bg-muted/40 p-3">
             <Switch id="backup-reinstall-plugins" checked={reinstallPlugins} onCheckedChange={setReinstallPlugins} />
-            <div className="space-y-1">
+            <Stack gap="1">
               <Label htmlFor="backup-reinstall-plugins" className="cursor-pointer">
                 Reinstall external plugins after import
               </Label>
-              <p className="text-xs text-muted-foreground">
+              <Text size="xs" tone="muted">
                 When enabled, FiestaBoard will attempt to clone any external plugins recorded in the backup that are not
                 yet installed on this instance. Their configuration is restored from the backup either way.
-              </p>
-            </div>
-          </div>
+              </Text>
+            </Stack>
+          </Flex>
 
-          <p className="text-xs text-muted-foreground">
+          <Text size="xs" tone="muted">
             Note: backups contain sensitive values such as API keys and board credentials in plain text. Store the file
             securely and do not share it publicly.
-          </p>
+          </Text>
         </CardContent>
       </Card>
 
@@ -193,7 +196,11 @@ export function BackupSettings() {
               Replace current configuration?
             </AlertDialogTitle>
             <AlertDialogDescription>
-              You are about to restore <span className="font-medium">{pending?.fileName}</span>. Your existing pages,
+              You are about to restore{" "}
+              <Text as="span" weight="medium" tone="muted">
+                {pending?.fileName}
+              </Text>
+              . Your existing pages,
               collections, schedules and configuration will be overwritten. A timestamped copy of each existing file is
               kept alongside the new one so you can roll back manually if needed.
             </AlertDialogDescription>

--- a/web/src/components/settings/beta-settings.tsx
+++ b/web/src/components/settings/beta-settings.tsx
@@ -14,8 +14,12 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  Flex,
   Skeleton,
+  Stack,
   Switch,
+  Text,
+  TextLink,
 } from "@fiestaboard/ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { AlertTriangle, ExternalLink, FlaskConical, Loader2, Lock, RefreshCw, ShieldCheck, Wand2 } from "lucide-react";
@@ -138,60 +142,68 @@ export function BetaSettings() {
           <CardDescription>{t("description")}</CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          <div className="flex items-start justify-between gap-4 rounded-md border p-4">
-            <div className="space-y-1">
-              <div className="flex items-center gap-2">
+          <Flex align="start" justify="between" gap="4" className="rounded-md border p-4">
+            <Stack gap="1">
+              <Flex align="center" gap="2">
                 <Lock className="h-4 w-4 text-muted-foreground" />
-                <span className="font-medium">{t("httpsLabel")}</span>
+                <Text as="span" weight="medium">
+                  {t("httpsLabel")}
+                </Text>
                 {httpsEnabled && certPresent && (
                   <Badge variant="default" className="text-[10px] bg-board-green">
                     <ShieldCheck className="h-3 w-3 mr-1" />
                     {t("httpsActive")}
                   </Badge>
                 )}
-              </div>
-              <p className="text-sm text-muted-foreground">{t("httpsDescription")}</p>
-              <p className="text-xs text-muted-foreground flex items-start gap-1.5 pt-1">
+              </Flex>
+              <Text tone="muted">{t("httpsDescription")}</Text>
+              <Flex align="start" gap="1.5" className="text-xs text-muted-foreground pt-1">
                 <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-                <span>{t("httpsWarning")}</span>
-              </p>
-            </div>
+                <Text as="span" size="xs" tone="muted">
+                  {t("httpsWarning")}
+                </Text>
+              </Flex>
+            </Stack>
             <Switch
               checked={httpsEnabled}
               disabled={mutation.isPending}
               onCheckedChange={(checked) => mutation.mutate(checked)}
               aria-label={t("httpsLabel")}
             />
-          </div>
+          </Flex>
 
-          <div className="flex items-start justify-between gap-4 rounded-md border p-4">
-            <div className="space-y-1">
-              <div className="flex items-center gap-2">
+          <Flex align="start" justify="between" gap="4" className="rounded-md border p-4">
+            <Stack gap="1">
+              <Flex align="center" gap="2">
                 <Wand2 className="h-4 w-4 text-muted-foreground" />
-                <span className="font-medium">{t("transitionsLabel")}</span>
-              </div>
-              <p className="text-sm text-muted-foreground">{t("transitionsDescription")}</p>
-              <p className="text-xs text-muted-foreground flex items-start gap-1.5 pt-1">
+                <Text as="span" weight="medium">
+                  {t("transitionsLabel")}
+                </Text>
+              </Flex>
+              <Text tone="muted">{t("transitionsDescription")}</Text>
+              <Flex align="start" gap="1.5" className="text-xs text-muted-foreground pt-1">
                 <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-                <span>{t("transitionsWarning")}</span>
-              </p>
+                <Text as="span" size="xs" tone="muted">
+                  {t("transitionsWarning")}
+                </Text>
+              </Flex>
               {transitionsEnabled && (
-                <a
+                <TextLink
                   href="/transitions"
-                  className="text-xs text-primary inline-flex items-center gap-1 pt-1 hover:underline"
+                  className="text-xs text-primary inline-flex items-center gap-1 pt-1 no-underline hover:underline"
                 >
                   <ExternalLink className="h-3 w-3" />
                   {t("transitionsLabLink")}
-                </a>
+                </TextLink>
               )}
-            </div>
+            </Stack>
             <Switch
               checked={transitionsEnabled}
               disabled={transitionsMutation.isPending}
               onCheckedChange={(checked) => transitionsMutation.mutate(checked)}
               aria-label={t("transitionsLabel")}
             />
-          </div>
+          </Flex>
         </CardContent>
       </Card>
 
@@ -209,7 +221,9 @@ export function BetaSettings() {
                 <>
                   <br />
                   <br />
-                  <span className="text-muted-foreground">{t("restartManualHint")}</span>
+                  <Text as="span" tone="muted">
+                    {t("restartManualHint")}
+                  </Text>
                 </>
               )}
             </DialogDescription>

--- a/web/src/components/settings/board-settings.tsx
+++ b/web/src/components/settings/board-settings.tsx
@@ -2,13 +2,19 @@
 
 import {
   Badge,
+  Box,
   Button,
   Card,
   CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
+  Flex,
+  Grid,
   Skeleton,
+  Stack,
+  Text,
+  TextLink,
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -167,12 +173,12 @@ export function BoardSettings() {
   return (
     <Card>
       <CardHeader>
-        <div className="flex items-start justify-between">
-          <div className="flex items-center gap-3">
-            <div className="p-2 rounded-md bg-primary/10">
+        <Flex align="start" justify="between">
+          <Flex align="center" gap="3">
+            <Box className="p-2 rounded-md bg-primary/10">
               <Monitor className="h-5 w-5 text-primary" />
-            </div>
-            <div>
+            </Box>
+            <Box>
               <CardTitle className="text-base flex items-center gap-2">
                 {t("connection")}
                 {isConfigValid ? (
@@ -188,25 +194,27 @@ export function BoardSettings() {
                 )}
               </CardTitle>
               <CardDescription className="text-xs mt-0.5">{t("configureDescription")}</CardDescription>
-            </div>
-          </div>
-        </div>
+            </Box>
+          </Flex>
+        </Flex>
       </CardHeader>
 
       <CardContent className="space-y-4">
         <TooltipProvider>
           {/* API Mode */}
-          <div className="space-y-1.5">
+          <Stack gap="1.5">
             <label className="text-xs font-medium">{t("connectionMode")}</label>
-            <div className="grid grid-cols-2 gap-2">
+            <Grid cols="2" gap="2">
               <button
                 onClick={() => handleChange("api_mode", "local")}
                 className={`p-3 rounded-md border text-left transition-colors ${
                   apiMode === "local" ? "border-primary bg-primary/10" : "border-muted hover:border-primary/50"
                 }`}
               >
-                <div className="text-sm font-medium">{t("localApi")}</div>
-                <div className="text-xs text-muted-foreground">{t("localApiDescription")}</div>
+                <Text weight="medium">{t("localApi")}</Text>
+                <Text size="xs" tone="muted">
+                  {t("localApiDescription")}
+                </Text>
               </button>
               <button
                 onClick={() => handleChange("api_mode", "cloud")}
@@ -214,21 +222,26 @@ export function BoardSettings() {
                   apiMode === "cloud" ? "border-primary bg-primary/10" : "border-muted hover:border-primary/50"
                 }`}
               >
-                <div className="text-sm font-medium">{t("cloudApi")}</div>
-                <div className="text-xs text-muted-foreground">{t("cloudApiDescription")}</div>
+                <Text weight="medium">{t("cloudApi")}</Text>
+                <Text size="xs" tone="muted">
+                  {t("cloudApiDescription")}
+                </Text>
               </button>
-            </div>
-          </div>
+            </Grid>
+          </Stack>
 
           {/* Local API Fields */}
           {apiMode === "local" && (
             <>
               {/* Board Host - always needed for local */}
-              <div className="space-y-1.5">
+              <Stack gap="1.5">
                 <label className="text-xs font-medium">
-                  {t("boardHost")} <span className="text-destructive">*</span>
+                  {t("boardHost")}{" "}
+                  <Text as="span" size="xs" tone="destructive">
+                    *
+                  </Text>
                 </label>
-                <div className="flex gap-2">
+                <Flex gap="2">
                   <input
                     type="text"
                     value={formData.host ?? ""}
@@ -252,15 +265,17 @@ export function BoardSettings() {
                       <Search className="h-3.5 w-3.5" />
                     )}
                   </Button>
-                </div>
-                <p className="text-xs text-muted-foreground">{t("boardHostHint")}</p>
-              </div>
+                </Flex>
+                <Text size="xs" tone="muted">
+                  {t("boardHostHint")}
+                </Text>
+              </Stack>
 
               {/* Scan results */}
               {scanStatus === "done" && discoveredBoards.length >= 1 && (
-                <div className="space-y-1.5">
+                <Stack gap="1.5">
                   <label className="text-xs font-medium">{t("foundBoards", { count: discoveredBoards.length })}</label>
-                  <div className="space-y-1">
+                  <Stack gap="1">
                     {discoveredBoards.map((board) => (
                       <button
                         key={board.ip}
@@ -274,18 +289,24 @@ export function BoardSettings() {
                             : "border-muted hover:border-primary/50"
                         }`}
                       >
-                        <span className="font-mono">{board.ip}</span>
-                        {board.hostname && <span className="text-muted-foreground">{board.hostname}</span>}
+                        <Text as="span" size="xs" className="font-mono">
+                          {board.ip}
+                        </Text>
+                        {board.hostname && (
+                          <Text as="span" size="xs" tone="muted">
+                            {board.hostname}
+                          </Text>
+                        )}
                       </button>
                     ))}
-                  </div>
-                </div>
+                  </Stack>
+                </Stack>
               )}
 
               {/* Local Key Mode Toggle */}
-              <div className="space-y-1.5">
+              <Stack gap="1.5">
                 <label className="text-xs font-medium">{t("authMethod")}</label>
-                <div className="grid grid-cols-2 gap-2">
+                <Grid cols="2" gap="2">
                   <button
                     type="button"
                     onClick={() => setLocalKeyMode("api_key")}
@@ -296,7 +317,9 @@ export function BoardSettings() {
                     }`}
                   >
                     <Key className="h-3.5 w-3.5" />
-                    <span>{t("apiKey")}</span>
+                    <Text as="span" size="xs">
+                      {t("apiKey")}
+                    </Text>
                   </button>
                   <button
                     type="button"
@@ -308,17 +331,22 @@ export function BoardSettings() {
                     }`}
                   >
                     <KeyRound className="h-3.5 w-3.5" />
-                    <span>{t("enablementToken")}</span>
+                    <Text as="span" size="xs">
+                      {t("enablementToken")}
+                    </Text>
                   </button>
-                </div>
-              </div>
+                </Grid>
+              </Stack>
 
               {localKeyMode === "api_key" ? (
-                <div className="space-y-1.5">
+                <Stack gap="1.5">
                   <label className="text-xs font-medium">
-                    {t("localApiKey")} <span className="text-destructive">*</span>
+                    {t("localApiKey")}{" "}
+                    <Text as="span" size="xs" tone="destructive">
+                      *
+                    </Text>
                   </label>
-                  <div className="flex gap-2">
+                  <Flex gap="2">
                     <input
                       type={showSecrets.local_api_key ? "text" : "password"}
                       value={formData.local_api_key === "***" ? "" : (formData.local_api_key ?? "")}
@@ -346,30 +374,30 @@ export function BoardSettings() {
                         </Button>
                       </TooltipTrigger>
                       <TooltipContent>
-                        <p>{formData.local_api_key === "***" ? t("cannotReveal") : t("toggleVisibility")}</p>
+                        <Text>{formData.local_api_key === "***" ? t("cannotReveal") : t("toggleVisibility")}</Text>
                       </TooltipContent>
                     </Tooltip>
-                  </div>
-                  <p className="text-xs text-muted-foreground">
+                  </Flex>
+                  <Text size="xs" tone="muted">
                     {t.rich("localApiSetupGuideHint", {
                       link: (chunks) => (
-                        <a
+                        <TextLink
                           href="https://fiestaboard.app/docs/setup/api-keys"
                           target="_blank"
                           rel="noopener noreferrer"
                           className="underline"
                         >
                           {chunks}
-                        </a>
+                        </TextLink>
                       ),
                     })}
-                  </p>
-                </div>
+                  </Text>
+                </Stack>
               ) : (
-                <div className="space-y-2">
-                  <div className="space-y-1.5">
+                <Stack gap="2">
+                  <Stack gap="1.5">
                     <label className="text-xs font-medium">{t("enablementToken")}</label>
-                    <div className="flex gap-2">
+                    <Flex gap="2">
                       <input
                         type={showSecrets.enablement_token ? "text" : "password"}
                         value={enablementToken}
@@ -392,22 +420,22 @@ export function BoardSettings() {
                       >
                         {showSecrets.enablement_token ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
                       </Button>
-                    </div>
-                    <p className="text-xs text-muted-foreground">
+                    </Flex>
+                    <Text size="xs" tone="muted">
                       {t.rich("enablementTokenHint", {
                         link: (chunks) => (
-                          <a
+                          <TextLink
                             href="https://www.vestaboard.com/local-api"
                             target="_blank"
                             rel="noopener noreferrer"
                             className="underline"
                           >
                             {chunks}
-                          </a>
+                          </TextLink>
                         ),
                       })}
-                    </p>
-                  </div>
+                    </Text>
+                  </Stack>
                   <Button
                     type="button"
                     variant="secondary"
@@ -425,18 +453,21 @@ export function BoardSettings() {
                       t("getApiKey")
                     )}
                   </Button>
-                </div>
+                </Stack>
               )}
             </>
           )}
 
           {/* Cloud API Fields */}
           {apiMode === "cloud" && (
-            <div className="space-y-1.5">
+            <Stack gap="1.5">
               <label className="text-xs font-medium">
-                {t("readWriteApiKey")} <span className="text-destructive">*</span>
+                {t("readWriteApiKey")}{" "}
+                <Text as="span" size="xs" tone="destructive">
+                  *
+                </Text>
               </label>
-              <div className="flex gap-2">
+              <Flex gap="2">
                 <input
                   type={showSecrets.cloud_key ? "text" : "password"}
                   value={formData.cloud_key === "***" ? "" : (formData.cloud_key ?? "")}
@@ -464,28 +495,34 @@ export function BoardSettings() {
                     </Button>
                   </TooltipTrigger>
                   <TooltipContent>
-                    <p>{formData.cloud_key === "***" ? t("cannotReveal") : t("toggleVisibility")}</p>
+                    <Text>{formData.cloud_key === "***" ? t("cannotReveal") : t("toggleVisibility")}</Text>
                   </TooltipContent>
                 </Tooltip>
-              </div>
-              <p className="text-xs text-muted-foreground">{t("cloudKeyHint")}</p>
-            </div>
+              </Flex>
+              <Text size="xs" tone="muted">
+                {t("cloudKeyHint")}
+              </Text>
+            </Stack>
           )}
 
           {/* Validation message */}
           {!isConfigValid && (
-            <div className="flex items-center gap-2 p-2 rounded-md bg-destructive/10 text-foreground text-xs">
+            <Flex align="center" gap="2" className="p-2 rounded-md bg-destructive/10 text-foreground text-xs">
               <AlertCircle className="h-4 w-4" />
-              <span>{apiMode === "local" ? t("localApiRequired") : t("cloudApiRequired")}</span>
-            </div>
+              <Text as="span" size="xs">
+                {apiMode === "local" ? t("localApiRequired") : t("cloudApiRequired")}
+              </Text>
+            </Flex>
           )}
 
           {/* Auto-save indicator */}
           {updateMutation.isPending && (
-            <div className="flex items-center justify-center gap-2 pt-2 text-xs text-muted-foreground">
-              <div className="h-3 w-3 animate-spin rounded-full border-2 border-primary border-t-transparent" />
-              <span>{tCommon("saving")}</span>
-            </div>
+            <Flex align="center" justify="center" gap="2" className="pt-2 text-xs text-muted-foreground">
+              <Box className="h-3 w-3 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+              <Text as="span" size="xs" tone="muted">
+                {tCommon("saving")}
+              </Text>
+            </Flex>
           )}
         </TooltipProvider>
       </CardContent>

--- a/web/src/components/settings/debug-settings.tsx
+++ b/web/src/components/settings/debug-settings.tsx
@@ -2,18 +2,25 @@
 
 import {
   Badge,
+  Box,
   Button,
   Card,
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
+  Flex,
+  Grid,
   Label,
+  List,
+  ListItem,
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
   Skeleton,
+  Stack,
+  Text,
 } from "@fiestaboard/ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
@@ -196,28 +203,32 @@ export function DebugSettings() {
     <Collapsible open={open} onOpenChange={setOpen}>
       <Card>
         <CollapsibleTrigger className="flex w-full items-center justify-between px-6 py-4 text-left hover:bg-accent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset">
-          <div className="flex items-center gap-2">
+          <Flex align="center" gap="2">
             <Bug className="h-4 w-4 text-muted-foreground" />
-            <span className="text-base font-semibold">{t("title")}</span>
+            <Text as="span" size="base" weight="semibold">
+              {t("title")}
+            </Text>
             {!isBoardConfigured && (
               <Badge variant="destructive" className="text-xs">
                 <AlertCircle className="h-3 w-3 mr-1" />
                 {t("boardNotConfiguredTitle")}
               </Badge>
             )}
-          </div>
+          </Flex>
           <ChevronDown
             className={`h-5 w-5 text-muted-foreground transition-transform duration-200 ${open ? "rotate-180" : ""}`}
           />
         </CollapsibleTrigger>
 
         <CollapsibleContent>
-          <div className="px-6 pb-4 pt-1 space-y-4">
-            <p className="text-sm text-muted-foreground">{t("description")}</p>
-            <div className="space-y-4">
+          <Stack gap="4" className="px-6 pb-4 pt-1">
+            <Text tone="muted">{t("description")}</Text>
+            <Stack gap="4">
               {/* Network Diagnostics */}
-              <div className="space-y-2">
-                <p className="text-xs font-medium">{t("networkDiagnosticsLabel")}</p>
+              <Stack gap="2">
+                <Text size="xs" weight="medium">
+                  {t("networkDiagnosticsLabel")}
+                </Text>
                 <Button
                   onClick={() => networkDiagnosticsMutation.mutate()}
                   disabled={isAnyMutationLoading}
@@ -232,14 +243,18 @@ export function DebugSettings() {
                   )}
                   {networkDiagnosticsMutation.isPending ? t("runningDiagnostics") : t("runNetworkDiagnostics")}
                 </Button>
-                <p className="text-xs text-muted-foreground">{t("diagnosticsDescription")}</p>
+                <Text size="xs" tone="muted">
+                  {t("diagnosticsDescription")}
+                </Text>
 
                 {/* Diagnostics Results */}
                 {networkDiagnosticsMutation.data && (
-                  <div className="space-y-2 mt-2">
+                  <Stack gap="2" className="mt-2">
                     {/* Overall Status Banner */}
-                    <div
-                      className={`flex items-center gap-2 text-sm font-medium p-2.5 rounded-md ${
+                    <Flex
+                      align="center"
+                      gap="2"
+                      className={`text-sm font-medium p-2.5 rounded-md ${
                         networkDiagnosticsMutation.data.overall_ok
                           ? "bg-success/10 text-success"
                           : "bg-destructive/10 text-foreground"
@@ -251,10 +266,10 @@ export function DebugSettings() {
                         <AlertCircle className="h-4 w-4 flex-shrink-0" />
                       )}
                       {networkDiagnosticsMutation.data.overall_ok ? t("allChecksPassed") : t("someChecksFailed")}
-                    </div>
+                    </Flex>
 
                     {/* Step-by-step results */}
-                    <div className="rounded-md border divide-y">
+                    <Box className="rounded-md border divide-y">
                       {/* DNS Check */}
                       <DiagnosticRow
                         icon={<Globe className="h-3.5 w-3.5" />}
@@ -287,37 +302,46 @@ export function DebugSettings() {
 
                       {/* Vestaboard Check */}
                       <VestaboardDiagnosticRow vestaboard={networkDiagnosticsMutation.data.vestaboard} />
-                    </div>
+                    </Box>
 
                     {/* Troubleshooting Recommendations */}
                     {networkDiagnosticsMutation.data.recommendations.length > 0 &&
                       !networkDiagnosticsMutation.data.overall_ok && (
-                        <div className="space-y-2">
-                          <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+                        <Stack gap="2">
+                          <Flex align="center" gap="1.5" className="text-xs font-medium text-muted-foreground">
                             <Lightbulb className="h-3.5 w-3.5" />
                             {t("troubleshooting")}
-                          </div>
+                          </Flex>
                           {networkDiagnosticsMutation.data.recommendations.map((rec, i) => (
-                            <div key={i} className="rounded-md border p-3 space-y-1.5 bg-muted/30">
-                              <div className="text-xs font-medium">{rec.summary}</div>
+                            <Stack key={i} gap="1.5" className="rounded-md border p-3 bg-muted/30">
+                              <Text size="xs" weight="medium">
+                                {rec.summary}
+                              </Text>
                               {rec.steps.length > 0 && (
-                                <ol className="text-xs text-muted-foreground space-y-1 list-decimal list-inside">
+                                <List
+                                  as="ol"
+                                  marker="decimal"
+                                  gap="1"
+                                  className="text-xs text-muted-foreground list-inside"
+                                >
                                   {rec.steps.map((step, j) => (
-                                    <li key={j}>{step}</li>
+                                    <ListItem key={j}>{step}</ListItem>
                                   ))}
-                                </ol>
+                                </List>
                               )}
-                            </div>
+                            </Stack>
                           ))}
-                        </div>
+                        </Stack>
                       )}
-                  </div>
+                  </Stack>
                 )}
-              </div>
+              </Stack>
 
               {/* Blank Board */}
-              <div className="space-y-2">
-                <p className="text-xs font-medium">{t("clearBoardLabel")}</p>
+              <Stack gap="2">
+                <Text size="xs" weight="medium">
+                  {t("clearBoardLabel")}
+                </Text>
                 <Button
                   onClick={() => blankMutation.mutate()}
                   disabled={!isBoardConfigured || isAnyMutationLoading}
@@ -332,15 +356,17 @@ export function DebugSettings() {
                   )}
                   {t("blankBoard")}
                 </Button>
-                <p className="text-xs text-muted-foreground">{t("blankBoardDescription")}</p>
-              </div>
+                <Text size="xs" tone="muted">
+                  {t("blankBoardDescription")}
+                </Text>
+              </Stack>
 
               {/* Fill Board with Character */}
-              <div className="space-y-2">
+              <Stack gap="2">
                 <Label htmlFor="fill-character" className="text-xs font-medium">
                   {t("fillWithCharacterLabel")}
                 </Label>
-                <div className="flex gap-2">
+                <Flex gap="2">
                   <Select
                     value={selectedCharacter.toString()}
                     onValueChange={(value) => setSelectedCharacter(parseInt(value))}
@@ -350,16 +376,16 @@ export function DebugSettings() {
                     </SelectTrigger>
                     <SelectContent className="max-h-80">
                       {Object.entries(CHARACTER_GROUPS).map(([group, chars]) => (
-                        <div key={group}>
-                          <div className="px-2 py-1.5 text-xs font-semibold text-muted-foreground">
+                        <Box key={group}>
+                          <Text weight="semibold" tone="muted" className="px-2 py-1.5 text-xs">
                             {t(`groups.${group}` as "groups.Letters")}
-                          </div>
+                          </Text>
                           {chars.map((char) => (
                             <SelectItem key={char.code} value={char.code.toString()} className="text-xs font-mono">
                               {char.display}
                             </SelectItem>
                           ))}
-                        </div>
+                        </Box>
                       ))}
                     </SelectContent>
                   </Select>
@@ -377,13 +403,17 @@ export function DebugSettings() {
                     )}
                     {t("fillButton")}
                   </Button>
-                </div>
-                <p className="text-xs text-muted-foreground">{t("fillBoardDescription")}</p>
-              </div>
+                </Flex>
+                <Text size="xs" tone="muted">
+                  {t("fillBoardDescription")}
+                </Text>
+              </Stack>
 
               {/* Show Debug Info */}
-              <div className="space-y-2">
-                <p className="text-xs font-medium">{t("displaySystemInfoLabel")}</p>
+              <Stack gap="2">
+                <Text size="xs" weight="medium">
+                  {t("displaySystemInfoLabel")}
+                </Text>
                 <Button
                   onClick={() => debugInfoMutation.mutate()}
                   disabled={!isBoardConfigured || isAnyMutationLoading}
@@ -398,12 +428,16 @@ export function DebugSettings() {
                   )}
                   Show Debug Info on Board
                 </Button>
-                <p className="text-xs text-muted-foreground">{t("showDebugInfoDescription")}</p>
-              </div>
+                <Text size="xs" tone="muted">
+                  {t("showDebugInfoDescription")}
+                </Text>
+              </Stack>
 
               {/* Clear Cache */}
-              <div className="space-y-2">
-                <p className="text-xs font-medium">{t("cacheManagementLabel")}</p>
+              <Stack gap="2">
+                <Text size="xs" weight="medium">
+                  {t("cacheManagementLabel")}
+                </Text>
                 <Button
                   onClick={() => clearCacheMutation.mutate()}
                   disabled={!isBoardConfigured || isAnyMutationLoading}
@@ -418,68 +452,98 @@ export function DebugSettings() {
                   )}
                   Clear Message Cache
                 </Button>
-                <p className="text-xs text-muted-foreground">{t("clearCacheDescription")}</p>
-              </div>
+                <Text size="xs" tone="muted">
+                  {t("clearCacheDescription")}
+                </Text>
+              </Stack>
 
               {/* System Info Collapsible */}
-              <div className="pt-2 border-t">
+              <Box className="pt-2 border-t">
                 <Collapsible open={showSystemInfo} onOpenChange={setShowSystemInfo}>
                   <CollapsibleTrigger asChild>
                     <Button variant="ghost" size="sm" className="w-full justify-between text-xs font-medium">
-                      <span>{t("systemInformation")}</span>
+                      <Text as="span" size="xs" weight="medium">
+                        {t("systemInformation")}
+                      </Text>
                       {showSystemInfo ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
                     </Button>
                   </CollapsibleTrigger>
                   <CollapsibleContent className="mt-3 space-y-3">
                     {isLoadingSystemInfo ? (
-                      <div className="space-y-2">
+                      <Stack gap="2">
                         <Skeleton className="h-4 w-full" />
                         <Skeleton className="h-4 w-full" />
                         <Skeleton className="h-4 w-full" />
-                      </div>
+                      </Stack>
                     ) : systemInfo ? (
-                      <div className="space-y-2 text-xs">
-                        <div className="grid grid-cols-2 gap-2 p-2 rounded bg-muted/50">
-                          <div className="font-medium text-muted-foreground">{t("boardIpLabel")}</div>
-                          <div className="font-mono">{systemInfo.board_ip || t("notSet")}</div>
+                      <Stack gap="2" className="text-xs">
+                        <Grid cols="2" gap="2" className="p-2 rounded bg-muted/50">
+                          <Text size="xs" weight="medium" tone="muted">
+                            {t("boardIpLabel")}
+                          </Text>
+                          <Text size="xs" className="font-mono">
+                            {systemInfo.board_ip || t("notSet")}
+                          </Text>
 
-                          <div className="font-medium text-muted-foreground">{t("serverIpLabel")}</div>
-                          <div className="font-mono">{systemInfo.server_ip}</div>
+                          <Text size="xs" weight="medium" tone="muted">
+                            {t("serverIpLabel")}
+                          </Text>
+                          <Text size="xs" className="font-mono">
+                            {systemInfo.server_ip}
+                          </Text>
 
-                          <div className="font-medium text-muted-foreground">{t("connectionLabel")}</div>
-                          <div className="font-mono">
+                          <Text size="xs" weight="medium" tone="muted">
+                            {t("connectionLabel")}
+                          </Text>
+                          <Text size="xs" className="font-mono">
                             {systemInfo.connection_mode.toUpperCase()} {t("apiSuffix")}
-                          </div>
+                          </Text>
 
-                          <div className="font-medium text-muted-foreground">{t("uptimeLabel")}</div>
-                          <div className="font-mono">{systemInfo.uptime_formatted}</div>
+                          <Text size="xs" weight="medium" tone="muted">
+                            {t("uptimeLabel")}
+                          </Text>
+                          <Text size="xs" className="font-mono">
+                            {systemInfo.uptime_formatted}
+                          </Text>
 
-                          <div className="font-medium text-muted-foreground">{t("versionLabel")}</div>
-                          <div className="font-mono">v{systemInfo.version}</div>
+                          <Text size="xs" weight="medium" tone="muted">
+                            {t("versionLabel")}
+                          </Text>
+                          <Text size="xs" className="font-mono">
+                            v{systemInfo.version}
+                          </Text>
 
-                          <div className="font-medium text-muted-foreground">{t("serviceLabel")}</div>
-                          <div className="flex items-center gap-1">
+                          <Text size="xs" weight="medium" tone="muted">
+                            {t("serviceLabel")}
+                          </Text>
+                          <Flex align="center" gap="1">
                             {systemInfo.service_running ? (
                               <>
-                                <div className="h-2 w-2 rounded-full bg-success" />
-                                <span>{t("serviceRunning")}</span>
+                                <Box className="h-2 w-2 rounded-full bg-success" />
+                                <Text as="span" size="xs">
+                                  {t("serviceRunning")}
+                                </Text>
                               </>
                             ) : (
                               <>
-                                <div className="h-2 w-2 rounded-full bg-destructive" />
-                                <span>{t("serviceStopped")}</span>
+                                <Box className="h-2 w-2 rounded-full bg-destructive" />
+                                <Text as="span" size="xs">
+                                  {t("serviceStopped")}
+                                </Text>
                               </>
                             )}
-                          </div>
-                        </div>
+                          </Flex>
+                        </Grid>
 
                         {/* Cache Status */}
                         {systemInfo.cache_status && (
-                          <div className="p-2 rounded bg-muted/50">
-                            <div className="font-medium text-muted-foreground mb-2">{t("cacheStatusLabel")}</div>
-                            <div className="space-y-1 ml-2">
-                              <div className="flex items-center gap-2">
-                                <div
+                          <Box className="p-2 rounded bg-muted/50">
+                            <Text size="xs" weight="medium" tone="muted" className="mb-2">
+                              {t("cacheStatusLabel")}
+                            </Text>
+                            <Stack gap="1" className="ml-2">
+                              <Flex align="center" gap="2">
+                                <Box
                                   className={`h-2 w-2 rounded-full ${
                                     systemInfo.cache_status.has_cached_text ||
                                     systemInfo.cache_status.has_cached_characters
@@ -487,53 +551,65 @@ export function DebugSettings() {
                                       : "bg-muted-foreground"
                                   }`}
                                 />
-                                <span>
+                                <Text as="span" size="xs">
                                   {systemInfo.cache_status.has_cached_text
                                     ? t("textCached")
                                     : systemInfo.cache_status.has_cached_characters
                                       ? "Characters cached"
                                       : t("noCache")}
-                                </span>
-                              </div>
-                              <div className="flex items-center gap-2">
-                                <span className="text-muted-foreground">{t("skipUnchanged")}</span>
-                                <span>
+                                </Text>
+                              </Flex>
+                              <Flex align="center" gap="2">
+                                <Text as="span" size="xs" tone="muted">
+                                  {t("skipUnchanged")}
+                                </Text>
+                                <Text as="span" size="xs">
                                   {systemInfo.cache_status.skip_unchanged_enabled ? tCommon("yes") : tCommon("no")}
-                                </span>
-                              </div>
+                                </Text>
+                              </Flex>
                               {systemInfo.cache_status.cached_text_preview && (
-                                <div className="mt-2">
-                                  <div className="text-muted-foreground">{t("cachePreviewLabel")}</div>
-                                  <div className="font-mono text-xs mt-1 p-1 bg-background rounded">
+                                <Box className="mt-2">
+                                  <Text size="xs" tone="muted">
+                                    {t("cachePreviewLabel")}
+                                  </Text>
+                                  <Text size="xs" className="font-mono mt-1 p-1 bg-background rounded">
                                     {systemInfo.cache_status.cached_text_preview}
-                                  </div>
-                                </div>
+                                  </Text>
+                                </Box>
                               )}
-                            </div>
-                          </div>
+                            </Stack>
+                          </Box>
                         )}
 
-                        <div className="text-xs text-muted-foreground text-center pt-1">{t("autoRefreshNote")}</div>
-                      </div>
+                        <Text size="xs" tone="muted" className="text-center pt-1">
+                          {t("autoRefreshNote")}
+                        </Text>
+                      </Stack>
                     ) : (
-                      <div className="text-xs text-center text-muted-foreground">{t("noSystemInfo")}</div>
+                      <Text size="xs" tone="muted" className="text-center">
+                        {t("noSystemInfo")}
+                      </Text>
                     )}
                   </CollapsibleContent>
                 </Collapsible>
-              </div>
+              </Box>
 
               {/* Warning message if not configured */}
               {!isBoardConfigured && (
-                <div className="flex items-start gap-2 p-2 rounded-md bg-muted text-foreground text-xs">
+                <Flex align="start" gap="2" className="p-2 rounded-md bg-muted text-foreground text-xs">
                   <Info className="h-4 w-4 mt-0.5 flex-shrink-0" />
-                  <div>
-                    <div className="font-medium">{t("boardNotConfiguredTitle")}</div>
-                    <div className="text-xs mt-0.5">{t("boardNotConfiguredDescription")}</div>
-                  </div>
-                </div>
+                  <Box>
+                    <Text size="xs" weight="medium">
+                      {t("boardNotConfiguredTitle")}
+                    </Text>
+                    <Text size="xs" className="mt-0.5">
+                      {t("boardNotConfiguredDescription")}
+                    </Text>
+                  </Box>
+                </Flex>
               )}
-            </div>
-          </div>
+            </Stack>
+          </Stack>
         </CollapsibleContent>
       </Card>
     </Collapsible>
@@ -564,10 +640,10 @@ function DiagnosticRow({
   detail: string;
 }) {
   return (
-    <div className="flex items-start gap-2 p-2.5 text-xs">
+    <Flex align="start" gap="2" className="p-2.5 text-xs">
       <DiagnosticStatusIcon ok={result.ok} />
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-1.5 font-medium">
+      <Box className="min-w-0 flex-1">
+        <Flex align="center" gap="1.5" className="font-medium">
           {icon}
           {label}
           {result.latency_ms != null && (
@@ -575,10 +651,12 @@ function DiagnosticRow({
               {result.latency_ms}ms
             </Badge>
           )}
-        </div>
-        <div className={`mt-0.5 ${result.ok ? "text-muted-foreground" : "text-destructive"}`}>{detail}</div>
-      </div>
-    </div>
+        </Flex>
+        <Text size="xs" tone={result.ok ? "muted" : "destructive"} className="mt-0.5">
+          {detail}
+        </Text>
+      </Box>
+    </Flex>
   );
 }
 
@@ -605,26 +683,28 @@ function VestaboardDiagnosticRow({
   const t = useTranslations("debugSettings");
   if (vestaboard.mode === null) {
     return (
-      <div className="flex items-start gap-2 p-2.5 text-xs">
+      <Flex align="start" gap="2" className="p-2.5 text-xs">
         <AlertCircle className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-1.5 font-medium">
+        <Box className="min-w-0 flex-1">
+          <Flex align="center" gap="1.5" className="font-medium">
             <Server className="h-3.5 w-3.5" />
             {t("vestaboardLabel")}
-          </div>
-          <div className="mt-0.5 text-muted-foreground">{vestaboard.error ?? t("noBoardConfigured")}</div>
-        </div>
-      </div>
+          </Flex>
+          <Text size="xs" tone="muted" className="mt-0.5">
+            {vestaboard.error ?? t("noBoardConfigured")}
+          </Text>
+        </Box>
+      </Flex>
     );
   }
 
   if (vestaboard.mode === "cloud") {
     const cloud = vestaboard.steps.cloud_api;
     return (
-      <div className="flex items-start gap-2 p-2.5 text-xs">
+      <Flex align="start" gap="2" className="p-2.5 text-xs">
         <DiagnosticStatusIcon ok={vestaboard.ok} />
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-1.5 font-medium">
+        <Box className="min-w-0 flex-1">
+          <Flex align="center" gap="1.5" className="font-medium">
             <Server className="h-3.5 w-3.5" />
             {t("vestaboardCloudApiLabel")}
             {cloud?.latency_ms != null && (
@@ -632,14 +712,14 @@ function VestaboardDiagnosticRow({
                 {cloud.latency_ms}ms
               </Badge>
             )}
-          </div>
-          <div className={`mt-0.5 ${vestaboard.ok ? "text-muted-foreground" : "text-destructive"}`}>
+          </Flex>
+          <Text size="xs" tone={vestaboard.ok ? "muted" : "destructive"} className="mt-0.5">
             {vestaboard.ok
               ? t("cloudApiReachable") + (cloud?.status_code ? ` (HTTP ${cloud.status_code})` : "")
               : (cloud?.error ?? (cloud?.status_code ? `HTTP ${cloud.status_code}` : t("cloudApiUnreachable")))}
-          </div>
-        </div>
-      </div>
+          </Text>
+        </Box>
+      </Flex>
     );
   }
 
@@ -652,55 +732,61 @@ function VestaboardDiagnosticRow({
   ];
 
   return (
-    <div className="p-2.5 text-xs space-y-1.5">
-      <div className="flex items-center gap-2">
+    <Stack gap="1.5" className="p-2.5 text-xs">
+      <Flex align="center" gap="2">
         <DiagnosticStatusIcon ok={vestaboard.ok} />
-        <div className="flex items-center gap-1.5 font-medium">
+        <Flex align="center" gap="1.5" className="font-medium">
           <Server className="h-3.5 w-3.5" />
           {t("vestaboardLocalApiLabel")}
-        </div>
-      </div>
-      <div className="space-y-1 pl-1 border-l-2 border-muted ml-[11px]">
+        </Flex>
+      </Flex>
+      <Stack gap="1" className="pl-1 border-l-2 border-muted ml-[11px]">
         {stepEntries.map(({ key, label, icon }) => {
           const step = steps[key];
           if (!step) {
             // Step wasn't reached (short-circuited)
             return (
-              <div key={key} className="flex items-center gap-1.5 pl-2 py-0.5 text-muted-foreground">
-                <div className="h-3 w-3 rounded-full border border-muted-foreground/30 flex-shrink-0" />
+              <Flex key={key} align="center" gap="1.5" className="pl-2 py-0.5 text-muted-foreground">
+                <Box className="h-3 w-3 rounded-full border border-muted-foreground/30 flex-shrink-0" />
                 {icon}
-                <span>{label}</span>
-                <span className="text-muted-foreground">— {t("skipped")}</span>
-              </div>
+                <Text as="span" size="xs" tone="muted">
+                  {label}
+                </Text>
+                <Text as="span" size="xs" tone="muted">
+                  — {t("skipped")}
+                </Text>
+              </Flex>
             );
           }
           return (
-            <div key={key} className="flex items-start gap-1.5 pl-2 py-0.5">
+            <Flex key={key} align="start" gap="1.5" className="pl-2 py-0.5">
               <DiagnosticStatusIcon ok={step.ok} />
               {icon}
-              <div className="min-w-0">
-                <span className="font-medium">{label}</span>
+              <Box className="min-w-0">
+                <Text as="span" size="xs" weight="medium">
+                  {label}
+                </Text>
                 {step.latency_ms != null && (
                   <Badge variant="secondary" className="ml-1 text-[10px] px-1 py-0 h-3.5 font-mono">
                     {step.latency_ms}ms
                   </Badge>
                 )}
                 {step.ok ? (
-                  <span className="text-muted-foreground ml-1">
+                  <Text as="span" size="xs" tone="muted" className="ml-1">
                     {key === "dns" && step.hostname ? t("hostnameResolved", { hostname: step.hostname }) : ""}
                     {key === "port" && step.port ? t("portOpen", { port: step.port }) : ""}
                     {key === "api" && step.status_code ? `HTTP ${step.status_code}` : ""}
-                  </span>
+                  </Text>
                 ) : (
-                  <span className="text-destructive ml-1">
+                  <Text as="span" size="xs" tone="destructive" className="ml-1">
                     {step.error ?? (step.status_code ? `HTTP ${step.status_code}` : t("failed"))}
-                  </span>
+                  </Text>
                 )}
-              </div>
-            </div>
+              </Box>
+            </Flex>
           );
         })}
-      </div>
-    </div>
+      </Stack>
+    </Stack>
   );
 }

--- a/web/src/components/settings/display-settings.tsx
+++ b/web/src/components/settings/display-settings.tsx
@@ -2,6 +2,7 @@
 
 import {
   Badge as BadgeUI,
+  Box,
   Button,
   Card,
   CardContent,
@@ -11,6 +12,8 @@ import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
+  Flex,
+  Grid,
   Label,
   Select,
   SelectContent,
@@ -20,7 +23,10 @@ import {
   SelectTrigger,
   SelectValue,
   Skeleton,
+  Stack,
   Switch,
+  Text,
+  TextLink,
 } from "@fiestaboard/ui";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
@@ -142,8 +148,8 @@ function BoardConnectionForm({
   };
 
   return (
-    <div className="space-y-3">
-      <div className="flex items-center justify-between">
+    <Stack gap="3">
+      <Flex align="center" justify="between">
         <Label className="text-xs font-medium">{t("connectionLabel")}</Label>
         {isConfigured ? (
           <BadgeUI variant="default" className="text-[10px] h-5 bg-board-green">
@@ -156,10 +162,10 @@ function BoardConnectionForm({
             {t("notConfigured")}
           </BadgeUI>
         )}
-      </div>
+      </Flex>
 
       {/* API Mode */}
-      <div className="grid grid-cols-2 gap-2">
+      <Grid cols="2" gap="2">
         <button
           onClick={() => onUpdate(board.id, { api_mode: "local" })}
           aria-pressed={apiMode === "local"}
@@ -167,8 +173,12 @@ function BoardConnectionForm({
             apiMode === "local" ? "border-primary bg-primary/10" : "border-muted hover:border-primary/50"
           }`}
         >
-          <div className="text-xs font-medium">{t("localApiLabel")}</div>
-          <div className="text-[10px] text-muted-foreground">{t("localApiDescription")}</div>
+          <Text size="xs" weight="medium">
+            {t("localApiLabel")}
+          </Text>
+          <Text tone="muted" className="text-[10px]">
+            {t("localApiDescription")}
+          </Text>
         </button>
         <button
           onClick={() => onUpdate(board.id, { api_mode: "cloud" })}
@@ -177,10 +187,14 @@ function BoardConnectionForm({
             apiMode === "cloud" ? "border-primary bg-primary/10" : "border-muted hover:border-primary/50"
           }`}
         >
-          <div className="text-xs font-medium">{t("cloudApiLabel")}</div>
-          <div className="text-[10px] text-muted-foreground">{t("cloudApiDescription")}</div>
+          <Text size="xs" weight="medium">
+            {t("cloudApiLabel")}
+          </Text>
+          <Text tone="muted" className="text-[10px]">
+            {t("cloudApiDescription")}
+          </Text>
         </button>
-      </div>
+      </Grid>
 
       {/* Local array mode: per-tile assignment grid instead of host/key fields */}
       {isArray && apiMode === "local" && <TileGridAssignment board={board} onUpdate={onUpdate} />}
@@ -188,9 +202,12 @@ function BoardConnectionForm({
       {/* Local API Fields (single boards) */}
       {apiMode === "local" && !isArray && (
         <>
-          <div className="space-y-1">
+          <Stack gap="1">
             <label className="text-xs font-medium">
-              {t("boardHostLabel")} <span className="text-destructive">*</span>
+              {t("boardHostLabel")}{" "}
+              <Text as="span" size="xs" tone="destructive">
+                *
+              </Text>
             </label>
             <input
               type="text"
@@ -203,10 +220,10 @@ function BoardConnectionForm({
               placeholder={t("boardHostPlaceholder")}
               className="w-full h-8 px-2 text-xs rounded-md border bg-background font-mono"
             />
-          </div>
+          </Stack>
 
           {/* Auth method toggle */}
-          <div className="grid grid-cols-2 gap-2">
+          <Grid cols="2" gap="2">
             <button
               type="button"
               onClick={() => setLocalKeyMode("api_key")}
@@ -231,14 +248,17 @@ function BoardConnectionForm({
               <KeyRound className="h-3 w-3" />
               {t("enablementTokenLabel")}
             </button>
-          </div>
+          </Grid>
 
           {localKeyMode === "api_key" ? (
-            <div className="space-y-1">
+            <Stack gap="1">
               <label className="text-xs font-medium">
-                {t("localApiKeyLabel")} <span className="text-destructive">*</span>
+                {t("localApiKeyLabel")}{" "}
+                <Text as="span" size="xs" tone="destructive">
+                  *
+                </Text>
               </label>
-              <div className="flex gap-1.5">
+              <Flex gap="1.5">
                 <input
                   type={showSecrets.local_api_key ? "text" : "password"}
                   defaultValue={board.local_api_key === "***" ? "" : (board.local_api_key ?? "")}
@@ -262,26 +282,26 @@ function BoardConnectionForm({
                 >
                   {showSecrets.local_api_key ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
                 </Button>
-              </div>
-              <p className="text-[10px] text-muted-foreground">
+              </Flex>
+              <Text tone="muted" className="text-[10px]">
                 {t.rich("localApiKeyHelp", {
                   link: (chunks) => (
-                    <a
+                    <TextLink
                       href="https://fiestaboard.app/docs/setup/api-keys"
                       target="_blank"
                       rel="noopener noreferrer"
                       className="underline"
                     >
                       {chunks}
-                    </a>
+                    </TextLink>
                   ),
                 })}
-              </p>
-            </div>
+              </Text>
+            </Stack>
           ) : (
-            <div className="space-y-1.5">
+            <Stack gap="1.5">
               <label className="text-xs font-medium">{t("enablementTokenLabel")}</label>
-              <div className="flex gap-1.5">
+              <Flex gap="1.5">
                 <input
                   type={showSecrets.enablement_token ? "text" : "password"}
                   value={enablementToken}
@@ -299,7 +319,7 @@ function BoardConnectionForm({
                 >
                   {showSecrets.enablement_token ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
                 </Button>
-              </div>
+              </Flex>
               <Button
                 type="button"
                 variant="secondary"
@@ -317,18 +337,21 @@ function BoardConnectionForm({
                   t("getApiKeyFromBoard")
                 )}
               </Button>
-            </div>
+            </Stack>
           )}
         </>
       )}
 
       {/* Cloud API Fields (single boards — arrays use the token below) */}
       {apiMode === "cloud" && !isArray && (
-        <div className="space-y-1">
+        <Stack gap="1">
           <label className="text-xs font-medium">
-            {t("cloudKeyLabel")} <span className="text-destructive">*</span>
+            {t("cloudKeyLabel")}{" "}
+            <Text as="span" size="xs" tone="destructive">
+              *
+            </Text>
           </label>
-          <div className="flex gap-1.5">
+          <Flex gap="1.5">
             <input
               type={showSecrets.cloud_key ? "text" : "password"}
               defaultValue={board.cloud_key === "***" ? "" : (board.cloud_key ?? "")}
@@ -352,18 +375,20 @@ function BoardConnectionForm({
             >
               {showSecrets.cloud_key ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
             </Button>
-          </div>
-          <p className="text-[10px] text-muted-foreground">{t("cloudKeyHelp")}</p>
-        </div>
+          </Flex>
+          <Text tone="muted" className="text-[10px]">
+            {t("cloudKeyHelp")}
+          </Text>
+        </Stack>
       )}
 
       {/* Note-array Cloud API token (X-Vestaboard-Token) */}
       {isArray && apiMode === "cloud" && (
-        <div className="space-y-1">
+        <Stack gap="1">
           <label className="text-xs font-medium" htmlFor={`note-array-token-${board.id}`}>
             {t("noteArrayTokenLabel")}
           </label>
-          <div className="flex gap-1.5">
+          <Flex gap="1.5">
             <input
               id={`note-array-token-${board.id}`}
               type={showSecrets.note_array_token ? "text" : "password"}
@@ -388,16 +413,18 @@ function BoardConnectionForm({
             >
               {showSecrets.note_array_token ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
             </Button>
-          </div>
-          <p className="text-[10px] text-muted-foreground">{t("noteArrayTokenHelp")}</p>
-        </div>
+          </Flex>
+          <Text tone="muted" className="text-[10px]">
+            {t("noteArrayTokenHelp")}
+          </Text>
+        </Stack>
       )}
 
       {/* Validation message */}
       {!isConfigured && (
-        <div className="flex items-center gap-1.5 p-1.5 rounded-md bg-destructive/10 text-foreground text-[10px]">
+        <Flex align="center" gap="1.5" className="p-1.5 rounded-md bg-destructive/10 text-foreground text-[10px]">
           <AlertCircle className="h-3 w-3 flex-shrink-0" />
-          <span>
+          <Text as="span" className="text-[10px]">
             {isArray
               ? apiMode === "local"
                 ? t("tileGrid.assignRequired")
@@ -405,10 +432,10 @@ function BoardConnectionForm({
               : apiMode === "local"
                 ? t("localApiRequired")
                 : t("cloudApiRequired")}
-          </span>
-        </div>
+          </Text>
+        </Flex>
       )}
-    </div>
+    </Stack>
   );
 }
 
@@ -610,7 +637,7 @@ export function DisplaySettings() {
         <CardDescription>{t("description")}</CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="space-y-3">
+        <Stack gap="3">
           {boards.map((board) => {
             const isPaused = board.paused === true;
             const apiMode = board.api_mode ?? "local";
@@ -633,22 +660,30 @@ export function DisplaySettings() {
                 className={`rounded-lg border overflow-hidden ${isPaused ? "border-amber-500/60 bg-amber-500/5" : ""}`}
               >
                 <CollapsibleTrigger className="flex items-center gap-3 p-3 w-full text-left hover:bg-muted/40 transition-colors [&[data-state=open]>div:first-child>svg:first-child]:hidden [&[data-state=closed]>div:first-child>svg:last-child]:hidden">
-                  <div className="flex-shrink-0 text-muted-foreground">
+                  <Box className="flex-shrink-0 text-muted-foreground">
                     <ChevronRight className="h-4 w-4" />
                     <ChevronDown className="h-4 w-4" />
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <div className="text-sm font-medium truncate">{board.name || t("unnamedBoard")}</div>
-                    <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                      <span className="capitalize">{board.device_type}</span>
-                      <span>•</span>
+                  </Box>
+                  <Box className="flex-1 min-w-0">
+                    <Text weight="medium" className="truncate">
+                      {board.name || t("unnamedBoard")}
+                    </Text>
+                    <Flex align="center" gap="2" className="text-xs text-muted-foreground">
+                      <Text as="span" size="xs" className="capitalize">
+                        {board.device_type}
+                      </Text>
+                      <Text as="span" size="xs" tone="muted">
+                        •
+                      </Text>
                       <BoardSizeIndicator
                         deviceType={board.device_type}
                         notesWide={board.notes_wide}
                         notesTall={board.notes_tall}
                       />
-                      <span>•</span>
-                      <div
+                      <Text as="span" size="xs" tone="muted">
+                        •
+                      </Text>
+                      <Box
                         className="h-3 w-3 rounded border"
                         style={{
                           backgroundColor:
@@ -657,9 +692,9 @@ export function DisplaySettings() {
                               : "var(--color-board-surface-dark)",
                         }}
                       />
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-1.5 flex-shrink-0">
+                    </Flex>
+                  </Box>
+                  <Flex align="center" gap="1.5" className="flex-shrink-0">
                     {isPaused && (
                       <BadgeUI
                         variant="default"
@@ -682,43 +717,49 @@ export function DisplaySettings() {
                         {t("notConfigured")}
                       </BadgeUI>
                     )}
-                  </div>
+                  </Flex>
                 </CollapsibleTrigger>
 
                 <CollapsibleContent>
-                  <div className="border-t px-4 pb-4 pt-3 space-y-3">
+                  <Stack gap="3" className="border-t px-4 pb-4 pt-3">
                     {/* Pause / Resume row (issue #970) */}
-                    <div
-                      className={`flex items-center justify-between rounded-md border px-3 py-2 ${
+                    <Flex
+                      align="center"
+                      justify="between"
+                      className={`rounded-md border px-3 py-2 ${
                         isPaused ? "border-amber-500/60 bg-amber-500/10" : "border-transparent bg-muted/30"
                       }`}
                     >
-                      <div className="flex items-start gap-2 min-w-0">
+                      <Flex align="start" gap="2" className="min-w-0">
                         <Pause
                           className={`h-3.5 w-3.5 mt-0.5 flex-shrink-0 ${
                             isPaused ? "text-amber-600" : "text-muted-foreground"
                           }`}
                         />
-                        <div className="min-w-0">
-                          <div className="text-xs font-medium">
+                        <Box className="min-w-0">
+                          <Text size="xs" weight="medium">
                             {isPaused ? t("pause.resumeToggle") : t("pause.toggle")}
-                          </div>
-                          <div className="text-[11px] text-muted-foreground">{t("pause.tooltip")}</div>
-                        </div>
-                      </div>
+                          </Text>
+                          <Text tone="muted" className="text-[11px]">
+                            {t("pause.tooltip")}
+                          </Text>
+                        </Box>
+                      </Flex>
                       <Switch
                         checked={isPaused}
                         onCheckedChange={(checked) => handleTogglePaused(board.id, checked)}
                         aria-label={isPaused ? t("pause.resumeToggle") : t("pause.toggle")}
                         data-testid="board-pause-switch"
                       />
-                    </div>
+                    </Flex>
 
                     {/* Type + Color row */}
-                    <div className="space-y-2">
-                      <div className="flex items-center gap-4 flex-wrap">
-                        <div className="flex items-center gap-2">
-                          <span className="text-[11px] text-muted-foreground">{t("typeLabel")}</span>
+                    <Stack gap="2">
+                      <Flex align="center" gap="4" wrap>
+                        <Flex align="center" gap="2">
+                          <Text as="span" tone="muted" className="text-[11px]">
+                            {t("typeLabel")}
+                          </Text>
                           <Select value={currentConfigValue(board)} onValueChange={(v) => handleConfigChange(board, v)}>
                             <SelectTrigger className="h-7 w-[200px] text-xs" aria-label={t("deviceTypeAriaLabel")}>
                               <SelectValue />
@@ -740,10 +781,12 @@ export function DisplaySettings() {
                               </SelectGroup>
                             </SelectContent>
                           </Select>
-                        </div>
-                        <div className="flex items-center gap-2">
-                          <span className="text-[11px] text-muted-foreground">{t("colorLabel")}</span>
-                          <div className="flex gap-2">
+                        </Flex>
+                        <Flex align="center" gap="2">
+                          <Text as="span" tone="muted" className="text-[11px]">
+                            {t("colorLabel")}
+                          </Text>
+                          <Flex gap="2">
                             <button
                               onClick={() => handleUpdateBoard(board.id, { board_color: "black" })}
                               aria-label={t("blackAriaLabel")}
@@ -764,14 +807,14 @@ export function DisplaySettings() {
                                   : "border-border hover:border-muted-foreground"
                               }`}
                             />
-                          </div>
-                        </div>
-                      </div>
+                          </Flex>
+                        </Flex>
+                      </Flex>
 
                       {/* Custom W×H inputs (note arrays only) */}
                       {(customOpen[board.id] || currentConfigValue(board) === "custom") && (
-                        <div className="space-y-1">
-                          <div className="flex items-end gap-2">
+                        <Stack gap="1">
+                          <Flex align="end" gap="2">
                             <label className="flex flex-col gap-1 text-[11px] text-muted-foreground">
                               {t("notesWideLabel")}
                               <input
@@ -783,7 +826,9 @@ export function DisplaySettings() {
                                 className="h-8 w-16 px-2 text-xs rounded-md border bg-background"
                               />
                             </label>
-                            <span className="pb-1.5 text-xs text-muted-foreground">×</span>
+                            <Text as="span" size="xs" tone="muted" className="pb-1.5">
+                              ×
+                            </Text>
                             <label className="flex flex-col gap-1 text-[11px] text-muted-foreground">
                               {t("notesTallLabel")}
                               <input
@@ -795,13 +840,13 @@ export function DisplaySettings() {
                                 className="h-8 w-16 px-2 text-xs rounded-md border bg-background"
                               />
                             </label>
-                          </div>
+                          </Flex>
                           {dimError[board.id] && (
-                            <p role="alert" className="text-[10px] text-destructive">
+                            <Text role="alert" tone="destructive" className="text-[10px]">
                               {dimError[board.id]}
-                            </p>
+                            </Text>
                           )}
-                        </div>
+                        </Stack>
                       )}
 
                       {/* Auto-detect from board — not offered for local-mode
@@ -810,7 +855,7 @@ export function DisplaySettings() {
                           Detection is meaningful via the Cloud API (which
                           knows the array's real shape) and for single boards. */}
                       {!(isNoteArray(board.device_type) && (board.api_mode ?? "cloud") === "local") && (
-                        <div className="space-y-1">
+                        <Stack gap="1">
                           <Button
                             type="button"
                             variant="secondary"
@@ -829,22 +874,24 @@ export function DisplaySettings() {
                             )}
                           </Button>
                           {detectError[board.id] && (
-                            <div role="alert" className="flex items-center gap-1.5 text-destructive text-[10px]">
+                            <Flex role="alert" align="center" gap="1.5" className="text-destructive text-[10px]">
                               <AlertCircle className="h-3 w-3 flex-shrink-0" />
-                              <span>{detectError[board.id]}</span>
-                            </div>
+                              <Text as="span" tone="destructive" className="text-[10px]">
+                                {detectError[board.id]}
+                              </Text>
+                            </Flex>
                           )}
-                        </div>
+                        </Stack>
                       )}
-                    </div>
+                    </Stack>
 
                     {/* Connection section */}
-                    <div className="border-t pt-3">
+                    <Box className="border-t pt-3">
                       <BoardConnectionForm board={board} onUpdate={handleUpdateBoard} />
-                    </div>
+                    </Box>
 
                     {/* Remove board - bottom */}
-                    <div className="border-t pt-2">
+                    <Box className="border-t pt-2">
                       <Button
                         variant="ghost"
                         size="sm"
@@ -855,24 +902,26 @@ export function DisplaySettings() {
                         <Trash2 className="h-3 w-3 mr-1" />
                         {t("removeBoard")}
                       </Button>
-                    </div>
-                  </div>
+                    </Box>
+                  </Stack>
                 </CollapsibleContent>
               </Collapsible>
             );
           })}
-        </div>
+        </Stack>
 
         {/* Add Board */}
-        <div className="pt-2">
+        <Box className="pt-2">
           {!showTypePicker ? (
             <Button variant="outline" size="sm" className="text-xs" onClick={() => setShowTypePicker(true)}>
               <Plus className="h-3 w-3 mr-1" />
               {t("addBoard")}
             </Button>
           ) : (
-            <div className="flex items-center gap-2">
-              <span className="text-xs text-muted-foreground">{t("selectType")}</span>
+            <Flex align="center" gap="2">
+              <Text as="span" size="xs" tone="muted">
+                {t("selectType")}
+              </Text>
               <Button variant="outline" size="sm" className="text-xs" onClick={() => handleAddBoard("flagship")}>
                 <Monitor className="h-3 w-3 mr-1" />
                 {t("flagshipLabel")}
@@ -893,9 +942,9 @@ export function DisplaySettings() {
               >
                 {tCommon("cancel")}
               </Button>
-            </div>
+            </Flex>
           )}
-        </div>
+        </Box>
       </CardContent>
     </Card>
   );

--- a/web/src/components/settings/festive-months-settings.tsx
+++ b/web/src/components/settings/festive-months-settings.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Card, CardContent, CardDescription, CardHeader, CardTitle, Switch } from "@fiestaboard/ui";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle, Flex, Stack, Switch, Text } from "@fiestaboard/ui";
 import { Sparkles } from "lucide-react";
 import { useEffect, useState } from "react";
 
@@ -57,13 +57,15 @@ export function FestiveMonthsSettings() {
         <CardDescription>{t("description")}</CardDescription>
       </CardHeader>
       <CardContent>
-        <div className="flex items-start justify-between gap-4 rounded-md border p-4">
-          <div className="space-y-1">
-            <span className="font-medium">{t("hideLabel")}</span>
-            <p className="text-sm text-muted-foreground">{t("hideHint")}</p>
-          </div>
+        <Flex align="start" justify="between" gap="4" className="rounded-md border p-4">
+          <Stack gap="1">
+            <Text as="span" weight="medium">
+              {t("hideLabel")}
+            </Text>
+            <Text tone="muted">{t("hideHint")}</Text>
+          </Stack>
           <Switch checked={hide} onCheckedChange={onToggle} aria-label={t("hideLabel")} />
-        </div>
+        </Flex>
       </CardContent>
     </Card>
   );

--- a/web/src/components/settings/instance-name.tsx
+++ b/web/src/components/settings/instance-name.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Card, CardContent, CardDescription, CardHeader, CardTitle, Input, Label, Skeleton } from "@fiestaboard/ui";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle, Input, Label, Skeleton, Stack } from "@fiestaboard/ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Tag } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
@@ -51,7 +51,7 @@ export function InstanceNameCard() {
         {isLoading ? (
           <Skeleton className="h-10 w-full max-w-sm" />
         ) : (
-          <div className="space-y-2 max-w-sm">
+          <Stack gap="2" className="max-w-sm">
             <Label htmlFor="instance-name">{t("instanceNameTitle")}</Label>
             <Input
               id="instance-name"
@@ -61,7 +61,7 @@ export function InstanceNameCard() {
               placeholder={t("instanceNamePlaceholder")}
               maxLength={50}
             />
-          </div>
+          </Stack>
         )}
       </CardContent>
     </Card>

--- a/web/src/components/settings/instance-name.tsx
+++ b/web/src/components/settings/instance-name.tsx
@@ -1,6 +1,16 @@
 "use client";
 
-import { Card, CardContent, CardDescription, CardHeader, CardTitle, Input, Label, Skeleton, Stack } from "@fiestaboard/ui";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Input,
+  Label,
+  Skeleton,
+  Stack,
+} from "@fiestaboard/ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Tag } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";

--- a/web/src/components/settings/location-settings.tsx
+++ b/web/src/components/settings/location-settings.tsx
@@ -1,6 +1,20 @@
 "use client";
 
-import { Button, Card, CardContent, CardDescription, CardHeader, CardTitle, Input, Label } from "@fiestaboard/ui";
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Flex,
+  Grid,
+  Input,
+  Label,
+  Stack,
+  Text,
+} from "@fiestaboard/ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Loader2, LocateFixed, MapPin } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -120,14 +134,14 @@ export function LocationSettingsCard() {
       </CardHeader>
       <CardContent className="space-y-4">
         {isLoading ? (
-          <div className="space-y-3">
-            <div className="h-10 bg-muted animate-pulse rounded" />
-            <div className="h-10 bg-muted animate-pulse rounded" />
-          </div>
+          <Stack gap="3">
+            <Box className="h-10 bg-muted animate-pulse rounded" />
+            <Box className="h-10 bg-muted animate-pulse rounded" />
+          </Stack>
         ) : (
           <>
-            <div className="grid grid-cols-2 gap-4">
-              <div className="space-y-2">
+            <Grid cols="2" gap="4">
+              <Stack gap="2">
                 <Label htmlFor="latitude">{t("latitudeLabel")}</Label>
                 <Input
                   id="latitude"
@@ -139,8 +153,8 @@ export function LocationSettingsCard() {
                   value={latitude}
                   onChange={(e) => handleLatChange(e.target.value)}
                 />
-              </div>
-              <div className="space-y-2">
+              </Stack>
+              <Stack gap="2">
                 <Label htmlFor="longitude">{t("longitudeLabel")}</Label>
                 <Input
                   id="longitude"
@@ -152,10 +166,12 @@ export function LocationSettingsCard() {
                   value={longitude}
                   onChange={(e) => handleLonChange(e.target.value)}
                 />
-              </div>
-            </div>
-            <p className="text-xs text-muted-foreground">{t("tip")}</p>
-            <div className="flex gap-2">
+              </Stack>
+            </Grid>
+            <Text size="xs" tone="muted">
+              {t("tip")}
+            </Text>
+            <Flex gap="2">
               <Button
                 variant="outline"
                 onClick={handleUseMyLocation}
@@ -178,7 +194,7 @@ export function LocationSettingsCard() {
                   {t("clear")}
                 </Button>
               )}
-            </div>
+            </Flex>
           </>
         )}
       </CardContent>

--- a/web/src/components/settings/mcp-settings.tsx
+++ b/web/src/components/settings/mcp-settings.tsx
@@ -10,19 +10,25 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
   Badge,
+  Box,
   Button,
   Card,
   CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
+  Code,
   Dialog,
   DialogContent,
   DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  Flex,
   Skeleton,
+  Stack,
+  Text,
+  TextLink,
 } from "@fiestaboard/ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { AlertTriangle, Bot, Check, Copy, KeyRound, Loader2, RefreshCw, Trash2 } from "lucide-react";
@@ -143,23 +149,25 @@ export function McpSettings() {
           <CardDescription>
             A pre-shared token that lets Claude Desktop, Claude Code, and other MCP clients talk to this FiestaBoard.
             The token authenticates as a single principal — scoped to the{" "}
-            <code className="font-mono text-xs">/api/mcp</code> endpoint only — so it can&apos;t edit pages or other
+            <Code className="font-mono text-xs">/api/mcp</Code> endpoint only — so it can&apos;t edit pages or other
             settings. See{" "}
-            <a
+            <TextLink
               href="https://github.com/Fiestaboard/FiestaBoard/blob/main/docs/setup/MCP_CLIENTS.md"
               target="_blank"
               rel="noreferrer"
               className="underline underline-offset-2"
             >
               MCP client setup
-            </a>{" "}
+            </TextLink>{" "}
             for client-specific quirks (Desktop needs an stdio proxy; claude.ai web Connectors require public HTTPS and
             OAuth, so they won&apos;t reach a LAN host).
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          <div className="flex items-center gap-2">
-            <span className="text-sm font-medium">Status:</span>
+          <Flex align="center" gap="2">
+            <Text as="span" size="sm" weight="medium">
+              Status:
+            </Text>
             {isPinnedByEnv ? (
               <Badge variant="secondary" className="gap-1.5">
                 <KeyRound className="h-3 w-3" />
@@ -173,33 +181,33 @@ export function McpSettings() {
             ) : (
               <Badge variant="outline">Not configured</Badge>
             )}
-          </div>
+          </Flex>
 
           {isPinnedByEnv && (
-            <p className="text-sm text-muted-foreground">
-              The active token is set by the <code className="font-mono text-xs">FIESTABOARD_MCP_TOKEN</code>{" "}
-              environment variable. Unset it in your <code className="font-mono text-xs">.env</code> and restart the
+            <Text tone="muted">
+              The active token is set by the <Code className="font-mono text-xs">FIESTABOARD_MCP_TOKEN</Code>{" "}
+              environment variable. Unset it in your <Code className="font-mono text-xs">.env</Code> and restart the
               container before managing the token from this UI.
-            </p>
+            </Text>
           )}
 
           {!isPinnedByEnv && !hasToken && (
-            <p className="text-sm text-muted-foreground">
+            <Text tone="muted">
               No token is configured. External MCP clients will fall back to cookie auth, which Claude Desktop / Claude
               Code don&apos;t support — they&apos;ll fail registration with an opaque error. Generate a token to unblock
               them.
-            </p>
+            </Text>
           )}
 
           {!isPinnedByEnv && hasToken && (
-            <p className="text-sm text-muted-foreground">
+            <Text tone="muted">
               A token is configured and active. Rotate it to invalidate the previous one (any client still using the old
               token will start receiving 401), or revoke it entirely to fall back to cookie-only auth.
-            </p>
+            </Text>
           )}
 
           {!isPinnedByEnv && (
-            <div className="flex flex-wrap gap-2">
+            <Flex wrap gap="2">
               <Button
                 onClick={() => setConfirmingRotate(true)}
                 disabled={rotateMutation.isPending}
@@ -228,7 +236,7 @@ export function McpSettings() {
                   Revoke token
                 </Button>
               )}
-            </div>
+            </Flex>
           )}
         </CardContent>
       </Card>
@@ -291,17 +299,19 @@ export function McpSettings() {
             <DialogTitle>Save this token</DialogTitle>
             <DialogDescription className="flex items-start gap-2">
               <AlertTriangle className="h-4 w-4 mt-0.5 flex-shrink-0 text-amber-500" />
-              <span>
+              <Text as="span" size="sm" tone="muted">
                 FiestaBoard stores only what&apos;s needed to verify future requests — this is the only time the
                 plaintext value is shown. Copy it into your MCP client now.
-              </span>
+              </Text>
             </DialogDescription>
           </DialogHeader>
 
-          <div className="space-y-4">
-            <div>
-              <div className="mb-1.5 flex items-center justify-between">
-                <span className="text-sm font-medium">Token</span>
+          <Stack gap="4">
+            <Box>
+              <Flex align="center" justify="between" className="mb-1.5">
+                <Text as="span" size="sm" weight="medium">
+                  Token
+                </Text>
                 <Button
                   size="sm"
                   variant="ghost"
@@ -311,15 +321,17 @@ export function McpSettings() {
                   {copied === "token" ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
                   {copied === "token" ? "Copied" : "Copy"}
                 </Button>
-              </div>
-              <code className="block w-full break-all rounded bg-muted px-3 py-2 font-mono text-xs">
+              </Flex>
+              <Code className="block w-full break-all rounded bg-muted px-3 py-2 font-mono text-xs">
                 {revealedToken}
-              </code>
-            </div>
+              </Code>
+            </Box>
 
-            <div>
-              <div className="mb-1.5 flex items-center justify-between">
-                <span className="text-sm font-medium">Claude Desktop config snippet</span>
+            <Box>
+              <Flex align="center" justify="between" className="mb-1.5">
+                <Text as="span" size="sm" weight="medium">
+                  Claude Desktop config snippet
+                </Text>
                 <Button
                   size="sm"
                   variant="ghost"
@@ -329,47 +341,52 @@ export function McpSettings() {
                   {copied === "config" ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
                   {copied === "config" ? "Copied" : "Copy"}
                 </Button>
-              </div>
-              <p className="mb-2 text-xs text-muted-foreground">
+              </Flex>
+              <Text size="xs" tone="muted" className="mb-2">
                 Paste this into{" "}
-                <code className="font-mono">~/Library/Application Support/Claude/claude_desktop_config.json</code>,
+                <Code className="font-mono">~/Library/Application Support/Claude/claude_desktop_config.json</Code>,
                 merging with anything that&apos;s already there, then fully quit and relaunch Claude Desktop (⌘Q —
                 closing the window isn&apos;t enough). Claude Desktop only supports stdio MCP servers, so this snippet
                 shells out to{" "}
-                <a
+                <TextLink
                   href="https://www.npmjs.com/package/mcp-remote"
                   target="_blank"
                   rel="noreferrer"
                   className="underline underline-offset-2"
                 >
                   mcp-remote
-                </a>{" "}
-                via <code className="font-mono">npx</code> as a proxy — Node 18+ must be installed and{" "}
-                <code className="font-mono">npx</code> reachable from Claude Desktop&apos;s PATH. If it errors with{" "}
-                <code className="font-mono">command not found</code>, replace{" "}
-                <code className="font-mono">&quot;npx&quot;</code> with the absolute path from{" "}
-                <code className="font-mono">which npx</code>.
-              </p>
+                </TextLink>{" "}
+                via <Code className="font-mono">npx</Code> as a proxy — Node 18+ must be installed and{" "}
+                <Code className="font-mono">npx</Code> reachable from Claude Desktop&apos;s PATH. If it errors with{" "}
+                <Code className="font-mono">command not found</Code>, replace{" "}
+                <Code className="font-mono">&quot;npx&quot;</Code> with the absolute path from{" "}
+                <Code className="font-mono">which npx</Code>.
+              </Text>
               <pre className="max-h-64 overflow-auto rounded bg-muted px-3 py-2 font-mono text-xs">{configSnippet}</pre>
-            </div>
+            </Box>
 
-            <p className="text-xs text-muted-foreground">
-              <strong>Claude Code (CLI):</strong> talks HTTP directly — no proxy needed.
+            <Text size="xs" tone="muted">
+              <Text as="span" size="xs" weight="semibold" tone="muted">
+                Claude Code (CLI):
+              </Text>{" "}
+              talks HTTP directly — no proxy needed.
               <br />
-              <code className="font-mono">
+              <Code className="font-mono">
                 claude mcp add fiestaboard --transport http --url{" "}
                 {typeof window !== "undefined"
                   ? `${window.location.protocol}//${window.location.host}`
                   : "http://fiestaboard.local:4420"}
                 /api/mcp/ --header &quot;Authorization: Bearer &lt;token&gt;&quot;
-              </code>
-            </p>
-            <p className="text-xs text-muted-foreground">
-              <strong>claude.ai web (Connectors):</strong> not supported for self-hosted FiestaBoard. The Connectors
-              flow requires a public HTTPS URL and OAuth 2.1 dynamic client registration, neither of which a LAN host
-              can provide. Use Desktop or Code instead.
-            </p>
-          </div>
+              </Code>
+            </Text>
+            <Text size="xs" tone="muted">
+              <Text as="span" size="xs" weight="semibold" tone="muted">
+                claude.ai web (Connectors):
+              </Text>{" "}
+              not supported for self-hosted FiestaBoard. The Connectors flow requires a public HTTPS URL and OAuth 2.1
+              dynamic client registration, neither of which a LAN host can provide. Use Desktop or Code instead.
+            </Text>
+          </Stack>
 
           <DialogFooter>
             <Button onClick={() => setRevealedToken(null)}>I&apos;ve saved it</Button>

--- a/web/src/components/settings/mqtt-settings.tsx
+++ b/web/src/components/settings/mqtt-settings.tsx
@@ -11,10 +11,14 @@ import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
+  Flex,
+  Grid,
   Input,
   Label,
   Skeleton,
+  Stack,
   Switch,
+  Text,
 } from "@fiestaboard/ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { CheckCircle2, ChevronDown, Eye, EyeOff, Loader2, Radio, XCircle } from "lucide-react";
@@ -95,12 +99,12 @@ export function MqttSettingsCard() {
   return (
     <Card>
       <CardHeader className="pb-3">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
+        <Flex align="center" justify="between">
+          <Flex align="center" gap="2">
             <Radio className="h-4 w-4" />
             <CardTitle className="text-base">{t("title")}</CardTitle>
-          </div>
-          <div className="flex items-center gap-3">
+          </Flex>
+          <Flex align="center" gap="3">
             {isEnabled &&
               (isConnected ? (
                 <Badge variant="default" className="text-[10px] h-5 bg-board-green flex items-center gap-1">
@@ -114,21 +118,23 @@ export function MqttSettingsCard() {
                 </Badge>
               ))}
             <Switch checked={isEnabled} onCheckedChange={handleToggleEnabled} disabled={saveMutation.isPending} />
-          </div>
-        </div>
+          </Flex>
+        </Flex>
         <CardDescription>{t("description")}</CardDescription>
       </CardHeader>
 
       <Collapsible open={expanded} onOpenChange={setExpanded}>
         <CollapsibleTrigger className="flex w-full items-center justify-between px-6 py-2 text-xs text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm">
-          <span>{t("brokerConfiguration")}</span>
+          <Text as="span" size="xs" tone="muted">
+            {t("brokerConfiguration")}
+          </Text>
           <ChevronDown className={`h-4 w-4 transition-transform duration-200 ${expanded ? "rotate-180" : ""}`} />
         </CollapsibleTrigger>
 
         <CollapsibleContent>
           <CardContent className="pt-2 space-y-4">
-            <div className="grid grid-cols-3 gap-3">
-              <div className="col-span-2 space-y-1">
+            <Grid cols="3" gap="3">
+              <Stack gap="1" className="col-span-2">
                 <Label htmlFor="mqtt-broker-host" className="text-xs">
                   {t("brokerHost")}
                 </Label>
@@ -139,8 +145,8 @@ export function MqttSettingsCard() {
                   placeholder="localhost"
                   className="h-8 text-xs font-mono"
                 />
-              </div>
-              <div className="space-y-1">
+              </Stack>
+              <Stack gap="1">
                 <Label htmlFor="mqtt-broker-port" className="text-xs">
                   {t("port")}
                 </Label>
@@ -152,11 +158,11 @@ export function MqttSettingsCard() {
                   placeholder="1883"
                   className="h-8 text-xs font-mono"
                 />
-              </div>
-            </div>
+              </Stack>
+            </Grid>
 
-            <div className="grid grid-cols-2 gap-3">
-              <div className="space-y-1">
+            <Grid cols="2" gap="3">
+              <Stack gap="1">
                 <Label htmlFor="mqtt-username" className="text-xs">
                   {t("username")}
                 </Label>
@@ -167,12 +173,12 @@ export function MqttSettingsCard() {
                   placeholder={t("optional")}
                   className="h-8 text-xs"
                 />
-              </div>
-              <div className="space-y-1">
+              </Stack>
+              <Stack gap="1">
                 <Label htmlFor="mqtt-password" className="text-xs">
                   {t("password")}
                 </Label>
-                <div className="flex gap-1.5">
+                <Flex gap="1.5">
                   <Input
                     id="mqtt-password"
                     type={showPassword ? "text" : "password"}
@@ -191,11 +197,11 @@ export function MqttSettingsCard() {
                   >
                     {showPassword ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
                   </Button>
-                </div>
-              </div>
-            </div>
+                </Flex>
+              </Stack>
+            </Grid>
 
-            <div className="space-y-1">
+            <Stack gap="1">
               <Label htmlFor="mqtt-external-url" className="text-xs">
                 {t("externalUrl")}
               </Label>
@@ -206,11 +212,13 @@ export function MqttSettingsCard() {
                 placeholder={t("externalUrlPlaceholder")}
                 className="h-8 text-xs font-mono"
               />
-              <p className="text-[10px] text-muted-foreground">{t("externalUrlHint")}</p>
-            </div>
+              <Text tone="muted" className="text-[10px]">
+                {t("externalUrlHint")}
+              </Text>
+            </Stack>
 
             {hasDraft && (
-              <div className="flex justify-end pt-1">
+              <Flex justify="end" className="pt-1">
                 <Button
                   size="sm"
                   variant="brand"
@@ -221,7 +229,7 @@ export function MqttSettingsCard() {
                   {saveMutation.isPending && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
                   {tCommon("save")}
                 </Button>
-              </div>
+              </Flex>
             )}
           </CardContent>
         </CollapsibleContent>

--- a/web/src/components/settings/network-settings.tsx
+++ b/web/src/components/settings/network-settings.tsx
@@ -2,6 +2,7 @@
 
 import {
   Badge,
+  Box,
   Button,
   Card,
   CardContent,
@@ -14,8 +15,13 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  Flex,
   Input,
   Label,
+  List,
+  ListItem,
+  Stack,
+  Text,
 } from "@fiestaboard/ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Check, Loader2, Lock, RefreshCw, Trash2, Unlink, Wifi, WifiOff, X } from "lucide-react";
@@ -154,7 +160,7 @@ export function NetworkSettings() {
           {statusQuery.isLoading ? (
             <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
           ) : !isConnected ? (
-            <p className="text-sm text-muted-foreground">{t("notConnected")}</p>
+            <Text tone="muted">{t("notConnected")}</Text>
           ) : (
             <dl className="grid grid-cols-[max-content_1fr] gap-x-4 gap-y-1 text-sm">
               <dt className="text-muted-foreground">{t("ssidLabel")}</dt>
@@ -190,7 +196,7 @@ export function NetworkSettings() {
               </dd>
             </dl>
           )}
-          <div className="flex gap-2 pt-2">
+          <Flex gap="2" className="pt-2">
             <Button
               size="sm"
               variant="outline"
@@ -215,14 +221,14 @@ export function NetworkSettings() {
                 {t("disconnect")}
               </Button>
             )}
-          </div>
+          </Flex>
         </CardContent>
       </Card>
 
       {/* ── Available networks ─────────────────────────────────────────── */}
       <Card>
         <CardHeader>
-          <div className="flex items-center justify-between">
+          <Flex align="center" justify="between">
             <CardTitle className="flex items-center gap-2 text-base">
               <Wifi className="h-4 w-4" />
               {t("availableNetworks")}
@@ -231,33 +237,35 @@ export function NetworkSettings() {
               {scanning ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <RefreshCw className="h-4 w-4 mr-2" />}
               {scanning ? t("scanning") : t("rescan")}
             </Button>
-          </div>
+          </Flex>
         </CardHeader>
         <CardContent>
           {networks.length === 0 && !scanning ? (
-            <p className="text-sm text-muted-foreground">{t("noNetworksFound")}</p>
+            <Text tone="muted">{t("noNetworksFound")}</Text>
           ) : (
-            <ul className="divide-y divide-border">
+            <List gap="0" className="divide-y divide-border">
               {networks.map((n) => (
-                <li key={`${n.ssid}-${n.signal}`} className="flex items-center justify-between py-2 gap-3">
-                  <div className="flex items-center gap-3 min-w-0">
+                <ListItem key={`${n.ssid}-${n.signal}`} className="flex items-center justify-between py-2 gap-3">
+                  <Flex align="center" gap="3" className="min-w-0">
                     <SignalIcon strength={n.signal} />
-                    <div className="min-w-0">
-                      <div className="flex items-center gap-2">
-                        <span className="font-medium truncate">{n.ssid}</span>
+                    <Box className="min-w-0">
+                      <Flex align="center" gap="2">
+                        <Text as="span" weight="medium" className="truncate">
+                          {n.ssid}
+                        </Text>
                         {needsPassword(n) && <Lock className="h-3 w-3 text-muted-foreground" />}
                         {n.in_use && (
                           <Badge variant="secondary" className="text-xs">
                             {t("currentConnection")}
                           </Badge>
                         )}
-                      </div>
+                      </Flex>
                       {}
-                      <div className="text-xs text-muted-foreground">
+                      <Text size="xs" tone="muted">
                         {n.signal}% · {needsPassword(n) ? t("secured") : t("open")}
-                      </div>
-                    </div>
-                  </div>
+                      </Text>
+                    </Box>
+                  </Flex>
                   <Button
                     size="sm"
                     variant="outline"
@@ -266,9 +274,9 @@ export function NetworkSettings() {
                   >
                     {t("connect")}
                   </Button>
-                </li>
+                </ListItem>
               ))}
-            </ul>
+            </List>
           )}
         </CardContent>
       </Card>
@@ -282,12 +290,14 @@ export function NetworkSettings() {
           {savedQuery.isLoading ? (
             <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
           ) : !savedQuery.data || savedQuery.data.length === 0 ? (
-            <p className="text-sm text-muted-foreground">{t("savedEmpty")}</p>
+            <Text tone="muted">{t("savedEmpty")}</Text>
           ) : (
-            <ul className="divide-y divide-border">
+            <List gap="0" className="divide-y divide-border">
               {savedQuery.data.map((s) => (
-                <li key={s.name} className="flex items-center justify-between py-2 gap-3">
-                  <span className="font-medium truncate">{s.name}</span>
+                <ListItem key={s.name} className="flex items-center justify-between py-2 gap-3">
+                  <Text as="span" weight="medium" className="truncate">
+                    {s.name}
+                  </Text>
                   <Button
                     size="sm"
                     variant="ghost"
@@ -297,9 +307,9 @@ export function NetworkSettings() {
                     <Trash2 className="h-4 w-4 mr-2" />
                     {t("forget")}
                   </Button>
-                </li>
+                </ListItem>
               ))}
-            </ul>
+            </List>
           )}
         </CardContent>
       </Card>
@@ -321,9 +331,9 @@ export function NetworkSettings() {
             <DialogDescription>{t("connectDialogDescription")}</DialogDescription>
           </DialogHeader>
           {connectTarget && needsPassword(connectTarget) && (
-            <div className="space-y-2">
+            <Stack gap="2">
               <Label htmlFor="wifi-password">{t("passwordLabel")}</Label>
-              <div className="flex gap-2">
+              <Flex gap="2">
                 <Input
                   id="wifi-password"
                   type={showPassword ? "text" : "password"}
@@ -337,8 +347,8 @@ export function NetworkSettings() {
                 <Button type="button" variant="outline" size="sm" onClick={() => setShowPassword((v) => !v)}>
                   {showPassword ? tCommon("off") : tCommon("on")}
                 </Button>
-              </div>
-            </div>
+              </Flex>
+            </Stack>
           )}
           <DialogFooter>
             <Button variant="outline" onClick={() => setConnectTarget(null)}>

--- a/web/src/components/settings/plugin-settings.tsx
+++ b/web/src/components/settings/plugin-settings.tsx
@@ -1,6 +1,18 @@
 "use client";
 
-import { Button, Card, CardContent, CardDescription, CardHeader, CardTitle, Skeleton, Switch } from "@fiestaboard/ui";
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Flex,
+  Skeleton,
+  Stack,
+  Switch,
+  Text,
+} from "@fiestaboard/ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Puzzle, RefreshCw } from "lucide-react";
 import { toast } from "sonner";
@@ -73,23 +85,27 @@ export function PluginSettingsCard() {
         <CardDescription>{t("description")}</CardDescription>
       </CardHeader>
       <CardContent className="space-y-3">
-        <div className="flex items-start justify-between gap-4 rounded-md border p-4">
-          <div className="space-y-1">
-            <span className="font-medium">{t("autoUpdateLabel")}</span>
-            <p className="text-sm text-muted-foreground">{t("autoUpdateDescription")}</p>
-          </div>
+        <Flex align="start" justify="between" gap="4" className="rounded-md border p-4">
+          <Stack gap="1">
+            <Text as="span" weight="medium">
+              {t("autoUpdateLabel")}
+            </Text>
+            <Text tone="muted">{t("autoUpdateDescription")}</Text>
+          </Stack>
           <Switch
             checked={data.settings.auto_update}
             disabled={mutation.isPending}
             onCheckedChange={(checked) => mutation.mutate(checked)}
             aria-label={t("autoUpdateLabel")}
           />
-        </div>
-        <div className="flex items-start justify-between gap-4 rounded-md border p-4">
-          <div className="space-y-1">
-            <span className="font-medium">{t("checkForUpdates")}</span>
-            <p className="text-sm text-muted-foreground">{t("checkDescription")}</p>
-          </div>
+        </Flex>
+        <Flex align="start" justify="between" gap="4" className="rounded-md border p-4">
+          <Stack gap="1">
+            <Text as="span" weight="medium">
+              {t("checkForUpdates")}
+            </Text>
+            <Text tone="muted">{t("checkDescription")}</Text>
+          </Stack>
           <Button
             variant="outline"
             size="sm"
@@ -100,7 +116,7 @@ export function PluginSettingsCard() {
             <RefreshCw className={cn("h-3.5 w-3.5", checkMutation.isPending && "animate-spin")} />
             {checkMutation.isPending ? t("checking") : t("checkForUpdates")}
           </Button>
-        </div>
+        </Flex>
       </CardContent>
     </Card>
   );

--- a/web/src/components/settings/silence-schedule.tsx
+++ b/web/src/components/settings/silence-schedule.tsx
@@ -1,11 +1,14 @@
 "use client";
 
 import {
+  Box,
   Card,
   CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
+  Flex,
+  Grid,
   Input,
   Label,
   Select,
@@ -14,7 +17,9 @@ import {
   SelectTrigger,
   SelectValue,
   Skeleton,
+  Stack,
   Switch,
+  Text,
 } from "@fiestaboard/ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Moon } from "lucide-react";
@@ -179,14 +184,14 @@ export function SilenceSchedule() {
       </CardHeader>
       <CardContent>
         {isLoading ? (
-          <div className="space-y-3">
+          <Stack gap="3">
             <Skeleton className="h-5 w-11 rounded-full" />
             <Skeleton className="h-4 w-32" />
             <Skeleton className="h-3 w-48" />
-          </div>
+          </Stack>
         ) : (
           <>
-            <div className="flex items-center justify-between gap-3">
+            <Flex align="center" justify="between" gap="3">
               <label htmlFor="silence-enabled" className="text-sm font-medium cursor-pointer">
                 {t("silenceScheduleLabel")}
               </label>
@@ -196,12 +201,12 @@ export function SilenceSchedule() {
                 disabled={isSaving}
                 id="silence-enabled"
               />
-            </div>
+            </Flex>
 
             {silenceEnabled && (
-              <div className="mt-6 space-y-6">
-                <div className="grid grid-cols-2 gap-4">
-                  <div className="space-y-2">
+              <Stack gap="6" className="mt-6">
+                <Grid cols="2" gap="4">
+                  <Stack gap="2">
                     <Label htmlFor="silence-start" className="text-sm font-medium">
                       {t("startTimeLabel")}
                     </Label>
@@ -211,9 +216,11 @@ export function SilenceSchedule() {
                       onChange={(val) => handleSilenceTimeChange("start", val)}
                       disabled={isSaving}
                     />
-                    <p className="text-xs text-muted-foreground">{t("whenSilenceBegins")}</p>
-                  </div>
-                  <div className="space-y-2">
+                    <Text size="xs" tone="muted">
+                      {t("whenSilenceBegins")}
+                    </Text>
+                  </Stack>
+                  <Stack gap="2">
                     <Label htmlFor="silence-end" className="text-sm font-medium">
                       {t("endTimeLabel")}
                     </Label>
@@ -223,11 +230,13 @@ export function SilenceSchedule() {
                       onChange={(val) => handleSilenceTimeChange("end", val)}
                       disabled={isSaving}
                     />
-                    <p className="text-xs text-muted-foreground">{t("whenSilenceEnds")}</p>
-                  </div>
-                </div>
+                    <Text size="xs" tone="muted">
+                      {t("whenSilenceEnds")}
+                    </Text>
+                  </Stack>
+                </Grid>
 
-                <div className="space-y-2">
+                <Stack gap="2">
                   <Label htmlFor="silence-mode" className="text-sm font-medium">
                     {t("silenceModeLabel")}
                   </Label>
@@ -245,16 +254,16 @@ export function SilenceSchedule() {
                       <SelectItem value="page">{t("silenceModePage")}</SelectItem>
                     </SelectContent>
                   </Select>
-                  <p className="text-xs text-muted-foreground">
+                  <Text size="xs" tone="muted">
                     {silenceMode === "indicator" && t("silenceModeIndicatorHelp")}
                     {silenceMode === "freeze" && t("silenceModeFreezeHelp")}
                     {silenceMode === "page" && t("silenceModePageHelp")}
-                  </p>
-                </div>
+                  </Text>
+                </Stack>
 
                 {silenceMode === "indicator" && (
                   <>
-                    <div className="space-y-2">
+                    <Stack gap="2">
                       <Label htmlFor="silence-indicator-text" className="text-sm font-medium">
                         {t("silenceIndicatorTextLabel")}
                       </Label>
@@ -267,9 +276,11 @@ export function SilenceSchedule() {
                         placeholder="SNOOZING"
                         className="uppercase"
                       />
-                      <p className="text-xs text-muted-foreground">{t("silenceIndicatorTextHelp")}</p>
-                    </div>
-                    <div className="space-y-2">
+                      <Text size="xs" tone="muted">
+                        {t("silenceIndicatorTextHelp")}
+                      </Text>
+                    </Stack>
+                    <Stack gap="2">
                       <Label htmlFor="silence-indicator-position" className="text-sm font-medium">
                         {t("silenceIndicatorPositionLabel")}
                       </Label>
@@ -289,12 +300,12 @@ export function SilenceSchedule() {
                           <SelectItem value="bottom-right">{t("positionBottomRight")}</SelectItem>
                         </SelectContent>
                       </Select>
-                    </div>
+                    </Stack>
                   </>
                 )}
 
                 {silenceMode === "page" && (
-                  <div className="space-y-2">
+                  <Stack gap="2">
                     <Label htmlFor="silence-page" className="text-sm font-medium">
                       {t("silencePageLabel")}
                     </Label>
@@ -314,17 +325,26 @@ export function SilenceSchedule() {
                         ))}
                       </SelectContent>
                     </Select>
-                    <p className="text-xs text-muted-foreground">{t("silencePageHelp")}</p>
-                  </div>
+                    <Text size="xs" tone="muted">
+                      {t("silencePageHelp")}
+                    </Text>
+                  </Stack>
                 )}
-              </div>
+              </Stack>
             )}
 
             {isSaving && (
-              <div className="flex items-center justify-center gap-2 pt-4 mt-4 border-t text-xs text-muted-foreground">
-                <div className="h-3 w-3 animate-spin rounded-full border-2 border-primary border-t-transparent" />
-                <span>{tc("savingIndicator")}</span>
-              </div>
+              <Flex
+                align="center"
+                justify="center"
+                gap="2"
+                className="pt-4 mt-4 border-t text-xs text-muted-foreground"
+              >
+                <Box className="h-3 w-3 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+                <Text as="span" size="xs" tone="muted">
+                  {tc("savingIndicator")}
+                </Text>
+              </Flex>
             )}
           </>
         )}

--- a/web/src/components/settings/system-controls.tsx
+++ b/web/src/components/settings/system-controls.tsx
@@ -13,6 +13,10 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  Flex,
+  Heading,
+  Stack,
+  Text,
 } from "@fiestaboard/ui";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { ArrowUpCircle, Cpu, Loader2, Power, RefreshCw } from "lucide-react";
@@ -91,7 +95,7 @@ export function SystemControls() {
           <CardDescription>{t("description")}</CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="flex flex-wrap gap-2">
+          <Flex wrap gap="2">
             <Button
               variant={updateAvailable ? "default" : "outline"}
               size="sm"
@@ -129,7 +133,7 @@ export function SystemControls() {
               )}
               {t("shutdown")}
             </Button>
-          </div>
+          </Flex>
         </CardContent>
       </Card>
 
@@ -292,31 +296,31 @@ function RestartingOverlay({ currentVersion }: { currentVersion?: string }) {
 
   if (phase === "error") {
     return (
-      <div className="fixed inset-0 z-[100] bg-background/95 backdrop-blur-sm flex items-center justify-center">
-        <div className="text-center space-y-4 max-w-sm mx-auto px-4">
-          <h2 className="text-xl font-semibold">{t("takingLonger")}</h2>
-          <p className="text-sm text-muted-foreground">{t("takingLongerDescription")}</p>
+      <Flex align="center" justify="center" className="fixed inset-0 z-[100] bg-background/95 backdrop-blur-sm">
+        <Stack gap="4" className="text-center max-w-sm mx-auto px-4">
+          <Heading level={2} size="xl">
+            {t("takingLonger")}
+          </Heading>
+          <Text tone="muted">{t("takingLongerDescription")}</Text>
           <Button variant="outline" onClick={() => window.location.reload()}>
             <RefreshCw className="h-4 w-4 mr-2" />
             {t("refreshPage")}
           </Button>
-        </div>
-      </div>
+        </Stack>
+      </Flex>
     );
   }
 
   return (
-    <div className="fixed inset-0 z-[100] bg-background/95 backdrop-blur-sm flex items-center justify-center">
-      <div className="text-center space-y-4">
+    <Flex align="center" justify="center" className="fixed inset-0 z-[100] bg-background/95 backdrop-blur-sm">
+      <Stack gap="4" className="text-center">
         <Loader2 className="h-12 w-12 mx-auto animate-spin text-primary" />
-        <h2 className="text-xl font-semibold">
+        <Heading level={2} size="xl">
           {phase === "restarting" ? t("restartingFiestaboard") : t("backOnline")}
-        </h2>
-        <p className="text-sm text-muted-foreground">
-          {phase === "restarting" ? t("restartingDuration") : t("almostThere")}
-        </p>
-      </div>
-    </div>
+        </Heading>
+        <Text tone="muted">{phase === "restarting" ? t("restartingDuration") : t("almostThere")}</Text>
+      </Stack>
+    </Flex>
   );
 }
 
@@ -327,12 +331,16 @@ function RestartingOverlay({ currentVersion }: { currentVersion?: string }) {
 function ShutdownOverlay() {
   const t = useTranslations("systemControls");
   return (
-    <div className="fixed inset-0 z-[100] bg-background/95 backdrop-blur-sm flex items-center justify-center">
-      <div className="text-center space-y-4">
+    <Flex align="center" justify="center" className="fixed inset-0 z-[100] bg-background/95 backdrop-blur-sm">
+      <Stack gap="4" className="text-center">
         <Power className="h-12 w-12 mx-auto text-muted-foreground" />
-        <h2 className="text-xl font-semibold">{t("shuttingDown")}</h2>
-        <p className="text-sm text-muted-foreground max-w-sm mx-auto">{t("shuttingDownDescription")}</p>
-      </div>
-    </div>
+        <Heading level={2} size="xl">
+          {t("shuttingDown")}
+        </Heading>
+        <Text tone="muted" className="max-w-sm mx-auto">
+          {t("shuttingDownDescription")}
+        </Text>
+      </Stack>
+    </Flex>
   );
 }

--- a/web/src/components/settings/system-update.tsx
+++ b/web/src/components/settings/system-update.tsx
@@ -5,12 +5,15 @@ import {
   AlertDescription,
   Badge,
   Button,
+  Code,
   Dialog,
   DialogContent,
   DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  Flex,
+  Text,
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -78,17 +81,22 @@ export function SystemUpdate() {
       <Alert className="border-warning/50 bg-warning/10">
         <ArrowUpCircle className="h-4 w-4 text-warning" />
         <AlertDescription className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
-          <div className="flex items-center gap-2 flex-wrap">
-            <span className="text-sm font-medium">{t("updateAvailable")}</span>
+          <Flex align="center" gap="2" wrap>
+            <Text as="span" weight="medium">
+              {t("updateAvailable")}
+            </Text>
             <Badge variant="secondary" className="text-xs">
               v{updateCheck.latest_version}
             </Badge>
-            <span className="text-sm text-muted-foreground">
+            <Text as="span" tone="muted">
               {t("youAreRunning", { currentVersion: updateCheck.current_version })}
-            </span>
-          </div>
-          <div className="flex items-center gap-2">
+            </Text>
+          </Flex>
+          <Flex align="center" gap="2">
             <Button variant="outline" size="sm" asChild>
+              {/* Plain <a> stays raw: it is the single Slot child of Button asChild,
+                  which merges button styling onto it; TextLink would layer conflicting
+                  link/underline treatment on top. */}
               <a href={updateCheck.package_url} target="_blank" rel="noopener noreferrer">
                 <ExternalLink className="h-4 w-4 mr-2" />
                 {t("viewRelease")}
@@ -116,21 +124,25 @@ export function SystemUpdate() {
                 </Button>
               </TooltipTrigger>
               <TooltipContent>
-                <p>{t("checkForUpdates")}</p>
+                <Text>{t("checkForUpdates")}</Text>
               </TooltipContent>
             </Tooltip>
-          </div>
+          </Flex>
         </AlertDescription>
       </Alert>
 
       {!sidecarReady && (
-        <p className="text-xs text-muted-foreground mt-2 ml-1">
+        <Text size="xs" tone="muted" className="mt-2 ml-1">
           {t.rich("oneClickHint", {
-            profile: () => <span className="font-mono">COMPOSE_PROFILES=fiestaupdater</span>,
-            envFile: () => <code>.env</code>,
-            command: () => <code>docker compose up -d</code>,
+            profile: () => (
+              <Text as="span" size="xs" tone="muted" className="font-mono">
+                COMPOSE_PROFILES=fiestaupdater
+              </Text>
+            ),
+            envFile: () => <Code>.env</Code>,
+            command: () => <Code>docker compose up -d</Code>,
           })}
-        </p>
+        </Text>
       )}
 
       <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
@@ -139,7 +151,11 @@ export function SystemUpdate() {
             <DialogTitle>{t("dialogTitle")}</DialogTitle>
             <DialogDescription>
               {t.rich("dialogDescription", {
-                version: () => <strong>v{updateCheck.latest_version}</strong>,
+                version: () => (
+                  <Text as="span" weight="semibold" tone="muted">
+                    v{updateCheck.latest_version}
+                  </Text>
+                ),
               })}
             </DialogDescription>
           </DialogHeader>

--- a/web/src/components/settings/tile-grid-assignment.tsx
+++ b/web/src/components/settings/tile-grid-assignment.tsx
@@ -379,11 +379,7 @@ export function TileGridAssignment({
         </Flex>
       )}
 
-      <Grid
-        gap="1.5"
-        style={{ gridTemplateColumns: `repeat(${notesWide}, minmax(0, 1fr))` }}
-        data-testid="tile-grid"
-      >
+      <Grid gap="1.5" style={{ gridTemplateColumns: `repeat(${notesWide}, minmax(0, 1fr))` }} data-testid="tile-grid">
         {Array.from({ length: notesTall }, (_, row) =>
           Array.from({ length: notesWide }, (_, col) => {
             const tile = tilesByPos.get(tileKey(row, col));
@@ -412,7 +408,10 @@ export function TileGridAssignment({
                   {position}
                 </Text>
                 {isAssigned ? (
-                  <Text as="span" className="flex items-center gap-1 text-[10px] font-mono truncate max-w-full text-foreground">
+                  <Text
+                    as="span"
+                    className="flex items-center gap-1 text-[10px] font-mono truncate max-w-full text-foreground"
+                  >
                     <Wifi className="h-2.5 w-2.5 flex-shrink-0 text-board-green" />
                     {tile?.host}
                   </Text>

--- a/web/src/components/settings/tile-grid-assignment.tsx
+++ b/web/src/components/settings/tile-grid-assignment.tsx
@@ -2,6 +2,7 @@
 
 import {
   Badge as BadgeUI,
+  Box,
   Button,
   Dialog,
   DialogContent,
@@ -9,11 +10,15 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  Flex,
+  Grid,
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
+  Stack,
+  Text,
 } from "@fiestaboard/ui";
 import { AlertCircle, Check, Key, KeyRound, Loader2, Plus, Radar, ScanSearch, Trash2, Wifi } from "lucide-react";
 import { useMemo, useState } from "react";
@@ -322,10 +327,12 @@ export function TileGridAssignment({
   const canIdentify = canIdentifySaved || keyIsPlaintext;
 
   return (
-    <div className="space-y-2" data-testid="tile-grid-assignment">
-      <div className="flex items-center justify-between gap-2 flex-wrap">
-        <div className="flex items-center gap-2">
-          <span className="text-xs font-medium">{t("tileGrid.title")}</span>
+    <Stack gap="2" data-testid="tile-grid-assignment">
+      <Flex align="center" justify="between" gap="2" wrap>
+        <Flex align="center" gap="2">
+          <Text as="span" size="xs" weight="medium">
+            {t("tileGrid.title")}
+          </Text>
           {assignedCount === totalSlots ? (
             <BadgeUI variant="default" className="text-[10px] h-5 bg-board-green">
               <Check className="h-2.5 w-2.5 mr-0.5" />
@@ -336,7 +343,7 @@ export function TileGridAssignment({
               {t("tileGrid.partialBadge", { assigned: assignedCount, total: totalSlots })}
             </BadgeUI>
           )}
-        </div>
+        </Flex>
         <Button
           type="button"
           variant="secondary"
@@ -352,22 +359,28 @@ export function TileGridAssignment({
           )}
           {t("tileGrid.identifyAll")}
         </Button>
-      </div>
+      </Flex>
 
-      <p className="text-[10px] text-muted-foreground">{t("tileGrid.help")}</p>
+      <Text tone="muted" className="text-[10px]">
+        {t("tileGrid.help")}
+      </Text>
 
       {duplicateHosts.length > 0 && (
-        <div
+        <Flex
           role="alert"
-          className="flex items-center gap-1.5 p-1.5 rounded-md bg-amber-500/10 text-foreground text-[10px]"
+          align="center"
+          gap="1.5"
+          className="p-1.5 rounded-md bg-amber-500/10 text-foreground text-[10px]"
         >
           <AlertCircle className="h-3 w-3 flex-shrink-0 text-amber-600" />
-          <span>{t("tileGrid.duplicateHostWarning", { hosts: duplicateHosts.join(", ") })}</span>
-        </div>
+          <Text as="span" className="text-[10px]">
+            {t("tileGrid.duplicateHostWarning", { hosts: duplicateHosts.join(", ") })}
+          </Text>
+        </Flex>
       )}
 
-      <div
-        className="grid gap-1.5"
+      <Grid
+        gap="1.5"
         style={{ gridTemplateColumns: `repeat(${notesWide}, minmax(0, 1fr))` }}
         data-testid="tile-grid"
       >
@@ -395,23 +408,25 @@ export function TileGridAssignment({
                     : "border-dashed border-muted hover:border-primary/60"
                 }`}
               >
-                <span className="text-[10px] font-semibold text-muted-foreground">{position}</span>
+                <Text as="span" weight="semibold" tone="muted" className="text-[10px]">
+                  {position}
+                </Text>
                 {isAssigned ? (
-                  <span className="flex items-center gap-1 text-[10px] font-mono truncate max-w-full text-foreground">
+                  <Text as="span" className="flex items-center gap-1 text-[10px] font-mono truncate max-w-full text-foreground">
                     <Wifi className="h-2.5 w-2.5 flex-shrink-0 text-board-green" />
                     {tile?.host}
-                  </span>
+                  </Text>
                 ) : (
-                  <span className="flex items-center gap-1 text-[10px] text-muted-foreground">
+                  <Text as="span" tone="muted" className="flex items-center gap-1 text-[10px]">
                     <Plus className="h-2.5 w-2.5" />
                     {t("tileGrid.assign")}
-                  </span>
+                  </Text>
                 )}
               </button>
             );
           }),
         )}
-      </div>
+      </Grid>
 
       <Dialog open={editingSlot !== null} onOpenChange={(open) => !open && closeDialog()}>
         <DialogContent className="max-w-md">
@@ -427,9 +442,9 @@ export function TileGridAssignment({
             <DialogDescription>{t("tileGrid.dialogDescription")}</DialogDescription>
           </DialogHeader>
 
-          <div className="space-y-3">
+          <Stack gap="3">
             {/* Network scan */}
-            <div className="space-y-1.5">
+            <Stack gap="1.5">
               <Button
                 type="button"
                 variant="outline"
@@ -442,12 +457,12 @@ export function TileGridAssignment({
                 {isScanning ? t("tileGrid.scanning") : t("tileGrid.scanNetwork")}
               </Button>
               {discovered && discovered.length > 0 && (
-                <p role="status" className="text-[10px] text-muted-foreground">
+                <Text role="status" tone="muted" className="text-[10px]">
                   {t("tileGrid.scanFound", { count: discovered.length })}
-                </p>
+                </Text>
               )}
               {discovered && discovered.length > 0 && (
-                <div className="max-h-28 overflow-y-auto rounded-md border divide-y">
+                <Box className="max-h-28 overflow-y-auto rounded-md border divide-y">
                   {discovered.map((found) => {
                     const usedBy = assignedHosts.get(found.ip);
                     return (
@@ -459,24 +474,29 @@ export function TileGridAssignment({
                           form.host === found.ip ? "bg-primary/10" : ""
                         }`}
                       >
-                        <span className="font-mono">{found.ip}</span>
-                        <span className="text-[10px] text-muted-foreground">
+                        <Text as="span" size="xs" className="font-mono">
+                          {found.ip}
+                        </Text>
+                        <Text as="span" tone="muted" className="text-[10px]">
                           {usedBy !== undefined
                             ? t("tileGrid.alreadyAssigned", { position: usedBy })
                             : found.hostname || found.source}
-                        </span>
+                        </Text>
                       </button>
                     );
                   })}
-                </div>
+                </Box>
               )}
-            </div>
+            </Stack>
 
             {/* Host + port */}
-            <div className="flex gap-2">
-              <div className="flex-1 space-y-1">
+            <Flex gap="2">
+              <Stack gap="1" className="flex-1">
                 <label className="text-xs font-medium" htmlFor={`tile-host-${board.id}`}>
-                  {t("boardHostLabel")} <span className="text-destructive">*</span>
+                  {t("boardHostLabel")}{" "}
+                  <Text as="span" size="xs" tone="destructive">
+                    *
+                  </Text>
                 </label>
                 <input
                   id={`tile-host-${board.id}`}
@@ -486,8 +506,8 @@ export function TileGridAssignment({
                   placeholder={t("boardHostPlaceholder")}
                   className="w-full h-8 px-2 text-xs rounded-md border bg-background font-mono"
                 />
-              </div>
-              <div className="w-20 space-y-1">
+              </Stack>
+              <Stack gap="1" className="w-20">
                 <label className="text-xs font-medium" htmlFor={`tile-port-${board.id}`}>
                   {t("tileGrid.portLabel")}
                 </label>
@@ -502,11 +522,11 @@ export function TileGridAssignment({
                   }
                   className="w-full h-8 px-2 text-xs rounded-md border bg-background font-mono"
                 />
-              </div>
-            </div>
+              </Stack>
+            </Flex>
 
             {/* Auth method toggle */}
-            <div className="grid grid-cols-2 gap-2">
+            <Grid cols="2" gap="2">
               <button
                 type="button"
                 aria-pressed={form.keyMode === "api_key"}
@@ -533,12 +553,15 @@ export function TileGridAssignment({
                 <KeyRound className="h-3 w-3" />
                 {t("enablementTokenLabel")}
               </button>
-            </div>
+            </Grid>
 
             {form.keyMode === "api_key" ? (
-              <div className="space-y-1">
+              <Stack gap="1">
                 <label className="text-xs font-medium" htmlFor={`tile-key-${board.id}`}>
-                  {t("localApiKeyLabel")} <span className="text-destructive">*</span>
+                  {t("localApiKeyLabel")}{" "}
+                  <Text as="span" size="xs" tone="destructive">
+                    *
+                  </Text>
                 </label>
                 <input
                   id={`tile-key-${board.id}`}
@@ -552,9 +575,9 @@ export function TileGridAssignment({
                   }
                   className="w-full h-8 px-2 text-xs rounded-md border bg-background font-mono"
                 />
-              </div>
+              </Stack>
             ) : (
-              <div className="space-y-1.5">
+              <Stack gap="1.5">
                 <label className="text-xs font-medium" htmlFor={`tile-token-${board.id}`}>
                   {t("enablementTokenLabel")}
                 </label>
@@ -583,11 +606,11 @@ export function TileGridAssignment({
                     t("getApiKeyFromBoard")
                   )}
                 </Button>
-              </div>
+              </Stack>
             )}
 
             {/* Test + Identify */}
-            <div className="flex gap-2">
+            <Flex gap="2">
               <Button
                 type="button"
                 variant="outline"
@@ -600,13 +623,13 @@ export function TileGridAssignment({
                 {t("tileGrid.testTile")}
                 {testResult === "ok" && <Check className="h-3 w-3 ml-1 text-board-green" />}
                 {testResult === "fail" && <AlertCircle className="h-3 w-3 ml-1 text-destructive" />}
-                <span role="status" className="sr-only">
+                <Text as="span" role="status" className="sr-only">
                   {testResult === "ok"
                     ? t("tileGrid.testSuccess")
                     : testResult === "fail"
                       ? t("tileGrid.testFailed")
                       : ""}
-                </span>
+                </Text>
               </Button>
               <Button
                 type="button"
@@ -623,12 +646,12 @@ export function TileGridAssignment({
                 )}
                 {t("tileGrid.identify")}
               </Button>
-            </div>
+            </Flex>
 
             {/* Move / swap — rearrange without retyping credentials. A plain
                 Select, so it is fully keyboard- and screen-reader-accessible. */}
             {editingSaved && totalSlots > 1 && (
-              <div className="space-y-1">
+              <Stack gap="1">
                 <label className="text-xs font-medium" htmlFor={`tile-move-${board.id}`}>
                   {t("tileGrid.moveTile")}
                 </label>
@@ -655,9 +678,9 @@ export function TileGridAssignment({
                     )}
                   </SelectContent>
                 </Select>
-              </div>
+              </Stack>
             )}
-          </div>
+          </Stack>
 
           <DialogFooter className="flex-row justify-between sm:justify-between gap-2">
             {editingSaved ? (
@@ -672,7 +695,7 @@ export function TileGridAssignment({
                 {t("tileGrid.clearTile")}
               </Button>
             ) : (
-              <span />
+              <Text as="span" />
             )}
             <Button type="button" size="sm" className="text-xs" disabled={!keyReady} onClick={handleSave}>
               {t("tileGrid.saveTile")}
@@ -680,6 +703,6 @@ export function TileGridAssignment({
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </div>
+    </Stack>
   );
 }

--- a/web/src/components/settings/time-and-date.tsx
+++ b/web/src/components/settings/time-and-date.tsx
@@ -6,6 +6,7 @@ import {
   CardDescription,
   CardHeader,
   CardTitle,
+  Grid,
   Label,
   Select,
   SelectContent,
@@ -13,6 +14,8 @@ import {
   SelectTrigger,
   SelectValue,
   Skeleton,
+  Stack,
+  Text,
 } from "@fiestaboard/ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { formatInTimeZone } from "date-fns-tz";
@@ -95,22 +98,22 @@ export function TimeAndDateCard() {
       </CardHeader>
       <CardContent>
         {isLoading ? (
-          <div className="space-y-4">
+          <Stack gap="4">
             <Skeleton className="h-10 w-full max-w-sm" />
             <Skeleton className="h-10 w-48" />
             <Skeleton className="h-10 w-48" />
-          </div>
+          </Stack>
         ) : (
-          <div className="space-y-4">
-            <div className="space-y-2 max-w-sm">
+          <Stack gap="4">
+            <Stack gap="2" className="max-w-sm">
               <Label id="timezone-label" htmlFor="timezone-picker" className="text-sm font-medium">
                 {t("timezoneLabel")}
               </Label>
               <TimezonePicker id="timezone-picker" value={timezone} onChange={handleTimezoneChange} />
-            </div>
+            </Stack>
 
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 max-w-md">
-              <div className="space-y-2">
+            <Grid cols="1" sm="2" gap="4" className="max-w-md">
+              <Stack gap="2">
                 <Label htmlFor="time-format" className="text-sm font-medium">
                   {t("timeFormat")}
                 </Label>
@@ -127,9 +130,9 @@ export function TimeAndDateCard() {
                     <SelectItem value="24h">{t("timeFormat24h")}</SelectItem>
                   </SelectContent>
                 </Select>
-              </div>
+              </Stack>
 
-              <div className="space-y-2">
+              <Stack gap="2">
                 <Label htmlFor="date-format" className="text-sm font-medium">
                   {t("dateFormat")}
                 </Label>
@@ -147,14 +150,18 @@ export function TimeAndDateCard() {
                     <SelectItem value="YYYY-MM-DD">{t("dateFormatISO")}</SelectItem>
                   </SelectContent>
                 </Select>
-              </div>
-            </div>
+              </Stack>
+            </Grid>
 
             {(() => {
               const preview = getFormatPreview();
-              return preview ? <p className="text-xs text-muted-foreground">{preview}</p> : null;
+              return preview ? (
+                <Text size="xs" tone="muted">
+                  {preview}
+                </Text>
+              ) : null;
             })()}
-          </div>
+          </Stack>
         )}
       </CardContent>
     </Card>

--- a/web/src/components/settings/transition-settings.tsx
+++ b/web/src/components/settings/transition-settings.tsx
@@ -1,6 +1,20 @@
 "use client";
 
-import { Card, CardContent, CardDescription, CardHeader, CardTitle, Input, Label, Skeleton } from "@fiestaboard/ui";
+import {
+  Box,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Flex,
+  Grid,
+  Input,
+  Label,
+  Skeleton,
+  Stack,
+  Text,
+} from "@fiestaboard/ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Info, Sparkles } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -128,9 +142,9 @@ export function TransitionSettings() {
       </CardHeader>
       <CardContent className="space-y-5">
         {/* Strategy Selector */}
-        <div className="space-y-2">
+        <Stack gap="2">
           <Label className="text-sm font-medium">{t("transitionStyle")}</Label>
-          <div className="flex flex-wrap gap-2">
+          <Flex wrap gap="2">
             {STRATEGY_VALUES.map((option) => {
               const isSelected = strategy === option.value;
               return (
@@ -147,24 +161,26 @@ export function TransitionSettings() {
                 </button>
               );
             })}
-          </div>
+          </Flex>
           {/* Description of selected strategy */}
           {(() => {
             const selected = STRATEGY_VALUES.find((o) => o.value === strategy);
             return selected ? (
-              <p className="text-xs text-muted-foreground">{t(`strategies.${selected.key}.description`)}</p>
+              <Text size="xs" tone="muted">
+                {t(`strategies.${selected.key}.description`)}
+              </Text>
             ) : null;
           })()}
-        </div>
+        </Stack>
 
         {/* Advanced options — only shown when a strategy is selected */}
         {strategy && (
-          <div className="space-y-4 pt-2 border-t">
+          <Stack gap="4" className="pt-2 border-t">
             <Label className="text-sm font-medium">{t("advancedOptions")}</Label>
 
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <Grid cols="1" sm="2" gap="4">
               {/* Step Interval */}
-              <div className="space-y-1.5">
+              <Stack gap="1.5">
                 <Label htmlFor="step-interval" className="text-xs">
                   {t("stepIntervalLabel")}
                 </Label>
@@ -177,11 +193,13 @@ export function TransitionSettings() {
                   onChange={(e) => handleStepIntervalChange(e.target.value)}
                   className="w-full"
                 />
-                <p className="text-[11px] text-muted-foreground">{t("stepIntervalDescription")}</p>
-              </div>
+                <Text size="xs" tone="muted">
+                  {t("stepIntervalDescription")}
+                </Text>
+              </Stack>
 
               {/* Step Size */}
-              <div className="space-y-1.5">
+              <Stack gap="1.5">
                 <Label htmlFor="step-size" className="text-xs">
                   {t("stepSizeLabel")}
                 </Label>
@@ -194,24 +212,30 @@ export function TransitionSettings() {
                   onChange={(e) => handleStepSizeChange(e.target.value)}
                   className="w-full"
                 />
-                <p className="text-[11px] text-muted-foreground">{t("stepSizeDescription")}</p>
-              </div>
-            </div>
-          </div>
+                <Text size="xs" tone="muted">
+                  {t("stepSizeDescription")}
+                </Text>
+              </Stack>
+            </Grid>
+          </Stack>
         )}
 
         {/* Info note */}
-        <div className="flex items-start gap-2 p-2.5 rounded-md bg-muted/50 text-xs text-muted-foreground">
+        <Flex align="start" gap="2" className="p-2.5 rounded-md bg-muted/50 text-xs text-muted-foreground">
           <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-          <span>{t("localApiNote")}</span>
-        </div>
+          <Text as="span" size="xs" tone="muted">
+            {t("localApiNote")}
+          </Text>
+        </Flex>
 
         {/* Saving indicator */}
         {updateMutation.isPending && (
-          <div className="flex items-center justify-center gap-2 pt-2 text-xs text-muted-foreground">
-            <div className="h-3 w-3 animate-spin rounded-full border-2 border-primary border-t-transparent" />
-            <span>{tCommon("saving")}</span>
-          </div>
+          <Flex align="center" justify="center" gap="2" className="pt-2 text-xs text-muted-foreground">
+            <Box className="h-3 w-3 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+            <Text as="span" size="xs" tone="muted">
+              {tCommon("saving")}
+            </Text>
+          </Flex>
         )}
       </CardContent>
     </Card>

--- a/web/src/components/settings/update-intervals.tsx
+++ b/web/src/components/settings/update-intervals.tsx
@@ -1,6 +1,18 @@
 "use client";
 
-import { Card, CardContent, CardDescription, CardHeader, CardTitle, Input, Label, Skeleton } from "@fiestaboard/ui";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Flex,
+  Input,
+  Label,
+  Skeleton,
+  Stack,
+  Text,
+} from "@fiestaboard/ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Timer } from "lucide-react";
 import { useDeferredValue, useEffect, useRef, useState } from "react";
@@ -101,29 +113,31 @@ export function UpdateIntervals() {
       </CardHeader>
       <CardContent className="space-y-6">
         {isLoading || !initialized ? (
-          <div className="space-y-6">
-            <div className="space-y-2">
+          <Stack gap="6">
+            <Stack gap="2">
               <Skeleton className="h-4 w-32" />
               <Skeleton className="h-10 w-32" />
               <Skeleton className="h-3 w-40" />
-            </div>
-            <div className="space-y-2">
+            </Stack>
+            <Stack gap="2">
               <Skeleton className="h-4 w-48" />
               <Skeleton className="h-10 w-32" />
-            </div>
-            <div className="space-y-2">
+            </Stack>
+            <Stack gap="2">
               <Skeleton className="h-4 w-48" />
               <Skeleton className="h-10 w-32" />
-            </div>
-          </div>
+            </Stack>
+          </Stack>
         ) : (
           <>
-            <div className="space-y-2">
+            <Stack gap="2">
               <Label htmlFor="polling-interval" className="text-sm font-medium">
                 {t("boardUpdateIntervalLabel")}
               </Label>
-              <p className="text-xs text-muted-foreground">{t("boardUpdateIntervalDescription")}</p>
-              <div className="flex items-center gap-3">
+              <Text size="xs" tone="muted">
+                {t("boardUpdateIntervalDescription")}
+              </Text>
+              <Flex align="center" gap="3">
                 <Input
                   id="polling-interval"
                   type="number"
@@ -135,17 +149,23 @@ export function UpdateIntervals() {
                   disabled={isSaving}
                   className="w-32"
                 />
-                <span className="text-sm text-muted-foreground">{tc("seconds")}</span>
-              </div>
-              <p className="text-xs text-muted-foreground">{t("requiresServiceRestart")}</p>
-            </div>
+                <Text as="span" tone="muted">
+                  {tc("seconds")}
+                </Text>
+              </Flex>
+              <Text size="xs" tone="muted">
+                {t("requiresServiceRestart")}
+              </Text>
+            </Stack>
 
-            <div className="space-y-2">
+            <Stack gap="2">
               <Label htmlFor="board-read-local" className="text-sm font-medium">
                 {t("boardReadIntervalLocalLabel")}
               </Label>
-              <p className="text-xs text-muted-foreground">{t("boardReadIntervalLocalDescription")}</p>
-              <div className="flex items-center gap-3">
+              <Text size="xs" tone="muted">
+                {t("boardReadIntervalLocalDescription")}
+              </Text>
+              <Flex align="center" gap="3">
                 <Input
                   id="board-read-local"
                   type="number"
@@ -160,16 +180,20 @@ export function UpdateIntervals() {
                   disabled={updateBoardReadIntervalMutation.isPending}
                   className="w-32"
                 />
-                <span className="text-sm text-muted-foreground">{tc("seconds")}</span>
-              </div>
-            </div>
+                <Text as="span" tone="muted">
+                  {tc("seconds")}
+                </Text>
+              </Flex>
+            </Stack>
 
-            <div className="space-y-2">
+            <Stack gap="2">
               <Label htmlFor="board-read-cloud" className="text-sm font-medium">
                 {t("boardReadIntervalCloudLabel")}
               </Label>
-              <p className="text-xs text-muted-foreground">{t("boardReadIntervalCloudDescription")}</p>
-              <div className="flex items-center gap-3">
+              <Text size="xs" tone="muted">
+                {t("boardReadIntervalCloudDescription")}
+              </Text>
+              <Flex align="center" gap="3">
                 <Input
                   id="board-read-cloud"
                   type="number"
@@ -184,10 +208,16 @@ export function UpdateIntervals() {
                   disabled={updateBoardReadIntervalMutation.isPending}
                   className="w-32"
                 />
-                <span className="text-sm text-muted-foreground">{tc("seconds")}</span>
-              </div>
-              {boardReadIntervalCloud < 60 && <p className="text-xs text-warning">{t("boardReadIntervalWarning")}</p>}
-            </div>
+                <Text as="span" tone="muted">
+                  {tc("seconds")}
+                </Text>
+              </Flex>
+              {boardReadIntervalCloud < 60 && (
+                <Text size="xs" tone="warning">
+                  {t("boardReadIntervalWarning")}
+                </Text>
+              )}
+            </Stack>
           </>
         )}
       </CardContent>


### PR DESCRIPTION
Wave 4 of 6 for epic #1474: migrates all 25 `web/src/components/settings/` files to `@fiestaboard/ui` primitives per the plan recipe.

## Highlights
- Form-dense area: all `aria`/`role`/`htmlFor`/`onSubmit` wiring preserved (reviewer-verified balanced counts); `role="radiogroup"`/`alert"/"status"` land on the correct replacements
- Every removed `gap-*`/`space-y-*` was already on the enumerated scale — zero rounding drift
- `about-card.tsx` keeps its `dl/dt/dd` raw (allowlisted); one documented raw `<a>` remains as a `Button asChild` Slot child (system-update.tsx) — Slot children must stay real elements
- Dynamic tones preserved (`tone={ok ? "success" : "destructive"}`)
- No tables existed in settings (the plan's table note was hypothetical) — nothing lost

## Verification
- ESLint 0 errors, prettier clean (Docker); DoD grep clean; zero new type errors (3 pre-existing TS7006 byte-identical at base)
- Task-reviewed (Approved). Two nits worth an eyeball on a logged-in instance: tooltip body text may bump `text-xs`→`text-sm` in two spots, and required-field `*` marks drop an inherited `font-medium`
- ⚠️ `/settings` is auth-gated on a fresh instance — no screenshots; please eyeball the tabs light+dark on your live instance

Part of #1474

🤖 Generated with [Claude Code](https://claude.com/claude-code)