### PR TITLE
feat(plugins): generic remote-options primitive (backend contract)

### DIFF
--- a/docs/development/PLUGIN_DEVELOPMENT.md
+++ b/docs/development/PLUGIN_DEVELOPMENT.md
@@ -386,6 +386,80 @@ plugins do not declare these fields.
 See the [plugin guide](https://fiestaboard.app/docs/development/plugin-guide#board-previews)
 for the full field reference.
 
+## Settings Options From Live Data (`remote-options`)
+
+When a setting is a choice out of your service's catalog — a ticker, a transit
+stop, a station — do not make the user hand-type it into a bare array. Declare
+the field as a remote-options field in the manifest and implement one method.
+No core change is needed for a new plugin.
+
+```json
+{
+  "settings_schema": {
+    "type": "object",
+    "properties": {
+      "symbols": {
+        "type": "array",
+        "title": "Symbols",
+        "ui:widget": "remote-options",
+        "ui:options": {
+          "options_id": "symbols",
+          "multiple": true,
+          "cache_seconds": 300
+        }
+      }
+    }
+  }
+}
+```
+
+`ui:options` accepts exactly four keys:
+
+| Key | Meaning |
+| --- | --- |
+| `options_id` | Which catalog this field wants. `^[a-z][a-z0-9_]*$`, unique across the schema. |
+| `depends_on` | Sibling or root property names whose values scope the catalog. |
+| `multiple` | Multi-select. Requires `"type": "array"`. |
+| `cache_seconds` | How long the UI may reuse the list. Integer, 0–3600. |
+
+Then implement `get_options()` — one method serves every `options_id`:
+
+```python
+from src.plugins.base import Option, OptionsRequest, OptionsResult, OptionsUnavailable
+
+class StocksPlugin(PluginBase):
+    def get_options(self, request: OptionsRequest) -> OptionsResult | list[Option]:
+        if not self.config.get("api_key"):
+            raise OptionsUnavailable("Add an API key first")
+        if request.options_id != "symbols":
+            raise NotImplementedError(request.options_id)
+
+        matches = search_symbols(request.query, timeout=5)
+        return [Option(value=m.ticker, label=m.name, group=m.exchange) for m in matches]
+```
+
+Returning a bare list is fine; return an `OptionsResult` when you need
+`has_more`/`cursor` paging.
+
+**This is not `fetch_data()`.** `fetch_data` returns board content for items the
+user has *already* chosen; `get_options` browses the whole upstream catalog so
+they can choose something new. It runs while the settings dialog is open,
+potentially on every keystroke, on a plugin that may not be configured yet:
+
+- Be safe when disabled or unconfigured — raise `OptionsUnavailable` rather than
+  assuming credentials exist
+- Put a timeout on every outbound call
+- Never mutate persisted state (no config writes, no cache priming, no
+  background threads or connections)
+
+The registry runs `get_options()` on a **throwaway instance** with your stored
+config applied, and calls `cleanup()` afterwards — your live instance is never
+touched, so a search box cannot disturb a running listener.
+
+A manifest that declares `remote-options` on a plugin that does not implement
+`get_options()` still loads, but the mismatch is reported by
+`GET /plugins/errors`. An unrecognized `ui:widget` is only a warning.
+
 ## Plugin Structure
 
 ```text

--- a/src/plugins/base.py
+++ b/src/plugins/base.py
@@ -10,7 +10,7 @@ import threading
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
 
@@ -114,6 +114,99 @@ class PluginInfo:
     author: str = "Unknown"
     repository: str = ""
     documentation: str = "README.md"
+
+
+class OptionsUnavailable(Exception):
+    """The plugin ran but cannot produce options right now.
+
+    Raise this for "ask me later" conditions — no API key configured yet, the
+    upstream service is unreachable, a dependent field has not been chosen.
+    It is *not* an error in the plugin; the UI turns it into a hint next to the
+    field rather than a stack trace.
+    """
+
+
+@dataclass
+class Option:
+    """One selectable choice offered by :meth:`PluginBase.get_options`.
+
+    Attributes:
+        value: What gets stored in the plugin config. JSON scalars only —
+            the value round-trips through config.json and the settings form.
+        label: Human-readable text shown in the picker.
+        description: Secondary line under the label.
+        group: Optional heading the option is filed under.
+        preview: Short sample of what this choice puts on the board.
+        disabled: Show the option but refuse selection (e.g. unsupported).
+        meta: Free-form extras for the widget; never persisted to config.
+    """
+
+    value: str | int | float | bool
+    label: str
+    description: str | None = None
+    group: str | None = None
+    preview: str | None = None
+    disabled: bool = False
+    meta: dict[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        # ``value`` is written verbatim into the plugin's stored config, so a
+        # dict or list here becomes an un-comparable, un-dedupable blob that
+        # only fails much later. Reject it where it is created.
+        if not isinstance(self.value, str | int | float | bool):
+            raise TypeError(f"Option.value must be a JSON scalar, got {type(self.value).__name__}")
+
+
+@dataclass
+class OptionsRequest:
+    """A request for one field's choices.
+
+    Attributes:
+        options_id: Which catalog the field asked for (from the manifest's
+            ``ui:options.options_id``).
+        parent: Values of the fields this one ``depends_on``, so the plugin can
+            scope the catalog (e.g. ``{"agency": "SF"}``).
+        query: Free-text the user has typed, for server-side search.
+        limit: Maximum number of options to return.
+        cursor: Opaque continuation token from a previous result.
+    """
+
+    options_id: str
+    parent: dict[str, Any] = field(default_factory=dict)
+    query: str = ""
+    limit: int = 200
+    cursor: str | None = None
+
+
+@dataclass
+class OptionsResult:
+    """The answer to an :class:`OptionsRequest`.
+
+    Attributes:
+        options: The choices to show.
+        has_more: Whether more options exist beyond this page.
+        cursor: Continuation token to pass back for the next page.
+        total: Total catalog size when the plugin knows it.
+        error: Human-readable reason the list is empty or partial.
+    """
+
+    options: list[Option] = field(default_factory=list)
+    has_more: bool = False
+    cursor: str | None = None
+    total: int | None = None
+    error: str | None = None
+
+
+def normalise(result: "OptionsResult | list[Option]") -> "OptionsResult":
+    """Coerce a plugin's ``get_options`` return value into an :class:`OptionsResult`.
+
+    Most plugins have a small catalog and just want to return a list; paging
+    and totals are the exception. Accepting both keeps the common case a
+    one-liner without making every caller handle two shapes.
+    """
+    if isinstance(result, OptionsResult):
+        return result
+    return OptionsResult(options=list(result))
 
 
 class PluginBase(ABC):
@@ -572,6 +665,48 @@ class PluginBase(ABC):
         The default implementation raises ``NotImplementedError`` (→ HTTP 405).
         """
         raise NotImplementedError(f"Plugin {self.plugin_id} does not support receive")
+
+    def get_options(self, request: "OptionsRequest") -> "OptionsResult | list[Option]":
+        """Browse this plugin's upstream catalog so the user can pick from it.
+
+        Override this in plugins whose settings schema declares
+        ``"ui:widget": "remote-options"`` on a field. The manifest's
+        ``ui:options.options_id`` selects which catalog is being asked for;
+        one method serves them all via ``request.options_id``.
+
+        **This is not** :meth:`fetch_data`. ``fetch_data`` returns board content
+        for items the user has *already* selected. ``get_options`` browses the
+        whole upstream catalog so the user can select something new — it runs
+        while the settings dialog is open, on every keystroke in a search box,
+        for a plugin that may not be configured yet.
+
+        That leads to four rules:
+
+        * **Be safe when disabled or unconfigured.** The method is called on a
+          throwaway instance with the draft config applied, whether or not the
+          plugin is enabled. Raise :class:`OptionsUnavailable` rather than
+          assuming credentials exist.
+        * **Set a timeout on every outbound call.** A hung request here blocks
+          a UI interaction, not a background poll.
+        * **Do not mutate persisted state.** No config writes, no cache
+          priming, no starting background threads or connections.
+        * **Raise** :class:`OptionsUnavailable` for "cannot answer right now"
+          (not configured, upstream down); let genuine bugs raise normally.
+
+        Return either an :class:`OptionsResult` or a bare ``list[Option]`` —
+        :func:`normalise` accepts both.
+
+        Args:
+            request: Which catalog to browse, plus query/paging context.
+
+        Returns:
+            An :class:`OptionsResult`, or a plain list of :class:`Option`.
+
+        Raises:
+            OptionsUnavailable: The plugin cannot answer right now.
+            NotImplementedError: The plugin offers no remote options (default).
+        """
+        raise NotImplementedError(f"Plugin {self.plugin_id} does not provide options")
 
     def check_triggers(self) -> list["TriggerResult"]:
         """Check whether any event-based triggers should fire.

--- a/src/plugins/loader.py
+++ b/src/plugins/loader.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from .base import PluginBase, TransitionPluginBase
-from .manifest import PluginManifest, load_manifest
+from .manifest import PluginManifest, collect_options_ids, load_manifest
 from .sources import (
     PluginSource,
     get_external_plugins_dir,
@@ -378,6 +378,24 @@ class PluginLoader:
                 )
                 self._load_errors[plugin_name] = errors
                 return None
+
+            # A manifest can promise remote options that the code never
+            # delivers. Soft failure on purpose: the plugin is otherwise fine
+            # and must keep working, but the mismatch is invisible until a
+            # user opens the settings dialog and the picker comes up empty,
+            # so surface it through GET /plugins/errors instead.
+            options_ids = collect_options_ids(manifest.settings_schema)
+            if (
+                options_ids
+                and isinstance(plugin_instance, PluginBase)
+                and type(plugin_instance).get_options is PluginBase.get_options
+            ):
+                message = (
+                    f"Manifest declares remote options {sorted(options_ids)} but "
+                    f"{type(plugin_instance).__name__} does not implement get_options()"
+                )
+                logger.warning("Plugin '%s': %s", plugin_name, message)
+                self._load_errors.setdefault(plugin_name, []).append(message)
 
             # Store loaded plugin and class
             self._loaded_plugins[manifest.id] = (plugin_instance, manifest)

--- a/src/plugins/manifest.py
+++ b/src/plugins/manifest.py
@@ -14,6 +14,8 @@ The manifest.json file is the heart of each plugin, defining:
 import copy
 import json
 import logging
+import re
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -37,6 +39,44 @@ TRIGGER_PAGE_ID_PROPERTY: dict[str, Any] = {
     "ui:widget": "page-picker",
     "default": "",
 }
+
+
+# ``ui:widget`` value that opts a settings field into the generic remote
+# options primitive: the field's choices come from the plugin's own
+# ``get_options()`` implementation rather than a static ``enum``.
+REMOTE_OPTIONS_WIDGET = "remote-options"
+
+# ``options_id`` becomes a URL path segment on the options route, so keep it to
+# a boring lowercase identifier.
+OPTIONS_ID_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+
+# Every key a ``ui:options`` block may carry. Anything else is a typo, and a
+# silently-ignored typo is how a picker ships without ever calling the plugin.
+UI_OPTIONS_KEYS = frozenset({"options_id", "depends_on", "multiple", "cache_seconds"})
+
+# How long the UI may reuse a fetched option list. Zero means "never cache";
+# the ceiling is an hour, above which a stale picker outlives the dialog it
+# was opened from.
+MIN_OPTIONS_CACHE_SECONDS = 0
+MAX_OPTIONS_CACHE_SECONDS = 3600
+
+# ``ui:widget`` values the settings form knows how to render. An unrecognised
+# value is a *warning*, never an error: several installed plugins declare
+# picker widgets core never implemented, and load_manifest() returns None on
+# any validation error -- rejecting them here would uninstall them in practice.
+KNOWN_SETTINGS_WIDGETS = frozenset(
+    {
+        "datetime",
+        "disney-parks-times-picker",
+        "generic-data-mapping-helper",
+        "page-picker",
+        "password",
+        REMOTE_OPTIONS_WIDGET,
+        "textarea",
+        "timezone",
+        "wsdot-route-picker",
+    }
+)
 
 
 def _inject_trigger_page_id(settings_schema: dict[str, Any]) -> dict[str, Any]:
@@ -658,6 +698,134 @@ class PluginManifest:
         return result
 
 
+def _iter_settings_fields(
+    settings_schema: dict[str, Any],
+) -> Iterator[tuple[str, dict[str, Any], dict[str, Any]]]:
+    """Yield ``(dotted_path, property_schema, sibling_properties)`` for every
+    field in *settings_schema*, recursing through nested ``properties`` and
+    array ``items.properties``.
+    """
+
+    def _walk(properties: dict[str, Any], path: str) -> Iterator[tuple[str, dict[str, Any], dict[str, Any]]]:
+        for name, prop in properties.items():
+            if not isinstance(prop, dict):
+                continue
+            field_path = f"{path}.{name}" if path else name
+            yield field_path, prop, properties
+
+            nested = prop.get("properties")
+            if isinstance(nested, dict):
+                yield from _walk(nested, field_path)
+            items = prop.get("items")
+            if isinstance(items, dict) and isinstance(items.get("properties"), dict):
+                yield from _walk(items["properties"], f"{field_path}.items")
+
+    yield from _walk(settings_schema.get("properties") or {}, "")
+
+
+def collect_options_ids(settings_schema: dict[str, Any]) -> set[str]:
+    """Return every ``ui:options.options_id`` declared anywhere in *settings_schema*.
+
+    A non-empty result means the plugin promises to answer options requests and
+    therefore must implement :meth:`~src.plugins.base.PluginBase.get_options`.
+    """
+    ids: set[str] = set()
+    for _path, prop, _siblings in _iter_settings_fields(settings_schema):
+        if prop.get("ui:widget") != REMOTE_OPTIONS_WIDGET:
+            continue
+        ui_options = prop.get("ui:options")
+        options_id = ui_options.get("options_id") if isinstance(ui_options, dict) else None
+        if isinstance(options_id, str) and options_id:
+            ids.add(options_id)
+    return ids
+
+
+def validate_settings_schema_ui(settings_schema: dict[str, Any]) -> list[str]:
+    """Validate the ``ui:*`` annotations in a plugin's ``settings_schema``.
+
+    Returns a list of hard **errors** (empty when the schema is fine). An
+    unrecognised ``ui:widget`` is deliberately *not* an error -- see the module
+    note on ``load_manifest`` returning ``None`` for any validation failure.
+
+    Args:
+        settings_schema: The manifest's ``settings_schema`` object.
+
+    Returns:
+        List of human-readable error strings.
+    """
+    errors: list[str] = []
+    seen_ids: dict[str, str] = {}
+    root_properties = settings_schema.get("properties") or {}
+
+    for field_path, prop, siblings in _iter_settings_fields(settings_schema):
+        widget = prop.get("ui:widget")
+        if widget is not None and widget not in KNOWN_SETTINGS_WIDGETS:
+            # Soft failure on purpose -- see KNOWN_SETTINGS_WIDGETS.
+            logger.warning(
+                "settings_schema.%s: unknown ui:widget '%s' — the settings form will fall back to a plain input",
+                field_path,
+                widget,
+            )
+        if widget != REMOTE_OPTIONS_WIDGET:
+            continue
+
+        ui_options = prop.get("ui:options") or {}
+        if not isinstance(ui_options, dict):
+            errors.append(f"settings_schema.{field_path}: ui:options must be an object")
+            # Fall through with an empty block so the field still gets the
+            # "missing options_id" error rather than two shapes of the same bug.
+            ui_options = {}
+
+        options_id = ui_options.get("options_id")
+        if not options_id:
+            errors.append(f"settings_schema.{field_path}: ui:widget 'remote-options' requires ui:options.options_id")
+        elif not isinstance(options_id, str) or not OPTIONS_ID_RE.match(options_id):
+            errors.append(
+                f"settings_schema.{field_path}: ui:options.options_id '{options_id}' must match {OPTIONS_ID_RE.pattern}"
+            )
+        elif options_id in seen_ids:
+            errors.append(
+                f"settings_schema.{field_path}: duplicate ui:options.options_id '{options_id}' "
+                f"(already declared by settings_schema.{seen_ids[options_id]})"
+            )
+        else:
+            seen_ids[options_id] = field_path
+
+        for key in sorted(set(ui_options) - UI_OPTIONS_KEYS):
+            errors.append(f"settings_schema.{field_path}: unknown ui:options key '{key}'")
+
+        if ui_options.get("multiple") and prop.get("type") != "array":
+            errors.append(
+                f"settings_schema.{field_path}: ui:options.multiple requires type 'array', got {prop.get('type')!r}"
+            )
+
+        cache_seconds = ui_options.get("cache_seconds")
+        if cache_seconds is not None and (
+            not isinstance(cache_seconds, int)
+            or isinstance(cache_seconds, bool)
+            or not (MIN_OPTIONS_CACHE_SECONDS <= cache_seconds <= MAX_OPTIONS_CACHE_SECONDS)
+        ):
+            errors.append(
+                f"settings_schema.{field_path}: ui:options.cache_seconds must be an integer between "
+                f"{MIN_OPTIONS_CACHE_SECONDS} and {MAX_OPTIONS_CACHE_SECONDS}, got {cache_seconds!r}"
+            )
+
+        depends_on = ui_options.get("depends_on") or []
+        if not isinstance(depends_on, list):
+            errors.append(f"settings_schema.{field_path}: ui:options.depends_on must be an array")
+        else:
+            # A dependency may point at a sibling (same object) or at a
+            # top-level setting -- array item fields routinely depend on a
+            # root field such as the account or agency the rows belong to.
+            for dep in depends_on:
+                if dep not in siblings and dep not in root_properties:
+                    errors.append(
+                        f"settings_schema.{field_path}: ui:options.depends_on references unknown property '{dep}'"
+                    )
+
+    return errors
+
+
 def validate_manifest(data: dict[str, Any]) -> tuple[bool, list[str]]:
     """Validate a manifest dictionary against the schema.
 
@@ -702,6 +870,8 @@ def validate_manifest(data: dict[str, Any]) -> tuple[bool, list[str]]:
     settings = data.get("settings_schema", {})
     if settings and not isinstance(settings, dict):
         errors.append("settings_schema must be an object")
+    elif isinstance(settings, dict):
+        errors.extend(validate_settings_schema_ui(settings))
 
     # Validate env_vars if present
     env_vars = data.get("env_vars", [])

--- a/src/plugins/registry.py
+++ b/src/plugins/registry.py
@@ -12,12 +12,13 @@ import logging
 import re
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import wait as futures_wait
+from dataclasses import replace
 from pathlib import Path
 from typing import Any, Optional
 
 from src.devices import BoardContext
 
-from .base import PluginBase, PluginResult
+from .base import OptionsRequest, OptionsResult, PluginBase, PluginResult, normalise
 from .loader import PluginLoader
 from .manifest import PluginManifest, VariableMetadata
 from .sources import (
@@ -809,6 +810,80 @@ class PluginRegistry:
         except Exception as e:
             logger.exception(f"Error fetching data from {plugin_id}")
             return PluginResult(available=False, error=str(e))
+
+    def get_plugin_options(
+        self,
+        plugin_id: str,
+        options_id: str,
+        request: OptionsRequest,
+        draft_config: dict[str, Any] | None = None,
+    ) -> OptionsResult:
+        """Ask a plugin to browse its upstream catalog for one settings field.
+
+        Runs on a **throwaway sandbox instance**, never the live one. Options
+        are fetched while the settings dialog is open — potentially on every
+        keystroke — and the live instance's ``config`` setter fires
+        :meth:`~src.plugins.base.PluginBase.clear_cache` and
+        :meth:`~src.plugins.base.PluginBase.on_config_change`. For the Home
+        Assistant plugin that tears down its running MQTT statestream listener,
+        so typing in a search box would repeatedly kill a live subscription.
+        The sandbox gets its config assigned to ``_config`` directly, bypassing
+        the property setter and its side effects, and is always cleaned up.
+
+        The plugin's stored config is applied whether or not it is enabled:
+        a user configuring a plugin for the first time has not enabled it yet.
+
+        Args:
+            plugin_id: Plugin identifier, possibly an instance key (``weather:sf``).
+            options_id: Which catalog to browse (from ``ui:options.options_id``).
+            request: Query/paging context. Its ``options_id`` is overridden by
+                the *options_id* argument so the caller's route wins.
+            draft_config: Unsaved settings-form values. Not yet applied — see
+                the TODO below.
+
+        Returns:
+            An :class:`OptionsResult`.
+
+        Raises:
+            KeyError: No such plugin, or its class is no longer loadable.
+            NotImplementedError: The plugin is a transition plugin, or does not
+                implement ``get_options``.
+            OptionsUnavailable: The plugin cannot answer right now.
+        """
+        base_id, _instance_label = self.parse_instance_key(plugin_id)
+
+        live = self._plugins.get(plugin_id)
+        if live is None:
+            raise KeyError(f"Plugin not found: {plugin_id}")
+
+        # Transition plugins animate sends; they have no settings catalog.
+        if not isinstance(live, PluginBase):
+            raise NotImplementedError(f"Plugin {plugin_id} is a transition plugin (no options)")
+
+        # Config comes from the full instance key, the class from the base id.
+        effective_config = dict(self._configs.get(plugin_id) or {})
+        # TODO(#options-route): merge *draft_config* over effective_config once
+        # the HTTP layer can unmask the redacted secrets the form sends back.
+        # Applying it verbatim today would overwrite a real API key with the
+        # placeholder the UI displays.
+        _ = draft_config
+
+        sandbox = self._loader.create_instance(base_id)
+        if sandbox is None:
+            raise KeyError(f"Cannot create sandbox instance for plugin: {base_id}")
+
+        # Direct field assignment on purpose: the ``config`` property setter
+        # calls clear_cache() + on_config_change(), which is exactly the
+        # teardown this sandbox exists to avoid.
+        sandbox._config = effective_config
+
+        try:
+            return normalise(sandbox.get_options(replace(request, options_id=options_id)))
+        finally:
+            try:
+                sandbox.cleanup()
+            except Exception:
+                logger.exception("Error cleaning up options sandbox for %s", plugin_id)
 
     def _discover_variables(self, plugin_id: str) -> list[str]:
         """Introspect a plugin's live data to discover top-level variable names.

--- a/tests/test_plugin_options.py
+++ b/tests/test_plugin_options.py
@@ -1,0 +1,653 @@
+"""Tests for the generic plugin options primitive.
+
+Covers the three backend pieces of the contract:
+
+1. ``src.plugins.manifest`` — settings-schema ``ui:widget``/``ui:options``
+   validation and options-id collection.
+2. ``src.plugins.base`` — the ``Option``/``OptionsRequest``/``OptionsResult``
+   value types and the ``PluginBase.get_options`` hook.
+3. ``src.plugins.registry`` — dispatch into a throwaway sandbox instance.
+"""
+
+import json
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.plugins.base import (
+    Option,
+    OptionsRequest,
+    OptionsResult,
+    OptionsUnavailable,
+    PluginBase,
+    PluginResult,
+    TransitionPluginBase,
+    normalise,
+)
+from src.plugins.loader import PluginLoader
+from src.plugins.manifest import collect_options_ids, validate_manifest, validate_settings_schema_ui
+from src.plugins.registry import PluginRegistry
+
+
+class _StubPlugin(PluginBase):
+    """Minimal concrete plugin used to exercise the base-class contract."""
+
+    @property
+    def plugin_id(self) -> str:
+        return "stub"
+
+    def fetch_data(self) -> PluginResult:
+        return PluginResult(available=True, data={})
+
+
+def test_remote_options_widget_without_options_id_is_an_error():
+    """``remote-options`` is meaningless without an id to dispatch on."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "symbols": {
+                "type": "array",
+                "ui:widget": "remote-options",
+            }
+        },
+    }
+
+    errors = validate_settings_schema_ui(schema)
+
+    assert any("options_id" in e for e in errors), errors
+
+
+def test_options_id_must_be_a_lowercase_snake_case_identifier():
+    """``options_id`` ends up in a URL path segment — keep it boring."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "symbols": {
+                "type": "array",
+                "ui:widget": "remote-options",
+                "ui:options": {"options_id": "Stock-Symbols"},
+            }
+        },
+    }
+
+    errors = validate_settings_schema_ui(schema)
+
+    assert any("Stock-Symbols" in e for e in errors), errors
+
+
+def test_unknown_key_inside_ui_options_is_an_error():
+    """Typos in ``ui:options`` fail loudly instead of being silently ignored."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "symbols": {
+                "type": "array",
+                "ui:widget": "remote-options",
+                "ui:options": {"options_id": "symbols", "cache_second": 60},
+            }
+        },
+    }
+
+    errors = validate_settings_schema_ui(schema)
+
+    assert any("cache_second" in e for e in errors), errors
+
+
+def test_multiple_requires_an_array_typed_field():
+    """A multi-select needs somewhere to put the second selection."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "symbol": {
+                "type": "string",
+                "ui:widget": "remote-options",
+                "ui:options": {"options_id": "symbols", "multiple": True},
+            }
+        },
+    }
+
+    errors = validate_settings_schema_ui(schema)
+
+    assert any("multiple" in e for e in errors), errors
+
+
+def test_cache_seconds_outside_the_allowed_range_is_an_error():
+    """Cache windows above an hour are almost always a units mistake."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "symbols": {
+                "type": "array",
+                "ui:widget": "remote-options",
+                "ui:options": {"options_id": "symbols", "cache_seconds": 86400},
+            }
+        },
+    }
+
+    errors = validate_settings_schema_ui(schema)
+
+    assert any("cache_seconds" in e for e in errors), errors
+
+
+def test_depends_on_must_name_a_real_property():
+    """A dangling dependency means the picker never unlocks."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "agency": {"type": "string"},
+            "stop": {
+                "type": "string",
+                "ui:widget": "remote-options",
+                "ui:options": {"options_id": "stops", "depends_on": ["agenncy"]},
+            },
+        },
+    }
+
+    errors = validate_settings_schema_ui(schema)
+
+    assert any("agenncy" in e for e in errors), errors
+
+
+def test_depends_on_may_reference_a_root_property_from_a_nested_field():
+    """Array rows routinely depend on the top-level account/agency setting."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "agency": {"type": "string"},
+            "routes": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "stop": {
+                            "type": "string",
+                            "ui:widget": "remote-options",
+                            "ui:options": {"options_id": "stops", "depends_on": ["agency"]},
+                        }
+                    },
+                },
+            },
+        },
+    }
+
+    assert validate_settings_schema_ui(schema) == []
+
+
+def test_validation_recurses_into_array_item_properties():
+    """Most real pickers live on array item fields, not at the root."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "routes": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {"stop": {"type": "string", "ui:widget": "remote-options"}},
+                },
+            }
+        },
+    }
+
+    errors = validate_settings_schema_ui(schema)
+
+    assert any("routes.items.stop" in e for e in errors), errors
+
+
+def test_duplicate_options_id_across_the_schema_is_an_error():
+    """``options_id`` is the dispatch key — two fields cannot share one."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "home": {
+                "type": "string",
+                "ui:widget": "remote-options",
+                "ui:options": {"options_id": "stops"},
+            },
+            "work": {
+                "type": "string",
+                "ui:widget": "remote-options",
+                "ui:options": {"options_id": "stops"},
+            },
+        },
+    }
+
+    errors = validate_settings_schema_ui(schema)
+
+    assert any("duplicate" in e.lower() and "stops" in e for e in errors), errors
+
+
+def test_collect_options_ids_finds_ids_nested_in_array_items():
+    """The loader needs every id, including ones on array item fields."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "agency": {
+                "type": "string",
+                "ui:widget": "remote-options",
+                "ui:options": {"options_id": "agencies"},
+            },
+            "routes": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "stop": {
+                            "type": "string",
+                            "ui:widget": "remote-options",
+                            "ui:options": {"options_id": "stops"},
+                        }
+                    },
+                },
+            },
+        },
+    }
+
+    assert collect_options_ids(schema) == {"agencies", "stops"}
+
+
+@pytest.mark.parametrize(
+    "widget",
+    ["stock-symbol-picker", "muni-stop-picker", "lyft-bikeshare-station-picker"],
+)
+def test_unknown_ui_widget_warns_but_the_manifest_still_validates(widget, caplog):
+    """Backward-compat guard.
+
+    ``load_manifest`` returns ``None`` on *any* validation error, so promoting
+    an unrecognised ``ui:widget`` to an error would stop already-installed
+    plugins from loading at all. Three shipped plugins declare picker widgets
+    core never implemented; they must keep working.
+    """
+    manifest = {
+        "id": "stocks",
+        "name": "Stocks",
+        "version": "1.0.0",
+        "settings_schema": {
+            "type": "object",
+            "properties": {"symbols": {"type": "array", "ui:widget": widget}},
+        },
+    }
+
+    with caplog.at_level(logging.WARNING, logger="src.plugins.manifest"):
+        is_valid, errors = validate_manifest(manifest)
+
+    assert is_valid, errors
+    assert errors == []
+    assert any(widget in record.message for record in caplog.records), caplog.text
+
+
+def test_validate_manifest_rejects_a_malformed_remote_options_field():
+    """Only a field that explicitly opts into ``remote-options`` is held to the
+    strict rules — and there the manifest must fail validation outright."""
+    manifest = {
+        "id": "muni",
+        "name": "Muni",
+        "version": "1.0.0",
+        "settings_schema": {
+            "type": "object",
+            "properties": {"stop": {"type": "string", "ui:widget": "remote-options"}},
+        },
+    }
+
+    is_valid, errors = validate_manifest(manifest)
+
+    assert not is_valid
+    assert any("options_id" in e for e in errors), errors
+
+
+# ── src.plugins.base ────────────────────────────────────────────────────
+
+
+def test_default_get_options_raises_not_implemented():
+    """Plugins opt in; the base class must not pretend to have a catalog."""
+    plugin = _StubPlugin({"id": "stub", "name": "Stub", "version": "1.0.0"})
+
+    with pytest.raises(NotImplementedError):
+        plugin.get_options(OptionsRequest(options_id="anything"))
+
+
+def test_normalise_wraps_a_bare_option_list_in_a_result():
+    """The ergonomic path: small catalogs just return a list."""
+    options = [Option(value="ktm", label="KT Muni Metro")]
+
+    result = normalise(options)
+
+    assert isinstance(result, OptionsResult)
+    assert result.options == options
+    assert result.has_more is False
+
+
+def test_option_rejects_a_non_scalar_value():
+    """``value`` is written straight into config.json — dicts do not belong."""
+    with pytest.raises(TypeError):
+        Option(value={"id": "ktm"}, label="KT Muni Metro")
+
+
+def test_normalise_passes_an_options_result_through_unchanged():
+    """Paging plugins build the result themselves; do not rebuild it."""
+    result = OptionsResult(options=[Option(value="ktm", label="KT")], has_more=True, cursor="page-2")
+
+    assert normalise(result) is result
+
+
+# ── src.plugins.registry ────────────────────────────────────────────────
+
+
+class _OptionsPlugin(PluginBase):
+    """Records every interaction so tests can assert on the sandbox lifecycle."""
+
+    def __init__(self, manifest, plugin_id="stocks"):
+        self._id = plugin_id
+        super().__init__(manifest)
+        self.requests: list[OptionsRequest] = []
+        self.config_changes: list[tuple[dict, dict]] = []
+        self.cleaned_up = False
+        self.raise_on_options: Exception | None = None
+
+    @property
+    def plugin_id(self) -> str:
+        return self._id
+
+    def fetch_data(self) -> PluginResult:
+        return PluginResult(available=True, data={})
+
+    def get_options(self, request: OptionsRequest):
+        self.requests.append(request)
+        if self.raise_on_options is not None:
+            raise self.raise_on_options
+        return [Option(value=self.config.get("account", "AAPL"), label="Apple")]
+
+    def on_config_change(self, old_config, new_config) -> None:
+        self.config_changes.append((old_config, new_config))
+
+    def cleanup(self) -> None:
+        self.cleaned_up = True
+
+
+@pytest.fixture
+def options_registry():
+    """Registry holding one live ``stocks`` plugin plus a sandbox factory."""
+    manifest_raw = {"id": "stocks", "name": "Stocks", "version": "1.0.0"}
+    sandboxes: list[_OptionsPlugin] = []
+    control: dict[str, Any] = {"sandbox_error": None}
+
+    def _create_instance(base_id):
+        sandbox = _OptionsPlugin(manifest_raw, plugin_id=base_id)
+        sandbox.raise_on_options = control["sandbox_error"]
+        sandboxes.append(sandbox)
+        return sandbox
+
+    loader = MagicMock()
+    loader.load_all_plugins.return_value = {}
+    loader.create_instance.side_effect = _create_instance
+
+    with patch("src.plugins.registry.PluginLoader", return_value=loader):
+        registry = PluginRegistry(plugins_dir=Path("/fake/plugins"))
+
+    live = _OptionsPlugin(manifest_raw)
+    registry._plugins["stocks"] = live
+    registry._configs["stocks"] = {"api_key": "test_key"}
+    registry._enabled["stocks"] = True
+
+    return SimpleNamespace(registry=registry, live=live, sandboxes=sandboxes, loader=loader, control=control)
+
+
+def test_get_plugin_options_calls_the_plugin_with_the_requested_options_id(options_registry):
+    """The request the plugin sees is the one the caller asked for."""
+    request = OptionsRequest(options_id="ignored", parent={"exchange": "NASDAQ"}, query="app", limit=25)
+
+    result = options_registry.registry.get_plugin_options("stocks", "symbols", request)
+
+    (sandbox,) = options_registry.sandboxes
+    (seen,) = sandbox.requests
+    assert seen.options_id == "symbols"
+    assert seen.parent == {"exchange": "NASDAQ"}
+    assert seen.query == "app"
+    assert seen.limit == 25
+    assert isinstance(result, OptionsResult)
+    assert [o.label for o in result.options] == ["Apple"]
+
+
+def test_options_use_a_fresh_sandbox_and_never_disturb_the_live_instance(options_registry):
+    """HA-MQTT-teardown regression guard.
+
+    Assigning to the live instance's ``config`` property fires ``clear_cache()``
+    and ``on_config_change()``. The Home Assistant plugin tears down its running
+    MQTT statestream listener in that hook — doing it on every keystroke in a
+    settings search box is unacceptable. Options must run on a throwaway
+    instance, so the live one must be left completely untouched.
+    """
+    live = options_registry.live
+
+    options_registry.registry.get_plugin_options("stocks", "symbols", OptionsRequest(options_id="symbols"))
+
+    assert live.config_changes == [], "live instance's on_config_change fired"
+    assert live.requests == [], "live instance served the options request"
+    assert live.cleaned_up is False, "live instance was cleaned up"
+    assert len(options_registry.sandboxes) == 1
+    assert options_registry.sandboxes[0] is not live
+    options_registry.loader.create_instance.assert_called_once_with("stocks")
+
+
+def test_sandbox_is_cleaned_up_even_when_get_options_raises(options_registry):
+    """A plugin that opens a socket before failing must not leak it."""
+    options_registry.control["sandbox_error"] = OptionsUnavailable("no API key configured")
+
+    with pytest.raises(OptionsUnavailable):
+        options_registry.registry.get_plugin_options("stocks", "symbols", OptionsRequest(options_id="symbols"))
+
+    (sandbox,) = options_registry.sandboxes
+    assert sandbox.cleaned_up is True
+
+
+def test_instance_key_resolves_class_from_base_id_and_config_from_the_full_key(options_registry):
+    """``stocks:growth`` shares the ``stocks`` class but has its own settings."""
+    registry = options_registry.registry
+    registry._plugins["stocks:growth"] = _OptionsPlugin(
+        {"id": "stocks", "name": "Stocks", "version": "1.0.0"}, plugin_id="stocks"
+    )
+    registry._configs["stocks:growth"] = {"account": "growth"}
+
+    result = registry.get_plugin_options("stocks:growth", "symbols", OptionsRequest(options_id="symbols"))
+
+    options_registry.loader.create_instance.assert_called_once_with("stocks")
+    (sandbox,) = options_registry.sandboxes
+    assert sandbox.config == {"account": "growth"}
+    assert [o.value for o in result.options] == ["growth"]
+
+
+def test_options_work_while_the_plugin_is_still_disabled(options_registry):
+    """You browse the catalog *in order to* configure the plugin — before
+    enabling it. The stored config is applied either way."""
+    registry = options_registry.registry
+    registry._enabled["stocks"] = False
+    registry._configs["stocks"] = {"account": "AMZN"}
+
+    result = registry.get_plugin_options("stocks", "symbols", OptionsRequest(options_id="symbols"))
+
+    assert [o.value for o in result.options] == ["AMZN"]
+
+
+def test_transition_plugin_has_no_options(options_registry):
+    """Transitions animate sends; there is no catalog to browse."""
+
+    class _Transition(TransitionPluginBase):
+        @property
+        def plugin_id(self) -> str:
+            return "typewriter"
+
+        def generate_frames(self, from_grid, to_grid, device, config):
+            yield from ()
+
+    registry = options_registry.registry
+    registry._plugins["typewriter"] = _Transition({"id": "typewriter", "plugin_type": "transition"})
+
+    with pytest.raises(NotImplementedError):
+        registry.get_plugin_options("typewriter", "anything", OptionsRequest(options_id="anything"))
+
+
+def test_sandbox_config_bypasses_the_property_setter(options_registry):
+    """``_config`` is assigned directly so no config-change hook fires at all —
+    not on the live instance, and not on the sandbox either."""
+    options_registry.registry.get_plugin_options("stocks", "symbols", OptionsRequest(options_id="symbols"))
+
+    (sandbox,) = options_registry.sandboxes
+    assert sandbox.config == {"api_key": "test_key"}
+    assert sandbox.config_changes == []
+
+
+def test_unknown_plugin_raises_key_error(options_registry):
+    """An options request for a plugin that is not loaded is a caller bug."""
+    with pytest.raises(KeyError):
+        options_registry.registry.get_plugin_options("nope", "symbols", OptionsRequest(options_id="symbols"))
+
+
+# ── src.plugins.loader ──────────────────────────────────────────────────
+
+
+def _write_options_plugin(tmp_path: Path, plugin_id: str, *, implements_get_options: bool) -> None:
+    """Write a plugin whose manifest declares a remote-options field."""
+    plugin_dir = tmp_path / plugin_id
+    plugin_dir.mkdir()
+    (plugin_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "id": plugin_id,
+                "name": "Stocks",
+                "version": "1.0.0",
+                "settings_schema": {
+                    "type": "object",
+                    "properties": {
+                        "symbols": {
+                            "type": "array",
+                            "ui:widget": "remote-options",
+                            "ui:options": {"options_id": "symbols"},
+                        }
+                    },
+                },
+            }
+        )
+    )
+    get_options_src = (
+        """
+    def get_options(self, request):
+        return []
+"""
+        if implements_get_options
+        else ""
+    )
+    (plugin_dir / "__init__.py").write_text(
+        f'''"""Test plugin."""
+from src.plugins.base import PluginBase, PluginResult
+
+
+class StocksPlugin(PluginBase):
+    @property
+    def plugin_id(self) -> str:
+        return "{plugin_id}"
+
+    def fetch_data(self) -> PluginResult:
+        return PluginResult(available=True, data={{}})
+{get_options_src}'''
+    )
+
+
+def test_loader_flags_a_manifest_that_promises_options_without_implementing_them(tmp_path):
+    """Non-fatal: the plugin still loads, but the mismatch surfaces in
+    ``GET /plugins/errors`` instead of failing silently at pick time."""
+    _write_options_plugin(tmp_path, "brokenopts", implements_get_options=False)
+    loader = PluginLoader(plugins_dir=tmp_path, external_dirs=[])
+
+    plugin = loader.load_plugin("brokenopts")
+
+    assert plugin is not None, "the plugin must still load"
+    assert any("get_options" in e for e in loader.load_errors.get("brokenopts", [])), loader.load_errors
+
+
+def test_loader_stays_quiet_when_the_plugin_implements_get_options(tmp_path):
+    """No false alarm for plugins that do hold up their end."""
+    _write_options_plugin(tmp_path, "goodopts", implements_get_options=True)
+    loader = PluginLoader(plugins_dir=tmp_path, external_dirs=[])
+
+    plugin = loader.load_plugin("goodopts")
+
+    assert plugin is not None
+    assert loader.load_errors.get("goodopts", []) == []
+
+
+def test_a_failing_sandbox_cleanup_does_not_fail_the_request(options_registry):
+    """Cleanup is best-effort — a sloppy teardown must not break the picker."""
+
+    def _boom():
+        raise RuntimeError("teardown exploded")
+
+    original = options_registry.loader.create_instance.side_effect
+
+    def _create_instance(base_id):
+        sandbox = original(base_id)
+        sandbox.cleanup = _boom
+        return sandbox
+
+    options_registry.loader.create_instance.side_effect = _create_instance
+
+    result = options_registry.registry.get_plugin_options("stocks", "symbols", OptionsRequest(options_id="symbols"))
+
+    assert [o.label for o in result.options] == ["Apple"]
+
+
+def test_missing_plugin_class_raises_key_error(options_registry):
+    """The class can go missing after an uninstall races the settings dialog."""
+    options_registry.loader.create_instance.side_effect = None
+    options_registry.loader.create_instance.return_value = None
+
+    with pytest.raises(KeyError):
+        options_registry.registry.get_plugin_options("stocks", "symbols", OptionsRequest(options_id="symbols"))
+
+
+def test_non_object_ui_options_is_reported_once():
+    """A scalar ``ui:options`` is a schema mistake, not a crash."""
+    schema = {
+        "type": "object",
+        "properties": {"symbols": {"type": "array", "ui:widget": "remote-options", "ui:options": "symbols"}},
+    }
+
+    errors = validate_settings_schema_ui(schema)
+
+    assert any("ui:options must be an object" in e for e in errors), errors
+
+
+def test_validation_recurses_into_nested_object_properties():
+    """Grouped settings nest a plain ``properties`` block, not ``items``."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "advanced": {
+                "type": "object",
+                "properties": {"stop": {"type": "string", "ui:widget": "remote-options"}},
+            }
+        },
+    }
+
+    errors = validate_settings_schema_ui(schema)
+
+    assert any("advanced.stop" in e for e in errors), errors
+
+
+def test_a_non_object_property_is_skipped_rather_than_crashing():
+    """Hand-edited manifests contain surprises; do not raise on them."""
+    schema = {"type": "object", "properties": {"broken": "not-a-schema"}}
+
+    assert validate_settings_schema_ui(schema) == []
+
+
+def test_collect_options_ids_ignores_a_field_with_no_usable_id():
+    """A malformed field is a validation error, not a phantom provider."""
+    schema = {
+        "type": "object",
+        "properties": {"stop": {"type": "string", "ui:widget": "remote-options", "ui:options": {}}},
+    }
+
+    assert collect_options_ids(schema) == set()


### PR DESCRIPTION
## Why

Core hardcodes plugin-specific settings widgets — `disney-parks-times-picker`, `wsdot-route-picker`, `generic-data-mapping-helper` all live in `web/src/components/plugin-settings/schema-form.tsx`. Three more plugins (`stocks`, `muni`, `lyft-bike-share`) declare picker widget names core *never* implemented, so their users hand-type tickers and stop codes into bare string arrays.

Every new picker currently costs a core change. The goal is one generic mechanism: a plugin declares "my options come from live data" in its manifest and ships Python — **zero core changes per new plugin**.

Plugins cannot register API routes (only `auth_router` is included, `src/api_server.py:917`), so core will expose **one** route that dispatches into a standard plugin method.

## What is in this PR

Backend contract only. No `web/` changes.

**`src/plugins/base.py`** — the value types and the hook:

- `Option` (JSON-scalar `value` enforced in `__post_init__`), `OptionsRequest`, `OptionsResult`, `OptionsUnavailable`
- `normalise()` so the common case can just `return [Option(...), ...]`
- `PluginBase.get_options()`, defaulting to `NotImplementedError` — the same shape as the existing `receive_payload` hook. Its docstring spells out that this is **not** `fetch_data` (that returns board content for already-selected items; this browses the full upstream catalog so the user can select something new), that it must be safe when the plugin is disabled or unconfigured, must time out its outbound calls, and must not mutate persisted state.

**`src/plugins/manifest.py`** — `validate_settings_schema_ui()` and `collect_options_ids()`, walking `properties` and `items.properties` recursively and wired into `validate_manifest()`. A field declaring `"ui:widget": "remote-options"` must carry a valid `ui:options.options_id`; unknown `ui:options` keys, `multiple` on a non-array, out-of-range `cache_seconds`, a dangling `depends_on`, and duplicate `options_id`s are all errors.

**`src/plugins/loader.py`** — a manifest that promises options its class does not implement is recorded as a non-fatal load error (surfaced by `GET /plugins/errors`) rather than failing silently the first time a user opens the dialog.

**`src/plugins/registry.py`** — `get_plugin_options()` dispatch.

**`docs/development/PLUGIN_DEVELOPMENT.md`** — the plugin-author guide for the new field and method.

## Backward compatibility

`load_manifest()` returns `None` on *any* validation error, so an over-strict rule here does not warn — it uninstalls plugins in practice. An **unknown `ui:widget` is a warning, never a validation failure**: `stock-symbol-picker`, `muni-stop-picker`, and `lyft-bikeshare-station-picker` are shipped today and must keep loading. Only malformed `ui:options` on a field that *explicitly* declares `remote-options` is a hard error. This follows the existing soft-warning precedent (version constraints in `loader.py`, board previews in `manifest.py`) and has a dedicated regression test.

## Why a throwaway sandbox instance

`get_plugin_options()` never touches the live plugin instance. It builds a fresh one through the existing `loader.create_instance(base_id)` seam and assigns `sandbox._config` **directly**, bypassing the `config` property setter.

That is not defensive tidiness. Assigning to the live instance's `.config` fires `clear_cache()` + `on_config_change()` (`base.py`), and for the Home Assistant plugin `on_config_change` **tears down its running MQTT statestream listener**. Options are fetched while the settings dialog is open — potentially on every keystroke in a search box — so reusing the live instance would repeatedly kill a live subscription. The sandbox is always `cleanup()`-ed in a `finally`.

Also handled: instance keys (`weather:sf` resolves its class from `weather` and its config from `weather:sf`), disabled plugins (config is applied either way — you browse the catalog *in order to* configure the plugin), and transition plugins (`NotImplementedError`).

`draft_config` is accepted but deliberately not applied yet — a TODO for the HTTP-route phase, which needs to unmask the redacted secrets the settings form sends back before merging them.

## Tests

Built test-first, 34 new tests in `tests/test_plugin_options.py`. The load-bearing one is `test_options_use_a_fresh_sandbox_and_never_disturb_the_live_instance` — the HA-MQTT-teardown regression guard. It was written against a naive implementation that reused the live instance and failed with `AssertionError: live instance's on_config_change fired` before the sandbox landed.

Platform tests: 4591 → 4625 passing, 0 failures. `ruff check` and `ruff format --check` clean. Plugin tests 7/7 plugins, 163 tests. `validate_plugins.py` passes. Coverage 88.05% (gate 80%).

## Follow-ups

The HTTP route (`GET /plugins/{id}/options/{options_id}`, including `draft_config` unmasking) and the React `remote-options` widget come in later PRs.