### PR TITLE
fix(mcp): persist plugin config and enable state through ConfigManager (#1588)

### DIFF
--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -197,7 +197,26 @@ def _build_mcp_server() -> Any:
 
     # -----------------------------------------------------------------------
     # Plugin tools
+    #
+    # The mutating ones delegate to the REST handlers in ``api_server``
+    # rather than driving ``PluginRegistry`` directly. Enabling or
+    # configuring a plugin is two writes, not one: the registry holds the
+    # live state, ConfigManager holds ``config.json``. #1588 is what going
+    # straight to the registry costs — every setting made over MCP looked
+    # fine until the container was recreated, then came back gone, because
+    # nothing had ever been written to disk.
     # -----------------------------------------------------------------------
+
+    def _rest_detail(exc: Any) -> str:
+        """Flatten an HTTPException detail into a single message.
+
+        The plugin-config endpoint raises ``detail={"errors": [...]}``; the
+        rest raise a plain string.
+        """
+        detail = getattr(exc, "detail", exc)
+        if isinstance(detail, dict) and detail.get("errors"):
+            return "; ".join(str(e) for e in detail["errors"])
+        return str(detail)
 
     @mcp.tool()
     def list_installed_plugins() -> list[dict[str, Any]] | dict[str, Any]:
@@ -245,7 +264,7 @@ def _build_mcp_server() -> Any:
             return _err(str(exc))
 
     @mcp.tool()
-    def install_plugin(plugin_id: str, auto_enable: bool = True) -> dict[str, Any]:
+    async def install_plugin(plugin_id: str, auto_enable: bool = True) -> dict[str, Any]:
         """Install a plugin from the official FiestaBoard registry and optionally enable it.
 
         Args:
@@ -255,36 +274,50 @@ def _build_mcp_server() -> Any:
         After installing, use configure_plugin() to set API keys and other settings.
         Use get_template_variables() to discover the variables the plugin exposes.
         """
-        try:
-            from .plugins import get_plugin_registry
+        from fastapi import HTTPException
 
-            registry = get_plugin_registry()
-            registry.install_from_registry(plugin_id)
-            if auto_enable:
-                registry.enable_plugin(plugin_id)
-            state = "installed and enabled" if auto_enable else "installed (disabled)"
-            return _ok(f"Plugin '{plugin_id}' {state} successfully.", plugin_id=plugin_id, enabled=auto_enable)
+        from .api_server import install_registry_plugin as _rest_install_registry_plugin
+
+        try:
+            await _rest_install_registry_plugin(plugin_id)
+        except HTTPException as exc:
+            return _err(f"Error installing plugin '{plugin_id}': {_rest_detail(exc)}")
         except Exception as exc:
             return _err(f"Error installing plugin '{plugin_id}': {exc}")
 
+        if auto_enable:
+            enabled = await enable_plugin(plugin_id)
+            if enabled.get("status") == "error":
+                return _err(f"Plugin '{plugin_id}' was installed but could not be enabled: {enabled['error']}")
+
+        state = "installed and enabled" if auto_enable else "installed (disabled)"
+        return _ok(f"Plugin '{plugin_id}' {state} successfully.", plugin_id=plugin_id, enabled=auto_enable)
+
     @mcp.tool()
-    def enable_plugin(plugin_id: str) -> dict[str, Any]:
+    async def enable_plugin(plugin_id: str) -> dict[str, Any]:
         """Enable an installed but currently-disabled plugin.
+
+        The plugin must already be installed — use install_plugin() first for
+        anything from list_registry_plugins().
 
         Args:
             plugin_id: The plugin identifier (from list_installed_plugins()).
         """
-        try:
-            from .plugins import get_plugin_registry
+        from fastapi import HTTPException
 
-            registry = get_plugin_registry()
-            registry.enable_plugin(plugin_id)
-            return _ok(f"Plugin '{plugin_id}' enabled successfully.", plugin_id=plugin_id)
+        from .api_server import enable_plugin as _rest_enable_plugin
+
+        try:
+            await _rest_enable_plugin(plugin_id)
+        except HTTPException as exc:
+            return _err(f"Error enabling plugin '{plugin_id}': {_rest_detail(exc)}")
         except Exception as exc:
             return _err(f"Error enabling plugin '{plugin_id}': {exc}")
 
+        return _ok(f"Plugin '{plugin_id}' enabled successfully.", plugin_id=plugin_id)
+
     @mcp.tool()
-    def disable_plugin(plugin_id: str) -> dict[str, Any]:
+    async def disable_plugin(plugin_id: str) -> dict[str, Any]:
         """Disable an installed plugin without uninstalling it.
 
         The plugin can be re-enabled later with enable_plugin().
@@ -292,17 +325,21 @@ def _build_mcp_server() -> Any:
         Args:
             plugin_id: The plugin identifier (from list_installed_plugins()).
         """
-        try:
-            from .plugins import get_plugin_registry
+        from fastapi import HTTPException
 
-            registry = get_plugin_registry()
-            registry.disable_plugin(plugin_id)
-            return _ok(f"Plugin '{plugin_id}' disabled successfully.", plugin_id=plugin_id)
+        from .api_server import disable_plugin as _rest_disable_plugin
+
+        try:
+            await _rest_disable_plugin(plugin_id)
+        except HTTPException as exc:
+            return _err(f"Error disabling plugin '{plugin_id}': {_rest_detail(exc)}")
         except Exception as exc:
             return _err(f"Error disabling plugin '{plugin_id}': {exc}")
 
+        return _ok(f"Plugin '{plugin_id}' disabled successfully.", plugin_id=plugin_id)
+
     @mcp.tool()
-    def uninstall_plugin(plugin_id: str) -> dict[str, Any]:
+    async def uninstall_plugin(plugin_id: str) -> dict[str, Any]:
         """Permanently remove an installed plugin.
 
         WARNING: This is irreversible. The plugin and all its configuration
@@ -312,21 +349,29 @@ def _build_mcp_server() -> Any:
         Args:
             plugin_id: The plugin identifier (from list_installed_plugins()).
         """
-        try:
-            from .plugins import get_plugin_registry
+        from fastapi import HTTPException
 
-            registry = get_plugin_registry()
-            registry.uninstall_external_plugin(plugin_id)
-            return _ok(f"Plugin '{plugin_id}' uninstalled successfully.", plugin_id=plugin_id)
+        from .api_server import uninstall_external_plugin as _rest_uninstall_external_plugin
+
+        try:
+            await _rest_uninstall_external_plugin(plugin_id)
+        except HTTPException as exc:
+            return _err(f"Error uninstalling plugin '{plugin_id}': {_rest_detail(exc)}")
         except Exception as exc:
             return _err(f"Error uninstalling plugin '{plugin_id}': {exc}")
 
+        return _ok(f"Plugin '{plugin_id}' uninstalled successfully.", plugin_id=plugin_id)
+
     @mcp.tool()
-    def configure_plugin(plugin_id: str, config: dict[str, Any]) -> dict[str, Any]:
+    async def configure_plugin(plugin_id: str, config: dict[str, Any]) -> dict[str, Any]:
         """Update configuration settings for an installed plugin.
 
         Use list_installed_plugins() to see the settings_schema for a plugin,
         which shows all valid config keys, their types, and which are required.
+
+        Settings are merged into the plugin's existing configuration and saved
+        to disk, so they survive a restart. A config the plugin rejects is
+        reported as an error and nothing is saved.
 
         IMPORTANT: Never guess API keys — only set values the user has provided.
         Sensitive fields (api_key, password, etc.) must be provided explicitly.
@@ -336,23 +381,26 @@ def _build_mcp_server() -> Any:
             config: Dictionary of configuration key-value pairs to update.
                     Only include keys you want to change.
         """
-        try:
-            from .config_manager import get_config_manager
-            from .plugins import get_plugin_registry
+        from fastapi import HTTPException
 
-            registry = get_plugin_registry()
-            cm = get_config_manager()
-            existing = cm.get_plugin_config(plugin_id) or {}
+        from .api_server import PluginConfigRequest
+        from .api_server import update_plugin_config as _rest_update_plugin_config
+        from .config_manager import get_config_manager
+
+        try:
+            existing = get_config_manager().get_plugin_config(plugin_id) or {}
             merged = {**existing, **config}
-            registry.set_plugin_config(plugin_id, merged)
-            updated = cm.get_plugin_config(plugin_id) or {}
-            return _ok(
-                f"Configuration updated for '{plugin_id}'.",
-                plugin_id=plugin_id,
-                config=_serialize(cm._mask_sensitive(updated)),
-            )
+            response = await _rest_update_plugin_config(plugin_id, PluginConfigRequest(config=merged))
+        except HTTPException as exc:
+            return _err(f"Error configuring plugin '{plugin_id}': {_rest_detail(exc)}")
         except Exception as exc:
             return _err(f"Error configuring plugin '{plugin_id}': {exc}")
+
+        return _ok(
+            f"Configuration updated for '{plugin_id}'.",
+            plugin_id=plugin_id,
+            config=_serialize(response.get("config", {})),
+        )
 
     @mcp.tool()
     def update_plugin(plugin_id: str) -> dict[str, Any]:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -551,7 +551,7 @@ class TestConfigurePlugin:
         config_manager.set_plugin_config.assert_not_called()
 
     def test_configure_error(self, mcp, plugin_services):
-        registry, config_manager = plugin_services
+        _, config_manager = plugin_services
         config_manager.get_plugin_config.side_effect = KeyError("plugin not found")
         result = _call_tool(
             mcp,

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -94,6 +94,14 @@ def mock_registry():
             "condition": {"description": "Weather condition", "example": "Sunny"},
         }
     }
