### PR TITLE
test(ingress): retry lazy-route nav until the route actually renders

### DIFF
--- a/web/tests/ingress.spec.ts
+++ b/web/tests/ingress.spec.ts
@@ -109,6 +109,10 @@ test.describe("HA Ingress", () => {
     // runtime preload helper, which used to build root-absolute
     // `/assets/...` URLs that bypassed the prefix and 404'd against the
     // Home Assistant origin.
+    // Two retried navigations on a loaded-from-cold container don't fit in
+    // the 30s default; the retries below need room to actually retry.
+    test.setTimeout(90_000);
+
     const { escapes, notFound } = trackIngressViolations(page);
 
     await page.goto(`${PREFIX}/`);
@@ -119,18 +123,21 @@ test.describe("HA Ingress", () => {
       ["Settings", "Settings", "settings"],
     ] as const) {
       // The click can land before the app is interactive — the dashboard is
-      // still fetching its board display at this point — and a swallowed
-      // click leaves us on the previous route with no navigation at all.
-      // Retry the click until the URL actually changes, so that a genuinely
-      // broken lazy chunk still fails below (on the heading + violation
-      // assertions) rather than being masked, and vice versa: a lost click
-      // no longer masquerades as a chunk failure.
+      // still fetching its board display at this point — and a half-landed
+      // click leaves the app on the previous route. That shows up two ways:
+      // no navigation at all, and — seen in CI — the URL swapping to
+      // `/pages` while the DOM keeps rendering the dashboard indefinitely,
+      // i.e. the router committed the history entry but React never
+      // committed the route. Waiting on the URL alone only catches the
+      // first, so retry the click until the route has actually *rendered*.
+      // A genuinely broken lazy chunk still fails: the heading never
+      // appears however many times we click, and the violation assertions
+      // below are untouched.
       await expect(async () => {
         await page.getByRole("link", { name: link }).first().click();
         await page.waitForURL(`**${PREFIX}/${path}`, { timeout: 5_000 });
-      }).toPass({ timeout: 20_000 });
-
-      await expect(page.getByRole("heading", { name: heading, exact: true })).toBeVisible({ timeout: 15_000 });
+        await expect(page.getByRole("heading", { name: heading, exact: true })).toBeVisible({ timeout: 10_000 });
+      }).toPass({ timeout: 30_000 });
     }
 
     expect(escapes, "lazy-route requests must stay under the ingress prefix").toEqual([]);


### PR DESCRIPTION
## What

The HA Ingress `lazy-route navigation stays under the prefix` test flaked on [PR #1508](https://github.com/Fiestaboard/FiestaBoard/pull/1508) — a pure `@fiestaboard/ui` version bump with no app-code changes. A re-run of the same commit went green, so the bump was never at fault.

## The failure mode

The failure artifact shows the URL already at `…/pages` (so `waitForURL` had passed) while the DOM still rendered the **dashboard** 15s later: the router committed the history entry but React never committed the route. The click-retry added in #1498 can't catch that — it only waits on the URL, so a half-landed click gets reported as a broken lazy chunk.

Two secondary problems made it worse:

- the retry budget (20s `toPass` + 15s heading wait) exceeded the 30s default test timeout, so the retries were being clipped before they could retry.

## The fix

- Fold the heading assertion **into** the `toPass` block, so the retry condition is "the route rendered", not "the URL changed" — a half-landed click gets re-clicked.
- `test.setTimeout(90_000)` so two retried navigations actually fit.

The test keeps its teeth: a genuinely broken lazy chunk never renders the heading however many times we click, and the prefix-escape / 404 assertions are untouched.

## Verification

Built the production image (`--target runtime`) and ran the spec behind the HA Ingress simulator locally:

- `--repeat-each=5` → 20/20 passed
- negative control (expected heading renamed to one that never appears) → still fails, inside the timeout, on the `toPass` exhaustion

🤖 Generated with [Claude Code](https://claude.com/claude-code)