### PR TITLE
test(web): cover the board-switch ref sync, correct the LanguageSelector comment

### DIFF
--- a/web/src/__tests__/current-board-context-ref-sync.test.tsx
+++ b/web/src/__tests__/current-board-context-ref-sync.test.tsx
@@ -1,0 +1,101 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CurrentBoardProvider, useCurrentBoard } from "@/components/current-board-context";
+
+import { server } from "./mocks/server";
+
+const API_BASE = "/api";
+
+function Probe() {
+  const { currentBoardId, setCurrentBoardId } = useCurrentBoard();
+  return (
+    <div>
+      <span data-testid="current-id">{currentBoardId}</span>
+      <button data-testid="select-one" onClick={() => setCurrentBoardId("one")} />
+    </div>
+  );
+}
+
+function renderProbe() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <CurrentBoardProvider>
+        <Probe />
+      </CurrentBoardProvider>
+    </QueryClientProvider>,
+  );
+}
+
+/**
+ * `CurrentBoardProvider` mirrors `currentBoardId` into a ref so `setCurrentBoardId`
+ * can compare against it without the callback changing identity on every
+ * selection. The sync has to happen in a LAYOUT effect, and nothing in the
+ * suite covered that until now.
+ *
+ * With a passive effect, React defers the sync until after paint. That leaves a
+ * window where the committed DOM already shows the reconciled board but the ref
+ * still holds the previous value — so a click landing in it compares against a
+ * stale id and starts a view transition to the board the user is already on.
+ *
+ * The window is real but narrow, so polling for it with `waitFor` only catches
+ * it intermittently. A MutationObserver closes it deterministically: its
+ * callback is a microtask, so it runs after the commit that paints the board
+ * but before React's scheduler gets the macrotask in which it would flush
+ * passive effects. Clicking from there lands exactly inside the window.
+ */
+describe("CurrentBoardProvider — ref sync timing", () => {
+  let startViewTransition: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    localStorage.clear();
+    startViewTransition = vi.fn((cb: () => void) => {
+      cb();
+      return { finished: Promise.resolve() };
+    });
+    (document as unknown as { startViewTransition: unknown }).startViewTransition = startViewTransition;
+    server.use(
+      http.get(`${API_BASE}/settings/board`, () =>
+        HttpResponse.json({
+          board_type: "black",
+          boards: [
+            { id: "one", name: "Kitchen", device_type: "flagship", board_color: "black" },
+            { id: "two", name: "Office", device_type: "flagship", board_color: "black" },
+          ],
+          devices: ["flagship"],
+        }),
+      ),
+    );
+  });
+
+  afterEach(() => {
+    delete (document as unknown as { startViewTransition?: unknown }).startViewTransition;
+    delete document.documentElement.dataset.boardSwitch;
+  });
+
+  it("does not start a transition for a click landing in the same commit that paints the board", async () => {
+    let clicked = false;
+    const observer = new MutationObserver(() => {
+      if (clicked) return;
+      const current = document.querySelector('[data-testid="current-id"]');
+      if (current?.textContent !== "one") return;
+      clicked = true;
+      (document.querySelector('[data-testid="select-one"]') as HTMLElement).click();
+    });
+    observer.observe(document.body, { subtree: true, childList: true, characterData: true });
+
+    try {
+      renderProbe();
+      await waitFor(() => expect(clicked).toBe(true));
+    } finally {
+      observer.disconnect();
+    }
+
+    // The click selected the board that was already current, so the guard in
+    // setCurrentBoardId must have seen an up-to-date ref and bailed out.
+    expect(startViewTransition).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/__tests__/language-selector.test.tsx
+++ b/web/src/__tests__/language-selector.test.tsx
@@ -49,11 +49,19 @@ describe("LanguageSelector", () => {
     const trigger = screen.getByRole("combobox", { name: /language/i });
     await user.click(trigger);
 
-    // The Select popup mounts with `opacity: 0; pointer-events: none` and only
-    // becomes interactive once its open transition has run. Waiting for the
-    // listbox before clicking keeps user-event from firing at a popup that
-    // still refuses pointer events.
-    await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument());
+    // Wait for the popup before clicking into it. The Select popup mounts
+    // non-interactive and only accepts pointer events once its open sequence
+    // has run; clicking too early aborts user-event with "Unable to perform
+    // pointer interaction as the element has `pointer-events: none`".
+    //
+    // Worth knowing when this bites: run this file on its own and the popup is
+    // already interactive by the time the trigger click resolves — probing the
+    // DOM at that point shows the listbox, all 14 options, and
+    // `pointer-events: auto` on every ancestor. The race only opens under
+    // full-suite load, when the open sequence has not finished settling. So a
+    // green single-file run proves nothing here; the failure is only ever
+    // visible in a full `npm run test:run`.
+    await screen.findByRole("listbox");
     await user.click(screen.getByRole("option", { name: "Español" }));
 
     await waitFor(() => expect(document.cookie).toContain("NEXT_LOCALE=es"));


### PR DESCRIPTION
## Why

#1531 shipped two changes. Neither was left in a defensible state: the production change had no test, and the test change carried a comment that overstated what had actually been established. This is **test-only** — it adds the missing coverage and rewrites the comment. No production code moves.

## 1. The board-switch ref sync had zero coverage

`current-board-context.tsx` syncs `currentBoardIdRef` in a `useLayoutEffect` rather than a passive `useEffect`. Nothing in the suite covered that: revert that one file and the whole suite still passes 10/10 runs, and `current-board-context.test.tsx` never failed once in 10 runs on the pre-#1531 tree either. The reasoning was plausible but unverified — a later refactor could quietly undo it and no test would notice.

**It is provable.** With a passive effect React defers the sync until after paint, leaving a window where the committed DOM already shows the reconciled board while the ref still holds the previous value. A click landing there compares against a stale id and starts a view transition to the board the user is already on.

The window is narrow, which is why polling for it with `waitFor` only catches it intermittently — and why the original report could not be reproduced on demand. A `MutationObserver` closes it deterministically: its callback is a **microtask**, so it runs after the commit that paints the board but before React gets the **macrotask** in which it would flush passive effects. Clicking from inside that callback lands in the window every time.

`current-board-context-ref-sync.test.tsx` does exactly that:

| Ref sync | Result |
| --- | --- |
| passive `useEffect` | **FAIL 3/3** — `expected "vi.fn()" to not be called at all, but actually been called 1 times` |
| `useLayoutEffect` (current `main`) | **PASS 10/10** |

## 2. The LanguageSelector comment claimed more than was checked

The wait is real and necessary — reverting it reproduces the failure. What was wrong was the explanation's confidence. It described the popup as mounting `opacity: 0; pointer-events: none` and becoming interactive only after its open transition, phrased as something you could go confirm. You cannot: probing the DOM immediately after the trigger click resolves shows the listbox present, all 14 options mounted, and `pointer-events: auto` with `opacity: 1` on every ancestor up to `body` — no `pointer-events: none` anywhere.

```
PROBE listbox present: true
PROBE option count: 14
    DIV[option] pe=auto op=1
    DIV[listbox] pe=auto op=1
    DIV[presentation] pe=auto op=1
    DIV[presentation] pe=auto op=1
    DIV[] pe=auto op=1
    BODY[] pe=auto op=1
PROBE any pointer-events:none in chain: false
```

**But that is only true when the file runs alone.** Under full-suite load the open sequence has not settled, and the failure is exactly what the original comment predicted:

```
Error: Unable to perform pointer interaction as the element has `pointer-events: none`
 ❯ src/__tests__/language-selector.test.tsx
    × sets NEXT_LOCALE cookie and changes i18next language when a language is selected
```

So the substance was right and the framing was misleading. The rewritten comment records **both** halves — because the second is the operationally important one: a green single-file run is worthless as evidence here, and only a full `npm run test:run` can show the bug.

Also applies the reviewer's nit: `await screen.findByRole("listbox")` instead of `waitFor` wrapping a redundant `expect(...).toBeInTheDocument()`.

## Verification

Full suite, **10 consecutive runs on this branch, 0 failures**:

```
 Test Files  112 passed (112)
      Tests  1397 passed | 13 skipped (1410)
```

Baseline for comparison — the pre-#1531 `language-selector.test.tsx` restored onto this same `main`, 10 full-suite runs on an otherwise idle machine: **5 failures**, every one the `pointer-events: none` error above.

```
run 1:  Test Files  1 failed | 110 passed (111)
run 2:  Test Files  1 failed | 110 passed (111)
run 3:  Test Files  111 passed (111)
run 4:  Test Files  111 passed (111)
run 5:  Test Files  111 passed (111)
run 6:  Test Files  111 passed (111)
run 7:  Test Files  1 failed | 110 passed (111)
run 8:  Test Files  111 passed (111)
run 9:  Test Files  1 failed | 110 passed (111)
run 10: Test Files  1 failed | 110 passed (111)
FAILING RUNS: 5 / 10
```

An earlier measurement of the same baseline taken while another suite shared the machine came in at 1/10 — worth noting, because it means a light run can easily under-report this and conclude the flake is gone.

`npm run test:coverage` — passes its 80% thresholds:

```
Statements   : 87.77%
Branches     : 83.73%
Functions    : 82.8%
Lines        : 89.04%
```

`npm run lint` — 0 errors, 410 warnings, identical to `main` at 23816956; none added. `npm run format:check` — clean. `cd web && npm run typecheck` — **137 before, 137 after**, all pre-existing and unrelated (CI does not typecheck `web/`).

## Related

#1538 fixes a separate, much wider window in the same function: `startViewTransition` invokes its callback asynchronously, so a double-click on one board starts two transitions. `useLayoutEffect` does not help there — that gap opens before there is a commit for a layout effect to run with — and the test in #1538 fails identically on `main` and on #1531 as written.
