### PR TITLE
Name each hero board demo (and add a pause control)

### DIFF
--- a/docs-site/src/components/HeroBoard/index.tsx
+++ b/docs-site/src/components/HeroBoard/index.tsx
@@ -1,4 +1,5 @@
-import { ScaledBoardDisplay } from "@fiestaboard/ui";
+import { Button, ScaledBoardDisplay } from "@fiestaboard/ui";
+import { Pause, Play } from "lucide-react";
 import { type ReactNode, useEffect, useRef, useState } from "react";
 
 import styles from "./styles.module.css";
@@ -8,14 +9,15 @@ import styles from "./styles.module.css";
  *
  * Cycles through a mix of the Vestaboard hardware families FiestaBoard supports
  * - Flagship (22×6), Note (15×3), and Note Arrays in several sizes (wide 2×1,
- * tall 1×2, big 2×2) - showing both data dashboards and colorful board art. For
- * each one it:
+ * tall 1×2, big 2×2) - showing data dashboards, colorful board art, and boards
+ * that combine the two. Each one is captioned with what it is showing (`title`)
+ * over what it is running on (`label`). For each board it:
  *   1. fades the previous board out,
  *   2. swaps to the new device (the grid-size change is hidden by the fade),
  *   3. fades the new board in while its contents flap in - every cell cycles
  *      through random values and settles on a staggered per-cell frame,
- *      left-to-right / top-to-bottom, like a real split-flap board. Text boards
- *      flap through glyphs; art boards flap through colors.
+ *      left-to-right / top-to-bottom, like a real split-flap board. Character
+ *      cells flap through glyphs; color tiles flap through colors.
  *
  * The flap is driven here (not FiestaUI's native board animation, which is
  * wired to the loading state) so it fires reliably on load and every cycle.
@@ -26,12 +28,16 @@ import styles from "./styles.module.css";
  * `prefers-reduced-motion`: no scramble, no fade - the message is set directly.
  */
 type BoardConfig = {
-  kind: "text" | "art";
   deviceType: "flagship" | "note" | "note_array";
+  /** What the board is showing, e.g. "Market Movers". */
+  title: string;
+  /** What it is running on, e.g. "Flagship · 22 × 6". */
   label: string;
   message: string;
   notesWide?: number;
   notesTall?: number;
+  /** Eligible to be the first board shown on load. See `pickOpener`. */
+  opener?: boolean;
 };
 
 const GLYPHS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 .-:%";
@@ -58,69 +64,129 @@ function diagonalGradient(rows: number, cols: number, palette: string[]): string
   return lines.join("\n");
 }
 
