### PR TITLE
refactor: adopt FiestaUI primitives — wave 6 (remainder) + enforce zero raw HTML

### DIFF
--- a/web/app/routes/integrations.$pluginId.tsx
+++ b/web/app/routes/integrations.$pluginId.tsx
@@ -163,6 +163,7 @@ export default function PluginDetailPage() {
                       {/* Custom card header (icon + badge + trailing actions) doesn't
                           match PageHeader's shape, so the page h1 stays raw here
                           (couldn't snap — see wave 1 report). */}
+                      {/* eslint-disable-next-line react/forbid-elements -- custom card-header hero title; PageHeader's icon+card shape doesn't fit and Heading has no level=1 */}
                       <h1 className="text-xl font-semibold">{entry?.name ?? pluginId}</h1>
                       <Badge variant="secondary" className="text-xs">
                         {categoryLabel}
@@ -192,6 +193,7 @@ export default function PluginDetailPage() {
                   {/* asChild hands this anchor Button's own chrome (border/bg/text) — TextLink's
                       underline+text-primary styling would clash with that, so it stays raw
                       (couldn't snap — see wave 1 report). */}
+                  {/* eslint-disable-next-line react/forbid-elements -- single Slot child of Button asChild; the Button merges its chrome onto this anchor and TextLink would layer conflicting link styling */}
                   <a href={entry.repository} target="_blank" rel="noopener noreferrer">
                     <ExternalLink className="h-3.5 w-3.5 mr-1.5" />
                     GitHub
@@ -257,6 +259,7 @@ export default function PluginDetailPage() {
                   code: ({ children, className, ...props }) => {
                     const isBlock = className?.startsWith("language-");
                     return isBlock ? (
+                      // eslint-disable-next-line react/forbid-elements -- react-markdown code-block override must render a native <code> inside <pre>; the Code primitive is used for inline code below
                       <code className={className} {...props}>
                         {children}
                       </code>
@@ -289,6 +292,7 @@ export default function PluginDetailPage() {
                   h1: ({ children, ...props }) => (
                     // Markdown README content — h1 here is document structure, not the app
                     // page's own title, so PageHeader doesn't fit; stays raw (couldn't snap).
+                    // eslint-disable-next-line react/forbid-elements -- react-markdown h1 override renders README document structure, not the app page title
                     <h1 className="text-xl font-bold mt-0 mb-4 pb-2 border-b" {...props}>
                       {children}
                     </h1>

--- a/web/app/routes/integrations._index.tsx
+++ b/web/app/routes/integrations._index.tsx
@@ -924,6 +924,7 @@ function renderValueWithColors(value: string): ReactNode[] {
       // Rendered inline into caller-supplied text contexts with varying ambient
       // size/color (font-mono chips, tooltip content, table cells) — Text's fixed
       // defaults would override whichever context this lands in, so this stays raw.
+      // eslint-disable-next-line react/forbid-elements -- inherit-only span rendered into varied ambient text contexts; Text's fixed size/tone defaults would override the caller's context
       nodes.push(<span key={`t${key++}`}>{textBuf}</span>);
       textBuf = "";
     }

--- a/web/app/routes/offline.tsx
+++ b/web/app/routes/offline.tsx
@@ -52,6 +52,7 @@ export default function OfflinePage() {
         <Stack gap="2">
           {/* Reserved for PageHeader elsewhere; this standalone offline splash has no icon/description
               card to match, so the h1 stays raw here (couldn't snap — see wave 1 report). */}
+          {/* eslint-disable-next-line react/forbid-elements -- standalone offline-splash hero title; PageHeader's icon+card shape doesn't fit and Heading has no level=1 */}
           <h1 className="text-3xl font-bold tracking-tight">{isOnline ? t("reconnecting") : t("youreOffline")}</h1>
           <Text tone="muted">{isOnline ? t("connectionRestored") : t("offlineDescription")}</Text>
         </Stack>

--- a/web/app/routes/settings.tsx
+++ b/web/app/routes/settings.tsx
@@ -179,6 +179,7 @@ export default function SettingsPage() {
                 <Icon className="h-4 w-4 flex-shrink-0" />
                 {/* Inherits size/weight/color from TabsTrigger's data-active state — Text's fixed
                     tone/weight defaults would break the active/inactive styling, so this stays raw. */}
+                {/* eslint-disable-next-line react/forbid-elements -- inherit-only span; TabsTrigger drives its active/inactive size/weight/color and Text's fixed defaults would break that */}
                 <span className="whitespace-nowrap">{label}</span>
               </TabsTrigger>
             ))}

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -221,6 +221,49 @@ const eslintConfig = [
       ],
     },
   },
+  // Design-system enforcement: app code renders @fiestaboard/ui components,
+  // not raw HTML. Allowlisted leaves (svg, canvas, iframe, img, br, em,
+  // small, kbd, pre, figure, dl, dt, dd) are simply not listed here.
+  {
+    files: ["app/**/*.tsx", "src/**/*.tsx"],
+    ignores: ["src/**/__tests__/**", "**/*.stories.tsx"],
+    rules: {
+      "react/forbid-elements": [
+        "error",
+        {
+          forbid: [
+            { element: "div", message: "Use Flex/Stack/Grid for layout, or Box (@fiestaboard/ui)" },
+            { element: "span", message: 'Use Text as="span" (@fiestaboard/ui)' },
+            { element: "p", message: "Use Text (@fiestaboard/ui)" },
+            { element: "h1", message: "Use PageHeader (@fiestaboard/ui)" },
+            { element: "h2", message: "Use Heading level={2} (@fiestaboard/ui)" },
+            { element: "h3", message: "Use Heading level={3} (@fiestaboard/ui)" },
+            { element: "h4", message: "Use Heading level={4} (@fiestaboard/ui)" },
+            { element: "h5", message: "Use Heading (@fiestaboard/ui)" },
+            { element: "h6", message: "Use Heading (@fiestaboard/ui)" },
+            { element: "ul", message: "Use List (@fiestaboard/ui)" },
+            { element: "ol", message: 'Use List as="ol" (@fiestaboard/ui)' },
+            { element: "li", message: "Use ListItem (@fiestaboard/ui)" },
+            { element: "section", message: 'Use Box as="section" (@fiestaboard/ui)' },
+            { element: "main", message: 'Use MainContent or Box as="main" (@fiestaboard/ui)' },
+            { element: "header", message: 'Use Box as="header" (@fiestaboard/ui)' },
+            { element: "footer", message: 'Use Box as="footer" (@fiestaboard/ui)' },
+            { element: "nav", message: 'Use Box as="nav" (@fiestaboard/ui)' },
+            { element: "form", message: 'Use Box as="form" (@fiestaboard/ui)' },
+            { element: "table", message: "Use Table (@fiestaboard/ui)" },
+            { element: "thead", message: "Use TableHeader (@fiestaboard/ui)" },
+            { element: "tbody", message: "Use TableBody (@fiestaboard/ui)" },
+            { element: "tr", message: "Use TableRow (@fiestaboard/ui)" },
+            { element: "th", message: "Use TableHead (@fiestaboard/ui)" },
+            { element: "td", message: "Use TableCell (@fiestaboard/ui)" },
+            { element: "a", message: "Use TextLink, or the router Link for navigation (@fiestaboard/ui)" },
+            { element: "code", message: "Use Code (@fiestaboard/ui)" },
+            { element: "strong", message: 'Use Text as="span" weight="semibold" (@fiestaboard/ui)' },
+          ],
+        },
+      ],
+    },
+  },
   {
     // Tests legitimately use `any` for mocks and may define fixtures (Playwright)
     // they don't always consume. Don't let strict src rules bleed in here.

--- a/web/src/components/ai-chat-panel.tsx
+++ b/web/src/components/ai-chat-panel.tsx
@@ -550,6 +550,7 @@ function ModelPill({
           <SelectValue>
             {/* Inherit-only span: relies on SelectTrigger's font-mono text-[11px];
                 Text as="span" would reset size/family, so this stays raw. */}
+            {/* eslint-disable-next-line react/forbid-elements -- inherit-only span relying on SelectTrigger's font-mono text-[11px]; Text as="span" would reset size/family */}
             <span className="truncate">{shortModel}</span>
           </SelectValue>
         </SelectTrigger>
@@ -827,6 +828,7 @@ function PatchDetailDisclosure({ count, children }: { count: number; children: R
           {/* Inherit-only span: the button's color flips on hover
               (text-muted-foreground → text-foreground); a Text tone would pin
               the color and defeat that transition, so this stays raw. */}
+          {/* eslint-disable-next-line react/forbid-elements -- inherit-only span; the button's text color flips on hover and a Text tone would pin the color and defeat that transition */}
           <span>{count === 1 ? "View change" : `View ${count} changes`}</span>
         </button>
       </CollapsibleTrigger>

--- a/web/src/components/chat-markdown.tsx
+++ b/web/src/components/chat-markdown.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+/* eslint-disable react/forbid-elements -- react-markdown component overrides must return the native HTML tag for each markdown AST node, and the bespoke VarChip/ColorChip inline token pills render hand-tuned raw code/span; see the file NOTEs. Whole-file exception. */
+
 import { Box } from "@fiestaboard/ui";
 import React, { useMemo } from "react";
 import ReactMarkdown from "react-markdown";

--- a/web/src/components/plugin-settings/schema-form.tsx
+++ b/web/src/components/plugin-settings/schema-form.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import {
+  Box,
   Button,
+  Code,
+  Flex,
+  Grid,
   Input,
   Label,
   Select,
@@ -9,7 +13,9 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  Stack,
   Switch,
+  Text,
 } from "@fiestaboard/ui";
 import {
   ArrowDown,
@@ -255,7 +261,7 @@ function StringField({ name, property, value, onChange, required, disabled }: Fi
   }
 
   return (
-    <div className="relative">
+    <Box className="relative">
       <Input
         id={name}
         type={isPassword && !showPassword ? "password" : "text"}
@@ -282,7 +288,7 @@ function StringField({ name, property, value, onChange, required, disabled }: Fi
           )}
         </Button>
       )}
-    </div>
+    </Box>
   );
 }
 
@@ -476,7 +482,7 @@ function NumberField(props: NumberFieldProps) {
   };
 
   return (
-    <div className="relative">
+    <Box className="relative">
       <Input
         id={name}
         type="number"
@@ -541,7 +547,7 @@ function NumberField(props: NumberFieldProps) {
           )}
         </Button>
       )}
-    </div>
+    </Box>
   );
 }
 
@@ -600,9 +606,9 @@ function WsdotRoutePicker({
   const canRemove = routeEntries.length > 0;
 
   return (
-    <div className="space-y-3">
+    <Stack gap="3">
       {routeEntries.map((routeId, index) => (
-        <div key={index} className="flex gap-2 items-center">
+        <Flex key={index} gap="2" align="center">
           <Select
             value={
               routeId && WSDOT_FERRY_ROUTES.some((r) => r.id === routeId)
@@ -636,7 +642,7 @@ function WsdotRoutePicker({
               <Trash2 className="h-4 w-4" />
             </Button>
           )}
-        </div>
+        </Flex>
       ))}
       {canAdd && (
         <Button type="button" variant="outline" size="sm" onClick={handleAdd} disabled={disabled} className="w-full">
@@ -644,7 +650,7 @@ function WsdotRoutePicker({
           {t("addFerryRoute")}
         </Button>
       )}
-    </div>
+    </Stack>
   );
 }
 
@@ -781,18 +787,18 @@ function DisneyParksTimesPicker({ name, property, value, onChange, disabled }: D
 
   if (parksLoading) {
     return (
-      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+      <Flex align="center" gap="2" className="text-sm text-muted-foreground">
         <Loader2 className="h-4 w-4 animate-spin" />
         {t("loadingParks")}
-      </div>
+      </Flex>
     );
   }
 
   return (
-    <div className="space-y-4">
+    <Stack gap="4">
       {items.map((entry, index) => (
-        <div key={index} className="rounded-lg border p-3 space-y-2">
-          <div className="flex gap-2 items-center">
+        <Stack key={index} gap="2" className="rounded-lg border p-3">
+          <Flex gap="2" align="center">
             <Select
               value={entry.park_id ? String(entry.park_id) : ""}
               onValueChange={(val) => setParkAt(index, parseInt(val, 10))}
@@ -820,20 +826,26 @@ function DisneyParksTimesPicker({ name, property, value, onChange, disabled }: D
             >
               <Trash2 className="h-4 w-4" />
             </Button>
-          </div>
+          </Flex>
           {entry.park_id > 0 && (
-            <div className="space-y-2">
-              <div className="text-xs text-muted-foreground">{t("rides")}</div>
-              <div className="rounded-md border p-2 space-y-2">
+            <Stack gap="2">
+              <Text size="xs" tone="muted">
+                {t("rides")}
+              </Text>
+              <Stack gap="2" className="rounded-md border p-2">
                 {(entry.ride_ids || []).map((rid, rideIndex) => (
-                  <div key={rid} className="rounded-sm border overflow-hidden">
-                    <div
-                      className={cn("flex items-center gap-1 bg-muted/50 px-2 py-1.5", allowCustomNames && "border-b")}
+                  <Box key={rid} className="rounded-sm border overflow-hidden">
+                    <Flex
+                      align="center"
+                      gap="1"
+                      className={cn("bg-muted/50 px-2 py-1.5", allowCustomNames && "border-b")}
                     >
-                      <span className="flex-1 text-sm font-medium">{rideName(entry.park_id, rid)}</span>
+                      <Text as="span" weight="medium" className="flex-1">
+                        {rideName(entry.park_id, rid)}
+                      </Text>
                       {allowReorder && (
                         <>
-                          <div className="flex items-center shrink-0">
+                          <Flex align="center" className="shrink-0">
                             <Button
                               type="button"
                               variant="ghost"
@@ -856,8 +868,8 @@ function DisneyParksTimesPicker({ name, property, value, onChange, disabled }: D
                             >
                               <ArrowDown className="h-4 w-4" />
                             </Button>
-                          </div>
-                          <div className="mx-1 h-5 w-px shrink-0 bg-border" />
+                          </Flex>
+                          <Box className="mx-1 h-5 w-px shrink-0 bg-border" />
                         </>
                       )}
                       <Button
@@ -871,9 +883,9 @@ function DisneyParksTimesPicker({ name, property, value, onChange, disabled }: D
                       >
                         <Trash2 className="h-4 w-4" />
                       </Button>
-                    </div>
+                    </Flex>
                     {allowCustomNames && (
-                      <div className="p-2">
+                      <Box className="p-2">
                         <Input
                           value={entry.custom_names?.[rid] ?? ""}
                           onChange={(e) => setCustomNameAt(index, rid, e.target.value)}
@@ -882,9 +894,9 @@ function DisneyParksTimesPicker({ name, property, value, onChange, disabled }: D
                           aria-label={t("customRideNameLabel", { ride: rideName(entry.park_id, rid) })}
                           className="h-8 text-sm"
                         />
-                      </div>
+                      </Box>
                     )}
-                  </div>
+                  </Box>
                 ))}
                 <Select value="" onValueChange={(val) => addRideAt(index, parseInt(val, 10))} disabled={disabled}>
                   <SelectTrigger className="w-full border-dashed text-muted-foreground">
@@ -900,16 +912,16 @@ function DisneyParksTimesPicker({ name, property, value, onChange, disabled }: D
                       ))}
                   </SelectContent>
                 </Select>
-              </div>
-            </div>
+              </Stack>
+            </Stack>
           )}
-        </div>
+        </Stack>
       ))}
       <Button type="button" variant="outline" size="sm" onClick={handleAddPark} disabled={disabled} className="w-full">
         <Plus className="h-4 w-4 mr-2" />
         {t("addPark")}
       </Button>
-    </div>
+    </Stack>
   );
 }
 
@@ -936,32 +948,45 @@ function JsonTreeNode({ data, path, onSelect, defaultExpanded = false }: JsonTre
   };
 
   if (data === null || data === undefined) {
-    return <span className="text-muted-foreground italic text-xs">null</span>;
+    return (
+      <Text as="span" size="xs" tone="muted" className="italic">
+        null
+      </Text>
+    );
   }
 
   if (typeof data === "object" && !Array.isArray(data)) {
     const entries = Object.entries(data as Record<string, unknown>);
     return (
-      <div className="ml-1">
+      <Box className="ml-1">
         <button
           type="button"
           className="flex items-center gap-1 text-xs hover:bg-muted/60 rounded px-1 py-0.5 -ml-1 w-full text-left"
           onClick={() => setExpanded(!expanded)}
         >
           {expanded ? <ChevronDown className="h-3 w-3 shrink-0" /> : <ChevronRight className="h-3 w-3 shrink-0" />}
-          <span className="text-muted-foreground">{`{${entries.length}}`}</span>
+          <Text as="span" size="xs" tone="muted">{`{${entries.length}}`}</Text>
         </button>
         {expanded && (
-          <div className="ml-3 border-l border-border pl-2 space-y-0.5">
+          <Stack gap="0.5" className="ml-3 border-l border-border pl-2">
             {entries.map(([key, val]) => {
               const childPath = path ? `${path}.${key}` : key;
               const isLeaf = val === null || val === undefined || typeof val !== "object";
               return (
-                <div key={key} className="flex items-start gap-1">
-                  <span className="text-xs font-medium text-blue-600 dark:text-blue-400 shrink-0 pt-0.5">{key}:</span>
+                <Flex key={key} align="start" gap="1">
+                  <Text
+                    as="span"
+                    size="xs"
+                    weight="medium"
+                    className="text-blue-600 dark:text-blue-400 shrink-0 pt-0.5"
+                  >
+                    {key}:
+                  </Text>
                   {isLeaf ? (
-                    <div className="flex items-center gap-1 group min-w-0">
-                      <span className="text-xs truncate">{String(val ?? "null")}</span>
+                    <Flex align="center" gap="1" className="group min-w-0">
+                      <Text as="span" size="xs" className="truncate">
+                        {String(val ?? "null")}
+                      </Text>
                       <button
                         type="button"
                         onClick={handleCopy.bind(null, { stopPropagation: () => {} } as React.MouseEvent)}
@@ -980,43 +1005,50 @@ function JsonTreeNode({ data, path, onSelect, defaultExpanded = false }: JsonTre
                           <Copy className="h-3 w-3 text-muted-foreground" />
                         )}
                       </button>
-                    </div>
+                    </Flex>
                   ) : (
                     <JsonTreeNode data={val} path={childPath} onSelect={onSelect} />
                   )}
-                </div>
+                </Flex>
               );
             })}
-          </div>
+          </Stack>
         )}
-      </div>
+      </Box>
     );
   }
 
   if (Array.isArray(data)) {
     return (
-      <div className="ml-1">
+      <Box className="ml-1">
         <button
           type="button"
           className="flex items-center gap-1 text-xs hover:bg-muted/60 rounded px-1 py-0.5 -ml-1 w-full text-left"
           onClick={() => setExpanded(!expanded)}
         >
           {expanded ? <ChevronDown className="h-3 w-3 shrink-0" /> : <ChevronRight className="h-3 w-3 shrink-0" />}
-          <span className="text-muted-foreground">{`[${data.length}]`}</span>
+          <Text as="span" size="xs" tone="muted">{`[${data.length}]`}</Text>
         </button>
         {expanded && (
-          <div className="ml-3 border-l border-border pl-2 space-y-0.5">
+          <Stack gap="0.5" className="ml-3 border-l border-border pl-2">
             {data.map((item, idx) => {
               const childPath = path ? `${path}[${idx}]` : `[${idx}]`;
               const isLeaf = item === null || item === undefined || typeof item !== "object";
               return (
-                <div key={idx} className="flex items-start gap-1">
-                  <span className="text-xs font-medium text-purple-600 dark:text-purple-400 shrink-0 pt-0.5">
+                <Flex key={idx} align="start" gap="1">
+                  <Text
+                    as="span"
+                    size="xs"
+                    weight="medium"
+                    className="text-purple-600 dark:text-purple-400 shrink-0 pt-0.5"
+                  >
                     [{idx}]:
-                  </span>
+                  </Text>
                   {isLeaf ? (
-                    <div className="flex items-center gap-1 group min-w-0">
-                      <span className="text-xs truncate">{String(item ?? "null")}</span>
+                    <Flex align="center" gap="1" className="group min-w-0">
+                      <Text as="span" size="xs" className="truncate">
+                        {String(item ?? "null")}
+                      </Text>
                       <button
                         type="button"
                         onClickCapture={(e) => {
@@ -1028,20 +1060,24 @@ function JsonTreeNode({ data, path, onSelect, defaultExpanded = false }: JsonTre
                       >
                         <Copy className="h-3 w-3 text-muted-foreground" />
                       </button>
-                    </div>
+                    </Flex>
                   ) : (
                     <JsonTreeNode data={item} path={childPath} onSelect={onSelect} />
                   )}
-                </div>
+                </Flex>
               );
             })}
-          </div>
+          </Stack>
         )}
-      </div>
+      </Box>
     );
   }
 
-  return <span className="text-xs">{String(data)}</span>;
+  return (
+    <Text as="span" size="xs">
+      {String(data)}
+    </Text>
+  );
 }
 
 interface MappingEntry {
@@ -1167,9 +1203,9 @@ function GenericDataMappingHelper({
   };
 
   return (
-    <div className="space-y-4">
+    <Stack gap="4">
       {/* Test & Preview button */}
-      <div className="flex gap-2">
+      <Flex gap="2">
         <Button
           type="button"
           variant="outline"
@@ -1181,28 +1217,36 @@ function GenericDataMappingHelper({
           {previewLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Zap className="h-4 w-4" />}
           {t("testAndPreview")}
         </Button>
-        <p className="text-xs text-muted-foreground self-center">{t("testAndPreviewHelp")}</p>
-      </div>
+        <Text size="xs" tone="muted" className="self-center">
+          {t("testAndPreviewHelp")}
+        </Text>
+      </Flex>
 
       {/* Preview error */}
-      {previewError && <div className="text-xs text-destructive bg-destructive/10 rounded-md p-2">{previewError}</div>}
+      {previewError && (
+        <Text size="xs" tone="destructive" className="bg-destructive/10 rounded-md p-2">
+          {previewError}
+        </Text>
+      )}
 
       {/* Response tree browser */}
       {previewData && (
-        <div className="border rounded-lg p-3 bg-muted/20 sm:max-h-64 sm:overflow-auto">
-          <div className="text-xs font-medium text-muted-foreground mb-2">{t("responseClickToAdd")}</div>
+        <Box className="border rounded-lg p-3 bg-muted/20 sm:max-h-64 sm:overflow-auto">
+          <Text size="xs" weight="medium" tone="muted" className="mb-2">
+            {t("responseClickToAdd")}
+          </Text>
           <JsonTreeNode data={previewData} path="" onSelect={handlePathSelect} defaultExpanded={true} />
-        </div>
+        </Box>
       )}
 
       {/* Mapping rows */}
       {mappings.map((mapping, index) => {
         const preview = resolvePreview(mapping.path || "");
         return (
-          <div key={index} className="flex gap-2">
-            <div className="flex-1 grid gap-2 p-3 border rounded-lg bg-muted/30">
-              <div className="grid grid-cols-2 gap-2">
-                <div className="grid gap-1">
+          <Flex key={index} gap="2">
+            <Grid gap="2" className="flex-1 p-3 border rounded-lg bg-muted/30">
+              <Grid cols="2" gap="2">
+                <Grid gap="1">
                   <Label htmlFor={`mapping-${index}-variable`} className="text-xs">
                     {t("variableName")}
                   </Label>
@@ -1214,8 +1258,8 @@ function GenericDataMappingHelper({
                     disabled={disabled}
                     className="h-8 text-sm"
                   />
-                </div>
-                <div className="grid gap-1">
+                </Grid>
+                <Grid gap="1">
                   <Label htmlFor={`mapping-${index}-path`} className="text-xs">
                     {t("dataPath")}
                   </Label>
@@ -1227,10 +1271,10 @@ function GenericDataMappingHelper({
                     disabled={disabled}
                     className="h-8 text-sm"
                   />
-                </div>
-              </div>
-              <div className="grid grid-cols-2 gap-2">
-                <div className="grid gap-1">
+                </Grid>
+              </Grid>
+              <Grid cols="2" gap="2">
+                <Grid gap="1">
                   <Label htmlFor={`mapping-${index}-default`} className="text-xs">
                     {t("defaultValue")}
                   </Label>
@@ -1242,24 +1286,27 @@ function GenericDataMappingHelper({
                     disabled={disabled}
                     className="h-8 text-sm"
                   />
-                </div>
+                </Grid>
                 {preview !== null && (
-                  <div className="grid gap-1">
+                  <Grid gap="1">
                     <Label className="text-xs text-green-700 dark:text-green-400">{t("preview")}</Label>
-                    <div className="h-8 flex items-center text-sm text-green-700 dark:text-green-300 bg-green-50 dark:bg-green-950/30 rounded-md px-2 truncate border border-green-200 dark:border-green-800">
+                    <Flex
+                      align="center"
+                      className="h-8 text-sm text-green-700 dark:text-green-300 bg-green-50 dark:bg-green-950/30 rounded-md px-2 truncate border border-green-200 dark:border-green-800"
+                    >
                       {preview}
-                    </div>
-                  </div>
+                    </Flex>
+                  </Grid>
                 )}
-              </div>
-              <p className="text-xs text-muted-foreground">
+              </Grid>
+              <Text size="xs" tone="muted">
                 {t("useInTemplates")}{" "}
-                <code className="bg-muted px-1 rounded">
+                <Code className="bg-muted px-1 rounded">
                   {"{{"}generic_data.{mapping.variable || "..."}
                   {"}}"}
-                </code>
-              </p>
-            </div>
+                </Code>
+              </Text>
+            </Grid>
             <Button
               type="button"
               variant="ghost"
@@ -1271,7 +1318,7 @@ function GenericDataMappingHelper({
             >
               <Trash2 className="h-4 w-4" />
             </Button>
-          </div>
+          </Flex>
         );
       })}
 
@@ -1279,7 +1326,7 @@ function GenericDataMappingHelper({
         <Plus className="h-4 w-4 mr-2" />
         {t("addMapping")}
       </Button>
-    </div>
+    </Stack>
   );
 }
 
@@ -1344,14 +1391,14 @@ function ArrayField({ name, property, value, onChange, disabled, itemSchema }: A
   const canRemove = !property.minItems || keyed.length > property.minItems;
 
   return (
-    <div className="space-y-3">
+    <Stack gap="3">
       {keyed.map(({ id, value: item }, index) => (
-        <div key={id} className="flex gap-2">
-          <div className="flex-1">
+        <Flex key={id} gap="2">
+          <Box className="flex-1">
             {itemSchema.type === "object" && itemSchema.properties ? (
-              <div className="grid gap-3 p-3 border rounded-lg bg-muted/30">
+              <Grid gap="3" className="p-3 border rounded-lg bg-muted/30">
                 {Object.entries(itemSchema.properties).map(([key, propSchema]) => (
-                  <div key={key} className="grid gap-1.5">
+                  <Grid key={key} gap="1.5">
                     <Label htmlFor={`${name}-${index}-${key}`} className="text-xs">
                       {propSchema.title || key}
                     </Label>
@@ -1368,9 +1415,9 @@ function ArrayField({ name, property, value, onChange, disabled, itemSchema }: A
                       showLocationButton={false}
                       isLocationLoading={false}
                     />
-                  </div>
+                  </Grid>
                 ))}
-              </div>
+              </Grid>
             ) : (
               <FormField
                 name={`${name}-${index}`}
@@ -1380,7 +1427,7 @@ function ArrayField({ name, property, value, onChange, disabled, itemSchema }: A
                 disabled={disabled}
               />
             )}
-          </div>
+          </Box>
           {canRemove && (
             <Button
               type="button"
@@ -1394,7 +1441,7 @@ function ArrayField({ name, property, value, onChange, disabled, itemSchema }: A
               <Trash2 className="h-4 w-4" />
             </Button>
           )}
-        </div>
+        </Flex>
       ))}
 
       {canAdd && (
@@ -1403,7 +1450,7 @@ function ArrayField({ name, property, value, onChange, disabled, itemSchema }: A
           Add {property.title || name}
         </Button>
       )}
-    </div>
+    </Stack>
   );
 }
 
@@ -1517,16 +1564,20 @@ function FormField({
           />
         );
       }
-      return <div className="text-sm text-muted-foreground">{t("arrayTypeNoItems")}</div>;
+      return <Text tone="muted">{t("arrayTypeNoItems")}</Text>;
     case "object":
       if (property.properties) {
         return (
-          <div className="grid gap-4 p-4 border rounded-lg">
+          <Grid gap="4" className="p-4 border rounded-lg">
             {Object.entries(property.properties).map(([key, propSchema]) => (
-              <div key={key} className="grid gap-1.5">
+              <Grid key={key} gap="1.5">
                 <Label htmlFor={`${name}-${key}`}>
                   {propSchema.title || key}
-                  {property.required?.includes(key) && <span className="text-destructive ml-1">*</span>}
+                  {property.required?.includes(key) && (
+                    <Text as="span" tone="destructive" className="ml-1">
+                      *
+                    </Text>
+                  )}
                 </Label>
                 <FormField
                   name={`${name}-${key}`}
@@ -1542,15 +1593,19 @@ function FormField({
                   showLocationButton={false}
                   isLocationLoading={false}
                 />
-                {propSchema.description && <p className="text-xs text-muted-foreground">{propSchema.description}</p>}
-              </div>
+                {propSchema.description && (
+                  <Text size="xs" tone="muted">
+                    {propSchema.description}
+                  </Text>
+                )}
+              </Grid>
             ))}
-          </div>
+          </Grid>
         );
       }
-      return <div className="text-sm text-muted-foreground">{t("objectTypeNoProperties")}</div>;
+      return <Text tone="muted">{t("objectTypeNoProperties")}</Text>;
     default:
-      return <div className="text-sm text-muted-foreground">Unknown type: {property.type}</div>;
+      return <Text tone="muted">Unknown type: {property.type}</Text>;
   }
 }
 
@@ -1591,11 +1646,11 @@ export function SchemaForm({ schema, values, onChange, disabled, className }: Sc
   );
 
   if (!schema.properties) {
-    return <div className="text-sm text-muted-foreground">{t("noSchemaProperties")}</div>;
+    return <Text tone="muted">{t("noSchemaProperties")}</Text>;
   }
 
   return (
-    <div className={cn("grid gap-4", className)}>
+    <Grid gap="4" className={className}>
       {Object.entries(schema.properties).map(([name, property]) => {
         // Skip the 'enabled' field as it's handled separately
         if (name === "enabled") return null;
@@ -1611,10 +1666,14 @@ export function SchemaForm({ schema, values, onChange, disabled, className }: Sc
         const fieldDisabled = disabled || shouldDisableDigitColor;
 
         return (
-          <div key={name} className="grid gap-1.5">
+          <Grid key={name} gap="1.5">
             <Label htmlFor={name} className="flex items-center gap-1">
               {property.title || name}
-              {isRequired && <span className="text-destructive">*</span>}
+              {isRequired && (
+                <Text as="span" tone="destructive">
+                  *
+                </Text>
+              )}
             </Label>
             <FormField
               name={name}
@@ -1628,13 +1687,25 @@ export function SchemaForm({ schema, values, onChange, disabled, className }: Sc
               isLocationLoading={false}
               allValues={values}
             />
-            {property.description && <p className="text-xs text-muted-foreground">{property.description}</p>}
-            {showLocationButton && <p className="text-xs text-muted-foreground">{t("clickLocationIcon")}</p>}
-            {shouldDisableDigitColor && <p className="text-xs text-muted-foreground">{t("digitColorNotUsed")}</p>}
-          </div>
+            {property.description && (
+              <Text size="xs" tone="muted">
+                {property.description}
+              </Text>
+            )}
+            {showLocationButton && (
+              <Text size="xs" tone="muted">
+                {t("clickLocationIcon")}
+              </Text>
+            )}
+            {shouldDisableDigitColor && (
+              <Text size="xs" tone="muted">
+                {t("digitColorNotUsed")}
+              </Text>
+            )}
+          </Grid>
         );
       })}
-    </div>
+    </Grid>
   );
 }
 

--- a/web/src/components/schedule/schedule-calendar-view.tsx
+++ b/web/src/components/schedule/schedule-calendar-view.tsx
@@ -2,7 +2,17 @@ import "react-big-calendar/lib/css/react-big-calendar.css";
 import "react-big-calendar/lib/addons/dragAndDrop/styles.css";
 import "@/styles/calendar.css";
 
-import { Button, Slider, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@fiestaboard/ui";
+import {
+  Box,
+  Button,
+  Flex,
+  Slider,
+  Text,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@fiestaboard/ui";
 import { addDays, format, getDay, parse, startOfWeek } from "date-fns";
 import { enUS } from "date-fns/locale/en-US";
 import { ChevronLeft, ChevronRight, ZoomIn, ZoomOut } from "lucide-react";
@@ -97,7 +107,8 @@ export function ScheduleCalendarView({
   // Track mobile state
   const [isMobile, setIsMobile] = useState(false);
   const [mobileStartDay, setMobileStartDay] = useState(0); // 0 = Sunday
-  const containerRef = useRef<HTMLDivElement>(null);
+  // Typed as HTMLElement (not HTMLDivElement) to satisfy Box's ref contract; only used as a ref target.
+  const containerRef = useRef<HTMLElement>(null);
 
   // Zoom state – persisted to localStorage
   const [zoomIndex, setZoomIndex] = useState<number>(() => {
@@ -326,15 +337,15 @@ export function ScheduleCalendarView({
 
   return (
     <TooltipProvider>
-      <div className="schedule-calendar-wrapper flex flex-col sm:h-full">
+      <Box className="schedule-calendar-wrapper flex flex-col sm:h-full">
         {/* Top bar: mobile day navigation (left) + zoom slider (right).
             flex-wrap: day nav + zoom together exceed narrow phone widths;
             wrapping drops the zoom control to its own line instead of
             pushing it off-screen. */}
-        <div className="flex flex-wrap items-center justify-between gap-y-1 mb-2 px-1">
+        <Flex wrap align="center" justify="between" className="gap-y-1 mb-2 px-1">
           {/* Mobile day navigation */}
           {isMobile ? (
-            <div className="flex items-center gap-1">
+            <Flex align="center" gap="1">
               <Button
                 variant="ghost"
                 size="sm"
@@ -344,7 +355,7 @@ export function ScheduleCalendarView({
               >
                 <ChevronLeft className="h-4 w-4" />
               </Button>
-              <div className="flex gap-1">
+              <Flex gap="1">
                 {DAY_NAMES.map((day, idx) => (
                   <button
                     key={day}
@@ -358,7 +369,7 @@ export function ScheduleCalendarView({
                     {day[0]}
                   </button>
                 ))}
-              </div>
+              </Flex>
               <Button
                 variant="ghost"
                 size="sm"
@@ -368,15 +379,15 @@ export function ScheduleCalendarView({
               >
                 <ChevronRight className="h-4 w-4" />
               </Button>
-            </div>
+            </Flex>
           ) : (
-            <div />
+            <Box />
           )}
 
           {/* Zoom slider */}
           <Tooltip>
             <TooltipTrigger asChild>
-              <div className="ml-auto flex items-center gap-2">
+              <Flex align="center" gap="2" className="ml-auto">
                 <Button
                   variant="ghost"
                   size="sm"
@@ -403,18 +414,18 @@ export function ScheduleCalendarView({
                 >
                   <ZoomIn className="h-3.5 w-3.5" />
                 </Button>
-                <span className="text-[10px] font-medium text-muted-foreground w-8 tabular-nums">
+                <Text as="span" weight="medium" tone="muted" className="text-[10px] w-8 tabular-nums">
                   {ZOOM_PRESETS[zoomIndex][0]}
-                </span>
-              </div>
+                </Text>
+              </Flex>
             </TooltipTrigger>
             <TooltipContent side="bottom">
               {zoomStep === 1 ? "1-minute grid" : `${zoomStep}-minute grid`}
             </TooltipContent>
           </Tooltip>
-        </div>
+        </Flex>
 
-        <div
+        <Box
           ref={containerRef}
           className={`schedule-calendar-container flex-1 min-h-0 ${isMobile ? "schedule-calendar-mobile" : ""}`}
           data-start-day={mobileStartDay}
@@ -459,8 +470,8 @@ export function ScheduleCalendarView({
             resizableAccessor={(event: CalendarEvent) => event.resource.kind !== "silence"}
             longPressThreshold={150}
           />
-        </div>
-      </div>
+        </Box>
+      </Box>
     </TooltipProvider>
   );
 }

--- a/web/src/components/schedule/schedule-event.tsx
+++ b/web/src/components/schedule/schedule-event.tsx
@@ -1,4 +1,4 @@
-import { Badge } from "@fiestaboard/ui";
+import { Badge, Box, Flex, Stack, Text } from "@fiestaboard/ui";
 import { format } from "date-fns";
 import { Moon } from "lucide-react";
 import { useMemo } from "react";
@@ -73,7 +73,7 @@ function RegularScheduleEvent({ event }: { event: ScheduleCalendarEvent }) {
   const activeColor = resource.enabled ? scheduleColor : "var(--muted-foreground)";
 
   return (
-    <div
+    <Box
       className="schedule-event-content h-full w-full overflow-hidden rounded px-1.5 py-1"
       data-testid={`calendar-event-${resource.scheduleId}`}
       data-schedule-id={resource.scheduleId}
@@ -87,22 +87,22 @@ function RegularScheduleEvent({ event }: { event: ScheduleCalendarEvent }) {
         ...(isEveningSplit ? { borderBottom: `1px dashed ${activeColor}` } : {}),
       }}
     >
-      <div className="flex flex-col gap-0">
+      <Stack gap="0">
         {isMorningSplit && continuationHint && (
-          <span className="text-[8px] leading-tight truncate opacity-85" style={{ color: activeColor }}>
+          <Text as="span" className="text-[8px] leading-tight truncate opacity-85" style={{ color: activeColor }}>
             {continuationHint}
-          </span>
+          </Text>
         )}
-        <div className="font-medium text-[10px] leading-tight truncate" style={{ color: activeColor }}>
+        <Text className="font-medium text-[10px] leading-tight truncate" style={{ color: activeColor }}>
           {event.title}
-        </div>
-        <span className="text-[9px] font-medium truncate" style={{ color: activeColor }}>
+        </Text>
+        <Text as="span" className="text-[9px] font-medium truncate" style={{ color: activeColor }}>
           {timeRange}
-        </span>
+        </Text>
         {isEveningSplit && continuationHint && (
-          <span className="text-[8px] leading-tight truncate opacity-85" style={{ color: activeColor }}>
+          <Text as="span" className="text-[8px] leading-tight truncate opacity-85" style={{ color: activeColor }}>
             {continuationHint}
-          </span>
+          </Text>
         )}
         {!resource.enabled && (
           <Badge variant="secondary" className="w-fit text-[10px] px-1 py-0 h-3.5">
@@ -110,10 +110,12 @@ function RegularScheduleEvent({ event }: { event: ScheduleCalendarEvent }) {
           </Badge>
         )}
         {resource.dayPattern !== "all" && (
-          <span className="text-[10px] text-muted-foreground truncate">{dayPatternDisplay}</span>
+          <Text as="span" tone="muted" className="text-[10px] truncate">
+            {dayPatternDisplay}
+          </Text>
         )}
-      </div>
-    </div>
+      </Stack>
+    </Box>
   );
 }
 
@@ -149,7 +151,7 @@ function SilenceEvent({ event }: { event: SilenceCalendarEvent }) {
   const isEveningSplit = resource.isMidnightSplit && resource.splitPart === "evening";
 
   return (
-    <div
+    <Box
       className="schedule-event-content h-full w-full overflow-hidden rounded px-1.5 py-1"
       data-testid="calendar-event-silence"
       data-split={resource.isMidnightSplit ? resource.splitPart : "none"}
@@ -157,20 +159,30 @@ function SilenceEvent({ event }: { event: SilenceCalendarEvent }) {
       tabIndex={0}
       aria-label={t("silenceEventAriaLabel", { range: timeRange })}
     >
-      <div className="flex flex-col gap-0">
+      <Stack gap="0">
         {isMorningSplit && continuationHint && (
-          <span className="text-[8px] leading-tight truncate opacity-85">{continuationHint}</span>
+          <Text as="span" tone="muted" className="text-[8px] leading-tight truncate opacity-85">
+            {continuationHint}
+          </Text>
         )}
-        <div className="flex items-center gap-1">
+        <Flex align="center" gap="1">
           <Moon className="h-2.5 w-2.5 flex-shrink-0" aria-hidden="true" />
-          <span className="font-medium text-[10px] leading-tight truncate">{t("silenceEventTitle")}</span>
-        </div>
-        <span className="text-[9px] font-medium truncate">{timeRange}</span>
+          <Text as="span" tone="muted" className="font-medium text-[10px] leading-tight truncate">
+            {t("silenceEventTitle")}
+          </Text>
+        </Flex>
+        <Text as="span" tone="muted" className="text-[9px] font-medium truncate">
+          {timeRange}
+        </Text>
         {isEveningSplit && continuationHint && (
-          <span className="text-[8px] leading-tight truncate opacity-85">{continuationHint}</span>
+          <Text as="span" tone="muted" className="text-[8px] leading-tight truncate opacity-85">
+            {continuationHint}
+          </Text>
         )}
-        <span className="text-[9px] truncate opacity-80">{subtitle}</span>
-      </div>
-    </div>
+        <Text as="span" tone="muted" className="text-[9px] truncate opacity-80">
+          {subtitle}
+        </Text>
+      </Stack>
+    </Box>
   );
 }

--- a/web/src/components/schedule/schedule-list-view.tsx
+++ b/web/src/components/schedule/schedule-list-view.tsx
@@ -1,4 +1,17 @@
-import { Badge, Button, Card, CardContent, CardHeader, CardTitle, Label, Switch } from "@fiestaboard/ui";
+import {
+  Badge,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Flex,
+  Label,
+  Stack,
+  Switch,
+  Text,
+} from "@fiestaboard/ui";
 import { format } from "date-fns";
 import { Calendar, ChevronRight, Edit, GalleryHorizontalEnd, Moon, Trash2 } from "lucide-react";
 
@@ -142,15 +155,17 @@ export function ScheduleListView({
         className="w-full text-left flex items-center justify-between p-4 border rounded-lg bg-muted/30 hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring transition-colors"
         data-testid="schedule-list-silence-row"
       >
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2 mb-1">
+        <Box className="flex-1 min-w-0">
+          <Flex align="center" gap="2" className="mb-1">
             <Moon className="h-4 w-4 text-muted-foreground flex-shrink-0" aria-hidden="true" />
-            <span className="font-medium">{t("silenceScheduleListTitle")}</span>
-          </div>
-          <div className="text-sm text-muted-foreground truncate">
+            <Text as="span" weight="medium">
+              {t("silenceScheduleListTitle")}
+            </Text>
+          </Flex>
+          <Text tone="muted" className="truncate">
             {timeRange} • {subtitle}
-          </div>
-        </div>
+          </Text>
+        </Box>
         <ChevronRight className="h-4 w-4 text-muted-foreground flex-shrink-0 ml-2" aria-hidden="true" />
       </button>
     );
@@ -163,34 +178,38 @@ export function ScheduleListView({
       </CardHeader>
       <CardContent>
         {schedules.length === 0 && !showSilenceRow ? (
-          <div className="text-center py-12 text-muted-foreground">
+          <Box className="text-center py-12 text-muted-foreground">
             <Calendar className="h-12 w-12 mx-auto mb-4" />
-            <p>{t("noSchedulesCreated")}</p>
-            <p className="text-sm mt-1">{t("useToolbarToAdd")}</p>
-          </div>
+            <Text tone="muted">{t("noSchedulesCreated")}</Text>
+            <Text tone="muted" className="mt-1">
+              {t("useToolbarToAdd")}
+            </Text>
+          </Box>
         ) : (
-          <div className="space-y-3">
+          <Stack gap="3">
             {renderSilenceRow()}
             {schedules.map((schedule) => {
               const pageName = getPageName(schedule.page_id);
               const toggleId = `schedule-enabled-${schedule.id}`;
               return (
-                <div key={schedule.id} className="flex items-center justify-between p-4 border rounded-lg">
-                  <div className="flex-1">
-                    <div className="flex items-center gap-2 mb-1">
+                <Flex key={schedule.id} align="center" justify="between" className="p-4 border rounded-lg">
+                  <Box className="flex-1">
+                    <Flex align="center" gap="2" className="mb-1">
                       {isCollectionId(schedule.page_id) && (
                         <GalleryHorizontalEnd className="h-4 w-4 text-muted-foreground flex-shrink-0" />
                       )}
-                      <span className="font-medium">{pageName}</span>
+                      <Text as="span" weight="medium">
+                        {pageName}
+                      </Text>
                       {!schedule.enabled && <Badge variant="secondary">{tCommon("disabled")}</Badge>}
-                    </div>
-                    <div className="text-sm text-muted-foreground">
+                    </Flex>
+                    <Text tone="muted">
                       {formatTimeDisplay(schedule)} • {formatDays(schedule)}
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-2">
+                    </Text>
+                  </Box>
+                  <Flex align="center" gap="2">
                     {onToggleEnabled && (
-                      <div className="flex items-center gap-2 pr-2 border-r mr-1">
+                      <Flex align="center" gap="2" className="pr-2 border-r mr-1">
                         <Label htmlFor={toggleId} className="text-xs text-muted-foreground cursor-pointer">
                           {t("scheduleEntryForm.enabledLabel")}
                         </Label>
@@ -200,7 +219,7 @@ export function ScheduleListView({
                           onCheckedChange={(checked) => onToggleEnabled(schedule, checked)}
                           aria-label={t("toggleEnabledAriaLabel", { pageName })}
                         />
-                      </div>
+                      </Flex>
                     )}
                     <Button
                       size="sm"
@@ -218,11 +237,11 @@ export function ScheduleListView({
                     >
                       <Trash2 className="h-4 w-4" />
                     </Button>
-                  </div>
-                </div>
+                  </Flex>
+                </Flex>
               );
             })}
-          </div>
+          </Stack>
         )}
       </CardContent>
     </Card>

--- a/web/src/components/settings/system-update.tsx
+++ b/web/src/components/settings/system-update.tsx
@@ -97,6 +97,7 @@ export function SystemUpdate() {
               {/* Plain <a> stays raw: it is the single Slot child of Button asChild,
                   which merges button styling onto it; TextLink would layer conflicting
                   link/underline treatment on top. */}
+              {/* eslint-disable-next-line react/forbid-elements -- single Slot child of Button asChild; the Button merges its chrome onto this anchor and TextLink would layer conflicting link styling */}
               <a href={updateCheck.package_url} target="_blank" rel="noopener noreferrer">
                 <ExternalLink className="h-4 w-4 mr-2" />
                 {t("viewRelease")}

--- a/web/src/components/tiptap-template-editor/node-views/ColorTileNodeView.tsx
+++ b/web/src/components/tiptap-template-editor/node-views/ColorTileNodeView.tsx
@@ -79,6 +79,7 @@ export function ColorTileNodeView({ node, deleteNode: _deleteNode }: ColorTileNo
           contentEditable and all styling is inline; wrapping it in <Text>
           would inject text-foreground/text-sm classes that could disturb the
           transparent-until-selected geometry. Correctness over coverage. */}
+            {/* eslint-disable-next-line react/forbid-elements -- selection-anchor span in TipTap contentEditable with all-inline styling; Text would inject classes that disturb the transparent-until-selected geometry */}
             <span
               aria-label={`${color} color tile`}
               style={{

--- a/web/src/components/tiptap-template-editor/node-views/FillSpaceNodeView.tsx
+++ b/web/src/components/tiptap-template-editor/node-views/FillSpaceNodeView.tsx
@@ -41,6 +41,7 @@ export function FillSpaceNodeView({ node, deleteNode: _deleteNode }: FillSpaceNo
                   contentEditable. <Text as="span"> would emit text-foreground,
                   overriding the Badge's inherited success tint, and text-[11px]
                   is sub-xs grid geometry. Kept raw for correctness. */}
+              {/* eslint-disable-next-line react/forbid-elements -- span inside a colored Badge in TipTap contentEditable; Text as="span" would override the Badge's inherited tint and text-[11px] is sub-xs grid geometry */}
               <span className="font-mono text-[11px] leading-none">
                 fill_space{hasRepeatChar && `_repeat:${repeatChar}`}
               </span>

--- a/web/src/components/tiptap-template-editor/node-views/FormulaNodeView.tsx
+++ b/web/src/components/tiptap-template-editor/node-views/FormulaNodeView.tsx
@@ -111,6 +111,7 @@ export function FormulaNodeView({ node, updateAttributes, deleteNode }: FormulaN
               {/* Raw <span>: colored Badge inside contentEditable; <Text as="span">
                   would reset the inherited pill color and text-[11px] is sub-xs
                   grid geometry. Kept raw for correctness. */}
+              {/* eslint-disable-next-line react/forbid-elements -- span inside a colored Badge in TipTap contentEditable; Text as="span" would reset the inherited pill color and text-[11px] is sub-xs grid geometry */}
               <span className="font-mono text-[11px] leading-none">{preview}</span>
             </Badge>
           </TooltipTrigger>

--- a/web/src/components/tiptap-template-editor/node-views/VariableNodeView.tsx
+++ b/web/src/components/tiptap-template-editor/node-views/VariableNodeView.tsx
@@ -41,15 +41,18 @@ export function VariableNodeView({ node, deleteNode: _deleteNode }: VariableNode
               Badge's inherited "variable" tint are pixel/color load-bearing.
               <Text as="span"> would reset color + size, so kept raw for
               correctness (only the portal Tooltip copy below is primitived). */}
+          {/* eslint-disable-next-line react/forbid-elements -- span in a colored Badge in TipTap contentEditable; Text would reset the inherited variable tint and sub-xs text-[11px] grid geometry */}
           <span className="font-mono text-[11px] leading-none">
             {pluginId}.{field}
           </span>
 
           {filters && filters.length > 0 && (
+            // eslint-disable-next-line react/forbid-elements -- inline-flex span wrapping filter chips inside the contentEditable Badge; Text would inject block/tone defaults
             <span className="inline-flex items-center gap-0.5">
               {filters.map((filter, idx) => (
                 <Tooltip key={idx}>
                   <TooltipTrigger asChild>
+                    {/* eslint-disable-next-line react/forbid-elements -- filter chip span in a colored Badge in contentEditable; Text would reset the inherited tint and sub-xs text-[10px] grid geometry */}
                     <span className="inline-flex items-center px-1 rounded text-[10px] bg-tag-variable/20 leading-none">
                       {filter.name}
                       {filter.arg && `:${filter.arg}`}
@@ -69,6 +72,7 @@ export function VariableNodeView({ node, deleteNode: _deleteNode }: VariableNode
           {maxLength && (
             <Tooltip>
               <TooltipTrigger asChild>
+                {/* eslint-disable-next-line react/forbid-elements -- hover-reveal max-length span in the contentEditable Badge; Text would reset sub-xs text-[10px] grid geometry and inherited tint */}
                 <span className="hidden group-hover:inline text-[10px] leading-none">~{maxLength}</span>
               </TooltipTrigger>
               <TooltipContent>

--- a/web/src/components/tiptap-template-editor/node-views/WrappedTextView.tsx
+++ b/web/src/components/tiptap-template-editor/node-views/WrappedTextView.tsx
@@ -46,6 +46,7 @@ export function WrappedTextView({ node, deleteNode }: WrappedTextViewProps) {
           Raw <span>: renders inside TipTap's contentEditable atom, inheriting
           the wrapper's text-warning color, with sub-xs text-[11px] grid
           geometry. <Text as="span"> would reset both. Kept raw for correctness. */}
+      {/* eslint-disable-next-line react/forbid-elements -- atom span in TipTap contentEditable inheriting the wrapper's text-warning color, with sub-xs text-[11px] grid geometry; Text would reset both */}
       <span className="font-mono text-[11px] inline-block align-middle ml-1">{text}</span>
 
       {/* Delete button */}

--- a/web/src/components/transitions/transition-grid-display.tsx
+++ b/web/src/components/transitions/transition-grid-display.tsx
@@ -1,3 +1,4 @@
+import { Box, Flex, Text } from "@fiestaboard/ui";
 import { memo } from "react";
 
 import { COLOR_CODE_MAP } from "@/lib/board-colors";
@@ -81,12 +82,12 @@ export const TransitionGridDisplay = memo(function TransitionGridDisplay({
   }
 
   return (
-    <div className={`w-full flex justify-center ${className}`}>
-      <div
+    <Flex justify="center" className={`w-full ${className}`}>
+      <Box
         className="rounded-lg border-[3px] max-w-full overflow-x-auto"
         style={{ backgroundColor: bezelBg, borderColor, width: "fit-content" }}
       >
-        <div
+        <Box
           className={`${padding} relative`}
           style={{
             background: isWhiteBoard
@@ -94,39 +95,43 @@ export const TransitionGridDisplay = memo(function TransitionGridDisplay({
               : "linear-gradient(135deg, var(--color-board-surface-dark) 0%, var(--color-board-black) 100%)",
           }}
         >
-          <div className={`flex flex-col ${gap}`}>
+          <Box className={`flex flex-col ${gap}`}>
             {grid.map((row, r) => (
-              <div key={r} className={`flex ${gap} justify-center`}>
+              <Flex key={r} justify="center" className={gap}>
                 {row.map((code, c) => {
                   const colorBg = COLOR_CODE_MAP[String(code)];
                   if (colorBg !== undefined) {
                     return (
-                      <div key={c} className={`${sizeClass} rounded-[3px]`} style={{ backgroundColor: colorBg }} />
+                      <Box key={c} className={`${sizeClass} rounded-[3px]`} style={{ backgroundColor: colorBg }} />
                     );
                   }
                   const char = codeToChar(code);
                   return (
-                    <div
+                    <Flex
                       key={c}
-                      className={`${sizeClass} rounded-[3px] flex items-center justify-center`}
+                      align="center"
+                      justify="center"
+                      className={`${sizeClass} rounded-[3px]`}
                       style={{ backgroundColor: tileBg }}
                     >
                       {char !== " " && (
-                        <span
-                          className={`${textSize} font-mono font-semibold select-none leading-none`}
+                        <Text
+                          as="span"
+                          weight="semibold"
+                          className={`${textSize} font-mono select-none leading-none`}
                           style={{ color: textColor }}
                         >
                           {char}
-                        </span>
+                        </Text>
                       )}
-                    </div>
+                    </Flex>
                   );
                 })}
-              </div>
+              </Flex>
             ))}
-          </div>
-        </div>
-      </div>
-    </div>
+          </Box>
+        </Box>
+      </Box>
+    </Flex>
   );
 });

--- a/web/src/components/ui/time-picker.tsx
+++ b/web/src/components/ui/time-picker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Button } from "@fiestaboard/ui";
+import { Box, Button, Flex, Text } from "@fiestaboard/ui";
 import { Clock } from "lucide-react";
 import type { CSSProperties } from "react";
 import { useEffect, useRef, useState } from "react";
@@ -33,8 +33,9 @@ export function TimePicker({
   const [hours, setHours] = useState("00");
   const [minutes, setMinutes] = useState("00");
   const [dropdownStyle, setDropdownStyle] = useState<CSSProperties>({});
-  const containerRef = useRef<HTMLDivElement>(null);
-  const dropdownRef = useRef<HTMLDivElement>(null);
+  // Typed as HTMLElement to satisfy Box's ref contract (only DOM methods common to HTMLElement are used).
+  const containerRef = useRef<HTMLElement>(null);
+  const dropdownRef = useRef<HTMLElement>(null);
 
   // Parse value on mount and when value changes
   useEffect(() => {
@@ -121,12 +122,12 @@ export function TimePicker({
   };
 
   const dropdown = isOpen ? (
-    <div ref={dropdownRef} style={dropdownStyle} className="rounded-md border bg-background p-4 shadow-md">
-      <div className="flex gap-4">
+    <Box ref={dropdownRef} style={dropdownStyle} className="rounded-md border bg-background p-4 shadow-md">
+      <Flex gap="4">
         {/* Hours */}
-        <div className="flex-1">
+        <Box className="flex-1">
           <label className="text-xs font-medium text-muted-foreground mb-2 block">{t("hour")}</label>
-          <div className="max-h-48 overflow-y-auto rounded-md border bg-background">
+          <Box className="max-h-48 overflow-y-auto rounded-md border bg-background">
             {hourOptions.map((option) => (
               <button
                 key={option.value}
@@ -140,13 +141,13 @@ export function TimePicker({
                 {option.label}
               </button>
             ))}
-          </div>
-        </div>
+          </Box>
+        </Box>
 
         {/* Minutes */}
-        <div className="flex-1">
+        <Box className="flex-1">
           <label className="text-xs font-medium text-muted-foreground mb-2 block">{t("minute")}</label>
-          <div className="max-h-48 overflow-y-auto rounded-md border bg-background">
+          <Box className="max-h-48 overflow-y-auto rounded-md border bg-background">
             {minuteOptions.map((option) => (
               <button
                 key={option.value}
@@ -160,14 +161,16 @@ export function TimePicker({
                 {option.label}
               </button>
             ))}
-          </div>
-        </div>
-      </div>
+          </Box>
+        </Box>
+      </Flex>
 
       {/* Quick presets */}
-      <div className="mt-4 pt-4 border-t">
-        <div className="text-xs font-medium text-muted-foreground mb-2">{t("quickPresets")}</div>
-        <div className="flex gap-2 flex-wrap">
+      <Box className="mt-4 pt-4 border-t">
+        <Text size="xs" weight="medium" tone="muted" className="mb-2">
+          {t("quickPresets")}
+        </Text>
+        <Flex gap="2" wrap>
           {[
             { label: "8 AM", value: "08:00" },
             { label: "12 PM", value: "12:00" },
@@ -189,13 +192,13 @@ export function TimePicker({
               {preset.label}
             </button>
           ))}
-        </div>
-      </div>
-    </div>
+        </Flex>
+      </Box>
+    </Box>
   ) : null;
 
   return (
-    <div ref={containerRef} className={cn("relative", className)}>
+    <Box ref={containerRef} className={cn("relative", className)}>
       <Button
         id={id}
         type="button"
@@ -208,10 +211,10 @@ export function TimePicker({
         className={cn("w-full h-9 px-3 text-sm justify-start font-normal", !value && "text-muted-foreground")}
       >
         <Clock className="mr-2 h-4 w-4" />
-        <span>{value ? formatDisplayValue() : placeholder}</span>
+        {value ? formatDisplayValue() : placeholder}
       </Button>
 
       {typeof window !== "undefined" && dropdown ? createPortal(dropdown, document.body) : null}
-    </div>
+    </Box>
   );
 }

--- a/web/src/components/ui/timezone-picker.tsx
+++ b/web/src/components/ui/timezone-picker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Button, Input } from "@fiestaboard/ui";
+import { Box, Button, Input, Text } from "@fiestaboard/ui";
 import { Check, ChevronsUpDown } from "lucide-react";
 import type { CSSProperties } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -26,8 +26,9 @@ export function TimezonePicker({ value, onChange, className, disabled, onValidat
   const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const [dropdownStyle, setDropdownStyle] = useState<CSSProperties>({});
   const inputRef = useRef<HTMLInputElement>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const listRef = useRef<HTMLDivElement>(null);
+  // Typed as HTMLElement to satisfy Box's ref contract (only DOM methods common to HTMLElement are used).
+  const containerRef = useRef<HTMLElement>(null);
+  const listRef = useRef<HTMLElement>(null);
 
   // Find the display label for the current value
   const _currentLabel = useMemo(() => {
@@ -242,8 +243,8 @@ export function TimezonePicker({ value, onChange, className, disabled, onValidat
   };
 
   return (
-    <div className={cn("relative", className)} ref={containerRef}>
-      <div className="relative">
+    <Box className={cn("relative", className)} ref={containerRef}>
+      <Box className="relative">
         <Input
           ref={inputRef}
           id={id}
@@ -275,11 +276,11 @@ export function TimezonePicker({ value, onChange, className, disabled, onValidat
         >
           <ChevronsUpDown className="h-4 w-4 text-muted-foreground" />
         </Button>
-      </div>
+      </Box>
 
       {typeof window !== "undefined" && isOpen && filteredTimezones.length > 0
         ? createPortal(
-            <div
+            <Box
               ref={listRef}
               role="listbox"
               aria-label={t("optionsAriaLabel")}
@@ -305,21 +306,26 @@ export function TimezonePicker({ value, onChange, className, disabled, onValidat
                     onMouseEnter={() => setHighlightedIndex(index)}
                   >
                     {isSelected && <Check className="mr-2 h-4 w-4" />}
+                    {/* eslint-disable-next-line react/forbid-elements -- inline label span inherits the option button's dynamic hover/highlight text color; Text as="span" would pin an explicit tone and break the hover/highlight color change */}
                     <span className={isSelected ? "" : "ml-6"}>{timezone.label}</span>
                   </button>
                 );
               })}
               {filteredTimezones.length > 50 && (
-                <div className="px-2 py-1.5 text-xs text-muted-foreground">
+                <Text size="xs" tone="muted" className="px-2 py-1.5">
                   {t("showingFirst", { total: filteredTimezones.length })}
-                </div>
+                </Text>
               )}
-            </div>,
+            </Box>,
             document.body,
           )
         : null}
 
-      {!isValid && value && <p className="mt-1 text-xs text-destructive">{t("invalidTimezone")}</p>}
-    </div>
+      {!isValid && value && (
+        <Text size="xs" tone="destructive" className="mt-1">
+          {t("invalidTimezone")}
+        </Text>
+      )}
+    </Box>
   );
 }

--- a/web/src/components/wizard/setup-wizard.tsx
+++ b/web/src/components/wizard/setup-wizard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Aurora, Button } from "@fiestaboard/ui";
+import { Aurora, Box, Button, Flex, Heading, Text } from "@fiestaboard/ui";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 
@@ -158,20 +158,25 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
   ];
 
   return (
-    <div className="fixed inset-0 z-50 bg-background overflow-y-auto">
+    <Box className="fixed inset-0 z-50 bg-background overflow-y-auto">
       {/* Aurora background - fixed so it stays in place while content scrolls */}
-      <div className="fixed inset-0 pointer-events-none">
+      <Box className="fixed inset-0 pointer-events-none">
         <Aurora colorStops={["#f8e71c", "#eb4034", "#AA00FF", "#9b59b6"]} blend={0.5} amplitude={1.0} speed={0.5} />
-      </div>
+      </Box>
 
       {/* Content container */}
-      <div className="relative min-h-full flex items-start justify-center py-6 sm:py-10 px-4 sm:px-6">
-        <div className="w-full max-w-lg bg-background/75 backdrop-blur-xl rounded-2xl shadow-2xl border border-white/10 p-6 sm:p-8">
+      <Flex align="start" justify="center" className="relative min-h-full py-6 sm:py-10 px-4 sm:px-6">
+        <Box className="w-full max-w-lg bg-background/75 backdrop-blur-xl rounded-2xl shadow-2xl border border-white/10 p-6 sm:p-8">
           {/* Header */}
-          <header className="text-center pb-4">
-            <div className="flex items-center justify-between mb-4">
-              <div />
-              <div className="inline-flex items-center justify-center w-14 h-14 sm:w-16 sm:h-16 rounded-2xl bg-primary/10 overflow-hidden">
+          <Box as="header" className="text-center pb-4">
+            <Flex align="center" justify="between" className="mb-4">
+              <Box />
+              <Flex
+                inline
+                align="center"
+                justify="center"
+                className="w-14 h-14 sm:w-16 sm:h-16 rounded-2xl bg-primary/10 overflow-hidden"
+              >
                 <img
                   src={appUrl("/icons/icon-96x96.png")}
                   alt=""
@@ -179,18 +184,21 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
                   height={48}
                   className="w-10 h-10 sm:w-12 sm:h-12"
                 />
-              </div>
+              </Flex>
               <LanguageSelector />
-            </div>
+            </Flex>
+            {/* eslint-disable-next-line react/forbid-elements -- wizard hero <h1>: Heading has no level=1 and PageHeader renders an icon+card layout unfit for this centered hero title */}
             <h1 className="text-2xl sm:text-3xl font-bold tracking-tight">{t("welcomeTitle")}</h1>
-            <p className="text-muted-foreground mt-2 text-sm sm:text-base">{t("welcomeSubtitle")}</p>
-          </header>
+            <Text tone="muted" className="mt-2 text-sm sm:text-base">
+              {t("welcomeSubtitle")}
+            </Text>
+          </Box>
 
           {/* Progress indicator */}
-          <div className="pb-4">
-            <div className="flex items-center gap-2">
+          <Box className="pb-4">
+            <Flex align="center" gap="2">
               {[1, 2, 3].map((step) => (
-                <div
+                <Box
                   key={step}
                   className={cn(
                     "flex-1 h-2 rounded-full transition-all duration-500",
@@ -198,38 +206,48 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
                   )}
                 />
               ))}
-            </div>
-            <div className="flex justify-between mt-2 text-xs text-muted-foreground">
-              <span>{t("progressConnect")}</span>
-              <span>{t("progressCustomize")}</span>
-              <span>{t("progressFinish")}</span>
-            </div>
-          </div>
+            </Flex>
+            <Flex justify="between" className="mt-2 text-xs text-muted-foreground">
+              <Text as="span" size="xs" tone="muted">
+                {t("progressConnect")}
+              </Text>
+              <Text as="span" size="xs" tone="muted">
+                {t("progressCustomize")}
+              </Text>
+              <Text as="span" size="xs" tone="muted">
+                {t("progressFinish")}
+              </Text>
+            </Flex>
+          </Box>
 
           {/* Step header */}
-          <div className="mb-6">
-            <h2 className="text-xl sm:text-2xl font-semibold">{stepTitles[currentStep - 1]}</h2>
-            <p className="text-muted-foreground mt-1">{stepDescriptions[currentStep - 1]}</p>
-          </div>
+          <Box className="mb-6">
+            <Heading level={2} className="text-xl sm:text-2xl">
+              {stepTitles[currentStep - 1]}
+            </Heading>
+            <Text tone="muted" className="mt-1">
+              {stepDescriptions[currentStep - 1]}
+            </Text>
+          </Box>
 
           {/* Step content */}
           {renderStep()}
 
           {/* Navigation */}
-          <div className="flex items-center justify-between mt-8 pt-6 border-t border-border">
-            <div>
+          <Flex align="center" justify="between" className="mt-8 pt-6 border-t border-border">
+            <Box>
               {currentStep > 1 && (
                 <Button variant="ghost" onClick={handleBack} disabled={isLoading} size="lg">
                   <ChevronLeft className="h-4 w-4 mr-1" />
                   {tc("back")}
                 </Button>
               )}
-            </div>
+            </Box>
 
-            <div className="flex items-center gap-3">
-              <span className="text-sm text-muted-foreground">
+            <Flex align="center" gap="3">
+              <Text as="span" tone="muted">
                 {t("stepOf", { current: currentStep, total: TOTAL_STEPS })}
-              </span>
+              </Text>
 
               {currentStep === 1 && (
                 <Button variant="ghost" onClick={handleComplete} disabled={isLoading} size="lg">
@@ -243,10 +261,10 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
                   <ChevronRight className="h-4 w-4 ml-1" />
                 </Button>
               )}
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
+            </Flex>
+          </Flex>
+        </Box>
+      </Flex>
+    </Box>
   );
 }

--- a/web/src/components/wizard/step-board-setup.tsx
+++ b/web/src/components/wizard/step-board-setup.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Button, Input, Label } from "@fiestaboard/ui";
+import { Box, Button, Flex, Grid, Input, Label, List, ListItem, Stack, Text } from "@fiestaboard/ui";
 import {
   CheckCircle,
   Cloud,
@@ -222,11 +222,13 @@ export function StepBoardSetup({
   }, [config.device_type]);
 
   return (
-    <div className="space-y-6">
+    <Stack gap="6">
       {/* API Mode Selection */}
-      <div className="space-y-3">
-        <p className="text-base font-medium">{t("connectionType")}</p>
-        <div className="grid grid-cols-2 gap-3">
+      <Stack gap="3">
+        <Text size="base" weight="medium">
+          {t("connectionType")}
+        </Text>
+        <Grid cols="2" gap="3">
           <button
             type="button"
             onClick={() => handleModeChange("cloud")}
@@ -236,8 +238,12 @@ export function StepBoardSetup({
             )}
           >
             <Cloud className={cn("h-8 w-8", config.api_mode === "cloud" ? "text-primary" : "text-muted-foreground")} />
-            <span className="font-medium">{t("cloudApi")}</span>
-            <span className="text-xs text-muted-foreground text-center">{t("cloudApiEasiest")}</span>
+            <Text as="span" weight="medium">
+              {t("cloudApi")}
+            </Text>
+            <Text as="span" size="xs" tone="muted" className="text-center">
+              {t("cloudApiEasiest")}
+            </Text>
           </button>
 
           <button
@@ -249,18 +255,22 @@ export function StepBoardSetup({
             )}
           >
             <Wifi className={cn("h-8 w-8", config.api_mode === "local" ? "text-primary" : "text-muted-foreground")} />
-            <span className="font-medium">{t("localApi")}</span>
-            <span className="text-xs text-muted-foreground text-center">{t("localApiFaster")}</span>
+            <Text as="span" weight="medium">
+              {t("localApi")}
+            </Text>
+            <Text as="span" size="xs" tone="muted" className="text-center">
+              {t("localApiFaster")}
+            </Text>
           </button>
-        </div>
-      </div>
+        </Grid>
+      </Stack>
 
       {/* Fields based on mode */}
       {config.api_mode === "cloud" ? (
-        <div className="space-y-4">
-          <div className="space-y-2">
+        <Stack gap="4">
+          <Stack gap="2">
             <Label htmlFor="cloud_key">{t("readWriteApiKey")}</Label>
-            <div className="relative">
+            <Box className="relative">
               <Input
                 id="cloud_key"
                 type={showApiKey ? "text" : "password"}
@@ -284,19 +294,19 @@ export function StepBoardSetup({
               >
                 {showApiKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
               </button>
-            </div>
-            <p className="text-xs text-muted-foreground flex items-center gap-1">
+            </Box>
+            <Text size="xs" tone="muted" className="flex items-center gap-1">
               <HelpCircle className="h-3 w-3" />
               {t("cloudKeyHelp")}
-            </p>
-          </div>
-        </div>
+            </Text>
+          </Stack>
+        </Stack>
       ) : (
-        <div className="space-y-4">
+        <Stack gap="4">
           {/* Board IP Address - always needed for local */}
-          <div className="space-y-2">
+          <Stack gap="2">
             <Label htmlFor="host">{t("boardIpAddress")}</Label>
-            <div className="flex gap-2">
+            <Flex gap="2">
               <Input
                 id="host"
                 placeholder={t("boardIpPlaceholder")}
@@ -326,30 +336,34 @@ export function StepBoardSetup({
                   <Search className="h-4 w-4" />
                 )}
               </Button>
-            </div>
-            <p className="text-xs text-muted-foreground flex items-center gap-1">
+            </Flex>
+            <Text size="xs" tone="muted" className="flex items-center gap-1">
               <HelpCircle className="h-3 w-3" />
               {t("boardIpHelp")}
-            </p>
-          </div>
+            </Text>
+          </Stack>
 
           {/* Scan results */}
           {scanStatus === "scanning" && (
-            <div className="flex items-center gap-2 p-3 rounded-lg bg-muted/50 text-sm text-muted-foreground">
+            <Flex align="center" gap="2" className="p-3 rounded-lg bg-muted/50 text-sm text-muted-foreground">
               <Loader2 className="h-4 w-4 animate-spin" />
-              <span>{t("scanningNetwork")}</span>
-            </div>
+              <Text as="span" tone="muted">
+                {t("scanningNetwork")}
+              </Text>
+            </Flex>
           )}
           {scanStatus === "done" && discoveredBoards.length === 0 && (
-            <div className="flex items-center gap-2 p-3 rounded-lg bg-muted/50 text-sm text-muted-foreground">
+            <Flex align="center" gap="2" className="p-3 rounded-lg bg-muted/50 text-sm text-muted-foreground">
               <HelpCircle className="h-4 w-4" />
-              <span>{t("noBoardsFound")}</span>
-            </div>
+              <Text as="span" tone="muted">
+                {t("noBoardsFound")}
+              </Text>
+            </Flex>
           )}
           {scanStatus === "done" && discoveredBoards.length >= 1 && (
-            <div className="space-y-2">
-              <p className="text-sm">{t("foundBoards", { count: discoveredBoards.length })}</p>
-              <div className="space-y-1.5">
+            <Stack gap="2">
+              <Text>{t("foundBoards", { count: discoveredBoards.length })}</Text>
+              <Stack gap="1.5">
                 {discoveredBoards.map((board) => (
                   <button
                     key={board.ip}
@@ -362,24 +376,32 @@ export function StepBoardSetup({
                         : "border-muted hover:border-muted-foreground/30",
                     )}
                   >
-                    <span className="font-mono">{board.ip}</span>
-                    {board.hostname && <span className="text-xs text-muted-foreground">{board.hostname}</span>}
+                    <Text as="span" className="font-mono">
+                      {board.ip}
+                    </Text>
+                    {board.hostname && (
+                      <Text as="span" size="xs" tone="muted">
+                        {board.hostname}
+                      </Text>
+                    )}
                   </button>
                 ))}
-              </div>
-            </div>
+              </Stack>
+            </Stack>
           )}
           {scanStatus === "error" && (
-            <div className="flex items-center gap-2 p-3 rounded-lg bg-destructive/10 text-destructive text-sm">
+            <Flex align="center" gap="2" className="p-3 rounded-lg bg-destructive/10 text-destructive text-sm">
               <XCircle className="h-4 w-4" />
-              <span>{t("scanFailed")}</span>
-            </div>
+              <Text as="span" tone="destructive">
+                {t("scanFailed")}
+              </Text>
+            </Flex>
           )}
 
           {/* Local Key Mode Toggle */}
-          <div className="space-y-3">
-            <p className="text-sm font-medium">{t("authenticationMethod")}</p>
-            <div className="grid grid-cols-2 gap-2">
+          <Stack gap="3">
+            <Text weight="medium">{t("authenticationMethod")}</Text>
+            <Grid cols="2" gap="2">
               <button
                 type="button"
                 onClick={() => setLocalKeyMode("api_key")}
@@ -391,7 +413,7 @@ export function StepBoardSetup({
                 )}
               >
                 <Key className="h-4 w-4" />
-                <span>{t("apiKey")}</span>
+                {t("apiKey")}
               </button>
               <button
                 type="button"
@@ -404,15 +426,15 @@ export function StepBoardSetup({
                 )}
               >
                 <KeyRound className="h-4 w-4" />
-                <span>{t("enablementToken")}</span>
+                {t("enablementToken")}
               </button>
-            </div>
-          </div>
+            </Grid>
+          </Stack>
 
           {localKeyMode === "api_key" ? (
-            <div className="space-y-2">
+            <Stack gap="2">
               <Label htmlFor="local_api_key">{t("localApiKey")}</Label>
-              <div className="relative">
+              <Box className="relative">
                 <Input
                   id="local_api_key"
                   type={showApiKey ? "text" : "password"}
@@ -436,17 +458,17 @@ export function StepBoardSetup({
                 >
                   {showApiKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
                 </button>
-              </div>
-              <p className="text-xs text-muted-foreground flex items-center gap-1">
+              </Box>
+              <Text size="xs" tone="muted" className="flex items-center gap-1">
                 <HelpCircle className="h-3 w-3" />
                 {t("localApiKeyHelp")}
-              </p>
-            </div>
+              </Text>
+            </Stack>
           ) : (
-            <div className="space-y-3">
-              <div className="space-y-2">
+            <Stack gap="3">
+              <Stack gap="2">
                 <Label htmlFor="enablement_token">{t("enablementToken")}</Label>
-                <div className="relative">
+                <Box className="relative">
                   <Input
                     id="enablement_token"
                     type={showApiKey ? "text" : "password"}
@@ -466,12 +488,12 @@ export function StepBoardSetup({
                   >
                     {showApiKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
                   </button>
-                </div>
-                <p className="text-xs text-muted-foreground flex items-center gap-1">
+                </Box>
+                <Text size="xs" tone="muted" className="flex items-center gap-1">
                   <HelpCircle className="h-3 w-3" />
                   {t("enablementTokenHelp")}
-                </p>
-              </div>
+                </Text>
+              </Stack>
 
               <Button
                 onClick={handleEnableLocalApi}
@@ -496,9 +518,11 @@ export function StepBoardSetup({
 
               {/* Enablement status message */}
               {enablementMessage && (
-                <div
+                <Flex
+                  align="start"
+                  gap="2"
                   className={cn(
-                    "flex items-start gap-2 p-3 rounded-lg text-sm",
+                    "p-3 rounded-lg text-sm",
                     enablementStatus === "success"
                       ? "bg-success/10 text-success"
                       : "bg-destructive/10 text-destructive",
@@ -509,16 +533,16 @@ export function StepBoardSetup({
                   ) : (
                     <XCircle className="h-5 w-5 flex-shrink-0 mt-0.5" />
                   )}
-                  <span>{enablementMessage}</span>
-                </div>
+                  {enablementMessage}
+                </Flex>
               )}
-            </div>
+            </Stack>
           )}
-        </div>
+        </Stack>
       )}
 
       {/* Test Connection */}
-      <div className="space-y-3">
+      <Stack gap="3">
         <Button
           onClick={handleTestConnection}
           disabled={!canTest || isLoading}
@@ -542,9 +566,11 @@ export function StepBoardSetup({
 
         {/* Status message */}
         {testMessage && (
-          <div
+          <Flex
+            align="start"
+            gap="2"
             className={cn(
-              "flex items-start gap-2 p-3 rounded-lg text-sm",
+              "p-3 rounded-lg text-sm",
               testStatus === "success" ? "bg-success/10 text-success" : "bg-destructive/10 text-destructive",
             )}
           >
@@ -553,28 +579,30 @@ export function StepBoardSetup({
             ) : (
               <XCircle className="h-5 w-5 flex-shrink-0 mt-0.5" />
             )}
-            <div className="flex-1 space-y-2">
-              <span>{testMessage}</span>
+            <Stack gap="2" className="flex-1">
+              {testMessage}
               {testStatus === "error" && troubleshootingSteps.length > 0 && (
-                <div className="mt-2 space-y-1.5">
-                  <p className="font-medium text-foreground/80 text-xs uppercase tracking-wide">{t("thingsToTry")}</p>
-                  <ol className="list-decimal list-inside space-y-1 text-foreground/70">
+                <Stack gap="1.5" className="mt-2">
+                  <Text size="xs" weight="medium" className="text-foreground/80 uppercase tracking-wide">
+                    {t("thingsToTry")}
+                  </Text>
+                  <List as="ol" marker="decimal" gap="1" className="text-foreground/70">
                     {troubleshootingSteps.map((step, i) => (
-                      <li key={i}>{step}</li>
+                      <ListItem key={i}>{step}</ListItem>
                     ))}
-                  </ol>
-                </div>
+                  </List>
+                </Stack>
               )}
-            </div>
-          </div>
+            </Stack>
+          </Flex>
         )}
-      </div>
+      </Stack>
 
       {/* Device Type & Board Color */}
-      <div className="space-y-4 pt-4 border-t">
-        <div className="space-y-3">
-          <p className="text-sm font-medium">{t("boardType")}</p>
-          <div className="grid grid-cols-2 gap-3">
+      <Stack gap="4" className="pt-4 border-t">
+        <Stack gap="3">
+          <Text weight="medium">{t("boardType")}</Text>
+          <Grid cols="2" gap="3">
             <button
               type="button"
               onClick={() => onConfigChange({ ...config, device_type: "flagship" })}
@@ -584,8 +612,12 @@ export function StepBoardSetup({
                 config.device_type === "flagship" ? "border-primary bg-primary/5" : "border-muted hover:border-border",
               )}
             >
-              <span className="font-medium text-sm">{tc("flagship")}</span>
-              <span className="text-xs text-muted-foreground">{t("flagshipDimensions")}</span>
+              <Text as="span" weight="medium">
+                {tc("flagship")}
+              </Text>
+              <Text as="span" size="xs" tone="muted">
+                {t("flagshipDimensions")}
+              </Text>
             </button>
             <button
               type="button"
@@ -596,15 +628,19 @@ export function StepBoardSetup({
                 config.device_type === "note" ? "border-primary bg-primary/5" : "border-muted hover:border-border",
               )}
             >
-              <span className="font-medium text-sm">{tc("note")}</span>
-              <span className="text-xs text-muted-foreground">{t("noteDimensions")}</span>
+              <Text as="span" weight="medium">
+                {tc("note")}
+              </Text>
+              <Text as="span" size="xs" tone="muted">
+                {t("noteDimensions")}
+              </Text>
             </button>
-          </div>
-        </div>
+          </Grid>
+        </Stack>
 
-        <div className="space-y-3">
-          <p className="text-sm font-medium">{t("boardColor")}</p>
-          <div className="flex items-center gap-3">
+        <Stack gap="3">
+          <Text weight="medium">{t("boardColor")}</Text>
+          <Flex align="center" gap="3">
             <button
               type="button"
               onClick={() => onConfigChange({ ...config, board_color: "black" })}
@@ -629,20 +665,22 @@ export function StepBoardSetup({
                   : "border-border hover:border-muted-foreground",
               )}
             />
-          </div>
-        </div>
+          </Flex>
+        </Stack>
 
         {/* Live board preview */}
-        <div className="space-y-2 pt-3">
-          <p className="text-sm font-medium text-muted-foreground">{tc("preview")}</p>
+        <Stack gap="2" className="pt-3">
+          <Text weight="medium" tone="muted">
+            {tc("preview")}
+          </Text>
           <ScaledBoardDisplay
             message={previewMessage}
             size="sm"
             boardType={config.board_color}
             deviceType={config.device_type}
           />
-        </div>
-      </div>
-    </div>
+        </Stack>
+      </Stack>
+    </Stack>
   );
 }

--- a/web/src/components/wizard/step-easy-plugins.tsx
+++ b/web/src/components/wizard/step-easy-plugins.tsx
@@ -1,6 +1,19 @@
 "use client";
 
-import { Badge, Card, CardContent, CardDescription, CardHeader, CardTitle, Label, Switch } from "@fiestaboard/ui";
+import {
+  Badge,
+  Box,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Flex,
+  Label,
+  Stack,
+  Switch,
+  Text,
+} from "@fiestaboard/ui";
 import type { LucideIcon } from "lucide-react";
 import { Clock, Cloud, Laugh, Rocket, Star, Timer, TrendingUp, Trophy, Waves, Wifi } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -170,17 +183,19 @@ export function StepEasyPlugins({ config, onConfigChange, onValidChange }: StepE
   };
 
   return (
-    <div className="space-y-4">
-      <p className="text-sm text-muted-foreground mb-1">{t("description")}</p>
-      <p className="text-xs text-muted-foreground mb-4">
+    <Stack gap="4">
+      <Text tone="muted" className="mb-1">
+        {t("description")}
+      </Text>
+      <Text size="xs" tone="muted" className="mb-4">
         You can add more from the{" "}
         <Link href="/integrations" className="underline hover:text-foreground">
           Integrations
         </Link>{" "}
         page at any time.
-      </p>
+      </Text>
 
-      <div className="space-y-3">
+      <Stack gap="3">
         {CURATED_PLUGINS.map((plugin) => {
           const Icon = plugin.icon;
           const selected = isSelected(plugin.id);
@@ -191,12 +206,12 @@ export function StepEasyPlugins({ config, onConfigChange, onValidChange }: StepE
               onClick={() => handleToggle(plugin, !selected)}
             >
               <CardHeader className="pb-2">
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-3">
-                    <div className={cn("p-2 rounded-lg", selected ? "bg-primary/10" : "bg-muted")}>
+                <Flex align="center" justify="between">
+                  <Flex align="center" gap="3">
+                    <Box className={cn("p-2 rounded-lg", selected ? "bg-primary/10" : "bg-muted")}>
                       <Icon className={cn("h-5 w-5", selected ? "text-primary" : "text-muted-foreground")} />
-                    </div>
-                    <div>
+                    </Box>
+                    <Box>
                       <CardTitle className="text-base flex items-center gap-2">
                         {plugin.name}
                         {plugin.badge && (
@@ -211,21 +226,21 @@ export function StepEasyPlugins({ config, onConfigChange, onValidChange }: StepE
                         )}
                       </CardTitle>
                       <CardDescription className="text-xs">{plugin.description}</CardDescription>
-                    </div>
-                  </div>
+                    </Box>
+                  </Flex>
                   <Switch
                     checked={selected}
                     onCheckedChange={(checked) => handleToggle(plugin, checked)}
                     onClick={(e) => e.stopPropagation()}
                     aria-label={`Toggle ${plugin.name}`}
                   />
-                </div>
+                </Flex>
               </CardHeader>
 
               {/* Inline timezone picker for date_time */}
               {plugin.id === "date_time" && selected && (
                 <CardContent className="pt-2 space-y-3" onClick={(e) => e.stopPropagation()}>
-                  <div className="space-y-2">
+                  <Stack gap="2">
                     <Label htmlFor="wizard-timezone" className="text-sm">
                       {t("timezoneLabel")}
                     </Label>
@@ -239,16 +254,19 @@ export function StepEasyPlugins({ config, onConfigChange, onValidChange }: StepE
                         })
                       }
                     />
-                  </div>
-                  <div className="text-sm text-muted-foreground bg-muted/50 p-2 rounded">
-                    Preview: <span className="font-mono">{currentTime}</span>
-                  </div>
+                  </Stack>
+                  <Text tone="muted" className="bg-muted/50 p-2 rounded">
+                    Preview:{" "}
+                    <Text as="span" tone="muted" className="font-mono">
+                      {currentTime}
+                    </Text>
+                  </Text>
                 </CardContent>
               )}
             </Card>
           );
         })}
-      </div>
-    </div>
+      </Stack>
+    </Stack>
   );
 }

--- a/web/src/components/wizard/step-welcome.tsx
+++ b/web/src/components/wizard/step-welcome.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Button, DecryptedText } from "@fiestaboard/ui";
+import { Box, Button, DecryptedText, Flex, Heading, Stack, Text } from "@fiestaboard/ui";
 import { CheckCircle, Clock, Loader2, PartyPopper, Puzzle, Send, XCircle } from "lucide-react";
 import { useState } from "react";
 
@@ -99,26 +99,28 @@ export function StepWelcome({ boardConfig, pluginConfig, onComplete, isLoading, 
   ].filter(Boolean) as { name: string; icon: typeof Clock }[];
 
   return (
-    <div className="space-y-6">
+    <Stack gap="6">
       {/* Success header */}
-      <div className="text-center space-y-2">
-        <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-primary/10 mb-2">
+      <Stack gap="2" className="text-center">
+        <Flex inline align="center" justify="center" className="w-16 h-16 rounded-full bg-primary/10 mb-2">
           <PartyPopper className="h-8 w-8 text-primary" />
-        </div>
-        <h3 className="text-xl font-semibold">
+        </Flex>
+        <Heading level={3} className="text-xl">
           <DecryptedText text={t("setupComplete")} speed={60} sequential animateOn="view" revealDirection="start" />
-        </h3>
-        <p className="text-muted-foreground">{t("boardReady")}</p>
-      </div>
+        </Heading>
+        <Text tone="muted">{t("boardReady")}</Text>
+      </Stack>
 
       {/* Summary */}
-      <div className="space-y-3 bg-muted/50 rounded-lg p-4">
-        <h4 className="font-medium text-sm">{t("summaryTitle")}</h4>
+      <Stack gap="3" className="bg-muted/50 rounded-lg p-4">
+        <Heading level={4} size="sm" className="font-medium">
+          {t("summaryTitle")}
+        </Heading>
 
-        <div className="space-y-2 text-sm">
-          <div className="flex items-center gap-2">
+        <Stack gap="2" className="text-sm">
+          <Flex align="center" gap="2">
             <CheckCircle className="h-4 w-4 text-success" />
-            <span>
+            <Text as="span">
               {boardConfig.api_mode === "local"
                 ? t("boardConnectedLocal", {
                     deviceType: boardConfig.device_type === "flagship" ? tc("flagship") : tc("note"),
@@ -128,32 +130,36 @@ export function StepWelcome({ boardConfig, pluginConfig, onComplete, isLoading, 
                     deviceType: boardConfig.device_type === "flagship" ? tc("flagship") : tc("note"),
                     apiMode: boardConfig.api_mode === "cloud" ? "Cloud" : "Local",
                   })}
-            </span>
-          </div>
+            </Text>
+          </Flex>
 
           {enabledPlugins.length > 0 && (
             <>
               {enabledPlugins.map(({ name, icon: _Icon }) => (
-                <div key={name} className="flex items-center gap-2">
+                <Flex key={name} align="center" gap="2">
                   <CheckCircle className="h-4 w-4 text-success" />
-                  <span>{t("pluginEnabled", { name })}</span>
-                </div>
+                  <Text as="span">{t("pluginEnabled", { name })}</Text>
+                </Flex>
               ))}
             </>
           )}
 
           {enabledPlugins.length === 0 && (
-            <div className="flex items-center gap-2 text-muted-foreground">
-              <span>{t("noPluginsEnabled")}</span>
-            </div>
+            <Flex align="center" gap="2" className="text-muted-foreground">
+              <Text as="span" tone="muted">
+                {t("noPluginsEnabled")}
+              </Text>
+            </Flex>
           )}
-        </div>
-      </div>
+        </Stack>
+      </Stack>
 
       {/* Send Welcome Message */}
-      <div className="space-y-3">
-        <div className="text-center">
-          <p className="text-sm text-muted-foreground mb-3">{t("sendWelcomeDescription")}</p>
+      <Stack gap="3">
+        <Box className="text-center">
+          <Text tone="muted" className="mb-3">
+            {t("sendWelcomeDescription")}
+          </Text>
 
           <Button
             onClick={handleSendWelcome}
@@ -178,13 +184,15 @@ export function StepWelcome({ boardConfig, pluginConfig, onComplete, isLoading, 
               </>
             )}
           </Button>
-        </div>
+        </Box>
 
         {/* Status message */}
         {sendMessage && (
-          <div
+          <Flex
+            align="start"
+            gap="2"
             className={cn(
-              "flex items-start gap-2 p-3 rounded-lg text-sm",
+              "p-3 rounded-lg text-sm",
               sendStatus === "success" ? "bg-success/10 text-success" : "bg-destructive/10 text-destructive",
             )}
           >
@@ -193,13 +201,13 @@ export function StepWelcome({ boardConfig, pluginConfig, onComplete, isLoading, 
             ) : (
               <XCircle className="h-5 w-5 flex-shrink-0 mt-0.5" />
             )}
-            <span>{sendMessage}</span>
-          </div>
+            {sendMessage}
+          </Flex>
         )}
-      </div>
+      </Stack>
 
       {/* Complete button */}
-      <div className="pt-4">
+      <Box className="pt-4">
         <Button
           onClick={onComplete}
           variant={sendStatus === "success" ? "default" : "outline"}
@@ -208,7 +216,7 @@ export function StepWelcome({ boardConfig, pluginConfig, onComplete, isLoading, 
         >
           {sendStatus === "success" ? t("goToDashboard") : t("skipGoToDashboard")}
         </Button>
-      </div>
-    </div>
+      </Box>
+    </Stack>
   );
 }


### PR DESCRIPTION
**Final wave** of epic #1474: migrates the last 12 files (wizard ×4, schedule ×3, transitions, plugin schema-form, ui trio) and flips on `react/forbid-elements` — raw HTML in `app/**`/`src/**` is now a lint **error**.

## The enforcement gate
- The rule bans 27 elements, each error message naming its replacement (`div → Flex/Stack/Grid/Box`, …); tests and stories excluded
- `npm run lint`: **0 errors** across the whole codebase
- **21 justified `eslint-disable` directives** are the complete, permanent exception ledger (audited one-by-one in review): TipTap NodeView pixel spans ×8, ReactMarkdown renderer maps, `Button asChild` Slot anchors ×2, hero `h1`s ×3, inherit-only spans ×6 — every one carries its reason inline

## Migration notes
- `sonner.tsx` needed no changes (no raw HTML); time/timezone pickers preserve portal positioning byte-for-byte; load-bearing refs retyped `HTMLDivElement`→`HTMLElement` for Box's contract
- One sanctioned visual change worth an eyeball: the wizard troubleshooting `<ol>` moves from `list-inside` to `List`'s outside-marker + indent

## Verification
- ESLint 0 errors, prettier clean, tsc baseline identical (138=138, zero new)
- Task-reviewed (Approved): rule block verified byte-identical to the plan, every disable audited as defensible, no migratable element hidden

Closes the migration for #1474. 🎉

🤖 Generated with [Claude Code](https://claude.com/claude-code)