### PR TITLE
docs-site: move navbar logo, paginator, and 404 onto FiestaUI

### DIFF
--- a/docs-site/src/css/custom.css
+++ b/docs-site/src/css/custom.css
@@ -83,17 +83,6 @@
   font-weight: 500;
 }
 
-/* Align logo with nav: anchor image to bottom so text baseline matches nav
-   links; object-position crops the floating top of the taco so icon and text
-   look aligned. (Carried over from the previous theme.) */
-.navbar__logo img {
-  height: 48px;
-  width: auto;
-  object-fit: cover;
-  object-position: left 100%;
-  transform: translateY(-8px);
-}
-
 /* Code blocks: card-style frame matching the design references. */
 .theme-code-block,
 div[class*="codeBlockContainer"] {
@@ -101,15 +90,32 @@ div[class*="codeBlockContainer"] {
   border-radius: var(--radius);
 }
 
-/* Prev/next pagination cards: rounded, hover ring (FiestaboardDocs.dc.html). */
+/* Prev/next pagination: the anchor keeps Infima's `.pagination-nav` grid
+   placement (`--prev` / `--next` column + text alignment) but hands its box
+   treatment to the FiestaUI `Card` inside it. See src/theme/PaginatorNavLink. */
 .pagination-nav__link {
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  transition: border-color 0.15s ease;
+  border: none;
+  padding: 0;
 }
 
-.pagination-nav__link:hover {
-  border-color: var(--ring);
+/* Navbar dropdown menu on DS surfaces - Infima's own dropdown tokens were
+   never part of the token bridge, so the panel kept its default white card. */
+.dropdown__menu {
+  background-color: var(--popover);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: none;
+}
+
+.dropdown__link {
+  border-radius: calc(var(--radius) - 4px);
+  color: var(--muted-foreground);
+}
+
+.dropdown__link:hover,
+.dropdown__link--active {
+  background-color: var(--accent);
+  color: var(--foreground);
 }
 
 /* Hide the per-page version badge - the navbar version dropdown is sufficient. */

--- a/docs-site/src/theme/Logo/index.tsx
+++ b/docs-site/src/theme/Logo/index.tsx
@@ -1,0 +1,55 @@
+/**
+ * Swizzled `@theme/Logo` — renders the brand mark with FiestaUI's `FiestaIcon`
+ * + `FiestaLogo` instead of a pair of PNG lockups.
+ *
+ * The stock component renders `themeConfig.navbar.logo` through `ThemedImage`,
+ * which meant shipping `logo-lockup-light.png` / `logo-lockup-dark.png` and then
+ * hand-nudging them into alignment in `custom.css`:
+ *
+ *     .navbar__logo img { height: 48px; object-fit: cover;
+ *                         object-position: left 100%; transform: translateY(-8px); }
+ *
+ * …because the raster lockup carried transparent padding above the taco. The DS
+ * components are vector, tint from the theme tokens (so no light/dark pair), and
+ * need no nudging — both the rule and the second image are gone.
+ *
+ * Swizzled here rather than at `@theme/Navbar/Logo` so every call site is
+ * covered: the navbar, the mobile sidebar header, and `DocSidebar/Desktop`
+ * (which renders a logo of its own whenever `navbar.hideOnScroll` is enabled).
+ *
+ * `themeConfig.navbar.logo` is left in place — it is a documented config
+ * surface and Docusaurus reads `logo.href`/`logo.target` — but the `src` /
+ * `srcDark` images are no longer rendered anywhere.
+ */
+
+import Link from "@docusaurus/Link";
+import { useThemeConfig } from "@docusaurus/theme-common";
+import useBaseUrl from "@docusaurus/useBaseUrl";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import { FiestaIcon, FiestaLogo } from "@fiestaboard/ui";
+import type { Props } from "@theme/Logo";
+import clsx from "clsx";
+import type { ReactNode } from "react";
+
+export default function Logo({ className, imageClassName, titleClassName, ...props }: Props): ReactNode {
+  const {
+    siteConfig: { title },
+  } = useDocusaurusContext();
+  const {
+    navbar: { logo },
+  } = useThemeConfig();
+  const logoLink = useBaseUrl(logo?.href || "/");
+
+  return (
+    <Link
+      to={logoLink}
+      aria-label={title}
+      {...(logo?.target && { target: logo.target })}
+      {...props}
+      className={clsx("flex items-center gap-2", className)}
+    >
+      <FiestaIcon size={28} className={imageClassName} />
+      <FiestaLogo size="md" className={clsx("text-foreground", titleClassName)} />
+    </Link>
+  );
+}

--- a/docs-site/src/theme/NotFound/Content/index.tsx
+++ b/docs-site/src/theme/NotFound/Content/index.tsx
@@ -1,0 +1,69 @@
+/**
+ * Swizzled `@theme/NotFound/Content` — the 404 page, rebuilt on FiestaUI's
+ * `EmptyState` (with `Button` CTAs) rather than Infima's bare hero title and
+ * two paragraphs of prose.
+ *
+ * Upstream's second paragraph asks the visitor to contact whoever linked them,
+ * which is not actionable on a docs site that reorganises its own URLs across
+ * versions; the CTAs send them somewhere useful instead. The title and first
+ * paragraph keep the upstream `theme.NotFound.*` ids so existing locale data
+ * still applies; the two button labels are new ids under the same namespace.
+ */
+
+import Link from "@docusaurus/Link";
+import { translate } from "@docusaurus/Translate";
+import useBaseUrl from "@docusaurus/useBaseUrl";
+import { Button, EmptyState } from "@fiestaboard/ui";
+import type { Props } from "@theme/NotFound/Content";
+import clsx from "clsx";
+import { Compass } from "lucide-react";
+import type { ReactNode } from "react";
+
+export default function NotFoundContent({ className }: Props): ReactNode {
+  const homeHref = useBaseUrl("/");
+  const docsHref = useBaseUrl("/docs/intro");
+
+  return (
+    <main className={clsx("container margin-vert--xl", className)}>
+      {/* `EmptyState` is sized for an empty list inside app chrome; a standalone
+          404 needs display sizing. Scaled through the component's own
+          `data-slot` hooks rather than by forking it. */}
+      <EmptyState
+        className="py-16 [&_[data-slot=empty-state-description]]:text-base [&_[data-slot=empty-state-title]]:text-2xl [&_[data-slot=empty-state-title]]:font-semibold"
+        icon={Compass}
+        title={translate({
+          id: "theme.NotFound.title",
+          description: "The title of the 404 page",
+          message: "Page Not Found",
+        })}
+        description={translate({
+          id: "theme.NotFound.p1",
+          description: "The first paragraph of the 404 page",
+          message: "We could not find what you were looking for.",
+        })}
+        action={
+          <div className="flex flex-wrap items-center justify-center gap-2">
+            <Button asChild>
+              <Link to={docsHref} className="no-underline">
+                {translate({
+                  id: "theme.NotFound.cta.docs",
+                  description: "Label for the 404 page button linking to the documentation",
+                  message: "Browse the docs",
+                })}
+              </Link>
+            </Button>
+            <Button asChild variant="outline">
+              <Link to={homeHref} className="no-underline">
+                {translate({
+                  id: "theme.NotFound.cta.home",
+                  description: "Label for the 404 page button returning to the homepage",
+                  message: "Back to home",
+                })}
+              </Link>
+            </Button>
+          </div>
+        }
+      />
+    </main>
+  );
+}

--- a/docs-site/src/theme/PaginatorNavLink/index.tsx
+++ b/docs-site/src/theme/PaginatorNavLink/index.tsx
@@ -1,0 +1,40 @@
+/**
+ * Swizzled `@theme/PaginatorNavLink` — the prev/next tiles at the foot of every
+ * doc page, rebuilt on FiestaUI's `Card` instead of Infima's `.pagination-nav__link`
+ * plus the hand-written border/radius/hover rules that used to live in `custom.css`.
+ *
+ * The Infima placement classes stay: `.pagination-nav` is a two-column grid and
+ * `--prev` / `--next` are what put each tile in its column and align its text.
+ * Only the box treatment moves to the design system, which `custom.css` now
+ * neutralises on the anchor so the `Card` inside owns the border and padding.
+ */
+
+import Link from "@docusaurus/Link";
+import { Card, CardDescription, cn, Text } from "@fiestaboard/ui";
+import type { Props } from "@theme/PaginatorNavLink";
+import type { ReactNode } from "react";
+
+export default function PaginatorNavLink({ permalink, title, subLabel, isNext }: Props): ReactNode {
+  return (
+    <Link
+      className={cn(
+        "pagination-nav__link no-underline",
+        isNext ? "pagination-nav__link--next" : "pagination-nav__link--prev",
+      )}
+      to={permalink}
+    >
+      {/* `Card`'s own `gap-6`/`py-6` are tuned for full content cards; a paginator
+          tile is a two-line label, so it tightens to `gap-1`/`p-4`. */}
+      <Card className="h-full gap-1 p-4 py-4 hover:border-ring">
+        {subLabel && <CardDescription className="text-xs">{subLabel}</CardDescription>}
+        {/* `Text`, not `CardTitle`: `CardTitle` only renders h1-h6, and upstream
+            deliberately uses a plain element here — a prev/next tile is a
+            navigation label, and promoting it would put two extra headings at
+            the foot of every page for anyone navigating by heading. */}
+        <Text as="span" size="base" weight="semibold" className="block">
+          {title}
+        </Text>
+      </Card>
+    </Link>
+  );
+}


### PR DESCRIPTION
**Stack 2 of 3.** Based on #1502 — review that first; this diff is only the chrome layer on top.

## What changed

Three pieces of docs chrome were hand-built against Infima while the design system already shipped a component for each.

**Logo.** `@theme/Logo` rendered a pair of PNG lockups through `ThemedImage`, which needed a CSS nudge to look right:

```css
.navbar__logo img { height: 48px; object-fit: cover;
                    object-position: left 100%; transform: translateY(-8px); }
```

That existed to crop transparent padding above the taco in the raster art. Now it renders `FiestaIcon` + `FiestaLogo` — vector, tinted from theme tokens, so one mark covers both themes and the nudge is gone. Swizzled at `Logo` rather than `Navbar/Logo` so the navbar, the mobile sidebar header, and `DocSidebar/Desktop` (rendered when `navbar.hideOnScroll` is on) all agree. `themeConfig.navbar.logo` stays — Docusaurus still reads `href`/`target` from it — but the images are no longer rendered.

**Paginator.** The prev/next tiles keep Infima's `.pagination-nav` grid placement (`--prev` / `--next` are what assign the column and text alignment) and hand their box treatment to `Card`, replacing the bespoke border/radius/hover-ring rules in `custom.css`. The title is a `Text`, not a `CardTitle`: `CardTitle` only renders h1–h6, and upstream deliberately uses a plain element here — promoting a navigation label would put two extra headings at the foot of every page for anyone navigating by heading.

**404.** Rebuilt on `EmptyState` with `Button` CTAs. Upstream's second paragraph tells visitors to contact whoever linked them, which isn't actionable on a docs site that reorganises its own URLs across versions, so two buttons point somewhere useful instead. Title and description keep the upstream `theme.NotFound.*` ids so existing locale data still applies; the button labels are new ids in the same namespace. `EmptyState` is sized for an empty list inside app chrome, so it's scaled up for a standalone page through the component's own `data-slot` hooks rather than by forking it.

Plus a token bridge for Infima's dropdown variables, which the re-skin never covered — the navbar menu panel was still rendering as a default white card in both themes.

## What I deliberately did *not* convert

I went through the rest of the Tier 2 list and four items are worse as DS components, not better:

- **`ThemeToggle`** — FiestaUI's is a controlled two-state `light | dark` toggle. Docusaurus's is tri-state and includes "system". Swapping it would silently drop a user-facing option, so this is a change to make in FiestaUI first, not here.
- **`Sheet` for the mobile sidebar** — Docusaurus's mobile drawer is wired into the navbar secondary menu, its back-button stack, and focus management. Replacing the container means reimplementing all of that.
- **`DropdownMenu` for the navbar** — Docusaurus's dropdown is SSR-rendered and already hover- and keyboard-managed. `DropdownMenu` is a client-mounted popup; this would be an a11y and no-JS regression. Bridged its tokens instead.
- **`DocCard`** — turns out it never renders on this site at all: no sidebar category uses a `generated-index` link, so there are no category index pages. Confirmed against the build output. Converting it would have been dead code, and my original audit was wrong to list it.

## Verification

- `npm run typecheck`, `npm run lint`, `npm run format:check` clean
- `DOCS_PR_MODE=1 npm run build` succeeds
- Checked in the browser in both themes: navbar logo (computed brand/foreground colours per theme, SVG present), paginator tiles at the foot of `/docs/setup/quick-start`, the 404 at an unknown `/docs/*` path, and the open navbar dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)