+    # These four return a list of error strings; an empty list means success.
+    # autospec would otherwise hand back a truthy MagicMock, which every
+    # caller reads as "it failed".
+    registry.set_plugin_config.return_value = []
+    registry.install_from_registry.return_value = []
+    registry.uninstall_external_plugin.return_value = []
+    registry.enable_plugin.return_value = True
+    registry.disable_plugin.return_value = True
     return registry
 
 
@@ -392,112 +400,165 @@ class TestListRegistryPlugins:
         assert "stocks" in ids
 
 
+@pytest.fixture
+def plugin_services(mock_registry, mock_config_manager):
+    """Patch the services the plugin tools reach through.
+
+    The mutating plugin tools delegate to the REST handlers in
+    ``api_server`` (#1588), so the registry and ConfigManager have to be
+    patched where *that* module resolves them, not where the tools used to
+    look them up.
+    """
+    with (
+        patch("src.api_server.get_plugin_registry", return_value=mock_registry),
+        patch("src.api_server.get_config_manager", return_value=mock_config_manager),
+        patch("src.config_manager.get_config_manager", return_value=mock_config_manager),
+        patch("src.plugins.get_plugin_registry", return_value=mock_registry),
+    ):
+        yield mock_registry, mock_config_manager
+
+
 class TestInstallPlugin:
-    def test_install_and_enable(self, mcp, mock_registry):
-        with patch("src.plugins.get_plugin_registry", return_value=mock_registry):
-            result = _call_tool(mcp, "install_plugin", plugin_id="stocks")
+    def test_install_and_enable(self, mcp, plugin_services):
+        registry, config_manager = plugin_services
+        result = _call_tool(mcp, "install_plugin", plugin_id="stocks")
         assert result["status"] == "success"
         assert "installed and enabled" in result["message"]
-        mock_registry.install_from_registry.assert_called_once_with("stocks")
-        mock_registry.enable_plugin.assert_called_once_with("stocks")
+        registry.install_from_registry.assert_called_once_with("stocks")
+        registry.enable_plugin.assert_called_once_with("stocks")
+        # The half that #1588 was missing: without this the plugin comes back
+        # disabled the next time the container is recreated.
+        config_manager.enable_plugin.assert_called_once_with("stocks")
 
-    def test_install_without_enable(self, mcp, mock_registry):
-        with patch("src.plugins.get_plugin_registry", return_value=mock_registry):
-            result = _call_tool(mcp, "install_plugin", plugin_id="stocks", auto_enable=False)
+    def test_install_without_enable(self, mcp, plugin_services):
+        registry, config_manager = plugin_services
+        result = _call_tool(mcp, "install_plugin", plugin_id="stocks", auto_enable=False)
         assert "installed (disabled)" in result["message"]
