### PR TITLE
fix(plugins): validate the full ui:options grammar the widget implements

### DIFF
--- a/docs/development/PLUGIN_DEVELOPMENT.md
+++ b/docs/development/PLUGIN_DEVELOPMENT.md
@@ -420,14 +420,21 @@ No core change is needed for a new plugin.
 }
 ```
 
-`ui:options` accepts exactly four keys:
+`ui:options` accepts exactly these nine keys — anything else is a validation
+error, because a silently-ignored typo is how a picker ships without ever
+calling your plugin:
 
 | Key | Meaning |
 | --- | --- |
-| `options_id` | Which catalog this field wants. `^[a-z][a-z0-9_]*$`, unique across the schema. |
+| `options_id` | Which catalog this field wants. `^[a-z][a-z0-9_]*$`, unique across the schema. Required. |
 | `depends_on` | Sibling or root property names whose values scope the catalog. |
 | `multiple` | Multi-select. Requires `"type": "array"`. |
 | `cache_seconds` | How long the UI may reuse the list. Integer, 0–3600. |
+| `searchable` | Render a filter box over the options already fetched. Boolean. |
+| `server_search` | Send the filter text to `get_options()` as `query`, debounced. Boolean. Turns the box on by itself, so `searchable` may be omitted — but `"server_search": true` with an explicit `"searchable": false` is rejected rather than quietly resolved. |
+| `reorderable` | Up/down arrows on the chosen items. Boolean. Requires `multiple`. |
+| `allow_custom` | Accept a typed value the catalog does not offer. Boolean. |
+| `placeholder` | Trigger placeholder text. String. |
 
 Then implement `get_options()` — one method serves every `options_id`:
 

--- a/src/plugins/manifest.py
+++ b/src/plugins/manifest.py
@@ -52,7 +52,14 @@ OPTIONS_ID_RE = re.compile(r"^[a-z][a-z0-9_]*$")
 
 # Every key a ``ui:options`` block may carry. Anything else is a typo, and a
 # silently-ignored typo is how a picker ships without ever calling the plugin.
-UI_OPTIONS_KEYS = frozenset({"options_id", "depends_on", "multiple", "cache_seconds"})
+#
+# The render flags below are plain booleans. ``multiple`` is deliberately not
+# one of them: it predates the flags and is already policed by its own
+# "requires type 'array'" rule, which a stricter type check would double up on.
+UI_OPTIONS_BOOLEAN_KEYS = frozenset({"searchable", "server_search", "reorderable", "allow_custom"})
+UI_OPTIONS_KEYS = (
+    frozenset({"options_id", "depends_on", "multiple", "cache_seconds", "placeholder"}) | UI_OPTIONS_BOOLEAN_KEYS
+)
 
 # How long the UI may reuse a fetched option list. Zero means "never cache";
 # the ceiling is an hour, above which a stale picker outlives the dialog it
@@ -824,9 +831,32 @@ def validate_settings_schema_ui(settings_schema: dict[str, Any]) -> list[str]:
         for key in sorted(set(ui_options) - UI_OPTIONS_KEYS):
             errors.append(f"settings_schema.{field_path}: unknown ui:options key '{key}'")
 
+        for key in sorted(UI_OPTIONS_BOOLEAN_KEYS):
+            value = ui_options.get(key)
+            if value is not None and not isinstance(value, bool):
+                errors.append(f"settings_schema.{field_path}: ui:options.{key} must be a boolean, got {value!r}")
+
+        placeholder = ui_options.get("placeholder")
+        if placeholder is not None and not isinstance(placeholder, str):
+            errors.append(f"settings_schema.{field_path}: ui:options.placeholder must be a string, got {placeholder!r}")
+
         if ui_options.get("multiple") and prop.get("type") != "array":
             errors.append(
                 f"settings_schema.{field_path}: ui:options.multiple requires type 'array', got {prop.get('type')!r}"
+            )
+
+        if ui_options.get("reorderable") and not ui_options.get("multiple"):
+            errors.append(f"settings_schema.{field_path}: ui:options.reorderable requires ui:options.multiple")
+
+        # ``server_search`` turns the filter box on by itself -- the widget
+        # renders it on ``searchable || server_search`` -- so an omitted
+        # ``searchable`` is fine. An explicit ``false`` is not: the author asked
+        # for a box and asked for no box, and the UI would quietly pick one.
+        searchable = ui_options.get("searchable")
+        if ui_options.get("server_search") and searchable is False:
+            errors.append(
+                f"settings_schema.{field_path}: ui:options.server_search implies ui:options.searchable, "
+                f"got searchable={searchable!r}"
             )
 
         cache_seconds = ui_options.get("cache_seconds")

--- a/tests/test_plugin_options.py
+++ b/tests/test_plugin_options.py
@@ -97,6 +97,24 @@ def test_unknown_key_inside_ui_options_is_an_error():
     assert any("cache_second" in e for e in errors), errors
 
 
+def test_a_key_outside_the_grammar_is_still_an_error_after_the_grammar_grew():
+    """Widening the key set for the widget's flags must not open the gate."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "symbols": {
+                "type": "array",
+                "ui:widget": "remote-options",
+                "ui:options": {"options_id": "symbols", "bogus_key": True},
+            }
+        },
+    }
+
+    errors = validate_settings_schema_ui(schema)
+
+    assert errors == ["settings_schema.symbols: unknown ui:options key 'bogus_key'"]
+
+
 def test_multiple_requires_an_array_typed_field():
     """A multi-select needs somewhere to put the second selection."""
     schema = {
@@ -131,6 +149,132 @@ def test_cache_seconds_outside_the_allowed_range_is_an_error():
     errors = validate_settings_schema_ui(schema)
 
     assert any("cache_seconds" in e for e in errors), errors
+
+
+@pytest.mark.parametrize("key", ["searchable", "server_search", "reorderable", "allow_custom"])
+def test_boolean_ui_options_flags_are_accepted(key):
+    """The widget's render flags are part of the grammar, not typos."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "symbols": {
+                "type": "array",
+                "ui:widget": "remote-options",
+                "ui:options": {"options_id": "symbols", "multiple": True, key: True},
+            }
+        },
+    }
+
+    assert validate_settings_schema_ui(schema) == []
+
+
+@pytest.mark.parametrize("key", ["searchable", "server_search", "reorderable", "allow_custom"])
+def test_boolean_ui_options_flags_reject_a_non_boolean(key):
+    """A truthy string renders the same as ``true`` in JS — say so in Python."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "symbols": {
+                "type": "array",
+                "ui:widget": "remote-options",
+                "ui:options": {"options_id": "symbols", "multiple": True, key: "yes"},
+            }
+        },
+    }
+
+    errors = validate_settings_schema_ui(schema)
+
+    assert errors == [f"settings_schema.symbols: ui:options.{key} must be a boolean, got 'yes'"]
+
+
+def test_placeholder_text_is_accepted():
+    """The trigger's placeholder is the plugin author's copy, not core's."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "symbol": {
+                "type": "string",
+                "ui:widget": "remote-options",
+                "ui:options": {"options_id": "symbols", "placeholder": "Search tickers"},
+            }
+        },
+    }
+
+    assert validate_settings_schema_ui(schema) == []
+
+
+def test_placeholder_must_be_a_string():
+    """Anything else reaches the DOM as ``[object Object]``."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "symbol": {
+                "type": "string",
+                "ui:widget": "remote-options",
+                "ui:options": {"options_id": "symbols", "placeholder": 42},
+            }
+        },
+    }
+
+    errors = validate_settings_schema_ui(schema)
+
+    assert errors == ["settings_schema.symbol: ui:options.placeholder must be a string, got 42"]
+
+
+def test_reorderable_requires_a_multi_select():
+    """There is nothing to reorder in a single choice — the arrows never render."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "symbol": {
+                "type": "string",
+                "ui:widget": "remote-options",
+                "ui:options": {"options_id": "symbols", "reorderable": True},
+            }
+        },
+    }
+
+    errors = validate_settings_schema_ui(schema)
+
+    assert errors == ["settings_schema.symbol: ui:options.reorderable requires ui:options.multiple"]
+
+
+def test_server_search_implies_searchable_without_declaring_it():
+    """The widget renders the box on ``searchable || server_search``, so asking
+    for a second flag would be ceremony the UI does not need."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "symbol": {
+                "type": "string",
+                "ui:widget": "remote-options",
+                "ui:options": {"options_id": "symbols", "server_search": True},
+            }
+        },
+    }
+
+    assert validate_settings_schema_ui(schema) == []
+
+
+def test_server_search_contradicting_an_explicit_searchable_false_is_an_error():
+    """``searchable: false`` here is a declaration the widget will ignore, and a
+    silently-ignored declaration is exactly what the unknown-key rule prevents."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "symbol": {
+                "type": "string",
+                "ui:widget": "remote-options",
+                "ui:options": {"options_id": "symbols", "server_search": True, "searchable": False},
+            }
+        },
+    }
+
+    errors = validate_settings_schema_ui(schema)
+
+    assert errors == [
+        "settings_schema.symbol: ui:options.server_search implies ui:options.searchable, got searchable=False"
+    ]
 
 
 def test_depends_on_must_name_a_real_property():


### PR DESCRIPTION
The `remote-options` settings widget (#1545) renders on nine `ui:options` keys. The manifest validator allowed four. The gap is mine — the widget was built to a grammar the backend contract (#1542) never grew to match.

Because `load_manifest()` returns `None` on *any* validation error, this was not a cosmetic mismatch: a manifest declaring `searchable`, `server_search`, `reorderable`, `allow_custom` or `placeholder` failed with `unknown ui:options key '<k>'` and the plugin did not load at all. No shipped plugin uses them yet, so nothing is broken in the wild — but the first plugin author to follow the widget's grammar would have hit it.

## What

`UI_OPTIONS_KEYS` widens from four keys to nine, and the five newcomers are validated rather than merely tolerated:

| Rule | Error |
| --- | --- |
| `searchable` / `server_search` / `reorderable` / `allow_custom` must be booleans | `settings_schema.<path>: ui:options.<key> must be a boolean, got 'yes'` |
| `placeholder` must be a string | `settings_schema.<path>: ui:options.placeholder must be a string, got 42` |
| `reorderable` requires `multiple` | `settings_schema.<path>: ui:options.reorderable requires ui:options.multiple` |
| `server_search: true` + `searchable: false` | `settings_schema.<path>: ui:options.server_search implies ui:options.searchable, got searchable=False` |

### `server_search` implies `searchable`

`server_search` is treated as **sufficient on its own** — a field may declare it and omit `searchable`. The widget renders the filter box on `ui.searchable || ui.server_search`, so requiring a second flag would be ceremony that changes nothing on screen, and would reject manifests the UI handles correctly.

What is *not* accepted is the contradiction: `server_search: true` with an explicit `searchable: false`. There the author asked for a box and asked for no box; the widget silently picks "box". A declaration the UI ignores is precisely the failure mode the unknown-key rule exists to prevent, so it is an error rather than a quiet resolution.

### Deliberately unchanged

- **`multiple` is not held to the new boolean check.** It predates the render flags and is already policed by its own `requires type 'array'` rule. Adding a type check would tighten validation this PR was not asked to touch.
- **An unknown `ui:widget` is still a warning, not an error.** `stocks`, `muni` and `lyft-bike-share` declare picker widget names core never implemented; promoting that to an error would uninstall them in practice. The existing parametrized guard for this stays green.

`docs/development/PLUGIN_DEVELOPMENT.md` said "exactly four keys" and now documents all nine, including the `server_search`/`searchable` rule.

## Tests

14 new tests in `tests/test_plugin_options.py`, written one behaviour at a time, each run and observed red before the code that satisfies it.

Two of them were green the moment they were written, because they are regression guards over behaviour rather than new behaviour. Both were proved non-vacuous by mutation:

- `test_a_key_outside_the_grammar_is_still_an_error_after_the_grammar_grew` — neutering the unknown-key loop gives:
  ```
  E   assert [] == ["settings_sc... 'bogus_key'"]
  E     Right contains one more item: "settings_schema.symbols: unknown ui:options key 'bogus_key'"
  ```
- `test_server_search_implies_searchable_without_declaring_it` — flipping the rule to `not searchable` (i.e. requiring an explicit `searchable: true`, the design alternative) gives:
  ```
  E   assert ['settings_sc...rchable=None'] == []
  E     Left contains one more item: 'settings_schema.symbol: ui:options.server_search implies ui:options.searchable, got searchable=None'
  ```

Both mutations were reverted and the suite re-confirmed green.

## Verification

Run serially — `-n auto` shares `/app/data` between xdist workers and flakes reproducibly, even on unmodified `main`.

- `pytest tests/ -m "not integration"` — **4689 passed**, 13 deselected (baseline on `main`: 4675 passed, 13 deselected)
- `--cov=src --cov-branch --cov-fail-under=80` — 88.16% (baseline 88.14%)
- `ruff check src/ plugins/ tests/ scripts/` — All checks passed (ruff 0.16.1)
- `ruff format --check src/ plugins/ tests/ scripts/` — 278 files already formatted
- `python scripts/validate_plugins.py --verbose` — 7/7 passed, 0 errors, 0 warnings
- `git diff --name-only` — three files, none under `web/`