### PR TITLE
docs-site: move navbar logo, paginator, and 404 onto FiestaUI

### DIFF
--- a/docs-site/eslint.config.mjs
+++ b/docs-site/eslint.config.mjs
@@ -60,5 +60,58 @@ export default [
       "react-hooks/exhaustive-deps": "warn",
     },
   },
+  // Design-system enforcement, mirroring web/eslint.config.mjs: the site's own
+  // React renders @fiestaboard/ui components, not raw HTML. Allowlisted leaves
+  // (svg, canvas, iframe, img, br, em, small, kbd, pre, figure, figcaption, dl,
+  // dt, dd, input, hr, blockquote) are simply not listed here.
+  //
+  // Scoped to src/components and src/pages on purpose. src/theme holds swizzled
+  // Docusaurus components, which must mirror upstream's markup and Infima class
+  // names to keep their behaviour (`.menu__list-item`, `.pagination-nav__link`,
+  // `.clean-btn`); forcing primitives there would break the theme rather than
+  // align it. Those files use DS components where the markup is genuinely ours.
+  {
+    files: ["src/components/**/*.tsx", "src/pages/**/*.tsx"],
+    rules: {
+      "react/forbid-elements": [
+        "error",
+        {
+          forbid: [
+            { element: "div", message: "Use Flex/Stack/Grid for layout, or Box (@fiestaboard/ui)" },
+            { element: "span", message: 'Use Text as="span" (@fiestaboard/ui)' },
+            { element: "p", message: "Use Text (@fiestaboard/ui)" },
+            // `h1` is intentionally absent. The web app forbids it in favour of
+            // `PageHeader`, but that is app chrome; FiestaUI's `Heading` covers
+            // h2-h4 only, so a docs/marketing page's single h1 has no primitive
+            // to move to and keeps its own element.
+            { element: "h2", message: "Use Heading level={2} (@fiestaboard/ui)" },
+            { element: "h3", message: "Use Heading level={3} (@fiestaboard/ui)" },
+            { element: "h4", message: "Use Heading level={4} (@fiestaboard/ui)" },
+            { element: "h5", message: "Use Heading (@fiestaboard/ui)" },
+            { element: "h6", message: "Use Heading (@fiestaboard/ui)" },
+            { element: "ul", message: "Use List (@fiestaboard/ui)" },
+            { element: "ol", message: 'Use List as="ol" (@fiestaboard/ui)' },
+            { element: "li", message: "Use ListItem (@fiestaboard/ui)" },
+            { element: "section", message: 'Use Box as="section" (@fiestaboard/ui)' },
+            { element: "main", message: 'Use Box as="main" (@fiestaboard/ui)' },
+            { element: "header", message: 'Use Box as="header" (@fiestaboard/ui)' },
+            { element: "footer", message: 'Use Box as="footer" (@fiestaboard/ui)' },
+            { element: "nav", message: 'Use Box as="nav" (@fiestaboard/ui)' },
+            { element: "form", message: 'Use Box as="form" (@fiestaboard/ui)' },
+            { element: "table", message: "Use Table (@fiestaboard/ui)" },
+            { element: "thead", message: "Use TableHeader (@fiestaboard/ui)" },
+            { element: "tbody", message: "Use TableBody (@fiestaboard/ui)" },
+            { element: "tr", message: "Use TableRow (@fiestaboard/ui)" },
+            { element: "th", message: "Use TableHead (@fiestaboard/ui)" },
+            { element: "td", message: "Use TableCell (@fiestaboard/ui)" },
+            { element: "button", message: "Use Button (@fiestaboard/ui)" },
+            { element: "a", message: "Use TextLink, or Docusaurus Link for navigation (@fiestaboard/ui)" },
+            { element: "code", message: "Use Code (@fiestaboard/ui)" },
+            { element: "strong", message: 'Use Text as="span" weight="semibold" (@fiestaboard/ui)' },
+          ],
+        },
+      ],
+    },
+  },
   prettierConfig,
 ];

--- a/docs-site/src/components/BoardScreenshot/index.tsx
+++ b/docs-site/src/components/BoardScreenshot/index.tsx
@@ -1,4 +1,7 @@
 import { useColorMode } from "@docusaurus/theme-common";
+import { Box, Button } from "@fiestaboard/ui";
+import clsx from "clsx";
+import { X } from "lucide-react";
 import { type ReactNode, useCallback, useEffect, useState } from "react";
 
 import styles from "./styles.module.css";
@@ -28,26 +31,22 @@ function BoardToggle({
   onSetStyle: (style: "black" | "white") => void;
 }) {
   return (
-    <div className={styles.toggleBar}>
-      <button
-        type="button"
-        className={`${styles.toggleButton} ${activeStyle === "black" ? styles.active : ""}`}
-        onClick={() => onSetStyle("black")}
-        aria-label="Show black board screenshot"
-        title="Black board"
-      >
-        Black
-      </button>
-      <button
-        type="button"
-        className={`${styles.toggleButton} ${activeStyle === "white" ? styles.active : ""}`}
-        onClick={() => onSetStyle("white")}
-        aria-label="Show white board screenshot"
-        title="White board"
-      >
-        White
-      </button>
-    </div>
+    <Box className={styles.toggleBar}>
+      {(["black", "white"] as const).map((style) => (
+        <Button
+          key={style}
+          type="button"
+          variant="ghost"
+          aria-pressed={activeStyle === style}
+          className={clsx(styles.toggleButton, activeStyle === style && styles.active)}
+          onClick={() => onSetStyle(style)}
+          aria-label={`Show ${style} board screenshot`}
+          title={`${style === "black" ? "Black" : "White"} board`}
+        >
+          {style === "black" ? "Black" : "White"}
+        </Button>
+      ))}
+    </Box>
   );
 }
 
@@ -81,27 +80,17 @@ function Lightbox({
   }, [handleKeyDown]);
 
   return (
-    <div className={styles.lightboxOverlay} onClick={onClose} role="dialog" aria-modal="true">
-      <div className={styles.lightboxContent} onClick={(e) => e.stopPropagation()}>
-        <button type="button" className={styles.lightboxClose} onClick={onClose} aria-label="Close">
-          <svg
-            viewBox="0 0 24 24"
-            width="24"
-            height="24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            aria-hidden="true"
-          >
-            <path d="M18 6L6 18M6 6l12 12" />
-          </svg>
-        </button>
+    <Box className={styles.lightboxOverlay} onClick={onClose} role="dialog" aria-modal="true">
+      <Box className={styles.lightboxContent} onClick={(e) => e.stopPropagation()}>
+        <Button type="button" variant="ghost" className={styles.lightboxClose} onClick={onClose} aria-label="Close">
+          <X aria-hidden="true" />
+        </Button>
         <img className={styles.lightboxImage} src={src} alt={alt} />
-        <div className={styles.lightboxFooter}>
+        <Box className={styles.lightboxFooter}>
           <BoardToggle activeStyle={activeStyle} onSetStyle={onSetStyle} />
-        </div>
-      </div>
-    </div>
+        </Box>
+      </Box>
+    </Box>
   );
 }
 

--- a/docs-site/src/components/HeroBoard/index.tsx
+++ b/docs-site/src/components/HeroBoard/index.tsx
@@ -1,4 +1,4 @@
-import { ScaledBoardDisplay } from "@fiestaboard/ui";
+import { Box, ScaledBoardDisplay, Text } from "@fiestaboard/ui";
 import { type ReactNode, useEffect, useRef, useState } from "react";
 
 import styles from "./styles.module.css";
