### PR TITLE
fix(web): stop remote-options deleting dependent values on cold open

### DIFF
--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -1707,6 +1707,7 @@
     "remoteOptionsEmpty": "Keine Optionen verfügbar",
     "remoteOptionsStale": "Zwischengespeicherte Ergebnisse werden angezeigt",
     "remoteOptionsRefineSearch": "Grenzen Sie die Suche ein, um mehr zu sehen",
+    "remoteOptionsTruncated": "Es werden nicht alle Optionen angezeigt",
     "remoteOptionsAdd": "Hinzufügen…",
     "remoteOptionsAddLabel": "Option hinzufügen",
     "remoteOptionsRemove": "{label} entfernen",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1664,6 +1664,7 @@
     "remoteOptionsEmpty": "No options available",
     "remoteOptionsStale": "Showing cached results",
     "remoteOptionsRefineSearch": "Refine your search to see more",
+    "remoteOptionsTruncated": "Not all options are shown",
     "remoteOptionsAdd": "Add…",
     "remoteOptionsAddLabel": "Add option",
     "remoteOptionsRemove": "Remove {label}",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -1707,6 +1707,7 @@
     "remoteOptionsEmpty": "No hay opciones disponibles",
     "remoteOptionsStale": "Mostrando resultados en caché",
     "remoteOptionsRefineSearch": "Refina tu búsqueda para ver más",
+    "remoteOptionsTruncated": "No se muestran todas las opciones",
     "remoteOptionsAdd": "Añadir…",
     "remoteOptionsAddLabel": "Añadir opción",
     "remoteOptionsRemove": "Eliminar {label}",

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -1707,6 +1707,7 @@
     "remoteOptionsEmpty": "Aucune option disponible",
     "remoteOptionsStale": "Affichage des résultats en cache",
     "remoteOptionsRefineSearch": "Affinez votre recherche pour en voir plus",
+    "remoteOptionsTruncated": "Toutes les options ne sont pas affichées",
     "remoteOptionsAdd": "Ajouter…",
     "remoteOptionsAddLabel": "Ajouter une option",
     "remoteOptionsRemove": "Supprimer {label}",

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -1707,6 +1707,7 @@
     "remoteOptionsEmpty": "Nessuna opzione disponibile",
     "remoteOptionsStale": "Visualizzazione dei risultati dalla cache",
     "remoteOptionsRefineSearch": "Affina la ricerca per vedere altri risultati",
+    "remoteOptionsTruncated": "Non tutte le opzioni sono mostrate",
     "remoteOptionsAdd": "Aggiungi…",
     "remoteOptionsAddLabel": "Aggiungi opzione",
     "remoteOptionsRemove": "Rimuovi {label}",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -1707,6 +1707,7 @@
     "remoteOptionsEmpty": "利用できるオプションがありません",
     "remoteOptionsStale": "キャッシュされた結果を表示しています",
     "remoteOptionsRefineSearch": "検索条件を絞り込むと、さらに表示されます",
+    "remoteOptionsTruncated": "すべてのオプションが表示されているわけではありません",
     "remoteOptionsAdd": "追加…",
     "remoteOptionsAddLabel": "オプションを追加",
     "remoteOptionsRemove": "{label}を削除",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -1707,6 +1707,7 @@
     "remoteOptionsEmpty": "사용할 수 있는 옵션이 없습니다",
     "remoteOptionsStale": "캐시된 결과를 표시하고 있습니다",
     "remoteOptionsRefineSearch": "더 보려면 검색 범위를 좁히세요",
+    "remoteOptionsTruncated": "모든 옵션이 표시되지는 않습니다",
     "remoteOptionsAdd": "추가…",
     "remoteOptionsAddLabel": "옵션 추가",
     "remoteOptionsRemove": "{label} 제거",

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -1707,6 +1707,7 @@
     "remoteOptionsEmpty": "Geen opties beschikbaar",
     "remoteOptionsStale": "Resultaten uit cache worden getoond",
     "remoteOptionsRefineSearch": "Verfijn je zoekopdracht om meer te zien",
+    "remoteOptionsTruncated": "Niet alle opties worden weergegeven",
     "remoteOptionsAdd": "Toevoegen…",
     "remoteOptionsAddLabel": "Optie toevoegen",
     "remoteOptionsRemove": "{label} verwijderen",

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -1707,6 +1707,7 @@
     "remoteOptionsEmpty": "Brak dostępnych opcji",
     "remoteOptionsStale": "Wyświetlanie wyników z pamięci podręcznej",
     "remoteOptionsRefineSearch": "Zawęź wyszukiwanie, aby zobaczyć więcej",
