### PR TITLE
feat(marketplace): carry plugin_type through the registry publish path

### DIFF
--- a/scripts/extract_plugin.py
+++ b/scripts/extract_plugin.py
@@ -148,6 +148,26 @@ def registry_has_plugin(data: dict, plugin_id: str) -> bool:
     return any(e.get("id") == plugin_id for e in data.get("plugins", []))
 
 
+def build_registry_entry(plugin_id: str, manifest: dict, repo_url: str) -> dict:
+    """Build the ``plugin-registry.json`` entry for a freshly extracted plugin.
+
+    ``plugin_type`` has to travel with the rest of the manifest metadata:
+    without it a published transition plugin would land in the marketplace
+    indistinguishable from a data plugin.
+    """
+    return {
+        "id": plugin_id,
+        "name": manifest.get("name", plugin_id),
+        "description": manifest.get("description", ""),
+        "repository": repo_url,
+        "author": manifest.get("author", "FiestaBoard Team"),
+        "fiestaboard_version": FIESTABOARD_VERSION_CONSTRAINT,
+        "icon": manifest.get("icon", "puzzle"),
+        "category": manifest.get("category", "utility"),
+        "plugin_type": manifest.get("plugin_type", "data"),
+    }
+
+
 def load_plugin_manifest(plugin_dir: Path) -> dict:
     manifest_path = plugin_dir / "manifest.json"
     with open(manifest_path, encoding="utf-8") as f:
@@ -309,18 +329,7 @@ def extract_plugin(plugin_id: str, dry_run: bool = False) -> bool:
         log(f"  Registry entry already exists for {plugin_id}, updating...")
         registry["plugins"] = [e for e in registry["plugins"] if e.get("id") != plugin_id]
 
-    registry["plugins"].append(
-        {
-            "id": plugin_id,
-            "name": manifest.get("name", plugin_id),
-            "description": manifest.get("description", ""),
-            "repository": repo_url,
-            "author": manifest.get("author", "FiestaBoard Team"),
-            "fiestaboard_version": FIESTABOARD_VERSION_CONSTRAINT,
-            "icon": manifest.get("icon", "puzzle"),
-            "category": manifest.get("category", "utility"),
-        }
-    )
+    registry["plugins"].append(build_registry_entry(plugin_id, manifest, repo_url))
 
     # Keep registry sorted by id for clean diffs
     registry["plugins"].sort(key=lambda e: e["id"])

--- a/src/plugins/registry.py
+++ b/src/plugins/registry.py
@@ -1306,6 +1306,7 @@ class PluginRegistry:
                     "fiestaboard_version": e.fiestaboard_version,
                     "icon": e.icon,
                     "category": e.category,
+                    "plugin_type": e.plugin_type,
                     "installed": installed,
                     "teaser": teaser,
                     "previews": previews,

--- a/src/plugins/sources.py
+++ b/src/plugins/sources.py
@@ -115,6 +115,10 @@ class RegistryEntry:
     #: Plugin category.
     category: str = "utility"
 
+    #: "data" or "transition".  Registry entries predating transition plugins
+    #: omit the key entirely, so the default has to be the data plugin.
+    plugin_type: str = "data"
+
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "RegistryEntry":
         return cls(
@@ -127,6 +131,7 @@ class RegistryEntry:
             fiestaboard_version=data.get("fiestaboard_version", ""),
             icon=data.get("icon", "puzzle"),
             category=data.get("category", "utility"),
+            plugin_type=data.get("plugin_type", "data"),
         )
 
 

