### PR TITLE
fix: react-hooks/exhaustive-deps warnings + no-console (#1570)

### DIFF
--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -275,6 +275,9 @@ const eslintConfig = [
       "**/*.stories.{ts,tsx}",
       "vitest.config.{ts,mts}",
       "playwright.config.{ts,mts}",
+      // Standalone CLI utility scripts (run manually via `node scripts/*.mjs`,
+      // never bundled into the app) — their console output IS the feature.
+      "scripts/**",
     ],
     rules: {
       "no-console": "off",

--- a/web/src/__tests__/active-page-display-locale-switch.test.tsx
+++ b/web/src/__tests__/active-page-display-locale-switch.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * Regression test for issue #1570: the `activePageName` useMemo in
+ * ActivePageDisplay was missing `t` from its dependency array. Because the
+ * memo's other deps (activePage, activePageId, scheduleEnabled,
+ * activeCollection) don't change on a language switch, the memoized
+ * "Schedule gap" string stayed frozen in whatever locale was active when it
+ * was first computed — even though the rest of the component (which calls
+ * `t()` directly during render, unmemoized) updated immediately.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The global test setup (src/__tests__/setup.ts) mocks `@/i18n/translations`
+// with a static English-only stub for determinism. This test specifically
+// exercises real locale switching, so it needs the actual react-i18next-backed
+// hook instead.
+vi.unmock("@/i18n/translations");
+
+import { ActivePageDisplay } from "@/components/active-page-display";
+import { ConfigOverridesProvider } from "@/hooks/use-config-overrides";
+import { ThemeProvider } from "@/hooks/use-theme";
+import i18n from "@/i18n/i18next";
+
+import { server } from "./mocks/server";
+
+const API_BASE = "/api";
+
+vi.mock("@/hooks/use-router", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+    back: vi.fn(),
+  }),
+}));
+
+vi.mock("@/components/smart-link", () => ({
+  default: ({ children, href, ...rest }: { children: React.ReactNode; href: string }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+function TestWrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <ConfigOverridesProvider>
+        <ThemeProvider attribute="class" defaultTheme="light">
+          {children}
+        </ThemeProvider>
+      </ConfigOverridesProvider>
+    </QueryClientProvider>
+  );
+}
+
+describe("ActivePageDisplay - locale switch (issue #1570)", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    // Always start from a known locale; changeLanguage is synchronous here
+    // because all 14 locale bundles are statically imported in i18next.ts.
+    await act(async () => {
+      await i18n.changeLanguage("en");
+    });
+  });
+
+  it("recomputes the memoized schedule-gap name when the language changes", async () => {
+    server.use(
+      http.get(`${API_BASE}/schedules/active/page`, () =>
+        HttpResponse.json({
+          page_id: null,
+          source: "schedule",
+          schedule_enabled: true,
+        }),
+      ),
+    );
+
+    render(<ActivePageDisplay />, { wrapper: TestWrapper });
+
+    // English first — this is the useMemo'd `activePageName` value.
+    await waitFor(() => {
+      expect(screen.getByText("Schedule gap (no default page set)")).toBeInTheDocument();
+    });
+
+    // A directly-rendered (unmemoized) t() call in the same component, used
+    // as a control: it MUST update to Spanish immediately, proving the
+    // component did re-render on the language switch.
+    expect(screen.getByText(/No page scheduled for current time/i)).toBeInTheDocument();
+
+    await act(async () => {
+      await i18n.changeLanguage("es");
+    });
+
+    // Control assertion: the unmemoized string updated to Spanish.
+    await waitFor(() => {
+      expect(screen.getByText(/No hay página programada para la hora actual/i)).toBeInTheDocument();
+    });
+
+    // The memoized schedule-gap name must ALSO have updated to Spanish. Before
+    // the fix (missing `t` dep), this stayed stuck on the English string
+    // because none of the memo's other deps changed on a locale switch.
+    expect(screen.getByText("Intervalo en el horario (sin página predeterminada)")).toBeInTheDocument();
+    expect(screen.queryByText("Schedule gap (no default page set)")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/__tests__/active-page-display-locale-switch.test.tsx
+++ b/web/src/__tests__/active-page-display-locale-switch.test.tsx
@@ -6,11 +6,57 @@
  * "Schedule gap" string stayed frozen in whatever locale was active when it
  * was first computed — even though the rest of the component (which calls
  * `t()` directly during render, unmemoized) updated immediately.
+ *
+ * The global test setup (src/__tests__/setup.ts) mocks `@/i18n/translations`
+ * with a static English-only stub for determinism, so this test needs the
+ * real react-i18next-backed hook to exercise an actual locale switch.
+ *
+ * IMPORTANT (perf): don't reach for `vi.unmock("@/i18n/translations")` +
+ * the app's shared `@/i18n/i18next` singleton for this. That singleton
+ * eagerly statically-imports all 14 locale bundles and registers
+ * `i18next-browser-languagedetector` — code no other test file ever
+ * executes (they're all on the mocked stub). The first time any test
+ * executes it, v8 coverage has to instrument that whole surface, which was
+ * enough to blow the 10-minute CI budget for the UI Tests job (PR #1591,
+ * job stalled after `schedule-entry-form-locale-switch.test.tsx` /
+ * `active-page-display-locale-switch.test.tsx` with zero further test
+ * output for 6+ minutes before being cancelled — see run 31565310402).
+ * Instead, mock just `@/i18n/i18next` with a tiny isolated i18next instance
+ * carrying only the `en`/`es` bundles and no language detector, while still
+ * exercising the real `useTranslations()` from `@/i18n/translations` (the
+ * file with the fix under test).
+ *
+ * The instance is built inside the `vi.mock` factory (dynamic imports, so
+ * it isn't subject to the module-hoisting order that would otherwise run
+ * this factory before a same-file top-level `const` is assigned) and handed
+ * back out through a `vi.hoisted()` holder so the test body can drive
+ * `changeLanguage` on the exact instance the component reads from.
  */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, render, screen, waitFor } from "@testing-library/react";
 import { http, HttpResponse } from "msw";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { i18nHolder } = vi.hoisted(() => ({ i18nHolder: {} as { current?: import("i18next").i18n } }));
+
+vi.mock("@/i18n/i18next", async () => {
+  const { default: i18next } = await import("i18next");
+  const { initReactI18next } = await import("react-i18next");
+  const { default: en } = await import("../../messages/en.json");
+  const { default: es } = await import("../../messages/es.json");
+
+  const instance = i18next.createInstance();
+  await instance.use(initReactI18next).init({
+    resources: { en: { translation: en }, es: { translation: es } },
+    lng: "en",
+    fallbackLng: "en",
+    interpolation: { escapeValue: false, prefix: "{{", suffix: "}}" },
+    returnNull: false,
+    react: { useSuspense: false },
+  });
+  i18nHolder.current = instance;
+  return { default: instance };
+});
 
 // The global test setup (src/__tests__/setup.ts) mocks `@/i18n/translations`
 // with a static English-only stub for determinism. This test specifically
@@ -21,7 +67,6 @@ vi.unmock("@/i18n/translations");
 import { ActivePageDisplay } from "@/components/active-page-display";
 import { ConfigOverridesProvider } from "@/hooks/use-config-overrides";
 import { ThemeProvider } from "@/hooks/use-theme";
-import i18n from "@/i18n/i18next";
 
 import { server } from "./mocks/server";
 
@@ -66,10 +111,11 @@ function TestWrapper({ children }: { children: React.ReactNode }) {
 describe("ActivePageDisplay - locale switch (issue #1570)", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
-    // Always start from a known locale; changeLanguage is synchronous here
-    // because all 14 locale bundles are statically imported in i18next.ts.
+    // Always start from a known locale; changeLanguage resolves synchronously
+    // here since both bundles are already loaded into the test i18next
+    // instance set up by the mock factory above.
     await act(async () => {
-      await i18n.changeLanguage("en");
+      await i18nHolder.current!.changeLanguage("en");
     });
   });
 
@@ -97,7 +143,7 @@ describe("ActivePageDisplay - locale switch (issue #1570)", () => {
     expect(screen.getByText(/No page scheduled for current time/i)).toBeInTheDocument();
 
     await act(async () => {
-      await i18n.changeLanguage("es");
+      await i18nHolder.current!.changeLanguage("es");
     });
 
     // Control assertion: the unmemoized string updated to Spanish.

--- a/web/src/__tests__/schedule-entry-form-locale-switch.test.tsx
+++ b/web/src/__tests__/schedule-entry-form-locale-switch.test.tsx
@@ -4,9 +4,38 @@
  * the effect's other deps (pageId, startTime, endTime, ...) change on a
  * language switch, the memoized validation-error strings stayed frozen in
  * whatever locale was active when the effect last ran.
+ *
+ * See the header comment in active-page-display-locale-switch.test.tsx for
+ * why this mocks just `@/i18n/i18next` with a tiny two-locale instance
+ * (built inside the `vi.mock` factory, handed out via `vi.hoisted()`)
+ * instead of `vi.unmock`-ing the app's shared 14-locale singleton: the
+ * latter blew the UI Tests job's 10-minute CI budget (PR #1591, run
+ * 31565310402) because v8 coverage had to instrument all 14 locale bundles
+ * plus `i18next-browser-languagedetector` for the first time.
  */
 import { act, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { i18nHolder } = vi.hoisted(() => ({ i18nHolder: {} as { current?: import("i18next").i18n } }));
+
+vi.mock("@/i18n/i18next", async () => {
+  const { default: i18next } = await import("i18next");
+  const { initReactI18next } = await import("react-i18next");
+  const { default: en } = await import("../../messages/en.json");
+  const { default: es } = await import("../../messages/es.json");
+
+  const instance = i18next.createInstance();
+  await instance.use(initReactI18next).init({
+    resources: { en: { translation: en }, es: { translation: es } },
+    lng: "en",
+    fallbackLng: "en",
+    interpolation: { escapeValue: false, prefix: "{{", suffix: "}}" },
+    returnNull: false,
+    react: { useSuspense: false },
+  });
+  i18nHolder.current = instance;
+  return { default: instance };
+});
 
 // The global test setup (src/__tests__/setup.ts) mocks `@/i18n/translations`
 // with a static English-only stub for determinism. This test specifically
@@ -15,7 +44,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.unmock("@/i18n/translations");
 
 import { ScheduleEntryForm } from "@/components/schedule-entry-form";
-import i18n from "@/i18n/i18next";
 
 const mockPages = [
   { id: "page-1", name: "Night Dashboard" },
@@ -25,7 +53,7 @@ const mockPages = [
 describe("ScheduleEntryForm - locale switch (issue #1570)", () => {
   beforeEach(async () => {
     await act(async () => {
-      await i18n.changeLanguage("en");
+      await i18nHolder.current!.changeLanguage("en");
     });
   });
 
@@ -43,7 +71,7 @@ describe("ScheduleEntryForm - locale switch (issue #1570)", () => {
     });
 
     await act(async () => {
-      await i18n.changeLanguage("es");
+      await i18nHolder.current!.changeLanguage("es");
     });
 
     // Before the fix (missing `t` dep) this stayed stuck on the English

--- a/web/src/__tests__/schedule-entry-form-locale-switch.test.tsx
+++ b/web/src/__tests__/schedule-entry-form-locale-switch.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * Regression test for issue #1570: the validation useEffect in
+ * ScheduleEntryForm was missing `t` from its dependency array. Since none of
+ * the effect's other deps (pageId, startTime, endTime, ...) change on a
+ * language switch, the memoized validation-error strings stayed frozen in
+ * whatever locale was active when the effect last ran.
+ */
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The global test setup (src/__tests__/setup.ts) mocks `@/i18n/translations`
+// with a static English-only stub for determinism. This test specifically
+// exercises real locale switching, so it needs the actual react-i18next-backed
+// hook instead.
+vi.unmock("@/i18n/translations");
+
+import { ScheduleEntryForm } from "@/components/schedule-entry-form";
+import i18n from "@/i18n/i18next";
+
+const mockPages = [
+  { id: "page-1", name: "Night Dashboard" },
+  { id: "page-2", name: "Morning Dashboard" },
+];
+
+describe("ScheduleEntryForm - locale switch (issue #1570)", () => {
+  beforeEach(async () => {
+    await act(async () => {
+      await i18n.changeLanguage("en");
+    });
+  });
+
+  it("recomputes validation error messages when the language changes", async () => {
+    const onSubmit = vi.fn();
+    const onCancel = vi.fn();
+
+    render(
+      // No prefillPageId -> pageId starts empty -> "Please select a page" validation error.
+      <ScheduleEntryForm pages={mockPages} onSubmit={onSubmit} onCancel={onCancel} prefillDayPattern="all" />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Please select a page")).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      await i18n.changeLanguage("es");
+    });
+
+    // Before the fix (missing `t` dep) this stayed stuck on the English
+    // string because none of the effect's other deps changed on a locale switch.
+    await waitFor(() => {
+      expect(screen.getByText("Por favor selecciona una página")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Please select a page")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/__tests__/setup.ts
+++ b/web/src/__tests__/setup.ts
@@ -31,9 +31,23 @@ function getNestedRaw(obj: unknown, path: string): unknown {
   return current;
 }
 
+// `t` must be a STABLE reference across renders, exactly like the real
+// `useTranslations` in `@/i18n/translations` (which memoizes on
+// [language, namespace]). Components legitimately put `t` in `useEffect` /
+// `useMemo` dependency arrays so their text recomputes on a language switch.
+// If this mock handed back a fresh `t` on every render, any such effect that
+// calls `setState` would re-fire every render -> re-render -> re-fire, an
+// infinite loop that OOMs the vitest worker and takes the whole test file
+// down with it (see #1570). The mock is English-only and stateless, so `t`
+// is fully determined by `namespace` and can be built once and cached.
+const intlMockTCache = new Map<string, unknown>();
+
 function makeIntlMock() {
   return {
     useTranslations: (namespace?: string) => {
+      const cacheKey = namespace ?? "";
+      const cached = intlMockTCache.get(cacheKey);
+      if (cached !== undefined) return cached;
       const ns = namespace ? getNestedRaw(enMessages, namespace) : enMessages;
       const lookup = (key: string): unknown => {
         const v = getNestedRaw(ns, key);
@@ -113,6 +127,7 @@ function makeIntlMock() {
         const v = getNestedRaw(ns, key);
         return v === undefined ? key : v;
       };
+      intlMockTCache.set(cacheKey, t);
       return t;
     },
     useLocale: () => "en",

--- a/web/src/components/active-page-display.tsx
+++ b/web/src/components/active-page-display.tsx
@@ -307,7 +307,7 @@ export function ActivePageDisplay() {
         },
       });
     }
-  }, [scheduleEnabled, isLoadingActivePage, isLoadingPages, activePageId, pages, setActivePageMutation]);
+  }, [scheduleEnabled, isLoadingActivePage, isLoadingPages, activePageId, pages, setActivePageMutation, t]);
 
   // Use transition for non-urgent updates to improve perceived performance
   const [isPending, startTransition] = useTransition();
@@ -407,7 +407,7 @@ export function ActivePageDisplay() {
       return activeCollection.name;
     }
     return activePage?.name || "No page selected";
-  }, [activePage, activePageId, scheduleEnabled, activeCollection]);
+  }, [activePage, activePageId, scheduleEnabled, activeCollection, t]);
 
   // Poll the actual board state from the backend cache (backend hits Vestaboard
   // at the configured interval; we just read the cached result here). Secondary

--- a/web/src/components/board-display.stories.tsx
+++ b/web/src/components/board-display.stories.tsx
@@ -52,6 +52,21 @@ MUNI 33 - 12 MIN
 {64}{64} TRAFFIC {64}{64}
 HOME TO WORK 25M`;
 
+// Hoisted to module scope (rather than declared inside the story components)
+// so it's a stable reference the mount-effect's dependency array doesn't need
+// to track.
+const LOADING_TRANSITION_MESSAGE = `{red}HELLO WORLD{/red}
+WELCOME TO
+FIESTABOARD
+{blue}52{/blue}°F {yellow}62{/yellow}°F CLOUDY
+{63}{64}{65}{66}{67}{68} SPLIT FLAP {63}{64}{65}{66}{67}{68}`;
+
+const LOADING_TO_LOADED_MESSAGE = `{red}BRUSH YOUR TEETH!{/red}
+{blue}SPENCER{/blue}
+{green}ROBBIE{/green}
+{orange}ELI{/orange}
+{yellow}FLOSS TOO!{/yellow}`;
+
 const multiColorBar = `{63}{63}{64}{64}{65}{65}{66}{66}{67}{67}{68}{68}
 {red}RED{/red} {orange}ORANGE{/orange} {yellow}YELLOW{/yellow}
 {green}GREEN{/green} {blue}BLUE{/blue} {violet}VIOLET{/violet}
@@ -168,16 +183,10 @@ export const LoadingTransition = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [message, setMessage] = useState<string | null>(null);
 
-  const testMessage = `{red}HELLO WORLD{/red}
-WELCOME TO
-FIESTABOARD
-{blue}52{/blue}°F {yellow}62{/yellow}°F CLOUDY
-{63}{64}{65}{66}{67}{68} SPLIT FLAP {63}{64}{65}{66}{67}{68}`;
-
   useEffect(() => {
     // Start with loading, then show message after 3 seconds
     const timer = setTimeout(() => {
-      setMessage(testMessage);
+      setMessage(LOADING_TRANSITION_MESSAGE);
       setIsLoading(false);
     }, 3000);
 
@@ -190,7 +199,7 @@ FIESTABOARD
 
     // After 3 seconds of loading, show the message again
     setTimeout(() => {
-      setMessage(testMessage);
+      setMessage(LOADING_TRANSITION_MESSAGE);
       setIsLoading(false);
     }, 3000);
   };
@@ -282,16 +291,10 @@ export const LoadingToLoadedTransition = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [message, setMessage] = useState<string | null>(null);
 
-  const testMessage = `{red}BRUSH YOUR TEETH!{/red}
-{blue}SPENCER{/blue}
-{green}ROBBIE{/green}
-{orange}ELI{/orange}
-{yellow}FLOSS TOO!{/yellow}`;
-
   useEffect(() => {
     // Start with loading for 3 seconds, then show message
     const timer = setTimeout(() => {
-      setMessage(testMessage);
+      setMessage(LOADING_TO_LOADED_MESSAGE);
       setIsLoading(false);
     }, 3000);
 
@@ -303,7 +306,7 @@ export const LoadingToLoadedTransition = () => {
     setMessage(null);
 
     setTimeout(() => {
-      setMessage(testMessage);
+      setMessage(LOADING_TO_LOADED_MESSAGE);
       setIsLoading(false);
     }, 3000);
   };

--- a/web/src/components/global-ai-chat-drawer.tsx
+++ b/web/src/components/global-ai-chat-drawer.tsx
@@ -523,7 +523,6 @@ export function GlobalAiChatDrawer() {
     },
     [
       router,
-      close,
       hasEditor,
       applyEditorOp,
       saveEditor,

--- a/web/src/components/page-builder.tsx
+++ b/web/src/components/page-builder.tsx
@@ -178,6 +178,11 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
   const [notesTall, setNotesTall] = useState(1);
   const dims = resolveDimensions(deviceType, notesWide, notesTall);
   const numLines = dims.rows;
+  // Latest numLines for effects that need it without becoming reactive to it
+  // (the load-draft effect below intentionally excludes notesWide/notesTall
+  // changes so resizing a note-array grid doesn't reset in-progress edits).
+  const numLinesRef = useRef(numLines);
+  numLinesRef.current = numLines;
 
   // Preview board color - defaults to the user's configured board color
   const defaultBoardColor = getEffectiveBoardColor(boardSettings);
@@ -494,7 +499,14 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
         liveTimeoutRef.current = null;
       }
     };
-  }, [liveOutputEnabled, debouncedTemplateLines, debouncedLineAlignments, debouncedLineWrapEnabled, disableLiveOutput]);
+  }, [
+    liveOutputEnabled,
+    debouncedTemplateLines,
+    debouncedLineAlignments,
+    debouncedLineWrapEnabled,
+    disableLiveOutput,
+    LIVE_OUTPUT_TIMEOUT_MS,
+  ]);
 
   // Keep lastPreviewRef in sync so the transition effect below can read the
   // current preview without creating a stale closure.
@@ -524,7 +536,7 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
       });
     }
     liveOutputEnabledRef.current = liveOutputEnabled;
-  }, [liveOutputEnabled]);
+  }, [liveOutputEnabled, queryClient]);
 
   // Restore board display when component unmounts if live output was active.
   // Also clear the shared live-output cache + localStorage so the Home page