+    "remoteOptionsTruncated": "Nie wszystkie opcje są wyświetlane",
     "remoteOptionsAdd": "Dodaj…",
     "remoteOptionsAddLabel": "Dodaj opcję",
     "remoteOptionsRemove": "Usuń: {label}",

--- a/web/messages/pt.json
+++ b/web/messages/pt.json
@@ -1707,6 +1707,7 @@
     "remoteOptionsEmpty": "Nenhuma opção disponível",
     "remoteOptionsStale": "A mostrar resultados em cache",
     "remoteOptionsRefineSearch": "Refine a sua pesquisa para ver mais",
+    "remoteOptionsTruncated": "Nem todas as opções são apresentadas",
     "remoteOptionsAdd": "Adicionar…",
     "remoteOptionsAddLabel": "Adicionar opção",
     "remoteOptionsRemove": "Remover {label}",

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -1707,6 +1707,7 @@
     "remoteOptionsEmpty": "Нет доступных вариантов",
     "remoteOptionsStale": "Показаны сохранённые результаты",
     "remoteOptionsRefineSearch": "Уточните запрос, чтобы увидеть больше",
+    "remoteOptionsTruncated": "Показаны не все варианты",
     "remoteOptionsAdd": "Добавить…",
     "remoteOptionsAddLabel": "Добавить вариант",
     "remoteOptionsRemove": "Удалить: {label}",

--- a/web/messages/sv.json
+++ b/web/messages/sv.json
@@ -1707,6 +1707,7 @@
     "remoteOptionsEmpty": "Inga alternativ tillgängliga",
     "remoteOptionsStale": "Visar cachade resultat",
     "remoteOptionsRefineSearch": "Förfina sökningen för att se fler",
+    "remoteOptionsTruncated": "Alla alternativ visas inte",
     "remoteOptionsAdd": "Lägg till…",
     "remoteOptionsAddLabel": "Lägg till alternativ",
     "remoteOptionsRemove": "Ta bort {label}",

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -1707,6 +1707,7 @@
     "remoteOptionsEmpty": "Kullanılabilir seçenek yok",
     "remoteOptionsStale": "Önbellekteki sonuçlar gösteriliyor",
     "remoteOptionsRefineSearch": "Daha fazlasını görmek için aramanızı daraltın",
+    "remoteOptionsTruncated": "Tüm seçenekler gösterilmiyor",
     "remoteOptionsAdd": "Ekle…",
     "remoteOptionsAddLabel": "Seçenek ekle",
     "remoteOptionsRemove": "{label} ögesini kaldır",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -1707,6 +1707,7 @@
     "remoteOptionsEmpty": "没有可用的选项",
     "remoteOptionsStale": "正在显示缓存结果",
     "remoteOptionsRefineSearch": "缩小搜索范围以查看更多",
+    "remoteOptionsTruncated": "并未显示全部选项",
     "remoteOptionsAdd": "添加…",
     "remoteOptionsAddLabel": "添加选项",
     "remoteOptionsRemove": "移除{label}",