-        mock_registry.enable_plugin.assert_not_called()
+        registry.enable_plugin.assert_not_called()
+        config_manager.enable_plugin.assert_not_called()
 
-    def test_install_error(self, mcp):
-        mock_reg = MagicMock()
-        mock_reg.install_from_registry.side_effect = ValueError("Not in registry")
-        with patch("src.plugins.get_plugin_registry", return_value=mock_reg):
-            result = _call_tool(mcp, "install_plugin", plugin_id="unknown")
+    def test_install_error(self, mcp, plugin_services):
+        registry, _ = plugin_services
+        registry.install_from_registry.return_value = ["Plugin 'unknown' not found in the registry"]
+        result = _call_tool(mcp, "install_plugin", plugin_id="unknown")
         assert result["status"] == "error"
-        assert "Not in registry" in result["error"]
+        assert "not found in the registry" in result["error"]
+
+    def test_install_reports_a_failed_enable(self, mcp, plugin_services):
+        """Installed-but-not-enabled must not be reported as fully successful."""
+        registry, _ = plugin_services
+        registry.get_plugin.return_value = None
+        result = _call_tool(mcp, "install_plugin", plugin_id="stocks")
+        assert result["status"] == "error"
+        assert "installed but could not be enabled" in result["error"]
 
 
 class TestEnablePlugin:
-    def test_enable_success(self, mcp, mock_registry):
-        with patch("src.plugins.get_plugin_registry", return_value=mock_registry):
-            result = _call_tool(mcp, "enable_plugin", plugin_id="openweather")
+    def test_enable_success(self, mcp, plugin_services):
+        registry, config_manager = plugin_services
+        result = _call_tool(mcp, "enable_plugin", plugin_id="openweather")
         assert result["status"] == "success"
         assert "enabled successfully" in result["message"]
+        registry.enable_plugin.assert_called_once_with("openweather")
+        config_manager.enable_plugin.assert_called_once_with("openweather")
 
-    def test_enable_error(self, mcp):
-        mock_reg = MagicMock()
-        mock_reg.enable_plugin.side_effect = KeyError("openweather not found")
-        with patch("src.plugins.get_plugin_registry", return_value=mock_reg):
-            result = _call_tool(mcp, "enable_plugin", plugin_id="openweather")
+    def test_enable_unknown_plugin_is_an_error(self, mcp, plugin_services):
+        registry, config_manager = plugin_services
+        registry.get_plugin.return_value = None
+        result = _call_tool(mcp, "enable_plugin", plugin_id="nope")
+        assert result["status"] == "error"
+        config_manager.enable_plugin.assert_not_called()
+
+    def test_enable_error(self, mcp, plugin_services):
+        registry, _ = plugin_services
+        registry.enable_plugin.side_effect = KeyError("openweather not found")
+        result = _call_tool(mcp, "enable_plugin", plugin_id="openweather")
         assert result["status"] == "error"
 
 
 class TestDisablePlugin:
-    def test_disable_success(self, mcp, mock_registry):
-        with patch("src.plugins.get_plugin_registry", return_value=mock_registry):
-            result = _call_tool(mcp, "disable_plugin", plugin_id="openweather")
+    def test_disable_success(self, mcp, plugin_services):
+        registry, config_manager = plugin_services
+        result = _call_tool(mcp, "disable_plugin", plugin_id="openweather")
         assert "disabled successfully" in result["message"]
+        registry.disable_plugin.assert_called_once_with("openweather")
+        config_manager.disable_plugin.assert_called_once_with("openweather")
+
+    def test_disable_unknown_plugin_is_an_error(self, mcp, plugin_services):
+        registry, config_manager = plugin_services
+        registry.get_plugin.return_value = None
+        result = _call_tool(mcp, "disable_plugin", plugin_id="nope")
+        assert result["status"] == "error"
+        config_manager.disable_plugin.assert_not_called()
 
 
 class TestUninstallPlugin:
-    def test_uninstall_success(self, mcp, mock_registry):
-        with patch("src.plugins.get_plugin_registry", return_value=mock_registry):
-            result = _call_tool(mcp, "uninstall_plugin", plugin_id="openweather")
+    def test_uninstall_success(self, mcp, plugin_services):
+        registry, config_manager = plugin_services
+        result = _call_tool(mcp, "uninstall_plugin", plugin_id="openweather")
         assert "uninstalled successfully" in result["message"]
-        mock_registry.uninstall_external_plugin.assert_called_once_with("openweather")
+        registry.uninstall_external_plugin.assert_called_once_with("openweather")
+        config_manager.delete_plugin_config.assert_any_call("openweather")
+
+    def test_uninstall_builtin_is_an_error(self, mcp, plugin_services):
+        registry, _ = plugin_services
+        registry.uninstall_external_plugin.return_value = ["Cannot uninstall a built-in plugin"]
+        result = _call_tool(mcp, "uninstall_plugin", plugin_id="date_time")
+        assert result["status"] == "error"
+        assert "built-in" in result["error"]
 
 
 class TestConfigurePlugin:
-    def test_merges_with_existing_config(self, mcp, mock_registry, mock_config_manager):
-        with (
-            patch("src.plugins.get_plugin_registry", return_value=mock_registry),
-            patch("src.config_manager.get_config_manager", return_value=mock_config_manager),
-        ):
-            result = _call_tool(
-                mcp,
-                "configure_plugin",
-                plugin_id="openweather",
-                config={"api_key": "new-key"},
-            )
-        data = result
-        assert data["status"] == "success"
-        assert data["plugin_id"] == "openweather"
-        # Should have called set_plugin_config with merged dict
-        mock_registry.set_plugin_config.assert_called_once()
-        call_args = mock_registry.set_plugin_config.call_args[0]
-        assert call_args[0] == "openweather"
-        # The merged config should include both existing "units" and new "api_key"
-        merged = call_args[1]
-        assert "api_key" in merged
+    def test_merges_with_existing_config(self, mcp, plugin_services):
+        registry, config_manager = plugin_services
+        result = _call_tool(
+            mcp,
+            "configure_plugin",
+            plugin_id="openweather",
+            config={"api_key": "new-key"},
+        )
+        assert result["status"] == "success"
+        assert result["plugin_id"] == "openweather"
+        registry.set_plugin_config.assert_called_once()
+        plugin_id, merged = registry.set_plugin_config.call_args[0]
+        assert plugin_id == "openweather"
+        # Both the newly-set key and the previously-stored one.
+        assert merged["api_key"] == "new-key"
+        assert merged["units"] == "imperial"
+        # And it reaches disk, which is the whole of #1588.
+        config_manager.set_plugin_config.assert_called_once_with("openweather", merged)
 
