### PR TITLE
ci: stop firing Claude workflows on fork PRs

### DIFF
--- a/.github/workflows/claude-a11y-audit-feedback.yml
+++ b/.github/workflows/claude-a11y-audit-feedback.yml
@@ -55,9 +55,15 @@ jobs:
     # On `pull_request_target.closed`, only fire for unmerged a11y-pipeline
     # branches. Draft and ready-for-review PRs both fire `closed`. The script
     # itself refuses to log a merged PR, so manual backfill stays safe.
+    #
+    # Same-repo only. A head ref is just a branch name: anyone can open a
+    # fork PR from a branch called `a11y-audit/x`, close it, and steer
+    # this `contents: write` job into committing their PR's text to the
+    # rejection log on main. The pipeline's own PRs are always same-repo.
     if: >-
       ${{ github.event_name == 'workflow_dispatch' ||
           (github.event.pull_request.merged == false &&
+           github.event.pull_request.head.repo.full_name == github.repository &&
            (startsWith(github.event.pull_request.head.ref, 'a11y/issue-') ||
             startsWith(github.event.pull_request.head.ref, 'a11y-audit/'))) }}
     permissions:

--- a/.github/workflows/claude-a11y-audit-review.yml
+++ b/.github/workflows/claude-a11y-audit-review.yml
@@ -43,9 +43,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # Skip drafts and Dependabot (its read-only token can't post a review).
+    # Skip fork PRs: `claude-code-action` gates on the ACTOR's repo
+    # permission, and a fork contributor has `read`, so the job can only
+    # fail with "Actor does not have write permissions to the repository"
+    # — a red X on an outside contribution the review never even read
+    # (#1593). No action input bypasses that gate. To review a fork PR,
+    # comment `@claude` on it as a maintainer, or run
+    # `claude-docs-review.yml` via workflow_dispatch for the docs half.
     if: >-
       github.event.pull_request.draft == false
       && github.event.pull_request.user.login != 'dependabot[bot]'
+      && github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/claude-bug-hunt-feedback.yml
+++ b/.github/workflows/claude-bug-hunt-feedback.yml
@@ -50,9 +50,15 @@ jobs:
     # On `pull_request_target.closed`, only fire for unmerged bug-hunt fix
     # branches. Draft and ready-for-review PRs both fire `closed`. The script
     # itself refuses to log a merged PR, so manual backfill stays safe.
+    #
+    # Same-repo only. A head ref is just a branch name: anyone can open a
+    # fork PR from a branch called `bug-hunt/issue-1`, close it, and steer
+    # this `contents: write` job into committing their PR's text to the
+    # rejection log on main. The loop's own PRs are always same-repo.
     if: >-
       ${{ github.event_name == 'workflow_dispatch' ||
           (github.event.pull_request.merged == false &&
+           github.event.pull_request.head.repo.full_name == github.repository &&
            startsWith(github.event.pull_request.head.ref, 'bug-hunt/issue-')) }}
     permissions:
       contents: write

--- a/.github/workflows/claude-bug-hunt-review.yml
+++ b/.github/workflows/claude-bug-hunt-review.yml
@@ -42,9 +42,17 @@ jobs:
     timeout-minutes: 15
     # Only the loop's own fix PRs (draft or not). Skip Dependabot (read-only
     # token can't post a review).
+    #
+    # The same-repo check is what makes the branch-prefix gate mean
+    # anything: a head ref is just a branch name, and anyone can open a
+    # fork PR from a branch called `bug-hunt/issue-1`. The loop's own PRs
+    # are always same-repo, so this costs nothing and stops a fork from
+    # summoning a secrets-bearing job. It also avoids the red X — the
+    # action's actor gate rejects fork contributors outright (#1593).
     if: >-
       github.event.pull_request.user.login != 'dependabot[bot]'
       && startsWith(github.event.pull_request.head.ref, 'bug-hunt/issue-')
