### PR TITLE
fix(mcp): route set_active_page and set_schedule_mode at services that exist

### DIFF
--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -957,7 +957,7 @@ def _build_mcp_server() -> Any:
             return _err(str(exc))
 
     @mcp.tool()
-    def set_active_page(page_id: str) -> dict[str, Any]:
+    async def set_active_page(page_id: str) -> dict[str, Any]:
         """Set which page is currently shown on the FiestaBoard display.
 
         This immediately changes what's visible on the board.
@@ -965,14 +965,34 @@ def _build_mcp_server() -> Any:
         Args:
             page_id: The page or collection ID to display (from list_pages() or list_collections()).
         """
-        try:
-            from .config_manager import get_config_manager
+        # Delegate to the REST handler rather than reimplementing it. Selecting
+        # a page is more than a settings write: it validates the ref, enforces
+        # page<->board size compatibility, dismisses active plugin triggers so
+        # the choice sticks (#856), and renders to the board. Issue #1559 was
+        # this tool going its own way and calling a method that never existed.
+        from fastapi import HTTPException
 
-            cm = get_config_manager()
-            cm.set_active_page(page_id)
-            return _ok(f"Active page set to '{page_id}'.", page_id=page_id)
+        from .api_server import set_active_page as _rest_set_active_page
+
+        try:
+            response = await _rest_set_active_page({"page_id": page_id})
+        except HTTPException as exc:
+            return _err(f"Error setting active page: {exc.detail}")
         except Exception as exc:
             return _err(f"Error setting active page: {exc}")
+
+        message = f"Active page set to '{page_id}'."
+        if response.get("paused"):
+            message += " The board is paused, so it will appear when you resume it."
+        elif not response.get("sent_to_board"):
+            message += " It will appear on the board on the next display refresh."
+        return _ok(
+            message,
+            page_id=page_id,
+            sent_to_board=bool(response.get("sent_to_board")),
+            paused=bool(response.get("paused")),
+            warnings=response.get("warnings", []),
+        )
 
     @mcp.tool()
     def set_schedule_mode(enabled: bool) -> dict[str, Any]:
@@ -985,9 +1005,11 @@ def _build_mcp_server() -> Any:
             enabled: True to enable schedule-based display, False to disable.
         """
         try:
-            from .schedules.service import get_schedule_service
+            # Schedule mode is a settings flag (per-board since #1244), not
+            # something ScheduleService owns — same mixup as issue #1559.
+            from .settings.service import get_settings_service
 
-            svc = get_schedule_service()
+            svc = get_settings_service()
             svc.set_schedule_enabled(enabled)
             state = "enabled" if enabled else "disabled"
             return _ok(f"Schedule mode {state}.", enabled=enabled)

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -17,8 +17,9 @@ Strategy
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
 
@@ -49,7 +50,9 @@ def _call_tool(mcp_instance: Any, tool_name: str, **kwargs: Any) -> Any:
         raise KeyError(f"Tool '{tool_name}' not registered. Available: {list(mgr._tools)}")
     result = tool.fn(**kwargs)
     if asyncio.iscoroutine(result):
-        result = asyncio.get_event_loop().run_until_complete(result)
+        # asyncio.run(), not get_event_loop(): 3.14 raises RuntimeError when
+        # there is no current loop rather than creating one implicitly.
+        result = asyncio.run(result)
     return result
 
 
@@ -68,8 +71,10 @@ def mcp():
 
 @pytest.fixture
 def mock_registry():
-    """Minimal mock plugin registry."""
-    registry = MagicMock()
+    """Minimal mock plugin registry, specced against the real class."""
+    from src.plugins.registry import PluginRegistry
+
+    registry = create_autospec(PluginRegistry, instance=True)
     registry.list_plugins.return_value = [
         {
             "id": "openweather",
@@ -94,8 +99,10 @@ def mock_registry():
 
 @pytest.fixture
 def mock_config_manager():
-    """Minimal mock config manager."""
-    cm = MagicMock()
+    """Minimal mock config manager, specced against the real class."""
+    from src.config_manager import ConfigManager
+
+    cm = create_autospec(ConfigManager, instance=True)
     cm.get_plugin_config.return_value = {"api_key": "secret123", "units": "imperial"}
     cm._mask_sensitive.return_value = {"api_key": "***", "units": "imperial"}
     return cm
@@ -103,8 +110,10 @@ def mock_config_manager():
 
 @pytest.fixture
 def mock_page_service():
-    """Minimal mock page service."""
-    svc = MagicMock()
+    """Minimal mock page service, specced against the real class."""
+    from src.pages.service import PageService
+
+    svc = create_autospec(PageService, instance=True)
     page = MagicMock()
     page.id = "page-001"
     page.name = "Weather"
@@ -136,8 +145,10 @@ def mock_page_service():
 
 @pytest.fixture
 def mock_schedule_service():
-    """Minimal mock schedule service."""
-    svc = MagicMock()
+    """Minimal mock schedule service, specced against the real class."""
+    from src.schedules.service import ScheduleService
+
+    svc = create_autospec(ScheduleService, instance=True)
     entry = MagicMock()
     entry.id = "sched-001"
     entry.page_id = "page-001"
@@ -161,8 +172,10 @@ def mock_schedule_service():
 
 @pytest.fixture
 def mock_collection_service():
-    """Minimal mock collection service."""
-    svc = MagicMock()
+    """Minimal mock collection service, specced against the real class."""
+    from src.collections.service import CollectionService
+
+    svc = create_autospec(CollectionService, instance=True)
     c = MagicMock()
     c.id = "collection-001"
     c.name = "Daily"
@@ -182,15 +195,73 @@ def mock_collection_service():
 
 
 @pytest.fixture
-def mock_settings_service():
-    """Minimal mock settings service.
+def autospec_settings_service():
+    """A SettingsService mock that refuses calls the real class doesn't define.
+
+    Plain MagicMock() conjures any attribute on access, which is how issue
+    #1559 shipped: the tool called a method that never existed and the test
+    asserting on it still passed. create_autospec() is what makes that
+    impossible — an unknown attribute raises AttributeError.
+    """
+    from src.settings.service import SettingsService
+
+    return create_autospec(SettingsService, instance=True)
+
+
+@pytest.fixture
+def api_stack(mock_page_service):
+    """Stand up the collaborators PUT /settings/active-page needs.
+
+    set_active_page delegates to that endpoint so the two can't drift apart,
+    so the tool's tests have to satisfy the endpoint's dependencies.
+    """
+    from src.pages.service import BoardCompatibility
+    from src.settings.service import SettingsService
+    from src.triggers.service import TriggerService
+
+    settings = create_autospec(SettingsService, instance=True)
+    settings.should_send_to_board.return_value = True
+    settings.get_primary_board_id.return_value = None
+    settings.get_transition_settings.return_value = SimpleNamespace(
+        strategy="instant", step_interval_ms=100, step_size=1
+    )
+
+    triggers = create_autospec(TriggerService, instance=True)
+
+    client = MagicMock()
+    client.render.return_value = (True, True)
+    service = MagicMock()
+    service.vb_client = client
+
+    preview = SimpleNamespace(available=True, formatted="HELLO")
+    mock_page_service.preview_page.return_value = preview
+
+    with (
+        patch("src.api_server.get_settings_service", return_value=settings),
+        patch("src.api_server.get_page_service", return_value=mock_page_service),
+        patch("src.api_server.get_service", return_value=service),
+        patch("src.triggers.service.get_trigger_service", return_value=triggers),
+        # ok is a derived property (error is None), not a constructor arg.
+        patch("src.api_server.check_ref_board_compatibility", return_value=BoardCompatibility()),
+        patch("src.api_server._board_is_paused", return_value=False),
+    ):
+        yield {
+            "settings": settings,
+            "pages": mock_page_service,
+            "triggers": triggers,
+            "service": service,
+            "client": client,
+        }
+
+
+@pytest.fixture
+def mock_settings_service(autospec_settings_service):
+    """Minimal mock settings service, specced against the real class.
 
     Uses SimpleNamespace for return values so Python 3.14's stricter
     MagicMock.__dict__ handling doesn't interfere.
     """