-    def test_returns_masked_config(self, mcp, mock_registry, mock_config_manager):
-        with (
-            patch("src.plugins.get_plugin_registry", return_value=mock_registry),
-            patch("src.config_manager.get_config_manager", return_value=mock_config_manager),
-        ):
-            result = _call_tool(
-                mcp,
-                "configure_plugin",
-                plugin_id="openweather",
-                config={"api_key": "new-key"},
-            )
-        data = result
-        # Sensitive value should be masked
-        assert data["config"]["api_key"] == "***"
+    def test_returns_masked_config(self, mcp, plugin_services):
+        result = _call_tool(
+            mcp,
+            "configure_plugin",
+            plugin_id="openweather",
+            config={"api_key": "new-key"},
+        )
+        assert result["config"]["api_key"] == "***"
 
-    def test_configure_error(self, mcp):
-        mock_reg = MagicMock()
-        mock_cm = MagicMock()
-        mock_cm.get_plugin_config.side_effect = KeyError("plugin not found")
-        with (
-            patch("src.plugins.get_plugin_registry", return_value=mock_reg),
-            patch("src.config_manager.get_config_manager", return_value=mock_cm),
-        ):
-            result = _call_tool(
-                mcp,
-                "configure_plugin",
-                plugin_id="nonexistent",
-                config={"api_key": "x"},
-            )
+    def test_validation_errors_are_reported_not_swallowed(self, mcp, plugin_services):
+        registry, config_manager = plugin_services
+        registry.set_plugin_config.return_value = ["station_id is required"]
+        result = _call_tool(
+            mcp,
+            "configure_plugin",
+            plugin_id="openweather",
+            config={"station_id": ""},
+        )
+        assert result["status"] == "error"
+        assert "station_id is required" in result["error"]
+        config_manager.set_plugin_config.assert_not_called()
+
+    def test_configure_error(self, mcp, plugin_services):
+        registry, config_manager = plugin_services
+        config_manager.get_plugin_config.side_effect = KeyError("plugin not found")
+        result = _call_tool(
+            mcp,
+            "configure_plugin",
+            plugin_id="nonexistent",
+            config={"api_key": "x"},
+        )
         assert result["status"] == "error"
 
 

--- a/tests/test_mcp_state_effects.py
+++ b/tests/test_mcp_state_effects.py
@@ -35,6 +35,9 @@ permanent exemption.
 from __future__ import annotations
 
 import asyncio
+import json
+import shutil
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -47,6 +50,8 @@ from src.config_manager import ConfigManager
 from src.mcp_server import _build_mcp_server
 from src.pages.service import PageService
 from src.pages.storage import PageStorage
+from src.plugins.loader import PluginLoader
+from src.plugins.registry import PluginRegistry
 from src.schedules.service import ScheduleService
 from src.schedules.storage import ScheduleStorage
 
@@ -74,18 +79,18 @@ COVERED = {
     "get_system_status",
     "get_settings_summary",
     "list_installed_plugins",
+    "install_plugin",
+    "enable_plugin",
+    "disable_plugin",
+    "uninstall_plugin",
+    "configure_plugin",
+    "get_plugin_data",
 }
 
 #: Tools not yet covered here, each with the reason. Not an exemption list.
 UNCOVERED = {
     "list_registry_plugins": "hits the network-backed registry; needs a fixture",
-    "install_plugin": "mutates the filesystem outside tmp_path",
-    "enable_plugin": "requires an installed plugin fixture",
-    "disable_plugin": "requires an installed plugin fixture",
-    "uninstall_plugin": "requires an installed plugin fixture",
-    "configure_plugin": "requires an installed plugin fixture",
-    "update_plugin": "requires an installed plugin fixture",
-    "get_plugin_data": "requires a live plugin instance",
+    "update_plugin": "reload_plugin() re-clones from git; needs a local git fixture",
     "set_active_page": "delegates to the REST handler; needs board render wiring",
     "set_schedule_mode": "routes through SettingsService; needs settings wiring",
 }
@@ -126,6 +131,166 @@ def services(tmp_path, monkeypatch):
     }
 
     ConfigManager._instance = None  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Plugin fixture — a real plugin package on disk, loaded by the real loader
