### PR TITLE
test(ai+mcp): five-layer harness for the AI and MCP surfaces, and the six bugs it found

### DIFF
--- a/docs/superpowers/plans/2026-08-11-ai-mcp-test-harness.md
+++ b/docs/superpowers/plans/2026-08-11-ai-mcp-test-harness.md
@@ -1,0 +1,375 @@
+# AI + MCP Test Harness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a five-layer test harness that permanently catches the class of silent AI/MCP breakage behind #1560 and #1561, then fix every bug it finds.
+
+**Architecture:** Five independent layers, each owning one bug class. Layer 1 parses source across the Python/TypeScript boundary and fails on contract drift. Layer 2 emulates each LLM provider's real request validation. Layer 3 drives MCP over real JSON-RPC transport against real services and asserts on re-read state. Layers 4–5 extend the existing `ai-mcp-e2e-tests` Playwright job. Each layer lands as its own PR.
+
+**Tech Stack:** pytest, Python `ast`, Pydantic, FastAPI `TestClient`, `mcp` (FastMCP), Playwright, stdlib `http.server` (mock-llm).
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-08-11-ai-mcp-test-harness-design.md`
+- Commit trailer is exactly `Co-Authored-By: Claude <noreply@anthropic.com>` — no model name or version (CLAUDE.md).
+- Never run the API server or `npm run dev` on the host. Python tests run in the dev container: `docker compose -f docker-compose.dev.yml exec fiestaboard pytest`.
+- Every analyzer carries meta-tests: one proving it fails on known-bad input, one enforcing a floor on symbols resolved. An analyzer that silently checks nothing is the bug being fixed, re-introduced.
+- Every Layer 2 emulator carries a test asserting it *rejects* what it should reject.
+- Layer 3 assertions are on re-read state, never on call records.
+- Test quality bar (CLAUDE.md): write the test first, watch it fail for the expected reason, put the observed failure output in the PR description.
+- No temporary markdown in the repo root.
+
+## Source-of-truth inventory (verified 2026-08-11)
+
+| Thing | Location | Count |
+|---|---|---|
+| Chat ops (Python) | `src/ai/chat_ops.py:497` `_OP_REGISTRY` | 19 |
+| Chat ops (TS) | `web/src/lib/ai-chat-types.ts:163` `ToolCall` union | 19 |
+| MCP tools | `src/mcp_server.py` `@mcp.tool()` | 28 |
+| MCP prompts | `src/mcp_server.py` `@mcp.prompt()` | 5 |
+| MCP resources | `src/mcp_server.py` `@mcp.resource()` | 6 |
+| Protocols | `src/ai/protocols.py:225` `PROTOCOLS` | 2 |
+
+## File Structure
+
+**Layer 1 — analyzers (pytest, no container)**
+- Create `tests/test_ai_op_contract.py` — chat-op registry ↔ TS union ↔ web switches
+- Create `tests/test_mcp_skill_quality.py` — tool/prompt/resource description + schema quality
+
+**Layer 2 — provider conformance (pytest, hermetic)**
+- Create `tests/ai/provider_emulators.py` — the emulator library (importable by tests *and* mock-llm)
+- Create `tests/ai/test_provider_conformance.py` — every outbound body × every emulator
+- Modify `integration-tests/mock-llm/server.py` — provider personality mode
+
+**Layer 3 — MCP over real transport (pytest)**
+- Create `tests/test_mcp_state_effects.py` — read → mutate → re-read, no service mocks
+
+**Layer 4 — browser apply-loop (Playwright)**
+- Modify `integration-tests/mock-llm/server.py` — `script` scenario
+- Modify `web/tests/ai.spec.ts` — both surfaces apply every op
+
+**Layer 5 — skill scenarios (Playwright)**
+- Modify `web/tests/mcp.spec.ts` — lifecycle, all prompts, all resources, chains
+
+---
+
+### Task 1: Chat-op contract analyzer (Layer 1)
+
+**Files:**
+- Create: `tests/test_ai_op_contract.py`
+
+**Interfaces:**
+- Consumes: `src.ai.chat_ops._OP_REGISTRY`, `src.ai.chat_ops.supported_ops()`
+- Produces: `_ts_union_ops(path) -> set[str]`, `_switch_case_ops(path, func_name) -> set[str]`
+
+- [ ] **Step 1: Write the failing test**
+
+Three assertions: Python registry == TS union; every op in the TS union is
+handled by `labelFor` in `ai-chat-panel.tsx`; same for the drawer's
+`labelFor`. Plus meta-tests.
+
+```python
+def test_python_registry_matches_ts_union():
+    py = set(_OP_REGISTRY)
+    ts = _ts_union_ops(WEB / "src/lib/ai-chat-types.ts")
+    assert py == ts, f"drift: py-only={py - ts}, ts-only={ts - py}"
+
+
+def test_editor_chat_panel_labels_every_op():
+    ts = _ts_union_ops(WEB / "src/lib/ai-chat-types.ts")
+    handled = _switch_case_ops(WEB / "src/components/ai-chat-panel.tsx", "labelFor")
+    assert ts <= handled, f"labelFor() returns undefined for: {sorted(ts - handled)}"
+
+
+def test_analyzer_rejects_known_bad_input(tmp_path):
+    f = tmp_path / "x.ts"
+    f.write_text('function labelFor(c: ToolCall): string {\n switch (c.op) {\n case "a": return "A";\n }\n}')
+    assert _switch_case_ops(f, "labelFor") == {"a"}
+
+
+def test_analyzer_floor():
+    assert len(_ts_union_ops(WEB / "src/lib/ai-chat-types.ts")) >= 19
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `docker compose -f docker-compose.dev.yml exec fiestaboard pytest tests/test_ai_op_contract.py -v`
+Expected: `test_editor_chat_panel_labels_every_op` FAILS listing
+`disable_plugin, enable_plugin, navigate_to_schedule, uninstall_plugin`.
+The other three PASS. If the meta-tests fail, the analyzer is broken, not the code.
+
+- [ ] **Step 3: Implement the analyzer helpers**
+
+Regex-based TS parsing (no TS parser available in the Python container):
+`_ts_union_ops` matches `op: "<name>"` inside the `ToolCall` union block;
+`_switch_case_ops` matches `case "<name>"` inside the named function's body,
+found by brace-matching from the function signature.
+
+- [ ] **Step 4: Run to verify the analyzer works and the finding stands**
+
+Expected: 3 pass, 1 fails with the four op names. That failure is finding #2.
+
+- [ ] **Step 5: Fix `labelFor` and re-run**
+
+Add the four missing cases to `ai-chat-panel.tsx`.
+Expected: all 4 tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/test_ai_op_contract.py web/src/components/ai-chat-panel.tsx
+git commit -m "test(ai): assert chat-op contract across Python and TS
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: MCP skill-quality analyzer (Layer 1)
+
+**Files:**
+- Create: `tests/test_mcp_skill_quality.py`
+
+**Interfaces:**
+- Consumes: `src.mcp_server._build_mcp_server()`, its `_tool_manager`, `_prompt_manager`, `_resource_manager`
+- Produces: nothing consumed by later tasks
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_every_tool_has_a_description(mcp):
+    bad = [n for n, t in mcp._tool_manager._tools.items() if not (t.description or "").strip()]
+    assert not bad
+
+
+def test_every_tool_parameter_is_described(mcp):
+    bad = []
+    for name, tool in mcp._tool_manager._tools.items():
+        props = (tool.parameters or {}).get("properties", {})
+        for p, schema in props.items():
+            if not schema.get("description", "").strip():
+                bad.append(f"{name}.{p}")
+    assert not bad
+
+
+def test_prompts_reference_only_tools_that_exist(mcp):
+    tools = set(mcp._tool_manager._tools)
+    # Prompt text names tools like `list_pages()`. Every such name must resolve.
+    ...
+
+
+def test_floor_on_surface_size(mcp):
+    assert len(mcp._tool_manager._tools) >= 28
+```
+
+- [ ] **Step 2: Run to see which assertions fail**
+
+Run: `... pytest tests/test_mcp_skill_quality.py -v`
+Expected: unknown until run. Record every failure as a finding.
+
+- [ ] **Step 3: Fix descriptions/schemas the analyzer flags**
+
+- [ ] **Step 4: Re-run — all PASS**
+
+- [ ] **Step 5: Commit**
+
+---
+
+### Task 3: Provider emulator library (Layer 2)
+
+**Files:**
+- Create: `tests/ai/provider_emulators.py`
+
+**Interfaces:**
+- Produces: `ProviderEmulator` (abstract: `name`, `validate(body, headers) -> None`, raises `ProviderRejection`), and concrete `OpenAIEmulator`, `OpenRouterEmulator`, `LMStudioEmulator`, `OllamaEmulator`, `VLLMEmulator`, `AnthropicEmulator`; `ALL_EMULATORS: list[ProviderEmulator]`; `ProviderRejection(status, message)`.
+
+- [ ] **Step 1: Write the failing test for the emulator itself**
+
+An emulator that accepts everything is the bug being fixed. Prove each says no.
+
+```python
+def test_lmstudio_rejects_json_object():
+    with pytest.raises(ProviderRejection) as exc:
+        LMStudioEmulator().validate(
+            {"model": "m", "messages": [], "response_format": {"type": "json_object"}}, {}
+        )
+    assert exc.value.status == 400
+    assert "json_schema" in exc.value.message
+
+
+def test_lmstudio_accepts_text():
+    LMStudioEmulator().validate(
+        {"model": "m", "messages": [], "response_format": {"type": "text"}}, {}
+    )
+
+
+def test_anthropic_requires_version_header():
+    with pytest.raises(ProviderRejection):
+        AnthropicEmulator().validate({"model": "m", "messages": [], "max_tokens": 1}, {})
+```
+
+- [ ] **Step 2: Run to verify it fails** — `ImportError`, module does not exist.
+
+- [ ] **Step 3: Implement the emulators**
+
+`LMStudioEmulator.validate` rejects `response_format.type not in {"json_schema","text"}`
+with the exact message from #1560. `AnthropicEmulator` requires `x-api-key` +
+`anthropic-version`, rejects `response_format`, requires `max_tokens`.
+
+- [ ] **Step 4: Run — all PASS**
+
+- [ ] **Step 5: Commit**
+
+---
+
+### Task 4: Provider conformance matrix (Layer 2)
+
+**Files:**
+- Create: `tests/ai/test_provider_conformance.py`
+
+**Interfaces:**
+- Consumes: `ALL_EMULATORS` from Task 3; `src.ai.protocols.PROTOCOLS`; the chat body builder in `src/ai/chat.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+@pytest.mark.parametrize("emulator", OPENAI_FAMILY_EMULATORS, ids=lambda e: e.name)
+def test_generator_body_accepted_by_every_openai_compatible_provider(emulator):
+    proto = PROTOCOLS["openai"]
+    body = proto.build_body("m", [{"role": "user", "content": "hi"}], 0.7, 1000)
+    headers = proto.build_headers("k", {})
+    emulator.validate(body, headers)   # raises ProviderRejection on drift
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Expected: FAILS for `lmstudio` with
+`'response_format.type' must be 'json_schema' or 'text'`. This is #1560,
+reproduced as a test. Other emulators pass.
+
+- [ ] **Step 3: Do NOT fix yet — commit the failing test as `xfail` with the issue ref**
+
+The fix ships as its own PR per the spec. Mark
+`@pytest.mark.xfail(reason="#1560", strict=True)` so the suite stays green and
+flips loudly when fixed.
+
+- [ ] **Step 4: Commit the harness**
+
+- [ ] **Step 5: In a separate branch/PR — fix #1560**
+
+Change `src/ai/protocols.py:72` to `{"type": "text"}`, remove the `xfail`,
+add a test asserting the generator still recovers JSON from prose via
+`_extract_json_object`. Reference the reporter's analysis in the PR.
+
+---
+
+### Task 5: mock-llm provider personalities (Layer 2)
+
+**Files:**
+- Modify: `integration-tests/mock-llm/server.py`
+
+- [ ] **Step 1: Add `POST /mock/provider {"provider": "lmstudio"}`**
+
+Default `"permissive"` preserves today's behavior so existing `ai.spec.ts`
+tests do not change meaning. When set, every `/v1/chat/completions` body is
+run through that provider's validator first and rejected with its real status
+and error shape.
+
+- [ ] **Step 2: Add an E2E test in `ai.spec.ts` proving generation succeeds against `lmstudio`**
+
+- [ ] **Step 3: Run, commit**
+
+---
+
+### Task 6: MCP state-effect suite (Layer 3)
+
+**Files:**
+- Create: `tests/test_mcp_state_effects.py`
+
+**Interfaces:**
+- Consumes: `src.mcp_server._build_mcp_server()`; real `ConfigManager`/`PageService`/`ScheduleService`/`CollectionService` on a `tmp_path` config
+
+- [ ] **Step 1: Write the failing test for one mutating tool**
+
+No mocks. Assert on re-read, not on a call record.
+
+```python
+async def test_create_page_actually_persists(real_services):
+    before = _call(mcp, "list_pages")["pages"]
+    _call(mcp, "create_page", name="Harness", device_type="flagship",
+          template=["HELLO", "", "", "", "", ""])
+    after = _call(mcp, "list_pages")["pages"]
+    assert len(after) == len(before) + 1
+    assert any(p["name"] == "Harness" for p in after)
+```
+
+- [ ] **Step 2: Run — expect PASS or a real finding**
+
+- [ ] **Step 3: Extend to all 28 tools**
+
+Table-driven: each entry names the tool, its args, and a `verify(services)`
+callable that re-reads state. Read-only tools assert shape; mutating tools
+assert change. Include `set_active_page` and `set_schedule_mode` — the #1561
+pair — as explicit regression cases.
+
+- [ ] **Step 4: Add the floor meta-test**
+
+```python
+def test_every_tool_is_covered(mcp):
+    assert set(mcp._tool_manager._tools) <= set(COVERED_TOOLS)
+```
+
+This is what makes the suite non-vacuous: a new tool added later fails this
+until someone writes its state-effect case.
+
+- [ ] **Step 5: Triage findings, commit harness**
+
+---
+
+### Task 7: mock-llm `script` scenario + browser apply-loop (Layer 4)
+
+**Files:**
+- Modify: `integration-tests/mock-llm/server.py`
+- Modify: `web/tests/ai.spec.ts`
+
+- [ ] **Step 1: Add `POST /mock/script {"ops": [...]}`**
+
+Next completion returns prose plus a `fiestaboard` fenced block per op,
+verbatim, so a test picks exactly which op the model "emits".
+
+- [ ] **Step 2: Write a Playwright test per op, per surface**
+
+Both `editor` (`ai-chat-panel`) and `global` (`global-ai-chat-drawer`) — they
+have different handler sets, which is how the `labelFor` gap arose. Assert the
+page/schedule/collection actually mutated, not that a card rendered.
+
+- [ ] **Step 3: Run against the container, triage, commit**
+
+---
+
+### Task 8: Skill scenarios (Layer 5)
+
+**Files:**
+- Modify: `web/tests/mcp.spec.ts`
+
+- [ ] **Step 1: Lifecycle** — `initialize` → `tools/list` → `prompts/list` → `resources/list`, asserting counts ≥ 28/5/6.
+
+- [ ] **Step 2: Execute all 5 prompts** via `prompts/get`, assert each returns non-empty messages and names only tools that exist.
+
+- [ ] **Step 3: Fetch all 6 resources** via `resources/read`, assert each returns parseable content of its declared mime type. Include `fiestaboard://page/{page_id}/preview.html` with a real page id created in the test.
+
+- [ ] **Step 4: Two multi-tool chains**, asserting final state:
+  - create page → create schedule referencing it → `set_active_page` → verify board state
+  - install plugin → configure → create page using its variable → render preview
+
+- [ ] **Step 5: Raise the CI job timeout if needed; triage; commit**
+
+---
+
+## Self-Review
+
+**Spec coverage:** Layer 1 → Tasks 1–2. Layer 2 → Tasks 3–5. Layer 3 → Task 6. Layer 4 → Task 7. Layer 5 → Task 8. Known work items (#1560, `labelFor`) → Tasks 4 and 1 respectively. CI integration → Tasks 5, 7, 8 extend existing jobs; Tasks 1–3, 6 join `test-platform`. Non-goal "no real providers" honored — all emulated. Non-goal "no model eval" honored — Task 2 covers only the static subset.
+
+**Placeholders:** Task 2 Step 3 and Task 6 Step 5 depend on findings not yet known, which is inherent to a bug hunt; both name the exact command that produces the list. Task 2's `test_prompts_reference_only_tools_that_exist` body is elided — implement by extracting `` `name()` `` and `name(` tokens from prompt text and intersecting with the tool registry.
+
+**Type consistency:** `ProviderRejection(status, message)` used identically in Tasks 3 and 4. `_ts_union_ops` / `_switch_case_ops` signatures match between Task 1 Steps 1 and 3. `_OP_REGISTRY` referenced consistently.

--- a/docs/superpowers/specs/2026-08-11-ai-mcp-test-harness-design.md
+++ b/docs/superpowers/specs/2026-08-11-ai-mcp-test-harness-design.md
@@ -1,0 +1,224 @@
+# AI + MCP Test Harness — Design
+
+**Date:** 2026-08-11
+**Status:** Approved, pending implementation
+**Tracking issue:** #1560 (one of the bugs this harness is built to catch)
+
+## Problem
+
+FiestaBoard's AI and MCP features have accumulated silent breakage. Two
+defects found in the last 48 hours establish the pattern:
+
+- **#1561** — `set_active_page` and `set_schedule_mode` called
+  `ConfigManager` / `ScheduleService` methods that *have never existed*.
+  Both tools were complete no-ops in every release shipped. `set_schedule_mode`
+  was never even reported by a user; it was found by a wiring analyzer.
+  The existing test passed because `MagicMock()` conjures any attribute on
+  access, so it asserted that production code called a method that does
+  not exist — and agreed with it.
+- **#1560** — `_openai_body()` unconditionally sends
+  `response_format: {"type": "json_object"}`. LM Studio validates that field
+  and returns HTTP 400. Every AI page generation fails against an LM Studio
+  provider. The mock LLM in `integration-tests/mock-llm/server.py` accepts
+  any body, so no test noticed.
+
+Both are the same failure of method: **the tests assert against a stand-in
+that agrees with the code, instead of against something that can say no.**
+
+The features are also under-covered in absolute terms. `mcp.spec.ts` has 5
+tests and exercises 1 of 28 tools. The 5 MCP prompts and 6 MCP resources have
+zero coverage of any kind.
+
+## Goals
+
+1. Build test infrastructure that catches this class of rot permanently, in CI.
+2. Run it, triage what it finds, and fix the bugs it surfaces.
+3. Be able to state, with evidence, that FiestaBoard's MCP skills work.
+
+## Non-goals
+
+- Calling real LLM providers. The matrix is emulated; hermetic and free.
+- Putting a real model in the loop to test tool *selection*. See
+  "Known limits" — this is an eval, not a test, and is explicitly deferred.
+- Refactoring `chat.py` or `mcp_server.py` beyond what a specific fix requires.
+- Any endpoint outside the AI and MCP surfaces.
+
+## The bug model
+
+Every known and suspected defect falls into one of five classes. The harness
+gets one layer per class, so a finding always maps to the layer that owns it.
+
+| Class | Description | Evidence | Why existing tests miss it |
+|---|---|---|---|
+| **A** | Wiring drift — calling a method that moved or never existed | #1561 | `MagicMock()` conjures the method |
+| **B** | Provider-compat drift — request body a real provider rejects | #1560 | mock-llm accepts any body |
+| **C** | Contract drift — an op handled on one surface, unhandled on another | `labelFor` (confirmed, below) | no cross-language exhaustiveness check |
+| **D** | Semantic no-op — call returns success, state unchanged | #1561 `set_schedule_mode` | assertions on mocks, never on state |
+| **E** | Shape drift — flagship assumptions surviving the W×H Note Arrays refactor (#1185) | suspected | AI tests hardcode `flagship` |
+
+### Class C, confirmed before implementation
+
+`web/src/components/ai-chat-panel.tsx:734` — `labelFor(call): string` is a
+`switch` over `call.op` with no `default`. The `ToolCall` union
+(`web/src/lib/ai-chat-types.ts:163`) declares 19 ops; `labelFor` handles 15.
+Missing: `navigate_to_schedule`, `enable_plugin`, `disable_plugin`,
+`uninstall_plugin` — all emittable by the backend. Those four return
+`undefined` from a function typed `string`.
+
+The same four are present in `global-ai-chat-drawer.tsx`, so the drawer
+surface handles them and the editor panel does not.
+
+## Architecture — five layers
+
+### Layer 1 — Contract analyzers
+
+**Where:** `tests/` (pytest). No container. Milliseconds.
+**Catches:** C, plus the static half of MCP skill quality.
+
+Extends the source-parsing approach already proven in
+`tests/test_service_wiring.py`. Each analyzer resolves names across
+language boundaries and fails on drift:
+
+- `src/ai/chat_ops.py` op registry ↔ `web/src/lib/ai-chat-types.ts` `ToolCall`
+  union ↔ every consuming `switch` in the web client. This is the analyzer
+  that catches `labelFor`.
+- The tool list `src/ai/prompt_builder.py` advertises to the model ↔ ops with
+  real handlers. A tool the prompt sells but nothing implements means the
+  model emits it and nothing happens.
+- MCP tools that delegate to REST handlers ↔ those handlers' real signatures.
+- **MCP skill quality (static):** every tool has a non-empty description;
+  every parameter is typed and described; every prompt references only tools
+  that exist in the live registry; no prompt cites board dimensions
+  contradicted by the device it targets.
+
+Every analyzer carries meta-tests proving it fails on a known-bad input and
+enforcing a floor on resolved-symbol count, so it fails loudly rather than
+passing on zero checks. This mirrors what `test_service_wiring.py` does and
+is non-negotiable: an analyzer that silently checks nothing is worse than no
+analyzer.
+
+### Layer 2 — Provider conformance matrix
+
+**Where:** `tests/ai/` (pytest). Hermetic.
+**Catches:** B.
+
+A `ProviderEmulator` per provider family, each encoding that provider's
+*actual* request validation, sourced from provider docs and bug reports:
+
+| Emulator | Key validation encoded |
+|---|---|
+| OpenAI | accepts `json_object`; `max_tokens` deprecation surface |
+| OpenRouter | accepts `json_object` |
+| **LM Studio** | **rejects `response_format.type` not in `{json_schema, text}` → 400** |
+| Ollama | ignores unknown fields; `/v1` path prefix behavior |
+| vLLM | OpenAI-compatible subset |
+| Anthropic | `x-api-key`, `anthropic-version` required; `system` top-level; no `response_format` |
+
+Every outbound body FiestaBoard constructs — generator and chat, streaming
+and non-streaming — is run through every emulator's validator. #1560 becomes
+a one-line failing test against `LMStudioEmulator`.
+
+`integration-tests/mock-llm/server.py` gains a **provider personality** mode
+driven by the same validators, so the existing `ai.spec.ts` E2E suite runs
+against a mock that refuses requests the way LM Studio refuses them. The mock
+stops being permissive.
+
+### Layer 3 — MCP over real transport, against real state
+
+**Where:** `tests/` (pytest) driving the real ASGI app.
+**Catches:** A, D.
+
+Real JSON-RPC over streamable HTTP, real services on a tmp config, **no
+service mocks**. For each of the 28 tools: read → mutate → **re-read and
+assert observable state changed**.
+
+Because nothing is mocked, a phantom method raises instead of being conjured
+(closing A) and a tool that returns `{"status": "ok"}` while writing nothing
+fails its re-read assertion (closing D). Both #1561 bugs would have been
+caught here independently of the wiring analyzer.
+
+### Layer 4 — Browser apply-loop
+
+**Where:** `web/tests/ai.spec.ts` (Playwright), existing `ai-mcp-e2e-tests` CI job.
+**Catches:** C at runtime, D in the AI path.
+
+`mock-llm` gains a `script` scenario that emits a caller-chosen op verbatim.
+Playwright then drives the real chat panel on **both** surfaces (`editor` and
+`global` — they have different handler sets, per the `labelFor` finding) and
+asserts the page, schedule, or collection actually mutated.
+
+### Layer 5 — Skill scenarios
+
+**Where:** `web/tests/mcp.spec.ts` (extends the existing 5 tests).
+**Catches:** the gap between "each tool is correct" and "skills work."
+
+- **Protocol lifecycle:** `initialize` → `tools/list` → `prompts/list` →
+  `resources/list`, plus session handling.
+- **All 5 prompts executed and validated:** `setup_fiestaboard`,
+  `create_display_page`, `schedule_my_day`, `build_a_collection`,
+  `troubleshoot_display`. These are the skill definitions; they currently
+  have zero coverage. A prompt instructing a model to call a renamed tool
+  fails silently today.
+- **All 6 resources fetched and validated:** `fiestaboard://plugins`,
+  `://pages`, `://page/{page_id}/preview.html`, `://variables`,
+  `://schedules`, `://collections`.
+- **Multi-tool task chains:** the flows the prompts describe, executed
+  end-to-end, asserting final board/config state. Individual tool correctness
+  does not prove a chain completes — state produced by tool 3 has to be
+  shaped correctly for tool 5.
+
+## Known limits
+
+**Tool selection is not covered.** Whether a model chooses the right tool
+from its description is probabilistic and requires a real model in the loop.
+That is an eval, not a test. Layers 1–5 prove a chain works *when executed
+correctly*; they cannot prove Claude will choose to execute it. Layer 1's
+static skill-quality checks flag the cases where selection obviously could
+not work (missing description, undescribed parameter, prompt citing a
+nonexistent tool), which is the deterministic subset of the problem.
+
+A model-in-the-loop eval is scoped as separate follow-up work.
+
+## Execution plan
+
+1. Build layers 1–5, in order. Layers are independent, so each lands as its
+   **own PR** — five harness PRs, not one. Ordering is by cost-to-value:
+   Layer 1 is nearly free and already has a confirmed finding, Layer 2 has a
+   confirmed finding in #1560, Layer 3 covers the surface with the most
+   suspected bugs, Layers 4–5 are the expensive container-bound ones.
+2. Run each layer as it lands. Triage failures into a ranked findings list,
+   each tagged with its bug class and owning layer.
+3. Then **one PR per confirmed bug**.
+4. Each fix is written test-first against the layer that caught it, per the
+   repo's test quality bar: watch the test fail for the right reason before
+   writing the fix, and put the observed failure output in the PR description.
+
+A harness layer PR may land with its own findings still red only if the
+failing assertions are marked as known-failing with an issue reference;
+otherwise the layer PR includes the fix. This keeps `main` green while the
+findings list is worked through.
+
+Known work items already identified, to be confirmed by the harness:
+
+- #1560 — `response_format` hardcoded to `json_object` (class B)
+- `labelFor` non-exhaustive switch, 4 ops unhandled (class C)
+
+## CI integration
+
+No new top-level job. Layers 1–3 join the existing `test-platform` pytest
+run. Layers 4–5 extend the existing `ai-mcp-e2e-tests` job, which already
+builds the image, starts `mock-llm` + FiestaBoard containers, probes the MCP
+mount, and runs `ai.spec.ts mcp.spec.ts`. The job's 12-minute timeout and
+8-minute test timeout may need raising as Layer 5 lands.
+
+## Testing the harness itself
+
+Per the repo's test quality bar, coverage is not proof, and a harness built
+to catch rot must itself be proven non-vacuous:
+
+- Every Layer 1 analyzer has a meta-test feeding it known-bad input and
+  asserting it fails, plus a floor on symbols resolved.
+- Every Layer 2 emulator has a test asserting it *rejects* the bodies it
+  should reject — an emulator that accepts everything is the bug we are
+  fixing, re-introduced.
+- Layer 3 assertions are on re-read state, never on call records.

--- a/integration-tests/mock-llm/server.py
+++ b/integration-tests/mock-llm/server.py
@@ -23,6 +23,33 @@ Mock control:
     GET  /mock/state       — return request history + current scenario
     POST /mock/reset       — clear history; reset scenario to "ok"
     POST /mock/scenario    — body {"scenario": "<name>"}; persist for later requests
+    POST /mock/provider    — body {"provider": "<name>"}; emulate that provider's
+                             request validation (see PROVIDERS below)
+    POST /mock/script      — body {"prose": str?, "ops": [ {...}, ... ]}; the next
+                             chat completion returns this content verbatim
+
+Provider personalities
+----------------------
+
+By default the mock is ``permissive``: it accepts any well-formed body. That
+is what let #1560 ship — the generator hardcoded
+``response_format: {"type": "json_object"}``, LM Studio rejects it with a
+400, and no test noticed because this server said yes to everything.
+
+``POST /mock/provider`` switches on validation matching a real provider, so a
+body that would 400 in production 400s here. The rules mirror
+``tests/ai/provider_emulators.py``, which is the canonical source and carries
+the citations; ``tests/test_mock_llm_provider_parity.py`` fails if the two
+drift apart.
+
+Streaming
+---------
+
+``/v1/chat/completions`` honors ``"stream": true`` and replies with an
+OpenAI-style SSE stream (``data: {choices:[{delta:{content}}]}`` lines
+terminated by ``data: [DONE]``), which is what ``src/ai/chat.py`` consumes.
+Combined with ``/mock/script`` this lets a test drive the real chat panel and
+choose exactly which tool ops the "model" emits.
 
 Env vars
 --------
@@ -50,7 +77,39 @@ VALID_SCENARIOS = (
     "auth_error",
     "server_error",
     "echo_prompt",
+    # Returns whatever POST /mock/script staged, verbatim. Used by the
+    # browser apply-loop tests to pick which tool ops the model "emits".
+    "script",
 )
+
+# Per-provider request validation. Mirrors tests/ai/provider_emulators.py —
+# that module is canonical and carries the source citations for each rule.
+# "permissive" is the default so existing tests keep their meaning.
+#
+#   response_formats: allowed response_format.type values; None = not validated
+#   requires_auth:    reject when no Authorization: Bearer header is present
+#   flat_error:       error envelope is {"error": "..."} not {"error": {...}}
+PROVIDERS = {
+    "permissive": {"response_formats": None, "requires_auth": False, "flat_error": False},
+    "openai": {
+        "response_formats": {"text", "json_object", "json_schema"},
+        "requires_auth": True,
+        "flat_error": False,
+    },
+    "openrouter": {
+        "response_formats": {"text", "json_object", "json_schema"},
+        "requires_auth": True,
+        "flat_error": False,
+    },
+    # The #1560 provider: rejects json_object, and reports errors as a flat string.
+    "lmstudio": {"response_formats": {"json_schema", "text"}, "requires_auth": False, "flat_error": True},
+    "ollama": {"response_formats": {"text", "json_object"}, "requires_auth": False, "flat_error": False},
+    "vllm": {
+        "response_formats": {"text", "json_object", "json_schema"},
+        "requires_auth": False,
+        "flat_error": False,
+    },
+}
 
 # A page payload the FiestaBoard generator will accept for a flagship board.
 # 6 rows × ≤22 cols, all required fields present.
@@ -88,12 +147,24 @@ class MockLLMState:
     def reset(self) -> None:
         with self._lock:
             self.scenario = "ok"
+            self.provider = "permissive"
+            self.script: dict | None = None
             self.history: list[dict] = []
             self.request_count = 0
 
     def set_scenario(self, scenario: str) -> None:
         with self._lock:
             self.scenario = scenario
+
+    def set_provider(self, provider: str) -> None:
+        with self._lock:
+            self.provider = provider
+
+    def set_script(self, script: dict) -> None:
+        """Stage the content the next chat completion returns, and arm it."""
+        with self._lock:
+            self.script = script
+            self.scenario = "script"
 
     def record_request(self, body: dict, headers: dict) -> None:
         with self._lock:
@@ -120,6 +191,8 @@ class MockLLMState:
         with self._lock:
             return {
                 "scenario": self.scenario,
+                "provider": self.provider,
+                "script": self.script,
                 "request_count": self.request_count,
                 "history": self.history[-10:],
             }
@@ -158,6 +231,49 @@ def _last_user_prompt(messages: list[dict]) -> str:
     return ""
 
 
+def _provider_rejection(provider: str, body: dict, headers: dict) -> tuple[int, dict] | None:
+    """Emulate a real provider's request validation.
+
+    Returns ``(status, error_body)`` when the provider would refuse, else None.
+    """
+    rules = PROVIDERS.get(provider) or PROVIDERS["permissive"]
+
+    def err(status: int, message: str) -> tuple[int, dict]:
+        if rules["flat_error"]:
+            return status, {"error": message}
+        return status, {"error": {"message": message, "type": "invalid_request_error"}}
+
+    lower = {k.lower(): v for k, v in headers.items()}
+    if rules["requires_auth"] and not str(lower.get("authorization", "")).startswith("Bearer "):
+        return err(401, "Missing bearer credentials.")
+
+    allowed = rules["response_formats"]
+    rf = body.get("response_format")
+    if allowed and rf is not None:
+        if not isinstance(rf, dict) or "type" not in rf:
+            return err(400, "'response_format' must be an object with a 'type'")
+        if rf["type"] not in allowed:
+            expected = " or ".join(f"'{v}'" for v in sorted(allowed))
+            return err(400, f"'response_format.type' must be {expected}")
+    return None
+
+
+def _scripted_content(script: dict | None) -> str:
+    """Render a staged script into assistant text.
+
+    Each op becomes a ``fiestaboard`` fenced JSON block, which is the tool
+    grammar ``src/ai/chat_ops.py`` parses out of the prose.
+    """
+    script = script or {}
+    parts: list[str] = []
+    prose = script.get("prose")
+    if isinstance(prose, str) and prose:
+        parts.append(prose)
+    for op in script.get("ops") or []:
+        parts.append("```fiestaboard\n" + json.dumps(op) + "\n```")
+    return "\n\n".join(parts) if parts else "Nothing staged."
+
+
 def _content_for_scenario(scenario: str, body: dict) -> tuple[int, dict]:
     """Return (http_status, response_body) for the given scenario."""
     model = body.get("model", "mock-model")
@@ -182,6 +298,9 @@ def _content_for_scenario(scenario: str, body: dict) -> tuple[int, dict]:
         page = dict(_DEFAULT_PAGE)
         page["name"] = f"Echo: {_last_user_prompt(body.get('messages') or [])[:60]}"
         return 200, _make_chat_completion(json.dumps(page), model=model)
+
+    if scenario == "script":
+        return 200, _make_chat_completion(_scripted_content(STATE.script), model=model)
 
     # "ok" — the default happy path.
     return 200, _make_chat_completion(json.dumps(_DEFAULT_PAGE), model=model)
@@ -213,6 +332,42 @@ class Handler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
+    def _send_sse_completion(self, content: str, *, model: str) -> None:
+        """Stream `content` as OpenAI-style SSE deltas.
+
+        This is the format ``src/ai/chat.py::_iter_provider_stream`` consumes:
+        ``data: {"choices":[{"delta":{"content": "..."}}]}`` lines, then
+        ``data: [DONE]``. Chunked deliberately so the fence parser in chat.py
+        is exercised across delta boundaries rather than handed one blob —
+        that split is where a streaming tool-block parser actually breaks.
+        """
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.end_headers()
+
+        chunk_size = 24
+        for i in range(0, len(content), chunk_size):
+            frame = {
+                "id": f"chatcmpl-{int(time.time() * 1000)}",
+                "object": "chat.completion.chunk",
+                "model": model,
+                "choices": [{"index": 0, "delta": {"content": content[i : i + chunk_size]}}],
+            }
+            self.wfile.write(f"data: {json.dumps(frame)}\n\n".encode())
+            self.wfile.flush()
+
+        final = {
+            "id": "chatcmpl-final",
+            "object": "chat.completion.chunk",
+            "model": model,
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 42, "completion_tokens": 17, "total_tokens": 59},
+        }
+        self.wfile.write(f"data: {json.dumps(final)}\n\n".encode())
+        self.wfile.write(b"data: [DONE]\n\n")
+        self.wfile.flush()
+
     # ----- routes ----------------------------------------------------------
 
     def do_GET(self) -> None:  # noqa: N802 — stdlib name
@@ -229,7 +384,19 @@ class Handler(BaseHTTPRequestHandler):
             body = self._read_json()
             headers = {k: v for k, v in self.headers.items()}
             STATE.record_request(body, headers)
+
+            # Provider validation runs first: a real server rejects the request
+            # before it ever reaches a model, so scenarios must not mask it.
+            rejection = _provider_rejection(STATE.provider, body, headers)
+            if rejection is not None:
+                self._send_json(*rejection)
+                return
+
             status, payload = _content_for_scenario(STATE.scenario, body)
+            if status == 200 and body.get("stream"):
+                content = payload["choices"][0]["message"]["content"]
+                self._send_sse_completion(content, model=body.get("model", "mock-model"))
+                return
             self._send_json(status, payload)
             return
 
@@ -256,6 +423,29 @@ class Handler(BaseHTTPRequestHandler):
                 return
             STATE.set_scenario(scenario)
             self._send_json(200, {"status": "ok", "scenario": scenario})
+            return
+
+        if self.path == "/mock/provider":
+            body = self._read_json()
+            provider = body.get("provider")
+            if provider not in PROVIDERS:
+                self._send_json(
+                    400,
+                    {"error": {"message": (f"Unknown provider {provider!r}. Valid: {sorted(PROVIDERS)}")}},
+                )
+                return
+            STATE.set_provider(provider)
+            self._send_json(200, {"status": "ok", "provider": provider})
+            return
+
+        if self.path == "/mock/script":
+            body = self._read_json()
+            ops = body.get("ops")
+            if ops is not None and not isinstance(ops, list):
+                self._send_json(400, {"error": {"message": "'ops' must be an array."}})
+                return
+            STATE.set_script({"prose": body.get("prose"), "ops": ops or []})
+            self._send_json(200, {"status": "ok", "scenario": "script", "ops": len(ops or [])})
             return
 
         self._send_json(404, {"error": {"message": "Not found"}})

--- a/src/ai/protocols.py
+++ b/src/ai/protocols.py
@@ -67,9 +67,18 @@ def _openai_body(
         "messages": messages,
         "temperature": temperature,
         "max_tokens": max_tokens,
-        # Honored by OpenAI / OpenRouter / many local servers; ignored
-        # silently by the rest. Prompt also asks for JSON explicitly.
-        "response_format": {"type": "json_object"},
+        # "text", not "json_object" (#1560). The previous comment here
+        # assumed servers that don't implement json_object ignore it. LM
+        # Studio doesn't — it validates the field and 400s the request, so
+        # a provider this repo lists as supported was hard-blocked from
+        # page generation with no setting that could unblock it.
+        #
+        # "text" is the portable choice: the prompt asks for JSON
+        # explicitly and _extract_json_object() in generator.py recovers it
+        # from raw, fenced, or prose-wrapped output regardless. chat.py has
+        # stripped this field since it shipped, which is why chat already
+        # worked against LM Studio while generation did not.
+        "response_format": {"type": "text"},
     }
 
 
@@ -107,6 +116,13 @@ def _openai_error(api_response: dict[str, Any]) -> str | None:
         msg = err.get("message")
         if isinstance(msg, str):
             return msg
+        return None
+    # LM Studio returns a flat string — {"error": "..."} — rather than
+    # OpenAI's {"error": {"message": ...}}. Without this branch every LM
+    # Studio failure returned None here and generator.py fell back to
+    # dumping the raw response body into the user-facing message.
+    if isinstance(err, str) and err.strip():
+        return err
     return None
 
 

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -48,7 +48,9 @@ including why claude.ai web Connectors can't reach a LAN host.
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Annotated, Any
+
+from pydantic import Field
 
 logger = logging.getLogger(__name__)
 
@@ -1178,8 +1180,17 @@ def _build_mcp_server() -> Any:
         )
 
     @mcp.prompt()
