### PR TITLE
feat(plugins): HTTP route for the generic remote-options primitive

### DIFF
--- a/docs/development/PLUGIN_DEVELOPMENT.md
+++ b/docs/development/PLUGIN_DEVELOPMENT.md
@@ -467,6 +467,61 @@ A manifest that declares `remote-options` on a plugin that does not implement
 `get_options()` still loads, but the mismatch is reported by
 `GET /plugins/errors`. An unrecognized `ui:widget` is only a warning.
 
+### The HTTP route
+
+The settings form reaches your `get_options()` through one core route:
+
+```text
+POST /plugins/{plugin_id}/options/{options_id}
+```
+
+It is a POST rather than a GET because `parent` carries arbitrary JSON and
+`draft_config` carries credentials — neither belongs in a URL, an access log,
+or browser history.
+
+Request body, all fields optional:
+
+| Field | Meaning |
+| --- | --- |
+| `parent` | Values of the fields this one `depends_on`. |
+| `query` | Free text the user has typed. |
+| `limit` | Page size. Clamped to 1–1000. |
+| `cursor` | Continuation token from a previous result. |
+| `refresh` | Bypass the cache. Rate-limited to once a second per question. |
+| `draft_config` | Unsaved settings values, layered over the stored config. |
+
+The response always carries the same keys: `plugin_id`, `options_id`,
+`options`, `has_more`, `cursor`, `total`, `error`, `cached`, `stale`,
+`cache_seconds`.
+
+Things core does for you, so your plugin does not have to:
+
+- **Authorization.** Only `options_id`s your own manifest declares can be
+  dispatched; anything else is a 400 and never reaches your code.
+- **Off the event loop.** Your method runs on a worker thread with a 20-second
+  ceiling, at most four at a time. Still set your own HTTP timeouts — a
+  timeout here abandons the *wait*, not your thread.
+- **Caching.** Per `ui:options.cache_seconds` (default 300, `0` disables),
+  keyed by the full instance id and a fingerprint of the effective config, so
+  two differently-credentialed installs never share a list.
+- **Sanitisation.** Options are capped at `min(limit, 1000)`; `label` and
+  `description` at 200 characters, `preview` at 120, `group` at 80; the whole
+  payload at 512KB. An option whose `value` is not a JSON scalar is dropped.
+- **Un-masking.** The browser holds sensitive fields as `"***"`; core swaps in
+  the stored secret before your method sees the draft config.
+
+What each failure means to the user:
+
+| Your plugin | Response |
+| --- | --- |
+| raises `OptionsUnavailable` | 200 with `error` set and `options: []` — shown as an inline hint, because "not configured yet" is the normal mid-setup state |
+| does not implement `get_options` | 501 |
+| raises anything else | 502, or 200 with `stale: true` if a previous answer is cached |
+| takes longer than 20s | 504, or 200 with `stale: true` |
+
+Options work while your plugin is **disabled** — users browse the catalog in
+order to configure it, before they ever turn it on.
+
 ## Plugin Structure
 
 ```text

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -1,6 +1,7 @@
 """REST API server for FiestaBoard Display Service."""
 
 import asyncio
+import hashlib
 import json
 import logging
 import logging.handlers
@@ -35,7 +36,7 @@ from .board_client import board_client_from_board_dict  # noqa: E402
 from .collections.models import CollectionCreate, CollectionUpdate, is_collection_id  # noqa: E402
 from .collections.service import get_collection_service  # noqa: E402
 from .config import Config  # noqa: E402
-from .config_manager import get_config_manager  # noqa: E402
+from .config_manager import get_config_manager, unmask_sensitive_values  # noqa: E402
 from .devices import classify_dimensions, resolve_dimensions  # noqa: E402
 from .displays.service import get_display_service, reset_display_service  # noqa: E402
 from .main import DisplayService  # noqa: E402
@@ -8991,6 +8992,408 @@ async def get_plugin_variables(plugin_id: str):
         "max_lengths": manifest.max_lengths,
         "color_rules_schema": manifest.raw.get("color_rules_schema", {}),
     }
+
+
+# ── Plugin remote options ────────────────────────────────────────────────────
+
+# Hard ceiling on how many options core will hand to the browser, whatever the
+# plugin returns. A picker that renders 50k rows wedges the settings dialog.
+PLUGIN_OPTIONS_MAX_RETURNED = 1000
+PLUGIN_OPTIONS_DEFAULT_CACHE_SECONDS = 300
+
+# Display-string ceilings, enforced by core rather than trusted to the plugin.
+# Different fields get different room because the picker gives them different
+# room. Over-long strings are trimmed, never a reason to drop the choice.
+PLUGIN_OPTIONS_MAX_LABEL_CHARS = 200
+PLUGIN_OPTIONS_MAX_DESCRIPTION_CHARS = 200
+PLUGIN_OPTIONS_MAX_PREVIEW_CHARS = 120
+PLUGIN_OPTIONS_MAX_GROUP_CHARS = 80
+
+# A continuation token is opaque to core, but it still has to fit back into a
+# request, and it is one more thing a plugin can make arbitrarily large.
+PLUGIN_OPTIONS_MAX_CURSOR_CHARS = 512
+
+PLUGIN_OPTIONS_MAX_PAYLOAD_BYTES = 512 * 1024
+
+# Wall-clock budget for one options lookup. Longer than a plugin's own HTTP
+# timeout should be, short enough that a stuck picker gives up while the
+# settings dialog is still open.
+PLUGIN_OPTIONS_TIMEOUT_SECONDS = 20.0
+
+# How many options lookups may occupy worker threads at once. See
+# _bounded_options_call for why this is not just politeness.
+PLUGIN_OPTIONS_MAX_CONCURRENCY = 4
+_PLUGIN_OPTIONS_SEMAPHORE = asyncio.Semaphore(PLUGIN_OPTIONS_MAX_CONCURRENCY)
+
+
+async def _bounded_options_call(work: Any, timeout: float) -> Any:
+    """Run blocking *work* on a worker thread with a hard wall-clock deadline.
+
+    ``asyncio.wait_for`` cancels the *await*, never the thread. A plugin that
+    hangs on a socket keeps its worker forever no matter what we do here, so
+    the semaphore is released from the task's done-callback — when the thread
+    genuinely finishes — rather than when we stop waiting for it.
+
+    That ordering is the whole point. Releasing on timeout would let four hung
+    lookups free their slots, the next four start fresh threads, and so on
+    until the default executor is exhausted and *every* other
+    ``asyncio.to_thread`` caller in the process starves behind a plugin nobody
+    is even waiting on. Holding the slot until the thread returns caps the
+    damage at ``PLUGIN_OPTIONS_MAX_CONCURRENCY`` threads.
+    """
+    await _PLUGIN_OPTIONS_SEMAPHORE.acquire()
+    task = asyncio.ensure_future(asyncio.to_thread(work))
+
+    def _release(finished: Any) -> None:
+        _PLUGIN_OPTIONS_SEMAPHORE.release()
+        if not finished.cancelled():
+            # Retrieve any exception so a lookup that fails after we gave up
+            # does not surface as "exception was never retrieved".
+            finished.exception()
+
+    task.add_done_callback(_release)
+    # shield() so the timeout abandons the wait without cancelling the task —
+    # cancelling it would drop the done-callback's release on the floor.
+    return await asyncio.wait_for(asyncio.shield(task), timeout)
+
+
+class PluginOptionsRequestBody(BaseModel):
+    """Body for ``POST /plugins/{plugin_id}/options/{options_id}``.
+
+    POST rather than GET on purpose: ``parent`` holds arbitrary JSON, and
+    ``draft_config`` carries credentials that must never reach a URL, an
+    access log, or browser history.
+    """
+
+    parent: dict[str, Any] = Field(default_factory=dict)
+    query: str = ""
+    limit: int = 200
+    cursor: str | None = None
+    refresh: bool = False
+    draft_config: dict[str, Any] = Field(default_factory=dict)
+
+
+# Answers are cached per (plugin instance, provider, effective config, query)
+# so that typing in a search box does not hammer an upstream API. Bounded so a
+# long-lived process cannot accumulate one entry per keystroke forever.
+PLUGIN_OPTIONS_CACHE_MAX_ENTRIES = 512
+_PLUGIN_OPTIONS_CACHE: dict[str, tuple[float, dict[str, Any]]] = {}
+_plugin_options_cache_lock = threading.Lock()
+
+
+def _config_fingerprint(config: dict[str, Any]) -> str:
+    """Return a stable digest of an effective plugin config.
+
+    Two installs of the same plugin with different credentials must never read
+    each other's cached options, and the digest keeps the secrets themselves
+    out of the cache key. ``default=str`` because a config may legitimately
+    hold values JSON does not know (e.g. a datetime from a draft form).
+    """
+    blob = json.dumps(config, sort_keys=True, default=str)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def _plugin_options_cache_key(
+    plugin_id: str,
+    options_id: str,
+    config_digest: str,
+    body: "PluginOptionsRequestBody",
+    limit: int,
+) -> str:
+    """Build the cache key for one options question.
+
+    ``plugin_id`` is the *full* key, instance label included: ``weather:home``
+    and ``weather:cabin`` are different installs with different configs and
+    must never share an entry.
+    """
+    blob = json.dumps(
+        {
+            "plugin_id": plugin_id,
+            "options_id": options_id,
+            "config": config_digest,
+            "parent": body.parent,
+            "query": body.query,
+            "limit": limit,
+            "cursor": body.cursor,
+        },
+        sort_keys=True,
+        default=str,
+    )
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+def _plugin_options_cache_get(key: str) -> tuple[float, dict[str, Any]] | None:
+    """Return the ``(stored_at, payload)`` entry for *key*, fresh or not."""
+    with _plugin_options_cache_lock:
+        return _PLUGIN_OPTIONS_CACHE.get(key)
+
+
+def _plugin_options_cache_put(key: str, payload: dict[str, Any]) -> None:
+    """Store *payload* under *key*, evicting the oldest entry when full."""
+    with _plugin_options_cache_lock:
+        if key not in _PLUGIN_OPTIONS_CACHE and len(_PLUGIN_OPTIONS_CACHE) >= PLUGIN_OPTIONS_CACHE_MAX_ENTRIES:
+            oldest = min(_PLUGIN_OPTIONS_CACHE, key=lambda k: _PLUGIN_OPTIONS_CACHE[k][0])
+            _PLUGIN_OPTIONS_CACHE.pop(oldest, None)
+        _PLUGIN_OPTIONS_CACHE[key] = (time.monotonic(), payload)
+
+
+def _stale_options_payload(cache_key: str, reason: str) -> dict[str, Any] | None:
+    """Return the last good answer for *cache_key*, flagged stale, or ``None``.
+
+    Expiry is deliberately ignored here. Once a lookup has failed, an old list
+    plus a visible "this may be out of date" is strictly better for the user
+    than an empty picker — they are usually re-opening a dialog to change one
+    unrelated field.
+    """
+    entry = _plugin_options_cache_get(cache_key)
+    if entry is None:
+        return None
+    return {**entry[1], "cached": True, "stale": True, "error": reason}
+
+
+# A cache-bypassing refresh is the one thing a user can trigger by hand that
+# reaches straight through to somebody else's API. One per second per question
+# is plenty for a Retry button and stops a stuck client from becoming a DoS.
+PLUGIN_OPTIONS_REFRESH_MIN_INTERVAL_SECONDS = 1.0
+_plugin_options_last_refresh: dict[str, float] = {}
+
+
+def _plugin_options_refresh_throttle(cache_key: str) -> None:
+    """Reject a forced refresh that lands too soon after the previous one.
+
+    Keyed per question rather than globally so a slow provider cannot lock out
+    refreshes for every other field in the dialog.
+    """
+    now = time.monotonic()
+    with _plugin_options_cache_lock:
+        previous = _plugin_options_last_refresh.get(cache_key, 0.0)
+        if previous and (now - previous) < PLUGIN_OPTIONS_REFRESH_MIN_INTERVAL_SECONDS:
+            raise HTTPException(
+                status_code=429,
+                detail="Options refresh is rate-limited. Please wait a moment and try again.",
+            )
+        _plugin_options_last_refresh[cache_key] = now
+        # Bounded alongside the cache it shadows.
+        if len(_plugin_options_last_refresh) > PLUGIN_OPTIONS_CACHE_MAX_ENTRIES:
+            oldest = min(_plugin_options_last_refresh, key=_plugin_options_last_refresh.get)  # type: ignore[arg-type]
+            _plugin_options_last_refresh.pop(oldest, None)
+
+
+def _declared_options_ids(manifest: Any) -> set[str]:
+    """Return the ``options_id``s this plugin's own manifest declares."""
+    from .plugins.manifest import collect_options_ids
+
+    if manifest is None:
+        return set()
+    return collect_options_ids(getattr(manifest, "settings_schema", None) or {})
+
+
+def _options_cache_seconds(manifest: Any, options_id: str) -> int:
+    """Return the cache TTL this provider declares, or the platform default."""
+    from .plugins.manifest import options_cache_seconds
+
+    declared = options_cache_seconds(getattr(manifest, "settings_schema", None) or {}, options_id)
+    return PLUGIN_OPTIONS_DEFAULT_CACHE_SECONDS if declared is None else declared
+
+
+def _truncate(text: Any, ceiling: int) -> str | None:
+    """Clip a plugin-supplied display string to *ceiling* characters."""
+    if text is None:
+        return None
+    return (text if isinstance(text, str) else str(text))[:ceiling]
+
+
+def _serialise_option(option: Any, plugin_id: str, options_id: str) -> dict[str, Any] | None:
+    """Render one plugin-supplied option, or ``None`` if it must be dropped.
+
+    Truncation rather than rejection for the display strings: a 10KB label
+    breaks the layout, but discarding the option would lose a choice the user
+    needs. ``value`` is the exception — it is written verbatim into
+    config.json, so a non-scalar there becomes an un-comparable blob that only
+    fails much later, somewhere unrelated.
+    """
+    value = getattr(option, "value", None)
+    if not isinstance(value, str | int | float | bool):
+        logger.warning(
+            "Plugin '%s' options provider '%s' returned an option with a non-scalar value (%s); dropping it",
+            plugin_id,
+            options_id,
+            type(value).__name__,
+        )
+        return None
+
+    return {
+        "value": value,
+        "label": _truncate(getattr(option, "label", None), PLUGIN_OPTIONS_MAX_LABEL_CHARS),
+        "description": _truncate(getattr(option, "description", None), PLUGIN_OPTIONS_MAX_DESCRIPTION_CHARS),
+        "group": _truncate(getattr(option, "group", None), PLUGIN_OPTIONS_MAX_GROUP_CHARS),
+        "preview": _truncate(getattr(option, "preview", None), PLUGIN_OPTIONS_MAX_PREVIEW_CHARS),
+        "disabled": bool(getattr(option, "disabled", False)),
+        "meta": getattr(option, "meta", None),
+    }
+
+
+def _serialise_options(options: Any, limit: int, plugin_id: str, options_id: str) -> tuple[list[dict[str, Any]], bool]:
+    """Return ``(sanitised_options, truncated)`` for one provider's answer."""
+    kept: list[dict[str, Any]] = []
+    truncated = False
+    for option in options or []:
+        if len(kept) >= limit:
+            truncated = True
+            break
+        rendered = _serialise_option(option, plugin_id, options_id)
+        if rendered is not None:
+            kept.append(rendered)
+    return kept, truncated
+
+
+def _fit_options_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Trim *payload* in place until it fits the response byte budget.
+
+    A count ceiling is not a size ceiling: 1000 options each carrying a full
+    label, description, preview and group is most of a megabyte, and the
+    typical FiestaBoard talks to a Raspberry Pi over a home LAN.
+
+    Measured with ``json.dumps`` defaults, which are looser than the compact
+    separators FastAPI actually serialises with — so the real response is
+    always a little under whatever this accepts.
+    """
+    encoded = len(json.dumps(payload, default=str).encode("utf-8"))
+    while encoded > PLUGIN_OPTIONS_MAX_PAYLOAD_BYTES and payload["options"]:
+        # Drop proportionally to the overshoot so this converges in a couple
+        # of passes instead of one option at a time.
+        per_option = max(1, encoded // len(payload["options"]))
+        drop = max(1, min(len(payload["options"]), (encoded - PLUGIN_OPTIONS_MAX_PAYLOAD_BYTES) // per_option + 1))
+        del payload["options"][-drop:]
+        payload["has_more"] = True
+        encoded = len(json.dumps(payload, default=str).encode("utf-8"))
+    return payload
+
+
+@app.post("/plugins/{plugin_id}/options/{options_id}")
+async def get_plugin_options_endpoint(plugin_id: str, options_id: str, body: PluginOptionsRequestBody):
+    """Browse a plugin's upstream catalog to populate one settings field."""
+    from .plugins.base import OptionsRequest, OptionsUnavailable
+
+    if not PLUGIN_SYSTEM_AVAILABLE:
+        raise HTTPException(status_code=503, detail="Plugin system is not available.")
+
+    registry = get_plugin_registry()
+
+    if registry.get_plugin(plugin_id) is None:
+        raise HTTPException(status_code=404, detail=f"Plugin not found: {plugin_id}")
+
+    manifest = registry.get_manifest(plugin_id)
+    if options_id not in _declared_options_ids(manifest):
+        raise HTTPException(
+            status_code=400,
+            detail=f"Plugin '{plugin_id}' does not declare options provider '{options_id}'",
+        )
+
+    limit = max(1, min(body.limit, PLUGIN_OPTIONS_MAX_RETURNED))
+    request = OptionsRequest(
+        options_id=options_id,
+        parent=body.parent,
+        query=body.query,
+        limit=limit,
+        cursor=body.cursor,
+    )
+
+    cache_seconds = _options_cache_seconds(manifest, options_id)
+
+    def _envelope(**overrides: Any) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "plugin_id": plugin_id,
+            "options_id": options_id,
+            "options": [],
+            "has_more": False,
+            "cursor": None,
+            "total": None,
+            "error": None,
+            "cached": False,
+            "stale": False,
+            "cache_seconds": cache_seconds,
+        }
+        payload.update(overrides)
+        return payload
+
+    stored_config = dict(registry.get_plugin_config(plugin_id) or {})
+    # The form posts back "***" wherever a sensitive field used to be, so the
+    # draft has to be un-masked against what is stored or the plugin gets three
+    # asterisks as its API key and every lookup fails mid-setup.
+    draft_config = unmask_sensitive_values(body.draft_config, stored_config) if body.draft_config else None
+    if draft_config:
+        # Key names only, never values: a settings dialog is exactly where
+        # credentials leak into logs.
+        logger.debug(
+            "Options request for '%s/%s' carries draft config keys: %s",
+            plugin_id,
+            options_id,
+            sorted(draft_config),
+        )
+
+    effective_config = {**stored_config, **(draft_config or {})}
+    cache_key = _plugin_options_cache_key(plugin_id, options_id, _config_fingerprint(effective_config), body, limit)
+
+    if body.refresh:
+        _plugin_options_refresh_throttle(cache_key)
+    elif cache_seconds > 0:
+        entry = _plugin_options_cache_get(cache_key)
+        if entry is not None and (time.monotonic() - entry[0]) < cache_seconds:
+            return {**entry[1], "cached": True, "stale": False}
+
+    try:
+        # Never call the plugin inline: get_options() makes network calls, and
+        # blocking the event loop here would stall every other request in the
+        # process. (GET /plugins/{id}/data still does this; do not copy it.)
+        result = await _bounded_options_call(
+            lambda: registry.get_plugin_options(plugin_id, options_id, request, draft_config=draft_config),
+            PLUGIN_OPTIONS_TIMEOUT_SECONDS,
+        )
+    except TimeoutError as e:
+        logger.warning("Options provider '%s' timed out for plugin '%s'", options_id, plugin_id)
+        stale = _stale_options_payload(cache_key, reason=f"Options provider '{options_id}' timed out")
+        if stale is not None:
+            return stale
+        raise HTTPException(
+            status_code=504,
+            detail=f"Options provider '{options_id}' timed out",
+        ) from e
+    except NotImplementedError as e:
+        # The manifest promised a provider the class never implemented, or the
+        # plugin is a transition. 501 lets the widget degrade to a plain input.
+        raise HTTPException(status_code=501, detail=str(e)) from e
+    except KeyError as e:
+        # The registry could not build a sandbox: the plugin was uninstalled
+        # while its settings dialog was open. Still "no such plugin".
+        raise HTTPException(status_code=404, detail=f"Plugin not found: {plugin_id}") from e
+    except OptionsUnavailable as e:
+        # Deliberately a 200. "No API key yet" is the *expected* state while
+        # the user is still filling the form in; the widget shows the reason
+        # inline next to the field instead of a failed-request toast.
+        return _envelope(error=str(e))
+    except Exception as e:
+        logger.exception("Options provider '%s' failed for plugin '%s'", options_id, plugin_id)
+        stale = _stale_options_payload(cache_key, reason=f"Options provider failed: {e}")
+        if stale is not None:
+            return stale
+        raise HTTPException(status_code=502, detail=f"Options provider failed: {e}") from e
+
+    options, truncated = _serialise_options(result.options, limit, plugin_id, options_id)
+    payload = _fit_options_payload(
+        _envelope(
+            options=options,
+            has_more=bool(result.has_more) or truncated,
+            cursor=_truncate(result.cursor, PLUGIN_OPTIONS_MAX_CURSOR_CHARS),
+            total=result.total,
+            error=result.error,
+        )
+    )
+
+    if cache_seconds > 0:
+        _plugin_options_cache_put(cache_key, payload)
+
+    return payload
 
 
 # ── Plugin Demo Pages ────────────────────────────────────────────────────────

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -306,6 +306,39 @@ SENSITIVE_FIELDS = {
     "client_secret",
 }
 
+# What the API substitutes for a sensitive value on the way out. Anything that
+# comes back from a settings form carries this rather than the real secret.
+MASKED_VALUE = "***"
+
+
+def unmask_sensitive_values(values: dict[str, Any], stored: dict[str, Any]) -> dict[str, Any]:
+    """Return *values* with every masked sensitive field restored from *stored*.
+
+    The browser never holds a real secret: :meth:`ConfigManager._mask_sensitive`
+    replaces every :data:`SENSITIVE_FIELDS` entry with :data:`MASKED_VALUE`
+    before the config leaves the process. Anything the form posts back
+    therefore says ``"***"`` where the API key used to be, and writing that
+    through — or handing it to a plugin — replaces a working credential with
+    three asterisks.
+
+    A masked key with nothing stored resolves to ``""`` rather than being
+    dropped, matching the persisted-config behaviour this was extracted from:
+    the field was explicitly submitted, so it should end up present and empty
+    rather than silently absent.
+
+    Args:
+        values: Incoming settings, possibly carrying masked placeholders.
+        stored: The currently persisted settings to restore secrets from.
+
+    Returns:
+        A new dict; *values* is not mutated.
+    """
+    merged = dict(values)
+    for key, value in values.items():
+        if key in SENSITIVE_FIELDS and value == MASKED_VALUE:
+            merged[key] = stored.get(key, "")
+    return merged
+
 
 class ConfigManager:
     """Manages configuration file read/write operations."""
@@ -1380,10 +1413,7 @@ class ConfigManager:
 
             # Preserve sensitive fields if they're masked
             existing = self._config["plugins"].get(plugin_id, {})
-            for key, value in config.items():
-                if key in SENSITIVE_FIELDS and value == "***":
-                    # Keep existing value
-                    config[key] = existing.get(key, "")
+            config.update(unmask_sensitive_values(config, existing))
 
             self._config["plugins"][plugin_id] = config
             self._save_internal()

--- a/src/plugins/manifest.py
+++ b/src/plugins/manifest.py
@@ -740,6 +740,36 @@ def collect_options_ids(settings_schema: dict[str, Any]) -> set[str]:
     return ids
 
 
+def options_cache_seconds(settings_schema: dict[str, Any], options_id: str) -> int | None:
+    """Return the ``ui:options.cache_seconds`` declared for *options_id*.
+
+    ``None`` means the field did not declare one and the caller's default
+    applies; ``0`` is a deliberate "never cache this". The TTL lives per
+    provider because only the plugin author knows whether the catalog is a
+    departure board that goes stale in seconds or a list of airports that does
+    not change this decade.
+
+    Args:
+        settings_schema: The plugin's ``settings_schema`` object.
+        options_id: The provider being asked about.
+
+    Returns:
+        The declared TTL in seconds, or ``None`` when unspecified.
+    """
+    for _path, prop, _siblings in _iter_settings_fields(settings_schema):
+        if prop.get("ui:widget") != REMOTE_OPTIONS_WIDGET:
+            continue
+        ui_options = prop.get("ui:options")
+        if not isinstance(ui_options, dict) or ui_options.get("options_id") != options_id:
+            continue
+        seconds = ui_options.get("cache_seconds")
+        # bool is an int subclass; a `true` here is a schema bug, not a TTL.
+        if isinstance(seconds, int) and not isinstance(seconds, bool):
+            return seconds
+        return None
+    return None
+
+
 def validate_settings_schema_ui(settings_schema: dict[str, Any]) -> list[str]:
     """Validate the ``ui:*`` annotations in a plugin's ``settings_schema``.
 

--- a/src/plugins/registry.py
+++ b/src/plugins/registry.py
@@ -839,8 +839,9 @@ class PluginRegistry:
             options_id: Which catalog to browse (from ``ui:options.options_id``).
             request: Query/paging context. Its ``options_id`` is overridden by
                 the *options_id* argument so the caller's route wins.
-            draft_config: Unsaved settings-form values. Not yet applied — see
-                the TODO below.
+            draft_config: Unsaved settings-form values, layered over the stored
+                config. Sensitive fields must already be un-masked by the
+                caller; see ``unmask_sensitive_values``.
 
         Returns:
             An :class:`OptionsResult`.
@@ -863,11 +864,13 @@ class PluginRegistry:
 
         # Config comes from the full instance key, the class from the base id.
         effective_config = dict(self._configs.get(plugin_id) or {})
-        # TODO(#options-route): merge *draft_config* over effective_config once
-        # the HTTP layer can unmask the redacted secrets the form sends back.
-        # Applying it verbatim today would overwrite a real API key with the
-        # placeholder the UI displays.
-        _ = draft_config
+        # Unsaved form values win: the user is browsing the catalog *in order
+        # to* fill the form in, so the credentials they just typed are the ones
+        # that matter. The HTTP layer un-masks the redacted secrets the form
+        # sends back before they get here — applying a raw draft would
+        # overwrite a real API key with the "***" placeholder the UI displays.
+        if draft_config:
+            effective_config.update(draft_config)
 
         sandbox = self._loader.create_instance(base_id)
         if sandbox is None:

--- a/tests/test_plugin_options.py
+++ b/tests/test_plugin_options.py
@@ -651,3 +651,29 @@ def test_collect_options_ids_ignores_a_field_with_no_usable_id():
     }
 
     assert collect_options_ids(schema) == set()
+
+
+def test_draft_config_is_layered_over_the_stored_config(options_registry):
+    """The picker has to work *before* Save — that is the whole point of a
+    settings dialog. Unsaved form values win over what is on disk, and keys the
+    form did not touch keep their stored values."""
+    options_registry.registry._configs["stocks"] = {"api_key": "stored_key", "account": "STORED"}
+
+    options_registry.registry.get_plugin_options(
+        "stocks",
+        "symbols",
+        OptionsRequest(options_id="symbols"),
+        draft_config={"account": "DRAFT"},
+    )
+
+    (sandbox,) = options_registry.sandboxes
+    assert sandbox.config == {"api_key": "stored_key", "account": "DRAFT"}
+
+
+def test_no_draft_config_leaves_the_stored_config_alone(options_registry):
+    """Opening a dialog without editing anything must not change what the
+    sandbox sees."""
+    options_registry.registry.get_plugin_options("stocks", "symbols", OptionsRequest(options_id="symbols"))
+
+    (sandbox,) = options_registry.sandboxes
+    assert sandbox.config == {"api_key": "test_key"}

--- a/tests/test_plugin_options_route.py
+++ b/tests/test_plugin_options_route.py
@@ -1,0 +1,695 @@
+"""Tests for ``POST /plugins/{plugin_id}/options/{options_id}``.
+
+The HTTP half of the generic plugin options primitive: authorization against
+the manifest, off-loop dispatch, caching, and core-enforced sanitisation of
+whatever the plugin hands back.
+"""
+
+import asyncio
+import logging
+import threading
+import time
+from types import SimpleNamespace
+from typing import Any
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from src.api_server import app
+from src.plugins.base import Option, OptionsRequest, OptionsResult, OptionsUnavailable
+
+OPTIONS_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "symbols": {
+            "type": "array",
+            "ui:widget": "remote-options",
+            "ui:options": {"options_id": "symbols"},
+        },
+    },
+}
+
+
+class _FakeManifest:
+    """Just enough manifest for the route to read declared options ids."""
+
+    def __init__(self, settings_schema: dict[str, Any]):
+        self.settings_schema = settings_schema
+
+
+class _FakeRegistry:
+    """A registry stand-in that records every options dispatch."""
+
+    def __init__(self) -> None:
+        self.plugins: dict[str, object] = {"stocks": object()}
+        self.manifests: dict[str, _FakeManifest] = {"stocks": _FakeManifest(OPTIONS_SCHEMA)}
+        self.configs: dict[str, dict[str, Any]] = {"stocks": {"api_key": "real-key"}}
+        self.calls: list[tuple[str, str, OptionsRequest, dict[str, Any] | None]] = []
+        self.result: Any = OptionsResult(options=[Option(value="AAPL", label="Apple")])
+        self.enabled: dict[str, bool] = {"stocks": True}
+
+    # -- registry surface the route uses -------------------------------
+    def get_plugin(self, plugin_id: str) -> object | None:
+        return self.plugins.get(plugin_id)
+
+    def get_manifest(self, plugin_id: str) -> _FakeManifest | None:
+        return self.manifests.get(plugin_id)
+
+    def get_plugin_config(self, plugin_id: str) -> dict[str, Any] | None:
+        return self.configs.get(plugin_id)
+
+    def is_enabled(self, plugin_id: str) -> bool:
+        return self.enabled.get(plugin_id, False)
+
+    def get_plugin_options(
+        self,
+        plugin_id: str,
+        options_id: str,
+        request: OptionsRequest,
+        draft_config: dict[str, Any] | None = None,
+    ) -> Any:
+        self.calls.append((plugin_id, options_id, request, draft_config))
+        if callable(self.result):
+            return self.result(plugin_id, options_id, request, draft_config)
+        return self.result
+
+
+@pytest.fixture
+def registry(monkeypatch):
+    """Install a fake plugin registry and reset the route's module state."""
+    from src import api_server
+
+    fake = _FakeRegistry()
+    monkeypatch.setattr(api_server, "PLUGIN_SYSTEM_AVAILABLE", True)
+    monkeypatch.setattr(api_server, "get_plugin_registry", lambda: fake)
+    # Both caches are process-global; give every test its own.
+    monkeypatch.setattr(api_server, "_PLUGIN_OPTIONS_CACHE", {})
+    monkeypatch.setattr(api_server, "_plugin_options_last_refresh", {})
+    return fake
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def _post(client: TestClient, plugin_id: str = "stocks", options_id: str = "symbols", **body: Any):
+    return client.post(f"/plugins/{plugin_id}/options/{options_id}", json=body)
+
+
+def test_an_options_id_the_manifest_never_declared_is_rejected(registry, client):
+    """Without this the route is an arbitrary-string channel into plugin code."""
+    response = _post(client, options_id="not_declared")
+
+    assert response.status_code == 400
+    assert registry.calls == [], "the plugin must not be dispatched at all"
+
+
+def test_unknown_plugin_is_a_404(registry, client):
+    """A missing plugin is not the same failure as a bad provider name."""
+    response = _post(client, plugin_id="nope")
+
+    assert response.status_code == 404
+
+
+def test_plugin_system_unavailable_is_a_503(registry, client, monkeypatch):
+    """No plugin system at all is an infrastructure problem, not a bad request."""
+    from src import api_server
+
+    monkeypatch.setattr(api_server, "PLUGIN_SYSTEM_AVAILABLE", False)
+
+    response = _post(client)
+
+    assert response.status_code == 503
+
+
+def test_a_successful_lookup_returns_the_documented_envelope(registry, client):
+    """The widget reads a fixed set of keys; all of them are always present."""
+    registry.result = OptionsResult(
+        options=[Option(value="AAPL", label="Apple", description="Apple Inc.", group="Tech", preview="AAPL 190")],
+        has_more=True,
+        cursor="page-2",
+        total=42,
+    )
+
+    response = _post(client, query="app", limit=25, parent={"exchange": "NASDAQ"})
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "plugin_id": "stocks",
+        "options_id": "symbols",
+        "options": [
+            {
+                "value": "AAPL",
+                "label": "Apple",
+                "description": "Apple Inc.",
+                "group": "Tech",
+                "preview": "AAPL 190",
+                "disabled": False,
+                "meta": None,
+            }
+        ],
+        "has_more": True,
+        "cursor": "page-2",
+        "total": 42,
+        "error": None,
+        "cached": False,
+        "stale": False,
+        "cache_seconds": 300,
+    }
+
+
+def test_the_request_body_reaches_the_plugin_as_an_options_request(registry, client):
+    """``parent``/``query``/``limit``/``cursor`` are the plugin's search inputs."""
+    _post(client, query="app", limit=25, parent={"exchange": "NASDAQ"}, cursor="page-1")
+
+    (plugin_id, options_id, request, _draft) = registry.calls[0]
+    assert plugin_id == "stocks"
+    assert options_id == "symbols"
+    assert isinstance(request, OptionsRequest)
+    assert request.options_id == "symbols"
+    assert request.parent == {"exchange": "NASDAQ"}
+    assert request.query == "app"
+    assert request.limit == 25
+    assert request.cursor == "page-1"
+
+
+def _raises(exc: BaseException):
+    """Build a fake-registry behaviour that always raises *exc*."""
+
+    def _behaviour(*_args: Any, **_kwargs: Any):
+        raise exc
+
+    return _behaviour
+
+
+def test_a_plugin_that_does_not_implement_get_options_is_a_501(registry, client):
+    """501 Not Implemented is the semantically correct answer, and it lets the
+    widget fall back to a plain input instead of showing an error."""
+    registry.result = _raises(NotImplementedError("Plugin stocks does not provide options"))
+
+    response = _post(client)
+
+    assert response.status_code == 501
+
+
+def test_options_unavailable_is_a_200_carrying_the_reason(registry, client):
+    """A not-configured-yet plugin is the expected mid-setup state. The widget
+    needs an inline hint next to the field, not a red toast on a 5xx."""
+    registry.result = _raises(OptionsUnavailable("Add an API key first"))
+
+    response = _post(client)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["error"] == "Add an API key first"
+    assert payload["options"] == []
+
+
+def test_an_unexpected_plugin_exception_is_a_502(registry, client):
+    """A genuine bug in the plugin is an upstream failure, not a 500 on core."""
+    registry.result = _raises(RuntimeError("boom"))
+
+    response = _post(client)
+
+    assert response.status_code == 502
+
+
+def _blocking_provider(release: threading.Event, seconds: float = 1.0):
+    """A plugin behaviour that hangs until *release* is set (or *seconds* pass).
+
+    The wall-clock cap is what keeps the suite bounded: the worker thread
+    survives the route's timeout by design, and ``TestClient`` tears its
+    portal down only once that thread has finished.
+    """
+
+    def _behaviour(*_args: Any, **_kwargs: Any):
+        release.wait(seconds)
+        return OptionsResult(options=[Option(value="late", label="Late")])
+
+    return _behaviour
+
+
+def test_a_plugin_that_hangs_gets_cut_off_with_a_504(registry, client, monkeypatch):
+    """A settings dialog cannot wait on an unbounded upstream call."""
+    from src import api_server
+
+    monkeypatch.setattr(api_server, "PLUGIN_OPTIONS_TIMEOUT_SECONDS", 0.2)
+    release = threading.Event()
+    registry.result = _blocking_provider(release)
+
+    try:
+        response = _post(client)
+    finally:
+        release.set()
+
+    assert response.status_code == 504
+
+
+@pytest.mark.asyncio
+async def test_a_slow_plugin_does_not_block_the_event_loop(registry, monkeypatch):
+    """The load-bearing test for requirement 2.
+
+    ``GET /plugins/{id}/data`` calls ``fetch_plugin_data`` inline inside an
+    ``async def``, so one slow plugin stalls the whole process. Options are
+    fetched on every keystroke in a settings search box, which would make that
+    bug continuous rather than occasional. Assert directly on the symptom: a
+    cheap endpoint must answer *while* a slow options lookup is in flight.
+    """
+    from src import api_server
+
+    monkeypatch.setattr(api_server, "PLUGIN_OPTIONS_TIMEOUT_SECONDS", 2.0)
+    release = threading.Event()
+    registry.result = _blocking_provider(release, seconds=2.0)
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as ac:
+        # The stopwatch has to start *before* the yield that lets the options
+        # request reach its handler. A blocking handler seizes the loop during
+        # that yield, so timing only the /health await would measure the world
+        # after the block had already finished — and pass either way.
+        started = time.monotonic()
+        in_flight = asyncio.create_task(ac.post("/plugins/stocks/options/symbols", json={}))
+        await asyncio.sleep(0.05)
+
+        health = await ac.get("/health")
+        waited = time.monotonic() - started
+        still_running = not in_flight.done()
+
+        release.set()
+        await in_flight
+
+    assert health.status_code == 200
+    assert waited < 0.5, f"/health waited {waited:.2f}s behind the options call — the event loop was blocked"
+    assert still_running, "the options call finished too early to prove anything"
+
+
+def test_a_second_identical_call_inside_the_ttl_skips_the_plugin(registry, client):
+    """A picker refetches on every keystroke; the upstream must not."""
+    first = _post(client, query="app")
+    second = _post(client, query="app")
+
+    assert len(registry.calls) == 1, "the plugin was invoked twice for the same question"
+    assert first.json()["cached"] is False
+    assert second.json()["cached"] is True
+    assert second.json()["options"] == first.json()["options"]
+
+
+def _echo_plugin_id(plugin_id: str, _options_id: str, _request: OptionsRequest, _draft: Any) -> OptionsResult:
+    """A behaviour whose answer identifies which install asked."""
+    return OptionsResult(options=[Option(value=plugin_id, label=plugin_id)])
+
+
+def test_two_instances_of_one_plugin_do_not_share_a_cache_entry(registry, client):
+    """``stocks:growth`` and ``stocks:income`` are separate installs and must
+    never be served each other's catalog.
+
+    Both are given the *same* config on purpose: the config fingerprint would
+    otherwise separate them on its own, and the point here is that the full
+    instance key — not just the base plugin id — is part of the cache key.
+    """
+    for key in ("stocks:growth", "stocks:income"):
+        registry.plugins[key] = object()
+        registry.manifests[key] = _FakeManifest(OPTIONS_SCHEMA)
+        registry.configs[key] = {"api_key": "shared-key"}
+    registry.result = _echo_plugin_id
+
+    growth = _post(client, plugin_id="stocks:growth")
+    income = _post(client, plugin_id="stocks:income")
+
+    assert len(registry.calls) == 2, "the second instance was served from the first instance's cache"
+    assert growth.json()["options"][0]["value"] == "stocks:growth"
+    assert income.json()["options"][0]["value"] == "stocks:income"
+
+
+def test_a_config_change_invalidates_the_cache(registry, client):
+    """The cache key fingerprints the effective config, so re-keying a plugin
+    cannot serve the answers the old credentials produced."""
+    _post(client)
+    registry.configs["stocks"] = {"api_key": "a-different-key"}
+    _post(client)
+
+    assert len(registry.calls) == 2
+
+
+def test_refresh_bypasses_the_cache(registry, client):
+    """The widget's Retry button has to actually reach the upstream."""
+    _post(client)
+    response = _post(client, refresh=True)
+
+    assert len(registry.calls) == 2
+    assert response.json()["cached"] is False
+
+
+def test_hammering_refresh_is_throttled(registry, client):
+    """Retry bypasses the cache by design, so it is the one lever a stuck
+    client can pull to hammer somebody else's API."""
+    _post(client, refresh=True)
+    second = _post(client, refresh=True)
+
+    assert second.status_code == 429
+    assert len(registry.calls) == 1
+
+
+def test_the_refresh_throttle_is_per_question_not_global(registry, client):
+    """One slow provider must not lock out Retry for every other field."""
+    _post(client, refresh=True)
+    other = _post(client, refresh=True, query="different")
+
+    assert other.status_code == 200
+
+
+def test_a_failing_refresh_falls_back_to_the_last_good_answer(registry, client):
+    """A transient upstream failure should not empty a picker the user is
+    already looking at — show yesterday's list and say that it is stale."""
+    good = _post(client)
+    registry.result = _raises(RuntimeError("upstream down"))
+
+    response = _post(client, refresh=True)
+
+    assert response.status_code == 200
+    assert response.json()["stale"] is True
+    assert response.json()["options"] == good.json()["options"]
+
+
+def test_a_timeout_after_a_good_answer_also_serves_stale(registry, client, monkeypatch):
+    """Same reasoning as a failing refresh: a hung upstream is not a reason to
+    throw away a list we already have."""
+    from src import api_server
+
+    good = _post(client)
+    monkeypatch.setattr(api_server, "PLUGIN_OPTIONS_TIMEOUT_SECONDS", 0.2)
+    release = threading.Event()
+    registry.result = _blocking_provider(release)
+
+    try:
+        response = _post(client, refresh=True)
+    finally:
+        release.set()
+
+    assert response.status_code == 200
+    assert response.json()["stale"] is True
+    assert response.json()["options"] == good.json()["options"]
+
+
+def _schema_with_cache_seconds(seconds: int) -> dict[str, Any]:
+    """The standard options schema with an explicit per-provider TTL."""
+    return {
+        "type": "object",
+        "properties": {
+            "symbols": {
+                "type": "array",
+                "ui:widget": "remote-options",
+                "ui:options": {"options_id": "symbols", "cache_seconds": seconds},
+            },
+        },
+    }
+
+
+def test_the_ttl_comes_from_the_providers_own_manifest_entry(registry, client):
+    """A departure board goes stale in seconds; a list of airports does not.
+    Only the plugin author knows which one this is."""
+    registry.manifests["stocks"] = _FakeManifest(_schema_with_cache_seconds(60))
+
+    response = _post(client)
+
+    assert response.json()["cache_seconds"] == 60
+
+
+def test_a_zero_ttl_disables_caching_entirely(registry, client):
+    """``cache_seconds: 0`` is how a plugin says "always ask me"."""
+    registry.manifests["stocks"] = _FakeManifest(_schema_with_cache_seconds(0))
+
+    first = _post(client)
+    second = _post(client)
+
+    assert len(registry.calls) == 2
+    assert first.json()["cache_seconds"] == 0
+    assert second.json()["cached"] is False
+
+
+def test_a_runaway_option_list_is_capped_with_has_more(registry, client):
+    """Core enforces the ceiling so a buggy plugin cannot wedge the browser.
+
+    The client asks for more than the ceiling to prove the ceiling is core's,
+    not just the default page size doing the work.
+    """
+    registry.result = OptionsResult(options=[Option(value=i, label=f"Row {i}") for i in range(5000)])
+
+    payload = _post(client, limit=5000).json()
+
+    assert len(payload["options"]) == 1000
+    assert payload["has_more"] is True
+
+
+def test_the_requested_limit_is_honoured_below_the_ceiling(registry, client):
+    """A picker that asked for 5 rows should not be handed 200."""
+    registry.result = OptionsResult(options=[Option(value=i, label=f"Row {i}") for i in range(50)])
+
+    payload = _post(client, limit=5).json()
+
+    assert len(payload["options"]) == 5
+    assert payload["has_more"] is True
+
+
+def test_an_absurd_limit_is_clamped_rather_than_rejected(registry, client):
+    """The clamp is on the way in, so the plugin never sees a silly number."""
+    _post(client, limit=999_999)
+    _post(client, limit=-4, query="second")
+
+    assert registry.calls[0][2].limit == 1000
+    assert registry.calls[1][2].limit == 1
+
+
+def test_an_oversized_label_is_truncated_not_rejected(registry, client):
+    """Dropping the option would lose data the user needs; a long label just
+    breaks the layout, so trim it and keep the choice."""
+    registry.result = OptionsResult(options=[Option(value="x", label="L" * 10_000)])
+
+    option = _post(client).json()["options"][0]
+
+    assert len(option["label"]) == 200
+    assert option["value"] == "x"
+
+
+def test_every_display_field_has_its_own_ceiling(registry, client):
+    """Each field has a different amount of room in the picker."""
+    registry.result = OptionsResult(
+        options=[
+            Option(
+                value="x",
+                label="L" * 500,
+                description="D" * 500,
+                preview="P" * 500,
+                group="G" * 500,
+            )
+        ]
+    )
+
+    option = _post(client).json()["options"][0]
+
+    assert (len(option["label"]), len(option["description"])) == (200, 200)
+    assert (len(option["preview"]), len(option["group"])) == (120, 80)
+
+
+def test_an_option_whose_value_is_not_a_json_scalar_is_dropped(registry, client):
+    """``value`` is written verbatim into config.json. A dict there becomes an
+    un-comparable blob that only fails much later, so refuse it at the door."""
+    registry.result = OptionsResult(
+        options=[
+            SimpleNamespace(
+                value={"nested": "object"},
+                label="Bad",
+                description=None,
+                group=None,
+                preview=None,
+                disabled=False,
+                meta=None,
+            ),
+            Option(value="good", label="Good"),
+        ]
+    )
+
+    payload = _post(client).json()
+
+    assert [o["value"] for o in payload["options"]] == ["good"]
+
+
+def test_an_oversized_cursor_is_truncated(registry, client):
+    """A continuation token is opaque, but it still has to fit in a request."""
+    registry.result = OptionsResult(options=[], cursor="c" * 4000)
+
+    assert len(_post(client).json()["cursor"]) == 512
+
+
+def test_a_payload_over_the_byte_budget_is_trimmed(registry, client):
+    """1000 options is a count ceiling, not a size one — 1000 fat options is
+    still megabytes down a LAN connection to a Raspberry Pi."""
+    registry.result = OptionsResult(
+        options=[
+            Option(value=i, label="L" * 200, description="D" * 200, preview="P" * 120, group="G" * 80)
+            for i in range(1000)
+        ]
+    )
+
+    # Ask for the full 1000 so the count ceiling cannot do the trimming for us.
+    response = _post(client, limit=1000)
+    payload = response.json()
+
+    assert len(response.content) <= 512 * 1024
+    assert len(payload["options"]) < 1000
+    assert payload["has_more"] is True
+
+
+def test_a_masked_secret_in_draft_config_is_replaced_with_the_stored_one(registry, client):
+    """The settings form only ever holds ``"***"`` for a sensitive field, so
+    forwarding the draft verbatim would hand the plugin a literal ``"***"`` as
+    its API key and every lookup would fail while the user was mid-setup."""
+    _post(client, draft_config={"api_key": "***", "exchange": "NASDAQ"})
+
+    (_plugin_id, _options_id, _request, draft) = registry.calls[0]
+    assert draft == {"api_key": "real-key", "exchange": "NASDAQ"}
+
+
+def test_an_unmasked_secret_in_draft_config_is_passed_through(registry, client):
+    """A key the user has just typed is the whole point of a draft config —
+    the picker has to work before Save."""
+    _post(client, draft_config={"api_key": "freshly-typed-key"})
+
+    assert registry.calls[0][3] == {"api_key": "freshly-typed-key"}
+
+
+def test_draft_config_values_are_never_logged(registry, client, caplog):
+    """Debug logging around a settings dialog is exactly where credentials
+    leak. Key names are useful; values are not worth the risk."""
+    with caplog.at_level(logging.DEBUG, logger="src.api_server"):
+        _post(client, draft_config={"api_key": "s3cr3t-do-not-log", "exchange": "NASDAQ"})
+
+    assert "s3cr3t-do-not-log" not in caplog.text
+
+
+def test_a_draft_config_changes_the_cache_key(registry, client):
+    """Two different unsaved credentials must not read each other's answers."""
+    _post(client, draft_config={"api_key": "first"})
+    _post(client, draft_config={"api_key": "second"})
+
+    assert len(registry.calls) == 2
+
+
+def test_options_work_while_the_plugin_is_still_disabled(registry, client):
+    """You browse the catalog *in order to* configure the plugin, and nobody
+    enables a plugin before they have picked what it should show. Gating this
+    on ``is_enabled`` — as ``GET /plugins/{id}/data`` does — would make the
+    picker useless exactly when it is needed."""
+    registry.enabled = {"stocks": False}
+
+    response = _post(client)
+
+    assert response.status_code == 200
+    assert response.json()["options"] != []
+
+
+@pytest.mark.asyncio
+async def test_concurrent_lookups_cannot_exhaust_the_thread_pool(registry, monkeypatch):
+    """``asyncio.to_thread`` shares one bounded default executor with the rest
+    of the process. Without a cap, a plugin that is merely slow would let a
+    settings dialog starve every other background call."""
+    from src import api_server
+
+    monkeypatch.setattr(api_server, "_PLUGIN_OPTIONS_SEMAPHORE", asyncio.Semaphore(2))
+    monkeypatch.setattr(api_server, "PLUGIN_OPTIONS_TIMEOUT_SECONDS", 10.0)
+
+    counter_lock = threading.Lock()
+    state = {"in_flight": 0, "peak": 0}
+
+    def _behaviour(*_args: Any, **_kwargs: Any):
+        with counter_lock:
+            state["in_flight"] += 1
+            state["peak"] = max(state["peak"], state["in_flight"])
+        time.sleep(0.1)
+        with counter_lock:
+            state["in_flight"] -= 1
+        return OptionsResult(options=[Option(value="x", label="X")])
+
+    registry.result = _behaviour
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as ac:
+        responses = await asyncio.gather(
+            *(ac.post("/plugins/stocks/options/symbols", json={"query": f"q{i}"}) for i in range(8))
+        )
+
+    assert all(r.status_code == 200 for r in responses)
+    assert state["peak"] <= 2, f"{state['peak']} lookups ran at once against a cap of 2"
+
+
+@pytest.mark.asyncio
+async def test_a_timed_out_lookup_holds_its_slot_until_the_thread_really_ends(registry, monkeypatch):
+    """The cap only caps anything if it counts *threads*, not waiters.
+
+    ``wait_for`` cancels the await, never the thread. Releasing the slot on
+    timeout would let hung lookups free their slots one after another and start
+    fresh threads forever, which is precisely the exhaustion the cap exists to
+    prevent.
+    """
+    from src import api_server
+
+    monkeypatch.setattr(api_server, "_PLUGIN_OPTIONS_SEMAPHORE", asyncio.Semaphore(1))
+    monkeypatch.setattr(api_server, "PLUGIN_OPTIONS_TIMEOUT_SECONDS", 0.2)
+    release = threading.Event()
+    registry.result = _blocking_provider(release, seconds=3.0)
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as ac:
+        first = await ac.post("/plugins/stocks/options/symbols", json={})
+        assert first.status_code == 504, "the first lookup should have timed out"
+
+        second = asyncio.create_task(ac.post("/plugins/stocks/options/symbols", json={"query": "other"}))
+        await asyncio.sleep(0.2)
+        # Count dispatches, not response timing: a naive implementation frees
+        # the slot on timeout and the second lookup would already have started
+        # its own thread by now, even though it will time out too.
+        dispatches_while_stuck = len(registry.calls)
+
+        release.set()
+        await second
+
+    assert dispatches_while_stuck == 1, "a second thread started while the abandoned one was still running"
+
+
+def test_a_plugin_uninstalled_mid_dialog_is_a_404_not_a_502(registry, client):
+    """The registry raises ``KeyError`` when the class has gone away — an
+    uninstall racing an open settings dialog. That is still "no such plugin",
+    not an upstream failure."""
+    registry.result = _raises(KeyError("Cannot create sandbox instance for plugin: stocks"))
+
+    response = _post(client)
+
+    assert response.status_code == 404
+
+
+def test_a_plugin_with_no_manifest_declares_no_providers(registry, client):
+    """A plugin can be loaded with its manifest missing from the registry. It
+    has declared nothing, so it authorizes nothing."""
+    registry.manifests.pop("stocks")
+
+    response = _post(client)
+
+    assert response.status_code == 400
+    assert registry.calls == []
+
+
+def test_the_caches_are_bounded(registry, client, monkeypatch):
+    """A settings search box makes one cache entry per keystroke, and this
+    process runs for months."""
+    from src import api_server
+
+    monkeypatch.setattr(api_server, "PLUGIN_OPTIONS_CACHE_MAX_ENTRIES", 3)
+
+    for i in range(8):
+        _post(client, query=f"q{i}")
+        _post(client, query=f"q{i}", refresh=True)
+
+    assert len(api_server._PLUGIN_OPTIONS_CACHE) <= 3
+    assert len(api_server._plugin_options_last_refresh) <= 4


### PR DESCRIPTION
## Context: #1542 has landed

This started life stacked on `feat/plugin-options-primitive`, but #1542
**squash-merged while this was in progress**. The branch is now rebased straight
onto `main` and carries a **single commit**. No prerequisite remains — the diff
below is only the HTTP route.

## Why

#1542 added the backend contract — `Option` / `OptionsRequest` /
`OptionsResult`, `PluginBase.get_options()`, manifest validation, and
`registry.get_plugin_options()` on a throwaway sandbox instance. Nothing could
reach it.

Plugins cannot register API routes (only `auth_router` is included,
`src/api_server.py:917`), so core exposes exactly one route that dispatches into
the standard method. That is what makes "zero core changes per new picker" true
rather than aspirational.

```text
POST /plugins/{plugin_id}/options/{options_id}
```

**POST rather than GET is deliberate.** `parent` carries arbitrary JSON, and
`draft_config` carries credentials — neither belongs in a URL, an access log, or
browser history.

## What it does

**Authorization.** Only `options_id`s the plugin's *own* manifest declares
(`collect_options_ids`) can be dispatched; anything else is a 400 that never
reaches plugin code. Without this the route is an arbitrary-string channel into
every installed plugin.

**It does not block the event loop.** `GET /plugins/{id}/data` calls
`fetch_plugin_data` inline inside an `async def`. That is not copied here:
options are fetched while the settings dialog is open, potentially on every
keystroke in a search box, which would turn an occasional stall into a
continuous one. `get_options()` runs on a worker thread via `asyncio.to_thread`
under `asyncio.wait_for(timeout=20)`, following the `/queue-times/*` and
`/home-assistant/entities` pattern.

`wait_for` cancels the *await*, never the thread — a plugin hung on a socket
keeps its worker regardless. The `asyncio.Semaphore(4)` cap is therefore
released from the task's **done-callback**, when the thread genuinely finishes,
not when we stop waiting. Releasing on timeout would let four hung lookups free
their slots, the next four start fresh threads, and so on until the default
executor is drained and every other `asyncio.to_thread` caller in the process
starves behind a plugin nobody is waiting on.

**Caching.** TTL per provider from the manifest's `ui:options.cache_seconds`
(default 300, `0` disables), keyed on the **full** instance id plus a sha256 of
the effective config — so `weather:home` and `weather:cabin`, and two
differently-credentialed installs of one plugin, never share entries.
`refresh: true` bypasses, throttled to once a second per question so a stuck
Retry button cannot become a DoS on somebody else's API. A failed or timed-out
lookup serves the last good answer with `stale: true` rather than emptying a
picker the user is already looking at.

**Sanitisation is core-enforced**, so a buggy plugin cannot wedge the browser:
options capped at `min(limit, 1000)` with `has_more`; `label`/`description` 200
chars, `preview` 120, `group` 80 (truncated, never a reason to drop the choice);
`cursor` 512; whole payload 512KB. An option whose `value` is not a JSON scalar
is dropped and logged — `value` is written verbatim into `config.json`, where a
dict becomes an un-comparable blob that only fails much later somewhere
unrelated.

**`draft_config` unmasking.** The browser holds sensitive fields as `"***"`, so
forwarding a draft verbatim would hand the plugin three asterisks as its API key
and fail every lookup mid-setup. The existing preservation logic in
`ConfigManager.set_plugin_config` is **extracted to
`config_manager.unmask_sensitive_values` and reused**, not duplicated; that
method now calls it. Only draft key *names* are ever logged, never values.
`registry.get_plugin_options` now layers the un-masked draft over the stored
config, replacing the `TODO(#options-route)` #1542 left behind.

## Error semantics

| Condition | Status |
| --- | --- |
| plugin system unavailable | 503 |
| unknown plugin (incl. an uninstall racing an open dialog → `KeyError`) | 404 |
| `options_id` not declared in the manifest | 400 |
| plugin has no `get_options` / transition plugin | **501** |
| `OptionsUnavailable` raised | **200**, `error` set, `options: []` |
| any other exception | 502, or 200 + `stale: true` when a prior good answer is cached |
| timeout | 504, or 200 + `stale: true` |
| forced refresh inside 1s | 429 |
| plugin disabled | **allowed** |

The 200-with-`error` case is the load-bearing one: "not configured yet" is the
expected state while the user is still filling the form in, and the widget needs
an inline hint next to the field, not a red toast on a 5xx. Options working
while the plugin is **disabled** is the same argument — you browse the catalog
*in order to* configure the plugin, before you ever enable it.

`receive_payload` answers the analogous not-implemented case with **405**. 501
is the semantically correct code and is what this route uses; aligning the two
should be a separate change.

## Tests

Built test-first: 38 new tests in `tests/test_plugin_options_route.py`, plus 2
in `tests/test_plugin_options.py` for the registry's draft-config layering.

The load-bearing one is `test_a_slow_plugin_does_not_block_the_event_loop`: it
fires a slow options request, then times a concurrent `GET /health` from
*before* the yield that lets the options request reach its handler. Replacing
the `to_thread` dispatch with a plain synchronous call fails it with
`AssertionError: /health waited 2.03s behind the options call — the event loop
was blocked`. An earlier version of that test started its stopwatch *after* the
yield and passed against the synchronous version; it was rewritten once the
mutation exposed it.

Every test that passed on first write was mutation-checked the same way. Three
were vacuous and got tightened:
`test_two_instances_of_one_plugin_do_not_share_a_cache_entry` was carried by the
config fingerprint rather than the instance key (both instances now share a
config); `test_a_payload_over_the_byte_budget_is_trimmed` was passing on the
count ceiling rather than the byte budget (now asks for `limit: 1000`); and
`test_a_timed_out_lookup_holds_its_slot_until_the_thread_really_ends` asserted
on response timing, which raced — it now counts plugin dispatches.

Platform tests **4635 → 4675** on the rebased branch, 0 failures. Coverage
88.18% (gate 80%); the new route has no uncovered lines or branches.
`ruff check` and `ruff format --check` clean on `src/ plugins/ tests/ scripts/`
(ruff 0.16.1). Plugin tests 7/7 plugins, 163 tests.
`scripts/validate_plugins.py` passes. No `web/` files touched.

Tests were run **serially**: `pytest -n auto` is flaky in containers because
xdist workers share `/app/data`, which reproduces on unmodified `main`.

## Follow-ups

The React `remote-options` widget, and aligning `receive_payload`'s 405 with
this route's 501.