@@ -203,8 +203,8 @@ export default function HeroBoard(): ReactNode {
   const board = BOARDS[shown];
 
   return (
-    <div className={styles.stage}>
-      <div className={styles.frame} data-visible={visible}>
+    <Box className={styles.stage}>
+      <Box className={styles.frame} data-visible={visible}>
         <ScaledBoardDisplay
           key={shown}
           message={message}
@@ -214,10 +214,10 @@ export default function HeroBoard(): ReactNode {
           size="md"
           animationsEnabled={false}
         />
-      </div>
-      <div className={styles.caption} data-visible={visible}>
+      </Box>
+      <Text as="span" className={styles.caption} data-visible={visible}>
         {board.label}
-      </div>
-    </div>
+      </Text>
+    </Box>
   );
 }

--- a/docs-site/src/components/HomepageFeatures/index.tsx
+++ b/docs-site/src/components/HomepageFeatures/index.tsx
@@ -1,7 +1,7 @@
 import BrowserOnly from "@docusaurus/BrowserOnly";
 import Link from "@docusaurus/Link";
 import { useColorMode } from "@docusaurus/theme-common";
-import { Badge, Button, Code, ScaledBoardDisplay, TextLink } from "@fiestaboard/ui";
+import { Badge, Box, Button, Code, Heading, ScaledBoardDisplay, Text, TextLink } from "@fiestaboard/ui";
 import { type ReactNode } from "react";
 
 import { plugins } from "../../plugin-data";
@@ -198,33 +198,37 @@ function deriveThemedPath(src: string, mode: "light" | "dark"): string {
 
 function FeatureCard({ title, icon, description }: FeatureItem) {
   return (
-    <div className={styles.featureCard}>
+    <Box className={styles.featureCard}>
       <img className={styles.featureCardImage} src={icon} alt={title} loading="lazy" />
-      <div className={styles.featureCardBody}>
-        <h3 className={styles.featureCardTitle}>{title}</h3>
-        <p className={styles.featureCardDesc}>{description}</p>
-      </div>
-    </div>
+      <Box className={styles.featureCardBody}>
+        <Heading level={3} className={styles.featureCardTitle}>
+          {title}
+        </Heading>
+        <Text className={styles.featureCardDesc}>{description}</Text>
+      </Box>
+    </Box>
   );
 }
 
 function HighlightCard({ title, description, primary, secondary }: HighlightItem) {
   return (
-    <div className={styles.highlightCard}>
+    <Box className={styles.highlightCard}>
       <Badge variant="success" className={styles.newBadge}>
         New
       </Badge>
-      <h3 className={styles.highlightTitle}>{title}</h3>
-      <p className={styles.highlightBody}>{description}</p>
-      <div className={styles.cardButtons}>
+      <Heading level={3} className={styles.highlightTitle}>
+        {title}
+      </Heading>
+      <Text className={styles.highlightBody}>{description}</Text>
+      <Box className={styles.cardButtons}>
         <Button variant="secondary" size="sm" asChild>
           <Link to={primary.to}>{primary.label}</Link>
         </Button>
         <Button variant="ghost" size="sm" asChild>
           <Link to={secondary.to}>{secondary.label}</Link>
         </Button>
-      </div>
-    </div>
+      </Box>
+    </Box>
   );
 }
 
@@ -232,29 +236,31 @@ function ShowcaseRow({ title, image, alt, description, link, reverse }: Showcase
   const { colorMode } = useColorMode();
   const src = deriveThemedPath(image, colorMode);
   return (
-    <div className={reverse ? styles.showcaseRowReverse : styles.showcaseRow}>
-      <div className={styles.showcaseImage}>
+    <Box className={reverse ? styles.showcaseRowReverse : styles.showcaseRow}>
+      <Box className={styles.showcaseImage}>
         <img src={src} alt={alt} loading="lazy" />
-      </div>
-      <div className={styles.showcaseContent}>
-        <h3 className={styles.showcaseTitle}>{title}</h3>
-        <p className={styles.showcaseDesc}>{description}</p>
+      </Box>
+      <Box className={styles.showcaseContent}>
+        <Heading level={3} className={styles.showcaseTitle}>
+          {title}
+        </Heading>
+        <Text className={styles.showcaseDesc}>{description}</Text>
         <TextLink href={link}>Learn More →</TextLink>
-      </div>
-    </div>
+      </Box>
+    </Box>
   );
 }
 
 function PluginCard({ title, description, link, message }: PluginItem) {
   return (
     <Link to={link} className={styles.pluginCard}>
-      <div className={styles.pluginCardBoard}>
-        <BrowserOnly fallback={<div className={styles.pluginBoardFallback} />}>
+      <Box className={styles.pluginCardBoard}>
+        <BrowserOnly fallback={<Box className={styles.pluginBoardFallback} />}>
           {() => <ScaledBoardDisplay message={message} size="sm" />}
         </BrowserOnly>
-      </div>
-      <div className={styles.pluginCardName}>{title}</div>
-      <div className={styles.pluginCardDesc}>{description}</div>
+      </Box>
+      <Text className={styles.pluginCardName}>{title}</Text>
+      <Text className={styles.pluginCardDesc}>{description}</Text>
     </Link>
   );
 }
@@ -264,81 +270,89 @@ export default function HomepageFeatures(): ReactNode {
   return (
     <>
       {/* Feature grid */}
-      <section className={styles.section}>
-        <div className={styles.inner}>
-          <div className={styles.featureGrid}>
+      <Box as="section" className={styles.section}>
+        <Box className={styles.inner}>
+          <Box className={styles.featureGrid}>
             {FeatureList.map((props) => (
               <FeatureCard key={props.title} {...props} />
             ))}
-          </div>
-        </div>
-      </section>
+          </Box>
+        </Box>
+      </Box>
 
       {/* What's New */}
-      <section className={styles.sectionMuted}>
-        <div className={styles.inner}>
-          <h2 className={styles.sectionTitle}>What&apos;s New</h2>
-          <p className={styles.sectionSubtitle}>
+      <Box as="section" className={styles.sectionMuted}>
+        <Box className={styles.inner}>
+          <Heading level={2} className={styles.sectionTitle}>
+            What&apos;s New
+          </Heading>
+          <Text className={styles.sectionSubtitle}>
             The fastest way to run FiestaBoard, and updates without ever touching a terminal
-          </p>
-          <div className={styles.highlightGrid}>
+          </Text>
+          <Box className={styles.highlightGrid}>
             {HighlightList.map((props) => (
               <HighlightCard key={props.title} {...props} />
             ))}
-          </div>
-        </div>
-      </section>
+          </Box>
+        </Box>
+      </Box>
 
       {/* See It in Action */}
-      <section className={styles.section}>
-        <div className={styles.inner}>
-          <h2 className={styles.sectionTitle}>See It in Action</h2>
-          <p className={styles.sectionSubtitle}>A powerful web interface to manage your split-flap display</p>
-          <div className={styles.showcaseStack}>
+      <Box as="section" className={styles.section}>
+        <Box className={styles.inner}>
+          <Heading level={2} className={styles.sectionTitle}>
+            See It in Action
+          </Heading>
+          <Text className={styles.sectionSubtitle}>A powerful web interface to manage your split-flap display</Text>
+          <Box className={styles.showcaseStack}>
             {FeatureShowcaseList.map((props, idx) => (
               <ShowcaseRow key={props.title} {...props} reverse={idx % 2 === 1} />
             ))}
-          </div>
-        </div>
-      </section>
+          </Box>
+        </Box>
+      </Box>
 
       {/* Plugin grid */}
-      <section className={styles.sectionMuted}>
-        <div className={styles.inner}>
-          <h2 className={styles.sectionTitle}>{pluginCount}+ Plugins and Counting</h2>
-          <p className={styles.sectionSubtitle}>
+      <Box as="section" className={styles.sectionMuted}>
+        <Box className={styles.inner}>
+          <Heading level={2} className={styles.sectionTitle}>
+            {pluginCount}+ Plugins and Counting
+          </Heading>
+          <Text className={styles.sectionSubtitle}>
             From weather and stocks to Disney park wait times - there&apos;s a plugin for everything
-          </p>
-          <div className={styles.pluginGrid}>
+          </Text>
+          <Box className={styles.pluginGrid}>
             {PluginList.map((props) => (
               <PluginCard key={props.title} {...props} />
             ))}
-          </div>
-          <div className={styles.centerAction}>
+          </Box>
+          <Box className={styles.centerAction}>
             <Button variant="outline" size="lg" asChild>
               <Link to="/plugins">Explore All Plugins</Link>
             </Button>
-          </div>
-        </div>
-      </section>
+          </Box>
+        </Box>
+      </Box>
 
       {/* CTA */}
-      <section className={styles.section}>
-        <div className={styles.ctaInner}>
-          <h2 className={styles.sectionTitle}>Ready to Get Started?</h2>
-          <p className={styles.ctaSubtitle}>
+      <Box as="section" className={styles.section}>
+        <Box className={styles.ctaInner}>
+          <Heading level={2} className={styles.sectionTitle}>
+            Ready to Get Started?
+          </Heading>
+          <Text className={styles.ctaSubtitle}>
             FiestaBoard is free, open source, and runs anywhere Docker does. Get up and running in minutes.
-          </p>
-          <div className={styles.centerAction}>
+          </Text>
+          <Box className={styles.centerAction}>
             <Button variant="brand" size="lg" asChild>
               <Link to="/docs/setup/beginners-guide">Beginner&apos;s Guide</Link>
             </Button>
             <Button variant="outline" size="lg" asChild>
               <Link to="/docs/development/plugin-guide">Build a Plugin</Link>
             </Button>
-          </div>
-        </div>
-      </section>
+          </Box>
+        </Box>
+      </Box>
     </>
   );
 }

--- a/docs-site/src/components/ThemedScreenshot/index.tsx
+++ b/docs-site/src/components/ThemedScreenshot/index.tsx
@@ -1,4 +1,7 @@
 import { useColorMode } from "@docusaurus/theme-common";
+import { Box, Button, Text } from "@fiestaboard/ui";
+import clsx from "clsx";
+import { Moon, Sun, X } from "lucide-react";
 import { type ReactNode, useCallback, useEffect, useState } from "react";
 
 import styles from "./styles.module.css";
@@ -27,33 +30,29 @@ function ThemeToggle({
   activeMode: "light" | "dark";
   onSetMode: (mode: "light" | "dark") => void;
 }) {
+  const MODES = [
+    { mode: "light", label: "Light", Icon: Sun },
+    { mode: "dark", label: "Dark", Icon: Moon },
+  ] as const;
+
   return (
-    <div className={styles.toggleBar}>
-      <button
-        type="button"
-        className={`${styles.toggleButton} ${activeMode === "light" ? styles.active : ""}`}
-        onClick={() => onSetMode("light")}
-        aria-label="Show light mode screenshot"
-        title="Light mode"
-      >
-        <svg viewBox="0 0 20 20" width="14" height="14" fill="currentColor" aria-hidden="true">
-          <path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" />
-        </svg>
-        <span>Light</span>
-      </button>
-      <button
-        type="button"
-        className={`${styles.toggleButton} ${activeMode === "dark" ? styles.active : ""}`}
-        onClick={() => onSetMode("dark")}
-        aria-label="Show dark mode screenshot"
-        title="Dark mode"
-      >
-        <svg viewBox="0 0 20 20" width="14" height="14" fill="currentColor" aria-hidden="true">
-          <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z" />
-        </svg>
-        <span>Dark</span>
-      </button>
-    </div>
+    <Box className={styles.toggleBar}>
+      {MODES.map(({ mode, label, Icon }) => (
+        <Button
+          key={mode}
+          type="button"
+          variant="ghost"
+          aria-pressed={activeMode === mode}
+          className={clsx(styles.toggleButton, activeMode === mode && styles.active)}
+          onClick={() => onSetMode(mode)}
+          aria-label={`Show ${mode} mode screenshot`}
+          title={`${label} mode`}
+        >
+          <Icon aria-hidden="true" />
+          <Text as="span">{label}</Text>
+        </Button>
+      ))}
+    </Box>
   );
 }
 
@@ -87,27 +86,17 @@ function Lightbox({
   }, [handleKeyDown]);
 
   return (
-    <div className={styles.lightboxOverlay} onClick={onClose} role="dialog" aria-modal="true">
-      <div className={styles.lightboxContent} onClick={(e) => e.stopPropagation()}>
-        <button type="button" className={styles.lightboxClose} onClick={onClose} aria-label="Close">
-          <svg
-            viewBox="0 0 24 24"
-            width="24"
-            height="24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            aria-hidden="true"
-          >
-            <path d="M18 6L6 18M6 6l12 12" />
-          </svg>
-        </button>
+    <Box className={styles.lightboxOverlay} onClick={onClose} role="dialog" aria-modal="true">
+      <Box className={styles.lightboxContent} onClick={(e) => e.stopPropagation()}>
+        <Button type="button" variant="ghost" className={styles.lightboxClose} onClick={onClose} aria-label="Close">
+          <X aria-hidden="true" />
+        </Button>
         <img className={styles.lightboxImage} src={src} alt={alt} />
-        <div className={styles.lightboxFooter}>
+        <Box className={styles.lightboxFooter}>
           <ThemeToggle activeMode={activeMode} onSetMode={onSetMode} />
-        </div>
-      </div>
-    </div>
+        </Box>
+      </Box>
+    </Box>
   );
 }
 

--- a/docs-site/src/css/custom.css
+++ b/docs-site/src/css/custom.css
@@ -83,17 +83,6 @@
   font-weight: 500;
 }
 