-    def create_display_page(topic: str = "weather") -> str:
-        """Create a new display page for a specific topic."""
+    def create_display_page(
+        topic: Annotated[
+            str,
+            Field(description="What the page should show, e.g. 'weather', 'my commute', 'stock prices'."),
+        ] = "weather",
+    ) -> str:
+        """Create a new display page for a specific topic.
+
+        Args:
+            topic: What the page should show, e.g. "weather", "my commute".
+        """
         return (
             f"Help me create a FiestaBoard display page for: {topic}\n\n"
             "Please:\n"

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -527,12 +527,24 @@ def _build_mcp_server() -> Any:
             from .pages.service import get_page_service
 
             svc = get_page_service()
-            data = PageUpdate(
-                name=name,
-                template=template_lines,
-                duration_seconds=duration_seconds,
-            )
-            page = svc.update_page(page_id, data)
+            # Only pass fields the caller actually supplied. PageService.update_page
+            # merges with model_dump(exclude_unset=True), and "unset" means *not
+            # passed to the constructor* — an explicit None counts as set. Passing
+            # name/template/duration unconditionally therefore sent template=None on
+            # every partial update, wiping the template and failing validation with
+            # "Template page requires template content". Renaming a page or changing
+            # its duration over MCP was impossible.
+            fields: dict[str, Any] = {}
+            if name is not None:
+                fields["name"] = name
+            if template_lines is not None:
+                fields["template"] = template_lines
+            if duration_seconds is not None:
+                fields["duration_seconds"] = duration_seconds
+            if not fields:
+                return _err("Nothing to update: pass at least one of name, template_lines, duration_seconds.")
+
+            page = svc.update_page(page_id, PageUpdate(**fields))
             if page is None:
                 return _err(f"Page '{page_id}' not found.")
             return _ok(f"Page '{page_id}' updated.", page_id=page.id, name=page.name)
@@ -554,9 +566,21 @@ def _build_mcp_server() -> Any:
 
             svc = get_page_service()
             result = svc.delete_page(page_id)
-            if not result.success:
-                return _err(f"Error deleting page: {result.message}")
-            return _ok(f"Page '{page_id}' deleted successfully.", page_id=page_id)
+            # DeleteResult exposes `deleted`, not `success`, and has no
+            # `message`. Reading `result.success` raised AttributeError, which
+            # this tool caught and returned as an error string — so delete_page
+            # never deleted anything over MCP. Same drift as #1559/#1561: the
+            # REST handler was updated (api_server.py uses result.deleted) and
+            # this call site was left behind.
+            if not result.deleted:
+                return _err(f"Page '{page_id}' was not deleted (it may not exist).")
+            return _ok(
+                f"Page '{page_id}' deleted successfully.",
+                page_id=page_id,
+                default_page_created=result.default_page_created,
+                new_page_id=result.new_page_id,
+                active_page_updated=result.active_page_updated,
+            )
         except Exception as exc:
             return _err(f"Error deleting page '{page_id}': {exc}")
 

--- a/tests/ai/provider_emulators.py
+++ b/tests/ai/provider_emulators.py
@@ -1,0 +1,249 @@
+"""Emulators for the request validation real LLM providers actually perform.
+
+Why this exists
+---------------
+
+``integration-tests/mock-llm/server.py`` accepts any well-formed body. That
+is what let #1560 ship: ``_openai_body()`` hardcodes
+``response_format: {"type": "json_object"}``, LM Studio validates that field
+and returns HTTP 400, and every AI page generation against an LM Studio
+provider fails. No test noticed, because nothing in the suite could say no.
+
+A mock that agrees with whatever you send it cannot tell you the wire format
+is wrong. These emulators are the opposite: each one encodes what a specific
+provider *rejects*, so an outbound body that would 400 in production 400s in
+the test suite instead.
+
+Scope and honesty
+-----------------
+
+These are emulators, not the real services. They encode the validation rules
+we have evidence for — from provider documentation and from bug reports
+against this repo — and nothing more. An emulator accepting a body is
+evidence that the body does not trip a *known* rule, not proof the provider
+will accept it. Each rule below cites its source.
+
+Every emulator is paired with a test asserting it rejects what it should
+reject. An emulator that accepts everything is the bug being fixed,
+re-introduced one layer down.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class ProviderRejection(Exception):
+    """A provider refused the request.
+
+    Carries the status and the provider's own error envelope so tests can
+    assert on how FiestaBoard surfaces it, not just that it failed.
+    """
+
+    def __init__(self, status: int, message: str, body: dict[str, Any]) -> None:
+        super().__init__(f"{status}: {message}")
+        self.status = status
+        self.message = message
+        self.body = body
+
+
+@dataclass(frozen=True)
+class ProviderEmulator:
+    """Base emulator. Subclasses override :meth:`validate`."""
+
+    name: str = "base"
+    protocol: str = "openai"
+
+    def error_body(self, message: str) -> dict[str, Any]:
+        """The provider's error envelope shape."""
+        return {"error": {"message": message, "type": "invalid_request_error"}}
+
+    def reject(self, status: int, message: str) -> None:
+        raise ProviderRejection(status, message, self.error_body(message))
+
+    def validate(self, body: dict[str, Any], headers: dict[str, str]) -> None:
+        """Raise :class:`ProviderRejection` if this provider would refuse."""
+        raise NotImplementedError
+
+
+# ---------------------------------------------------------------------------
+# OpenAI-compatible family
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _OpenAICompatible(ProviderEmulator):
+    """Validation shared by every server speaking /chat/completions.
+
+    Source: OpenAI Chat Completions API reference — ``model`` and ``messages``
+    are required; ``messages`` entries require ``role`` and ``content``.
+    """
+
+    name: str = "openai-compatible"
+    protocol: str = "openai"
+    #: response_format.type values this server accepts. Empty set = the field
+    #: is ignored entirely rather than validated.
+    allowed_response_formats: frozenset[str] = field(default_factory=frozenset)
+    requires_auth: bool = True
+
+    def validate(self, body: dict[str, Any], headers: dict[str, str]) -> None:
+        lower = {k.lower(): v for k, v in headers.items()}
+
+        if self.requires_auth and not lower.get("authorization", "").startswith("Bearer "):
+            self.reject(401, "Missing bearer credentials.")
+
+        if not body.get("model"):
+            self.reject(400, "'model' is a required property")
+        if not isinstance(body.get("messages"), list):
+            self.reject(400, "'messages' is a required property")
+        for i, msg in enumerate(body.get("messages") or []):
+            if not isinstance(msg, dict) or "role" not in msg or "content" not in msg:
+                self.reject(400, f"messages[{i}] must have 'role' and 'content'")
+
+        rf = body.get("response_format")
+        if rf is not None and self.allowed_response_formats:
+            if not isinstance(rf, dict) or "type" not in rf:
+                self.reject(400, "'response_format' must be an object with a 'type'")
+            if rf["type"] not in self.allowed_response_formats:
+                allowed = " or ".join(f"'{v}'" for v in sorted(self.allowed_response_formats))
+                self.reject(400, f"'response_format.type' must be {allowed}")
+
+
+@dataclass(frozen=True)
+class OpenAIEmulator(_OpenAICompatible):
+    """OpenAI proper.
+
+    Source: OpenAI docs — ``response_format`` accepts ``text``,
+    ``json_object`` and ``json_schema``.
+    """
+
+    name: str = "openai"
+    allowed_response_formats: frozenset[str] = frozenset({"text", "json_object", "json_schema"})
+
+
+@dataclass(frozen=True)
+class OpenRouterEmulator(_OpenAICompatible):
+    """OpenRouter. Proxies to many models; mirrors OpenAI's surface."""
+
+    name: str = "openrouter"
+    allowed_response_formats: frozenset[str] = frozenset({"text", "json_object", "json_schema"})
+
+
+@dataclass(frozen=True)
+class LMStudioEmulator(_OpenAICompatible):
+    """LM Studio's local OpenAI-compatible server.
+
+    Source: Fiestaboard/FiestaBoard#1560. LM Studio validates
+    ``response_format.type`` and rejects anything other than ``json_schema``
+    or ``text``::
+
+        {"error":"'response_format.type' must be 'json_schema' or 'text'"}
+
+    Note the envelope: LM Studio returns ``error`` as a flat **string**, not
+    the ``{"error": {"message": ...}}`` object OpenAI uses. That matters —
+    ``src.ai.protocols._openai_error`` only reads the object form, so it
+    returns None here and the generator falls back to dumping the raw
+    response body at ``generator.py:391``.
+
+    Local server: no API key required.
+    """
+
+    name: str = "lmstudio"
+    allowed_response_formats: frozenset[str] = frozenset({"json_schema", "text"})
+    requires_auth: bool = False
+
+    def error_body(self, message: str) -> dict[str, Any]:
+        return {"error": message}
+
+
+@dataclass(frozen=True)
+class OllamaEmulator(_OpenAICompatible):
+    """Ollama's ``/v1`` OpenAI-compatibility layer.
+
+    Source: Ollama OpenAI-compatibility docs — supports ``response_format``
+    with ``json_object``, and ignores parameters it does not implement rather
+    than rejecting them. Local server: no API key required.
+    """
+
+    name: str = "ollama"
+    allowed_response_formats: frozenset[str] = frozenset({"text", "json_object"})
+    requires_auth: bool = False
+
+
+@dataclass(frozen=True)
+class VLLMEmulator(_OpenAICompatible):
+    """vLLM's OpenAI-compatible server.
+
+    Source: vLLM docs — implements ``response_format`` with ``json_object``
+    and ``json_schema`` via guided decoding.
+    """
+
+    name: str = "vllm"
+    allowed_response_formats: frozenset[str] = frozenset({"text", "json_object", "json_schema"})
+    requires_auth: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Anthropic Messages API
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AnthropicEmulator(ProviderEmulator):
+    """Anthropic's native Messages API.
+
+    Source: Anthropic Messages API reference —
+
+    - auth via ``x-api-key``, not ``Authorization: Bearer``
+    - ``anthropic-version`` header is required
+    - ``max_tokens`` is required
+    - ``messages`` roles are limited to ``user``/``assistant``; the system
+      prompt is a top-level ``system`` field
+    - unknown top-level parameters are rejected as ``invalid_request_error``,
+      which is why sending OpenAI's ``response_format`` here is a bug
+    """
+
+    name: str = "anthropic"
+    protocol: str = "anthropic"
+
+    def validate(self, body: dict[str, Any], headers: dict[str, str]) -> None:
+        lower = {k.lower(): v for k, v in headers.items()}
+
+        if not lower.get("x-api-key"):
+            self.reject(401, "missing x-api-key header")
+        if not lower.get("anthropic-version"):
+            self.reject(400, "missing anthropic-version header")
+
+        if not body.get("model"):
+            self.reject(400, "model: field required")
+        if not isinstance(body.get("messages"), list):
+            self.reject(400, "messages: field required")
+        if not isinstance(body.get("max_tokens"), int):
+            self.reject(400, "max_tokens: field required")
+
+        for i, msg in enumerate(body.get("messages") or []):
+            role = msg.get("role") if isinstance(msg, dict) else None
+            if role not in ("user", "assistant"):
+                self.reject(400, f"messages.{i}.role: must be 'user' or 'assistant'")
+
+        if "response_format" in body:
+            self.reject(400, "response_format: extra fields not permitted")
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+OPENAI_FAMILY: list[ProviderEmulator] = [
+    OpenAIEmulator(),
+    OpenRouterEmulator(),
+    LMStudioEmulator(),
+    OllamaEmulator(),
+    VLLMEmulator(),
+]
+
+ALL_EMULATORS: list[ProviderEmulator] = [*OPENAI_FAMILY, AnthropicEmulator()]
+
+BY_NAME: dict[str, ProviderEmulator] = {e.name: e for e in ALL_EMULATORS}

--- a/tests/ai/test_protocols.py
+++ b/tests/ai/test_protocols.py
@@ -65,7 +65,16 @@ def test_openai_headers_omit_auth_when_no_key():
     assert "Authorization" not in headers
 
 
-def test_openai_body_keeps_messages_unchanged_and_requests_json_object():
+def test_openai_body_keeps_messages_unchanged_and_requests_text_format():
+    """``text``, not ``json_object`` — see #1560.
+
+    This test previously asserted ``json_object``, pinning the assumption
+    that servers not implementing it would ignore it. LM Studio validates
+    the field and returns a 400, so that assumption was the defect. The
+    prompt asks for JSON and ``_extract_json_object()`` recovers it from
+    prose, so ``text`` is portable across the whole OpenAI-compatible
+    family.
+    """
     proto = PROTOCOLS["openai"]
     messages = [
         {"role": "system", "content": "be brief"},
@@ -75,7 +84,7 @@ def test_openai_body_keeps_messages_unchanged_and_requests_json_object():
     assert body["model"] == "gpt-4o-mini"
     assert body["messages"] == messages
     assert body["max_tokens"] == 100
-    assert body["response_format"] == {"type": "json_object"}
+    assert body["response_format"] == {"type": "text"}
 
 
 def test_openai_parse_content_string():
@@ -114,10 +123,23 @@ def test_openai_parse_usage():
 
 
 def test_openai_parse_error_extracts_message():
+    """Both envelope shapes in the OpenAI-compatible family.
+
+    The flat-string case previously asserted ``is None``, encoding LM
+    Studio's error format as unparseable. That is what made every LM Studio
+    failure surface as a raw ``response.text`` dump from
+    ``generator.py:391`` instead of the provider's own message.
+    """
     proto = PROTOCOLS["openai"]
+    # OpenAI / OpenRouter / vLLM
     assert proto.parse_error({"error": {"message": "bad key"}}) == "bad key"
-    assert proto.parse_error({"error": "string"}) is None
+    # LM Studio
+    assert proto.parse_error({"error": "bad key"}) == "bad key"
+    # Nothing usable
     assert proto.parse_error({}) is None
+    assert proto.parse_error({"error": {}}) is None
+    assert proto.parse_error({"error": "   "}) is None
+    assert proto.parse_error({"error": 42}) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ai/test_provider_conformance.py
+++ b/tests/ai/test_provider_conformance.py
@@ -1,0 +1,270 @@
+"""Every body FiestaBoard sends must be accepted by every provider it claims to support.
+
+``src/ai/protocols.py`` buckets OpenAI, OpenRouter, LM Studio, Ollama and
+vLLM under a single ``openai`` protocol, so one wire format has to satisfy
+all of them. Nothing checked that. #1560 is the result: the generator
+hardcodes ``response_format: {"type": "json_object"}``, which LM Studio
+rejects with a 400, so page generation is hard-blocked against a provider
+this repo names as supported.
+
+Two halves to this module:
+
+1. **Emulator self-tests** — prove each emulator actually rejects what it is
+   supposed to reject. An emulator that accepts everything would make the
+   conformance matrix below pass vacuously, which is the original bug one
+   layer down.
+2. **The conformance matrix** — every outbound body, against every emulator.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.ai.protocols import PROTOCOLS, get_protocol
+from tests.ai.provider_emulators import (
+    ALL_EMULATORS,
+    OPENAI_FAMILY,
+    AnthropicEmulator,
+    LMStudioEmulator,
+    OllamaEmulator,
+    OpenAIEmulator,
+    ProviderRejection,
+)
+
+MESSAGES = [
+    {"role": "system", "content": "You are a board designer."},
+    {"role": "user", "content": "A page that says hello."},
+]
+
+OPENAI_HEADERS = {"Content-Type": "application/json", "Authorization": "Bearer sk-test"}
+ANTHROPIC_HEADERS = {
+    "Content-Type": "application/json",
+    "x-api-key": "sk-ant-test",
+    "anthropic-version": "2023-06-01",
+}
+
+
+# ---------------------------------------------------------------------------
+# Emulator self-tests — each must be able to say no
+# ---------------------------------------------------------------------------
+
+
+def test_lmstudio_rejects_json_object():
+    """The #1560 rule, stated directly."""
+    with pytest.raises(ProviderRejection) as exc:
+        LMStudioEmulator().validate(
+            {"model": "m", "messages": MESSAGES, "response_format": {"type": "json_object"}},
+            {},
+        )
+    assert exc.value.status == 400
+    assert "json_schema" in exc.value.message
+
+
+def test_lmstudio_accepts_text_and_json_schema():
+    for kind in ("text", "json_schema"):
+        LMStudioEmulator().validate(
+            {"model": "m", "messages": MESSAGES, "response_format": {"type": kind}}, {}
+        )
+
+
+def test_lmstudio_error_envelope_is_a_flat_string():
+    """LM Studio returns ``{"error": "..."}``, not ``{"error": {"message": ...}}``."""
+    body = LMStudioEmulator().error_body("boom")
+    assert body == {"error": "boom"}
+
+
+def test_openai_accepts_json_object():
+    OpenAIEmulator().validate(
+        {"model": "m", "messages": MESSAGES, "response_format": {"type": "json_object"}},
+        OPENAI_HEADERS,
+    )
+
+
+def test_openai_rejects_missing_model():
+    with pytest.raises(ProviderRejection):
+        OpenAIEmulator().validate({"messages": MESSAGES}, OPENAI_HEADERS)
+
+
+def test_openai_rejects_missing_credentials():
+    with pytest.raises(ProviderRejection) as exc:
+        OpenAIEmulator().validate({"model": "m", "messages": MESSAGES}, {})
+    assert exc.value.status == 401
+
+
+def test_ollama_rejects_json_schema_it_does_not_implement():
+    with pytest.raises(ProviderRejection):
+        OllamaEmulator().validate(
+            {"model": "m", "messages": MESSAGES, "response_format": {"type": "json_schema"}}, {}
+        )
+
+
+def test_anthropic_requires_version_header():
+    with pytest.raises(ProviderRejection):
+        AnthropicEmulator().validate(
+            {"model": "m", "messages": [{"role": "user", "content": "hi"}], "max_tokens": 10},
+            {"x-api-key": "k"},
+        )
+
+
+def test_anthropic_rejects_system_role_in_messages():
+    with pytest.raises(ProviderRejection) as exc:
+        AnthropicEmulator().validate(
+            {"model": "m", "messages": MESSAGES, "max_tokens": 10},
+            ANTHROPIC_HEADERS,
+        )
+    assert "role" in exc.value.message
+
+
+def test_anthropic_rejects_response_format():
+    with pytest.raises(ProviderRejection):
+        AnthropicEmulator().validate(
+            {
+                "model": "m",
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 10,
+                "response_format": {"type": "json_object"},
+            },
+            ANTHROPIC_HEADERS,
+        )
+
+
+def test_every_emulator_rejects_a_garbage_body():
+    """Floor: no emulator is a pass-through."""
+    for emulator in ALL_EMULATORS:
+        with pytest.raises(ProviderRejection):
+            emulator.validate({}, {})
+
+
+# ---------------------------------------------------------------------------
+# Conformance: the generator's outbound body
+# ---------------------------------------------------------------------------
+
+
+def _generator_body() -> dict:
+    return PROTOCOLS["openai"].build_body("test-model", MESSAGES, 0.7, 1200)
+
+
+@pytest.mark.parametrize(
+    "emulator",
+    [
+        pytest.param(
+            e,
+            marks=pytest.mark.xfail(
+                strict=True,
+                reason=(
+                    "#1560 — _openai_body() hardcodes response_format json_object, "
+                    "which LM Studio rejects with a 400. Fix lands separately; "
+                    "strict=True so this flips loudly when it does."
+                ),
+            )
+            if e.name == "lmstudio"
+            else (),
+        )
+        for e in OPENAI_FAMILY
+    ],
+    ids=lambda e: e.name,
+)
+def test_generator_body_is_accepted_by_every_openai_compatible_provider(emulator):
+    """#1560: fails for lmstudio until ``response_format`` stops being json_object."""
+    headers = PROTOCOLS["openai"].build_headers("sk-test", {})
+    emulator.validate(_generator_body(), headers)
+
+
+def test_anthropic_generator_body_is_accepted():
+    proto = PROTOCOLS["anthropic"]
+    body = proto.build_body("claude-test", MESSAGES, 0.7, 1200)
+    headers = proto.build_headers("sk-ant-test", {})
+    AnthropicEmulator().validate(body, headers)
+
+
+def test_anthropic_body_moves_system_out_of_messages():
+    """Guards the split that keeps the Anthropic body legal."""
+    body = PROTOCOLS["anthropic"].build_body("claude-test", MESSAGES, 0.7, 1200)
+    assert body["system"] == "You are a board designer."
+    assert [m["role"] for m in body["messages"]] == ["user"]
+
+
+# ---------------------------------------------------------------------------
+# Conformance: the chat (streaming) outbound body
+# ---------------------------------------------------------------------------
+
+
+def _chat_body(protocol_name: str) -> dict:
+    """Reproduce what ``src/ai/chat.py`` puts on the wire.
+
+    Mirrors chat.py's build → ``stream = True`` → ``pop("response_format")``
+    sequence. Kept in step with the source by
+    ``test_chat_still_strips_response_format`` below, which fails if chat.py
+    stops popping the field.
+    """
+    proto = get_protocol(protocol_name)
+    payload = proto.build_body("test-model", MESSAGES, 0.7, 2000)
+    payload["stream"] = True
+    payload.pop("response_format", None)
+    return payload
+
+
+@pytest.mark.parametrize("emulator", OPENAI_FAMILY, ids=lambda e: e.name)
+def test_chat_body_is_accepted_by_every_openai_compatible_provider(emulator):
+    emulator.validate(_chat_body("openai"), PROTOCOLS["openai"].build_headers("sk-test", {}))
+
+
+def test_chat_body_is_accepted_by_anthropic():
+    AnthropicEmulator().validate(
+        _chat_body("anthropic"), PROTOCOLS["anthropic"].build_headers("sk-ant-test", {})
+    )
+
+
+def test_chat_still_strips_response_format():
+    """chat.py pops the field; if that stops, this local reproduction is stale.
+
+    Pins the asymmetry #1560 describes: chat works against LM Studio because
+    it drops ``response_format``, while the generator does not.
+    """
+    source = (
+        __import__("pathlib").Path(__file__).resolve().parents[2] / "src" / "ai" / "chat.py"
+    ).read_text(encoding="utf-8")
+    assert 'payload.pop("response_format", None)' in source, (
+        "src/ai/chat.py no longer strips response_format — _chat_body() above "
+        "no longer reproduces what chat puts on the wire."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Error-envelope handling
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "emulator",
+    [
+        pytest.param(
+            e,
+            marks=pytest.mark.xfail(
+                strict=True,
+                reason=(
+                    "_openai_error() only reads {'error': {'message': ...}}, so "
+                    "LM Studio's flat-string envelope yields None and the user "
+                    "gets a raw JSON dump. Fix lands with #1560."
+                ),
+            )
+            if e.name == "lmstudio"
+            else (),
+        )
+        for e in ALL_EMULATORS
+    ],
+    ids=lambda e: e.name,
+)
+def test_provider_error_messages_reach_the_user(emulator):
+    """``parse_error`` should extract the provider's message, whatever its shape.
+
+    When it returns None, ``generator.py:391`` falls back to dumping the raw
+    response body into the user-facing error. LM Studio's flat-string
+    envelope is the case that trips this.
+    """
+    proto = get_protocol(emulator.protocol)
+    body = emulator.error_body("Invalid API key.")
+    assert proto.parse_error(body) == "Invalid API key.", (
+        f"{emulator.name} returns {body!r}; parse_error could not extract the "
+        "message, so the user sees a raw JSON dump instead."
+    )

--- a/tests/ai/test_provider_conformance.py
+++ b/tests/ai/test_provider_conformance.py
@@ -62,9 +62,7 @@ def test_lmstudio_rejects_json_object():
 
 def test_lmstudio_accepts_text_and_json_schema():
     for kind in ("text", "json_schema"):
-        LMStudioEmulator().validate(
-            {"model": "m", "messages": MESSAGES, "response_format": {"type": kind}}, {}
-        )
+        LMStudioEmulator().validate({"model": "m", "messages": MESSAGES, "response_format": {"type": kind}}, {})
 
 
 def test_lmstudio_error_envelope_is_a_flat_string():
@@ -93,9 +91,7 @@ def test_openai_rejects_missing_credentials():
 
 def test_ollama_rejects_json_schema_it_does_not_implement():
     with pytest.raises(ProviderRejection):
-        OllamaEmulator().validate(
-            {"model": "m", "messages": MESSAGES, "response_format": {"type": "json_schema"}}, {}
-        )
+        OllamaEmulator().validate({"model": "m", "messages": MESSAGES, "response_format": {"type": "json_schema"}}, {})
 
 
 def test_anthropic_requires_version_header():
@@ -144,30 +140,43 @@ def _generator_body() -> dict:
     return PROTOCOLS["openai"].build_body("test-model", MESSAGES, 0.7, 1200)
 
 
-@pytest.mark.parametrize(
-    "emulator",
-    [
-        pytest.param(
-            e,
-            marks=pytest.mark.xfail(
-                strict=True,
-                reason=(
-                    "#1560 — _openai_body() hardcodes response_format json_object, "
-                    "which LM Studio rejects with a 400. Fix lands separately; "
-                    "strict=True so this flips loudly when it does."
-                ),
-            )
-            if e.name == "lmstudio"
-            else (),
-        )
-        for e in OPENAI_FAMILY
-    ],
-    ids=lambda e: e.name,
-)
+@pytest.mark.parametrize("emulator", OPENAI_FAMILY, ids=lambda e: e.name)
 def test_generator_body_is_accepted_by_every_openai_compatible_provider(emulator):
-    """#1560: fails for lmstudio until ``response_format`` stops being json_object."""
+    """Regression for #1560 — lmstudio is the parametrization that used to fail."""
     headers = PROTOCOLS["openai"].build_headers("sk-test", {})
     emulator.validate(_generator_body(), headers)
+
+
+def test_generator_does_not_request_json_object_mode():
+    """Pins the #1560 fix against a well-meaning revert.
+
+    LM Studio validates ``response_format.type`` and 400s on
+    ``json_object``. The prompt asks for JSON and
+    ``_extract_json_object()`` recovers it from prose, so ``text`` is the
+    portable choice.
+    """
+    assert _generator_body()["response_format"] == {"type": "text"}
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        '{"name": "A", "template": ["HI"]}',
+        '```json\n{"name": "A", "template": ["HI"]}\n```',
+        'Sure! Here is your page:\n\n{"name": "A", "template": ["HI"]}\n\nHope that helps.',
+    ],
+    ids=["bare", "fenced", "prose-wrapped"],
+)
+def test_json_is_recovered_without_json_object_mode(raw):
+    """The safety net that makes dropping ``json_object`` viable.
+
+    Without a server-enforced JSON mode a model may wrap its object in
+    prose or a markdown fence. If this ever stops holding, the #1560 fix
+    needs revisiting rather than the parser.
+    """
+    from src.ai.generator import _extract_json_object
+
+    assert _extract_json_object(raw)["name"] == "A"
 
 
 def test_anthropic_generator_body_is_accepted():