+# ---------------------------------------------------------------------------
+
+#: Installed by the fixture before each test.
+PLUGIN_ID = "harness_tide"
+
+#: Staged but *not* installed, so install_plugin() has something to install.
+UNINSTALLED_PLUGIN_ID = "harness_surf"
+
+
+def _manifest(plugin_id: str) -> dict[str, Any]:
+    return {
+        "id": plugin_id,
+        "name": plugin_id.replace("_", " ").title(),
+        "version": "1.0.0",
+        "description": "Fixture plugin for MCP state-effect tests.",
+        "author": "FiestaBoard Tests",
+        "icon": "puzzle",
+        "category": "utility",
+        "settings_schema": {
+            "type": "object",
+            "properties": {
+                "station_id": {"type": "string", "title": "Station ID"},
+                "api_key": {"type": "string", "title": "API Key", "ui:widget": "password"},
+                "enabled": {"type": "boolean", "title": "Enabled", "default": False},
+            },
+            "required": ["station_id"],
+        },
+        "variables": {
+            "simple": {
+                "next_high": {
+                    "description": "Time of the next high tide",
+                    "type": "string",
+                    "max_length": 5,
+                    "example": "06:12",
+                }
+            }
+        },
+    }
+
+
+#: ``station_id`` is required by ``validate_config``, which is what makes
+#: "configure_plugin swallows validation errors" testable.
+_PLUGIN_SOURCE = '''\
+"""Fixture plugin for tests/test_mcp_state_effects.py."""
+
+from src.plugins.base import PluginBase, PluginResult
+
+
+class HarnessPlugin(PluginBase):
+    @property
+    def plugin_id(self) -> str:
+        return "{plugin_id}"
+
+    def validate_config(self, config):
+        if not config.get("station_id"):
+            return ["station_id is required"]
+        return []
+
+    def fetch_data(self) -> PluginResult:
+        return PluginResult(available=True, data={{"next_high": "06:12"}})
+'''
+
+
+def _write_plugin(directory: Path, plugin_id: str) -> None:
+    """Write a real, loadable plugin package to *directory*."""
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "manifest.json").write_text(json.dumps(_manifest(plugin_id)), encoding="utf-8")
+    (directory / "__init__.py").write_text(_PLUGIN_SOURCE.format(plugin_id=plugin_id), encoding="utf-8")
+
+
+class _LocalRegistry(PluginRegistry):
+    """A real registry whose "registry install" copies from a local staging dir.
+
+    Everything after the copy is the production code path: the real
+    ``PluginLoader`` imports the package, and the real bookkeeping runs. Only
+    the git clone is replaced, so ``install_plugin`` can be exercised without
+    the network.
+    """
+
+    def __init__(self, plugins_dir: Path, external_dir: Path, staging_dir: Path):
+        super().__init__(plugins_dir=plugins_dir)
+        self._loader = PluginLoader(plugins_dir=plugins_dir, external_dirs=[external_dir])
+        self._external_dir = external_dir
+        self._staging_dir = staging_dir
+
+    def install_from_registry(self, plugin_id: str) -> list[str]:
+        staged = self._staging_dir / plugin_id
+        if not staged.is_dir():
+            return [f"Plugin '{plugin_id}' not found in the registry"]
+
+        shutil.copytree(staged, self._external_dir / plugin_id, dirs_exist_ok=True)
+
+        plugin = self._loader.load_plugin(plugin_id)
+        if plugin is None:
+            return self._loader.load_errors.get(plugin_id, []) or [f"Failed to load plugin: {plugin_id}"]
+
+        manifest = self._loader.get_manifest(plugin_id)
+        assert manifest is not None
+        self._plugins[plugin_id] = plugin
+        self._manifests[plugin_id] = manifest
+        self._enabled[plugin_id] = False
+        self._clear_removed_tombstone(plugin_id)
+        return []
+
+
+@pytest.fixture
+def plugins(services, tmp_path, monkeypatch):
+    """Install ``harness_tide`` into a real registry wired to the singleton.
+
+    ``harness_surf`` is staged but left uninstalled so ``install_plugin`` has
+    a target. Both live under ``tmp_path``; nothing touches the repo's own
+    ``plugins/`` or ``external_plugins/`` directories.
+    """
+    builtin_dir = tmp_path / "builtin_plugins"
+    builtin_dir.mkdir()
+    external_dir = tmp_path / "external_plugins"
+    external_dir.mkdir()
+    staging_dir = tmp_path / "staged_plugins"
+
+    _write_plugin(staging_dir / PLUGIN_ID, PLUGIN_ID)
+    _write_plugin(staging_dir / UNINSTALLED_PLUGIN_ID, UNINSTALLED_PLUGIN_ID)
+
+    def build_registry() -> _LocalRegistry:
+        registry = _LocalRegistry(builtin_dir, external_dir, staging_dir)
+        registry.initialize()
+        monkeypatch.setattr("src.plugins.registry._registry", registry)
+        return registry
+
+    registry = build_registry()
+    assert not registry.install_from_registry(PLUGIN_ID), "fixture failed to install the harness plugin"
+
+    yield {
+        "registry": registry,
+        "config_path": str(tmp_path / "config.json"),
+        # Rebuild the registry and ConfigManager from the same files — what
+        # `docker compose up -d` does to a container.
+        "restart": lambda: (_restart_config_manager(str(tmp_path / "config.json")), build_registry())[1],
+    }
+
+    monkeypatch.setattr("src.plugins.registry._registry", None, raising=False)
+
+
+def _restart_config_manager(config_path: str) -> ConfigManager:
+    """Drop the ConfigManager singleton and re-read the file from disk."""
+    ConfigManager._instance = None  # type: ignore[attr-defined]
+    return ConfigManager(config_path=config_path)
+
+
+def stored_plugin_config(config_path: str, plugin_id: str) -> dict[str, Any] | None:
+    """Read a plugin's config straight out of ``config.json``.
+
+    Deliberately bypasses ConfigManager: the whole bug is that the in-memory
+    copy looked right while the file had nothing in it.
+    """
+    raw = json.loads(Path(config_path).read_text(encoding="utf-8"))
+    return raw.get("plugins", {}).get(plugin_id)
 
 
 def call(mcp: Any, tool_name: str, /, **kwargs: Any) -> Any:
@@ -445,3 +610,197 @@ def test_get_settings_summary_returns_a_payload(mcp, services):
 def test_list_installed_plugins_returns_a_list(mcp, services):
     result = call(mcp, "list_installed_plugins")
     assert isinstance(result, (list, dict))
