### PR TITLE
test(web): de-flake page-builder suite by warming the lazy editor chunk

### DIFF
--- a/web/src/__tests__/page-builder.test.tsx
+++ b/web/src/__tests__/page-builder.test.tsx
@@ -2,7 +2,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ConfigOverridesProvider } from "@/hooks/use-config-overrides";
 import { ThemeProvider } from "@/hooks/use-theme";
@@ -40,6 +40,17 @@ function TestWrapper({ children }: { children: React.ReactNode }) {
   );
 }
 
+// PageBuilder renders the TipTap editor — which owns the toolbar and its Sync
+// from Board button — behind lazy() + Suspense. Resolving that chunk at first
+// render costs ~450ms locally, which the assertions below would otherwise have
+// to absorb inside waitFor's 1s default; on a loaded CI runner that overruns
+// and the suite fails for a reason that has nothing to do with the behavior
+// under test. Warm the chunk once so the waits below measure rendering, not
+// module resolution.
+beforeAll(async () => {
+  await import("@/components/tiptap-template-editor/TipTapTemplateEditor");
+});
+
 describe("PageBuilder — Sync from Board", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -58,10 +69,10 @@ describe("PageBuilder — Sync from Board", () => {
       wrapper: TestWrapper,
     });
 
-    // Wait for the page data to load
-    await waitFor(() => {
-      expect(screen.queryByText("Syncing...")).not.toBeInTheDocument();
-    });
+    // Wait for the editor toolbar itself to mount. Without this the assertion
+    // below passes vacuously — before the lazy editor renders, *no* toolbar
+    // button exists, so "sync button absent" is trivially true.
+    await screen.findByRole("button", { name: "Align right" });
 
     // The button must not be present in edit mode
     expect(screen.queryByRole("button", { name: "Sync from current board display" })).not.toBeInTheDocument();


### PR DESCRIPTION
## Why

PR #1592 was evicted from the merge queue by a failure with nothing to do with its diff:

```
FAIL src/__tests__/page-builder.test.tsx > PageBuilder — Sync from Board >
     shows the Sync from Board button when creating a new page
TestingLibraryElementError: Unable to find role="button" and name "Sync from current board display"
```

([run 31659897047](https://github.com/Fiestaboard/FiestaBoard/actions/runs/31659897047), `gh-readonly-queue/main/pr-1592-d87a6ce1`)

I rebuilt that exact merge-queue tree locally (`d87a6ce1` + `feat-registry-plugin-type`) and the file passes 7/7 deterministically, so this is a flake rather than a regression in #1592.

## Root cause

`PageBuilder` renders the TipTap editor — which owns the toolbar and its Sync from Board button — behind `lazy()` + `Suspense` (code-split in #1587). Every assertion in this file was absorbing that chunk's resolve/mount cost inside its own async window:

| | before | after |
|---|---|---|
| test 1 ("shows the Sync button") | 675 ms | 331 ms |
| subsequent tests (chunk cached) | ~200 ms | ~200 ms |

That ~450 ms delta is pure module resolution, on a **warm** vite cache. `setup.ts` already had to raise `asyncUtilTimeout` to 5000 ms for exactly this class of problem (#1575); on a loaded runner with a cold cache, that budget still runs out.

The fix warms the chunk once in `beforeAll`, so the waits measure rendering rather than module resolution and the cost lands in a hook instead of an assertion window. I also reproduced the general failure mode by running the full suite under a 2-CPU cap: an editor test that normally takes ~1 s failed at **16649 ms**, confirming these editor-backed async waits are load-sensitive.

## Also: a vacuous assertion the same lazy boundary was hiding

The edit-mode test only waited for `"Syncing..."` to be absent — trivially true before the editor mounts — then asserted the sync button was absent at a point where *no* toolbar button existed yet.

Per the repo's test quality bar, I verified it was vacuous by breaking the production behavior it claims to cover (making `PageBuilder` pass `onSyncFromBoard` unconditionally, leaking the button into edit mode):

- **old test against broken code:** passes, green in 42 ms
- **new test against broken code:** fails as it should —

```
 × does not show the Sync from Board button when editing an existing page  591ms
   → expect(element).not.toBeInTheDocument()
     expected document not to contain element, found <button
       aria-label="Sync from current board display" ...
```

Production code was restored afterwards; this PR touches only the test file.

## Verification

- `page-builder.test.tsx` — 7/7 pass
- `prettier --check` and `eslint` clean on the changed file

## Note

Sibling suites (`page-builder-draw-mode`, `page-builder-transition-picker`, `page-builder-device-switch`, `live-output`) render the same lazy editor and have the same structural exposure. I left them alone to keep this scoped to the eviction; worth a follow-up if they start flaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)