### PR TITLE
test(ingress): stop lazy-route nav test flaking on swallowed clicks

### DIFF
--- a/web/tests/ingress.spec.ts
+++ b/web/tests/ingress.spec.ts
@@ -114,12 +114,23 @@ test.describe("HA Ingress", () => {
     await page.goto(`${PREFIX}/`);
     await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible({ timeout: 15_000 });
 
-    for (const [link, heading] of [
-      ["Pages", "Pages"],
-      ["Settings", "Settings"],
+    for (const [link, heading, path] of [
+      ["Pages", "Pages", "pages"],
+      ["Settings", "Settings", "settings"],
     ] as const) {
-      await page.getByRole("link", { name: link }).first().click();
-      await expect(page.getByRole("heading", { name: heading, exact: true })).toBeVisible({ timeout: 10_000 });
+      // The click can land before the app is interactive — the dashboard is
+      // still fetching its board display at this point — and a swallowed
+      // click leaves us on the previous route with no navigation at all.
+      // Retry the click until the URL actually changes, so that a genuinely
+      // broken lazy chunk still fails below (on the heading + violation
+      // assertions) rather than being masked, and vice versa: a lost click
+      // no longer masquerades as a chunk failure.
+      await expect(async () => {
+        await page.getByRole("link", { name: link }).first().click();
+        await page.waitForURL(`**${PREFIX}/${path}`, { timeout: 5_000 });
+      }).toPass({ timeout: 20_000 });
+
+      await expect(page.getByRole("heading", { name: heading, exact: true })).toBeVisible({ timeout: 15_000 });
     }
 
     expect(escapes, "lazy-route requests must stay under the ingress prefix").toEqual([]);


### PR DESCRIPTION
## Problem

`web/tests/ingress.spec.ts:105` — *"lazy-route navigation stays under the prefix"* — clicks the sidebar link the instant the Dashboard `<h1>` renders, while the dashboard is still fetching its board display, then allows the first client-side navigation only 10s (vs 15s for the initial load).

When the click lands before the app is interactive it gets swallowed: no navigation starts, and the test fails on a heading timeout that is **indistinguishable from a genuinely broken lazy chunk** — which is the actual regression this test exists to catch.

## Evidence it's the test, not the app

Hit on three PRs during a single chore/docs sweep — #1490 (`web/package-lock.json` only), #1493 (`requirements*.txt` only) and #1496 (`web/package-lock.json` only). None can affect React Router mounting, and #1493 has no web changes at all. On #1496 it also survived Playwright's own retry.

The captured failure artifacts show, in every case:

- the sidebar href correctly prefixed — `/api/hassio_ingress/test-token/pages`
- every prefixed asset chunk returning 200, zero 404s, zero unprefixed requests
- the page still on `Dashboard`, with `img "Loading board display"` — i.e. mid-fetch
- the other three ingress tests (the actual escape guarantees) passing

## Fix

Retry the click until the URL actually changes, then assert the heading:

```ts
await expect(async () => {
  await page.getByRole("link", { name: link }).first().click();
  await page.waitForURL(`**${PREFIX}/${path}`, { timeout: 5_000 });
}).toPass({ timeout: 20_000 });

await expect(page.getByRole("heading", { name: heading, exact: true })).toBeVisible({ timeout: 15_000 });
```

This separates the two failure modes rather than papering over both. A lost click is retried; a broken lazy chunk still fails — on the heading assertion and on the `escapes` / `notFound` assertions below, which are unchanged. The test's guarantee is not weakened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)