-/* Align logo with nav: anchor image to bottom so text baseline matches nav
-   links; object-position crops the floating top of the taco so icon and text
-   look aligned. (Carried over from the previous theme.) */
-.navbar__logo img {
-  height: 48px;
-  width: auto;
-  object-fit: cover;
-  object-position: left 100%;
-  transform: translateY(-8px);
-}
-
 /* Code blocks: card-style frame matching the design references. */
 .theme-code-block,
 div[class*="codeBlockContainer"] {
@@ -101,15 +90,32 @@ div[class*="codeBlockContainer"] {
   border-radius: var(--radius);
 }
 
-/* Prev/next pagination cards: rounded, hover ring (FiestaboardDocs.dc.html). */
+/* Prev/next pagination: the anchor keeps Infima's `.pagination-nav` grid
+   placement (`--prev` / `--next` column + text alignment) but hands its box
+   treatment to the FiestaUI `Card` inside it. See src/theme/PaginatorNavLink. */
 .pagination-nav__link {
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  transition: border-color 0.15s ease;
+  border: none;
+  padding: 0;
 }
 
-.pagination-nav__link:hover {
-  border-color: var(--ring);
+/* Navbar dropdown menu on DS surfaces - Infima's own dropdown tokens were
+   never part of the token bridge, so the panel kept its default white card. */
+.dropdown__menu {
+  background-color: var(--popover);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: none;
+}
+
+.dropdown__link {
+  border-radius: calc(var(--radius) - 4px);
+  color: var(--muted-foreground);
+}
+
+.dropdown__link:hover,
+.dropdown__link--active {
+  background-color: var(--accent);
+  color: var(--foreground);
 }
 
 /* Hide the per-page version badge - the navbar version dropdown is sufficient. */

--- a/docs-site/src/pages/index.module.css
+++ b/docs-site/src/pages/index.module.css
@@ -55,11 +55,10 @@
   text-wrap: balance;
 }
 
+/* Layout (flex/gap/wrap) comes from the `Flex` primitive in index.tsx; only
+   the spacing above it is page-specific. */
 .heroButtons {
-  display: flex;
-  gap: 12px;
   margin-top: 32px;
-  flex-wrap: wrap;
 }
 
 .heroBoard {

--- a/docs-site/src/pages/index.tsx
+++ b/docs-site/src/pages/index.tsx
@@ -1,6 +1,6 @@
 import BrowserOnly from "@docusaurus/BrowserOnly";
 import Link from "@docusaurus/Link";
-import { Button } from "@fiestaboard/ui";
+import { Box, Button, Flex, Text } from "@fiestaboard/ui";
 import HeroBoard from "@site/src/components/HeroBoard";
 import HomepageFeatures from "@site/src/components/HomepageFeatures";
 import Layout from "@theme/Layout";
@@ -10,32 +10,35 @@ import styles from "./index.module.css";
 
 function Hero() {
   return (
-    <section className={styles.section}>
-      <div className={styles.heroInner}>
-        <div className={styles.heroCopy}>
+    <Box as="section" className={styles.section}>
+      <Box className={styles.heroInner}>
+        <Box className={styles.heroCopy}>
+          {/* The page's sole h1. FiestaUI's `Heading` covers h2-h4 only (h1 is
+              reserved for the app's `PageHeader`), so the hero title keeps its
+              own element and takes its type scale from `index.module.css`. */}
           <h1 className={styles.heroTitle}>Turn your split-flap display into a living dashboard</h1>
-          <p className={styles.heroBody}>
+          <Text className={styles.heroBody}>
             Transform your Vestaboard into a real-time information hub - track your morning commute, monitor the
             markets, check surf conditions, or display Star Trek wisdom. Compatible with Vestaboard Flagship and Note.
             All beautifully formatted, endlessly customizable, and running in Docker with zero hassle.
-          </p>
-          <p className={styles.heroSubline}>
+          </Text>
+          <Text className={styles.heroSubline}>
             Weather, stocks, sports &amp; more - flash a Raspberry Pi or run with Docker
-          </p>
-          <div className={styles.heroButtons}>
+          </Text>
+          <Flex gap="3" wrap className={styles.heroButtons}>
             <Button variant="brand" size="lg" asChild>
               <Link to="/docs/intro">Get Started</Link>
             </Button>
             <Button variant="outline" size="lg" asChild>
               <Link href="https://github.com/Fiestaboard/FiestaBoard">View on GitHub</Link>
             </Button>
-          </div>
-        </div>
-        <div className={styles.heroBoard}>
-          <BrowserOnly fallback={<div className={styles.heroBoardFallback} />}>{() => <HeroBoard />}</BrowserOnly>
-        </div>
-      </div>
-    </section>
+          </Flex>
+        </Box>
+        <Box className={styles.heroBoard}>
+          <BrowserOnly fallback={<Box className={styles.heroBoardFallback} />}>{() => <HeroBoard />}</BrowserOnly>
+        </Box>
+      </Box>
+    </Box>
   );
 }
 
@@ -46,9 +49,9 @@ export default function Home(): ReactNode {
       description="FiestaBoard is free, open-source software for Vestaboard and split-flap displays. 26 plugins for weather, stocks, sports, transit, and more. Compatible with Vestaboard Flagship and Note."
     >
       <Hero />
-      <main>
+      <Box as="main">
         <HomepageFeatures />
-      </main>
+      </Box>
     </Layout>
   );
 }

--- a/docs-site/src/pages/plugins/detail.tsx
+++ b/docs-site/src/pages/plugins/detail.tsx
@@ -1,11 +1,26 @@
 import BrowserOnly from "@docusaurus/BrowserOnly";
 import Link from "@docusaurus/Link";
+import {
+  Badge,
+  Box,
+  Button,
+  EmptyState,
+  Flex,
+  Heading,
+  Skeleton,
+  Table,
+  TableCell,
+  TableHead,
+  TableHeader,
+  Text,
+  TextLink,
+} from "@fiestaboard/ui";
 import { fetchPluginReadme, rewriteMarkdownImageUrls, rewriteMarkdownRepoLinks } from "@site/src/lib/github-readme";
 import type { PluginEntry } from "@site/src/plugin-data";
 import { CATEGORY_LABELS, pluginBoardImagePath, plugins } from "@site/src/plugin-data";
-import Heading from "@theme/Heading";
 import Layout from "@theme/Layout";
 import clsx from "clsx";
+import { PackageX } from "lucide-react";
 import { type ReactNode, useEffect, useState } from "react";
 
 import styles from "./detail.module.css";
@@ -26,6 +41,16 @@ function ReadmeContent({ markdown }: { markdown: string }) {
       const Wrapper = ({ children }: { children: string }) => (
         <ReactMarkdown
           remarkPlugins={[remarkGfm]}
+          /*
+           * These renderers are markdown *output* nodes, not app markup, so the
+           * prose ones stay as raw elements for the same reason the docs' own
+           * MDX does (see src/css/custom.css): FiestaUI's Text/Heading/List/Code
+           * are sized for the app's dense chrome, and README bodies need the
+           * long-form type scale that detail.module.css defines. Table nodes are
+           * the exception and do map onto the DS Table set, matching
+           * src/theme/MDXComponents.ts.
+           */
+          /* eslint-disable react/forbid-elements */
           components={{
             a: ({ href, children: kids, ...props }) => (
               <a href={href} target="_blank" rel="noopener noreferrer" {...props}>
@@ -52,27 +77,29 @@ function ReadmeContent({ markdown }: { markdown: string }) {
                 </code>
               );
             },
+            // Table nodes map onto the design-system Table set, the same way
+            // src/theme/MDXComponents.ts maps GFM tables in the docs themselves.
             table: ({ children: kids, ...props }) => (
-              <div className={styles.readmeTableWrap}>
-                <table className={styles.readmeTable} {...props}>
+              <Box className={styles.readmeTableWrap}>
+                <Table className={styles.readmeTable} {...props}>
                   {kids}
-                </table>
-              </div>
+                </Table>
+              </Box>
             ),
             thead: ({ children: kids, ...props }) => (
-              <thead className={styles.readmeThead} {...props}>
+              <TableHeader className={styles.readmeThead} {...props}>
                 {kids}
-              </thead>
+              </TableHeader>
             ),
             th: ({ children: kids, ...props }) => (
-              <th className={styles.readmeTh} {...props}>
+              <TableHead className={styles.readmeTh} {...props}>
                 {kids}
-              </th>
+              </TableHead>
             ),
             td: ({ children: kids, ...props }) => (
-              <td className={styles.readmeTd} {...props}>
+              <TableCell className={styles.readmeTd} {...props}>
                 {kids}
-              </td>
+              </TableCell>
             ),
             h1: ({ children: kids, ...props }) => (
               <h1 className={styles.readmeH1} {...props}>
@@ -116,6 +143,7 @@ function ReadmeContent({ markdown }: { markdown: string }) {
               </strong>
             ),
           }}
+          /* eslint-enable react/forbid-elements */
         >
           {children}
         </ReactMarkdown>
@@ -129,12 +157,12 @@ function ReadmeContent({ markdown }: { markdown: string }) {
 
   if (!Markdown) {
     return (
-      <div className={styles.skeleton}>
-        <div />
-        <div />
-        <div />
-        <div />
-      </div>
+      <Box className={styles.skeleton}>
+        <Skeleton />
+        <Skeleton />
+        <Skeleton />
+        <Skeleton />
+      </Box>
     );
   }
 
@@ -186,13 +214,17 @@ function DetailContent() {
 
   if (!plugin) {
     return (
-      <div className={styles.notFound}>
-        <Heading as="h1">Plugin Not Found</Heading>
-        <p>The plugin "{pluginId}" doesn't exist in the registry.</p>
-        <Link className="button button--primary" to="/plugins">
-          ← Back to Plugin Directory
-        </Link>
-      </div>
+      <EmptyState
+        className={styles.notFound}
+        icon={PackageX}
+        title="Plugin not found"
+        description={`The plugin "${pluginId}" doesn't exist in the registry.`}
+        action={
+          <Button asChild>
+            <Link to="/plugins">← Back to Plugin Directory</Link>
+          </Button>
+        }
+      />
     );
   }
 
@@ -202,14 +234,14 @@ function DetailContent() {
   return (
     <>
       {/* Back link */}
-      <div className={styles.backRow}>
+      <Box className={styles.backRow}>
         <Link to="/plugins" className={styles.backLink}>
           ← Back to Plugin Directory
         </Link>
-      </div>
+      </Box>
 
       {/* Hero image */}
-      <div className={styles.heroImage}>
+      <Box className={styles.heroImage}>
         <img
           src={heroImage}
           alt={`${plugin.name} displayed on a split-flap board`}
@@ -217,88 +249,82 @@ function DetailContent() {
             (e.target as HTMLImageElement).parentElement!.style.display = "none";
           }}
         />
-      </div>
+      </Box>
 
       {/* Board color toggle */}
-      <div className={styles.boardColorToggle} role="radiogroup" aria-label="Board color">
-        <button
-          type="button"
-          role="radio"
-          className={clsx(styles.boardColorOption, boardColor === "black" && styles.boardColorOptionActive)}
-          onClick={() => setBoardColor("black")}
-          aria-checked={boardColor === "black"}
-        >
-          Black Board
-        </button>
-        <button
-          type="button"
-          role="radio"
-          className={clsx(styles.boardColorOption, boardColor === "white" && styles.boardColorOptionActive)}
-          onClick={() => setBoardColor("white")}
-          aria-checked={boardColor === "white"}
-        >
-          White Board
-        </button>
-      </div>
+      <Box className={styles.boardColorToggle} role="radiogroup" aria-label="Board color">
+        {(["black", "white"] as const).map((color) => (
+          <Button
+            key={color}
+            type="button"
+            variant="ghost"
+            role="radio"
+            className={clsx(styles.boardColorOption, boardColor === color && styles.boardColorOptionActive)}
+            onClick={() => setBoardColor(color)}
+            aria-checked={boardColor === color}
+          >
+            {color === "black" ? "Black Board" : "White Board"}
+          </Button>
+        ))}
+      </Box>
 
       {/* Plugin header */}
-      <div className={styles.pluginHeader}>
-        <div className={styles.pluginMeta}>
-          <div className={styles.pluginTitleRow}>
-            <Heading as="h1" className={styles.pluginName}>
-              {plugin.name}
-            </Heading>
-            <span className={clsx(styles.categoryBadge, styles[`category_${plugin.category}`])}>{categoryLabel}</span>
-          </div>
-          <p className={styles.pluginDescription}>{plugin.description}</p>
-          <div className={styles.pluginDetails}>
-            <span>by {plugin.author}</span>
-            <span className={styles.detailDot}>·</span>
-            <span>Requires FiestaBoard {plugin.fiestaboard_version}</span>
-          </div>
-        </div>
+      <Box className={styles.pluginHeader}>
+        <Box className={styles.pluginMeta}>
+          <Box className={styles.pluginTitleRow}>
+            <h1 className={styles.pluginName}>{plugin.name}</h1>
+            <Badge variant="secondary" className={clsx(styles.categoryBadge, styles[`category_${plugin.category}`])}>
+              {categoryLabel}
+            </Badge>
+          </Box>
+          <Text className={styles.pluginDescription}>{plugin.description}</Text>
+          <Flex align="center" gap="2" wrap className={styles.pluginDetails}>
+            <Text as="span">by {plugin.author}</Text>
+            <Text as="span" className={styles.detailDot}>
+              ·
+            </Text>
+            <Text as="span">Requires FiestaBoard {plugin.fiestaboard_version}</Text>
+          </Flex>
+        </Box>
 
-        <div className={styles.pluginActions}>
+        <Box className={styles.pluginActions}>
           {plugin.repository && (
-            <a
-              href={plugin.repository}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="button button--outline button--primary button--sm"
-            >
-              View on GitHub ↗
-            </a>
+            <Button variant="outline" size="sm" asChild>
+              <Link href={plugin.repository} target="_blank" rel="noopener noreferrer">
+                View on GitHub ↗
+              </Link>
+            </Button>
           )}
-        </div>
-      </div>
+        </Box>
+      </Box>
 
       {/* README section */}
-      <div className={styles.readmeSection}>
-        <Heading as="h2" className={styles.readmeSectionTitle}>
+      <Box className={styles.readmeSection}>
+        <Heading level={2} className={styles.readmeSectionTitle}>
           Documentation
         </Heading>
         {loadingReadme ? (
-          <div className={styles.skeleton}>
-            <div />
-            <div />
-            <div />
-            <div />
-          </div>
+          <Box className={styles.skeleton}>
+            <Skeleton />
+            <Skeleton />
+            <Skeleton />
+            <Skeleton />
+          </Box>
         ) : readme ? (
-          <div className={styles.readmeBody}>
+          <Box className={styles.readmeBody}>
             <ReadmeContent markdown={readme} />
-          </div>
+          </Box>
         ) : (
-          <p className={styles.readmeEmpty}>
+          <Text className={styles.readmeEmpty}>
             Documentation not available.{" "}
             {plugin.repository && (
-              <a href={plugin.repository} target="_blank" rel="noopener noreferrer">
+              <TextLink href={plugin.repository} target="_blank" rel="noopener noreferrer">
                 View the source on GitHub
-              </a>
+              </TextLink>
             )}
-          </p>
+          </Text>
         )}
-      </div>
+      </Box>
     </>
   );
 }
@@ -308,21 +334,21 @@ function DetailContent() {
 export default function PluginDetailPage(): ReactNode {
   return (
     <Layout title="Plugin Details" description="View plugin details, documentation, and screenshots.">
-      <main className={styles.detailPage}>
-        <div className="container">
+      <Box as="main" className={styles.detailPage}>
+        <Box className="container">
           <BrowserOnly
             fallback={
-              <div className={styles.skeleton}>
-                <div />
-                <div />
-                <div />
-              </div>
+              <Box className={styles.skeleton}>
+                <Skeleton />
+                <Skeleton />
+                <Skeleton />
+              </Box>
             }
           >
             {() => <DetailContent />}
           </BrowserOnly>
-        </div>
-      </main>
+        </Box>
+      </Box>
     </Layout>
   );
 }

--- a/docs-site/src/pages/plugins/index.tsx
+++ b/docs-site/src/pages/plugins/index.tsx
@@ -1,16 +1,21 @@
 import Link from "@docusaurus/Link";
+import { Badge, Box, Button, EmptyState, Flex, Heading, Input, Text } from "@fiestaboard/ui";
 import type { PluginEntry } from "@site/src/plugin-data";
 import { CATEGORIES, CATEGORY_LABELS, pluginBoardImagePath, plugins } from "@site/src/plugin-data";
-import Heading from "@theme/Heading";
 import Layout from "@theme/Layout";
 import clsx from "clsx";
+import { SearchX } from "lucide-react";
 import { type ReactNode, useMemo, useState } from "react";
 
 import styles from "./index.module.css";
 
 function CategoryBadge({ category }: { category: string }) {
   const label = CATEGORY_LABELS[category] ?? category;
-  return <span className={clsx(styles.categoryBadge, styles[`category_${category}`])}>{label}</span>;
+  return (
+    <Badge variant="secondary" className={clsx(styles.categoryBadge, styles[`category_${category}`])}>
+      {label}
+    </Badge>
+  );
 }
 
 function PluginCard({ plugin, boardColor }: { plugin: PluginEntry; boardColor: "black" | "white" }) {
@@ -18,7 +23,7 @@ function PluginCard({ plugin, boardColor }: { plugin: PluginEntry; boardColor: "
 
   return (
     <Link to={`/plugins/detail?id=${plugin.id}`} className={styles.pluginCard}>
-      <div className={styles.pluginCardImage}>
+      <Box className={styles.pluginCardImage}>
         <img
           src={imgSrc}
           alt={`${plugin.name} displayed on a split-flap board`}
@@ -27,17 +32,19 @@ function PluginCard({ plugin, boardColor }: { plugin: PluginEntry; boardColor: "
             (e.target as HTMLImageElement).style.display = "none";
           }}
         />
-      </div>
-      <div className={styles.pluginCardBody}>
-        <div className={styles.pluginCardHeader}>
-          <Heading as="h3" className={styles.pluginCardTitle}>
+      </Box>
+      <Box className={styles.pluginCardBody}>
+        <Box className={styles.pluginCardHeader}>
+          <Heading level={3} className={styles.pluginCardTitle}>
             {plugin.name}
           </Heading>
           <CategoryBadge category={plugin.category} />
-        </div>
-        <p className={styles.pluginCardDescription}>{plugin.description}</p>
-        <span className={styles.pluginCardAuthor}>by {plugin.author}</span>
-      </div>
+        </Box>
+        <Text className={styles.pluginCardDescription}>{plugin.description}</Text>
+        <Text as="span" className={styles.pluginCardAuthor}>
+          by {plugin.author}
+        </Text>
+      </Box>
     </Link>
   );
 }
@@ -65,22 +72,20 @@ export default function PluginDirectory(): ReactNode {
       title="Plugin Directory"
       description="Browse all FiestaBoard plugins - weather, stocks, transit, sports, art, and more. Explore what's available for your split-flap display."
     >
-      <main className={styles.directoryPage}>
-        <div className="container">
+      <Box as="main" className={styles.directoryPage}>
+        <Box className="container">
           {/* Header */}
-          <div className={styles.header}>
-            <Heading as="h1" className={styles.title}>
-              Plugin Directory
-            </Heading>
-            <p className={styles.subtitle}>
+          <Box className={styles.header}>
+            <h1 className={styles.title}>Plugin Directory</h1>
+            <Text className={styles.subtitle}>
               Explore {plugins.length} plugins for your split-flap display - from weather and stocks to Disney park wait
               times and generative art.
-            </p>
-          </div>
+            </Text>
+          </Box>
 
           {/* Search and filters */}
-          <div className={styles.controls}>
-            <input
+          <Box className={styles.controls}>
+            <Input
               type="search"
               className={styles.searchInput}
               placeholder="Search plugins..."
@@ -88,71 +93,73 @@ export default function PluginDirectory(): ReactNode {
               onChange={(e) => setSearch(e.target.value)}
               aria-label="Search plugins"
             />
-            <div className={styles.categoryFilters}>
-              <button
+            <Flex wrap gap="2" className={styles.categoryFilters}>
+              <Button
                 type="button"
+                variant="ghost"
+                aria-pressed={activeCategory === null}
                 className={clsx(styles.filterButton, activeCategory === null && styles.filterButtonActive)}
                 onClick={() => setActiveCategory(null)}
               >
                 All
-              </button>
+              </Button>
               {CATEGORIES.map((cat) => (
-                <button
+                <Button
                   key={cat}
                   type="button"
+                  variant="ghost"
+                  aria-pressed={activeCategory === cat}
                   className={clsx(styles.filterButton, activeCategory === cat && styles.filterButtonActive)}
                   onClick={() => setActiveCategory(cat === activeCategory ? null : cat)}
                 >
                   {CATEGORY_LABELS[cat]}
-                </button>
+                </Button>
               ))}
-            </div>
-          </div>
+            </Flex>
+          </Box>
 
           {/* Board color toggle */}
-          <div className={styles.boardColorToggle} role="radiogroup" aria-label="Board color">
-            <button
-              type="button"
-              role="radio"
-              className={clsx(styles.boardColorOption, boardColor === "black" && styles.boardColorOptionActive)}
-              onClick={() => setBoardColor("black")}
-              aria-checked={boardColor === "black"}
-            >
-              Black Board
-            </button>
-            <button
-              type="button"
-              role="radio"
-              className={clsx(styles.boardColorOption, boardColor === "white" && styles.boardColorOptionActive)}
-              onClick={() => setBoardColor("white")}
-              aria-checked={boardColor === "white"}
-            >
-              White Board
-            </button>
-          </div>
+          <Box className={styles.boardColorToggle} role="radiogroup" aria-label="Board color">
+            {(["black", "white"] as const).map((color) => (
+              <Button
+                key={color}
+                type="button"
+                variant="ghost"
+                role="radio"
+                className={clsx(styles.boardColorOption, boardColor === color && styles.boardColorOptionActive)}
+                onClick={() => setBoardColor(color)}
+                aria-checked={boardColor === color}
+              >
+                {color === "black" ? "Black Board" : "White Board"}
+              </Button>
+            ))}
+          </Box>
 
           {/* Results */}
           {filtered.length > 0 ? (
-            <div className={styles.pluginGrid}>
+            <Box className={styles.pluginGrid}>
               {filtered.map((plugin) => (
                 <PluginCard key={plugin.id} plugin={plugin} boardColor={boardColor} />
               ))}
-            </div>
+            </Box>
           ) : (
-            <div className={styles.emptyState}>
-              <p>No plugins match your search. Try a different query or category.</p>
-            </div>
+            <EmptyState
+              className={styles.emptyState}
+              icon={SearchX}
+              title="No plugins found"
+              description="No plugins match your search. Try a different query or category."
+            />
           )}
 
           {/* CTA */}
-          <div className={styles.cta}>
-            <p>
+          <Box className={styles.cta}>
+            <Text>
               Want to build your own plugin?{" "}
               <Link to="/docs/development/plugin-guide">Check out the Plugin Development Guide →</Link>
-            </p>
-          </div>
-        </div>
-      </main>
+            </Text>
+          </Box>
+        </Box>
+      </Box>
     </Layout>
   );
 }

--- a/docs-site/src/pages/stats.tsx
+++ b/docs-site/src/pages/stats.tsx
@@ -1,7 +1,7 @@
 import Link from "@docusaurus/Link";
+import { Badge, Box, Button, Heading, List, ListItem, Text } from "@fiestaboard/ui";
 import type { PluginEntry } from "@site/src/plugin-data";
 import { CATEGORY_LABELS as REGISTRY_CATEGORY_LABELS, pluginBoardImagePath, plugins } from "@site/src/plugin-data";
-import Heading from "@theme/Heading";
 import Layout from "@theme/Layout";
 import * as Icons from "lucide-react";
 import { type ReactNode, useEffect, useState } from "react";
@@ -42,29 +42,35 @@ function PluginIcon({ name, size = 24 }: { name: string; size?: number }) {
 
 function StatStrip({ items }: { items: { value: string | number; label: string }[] }) {
   return (
-    <div className={styles.statStrip}>
+    <Box className={styles.statStrip}>
       {items.map((item, i) => (
-        <div key={i} className={styles.statStripItem}>
-          <span className={styles.statStripValue}>{item.value}</span>
-          <span className={styles.statStripLabel}>{item.label}</span>
-        </div>
+        <Box key={i} className={styles.statStripItem}>
+          <Text as="span" className={styles.statStripValue}>
+            {item.value}
+          </Text>
+          <Text as="span" className={styles.statStripLabel}>
+            {item.label}
+          </Text>
+        </Box>
       ))}
-    </div>
+    </Box>
   );
 }
 
 function BarRow({ plugin, max }: { plugin: PluginStat; max: number }) {
   const pct = max > 0 ? (plugin.clones_14d_uniques / max) * 100 : 0;
   return (
-    <div className={styles.barRow}>
+    <Box className={styles.barRow}>
       <Link to={`/plugins/detail?id=${plugin.id}`} className={styles.barName}>
         {plugin.name}
       </Link>
-      <div className={styles.barTrack}>
-        <div className={styles.barFill} style={{ width: `${pct}%` }} />
-      </div>
-      <span className={styles.barValue}>{plugin.clones_14d_uniques.toLocaleString()}</span>
-    </div>
+      <Box className={styles.barTrack}>
+        <Box className={styles.barFill} style={{ width: `${pct}%` }} />
+      </Box>
+      <Text as="span" className={styles.barValue}>
+        {plugin.clones_14d_uniques.toLocaleString()}
+      </Text>
+    </Box>
   );
 }
 
@@ -91,22 +97,24 @@ function TopPluginSpotlight({
           onError={() => setImgOk(false)}
         />
       ) : (
-        <div className={styles.spotlightImagePlaceholder}>
+        <Box className={styles.spotlightImagePlaceholder}>
           <PluginIcon name={entry.icon} size={32} />
-        </div>
+        </Box>
       )}
-      <div className={styles.spotlightFooter}>
-        <div className={styles.spotlightIcon}>
+      <Box className={styles.spotlightFooter}>
+        <Box className={styles.spotlightIcon}>
           <PluginIcon name={entry.icon} size={20} />
-        </div>
-        <div className={styles.spotlightBody}>
-          <div className={styles.spotlightName}>{plugin.name}</div>
-          <div className={styles.spotlightStat}>
+        </Box>
+        <Box className={styles.spotlightBody}>
+          <Box className={styles.spotlightName}>{plugin.name}</Box>
+          <Box className={styles.spotlightStat}>
             {plugin.clones_14d_uniques.toLocaleString()} unique installs in the last {windowDays} days
-          </div>
-        </div>
-        <div className={styles.spotlightBadge}>Most popular</div>
-      </div>
+          </Box>
+        </Box>
+        <Badge variant="secondary" className={styles.spotlightBadge}>
+          Most popular
+        </Badge>
+      </Box>
     </Link>
   );
 }
@@ -171,23 +179,23 @@ export default function StatsPage(): ReactNode {
       title="Plugin Stats"
       description="Live popularity and activity stats for all FiestaBoard plugins, updated daily from GitHub."
     >
-      <main className={styles.page}>
-        <div className="container">
-          <div className={styles.header}>
-            <Heading as="h1">Plugin Stats</Heading>
-            <p className={styles.subtitle}>
+      <Box as="main" className={styles.page}>
+        <Box className="container">
+          <Box className={styles.header}>
+            <h1>Plugin Stats</h1>
+            <Text className={styles.subtitle}>
               Popularity across all {data ? data.plugins.length : "…"} FiestaBoard plugins, updated daily.
-            </p>
-          </div>
+            </Text>
+          </Box>
 
-          {error && <p className={styles.error}>Stats are unavailable right now - check back soon.</p>}
+          {error && <Text className={styles.error}>Stats are unavailable right now - check back soon.</Text>}
 
-          {!data && !error && <div className={styles.loading}>Loading…</div>}
+          {!data && !error && <Box className={styles.loading}>Loading…</Box>}
 
           {data && (
             <>
-              <div className={styles.dashboard}>
-                <div className={styles.dashboardLeft}>
+              <Box className={styles.dashboard}>
+                <Box className={styles.dashboardLeft}>
                   <StatStrip
                     items={[
                       { value: data.plugins.length, label: "plugins" },
@@ -204,94 +212,104 @@ export default function StatsPage(): ReactNode {
                         <TopPluginSpotlight plugin={topPlugin} entry={entry} windowDays={data.window_days} />
                       ) : null;
                     })()}
-                </div>
+                </Box>
 
-                <section className={styles.dashboardRight}>
-                  <Heading as="h2">Popularity ranking</Heading>
-                  <p className={styles.sectionNote}>Unique cloners in the last {data.window_days} days</p>
-                  <div className={styles.barChart}>
+                <Box as="section" className={styles.dashboardRight}>
+                  <Heading level={2}>Popularity ranking</Heading>
+                  <Text className={styles.sectionNote}>Unique cloners in the last {data.window_days} days</Text>
+                  <Box className={styles.barChart}>
                     {displayedPlugins.map((plugin) => (
                       <BarRow key={plugin.id} plugin={plugin} max={maxUniques} />
                     ))}
-                  </div>
+                  </Box>
                   {sorted.length > RANKING_PREVIEW && (
-                    <button className={styles.showMoreBtn} onClick={() => setShowAllRanking(!showAllRanking)}>
+                    <Button
+                      variant="ghost"
+                      className={styles.showMoreBtn}
+                      onClick={() => setShowAllRanking(!showAllRanking)}
+                    >
                       {showAllRanking ? "Show fewer" : `Show all ${sorted.length} plugins`}
-                    </button>
+                    </Button>
                   )}
-                </section>
-              </div>
+                </Box>
+              </Box>
 
-              <section className={styles.section}>
-                <Heading as="h2">By category</Heading>
-                <p className={styles.sectionNote}>
+              <Box as="section" className={styles.section}>
+                <Heading level={2}>By category</Heading>
+                <Text className={styles.sectionNote}>
                   Sum of per-plugin installs by category, last {data.window_days} days - users installing multiple
                   plugins in the same category are counted once per plugin
-                </p>
-                <div className={styles.categoryGrid}>
+                </Text>
+                <Box className={styles.categoryGrid}>
                   {byCategory.map(([cat, count]) => (
-                    <div key={cat} className={styles.categoryCard}>
-                      <div className={styles.categoryCount}>{count.toLocaleString()}</div>
-                      <div className={styles.categoryName}>{CATEGORY_LABELS[cat] ?? cat}</div>
-                    </div>
+                    <Box key={cat} className={styles.categoryCard}>
+                      <Box className={styles.categoryCount}>{count.toLocaleString()}</Box>
+                      <Box className={styles.categoryName}>{CATEGORY_LABELS[cat] ?? cat}</Box>
+                    </Box>
                   ))}
-                </div>
-              </section>
+                </Box>
+              </Box>
 
-              <section className={styles.section}>
-                <div className={styles.recentColumns}>
-                  <div>
-                    <Heading as="h2">Recently added</Heading>
-                    <ul className={styles.recentList}>
+              <Box as="section" className={styles.section}>
+                <Box className={styles.recentColumns}>
+                  <Box>
+                    <Heading level={2}>Recently added</Heading>
+                    <List gap="0" className={styles.recentList}>
                       {recentlyAdded.map((p) => (
-                        <li key={p.id} className={styles.recentItem}>
+                        <ListItem key={p.id} className={styles.recentItem}>
                           <Link to={`/plugins/detail?id=${p.id}`}>{p.name}</Link>
-                          <span className={styles.recentMeta}>
-                            <span className={styles.recentCategory}>{CATEGORY_LABELS[p.category] ?? p.category}</span>
-                            <span className={styles.recentDate}>
+                          <Text as="span" className={styles.recentMeta}>
+                            <Text as="span" className={styles.recentCategory}>
+                              {CATEGORY_LABELS[p.category] ?? p.category}
+                            </Text>
+                            <Text as="span" className={styles.recentDate}>
                               {new Date(p.created_at!).toLocaleDateString("en-US", {
                                 month: "short",
                                 day: "numeric",
                                 year: "numeric",
                               })}
-                            </span>
-                          </span>
-                        </li>
+                            </Text>
+                          </Text>
+                        </ListItem>
                       ))}
-                    </ul>
-                  </div>
-                  <div>
-                    <Heading as="h2">Recently updated</Heading>
-                    <ul className={styles.recentList}>
+                    </List>
+                  </Box>
+                  <Box>
+                    <Heading level={2}>Recently updated</Heading>
+                    <List gap="0" className={styles.recentList}>
                       {recentlyUpdated.map((p) => (
-                        <li key={p.id} className={styles.recentItem}>
+                        <ListItem key={p.id} className={styles.recentItem}>
                           <Link to={`/plugins/detail?id=${p.id}`}>{p.name}</Link>
-                          <span className={styles.recentMeta}>
-                            <span className={styles.recentCategory}>{CATEGORY_LABELS[p.category] ?? p.category}</span>
-                            <span className={styles.recentVersion}>v{p.version}</span>
-                            <span className={styles.recentDate}>
+                          <Text as="span" className={styles.recentMeta}>
+                            <Text as="span" className={styles.recentCategory}>
+                              {CATEGORY_LABELS[p.category] ?? p.category}
+                            </Text>
+                            <Text as="span" className={styles.recentVersion}>
+                              v{p.version}
+                            </Text>
+                            <Text as="span" className={styles.recentDate}>
                               {new Date(p.updated_at!).toLocaleDateString("en-US", {
                                 month: "short",
                                 day: "numeric",
                                 year: "numeric",
                               })}
-                            </span>
-                          </span>
-                        </li>
+                            </Text>
+                          </Text>
+                        </ListItem>
                       ))}
-                    </ul>
-                  </div>
-                </div>
-              </section>
+                    </List>
+                  </Box>
+                </Box>
+              </Box>
 
-              <p className={styles.freshness}>
+              <Text className={styles.freshness}>
                 Data refreshed {generatedAt}. Clone counts reflect the {data.window_days}-day window provided by the
                 GitHub Traffic API.
-              </p>
+              </Text>
             </>
           )}
-        </div>
-      </main>
+        </Box>
+      </Box>
     </Layout>
   );
 }

--- a/docs-site/src/pages/versions.module.css
+++ b/docs-site/src/pages/versions.module.css
@@ -12,12 +12,8 @@
 /* Current version reads as a card, not a one-row table - it is the thing most
    visitors want, so it gets weight rather than the same treatment as the list
    of older versions below it. */
+/* Flex layout (wrap/align/justify/gap) comes from the `Flex` primitive. */
 .currentCard {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
   margin-top: 14px;
   padding: 20px 22px;
   border: 1px solid var(--border);
@@ -53,11 +49,7 @@
   margin-bottom: 10px;
 }
 
-.chipGrid {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-}
+/* Flex layout (wrap/gap) comes from the `Flex` primitive. */
 
 .chip {
   display: inline-flex;

--- a/docs-site/src/pages/versions.tsx
+++ b/docs-site/src/pages/versions.tsx
@@ -1,6 +1,6 @@
 import Link from "@docusaurus/Link";
 import { type GlobalVersion, useLatestVersion, useVersions } from "@docusaurus/plugin-content-docs/client";
-import { Button, Table, TableBody, TableCell, TableRow } from "@fiestaboard/ui";
+import { Box, Button, Flex, Heading, Table, TableBody, TableCell, TableRow, Text, TextLink } from "@fiestaboard/ui";
 import allVersions from "@site/versions.json";
 import Layout from "@theme/Layout";
 import type { ReactNode } from "react";
@@ -52,28 +52,36 @@ export default function Versions(): ReactNode {
 
   return (
     <Layout title="Versions" description="Browse every version of the FiestaBoard documentation.">
-      <main className="container margin-vert--lg">
+      <Box as="main" className="container margin-vert--lg">
         <h1>FiestaBoard documentation versions</h1>
-        <p>
-          We recommend the <strong>latest</strong> version - it has the newest features and fixes, and it&apos;s what
-          the docs default to. Every released version is listed below.
-        </p>
+        <Text size="base">
+          We recommend the{" "}
+          <Text as="span" size="base" weight="semibold">
+            latest
+          </Text>{" "}
+          version - it has the newest features and fixes, and it&apos;s what the docs default to. Every released version
+          is listed below.
+        </Text>
 
-        <h2>Current version</h2>
-        <div className={styles.currentCard}>
-          <div>
-            <span className={styles.currentLabel}>{latest.label}</span>
-            <span className={styles.currentTag}>recommended</span>
-          </div>
+        <Heading level={2}>Current version</Heading>
+        <Flex align="center" justify="between" gap="4" wrap className={styles.currentCard}>
+          <Box>
+            <Text as="span" className={styles.currentLabel}>
+              {latest.label}
+            </Text>
+            <Text as="span" className={styles.currentTag}>
+              recommended
+            </Text>
+          </Box>
           <Button asChild>
             <Link to={versionEntryPath(latest)}>Read the docs</Link>
           </Button>
-        </div>
+        </Flex>
 
         {maintained.length > 0 && (
-          <div className={styles.section}>
-            <h2>Maintained versions</h2>
-            <p className={styles.note}>Previous versions still hosted on the site, with full browsable docs.</p>
+          <Box className={styles.section}>
+            <Heading level={2}>Maintained versions</Heading>
+            <Text className={styles.note}>Previous versions still hosted on the site, with full browsable docs.</Text>
             <Table>
               <TableBody>
                 {maintained.map((version) => (
@@ -86,31 +94,31 @@ export default function Versions(): ReactNode {
                 ))}
               </TableBody>
             </Table>
-          </div>
+          </Box>
         )}
 
         {archived.length > 0 && (
-          <div className={styles.section}>
-            <h2>Archived versions</h2>
-            <p className={styles.note}>
+          <Box className={styles.section}>
+            <Heading level={2}>Archived versions</Heading>
+            <Text className={styles.note}>
               No longer hosted - these {archived.length} snapshots redirect to the latest docs, but the original
               markdown is preserved in the repository. Follow a version to read its docs source on GitHub.
-            </p>
+            </Text>
             {majors.map((major) => (
-              <div key={major} className={styles.archivedGroup}>
-                <div className={styles.archivedMajor}>{major}.x</div>
-                <div className={styles.chipGrid}>
+              <Box key={major} className={styles.archivedGroup}>
+                <Text className={styles.archivedMajor}>{major}.x</Text>
+                <Flex wrap gap="2">
                   {archivedByMajor.get(major)!.map((name) => (
-                    <a key={name} className={styles.chip} href={`${VERSIONED_DOCS}/version-${name}`}>
+                    <TextLink key={name} className={styles.chip} href={`${VERSIONED_DOCS}/version-${name}`}>
                       {name}
-                    </a>
+                    </TextLink>
                   ))}
-                </div>
-              </div>
+                </Flex>
+              </Box>
             ))}
-          </div>
+          </Box>
         )}
-      </main>
+      </Box>
     </Layout>
   );
 }

--- a/docs-site/src/theme/Logo/index.tsx
+++ b/docs-site/src/theme/Logo/index.tsx
@@ -1,0 +1,55 @@
+/**
+ * Swizzled `@theme/Logo` — renders the brand mark with FiestaUI's `FiestaIcon`
+ * + `FiestaLogo` instead of a pair of PNG lockups.
+ *
+ * The stock component renders `themeConfig.navbar.logo` through `ThemedImage`,
+ * which meant shipping `logo-lockup-light.png` / `logo-lockup-dark.png` and then
+ * hand-nudging them into alignment in `custom.css`:
+ *
+ *     .navbar__logo img { height: 48px; object-fit: cover;
+ *                         object-position: left 100%; transform: translateY(-8px); }
+ *
+ * …because the raster lockup carried transparent padding above the taco. The DS
+ * components are vector, tint from the theme tokens (so no light/dark pair), and
+ * need no nudging — both the rule and the second image are gone.
+ *
+ * Swizzled here rather than at `@theme/Navbar/Logo` so every call site is
+ * covered: the navbar, the mobile sidebar header, and `DocSidebar/Desktop`
+ * (which renders a logo of its own whenever `navbar.hideOnScroll` is enabled).
+ *
+ * `themeConfig.navbar.logo` is left in place — it is a documented config
+ * surface and Docusaurus reads `logo.href`/`logo.target` — but the `src` /
+ * `srcDark` images are no longer rendered anywhere.
+ */
+
+import Link from "@docusaurus/Link";
+import { useThemeConfig } from "@docusaurus/theme-common";
+import useBaseUrl from "@docusaurus/useBaseUrl";
+import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import { FiestaIcon, FiestaLogo } from "@fiestaboard/ui";
+import type { Props } from "@theme/Logo";
+import clsx from "clsx";
+import type { ReactNode } from "react";
+
+export default function Logo({ className, imageClassName, titleClassName, ...props }: Props): ReactNode {
+  const {
+    siteConfig: { title },
+  } = useDocusaurusContext();
+  const {
+    navbar: { logo },
+  } = useThemeConfig();
+  const logoLink = useBaseUrl(logo?.href || "/");
+
+  return (
+    <Link
+      to={logoLink}
+      aria-label={title}
+      {...(logo?.target && { target: logo.target })}
+      {...props}
+      className={clsx("flex items-center gap-2", className)}
+    >
+      <FiestaIcon size={28} className={imageClassName} />
+      <FiestaLogo size="md" className={clsx("text-foreground", titleClassName)} />
+    </Link>
+  );
+}

--- a/docs-site/src/theme/NotFound/Content/index.tsx
+++ b/docs-site/src/theme/NotFound/Content/index.tsx
@@ -1,0 +1,69 @@
+/**
+ * Swizzled `@theme/NotFound/Content` — the 404 page, rebuilt on FiestaUI's
+ * `EmptyState` (with `Button` CTAs) rather than Infima's bare hero title and
+ * two paragraphs of prose.
+ *
+ * Upstream's second paragraph asks the visitor to contact whoever linked them,
+ * which is not actionable on a docs site that reorganises its own URLs across
+ * versions; the CTAs send them somewhere useful instead. The title and first
+ * paragraph keep the upstream `theme.NotFound.*` ids so existing locale data
+ * still applies; the two button labels are new ids under the same namespace.
+ */
+
+import Link from "@docusaurus/Link";
+import { translate } from "@docusaurus/Translate";
+import useBaseUrl from "@docusaurus/useBaseUrl";
+import { Button, EmptyState } from "@fiestaboard/ui";
+import type { Props } from "@theme/NotFound/Content";
+import clsx from "clsx";
+import { Compass } from "lucide-react";
+import type { ReactNode } from "react";
+
+export default function NotFoundContent({ className }: Props): ReactNode {
+  const homeHref = useBaseUrl("/");
+  const docsHref = useBaseUrl("/docs/intro");
+
+  return (
+    <main className={clsx("container margin-vert--xl", className)}>
+      {/* `EmptyState` is sized for an empty list inside app chrome; a standalone
+          404 needs display sizing. Scaled through the component's own
+          `data-slot` hooks rather than by forking it. */}
+      <EmptyState
+        className="py-16 [&_[data-slot=empty-state-description]]:text-base [&_[data-slot=empty-state-title]]:text-2xl [&_[data-slot=empty-state-title]]:font-semibold"
+        icon={Compass}
+        title={translate({
+          id: "theme.NotFound.title",
+          description: "The title of the 404 page",
+          message: "Page Not Found",
+        })}
+        description={translate({
+          id: "theme.NotFound.p1",
+          description: "The first paragraph of the 404 page",
+          message: "We could not find what you were looking for.",
+        })}
+        action={
+          <div className="flex flex-wrap items-center justify-center gap-2">
+            <Button asChild>
+              <Link to={docsHref} className="no-underline">
+                {translate({
+                  id: "theme.NotFound.cta.docs",
+                  description: "Label for the 404 page button linking to the documentation",
+                  message: "Browse the docs",
+                })}
+              </Link>
+            </Button>
+            <Button asChild variant="outline">
+              <Link to={homeHref} className="no-underline">
+                {translate({
+                  id: "theme.NotFound.cta.home",
+                  description: "Label for the 404 page button returning to the homepage",
+                  message: "Back to home",
+                })}
+              </Link>
+            </Button>
+          </div>
+        }
+      />
+    </main>
+  );
+}

--- a/docs-site/src/theme/PaginatorNavLink/index.tsx
+++ b/docs-site/src/theme/PaginatorNavLink/index.tsx
@@ -1,0 +1,40 @@
+/**
+ * Swizzled `@theme/PaginatorNavLink` — the prev/next tiles at the foot of every
+ * doc page, rebuilt on FiestaUI's `Card` instead of Infima's `.pagination-nav__link`
+ * plus the hand-written border/radius/hover rules that used to live in `custom.css`.
+ *
+ * The Infima placement classes stay: `.pagination-nav` is a two-column grid and
+ * `--prev` / `--next` are what put each tile in its column and align its text.
+ * Only the box treatment moves to the design system, which `custom.css` now
+ * neutralises on the anchor so the `Card` inside owns the border and padding.
+ */
+
+import Link from "@docusaurus/Link";
+import { Card, CardDescription, cn, Text } from "@fiestaboard/ui";
+import type { Props } from "@theme/PaginatorNavLink";
+import type { ReactNode } from "react";
+
+export default function PaginatorNavLink({ permalink, title, subLabel, isNext }: Props): ReactNode {
+  return (
+    <Link
+      className={cn(
+        "pagination-nav__link no-underline",
+        isNext ? "pagination-nav__link--next" : "pagination-nav__link--prev",
+      )}
+      to={permalink}
+    >
+      {/* `Card`'s own `gap-6`/`py-6` are tuned for full content cards; a paginator
+          tile is a two-line label, so it tightens to `gap-1`/`p-4`. */}
+      <Card className="h-full gap-1 p-4 py-4 hover:border-ring">
+        {subLabel && <CardDescription className="text-xs">{subLabel}</CardDescription>}
+        {/* `Text`, not `CardTitle`: `CardTitle` only renders h1-h6, and upstream
+            deliberately uses a plain element here — a prev/next tile is a
+            navigation label, and promoting it would put two extra headings at
+            the foot of every page for anyone navigating by heading. */}
+        <Text as="span" size="base" weight="semibold" className="block">
+          {title}
+        </Text>
+      </Card>
+    </Link>
+  );
+}


### PR DESCRIPTION
Re-opens the Tier 2 work from #1503 against `main`.

#1503 was targeted at `feat-docs-fiestaui-prose` (the Tier 1 branch) as part of a stack. When #1502 squash-merged Tier 1 into `main` and #1503 merged into the prose branch, these four files landed on a branch that `main` had already absorbed by squash — so the chrome changes were never actually reachable from `main`. This is the same commit, cherry-picked onto current `main`; the diff below is only the Tier 2 files.

---

Three pieces of docs chrome were hand-built against Infima while the design system already shipped a component for each.

**Logo.** `@theme/Logo` rendered a pair of PNG lockups through `ThemedImage`, which needed a CSS nudge to look right:

```css
.navbar__logo img { height: 48px; object-fit: cover;
                    object-position: left 100%; transform: translateY(-8px); }
```

That existed to crop transparent padding above the taco in the raster art. Now it renders `FiestaIcon` + `FiestaLogo` — vector, tinted from theme tokens, so one mark covers both themes and the nudge is gone. Swizzled at `Logo` rather than `Navbar/Logo` so the navbar, the mobile sidebar header, and `DocSidebar/Desktop` (rendered when `navbar.hideOnScroll` is on) all agree. `themeConfig.navbar.logo` stays — Docusaurus still reads `href`/`target` from it — but the images are no longer rendered.

**Paginator.** The prev/next tiles keep Infima's `.pagination-nav` grid placement (`--prev` / `--next` are what assign the column and text alignment) and hand their box treatment to `Card`, replacing the bespoke border/radius/hover-ring rules in `custom.css`. The title is a `Text`, not a `CardTitle`: `CardTitle` only renders h1–h6, and upstream deliberately uses a plain element here — promoting a navigation label would put two extra headings at the foot of every page for anyone navigating by heading.

**404.** Rebuilt on `EmptyState` with `Button` CTAs. Upstream's second paragraph tells visitors to contact whoever linked them, which isn't actionable on a docs site that reorganises its own URLs across versions, so two buttons point somewhere useful instead. Title and description keep the upstream `theme.NotFound.*` ids so existing locale data still applies; the button labels are new ids in the same namespace. `EmptyState` is sized for an empty list inside app chrome, so it's scaled up for a standalone page through the component's own `data-slot` hooks rather than by forking it.

Plus a token bridge for Infima's dropdown variables, which the re-skin never covered — the navbar menu panel was still rendering as a default white card in both themes.

## What I deliberately did *not* convert

Four items on the original list are worse as DS components, not better:

- **`ThemeToggle`** — FiestaUI's is a controlled two-state `light | dark` toggle. Docusaurus's is tri-state and includes "system". Swapping it would silently drop a user-facing option, so this is a change to make in FiestaUI first, not here.
- **`Sheet` for the mobile sidebar** — Docusaurus's mobile drawer is wired into the navbar secondary menu, its back-button stack, and focus management. Replacing the container means reimplementing all of that.
- **`DropdownMenu` for the navbar** — Docusaurus's dropdown is SSR-rendered and already hover- and keyboard-managed. `DropdownMenu` is a client-mounted popup; this would be an a11y and no-JS regression. Bridged its tokens instead.
- **`DocCard`** — never renders on this site at all: no sidebar category uses a `generated-index` link, so there are no category index pages. Confirmed against the build output. Converting it would have been dead code, and my original audit was wrong to list it.

## Verification

- `npm run typecheck`, `npm run lint`, `npm run format:check` clean
- `DOCS_PR_MODE=1 npm run build` succeeds
- Checked in the browser in both themes: navbar logo (computed brand/foreground colours per theme, SVG present), paginator tiles at the foot of `/docs/setup/quick-start`, the 404 at an unknown `/docs/*` path, and the open navbar dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)