### PR TITLE
fix(docs-site): scale homepage vertical spacing down on mobile

### DIFF
--- a/docs-site/src/components/HeroBoard/styles.module.css
+++ b/docs-site/src/components/HeroBoard/styles.module.css
@@ -6,8 +6,10 @@
 .stage {
   width: 100%;
   /* Tall enough for the tallest board (the narrow 1×2 note array renders at
-     natural height rather than being width-scaled down). */
-  min-height: 360px;
+     natural height rather than being width-scaled down). Below ~630px the
+     boards fit-scale with the viewport (tallest ≈ 50vw), so scale the reserve
+     down too instead of holding ~200px of blank space on phones. */
+  min-height: min(360px, 57vw);
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/docs-site/src/components/HomepageFeatures/styles.module.css
+++ b/docs-site/src/components/HomepageFeatures/styles.module.css
@@ -17,7 +17,8 @@
 .inner {
   max-width: 1140px;
   margin: 0 auto;
-  padding: 80px 24px;
+  /* Fluid vertical rhythm: full 80px on desktop, ~half on phones. */
+  padding: clamp(48px, 8vw, 80px) 24px;
 }
 
 .sectionTitle {
@@ -29,7 +30,7 @@
 }
 
 .sectionSubtitle {
-  margin: 10px 0 36px;
+  margin: 10px 0 clamp(28px, 5vw, 36px);
   font-size: 17px;
   color: var(--muted-foreground);
 }
@@ -143,13 +144,15 @@
 .showcaseStack {
   display: flex;
   flex-direction: column;
-  gap: 56px;
+  /* Stays larger than the intra-row gap below so stacked rows still read as
+     separate image + caption groups on phones. */
+  gap: clamp(44px, 7vw, 56px);
 }
 
 .showcaseRow {
   display: flex;
   flex-wrap: wrap;
-  gap: 36px;
+  gap: clamp(20px, 4vw, 36px);
   align-items: center;
 }
 
@@ -161,7 +164,7 @@
 .showcaseRowReverse {
   display: flex;
   flex-wrap: wrap;
-  gap: 36px;
+  gap: clamp(20px, 4vw, 36px);
   align-items: center;
 }
 
@@ -255,7 +258,7 @@
 .ctaInner {
   max-width: 760px;
   margin: 0 auto;
-  padding: 88px 24px;
+  padding: clamp(56px, 9vw, 88px) 24px;
   text-align: center;
 }
 

--- a/docs-site/src/pages/index.module.css
+++ b/docs-site/src/pages/index.module.css
@@ -10,10 +10,11 @@
 .heroInner {
   max-width: 1140px;
   margin: 0 auto;
-  padding: 80px 24px 88px;
+  /* Fluid vertical rhythm: full 80/88px on desktop, ~half on phones. */
+  padding: clamp(48px, 8vw, 80px) 24px clamp(56px, 9vw, 88px);
   display: flex;
   flex-wrap: wrap;
-  gap: 56px;
+  gap: clamp(32px, 6vw, 56px);
   align-items: center;
 }
 
@@ -72,5 +73,6 @@
    shift when the client-only <HeroBoard> mounts. */
 .heroBoardFallback {
   width: 100%;
-  min-height: 392px;
+  /* Match .stage's responsive min-height (+ gap and caption). */
+  min-height: min(392px, 57vw + 32px);
 }


### PR DESCRIPTION
## Summary

The FiestaUI re-skin (#1481) gave every homepage section fixed desktop paddings (`80–88px` top/bottom) with **no mobile breakpoints**, so on a 390px phone:

- every section boundary showed **~160px of blank space** (80px bottom + 80px top)
- the hero board stage reserved a fixed `360px` while the tallest fit-scaled mobile board frame is only ~172px → **~190px of dead space inside the hero**
- stacked-layout gaps (hero 56px, showcase stack 56px) never shrank

## Fix

Replace the fixed values with fluid `clamp()` / `min()` expressions — no media queries, and desktop resolves to the exact previous values.

| Property | Desktop (unchanged) | 390px phone |
|---|---|---|
| Section padding (`.inner`) | 80px | 48px |
| Hero padding | 80px / 88px | 48px / 56px |
| CTA padding | 88px | 56px |
| Hero column gap | 56px | 32px |
| Showcase stack / row gaps | 56px / 36px | 44px / 20px |
| Hero board stage `min-height` | 360px | ~214px |

Full mobile page height drops **8903px → 8253px**.

## Verification

- Measured computed styles via Playwright against the built site at 390×844, 768×1024, and 1440×900 — desktop values are pixel-identical to production (80/88px paddings, 56px gaps, 360px stage)
- Watched the full 6-board hero cycle at 390px: stage height stays constant at 214px (no layout shift; tallest mobile frame is 172px)
- `npm run build` (with `onBrokenLinks: throw`), `format:check`, `lint`, `typecheck` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)