### PR TITLE
fix(plugins): don't auto-update a plugin past its core

### DIFF
--- a/docs/development/PLUGIN_DEVELOPMENT.md
+++ b/docs/development/PLUGIN_DEVELOPMENT.md
@@ -1326,6 +1326,22 @@ Open a pull request against the FiestaBoard repository that adds one entry to th
 
 Set `fiestaboard_version` to the minimum FiestaBoard version your plugin requires. Use an existing `category` value (`art`, `data`, `entertainment`, `home`, `transit`, `utility`, `weather`).
 
+#### `fiestaboard_version` gates auto-update
+
+The same field in your plugin's own `manifest.json` decides whether installed
+copies of your plugin will pick up a new commit. Before offering an update,
+FiestaBoard reads `manifest.json` at your repository's remote head (without
+checking anything out) and compares its `fiestaboard_version` against the
+running core. If the incoming manifest needs a newer core than the user is on,
+no update is offered and the reason is reported through `GET /plugins/updates`
+(`blocked`) and each plugin's `update_blocked_reason`.
+
+This matters because plugin auto-update is on by default and polls hourly,
+while core updates are a manual image pull. Raising the floor in the same
+commit that starts using newer manifest grammar keeps users on the last commit
+their core can load, instead of pulling a manifest the loader rejects — which
+removes the plugin from their board.
+
 ### Registry checklist
 
 Before submitting your PR, verify all of the following:

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -8732,12 +8732,20 @@ async def get_plugin_updates():
 
     Results are refreshed by a background task every 6 hours.  Call
     ``POST /plugins/updates/check`` to trigger an immediate check.
+
+    ``blocked`` maps plugin ids to the reason an upstream commit was *not*
+    offered — currently only "the incoming manifest needs a newer FiestaBoard
+    core".  Those plugins appear in ``updates`` as ``False``; the reason is
+    what lets the UI say so rather than looking stuck.
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
         raise HTTPException(status_code=503, detail="Plugin system is not available.")
 
     registry = get_plugin_registry()
-    return {"updates": registry.get_update_status()}
+    return {
+        "updates": registry.get_update_status(),
+        "blocked": registry.get_update_blocked_reasons(),
+    }
 
 
 @app.get("/plugins/{plugin_id}")

--- a/src/plugins/registry.py
+++ b/src/plugins/registry.py
@@ -82,6 +82,12 @@ class PluginRegistry:
         # Maps plugin_id -> bool (True = update available).
         self._update_status: dict[str, bool] = {}
 
+        # Why an upstream commit was *not* offered as an update, for the
+        # plugins where that happened.  Maps plugin_id -> reason.  Kept
+        # alongside (not inside) _update_status so the boolean shape the API
+        # and UI already consume is unchanged.
+        self._update_blocked: dict[str, str] = {}
+
         # Auto-discovery cache: maps plugin_id -> discovered variable names
         self._discovered_vars: dict[str, list[str]] = {}
 
@@ -1079,6 +1085,7 @@ class PluginRegistry:
                 "fiestaboard_version": manifest.fiestaboard_version if manifest else "",
                 "source": source.to_dict() if source else {"source_type": "builtin"},
                 "update_available": self._update_status.get(plugin_id, False),
+                "update_blocked_reason": self._update_blocked.get(plugin_id, ""),
                 "supports_triggers": manifest.supports_triggers if manifest else False,
                 "instance_label": instance_label,
                 "base_plugin_id": base_id,
@@ -1208,10 +1215,17 @@ class PluginRegistry:
         ``_update_status`` so the ``/plugins/updates`` endpoint can return
         instantly between checks.
 
