### PR TITLE
fix(plugins): make an unknown ui:options key a warning, not a fatal error

### DIFF
--- a/docs/development/PLUGIN_DEVELOPMENT.md
+++ b/docs/development/PLUGIN_DEVELOPMENT.md
@@ -420,9 +420,7 @@ No core change is needed for a new plugin.
 }
 ```
 
-`ui:options` accepts exactly these ten keys — anything else is a validation
-error, because a silently-ignored typo is how a picker ships without ever
-calling your plugin:
+`ui:options` understands these ten keys:
 
 | Key | Meaning |
 | --- | --- |
@@ -436,6 +434,47 @@ calling your plugin:
 | `allow_custom` | Accept a typed value the catalog does not offer. Boolean. |
 | `placeholder` | Trigger placeholder text. String. |
 | `labels_field` | Name of a sibling property collecting a short display name per chosen option. String. Requires `multiple`. |
+
+### Forward compatibility: keys from a newer core
+
+**You may use a `ui:options` key that the user's core does not have yet.** A
+core that does not recognize a key ignores it, records a warning against your
+plugin in `GET /plugins/errors`, and loads the plugin normally. The field still
+renders and still calls `get_options()` — it simply goes without whatever that
+key was going to add.
+
+This matters because the two halves update on different clocks. Plugin
+auto-update runs hourly and is on by default; core updates are a manual image
+pull. Your plugin therefore lands on cores older than the one you wrote it
+against, routinely. When `disney-parks-times` adopted `labels_field` (added in
+core 8.25.0), every board still on 8.24.x would have lost the plugin outright
+at the next auto-update, because an unrecognized `ui:options` key used to be a
+hard validation error and a manifest that fails validation does not load at
+all.
+
+So adopt new grammar freely, but treat it as an enhancement: keep the field
+usable for someone whose core ignores the key. Prefer a picker that degrades to
+"no custom labels" over one that is meaningless without them.
+
+The forgiveness covers **unknown keys only**. A key core does know, carrying a
+value core knows is wrong, is unambiguously your bug and still fails the whole
+manifest:
+
+- a malformed value for a known key — `"cache_seconds": "soon"`,
+  `"labels_field": true`
+- `"ui:widget": "remote-options"` with no `options_id`, or an `options_id` that
+  is not `^[a-z][a-z0-9_]*$`
+- the same `options_id` declared twice anywhere in the schema
+- `depends_on` naming a property that does not exist
+- `labels_field` without `multiple`, or naming a non-sibling
+- `"multiple": true` on a field that is not `"type": "array"`
+- `ui:options` that is not an object at all
+
+The warning names the key and the field path, so a typo (`cache_second`) shows
+up in `GET /plugins/errors` and the container log rather than disappearing. If
+you meant the key, the warning is the expected cost of shipping ahead of core;
+if you did not, it is the typo report. An unrecognized `ui:widget` behaves the
+same way and always has.
 
 ### Per-choice display names (`labels_field`)
 
@@ -527,7 +566,9 @@ touched, so a search box cannot disturb a running listener.
 
 A manifest that declares `remote-options` on a plugin that does not implement
 `get_options()` still loads, but the mismatch is reported by
-`GET /plugins/errors`. An unrecognized `ui:widget` is only a warning.
+`GET /plugins/errors`. An unrecognized `ui:widget`, or an unrecognized
+`ui:options` key, is reported the same way and is likewise not fatal — see
+[Forward compatibility](#forward-compatibility-keys-from-a-newer-core).
 
 ### The HTTP route
 

--- a/src/plugins/loader.py
+++ b/src/plugins/loader.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from .base import PluginBase, TransitionPluginBase
-from .manifest import PluginManifest, collect_options_ids, load_manifest
+from .manifest import PluginManifest, collect_options_ids, load_manifest, settings_schema_ui_warnings
 from .sources import (
     PluginSource,
     get_external_plugins_dir,
@@ -284,6 +284,14 @@ class PluginLoader:
             errors.append(f"Manifest id '{manifest.id}' does not match directory name '{plugin_name}'")
             self._load_errors[plugin_name] = errors
             return None
+
+        # Vocabulary this core does not recognise -- a ui:widget or a
+        # ui:options key from a newer release. Soft failure on purpose: the
+        # manifest is otherwise valid and the plugin must keep working, but an
+        # ignored key is invisible from the settings dialog, so surface it
+        # through GET /plugins/errors rather than only in the container log.
+        for message in settings_schema_ui_warnings(manifest.settings_schema):
+            self._load_errors.setdefault(plugin_name, []).append(message)
 
         # Check FiestaBoard version compatibility (soft failure -- warn but still load)
         if manifest.fiestaboard_version:

--- a/src/plugins/manifest.py
+++ b/src/plugins/manifest.py
@@ -50,8 +50,10 @@ REMOTE_OPTIONS_WIDGET = "remote-options"
 # a boring lowercase identifier.
 OPTIONS_ID_RE = re.compile(r"^[a-z][a-z0-9_]*$")
 
-# Every key a ``ui:options`` block may carry. Anything else is a typo, and a
-# silently-ignored typo is how a picker ships without ever calling the plugin.
+# Every key a ``ui:options`` block *this core* understands. Anything else is
+# either a typo or a key a newer core introduced, and core has no way to tell
+# which -- so it is reported and ignored, never fatal. See
+# ``settings_schema_ui_warnings``.
 #
 # The render flags below are plain booleans. ``multiple`` is deliberately not
 # one of them: it predates the flags and is already policed by its own
@@ -778,12 +780,63 @@ def options_cache_seconds(settings_schema: dict[str, Any], options_id: str) -> i
     return None
 
 
+def settings_schema_ui_warnings(settings_schema: dict[str, Any]) -> list[str]:
+    """Collect the *non-fatal* ``ui:*`` findings in a ``settings_schema``.
+
+    These are the vocabulary gaps -- a ``ui:widget`` or a ``ui:options`` key
+    this core has never heard of. Core cannot tell an author's typo from a
+    piece of grammar a *newer* core introduced, and ``load_manifest`` returns
+    ``None`` on any validation error, so guessing "typo" and failing would
+    uninstall the plugin from every user running a release behind. Plugin
+    auto-update is hourly and on by default; core updates are a manual image
+    pull, so plugin versions routinely run ahead of core versions.
+
+    Malformed *values* for keys this core does know stay hard errors in
+    :func:`validate_settings_schema_ui` -- those are unambiguously author bugs,
+    with no newer-core reading available.
+
+    Args:
+        settings_schema: The manifest's ``settings_schema`` object.
+
+    Returns:
+        List of human-readable warning strings.
+    """
+    warnings: list[str] = []
+
+    for field_path, prop, _siblings in _iter_settings_fields(settings_schema):
+        widget = prop.get("ui:widget")
+        if widget is not None and widget not in KNOWN_SETTINGS_WIDGETS:
+            warnings.append(
+                f"settings_schema.{field_path}: unknown ui:widget '{widget}' — "
+                f"the settings form will fall back to a plain input"
+            )
+        if widget != REMOTE_OPTIONS_WIDGET:
+            continue
+
+        ui_options = prop.get("ui:options")
+        if not isinstance(ui_options, dict):
+            # A non-object ``ui:options`` is a hard error, not a vocabulary
+            # gap -- there are no keys to be forward-compatible about.
+            continue
+
+        for key in sorted(set(ui_options) - UI_OPTIONS_KEYS):
+            warnings.append(
+                f"settings_schema.{field_path}: unknown ui:options key '{key}' — ignored. "
+                f"Check the spelling; if the key is spelled correctly it was added in a newer "
+                f"FiestaBoard, and this core will ignore it until you update."
+            )
+
+    return warnings
+
+
 def validate_settings_schema_ui(settings_schema: dict[str, Any]) -> list[str]:
     """Validate the ``ui:*`` annotations in a plugin's ``settings_schema``.
 
-    Returns a list of hard **errors** (empty when the schema is fine). An
-    unrecognised ``ui:widget`` is deliberately *not* an error -- see the module
-    note on ``load_manifest`` returning ``None`` for any validation failure.
+    Returns a list of hard **errors** (empty when the schema is fine).
+    Unrecognised vocabulary -- an unknown ``ui:widget`` or an unknown
+    ``ui:options`` key -- is deliberately *not* an error; it is reported by
+    :func:`settings_schema_ui_warnings`, which this function logs and the
+    plugin loader surfaces through ``GET /plugins/errors``.
 
     Args:
         settings_schema: The manifest's ``settings_schema`` object.
@@ -795,15 +848,11 @@ def validate_settings_schema_ui(settings_schema: dict[str, Any]) -> list[str]:
     seen_ids: dict[str, str] = {}
     root_properties = settings_schema.get("properties") or {}
 
+    for warning in settings_schema_ui_warnings(settings_schema):
+        logger.warning("%s", warning)
+
     for field_path, prop, siblings in _iter_settings_fields(settings_schema):
         widget = prop.get("ui:widget")
-        if widget is not None and widget not in KNOWN_SETTINGS_WIDGETS:
-            # Soft failure on purpose -- see KNOWN_SETTINGS_WIDGETS.
-            logger.warning(
-                "settings_schema.%s: unknown ui:widget '%s' — the settings form will fall back to a plain input",
-                field_path,
-                widget,
-            )
         if widget != REMOTE_OPTIONS_WIDGET:
             continue
 
@@ -828,9 +877,6 @@ def validate_settings_schema_ui(settings_schema: dict[str, Any]) -> list[str]:
             )
         else:
             seen_ids[options_id] = field_path
-
-        for key in sorted(set(ui_options) - UI_OPTIONS_KEYS):
-            errors.append(f"settings_schema.{field_path}: unknown ui:options key '{key}'")
 
         for key in sorted(UI_OPTIONS_BOOLEAN_KEYS):
             value = ui_options.get(key)

--- a/tests/test_plugin_options.py
+++ b/tests/test_plugin_options.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from src.plugins import manifest as manifest_module
 from src.plugins.base import (
     Option,
     OptionsRequest,
@@ -29,7 +30,12 @@ from src.plugins.base import (
     normalise,
 )
 from src.plugins.loader import PluginLoader
-from src.plugins.manifest import collect_options_ids, validate_manifest, validate_settings_schema_ui
+from src.plugins.manifest import (
+    collect_options_ids,
+    settings_schema_ui_warnings,
+    validate_manifest,
+    validate_settings_schema_ui,
+)
 from src.plugins.registry import PluginRegistry
 
 
@@ -79,8 +85,14 @@ def test_options_id_must_be_a_lowercase_snake_case_identifier():
     assert any("Stock-Symbols" in e for e in errors), errors
 
 
-def test_unknown_key_inside_ui_options_is_an_error():
-    """Typos in ``ui:options`` fail loudly instead of being silently ignored."""
+def test_unknown_key_inside_ui_options_is_a_warning_not_an_error():
+    """Forward compatibility.
+
+    Core cannot tell a typo from a key added by a newer core, and
+    ``load_manifest`` returns ``None`` on *any* validation error — so treating
+    an unrecognised key as fatal uninstalls the plugin from every user whose
+    core is a release behind. It is reported, never fatal.
+    """
     schema = {
         "type": "object",
         "properties": {
@@ -92,27 +104,30 @@ def test_unknown_key_inside_ui_options_is_an_error():
         },
     }
 
-    errors = validate_settings_schema_ui(schema)
-
-    assert any("cache_second" in e for e in errors), errors
+    assert validate_settings_schema_ui(schema) == []
 
 
-def test_a_key_outside_the_grammar_is_still_an_error_after_the_grammar_grew():
-    """Widening the key set for the widget's flags must not open the gate."""
+def test_an_unknown_ui_options_key_is_reported_as_a_warning():
+    """The key still has to be *named* — a silently-ignored typo is how a
+    picker ships without ever calling the plugin."""
     schema = {
         "type": "object",
         "properties": {
             "symbols": {
                 "type": "array",
                 "ui:widget": "remote-options",
-                "ui:options": {"options_id": "symbols", "bogus_key": True},
+                "ui:options": {"options_id": "symbols", "group_by": "exchange"},
             }
         },
     }
 
-    errors = validate_settings_schema_ui(schema)
+    warnings = settings_schema_ui_warnings(schema)
 
-    assert errors == ["settings_schema.symbols: unknown ui:options key 'bogus_key'"]
+    assert warnings == [
+        "settings_schema.symbols: unknown ui:options key 'group_by' — ignored. Check the spelling; "
+        "if the key is spelled correctly it was added in a newer FiestaBoard, and this core will "
+        "ignore it until you update."
+    ]
 
 
 def test_multiple_requires_an_array_typed_field():
@@ -552,6 +567,128 @@ def test_validate_manifest_rejects_a_malformed_remote_options_field():
     assert any("options_id" in e for e in errors), errors
 
 
+# Every ui:options mistake that must keep costing the plugin its load.
+#
+# Forward compatibility is for keys this core has never *heard of* — core
+# cannot tell those from grammar a newer core added. Everything below is
+# either a key core knows carrying a value core knows is wrong, or a broken
+# reference core can resolve for itself. There is no newer-core reading of
+# any of them, so they stay fatal and this table is the fence around that.
+_STILL_FATAL_SETTINGS_SCHEMAS: dict[str, dict[str, Any]] = {
+    "cache_seconds_is_not_an_integer": {
+        "type": "object",
+        "properties": {
+            "symbols": {
+                "type": "array",
+                "ui:widget": "remote-options",
+                "ui:options": {"options_id": "symbols", "cache_seconds": "soon"},
+            }
+        },
+    },
+    "labels_field_is_not_a_string": {
+        "type": "object",
+        "properties": {
+            "symbols": {
+                "type": "array",
+                "ui:widget": "remote-options",
+                "ui:options": {"options_id": "symbols", "multiple": True, "labels_field": True},
+            },
+            "custom_names": {"type": "object"},
+        },
+    },
+    "multiple_is_not_a_boolean": {
+        "type": "object",
+        "properties": {
+            "symbol": {
+                "type": "string",
+                "ui:widget": "remote-options",
+                "ui:options": {"options_id": "symbols", "multiple": "yes"},
+            }
+        },
+    },
+    "remote_options_without_an_options_id": {
+        "type": "object",
+        "properties": {"symbols": {"type": "array", "ui:widget": "remote-options"}},
+    },
+    "depends_on_names_a_property_that_does_not_exist": {
+        "type": "object",
+        "properties": {
+            "stop": {
+                "type": "string",
+                "ui:widget": "remote-options",
+                "ui:options": {"options_id": "stops", "depends_on": ["agencyy"]},
+            },
+            "agency": {"type": "string"},
+        },
+    },
+    "labels_field_without_multiple": {
+        "type": "object",
+        "properties": {
+            "ride_id": {
+                "type": "string",
+                "ui:widget": "remote-options",
+                "ui:options": {"options_id": "rides", "labels_field": "custom_names"},
+            },
+            "custom_names": {"type": "object"},
+        },
+    },
+    "labels_field_names_a_non_sibling": {
+        "type": "object",
+        "properties": {
+            "ride_ids": {
+                "type": "array",
+                "ui:widget": "remote-options",
+                "ui:options": {"options_id": "rides", "multiple": True, "labels_field": "custom_nmaes"},
+            },
+            "custom_names": {"type": "object"},
+        },
+    },
+    "duplicate_options_id_across_the_schema": {
+        "type": "object",
+        "properties": {
+            "home": {"type": "string", "ui:widget": "remote-options", "ui:options": {"options_id": "stops"}},
+            "work": {"type": "string", "ui:widget": "remote-options", "ui:options": {"options_id": "stops"}},
+        },
+    },
+    "multiple_true_on_a_non_array_field": {
+        "type": "object",
+        "properties": {
+            "symbol": {
+                "type": "string",
+                "ui:widget": "remote-options",
+                "ui:options": {"options_id": "symbols", "multiple": True},
+            }
+        },
+    },
+    "ui_options_is_not_an_object_at_all": {
+        "type": "object",
+        "properties": {"symbols": {"type": "array", "ui:widget": "remote-options", "ui:options": "symbols"}},
+    },
+}
+
+
+@pytest.mark.parametrize("case", sorted(_STILL_FATAL_SETTINGS_SCHEMAS))
+def test_a_known_ui_options_mistake_still_stops_the_manifest_loading(case):
+    """Guard against this being 'simplified' into blanket leniency.
+
+    Unknown *keys* became a warning so a plugin built for a newer core keeps
+    working on an older one. That reasoning does not reach any of these: each
+    is a value or a reference this core can judge on its own, and letting one
+    through ships a picker that silently does the wrong thing.
+    """
+    manifest = {
+        "id": "guard",
+        "name": "Guard",
+        "version": "1.0.0",
+        "settings_schema": _STILL_FATAL_SETTINGS_SCHEMAS[case],
+    }
+
+    is_valid, errors = validate_manifest(manifest)
+
+    assert not is_valid, f"{case} must fail validation outright"
+    assert errors, f"{case} must say why"
+
+
 # ── src.plugins.base ────────────────────────────────────────────────────
 
 
@@ -762,7 +899,13 @@ def test_unknown_plugin_raises_key_error(options_registry):
 # ── src.plugins.loader ──────────────────────────────────────────────────
 
 
-def _write_options_plugin(tmp_path: Path, plugin_id: str, *, implements_get_options: bool) -> None:
+def _write_options_plugin(
+    tmp_path: Path,
+    plugin_id: str,
+    *,
+    implements_get_options: bool,
+    ui_options: dict[str, Any] | None = None,
+) -> None:
     """Write a plugin whose manifest declares a remote-options field."""
     plugin_dir = tmp_path / plugin_id
     plugin_dir.mkdir()
@@ -778,7 +921,7 @@ def _write_options_plugin(tmp_path: Path, plugin_id: str, *, implements_get_opti
                         "symbols": {
                             "type": "array",
                             "ui:widget": "remote-options",
-                            "ui:options": {"options_id": "symbols"},
+                            "ui:options": ui_options if ui_options is not None else {"options_id": "symbols"},
                         }
                     },
                 },
@@ -819,6 +962,107 @@ def test_loader_flags_a_manifest_that_promises_options_without_implementing_them
 
     assert plugin is not None, "the plugin must still load"
     assert any("get_options" in e for e in loader.load_errors.get("brokenopts", [])), loader.load_errors
+
+
+def test_loader_loads_a_plugin_using_an_unknown_ui_options_key_and_reports_it(tmp_path):
+    """A key from a newer core must not cost the user the whole plugin.
+
+    It is still reported through ``GET /plugins/errors`` so the author who
+    typed ``cache_second`` finds out, rather than shipping a picker that
+    silently ignores half its configuration.
+    """
+    _write_options_plugin(
+        tmp_path,
+        "futurekeys",
+        implements_get_options=True,
+        ui_options={"options_id": "symbols", "group_by": "exchange"},
+    )
+    loader = PluginLoader(plugins_dir=tmp_path, external_dirs=[])
+
+    plugin = loader.load_plugin("futurekeys")
+
+    assert plugin is not None, "the plugin must still load"
+    assert any("group_by" in e for e in loader.load_errors.get("futurekeys", [])), loader.load_errors
+
+
+_DISNEY_RIDE_PICKER = {
+    "type": "object",
+    "properties": {
+        "ride_ids": {
+            "type": "array",
+            "ui:widget": "remote-options",
+            "ui:options": {
+                "options_id": "rides",
+                "multiple": True,
+                "searchable": True,
+                "labels_field": "custom_names",
+            },
+        },
+        "custom_names": {"type": "object"},
+    },
+}
+
+
+def test_a_manifest_using_a_ui_options_key_from_a_newer_core_still_loads(tmp_path, monkeypatch):
+    """The Disney incident, reproduced.
+
+    ``disney-parks-times`` adopted ``labels_field`` in the release that core
+    8.25.0 introduced it. On 8.24.x that key did not exist, and an unknown
+    ``ui:options`` key was fatal — so the hourly plugin auto-update would have
+    deleted the plugin from every board still on the older image. Core updates
+    are a manual image pull, so that is a lot of boards.
+
+    An older core is simulated by taking the key back out of the grammar.
+    """
+    monkeypatch.setattr(manifest_module, "UI_OPTIONS_KEYS", manifest_module.UI_OPTIONS_KEYS - {"labels_field"})
+    plugin_dir = tmp_path / "disneyparks"
+    plugin_dir.mkdir()
+    (plugin_dir / "manifest.json").write_text(
+        json.dumps(
+            {
+                "id": "disneyparks",
+                "name": "Disney Parks",
+                "version": "1.0.0",
+                "settings_schema": _DISNEY_RIDE_PICKER,
+            }
+        )
+    )
+    (plugin_dir / "__init__.py").write_text(
+        '''"""Test plugin."""
+from src.plugins.base import PluginBase, PluginResult
+
+
+class DisneyPlugin(PluginBase):
+    @property
+    def plugin_id(self) -> str:
+        return "disneyparks"
+
+    def fetch_data(self) -> PluginResult:
+        return PluginResult(available=True, data={})
+
+    def get_options(self, request):
+        return []
+'''
+    )
+    loader = PluginLoader(plugins_dir=tmp_path, external_dirs=[])
+
+    plugin = loader.load_plugin("disneyparks")
+
+    assert plugin is not None, "the plugin must survive a core that predates the key"
+    assert any("labels_field" in e for e in loader.load_errors.get("disneyparks", [])), loader.load_errors
+
+
+def test_a_field_using_a_newer_cores_key_still_works_minus_that_capability(monkeypatch):
+    """Degrade, do not disappear.
+
+    The ride picker keeps dispatching to ``get_options`` and keeps its
+    multi-select; only the per-ride custom labels — the part the older core
+    cannot render — are missing.
+    """
+    monkeypatch.setattr(manifest_module, "UI_OPTIONS_KEYS", manifest_module.UI_OPTIONS_KEYS - {"labels_field"})
+
+    assert validate_settings_schema_ui(_DISNEY_RIDE_PICKER) == []
+    assert collect_options_ids(_DISNEY_RIDE_PICKER) == {"rides"}
 
 
 def test_loader_stays_quiet_when_the_plugin_implements_get_options(tmp_path):


### PR DESCRIPTION
## The asymmetry

Core treated the two halves of the settings-schema vocabulary inconsistently, and the inconsistency was pointed the wrong way.

| | Before | Result |
| --- | --- | --- |
| Unknown `ui:widget` | warning | manifest loads, field falls back to a plain input |
| Unknown `ui:options` key | **hard error** | `validate_settings_schema_ui` → `validate_manifest` → `load_manifest()` returns `None` → **the plugin does not load at all** |

The widget leniency was deliberate. `stocks`, `muni` and `lyft-bike-share` all ship widget names core never implemented, and the comment next to `KNOWN_SETTINGS_WIDGETS` says rejecting them "would uninstall them in practice."

The exact same reasoning applies to `ui:options` keys, and more strongly — new keys arrive there far more often than new widgets do. Core cannot tell whether an unknown key is the author's typo or a key from a newer core, and it was resolving that ambiguity by deleting the plugin.

## The Disney incident this prevents

`disney-parks-times` v1.3.0 adopted `labels_field`, added in core **8.25.0**. Anyone still on 8.24.x would have lost the plugin entirely at the next auto-update. Plugin auto-update runs hourly and is on by default; core updates are a manual image pull — so plugin versions routinely run ahead of core versions, and this is a normal state, not an edge case.

Verified against the live `disney-parks-times` manifest (`main` @ `97159f4`, v1.3.0), with `labels_field` removed from the grammar to simulate 8.24.x:

```
--- with origin/main (pre-change) ---
disney-parks-times on a core that predates labels_field -> REJECTED
   ERROR: settings_schema.parks.items.ride_ids: unknown ui:options key 'labels_field'