@@ -602,7 +614,7 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
       const pageName = existingPage.name;
       setName(pageName);
 
-      const rawLines = existingPage.template || emptyLines();
+      const rawLines = existingPage.template || Array.from({ length: numLinesRef.current }, () => "");
       const meta = existingPage.line_metadata;
 
       const alignments: LineAlignment[] = [];
@@ -1065,14 +1077,24 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
     },
   });
 
+  // react-query returns a new `previewMutation` object identity on most
+  // renders, so it can't be listed directly in the effect's dependency array
+  // below without making the debounced-preview effect (and its 200ms
+  // setTimeout) re-fire on every render instead of only when the tracked
+  // template/alignment/wrap state actually changes. Read the latest mutation
+  // through a ref instead — same pattern as lastPreviewRef/liveOutputEnabledRef
+  // above.
+  const previewMutationRef = useRef(previewMutation);
+  previewMutationRef.current = previewMutation;
+
   // Auto-preview when debounced template lines or alignments change (debounced)
   // Skipped when live mode is on — the live fast path handles preview updates directly.
   useEffect(() => {
     if (liveOutputEnabled) {
       needsRePreview.current = false;
-      if (previewMutation.isPending) {
+      if (previewMutationRef.current.isPending) {
         shouldIgnoreNextResponse.current = true;
-        previewMutation.reset();
+        previewMutationRef.current.reset();
       }
       return;
     }
@@ -1082,9 +1104,9 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
     if (!hasContent) {
       setPreview(null);
       needsRePreview.current = false;
-      if (previewMutation.isPending) {
+      if (previewMutationRef.current.isPending) {
         shouldIgnoreNextResponse.current = true;
-        previewMutation.reset();
+        previewMutationRef.current.reset();
       }
       return;
     }
@@ -1101,15 +1123,15 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
       if (!stillHasContent) {
         setPreview(null);
         shouldIgnoreNextResponse.current = false;
-        if (previewMutation.isPending) {
+        if (previewMutationRef.current.isPending) {
           shouldIgnoreNextResponse.current = true;
-          previewMutation.reset();
+          previewMutationRef.current.reset();
         }
         return;
       }
 
-      if (!previewMutation.isPending) {
-        previewMutation.mutate();
+      if (!previewMutationRef.current.isPending) {
+        previewMutationRef.current.mutate();
       } else {
         needsRePreview.current = true;
       }
@@ -1149,6 +1171,10 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
     },
   });
 
+  // Same react-query identity-churn concern as previewMutationRef above.
+  const liveSendMutationRef = useRef(liveSendMutation);
+  liveSendMutationRef.current = liveSendMutation;
+
   // Legacy live send path — only used as fallback when fast path hasn't handled the update.
   // The fast path sets lastLiveSentPreview to match preview, so this is effectively a no-op
   // when live mode is active. Kept for safety if the fast path request fails.
@@ -1160,10 +1186,10 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
     const hasContent = debouncedTemplateLines.some((line) => line.trim().length > 0);
     if (!hasContent) return;
 
-    if (!liveSendMutation.isPending) {
-      liveSendMutation.mutate(preview);
+    if (!liveSendMutationRef.current.isPending) {
+      liveSendMutationRef.current.mutate(preview);
     }
-  }, [preview, liveOutputEnabled]);
+  }, [preview, liveOutputEnabled, debouncedTemplateLines]);
 
   // Live edit fast path: single 100ms debounce → single API call → preview + board update.
   // Bypasses the normal double-debounce (150ms + 200ms) and double API call chain.
