### PR TITLE
perf(web): code-split TipTap/CodeMirror/lucide-icons out of page-builder

### DIFF
--- a/web/src/__tests__/setup.ts
+++ b/web/src/__tests__/setup.ts
@@ -5,12 +5,23 @@ import "@testing-library/jest-dom/vitest";
 // en messages are statically imported so lookups resolve synchronously.
 import "../i18n/i18next";
 
-import { cleanup } from "@testing-library/react";
+import { cleanup, configure } from "@testing-library/react";
 import React from "react";
 import { afterAll, afterEach, beforeAll, vi } from "vitest";
 
 import enMessages from "../../messages/en.json";
 import { server } from "./mocks/server";
+
+// Several routes now lazy-load heavy dependencies (TipTap/ProseMirror,
+// CodeMirror, the lucide-react icon barrel — see #1575) via `React.lazy` +
+// `Suspense`. The first `render()` that touches one of those modules in a
+// given worker pays the cost of vitest transforming a large module graph on
+// demand, which can exceed testing-library's default 1000ms `waitFor` /
+// `findBy*` timeout — especially under full-suite parallelism where workers
+// have less CPU time each. Bump the default so async assertions have
+// realistic headroom; this doesn't weaken any assertion, it just gives
+// intentionally-async renders enough time to resolve.
+configure({ asyncUtilTimeout: 5000 });
 
 // Tests mock `@/i18n/translations` with a synchronous English-only
 // implementation so component output is deterministic without

--- a/web/src/components/page-builder.tsx
+++ b/web/src/components/page-builder.tsx
@@ -49,7 +49,17 @@ import {
 } from "@fiestaboard/ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowLeft, Check, Copy, Radio, Save, Sparkles, Trash2, Upload } from "lucide-react";
