### PR TITLE
chore(ci): consolidate bot commit identities

### DIFF
--- a/.github/workflows/build-fiestapi.yml
+++ b/.github/workflows/build-fiestapi.yml
@@ -334,7 +334,7 @@ jobs:
           # Checkout the main branch of FiestaBoard so we can commit to it.
           cd "$GITHUB_WORKSPACE/FiestaBoard"
           git config user.name "FiestaBoard CI"
-          git config user.email "ci@fiestaboard.dev"
+          git config user.email "ci@fiestaboard.app"
           git fetch origin main
           git checkout -B main origin/main
 

--- a/.github/workflows/build-fiestapi.yml
+++ b/.github/workflows/build-fiestapi.yml
@@ -333,8 +333,8 @@ jobs:
         run: |
           # Checkout the main branch of FiestaBoard so we can commit to it.
           cd "$GITHUB_WORKSPACE/FiestaBoard"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "FiestaBoard CI"
+          git config user.email "ci@fiestaboard.dev"
           git fetch origin main
           git checkout -B main origin/main
 

--- a/.github/workflows/claude-a11y-audit-feedback.yml
+++ b/.github/workflows/claude-a11y-audit-feedback.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Configure git identity
         run: |
           git config user.name "FiestaBoard CI"
-          git config user.email "ci@fiestaboard.dev"
+          git config user.email "ci@fiestaboard.app"
 
       - name: Capture rejection
         env:

--- a/.github/workflows/claude-a11y-audit-feedback.yml
+++ b/.github/workflows/claude-a11y-audit-feedback.yml
@@ -85,8 +85,8 @@ jobs:
 
       - name: Configure git identity
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "FiestaBoard CI"
+          git config user.email "ci@fiestaboard.dev"
 
       - name: Capture rejection
         env:

--- a/.github/workflows/claude-a11y-audit.yml
+++ b/.github/workflows/claude-a11y-audit.yml
@@ -159,8 +159,8 @@ jobs:
       - name: Configure git identity
         if: steps.dedup.outputs.go == 'true'
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "FiestaBoard CI"
+          git config user.email "ci@fiestaboard.dev"
 
       - name: Run Claude a11y-audit
         if: steps.dedup.outputs.go == 'true'
@@ -193,7 +193,7 @@ jobs:
           claude_args: >-
             --model claude-opus-4-8
             --max-turns 250
-            --allowed-tools "Read,Glob,Grep,Edit,Write,Bash(ls:*),Bash(cat:*),Bash(find:*),Bash(date:*),Bash(jq:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git rev-parse:*),Bash(gh issue list:*),Bash(gh issue view:*),Bash(gh issue create:*),Bash(gh issue edit:*),Bash(gh label list:*),Bash(gh label create:*)"
+            --allowed-tools "Read,Glob,Grep,Edit,Write,Bash(ls:*),Bash(cat:*),Bash(find:*),Bash(date:*),Bash(jq:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git add:*),Bash(git commit:*),Bash(git -c:*),Bash(git push:*),Bash(git rev-parse:*),Bash(gh issue list:*),Bash(gh issue view:*),Bash(gh issue create:*),Bash(gh issue edit:*),Bash(gh label list:*),Bash(gh label create:*)"
           prompt: |
             You are the FiestaBoard **accessibility (a11y) auditor**. You run
             unattended once a week and statically audit a batch of web UI
@@ -436,7 +436,7 @@ jobs:
             4. Commit to `main` directly and push:
                ```bash
                git add .github/a11y-audit-state.json
-               git commit -m "chore(a11y-audit): advance sweep state [skip ci]" || exit 0
+               git -c user.name="FiestaBoard CI" -c user.email="ci@fiestaboard.dev" commit -m "chore(a11y-audit): advance sweep state [skip ci]" || exit 0
                git push origin HEAD:main
                ```
                This is the ONLY commit you make.
@@ -478,5 +478,5 @@ jobs:
             exit 0
           fi
           git add .github/a11y-audit-state.json
-          git commit -m "chore(a11y-audit): advance sweep state [skip ci]"
+          git -c user.name="FiestaBoard CI" -c user.email="ci@fiestaboard.dev" commit -m "chore(a11y-audit): advance sweep state [skip ci]"
           git push origin HEAD:main

