### PR TITLE
fix(ci): stop integration tests from inflating plugin clone stats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,8 +203,10 @@ jobs:
 
     - name: Run plugin install integration tests
       run: |
-        # Real git clone/pull/uninstall against live Fiestaboard plugin repos on GitHub.
-        # Requires network access and git binary (both available on ubuntu-latest).
+        # Real git install/update/uninstall flows against local file:// fixture
+        # repos — hermetic on purpose. Cloning the live plugin repos from here
+        # made every CI run count as a "unique cloner" in their GitHub traffic
+        # stats, inflating fiestaboard.app/stats (dad-jokes, star-trek-quotes).
         pytest -m integration tests/test_plugin_install_integration.py -v
       env:
         BOARD_READ_WRITE_KEY: test_key

--- a/docs-site/src/pages/stats.tsx
+++ b/docs-site/src/pages/stats.tsx
@@ -16,8 +16,10 @@ interface PluginStat {
   version: string | null;
   created_at: string | null;
   updated_at: string | null;
-  clones_14d_count: number;
-  clones_14d_uniques: number;
+  // null when GitHub exposes no traffic data for the repo (community-hosted
+  // plugins outside the Fiestaboard org — the traffic API needs push access).
+  clones_14d_count: number | null;
+  clones_14d_uniques: number | null;
 }
 
 interface StatsData {
@@ -58,7 +60,8 @@ function StatStrip({ items }: { items: { value: string | number; label: string }
 }
 
 function BarRow({ plugin, max }: { plugin: PluginStat; max: number }) {
-  const pct = max > 0 ? (plugin.clones_14d_uniques / max) * 100 : 0;
+  const uniques = plugin.clones_14d_uniques ?? 0;
+  const pct = max > 0 ? (uniques / max) * 100 : 0;
   return (
     <Box className={styles.barRow}>
       <Link to={`/plugins/detail?id=${plugin.id}`} className={styles.barName}>
@@ -68,7 +71,7 @@ function BarRow({ plugin, max }: { plugin: PluginStat; max: number }) {
         <Box className={styles.barFill} style={{ width: `${pct}%` }} />
       </Box>
       <Text as="span" className={styles.barValue}>
-        {plugin.clones_14d_uniques.toLocaleString()}
+        {uniques.toLocaleString()}
       </Text>
     </Box>
   );
@@ -108,7 +111,7 @@ function TopPluginSpotlight({
         <Box className={styles.spotlightBody}>
           <Box className={styles.spotlightName}>{plugin.name}</Box>
           <Box className={styles.spotlightStat}>
-            {plugin.clones_14d_uniques.toLocaleString()} unique cloners in the last {windowDays} days
+            {(plugin.clones_14d_uniques ?? 0).toLocaleString()} unique cloners in the last {windowDays} days
           </Box>
         </Box>
         <Badge variant="secondary" className={styles.spotlightBadge}>
@@ -136,17 +139,25 @@ export default function StatsPage(): ReactNode {
       .catch(() => setError(true));
   }, []);
 
-  const sorted = data ? [...data.plugins].sort((a, b) => b.clones_14d_uniques - a.clones_14d_uniques) : [];
+  // Plugins with null traffic (community-hosted repos GitHub exposes no
+  // traffic data for) stay in the directory sections below but are excluded
+  // from the popularity ranking and totals — "unknown" is not "zero".
+  const ranked = data
+    ? data.plugins
+        .filter((p) => p.clones_14d_uniques != null)
+        .sort((a, b) => (b.clones_14d_uniques ?? 0) - (a.clones_14d_uniques ?? 0))
+    : [];
 
-  const topPlugin = sorted[0];
-  const totalUniques = sorted.reduce((s, p) => s + p.clones_14d_uniques, 0);
+  const topPlugin = ranked[0];
+  const totalUniques = ranked.reduce((s, p) => s + (p.clones_14d_uniques ?? 0), 0);
   const maxUniques = topPlugin?.clones_14d_uniques ?? 1;
-  const displayedPlugins = showAllRanking ? sorted : sorted.slice(0, RANKING_PREVIEW);
+  const hiddenFromRanking = data ? data.plugins.length - ranked.length : 0;
+  const displayedPlugins = showAllRanking ? ranked : ranked.slice(0, RANKING_PREVIEW);
 
   const byCategory = data
     ? Object.entries(
         data.plugins.reduce<Record<string, number>>((acc, p) => {
-          acc[p.category] = (acc[p.category] ?? 0) + p.clones_14d_uniques;
+          acc[p.category] = (acc[p.category] ?? 0) + (p.clones_14d_uniques ?? 0);
           return acc;
         }, {}),
       ).sort(([, a], [, b]) => b - a)
@@ -216,19 +227,23 @@ export default function StatsPage(): ReactNode {
 
                 <Box as="section" className={styles.dashboardRight}>
                   <Heading level={2}>Popularity ranking</Heading>
-                  <Text className={styles.sectionNote}>Unique cloners in the last {data.window_days} days</Text>
+                  <Text className={styles.sectionNote}>
+                    Unique cloners in the last {data.window_days} days
+                    {hiddenFromRanking > 0 &&
+                      ` - ${hiddenFromRanking} community-hosted ${hiddenFromRanking === 1 ? "plugin doesn't" : "plugins don't"} expose clone data and ${hiddenFromRanking === 1 ? "is" : "are"} not ranked`}
+                  </Text>
                   <Box className={styles.barChart}>
                     {displayedPlugins.map((plugin) => (
                       <BarRow key={plugin.id} plugin={plugin} max={maxUniques} />
                     ))}
                   </Box>
-                  {sorted.length > RANKING_PREVIEW && (
+                  {ranked.length > RANKING_PREVIEW && (
                     <Button
                       variant="ghost"
                       className={styles.showMoreBtn}
                       onClick={() => setShowAllRanking(!showAllRanking)}
                     >
-                      {showAllRanking ? "Show fewer" : `Show all ${sorted.length} plugins`}
+                      {showAllRanking ? "Show fewer" : `Show all ${ranked.length} plugins`}
                     </Button>
                   )}
                 </Box>

--- a/docs-site/src/pages/stats.tsx
+++ b/docs-site/src/pages/stats.tsx
@@ -108,7 +108,7 @@ function TopPluginSpotlight({
         <Box className={styles.spotlightBody}>
           <Box className={styles.spotlightName}>{plugin.name}</Box>
           <Box className={styles.spotlightStat}>
-            {plugin.clones_14d_uniques.toLocaleString()} unique installs in the last {windowDays} days
+            {plugin.clones_14d_uniques.toLocaleString()} unique cloners in the last {windowDays} days
           </Box>
         </Box>
         <Badge variant="secondary" className={styles.spotlightBadge}>
@@ -201,7 +201,7 @@ export default function StatsPage(): ReactNode {
                       { value: data.plugins.length, label: "plugins" },
                       {
                         value: totalUniques.toLocaleString(),
-                        label: `unique installs (last ${data.window_days} days)`,
+                        label: `unique cloners (last ${data.window_days} days)`,
                       },
                     ]}
                   />
@@ -237,7 +237,7 @@ export default function StatsPage(): ReactNode {
               <Box as="section" className={styles.section}>
                 <Heading level={2}>By category</Heading>
                 <Text className={styles.sectionNote}>
-                  Sum of per-plugin installs by category, last {data.window_days} days - users installing multiple
+                  Sum of per-plugin unique cloners by category, last {data.window_days} days - users cloning multiple
                   plugins in the same category are counted once per plugin
                 </Text>
                 <Box className={styles.categoryGrid}>
@@ -304,7 +304,8 @@ export default function StatsPage(): ReactNode {
 
               <Text className={styles.freshness}>
                 Data refreshed {generatedAt}. Clone counts reflect the {data.window_days}-day window provided by the
-                GitHub Traffic API.
+                GitHub Traffic API and include automated traffic such as fleet auto-updates and the weekly security
+                scan.
               </Text>
             </>
           )}

--- a/docs-site/static/plugin-stats.json
+++ b/docs-site/static/plugin-stats.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-08T05:01:03Z",
+  "generated_at": "2026-08-08T07:06:36Z",
   "window_days": 14,
   "plugins": [
     {
@@ -596,11 +596,11 @@
       "name": "Airport Departures",
       "category": "transit",
       "description": "Display upcoming scheduled airline departures with codeshare deduplication, delays, gates, and Note-ready formatting.",
-      "version": null,
-      "created_at": null,
-      "updated_at": null,
-      "clones_14d_count": 0,
-      "clones_14d_uniques": 0
+      "version": "1.3.0",
+      "created_at": "2026-07-14T03:20:02Z",
+      "updated_at": "2026-07-18T19:28:07Z",
+      "clones_14d_count": null,
+      "clones_14d_uniques": null
     },
     {
       "id": "wsdot",

--- a/scripts/fetch_plugin_stats.py
+++ b/scripts/fetch_plugin_stats.py
@@ -31,14 +31,20 @@ def gh_api(path: str):
 
 
 def fetch_plugin(plugin: dict) -> dict:
-    repo_name = plugin["repository"].rstrip("/").split("/")[-1]
-    print(f"  {repo_name}", file=sys.stderr)
+    # Registry plugins are not all org-hosted (community plugins live under
+    # their author's account), so derive owner/repo from the registry URL
+    # instead of assuming the Fiestaboard org.
+    owner, repo_name = plugin["repository"].rstrip("/").split("/")[-2:]
+    print(f"  {owner}/{repo_name}", file=sys.stderr)
 
-    traffic = gh_api(f"repos/Fiestaboard/{repo_name}/traffic/clones") or {}
-    meta = gh_api(f"repos/Fiestaboard/{repo_name}") or {}
+    # The traffic API needs push access, which we only have for org repos.
+    # For community repos it 403s — keep None so the output distinguishes
+    # "no data" (null) from a genuine zero.
+    traffic = gh_api(f"repos/{owner}/{repo_name}/traffic/clones")
+    meta = gh_api(f"repos/{owner}/{repo_name}") or {}
 
     version = None
-    manifest_raw = gh_api(f"repos/Fiestaboard/{repo_name}/contents/manifest.json")
+    manifest_raw = gh_api(f"repos/{owner}/{repo_name}/contents/manifest.json")
     if manifest_raw and manifest_raw.get("content"):
         try:
             manifest_data = json.loads(base64.b64decode(manifest_raw["content"]).decode())
@@ -55,8 +61,8 @@ def fetch_plugin(plugin: dict) -> dict:
         "version": version,
         "created_at": meta.get("created_at"),
         "updated_at": meta.get("updated_at"),
-        "clones_14d_count": traffic.get("count", 0),
-        "clones_14d_uniques": traffic.get("uniques", 0),
+        "clones_14d_count": traffic.get("count", 0) if traffic is not None else None,
+        "clones_14d_uniques": traffic.get("uniques", 0) if traffic is not None else None,
     }
 
 

--- a/tests/test_plugin_install_integration.py
+++ b/tests/test_plugin_install_integration.py
@@ -1,21 +1,33 @@
 """Integration tests for the plugin install/update/uninstall system.
 
-These tests perform real ``git clone`` and ``git pull`` operations against
-actual Fiestaboard plugin repositories on GitHub.  They require network
-access and a working ``git`` binary.
+These tests exercise the real ``git`` binary end-to-end — the ``git init`` +
+``fetch`` + ``reset`` install path, the fetch/reset update path, and
+uninstall — but against **local fixture repositories** (``file://`` URLs)
+rather than the live plugin repos on GitHub.
+
+They used to clone ``fiestaboard-plugin--dad-jokes`` and
+``fiestaboard-plugin--star-trek-quotes`` for real. Every CI run then counted
+as a fresh "unique cloner" in those repos' GitHub traffic stats, inflating
+the numbers shown on fiestaboard.app/stats far above the real fleet
+baseline (each Actions runner IP is a new unique). Local fixtures keep the
+same git mechanics under test with zero external traffic and no network
+flake.
 
 Run explicitly with::
 
     pytest -m integration tests/test_plugin_install_integration.py -v
 
 They are intentionally excluded from the main coverage run so they do not
-slow down fast, offline unit tests.
+slow down fast unit tests.
 """
 
+import json
 import subprocess
+from pathlib import Path
 
 import pytest
 
+from src.plugins import sources
 from src.plugins.sources import (
     RegistryEntry,
     clone_or_update_repo,
@@ -27,18 +39,26 @@ from src.plugins.sources import (
 
 pytestmark = pytest.mark.integration
 
-# Use dad_jokes for registry flow (tiny repo, no API key required)
-REGISTRY_PLUGIN_ID = "dad_jokes"
-REGISTRY_REPO_URL = "https://github.com/Fiestaboard/fiestaboard-plugin--dad-jokes"
-
-# Use star_trek_quotes for the arbitrary git URL flow (also tiny, no API key)
-GIT_PLUGIN_ID = "star_trek_quotes"
-GIT_REPO_URL = "https://github.com/Fiestaboard/fiestaboard-plugin--star-trek-quotes"
+# The fixture repo follows the registry naming convention so it passes
+# validate_registry_repo_name and plugin-id derivation, exactly like a
+# published plugin repo would.
+FIXTURE_REPO_NAME = "fiestaboard-plugin--ci-fixture"
+FIXTURE_PLUGIN_ID = "ci_fixture"
 
 
 # ---------------------------------------------------------------------------
-# Helpers
+# Helpers / fixtures
 # ---------------------------------------------------------------------------
+
+
+def _git(*args: str, cwd: Path) -> None:
+    subprocess.run(
+        ["git", "-c", "user.email=ci-fixture@example.com", "-c", "user.name=CI Fixture", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
 
 
 def _git_log(path, n=3):
@@ -52,12 +72,49 @@ def _git_log(path, n=3):
     return result.stdout.strip().splitlines()
 
 
-def _has_git():
-    try:
-        subprocess.run(["git", "--version"], check=True, capture_output=True)
-        return True
-    except (FileNotFoundError, subprocess.CalledProcessError):
-        return False
+def _make_plugin_repo(base: Path, repo_name: str = FIXTURE_REPO_NAME) -> Path:
+    """Create a local git repo that looks like a published plugin repo."""
+    src = base / repo_name
+    src.mkdir(parents=True)
+    manifest = {
+        "id": FIXTURE_PLUGIN_ID,
+        "name": "CI Fixture",
+        "version": "1.0.0",
+        "description": "Local fixture plugin for install integration tests",
+        "fiestaboard_version": "1.0.0",
+    }
+    (src / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n")
+    (src / "__init__.py").write_text('"""CI fixture plugin."""\n')
+    _git("init", "--quiet", "-b", "main", cwd=src)
+    _git("add", ".", cwd=src)
+    _git("-c", "commit.gpgsign=false", "commit", "--quiet", "-m", "initial", cwd=src)
+    return src
+
+
+@pytest.fixture(autouse=True)
+def _allow_file_urls(monkeypatch):
+    """Bypass the https-only URL validation for local ``file://`` fixtures.
+
+    Production only ever clones ``https://`` URLs; the validation rules
+    themselves are unit-tested in test_plugin_sources.py. Bypassing here
+    lets the full git install path run against local repos.
+    """
+    monkeypatch.setattr(sources, "_validate_git_url", lambda url: (True, ""))
+
+
+@pytest.fixture
+def fixture_repo(tmp_path):
+    """A local plugin source repo. Returns (file_url, source_path)."""
+    src = _make_plugin_repo(tmp_path / "remote")
+    return src.as_uri(), src
+
+
+@pytest.fixture
+def external_dir(tmp_path):
+    """The external-plugins install target, separate from the source repo."""
+    dest = tmp_path / "external"
+    dest.mkdir()
+    return dest
 
 
 # ---------------------------------------------------------------------------
@@ -66,51 +123,52 @@ def _has_git():
 
 
 class TestCloneOrUpdateRepoIntegration:
-    def test_fresh_clone(self, tmp_path):
+    def test_fresh_clone(self, fixture_repo, external_dir):
         """Cloning a real repo succeeds and creates expected plugin files."""
-        ok, err = clone_or_update_repo(REGISTRY_REPO_URL, REGISTRY_PLUGIN_ID, external_dir=tmp_path)
+        url, _ = fixture_repo
+        ok, err = clone_or_update_repo(url, FIXTURE_PLUGIN_ID, external_dir=external_dir)
 
         assert ok, f"clone failed: {err}"
         assert err == ""
-        dest = tmp_path / REGISTRY_PLUGIN_ID
+        dest = external_dir / FIXTURE_PLUGIN_ID
         assert dest.is_dir()
         assert (dest / "manifest.json").exists()
         assert (dest / "__init__.py").exists()
 
-    def test_clone_creates_valid_git_repo(self, tmp_path):
+    def test_clone_creates_valid_git_repo(self, fixture_repo, external_dir):
         """Cloned directory is a proper git repo with commit history."""
-        clone_or_update_repo(REGISTRY_REPO_URL, REGISTRY_PLUGIN_ID, external_dir=tmp_path)
+        url, _ = fixture_repo
+        clone_or_update_repo(url, FIXTURE_PLUGIN_ID, external_dir=external_dir)
 
-        dest = tmp_path / REGISTRY_PLUGIN_ID
+        dest = external_dir / FIXTURE_PLUGIN_ID
         commits = _git_log(dest)
         assert len(commits) >= 1, "expected at least one commit in cloned repo"
 
-    def test_update_existing_clone_via_pull(self, tmp_path):
-        """Re-running clone_or_update_repo on an existing directory runs git pull."""
-        # First clone
-        ok, err = clone_or_update_repo(REGISTRY_REPO_URL, REGISTRY_PLUGIN_ID, external_dir=tmp_path)
+    def test_update_existing_clone_fetches_new_commits(self, fixture_repo, external_dir):
+        """Re-running clone_or_update_repo picks up new upstream commits."""
+        url, src = fixture_repo
+        ok, err = clone_or_update_repo(url, FIXTURE_PLUGIN_ID, external_dir=external_dir)
         assert ok, f"initial clone failed: {err}"
-        dest = tmp_path / REGISTRY_PLUGIN_ID
-        commits_before = _git_log(dest)
+        dest = external_dir / FIXTURE_PLUGIN_ID
+        assert not (dest / "NEW_FILE.txt").exists()
 
-        # Second call should succeed (pull, already up-to-date is fine)
-        ok, err = clone_or_update_repo(REGISTRY_REPO_URL, REGISTRY_PLUGIN_ID, external_dir=tmp_path)
-        assert ok, f"update (git pull) failed: {err}"
+        # Land a new commit upstream, then update.
+        (src / "NEW_FILE.txt").write_text("updated\n")
+        _git("add", ".", cwd=src)
+        _git("-c", "commit.gpgsign=false", "commit", "--quiet", "-m", "update", cwd=src)
 
-        commits_after = _git_log(dest)
-        # History must be at least as long (pull never loses commits)
-        assert len(commits_after) >= len(commits_before)
+        ok, err = clone_or_update_repo(url, FIXTURE_PLUGIN_ID, external_dir=external_dir)
+        assert ok, f"update (git fetch/reset) failed: {err}"
+        assert (dest / "NEW_FILE.txt").exists(), "update did not fetch the new commit"
 
-    def test_invalid_url_returns_error(self, tmp_path):
+    def test_missing_repo_returns_error(self, tmp_path, external_dir):
         """Cloning a non-existent repo returns (False, <error message>)."""
-        ok, err = clone_or_update_repo(
-            "https://github.com/Fiestaboard/fiestaboard-plugin--does-not-exist-xyz",
-            "nonexistent",
-            external_dir=tmp_path,
-        )
+        missing_url = (tmp_path / "remote" / "fiestaboard-plugin--does-not-exist").as_uri()
+        ok, err = clone_or_update_repo(missing_url, "nonexistent", external_dir=external_dir)
+
         assert not ok
         assert err  # some error message present
-        dest = tmp_path / "nonexistent"
+        dest = external_dir / "nonexistent"
         assert not dest.exists()
 
 
@@ -120,44 +178,46 @@ class TestCloneOrUpdateRepoIntegration:
 
 
 class TestInstallRegistryPluginIntegration:
-    def test_installs_from_registry_entry(self, tmp_path):
-        """install_registry_plugin clones the repo into external_dir/plugin_id."""
+    def test_real_registry_parses(self):
+        """plugin-registry.json loads and contains known plugins (no cloning)."""
         registry = load_registry()
-        entry = next((e for e in registry if e.plugin_id == REGISTRY_PLUGIN_ID), None)
-        assert entry is not None, f"{REGISTRY_PLUGIN_ID} not found in plugin-registry.json"
+        ids = {e.plugin_id for e in registry}
+        assert "dad_jokes" in ids, "dad_jokes not found in plugin-registry.json"
 
-        ok, err = install_registry_plugin(entry, external_dir=tmp_path)
+    def test_installs_from_registry_entry(self, fixture_repo, external_dir):
+        """install_registry_plugin clones the repo into external_dir/plugin_id."""
+        url, _ = fixture_repo
+        entry = RegistryEntry(plugin_id=FIXTURE_PLUGIN_ID, name="CI Fixture", repository=url)
+
+        ok, err = install_registry_plugin(entry, external_dir=external_dir)
 
         assert ok, f"registry install failed: {err}"
-        dest = tmp_path / REGISTRY_PLUGIN_ID
+        dest = external_dir / FIXTURE_PLUGIN_ID
         assert dest.is_dir()
         assert (dest / "manifest.json").exists()
         assert (dest / "__init__.py").exists()
 
-    def test_manifest_has_expected_fields(self, tmp_path):
+    def test_manifest_has_expected_fields(self, fixture_repo, external_dir):
         """Cloned manifest contains the required fields set during extraction."""
-        import json
+        url, _ = fixture_repo
+        entry = RegistryEntry(plugin_id=FIXTURE_PLUGIN_ID, name="CI Fixture", repository=url)
 
-        registry = load_registry()
-        entry = next((e for e in registry if e.plugin_id == REGISTRY_PLUGIN_ID), None)
-        assert entry is not None
+        install_registry_plugin(entry, external_dir=external_dir)
+        manifest = json.loads((external_dir / FIXTURE_PLUGIN_ID / "manifest.json").read_text())
 
-        install_registry_plugin(entry, external_dir=tmp_path)
-        manifest = json.loads((tmp_path / REGISTRY_PLUGIN_ID / "manifest.json").read_text())
-
-        assert manifest.get("id") == REGISTRY_PLUGIN_ID
+        assert manifest.get("id") == FIXTURE_PLUGIN_ID
         assert "name" in manifest
         assert "version" in manifest
         assert "fiestaboard_version" in manifest, "fiestaboard_version must be set during extraction"
 
-    def test_rejects_non_registry_naming(self, tmp_path):
+    def test_rejects_non_registry_naming(self, external_dir):
         """install_registry_plugin refuses repos that don't follow the naming convention."""
         entry = RegistryEntry(
             plugin_id="bad",
             name="Bad",
             repository="https://github.com/someone/my-random-repo",
         )
-        ok, err = install_registry_plugin(entry, external_dir=tmp_path)
+        ok, err = install_registry_plugin(entry, external_dir=external_dir)
 
         assert not ok
         assert "fiestaboard-plugin--" in err
@@ -169,34 +229,37 @@ class TestInstallRegistryPluginIntegration:
 
 
 class TestInstallGitPluginIntegration:
-    def test_installs_from_arbitrary_url(self, tmp_path):
+    def test_installs_from_arbitrary_url(self, fixture_repo, external_dir):
         """install_git_plugin clones any valid Fiestaboard plugin URL."""
-        ok, err = install_git_plugin(GIT_REPO_URL, external_dir=tmp_path)
+        url, _ = fixture_repo
+        ok, err = install_git_plugin(url, external_dir=external_dir)
 
         assert ok, f"git URL install failed: {err}"
-        dest = tmp_path / GIT_PLUGIN_ID
+        dest = external_dir / FIXTURE_PLUGIN_ID
         assert dest.is_dir()
         assert (dest / "manifest.json").exists()
         assert (dest / "__init__.py").exists()
 
-    def test_plugin_id_derived_from_repo_name(self, tmp_path):
+    def test_plugin_id_derived_from_repo_name(self, fixture_repo, external_dir):
         """Plugin directory name is correctly derived from the repository name."""
-        install_git_plugin(GIT_REPO_URL, external_dir=tmp_path)
+        url, _ = fixture_repo
+        install_git_plugin(url, external_dir=external_dir)
 
-        # fiestaboard-plugin--star-trek-quotes → star_trek_quotes
-        assert (tmp_path / GIT_PLUGIN_ID).is_dir()
+        # fiestaboard-plugin--ci-fixture → ci_fixture
+        assert (external_dir / FIXTURE_PLUGIN_ID).is_dir()
 
-    def test_plugin_id_override(self, tmp_path):
+    def test_plugin_id_override(self, fixture_repo, external_dir):
         """Explicit plugin_id overrides the name derived from the URL."""
+        url, _ = fixture_repo
         ok, err = install_git_plugin(
-            GIT_REPO_URL,
+            url,
             plugin_id="custom_alias",
-            external_dir=tmp_path,
+            external_dir=external_dir,
         )
 
         assert ok, f"install with override id failed: {err}"
-        assert (tmp_path / "custom_alias").is_dir()
-        assert not (tmp_path / GIT_PLUGIN_ID).exists()
+        assert (external_dir / "custom_alias").is_dir()
+        assert not (external_dir / FIXTURE_PLUGIN_ID).exists()
 
 
 # ---------------------------------------------------------------------------
@@ -205,14 +268,13 @@ class TestInstallGitPluginIntegration:
 
 
 class TestUninstallIntegration:
-    def test_uninstall_removes_cloned_directory(self, tmp_path):
+    def test_uninstall_removes_cloned_directory(self, fixture_repo, external_dir):
         """Uninstalling a real cloned plugin removes its directory from disk."""
-        registry = load_registry()
-        entry = next((e for e in registry if e.plugin_id == REGISTRY_PLUGIN_ID), None)
-        assert entry is not None
+        url, _ = fixture_repo
+        entry = RegistryEntry(plugin_id=FIXTURE_PLUGIN_ID, name="CI Fixture", repository=url)
 
-        install_registry_plugin(entry, external_dir=tmp_path)
-        dest = tmp_path / REGISTRY_PLUGIN_ID
+        install_registry_plugin(entry, external_dir=external_dir)
+        dest = external_dir / FIXTURE_PLUGIN_ID
         assert dest.exists(), "plugin directory should exist before uninstall"
 
         removed = remove_external_plugin(dest)
@@ -220,21 +282,20 @@ class TestUninstallIntegration:
         assert removed
         assert not dest.exists(), "plugin directory should be gone after uninstall"
 
-    def test_uninstall_then_reinstall(self, tmp_path):
+    def test_uninstall_then_reinstall(self, fixture_repo, external_dir):
         """A plugin can be reinstalled cleanly after being uninstalled."""
-        registry = load_registry()
-        entry = next((e for e in registry if e.plugin_id == REGISTRY_PLUGIN_ID), None)
-        assert entry is not None
+        url, _ = fixture_repo
+        entry = RegistryEntry(plugin_id=FIXTURE_PLUGIN_ID, name="CI Fixture", repository=url)
 
-        dest = tmp_path / REGISTRY_PLUGIN_ID
+        dest = external_dir / FIXTURE_PLUGIN_ID
 
-        install_registry_plugin(entry, external_dir=tmp_path)
+        install_registry_plugin(entry, external_dir=external_dir)
         assert dest.exists()
 
         remove_external_plugin(dest)
         assert not dest.exists()
 
-        ok, err = install_registry_plugin(entry, external_dir=tmp_path)
+        ok, err = install_registry_plugin(entry, external_dir=external_dir)
         assert ok, f"reinstall after uninstall failed: {err}"
         assert dest.exists()
         assert (dest / "manifest.json").exists()


### PR DESCRIPTION
## Summary
- The docs stats page (fiestaboard.app/stats) showed Dad Jokes at 678 unique cloners / 2,302 clones in 14 days and crowned it "Most popular" — but the traffic was our own CI. `tests/test_plugin_install_integration.py` really cloned `fiestaboard-plugin--dad-jokes` (~8×/run) and `--star-trek-quotes` (~3×/run) on every `python-tests` job, and each Actions runner IP counts as a new "unique cloner" in the GitHub Traffic API. The daily traffic breakdown is bursty and weekday-shaped (456 clones on Aug 2, 408 on Jul 25), unlike the steady ~300-unique fleet baseline of genuinely popular plugins like weather/stocks.
- Rewrite the integration tests to run the same real-git install/update/uninstall flows against local `file://` fixture repos — hermetic, no network flake, and zero pollution of the plugin repos' traffic stats.

## Changes
- `tests/test_plugin_install_integration.py`: local fixture repo (`fiestaboard-plugin--ci-fixture`) built per-test with git init/commit; all 13 tests exercise the real `git init`+`fetch`+`reset` install path, update path, and uninstall against it. The https-only URL validation is bypassed via monkeypatch (it stays unit-tested in `test_plugin_sources.py`). The update test now asserts a new upstream commit actually arrives instead of just comparing history length.
- `.github/workflows/ci.yml`: updated the step comment to record why the tests are hermetic.
- `docs-site/src/pages/stats.tsx`: honest labels — "unique cloners" instead of "unique installs", and the footer notes counts include automated traffic (fleet auto-updates, weekly security scan).

Note: GitHub's traffic window is a rolling 14 days, so the inflated Dad Jokes / Star Trek Quotes numbers will decay over the two weeks after this merges — they can't be corrected retroactively.

## Test plan
- [x] `pytest -m integration tests/test_plugin_install_integration.py -v` in a container from the project image — 13 passed in 0.20s, fully offline
- [x] `ruff check` + `ruff format --check` on the test file — clean
- [x] `prettier --check src/pages/stats.tsx` (prettier 3.4.2, docs-site config) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)