### PR TITLE
feat(plugins): per-choice display names for remote-options (labels_field)

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -90,6 +90,7 @@
     "retags",
     "rfkill",
     "rounddown",
+    "sanitisation",
     "scrobbling",
     "stardate",
     "streamflow",

--- a/docs/development/PLUGIN_DEVELOPMENT.md
+++ b/docs/development/PLUGIN_DEVELOPMENT.md
@@ -420,7 +420,7 @@ No core change is needed for a new plugin.
 }
 ```
 
-`ui:options` accepts exactly these nine keys — anything else is a validation
+`ui:options` accepts exactly these ten keys — anything else is a validation
 error, because a silently-ignored typo is how a picker ships without ever
 calling your plugin:
 
@@ -435,6 +435,61 @@ calling your plugin:
 | `reorderable` | Up/down arrows on the chosen items. Boolean. Requires `multiple`. |
 | `allow_custom` | Accept a typed value the catalog does not offer. Boolean. |
 | `placeholder` | Trigger placeholder text. String. |
+| `labels_field` | Name of a sibling property collecting a short display name per chosen option. String. Requires `multiple`. |
+
+### Per-choice display names (`labels_field`)
+
+A board row is 22 tiles wide, so "Seven Dwarfs Mine Train" has to be shortened
+before it will fit. `labels_field` gives every *chosen* row of a multi-select a
+small text box, and collects what the user types into the sibling property it
+names — a plain object keyed by the option's value:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "ride_ids": {
+      "type": "array",
+      "title": "Rides",
+      "items": { "type": "integer" },
+      "ui:widget": "remote-options",
+      "ui:options": { "options_id": "rides", "multiple": true, "labels_field": "custom_names" }
+    },
+    "custom_names": {
+      "type": "object",
+      "title": "Custom ride names",
+      "additionalProperties": { "type": "string" }
+    }
+  }
+}
+```
+
+```python
+custom_names = self.config.get("custom_names") or {}
+label = custom_names.get(str(ride_id)) or ride.name
+```
+
+Rules, all enforced at manifest validation time:
+
+- `labels_field` must be a string naming a property declared **in the same
+  object** as the picker. On an array row that means a property of the row, not
+  a same-named one at the root
+- it requires `"multiple": true` — a single choice is already named by the
+  field's own title, and the widget renders no box for it
+
+**Keys are always the value stringified.** Look them up as `str(value)` in
+Python, exactly as above: the widget writes `String(value)` whatever the
+declared item type is, so integer option values arrive as `"284"`, not `284`.
+Indexing with the raw integer happens to work through a JSON round trip in
+JavaScript and does not in Python.
+
+Removing a chosen row deletes that one key; reordering rows changes nothing,
+because the map is keyed by value rather than by position. A name for a value
+the catalog no longer offers is kept, not pruned — the catalog going quiet is
+not the user un-choosing anything.
+
+The sibling is an ordinary schema property and the settings form still renders
+it as one, so give it a `title` that reads sensibly on its own.
 
 Then implement `get_options()` — one method serves every `options_id`:
 

--- a/src/plugins/manifest.py
+++ b/src/plugins/manifest.py
@@ -58,7 +58,8 @@ OPTIONS_ID_RE = re.compile(r"^[a-z][a-z0-9_]*$")
 # "requires type 'array'" rule, which a stricter type check would double up on.
 UI_OPTIONS_BOOLEAN_KEYS = frozenset({"searchable", "server_search", "reorderable", "allow_custom"})
 UI_OPTIONS_KEYS = (
-    frozenset({"options_id", "depends_on", "multiple", "cache_seconds", "placeholder"}) | UI_OPTIONS_BOOLEAN_KEYS
+    frozenset({"options_id", "depends_on", "multiple", "cache_seconds", "placeholder", "labels_field"})
+    | UI_OPTIONS_BOOLEAN_KEYS
 )
 
 # How long the UI may reuse a fetched option list. Zero means "never cache";
@@ -844,6 +845,27 @@ def validate_settings_schema_ui(settings_schema: dict[str, Any]) -> list[str]:
             errors.append(
                 f"settings_schema.{field_path}: ui:options.multiple requires type 'array', got {prop.get('type')!r}"
             )
+
+        # ``labels_field`` is the one key that makes the widget write *outside*
+        # its own property: it names the sibling that collects the per-choice
+        # display names, keyed by option value. That sibling therefore has to
+        # exist in the same object schema, and there has to be more than one
+        # choice for the names to be worth keying.
+        labels_field = ui_options.get("labels_field")
+        if labels_field is not None:
+            if not isinstance(labels_field, str):
+                errors.append(
+                    f"settings_schema.{field_path}: ui:options.labels_field must be a string, got {labels_field!r}"
+                )
+            elif labels_field not in siblings:
+                # Siblings only, unlike ``depends_on``: this is a write target,
+                # and the widget writes into the object its own key lives in.
+                errors.append(
+                    f"settings_schema.{field_path}: ui:options.labels_field "
+                    f"references unknown property '{labels_field}'"
+                )
+            if not ui_options.get("multiple"):
+                errors.append(f"settings_schema.{field_path}: ui:options.labels_field requires ui:options.multiple")
 
         if ui_options.get("reorderable") and not ui_options.get("multiple"):
             errors.append(f"settings_schema.{field_path}: ui:options.reorderable requires ui:options.multiple")

--- a/tests/test_plugin_options.py
+++ b/tests/test_plugin_options.py
@@ -321,6 +321,116 @@ def test_depends_on_may_reference_a_root_property_from_a_nested_field():
     assert validate_settings_schema_ui(schema) == []
 
 