--- a/.github/workflows/claude-a11y-audit.yml
+++ b/.github/workflows/claude-a11y-audit.yml
@@ -160,7 +160,7 @@ jobs:
         if: steps.dedup.outputs.go == 'true'
         run: |
           git config user.name "FiestaBoard CI"
-          git config user.email "ci@fiestaboard.dev"
+          git config user.email "ci@fiestaboard.app"
 
       - name: Run Claude a11y-audit
         if: steps.dedup.outputs.go == 'true'
@@ -436,7 +436,7 @@ jobs:
             4. Commit to `main` directly and push:
                ```bash
                git add .github/a11y-audit-state.json
-               git -c user.name="FiestaBoard CI" -c user.email="ci@fiestaboard.dev" commit -m "chore(a11y-audit): advance sweep state [skip ci]" || exit 0
+               git -c user.name="FiestaBoard CI" -c user.email="ci@fiestaboard.app" commit -m "chore(a11y-audit): advance sweep state [skip ci]" || exit 0
                git push origin HEAD:main
                ```
                This is the ONLY commit you make.
@@ -478,5 +478,5 @@ jobs:
             exit 0
           fi
           git add .github/a11y-audit-state.json
-          git -c user.name="FiestaBoard CI" -c user.email="ci@fiestaboard.dev" commit -m "chore(a11y-audit): advance sweep state [skip ci]"
+          git -c user.name="FiestaBoard CI" -c user.email="ci@fiestaboard.app" commit -m "chore(a11y-audit): advance sweep state [skip ci]"
           git push origin HEAD:main

--- a/.github/workflows/claude-bug-hunt-feedback.yml
+++ b/.github/workflows/claude-bug-hunt-feedback.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Configure git identity
         run: |
           git config user.name "FiestaBoard CI"
-          git config user.email "ci@fiestaboard.dev"
+          git config user.email "ci@fiestaboard.app"
 
       - name: Capture rejection
         env:

--- a/.github/workflows/claude-bug-hunt-feedback.yml
+++ b/.github/workflows/claude-bug-hunt-feedback.yml
@@ -79,8 +79,8 @@ jobs:
 
       - name: Configure git identity
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "FiestaBoard CI"
+          git config user.email "ci@fiestaboard.dev"
 
       - name: Capture rejection
         env:

--- a/.github/workflows/claude-bug-hunt-learn.yml
+++ b/.github/workflows/claude-bug-hunt-learn.yml
@@ -97,8 +97,8 @@ jobs:
       - name: Configure git identity
         if: steps.dedup.outputs.go == 'true'
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "FiestaBoard CI"
+          git config user.email "ci@fiestaboard.dev"
 
       - name: Gather fixed bugs since last learn
         id: gather
@@ -127,7 +127,7 @@ jobs:
           claude_args: >-
             --model claude-sonnet-4-6
             --max-turns 60
-            --allowed-tools "Read,Glob,Grep,Edit,Write,Bash(cat:*),Bash(jq:*),Bash(date:*),Bash(git status:*),Bash(git diff:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*)"
+            --allowed-tools "Read,Glob,Grep,Edit,Write,Bash(cat:*),Bash(jq:*),Bash(date:*),Bash(git status:*),Bash(git diff:*),Bash(git add:*),Bash(git commit:*),Bash(git -c:*),Bash(git push:*)"
           prompt: |
             You maintain the FiestaBoard bug-hunt **pattern memory** — the
             positive-learning file the daily bug hunter reads to hunt smarter.
@@ -171,7 +171,7 @@ jobs:
             2. Commit and push to `main`:
                ```bash
                git add .github/bug-hunt/pattern-memory.md .github/bug-hunt-state.json
-               git commit -m "chore(bug-hunt): refresh pattern memory [skip ci]" || exit 0
+               git -c user.name="FiestaBoard CI" -c user.email="ci@fiestaboard.dev" commit -m "chore(bug-hunt): refresh pattern memory [skip ci]" || exit 0
                git push origin HEAD:main
                ```
 
@@ -193,5 +193,5 @@ jobs:
             exit 0
           fi
           git add .github/bug-hunt/pattern-memory.md .github/bug-hunt-state.json
-          git commit -m "chore(bug-hunt): refresh pattern memory [skip ci]"
+          git -c user.name="FiestaBoard CI" -c user.email="ci@fiestaboard.dev" commit -m "chore(bug-hunt): refresh pattern memory [skip ci]"
           git push origin HEAD:main

