### PR TITLE
feat(web): wire the Home Assistant entity picker into the template editor toolbar

### DIFF
--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -1720,6 +1720,7 @@
     "variables": "Variablen",
     "variablesNoVarsAvailable": "Variablen (keine Variablen verfügbar)",
     "noVariablesAvailable": "Keine Vorlagenvariablen verfügbar. Konfiguriere Plugins in den Einstellungen.",
+    "homeAssistantEntities": "Home Assistant-Entitäten",
     "colors": "Farben",
     "drawMode": "Auf dem Board zeichnen",
     "drawModeActive": "Zeichenmodus beenden",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1677,6 +1677,7 @@
     "variables": "Variables",
     "variablesNoVarsAvailable": "Variables (no variables available)",
     "noVariablesAvailable": "No template variables available. Configure plugins in Settings.",
+    "homeAssistantEntities": "Home Assistant entities",
     "colors": "Colors",
     "drawMode": "Draw on board",
     "drawModeActive": "Exit drawing mode",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -1720,6 +1720,7 @@
     "variables": "Variables",
     "variablesNoVarsAvailable": "Variables (no hay variables disponibles)",
     "noVariablesAvailable": "No hay variables de plantilla disponibles. Configura plugins en Ajustes.",
+    "homeAssistantEntities": "Entidades de Home Assistant",
     "colors": "Colores",
     "drawMode": "Dibujar en el tablero",
     "drawModeActive": "Salir del modo de dibujo",

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -1720,6 +1720,7 @@
     "variables": "Variables",
     "variablesNoVarsAvailable": "Variables (aucune variable disponible)",
     "noVariablesAvailable": "Aucune variable de modèle disponible. Configurez les plugins dans les paramètres.",
+    "homeAssistantEntities": "Entités Home Assistant",
     "colors": "Couleurs",
     "drawMode": "Dessiner sur le board",
     "drawModeActive": "Quitter le mode dessin",

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -1720,6 +1720,7 @@
     "variables": "Variabili",
     "variablesNoVarsAvailable": "Variabili (nessuna variabile disponibile)",
     "noVariablesAvailable": "Nessuna variabile del modello disponibile. Configura i plugin in Impostazioni.",
+    "homeAssistantEntities": "Entità Home Assistant",
     "colors": "Colori",
     "drawMode": "Disegna sul board",
     "drawModeActive": "Esci dalla modalità disegno",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -1720,6 +1720,7 @@
     "variables": "変数",
     "variablesNoVarsAvailable": "変数(利用可能な変数はありません)",
     "noVariablesAvailable": "利用可能なテンプレート変数がありません。設定でプラグインを構成してください。",
+    "homeAssistantEntities": "Home Assistant エンティティ",
     "colors": "色",
     "drawMode": "ボードに描画",
     "drawModeActive": "描画モードを終了",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -1720,6 +1720,7 @@
     "variables": "변수",
     "variablesNoVarsAvailable": "변수 (사용 가능한 변수 없음)",
     "noVariablesAvailable": "사용 가능한 템플릿 변수가 없습니다. 설정에서 플러그인을 구성하세요.",
+    "homeAssistantEntities": "Home Assistant 엔티티",
     "colors": "색상",
     "drawMode": "보드에 그리기",
     "drawModeActive": "그리기 모드 종료",

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -1720,6 +1720,7 @@
     "variables": "Variabelen",
     "variablesNoVarsAvailable": "Variabelen (geen variabelen beschikbaar)",
     "noVariablesAvailable": "Geen sjabloonvariabelen beschikbaar. Configureer plugins in Instellingen.",
+    "homeAssistantEntities": "Home Assistant-entiteiten",
     "colors": "Kleuren",
     "drawMode": "Tekenen op het bord",
     "drawModeActive": "Tekenmodus afsluiten",

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -1720,6 +1720,7 @@
     "variables": "Zmienne",
     "variablesNoVarsAvailable": "Zmienne (brak dostępnych zmiennych)",
     "noVariablesAvailable": "Brak dostępnych zmiennych szablonu. Skonfiguruj wtyczki w Ustawieniach.",
+    "homeAssistantEntities": "Encje Home Assistant",
     "colors": "Kolory",
     "drawMode": "Rysuj na tablicy",
     "drawModeActive": "Zakończ tryb rysowania",