+def test_labels_field_naming_a_sibling_of_a_multi_select_is_accepted():
+    """``labels_field`` lets a multi-select carry a per-choice display name.
+
+    The names land in the *sibling* property it points at, keyed by option
+    value, so the sibling has to be declared alongside the picker.
+    """
+    schema = {
+        "type": "object",
+        "properties": {
+            "ride_ids": {
+                "type": "array",
+                "ui:widget": "remote-options",
+                "ui:options": {"options_id": "rides", "multiple": True, "labels_field": "custom_names"},
+            },
+            "custom_names": {"type": "object"},
+        },
+    }
+
+    assert validate_settings_schema_ui(schema) == []
+
+
+def test_labels_field_must_be_a_string():
+    """It is a property *name*; anything else cannot be looked up at all."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "ride_ids": {
+                "type": "array",
+                "ui:widget": "remote-options",
+                "ui:options": {"options_id": "rides", "multiple": True, "labels_field": True},
+            },
+            "custom_names": {"type": "object"},
+        },
+    }
+
+    errors = validate_settings_schema_ui(schema)
+
+    assert errors == ["settings_schema.ride_ids: ui:options.labels_field must be a string, got True"]
+
+
+def test_labels_field_must_name_a_declared_sibling_property():
+    """The names are written into that sibling, so a typo silently discards
+    every display name the user types."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "ride_ids": {
+                "type": "array",
+                "ui:widget": "remote-options",
+                "ui:options": {"options_id": "rides", "multiple": True, "labels_field": "custom_nmaes"},
+            },
+            "custom_names": {"type": "object"},
+        },
+    }
+
+    errors = validate_settings_schema_ui(schema)
+
+    assert errors == ["settings_schema.ride_ids: ui:options.labels_field references unknown property 'custom_nmaes'"]
+
+
+def test_labels_field_sibling_is_resolved_inside_the_array_item_not_at_the_root():
+    """A picker on an array row writes into *that row*, so a same-named root
+    property is not the sibling it means."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "custom_names": {"type": "object"},
+            "rows": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "ride_ids": {
+                            "type": "array",
+                            "ui:widget": "remote-options",
+                            "ui:options": {"options_id": "rides", "multiple": True, "labels_field": "custom_names"},
+                        }
+                    },
+                },
+            },
+        },
+    }
+
+    errors = validate_settings_schema_ui(schema)
+
+    assert errors == [
+        "settings_schema.rows.items.ride_ids: ui:options.labels_field references unknown property 'custom_names'"
+    ]
+
+
+def test_labels_field_without_multiple_is_an_error():
+    """A single choice has nothing to key a map of names by — the field's own
+    title already names it, and the widget renders no label input at all."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "ride_id": {
+                "type": "string",
+                "ui:widget": "remote-options",
+                "ui:options": {"options_id": "rides", "labels_field": "custom_names"},
+            },
+            "custom_names": {"type": "object"},
+        },
+    }
+
+    errors = validate_settings_schema_ui(schema)
+
+    assert errors == ["settings_schema.ride_id: ui:options.labels_field requires ui:options.multiple"]
+
+
 def test_validation_recurses_into_array_item_properties():
     """Most real pickers live on array item fields, not at the root."""
     schema = {

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -1711,6 +1711,8 @@
     "remoteOptionsAdd": "Hinzufügen…",
     "remoteOptionsAddLabel": "Option hinzufügen",
     "remoteOptionsRemove": "{label} entfernen",
+    "remoteOptionsLabelFor": "Anzeigename für {label}",
+    "remoteOptionsLabelPlaceholder": "Kurzname",
     "remoteOptionsMoveUp": "{label} nach oben verschieben",
     "remoteOptionsMoveDown": "{label} nach unten verschieben",
     "remoteOptionsSearchLabel": "Optionen durchsuchen",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1668,6 +1668,8 @@
     "remoteOptionsAdd": "Add…",
     "remoteOptionsAddLabel": "Add option",
     "remoteOptionsRemove": "Remove {label}",
+    "remoteOptionsLabelFor": "Display name for {label}",
+    "remoteOptionsLabelPlaceholder": "Short name",
     "remoteOptionsMoveUp": "Move {label} up",
     "remoteOptionsMoveDown": "Move {label} down",
     "remoteOptionsSearchLabel": "Search options",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -1711,6 +1711,8 @@
     "remoteOptionsAdd": "Añadir…",
     "remoteOptionsAddLabel": "Añadir opción",
     "remoteOptionsRemove": "Eliminar {label}",
+    "remoteOptionsLabelFor": "Nombre visible de {label}",
+    "remoteOptionsLabelPlaceholder": "Nombre corto",
     "remoteOptionsMoveUp": "Mover {label} hacia arriba",
     "remoteOptionsMoveDown": "Mover {label} hacia abajo",
     "remoteOptionsSearchLabel": "Buscar opciones",

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -1711,6 +1711,8 @@
     "remoteOptionsAdd": "Ajouter…",
     "remoteOptionsAddLabel": "Ajouter une option",
     "remoteOptionsRemove": "Supprimer {label}",
+    "remoteOptionsLabelFor": "Nom affiché pour {label}",
+    "remoteOptionsLabelPlaceholder": "Nom court",
     "remoteOptionsMoveUp": "Déplacer {label} vers le haut",
     "remoteOptionsMoveDown": "Déplacer {label} vers le bas",
     "remoteOptionsSearchLabel": "Rechercher des options",

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -1711,6 +1711,8 @@
     "remoteOptionsAdd": "Aggiungi…",
     "remoteOptionsAddLabel": "Aggiungi opzione",
     "remoteOptionsRemove": "Rimuovi {label}",
+    "remoteOptionsLabelFor": "Nome visualizzato per {label}",
+    "remoteOptionsLabelPlaceholder": "Nome breve",
     "remoteOptionsMoveUp": "Sposta {label} in alto",
     "remoteOptionsMoveDown": "Sposta {label} in basso",
     "remoteOptionsSearchLabel": "Cerca tra le opzioni",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -1711,6 +1711,8 @@
     "remoteOptionsAdd": "追加…",
     "remoteOptionsAddLabel": "オプションを追加",
     "remoteOptionsRemove": "{label}を削除",
+    "remoteOptionsLabelFor": "{label}の表示名",
+    "remoteOptionsLabelPlaceholder": "短い名前",
     "remoteOptionsMoveUp": "{label}を上に移動",
     "remoteOptionsMoveDown": "{label}を下に移動",
     "remoteOptionsSearchLabel": "オプションを検索",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -1711,6 +1711,8 @@
     "remoteOptionsAdd": "추가…",
     "remoteOptionsAddLabel": "옵션 추가",
     "remoteOptionsRemove": "{label} 제거",
+    "remoteOptionsLabelFor": "{label}의 표시 이름",
+    "remoteOptionsLabelPlaceholder": "짧은 이름",
     "remoteOptionsMoveUp": "{label} 위로 이동",
     "remoteOptionsMoveDown": "{label} 아래로 이동",
     "remoteOptionsSearchLabel": "옵션 검색",

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -1711,6 +1711,8 @@
     "remoteOptionsAdd": "Toevoegen…",
     "remoteOptionsAddLabel": "Optie toevoegen",
     "remoteOptionsRemove": "{label} verwijderen",
+    "remoteOptionsLabelFor": "Weergavenaam voor {label}",
+    "remoteOptionsLabelPlaceholder": "Korte naam",
     "remoteOptionsMoveUp": "{label} omhoog verplaatsen",
     "remoteOptionsMoveDown": "{label} omlaag verplaatsen",
     "remoteOptionsSearchLabel": "Opties zoeken",

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -1711,6 +1711,8 @@
     "remoteOptionsAdd": "Dodaj…",
     "remoteOptionsAddLabel": "Dodaj opcję",
     "remoteOptionsRemove": "Usuń: {label}",
+    "remoteOptionsLabelFor": "Nazwa wyświetlana dla {label}",
+    "remoteOptionsLabelPlaceholder": "Krótka nazwa",
     "remoteOptionsMoveUp": "Przenieś {label} w górę",
     "remoteOptionsMoveDown": "Przenieś {label} w dół",
     "remoteOptionsSearchLabel": "Szukaj opcji",

--- a/web/messages/pt.json
+++ b/web/messages/pt.json
@@ -1711,6 +1711,8 @@
     "remoteOptionsAdd": "Adicionar…",
     "remoteOptionsAddLabel": "Adicionar opção",
     "remoteOptionsRemove": "Remover {label}",
+    "remoteOptionsLabelFor": "Nome exibido para {label}",
+    "remoteOptionsLabelPlaceholder": "Nome curto",
     "remoteOptionsMoveUp": "Mover {label} para cima",
     "remoteOptionsMoveDown": "Mover {label} para baixo",
     "remoteOptionsSearchLabel": "Pesquisar opções",

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -1711,6 +1711,8 @@
     "remoteOptionsAdd": "Добавить…",
     "remoteOptionsAddLabel": "Добавить вариант",
     "remoteOptionsRemove": "Удалить: {label}",
+    "remoteOptionsLabelFor": "Отображаемое имя для {label}",
+    "remoteOptionsLabelPlaceholder": "Краткое имя",
     "remoteOptionsMoveUp": "Переместить {label} вверх",
     "remoteOptionsMoveDown": "Переместить {label} вниз",
     "remoteOptionsSearchLabel": "Поиск вариантов",

--- a/web/messages/sv.json
+++ b/web/messages/sv.json
@@ -1711,6 +1711,8 @@
     "remoteOptionsAdd": "Lägg till…",
     "remoteOptionsAddLabel": "Lägg till alternativ",
     "remoteOptionsRemove": "Ta bort {label}",
+    "remoteOptionsLabelFor": "Visningsnamn för {label}",
+    "remoteOptionsLabelPlaceholder": "Kort namn",
     "remoteOptionsMoveUp": "Flytta {label} uppåt",
     "remoteOptionsMoveDown": "Flytta {label} nedåt",
     "remoteOptionsSearchLabel": "Sök bland alternativ",

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -1711,6 +1711,8 @@
     "remoteOptionsAdd": "Ekle…",
     "remoteOptionsAddLabel": "Seçenek ekle",
     "remoteOptionsRemove": "{label} ögesini kaldır",
+    "remoteOptionsLabelFor": "{label} için görünen ad",
+    "remoteOptionsLabelPlaceholder": "Kısa ad",
     "remoteOptionsMoveUp": "{label} ögesini yukarı taşı",
     "remoteOptionsMoveDown": "{label} ögesini aşağı taşı",
     "remoteOptionsSearchLabel": "Seçeneklerde ara",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -1711,6 +1711,8 @@
     "remoteOptionsAdd": "添加…",
     "remoteOptionsAddLabel": "添加选项",
     "remoteOptionsRemove": "移除{label}",
+    "remoteOptionsLabelFor": "{label}的显示名称",
+    "remoteOptionsLabelPlaceholder": "简称",
     "remoteOptionsMoveUp": "上移{label}",
     "remoteOptionsMoveDown": "下移{label}",
     "remoteOptionsSearchLabel": "搜索选项",

--- a/web/src/__tests__/remote-options-field.test.tsx
+++ b/web/src/__tests__/remote-options-field.test.tsx
@@ -1083,3 +1083,291 @@ describe("RemoteOptionsField - truncated catalogs", () => {
     expect(screen.queryByText("Not all options are shown")).not.toBeInTheDocument();
   });
 });