+      && github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/claude-docs-review.yml
+++ b/.github/workflows/claude-docs-review.yml
@@ -24,6 +24,16 @@ name: 'Claude: Docs Auto-Review'
 # Draft PRs are skipped — a draft signals "not ready for review yet."
 # The trigger includes `ready_for_review` so the review fires when the
 # author flips draft → ready.
+#
+# FORK PRs ARE SKIPPED. `claude-code-action` gates every run on the
+# ACTOR's repo permission, and a fork contributor has `read` — so the job
+# died at "Actor does not have write permissions to the repository"
+# before reading a line of the diff, painting a red X on every outside
+# contribution that touched a markdown file (#1593). There is no input
+# that bypasses that gate, so the honest move is not to fire at all.
+# Maintainers who still want the review run it from the Actions tab via
+# `workflow_dispatch` with the PR number: the actor is then a maintainer,
+# the gate passes, and the review posts exactly as it would have.
 # =============================================================================
 
 on:
@@ -34,6 +44,12 @@ on:
       - 'plugins/*/docs/**'
       - 'docs/**'
       - 'docs-site/**'
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to review. Use this for fork PRs — the automatic trigger skips them.'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -41,7 +57,7 @@ permissions:
 # Cancel a prior review for the same PR if a new push comes in — only the
 # latest diff matters and we don't want two reviews racing the same comment.
 concurrency:
-  group: claude-docs-review-${{ github.event.pull_request.number }}
+  group: claude-docs-review-${{ github.event.pull_request.number || inputs.pr_number }}
   cancel-in-progress: true
 
 jobs:
@@ -53,15 +69,59 @@ jobs:
     # touch docs in a way this review can usefully critique. The job also
     # can't post a review on them: Dependabot PRs receive a read-only
     # GITHUB_TOKEN, so the gh api review POST 403s every time.
+    #
+    # Skip fork PRs — the action's actor permission gate fails them (see
+    # the header). `workflow_dispatch` is the maintainer-run path and is
+    # never gated here: the dispatcher already needs write access, and
+    # dispatch carries no `pull_request` context to test.
     if: >-
-      github.event.pull_request.draft == false
-      && github.event.pull_request.user.login != 'dependabot[bot]'
+      github.event_name == 'workflow_dispatch'
+      || (github.event.pull_request.draft == false
+          && github.event.pull_request.user.login != 'dependabot[bot]'
+          && github.event.pull_request.head.repo.full_name == github.repository)
     permissions:
       contents: read
       pull-requests: write
       id-token: write
       actions: read
     steps:
+      # One source of truth for the PR coordinates, so the rest of the job
+      # doesn't branch on event type. On `pull_request_target` they come
+      # from the event payload; on `workflow_dispatch` only a number was
+      # supplied, so ask the API for the head SHA and base ref. All three
+      # values are repo metadata (never PR file content) — safe to expand
+      # into later expressions.
+      - name: Resolve PR coordinates
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_NUMBER: ${{ inputs.pr_number }}
+          EVENT_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            number="$INPUT_NUMBER"
+            # Fail loudly on a typo'd number rather than running the
+            # review against an empty head SHA.
+            meta=$(gh pr view "$number" --json headRefOid,baseRefName)
+            head_sha=$(printf '%s' "$meta" | jq -er .headRefOid)
+            base_ref=$(printf '%s' "$meta" | jq -er .baseRefName)
+          else
+            number="$EVENT_NUMBER"
+            head_sha="$EVENT_HEAD_SHA"
+            base_ref="$EVENT_BASE_REF"
+          fi
+          {
+            echo "number=$number"
+            echo "head_sha=$head_sha"
+            echo "base_ref=$base_ref"
+          } >> "$GITHUB_OUTPUT"
+          echo "Reviewing PR #$number (head $head_sha, base $base_ref)"
+
       - name: Checkout base ref (trusted)
         uses: actions/checkout@v7
         with:
@@ -73,7 +133,7 @@ jobs:
           # for voice/format comparison. PR head content is read read-only
           # via `gh api .../contents/<path>?ref=<head_sha>` from inside
           # the prompt — data piped through Claude, never executed.
-          ref: ${{ github.event.pull_request.base.ref }}
+          ref: ${{ steps.pr.outputs.base_ref }}
           fetch-depth: 1
           persist-credentials: false
 
@@ -106,7 +166,7 @@ jobs:
             --allowed-tools "Read,Glob,Grep,Bash(ls:*),Bash(cat:*),Bash(find:*),Bash(grep:*),Bash(rg:*),Bash(python3:*),Bash(jq:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*)"
           prompt: |
             You are the FiestaBoard docs reviewer. Review PR
-            #${{ github.event.pull_request.number }} — only the docs changes
+            #${{ steps.pr.outputs.number }} — only the docs changes
             it makes. Skim any non-docs changes for context but don't review
             them; another workflow handles code review.
 
@@ -118,13 +178,13 @@ jobs:
             content. PR-head content is read on-demand via:
 
                 gh api \
-                  "repos/${{ github.repository }}/contents/<path>?ref=${{ github.event.pull_request.head.sha }}" \
+                  "repos/${{ github.repository }}/contents/<path>?ref=${{ steps.pr.outputs.head_sha }}" \
                   -H "Accept: application/vnd.github.raw"
 
             That returns raw file bytes (data only — never executed). Use
             this whenever you need the PR's version of a file.
 
-            1. Run `gh pr diff ${{ github.event.pull_request.number }}` to
+            1. Run `gh pr diff ${{ steps.pr.outputs.number }}` to
                see the exact diff. Focus on `*.md` files and files under
                `plugins/*/docs/`, `docs/`, or `docs-site/`.
             2. Read the root `CLAUDE.md` and `plugins/CLAUDE.md` (if
@@ -172,7 +232,7 @@ jobs:
 
             Inline comments only attach to lines in the PR diff (added
             `+` lines and surrounding context). Run
-            `gh pr diff ${{ github.event.pull_request.number }}` to see
+            `gh pr diff ${{ steps.pr.outputs.number }}` to see
             what's eligible. For each finding, you need:
               - `path` — file path relative to the repo root
               - `line` — the RIGHT-side line number (the line as it
@@ -223,7 +283,7 @@ jobs:
             Build the JSON in python3 and pipe to gh api:
 
                 python3 <<'PY' | gh api \
-                  "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
+                  "repos/${{ github.repository }}/pulls/${{ steps.pr.outputs.number }}/reviews" \
                   --method POST --input -
                 import json
                 payload = {
@@ -291,7 +351,7 @@ jobs:
                     ),
                 }))
                 " | gh api \
-                  "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews" \
+                  "repos/${{ github.repository }}/pulls/${{ steps.pr.outputs.number }}/reviews" \
                   --method POST --input -
 
             Don't manufacture findings to look thorough.

--- a/.github/workflows/docs-audit-feedback.yml
+++ b/.github/workflows/docs-audit-feedback.yml
@@ -66,9 +66,16 @@ jobs:
     # draft-state gate here. `workflow_dispatch` always proceeds — the
     # script itself refuses to log a merged PR, so manual backfill
     # remains safe.
+    #
+    # Same-repo only. A head ref is just a branch name: anyone can open a
+    # fork PR from a branch called `docs-audit/x`, close it, and steer
+    # this `contents: write` job into committing their PR's text to the
+    # rejection log on main. The audit cron's own PRs are always
+    # same-repo, so the check costs nothing.
     if: >-
       ${{ github.event_name == 'workflow_dispatch' ||
           (github.event.pull_request.merged == false &&
+           github.event.pull_request.head.repo.full_name == github.repository &&
            (startsWith(github.event.pull_request.head.ref, 'docs-audit/') ||
             startsWith(github.event.pull_request.head.ref, 'docs/issue-'))) }}
     permissions:

--- a/.github/workflows/pr-changelog.yml
+++ b/.github/workflows/pr-changelog.yml
@@ -9,9 +9,20 @@ name: 'Claude: PR Changelog'
 # Also supports manual workflow_dispatch with a `pr_number` input — useful
 # for retroactively summarizing a PR that merged before this workflow
 # existed, or for re-running a failed summary.
+#
+# `pull_request_target`, not `pull_request`, so that merged FORK PRs get a
+# changelog line too. A `pull_request` run whose head is a fork receives no
+# repo secrets and a read-only GITHUB_TOKEN, so this job would fail twice
+# over on an outside contribution — empty `CLAUDE_CODE_OAUTH_TOKEN`, then a
+# 403 on `gh pr comment` — and the release notes would silently lose the
+# entry. `pull_request_target` is safe here: it evaluates this file from the
+# base ref, the checkout below takes the base ref (never PR head code), and
+# `--allowed-tools` is three read-only `gh` verbs plus the comment post.
+# The actor is whoever merged the PR — a maintainer — so the action's actor
+# permission gate passes.
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches:
       - main
@@ -27,7 +38,7 @@ jobs:
     name: Summarize merged PR
     if: |
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+      (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -37,7 +48,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
+          # No `ref:` — on `pull_request_target` this resolves to the base
+          # branch, which is what we want. Never check out PR head code in
+          # a job that holds secrets (CodeQL `actions/untrusted-checkout`).
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
@@ -45,6 +60,15 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # Required now that the trigger is `pull_request_target`: without
+          # an explicit token the action tries the OIDC→claude[bot] App
+          # exchange, which returns `401 Invalid OIDC token` on
+          # pull_request_target subs (same finding as claude-docs-review.yml).
+          # Passing a token skips the exchange. The cost is the comment
+          # badge — `github-actions[bot]` instead of `claude[bot]` — which
+          # nothing depends on: release.yml harvests these by the
+          # `<!-- claude-changelog -->` marker, never by author.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           claude_args: '--model claude-sonnet-4-6 --allowed-tools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*)"'
           prompt: |
             You are writing one line of a FiestaBoard changelog. FiestaBoard is


### PR DESCRIPTION
## The report

From #1593 (first outside plugin PR in a while):

> Claude: Docs Auto-Review fires on `**.md`, which this PR now matches because I added the Word Clock row to the plugin table in README.md (the plugin-development checklist asks for it). The job stops at the action's actor gate […] So it fails for any fork contributor whose PR touches a markdown file, before it reads a single line of the diff.

Correct diagnosis. `claude-code-action` checks the **actor's** repo permission on every run:

```
Checking permissions for actor: rummeyer
Permission level retrieved: read
Actor has insufficient permissions: read
Action failed with error: Actor does not have write permissions to the repository
```

Fails in 8s, every time, for anyone outside the org. And the plugin checklist *tells* contributors to touch `README.md`, so this hits essentially every outside plugin PR. No action input bypasses the gate.

## What this does

| Workflow | Change |
|---|---|
| `claude-docs-review.yml` | Skip fork PRs + add a `workflow_dispatch` path so a maintainer can still run the review on one |
| `claude-a11y-audit-review.yml` | Skip fork PRs |
| `claude-bug-hunt-review.yml` | Skip fork PRs |
| `docs-audit-feedback.yml`, `claude-a11y-audit-feedback.yml`, `claude-bug-hunt-feedback.yml` | Same-repo check on the `pull_request_target` arm |
| `pr-changelog.yml` | `pull_request` → `pull_request_target` (opposite direction — see below) |

The three review jobs now show **skipped (grey)** instead of **failed (red)**.

### Keeping the capability instead of deleting it

Outside plugin PRs are exactly the docs most worth reviewing, so `claude-docs-review.yml` gets a `workflow_dispatch` input taking a PR number. Dispatching requires write access, so the actor is a maintainer and the gate passes — the review posts exactly as it would have. A `Resolve PR coordinates` step feeds number / head SHA / base ref from either trigger, so the prompt body stays event-agnostic.

### The three capture workflows

Their gates are branch-prefix matches, and a head ref is just a branch name. Anyone can open a fork PR from a branch called `docs-audit/x`, close it, and steer a `contents: write` job into committing their PR's text into the rejection log on `main`. The pipelines' own PRs are always same-repo, so the check costs nothing.

### `pr-changelog.yml` moves the other way

It fires on **merge**, and a `pull_request` run whose head is a fork gets no repo secrets and a read-only `GITHUB_TOKEN`. Merging an outside contribution would have failed twice over — empty `CLAUDE_CODE_OAUTH_TOKEN`, then a 403 on `gh pr comment` — and the PR would have vanished from the release notes silently. It has never been exercised: no fork PR has merged in the last 25 runs, all same-repo.

`pull_request_target` is safe here — base-ref checkout, no head code, `--allowed-tools` is three read-only `gh` verbs plus the comment post — and the actor is whoever merged, i.e. a maintainer. It needs an explicit `github_token` because the OIDC→`claude[bot]` exchange returns `401 Invalid OIDC token` on `pull_request_target` subs (the same finding already documented in `claude-docs-review.yml`). Cost is the comment badge: `github-actions[bot]` instead of `claude[bot]`. Nothing depends on it — `release.yml:405` harvests these by the `<!-- claude-changelog -->` marker, never by author.

## On the token-exposure worry

Worth stating plainly: **the token was never reachable by a fork.** These workflows already check out the *base* ref only, never PR head code, and run read-only tool allowlists — that's the `actions/untrusted-checkout` hardening in their headers. The actor gate was the second belt, and it held. This PR is about the red X and about not summoning secrets-bearing jobs on outsider-controlled triggers in the first place, not about closing an active leak.

## Verification

No test harness for workflow YAML, so this is what I checked directly:

- **`actionlint`** clean on all 7 files.
- **Guard expression against real payloads** — the same-repo check has to match on exact casing:
  ```
  PR #1592  head.repo.full_name=Fiestaboard/FiestaBoard   → == github.repository, runs
  PR #1593  head.repo.full_name=rummeyer/FiestaBoard      → != github.repository, skipped
  ```
- **Ran the `Resolve PR coordinates` dispatch branch** against the real fork PR:
  ```
  Reviewing PR #1593 (head e23d4879d8317930c033de069703fb4583892f48, base main)
  number=1593 / head_sha=e23d487… / base_ref=main
  ```
  and a bad number exits 1 under `set -euo pipefail` rather than reviewing an empty SHA.
- **The manual path's core assumption** — that fork head content is readable through the *base* repo's contents API, which is how the prompt reads PR files without checking them out:
  ```
  $ gh api "repos/Fiestaboard/FiestaBoard/contents/README.md?ref=e23d487…" -H "Accept: application/vnd.github.raw"
  | [Word Clock](…) | Time spelled out in words, QLOCKTWO style | No |
  ```
  Returns the fork's version. The dispatch review will work on fork PRs.
- **Swept every workflow using `claude-code-action`** for fork reachability. Remaining unguarded ones are correct as-is: `claude-issue-triage.yml` already gates on `author_association` (OWNER/MEMBER/COLLABORATOR) or a maintainer-applied label, and `claude.yml`'s `@claude` mention path relies on the actor gate by design.

## Caveat

`pull_request_target` always evaluates the workflow from the **base** ref, so none of this takes effect until it's on `main`. The existing red X on #1593 will stay until a new event fires there; only `CI Success` is a required check, so it isn't blocking the merge either way.