### PR TITLE
fix(web): stop the update overlay from declaring victory mid-pull

### DIFF
--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -1227,7 +1227,11 @@
     "waiting": "Warten auf den Start…",
     "errorHeading": "Verbindung zu FiestaBoard fehlgeschlagen",
     "errorDescription": "Prüfe, ob die App läuft, und versuche, die Seite neu zu laden.",
-    "refreshPage": "Seite neu laden"
+    "refreshPage": "Seite neu laden",
+    "updateWaiting": "Update wird abgeschlossen…",
+    "updateWaitingDescription": "FiestaBoard startet neu, um das Update abzuschließen. Das kann eine Minute dauern.",
+    "updateErrorHeading": "FiestaBoard ist noch nicht zurück",
+    "updateErrorDescription": "Das Update ist abgeschlossen, aber die App startet noch. Warten Sie einen Moment und aktualisieren Sie die Seite."
   },
   "globalAiChatDrawer": {
     "panelAriaLabel": "FiestaBot-KI-Chat"
@@ -1627,7 +1631,11 @@
     "dontCloseTab": "Updates können einige Minuten dauern – bitte schließen Sie diesen Tab nicht.",
     "stepPull": "Herunterladen",
     "stepRestart": "Neustart",
-    "stepDone": "Fertig"
+    "stepDone": "Fertig",
+    "failedHeading": "Update nicht abgeschlossen",
+    "failedDescription": "FiestaBoard läuft weiterhin mit der Version, mit der Sie begonnen haben. Prüfen Sie <code>docker logs fiestaupdater</code> auf dem Host für Details.",
+    "failedReason": "Grund: {reason}",
+    "dismiss": "Schließen"
   },
   "wizardProvider": {
     "loadingSetupWizard": "Einrichtungsassistent wird geladen...",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1184,7 +1184,11 @@
     "waiting": "Waiting to start…",
     "errorHeading": "Couldn't connect to FiestaBoard",
     "errorDescription": "Check that the app is running and try refreshing the page.",
-    "refreshPage": "Refresh page"
+    "refreshPage": "Refresh page",
+    "updateWaiting": "Finishing update…",
+    "updateWaitingDescription": "FiestaBoard is restarting to finish the update. This can take a minute.",
+    "updateErrorHeading": "FiestaBoard hasn't come back yet",
+    "updateErrorDescription": "The update finished, but the app is still restarting. Give it another moment, then refresh."
   },
   "globalAiChatDrawer": {
     "panelAriaLabel": "FiestaBot AI chat"
@@ -1584,7 +1588,11 @@
     "dontCloseTab": "Updates can take a few minutes — please don't close this tab.",
     "stepPull": "Pulling",
     "stepRestart": "Restarting",
-    "stepDone": "Done"
+    "stepDone": "Done",
+    "failedHeading": "Update didn't complete",
+    "failedDescription": "FiestaBoard is still running the version you started on. Check <code>docker logs fiestaupdater</code> on the host for details.",
+    "failedReason": "Reason: {reason}",
+    "dismiss": "Dismiss"
   },
   "wizardProvider": {
     "loadingSetupWizard": "Loading setup wizard...",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -1227,7 +1227,11 @@
     "waiting": "Esperando para iniciar…",
     "errorHeading": "No se pudo conectar con FiestaBoard",
     "errorDescription": "Comprueba que la aplicación está en ejecución e intenta recargar la página.",
-    "refreshPage": "Recargar página"
+    "refreshPage": "Recargar página",
+    "updateWaiting": "Finalizando la actualización…",
+    "updateWaitingDescription": "FiestaBoard se está reiniciando para finalizar la actualización. Puede tardar un minuto.",
+    "updateErrorHeading": "FiestaBoard aún no ha vuelto",
+    "updateErrorDescription": "La actualización terminó, pero la aplicación aún se está reiniciando. Espera un momento y actualiza la página."
   },
   "globalAiChatDrawer": {
     "panelAriaLabel": "Chat de IA de FiestaBot"
@@ -1627,7 +1631,11 @@
     "dontCloseTab": "Las actualizaciones pueden tardar unos minutos. Por favor, no cierres esta pestaña.",
     "stepPull": "Descargando",
     "stepRestart": "Reiniciando",
-    "stepDone": "Listo"
+    "stepDone": "Listo",
+    "failedHeading": "La actualización no se completó",
+    "failedDescription": "FiestaBoard sigue ejecutando la versión inicial. Consulta <code>docker logs fiestaupdater</code> en el host para ver los detalles.",
+    "failedReason": "Motivo: {reason}",
+    "dismiss": "Descartar"
   },
   "wizardProvider": {
     "loadingSetupWizard": "Cargando asistente de configuración...",

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -1227,7 +1227,11 @@
     "waiting": "En attente de démarrage…",
     "errorHeading": "Impossible de se connecter à FiestaBoard",
     "errorDescription": "Vérifiez que l'application est en cours d'exécution et essayez de recharger la page.",
-    "refreshPage": "Recharger la page"
+    "refreshPage": "Recharger la page",
+    "updateWaiting": "Finalisation de la mise à jour…",
+    "updateWaitingDescription": "FiestaBoard redémarre pour terminer la mise à jour. Cela peut prendre une minute.",
+    "updateErrorHeading": "FiestaBoard n'est pas encore revenu",
+    "updateErrorDescription": "La mise à jour est terminée, mais l'application redémarre encore. Patientez un instant, puis actualisez."
   },
   "globalAiChatDrawer": {
     "panelAriaLabel": "Chat IA FiestaBot"
@@ -1627,7 +1631,11 @@
     "dontCloseTab": "Les mises à jour peuvent prendre quelques minutes — veuillez ne pas fermer cet onglet.",
     "stepPull": "Téléchargement",
     "stepRestart": "Redémarrage",
-    "stepDone": "Terminé"
+    "stepDone": "Terminé",
+    "failedHeading": "La mise à jour n'est pas terminée",
+    "failedDescription": "FiestaBoard exécute toujours la version de départ. Consultez <code>docker logs fiestaupdater</code> sur l'hôte pour plus de détails.",
+    "failedReason": "Raison : {reason}",
+    "dismiss": "Ignorer"
   },
   "wizardProvider": {
     "loadingSetupWizard": "Chargement de l'assistant de configuration...",

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -1227,7 +1227,11 @@
     "waiting": "In attesa di avvio…",
     "errorHeading": "Impossibile connettersi a FiestaBoard",
     "errorDescription": "Verifica che l'app sia in esecuzione e prova a ricaricare la pagina.",
-    "refreshPage": "Ricarica la pagina"
+    "refreshPage": "Ricarica la pagina",
+    "updateWaiting": "Completamento dell'aggiornamento…",
+    "updateWaitingDescription": "FiestaBoard si sta riavviando per completare l'aggiornamento. Può richiedere un minuto.",
+    "updateErrorHeading": "FiestaBoard non è ancora tornato",
+    "updateErrorDescription": "L'aggiornamento è terminato, ma l'app si sta ancora riavviando. Attendi un momento, poi aggiorna la pagina."
   },
   "globalAiChatDrawer": {
     "panelAriaLabel": "Chat IA di FiestaBot"
@@ -1627,7 +1631,11 @@
     "dontCloseTab": "Gli aggiornamenti possono richiedere qualche minuto — non chiudere questa scheda.",
     "stepPull": "Download",
     "stepRestart": "Riavvio",
-    "stepDone": "Fatto"
+    "stepDone": "Fatto",
+    "failedHeading": "Aggiornamento non completato",
+    "failedDescription": "FiestaBoard sta ancora eseguendo la versione di partenza. Controlla <code>docker logs fiestaupdater</code> sull'host per i dettagli.",
+    "failedReason": "Motivo: {reason}",
+    "dismiss": "Ignora"
   },
   "wizardProvider": {
     "loadingSetupWizard": "Caricamento procedura guidata...",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -1227,7 +1227,11 @@
     "waiting": "起動を待機中…",
     "errorHeading": "FiestaBoard に接続できませんでした",
     "errorDescription": "アプリが起動していることを確認し、ページを再読み込みしてください。",
-    "refreshPage": "ページを再読み込み"
+    "refreshPage": "ページを再読み込み",
+    "updateWaiting": "アップデートを完了しています…",
+    "updateWaitingDescription": "アップデートを完了するために FiestaBoard を再起動しています。1 分ほどかかることがあります。",
+    "updateErrorHeading": "FiestaBoard がまだ復帰していません",
+    "updateErrorDescription": "アップデートは完了しましたが、アプリはまだ再起動中です。少し待ってから再読み込みしてください。"
   },
   "globalAiChatDrawer": {
     "panelAriaLabel": "FiestaBot AI チャット"
@@ -1627,7 +1631,11 @@
     "dontCloseTab": "更新には数分かかる場合があります — このタブを閉じないでください。",
     "stepPull": "ダウンロード中",
     "stepRestart": "再起動中",
-    "stepDone": "完了"
+    "stepDone": "完了",
+    "failedHeading": "アップデートが完了しませんでした",
+    "failedDescription": "FiestaBoard は開始時のバージョンのままです。詳細はホストで <code>docker logs fiestaupdater</code> を確認してください。",
+    "failedReason": "理由: {reason}",
+    "dismiss": "閉じる"
   },
   "wizardProvider": {
     "loadingSetupWizard": "セットアップウィザードを読み込み中...",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -1227,7 +1227,11 @@
     "waiting": "시작을 기다리는 중…",
     "errorHeading": "FiestaBoard에 연결할 수 없습니다",
     "errorDescription": "앱이 실행 중인지 확인하고 페이지를 새로 고쳐 보세요.",
-    "refreshPage": "페이지 새로 고침"
+    "refreshPage": "페이지 새로 고침",
+    "updateWaiting": "업데이트 마무리 중…",
+    "updateWaitingDescription": "업데이트를 마치기 위해 FiestaBoard를 다시 시작하는 중입니다. 1분 정도 걸릴 수 있습니다.",
+    "updateErrorHeading": "FiestaBoard가 아직 돌아오지 않았습니다",
+    "updateErrorDescription": "업데이트는 끝났지만 앱이 아직 다시 시작 중입니다. 잠시 후 새로고침하세요."
   },
   "globalAiChatDrawer": {
     "panelAriaLabel": "FiestaBot AI 채팅"
@@ -1627,7 +1631,11 @@
     "dontCloseTab": "업데이트는 몇 분이 걸릴 수 있습니다 — 이 탭을 닫지 마세요.",
     "stepPull": "다운로드",
     "stepRestart": "재시작",
-    "stepDone": "완료"
+    "stepDone": "완료",
+    "failedHeading": "업데이트가 완료되지 않았습니다",
+    "failedDescription": "FiestaBoard가 시작 시점의 버전으로 계속 실행 중입니다. 자세한 내용은 호스트에서 <code>docker logs fiestaupdater</code>를 확인하세요.",
+    "failedReason": "이유: {reason}",
+    "dismiss": "닫기"
   },
   "wizardProvider": {
     "loadingSetupWizard": "설정 마법사 로드 중...",

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -1227,7 +1227,11 @@
     "waiting": "Wachten op opstarten…",
     "errorHeading": "Kan geen verbinding maken met FiestaBoard",
     "errorDescription": "Controleer of de app draait en probeer de pagina opnieuw te laden.",
-    "refreshPage": "Pagina vernieuwen"
+    "refreshPage": "Pagina vernieuwen",
+    "updateWaiting": "Update afronden…",
+    "updateWaitingDescription": "FiestaBoard start opnieuw op om de update af te ronden. Dit kan een minuut duren.",
+    "updateErrorHeading": "FiestaBoard is nog niet terug",
+    "updateErrorDescription": "De update is klaar, maar de app start nog op. Wacht even en vernieuw daarna de pagina."
   },
   "globalAiChatDrawer": {
     "panelAriaLabel": "FiestaBot AI-chat"
@@ -1627,7 +1631,11 @@
     "dontCloseTab": "Updates kunnen enkele minuten duren — sluit dit tabblad niet.",
     "stepPull": "Downloaden",
     "stepRestart": "Herstarten",
-    "stepDone": "Klaar"
+    "stepDone": "Klaar",
+    "failedHeading": "Update is niet voltooid",
+    "failedDescription": "FiestaBoard draait nog steeds op de versie waarmee je begon. Bekijk <code>docker logs fiestaupdater</code> op de host voor details.",
+    "failedReason": "Reden: {reason}",
+    "dismiss": "Sluiten"
   },
   "wizardProvider": {
     "loadingSetupWizard": "Installatiewizard laden...",

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -1227,7 +1227,11 @@
     "waiting": "Oczekiwanie na uruchomienie…",
     "errorHeading": "Nie można połączyć się z FiestaBoard",
     "errorDescription": "Sprawdź, czy aplikacja działa, i spróbuj odświeżyć stronę.",
-    "refreshPage": "Odśwież stronę"
+    "refreshPage": "Odśwież stronę",
+    "updateWaiting": "Kończenie aktualizacji…",
+    "updateWaitingDescription": "FiestaBoard uruchamia się ponownie, aby dokończyć aktualizację. Może to potrwać minutę.",
+    "updateErrorHeading": "FiestaBoard jeszcze nie wrócił",
+    "updateErrorDescription": "Aktualizacja się zakończyła, ale aplikacja nadal się uruchamia. Poczekaj chwilę i odśwież stronę."
   },
   "globalAiChatDrawer": {
     "panelAriaLabel": "Czat AI FiestaBot"
@@ -1627,7 +1631,11 @@
     "dontCloseTab": "Aktualizacje mogą zająć kilka minut — nie zamykaj tej karty.",
     "stepPull": "Pobieranie",
     "stepRestart": "Restart",
-    "stepDone": "Gotowe"
+    "stepDone": "Gotowe",
+    "failedHeading": "Aktualizacja nie została ukończona",
+    "failedDescription": "FiestaBoard nadal działa w wersji początkowej. Sprawdź <code>docker logs fiestaupdater</code> na hoście, aby poznać szczegóły.",
+    "failedReason": "Powód: {reason}",
+    "dismiss": "Zamknij"
   },
   "wizardProvider": {
     "loadingSetupWizard": "Ładowanie kreatora konfiguracji...",

--- a/web/messages/pt.json
+++ b/web/messages/pt.json
@@ -1227,7 +1227,11 @@
     "waiting": "A aguardar o início…",
     "errorHeading": "Não foi possível ligar ao FiestaBoard",
     "errorDescription": "Verifica se a aplicação está em execução e tenta recarregar a página.",
-    "refreshPage": "Recarregar página"
+    "refreshPage": "Recarregar página",
+    "updateWaiting": "A concluir a atualização…",
+    "updateWaitingDescription": "O FiestaBoard está a reiniciar para concluir a atualização. Pode demorar um minuto.",
+    "updateErrorHeading": "O FiestaBoard ainda não voltou",
+    "updateErrorDescription": "A atualização terminou, mas a aplicação ainda está a reiniciar. Aguarde um momento e recarregue a página."
   },
   "globalAiChatDrawer": {
     "panelAriaLabel": "Chat de IA do FiestaBot"
@@ -1627,7 +1631,11 @@
     "dontCloseTab": "As atualizações podem demorar alguns minutos — não feche este separador.",
     "stepPull": "Baixando",
     "stepRestart": "Reiniciando",
-    "stepDone": "Concluído"
+    "stepDone": "Concluído",
+    "failedHeading": "A atualização não foi concluída",
+    "failedDescription": "O FiestaBoard continua a executar a versão inicial. Verifique <code>docker logs fiestaupdater</code> no host para mais detalhes.",
+    "failedReason": "Motivo: {reason}",
+    "dismiss": "Dispensar"
   },
   "wizardProvider": {
     "loadingSetupWizard": "A carregar assistente de configuração...",

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -1227,7 +1227,11 @@
     "waiting": "Ожидание запуска…",
     "errorHeading": "Не удалось подключиться к FiestaBoard",
     "errorDescription": "Убедитесь, что приложение запущено, и попробуйте обновить страницу.",
-    "refreshPage": "Обновить страницу"
+    "refreshPage": "Обновить страницу",
+    "updateWaiting": "Завершение обновления…",
+    "updateWaitingDescription": "FiestaBoard перезапускается, чтобы завершить обновление. Это может занять минуту.",
+    "updateErrorHeading": "FiestaBoard ещё не вернулся",
+    "updateErrorDescription": "Обновление завершено, но приложение всё ещё перезапускается. Подождите немного и обновите страницу."
   },
   "globalAiChatDrawer": {
     "panelAriaLabel": "ИИ-чат FiestaBot"
@@ -1627,7 +1631,11 @@
     "dontCloseTab": "Обновления могут занять несколько минут — не закрывайте эту вкладку.",
     "stepPull": "Загрузка",
     "stepRestart": "Перезапуск",
-    "stepDone": "Готово"
+    "stepDone": "Готово",
+    "failedHeading": "Обновление не завершено",
+    "failedDescription": "FiestaBoard по-прежнему работает на исходной версии. Подробности смотрите в <code>docker logs fiestaupdater</code> на хосте.",
+    "failedReason": "Причина: {reason}",
+    "dismiss": "Закрыть"
   },
   "wizardProvider": {
     "loadingSetupWizard": "Загрузка мастера настройки...",

--- a/web/messages/sv.json
+++ b/web/messages/sv.json
@@ -1227,7 +1227,11 @@
     "waiting": "Väntar på start…",
     "errorHeading": "Det gick inte att ansluta till FiestaBoard",
     "errorDescription": "Kontrollera att appen körs och försök ladda om sidan.",
-    "refreshPage": "Ladda om sidan"
+    "refreshPage": "Ladda om sidan",
+    "updateWaiting": "Slutför uppdateringen…",
+    "updateWaitingDescription": "FiestaBoard startar om för att slutföra uppdateringen. Det kan ta en minut.",
+    "updateErrorHeading": "FiestaBoard är inte tillbaka än",
+    "updateErrorDescription": "Uppdateringen är klar, men appen startar fortfarande om. Vänta en stund och uppdatera sedan sidan."
   },
   "globalAiChatDrawer": {
     "panelAriaLabel": "FiestaBot AI-chatt"
@@ -1627,7 +1631,11 @@
     "dontCloseTab": "Uppdateringar kan ta några minuter — stäng inte denna flik.",
     "stepPull": "Laddar ned",
     "stepRestart": "Startar om",
-    "stepDone": "Klar"
+    "stepDone": "Klar",
+    "failedHeading": "Uppdateringen slutfördes inte",
+    "failedDescription": "FiestaBoard kör fortfarande versionen du startade på. Kontrollera <code>docker logs fiestaupdater</code> på värden för detaljer.",
+    "failedReason": "Orsak: {reason}",
+    "dismiss": "Stäng"
   },
   "wizardProvider": {
     "loadingSetupWizard": "Laddar installationsguide...",

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -1227,7 +1227,11 @@
     "waiting": "Başlatılması bekleniyor…",
     "errorHeading": "FiestaBoard'a bağlanılamadı",
     "errorDescription": "Uygulamanın çalıştığından emin olun ve sayfayı yenilemeyi deneyin.",
-    "refreshPage": "Sayfayı yenile"
+    "refreshPage": "Sayfayı yenile",
+    "updateWaiting": "Güncelleme tamamlanıyor…",
+    "updateWaitingDescription": "Güncellemeyi tamamlamak için FiestaBoard yeniden başlatılıyor. Bu bir dakika sürebilir.",
+    "updateErrorHeading": "FiestaBoard henüz geri dönmedi",
+    "updateErrorDescription": "Güncelleme bitti ancak uygulama hâlâ yeniden başlıyor. Biraz bekleyip sayfayı yenileyin."
   },
   "globalAiChatDrawer": {
     "panelAriaLabel": "FiestaBot yapay zeka sohbeti"
@@ -1627,7 +1631,11 @@
     "dontCloseTab": "Güncellemeler birkaç dakika sürebilir — lütfen bu sekmeyi kapatmayın.",
     "stepPull": "İndiriliyor",
     "stepRestart": "Yeniden başlatılıyor",
-    "stepDone": "Tamam"
+    "stepDone": "Tamam",
+    "failedHeading": "Güncelleme tamamlanmadı",
+    "failedDescription": "FiestaBoard hâlâ başladığınız sürümü çalıştırıyor. Ayrıntılar için ana makinede <code>docker logs fiestaupdater</code> komutuna bakın.",
+    "failedReason": "Neden: {reason}",
+    "dismiss": "Kapat"
   },
   "wizardProvider": {
     "loadingSetupWizard": "Kurulum sihirbazı yükleniyor...",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -1227,7 +1227,11 @@
     "waiting": "正在等待启动…",
     "errorHeading": "无法连接到 FiestaBoard",
     "errorDescription": "请确认应用正在运行，然后尝试刷新页面。",
-    "refreshPage": "刷新页面"
+    "refreshPage": "刷新页面",
+    "updateWaiting": "正在完成更新…",
+    "updateWaitingDescription": "FiestaBoard 正在重启以完成更新，可能需要一分钟。",
+    "updateErrorHeading": "FiestaBoard 尚未恢复",
+    "updateErrorDescription": "更新已完成，但应用仍在重启。请稍候片刻，然后刷新页面。"
   },
   "globalAiChatDrawer": {
     "panelAriaLabel": "FiestaBot AI 聊天"
@@ -1627,7 +1631,11 @@
     "dontCloseTab": "更新可能需要几分钟 — 请勿关闭此选项卡。",
     "stepPull": "拉取中",
     "stepRestart": "重启中",
-    "stepDone": "完成"
+    "stepDone": "完成",
+    "failedHeading": "更新未完成",
+    "failedDescription": "FiestaBoard 仍在运行你开始时的版本。请在主机上查看 <code>docker logs fiestaupdater</code> 了解详情。",
+    "failedReason": "原因：{reason}",
+    "dismiss": "关闭"
   },
   "wizardProvider": {
     "loadingSetupWizard": "加载设置向导中...",

--- a/web/src/__tests__/update-context.test.tsx
+++ b/web/src/__tests__/update-context.test.tsx
@@ -1,0 +1,225 @@
+/**
+ * Regression tests for the in-place update overlay.
+ *
+ * The bug these pin down: the overlay used to infer everything from /version.
+ * One failed poll flipped it to "restarting", and the very next successful
+ * poll — even from the same, unchanged container — was read as "update
+ * complete", so it reloaded the user back to Settings while `docker compose
+ * pull` was still running. The update banner was of course still there
+ * (nothing had been updated), and the real restart landed a minute later with
+ * no explanation on screen.
+ *
+ * The overlay now believes only the fiestaupdater sidecar's own record of the
+ * attempt, which lives in a separate container and therefore survives
+ * FiestaBoard being recreated.
+ */
+import { act, render, screen } from "@testing-library/react";
+import { useEffect } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { UpdateProvider, useUpdate } from "@/components/update-context";
+import { api, type UpdateStatusResponse } from "@/lib/api";
+
+const LS_KEY = "fb_updating";
+const FROM_VERSION = "8.20.5";
+
+/** A status payload with no verdict yet — the sidecar is still working. */
+function status(overrides: Partial<UpdateStatusResponse> = {}): UpdateStatusResponse {
+  return {
+    updater_available: true,
+    auto_update_enabled: false,
+    auto_update_interval: "manual",
+    managed_externally: false,
+    profile: "docker",
+    sidecar_url: "http://fiestaupdater:8765",
+    last_check: null,
+    last_update: null,
+    last_update_status: "in_progress",
+    last_update_action: "update",
+    last_update_error: null,
+    last_update_previous_digest: null,
+    last_update_completed_at: null,
+    ...overrides,
+  };
+}
+
+let reload: ReturnType<typeof vi.fn>;
+
+/** Kicks off an update as soon as it mounts, mirroring the Settings banner. */
+function StartUpdateOnMount() {
+  const { startUpdate } = useUpdate();
+  useEffect(() => {
+    startUpdate(FROM_VERSION);
+  }, [startUpdate]);
+  return null;
+}
+
+async function advance(ms: number) {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  window.localStorage.clear();
+  reload = vi.fn();
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: { ...window.location, reload },
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("UpdateOverlay", () => {
+  it("keeps waiting through a transient API failure during the pull", async () => {
+    // One blip — a 503 from nginx's @api_starting, or a request that timed out
+    // while the box was busy pulling — must not be read as a restart.
+    const getUpdateStatus = vi
+      .spyOn(api, "getUpdateStatus")
+      .mockRejectedValueOnce(new Error("API error: 503"))
+      .mockResolvedValue(status());
+
+    render(
+      <UpdateProvider>
+        <StartUpdateOnMount />
+      </UpdateProvider>,
+    );
+
+    await advance(1500 + 2000 * 3);
+
+    expect(getUpdateStatus).toHaveBeenCalled();
+    expect(reload).not.toHaveBeenCalled();
+    // Still on step one, not "Restarting".
+    expect(screen.getByText("Pulling the latest image from Docker Hub…")).toBeInTheDocument();
+  });
+
+  it("only calls the restart done when the sidecar reports success", async () => {
+    // Three consecutive failures = the container really is gone.
+    const getUpdateStatus = vi
+      .spyOn(api, "getUpdateStatus")
+      .mockRejectedValueOnce(new Error("network"))
+      .mockRejectedValueOnce(new Error("network"))
+      .mockRejectedValueOnce(new Error("network"))
+      .mockResolvedValue(status({ last_update_status: "success" }));
+
+    render(
+      <UpdateProvider>
+        <StartUpdateOnMount />
+      </UpdateProvider>,
+    );
+
+    // Initial delay + three failing polls.
+    await advance(1500 + 2000 * 2);
+    expect(reload).not.toHaveBeenCalled();
+    expect(screen.getByText("Restarting FiestaBoard…")).toBeInTheDocument();
+
+    // Next poll returns the sidecar's success verdict.
+    await advance(2000);
+    expect(screen.getByText("Update complete. Reloading…")).toBeInTheDocument();
+    expect(reload).not.toHaveBeenCalled();
+
+    // …and only reloads after the hold.
+    await advance(800);
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(getUpdateStatus).toHaveBeenCalled();
+  });
+
+  it("surfaces a sidecar failure instead of reloading into the old version", async () => {
+    vi.spyOn(api, "getUpdateStatus").mockResolvedValue(
+      status({ last_update_status: "failed", last_update_error: "pull_failed" }),
+    );
+
+    render(
+      <UpdateProvider>
+        <StartUpdateOnMount />
+      </UpdateProvider>,
+    );
+
+    await advance(1500 + 2000);
+
+    expect(screen.getByText("Update didn't complete")).toBeInTheDocument();
+    expect(screen.getByText("Reason: pull_failed")).toBeInTheDocument();
+    expect(reload).not.toHaveBeenCalled();
+    // The attempt is over — nothing left to resume on the next page load.
+    expect(window.localStorage.getItem(LS_KEY)).toBeNull();
+  });
+
+  it("hands the reload off to BootGate instead of clearing the marker", async () => {
+    vi.spyOn(api, "getUpdateStatus").mockResolvedValue(status({ last_update_status: "success" }));
+
+    render(
+      <UpdateProvider>
+        <StartUpdateOnMount />
+      </UpdateProvider>,
+    );
+
+    await advance(1500 + 2000 + 800);
+
+    expect(reload).toHaveBeenCalledTimes(1);
+    const persisted = JSON.parse(window.localStorage.getItem(LS_KEY) ?? "{}");
+    expect(persisted.awaitingBoot).toBe(true);
+    expect(persisted.fromVersion).toBe(FROM_VERSION);
+  });
+
+  it("does not re-show the overlay after the post-update reload", async () => {
+    // The reload loop this guards against: resuming the overlay here would see
+    // "success" again and reload again, forever.
+    window.localStorage.setItem(
+      LS_KEY,
+      JSON.stringify({ fromVersion: FROM_VERSION, startedAt: Date.now(), awaitingBoot: true }),
+    );
+    const getUpdateStatus = vi
+      .spyOn(api, "getUpdateStatus")
+      .mockResolvedValue(status({ last_update_status: "success" }));
+
+    function ShowsFlag() {
+      const { isUpdating, awaitingPostUpdateBoot } = useUpdate();
+      return (
+        <div>
+          <span data-testid="updating">{String(isUpdating)}</span>
+          <span data-testid="awaiting">{String(awaitingPostUpdateBoot)}</span>
+        </div>
+      );
+    }
+
+    render(
+      <UpdateProvider>
+        <ShowsFlag />
+      </UpdateProvider>,
+    );
+
+    await advance(1500 + 2000 * 3);
+
+    expect(screen.getByTestId("updating")).toHaveTextContent("false");
+    expect(screen.getByTestId("awaiting")).toHaveTextContent("true");
+    expect(getUpdateStatus).not.toHaveBeenCalled();
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  it("ignores a stale awaiting-boot marker", async () => {
+    window.localStorage.setItem(
+      LS_KEY,
+      JSON.stringify({ fromVersion: FROM_VERSION, startedAt: Date.now() - 6 * 60 * 1000, awaitingBoot: true }),
+    );
+
+    function ShowsFlag() {
+      const { awaitingPostUpdateBoot } = useUpdate();
+      return <span data-testid="awaiting">{String(awaitingPostUpdateBoot)}</span>;
+    }
+
+    render(
+      <UpdateProvider>
+        <ShowsFlag />
+      </UpdateProvider>,
+    );
+
+    await advance(100);
+
+    expect(screen.getByTestId("awaiting")).toHaveTextContent("false");
+  });
+});

--- a/web/src/components/boot-gate.tsx
+++ b/web/src/components/boot-gate.tsx
@@ -5,6 +5,7 @@ import { useQuery } from "@tanstack/react-query";
 import { WifiOff } from "lucide-react";
 import { useEffect, useState } from "react";
 
+import { useUpdate } from "@/components/update-context";
 import { useTranslations } from "@/i18n/translations";
 import { apiUrl, appUrl } from "@/lib/base-path";
 
@@ -15,16 +16,29 @@ const SHOW_SPLASH_DELAY_MS = 600;
 const ERROR_TIMEOUT_MS = 30_000;
 
 /**
+ * Restarting after an update legitimately takes longer than a cold boot — the
+ * new container has to start from scratch on hardware that was just busy
+ * pulling an image. Showing "Couldn't connect to FiestaBoard" at 30 s there
+ * reads as a failure when the machine is simply still coming up.
+ */
+const POST_UPDATE_ERROR_TIMEOUT_MS = 120_000;
+
+/**
  * Gates the main UI behind an API availability check on boot.
  *
  * - If the API responds within SHOW_SPLASH_DELAY_MS → no splash ever shown.
  * - If the API is still unavailable after SHOW_SPLASH_DELAY_MS → "Waiting to start…" screen.
- * - If still unavailable after ERROR_TIMEOUT_MS → error screen with a refresh button.
+ * - If still unavailable after the error timeout → error screen with a refresh button.
  * - Once the API responds for the first time → the gate is removed permanently for this session.
  *   A brief connection hiccup during normal use never re-shows the splash.
+ *
+ * When the page has just reloaded itself to finish an update (see
+ * `UpdateProvider`), the same states get update-specific copy and a longer
+ * error timeout, so a normal post-update restart doesn't look like a crash.
  */
 export function BootGate({ children }: { children: React.ReactNode }) {
   const t = useTranslations("bootGate");
+  const { awaitingPostUpdateBoot, markPostUpdateBootComplete } = useUpdate();
   const [hasConnected, setHasConnected] = useState(false);
   const [showSplash, setShowSplash] = useState(false);
   const [timedOut, setTimedOut] = useState(false);
@@ -46,10 +60,13 @@ export function BootGate({ children }: { children: React.ReactNode }) {
     enabled: !hasConnected,
   });
 
-  // Mark connected on first successful response.
+  // Mark connected on first successful response. This is also what retires a
+  // post-update marker: the new container answered, so the update is over.
   useEffect(() => {
-    if (data) setHasConnected(true);
-  }, [data]);
+    if (!data) return;
+    setHasConnected(true);
+    markPostUpdateBootComplete();
+  }, [data, markPostUpdateBootComplete]);
 
   // Delay showing the splash so fast startups never flash it.
   useEffect(() => {
@@ -61,11 +78,14 @@ export function BootGate({ children }: { children: React.ReactNode }) {
 
   // Switch to error state after the timeout elapses.
   useEffect(() => {
-    const timer = setTimeout(() => {
-      setTimedOut(true);
-    }, ERROR_TIMEOUT_MS);
+    const timer = setTimeout(
+      () => {
+        setTimedOut(true);
+      },
+      awaitingPostUpdateBoot ? POST_UPDATE_ERROR_TIMEOUT_MS : ERROR_TIMEOUT_MS,
+    );
     return () => clearTimeout(timer);
-  }, []);
+  }, [awaitingPostUpdateBoot]);
 
   // API is up — show the real app.
   if (hasConnected) return <>{children}</>;
@@ -96,9 +116,9 @@ export function BootGate({ children }: { children: React.ReactNode }) {
             <WifiOff className="h-10 w-10 text-muted-foreground" strokeWidth={1.5} aria-hidden="true" />
             <Stack gap="1.5">
               <Text size="base" weight="semibold">
-                {t("errorHeading")}
+                {awaitingPostUpdateBoot ? t("updateErrorHeading") : t("errorHeading")}
               </Text>
-              <Text tone="muted">{t("errorDescription")}</Text>
+              <Text tone="muted">{awaitingPostUpdateBoot ? t("updateErrorDescription") : t("errorDescription")}</Text>
             </Stack>
             <button
               onClick={() => window.location.reload()}
@@ -114,7 +134,16 @@ export function BootGate({ children }: { children: React.ReactNode }) {
               className="h-8 w-8 rounded-full border-[2.5px] border-muted-foreground/25 border-t-muted-foreground animate-spin"
               aria-hidden="true"
             />
-            <Text tone="muted">{t("waiting")}</Text>
+            {awaitingPostUpdateBoot ? (
+              <Stack gap="1.5">
+                <Text size="base" weight="semibold">
+                  {t("updateWaiting")}
+                </Text>
+                <Text tone="muted">{t("updateWaitingDescription")}</Text>
+              </Stack>
+            ) : (
+              <Text tone="muted">{t("waiting")}</Text>
+            )}
           </>
         )}
       </Flex>

--- a/web/src/components/update-context.tsx
+++ b/web/src/components/update-context.tsx
@@ -5,18 +5,27 @@ import { RefreshCw } from "lucide-react";
 import { createContext, Fragment, useCallback, useContext, useEffect, useRef, useState } from "react";
 
 import { useTranslations } from "@/i18n/translations";
-import { api } from "@/lib/api";
+import { api, type UpdateAttemptStatus } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-type UpdatePhase = "pulling" | "restarting" | "ready" | "error";
+type UpdatePhase = "pulling" | "restarting" | "ready" | "failed" | "error";
 
 interface UpdateContextValue {
   isUpdating: boolean;
   startUpdate: (currentVersion?: string) => void;
+  /**
+   * True when the page has just reloaded itself at the end of an update and
+   * the API hasn't answered yet. BootGate reads this to explain the wait
+   * ("finishing update") instead of showing its generic "can't connect"
+   * treatment, which reads as a failure when nothing is wrong.
+   */
+  awaitingPostUpdateBoot: boolean;
+  /** Called by BootGate once the API answers, retiring the marker. */
+  markPostUpdateBootComplete: () => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -26,23 +35,41 @@ interface UpdateContextValue {
 const UpdateContext = createContext<UpdateContextValue>({
   isUpdating: false,
   startUpdate: () => {},
+  awaitingPostUpdateBoot: false,
+  markPostUpdateBootComplete: () => {},
 });
 
 // ---------------------------------------------------------------------------
-// localStorage persistence key
-// Stored value: JSON string of { fromVersion?: string; startedAt: number }
+// localStorage persistence
+//
+// Two distinct states share one key:
+//   * `awaitingBoot` unset — an update is in flight; the overlay resumes and
+//     keeps polling (survives a manual refresh mid-update).
+//   * `awaitingBoot: true` — the update FINISHED and we reloaded the page on
+//     purpose. The overlay must NOT resume (it would see "success" again and
+//     reload forever); only BootGate cares, so it can say "finishing update"
+//     while the new container's API warms up.
 // ---------------------------------------------------------------------------
 
 const LS_KEY = "fb_updating";
 const MAX_AGE_MS = 10 * 60 * 1000; // 10 minutes — matches UPDATE_TIMEOUT_MS
+/** A post-update boot that hasn't completed within this window is stale. */
+const AWAITING_BOOT_MAX_AGE_MS = 5 * 60 * 1000;
 
-function readPersisted(): { fromVersion?: string; startedAt: number } | null {
+interface PersistedUpdate {
+  fromVersion?: string;
+  startedAt: number;
+  awaitingBoot?: boolean;
+}
+
+function readPersisted(): PersistedUpdate | null {
   try {
     const raw = localStorage.getItem(LS_KEY);
     if (!raw) return null;
-    const parsed = JSON.parse(raw) as { fromVersion?: string; startedAt: number };
+    const parsed = JSON.parse(raw) as PersistedUpdate;
     if (typeof parsed.startedAt !== "number") return null;
-    if (Date.now() - parsed.startedAt > MAX_AGE_MS) {
+    const maxAge = parsed.awaitingBoot ? AWAITING_BOOT_MAX_AGE_MS : MAX_AGE_MS;
+    if (Date.now() - parsed.startedAt > maxAge) {
       localStorage.removeItem(LS_KEY);
       return null;
     }
@@ -52,9 +79,9 @@ function readPersisted(): { fromVersion?: string; startedAt: number } | null {
   }
 }
 
-function writePersisted(fromVersion?: string) {
+function writePersisted(entry: PersistedUpdate) {
   try {
-    localStorage.setItem(LS_KEY, JSON.stringify({ fromVersion, startedAt: Date.now() }));
+    localStorage.setItem(LS_KEY, JSON.stringify(entry));
   } catch {}
 }
 
@@ -64,6 +91,15 @@ function clearPersisted() {
   } catch {}
 }
 
+/**
+ * Flip the persisted entry into "we reloaded, waiting for the new container"
+ * mode. Keeps `startedAt` fresh so the staleness window is measured from the
+ * reload, not from when the update began.
+ */
+function markAwaitingBoot(fromVersion?: string) {
+  writePersisted({ fromVersion, startedAt: Date.now(), awaitingBoot: true });
+}
+
 // ---------------------------------------------------------------------------
 // Provider
 // ---------------------------------------------------------------------------
@@ -71,20 +107,29 @@ function clearPersisted() {
 export function UpdateProvider({ children }: { children: React.ReactNode }) {
   const [isUpdating, setIsUpdating] = useState(false);
   const [currentVersion, setCurrentVersion] = useState<string | undefined>(undefined);
+  const [awaitingPostUpdateBoot, setAwaitingPostUpdateBoot] = useState(false);
 
-  // On mount: resume an in-progress update if a recent entry exists in localStorage.
+  // On mount: pick up whatever the previous page life left behind.
   useEffect(() => {
     const persisted = readPersisted();
-    if (persisted) {
-      setCurrentVersion(persisted.fromVersion);
+    if (!persisted) return;
+    setCurrentVersion(persisted.fromVersion);
+    if (persisted.awaitingBoot) {
+      setAwaitingPostUpdateBoot(true);
+    } else {
       setIsUpdating(true);
     }
   }, []);
 
   const startUpdate = useCallback((version?: string) => {
-    writePersisted(version);
+    writePersisted({ fromVersion: version, startedAt: Date.now() });
     setCurrentVersion(version);
     setIsUpdating(true);
+  }, []);
+
+  const markPostUpdateBootComplete = useCallback(() => {
+    clearPersisted();
+    setAwaitingPostUpdateBoot(false);
   }, []);
 
   const handleDone = useCallback(() => {
@@ -93,7 +138,7 @@ export function UpdateProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   return (
-    <UpdateContext.Provider value={{ isUpdating, startUpdate }}>
+    <UpdateContext.Provider value={{ isUpdating, startUpdate, awaitingPostUpdateBoot, markPostUpdateBootComplete }}>
       {children}
       {isUpdating && <UpdateOverlay currentVersion={currentVersion} onDone={handleDone} />}
     </UpdateContext.Provider>
@@ -113,32 +158,79 @@ export function useUpdate() {
 // ---------------------------------------------------------------------------
 
 const UPDATE_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+const POLL_INTERVAL_MS = 2000;
+/** Docker needs a beat to start acting on the request before we poll. */
+const INITIAL_DELAY_MS = 1500;
+/** Let the user read "update complete" before the page goes white. */
+const READY_HOLD_MS = 800;
+/**
+ * Consecutive failed polls before we believe the container is actually gone.
+ * A single failure means nothing: while the sidecar pulls a few hundred MB the
+ * box is busy enough that one request can time out, and nginx answers 503 from
+ * its `@api_starting` fallback whenever uvicorn is slow to respond. Treating
+ * either as "the container went down" is what used to end the overlay early.
+ */
+const DOWN_THRESHOLD = 3;
+
+/** Sidecar states that mean the attempt is over and it worked. */
+const SUCCESS_STATES: ReadonlySet<UpdateAttemptStatus> = new Set<UpdateAttemptStatus>(["success", "rolled_back"]);
+/** Sidecar states that mean the attempt is over and it did not work. */
+const FAILURE_STATES: ReadonlySet<UpdateAttemptStatus> = new Set<UpdateAttemptStatus>(["failed", "rollback_failed"]);
 
 /**
- * Full-screen black overlay rendered at the provider level (app layout).
- * Survives client-side navigation and even a manual browser refresh (via
- * localStorage).
+ * Full-screen overlay rendered at the provider level (app layout). Survives
+ * client-side navigation and a manual browser refresh (via localStorage).
  *
- * Polling strategy — two-phase:
- *   Phase 1 ("pulling"): poll /version every 2 s.
- *     - If the API throws (container stopped) → set everWentDown = true.
- *     - If the API returns a NEW version (without going down first) →
- *       rare fast swap, treat as done.
- *   Phase 2 (everWentDown): poll /version every 2 s.
- *     - Once the API responds successfully → "ready" → reload.
+ * Polling strategy — the fiestaupdater sidecar is the source of truth:
  *
- * A 10-minute deadline surfaces an error state with a manual refresh
- * button so the user can never be stuck in an infinite spinner.
+ *   Every 2 s, ask the API for /system/update/status, which proxies the
+ *   sidecar's own record of the attempt. The sidecar is a separate container,
+ *   so that record survives FiestaBoard being torn down and recreated.
+ *
+ *     - `in_progress` / `none`  → still working; keep waiting.
+ *     - `success` / `rolled_back` → the new image is in place; reload.
+ *     - `failed` / `rollback_failed` → surface the sidecar's error instead of
+ *       silently reloading into the version the user was already on.
+ *     - request failed → the API is unreachable. Only after DOWN_THRESHOLD
+ *       *consecutive* failures do we call that a restart; single blips during
+ *       the pull are noise.
+ *
+ * The previous implementation inferred everything from /version alone: one
+ * failed poll flipped it to "restarting", and the next successful poll — even
+ * from the same, unchanged container — was read as "update complete", so it
+ * reloaded the user back to Settings while the pull was still running. The
+ * banner was of course still there (nothing had been updated yet), and the
+ * real restart landed a minute later with no explanation on screen.
+ *
+ * Fallback: if the sidecar's record is unavailable (state file lost, sidecar
+ * replaced) but the API came back reporting a *different* package version
+ * after a confirmed down period, that is also proof the swap happened.
+ *
+ * A 10-minute deadline surfaces an error state with a manual refresh button so
+ * the user can never be stuck in an infinite spinner.
  */
 function UpdateOverlay({ currentVersion, onDone }: { currentVersion?: string; onDone: () => void }) {
   const t = useTranslations("updateOverlay");
   const [phase, setPhase] = useState<UpdatePhase>("pulling");
+  const [failureReason, setFailureReason] = useState<string | null>(null);
   const everWentDown = useRef(false);
 
   // Polling loop.
   useEffect(() => {
     let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
     const deadline = Date.now() + UPDATE_TIMEOUT_MS;
+    let consecutiveFailures = 0;
+
+    const finish = () => {
+      if (cancelled) return;
+      setPhase("ready");
+      // Deliberately NOT clearPersisted(): the marker flips to "awaiting boot"
+      // so that after the reload BootGate can explain the wait rather than
+      // showing a bare "Waiting to start…" / "Couldn't connect".
+      markAwaitingBoot(currentVersion);
+      timer = setTimeout(() => window.location.reload(), READY_HOLD_MS);
+    };
 
     const tick = async () => {
       if (cancelled) return;
@@ -148,42 +240,82 @@ function UpdateOverlay({ currentVersion, onDone }: { currentVersion?: string; on
       }
 
       try {
-        const v = await api.getVersion();
+        const status = await api.getUpdateStatus();
+        consecutiveFailures = 0;
+        const attempt = status.last_update_status;
+
+        if (attempt && SUCCESS_STATES.has(attempt)) {
+          finish();
+          return;
+        }
+        if (attempt && FAILURE_STATES.has(attempt)) {
+          if (!cancelled) {
+            setFailureReason(status.last_update_error);
+            setPhase("failed");
+            clearPersisted();
+          }
+          return;
+        }
+
+        // No usable sidecar verdict. If the container demonstrably went away
+        // and came back on a different version, the swap happened regardless
+        // of what the state file says.
         if (everWentDown.current) {
-          // Container came back up after being down — reload.
-          if (!cancelled) {
-            setPhase("ready");
-            clearPersisted();
-            setTimeout(() => window.location.reload(), 800);
+          const v = await api.getVersion();
+          if (currentVersion && v.package_version && v.package_version !== currentVersion) {
+            finish();
+            return;
           }
-          return;
         }
-        // Container still running. Detect version change (fast swap without
-        // a visible down period).
-        if (currentVersion && v.package_version && v.package_version !== currentVersion) {
-          if (!cancelled) {
-            setPhase("ready");
-            clearPersisted();
-            setTimeout(() => window.location.reload(), 800);
-          }
-          return;
-        }
+
+        if (!cancelled) setPhase(everWentDown.current ? "restarting" : "pulling");
       } catch {
-        // API is unreachable — the old container stopped.
-        everWentDown.current = true;
-        setPhase("restarting");
+        // The API is unreachable — but one failure is not a restart.
+        consecutiveFailures += 1;
+        if (consecutiveFailures >= DOWN_THRESHOLD) {
+          everWentDown.current = true;
+          if (!cancelled) setPhase("restarting");
+        }
       }
 
-      setTimeout(tick, 2000);
+      if (!cancelled) timer = setTimeout(tick, POLL_INTERVAL_MS);
     };
 
-    // Brief initial pause so Docker has time to begin processing the
-    // update command before we start checking.
-    setTimeout(tick, 1500);
+    timer = setTimeout(tick, INITIAL_DELAY_MS);
     return () => {
       cancelled = true;
+      if (timer) clearTimeout(timer);
     };
   }, [currentVersion]);
+
+  if (phase === "failed") {
+    return (
+      <Flex align="center" justify="center" className="fixed inset-0 z-[200] bg-black text-white">
+        <Stack gap="4" className="text-center max-w-sm mx-auto px-4">
+          <Heading level={2} className="text-xl">
+            {t("failedHeading")}
+          </Heading>
+          <Text className="text-white/70">
+            {t.rich("failedDescription", {
+              code: (chunks: React.ReactNode) => <Code className="text-xs bg-white/10 px-1 rounded">{chunks}</Code>,
+            })}
+          </Text>
+          {failureReason && (
+            <Text size="xs" className="text-white/50">
+              {t("failedReason", { reason: failureReason })}
+            </Text>
+          )}
+          <Button
+            variant="outline"
+            className="border-white/30 text-white hover:bg-white/10 hover:text-white"
+            onClick={onDone}
+          >
+            {t("dismiss")}
+          </Button>
+        </Stack>
+      </Flex>
+    );
+  }
 
   if (phase === "error") {
     return (
@@ -194,7 +326,7 @@ function UpdateOverlay({ currentVersion, onDone }: { currentVersion?: string; on
           </Heading>
           <Text className="text-white/70">
             {t.rich("takingLongerDescription", {
-              code: (chunks) => <Code className="text-xs bg-white/10 px-1 rounded">{chunks}</Code>,
+              code: (chunks: React.ReactNode) => <Code className="text-xs bg-white/10 px-1 rounded">{chunks}</Code>,
             })}
           </Text>
           <Button
@@ -221,11 +353,7 @@ function UpdateOverlay({ currentVersion, onDone }: { currentVersion?: string; on
   const stepIndex = phase === "ready" ? 2 : phase === "restarting" ? 1 : 0;
 
   const phaseMessage =
-    phase === "pulling" && !everWentDown.current
-      ? t("phasePulling")
-      : phase === "ready"
-        ? t("phaseReady")
-        : t("phaseRestarting");
+    phase === "pulling" ? t("phasePulling") : phase === "ready" ? t("phaseReady") : t("phaseRestarting");
 
   return (
     <Flex align="center" justify="center" className="fixed inset-0 z-[200] bg-black text-white">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1376,7 +1376,26 @@ export interface UpdateStatusResponse {
   sidecar_url: string;
   last_check: string | null;
   last_update: string | null;
+  /**
+   * Outcome of the most recent /update or /rollback attempt, as recorded by
+   * the fiestaupdater sidecar. The sidecar owns this state, so it survives
+   * the FiestaBoard container being torn down and recreated — which makes it
+   * the only trustworthy "did the update actually finish?" signal available
+   * to the UI. `null` when the sidecar is unreachable.
+   */
+  last_update_status: UpdateAttemptStatus | null;
+  last_update_action: "update" | "rollback" | null;
+  /** Sidecar error code, e.g. "pull_failed" | "recreate_failed" | "retag_failed". */
+  last_update_error: string | null;
+  last_update_previous_digest: string | null;
+  last_update_completed_at: string | null;
 }
+
+/**
+ * Sidecar-reported lifecycle of an update/rollback attempt.
+ * `none` means no attempt has ever been recorded.
+ */
+export type UpdateAttemptStatus = "in_progress" | "success" | "rolled_back" | "rollback_failed" | "failed" | "none";
 
 export type AutoUpdateInterval = "daily" | "weekly" | "monthly" | "manual";
 


### PR DESCRIPTION
## The report

> When updating, sometimes it's like the updater finishes, or something restarts, and the user lands back on the settings page showing they have an update, then like 60 seconds later we land on a page saying we are starting up.

## Root cause

`UpdateOverlay` inferred the entire update lifecycle from `/version` alone:

```ts
try {
  const v = await api.getVersion();
  if (everWentDown.current) { /* ready → reload */ }
} catch {
  everWentDown.current = true;   // ← any single failure
}
```

**One** failed poll set `everWentDown`, and the **next** successful poll — even from the same, unchanged container — was read as "update complete" and triggered `window.location.reload()`.

During `docker compose pull` a single failure is easy to come by. The box is busy enough for a request to hit `DEFAULT_TIMEOUT_MS`, and nginx answers `503` from its `@api_starting` fallback (`nginx.conf`) whenever uvicorn is slow to respond — and `fetchApi` throws on any non-ok response. So:

1. Pull starts, overlay shows "Pulling…"
2. One poll blips → `everWentDown = true`
3. Next poll succeeds (old container, still running, still the old version) → **"Update complete. Reloading…"** → reload
4. User lands on Settings. The banner is still there, because nothing has been updated yet.
5. ~60 s later the pull finishes and `compose up -d` actually recreates the container. The API goes away with nothing on screen to explain it, and the user ends up at the boot splash / nginx's `starting.html`.

## The fix

The fiestaupdater sidecar already records the authoritative verdict of every attempt (`in_progress` / `success` / `failed` / `rolled_back` / `rollback_failed`, written by `handle_update` in `fiestaupdater/handler.sh`). It runs in a **separate container**, so that record survives FiestaBoard being torn down and recreated — which makes it the only trustworthy "did this actually finish?" signal the UI can reach. `/system/update/status` has always forwarded it; the TypeScript interface just never declared the fields.

- **`api.ts`** — declare `last_update_status`, `last_update_action`, `last_update_error`, `last_update_previous_digest`, `last_update_completed_at` on `UpdateStatusResponse`. Real Python↔TS drift: `src/api_server.py` returns them and the MSW mock handlers already included them.
- **`update-context.tsx`** — poll `/system/update/status` and reload **only** on the sidecar's success verdict. Require 3 consecutive failures before calling it a restart, so a single blip is noise. Surface `failed` / `rollback_failed` as an explained error state with the sidecar's reason instead of silently reloading into the version the user was already on. Keep the changed-`package_version` check as a fallback for when no sidecar record is available.
- **`update-context.tsx`** — the final reload hands off a persisted `awaitingBoot` marker instead of clearing state. The provider deliberately does **not** resume the overlay in that mode: resuming would re-read "success" and reload forever.
- **`boot-gate.tsx`** — consume that marker. "Finishing update…" / "FiestaBoard is restarting to finish the update" instead of the bare "Waiting to start…", and 120 s (not 30 s) before the "Couldn't connect to FiestaBoard" treatment, since a post-update restart on a Pi legitimately takes longer than a cold boot.

Strings added to all 14 locales.

## Verification

Run in a `node:24` container against this branch:

- `vitest run src/__tests__/update-context.test.tsx` — 6/6 pass (new file). Covers: a single transient failure keeps the overlay in "Pulling"; three failures move it to "Restarting" and only a sidecar `success` reloads; `failed` shows the reason and does not reload; the reload leaves `awaitingBoot: true` behind; a resumed `awaitingBoot` page does not re-show the overlay or re-poll (the reload-loop guard); a stale marker is ignored.
- `vitest run` on `ingress-base-path`, `system-update`, `auto-update-interval`, `update-intervals-extended` — 25/25 pass
- `eslint` on the changed files — 0 errors
- `prettier --check .` — clean
- `npm run typecheck` — no new errors; the 5 remaining are pre-existing on `main` (`FullConfig` declares `board` twice in `api.ts`)

**Not verified end-to-end against a live sidecar** — this needs a real `docker compose pull` + recreate cycle with the `fiestaupdater` profile enabled to exercise for real. Worth a manual pass before release.

## Note

`settings_snapshots` and `post_upgrade_regression` are also returned by the API and still missing from `UpdateStatusResponse`. Left alone here since nothing in the UI reads them yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)