### PR TITLE
fix(plugins): stop re-adding a named instance from wiping its saved config

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -9091,9 +9091,29 @@ async def create_plugin_instance(plugin_id: str, request: PluginInstanceCreateRe
 
     compound_key = registry.make_instance_key(base_id, request.label)
 
-    # Persist empty config so the instance survives restarts
     config_manager = get_config_manager()
-    config_manager.set_plugin_config(compound_key, {"enabled": False})
+    # The registry can come up without its named instances — an unreadable
+    # config.json, or a base plugin that failed to load, both leave the stored
+    # entries untouched but drop the live instances. The UI then shows nothing
+    # and the user re-adds the label by hand. Blindly persisting an empty
+    # config here used to overwrite their saved settings with
+    # `{"enabled": false}`, so the plugin fell back to manifest defaults.
+    # Adopt whatever is still on disk instead.
+    stored = config_manager.get_plugin_config(compound_key)
+    if stored:
+        errors = registry.apply_stored_config(compound_key, stored)
+        if errors:
+            logger.warning(
+                "Adopted stored config for re-created instance '%s' despite validation errors: %s",
+                compound_key,
+                errors,
+            )
+        if stored.get("enabled"):
+            registry.enable_plugin(compound_key)
+        logger.info("Re-created instance '%s' adopted its existing stored config", compound_key)
+    else:
+        # Persist empty config so the instance survives restarts
+        config_manager.set_plugin_config(compound_key, {"enabled": False})
     # Re-creating an instance is an explicit user action — drop any
     # deliberate-removal tombstone left by a prior delete (#1394).
     config_manager.clear_plugin_removed(compound_key)
@@ -9104,12 +9124,16 @@ async def create_plugin_instance(plugin_id: str, request: PluginInstanceCreateRe
 
     logger.info(f"Created plugin instance: {compound_key}")
 
+    # Report the normalized label — that is the instance the registry holds and
+    # the one `{{plugin:label.field}}` template references must use.
+    _, instance_label = registry.parse_instance_key(compound_key)
+
     return {
         "status": "success",
         "plugin_id": base_id,
-        "instance_label": request.label,
+        "instance_label": instance_label,
         "instance_key": compound_key,
-        "message": f"Instance '{request.label}' created for plugin '{base_id}'.",
+        "message": f"Instance '{instance_label}' created for plugin '{base_id}'.",
     }
 
 

--- a/src/plugins/registry.py
+++ b/src/plugins/registry.py
@@ -91,9 +91,15 @@ class PluginRegistry:
     def make_instance_key(plugin_id: str, instance_label: str) -> str:
         """Build a compound key from a base plugin ID and instance label.
 
-        Example: ``make_instance_key("weather", "sf")`` → ``"weather:sf"``
+        The label is normalized to lowercase to match how ``create_instance``
+        registers it (#774). Callers pass the label the user typed, so without
+        this a mixed-case label like ``"Xmas"`` would build ``countdown:Xmas``
+        while the registry holds ``countdown:xmas`` — the config would be
+        stored under a key nothing reads, and delete would miss entirely.
+
+        Example: ``make_instance_key("weather", "SF")`` → ``"weather:sf"``
         """
-        return f"{plugin_id}{INSTANCE_SEPARATOR}{instance_label}"
+        return f"{plugin_id}{INSTANCE_SEPARATOR}{instance_label.lower()}"
 
     @staticmethod
     def parse_instance_key(key: str) -> tuple[str, str | None]:
@@ -252,8 +258,13 @@ class PluginRegistry:
             config_manager = get_config_manager()
             # Get all plugin configs
             stored_configs = config_manager.get_all_plugin_configs()
-        except Exception as e:
-            logger.warning(f"Could not load stored plugin configs: {e}")
+        except Exception:
+            # Not cosmetic: with no stored configs every plugin is marked
+            # disabled below and _restore_instances creates no named instances
+            # at all, so the whole Integrations page comes up empty. Log it
+            # loudly — this is the fingerprint to look for when a user reports
+            # that their integrations "turned themselves off".
+            logger.exception("Could not load stored plugin configs — all plugins will start disabled")
 
         for plugin_id, plugin in loaded.items():
             manifest = self._loader.get_manifest(plugin_id)
@@ -311,8 +322,12 @@ class PluginRegistry:
 
             # Base plugin must be loaded for us to create an instance
             if base_id not in self._plugins:
-                logger.warning(
-                    "Cannot restore instance '%s': base plugin '%s' not loaded",
+                # The stored config survives, but the instance is invisible in
+                # the UI until the base plugin loads again — which reads to the
+                # user as "my integrations got disabled".
+                logger.error(
+                    "Cannot restore instance '%s': base plugin '%s' not loaded — "
+                    "its saved configuration is retained but the instance is unavailable",
                     config_key,
                     base_id,
                 )
@@ -331,16 +346,13 @@ class PluginRegistry:
 
             # Apply stored config via the proper pipeline so any future
             # side-effects (e.g. validation hooks) are consistently triggered.
-            config_errors = self.set_plugin_config(normalized_key, config)
+            config_errors = self.apply_stored_config(normalized_key, config)
             if config_errors:
                 logger.warning(
                     "Instance '%s' config failed validation on restore: %s — applying raw config to avoid data loss",
                     normalized_key,
                     config_errors,
                 )
-                # Fall back to direct assignment so we don't silently discard config
-                self._configs[normalized_key] = config
-                self._plugins[normalized_key].config = config
 
             # Enable via the proper pipeline so any future side-effects are
             # consistently triggered.
@@ -732,6 +744,29 @@ class PluginRegistry:
         logger.debug(f"Updated config for {plugin_id}")
         return []
 
+    def apply_stored_config(self, plugin_id: str, config: dict[str, Any]) -> list[str]:
+        """Apply a config that is already persisted in ``config.json``.
+
+        Unlike :meth:`set_plugin_config` — which rejects an invalid config so
+        the API can 400 a bad request — this keeps the config even when
+        validation fails. Stored config is the user's data: a plugin whose
+        manifest later gained a required field would otherwise have its saved
+        settings silently discarded on restore.
+
+        Args:
+            plugin_id: Plugin identifier (base or ``base:label`` instance key).
+            config: The stored configuration dictionary.
+
+        Returns:
+            List of validation errors. Non-empty means the config was applied
+            anyway and the caller should log it.
+        """
+        errors = self.set_plugin_config(plugin_id, config)
+        if errors and plugin_id in self._plugins:
+            self._configs[plugin_id] = config
+            self._plugins[plugin_id].config = config
+        return errors
+
     def get_plugin_config(self, plugin_id: str) -> dict[str, Any] | None:
         """Get configuration for a plugin.
 
@@ -1068,15 +1103,13 @@ class PluginRegistry:
                 self.enable_plugin(compound_key)
             instance_config = self._configs.get(compound_key, {})
             if instance_config:
-                errors = self.set_plugin_config(compound_key, instance_config)
+                errors = self.apply_stored_config(compound_key, instance_config)
                 if errors:
                     logger.warning(
                         "Config validation failed after reload for '%s': %s — applying raw config to avoid data loss",
                         compound_key,
                         errors,
                     )
-                    self._configs[compound_key] = instance_config
-                    new_instance.config = instance_config
 
             logger.info("Rebuilt plugin instance after reload: %s", compound_key)
 

--- a/tests/test_plugin_instances.py
+++ b/tests/test_plugin_instances.py
@@ -106,6 +106,12 @@ class TestInstanceKeyHelpers:
     def test_make_instance_key_with_underscores(self):
         assert PluginRegistry.make_instance_key("generic_data", "my_api") == "generic_data:my_api"
 
+    def test_make_instance_key_normalizes_label_case(self):
+        """Instance labels are registered lowercase (#774), so building a key
+        from a mixed-case label must produce the key the registry actually
+        holds — otherwise config is stored under a key nothing ever reads."""
+        assert PluginRegistry.make_instance_key("countdown", "Xmas") == "countdown:xmas"
+
     def test_parse_instance_key_compound(self):
         base, label = PluginRegistry.parse_instance_key("weather:sf")
         assert base == "weather"
@@ -228,6 +234,44 @@ class TestCreateInstance:
         assert "already exists" in errors[0]
 
 
+# ── apply_stored_config ─────────────────────────────────────────────────────
+
+
+class TestApplyStoredConfig:
+    """Tests for PluginRegistry.apply_stored_config()."""
+
+    def test_applies_valid_config(self, registry_with_plugin):
+        registry_with_plugin.create_instance("test_plugin", "inst")
+        plugin = registry_with_plugin._plugins["test_plugin:inst"]
+        plugin._validate_refresh_seconds.return_value = []
+        plugin.validate_config.return_value = []
+
+        config = {"enabled": True, "event_name": "Christmas"}
+        assert registry_with_plugin.apply_stored_config("test_plugin:inst", config) == []
+        assert registry_with_plugin._configs["test_plugin:inst"] == config
+        assert plugin.config == config
+
+    def test_keeps_raw_config_when_validation_fails(self, registry_with_plugin):
+        """A config that no longer validates (e.g. the manifest gained a
+        required field) must still be kept — reporting the error is fine,
+        silently dropping the user's settings is not."""
+        registry_with_plugin.create_instance("test_plugin", "inst")
+        plugin = registry_with_plugin._plugins["test_plugin:inst"]
+        plugin._validate_refresh_seconds.return_value = []
+        plugin.validate_config.return_value = ["Target date/time is required"]
+
+        config = {"enabled": True, "event_name": "Christmas"}
+        errors = registry_with_plugin.apply_stored_config("test_plugin:inst", config)
+        assert errors == ["Target date/time is required"]
+        assert registry_with_plugin._configs["test_plugin:inst"] == config
+        assert plugin.config == config
+
+    def test_unknown_plugin_reports_error(self, registry_with_plugin):
+        errors = registry_with_plugin.apply_stored_config("test_plugin:missing", {"enabled": True})
+        assert len(errors) == 1
+        assert "Plugin not found" in errors[0]
+
+
 # ── delete_instance ─────────────────────────────────────────────────────────
 
 
@@ -255,6 +299,14 @@ class TestDeleteInstance:
         errors = registry_with_plugin.delete_instance("test_plugin", "nope")
         assert len(errors) == 1
         assert "not found" in errors[0]
+
+    def test_delete_instance_with_mixed_case_label(self, registry_with_plugin):
+        """create_instance normalizes labels to lowercase, so deleting by the
+        label the user originally typed must resolve to the same key."""
+        registry_with_plugin.create_instance("test_plugin", "Wedding")
+        errors = registry_with_plugin.delete_instance("test_plugin", "Wedding")
+        assert errors == []
+        assert "test_plugin:wedding" not in registry_with_plugin._plugins
 
     def test_delete_instance_clears_discovered_vars(self, registry_with_plugin):
         registry_with_plugin.create_instance("test_plugin", "dv")
@@ -707,9 +759,16 @@ class TestPluginInstanceEndpoints:
             k.split(":", 1)[0],
             k.split(":", 1)[1] if ":" in k else None,
         )
-        registry.make_instance_key.side_effect = lambda base, label: f"{base}:{label}"
+        registry.make_instance_key.side_effect = lambda base, label: f"{base}:{label.lower()}"
         registry.is_instance_key.side_effect = lambda k: ":" in k
         return registry
+
+    @pytest.fixture
+    def mock_cm(self):
+        """Config manager with no stored config for the instance being created."""
+        cm = Mock()
+        cm.get_plugin_config.return_value = None
+        return cm
 
     # ── list instances ──────────────────────────────────────────────────────
 
@@ -745,10 +804,9 @@ class TestPluginInstanceEndpoints:
 
     # ── create instance ─────────────────────────────────────────────────────
 
-    def test_create_instance_success(self, client, mock_registry):
+    def test_create_instance_success(self, client, mock_registry, mock_cm):
         mock_registry.get_plugin.return_value = Mock()
         mock_registry.create_instance.return_value = []  # no errors
-        mock_cm = Mock()
         with (
             patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
             patch("src.api_server.get_plugin_registry", return_value=mock_registry),
@@ -765,20 +823,70 @@ class TestPluginInstanceEndpoints:
         # Persists config
         mock_cm.set_plugin_config.assert_called_once_with("weather:sf", {"enabled": False})
 
-    def test_create_instance_resets_services(self, client, mock_registry):
+    def test_create_instance_resets_services(self, client, mock_registry, mock_cm):
         """Creating an instance should reset display and template services."""
         mock_registry.get_plugin.return_value = Mock()
         mock_registry.create_instance.return_value = []
         with (
             patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
             patch("src.api_server.get_plugin_registry", return_value=mock_registry),
-            patch("src.api_server.get_config_manager", return_value=Mock()),
+            patch("src.api_server.get_config_manager", return_value=mock_cm),
             patch("src.api_server.reset_display_service") as mock_rds,
             patch("src.api_server.reset_template_engine") as mock_rte,
         ):
             client.post("/plugins/weather/instances", json={"label": "nyc"})
         mock_rds.assert_called_once()
         mock_rte.assert_called_once()
+
+    def test_create_instance_stores_config_under_normalized_key(self, client, mock_registry, mock_cm):
+        """create_instance registers the label lowercase, so the endpoint must
+        persist — and hand back — the same lowercase key. Storing under the
+        raw label leaves the config where nothing ever reads it, and the
+        instance runs on manifest fallbacks instead of the user's settings."""
+        mock_registry.get_plugin.return_value = Mock()
+        mock_registry.create_instance.return_value = []
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+            patch("src.api_server.get_config_manager", return_value=mock_cm),
+            patch("src.api_server.reset_display_service"),
+            patch("src.api_server.reset_template_engine"),
+        ):
+            resp = client.post("/plugins/countdown/instances", json={"label": "Xmas"})
+        assert resp.status_code == 200
+        assert resp.json()["instance_key"] == "countdown:xmas"
+        mock_cm.set_plugin_config.assert_called_once_with("countdown:xmas", {"enabled": False})
+        mock_cm.clear_plugin_removed.assert_called_once_with("countdown:xmas")
+
+    def test_create_instance_preserves_existing_stored_config(self, client, mock_registry, mock_cm):
+        """The registry can boot without its instances (unreadable config, or a
+        base plugin that failed to load) while config.json still holds them.
+        Re-adding the same label must adopt those settings, not overwrite them
+        with a blank disabled config."""
+        stored = {
+            "enabled": True,
+            "event_name": "Christmas",
+            "target_datetime": "2027-12-25T00:00:00",
+            "timezone": "America/Los_Angeles",
+        }
+        mock_registry.get_plugin.return_value = Mock()
+        mock_registry.create_instance.return_value = []
+        mock_registry.apply_stored_config.return_value = []
+        mock_cm.get_plugin_config.return_value = stored
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+            patch("src.api_server.get_config_manager", return_value=mock_cm),
+            patch("src.api_server.reset_display_service"),
+            patch("src.api_server.reset_template_engine"),
+        ):
+            resp = client.post("/plugins/countdown/instances", json={"label": "xmas"})
+        assert resp.status_code == 200
+        # The user's settings are neither overwritten on disk...
+        mock_cm.set_plugin_config.assert_not_called()
+        # ...nor left behind: the live instance picks them up, still enabled.
+        mock_registry.apply_stored_config.assert_called_once_with("countdown:xmas", stored)
+        mock_registry.enable_plugin.assert_called_once_with("countdown:xmas")
 
     def test_create_instance_validation_error(self, client, mock_registry):
         mock_registry.get_plugin.return_value = Mock()
@@ -841,12 +949,11 @@ class TestPluginInstanceEndpoints:
         assert resp.status_code == 200
         mock_cm.mark_plugin_removed.assert_called_once_with("weather:sf")
 
-    def test_create_instance_clears_tombstone(self, client, mock_registry):
+    def test_create_instance_clears_tombstone(self, client, mock_registry, mock_cm):
         """Re-creating an instance clears any deliberate-removal tombstone for
         its compound key (#1394)."""
         mock_registry.get_plugin.return_value = Mock()
         mock_registry.create_instance.return_value = []
-        mock_cm = Mock()
         with (
             patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
             patch("src.api_server.get_plugin_registry", return_value=mock_registry),


### PR DESCRIPTION
## Summary

- A user reported all their Countdown instances turning off, and after re-enabling them `countdown:<label>.event_name` rendered the literal `"Event"`. That string is the plugin's fallback for an **empty config dict** (`plugins/countdown/__init__.py:81`), so the stored settings were genuinely lost — not defaulted over. Countdown's own code is untouched since June; this is platform-side.
- Two defects in named-instance handling combine to produce it. Both are reproducible.
- This is the recovery path, not the trigger: it turns a transient "instances didn't come up this boot" glitch into permanent data loss. See *Still open* below.

## Changes

**1. Re-adding an instance no longer destroys its saved settings.**
`create_instance` only checked the *in-memory* registry for duplicates, then `POST /plugins/{id}/instances` full-replaced the stored entry with `{"enabled": false}`. The registry can legitimately come up without its instances — an unreadable config (`registry.py:249`) or a base plugin that failed to load (`registry.py:313`) — while `config.json` still holds them. Both were swallowed as warnings, so the UI showed nothing, the user re-added the label by hand, and `event_name` / `target_datetime` / `timezone` were overwritten. The endpoint now **adopts** an existing stored config, re-enabling it when it was enabled, so re-adding is self-healing.

**2. A capitalized label wrote config to a key nothing reads.**
`create_instance` normalizes labels to lowercase (#775), but `make_instance_key` did not. Label `Xmas` → registry holds `countdown:xmas`, config persisted under `countdown:Xmas`, and that mixed-case key handed back to the UI — so the follow-up config `PUT` 404s and the instance runs on manifest fallbacks. The same bug made `delete_instance("Xmas")` miss entirely. Normalized at `make_instance_key`, the single choke point for create, delete, and the removal tombstone.

**Supporting:**
- New `registry.apply_stored_config()` keeps a stored config even when validation fails (stored config is user data; a manifest that later gains a required field shouldn't silently discard it). Replaces the duplicated fallback in `_restore_instances` and `_rebuild_instances`.
- Escalated the two silently swallowed boot paths to `error` / `exception` — they are the fingerprint for "my integrations turned themselves off", and were invisible in logs before.

## Test plan

- [x] 6 failing tests written first, then the fix — `tests/test_plugin_instances.py` (key normalization, mixed-case delete, `apply_stored_config` incl. the validation-failure case, and two endpoint tests reproducing the data loss).
- [x] `pytest tests/test_plugin_instances.py` — 91 passed.
- [x] `pytest tests/test_plugin_registry.py tests/test_plugin_loader.py tests/test_config_manager.py tests/test_post_upgrade_restore.py tests/test_config_migration.py tests/test_plugin_validation.py tests/test_plugin_config_interpolation.py` — 406 passed.
- [x] Full suite diffed against an unmodified baseline of the same tree: **zero new failures**. The remaining 91 are pre-existing (mcp_server env errors + known full-suite date_time/countdown pollution).
- [x] `ruff check` clean on all changed files. (`ruff format --check` flags `api_server.py`, but identically on the unmodified baseline — pre-existing drift around line 5400 from the unpinned-ruff version skew, not from this change.)
- [x] End-to-end against the real boot path: simulated a failed stored-config read so the registry loses its instances, then re-added `Xmas`. Before: on-disk config reduced to `{"enabled": false}` and the variable rendered `'Event'`. After: config preserved, instance re-enabled, `countdown:xmas.event_name -> 'Christmas'`.

## Still open

The **trigger** — why the instances stopped coming up in the first place — is not identified here. Nothing in 8.17.x touches the plugin system, and a clean upgrade boot preserves everything (verified). It is one of the two now-loud paths above. Diagnosing the next occurrence needs, from an affected instance: `removed_plugins` and the `plugins` block from `config.json`, plus startup logs around `Could not load stored plugin configs` / `Cannot restore instance`.

Users who already lost settings can likely recover them from `data/update-backups/pre-update-*.json` — the pre-init snapshot includes `config.json` and is written on every version change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)