### PR TITLE
fix(nginx): stop rewriting app-returned 502/504 into the boot-race 503

### DIFF
--- a/nginx-dev.conf
+++ b/nginx-dev.conf
@@ -50,13 +50,26 @@ http {
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-XSS-Protection "1; mode=block" always;
 
-        # Intercept CONNECTION-LEVEL upstream errors (502 refused / 504 timeout) so we
+        # Handle CONNECTION-LEVEL upstream errors (502 refused / 504 timeout) so we
         # can serve the "please wait" page instead of a raw gateway error while the
-        # API is still starting. 503 is deliberately NOT intercepted: the API uses it
-        # for real conditions ("board unreachable", "client not initialized") whose
-        # JSON detail must reach the UI — intercepting it masked every app-level
-        # error as "starting up" forever.
-        proxy_intercept_errors on;
+        # API is still starting.
+        #
+        # `proxy_intercept_errors` MUST stay off. With it on, `error_page` also
+        # swallows 502/504 responses the FastAPI app *itself* returns and rewrites
+        # them to the "starting up" 503 — so a plugin whose options provider blew
+        # up (502) or timed out (504), a failed system update, a Queue-Times
+        # outage, or a generic-data test-fetch against a dead URL all reached the
+        # client as "Service is starting up", with the real JSON `detail` gone and
+        # genuine gateway failures invisible in the logs. Off is nginx's default
+        # and means only errors nginx generates on its own — connect refused,
+        # upstream timed out, i.e. exactly the boot race this block exists for —
+        # are turned into the friendly page. Application responses pass through
+        # untouched.
+        #
+        # 503 is likewise not listed here: the API uses it for real conditions
+        # ("board unreachable", "client not initialized") whose JSON detail must
+        # reach the UI.
+        proxy_intercept_errors off;
         error_page 502 504 /starting.html;
 
         location = /starting.html {

--- a/nginx.conf
+++ b/nginx.conf
@@ -62,13 +62,26 @@ http {
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-XSS-Protection "1; mode=block" always;
 
-        # Intercept CONNECTION-LEVEL upstream errors (502 refused / 504 timeout) so we
+        # Handle CONNECTION-LEVEL upstream errors (502 refused / 504 timeout) so we
         # can serve the "please wait" page instead of a raw gateway error while the
-        # API is still starting. 503 is deliberately NOT intercepted: the API uses it
-        # for real conditions ("board unreachable", "client not initialized") whose
-        # JSON detail must reach the UI — intercepting it masked every app-level
-        # error as "starting up" forever.
-        proxy_intercept_errors on;
+        # API is still starting.
+        #
+        # `proxy_intercept_errors` MUST stay off. With it on, `error_page` also
+        # swallows 502/504 responses the FastAPI app *itself* returns and rewrites
+        # them to the "starting up" 503 — so a plugin whose options provider blew
+        # up (502) or timed out (504), a failed system update, a Queue-Times
+        # outage, or a generic-data test-fetch against a dead URL all reached the
+        # client as "Service is starting up", with the real JSON `detail` gone and
+        # genuine gateway failures invisible in the logs. Off is nginx's default
+        # and means only errors nginx generates on its own — connect refused,
+        # upstream timed out, i.e. exactly the boot race this block exists for —
+        # are turned into the friendly page. Application responses pass through
+        # untouched.
+        #
+        # 503 is likewise not listed here: the API uses it for real conditions
+        # ("board unreachable", "client not initialized") whose JSON detail must
+        # reach the UI.
+        proxy_intercept_errors off;
         error_page 502 504 /starting.html;
 
         location = /starting.html {

--- a/nginx.https.conf
+++ b/nginx.https.conf
@@ -59,13 +59,26 @@ http {
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-XSS-Protection "1; mode=block" always;
 
-        # Intercept CONNECTION-LEVEL upstream errors (502 refused / 504 timeout) so we
+        # Handle CONNECTION-LEVEL upstream errors (502 refused / 504 timeout) so we
         # can serve the "please wait" page instead of a raw gateway error while the
-        # API is still starting. 503 is deliberately NOT intercepted: the API uses it
-        # for real conditions ("board unreachable", "client not initialized") whose
-        # JSON detail must reach the UI — intercepting it masked every app-level
-        # error as "starting up" forever.
-        proxy_intercept_errors on;
+        # API is still starting.
+        #
+        # `proxy_intercept_errors` MUST stay off. With it on, `error_page` also
+        # swallows 502/504 responses the FastAPI app *itself* returns and rewrites
+        # them to the "starting up" 503 — so a plugin whose options provider blew
+        # up (502) or timed out (504), a failed system update, a Queue-Times
+        # outage, or a generic-data test-fetch against a dead URL all reached the
+        # client as "Service is starting up", with the real JSON `detail` gone and
+        # genuine gateway failures invisible in the logs. Off is nginx's default
+        # and means only errors nginx generates on its own — connect refused,
+        # upstream timed out, i.e. exactly the boot race this block exists for —
+        # are turned into the friendly page. Application responses pass through
+        # untouched.
+        #
+        # 503 is likewise not listed here: the API uses it for real conditions
+        # ("board unreachable", "client not initialized") whose JSON detail must
+        # reach the UI.
+        proxy_intercept_errors off;
         error_page 502 504 /starting.html;
 
         location = /starting.html {

--- a/tests/test_nginx_error_semantics.py
+++ b/tests/test_nginx_error_semantics.py
@@ -1,0 +1,53 @@
+"""nginx must not rewrite application-generated gateway errors.
+
+The `@api_starting` fallback exists for one window only: nginx is listening but
+the API process is not yet bound to 127.0.0.1:8000, so nginx *itself* generates
+a 502/504 and we serve a friendly "starting up" JSON instead of a raw gateway
+error.
+
+`proxy_intercept_errors on` widens that from "errors nginx generated" to "any
+response with status >= 300", which swallowed the 502/504 responses FastAPI
+returns deliberately (a plugin options provider that raised or timed out, a
+failed system update, a dead generic-data URL) and rewrote every one of them
+into the boot-race 503 — real status gone, JSON `detail` gone.
+
+These tests pin the two halves of that contract in all three configs.
+"""
+
+from pathlib import Path
+
+import pytest
+
+CONFIGS = ("nginx.conf", "nginx.https.conf", "nginx-dev.conf")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _read(name: str) -> str:
+    return (REPO_ROOT / name).read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("config_name", CONFIGS)
+def test_upstream_responses_are_not_intercepted(config_name: str) -> None:
+    """App-returned 502/504 must reach the client, so interception stays off."""
+    directives = [
+        line.strip() for line in _read(config_name).splitlines() if line.strip().startswith("proxy_intercept_errors")
+    ]
+
+    assert directives == ["proxy_intercept_errors off;"], (
+        f"{config_name} must declare `proxy_intercept_errors off;` exactly once. "
+        "Turning it on makes error_page swallow the 502/504 the API returns itself."
+    )
+
+
+@pytest.mark.parametrize("config_name", CONFIGS)
+def test_boot_race_still_falls_back_to_the_starting_response(config_name: str) -> None:
+    """nginx-generated 502/504 on /api must still produce the JSON boot-race body."""
+    text = _read(config_name)
+
+    assert text.count("error_page 502 504 = @api_starting;") == 2, (
+        f"{config_name} must keep the @api_starting fallback on both /api locations "
+        "(/api/mcp and /api/) so a not-yet-listening upstream stays friendly."
+    )
+    assert '"detail":"Service is starting up, please try again shortly"' in text
+    assert "location @api_starting {" in text


### PR DESCRIPTION
## The bug is real, and it is wider than one route

nginx was rewriting **application-generated** 502/504 responses into the boot-race
503, not just the connection-level failures it generates itself.

The trigger is `proxy_intercept_errors on;` at the `server` level of all three
configs. nginx's default (`off`) only routes errors *nginx* produces — connect
refused, upstream timed out — through `error_page`. With it `on`, every upstream
response with a listed status is intercepted too, so `error_page 502 504 =
@api_starting;` on the `/api` locations swallowed the 502/504 FastAPI returns on
purpose and replaced them with:

```
HTTP/1.1 503 Service Temporarily Unavailable
{"detail":"Service is starting up, please try again shortly"}
```

The real status and the real JSON `detail` never reached the client, and a
genuine upstream failure was indistinguishable from a container boot race in the
logs.

### Conditions

Any `/api/*` request where the FastAPI app itself answers 502 or 504. It does not
depend on the request being slow or the container being fresh — it is
deterministic.

### Blast radius — 12 routes, not one

| Route | Status | `src/api_server.py` |
| --- | --- | --- |
| `POST /plugins/{plugin_id}/options/{options_id}` | 504 provider timed out | `:9359` |
| `POST /plugins/{plugin_id}/options/{options_id}` | 502 provider raised | `:9380` |
| `POST /system/update` | 502 | `:2516`, `:2528` |
| `POST /system/update/rollback` | 502 | `:2683`, `:2692` |
| `POST /system/update/auto` | 502 | `:2785` |
| `POST /system/restart` | 502 | `:2808` |
| `POST /system/shutdown` | 502 | `:2830` |
| `GET /queue-times/parks` | 502 | `:4896` |
| `GET /queue-times/parks/{park_id}/rides` | 502 | `:4915` |
| `POST /transitions/preview` | 504 | `:5657` |
| `POST /transitions/test-live` | 504 | `:5821` |
| `POST /transitions/restore` | 502 board unreachable | `:5891` |
| `POST /generic-data/test-fetch` | 504 timeout / 502 connection / 502 HTTP error | `:10220`, `:10222`, `:10226` |

Every one of these lost its `detail` at the proxy. The 503 case was already
noticed and fixed once — the existing comment says intercepting 503 "masked every
app-level error as 'starting up' forever" — but 502/504 were left on the list
while the directive that made interception apply to app responses stayed on.

## The change

`proxy_intercept_errors off;` at the `server` level in `nginx.conf`,
`nginx.https.conf`, `nginx-dev.conf`, with a comment explaining why it must not
be flipped back.

### Why this over the alternatives

- **Narrowing `error_page`** — there is no nginx condition that distinguishes
  "upstream said 502" from "nginx could not reach upstream" at `error_page`
  granularity. `$upstream_status` is only populated once a response exists, and
  `error_page` cannot branch on it.
- **Passing the upstream body through `@api_starting`** — a named location cannot
  reach back for the intercepted upstream body; it can only produce a new
  response. It would need `proxy_pass` to a second internal location, i.e. a
  duplicate request with side effects.
- **`proxy_intercept_errors off` only inside the two `/api` locations** — works,
  but leaves the trap armed for `location /`, which in dev proxies to the Vite
  server. Server-level `off` is one directive per file and restores exactly the
  behavior the block's own comment already claimed ("intercept CONNECTION-LEVEL
  upstream errors").

Both `error_page` fallbacks are untouched: nginx-generated 502/504 on `/api/*`
still go to `@api_starting`, and everything else still gets `starting.html`.

## Evidence

Run against a dedicated dev stack (`docker-compose.dev.yml`, separate project
name, port 4462), using a scratch plugin whose `get_options` raises for
`options_id=boom` and sleeps past the route's 20s timeout for `options_id=slow`.

### Before — app returns 502, client sees 503

```
$ curl -i -s -X POST http://localhost:4462/api/plugins/nginx_probe/options/boom -d '{}'
HTTP/1.1 503 Service Temporarily Unavailable
Server: nginx/1.26.3
Content-Type: application/json
Content-Length: 61

{"detail":"Service is starting up, please try again shortly"}
```

Same request straight to uvicorn inside the container, bypassing nginx:

```
$ docker exec … curl -i -s -X POST http://127.0.0.1:8000/plugins/nginx_probe/options/boom -d '{}'
HTTP/1.1 502 Bad Gateway
server: uvicorn
content-length: 75

{"detail":"Options provider failed: deliberate options provider explosion"}
```

### Before — app returns 504, client sees 503

```
$ curl -i -s -X POST http://localhost:4462/api/plugins/nginx_probe/options/slow -d '{}'
HTTP/1.1 503 Service Temporarily Unavailable
Content-Length: 61

{"detail":"Service is starting up, please try again shortly"}
```

```
$ docker exec … curl -i -s -X POST http://127.0.0.1:8000/plugins/nginx_probe/options/slow -d '{}'
HTTP/1.1 504 Gateway Timeout
server: uvicorn

{"detail":"Options provider 'slow' timed out"}
```

### After — real status and detail reach the client

```
$ curl -i -s -X POST http://localhost:4462/api/plugins/nginx_probe/options/boom -d '{}'
HTTP/1.1 502 Bad Gateway
Server: nginx/1.26.3
Content-Type: application/json
Content-Length: 75

{"detail":"Options provider failed: deliberate options provider explosion"}
```

```
$ curl -i -s -X POST http://localhost:4462/api/plugins/nginx_probe/options/slow -d '{}'
HTTP/1.1 504 Gateway Timeout
Server: nginx/1.26.3
Content-Type: application/json
Content-Length: 46

{"detail":"Options provider 'slow' timed out"}
```

### After — no regression on the boot race

The check that matters. A single uninterrupted poll across a container restart:
nginx comes up first, the API is not yet bound to `127.0.0.1:8000`, and the
friendly response is still served — then flips to the real 502 the instant the
app starts listening. No raw gateway error at any point.

```
--- attempt 28 (03:07:54)  ← nginx up, API not listening
HTTP/1.1 503 Service Temporarily Unavailable
Server: nginx/1.26.3
Content-Type: application/json
Content-Length: 61

{"detail":"Service is starting up, please try again shortly"}

--- attempt 29 (03:07:55)  ← API now listening
HTTP/1.1 502 Bad Gateway
Server: nginx/1.26.3
Content-Type: application/json
Content-Length: 75

{"detail":"Options provider failed: deliberate options provider explosion"}
```

Attempts 1–28 were all the 503 boot-race body; the transition at attempt 29 is
the only change in the run.

`nginx -t` passes on all three configs (`nginx.https.conf` gets past parsing and
stops only on the absent dev TLS certificate, as expected).

## Test

`tests/test_nginx_error_semantics.py` pins both halves of the contract across all
three configs: `proxy_intercept_errors` is declared exactly once and is `off`,
and both `/api` locations keep the `@api_starting` fallback.

Proved non-vacuous by reverting each half of the production change and watching
the matching test fail:

```
E   AssertionError: nginx.conf must declare `proxy_intercept_errors off;` exactly once.
E   assert ['proxy_intercept_errors on;'] == ['proxy_intercept_errors off;']

E   AssertionError: nginx-dev.conf must keep the @api_starting fallback on both /api locations
E   assert 0 == 2

FAILED tests/test_nginx_error_semantics.py::test_upstream_responses_are_not_intercepted[nginx.conf]
FAILED tests/test_nginx_error_semantics.py::test_boot_race_still_falls_back_to_the_starting_response[nginx-dev.conf]
```

Restored, 6 passed.

## Not verified

- `nginx.https.conf` was checked for syntax and diff-equivalence only; the TLS
  server block was not exercised end-to-end (no certs in the dev container). The
  changed directive is identical in all three files.
- The scratch plugin used to force the failures lives in the gitignored
  `data/external_plugins/` and is not part of this branch.