+
+
+# ---------------------------------------------------------------------------
+# Plugins — #1588
+#
+# Every one of these tools mutated only the in-memory registry and never
+# ConfigManager, so the settings evaporated the next time the container was
+# recreated. The assertions below read `config.json` off disk rather than
+# asking the registry, because the registry is exactly what lied.
+# ---------------------------------------------------------------------------
+
+
+def test_configure_plugin_writes_the_settings_to_config_json(mcp, plugins):
+    assert_ok(
+        call(mcp, "configure_plugin", plugin_id=PLUGIN_ID, config={"station_id": "9447427"}),
+        "configure_plugin",
+    )
+
+    stored = stored_plugin_config(plugins["config_path"], PLUGIN_ID)
+    assert stored is not None, "configure_plugin reported success but wrote nothing to config.json"
+    assert stored["station_id"] == "9447427"
+
+
+def test_configure_plugin_returns_the_config_it_saved(mcp, plugins):
+    """An empty ``config`` echo was the only hint the write never happened."""
+    result = assert_ok(
+        call(mcp, "configure_plugin", plugin_id=PLUGIN_ID, config={"station_id": "9447427"}),
+        "configure_plugin",
+    )
+    assert result["config"].get("station_id") == "9447427"
+
+
+def test_configure_plugin_masks_sensitive_values_in_its_response(mcp, plugins):
+    result = assert_ok(
+        call(
+            mcp,
+            "configure_plugin",
+            plugin_id=PLUGIN_ID,
+            config={"station_id": "9447427", "api_key": "test_secret"},
+        ),
+        "configure_plugin",
+    )
+    assert result["config"]["api_key"] == "***", "an API key was echoed back in the clear"
+    assert stored_plugin_config(plugins["config_path"], PLUGIN_ID)["api_key"] == "test_secret"
+
+
+def test_configure_plugin_merges_with_the_existing_stored_config(mcp, plugins):
+    assert_ok(
+        call(mcp, "configure_plugin", plugin_id=PLUGIN_ID, config={"station_id": "9447427"}),
+        "configure_plugin",
+    )
+    assert_ok(
+        call(mcp, "configure_plugin", plugin_id=PLUGIN_ID, config={"api_key": "test_secret"}),
+        "configure_plugin (partial)",
+    )
+
+    stored = stored_plugin_config(plugins["config_path"], PLUGIN_ID)
+    assert stored["station_id"] == "9447427", "a partial update dropped a previously-set field"
+    assert stored["api_key"] == "test_secret"
+
+
+def test_configure_plugin_reports_validation_errors_instead_of_success(mcp, plugins):
+    """``registry.set_plugin_config()`` returns errors; the tool discarded them."""
+    result = call(mcp, "configure_plugin", plugin_id=PLUGIN_ID, config={"station_id": ""})
+
+    assert result.get("status") == "error", "an invalid config was reported as a successful update"
+    assert "station_id" in str(result.get("error", "")), (
+        f"the plugin's own validation message was not surfaced: {result}"
+    )
+
+
+def test_configure_plugin_does_not_overwrite_a_good_config_with_a_rejected_one(mcp, plugins):
+    assert_ok(
+        call(mcp, "configure_plugin", plugin_id=PLUGIN_ID, config={"station_id": "9447427"}),
+        "configure_plugin",
+    )
+
+    call(mcp, "configure_plugin", plugin_id=PLUGIN_ID, config={"station_id": ""})
+
+    stored = stored_plugin_config(plugins["config_path"], PLUGIN_ID)
+    assert stored["station_id"] == "9447427", "a rejected config was persisted over a valid one"
+
+
+def test_configure_plugin_reports_an_error_for_an_unknown_plugin(mcp, plugins):
+    result = call(mcp, "configure_plugin", plugin_id="not_a_plugin", config={"station_id": "1"})
+    assert result.get("status") == "error"
+    assert stored_plugin_config(plugins["config_path"], "not_a_plugin") is None
+
+
+def test_enable_plugin_persists_enabled_true(mcp, plugins):
+    assert_ok(call(mcp, "enable_plugin", plugin_id=PLUGIN_ID), "enable_plugin")
+
+    stored = stored_plugin_config(plugins["config_path"], PLUGIN_ID)
+    assert stored is not None, "enable_plugin reported success but wrote nothing to config.json"
+    assert stored["enabled"] is True
+
+
+def test_disable_plugin_persists_enabled_false(mcp, plugins):
+    assert_ok(call(mcp, "enable_plugin", plugin_id=PLUGIN_ID), "enable_plugin")
+
+    assert_ok(call(mcp, "disable_plugin", plugin_id=PLUGIN_ID), "disable_plugin")
+
+    stored = stored_plugin_config(plugins["config_path"], PLUGIN_ID)
+    assert stored["enabled"] is False, "disable_plugin reported success but config.json still says enabled"
+
+
+def test_enable_plugin_reports_an_error_for_an_unknown_plugin(mcp, plugins):
+    """``registry.enable_plugin()`` returns False here; the tool ignored it."""
+    result = call(mcp, "enable_plugin", plugin_id="not_a_plugin")
+    assert result.get("status") == "error", "enabling a plugin that does not exist reported success"
+
+
+def test_disable_plugin_reports_an_error_for_an_unknown_plugin(mcp, plugins):
+    result = call(mcp, "disable_plugin", plugin_id="not_a_plugin")
+    assert result.get("status") == "error", "disabling a plugin that does not exist reported success"
+
+
+def test_enable_plugin_does_not_disturb_the_stored_settings(mcp, plugins):
+    assert_ok(
+        call(mcp, "configure_plugin", plugin_id=PLUGIN_ID, config={"station_id": "9447427"}),
+        "configure_plugin",
+    )
+
+    assert_ok(call(mcp, "enable_plugin", plugin_id=PLUGIN_ID), "enable_plugin")
+
+    stored = stored_plugin_config(plugins["config_path"], PLUGIN_ID)
+    assert stored["station_id"] == "9447427", "enabling the plugin wiped its settings"
+    assert stored["enabled"] is True
+
+
+def test_install_plugin_with_auto_enable_persists_enabled(mcp, plugins):
+    assert_ok(call(mcp, "install_plugin", plugin_id=UNINSTALLED_PLUGIN_ID), "install_plugin")
+
+    stored = stored_plugin_config(plugins["config_path"], UNINSTALLED_PLUGIN_ID)
+    assert stored is not None, "install_plugin(auto_enable=True) never recorded the plugin in config.json"
+    assert stored["enabled"] is True
+
+
+def test_install_plugin_without_auto_enable_does_not_enable_it(mcp, plugins):
+    assert_ok(
+        call(mcp, "install_plugin", plugin_id=UNINSTALLED_PLUGIN_ID, auto_enable=False),
+        "install_plugin",
+    )
+
+    stored = stored_plugin_config(plugins["config_path"], UNINSTALLED_PLUGIN_ID)
+    assert not (stored or {}).get("enabled"), "auto_enable=False still enabled the plugin"
+
+
+def test_uninstall_plugin_purges_the_persisted_config(mcp, plugins):
+    """A leftover entry is what resurrects a deliberately removed plugin (#937)."""
+    assert_ok(
+        call(mcp, "configure_plugin", plugin_id=PLUGIN_ID, config={"station_id": "9447427"}),
+        "configure_plugin",
+    )
+
+    assert_ok(call(mcp, "uninstall_plugin", plugin_id=PLUGIN_ID), "uninstall_plugin")
+
+    assert stored_plugin_config(plugins["config_path"], PLUGIN_ID) is None, (
+        "uninstall left the plugin's config behind, so a later boot can reinstall it"
+    )
+
+
+def test_get_plugin_data_returns_the_live_values(mcp, plugins):
+    assert_ok(
+        call(mcp, "configure_plugin", plugin_id=PLUGIN_ID, config={"station_id": "9447427"}),
+        "configure_plugin",
+    )
+    assert_ok(call(mcp, "enable_plugin", plugin_id=PLUGIN_ID), "enable_plugin")
+
+    result = assert_ok(call(mcp, "get_plugin_data", plugin_id=PLUGIN_ID), "get_plugin_data")
+    assert result["data"]["next_high"] == "06:12"
+
+
+def test_plugin_configured_over_mcp_survives_a_container_recreate(mcp, plugins):
+    """The reported bug, end to end.
+
+    Configure and enable over MCP, throw the process away, and bring a fresh
+    registry up from the same ``config.json``. Before the fix the plugin came
+    back disabled and unconfigured, and every template variable rendered
+    ``#REF``.
+    """
+    assert_ok(
+        call(mcp, "configure_plugin", plugin_id=PLUGIN_ID, config={"station_id": "9447427"}),
+        "configure_plugin",
+    )
+    assert_ok(call(mcp, "enable_plugin", plugin_id=PLUGIN_ID), "enable_plugin")
+
+    restarted = plugins["restart"]()
+
+    assert restarted.is_enabled(PLUGIN_ID), "the plugin came back disabled after a restart"
+    assert restarted.get_plugin_config(PLUGIN_ID).get("station_id") == "9447427", (
+        "the plugin came back unconfigured after a restart"
+    )
+    assert PLUGIN_ID in restarted.get_all_variables(), "the plugin's template variables did not come back"