--- a/.github/workflows/claude-bug-hunt-learn.yml
+++ b/.github/workflows/claude-bug-hunt-learn.yml
@@ -98,7 +98,7 @@ jobs:
         if: steps.dedup.outputs.go == 'true'
         run: |
           git config user.name "FiestaBoard CI"
-          git config user.email "ci@fiestaboard.dev"
+          git config user.email "ci@fiestaboard.app"
 
       - name: Gather fixed bugs since last learn
         id: gather
@@ -171,7 +171,7 @@ jobs:
             2. Commit and push to `main`:
                ```bash
                git add .github/bug-hunt/pattern-memory.md .github/bug-hunt-state.json
-               git -c user.name="FiestaBoard CI" -c user.email="ci@fiestaboard.dev" commit -m "chore(bug-hunt): refresh pattern memory [skip ci]" || exit 0
+               git -c user.name="FiestaBoard CI" -c user.email="ci@fiestaboard.app" commit -m "chore(bug-hunt): refresh pattern memory [skip ci]" || exit 0
                git push origin HEAD:main
                ```
 
@@ -193,5 +193,5 @@ jobs:
             exit 0
           fi
           git add .github/bug-hunt/pattern-memory.md .github/bug-hunt-state.json
-          git -c user.name="FiestaBoard CI" -c user.email="ci@fiestaboard.dev" commit -m "chore(bug-hunt): refresh pattern memory [skip ci]"
+          git -c user.name="FiestaBoard CI" -c user.email="ci@fiestaboard.app" commit -m "chore(bug-hunt): refresh pattern memory [skip ci]"
           git push origin HEAD:main

--- a/.github/workflows/claude-bug-hunt.yml
+++ b/.github/workflows/claude-bug-hunt.yml
@@ -172,7 +172,7 @@ jobs:
         if: steps.dedup.outputs.go == 'true'
         run: |
           git config user.name "FiestaBoard CI"
-          git config user.email "ci@fiestaboard.dev"
+          git config user.email "ci@fiestaboard.app"
 
       - name: Run Claude bug-hunt
         if: steps.dedup.outputs.go == 'true'
@@ -406,7 +406,7 @@ jobs:
             4. Commit to `main` directly and push:
                ```bash
                git add .github/bug-hunt-state.json
-               git -c user.name="FiestaBoard CI" -c user.email="ci@fiestaboard.dev" commit -m "chore(bug-hunt): advance sweep state [skip ci]" || exit 0
+               git -c user.name="FiestaBoard CI" -c user.email="ci@fiestaboard.app" commit -m "chore(bug-hunt): advance sweep state [skip ci]" || exit 0
                git push origin HEAD:main
                ```
                This is the ONLY commit you make.
@@ -451,5 +451,5 @@ jobs:
             exit 0
           fi
           git add .github/bug-hunt-state.json
-          git -c user.name="FiestaBoard CI" -c user.email="ci@fiestaboard.dev" commit -m "chore(bug-hunt): advance sweep state [skip ci]"
+          git -c user.name="FiestaBoard CI" -c user.email="ci@fiestaboard.app" commit -m "chore(bug-hunt): advance sweep state [skip ci]"
           git push origin HEAD:main

--- a/.github/workflows/claude-bug-hunt.yml
+++ b/.github/workflows/claude-bug-hunt.yml
@@ -171,8 +171,8 @@ jobs:
       - name: Configure git identity
         if: steps.dedup.outputs.go == 'true'
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "FiestaBoard CI"
+          git config user.email "ci@fiestaboard.dev"
 
       - name: Run Claude bug-hunt
         if: steps.dedup.outputs.go == 'true'
@@ -206,7 +206,7 @@ jobs:
           claude_args: >-
             --model claude-sonnet-4-6
             --max-turns 250
-            --allowed-tools "Task,Read,Glob,Grep,Edit,Write,Bash(ls:*),Bash(cat:*),Bash(find:*),Bash(grep:*),Bash(rg:*),Bash(date:*),Bash(jq:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git rev-parse:*),Bash(gh issue list:*),Bash(gh issue view:*),Bash(gh issue create:*),Bash(gh issue edit:*),Bash(gh label list:*),Bash(gh label create:*)"
+            --allowed-tools "Task,Read,Glob,Grep,Edit,Write,Bash(ls:*),Bash(cat:*),Bash(find:*),Bash(grep:*),Bash(rg:*),Bash(date:*),Bash(jq:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git add:*),Bash(git commit:*),Bash(git -c:*),Bash(git push:*),Bash(git rev-parse:*),Bash(gh issue list:*),Bash(gh issue view:*),Bash(gh issue create:*),Bash(gh issue edit:*),Bash(gh label list:*),Bash(gh label create:*)"
           prompt: |
             You are the FiestaBoard **bug hunter**. You run unattended once a
             day and proactively hunt for REAL functional bugs in a batch of the
