### PR TITLE
fix(config): scope atomic-write staging files to the process

### DIFF
--- a/src/atomic_io.py
+++ b/src/atomic_io.py
@@ -1,0 +1,30 @@
+"""Naming for the staging files used by FiestaBoard's atomic JSON writes.
+
+Every long-lived store under ``data/`` (config, settings, pages, schedules,
+collections, auth) writes by staging a temp file next to the target and then
+``os.replace``-ing it into place, so a mid-write crash never truncates the
+real file (see #1304).
+
+That pattern is only safe if each writer owns its staging file. The in-process
+locks guarding these stores are ``threading.Lock``, so they serialise threads
+and nothing else — and ``data/`` is routinely shared by more than one process:
+every ``pytest -n auto`` xdist worker, the API server alongside a CLI script or
+the MQTT bridge. With one fixed ``<file>.tmp`` name, the process that renames
+second finds its source already renamed away and ``os.replace`` fails with
+``ENOENT``, taking the save (and, in tests, an unrelated request) down with it.
+
+Scoping the staging name to the process removes the collision. The write stays
+atomic: staging file and target are still siblings, so the rename is still a
+same-filesystem rename.
+"""
+
+import os
+from pathlib import Path
+
+
+def staging_path(target: Path) -> Path:
+    """Return the process-scoped staging path to write before renaming onto *target*.
+
+    ``data/pages.json`` becomes ``data/pages.json.<pid>.tmp``.
+    """
+    return target.with_suffix(f"{target.suffix}.{os.getpid()}.tmp")

--- a/src/auth/service.py
+++ b/src/auth/service.py
@@ -33,6 +33,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from src.atomic_io import staging_path
+
 logger = logging.getLogger(__name__)
 
 # --- Config ----------------------------------------------------------------
@@ -400,7 +402,7 @@ class AuthService:
 
     def _save(self) -> None:
         self._path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = self._path.with_suffix(self._path.suffix + ".tmp")
+        tmp = staging_path(self._path)
         # Restrictive perms on the temp file before fdopen writes to it.
         fd = os.open(
             str(tmp),

--- a/src/collections/storage.py
+++ b/src/collections/storage.py
@@ -14,6 +14,8 @@ from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
 
+from src.atomic_io import staging_path
+
 from .models import COLLECTION_ID_PREFIX, Collection
 
 logger = logging.getLogger(__name__)
@@ -263,7 +265,7 @@ class CollectionStorage:
                 "collections": records,
             }
 
-            tmp_path = self.storage_file.with_suffix(self.storage_file.suffix + ".tmp")
+            tmp_path = staging_path(self.storage_file)
             try:
                 with open(tmp_path, "w") as f:  # noqa: PTH123
                     json.dump(data, f, indent=2)

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 # Import TimeService for migration
+from .atomic_io import staging_path
 from .time_service import get_time_service
 
 logger = logging.getLogger(__name__)
@@ -744,12 +745,13 @@ class ConfigManager:
     def _save_internal(self) -> None:
         """Internal save without acquiring lock (called from locked context).
 
-        Writes to a sibling ``<file>.tmp`` and ``os.replace``s it into place so
-        a mid-write crash (OOM, SIGKILL, power loss) never leaves a truncated
-        config file (see #1304).
+        Writes to a process-scoped sibling staging file and ``os.replace``s it
+        into place so a mid-write crash (OOM, SIGKILL, power loss) never leaves
+        a truncated config file (see #1304). See :mod:`src.atomic_io` for why
+        the staging name has to be per-process.
         """
         try:
-            tmp_path = self._config_path.with_suffix(self._config_path.suffix + ".tmp")
+            tmp_path = staging_path(self._config_path)
             try:
                 with tmp_path.open("w") as f:
                     json.dump(self._config, f, indent=2)

--- a/src/pages/storage.py
+++ b/src/pages/storage.py
@@ -13,6 +13,7 @@ from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 
+from src.atomic_io import staging_path
 from src.text_utils import extract_alignment_from_line as _extract_alignment_from_line
 
 from .models import Page
