### PR TITLE
fix(web): stop a double-click on one board starting two view transitions

### DIFF
--- a/web/src/__tests__/current-board-context.test.tsx
+++ b/web/src/__tests__/current-board-context.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -226,5 +226,109 @@ describe("CurrentBoardProvider — board switch view transition", () => {
 
     await waitFor(() => expect(screen.getByTestId("current-id")).toHaveTextContent("two"));
     expect(document.documentElement.dataset.boardSwitch).toBeUndefined();
+  });
+});
+
+// The suite above stubs `startViewTransition` so it invokes the update callback
+// SYNCHRONOUSLY. Real browsers do not: they take the "old" snapshot, yield, and
+// call back a frame or more later. That gap is where `setCurrentBoardIdState`
+// has not run yet, so `currentBoardIdRef` still holds the previous board and a
+// second click sails past the guard in `setCurrentBoardId`. The stub below
+// models the real contract by deferring the callback.
+describe("CurrentBoardProvider — asynchronous view transitions", () => {
+  const twoBoards = () =>
+    server.use(
+      http.get(`${API_BASE}/settings/board`, () =>
+        boardsResponse([
+          { id: "one", name: "Kitchen" },
+          { id: "two", name: "Office" },
+        ]),
+      ),
+    );
+
+  let startViewTransition: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    localStorage.clear();
+    startViewTransition = vi.fn((cb: () => void) => {
+      // Deferred, not inline — `act` only keeps React's warning quiet, it does
+      // not pull the callback back into the caller's synchronous frame.
+      queueMicrotask(() => act(() => cb()));
+      return { finished: Promise.resolve() };
+    });
+    (document as unknown as { startViewTransition: unknown }).startViewTransition = startViewTransition;
+  });
+
+  afterEach(() => {
+    delete (document as unknown as { startViewTransition?: unknown }).startViewTransition;
+    delete document.documentElement.dataset.boardSwitch;
+  });
+
+  it("double-clicking the same board starts exactly one transition", async () => {
+    twoBoards();
+    renderProbe();
+    await waitFor(() => expect(screen.getByTestId("current-id")).toHaveTextContent("one"));
+
+    // Both clicks land inside the browser's callback gap. Per spec, starting a
+    // transition while one is active SKIPS the first and rejects its `finished`
+    // with AbortError, so the second one here is not merely wasteful — it
+    // aborts the animation the user is already watching.
+    fireEvent.click(screen.getByTestId("select-two"));
+    fireEvent.click(screen.getByTestId("select-two"));
+
+    expect(startViewTransition).toHaveBeenCalledTimes(1);
+  });
+
+  it("an aborted transition does not surface an unhandled rejection", async () => {
+    // A skipped transition rejects `finished` with AbortError. `.finally()`
+    // does not consume a rejection — it re-raises it on the promise it returns
+    // — so a `.finally()` with no `.catch()` leaks one on every abort.
+    const unhandled: unknown[] = [];
+    const record = (reason: unknown) => unhandled.push(reason);
+    process.on("unhandledRejection", record);
+
+    try {
+      startViewTransition.mockImplementation((cb: () => void) => {
+        queueMicrotask(() => act(() => cb()));
+        return { finished: Promise.reject(new DOMException("Transition was skipped", "AbortError")) };
+      });
+
+      twoBoards();
+      renderProbe();
+      await waitFor(() => expect(screen.getByTestId("current-id")).toHaveTextContent("one"));
+
+      fireEvent.click(screen.getByTestId("select-two"));
+      await waitFor(() => expect(screen.getByTestId("current-id")).toHaveTextContent("two"));
+      // Node only reports a rejection as unhandled once the microtask queue has
+      // drained, so give it a macrotask to do that.
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", record);
+    }
+  });
+
+  it("keeps a board selectable after its transition is aborted", async () => {
+    // A skipped transition never runs its update callback, so `currentBoardId`
+    // never moves. If the pending target survives the abort, the guard reads
+    // that board as already-current forever and the user can never reach it.
+    startViewTransition.mockImplementation(() => ({
+      finished: Promise.reject(new DOMException("Transition was skipped", "AbortError")),
+    }));
+
+    twoBoards();
+    renderProbe();
+    await waitFor(() => expect(screen.getByTestId("current-id")).toHaveTextContent("one"));
+
+    fireEvent.click(screen.getByTestId("select-two"));
+    expect(startViewTransition).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("current-id")).toHaveTextContent("one");
+
+    // Let the abort settle.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    fireEvent.click(screen.getByTestId("select-two"));
+    expect(startViewTransition).toHaveBeenCalledTimes(2);
   });
 });