-    from types import SimpleNamespace
-
-    svc = MagicMock()
+    svc = autospec_settings_service
     svc.get_display_settings.return_value = SimpleNamespace(brightness=80, refresh_rate=30)
     svc.get_location_settings.return_value = SimpleNamespace(
         latitude=40.7128, longitude=-74.0060, timezone="America/New_York"
@@ -750,33 +821,62 @@ class TestGetSettingsSummary:
 
 
 class TestSetActivePage:
-    def test_set_active_page(self, mcp):
-        mock_cm = MagicMock()
-        with patch("src.config_manager.get_config_manager", return_value=mock_cm):
-            result = _call_tool(mcp, "set_active_page", page_id="page-001")
-        assert result["page_id"] == "page-001"
-        mock_cm.set_active_page.assert_called_once_with("page-001")
+    """Issue #1559 — the tool called ConfigManager.set_active_page(), which
+    does not exist, so every call was a no-op that returned an error string.
 
-    def test_error_handling(self, mcp):
-        mock_cm = MagicMock()
-        mock_cm.set_active_page.side_effect = ValueError("page not found")
-        with patch("src.config_manager.get_config_manager", return_value=mock_cm):
-            result = _call_tool(mcp, "set_active_page", page_id="bad-id")
+    These tests pin the tool to the same path the REST endpoint takes:
+    persist via SettingsService, dismiss plugin triggers, push to the board.
+    """
+
+    def test_persists_selection_via_settings_service(self, mcp, api_stack):
+        result = _call_tool(mcp, "set_active_page", page_id="page-001")
+
+        assert result["status"] == "success", result
+        api_stack["settings"].set_active_page_id.assert_called_once_with("page-001")
+
+    def test_pushes_the_page_to_the_board(self, mcp, api_stack):
+        """The docstring promises it immediately changes what's on the board."""
+        result = _call_tool(mcp, "set_active_page", page_id="page-001")
+
+        assert result["status"] == "success", result
+        api_stack["client"].render.assert_called_once()
+
+    def test_dismisses_plugin_triggers_so_the_choice_sticks(self, mcp, api_stack):
+        """Without this a re-emitting plugin trigger overwrites the user's pick (#856)."""
+        _call_tool(mcp, "set_active_page", page_id="page-001")
+
+        api_stack["triggers"].dismiss_active_for_user_override.assert_called_once()
+
+    def test_unknown_page_reports_error_and_persists_nothing(self, mcp, api_stack):
+        api_stack["pages"].get_page.return_value = None
+
+        result = _call_tool(mcp, "set_active_page", page_id="no-such-page")
+
         assert result["status"] == "error"
+        assert "no-such-page" in result["error"]
+        api_stack["settings"].set_active_page_id.assert_not_called()
 
 
 class TestSetScheduleMode:
-    def test_enable(self, mcp, mock_schedule_service):
-        with patch("src.schedules.service.get_schedule_service", return_value=mock_schedule_service):
-            result = _call_tool(mcp, "set_schedule_mode", enabled=True)
-        assert result["enabled"] is True
-        assert "enabled" in result["message"]
+    """Same defect class as #1559: the tool called
+    ScheduleService.set_schedule_enabled(), which lives on SettingsService.
+    """
 
-    def test_disable(self, mcp, mock_schedule_service):
-        with patch("src.schedules.service.get_schedule_service", return_value=mock_schedule_service):
+    def test_enable_persists_via_settings_service(self, mcp, autospec_settings_service):
+        with patch("src.settings.service.get_settings_service", return_value=autospec_settings_service):
+            result = _call_tool(mcp, "set_schedule_mode", enabled=True)
+
+        assert result["status"] == "success", result
+        assert result["enabled"] is True
+        autospec_settings_service.set_schedule_enabled.assert_called_once_with(True)
+
+    def test_disable_persists_via_settings_service(self, mcp, autospec_settings_service):
+        with patch("src.settings.service.get_settings_service", return_value=autospec_settings_service):
             result = _call_tool(mcp, "set_schedule_mode", enabled=False)
+
+        assert result["status"] == "success", result
         assert result["enabled"] is False
-        assert "disabled" in result["message"]
+        autospec_settings_service.set_schedule_enabled.assert_called_once_with(False)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_service_wiring.py
+++ b/tests/test_service_wiring.py
@@ -1,0 +1,297 @@
+"""Contract test: service calls in client-facing surfaces must actually exist.
+
+Issue #1559 — the MCP tool ``set_active_page`` called
+``ConfigManager.set_active_page()``, a method that has never existed. The tool
+caught its own ``AttributeError`` and returned it as an error string, so it
+failed silently for every user, in every release, while its unit test passed.
+
+The test passed because it asserted against ``MagicMock()``, which conjures any
+attribute on access. A mock that agrees with whatever you call on it cannot
+tell you that production code is calling into thin air.
+
+Two things guard against that now:
+
+1. ``tests/test_mcp_server.py`` builds its service mocks with
+   ``create_autospec()``, so a phantom method raises instead of passing.
+   That covers the code paths tests actually execute.
+2. This module, which covers the rest. It parses each surface's AST, resolves
+   every ``svc = get_x_service(); svc.method(...)`` call against the real class
+   behind ``get_x_service``, and fails if the attribute does not exist —
+   whether or not any test ever calls that tool.
+
+The same scan found a second live bug in the same commit: ``set_schedule_mode``
+called ``ScheduleService.set_schedule_enabled()``, which lives on
+``SettingsService``. Nobody had reported it.
+
+Scope: surfaces where a lazily-imported singleton is called by name and a typo
+or a moved method degrades into a runtime error string rather than a crash.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import types
+import typing
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+# Surfaces scanned. Each is a client-facing command layer that resolves service
+# singletons by lazy import and swallows exceptions into an error response.
+SCANNED_MODULES = [
+    "src/mcp_server.py",
+    "src/mqtt/commands.py",
+]
+
+# A scan that resolves nothing passes vacuously. If the import or call style in
+# these modules changes such that the analyzer stops recognizing it, this floor
+# fails and tells us the test went blind rather than quietly finding nothing.
+MIN_RESOLVED_CALLS = {
+    "src/mcp_server.py": 35,
+    "src/mqtt/commands.py": 15,
+}
+
+
+@dataclass(frozen=True)
+class MissingCall:
+    """A call to a service attribute that the real class does not define."""
+
+    path: str
+    line: int
+    func: str
+    expr: str
+    detail: str
+
+    def __str__(self) -> str:
+        return f"{self.path}:{self.line} in {self.func}(): {self.expr} — {self.detail}"
+
+
+def _own_nodes(fn: ast.AST) -> list[ast.AST]:
+    """Every node in ``fn``'s body, not descending into nested functions.
+
+    Required for ``mcp_server.py``: all ~39 tools are nested inside
+    ``_build_mcp_server``, and a naive ``ast.walk`` would pool their locals
+    into one namespace where ``svc`` means whatever the last tool assigned.
+    """
+    nested = (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)
+    out: list[ast.AST] = []
+    stack = [n for n in fn.body if not isinstance(n, nested)]
+    while stack:
+        node = stack.pop()
+        out.append(node)
+        stack.extend(c for c in ast.iter_child_nodes(node) if not isinstance(c, nested))
+    return out
+
+
+def _candidate_classes(annotation: object) -> list[type]:
+    """Unwrap ``X | None`` / ``Optional[X]`` to the concrete classes.
+
+    ``get_service() -> DisplayService | None`` is the common shape; callers
+    null-check and then use it, so the attribute must exist on ``DisplayService``
+    and ``None`` is not a counterexample.
+    """
+    origin = typing.get_origin(annotation)
+    if origin in (typing.Union, types.UnionType):
+        return [a for arg in typing.get_args(annotation) for a in _candidate_classes(arg) if a is not type(None)]
+    return [annotation] if isinstance(annotation, type) and annotation is not type(None) else []
+
+
+def _collect_getters(tree: ast.AST) -> dict[str, str]:
+    """Map imported ``get_*`` names to the module they come from."""
+    getters: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            module = f"src.{node.module}" if node.level else node.module
+            for alias in node.names:
+                if alias.name.startswith("get_"):
+                    getters[alias.asname or alias.name] = module
+    return getters
+
+
+def _resolve(getter: str, module: str) -> tuple[list[type], str | None]:
+    """Resolve a getter to the class(es) it can return, via its return annotation."""
+    try:
+        mod = importlib.import_module(module)
+    except Exception as exc:  # pragma: no cover - import failure is its own signal
+        return [], f"cannot import {module}: {exc}"
+    fn = getattr(mod, getter, None)
+    if fn is None:
+        return [], f"{module} has no attribute {getter!r}"
+    try:
+        hints = typing.get_type_hints(fn)
+    except Exception as exc:  # pragma: no cover - unresolvable forward ref
+        return [], f"cannot resolve type hints for {getter}: {exc}"
+    if "return" not in hints:
+        # Unannotated getter: nothing to check against, and not a defect.
+        return [], None
+    return _candidate_classes(hints["return"]), None
+
+
+def scan_source(source: str, path: str, getters_scope: dict[str, str] | None = None) -> tuple[list[MissingCall], int]:
+    """Find calls to service attributes that don't exist on the real class.
+
+    Returns the findings plus how many attribute accesses were successfully
+    resolved and checked — the latter is what proves the scan wasn't a no-op.
+
+    Recognizes both shapes used in the codebase::
+
+        svc = get_page_service()
+        svc.list_pages()            # via local binding
+        get_page_service().list_pages()   # chained
+    """
+    tree = ast.parse(source, path)
+    getters = getters_scope if getters_scope is not None else _collect_getters(tree)
+    findings: list[MissingCall] = []
+    checked = 0
+
+    def check(classes: list[type], attr: str, node: ast.AST, func: str, expr: str, err: str | None) -> None:
+        nonlocal checked
+        if err:
+            findings.append(MissingCall(path, node.lineno, func, expr, err))
+            return
+        if not classes:
+            return
+        checked += 1
+        if not any(hasattr(cls, attr) for cls in classes):
+            names = " / ".join(c.__name__ for c in classes)
+            findings.append(MissingCall(path, node.lineno, func, expr, f"{names} has no attribute {attr!r}"))
+
+    for fn in ast.walk(tree):
+        if not isinstance(fn, ast.FunctionDef | ast.AsyncFunctionDef):
+            continue
+        body = _own_nodes(fn)
+
+        bindings: dict[str, str] = {}
+        for node in body:
+            if isinstance(node, ast.Assign) and isinstance(node.value, ast.Call):
+                target = node.value.func
+                if isinstance(target, ast.Name) and target.id in getters:
+                    for t in node.targets:
+                        if isinstance(t, ast.Name):
+                            bindings[t.id] = target.id
+
+        for node in body:
+            if not isinstance(node, ast.Attribute):
+                continue
+            # svc.method
+            if isinstance(node.value, ast.Name) and node.value.id in bindings:
+                getter = bindings[node.value.id]
+                classes, err = _resolve(getter, getters[getter])
+                check(classes, node.attr, node, fn.name, f"{node.value.id}.{node.attr}", err)
+            # get_x_service().method
+            elif (
+                isinstance(node.value, ast.Call)
+                and isinstance(node.value.func, ast.Name)
+                and node.value.func.id in getters
+            ):
+                getter = node.value.func.id
+                classes, err = _resolve(getter, getters[getter])
+                check(classes, node.attr, node, fn.name, f"{getter}().{node.attr}", err)
+
+    return findings, checked
+
+
+# ---------------------------------------------------------------------------
+# The analyzer has to be trustworthy before its green result means anything.
+# ---------------------------------------------------------------------------
+
+_GOOD_SOURCE = """
+from src.settings.service import get_settings_service
+
+def tool():
+    svc = get_settings_service()
+    svc.set_active_page_id("page-1")
+"""
+
+_BAD_SOURCE = """
+from src.config_manager import get_config_manager
+
+def tool():
+    cm = get_config_manager()
+    cm.set_active_page("page-1")
+"""
+
+_BAD_CHAINED_SOURCE = """
+from src.settings.service import get_settings_service
+
+def tool():
+    get_settings_service().set_active_page("page-1")
+"""
+
+_NESTED_SOURCE = """
+from src.pages.service import get_page_service
+from src.settings.service import get_settings_service
+
+def build():
+    def tool_a():
+        svc = get_page_service()
+        return svc.list_pages()
+
+    def tool_b():
+        svc = get_settings_service()
+        return svc.get_active_page_id()
+"""
+
+
+class TestAnalyzerIsNotVacuous:
+    """If these fail, a green wiring scan means nothing."""
+
+    def test_flags_the_call_from_issue_1559(self):
+        findings, checked = scan_source(_BAD_SOURCE, "<bad>")
+
+        assert checked == 1
+        assert len(findings) == 1
+        assert "set_active_page" in findings[0].detail
+        assert "ConfigManager" in findings[0].detail
+
+    def test_flags_a_chained_getter_call(self):
+        findings, _ = scan_source(_BAD_CHAINED_SOURCE, "<bad-chained>")
+
+        assert len(findings) == 1
+        assert "SettingsService" in findings[0].detail
+
+    def test_accepts_a_method_that_exists(self):
+        findings, checked = scan_source(_GOOD_SOURCE, "<good>")
+
+        assert findings == []
+        assert checked == 1
+
+    def test_does_not_leak_locals_between_sibling_functions(self):
+        """``svc`` means a different class in each nested tool."""
+        findings, checked = scan_source(_NESTED_SOURCE, "<nested>")
+
+        assert findings == []
+        assert checked == 2
+
+    def test_optional_return_resolves_to_the_concrete_class(self):
+        """``get_service() -> DisplayService | None`` must not degrade to Union."""
+        from src.api_server import get_service
+
+        classes, err = _resolve("get_service", "src.api_server")
+
+        assert err is None
+        assert get_service is not None
+        assert classes, "Optional[...] unwrapped to nothing — every call would be skipped"
+        assert type(None) not in classes
+
+
+# ---------------------------------------------------------------------------
+# The actual contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("path", SCANNED_MODULES)
+def test_service_calls_resolve_to_real_methods(path):
+    """Every service method a client surface calls must exist on the real class."""
+    pytest.importorskip("mcp", reason="mcp package not installed")
+
+    findings, checked = scan_source(Path(path).read_text(), path)
+
+    assert checked >= MIN_RESOLVED_CALLS[path], (
+        f"only resolved {checked} service calls in {path} (expected >= {MIN_RESOLVED_CALLS[path]}). "
+        "The analyzer has likely stopped recognizing this module's call style — "
+        "a low count makes this test pass without checking anything."
+    )
+    assert not findings, "Calls to methods that do not exist:\n" + "\n".join(f"  {f}" for f in findings)


### PR DESCRIPTION
Fixes #1559.

## The bug

`set_active_page` called `ConfigManager.set_active_page()` — a method that has never existed. The tool caught its own `AttributeError` and returned it to the client as an error string, so it was a complete no-op: nothing written, board unchanged, in every release.

Hardening the tests to catch it found a **second, unreported instance of the same defect**:

| Tool | Called | Actually lives on |
|---|---|---|
| `set_active_page` | `ConfigManager.set_active_page()` | `SettingsService.set_active_page_id()` |
| `set_schedule_mode` | `ScheduleService.set_schedule_enabled()` | `SettingsService.set_schedule_enabled()` |

This is one defect, not two: the settings API moved to `SettingsService` and these two call sites were left behind. Every other caller — REST (`api_server.py`), MQTT (`mqtt/commands.py`), the main loop, the page service — had been updated. MCP schedule mode has never worked and nobody had reported it.

## The fix

**`set_active_page`** now delegates to the `PUT /settings/active-page` handler instead of reimplementing it. Selecting a page is more than a settings write — it validates the ref, enforces page↔board size compatibility, dismisses active plugin triggers so the choice sticks (#856), and renders to the board. Delegating removes the drift that caused this in the first place. The tool became `async` to await the handler, and now returns `sent_to_board` / `paused` so a client can tell the user *why* the board hasn't changed yet (board paused, or waiting for the next display refresh).

**`set_schedule_mode`** routes through `SettingsService`, matching the REST endpoint exactly.

## Why no test caught it

There *was* a test for `set_active_page`, and it passed:

```python
mock_cm = MagicMock()
...
mock_cm.set_active_page.assert_called_once_with("page-001")   # phantom method
```

`MagicMock()` conjures any attribute on access. The test asserted that production code called a method that doesn't exist — and agreed with it. Every service mock in the file had this problem, so none of the ~60 tool tests could catch a miswired call.

## Testing

**1. Autospec fixtures.** All six service fixtures in `test_mcp_server.py` now use `create_autospec(RealClass, instance=True)`, so a phantom method raises instead of passing. All 93 existing tests still pass — nothing else was hiding in the paths tests already execute.

**2. Behavioral tests** for both tools, asserting real outcomes rather than mock calls: the selection persists, the page is pushed to the board, plugin triggers are dismissed, and an unknown page id errors *without* persisting.

**3. `tests/test_service_wiring.py` (new).** A contract test that parses `src/mcp_server.py` and `src/mqtt/commands.py`, resolves every `svc = get_x_service(); svc.method()` call against the real class behind the getter, and fails if the method doesn't exist. This is what found the `set_schedule_mode` bug — it covers all 39 MCP tools whether or not any test calls them. MQTT is included because it's the other surface with the same lazy-import-and-swallow-exceptions shape; it scans clean.

The analyzer handles the three traps that would make this check quietly useless:
- **nested scoping** — all 39 tools live inside `_build_mcp_server`, so a naive `ast.walk` pools their locals into one namespace where `svc` means whatever the last tool assigned
- **chained calls** — `get_settings_service().method()`, not just local bindings
- **`Optional` returns** — `get_service() -> DisplayService | None` must resolve to `DisplayService`, not `Union`

## Evidence the tests aren't vacuous

The wiring test carries meta-tests asserting the analyzer flags a known-bad call, accepts a known-good one, and doesn't leak locals between sibling functions — plus a floor on resolved-call count (43 and 21 actual, 35/15 floors) so it fails loudly if it ever goes blind instead of passing on zero checks.

I reintroduced both bugs in `mcp_server.py` and re-ran the suite:

```
FAILED tests/test_service_wiring.py::test_service_calls_resolve_to_real_methods[src/mcp_server.py]
E   AssertionError: Calls to methods that do not exist:
E     src/mcp_server.py:978 in set_active_page(): get_config_manager().set_active_page
E         — ConfigManager has no attribute 'set_active_page'
E     src/mcp_server.py:1014 in set_schedule_mode(): svc.set_schedule_enabled
E         — ScheduleService has no attribute 'set_schedule_enabled'

FAILED tests/test_mcp_server.py::TestSetActivePage::test_persists_selection_via_settings_service
FAILED tests/test_mcp_server.py::TestSetActivePage::test_pushes_the_page_to_the_board
FAILED tests/test_mcp_server.py::TestSetActivePage::test_dismisses_plugin_triggers_so_the_choice_sticks
FAILED tests/test_mcp_server.py::TestSetActivePage::test_unknown_page_reports_error_and_persists_nothing
FAILED tests/test_mcp_server.py::TestSetScheduleMode::test_enable_persists_via_settings_service
FAILED tests/test_mcp_server.py::TestSetScheduleMode::test_disable_persists_via_settings_service

7 failed, 93 passed
```

Then restored and confirmed green: 296 passed across `test_mcp_server`, `test_service_wiring`, the MCP auth suites, `test_api_coverage`, and `tests/contract`. `ruff check` clean over `src/` and the changed tests; `ruff format --check` clean.

## End-to-end verification

Ran against real services with no mocks (containerized, isolated data dir):

```
before         : b7d08ab8-…
set_active_page: {'status': 'success', 'message': "Active page set to '94ccceef-…'.
                  It will appear on the board on the next display refresh.",
                  'sent_to_board': False, 'paused': False, 'warnings': []}
after          : 94ccceef-…
bad page       : {'status': 'error', 'error': 'Error setting active page: Page not found: does-not-exist'}
set_schedule_mode(True)  -> persisted=True
set_schedule_mode(False) -> persisted=False
```

The active page persists to `settings.json`, a bad id returns a clean error without clobbering the current selection, and schedule mode persists both directions. (`sent_to_board: False` because no board is configured in that bare environment — the message explains it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)