+        An upstream commit whose manifest requires a newer FiestaBoard core is
+        reported as *no* update — applying it would leave the running core
+        unable to parse the manifest, which drops the plugin off the user's
+        board.  The explanation is cached in ``_update_blocked`` so the UI can
+        say why instead of looking broken.
+
         Returns:
             Mapping of plugin_id -> True if an update is available.
         """
         results: dict[str, bool] = {}
+        blocked: dict[str, str] = {}
         for plugin_id, source in self._loader.plugin_sources.items():
             if source.source_type != "external" or not source.local_path:
                 continue
@@ -1221,17 +1235,33 @@ class PluginRegistry:
             if not self._plugin_in_use(plugin_id):
                 continue
             local_path = Path(source.local_path)
-            update_available = check_plugin_update_available(local_path)
-            results[plugin_id] = update_available
-            if update_available:
+            check = check_plugin_update_available(local_path)
+            results[plugin_id] = check.available
+            if check.available:
                 logger.info("Update available for external plugin: %s", plugin_id)
+            elif check.blocked_reason:
+                blocked[plugin_id] = check.blocked_reason
+                logger.warning(
+                    "Update for external plugin '%s' held back: %s",
+                    plugin_id,
+                    check.blocked_reason,
+                )
 
         self._update_status = results
+        self._update_blocked = blocked
         return results
 
     def get_update_status(self) -> dict[str, bool]:
         """Return cached update status from the last check_for_updates() call."""
         return self._update_status.copy()
+
+    def get_update_blocked_reasons(self) -> dict[str, str]:
+        """Return why held-back updates were held back, by plugin id.
+
+        Only contains plugins that have an upstream commit which the running
+        core cannot run.  Empty for every plugin that is simply up to date.
+        """
+        return self._update_blocked.copy()
 
     def get_plugin_source(self, plugin_id: str) -> PluginSource | None:
         """Get the source information for a loaded plugin.

--- a/src/plugins/sources.py
+++ b/src/plugins/sources.py
@@ -130,6 +130,25 @@ class RegistryEntry:
         )
 
 
+@dataclass(frozen=True)
+class PluginUpdateCheck:
+    """Outcome of an upstream update check for one cloned external plugin.
+
+    ``blocked_reason`` is non-empty only when an upstream commit exists but was
+    deliberately withheld — currently because the incoming manifest requires a
+    newer FiestaBoard core.  It is carried on the result rather than fetched by
+    a separate call because it falls out of the same network round trip that
+    decides ``available``; a companion function would either double the git
+    traffic on an hourly poll or need its own cache.
+    """
+
+    #: True when an upstream commit exists that this core can actually run.
+    available: bool
+
+    #: Human-readable explanation when an update exists but is being held back.
+    blocked_reason: str = ""
+
+
 # ── registry loading ────────────────────────────────────────────────────────
 
 
@@ -524,13 +543,110 @@ def get_local_head_sha(dest_dir: Path) -> str | None:
         return None
 
 