@@ -210,9 +219,7 @@ def test_chat_body_is_accepted_by_every_openai_compatible_provider(emulator):
 
 
 def test_chat_body_is_accepted_by_anthropic():
-    AnthropicEmulator().validate(
-        _chat_body("anthropic"), PROTOCOLS["anthropic"].build_headers("sk-ant-test", {})
-    )
+    AnthropicEmulator().validate(_chat_body("anthropic"), PROTOCOLS["anthropic"].build_headers("sk-ant-test", {}))
 
 
 def test_chat_still_strips_response_format():
@@ -221,9 +228,9 @@ def test_chat_still_strips_response_format():
     Pins the asymmetry #1560 describes: chat works against LM Studio because
     it drops ``response_format``, while the generator does not.
     """
-    source = (
-        __import__("pathlib").Path(__file__).resolve().parents[2] / "src" / "ai" / "chat.py"
-    ).read_text(encoding="utf-8")
+    source = (__import__("pathlib").Path(__file__).resolve().parents[2] / "src" / "ai" / "chat.py").read_text(
+        encoding="utf-8"
+    )
     assert 'payload.pop("response_format", None)' in source, (
         "src/ai/chat.py no longer strips response_format — _chat_body() above "
         "no longer reproduces what chat puts on the wire."
@@ -235,26 +242,7 @@ def test_chat_still_strips_response_format():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize(
-    "emulator",
-    [
-        pytest.param(
-            e,
-            marks=pytest.mark.xfail(
-                strict=True,
-                reason=(
-                    "_openai_error() only reads {'error': {'message': ...}}, so "
-                    "LM Studio's flat-string envelope yields None and the user "
-                    "gets a raw JSON dump. Fix lands with #1560."
-                ),
-            )
-            if e.name == "lmstudio"
-            else (),
-        )
-        for e in ALL_EMULATORS
-    ],
-    ids=lambda e: e.name,
-)
+@pytest.mark.parametrize("emulator", ALL_EMULATORS, ids=lambda e: e.name)
 def test_provider_error_messages_reach_the_user(emulator):
     """``parse_error`` should extract the provider's message, whatever its shape.
 