@@ -406,7 +406,7 @@ jobs:
             4. Commit to `main` directly and push:
                ```bash
                git add .github/bug-hunt-state.json
-               git commit -m "chore(bug-hunt): advance sweep state [skip ci]" || exit 0
+               git -c user.name="FiestaBoard CI" -c user.email="ci@fiestaboard.dev" commit -m "chore(bug-hunt): advance sweep state [skip ci]" || exit 0
                git push origin HEAD:main
                ```
                This is the ONLY commit you make.
@@ -451,5 +451,5 @@ jobs:
             exit 0
           fi
           git add .github/bug-hunt-state.json
-          git commit -m "chore(bug-hunt): advance sweep state [skip ci]"
+          git -c user.name="FiestaBoard CI" -c user.email="ci@fiestaboard.dev" commit -m "chore(bug-hunt): advance sweep state [skip ci]"
           git push origin HEAD:main

--- a/.github/workflows/claude-docs-audit.yml
+++ b/.github/workflows/claude-docs-audit.yml
@@ -247,8 +247,8 @@ jobs:
 
       - name: Configure git identity
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "FiestaBoard CI"
+          git config user.email "ci@fiestaboard.dev"
 
       - name: Run Claude docs audit
         uses: anthropics/claude-code-action@v1
@@ -291,7 +291,7 @@ jobs:
           claude_args: >-
             --model claude-opus-4-8
             --max-turns 250
-            --allowed-tools "Read,Glob,Grep,Edit,Write,Bash(ls:*),Bash(cat:*),Bash(find:*),Bash(date:*),Bash(jq:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git branch:*),Bash(git checkout:*),Bash(git switch:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git fetch:*),Bash(git pull:*),Bash(git rebase:*),Bash(git rev-parse:*),Bash(git reset:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh issue list:*),Bash(gh issue view:*),Bash(gh issue create:*),Bash(gh issue edit:*),Bash(gh label list:*),Bash(gh label create:*)"
+            --allowed-tools "Read,Glob,Grep,Edit,Write,Bash(ls:*),Bash(cat:*),Bash(find:*),Bash(date:*),Bash(jq:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git branch:*),Bash(git checkout:*),Bash(git switch:*),Bash(git add:*),Bash(git commit:*),Bash(git -c:*),Bash(git push:*),Bash(git fetch:*),Bash(git pull:*),Bash(git rebase:*),Bash(git rev-parse:*),Bash(git reset:*),Bash(gh pr create:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh issue list:*),Bash(gh issue view:*),Bash(gh issue create:*),Bash(gh issue edit:*),Bash(gh label list:*),Bash(gh label create:*)"
           prompt: |
             You are the FiestaBoard docs auditor. You run unattended twice a
             day (noon and 4pm America/Los_Angeles) and audit a batch of repo
@@ -627,7 +627,7 @@ jobs:
 
                ```bash
                git add .github/docs-audit-state.json
-               git commit -m "chore(docs-audit): advance sweep state [skip ci]" || exit 0
+               git -c user.name="FiestaBoard CI" -c user.email="ci@fiestaboard.dev" commit -m "chore(docs-audit): advance sweep state [skip ci]" || exit 0
                for attempt in 1 2 3 4 5; do
                  if git push origin HEAD:main; then
                    echo "State pushed on attempt $attempt."
@@ -683,7 +683,7 @@ jobs:
             exit 0
           fi
           git add .github/docs-audit-state.json
-          git commit -m "chore(docs-audit): advance sweep state [skip ci]"
+          git -c user.name="FiestaBoard CI" -c user.email="ci@fiestaboard.dev" commit -m "chore(docs-audit): advance sweep state [skip ci]"
           for attempt in 1 2 3 4 5; do
             if git push origin HEAD:main; then
               echo "State pushed on attempt $attempt."

--- a/.github/workflows/claude-docs-audit.yml
+++ b/.github/workflows/claude-docs-audit.yml
@@ -248,7 +248,7 @@ jobs:
       - name: Configure git identity
         run: |
           git config user.name "FiestaBoard CI"
-          git config user.email "ci@fiestaboard.dev"
+          git config user.email "ci@fiestaboard.app"
 
       - name: Run Claude docs audit
         uses: anthropics/claude-code-action@v1
@@ -627,7 +627,7 @@ jobs:
 
                ```bash
                git add .github/docs-audit-state.json