-def check_plugin_update_available(dest_dir: Path) -> bool:
-    """Return True if the remote has commits not yet pulled locally."""
+def _read_remote_manifest_version(dest_dir: Path) -> str:
+    """Return the *incoming* manifest's ``fiestaboard_version`` constraint.
+
+    Reads ``manifest.json`` at the remote head **without touching the working
+    tree**: ``git fetch`` only writes into ``.git`` (objects plus
+    ``FETCH_HEAD``) and ``git show`` reads the blob straight out of the object
+    database.  Nothing is checked out, so a refused update leaves the plugin
+    exactly as it was.
+
+    Returns ``""`` whenever the constraint cannot be determined — missing
+    remote, unreadable or malformed manifest, no ``fiestaboard_version`` key.
+    Callers treat that as "no opinion" and fall back to the plain SHA
+    comparison, so a network hiccup can never freeze a user's updates.
+    """
+    if not dest_dir.exists() or not (dest_dir / ".git").is_dir():
+        return ""
+
+    env = {**os.environ, "GIT_TERMINAL_PROMPT": "0"}
+    try:
+        # The local branch name is only a hint about which remote branch this
+        # clone tracks; fall back to the remote's advertised HEAD exactly like
+        # get_remote_head_sha does, because ``git init`` creates "master"
+        # while most plugin repos publish "main".
+        branch_result = subprocess.run(
+            ["git", "-C", str(dest_dir), "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True, text=True, timeout=10, env=env,
+        )
+        refs: list[str] = []
+        branch = branch_result.stdout.strip()
+        # Re-derive the branch from the match result so the subprocess sink
+        # does not see it as tainted (CodeQL py/command-line-injection).
+        branch_m = re.fullmatch(r"[A-Za-z0-9_./-]+", branch)
+        if branch_m and branch_m.group(0) != "HEAD":
+            refs.append(branch_m.group(0))
+        refs.append("HEAD")
+
+        fetched = False
+        for ref in refs:
+            fetch_result = subprocess.run(
+                ["git", "-C", str(dest_dir), "fetch", "--quiet", "--depth=1", "origin", ref],
+                capture_output=True, text=True, timeout=120, env=env,
+            )
+            if fetch_result.returncode == 0:
+                fetched = True
+                break
+        if not fetched:
+            return ""
+
+        show_result = subprocess.run(
+            ["git", "-C", str(dest_dir), "show", "FETCH_HEAD:manifest.json"],
+            capture_output=True, text=True, timeout=30, env=env,
+        )
+        if show_result.returncode != 0:
+            return ""
+        data = json.loads(show_result.stdout)
+    except (subprocess.SubprocessError, OSError, json.JSONDecodeError):
+        return ""
+
+    if not isinstance(data, dict):
+        return ""
+    # RegistryEntry.from_dict is the tolerant parser: every field has a
+    # default and none is required, so a manifest written for a *newer* core
+    # still yields its version floor.  PluginManifest.from_dict would be the
+    # wrong tool here — it requires keys and parses nested structures, and the
+    # manifests this guard exists for are exactly the ones this core cannot
+    # parse.
+    return RegistryEntry.from_dict(data).fiestaboard_version
+
+
+def check_plugin_update_available(dest_dir: Path) -> PluginUpdateCheck:
+    """Check whether an external plugin has an upstream update it can run.
+
+    An update is available when the remote has commits not yet pulled locally
+    **and** the incoming manifest's ``fiestaboard_version`` floor is satisfied
+    by the running core.  Pulling a manifest this core cannot parse makes the
+    loader reject the plugin outright, which removes it from the user's board
+    — see ``KNOWN_SETTINGS_WIDGETS`` in :mod:`src.plugins.manifest`.
+    """
     local = get_local_head_sha(dest_dir)
     remote = get_remote_head_sha(dest_dir)
     if local is None or remote is None:
-        return False
-    return local != remote
+        return PluginUpdateCheck(available=False)
+    if local == remote:
+        # Already up to date — never spend a network round trip reading a
+        # manifest we have on disk.
+        return PluginUpdateCheck(available=False)
+
+    constraint = _read_remote_manifest_version(dest_dir)
+    if not constraint:
+        return PluginUpdateCheck(available=True)
+
+    # Imported lazily: loader imports this module at import time, so a
+    # module-level import here would be circular.  Reusing the loader's
+    # comparator keeps one definition of "does this core satisfy the floor".
+    from .loader import _check_version_constraint, _get_fiestaboard_version
+
+    satisfied, reason = _check_version_constraint(constraint, _get_fiestaboard_version())
+    if satisfied:
+        # Includes constraints this core cannot parse: the loader's comparator
+        # reports those as satisfied, and failing open is deliberate.
+        return PluginUpdateCheck(available=True)
+
+    logger.info("Holding back plugin update in %s: %s", dest_dir, reason)
+    return PluginUpdateCheck(available=False, blocked_reason=reason)
 
 
 def remove_external_plugin(dest_dir: Path) -> bool:

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -1629,10 +1629,25 @@ class TestPluginUpdates:
         ):
             registry = Mock()
             registry.get_update_status.return_value = {"my_plugin": True}
+            registry.get_update_blocked_reasons.return_value = {}
             mock_reg.return_value = registry
             response = client.get("/plugins/updates")
             assert response.status_code == 200
             assert response.json()["updates"]["my_plugin"] is True
+
+    def test_get_updates_includes_blocked_reasons(self, client):
+        """Held-back updates are reported with the reason they were held back."""
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_plugin_registry") as mock_reg,
+        ):
+            registry = Mock()
+            registry.get_update_status.return_value = {"my_plugin": False}
+            registry.get_update_blocked_reasons.return_value = {"my_plugin": "needs FiestaBoard >=99.0.0"}
+            mock_reg.return_value = registry
+            response = client.get("/plugins/updates")
+            assert response.status_code == 200
+            assert response.json()["blocked"] == {"my_plugin": "needs FiestaBoard >=99.0.0"}
 
     def test_get_updates_unavailable(self, client):
         """Plugin system unavailable → 503."""

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -13,7 +13,7 @@ from src.plugins.registry import (
     get_plugin_registry,
     reset_plugin_registry,
 )
-from src.plugins.sources import PluginSource, RegistryEntry
+from src.plugins.sources import PluginSource, PluginUpdateCheck, RegistryEntry
 
 
 @pytest.fixture
@@ -811,7 +811,10 @@ def test_check_for_updates_skips_builtin(registry, mock_loader):
     assert results == {}
 
 