+/**
+ * The rotation, ordered so a text-heavy board never follows another one.
+ * Color tiles (`{green}`) count as one cell each, so rows that mix tiles and
+ * text still have to fit the device width: 22 cells on Flagship, 15 on Note.
+ */
 const BOARDS: BoardConfig[] = [
   {
-    kind: "text",
     deviceType: "flagship",
+    title: "Morning Dashboard",
     label: "Flagship · 22 × 6",
     message:
       "GOOD MORNING SF\n62F CLEAR   UV 4\nN JUDAH OB   4 MIN\nAAPL 232.10  +1.24%\nOCEAN BEACH 3-4 FT\nHAVE A GREAT DAY",
   },
   {
-    kind: "art",
     deviceType: "flagship",
+    title: "Market Movers",
+    label: "Flagship · 22 × 6",
+    opener: true,
+    message:
+      "MARKET MOVERS\n{green}AAPL  232.10  +1.24%\n{green}NVDA  121.44  +0.86%\n{red}TSLA  244.90  -2.10%\n{red}BTC   61,204  -1.40%\n{green}S+P   5,712   +0.42%",
+  },
+  {
+    deviceType: "flagship",
+    title: "Sunset Gradient",
     label: "Sun Art · 22 × 6",
     message: diagonalGradient(6, 22, SUNSET),
   },
   {
-    kind: "text",
+    deviceType: "flagship",
+    title: "Weekly Forecast",
+    label: "Flagship · 22 × 6",
+    opener: true,
+    message:
+      "SF FORECAST\nMON {yellow} SUNNY     68 54\nTUE {blue} RAIN      61 52\nWED {violet} FOG       59 51\nTHU {yellow} SUNNY     70 55\nFRI {orange} HOT       78 58",
+  },
+  {
     deviceType: "note",
+    title: "Daily Briefing",
     label: "Note · 15 × 3",
     message: "N JUDAH  4 MIN\nAAPL 232  +1.2%\n62F SUNNY   SF",
   },
   {
-    kind: "text",
+    deviceType: "note",
+    title: "Game Day",
+    label: "Note · 15 × 3",
+    message: "{orange}SF 24  {red}LA 17\n4TH QTR   2:41\n{orange}SF BALL 1ST+10",
+  },
+  {
     deviceType: "note_array",
     notesWide: 2,
     notesTall: 1,
+    title: "Transit + Markets",
     label: "Note Array · 2 × 1",
-    message: "MUNI N JUDAH 4MIN   BART  9 MIN\nAAPL 232 +1.2%   NVDA 121 -0.9%\nOCEAN BEACH 3-4FT   UV INDEX 4",
+    // A 2 × 1 array is two 15-col Notes side by side, so each half is laid out
+    // to its own 15 cells, with a blank column either side of the seam so the
+    // two halves read as separate panels. (The rows this replaced were 31 cells
+    // wide and lost their last character off the edge of the grid.)
+    message: [
+      "N JUDAH  4 MIN " + " BART    9 MIN",
+      "AAPL 232 +1.2% " + " NVDA 121 -0.9%",
+      "SURF OB 3-4 FT " + " UV INDEX    4",
+    ].join("\n"),
   },
   {
-    kind: "art",
     deviceType: "note_array",
     notesWide: 1,
     notesTall: 2,
+    title: "Sunrise Column",
     label: "Note Array · 1 × 2 (tall)",
     message: verticalGradient(15, ["{yellow}", "{orange}", "{orange}", "{red}", "{violet}", "{blue}"]),
   },
   {
-    kind: "art",
     deviceType: "note_array",
     notesWide: 2,
     notesTall: 2,
+    title: "Rainbow Wash",
     label: "Note Array · 2 × 2",
     message: diagonalGradient(6, 30, RAINBOW),
   },
 ];
+
+/**
+ * Nine boards at ROTATE_MS each is a ~43s loop - longer than most visitors
+ * stay - so start somewhere random rather than always on board 0. Openers are
+ * limited to the full-size boards that show data and color at once, which is
+ * the strongest first impression. Safe to randomize: this component only ever
+ * renders in the browser (<BrowserOnly>), so there is no SSR markup to match.
+ */
+function pickOpener(): number {
+  const openers = BOARDS.map((board, i) => (board.opener ? i : -1)).filter((i) => i >= 0);
+  return openers[Math.floor(Math.random() * openers.length)];
+}
 
 const ROTATE_MS = 4800; // time each board is shown
 const FADE_MS = 380; // fade-out before swapping devices
 const FRAME_MS = 45; // scramble frame interval
 
 /**
+ * Split a row into board cells the way FiestaUI's renderer does: a `{color}`
+ * token is one cell (a color tile), every other character is one cell. Lets a
+ * single board mix data and color - `{green}AAPL 232.10` is one tile plus text.
+ *
+ * Closing tags (`{/red}`) render as zero cells and so would throw the cell
+ * count off here; the boards above use bare color tiles only.
+ */
+function toCells(row: string): string[] {
+  return row.match(/\{[^}]+\}|[\s\S]/g) ?? [];
+}
+
+/**
  * Run the split-flap scramble for a board, calling `onFrame` with each frame.
  * Cell (row r, col c) locks to its final value at frame
- * 4 + c*0.8 + r*1.6 + rand(0..7); until then it shows a random value - a glyph
- * for text boards, a color tile for art boards. Returns the interval id.
+ * 4 + c*0.8 + r*1.6 + rand(0..7); until then it shows a random value of its own
+ * kind - color tiles flap through colors, characters through glyphs. Returns
+ * the interval id.
  */
 function runScramble(board: BoardConfig, onFrame: (frame: string) => void): ReturnType<typeof setInterval> {
-  const art = board.kind === "art";
-  // Split each row into cells: color tokens (`{red}`) for art, characters for text.
-  const rows = board.message.split("\n").map((row) => (art ? (row.match(/\{[^}]+\}/g) ?? []) : Array.from(row)));
+  const rows = board.message.split("\n").map(toCells);
   const settleAt = rows.map((cells, ri) => cells.map((_, ci) => 4 + ci * 0.8 + ri * 1.6 + Math.random() * 7));
