### PR TITLE
refactor: adopt FiestaUI primitives — wave 5 (tiptap template editor)

### DIFF
--- a/web/src/components/tiptap-template-editor/TipTapTemplateEditor.tsx
+++ b/web/src/components/tiptap-template-editor/TipTapTemplateEditor.tsx
@@ -31,7 +31,7 @@ import { brushToCell } from "./utils/draw-mode";
 import { parseLineContent, parseTemplateSimple, serializeTemplateSimple } from "./utils/serialization";
 import { buildStrokeTransaction } from "./utils/stroke-transaction";
 export type LineAlignment = "left" | "center" | "right";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@fiestaboard/ui";
+import { Box, Flex, Stack, Text, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@fiestaboard/ui";
 
 import { useTranslations } from "@/i18n/translations";
 
@@ -1216,13 +1216,13 @@ export const TipTapTemplateEditor = forwardRef<TipTapTemplateEditorHandle, TipTa
 
     if (!editor) {
       return (
-        <div className={cn("min-h-[9rem] border rounded-md p-2 bg-muted/30", className)}>
-          <div className="space-y-1">
+        <Box className={cn("min-h-[9rem] border rounded-md p-2 bg-muted/30", className)}>
+          <Stack gap="1">
             {Array.from({ length: boardLines }).map((_, i) => (
-              <div key={i} className="h-6 bg-background/50 rounded" />
+              <Box key={i} className="h-6 bg-background/50 rounded" />
             ))}
-          </div>
-        </div>
+          </Stack>
+        </Box>
       );
     }
     const currentWrapEnabled =
@@ -1233,7 +1233,7 @@ export const TipTapTemplateEditor = forwardRef<TipTapTemplateEditorHandle, TipTa
     const isOverLineLimit = editorLineCount > boardLines;
 
     return (
-      <div className={cn("relative", className)}>
+      <Box className={cn("relative", className)}>
         {/* Toolbar */}
         {showToolbar && (
           <TemplateEditorToolbar
@@ -1260,8 +1260,8 @@ export const TipTapTemplateEditor = forwardRef<TipTapTemplateEditorHandle, TipTa
           mounted) while draw mode is active so applyStroke can keep
           operating on the live ProseMirror doc without the user seeing the
           rich-text view underneath the drawing canvas. */}
-        <div className={cn("flex-1", drawMode && "hidden")}>
-          <div
+        <Box className={cn("flex-1", drawMode && "hidden")}>
+          <Box
             className={cn(
               "border bg-background relative rounded-md",
               showToolbar ? "rounded-t-none" : "",
@@ -1272,9 +1272,9 @@ export const TipTapTemplateEditor = forwardRef<TipTapTemplateEditorHandle, TipTa
               minHeight: `${boardLines * 1.5 + 1.5}rem`,
             }}
           >
-            <div className="flex gap-2" style={{ minHeight: `${boardLines * 1.5}rem` }}>
+            <Flex gap="2" style={{ minHeight: `${boardLines * 1.5}rem` }}>
               {/* Line numbers gutter */}
-              <div
+              <Box
                 className="select-none shrink-0 text-right"
                 style={{
                   fontSize: "0.75rem",
@@ -1284,7 +1284,7 @@ export const TipTapTemplateEditor = forwardRef<TipTapTemplateEditorHandle, TipTa
                 aria-hidden="true"
               >
                 {Array.from({ length: Math.max(editorLineCount, boardLines) }, (_, i) => (
-                  <div
+                  <Box
                     key={i}
                     style={{
                       height: `${lineHeights[i] ?? 24}px`,
@@ -1294,29 +1294,34 @@ export const TipTapTemplateEditor = forwardRef<TipTapTemplateEditorHandle, TipTa
                     }}
                   >
                     {i + 1}
-                  </div>
+                  </Box>
                 ))}
-              </div>
+              </Box>
 
               {/* Editor content */}
-              <div className="relative flex-1 min-w-0">
+              <Box className="relative flex-1 min-w-0">
                 <EditorContent editor={editor} />
-              </div>
-            </div>
-          </div>
+              </Box>
+            </Flex>
+          </Box>
 
           {/* Line counter */}
-          <div className={cn("mt-1 text-xs", isOverLineLimit ? "text-warning font-medium" : "text-muted-foreground")}>
+          <Text
+            size="xs"
+            className={cn("mt-1", isOverLineLimit ? "text-warning font-medium" : "text-muted-foreground")}
+          >
             {editorLineCount} / {boardLines} lines
             {isOverLineLimit && ` — exceeds the ${boardLines}-line board limit`}
-          </div>
+          </Text>
 
           {/* Alignment controls - only show if toolbar is hidden */}
           {!showToolbar && showAlignmentControls && (
             <TooltipProvider>
-              <div className="flex items-center gap-2 mt-2">
-                <span className="text-xs text-muted-foreground">{t("alignment")}</span>
-                <div className="flex rounded-md border overflow-hidden">
+              <Flex align="center" gap="2" className="mt-2">
+                <Text as="span" size="xs" tone="muted">
+                  {t("alignment")}
+                </Text>
+                <Flex className="rounded-md border overflow-hidden">
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <button
@@ -1368,14 +1373,16 @@ export const TipTapTemplateEditor = forwardRef<TipTapTemplateEditorHandle, TipTa
                     </TooltipTrigger>
                     <TooltipContent>{t("alignRight")}</TooltipContent>
                   </Tooltip>
-                </div>
+                </Flex>
                 {currentLineIndex !== null && (
-                  <span className="text-xs text-muted-foreground">(Line {currentLineIndex + 1})</span>
+                  <Text as="span" size="xs" tone="muted">
+                    (Line {currentLineIndex + 1})
+                  </Text>
                 )}
-              </div>
+              </Flex>
             </TooltipProvider>
           )}
-        </div>
+        </Box>
 
         {/* Placeholder styling */}
         <style jsx global>{`
@@ -1520,7 +1527,7 @@ export const TipTapTemplateEditor = forwardRef<TipTapTemplateEditorHandle, TipTa
             border-radius: 3px;
           }
         `}</style>
-      </div>
+      </Box>
     );
   },
 );

--- a/web/src/components/tiptap-template-editor/components/ColorPickerContent.tsx
+++ b/web/src/components/tiptap-template-editor/components/ColorPickerContent.tsx
@@ -3,7 +3,7 @@
  */
 "use client";
 
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@fiestaboard/ui";
+import { Box, Grid, Text, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@fiestaboard/ui";
 import { Heart } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
@@ -32,7 +32,7 @@ const COLOR_ORDER = ["red", "orange", "yellow", "green", "blue", "violet", "whit
 export function ColorPickerContent({ onInsert, deviceType }: ColorPickerContentProps) {
   const isNote = deviceType === "note";
   const [highlightedIndex, setHighlightedIndex] = useState(-1);
-  const containerRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLElement>(null);
   const buttonRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
   // Handle keyboard navigation
@@ -150,14 +150,14 @@ export function ColorPickerContent({ onInsert, deviceType }: ColorPickerContentP
 
   return (
     <TooltipProvider>
-      <div
+      <Box
         ref={containerRef}
         className={cn("p-2", !isNote && "pb-1")}
         tabIndex={0}
         role="listbox"
         aria-label="Color picker"
       >
-        <div className="grid grid-cols-4 gap-2 w-64">
+        <Grid cols="4" gap="2" className="w-64">
           {COLOR_ORDER.map((colorName, index) => {
             const colorInfo = COLOR_MAP[colorName];
             if (!colorInfo) return null;
@@ -189,14 +189,14 @@ export function ColorPickerContent({ onInsert, deviceType }: ColorPickerContentP
                   </button>
                 </TooltipTrigger>
                 <TooltipContent>
-                  <p>{colorName}</p>
+                  <Text>{colorName}</Text>
                 </TooltipContent>
               </Tooltip>
             );
           })}
-        </div>
+        </Grid>
         {isNote && (
-          <div className="mt-2 pt-2 border-t border-border">
+          <Box className="mt-2 pt-2 border-t border-border">
             <Tooltip>
               <TooltipTrigger asChild>
                 <button
@@ -212,16 +212,18 @@ export function ColorPickerContent({ onInsert, deviceType }: ColorPickerContentP
                   aria-selected={false}
                 >
                   <Heart className="w-4 h-4 fill-current" />
-                  <span>heart</span>
+                  <Text as="span" weight="medium" className="text-red-500">
+                    heart
+                  </Text>
                 </button>
               </TooltipTrigger>
               <TooltipContent>
-                <p>Insert heart character (Note only)</p>
+                <Text>Insert heart character (Note only)</Text>
               </TooltipContent>
             </Tooltip>
-          </div>
+          </Box>
         )}
-      </div>
+      </Box>
     </TooltipProvider>
   );
 }

--- a/web/src/components/tiptap-template-editor/components/DrawCharPickerContent.tsx
+++ b/web/src/components/tiptap-template-editor/components/DrawCharPickerContent.tsx
@@ -3,6 +3,7 @@
  */
 "use client";
 
+import { Box, Grid } from "@fiestaboard/ui";
 import { useRef, useState } from "react";
 
 import { cn } from "@/lib/utils";
@@ -67,8 +68,8 @@ export function DrawCharPickerContent({ current, onSelect }: DrawCharPickerConte
     // trigger-sized wrapper, so without an explicit width the panel
     // shrink-fits to ~36px and the grid-cols-8 tracks (minmax(0,1fr))
     // collapse until the glyph buttons overlap.
-    <div className="w-64 p-2" data-testid="draw-char-picker">
-      <div className="grid grid-cols-8 gap-1">
+    <Box className="w-64 p-2" data-testid="draw-char-picker">
+      <Grid cols="8" gap="1">
         {DRAW_CHARS.map((char, index) => (
           <button
             key={char}
@@ -91,7 +92,7 @@ export function DrawCharPickerContent({ current, onSelect }: DrawCharPickerConte
             {char}
           </button>
         ))}
-      </div>
-    </div>
+      </Grid>
+    </Box>
   );
 }

--- a/web/src/components/tiptap-template-editor/components/FilterPickerContent.tsx
+++ b/web/src/components/tiptap-template-editor/components/FilterPickerContent.tsx
@@ -4,7 +4,7 @@
  */
 "use client";
 
-import { Badge } from "@fiestaboard/ui";
+import { Badge, Box, Flex, Stack, Text } from "@fiestaboard/ui";
 import type { Editor } from "@tiptap/react";
 import { AlertCircle } from "lucide-react";
 
@@ -20,7 +20,11 @@ interface FilterPickerContentProps {
 export function FilterPickerContent({ filters, editor, onInsert }: FilterPickerContentProps) {
   const t = useTranslations("filterPicker");
   if (filters.length === 0) {
-    return <div className="p-3 text-sm text-muted-foreground">{t("noFiltersAvailable")}</div>;
+    return (
+      <Text tone="muted" className="p-3">
+        {t("noFiltersAvailable")}
+      </Text>
+    );
   }
 
   const handleFilterClick = (filterName: string) => {
@@ -157,14 +161,16 @@ export function FilterPickerContent({ filters, editor, onInsert }: FilterPickerC
     : false;
 
   return (
-    <div className="p-2 min-w-[250px]">
+    <Box className="p-2 min-w-[250px]">
       {!hasVariableSelected && editor && (
-        <div className="mb-2 p-2 bg-muted/50 rounded-md text-xs text-muted-foreground flex items-start gap-2">
+        <Flex align="start" gap="2" className="mb-2 p-2 bg-muted/50 rounded-md text-xs text-muted-foreground">
           <AlertCircle className="w-3.5 h-3.5 mt-0.5 flex-shrink-0" />
-          <span>{t("selectVariableFirst")}</span>
-        </div>
+          <Text as="span" size="xs" tone="muted">
+            {t("selectVariableFirst")}
+          </Text>
+        </Flex>
       )}
-      <div className="space-y-2">
+      <Stack gap="2">
         {filters.map((filter) => {
           const filterName = filter.split(":")[0];
           return (
@@ -181,21 +187,26 @@ export function FilterPickerContent({ filters, editor, onInsert }: FilterPickerC
               <Badge variant="secondary" className="font-mono text-xs">
                 |{filter}
               </Badge>
-              <span className="text-xs text-muted-foreground">
+              <Text as="span" size="xs" tone="muted">
                 {filterName === "wrap" && t("filterDescWrap")}
                 {filterName === "pad" && t("filterDescPad")}
                 {filterName === "truncate" && t("filterDescTruncate")}
-              </span>
+              </Text>
             </button>
           );
         })}
-      </div>
-      <div className="mt-3 pt-3 border-t text-xs text-muted-foreground space-y-1">
-        <p>Example: {"{{weather.temperature|pad:3}}"}</p>
-        <p className="text-[10px]">
-          <strong>|wrap</strong>: {t("wrapInstruction")}
-        </p>
-      </div>
-    </div>
+      </Stack>
+      <Stack gap="1" className="mt-3 pt-3 border-t text-xs text-muted-foreground">
+        <Text size="xs" tone="muted">
+          Example: {"{{weather.temperature|pad:3}}"}
+        </Text>
+        <Text tone="muted" className="text-[10px]">
+          <Text as="span" weight="semibold" tone="muted" className="text-[10px]">
+            |wrap
+          </Text>
+          : {t("wrapInstruction")}
+        </Text>
+      </Stack>
+    </Box>
   );
 }

--- a/web/src/components/tiptap-template-editor/components/FormattingPickerContent.tsx
+++ b/web/src/components/tiptap-template-editor/components/FormattingPickerContent.tsx
@@ -3,7 +3,18 @@
  */
 "use client";
 
-import { Badge, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@fiestaboard/ui";
+import {
+  Badge,
+  Box,
+  Flex,
+  Grid,
+  Stack,
+  Text,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@fiestaboard/ui";
 import { ChevronRight, ChevronsLeftRight } from "lucide-react";
 import React from "react";
 
@@ -47,7 +58,11 @@ export function FormattingPickerContent({ formatting, onInsert }: FormattingPick
   }));
 
   if (options.length === 0) {
-    return <div className="p-3 text-sm text-muted-foreground">{t("noFormattingAvailable")}</div>;
+    return (
+      <Text tone="muted" className="p-3">
+        {t("noFormattingAvailable")}
+      </Text>
+    );
   }
 
   const handleOptionClick = (option: FormattingOption) => {
@@ -76,7 +91,7 @@ export function FormattingPickerContent({ formatting, onInsert }: FormattingPick
   if (showRepeatColorPicker) {
     return (
       <TooltipProvider>
-        <div className="p-2 min-w-[240px] max-w-[280px]">
+        <Box className="p-2 min-w-[240px] max-w-[280px]">
           <button
             type="button"
             onClick={() => setShowRepeatColorPicker(false)}
@@ -86,9 +101,11 @@ export function FormattingPickerContent({ formatting, onInsert }: FormattingPick
           </button>
 
           {/* Colors Section */}
-          <div className="text-xs font-medium mb-2 text-muted-foreground">{t("selectColor")}</div>
+          <Text size="xs" tone="muted" weight="medium" className="mb-2">
+            {t("selectColor")}
+          </Text>
 
-          <div className="grid grid-cols-4 gap-2 mb-3">
+          <Grid cols="4" gap="2" className="mb-3">
             {COLOR_ORDER.map((colorName) => {
               const colorInfo = COLOR_MAP[colorName];
               if (!colorInfo) return null;
@@ -111,17 +128,19 @@ export function FormattingPickerContent({ formatting, onInsert }: FormattingPick
                     </button>
                   </TooltipTrigger>
                   <TooltipContent>
-                    <p>{colorName}</p>
+                    <Text>{colorName}</Text>
                   </TooltipContent>
                 </Tooltip>
               );
             })}
-          </div>
+          </Grid>
 
           {/* Custom String */}
-          <div className="pt-2 border-t border-border">
-            <div className="text-xs text-muted-foreground mb-1.5">{t("orCustomPattern")}</div>
-            <form onSubmit={handleCustomCharSubmit} className="flex gap-1.5">
+          <Box className="pt-2 border-t border-border">
+            <Text size="xs" tone="muted" className="mb-1.5">
+              {t("orCustomPattern")}
+            </Text>
+            <Box as="form" onSubmit={handleCustomCharSubmit} className="flex gap-1.5">
               <input
                 type="text"
                 value={customChar}
@@ -146,9 +165,9 @@ export function FormattingPickerContent({ formatting, onInsert }: FormattingPick
               >
                 {t("use")}
               </button>
-            </form>
-          </div>
-        </div>
+            </Box>
+          </Box>
+        </Box>
       </TooltipProvider>
     );
   }
@@ -156,8 +175,8 @@ export function FormattingPickerContent({ formatting, onInsert }: FormattingPick
   // Show main formatting options
   return (
     <TooltipProvider>
-      <div className="p-1.5 min-w-[240px] max-w-[280px]">
-        <div className="space-y-0.5">
+      <Box className="p-1.5 min-w-[240px] max-w-[280px]">
+        <Stack gap="0.5">
           {options.map((option) => {
             const isRepeat = option.syntax.includes("fill_space_repeat");
 
@@ -173,10 +192,16 @@ export function FormattingPickerContent({ formatting, onInsert }: FormattingPick
                       "flex items-center justify-between gap-2 group",
                     )}
                   >
-                    <div className="flex items-center gap-2 flex-1 min-w-0">
+                    <Flex align="center" gap="2" className="flex-1 min-w-0">
                       <ChevronsLeftRight className="w-3.5 h-3.5 text-muted-foreground group-hover:text-accent-foreground flex-shrink-0" />
-                      <span className="font-medium capitalize truncate">{option.name}</span>
-                    </div>
+                      <Text
+                        as="span"
+                        weight="medium"
+                        className="capitalize truncate group-hover:text-accent-foreground"
+                      >
+                        {option.name}
+                      </Text>
+                    </Flex>
                     {isRepeat ? (
                       <ChevronRight className="w-3.5 h-3.5 text-muted-foreground group-hover:text-accent-foreground flex-shrink-0" />
                     ) : (
@@ -187,13 +212,13 @@ export function FormattingPickerContent({ formatting, onInsert }: FormattingPick
                   </button>
                 </TooltipTrigger>
                 <TooltipContent>
-                  <p>{option.description ?? option.name}</p>
+                  <Text>{option.description ?? option.name}</Text>
                 </TooltipContent>
               </Tooltip>
             );
           })}
-        </div>
-      </div>
+        </Stack>
+      </Box>
     </TooltipProvider>
   );
 }

--- a/web/src/components/tiptap-template-editor/components/FormulaEditorPanel.tsx
+++ b/web/src/components/tiptap-template-editor/components/FormulaEditorPanel.tsx
@@ -16,10 +16,16 @@ import { HighlightStyle, StreamLanguage, syntaxHighlighting } from "@codemirror/
 import { EditorState } from "@codemirror/state";
 import { EditorView, keymap } from "@codemirror/view";
 import {
+  Box,
+  Flex,
+  List,
+  ListItem,
+  Stack,
   Tabs,
   TabsContent,
   TabsList,
   TabsTrigger,
+  Text,
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -232,7 +238,7 @@ export function FormulaEditorPanel({ initialExpr = "", mode, onConfirm, onCancel
   const [collapsedCategories, setCollapsedCategories] = useState<Set<string>>(new Set());
 
   // CodeMirror refs
-  const editorContainerRef = useRef<HTMLDivElement>(null);
+  const editorContainerRef = useRef<HTMLElement>(null);
   const viewRef = useRef<EditorView | null>(null);
 
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -443,9 +449,9 @@ export function FormulaEditorPanel({ initialExpr = "", mode, onConfirm, onCancel
   return (
     <TooltipProvider>
       {/* Root: stacked on mobile, side-by-side on desktop */}
-      <div className="flex flex-col sm:flex-row w-full sm:h-[560px]">
+      <Flex direction="col" className="sm:flex-row w-full sm:h-[560px]">
         {/* ── LEFT COLUMN (desktop) / BOTTOM (mobile): Functions + Variables selector ── */}
-        <div
+        <Box
           className={cn(
             "order-2 sm:order-1",
             "sm:w-[260px] sm:flex-shrink-0",
@@ -455,7 +461,7 @@ export function FormulaEditorPanel({ initialExpr = "", mode, onConfirm, onCancel
         >
           <Tabs defaultValue="functions">
             {/* Tab switcher — sticky on desktop so it stays visible while scrolling the list */}
-            <div className="px-3 pt-2 pb-1 sm:sticky sm:top-0 sm:bg-popover sm:z-10 sm:border-b sm:border-border/50">
+            <Box className="px-3 pt-2 pb-1 sm:sticky sm:top-0 sm:bg-popover sm:z-10 sm:border-b sm:border-border/50">
               <TabsList className="h-8 w-full bg-muted p-0.5">
                 <TabsTrigger
                   value="functions"
@@ -470,20 +476,24 @@ export function FormulaEditorPanel({ initialExpr = "", mode, onConfirm, onCancel
                   {t("variablesTab")}
                 </TabsTrigger>
               </TabsList>
-            </div>
+            </Box>
 
             {/* ── Functions tab ── */}
             <TabsContent value="functions" className="mt-0">
-              {loadingFns && <p className="text-xs text-muted-foreground px-3 py-2">{t("loading") ?? "Loading…"}</p>}
+              {loadingFns && (
+                <Text size="xs" tone="muted" className="px-3 py-2">
+                  {t("loading") ?? "Loading…"}
+                </Text>
+              )}
               {/* Parent column (desktop) or modal (mobile) scrolls — don't nest a scroll here. */}
-              <div className="px-2 pb-2 space-y-1">
+              <Stack gap="1" className="px-2 pb-2">
                 {CATEGORY_ORDER.filter((cat) => grouped[cat]?.length).map((cat) => {
                   const isCollapsed = collapsedCategories.has(cat);
                   const fns = grouped[cat] ?? [];
                   const meta = CATEGORY_META[cat];
                   const IconComp = meta?.icon;
                   return (
-                    <div key={cat} className={cn("overflow-hidden border-l-2", meta?.border ?? "border-border/0")}>
+                    <Box key={cat} className={cn("overflow-hidden border-l-2", meta?.border ?? "border-border/0")}>
                       <button
                         type="button"
                         onClick={() => toggleCategory(cat)}
@@ -493,10 +503,16 @@ export function FormulaEditorPanel({ initialExpr = "", mode, onConfirm, onCancel
                           meta?.text ?? "text-muted-foreground",
                         )}
                       >
-                        <span className="flex items-center gap-1.5">
+                        {/* Carry the button's dynamic category color + sub-xs size
+                            so <Text as="span">'s default tone/size don't clobber them. */}
+                        <Text
+                          as="span"
+                          weight="semibold"
+                          className={cn("flex items-center gap-1.5 text-[11px]", meta?.text ?? "text-muted-foreground")}
+                        >
                           {IconComp && <IconComp className="w-3 h-3" />}
                           {categoryLabels[cat] ?? cat}
-                        </span>
+                        </Text>
                         {isCollapsed ? (
                           <ChevronRight className="w-3 h-3 text-muted-foreground" />
                         ) : (
@@ -505,7 +521,7 @@ export function FormulaEditorPanel({ initialExpr = "", mode, onConfirm, onCancel
                       </button>
 
                       {!isCollapsed && (
-                        <div className="py-0.5">
+                        <Box className="py-0.5">
                           {fns.map((fn) => (
                             <Tooltip key={fn.name}>
                               <TooltipTrigger asChild>
@@ -514,24 +530,39 @@ export function FormulaEditorPanel({ initialExpr = "", mode, onConfirm, onCancel
                                   onClick={() => handleFunctionClick(fn.name)}
                                   className="w-full text-left px-3 py-1 text-xs hover:bg-accent hover:text-accent-foreground transition-colors flex items-baseline gap-2 group"
                                 >
-                                  <span className="font-mono font-semibold flex-shrink-0">{fn.name}</span>
-                                  <span className="font-mono text-[10px] text-muted-foreground truncate group-hover:text-accent-foreground/70">
+                                  <Text
+                                    as="span"
+                                    size="xs"
+                                    weight="semibold"
+                                    className="font-mono flex-shrink-0 group-hover:text-accent-foreground"
+                                  >
+                                    {fn.name}
+                                  </Text>
+                                  <Text
+                                    as="span"
+                                    tone="muted"
+                                    className="font-mono text-[10px] truncate group-hover:text-accent-foreground/70"
+                                  >
                                     {fn.signature}
-                                  </span>
+                                  </Text>
                                 </button>
                               </TooltipTrigger>
                               <TooltipContent side="right" className="max-w-[220px]">
-                                <p className="font-mono text-xs font-semibold">{fn.signature}</p>
-                                <p className="text-xs text-muted-foreground mt-0.5">{fn.summary}</p>
+                                <Text size="xs" weight="semibold" className="font-mono">
+                                  {fn.signature}
+                                </Text>
+                                <Text size="xs" tone="muted" className="mt-0.5">
+                                  {fn.summary}
+                                </Text>
                               </TooltipContent>
                             </Tooltip>
                           ))}
-                        </div>
+                        </Box>
                       )}
-                    </div>
+                    </Box>
                   );
                 })}
-              </div>
+              </Stack>
             </TabsContent>
 
             {/* ── Variables tab ── */}
@@ -545,18 +576,18 @@ export function FormulaEditorPanel({ initialExpr = "", mode, onConfirm, onCancel
               />
             </TabsContent>
           </Tabs>
-        </div>
+        </Box>
 
         {/* ── RIGHT COLUMN (desktop) / TOP (mobile): Expression editor + action buttons ── */}
-        <div className="order-1 sm:order-2 flex flex-col flex-1 min-w-0 sm:overflow-hidden">
+        <Flex direction="col" className="order-1 sm:order-2 flex-1 min-w-0 sm:overflow-hidden">
           {/* Desktop: flex column fills, editor sizes within. Mobile: parent modal scrolls — no nested scroll. */}
-          <div className="px-3 pt-3 pb-2.5 space-y-1.5 sm:flex-1 sm:flex sm:flex-col sm:overflow-hidden">
+          <Stack gap="1.5" className="px-3 pt-3 pb-2.5 sm:flex-1 sm:flex sm:flex-col sm:overflow-hidden">
             <label className="text-[10px] font-semibold text-muted-foreground uppercase tracking-widest">
               {t("formulaExpression")}
             </label>
 
             {/* Editor container — border changes colour with validation state */}
-            <div
+            <Box
               className={cn(
                 "rounded-md border overflow-hidden sm:flex-1 sm:flex sm:flex-col sm:min-h-0",
                 validationState === "invalid" && "border-destructive",
@@ -565,17 +596,21 @@ export function FormulaEditorPanel({ initialExpr = "", mode, onConfirm, onCancel
               )}
             >
               {/* Top chrome: {{= prefix + validation icon */}
-              <div
+              <Flex
+                align="center"
+                justify="between"
                 className={cn(
-                  "flex items-center justify-between px-2.5 py-1 border-b sm:flex-shrink-0",
+                  "px-2.5 py-1 border-b sm:flex-shrink-0",
                   "bg-muted/20 select-none",
                   validationState === "invalid" && "border-destructive/40",
                   validationState === "valid" && "border-green-500/40",
                   validationState !== "invalid" && validationState !== "valid" && "border-border",
                 )}
               >
-                <span className="text-[10px] text-muted-foreground/50 font-mono">{"{{="}</span>
-                <span className="flex items-center">
+                <Text as="span" className="text-[10px] text-muted-foreground/50 font-mono">
+                  {"{{="}
+                </Text>
+                <Text as="span" className="flex items-center">
                   {validationState === "valid" && expr.trim() ? (
                     <CheckCircle2 className="w-3.5 h-3.5 text-green-500" />
                   ) : validationState === "invalid" ? (
@@ -583,14 +618,14 @@ export function FormulaEditorPanel({ initialExpr = "", mode, onConfirm, onCancel
                   ) : validationState === "validating" ? (
                     <Loader2 className="w-3.5 h-3.5 text-muted-foreground/50 animate-spin" />
                   ) : null}
-                </span>
-              </div>
+                </Text>
+              </Flex>
 
               {/* CodeMirror mounts here */}
-              <div ref={editorContainerRef} className="sm:flex-1 sm:min-h-0 sm:overflow-hidden" />
+              <Box ref={editorContainerRef} className="sm:flex-1 sm:min-h-0 sm:overflow-hidden" />
 
               {/* Bottom chrome: }} */}
-              <div
+              <Box
                 className={cn(
                   "px-2.5 py-1 border-t bg-muted/20 select-none sm:flex-shrink-0",
                   validationState === "invalid" && "border-destructive/40",
@@ -598,25 +633,29 @@ export function FormulaEditorPanel({ initialExpr = "", mode, onConfirm, onCancel
                   validationState !== "invalid" && validationState !== "valid" && "border-border",
                 )}
               >
-                <span className="text-[10px] text-muted-foreground/50 font-mono">{"}}"}</span>
-              </div>
-            </div>
+                <Text as="span" className="text-[10px] text-muted-foreground/50 font-mono">
+                  {"}}"}
+                </Text>
+              </Box>
+            </Box>
 
             {/* Error messages */}
             {validationState === "invalid" && errors.length > 0 && (
-              <ul className="space-y-0.5">
+              <List className="space-y-0.5">
                 {errors.map((msg, i) => (
-                  <li key={i} className="flex items-start gap-1 text-[10px] text-destructive">
+                  <ListItem key={i} className="flex items-start gap-1 text-[10px] text-destructive">
                     <XCircle className="w-3 h-3 flex-shrink-0 mt-0.5" />
-                    <span>{msg}</span>
-                  </li>
+                    <Text as="span" tone="destructive" className="text-[10px]">
+                      {msg}
+                    </Text>
+                  </ListItem>
                 ))}
-              </ul>
+              </List>
             )}
-          </div>
+          </Stack>
 
           {/* Action buttons — pinned to bottom of right column */}
-          <div className="flex-shrink-0 border-t border-border px-3 py-2 flex justify-end gap-2">
+          <Flex justify="end" gap="2" className="flex-shrink-0 border-t border-border px-3 py-2">
             {mode === "edit" && onCancel && (
               <button
                 type="button"
@@ -642,9 +681,9 @@ export function FormulaEditorPanel({ initialExpr = "", mode, onConfirm, onCancel
                 ⌘↵
               </kbd>
             </button>
-          </div>
-        </div>
-      </div>
+          </Flex>
+        </Flex>
+      </Flex>
     </TooltipProvider>
   );
 }

--- a/web/src/components/tiptap-template-editor/components/TemplateEditorToolbar.tsx
+++ b/web/src/components/tiptap-template-editor/components/TemplateEditorToolbar.tsx
@@ -4,7 +4,7 @@
  */
 "use client";
 
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@fiestaboard/ui";
+import { Box, Flex, Text, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@fiestaboard/ui";
 import { useQuery } from "@tanstack/react-query";
 import type { Editor } from "@tiptap/react";
 import {
@@ -253,11 +253,11 @@ export function TemplateEditorToolbar({
     // adjacent buttons (e.g. the editor card's AI toggle) shifts the
     // layout and the cursor briefly hovers a different button.
     <TooltipProvider skipDelayDuration={0}>
-      <div className={cn("flex items-center gap-1 p-2 border rounded-t-md bg-background", "flex-wrap", className)}>
+      <Flex align="center" gap="1" wrap className={cn("p-2 border rounded-t-md bg-background", className)}>
         {/* Draw Mode Toggle */}
         {onDrawModeToggle && (
           <>
-            <div className="flex items-center gap-0.5 rounded-md border border-border overflow-hidden bg-background">
+            <Flex align="center" gap="0.5" className="rounded-md border border-border overflow-hidden bg-background">
               <Tooltip>
                 <TooltipTrigger asChild>
                   <button
@@ -275,18 +275,18 @@ export function TemplateEditorToolbar({
                   </button>
                 </TooltipTrigger>
                 <TooltipContent>
-                  <p>{drawMode ? t("drawModeActive") : t("drawMode")}</p>
+                  <Text>{drawMode ? t("drawModeActive") : t("drawMode")}</Text>
                 </TooltipContent>
               </Tooltip>
-            </div>
+            </Flex>
 
             {/* Divider after draw toggle */}
-            <div className="h-6 w-px bg-border mx-1" />
+            <Box className="h-6 w-px bg-border mx-1" />
           </>
         )}
 
         {/* Undo/Redo Controls */}
-        <div className="flex items-center gap-0.5 rounded-md border border-border overflow-hidden bg-background">
+        <Flex align="center" gap="0.5" className="rounded-md border border-border overflow-hidden bg-background">
           <Tooltip>
             <TooltipTrigger asChild>
               <button
@@ -304,7 +304,7 @@ export function TemplateEditorToolbar({
               </button>
             </TooltipTrigger>
             <TooltipContent>
-              <p>{t("undo")}</p>
+              <Text>{t("undo")}</Text>
             </TooltipContent>
           </Tooltip>
 
@@ -324,20 +324,20 @@ export function TemplateEditorToolbar({
               </button>
             </TooltipTrigger>
             <TooltipContent>
-              <p>{t("redo")}</p>
+              <Text>{t("redo")}</Text>
             </TooltipContent>
           </Tooltip>
-        </div>
+        </Flex>
 
         {/* Divider after undo/redo */}
-        <div className="h-6 w-px bg-border mx-1" />
+        <Box className="h-6 w-px bg-border mx-1" />
 
         {/* Drawing controls — in draw mode the toolbar transforms: all
             content-editing controls are hidden and replaced by inline color
             swatches, an eraser, and a stamp-character dropdown. */}
         {drawMode && (
           <>
-            <div className="flex items-center gap-0.5">
+            <Flex align="center" gap="0.5">
               {AVAILABLE_COLORS.map((name) => {
                 const selected = effectiveBrush.kind === "color" && effectiveBrush.color === name;
                 return (
@@ -355,14 +355,15 @@ export function TemplateEditorToolbar({
                           selected ? "ring-2 ring-primary" : "hover:bg-muted/50",
                         )}
                       >
-                        <span
+                        <Text
+                          as="span"
                           className="block h-4 w-4 rounded border border-border/50"
                           style={{ backgroundColor: getBoardColor(name) }}
                         />
                       </button>
                     </TooltipTrigger>
                     <TooltipContent>
-                      <p>{t(`drawColors.${name}`)}</p>
+                      <Text>{t(`drawColors.${name}`)}</Text>
                     </TooltipContent>
                   </Tooltip>
                 );
@@ -386,10 +387,10 @@ export function TemplateEditorToolbar({
                   </button>
                 </TooltipTrigger>
                 <TooltipContent>
-                  <p>{t("drawEraser")}</p>
+                  <Text>{t("drawEraser")}</Text>
                 </TooltipContent>
               </Tooltip>
-            </div>
+            </Flex>
 
             <ToolbarDropdown
               label={t("drawCharacter")}
@@ -397,9 +398,13 @@ export function TemplateEditorToolbar({
               className={cn(effectiveBrush.kind === "char" && "ring-2 ring-primary")}
               icon={
                 effectiveBrush.kind === "char" ? (
-                  <span className="flex h-4 w-4 items-center justify-center rounded border border-border font-mono text-xs leading-none">
+                  <Text
+                    as="span"
+                    size="xs"
+                    className="flex h-4 w-4 items-center justify-center rounded border border-border font-mono leading-none"
+                  >
                     {effectiveBrush.char}
-                  </span>
+                  </Text>
                 ) : (
                   <Type className="w-4 h-4" />
                 )
@@ -421,7 +426,7 @@ export function TemplateEditorToolbar({
         {!drawMode && (
           <>
             {/* Cut/Copy/Paste Controls */}
-            <div className="flex items-center gap-0.5 rounded-md border border-border overflow-hidden bg-background">
+            <Flex align="center" gap="0.5" className="rounded-md border border-border overflow-hidden bg-background">
               <Tooltip>
                 <TooltipTrigger asChild>
                   <button
@@ -439,7 +444,7 @@ export function TemplateEditorToolbar({
                   </button>
                 </TooltipTrigger>
                 <TooltipContent>
-                  <p>{t("cut")}</p>
+                  <Text>{t("cut")}</Text>
                 </TooltipContent>
               </Tooltip>
 
@@ -460,7 +465,7 @@ export function TemplateEditorToolbar({
                   </button>
                 </TooltipTrigger>
                 <TooltipContent>
-                  <p>{t("copy")}</p>
+                  <Text>{t("copy")}</Text>
                 </TooltipContent>
               </Tooltip>
 
@@ -480,13 +485,13 @@ export function TemplateEditorToolbar({
                   </button>
                 </TooltipTrigger>
                 <TooltipContent>
-                  <p>{t("paste")}</p>
+                  <Text>{t("paste")}</Text>
                 </TooltipContent>
               </Tooltip>
-            </div>
+            </Flex>
 
             {/* Divider after clipboard controls */}
-            <div className="h-6 w-px bg-border mx-1" />
+            <Box className="h-6 w-px bg-border mx-1" />
 
             {/* Variables Dropdown */}
             {hasVariables ? (
@@ -517,7 +522,7 @@ export function TemplateEditorToolbar({
                   </button>
                 </TooltipTrigger>
                 <TooltipContent>
-                  <p>{t("noVariablesAvailable")}</p>
+                  <Text>{t("noVariablesAvailable")}</Text>
                 </TooltipContent>
               </Tooltip>
             )}
@@ -577,7 +582,7 @@ export function TemplateEditorToolbar({
                 </button>
               </TooltipTrigger>
               <TooltipContent>
-                <p>{t("insertFormula")}</p>
+                <Text>{t("insertFormula")}</Text>
               </TooltipContent>
             </Tooltip>
 
@@ -598,15 +603,15 @@ export function TemplateEditorToolbar({
                 </button>
               </TooltipTrigger>
               <TooltipContent>
-                <p>{currentWrapEnabled ? t("disableWrap") : t("enableWrap")}</p>
+                <Text>{currentWrapEnabled ? t("disableWrap") : t("enableWrap")}</Text>
               </TooltipContent>
             </Tooltip>
 
             {/* Divider */}
-            {(hasVariables || hasColors || hasFormatting) && <div className="h-6 w-px bg-border mx-1" />}
+            {(hasVariables || hasColors || hasFormatting) && <Box className="h-6 w-px bg-border mx-1" />}
 
             {/* Alignment Controls */}
-            <div className="flex items-center gap-0.5 rounded-md border border-border overflow-hidden bg-background">
+            <Flex align="center" gap="0.5" className="rounded-md border border-border overflow-hidden bg-background">
               <Tooltip>
                 <TooltipTrigger asChild>
                   <button
@@ -657,7 +662,7 @@ export function TemplateEditorToolbar({
                 </TooltipTrigger>
                 <TooltipContent>{t("alignRight")}</TooltipContent>
               </Tooltip>
-            </div>
+            </Flex>
 
             {/* Sync from Board — icon-only button pushed to the far right */}
             {onSyncFromBoard && (
@@ -679,14 +684,14 @@ export function TemplateEditorToolbar({
                     </button>
                   </TooltipTrigger>
                   <TooltipContent>
-                    <p>{t("syncFromBoardTooltip")}</p>
+                    <Text>{t("syncFromBoardTooltip")}</Text>
                   </TooltipContent>
                 </Tooltip>
               </>
             )}
           </>
         )}
-      </div>
+      </Flex>
     </TooltipProvider>
   );
 }

--- a/web/src/components/tiptap-template-editor/components/ToolbarDropdown.tsx
+++ b/web/src/components/tiptap-template-editor/components/ToolbarDropdown.tsx
@@ -3,7 +3,7 @@
  */
 "use client";
 
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@fiestaboard/ui";
+import { Box, Text, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@fiestaboard/ui";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 
 import { cn } from "@/lib/utils";
@@ -32,8 +32,8 @@ export function ToolbarDropdown({
   "data-testid": dataTestId,
 }: ToolbarDropdownProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const dropdownRef = useRef<HTMLDivElement>(null);
-  const panelRef = useRef<HTMLDivElement>(null);
+  const dropdownRef = useRef<HTMLElement>(null);
+  const panelRef = useRef<HTMLElement>(null);
   const [panelShift, setPanelShift] = useState(0);
 
   // The panel is plain `absolute top-full left-0` with no collision handling,
@@ -110,7 +110,7 @@ export function ToolbarDropdown({
 
   return (
     <TooltipProvider>
-      <div ref={dropdownRef} className="relative">
+      <Box ref={dropdownRef} className="relative">
         <Tooltip>
           <TooltipTrigger asChild>
             <button
@@ -133,28 +133,36 @@ export function ToolbarDropdown({
               aria-haspopup="true"
               aria-label={label || "Menu"}
             >
-              {icon && <span className="w-4 h-4">{icon}</span>}
-              {label && <span className="sr-only">{label}</span>}
+              {icon && (
+                <Text as="span" className="w-4 h-4">
+                  {icon}
+                </Text>
+              )}
+              {label && (
+                <Text as="span" className="sr-only">
+                  {label}
+                </Text>
+              )}
             </button>
           </TooltipTrigger>
           {label && (
             <TooltipContent>
-              <p>{label}</p>
+              <Text>{label}</Text>
             </TooltipContent>
           )}
         </Tooltip>
 
         {isOpen && (
-          <div
+          <Box
             ref={panelRef}
             data-testid="toolbar-dropdown-panel"
             className="absolute top-full left-0 mt-1 z-50 bg-popover border border-border rounded-md shadow-lg max-w-[calc(100vw-16px)] overflow-x-auto"
             style={{ transform: panelShift ? `translateX(${panelShift}px)` : undefined }}
           >
             {typeof children === "function" ? children(handleClose) : children}
-          </div>
+          </Box>
         )}
-      </div>
+      </Box>
     </TooltipProvider>
   );
 }

--- a/web/src/components/tiptap-template-editor/components/VariablePickerContent.tsx
+++ b/web/src/components/tiptap-template-editor/components/VariablePickerContent.tsx
@@ -11,9 +11,14 @@ import {
   AccordionItem,
   AccordionTrigger,
   Badge,
+  Box,
+  Code,
+  Flex,
   Input,
   ScrollArea,
   Skeleton,
+  Stack,
+  Text,
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -62,9 +67,9 @@ function VariablePill({
       <button type="button" onClick={onInsert}>
         {label}
         {preview && (
-          <span className="ml-1.5 text-muted-foreground font-normal text-[10px] opacity-70">
+          <Text as="span" tone="muted" weight="normal" className="ml-1.5 text-[10px] opacity-70">
             {preview.length > 12 ? preview.slice(0, 12) + "…" : preview}
-          </span>
+          </Text>
         )}
       </button>
     </Badge>
@@ -155,11 +160,11 @@ function renderSubArraySection(
   if (filteredEntries.length === 0) return null;
 
   return (
-    <div>
-      <p className="text-xs text-muted-foreground mb-1.5 flex items-center gap-1">
+    <Box>
+      <Text size="xs" tone="muted" className="mb-1.5 flex items-center gap-1">
         {IconComp && <IconComp className="h-3 w-3" />}
         {subArrayName.charAt(0).toUpperCase() + subArrayName.slice(1)} ({filteredEntries.length})
-      </p>
+      </Text>
       <Accordion type="single" collapsible className="w-full">
         {filteredEntries.map(([key, itemData]) => {
           const displayKey = keyType === "dynamic" && keyField ? String(itemData[keyField] ?? key) : key;
@@ -177,37 +182,39 @@ function renderSubArraySection(
               className="border-b-0"
             >
               <AccordionTrigger className="py-1.5 hover:no-underline text-xs">
-                <div className="flex items-center gap-2">
+                <Flex align="center" gap="2">
                   {keyType === "dynamic" && (
                     <Badge variant="outline" className="text-[10px] font-mono px-1.5">
                       {displayKey}
                     </Badge>
                   )}
-                  <span className="text-left">{itemLabel}</span>
-                </div>
+                  <Text as="span" size="xs" className="text-left">
+                    {itemLabel}
+                  </Text>
+                </Flex>
               </AccordionTrigger>
               <AccordionContent>
-                <div className="space-y-2 pt-2 pl-2">
-                  <div className="flex flex-wrap gap-1.5">
+                <Stack gap="2" className="pt-2 pl-2">
+                  <Flex wrap gap="1.5">
                     {filteredFields.map((field: string) => {
                       const varValue = `{{${pluginId}.${parentArrayName}.${parentIndex}.${subArrayName}.${key}.${field}}}`;
                       return (
                         <VariablePill key={field} label={field} value={varValue} onInsert={() => onInsert(varValue)} />
                       );
                     })}
-                  </div>
-                  <div className="text-xs text-muted-foreground bg-muted/50 p-2 rounded">
-                    <code className="text-xs">
+                  </Flex>
+                  <Box className="text-xs text-muted-foreground bg-muted/50 p-2 rounded">
+                    <Code className="text-xs bg-transparent px-0">
                       {parentArrayName}.{parentIndex}.{subArrayName}.{key}.*
-                    </code>
-                  </div>
-                </div>
+                    </Code>
+                  </Box>
+                </Stack>
               </AccordionContent>
             </AccordionItem>
           );
         })}
       </Accordion>
-    </div>
+    </Box>
   );
 }
 
@@ -224,14 +231,15 @@ function renderArraySection(
 ) {
   if (!arrayData || arrayData.length === 0) {
     return (
-      <div className="p-3 bg-muted/30 rounded-lg text-xs text-muted-foreground">
-        <p className="mb-2">
+      <Box className="p-3 bg-muted/30 rounded-lg text-xs text-muted-foreground">
+        <Text size="xs" tone="muted" className="mb-2">
           {t ? t("configureHint", { arrayName }) : `Configure ${arrayName} in Settings to see indexed variables here.`}
-        </p>
-        <p className="font-mono text-[10px]">
-          {t ? t("configureExample") : "Example:"} <code className="bg-background px-1 rounded">{arrayName}.0.*</code>
-        </p>
-      </div>
+        </Text>
+        <Text tone="muted" className="font-mono text-[10px]">
+          {t ? t("configureExample") : "Example:"}{" "}
+          <Code className="bg-background px-1 text-[10px]">{arrayName}.0.*</Code>
+        </Text>
+      </Box>
     );
   }
 
@@ -266,9 +274,11 @@ function renderArraySection(
 
   if (filteredArrayData.length === 0) {
     return (
-      <div className="p-3 bg-muted/30 rounded-lg text-xs text-muted-foreground">
-        <p>No matching variables found.</p>
-      </div>
+      <Box className="p-3 bg-muted/30 rounded-lg text-xs text-muted-foreground">
+        <Text size="xs" tone="muted">
+          No matching variables found.
+        </Text>
+      </Box>
     );
   }
 
@@ -300,22 +310,26 @@ function renderArraySection(
           return (
             <AccordionItem key={index} value={`${arrayName}-${index}`} className="border-b-0">
               <AccordionTrigger className="py-2 hover:no-underline">
-                <div className="flex items-center gap-2 text-xs">
+                <Flex align="center" gap="2" className="text-xs">
                   {IconComp && <IconComp className="h-3 w-3" />}
-                  <div className="text-left">
-                    <div className="font-medium">{itemLabel}</div>
-                    <div className="text-muted-foreground text-xs">
+                  <Box className="text-left">
+                    <Text size="xs" weight="medium">
+                      {itemLabel}
+                    </Text>
+                    <Text size="xs" tone="muted">
                       {t ? t("indexLabel", { index }) : `Index: ${index}`}
-                    </div>
-                  </div>
-                </div>
+                    </Text>
+                  </Box>
+                </Flex>
               </AccordionTrigger>
               <AccordionContent>
-                <div className="space-y-3 pt-2 pl-2">
+                <Stack gap="3" className="pt-2 pl-2">
                   {filteredItemFields.length > 0 && (
-                    <div>
-                      <p className="text-xs text-muted-foreground mb-1.5">{t ? t("itemInfo") : "Item Info"}</p>
-                      <div className="flex flex-wrap gap-1.5">
+                    <Box>
+                      <Text size="xs" tone="muted" className="mb-1.5">
+                        {t ? t("itemInfo") : "Item Info"}
+                      </Text>
+                      <Flex wrap gap="1.5">
                         {filteredItemFields.map((field: string) => {
                           const varValue = `{{${pluginId}.${arrayName}.${index}.${field}}}`;
                           return (
@@ -327,15 +341,15 @@ function renderArraySection(
                             />
                           );
                         })}
-                      </div>
-                    </div>
+                      </Flex>
+                    </Box>
                   )}
 
                   {filteredSubArrays.map(([subArrayName]) => {
                     const subArrayData = item[subArrayName];
                     if (!subArrayData) return null;
                     return (
-                      <div key={subArrayName}>
+                      <Box key={subArrayName}>
                         {renderSubArraySection(
                           pluginId,
                           index,
@@ -348,10 +362,10 @@ function renderArraySection(
                           showAll,
                           IconComp,
                         )}
-                      </div>
+                      </Box>
                     );
                   })}
-                </div>
+                </Stack>
               </AccordionContent>
             </AccordionItem>
           );
@@ -433,16 +447,20 @@ export function VariablePickerContent({
 
   if (isLoadingVars || isLoadingManifests) {
     return (
-      <div className="p-3 min-w-[300px]">
+      <Box className="p-3 min-w-[300px]">
         <Skeleton className="h-4 w-full mb-2" />
         <Skeleton className="h-4 w-3/4 mb-2" />
         <Skeleton className="h-4 w-1/2" />
-      </div>
+      </Box>
     );
   }
 
   if (!templateVars?.variables) {
-    return <div className="p-3 text-sm text-muted-foreground min-w-[300px]">{t("noVariablesAvailable")}</div>;
+    return (
+      <Text tone="muted" className="p-3 min-w-[300px]">
+        {t("noVariablesAvailable")}
+      </Text>
+    );
   }
 
   const categories = Object.entries(templateVars.variables);
@@ -494,9 +512,9 @@ export function VariablePickerContent({
 
   return (
     <TooltipProvider delayDuration={300}>
-      <div className={`w-full min-w-[min(340px,calc(100vw-24px))] flex flex-col${className ? ` ${className}` : ""}`}>
-        <div className="p-2 border-b">
-          <div className="relative">
+      <Flex direction="col" className={`w-full min-w-[min(340px,calc(100vw-24px))]${className ? ` ${className}` : ""}`}>
+        <Box className="p-2 border-b">
+          <Box className="relative">
             <Search className="absolute left-2.5 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
             <Input
               autoFocus={autoFocusSearch}
@@ -507,15 +525,15 @@ export function VariablePickerContent({
               onChange={(e) => setSearchQuery(e.target.value)}
               className="pl-8 h-9"
             />
-          </div>
-        </div>
+          </Box>
+        </Box>
 
         <ScrollArea className="flex-1" style={{ height: maxHeight }}>
-          <div className="p-2 space-y-3">
+          <Stack gap="3" className="p-2">
             {filteredCategories.length === 0 ? (
-              <div className="p-3 text-sm text-muted-foreground text-center">
+              <Text tone="muted" className="p-3 text-center">
                 {t("noVariablesFound", { searchQuery })}
-              </div>
+              </Text>
             ) : (
               filteredCategories.map(([category, vars]) => {
                 const manifest = manifests[category];
@@ -591,13 +609,13 @@ export function VariablePickerContent({
                 };
 
                 return (
-                  <div key={category} className="space-y-1.5">
-                    <div className="flex items-center gap-2 bg-muted/30 rounded px-2 py-1.5 -mx-1">
+                  <Stack key={category} gap="1.5">
+                    <Flex align="center" gap="2" className="bg-muted/30 rounded px-2 py-1.5 -mx-1">
                       {IconComp && <IconComp className="h-3 w-3 text-muted-foreground" />}
-                      <span className="text-xs font-semibold text-foreground">
+                      <Text as="span" size="xs" weight="semibold">
                         {category.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())}
-                      </span>
-                    </div>
+                      </Text>
+                    </Flex>
 
                     {/* Grouped variables */}
                     {hasGroups ? (
@@ -606,33 +624,37 @@ export function VariablePickerContent({
                           const groupVars = groupedVars[groupId];
                           if (!groupVars || groupVars.length === 0) return null;
                           return (
-                            <div key={groupId}>
-                              <p className="text-[9px] uppercase tracking-widest text-muted-foreground/70 mt-1 mb-1 pb-0.5 border-b border-border/30">
+                            <Box key={groupId}>
+                              <Text className="text-[9px] uppercase tracking-widest text-muted-foreground/70 mt-1 mb-1 pb-0.5 border-b border-border/30">
                                 {groupDef.label}
-                              </p>
-                              <div className="flex flex-wrap gap-1.5">{groupVars.map(renderVarPill)}</div>
-                            </div>
+                              </Text>
+                              <Flex wrap gap="1.5">
+                                {groupVars.map(renderVarPill)}
+                              </Flex>
+                            </Box>
                           );
                         })}
                         {groupedVars["__ungrouped__"] && groupedVars["__ungrouped__"].length > 0 && (
-                          <div>
-                            <p className="text-[9px] uppercase tracking-widest text-muted-foreground/70 mt-1 mb-1 pb-0.5 border-b border-border/30">
+                          <Box>
+                            <Text className="text-[9px] uppercase tracking-widest text-muted-foreground/70 mt-1 mb-1 pb-0.5 border-b border-border/30">
                               {t("general")}
-                            </p>
-                            <div className="flex flex-wrap gap-1.5">
+                            </Text>
+                            <Flex wrap gap="1.5">
                               {groupedVars["__ungrouped__"].map(renderVarPill)}
-                            </div>
-                          </div>
+                            </Flex>
+                          </Box>
                         )}
                       </>
                     ) : (
                       filteredGeneralVars.length > 0 && (
-                        <div>
-                          <p className="text-[9px] uppercase tracking-widest text-muted-foreground/70 mt-1 mb-1 pb-0.5 border-b border-border/30">
+                        <Box>
+                          <Text className="text-[9px] uppercase tracking-widest text-muted-foreground/70 mt-1 mb-1 pb-0.5 border-b border-border/30">
                             {t("general")}
-                          </p>
-                          <div className="flex flex-wrap gap-1.5">{filteredGeneralVars.map(renderVarPill)}</div>
-                        </div>
+                          </Text>
+                          <Flex wrap gap="1.5">
+                            {filteredGeneralVars.map(renderVarPill)}
+                          </Flex>
+                        </Box>
                       )
                     )}
 
@@ -647,12 +669,12 @@ export function VariablePickerContent({
                       if (!shouldShow) return null;
 
                       return (
-                        <div key={arrayName} className="space-y-1.5">
-                          <p className="text-xs text-muted-foreground flex items-center gap-1">
+                        <Stack key={arrayName} gap="1.5">
+                          <Text size="xs" tone="muted" className="flex items-center gap-1">
                             {IconComp && <IconComp className="h-3 w-3" />}
                             {arrayName.charAt(0).toUpperCase() + arrayName.slice(1)}{" "}
                             {arrayData ? `(${arrayData.length})` : "(None configured)"}
-                          </p>
+                          </Text>
                           {renderArraySection(
                             category,
                             arrayName,
@@ -664,16 +686,16 @@ export function VariablePickerContent({
                             IconComp,
                             t,
                           )}
-                        </div>
+                        </Stack>
                       );
                     })}
-                  </div>
+                  </Stack>
                 );
               })
             )}
-          </div>
+          </Stack>
         </ScrollArea>
-      </div>
+      </Flex>
     </TooltipProvider>
   );
 }

--- a/web/src/components/tiptap-template-editor/node-views/ColorTileNodeView.tsx
+++ b/web/src/components/tiptap-template-editor/node-views/ColorTileNodeView.tsx
@@ -3,7 +3,7 @@
  * Displays {{red}}, {{blue}}, etc. as solid colored tiles
  * Can be dragged and dropped, deleted with backspace, and copied/pasted
  */
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@fiestaboard/ui";
+import { Box, Text, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@fiestaboard/ui";
 import { NodeViewWrapper } from "@tiptap/react";
 import React from "react";
 
@@ -62,10 +62,10 @@ export function ColorTileNodeView({ node, deleteNode: _deleteNode }: ColorTileNo
             }}
           >
             {/* Subtle split flip effect - horizontal line in middle */}
-            <div className="absolute top-1/2 left-0 right-0 h-[1px] bg-black/10" />
+            <Box className="absolute top-1/2 left-0 right-0 h-[1px] bg-black/10" />
 
             {/* Subtle gradient for curvature */}
-            <div
+            <Box
               className="absolute inset-0 pointer-events-none rounded-[3px]"
               style={{
                 background: "linear-gradient(180deg, rgba(255,255,255,0.15) 0%, transparent 50%, rgba(0,0,0,0.2) 100%)",
@@ -74,7 +74,11 @@ export function ColorTileNodeView({ node, deleteNode: _deleteNode }: ColorTileNo
 
             {/* Block character gives the browser selectable text so the native
           selection highlight (blue overlay) is visible on the tile.
-          Transparent color keeps it invisible until selected. */}
+          Transparent color keeps it invisible until selected.
+          Kept as a raw <span>: this is a selection-anchor inside TipTap's
+          contentEditable and all styling is inline; wrapping it in <Text>
+          would inject text-foreground/text-sm classes that could disturb the
+          transparent-until-selected geometry. Correctness over coverage. */}
             <span
               aria-label={`${color} color tile`}
               style={{
@@ -92,9 +96,9 @@ export function ColorTileNodeView({ node, deleteNode: _deleteNode }: ColorTileNo
           </NodeViewWrapper>
         </TooltipTrigger>
         <TooltipContent>
-          <p>
+          <Text>
             {color} tile (code {code}) - drag to move, backspace to delete
-          </p>
+          </Text>
         </TooltipContent>
       </Tooltip>
     </TooltipProvider>

--- a/web/src/components/tiptap-template-editor/node-views/FillSpaceNodeView.tsx
+++ b/web/src/components/tiptap-template-editor/node-views/FillSpaceNodeView.tsx
@@ -2,7 +2,7 @@
  * React NodeView for FillSpace nodes
  * Displays {{fill_space}} as an expandable ruler with estimated expansion
  */
-import { Badge, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@fiestaboard/ui";
+import { Badge, Text, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@fiestaboard/ui";
 import { NodeViewWrapper } from "@tiptap/react";
 import React from "react";
 
@@ -37,17 +37,21 @@ export function FillSpaceNodeView({ node, deleteNode: _deleteNode }: FillSpaceNo
               variant="success"
               className="group inline-flex flex-nowrap items-center px-1.5 py-0 border-dashed cursor-grab hover:bg-tag-success/25 mr-0.5 transition-all duration-150"
             >
+              {/* Raw <span>: lives inside a colored Badge within TipTap's
+                  contentEditable. <Text as="span"> would emit text-foreground,
+                  overriding the Badge's inherited success tint, and text-[11px]
+                  is sub-xs grid geometry. Kept raw for correctness. */}
               <span className="font-mono text-[11px] leading-none">
                 fill_space{hasRepeatChar && `_repeat:${repeatChar}`}
               </span>
             </Badge>
           </TooltipTrigger>
           <TooltipContent>
-            <p>
+            <Text>
               {hasRepeatChar
                 ? `Fill space repeating: ${repeatChar}`
                 : "Fill space - expands to fill remaining line width"}
-            </p>
+            </Text>
           </TooltipContent>
         </Tooltip>
       </TooltipProvider>

--- a/web/src/components/tiptap-template-editor/node-views/FormulaNodeView.tsx
+++ b/web/src/components/tiptap-template-editor/node-views/FormulaNodeView.tsx
@@ -9,7 +9,7 @@
  */
 "use client";
 
-import { Badge, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@fiestaboard/ui";
+import { Badge, Box, Flex, Text, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@fiestaboard/ui";
 import { NodeViewWrapper } from "@tiptap/react";
 import { SquareFunction } from "lucide-react";
 import React, { useCallback, useEffect, useRef, useState } from "react";
@@ -108,35 +108,44 @@ export function FormulaNodeView({ node, updateAttributes, deleteNode }: FormulaN
               }}
             >
               <SquareFunction className="w-2.5 h-2.5 flex-shrink-0" />
+              {/* Raw <span>: colored Badge inside contentEditable; <Text as="span">
+                  would reset the inherited pill color and text-[11px] is sub-xs
+                  grid geometry. Kept raw for correctness. */}
               <span className="font-mono text-[11px] leading-none">{preview}</span>
             </Badge>
           </TooltipTrigger>
           <TooltipContent>
-            <p className="font-mono text-xs">{"{{= " + expression + " }}"}</p>
-            <p className="text-xs text-muted-foreground mt-0.5">{t("clickToEditFormula")}</p>
+            <Text size="xs" className="font-mono">
+              {"{{= " + expression + " }}"}
+            </Text>
+            <Text size="xs" tone="muted" className="mt-0.5">
+              {t("clickToEditFormula")}
+            </Text>
           </TooltipContent>
         </Tooltip>
       </TooltipProvider>
 
       {open &&
         createPortal(
-          <div
-            className="fixed inset-0 z-[999] flex items-center justify-center p-4"
+          <Flex
+            align="center"
+            justify="center"
+            className="fixed inset-0 z-[999] p-4"
             onMouseDown={(e) => e.stopPropagation()}
           >
             {/* Backdrop — intentionally has no click handler to prevent accidental close */}
-            <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
+            <Box className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
 
             {/* Modal panel */}
-            <div className="relative rounded-lg border border-border bg-popover shadow-2xl max-h-[90vh] overflow-y-auto w-full max-w-[min(660px,90vw)]">
+            <Box className="relative rounded-lg border border-border bg-popover shadow-2xl max-h-[90vh] overflow-y-auto w-full max-w-[min(660px,90vw)]">
               <FormulaEditorPanel
                 mode="edit"
                 initialExpr={expression}
                 onConfirm={handleConfirm}
                 onCancel={handleCancel}
               />
-            </div>
-          </div>,
+            </Box>
+          </Flex>,
           document.body,
         )}
     </NodeViewWrapper>

--- a/web/src/components/tiptap-template-editor/node-views/VariableNodeView.tsx
+++ b/web/src/components/tiptap-template-editor/node-views/VariableNodeView.tsx
@@ -2,7 +2,7 @@
  * React NodeView for Variable nodes
  * Displays {{plugin.field}} as an interactive badge with filters
  */
-import { Badge, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@fiestaboard/ui";
+import { Badge, Text, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@fiestaboard/ui";
 import { NodeViewWrapper } from "@tiptap/react";
 import React from "react";
 
@@ -36,6 +36,11 @@ export function VariableNodeView({ node, deleteNode: _deleteNode }: VariableNode
           variant="variable"
           className="inline-flex flex-nowrap items-center gap-1 px-1.5 py-0 border-dashed cursor-grab hover:bg-tag-variable/20 active:cursor-grabbing mr-0.5 transition-all duration-150"
         >
+          {/* Raw <span>s throughout this Badge: they render inside TipTap's
+              contentEditable where sub-xs sizes (text-[10px]/[11px]) and the
+              Badge's inherited "variable" tint are pixel/color load-bearing.
+              <Text as="span"> would reset color + size, so kept raw for
+              correctness (only the portal Tooltip copy below is primitived). */}
           <span className="font-mono text-[11px] leading-none">
             {pluginId}.{field}
           </span>
@@ -51,10 +56,10 @@ export function VariableNodeView({ node, deleteNode: _deleteNode }: VariableNode
                     </span>
                   </TooltipTrigger>
                   <TooltipContent>
-                    <p>
+                    <Text>
                       Filter: {filter.name}
                       {filter.arg ? `:${filter.arg}` : ""}
-                    </p>
+                    </Text>
                   </TooltipContent>
                 </Tooltip>
               ))}
@@ -67,7 +72,7 @@ export function VariableNodeView({ node, deleteNode: _deleteNode }: VariableNode
                 <span className="hidden group-hover:inline text-[10px] leading-none">~{maxLength}</span>
               </TooltipTrigger>
               <TooltipContent>
-                <p>Max length: {maxLength} characters</p>
+                <Text>Max length: {maxLength} characters</Text>
               </TooltipContent>
             </Tooltip>
           )}

--- a/web/src/components/tiptap-template-editor/node-views/WrappedTextView.tsx
+++ b/web/src/components/tiptap-template-editor/node-views/WrappedTextView.tsx
@@ -42,7 +42,10 @@ export function WrappedTextView({ node, deleteNode }: WrappedTextViewProps) {
       {/* Wrap icon */}
       <WrapText className="w-3 h-3 inline-block align-middle" />
 
-      {/* Wrapped text display */}
+      {/* Wrapped text display.
+          Raw <span>: renders inside TipTap's contentEditable atom, inheriting
+          the wrapper's text-warning color, with sub-xs text-[11px] grid
+          geometry. <Text as="span"> would reset both. Kept raw for correctness. */}
       <span className="font-mono text-[11px] inline-block align-middle ml-1">{text}</span>
 
       {/* Delete button */}


### PR DESCRIPTION
Wave 5 of 6 for epic #1474: migrates the 14 tiptap template-editor files to `@fiestaboard/ui` primitives.

## What changed
- Editor chrome (toolbar, picker panels, formula editor, dropdown) fully migrated per the recipe
- **NodeViews handled conservatively**: review verified that no element inside TipTap's contentEditable changed its rendered tag — grid-load-bearing work is limited to div→`Box`(div) overlays; **8 inline spans stay raw** with rationale comments (character-grid tiles, inherited tints) — these get `eslint-disable` handling when wave 6 flips the rule
- ToolbarDropdown's viewport-clamp positioning (#1397) preserved byte-for-byte (classes + transform style + measurement logic)
- All `<p>`→`Text` conversions in NodeViews are inside portalled tooltips, outside the editable grid

## Verification
- Reviewer independently re-ran ESLint (0 errors) + prettier (clean) in Docker; every variant value verified against package source
- **Manual check requested**: open the template editor, exercise variables/formulas/color tiles/draw mode — the e2e draw-mode suites in CI are the strongest automated signal here

No ESLint rule yet — wave 6.

Part of #1474

🤖 Generated with [Claude Code](https://claude.com/claude-code)