+
+/**
+ * `labels_field` — a per-choice display name.
+ *
+ * A board row is 22 tiles wide, so "Seven Dwarfs Mine Train" has to be
+ * shortened before it can be shown. The widget therefore lets each *chosen*
+ * row carry a short name, and writes those names into the sibling property the
+ * manifest names — the only case where this widget writes outside its own key.
+ *
+ * The map is keyed by `String(value)` because that is what the plugin reads:
+ * Disney's does `custom_names.get(str(ride_id))` against integer ride ids.
+ */
+const RIDES: MockOption[] = [
+  { value: 279, label: "Space Mountain" },
+  { value: 284, label: "Seven Dwarfs Mine Train" },
+  { value: 291, label: "Big Thunder Mountain Railroad" },
+];
+
+function labelledSchema(uiOptions: Record<string, unknown> = {}): JSONSchema {
+  return {
+    type: "object",
+    properties: {
+      ride_ids: {
+        type: "array",
+        title: "Rides",
+        items: { type: "integer" },
+        "ui:widget": "remote-options",
+        "ui:options": { options_id: "rides", multiple: true, labels_field: "custom_names", ...uiOptions },
+      },
+      custom_names: { type: "object", title: "Custom ride names" },
+    },
+  };
+}
+
+describe("RemoteOptionsField - labels_field", () => {
+  it("writes a typed display name into the sibling map under the option's value", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    mockOptions(RIDES);
+
+    render(
+      <Harness
+        schema={labelledSchema()}
+        initial={{ ride_ids: [279], custom_names: {} }}
+        pluginId="disney-parks-times"
+        onChange={onChange}
+      />,
+    );
+
+    await user.type(await screen.findByRole("textbox", { name: "Display name for Space Mountain" }), "SPACE MTN");
+
+    const last = onChange.mock.calls.at(-1)?.[0] as { ride_ids: unknown; custom_names: unknown };
+    expect(last.custom_names).toEqual({ "279": "SPACE MTN" });
+    // The picker's own value is untouched: the label rides alongside it, and a
+    // write that replaced the selection would be a data-loss bug.
+    expect(last.ride_ids).toEqual([279]);
+  });
+
+  it("renders no label input at all when the manifest does not ask for one", async () => {
+    mockOptions(TICKERS);
+
+    render(<Harness schema={multiSchema()} initial={{ symbols: ["AAPL"] }} pluginId="stocks" />);
+
+    await screen.findByText("Apple Inc.");
+    // Every other multi-select must be untouched by this capability — the
+    // widget writing outside its own key is opt-in, and so is the extra input.
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+  });
+
+  /**
+   * The Disney-shaped case, and the one that has bitten before: the picker
+   * lives on an array *row*, its values are integers, and the plugin reads the
+   * map back with `custom_names.get(str(ride_id))`. The key therefore has to be
+   * the stringified value, and the row's own `custom_names` — not a same-named
+   * property at the root — is what gets written.
+   */
+  it("keys the map by the stringified value when the option values are integers", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    mockOptions(RIDES);
+    const disneySchema: JSONSchema = {
+      type: "object",
+      properties: {
+        parks: {
+          type: "array",
+          title: "Parks and rides",
+          items: {
+            type: "object",
+            properties: {
+              ride_ids: {
+                type: "array",
+                title: "Rides",
+                items: { type: "integer" },
+                "ui:widget": "remote-options",
+                "ui:options": { options_id: "rides", multiple: true, labels_field: "custom_names" },
+              },
+              custom_names: { type: "object", title: "Custom ride names" },
+            },
+          },
+        },
+      },
+    };
+
+    render(
+      <Harness
+        schema={disneySchema}
+        initial={{ parks: [{ ride_ids: [279, 284], custom_names: {} }] }}
+        pluginId="disney-parks-times"
+        onChange={onChange}
+      />,
+    );
+
+    await user.type(
+      await screen.findByRole("textbox", { name: "Display name for Seven Dwarfs Mine Train" }),
+      "MINE TRAIN",
+    );
+
+    const last = onChange.mock.calls.at(-1)?.[0] as { parks: { ride_ids: unknown; custom_names: unknown }[] };
+    // Serialised, because what reaches the plugin is JSON: a Map here would
+    // stringify to `{}`, and a numeric key would have to survive as `"284"`.
+    expect(JSON.stringify(last.parks[0])).toBe('{"ride_ids":[279,284],"custom_names":{"284":"MINE TRAIN"}}');
+    expect(Object.keys(last.parks[0].custom_names as object)).toEqual(["284"]);
+    // The selection is still integers — the schema's declared type, and what
+    // the plugin's own ride lookups use.
+    expect(last.parks[0].ride_ids).toEqual([279, 284]);
+  });
+
+  it("hydrates the inputs from display names already in the stored config", async () => {
+    mockOptions(RIDES);
+
+    render(
+      <Harness
+        schema={labelledSchema()}
+        // Integer values, string keys — the shape that comes back from JSON.
+        initial={{ ride_ids: [279, 284], custom_names: { "279": "SPACE MTN", "284": "MINE TRAIN" } }}
+        pluginId="disney-parks-times"
+      />,
+    );
+
+    expect(await screen.findByRole("textbox", { name: "Display name for Space Mountain" })).toHaveValue("SPACE MTN");
+    expect(screen.getByRole("textbox", { name: "Display name for Seven Dwarfs Mine Train" })).toHaveValue("MINE TRAIN");
+  });
+
+  it("drops only the removed row's display name, leaving the others alone", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    mockOptions(RIDES);
+
+    render(
+      <Harness
+        schema={labelledSchema()}
+        initial={{
+          ride_ids: [279, 284, 291],
+          custom_names: { "279": "SPACE MTN", "284": "MINE TRAIN", "291": "BIG THUNDER" },
+        }}
+        pluginId="disney-parks-times"
+        onChange={onChange}
+      />,
+    );
+
+    await user.click(await screen.findByRole("button", { name: "Remove Seven Dwarfs Mine Train" }));
+
+    const last = onChange.mock.calls.at(-1)?.[0] as { ride_ids: unknown; custom_names: unknown };
+    // A name for a ride that is no longer chosen is dead weight the plugin
+    // would carry forever…
+    expect(last.custom_names).toEqual({ "279": "SPACE MTN", "291": "BIG THUNDER" });
+    // …but the other two rides keep theirs, and the removal itself still works.
+    expect(last.ride_ids).toEqual([279, 291]);
+  });
+
+  it("forgets a display name the user clears instead of storing an empty one", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    mockOptions(RIDES);
+
+    render(
+      <Harness
+        schema={labelledSchema()}
+        initial={{ ride_ids: [279, 284], custom_names: { "279": "SPACE MTN", "284": "MINE TRAIN" } }}
+        pluginId="disney-parks-times"
+        onChange={onChange}
+      />,
+    );
+
+    await user.clear(await screen.findByRole("textbox", { name: "Display name for Space Mountain" }));
+
+    const last = onChange.mock.calls.at(-1)?.[0] as { custom_names: unknown };
+    // "" is not a display name — keeping it would grow the stored config with
+    // entries that mean exactly what an absent key already means.
+    expect(last.custom_names).toEqual({ "284": "MINE TRAIN" });
+  });
+
+  it("leaves the display names untouched when the chosen rows are reordered", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    mockOptions(RIDES);
+    const stored = { "279": "SPACE MTN", "284": "MINE TRAIN" };
+
+    render(
+      <Harness
+        schema={labelledSchema({ reorderable: true })}
+        initial={{ ride_ids: [279, 284], custom_names: stored }}
+        pluginId="disney-parks-times"
+        onChange={onChange}
+      />,
+    );
+
+    await user.click(await screen.findByRole("button", { name: "Move Space Mountain down" }));
+
+    const last = onChange.mock.calls.at(-1)?.[0] as { ride_ids: unknown; custom_names: unknown };
+    expect(last.ride_ids).toEqual([284, 279]);
+    // The map is keyed by value, not by position, so reordering has nothing to
+    // say about it — and each row's input still shows its own name.
+    expect(last.custom_names).toEqual(stored);
+    expect(screen.getByRole("textbox", { name: "Display name for Space Mountain" })).toHaveValue("SPACE MTN");
+    expect(screen.getByRole("textbox", { name: "Display name for Seven Dwarfs Mine Train" })).toHaveValue("MINE TRAIN");
+  });
+
+  it("keeps a display name for a value the catalog no longer offers", async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    mockOptions(RIDES);
+
+    render(
+      <Harness
+        schema={labelledSchema()}
+        // 999 was closed since the config was saved: it is still chosen, and
+        // still named, but the catalog has never heard of it.
+        initial={{ ride_ids: [279, 999], custom_names: { "279": "SPACE MTN", "999": "OLD RIDE" } }}
+        pluginId="disney-parks-times"
+        onChange={onChange}
+      />,
+    );
+
+    // Assert only once the catalog has arrived — until then *every* row is
+    // unrecognised, which would pass this vacuously.
+    const known = await screen.findByRole("textbox", { name: "Display name for Space Mountain" });
+    // Rendering it at all is the first half: the row shows as its own value…
+    expect(screen.getByRole("textbox", { name: "Display name for 999" })).toHaveValue("OLD RIDE");
+    // …and nothing is rewritten behind the user's back just by opening the form.
+    expect(onChange).not.toHaveBeenCalled();
+
+    // Editing a *different* row must carry the orphaned name through untouched
+    // rather than quietly pruning it on the next save.
+    await user.type(known, "!");
+
+    const last = onChange.mock.calls.at(-1)?.[0] as { custom_names: unknown };
+    expect(last.custom_names).toEqual({ "279": "SPACE MTN!", "999": "OLD RIDE" });
+  });
+
+  /**
+   * The cold-open case, mandatory for anything in this file that touches
+   * stored config: `InstalledPluginRow` mounts the form with `{}` and fills it
+   * in when the `["plugin", id]` query resolves. A widget that reconciled its
+   * label map in an effect would see "no rides chosen, but names stored" on
+   * that first render and prune every name the user had saved.
+   */
+  it("keeps stored display names when the config arrives after the first render", async () => {
+    const onChange = vi.fn();
+    const captured = mockOptions(RIDES);
+
+    render(
+      <ColdOpenHarness
+        schema={labelledSchema()}
+        stored={{ ride_ids: [279, 284], custom_names: { "279": "SPACE MTN", "284": "MINE TRAIN" } }}
+        pluginId="disney-parks-times"
+        onChange={onChange}
+      />,
+    );
+
+    // The catalog is only fetched once, but the form definitely rendered empty
+    // first — the inputs below can only exist after hydration.
+    await waitFor(() => expect(captured).toHaveLength(1));
+    // Let every effect from the hydrating render run, so a map that is about to
+    // be wiped is not mistaken for one that survived.
+    await delay(30);
+
+    // The user touched nothing, so the form must write nothing back…
+    expect(onChange).not.toHaveBeenCalled();
+    // …and both names are still in what the dialog would POST.
+    expect(savedConfig()).toEqual({
+      ride_ids: [279, 284],
+      custom_names: { "279": "SPACE MTN", "284": "MINE TRAIN" },
+    });
+    expect(await screen.findByRole("textbox", { name: "Display name for Space Mountain" })).toHaveValue("SPACE MTN");
+    expect(screen.getByRole("textbox", { name: "Display name for Seven Dwarfs Mine Train" })).toHaveValue("MINE TRAIN");
+  });
+});

