### PR TITLE
feat(transitions): add global and per-page transition plugin pickers

### DIFF
--- a/docs-site/docs/features/page-editor.md
+++ b/docs-site/docs/features/page-editor.md
@@ -158,6 +158,18 @@ The split-flap display supports colored tiles using special character codes. You
 
 See the [Color Guide](/docs/reference/color-guide) for detailed usage examples.
 
+## Page Transitions
+
+The editor's header toolbar has a **Transition** dropdown that controls how the board animates when it changes to this page.
+
+- **Use global default** - inherit the transition set in **Settings → Behavior → Board Transitions**
+- A **built-in strategy** (Wave, Drift, Curtain, Row, Diagonal, Random) - performed by the board itself, Local API only
+- A **transition plugin** (Typewriter, Simple Dissolve, and others) - animated by FiestaBoard, works on any connection, shown only when the Transition Plugins beta is enabled
+
+Anything other than **Use global default** becomes a page-level override that applies whenever this page is sent. Switching back to **Use global default** clears it.
+
+See [Transitions](/docs/features/transitions) for how the two kinds differ, what they require, and how to preview them in the Transition Lab.
+
 ## Page Layout
 
 The board display dimensions depend on the target device:
@@ -198,6 +210,7 @@ Pages that are referenced in schedules should be updated or removed from the sch
 
 ## Next Steps
 
+- [Transitions](/docs/features/transitions) - Choose how the board animates into this page
 - [Schedule Mode](/docs/features/schedule) - Automate when pages are displayed
 - [Plugins Overview](/docs/plugins/overview) - See available data sources for your pages
 - [Color Guide](/docs/reference/color-guide) - Learn about color formatting options