--- a/tests/test_ai_op_contract.py
+++ b/tests/test_ai_op_contract.py
@@ -1,0 +1,251 @@
+"""Contract test: the AI chat-op grammar must agree across every surface.
+
+The streaming chat lets the model emit ``fiestaboard`` fenced JSON blocks,
+each one an *operation* the frontend applies. Three places have to agree on
+what ops exist:
+
+1. ``src/ai/chat_ops.py`` — ``_OP_REGISTRY``, the server-side validator and
+   the source of the list the system prompt advertises to the model.
+2. ``web/src/lib/ai-chat-types.ts`` — the ``ToolCall`` discriminated union.
+3. Every ``switch (call.op)`` in the web client that consumes a ``ToolCall``.
+
+Nothing enforced that agreement, and it had already drifted. ``labelFor()``
+in ``ai-chat-panel.tsx`` is declared ``: string`` and switches on ``call.op``
+with no ``default``, but handled only 15 of the 19 ops. For
+``navigate_to_schedule``, ``enable_plugin``, ``disable_plugin`` and
+``uninstall_plugin`` — all of which the backend can emit — it fell off the
+end and returned ``undefined`` from a function typed ``string``.
+
+This is the same shape as #1559/#1561 on the MCP side: several surfaces that
+must agree, only some of them do, and no test looks across the boundary.
+
+Why a ``default`` clause matters
+--------------------------------
+
+An op-switch *with* a ``default`` is safe by construction — an unknown op
+degrades to a generic branch. ``buildToolResultText()`` in
+``global-ai-chat-drawer.tsx`` does exactly that and is fine. So the rule
+enforced here is narrow and behavioral rather than stylistic:
+
+    a switch over ``.op`` that has no ``default`` must cover every op.
+
+Why regex and not a TS parser
+-----------------------------
+
+The Python test image has no TypeScript toolchain, and shelling out to one
+would make this test depend on ``npm install`` having run. The patterns
+matched here (``op: "name"`` in a union, ``case "name":`` in a switch) are
+narrow enough to parse reliably, and the meta-tests below prove the parser
+actually resolves symbols rather than silently finding nothing.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from src.ai.chat_ops import _OP_REGISTRY, supported_ops
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WEB = REPO_ROOT / "web"
+
+TS_TYPES = WEB / "src/lib/ai-chat-types.ts"
+CHAT_PANEL = WEB / "src/components/ai-chat-panel.tsx"
+CHAT_DRAWER = WEB / "src/components/global-ai-chat-drawer.tsx"
+
+# A parse that resolves nothing passes vacuously. These floors fail loudly if
+# the source moves or the declaration style changes such that the analyzer
+# stops recognizing it, rather than quietly reporting no drift.
+MIN_UNION_OPS = 19
+MIN_SWITCH_CASES = 15
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def _match_braces(text: str, open_idx: int) -> int:
+    """Return the index just past the ``}`` closing the brace at *open_idx*.
+
+    Naive depth counting. Adequate here because the regions scanned are
+    switch bodies over string literals — the only braces are structural or
+    inside template strings, and template strings in these files are balanced.
+    """
+    depth = 0
+    for i in range(open_idx, len(text)):
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return i + 1
+    raise ValueError(f"unbalanced braces from index {open_idx}")
+
+
+def _ts_union_ops(path: Path) -> set[str]:
+    """Extract the op names declared in the ``ToolCall`` union.
+
+    Scans line-wise rather than with a single regex: each union member is
+    ``| { id: string; op: "name"; args: T }``, so a non-greedy match to the
+    first ``;`` stops inside the *first member's* braces and silently returns
+    nothing. The declaration ends at the first line whose content ends in
+    ``;`` — that is the final member.
+    """
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    start = next(
+        (i for i, ln in enumerate(lines) if re.match(r"\s*export type ToolCall\s*=", ln)),
+        None,
+    )
+    if start is None:
+        raise AssertionError(f"Could not find the `export type ToolCall` union in {path}")
+
+    collected: list[str] = []
+    for ln in lines[start:]:
+        collected.append(ln)
+        if ln.rstrip().endswith(";"):
+            break
+    else:
+        raise AssertionError(f"`export type ToolCall` in {path} is never terminated by ';'")
+
+    return set(re.findall(r'op:\s*"([a-z_]+)"', "\n".join(collected)))
+
+
+def _op_switch(path: Path, func_name: str) -> tuple[set[str], bool]:
+    """Return ``(case_ops, has_default)`` for the ``.op`` switch in *func_name*.
+
+    Locates the function, brace-matches its body, then finds the ``switch``
+    inside it that discriminates on something ending in ``.op``.
+    """
+    text = path.read_text(encoding="utf-8")
+    m = re.search(rf"function\s+{re.escape(func_name)}\s*\(", text)
+    if m is None:
+        raise AssertionError(f"Could not find function {func_name}() in {path}")
+
+    body_open = text.index("{", m.end())
+    body = text[body_open : _match_braces(text, body_open)]
+
+    sw = re.search(r"switch\s*\(\s*[A-Za-z_][\w.]*\.op\s*\)\s*\{", body)
+    if sw is None:
+        raise AssertionError(f"{func_name}() in {path} has no switch over `.op`")
+
+    block_open = body.index("{", sw.end() - 1)
+    block = body[block_open : _match_braces(body, block_open)]
+
+    cases = set(re.findall(r'case\s+"([a-z_]+)"\s*:', block))
+    has_default = re.search(r"\bdefault\s*:", block) is not None
+    return cases, has_default
+
+
+# ---------------------------------------------------------------------------
+# Meta-tests — prove the analyzer can actually fail and is not scanning air
+# ---------------------------------------------------------------------------
+
+
+def test_union_parser_resolves_a_realistic_floor():
+    assert len(_ts_union_ops(TS_TYPES)) >= MIN_UNION_OPS
+
+
+def test_switch_parser_resolves_a_realistic_floor():
+    cases, _ = _op_switch(CHAT_DRAWER, "buildToolResultText")
+    assert len(cases) >= MIN_SWITCH_CASES
+
+
+def test_union_parser_flags_a_known_bad_input(tmp_path):
+    f = tmp_path / "types.ts"
+    f.write_text(
+        'export type ToolCall =\n'
+        '  | { id: string; op: "alpha"; args: A }\n'
+        '  | { id: string; op: "beta"; args: B };\n',
+        encoding="utf-8",
+    )
+    assert _ts_union_ops(f) == {"alpha", "beta"}
+
+
+def test_switch_parser_flags_a_known_bad_input(tmp_path):
+    """A switch missing an op and missing a default must be reported as such."""
+    f = tmp_path / "panel.tsx"
+    f.write_text(
+        "function labelFor(call: ToolCall): string {\n"
+        "  switch (call.op) {\n"
+        '    case "alpha":\n'
+        '      return "A";\n'
+        "  }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    cases, has_default = _op_switch(f, "labelFor")
+    assert cases == {"alpha"}
+    assert has_default is False
+
+
+def test_switch_parser_detects_a_default_clause(tmp_path):
+    f = tmp_path / "panel.tsx"
+    f.write_text(
+        "function labelFor(call: ToolCall): string {\n"
+        "  switch (call.op) {\n"
+        '    case "alpha":\n'
+        '      return "A";\n'
+        "    default:\n"
+        '      return "?";\n'
+        "  }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    _, has_default = _op_switch(f, "labelFor")
+    assert has_default is True
+
+
+def test_missing_function_is_an_error_not_an_empty_result(tmp_path):
+    f = tmp_path / "panel.tsx"
+    f.write_text("const x = 1;\n", encoding="utf-8")
+    with pytest.raises(AssertionError):
+        _op_switch(f, "labelFor")
+
+
+# ---------------------------------------------------------------------------
+# The actual contract
+# ---------------------------------------------------------------------------
+
+
+def test_python_registry_matches_the_typescript_union():
+    py = set(_OP_REGISTRY)
+    ts = _ts_union_ops(TS_TYPES)
+    assert py == ts, (
+        "chat-op grammar has drifted between Python and TypeScript.\n"
+        f"  Python only: {sorted(py - ts)}\n"
+        f"  TypeScript only: {sorted(ts - py)}"
+    )
+
+
+def test_supported_ops_matches_the_registry():
+    """The list advertised to the model must be the list we can validate.
+
+    ``supported_ops()`` feeds the system prompt. If it drifts from
+    ``_OP_REGISTRY``, the model is either told about an op that
+    ``parse_tool_call`` will reject, or never told about one it could use.
+    """
+    assert set(supported_ops()) == set(_OP_REGISTRY)
+
+
+@pytest.mark.parametrize(
+    ("path", "func"),
+    [
+        (CHAT_PANEL, "labelFor"),
+        (CHAT_DRAWER, "buildToolResultText"),
+    ],
+    ids=["ai-chat-panel:labelFor", "global-ai-chat-drawer:buildToolResultText"],
+)
+def test_op_switches_are_exhaustive_or_have_a_default(path, func):
+    ops = _ts_union_ops(TS_TYPES)
+    cases, has_default = _op_switch(path, func)
+    if has_default:
+        pytest.skip(f"{func}() has a default clause — unknown ops degrade safely")
+    missing = ops - cases
+    assert not missing, (
+        f"{path.relative_to(REPO_ROOT)}::{func}() switches on .op with no `default` "
+        f"clause, so these ops fall through and return undefined: {sorted(missing)}"
+    )

--- a/tests/test_ai_op_contract.py
+++ b/tests/test_ai_op_contract.py
@@ -157,9 +157,7 @@ def test_switch_parser_resolves_a_realistic_floor():
 def test_union_parser_flags_a_known_bad_input(tmp_path):
     f = tmp_path / "types.ts"
     f.write_text(
-        'export type ToolCall =\n'
-        '  | { id: string; op: "alpha"; args: A }\n'
-        '  | { id: string; op: "beta"; args: B };\n',
+        'export type ToolCall =\n  | { id: string; op: "alpha"; args: A }\n  | { id: string; op: "beta"; args: B };\n',
         encoding="utf-8",
     )
     assert _ts_union_ops(f) == {"alpha", "beta"}

--- a/tests/test_mcp_prompts_and_resources.py
+++ b/tests/test_mcp_prompts_and_resources.py
@@ -1,0 +1,213 @@
+"""Every MCP prompt and resource must actually execute.
+
+The MCP surface is not 28 tools — it is 28 tools, 5 prompts and 6 resources.
+The prompts *are* the skill definitions: they are what a client invokes when a
+user picks "Set up FiestaBoard" from a menu, and their text is what steers the
+model through a multi-tool task.
+
+Before this file, no test executed a single one of them. ``prompts/list``
+returning them is not evidence they work — a prompt whose body raises, or
+which renders empty, or which instructs the model to call a tool that has
+since been renamed, fails silently and shows up only as a user saying the
+assistant got confused.
+
+Same for resources. ``fiestaboard://page/{page_id}/preview.html`` is a URI
+template that takes a real page id and renders HTML; nothing checked that it
+does.
+
+This runs the prompt and resource functions directly against real services on
+``tmp_path``, in the spirit of ``tests/test_mcp_state_effects.py``: no mocks,
+so a call into thin air raises rather than being conjured.
+
+Coverage floors below fail if a prompt or resource is added without a case
+here, so the surface cannot grow untested.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+
+pytest.importorskip("mcp", reason="mcp package not installed")
+
+from src.collections.service import CollectionService
+from src.collections.storage import CollectionStorage
+from src.config_manager import ConfigManager
+from src.mcp_server import _build_mcp_server
+from src.pages.service import PageService
+from src.pages.storage import PageStorage
+from src.schedules.service import ScheduleService
+from src.schedules.storage import ScheduleStorage
+
+EXPECTED_PROMPTS = {
+    "setup_fiestaboard",
+    "create_display_page",
+    "schedule_my_day",
+    "build_a_collection",
+    "troubleshoot_display",
+}
+
+EXPECTED_RESOURCES = {
+    "fiestaboard://plugins",
+    "fiestaboard://pages",
+    "fiestaboard://variables",
+    "fiestaboard://schedules",
+    "fiestaboard://collections",
+}
+
+EXPECTED_RESOURCE_TEMPLATES = {"fiestaboard://page/{page_id}/preview.html"}
+
+FLAGSHIP_TEMPLATE = ["HELLO", "", "", "", "", ""]
+
+
+@pytest.fixture(scope="module")
+def mcp():
+    instance = _build_mcp_server()
+    assert instance is not None, "mcp installed but _build_mcp_server() returned None"
+    return instance
+
+
+@pytest.fixture
+def services(tmp_path, monkeypatch):
+    """Real services on throwaway storage — mirrors test_mcp_state_effects."""
+    pages = PageService(PageStorage(str(tmp_path / "pages.json")))
+    schedules = ScheduleService(ScheduleStorage(str(tmp_path / "schedules.json")))
+    collections = CollectionService(CollectionStorage(str(tmp_path / "collections.json")))
+
+    ConfigManager._instance = None  # type: ignore[attr-defined]
+    config = ConfigManager(config_path=str(tmp_path / "config.json"))
+
+    monkeypatch.setattr("src.pages.service._page_service", pages)
+    monkeypatch.setattr("src.schedules.service._schedule_service", schedules)
+    monkeypatch.setattr("src.collections.service._collection_service", collections)
+    monkeypatch.setattr("src.config_manager.ConfigManager._instance", config, raising=False)
+
+    yield {"pages": pages, "schedules": schedules, "collections": collections, "config": config}
+
+    ConfigManager._instance = None  # type: ignore[attr-defined]
+
+
+def _run(value: Any) -> Any:
+    return asyncio.run(value) if asyncio.iscoroutine(value) else value
+
+
+# ---------------------------------------------------------------------------
+# Registry floors
+# ---------------------------------------------------------------------------
+
+
+def test_all_expected_prompts_are_registered(mcp):
+    assert set(mcp._prompt_manager._prompts) == EXPECTED_PROMPTS
+
+
+def test_all_expected_resources_are_registered(mcp):
+    assert set(mcp._resource_manager._resources) == EXPECTED_RESOURCES
+
+
+def test_all_expected_resource_templates_are_registered(mcp):
+    assert set(mcp._resource_manager._templates) == EXPECTED_RESOURCE_TEMPLATES
+
+
+# ---------------------------------------------------------------------------
+# Prompts must render
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("prompt_name", sorted(EXPECTED_PROMPTS))
+def test_prompt_renders_non_empty_text(mcp, services, prompt_name):
+    """A prompt that raises or renders empty is a dead menu entry."""
+    prompt = mcp._prompt_manager._prompts[prompt_name]
+    required = [a.name for a in (prompt.arguments or []) if a.required]
+    assert not required, (
+        f"{prompt_name} now has required arguments {required}; this test calls it with none, "
+        "so it needs a case supplying them"
+    )
+
+    # Optional arguments are omitted deliberately: a prompt must render
+    # usefully when a client invokes it straight off a menu with nothing filled in.
+    rendered = _run(prompt.fn())
+
+    text = rendered if isinstance(rendered, str) else json.dumps(rendered, default=str)
+    assert text and text.strip(), f"{prompt_name} rendered empty"
+    assert len(text.strip()) > 40, f"{prompt_name} rendered suspiciously little text: {text!r}"
+
+
+def test_prompt_arguments_are_described(mcp):
+    """A bare argument name is all the user sees in a client's prompt form.
+
+    MCP clients render prompt arguments as an input form, labelled from
+    ``description``. When that is None the user gets a naked field name and
+    has to guess what belongs in it.
+    """
+    undescribed: list[str] = []
+    for name, prompt in sorted(mcp._prompt_manager._prompts.items()):
+        for arg in prompt.arguments or []:
+            if not (arg.description or "").strip():
+                undescribed.append(f"{name}.{arg.name}")
+    assert not undescribed, f"prompt arguments with no description: {undescribed}"
+
+
+@pytest.mark.parametrize("prompt_name", sorted(EXPECTED_PROMPTS))
+def test_prompt_body_references_only_tools_that_exist(mcp, services, prompt_name):
+    """A prompt naming a renamed tool sends the model somewhere that isn't there.
+
+    Complements the description-level check in test_mcp_skill_quality.py —
+    this one reads the *rendered body*, which is what actually reaches the
+    model.
+    """
+    import re
+
+    known = set(mcp._tool_manager._tools)
+    # Prose that looks like a call but isn't a tool reference.
+    ignore = {"e.g", "i.e", "etc"}
+
+    rendered = _run(mcp._prompt_manager._prompts[prompt_name].fn())
+    text = rendered if isinstance(rendered, str) else json.dumps(rendered, default=str)
+
+    refs = {n for n in re.findall(r"\b([a-z_][a-z0-9_]{2,})\(\)", text) if n not in ignore}
+    dangling = sorted(refs - known)
+    assert not dangling, f"{prompt_name} tells the model to call tools that do not exist: {dangling}"
+
+
+# ---------------------------------------------------------------------------
+# Resources must read
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("uri", sorted(EXPECTED_RESOURCES))
+def test_resource_reads_and_returns_declared_mime_type(mcp, services, uri):
+    resource = mcp._resource_manager._resources[uri]
+    content = _run(resource.fn())
+
+    assert content is not None, f"{uri} returned None"
+    assert isinstance(content, str), f"{uri} returned {type(content).__name__}, expected str"
+
+    mime = (resource.mime_type or "").lower()
+    if "json" in mime:
+        json.loads(content)  # raises if the declared type is a lie
+
+
+def test_page_preview_resource_template_renders_html_for_a_real_page(mcp, services):
+    """The one URI template on the surface, exercised with a real page id."""
+    create = mcp._tool_manager._tools["create_page"].fn(
+        name="Preview Target", template_lines=FLAGSHIP_TEMPLATE, device_type="flagship"
+    )
+    page_id = create["page_id"]
+
+    template = mcp._resource_manager._templates["fiestaboard://page/{page_id}/preview.html"]
+    html = _run(template.fn(page_id=page_id))
+
+    assert isinstance(html, str) and html.strip(), "page preview resource rendered nothing"
+    assert "<" in html, "page preview resource is declared text/html but returned no markup"
+
+
+def test_pages_resource_reflects_a_page_created_through_a_tool(mcp, services):
+    """Resources must read live state, not a snapshot taken at registration."""
+    mcp._tool_manager._tools["create_page"].fn(
+        name="Visible In Resource", template_lines=FLAGSHIP_TEMPLATE, device_type="flagship"
+    )
+    content = _run(mcp._resource_manager._resources["fiestaboard://pages"].fn())
+    assert "Visible In Resource" in content

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -136,10 +136,12 @@ def mock_page_service():
     result.name = "New Page"
     svc.create_page.return_value = result
     svc.update_page.return_value = page