-  const randomCell = () =>
-    art ? COLORS[Math.floor(Math.random() * COLORS.length)] : GLYPHS[Math.floor(Math.random() * GLYPHS.length)];
+  const randomCell = (cell: string) =>
+    cell.startsWith("{")
+      ? COLORS[Math.floor(Math.random() * COLORS.length)]
+      : GLYPHS[Math.floor(Math.random() * GLYPHS.length)];
 
   let frame = 0;
   const render = () => {
@@ -132,7 +198,7 @@ function runScramble(board: BoardConfig, onFrame: (frame: string) => void): Retu
           .map((cell, ci) => {
             if (frame >= settleAt[ri][ci]) return cell;
             done = false;
-            return randomCell();
+            return randomCell(cell);
           })
           .join(""),
       )
@@ -148,12 +214,17 @@ function runScramble(board: BoardConfig, onFrame: (frame: string) => void): Retu
   return interval;
 }
 
-export default function HeroBoard(): ReactNode {
-  const [shown, setShown] = useState(0);
-  const [message, setMessage] = useState(BOARDS[0].message);
-  const [visible, setVisible] = useState(true);
+function prefersReducedMotion(): boolean {
+  return window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+}
 
-  const shownRef = useRef(0);
+export default function HeroBoard(): ReactNode {
+  const [shown, setShown] = useState(pickOpener);
+  const [message, setMessage] = useState(() => BOARDS[shown].message);
+  const [visible, setVisible] = useState(true);
+  const [paused, setPaused] = useState(false);
+
+  const shownRef = useRef(shown);
   const scrambleTimer = useRef<ReturnType<typeof setInterval> | undefined>(undefined);
   const fadeTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const cycleTimer = useRef<ReturnType<typeof setInterval> | undefined>(undefined);
@@ -162,20 +233,18 @@ export default function HeroBoard(): ReactNode {
     shownRef.current = shown;
   }, [shown]);
 
+  // The opening board flaps in on load.
   useEffect(() => {
-    const reduceMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+    if (prefersReducedMotion()) return;
+    scrambleTimer.current = runScramble(BOARDS[shownRef.current], setMessage);
+    return () => clearInterval(scrambleTimer.current);
+  }, []);
 
-    const flapIn = (n: number) => {
-      clearInterval(scrambleTimer.current);
-      if (reduceMotion) {
-        setMessage(BOARDS[n].message);
-        return;
-      }
-      scrambleTimer.current = runScramble(BOARDS[n], setMessage);
-    };
+  // The rotation itself, torn down and rebuilt when the user pauses/resumes.
+  useEffect(() => {
+    if (paused) return;
 
-    // First board flaps in on load.
-    flapIn(0);
+    const reduceMotion = prefersReducedMotion();
 
     cycleTimer.current = setInterval(() => {
       const next = (shownRef.current + 1) % BOARDS.length;
@@ -189,16 +258,19 @@ export default function HeroBoard(): ReactNode {
       fadeTimer.current = setTimeout(() => {
         setShown(next); // swap device (hidden by the fade)
         setVisible(true); // fade the new one in
-        flapIn(next); // flap the new contents in
+        clearInterval(scrambleTimer.current);
+        scrambleTimer.current = runScramble(BOARDS[next], setMessage); // flap the new contents in
       }, FADE_MS);
     }, ROTATE_MS);
 
     return () => {
-      clearInterval(scrambleTimer.current);
       clearInterval(cycleTimer.current);
+      // Pausing mid-fade would otherwise strand the board half-faded, since the
+      // timeout that fades it back in never fires.
       clearTimeout(fadeTimer.current);
+      setVisible(true);
     };
-  }, []);
+  }, [paused]);
 
   const board = BOARDS[shown];
 
@@ -215,8 +287,23 @@ export default function HeroBoard(): ReactNode {
           animationsEnabled={false}
         />
       </div>
-      <div className={styles.caption} data-visible={visible}>
-        {board.label}
+      <div className={styles.captionRow}>
+        <div className={styles.caption} data-visible={visible}>
+          <div className={styles.captionTitle}>{board.title}</div>
+          <div className={styles.captionMeta}>{board.label}</div>
+        </div>
+        {/* WCAG 2.2.2 (Pause, Stop, Hide): the rotation runs indefinitely, so it
+            needs a control to stop it. Always visible - a hover-only control is
+            unreachable by keyboard and touch users. */}
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          className={styles.pauseButton}
+          onClick={() => setPaused((p) => !p)}
+          aria-label={paused ? "Resume board rotation" : "Pause board rotation"}
+        >
+          {paused ? <Play aria-hidden="true" /> : <Pause aria-hidden="true" />}
+        </Button>
       </div>
     </div>
   );

