### PR TITLE
feat(schedule): Order schedule entries by next occurrence

### DIFF
--- a/web/src/__tests__/schedule-sort.test.ts
+++ b/web/src/__tests__/schedule-sort.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+
+import type { ScheduleEntry } from "@/lib/api";
+import { sortSchedulesByStart } from "@/lib/schedule-sort";
+
+// Pinned reference point so "next occurrence" ordering is deterministic.
+const TODAY = new Date(2026, 7, 8); // Sat Aug 8 2026
+
+function makeSchedule(overrides: Partial<ScheduleEntry> & { id: string }): ScheduleEntry {
+  return {
+    page_id: "page1",
+    start_time: "09:00",
+    end_time: "17:00",
+    day_pattern: "all",
+    enabled: true,
+    created_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function annual(id: string, annual_date: string, extra: Partial<ScheduleEntry> = {}): ScheduleEntry {
+  return makeSchedule({ id, recurrence_type: "annual_date", annual_date, ...extra });
+}
+
+function oneOff(id: string, one_off_date: string, extra: Partial<ScheduleEntry> = {}): ScheduleEntry {
+  return makeSchedule({ id, recurrence_type: "one_off_date", one_off_date, ...extra });
+}
+
+const ids = (schedules: ScheduleEntry[]) => schedules.map((s) => s.id);
+
+describe("sortSchedulesByStart", () => {
+  it("orders weekly entries by start time rather than creation order", () => {
+    const schedules = [
+      makeSchedule({ id: "evening", start_time: "18:00" }),
+      makeSchedule({ id: "morning", start_time: "06:30" }),
+      makeSchedule({ id: "noon", start_time: "12:00" }),
+    ];
+
+    expect(ids(sortSchedulesByStart(schedules, TODAY))).toEqual(["morning", "noon", "evening"]);
+  });
+
+  it("uses the resolved time for sun-based entries", () => {
+    const schedules = [
+      makeSchedule({ id: "fixed-seven", start_time: "07:00" }),
+      makeSchedule({
+        id: "sunrise",
+        start_time: "06:00",
+        start_type: "sunrise",
+        resolved_start_time: "05:12",
+      }),
+      makeSchedule({
+        id: "sunset",
+        start_time: "18:00",
+        start_type: "sunset",
+        resolved_start_time: "20:41",
+      }),
+    ];
+
+    expect(ids(sortSchedulesByStart(schedules, TODAY))).toEqual(["sunrise", "fixed-seven", "sunset"]);
+  });
+
+  it("puts every weekly entry ahead of the dated ones", () => {
+    const schedules = [
+      oneOff("one-off", "2026-08-10", { start_time: "08:00" }),
+      annual("annual", "12-25", { start_time: "08:00" }),
+      makeSchedule({ id: "weekly", start_time: "23:00" }),
+    ];
+
+    expect(ids(sortSchedulesByStart(schedules, TODAY))).toEqual(["weekly", "one-off", "annual"]);
+  });
+
+  it("interleaves annual and one-off entries by next occurrence", () => {
+    const schedules = [
+      annual("christmas", "12-25"),
+      oneOff("next-week", "2026-08-15"),
+      annual("halloween", "10-31"),
+      oneOff("tomorrow", "2026-08-09"),
+    ];
+
+    expect(ids(sortSchedulesByStart(schedules, TODAY))).toEqual(["tomorrow", "next-week", "halloween", "christmas"]);
+  });
+
+  it("rolls an annual date that has already passed into next year", () => {
+    const schedules = [
+      annual("new-year", "01-01"), // already passed in 2026 → Jan 1 2027
+      annual("christmas", "12-25"), // still ahead in 2026
+    ];
+
+    expect(ids(sortSchedulesByStart(schedules, TODAY))).toEqual(["christmas", "new-year"]);
+  });
+
+  it("sorts an in-progress entry as happening today", () => {
+    const schedules = [
+      oneOff("upcoming", "2026-08-20"),
+      oneOff("in-progress", "2026-08-01", { one_off_end_date: "2026-08-12" }),
+    ];
+
+    expect(ids(sortSchedulesByStart(schedules, TODAY))).toEqual(["in-progress", "upcoming"]);
+  });
+
+  it("treats an annual window spanning the year boundary as active", () => {
+    const newYearsEve = new Date(2026, 11, 31); // Dec 31 2026
+    const schedules = [annual("upcoming", "01-15"), annual("holidays", "12-30", { annual_end_date: "01-02" })];
+
+    expect(ids(sortSchedulesByStart(schedules, newYearsEve))).toEqual(["holidays", "upcoming"]);
+  });
+
+  it("sinks expired one-offs below everything else, most recent first", () => {
+    const schedules = [
+      oneOff("last-year", "2025-06-01"),
+      oneOff("upcoming", "2026-09-01"),
+      oneOff("last-month", "2026-07-04"),
+      makeSchedule({ id: "weekly" }),
+    ];
+
+    expect(ids(sortSchedulesByStart(schedules, TODAY))).toEqual(["weekly", "upcoming", "last-month", "last-year"]);
+  });
+
+  it("keeps creation order for entries that start at the same moment", () => {
+    const schedules = [
+      makeSchedule({ id: "first", start_time: "09:00" }),
+      makeSchedule({ id: "second", start_time: "09:00" }),
+      makeSchedule({ id: "third", start_time: "09:00" }),
+    ];
+
+    expect(ids(sortSchedulesByStart(schedules, TODAY))).toEqual(["first", "second", "third"]);
+  });
+
+  it("orders same-day dated entries by start time", () => {
+    const schedules = [
+      oneOff("evening", "2026-08-09", { start_time: "19:00" }),
+      annual("morning", "08-09", { start_time: "07:00" }),
+    ];
+
+    expect(ids(sortSchedulesByStart(schedules, TODAY))).toEqual(["morning", "evening"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const schedules = [
+      makeSchedule({ id: "later", start_time: "18:00" }),
+      makeSchedule({ id: "earlier", start_time: "06:00" }),
+    ];
+
+    sortSchedulesByStart(schedules, TODAY);
+
+    expect(ids(schedules)).toEqual(["later", "earlier"]);
+  });
+});

--- a/web/src/components/schedule/schedule-list-view.tsx
+++ b/web/src/components/schedule/schedule-list-view.tsx
@@ -14,11 +14,13 @@ import {
 } from "@fiestaboard/ui";
 import { format } from "date-fns";
 import { Calendar, ChevronRight, Edit, GalleryHorizontalEnd, Moon, Trash2 } from "lucide-react";
+import { useMemo } from "react";
 
 import { useTranslations } from "@/i18n/translations";
 import type { Collection, Page, ScheduleEntry } from "@/lib/api";
 import { isCollectionId } from "@/lib/api";
 import type { ResolvedSilenceSchedule } from "@/lib/schedule-calendar";
+import { sortSchedulesByStart } from "@/lib/schedule-sort";
 
 interface ScheduleListViewProps {
   schedules: ScheduleEntry[];
@@ -123,6 +125,9 @@ export function ScheduleListView({
 
   const showSilenceRow = !!silenceSchedule?.enabled;
 
+  // Entries read chronologically, not in creation order.
+  const sortedSchedules = useMemo(() => sortSchedulesByStart(schedules), [schedules]);
+
   const getPageName = (pageId: string): string => {
     if (isCollectionId(pageId)) {
       const collection = collections.find((c) => c.id === pageId);
@@ -188,7 +193,7 @@ export function ScheduleListView({
         ) : (
           <Stack gap="3">
             {renderSilenceRow()}
-            {schedules.map((schedule) => {
+            {sortedSchedules.map((schedule) => {
               const pageName = getPageName(schedule.page_id);
               const toggleId = `schedule-enabled-${schedule.id}`;
               return (

--- a/web/src/lib/schedule-sort.ts
+++ b/web/src/lib/schedule-sort.ts
@@ -1,0 +1,102 @@
+/**
+ * Chronological ordering for schedule entries.
+ *
+ * The Schedule Entries list is read top-to-bottom to answer "when does what
+ * run?", so entries are ordered by when they next matter rather than by when
+ * they were created.
+ *
+ * Two groups:
+ *   1. Weekly entries — the everyday baseline, ordered by start time. They have
+ *      no start date, so there is nothing to order them against.
+ *   2. Dated entries — annual and one-off together, ordered by next occurrence,
+ *      so the section reads as a queue of what is coming up. One-offs whose
+ *      window has already passed sink to the bottom, most recent first.
+ */
+
+import { format } from "date-fns";
+
+import type { ScheduleEntry } from "./api";
+
+const WEEKLY = 0;
+const DATED = 1;
+const PAST = 2;
+
+interface SortKey {
+  /** WEEKLY | DATED | PAST */
+  group: number;
+  /** YYYY-MM-DD of the next occurrence; "" for weekly entries. */
+  date: string;
+  /** HH:MM start time. */
+  time: string;
+}
+
+/**
+ * Start time as HH:MM. Sun-based entries use the server-resolved time for today
+ * so a sunrise entry sorts where it actually fires, not where its fallback sits.
+ */
+function startTime(schedule: ScheduleEntry): string {
+  return schedule.resolved_start_time || schedule.start_time;
+}
+
+/** Next occurrence of an annual MM-DD relative to `today` (YYYY-MM-DD). */
+function nextAnnualDate(schedule: ScheduleEntry, today: string): SortKey {
+  const start = schedule.annual_date;
+  if (!start) return { group: DATED, date: today, time: startTime(schedule) };
+
+  const todayMmdd = today.slice(5);
+  const end = schedule.annual_end_date || start;
+  // A window that wraps the year boundary (12-30 → 01-02) is active when today
+  // is past the start OR before the end; a normal window needs both.
+  const active = start <= end ? todayMmdd >= start && todayMmdd <= end : todayMmdd >= start || todayMmdd <= end;
+  if (active) return { group: DATED, date: today, time: startTime(schedule) };
+
+  const year = Number(today.slice(0, 4));
+  const nextYear = todayMmdd <= start ? year : year + 1;
+  return { group: DATED, date: `${nextYear}-${start}`, time: startTime(schedule) };
+}
+
+/** Where a one-off date sits relative to `today` (YYYY-MM-DD). */
+function oneOffDate(schedule: ScheduleEntry, today: string): SortKey {
+  const start = schedule.one_off_date;
+  if (!start) return { group: DATED, date: today, time: startTime(schedule) };
+
+  const end = schedule.one_off_end_date || start;
+  if (end < today) return { group: PAST, date: start, time: startTime(schedule) };
+  // In progress: started before today but still running.
+  return { group: DATED, date: start < today ? today : start, time: startTime(schedule) };
+}
+
+function sortKey(schedule: ScheduleEntry, today: string): SortKey {
+  if (schedule.recurrence_type === "annual_date") return nextAnnualDate(schedule, today);
+  if (schedule.recurrence_type === "one_off_date") return oneOffDate(schedule, today);
+  return { group: WEEKLY, date: "", time: startTime(schedule) };
+}
+
+function compareKeys(a: SortKey, b: SortKey): number {
+  if (a.group !== b.group) return a.group - b.group;
+
+  const dateDiff = a.date.localeCompare(b.date);
+  // Expired entries read newest-first, so the most recently finished sits
+  // closest to the live entries above it.
+  if (dateDiff !== 0) return a.group === PAST ? -dateDiff : dateDiff;
+
+  return a.time.localeCompare(b.time);
+}
+
+/**
+ * Return a new array of schedules ordered by when they next run.
+ *
+ * `today` defaults to the current local date and exists so callers (and tests)
+ * can pin the reference point — the ordering of dated entries shifts as days
+ * pass, which is the point.
+ *
+ * Sorting is stable, so entries that start at the same moment keep their
+ * existing (creation) order.
+ */
+export function sortSchedulesByStart(schedules: ScheduleEntry[], today: Date = new Date()): ScheduleEntry[] {
+  const todayIso = format(today, "yyyy-MM-dd");
+  return schedules
+    .map((schedule) => ({ schedule, key: sortKey(schedule, todayIso) }))
+    .sort((a, b) => compareKeys(a.key, b.key))
+    .map(({ schedule }) => schedule);
+}


### PR DESCRIPTION
## Description
The Schedule Entries list rendered in creation order, which made it hard to read off when the board actually changes. 

This PR changes to sort chronologically instead: weekly entries first (the everyday baseline, ordered by start time), then annual and one-off entries merged and ordered by their next occurrence, so that section reads as a queue of what is coming up. One-offs whose window has already passed sink to the bottom, most recent first.

Sun-based entries sort on their server-resolved time, so a sunrise entry lands where it actually fires rather than at its stored fallback. The reference date is injectable so the ordering stays testable as days pass.

### Before
<img width="931" height="816" alt="Screenshot 2026-08-08 at 12 40 42 PM" src="https://github.com/user-attachments/assets/72b86943-1914-4ede-bfcc-9a504bf86792" />
### After
<img width="935" height="821" alt="Screenshot 2026-08-08 at 12 41 03 PM" src="https://github.com/user-attachments/assets/f1986b20-0e00-432a-af3e-4a3dea36b94f" />


## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] New plugin
- [ ] Documentation update
- [ ] Refactor / maintenance

## Checklist

- [X] I have tested my changes locally
- [X] I have added/updated tests where applicable
- [X] I have updated documentation where applicable
- [X] My code follows the project's coding standards