--- a/docs-site/docs/features/transitions.md
+++ b/docs-site/docs/features/transitions.md
@@ -1,0 +1,146 @@
+---
+sidebar_position: 6
+description: "Animate how your FiestaBoard changes between messages — built-in Vestaboard flip strategies and beta transition plugins like typewriter, dissolve, and slot machine."
+keywords: [FiestaBoard transitions, Vestaboard transition, flip animation, transition plugins, typewriter transition, dissolve transition, split-flap animation, Transition Lab]
+---
+
+# Transitions
+
+Transitions control how your board gets from the message it is showing now to the next one — a left-to-right wave, a dissolve, a typewriter reveal, or nothing at all.
+
+## Overview
+
+FiestaBoard has **two different kinds of transitions**, and they behave differently. Knowing which one you are looking at explains most of the surprises people run into.
+
+| | Built-in flip strategies | Transition plugins (beta) |
+|---|---|---|
+| **Who animates** | The Vestaboard itself | FiestaBoard, by sending many frames |
+| **Works on** | Local API connections only | Any board connection (Local or Cloud) |
+| **Examples** | Wave, Drift, Curtain, Row, Diagonal, Random | Typewriter, Simple Dissolve, Slot Machine, Quiet Library |
+| **Where to turn on** | Always available | **Settings → Advanced → Beta Features → Transition Plugins** |
+| **Step Interval / Step Size** | Supported | Not used — plugins set their own pacing |
+| **Stability** | Stable | Experimental; behavior and settings may change |
+
+## Built-in Flip Strategies
+
+Built-in strategies are a **Vestaboard Local API** feature. FiestaBoard sends the new message plus the name of a flip pattern, and the board hardware performs the animation itself.
+
+Set the default in **Settings → Behavior → Board Transitions**:
+
+| Name in the UI | API value | What it looks like |
+|---|---|---|
+| **None** | `null` | No animation — every character flips at once |
+| **Wave** | `column` | Flips column by column, left to right |
+| **Drift** | `reverse-column` | Flips column by column, right to left |
+| **Curtain** | `edges-to-center` | Flips from both edges, meeting in the middle |
+| **Row** | `row` | Flips row by row, top to bottom |
+| **Diagonal** | `diagonal` | Flips in a diagonal wave, corner to corner |
+| **Random** | `random` | Flips tiles in a random order |
+
+Two optional settings tune the built-in strategies:
+
+- **Step Interval (ms)** — delay between animation steps. Leave empty for the board default.
+- **Step Size** — how many rows or columns animate at once. Leave empty for the board default.
+
+:::info
+Built-in strategies only work over the **Local API**. If your board is configured for the Cloud API, FiestaBoard still sends your message, but the strategy is dropped and the board flips all tiles at once. Note-array boards also ignore built-in strategies and their step settings.
+:::
+
+## Transition Plugins (Beta)
+
+Transition plugins are animated by FiestaBoard, not by the board. The plugin generates a sequence of complete board frames, and FiestaBoard sends them one after another. Because each frame is an ordinary board update, plugin transitions work on **any** connection type — including Cloud API boards that cannot use the built-in strategies.
+
+FiestaBoard ships with four:
+
+| Plugin | What it does |
+|---|---|
+| **Typewriter** | Reveals the target message left to right, character by character |
+| **Simple Dissolve** | Replaces tiles in random order, dissolving the old message into the new one |
+| **Slot Machine** | Spins each column through random characters, then locks columns left to right |
+| **Quiet Library** | Updates word by word in small batches with long pauses, for the quietest possible refresh |
+
+### Turning the beta on
+
+1. Open **Settings → Advanced → Beta Features**.
+2. Enable **Transition Plugins**. The change takes effect immediately — no restart.
+3. **Transition Lab** appears in the sidebar, and installed transition plugins appear in every transition picker.
+
+There is no separate enable step for an individual transition plugin. Installing one is opting in: any installed transition plugin is selectable as soon as the beta flag is on. On the **Integrations** page they show up badged **Transition**, with no on/off toggle.
+
+:::warning This is genuinely experimental
+Every frame of a plugin transition is a real send to your board, so plugin transitions are bound by the board's send pacing. On some connections and some boards an animation will look less smooth than the preview does, or will take longer than you expect. The plugin SDK is experimental and its APIs, settings, and behavior may change before general availability.
+:::
+
+FiestaBoard enforces per-plugin caps so a runaway animation cannot take your board hostage — a maximum frame count (default 500), a maximum runtime (default 120 seconds), and a minimum interval between frames (default 50 ms). When a run hits a cap, FiestaBoard snaps the board to the final message and stops.
+
+## Choosing Where a Transition Applies
+
+There are two places to choose a transition, and the more specific one wins.
+
+### Global default
+
+**Settings → Behavior → Board Transitions** sets the default for every board update. When the beta is on, the picker lists the built-in strategies under **Built-in** and your installed transition plugins under **Transition Plugins**.
+
+### Per page
+
+The page editor's header toolbar has a **Transition** dropdown. It offers:
+
+- **Use global default** — the page inherits whatever is set in Settings
+- Any built-in strategy
+- Any installed transition plugin, when the beta is on
+
+Picking anything other than **Use global default** creates a page-level override that applies whenever that page is sent. Switching back to **Use global default** clears the override.
+
+### Resolution order
+
+1. The page's own transition, if it has one
+2. Otherwise, the global default from Settings
+
+:::note
+Transitions cannot currently be set per collection or per schedule entry. A scheduled page uses its own page-level transition if it has one, and the global default otherwise.
+:::
+
+## Transition Lab
+
+The **Transition Lab** (`/transitions`) is a preview harness for plugin transitions. It appears in the sidebar only while the Transition Plugins beta is on.
+
+In the Lab you can:
+
+- Pick a transition plugin and two of your real pages to transition between
+- Choose the device shape — Flagship, Note, or a note array
+- Override the plugin's settings for a single run with a JSON config
+- Play, pause, step frame by frame, or scrub the generated sequence
+
+Previews are generated in FiestaBoard and rendered in your browser. Nothing is sent to your board, so you can iterate as much as you like.
+
+When you want to see it on real tiles, **Test live on board** runs the transition once on your actual board, and **Restore board** snaps it back to its active page. (The normal display loop would restore it on its own too.) Live tests are blocked while silence mode is active or the board is paused, so a quiet-hours board stays quiet.
+
+## Troubleshooting
+
+### Nothing animates — the whole board just changes at once
+
+Most often this is a Cloud API board with a built-in strategy selected. Built-in strategies are a Local API feature. Either switch the board to the Local API (see [API Keys](/docs/setup/api-keys)), or use a transition plugin, which works on any connection.
+
+Note-array boards do not support built-in strategies at all.
+
+### No Transition Lab in the sidebar, and no plugins in the transition pickers
+
+Plugin transitions stay hidden until the beta is on. Enable **Settings → Advanced → Beta Features → Transition Plugins** — the Transition Lab and the plugin entries appear immediately. Built-in strategies do not need the beta flag; they are always listed in Settings and in the page editor's **Transition** dropdown.
+
+### A plugin transition looks choppy or slower than the preview
+
+The preview runs entirely in FiestaBoard; a live run sends every frame to the board and is limited by the board's send pacing. Increasing the plugin's frame interval usually looks better than fighting for a faster one. This is a known limitation of animating a physical split-flap over an API.
+
+### Step Interval and Step Size seem to do nothing
+
+They only apply to built-in strategies. Transition plugins pace themselves through their own settings — for example Typewriter's `chars_per_frame` and `frame_interval_ms`.
+
+### A transition endpoint returns 404
+
+The `/transitions/*` API endpoints are gated behind the beta flag and respond `404` while it is off. See [API Endpoints](/docs/reference/api-endpoints#transition-plugin-endpoints).
+
+## Next Steps
+
+- [Page Editor](/docs/features/page-editor) - Set a per-page transition while you build a page
+- [Plugin Development Guide](/docs/development/plugin-guide) - Build your own transition plugin
+- [API Endpoints](/docs/reference/api-endpoints) - Drive transitions from the REST API

--- a/docs-site/docs/reference/api-endpoints.md
+++ b/docs-site/docs/reference/api-endpoints.md
@@ -98,8 +98,8 @@ When creating or updating a page, the following fields are available:
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | `GET` | `/settings/all` | Get all settings in a single call |
-| `GET` | `/settings/transitions` | Get transition animation settings |
-| `PUT` | `/settings/transitions` | Update transition settings |
+| `GET` | `/settings/transitions` | Get transition animation settings and the built-in strategy list |
+| `PUT` | `/settings/transitions` | Update transition settings. `strategy` accepts a built-in name (`column`, `reverse-column`, `edges-to-center`, `row`, `diagonal`, `random`), `"plugin:<id>"` to drive a [transition plugin](/docs/features/transitions), or `null` for no animation |
 | `GET` | `/settings/output` | Get output target settings |
 | `PUT` | `/settings/output` | Update output target |
 | `GET` | `/settings/board` | Get board configuration |
@@ -158,6 +158,42 @@ pickers filter to the boards they're compatible with (see
 | `enabled` | boolean | Whether this board is active |
 | `schedule_enabled` | boolean | Whether this board follows its schedule (vs. manual mode) |
 | `paused` | boolean | Whether this board's output is paused |
+
+## Transition Plugin Endpoints
+
+These endpoints back the **Transition Lab** and the transition pickers in the UI. They are gated behind the Transition Plugins beta flag (**Settings → Advanced → Beta Features**) and return `404` while it is off. See [Transitions](/docs/features/transitions) for the feature itself.
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/transitions/plugins` | List installed transition plugins with their settings schema, runtime caps, and `plugin:<id>` strategy string |
+| `POST` | `/transitions/preview` | Run a transition plugin in-process and return its frame sequence — nothing is sent to a board |
+| `POST` | `/transitions/test-live` | Run a transition plugin once on the real board |
+| `POST` | `/transitions/restore` | Snap a board back to its active page after a live test |
+
+### `POST /transitions/preview` — request body fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `plugin_id` | string | Transition plugin to drive (required) |
+| `to_text` | string | Text rendered into the target grid |
+| `from_text` | string | Optional. Text rendered into the starting grid. Default: blank |
+| `config` | object | Optional. Per-run overrides for the plugin's settings fields |
+| `device_type` | string | Optional. `"flagship"` (default), `"note"`, or `"note_array"` |
+| `notes_wide` / `notes_tall` | number | Optional. Note-array geometry (1–8 each) |
+
+The response is `{"frames": [{"grid": [[...]], "delay_ms": n}, ...], "total_delay_ms": n, "capped": bool, "plugin_id": "..."}`. `capped` is `true` when the plugin hit its `max_frames` or `max_runtime_seconds` limit and the sequence was truncated.
+
+### `POST /transitions/test-live` — request body fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `plugin_id` | string | Transition plugin to drive (required) |
+| `to_page_id` | string | Page the transition lands on (required) |
+| `from_page_id` | string | Optional. Page snapped to the board first, so the transition visibly starts from it |
+| `config` | object | Optional. Per-run overrides for the plugin's settings fields |
+| `board_id` | string | Optional. Omitted → primary board |
+
+Live tests respect silence mode and board pause, returning `409` rather than writing to a quiet or paused board. The board is left showing the target page — call `POST /transitions/restore` (body: optional `board_id`) to return it to its active page, or wait for the normal display loop.
 
 ## Example Requests
 

--- a/docs-site/sidebars.ts
+++ b/docs-site/sidebars.ts
@@ -24,6 +24,7 @@ const sidebars: SidebarsConfig = {
         "plugins/overview",
         "plugins/configuration",
         "features/page-editor",
+        "features/transitions",
         "setup/ai-providers",
         "features/schedule",
         "features/silence-schedule",

--- a/docs/development/TRANSITION_PLUGIN_DEVELOPMENT.md
+++ b/docs/development/TRANSITION_PLUGIN_DEVELOPMENT.md
@@ -1,13 +1,14 @@
 # Transition Plugin Development Guide
 
 > ⚠️ **Beta / Experimental.** Transition plugins ship behind the
-> ``beta.transition_plugins_enabled`` settings flag (Settings → Beta).
+> ``beta.transition_plugins_enabled`` settings flag
+> (Settings → Advanced → Beta Features → Transition Plugins).
 > The SDK contract is not yet stable -- method signatures, manifest
 > fields, and runtime semantics may change in future releases before
 > general availability. Use it, build with it, send feedback, but don't
 > treat your plugin's interface as locked in yet.
 
-Transition plugins drive **frame-by-frame board animations** that change one display state into another. Unlike Vestaboard's built-in hardware transitions (column wave, edges-to-center, etc.), a transition plugin emits a sequence of intermediate board grids and the runtime sends them as separate frames -- enabling typewriter reveals, slot-machine spins, dissolves, and anything else that needs custom per-frame control.
+Transition plugins drive **frame-by-frame board animations** that change one display state into another. Unlike Vestaboard's built-in strategies (column wave, edges-to-center, etc.), which are Local API features the board performs on its own, a transition plugin emits a sequence of intermediate board grids and the runtime sends each one as a separate ordinary board update -- enabling typewriter reveals, slot-machine spins, dissolves, and anything else that needs custom per-frame control. Because the frames are just normal sends, plugin transitions run on Cloud connections too.
 
 This is a different plugin type from the data plugins documented in [PLUGIN_DEVELOPMENT.md](./PLUGIN_DEVELOPMENT.md). Data plugins fetch information and expose template variables; transition plugins shape *how* a board update happens, not *what* it shows.
 
@@ -27,7 +28,7 @@ This is a different plugin type from the data plugins documented in [PLUGIN_DEVE
 3. Implement `generate_frames()` in `plugins/my_transition/__init__.py`.
 4. Add tests under `plugins/my_transition/tests/` aiming for >80% coverage.
 5. Run `python scripts/run_plugin_tests.py --plugin=my_transition` to verify.
-6. Open Transition Lab in the web UI (`/transitions`) to preview your plugin against arbitrary from/to text.
+6. Turn on Settings → Advanced → Beta Features → **Transition Plugins**, then open **Transition Lab** (`/transitions`) to preview your plugin frame by frame between two pages.
 
 ## The Plugin Class
 
@@ -128,21 +129,27 @@ Choose conservatively. A transition with `max_frames: 5000` and `min_interval_ms
 
 ## Selecting a transition plugin
 
-Once your plugin is installed it is ready to use — unlike data plugins, transition plugins don't need to be enabled on the Integrations page; installing one is opting in. (The `beta.transition_plugins_enabled` flag above still gates the feature as a whole.) Users select it from:
+Once your plugin is installed it is ready to use. Unlike data plugins, transition plugins are not gated on the Integrations page's enabled toggle — `PluginRegistry.get_transition_plugin()` never consults it, because a transition has no polling loop or background cost. Installing is opting in. (The `beta.transition_plugins_enabled` flag above still gates the feature as a whole; with it off, `BoardClient.render()` logs and snaps to the target grid.) Users select your plugin from:
 
-- A specific page's Transition picker in the page editor
-- The global default in Settings → Board Transitions
+- The **Transition** dropdown in the page editor's toolbar, which sets that one page's transition
+- Settings → Behavior → Board Transitions, which sets the default for every page
+
+A page's own transition wins over the global default; the dropdown's "Use global default" option clears the page-level override.
 
 Pages store the choice as `transition_strategy = "plugin:my_transition"`. The runtime parses the `plugin:` prefix and routes the send through `TransitionRunner`.
 
 ## Visual testing
 
-The **Transition Lab** at `/transitions` lets you preview any installed transition plugin against arbitrary from/to text without a real board. It uses `POST /transitions/preview` under the hood, which calls your `generate_frames()` and returns the resulting grids as JSON. Use the timeline scrubber to step through frames and verify each intermediate state.
+The **Transition Lab** at `/transitions` (sidebar entry, visible once the beta is on) previews any installed transition plugin between two of your real pages without touching the board. It uses `POST /transitions/preview` under the hood, which calls your `generate_frames()` and returns the resulting grids as JSON. Use the timeline scrubber to step through frames and verify each intermediate state.
+
+The Lab's config box is seeded with the plugin's saved config and passed straight through to `generate_frames()`, so you can try values without saving them — the fastest way to sanity-check `validate_config()` and your defaults.
+
+When you're ready to see it on hardware, **Test live** runs the transition once on the real board and **Restore** puts the active page back (the display loop restores it on its own as well).
 
 ## Performance & rate limits
 
 - The Vestaboard hardware has internal timing constraints. Sending frames faster than the flap mechanism can settle (~14s for a full revolution under heavy update) will cause the board to drop requests.
-- The Cloud API has stricter rate limits than the Local API. Transition plugins are the *only* way to animate on Cloud-mode boards (hardware strategies are ignored), but the practical frame rate is much lower.
+- The Cloud API has stricter rate limits than the Local API. Transition plugins are the *only* way to animate on Cloud-mode boards (the built-in strategies are Local API features and are ignored there), but the practical frame rate is much lower.
 - Cloud **note arrays** are throttled to one send per 15 seconds. The runner automatically paces your frames (and the final snap) to the board client's `min_send_interval_ms`, so your plugin still works — it just runs no faster than that floor. Slow, deliberate transitions are the natural fit there.
 - Use `min_interval_ms` to protect users from runaway loops in your own plugin.
 
@@ -156,4 +163,4 @@ External plugins follow the same registry mechanism as data plugins (see [PLUGIN
 - **Runner**: `src/transitions/runner.py` → `TransitionRunner`
 - **Send chokepoint**: `src/board_client.py` → `BoardClient.render()`
 - **API endpoints**: `GET /transitions/plugins`, `POST /transitions/preview` in `src/api_server.py`
-- **First-party examples**: `plugins/typewriter`, `plugins/simple_dissolve`, `plugins/slot_machine`
+- **First-party examples**: `plugins/typewriter`, `plugins/simple_dissolve`, `plugins/slot_machine`, `plugins/quiet_library`

--- a/plugins/quiet_library/README.md
+++ b/plugins/quiet_library/README.md
@@ -18,7 +18,7 @@ None. Transition plugins do not expose template variables; they are selected as 
 
 ## Example Templates
 
-Not applicable — enable the **Transition Plugins** beta in Settings → Advanced → Beta Features, then pick *Quiet Library* as a page's transition (or preview it on the Transition Lab page).
+Not applicable — Quiet Library is chosen, not written into a template. Enable the **Transition Plugins** beta in Settings → Advanced → Beta Features, then pick *Quiet Library* from the **Transition** dropdown in the page editor's toolbar for one page, or under Settings → Behavior → Board Transitions for every page. The per-page choice wins over the global default, and "Use global default" gives the page back to it. Preview it first on the **Transition Lab** page.
 
 ## Configuration
 
@@ -35,7 +35,7 @@ Runtime caps (from `transition_settings`): interruptible, ≤512 frames, ≤30 m
 - Micro-batching (default ≤6 tiles per step) to soften the flap sound
 - Long inter-step delay tuned to the hardware's flap debounce timer
 - Trailing/leading blank cleanup rides along with the adjacent word
-- Works on Flagship, Note, and W×H note-array boards
+- Works on Flagship, Note, and W×H note-array boards, on Local API or Cloud connections (the built-in strategies are Local API only)
 
 ## Author
 

--- a/plugins/quiet_library/docs/SETUP.md
+++ b/plugins/quiet_library/docs/SETUP.md
@@ -9,14 +9,14 @@ Quiet Library is a **transition plugin**: it animates the change from the curren
 **Prerequisites**
 
 - FiestaBoard with the **Transition Plugins** beta enabled (Settings → Advanced → Beta Features)
-- Any board type (Flagship, Note, or a note array)
+- Any board type (Flagship, Note, or a note array) on either a Local API or Cloud connection — FiestaBoard sends each step as a regular board update, so unlike the built-in Local API strategies, this works on Cloud boards too
 
 ## Quick Setup
 
-1. **Enable the beta**: Settings → Advanced → Beta Features → toggle **Transition Plugins** on.
-2. **Enable the plugin**: Integrations → Quiet Library → enable. Optionally adjust *Tiles per step* and *Delay between steps*.
-3. **Select the transition**: edit a page and choose **Quiet Library** as its transition, or set it as the system default in Settings → Board Transitions.
-4. **View**: the next time that page is sent, the board updates one small batch of tiles at a time. Preview it any time on the **Transitions** page (Transition Lab).
+1. **Enable the beta**: Settings → Advanced → Beta Features → toggle **Transition Plugins** on. That single switch is all that gates Quiet Library — installed transition plugins have no enable step of their own.
+2. **Adjust the pacing (optional)**: *Tiles per step* and *Delay between steps* are in Quiet Library's settings on the Integrations page. The 6-tile, 14.5-second defaults are tuned for the hardware's flap debounce; change them only if you know what you want instead.
+3. **Select the transition**: open a page in the editor and choose **Quiet Library** from the **Transition** dropdown in the toolbar, or set it as the system default under Settings → Behavior → Board Transitions. A page's own choice overrides the default; "Use global default" clears it.
+4. **View**: the next time that page is sent, the board updates one small batch of tiles at a time. Preview it any time on the **Transition Lab** page, which also has a config box for trying different pacing on a single run.
 
 ## Template Variables
 
@@ -33,7 +33,7 @@ No environment variables.
 
 ## Troubleshooting
 
-- **The board snaps instantly instead of animating** — the Transition Plugins beta is off, or the plugin is disabled on the Integrations page. Both must be on.
+- **The board snaps instantly instead of animating** — the Transition Plugins beta is off (Settings → Advanced → Beta Features), or the page in question has a different Transition set. With the beta off, pages saved with a plugin transition go straight to the target.
 - **A full-board change takes a long time** — that is the point: with the default settings a completely different message updates in ~14.5s steps. Lower `step_delay_ms` (at the cost of dropped animation steps on hardware, which debounces sends for ~14s) or raise `batch_size` for a faster, louder update.
 - **The transition stops partway** — a new page, trigger, or manual send preempted it; the board lands on the newest content. Rotation dwell times shorter than the full transition will regularly do this — that final snap to the new target is expected behavior, not an error.
 - **Cloud note arrays** — the Cloud API throttles note-array sends to one per 15 seconds; the runner paces steps automatically, so transitions work but never faster than that floor.

--- a/plugins/simple_dissolve/README.md
+++ b/plugins/simple_dissolve/README.md
@@ -12,13 +12,17 @@ Simple Dissolve is a transition plugin -- it doesn't display its own content. Wh
 
 Only tiles that actually differ between the current and target grids are flipped. Unchanged content stays in place throughout.
 
+Each frame is drawn by FiestaBoard and sent as a normal board update, so Simple Dissolve runs on any board connection — unlike the built-in strategies (Wave, Edges to Center, and the rest), which are Vestaboard Local API features.
+
 ## Template Variables
 
 None. Transition plugins don't expose template variables.
 
 ## Example Templates
 
-Select Simple Dissolve from a page's Transition picker or set it as the global default in Settings → Board Transitions.
+Simple Dissolve isn't referenced from a template. Once the **Transition Plugins** beta is on (Settings → Advanced → Beta Features), pick it from the **Transition** dropdown in the page editor's toolbar for a single page, or from Settings → Behavior → Board Transitions for every page. A page's own setting wins over the global default; "Use global default" clears it.
+
+Pages store the choice as `transition_strategy = "plugin:simple_dissolve"`.
 
 ## Configuration
 
@@ -32,6 +36,7 @@ Select Simple Dissolve from a page's Transition picker or set it as the global d
 
 - Animates only the tiles that change; unchanged content stays put
 - Random shuffle each run (or seeded for predictable previews)
+- Works on any board connection, Local API or Cloud
 - Bounded: capped at 200 frames / 60 seconds runtime
 - Interruptible: a new page or trigger cancels the in-flight dissolve cleanly
 

--- a/plugins/simple_dissolve/docs/SETUP.md
+++ b/plugins/simple_dissolve/docs/SETUP.md
@@ -6,14 +6,16 @@ How to enable Simple Dissolve and use it on a page.
 
 **What it does**: Animates board updates by flipping changed tiles in a random order, producing a gradual dissolve from the current message to the target.
 
-**Prerequisites**: The **Transition Plugins** beta must be enabled first (Settings → Advanced → Beta Features).
+**Prerequisites**: The **Transition Plugins** beta must be enabled first (Settings → Advanced → Beta Features). Local API and Cloud boards both work — FiestaBoard draws the dissolve itself and sends each frame as a regular board update.
 
 ## Quick Setup
 
-1. **Enable** — Open the Integrations page, find Simple Dissolve under "Transition Plugins", and toggle it on.
-2. **Configure** — Optionally adjust `tiles_per_frame`, `frame_interval_ms`, and `seed`.
-3. **Apply** — Open a page in the editor, set its Transition to "Simple Dissolve", and save. Or set it as the global default in Settings → Board Transitions.
-4. **View** — The next page transition will dissolve into the new content.
+1. **Turn on the beta** — Settings → Advanced → Beta Features → **Transition Plugins**. Every installed transition plugin becomes selectable at that point; there is nothing else to switch on.
+2. **Tune it (optional)** — `tiles_per_frame`, `frame_interval_ms`, and `seed` live in Simple Dissolve's settings on the Integrations page. Six tiles every 100 ms is the default.
+3. **Apply it** — Open a page in the editor, pick **Simple Dissolve** from the **Transition** dropdown in the toolbar, and save. To dissolve everywhere, pick it under Settings → Behavior → Board Transitions instead. A page's own Transition beats the global default, and "Use global default" hands the page back to it.
+4. **View** — The next time that page becomes active, the changed tiles flip away in random batches until the new message is complete.
+
+Not sure how chunky the dissolve will look on your board? Open **Transition Lab** from the sidebar, pick Simple Dissolve and two pages, and scrub the frames. The config box there starts from the saved settings and applies your edits to that preview only.
 
 ## Template Variables
 
@@ -35,3 +37,5 @@ No environment variables required.
 - **Want a preview that always plays the same way** — Set `seed` to any non-zero integer.
 - **Transition feels chunky** — Lower `tiles_per_frame` and/or raise `frame_interval_ms`.
 - **Transition is too slow** — Raise `tiles_per_frame` or lower `frame_interval_ms`.
+- **The board changes instantly, no dissolve** — The **Transition Plugins** beta is off. Turn it on under Settings → Advanced → Beta Features; with it off, pages saved with a plugin transition snap to the target.
+- **One page dissolves, another doesn't** — Each page can carry its own Transition. Check that page's Transition dropdown in the editor.

--- a/plugins/slot_machine/README.md
+++ b/plugins/slot_machine/README.md
@@ -10,7 +10,7 @@ A transition plugin where each column "spins" through random characters like a s
 
 Slot Machine is a transition plugin -- it doesn't display its own content. When the active page changes, each column of the board spins through a sequence of random tile codes (mimicking a flap reel cycling) and then locks on the target. The stagger setting controls how much later each column starts locking than the previous one, producing a left-to-right cascade.
 
-This plugin plays to the unique nature of the Vestaboard's split-flap mechanism: where hardware transitions like "wave" or "edges-to-center" simply *move* the final state into place, Slot Machine animates the *flaps themselves* as if the board were a row of mechanical reels.
+This plugin plays to the unique nature of the Vestaboard's split-flap mechanism: where the built-in strategies like Wave or Edges to Center simply *move* the final state into place, Slot Machine animates the *flaps themselves* as if the board were a row of mechanical reels. Those built-in strategies are Local API features; Slot Machine is drawn frame by frame by FiestaBoard and sent as ordinary board updates, so it runs on any board connection.
 
 ## Template Variables
 
@@ -18,7 +18,9 @@ None. Transition plugins don't expose template variables.
 
 ## Example Templates
 
-Select Slot Machine from a page's Transition picker or set it as the global default in Settings → Board Transitions.
+Slot Machine isn't referenced from a template. With the **Transition Plugins** beta on (Settings → Advanced → Beta Features), select it from the **Transition** dropdown in the page editor's toolbar for one page, or from Settings → Behavior → Board Transitions for every page. The per-page choice wins; "Use global default" clears it.
+
+Pages store the choice as `transition_strategy = "plugin:slot_machine"`.
 
 ## Configuration
 
@@ -34,6 +36,7 @@ Select Slot Machine from a page's Transition picker or set it as the global defa
 - Visually striking flap-reel effect that plays to the Vestaboard's mechanical character
 - Tunable cascade pattern via `column_stagger`
 - Random spin per run (or seeded for predictable previews)
+- Works on any board connection, Local API or Cloud
 - Bounded: capped at 300 frames / 60 seconds runtime
 - Interruptible: a new page or trigger cancels the in-flight spin cleanly
 

--- a/plugins/slot_machine/docs/SETUP.md
+++ b/plugins/slot_machine/docs/SETUP.md
@@ -6,14 +6,16 @@ How to enable Slot Machine and use it on a page.
 
 **What it does**: Animates board updates by spinning each column through random characters like a slot-machine reel before locking on the target. Columns lock left-to-right with a configurable stagger.
 
-**Prerequisites**: The **Transition Plugins** beta must be enabled first (Settings → Advanced → Beta Features).
+**Prerequisites**: The **Transition Plugins** beta must be enabled first (Settings → Advanced → Beta Features). Any board connection works — the spin is drawn by FiestaBoard and sent as regular board updates, not by the Local API's built-in transitions.
 
 ## Quick Setup
 
-1. **Enable** — Open the Integrations page, find Slot Machine under "Transition Plugins", and toggle it on.
-2. **Configure** — Optionally adjust `spin_frames`, `column_stagger`, `frame_interval_ms`, and `seed`.
-3. **Apply** — Open a page in the editor, set its Transition to "Slot Machine", and save. Or set it as the global default in Settings → Board Transitions.
+1. **Turn on the beta** — Settings → Advanced → Beta Features → **Transition Plugins**. That is the only switch; installed transition plugins have no separate enable step.
+2. **Tune the spin (optional)** — `spin_frames`, `column_stagger`, `frame_interval_ms`, and `seed` live in Slot Machine's settings on the Integrations page. The defaults give a six-frame spin with a one-frame cascade between columns.
+3. **Apply it** — In the page editor, pick **Slot Machine** from the **Transition** dropdown in the toolbar and save that page. To spin on every page instead, pick it under Settings → Behavior → Board Transitions. Whatever a page sets for itself overrides the global default.
 4. **View** — The next page transition will spin each column before locking on the new content.
+
+Slot Machine is the most fun to tune with a preview in front of you. Open **Transition Lab** in the sidebar, pick Slot Machine and two pages, and scrub the frames. The config box there starts from the saved settings and applies your edits to that run only, so you can try `column_stagger: 3` before deciding to keep it.
 
 ## Template Variables
 
@@ -36,3 +38,5 @@ No environment variables required.
 - **All columns lock at the same time, no cascade** — Raise `column_stagger` (try 2-3).
 - **Cascade takes too long** — Lower `column_stagger` and/or `frame_interval_ms`.
 - **Want a preview that always plays the same way** — Set `seed` to any non-zero integer.
+- **The board snaps instead of spinning** — The **Transition Plugins** beta is off. Turn it on under Settings → Advanced → Beta Features; until then, pages saved with a plugin transition jump straight to the target.
+- **One page won't spin but the rest do** — That page has its own Transition set to something else. Open it in the page editor and choose Slot Machine, or "Use global default".

--- a/plugins/typewriter/README.md
+++ b/plugins/typewriter/README.md
@@ -10,13 +10,17 @@ A transition plugin that reveals the target message left-to-right, character by 
 
 Typewriter is a transition plugin -- it doesn't display its own content. Instead, when one page replaces another on the board, Typewriter animates the change by revealing the new content one tile at a time, sweeping left-to-right and top-to-bottom.
 
+FiestaBoard draws each frame itself and sends it as an ordinary board update, so Typewriter works on any board connection. (The built-in strategies -- Wave, Edges to Center, and friends -- are Vestaboard Local API features and only animate on a local-API board.)
+
 ## Template Variables
 
 None. Transition plugins don't expose template variables; they shape *how* a board update happens, not *what* it shows.
 
 ## Example Templates
 
-Transition plugins are selected per page from the page editor's "Transition" picker (or globally from Settings → Board Transitions). They aren't placed in templates directly.
+Typewriter is never placed in a template. Turn on the **Transition Plugins** beta (Settings → Advanced → Beta Features), then pick Typewriter from the **Transition** dropdown in the page editor's toolbar to use it on one page, or from Settings → Behavior → Board Transitions to make it the default for every page. A page's own choice wins over the global default; "Use global default" clears it.
+
+Pages store the choice as `transition_strategy = "plugin:typewriter"`.
 
 ## Configuration
 
@@ -29,6 +33,7 @@ Transition plugins are selected per page from the page editor's "Transition" pic
 
 - Smooth left-to-right reveal of the target grid
 - Tunable speed: choose how many tiles per step and how long between steps
+- Works on any board connection, Local API or Cloud
 - Bounded: capped at 200 frames / 60 seconds runtime
 - Interruptible: a new page or trigger cancels the in-flight typewriter cleanly
 

--- a/plugins/typewriter/docs/SETUP.md
+++ b/plugins/typewriter/docs/SETUP.md
@@ -6,14 +6,16 @@ How to enable the Typewriter transition and use it on a page.
 
 **What it does**: Reveals new content on the board left-to-right, one tile (or small batch of tiles) at a time, like a typewriter.
 
-**Prerequisites**: The **Transition Plugins** beta must be enabled first (Settings → Advanced → Beta Features). No API keys or external accounts are required.
+**Prerequisites**: The **Transition Plugins** beta must be enabled first (Settings → Advanced → Beta Features). No API keys or external accounts are required, and any board connection works — FiestaBoard sends each frame as a normal board update rather than relying on the Local API's built-in transitions.
 
 ## Quick Setup
 
-1. **Enable** — Open the Integrations page, find Typewriter under "Transition Plugins", and toggle it on.
-2. **Configure** — Optionally adjust `chars_per_frame` and `frame_interval_ms` (defaults are a good starting point).
-3. **Apply** — Open the page editor for any page, set the Transition picker to "Typewriter", and save. Or set it as the global default in Settings → Board Transitions.
+1. **Turn on the beta** — Settings → Advanced → Beta Features → **Transition Plugins**. Installed transition plugins are usable as soon as the beta is on; there is no separate on/off switch for Typewriter itself.
+2. **Tune it (optional)** — The defaults (one tile every 120 ms) are a good starting point. Adjust `chars_per_frame` and `frame_interval_ms` in Typewriter's settings on the Integrations page.
+3. **Apply it** — For a single page, open it in the page editor and choose **Typewriter** from the **Transition** dropdown in the toolbar, then save. For every page, choose Typewriter under Settings → Behavior → Board Transitions. A page's own choice wins over the global default; picking "Use global default" clears it.
 4. **View** — The next time that page becomes active, the board sweeps left-to-right as the new content lands.
+
+To see the reveal before you commit to it, open **Transition Lab** in the sidebar (it appears once the beta is on). Pick Typewriter and two pages, and step through the frames one at a time. The config box there is seeded with Typewriter's saved settings and lets you try different values for that run only — handy for finding a speed you like before saving it.
 
 ## Template Variables
 
@@ -32,4 +34,5 @@ No environment variables required.
 
 - **Transition is too slow** — Lower `frame_interval_ms` or raise `chars_per_frame`.
 - **Transition is too fast to see** — Raise `frame_interval_ms` (e.g. to 200-300).
-- **Transition not visible** — Confirm the plugin is enabled on the **Integrations** page and selected on the page (or as the global default).
+- **Transition not visible** — Confirm the **Transition Plugins** beta is on (Settings → Advanced → Beta Features). With the beta off, pages saved with a plugin transition snap straight to the target instead.
+- **A page ignores the global default** — That page has its own Transition set. Open it in the page editor and pick "Use global default" from the Transition dropdown.

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -8723,6 +8723,9 @@ async def get_plugin(plugin_id: str):
         "author": manifest.author,
         "icon": manifest.icon,
         "category": manifest.category,
+        # "data" or "transition" -- the UI hides the enable toggle for
+        # transition plugins, which run whenever selected regardless of it.
+        "plugin_type": manifest.plugin_type,
         "enabled": registry.is_enabled(plugin_id),
         "config": config_manager._mask_sensitive(plugin_config) if plugin_config else {},
         "settings_schema": manifest.settings_schema,

--- a/src/plugins/registry.py
+++ b/src/plugins/registry.py
@@ -1082,6 +1082,7 @@ class PluginRegistry:
                 "enabled": self._enabled.get(plugin_id, False),
                 "icon": manifest.icon if manifest else "puzzle",
                 "category": manifest.category if manifest else "utility",
+                "plugin_type": manifest.plugin_type if manifest else "data",
                 "fiestaboard_version": manifest.fiestaboard_version if manifest else "",
                 "source": source.to_dict() if source else {"source_type": "builtin"},
                 "update_available": self._update_status.get(plugin_id, False),

--- a/tests/test_api_extended.py
+++ b/tests/test_api_extended.py
@@ -265,6 +265,7 @@ def mock_plugin_registry():
         manifest.author = "Test"
         manifest.icon = "cloud"
         manifest.category = "weather"
+        manifest.plugin_type = "data"
         manifest.settings_schema = {}
         manifest.raw = {"variables": {"temperature": "number"}}
         manifest.max_lengths = {"temperature": 5}

--- a/tests/test_plugin_detail_plugin_type.py
+++ b/tests/test_plugin_detail_plugin_type.py
@@ -1,0 +1,94 @@
+"""Tests that ``GET /plugins/{plugin_id}`` reports the plugin's type.
+
+The Integrations UI hides the enable/disable toggle for transition plugins
+(they run whenever selected -- ``PluginRegistry.get_transition_plugin`` never
+consults the enabled flag), so the detail payload must say which kind of
+plugin it is describing.  ``list_plugins`` carries ``plugin_type``; this
+endpoint builds its own dict and has to carry it too or the detail view
+falls back to data-plugin chrome.
+"""
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.api_server import app
+
+
+def _manifest(plugin_type: str) -> SimpleNamespace:
+    """Minimal manifest stand-in covering every field the route reads."""
+    return SimpleNamespace(
+        name="Typewriter",
+        version="1.0.0",
+        description="Reveals content left-to-right.",
+        author="FiestaBoard",
+        icon="type",
+        category="transition",
+        plugin_type=plugin_type,
+        settings_schema={},
+        raw={},
+        max_lengths={},
+        env_vars=[],
+        documentation=None,
+        demo=None,
+    )
+
+
+class _FakeRegistry:
+    def __init__(self, plugin_type: str) -> None:
+        self._manifest = _manifest(plugin_type)
+
+    def get_manifest(self, plugin_id: str) -> SimpleNamespace | None:
+        return self._manifest if plugin_id == "typewriter" else None
+
+    def is_enabled(self, plugin_id: str) -> bool:
+        return False
+
+    def parse_instance_key(self, plugin_id: str) -> tuple[str, None]:
+        return plugin_id, None
+
+    def list_instances(self, base_id: str) -> list[Any]:
+        return []
+
+
+class _FakeConfigManager:
+    def get_plugin_config(self, plugin_id: str) -> dict[str, Any] | None:
+        return None
+
+    def _mask_sensitive(self, config: dict[str, Any]) -> dict[str, Any]:
+        return config
+
+
+@pytest.fixture
+def client_for(request):
+    """Build a TestClient whose registry reports *plugin_type*."""
+
+    def _build(plugin_type: str) -> TestClient:
+        registry_patch = patch("src.api_server.get_plugin_registry", return_value=_FakeRegistry(plugin_type))
+        config_patch = patch("src.api_server.get_config_manager", return_value=_FakeConfigManager())
+        registry_patch.start()
+        config_patch.start()
+        request.addfinalizer(registry_patch.stop)
+        request.addfinalizer(config_patch.stop)
+        return TestClient(app)
+
+    return _build
+
+
+def test_plugin_detail_reports_transition_plugin_type(client_for):
+    """A transition plugin's detail payload identifies it as a transition."""
+    response = client_for("transition").get("/plugins/typewriter")
+
+    assert response.status_code == 200
+    assert response.json()["plugin_type"] == "transition"
+
+
+def test_plugin_detail_reports_data_plugin_type(client_for):
+    """A data plugin's detail payload identifies it as data."""
+    response = client_for("data").get("/plugins/typewriter")
+
+    assert response.status_code == 200
+    assert response.json()["plugin_type"] == "data"

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from src.plugins.base import PluginBase, PluginResult
-from src.plugins.manifest import PluginManifest
+from src.plugins.manifest import PluginManifest, load_manifest
 from src.plugins.previews import BoardPreview
 from src.plugins.registry import (
     PluginRegistry,
@@ -14,6 +14,8 @@ from src.plugins.registry import (
     reset_plugin_registry,
 )
 from src.plugins.sources import PluginSource, PluginUpdateCheck, RegistryEntry
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 @pytest.fixture
@@ -453,6 +455,34 @@ def test_list_plugins_returns_sorted_info(registry, mock_loader, mock_plugin, mo
     assert info["enabled"] is False
     assert info["icon"] == "puzzle"
     assert info["category"] == "utility"
+
+
+def test_list_plugins_reports_transition_plugin_type(registry, mock_loader, mock_plugin):
+    """A transition plugin's manifest plugin_type reaches the UI via list_plugins."""
+    manifest, errors = load_manifest(REPO_ROOT / "plugins" / "typewriter" / "manifest.json")
+    assert manifest is not None, errors
+    mock_plugin.plugin_id = "typewriter"
+    mock_loader.load_all_plugins.return_value = {"typewriter": mock_plugin}
+    mock_loader.get_manifest.side_effect = lambda pid: manifest if pid == "typewriter" else None
+    registry.initialize()
+
+    info = registry.list_plugins()[0]
+
+    assert info["plugin_type"] == "transition"
+
+
+def test_list_plugins_reports_data_plugin_type(registry, mock_loader, mock_plugin):
+    """A plugin whose manifest omits plugin_type is reported as a data plugin."""
+    manifest, errors = load_manifest(REPO_ROOT / "plugins" / "date_time" / "manifest.json")
+    assert manifest is not None, errors
+    mock_plugin.plugin_id = "date_time"
+    mock_loader.load_all_plugins.return_value = {"date_time": mock_plugin}
+    mock_loader.get_manifest.side_effect = lambda pid: manifest if pid == "date_time" else None
+    registry.initialize()
+
+    info = registry.list_plugins()[0]
+
+    assert info["plugin_type"] == "data"
 
 
 def test_list_plugins_sorted_by_name(registry, mock_loader, mock_plugin, mock_manifest):

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -59,6 +59,7 @@ def mock_plugin_with_sensitive_config():
         manifest.author = "Test"
         manifest.icon = "puzzle"
         manifest.category = "utility"
+        manifest.plugin_type = "data"
         manifest.settings_schema = {
             "type": "object",
             "properties": {

--- a/web/app/routes/integrations.$pluginId.tsx
+++ b/web/app/routes/integrations.$pluginId.tsx
@@ -61,6 +61,7 @@ export default function PluginDetailPage() {
     finance: t("categories.finance"),
     home: t("categories.home"),
     transit: t("categories.transit"),
+    transition: t("categories.transition"),
     utility: t("categories.utility"),
     weather: t("categories.weather"),
   };

--- a/web/app/routes/integrations._index.tsx
+++ b/web/app/routes/integrations._index.tsx
@@ -852,17 +852,29 @@ function ColorRulesEditor({
   );
 }
 
-// Category labels
-const CATEGORY_LABELS: Record<string, string> = {
-  art: "Display Art",
-  data: "Data & Information",
-  entertainment: "Entertainment",
-  finance: "Finance",
-  home: "Smart Home",
-  transit: "Transportation",
-  utility: "Utilities",
-  weather: "Weather & Environment",
-};
+// Category ids that have a translated label. Anything else falls back to the
+// raw manifest category string at the call site.
+const CATEGORY_KEYS = [
+  "art",
+  "data",
+  "entertainment",
+  "finance",
+  "home",
+  "transit",
+  "transition",
+  "utility",
+  "weather",
+] as const;
+
+/**
+ * Category id → display label, sourced from `integrations.categories` so the
+ * chips, the sort keys and the marketplace section headings all read the same
+ * translated string.
+ */
+function useCategoryLabels(): Record<string, string> {
+  const t = useTranslations("integrations");
+  return Object.fromEntries(CATEGORY_KEYS.map((key) => [key, t(`categories.${key}`)]));
+}
 
 // Resolve the live value of a template variable from a plugin's raw display data.
 // Variable names come in two shapes:
@@ -996,10 +1008,18 @@ function InstalledPluginRow({
   const [isCreatingInstance, setIsCreatingInstance] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const queryClient = useQueryClient();
+  const t = useTranslations("integrations");
+  const categoryLabels = useCategoryLabels();
 
   const isExternal = plugin.source?.source_type !== "builtin";
   const hasUpdate = plugin.update_available === true;
   const isInstance = !!plugin.instance_label;
+  // Transitions have no polling loop, so `PluginRegistry.get_transition_plugin()`
+  // runs any installed one whether or not it is "enabled". Offering a toggle
+  // here would promise control the backend does not honour, so the row shows a
+  // type badge instead of a switch and instead of an enabled/disabled status.
+  const isTransition = plugin.plugin_type === "transition";
+  const isActive = plugin.enabled || isTransition;
 
   // Fetch plugin details when opening config
   const { data: pluginDetails, isLoading: isLoadingDetails } = useQuery({
@@ -1175,7 +1195,7 @@ function InstalledPluginRow({
   const isCore = sourceType === "builtin";
   const isMarketplace = sourceType === "registry" || sourceType === "external";
   const isGitExternal = sourceType === "git";
-  const categoryLabel = CATEGORY_LABELS[plugin.category || "utility"] || plugin.category || "Utility";
+  const categoryLabel = categoryLabels[plugin.category || "utility"] || plugin.category || categoryLabels.utility;
 
   function handleCreateInstance() {
     if (!instanceLabel.trim()) return;
@@ -1475,7 +1495,7 @@ function InstalledPluginRow({
       <TableRow
         className={cn(
           "border-b last:border-b-0 transition-colors",
-          plugin.enabled ? "hover:bg-muted/30" : "opacity-60 hover:opacity-80 hover:bg-muted/20",
+          isActive ? "hover:bg-muted/30" : "opacity-60 hover:opacity-80 hover:bg-muted/20",
         )}
       >
         {/* Name column: icon + name + version + source badges */}
@@ -1484,7 +1504,7 @@ function InstalledPluginRow({
             <Box
               className={cn(
                 "p-1.5 rounded-md shrink-0",
-                plugin.enabled ? "bg-primary/10 text-primary" : "bg-muted text-muted-foreground",
+                isActive ? "bg-primary/10 text-primary" : "bg-muted text-muted-foreground",
               )}
             >
               <Icon className="h-4 w-4" />
@@ -1541,9 +1561,18 @@ function InstalledPluginRow({
           {categoryLabel}
         </TableCell>
 
-        {/* Status column */}
+        {/* Status column — transitions have no enabled state to report, so the
+            cell carries the plugin type instead. */}
         <TableCell className="px-4 py-2.5 whitespace-nowrap hidden md:table-cell">
-          {plugin.enabled ? (
+          {isTransition ? (
+            <Badge
+              variant="outline"
+              className="text-[10px] gap-1 px-1.5 py-0 h-5 border-violet-300 text-violet-600 dark:text-violet-400 dark:border-violet-700"
+            >
+              <Wand2 className="h-2.5 w-2.5" />
+              {t("transitionBadge")}
+            </Badge>
+          ) : plugin.enabled ? (
             plugin.configured ? (
               <Badge variant="default" className="text-[10px] gap-1 px-1.5 py-0 h-5">
                 <CheckCircle className="h-2.5 w-2.5" />
@@ -1566,12 +1595,14 @@ function InstalledPluginRow({
         {/* Actions column: toggle + configure + overflow */}
         <TableCell className="px-4 py-2.5">
           <Flex align="center" justify="end" gap="0.5">
-            <Switch
-              checked={plugin.enabled}
-              onCheckedChange={(checked) => onToggle(plugin.id, checked)}
-              disabled={isToggling}
-              aria-label={`Toggle ${plugin.name}`}
-            />
+            {!isTransition && (
+              <Switch
+                checked={plugin.enabled}
+                onCheckedChange={(checked) => onToggle(plugin.id, checked)}
+                disabled={isToggling}
+                aria-label={t("toggleAriaLabel", { pluginName: plugin.name })}
+              />
+            )}
             {configSheet}
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
@@ -1590,14 +1621,16 @@ function InstalledPluginRow({
                     Add Instance
                   </DropdownMenuItem>
                 )}
-                <DropdownMenuItem onClick={() => onToggle(plugin.id, !plugin.enabled)} disabled={isToggling}>
-                  {plugin.enabled ? (
-                    <XCircle className="h-3.5 w-3.5 mr-2" />
-                  ) : (
-                    <CheckCircle className="h-3.5 w-3.5 mr-2" />
-                  )}
-                  {plugin.enabled ? "Disable" : "Enable"}
-                </DropdownMenuItem>
+                {!isTransition && (
+                  <DropdownMenuItem onClick={() => onToggle(plugin.id, !plugin.enabled)} disabled={isToggling}>
+                    {plugin.enabled ? (
+                      <XCircle className="h-3.5 w-3.5 mr-2" />
+                    ) : (
+                      <CheckCircle className="h-3.5 w-3.5 mr-2" />
+                    )}
+                    {plugin.enabled ? "Disable" : "Enable"}
+                  </DropdownMenuItem>
+                )}
                 {hasUpdate && onUpdate && (
                   <>
                     <DropdownMenuSeparator />
@@ -1807,6 +1840,7 @@ function RegistryPluginRow({
   isInstalled?: boolean;
 }) {
   const t = useTranslations("integrations");
+  const categoryLabels = useCategoryLabels();
   const Icon = getPluginIcon(entry.icon);
   return (
     <TableRow className="border-b last:border-b-0 hover:bg-muted/30 transition-colors">
@@ -1836,7 +1870,7 @@ function RegistryPluginRow({
         </Link>
       </TableCell>
       <TableCell className="px-4 py-2.5 text-sm text-muted-foreground whitespace-nowrap">
-        {CATEGORY_LABELS[entry.category || "utility"] || entry.category || "Utility"}
+        {categoryLabels[entry.category || "utility"] || entry.category || categoryLabels.utility}
       </TableCell>
       <TableCell className="px-4 py-2.5 text-sm text-muted-foreground whitespace-nowrap">{entry.author}</TableCell>
       <TableCell className="px-4 py-2.5 text-right">
@@ -1860,6 +1894,7 @@ function RegistryPluginRow({
 export default function IntegrationsPage() {
   const t = useTranslations("integrations");
   const tCommon = useTranslations("common");
+  const categoryLabels = useCategoryLabels();
   const queryClient = useQueryClient();
   const searchParams = useSearchParams();
   const [activeTab, setActiveTab] = useState(() => {
@@ -2103,7 +2138,7 @@ export default function IntegrationsPage() {
   );
 
   const marketplaceCategories = Object.keys(groupedRegistry).sort((a, b) =>
-    (CATEGORY_LABELS[a] || a).localeCompare(CATEGORY_LABELS[b] || b),
+    (categoryLabels[a] || a).localeCompare(categoryLabels[b] || b),
   );
 
   const availableCount = allRegistryEntries.length;
@@ -2116,8 +2151,8 @@ export default function IntegrationsPage() {
       valA = a.name;
       valB = b.name;
     } else if (marketplaceSort.key === "category") {
-      valA = CATEGORY_LABELS[a.category || "utility"] || a.category || "";
-      valB = CATEGORY_LABELS[b.category || "utility"] || b.category || "";
+      valA = categoryLabels[a.category || "utility"] || a.category || "";
+      valB = categoryLabels[b.category || "utility"] || b.category || "";
     } else if (marketplaceSort.key === "author") {
       valA = a.author || "";
       valB = b.author || "";
@@ -2144,8 +2179,8 @@ export default function IntegrationsPage() {
       valA = a.name;
       valB = b.name;
     } else if (installedSort.key === "category") {
-      valA = CATEGORY_LABELS[a.category || "utility"] || a.category || "";
-      valB = CATEGORY_LABELS[b.category || "utility"] || b.category || "";
+      valA = categoryLabels[a.category || "utility"] || a.category || "";
+      valB = categoryLabels[b.category || "utility"] || b.category || "";
     } else if (installedSort.key === "status") {
       const statusRank = (p: PluginInfo) => (!p.enabled ? 2 : p.configured ? 0 : 1);
       return installedSort.dir === "asc" ? statusRank(a) - statusRank(b) : statusRank(b) - statusRank(a);
@@ -2503,7 +2538,7 @@ export default function IntegrationsPage() {
                           repeat the heading verbatim N times. Cards in the public
                           directory carry it because that grid is flat. */}
                       <Heading level={2} size="sm" className="mb-3 flex items-center gap-2">
-                        <PluginCategoryBadge category={category} label={CATEGORY_LABELS[category] || category} />
+                        <PluginCategoryBadge category={category} label={categoryLabels[category] || category} />
                         <Text as="span" size="xs" tone="muted" className="normal-case tracking-normal">
                           ({entries.length})
                         </Text>

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -418,9 +418,11 @@
       "finance": "Finanzen",
       "home": "Smart Home",
       "transit": "Verkehr",
+      "transition": "Übergänge",
       "utility": "Dienstprogramme",
       "weather": "Wetter & Umwelt"
     },
+    "transitionBadge": "Übergang",
     "tabInstalled": "Installiert",
     "tabMarketplace": "Marktplatz",
     "searchInstalledPlaceholder": "Installierte Plugins suchen...",
@@ -737,7 +739,14 @@
     "retargetSurfaceSchedule": "Zeitplaneintrag",
     "retargetSurfaceActivePage": "aktive Seite",
     "notesWideOption": "{count} breit",
-    "notesTallOption": "{count} hoch"
+    "notesTallOption": "{count} hoch",
+    "transitionMenuTitle": "Übergang",
+    "transitionPickerAriaLabel": "Seitenübergang",
+    "transitionPickerTooltip": "Übergang für diese Seite: {strategy}",
+    "transitionUseGlobalDefault": "Globalen Standard verwenden",
+    "transitionBuiltInGroup": "Integriert",
+    "transitionPluginsGroup": "Plugins (Beta)",
+    "transitionOpenLab": "Übergangs-Labor öffnen"
   },
   "displaySettings": {
     "title": "Ihre Boards",
@@ -887,6 +896,11 @@
     "stepSizePlaceholder": "Standard",
     "stepSizeDescription": "Wie viele Zeilen oder Spalten gleichzeitig animiert werden. Leer lassen für den Board-Standard.",
     "localApiNote": "Übergänge werden nur von der lokalen API unterstützt. Wenn Ihr Board für die Cloud API konfiguriert ist, haben Übergangseinstellungen keine Wirkung. Einzelne Seiten können diesen Standard auch im Seiteneditor überschreiben.",
+    "pluginNote": "Plugin-Übergänge werden von FiestaBoard animiert und als normale Board-Aktualisierungen gesendet, funktionieren also mit jeder Board-Verbindung.",
+    "builtInGroup": "Integriert",
+    "pluginsGroup": "Übergangs-Plugins",
+    "pluginsBetaBadge": "Beta",
+    "unavailablePluginNote": "Dieses Übergangs-Plugin ist derzeit nicht verfügbar. Wählen Sie eine andere Option, um es zu ändern.",
     "toastSaved": "Übergangseinstellungen gespeichert",
     "toastSaveFailed": "Übergangseinstellungen konnten nicht gespeichert werden: {error}",
     "strategies": {
@@ -1518,7 +1532,7 @@
     "setupDescription": "Wähle ein Übergangs-Plugin und dann die Von- und Nach-Seiten.",
     "pluginLabel": "Übergangs-Plugin",
     "pluginPlaceholder": "Plugin auswählen...",
-    "noPlugins": "Keine Übergangs-Plugins aktiviert. Aktiviere eines auf der Integrationen-Seite.",
+    "noPlugins": "Keine Übergangs-Plugins installiert. Füge eines auf der Integrationen-Seite hinzu.",
     "deviceLabel": "Gerät",
     "deviceFlagship": "Flagship (6×22)",
     "deviceNote": "Note (3×15)",
@@ -1604,6 +1618,7 @@
       "finance": "Finanzen",
       "home": "Smart Home",
       "transit": "Verkehr",
+      "transition": "Übergänge",
       "utility": "Dienstprogramme",
       "weather": "Wetter & Umwelt"
     },

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -375,9 +375,11 @@
       "finance": "Finance",
       "home": "Smart Home",
       "transit": "Transportation",
+      "transition": "Transitions",
       "utility": "Utilities",
       "weather": "Weather & Environment"
     },
+    "transitionBadge": "Transition",
     "tabInstalled": "Installed",
     "tabMarketplace": "Marketplace",
     "searchInstalledPlaceholder": "Search installed plugins...",
@@ -694,7 +696,14 @@
     "retargetSurfaceSchedule": "schedule entry",
     "retargetSurfaceActivePage": "active page",
     "notesWideOption": "{count} wide",
-    "notesTallOption": "{count} tall"
+    "notesTallOption": "{count} tall",
+    "transitionMenuTitle": "Transition",
+    "transitionPickerAriaLabel": "Page transition",
+    "transitionPickerTooltip": "Transition for this page: {strategy}",
+    "transitionUseGlobalDefault": "Use global default",
+    "transitionBuiltInGroup": "Built-in",
+    "transitionPluginsGroup": "Plugins (beta)",
+    "transitionOpenLab": "Open Transition Lab"
   },
   "displaySettings": {
     "title": "Your Boards",
@@ -844,6 +853,11 @@
     "stepSizePlaceholder": "Default",
     "stepSizeDescription": "How many rows or columns animate at once. Leave empty for the board default.",
     "localApiNote": "Transitions are supported on the Local API only. If your board is configured to use the Cloud API, transition settings will have no effect. Individual pages can also override this default in the page builder.",
+    "pluginNote": "Plugin transitions are animated by FiestaBoard and sent as regular board updates, so they work on any board connection.",
+    "builtInGroup": "Built-in",
+    "pluginsGroup": "Transition Plugins",
+    "pluginsBetaBadge": "Beta",
+    "unavailablePluginNote": "This transition plugin is not currently available. Pick another option to change it.",
     "toastSaved": "Transition settings saved",
     "toastSaveFailed": "Failed to save transition settings: {error}",
     "strategies": {
@@ -1475,7 +1489,7 @@
     "setupDescription": "Pick a transition plugin, then choose the from and to pages.",
     "pluginLabel": "Transition plugin",
     "pluginPlaceholder": "Select a plugin...",
-    "noPlugins": "No transition plugins enabled. Enable one on the Integrations page.",
+    "noPlugins": "No transition plugins installed. Add one from the Integrations page.",
     "deviceLabel": "Device",
     "deviceFlagship": "Flagship (6×22)",
     "deviceNote": "Note (3×15)",
@@ -1561,6 +1575,7 @@
       "finance": "Finance",
       "home": "Smart Home",
       "transit": "Transportation",
+      "transition": "Transitions",
       "utility": "Utilities",
       "weather": "Weather & Environment"
     },

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -418,9 +418,11 @@
       "finance": "Finanzas",
       "home": "Hogar inteligente",
       "transit": "Transporte",
+      "transition": "Transiciones",
       "utility": "Utilidades",
       "weather": "Clima y medio ambiente"
     },
+    "transitionBadge": "Transición",
     "tabInstalled": "Instalados",
     "tabMarketplace": "Mercado",
     "searchInstalledPlaceholder": "Buscar plugins instalados...",
@@ -737,7 +739,14 @@
     "retargetSurfaceSchedule": "entrada de horario",
     "retargetSurfaceActivePage": "página activa",
     "notesWideOption": "{count} de ancho",
-    "notesTallOption": "{count} de alto"
+    "notesTallOption": "{count} de alto",
+    "transitionMenuTitle": "Transición",
+    "transitionPickerAriaLabel": "Transición de la página",
+    "transitionPickerTooltip": "Transición de esta página: {strategy}",
+    "transitionUseGlobalDefault": "Usar el valor predeterminado global",
+    "transitionBuiltInGroup": "Integradas",
+    "transitionPluginsGroup": "Plugins (beta)",
+    "transitionOpenLab": "Abrir el laboratorio de transiciones"
   },
   "displaySettings": {
     "title": "Tus tableros",
@@ -887,6 +896,11 @@
     "stepSizePlaceholder": "Predeterminado",
     "stepSizeDescription": "Cuántas filas o columnas se animan a la vez. Deja vacío para el valor predeterminado del tablero.",
     "localApiNote": "Las transiciones solo son compatibles con la API local. Si tu tablero está configurado para usar la API en la nube, los ajustes de transición no tendrán efecto. Las páginas individuales también pueden anular este valor predeterminado en el editor de páginas.",
+    "pluginNote": "Las transiciones de plugin las anima FiestaBoard y se envían como actualizaciones normales del tablero, así que funcionan con cualquier conexión de tablero.",
+    "builtInGroup": "Integradas",
+    "pluginsGroup": "Plugins de transición",
+    "pluginsBetaBadge": "Beta",
+    "unavailablePluginNote": "Este plugin de transición no está disponible actualmente. Elige otra opción para cambiarla.",
     "toastSaved": "Ajustes de transición guardados",
     "toastSaveFailed": "Error al guardar los ajustes de transición: {error}",
     "strategies": {
@@ -1518,7 +1532,7 @@
     "setupDescription": "Elige un plugin de transición y luego las páginas de origen y destino.",
     "pluginLabel": "Plugin de transición",
     "pluginPlaceholder": "Selecciona un plugin...",
-    "noPlugins": "No hay plugins de transición activados. Activa uno en la página de Integraciones.",
+    "noPlugins": "No hay plugins de transición instalados. Añade uno desde la página de Integraciones.",
     "deviceLabel": "Dispositivo",
     "deviceFlagship": "Flagship (6×22)",
     "deviceNote": "Note (3×15)",
@@ -1604,6 +1618,7 @@
       "finance": "Finanzas",
       "home": "Hogar inteligente",
       "transit": "Transporte",
+      "transition": "Transiciones",
       "utility": "Utilidades",
       "weather": "Clima y medio ambiente"
     },

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -418,9 +418,11 @@
       "finance": "Finance",
       "home": "Maison connectée",
       "transit": "Transports",
+      "transition": "Transitions",
       "utility": "Utilitaires",
       "weather": "Météo et environnement"
     },
+    "transitionBadge": "Transition",
     "tabInstalled": "Installés",
     "tabMarketplace": "Marché",
     "searchInstalledPlaceholder": "Rechercher des plugins installés...",
@@ -737,7 +739,14 @@
     "retargetSurfaceSchedule": "entrée de planning",
     "retargetSurfaceActivePage": "page active",
     "notesWideOption": "{count} en largeur",
-    "notesTallOption": "{count} en hauteur"
+    "notesTallOption": "{count} en hauteur",
+    "transitionMenuTitle": "Transition",
+    "transitionPickerAriaLabel": "Transition de la page",
+    "transitionPickerTooltip": "Transition de cette page : {strategy}",
+    "transitionUseGlobalDefault": "Utiliser le réglage par défaut global",
+    "transitionBuiltInGroup": "Intégrées",
+    "transitionPluginsGroup": "Plugins (bêta)",
+    "transitionOpenLab": "Ouvrir le labo des transitions"
   },
   "displaySettings": {
     "title": "Vos tableaux",
@@ -887,6 +896,11 @@
     "stepSizePlaceholder": "Par défaut",
     "stepSizeDescription": "Combien de lignes ou colonnes s'animent simultanément. Laissez vide pour la valeur par défaut du tableau.",
     "localApiNote": "Les transitions ne sont prises en charge que par l'API locale. Si votre tableau est configuré pour utiliser l'API Cloud, les paramètres de transition n'auront aucun effet. Les pages individuelles peuvent également remplacer ce réglage par défaut dans le constructeur de pages.",
+    "pluginNote": "Les transitions de plugin sont animées par FiestaBoard et envoyées comme des mises à jour normales du tableau ; elles fonctionnent donc avec n'importe quelle connexion au tableau.",
+    "builtInGroup": "Intégrées",
+    "pluginsGroup": "Plugins de transition",
+    "pluginsBetaBadge": "Bêta",
+    "unavailablePluginNote": "Ce plugin de transition n'est pas disponible actuellement. Choisissez une autre option pour la modifier.",
     "toastSaved": "Paramètres de transition enregistrés",
     "toastSaveFailed": "Échec de l'enregistrement des paramètres de transition : {error}",
     "strategies": {
@@ -1518,7 +1532,7 @@
     "setupDescription": "Choisissez un plugin de transition, puis les pages de départ et d'arrivée.",
     "pluginLabel": "Plugin de transition",
     "pluginPlaceholder": "Sélectionner un plugin...",
-    "noPlugins": "Aucun plugin de transition activé. Activez-en un sur la page Intégrations.",
+    "noPlugins": "Aucun plugin de transition installé. Ajoutez-en un depuis la page Intégrations.",
     "deviceLabel": "Appareil",
     "deviceFlagship": "Flagship (6×22)",
     "deviceNote": "Note (3×15)",
@@ -1604,6 +1618,7 @@
       "finance": "Finance",
       "home": "Maison connectée",
       "transit": "Transport",
+      "transition": "Transitions",
       "utility": "Utilitaires",
       "weather": "Météo & environnement"
     },

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -418,9 +418,11 @@
       "finance": "Finanza",
       "home": "Casa intelligente",
       "transit": "Trasporti",
+      "transition": "Transizioni",
       "utility": "Utilità",
       "weather": "Meteo e ambiente"
     },
+    "transitionBadge": "Transizione",
     "tabInstalled": "Installati",
     "tabMarketplace": "Marketplace",
     "searchInstalledPlaceholder": "Cerca plugin installati...",
@@ -737,7 +739,14 @@
     "retargetSurfaceSchedule": "voce della pianificazione",
     "retargetSurfaceActivePage": "pagina attiva",
     "notesWideOption": "{count} in larghezza",
-    "notesTallOption": "{count} in altezza"
+    "notesTallOption": "{count} in altezza",
+    "transitionMenuTitle": "Transizione",
+    "transitionPickerAriaLabel": "Transizione della pagina",
+    "transitionPickerTooltip": "Transizione di questa pagina: {strategy}",
+    "transitionUseGlobalDefault": "Usa il valore predefinito globale",
+    "transitionBuiltInGroup": "Integrate",
+    "transitionPluginsGroup": "Plugin (beta)",
+    "transitionOpenLab": "Apri il laboratorio transizioni"
   },
   "displaySettings": {
     "title": "Le tue bacheche",
@@ -887,6 +896,11 @@
     "stepSizePlaceholder": "Predefinito",
     "stepSizeDescription": "Quante righe o colonne si animano contemporaneamente. Lascia vuoto per il valore predefinito della bacheca.",
     "localApiNote": "Le transizioni sono supportate solo con l'API locale. Se la tua bacheca è configurata per usare l'API cloud, le impostazioni di transizione non avranno effetto. Le singole pagine possono anche sovrascrivere questo valore predefinito nel generatore di pagine.",
+    "pluginNote": "Le transizioni dei plugin sono animate da FiestaBoard e inviate come normali aggiornamenti della bacheca, quindi funzionano con qualsiasi connessione.",
+    "builtInGroup": "Integrate",
+    "pluginsGroup": "Plugin di transizione",
+    "pluginsBetaBadge": "Beta",
+    "unavailablePluginNote": "Questo plugin di transizione non è attualmente disponibile. Scegli un'altra opzione per cambiarla.",
     "toastSaved": "Impostazioni di transizione salvate",
     "toastSaveFailed": "Impossibile salvare le impostazioni di transizione: {error}",
     "strategies": {
@@ -1518,7 +1532,7 @@
     "setupDescription": "Scegli un plugin di transizione, poi le pagine di partenza e di arrivo.",
     "pluginLabel": "Plugin di transizione",
     "pluginPlaceholder": "Seleziona un plugin...",
-    "noPlugins": "Nessun plugin di transizione attivo. Attivane uno nella pagina Integrazioni.",
+    "noPlugins": "Nessun plugin di transizione installato. Aggiungine uno dalla pagina Integrazioni.",
     "deviceLabel": "Dispositivo",
     "deviceFlagship": "Flagship (6×22)",
     "deviceNote": "Note (3×15)",
@@ -1604,6 +1618,7 @@
       "finance": "Finanza",
       "home": "Smart Home",
       "transit": "Trasporti",
+      "transition": "Transizioni",
       "utility": "Utilità",
       "weather": "Meteo e ambiente"
     },

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -418,9 +418,11 @@
       "finance": "ファイナンス",
       "home": "スマートホーム",
       "transit": "交通",
+      "transition": "トランジション",
       "utility": "ユーティリティ",
       "weather": "天気・環境"
     },
+    "transitionBadge": "トランジション",
     "tabInstalled": "インストール済み",
     "tabMarketplace": "マーケットプレイス",
     "searchInstalledPlaceholder": "インストール済みプラグインを検索...",
@@ -737,7 +739,14 @@
     "retargetSurfaceSchedule": "スケジュール項目",
     "retargetSurfaceActivePage": "アクティブページ",
     "notesWideOption": "横 {count} 枚",
-    "notesTallOption": "縦 {count} 枚"
+    "notesTallOption": "縦 {count} 枚",
+    "transitionMenuTitle": "トランジション",
+    "transitionPickerAriaLabel": "ページのトランジション",
+    "transitionPickerTooltip": "このページのトランジション: {strategy}",
+    "transitionUseGlobalDefault": "全体のデフォルトを使用",
+    "transitionBuiltInGroup": "組み込み",
+    "transitionPluginsGroup": "プラグイン (ベータ)",
+    "transitionOpenLab": "トランジションラボを開く"
   },
   "displaySettings": {
     "title": "ボード一覧",
@@ -887,6 +896,11 @@
     "stepSizePlaceholder": "デフォルト",
     "stepSizeDescription": "一度にアニメーションする行または列の数。ボードのデフォルトを使用する場合は空のままにしてください。",
     "localApiNote": "トランジションはローカル API のみでサポートされています。ボードがクラウド API を使用するよう設定されている場合、トランジション設定は反映されません。個別のページでこのデフォルトをページビルダーで上書きすることもできます。",
+    "pluginNote": "プラグイントランジションは FiestaBoard がアニメーションを生成し、通常のボード更新として送信されるため、どのボード接続でも動作します。",
+    "builtInGroup": "組み込み",
+    "pluginsGroup": "トランジションプラグイン",
+    "pluginsBetaBadge": "ベータ",
+    "unavailablePluginNote": "このトランジションプラグインは現在利用できません。変更するには別のオプションを選択してください。",
     "toastSaved": "トランジション設定を保存しました",
     "toastSaveFailed": "トランジション設定の保存に失敗しました: {error}",
     "strategies": {
@@ -1518,7 +1532,7 @@
     "setupDescription": "トランジションプラグインを選び、開始ページと終了ページを選択します。",
     "pluginLabel": "トランジションプラグイン",
     "pluginPlaceholder": "プラグインを選択...",
-    "noPlugins": "有効なトランジションプラグインがありません。連携ページで有効にしてください。",
+    "noPlugins": "トランジションプラグインがインストールされていません。連携ページから追加してください。",
     "deviceLabel": "デバイス",
     "deviceFlagship": "Flagship（6×22）",
     "deviceNote": "Note（3×15）",
@@ -1604,6 +1618,7 @@
       "finance": "ファイナンス",
       "home": "スマートホーム",
       "transit": "交通",
+      "transition": "トランジション",
       "utility": "ユーティリティ",
       "weather": "天気と環境"
     },

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -418,9 +418,11 @@
       "finance": "금융",
       "home": "스마트 홈",
       "transit": "교통",
+      "transition": "전환 효과",
       "utility": "유틸리티",
       "weather": "날씨 및 환경"
     },
+    "transitionBadge": "전환 효과",
     "tabInstalled": "설치됨",
     "tabMarketplace": "마켓플레이스",
     "searchInstalledPlaceholder": "설치된 플러그인 검색...",
@@ -737,7 +739,14 @@
     "retargetSurfaceSchedule": "일정 항목",
     "retargetSurfaceActivePage": "활성 페이지",
     "notesWideOption": "가로 {count}개",
-    "notesTallOption": "세로 {count}개"
+    "notesTallOption": "세로 {count}개",
+    "transitionMenuTitle": "전환 효과",
+    "transitionPickerAriaLabel": "페이지 전환 효과",
+    "transitionPickerTooltip": "이 페이지의 전환 효과: {strategy}",
+    "transitionUseGlobalDefault": "전역 기본값 사용",
+    "transitionBuiltInGroup": "기본 제공",
+    "transitionPluginsGroup": "플러그인 (베타)",
+    "transitionOpenLab": "전환 실험실 열기"
   },
   "displaySettings": {
     "title": "내 보드",
@@ -887,6 +896,11 @@
     "stepSizePlaceholder": "기본값",
     "stepSizeDescription": "한 번에 애니메이션되는 행 또는 열의 수입니다. 보드 기본값을 사용하려면 비워 두세요.",
     "localApiNote": "전환 효과는 로컬 API에서만 지원됩니다. 보드가 클라우드 API를 사용하도록 설정된 경우 전환 설정은 효과가 없습니다. 개별 페이지에서 페이지 빌더를 통해 이 기본값을 재정의할 수도 있습니다.",
+    "pluginNote": "플러그인 전환 효과는 FiestaBoard가 애니메이션을 만들어 일반 보드 업데이트로 전송하므로 어떤 보드 연결에서도 작동합니다.",
+    "builtInGroup": "기본 제공",
+    "pluginsGroup": "전환 플러그인",
+    "pluginsBetaBadge": "베타",
+    "unavailablePluginNote": "이 전환 플러그인은 현재 사용할 수 없습니다. 변경하려면 다른 옵션을 선택하세요.",
     "toastSaved": "전환 설정이 저장되었습니다",
     "toastSaveFailed": "전환 설정 저장에 실패했습니다: {error}",
     "strategies": {
@@ -1518,7 +1532,7 @@
     "setupDescription": "전환 플러그인을 선택한 다음 시작 페이지와 대상 페이지를 선택하세요.",
     "pluginLabel": "전환 플러그인",
     "pluginPlaceholder": "플러그인 선택...",
-    "noPlugins": "활성화된 전환 플러그인이 없습니다. 통합 페이지에서 활성화하세요.",
+    "noPlugins": "설치된 전환 플러그인이 없습니다. 연동 페이지에서 추가하세요.",
     "deviceLabel": "기기",
     "deviceFlagship": "Flagship (6×22)",
     "deviceNote": "Note (3×15)",
@@ -1604,6 +1618,7 @@
       "finance": "금융",
       "home": "스마트 홈",
       "transit": "교통",
+      "transition": "전환 효과",
       "utility": "유틸리티",
       "weather": "날씨 및 환경"
     },

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -418,9 +418,11 @@
       "finance": "Financiën",
       "home": "Slim huis",
       "transit": "Vervoer",
+      "transition": "Transities",
       "utility": "Hulpprogramma's",
       "weather": "Weer & omgeving"
     },
+    "transitionBadge": "Transitie",
     "tabInstalled": "Geïnstalleerd",
     "tabMarketplace": "Marketplace",
     "searchInstalledPlaceholder": "Geïnstalleerde plugins zoeken...",
@@ -737,7 +739,14 @@
     "retargetSurfaceSchedule": "schema-item",
     "retargetSurfaceActivePage": "actieve pagina",
     "notesWideOption": "{count} breed",
-    "notesTallOption": "{count} hoog"
+    "notesTallOption": "{count} hoog",
+    "transitionMenuTitle": "Overgang",
+    "transitionPickerAriaLabel": "Paginaovergang",
+    "transitionPickerTooltip": "Overgang voor deze pagina: {strategy}",
+    "transitionUseGlobalDefault": "Globale standaard gebruiken",
+    "transitionBuiltInGroup": "Ingebouwd",
+    "transitionPluginsGroup": "Plugins (bèta)",
+    "transitionOpenLab": "Transitielab openen"
   },
   "displaySettings": {
     "title": "Je borden",
@@ -887,6 +896,11 @@
     "stepSizePlaceholder": "Standaard",
     "stepSizeDescription": "Hoeveel rijen of kolommen tegelijk animeren. Laat leeg voor de standaardwaarde van het bord.",
     "localApiNote": "Overgangen worden alleen ondersteund via de lokale API. Als je bord is geconfigureerd voor de Cloud API, hebben overgangsinstellingen geen effect. Individuele pagina's kunnen deze standaard ook overschrijven in de paginabouwer.",
+    "pluginNote": "Pluginovergangen worden door FiestaBoard geanimeerd en als gewone bordupdates verstuurd, dus ze werken met elke bordverbinding.",
+    "builtInGroup": "Ingebouwd",
+    "pluginsGroup": "Transitieplugins",
+    "pluginsBetaBadge": "Bèta",
+    "unavailablePluginNote": "Deze transitieplugin is momenteel niet beschikbaar. Kies een andere optie om dit te wijzigen.",
     "toastSaved": "Overgangsinstellingen opgeslagen",
     "toastSaveFailed": "Overgangsinstellingen opslaan mislukt: {error}",
     "strategies": {
@@ -1518,7 +1532,7 @@
     "setupDescription": "Kies een overgangsplugin en daarna de van- en naar-pagina's.",
     "pluginLabel": "Transitieplugin",
     "pluginPlaceholder": "Selecteer een plugin...",
-    "noPlugins": "Geen transitieplugins ingeschakeld. Schakel er een in op de Integraties-pagina.",
+    "noPlugins": "Geen transitieplugins geïnstalleerd. Voeg er een toe via de Integraties-pagina.",
     "deviceLabel": "Apparaat",
     "deviceFlagship": "Flagship (6×22)",
     "deviceNote": "Note (3×15)",
@@ -1604,6 +1618,7 @@
       "finance": "Financiën",
       "home": "Smart home",
       "transit": "Vervoer",
+      "transition": "Transities",
       "utility": "Hulpprogramma's",
       "weather": "Weer & omgeving"
     },

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -418,9 +418,11 @@
       "finance": "Finanse",
       "home": "Inteligentny dom",
       "transit": "Transport",
+      "transition": "Przejścia",
       "utility": "Narzędzia",
       "weather": "Pogoda i środowisko"
     },
+    "transitionBadge": "Przejście",
     "tabInstalled": "Zainstalowane",
     "tabMarketplace": "Marketplace",
     "searchInstalledPlaceholder": "Szukaj zainstalowanych wtyczek...",
@@ -737,7 +739,14 @@
     "retargetSurfaceSchedule": "wpis harmonogramu",
     "retargetSurfaceActivePage": "aktywna strona",
     "notesWideOption": "{count} wszerz",
-    "notesTallOption": "{count} wzwyż"
+    "notesTallOption": "{count} wzwyż",
+    "transitionMenuTitle": "Przejście",
+    "transitionPickerAriaLabel": "Przejście strony",
+    "transitionPickerTooltip": "Przejście dla tej strony: {strategy}",
+    "transitionUseGlobalDefault": "Użyj domyślnego ustawienia globalnego",
+    "transitionBuiltInGroup": "Wbudowane",
+    "transitionPluginsGroup": "Wtyczki (beta)",
+    "transitionOpenLab": "Otwórz laboratorium przejść"
   },
   "displaySettings": {
     "title": "Twoje tablice",
@@ -887,6 +896,11 @@
     "stepSizePlaceholder": "Domyślny",
     "stepSizeDescription": "Ile wierszy lub kolumn animuje się jednocześnie. Pozostaw puste, aby użyć domyślnej wartości tablicy.",
     "localApiNote": "Przejścia są obsługiwane tylko przez Local API. Jeśli Twoja tablica jest skonfigurowana z Cloud API, ustawienia przejść nie będą miały efektu. Poszczególne strony mogą również nadpisać to domyślne ustawienie w edytorze stron.",
+    "pluginNote": "Przejścia wtyczek są animowane przez FiestaBoard i wysyłane jako zwykłe aktualizacje tablicy, więc działają przy każdym rodzaju połączenia.",
+    "builtInGroup": "Wbudowane",
+    "pluginsGroup": "Wtyczki przejść",
+    "pluginsBetaBadge": "Beta",
+    "unavailablePluginNote": "Ta wtyczka przejścia jest obecnie niedostępna. Wybierz inną opcję, aby ją zmienić.",
     "toastSaved": "Ustawienia przejść zapisane",
     "toastSaveFailed": "Nie udało się zapisać ustawień przejść: {error}",
     "strategies": {
@@ -1518,7 +1532,7 @@
     "setupDescription": "Wybierz wtyczkę przejścia, a następnie strony początkową i docelową.",
     "pluginLabel": "Wtyczka przejścia",
     "pluginPlaceholder": "Wybierz wtyczkę...",
-    "noPlugins": "Brak włączonych wtyczek przejść. Włącz jedną na stronie Integracje.",
+    "noPlugins": "Brak zainstalowanych wtyczek przejść. Dodaj jedną na stronie Integracje.",
     "deviceLabel": "Urządzenie",
     "deviceFlagship": "Flagship (6×22)",
     "deviceNote": "Note (3×15)",
@@ -1604,6 +1618,7 @@
       "finance": "Finanse",
       "home": "Smart Home",
       "transit": "Transport",
+      "transition": "Przejścia",
       "utility": "Narzędzia",
       "weather": "Pogoda i środowisko"
     },

--- a/web/messages/pt.json
+++ b/web/messages/pt.json
@@ -418,9 +418,11 @@
       "finance": "Finanças",
       "home": "Casa Inteligente",
       "transit": "Transporte",
+      "transition": "Transições",
       "utility": "Utilitários",
       "weather": "Clima e Meio Ambiente"
     },
+    "transitionBadge": "Transição",
     "tabInstalled": "Instalados",
     "tabMarketplace": "Marketplace",
     "searchInstalledPlaceholder": "Pesquisar plugins instalados...",
@@ -737,7 +739,14 @@
     "retargetSurfaceSchedule": "entrada de agenda",
     "retargetSurfaceActivePage": "página ativa",
     "notesWideOption": "{count} de largura",
-    "notesTallOption": "{count} de altura"
+    "notesTallOption": "{count} de altura",
+    "transitionMenuTitle": "Transição",
+    "transitionPickerAriaLabel": "Transição da página",
+    "transitionPickerTooltip": "Transição desta página: {strategy}",
+    "transitionUseGlobalDefault": "Usar o padrão global",
+    "transitionBuiltInGroup": "Integradas",
+    "transitionPluginsGroup": "Plugins (beta)",
+    "transitionOpenLab": "Abrir o laboratório de transições"
   },
   "displaySettings": {
     "title": "Seus Painéis",
@@ -887,6 +896,11 @@
     "stepSizePlaceholder": "Padrão",
     "stepSizeDescription": "Quantas linhas ou colunas são animadas de cada vez. Deixe vazio para usar o padrão do painel.",
     "localApiNote": "As transições são suportadas apenas na API Local. Se o seu painel estiver configurado para usar a API na Nuvem, as configurações de transição não terão efeito. Páginas individuais também podem substituir este padrão no editor de páginas.",
+    "pluginNote": "As transições de plugin são animadas pelo FiestaBoard e enviadas como atualizações normais do painel, por isso funcionam em qualquer conexão do painel.",
+    "builtInGroup": "Integradas",
+    "pluginsGroup": "Plugins de transição",
+    "pluginsBetaBadge": "Beta",
+    "unavailablePluginNote": "Este plugin de transição não está disponível no momento. Escolha outra opção para alterá-la.",
     "toastSaved": "Configurações de transição salvas",
     "toastSaveFailed": "Falha ao salvar configurações de transição: {error}",
     "strategies": {
@@ -1518,7 +1532,7 @@
     "setupDescription": "Escolha um plugin de transição e depois as páginas de origem e destino.",
     "pluginLabel": "Plugin de transição",
     "pluginPlaceholder": "Selecione um plugin...",
-    "noPlugins": "Nenhum plugin de transição ativado. Ative um na página de Integrações.",
+    "noPlugins": "Nenhum plugin de transição instalado. Adicione um a partir da página de Integrações.",
     "deviceLabel": "Dispositivo",
     "deviceFlagship": "Flagship (6×22)",
     "deviceNote": "Note (3×15)",
@@ -1604,6 +1618,7 @@
       "finance": "Finanças",
       "home": "Smart Home",
       "transit": "Transportes",
+      "transition": "Transições",
       "utility": "Utilidades",
       "weather": "Tempo e ambiente"
     },

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -418,9 +418,11 @@
       "finance": "Финансы",
       "home": "Умный дом",
       "transit": "Транспорт",
+      "transition": "Переходы",
       "utility": "Утилиты",
       "weather": "Погода и окружающая среда"
     },
+    "transitionBadge": "Переход",
     "tabInstalled": "Установленные",
     "tabMarketplace": "Marketplace",
     "searchInstalledPlaceholder": "Искать установленные плагины...",
@@ -737,7 +739,14 @@
     "retargetSurfaceSchedule": "запись расписания",
     "retargetSurfaceActivePage": "активная страница",
     "notesWideOption": "{count} в ширину",
-    "notesTallOption": "{count} в высоту"
+    "notesTallOption": "{count} в высоту",
+    "transitionMenuTitle": "Переход",
+    "transitionPickerAriaLabel": "Переход страницы",
+    "transitionPickerTooltip": "Переход для этой страницы: {strategy}",
+    "transitionUseGlobalDefault": "Использовать глобальное значение по умолчанию",
+    "transitionBuiltInGroup": "Встроенные",
+    "transitionPluginsGroup": "Плагины (бета)",
+    "transitionOpenLab": "Открыть лабораторию переходов"
   },
   "displaySettings": {
     "title": "Ваши доски",
@@ -887,6 +896,11 @@
     "stepSizePlaceholder": "По умолчанию",
     "stepSizeDescription": "Сколько строк или столбцов анимируются одновременно. Оставьте пустым для значения по умолчанию.",
     "localApiNote": "Переходы поддерживаются только через локальный API. Если ваша доска настроена на облачный API, настройки переходов не будут применяться. Отдельные страницы также могут переопределить эти настройки в редакторе страниц.",
+    "pluginNote": "Переходы из плагинов анимируются самим FiestaBoard и отправляются как обычные обновления доски, поэтому работают при любом типе подключения.",
+    "builtInGroup": "Встроенные",
+    "pluginsGroup": "Плагины переходов",
+    "pluginsBetaBadge": "Бета",
+    "unavailablePluginNote": "Этот плагин перехода сейчас недоступен. Выберите другой вариант, чтобы изменить переход.",
     "toastSaved": "Настройки переходов сохранены",
     "toastSaveFailed": "Не удалось сохранить настройки переходов: {error}",
     "strategies": {
@@ -1518,7 +1532,7 @@
     "setupDescription": "Выберите плагин перехода, затем начальную и конечную страницы.",
     "pluginLabel": "Плагин перехода",
     "pluginPlaceholder": "Выберите плагин...",
-    "noPlugins": "Нет включённых плагинов переходов. Включите один на странице «Интеграции».",
+    "noPlugins": "Плагины переходов не установлены. Добавьте плагин на странице «Интеграции».",
     "deviceLabel": "Устройство",
     "deviceFlagship": "Flagship (6×22)",
     "deviceNote": "Note (3×15)",
@@ -1604,6 +1618,7 @@
       "finance": "Финансы",
       "home": "Умный дом",
       "transit": "Транспорт",
+      "transition": "Переходы",
       "utility": "Утилиты",
       "weather": "Погода и окружающая среда"
     },

--- a/web/messages/sv.json
+++ b/web/messages/sv.json
@@ -418,9 +418,11 @@
       "finance": "Finans",
       "home": "Smart hem",
       "transit": "Transport",
+      "transition": "Övergångar",
       "utility": "Verktyg",
       "weather": "Väder och miljö"
     },
+    "transitionBadge": "Övergång",
     "tabInstalled": "Installerade",
     "tabMarketplace": "Marketplace",
     "searchInstalledPlaceholder": "Sök installerade plugins...",
@@ -737,7 +739,14 @@
     "retargetSurfaceSchedule": "schemapost",
     "retargetSurfaceActivePage": "aktiv sida",
     "notesWideOption": "{count} bred",
-    "notesTallOption": "{count} hög"
+    "notesTallOption": "{count} hög",
+    "transitionMenuTitle": "Övergång",
+    "transitionPickerAriaLabel": "Sidövergång",
+    "transitionPickerTooltip": "Övergång för den här sidan: {strategy}",
+    "transitionUseGlobalDefault": "Använd global standard",
+    "transitionBuiltInGroup": "Inbyggda",
+    "transitionPluginsGroup": "Plugins (beta)",
+    "transitionOpenLab": "Öppna övergångslabbet"
   },
   "displaySettings": {
     "title": "Dina tavlor",
@@ -887,6 +896,11 @@
     "stepSizePlaceholder": "Standard",
     "stepSizeDescription": "Hur många rader eller kolumner som animeras samtidigt. Lämna tomt för tavlans standard.",
     "localApiNote": "Övergångar stöds bara via lokalt API. Om din tavla är konfigurerad att använda moln-API kommer övergångsinställningar inte att ha någon effekt. Enskilda sidor kan också åsidosätta denna standard i sidredigeraren.",
+    "pluginNote": "Pluginövergångar animeras av FiestaBoard och skickas som vanliga uppdateringar av tavlan, så de fungerar med alla typer av anslutningar.",
+    "builtInGroup": "Inbyggda",
+    "pluginsGroup": "Övergångsplugins",
+    "pluginsBetaBadge": "Beta",
+    "unavailablePluginNote": "Det här övergångspluginet är inte tillgängligt just nu. Välj ett annat alternativ för att ändra övergången.",
     "toastSaved": "Övergångsinställningar sparade",
     "toastSaveFailed": "Kunde inte spara övergångsinställningar: {error}",
     "strategies": {
@@ -1518,7 +1532,7 @@
     "setupDescription": "Välj ett övergångsplugin och sedan från- och till-sidorna.",
     "pluginLabel": "Övergångsplugin",
     "pluginPlaceholder": "Välj en plugin...",
-    "noPlugins": "Inga övergångsplugins aktiverade. Aktivera en på sidan Integrationer.",
+    "noPlugins": "Inga övergångsplugins installerade. Lägg till ett från sidan Integrationer.",
     "deviceLabel": "Enhet",
     "deviceFlagship": "Flagship (6×22)",
     "deviceNote": "Note (3×15)",
@@ -1604,6 +1618,7 @@
       "finance": "Finans",
       "home": "Smart Home",
       "transit": "Transport",
+      "transition": "Övergångar",
       "utility": "Verktyg",
       "weather": "Väder & miljö"
     },

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -418,9 +418,11 @@
       "finance": "Finans",
       "home": "Akıllı Ev",
       "transit": "Ulaşım",
+      "transition": "Geçişler",
       "utility": "Araçlar",
       "weather": "Hava Durumu ve Çevre"
     },
+    "transitionBadge": "Geçiş",
     "tabInstalled": "Kurulu",
     "tabMarketplace": "Marketplace",
     "searchInstalledPlaceholder": "Kurulu eklentileri ara...",
@@ -737,7 +739,14 @@
     "retargetSurfaceSchedule": "zamanlama girdisi",
     "retargetSurfaceActivePage": "etkin sayfa",
     "notesWideOption": "{count} genişlik",
-    "notesTallOption": "{count} yükseklik"
+    "notesTallOption": "{count} yükseklik",
+    "transitionMenuTitle": "Geçiş",
+    "transitionPickerAriaLabel": "Sayfa geçişi",
+    "transitionPickerTooltip": "Bu sayfanın geçişi: {strategy}",
+    "transitionUseGlobalDefault": "Genel varsayılanı kullan",
+    "transitionBuiltInGroup": "Yerleşik",
+    "transitionPluginsGroup": "Eklentiler (beta)",
+    "transitionOpenLab": "Geçiş Laboratuvarını aç"
   },
   "displaySettings": {
     "title": "Panolarınız",
@@ -887,6 +896,11 @@
     "stepSizePlaceholder": "Varsayılan",
     "stepSizeDescription": "Aynı anda kaç satır veya sütunun animasyon yapacağı. Pano varsayılanı için boş bırakın.",
     "localApiNote": "Geçişler yalnızca Yerel API üzerinde desteklenir. Panonuz Bulut API kullanacak şekilde yapılandırılmışsa geçiş ayarlarının bir etkisi olmaz. Sayfa oluşturucuda her sayfa bu varsayılanı ayrıca geçersiz kılabilir.",
+    "pluginNote": "Eklenti geçişleri FiestaBoard tarafından canlandırılır ve normal pano güncellemeleri olarak gönderilir, bu yüzden her pano bağlantısında çalışır.",
+    "builtInGroup": "Yerleşik",
+    "pluginsGroup": "Geçiş Eklentileri",
+    "pluginsBetaBadge": "Beta",
+    "unavailablePluginNote": "Bu geçiş eklentisi şu anda kullanılamıyor. Değiştirmek için başka bir seçenek seçin.",
     "toastSaved": "Geçiş ayarları kaydedildi",
     "toastSaveFailed": "Geçiş ayarları kaydedilemedi: {error}",
     "strategies": {
@@ -1518,7 +1532,7 @@
     "setupDescription": "Bir geçiş eklentisi seçin, ardından başlangıç ve hedef sayfaları seçin.",
     "pluginLabel": "Geçiş eklentisi",
     "pluginPlaceholder": "Bir eklenti seçin...",
-    "noPlugins": "Etkin geçiş eklentisi yok. Entegrasyonlar sayfasından birini etkinleştirin.",
+    "noPlugins": "Kurulu geçiş eklentisi yok. Entegrasyonlar sayfasından bir tane ekleyin.",
     "deviceLabel": "Cihaz",
     "deviceFlagship": "Flagship (6×22)",
     "deviceNote": "Note (3×15)",
@@ -1604,6 +1618,7 @@
       "finance": "Finans",
       "home": "Akıllı Ev",
       "transit": "Ulaşım",
+      "transition": "Geçişler",
       "utility": "Yardımcı Programlar",
       "weather": "Hava ve Çevre"
     },

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -418,9 +418,11 @@
       "finance": "金融",
       "home": "智能家居",
       "transit": "交通出行",
+      "transition": "过渡效果",
       "utility": "实用工具",
       "weather": "天气与环境"
     },
+    "transitionBadge": "过渡效果",
     "tabInstalled": "已安装",
     "tabMarketplace": "Marketplace",
     "searchInstalledPlaceholder": "搜索已安装的插件...",
@@ -737,7 +739,14 @@
     "retargetSurfaceSchedule": "排程条目",
     "retargetSurfaceActivePage": "活动页面",
     "notesWideOption": "横向 {count} 块",
-    "notesTallOption": "纵向 {count} 块"
+    "notesTallOption": "纵向 {count} 块",
+    "transitionMenuTitle": "过渡效果",
+    "transitionPickerAriaLabel": "页面过渡效果",
+    "transitionPickerTooltip": "此页面的过渡效果：{strategy}",
+    "transitionUseGlobalDefault": "使用全局默认设置",
+    "transitionBuiltInGroup": "内置",
+    "transitionPluginsGroup": "插件（测试版）",
+    "transitionOpenLab": "打开过渡实验室"
   },
   "displaySettings": {
     "title": "您的看板",
@@ -887,6 +896,11 @@
     "stepSizePlaceholder": "默认",
     "stepSizeDescription": "每次同时执行动画的行或列数。留空使用看板默认值。",
     "localApiNote": "过渡效果仅在本地 API 上支持。如果您的看板配置为使用云端 API，过渡效果设置将不会生效。单个页面也可以在页面编辑器中覆盖此默认设置。",
+    "pluginNote": "插件过渡效果由 FiestaBoard 生成动画，并作为普通的看板更新发送，因此适用于任何看板连接方式。",
+    "builtInGroup": "内置",
+    "pluginsGroup": "过渡插件",
+    "pluginsBetaBadge": "测试版",
+    "unavailablePluginNote": "此过渡插件当前不可用。请选择其他选项进行更改。",
     "toastSaved": "过渡效果设置已保存",
     "toastSaveFailed": "保存过渡效果设置失败：{error}",
     "strategies": {
@@ -1518,7 +1532,7 @@
     "setupDescription": "选择一个过渡插件，然后选择起始页面和目标页面。",
     "pluginLabel": "过渡插件",
     "pluginPlaceholder": "选择插件...",
-    "noPlugins": "没有已启用的过渡插件。请在集成页面启用一个。",
+    "noPlugins": "尚未安装过渡插件。请从集成页面添加。",
     "deviceLabel": "设备",
     "deviceFlagship": "Flagship（6×22）",
     "deviceNote": "Note（3×15）",
@@ -1604,6 +1618,7 @@
       "finance": "金融",
       "home": "智能家居",
       "transit": "交通",
+      "transition": "过渡效果",
       "utility": "实用工具",
       "weather": "天气与环境"
     },

--- a/web/src/__tests__/integrations-transition-plugins.test.tsx
+++ b/web/src/__tests__/integrations-transition-plugins.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * Transition plugins on the Integrations page.
+ *
+ * `PluginRegistry.get_transition_plugin()` never consults the enabled flag —
+ * a transition runs as soon as it is installed and selected. Rendering the
+ * usual enable/disable Switch for one therefore promises control the backend
+ * does not honour. These tests pin the corrected presentation: transition
+ * plugins get a "Transition" badge instead of a toggle and instead of an
+ * enabled/disabled status, while ordinary data plugins keep both.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+
+import IntegrationsPage from "../../app/routes/integrations._index";
+import { server } from "./mocks/server";
+
+const API_BASE = "/api";
+
+interface MockPlugin {
+  id: string;
+  name: string;
+  category: string;
+  plugin_type?: "data" | "transition";
+  enabled?: boolean;
+  configured?: boolean;
+}
+
+function mockPlugins(plugins: MockPlugin[]) {
+  const full = plugins.map((p) => ({
+    version: "1.0.0",
+    description: `${p.name} description`,
+    author: "FiestaBoard",
+    enabled: true,
+    configured: true,
+    icon: "puzzle",
+    config: {},
+    source: { source_type: "builtin" as const },
+    update_available: false,
+    instance_label: null,
+    base_plugin_id: p.id,
+    settings_schema: {},
+    ...p,
+  }));
+  server.use(
+    http.get(`${API_BASE}/plugins`, () =>
+      HttpResponse.json({
+        plugins: full,
+        plugin_system_enabled: true,
+        total: full.length,
+        enabled_count: full.filter((p) => p.enabled).length,
+      }),
+    ),
+    http.get(`${API_BASE}/plugins/registry`, () => HttpResponse.json({ entries: [] })),
+  );
+}
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <IntegrationsPage />
+    </QueryClientProvider>,
+  );
+}
+
+/** The installed-table row whose Name cell holds `name`. */
+async function rowFor(name: string): Promise<HTMLElement> {
+  const cell = await screen.findByText(name);
+  const row = cell.closest("tr");
+  if (!row) throw new Error(`No table row found for plugin "${name}"`);
+  return row as HTMLElement;
+}
+
+describe("Integrations page — transition plugins", () => {
+  it("renders no enable toggle for a transition plugin", async () => {
+    mockPlugins([{ id: "typewriter", name: "Typewriter", category: "transition", plugin_type: "transition" }]);
+    renderPage();
+
+    const row = await rowFor("Typewriter");
+    expect(within(row).queryByRole("switch")).not.toBeInTheDocument();
+  });
+
+  it("badges a transition plugin as a Transition", async () => {
+    mockPlugins([{ id: "typewriter", name: "Typewriter", category: "transition", plugin_type: "transition" }]);
+    renderPage();
+
+    const row = await rowFor("Typewriter");
+    expect(within(row).getByText("Transition")).toBeInTheDocument();
+  });
+
+  it("shows no enabled/disabled status for a transition plugin", async () => {
+    mockPlugins([
+      {
+        id: "typewriter",
+        name: "Typewriter",
+        category: "transition",
+        plugin_type: "transition",
+        enabled: false,
+        configured: false,
+      },
+    ]);
+    renderPage();
+
+    const row = await rowFor("Typewriter");
+    expect(within(row).queryByText("Disabled")).not.toBeInTheDocument();
+    expect(within(row).queryByText("Configured")).not.toBeInTheDocument();
+    expect(within(row).queryByText("Setup Required")).not.toBeInTheDocument();
+  });
+
+  it("labels the transition category with its translated name", async () => {
+    mockPlugins([{ id: "typewriter", name: "Typewriter", category: "transition", plugin_type: "transition" }]);
+    renderPage();
+
+    const row = await rowFor("Typewriter");
+    expect(within(row).getByText("Transitions")).toBeInTheDocument();
+  });
+
+  it("still renders the enable toggle for a data plugin", async () => {
+    mockPlugins([{ id: "weather", name: "Weather", category: "weather", plugin_type: "data" }]);
+    renderPage();
+
+    const row = await rowFor("Weather");
+    expect(within(row).getByRole("switch")).toBeInTheDocument();
+    expect(within(row).queryByText("Transition")).not.toBeInTheDocument();
+  });
+
+  it("treats a plugin with no plugin_type as a data plugin", async () => {
+    mockPlugins([{ id: "weather", name: "Weather", category: "weather" }]);
+    renderPage();
+
+    const row = await rowFor("Weather");
+    expect(within(row).getByRole("switch")).toBeInTheDocument();
+  });
+
+  it("keeps the Configure action available on a transition plugin", async () => {
+    mockPlugins([{ id: "typewriter", name: "Typewriter", category: "transition", plugin_type: "transition" }]);
+    renderPage();
+
+    const row = await rowFor("Typewriter");
+    await waitFor(() => {
+      expect(within(row).getByRole("button", { name: /more options/i })).toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/__tests__/page-builder-transition-picker.test.tsx
+++ b/web/src/__tests__/page-builder-transition-picker.test.tsx
@@ -1,0 +1,205 @@
+/**
+ * Per-page transition override picker in the PageBuilder header.
+ *
+ * The backend has accepted `Page.transition_strategy` (a built-in strategy
+ * name, `plugin:<id>`, or null = inherit the global default) for a while; these
+ * tests cover the UI that finally reads and writes it. The load-bearing detail
+ * is the clear path: clearing back to "Use global default" must send an
+ * explicit `null`, because an omitted key leaves the previous override in place
+ * on the server.
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { PageBuilder } from "@/components/page-builder";
+import { ConfigOverridesProvider } from "@/hooks/use-config-overrides";
+import { ThemeProvider } from "@/hooks/use-theme";
+
+import { server } from "./mocks/server";
+
+const API_BASE = "/api";
+
+vi.mock("@/hooks/use-router", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+    back: vi.fn(),
+  }),
+}));
+
+function TestWrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ConfigOverridesProvider>
+        <ThemeProvider attribute="class" defaultTheme="light">
+          {children}
+        </ThemeProvider>
+      </ConfigOverridesProvider>
+    </QueryClientProvider>
+  );
+}
+
+/** Serve GET /pages/page-1 with the given saved override. */
+function servePageWithTransition(transitionStrategy: string | null) {
+  server.use(
+    http.get(`${API_BASE}/pages/page-1`, () =>
+      HttpResponse.json({
+        id: "page-1",
+        name: "Weather Page",
+        type: "template",
+        device_type: "flagship",
+        template: ["HELLO", "", "", "", "", ""],
+        duration_seconds: 300,
+        transition_strategy: transitionStrategy,
+        created_at: "2024-01-01T00:00:00Z",
+      }),
+    ),
+  );
+}
+
+/** Capture the body of the next PUT /pages/:id. */
+function captureUpdate(): { body: Record<string, unknown> | null } {
+  const captured: { body: Record<string, unknown> | null } = { body: null };
+  server.use(
+    http.put(`${API_BASE}/pages/page-1`, async ({ request }) => {
+      captured.body = (await request.json()) as Record<string, unknown>;
+      return HttpResponse.json({
+        status: "success",
+        page: { id: "page-1", name: "Weather Page", type: "template", device_type: "flagship" },
+      });
+    }),
+  );
+  return captured;
+}
+
+async function openTransitionMenu(user: ReturnType<typeof userEvent.setup>) {
+  const trigger = await screen.findByRole("button", { name: "Page transition" });
+  await user.click(trigger);
+  return trigger;
+}
+
+describe("PageBuilder — per-page transition picker", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sends the chosen built-in strategy as transition_strategy on save", async () => {
+    servePageWithTransition(null);
+    const captured = captureUpdate();
+    const user = userEvent.setup();
+
+    render(<PageBuilder pageId="page-1" onClose={vi.fn()} />, { wrapper: TestWrapper });
+
+    await openTransitionMenu(user);
+    await user.click(await screen.findByRole("menuitemradio", { name: "Diagonal" }));
+
+    await user.click(await screen.findByRole("button", { name: "Save Page" }));
+
+    await waitFor(() => expect(captured.body).not.toBeNull());
+    expect(captured.body?.transition_strategy).toBe("diagonal");
+  });
+
+  it("sends an explicit null when clearing an existing override back to the global default", async () => {
+    servePageWithTransition("column");
+    const captured = captureUpdate();
+    const user = userEvent.setup();
+
+    render(<PageBuilder pageId="page-1" onClose={vi.fn()} />, { wrapper: TestWrapper });
+
+    await openTransitionMenu(user);
+    await user.click(await screen.findByRole("menuitemradio", { name: "Use global default" }));
+
+    await user.click(await screen.findByRole("button", { name: "Save Page" }));
+
+    await waitFor(() => expect(captured.body).not.toBeNull());
+    // The key must be PRESENT and null — omitting it leaves the old override
+    // in place, since the API only clears fields it is explicitly sent.
+    expect(captured.body).toHaveProperty("transition_strategy");
+    expect(captured.body?.transition_strategy).toBeNull();
+  });
+
+  it("shows the saved override as the selected menu item when the editor loads", async () => {
+    servePageWithTransition("edges-to-center");
+    const user = userEvent.setup();
+
+    render(<PageBuilder pageId="page-1" onClose={vi.fn()} />, { wrapper: TestWrapper });
+
+    await openTransitionMenu(user);
+
+    expect(await screen.findByRole("menuitemradio", { name: "Curtain", checked: true })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("menuitemradio", { name: "Use global default", checked: false }),
+    ).toBeInTheDocument();
+  });
+
+  it("marks the editor dirty when the transition changes", async () => {
+    servePageWithTransition(null);
+    const user = userEvent.setup();
+
+    render(<PageBuilder pageId="page-1" onClose={vi.fn()} />, { wrapper: TestWrapper });
+
+    // Export is gated on hasUnsavedChanges, so it doubles as a dirty-state probe.
+    const exportBtn = await screen.findByRole("button", { name: "Export Page" });
+    await waitFor(() => expect(exportBtn).toBeEnabled());
+
+    await openTransitionMenu(user);
+    await user.click(await screen.findByRole("menuitemradio", { name: "Row" }));
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Export Page" })).toBeDisabled());
+  });
+
+  it("offers installed transition plugins as plugin:<id> once the beta flag is on", async () => {
+    servePageWithTransition(null);
+    server.use(
+      http.get(`${API_BASE}/settings/beta`, () =>
+        HttpResponse.json({
+          settings: { https_enabled: false, transition_plugins_enabled: true },
+          https: { cert_present: false, cert_path: "", key_path: "", updater_available: false },
+        }),
+      ),
+      http.get(`${API_BASE}/transitions/plugins`, () =>
+        HttpResponse.json({
+          plugins: [{ id: "typewriter", name: "Typewriter", description: "", icon: "", version: "1.0.0" }],
+        }),
+      ),
+    );
+    const captured = captureUpdate();
+    const user = userEvent.setup();
+
+    render(<PageBuilder pageId="page-1" onClose={vi.fn()} />, { wrapper: TestWrapper });
+
+    await openTransitionMenu(user);
+    await user.click(await screen.findByRole("menuitemradio", { name: "Typewriter" }));
+
+    await user.click(await screen.findByRole("button", { name: "Save Page" }));
+
+    await waitFor(() => expect(captured.body).not.toBeNull());
+    expect(captured.body?.transition_strategy).toBe("plugin:typewriter");
+  });
+
+  it("keeps showing a plugin override by its raw id when the beta flag is off", async () => {
+    servePageWithTransition("plugin:typewriter");
+    const user = userEvent.setup();
+
+    render(<PageBuilder pageId="page-1" onClose={vi.fn()} />, { wrapper: TestWrapper });
+
+    await openTransitionMenu(user);
+
+    expect(await screen.findByRole("menuitemradio", { name: "typewriter", checked: true })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("menuitemradio", { name: "Use global default", checked: false }),
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/__tests__/transition-settings-plugins.test.tsx
+++ b/web/src/__tests__/transition-settings-plugins.test.tsx
@@ -1,0 +1,259 @@
+/**
+ * Transition-plugin picker inside the global Board Transitions settings card.
+ *
+ * The backend accepts `"plugin:<id>"` anywhere a built-in Vestaboard local-API
+ * strategy is accepted, but the card historically only offered the 7 built-ins.
+ * These tests pin the beta-gated plugin group: it appears only when
+ * `beta.transition_plugins_enabled` is on, selecting a plugin saves
+ * `plugin:<id>`, the local-API-only advanced knobs disappear (they are
+ * meaningless for plugin transitions), and an already-saved plugin strategy is
+ * never silently dropped when the plugin is unavailable.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TransitionSettings } from "@/components/settings/transition-settings";
+import { ThemeProvider } from "@/hooks/use-theme";
+
+import { mockTransitionSettings } from "./mocks/handlers";
+import { server } from "./mocks/server";
+
+const API_BASE = "/api";
+
+function TestWrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider attribute="class" defaultTheme="light">
+        {children}
+      </ThemeProvider>
+    </QueryClientProvider>
+  );
+}
+
+/** Override /settings/all so the card loads with a specific saved strategy. */
+function useStrategy(strategy: string | null) {
+  server.use(
+    http.get(`${API_BASE}/settings/all`, () => {
+      return HttpResponse.json({
+        general: { timezone: "America/Los_Angeles" },
+        silence_schedule: {},
+        polling: { interval_seconds: 300 },
+        transitions: { ...mockTransitionSettings, strategy },
+        output: { target: "board", effective_target: "board", available_targets: [] },
+        board: {
+          board_type: "black",
+          boards: [{ id: "default", name: "Flagship", device_type: "flagship", board_color: "black" }],
+          devices: ["flagship"],
+        },
+        mqtt: {
+          enabled: false,
+          broker_host: "localhost",
+          broker_port: 1883,
+          username: "",
+          password: "",
+          external_url: "",
+        },
+        status: { running: true, config_summary: {} },
+      });
+    }),
+  );
+}
+
+function useBeta(enabled: boolean) {
+  server.use(
+    http.get(`${API_BASE}/settings/beta`, () => {
+      return HttpResponse.json({
+        settings: { https_enabled: false, transition_plugins_enabled: enabled },
+        https: { cert_present: false, cert_path: "", key_path: "", updater_available: false },
+      });
+    }),
+  );
+}
+
+function pluginEntry(id: string, name: string, description: string) {
+  return {
+    id,
+    name,
+    description,
+    icon: "Sparkles",
+    version: "1.0.0",
+    author: "Test",
+    settings_schema: {},
+    transition_settings: {
+      interruptible: true,
+      min_interval_ms: 0,
+      max_frames: 100,
+      max_runtime_seconds: 30,
+    },
+    config: {},
+    strategy: `plugin:${id}`,
+  };
+}
+
+function usePlugins(...entries: ReturnType<typeof pluginEntry>[]) {
+  let called = 0;
+  server.use(
+    http.get(`${API_BASE}/transitions/plugins`, () => {
+      called += 1;
+      return HttpResponse.json({ plugins: entries });
+    }),
+  );
+  return () => called;
+}
+
+describe("TransitionSettings transition plugins", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders installed transition plugins as options when the beta is enabled", async () => {
+    useBeta(true);
+    usePlugins(pluginEntry("typewriter", "Typewriter", "Types the new message one character at a time."));
+
+    render(<TransitionSettings />, { wrapper: TestWrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Board Transitions")).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Typewriter" })).toBeInTheDocument();
+    });
+  });
+
+  it("saves strategy as plugin:<id> when a plugin option is clicked", async () => {
+    useBeta(true);
+    usePlugins(pluginEntry("slot_machine", "Slot Machine", "Spins each column into place."));
+
+    let updatePayload: Record<string, unknown> | undefined;
+    server.use(
+      http.put(`${API_BASE}/settings/transitions`, async ({ request }) => {
+        updatePayload = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({
+          status: "success",
+          settings: { strategy: "plugin:slot_machine", step_interval_ms: 500, step_size: 2 },
+        });
+      }),
+    );
+
+    render(<TransitionSettings />, { wrapper: TestWrapper });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Slot Machine" })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Slot Machine" }));
+
+    await waitFor(
+      () => {
+        expect(updatePayload).toBeDefined();
+      },
+      { timeout: 3000 },
+    );
+
+    expect(updatePayload?.strategy).toBe("plugin:slot_machine");
+  });
+
+  it("does not render or fetch plugin options when the beta is disabled", async () => {
+    useBeta(false);
+    const pluginFetches = usePlugins(pluginEntry("typewriter", "Typewriter", "Types one character at a time."));
+
+    render(<TransitionSettings />, { wrapper: TestWrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Board Transitions")).toBeInTheDocument();
+    });
+
+    // Built-ins still render exactly as before.
+    expect(screen.getByRole("button", { name: "Random" })).toBeInTheDocument();
+
+    expect(screen.queryByRole("button", { name: "Typewriter" })).not.toBeInTheDocument();
+    expect(pluginFetches()).toBe(0);
+  });
+
+  it("hides the local-API advanced options while a plugin strategy is selected", async () => {
+    useBeta(true);
+    usePlugins(pluginEntry("typewriter", "Typewriter", "Types one character at a time."));
+    useStrategy("plugin:typewriter");
+
+    render(<TransitionSettings />, { wrapper: TestWrapper });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Typewriter" })).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText("Advanced Options")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Step Interval (ms)")).not.toBeInTheDocument();
+  });
+
+  it("notes that plugin transitions work on any board connection when one is selected", async () => {
+    useBeta(true);
+    usePlugins(pluginEntry("typewriter", "Typewriter", "Types one character at a time."));
+    useStrategy("plugin:typewriter");
+
+    render(<TransitionSettings />, { wrapper: TestWrapper });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Typewriter" })).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/any board connection/i)).toBeInTheDocument();
+  });
+
+  it("shows a chip for a saved plugin strategy that is no longer available", async () => {
+    // Beta off, but the user previously saved a plugin strategy: it must stay
+    // visible and selectable-away-from rather than silently vanishing.
+    useBeta(false);
+    useStrategy("plugin:quiet_library");
+
+    render(<TransitionSettings />, { wrapper: TestWrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Board Transitions")).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole("button", { name: "quiet_library" })).toBeInTheDocument();
+  });
+
+  it("keeps built-in strategy saves unchanged when the beta is enabled", async () => {
+    useBeta(true);
+    usePlugins(pluginEntry("typewriter", "Typewriter", "Types one character at a time."));
+
+    let updatePayload: Record<string, unknown> | undefined;
+    server.use(
+      http.put(`${API_BASE}/settings/transitions`, async ({ request }) => {
+        updatePayload = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json({
+          status: "success",
+          settings: { strategy: "random", step_interval_ms: 500, step_size: 2 },
+        });
+      }),
+    );
+
+    render(<TransitionSettings />, { wrapper: TestWrapper });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Random" })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Random" }));
+
+    await waitFor(
+      () => {
+        expect(updatePayload).toBeDefined();
+      },
+      { timeout: 3000 },
+    );
+
+    expect(updatePayload?.strategy).toBe("random");
+  });
+});

--- a/web/src/components/page-builder.tsx
+++ b/web/src/components/page-builder.tsx
@@ -1566,14 +1566,24 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
                           setTransitionStrategy(value === TRANSITION_INHERIT ? null : String(value))
                         }
                       >
-                        <DropdownMenuRadioItem value={TRANSITION_INHERIT} className="text-xs">
+                        {/* Base UI's MenuRadioItem defaults closeOnClick to
+                         *  false; without this the menu stays open after a
+                         *  pick and its inert backdrop swallows clicks on
+                         *  Save. Picking a transition is a one-shot choice,
+                         *  so every item closes the menu. */}
+                        <DropdownMenuRadioItem value={TRANSITION_INHERIT} className="text-xs" closeOnClick>
                           {t("transitionUseGlobalDefault")}
                         </DropdownMenuRadioItem>
                         <DropdownMenuLabel className="text-[11px] text-muted-foreground">
                           {t("transitionBuiltInGroup")}
                         </DropdownMenuLabel>
                         {BUILT_IN_TRANSITIONS.map((strategy) => (
-                          <DropdownMenuRadioItem key={strategy.value} value={strategy.value} className="text-xs">
+                          <DropdownMenuRadioItem
+                            key={strategy.value}
+                            value={strategy.value}
+                            className="text-xs"
+                            closeOnClick
+                          >
                             {tTransitions(`strategies.${strategy.labelKey}.label`)}
                           </DropdownMenuRadioItem>
                         ))}
@@ -1587,12 +1597,13 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
                             key={plugin.id}
                             value={`${PLUGIN_STRATEGY_PREFIX}${plugin.id}`}
                             className="text-xs"
+                            closeOnClick
                           >
                             {plugin.name}
                           </DropdownMenuRadioItem>
                         ))}
                         {unknownPluginStrategy && (
-                          <DropdownMenuRadioItem value={transitionStrategy!} className="text-xs">
+                          <DropdownMenuRadioItem value={transitionStrategy!} className="text-xs" closeOnClick>
                             {unknownPluginStrategy}
                           </DropdownMenuRadioItem>
                         )}

--- a/web/src/components/page-builder.tsx
+++ b/web/src/components/page-builder.tsx
@@ -23,6 +23,14 @@ import {
   DialogDescription,
   DialogHeader,
   DialogTitle,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
   Flex,
   ScrollArea,
   Select,
@@ -40,7 +48,7 @@ import {
   TooltipTrigger,
 } from "@fiestaboard/ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { ArrowLeft, Check, Copy, Radio, Save, Trash2, Upload } from "lucide-react";
+import { ArrowLeft, Check, Copy, Radio, Save, Sparkles, Trash2, Upload } from "lucide-react";
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
@@ -65,6 +73,7 @@ import {
 } from "@/components/tiptap-template-editor/utils/draw-mode";
 import { queryKeys } from "@/hooks/use-board";
 import { getEffectiveBoardColor, useBoardSettings } from "@/hooks/use-board";
+import { useRouter } from "@/hooks/use-router";
 import { useTranslations } from "@/i18n/translations";
 import type { CurrentPageSnapshot, ToolCall } from "@/lib/ai-chat-types";
 import type {
@@ -148,6 +157,28 @@ function getStoredEditorMode(): "rich" | "plain" {
   return "rich";
 }
 
+/**
+ * Sentinel used as the radio-group value for "no per-page override". The menu
+ * needs a non-empty string; the saved value is `null`.
+ */
+const TRANSITION_INHERIT = "__inherit__";
+
+/**
+ * Built-in transition strategies, paired with their key under the shared
+ * `transitionSettings.strategies.*` namespace so the per-page picker and the
+ * global settings card always read the same labels.
+ */
+const BUILT_IN_TRANSITIONS: { value: string; labelKey: string }[] = [
+  { value: "column", labelKey: "column" },
+  { value: "reverse-column", labelKey: "reverseColumn" },
+  { value: "edges-to-center", labelKey: "edgesToCenter" },
+  { value: "row", labelKey: "row" },
+  { value: "diagonal", labelKey: "diagonal" },
+  { value: "random", labelKey: "random" },
+];
+
+const PLUGIN_STRATEGY_PREFIX = "plugin:";
+
 interface DraftData {
   name: string;
   templateLines: string[];
@@ -163,7 +194,11 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
   const t = useTranslations("pageBuilder");
   const tCommon = useTranslations("common");
   const tDisplaySettings = useTranslations("displaySettings");
+  // Shared with the global transition settings card so both surfaces label the
+  // built-in strategies identically.
+  const tTransitions = useTranslations("transitionSettings");
   const queryClient = useQueryClient();
+  const router = useRouter();
 
   // Fetch board settings for display type
   const { data: boardSettings } = useBoardSettings();
@@ -201,6 +236,11 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
   const [draftRestored, setDraftRestored] = useState(false);
   const [editorMode, setEditorMode] = useState<"rich" | "plain">(getStoredEditorMode);
 
+  // Per-page transition override. `null` means "inherit the global default"
+  // — the backend clears a stored override only when it is sent an explicit
+  // null, so this always goes out on the wire (see the save mutation).
+  const [transitionStrategy, setTransitionStrategy] = useState<string | null>(null);
+
   // Pencil draw-mode state — see handleStrokeCommit / drawPreviewMessage
   // below for how a painted stroke flows back into templateLines.
   const [drawMode, setDrawMode] = useState(false);
@@ -220,6 +260,7 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
     templateLines: string[];
     lineAlignments: LineAlignment[];
     lineWrapEnabled: boolean[];
+    transitionStrategy: string | null;
   } | null>(null);
 
   // Export dialog
@@ -280,9 +321,10 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
       name !== savedSnapshot.name ||
       JSON.stringify(templateLines) !== JSON.stringify(savedSnapshot.templateLines) ||
       JSON.stringify(lineAlignments) !== JSON.stringify(savedSnapshot.lineAlignments) ||
-      JSON.stringify(lineWrapEnabled) !== JSON.stringify(savedSnapshot.lineWrapEnabled)
+      JSON.stringify(lineWrapEnabled) !== JSON.stringify(savedSnapshot.lineWrapEnabled) ||
+      transitionStrategy !== savedSnapshot.transitionStrategy
     );
-  }, [savedSnapshot, name, templateLines, lineAlignments, lineWrapEnabled]);
+  }, [savedSnapshot, name, templateLines, lineAlignments, lineWrapEnabled, transitionStrategy]);
 
   const pushUndoSnapshot = useCallback(() => {
     const snap: PageSnapshot = {
@@ -574,6 +616,44 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
     enabled: !!pageId,
   });
 
+  // Transition plugins (beta): the /transitions/plugins endpoint 404s while
+  // the flag is off, so only fetch once the flag is known to be on. Query keys
+  // match the Transition Lab route so both share one cache entry.
+  const { data: betaSettings } = useQuery({
+    queryKey: ["settings", "beta"],
+    queryFn: () => api.getBetaSettings(),
+  });
+  const transitionPluginsEnabled = betaSettings?.settings.transition_plugins_enabled ?? false;
+
+  const { data: transitionPluginsData } = useQuery({
+    queryKey: ["transition-plugins"],
+    queryFn: () => api.listTransitionPlugins(),
+    enabled: transitionPluginsEnabled,
+  });
+  const transitionPlugins = useMemo(() => transitionPluginsData?.plugins ?? [], [transitionPluginsData]);
+
+  // A `plugin:<id>` override whose plugin isn't in the list — the beta is off,
+  // or the plugin was uninstalled. Surface it under its raw id rather than
+  // silently showing "Use global default"; the user's setting is never cleared
+  // behind their back.
+  const unknownPluginStrategy = useMemo(() => {
+    if (!transitionStrategy?.startsWith(PLUGIN_STRATEGY_PREFIX)) return null;
+    const id = transitionStrategy.slice(PLUGIN_STRATEGY_PREFIX.length);
+    return transitionPlugins.some((p) => p.id === id) ? null : id;
+  }, [transitionStrategy, transitionPlugins]);
+
+  // Human-readable name for the currently selected transition, for the tooltip.
+  const transitionLabel = useMemo(() => {
+    if (!transitionStrategy) return t("transitionUseGlobalDefault");
+    if (unknownPluginStrategy) return unknownPluginStrategy;
+    if (transitionStrategy.startsWith(PLUGIN_STRATEGY_PREFIX)) {
+      const id = transitionStrategy.slice(PLUGIN_STRATEGY_PREFIX.length);
+      return transitionPlugins.find((p) => p.id === id)?.name ?? id;
+    }
+    const builtIn = BUILT_IN_TRANSITIONS.find((s) => s.value === transitionStrategy);
+    return builtIn ? tTransitions(`strategies.${builtIn.labelKey}.label`) : transitionStrategy;
+  }, [transitionStrategy, unknownPluginStrategy, transitionPlugins, t, tTransitions]);
+
   // Device/size retarget (issue #1250): compare the saved geometry with the
   // editor's current one. A shrink on either axis is lossy (content that
   // doesn't fit is cut off), so the save asks for confirmation first.
@@ -625,11 +705,15 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
       setDebouncedLineAlignments(alignments);
       setDebouncedLineWrapEnabled(wrapStates);
       setDebouncedTemplateLines(contents);
+      // Per-page transition override (null = inherit the global default).
+      const savedTransition = existingPage.transition_strategy ?? null;
+      setTransitionStrategy(savedTransition);
       setSavedSnapshot({
         name: pageName,
         templateLines: contents,
         lineAlignments: alignments,
         lineWrapEnabled: wrapStates,
+        transitionStrategy: savedTransition,
       });
     } else if (!pageId && !loadingPage) {
       const draftKey = getDraftKey();
@@ -840,6 +924,10 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
           device_type: deviceType,
           template: cleanedLines,
           line_metadata: metadata,
+          // Always sent, even when null: the API clears a stored override only
+          // for keys it actually receives, so omitting this would silently keep
+          // a previous per-page transition after the user chose "global default".
+          transition_strategy: transitionStrategy,
           ...(deviceType === "note_array" ? { notes_wide: notesWide, notes_tall: notesTall } : {}),
         };
         return api.updatePage(pageId, payload);
@@ -850,6 +938,7 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
           device_type: deviceType,
           template: cleanedLines,
           line_metadata: metadata,
+          transition_strategy: transitionStrategy,
           ...(deviceType === "note_array" ? { notes_wide: notesWide, notes_tall: notesTall } : {}),
         };
         return api.createPage(payload);
@@ -1440,6 +1529,80 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
                *  tooltip pops. */}
               <TooltipProvider skipDelayDuration={0}>
                 <Flex align="center" gap="1.5">
+                  {/* Per-page transition override. Null (the default) inherits
+                   *  the global setting; the trigger carries a dot when this
+                   *  page overrides it. */}
+                  <DropdownMenu>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="relative h-9 w-9"
+                            aria-label={t("transitionPickerAriaLabel")}
+                          >
+                            <Sparkles className={`h-4 w-4 ${transitionStrategy ? "text-brand" : ""}`} />
+                            {transitionStrategy && (
+                              <Text
+                                as="span"
+                                aria-hidden="true"
+                                className="absolute right-1.5 top-1.5 h-1.5 w-1.5 rounded-full bg-brand"
+                              />
+                            )}
+                          </Button>
+                        </DropdownMenuTrigger>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <Text>{t("transitionPickerTooltip", { strategy: transitionLabel })}</Text>
+                      </TooltipContent>
+                    </Tooltip>
+                    <DropdownMenuContent align="end" className="w-56">
+                      <DropdownMenuLabel className="text-xs font-medium">{t("transitionMenuTitle")}</DropdownMenuLabel>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuRadioGroup
+                        value={transitionStrategy ?? TRANSITION_INHERIT}
+                        onValueChange={(value) =>
+                          setTransitionStrategy(value === TRANSITION_INHERIT ? null : String(value))
+                        }
+                      >
+                        <DropdownMenuRadioItem value={TRANSITION_INHERIT} className="text-xs">
+                          {t("transitionUseGlobalDefault")}
+                        </DropdownMenuRadioItem>
+                        <DropdownMenuLabel className="text-[11px] text-muted-foreground">
+                          {t("transitionBuiltInGroup")}
+                        </DropdownMenuLabel>
+                        {BUILT_IN_TRANSITIONS.map((strategy) => (
+                          <DropdownMenuRadioItem key={strategy.value} value={strategy.value} className="text-xs">
+                            {tTransitions(`strategies.${strategy.labelKey}.label`)}
+                          </DropdownMenuRadioItem>
+                        ))}
+                        {transitionPlugins.length > 0 && (
+                          <DropdownMenuLabel className="text-[11px] text-muted-foreground">
+                            {t("transitionPluginsGroup")}
+                          </DropdownMenuLabel>
+                        )}
+                        {transitionPlugins.map((plugin) => (
+                          <DropdownMenuRadioItem
+                            key={plugin.id}
+                            value={`${PLUGIN_STRATEGY_PREFIX}${plugin.id}`}
+                            className="text-xs"
+                          >
+                            {plugin.name}
+                          </DropdownMenuRadioItem>
+                        ))}
+                        {unknownPluginStrategy && (
+                          <DropdownMenuRadioItem value={transitionStrategy!} className="text-xs">
+                            {unknownPluginStrategy}
+                          </DropdownMenuRadioItem>
+                        )}
+                      </DropdownMenuRadioGroup>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem className="text-xs" onClick={() => router.push("/transitions")}>
+                        {t("transitionOpenLab")}
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
                   {/* Delete button - only show when editing */}
                   {pageId && (
                     <AlertDialog>

--- a/web/src/components/settings/transition-settings.tsx
+++ b/web/src/components/settings/transition-settings.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  Badge,
   Box,
   Card,
   CardContent,
@@ -17,7 +18,7 @@ import {
 } from "@fiestaboard/ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Info, Sparkles } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
 import { useTranslations } from "@/i18n/translations";
@@ -37,6 +38,13 @@ const STRATEGY_VALUES: {
   { value: "random", key: "random" },
 ];
 
+/** Prefix the backend uses for transition-plugin strategies (`plugin:<id>`). */
+const PLUGIN_PREFIX = "plugin:";
+
+const OPTION_BASE_CLASS = "px-3 py-1.5 rounded-md border text-xs font-medium transition-colors";
+const OPTION_SELECTED_CLASS = "border-brand bg-brand/10 text-brand";
+const OPTION_IDLE_CLASS = "border-muted hover:border-brand/50 text-foreground";
+
 export function TransitionSettings() {
   const t = useTranslations("transitionSettings");
   const tCommon = useTranslations("common");
@@ -48,6 +56,22 @@ export function TransitionSettings() {
   });
 
   const transitions = allSettings?.transitions;
+
+  // Transition plugins are beta-gated: the backend rejects `plugin:` strategies
+  // (and 404s the plugin list) while the flag is off, so don't even fetch.
+  // Same queryKey as the Transition Lab page so the cache is shared.
+  const betaQuery = useQuery({
+    queryKey: ["settings", "beta"],
+    queryFn: () => api.getBetaSettings(),
+  });
+  const betaEnabled = betaQuery.data?.settings.transition_plugins_enabled ?? false;
+
+  const pluginsQuery = useQuery({
+    queryKey: ["transition-plugins"],
+    queryFn: () => api.listTransitionPlugins(),
+    enabled: betaEnabled,
+  });
+  const plugins = useMemo(() => pluginsQuery.data?.plugins ?? [], [pluginsQuery.data]);
 
   const [strategy, setStrategy] = useState<string | null>(null);
   const [stepIntervalMs, setStepIntervalMs] = useState<number | "">("");
@@ -117,6 +141,16 @@ export function TransitionSettings() {
     setHasChanges(true);
   };
 
+  // `plugin:<id>` strategies are rendered frame-by-frame by FiestaBoard rather
+  // than handed to the Vestaboard local API, so they behave differently from
+  // the built-ins: no step interval/size, and no Local-API-only caveat.
+  const selectedPluginId = strategy?.startsWith(PLUGIN_PREFIX) ? strategy.slice(PLUGIN_PREFIX.length) : null;
+  const selectedPlugin = selectedPluginId ? (plugins.find((p) => p.id === selectedPluginId) ?? null) : null;
+  // A saved plugin strategy whose plugin isn't in the list — beta turned off, or
+  // the plugin was uninstalled. Show it rather than silently clearing it.
+  const orphanPluginId = selectedPluginId && !selectedPlugin ? selectedPluginId : null;
+  const showPluginGroup = betaEnabled && plugins.length > 0;
+
   if (isLoading) {
     return (
       <Card>
@@ -144,6 +178,14 @@ export function TransitionSettings() {
         {/* Strategy Selector */}
         <Stack gap="2">
           <Label className="text-sm font-medium">{t("transitionStyle")}</Label>
+
+          {/* Group headings only appear once there is a second group to
+              disambiguate from — otherwise the card looks exactly as before. */}
+          {showPluginGroup && (
+            <Text size="xs" tone="muted" className="font-medium">
+              {t("builtInGroup")}
+            </Text>
+          )}
           <Flex wrap gap="2">
             {STRATEGY_VALUES.map((option) => {
               const isSelected = strategy === option.value;
@@ -151,19 +193,66 @@ export function TransitionSettings() {
                 <button
                   key={option.value ?? "none"}
                   onClick={() => handleStrategyChange(option.value)}
-                  className={`px-3 py-1.5 rounded-md border text-xs font-medium transition-colors ${
-                    isSelected
-                      ? "border-brand bg-brand/10 text-brand"
-                      : "border-muted hover:border-brand/50 text-foreground"
-                  }`}
+                  className={`${OPTION_BASE_CLASS} ${isSelected ? OPTION_SELECTED_CLASS : OPTION_IDLE_CLASS}`}
                 >
                   {t(`strategies.${option.key}.label`)}
                 </button>
               );
             })}
           </Flex>
+
+          {showPluginGroup && (
+            <>
+              <Flex align="center" gap="2" className="pt-2">
+                <Text size="xs" tone="muted" className="font-medium">
+                  {t("pluginsGroup")}
+                </Text>
+                <Badge variant="secondary">{t("pluginsBetaBadge")}</Badge>
+              </Flex>
+              <Flex wrap gap="2">
+                {plugins.map((plugin) => {
+                  const isSelected = selectedPluginId === plugin.id;
+                  return (
+                    <button
+                      key={plugin.id}
+                      onClick={() => handleStrategyChange(`${PLUGIN_PREFIX}${plugin.id}`)}
+                      className={`${OPTION_BASE_CLASS} ${isSelected ? OPTION_SELECTED_CLASS : OPTION_IDLE_CLASS}`}
+                    >
+                      {plugin.name}
+                    </button>
+                  );
+                })}
+              </Flex>
+            </>
+          )}
+
+          {orphanPluginId && (
+            <Flex wrap gap="2">
+              {/* Already selected, so there is nothing to click toward — it
+                  exists purely so the setting stays visible and the user can
+                  choose a different option instead of it. */}
+              <button type="button" aria-pressed className={`${OPTION_BASE_CLASS} ${OPTION_SELECTED_CLASS}`}>
+                {orphanPluginId}
+              </button>
+            </Flex>
+          )}
+
           {/* Description of selected strategy */}
           {(() => {
+            if (selectedPlugin) {
+              return (
+                <Text size="xs" tone="muted">
+                  {selectedPlugin.description}
+                </Text>
+              );
+            }
+            if (orphanPluginId) {
+              return (
+                <Text size="xs" tone="muted">
+                  {t("unavailablePluginNote")}
+                </Text>
+              );
+            }
             const selected = STRATEGY_VALUES.find((o) => o.value === strategy);
             return selected ? (
               <Text size="xs" tone="muted">
@@ -173,8 +262,10 @@ export function TransitionSettings() {
           })()}
         </Stack>
 
-        {/* Advanced options — only shown when a strategy is selected */}
-        {strategy && (
+        {/* Advanced options — only for built-in strategies. Step interval and
+            step size are forwarded to the Vestaboard local API, which never
+            sees a plugin transition, so they are ignored there. */}
+        {strategy && !selectedPluginId && (
           <Stack gap="4" className="pt-2 border-t">
             <Label className="text-sm font-medium">{t("advancedOptions")}</Label>
 
@@ -227,6 +318,17 @@ export function TransitionSettings() {
             {t("localApiNote")}
           </Text>
         </Flex>
+
+        {/* Plugin transitions are repeated full-grid sends, not local-API
+            transition hints, so the note above does not apply to them. */}
+        {selectedPluginId && (
+          <Flex align="start" gap="2" className="p-2.5 rounded-md bg-muted/50 text-xs text-muted-foreground">
+            <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+            <Text as="span" size="xs" tone="muted">
+              {t("pluginNote")}
+            </Text>
+          </Flex>
+        )}
 
         {/* Saving indicator */}
         {updateMutation.isPending && (

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1132,6 +1132,13 @@ export interface PluginInfo {
   configured: boolean;
   icon: string;
   category: string;
+  /**
+   * `"transition"` plugins supply a board-transition animation instead of
+   * template data. They have no polling loop, so the registry runs any
+   * installed one regardless of `enabled` — the UI must not offer a toggle
+   * for them. Absent on responses that predate the field; treat as `"data"`.
+   */
+  plugin_type?: "data" | "transition";
   fiestaboard_version?: string;
   config: Record<string, unknown>;
   source?: { source_type: "builtin" | "registry" | "external" | "git"; repository_url?: string; local_path?: string };

--- a/web/tests/transition-pickers.spec.ts
+++ b/web/tests/transition-pickers.spec.ts
@@ -1,0 +1,138 @@
+/**
+ * Transition pickers (beta): the two surfaces that select a transition.
+ *
+ * Transition plugins shipped fully wired on the backend but with no UI to
+ * select one -- a user following a plugin's SETUP guide could not apply it
+ * at all (Discord report, PR #1589). These tests pin the two controls that
+ * closed that gap, and assert against the *API* after each interaction
+ * rather than trusting the rendered state: the bug being guarded is
+ * precisely "the control exists but nothing reaches the backend".
+ *
+ * Every test forces the transition-plugins beta on, since both pickers hide
+ * their plugin groups when it is off, and restores the prior state after.
+ */
+import { API_URL, authHeaders, createPage, deletePage, expect, test, waitForApi } from "./helpers";
+
+/** A bundled transition plugin, present in every install. */
+const PLUGIN_ID = "typewriter";
+const PLUGIN_NAME = "Typewriter";
+/** A bundled *data* plugin, used as a positive control on Integrations. */
+const DATA_PLUGIN_NAME = "Date & Time";
+
+async function setBeta(enabled: boolean): Promise<void> {
+  const res = await fetch(`${API_URL}/settings/beta`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json", ...authHeaders() },
+    body: JSON.stringify({ transition_plugins_enabled: enabled }),
+  });
+  expect(res.ok, `failed to set beta flag to ${enabled}`).toBe(true);
+}
+
+async function getGlobalStrategy(): Promise<string | null> {
+  const res = await fetch(`${API_URL}/settings/transitions`, { headers: authHeaders() });
+  expect(res.ok).toBe(true);
+  return (await res.json()).strategy ?? null;
+}
+
+async function setGlobalStrategy(strategy: string | null): Promise<void> {
+  await fetch(`${API_URL}/settings/transitions`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json", ...authHeaders() },
+    body: JSON.stringify({ strategy }),
+  });
+}
+
+async function getPageStrategy(pageId: string): Promise<string | null> {
+  const res = await fetch(`${API_URL}/pages/${pageId}`, { headers: authHeaders() });
+  expect(res.ok).toBe(true);
+  return (await res.json()).transition_strategy ?? null;
+}
+
+test.describe("transition pickers", () => {
+  let priorStrategy: string | null = null;
+
+  test.beforeEach(async () => {
+    await waitForApi();
+    priorStrategy = await getGlobalStrategy();
+    await setBeta(true);
+  });
+
+  test.afterEach(async () => {
+    await setGlobalStrategy(priorStrategy);
+    await setBeta(false);
+  });
+
+  test("global picker saves a transition plugin as plugin:<id>", async ({ page }) => {
+    await page.goto("/settings");
+    await page.getByRole("tab", { name: /behavior/i }).click();
+
+    const option = page.getByRole("button", { name: PLUGIN_NAME, exact: true });
+    await expect(option, "transition plugin missing from Board Transitions").toBeVisible();
+    await option.click();
+
+    // The card auto-saves on a 1s debounce; poll the API rather than the DOM
+    // so this asserts the value actually reached the backend.
+    await expect.poll(getGlobalStrategy, { timeout: 10_000 }).toBe(`plugin:${PLUGIN_ID}`);
+  });
+
+  test("global picker hides plugin options when the beta is off", async ({ page }) => {
+    await setBeta(false);
+    await page.goto("/settings");
+    await page.getByRole("tab", { name: /behavior/i }).click();
+
+    // The built-in strategies must still be there -- only the plugin group
+    // goes. "Wave" is the display label for the `column` strategy.
+    await expect(page.getByRole("button", { name: /^wave$/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: PLUGIN_NAME, exact: true })).toHaveCount(0);
+  });
+
+  test("page picker saves an override and clears it back to the global default", async ({ page }) => {
+    const pageId = await createPage("Transition Picker E2E", ["HELLO"]);
+
+    try {
+      await page.goto(`/pages/edit?id=${pageId}`);
+
+      const trigger = page.getByRole("button", { name: /transition/i }).first();
+      await expect(trigger, "per-page Transition control missing").toBeVisible();
+
+      // --- set an override ---
+      await trigger.click();
+      await page.getByRole("menuitemradio", { name: PLUGIN_NAME }).click();
+      await page.getByRole("button", { name: /save/i }).first().click();
+
+      await expect.poll(() => getPageStrategy(pageId), { timeout: 10_000 }).toBe(`plugin:${PLUGIN_ID}`);
+
+      // --- it survives a reload, selected in the menu ---
+      await page.reload();
+      await trigger.click();
+      await expect(page.getByRole("menuitemradio", { name: PLUGIN_NAME })).toHaveAttribute("aria-checked", "true");
+
+      // --- clear it: must persist as null, not stay sticky ---
+      await page.getByRole("menuitemradio", { name: /use global default/i }).click();
+      await page.getByRole("button", { name: /save/i }).first().click();
+
+      await expect.poll(() => getPageStrategy(pageId), { timeout: 10_000 }).toBeNull();
+    } finally {
+      await deletePage(pageId);
+    }
+  });
+
+  test("integrations badges a transition plugin and offers no enable toggle", async ({ page }) => {
+    await page.goto("/integrations");
+
+    const row = page.getByRole("row").filter({ hasText: PLUGIN_NAME });
+    await expect(row).toBeVisible();
+    await expect(row.getByText("Transition", { exact: true })).toBeVisible();
+    // The toggle is a no-op for transitions -- get_transition_plugin() ignores
+    // the enabled flag -- so it must not be offered.
+    await expect(row.getByRole("switch")).toHaveCount(0);
+
+    // Positive control: a data plugin in the same table still gets its
+    // toggle. Without this, the assertion above would also pass if the
+    // switch selector simply stopped matching anything.
+    const dataRow = page.getByRole("row").filter({ hasText: DATA_PLUGIN_NAME });
+    await expect(dataRow).toBeVisible();
+    await expect(dataRow.getByRole("switch")).toHaveCount(1);
+    await expect(dataRow.getByText("Transition", { exact: true })).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Why

From Discord: a community member enabled the Transitions beta, followed [`plugins/typewriter/docs/SETUP.md`](https://github.com/Fiestaboard/FiestaBoard/blob/main/plugins/typewriter/docs/SETUP.md), and could not find the UI it described.

They were right, and the docs were less wrong than they looked. Transition plugins were implemented end to end but **unreachable from any UI** — the only way to apply one was `PUT /settings/transitions` or `PUT /pages/{id}` by hand.

Per-page overrides were the more surprising gap. `Page.transition_strategy` is honored at send time (`src/main.py:774`, `:977`; `src/api_server.py:6025`, `:7707`) with fallback to the global default, is persisted, shareable, and clearable — it simply never had a control in the page editor.

## What changed

**Global picker** — `Settings → Behavior → Board Transitions` now lists installed transition plugins in a "Plugins (beta)" group beside the built-in strategies, saving `strategy` as `plugin:<id>`. Step Interval / Step Size are hidden for plugin strategies, since those are forwarded to the Local API and ignored by plugins.

**Per-page picker** — the page editor header gains a `Transition` dropdown: "Use global default", the built-in strategies, and (beta on) the installed plugins, plus a link to the Transition Lab. Clearing sends explicit `null` so the backend's nullable allowset actually drops the override rather than leaving it sticky.

Neither picker discards a setting it can't resolve: a `plugin:<id>` whose plugin is uninstalled, or whose beta flag is off, still renders under its raw id instead of silently reading as "Use global default".

**Integrations** — transition plugins no longer show an enable/disable toggle. It was a no-op: `get_transition_plugin()` (`src/plugins/registry.py:618`) deliberately ignores the enabled flag, so disabling Typewriter still ran Typewriter. They're badged "Transition" instead. `plugin_type` is now returned by `list_plugins()` and `GET /plugins/{plugin_id}`.

**Docs** — built-in strategies are Vestaboard **Local API** features; transition plugins are host-driven full-grid sends that work on **any** connection. The docs conflated the two, and `transitionLab.noPlugins` told users to "enable one on the Integrations page" — the exact step that doesn't exist. All four plugin READMEs + SETUP guides corrected, `TRANSITION_PLUGIN_DEVELOPMENT.md` updated, and a new `docs-site/docs/features/transitions.md`, since the site documented the feature nowhere at all.

## Test evidence

Every test was written before its implementation and proven non-vacuous by breaking the specific production behavior and recording the failure. Representative:

```
# omit the key when null, rather than sending explicit null
× sends an explicit null when clearing an existing override back to the global default
  AssertionError: expected { name: 'Weather Page', …(3) } to have property "transition_strategy"

# drop the plugin: prefix on save
  AssertionError: expected 'slot_machine' to be 'plugin:slot_machine'

# ungate the toggle so transitions render it again
× renders no enable toggle for a transition plugin
  expected document not to contain element, found <button ...

# remove plugin_type from the registry payload
E   KeyError: 'plugin_type'
```

- Python: **4679 passed**. Two files (`test_plugin_sources.py`, `test_plugin_install_integration.py`) fail only in the local test image, which has no `git` binary — unrelated and green in CI.
- Web: **1497 passed / 119 files**, including the zero-key-drift i18n guard after all 15 new keys were translated into the 13 non-English locales.
- Ruff, Prettier, ESLint, and `validate_plugins.py` (7/7) clean.
- `docs-site` verified with a real Docusaurus build; `onBrokenLinks: "throw"` passes.

## Follow-ups not in this PR

- The **Marketplace** tab still can't distinguish transition plugins — `plugin-registry.json` carries no `plugin_type` on any of its 51 entries, so it needs a `RegistryEntry` field plus a seed backfill.
- **Per-collection / per-schedule transitions**, the original feature request. Page-level is now the first rung of the hierarchy (page → global).

🤖 Generated with [Claude Code](https://claude.com/claude-code)