@@ -1242,7 +1268,7 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
         liveAbortRef.current = null;
       }
     };
-  }, [liveOutputEnabled, templateLines, lineAlignments, lineWrapEnabled, selectedBoardId]);
+  }, [liveOutputEnabled, templateLines, lineAlignments, lineWrapEnabled, selectedBoardId, deviceType, queryClient]);
 
   // Initialize selected board to first board when settings load
   useEffect(() => {

--- a/web/src/components/schedule-entry-form.tsx
+++ b/web/src/components/schedule-entry-form.tsx
@@ -259,6 +259,7 @@ export function ScheduleEntryForm({
     oneOffDate,
     oneOffEndDate,
     oneOffHasRange,
+    t,
   ]);
 
   const timeToMinutes = (time: string): number => {

--- a/web/src/components/tiptap-template-editor/TipTapTemplateEditor.tsx
+++ b/web/src/components/tiptap-template-editor/TipTapTemplateEditor.tsx
@@ -1073,7 +1073,7 @@ export const TipTapTemplateEditor = forwardRef<TipTapTemplateEditorHandle, TipTa
         onLineCountChange(lineCount);
       }
       scheduleMeasureRef.current?.();
-    }, [value, editor, boardLines]);
+    }, [value, editor, boardLines, onLineCountChange]);
 
     // No need to enforce paragraph count - we use line breaks now
 