-    delete_result = MagicMock()
-    delete_result.success = True
-    delete_result.message = "Deleted"
-    svc.delete_page.return_value = delete_result
+    # A real DeleteResult, not MagicMock with invented attributes. The old
+    # stub set .success/.message, neither of which DeleteResult defines, so
+    # it agreed with a tool that was reading attributes into thin air.
+    from src.pages.service import DeleteResult
+
+    svc.delete_page.return_value = DeleteResult(deleted=True)
     return svc
 
 
@@ -628,15 +630,36 @@ class TestDeletePage:
         assert "deleted successfully" in result["message"]
 
     def test_delete_failure(self, mcp):
-        mock_svc = MagicMock()
-        fail = MagicMock()
-        fail.success = False
-        fail.message = "Page is in use"
-        mock_svc.delete_page.return_value = fail
+        """Uses a real DeleteResult, not a MagicMock with invented attributes.
+
+        This test previously built ``MagicMock()`` and set ``.success`` and
+        ``.message`` on it — neither of which ``DeleteResult`` defines. It
+        therefore asserted that production code read attributes that do not
+        exist, and passed. The tool really was reading ``result.success``,
+        catching the AttributeError, and returning it as an error string, so
+        delete_page never deleted anything over MCP.
+        """
+        from src.pages.service import DeleteResult, PageService
+
+        mock_svc = create_autospec(PageService, instance=True)
+        mock_svc.delete_page.return_value = DeleteResult(deleted=False)
         with patch("src.pages.service.get_page_service", return_value=mock_svc):
             result = _call_tool(mcp, "delete_page", page_id="page-001")
         assert result["status"] == "error"
-        assert "Page is in use" in result["error"]
+        assert "not deleted" in result["error"]
+
+    def test_delete_reports_default_page_creation(self, mcp):
+        """Deleting the last page creates a default one; the client is told."""
+        from src.pages.service import DeleteResult, PageService
+
+        mock_svc = create_autospec(PageService, instance=True)
+        mock_svc.delete_page.return_value = DeleteResult(
+            deleted=True, default_page_created=True, new_page_id="page-new"
+        )
+        with patch("src.pages.service.get_page_service", return_value=mock_svc):
+            result = _call_tool(mcp, "delete_page", page_id="page-001")
+        assert result["default_page_created"] is True
+        assert result["new_page_id"] == "page-new"
 
 
 class TestRenderPagePreview:

--- a/tests/test_mcp_skill_quality.py
+++ b/tests/test_mcp_skill_quality.py
@@ -1,0 +1,231 @@
+"""Contract test: the MCP surface must describe itself accurately.
+
+An MCP client sees this server only through what it advertises: tool names,
+tool descriptions, parameter schemas, prompt text. A tool can be perfectly
+correct and still unusable if its description points the model at a tool
+that no longer exists, or documents a parameter it does not take.
+
+That failure mode is invisible to every other test we have. ``tools/list``
+still returns 200. The tool still works when called correctly. Nothing
+raises. The model simply gets bad instructions and does the wrong thing —
+and the only symptom is a user saying "the AI couldn't figure it out".
+
+What is checked here
+--------------------
+
+- Every tool, prompt and resource has a non-empty description.
+- Every ``Args:`` entry in a tool docstring names a real parameter, and
+  every parameter appears in ``Args:``. A renamed parameter that leaves its
+  docstring behind actively misleads the model.
+- Every ``tool_name()`` cross-reference inside a description resolves to a
+  registered tool. Descriptions routinely say things like
+  "(from list_pages() or list_collections())"; a rename silently strands
+  those.
+- The hardcoded prompt roster in the server ``instructions`` matches the
+  prompts actually registered.
+
+What is deliberately NOT checked
+--------------------------------
+
+Whether a model *chooses* the right tool given these descriptions. That is
+probabilistic and needs a real model in the loop — an eval, not a test. The
+checks here cover the deterministic subset: the cases where selection could
+not possibly work because the description is self-contradictory or points
+into thin air.
+
+Note on parameter schemas: FastMCP does not lift a docstring's ``Args:``
+section into the JSON Schema, so ``parameters.properties[x].description`` is
+absent for every tool in this server. The whole docstring is shipped as the
+tool description instead, so the Args text does reach the model. Asserting on
+schema-level descriptions would therefore fail all 28 tools while describing
+no defect — hence the docstring-consistency check below instead.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+pytest.importorskip("mcp", reason="mcp package not installed")
+
+from src.mcp_server import _build_mcp_server
+
+# Floors. A scan that resolves nothing passes vacuously; these fail loudly if
+# the registry shape changes such that the analyzer goes blind.
+MIN_TOOLS = 28
+MIN_PROMPTS = 5
+MIN_RESOURCES = 6
+
+# Words that look like `something()` in prose but are not tool references.
+_NOT_TOOL_REFS = {
+    "e.g",
+    "i.e",
+    "etc",
+    "HH:MM",
+}
+
+
+@pytest.fixture(scope="module")
+def mcp():
+    instance = _build_mcp_server()
+    assert instance is not None, "mcp installed but _build_mcp_server() returned None"
+    return instance
+
+
+@pytest.fixture(scope="module")
+def tools(mcp):
+    return mcp._tool_manager._tools
+
+
+@pytest.fixture(scope="module")
+def prompts(mcp):
+    return mcp._prompt_manager._prompts
+
+
+@pytest.fixture(scope="module")
+def resources(mcp):
+    # Static resources plus URI templates like fiestaboard://page/{id}/preview.html
+    return {**mcp._resource_manager._resources, **mcp._resource_manager._templates}
+
+
+# ---------------------------------------------------------------------------
+# Floors — prove the analyzer is looking at a real registry
+# ---------------------------------------------------------------------------
+
+
+def test_tool_registry_floor(tools):
+    assert len(tools) >= MIN_TOOLS
+
+
+def test_prompt_registry_floor(prompts):
+    assert len(prompts) >= MIN_PROMPTS
+
+
+def test_resource_registry_floor(resources):
+    assert len(resources) >= MIN_RESOURCES
+
+
+# ---------------------------------------------------------------------------
+# Descriptions exist
+# ---------------------------------------------------------------------------
+
+
+def test_every_tool_has_a_description(tools):
+    missing = sorted(n for n, t in tools.items() if not (t.description or "").strip())
+    assert not missing, f"tools with no description: {missing}"
+
+
+def test_every_prompt_has_a_description(prompts):
+    missing = sorted(n for n, p in prompts.items() if not (p.description or "").strip())
+    assert not missing, f"prompts with no description: {missing}"
+
+
+def test_every_resource_has_a_description(resources):
+    missing = sorted(k for k, r in resources.items() if not (r.description or "").strip())
+    assert not missing, f"resources with no description: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# Docstring Args: must match the real signature
+# ---------------------------------------------------------------------------
+
+
+def _documented_args(description: str) -> set[str]:
+    """Parse the ``Args:`` block of a Google-style docstring."""
+    m = re.search(r"^\s*Args:\s*$(.*?)(?=^\s*(?:Returns|Raises|Examples?|Note):|\Z)",
+                  description, re.MULTILINE | re.DOTALL)
+    if m is None:
+        return set()
+    return set(re.findall(r"^\s{4,}(\w+)\s*:", m.group(1), re.MULTILINE))
+
+
+def test_documented_args_match_real_parameters(tools):
+    problems: list[str] = []
+    for name, tool in sorted(tools.items()):
+        real = set((tool.parameters or {}).get("properties", {}))
+        documented = _documented_args(tool.description or "")
+        if not documented and not real:
+            continue
+        if not documented and real:
+            problems.append(f"{name}: takes {sorted(real)} but documents no Args:")
+            continue
+        phantom = documented - real
+        undocumented = real - documented
+        if phantom:
+            problems.append(f"{name}: documents non-existent params {sorted(phantom)}")
+        if undocumented:
+            problems.append(f"{name}: params not documented {sorted(undocumented)}")
+    assert not problems, "tool docstrings disagree with their signatures:\n  " + "\n  ".join(problems)
+
+
+def test_args_parser_flags_a_known_bad_input():
+    """Meta-test: the Args parser must actually extract names."""
+    doc = "Do a thing.\n\nArgs:\n    alpha: first\n    beta: second\n\nReturns:\n    stuff\n"
+    assert _documented_args(doc) == {"alpha", "beta"}
+
+
+def test_args_parser_returns_empty_when_absent():
+    assert _documented_args("No args block here.") == set()
+
+
+# ---------------------------------------------------------------------------
+# Cross-references must resolve
+# ---------------------------------------------------------------------------
+
+
+def _tool_refs(text: str) -> set[str]:
+    """Names written as ``something()`` in prose."""
+    return {n for n in re.findall(r"\b([a-z_][a-z0-9_]{2,})\(\)", text) if n not in _NOT_TOOL_REFS}
+
+
+def test_tool_cross_references_resolve(tools):
+    known = set(tools)
+    dangling: list[str] = []
+    for name, tool in sorted(tools.items()):
+        for ref in sorted(_tool_refs(tool.description or "")):
+            if ref not in known:
+                dangling.append(f"{name} -> {ref}()")
+    assert not dangling, (
+        "tool descriptions reference tools that do not exist, so a model "
+        "following them will call into thin air:\n  " + "\n  ".join(dangling)
+    )
+
+
+def test_prompt_cross_references_resolve(prompts, tools):
+    known = set(tools)
+    dangling: list[str] = []
+    for name, prompt in sorted(prompts.items()):
+        for ref in sorted(_tool_refs(prompt.description or "")):
+            if ref not in known:
+                dangling.append(f"{name} -> {ref}()")
+    assert not dangling, "prompt descriptions reference non-existent tools:\n  " + "\n  ".join(dangling)
+
+
+def test_tool_ref_parser_flags_a_known_bad_input():
+    assert _tool_refs("use list_pages() or get_page() first") == {"list_pages", "get_page"}
+
+
+# ---------------------------------------------------------------------------
+# The hardcoded prompt roster in `instructions` must match reality
+# ---------------------------------------------------------------------------
+
+
+def test_instructions_prompt_roster_matches_registered_prompts(mcp, prompts):
+    """The connection instructions name the prompts by hand.
+
+    That list is a string literal, so adding or renaming a prompt does not
+    update it. A client told to invoke a prompt that no longer exists gets a
+    dead end.
+    """
+    instructions = mcp.instructions or ""
+    m = re.search(r"PROMPTS:(.*?)\.", instructions, re.DOTALL)
+    assert m, "could not find the 'Available user-invokable PROMPTS:' roster in instructions"
+
+    advertised = set(re.findall(r"[a-z_][a-z0-9_]+", m.group(1)))
+    registered = set(prompts)
+    assert advertised == registered, (
+        "the prompt roster in the server instructions has drifted from the registry.\n"
+        f"  advertised but not registered: {sorted(advertised - registered)}\n"
+        f"  registered but not advertised: {sorted(registered - advertised)}"
+    )

--- a/tests/test_mcp_skill_quality.py
+++ b/tests/test_mcp_skill_quality.py
@@ -133,8 +133,9 @@ def test_every_resource_has_a_description(resources):
 
 def _documented_args(description: str) -> set[str]:
     """Parse the ``Args:`` block of a Google-style docstring."""
-    m = re.search(r"^\s*Args:\s*$(.*?)(?=^\s*(?:Returns|Raises|Examples?|Note):|\Z)",
-                  description, re.MULTILINE | re.DOTALL)
+    m = re.search(
+        r"^\s*Args:\s*$(.*?)(?=^\s*(?:Returns|Raises|Examples?|Note):|\Z)", description, re.MULTILINE | re.DOTALL
+    )
     if m is None:
         return set()
     return set(re.findall(r"^\s{4,}(\w+)\s*:", m.group(1), re.MULTILINE))

--- a/tests/test_mcp_state_effects.py
+++ b/tests/test_mcp_state_effects.py
@@ -1,0 +1,447 @@
+"""MCP tools must actually change state — asserted by re-reading, not by mocks.
+
+Why this file exists
+--------------------
+
+``tests/test_mcp_server.py`` mocks every service. That is fine for checking
+argument plumbing, but it cannot answer the only question that matters to a
+user: *did anything happen?* #1559/#1561 is what that gap costs —
+``set_active_page`` and ``set_schedule_mode`` called methods that have never
+existed, caught their own AttributeError, returned it as an error string, and
+were complete no-ops in every release shipped. One of them was never even
+reported.
+
+The rule here is simple and is what makes the suite non-vacuous:
+
+    Every assertion is on state read back *after* the call, through a
+    different tool or the service itself. Never on a call record.
+
+Nothing is mocked. Real ``PageService``, ``ScheduleService``,
+``CollectionService`` and ``ConfigManager`` instances run against files in
+``tmp_path``. A tool calling a method that does not exist therefore raises
+instead of being conjured, and a tool that returns ``{"status": "ok"}``
+while writing nothing fails its re-read.
+
+Coverage floor
+--------------
+
+``test_every_tool_has_a_state_effect_case`` fails when a tool is registered
+without an entry in ``COVERED`` or ``UNCOVERED``. A new tool cannot be added
+without someone deciding, in writing, whether it gets a state-effect test.
+Tools in ``UNCOVERED`` carry a reason — that list is a to-do, not a
+permanent exemption.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+pytest.importorskip("mcp", reason="mcp package not installed")
+
+from src.collections.service import CollectionService
+from src.collections.storage import CollectionStorage
+from src.config_manager import ConfigManager
+from src.mcp_server import _build_mcp_server
+from src.pages.service import PageService
+from src.pages.storage import PageStorage
+from src.schedules.service import ScheduleService
+from src.schedules.storage import ScheduleStorage
+
+# ---------------------------------------------------------------------------
+# Tool coverage ledger
+# ---------------------------------------------------------------------------
+
+#: Tools with a state-effect or shape assertion in this module.
+COVERED = {
+    "list_pages",
+    "get_page",
+    "create_page",
+    "update_page",
+    "delete_page",
+    "render_page_preview",
+    "list_schedules",
+    "create_schedule",
+    "update_schedule",
+    "delete_schedule",
+    "list_collections",
+    "create_collection",
+    "update_collection",
+    "delete_collection",
+    "get_template_variables",
+    "get_system_status",
+    "get_settings_summary",
+    "list_installed_plugins",
+}
+
+#: Tools not yet covered here, each with the reason. Not an exemption list.
+UNCOVERED = {
+    "list_registry_plugins": "hits the network-backed registry; needs a fixture",
+    "install_plugin": "mutates the filesystem outside tmp_path",
+    "enable_plugin": "requires an installed plugin fixture",
+    "disable_plugin": "requires an installed plugin fixture",
+    "uninstall_plugin": "requires an installed plugin fixture",
+    "configure_plugin": "requires an installed plugin fixture",
+    "update_plugin": "requires an installed plugin fixture",
+    "get_plugin_data": "requires a live plugin instance",
+    "set_active_page": "delegates to the REST handler; needs board render wiring",
+    "set_schedule_mode": "routes through SettingsService; needs settings wiring",
+}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — real services, real files, no mocks
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def mcp():
+    instance = _build_mcp_server()
+    assert instance is not None, "mcp installed but _build_mcp_server() returned None"
+    return instance
+
+
+@pytest.fixture
+def services(tmp_path, monkeypatch):
+    """Point every service singleton at throwaway storage under tmp_path."""
+    pages = PageService(PageStorage(str(tmp_path / "pages.json")))
+    schedules = ScheduleService(ScheduleStorage(str(tmp_path / "schedules.json")))
+    collections = CollectionService(CollectionStorage(str(tmp_path / "collections.json")))
+
+    ConfigManager._instance = None  # type: ignore[attr-defined]
+    config = ConfigManager(config_path=str(tmp_path / "config.json"))
+
+    monkeypatch.setattr("src.pages.service._page_service", pages)
+    monkeypatch.setattr("src.schedules.service._schedule_service", schedules)
+    monkeypatch.setattr("src.collections.service._collection_service", collections)
+    monkeypatch.setattr("src.config_manager.ConfigManager._instance", config, raising=False)
+
+    yield {
+        "pages": pages,
+        "schedules": schedules,
+        "collections": collections,
+        "config": config,
+    }
+
+    ConfigManager._instance = None  # type: ignore[attr-defined]
+
+
+def call(mcp: Any, tool_name: str, /, **kwargs: Any) -> Any:
+    """Invoke a registered MCP tool, awaiting it if it is async.
+
+    Both leading parameters are positional-only: several tools take their
+    own ``name`` argument, which would otherwise collide with this
+    helper's signature.
+    """
+    tool = mcp._tool_manager._tools.get(tool_name)
+    if tool is None:
+        raise KeyError(f"tool {tool_name!r} is not registered; have: {sorted(mcp._tool_manager._tools)}")
+    result = tool.fn(**kwargs)
+    if asyncio.iscoroutine(result):
+        result = asyncio.run(result)
+    return result
+
+
+def assert_ok(result: Any, what: str) -> Any:
+    """Fail with the tool's own error string rather than a shape mismatch.
+
+    Tools catch their exceptions and return ``{"error": "..."}``. Without
+    this, a broken tool surfaces as a confusing KeyError three lines later.
+    """
+    if isinstance(result, dict) and result.get("error"):
+        pytest.fail(f"{what} returned an error instead of doing the work: {result['error']}")
+    return result
+
+
+FLAGSHIP_TEMPLATE = ["HELLO", "", "", "", "", ""]
+
+
+# ---------------------------------------------------------------------------
+# Coverage floor
+# ---------------------------------------------------------------------------
+
+
+def test_every_tool_has_a_state_effect_case(mcp):
+    registered = set(mcp._tool_manager._tools)
+    accounted = COVERED | set(UNCOVERED)
+    unaccounted = registered - accounted
+    assert not unaccounted, (
+        f"these MCP tools have no state-effect case and no recorded reason for not having one: {sorted(unaccounted)}"
+    )
+
+
+def test_coverage_ledger_has_no_phantom_entries(mcp):
+    """The ledger must describe the real registry, not a stale copy."""
+    registered = set(mcp._tool_manager._tools)
+    phantom = (COVERED | set(UNCOVERED)) - registered
+    assert not phantom, f"ledger names tools that are not registered: {sorted(phantom)}"
+
+
+# ---------------------------------------------------------------------------
+# Pages
+# ---------------------------------------------------------------------------
+
+
+def test_create_page_persists_and_is_visible_to_list_pages(mcp, services):
+    before = assert_ok(call(mcp, "list_pages"), "list_pages")
+    before_ids = {p["id"] for p in before}
+
+    created = assert_ok(
+        call(
+            mcp,
+            "create_page",
+            name="Harness Page",
+            template_lines=FLAGSHIP_TEMPLATE,
+            device_type="flagship",
+        ),
+        "create_page",
+    )
+
+    after = assert_ok(call(mcp, "list_pages"), "list_pages")
+    after_ids = {p["id"] for p in after}
+    new_ids = after_ids - before_ids
+
+    assert len(new_ids) == 1, "create_page did not add exactly one page"
+    assert created["page_id"] in new_ids
+    assert any(p["name"] == "Harness Page" for p in after)
+
+
+def test_create_page_writes_through_to_storage(mcp, services):
+    """Re-read from a *fresh* service over the same file.
+
+    Catches a tool that mutates the in-memory cache but never persists.
+    """
+    assert_ok(
+        call(mcp, "create_page", name="Durable", template_lines=FLAGSHIP_TEMPLATE, device_type="flagship"),
+        "create_page",
+    )
+    reloaded = PageService(PageStorage(str(services["pages"].storage.storage_file)))
+    assert any(p.name == "Durable" for p in reloaded.list_pages())
+
+
+def test_get_page_returns_the_page_that_was_created(mcp, services):
+    created = assert_ok(
+        call(mcp, "create_page", name="Fetch Me", template_lines=FLAGSHIP_TEMPLATE, device_type="flagship"),
+        "create_page",
+    )
+    fetched = assert_ok(call(mcp, "get_page", page_id=created["page_id"]), "get_page")
+    assert fetched["name"] == "Fetch Me"
+
+
+def test_update_page_changes_the_stored_name(mcp, services):
+    created = assert_ok(
+        call(mcp, "create_page", name="Before", template_lines=FLAGSHIP_TEMPLATE, device_type="flagship"),
+        "create_page",
+    )
+    page_id = created["page_id"]
+
+    assert_ok(call(mcp, "update_page", page_id=page_id, name="After"), "update_page")
+
+    refetched = assert_ok(call(mcp, "get_page", page_id=page_id), "get_page")
+    assert refetched["name"] == "After", "update_page reported success but the name did not change"
+
+
+def test_update_page_name_only_does_not_wipe_the_template(mcp, services):
+    """Regression: a rename over MCP used to fail outright.
+
+    ``PageService.update_page`` merges with
+    ``model_dump(exclude_unset=True)``, where "unset" means *not passed to
+    the constructor* — an explicit ``None`` counts as set. The tool passed
+    name/template/duration unconditionally, so every partial update sent
+    ``template=None``, wiped the template, and failed validation with
+    "Template page requires template content".
+    """
+    created = assert_ok(
+        call(mcp, "create_page", name="Before", template_lines=FLAGSHIP_TEMPLATE, device_type="flagship"),
+        "create_page",
+    )
+    page_id = created["page_id"]
+
+    assert_ok(call(mcp, "update_page", page_id=page_id, name="After"), "update_page (name only)")
+
+    page = assert_ok(call(mcp, "get_page", page_id=page_id), "get_page")
+    assert page["name"] == "After"
+    assert page["template"] == FLAGSHIP_TEMPLATE, "renaming a page destroyed its template"
+
+
+def test_update_page_duration_only_does_not_wipe_the_template(mcp, services):
+    created = assert_ok(
+        call(mcp, "create_page", name="Timed", template_lines=FLAGSHIP_TEMPLATE, device_type="flagship"),
+        "create_page",
+    )
+    page_id = created["page_id"]
+
+    assert_ok(call(mcp, "update_page", page_id=page_id, duration_seconds=90), "update_page (duration only)")
+
+    page = assert_ok(call(mcp, "get_page", page_id=page_id), "get_page")
+    assert page["duration_seconds"] == 90
+    assert page["template"] == FLAGSHIP_TEMPLATE, "changing duration destroyed the template"
+    assert page["name"] == "Timed", "changing duration destroyed the name"
+
+
+def test_update_page_with_no_fields_is_reported_not_silently_ignored(mcp, services):
+    created = assert_ok(
+        call(mcp, "create_page", name="Untouched", template_lines=FLAGSHIP_TEMPLATE, device_type="flagship"),
+        "create_page",
+    )
+    result = call(mcp, "update_page", page_id=created["page_id"])
+    assert isinstance(result, dict) and result.get("error"), "a no-op update should say so, not report success"
+
+
+def test_delete_page_removes_it_from_list_pages(mcp, services):
+    created = assert_ok(
+        call(mcp, "create_page", name="Doomed", template_lines=FLAGSHIP_TEMPLATE, device_type="flagship"),
+        "create_page",
+    )
+    page_id = created["page_id"]
+
+    assert_ok(call(mcp, "delete_page", page_id=page_id), "delete_page")
+
+    remaining = assert_ok(call(mcp, "list_pages"), "list_pages")
+    assert page_id not in {p["id"] for p in remaining}
+
+
+def test_render_page_preview_renders_a_template_without_saving_it(mcp, services):
+    """Preview takes raw ``template_lines``, not a saved page id.
+
+    Asserts the no-save contract too: previewing must not create a page.
+    """
+    before = assert_ok(call(mcp, "list_pages"), "list_pages")
+
+    preview = assert_ok(
+        call(mcp, "render_page_preview", template_lines=FLAGSHIP_TEMPLATE, device_type="flagship"),
+        "render_page_preview",
+    )
+    assert preview, "render_page_preview returned nothing"
+
+    after = assert_ok(call(mcp, "list_pages"), "list_pages")
+    assert len(after) == len(before), "render_page_preview persisted a page; it should not"
+
+
+# ---------------------------------------------------------------------------
+# Schedules
+# ---------------------------------------------------------------------------
+
+
+def _make_page(mcp, name: str = "Scheduled") -> str:
+    created = assert_ok(
+        call(mcp, "create_page", name=name, template_lines=FLAGSHIP_TEMPLATE, device_type="flagship"),
+        "create_page",
+    )
+    return created["page_id"]
+
+
+def test_create_schedule_persists_and_is_visible_to_list_schedules(mcp, services):
+    page_id = _make_page(mcp)
+    before = assert_ok(call(mcp, "list_schedules"), "list_schedules")
+    before_ids = {s["id"] for s in before}
+
+    assert_ok(
+        call(mcp, "create_schedule", page_id=page_id, start_time="08:00", day_pattern="all"),
+        "create_schedule",
+    )
+
+    after = assert_ok(call(mcp, "list_schedules"), "list_schedules")
+    assert len(({s["id"] for s in after}) - before_ids) == 1
+
+
+def test_update_schedule_changes_the_stored_start_time(mcp, services):
+    page_id = _make_page(mcp)
+    created = assert_ok(
+        call(mcp, "create_schedule", page_id=page_id, start_time="08:00", day_pattern="all"),
+        "create_schedule",
+    )
+    schedule_id = created["schedule_id"]
+
+    assert_ok(call(mcp, "update_schedule", schedule_id=schedule_id, start_time="09:30"), "update_schedule")
+
+    after = assert_ok(call(mcp, "list_schedules"), "list_schedules")
+    stored = next(s for s in after if s["id"] == schedule_id)
+    assert stored["start_time"] == "09:30", "update_schedule reported success but start_time did not change"
+
+
+def test_delete_schedule_removes_it(mcp, services):
+    page_id = _make_page(mcp)
+    created = assert_ok(
+        call(mcp, "create_schedule", page_id=page_id, start_time="08:00", day_pattern="all"),
+        "create_schedule",
+    )
+    schedule_id = created["schedule_id"]
+
+    assert_ok(call(mcp, "delete_schedule", schedule_id=schedule_id), "delete_schedule")
+
+    after = assert_ok(call(mcp, "list_schedules"), "list_schedules")
+    assert schedule_id not in {s["id"] for s in after}
+
+
+# ---------------------------------------------------------------------------
+# Collections
+# ---------------------------------------------------------------------------
+
+
+def test_create_collection_persists_and_is_visible_to_list_collections(mcp, services):
+    page_id = _make_page(mcp, "In A Collection")
+    before = assert_ok(call(mcp, "list_collections"), "list_collections")
+    before_ids = {c["id"] for c in before}
+
+    assert_ok(call(mcp, "create_collection", name="Harness Collection", page_ids=[page_id]), "create_collection")
+
+    after = assert_ok(call(mcp, "list_collections"), "list_collections")
+    assert len(({c["id"] for c in after}) - before_ids) == 1
+    assert any(c["name"] == "Harness Collection" for c in after)
+
+
+def test_update_collection_changes_the_stored_name(mcp, services):
+    page_id = _make_page(mcp, "Collected")
+    created = assert_ok(call(mcp, "create_collection", name="Before", page_ids=[page_id]), "create_collection")
+    collection_id = created["collection_id"]
+
+    assert_ok(call(mcp, "update_collection", collection_id=collection_id, name="After"), "update_collection")
+
+    after = assert_ok(call(mcp, "list_collections"), "list_collections")
+    stored = next(c for c in after if c["id"] == collection_id)
+    assert stored["name"] == "After", "update_collection reported success but the name did not change"
+
+
+def test_delete_collection_removes_it(mcp, services):
+    page_id = _make_page(mcp, "Temporary")
+    created = assert_ok(call(mcp, "create_collection", name="Doomed", page_ids=[page_id]), "create_collection")
+    collection_id = created["collection_id"]
+
+    assert_ok(call(mcp, "delete_collection", collection_id=collection_id), "delete_collection")
+
+    after = assert_ok(call(mcp, "list_collections"), "list_collections")
+    assert collection_id not in {c["id"] for c in after}
+
+
+# ---------------------------------------------------------------------------
+# Read-only tools — shape assertions
+# ---------------------------------------------------------------------------
+
+
+def test_get_template_variables_returns_a_mapping(mcp, services):
+    """Shape only.
+
+    The payload is ``{plugin_id: {variable: {...}}}`` and is legitimately
+    empty here — the fixture enables no plugins. Asserting non-emptiness
+    would be asserting on the fixture, not on the tool.
+    """
+    result = assert_ok(call(mcp, "get_template_variables"), "get_template_variables")
+    assert isinstance(result, dict)
+
+
+def test_get_system_status_returns_a_payload(mcp, services):
+    result = assert_ok(call(mcp, "get_system_status"), "get_system_status")
+    assert isinstance(result, dict) and result
+
+
+def test_get_settings_summary_returns_a_payload(mcp, services):
+    result = assert_ok(call(mcp, "get_settings_summary"), "get_settings_summary")
+    assert isinstance(result, dict) and result
+
+
+def test_list_installed_plugins_returns_a_list(mcp, services):
+    result = call(mcp, "list_installed_plugins")
+    assert isinstance(result, (list, dict))

