### PR TITLE
registry: add Word Clock

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ FiestaBoard has a catalog of **50+ plugins** covering weather, finance, transit,
 | [Webhook](https://github.com/Fiestaboard/fiestaboard-plugin--webhook) | Custom message via HTTP webhook | No |
 | [White Noise](https://github.com/Fiestaboard/fiestaboard-plugin--white-noise) | Ambient rain/white noise effect | No |
 | [Wildfire Monitor](https://github.com/Fiestaboard/fiestaboard-plugin--wildfire) | Active wildfires from NIFC | No |
+| [Word Clock](https://github.com/rummeyer/fiestaboard-plugin--word-clock) | Time spelled out in words, QLOCKTWO style | No |
 | [Word of the Day](https://github.com/Fiestaboard/fiestaboard-plugin--word-of-day) | Word, pronunciation, and definition | No |
 | [WSDOT Ferries](https://github.com/Fiestaboard/fiestaboard-plugin--wsdot) | WA State ferry schedules and alerts | Yes (free) |
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ FiestaBoard has a catalog of **50+ plugins** covering weather, finance, transit,
 | [Webhook](https://github.com/Fiestaboard/fiestaboard-plugin--webhook) | Custom message via HTTP webhook | No |
 | [White Noise](https://github.com/Fiestaboard/fiestaboard-plugin--white-noise) | Ambient rain/white noise effect | No |
 | [Wildfire Monitor](https://github.com/Fiestaboard/fiestaboard-plugin--wildfire) | Active wildfires from NIFC | No |
-| [Word Clock](https://github.com/rummeyer/fiestaboard-plugin--word-clock) | Time spelled out in words, QLOCKTWO style | No |
+| [Word Clock](https://github.com/Fiestaboard/fiestaboard-plugin--word-clock) | Time spelled out in words, QLOCKTWO style | No |
 | [Word of the Day](https://github.com/Fiestaboard/fiestaboard-plugin--word-of-day) | Word, pronunciation, and definition | No |
 | [WSDOT Ferries](https://github.com/Fiestaboard/fiestaboard-plugin--wsdot) | WA State ferry schedules and alerts | Yes (free) |
 

--- a/cspell.json
+++ b/cspell.json
@@ -86,6 +86,7 @@
     "organise",
     "pylint",
     "pytest",
+    "QLOCKTWO",
     "rescan",
     "retags",
     "rfkill",

--- a/plugin-registry.json
+++ b/plugin-registry.json
@@ -484,6 +484,16 @@
       "category": "data"
     },
     {
+      "id": "word_clock",
+      "name": "Word Clock",
+      "description": "Tell the time in words, QLOCKTWO style, in German, English, Spanish or French.",
+      "repository": "https://github.com/rummeyer/fiestaboard-plugin--word-clock",
+      "author": "Oliver Rummeyer",
+      "fiestaboard_version": ">=7.9.5",
+      "icon": "clock",
+      "category": "utility"
+    },
+    {
       "id": "word_of_day",
       "name": "Word of the Day",
       "description": "Display a word, its pronunciation, and definition.",

--- a/plugin-registry.json
+++ b/plugin-registry.json
@@ -487,7 +487,7 @@
       "id": "word_clock",
       "name": "Word Clock",
       "description": "Tell the time in words, QLOCKTWO style, in German, English, Spanish or French.",
-      "repository": "https://github.com/rummeyer/fiestaboard-plugin--word-clock",
+      "repository": "https://github.com/Fiestaboard/fiestaboard-plugin--word-clock",
       "author": "Oliver Rummeyer",
       "fiestaboard_version": ">=7.9.5",
       "icon": "clock",


### PR DESCRIPTION
## Description

Adds [`fiestaboard-plugin--word-clock`](https://github.com/rummeyer/fiestaboard-plugin--word-clock) to `plugin-registry.json` and to the plugin table in `README.md` — a QLOCKTWO-style word clock that spells the time out in words rather than digits.

A physical word clock lights letters inside a fixed matrix. A split-flap has no dim state, so the plugin renders only the words that would be lit, which is what the matrix visually reduces to anyway.

```
IT IS QUARTER PAST TEN
```

### What it does

- **Four languages.** English, German, Spanish and French. Spanish agrees the opener with the hour the phrase *names* (`ES LA UNA MENOS VEINTE` at 12:40, singular); French carries the unit with the hour and says `MIDI`/`MINUIT` rather than "douze heures".
- **German dialects.** Standard `VIERTEL NACH ZEHN` and the East German / Franconian / Saxon `VIERTEL ELF`, `DREIVIERTEL ELF`.
- **Fits both boards.** Reads `self.board` at render time and re-wraps, so one page works on a Flagship (22×6) and a Note (15×3). A test walks all 24 hours × 12 five-minute steps × every language and option combination on both shapes and asserts no word is lost. French is the tight case at 37 characters (`IL EST QUATRE HEURES MOINS VINGT-CINQ`).
- **Minute dots.** Up to four colour tiles in the bottom-right for the minutes the words cannot express, like the corner dots on a QLOCKTWO. Dropped when the bottom row is full — the time outranks them.
- **`live_data`**, so the board never shows a cached time. Content only reaches the board when the phrase actually changes, so the flaps move once every five minutes.

## Related Issue

None — new plugin submission, no tracking issue.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] New plugin
- [x] Documentation update
- [ ] Refactor / maintenance

## Checklist

- [x] I have tested my changes locally
- [x] I have added/updated tests where applicable
- [x] I have updated documentation where applicable
- [x] My code follows the project's coding standards

### Plugin submission checklist

- [x] Plugin ID `word_clock` matches the repository name `fiestaboard-plugin--word-clock`
- [x] `manifest.json` has `id`, `name`, `version`
- [x] `manifest.json` includes `screenshots` with `"primary": true`
- [x] `__init__.py` implements `PluginBase` (`plugin_id`, `fetch_data` → `PluginResult` with `formatted_lines`, `validate_config`)
- [x] Tests exist with >80% coverage — 187 tests, 100% coverage, enforced in the plugin repo's CI
- [x] `README.md` and `docs/SETUP.md` follow the canonical section order
- [x] `docs/board-display.png` exists
- [x] No hardcoded secrets or personal information
- [x] Plugin added to the main `README.md` table alphabetically (between Wildfire Monitor and Word of the Day)
- [x] `python scripts/validate_plugins.py --registry` passes with this entry

## Notes for review

- No network access, no API key, no environment variables.
- `fiestaboard_version` is `>=7.9.5` — the plugin needs `BoardContext` for the board-adaptive layout, which first appears in `src/plugins/base.py` at that release (7.9.4 does not have it). Every other registry entry pins `>=2.10.0` or `>=4.2.0`, so this one is deliberately stricter.
- Category `utility`, icon `clock`.
- `teaser` and `previews` are declared and rendered from real plugin output, so the directory card matches what a default install produces.
- The plugin repo is MIT licensed and has its own CI.
- The repo lives under my own account rather than the `Fiestaboard` org — happy to transfer it if you would rather host it there.