--- a/web/src/components/current-board-context.tsx
+++ b/web/src/components/current-board-context.tsx
@@ -27,11 +27,15 @@ function motionDisabled(): boolean {
  * the other (CSS in globals.css keys off `html[data-board-switch]`). Falls
  * back to an instant switch when the View Transitions API is unavailable or
  * the user prefers reduced motion.
+ *
+ * `onSettled` runs once the transition finishes OR is aborted, and on the
+ * instant-switch path runs immediately.
  */
-function runBoardSwitchTransition(direction: BoardSwitchDirection, update: () => void) {
+function runBoardSwitchTransition(direction: BoardSwitchDirection, update: () => void, onSettled: () => void) {
   const doc = document as DocumentWithViewTransition;
   if (typeof doc.startViewTransition !== "function" || motionDisabled()) {
     update();
+    onSettled();
     return;
   }
   doc.documentElement.dataset.boardSwitch = direction;
@@ -40,9 +44,17 @@ function runBoardSwitchTransition(direction: BoardSwitchDirection, update: () =>
     // React commit must land synchronously inside it.
     flushSync(update);
   });
-  transition.finished.finally(() => {
-    delete doc.documentElement.dataset.boardSwitch;
-  });
+  transition.finished
+    // A transition started while another is active SKIPS the earlier one and
+    // rejects its `finished` with AbortError. That is a normal outcome of a
+    // fast second switch, not an error — but `.finally()` re-raises a rejection
+    // on the promise it returns, so without this `.catch()` every abort leaks
+    // an unhandled rejection.
+    .catch(() => {})
+    .finally(() => {
+      delete doc.documentElement.dataset.boardSwitch;
+      onSettled();
+    });
 }
 
 interface CurrentBoardContextValue {
@@ -118,8 +130,16 @@ export function CurrentBoardProvider({ children }: { children: React.ReactNode }
     boardsRef.current = boards;
   }, [boards]);
 
+  // The board a transition is currently heading toward, or "" when none is in
+  // flight. `startViewTransition` invokes its callback asynchronously, so
+  // `setCurrentBoardIdState` — and therefore `currentBoardIdRef` — has not
+  // moved yet while a switch is in flight. Recording the target synchronously,
+  // with no commit required, is what lets the guard below see it.
+  const pendingIdRef = useRef("");
+
   const setCurrentBoardId = useCallback((boardId: string) => {
-    if (boardId === currentBoardIdRef.current) return;
+    if (boardId === (pendingIdRef.current || currentBoardIdRef.current)) return;
+    pendingIdRef.current = boardId;
 
     // Moving down the board list slides forward; moving up slides backward —
     // mirrors the order the user sees in the sidebar selector.
@@ -128,9 +148,18 @@ export function CurrentBoardProvider({ children }: { children: React.ReactNode }
     const toIndex = list.findIndex((b) => b.id === boardId);
     const direction: BoardSwitchDirection = toIndex >= fromIndex ? "forward" : "backward";
 
-    runBoardSwitchTransition(direction, () => {
-      setCurrentBoardIdState(boardId);
-    });
+    runBoardSwitchTransition(
+      direction,
+      () => {
+        setCurrentBoardIdState(boardId);
+      },
+      () => {
+        // Only clear if a newer switch has not already claimed the slot —
+        // otherwise an earlier transition aborting would drop the guard for the
+        // switch that superseded it.
+        if (pendingIdRef.current === boardId) pendingIdRef.current = "";
+      },
+    );
     try {
       localStorage.setItem(STORAGE_KEY, boardId);
     } catch {}


### PR DESCRIPTION
## The bug

`setCurrentBoardId` guards against re-selecting the board you are already on:

```js
if (boardId === currentBoardIdRef.current) return;
```

That ref cannot answer the question while a switch is in flight. `runBoardSwitchTransition` defers `setCurrentBoardIdState` into the `document.startViewTransition` callback, and **the browser invokes that callback asynchronously** — a frame or more after the click. Until it runs, no state has changed, so `currentBoardIdRef` still holds the board the user is leaving. A second click on the same board sails straight past the guard and starts a **second** view transition.

Per the View Transitions spec, starting a transition while one is active **skips** the first and **rejects its `finished` promise with `AbortError`**. Two consequences fell out of that:

- `transition.finished` had a `.finally()` and **no `.catch()`** → every abort left an **unhandled promise rejection**.
- That same `.finally()` deletes `data-board-switch`, so the aborted first transition **stripped the slide direction out from under the second one, mid-animation**.

## Why the suite never caught it

The existing `startViewTransition` stub invoked the update callback **synchronously**:

```js
startViewTransition = vi.fn((cb) => { cb(); return { finished: Promise.resolve() }; });
```

That closes the exact window the bug lives in. The new tests defer the callback with `queueMicrotask` so the stub models the real contract.

## The fix

Record the transition target **synchronously** in `pendingIdRef` — no commit required, so the very next click can read it — and compare against it in preference to the committed id:

```js
if (boardId === (pendingIdRef.current || currentBoardIdRef.current)) return;
pendingIdRef.current = boardId;
```

It is cleared when the transition settles **or aborts**, and only if a newer switch has not already claimed the slot — otherwise an earlier abort would drop the guard protecting the switch that superseded it. `.catch()` now sits ahead of the `.finally()`.

## Relationship to #1531

#1531 moved the ref syncs from passive effects to `useLayoutEffect`, described as fixing a stale-ref race in this same function. **It does not fix this window**, and the new test is the evidence. Run against `main` and against #1531 exactly as written, `double-clicking the same board starts exactly one transition` fails identically:

```
AssertionError: expected "vi.fn()" to be called 1 times, but got 2 times
```

Layout effects run synchronously *with the commit*. This gap opens **before there is a commit to run with** — `setCurrentBoardIdState` has not been called yet. Nothing about effect timing reaches it.

That change is left in place; it closes a different, narrower window, and #1539 (`current-board-context-ref-sync.test.tsx`) adds the coverage that proves it.

## Three-way verification

| Tree | `double-clicking the same board starts exactly one transition` |
| --- | --- |
| `main` before #1531 (passive effects) | **FAIL** — `expected "vi.fn()" to be called 1 times, but got 2 times` |
| #1531 as written / current `main` (`useLayoutEffect`) | **FAIL** — same message, identical |
| This PR (`pendingIdRef` guard) | **PASS** |

## Tests added

- `double-clicking the same board starts exactly one transition`
- `an aborted transition does not surface an unhandled rejection` — records `process.on("unhandledRejection")` and asserts nothing lands. Before the `.catch()`: `expected [ …(1) ] to deeply equal []` with a `DOMException`.
- `keeps a board selectable after its transition is aborted` — a skipped transition never runs its update callback, so without clearing the pending target the guard reads that board as already-current forever and the user can never reach it. Before the fix: `expected "vi.fn()" to be called 2 times, but got 1 times`.

## Verification

`npm run test:run`, three consecutive runs:

```
 Test Files  111 passed (111)
      Tests  1399 passed | 13 skipped (1412)
```

`npm run test:coverage` — passes its 80% thresholds:

```
Statements   : 87.94%
Branches     : 83.82%
Functions    : 83.1%
Lines        : 89.17%
```

`npm run lint` — 0 errors, 410 warnings, identical to `main` at 23816956; none added. `npm run format:check` — clean. `cd web && npm run typecheck` — **137 before, 137 after**, all pre-existing and unrelated (CI does not run it for `web/`).

## Known follow-up, deliberately not in scope

Two clicks on *different* boards in quick succession still legitimately start a second transition and abort the first. The abort no longer throws, but the first transition's `.finally()` still deletes `data-board-switch` while the second is animating, so that switch loses its slide direction. Fixing it means tracking transition identity through the cleanup. It needs its own failing test, so it gets its own PR rather than riding along here untested.
