### PR TITLE
fix(tests): freeze wall clock in mqtt dedup test to fix #1571 flake

### DIFF
--- a/tests/test_mqtt_state.py
+++ b/tests/test_mqtt_state.py
@@ -96,12 +96,22 @@ class TestStatePublisherGather:
             get_display_running=lambda: False,
             get_current_message=lambda: "—",
         )
-        pub.gather_and_publish()
-        first_state_count = mock_client.publish_state.call_count
-        first_attrs_count = mock_client.publish_attributes.call_count
-        pub.gather_and_publish()
-        second_state_count = mock_client.publish_state.call_count
-        second_attrs_count = mock_client.publish_attributes.call_count
+        # `uptime` is derived from the real, unmocked wall clock
+        # (`time.time()` inside StatePublisher._get_uptime) -- only
+        # `_service_start_time` is patched above. Two back-to-back
+        # gather_and_publish() calls can straddle a whole-second boundary
+        # (more likely under xdist CPU contention), making `uptime`
+        # legitimately change between calls and get republished. That is
+        # correct dedup behavior, not a bug -- but it makes this specific
+        # test flaky since it isn't about `uptime` at all. Freeze time so
+        # both calls observe identical state (see #1571).
+        with patch("time.time", return_value=1_000_042.0):
+            pub.gather_and_publish()
+            first_state_count = mock_client.publish_state.call_count
+            first_attrs_count = mock_client.publish_attributes.call_count
+            pub.gather_and_publish()
+            second_state_count = mock_client.publish_state.call_count
+            second_attrs_count = mock_client.publish_attributes.call_count
         assert second_state_count == first_state_count
         assert second_attrs_count == first_attrs_count
 


### PR DESCRIPTION
## Summary

Fixes #1571 — `tests/test_mqtt_state.py::TestStatePublisherGather::test_gather_dedup_does_not_republish_unchanged` intermittently failed CI with `assert 17 == 16`.

## Root cause: (b)-adjacent — real, not test pollution, not a production race

The test calls `StatePublisher.gather_and_publish()` twice back-to-back and asserts the second call publishes no additional messages (dedup). `StatePublisher._get_uptime()` (`src/mqtt/state.py`) computes `uptime` from the **real, unmocked `time.time()`** — only `_service_start_time` is patched via `@patch("src.api_server._service_start_time", 1000000.0)`.

If a whole-second wall-clock boundary falls between the two `gather_and_publish()` calls — more likely under `pytest-xdist` CPU contention/scheduling jitter — `uptime` legitimately changes value (e.g. `"42"` → `"43"`), and the (correctly functioning) dedup logic republishes it. That's exactly one extra `publish_state` call: `_gather_state()` produces 16 keys, so `first_state_count == 16`; the extra `uptime` republish on the second call makes `second_state_count == 17` — the exact `assert 17 == 16` seen in CI.

This ruled out both hypotheses from the issue:
- **Not a dedup race**: `StatePublisher._cache`, `_prev_silence_mode`, etc. are per-instance attributes, not module/class-level shared state, and each test builds its own `StatePublisher`/`mock_client`.
- **Not cross-test pollution**: nothing leaks between tests; the nondeterminism is entirely within this one test's two calls, from an uncontrolled real time source.

It's a third case: the test doesn't control all of its inputs (wall-clock time), so it's occasionally flaky even in complete isolation.

## Reproduction

Standalone script forcing a synthetic second-boundary crossing between the two calls reproduced the exact failure:
```
first_state_count=16 second_state_count=17
AssertionError: assert 17 == 16
```

Then, at the pytest level, a small plugin (`boundary_plugin.py`, not committed) swaps `time.time` for a fake clock that crosses a second boundary between the two calls, scoped only to this test via `pytest_runtest_call`:

```
docker run --rm -v "$PWD":/app -v "$PWD/boundary_plugin.py":/boundary_plugin.py:ro \
  -w /app -e PYTHONPATH=/ python:3.11 sh -c \
  "pip install -q -r requirements.txt -r requirements-dev.txt && \
   pytest tests/test_mqtt_state.py -v -p boundary_plugin -k test_gather_dedup_does_not_republish_unchanged"
```

- **Before the fix** (original test body): `FAILED ... assert 17 == 16` — same line, same numbers as the CI failure.
- **After the fix** (this PR's test body, which freezes `time.time()` around both calls): `PASSED`, with the identical forced boundary-crossing plugin active — proving the fix isn't vacuous.

Also ran `pytest tests/test_mqtt_state.py -n 4` 30 times in a row post-fix; all green.

## Fix

Wrap the two `gather_and_publish()` calls in `with patch("time.time", return_value=1_000_042.0):` so `uptime` is identical for both calls. This only affects the one test that asserts on unchanged state across two calls — it doesn't touch production code, since the dedup behavior itself is correct (an actually-changing `uptime` *should* republish).

## Test plan

- [x] `pytest tests/test_mqtt_state.py -v` — 14/14 pass
- [x] `pytest tests/test_mqtt_state.py -n 4` × 30 — all green
- [x] Forced-boundary-crossing plugin: fails against old test body, passes against new
- [x] `ruff check tests/test_mqtt_state.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