--- a/docs-site/src/components/HeroBoard/styles.module.css
+++ b/docs-site/src/components/HeroBoard/styles.module.css
@@ -5,11 +5,14 @@
  */
 .stage {
   width: 100%;
-  /* Tall enough for the tallest board (the narrow 1×2 note array renders at
-     natural height rather than being width-scaled down). Below ~630px the
-     boards fit-scale with the viewport (tallest ≈ 50vw), so scale the reserve
-     down too instead of holding ~200px of blank space on phones. */
-  min-height: min(360px, 57vw);
+  /* Tall enough for the tallest board plus the caption (the narrow 1×2 note
+     array renders at natural height rather than being width-scaled down), so
+     the stage is the same height on every board and the hero never shifts as
+     it cycles. Below ~630px the boards fit-scale with the viewport (tallest
+     ≈ 50vw), so scale the reserve down too instead of holding ~200px of blank
+     space on phones. Kept in sync with .heroBoardFallback in
+     src/pages/index.module.css, which reserves this height before hydration. */
+  min-height: min(409px, 57vw + 49px);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -36,14 +39,43 @@
   transform: scale(0.985);
 }
 
+/* Caption plus the pause control. Only the caption fades with the board - the
+   control stays put so it is never mid-fade when someone reaches for it. */
+.captionRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* This stylesheet is compiled without Tailwind's preflight (see
+   css/fiestaui.src.css), so a bare <button> keeps the browser's default border
+   and background. Set them from tokens rather than inheriting the UA's - the
+   outline is worth keeping, it makes the control easier to spot. */
+.pauseButton {
+  color: var(--muted-foreground);
+  background: transparent;
+  border: 1px solid var(--border);
+}
+
+/* Two lines: what the board is showing, over what it is running on. */
 .caption {
   font-family: var(--font-geist-mono);
-  font-size: 12px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--muted-foreground);
+  text-align: center;
   opacity: 1;
   transition: opacity 380ms ease;
+}
+
+.captionTitle {
+  font-size: 14px;
+  color: var(--foreground);
+}
+
+.captionMeta {
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--muted-foreground);
 }
 
 .caption[data-visible="false"] {
@@ -57,7 +89,9 @@
   }
 }
 