--- a/web/src/components/plugin-settings/remote-options-field.tsx
+++ b/web/src/components/plugin-settings/remote-options-field.tsx
@@ -109,6 +109,47 @@ export interface RemoteOptionsUiOptions {
   allow_custom?: boolean;
   cache_seconds?: number;
   placeholder?: string;
+  /**
+   * Name of a *sibling* property collecting a short display name per chosen
+   * option, keyed by `String(value)`. Multi-select only.
+   */
+  labels_field?: string;
+}
+
+/**
+ * Read the stored label map out of the sibling property.
+ *
+ * A `Map`, not a bare object, so the widget cannot look a label up by a raw
+ * numeric value and be rescued by JS coercing the key: stored config arrives
+ * from JSON with string keys, and every lookup has to go through
+ * {@link optionKey} to find them.
+ *
+ * Anything that is not a plain object — absent, `null`, a leftover array —
+ * reads as empty rather than throwing, because the widget must survive config
+ * written before the field existed. Entries whose value is not a string are
+ * not display names and are ignored.
+ */
+function readLabels(stored: unknown): Map<string, string> {
+  const labels = new Map<string, string>();
+  if (typeof stored !== "object" || stored === null || Array.isArray(stored)) return labels;
+  for (const [key, text] of Object.entries(stored as Record<string, unknown>)) {
+    if (typeof text === "string") labels.set(key, text);
+  }
+  return labels;
+}
+
+/**
+ * The canonical string key for an option value — what the catalog is indexed
+ * by, and what a `labels_field` map is keyed by.
+ *
+ * Explicitly stringified, because the plugin reads the map back with string
+ * keys: Disney's does `custom_names.get(str(ride_id))` while its option values
+ * are integers. Leaving the raw value in place would happen to survive being
+ * written into a JS object — keys coerce — but every lookup the widget itself
+ * does would then miss the string keys that came back from stored config.
+ */
+function optionKey(value: unknown): string {
+  return String(value);
 }
 
 /** The slice of a JSON-schema property this widget reads. */
