### PR TITLE
fix(schedule): stack schedule list rows on phone viewports

### DIFF
--- a/web/src/components/schedule/schedule-list-view.tsx
+++ b/web/src/components/schedule/schedule-list-view.tsx
@@ -197,24 +197,39 @@ export function ScheduleListView({
               const pageName = getPageName(schedule.page_id);
               const toggleId = `schedule-enabled-${schedule.id}`;
               return (
-                <Flex key={schedule.id} align="center" justify="between" className="p-4 border rounded-lg">
-                  <Box className="flex-1">
-                    <Flex align="center" gap="2" className="mb-1">
+                <Flex
+                  key={schedule.id}
+                  direction="col"
+                  gap="3"
+                  // Phone: description on top, controls on their own row beneath.
+                  // Squeezing both into one row can't work — the text column's
+                  // min-content plus the toggle and buttons is wider than a
+                  // phone viewport, so the actions used to render off-screen
+                  // (#1558). From `sm` up it's the original single row.
+                  className="p-4 border rounded-lg sm:flex-row sm:items-center sm:justify-between sm:gap-4"
+                  data-testid="schedule-list-row"
+                >
+                  {/* min-w-0 lets the text column shrink past its min-content
+                      width instead of pushing the actions out of the row. */}
+                  <Box className="min-w-0 sm:flex-1">
+                    <Flex align="center" gap="2" wrap className="mb-1">
                       {isCollectionId(schedule.page_id) && (
                         <GalleryHorizontalEnd className="h-4 w-4 text-muted-foreground flex-shrink-0" />
                       )}
-                      <Text as="span" weight="medium">
+                      <Text as="span" weight="medium" className="break-words">
                         {pageName}
                       </Text>
                       {!schedule.enabled && <Badge variant="secondary">{tCommon("disabled")}</Badge>}
                     </Flex>
-                    <Text tone="muted">
+                    <Text tone="muted" className="break-words">
                       {formatTimeDisplay(schedule)} • {formatDays(schedule)}
                     </Text>
                   </Box>
-                  <Flex align="center" gap="2">
+                  <Flex align="center" gap="2" className="sm:flex-shrink-0">
                     {onToggleEnabled && (
-                      <Flex align="center" gap="2" className="pr-2 border-r mr-1">
+                      // The divider only reads as one on the single-row layout;
+                      // stacked, the toggle and the buttons sit at opposite ends.
+                      <Flex align="center" gap="2" className="sm:pr-2 sm:border-r sm:mr-1">
                         <Label htmlFor={toggleId} className="text-xs text-muted-foreground cursor-pointer">
                           {t("scheduleEntryForm.enabledLabel")}
                         </Label>
@@ -226,22 +241,27 @@ export function ScheduleListView({
                         />
                       </Flex>
                     )}
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      onClick={() => onEdit(schedule)}
-                      aria-label={t("editScheduleAriaLabel", { pageName })}
-                    >
-                      <Edit className="h-4 w-4" />
-                    </Button>
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      onClick={() => onDelete(schedule.id)}
-                      aria-label={t("deleteScheduleAriaLabel", { pageName })}
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
+                    {/* ml-auto pins Edit/Delete to the right edge of the stacked
+                        control row; on the single-row layout they sit next to
+                        the toggle exactly as before. */}
+                    <Flex align="center" gap="2" className="ml-auto sm:ml-0">
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => onEdit(schedule)}
+                        aria-label={t("editScheduleAriaLabel", { pageName })}
+                      >
+                        <Edit className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => onDelete(schedule.id)}
+                        aria-label={t("deleteScheduleAriaLabel", { pageName })}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </Flex>
                   </Flex>
                 </Flex>
               );

--- a/web/tests/mobile-critical-flows.spec.ts
+++ b/web/tests/mobile-critical-flows.spec.ts
@@ -10,8 +10,10 @@ import {
   configureBoard,
   createCollection,
   createPage,
+  createSchedule,
   deleteAllCollections,
   deleteAllPages,
+  deleteAllSchedules,
   expect,
   suppressWizard,
   test,
@@ -240,6 +242,40 @@ test.describe("Mobile — Long names stay inside the viewport", () => {
     }, MOBILE_VIEWPORT.width);
     expect(chipRows.count).toBeGreaterThan(0); // guard against a vacuous pass
     expect(chipRows.overflowing).toBe(0);
+  });
+
+  test("schedule list rows keep their action buttons on screen", async ({ page }) => {
+    // Mirrors the report in #1558: a multi-word page name plus the
+    // "Disabled" badge is enough to blow the row past the phone viewport.
+    const pageId = await createPage("School Departure Countdown");
+    await createSchedule(pageId, "07:40", "07:45", "weekdays", undefined, {
+      enabled: false,
+    });
+
+    try {
+      await page.goto("/schedule");
+      await expect(page.getByTestId("schedule-list-row").first()).toBeVisible({ timeout: 15_000 });
+
+      // The row is overflow:visible, so a too-wide row never widens
+      // document.body — the Edit/Delete buttons simply render past the
+      // right edge. Measure the row's own content box instead.
+      const geometry = await page.evaluate((vw) => {
+        const rows = [...document.querySelectorAll('[data-testid="schedule-list-row"]')];
+        return {
+          count: rows.length,
+          overflowingRows: rows.filter((r) => r.scrollWidth > r.clientWidth + 1).length,
+          offscreenButtons: rows
+            .flatMap((r) => [...r.querySelectorAll("button")])
+            .filter((b) => b.getBoundingClientRect().right > vw + 1).length,
+        };
+      }, MOBILE_VIEWPORT.width);
+
+      expect(geometry.count).toBeGreaterThan(0); // guard against a vacuous pass
+      expect(geometry.overflowingRows).toBe(0);
+      expect(geometry.offscreenButtons).toBe(0);
+    } finally {
+      await deleteAllSchedules().catch(() => {});
+    }
   });
 
   test("collections card truncates long collection and page names", async ({ page }) => {


### PR DESCRIPTION
Fixes #1558

## Root cause

`ScheduleListView` renders each entry as a single horizontal flex row holding the page name, the time/day summary, the enabled toggle, and the Edit/Delete buttons.

The text column used `flex-1` **without `min-w-0`**. A flex item's `min-width` defaults to `auto`, so the column could not shrink below its min-content width — and the inner name row (icon + name + `Disabled` badge) is `flex-nowrap`, so its min-content is `width("Countdown") + gap + width(badge)`. The controls group had nothing left to give, and the row's children ended up wider than the row itself.

Measured on the live app at a 375px viewport, with the entries from the report:

| row | `clientWidth` | `scrollWidth` | Delete button right edge |
|---|---|---|---|
| Default Collection | 284 | 284 | 321 |
| School Lunch - 1 | 284 | **337** | 375 |
| School Lunch - 2 | 284 | **337** | 375 |
| School Departure Countdown | 284 | **367** | **405** |

Three of four rows overflow, and the last row's Delete button sits 30px past the right edge of a 375px viewport. Because the row is `overflow: visible` the overflow never widens `document.body` (`body.scrollWidth` stayed at 375), so no scrollbar appears — the buttons are simply unreachable. That's also why the existing `body.scrollWidth` mobile check never caught this.

## Fix

Below `sm` the row stacks:

```
┌──────────────────────────────────┐
│ School Departure Countdown       │
│ [Disabled]                       │
│ 07:40 - 07:45 • Mon-Fri          │
│                                  │
│ Enabled ( o )            [✎] [🗑] │
└──────────────────────────────────┘
```

- outer row is `flex-col` on phones, `sm:flex-row sm:items-center sm:justify-between` from the `sm` breakpoint up — identical to the current desktop layout
- `min-w-0` on the text column so it can shrink; a long page name now wraps **inside its own column** instead of shoving the actions out of the row
- `wrap` on the name row so the `Disabled` badge drops to its own line rather than squeezing the name to one word per line
- Edit/Delete grouped and `ml-auto`'d so they pin to the right edge of the stacked control row; on `sm+` they sit next to the toggle exactly as before
- the toggle/buttons divider (`border-r`) is `sm:`-only — stacked, the two groups sit at opposite ends and a trailing rule there reads as a stray line

Verified clean (0 overflowing rows, 0 off-screen elements) at 320, 375, 390, 639, 640 and 1280px.

## Test

New Playwright case in the existing `Mobile — Long names stay inside the viewport` block. It measures the row's own content box rather than `document.body`, since the overflow is invisible to a body-width check.

**Proof it isn't vacuous** — run against the unfixed component, the `count` guard passes (the row was found) and the overflow assertion fails:

```
✘ tests/mobile-critical-flows.spec.ts:247:3 › Mobile — Long names stay inside the viewport ›
    schedule list rows keep their action buttons on screen

    Error: expect(received).toBe(expected) // Object.is equality

    Expected: 0
    Received: 1

      273 |       expect(geometry.count).toBeGreaterThan(0); // guard against a vacuous pass
    > 274 |       expect(geometry.overflowingRows).toBe(0);
          |                                        ^
```

The `offscreenButtons` assertion catches it too — measured directly in the browser pre-fix, one button had `getBoundingClientRect().right = 405.4` at a 390px viewport. After the fix the test passes in 797ms.

## Verification

Run against a production-layout container built from this branch (isolated compose project on `:4499`):

- `tests/mobile-critical-flows.spec.ts`, `tests/regression/schedule-list.spec.ts`, `tests/schedule-management.spec.ts` — **35 passed, 1 skipped**
- full web unit suite — **112/114 files passed, identical to the `origin/main` baseline** (2 skipped)
- `npm run lint` — 0 errors (404 pre-existing `i18next/no-literal-string` warnings, unchanged)
- `prettier --check` on both touched files — clean
- `npm run typecheck` — 137 errors, **byte-identical count to the `origin/main` baseline**, none in the touched files

Only `web/src/components/schedule/schedule-list-view.tsx` and `web/tests/mobile-critical-flows.spec.ts` changed. No design-system changes — this is app-level layout wiring, so nothing needs to move to FiestaUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