-               git -c user.name="FiestaBoard CI" -c user.email="ci@fiestaboard.dev" commit -m "chore(docs-audit): advance sweep state [skip ci]" || exit 0
+               git -c user.name="FiestaBoard CI" -c user.email="ci@fiestaboard.app" commit -m "chore(docs-audit): advance sweep state [skip ci]" || exit 0
                for attempt in 1 2 3 4 5; do
                  if git push origin HEAD:main; then
                    echo "State pushed on attempt $attempt."
@@ -683,7 +683,7 @@ jobs:
             exit 0
           fi
           git add .github/docs-audit-state.json
-          git -c user.name="FiestaBoard CI" -c user.email="ci@fiestaboard.dev" commit -m "chore(docs-audit): advance sweep state [skip ci]"
+          git -c user.name="FiestaBoard CI" -c user.email="ci@fiestaboard.app" commit -m "chore(docs-audit): advance sweep state [skip ci]"
           for attempt in 1 2 3 4 5; do
             if git push origin HEAD:main; then
               echo "State pushed on attempt $attempt."

--- a/.github/workflows/claude-pr-rebase.yml
+++ b/.github/workflows/claude-pr-rebase.yml
@@ -109,7 +109,7 @@ jobs:
         run: |
           set -euo pipefail
           git config user.name "FiestaBoard CI"
-          git config user.email "ci@fiestaboard.dev"
+          git config user.email "ci@fiestaboard.app"
           git fetch origin main
 
           if git merge-base --is-ancestor origin/main HEAD; then

--- a/.github/workflows/claude-pr-rebase.yml
+++ b/.github/workflows/claude-pr-rebase.yml
@@ -108,8 +108,8 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "FiestaBoard CI"
+          git config user.email "ci@fiestaboard.dev"
           git fetch origin main
 
           if git merge-base --is-ancestor origin/main HEAD; then

--- a/.github/workflows/docs-audit-feedback.yml
+++ b/.github/workflows/docs-audit-feedback.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Configure git identity
         run: |
           git config user.name "FiestaBoard CI"
-          git config user.email "ci@fiestaboard.dev"
+          git config user.email "ci@fiestaboard.app"
 
       - name: Capture rejection
         env:

--- a/.github/workflows/docs-audit-feedback.yml
+++ b/.github/workflows/docs-audit-feedback.yml
@@ -96,8 +96,8 @@ jobs:
 
       - name: Configure git identity
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "FiestaBoard CI"
+          git config user.email "ci@fiestaboard.dev"
 
       - name: Capture rejection
         env:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -116,8 +116,8 @@ jobs:
       - name: Commit and push versioned docs
         if: inputs.tag != '' && steps.check-version.outputs.skip != 'true'
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "FiestaBoard CI"
+          git config user.email "ci@fiestaboard.dev"
 
           git add docs-site/versions.json docs-site/versioned_docs docs-site/versioned_sidebars
           git commit -m "docs: snapshot version ${{ steps.version.outputs.docs_version }} docs"
@@ -132,8 +132,8 @@ jobs:
           REPO_URL="https://x-access-token:${DEPLOY_TOKEN}@github.com/Fiestaboard/fiestaboard.github.io.git"
           git clone --depth 1 "$REPO_URL" deploy-target
           cd deploy-target
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "FiestaBoard CI"
+          git config user.email "ci@fiestaboard.dev"
           # Remove old site files but keep .git
           git rm -rf --ignore-unmatch .
           # Copy in the new build (including hidden files like .nojekyll)

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -117,7 +117,7 @@ jobs:
         if: inputs.tag != '' && steps.check-version.outputs.skip != 'true'
         run: |
           git config user.name "FiestaBoard CI"