--- a/web/src/__tests__/remote-options-field.test.tsx
+++ b/web/src/__tests__/remote-options-field.test.tsx
@@ -1,4 +1,4 @@
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { delay, http, HttpResponse } from "msw";
@@ -760,5 +760,326 @@ describe("RemoteOptionsField - missing plugin context", () => {
     // …and must never guess at a plugin id by firing a request anyway.
     await new Promise((resolve) => setTimeout(resolve, 50));
     expect(captured).toHaveLength(0);
+  });
+});
+
+/**
+ * Cold-load hydration.
+ *
+ * `InstalledPluginRow` (app/routes/integrations._index.tsx) mounts `SchemaForm`
+ * with `configValues` still `{}` and only fills it in once the `["plugin", id]`
+ * query resolves. Reopen the dialog in the same session and react-query answers
+ * from cache, so the form never sees the empty state — but on a cold page load
+ * it does, and a dependent field then watches its parent go from *absent* to
+ * *answered* with no user involved. Reading that as "the user changed the
+ * parent" silently deletes the saved child value on the next save.
+ *
+ * The harness below reproduces exactly that order: first render with no config
+ * at all, config on a later render.
+ */
+function ColdOpenForm({
+  schema,
+  stored,
+  pluginId,
+  onChange,
+}: {
+  schema: JSONSchema;
+  stored: Record<string, unknown>;
+  pluginId: string;
+  onChange?: (values: Record<string, unknown>) => void;
+}) {
+  // Stands in for the dialog's `["plugin", id]` query: nothing is cached on a
+  // cold load, so `data` is undefined for the first render and only the second
+  // render carries the saved config.
+  const config = useQuery({
+    queryKey: ["stored-config"],
+    queryFn: async () => {
+      await delay(5);
+      return stored;
+    },
+  });
+  const [edited, setEdited] = useState<Record<string, unknown> | null>(null);
+  const values = edited ?? config.data ?? {};
+  // The parent is driven from outside the form as well as through it, so that
+  // "the user cleared the parent" can be exercised — the enum select offers no
+  // blank row to click.
+  const setParent = (agency: unknown) => setEdited({ ...values, agency });
+
+  return (
+    <>
+      <button type="button" data-testid="parent-sf" onClick={() => setParent("SF")} />
+      <button type="button" data-testid="parent-ac" onClick={() => setParent("AC")} />
+      <button type="button" data-testid="parent-clear" onClick={() => setParent("")} />
+      {/* What `handleSaveConfig` would POST. `undefined` drops out of JSON
+          exactly as it does on the wire, so a deleted key shows up as absent. */}
+      <output data-testid="config-json">{JSON.stringify(values)}</output>
+      <SchemaForm
+        schema={schema}
+        values={values}
+        pluginId={pluginId}
+        onChange={(next) => {
+          setEdited(next);
+          onChange?.(next);
+        }}
+      />
+    </>
+  );
+}
+
+function ColdOpenHarness({
+  schema,
+  stored,
+  pluginId = "muni",
+  onChange,
+}: {
+  schema: JSONSchema;
+  stored: Record<string, unknown>;
+  pluginId?: string;
+  onChange?: (values: Record<string, unknown>) => void;
+}) {
+  const [client] = useState(() => new QueryClient({ defaultOptions: { queries: { retry: false } } }));
+  return (
+    <QueryClientProvider client={client}>
+      <ColdOpenForm schema={schema} stored={stored} pluginId={pluginId} onChange={onChange} />
+    </QueryClientProvider>
+  );
+}
+
+/** The config the dialog would save right now. */
+function savedConfig(): Record<string, unknown> {
+  return JSON.parse(screen.getByTestId("config-json").textContent || "{}");
+}
+
+/**
+ * What the named select's trigger currently shows.
+ *
+ * Not `findByText(label)`: the closed dropdown keeps its rows in the DOM, so
+ * an option's text is present whether or not it is the chosen one. Only the
+ * trigger says what the field actually holds.
+ */
+function selectedLabel(name: string): string {
+  return screen.getByRole("combobox", { name }).textContent?.trim() ?? "";
+}
+
+const dependentMultiSchema: JSONSchema = {
+  type: "object",
+  properties: {
+    agency: agencyField,
+    stop_codes: {
+      type: "array",
+      title: "Stops",
+      items: { type: "string" },
+      "ui:widget": "remote-options",
+      "ui:options": { options_id: "stops", depends_on: ["agency"], multiple: true },
+    },
+  },
+};
+
+/** Two agencies with disjoint catalogs, so a stop can never span both. */
+function mockTwoAgencies(): CapturedRequest[] {
+  const captured: CapturedRequest[] = [];
+  server.use(
+    http.post(OPTIONS_PATH, async ({ params, request }) => {
+      const body = (await request.json()) as CapturedRequest["body"];
+      captured.push({ pluginId: String(params.pluginId), optionsId: String(params.optionsId), body });
+      const agency = body.parent?.agency;
+      return HttpResponse.json({
+        plugin_id: String(params.pluginId),
+        options_id: String(params.optionsId),
+        options:
+          agency === "SF"
+            ? [{ value: "13915", label: "Market St & 5th" }]
+            : [{ value: "55555", label: "Broadway & 12th" }],
+        has_more: false,
+        cursor: null,
+        total: 1,
+        error: null,
+        cached: false,
+        stale: false,
+        cache_seconds: 300,
+      });
+    }),
+  );
+  return captured;
+}
+
+describe("RemoteOptionsField - cold-load hydration", () => {
+  it("keeps the stored dependent value when the config arrives after the first render", async () => {
+    const onChange = vi.fn();
+    const captured = mockOptions([{ value: "13915", label: "Market St & 5th" }]);
+
+    render(
+      <ColdOpenHarness schema={dependentSchema} stored={{ agency: "SF", stop_code: "13915" }} onChange={onChange} />,
+    );
+
+    // The catalog is only asked for once the parent has hydrated, so this also
+    // proves the empty first render really happened.
+    await waitFor(() => expect(captured).toHaveLength(1));
+    expect(captured[0].body.parent).toEqual({ agency: "SF" });
+    // Give every effect from the hydrating render time to run, so a value that
+    // is about to be wiped is not mistaken for one that survived.
+    await delay(30);
+
+    // The user touched nothing, so the form must write nothing back…
+    expect(onChange).not.toHaveBeenCalled();
+    // …and the stop the user saved is still in what the dialog would POST.
+    expect(savedConfig()).toEqual({ agency: "SF", stop_code: "13915" });
+    await waitFor(() => expect(selectedLabel("Stop")).toBe("Market St & 5th"));
+  });
+
+  it("keeps a stored multi-select dependent array when the config arrives after the first render", async () => {
+    const onChange = vi.fn();
+    const captured = mockOptions([
+      { value: "13915", label: "Market St & 5th" },
+      { value: "13916", label: "Market St & 6th" },
+    ]);
+
+    render(
+      <ColdOpenHarness
+        schema={dependentMultiSchema}
+        stored={{ agency: "SF", stop_codes: ["13915", "13916"] }}
+        onChange={onChange}
+      />,
+    );
+
+    await waitFor(() => expect(captured).toHaveLength(1));
+    await delay(30);
+
+    expect(onChange).not.toHaveBeenCalled();
+    // An emptied array is the multi-select shape of the same data loss.
+    expect(savedConfig()).toEqual({ agency: "SF", stop_codes: ["13915", "13916"] });
+    const chosen = await screen.findAllByTestId("remote-options-chosen");
+    expect(chosen.map((node) => node.textContent)).toEqual([
+      expect.stringContaining("Market St & 5th"),
+      expect.stringContaining("Market St & 6th"),
+    ]);
+  });
+
+  it("still drops the dependent value when the user changes the parent after hydration", async () => {
+    const user = userEvent.setup();
+    const captured = mockTwoAgencies();
+
+    render(<ColdOpenHarness schema={dependentSchema} stored={{ agency: "SF", stop_code: "13915" }} />);
+    await waitFor(() => expect(selectedLabel("Stop")).toBe("Market St & 5th"));
+
+    await user.click(screen.getByRole("combobox", { name: "Transit Agency" }));
+    await user.click(await screen.findByRole("option", { name: "AC Transit" }));
+
+    // A Muni stop cannot exist under AC Transit, so it goes.
+    await waitFor(() => expect(savedConfig()).toEqual({ agency: "AC" }));
+    await waitFor(() => expect(captured.at(-1)?.body.parent).toEqual({ agency: "AC" }));
+  });
+
+  it("keeps the dependent value when the user clears the parent", async () => {
+    const user = userEvent.setup();
+    mockOptions([{ value: "13915", label: "Market St & 5th" }]);
+
+    render(<ColdOpenHarness schema={dependentSchema} stored={{ agency: "SF", stop_code: "13915" }} />);
+    await waitFor(() => expect(selectedLabel("Stop")).toBe("Market St & 5th"));
+
+    await user.click(screen.getByTestId("parent-clear"));
+
+    expect(await screen.findByText("Select Transit Agency first")).toBeInTheDocument();
+    await delay(30);
+    // An unanswered parent says nothing about whether the stop is still valid.
+    // Dropping it here would punish a mis-click; it is dropped only once a
+    // *different* agency is actually chosen.
+    expect(savedConfig()).toEqual({ agency: "", stop_code: "13915" });
+  });
+
+  it("restores the dependent value when the cleared parent comes back unchanged", async () => {
+    const user = userEvent.setup();
+    mockOptions([{ value: "13915", label: "Market St & 5th" }]);
+
+    render(<ColdOpenHarness schema={dependentSchema} stored={{ agency: "SF", stop_code: "13915" }} />);
+    await waitFor(() => expect(selectedLabel("Stop")).toBe("Market St & 5th"));
+
+    await user.click(screen.getByTestId("parent-clear"));
+    expect(await screen.findByText("Select Transit Agency first")).toBeInTheDocument();
+    await user.click(screen.getByTestId("parent-sf"));
+
+    await waitFor(() => expect(selectedLabel("Stop")).toBe("Market St & 5th"));
+    expect(savedConfig()).toEqual({ agency: "SF", stop_code: "13915" });
+  });
+
+  it("drops the dependent value once a cleared parent is replaced by a different one", async () => {
+    const user = userEvent.setup();
+    mockTwoAgencies();
+
+    render(<ColdOpenHarness schema={dependentSchema} stored={{ agency: "SF", stop_code: "13915" }} />);
+    await waitFor(() => expect(selectedLabel("Stop")).toBe("Market St & 5th"));
+
+    await user.click(screen.getByTestId("parent-clear"));
+    expect(await screen.findByText("Select Transit Agency first")).toBeInTheDocument();
+    await user.click(screen.getByTestId("parent-ac"));
+
+    await waitFor(() => expect(savedConfig()).toEqual({ agency: "AC" }));
+  });
+});
+
+/**
+ * The route caps a catalog it considers too large and reports `has_more`. A cap
+ * the user cannot see is indistinguishable from "your option does not exist",
+ * so every truncated list has to say so — not only the server-searchable ones,
+ * which were the only case the hint used to cover.
+ */
+describe("RemoteOptionsField - truncated catalogs", () => {
+  it("says the list is incomplete when has_more is set and the plugin has no server search", async () => {
+    mockOptions([{ value: 16, label: "Magic Kingdom" }], { has_more: true, total: 3000 });
+
+    render(<Harness schema={singleSchema} initial={{ park_id: 16 }} />);
+
+    expect(await screen.findByText("Not all options are shown")).toBeInTheDocument();
+  });
+
+  it("keeps saying so when the list is only searchable client-side", async () => {
+    // Client-side search filters the truncated list; it cannot reach the rest.
+    const searchableSchema: JSONSchema = {
+      type: "object",
+      properties: {
+        park_id: {
+          type: "integer",
+          title: "Park",
+          "ui:widget": "remote-options",
+          "ui:options": { options_id: "parks", searchable: true },
+        },
+      },
+    };
+    mockOptions([{ value: 16, label: "Magic Kingdom" }], { has_more: true, total: 3000 });
+
+    render(<Harness schema={searchableSchema} initial={{ park_id: 16 }} />);
+
+    expect(await screen.findByText("Not all options are shown")).toBeInTheDocument();
+  });
+
+  it("prefers the refine-search hint when the plugin does search server-side", async () => {
+    const serverSearchSchema: JSONSchema = {
+      type: "object",
+      properties: {
+        park_id: {
+          type: "integer",
+          title: "Park",
+          "ui:widget": "remote-options",
+          "ui:options": { options_id: "parks", server_search: true },
+        },
+      },
+    };
+    mockOptions([{ value: 16, label: "Magic Kingdom" }], { has_more: true, total: 3000 });
+
+    render(<Harness schema={serverSearchSchema} initial={{ park_id: 16 }} />);
+
+    // Typing more really can return different rows here, so the actionable
+    // hint wins and the generic one must not also appear.
+    expect(await screen.findByText("Refine your search to see more")).toBeInTheDocument();
+    expect(screen.queryByText("Not all options are shown")).not.toBeInTheDocument();
+  });
+
+  it("stays quiet when the catalog is complete", async () => {
+    mockOptions([{ value: 16, label: "Magic Kingdom" }]);
+
+    render(<Harness schema={singleSchema} initial={{ park_id: 16 }} />);
+
+    await screen.findByText("Magic Kingdom");
+    expect(screen.queryByText("Not all options are shown")).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/plugin-settings/remote-options-field.tsx
+++ b/web/src/components/plugin-settings/remote-options-field.tsx
@@ -165,19 +165,34 @@ export function RemoteOptionsField({ name, property, value, onChange, disabled }
   });
 
   // A value chosen under one parent cannot be assumed to exist under another
-  // (stop 13915 is a Muni stop, not an AC Transit one), so switching the parent
-  // drops it instead of persisting something the plugin will fail to resolve.
+  // (stop 13915 is a Muni stop, not an AC Transit one), so moving from one
+  // answered parent to a *different* answered parent drops it instead of
+  // persisting something the plugin will fail to resolve.
+  //
+  // Only answered parents are remembered, and that is the whole point: a form
+  // may render before its saved config has loaded — `InstalledPluginRow` mounts
+  // `SchemaForm` with `{}` and fills it in from a `useEffect` — so a dependency
+  // going from *unanswered* to *answered* is hydration, not the user changing
+  // anything, and must leave the stored value alone. (Comparing raw parent keys
+  // instead deleted the saved child value on every cold dialog open; reopening
+  // it in the same session hid the bug, because react-query then had the config
+  // cached and the empty first render never happened.) The same rule means
+  // clearing a parent keeps the child until a different parent is actually
+  // chosen, so a mis-click costs nothing.
   const parentKey = JSON.stringify(parent);
   const multiple = Boolean(ui.multiple);
   const hasValue = multiple ? Array.isArray(value) && value.length > 0 : isAnswered(value);
   // `onChange` gets a new identity every render, so the effect re-runs often;
   // the recorded key is what makes it a no-op unless the parent really moved.
-  const lastParentKey = useRef(parentKey);
+  const lastSatisfiedParentKey = useRef<string | null>(dependsSatisfied ? parentKey : null);
   useEffect(() => {
-    if (lastParentKey.current === parentKey) return;
-    lastParentKey.current = parentKey;
+    if (!dependsSatisfied) return;
+    const previous = lastSatisfiedParentKey.current;
+    lastSatisfiedParentKey.current = parentKey;
+    // `null` is "we have never seen this field scoped" — nothing to invalidate.
+    if (previous === null || previous === parentKey) return;
     if (hasValue) onChange(multiple ? [] : undefined);
-  }, [parentKey, hasValue, multiple, onChange]);
+  }, [dependsSatisfied, parentKey, hasValue, multiple, onChange]);
 
   const options = query.data?.options ?? [];
   const scalarType = ui.multiple ? property.items?.type : property.type;
@@ -541,9 +556,13 @@ function FieldNotes({
           {t("remoteOptionsStale")}
         </Text>
       )}
-      {data.has_more && serverSearch && (
+      {/* A cap the user cannot see is indistinguishable from "your option does
+          not exist", so every truncated catalog says so. Only `server_search`
+          can actually reach the rest — client-side search just filters what
+          already arrived — so only it gets the "narrow it down" wording. */}
+      {data.has_more && (
         <Text size="xs" tone="muted">
-          {t("remoteOptionsRefineSearch")}
+          {serverSearch ? t("remoteOptionsRefineSearch") : t("remoteOptionsTruncated")}
         </Text>
       )}
     </Stack>


### PR DESCRIPTION
## The bug

A `remote-options` field that declares `depends_on` silently deleted its stored
value on a cold dialog open, and the deletion was written to disk on the next
Save.

With `city: "new_orleans"` on disk, opening the plugin settings dialog on a cold
page load rendered the placeholder "Choose a city" instead of the stored value.
Pressing Save without touching anything:

```
old_keys=['channels','city','region','station']
new_keys=['channels','region','station']
```

## Why it only reproduces on a cold load

`InstalledPluginRow` (`web/app/routes/integrations._index.tsx`) mounts
`SchemaForm` with `configValues` still `{}` and only seeds it from a
`useEffect` once the `["plugin", id]` query resolves. So the first render the
widget sees has no config at all:

- render 1 — `parent = {region: null}`, dependencies unanswered
- render 2 — `parent = {region: 27}`, dependencies answered

The widget compared raw parent keys and treated any change as "the user picked a
different parent", so it cleared the child value.

Reopening the dialog inside the same session is fine: react-query answers
`["plugin", id]` from cache, the config is present on the very first render, and
the empty state never happens. That is why it looked intermittent — and why the
existing MSW tests missed it, since they all mount with values already in place.

## The fix

`web/src/components/plugin-settings/remote-options-field.tsx` now remembers only
*answered* parent states:

| transition | meaning | child value |
| --- | --- | --- |
| unanswered → answered | hydration (or the user answering the parent for the first time) | kept |
| answered A → answered B | a real parent change | cleared |
| answered → unanswered | the user cleared the parent | kept |
| unanswered → the same answered value | mis-click undone | kept (restored) |

The clearing behaviour that motivated the original code is preserved: a stop
chosen under SF Muni is still dropped the moment the agency becomes AC Transit,
because that value provably cannot resolve under the new parent.

Clearing the parent deliberately keeps the child. An unanswered parent says
nothing about whether the child is still valid, the field is inert while the
parent is blank, and the value is dropped as soon as a *different* parent is
actually chosen — so nothing invalid can be saved under a new parent, and a
mis-click costs nothing.

### Why the widget and not the call site

The call site could have been fixed instead — not rendering `SchemaForm` until
the config has hydrated, or keying it on the loaded config. That fixes today's
only caller and leaves the widget still unable to tell hydration from a real
change, so any future caller that mounts the form before its data arrives
(another dialog, an SSR pass, a form that streams defaults in) reintroduces
silent data loss. The invariant belongs in the widget, so it holds regardless of
how the form is mounted. `integrations._index.tsx` is unchanged.

## Second issue: silently truncated option lists

The options route caps large catalogs and reports `has_more: true` (3000 options
→ 200 returned), but the "Refine your search to see more" hint was gated on
`has_more && server_search`. A plain large list without `server_search` arrived
silently cut with no affordance at all — Disney's attraction lists hit this.

Every truncated catalog now says so. `server_search` keeps the actionable
"Refine your search to see more", because typing really can return different
rows there; everything else — including client-side `searchable`, which can only
filter what already arrived — gets "Not all options are shown". Added to all 14
locales.

## Tests

All eight new tests were written first and watched fail.

`RemoteOptionsField - cold-load hydration` mounts the form the way the dialog
really does — a query that resolves after the first render — instead of handing
it values that are already there:

- keeps the stored dependent value when the config arrives after the first render
- keeps a stored multi-select dependent array when the config arrives after the first render
- still drops the dependent value when the user changes the parent after hydration
- keeps the dependent value when the user clears the parent
- restores the dependent value when the cleared parent comes back unchanged
- drops the dependent value once a cleared parent is replaced by a different one

`RemoteOptionsField - truncated catalogs` covers the `has_more` affordance with
and without `server_search`, and its absence on a complete catalog.

The tests assert on the JSON the dialog would POST, so a deleted key shows up
exactly as it does on the wire.

### RED before the fix

```
 × keeps the stored dependent value when the config arrives after the first render
 × keeps a stored multi-select dependent array when the config arrives after the first render
 × still drops the dependent value when the user changes the parent after hydration
 × keeps the dependent value when the user clears the parent
 × restores the dependent value when the cleared parent comes back unchanged
 × drops the dependent value once a cleared parent is replaced by a different one
 × says the list is incomplete when has_more is set and the plugin has no server search
 × keeps saying so when the list is only searchable client-side

AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times

Received:

  1st vi.fn() call:

    Array [
      Object {
        "agency": "SF",
        "stop_code": undefined,
      },
    ]

AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times

  1st vi.fn() call:

    Array [
      Object {
        "agency": "SF",
        "stop_codes": Array [],
      },
    ]

AssertionError: expected 'Select an option…' to be 'Market St & 5th' // Object.is equality
TestingLibraryElementError: Unable to find an element with the text: Not all options are shown.

      Tests  8 failed | 33 passed (41)
```

The first failure is the reported bug verbatim: `stop_code: undefined` is the
key that disappears from the saved config.

### Mutation checks on the tests that already passed

Two of the new tests guard existing behaviour, so they were green before the
change. Breaking that behaviour on purpose fails them:

- rendering the truncation notice unconditionally instead of choosing on
  `serverSearch` → `× prefers the refine-search hint when the plugin does search
  server-side` and `× invites the user to narrow the search when a
  server-searched catalog is truncated`
- rendering it regardless of `has_more` → `× stays quiet when the catalog is
  complete`
- removing the clear entirely (an over-correction of this fix) → `× still drops
  the dependent value when the user changes the parent after hydration`,
  `× drops the dependent value once a cleared parent is replaced by a different
  one`, and the pre-existing `× refetches for the new parent and drops the
  now-stale child value` (`AssertionError: expected '13915' to be undefined`)

### Verification

- `npm run test:run` ×3 — `113 files, 1449 passed | 13 skipped (1462)` each time (baseline `1439 passed | 13 skipped`)
- new test file ×10 — `41 passed (41)` every run, no flake
- `npm run test:coverage` — statements 87.64%, branches 83.65%, functions 82.70%, lines 88.88% (80% thresholds)
- `npm run lint` — 0 errors, 406 warnings (identical to baseline)
- `npm run format:check` — clean
- `npm run typecheck` — 137 errors before and after (unchanged pre-existing baseline; CI does not typecheck `web/`)
