### PR TITLE
fix(web): close two UI-test races (board-switch ref, LanguageSelector click)

### DIFF
--- a/web/src/__tests__/language-selector.test.tsx
+++ b/web/src/__tests__/language-selector.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -49,10 +49,14 @@ describe("LanguageSelector", () => {
     const trigger = screen.getByRole("combobox", { name: /language/i });
     await user.click(trigger);
 
-    const spanishOption = screen.getByText("Español");
-    await user.click(spanishOption);
+    // The Select popup mounts with `opacity: 0; pointer-events: none` and only
+    // becomes interactive once its open transition has run. Waiting for the
+    // listbox before clicking keeps user-event from firing at a popup that
+    // still refuses pointer events.
+    await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument());
+    await user.click(screen.getByRole("option", { name: "Español" }));
 
-    expect(document.cookie).toContain("NEXT_LOCALE=es");
+    await waitFor(() => expect(document.cookie).toContain("NEXT_LOCALE=es"));
     expect(changeLanguageMock).toHaveBeenCalledWith("es");
   });
 

--- a/web/src/components/current-board-context.tsx
+++ b/web/src/components/current-board-context.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { flushSync } from "react-dom";
 
 import { useBoardSettings } from "@/hooks/use-board";
@@ -100,12 +100,21 @@ export function CurrentBoardProvider({ children }: { children: React.ReactNode }
 
   // Refs so setCurrentBoardId can compute the switch direction without
   // changing identity every time the selection or board list updates.
+  //
+  // These sync in a LAYOUT effect, not a passive one: passive effects are
+  // deferred until after paint, which leaves a window where the committed DOM
+  // already shows the reconciled board but the refs still hold the previous
+  // value. A click landing in that window makes setCurrentBoardId compare
+  // against a stale id — re-selecting the board that is already current would
+  // run a spurious view transition, and a real switch would compute its
+  // direction from the wrong `fromIndex`. Layout effects run synchronously
+  // with the commit, so the refs can never lag what the user sees.
   const currentBoardIdRef = useRef(currentBoardId);
   const boardsRef = useRef(boards);
-  useEffect(() => {
+  useLayoutEffect(() => {
     currentBoardIdRef.current = currentBoardId;
   }, [currentBoardId]);
-  useEffect(() => {
+  useLayoutEffect(() => {
     boardsRef.current = boards;
   }, [boards]);
 


### PR DESCRIPTION
## What the CI bot reported, and what was actually true

`fiestaboard-ci-bot` blocked the FiestaUI v1.6.4 upgrade (#1530) with:

> FiestaBoard `main` fails typecheck/tests **before** the v1.6.4 bump — baseline failure, not an upgrade issue.

**That was a false alarm.** The log the bot pasted as evidence is React `act(...)` warnings from `board-display-colors.test.tsx`. Those go to stderr and are warnings only — nothing in `vitest.config.ts` or `src/__tests__/setup.ts` escalates `console.error` to a failure. The bot's own pasted summary ends with:

```
 Test Files  109 passed (109)
      Tests  1375 passed | 13 skipped (1388)
```

Zero failures. `CI: Lint, Test & Build` on `main` is green, and #1530 has since merged on its own.

## The real problems this PR fixes

Reproducing the suite locally (macOS) surfaced two failures that CI's slower Linux runners happen not to hit. Both are genuine races, not test noise.

### 1. `CurrentBoardProvider` compares against a stale ref

`currentBoardIdRef` and `boardsRef` were synced in **passive** effects, which React defers until after paint. Between the commit and that flush, the committed DOM already shows the reconciled board while the refs still hold the previous value. A click landing in that window makes `setCurrentBoardId` compare `boardId` against a stale id, so:

- re-selecting the board that is already current starts a spurious view transition, and
- a real switch computes its direction from the wrong `fromIndex` (slide-left vs slide-right).

That is exactly the observed failure — `expected "vi.fn()" to not be called at all, but actually been called 1 times` in *"re-selecting the current board does not start a transition"*. `runBoardSwitchTransition` is reachable only when `boardId !== currentBoardIdRef.current`, and `waitFor` had already asserted the DOM read `one`, so the ref must have been stale.

This is a production bug, not just a test bug: in a browser, passive effects are deferred to a scheduler callback after paint, so a fast click right as the board list loads can land in the same window.

Fix: sync both refs in `useLayoutEffect`, which runs synchronously with the commit, so the refs can never lag what the user sees. `react-router.config.ts` sets `ssr: false`, so there is no hydration tradeoff, and `useLayoutEffect` is already used elsewhere in `web/src`.

### 2. `LanguageSelector` test clicks a popup that still refuses pointer events

The test clicked the option as soon as the trigger click resolved. The Select popup mounts with `opacity: 0; pointer-events: none` and only becomes interactive once its open transition has run, so user-event aborted with `Unable to perform pointer interaction as the element has pointer-events: none`. Confirmed by polling: the option does become interactive a moment later.

Fix: wait for the listbox before clicking and select by role — the pattern the other Select tests in this suite (`display-settings`, `schedule-entry-form-select`) already use. No suppression, no `pointerEventsCheck` escape hatch.

## Verification

`npm run test:run`, three consecutive full runs on the branch:

```
 Test Files  109 passed (109)
      Tests  1375 passed | 13 skipped (1388)
```

`npm run test:coverage` (the command CI actually runs) passes its 80% thresholds, matching CI's numbers exactly:

```
Statements   : 87.77% ( 2162/2463 )
Branches     : 83.78% ( 1715/2047 )
Functions    : 82.8% ( 549/663 )
Lines        : 89.04% ( 2015/2263 )
```

`npm run lint` — 0 errors (413 pre-existing `i18next/no-literal-string` warnings). `npm run format:check` — clean.

## Known follow-up: `web` typecheck is red and unenforced

`cd web && npm run typecheck` reports **138 errors across 43 files** on `main`. This is untouched here because it is pre-existing and out of scope for a test fix — and because **CI never runs it**: `.github/workflows/ci.yml` runs `npm run typecheck` only for `docs-site`; the `Lint UI (web)` job runs ESLint and Prettier and nothing else. None of the 138 errors involve `@fiestaboard/ui`, so none are upgrade-related.

Error count before and after this PR is identical (138 → 138). Worst offenders:

| Errors | File |
| --- | --- |
| 12 | `tests/note-pages.spec.ts` |
| 10 | `src/components/page-builder.tsx` |
| 9 | `src/components/page-grid-selector.stories.tsx` |
| 9 | `src/__tests__/page-grid-selector.test.tsx` |
| 8 | `src/components/tiptap-template-editor/components/VariablePickerContent.tsx` |
| 8 | `src/__tests__/tiptap-template-editor-enter.test.ts` |

Much of it is TipTap v3 type drift (`ReactNodeViewProps` vs the hand-written `*NodeViewProps`) plus `Playwright` specs missing optional-property narrowing. Worth a dedicated PR that fixes the tree and then adds a `Typecheck (web)` step to `lint-web` so it cannot rot again.

## Relationship to #1530

#1530 was never actually blocked by a baseline failure and has already merged. This PR does not touch it. It removes the two real races so the next upgrade PR's CI signal is trustworthy, and documents that the "typecheck fails" half of the bot's claim is true but has never been gated.