-          git config user.email "ci@fiestaboard.dev"
+          git config user.email "ci@fiestaboard.app"
 
           git add docs-site/versions.json docs-site/versioned_docs docs-site/versioned_sidebars
           git commit -m "docs: snapshot version ${{ steps.version.outputs.docs_version }} docs"
@@ -133,7 +133,7 @@ jobs:
           git clone --depth 1 "$REPO_URL" deploy-target
           cd deploy-target
           git config user.name "FiestaBoard CI"
-          git config user.email "ci@fiestaboard.dev"
+          git config user.email "ci@fiestaboard.app"
           # Remove old site files but keep .git
           git rm -rf --ignore-unmatch .
           # Copy in the new build (including hidden files like .nojekyll)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,8 +127,8 @@ jobs:
 
       - name: Configure Git
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "FiestaBoard CI"
+          git config user.email "ci@fiestaboard.dev"
 
       - name: Sync with latest main
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Configure Git
         run: |
           git config user.name "FiestaBoard CI"
-          git config user.email "ci@fiestaboard.dev"
+          git config user.email "ci@fiestaboard.app"
 
       - name: Sync with latest main
         run: |

--- a/.github/workflows/scheduled-maintenance.yml
+++ b/.github/workflows/scheduled-maintenance.yml
@@ -65,8 +65,8 @@ jobs:
 
       - name: Commit and push
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "FiestaBoard CI"
+          git config user.email "ci@fiestaboard.dev"
           git add docs-site/static/plugin-stats.json plugin-previews.json
           if git diff --staged --quiet; then
             echo "No changes."

--- a/.github/workflows/scheduled-maintenance.yml
+++ b/.github/workflows/scheduled-maintenance.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Commit and push
         run: |
           git config user.name "FiestaBoard CI"
-          git config user.email "ci@fiestaboard.dev"
+          git config user.email "ci@fiestaboard.app"
           git add docs-site/static/plugin-stats.json plugin-previews.json
           if git diff --staged --quiet; then
             echo "No changes."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,6 +252,55 @@ Before completing any feature or task:
 3. Delete all temporary implementation/testing markdown files
 4. Ensure all critical information is preserved in proper documentation
 
+## Commit Attribution
+
+Git history is public and feeds the repo's GitHub Insights graph. Attribution
+must be consistent so that one contributor reads as one contributor.
+
+### Claude co-author trailer
+
+End Claude-assisted commit messages with **exactly** this line, and nothing else
+resembling it:
+
+```
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+- No model name, version, or context-window suffix — not `Claude Opus 5`, not
+  `Claude Sonnet 4.6 (1M context)`, not `Claude Fable 5`
+- Use this capitalization (`Co-Authored-By`) so trailers group cleanly
+- One trailer per commit — never repeat it
+
+Model-specific trailers fragment Claude into a separate Insights contributor per
+model per capitalization (history already carries 12 such variants), and they
+leak model-selection history into permanent public metadata for no benefit.
+
+### Other agents
+
+Do not add `Co-authored-by:` or `Made-with:` trailers for other coding agents
+(Cursor, Copilot, etc.). If an agent's tooling adds one automatically, strip it
+before committing, or edit it out of the squash-merge body at merge time.
+
+### Automation identity
+
+Workflows that commit must set an identity matching what actually authored the
+change:
+
+- **Mechanical commits** (version bumps, docs snapshots, stats refreshes, state
+  bookkeeping) → `FiestaBoard CI <ci@fiestaboard.dev>`
+- **Claude-authored content** → left to `claude[bot]`, which the Claude action
+  sets itself
+
+The Claude action rewrites global git config while it runs, so any shell step
+that commits *after* it inherits `claude[bot]`. Bookkeeping commits in those
+jobs must pin their identity inline rather than rely on an earlier
+`git config`:
+
+```bash
+git -c user.name="FiestaBoard CI" -c user.email="ci@fiestaboard.dev" \
+  commit -m "chore(scope): advance sweep state [skip ci]"
+```
+
 ## Plugin Development Rules
 
 ### Creating a New Plugin

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,7 +287,7 @@ Workflows that commit must set an identity matching what actually authored the
 change:
 
 - **Mechanical commits** (version bumps, docs snapshots, stats refreshes, state
-  bookkeeping) → `FiestaBoard CI <ci@fiestaboard.dev>`
+  bookkeeping) → `FiestaBoard CI <ci@fiestaboard.app>`
 - **Claude-authored content** → left to `claude[bot]`, which the Claude action
   sets itself
 
@@ -297,7 +297,7 @@ jobs must pin their identity inline rather than rely on an earlier
 `git config`:
 
 ```bash