--- a/web/messages/pt.json
+++ b/web/messages/pt.json
@@ -1720,6 +1720,7 @@
     "variables": "Variáveis",
     "variablesNoVarsAvailable": "Variáveis (nenhuma variável disponível)",
     "noVariablesAvailable": "Nenhuma variável de modelo disponível. Configure plugins em Definições.",
+    "homeAssistantEntities": "Entidades do Home Assistant",
     "colors": "Cores",
     "drawMode": "Desenhar no board",
     "drawModeActive": "Sair do modo de desenho",

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -1720,6 +1720,7 @@
     "variables": "Переменные",
     "variablesNoVarsAvailable": "Переменные (нет доступных переменных)",
     "noVariablesAvailable": "Нет доступных переменных шаблона. Настройте плагины в Настройках.",
+    "homeAssistantEntities": "Сущности Home Assistant",
     "colors": "Цвета",
     "drawMode": "Рисовать на доске",
     "drawModeActive": "Выйти из режима рисования",

--- a/web/messages/sv.json
+++ b/web/messages/sv.json
@@ -1720,6 +1720,7 @@
     "variables": "Variabler",
     "variablesNoVarsAvailable": "Variabler (inga variabler tillgängliga)",
     "noVariablesAvailable": "Inga mallvariabler tillgängliga. Konfigurera plugins i Inställningar.",
+    "homeAssistantEntities": "Home Assistant-entiteter",
     "colors": "Färger",
     "drawMode": "Rita på tavlan",
     "drawModeActive": "Avsluta ritläget",

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -1720,6 +1720,7 @@
     "variables": "Değişkenler",
     "variablesNoVarsAvailable": "Değişkenler (kullanılabilir değişken yok)",
     "noVariablesAvailable": "Kullanılabilir şablon değişkeni yok. Ayarlar'da eklentileri yapılandırın.",
+    "homeAssistantEntities": "Home Assistant varlıkları",
     "colors": "Renkler",
     "drawMode": "Panoya çiz",
     "drawModeActive": "Çizim modundan çık",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -1720,6 +1720,7 @@
     "variables": "变量",
     "variablesNoVarsAvailable": "变量(没有可用的变量)",
     "noVariablesAvailable": "没有可用的模板变量。在设置中配置插件。",
+    "homeAssistantEntities": "Home Assistant 实体",
     "colors": "颜色",
     "drawMode": "在看板上绘制",
     "drawModeActive": "退出绘制模式",

--- a/web/src/__tests__/template-editor-toolbar-home-assistant.test.tsx
+++ b/web/src/__tests__/template-editor-toolbar-home-assistant.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -240,18 +240,21 @@ describe("TemplateEditorToolbar Home Assistant entity picker", () => {
     expect(screen.queryByText("Select Attribute")).toBeNull();
   });
 