--- a/tests/test_mock_llm_provider_parity.py
+++ b/tests/test_mock_llm_provider_parity.py
@@ -1,0 +1,117 @@
+"""The mock LLM's provider rules must match the canonical emulators.
+
+``tests/ai/provider_emulators.py`` encodes what each provider rejects and is
+where the source citations live. ``integration-tests/mock-llm/server.py``
+re-states a subset of those rules, because it runs in its own container as a
+stdlib-only script and cannot import from ``tests/``.
+
+Two copies of a rule drift. When they do, the E2E suite silently stops
+emulating the provider it claims to — which is exactly the failure that let
+#1560 ship, one level up. This module fails when they disagree.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from tests.ai.provider_emulators import BY_NAME
+
+MOCK_LLM = Path(__file__).resolve().parent.parent / "integration-tests" / "mock-llm" / "server.py"
+
+
+@pytest.fixture(scope="module")
+def mock_server():
+    """Import the mock server by path — it is not an installed package."""
+    spec = importlib.util.spec_from_file_location("mock_llm_server", MOCK_LLM)
+    assert spec and spec.loader, f"could not load {MOCK_LLM}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_mock_llm_source_exists():
+    assert MOCK_LLM.is_file(), f"{MOCK_LLM} is missing; the E2E provider tests depend on it"
+
+
+def test_every_mock_provider_except_permissive_has_an_emulator(mock_server):
+    named = set(mock_server.PROVIDERS) - {"permissive"}
+    missing = sorted(named - set(BY_NAME))
+    assert not missing, f"mock-llm emulates providers with no canonical emulator: {missing}"
+
+
+def test_response_format_rules_match_the_canonical_emulators(mock_server):
+    """The #1560 rule specifically, plus every other provider's."""
+    mismatches: list[str] = []
+    for name, rules in sorted(mock_server.PROVIDERS.items()):
+        if name == "permissive":
+            continue
+        emulator = BY_NAME[name]
+        canonical = set(getattr(emulator, "allowed_response_formats", frozenset()))
+        mock_allowed = set(rules["response_formats"] or set())
+        if canonical != mock_allowed:
+            mismatches.append(f"{name}: emulator={sorted(canonical)} mock-llm={sorted(mock_allowed)}")
+    assert not mismatches, "mock-llm response_format rules have drifted:\n  " + "\n  ".join(mismatches)
+
+
+def test_auth_requirements_match_the_canonical_emulators(mock_server):
+    mismatches: list[str] = []
+    for name, rules in sorted(mock_server.PROVIDERS.items()):
+        if name == "permissive":
+            continue
+        canonical = bool(getattr(BY_NAME[name], "requires_auth", False))
+        if canonical != bool(rules["requires_auth"]):
+            mismatches.append(f"{name}: emulator={canonical} mock-llm={rules['requires_auth']}")
+    assert not mismatches, "mock-llm auth rules have drifted:\n  " + "\n  ".join(mismatches)
+
+
+def test_lmstudio_flat_error_envelope_is_modelled_in_both(mock_server):
+    """LM Studio reports errors as {"error": "..."}; both copies must agree."""
+    assert mock_server.PROVIDERS["lmstudio"]["flat_error"] is True
+    assert BY_NAME["lmstudio"].error_body("x") == {"error": "x"}
+
+
+def test_permissive_is_the_default_so_existing_specs_keep_their_meaning(mock_server):
+    state = mock_server.MockLLMState()
+    assert state.provider == "permissive"
+    assert state.scenario == "ok"
+
+
+def test_script_scenario_renders_ops_as_fenced_tool_blocks(mock_server):
+    """The fence format is the contract src/ai/chat_ops.py parses."""
+    content = mock_server._scripted_content(
+        {"prose": "On it.", "ops": [{"op": "navigate_to_page", "args": {"page_id": "new"}}]}
+    )
+    assert "On it." in content
+    assert "```fiestaboard" in content
+    assert '"op": "navigate_to_page"' in content
+
+
+def test_script_with_no_ops_still_returns_text(mock_server):
+    assert mock_server._scripted_content(None).strip()
+
+
+def test_provider_rejection_reproduces_1560(mock_server):
+    """Meta-test: the mock must be able to say no, or it emulates nothing."""
+    rejection = mock_server._provider_rejection(
+        "lmstudio",
+        {"model": "m", "messages": [], "response_format": {"type": "json_object"}},
+        {},
+    )
+    assert rejection is not None
+    status, body = rejection
+    assert status == 400
+    assert "json_schema" in body["error"]
+
+
+def test_permissive_provider_accepts_what_lmstudio_rejects(mock_server):
+    assert (
+        mock_server._provider_rejection(
+            "permissive",
+            {"model": "m", "messages": [], "response_format": {"type": "json_object"}},
+            {},
+        )
+        is None
+    )

--- a/web/src/components/ai-chat-panel.tsx
+++ b/web/src/components/ai-chat-panel.tsx
@@ -741,12 +741,20 @@ function labelFor(call: ToolCall): string {
       return `${call.args.suggestions.length} suggestion${call.args.suggestions.length === 1 ? "" : "s"}`;
     case "navigate_to_page":
       return call.args.page_id === "new" ? "New page" : "Navigate to page";
+    case "navigate_to_schedule":
+      return "Navigate to schedule";
     case "install_plugin":
       return `Install: ${call.args.plugin_id}`;
     case "update_plugin_config":
       return `Configure: ${call.args.plugin_id}`;
     case "update_plugin":
       return `Update: ${call.args.plugin_id}`;
+    case "enable_plugin":
+      return `Enable: ${call.args.plugin_id}`;
+    case "disable_plugin":
+      return `Disable: ${call.args.plugin_id}`;
+    case "uninstall_plugin":
+      return `Uninstall: ${call.args.plugin_id}`;
     case "update_setting":
       return `Setting: ${call.args.category}`;
     case "create_collection":

--- a/web/tests/ai.spec.ts
+++ b/web/tests/ai.spec.ts
@@ -624,4 +624,117 @@ test.describe("AI", () => {
       expect(res.status()).toBe(400);
     });
   });
+
+  // -------------------------------------------------------------------
+  // Browser apply-loop (Layer 4)
+  //
+  // Everything above proves the backend *emits* a validated tool_call.
+  // It does not prove the browser applies it. That gap is where the
+  // labelFor() drift lived: the drawer handled all 19 ops, the editor
+  // panel handled 15, and no test looked. These drive the real drawer
+  // and assert the server state actually changed.
+  // -------------------------------------------------------------------
+  test.describe("browser apply-loop", () => {
+    /** The setup wizard holds every page behind a loader until a board exists. */
+    async function stubBoard(request: APIRequestContext): Promise<void> {
+      const res = await request.put(`${API_URL}/config/board`, {
+        data: { api_mode: "local", local_api_key: "ai-e2e-stub", host: "127.0.0.1" },
+      });
+      expect(res.ok()).toBe(true);
+    }
+
+    async function openDrawer(page: import("@playwright/test").Page): Promise<void> {
+      await page.goto("/");
+      // The trigger only renders when an AI provider is configured.
+      await page.getByRole("button", { name: "AI Assistant" }).first().click();
+      await expect(page.getByRole("dialog", { name: /FiestaBot/i })).toBeVisible();
+    }
+
+    async function sendMessage(page: import("@playwright/test").Page, text: string): Promise<void> {
+      const box = page
+        .getByRole("dialog", { name: /FiestaBot/i })
+        .getByRole("textbox")
+        .first();
+      await box.fill(text);
+      await page.getByRole("button", { name: "Send", exact: true }).click();
+    }
+
+    test("a scripted create_schedule op reaches the server", async ({ page, request }) => {
+      await configureMockProvider(request);
+      await stubBoard(request);
+
+      // A page for the schedule to point at.
+      const pageRes = await request.post(`${API_URL}/pages`, {
+        data: {
+          name: "Apply Loop Target",
+          type: "template",
+          device_type: "flagship",
+          template: ["APPLY LOOP", "", "", "", "", ""],
+          duration_seconds: 300,
+        },
+      });
+      expect(pageRes.ok(), await pageRes.text()).toBe(true);
+      // POST /pages wraps the page: {status, page: {...}}.
+      const pageId = (await pageRes.json()).page.id as string;
+      expect(pageId, "page id missing from POST /pages response").toBeTruthy();
+
+      const before = await (await request.get(`${API_URL}/schedules`)).json();
+      const beforeCount = (Array.isArray(before) ? before : before.schedules || []).length;
+
+      await setMockScript({
+        prose: "Scheduling that for you.",
+        ops: [
+          {
+            op: "create_schedule",
+            args: { page_id: pageId, start_time: "06:45", day_pattern: "all" },
+          },
+        ],
+      });
+
+      await openDrawer(page);
+      await sendMessage(page, "schedule my page for the morning");
+
+      // The drawer renders a card per applied call; wait on the effect, not
+      // the chrome, then confirm against the server.
+      await expect
+        .poll(
+          async () => {
+            const res = await request.get(`${API_URL}/schedules`);
+            const body = await res.json();
+            const list = (Array.isArray(body) ? body : body.schedules || []) as Array<Record<string, unknown>>;
+            return list.filter((s) => s.page_id === pageId && s.start_time === "06:45").length;
+          },
+          {
+            message: "the drawer never applied create_schedule to the server",
+            timeout: 15_000,
+          },
+        )
+        .toBeGreaterThan(0);
+
+      const after = await (await request.get(`${API_URL}/schedules`)).json();
+      const afterCount = (Array.isArray(after) ? after : after.schedules || []).length;
+      expect(afterCount).toBe(beforeCount + 1);
+    });
+
+    test("a tool_call card is rendered for an op the panel must label", async ({ page, request }) => {
+      // navigate_to_schedule is one of the four ops labelFor() used to fall
+      // through on, returning undefined from a function typed string.
+      await configureMockProvider(request);
+      await stubBoard(request);
+
+      await setMockScript({
+        prose: "Opening the schedule form.",
+        ops: [{ op: "navigate_to_schedule", args: { prefill: { start_time: "09:00" } } }],
+      });
+
+      await openDrawer(page);
+      await sendMessage(page, "open the schedule editor");
+
+      const dialog = page.getByRole("dialog", { name: /FiestaBot/i });
+      // The assistant's reply must render — an unlabelled op used to produce
+      // an empty card here.
+      await expect(dialog.getByText(/Opening the schedule form/i)).toBeVisible({ timeout: 15_000 });
+      await expect(dialog.getByText(/schedule/i).first()).toBeVisible();
+    });
+  });
 });

--- a/web/tests/ai.spec.ts
+++ b/web/tests/ai.spec.ts
@@ -116,6 +116,62 @@ async function callGenerate(
   throw new Error("callGenerate: retried but still got 429");
 }
 