-import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
+import {
+  forwardRef,
+  lazy,
+  Suspense,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { toast } from "sonner";
 
 import { BoardSizeIndicator } from "@/components/board-size-indicator";
@@ -61,9 +71,6 @@ import type {
   DrawHistoryEvent,
   TipTapTemplateEditorHandle,
 } from "@/components/tiptap-template-editor/TipTapTemplateEditor";
-// Direct import – bypasses next/dynamic chunk caching issues in dev mode.
-// TipTap's useEditor({ immediatelyRender: false }) handles SSR safely.
-import { TipTapTemplateEditor } from "@/components/tiptap-template-editor/TipTapTemplateEditor";
 import type { CellPaint, DrawBrush } from "@/components/tiptap-template-editor/utils/draw-mode";
 import {
   brushToCell,
@@ -90,6 +97,19 @@ import { MAX_NOTES_PER_AXIS, resolveDimensions } from "@/lib/board-dimensions";
 import { applyLineOpInPlace } from "@/lib/line-ops";
 import { onLiveOutputMessageChange, writeLiveOutputMessage } from "@/lib/live-output-channel";
 import { clearPreviewCacheForPage } from "@/lib/preview-cache";
+
+// Lazy-loaded — TipTap + ProseMirror + CodeMirror + the lucide-react icon
+// barrel push this module past 500 kB minified on their own (see #1575).
+// It's route-split from the surrounding page-builder chunk so "plain" text
+// editor mode (below) never pays for it, and "rich" mode streams it in
+// behind a Suspense fallback instead of blocking the whole page-builder
+// chunk's parse/eval. TipTap's useEditor({ immediatelyRender: false })
+// handles SSR safely, so deferring the import is safe under RR7 SPA mode.
+const TipTapTemplateEditor = lazy(() =>
+  import("@/components/tiptap-template-editor/TipTapTemplateEditor").then((m) => ({
+    default: m.TipTapTemplateEditor,
+  })),
+);
 
 interface PageBuilderProps {
   pageId?: string; // If provided, edit existing page
@@ -1775,90 +1795,92 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
                 {editorMode === "rich" ? (
                   <Box>
                     {/* Template editor with device-specific dimensions */}
-                    <TipTapTemplateEditor
-                      ref={tipTapRef}
-                      value={templateLines.join("\n")}
-                      onChange={(newValue) => {
-                        if (isUpdatingWrap.current) {
-                          return;
-                        }
-                        const lines = newValue.split("\n");
-                        setTemplateLines(lines);
-
-                        const oldLen = templateLines.length;
-                        const newLen = lines.length;
-                        if (newLen !== oldLen) {
-                          let prefixMatch = 0;
-                          while (
-                            prefixMatch < Math.min(newLen, oldLen) &&
-                            lines[prefixMatch] === templateLines[prefixMatch]
-                          ) {
-                            prefixMatch++;
+                    <Suspense fallback={<Skeleton className="h-48 w-full rounded-md" />}>
+                      <TipTapTemplateEditor
+                        ref={tipTapRef}
+                        value={templateLines.join("\n")}
+                        onChange={(newValue) => {
+                          if (isUpdatingWrap.current) {
+                            return;
                           }
-                          let suffixMatch = 0;
-                          while (
-                            suffixMatch < Math.min(newLen, oldLen) - prefixMatch &&
-                            lines[newLen - 1 - suffixMatch] === templateLines[oldLen - 1 - suffixMatch]
-                          ) {
-                            suffixMatch++;
-                          }
+                          const lines = newValue.split("\n");
+                          setTemplateLines(lines);
 
-                          const updatedAlignments = [...lineAlignments];
-                          const updatedWrap = [...lineWrapEnabled];
-
-                          if (newLen < oldLen) {
-                            const deleteCount = oldLen - newLen;
-                            const deleteStart = prefixMatch + (newLen - prefixMatch - suffixMatch);
-                            updatedAlignments.splice(deleteStart, deleteCount);
-                            updatedWrap.splice(deleteStart, deleteCount);
-                          } else {
-                            const insertCount = newLen - oldLen;
-                            const insertStart = prefixMatch + (oldLen - prefixMatch - suffixMatch);
-                            for (let i = 0; i < insertCount; i++) {
-                              updatedAlignments.splice(insertStart + i, 0, "left");
-                              updatedWrap.splice(insertStart + i, 0, false);
+                          const oldLen = templateLines.length;
+                          const newLen = lines.length;
+                          if (newLen !== oldLen) {
+                            let prefixMatch = 0;
+                            while (
+                              prefixMatch < Math.min(newLen, oldLen) &&
+                              lines[prefixMatch] === templateLines[prefixMatch]
+                            ) {
+                              prefixMatch++;
                             }
+                            let suffixMatch = 0;
+                            while (
+                              suffixMatch < Math.min(newLen, oldLen) - prefixMatch &&
+                              lines[newLen - 1 - suffixMatch] === templateLines[oldLen - 1 - suffixMatch]
+                            ) {
+                              suffixMatch++;
+                            }
+
+                            const updatedAlignments = [...lineAlignments];
+                            const updatedWrap = [...lineWrapEnabled];
+
+                            if (newLen < oldLen) {
+                              const deleteCount = oldLen - newLen;
+                              const deleteStart = prefixMatch + (newLen - prefixMatch - suffixMatch);
+                              updatedAlignments.splice(deleteStart, deleteCount);
+                              updatedWrap.splice(deleteStart, deleteCount);
+                            } else {
+                              const insertCount = newLen - oldLen;
+                              const insertStart = prefixMatch + (oldLen - prefixMatch - suffixMatch);
+                              for (let i = 0; i < insertCount; i++) {
+                                updatedAlignments.splice(insertStart + i, 0, "left");
+                                updatedWrap.splice(insertStart + i, 0, false);
+                              }
+                            }
+
+                            while (updatedAlignments.length < newLen) updatedAlignments.push("left");
+                            while (updatedWrap.length < newLen) updatedWrap.push(false);
+                            updatedAlignments.length = newLen;
+                            updatedWrap.length = newLen;
+
+                            setLineAlignments(updatedAlignments);
+                            setLineWrapEnabled(updatedWrap);
                           }
-
-                          while (updatedAlignments.length < newLen) updatedAlignments.push("left");
-                          while (updatedWrap.length < newLen) updatedWrap.push(false);
-                          updatedAlignments.length = newLen;
-                          updatedWrap.length = newLen;
-
-                          setLineAlignments(updatedAlignments);
-                          setLineWrapEnabled(updatedWrap);
-                        }
-                      }}
-                      lineAlignments={lineAlignments}
-                      lineWrapEnabled={lineWrapEnabled}
-                      onLineAlignmentChange={(lineIndex, alignment) => {
-                        setLineAlignments((prev) => {
-                          const newAlignments = [...prev];
-                          newAlignments[lineIndex] = alignment;
-                          return newAlignments;
-                        });
-                      }}
-                      onLineWrapChange={(lineIndex, wrapEnabled) => {
-                        setLineWrapEnabled((prev) => {
-                          const newWrapStates = [...prev];
-                          newWrapStates[lineIndex] = wrapEnabled;
-                          return newWrapStates;
-                        });
-                      }}
-                      placeholder={t("richEditorPlaceholder")}
-                      showAlignmentControls={true}
-                      showToolbar={true}
-                      boardWidth={dims.cols}
-                      boardLines={numLines}
-                      deviceType={deviceType}
-                      onSyncFromBoard={!pageId ? () => syncFromBoardMutation.mutate() : undefined}
-                      syncFromBoardPending={syncFromBoardMutation.isPending}
-                      drawMode={drawMode}
-                      onDrawModeToggle={() => setDrawMode((v) => !v)}
-                      drawBrush={drawBrush}
-                      onDrawBrushChange={setDrawBrush}
-                      onDrawHistoryEvent={handleDrawHistoryEvent}
-                    />
+                        }}
+                        lineAlignments={lineAlignments}
+                        lineWrapEnabled={lineWrapEnabled}
+                        onLineAlignmentChange={(lineIndex, alignment) => {
+                          setLineAlignments((prev) => {
+                            const newAlignments = [...prev];
+                            newAlignments[lineIndex] = alignment;
+                            return newAlignments;
+                          });
+                        }}
+                        onLineWrapChange={(lineIndex, wrapEnabled) => {
+                          setLineWrapEnabled((prev) => {
+                            const newWrapStates = [...prev];
+                            newWrapStates[lineIndex] = wrapEnabled;
+                            return newWrapStates;
+                          });
+                        }}
+                        placeholder={t("richEditorPlaceholder")}
+                        showAlignmentControls={true}
+                        showToolbar={true}
+                        boardWidth={dims.cols}
+                        boardLines={numLines}
+                        deviceType={deviceType}
+                        onSyncFromBoard={!pageId ? () => syncFromBoardMutation.mutate() : undefined}
+                        syncFromBoardPending={syncFromBoardMutation.isPending}
+                        drawMode={drawMode}
+                        onDrawModeToggle={() => setDrawMode((v) => !v)}
+                        drawBrush={drawBrush}
+                        onDrawBrushChange={setDrawBrush}
+                        onDrawHistoryEvent={handleDrawHistoryEvent}
+                      />
+                    </Suspense>
                   </Box>
                 ) : (
                   <Box>

--- a/web/src/components/tiptap-template-editor/components/FormulaEditorPanel.tsx
+++ b/web/src/components/tiptap-template-editor/components/FormulaEditorPanel.tsx
@@ -20,6 +20,7 @@ import {
   Flex,
   List,
   ListItem,
+  Skeleton,
   Stack,
   Tabs,
   TabsContent,
@@ -46,13 +47,20 @@ import {
   Type as TypeIcon,
   XCircle,
 } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
 
 import { useTranslations } from "@/i18n/translations";
 import { api } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
-import { VariablePickerContent } from "./VariablePickerContent";
+// Lazy-loaded — see TemplateEditorToolbar.tsx for why: it pulls in
+// lucide-react's full `icons` barrel. Dynamically importing it here too
+// (rather than statically) means the "Variables" tab shares one chunk with
+// the toolbar's Variables dropdown instead of duplicating the barrel into
+// this already-CodeMirror-heavy formula panel chunk (#1575).
+const VariablePickerContent = lazy(() =>
+  import("./VariablePickerContent").then((m) => ({ default: m.VariablePickerContent })),
+);
 
 // ─── Formula pretty-printer ────────────────────────────────────────────────────
 
@@ -568,12 +576,22 @@ export function FormulaEditorPanel({ initialExpr = "", mode, onConfirm, onCancel
             {/* ── Variables tab ── */}
             <TabsContent value="variables" className="mt-0">
               {/* sm:min-w-0 overrides the component's own min-w to fit the column */}
-              <VariablePickerContent
-                onInsert={handleVariableInsert}
-                maxHeight="400px"
-                autoFocusSearch={false}
-                className="sm:min-w-0"
-              />
+              <Suspense
+                fallback={
+                  <Box className="p-3 min-w-[300px]">
+                    <Skeleton className="h-4 w-full mb-2" />
+                    <Skeleton className="h-4 w-3/4 mb-2" />
+                    <Skeleton className="h-4 w-1/2" />
+                  </Box>
+                }
+              >
+                <VariablePickerContent
+                  onInsert={handleVariableInsert}
+                  maxHeight="400px"
+                  autoFocusSearch={false}
+                  className="sm:min-w-0"
+                />
+              </Suspense>
             </TabsContent>
           </Tabs>
         </Box>

--- a/web/src/components/tiptap-template-editor/components/TemplateEditorToolbar.tsx
+++ b/web/src/components/tiptap-template-editor/components/TemplateEditorToolbar.tsx
@@ -4,7 +4,7 @@
  */
 "use client";
 
-import { Box, Flex, Text, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@fiestaboard/ui";
+import { Box, Flex, Skeleton, Text, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@fiestaboard/ui";
 import { useQuery } from "@tanstack/react-query";
 import type { Editor } from "@tiptap/react";
 import {
@@ -26,7 +26,7 @@ import {
   Undo2,
   WrapText,
 } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
 
 import { HomeAssistantEntityPicker } from "@/components/home-assistant-entity-picker";
 import { useTranslations } from "@/i18n/translations";
@@ -42,7 +42,14 @@ import { ColorPickerContent } from "./ColorPickerContent";
 import { DrawCharPickerContent } from "./DrawCharPickerContent";
 import { FormattingPickerContent } from "./FormattingPickerContent";
 import { ToolbarDropdown } from "./ToolbarDropdown";
-import { VariablePickerContent } from "./VariablePickerContent";
+
+// Lazy-loaded — pulls in lucide-react's full `icons` barrel (every icon in
+// the library, ~1.2 MB) to resolve plugin-provided icon names dynamically.
+// Deferring it until the "Variables" dropdown is actually opened keeps that
+// cost out of the base TipTap editor chunk (#1575).
+const VariablePickerContent = lazy(() =>
+  import("./VariablePickerContent").then((m) => ({ default: m.VariablePickerContent })),
+);
 
 interface TemplateEditorToolbarProps {
   editor: Editor | null;
@@ -530,12 +537,22 @@ export function TemplateEditorToolbar({
             {hasVariables ? (
               <ToolbarDropdown label={t("variables")} icon={<Code2 className="w-4 h-4" />}>
                 {(close) => (
-                  <VariablePickerContent
-                    onInsert={(variable) => {
-                      handleInsert(variable);
-                      close();
-                    }}
-                  />
+                  <Suspense
+                    fallback={
+                      <Box className="p-3 min-w-[300px]">
+                        <Skeleton className="h-4 w-full mb-2" />
+                        <Skeleton className="h-4 w-3/4 mb-2" />
+                        <Skeleton className="h-4 w-1/2" />
+                      </Box>
+                    }
+                  >
+                    <VariablePickerContent
+                      onInsert={(variable) => {
+                        handleInsert(variable);
+                        close();
+                      }}
+                    />
+                  </Suspense>
                 )}
               </ToolbarDropdown>
             ) : (

--- a/web/src/components/tiptap-template-editor/node-views/FormulaNodeView.tsx
+++ b/web/src/components/tiptap-template-editor/node-views/FormulaNodeView.tsx
@@ -9,15 +9,31 @@
  */
 "use client";
 
-import { Badge, Box, Flex, Text, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@fiestaboard/ui";
+import {
+  Badge,
+  Box,
+  Flex,
+  Skeleton,
+  Text,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@fiestaboard/ui";
 import { NodeViewWrapper } from "@tiptap/react";
 import { SquareFunction } from "lucide-react";
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
 import { useTranslations } from "@/i18n/translations";
 
-import { FormulaEditorPanel } from "../components/FormulaEditorPanel";
+// Lazy-loaded — CodeMirror (+ the lucide-react icon barrel pulled in via
+// VariablePickerContent's "Variables" tab) is only needed once the formula
+// modal is actually opened, and keeping it out of the base TipTap editor
+// chunk is what keeps that chunk under the 500 kB warning threshold (#1575).
+const FormulaEditorPanel = lazy(() =>
+  import("../components/FormulaEditorPanel").then((m) => ({ default: m.FormulaEditorPanel })),
+);
 
 interface FormulaNodeViewProps {
   node: {
@@ -139,12 +155,14 @@ export function FormulaNodeView({ node, updateAttributes, deleteNode }: FormulaN
 
             {/* Modal panel */}
             <Box className="relative rounded-lg border border-border bg-popover shadow-2xl max-h-[90vh] overflow-y-auto w-full max-w-[min(660px,90vw)]">
-              <FormulaEditorPanel
-                mode="edit"
-                initialExpr={expression}
-                onConfirm={handleConfirm}
-                onCancel={handleCancel}
-              />
+              <Suspense fallback={<Skeleton className="h-64 w-full" />}>
+                <FormulaEditorPanel
+                  mode="edit"
+                  initialExpr={expression}
+                  onConfirm={handleConfirm}
+                  onCancel={handleCancel}
+                />
+              </Suspense>
             </Box>
           </Flex>,
           document.body,


### PR DESCRIPTION
## Summary

`npm run build` prints, twice (client and server passes):

```
(!) Some chunks are larger than 500 kB after minification.
```

Measured with `ANALYZE=true npm run build` + sourcemap `sources`/`sourcesContent` inspection before changing anything (not assumed from the issue's "likely candidates" list). The `page-builder` client chunk (1,216.31 kB minified) turned out to be three things statically bundled together:

- **lucide-react's full `icons` barrel** (~1.18 MB source) — `VariablePickerContent.tsx` does `import { icons as lucideIcons } from "lucide-react"` to resolve plugin-provided icon names dynamically, which pulls in every icon in the library (1,518 modules), not just the ones used
- **CodeMirror** (`@codemirror/*`, `@lezer/*`) — used only inside the formula editor's modal (`FormulaEditorPanel`)
- **TipTap/ProseMirror** itself

None of this needs to load for the dashboard, and two of the three (CodeMirror, the icon barrel) don't even need to load for most of the *page editor* — only when a user actually opens the formula modal or the variables dropdown.

## Fix

Route/component-level `React.lazy` + `Suspense`, not `chunkSizeWarningLimit`:

| File | Change |
|---|---|
| `web/src/components/page-builder.tsx` | `TipTapTemplateEditor` is lazy-loaded. "Plain" editor mode never pays for TipTap/ProseMirror/CodeMirror/lucide at all; "rich" mode (the default) streams it in behind a `Skeleton` fallback instead of blocking page-builder's own parse/eval. |
| `web/src/components/tiptap-template-editor/node-views/FormulaNodeView.tsx` | `FormulaEditorPanel` (CodeMirror) is lazy-loaded, deferred until the formula pill's modal is actually opened. |
| `web/src/components/tiptap-template-editor/components/TemplateEditorToolbar.tsx` | `VariablePickerContent` (the lucide icon barrel) is lazy-loaded, deferred until the toolbar's "Variables" dropdown is opened. |
| `web/src/components/tiptap-template-editor/components/FormulaEditorPanel.tsx` | Same lazy `VariablePickerContent` import for its own "Variables" tab — both call sites resolve to one shared chunk, so opening either surface loads it once. |

## Before / after (client, minified)

| Chunk | Before | After |
|---|---|---|
| `page-builder` | 1,216.31 kB | **39.95 kB** |
| `TipTapTemplateEditor` (new) | — | 465.93 kB |
| `VariablePickerContent` (new) | — | 465.03 kB |
| `FormulaEditorPanel` (new) | — | 277.64 kB |

All four are now under the 500 kB warning threshold. `chunkSizeWarningLimit` was **not** touched.

## What's *not* fixed — the warning is not fully gone

Please don't read this PR as "the build warning is fixed." It isn't, fully. The eagerly-loaded (`modulepreload`'d in `index.html`) client chunk `jsx-runtime-*.js` is **1,287.60 kB** minified, unchanged by this PR, and still trips the same warning. Root cause: `web/src/i18n/i18next.ts` statically imports all 14 locale JSON files so translations are available synchronously at first render (its own comment already flags this as a known future tradeoff). The same root cause also produces an oversized `setup-detection` chunk in the build-time-only server bundle (`build/server/`) — that one never ships to users since `react-router.config.ts` sets `ssr: false` and nginx only serves `build/client/`, but it still trips the same build-time warning.

I deliberately did **not** touch this. Converting eager locale bundling to lazy/dynamic per-locale loading is a different risk class than route-level editor splitting — it affects hydration timing across every route in the app (flash-of-untranslated-content risk, SSR/hydration interaction), not just one editor component. That's follow-up work for a dedicated issue, not something to bundle into a "split the editor out of the dashboard" PR.

So: **client bundle warning reduced from 3 offending chunks to 1** (the i18n one), server-side warning unchanged (but harmless — never shipped).

## Test changes

- `web/src/__tests__/setup.ts`: bumped testing-library's `asyncUtilTimeout` to 5000ms globally. This is a real consequence of the lazy-loading change, not papering over a failure: the first `render()` in a given vitest worker that touches a newly-lazy module (e.g. `TipTapTemplateEditor`) now pays a real cold transform cost for that module graph, which can exceed the default 1000ms `waitFor`/`findBy*` timeout. No assertion was weakened — tests still assert the exact same end state, they just get realistic headroom to reach it.
- `web/src/__tests__/page-builder.test.tsx`, `page-builder-draw-mode.test.tsx`: no changes needed once the timeout was bumped globally — these were the two tests that intermittently failed before the `setup.ts` fix (see next point).

## Verification

- `npm run build` — succeeds, warning present but reduced to the one documented chunk above.
- `npm run test:run` — full suite green (1,477 passed, 13 skipped, 116/116 files) when run with adequate container resources (`--maxWorkers=2` / raised `--memory`). Under the default resource-constrained `docker run` used for local iteration, I saw intermittent `Worker exited unexpectedly` crashes and knock-on timeouts in *unrelated* test files (e.g. `home-page-banner.test.tsx`, `import-page-dialog.test.tsx`) — I confirmed via `git stash` that this same worker-crash pattern reproduces on unmodified `main`, so it's pre-existing container resource contention, not a regression from this change.
- `npm run typecheck` — diffed error output against baseline `main`; identical pre-existing errors (line numbers shifted by the added import lines), no new errors introduced.
- `npm run format:check` — passes.
- `npm run lint` — 0 errors, 404 pre-existing warnings (all `i18next/no-literal-string`, `react-hooks/set-state-in-effect`, `react-hooks/refs`, `react-hooks/exhaustive-deps` — owned by other in-flight PRs per project scope discipline). No new warnings in touched files.
- Playwright E2E — not run. Given the size of the verification already done (build + full unit suite + typecheck + lint + format) and the container-resource constraints already observed above, I did not attempt the E2E suite for this PR. Flagging explicitly rather than claiming it passed.

Fixes #1575

🤖 Generated with [Claude Code](https://claude.com/claude-code)