--- with this branch ---
settings_schema.parks.items.ride_ids: unknown ui:options key 'labels_field' — ignored.
Check the spelling; if the key is spelled correctly it was added in a newer FiestaBoard,
and this core will ignore it until you update.
disney-parks-times on a core that predates labels_field -> LOADS
```

The ride picker keeps its `options_id`, keeps dispatching to `get_options()`, keeps its multi-select. Only the per-ride custom labels — the part the older core genuinely cannot render — go missing.

#1553 blocks auto-update when the incoming `fiestaboard_version` floor exceeds the running core, which helps going forward but only protects users who already have that guard. This PR addresses the deeper issue: an unknown key should never have been fatal.

## What now warns

An unknown `ui:options` key on a `remote-options` field. It is collected by the new `settings_schema_ui_warnings()`, logged by `validate_settings_schema_ui()`, and recorded by the loader into `_load_errors` so it surfaces through `GET /plugins/errors`. An ignored key is invisible from the settings dialog, so a typo still has to land somewhere the author will look.

Unknown `ui:widget` values now flow through the same collector. Behaviour is unchanged except that they, too, now appear in `GET /plugins/errors` instead of only the container log.

Wording is deliberately typo-first — "Check the spelling; if the key is spelled correctly it was added in a newer FiestaBoard" — so an author debugging `cache_second` is not sent looking for a core upgrade.

## What stays fatal

Everything core can judge on its own. No newer-core reading is available for any of these, so they remain hard errors, one test each so nobody can later "simplify" this into blanket leniency:

- a malformed value for a key core knows — `"cache_seconds": "soon"`, `"labels_field": true`, `"multiple": "yes"` on a non-array field
- `"ui:widget": "remote-options"` with no `options_id`
- `depends_on` naming a property that does not exist
- `labels_field` without `multiple`
- `labels_field` naming a non-sibling
- duplicate `options_id` across the schema
- `"multiple": true` on a non-array field
- `ui:options` that is not an object at all

## Tests

13 new tests. Non-vacuity was proved by mutation for every one of them:

- restoring the `errors.append(...)` for unknown keys fails the four forward-compatibility tests (`the plugin must survive a core that predates the key` / `assert None is not None`)
- replacing `return errors` with `return []` in `validate_settings_schema_ui` fails all 10 still-fatal cases
- disabling only the `cache_seconds` range check fails exactly that one case
- removing the loader's warning-recording loop fails both loader tests with `AssertionError: {}`

The pre-existing `test_unknown_ui_widget_warns_but_the_manifest_still_validates` is unchanged and still passes.

Two tests that encoded the old contract were rewritten rather than deleted: `test_unknown_key_inside_ui_options_is_an_error` became `..._is_a_warning_not_an_error`, and `test_a_key_outside_the_grammar_is_still_an_error_after_the_grammar_grew` became `test_an_unknown_ui_options_key_is_reported_as_a_warning`, which pins the exact warning text.

## Verification

- Python suite: **4717 → 4730 passed**, 13 deselected, 0 failed
- Coverage: 88.24% → **88.25%**, gate `--cov-fail-under=80` met
- `ruff check` and `ruff format --check` (ruff 0.16.1) clean over `src/ plugins/ tests/ scripts/`
- `scripts/validate_plugins.py --verbose`: 7 plugins, 0 errors, 0 warnings
- All six live shipped manifests fetched from their repos and asserted to load: `disney-parks-times` v1.3.0, `home-assistant` v1.3.0, `lyft-bike-share` v2.1.0, `muni` v1.2.0, `wsdot` v1.2.0, `stocks` v1.1.2

## Known gap, not changed here

`"multiple": "yes"` on a field that *is* `"type": "array"` is accepted today — `multiple` is deliberately outside `UI_OPTIONS_BOOLEAN_KEYS` and is policed only by its "requires type 'array'" rule, which does not fire there. This PR does not tighten it: adding a new hard error would strand any manifest already shipping that value, which is exactly the failure mode being fixed. The still-fatal test covers `"multiple": "yes"` in the form that is fatal today (on a non-array field).

## Docs

`docs/development/PLUGIN_DEVELOPMENT.md` gains a "Forward compatibility: keys from a newer core" section stating the contract explicitly — plugins may use `ui:options` keys from newer cores, older cores ignore them with a warning rather than refusing to load — with the full list of what remains fatal, and guidance to treat new grammar as an enhancement that degrades rather than a hard requirement.