@@ -1169,35 +1169,37 @@ export const TipTapTemplateEditor = forwardRef<TipTapTemplateEditorHandle, TipTa
       if (onLineWrapChange) {
         onLineWrapChange(lineIndex, newWrap);
       }
-    }, [editor, getCurrentLineIndex, onLineWrapChange, lineWrapEnabled]);
+      // Depend on the actual values read above (boardLines for the bounds
+      // check, effectiveWrapEnabled for the current-state read) rather than
+      // the raw lineWrapEnabled prop, which this callback doesn't reference
+      // directly and which is stale once the fallback branch of
+      // effectiveWrapEnabled (undefined lineWrapEnabled) is in play.
+    }, [editor, getCurrentLineIndex, onLineWrapChange, boardLines, effectiveWrapEnabled]);
 
     // Safely get current line index - use useMemo to prevent calculation during problematic renders
-    // MUST be called before any early returns to maintain hook order
+    // MUST be called before any early returns to maintain hook order.
+    //
+    // TipTap's `editor` instance keeps a stable reference across selection
+    // changes (it mutates `editor.state` in place rather than being replaced),
+    // so `editor` alone in the dependency array would never pick up a cursor
+    // move; `editor?.state?.selection?.$from?.pos` is what actually needs to
+    // trigger a recompute. eslint-plugin-react-hooks only allows "extra"
+    // dependencies like this for useEffect (where it can't prove they're
+    // unnecessary), not for useMemo/useCallback — so it always flags this one
+    // as unnecessary, even though removing it would leave currentLineIndex
+    // frozen after the very first cursor position (a real regression, not a
+    // lint nit).
     const currentLineIndex = useMemo(() => {
       try {
-        // Only try to get line index if editor is fully initialized
-        if (!editor) {
+        if (!editor?.state?.selection?.$from) {
           return null;
         }
-        if (!editor.state) {
-          return null;
-        }
-        if (!editor.state.selection) {
-          return null;
-        }
-        const { state } = editor;
-        const { selection } = state;
-        if (!selection || !selection.$from) {
-          return null;
-        }
-        const { $from } = selection;
-
-        if (!state.doc) {
+        if (!editor.state.doc) {
           return null;
         }
 
         let lineIndex = 0;
-        state.doc.nodesBetween(0, $from.pos, (node) => {
+        editor.state.doc.nodesBetween(0, editor.state.selection.$from.pos, (node) => {
           if (node && node.type && node.type.name === "hardBreak") {
             lineIndex++;
           }
@@ -1207,6 +1209,7 @@ export const TipTapTemplateEditor = forwardRef<TipTapTemplateEditorHandle, TipTa
         console.warn("Error getting current line index:", error);
         return null;
       }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [editor, editor?.state?.selection?.$from?.pos]);
 
     const currentAlignment =

--- a/web/src/i18n/translations.tsx
+++ b/web/src/i18n/translations.tsx
@@ -13,7 +13,7 @@
  * `messages/*.json` (which uses next-intl's ICU syntax) keeps working
  * without a per-string codemod across 14 locales.
  */
-import React, { Fragment } from "react";
+import React, { Fragment, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 import i18n from "@/i18n/i18next";
@@ -67,70 +67,80 @@ export function useTranslations(namespace?: string): TFn {
   void rrtT;
   const language = rrtI18n.language || i18n.language || "en";
 
-  const resources = (i18n.getResourceBundle(language, "translation") ?? {}) as Record<string, unknown>;
-  const ns = namespace ? getNestedRaw(resources, namespace) : resources;
+  // Memoize `t` itself so it's a stable reference across renders as long as
+  // the language and namespace haven't changed. Without this, `t` is a new
+  // function identity on every render, which makes it unsafe to add to a
+  // `useEffect`/`useMemo` dependency array — an effect that unconditionally
+  // calls `setState` would re-fire (and re-render) on every render, not just
+  // on an actual language change, causing an infinite render loop. Consumers
+  // still need `t` in their dependency arrays to recompute derived text on a
+  // real language switch (see issue #1570); this makes that safe.
+  return useMemo(() => {
+    const resources = (i18n.getResourceBundle(language, "translation") ?? {}) as Record<string, unknown>;
+    const ns = namespace ? getNestedRaw(resources, namespace) : resources;
 
-  const lookup = (key: string): unknown => {
-    const v = getNestedRaw(ns, key);
-    if (v === undefined && language !== "en") {
-      // Fall back to English if the active locale is missing the key,
-      // mirroring i18next's fallbackLng behavior at a per-key level.
-      const en = i18n.getResourceBundle("en", "translation") as Record<string, unknown> | undefined;
-      const enNs = namespace ? getNestedRaw(en, namespace) : en;
-      const enV = getNestedRaw(enNs, key);
-      if (enV !== undefined) return enV;
-    }
-    return v === undefined ? (namespace ? `${namespace}.${key}` : key) : v;
-  };
-
-  const t = ((key: string, params?: Record<string, unknown>) => {
-    const raw = lookup(key);
-    const rawStr = typeof raw === "string" ? raw : namespace ? `${namespace}.${key}` : key;
-    return interpolatePlural(rawStr, params);
-  }) as TFn;
-
-  t.rich = (key: string, values?: Record<string, unknown>) => {
-    const rawVal = lookup(key);
-    const raw = typeof rawVal === "string" ? rawVal : key;
-    if (!values) return raw;
-    const parts: React.ReactNode[] = [];
-    const regex = /<(\w+)>(.*?)<\/\1>|\{(\w+)\}/g;
-    let lastIndex = 0;
-    let match: RegExpExecArray | null;
-    let nodeKey = 0;
-    while ((match = regex.exec(raw)) !== null) {
-      if (match.index > lastIndex) {
-        parts.push(raw.slice(lastIndex, match.index));
+    const lookup = (key: string): unknown => {
+      const v = getNestedRaw(ns, key);
+      if (v === undefined && language !== "en") {
+        // Fall back to English if the active locale is missing the key,
+        // mirroring i18next's fallbackLng behavior at a per-key level.
+        const en = i18n.getResourceBundle("en", "translation") as Record<string, unknown> | undefined;
+        const enNs = namespace ? getNestedRaw(en, namespace) : en;
+        const enV = getNestedRaw(enNs, key);
+        if (enV !== undefined) return enV;
       }
-      if (match[1]) {
-        const fn = values[match[1]];
-        if (typeof fn === "function") {
-          parts.push(
-            React.createElement(Fragment, { key: nodeKey++ }, (fn as (chunks: string) => React.ReactNode)(match[2])),
-          );
-        } else {
-          parts.push(match[2]);
+      return v === undefined ? (namespace ? `${namespace}.${key}` : key) : v;
+    };
+
+    const t = ((key: string, params?: Record<string, unknown>) => {
+      const raw = lookup(key);
+      const rawStr = typeof raw === "string" ? raw : namespace ? `${namespace}.${key}` : key;
+      return interpolatePlural(rawStr, params);
+    }) as TFn;
+
+    t.rich = (key: string, values?: Record<string, unknown>) => {
+      const rawVal = lookup(key);
+      const raw = typeof rawVal === "string" ? rawVal : key;
+      if (!values) return raw;
+      const parts: React.ReactNode[] = [];
+      const regex = /<(\w+)>(.*?)<\/\1>|\{(\w+)\}/g;
+      let lastIndex = 0;
+      let match: RegExpExecArray | null;
+      let nodeKey = 0;
+      while ((match = regex.exec(raw)) !== null) {
+        if (match.index > lastIndex) {
+          parts.push(raw.slice(lastIndex, match.index));
         }
-      } else if (match[3]) {
-        const v = values[match[3]];
-        if (typeof v === "function") {
-          parts.push(React.createElement(Fragment, { key: nodeKey++ }, (v as () => React.ReactNode)()));
-        } else if (v != null) {
-          parts.push(String(v));
+        if (match[1]) {
+          const fn = values[match[1]];
+          if (typeof fn === "function") {
+            parts.push(
+              React.createElement(Fragment, { key: nodeKey++ }, (fn as (chunks: string) => React.ReactNode)(match[2])),
+            );
+          } else {
+            parts.push(match[2]);
+          }
+        } else if (match[3]) {
+          const v = values[match[3]];
+          if (typeof v === "function") {
+            parts.push(React.createElement(Fragment, { key: nodeKey++ }, (v as () => React.ReactNode)()));
+          } else if (v != null) {
+            parts.push(String(v));
+          }
         }
+        lastIndex = regex.lastIndex;
       }
-      lastIndex = regex.lastIndex;
-    }
-    if (lastIndex < raw.length) parts.push(raw.slice(lastIndex));
-    return React.createElement(Fragment, null, ...parts);
-  };
+      if (lastIndex < raw.length) parts.push(raw.slice(lastIndex));
+      return React.createElement(Fragment, null, ...parts);
+    };
 
-  t.raw = (key: string) => {
-    const v = getNestedRaw(ns, key);
-    return v === undefined ? key : v;
-  };
+    t.raw = (key: string) => {
+      const v = getNestedRaw(ns, key);
+      return v === undefined ? key : v;
+    };
 
-  return t;
+    return t;
+  }, [language, namespace]);
 }
 
 export function useLocale(): string {


### PR DESCRIPTION
## Summary

Fixes GitHub issue #1570 — the 15 `react-hooks/exhaustive-deps` + 1 `no-console` ESLint warnings left after the i18n (#1567) and React Compiler (#1568/#1569) groups. Lint warning count: **404 → 388** (-16, matching exactly).

## Priority fix: the `t`-dependency locale bug (real, user-visible)

Three `useMemo`/`useEffect` hooks read `t()` without `t` in their dependency array, so the memoized text stayed frozen in whatever locale was active when it last recomputed — it would not update on a language switch even though the rest of the component did:

- `web/src/components/active-page-display.tsx:310` — `useEffect` missing `t`
- `web/src/components/active-page-display.tsx:410` — `useMemo` (`activePageName`, the "Schedule gap" text) missing `t`
- `web/src/components/schedule-entry-form.tsx:244` — `useEffect` (validation errors) missing `t`

**The naive fix is unsafe.** `useTranslations()` returned a brand-new function identity on every render. Adding `t` to `ScheduleEntryForm`'s validation effect (which unconditionally calls `setValidationErrors(errors)`) turned it into a run-every-render effect calling `setState` with a new array reference every time → infinite render loop → the test worker crashed with an OOM/segfault. Confirmed this failure mode directly (see below), then fixed the **root cause**: `web/src/i18n/translations.tsx`'s `useTranslations()` now memoizes the returned `t` via `useMemo(() => {...}, [language, namespace])`, so it's stable across renders unless the locale actually changes. This also fixes every other `t`-in-deps case across the codebase for free — most were previously firing on every render without anyone noticing.

### TDD evidence

Added `web/src/__tests__/active-page-display-locale-switch.test.tsx` and `web/src/__tests__/schedule-entry-form-locale-switch.test.tsx`. Each renders the real component (global test setup normally mocks `@/i18n/translations` with a static English stub — these two files `vi.unmock` it to exercise real react-i18next locale switching), asserts the English text, calls `i18n.changeLanguage("es")`, and asserts the memoized text updates to Spanish.

**Before the fix** (both `t` missing from deps, `useTranslations` unmemoized) — failed exactly as expected, with the DOM showing the *rest* of the component switched to Spanish ("Pantalla activa", "Cambiar página") while the memoized text stayed in English ("Schedule gap (no default page set)"):

```
FAIL  active-page-display-locale-switch.test.tsx > recomputes the memoized schedule-gap name when the language changes
TestingLibraryElementError: Unable to find an element with the text: Intervalo en el horario (sin página predeterminada).
  <h3 data-slot="card-title">Pantalla activa</h3>   <!-- unmemoized text: switched -->
  ...
  <span data-slot="text">Schedule gap (no default page set)</span>   <!-- memoized text: stale -->

FAIL  schedule-entry-form-locale-switch.test.tsx > recomputes validation error messages when the language changes
TestingLibraryElementError: Unable to find an element with the text: Por favor selecciona una página.
```

**Non-vacuity check**: reverted just the two `t`-in-deps additions (kept the `useTranslations` memoization) — both tests failed again with the same stale-locale symptom, confirming the test detects the specific missing-dependency bug, not just the infinite-loop fix. Restored the fix — both pass.

**After the fix**, both pass:
```
✓ src/__tests__/schedule-entry-form-locale-switch.test.tsx (1 test) 144ms
✓ src/__tests__/active-page-display-locale-switch.test.tsx (1 test) 437ms
    ✓ recomputes the memoized schedule-gap name when the language changes  434ms
```

## Remaining `react-hooks/exhaustive-deps` warnings (12)

| File:line | Warning | Fix |
|---|---|---|
| `active-page-display.tsx:310` | missing `t` | added (see above) |
| `active-page-display.tsx:410` | missing `t` | added (see above) |
| `board-display.stories.tsx:185` | missing `testMessage` | hoisted to module-scope const (Storybook file; not behavior) |
| `board-display.stories.tsx:299` | missing `testMessage` | hoisted to module-scope const |
| `global-ai-chat-drawer.tsx:524` | unnecessary `close` | removed — verified `close()` is never called inside `handleToolCall` |
| `page-builder.tsx:497` | missing `LIVE_OUTPUT_TIMEOUT_MS` | added directly (stable literal) |
| `page-builder.tsx:527` | missing `queryClient` | added directly (stable react-query client) |
| `page-builder.tsx:672` | missing `emptyLines` | **not added directly** — would re-run the load-draft effect on every `numLines` change, wiping in-progress edits on note-array resize. Replaced the fallback with a `numLinesRef` read instead |
| `page-builder.tsx:1126` | missing `previewMutation` | **not added directly** — react-query returns a new object identity most renders; adding it would break the 200ms debounce / risk a render loop. Read via `previewMutationRef`, matching the existing `lastPreviewRef` pattern in this file |
| `page-builder.tsx:1166` | missing `debouncedTemplateLines`, `liveSendMutation` | `debouncedTemplateLines` added directly (safe); `liveSendMutation` via `liveSendMutationRef` (same reasoning as above) |
| `page-builder.tsx:1245` | missing `deviceType`, `queryClient` | both added directly (safe) |
| `schedule-entry-form.tsx:244` | missing `t` | added (see above) |
| `TipTapTemplateEditor.tsx:1076` | missing `onLineCountChange` | added directly (no current caller passes an unstable function) |
| `TipTapTemplateEditor.tsx:1172` | missing `boardLines`, `effectiveWrapEnabled` | fixed a real stale-closure bug: the callback read `effectiveWrapEnabled`/`boardLines` but the deps array listed the raw `lineWrapEnabled` prop instead |
| `TipTapTemplateEditor.tsx:1210` | unnecessary `editor.state.selection.$from.pos` | **kept**, with a scoped `eslint-disable-next-line` + comment. TipTap's `editor` mutates its internal state in place, so `editor` alone never changes reference on a cursor move — this dependency is what actually drives the recompute. `eslint-plugin-react-hooks` v7 only tolerates "extra" deps like this for `useEffect`, not `useMemo`/`useCallback` (confirmed in the rule source), so it unconditionally flags it. Removing it would freeze `currentLineIndex` after the first cursor position — a real regression. Existing precedent for scoped disables on this exact rule in `ai-action-confirmation.tsx`, `schema-form.tsx`, `board-settings.tsx`, and others |

Did not write behavioral tests for these 12 — they're either dev-only files (Storybook stories), or fixes to non-visible internal timing/reactivity that would require mocking react-query's internal object-identity churn or TipTap's ProseMirror internals to meaningfully assert on, which risks testing the mock rather than the behavior.

## `no-console` (1)

`web/scripts/screenshot-navbar.mjs:26` — a standalone CLI dev script (`node scripts/screenshot-navbar.mjs`, never bundled into the app) whose `console.log` reports where it saved its screenshot. Converting to `warn`/`error` would misrepresent success as a problem. Added `scripts/**` to the existing no-console exemption block in `eslint.config.mjs` (same block already exempts tests/stories/configs for the same reason).

## Verify

- `npm run lint` — 404 → 388 warnings (-16); zero `react-hooks/exhaustive-deps` and zero `no-console` remain.
- `npm run format:check` — passes (ran `prettier --write` on `translations.tsx` after the refactor).
- `npm run typecheck` — pre-existing errors unrelated to this change (confirmed identical on `origin/main`, none touch lines this PR modified).
- `npm run test:run` — full suite: 1433 passed, 13 skipped, 0 failed (some worker-pool crashes from resource contention in this environment, no assertion failures — a pre-existing flake pattern, not introduced here). Targeted rerun of every file touched by this PR plus the two new regression tests: all pass.

Fixes #1570

🤖 Generated with [Claude Code](https://claude.com/claude-code)
