### PR TITLE
fix(docs): turn v2-migration example anchor into a real heading

### DIFF
--- a/docs-site/docs/setup/v2-migration.md
+++ b/docs-site/docs/setup/v2-migration.md
@@ -77,8 +77,7 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
-<a id="example-full-board-instance"></a>
-**Example — configure a full board instance:**
+#### Example — configure a full board instance {#example-full-board-instance}
 
 ```json
 {

--- a/docs-site/versioned_docs/version-6.11/setup/v2-migration.md
+++ b/docs-site/versioned_docs/version-6.11/setup/v2-migration.md
@@ -75,8 +75,8 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
-<a id="example-full-board-instance"></a>
-**Example — configure a full board instance:**
+#### Example — configure a full board instance {#example-full-board-instance}
+
 ```json
 {
   "boards": [{

--- a/docs-site/versioned_docs/version-6.12/setup/v2-migration.md
+++ b/docs-site/versioned_docs/version-6.12/setup/v2-migration.md
@@ -75,8 +75,8 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
-<a id="example-full-board-instance"></a>
-**Example — configure a full board instance:**
+#### Example — configure a full board instance {#example-full-board-instance}
+
 ```json
 {
   "boards": [{

--- a/docs-site/versioned_docs/version-6.13/setup/v2-migration.md
+++ b/docs-site/versioned_docs/version-6.13/setup/v2-migration.md
@@ -75,8 +75,8 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
-<a id="example-full-board-instance"></a>
-**Example — configure a full board instance:**
+#### Example — configure a full board instance {#example-full-board-instance}
+
 ```json
 {
   "boards": [{

--- a/docs-site/versioned_docs/version-6.14/setup/v2-migration.md
+++ b/docs-site/versioned_docs/version-6.14/setup/v2-migration.md
@@ -75,8 +75,8 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
-<a id="example-full-board-instance"></a>
-**Example — configure a full board instance:**
+#### Example — configure a full board instance {#example-full-board-instance}
+
 ```json
 {
   "boards": [{

--- a/docs-site/versioned_docs/version-6.15/setup/v2-migration.md
+++ b/docs-site/versioned_docs/version-6.15/setup/v2-migration.md
@@ -75,8 +75,8 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
-<a id="example-full-board-instance"></a>
-**Example — configure a full board instance:**
+#### Example — configure a full board instance {#example-full-board-instance}
+
 ```json
 {
   "boards": [{

--- a/docs-site/versioned_docs/version-6.16/setup/v2-migration.md
+++ b/docs-site/versioned_docs/version-6.16/setup/v2-migration.md
@@ -75,8 +75,8 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
-<a id="example-full-board-instance"></a>
-**Example — configure a full board instance:**
+#### Example — configure a full board instance {#example-full-board-instance}
+
 ```json
 {
   "boards": [{

--- a/docs-site/versioned_docs/version-6.17/setup/v2-migration.md
+++ b/docs-site/versioned_docs/version-6.17/setup/v2-migration.md
@@ -75,8 +75,8 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
-<a id="example-full-board-instance"></a>
-**Example — configure a full board instance:**
+#### Example — configure a full board instance {#example-full-board-instance}
+
 ```json
 {
   "boards": [{

--- a/docs-site/versioned_docs/version-7.0/setup/v2-migration.md
+++ b/docs-site/versioned_docs/version-7.0/setup/v2-migration.md
@@ -75,8 +75,8 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
-<a id="example-full-board-instance"></a>
-**Example — configure a full board instance:**
+#### Example — configure a full board instance {#example-full-board-instance}
+
 ```json
 {
   "boards": [{

--- a/docs-site/versioned_docs/version-7.1/setup/v2-migration.md
+++ b/docs-site/versioned_docs/version-7.1/setup/v2-migration.md
@@ -75,8 +75,8 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
-<a id="example-full-board-instance"></a>
-**Example — configure a full board instance:**
+#### Example — configure a full board instance {#example-full-board-instance}
+
 ```json
 {
   "boards": [{

--- a/docs-site/versioned_docs/version-7.11/setup/v2-migration.md
+++ b/docs-site/versioned_docs/version-7.11/setup/v2-migration.md
@@ -77,8 +77,7 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
-<a id="example-full-board-instance"></a>
-**Example — configure a full board instance:**
+#### Example — configure a full board instance {#example-full-board-instance}
 
 ```json
 {

--- a/docs-site/versioned_docs/version-7.2/setup/v2-migration.md
+++ b/docs-site/versioned_docs/version-7.2/setup/v2-migration.md
@@ -75,8 +75,8 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
-<a id="example-full-board-instance"></a>
-**Example — configure a full board instance:**
+#### Example — configure a full board instance {#example-full-board-instance}
+
 ```json
 {
   "boards": [{

--- a/docs-site/versioned_docs/version-7.3/setup/v2-migration.md
+++ b/docs-site/versioned_docs/version-7.3/setup/v2-migration.md
@@ -75,8 +75,8 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
-<a id="example-full-board-instance"></a>
-**Example — configure a full board instance:**
+#### Example — configure a full board instance {#example-full-board-instance}
+
 ```json
 {
   "boards": [{

--- a/docs-site/versioned_docs/version-8.0/setup/v2-migration.md
+++ b/docs-site/versioned_docs/version-8.0/setup/v2-migration.md
@@ -77,8 +77,7 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
-<a id="example-full-board-instance"></a>
-**Example — configure a full board instance:**
+#### Example — configure a full board instance {#example-full-board-instance}
 
 ```json
 {

--- a/docs-site/versioned_docs/version-8.1/setup/v2-migration.md
+++ b/docs-site/versioned_docs/version-8.1/setup/v2-migration.md
@@ -77,8 +77,7 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
-<a id="example-full-board-instance"></a>
-**Example — configure a full board instance:**
+#### Example — configure a full board instance {#example-full-board-instance}
 
 ```json
 {

--- a/docs-site/versioned_docs/version-8.10/setup/v2-migration.md
+++ b/docs-site/versioned_docs/version-8.10/setup/v2-migration.md
@@ -77,8 +77,7 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
-<a id="example-full-board-instance"></a>
-**Example — configure a full board instance:**
+#### Example — configure a full board instance {#example-full-board-instance}
 
 ```json
 {

--- a/docs-site/versioned_docs/version-8.11/setup/v2-migration.md
+++ b/docs-site/versioned_docs/version-8.11/setup/v2-migration.md
@@ -77,8 +77,7 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
-<a id="example-full-board-instance"></a>
-**Example — configure a full board instance:**
+#### Example — configure a full board instance {#example-full-board-instance}
 
 ```json
 {

--- a/docs-site/versioned_docs/version-8.12/setup/v2-migration.md
+++ b/docs-site/versioned_docs/version-8.12/setup/v2-migration.md
@@ -77,8 +77,7 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
-<a id="example-full-board-instance"></a>
-**Example — configure a full board instance:**
+#### Example — configure a full board instance {#example-full-board-instance}
 
 ```json
 {

--- a/docs-site/versioned_docs/version-8.13/setup/v2-migration.md
+++ b/docs-site/versioned_docs/version-8.13/setup/v2-migration.md
@@ -77,8 +77,7 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
-<a id="example-full-board-instance"></a>
-**Example — configure a full board instance:**
+#### Example — configure a full board instance {#example-full-board-instance}
 
 ```json
 {

--- a/docs-site/versioned_docs/version-8.14/setup/v2-migration.md
+++ b/docs-site/versioned_docs/version-8.14/setup/v2-migration.md
@@ -77,8 +77,7 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
-<a id="example-full-board-instance"></a>
-**Example — configure a full board instance:**
+#### Example — configure a full board instance {#example-full-board-instance}
 
 ```json
 {

--- a/docs-site/versioned_docs/version-8.15/setup/v2-migration.md
+++ b/docs-site/versioned_docs/version-8.15/setup/v2-migration.md
@@ -77,8 +77,7 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
-<a id="example-full-board-instance"></a>
-**Example — configure a full board instance:**
+#### Example — configure a full board instance {#example-full-board-instance}
 
 ```json
 {

--- a/docs-site/versioned_docs/version-8.17/setup/v2-migration.md
+++ b/docs-site/versioned_docs/version-8.17/setup/v2-migration.md
@@ -77,8 +77,7 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
-<a id="example-full-board-instance"></a>
-**Example — configure a full board instance:**
+#### Example — configure a full board instance {#example-full-board-instance}
 
 ```json
 {

--- a/docs-site/versioned_docs/version-8.18/setup/v2-migration.md
+++ b/docs-site/versioned_docs/version-8.18/setup/v2-migration.md
@@ -77,8 +77,7 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
-<a id="example-full-board-instance"></a>
-**Example — configure a full board instance:**
+#### Example — configure a full board instance {#example-full-board-instance}
 
 ```json
 {

--- a/docs-site/versioned_docs/version-8.19/setup/v2-migration.md
+++ b/docs-site/versioned_docs/version-8.19/setup/v2-migration.md
@@ -77,8 +77,7 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
-<a id="example-full-board-instance"></a>
-**Example — configure a full board instance:**
+#### Example — configure a full board instance {#example-full-board-instance}
 
 ```json
 {

--- a/docs-site/versioned_docs/version-8.2/setup/v2-migration.md
+++ b/docs-site/versioned_docs/version-8.2/setup/v2-migration.md
@@ -77,8 +77,7 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
-<a id="example-full-board-instance"></a>
-**Example — configure a full board instance:**
+#### Example — configure a full board instance {#example-full-board-instance}
 
 ```json
 {

--- a/docs-site/versioned_docs/version-8.20/setup/v2-migration.md
+++ b/docs-site/versioned_docs/version-8.20/setup/v2-migration.md
@@ -77,8 +77,7 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
-<a id="example-full-board-instance"></a>
-**Example — configure a full board instance:**
+#### Example — configure a full board instance {#example-full-board-instance}
 
 ```json
 {

--- a/docs-site/versioned_docs/version-8.21/setup/v2-migration.md
+++ b/docs-site/versioned_docs/version-8.21/setup/v2-migration.md
@@ -77,8 +77,7 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
-<a id="example-full-board-instance"></a>
-**Example — configure a full board instance:**
+#### Example — configure a full board instance {#example-full-board-instance}
 
 ```json
 {

--- a/docs-site/versioned_docs/version-8.22/setup/v2-migration.md
+++ b/docs-site/versioned_docs/version-8.22/setup/v2-migration.md
@@ -77,8 +77,7 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
-<a id="example-full-board-instance"></a>
-**Example — configure a full board instance:**
+#### Example — configure a full board instance {#example-full-board-instance}
 
 ```json
 {

--- a/docs-site/versioned_docs/version-8.23/setup/v2-migration.md
+++ b/docs-site/versioned_docs/version-8.23/setup/v2-migration.md
@@ -77,8 +77,7 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
-<a id="example-full-board-instance"></a>
-**Example — configure a full board instance:**
+#### Example — configure a full board instance {#example-full-board-instance}
 
 ```json
 {

--- a/docs-site/versioned_docs/version-8.24/setup/v2-migration.md
+++ b/docs-site/versioned_docs/version-8.24/setup/v2-migration.md
@@ -77,8 +77,7 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
-<a id="example-full-board-instance"></a>
-**Example — configure a full board instance:**
+#### Example — configure a full board instance {#example-full-board-instance}
 
 ```json
 {

--- a/docs-site/versioned_docs/version-8.25/setup/v2-migration.md
+++ b/docs-site/versioned_docs/version-8.25/setup/v2-migration.md
@@ -77,8 +77,7 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
-<a id="example-full-board-instance"></a>
-**Example — configure a full board instance:**
+#### Example — configure a full board instance {#example-full-board-instance}
 
 ```json
 {

--- a/docs-site/versioned_docs/version-8.3/setup/v2-migration.md
+++ b/docs-site/versioned_docs/version-8.3/setup/v2-migration.md
@@ -77,8 +77,7 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
-<a id="example-full-board-instance"></a>
-**Example — configure a full board instance:**
+#### Example — configure a full board instance {#example-full-board-instance}
 
 ```json
 {

--- a/docs-site/versioned_docs/version-8.4/setup/v2-migration.md
+++ b/docs-site/versioned_docs/version-8.4/setup/v2-migration.md
@@ -77,8 +77,7 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
-<a id="example-full-board-instance"></a>
-**Example — configure a full board instance:**
+#### Example — configure a full board instance {#example-full-board-instance}
 
 ```json
 {

--- a/docs-site/versioned_docs/version-8.5/setup/v2-migration.md
+++ b/docs-site/versioned_docs/version-8.5/setup/v2-migration.md
@@ -77,8 +77,7 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
-<a id="example-full-board-instance"></a>
-**Example — configure a full board instance:**
+#### Example — configure a full board instance {#example-full-board-instance}
 
 ```json
 {

--- a/docs-site/versioned_docs/version-8.6/setup/v2-migration.md
+++ b/docs-site/versioned_docs/version-8.6/setup/v2-migration.md
@@ -77,8 +77,7 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
-<a id="example-full-board-instance"></a>
-**Example — configure a full board instance:**
+#### Example — configure a full board instance {#example-full-board-instance}
 
 ```json
 {

--- a/docs-site/versioned_docs/version-8.7/setup/v2-migration.md
+++ b/docs-site/versioned_docs/version-8.7/setup/v2-migration.md
@@ -77,8 +77,7 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
-<a id="example-full-board-instance"></a>
-**Example — configure a full board instance:**
+#### Example — configure a full board instance {#example-full-board-instance}
 
 ```json
 {

--- a/docs-site/versioned_docs/version-8.8/setup/v2-migration.md
+++ b/docs-site/versioned_docs/version-8.8/setup/v2-migration.md
@@ -77,8 +77,7 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
-<a id="example-full-board-instance"></a>
-**Example — configure a full board instance:**
+#### Example — configure a full board instance {#example-full-board-instance}
 
 ```json
 {

--- a/docs-site/versioned_docs/version-8.9/setup/v2-migration.md
+++ b/docs-site/versioned_docs/version-8.9/setup/v2-migration.md
@@ -77,8 +77,7 @@ The `PUT /settings/board` endpoint previously accepted only a `board_type` field
 { "devices": ["flagship", "note"] }
 ```
 
-<a id="example-full-board-instance"></a>
-**Example — configure a full board instance:**
+#### Example — configure a full board instance {#example-full-board-instance}
 
 ```json
 {


### PR DESCRIPTION
## Summary

Fixes #1573. Every docs deploy printed a `[WARNING] Docusaurus found broken anchors!` for `#example-full-board-instance` across every built version of `setup/v2-migration.md` (8.13 through the current docs).

The anchor target existed, but as a raw `<a id="example-full-board-instance"></a>` next to a bold paragraph, not a Markdown heading:

```markdown
<a id="example-full-board-instance"></a>
**Example — configure a full board instance:**
```

Docusaurus's `onBrokenAnchors` checker only collects anchors it generates from headings, so it never sees a raw `<a id>` — the link works fine in a browser, but the checker reports a false break. Converted it into a real heading with an explicit id, which both renders as a heading and registers the anchor:

```markdown
#### Example — configure a full board instance {#example-full-board-instance}
```

`####` matches the existing heading pattern in this doc (the sibling `### 2. Settings API…` section already uses `####` for its other sub-items, e.g. `#### POST /settings/board/add`), so this doesn't break the heading outline, sidebar, or TOC. The other bold "Example" line right above it (`**Example — set devices using the compatibility format:**`) is untouched — it has no anchor pointing at it, so no reason to touch its structure.

**38 files changed**: `docs-site/docs/setup/v2-migration.md` (current) + every `docs-site/versioned_docs/version-*/setup/v2-migration.md` that carries the pattern (6.11 through 8.25).

## All-versions vs. built-versions-only

I fixed **all 38 occurrences** rather than just the ~12 versions currently inside `DEPLOY_VERSION_CAP` (`docs-site/docusaurus.config.ts`). Verified the cap logic: `onlyIncludeVersions = versions.slice(0, DEPLOY_VERSION_CAP)`, and `versions.json` is ordered newest-first, so the cap always keeps a *sliding window* of the 12 most recent versions. As new releases publish new version snapshots, older ones age out of the window while newer ones age in — any older, unfixed snapshot will eventually enter the built window and re-trigger this exact warning. Fixing all of them now is a small, mechanical diff and makes the fix permanent rather than deferred. The alternative (fixing only the currently-built ~12) would need to be redone every time the window slides, for no smaller a diff in the long run.

## Verification

Built the full docs site in Docker (`node:20`, `--platform=linux/amd64`), mounting the real repo `.git` since Docusaurus's sitemap plugin shells out to `git log` for last-modified dates:

```
$ npm run build 2>&1 | tail -20
...
[webpackbar] ✔ Server: Compiled successfully in 13.21s
[webpackbar] ✔ Client: Compiled successfully in 16.65s
Generating LLM-friendly documentation...
Processed 62 documentation files for standard LLM files
...
Stats: 62 total available documents processed
[SUCCESS] Generated static files in "build".
[INFO] Use `npm run serve` command to test your build locally.
```

And confirmed directly that no broken-anchor warning is emitted anywhere in the build output:

```
$ npm run build 2>&1 | grep -i "broken anchor" || echo "NO_BROKEN_ANCHOR_WARNINGS_FOUND"
NO_BROKEN_ANCHOR_WARNINGS_FOUND
```

Also ran, all clean:
- `npm run format:check` in `docs-site` (`docs/` and `versioned_docs/` are in `.prettierignore`, so this only covers non-doc source, but confirmed anyway)
- `npx markdownlint-cli2` at the repo root (covers `docs-site/docs/**`, not `versioned_docs/**`, which is excluded from markdownlint entirely) — 0 issues
- `cspell` on the edited current-docs file — 0 issues

## Test plan

- [x] `docker run … npm run build` ends with `[SUCCESS] Generated static files in "build"`
- [x] Build output contains no "broken anchor" text
- [x] `npm run format:check` passes in `docs-site`
- [x] `markdownlint-cli2` passes repo-wide
- [x] Spot-checked several edited files by hand: current doc, oldest (6.11), and newest (8.25) versioned snapshots — heading level, blank-line spacing, and the anchor id all correct in each

🤖 Generated with [Claude Code](https://claude.com/claude-code)
