### PR TITLE
fix(dashboard): drop the pencil icon from the active-page edit link

### DIFF
--- a/web/src/__tests__/active-page-display.test.tsx
+++ b/web/src/__tests__/active-page-display.test.tsx
@@ -86,8 +86,8 @@ describe("ActivePageDisplay", () => {
   it("renders the page name as a direct child of the link so hover styling reaches it", async () => {
     // A descendant carrying its own text-* color class (e.g. <Text>, which
     // always emits one) beats the anchor's inherited hover:text-primary, so the
-    // name would stay static while only the pencil icon changed color. Keep
-    // the name an unwrapped text node and the color on the anchor itself.
+    // name would stay static on hover. Keep the name an unwrapped text node and
+    // the color on the anchor itself.
     render(<ActivePageDisplay />, { wrapper: TestWrapper });
 
     await waitFor(() => {
@@ -102,8 +102,8 @@ describe("ActivePageDisplay", () => {
     );
     expect(namedByOwnText).toBe(true);
 
-    // getAttribute, not .className — the pencil is an <svg>, whose className is
-    // an SVGAnimatedString rather than a string.
+    // getAttribute, not .className — an <svg> descendant's className is an
+    // SVGAnimatedString rather than a string.
     const coloredDescendants = Array.from(editLink.querySelectorAll("*")).filter((el) =>
       /(^|\s)text-(foreground|muted-foreground|primary|destructive|info|success|warning)(\s|$)/.test(
         el.getAttribute("class") ?? "",

--- a/web/src/components/active-page-display.tsx
+++ b/web/src/components/active-page-display.tsx
@@ -37,7 +37,6 @@ import {
   Loader2,
   Moon,
   Pause,
-  Pencil,
   Radio,
   Timer,
   UploadCloud,
@@ -474,12 +473,11 @@ export function ActivePageDisplay() {
                 // so `hover:text-primary` isn't overridden on the name itself.
                 <Link
                   href={`/pages/edit/${activePage.id}`}
-                  className="inline-flex items-center gap-1 text-xs font-medium text-foreground underline-offset-2 hover:underline hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
+                  className="inline-flex items-center text-xs font-medium text-foreground underline-offset-2 hover:underline hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
                   aria-label={t("editActivePage", { pageName: activePage.name })}
                   title={t("editActivePage", { pageName: activePage.name })}
                 >
                   {activePage.name}
-                  <Pencil className="h-3 w-3" aria-hidden="true" />
                 </Link>
               ) : (
                 <Text as="span" size="xs" weight="medium">


### PR DESCRIPTION
## Summary

The Dashboard's Active Display card links the active page name to its editor (shipped in #1499). This drops the trailing pencil icon — the link is already underlined on hover, highlights to primary, and carries an `Edit page "…"` tooltip and aria-label, so the icon was pure visual noise in a 12px metadata row.

## Changes

- Remove `<Pencil />` from the link and the now-unused `lucide-react` import
- Drop the `gap-1` that only existed to space the name from the icon
- Update the two comment references to the pencil in the structural regression test

Link target, accessible name, and hover/focus styling are unchanged.

## Testing

- `vitest run src/__tests__/active-page-display.test.tsx` — 19/19 pass
- `prettier --check` clean; `eslint` clean (7 pre-existing `i18next/no-literal-string` warnings in this file, none new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)