@@ -356,7 +357,7 @@ class PageStorage:
             # Datetimes are already coerced to ISO strings while building
             # pages_out above (covers both parsed pages and preserved
             # _failed_entries), so write data straight out — atomically.
-            tmp_path = self.storage_file.with_suffix(self.storage_file.suffix + ".tmp")
+            tmp_path = staging_path(self.storage_file)
             try:
                 with tmp_path.open("w") as f:
                     json.dump(data, f, indent=2)

--- a/src/schedules/storage.py
+++ b/src/schedules/storage.py
@@ -12,6 +12,8 @@ from collections.abc import Callable
 from datetime import UTC, datetime
 from pathlib import Path
 
+from src.atomic_io import staging_path
+
 from .models import DEFAULT_BOARD_ID, ScheduleEntry
 
 logger = logging.getLogger(__name__)
@@ -248,7 +250,7 @@ class ScheduleStorage:
             # Datetimes are already coerced to ISO strings while building
             # schedules_out above (covers both parsed schedules and preserved
             # _failed_entries), so write data straight out — atomically.
-            tmp_path = self.storage_file.with_suffix(self.storage_file.suffix + ".tmp")
+            tmp_path = staging_path(self.storage_file)
             try:
                 # Use builtins.open (not Path.open) on the tmp path so existing
                 # tests can patch builtins.open to inject I/O errors.

--- a/src/settings/service.py
+++ b/src/settings/service.py
@@ -15,6 +15,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Literal, Optional
 
+from src.atomic_io import staging_path
+
 logger = logging.getLogger(__name__)
 
 # Valid values for the built-in (hardware) transition strategies.  Plugin
