### PR TITLE
fix(web): resolve 10 React Compiler render-purity warnings

### DIFF
--- a/web/app/routes/integrations._index.tsx
+++ b/web/app/routes/integrations._index.tsx
@@ -539,16 +539,22 @@ const ICON_MAP: Record<string, LucideIcon> = {
 };
 
 /**
- * Get the Lucide icon component for a plugin based on its manifest icon field.
- * Falls back to Puzzle icon if not found.
+ * Normalize a plugin manifest icon field into an `ICON_MAP` key
+ * (lowercase, snake_case). Used to look up the Lucide icon component
+ * for a plugin, falling back to Puzzle if not found.
+ *
+ * This resolves the map *key* rather than the component itself so
+ * callers can do a plain `ICON_MAP[key] ?? Puzzle` lookup inline —
+ * assigning a function's return value directly to a capitalized
+ * variable used as a JSX tag defines a new component reference during
+ * render (see React Compiler's "Cannot create components during
+ * render" rule).
  */
-function getPluginIcon(iconName?: string): LucideIcon {
-  if (!iconName) return Puzzle;
+function normalizePluginIconKey(iconName?: string): string {
+  if (!iconName) return "";
 
   // Normalize: lowercase and handle both snake_case and lowercase
-  const normalized = iconName.toLowerCase().replace(/-/g, "_");
-
-  return ICON_MAP[normalized] || Puzzle;
+  return iconName.toLowerCase().replace(/-/g, "_");
 }
 
 // Color display helpers - using board's official colors
@@ -1188,7 +1194,7 @@ function InstalledPluginRow({
   };
 
   // Use icon from plugin manifest, falling back to Puzzle
-  const Icon = getPluginIcon(plugin.icon);
+  const Icon = ICON_MAP[normalizePluginIconKey(plugin.icon)] ?? Puzzle;
 
   const sourceType = plugin.source?.source_type;
   // "builtin" = ships with FiestaBoard, "external"/"registry" = from marketplace, "git" = user custom git URL
@@ -1841,7 +1847,7 @@ function RegistryPluginRow({
 }) {
   const t = useTranslations("integrations");
   const categoryLabels = useCategoryLabels();
-  const Icon = getPluginIcon(entry.icon);
+  const Icon = ICON_MAP[normalizePluginIconKey(entry.icon)] ?? Puzzle;
   return (
     <TableRow className="border-b last:border-b-0 hover:bg-muted/30 transition-colors">
       <TableCell className="px-4 py-2.5">

--- a/web/src/components/active-page-display.tsx
+++ b/web/src/components/active-page-display.tsx
@@ -98,6 +98,13 @@ export function ActivePageDisplay() {
   // When true, the page selector treats selection as manual (after disabling schedule)
   const [openSheetAsManual, setOpenSheetAsManual] = useState(false);
 
+  // Use transition for non-urgent updates to improve perceived performance.
+  // Declared before the effects below so `startTransition` isn't referenced
+  // before its declaration (react-hooks/immutability).
+  const [isPending, startTransition] = useTransition();
+  const lastClickTimeRef = useRef<number>(0);
+  const lastPageIdRef = useRef<string | null>(null);
+
   // Start pre-rendering grid in background after component mounts
   useEffect(() => {
     // Use startTransition to make this low-priority
@@ -308,11 +315,6 @@ export function ActivePageDisplay() {
       });
     }
   }, [scheduleEnabled, isLoadingActivePage, isLoadingPages, activePageId, pages, setActivePageMutation]);
-
-  // Use transition for non-urgent updates to improve perceived performance
-  const [isPending, startTransition] = useTransition();
-  const lastClickTimeRef = useRef<number>(0);
-  const lastPageIdRef = useRef<string | null>(null);
 
   // Handle page selection with debouncing and optimistic updates
   const handleSelectPage = useCallback(

--- a/web/src/components/plugin-settings/schema-form.tsx
+++ b/web/src/components/plugin-settings/schema-form.tsx
@@ -574,9 +574,17 @@ function ArrayField({ name, property, value, onChange, disabled, itemSchema }: A
   // Track items with stable IDs so React doesn't reuse component instances
   // when items are added or removed — index-based keys cause Radix UI portal
   // cleanup to call removeChild on a detached node.
-  const nextId = useRef(0);
+  //
+  // `nextId` seeds from the initial item count rather than 0 so IDs assigned
+  // later (handleAdd, the resync effect) never collide with the initial
+  // index-based IDs below. The initial `keyed` state uses plain array
+  // indices instead of `nextId.current++` because reading a ref's value
+  // during render (even inside a useState lazy initializer, which runs
+  // during the render phase) is unsound under Strict Mode / concurrent
+  // rendering — refs must only be read in effects or event handlers.
+  const nextId = useRef(rawItems.length);
   const [keyed, setKeyed] = useState<{ id: number; value: unknown }[]>(() =>
-    rawItems.map((v) => ({ id: nextId.current++, value: v })),
+    rawItems.map((v, i) => ({ id: i, value: v })),
   );
 
   // Keep keyed list in sync when the parent value changes from outside

--- a/web/src/components/schedule-entry-form.tsx
+++ b/web/src/components/schedule-entry-form.tsx
@@ -109,6 +109,11 @@ const todayISO = (): string => {
   return `${d.getFullYear()}-${m}-${day}`;
 };
 
+const timeToMinutes = (time: string): number => {
+  const [h, m] = time.split(":").map(Number);
+  return h * 60 + m;
+};
+
 export function ScheduleEntryForm({
   schedule,
   pages,
@@ -260,11 +265,6 @@ export function ScheduleEntryForm({
     oneOffEndDate,
     oneOffHasRange,
   ]);
-
-  const timeToMinutes = (time: string): number => {
-    const [h, m] = time.split(":").map(Number);
-    return h * 60 + m;
-  };
 
   const getTimeTypeLabel = (type: TimeType): string => {
     switch (type) {

--- a/web/src/components/tiptap-template-editor/components/FormulaEditorPanel.tsx
+++ b/web/src/components/tiptap-template-editor/components/FormulaEditorPanel.tsx
@@ -242,14 +242,29 @@ export function FormulaEditorPanel({ initialExpr = "", mode, onConfirm, onCancel
   const viewRef = useRef<EditorView | null>(null);
 
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Mirrors `expr` for the debounced validation callback below, which needs
+  // to compare against the *latest* expression, not the one captured in its
+  // closure. Refs may only be read/written outside of render (effects,
+  // event handlers), so the mirror is synced in an effect rather than
+  // assigned inline during render.
   const latestExprRef = useRef(expr);
-  latestExprRef.current = expr;
+  useEffect(() => {
+    latestExprRef.current = expr;
+  }, [expr]);
 
+  // Mirrors the last expression that passed validation. Kept as a ref (not
+  // state) because it's read from the CodeMirror Mod-Enter keybinding
+  // below, whose closure is created once when the editor mounts and would
+  // otherwise see a stale value; `lastValidExpr` state (below) is the
+  // render-safe counterpart used for `isConfirmDisabled`.
   const lastValidExprRef = useRef<string | null>(null);
+  const [lastValidExpr, setLastValidExpr] = useState<string | null>(null);
 
   // Always-current snapshot of state for use inside CodeMirror keybinding handlers
   const latestStateRef = useRef({ expr, validationState });
-  latestStateRef.current = { expr, validationState };
+  useEffect(() => {
+    latestStateRef.current = { expr, validationState };
+  }, [expr, validationState]);
 
   // ─── Fetch built-in function signatures ──────────────────────────────────
 
@@ -267,6 +282,7 @@ export function FormulaEditorPanel({ initialExpr = "", mode, onConfirm, onCancel
     const trimmed = expression.trim();
     if (!trimmed) {
       lastValidExprRef.current = null;
+      setLastValidExpr(null);
       setValidationState("idle");
       setErrors([]);
       return;
@@ -283,10 +299,12 @@ export function FormulaEditorPanel({ initialExpr = "", mode, onConfirm, onCancel
 
         if (result.valid) {
           lastValidExprRef.current = trimmed;
+          setLastValidExpr(trimmed);
           setValidationState("valid");
           setErrors([]);
         } else {
           lastValidExprRef.current = null;
+          setLastValidExpr(null);
           setValidationState("invalid");
           setErrors(result.errors.map((e) => e.message.replace(/^Formula\s+/, "")));
         }
@@ -428,7 +446,7 @@ export function FormulaEditorPanel({ initialExpr = "", mode, onConfirm, onCancel
     });
   };
 
-  const isConfirmDisabled = !expr.trim() || validationState !== "valid" || lastValidExprRef.current !== expr.trim();
+  const isConfirmDisabled = !expr.trim() || validationState !== "valid" || lastValidExpr !== expr.trim();
 
   // ─── Group functions by category ─────────────────────────────────────────
 

--- a/web/src/components/wizard/step-board-setup.tsx
+++ b/web/src/components/wizard/step-board-setup.tsx
@@ -52,8 +52,14 @@ export function StepBoardSetup({
   const t = useTranslations("wizard.boardSetup");
   const tc = useTranslations("common");
   const tbs = useTranslations("boardSettings");
+  // Mirrors `config` for use inside async callbacks (connection tests, board
+  // scans) so they always read the latest value instead of a stale closure.
+  // Refs may only be read/written outside of render, so the mirror is
+  // synced in an effect rather than assigned inline during render.
   const configRef = useRef(config);
-  configRef.current = config;
+  useEffect(() => {
+    configRef.current = config;
+  }, [config]);
 
   const [testStatus, setTestStatus] = useState<"idle" | "testing" | "success" | "error">("idle");
   const [testMessage, setTestMessage] = useState("");


### PR DESCRIPTION
## Summary

Fixes #1569 — resolves all 10 render-purity violations reported by the React Compiler ESLint rules in `web/` (all previously at warning severity):

| Count | Message |
| --- | --- |
| 5 | `Cannot access refs during render` |
| 3 | `Cannot create components during render` |
| 2 | `Cannot access variable before it is declared` |

Scope discipline per the issue: only these three rule categories were touched. `i18next/no-literal-string` (#1567), `react-hooks/set-state-in-effect` (#1568), and `react-hooks/exhaustive-deps` (#1570) warnings were left untouched.

## Violations fixed

**Cannot create components during render** (`app/routes/integrations._index.tsx`)
- `1224:14` and `1490:16` — `InstalledPluginRow`'s `const Icon = getPluginIcon(plugin.icon)` (declared `1171:16`)
- `1816:14` — `RegistryPluginRow`'s `const Icon = getPluginIcon(entry.icon)` (declared `1810:16`)

Fix: `getPluginIcon` now resolves only the `ICON_MAP` key (renamed `normalizePluginIconKey`); call sites do `ICON_MAP[normalizePluginIconKey(...)] ?? Puzzle` inline instead of assigning a function-call result to the capitalized JSX-tag variable.

**Cannot access variable before it is declared**
- `src/components/active-page-display.tsx:105:7` — an effect referenced `startTransition` before the `useTransition()` call at `313:21` that declares it. Moved the `useTransition`/ref declarations above the effect.
- `src/components/schedule-entry-form.tsx:210:28` — an effect referenced `timeToMinutes` before its declaration at `264:3`. Hoisted the pure helper to module scope next to the file's other module-scope helpers (`splitMMDD`, `joinMMDD`, `todayISO`).

**Cannot access refs during render**
- `src/components/plugin-settings/schema-form.tsx:578:72` — `ArrayField`'s `useState` lazy initializer mutated `nextId.current` while seeding item IDs. `nextId` now seeds from `rawItems.length`; the initial IDs use the array index (numerically identical to the old sequence, since `nextId` always started at 0).
- `src/components/tiptap-template-editor/components/FormulaEditorPanel.tsx:246:3` — `latestExprRef.current = expr` assigned unconditionally during render. Moved into a `useEffect` keyed on `[expr]`.
- `src/components/tiptap-template-editor/components/FormulaEditorPanel.tsx:252:3` — `latestStateRef.current = { expr, validationState }` assigned unconditionally during render. Moved into a `useEffect` keyed on `[expr, validationState]`.
- `src/components/tiptap-template-editor/components/FormulaEditorPanel.tsx:431:76` — `isConfirmDisabled` read `lastValidExprRef.current` during render. Added a `lastValidExpr` state variable, set alongside the ref at all 3 mutation sites in `validate()`; render now reads the state. The ref itself is kept for the Mod-Enter CodeMirror keybinding closure (created once, needs the "always current" ref pattern — reading it there is fine, it's an event-handler-style callback).
- `src/components/wizard/step-board-setup.tsx:56:3` — `configRef.current = config` assigned unconditionally during render for use inside async connection-test callbacks. Moved into a `useEffect` keyed on `[config]`.

## Before/after lint counts

```
Before: ✖ 404 problems (0 errors, 404 warnings)
After:  ✖ 394 problems (0 errors, 394 warnings)
```

`grep -E "Cannot access refs|Cannot create components|Cannot access variable"` on the full `npm run lint` output returns 0 matches after this change.

## Test evidence

Per the repo's TDD/test-quality-bar guidance, I looked for a behavioral test for each category that would fail before the fix and pass after. For the "component creation" cases specifically (the ones flagged as highest-value/most-likely-user-visible in the issue), I wrote a throwaway RTL test reproducing the exact pre-fix shape — a static lookup table + a wrapper function whose return value is assigned to a capitalized variable used as a JSX tag — and forced a parent re-render while a child held local input state:

```
✓ icon lookup remount experiment > does NOT lose child state across parent re-renders even with the call-expression pattern
```

**This test passed even with the pre-fix code.** Root cause: `web/vite.config.ts` intentionally does not run the react-compiler babel transform (only the ESLint plugin runs, for static analysis) — `@vitejs/plugin-react` is excluded to avoid a React Refresh collision with RR7's own HMR, and no other babel-plugin-react-compiler entry exists anywhere in the build. Without the compiler's runtime transform, React's ordinary reconciliation compares component *identity*, and since `ICON_MAP` entries are stable, static, module-level Lucide exports, `getPluginIcon(name)` and the new `ICON_MAP[key] ?? Puzzle` resolve to the byte-identical object for a fixed icon name — so no remount occurs in either version. I did not fabricate a test that can't fail; instead I fixed the pattern (it's still the correct, idiomatic form and future-proofs against the compiler transform ever being adopted) and verified via the lint rule going silent plus the full existing suite staying green.

The same reasoning extends to the ref and TDZ fixes: every ref mutation being moved out of render was, in the pre-fix code, always followed same-tick by a `setState` call that already forced the re-render needed for consistency, and every TDZ access only executes from inside an effect/timeout callback that runs after the whole component function (including the later declaration) has completed. None of the 10 warnings correspond to a currently-reproducible runtime bug in this codebase — they're forward-looking correctness fixes for a rule that models undefined behavior under concurrent rendering, which this build doesn't yet exercise via the compiler transform. I did not fabricate tests for any of them.

## Test plan

- [x] `npm run lint` — 404 → 394 warnings; 0 matches for the three target categories
- [x] `npm run test:run` — 116 test files, 1477 tests passed, 13 skipped, 0 failed (full suite, unchanged)
- [x] `npm run format:check` — passes
- [x] `npm run typecheck` — identical error set to `main` (137 pre-existing errors, unrelated TS7/vite8 migration debt); no new errors introduced by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