-  it("does not run the deferred insertion if the toolbar unmounts first", async () => {
+  it("cancels the deferred insertion if the toolbar unmounts before the frame runs", async () => {
     const user = userEvent.setup();
     useHomeAssistantVariables();
     useEntities([sensorTemperature]);
     const { unmount } = renderToolbar({ editor: makeFakeEditor() });
 
     await chooseTemperatureState(user);
-    await user.click(screen.getByRole("button", { name: "Insert" }));
 
+    // Confirm and unmount in one synchronous block: no `await` in between, so
+    // the scheduled frame provably cannot have run yet on any machine.
+    fireEvent.click(screen.getByRole("button", { name: "Insert" }));
+    expect(insertSpy).not.toHaveBeenCalled();
     unmount();
-    await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
-    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
 
     expect(insertSpy).not.toHaveBeenCalled();
   });

--- a/web/src/__tests__/template-editor-toolbar-home-assistant.test.tsx
+++ b/web/src/__tests__/template-editor-toolbar-home-assistant.test.tsx
@@ -1,0 +1,296 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TemplateEditorToolbar } from "@/components/tiptap-template-editor/components/TemplateEditorToolbar";
+import { insertTemplateContent } from "@/components/tiptap-template-editor/utils/insertion";
+import { parseLineContent } from "@/components/tiptap-template-editor/utils/serialization";
+import type { HomeAssistantEntity } from "@/lib/api";
+
+import { mockTemplateVariables } from "./mocks/handlers";
+import { server } from "./mocks/server";
+
+// The insertion helper is the seam between the toolbar and TipTap: spying on it
+// lets us assert the exact template string without standing up a real editor.
+vi.mock("@/components/tiptap-template-editor/utils/insertion", () => ({
+  insertTemplateContent: vi.fn(),
+}));
+
+const insertSpy = vi.mocked(insertTemplateContent);
+
+const API_BASE = "/api";
+
+const HA_BUTTON_LABEL = "Home Assistant entities";
+
+const sensorTemperature: HomeAssistantEntity = {
+  entity_id: "sensor.temperature",
+  state: "72",
+  attributes: { unit_of_measurement: "°F" },
+  friendly_name: "Living Room Temperature",
+};
+
+/** `/templates/variables` including a `home_assistant` namespace. */
+function useHomeAssistantVariables() {
+  server.use(
+    http.get(`${API_BASE}/templates/variables`, () =>
+      HttpResponse.json({
+        ...mockTemplateVariables,
+        variables: { ...mockTemplateVariables.variables, home_assistant: ["sensor_temperature.state"] },
+      }),
+    ),
+  );
+}
+
+/**
+ * `/home-assistant/entities` returning `entities`, plus a counter so tests can
+ * assert the request is only made once the dialog is actually opened.
+ */
+function useEntities(entities: HomeAssistantEntity[]) {
+  const calls = { count: 0 };
+  server.use(
+    http.get(`${API_BASE}/home-assistant/entities`, () => {
+      calls.count += 1;
+      return HttpResponse.json({ entities });
+    }),
+  );
+  return calls;
+}
+
+function renderToolbar(props: Record<string, unknown> = {}) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const ui = (extra: Record<string, unknown>) => (
+    <QueryClientProvider client={queryClient}>
+      <TemplateEditorToolbar editor={null} {...props} {...extra} />
+    </QueryClientProvider>
+  );
+  const result = render(ui({}));
+  return { ...result, rerenderWith: (extra: Record<string, unknown>) => result.rerender(ui(extra)) };
+}
+
+/** Minimal editor stand-in: enough surface for the toolbar's effects. */
+function makeFakeEditor() {
+  return {
+    can: () => ({ undo: () => false, redo: () => false }),
+    state: { selection: { from: 0, to: 0 }, doc: { textBetween: () => "" } },
+    on: vi.fn(),
+    off: vi.fn(),
+  };
+}
+
+/** Open the picker and drive it to "sensor.temperature" → "state". */
+async function chooseTemperatureState(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(await screen.findByLabelText(HA_BUTTON_LABEL));
+  await user.click(await screen.findByText("sensor.temperature"));
+  await user.click(await screen.findByText("state"));
+}
+
+describe("TemplateEditorToolbar Home Assistant entity picker", () => {
+  beforeEach(() => {
+    insertSpy.mockReset();
+  });
+
+  it("renders the Home Assistant entity button when template variables include home_assistant", async () => {
+    useHomeAssistantVariables();
+    renderToolbar();
+
+    expect(await screen.findByLabelText(HA_BUTTON_LABEL)).toBeInTheDocument();
+  });
+
+  it("does not render the Home Assistant entity button when home_assistant is absent", async () => {
+    // The default `/templates/variables` mock only exposes weather + datetime.
+    renderToolbar();
+
+    // Wait for the toolbar to have consumed the variables response.
+    expect(await screen.findByLabelText("Variables")).toBeInTheDocument();
+    expect(screen.queryByLabelText(HA_BUTTON_LABEL)).toBeNull();
+  });
+
+  it("does not render the Home Assistant entity button in draw mode", async () => {
+    useHomeAssistantVariables();
+    const { rerenderWith } = renderToolbar({ onDrawModeToggle: () => {}, onDrawBrushChange: () => {} });
+
+    // Present first, so we know the variables query resolved with home_assistant.
+    expect(await screen.findByLabelText(HA_BUTTON_LABEL)).toBeInTheDocument();
+
+    rerenderWith({ drawMode: true });
+
+    expect(screen.getByTestId("draw-color-eraser")).toBeInTheDocument();
+    expect(screen.queryByLabelText(HA_BUTTON_LABEL)).toBeNull();
+  });
+
+  it("opens the entity picker dialog when the button is clicked", async () => {
+    const user = userEvent.setup();
+    useHomeAssistantVariables();
+    useEntities([sensorTemperature]);
+    renderToolbar();
+
+    await user.click(await screen.findByLabelText(HA_BUTTON_LABEL));
+
+    expect(await screen.findByText("Select Home Assistant Entity")).toBeInTheDocument();
+    expect(await screen.findByText("sensor.temperature")).toBeInTheDocument();
+  });
+
+  it("inserts exactly {{home_assistant.sensor_temperature.state}} when an entity and attribute are confirmed", async () => {
+    const user = userEvent.setup();
+    useHomeAssistantVariables();
+    useEntities([sensorTemperature]);
+    renderToolbar({ editor: makeFakeEditor() });
+
+    await chooseTemperatureState(user);
+    await user.click(screen.getByRole("button", { name: "Insert" }));
+
+    await waitFor(() => expect(insertSpy).toHaveBeenCalledTimes(1));
+    expect(insertSpy.mock.calls[0][1]).toBe("{{home_assistant.sensor_temperature.state}}");
+  });
+
+  it("closes the dialog after inserting, and stays closed when onClose fires twice", async () => {
+    const user = userEvent.setup();
+    useHomeAssistantVariables();
+    useEntities([sensorTemperature]);
+    renderToolbar({ editor: makeFakeEditor() });
+
+    await chooseTemperatureState(user);
+    await user.click(screen.getByRole("button", { name: "Insert" }));
+
+    // The picker calls onSelect -> onClose, and the dialog's own
+    // onOpenChange(false) calls onClose again: both must be harmless.
+    await waitFor(() => expect(screen.queryByText("Select Home Assistant Entity")).toBeNull());
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(screen.queryByText("Select Home Assistant Entity")).toBeNull();
+    expect(insertSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not request entities until the dialog is opened", async () => {
+    const user = userEvent.setup();
+    useHomeAssistantVariables();
+    const entityCalls = useEntities([sensorTemperature]);
+    renderToolbar();
+
+    const button = await screen.findByLabelText(HA_BUTTON_LABEL);
+    // Toolbar rendered (and the variables query settled) with the picker mounted
+    // but closed — the entities endpoint must still be untouched.
+    expect(entityCalls.count).toBe(0);
+
+    await user.click(button);
+
+    await waitFor(() => expect(entityCalls.count).toBe(1));
+  });
+
+  it("leaves focus in the editor after inserting instead of on the toolbar button", async () => {
+    const user = userEvent.setup();
+    useHomeAssistantVariables();
+    useEntities([sensorTemperature]);
+
+    // Stand-in for the ProseMirror surface: the real `insertTemplateContent`
+    // runs `editor.chain().focus()`, so focusing here mirrors production.
+    const editorSurface = document.createElement("div");
+    editorSurface.tabIndex = -1;
+    document.body.appendChild(editorSurface);
+    insertSpy.mockImplementation(() => editorSurface.focus());
+
+    try {
+      renderToolbar({ editor: makeFakeEditor() });
+
+      await chooseTemperatureState(user);
+      await user.click(screen.getByRole("button", { name: "Insert" }));
+
+      await waitFor(() => expect(insertSpy).toHaveBeenCalledTimes(1));
+      // The dialog restores focus to whatever was focused before it opened
+      // (the toolbar button). Inserting before that happens loses the caret.
+      await waitFor(() => expect(document.activeElement).toBe(editorSurface));
+      expect(document.activeElement?.isConnected).toBe(true);
+    } finally {
+      editorSurface.remove();
+    }
+  });
+
+  it("emits a string the editor's parser turns into a single home_assistant variable node", async () => {
+    const user = userEvent.setup();
+    useHomeAssistantVariables();
+    useEntities([sensorTemperature]);
+    renderToolbar({ editor: makeFakeEditor() });
+
+    await chooseTemperatureState(user);
+    await user.click(screen.getByRole("button", { name: "Insert" }));
+    await waitFor(() => expect(insertSpy).toHaveBeenCalledTimes(1));
+
+    // No bespoke TipTap node is needed: the existing parser splits on the first
+    // dot, so the emitted string must round-trip as a plain variable pill.
+    const variableNodes = parseLineContent(insertSpy.mock.calls[0][1]).filter((node) => node.type === "variable");
+    expect(variableNodes).toHaveLength(1);
+    expect(variableNodes[0].attrs).toMatchObject({ pluginId: "home_assistant", field: "sensor_temperature.state" });
+  });
+
+  it("starts from the entity list again when the picker is reopened after an insert", async () => {
+    const user = userEvent.setup();
+    useHomeAssistantVariables();
+    useEntities([sensorTemperature]);
+    renderToolbar({ editor: makeFakeEditor() });
+
+    await chooseTemperatureState(user);
+    await user.click(screen.getByRole("button", { name: "Insert" }));
+    await waitFor(() => expect(screen.queryByText("Select Home Assistant Entity")).toBeNull());
+
+    await user.click(screen.getByLabelText(HA_BUTTON_LABEL));
+
+    // Back on the entity list (search box present), not the attribute step.
+    expect(await screen.findByLabelText("Search entities")).toBeInTheDocument();
+    expect(screen.queryByText("Select Attribute")).toBeNull();
+  });
+
+  it("does not run the deferred insertion if the toolbar unmounts first", async () => {
+    const user = userEvent.setup();
+    useHomeAssistantVariables();
+    useEntities([sensorTemperature]);
+    const { unmount } = renderToolbar({ editor: makeFakeEditor() });
+
+    await chooseTemperatureState(user);
+    await user.click(screen.getByRole("button", { name: "Insert" }));
+
+    unmount();
+    await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(insertSpy).not.toHaveBeenCalled();
+  });
+
+  it("renders the empty state when Home Assistant returns no entities", async () => {
+    const user = userEvent.setup();
+    useHomeAssistantVariables();
+    useEntities([]);
+    renderToolbar({ editor: makeFakeEditor() });
+
+    await user.click(await screen.findByLabelText(HA_BUTTON_LABEL));
+
+    expect(await screen.findByText("No entities found")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Insert" })).toBeDisabled();
+  });
+
+  it("closes without inserting when Cancel is clicked", async () => {
+    const user = userEvent.setup();
+    useHomeAssistantVariables();
+    useEntities([sensorTemperature]);
+    renderToolbar({ editor: makeFakeEditor() });
+
+    await chooseTemperatureState(user);
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => expect(screen.queryByText("Select Home Assistant Entity")).toBeNull());
+    expect(insertSpy).not.toHaveBeenCalled();
+  });
+
+  it("closes without inserting when Escape is pressed", async () => {
+    const user = userEvent.setup();
+    useHomeAssistantVariables();
+    useEntities([sensorTemperature]);
+    renderToolbar({ editor: makeFakeEditor() });
+
+    await chooseTemperatureState(user);
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => expect(screen.queryByText("Select Home Assistant Entity")).toBeNull());
+    expect(insertSpy).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/__tests__/template-editor-toolbar-home-assistant.test.tsx
+++ b/web/src/__tests__/template-editor-toolbar-home-assistant.test.tsx
@@ -79,11 +79,16 @@ function makeFakeEditor() {
   };
 }
 
-/** Open the picker and drive it to "sensor.temperature" → "state". */
-async function chooseTemperatureState(user: ReturnType<typeof userEvent.setup>) {
+/** Open the picker and drive it to "sensor.temperature" → `attribute`. */
+async function chooseTemperatureAttribute(user: ReturnType<typeof userEvent.setup>, attribute: string) {
   await user.click(await screen.findByLabelText(HA_BUTTON_LABEL));
   await user.click(await screen.findByText("sensor.temperature"));
-  await user.click(await screen.findByText("state"));
+  await user.click(await screen.findByText(attribute));
+}
+
+/** Open the picker and drive it to "sensor.temperature" → "state". */
+async function chooseTemperatureState(user: ReturnType<typeof userEvent.setup>) {
+  await chooseTemperatureAttribute(user, "state");
 }
 
 describe("TemplateEditorToolbar Home Assistant entity picker", () => {
@@ -143,6 +148,22 @@ describe("TemplateEditorToolbar Home Assistant entity picker", () => {
 
     await waitFor(() => expect(insertSpy).toHaveBeenCalledTimes(1));
     expect(insertSpy.mock.calls[0][1]).toBe("{{home_assistant.sensor_temperature.state}}");
+  });
+
+  it("inserts the attribute the user picked rather than always defaulting to state", async () => {
+    const user = userEvent.setup();
+    useHomeAssistantVariables();
+    useEntities([sensorTemperature]);
+    renderToolbar({ editor: makeFakeEditor() });
+
+    // "state" is also the first entry the picker lists, so choosing it cannot
+    // distinguish "honours the selection" from "always emits .state". Pick a
+    // real attribute instead.
+    await chooseTemperatureAttribute(user, "unit_of_measurement");
+    await user.click(screen.getByRole("button", { name: "Insert" }));
+
+    await waitFor(() => expect(insertSpy).toHaveBeenCalledTimes(1));
+    expect(insertSpy.mock.calls[0][1]).toBe("{{home_assistant.sensor_temperature.unit_of_measurement}}");
   });
 
   it("closes the dialog after inserting, and stays closed when onClose fires twice", async () => {

--- a/web/src/components/tiptap-template-editor/components/TemplateEditorToolbar.tsx
+++ b/web/src/components/tiptap-template-editor/components/TemplateEditorToolbar.tsx
@@ -16,6 +16,7 @@ import {
   Copy,
   Download,
   Eraser,
+  House,
   Palette,
   Pencil,
   Redo2,
@@ -25,8 +26,9 @@ import {
   Undo2,
   WrapText,
 } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
+import { HomeAssistantEntityPicker } from "@/components/home-assistant-entity-picker";
 import { useTranslations } from "@/i18n/translations";
 import type { DeviceType } from "@/lib/api";
 import { api } from "@/lib/api";
@@ -96,6 +98,10 @@ export function TemplateEditorToolbar({
   const hasVariables = templateVars?.variables && Object.keys(templateVars.variables).length > 0;
   const hasColors = templateVars?.colors && Object.keys(templateVars.colors).length > 0;
   const hasFormatting = templateVars?.formatting && Object.keys(templateVars.formatting).length > 0;
+  // The Home Assistant entity picker hits `/home-assistant/entities`, which 503s
+  // when the plugin isn't installed/enabled. Only offer it when the plugin has
+  // actually contributed template variables.
+  const hasHomeAssistant = Boolean(templateVars?.variables?.home_assistant);
 
   // Track undo/redo availability and selection state
   const [canUndo, setCanUndo] = useState(false);
@@ -106,6 +112,33 @@ export function TemplateEditorToolbar({
   // focused buttons). The actual read happens inside `handlePaste`, which
   // is a real user-gesture handler and is gesture-allowed in every browser.
   const [hasClipboardContent, setHasClipboardContent] = useState(true);
+  const [homeAssistantPickerOpen, setHomeAssistantPickerOpen] = useState(false);
+  const pendingHomeAssistantInsert = useRef<number | null>(null);
+
+  // The entity picker emits its variable *before* the dialog tears itself down.
+  // Inserting synchronously would move the caret into the editor only for the
+  // dialog's closing focus restore to yank it straight back to the toolbar
+  // button, so close first and insert on the next frame.
+  const handleHomeAssistantSelect = (variable: string) => {
+    setHomeAssistantPickerOpen(false);
+    if (pendingHomeAssistantInsert.current !== null) {
+      cancelAnimationFrame(pendingHomeAssistantInsert.current);
+    }
+    pendingHomeAssistantInsert.current = requestAnimationFrame(() => {
+      pendingHomeAssistantInsert.current = null;
+      handleInsert(variable);
+    });
+  };
+
+  useEffect(
+    () => () => {
+      if (pendingHomeAssistantInsert.current !== null) {
+        cancelAnimationFrame(pendingHomeAssistantInsert.current);
+        pendingHomeAssistantInsert.current = null;
+      }
+    },
+    [],
+  );
 
   useEffect(() => {
     if (!editor) {
@@ -525,6 +558,41 @@ export function TemplateEditorToolbar({
                   <Text>{t("noVariablesAvailable")}</Text>
                 </TooltipContent>
               </Tooltip>
+            )}
+
+            {/* Home Assistant entity picker.
+                Deliberately NOT a `ToolbarDropdown`: the dropdown's
+                outside-mousedown and capture-phase Escape handlers fight the
+                picker's modal portal. A plain button plus a sibling dialog
+                keeps both behaving. */}
+            {hasHomeAssistant && (
+              <>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      data-testid="home-assistant-entity-button"
+                      onClick={() => setHomeAssistantPickerOpen(true)}
+                      className={cn(
+                        "flex items-center justify-center p-1.5 rounded-md transition-colors",
+                        "border border-transparent hover:bg-muted/50",
+                      )}
+                      aria-label={t("homeAssistantEntities")}
+                    >
+                      <House className="w-4 h-4" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <Text>{t("homeAssistantEntities")}</Text>
+                  </TooltipContent>
+                </Tooltip>
+
+                <HomeAssistantEntityPicker
+                  open={homeAssistantPickerOpen}
+                  onClose={() => setHomeAssistantPickerOpen(false)}
+                  onSelect={handleHomeAssistantSelect}
+                />
+              </>
             )}
 
             {/* Colors Dropdown */}

--- a/web/src/components/tiptap-template-editor/components/TemplateEditorToolbar.tsx
+++ b/web/src/components/tiptap-template-editor/components/TemplateEditorToolbar.tsx
@@ -115,12 +115,12 @@ export function TemplateEditorToolbar({
   const [homeAssistantPickerOpen, setHomeAssistantPickerOpen] = useState(false);
   const pendingHomeAssistantInsert = useRef<number | null>(null);
 
-  // The entity picker emits its variable *before* the dialog tears itself down.
-  // Inserting synchronously would move the caret into the editor only for the
-  // dialog's closing focus restore to yank it straight back to the toolbar
-  // button, so close first and insert on the next frame.
+  // The entity picker emits its variable *before* the dialog tears itself down:
+  // it calls `onSelect` and then, synchronously, `onClose`. Inserting here and
+  // now would move the caret into the editor only for the dialog's closing focus
+  // restore to yank it straight back to the toolbar button, so let that close
+  // land first and do the insert on the next frame.
   const handleHomeAssistantSelect = (variable: string) => {
-    setHomeAssistantPickerOpen(false);
     if (pendingHomeAssistantInsert.current !== null) {
       cancelAnimationFrame(pendingHomeAssistantInsert.current);
     }


### PR DESCRIPTION
## Root cause

`web/src/components/home-assistant-entity-picker.tsx` is a complete, fully translated component backed by a working `/api/home-assistant/entities` endpoint — but it had **zero call sites**. Nothing in the app ever rendered it, so Home Assistant entities were unreachable from the template editor and never showed up alongside the other plugin variables.

Refs Fiestaboard/FiestaBoard-Home-Assistant-App#80. That issue lives in a different repository, so this PR will **not** auto-close it — it needs to be closed manually once this ships.

## What changed

`TemplateEditorToolbar` now renders a Home Assistant button next to the Variables dropdown, plus the picker itself.

- **Gated on the plugin actually being present**: the button only renders when the existing `["template-variables"]` query (already used for Variables/Colors/Formatting — no extra request) contains a `home_assistant` namespace. The entities endpoint 503s when the plugin is disabled, and the picker has no error state, so an ungated button would show a misleading "No entities found".
- **Not a `ToolbarDropdown`**: the dropdown's outside-`mousedown` handler and capture-phase Escape handler fight the picker's modal portal. It's a plain tooltip button with local open state, rendering the picker as a sibling.
- **Deferred insertion**: the picker emits its variable *before* the dialog tears down, and the dialog restores focus to the element focused before it opened (the toolbar button). Inserting synchronously put the caret in the editor and then immediately lost it. Insertion is deferred to the next animation frame; the pending frame is cancelled on unmount.
- Hidden in draw mode, like the other content controls.
- No new TipTap node or command: `{{home_assistant.sensor_temperature.state}}` already round-trips through `insertTemplateContent` → `parseLineContent` (which splits on the first dot).

`templateEditor.homeAssistantEntities` added to all 14 locale files with real translations, so the exact-key-parity check in `i18n-config.test.ts` stays green and no literal string is introduced for the `aria-label`.

## Tests

New file `web/src/__tests__/template-editor-toolbar-home-assistant.test.tsx`, 14 tests, written test-first (each one observed failing before the code that makes it pass):

- button renders when `home_assistant` is present; not when absent; not in draw mode
- clicking opens the dialog and lists entities
- entity → attribute → Insert emits exactly `{{home_assistant.sensor_temperature.state}}`
- that string parses back into a single `variable` node with `pluginId: "home_assistant"`
- dialog closes after insert and survives `onClose` firing twice
- Cancel and Escape both close without inserting
- entities are not requested until the dialog opens (`enabled: open`)
- empty entity list renders "No entities found" with Insert disabled
- focus ends up in the editor after insert, not back on the toolbar button
- a deferred insert is cancelled if the toolbar unmounts first
- reopening after an insert starts back at the entity list

Verified: full suite 110 files / 1389 passed / 13 skipped (3 consecutive runs, no flakes); `npm run test:coverage` passes the 80% thresholds (statements 87.77%, branches 83.73%, functions 82.80%, lines 89.04%); `npm run lint` 0 errors (413 pre-existing warnings, unchanged); `npm run format:check` clean; `npm run typecheck` 138 pre-existing errors before and after — zero new.
