### PR TITLE
fix(api): split /health GET+HEAD into separate routes for unique operation IDs

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -1027,11 +1027,25 @@ async def root():
     return {"name": "FiestaBoard Display API", "version": "1.0.0", "status": "running"}
 
 
-@app.api_route("/health", methods=["GET", "HEAD"], response_model=HealthResponse)
+@app.get("/health", response_model=HealthResponse)
 async def health():
     """Health check endpoint."""
     service = get_service()
     return HealthResponse(status="ok", service_running=_service_running and service is not None, version=__version__)
+
+
+@app.head("/health", response_model=HealthResponse)
+async def health_head():
+    """Health check endpoint (HEAD).
+
+    Split from `health()` above into its own handler with a distinct name so
+    each HTTP method gets its own APIRoute and its own OpenAPI operationId.
+    A single @app.api_route(methods=["GET", "HEAD"]) produces one APIRoute
+    whose unique_id is derived from `list(route.methods)[0]` — since
+    route.methods is a set, that pick is non-deterministic, and FastAPI emits
+    the same operationId for both the GET and HEAD operations (see #1572).
+    """
+    return await health()
 
 
 @app.get("/mqtt/status")

--- a/tests/test_api_docs.py
+++ b/tests/test_api_docs.py
@@ -31,3 +31,58 @@ def test_docs_page_references_prefixed_openapi_url():
     assert response.status_code == 200
     # Swagger UI is configured with the prefixed openapi URL.
     assert "/api/openapi.json" in response.text
+
+
+def _operation_ids(schema: dict) -> list[str]:
+    ids = []
+    for path_item in schema.get("paths", {}).values():
+        for operation in path_item.values():
+            if isinstance(operation, dict) and "operationId" in operation:
+                ids.append(operation["operationId"])
+    return ids
+
+
+def test_openapi_schema_has_unique_operation_ids():
+    """Every operationId in the schema must be unique.
+
+    A route registered with @app.api_route(methods=["GET", "HEAD"]) collapses
+    to a single APIRoute whose unique_id is computed once (not once per HTTP
+    method), so FastAPI's default generate_unique_id emits the same
+    operationId for both the GET and HEAD operations. Duplicate operationIds
+    break OpenAPI client generators (openapi-generator, orval, etc.), which
+    key off operationId to name generated methods.
+    """
+    client = TestClient(app)
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    schema = response.json()
+
+    ids = _operation_ids(schema)
+    duplicates = {op_id for op_id in ids if ids.count(op_id) > 1}
+    assert not duplicates, f"Duplicate operationId(s) in /openapi.json: {sorted(duplicates)}"
+
+
+def test_openapi_schema_operation_ids_are_deterministic():
+    """The schema must not depend on Python set-iteration order.
+
+    route.methods is a set, so a default generate_unique_id that reads
+    list(route.methods)[0] can pick GET one process run and HEAD the next.
+    Rebuilding the schema (as FastAPI does lazily, cached on app.openapi_schema)
+    must produce the same operationId for the /health route every time.
+    """
+    client = TestClient(app)
+
+    # Force a fresh schema build each time, bypassing FastAPI's cache, so we
+    # actually re-exercise generate_unique_id rather than reading a cached dict.
+    app.openapi_schema = None
+    first = client.get("/openapi.json").json()
+    app.openapi_schema = None
+    second = client.get("/openapi.json").json()
+
+    first_health_ids = sorted(
+        op.get("operationId") for op in first["paths"]["/health"].values() if isinstance(op, dict)
+    )
+    second_health_ids = sorted(
+        op.get("operationId") for op in second["paths"]["/health"].values() if isinstance(op, dict)
+    )
+    assert first_health_ids == second_health_ids


### PR DESCRIPTION
Fixes #1572

## Cause

There is exactly one `/health` registration (`src/api_server.py:1030`, verified via `grep -n "\"/health\"" src/api_server.py`):

```python
@app.api_route("/health", methods=["GET", "HEAD"], response_model=HealthResponse)
async def health():
```