--- a/tests/test_extract_plugin.py
+++ b/tests/test_extract_plugin.py
@@ -1,0 +1,49 @@
+"""The registry entry ``scripts/extract_plugin.py`` writes when publishing a plugin.
+
+``extract_plugin`` itself clones, commits and pushes to GitHub, so the piece
+worth guarding is the pure translation from a plugin's manifest into its
+``plugin-registry.json`` entry — in particular that a transition plugin does
+not silently arrive in the marketplace as a data plugin.
+"""
+
+from scripts.extract_plugin import FIESTABOARD_VERSION_CONSTRAINT, build_registry_entry
+
+REPO_URL = "https://github.com/Fiestaboard/fiestaboard-plugin--typewriter"
+
+
+class TestBuildRegistryEntry:
+    def test_carries_transition_plugin_type_from_manifest(self):
+        entry = build_registry_entry(
+            "typewriter",
+            {"name": "Typewriter", "plugin_type": "transition"},
+            REPO_URL,
+        )
+        assert entry["plugin_type"] == "transition"
+
+    def test_defaults_plugin_type_to_data_when_manifest_omits_it(self):
+        entry = build_registry_entry("weather", {"name": "Weather"}, REPO_URL)
+        assert entry["plugin_type"] == "data"
+
+    def test_carries_manifest_metadata(self):
+        entry = build_registry_entry(
+            "weather",
+            {
+                "name": "Weather",
+                "description": "Weather data",
+                "author": "Alice",
+                "icon": "cloud-sun",
+                "category": "weather",
+            },
+            REPO_URL,
+        )
+        assert entry == {
+            "id": "weather",
+            "name": "Weather",
+            "description": "Weather data",
+            "repository": REPO_URL,
+            "author": "Alice",
+            "fiestaboard_version": FIESTABOARD_VERSION_CONSTRAINT,
+            "icon": "cloud-sun",
+            "category": "weather",
+            "plugin_type": "data",
+        }

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -996,6 +996,35 @@ def test_get_registry_entries_marks_installed(mock_load, registry, mock_loader, 
     assert entries[0]["installed"] is True
 
 
+@patch("src.plugins.registry.load_registry")
+def test_get_registry_entries_includes_plugin_type(mock_load, registry):
+    """The marketplace payload carries plugin_type so transitions aren't shown as data plugins."""
+    mock_load.return_value = [
+        RegistryEntry(
+            plugin_id="typewriter",
+            name="Typewriter",
+            repository="https://github.com/Org/fiestaboard-plugin--typewriter",
+            plugin_type="transition",
+        ),
+    ]
+    entries = registry.get_registry_entries()
+    assert entries[0]["plugin_type"] == "transition"
+
+
+@patch("src.plugins.registry.load_registry")
+def test_get_registry_entries_defaults_plugin_type_to_data(mock_load, registry):
+    """Entries that never declared a type surface as data plugins."""
+    mock_load.return_value = [
+        RegistryEntry(
+            plugin_id="weather",
+            name="Weather",
+            repository="https://github.com/Org/fiestaboard-plugin--weather",
+        ),
+    ]
+    entries = registry.get_registry_entries()
+    assert entries[0]["plugin_type"] == "data"
+
+
 # --- get_registry_entries: board previews ---
 
 

--- a/tests/test_plugin_sources.py
+++ b/tests/test_plugin_sources.py
@@ -73,6 +73,16 @@ class TestRegistryEntry:
         assert entry.repository == ""
         assert entry.branch == ""
 
+    def test_from_dict_carries_declared_plugin_type(self):
+        """A registry entry declaring a transition plugin stays a transition plugin."""
+        entry = RegistryEntry.from_dict({"id": "typewriter", "name": "Typewriter", "plugin_type": "transition"})
+        assert entry.plugin_type == "transition"
+
+    def test_from_dict_defaults_plugin_type_to_data(self):
+        """Existing entries omit plugin_type entirely; they are data plugins."""
+        entry = RegistryEntry.from_dict({"id": "foo", "name": "Foo"})
+        assert entry.plugin_type == "data"
+
 
 # ── Naming convention ────────────────────────────────────────────────────────
 

--- a/web/app/routes/integrations._index.tsx
+++ b/web/app/routes/integrations._index.tsx
@@ -1860,6 +1860,18 @@ function RegistryPluginRow({
                   {t("installedBadge")}
                 </Badge>
               )}
+              {/* Transitions behave nothing like data plugins once installed —
+                  no variables, no enable toggle — so the marketplace flags the
+                  type up front, with the same badge the Installed table uses. */}
+              {entry.plugin_type === "transition" && (
+                <Badge
+                  variant="outline"
+                  className="text-[10px] gap-1 px-1.5 py-0 h-5 border-violet-300 text-violet-600 dark:text-violet-400 dark:border-violet-700"
+                >
+                  <Wand2 className="h-2.5 w-2.5" />
+                  {t("transitionBadge")}
+                </Badge>
+              )}
             </Flex>
             {entry.description && (
               <Text size="xs" tone="muted" className="truncate max-w-xs">

--- a/web/src/__tests__/integrations-transition-plugins.test.tsx
+++ b/web/src/__tests__/integrations-transition-plugins.test.tsx
@@ -10,6 +10,7 @@
  */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { describe, expect, it } from "vitest";
 
@@ -25,6 +26,13 @@ interface MockPlugin {
   plugin_type?: "data" | "transition";
   enabled?: boolean;
   configured?: boolean;
+}
+
+interface MockRegistryEntry {
+  id: string;
+  name: string;
+  category: string;
+  plugin_type?: "data" | "transition";
 }
 
 function mockPlugins(plugins: MockPlugin[]) {
@@ -54,6 +62,35 @@ function mockPlugins(plugins: MockPlugin[]) {
     ),
     http.get(`${API_BASE}/plugins/registry`, () => HttpResponse.json({ entries: [] })),
   );
+}
+
+/** Marketplace fixtures: nothing installed, `entries` available in the registry. */
+function mockRegistry(entries: MockRegistryEntry[]) {
+  const full = entries.map((e) => ({
+    description: `${e.name} description`,
+    repository: `https://example.com/${e.id}`,
+    branch: "main",
+    author: "FiestaBoard",
+    fiestaboard_version: ">=8.0.0",
+    icon: "puzzle",
+    installed: false,
+    teaser: "",
+    previews: [],
+    ...e,
+  }));
+  server.use(
+    http.get(`${API_BASE}/plugins`, () =>
+      HttpResponse.json({ plugins: [], plugin_system_enabled: true, total: 0, enabled_count: 0 }),
+    ),
+    http.get(`${API_BASE}/plugins/registry`, () => HttpResponse.json({ entries: full })),
+  );
+}
+
+/** Open Marketplace → list view, where registry entries render as table rows. */
+async function openMarketplaceList() {
+  const user = userEvent.setup();
+  await user.click(await screen.findByRole("tab", { name: /marketplace/i }));
+  await user.click(await screen.findByRole("button", { name: /list view/i }));
 }
 
 function renderPage() {
@@ -144,5 +181,46 @@ describe("Integrations page — transition plugins", () => {
     await waitFor(() => {
       expect(within(row).getByRole("button", { name: /more options/i })).toBeInTheDocument();
     });
+  });
+});
+
+/**
+ * The Marketplace tab is a separate code path from the Installed table: it
+ * renders `RegistryEntry` rows straight from the registry payload. Without a
+ * type marker there, a transition plugin is indistinguishable from a data
+ * plugin until after it is installed.
+ */
+describe("Integrations page — transition plugins in the Marketplace", () => {
+  it("badges a registry entry whose plugin_type is transition", async () => {
+    mockRegistry([{ id: "typewriter", name: "Typewriter", category: "transition", plugin_type: "transition" }]);
+    renderPage();
+    await openMarketplaceList();
+
+    const row = await rowFor("Typewriter");
+    expect(within(row).getByText("Transition")).toBeInTheDocument();
+  });
+
+  it("does not badge a registry entry that declares no plugin_type", async () => {
+    mockRegistry([{ id: "weather", name: "Weather", category: "weather" }]);
+    renderPage();
+    await openMarketplaceList();
+
+    // Positive control: the row rendered at all, so the absent badge below is
+    // a real absence and not a selector that quietly stopped matching.
+    const row = await rowFor("Weather");
+    expect(within(row).getByRole("button", { name: /install/i })).toBeInTheDocument();
+    expect(within(row).queryByText("Transition")).not.toBeInTheDocument();
+  });
+
+  it("labels a transition category group with its translated name", async () => {
+    mockRegistry([{ id: "typewriter", name: "Typewriter", category: "transition", plugin_type: "transition" }]);
+    renderPage();
+
+    const user = userEvent.setup();
+    await user.click(await screen.findByRole("tab", { name: /marketplace/i }));
+
+    const heading = await screen.findByRole("heading", { name: /transitions/i });
+    expect(within(heading).getByText("Transitions")).toBeInTheDocument();
+    expect(within(heading).queryByText("transition")).not.toBeInTheDocument();
   });
 });

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1360,6 +1360,12 @@ export interface RegistryEntry {
   category: string;
   installed: boolean;
   /**
+   * "data" (a plugin that publishes template variables) or "transition" (a
+   * frame-by-frame board animation). Absent on registry payloads that predate
+   * the field — treat missing as "data".
+   */
+  plugin_type?: "data" | "transition";
+  /**
    * One-line board strip for the marketplace card, at most 15 tiles. Empty for
    * plugins that predate the previews contract.
    */


### PR DESCRIPTION
Follow-up to #1589, which taught the *installed* plugin surfaces the difference between data and transition plugins. The Marketplace renders `plugin-registry.json` through a separate path that had no concept of plugin type.

## The gap was the publish path, not the seed file

Worth stating plainly, because it changes what's worth doing: **there are currently zero transition plugins in the registry.** All 51 entries are data plugins across 7 categories. So the marketplace display issue is latent, not active.

The live bug is in `scripts/extract_plugin.py`. It builds a registry entry from a plugin's manifest — reading `name`, `description`, `icon`, `category` — and dropped `plugin_type` on the floor. That script is how the four bundled transition plugins (`typewriter`, `slot_machine`, `simple_dissolve`, `quiet_library`) would ship to their own repos, so the first published transition plugin would have silently landed in the marketplace as a data plugin.

## Changes

- `RegistryEntry` gains `plugin_type` (defaults to `"data"`, since every existing entry omits the key) and parses it in `from_dict`
- `get_registry_entries()` carries it into the marketplace payload
- `extract_plugin.py` carries `manifest["plugin_type"]` into the entry it appends
- The Marketplace **list view** badges transition entries, reusing the exact `Badge` treatment from the Installed table rather than inventing a second one
- `RegistryEntry` TS interface gains `plugin_type?: "data" | "transition"` — optional, so pre-field payloads and existing fixtures stay valid

### One structural change, deliberately

The registry-entry dict moved out of `extract_plugin()` into a pure `build_registry_entry()` helper. `extract_plugin()` shells out to `gh` and `git` for ~160 lines before reaching the append, so reaching that dict from a test meant mocking five subprocess boundaries to assert one return value. Lifting it is cleaner and mirrors `sync_plugin_previews.manifest_entry`, which is tested the same way. Behavior is identical.

## Deliberately not done

**`plugin-registry.json` is untouched.** All 51 entries are data plugins and the dataclass default covers them; writing `"plugin_type": "data"` 51 times would be a large diff that changes no behavior. Say the word if you'd rather have it explicit in the file.

**Card view needs no change.** It's the default Marketplace view and carries no per-card type badge — but transition plugins group under the existing "Transitions" category heading (already wired to `useCategoryLabels()` in #1589), and `PluginCard` guards its teaser footer on truthiness, so a transition plugin — which CLAUDE.md forbids from declaring a `teaser` — renders a clean card rather than an empty board strip. Verified in the bundled component, not assumed.

A per-card *type* badge would need a new `PluginCard` prop in FiestaUI, or repurposing its category badge (which this view intentionally omits, since the group heading already says it). Out of scope here; worth doing if a transition plugin ever ships under a non-`transition` category, where the grouping alone wouldn't mark it.

## Test evidence

Every test written first and proven non-vacuous by breaking the specific production line and recording the failure:

```
# extract_plugin hardcoded to "data" -- the actual bug
    assert entry["plugin_type"] == "transition"
E   AssertionError: assert 'data' == 'transition'

# get_registry_entries payload key removed
E   KeyError: 'plugin_type'

# from_dict default weakened to ""
E   AssertionError: assert '' == 'data'

# marketplace badge guard inverted (positive control fires)
Error: expect(element).not.toBeInTheDocument()

# category heading label reverted to the raw id
TestingLibraryElementError: Unable to find role="heading" and name `/transitions/i`
```

- Python: **4796 passed**. `test_plugin_sources.py`'s 12 failures are all `FileNotFoundError: 'git'` — the local image has no `git` binary; verified 1:1 against the failure messages, not just the count.
- Web: **1500 passed / 119 files**.
- Ruff, Prettier, ESLint clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)