-/* Hide the Fit/Actual toggle ScaledBoardDisplay renders for note-array boards -    the hero always uses fit mode. */
-.stage button {
+/* Hide the Fit/Actual toggle ScaledBoardDisplay renders for note-array boards -
+   the hero always uses fit mode. Scoped to .frame so it does not also hide the
+   pause control in the caption row. */
+.frame button {
   display: none;
 }

--- a/docs-site/src/pages/index.module.css
+++ b/docs-site/src/pages/index.module.css
@@ -73,6 +73,6 @@
    shift when the client-only <HeroBoard> mounts. */
 .heroBoardFallback {
   width: 100%;
-  /* Match .stage's responsive min-height (+ gap and caption). */
-  min-height: min(392px, 57vw + 32px);
+  /* Match .stage's responsive min-height (+ gap and the two-line caption). */
+  min-height: min(409px, 57vw + 49px);
 }

--- a/docs/superpowers/specs/2026-08-05-hero-board-titles-design.md
+++ b/docs/superpowers/specs/2026-08-05-hero-board-titles-design.md
@@ -38,10 +38,17 @@ change to the fade logic. The caption is not a live region: it is plain text
 that changes every few seconds, and announcing each change would spam screen
 readers for content that is decorative on a marketing page.
 
-**Layout shift:** the extra line makes the stage taller. `.stage`'s
-`min-height` reserve and `.heroBoardFallback`'s matching reserve in
-`src/pages/index.module.css` both grow by one line-height (~18px), keeping the
-pre-hydration placeholder the same height as the mounted component.
+**Layout shift:** the extra line makes the stage taller, and the two reserves
+that keep the hero from shifting — `.stage`'s `min-height` and
+`.heroBoardFallback`'s pre-hydration placeholder in `src/pages/index.module.css`
+— have to grow with it.
+
+Rather than re-estimate them, both are set to the measured height of the
+tallest board plus the two-line caption: `min(409px, 57vw + 49px)`. Previously
+they disagreed (360px vs 392px), so the hero shrank on hydration and grew again
+whenever the tall 1×2 array came around. With both at the same value the stage
+is the same height on all nine boards and matches the placeholder exactly, so
+the hero never shifts at all.
 
 ### 2. Three data-and-color boards
 
@@ -100,6 +107,12 @@ FRI {orange} HOT       78 58
 {orange}SF BALL 1ST+10
 ```
 
+**Existing board fixed in passing.** Checking every row against its grid turned
+up a pre-existing overflow: Transit + Markets had 31-cell rows on a 30-cell
+grid, so two of its three rows lost their last character (`BART 9 MI`,
+`-0.9`). A 2 × 1 array is two 15-column Notes side by side, so its content is
+relaid to 15 cells per half with a blank column either side of the seam.
+
 ### 3. Random colorful opener
 
 Nine boards at 4.8s each is a 43-second loop — longer than most visitors stay,
@@ -130,6 +143,38 @@ field disappears from `BoardConfig` entirely.
 The staggered settle timing (`4 + col * 0.8 + row * 1.6 + rand(0..7)` frames)
 is unchanged.
 
+### 5. Pause control (WCAG 2.2.2)
+
+The rotation starts on load and runs indefinitely, which fails WCAG 2.2.2
+(Pause, Stop, Hide): any automatically moving or auto-updating content lasting
+more than five seconds needs a mechanism to pause it. Today there is none.
+
+A pause/resume toggle sits next to the caption, below the board:
+
+- A real `<button>` (FiestaUI `Button`, `variant="ghost"`, `size="icon-sm"` —
+  32px, above the 24px WCAG 2.5.8 target minimum), so it is keyboard-focusable
+  and gets the design system's focus ring for free
+- Always visible. A control revealed only on hover is unreachable by keyboard
+  and touch users, which would not satisfy 2.2.2
+- Lucide `Pause`/`Play` icon, `aria-hidden`, with the accessible name carried
+  by `aria-label` — "Pause board rotation" / "Resume board rotation". The label
+  changes with state, so no `aria-pressed` (which would double-announce it)
+- It does not fade with the board: only the caption text is inside the fading
+  element, so the control is never mid-fade when someone reaches for it
+
+Clicking the board itself was considered and rejected — a clickable `div` is
+not focusable or announced, and making the board a `<button>` would wrap a grid
+of content in an interactive element.
+
+Implementation: the single mount effect splits in two — one that flaps the
+opening board in, and one that owns the rotation interval and re-runs on
+`paused`. Pausing mid-fade clears the pending fade-in timeout, so its cleanup
+also restores `visible`, otherwise the board would be stranded half-faded.
+
+One CSS knock-on: `.stage button { display: none }` (which hides the Fit/Actual
+toggle `ScaledBoardDisplay` renders for note arrays) would hide the pause
+button too. It narrows to `.frame button`.
+
 ## Testing
 
 `docs-site` has no test runner. Verification is:
@@ -140,6 +185,8 @@ is unchanged.
   caption, that no row overflows its grid, and that the mixed boards scramble
   through colors rather than glyph garbage
 - Reduced-motion path: message set directly, caption still correct
+- Pause control: keyboard-reachable, toggles the rotation, label flips, and
+  pausing mid-fade leaves the board fully visible
 
 Per the repo's container rules, all of this runs in a throwaway node container
 rather than installing `docs-site` dependencies on the host.

--- a/docs/superpowers/specs/2026-08-05-hero-board-titles-design.md
+++ b/docs/superpowers/specs/2026-08-05-hero-board-titles-design.md
@@ -1,0 +1,152 @@
+# Hero board: name what you're looking at
+
+**Date:** 2026-08-05
+**Component:** `docs-site/src/components/HeroBoard/`
+
+## Problem
+
+The homepage hero cycles through six boards — dashboards and color art across
+Flagship, Note, and three Note Array sizes. It captions each one with the
+hardware only: `Flagship · 22 × 6`, `Note Array · 2 × 1`. A visitor can tell
+what device they're looking at but never what it is *showing*. A diagonal
+sunset gradient arrives with no explanation of what it is or why FiestaBoard
+can draw it.
+
+Separately, the rotation splits cleanly into "text boards" and "art boards".
+Nothing demonstrates the more interesting case: data and color on the same
+board.
+
+## Design
+
+### 1. Two-line caption
+
+The caption becomes a title plus the existing device string:
+
+```
+      MORNING DASHBOARD      ← what you're looking at
+      Flagship · 22 × 6      ← hardware, smaller and muted
+```
+
+`BoardConfig` gains a `title` field. The existing `label` field keeps its
+current job (device and size) and its current styling — 12px mono, uppercase,
+tracked, `--muted-foreground`. The title renders above it at 14px in
+`--foreground`, same mono/uppercase/tracked treatment, so the pair reads as one
+block with a clear hierarchy.
+
+Both lines live in the existing `.caption` element and fade with it, so no
+change to the fade logic. The caption is not a live region: it is plain text
+that changes every few seconds, and announcing each change would spam screen
+readers for content that is decorative on a marketing page.
+
+**Layout shift:** the extra line makes the stage taller. `.stage`'s
+`min-height` reserve and `.heroBoardFallback`'s matching reserve in
+`src/pages/index.module.css` both grow by one line-height (~18px), keeping the
+pre-hydration placeholder the same height as the mounted component.
+
+### 2. Three data-and-color boards
+
+FiestaUI's parser (`board-characters.ts`, `parseLine`) emits each `{color}`
+token as a single cell and ignores closing tags, so a color tile can sit inline
+anywhere in a row of text. That is enough to build hybrid boards with no
+FiestaUI change.
+
+Final rotation, ordered so a text-heavy board never follows another one:
+
+| # | Title | Device | Kind |
+|---|-------|--------|------|
+| 1 | Morning Dashboard | Flagship 22×6 | text |
+| 2 | Market Movers | Flagship 22×6 | **new** — data + color |
+| 3 | Sunset Gradient | Flagship 22×6 | art |
+| 4 | Weekly Forecast | Flagship 22×6 | **new** — data + color |
+| 5 | Daily Briefing | Note 15×3 | text |
+| 6 | Game Day | Note 15×3 | **new** — data + color |
+| 7 | Transit + Markets | Note Array 2×1 | text |
+| 8 | Sunrise Column | Note Array 1×2 | art |
+| 9 | Rainbow Wash | Note Array 2×2 | art |
+
+Board content (`{tile}` counts as one cell; all glyphs used — `+ - % , . :` —
+are in `BOARD_CHARS`):
+
+**Market Movers** (Flagship, 22 cols). Green and red tiles gutter the board so
+direction reads before the numbers do; price and change columns align across
+rows.
+
+```
+MARKET MOVERS
+{green}AAPL  232.10  +1.24%
+{green}NVDA  121.44  +0.86%
+{red}TSLA  244.90  -2.10%
+{red}BTC   61,204  -1.40%
+{green}S+P   5,712   +0.42%
+```
+
+**Weekly Forecast** (Flagship, 22 cols). One condition tile per day — yellow
+sun, blue rain, violet fog, orange heat.
+
+```
+SF FORECAST
+MON {yellow} SUNNY     68 54
+TUE {blue} RAIN      61 52
+WED {violet} FOG       59 51
+THU {yellow} SUNNY     70 55
+FRI {orange} HOT       78 58
+```
+
+**Game Day** (Note, 15 cols). Team-color tiles against the score.
+
+```
+{orange}SF 24  {red}LA 17
+4TH QTR   2:41
+{orange}SF BALL 1ST+10
+```
+
+### 3. Random colorful opener
+
+Nine boards at 4.8s each is a 43-second loop — longer than most visitors stay,
+so the rotation starts at a random index instead of always at board 1. The
+start is drawn only from boards flagged `opener: true`: **Market Movers** and
+**Weekly Forecast**. Both are Flagship-sized and show data and color at once,
+which is the strongest first impression. Game Day is colorful but renders on
+the small 15×3 Note grid, so it is not an opener. From there the rotation
+proceeds in table order and wraps.
+
+Randomizing is safe because `HeroBoard` renders inside `<BrowserOnly>` — there
+is no server-rendered markup to mismatch.
+
+### 4. Scramble handles mixed cells
+
+`runScramble` currently branches on a per-board `kind: "text" | "art"` field:
+art rows are split with `row.match(/\{[^}]+\}/g)`, text rows with
+`Array.from(row)`. A mixed board breaks both paths — as text, `{red}` shreds
+into six cells that flap through garbage glyphs and briefly render as literal
+`{`, `r`, `e` characters.
+
+Replace both with one tokenizer that walks a row emitting `{...}` as a single
+cell and every other character as its own cell. Each cell then scrambles
+through values of its own type: color cells flap through colors, character
+cells flap through glyphs. Mixed boards need no special case, and the `kind`
+field disappears from `BoardConfig` entirely.
+
+The staggered settle timing (`4 + col * 0.8 + row * 1.6 + rand(0..7)` frames)
+is unchanged.
+
+## Testing
+
+`docs-site` has no test runner. Verification is:
+
+- `npm run typecheck`, `npm run lint`, `npm run format:check`
+- `npm run build` — the production Docusaurus build
+- Screenshots of all nine boards from a local dev server, confirming each
+  caption, that no row overflows its grid, and that the mixed boards scramble
+  through colors rather than glyph garbage
+- Reduced-motion path: message set directly, caption still correct
+
+Per the repo's container rules, all of this runs in a throwaway node container
+rather than installing `docs-site` dependencies on the host.
+
+## Out of scope
+
+- Plugin cards further down the homepage — they already carry names and
+  descriptions
+- `BoardScreenshot` in the plugin docs pages — static images with alt text
+- Any FiestaUI change


### PR DESCRIPTION
## Why

The homepage hero cycles through boards captioned with the hardware only — `Flagship · 22 × 6`, `Note Array · 2 × 1`. You can tell what device you're looking at, but never what it's *showing*. A diagonal sunset gradient just arrives, unexplained.

## What changed

**Every board now says what it is,** over what it runs on:

```
      MARKET MOVERS
      Flagship · 22 × 6
```

**Three new boards put data and color together** instead of splitting the rotation into "text boards" and "art boards". FiestaUI's parser emits each `{color}` token as one cell, so tiles sit inline with text — no FiestaUI change needed:

| Title | Device | |
|---|---|---|
| Morning Dashboard | Flagship | |
| **Market Movers** | Flagship | new — green/red tiles per ticker |
| Sunset Gradient | Flagship | |
| **Weekly Forecast** | Flagship | new — a condition tile per day |
| Daily Briefing | Note | |
| **Game Day** | Note | new — team-color tiles |
| Transit + Markets | Note Array 2×1 | |
| Sunrise Column | Note Array 1×2 | |
| Rainbow Wash | Note Array 2×2 | |

**The rotation opens on a random colorful data board** (Market Movers or Weekly Forecast). Nine boards is a ~43s loop, longer than most visitors stay, so it no longer always starts in the same place. Safe to randomize — the component is `<BrowserOnly>`, so there's no SSR markup to mismatch.

**A pause/resume control** — the rotation runs indefinitely with no way to stop it, which fails WCAG 2.2.2 (Pause, Stop, Hide). It's a real `<button>` (32px, above the 2.5.8 target minimum), always visible rather than hover-only so keyboard and touch users can reach it, labelled "Pause board rotation" / "Resume board rotation". It sits outside the fading element so it's never mid-fade when you reach for it.

## Two bugs found while verifying

- **Transit + Markets overflowed its grid** — 31-cell rows on a 30-cell grid, silently dropping the last character of two rows (`BART  9 MI`, `-0.9`). A 2×1 array is two 15-column Notes side by side, so its content is relaid to 15 cells per half with a blank column either side of the seam.
- **The hero shifted on load** — `.stage`'s height reserve (360px) disagreed with the pre-hydration placeholder (392px). Both are now set to the measured height of the tallest board plus caption, so the stage is identical on all nine boards and matches the placeholder exactly.

## Verification

`typecheck`, `lint`, `format:check` and the production `build` all pass (run in a container, per the repo's no-host-installs rule). Against the built site:

- All nine boards cycle, each with the right caption
- Every row fits its grid — checked cell-by-cell with `{color}` counted as one cell
- Opener landed on a colorful data board on 8/8 loads
- Pause stops the rotation and holds; Tab reaches the button with a visible focus ring, Enter toggles it, label flips
- `prefers-reduced-motion`: message set directly with no scramble, pause still works
- Light and dark themes; 1280px and 390px wide, no horizontal overflow
- Stage height identical across all nine boards at both widths, matching the placeholder exactly (409px / 262.75px) — zero layout shift

Design doc: `docs/superpowers/specs/2026-08-05-hero-board-titles-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)