### PR TITLE
docs(docs-site): document that the postcss-calc infinity warning is benign

### DIFF
--- a/docs-site/scripts/build-fiestaui-css.mjs
+++ b/docs-site/scripts/build-fiestaui-css.mjs
@@ -24,6 +24,21 @@ const output = path.join(siteDir, "src/css/fiestaui.generated.css");
 const src = fs.readFileSync(input, "utf8");
 const result = await postcss([tailwindcss({ optimize: true })]).process(src, { from: input });
 
+// NOTE on the "postcss-calc ... Lexical error ... infinity * 1px" warning that
+// Docusaurus's production build prints (fiestaboard#1574):
+//
+// Tailwind v4 compiles `rounded-full` etc. to a literal huge finite radius
+// (e.g. `3.40282e+38px`) right here, during this precompile step — that value
+// is never touched by the warning. The warning instead comes from the design
+// token `--radius-pill: calc(infinity * 1px);`, which Tailwind emits verbatim
+// (`infinity` is a valid CSS <calc-keyword>, just one the postcss-calc version
+// bundled in Docusaurus's css-minimizer-webpack-plugin predates and can't
+// tokenize). Confirmed empirically (see #1574) that when postcss-calc fails to
+// parse it, it leaves the declaration completely untouched — byte-for-byte
+// identical before and after minification — rather than dropping or mangling
+// it. So the warning is noise, not a lossy minification bug. Do not "fix" it
+// by rewriting this token to a finite px value.
+
 // Make FiestaUI's class-based dark mode ALSO respond to Docusaurus's native
 // `data-theme="dark"` attribute, so the theme works with zero JavaScript — no
 // `.dark` class needs to be synced. Two compiled selector forms carry dark


### PR DESCRIPTION
## Summary

Every docs deploy prints:

```
[WARNING] {"message":"assets/css/styles.fce4ec09.css from Css Minimizer plugin
postcss-calc: .../docs-site/assets/css/styles.fce4ec09.css:3099:116290: Lexical error on line 1: Unrecognized text.

  Erroneous area:
1: infinity * 1px
^..^","compilerPath":"client"}
```

`calc(infinity * 1px)` is the Tailwind v4 idiom for a maximally rounded corner. It's valid modern CSS (`infinity` is a CSS `<calc-keyword>`), but the `postcss-calc` bundled inside Docusaurus's `css-minimizer-webpack-plugin` (v9.0.1, pulled in transitively via `cssnano` — `postcss-calc` 10.x does understand `infinity`, but it isn't a direct dependency here so there's no clean override point without forcing an unrelated transitive bump) predates that keyword and can't tokenize it.

## Investigation — is it lossy?

Built the docs site in a clean `node:20` container and diffed the emitted CSS against the pre-minified Tailwind output (`docs-site/src/css/fiestaui.generated.css`) to find out what postcss-calc actually does when it fails to parse the declaration.

**Finding: it is not lossy (case 1 — harmless).** The only declaration in the whole stylesheet using this idiom is a design token:

```css
--radius-pill: calc(infinity * 1px);
```

Before minification (`fiestaui.generated.css`) and after minification (`build/assets/css/styles.*.css`), this declaration is **byte-for-byte identical**:

```
$ grep -o "radius-pill[^;]*;" docs-site/src/css/fiestaui.generated.css
radius-pill:calc(infinity * 1px);

$ grep -o "radius-pill[^;]*;" docs-site/build/assets/css/styles.5643896a.css
radius-pill:calc(infinity * 1px);
```

When postcss-calc can't parse a `calc()`, it leaves the whole declaration untouched rather than dropping or mangling it.

Separately: the `rounded-full` utility class itself (what most people picture when they think of "rounded corners breaking") is **not** affected by this at all — Tailwind v4 already resolves it to a literal huge finite radius during the docs-site's own precompile step (`npm run build:css`, which runs `@tailwindcss/postcss` before webpack ever sees the file), well before webpack's minifier runs:

```
$ grep -o "rounded-full{[^}]*}" docs-site/build/assets/css/styles.5643896a.css
rounded-full{border-radius:3.40282e+38px}
```

So neither the token nor the utility class is silently broken by this warning — it's pure noise from an out-of-date lexer inside a bundled transitive dependency.

## Change

Adds a comment to `docs-site/scripts/build-fiestaui-css.mjs` (the CSS precompile script) documenting this finding, so the next person who sees the warning doesn't have to re-investigate. No build behavior change — confirmed the generated CSS is byte-identical (88976 bytes) before and after this commit.

Fixes #1574

## Test plan

- [x] Built docs-site in a clean `node:20` container (`npm ci && npm run build`) — build succeeds, warning reproduces
- [x] Compared `--radius-pill` declaration in pre-minified vs. minified CSS — byte-identical
- [x] Compared `rounded-full` utility output — resolved to a finite value by Tailwind before minification, unaffected by the warning either way
- [x] Re-ran `npm run build:css` after the doc comment change — output unchanged (88976 bytes)
- [x] `npx prettier --check scripts/build-fiestaui-css.mjs` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)