@@ -124,7 +165,11 @@ export interface RemoteOptionsFieldProps {
   name: string;
   property: RemoteOptionsProperty;
   value: unknown;
-  onChange: (value: unknown) => void;
+  /**
+   * Commit the field's value, plus — only for `labels_field` — a patch of the
+   * sibling properties in the same object, applied in the same update.
+   */
+  onChange: (value: unknown, siblings?: Record<string, unknown>) => void;
   disabled?: boolean;
 }
 
@@ -197,6 +242,14 @@ export function RemoteOptionsField({ name, property, value, onChange, disabled }
   const options = query.data?.options ?? [];
   const scalarType = ui.multiple ? property.items?.type : property.type;
 
+  // `labels_field` is the only thing this widget writes outside its own key, so
+  // it stays inert unless the manifest asked for it on a multi-select. The map
+  // is read straight out of the field's scope on every render and written only
+  // from a user action — never from an effect, because an effect would fire on
+  // the empty first render of a cold dialog open and wipe saved names.
+  const labelsField = multiple && ui.labels_field ? ui.labels_field : undefined;
+  const labels = readLabels(labelsField ? fieldScope.scope[labelsField] : undefined);
+
   // Without a plugin id there is nothing to ask. Say so and stay inert rather
   // than throwing or requesting `/plugins/null/options/…`.
   if (!pluginId) {
@@ -239,6 +292,8 @@ export function RemoteOptionsField({ name, property, value, onChange, disabled }
           maxItems={property.maxItems}
           reorderable={Boolean(ui.reorderable)}
           placeholder={ui.placeholder}
+          labelsField={labelsField}
+          labels={labels}
         />
       ) : (
         <SingleSelectControl
@@ -333,7 +388,8 @@ interface ControlProps {
   options: PluginOption[];
   /** What search has left to offer. */
   visible: PluginOption[];
-  onChange: (value: unknown) => void;
+  /** Same contract as {@link RemoteOptionsFieldProps.onChange}. */
+  onChange: (value: unknown, siblings?: Record<string, unknown>) => void;
   disabled?: boolean;
   scalarType: string | undefined;
   placeholder?: string;
@@ -408,17 +464,56 @@ function MultiSelectControl({
   maxItems,
   reorderable,
   placeholder,
-}: ControlProps & { value: unknown[]; maxItems?: number; reorderable: boolean }) {
+  labelsField,
+  labels,
+}: ControlProps & {
+  value: unknown[];
+  maxItems?: number;
+  reorderable: boolean;
+  /** Sibling property collecting per-choice display names, or undefined. */
+  labelsField?: string;
+  /** Those names as stored, keyed by {@link optionKey}. */
+  labels: Map<string, string>;
+}) {
   const t = useTranslations("schemaForm");
-  const labels = new Map(options.map((option) => [String(option.value), option.label]));
-  const chosen = value.map((item) => String(item));
+  const catalogLabels = new Map(options.map((option) => [optionKey(option.value), option.label]));
+  const chosen = value.map((item) => optionKey(item));
   const chosenSet = new Set(chosen);
   // Offering an already-chosen option again can only produce a duplicate.
-  const available = visible.filter((option) => !chosenSet.has(String(option.value)));
+  const available = visible.filter((option) => !chosenSet.has(optionKey(option.value)));
   const atMax = maxItems !== undefined && value.length >= maxItems;
   // Same rule as the single control: an unrecognised stored value shows as
   // itself so a save never silently drops it.
-  const labelOf = (raw: string) => labels.get(raw) ?? raw;
+  const labelOf = (raw: string) => catalogLabels.get(raw) ?? raw;
+
+  // The display name and the selection are one edit, committed together — see
+  // `FieldProps.onChange`. Only the keys the user actually touched move.
+  const setLabel = (raw: string, text: string) => {
+    if (!labelsField) return;
+    const next = new Map(labels);
+    // An empty box means "no custom name", which the *absence* of a key
+    // already says — storing "" would only accumulate entries that mean
+    // nothing to the plugin.
+    if (text === "") next.delete(raw);
+    else next.set(raw, text);
+    onChange(value, { [labelsField]: Object.fromEntries(next) });
+  };
+
+  /**
+   * Remove a chosen option, and with it the display name that only existed to
+   * describe it. Exactly that one key: names for the rows that stay, and for
+   * anything else already in the map, are left as they are.
+   */
+  const remove = (index: number) => {
+    const remaining = value.filter((_, i) => i !== index);
+    if (!labelsField) {
+      onChange(remaining);
+      return;
+    }
+    const next = new Map(labels);
+    next.delete(chosen[index]);
+    onChange(remaining, { [labelsField]: Object.fromEntries(next) });
+  };
 
   const move = (index: number, direction: -1 | 1) => {
     const target = index + direction;
@@ -441,6 +536,16 @@ function MultiSelectControl({
           <Text as="span" className="flex-1 truncate">
             {labelOf(raw)}
           </Text>
+          {labelsField && (
+            <Input
+              value={labels.get(raw) ?? ""}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setLabel(raw, e.target.value)}
+              aria-label={t("remoteOptionsLabelFor", { label: labelOf(raw) })}
+              placeholder={t("remoteOptionsLabelPlaceholder")}
+              disabled={disabled}
+              className="h-7 w-32 shrink-0 text-sm"
+            />
+          )}
           {reorderable && (
             <Flex align="center" className="shrink-0">
               <Button
@@ -473,7 +578,7 @@ function MultiSelectControl({
             size="icon"
             className="h-7 w-7 shrink-0 text-destructive hover:text-destructive"
             disabled={disabled}
-            onClick={() => onChange(value.filter((_, i) => i !== index))}
+            onClick={() => remove(index)}
             aria-label={t("remoteOptionsRemove", { label: labelOf(raw) })}
           >
             <Trash2 className="h-4 w-4" />

--- a/web/src/components/plugin-settings/schema-form.tsx
+++ b/web/src/components/plugin-settings/schema-form.tsx
@@ -104,7 +104,18 @@ interface FieldProps {
   name: string;
   property: SchemaProperty;
   value: unknown;
-  onChange: (value: unknown) => void;
+  /**
+   * Commit this field's value, optionally together with a patch of *sibling*
+   * properties in the same object.
+   *
+   * Only `remote-options` with `ui:options.labels_field` uses the second
+   * argument, and it has to exist because the two writes are one edit:
+   * removing a chosen row changes the array *and* drops that row's display
+   * name. Two separate `onChange` calls in one handler would both be computed
+   * from the same pre-edit object, so the second would silently undo the
+   * first. Every other field ignores the argument and nothing changes for it.
+   */
+  onChange: (value: unknown, siblings?: Record<string, unknown>) => void;
   required?: boolean;
   disabled?: boolean;
 }
@@ -1346,8 +1357,8 @@ function ArrayField({ name, property, value, onChange, disabled, itemSchema }: A
                         name={`${name}-${index}-${key}`}
                         property={propSchema}
                         value={(item as Record<string, unknown>)?.[key]}
-                        onChange={(val) => {
-                          const newItem = { ...(item as Record<string, unknown>), [key]: val };
+                        onChange={(val, siblings) => {
+                          const newItem = { ...(item as Record<string, unknown>), ...siblings, [key]: val };
                           handleItemChange(index, newItem);
                         }}
                         disabled={disabled}
@@ -1530,8 +1541,8 @@ function FormField({
                     name={`${name}-${key}`}
                     property={propSchema}
                     value={(value as Record<string, unknown>)?.[key]}
-                    onChange={(val) => {
-                      const newValue = { ...(value as Record<string, unknown>), [key]: val };
+                    onChange={(val, siblings) => {
+                      const newValue = { ...(value as Record<string, unknown>), ...siblings, [key]: val };
                       onChange(newValue);
                     }}
                     required={property.required?.includes(key)}
@@ -1577,8 +1588,8 @@ export function SchemaForm({ schema, values, onChange, disabled, className, plug
     [values, schema.properties],
   );
   const handleFieldChange = useCallback(
-    (fieldName: string, fieldValue: unknown) => {
-      onChange({ ...values, [fieldName]: fieldValue });
+    (fieldName: string, fieldValue: unknown, siblings?: Record<string, unknown>) => {
+      onChange({ ...values, ...siblings, [fieldName]: fieldValue });
     },
     [values, onChange],
   );
@@ -1635,7 +1646,7 @@ export function SchemaForm({ schema, values, onChange, disabled, className, plug
                   name={name}
                   property={property}
                   value={values[name]}
-                  onChange={(val) => handleFieldChange(name, val)}
+                  onChange={(val, siblings) => handleFieldChange(name, val, siblings)}
                   required={isRequired}
                   disabled={fieldDisabled}
                   onLocationRequest={showLocationButton ? handleLocationRequest : undefined}


### PR DESCRIPTION
## Why

This is the last capability blocking Disney's migration off its bespoke `disney-parks-times-picker`. That widget lets a user give each chosen ride a short display name — a board row is 22 tiles wide, so "Seven Dwarfs Mine Train" has to be shortened before it will fit. The generic `remote-options` widget could not do that, so migrating Disney would have been a real feature regression. With this in place the bespoke widget can be deleted.

## What

A tenth `ui:options` key, `labels_field` (string), valid only alongside `multiple: true`.

When set, each chosen row of the multi-select gains a small text box. What the user types is collected into the **sibling** property `labels_field` names, as a map keyed by the option's value:

```json
"ride_ids": {
  "type": "array",
  "items": { "type": "integer" },
  "ui:widget": "remote-options",
  "ui:options": { "options_id": "rides", "multiple": true, "labels_field": "custom_names" }
},
"custom_names": { "type": "object", "additionalProperties": { "type": "string" } }
```

```python
custom_names.get(str(ride_id)) or ride.name
```

### Key type

Keys are always `String(value)`. Disney's plugin reads the map as `custom_names.get(str(ride_id))` while its option values are integers; the old React widget indexed it with a number and only worked because JS coerces and JSON stringifies. The new implementation stringifies explicitly and holds the map as a `Map<string, string>`, which cannot be rescued by coercion on lookup — a numeric key genuinely misses, and the tests pin that.

### Writing outside the field's own key

New for this widget, so the mechanism is deliberately narrow and explicit: `FieldProps.onChange` takes an optional second argument, a patch of siblings in the same object, applied in the same update as the field's own value. All three places that own a containing object (root, array item, nested object) merge it; every other field ignores it.

It has to be one call rather than two. Removing a chosen row changes the array *and* drops that row's display name — two separate `onChange` calls in one handler would both be computed from the same pre-edit object, so the second would silently undo the first.

Nothing writes from an effect. `SchemaForm` is mounted with `{}` and filled in when the `["plugin", id]` query resolves (`integrations._index.tsx`), and a reconcile-in-an-effect would fire on that empty first render and wipe every saved name — the same shape as the cold-load bug this file already shipped once.

### Behaviour

- Removing a chosen row deletes exactly its key; the other names are untouched
- Reordering rows changes nothing — the map is keyed by value, not by position
- Clearing a box forgets the key rather than storing `""`
- A name for a value the catalog no longer offers is kept, not pruned: the catalog going quiet is not the user un-choosing anything
- No label input renders at all without `labels_field`

### Validation (`src/plugins/manifest.py`)

- `labels_field` must be a string
- it must name a property declared in the **same object schema** — siblings only, unlike `depends_on`, because this is a write target. On an array row that means a property of the row, not a same-named one at the root
- `labels_field` without `multiple: true` is an error
- added to `UI_OPTIONS_KEYS`; `bogus_key` is still rejected, and an unknown `ui:widget` is still a WARNING (`stocks`, `muni`, `lyft-bike-share` keep loading)

## Tests

Written test-first, each one run and observed failing before the code that satisfies it. 9 new widget tests, 5 new manifest tests.

Two that passed on first run — because the generic mechanism already covered them — were proven non-vacuous by mutating the production code:

**`optionKey` returning the raw value instead of `String(value)`** kills 8 of the 9 new widget tests and leaves the other 42 in the file green:

\`\`\`
FAIL > keys the map by the stringified value when the option values are integers
AssertionError: expected '{"ride_ids":[279,284],"custom_names":…' to be '{"ride_ids":[279,284],"custom_names":…'
FAIL > hydrates the inputs from display names already in the stored config
FAIL > keeps stored display names when the config arrives after the first render
Tests  8 failed | 42 passed (50)
\`\`\`

**Writing the label map from an effect** (`useEffect(() => { if (siblingMissing) onChange(value, { [labelsField]: {} }) })`) fails exactly one test — the cold-hydration guard, and nothing else:

\`\`\`
FAIL > keeps stored display names when the config arrives after the first render
AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times
Tests  1 failed | 49 passed (50)
\`\`\`

The widget test file was run 10× with no flake (50/50 every run).

## Verification

| Gate | Before | After |
| --- | --- | --- |
| `npm run test:run` | 113 files, 1449 passed / 13 skipped | 113 files, 1458 passed / 13 skipped (3 runs, identical) |
| `npm run test:coverage` | — | passes all 80% thresholds (stmts 87.64, branch 83.65, func 82.70, lines 88.88) |
| `npm run lint` | 0 errors, 406 warnings | 0 errors, 406 warnings |
| `npm run format:check` | pass | pass |
| `npm run typecheck` | 137 errors | 137 errors, identical set |
| pytest (serial, `-m "not integration"`) | 4695 passed, 88.19% | 4700 passed, 88.20% |
| `ruff check` / `ruff format --check` (0.16.1) | pass | pass |
| `scripts/validate_plugins.py` | pass | pass |
| markdown lint / frontmatter / spell | spell **failing on main** | pass |

The new i18n strings (`remoteOptionsLabelFor`, `remoteOptionsLabelPlaceholder`) are in all 14 locale files with real translations; `i18n-config.test.ts` key-path parity is green.

## Note on `cspell.json`

`docs:lint:spell` fails on unmodified `main` — `Sanitisation` in `PLUGIN_DEVELOPMENT.md`, from #1547. `lint-markdown` only runs when markdown changed, so it went unnoticed. This PR touches that file, which surfaces it, so `sanitisation` is added to the dictionary alongside the other British spellings already there (`behaviour`, `colour`, `customisation`).

## Known gap

The sibling property is an ordinary schema property, so `SchemaForm` still renders it as one — for a bare `{"type": "object"}` with no `properties` that is an "Object type without properties schema" row under the picker. Suppressing it would mean teaching `SchemaForm` about widget-managed properties, which is a wider change than this key; noted in the docs instead, and worth a follow-up if the Disney migration finds it noisy.

## Unrelated CI finding (not fixed here)

`Lint Markdown` and `Check Markdown Links` are gated on `needs.detect-changes.outputs.markdown`, but the `detect-changes` job's `outputs:` block only declares `api`, `ui`, `plugins`, `shared`, `docs` — not `markdown`. The filter itself is defined and correct; its result is simply never exported, so that expression is always empty and both jobs only ever run when `shared` is true. Both are skipped on this PR despite it changing `docs/**/*.md` and `cspell.json`.

That is why the `Sanitisation` spell failure from #1547 sat unnoticed. Fixing the wiring belongs in its own PR — turning those jobs back on may surface other accumulated prose failures, and that should not ride along with a feature change.