A single `api_route` carrying two methods becomes one `APIRoute` whose `unique_id` is computed once, not once per method. FastAPI's default `generate_unique_id` derives it from route name, path, and `list(route.methods)[0]` — and `route.methods` is a `set`, so which method lands in the id is non-deterministic. That one id is then emitted for both the GET and HEAD operation in the OpenAPI schema.

## TDD

Per the repo's test quality bar, I wrote the regression tests first and watched them fail before touching production code.

Added to `tests/test_api_docs.py`:
- `test_openapi_schema_has_unique_operation_ids` — asserts no duplicate `operationId` values anywhere in `/openapi.json`
- `test_openapi_schema_operation_ids_are_deterministic` — forces two fresh schema rebuilds (clearing `app.openapi_schema`) and asserts the `/health` operationIds are stable, since the root cause is `set` ordering

**Observed failure before the fix** (`pytest tests/test_api_docs.py -v`):

```
tests/test_api_docs.py::test_app_has_api_root_path PASSED
tests/test_api_docs.py::test_openapi_json_served PASSED
tests/test_api_docs.py::test_docs_page_references_prefixed_openapi_url PASSED
tests/test_api_docs.py::test_openapi_schema_has_unique_operation_ids FAILED
tests/test_api_docs.py::test_openapi_schema_operation_ids_are_deterministic PASSED

=================================== FAILURES ===================================
_________________ test_openapi_schema_has_unique_operation_ids _________________
tests/test_api_docs.py:62: in test_openapi_schema_has_unique_operation_ids
    assert not duplicates, f"Duplicate operationId(s) in /openapi.json: {sorted(duplicates)}"
E   AssertionError: Duplicate operationId(s) in /openapi.json: ['health_health_get']
E   assert not {'health_health_get'}
=============================== warnings summary ===============================
tests/test_api_docs.py::test_openapi_json_served
tests/test_api_docs.py::test_openapi_schema_operation_ids_are_deterministic
tests/test_api_docs.py::test_openapi_schema_operation_ids_are_deterministic
  .../fastapi/openapi/utils.py:303: UserWarning: Duplicate Operation ID health_health_get for function health at /app/src/api_server.py

1 failed, 4 passed, 3 warnings in 0.86s
```

This confirms the failure is a genuine duplicate id, not a typo/import error.

## Fix

Split the single `@app.api_route(methods=["GET", "HEAD"])` into two handlers with distinct names, `health()` (`@app.get`) and `health_head()` (`@app.head`), so each HTTP method gets its own `APIRoute` and its own deterministic `operationId`. `health_head()` delegates to `health()` (`return await health()`) to keep byte-identical response behavior. This was the option the issue called "clearest" over a per-route `operation_id` override or a global `generate_unique_id_function`.

## Verification

All run via the isolated container recipe:
```
docker run --rm -v "$PWD":/app -w /app python:3.11 sh -c \
  "pip install -q -r requirements.txt -r requirements-dev.txt && pytest tests/test_api_docs.py -v"
```

- After the fix: all 5 tests in `tests/test_api_docs.py` pass, no warnings.
- Ran the broader set (`tests/test_api_docs.py tests/test_api_extended.py tests/test_service_lifecycle.py tests/test_auth_routes.py`, 291 tests) with `-W error::UserWarning` — all pass, confirming the `Duplicate Operation ID` warnings that were previously raised in `test_openapi_json_served` and `test_middleware_public_paths_when_enabled` are gone.
- Confirmed existing `/health` GET and HEAD tests (`test_api_extended.py::TestRootAndHealth`, `test_service_lifecycle.py::TestHealthEndpoint`) still pass unchanged.
- `ruff check` passes on both changed files.

**Vacuity check** (per the test quality bar): stashed the `src/api_server.py` fix only, re-ran `tests/test_api_docs.py` — `test_openapi_schema_has_unique_operation_ids` failed again with the identical `AssertionError: Duplicate operationId(s) in /openapi.json: ['health_health_get']`. Restored the fix and re-ran to confirm green. This proves the test is not vacuous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