-git -c user.name="FiestaBoard CI" -c user.email="ci@fiestaboard.dev" \
+git -c user.name="FiestaBoard CI" -c user.email="ci@fiestaboard.app" \
   commit -m "chore(scope): advance sweep state [skip ci]"
 ```
 


### PR DESCRIPTION
## Why

Git history is public and feeds the repo's GitHub Insights graph. We looked at
rewriting history to clean it up and **decided against it** — 4,018 commits, 8
forks, 623 tags, and ~49% of recent `main` commits carry GitHub's GPG signature
that a rewrite would permanently invalidate. This PR is the going-forward half:
nothing retroactive, no force-push, no lost signatures.

## What's fragmenting attribution today

**1. Claude shows up as 12 separate contributors.** One row per model name per
capitalization:

```
Claude <noreply@anthropic.com>
Claude Fable 5 <noreply@anthropic.com>
Claude Opus 4.7 (1M context) <noreply@anthropic.com>
Claude Opus 4.8 <noreply@anthropic.com>
Claude Sonnet 4.6 (1M context) <noreply@anthropic.com>   ... and 7 more
```

Twelve slivers instead of one contributor, plus our model-selection history
leaked into permanent public metadata. `CLAUDE.md` now pins one canonical
trailer.

**2. `github-actions[bot]` is the largest contributor in the repo** — 764 of
1,756 commits on `main`, of which 682 are `chore:` version bumps and plugin-stats
refreshes and 77 are docs snapshots. It out-commits every human 2:1. All 13
identity sites across 12 workflows now commit as `FiestaBoard CI`.

**3. A config leak was mis-attributing bookkeeping commits.** The Claude action
rewrites global git config while it runs, so shell steps committing *after* it
inherited `claude[bot] <41898282+claude[bot]@users.noreply.github.com>`. That
address embeds **github-actions' numeric ID** (`41898282`), not claude[bot]'s
(`209825114`), so it resolves to no GitHub account — 54 commits on `main` are
attributed to a dangling identity. Fixed by pinning inline with `git -c` so step
ordering can't leak.

## Changes

| File(s) | Change |
|---|---|
| `CLAUDE.md` | New **Commit Attribution** section: canonical Claude trailer, no trailers for other agents, automation-identity rules |
| 12 workflows, 13 sites | `github-actions[bot]` → `FiestaBoard CI <ci@fiestaboard.dev>` |
| 4 `claude-*` audit workflows, 8 sites | Bookkeeping commits pin identity inline via `git -c` |
| Same 4 workflows | `Bash(git -c:*)` added to `--allowed-tools` |

That last row matters: four of the eight pinned commits live inside the Claude
**prompt**, so `git -c ...` would not have matched the existing
`Bash(git commit:*)` allowlist and would have been denied at runtime. Verified
all 12 workflow files still parse as valid YAML.

## Deliberately not included

- **Copilot** (267 authored commits, 468 trailers) — already stopped on its own;
  last commit 2026-05. Nothing to change.
- **Cursor** (208 trailers) — dead since 2026-04, no tracked config remains.
- **Dependabot** (117) — normal repo life, already has 4 update groups.
- **Remapping Copilot's authored commits** — that would put a false statement in
  the commit object rather than remove redundant metadata.

## Follow-up you need to run (not a code change)

The single biggest source of trailer noise is a repo setting, not our code.
`squash_merge_commit_message` is `COMMIT_MESSAGES`, which concatenates every WIP
commit's full message into the squash commit. Result: **3,564 trailer lines
across 1,756 commits**, one carrying fourteen.

```bash
gh api -X PATCH repos/Fiestaboard/FiestaBoard -f squash_merge_commit_message=PR_BODY
```

Note `PR_BODY` imports the PR description verbatim, so the
`🤖 Generated with Claude Code` footer should come out of the PR template — or
use `BLANK` for an empty body.

## Trade-off worth a second opinion

`ci@fiestaboard.dev` doesn't map to a GitHub account, so `FiestaBoard CI` will
render without an avatar or profile link. I think a branded CI identity reads
better than an anonymous bot at the top of the graph, but if you'd rather keep
the linked bot account, it's a one-line `sed` back to
`github-actions[bot]@users.noreply.github.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