--- a/tests/test_mcp_state_effects.py
+++ b/tests/test_mcp_state_effects.py
@@ -241,13 +241,25 @@ class _LocalRegistry(PluginRegistry):
 
 
 @pytest.fixture
-def plugins(services, tmp_path, monkeypatch):
+def plugins(services, tmp_path):
     """Install ``harness_tide`` into a real registry wired to the singleton.
 
     ``harness_surf`` is staged but left uninstalled so ``install_plugin`` has
     a target. Both live under ``tmp_path``; nothing touches the repo's own
     ``plugins/`` or ``external_plugins/`` directories.
+
+    Teardown is hand-rolled rather than left to ``monkeypatch`` because the
+    order matters. The REST handlers these tools delegate to call
+    ``reset_template_engine()``, and ``TemplateEngine.reset_cache()`` binds
+    ``get_plugin_registry()`` onto the long-lived engine singleton. Restoring
+    ``_registry`` alone would leave that engine holding this throwaway
+    registry — which knows only about the harness plugins — and every later
+    test in the session would find ``date_time`` and friends missing. So the
+    registry is put back first, and only then is the engine rebound to it.
     """
+    import src.plugins.registry as registry_module
+    import src.templates.engine as engine_module
+
     builtin_dir = tmp_path / "builtin_plugins"
     builtin_dir.mkdir()
     external_dir = tmp_path / "external_plugins"
@@ -257,24 +269,29 @@ def plugins(services, tmp_path, monkeypatch):
     _write_plugin(staging_dir / PLUGIN_ID, PLUGIN_ID)
     _write_plugin(staging_dir / UNINSTALLED_PLUGIN_ID, UNINSTALLED_PLUGIN_ID)
 
+    original_registry = registry_module._registry
+
     def build_registry() -> _LocalRegistry:
         registry = _LocalRegistry(builtin_dir, external_dir, staging_dir)
         registry.initialize()
-        monkeypatch.setattr("src.plugins.registry._registry", registry)
+        registry_module._registry = registry
         return registry
 
     registry = build_registry()
     assert not registry.install_from_registry(PLUGIN_ID), "fixture failed to install the harness plugin"
 
-    yield {
-        "registry": registry,
-        "config_path": str(tmp_path / "config.json"),
-        # Rebuild the registry and ConfigManager from the same files — what
-        # `docker compose up -d` does to a container.
-        "restart": lambda: (_restart_config_manager(str(tmp_path / "config.json")), build_registry())[1],
-    }
-
-    monkeypatch.setattr("src.plugins.registry._registry", None, raising=False)
+    try:
+        yield {
+            "registry": registry,
+            "config_path": str(tmp_path / "config.json"),
+            # Rebuild the registry and ConfigManager from the same files —
+            # what `docker compose up -d` does to a container.
+            "restart": lambda: (_restart_config_manager(str(tmp_path / "config.json")), build_registry())[1],
+        }
+    finally:
+        registry_module._registry = original_registry
+        if engine_module._template_engine is not None:
+            engine_module.reset_template_engine()
 
 
 def _restart_config_manager(config_path: str) -> ConfigManager:

--- a/tests/test_service_wiring.py
+++ b/tests/test_service_wiring.py
@@ -49,7 +49,11 @@ SCANNED_MODULES = [
 # these modules changes such that the analyzer stops recognizing it, this floor
 # fails and tells us the test went blind rather than quietly finding nothing.
 MIN_RESOLVED_CALLS = {
-    "src/mcp_server.py": 35,
+    # Dropped 35 -> 34 in #1588: the mutating plugin tools now delegate to the
+    # REST handlers instead of calling PluginRegistry themselves, so there is
+    # one fewer directly-resolvable service call in this module. Lower this
+    # only alongside a change that genuinely removes a direct service call.
+    "src/mcp_server.py": 34,
     "src/mqtt/commands.py": 15,
 }
 


### PR DESCRIPTION
Fixes #1588.

## The bug

The MCP plugin tools drove `PluginRegistry` directly and never touched `ConfigManager`, which is the only thing that writes `data/config.json`. Every setting made over MCP therefore lived in memory only. It looked correct, `get_plugin_data()` returned real values, pages rendered — and then the next `docker compose up -d` recreated the container and the plugin came back disabled and unconfigured, rendering `#REF` for every one of its variables.

Two things hid it, both noted in the report:

1. `configure_plugin` returned `status: success` unconditionally.
2. It discarded the validation-error list that `registry.set_plugin_config()` returns, so an invalid config also reported success.

The only tell was the empty `config` echo in the response — read back from a `ConfigManager` that had never been written to.

## The fix

The mutating tools now delegate to the REST handlers in `api_server`, the same way `set_active_page` has since #1559. Those handlers already do both writes, 404 on an unknown plugin, 400 on a rejected config, and reset the display/template singletons. Sharing the path is the fix; reimplementing half of it in a second place is what caused this.

| Tool | Before | After |
|---|---|---|
| `configure_plugin` | registry only; validation errors discarded | persists to `config.json`; reports the plugin's own validation errors and fails |
| `enable_plugin` | registry only; `False` return ignored | persists; errors on an unknown plugin |
| `disable_plugin` | registry only; `False` return ignored | persists; errors on an unknown plugin |
| `install_plugin(auto_enable=True)` | enabled in registry only | persists; reports failure if the enable half failed |
| `uninstall_plugin` | already purged configs (#1394) | unchanged, now covered by tests |

### One deliberate behavior change

`enable_plugin` no longer installs a not-yet-installed registry plugin on demand. It returns `Plugin not found` and the caller should call `install_plugin()` first, which is what the tool's own docstring already promised. That on-demand path in `registry.enable_plugin()` exists for the startup config restore (#1393) and was never reachable from REST.

## Reproducing it first (TDD)

17 new tests in `tests/test_mcp_state_effects.py`, which asserts on state read back after the call rather than on mocks. Every assertion reads `config.json` off disk, because the in-memory registry is exactly what lied. 14 of them failed before the fix:

```
FAILED test_configure_plugin_writes_the_settings_to_config_json
  AssertionError: configure_plugin reported success but wrote nothing to config.json
FAILED test_configure_plugin_returns_the_config_it_saved
  AssertionError: assert None == '9447427'   # {} .get('station_id')
FAILED test_configure_plugin_masks_sensitive_values_in_its_response - KeyError: 'api_key'
FAILED test_configure_plugin_merges_with_the_existing_stored_config
FAILED test_configure_plugin_reports_validation_errors_instead_of_success
  AssertionError: an invalid config was reported as a successful update
  assert 'success' == 'error'
FAILED test_configure_plugin_does_not_overwrite_a_good_config_with_a_rejected_one
FAILED test_configure_plugin_reports_an_error_for_an_unknown_plugin
FAILED test_enable_plugin_persists_enabled_true
  AssertionError: enable_plugin reported success but wrote nothing to config.json
FAILED test_disable_plugin_persists_enabled_false
FAILED test_enable_plugin_reports_an_error_for_an_unknown_plugin
  AssertionError: enabling a plugin that does not exist reported success
FAILED test_disable_plugin_reports_an_error_for_an_unknown_plugin
FAILED test_enable_plugin_does_not_disturb_the_stored_settings
FAILED test_install_plugin_with_auto_enable_persists_enabled
  AssertionError: install_plugin(auto_enable=True) never recorded the plugin in config.json
FAILED test_plugin_configured_over_mcp_survives_a_container_recreate
  AssertionError: the plugin came back disabled after a restart
14 failed, 24 passed
```

The headline test is `test_plugin_configured_over_mcp_survives_a_container_recreate`: configure and enable over MCP, throw the process away, bring a fresh registry up from the same `config.json`.

The fixture builds a real plugin package under `tmp_path` and loads it with the real `PluginLoader`, so there is no mock to disagree with production.

## Non-vacuity

Per the repo's test-quality bar, each behavior was broken in the production code and confirmed to fail:

| Break | Result |
|---|---|
| config endpoint stops calling `config_manager.set_plugin_config` | 5 configure state-effect tests + `TestConfigurePlugin::test_merges` fail |
| config endpoint stops raising on validation errors | both "validation errors are reported" tests fail |
| enable/disable stop persisting | persistence + container-recreate tests fail |
| **both** uninstall purge layers (registry #1394 and REST #937) removed | uninstall purge tests fail — one layer alone is redundant, hence both |
| **both** enable guards (404 + the success check) removed | unknown-plugin tests fail |
| `install_plugin` ignores `auto_enable=False` | auto_enable tests fail |
| `get_plugin_data` returns `{}` | live-values test fails |

## Also in this PR

- `tests/test_mcp_server.py`: the mocked tests move their patches to `src.api_server`, where the tools now resolve their services, and assert that the `ConfigManager` half of each write happens — the half whose absence was the bug.
- A test-isolation bug the new fixture surfaced: `TemplateEngine.reset_cache()` latches `get_plugin_registry()` onto the long-lived engine singleton, so restoring `_registry` alone left every later test in the session looking at a registry that only knew the harness plugins. The fixture now restores the registry first and rebinds the engine second.
- `MIN_RESOLVED_CALLS["src/mcp_server.py"]` 35 → 34: delegating removes one directly-resolvable service call from that module.

## Verification

- Full suite: `4919 passed, 1 skipped` (ordered and randomized), against a baseline of the same on `origin/main`.
- `ruff check` / `ruff format --check` clean on all changed files.
- End-to-end against a real container on `:4499`, following the issue's own reproduction steps: configure + enable over MCP JSON-RPC → entry present in `data/config.json` → container destroyed and recreated on the same volume → plugin comes back `enabled: True, configured: True`, `get_template_variables()` lists its variables again, and `{{countdown.event_name}}` renders `LAUNCH` instead of `#REF`. Invalid config returns `status: error` with the plugin's message and leaves the stored config intact; unknown plugin returns `Plugin not found` from both enable and disable.

## Not addressed

`configure_plugin({"enabled": true, ...})` writes `enabled: true` to `config.json` but does not flip the running registry — it takes effect on the next start. That matches the REST config endpoint exactly (the web UI always pairs a config write with a separate enable call), and it is not a regression, but it is a rough edge worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
