### PR TITLE
refactor(web): use FiestaUI's SVG taco mark for in-app brand icons

### DIFF
--- a/web/app/routes/login.tsx
+++ b/web/app/routes/login.tsx
@@ -34,6 +34,7 @@ import {
   CardHeader,
   CardTitle,
   Checkbox,
+  FiestaIcon,
   FiestaLogo,
   Flex,
   Input,
@@ -48,7 +49,7 @@ import { type FormEvent, useCallback, useEffect, useRef, useState } from "react"
 import { useRouter, useSearchParams } from "@/hooks/use-router";
 import { useTranslations } from "@/i18n/translations";
 import type { AuthStatusResponse } from "@/lib/api";
-import { apiUrl, appUrl } from "@/lib/base-path";
+import { apiUrl } from "@/lib/base-path";
 
 type AuthStatus = AuthStatusResponse;
 
@@ -485,7 +486,7 @@ function CenteredCard({
   return (
     <Flex direction="col" align="center" justify="center" className="min-h-screen bg-background p-4">
       <Flex align="center" gap="3" className="mb-6">
-        <img src={appUrl("/icons/favicon-32x32.png")} alt="" width={36} height={36} className="flex-shrink-0" />
+        <FiestaIcon size={36} className="flex-shrink-0" />
         <FiestaLogo className="text-2xl" />
       </Flex>
       <Card className="w-full max-w-md">

--- a/web/src/components/boot-gate.tsx
+++ b/web/src/components/boot-gate.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { Box, FiestaLogo, Flex, Stack, Text } from "@fiestaboard/ui";
+import { Box, FiestaIcon, FiestaLogo, Flex, Stack, Text } from "@fiestaboard/ui";
 import { useQuery } from "@tanstack/react-query";
 import { WifiOff } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { useTranslations } from "@/i18n/translations";
-import { apiUrl, appUrl } from "@/lib/base-path";
+import { apiUrl } from "@/lib/base-path";
 
 /** How long to wait before showing the splash (avoids a flash for fast startups). */
 const SHOW_SPLASH_DELAY_MS = 600;
@@ -86,7 +86,7 @@ export function BootGate({ children }: { children: React.ReactNode }) {
       >
         {/* Branding */}
         <Flex align="center" gap="3">
-          <img src={appUrl("/icons/favicon-32x32.png")} alt="" width={36} height={36} className="flex-shrink-0" />
+          <FiestaIcon size={36} className="flex-shrink-0" />
           <FiestaLogo className="text-2xl" />
         </Flex>
 

--- a/web/src/components/navigation-sidebar.tsx
+++ b/web/src/components/navigation-sidebar.tsx
@@ -36,7 +36,6 @@ import { useActiveSeason } from "@/hooks/use-pride-active";
 import { usePathname } from "@/hooks/use-router";
 import { useTranslations } from "@/i18n/translations";
 import { type AISettings, api } from "@/lib/api";
-import { appUrl } from "@/lib/base-path";
 import { MAX_APP_WIDTH, SIDEBAR_INSET } from "@/lib/layout-constants";
 
 interface NavItemDef {
@@ -173,7 +172,6 @@ export function NavigationSidebar() {
       transitioning={transitioning}
       onToggleCollapsed={toggle}
       onTransitionEnd={onTransitionEnd}
-      logoIconSrc={appUrl("/icons/favicon-32x32.png")}
       season={season}
       onLogoClick={fireCelebration}
       ai={hasAiProviders ? { active: aiPanelOpen, onOpen: openAiPanel } : undefined}

--- a/web/tests/ingress.spec.ts
+++ b/web/tests/ingress.spec.ts
@@ -145,20 +145,24 @@ test.describe("HA Ingress", () => {
   });
 
   test("in-app logo icon renders (not just requested)", async ({ page }) => {
-    // The sidebar logo is a JSX `<img src>` that lands in the JS bundle,
-    // where sub_filter can't reliably reach it — it must go through the
-    // runtime base path (appUrl) instead.
+    // The sidebar logo used to be a JSX `<img src>` pointing at a PNG under
+    // /icons, which sub_filter can't reliably reach inside the JS bundle and
+    // so had to go through the runtime base path (appUrl). It is now
+    // FiestaUI's `FiestaIcon` — an inline SVG with no URL at all — so the
+    // ingress prefix can't break it. Assert it actually paints.
     await page.goto(`${PREFIX}/`);
     await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible({ timeout: 15_000 });
 
     // The sidebar renders several logo copies (desktop expanded/collapsed,
     // mobile) — assert on the one that's actually visible.
-    const logo = page.locator('img[src*="/icons/favicon-32x32.png"]').filter({ visible: true }).first();
+    const logo = page
+      .locator('svg[viewBox="0 0 32 32"][shape-rendering="crispEdges"]')
+      .filter({ visible: true })
+      .first();
     await expect(logo).toBeVisible({ timeout: 10_000 });
-    expect(await logo.getAttribute("src"), "logo src must carry the ingress prefix").toContain(PREFIX);
     await expect
-      .poll(async () => logo.evaluate((el: HTMLImageElement) => el.naturalWidth), {
-        message: "logo image bytes must actually load",
+      .poll(async () => logo.evaluate((el: SVGSVGElement) => el.querySelectorAll("rect").length), {
+        message: "logo mark must render its pixel rects",
       })
       .toBeGreaterThan(0);
   });

--- a/web/tests/ingress.spec.ts
+++ b/web/tests/ingress.spec.ts
@@ -146,25 +146,27 @@ test.describe("HA Ingress", () => {
 
   test("in-app logo icon renders (not just requested)", async ({ page }) => {
     // The sidebar logo used to be a JSX `<img src>` pointing at a PNG under
-    // /icons, which sub_filter can't reliably reach inside the JS bundle and
-    // so had to go through the runtime base path (appUrl). It is now
-    // FiestaUI's `FiestaIcon` — an inline SVG with no URL at all — so the
-    // ingress prefix can't break it. Assert it actually paints.
+    // /icons — a URL that lives in the JS bundle, where sub_filter can't
+    // reliably reach it, so it had to be threaded through the runtime base
+    // path (appUrl) to survive the prefix. It is now FiestaUI's own mark,
+    // which the package inlines as a `data:image/svg+xml` URI: nothing for
+    // the ingress prefix to rewrite, and nothing to 404.
     await page.goto(`${PREFIX}/`);
     await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible({ timeout: 15_000 });
 
     // The sidebar renders several logo copies (desktop expanded/collapsed,
     // mobile) — assert on the one that's actually visible.
-    const logo = page
-      .locator('svg[viewBox="0 0 32 32"][shape-rendering="crispEdges"]')
-      .filter({ visible: true })
-      .first();
+    const logo = page.locator('img[src^="data:image/svg+xml"]').filter({ visible: true }).first();
     await expect(logo).toBeVisible({ timeout: 10_000 });
     await expect
-      .poll(async () => logo.evaluate((el: SVGSVGElement) => el.querySelectorAll("rect").length), {
-        message: "logo mark must render its pixel rects",
+      .poll(async () => logo.evaluate((el: HTMLImageElement) => el.naturalWidth), {
+        message: "logo image bytes must actually load",
       })
       .toBeGreaterThan(0);
+
+    // Nothing may fall back to the old prefixed raster: that URL is the whole
+    // reason this test exists.
+    await expect(page.locator('img[src*="/icons/favicon-32x32.png"]')).toHaveCount(0);
   });
 
   test("deep-route document load resolves under the prefix", async ({ page }) => {


### PR DESCRIPTION
## What

The sidebar, boot splash, and login header each rendered the FiestaBoard taco as an `<img>` pointing at `/icons/favicon-32x32.png`. `@fiestaboard/ui` already ships that exact mark as an SVG — recovered from that same 32×32 PNG, quantized onto a semantic palette. This switches the three in-app renderers over to it.

Two forms, because the package exposes two:

- **`boot-gate.tsx`, `login.tsx`** → `<FiestaIcon size={36} />`, a true inline SVG whose palette slots are themeable via `--fiesta-icon-*`
- **`navigation-sidebar.tsx`** → drops the `logoIconSrc` override so `Sidebar` falls back to `FIESTA_ICON_DATA_URI`. `Sidebar` renders its mark as `<img src>`, so this is a `data:image/svg+xml` URI rather than an inlined element — vector and prefix-proof, but not CSS-themeable (inside an `<img>` the custom properties can't cascade, so the classic brand colors apply).

Making the sidebar use the inline component too would need a change in FiestaUI itself — happy to open that as a follow-up.

## Why

- **Sharp at any size.** The 36px headers were upscaling a 32px raster.
- **Themeable** where it's inlined. The `--fiesta-icon-*` slots re-tint the mark; a PNG can't.
- **One fewer base-path hazard.** The PNG URL lived in the JS bundle, where nginx's `sub_filter` can't reach it, so it had to be threaded through `appUrl()` to survive HA Ingress. Neither an inline SVG nor a `data:` URI has anything for the prefix to rewrite.

## Changes

- `boot-gate.tsx`, `login.tsx` — `<img src={appUrl(...)}>` → `<FiestaIcon size={36} />`
- `navigation-sidebar.tsx` — drops the `logoIconSrc` override
- `tests/ingress.spec.ts` — the "in-app logo icon renders" test asserted an `<img src>` carried the ingress prefix. It now asserts the visible logo is a `data:` SVG that decodes, and that no `/icons/favicon-32x32.png` image remains on the page — the same guarantee, stated in terms of what the page actually does now

Now-unused `appUrl` imports removed from the two components; `navigation-sidebar.tsx` drops the import entirely.

## Out of scope

Browser-level icons stay raster on purpose — favicon links, `apple-touch-icon`, and the PWA manifest entries are fetched by the browser, not rendered by React. Happy to add an SVG favicon as a follow-up if wanted.

## Verification

Web checks in a `node:24` container against this branch:

- `npm run typecheck` — 20 errors, all pre-existing on `main` and none in the touched files (e.g. `FullConfig` declares `board` twice in `api.ts`)
- `eslint` — 0 errors
- `prettier --check` — clean
- `vitest run src/__tests__/ingress-base-path.test.tsx` — 13/13 pass

Ingress E2E run locally against the real simulator stack (production image + `infra/ha-ingress-proxy.conf`, same wiring as the CI job):

- `playwright test ingress.spec.ts` — **4/4 pass**
- Live DOM check on the dashboard: two `data:image/svg+xml` logo copies (one visible, `naturalWidth > 0`), zero `/icons/favicon-32x32.png` images

The first push of this PR failed that E2E job — the test asserted an inline `<svg>` that `Sidebar` never renders. Fixed in 2a39c5d0 and verified against a real container rather than by inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)