### PR TITLE
fix(docs-site): import Box in HeroBoard so the homepage stops crashing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,6 +372,15 @@ jobs:
       working-directory: docs-site
       run: npm run lint
 
+    # A green `Build Docs` is not proof the site runs. Docusaurus prerenders
+    # at build time, so anything inside <BrowserOnly> is never evaluated and a
+    # broken reference in one of those components ships silently (a missing
+    # `Box` import in HeroBoard took the homepage down in prod this way).
+    # tsc sees the whole tree, so it catches what the build cannot.
+    - name: Typecheck
+      working-directory: docs-site
+      run: npm run typecheck
+
     - name: Prettier check
       working-directory: docs-site
       run: npm run format:check

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -102,15 +102,6 @@ jobs:
 
       # --- Build (always) ---
 
-      # A green build is not proof the site runs. Docusaurus prerenders at
-      # build time, so anything inside <BrowserOnly> is never evaluated and a
-      # broken reference in one of those components ships silently (a missing
-      # `Box` import in HeroBoard took the homepage down in prod this way).
-      # tsc sees the whole tree, so it catches what the build cannot.
-      - name: Typecheck
-        working-directory: docs-site
-        run: npm run typecheck
-
       - name: Build Docusaurus site
         working-directory: docs-site
         run: npm run build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -102,6 +102,15 @@ jobs:
 
       # --- Build (always) ---
 
+      # A green build is not proof the site runs. Docusaurus prerenders at
+      # build time, so anything inside <BrowserOnly> is never evaluated and a
+      # broken reference in one of those components ships silently (a missing
+      # `Box` import in HeroBoard took the homepage down in prod this way).
+      # tsc sees the whole tree, so it catches what the build cannot.
+      - name: Typecheck
+        working-directory: docs-site
+        run: npm run typecheck
+
       - name: Build Docusaurus site
         working-directory: docs-site
         run: npm run build

--- a/docs-site/src/components/HeroBoard/index.tsx
+++ b/docs-site/src/components/HeroBoard/index.tsx
@@ -1,4 +1,4 @@
-import { Button, ScaledBoardDisplay, Text } from "@fiestaboard/ui";
+import { Box, Button, ScaledBoardDisplay, Text } from "@fiestaboard/ui";
 import { Pause, Play } from "lucide-react";
 import { type ReactNode, useEffect, useRef, useState } from "react";
 


### PR DESCRIPTION
## Description

The docs-site homepage crashed on load in production with `ReferenceError: Box is not defined`.

`docs-site/src/components/HeroBoard/index.tsx` used `<Box>` at four call sites but never imported it. #1505 migrated docs-site's raw elements onto FiestaUI primitives and converted HeroBoard's wrappers to `Box`, but missed the import line:

```ts
import { Button, ScaledBoardDisplay, Text } from "@fiestaboard/ui";   // no Box
```

`Box` **is** exported by the vendored `@fiestaboard/ui@1.1.0` tarball (confirmed by unpacking it), so this was never a design-system or packaging problem — just a missing import in the consumer.

### Why CI was green

`HeroBoard` renders inside `<BrowserOnly>` (`src/pages/index.tsx:38`), so Docusaurus never prerenders it and `Build Docs` cannot reach the broken code. Nothing else in the docs pipeline typechecked. The error only fired at hydration, in the browser, after deploy.

Verified end to end by building both trees and loading each in Chromium:

| | pre-fix | fixed |
|---|---|---|
| `npm run build` | **succeeds** | succeeds |
| console | `ReferenceError: Box is not defined` | clean |
| hero board | 0 elements | 685 |
| pause control | absent | present |
| body text | 489 chars | 4925 chars |

The pre-fix build succeeding is the whole story — that is exactly what CI saw.

### Changes

1. `docs-site/src/components/HeroBoard/index.tsx` — add `Box` to the `@fiestaboard/ui` import.
2. `.github/workflows/ci.yml` — add a `Typecheck` step to the `lint-docs` job. `tsc` flags all four call sites on the pre-fix tree, so it catches the class of bug the build structurally cannot.

On the second commit: the typecheck first went into `docs.yml`, which only runs on push to main and workflow_dispatch — it is the deploy workflow, so it would have failed the deploy *after* the broken commit landed. It now lives in `ci.yml`, which covers `pull_request`, push to main/develop, and `merge_group`, so the check blocks the merge instead. `lint-docs` already installs docs-site for eslint/prettier, and its `docs` path filter is `docs-site/**`, so the job fires on exactly the changes that can trigger this.

The rest of docs-site was swept for the same mistake; HeroBoard was the only real instance (a static check flagged four others, all false positives: destructured locals and TS generics).

Note that touching `ci.yml` puts this PR in the `shared` path filter, so the full job matrix runs here rather than just the docs jobs.

## Related Issue

N/A — reported directly.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] New plugin
- [ ] Documentation update
- [ ] Refactor / maintenance

## Checklist

- [x] I have tested my changes locally
- [ ] I have added/updated tests where applicable — no test added; the `Typecheck` step in `lint-docs` is the regression guard for this class of bug
- [ ] I have updated documentation where applicable — not applicable
- [x] My code follows the project's coding standards

`npm run typecheck`, `npm run lint`, `npm run format:check`, and `npm run build` are all clean on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y5arHMHkTN2YdZSjJJbvm4