-@patch("src.plugins.registry.check_plugin_update_available", return_value=True)
+@patch(
+    "src.plugins.registry.check_plugin_update_available",
+    return_value=PluginUpdateCheck(available=True),
+)
 def test_check_for_updates_detects_external(mock_check, registry, mock_loader):
     """check_for_updates checks enabled external plugins and caches results."""
     mock_loader.plugin_sources = {
@@ -824,7 +827,10 @@ def test_check_for_updates_detects_external(mock_check, registry, mock_loader):
     mock_check.assert_called_once()
 
 
-@patch("src.plugins.registry.check_plugin_update_available", return_value=False)
+@patch(
+    "src.plugins.registry.check_plugin_update_available",
+    return_value=PluginUpdateCheck(available=False),
+)
 def test_check_for_updates_no_update(mock_check, registry, mock_loader):
     """check_for_updates returns False when up to date."""
     mock_loader.plugin_sources = {
@@ -833,6 +839,62 @@ def test_check_for_updates_no_update(mock_check, registry, mock_loader):
     registry._enabled = {"ext_plugin": True}
     results = registry.check_for_updates()
     assert results == {"ext_plugin": False}
+
+
+@patch("src.plugins.registry.check_plugin_update_available")
+def test_check_for_updates_records_blocked_reason(mock_check, registry, mock_loader):
+    """A withheld update is reported as "no update" plus a reason to show."""
+    mock_check.return_value = PluginUpdateCheck(
+        available=False,
+        blocked_reason="Plugin requires FiestaBoard >=99.0.0, but running version is 8.25.0",
+    )
+    mock_loader.plugin_sources = {
+        "ext_plugin": PluginSource(source_type="external", local_path="/ext/ext_plugin"),
+    }
+    registry._enabled = {"ext_plugin": True}
+
+    results = registry.check_for_updates()
+
+    assert results == {"ext_plugin": False}
+    assert registry.get_update_blocked_reasons() == {
+        "ext_plugin": "Plugin requires FiestaBoard >=99.0.0, but running version is 8.25.0"
+    }
+
+
+@patch("src.plugins.registry.check_plugin_update_available")
+def test_check_for_updates_clears_stale_blocked_reason(mock_check, registry, mock_loader):
+    """Once the core catches up the reason must not linger on the plugin."""
+    mock_check.return_value = PluginUpdateCheck(available=True)
+    mock_loader.plugin_sources = {
+        "ext_plugin": PluginSource(source_type="external", local_path="/ext/ext_plugin"),
+    }
+    registry._enabled = {"ext_plugin": True}
+    registry._update_blocked = {"ext_plugin": "stale reason"}
+
+    registry.check_for_updates()
+
+    assert registry.get_update_blocked_reasons() == {}
+
+
+def test_get_update_blocked_reasons_returns_copy(registry):
+    """Callers cannot mutate the registry's cached reasons."""
+    registry._update_blocked = {"p": "because"}
+    reasons = registry.get_update_blocked_reasons()
+    reasons["p"] = "tampered"
+    assert registry._update_blocked["p"] == "because"
+
+
+def test_list_plugins_exposes_update_blocked_reason(registry, mock_loader, mock_plugin, mock_manifest):
+    """The reason rides along with update_available so the UI can explain it."""
+    mock_loader.load_all_plugins.return_value = {"test_plugin": mock_plugin}
+    mock_loader.get_manifest.side_effect = lambda pid: mock_manifest if pid == "test_plugin" else None
+    registry.initialize()
+    registry._update_blocked = {"test_plugin": "needs a newer core"}
+
+    info = registry.list_plugins()[0]
+
+    assert info["update_available"] is False
+    assert info["update_blocked_reason"] == "needs a newer core"
 
 
 def test_get_update_status_returns_copy(registry):
@@ -1790,7 +1852,10 @@ def test_check_for_updates_checks_enabled_plugin(registry, mock_loader, tmp_path
     mock_loader.plugin_sources = {"foo": _external_source(tmp_path)}
     registry._enabled = {"foo": True}
 
-    with patch("src.plugins.registry.check_plugin_update_available", return_value=True) as mock_check:
+    with patch(
+        "src.plugins.registry.check_plugin_update_available",
+        return_value=PluginUpdateCheck(available=True),
+    ) as mock_check:
         results = registry.check_for_updates()
 
     mock_check.assert_called_once()
@@ -1803,7 +1868,10 @@ def test_check_for_updates_checks_base_with_enabled_instance(registry, mock_load
     mock_loader.plugin_sources = {"foo": _external_source(tmp_path)}
     registry._enabled = {"foo": False, "foo:home": True}
 
-    with patch("src.plugins.registry.check_plugin_update_available", return_value=False) as mock_check:
+    with patch(
+        "src.plugins.registry.check_plugin_update_available",
+        return_value=PluginUpdateCheck(available=False),
+    ) as mock_check:
         results = registry.check_for_updates()
 
     mock_check.assert_called_once()

--- a/tests/test_plugin_sources.py
+++ b/tests/test_plugin_sources.py
@@ -1,11 +1,17 @@
 """Tests for the external plugin sources module."""
 
 import json
+import os
+import shutil
 import subprocess
 from pathlib import Path
 from unittest import mock
 
-from src.plugins.loader import _check_version_constraint, _parse_version
+from src.plugins.loader import (
+    _check_version_constraint,
+    _get_fiestaboard_version,
+    _parse_version,
+)
 from src.plugins.sources import (
     PluginSource,
     RegistryEntry,
@@ -679,21 +685,303 @@ class TestCheckPluginUpdateAvailable:
     def test_no_update_when_shas_match(self, _remote, _local, tmp_path):
         d = tmp_path / "plugin"
         d.mkdir()
-        assert not check_plugin_update_available(d)
+        assert check_plugin_update_available(d).available is False
 
     @mock.patch("src.plugins.sources.get_local_head_sha", return_value="abc")
     @mock.patch("src.plugins.sources.get_remote_head_sha", return_value="def")
     def test_update_available_when_shas_differ(self, _remote, _local, tmp_path):
         d = tmp_path / "plugin"
         d.mkdir()
-        assert check_plugin_update_available(d)
+        assert check_plugin_update_available(d).available is True
 
     @mock.patch("src.plugins.sources.get_local_head_sha", return_value=None)
     @mock.patch("src.plugins.sources.get_remote_head_sha", return_value="def")
     def test_no_update_when_local_sha_missing(self, _remote, _local, tmp_path):
         d = tmp_path / "plugin"
         d.mkdir()
-        assert not check_plugin_update_available(d)
+        assert check_plugin_update_available(d).available is False
+
+
+# ── incoming-version guard ───────────────────────────────────────────────────
+
+
+_GIT_ENV = {
+    "GIT_CONFIG_GLOBAL": os.devnull,
+    "GIT_CONFIG_SYSTEM": os.devnull,
+    "GIT_AUTHOR_NAME": "Test",
+    "GIT_AUTHOR_EMAIL": "test@example.com",
+    "GIT_COMMITTER_NAME": "Test",
+    "GIT_COMMITTER_EMAIL": "test@example.com",
+    "GIT_TERMINAL_PROMPT": "0",
+}
+
+
+def _git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, **_GIT_ENV},
+    )
+    return result.stdout.strip()
+
+
+def _origin_and_clone(tmp_path: Path, incoming_manifest: str) -> tuple[Path, Path]:
+    """Build a real origin repo plus a clone one commit behind it.
+
+    The clone's checked-out manifest is always a plain, current-core manifest;
+    ``incoming_manifest`` is only ever the *remote* head's content, so any test
+    that reads it proves the read came from the remote and not from disk.
+    """
+    origin = tmp_path / "origin"
+    origin.mkdir()
+    _git(origin, "init", "--quiet", "--initial-branch=main")
+    (origin / "manifest.json").write_text(
+        json.dumps({"id": "p", "name": "P", "version": "1.0.0"}),
+        encoding="utf-8",
+    )
+    _git(origin, "add", "-A")
+    _git(origin, "commit", "--quiet", "-m", "initial")
+
+    clone = tmp_path / "clone"
+    subprocess.run(
+        ["git", "clone", "--quiet", str(origin), str(clone)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, **_GIT_ENV},
+    )
+
+    (origin / "manifest.json").write_text(incoming_manifest, encoding="utf-8")
+    _git(origin, "add", "-A")
+    _git(origin, "commit", "--quiet", "-m", "incoming")
+    return origin, clone
+
+
+def _check_against_real_remote(origin: Path, clone: Path):
+    """Run the check with the real SHAs of ``origin``/``clone``.
+
+    Only the two SHA helpers are stubbed, and only because
+    :func:`get_remote_head_sha` refuses non-HTTPS remotes.  The manifest read
+    under test still runs for real against the local origin.
+    """
+    local_sha = _git(clone, "rev-parse", "HEAD")
+    remote_sha = _git(origin, "rev-parse", "HEAD")
+    with (
+        mock.patch("src.plugins.sources.get_local_head_sha", return_value=local_sha),
+        mock.patch("src.plugins.sources.get_remote_head_sha", return_value=remote_sha),
+    ):
+        return check_plugin_update_available(clone)
+
+
+class TestUpdateBlockedByCoreVersion:
+    """An update must not be offered when the incoming manifest declares a
+    ``fiestaboard_version`` floor above the running core.
+
+    The loader rejects a manifest it cannot parse outright (``load_manifest``
+    returns *None*), which uninstalls the plugin from the user's board in
+    practice.  Auto-update polls hourly and is on by default while core
+    updates are a manual image pull, so without this guard a plugin can
+    update past its core and silently vanish.
+    """
+
+    def test_no_update_when_incoming_requires_newer_core(self, tmp_path):
+        origin, clone = _origin_and_clone(
+            tmp_path,
+            json.dumps(
+                {
+                    "id": "p",
+                    "name": "P",
+                    "version": "2.0.0",
+                    "fiestaboard_version": ">=99.0.0",
+                }
+            ),
+        )
+        local_sha = _git(clone, "rev-parse", "HEAD")
+        remote_sha = _git(origin, "rev-parse", "HEAD")
+
+        with (
+            mock.patch("src.plugins.sources.get_local_head_sha", return_value=local_sha),
+            mock.patch("src.plugins.sources.get_remote_head_sha", return_value=remote_sha),
+        ):
+            result = check_plugin_update_available(clone)
+
+        assert result.available is False
+        assert ">=99.0.0" in result.blocked_reason
+
+    def test_update_offered_when_running_core_satisfies_floor(self, tmp_path):
+        origin, clone = _origin_and_clone(
+            tmp_path,
+            json.dumps(
+                {
+                    "id": "p",
+                    "name": "P",
+                    "version": "2.0.0",
+                    "fiestaboard_version": ">=1.0.0",
+                }
+            ),
+        )
+        result = _check_against_real_remote(origin, clone)
+
+        assert result.available is True
+        assert result.blocked_reason == ""
+
+    def test_update_offered_when_incoming_manifest_has_no_version(self, tmp_path):
+        origin, clone = _origin_and_clone(
+            tmp_path,
+            json.dumps({"id": "p", "name": "P", "version": "2.0.0"}),
+        )
+        result = _check_against_real_remote(origin, clone)
+
+        assert result.available is True
+        assert result.blocked_reason == ""
+
+    def test_update_offered_when_remote_manifest_is_malformed_json(self, tmp_path):
+        origin, clone = _origin_and_clone(tmp_path, "{ not json at all")
+        result = _check_against_real_remote(origin, clone)
+
+        assert result.available is True
+        assert result.blocked_reason == ""
+
+    def test_update_offered_when_remote_manifest_cannot_be_read(self, tmp_path):
+        """The remote is unreachable — fail open, and let no exception escape."""
+        origin, clone = _origin_and_clone(
+            tmp_path,
+            json.dumps(
+                {
+                    "id": "p",
+                    "name": "P",
+                    "version": "2.0.0",
+                    "fiestaboard_version": ">=99.0.0",
+                }
+            ),
+        )
+        remote_sha = _git(origin, "rev-parse", "HEAD")
+        local_sha = _git(clone, "rev-parse", "HEAD")
+        shutil.rmtree(origin)
+
+        with (
+            mock.patch("src.plugins.sources.get_local_head_sha", return_value=local_sha),
+            mock.patch("src.plugins.sources.get_remote_head_sha", return_value=remote_sha),
+        ):
+            result = check_plugin_update_available(clone)
+
+        assert result.available is True
+        assert result.blocked_reason == ""
+
+    def test_update_offered_when_remote_head_has_no_manifest(self, tmp_path):
+        origin, clone = _origin_and_clone(tmp_path, "{}")
+        (origin / "manifest.json").unlink()
+        _git(origin, "add", "-A")
+        _git(origin, "commit", "--quiet", "-m", "drop manifest")
+
+        result = _check_against_real_remote(origin, clone)
+
+        assert result.available is True
+        assert result.blocked_reason == ""
+
+    def test_update_offered_when_remote_manifest_is_not_an_object(self, tmp_path):
+        origin, clone = _origin_and_clone(tmp_path, json.dumps(["not", "a", "manifest"]))
+        result = _check_against_real_remote(origin, clone)
+
+        assert result.available is True
+        assert result.blocked_reason == ""
+
+    def test_detached_clone_still_reads_the_remote_floor(self, tmp_path):
+        """A clone checked out at a tag reports "HEAD" as its branch name."""
+        origin, clone = _origin_and_clone(
+            tmp_path,
+            json.dumps(
+                {
+                    "id": "p",
+                    "name": "P",
+                    "version": "2.0.0",
+                    "fiestaboard_version": ">=99.0.0",
+                }
+            ),
+        )
+        _git(clone, "checkout", "--quiet", "--detach", "HEAD")
+
+        result = _check_against_real_remote(origin, clone)
+
+        assert result.available is False
+        assert ">=99.0.0" in result.blocked_reason
+
+    def test_update_offered_when_constraint_is_unparseable(self, tmp_path):
+        origin, clone = _origin_and_clone(
+            tmp_path,
+            json.dumps(
+                {
+                    "id": "p",
+                    "name": "P",
+                    "version": "2.0.0",
+                    "fiestaboard_version": "whatever-comes-next",
+                }
+            ),
+        )
+        result = _check_against_real_remote(origin, clone)
+
+        assert result.available is True
+        assert result.blocked_reason == ""
+
+    def test_equal_version_satisfies_a_greater_or_equal_floor(self, tmp_path):
+        """Boundary: the running core exactly meets the floor it declares."""
+        origin, clone = _origin_and_clone(
+            tmp_path,
+            json.dumps(
+                {
+                    "id": "p",
+                    "name": "P",
+                    "version": "2.0.0",
+                    "fiestaboard_version": f">={_get_fiestaboard_version()}",
+                }
+            ),
+        )
+        result = _check_against_real_remote(origin, clone)
+
+        assert result.available is True
+        assert result.blocked_reason == ""
+
+    def test_no_update_when_shas_identical_and_remote_is_never_read(self, tmp_path):
+        _origin, clone = _origin_and_clone(
+            tmp_path,
+            json.dumps({"id": "p", "name": "P", "version": "2.0.0"}),
+        )
+        local_sha = _git(clone, "rev-parse", "HEAD")
+
+        with (
+            mock.patch("src.plugins.sources.get_local_head_sha", return_value=local_sha),
+            mock.patch("src.plugins.sources.get_remote_head_sha", return_value=local_sha),
+            mock.patch("src.plugins.sources._read_remote_manifest_version") as read_manifest,
+        ):
+            result = check_plugin_update_available(clone)
+
+        assert result.available is False
+        assert result.blocked_reason == ""
+        read_manifest.assert_not_called()
+
+    def test_check_does_not_modify_the_working_tree(self, tmp_path):
+        """The guard inspects the remote ref; it never pulls first and asks later."""
+        origin, clone = _origin_and_clone(
+            tmp_path,
+            json.dumps(
+                {
+                    "id": "p",
+                    "name": "P",
+                    "version": "2.0.0",
+                    "fiestaboard_version": ">=99.0.0",
+                }
+            ),
+        )
+        head_before = _git(clone, "rev-parse", "HEAD")
+        manifest_before = (clone / "manifest.json").read_text(encoding="utf-8")
+
+        _check_against_real_remote(origin, clone)
+
+        assert _git(clone, "rev-parse", "HEAD") == head_before
+        assert (clone / "manifest.json").read_text(encoding="utf-8") == manifest_before
+        assert _git(clone, "status", "--porcelain") == ""
 
 
 class TestRegistryPluginDependencies:


### PR DESCRIPTION
## The failure mode

Plugin auto-update is **on by default and polls hourly**. Core updates are a **manual image pull**. Those two facts together mean a plugin can move ahead of the core it runs on, unattended.

`check_plugin_update_available` was a pure git SHA comparison — it never looked at the incoming manifest:

```python
local = get_local_head_sha(dest_dir)
remote = get_remote_head_sha(dest_dir)
if local is None or remote is None:
    return False
return local != remote
```

Meanwhile the loader **rejects** a manifest whose `settings_schema` uses `ui:options` keys this core doesn't know: `validate_settings_schema_ui` → `validate_manifest` → `load_manifest()` returns `None`. The comment near `KNOWN_SETTINGS_WIDGETS` already says rejecting a manifest "would uninstall them in practice". The loader's own `fiestaboard_version` check is explicitly a soft failure ("warn but still load") **and it runs after that `return None`**, so it can never save the plugin.

Net effect today: a plugin that publishes a newer `ui:options` grammar gets pulled within the hour, the loader refuses the new manifest, and the plugin silently disappears from the user's board. The user did nothing and sees nothing explaining it.

## The change

Before offering an update, read `manifest.json` at the **remote head** and check its `fiestaboard_version` floor against the running core:

- The remote read is `git fetch --depth=1 origin <ref>` followed by `git show FETCH_HEAD:manifest.json`. `fetch` writes only into `.git`; `show` reads a blob out of the object database. **Nothing is checked out** — a refused update leaves the plugin byte-for-byte as it was. This is the "don't pull first and ask questions later" property, and there is a test asserting local `HEAD`, the working-tree manifest, and `git status --porcelain` are all unchanged after a blocked check.
- The comparison reuses the loader's existing `_check_version_constraint` / `_get_fiestaboard_version`. No second version comparator.
- The manifest blob is parsed with `RegistryEntry.from_dict` — every field has a default and none is required. `PluginManifest.from_dict` would be the wrong tool: it requires keys and parses nested structures, and the manifests this guard exists for are exactly the ones this core cannot parse.

### Return type

`check_plugin_update_available` now returns `PluginUpdateCheck(available: bool, blocked_reason: str)` instead of a bare `bool`.

The reason falls out of the *same network round trip* that decides `available`. A companion function would either repeat the fetch — doubling git traffic on an hourly poll across every installed plugin — or need its own cache to avoid it. The function had exactly one caller, so widening the return type cost one call site.

### Where the reason surfaces

`check_for_updates()` still returns `dict[str, bool]`, so the shape the API and UI already consume is unchanged. The reason rides alongside:

- `GET /plugins` → each plugin gains `update_blocked_reason` (empty string when nothing is held back)
- `GET /plugins/updates` → gains a `blocked` map of plugin id → reason
- a `logger.warning` per held-back plugin on every check

**No `web/` files are touched.** The data is available at the API, but rendering it (badge/tooltip copy in `integrations._index.tsx` plus keys across 14 locale files) is a separate, separately-reviewable UI change. Nothing regresses in the meantime: a blocked plugin reports `update_available: false`, so the UI shows it as up to date rather than offering a button that would break it.

### Fails open, never closed

Every uncertain path falls back to exactly today's behaviour — update available on SHA difference:

| Situation | Result |
|---|---|
| Remote unreachable / fetch fails | update offered |
| `manifest.json` absent at remote head | update offered |
| Manifest is malformed JSON | update offered |
| Manifest parses but isn't an object | update offered |
| No `fiestaboard_version` key | update offered |
| Constraint string unparseable | update offered |

Nothing escapes as an exception. A network hiccup must never silently freeze a user's plugin updates forever.

## Tests

17 new tests, all mutation-verified. Highlights:

- incoming floor above the running core → no update, reason present
- floor satisfied → update offered as before
- equal version satisfies a `>=` floor (boundary, computed from the live core version)
- all six fail-open cases above
- identical SHAs → no update **and the remote manifest is never read** (no wasted round trip)
- detached-HEAD clone still resolves the remote floor
- the check does not modify the working tree

The suite went 4700 → 4717 passing, coverage 88.20% → 88.24%.

### Mutation evidence

Each new test was proved non-vacuous by breaking the specific production behaviour it covers and observing the failure:

| Mutation | Observed failure |
|---|---|
| Drop the version guard | `test_no_update_when_incoming_requires_newer_core` — `AssertionError: assert True is False` |
| Fail closed on a missing floor | 5 fail-open tests — `AssertionError: assert False is True` |
| Treat an unparseable constraint as a block | `test_update_offered_when_constraint_is_unparseable` — `assert False is True` |
| `">="` → `">"` in the comparator | `test_equal_version_satisfies_a_greater_or_equal_floor` — `assert False is True` |
| Remove the equal-SHA early return | `test_no_update_when_shas_match` — `assert True is False` |
| Read `HEAD:manifest.json` instead of `FETCH_HEAD:` | `test_no_update_when_incoming_requires_newer_core` — `assert True is False` |
| `git reset --hard FETCH_HEAD` after fetch | `test_check_does_not_modify_the_working_tree` — `AssertionError: assert 'bc56dec1...' == '3dc44a52...'` |
| Keep stale blocked reasons | `test_check_for_updates_clears_stale_blocked_reason` — `assert {'ext_plugin': 'stale reason'} == {}` |
| Drop `blocked` from the endpoint | `test_get_updates_includes_blocked_reasons` — `KeyError: 'blocked'` |
| Drop `update_blocked_reason` from `list_plugins` | `test_list_plugins_exposes_update_blocked_reason` — `KeyError: 'update_blocked_reason'` |

## Scope

`POST /plugins/{id}/update` (the manual "Update" button) still pulls unconditionally. That is a deliberate, user-initiated action with visible feedback, unlike the silent hourly poll this PR fixes. In practice the UI only offers that button when `update_available` is true, which is now false for held-back plugins.

## Verification

- `pytest tests/ -m "not integration"` (serial): 4717 passed, 13 deselected
- `--cov-fail-under=80`: 88.24%
- `ruff check src/ plugins/ tests/ scripts/`: clean
- `ruff format --check`: 279 files already formatted
- `scripts/validate_plugins.py --verbose`: VALIDATION PASSED
- `git diff --name-only`: no `web/` files