+/**
+ * Switch the mock LLM into a provider personality — it then validates
+ * request bodies the way that real provider does. Default is "permissive".
+ */
+async function setMockProvider(provider: string): Promise<void> {
+  const res = await fetch(`${MOCK_LLM_CONTROL_URL}/mock/provider`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ provider }),
+  });
+  if (!res.ok) throw new Error(`setMockProvider(${provider}) failed: ${res.status}`);
+}
+
+/**
+ * Stage exactly what the "model" emits on the next chat completion: prose
+ * plus one fenced tool block per op. Arms the "script" scenario.
+ */
+async function setMockScript(script: { prose?: string; ops: Array<Record<string, unknown>> }): Promise<void> {
+  const res = await fetch(`${MOCK_LLM_CONTROL_URL}/mock/script`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(script),
+  });
+  if (!res.ok) throw new Error(`setMockScript failed: ${res.status}`);
+}
+
+/** One parsed SSE frame from /pages/ai/chat. */
+interface ChatFrame {
+  event: string;
+  data: Record<string, unknown>;
+}
+
+/**
+ * POST /pages/ai/chat and parse the SSE stream into frames.
+ *
+ * Playwright's APIRequestContext buffers the body, which is fine here: the
+ * mock closes the stream promptly and we assert on the whole transcript.
+ */
+async function callChat(request: APIRequestContext, body: Record<string, unknown>): Promise<ChatFrame[]> {
+  const res = await request.post(`${API_URL}/pages/ai/chat`, { data: body });
+  expect(res.status(), await res.text()).toBe(200);
+  const raw = await res.text();
+
+  const frames: ChatFrame[] = [];
+  for (const block of raw.split("\n\n")) {
+    const eventLine = block.split("\n").find((l) => l.startsWith("event: "));
+    const dataLine = block.split("\n").find((l) => l.startsWith("data: "));
+    if (!eventLine || !dataLine) continue;
+    frames.push({
+      event: eventLine.slice("event: ".length).trim(),
+      data: JSON.parse(dataLine.slice("data: ".length)),
+    });
+  }
+  return frames;
+}
+
 test.describe("AI", () => {
   test.beforeAll(async () => {
     // Sanity: confirm the mock LLM is actually reachable from the test
@@ -130,6 +186,8 @@ test.describe("AI", () => {
   });
 
   test.beforeEach(async () => {
+    // resetMock() restores scenario="ok" AND provider="permissive", so a
+    // provider-matrix test can't leak strict validation into its neighbours.
     await resetMock();
   });
 
@@ -378,6 +436,192 @@ test.describe("AI", () => {
       await expect(page.getByText(/AI Providers|AI Settings|Add provider/i).first()).toBeVisible();
       // The provider we configured via the API should appear in the list.
       await expect(page.getByText(PROVIDER_NAME, { exact: false }).first()).toBeVisible();
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // Provider conformance (Layer 2, end-to-end)
+  //
+  // tests/ai/test_provider_conformance.py checks the outbound body against
+  // emulators in-process. This runs the same idea through the real HTTP
+  // path: a mock that refuses requests the way the named provider refuses
+  // them. #1560 is the case that matters — LM Studio 400s on
+  // response_format json_object, so generation was hard-blocked there.
+  // -------------------------------------------------------------------
+  test.describe("provider conformance", () => {
+    for (const provider of ["openai", "openrouter", "lmstudio", "ollama", "vllm"]) {
+      test(`page generation succeeds against ${provider} validation`, async ({ request }) => {
+        await configureMockProvider(request);
+        await setMockProvider(provider);
+
+        const { status, data } = await callGenerate(request, {
+          prompt: `a page, generated against ${provider}`,
+          device_type: "flagship",
+        });
+
+        expect(status, JSON.stringify(data)).toBe(200);
+        expect(data.page).toBeTruthy();
+      });
+    }
+
+    test("the mock actually rejects what LM Studio rejects", async () => {
+      // Without this, every test above could be passing vacuously against a
+      // mock that says yes to everything — precisely how #1560 shipped.
+      await setMockProvider("lmstudio");
+      const res = await fetch(`${MOCK_LLM_CONTROL_URL}/v1/chat/completions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "mock-model-v1",
+          messages: [{ role: "user", content: "hi" }],
+          response_format: { type: "json_object" },
+        }),
+      });
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { error: string };
+      // LM Studio's envelope is a flat string, not {error:{message}}.
+      expect(typeof body.error).toBe("string");
+      expect(body.error).toContain("json_schema");
+    });
+
+    test("the generator does not ask for json_object mode", async ({ request }) => {
+      await configureMockProvider(request);
+      await callGenerate(request, { prompt: "check the wire format", device_type: "flagship" });
+
+      const state = await getMockState();
+      const last = state.history[state.history.length - 1];
+      expect(last, "no request reached the mock").toBeTruthy();
+      // Regression pin for #1560 at the wire level.
+      expect(last.response_format).toEqual({ type: "text" });
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // Chat streaming + tool-call grammar (Layer 4)
+  //
+  // /pages/ai/chat had no E2E coverage at all: the mock could not stream,
+  // so nothing exercised the SSE path or the fenced-tool-block parser that
+  // turns model prose into structured ops.
+  // -------------------------------------------------------------------
+  test.describe("/pages/ai/chat", () => {
+    test("streams prose as text frames and ends with done", async ({ request }) => {
+      await configureMockProvider(request);
+      await setMockScript({ prose: "Here is what I will do.", ops: [] });
+
+      const frames = await callChat(request, {
+        messages: [{ role: "user", content: "hello" }],
+        device_type: "flagship",
+        surface: "editor",
+      });
+
+      const text = frames
+        .filter((f) => f.event === "text")
+        .map((f) => f.data.delta as string)
+        .join("");
+      expect(text).toContain("Here is what I will do.");
+
+      const done = frames.find((f) => f.event === "done");
+      expect(done, "stream never emitted a done frame").toBeTruthy();
+      expect(done!.data.model_used).toBe(PROVIDER_MODEL);
+    });
+
+    test("a fenced tool block becomes a validated tool_call frame", async ({ request }) => {
+      await configureMockProvider(request);
+      await setMockScript({
+        prose: "Creating that page.",
+        ops: [
+          {
+            op: "replace_page",
+            args: {
+              name: "Scripted Page",
+              template: ["SCRIPTED", "", "", "", "", ""],
+              duration_seconds: 300,
+            },
+          },
+        ],
+      });
+
+      const frames = await callChat(request, {
+        messages: [{ role: "user", content: "make a page" }],
+        device_type: "flagship",
+        surface: "editor",
+      });
+
+      const call = frames.find((f) => f.event === "tool_call");
+      expect(call, `no tool_call frame in: ${JSON.stringify(frames)}`).toBeTruthy();
+      expect(call!.data.op).toBe("replace_page");
+      expect((call!.data.args as Record<string, unknown>).name).toBe("Scripted Page");
+    });
+
+    test("tool blocks are parsed across SSE delta boundaries", async ({ request }) => {
+      // The mock chunks content at 24 chars, so a fenced block is split
+      // across several deltas. A parser that only handled whole-chunk
+      // fences would pass the test above and fail here.
+      await configureMockProvider(request);
+      await setMockScript({
+        prose: "x".repeat(200),
+        ops: [{ op: "navigate_to_page", args: { page_id: "new" } }],
+      });
+
+      const frames = await callChat(request, {
+        messages: [{ role: "user", content: "go" }],
+        device_type: "flagship",
+        surface: "global",
+      });
+
+      expect(frames.filter((f) => f.event === "text").length).toBeGreaterThan(1);
+      const call = frames.find((f) => f.event === "tool_call");
+      expect(call, "fence split across deltas was not reassembled").toBeTruthy();
+      expect(call!.data.op).toBe("navigate_to_page");
+    });
+
+    test("an unknown op is reported as a warning, not a tool_call", async ({ request }) => {
+      await configureMockProvider(request);
+      await setMockScript({ ops: [{ op: "definitely_not_a_real_op", args: {} }] });
+
+      const frames = await callChat(request, {
+        messages: [{ role: "user", content: "do something odd" }],
+        device_type: "flagship",
+        surface: "editor",
+      });
+
+      expect(frames.find((f) => f.event === "tool_call")).toBeFalsy();
+      expect(frames.some((f) => f.event === "warning" || f.event === "error")).toBe(true);
+    });
+
+    test("a malformed op is rejected rather than passed through", async ({ request }) => {
+      // replace_page requires a non-empty name and a template.
+      await configureMockProvider(request);
+      await setMockScript({ ops: [{ op: "replace_page", args: { name: "" } }] });
+
+      const frames = await callChat(request, {
+        messages: [{ role: "user", content: "break it" }],
+        device_type: "flagship",
+        surface: "editor",
+      });
+
+      expect(frames.find((f) => f.event === "tool_call")).toBeFalsy();
+      expect(frames.some((f) => f.event === "warning" || f.event === "error")).toBe(true);
+    });
+
+    test("rejects an empty messages array", async ({ request }) => {
+      await configureMockProvider(request);
+      const res = await request.post(`${API_URL}/pages/ai/chat`, {
+        data: { messages: [], device_type: "flagship" },
+      });
+      expect(res.status()).toBe(400);
+    });
+
+    test("rejects an invalid surface", async ({ request }) => {
+      await configureMockProvider(request);
+      const res = await request.post(`${API_URL}/pages/ai/chat`, {
+        data: {
+          messages: [{ role: "user", content: "hi" }],
+          device_type: "flagship",
+          surface: "nonsense",
+        },
+      });
+      expect(res.status()).toBe(400);
     });
   });
 });

--- a/web/tests/mcp.spec.ts
+++ b/web/tests/mcp.spec.ts
@@ -210,4 +210,310 @@ test.describe("MCP", () => {
     }
     expect(res.body.error || res.body.result?.isError).toBeTruthy();
   });
+
+  // ===================================================================
+  // Layer 5 — skill scenarios
+  //
+  // Everything above proves the transport works and that one tool
+  // responds. None of it proves a *skill* works. The MCP surface is 28
+  // tools, 5 prompts and 6 resources, and what a client actually runs is
+  // a chain across them. The prompts are the skill definitions.
+  // ===================================================================
+
+  /** tools/call, unwrapping the structured payload MCP wraps returns in. */
+  async function callTool(
+    request: APIRequestContext,
+    sessionId: string | undefined,
+    name: string,
+    args: Record<string, unknown> = {},
+    id = 100,
+  ): Promise<unknown> {
+    const res = await rpc(
+      request,
+      { jsonrpc: "2.0", id, method: "tools/call", params: { name, arguments: args } },
+      sessionId,
+    );
+    expect(res.status, `${name}: HTTP ${res.status}`).toBeLessThan(400);
+    expect(res.body.error, `${name}: ${JSON.stringify(res.body.error)}`).toBeUndefined();
+
+    const result = res.body.result || {};
+    const structured = result.structuredContent;
+    if (structured !== undefined) {
+      return typeof structured === "object" && structured !== null && "result" in structured
+        ? (structured as { result: unknown }).result
+        : structured;
+    }
+    const content = (result.content || []) as Array<{ type: string; text?: string }>;
+    const textBlock = content.find((b) => b.type === "text" && typeof b.text === "string");
+    expect(textBlock, `${name}: no structuredContent and no text block`).toBeDefined();
+    try {
+      return JSON.parse(textBlock!.text as string);
+    } catch {
+      return textBlock!.text;
+    }
+  }
+
+  /** Fail loudly with the tool's own error string rather than a shape mismatch. */
+  function expectNoToolError(payload: unknown, what: string): Record<string, unknown> {
+    const obj = payload as Record<string, unknown>;
+    expect(obj, `${what} returned nothing`).toBeTruthy();
+    expect(obj.error, `${what} failed: ${JSON.stringify(obj.error)}`).toBeFalsy();
+    return obj;
+  }
+
+  test.describe("protocol lifecycle", () => {
+    test("initialize then list tools, prompts and resources", async ({ request }) => {
+      const { sessionId, protocolVersion } = await initialize(request);
+      expect(protocolVersion, "server did not negotiate a protocol version").toBeTruthy();
+
+      const tools = await rpc(request, { jsonrpc: "2.0", id: 10, method: "tools/list" }, sessionId);
+      expect(((tools.body.result?.tools || []) as unknown[]).length).toBeGreaterThanOrEqual(28);
+
+      const prompts = await rpc(request, { jsonrpc: "2.0", id: 11, method: "prompts/list" }, sessionId);
+      expect(prompts.body.error, JSON.stringify(prompts.body.error)).toBeUndefined();
+      expect(((prompts.body.result?.prompts || []) as unknown[]).length).toBeGreaterThanOrEqual(5);
+
+      const resources = await rpc(request, { jsonrpc: "2.0", id: 12, method: "resources/list" }, sessionId);
+      expect(resources.body.error, JSON.stringify(resources.body.error)).toBeUndefined();
+      expect(((resources.body.result?.resources || []) as unknown[]).length).toBeGreaterThanOrEqual(5);
+    });
+  });
+
+  test.describe("prompts", () => {
+    // The skill definitions. Before this, nothing executed a single one.
+    for (const name of [
+      "setup_fiestaboard",
+      "create_display_page",
+      "schedule_my_day",
+      "build_a_collection",
+      "troubleshoot_display",
+    ]) {
+      test(`prompts/get ${name} returns usable messages`, async ({ request }) => {
+        const { sessionId } = await initialize(request);
+        const res = await rpc(
+          request,
+          { jsonrpc: "2.0", id: 20, method: "prompts/get", params: { name, arguments: {} } },
+          sessionId,
+        );
+        expect(res.status, `${name}: HTTP ${res.status}`).toBeLessThan(400);
+        expect(res.body.error, `${name}: ${JSON.stringify(res.body.error)}`).toBeUndefined();
+
+        const messages = (res.body.result?.messages || []) as Array<{
+          role: string;
+          content: { type: string; text?: string };
+        }>;
+        expect(messages.length, `${name} rendered no messages`).toBeGreaterThan(0);
+        const text = messages.map((m) => m.content?.text || "").join("\n");
+        expect(text.trim().length, `${name} rendered empty text`).toBeGreaterThan(40);
+      });
+    }
+  });
+
+  test.describe("resources", () => {
+    for (const uri of [
+      "fiestaboard://plugins",
+      "fiestaboard://pages",
+      "fiestaboard://variables",
+      "fiestaboard://schedules",
+      "fiestaboard://collections",
+    ]) {
+      test(`resources/read ${uri} returns content`, async ({ request }) => {
+        const { sessionId } = await initialize(request);
+        const res = await rpc(
+          request,
+          { jsonrpc: "2.0", id: 30, method: "resources/read", params: { uri } },
+          sessionId,
+        );
+        expect(res.status, `${uri}: HTTP ${res.status}`).toBeLessThan(400);
+        expect(res.body.error, `${uri}: ${JSON.stringify(res.body.error)}`).toBeUndefined();
+
+        const contents = (res.body.result?.contents || []) as Array<{ text?: string; mimeType?: string }>;
+        expect(contents.length, `${uri} returned no contents`).toBeGreaterThan(0);
+        expect((contents[0].text || "").trim().length, `${uri} returned empty text`).toBeGreaterThan(0);
+      });
+    }
+
+    test("the page preview URI template renders HTML for a real page", async ({ request }) => {
+      const { sessionId } = await initialize(request);
+      const created = expectNoToolError(
+        await callTool(request, sessionId, "create_page", {
+          name: "MCP Preview Target",
+          template_lines: ["PREVIEW", "", "", "", "", ""],
+          device_type: "flagship",
+        }),
+        "create_page",
+      );
+
+      const res = await rpc(
+        request,
+        {
+          jsonrpc: "2.0",
+          id: 31,
+          method: "resources/read",
+          params: { uri: `fiestaboard://page/${created.page_id}/preview.html` },
+        },
+        sessionId,
+      );
+      expect(res.body.error, JSON.stringify(res.body.error)).toBeUndefined();
+      const contents = (res.body.result?.contents || []) as Array<{ text?: string }>;
+      expect(contents.length).toBeGreaterThan(0);
+      expect(contents[0].text || "").toContain("<");
+    });
+  });
+
+  test.describe("multi-tool chains", () => {
+    // Individual tool correctness does not prove a chain completes: state
+    // produced by tool 3 has to be shaped right for tool 5. This is the
+    // closest deterministic proxy for "a skill works".
+
+    test("create a page, schedule it, and see both in a re-read", async ({ request }) => {
+      const { sessionId } = await initialize(request);
+
+      const created = expectNoToolError(
+        await callTool(request, sessionId, "create_page", {
+          name: "Chain Morning Page",
+          template_lines: ["GOOD MORNING", "", "", "", "", ""],
+          device_type: "flagship",
+        }),
+        "create_page",
+      );
+      const pageId = created.page_id as string;
+      expect(pageId).toBeTruthy();
+
+      const scheduled = expectNoToolError(
+        await callTool(request, sessionId, "create_schedule", {
+          page_id: pageId,
+          start_time: "07:30",
+          day_pattern: "all",
+        }),
+        "create_schedule",
+      );
+      const scheduleId = scheduled.schedule_id as string;
+
+      // Re-read through different tools — the chain is only real if the
+      // state it produced is visible to a fresh call.
+      const pages = (await callTool(request, sessionId, "list_pages", {}, 101)) as Array<Record<string, unknown>>;
+      expect(pages.some((p) => p.id === pageId)).toBe(true);
+
+      const schedules = (await callTool(request, sessionId, "list_schedules", {}, 102)) as Array<
+        Record<string, unknown>
+      >;
+      const mine = schedules.find((s) => s.id === scheduleId);
+      expect(mine, "schedule vanished between create and list").toBeTruthy();
+      expect(mine!.page_id).toBe(pageId);
+      expect(mine!.start_time).toBe("07:30");
+    });
+
+    test("rename a page mid-chain without destroying it", async ({ request }) => {
+      // Regression for the partial-update bug: update_page passed
+      // template=None on every call, wiping the template and failing
+      // validation, so renaming over MCP was impossible.
+      const { sessionId } = await initialize(request);
+
+      const created = expectNoToolError(
+        await callTool(request, sessionId, "create_page", {
+          name: "Chain Before",
+          template_lines: ["KEEP ME", "", "", "", "", ""],
+          device_type: "flagship",
+        }),
+        "create_page",
+      );
+      const pageId = created.page_id as string;
+
+      expectNoToolError(
+        await callTool(request, sessionId, "update_page", { page_id: pageId, name: "Chain After" }, 103),
+        "update_page (name only)",
+      );
+
+      const page = expectNoToolError(
+        await callTool(request, sessionId, "get_page", { page_id: pageId }, 104),
+        "get_page",
+      );
+      expect(page.name).toBe("Chain After");
+      expect(page.template, "renaming destroyed the template").toEqual(["KEEP ME", "", "", "", "", ""]);
+    });
+
+    test("collect pages, then delete the collection and a page", async ({ request }) => {
+      // Exercises delete_page over the real transport — it read
+      // DeleteResult.success, an attribute that does not exist, so it
+      // never deleted anything.
+      const { sessionId } = await initialize(request);
+
+      const a = expectNoToolError(
+        await callTool(request, sessionId, "create_page", {
+          name: "Chain Collected A",
+          template_lines: ["A", "", "", "", "", ""],
+          device_type: "flagship",
+        }),
+        "create_page A",
+      );
+      const b = expectNoToolError(
+        await callTool(
+          request,
+          sessionId,
+          "create_page",
+          {
+            name: "Chain Collected B",
+            template_lines: ["B", "", "", "", "", ""],
+            device_type: "flagship",
+          },
+          105,
+        ),
+        "create_page B",
+      );
+
+      const collection = expectNoToolError(
+        await callTool(
+          request,
+          sessionId,
+          "create_collection",
+          { name: "Chain Collection", page_ids: [a.page_id, b.page_id] },
+          106,
+        ),
+        "create_collection",
+      );
+      const collectionId = collection.collection_id as string;
+
+      const collections = (await callTool(request, sessionId, "list_collections", {}, 107)) as Array<
+        Record<string, unknown>
+      >;
+      expect(collections.some((c) => c.id === collectionId)).toBe(true);
+
+      expectNoToolError(
+        await callTool(request, sessionId, "delete_collection", { collection_id: collectionId }, 108),
+        "delete_collection",
+      );
+      expectNoToolError(await callTool(request, sessionId, "delete_page", { page_id: b.page_id }, 109), "delete_page");
+
+      const afterCollections = (await callTool(request, sessionId, "list_collections", {}, 110)) as Array<
+        Record<string, unknown>
+      >;
+      expect(afterCollections.some((c) => c.id === collectionId)).toBe(false);
+
+      const afterPages = (await callTool(request, sessionId, "list_pages", {}, 111)) as Array<Record<string, unknown>>;
+      expect(
+        afterPages.some((p) => p.id === b.page_id),
+        "delete_page did not delete",
+      ).toBe(false);
+    });
+
+    test("render_page_preview does not persist a page", async ({ request }) => {
+      const { sessionId } = await initialize(request);
+      const before = (await callTool(request, sessionId, "list_pages", {}, 112)) as unknown[];
+
+      expectNoToolError(
+        await callTool(
+          request,
+          sessionId,
+          "render_page_preview",
+          { template_lines: ["PREVIEW ONLY", "", "", "", "", ""], device_type: "flagship" },
+          113,
+        ),
+        "render_page_preview",
+      );
+
+      const after = (await callTool(request, sessionId, "list_pages", {}, 114)) as unknown[];
+      expect(after.length).toBe(before.length);
+    });
+  });
 });


### PR DESCRIPTION
Builds a five-layer test harness for the AI and MCP surfaces, and fixes the six bugs it found.

Motivated by #1560, but the harness is the point: #1560 and #1561 were the same failure of method — **tests asserting against a stand-in that agrees with the code, instead of something that can say no.** `MagicMock()` conjures any attribute you touch. The mock LLM accepted any body you sent it. Both defects shipped in every release, and one of them (`set_schedule_mode`) was never reported by anyone.

## Bugs found and fixed

| # | Bug | Impact | Found by |
|---|---|---|---|
| 1 | `_openai_body()` hardcoded `response_format: json_object` | **#1560** — all AI page generation fails against LM Studio | Layer 2 |
| 2 | `_openai_error()` couldn't read LM Studio's flat-string error envelope | *Every* LM Studio error surfaced as a raw JSON dump | Layer 2 |
| 3 | `delete_page` read `DeleteResult.success`, which does not exist | **`delete_page` has never worked over MCP, in any release** | Layer 3 |
| 4 | `update_page` sent `template=None` on every partial update | **Renaming a page or changing its duration over MCP always errored** | Layer 3 |
| 5 | `labelFor()` handled 15 of 19 chat ops with no `default` | 4 ops returned `undefined` from a function typed `string` | Layer 1 |
| 6 | `create_display_page.topic` had no description | MCP clients render prompt args as a form; users saw a naked field | Layer 5 |

Only #1 was reported. #3 and #4 sit in tools adjacent to the two #1561 fixed — and #3 is a case `test_service_wiring.py` structurally **cannot** catch, because it resolves `svc.method()` calls, not attribute access on returned objects.

## The five layers

1. **Contract analyzers** (`test_ai_op_contract.py`, `test_mcp_skill_quality.py`) — parse across the Python/TypeScript boundary. Chat-op registry ↔ TS `ToolCall` union ↔ every consuming `switch`. Tool docstring `Args:` ↔ real signatures. `tool_name()` cross-references resolve. The hardcoded prompt roster in `instructions` matches the registry.
2. **Provider conformance** (`provider_emulators.py`, `test_provider_conformance.py`) — an emulator per provider encoding what it *rejects*, sourced from docs and bug reports. Every outbound body (generator + chat, both protocols) runs through every emulator.
3. **MCP state effects** (`test_mcp_state_effects.py`) — real services on `tmp_path`, **nothing mocked**, every assertion on state re-read after the call.
4. **Browser apply-loop** (`ai.spec.ts`) — mock-llm gains SSE streaming and a script scenario; tests drive the real chat drawer and assert the *server* changed.
5. **Skill scenarios** (`mcp.spec.ts`, `test_mcp_prompts_and_resources.py`) — full JSON-RPC lifecycle, all 5 prompts and all 6 resources executed, four multi-tool chains.

## Why this isn't another vacuous suite

Every analyzer carries meta-tests proving it fails on known-bad input, plus a floor on symbols resolved. This earned its keep on the first run: my TS union parser silently returned an empty set (a non-greedy `;` match stopped inside `{ id: string;`), so the `labelFor` check "passed" — against nothing. Only `assert 0 >= 19` caught it. That vacuous pass is precisely what this suite exists to prevent, and it happened immediately.

Each emulator has a test asserting it rejects what it should; a pass-through emulator would reintroduce the original bug one layer down. `test_mock_llm_provider_parity.py` fails if mock-llm's rules drift from the canonical emulators.

## Proof the tests are not vacuous

Per the repo's test quality bar, every fix was reverted in a running container and the corresponding E2E test observed failing with the original error:

```
delete_page reverted to result.success:
  Error: delete_page failed: "Error deleting page '...':
  'DeleteResult' object has no attribute 'success'"

update_page reverted to passing all fields:
  Error: update_page (name only) failed: "Error updating page '...':
  Invalid page configuration: ['Template page requires template content']"

response_format reverted to json_object:
  Error: {"detail":"AI provider returned 400: 'response_format.type'
  must be 'json_schema' or 'text'"}
  and expect(last.response_format).toEqual({type:"text"}) failed
```

All three restored afterwards.

## Tests corrected, not weakened

Four existing tests encoded the broken behaviour as intended:

- `test_openai_body_..._requests_json_object` asserted the value that *was* the defect.
- `test_openai_parse_error_extracts_message` asserted `parse_error({"error": "string"}) is None` — it pinned the LM Studio parsing gap as correct.
- `TestDeletePage::test_delete_failure` and the shared `mock_page_service` fixture both built `MagicMock()` and set `.success`/`.message`, attributes `DeleteResult` does not define. The #1561 anti-pattern, still live in the file #1561 hardened.

## The one judgement call

For #1560 I shipped the reporter's one-liner (`response_format: text`) rather than adding a per-provider setting. `json_object` **is** honored by OpenAI proper, so this trades away a server-side guarantee where one existed, in exchange for working at all everywhere else. The prompt asks for JSON and `_extract_json_object()` recovers it from bare, fenced, and prose-wrapped output — all three now tested. If OpenAI output reliability measurably degrades, the follow-up is a setting, not a revert.

## Deviation from plan

Intended as one PR per bug. The commits turned out genuinely stacked — each fix's proof lives in the harness commit that found it, and the conformance test's `xfail` removal is meaningless without the fix. Splitting would produce PRs that can't demonstrate their own failure. The 9 commits tell the per-bug story in order and are individually revertable. Happy to split if you'd rather.

## Verification

- **4891 Python tests pass, 0 failures** (109 new)
- **52 E2E tests pass** (was 20; 32 new) against the containers
- `ruff check` / `ruff format --check` clean on `src/ plugins/ tests/ scripts/` with the newly-bumped ruff 0.16.2
- `npm run lint` and `npm run format:check` clean
- No CI changes needed — `ai-mcp-e2e-tests` already runs both specs

## Not in scope

Layer 5's model-in-the-loop eval. Whether a model *chooses* the right tool is probabilistic and needs a real model — an eval, not a test. Layer 1 covers the deterministic subset. Separately, `npm run typecheck` is already red on `main` across ~40 unrelated files (likely the TS7 breakage from #1442); untouched here.

Fixes #1560

🤖 Generated with [Claude Code](https://claude.com/claude-code)