@@ -709,7 +711,7 @@ class SettingsService:
         renamed over it (see #1304). Uses builtins.open on the tmp path so
         existing tests can patch builtins.open to inject write errors.
         """
-        tmp_path = self.settings_file.with_suffix(self.settings_file.suffix + ".tmp")
+        tmp_path = staging_path(self.settings_file)
         try:
             with open(tmp_path, "w") as f:  # noqa: PTH123
                 json.dump(data, f, indent=2)

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -1,0 +1,173 @@
+"""Every atomic JSON store must survive a second process saving the same file.
+
+The stores under ``data/`` guard themselves with ``threading.Lock``, which
+serialises threads and nothing else. ``data/`` is shared across processes all
+the time — one per ``pytest -n auto`` xdist worker, or the API server next to a
+CLI script — and with a fixed ``<file>.tmp`` staging name the process that
+renames second finds its source already gone:
+
+    FileNotFoundError: [Errno 2] No such file or directory:
+      '.../data/config.json.tmp' -> '.../data/config.json'
+
+That is a real CI failure: it took down ``test_welcome_success`` on #1555 and
+``test_renders_plain_text`` on main, neither of which has anything to do with
+saving config. These tests pin the contract that makes it impossible.
+"""
+
+import contextlib
+import json
+import threading
+from pathlib import Path
+
+import pytest
+
+from src.atomic_io import staging_path
+
+
+@pytest.fixture
+def competing_writer(monkeypatch):
+    """Run one full competing save inside the window before our rename.
+
+    The competitor does exactly what a second process would: stage a temp file
+    under the fixed ``<target>.tmp`` name, then rename it over the target.
+    """
+    state = {"ran": False}
+
+    real_replace = Path.replace
+
+    def replace_after_a_competing_save(self, target):
+        if not state["ran"]:
+            state["ran"] = True
+            competitor_tmp = Path(f"{target}.tmp")
+            competitor_tmp.write_text(json.dumps({"written_by": "the other process"}))
+            real_replace(competitor_tmp, target)
+        return real_replace(self, target)
+
+    monkeypatch.setattr(Path, "replace", replace_after_a_competing_save)
+    yield state
+    monkeypatch.undo()
+
+
+def test_staging_path_is_scoped_to_the_process():
+    """Two processes must never pick the same staging filename."""
+    import os
+
+    assert staging_path(Path("/data/pages.json")) == Path(f"/data/pages.json.{os.getpid()}.tmp")
+
+
+def _saved_without_error(save, target: Path, competing_writer) -> dict:
+    save()
+    assert competing_writer["ran"], "the competing save never ran — the test proves nothing"
+    assert not list(target.parent.glob(f"{target.name}*.tmp")), "staging file left behind"
+    return json.loads(target.read_text())
+
+
+def test_config_manager_survives_a_competing_process(tmp_path, competing_writer):
+    from src.config_manager import ConfigManager
+
+    ConfigManager._instance = None
+    ConfigManager._lock = threading.Lock()
+    target = tmp_path / "config.json"
+    cm = ConfigManager(config_path=str(target))
+    cm._config["general"]["timezone"] = "America/Chicago"
+
+    on_disk = _saved_without_error(cm._save_internal, target, competing_writer)
+    assert on_disk["general"]["timezone"] == "America/Chicago"
+
+    ConfigManager._instance = None
+
+
+def test_settings_service_survives_a_competing_process(tmp_path, competing_writer):
+    from src.settings.service import SettingsService
+
+    target = tmp_path / "settings.json"
+    svc = SettingsService(settings_file=str(target))
+
+    on_disk = _saved_without_error(
+        lambda: svc._atomic_write_json({"display": {"reduce_motion": True}}), target, competing_writer
+    )
+    assert on_disk["display"]["reduce_motion"] is True
+
+
+def test_page_storage_survives_a_competing_process(tmp_path, competing_writer):
+    from src.pages.models import Page
+    from src.pages.storage import PageStorage
+
+    target = tmp_path / "pages.json"
+    storage = PageStorage(storage_file=str(target))
+    storage._pages["p1"] = Page(id="p1", name="Kept", type="template", template=["hi", "", "", "", "", ""])
+
+    on_disk = _saved_without_error(storage._save, target, competing_writer)
+    assert [p["name"] for p in on_disk["pages"]] == ["Kept"]
+
+
+def test_schedule_storage_survives_a_competing_process(tmp_path, competing_writer):
+    from src.schedules.storage import ScheduleStorage
+
+    target = tmp_path / "schedules.json"
+    storage = ScheduleStorage(storage_file=str(target))
+    storage._default_page_by_board = {"board-1": "page-9"}
+
+    on_disk = _saved_without_error(storage._save, target, competing_writer)
+    assert on_disk["default_page_by_board"] == {"board-1": "page-9"}
+
+
+def test_collection_storage_survives_a_competing_process(tmp_path, competing_writer):
+    from src.collections.models import Collection
+    from src.collections.storage import CollectionStorage
+
+    target = tmp_path / "collections.json"
+    storage = CollectionStorage(storage_file=str(target))
+    collection = Collection(name="Mornings", page_ids=["page-1"])
+    storage._collections[collection.id] = collection
+
+    on_disk = _saved_without_error(storage._save, target, competing_writer)
+    assert [c["name"] for c in on_disk["collections"]] == ["Mornings"]
+
+
+def test_auth_service_survives_a_competing_process(tmp_path, competing_writer):
+    from src.auth.service import AuthService
+
+    target = tmp_path / "auth.json"
+    svc = AuthService(auth_file=target)
+    svc._data["auth_pref"] = "enabled"
+
+    on_disk = _saved_without_error(svc._save, target, competing_writer)
+    assert on_disk["auth_pref"] == "enabled"
+
+
+def test_auth_file_keeps_owner_only_permissions_through_a_competing_save(tmp_path, competing_writer):
+    """The credential store is 0600; a per-process staging name must not widen it."""
+    import stat
+
+    from src.auth.service import AuthService
+
+    target = tmp_path / "auth.json"
+    svc = AuthService(auth_file=target)
+    svc._save()
+
+    assert competing_writer["ran"]
+    mode = stat.S_IMODE(target.stat().st_mode)
+    assert mode & (stat.S_IRWXG | stat.S_IRWXO) == 0, f"auth.json is group/world accessible: {mode:o}"
+
+
+def test_a_crashed_process_leaves_a_staging_file_that_does_not_block_the_next_save(tmp_path):
+    """A SIGKILLed writer's orphaned staging file must not wedge later saves."""
+    from src.config_manager import ConfigManager
+
+    ConfigManager._instance = None
+    ConfigManager._lock = threading.Lock()
+    target = tmp_path / "config.json"
+    cm = ConfigManager(config_path=str(target))
+
+    orphan = staging_path(target)
+    orphan.write_text("{ truncated by a crash")
+
+    cm._config["general"]["timezone"] = "America/Chicago"
+    cm._save_internal()
+
+    assert json.loads(target.read_text())["general"]["timezone"] == "America/Chicago"
+    with contextlib.suppress(FileNotFoundError):
+        orphan.unlink()
+
+    ConfigManager._instance = None

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -3,6 +3,7 @@
 import importlib
 import json
 import threading
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -1319,6 +1320,50 @@ def test_save_internal_is_atomic_on_mid_write_crash(tmp_path, monkeypatch):
     # The original file must be byte-identical — the crash should have hit a
     # .tmp file that never got renamed over the real one.
     assert config_path.read_bytes() == original_bytes
+
+
+def test_save_internal_survives_a_concurrent_process_saving_the_same_config(tmp_path, monkeypatch):
+    """A second process saving the same config must not break our save.
+
+    ``_file_lock`` is a ``threading.Lock``, so it serialises threads and
+    nothing else. Under ``pytest -n auto`` every xdist worker is its own
+    process sharing one ``data/`` directory, and in production the API
+    server, MQTT bridge and CLI scripts all construct a ConfigManager. If
+    every one of them stages through the same fixed ``config.json.tmp``,
+    the process that renames second finds its source already gone and
+    ``os.replace`` raises ENOENT.
+
+    Simulated deterministically here: a competing writer completes a full
+    save — same naming scheme, tmp staged then renamed into place — in the
+    window between our write and our rename.
+    """
+    config_path = tmp_path / "config.json"
+    cm = ConfigManager(config_path=str(config_path))
+    cm._save_internal()
+
+    real_replace = Path.replace
+    competitor_ran = False
+
+    def replace_after_a_competing_save(self, target):
+        nonlocal competitor_ran
+        if not competitor_ran:
+            competitor_ran = True
+            competitor_tmp = Path(f"{target}.tmp")
+            competitor_tmp.write_text(json.dumps({"written_by": "the other process"}))
+            real_replace(competitor_tmp, target)
+        return real_replace(self, target)
+
+    monkeypatch.setattr(Path, "replace", replace_after_a_competing_save)
+    cm._config["general"]["timezone"] = "America/Chicago"
+    cm._save_internal()
+    monkeypatch.undo()
+
+    assert competitor_ran, "the competing save never ran — the test proves nothing"
+    # We renamed last, so our config is what survives, intact and parseable.
+    on_disk = json.loads(config_path.read_text())
+    assert on_disk["general"]["timezone"] == "America/Chicago"
+    # And we left no staging file behind.
+    assert list(tmp_path.glob("config.json*.tmp")) == []
 
 
 # --- deliberate-removal tombstones (issue #1394) ---


### PR DESCRIPTION
## The failure

`Platform Tests` failed on #1555 with `assert 500 == 200` in
`tests/test_api_coverage.py::TestSendWelcomeMessage::test_welcome_success`.
The captured log gives the real cause, and it has nothing to do with sending a
welcome message:

```
ERROR src.config_manager: Failed to save config: [Errno 2] No such file or directory:
  '.../data/config.json.tmp' -> '.../data/config.json'
ERROR src.api_server:  Error sending welcome message: [Errno 2] ...
```

The same error hit **main** four hours earlier ([run 31350209954](https://github.com/Fiestaboard/FiestaBoard/actions/runs/31350209954)), where it took down
`tests/test_mcp_server.py::TestRenderPagePreview::test_renders_plain_text` instead.
Two unrelated tests, one shared cause — it lands on whatever happens to be
running.

## Root cause

Every long-lived JSON store under `data/` writes atomically by staging a temp
file next to the target and `os.replace`-ing it into place, so a mid-write
crash can't truncate the real file (#1304). The staging name was **fixed** —
`<file>.tmp` — and the locks guarding these stores are `threading.Lock`, so
they serialise threads and nothing else.

`data/` is shared across *processes* routinely:

- every `pytest -n auto` xdist worker is its own process against one repo `data/`
- in production the API server runs alongside CLI scripts and the MQTT bridge

Two processes saving at once both stage through the same `<file>.tmp`. The one
that renames second finds its source already renamed away, and `os.replace`
raises `ENOENT` — a two-path error, which is exactly the shape in the log
above (a missing `data/` dir would fail earlier, on `open`, with one path).

Reproduced standalone — 6 processes, 300 saves each:

```
shared tmp name (current):   5 of 6 processes died
    FileNotFoundError: [Errno 2] No such file or directory:
      'racedata/config.json.tmp' -> 'racedata/config.json'
pid-scoped tmp name (this PR):  6 of 6 ok
```

## The change

A one-function module, `src/atomic_io.py`, whose `staging_path()` appends the
pid, and all six shared stores routed through it:

| store | file |
|---|---|
| config | `src/config_manager.py` |
| settings | `src/settings/service.py` |
| pages | `src/pages/storage.py` |
| schedules | `src/schedules/storage.py` |
| collections | `src/collections/storage.py` |
| auth | `src/auth/service.py` |

`data/pages.json` now stages through `data/pages.json.<pid>.tmp`. The write
stays atomic — staging file and target are still siblings, so the rename is
still a same-filesystem rename — and the crash-safety contract from #1304 is
untouched. It is one place to change the convention rather than six copies of
the same subtle expression.

Two snapshot writers (`config_manager._maybe_snapshot_on_version_change`,
`api_server` settings snapshots) and the backup restore path are deliberately
left alone: their targets are already uniquely named per attempt and their
failures are non-fatal (`logger.warning` / `return None`).

## Tests

`tests/test_atomic_io.py` (9) plus one in `tests/test_config_manager.py`. Each
one drives a real save while a competing writer completes a full save —
staging under the fixed `<target>.tmp` name, then renaming it into place — in
the window before our rename. That is a deterministic simulation of the exact
interleaving, no real processes and no sleeps.

**Written first, watched fail.** Before the fix,
`test_save_internal_survives_a_concurrent_process_saving_the_same_config`
failed with the CI error verbatim:

```
E FileNotFoundError: [Errno 2] No such file or directory:
    '.../test_save_internal_survives_a_0/config.json.tmp' -> '.../config.json'
```

**Mutation-checked.** Reverting `staging_path()` to the fixed name:

```
FAILED test_staging_path_is_scoped_to_the_process
FAILED test_config_manager_survives_a_competing_process
FAILED test_settings_service_survives_a_competing_process
FAILED test_page_storage_survives_a_competing_process
FAILED test_schedule_storage_survives_a_competing_process
FAILED test_collection_storage_survives_a_competing_process
FAILED test_auth_service_survives_a_competing_process
FAILED test_auth_file_keeps_owner_only_permissions_through_a_competing_save
FAILED test_save_internal_survives_a_concurrent_process_saving_the_same_config
9 failed, 1 passed
```

The one that still passes is
`test_a_crashed_process_leaves_a_staging_file_that_does_not_block_the_next_save`
— correctly so. It guards against a regression *from* this change (a SIGKILLed
writer now leaves `<file>.<pid>.tmp` rather than `<file>.tmp`), not the fix
itself. `test_auth_file_keeps_owner_only_permissions_through_a_competing_save`
pins that `auth.json` stays `0600` through the new path, since that store
stages via `os.open` with explicit mode bits.

## Verification

Run in Docker per CLAUDE.md, on the repo image with this branch mounted:

- `pytest tests/ -m "not integration" -n auto --cov=src --cov-fail-under=80` — **4746 passed**, coverage 88.30%
- `ruff check src/ plugins/ tests/ scripts/` — clean
- `ruff format --check` — clean