### PR TITLE
i18n(web): drive i18next/no-literal-string to zero and enforce it as an error

### DIFF
--- a/web/app/routes/collections.tsx
+++ b/web/app/routes/collections.tsx
@@ -822,8 +822,7 @@ export default function CollectionsPage() {
                         )}
                       </CardTitle>
                       <CardDescription className="text-xs">
-                        {collection.page_ids.length} page
-                        {collection.page_ids.length !== 1 ? "s" : ""} &middot; {describeMode(collection)}
+                        {tc("pageCount", { count: collection.page_ids.length })} &middot; {describeMode(collection)}
                       </CardDescription>
                     </Box>
                   </Flex>

--- a/web/app/routes/integrations.$pluginId.tsx
+++ b/web/app/routes/integrations.$pluginId.tsx
@@ -220,7 +220,7 @@ export default function PluginDetailPage() {
                   {/* eslint-disable-next-line react/forbid-elements -- single Slot child of Button asChild; the Button merges its chrome onto this anchor and TextLink would layer conflicting link styling */}
                   <a href={entry.repository} target="_blank" rel="noopener noreferrer">
                     <ExternalLink className="h-3.5 w-3.5 mr-1.5" />
-                    GitHub
+                    {t("githubLink")}
                   </a>
                 </Button>
               )}
@@ -382,9 +382,7 @@ export default function PluginDetailPage() {
       <Dialog open={addInstanceOpen} onOpenChange={setAddInstanceOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>
-              {t("addInstance")} of {entry?.name ?? pluginId}
-            </DialogTitle>
+            <DialogTitle>{t("addInstanceOfTitle", { name: entry?.name ?? pluginId })}</DialogTitle>
             <DialogDescription>{t("addInstanceDescription")}</DialogDescription>
           </DialogHeader>
           <Stack gap="2" className="py-2">

--- a/web/app/routes/integrations._index.tsx
+++ b/web/app/routes/integrations._index.tsx
@@ -684,7 +684,7 @@ function ColorRulesEditor({
               type="text"
               value={newFieldName}
               onChange={(e) => setNewFieldName(e.target.value)}
-              placeholder="Field name (e.g., temperature)"
+              placeholder={t("colorRules.fieldPlaceholder")}
               className="flex-1 h-8 px-2 text-xs rounded border bg-background"
             />
             <Button size="sm" className="h-8 text-xs" onClick={handleAddField}>
@@ -698,7 +698,7 @@ function ColorRulesEditor({
 
         {fieldNames.length === 0 ? (
           <Text size="xs" tone="muted" className="py-2">
-            No color rules configured. Add a field to create dynamic colors.
+            {t("colorRules.noRulesConfigured")}
           </Text>
         ) : (
           <Stack gap="3">
@@ -713,7 +713,7 @@ function ColorRulesEditor({
                         {pluginId}.{fieldName}
                       </CodeChip>
                       <Text as="span" size="xs" tone="muted">
-                        → color based on value
+                        {t("colorRules.colorBasedOnValue")}
                       </Text>
                     </Flex>
                     <Flex align="center" gap="1">
@@ -790,7 +790,7 @@ function ColorRulesEditor({
                           </select>
 
                           <Text as="span" size="xs" tone="muted" className="shrink-0">
-                            when
+                            {t("colorRules.when")}
                           </Text>
 
                           {/* Condition picker */}
@@ -819,7 +819,7 @@ function ColorRulesEditor({
                               });
                             }}
                             className="w-20 h-7 px-2 rounded border bg-background text-xs font-mono"
-                            placeholder="value"
+                            placeholder={t("colorRules.valuePlaceholder")}
                           />
 
                           {/* Delete button */}
@@ -1015,6 +1015,7 @@ function InstalledPluginRow({
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const queryClient = useQueryClient();
   const t = useTranslations("integrations");
+  const tCommon = useTranslations("common");
   const categoryLabels = useCategoryLabels();
 
   const isExternal = plugin.source?.source_type !== "builtin";
@@ -1160,7 +1161,7 @@ function InstalledPluginRow({
             <Skeleton className="h-3 w-16" />
           ) : rawDisplay && rawDisplay.available === false ? (
             <Text as="span" tone="muted" className="italic">
-              Unavailable
+              {t("valueUnavailable")}
             </Text>
           ) : resolved && resolved.short !== "" ? (
             <Tooltip>
@@ -1240,7 +1241,7 @@ function InstalledPluginRow({
   const configSheet = (
     <Sheet open={isConfigOpen} onOpenChange={setIsConfigOpen}>
       <SheetTrigger asChild>
-        <Button variant="ghost" size="icon" className="h-7 w-7" aria-label="Configure">
+        <Button variant="ghost" size="icon" className="h-7 w-7" aria-label={t("configureButton")}>
           <Settings className="h-3.5 w-3.5" />
         </Button>
       </SheetTrigger>
@@ -1250,7 +1251,7 @@ function InstalledPluginRow({
             <Icon className="h-5 w-5" />
             {plugin.name}
           </SheetTitle>
-          <SheetDescription>Configure settings for this integration</SheetDescription>
+          <SheetDescription>{t("configureDescription")}</SheetDescription>
         </SheetHeader>
         <Stack gap="6" className="py-6">
           {isLoadingDetails ? (
@@ -1267,12 +1268,10 @@ function InstalledPluginRow({
                   <Flex align="center" justify="between">
                     <Box>
                       <Heading level={4} size="sm" className="font-medium">
-                        Demo Page
+                        {t("demoPage.title")}
                       </Heading>
                       <Text size="xs" tone="muted" className="mt-0.5">
-                        {pluginDetails.demo_page_id
-                          ? "A demo page already exists for this plugin."
-                          : "Create a ready-to-use page that showcases this plugin."}
+                        {pluginDetails.demo_page_id ? t("demoPage.alreadyExists") : t("demoPage.createDescription")}
                       </Text>
                     </Box>
                     {pluginDetails.demo_page_id ? (
@@ -1280,23 +1279,20 @@ function InstalledPluginRow({
                         <DialogTrigger asChild>
                           <Button variant="outline" size="sm" disabled={!areDemoRequirementsMet() || isCreatingDemo}>
                             <RefreshCw className="h-3.5 w-3.5 mr-1.5" />
-                            Recreate
+                            {t("demoPage.recreateButton")}
                           </Button>
                         </DialogTrigger>
                         <DialogContent>
                           <DialogHeader>
-                            <DialogTitle>Recreate Demo Page?</DialogTitle>
-                            <DialogDescription>
-                              This will delete the existing demo page and create a fresh one with default settings. This
-                              action cannot be undone.
-                            </DialogDescription>
+                            <DialogTitle>{t("demoPage.recreateConfirmTitle")}</DialogTitle>
+                            <DialogDescription>{t("demoPage.recreateConfirmDescription")}</DialogDescription>
                           </DialogHeader>
                           <DialogFooter>
                             <Button variant="outline" onClick={() => setShowDemoConfirm(false)}>
-                              Cancel
+                              {tCommon("cancel")}
                             </Button>
                             <Button onClick={handleCreateDemoPage} disabled={isCreatingDemo}>
-                              {isCreatingDemo ? "Creating..." : "Recreate Demo Page"}
+                              {isCreatingDemo ? t("demoPage.creating") : t("demoPage.recreateAction")}
                             </Button>
                           </DialogFooter>
                         </DialogContent>
@@ -1309,13 +1305,13 @@ function InstalledPluginRow({
                         disabled={!areDemoRequirementsMet() || isCreatingDemo}
                       >
                         <Play className="h-3.5 w-3.5 mr-1.5" />
-                        {isCreatingDemo ? "Creating..." : "Create Demo Page"}
+                        {isCreatingDemo ? t("demoPage.creating") : t("demoPage.createAction")}
                       </Button>
                     )}
                   </Flex>
                   {!areDemoRequirementsMet() && (
                     <Text size="xs" tone="warning">
-                      Configure the required settings below before creating a demo page.
+                      {t("demoPage.requirementsWarning")}
                     </Text>
                   )}
                 </Stack>
@@ -1326,7 +1322,7 @@ function InstalledPluginRow({
                 Object.keys(pluginDetails.settings_schema.properties || {}).length > 0 && (
                   <Stack gap="4">
                     <Heading level={4} size="sm" className="font-medium text-muted-foreground">
-                      Settings
+                      {t("settingsSection")}
                     </Heading>
                     <SchemaForm
                       schema={pluginDetails.settings_schema}
@@ -1345,37 +1341,42 @@ function InstalledPluginRow({
                 <TooltipProvider delayDuration={200}>
                   <Stack gap="3">
                     <Heading level={4} size="sm" className="font-medium text-muted-foreground">
-                      Template Variables
+                      {t("templateVariablesSection")}
                       <Text as="span" size="xs" tone="muted" className="ml-2">
-                        (click to copy)
+                        ({t("templateVariablesClickToCopy")})
                       </Text>
                     </Heading>
                     {!plugin.enabled && (
                       <Text size="xs" tone="muted" className="italic">
-                        Enable the plugin to see live values.
+                        {t("enablePluginForLiveValues")}
                       </Text>
                     )}
                     {plugin.enabled && rawDisplay && rawDisplay.available === false && (
                       <Text size="xs" tone="warning">
-                        Live values are unavailable
-                        {rawDisplay.error ? `: ${rawDisplay.error}` : "."}
+                        {rawDisplay.error
+                          ? t("liveValuesUnavailableWithError", { error: rawDisplay.error })
+                          : t("liveValuesUnavailable")}
                       </Text>
                     )}
                     <Box className="rounded-md border overflow-hidden">
                       <Table className="text-xs">
                         <TableHeader className="bg-muted/50">
                           <TableRow>
-                            <TableHead className="text-left px-3 py-2 font-medium h-auto">Variable</TableHead>
-                            <TableHead className="text-left px-3 py-2 font-medium h-auto">Description</TableHead>
                             <TableHead className="text-left px-3 py-2 font-medium h-auto">
-                              Current Value
+                              {t("variableColumn")}
+                            </TableHead>
+                            <TableHead className="text-left px-3 py-2 font-medium h-auto">
+                              {t("descriptionColumn")}
+                            </TableHead>
+                            <TableHead className="text-left px-3 py-2 font-medium h-auto">
+                              {t("currentValueColumn")}
                               {plugin.enabled && isFetchingRawDisplay && !isLoadingRawDisplay && (
                                 <Text as="span" size="xs" tone="muted" className="ml-1.5 text-[10px] font-normal">
-                                  (refreshing…)
+                                  ({t("refreshingValues")})
                                 </Text>
                               )}
                             </TableHead>
-                            <TableHead className="text-center px-3 py-2 font-medium h-auto">Max</TableHead>
+                            <TableHead className="text-center px-3 py-2 font-medium h-auto">{t("maxColumn")}</TableHead>
                           </TableRow>
                         </TableHeader>
                         <TableBody className="divide-y">
@@ -1399,8 +1400,11 @@ function InstalledPluginRow({
                       </Table>
                     </Box>
                     <Text size="xs" tone="muted">
-                      Use in templates as{" "}
-                      <CodeChip className="bg-muted px-1 py-0 rounded">{`{{${plugin.id}.variable}}`}</CodeChip>
+                      {t.rich("useInTemplates", {
+                        example: () => (
+                          <CodeChip className="bg-muted px-1 py-0 rounded">{`{{${plugin.id}.variable}}`}</CodeChip>
+                        ),
+                      })}
                     </Text>
                   </Stack>
                 </TooltipProvider>
@@ -1410,15 +1414,21 @@ function InstalledPluginRow({
               {pluginDetails?.env_vars && pluginDetails.env_vars.length > 0 && (
                 <Stack gap="3">
                   <Heading level={4} size="sm" className="font-medium text-muted-foreground">
-                    Environment Variables
+                    {t("environmentVariablesSection")}
                   </Heading>
                   <Box className="rounded-md border overflow-hidden">
                     <Table className="text-xs">
                       <TableHeader className="bg-muted/50">
                         <TableRow>
-                          <TableHead className="text-left px-3 py-2 font-medium h-auto">Variable</TableHead>
-                          <TableHead className="text-left px-3 py-2 font-medium h-auto">Description</TableHead>
-                          <TableHead className="text-center px-3 py-2 font-medium h-auto">Required</TableHead>
+                          <TableHead className="text-left px-3 py-2 font-medium h-auto">
+                            {t("variableColumn")}
+                          </TableHead>
+                          <TableHead className="text-left px-3 py-2 font-medium h-auto">
+                            {t("descriptionColumn")}
+                          </TableHead>
+                          <TableHead className="text-center px-3 py-2 font-medium h-auto">
+                            {t("requiredBadge")}
+                          </TableHead>
                         </TableRow>
                       </TableHeader>
                       <TableBody className="divide-y">
@@ -1431,11 +1441,11 @@ function InstalledPluginRow({
                             <TableCell className="px-3 py-2 text-center">
                               {envVar.required ? (
                                 <Badge variant="destructive" className="text-[10px]">
-                                  Required
+                                  {t("requiredBadge")}
                                 </Badge>
                               ) : (
                                 <Badge variant="outline" className="text-[10px]">
-                                  Optional
+                                  {t("optionalBadge")}
                                 </Badge>
                               )}
                             </TableCell>
@@ -1461,9 +1471,7 @@ function InstalledPluginRow({
               {/* No config message */}
               {(!pluginDetails?.settings_schema ||
                 Object.keys(pluginDetails.settings_schema.properties || {}).length === 0) &&
-                variableRows.length === 0 && (
-                  <Text tone="muted">No configuration options available for this plugin.</Text>
-                )}
+                variableRows.length === 0 && <Text tone="muted">{t("noConfigOptions")}</Text>}
             </>
           )}
         </Stack>
@@ -1485,7 +1493,7 @@ function InstalledPluginRow({
           )}
           <SheetClose asChild>
             <Button variant="outline" disabled={isSaving}>
-              Cancel
+              {tCommon("cancel")}
             </Button>
           </SheetClose>
           <Button onClick={handleSaveConfig} disabled={isSaving || isLoadingDetails}>
@@ -1520,7 +1528,7 @@ function InstalledPluginRow({
                 {plugin.name}
               </Text>
               <Badge variant="outline" className="text-[10px] font-normal px-1.5 py-0 h-4 shrink-0">
-                v{plugin.version}
+                {tCommon("versionShort", { version: plugin.version })}
               </Badge>
               {isCore && (
                 <Badge
@@ -1528,7 +1536,7 @@ function InstalledPluginRow({
                   className="text-[10px] gap-1 font-normal px-1.5 py-0 h-4 shrink-0 border-orange-300 text-orange-600 dark:text-orange-400 dark:border-orange-700"
                 >
                   <BoxIcon className="h-2.5 w-2.5" />
-                  Core
+                  {t("sourceCoreBadge")}
                 </Badge>
               )}
               {isMarketplace && (
@@ -1537,7 +1545,7 @@ function InstalledPluginRow({
                   className="text-[10px] gap-1 font-normal px-1.5 py-0 h-4 shrink-0 border-sky-300 text-sky-600 dark:text-sky-400 dark:border-sky-700"
                 >
                   <Package className="h-2.5 w-2.5" />
-                  Marketplace
+                  {t("sourceMarketplaceBadge")}
                 </Badge>
               )}
               {isGitExternal && (
@@ -1546,7 +1554,7 @@ function InstalledPluginRow({
                   className="text-[10px] gap-1 font-normal px-1.5 py-0 h-4 shrink-0 border-purple-300 text-purple-600 dark:text-purple-400 dark:border-purple-700"
                 >
                   <GitBranch className="h-2.5 w-2.5" />
-                  External
+                  {t("sourceExternalBadge")}
                 </Badge>
               )}
               {hasUpdate && (
@@ -1555,7 +1563,7 @@ function InstalledPluginRow({
                   className="text-[10px] gap-1 font-normal px-1.5 py-0 h-4 shrink-0 text-amber-600 border-amber-300 bg-amber-50 dark:bg-amber-950 dark:text-amber-400"
                 >
                   <ArrowDownToLine className="h-2.5 w-2.5" />
-                  Update
+                  {t("updateAvailableBadge")}
                 </Badge>
               )}
             </Flex>
@@ -1582,18 +1590,18 @@ function InstalledPluginRow({
             plugin.configured ? (
               <Badge variant="default" className="text-[10px] gap-1 px-1.5 py-0 h-5">
                 <CheckCircle className="h-2.5 w-2.5" />
-                Configured
+                {t("configuredBadge")}
               </Badge>
             ) : (
               <Badge variant="secondary" className="text-[10px] gap-1 px-1.5 py-0 h-5">
                 <AlertCircle className="h-2.5 w-2.5" />
-                Setup Required
+                {t("setupRequiredBadge")}
               </Badge>
             )
           ) : (
             <Badge variant="outline" className="text-[10px] gap-1 px-1.5 py-0 h-5">
               <XCircle className="h-2.5 w-2.5" />
-              Disabled
+              {t("disabledBadge")}
             </Badge>
           )}
         </TableCell>
@@ -1612,19 +1620,19 @@ function InstalledPluginRow({
             {configSheet}
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="icon" className="h-7 w-7" aria-label="More options">
+                <Button variant="ghost" size="icon" className="h-7 w-7" aria-label={t("moreOptionsAriaLabel")}>
                   <MoreHorizontal className="h-3.5 w-3.5" />
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
                 <DropdownMenuItem onClick={() => setIsConfigOpen(true)}>
                   <Settings className="h-3.5 w-3.5 mr-2" />
-                  Configure
+                  {t("configureButton")}
                 </DropdownMenuItem>
                 {!isInstance && (
                   <DropdownMenuItem onClick={() => setShowAddInstance(true)}>
                     <CopyPlus className="h-3.5 w-3.5 mr-2" />
-                    Add Instance
+                    {t("addInstanceAction")}
                   </DropdownMenuItem>
                 )}
                 {!isTransition && (
@@ -1654,7 +1662,7 @@ function InstalledPluginRow({
                       className="text-destructive focus:text-destructive"
                     >
                       <Trash2 className="h-3.5 w-3.5 mr-2" />
-                      Delete
+                      {tCommon("delete")}
                     </DropdownMenuItem>
                   </>
                 )}
@@ -1681,7 +1689,7 @@ function InstalledPluginRow({
           <TableCell colSpan={4} className="px-4 py-3">
             <Flex align="center" gap="3" className="max-w-md">
               <Label htmlFor={`instance-label-${plugin.id}`} className="text-sm whitespace-nowrap">
-                Instance name:
+                {t("instanceNameInlineLabel")}
               </Label>
               <Input
                 id={`instance-label-${plugin.id}`}
@@ -1717,12 +1725,11 @@ function InstalledPluginRow({
                   setInstanceLabel("");
                 }}
               >
-                Cancel
+                {tCommon("cancel")}
               </Button>
             </Flex>
             <Text size="xs" tone="muted" className="mt-1.5">
-              Creates a new independent instance of this plugin with its own configuration. Use alphanumeric characters,
-              hyphens, or underscores (1-40 chars).
+              {t("addInstanceInlineHelp")}
             </Text>
           </TableCell>
         </TableRow>
@@ -1736,18 +1743,16 @@ function InstalledPluginRow({
       <AlertDialogContent>
         <AlertDialogHeader>
           {isInstance ? (
-            <AlertDialogTitle>Delete instance &ldquo;{plugin.instance_label}&rdquo;?</AlertDialogTitle>
+            <AlertDialogTitle>{t("deleteInstanceConfirmTitle", { label: plugin.instance_label })}</AlertDialogTitle>
           ) : (
-            <AlertDialogTitle>Delete &ldquo;{plugin.name}&rdquo;?</AlertDialogTitle>
+            <AlertDialogTitle>{t("deletePluginConfirmTitle", { name: plugin.name })}</AlertDialogTitle>
           )}
           <AlertDialogDescription>
-            {isInstance
-              ? "This will permanently remove this instance and its configuration. This action cannot be undone."
-              : "This will permanently remove the plugin and all its instances. This action cannot be undone."}
+            {isInstance ? t("deleteInstanceConfirmDescription") : t("deletePluginConfirmDescription")}
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogCancel>{tCommon("cancel")}</AlertDialogCancel>
           <AlertDialogAction
             onClick={
               isInstance
@@ -1759,7 +1764,7 @@ function InstalledPluginRow({
             }
             className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
           >
-            Delete
+            {tCommon("delete")}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/web/app/routes/pages.edit._index.tsx
+++ b/web/app/routes/pages.edit._index.tsx
@@ -3,8 +3,10 @@ import { useEffect, useState } from "react";
 
 import { PageBuilder } from "@/components/page-builder";
 import { useViewTransition } from "@/hooks/use-view-transition";
+import { useTranslations } from "@/i18n/translations";
 
 export default function EditPage() {
+  const tCommon = useTranslations("common");
   const { push } = useViewTransition();
   const [pageId, setPageId] = useState<string | null>(null);
 
@@ -34,7 +36,7 @@ export default function EditPage() {
     return (
       <PageLayout>
         <Text tone="muted" className="text-center">
-          Loading...
+          {tCommon("loading")}
         </Text>
       </PageLayout>
     );

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -1,5 +1,9 @@
 import prettierConfig from "eslint-config-prettier";
 import i18nextPlugin from "eslint-plugin-i18next";
+// The rule shallow-merges its option object over its own defaults, so a bare
+// `words: { exclude: [...] }` REPLACES the plugin's default excludes instead of
+// extending them. Import the defaults and spread them back in.
+import i18nextDefaults from "eslint-plugin-i18next/lib/options/defaults.js";
 import jsxA11y from "eslint-plugin-jsx-a11y";
 import reactPlugin from "eslint-plugin-react";
 import reactHooks from "eslint-plugin-react-hooks";
@@ -92,20 +96,50 @@ const eslintConfig = [
     },
   },
   {
-    // i18n: catch hardcoded user-facing strings in JSX that should be translated
+    // i18n: catch hardcoded user-facing strings in JSX that should be translated.
     plugins: {
       i18next: i18nextPluginFlatConfigAdapter,
     },
+    // Storybook stories and unit tests are developer-facing fixtures that never
+    // render to an end user, so their copy is deliberately untranslated. They are
+    // already exempted from other app-only rules further down this config.
+    ignores: ["**/*.stories.{ts,tsx}", "**/__tests__/**", "**/*.test.{ts,tsx}", "**/*.spec.{ts,tsx}", "tests/**"],
     rules: {
       "i18next/no-literal-string": [
         "warn",
         {
           mode: "jsx-text-only",
+          // NOTE: inert under `jsx-text-only` — that mode only visits literals
+          // whose direct parent is a JSXElement/JSXFragment, so attribute
+          // values are never reached. Kept so the intent survives if the mode
+          // is ever widened to "jsx-only". The literal `aria-label` / `title`
+          // values that existed when #1567 landed were translated by hand;
+          // enforcing them needs "jsx-only", which also pulls in every string
+          // inside a JSX expression container (ternaries, toasts) — a separate
+          // sweep.
           "jsx-attributes": {
             include: ["title", "placeholder", "alt", "aria-label"],
           },
+          "jsx-components": {
+            // `Code` / `CodeChip` render shell commands, file paths, env var
+            // names and template syntax. Those are literal by definition and
+            // must NOT be translated, so their children are exempt.
+            exclude: [...i18nextDefaults["jsx-components"].exclude, "Code", "CodeChip"],
+          },
           words: {
-            exclude: ["FiestaBoard", "Vestaboard", "•", "&middot;"],
+            exclude: [
+              ...i18nextDefaults.words.exclude,
+              // Brand names are identical in every locale.
+              "FiestaBoard",
+              "Vestaboard",
+              // Runs of punctuation / symbols / whitespace with no letters in
+              // them — "*", "(", ")", "—", "·", "×", "→", "⌘↵". These are
+              // typography around a neighbouring {t(...)} call, not copy. The
+              // plugin's own ASCII-only default misses the non-ASCII ones.
+              /^[\p{P}\p{S}\s]+$/u,
+              // Emoji sequences (ZWJ + variation selectors), e.g. "🏳️‍🌈".
+              /^[\p{Emoji}‍️\s]+$/u,
+            ],
           },
           "should-validate-template": false,
         },

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -97,6 +97,8 @@ const eslintConfig = [
   },
   {
     // i18n: catch hardcoded user-facing strings in JSX that should be translated.
+    // Errors, not warnings — every string rendered to a user has to exist in all
+    // 14 locale files under messages/ (issue #1567).
     plugins: {
       i18next: i18nextPluginFlatConfigAdapter,
     },
@@ -106,7 +108,7 @@ const eslintConfig = [
     ignores: ["**/*.stories.{ts,tsx}", "**/__tests__/**", "**/*.test.{ts,tsx}", "**/*.spec.{ts,tsx}", "tests/**"],
     rules: {
       "i18next/no-literal-string": [
-        "warn",
+        "error",
         {
           mode: "jsx-text-only",
           // NOTE: inert under `jsx-text-only` — that mode only visits literals

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -50,7 +50,8 @@
     "pageCount": "{count, plural, one {# Seite} other {# Seiten}}",
     "unknownError": "Unbekannter Fehler",
     "opensInNewTab": "(wird in einem neuen Tab geöffnet)",
-    "notificationsRegionLabel": "Benachrichtigungen"
+    "notificationsRegionLabel": "Benachrichtigungen",
+    "versionShort": "v{version}"
   },
   "metadata": {
     "appTitle": "FiestaBoard-Steuerung",
@@ -81,7 +82,8 @@
     "boardSelector": "Zu verwaltendes Board auswählen",
     "selectBoard": "Board auswählen",
     "unnamedBoard": "Unbenanntes Board",
-    "transitions": "Übergangs-Labor"
+    "transitions": "Übergangs-Labor",
+    "prideCelebration": "Frohen Pride Month!"
   },
   "network": {
     "title": "WLAN",
@@ -330,7 +332,11 @@
       "validationOneOffDateRequired": "Please pick a date",
       "validationEndDateBeforeStart": "End date must be on or after start date",
       "collectionSizeWarning": "{count} von {total} Seiten in dieser Sammlung passen nicht zur Größe dieses Boards und werden übersprungen.",
-      "incompatiblePageWarning": "Diese Seite passt nicht zur Größe dieses Boards und wird möglicherweise nicht richtig angezeigt."
+      "incompatiblePageWarning": "Diese Seite passt nicht zur Größe dieses Boards und wird möglicherweise nicht richtig angezeigt.",
+      "monthAriaLabel": "Monat",
+      "dayAriaLabel": "Tag",
+      "endMonthAriaLabel": "Endmonat",
+      "endDayAriaLabel": "Endtag"
     },
     "descriptionWithTimezone": "Automatisiere die Seitenrotation nach Zeit und Tag · {timezone}",
     "gapDefaultPlaceholder": "Standard für Lücken…",
@@ -472,7 +478,37 @@
     "toastNoUpdates": "Alle Plugins sind aktuell",
     "toastCheckFailed": "Suche nach Updates fehlgeschlagen: {error}",
     "installAction": "Installieren",
-    "installedBadge": "Installiert"
+    "installedBadge": "Installiert",
+    "valueUnavailable": "Nicht verfügbar",
+    "enablePluginForLiveValues": "Aktivieren Sie das Plugin, um Live-Werte zu sehen.",
+    "liveValuesUnavailable": "Live-Werte sind nicht verfügbar.",
+    "liveValuesUnavailableWithError": "Live-Werte sind nicht verfügbar: {error}",
+    "currentValueColumn": "Aktueller Wert",
+    "refreshingValues": "wird aktualisiert…",
+    "sourceCoreBadge": "Kern",
+    "sourceMarketplaceBadge": "Marktplatz",
+    "sourceExternalBadge": "Extern",
+    "updateAvailableBadge": "Update",
+    "moreOptionsAriaLabel": "Weitere Optionen",
+    "addInstanceAction": "Instanz hinzufügen",
+    "instanceNameInlineLabel": "Instanzname:",
+    "addInstanceInlineHelp": "Erstellt eine neue unabhängige Instanz dieses Plugins mit eigener Konfiguration. Verwenden Sie alphanumerische Zeichen, Bindestriche oder Unterstriche (1–40 Zeichen).",
+    "deleteInstanceConfirmTitle": "Instanz „{label}“ löschen?",
+    "deletePluginConfirmTitle": "„{name}“ löschen?",
+    "deleteInstanceConfirmDescription": "Dadurch werden diese Instanz und ihre Konfiguration dauerhaft entfernt. Diese Aktion kann nicht rückgängig gemacht werden.",
+    "deletePluginConfirmDescription": "Dadurch werden das Plugin und alle seine Instanzen dauerhaft entfernt. Diese Aktion kann nicht rückgängig gemacht werden.",
+    "demoPage": {
+      "title": "Demoseite",
+      "alreadyExists": "Für dieses Plugin existiert bereits eine Demoseite.",
+      "createDescription": "Erstellen Sie eine sofort nutzbare Seite, die dieses Plugin präsentiert.",
+      "recreateButton": "Neu erstellen",
+      "recreateConfirmTitle": "Demoseite neu erstellen?",
+      "recreateConfirmDescription": "Dadurch wird die vorhandene Demoseite gelöscht und eine neue mit Standardeinstellungen erstellt. Diese Aktion kann nicht rückgängig gemacht werden.",
+      "creating": "Wird erstellt...",
+      "createAction": "Demoseite erstellen",
+      "recreateAction": "Demoseite neu erstellen",
+      "requirementsWarning": "Konfigurieren Sie unten die erforderlichen Einstellungen, bevor Sie eine Demoseite erstellen."
+    }
   },
   "settings": {
     "title": "Einstellungen",
@@ -496,7 +532,43 @@
     "sectionAccount": "Konto",
     "sectionAccountDescription": "Benutzername, Passwort und Abmelden",
     "sectionNetwork": "Netzwerk",
-    "sectionNetworkDescription": "WLAN und Konnektivität verwalten"
+    "sectionNetworkDescription": "WLAN und Konnektivität verwalten",
+    "ai": {
+      "removeProviderAriaLabel": "Anbieter entfernen",
+      "cardTitle": "KI-Anbieter",
+      "cardDescription": "Konfigurieren Sie OpenAI-kompatible LLMs für den Seitengenerator „Gen AI“. BYO-LLM: FiestaBoard liefert nie einen Schlüssel mit.",
+      "privacyNotice": "Ihre Prompts und die Variablenliste Ihrer aktivierten Plugins werden direkt an den von Ihnen konfigurierten Anbieter gesendet. API-Schlüssel werden auf diesem Gerät gespeichert und nirgendwo anders hin übertragen.",
+      "emptyState": "Noch keine Anbieter konfiguriert.",
+      "addProviderButton": "Anbieter hinzufügen",
+      "discardButton": "Verwerfen",
+      "saveChangesButton": "Änderungen speichern",
+      "defaultBadge": "Standard",
+      "anthropicBadge": "Anthropic",
+      "makeDefaultButton": "Als Standard festlegen",
+      "nameLabel": "Name",
+      "protocolLabel": "Protokoll",
+      "protocolOpenaiOption": "OpenAI-kompatibel (OpenAI, OpenRouter, Groq, DeepSeek, Mistral, Together, Fireworks, Ollama, LM Studio, vLLM, …)",
+      "protocolAnthropicOption": "Anthropic (Messages API)",
+      "baseUrlLabel": "Basis-URL",
+      "quickPresetsLabel": "Voreinstellungen",
+      "apiKeyLabel": "API-Schlüssel",
+      "modelsLabel": "Modelle",
+      "defaultModelLabel": "Standardmodell",
+      "testConnectionButton": "Verbindung testen"
+    },
+    "backup": {
+      "cardTitle": "Sicherung & Wiederherstellung",
+      "cardDescription": "Exportieren Sie Ihre gesamte FiestaBoard-Konfiguration — Board-Einstellungen, Seiten, Karussells, Zeitpläne und Plugin-Konfiguration — als einzelne JSON-Datei. Laden Sie diese Datei auf einer neuen Instanz wieder hoch, um zu migrieren oder nach einem Upgrade wiederherzustellen.",
+      "exportButton": "Sicherung exportieren",
+      "importButton": "Sicherung importieren…",
+      "reinstallPluginsLabel": "Externe Plugins nach dem Import neu installieren",
+      "reinstallPluginsDescription": "Wenn aktiviert, versucht FiestaBoard, alle in der Sicherung erfassten externen Plugins zu klonen, die auf dieser Instanz noch nicht installiert sind. Ihre Konfiguration wird ohnehin aus der Sicherung wiederhergestellt.",
+      "sensitiveNote": "Hinweis: Sicherungen enthalten sensible Werte wie API-Schlüssel und Board-Zugangsdaten im Klartext. Bewahren Sie die Datei sicher auf und geben Sie sie nicht öffentlich weiter.",
+      "confirmTitle": "Aktuelle Konfiguration ersetzen?",
+      "confirmDescription": "Sie sind dabei, <file></file> wiederherzustellen. Ihre vorhandenen Seiten, Karussells, Zeitpläne und Konfiguration werden überschrieben. Von jeder vorhandenen Datei wird eine Kopie mit Zeitstempel neben der neuen aufbewahrt, sodass Sie bei Bedarf manuell zurückkehren können.",
+      "restoringButton": "Wird wiederhergestellt…",
+      "restoreButton": "Sicherung wiederherstellen"
+    }
   },
   "offline": {
     "youreOffline": "Sie sind offline",
@@ -581,7 +653,10 @@
       "passwordPlaceholder": "IhrPasswort",
       "wifiPreview": "WLAN: {ssid}",
       "passPreview": "PASS: {password}",
-      "noPassword": "(kein Passwort)"
+      "noPassword": "(kein Passwort)",
+      "addMoreHint": "Sie können jederzeit weitere über die Seite <link>Integrationen</link> hinzufügen.",
+      "builtInBadge": "Integriert",
+      "previewLabel": "Vorschau:"
     },
     "welcome": {
       "setupComplete": "Einrichtung abgeschlossen!",
@@ -639,7 +714,9 @@
     "changeModeDisableTitle": "Zeitplan-Modus deaktivieren",
     "changeModeDisableDescription": "Deaktiviere den Zeitplan und steuere das Board manuell.",
     "changeModeDisableSuccess": "Zeitplan-Modus deaktiviert",
-    "collectionSizeWarning": "{count} von {total} Seiten in dieser Sammlung passen nicht zur Größe dieses Boards und werden übersprungen."
+    "collectionSizeWarning": "{count} von {total} Seiten in dieser Sammlung passen nicht zur Größe dieses Boards und werden übersprungen.",
+    "turnOffLiveModeAriaLabel": "Live-Modus deaktivieren",
+    "liveModeBadge": "Live-Modus"
   },
   "forceSetDialog": {
     "title": "Board erzwingen",
@@ -882,7 +959,10 @@
     "updateNow": "Jetzt aktualisieren",
     "oneClickHint": "Möchten Sie hier einen Ein-Klick-„Jetzt aktualisieren“-Button? Setzen Sie <profile></profile> in Ihrer <envFile></envFile>-Datei und führen Sie dann <command></command> aus.",
     "dialogTitle": "FiestaBoard aktualisieren?",
-    "dialogDescription": "Dadurch wird <version></version> heruntergeladen und FiestaBoard neu gestartet. Die Boardanzeige pausiert ca. 30 Sekunden und diese Seite wird automatisch neu geladen."
+    "dialogDescription": "Dadurch wird <version></version> heruntergeladen und FiestaBoard neu gestartet. Die Boardanzeige pausiert ca. 30 Sekunden und diese Seite wird automatisch neu geladen.",
+    "intervalSelectAriaLabel": "Häufigkeit der Updatesuche",
+    "intervalCardDescription": "Wie oft FiestaBoard im Hintergrund nach einer neuen Version suchen soll. Sie sehen hier ein Banner, sobald eine gefunden wurde.",
+    "lastChecked": "Zuletzt geprüft: {time}"
   },
   "transitionSettings": {
     "title": "Board-Übergänge",
@@ -1008,7 +1088,8 @@
       "Numbers": "Zahlen",
       "Symbols": "Symbole",
       "Colors": "Farben"
-    }
+    },
+    "latencyMs": "{ms} ms"
   },
   "generalSettings": {
     "title": "Allgemeine Einstellungen",
@@ -1375,7 +1456,8 @@
     "flapSpeed_relaxedHint": "{ms} ms – ein langsames, bewusstes Umklappen für ruhige Displays.",
     "flapSpeedPreviewLabel": "Vorschau",
     "flapSpeedInactive": "Board-Animationen sind aus, die Umklappgeschwindigkeit hat daher keine Wirkung.",
-    "flapSpeedScreenOnlyNote": "Dies ändert nur die Board-Vorschau auf dem Bildschirm. Wie Ihr physisches Vestaboard seine eigenen Übergänge taktet, wird separat unter Verhalten → Board-Übergänge eingestellt."
+    "flapSpeedScreenOnlyNote": "Dies ändert nur die Board-Vorschau auf dem Bildschirm. Wie Ihr physisches Vestaboard seine eigenen Übergänge taktet, wird separat unter Verhalten → Board-Übergänge eingestellt.",
+    "updateAvailableBadge": "v{version} verfügbar"
   },
   "monitor": {
     "title": "Monitor",
@@ -1647,7 +1729,8 @@
     "whiteBoard": "Weiße Anzeige",
     "deviceFlagship": "Flagship",
     "deviceNote": "Note",
-    "deviceNoteArray": "Note-Array {w}×{h}"
+    "deviceNoteArray": "Note-Array {w}×{h}",
+    "githubLink": "GitHub"
   },
   "boardDisplay": {
     "loading": "Board-Anzeige wird geladen",
@@ -1736,7 +1819,12 @@
     "remoteOptionsSearchPlaceholder": "Suchen…",
     "remoteOptionsCustomLabel": "Eigener Wert",
     "remoteOptionsCustomPlaceholder": "Einen Wert eingeben, der nicht in der Liste steht",
-    "remoteOptionsCustomAdd": "Eigenen Wert hinzufügen"
+    "remoteOptionsCustomAdd": "Eigenen Wert hinzufügen",
+    "addItemLabel": "{label} hinzufügen",
+    "unknownType": "Unbekannter Typ: {type}",
+    "pagePickerNone": "Keine (keine Übersteuerung)",
+    "pagePickerLoading": "Seiten werden geladen…",
+    "pagePickerPlaceholder": "Seite auswählen…"
   },
   "filterPicker": {
     "noFiltersAvailable": "Keine Filter verfügbar",
@@ -1744,7 +1832,8 @@
     "filterDescWrap": "Bricht langen Text über mehrere Zeilen um",
     "filterDescPad": "Füllt Text auf die angegebene Breite auf",
     "filterDescTruncate": "Kürzt Text auf die angegebene Länge",
-    "wrapInstruction": "|wrap: Bricht langen Text um. Lasse leere Zeilen darunter, damit Text hineinfließen kann."
+    "wrapInstruction": "Bricht langen Text um. Lasse leere Zeilen darunter, damit Text hineinfließen kann.",
+    "exampleLabel": "Beispiel: {example}"
   },
   "formattingPicker": {
     "noFormattingAvailable": "Keine Formatierungsoptionen verfügbar",
@@ -1805,7 +1894,25 @@
     "alignRight": "Rechtsbündig",
     "syncFromBoardTooltip": "Vorlage mit dem füllen, was gerade auf dem Board angezeigt wird",
     "syncFromBoard": "Mit aktueller Board-Anzeige synchronisieren",
-    "alignment": "Ausrichtung:"
+    "alignment": "Ausrichtung:",
+    "undoAriaLabel": "Rückgängig",
+    "redoAriaLabel": "Wiederholen",
+    "cutAriaLabel": "Ausschneiden",
+    "copyAriaLabel": "Kopieren",
+    "pasteAriaLabel": "Einfügen",
+    "removeWrappedTextAriaLabel": "Umgebrochenen Text entfernen",
+    "colorPickerAriaLabel": "Farbauswahl",
+    "heartCharacterAriaLabel": "Herzzeichen",
+    "lineCount": "{used} / {max} Zeilen",
+    "overLineLimit": " — überschreitet das Board-Limit von {max} Zeilen",
+    "currentLine": "(Zeile {line})",
+    "heartLabel": "Herz",
+    "insertHeartTooltip": "Herzzeichen einfügen (nur Note)",
+    "colorTileTooltip": "{color}-Kachel (Code {code}) - zum Verschieben ziehen, Rücktaste zum Löschen",
+    "fillSpaceTooltip": "Füllbereich - dehnt sich auf die restliche Zeilenbreite aus",
+    "fillSpaceRepeatTooltip": "Füllbereich wiederholt: {char}",
+    "variableFilterTooltip": "Filter: {filter}",
+    "variableMaxLengthTooltip": "Maximale Länge: {maxLength} Zeichen"
   },
   "variablePicker": {
     "noVariablesAvailable": "Keine Variablen verfügbar",
@@ -1815,7 +1922,8 @@
     "searchPlaceholder": "Variablen suchen...",
     "indexLabel": "Index: {index}",
     "configureHint": "Konfiguriere {arrayName} in den Einstellungen, um indizierte Variablen hier zu sehen.",
-    "configureExample": "Beispiel:"
+    "configureExample": "Beispiel:",
+    "noMatchingVariables": "Keine passenden Variablen gefunden."
   },
   "login": {
     "signInTitle": "Bei FiestaBoard anmelden",
@@ -1873,11 +1981,62 @@
     "taskStatusAriaLabel": "Aufgabenfortschritt",
     "taskProgressAriaLabel": "Fortschritt der KI-Aufgaben",
     "clearConversationAriaLabel": "Konversation löschen",
-    "closePanelAriaLabel": "FiestaBot (Beta) schließen"
+    "closePanelAriaLabel": "FiestaBot (Beta) schließen",
+    "providerSelectAriaLabel": "Anbieter",
+    "modelSelectAriaLabel": "Modell",
+    "showBoardTooltip": "Board-Vorschau anzeigen",
+    "hideBoardTooltip": "Board-Vorschau ausblenden",
+    "undoTooltip": "Letzte KI-Änderung rückgängig machen",
+    "panelTitle": "FiestaBot (Beta)",
+    "retryButton": "Erneut versuchen",
+    "messageLabel": "Nachricht",
+    "stopButton": "Stoppen",
+    "sendButton": "Senden",
+    "tasksHeading": "Aufgaben ({done}/{total})",
+    "emptyStateTitle": "Wie kann ich helfen?",
+    "emptyStateDescription": "Beschreibe, was du erstellen oder ändern möchtest.",
+    "showBoardButton": "Board anzeigen",
+    "undoButton": "Rückgängig",
+    "renameSummary": "→ umbenennen in „{name}“",
+    "previewUnavailable": "(Vorschau nicht verfügbar)"
   },
   "boardSizeIndicator": {
     "custom": "Benutzerdefiniert",
     "ariaLabel": "{rows} Zeilen mal {cols} Spalten",
     "ariaLabelWithLayout": "{rows} Zeilen mal {cols} Spalten, {layout}"
+  },
+  "mcpSettings": {
+    "title": "MCP / externe Clients",
+    "description": "Ein vorab geteiltes Token, mit dem Claude Desktop, Claude Code und andere MCP-Clients mit diesem FiestaBoard kommunizieren können. Das Token authentifiziert sich als einzelner Principal — beschränkt auf den Endpunkt {endpoint} — und kann daher keine Seiten oder anderen Einstellungen bearbeiten. Siehe <link>MCP-Client-Einrichtung</link> für client-spezifische Eigenheiten (Desktop benötigt einen stdio-Proxy; Connectors im claude.ai-Web erfordern öffentliches HTTPS und OAuth und erreichen daher keinen Host im LAN).",
+    "statusLabel": "Status:",
+    "pinnedByEnvBadge": "Festgelegt durch {envVar}",
+    "configuredBadge": "Konfiguriert",
+    "pinnedByEnvDescription": "Das aktive Token wird durch die Umgebungsvariable {envVar} festgelegt. Entfernen Sie sie aus Ihrer {envFile} und starten Sie den Container neu, bevor Sie das Token über diese Oberfläche verwalten.",
+    "noTokenDescription": "Es ist kein Token konfiguriert. Externe MCP-Clients fallen auf Cookie-Authentifizierung zurück, die Claude Desktop / Claude Code nicht unterstützen — ihre Registrierung schlägt dann mit einer nichtssagenden Fehlermeldung fehl. Generieren Sie ein Token, um sie freizuschalten.",
+    "activeTokenDescription": "Ein Token ist konfiguriert und aktiv. Rotieren Sie es, um das vorherige ungültig zu machen (jeder Client, der noch das alte Token verwendet, erhält dann 401), oder widerrufen Sie es vollständig, um auf reine Cookie-Authentifizierung zurückzufallen.",
+    "rotateTokenButton": "Token rotieren",
+    "generateTokenButton": "Token generieren",
+    "revokeTokenButton": "Token widerrufen",
+    "rotateConfirmTitle": "MCP-Token rotieren?",
+    "generateConfirmTitle": "MCP-Token generieren?",
+    "rotateConfirmDescription": "Jeder Client, der noch das vorherige Token verwendet, wird bei seiner nächsten Anfrage mit 401 + Bearer-Challenge abgewiesen. Sie sehen das neue Token nur einmal — bewahren Sie es sicher auf (es lässt sich später nicht erneut über die Oberfläche auslesen).",
+    "generateConfirmDescription": "Sie sehen das Token nur einmal — bewahren Sie es sicher auf (es lässt sich später nicht erneut über die Oberfläche auslesen). Externe MCP-Clients authentifizieren sich damit bei {endpoint}.",
+    "rotateConfirmButton": "Rotieren",
+    "generateConfirmButton": "Generieren",
+    "revokeConfirmTitle": "MCP-Token widerrufen?",
+    "revokeConfirmDescription": "Externe MCP-Clients erhalten bei ihrer nächsten Anfrage 401. Sie können später jederzeit ein neues Token generieren.",
+    "revokeConfirmButton": "Widerrufen",
+    "revealTitle": "Dieses Token speichern",
+    "revealDescription": "FiestaBoard speichert nur das, was zur Prüfung künftiger Anfragen nötig ist — dies ist das einzige Mal, dass der Klartextwert angezeigt wird. Kopieren Sie ihn jetzt in Ihren MCP-Client.",
+    "tokenLabel": "Token",
+    "copyButton": "Kopieren",
+    "copiedButton": "Kopiert",
+    "configSnippetLabel": "Claude Desktop-Konfigurationsausschnitt",
+    "configSnippetDescription": "Fügen Sie dies in {configPath} ein und führen Sie es mit bereits vorhandenen Einträgen zusammen. Beenden Sie Claude Desktop danach vollständig und starten Sie es neu (⌘Q — das Schließen des Fensters genügt nicht). Claude Desktop unterstützt nur stdio-MCP-Server, daher ruft dieses Snippet {mcpRemoteLink} über {npx} als Proxy auf — Node 18+ muss installiert und {npx} über den PATH von Claude Desktop erreichbar sein. Schlägt es mit {commandNotFound} fehl, ersetzen Sie {npxQuoted} durch den absoluten Pfad aus {whichNpx}.",
+    "claudeCodeDescription": "<label>Claude Code (CLI):</label> kommuniziert direkt über HTTP — kein Proxy nötig.",
+    "claudeWebDescription": "<label>claude.ai web (Connectors):</label> wird für selbst gehostete FiestaBoards nicht unterstützt. Der Connectors-Ablauf erfordert eine öffentliche HTTPS-URL und dynamische OAuth-2.1-Client-Registrierung — beides kann ein Host im LAN nicht bereitstellen. Verwenden Sie stattdessen Desktop oder Code.",
+    "savedItButton": "Ich habe es gespeichert",
+    "toastTokenRevoked": "MCP-Token widerrufen",
+    "toastCopyFailed": "Kopieren in die Zwischenablage fehlgeschlagen"
   }
 }

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -50,7 +50,8 @@
     "pageCount": "{count, plural, one {# page} other {# pages}}",
     "unknownError": "Unknown error",
     "opensInNewTab": "(opens in new tab)",
-    "notificationsRegionLabel": "Notifications"
+    "notificationsRegionLabel": "Notifications",
+    "versionShort": "v{version}"
   },
   "metadata": {
     "appTitle": "FiestaBoard Control",
@@ -81,7 +82,8 @@
     "boardSelector": "Select board to manage",
     "selectBoard": "Select board",
     "unnamedBoard": "Unnamed board",
-    "transitions": "Transition Lab"
+    "transitions": "Transition Lab",
+    "prideCelebration": "Happy Pride!"
   },
   "home": {
     "title": "Dashboard",
@@ -287,7 +289,11 @@
       "validationOneOffDateRequired": "Please pick a date",
       "validationEndDateBeforeStart": "End date must be on or after start date",
       "collectionSizeWarning": "{count} of {total} pages in this collection don't fit this board's size and will be skipped.",
-      "incompatiblePageWarning": "This page doesn't match this board's size and may not display correctly."
+      "incompatiblePageWarning": "This page doesn't match this board's size and may not display correctly.",
+      "monthAriaLabel": "Month",
+      "dayAriaLabel": "Day",
+      "endMonthAriaLabel": "End month",
+      "endDayAriaLabel": "End day"
     },
     "descriptionWithTimezone": "Automate page rotation by time and day · {timezone}",
     "gapDefaultPlaceholder": "Gap default…",
@@ -429,7 +435,37 @@
     "toastNoUpdates": "All plugins are up to date",
     "toastCheckFailed": "Couldn't check for updates: {error}",
     "installAction": "Install",
-    "installedBadge": "Installed"
+    "installedBadge": "Installed",
+    "valueUnavailable": "Unavailable",
+    "enablePluginForLiveValues": "Enable the plugin to see live values.",
+    "liveValuesUnavailable": "Live values are unavailable.",
+    "liveValuesUnavailableWithError": "Live values are unavailable: {error}",
+    "currentValueColumn": "Current Value",
+    "refreshingValues": "refreshing…",
+    "sourceCoreBadge": "Core",
+    "sourceMarketplaceBadge": "Marketplace",
+    "sourceExternalBadge": "External",
+    "updateAvailableBadge": "Update",
+    "moreOptionsAriaLabel": "More options",
+    "addInstanceAction": "Add Instance",
+    "instanceNameInlineLabel": "Instance name:",
+    "addInstanceInlineHelp": "Creates a new independent instance of this plugin with its own configuration. Use alphanumeric characters, hyphens, or underscores (1-40 chars).",
+    "deleteInstanceConfirmTitle": "Delete instance “{label}”?",
+    "deletePluginConfirmTitle": "Delete “{name}”?",
+    "deleteInstanceConfirmDescription": "This will permanently remove this instance and its configuration. This action cannot be undone.",
+    "deletePluginConfirmDescription": "This will permanently remove the plugin and all its instances. This action cannot be undone.",
+    "demoPage": {
+      "title": "Demo Page",
+      "alreadyExists": "A demo page already exists for this plugin.",
+      "createDescription": "Create a ready-to-use page that showcases this plugin.",
+      "recreateButton": "Recreate",
+      "recreateConfirmTitle": "Recreate Demo Page?",
+      "recreateConfirmDescription": "This will delete the existing demo page and create a fresh one with default settings. This action cannot be undone.",
+      "creating": "Creating...",
+      "createAction": "Create Demo Page",
+      "recreateAction": "Recreate Demo Page",
+      "requirementsWarning": "Configure the required settings below before creating a demo page."
+    }
   },
   "settings": {
     "title": "Settings",
@@ -453,7 +489,43 @@
     "sectionAccount": "Account",
     "sectionAccountDescription": "Username, password, and sign out",
     "sectionNetwork": "Network",
-    "sectionNetworkDescription": "Manage Wi-Fi and connectivity"
+    "sectionNetworkDescription": "Manage Wi-Fi and connectivity",
+    "ai": {
+      "removeProviderAriaLabel": "Remove provider",
+      "cardTitle": "AI Providers",
+      "cardDescription": "Configure OpenAI-compatible LLMs for the “Gen AI” page generator. BYO-LLM: FiestaBoard never bundles a key.",
+      "privacyNotice": "Your prompts and the variable list of your enabled plugins are sent directly to the provider you configure. API keys are stored on this device and never sent anywhere else.",
+      "emptyState": "No providers configured yet.",
+      "addProviderButton": "Add provider",
+      "discardButton": "Discard",
+      "saveChangesButton": "Save changes",
+      "defaultBadge": "Default",
+      "anthropicBadge": "Anthropic",
+      "makeDefaultButton": "Make default",
+      "nameLabel": "Name",
+      "protocolLabel": "Protocol",
+      "protocolOpenaiOption": "OpenAI-compatible (OpenAI, OpenRouter, Groq, DeepSeek, Mistral, Together, Fireworks, Ollama, LM Studio, vLLM, …)",
+      "protocolAnthropicOption": "Anthropic (Messages API)",
+      "baseUrlLabel": "Base URL",
+      "quickPresetsLabel": "Quick presets",
+      "apiKeyLabel": "API Key",
+      "modelsLabel": "Models",
+      "defaultModelLabel": "Default model",
+      "testConnectionButton": "Test connection"
+    },
+    "backup": {
+      "cardTitle": "Backup & Restore",
+      "cardDescription": "Export all of your FiestaBoard configuration — board settings, pages, collections, schedules and plugin configuration — as a single JSON file. Re-upload that file on a new instance to migrate or recover after an upgrade.",
+      "exportButton": "Export backup",
+      "importButton": "Import backup…",
+      "reinstallPluginsLabel": "Reinstall external plugins after import",
+      "reinstallPluginsDescription": "When enabled, FiestaBoard will attempt to clone any external plugins recorded in the backup that are not yet installed on this instance. Their configuration is restored from the backup either way.",
+      "sensitiveNote": "Note: backups contain sensitive values such as API keys and board credentials in plain text. Store the file securely and do not share it publicly.",
+      "confirmTitle": "Replace current configuration?",
+      "confirmDescription": "You are about to restore <file></file>. Your existing pages, collections, schedules and configuration will be overwritten. A timestamped copy of each existing file is kept alongside the new one so you can roll back manually if needed.",
+      "restoringButton": "Restoring…",
+      "restoreButton": "Restore backup"
+    }
   },
   "offline": {
     "youreOffline": "You're Offline",
@@ -538,7 +610,10 @@
       "passwordPlaceholder": "YourPassword",
       "wifiPreview": "WIFI: {ssid}",
       "passPreview": "PASS: {password}",
-      "noPassword": "(no password)"
+      "noPassword": "(no password)",
+      "addMoreHint": "You can add more from the <link>Integrations</link> page at any time.",
+      "builtInBadge": "Built-in",
+      "previewLabel": "Preview:"
     },
     "welcome": {
       "setupComplete": "Setup Complete!",
@@ -596,7 +671,9 @@
     "changeModeDisableTitle": "Turn off schedule mode",
     "changeModeDisableDescription": "Disable the schedule and control the board manually.",
     "changeModeDisableSuccess": "Schedule mode disabled",
-    "collectionSizeWarning": "{count} of {total} pages in this collection don't fit this board's size and will be skipped."
+    "collectionSizeWarning": "{count} of {total} pages in this collection don't fit this board's size and will be skipped.",
+    "turnOffLiveModeAriaLabel": "Turn off Live Mode",
+    "liveModeBadge": "Live Mode"
   },
   "forceSetDialog": {
     "title": "Force Set Board",
@@ -839,7 +916,10 @@
     "updateNow": "Update Now",
     "oneClickHint": "Want a one-click \"Update Now\" button here? Set <profile></profile> in your <envFile></envFile>, then run <command></command>.",
     "dialogTitle": "Update FiestaBoard?",
-    "dialogDescription": "This will pull <version></version> and restart FiestaBoard. The board display will pause for about 30 seconds and this page will reload automatically."
+    "dialogDescription": "This will pull <version></version> and restart FiestaBoard. The board display will pause for about 30 seconds and this page will reload automatically.",
+    "intervalSelectAriaLabel": "Update check frequency",
+    "intervalCardDescription": "How often FiestaBoard should look for a new release in the background. You'll see a banner here when one is found.",
+    "lastChecked": "Last checked: {time}"
   },
   "transitionSettings": {
     "title": "Board Transitions",
@@ -965,7 +1045,8 @@
       "Numbers": "Numbers",
       "Symbols": "Symbols",
       "Colors": "Colors"
-    }
+    },
+    "latencyMs": "{ms}ms"
   },
   "generalSettings": {
     "title": "Schedule & Automation",
@@ -1332,7 +1413,8 @@
     "statusStopped": "Stopped",
     "devBuild": "Development build",
     "viewDocs": "View documentation",
-    "timezoneLabel": "Timezone"
+    "timezoneLabel": "Timezone",
+    "updateAvailableBadge": "v{version} available"
   },
   "monitor": {
     "title": "Monitor",
@@ -1604,7 +1686,8 @@
     "whiteBoard": "White Board",
     "deviceFlagship": "Flagship",
     "deviceNote": "Note",
-    "deviceNoteArray": "Note Array {w}×{h}"
+    "deviceNoteArray": "Note Array {w}×{h}",
+    "githubLink": "GitHub"
   },
   "boardDisplay": {
     "loading": "Loading board display",
@@ -1693,7 +1776,12 @@
     "remoteOptionsSearchPlaceholder": "Search…",
     "remoteOptionsCustomLabel": "Custom value",
     "remoteOptionsCustomPlaceholder": "Enter a value not in the list",
-    "remoteOptionsCustomAdd": "Add custom value"
+    "remoteOptionsCustomAdd": "Add custom value",
+    "addItemLabel": "Add {label}",
+    "unknownType": "Unknown type: {type}",
+    "pagePickerNone": "None (no override)",
+    "pagePickerLoading": "Loading pages…",
+    "pagePickerPlaceholder": "Choose a page…"
   },
   "filterPicker": {
     "noFiltersAvailable": "No filters available",
@@ -1701,7 +1789,8 @@
     "filterDescWrap": "Wraps long text across multiple lines",
     "filterDescPad": "Pads text to specified width",
     "filterDescTruncate": "Truncates text to specified length",
-    "wrapInstruction": "|wrap: Wraps long text. Leave empty lines below for text to flow into."
+    "wrapInstruction": "Wraps long text. Leave empty lines below for text to flow into.",
+    "exampleLabel": "Example: {example}"
   },
   "formattingPicker": {
     "noFormattingAvailable": "No formatting options available",
@@ -1762,7 +1851,25 @@
     "alignRight": "Align right",
     "syncFromBoardTooltip": "Populate template from what's currently displayed on the board",
     "syncFromBoard": "Sync from current board display",
-    "alignment": "Alignment:"
+    "alignment": "Alignment:",
+    "undoAriaLabel": "Undo",
+    "redoAriaLabel": "Redo",
+    "cutAriaLabel": "Cut",
+    "copyAriaLabel": "Copy",
+    "pasteAriaLabel": "Paste",
+    "removeWrappedTextAriaLabel": "Remove wrapped text",
+    "colorPickerAriaLabel": "Color picker",
+    "heartCharacterAriaLabel": "Heart character",
+    "lineCount": "{used} / {max} lines",
+    "overLineLimit": " — exceeds the {max}-line board limit",
+    "currentLine": "(Line {line})",
+    "heartLabel": "heart",
+    "insertHeartTooltip": "Insert heart character (Note only)",
+    "colorTileTooltip": "{color} tile (code {code}) - drag to move, backspace to delete",
+    "fillSpaceTooltip": "Fill space - expands to fill remaining line width",
+    "fillSpaceRepeatTooltip": "Fill space repeating: {char}",
+    "variableFilterTooltip": "Filter: {filter}",
+    "variableMaxLengthTooltip": "Max length: {maxLength} characters"
   },
   "variablePicker": {
     "noVariablesAvailable": "No variables available",
@@ -1772,7 +1879,8 @@
     "searchPlaceholder": "Search variables...",
     "indexLabel": "Index: {index}",
     "configureHint": "Configure {arrayName} in Settings to see indexed variables here.",
-    "configureExample": "Example:"
+    "configureExample": "Example:",
+    "noMatchingVariables": "No matching variables found."
   },
   "network": {
     "title": "Wi-Fi",
@@ -1873,11 +1981,62 @@
     "taskStatusAriaLabel": "Task progress",
     "taskProgressAriaLabel": "AI task progress",
     "clearConversationAriaLabel": "Clear conversation",
-    "closePanelAriaLabel": "Close FiestaBot (Beta)"
+    "closePanelAriaLabel": "Close FiestaBot (Beta)",
+    "providerSelectAriaLabel": "Provider",
+    "modelSelectAriaLabel": "Model",
+    "showBoardTooltip": "Show board preview",
+    "hideBoardTooltip": "Hide board preview",
+    "undoTooltip": "Undo last AI change",
+    "panelTitle": "FiestaBot (Beta)",
+    "retryButton": "Retry",
+    "messageLabel": "Message",
+    "stopButton": "Stop",
+    "sendButton": "Send",
+    "tasksHeading": "Tasks ({done}/{total})",
+    "emptyStateTitle": "How can I help?",
+    "emptyStateDescription": "Describe what you'd like to build or change.",
+    "showBoardButton": "Show board",
+    "undoButton": "Undo",
+    "renameSummary": "→ rename to \"{name}\"",
+    "previewUnavailable": "(preview unavailable)"
   },
   "boardSizeIndicator": {
     "custom": "Custom",
     "ariaLabel": "{rows} rows by {cols} columns",
     "ariaLabelWithLayout": "{rows} rows by {cols} columns, {layout}"
+  },
+  "mcpSettings": {
+    "title": "MCP / external clients",
+    "description": "A pre-shared token that lets Claude Desktop, Claude Code, and other MCP clients talk to this FiestaBoard. The token authenticates as a single principal — scoped to the {endpoint} endpoint only — so it can't edit pages or other settings. See <link>MCP client setup</link> for client-specific quirks (Desktop needs an stdio proxy; claude.ai web Connectors require public HTTPS and OAuth, so they won't reach a LAN host).",
+    "statusLabel": "Status:",
+    "pinnedByEnvBadge": "Pinned by {envVar}",
+    "configuredBadge": "Configured",
+    "pinnedByEnvDescription": "The active token is set by the {envVar} environment variable. Unset it in your {envFile} and restart the container before managing the token from this UI.",
+    "noTokenDescription": "No token is configured. External MCP clients will fall back to cookie auth, which Claude Desktop / Claude Code don't support — they'll fail registration with an opaque error. Generate a token to unblock them.",
+    "activeTokenDescription": "A token is configured and active. Rotate it to invalidate the previous one (any client still using the old token will start receiving 401), or revoke it entirely to fall back to cookie-only auth.",
+    "rotateTokenButton": "Rotate token",
+    "generateTokenButton": "Generate token",
+    "revokeTokenButton": "Revoke token",
+    "rotateConfirmTitle": "Rotate MCP token?",
+    "generateConfirmTitle": "Generate MCP token?",
+    "rotateConfirmDescription": "Any client still using the previous token will be denied with a 401 + Bearer challenge on its next request. You'll see the new token once — store it somewhere safe (it's not readable from the UI again).",
+    "generateConfirmDescription": "You'll see the token once — store it somewhere safe (it's not readable from the UI again). External MCP clients will use it to authenticate to {endpoint}.",
+    "rotateConfirmButton": "Rotate",
+    "generateConfirmButton": "Generate",
+    "revokeConfirmTitle": "Revoke MCP token?",
+    "revokeConfirmDescription": "External MCP clients will start receiving 401 on their next request. You can always generate a new token later.",
+    "revokeConfirmButton": "Revoke",
+    "revealTitle": "Save this token",
+    "revealDescription": "FiestaBoard stores only what's needed to verify future requests — this is the only time the plaintext value is shown. Copy it into your MCP client now.",
+    "tokenLabel": "Token",
+    "copyButton": "Copy",
+    "copiedButton": "Copied",
+    "configSnippetLabel": "Claude Desktop config snippet",
+    "configSnippetDescription": "Paste this into {configPath}, merging with anything that's already there, then fully quit and relaunch Claude Desktop (⌘Q — closing the window isn't enough). Claude Desktop only supports stdio MCP servers, so this snippet shells out to {mcpRemoteLink} via {npx} as a proxy — Node 18+ must be installed and {npx} reachable from Claude Desktop's PATH. If it errors with {commandNotFound}, replace {npxQuoted} with the absolute path from {whichNpx}.",
+    "claudeCodeDescription": "<label>Claude Code (CLI):</label> talks HTTP directly — no proxy needed.",
+    "claudeWebDescription": "<label>claude.ai web (Connectors):</label> not supported for self-hosted FiestaBoard. The Connectors flow requires a public HTTPS URL and OAuth 2.1 dynamic client registration, neither of which a LAN host can provide. Use Desktop or Code instead.",
+    "savedItButton": "I've saved it",
+    "toastTokenRevoked": "MCP token revoked",
+    "toastCopyFailed": "Couldn't copy to clipboard"
   }
 }

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -50,7 +50,8 @@
     "pageCount": "{count, plural, one {# página} other {# páginas}}",
     "unknownError": "Error desconocido",
     "opensInNewTab": "(se abre en una pestaña nueva)",
-    "notificationsRegionLabel": "Notificaciones"
+    "notificationsRegionLabel": "Notificaciones",
+    "versionShort": "v{version}"
   },
   "metadata": {
     "appTitle": "Panel de FiestaBoard",
@@ -81,7 +82,8 @@
     "boardSelector": "Seleccionar tablero a gestionar",
     "selectBoard": "Seleccionar tablero",
     "unnamedBoard": "Tablero sin nombre",
-    "transitions": "Laboratorio de transiciones"
+    "transitions": "Laboratorio de transiciones",
+    "prideCelebration": "¡Feliz Orgullo!"
   },
   "network": {
     "title": "Wi-Fi",
@@ -330,7 +332,11 @@
       "validationOneOffDateRequired": "Please pick a date",
       "validationEndDateBeforeStart": "End date must be on or after start date",
       "collectionSizeWarning": "{count} de {total} páginas de esta colección no se ajustan al tamaño de este tablero y se omitirán.",
-      "incompatiblePageWarning": "Esta página no coincide con el tamaño de este tablero y puede no mostrarse correctamente."
+      "incompatiblePageWarning": "Esta página no coincide con el tamaño de este tablero y puede no mostrarse correctamente.",
+      "monthAriaLabel": "Mes",
+      "dayAriaLabel": "Día",
+      "endMonthAriaLabel": "Mes de fin",
+      "endDayAriaLabel": "Día de fin"
     },
     "descriptionWithTimezone": "Automatiza la rotación de páginas por hora y día · {timezone}",
     "gapDefaultPlaceholder": "Predeterminada para huecos…",
@@ -472,7 +478,37 @@
     "toastNoUpdates": "Todos los plugins están actualizados",
     "toastCheckFailed": "No se pudo comprobar las actualizaciones: {error}",
     "installAction": "Instalar",
-    "installedBadge": "Instalado"
+    "installedBadge": "Instalado",
+    "valueUnavailable": "No disponible",
+    "enablePluginForLiveValues": "Habilita el plugin para ver los valores en vivo.",
+    "liveValuesUnavailable": "Los valores en vivo no están disponibles.",
+    "liveValuesUnavailableWithError": "Los valores en vivo no están disponibles: {error}",
+    "currentValueColumn": "Valor actual",
+    "refreshingValues": "actualizando…",
+    "sourceCoreBadge": "Nativo",
+    "sourceMarketplaceBadge": "Mercado",
+    "sourceExternalBadge": "Externo",
+    "updateAvailableBadge": "Actualización",
+    "moreOptionsAriaLabel": "Más opciones",
+    "addInstanceAction": "Añadir instancia",
+    "instanceNameInlineLabel": "Nombre de la instancia:",
+    "addInstanceInlineHelp": "Crea una nueva instancia independiente de este plugin con su propia configuración. Usa caracteres alfanuméricos, guiones o guiones bajos (1-40 caracteres).",
+    "deleteInstanceConfirmTitle": "¿Eliminar la instancia «{label}»?",
+    "deletePluginConfirmTitle": "¿Eliminar «{name}»?",
+    "deleteInstanceConfirmDescription": "Esto eliminará permanentemente esta instancia y su configuración. Esta acción no se puede deshacer.",
+    "deletePluginConfirmDescription": "Esto eliminará permanentemente el plugin y todas sus instancias. Esta acción no se puede deshacer.",
+    "demoPage": {
+      "title": "Página de demostración",
+      "alreadyExists": "Ya existe una página de demostración para este plugin.",
+      "createDescription": "Crea una página lista para usar que muestra este plugin.",
+      "recreateButton": "Recrear",
+      "recreateConfirmTitle": "¿Recrear la página de demostración?",
+      "recreateConfirmDescription": "Esto eliminará la página de demostración existente y creará una nueva con los ajustes predeterminados. Esta acción no se puede deshacer.",
+      "creating": "Creando...",
+      "createAction": "Crear página de demostración",
+      "recreateAction": "Recrear página de demostración",
+      "requirementsWarning": "Configura los ajustes requeridos a continuación antes de crear una página de demostración."
+    }
   },
   "settings": {
     "title": "Configuración",
@@ -496,7 +532,43 @@
     "sectionAccount": "Cuenta",
     "sectionAccountDescription": "Usuario, contraseña y cerrar sesión",
     "sectionNetwork": "Red",
-    "sectionNetworkDescription": "Gestionar Wi-Fi y conectividad"
+    "sectionNetworkDescription": "Gestionar Wi-Fi y conectividad",
+    "ai": {
+      "removeProviderAriaLabel": "Eliminar proveedor",
+      "cardTitle": "Proveedores de IA",
+      "cardDescription": "Configura LLM compatibles con OpenAI para el generador de páginas «Gen AI». Trae tu propio LLM: FiestaBoard nunca incluye una clave.",
+      "privacyNotice": "Tus indicaciones y la lista de variables de los plugins que tengas activados se envían directamente al proveedor que configures. Las claves API se guardan en este dispositivo y no se envían a ningún otro sitio.",
+      "emptyState": "Aún no hay proveedores configurados.",
+      "addProviderButton": "Añadir proveedor",
+      "discardButton": "Descartar",
+      "saveChangesButton": "Guardar cambios",
+      "defaultBadge": "Predeterminado",
+      "anthropicBadge": "Anthropic",
+      "makeDefaultButton": "Hacer predeterminado",
+      "nameLabel": "Nombre",
+      "protocolLabel": "Protocolo",
+      "protocolOpenaiOption": "Compatible con OpenAI (OpenAI, OpenRouter, Groq, DeepSeek, Mistral, Together, Fireworks, Ollama, LM Studio, vLLM, …)",
+      "protocolAnthropicOption": "Anthropic (API Messages)",
+      "baseUrlLabel": "URL base",
+      "quickPresetsLabel": "Preajustes rápidos",
+      "apiKeyLabel": "Clave API",
+      "modelsLabel": "Modelos",
+      "defaultModelLabel": "Modelo predeterminado",
+      "testConnectionButton": "Probar conexión"
+    },
+    "backup": {
+      "cardTitle": "Copia de seguridad y restauración",
+      "cardDescription": "Exporta toda la configuración de tu FiestaBoard —ajustes del tablero, páginas, carruseles, horarios y configuración de plugins— en un único archivo JSON. Vuelve a subir ese archivo en una instancia nueva para migrar o recuperarte tras una actualización.",
+      "exportButton": "Exportar copia de seguridad",
+      "importButton": "Importar copia de seguridad…",
+      "reinstallPluginsLabel": "Reinstalar los plugins externos tras la importación",
+      "reinstallPluginsDescription": "Cuando está activado, FiestaBoard intentará clonar los plugins externos registrados en la copia de seguridad que aún no estén instalados en esta instancia. Su configuración se restaura desde la copia de seguridad en cualquier caso.",
+      "sensitiveNote": "Nota: las copias de seguridad contienen valores sensibles, como claves API y credenciales del tablero, en texto plano. Guarda el archivo de forma segura y no lo compartas públicamente.",
+      "confirmTitle": "¿Reemplazar la configuración actual?",
+      "confirmDescription": "Estás a punto de restaurar <file></file>. Tus páginas, carruseles, horarios y configuración actuales se sobrescribirán. Se conserva una copia con marca de tiempo de cada archivo existente junto al nuevo, para que puedas revertir manualmente si hace falta.",
+      "restoringButton": "Restaurando…",
+      "restoreButton": "Restaurar copia de seguridad"
+    }
   },
   "offline": {
     "youreOffline": "Estás sin conexión",
@@ -581,7 +653,10 @@
       "passwordPlaceholder": "TuContraseña",
       "wifiPreview": "WIFI: {ssid}",
       "passPreview": "CLAVE: {password}",
-      "noPassword": "(sin contraseña)"
+      "noPassword": "(sin contraseña)",
+      "addMoreHint": "Puedes añadir más desde la página de <link>Integraciones</link> en cualquier momento.",
+      "builtInBadge": "Integrado",
+      "previewLabel": "Vista previa:"
     },
     "welcome": {
       "setupComplete": "¡Configuración completa!",
@@ -639,7 +714,9 @@
     "changeModeDisableTitle": "Desactivar modo programado",
     "changeModeDisableDescription": "Desactivar la programación y controlar la pantalla manualmente.",
     "changeModeDisableSuccess": "Modo programado desactivado",
-    "collectionSizeWarning": "{count} de {total} páginas de esta colección no se ajustan al tamaño de este tablero y se omitirán."
+    "collectionSizeWarning": "{count} de {total} páginas de esta colección no se ajustan al tamaño de este tablero y se omitirán.",
+    "turnOffLiveModeAriaLabel": "Desactivar el modo en vivo",
+    "liveModeBadge": "Modo en vivo"
   },
   "forceSetDialog": {
     "title": "Forzar pantalla",
@@ -882,7 +959,10 @@
     "updateNow": "Actualizar ahora",
     "oneClickHint": "¿Quieres un botón de \"Actualizar ahora\" con un solo clic aquí? Establece <profile></profile> en tu <envFile></envFile>, luego ejecuta <command></command>.",
     "dialogTitle": "¿Actualizar FiestaBoard?",
-    "dialogDescription": "Esto descargará <version></version> y reiniciará FiestaBoard. La pantalla del tablero se pausará durante unos 30 segundos y esta página se recargará automáticamente."
+    "dialogDescription": "Esto descargará <version></version> y reiniciará FiestaBoard. La pantalla del tablero se pausará durante unos 30 segundos y esta página se recargará automáticamente.",
+    "intervalSelectAriaLabel": "Frecuencia de búsqueda de actualizaciones",
+    "intervalCardDescription": "Con qué frecuencia debe buscar FiestaBoard una nueva versión en segundo plano. Verás un aviso aquí cuando encuentre una.",
+    "lastChecked": "Última comprobación: {time}"
   },
   "transitionSettings": {
     "title": "Transiciones del tablero",
@@ -1008,7 +1088,8 @@
       "Numbers": "Números",
       "Symbols": "Símbolos",
       "Colors": "Colores"
-    }
+    },
+    "latencyMs": "{ms} ms"
   },
   "generalSettings": {
     "title": "Configuración general",
@@ -1375,7 +1456,8 @@
     "flapSpeed_relaxedHint": "{ms} ms: un giro lento y deliberado para pantallas ambientales.",
     "flapSpeedPreviewLabel": "Vista previa",
     "flapSpeedInactive": "Las animaciones de la pantalla están desactivadas, así que la velocidad de giro no tiene efecto.",
-    "flapSpeedScreenOnlyNote": "Esto solo cambia la vista previa en pantalla. El ritmo de las transiciones de tu Vestaboard físico se configura aparte, en Comportamiento → Transiciones de la pantalla."
+    "flapSpeedScreenOnlyNote": "Esto solo cambia la vista previa en pantalla. El ritmo de las transiciones de tu Vestaboard físico se configura aparte, en Comportamiento → Transiciones de la pantalla.",
+    "updateAvailableBadge": "v{version} disponible"
   },
   "monitor": {
     "title": "Monitor",
@@ -1647,7 +1729,8 @@
     "whiteBoard": "Panel blanco",
     "deviceFlagship": "Flagship",
     "deviceNote": "Note",
-    "deviceNoteArray": "Matriz Note {w}×{h}"
+    "deviceNoteArray": "Matriz Note {w}×{h}",
+    "githubLink": "GitHub"
   },
   "boardDisplay": {
     "loading": "Cargando visualización del tablero",
@@ -1736,7 +1819,12 @@
     "remoteOptionsSearchPlaceholder": "Buscar…",
     "remoteOptionsCustomLabel": "Valor personalizado",
     "remoteOptionsCustomPlaceholder": "Introduce un valor que no esté en la lista",
-    "remoteOptionsCustomAdd": "Añadir valor personalizado"
+    "remoteOptionsCustomAdd": "Añadir valor personalizado",
+    "addItemLabel": "Añadir {label}",
+    "unknownType": "Tipo desconocido: {type}",
+    "pagePickerNone": "Ninguna (sin anulación)",
+    "pagePickerLoading": "Cargando páginas…",
+    "pagePickerPlaceholder": "Elige una página…"
   },
   "filterPicker": {
     "noFiltersAvailable": "No hay filtros disponibles",
@@ -1744,7 +1832,8 @@
     "filterDescWrap": "Ajusta texto largo en varias líneas",
     "filterDescPad": "Rellena el texto al ancho especificado",
     "filterDescTruncate": "Trunca el texto a la longitud especificada",
-    "wrapInstruction": "|wrap: Ajusta texto largo. Deja líneas vacías debajo para que el texto fluya."
+    "wrapInstruction": "Ajusta texto largo. Deja líneas vacías debajo para que el texto fluya.",
+    "exampleLabel": "Ejemplo: {example}"
   },
   "formattingPicker": {
     "noFormattingAvailable": "No hay opciones de formato disponibles",
@@ -1805,7 +1894,25 @@
     "alignRight": "Alinear a la derecha",
     "syncFromBoardTooltip": "Rellenar la plantilla con lo que se muestra actualmente en la pantalla",
     "syncFromBoard": "Sincronizar desde la pantalla actual",
-    "alignment": "Alineación:"
+    "alignment": "Alineación:",
+    "undoAriaLabel": "Deshacer",
+    "redoAriaLabel": "Rehacer",
+    "cutAriaLabel": "Cortar",
+    "copyAriaLabel": "Copiar",
+    "pasteAriaLabel": "Pegar",
+    "removeWrappedTextAriaLabel": "Eliminar el texto ajustado",
+    "colorPickerAriaLabel": "Selector de color",
+    "heartCharacterAriaLabel": "Carácter de corazón",
+    "lineCount": "{used} / {max} líneas",
+    "overLineLimit": " — excede el límite de {max} líneas del tablero",
+    "currentLine": "(Línea {line})",
+    "heartLabel": "corazón",
+    "insertHeartTooltip": "Insertar carácter de corazón (solo Note)",
+    "colorTileTooltip": "Mosaico {color} (código {code}) - arrastra para mover, retroceso para eliminar",
+    "fillSpaceTooltip": "Espacio de relleno: se expande para ocupar el ancho restante de la línea",
+    "fillSpaceRepeatTooltip": "Relleno repitiendo: {char}",
+    "variableFilterTooltip": "Filtro: {filter}",
+    "variableMaxLengthTooltip": "Longitud máxima: {maxLength} caracteres"
   },
   "variablePicker": {
     "noVariablesAvailable": "No hay variables disponibles",
@@ -1815,7 +1922,8 @@
     "searchPlaceholder": "Buscar variables...",
     "indexLabel": "Índice: {index}",
     "configureHint": "Configura {arrayName} en Ajustes para ver aquí las variables indexadas.",
-    "configureExample": "Ejemplo:"
+    "configureExample": "Ejemplo:",
+    "noMatchingVariables": "No se encontraron variables coincidentes."
   },
   "login": {
     "signInTitle": "Iniciar sesión en FiestaBoard",
@@ -1873,11 +1981,62 @@
     "taskStatusAriaLabel": "Progreso de tareas",
     "taskProgressAriaLabel": "Progreso de tareas de IA",
     "clearConversationAriaLabel": "Borrar conversación",
-    "closePanelAriaLabel": "Cerrar FiestaBot (Beta)"
+    "closePanelAriaLabel": "Cerrar FiestaBot (Beta)",
+    "providerSelectAriaLabel": "Proveedor",
+    "modelSelectAriaLabel": "Modelo",
+    "showBoardTooltip": "Mostrar la vista previa del tablero",
+    "hideBoardTooltip": "Ocultar la vista previa del tablero",
+    "undoTooltip": "Deshacer el último cambio de la IA",
+    "panelTitle": "FiestaBot (Beta)",
+    "retryButton": "Reintentar",
+    "messageLabel": "Mensaje",
+    "stopButton": "Detener",
+    "sendButton": "Enviar",
+    "tasksHeading": "Tareas ({done}/{total})",
+    "emptyStateTitle": "¿En qué puedo ayudarte?",
+    "emptyStateDescription": "Describe lo que quieres crear o cambiar.",
+    "showBoardButton": "Mostrar tablero",
+    "undoButton": "Deshacer",
+    "renameSummary": "→ renombrar a \"{name}\"",
+    "previewUnavailable": "(vista previa no disponible)"
   },
   "boardSizeIndicator": {
     "custom": "Personalizado",
     "ariaLabel": "{rows} filas por {cols} columnas",
     "ariaLabelWithLayout": "{rows} filas por {cols} columnas, {layout}"
+  },
+  "mcpSettings": {
+    "title": "MCP / clientes externos",
+    "description": "Un token precompartido que permite que Claude Desktop, Claude Code y otros clientes MCP se comuniquen con este FiestaBoard. El token se autentica como un único principal —limitado solo al endpoint {endpoint}—, así que no puede editar páginas ni otros ajustes. Consulta <link>Configuración de clientes MCP</link> para conocer las particularidades de cada cliente (Desktop necesita un proxy stdio; los Connectors de claude.ai web requieren HTTPS público y OAuth, así que no llegarán a un host de la LAN).",
+    "statusLabel": "Estado:",
+    "pinnedByEnvBadge": "Fijado por {envVar}",
+    "configuredBadge": "Configurado",
+    "pinnedByEnvDescription": "El token activo lo establece la variable de entorno {envVar}. Elimínala de tu {envFile} y reinicia el contenedor antes de gestionar el token desde esta interfaz.",
+    "noTokenDescription": "No hay ningún token configurado. Los clientes MCP externos recurrirán a la autenticación por cookies, que Claude Desktop / Claude Code no admiten: fallarán al registrarse con un error poco claro. Genera un token para desbloquearlos.",
+    "activeTokenDescription": "Hay un token configurado y activo. Rótalo para invalidar el anterior (cualquier cliente que siga usando el token antiguo empezará a recibir 401), o revócalo por completo para volver a la autenticación solo con cookies.",
+    "rotateTokenButton": "Rotar token",
+    "generateTokenButton": "Generar token",
+    "revokeTokenButton": "Revocar token",
+    "rotateConfirmTitle": "¿Rotar el token MCP?",
+    "generateConfirmTitle": "¿Generar un token MCP?",
+    "rotateConfirmDescription": "Cualquier cliente que siga usando el token anterior recibirá un 401 + desafío Bearer en su próxima solicitud. Verás el token nuevo una sola vez: guárdalo en un lugar seguro (no se puede volver a leer desde la interfaz).",
+    "generateConfirmDescription": "Verás el token una sola vez: guárdalo en un lugar seguro (no se puede volver a leer desde la interfaz). Los clientes MCP externos lo usarán para autenticarse en {endpoint}.",
+    "rotateConfirmButton": "Rotar",
+    "generateConfirmButton": "Generar",
+    "revokeConfirmTitle": "¿Revocar el token MCP?",
+    "revokeConfirmDescription": "Los clientes MCP externos empezarán a recibir 401 en su próxima solicitud. Siempre puedes generar un token nuevo más tarde.",
+    "revokeConfirmButton": "Revocar",
+    "revealTitle": "Guarda este token",
+    "revealDescription": "FiestaBoard solo guarda lo necesario para verificar futuras solicitudes: esta es la única vez que se muestra el valor en texto plano. Cópialo ahora en tu cliente MCP.",
+    "tokenLabel": "Token",
+    "copyButton": "Copiar",
+    "copiedButton": "Copiado",
+    "configSnippetLabel": "Fragmento de configuración para Claude Desktop",
+    "configSnippetDescription": "Pega esto en {configPath}, combinándolo con lo que ya haya, y luego cierra por completo y vuelve a abrir Claude Desktop (⌘Q — cerrar la ventana no basta). Claude Desktop solo admite servidores MCP por stdio, así que este fragmento invoca {mcpRemoteLink} a través de {npx} como proxy: debes tener Node 18+ instalado y {npx} accesible desde el PATH de Claude Desktop. Si falla con {commandNotFound}, sustituye {npxQuoted} por la ruta absoluta que devuelva {whichNpx}.",
+    "claudeCodeDescription": "<label>Claude Code (CLI):</label> habla HTTP directamente — no necesita proxy.",
+    "claudeWebDescription": "<label>claude.ai web (Connectors):</label> no es compatible con un FiestaBoard autoalojado. El flujo de Connectors requiere una URL HTTPS pública y registro dinámico de clientes OAuth 2.1, y un host en la LAN no puede ofrecer ninguna de las dos cosas. Usa Desktop o Code en su lugar.",
+    "savedItButton": "Ya lo he guardado",
+    "toastTokenRevoked": "Token MCP revocado",
+    "toastCopyFailed": "No se pudo copiar al portapapeles"
   }
 }

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -50,7 +50,8 @@
     "pageCount": "{count, plural, one {# page} other {# pages}}",
     "unknownError": "Erreur inconnue",
     "opensInNewTab": "(ouvre dans un nouvel onglet)",
-    "notificationsRegionLabel": "Notifications"
+    "notificationsRegionLabel": "Notifications",
+    "versionShort": "v{version}"
   },
   "metadata": {
     "appTitle": "Panneau FiestaBoard",
@@ -81,7 +82,8 @@
     "boardSelector": "Sélectionner le tableau à gérer",
     "selectBoard": "Sélectionner un tableau",
     "unnamedBoard": "Tableau sans nom",
-    "transitions": "Labo des transitions"
+    "transitions": "Labo des transitions",
+    "prideCelebration": "Joyeuses Fiertés !"
   },
   "network": {
     "title": "Wi-Fi",
@@ -330,7 +332,11 @@
       "validationOneOffDateRequired": "Please pick a date",
       "validationEndDateBeforeStart": "End date must be on or after start date",
       "collectionSizeWarning": "{count} des {total} pages de cette collection ne correspondent pas à la taille de ce tableau et seront ignorées.",
-      "incompatiblePageWarning": "Cette page ne correspond pas à la taille de ce tableau et pourrait ne pas s'afficher correctement."
+      "incompatiblePageWarning": "Cette page ne correspond pas à la taille de ce tableau et pourrait ne pas s'afficher correctement.",
+      "monthAriaLabel": "Mois",
+      "dayAriaLabel": "Jour",
+      "endMonthAriaLabel": "Mois de fin",
+      "endDayAriaLabel": "Jour de fin"
     },
     "descriptionWithTimezone": "Automatisez la rotation des pages par heure et jour · {timezone}",
     "gapDefaultPlaceholder": "Page par défaut…",
@@ -472,7 +478,37 @@
     "toastNoUpdates": "Tous les plugins sont à jour",
     "toastCheckFailed": "Impossible de rechercher des mises à jour : {error}",
     "installAction": "Installer",
-    "installedBadge": "Installé"
+    "installedBadge": "Installé",
+    "valueUnavailable": "Indisponible",
+    "enablePluginForLiveValues": "Activez le plugin pour voir les valeurs en direct.",
+    "liveValuesUnavailable": "Les valeurs en direct sont indisponibles.",
+    "liveValuesUnavailableWithError": "Les valeurs en direct sont indisponibles : {error}",
+    "currentValueColumn": "Valeur actuelle",
+    "refreshingValues": "actualisation…",
+    "sourceCoreBadge": "Natif",
+    "sourceMarketplaceBadge": "Marché",
+    "sourceExternalBadge": "Externe",
+    "updateAvailableBadge": "Mise à jour",
+    "moreOptionsAriaLabel": "Plus d'options",
+    "addInstanceAction": "Ajouter une instance",
+    "instanceNameInlineLabel": "Nom de l'instance :",
+    "addInstanceInlineHelp": "Crée une nouvelle instance indépendante de ce plugin avec sa propre configuration. Utilisez des caractères alphanumériques, des tirets ou des soulignements (1 à 40 caractères).",
+    "deleteInstanceConfirmTitle": "Supprimer l'instance « {label} » ?",
+    "deletePluginConfirmTitle": "Supprimer « {name} » ?",
+    "deleteInstanceConfirmDescription": "Cela supprimera définitivement cette instance et sa configuration. Cette action est irréversible.",
+    "deletePluginConfirmDescription": "Cela supprimera définitivement le plugin et toutes ses instances. Cette action est irréversible.",
+    "demoPage": {
+      "title": "Page de démonstration",
+      "alreadyExists": "Une page de démonstration existe déjà pour ce plugin.",
+      "createDescription": "Créez une page prête à l'emploi qui met en valeur ce plugin.",
+      "recreateButton": "Recréer",
+      "recreateConfirmTitle": "Recréer la page de démonstration ?",
+      "recreateConfirmDescription": "Cela supprimera la page de démonstration existante et en créera une nouvelle avec les paramètres par défaut. Cette action est irréversible.",
+      "creating": "Création...",
+      "createAction": "Créer une page de démonstration",
+      "recreateAction": "Recréer la page de démonstration",
+      "requirementsWarning": "Configurez les paramètres obligatoires ci-dessous avant de créer une page de démonstration."
+    }
   },
   "settings": {
     "title": "Paramètres",
@@ -496,7 +532,43 @@
     "sectionAccount": "Compte",
     "sectionAccountDescription": "Nom d'utilisateur, mot de passe et déconnexion",
     "sectionNetwork": "Réseau",
-    "sectionNetworkDescription": "Gérer le Wi-Fi et la connectivité"
+    "sectionNetworkDescription": "Gérer le Wi-Fi et la connectivité",
+    "ai": {
+      "removeProviderAriaLabel": "Supprimer le fournisseur",
+      "cardTitle": "Fournisseurs IA",
+      "cardDescription": "Configurez des LLM compatibles OpenAI pour le générateur de pages « Gen AI ». Apportez votre propre LLM : FiestaBoard n'inclut jamais de clé.",
+      "privacyNotice": "Vos requêtes et la liste des variables de vos plugins activés sont envoyées directement au fournisseur que vous configurez. Les clés API sont stockées sur cet appareil et ne sont envoyées nulle part ailleurs.",
+      "emptyState": "Aucun fournisseur configuré pour l'instant.",
+      "addProviderButton": "Ajouter un fournisseur",
+      "discardButton": "Abandonner",
+      "saveChangesButton": "Enregistrer les modifications",
+      "defaultBadge": "Par défaut",
+      "anthropicBadge": "Anthropic",
+      "makeDefaultButton": "Définir par défaut",
+      "nameLabel": "Nom",
+      "protocolLabel": "Protocole",
+      "protocolOpenaiOption": "Compatible OpenAI (OpenAI, OpenRouter, Groq, DeepSeek, Mistral, Together, Fireworks, Ollama, LM Studio, vLLM, …)",
+      "protocolAnthropicOption": "Anthropic (API Messages)",
+      "baseUrlLabel": "URL de base",
+      "quickPresetsLabel": "Préréglages rapides",
+      "apiKeyLabel": "Clé API",
+      "modelsLabel": "Modèles",
+      "defaultModelLabel": "Modèle par défaut",
+      "testConnectionButton": "Tester la connexion"
+    },
+    "backup": {
+      "cardTitle": "Sauvegarde et restauration",
+      "cardDescription": "Exportez toute la configuration de votre FiestaBoard — paramètres du tableau, pages, carrousels, planifications et configuration des plugins — dans un seul fichier JSON. Téléversez à nouveau ce fichier sur une nouvelle instance pour migrer ou récupérer vos données après une mise à jour.",
+      "exportButton": "Exporter la sauvegarde",
+      "importButton": "Importer une sauvegarde…",
+      "reinstallPluginsLabel": "Réinstaller les plugins externes après l'import",
+      "reinstallPluginsDescription": "Lorsque cette option est activée, FiestaBoard tentera de cloner les plugins externes enregistrés dans la sauvegarde qui ne sont pas encore installés sur cette instance. Leur configuration est restaurée depuis la sauvegarde dans tous les cas.",
+      "sensitiveNote": "Remarque : les sauvegardes contiennent des valeurs sensibles, comme les clés API et les identifiants du tableau, en clair. Conservez le fichier en lieu sûr et ne le partagez pas publiquement.",
+      "confirmTitle": "Remplacer la configuration actuelle ?",
+      "confirmDescription": "Vous êtes sur le point de restaurer <file></file>. Vos pages, carrousels, planifications et configuration actuels seront écrasés. Une copie horodatée de chaque fichier existant est conservée à côté du nouveau, pour pouvoir revenir en arrière manuellement si nécessaire.",
+      "restoringButton": "Restauration…",
+      "restoreButton": "Restaurer la sauvegarde"
+    }
   },
   "offline": {
     "youreOffline": "Vous êtes hors ligne",
@@ -581,7 +653,10 @@
       "passwordPlaceholder": "VotreMotDePasse",
       "wifiPreview": "WIFI : {ssid}",
       "passPreview": "MDP : {password}",
-      "noPassword": "(pas de mot de passe)"
+      "noPassword": "(pas de mot de passe)",
+      "addMoreHint": "Vous pouvez en ajouter d'autres depuis la page <link>Intégrations</link> à tout moment.",
+      "builtInBadge": "Intégré",
+      "previewLabel": "Aperçu :"
     },
     "welcome": {
       "setupComplete": "Configuration terminée !",
@@ -639,7 +714,9 @@
     "changeModeDisableTitle": "Désactiver le mode planning",
     "changeModeDisableDescription": "Désactivez le planning et contrôlez le board manuellement.",
     "changeModeDisableSuccess": "Mode planning désactivé",
-    "collectionSizeWarning": "{count} des {total} pages de cette collection ne correspondent pas à la taille de ce tableau et seront ignorées."
+    "collectionSizeWarning": "{count} des {total} pages de cette collection ne correspondent pas à la taille de ce tableau et seront ignorées.",
+    "turnOffLiveModeAriaLabel": "Désactiver le mode direct",
+    "liveModeBadge": "Mode direct"
   },
   "forceSetDialog": {
     "title": "Forcer l'affichage",
@@ -882,7 +959,10 @@
     "updateNow": "Mettre à jour maintenant",
     "oneClickHint": "Vous voulez un bouton « Mettre à jour maintenant » en un clic ici ? Définissez <profile></profile> dans votre <envFile></envFile>, puis exécutez <command></command>.",
     "dialogTitle": "Mettre à jour FiestaBoard ?",
-    "dialogDescription": "Cela téléchargera <version></version> et redémarrera FiestaBoard. L'affichage du tableau s'interrompra pendant environ 30 secondes et cette page se rechargera automatiquement."
+    "dialogDescription": "Cela téléchargera <version></version> et redémarrera FiestaBoard. L'affichage du tableau s'interrompra pendant environ 30 secondes et cette page se rechargera automatiquement.",
+    "intervalSelectAriaLabel": "Fréquence de vérification des mises à jour",
+    "intervalCardDescription": "À quelle fréquence FiestaBoard doit rechercher une nouvelle version en arrière-plan. Une bannière s'affichera ici lorsqu'une version sera trouvée.",
+    "lastChecked": "Dernière vérification : {time}"
   },
   "transitionSettings": {
     "title": "Transitions du tableau",
@@ -1008,7 +1088,8 @@
       "Numbers": "Chiffres",
       "Symbols": "Symboles",
       "Colors": "Couleurs"
-    }
+    },
+    "latencyMs": "{ms} ms"
   },
   "generalSettings": {
     "title": "Paramètres généraux",
@@ -1375,7 +1456,8 @@
     "flapSpeed_relaxedHint": "{ms} ms — un basculement lent et posé pour les affichages d'ambiance.",
     "flapSpeedPreviewLabel": "Aperçu",
     "flapSpeedInactive": "Les animations du board sont désactivées : la vitesse de basculement n'a aucun effet.",
-    "flapSpeedScreenOnlyNote": "Cela ne modifie que l'aperçu du board à l'écran. La cadence des transitions de votre Vestaboard physique se règle séparément, dans Comportement → Transitions du board."
+    "flapSpeedScreenOnlyNote": "Cela ne modifie que l'aperçu du board à l'écran. La cadence des transitions de votre Vestaboard physique se règle séparément, dans Comportement → Transitions du board.",
+    "updateAvailableBadge": "v{version} disponible"
   },
   "monitor": {
     "title": "Moniteur",
@@ -1647,7 +1729,8 @@
     "whiteBoard": "Tableau blanc",
     "deviceFlagship": "Flagship",
     "deviceNote": "Note",
-    "deviceNoteArray": "Matrice Note {w}×{h}"
+    "deviceNoteArray": "Matrice Note {w}×{h}",
+    "githubLink": "GitHub"
   },
   "boardDisplay": {
     "loading": "Chargement de l'affichage du tableau",
@@ -1736,7 +1819,12 @@
     "remoteOptionsSearchPlaceholder": "Rechercher…",
     "remoteOptionsCustomLabel": "Valeur personnalisée",
     "remoteOptionsCustomPlaceholder": "Saisissez une valeur absente de la liste",
-    "remoteOptionsCustomAdd": "Ajouter une valeur personnalisée"
+    "remoteOptionsCustomAdd": "Ajouter une valeur personnalisée",
+    "addItemLabel": "Ajouter {label}",
+    "unknownType": "Type inconnu : {type}",
+    "pagePickerNone": "Aucune (pas de remplacement)",
+    "pagePickerLoading": "Chargement des pages…",
+    "pagePickerPlaceholder": "Choisissez une page…"
   },
   "filterPicker": {
     "noFiltersAvailable": "Aucun filtre disponible",
@@ -1744,7 +1832,8 @@
     "filterDescWrap": "Répartit le texte long sur plusieurs lignes",
     "filterDescPad": "Remplit le texte à la largeur spécifiée",
     "filterDescTruncate": "Tronque le texte à la longueur spécifiée",
-    "wrapInstruction": "|wrap : Répartit le texte long. Laissez des lignes vides en dessous pour que le texte puisse s'y écouler."
+    "wrapInstruction": "Répartit le texte long. Laissez des lignes vides en dessous pour que le texte puisse s'y écouler.",
+    "exampleLabel": "Exemple : {example}"
   },
   "formattingPicker": {
     "noFormattingAvailable": "Aucune option de formatage disponible",
@@ -1805,7 +1894,25 @@
     "alignRight": "Aligner à droite",
     "syncFromBoardTooltip": "Remplir le modèle à partir de ce qui est actuellement affiché sur le board",
     "syncFromBoard": "Synchroniser depuis l'affichage actuel du board",
-    "alignment": "Alignement :"
+    "alignment": "Alignement :",
+    "undoAriaLabel": "Annuler",
+    "redoAriaLabel": "Rétablir",
+    "cutAriaLabel": "Couper",
+    "copyAriaLabel": "Copier",
+    "pasteAriaLabel": "Coller",
+    "removeWrappedTextAriaLabel": "Supprimer le texte reporté à la ligne",
+    "colorPickerAriaLabel": "Sélecteur de couleur",
+    "heartCharacterAriaLabel": "Caractère cœur",
+    "lineCount": "{used} / {max} lignes",
+    "overLineLimit": " — dépasse la limite de {max} lignes du tableau",
+    "currentLine": "(Ligne {line})",
+    "heartLabel": "cœur",
+    "insertHeartTooltip": "Insérer le caractère cœur (Note uniquement)",
+    "colorTileTooltip": "Tuile {color} (code {code}) - faites glisser pour déplacer, retour arrière pour supprimer",
+    "fillSpaceTooltip": "Espace de remplissage - s'étend pour occuper la largeur restante de la ligne",
+    "fillSpaceRepeatTooltip": "Remplissage en répétant : {char}",
+    "variableFilterTooltip": "Filtre : {filter}",
+    "variableMaxLengthTooltip": "Longueur maximale : {maxLength} caractères"
   },
   "variablePicker": {
     "noVariablesAvailable": "Aucune variable disponible",
@@ -1815,7 +1922,8 @@
     "searchPlaceholder": "Rechercher des variables…",
     "indexLabel": "Index : {index}",
     "configureHint": "Configurez {arrayName} dans les paramètres pour voir ici les variables indexées.",
-    "configureExample": "Exemple :"
+    "configureExample": "Exemple :",
+    "noMatchingVariables": "Aucune variable correspondante trouvée."
   },
   "login": {
     "signInTitle": "Se connecter à FiestaBoard",
@@ -1873,11 +1981,62 @@
     "taskStatusAriaLabel": "Progression des tâches",
     "taskProgressAriaLabel": "Progression des tâches IA",
     "clearConversationAriaLabel": "Effacer la conversation",
-    "closePanelAriaLabel": "Fermer FiestaBot (Beta)"
+    "closePanelAriaLabel": "Fermer FiestaBot (Beta)",
+    "providerSelectAriaLabel": "Fournisseur",
+    "modelSelectAriaLabel": "Modèle",
+    "showBoardTooltip": "Afficher l'aperçu du tableau",
+    "hideBoardTooltip": "Masquer l'aperçu du tableau",
+    "undoTooltip": "Annuler la dernière modification de l'IA",
+    "panelTitle": "FiestaBot (Beta)",
+    "retryButton": "Réessayer",
+    "messageLabel": "Message",
+    "stopButton": "Arrêter",
+    "sendButton": "Envoyer",
+    "tasksHeading": "Tâches ({done}/{total})",
+    "emptyStateTitle": "Comment puis-je vous aider ?",
+    "emptyStateDescription": "Décrivez ce que vous souhaitez créer ou modifier.",
+    "showBoardButton": "Afficher le tableau",
+    "undoButton": "Annuler",
+    "renameSummary": "→ renommer en \"{name}\"",
+    "previewUnavailable": "(aperçu indisponible)"
   },
   "boardSizeIndicator": {
     "custom": "Personnalisé",
     "ariaLabel": "{rows} lignes par {cols} colonnes",
     "ariaLabelWithLayout": "{rows} lignes par {cols} colonnes, {layout}"
+  },
+  "mcpSettings": {
+    "title": "MCP / clients externes",
+    "description": "Un jeton pré-partagé qui permet à Claude Desktop, Claude Code et aux autres clients MCP de communiquer avec ce FiestaBoard. Le jeton s'authentifie comme un unique principal — limité au seul point de terminaison {endpoint} — et ne peut donc pas modifier les pages ni les autres paramètres. Consultez <link>Configuration des clients MCP</link> pour les particularités de chaque client (Desktop nécessite un proxy stdio ; les Connectors de claude.ai web exigent HTTPS public et OAuth, ils n'atteindront donc pas un hôte du LAN).",
+    "statusLabel": "Statut :",
+    "pinnedByEnvBadge": "Défini par {envVar}",
+    "configuredBadge": "Configuré",
+    "pinnedByEnvDescription": "Le jeton actif est défini par la variable d'environnement {envVar}. Supprimez-la de votre {envFile} et redémarrez le conteneur avant de gérer le jeton depuis cette interface.",
+    "noTokenDescription": "Aucun jeton n'est configuré. Les clients MCP externes se rabattront sur l'authentification par cookie, que Claude Desktop / Claude Code ne prennent pas en charge — leur enregistrement échouera avec une erreur obscure. Générez un jeton pour les débloquer.",
+    "activeTokenDescription": "Un jeton est configuré et actif. Renouvelez-le pour invalider le précédent (tout client utilisant encore l'ancien jeton recevra des 401), ou révoquez-le entièrement pour revenir à l'authentification par cookie uniquement.",
+    "rotateTokenButton": "Renouveler le jeton",
+    "generateTokenButton": "Générer un jeton",
+    "revokeTokenButton": "Révoquer le jeton",
+    "rotateConfirmTitle": "Renouveler le jeton MCP ?",
+    "generateConfirmTitle": "Générer un jeton MCP ?",
+    "rotateConfirmDescription": "Tout client utilisant encore le jeton précédent se verra refuser sa prochaine requête avec un 401 + défi Bearer. Vous ne verrez le nouveau jeton qu'une seule fois — conservez-le en lieu sûr (il n'est plus lisible depuis l'interface).",
+    "generateConfirmDescription": "Vous ne verrez le jeton qu'une seule fois — conservez-le en lieu sûr (il n'est plus lisible depuis l'interface). Les clients MCP externes l'utiliseront pour s'authentifier auprès de {endpoint}.",
+    "rotateConfirmButton": "Renouveler",
+    "generateConfirmButton": "Générer",
+    "revokeConfirmTitle": "Révoquer le jeton MCP ?",
+    "revokeConfirmDescription": "Les clients MCP externes recevront un 401 dès leur prochaine requête. Vous pourrez toujours générer un nouveau jeton plus tard.",
+    "revokeConfirmButton": "Révoquer",
+    "revealTitle": "Conservez ce jeton",
+    "revealDescription": "FiestaBoard ne conserve que ce qui est nécessaire pour vérifier les requêtes futures — c'est la seule fois où la valeur en clair est affichée. Copiez-la dès maintenant dans votre client MCP.",
+    "tokenLabel": "Jeton",
+    "copyButton": "Copier",
+    "copiedButton": "Copié",
+    "configSnippetLabel": "Extrait de configuration Claude Desktop",
+    "configSnippetDescription": "Collez ceci dans {configPath}, en fusionnant avec ce qui s'y trouve déjà, puis quittez complètement et relancez Claude Desktop (⌘Q — fermer la fenêtre ne suffit pas). Claude Desktop ne prend en charge que les serveurs MCP en stdio ; cet extrait lance donc {mcpRemoteLink} via {npx} comme proxy — Node 18+ doit être installé et {npx} accessible depuis le PATH de Claude Desktop. En cas d'erreur {commandNotFound}, remplacez {npxQuoted} par le chemin absolu renvoyé par {whichNpx}.",
+    "claudeCodeDescription": "<label>Claude Code (CLI) :</label> communique directement en HTTP — aucun proxy nécessaire.",
+    "claudeWebDescription": "<label>claude.ai web (Connectors) :</label> non pris en charge pour un FiestaBoard auto-hébergé. Le flux Connectors exige une URL HTTPS publique et l'enregistrement dynamique de clients OAuth 2.1, or un hôte du LAN ne peut fournir ni l'un ni l'autre. Utilisez plutôt Desktop ou Code.",
+    "savedItButton": "Je l'ai enregistré",
+    "toastTokenRevoked": "Jeton MCP révoqué",
+    "toastCopyFailed": "Impossible de copier dans le presse-papiers"
   }
 }

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -50,7 +50,8 @@
     "pageCount": "{count, plural, one {# pagina} other {# pagine}}",
     "unknownError": "Errore sconosciuto",
     "opensInNewTab": "(si apre in una nuova scheda)",
-    "notificationsRegionLabel": "Notifiche"
+    "notificationsRegionLabel": "Notifiche",
+    "versionShort": "v{version}"
   },
   "metadata": {
     "appTitle": "Pannello FiestaBoard",
@@ -81,7 +82,8 @@
     "boardSelector": "Seleziona la bacheca da gestire",
     "selectBoard": "Seleziona bacheca",
     "unnamedBoard": "Bacheca senza nome",
-    "transitions": "Laboratorio transizioni"
+    "transitions": "Laboratorio transizioni",
+    "prideCelebration": "Buon Orgoglio!"
   },
   "network": {
     "title": "Wi-Fi",
@@ -330,7 +332,11 @@
       "validationOneOffDateRequired": "Please pick a date",
       "validationEndDateBeforeStart": "End date must be on or after start date",
       "collectionSizeWarning": "{count} pagine su {total} in questa raccolta non corrispondono alle dimensioni di questa board e verranno saltate.",
-      "incompatiblePageWarning": "Questa pagina non corrisponde alle dimensioni di questa board e potrebbe non essere visualizzata correttamente."
+      "incompatiblePageWarning": "Questa pagina non corrisponde alle dimensioni di questa board e potrebbe non essere visualizzata correttamente.",
+      "monthAriaLabel": "Mese",
+      "dayAriaLabel": "Giorno",
+      "endMonthAriaLabel": "Mese di fine",
+      "endDayAriaLabel": "Giorno di fine"
     },
     "descriptionWithTimezone": "Automatizza la rotazione delle pagine per ora e giorno · {timezone}",
     "gapDefaultPlaceholder": "Predefinita per intervalli…",
@@ -472,7 +478,37 @@
     "toastNoUpdates": "Tutti i plugin sono aggiornati",
     "toastCheckFailed": "Ricerca aggiornamenti non riuscita: {error}",
     "installAction": "Installa",
-    "installedBadge": "Installato"
+    "installedBadge": "Installato",
+    "valueUnavailable": "Non disponibile",
+    "enablePluginForLiveValues": "Attiva il plugin per vedere i valori in tempo reale.",
+    "liveValuesUnavailable": "I valori in tempo reale non sono disponibili.",
+    "liveValuesUnavailableWithError": "I valori in tempo reale non sono disponibili: {error}",
+    "currentValueColumn": "Valore attuale",
+    "refreshingValues": "aggiornamento…",
+    "sourceCoreBadge": "Nativo",
+    "sourceMarketplaceBadge": "Marketplace",
+    "sourceExternalBadge": "Esterno",
+    "updateAvailableBadge": "Aggiornamento",
+    "moreOptionsAriaLabel": "Altre opzioni",
+    "addInstanceAction": "Aggiungi istanza",
+    "instanceNameInlineLabel": "Nome dell'istanza:",
+    "addInstanceInlineHelp": "Crea una nuova istanza indipendente di questo plugin con la propria configurazione. Usa caratteri alfanumerici, trattini o underscore (1-40 caratteri).",
+    "deleteInstanceConfirmTitle": "Eliminare l'istanza «{label}»?",
+    "deletePluginConfirmTitle": "Eliminare «{name}»?",
+    "deleteInstanceConfirmDescription": "Questa operazione rimuoverà definitivamente questa istanza e la sua configurazione. Questa azione non può essere annullata.",
+    "deletePluginConfirmDescription": "Questa operazione rimuoverà definitivamente il plugin e tutte le sue istanze. Questa azione non può essere annullata.",
+    "demoPage": {
+      "title": "Pagina dimostrativa",
+      "alreadyExists": "Esiste già una pagina dimostrativa per questo plugin.",
+      "createDescription": "Crea una pagina pronta all'uso che mostra questo plugin.",
+      "recreateButton": "Ricrea",
+      "recreateConfirmTitle": "Ricreare la pagina dimostrativa?",
+      "recreateConfirmDescription": "Questa operazione eliminerà la pagina dimostrativa esistente e ne creerà una nuova con le impostazioni predefinite. Questa azione non può essere annullata.",
+      "creating": "Creazione...",
+      "createAction": "Crea pagina dimostrativa",
+      "recreateAction": "Ricrea pagina dimostrativa",
+      "requirementsWarning": "Configura le impostazioni obbligatorie qui sotto prima di creare una pagina dimostrativa."
+    }
   },
   "settings": {
     "title": "Impostazioni",
@@ -496,7 +532,43 @@
     "sectionAccount": "Account",
     "sectionAccountDescription": "Nome utente, password e disconnessione",
     "sectionNetwork": "Rete",
-    "sectionNetworkDescription": "Gestisci Wi-Fi e connettività"
+    "sectionNetworkDescription": "Gestisci Wi-Fi e connettività",
+    "ai": {
+      "removeProviderAriaLabel": "Rimuovi fornitore",
+      "cardTitle": "Fornitori IA",
+      "cardDescription": "Configura LLM compatibili con OpenAI per il generatore di pagine «Gen AI». Porta il tuo LLM: FiestaBoard non include mai una chiave.",
+      "privacyNotice": "I tuoi prompt e l'elenco delle variabili dei plugin attivati vengono inviati direttamente al fornitore che configuri. Le chiavi API sono memorizzate su questo dispositivo e non vengono inviate altrove.",
+      "emptyState": "Nessun fornitore ancora configurato.",
+      "addProviderButton": "Aggiungi fornitore",
+      "discardButton": "Scarta",
+      "saveChangesButton": "Salva modifiche",
+      "defaultBadge": "Predefinito",
+      "anthropicBadge": "Anthropic",
+      "makeDefaultButton": "Imposta come predefinito",
+      "nameLabel": "Nome",
+      "protocolLabel": "Protocollo",
+      "protocolOpenaiOption": "Compatibile con OpenAI (OpenAI, OpenRouter, Groq, DeepSeek, Mistral, Together, Fireworks, Ollama, LM Studio, vLLM, …)",
+      "protocolAnthropicOption": "Anthropic (API Messages)",
+      "baseUrlLabel": "URL di base",
+      "quickPresetsLabel": "Preimpostazioni rapide",
+      "apiKeyLabel": "Chiave API",
+      "modelsLabel": "Modelli",
+      "defaultModelLabel": "Modello predefinito",
+      "testConnectionButton": "Prova connessione"
+    },
+    "backup": {
+      "cardTitle": "Backup e ripristino",
+      "cardDescription": "Esporta tutta la configurazione del tuo FiestaBoard — impostazioni della bacheca, pagine, caroselli, programmazioni e configurazione dei plugin — in un unico file JSON. Ricarica quel file su una nuova istanza per migrare o ripristinare i dati dopo un aggiornamento.",
+      "exportButton": "Esporta backup",
+      "importButton": "Importa backup…",
+      "reinstallPluginsLabel": "Reinstalla i plugin esterni dopo l'importazione",
+      "reinstallPluginsDescription": "Se attivato, FiestaBoard proverà a clonare i plugin esterni registrati nel backup che non sono ancora installati su questa istanza. La loro configurazione viene comunque ripristinata dal backup.",
+      "sensitiveNote": "Nota: i backup contengono valori sensibili, come chiavi API e credenziali della bacheca, in chiaro. Conserva il file in modo sicuro e non condividerlo pubblicamente.",
+      "confirmTitle": "Sostituire la configurazione attuale?",
+      "confirmDescription": "Stai per ripristinare <file></file>. Le tue pagine, i caroselli, le programmazioni e la configurazione attuali verranno sovrascritti. Una copia con marca temporale di ogni file esistente viene conservata accanto a quello nuovo, così puoi tornare indietro manualmente se necessario.",
+      "restoringButton": "Ripristino…",
+      "restoreButton": "Ripristina backup"
+    }
   },
   "offline": {
     "youreOffline": "Sei offline",
@@ -581,7 +653,10 @@
       "passwordPlaceholder": "LaTuaPassword",
       "wifiPreview": "WIFI: {ssid}",
       "passPreview": "PASS: {password}",
-      "noPassword": "(nessuna password)"
+      "noPassword": "(nessuna password)",
+      "addMoreHint": "Puoi aggiungerne altri dalla pagina <link>Integrazioni</link> in qualsiasi momento.",
+      "builtInBadge": "Integrato",
+      "previewLabel": "Anteprima:"
     },
     "welcome": {
       "setupComplete": "Configurazione completata!",
@@ -639,7 +714,9 @@
     "changeModeDisableTitle": "Disattiva modalità pianificazione",
     "changeModeDisableDescription": "Disattiva la pianificazione e controlla il board manualmente.",
     "changeModeDisableSuccess": "Modalità pianificazione disattivata",
-    "collectionSizeWarning": "{count} pagine su {total} in questa raccolta non corrispondono alle dimensioni di questa board e verranno saltate."
+    "collectionSizeWarning": "{count} pagine su {total} in questa raccolta non corrispondono alle dimensioni di questa board e verranno saltate.",
+    "turnOffLiveModeAriaLabel": "Disattiva la modalità dal vivo",
+    "liveModeBadge": "Modalità dal vivo"
   },
   "forceSetDialog": {
     "title": "Forza impostazione board",
@@ -882,7 +959,10 @@
     "updateNow": "Aggiorna ora",
     "oneClickHint": "Vuoi un pulsante «Aggiorna ora» a un clic qui? Imposta <profile></profile> nel tuo <envFile></envFile>, poi esegui <command></command>.",
     "dialogTitle": "Aggiornare FiestaBoard?",
-    "dialogDescription": "Verrà scaricata <version></version> e FiestaBoard verrà riavviato. Il display del board si fermerà per circa 30 secondi e questa pagina verrà ricaricata automaticamente."
+    "dialogDescription": "Verrà scaricata <version></version> e FiestaBoard verrà riavviato. Il display del board si fermerà per circa 30 secondi e questa pagina verrà ricaricata automaticamente.",
+    "intervalSelectAriaLabel": "Frequenza di controllo aggiornamenti",
+    "intervalCardDescription": "Con quale frequenza FiestaBoard deve cercare una nuova release in background. Quando ne trova una, qui comparirà un banner.",
+    "lastChecked": "Ultimo controllo: {time}"
   },
   "transitionSettings": {
     "title": "Transizioni della bacheca",
@@ -1008,7 +1088,8 @@
       "Numbers": "Numeri",
       "Symbols": "Simboli",
       "Colors": "Colori"
-    }
+    },
+    "latencyMs": "{ms} ms"
   },
   "generalSettings": {
     "title": "Impostazioni generali",
@@ -1375,7 +1456,8 @@
     "flapSpeed_relaxedHint": "{ms} ms — un ribaltamento lento e deliberato per display d'ambiente.",
     "flapSpeedPreviewLabel": "Anteprima",
     "flapSpeedInactive": "Le animazioni del board sono disattivate, quindi la velocità di ribaltamento non ha effetto.",
-    "flapSpeedScreenOnlyNote": "Questo cambia solo l'anteprima del board a schermo. Il ritmo delle transizioni del tuo Vestaboard fisico si imposta separatamente, in Comportamento → Transizioni del board."
+    "flapSpeedScreenOnlyNote": "Questo cambia solo l'anteprima del board a schermo. Il ritmo delle transizioni del tuo Vestaboard fisico si imposta separatamente, in Comportamento → Transizioni del board.",
+    "updateAvailableBadge": "v{version} disponibile"
   },
   "monitor": {
     "title": "Monitor",
@@ -1647,7 +1729,8 @@
     "whiteBoard": "Tabellone bianco",
     "deviceFlagship": "Flagship",
     "deviceNote": "Note",
-    "deviceNoteArray": "Matrice Note {w}×{h}"
+    "deviceNoteArray": "Matrice Note {w}×{h}",
+    "githubLink": "GitHub"
   },
   "boardDisplay": {
     "loading": "Caricamento display board",
@@ -1736,7 +1819,12 @@
     "remoteOptionsSearchPlaceholder": "Cerca…",
     "remoteOptionsCustomLabel": "Valore personalizzato",
     "remoteOptionsCustomPlaceholder": "Inserisci un valore non presente nell'elenco",
-    "remoteOptionsCustomAdd": "Aggiungi valore personalizzato"
+    "remoteOptionsCustomAdd": "Aggiungi valore personalizzato",
+    "addItemLabel": "Aggiungi {label}",
+    "unknownType": "Tipo sconosciuto: {type}",
+    "pagePickerNone": "Nessuna (nessuna sostituzione)",
+    "pagePickerLoading": "Caricamento pagine…",
+    "pagePickerPlaceholder": "Scegli una pagina…"
   },
   "filterPicker": {
     "noFiltersAvailable": "Nessun filtro disponibile",
@@ -1744,7 +1832,8 @@
     "filterDescWrap": "Manda a capo il testo lungo su più righe",
     "filterDescPad": "Riempie il testo alla larghezza specificata",
     "filterDescTruncate": "Tronca il testo alla lunghezza specificata",
-    "wrapInstruction": "|wrap: manda a capo il testo lungo. Lascia righe vuote sotto perché il testo possa fluire."
+    "wrapInstruction": "manda a capo il testo lungo. Lascia righe vuote sotto perché il testo possa fluire.",
+    "exampleLabel": "Esempio: {example}"
   },
   "formattingPicker": {
     "noFormattingAvailable": "Nessuna opzione di formattazione disponibile",
@@ -1805,7 +1894,25 @@
     "alignRight": "Allinea a destra",
     "syncFromBoardTooltip": "Riempi il modello da ciò che è attualmente mostrato sul board",
     "syncFromBoard": "Sincronizza dal display attuale del board",
-    "alignment": "Allineamento:"
+    "alignment": "Allineamento:",
+    "undoAriaLabel": "Annulla",
+    "redoAriaLabel": "Ripristina",
+    "cutAriaLabel": "Taglia",
+    "copyAriaLabel": "Copia",
+    "pasteAriaLabel": "Incolla",
+    "removeWrappedTextAriaLabel": "Rimuovi il testo mandato a capo",
+    "colorPickerAriaLabel": "Selettore colore",
+    "heartCharacterAriaLabel": "Carattere cuore",
+    "lineCount": "{used} / {max} righe",
+    "overLineLimit": " — supera il limite di {max} righe della bacheca",
+    "currentLine": "(Riga {line})",
+    "heartLabel": "cuore",
+    "insertHeartTooltip": "Inserisci il carattere cuore (solo Note)",
+    "colorTileTooltip": "Riquadro {color} (codice {code}) - trascina per spostare, backspace per eliminare",
+    "fillSpaceTooltip": "Spazio di riempimento - si espande per occupare la larghezza rimanente della riga",
+    "fillSpaceRepeatTooltip": "Riempimento ripetendo: {char}",
+    "variableFilterTooltip": "Filtro: {filter}",
+    "variableMaxLengthTooltip": "Lunghezza massima: {maxLength} caratteri"
   },
   "variablePicker": {
     "noVariablesAvailable": "Nessuna variabile disponibile",
@@ -1815,7 +1922,8 @@
     "searchPlaceholder": "Cerca variabili...",
     "indexLabel": "Indice: {index}",
     "configureHint": "Configura {arrayName} in Impostazioni per vedere qui le variabili indicizzate.",
-    "configureExample": "Esempio:"
+    "configureExample": "Esempio:",
+    "noMatchingVariables": "Nessuna variabile corrispondente trovata."
   },
   "login": {
     "signInTitle": "Accedi a FiestaBoard",
@@ -1873,11 +1981,62 @@
     "taskStatusAriaLabel": "Avanzamento delle attività",
     "taskProgressAriaLabel": "Avanzamento attività IA",
     "clearConversationAriaLabel": "Cancella conversazione",
-    "closePanelAriaLabel": "Chiudi FiestaBot (Beta)"
+    "closePanelAriaLabel": "Chiudi FiestaBot (Beta)",
+    "providerSelectAriaLabel": "Fornitore",
+    "modelSelectAriaLabel": "Modello",
+    "showBoardTooltip": "Mostra l'anteprima del board",
+    "hideBoardTooltip": "Nascondi l'anteprima del board",
+    "undoTooltip": "Annulla l'ultima modifica dell'IA",
+    "panelTitle": "FiestaBot (Beta)",
+    "retryButton": "Riprova",
+    "messageLabel": "Messaggio",
+    "stopButton": "Interrompi",
+    "sendButton": "Invia",
+    "tasksHeading": "Attività ({done}/{total})",
+    "emptyStateTitle": "Come posso aiutarti?",
+    "emptyStateDescription": "Descrivi cosa vuoi creare o modificare.",
+    "showBoardButton": "Mostra board",
+    "undoButton": "Annulla",
+    "renameSummary": "→ rinomina in \"{name}\"",
+    "previewUnavailable": "(anteprima non disponibile)"
   },
   "boardSizeIndicator": {
     "custom": "Personalizzato",
     "ariaLabel": "{rows} righe per {cols} colonne",
     "ariaLabelWithLayout": "{rows} righe per {cols} colonne, {layout}"
+  },
+  "mcpSettings": {
+    "title": "MCP / client esterni",
+    "description": "Un token precondiviso che consente a Claude Desktop, Claude Code e ad altri client MCP di comunicare con questo FiestaBoard. Il token si autentica come un unico principal — limitato al solo endpoint {endpoint} — quindi non può modificare pagine o altre impostazioni. Consulta <link>Configurazione dei client MCP</link> per le particolarità dei singoli client (Desktop richiede un proxy stdio; i Connectors di claude.ai web richiedono HTTPS pubblico e OAuth, quindi non raggiungeranno un host sulla LAN).",
+    "statusLabel": "Stato:",
+    "pinnedByEnvBadge": "Fissato da {envVar}",
+    "configuredBadge": "Configurato",
+    "pinnedByEnvDescription": "Il token attivo è impostato dalla variabile d'ambiente {envVar}. Rimuovila dal tuo {envFile} e riavvia il container prima di gestire il token da questa interfaccia.",
+    "noTokenDescription": "Nessun token è configurato. I client MCP esterni ripiegheranno sull'autenticazione tramite cookie, che Claude Desktop / Claude Code non supportano: la registrazione fallirà con un errore poco chiaro. Genera un token per sbloccarli.",
+    "activeTokenDescription": "Un token è configurato e attivo. Ruotalo per invalidare quello precedente (qualsiasi client che usa ancora il vecchio token inizierà a ricevere 401), oppure revocalo del tutto per tornare all'autenticazione solo tramite cookie.",
+    "rotateTokenButton": "Ruota token",
+    "generateTokenButton": "Genera token",
+    "revokeTokenButton": "Revoca token",
+    "rotateConfirmTitle": "Ruotare il token MCP?",
+    "generateConfirmTitle": "Generare un token MCP?",
+    "rotateConfirmDescription": "Qualsiasi client che usa ancora il token precedente riceverà un 401 + challenge Bearer alla prossima richiesta. Vedrai il nuovo token una sola volta: conservalo in un luogo sicuro (non è più leggibile dall'interfaccia).",
+    "generateConfirmDescription": "Vedrai il token una sola volta: conservalo in un luogo sicuro (non è più leggibile dall'interfaccia). I client MCP esterni lo useranno per autenticarsi su {endpoint}.",
+    "rotateConfirmButton": "Ruota",
+    "generateConfirmButton": "Genera",
+    "revokeConfirmTitle": "Revocare il token MCP?",
+    "revokeConfirmDescription": "I client MCP esterni inizieranno a ricevere 401 alla prossima richiesta. Puoi sempre generare un nuovo token in seguito.",
+    "revokeConfirmButton": "Revoca",
+    "revealTitle": "Salva questo token",
+    "revealDescription": "FiestaBoard memorizza solo ciò che serve a verificare le richieste future: questa è l'unica volta in cui il valore in chiaro viene mostrato. Copialo subito nel tuo client MCP.",
+    "tokenLabel": "Token",
+    "copyButton": "Copia",
+    "copiedButton": "Copiato",
+    "configSnippetLabel": "Snippet di configurazione per Claude Desktop",
+    "configSnippetDescription": "Incolla questo in {configPath}, unendolo a quanto è già presente, poi esci completamente e riavvia Claude Desktop (⌘Q — chiudere la finestra non basta). Claude Desktop supporta solo server MCP via stdio, quindi questo snippet richiama {mcpRemoteLink} tramite {npx} come proxy: Node 18+ deve essere installato e {npx} raggiungibile dal PATH di Claude Desktop. Se restituisce l'errore {commandNotFound}, sostituisci {npxQuoted} con il percorso assoluto restituito da {whichNpx}.",
+    "claudeCodeDescription": "<label>Claude Code (CLI):</label> comunica direttamente via HTTP — nessun proxy necessario.",
+    "claudeWebDescription": "<label>claude.ai web (Connectors):</label> non supportato per un FiestaBoard self-hosted. Il flusso Connectors richiede un URL HTTPS pubblico e la registrazione dinamica dei client OAuth 2.1, e un host sulla LAN non può fornire né l'uno né l'altro. Usa invece Desktop o Code.",
+    "savedItButton": "L'ho salvato",
+    "toastTokenRevoked": "Token MCP revocato",
+    "toastCopyFailed": "Impossibile copiare negli appunti"
   }
 }

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -50,7 +50,8 @@
     "pageCount": "{count, plural, one {# ページ} other {# ページ}}",
     "unknownError": "不明なエラー",
     "opensInNewTab": "(新しいタブで開きます)",
-    "notificationsRegionLabel": "通知"
+    "notificationsRegionLabel": "通知",
+    "versionShort": "v{version}"
   },
   "metadata": {
     "appTitle": "FiestaBoard コントロール",
@@ -81,7 +82,8 @@
     "boardSelector": "管理するボードを選択",
     "selectBoard": "ボードを選択",
     "unnamedBoard": "名前のないボード",
-    "transitions": "トランジションラボ"
+    "transitions": "トランジションラボ",
+    "prideCelebration": "ハッピープライド！"
   },
   "network": {
     "title": "Wi-Fi",
@@ -330,7 +332,11 @@
       "validationOneOffDateRequired": "Please pick a date",
       "validationEndDateBeforeStart": "End date must be on or after start date",
       "collectionSizeWarning": "このコレクションの{total}ページ中{count}ページがこのボードのサイズに合わないため、スキップされます。",
-      "incompatiblePageWarning": "このページはこのボードのサイズに合わないため、正しく表示されない可能性があります。"
+      "incompatiblePageWarning": "このページはこのボードのサイズに合わないため、正しく表示されない可能性があります。",
+      "monthAriaLabel": "月",
+      "dayAriaLabel": "日",
+      "endMonthAriaLabel": "終了月",
+      "endDayAriaLabel": "終了日"
     },
     "descriptionWithTimezone": "時刻と曜日でページの切り替えを自動化 · {timezone}",
     "gapDefaultPlaceholder": "空き時間のデフォルト…",
@@ -472,7 +478,37 @@
     "toastNoUpdates": "すべてのプラグインは最新です",
     "toastCheckFailed": "更新の確認に失敗: {error}",
     "installAction": "インストール",
-    "installedBadge": "インストール済み"
+    "installedBadge": "インストール済み",
+    "valueUnavailable": "利用不可",
+    "enablePluginForLiveValues": "ライブの値を確認するにはプラグインを有効にしてください。",
+    "liveValuesUnavailable": "ライブの値を利用できません。",
+    "liveValuesUnavailableWithError": "ライブの値を利用できません: {error}",
+    "currentValueColumn": "現在の値",
+    "refreshingValues": "更新中…",
+    "sourceCoreBadge": "コア",
+    "sourceMarketplaceBadge": "マーケットプレイス",
+    "sourceExternalBadge": "外部",
+    "updateAvailableBadge": "更新あり",
+    "moreOptionsAriaLabel": "その他のオプション",
+    "addInstanceAction": "インスタンスを追加",
+    "instanceNameInlineLabel": "インスタンス名:",
+    "addInstanceInlineHelp": "独自の設定を持つ、このプラグインの新しい独立したインスタンスを作成します。英数字、ハイフン、アンダースコアを使用してください (1〜40 文字)。",
+    "deleteInstanceConfirmTitle": "インスタンス「{label}」を削除しますか？",
+    "deletePluginConfirmTitle": "「{name}」を削除しますか？",
+    "deleteInstanceConfirmDescription": "このインスタンスとその設定を完全に削除します。この操作は取り消せません。",
+    "deletePluginConfirmDescription": "このプラグインとそのすべてのインスタンスを完全に削除します。この操作は取り消せません。",
+    "demoPage": {
+      "title": "デモページ",
+      "alreadyExists": "このプラグインのデモページは既に存在します。",
+      "createDescription": "このプラグインを紹介する、すぐに使えるページを作成します。",
+      "recreateButton": "再作成",
+      "recreateConfirmTitle": "デモページを再作成しますか？",
+      "recreateConfirmDescription": "既存のデモページを削除し、デフォルト設定で新しく作成します。この操作は取り消せません。",
+      "creating": "作成中...",
+      "createAction": "デモページを作成",
+      "recreateAction": "デモページを再作成",
+      "requirementsWarning": "デモページを作成する前に、下の必須設定を構成してください。"
+    }
   },
   "settings": {
     "title": "設定",
@@ -496,7 +532,43 @@
     "sectionAccount": "アカウント",
     "sectionAccountDescription": "ユーザー名、パスワード、サインアウト",
     "sectionNetwork": "ネットワーク",
-    "sectionNetworkDescription": "Wi-Fi と接続を管理"
+    "sectionNetworkDescription": "Wi-Fi と接続を管理",
+    "ai": {
+      "removeProviderAriaLabel": "プロバイダーを削除",
+      "cardTitle": "AI プロバイダー",
+      "cardDescription": "「Gen AI」ページジェネレーター用に OpenAI 互換の LLM を設定します。BYO-LLM 方式のため、FiestaBoard がキーを同梱することはありません。",
+      "privacyNotice": "入力したプロンプトと有効なプラグインの変数一覧は、設定したプロバイダーに直接送信されます。API キーはこのデバイスに保存され、他のどこにも送信されません。",
+      "emptyState": "プロバイダーはまだ設定されていません。",
+      "addProviderButton": "プロバイダーを追加",
+      "discardButton": "破棄",
+      "saveChangesButton": "変更を保存",
+      "defaultBadge": "デフォルト",
+      "anthropicBadge": "Anthropic",
+      "makeDefaultButton": "デフォルトにする",
+      "nameLabel": "名前",
+      "protocolLabel": "プロトコル",
+      "protocolOpenaiOption": "OpenAI 互換 (OpenAI, OpenRouter, Groq, DeepSeek, Mistral, Together, Fireworks, Ollama, LM Studio, vLLM, …)",
+      "protocolAnthropicOption": "Anthropic (Messages API)",
+      "baseUrlLabel": "ベース URL",
+      "quickPresetsLabel": "クイックプリセット",
+      "apiKeyLabel": "API キー",
+      "modelsLabel": "モデル",
+      "defaultModelLabel": "デフォルトモデル",
+      "testConnectionButton": "接続テスト"
+    },
+    "backup": {
+      "cardTitle": "バックアップと復元",
+      "cardDescription": "FiestaBoard のすべての設定 — ボード設定、ページ、カルーセル、スケジュール、プラグイン設定 — を 1 つの JSON ファイルとしてエクスポートします。新しいインスタンスでそのファイルをアップロードすれば、移行やアップグレード後の復旧ができます。",
+      "exportButton": "バックアップをエクスポート",
+      "importButton": "バックアップをインポート…",
+      "reinstallPluginsLabel": "インポート後に外部プラグインを再インストール",
+      "reinstallPluginsDescription": "有効にすると、FiestaBoard はバックアップに記録された外部プラグインのうち、このインスタンスにまだインストールされていないものをクローンしようとします。いずれの場合も、それらの設定はバックアップから復元されます。",
+      "sensitiveNote": "注意: バックアップには API キーやボードの認証情報などの機密情報が平文で含まれます。ファイルは安全に保管し、公開しないでください。",
+      "confirmTitle": "現在の設定を置き換えますか？",
+      "confirmDescription": "<file></file> を復元しようとしています。既存のページ、カルーセル、スケジュール、設定は上書きされます。既存の各ファイルはタイムスタンプ付きのコピーが新しいファイルと並べて保持されるため、必要に応じて手動で元に戻せます。",
+      "restoringButton": "復元中…",
+      "restoreButton": "バックアップを復元"
+    }
   },
   "offline": {
     "youreOffline": "オフラインです",
@@ -581,7 +653,10 @@
       "passwordPlaceholder": "YourPassword",
       "wifiPreview": "WIFI: {ssid}",
       "passPreview": "PASS: {password}",
-      "noPassword": "（パスワードなし）"
+      "noPassword": "（パスワードなし）",
+      "addMoreHint": "<link>連携</link>ページからいつでも追加できます。",
+      "builtInBadge": "組み込み",
+      "previewLabel": "プレビュー:"
     },
     "welcome": {
       "setupComplete": "セットアップ完了！",
@@ -639,7 +714,9 @@
     "changeModeDisableTitle": "スケジュールモードをオフ",
     "changeModeDisableDescription": "スケジュールを無効化し、ボードを手動で操作します。",
     "changeModeDisableSuccess": "スケジュールモードを無効化しました",
-    "collectionSizeWarning": "このコレクションの{total}ページ中{count}ページがこのボードのサイズに合わないため、スキップされます。"
+    "collectionSizeWarning": "このコレクションの{total}ページ中{count}ページがこのボードのサイズに合わないため、スキップされます。",
+    "turnOffLiveModeAriaLabel": "ライブモードをオフにする",
+    "liveModeBadge": "ライブモード"
   },
   "forceSetDialog": {
     "title": "ボードを強制設定",
@@ -882,7 +959,10 @@
     "updateNow": "今すぐ更新",
     "oneClickHint": "ここにワンクリックの「今すぐ更新」ボタンが欲しいですか? <envFile></envFile> に <profile></profile> を設定して、<command></command> を実行してください。",
     "dialogTitle": "FiestaBoard を更新しますか?",
-    "dialogDescription": "<version></version> をプルして FiestaBoard を再起動します。ボード表示は約 30 秒停止し、このページは自動的に再読み込みされます。"
+    "dialogDescription": "<version></version> をプルして FiestaBoard を再起動します。ボード表示は約 30 秒停止し、このページは自動的に再読み込みされます。",
+    "intervalSelectAriaLabel": "アップデート確認の頻度",
+    "intervalCardDescription": "FiestaBoard がバックグラウンドで新しいリリースを確認する頻度です。見つかるとここにバナーが表示されます。",
+    "lastChecked": "最終確認: {time}"
   },
   "transitionSettings": {
     "title": "ボードトランジション",
@@ -1008,7 +1088,8 @@
       "Numbers": "数字",
       "Symbols": "記号",
       "Colors": "色"
-    }
+    },
+    "latencyMs": "{ms} ms"
   },
   "generalSettings": {
     "title": "一般設定",
@@ -1375,7 +1456,8 @@
     "flapSpeed_relaxedHint": "{ms} ミリ秒 — アンビエント表示向けの、ゆっくりとした反転。",
     "flapSpeedPreviewLabel": "プレビュー",
     "flapSpeedInactive": "ボードアニメーションがオフのため、反転速度は影響しません。",
-    "flapSpeedScreenOnlyNote": "これは画面上のボードプレビューだけを変更します。実機の Vestaboard の切り替え速度は、動作 → ボードトランジションで別に設定します。"
+    "flapSpeedScreenOnlyNote": "これは画面上のボードプレビューだけを変更します。実機の Vestaboard の切り替え速度は、動作 → ボードトランジションで別に設定します。",
+    "updateAvailableBadge": "v{version} が利用可能"
   },
   "monitor": {
     "title": "モニター",
@@ -1647,7 +1729,8 @@
     "whiteBoard": "ホワイトボード",
     "deviceFlagship": "Flagship",
     "deviceNote": "Note",
-    "deviceNoteArray": "Note アレイ {w}×{h}"
+    "deviceNoteArray": "Note アレイ {w}×{h}",
+    "githubLink": "GitHub"
   },
   "boardDisplay": {
     "loading": "ボード表示を読み込み中",
@@ -1736,7 +1819,12 @@
     "remoteOptionsSearchPlaceholder": "検索…",
     "remoteOptionsCustomLabel": "カスタム値",
     "remoteOptionsCustomPlaceholder": "一覧にない値を入力",
-    "remoteOptionsCustomAdd": "カスタム値を追加"
+    "remoteOptionsCustomAdd": "カスタム値を追加",
+    "addItemLabel": "{label}を追加",
+    "unknownType": "不明な型: {type}",
+    "pagePickerNone": "なし（上書きなし）",
+    "pagePickerLoading": "ページを読み込み中…",
+    "pagePickerPlaceholder": "ページを選択…"
   },
   "filterPicker": {
     "noFiltersAvailable": "利用可能なフィルターがありません",
@@ -1744,7 +1832,8 @@
     "filterDescWrap": "長いテキストを複数行に折り返します",
     "filterDescPad": "テキストを指定幅まで埋めます",
     "filterDescTruncate": "テキストを指定長まで切り詰めます",
-    "wrapInstruction": "|wrap: 長いテキストを折り返します。下に空行を残しておくと、テキストがそこに流れ込みます。"
+    "wrapInstruction": "長いテキストを折り返します。下に空行を残しておくと、テキストがそこに流れ込みます。",
+    "exampleLabel": "例: {example}"
   },
   "formattingPicker": {
     "noFormattingAvailable": "利用可能なフォーマットオプションがありません",
@@ -1805,7 +1894,25 @@
     "alignRight": "右揃え",
     "syncFromBoardTooltip": "現在ボードに表示されている内容からテンプレートを設定",
     "syncFromBoard": "現在のボード表示から同期",
-    "alignment": "配置:"
+    "alignment": "配置:",
+    "undoAriaLabel": "元に戻す",
+    "redoAriaLabel": "やり直し",
+    "cutAriaLabel": "切り取り",
+    "copyAriaLabel": "コピー",
+    "pasteAriaLabel": "貼り付け",
+    "removeWrappedTextAriaLabel": "折り返しテキストを削除",
+    "colorPickerAriaLabel": "カラーピッカー",
+    "heartCharacterAriaLabel": "ハート文字",
+    "lineCount": "{used} / {max} 行",
+    "overLineLimit": " — ボードの {max} 行制限を超えています",
+    "currentLine": "（{line} 行目）",
+    "heartLabel": "ハート",
+    "insertHeartTooltip": "ハート文字を挿入（Note のみ）",
+    "colorTileTooltip": "{color} タイル（コード {code}）— ドラッグで移動、Backspace で削除",
+    "fillSpaceTooltip": "スペース埋め — 行の残りの幅いっぱいに広がります",
+    "fillSpaceRepeatTooltip": "スペースを繰り返して埋める: {char}",
+    "variableFilterTooltip": "フィルター: {filter}",
+    "variableMaxLengthTooltip": "最大長: {maxLength} 文字"
   },
   "variablePicker": {
     "noVariablesAvailable": "利用可能な変数がありません",
@@ -1815,7 +1922,8 @@
     "searchPlaceholder": "変数を検索...",
     "indexLabel": "インデックス: {index}",
     "configureHint": "ここにインデックス付き変数を表示するには、設定で {arrayName} を構成してください。",
-    "configureExample": "例:"
+    "configureExample": "例:",
+    "noMatchingVariables": "一致する変数が見つかりません。"
   },
   "login": {
     "signInTitle": "FiestaBoard にサインイン",
@@ -1873,11 +1981,62 @@
     "taskStatusAriaLabel": "タスクの進捗",
     "taskProgressAriaLabel": "AI タスクの進行状況",
     "clearConversationAriaLabel": "会話をクリア",
-    "closePanelAriaLabel": "FiestaBot (Beta) を閉じる"
+    "closePanelAriaLabel": "FiestaBot (Beta) を閉じる",
+    "providerSelectAriaLabel": "プロバイダー",
+    "modelSelectAriaLabel": "モデル",
+    "showBoardTooltip": "ボードプレビューを表示",
+    "hideBoardTooltip": "ボードプレビューを非表示",
+    "undoTooltip": "AI による最後の変更を元に戻す",
+    "panelTitle": "FiestaBot (Beta)",
+    "retryButton": "再試行",
+    "messageLabel": "メッセージ",
+    "stopButton": "停止",
+    "sendButton": "送信",
+    "tasksHeading": "タスク ({done}/{total})",
+    "emptyStateTitle": "何かお手伝いできますか？",
+    "emptyStateDescription": "作成または変更したい内容を説明してください。",
+    "showBoardButton": "ボードを表示",
+    "undoButton": "元に戻す",
+    "renameSummary": "→ 「{name}」に名前を変更",
+    "previewUnavailable": "（プレビューを利用できません）"
   },
   "boardSizeIndicator": {
     "custom": "カスタム",
     "ariaLabel": "{rows}行×{cols}列",
     "ariaLabelWithLayout": "{rows}行×{cols}列、{layout}"
+  },
+  "mcpSettings": {
+    "title": "MCP / 外部クライアント",
+    "description": "Claude Desktop、Claude Code、その他の MCP クライアントがこの FiestaBoard と通信できるようにする事前共有トークンです。このトークンは単一のプリンシパルとして認証され、{endpoint} エンドポイントのみに限定されるため、ページやその他の設定を編集することはできません。クライアント固有の注意点については <link>MCP クライアントのセットアップ</link> を参照してください（Desktop には stdio プロキシが必要です。claude.ai web の Connectors は公開 HTTPS と OAuth が必要なため、LAN 上のホストには接続できません）。",
+    "statusLabel": "ステータス:",
+    "pinnedByEnvBadge": "{envVar} で固定",
+    "configuredBadge": "設定済み",
+    "pinnedByEnvDescription": "有効なトークンは環境変数 {envVar} で設定されています。この UI からトークンを管理するには、{envFile} でその設定を解除し、コンテナを再起動してください。",
+    "noTokenDescription": "トークンが設定されていません。外部の MCP クライアントは cookie 認証にフォールバックしますが、Claude Desktop と Claude Code はこれをサポートしていないため、原因のわかりにくいエラーで登録に失敗します。トークンを生成して利用できるようにしてください。",
+    "activeTokenDescription": "トークンが設定され、有効になっています。ローテーションすると以前のトークンは無効になり（古いトークンを使い続けているクライアントは 401 を受け取るようになります）、完全に失効させると cookie のみの認証に戻ります。",
+    "rotateTokenButton": "トークンをローテーション",
+    "generateTokenButton": "トークンを生成",
+    "revokeTokenButton": "トークンを失効",
+    "rotateConfirmTitle": "MCP トークンをローテーションしますか？",
+    "generateConfirmTitle": "MCP トークンを生成しますか？",
+    "rotateConfirmDescription": "以前のトークンを使い続けているクライアントは、次のリクエストで 401 と Bearer チャレンジによって拒否されます。新しいトークンが表示されるのは一度だけです — 安全な場所に保管してください（UI から再度読み取ることはできません）。",
+    "generateConfirmDescription": "トークンが表示されるのは一度だけです — 安全な場所に保管してください（UI から再度読み取ることはできません）。外部の MCP クライアントはこのトークンを使って {endpoint} に認証します。",
+    "rotateConfirmButton": "ローテーション",
+    "generateConfirmButton": "生成",
+    "revokeConfirmTitle": "MCP トークンを失効させますか？",
+    "revokeConfirmDescription": "外部の MCP クライアントは次のリクエストから 401 を受け取るようになります。新しいトークンは後でいつでも生成できます。",
+    "revokeConfirmButton": "失効",
+    "revealTitle": "このトークンを保存してください",
+    "revealDescription": "FiestaBoard は今後のリクエストを検証するために必要な情報のみを保存します — 平文の値が表示されるのはこの一度だけです。今のうちに MCP クライアントにコピーしてください。",
+    "tokenLabel": "トークン",
+    "copyButton": "コピー",
+    "copiedButton": "コピーしました",
+    "configSnippetLabel": "Claude Desktop の設定スニペット",
+    "configSnippetDescription": "これを {configPath} に貼り付け、既にある内容とマージしてから、Claude Desktop を完全に終了して再起動してください（⌘Q — ウィンドウを閉じるだけでは不十分です）。Claude Desktop は stdio の MCP サーバーのみをサポートするため、このスニペットはプロキシとして {npx} 経由で {mcpRemoteLink} を実行します — Node 18 以上がインストールされ、Claude Desktop の PATH から {npx} に到達できる必要があります。{commandNotFound} というエラーになる場合は、{npxQuoted} を {whichNpx} で得られる絶対パスに置き換えてください。",
+    "claudeCodeDescription": "<label>Claude Code (CLI):</label> HTTP で直接通信します — プロキシは不要です。",
+    "claudeWebDescription": "<label>claude.ai web (Connectors):</label> セルフホストの FiestaBoard ではサポートされていません。Connectors のフローには公開 HTTPS の URL と OAuth 2.1 の動的クライアント登録が必要ですが、LAN 上のホストはどちらも提供できません。代わりに Desktop または Code をご利用ください。",
+    "savedItButton": "保存しました",
+    "toastTokenRevoked": "MCP トークンを失効しました",
+    "toastCopyFailed": "クリップボードにコピーできませんでした"
   }
 }

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -50,7 +50,8 @@
     "pageCount": "{count, plural, one {# 페이지} other {# 페이지}}",
     "unknownError": "알 수 없는 오류",
     "opensInNewTab": "(새 탭에서 열림)",
-    "notificationsRegionLabel": "알림"
+    "notificationsRegionLabel": "알림",
+    "versionShort": "v{version}"
   },
   "metadata": {
     "appTitle": "FiestaBoard 컨트롤",
@@ -81,7 +82,8 @@
     "boardSelector": "관리할 보드 선택",
     "selectBoard": "보드 선택",
     "unnamedBoard": "이름 없는 보드",
-    "transitions": "전환 실험실"
+    "transitions": "전환 실험실",
+    "prideCelebration": "해피 프라이드!"
   },
   "network": {
     "title": "Wi-Fi",
@@ -330,7 +332,11 @@
       "validationOneOffDateRequired": "Please pick a date",
       "validationEndDateBeforeStart": "End date must be on or after start date",
       "collectionSizeWarning": "이 컬렉션의 {total}개 페이지 중 {count}개가 이 보드의 크기와 맞지 않아 건너뜁니다.",
-      "incompatiblePageWarning": "이 페이지는 이 보드의 크기와 맞지 않아 올바르게 표시되지 않을 수 있습니다."
+      "incompatiblePageWarning": "이 페이지는 이 보드의 크기와 맞지 않아 올바르게 표시되지 않을 수 있습니다.",
+      "monthAriaLabel": "월",
+      "dayAriaLabel": "일",
+      "endMonthAriaLabel": "종료 월",
+      "endDayAriaLabel": "종료일"
     },
     "descriptionWithTimezone": "시간과 요일별로 페이지 회전을 자동화 · {timezone}",
     "gapDefaultPlaceholder": "공백 기본…",
@@ -472,7 +478,37 @@
     "toastNoUpdates": "모든 플러그인이 최신입니다",
     "toastCheckFailed": "업데이트 확인 실패: {error}",
     "installAction": "설치",
-    "installedBadge": "설치됨"
+    "installedBadge": "설치됨",
+    "valueUnavailable": "사용 불가",
+    "enablePluginForLiveValues": "실시간 값을 보려면 플러그인을 활성화하세요.",
+    "liveValuesUnavailable": "실시간 값을 사용할 수 없습니다.",
+    "liveValuesUnavailableWithError": "실시간 값을 사용할 수 없습니다: {error}",
+    "currentValueColumn": "현재 값",
+    "refreshingValues": "새로 고치는 중…",
+    "sourceCoreBadge": "코어",
+    "sourceMarketplaceBadge": "마켓플레이스",
+    "sourceExternalBadge": "외부",
+    "updateAvailableBadge": "업데이트",
+    "moreOptionsAriaLabel": "추가 옵션",
+    "addInstanceAction": "인스턴스 추가",
+    "instanceNameInlineLabel": "인스턴스 이름:",
+    "addInstanceInlineHelp": "이 플러그인의 새로운 독립 인스턴스를 고유한 구성으로 만듭니다. 영숫자, 하이픈 또는 밑줄을 사용하세요 (1-40자).",
+    "deleteInstanceConfirmTitle": "인스턴스 \"{label}\"을(를) 삭제하시겠습니까?",
+    "deletePluginConfirmTitle": "\"{name}\"을(를) 삭제하시겠습니까?",
+    "deleteInstanceConfirmDescription": "이 인스턴스와 해당 구성을 영구적으로 제거합니다. 이 작업은 되돌릴 수 없습니다.",
+    "deletePluginConfirmDescription": "플러그인과 모든 인스턴스를 영구적으로 제거합니다. 이 작업은 되돌릴 수 없습니다.",
+    "demoPage": {
+      "title": "데모 페이지",
+      "alreadyExists": "이 플러그인의 데모 페이지가 이미 있습니다.",
+      "createDescription": "이 플러그인을 보여주는 바로 사용 가능한 페이지를 만듭니다.",
+      "recreateButton": "다시 만들기",
+      "recreateConfirmTitle": "데모 페이지를 다시 만드시겠습니까?",
+      "recreateConfirmDescription": "기존 데모 페이지를 삭제하고 기본 설정으로 새 페이지를 만듭니다. 이 작업은 되돌릴 수 없습니다.",
+      "creating": "만드는 중...",
+      "createAction": "데모 페이지 만들기",
+      "recreateAction": "데모 페이지 다시 만들기",
+      "requirementsWarning": "데모 페이지를 만들기 전에 아래 필수 설정을 구성하세요."
+    }
   },
   "settings": {
     "title": "설정",
@@ -496,7 +532,43 @@
     "sectionAccount": "계정",
     "sectionAccountDescription": "사용자 이름, 비밀번호 및 로그아웃",
     "sectionNetwork": "네트워크",
-    "sectionNetworkDescription": "Wi-Fi 및 연결 관리"
+    "sectionNetworkDescription": "Wi-Fi 및 연결 관리",
+    "ai": {
+      "removeProviderAriaLabel": "제공자 제거",
+      "cardTitle": "AI 제공자",
+      "cardDescription": "「Gen AI」 페이지 생성기에 사용할 OpenAI 호환 LLM을 설정하세요. BYO-LLM 방식이므로 FiestaBoard는 키를 포함하지 않습니다.",
+      "privacyNotice": "프롬프트와 활성화된 플러그인의 변수 목록은 설정한 제공자에게 직접 전송됩니다. API 키는 이 기기에 저장되며 다른 곳으로는 전송되지 않습니다.",
+      "emptyState": "아직 설정된 제공자가 없습니다.",
+      "addProviderButton": "제공자 추가",
+      "discardButton": "변경 취소",
+      "saveChangesButton": "변경 사항 저장",
+      "defaultBadge": "기본값",
+      "anthropicBadge": "Anthropic",
+      "makeDefaultButton": "기본값으로 설정",
+      "nameLabel": "이름",
+      "protocolLabel": "프로토콜",
+      "protocolOpenaiOption": "OpenAI 호환 (OpenAI, OpenRouter, Groq, DeepSeek, Mistral, Together, Fireworks, Ollama, LM Studio, vLLM, …)",
+      "protocolAnthropicOption": "Anthropic (Messages API)",
+      "baseUrlLabel": "기본 URL",
+      "quickPresetsLabel": "빠른 프리셋",
+      "apiKeyLabel": "API 키",
+      "modelsLabel": "모델",
+      "defaultModelLabel": "기본 모델",
+      "testConnectionButton": "연결 테스트"
+    },
+    "backup": {
+      "cardTitle": "백업 및 복원",
+      "cardDescription": "FiestaBoard의 모든 설정 — 보드 설정, 페이지, 캐러셀, 스케줄, 플러그인 설정 — 을 하나의 JSON 파일로 내보냅니다. 새 인스턴스에서 이 파일을 다시 업로드하면 마이그레이션하거나 업그레이드 후 복구할 수 있습니다.",
+      "exportButton": "백업 내보내기",
+      "importButton": "백업 가져오기…",
+      "reinstallPluginsLabel": "가져오기 후 외부 플러그인 다시 설치",
+      "reinstallPluginsDescription": "활성화하면 FiestaBoard가 백업에 기록된 외부 플러그인 중 이 인스턴스에 아직 설치되지 않은 항목을 복제하려고 시도합니다. 어느 경우든 해당 설정은 백업에서 복원됩니다.",
+      "sensitiveNote": "참고: 백업에는 API 키와 보드 자격 증명 같은 민감한 값이 평문으로 포함됩니다. 파일을 안전하게 보관하고 공개적으로 공유하지 마세요.",
+      "confirmTitle": "현재 설정을 교체하시겠습니까?",
+      "confirmDescription": "<file></file>을(를) 복원하려고 합니다. 기존 페이지, 캐러셀, 스케줄 및 설정을 덮어씁니다. 각 기존 파일의 타임스탬프가 붙은 사본이 새 파일과 함께 보관되므로 필요하면 수동으로 되돌릴 수 있습니다.",
+      "restoringButton": "복원 중…",
+      "restoreButton": "백업 복원"
+    }
   },
   "offline": {
     "youreOffline": "오프라인 상태입니다",
@@ -581,7 +653,10 @@
       "passwordPlaceholder": "YourPassword",
       "wifiPreview": "WIFI: {ssid}",
       "passPreview": "PASS: {password}",
-      "noPassword": "(비밀번호 없음)"
+      "noPassword": "(비밀번호 없음)",
+      "addMoreHint": "언제든지 <link>연동</link> 페이지에서 더 추가할 수 있습니다.",
+      "builtInBadge": "기본 제공",
+      "previewLabel": "미리보기:"
     },
     "welcome": {
       "setupComplete": "설정 완료!",
@@ -639,7 +714,9 @@
     "changeModeDisableTitle": "일정 모드 끄기",
     "changeModeDisableDescription": "일정을 비활성화하고 보드를 수동으로 제어합니다.",
     "changeModeDisableSuccess": "일정 모드가 비활성화됨",
-    "collectionSizeWarning": "이 컬렉션의 {total}개 페이지 중 {count}개가 이 보드의 크기와 맞지 않아 건너뜁니다."
+    "collectionSizeWarning": "이 컬렉션의 {total}개 페이지 중 {count}개가 이 보드의 크기와 맞지 않아 건너뜁니다.",
+    "turnOffLiveModeAriaLabel": "실시간 모드 끄기",
+    "liveModeBadge": "실시간 모드"
   },
   "forceSetDialog": {
     "title": "보드 강제 설정",
@@ -882,7 +959,10 @@
     "updateNow": "지금 업데이트",
     "oneClickHint": "여기에 원클릭 \"지금 업데이트\" 버튼을 원하시나요? <envFile></envFile>에서 <profile></profile>을 설정한 후 <command></command>을 실행하세요.",
     "dialogTitle": "FiestaBoard를 업데이트하시겠습니까?",
-    "dialogDescription": "<version></version>을 가져와 FiestaBoard를 재시작합니다. 보드 디스플레이는 약 30초간 일시 중지되고 이 페이지는 자동으로 다시 로드됩니다."
+    "dialogDescription": "<version></version>을 가져와 FiestaBoard를 재시작합니다. 보드 디스플레이는 약 30초간 일시 중지되고 이 페이지는 자동으로 다시 로드됩니다.",
+    "intervalSelectAriaLabel": "업데이트 확인 주기",
+    "intervalCardDescription": "FiestaBoard가 백그라운드에서 새 릴리스를 확인하는 주기입니다. 새 릴리스를 찾으면 여기에 배너가 표시됩니다.",
+    "lastChecked": "마지막 확인: {time}"
   },
   "transitionSettings": {
     "title": "보드 전환 효과",
@@ -1008,7 +1088,8 @@
       "Numbers": "숫자",
       "Symbols": "기호",
       "Colors": "색상"
-    }
+    },
+    "latencyMs": "{ms}ms"
   },
   "generalSettings": {
     "title": "일반 설정",
@@ -1375,7 +1456,8 @@
     "flapSpeed_relaxedHint": "{ms}ms — 은은한 디스플레이를 위한 느리고 차분한 회전.",
     "flapSpeedPreviewLabel": "미리보기",
     "flapSpeedInactive": "보드 애니메이션이 꺼져 있어 회전 속도는 적용되지 않습니다.",
-    "flapSpeedScreenOnlyNote": "이 설정은 화면의 보드 미리보기만 바꿉니다. 실제 Vestaboard의 전환 속도는 동작 → 보드 전환에서 따로 설정합니다."
+    "flapSpeedScreenOnlyNote": "이 설정은 화면의 보드 미리보기만 바꿉니다. 실제 Vestaboard의 전환 속도는 동작 → 보드 전환에서 따로 설정합니다.",
+    "updateAvailableBadge": "v{version} 사용 가능"
   },
   "monitor": {
     "title": "모니터",
@@ -1647,7 +1729,8 @@
     "whiteBoard": "화이트 보드",
     "deviceFlagship": "Flagship",
     "deviceNote": "Note",
-    "deviceNoteArray": "Note 배열 {w}×{h}"
+    "deviceNoteArray": "Note 배열 {w}×{h}",
+    "githubLink": "GitHub"
   },
   "boardDisplay": {
     "loading": "보드 디스플레이 로드 중",
@@ -1736,7 +1819,12 @@
     "remoteOptionsSearchPlaceholder": "검색…",
     "remoteOptionsCustomLabel": "사용자 지정 값",
     "remoteOptionsCustomPlaceholder": "목록에 없는 값을 입력하세요",
-    "remoteOptionsCustomAdd": "사용자 지정 값 추가"
+    "remoteOptionsCustomAdd": "사용자 지정 값 추가",
+    "addItemLabel": "{label} 추가",
+    "unknownType": "알 수 없는 타입: {type}",
+    "pagePickerNone": "없음 (재정의 안 함)",
+    "pagePickerLoading": "페이지를 불러오는 중…",
+    "pagePickerPlaceholder": "페이지 선택…"
   },
   "filterPicker": {
     "noFiltersAvailable": "사용 가능한 필터가 없습니다",
@@ -1744,7 +1832,8 @@
     "filterDescWrap": "긴 텍스트를 여러 줄로 줄바꿈",
     "filterDescPad": "텍스트를 지정된 너비로 채움",
     "filterDescTruncate": "텍스트를 지정된 길이로 잘라냄",
-    "wrapInstruction": "|wrap: 긴 텍스트를 줄바꿈합니다. 아래에 빈 줄을 남겨두면 텍스트가 그곳으로 흐릅니다."
+    "wrapInstruction": "긴 텍스트를 줄바꿈합니다. 아래에 빈 줄을 남겨두면 텍스트가 그곳으로 흐릅니다.",
+    "exampleLabel": "예시: {example}"
   },
   "formattingPicker": {
     "noFormattingAvailable": "사용 가능한 형식 옵션이 없습니다",
@@ -1805,7 +1894,25 @@
     "alignRight": "오른쪽 정렬",
     "syncFromBoardTooltip": "현재 보드에 표시되어 있는 내용으로 템플릿 채우기",
     "syncFromBoard": "현재 보드 디스플레이에서 동기화",
-    "alignment": "정렬:"
+    "alignment": "정렬:",
+    "undoAriaLabel": "실행 취소",
+    "redoAriaLabel": "다시 실행",
+    "cutAriaLabel": "잘라내기",
+    "copyAriaLabel": "복사",
+    "pasteAriaLabel": "붙여넣기",
+    "removeWrappedTextAriaLabel": "줄바꿈된 텍스트 제거",
+    "colorPickerAriaLabel": "색상 선택기",
+    "heartCharacterAriaLabel": "하트 문자",
+    "lineCount": "{used} / {max}줄",
+    "overLineLimit": " — {max}줄 보드 제한을 초과합니다",
+    "currentLine": "({line}번째 줄)",
+    "heartLabel": "하트",
+    "insertHeartTooltip": "하트 문자 삽입 (Note 전용)",
+    "colorTileTooltip": "{color} 타일 (코드 {code}) - 드래그하여 이동, backspace로 삭제",
+    "fillSpaceTooltip": "공간 채우기 - 남은 줄 너비를 채우도록 확장됩니다",
+    "fillSpaceRepeatTooltip": "반복하여 공간 채우기: {char}",
+    "variableFilterTooltip": "필터: {filter}",
+    "variableMaxLengthTooltip": "최대 길이: {maxLength}자"
   },
   "variablePicker": {
     "noVariablesAvailable": "사용 가능한 변수가 없습니다",
@@ -1815,7 +1922,8 @@
     "searchPlaceholder": "변수 검색...",
     "indexLabel": "인덱스: {index}",
     "configureHint": "여기서 인덱싱된 변수를 보려면 설정에서 {arrayName}을(를) 구성하세요.",
-    "configureExample": "예시:"
+    "configureExample": "예시:",
+    "noMatchingVariables": "일치하는 변수를 찾을 수 없습니다."
   },
   "login": {
     "signInTitle": "FiestaBoard에 로그인",
@@ -1873,11 +1981,62 @@
     "taskStatusAriaLabel": "작업 진행 상황",
     "taskProgressAriaLabel": "AI 작업 진행률",
     "clearConversationAriaLabel": "대화 지우기",
-    "closePanelAriaLabel": "FiestaBot (Beta) 닫기"
+    "closePanelAriaLabel": "FiestaBot (Beta) 닫기",
+    "providerSelectAriaLabel": "제공자",
+    "modelSelectAriaLabel": "모델",
+    "showBoardTooltip": "보드 미리보기 표시",
+    "hideBoardTooltip": "보드 미리보기 숨기기",
+    "undoTooltip": "마지막 AI 변경 실행 취소",
+    "panelTitle": "FiestaBot (Beta)",
+    "retryButton": "다시 시도",
+    "messageLabel": "메시지",
+    "stopButton": "중지",
+    "sendButton": "보내기",
+    "tasksHeading": "작업 ({done}/{total})",
+    "emptyStateTitle": "무엇을 도와드릴까요?",
+    "emptyStateDescription": "만들거나 변경하고 싶은 내용을 설명하세요.",
+    "showBoardButton": "보드 표시",
+    "undoButton": "실행 취소",
+    "renameSummary": "→ \"{name}\"(으)로 이름 변경",
+    "previewUnavailable": "(미리보기를 사용할 수 없음)"
   },
   "boardSizeIndicator": {
     "custom": "사용자 지정",
     "ariaLabel": "{rows}행 {cols}열",
     "ariaLabelWithLayout": "{rows}행 {cols}열, {layout}"
+  },
+  "mcpSettings": {
+    "title": "MCP / 외부 클라이언트",
+    "description": "Claude Desktop, Claude Code 및 기타 MCP 클라이언트가 이 FiestaBoard와 통신할 수 있게 해주는 사전 공유 토큰입니다. 이 토큰은 단일 주체로 인증되며 {endpoint} 엔드포인트로만 범위가 제한되므로 페이지나 다른 설정은 편집할 수 없습니다. 클라이언트별 유의 사항은 <link>MCP 클라이언트 설정</link>을 참고하세요(Desktop은 stdio 프록시가 필요하고, claude.ai 웹 Connectors는 공개 HTTPS와 OAuth를 요구하므로 LAN 호스트에는 연결할 수 없습니다).",
+    "statusLabel": "상태:",
+    "pinnedByEnvBadge": "{envVar}로 고정됨",
+    "configuredBadge": "설정됨",
+    "pinnedByEnvDescription": "활성 토큰은 {envVar} 환경 변수로 설정되어 있습니다. 이 UI에서 토큰을 관리하려면 {envFile}에서 해당 변수를 해제하고 컨테이너를 재시작하세요.",
+    "noTokenDescription": "설정된 토큰이 없습니다. 외부 MCP 클라이언트는 쿠키 인증으로 대체되는데, Claude Desktop / Claude Code는 이를 지원하지 않아 알 수 없는 오류와 함께 등록에 실패합니다. 토큰을 생성해 문제를 해결하세요.",
+    "activeTokenDescription": "토큰이 설정되어 활성화되어 있습니다. 토큰을 교체하면 이전 토큰이 무효화되며(이전 토큰을 계속 사용하는 클라이언트는 401을 받게 됩니다), 완전히 해지하면 쿠키 전용 인증으로 되돌아갑니다.",
+    "rotateTokenButton": "토큰 교체",
+    "generateTokenButton": "토큰 생성",
+    "revokeTokenButton": "토큰 해지",
+    "rotateConfirmTitle": "MCP 토큰을 교체하시겠습니까?",
+    "generateConfirmTitle": "MCP 토큰을 생성하시겠습니까?",
+    "rotateConfirmDescription": "이전 토큰을 계속 사용하는 클라이언트는 다음 요청에서 401 + Bearer 챌린지로 거부됩니다. 새 토큰은 한 번만 표시되므로 안전한 곳에 보관하세요(UI에서 다시 볼 수 없습니다).",
+    "generateConfirmDescription": "토큰은 한 번만 표시됩니다 — 안전한 곳에 보관하세요(UI에서 다시 볼 수 없습니다). 외부 MCP 클라이언트는 이 토큰으로 {endpoint}에 인증합니다.",
+    "rotateConfirmButton": "교체",
+    "generateConfirmButton": "생성",
+    "revokeConfirmTitle": "MCP 토큰을 해지하시겠습니까?",
+    "revokeConfirmDescription": "외부 MCP 클라이언트는 다음 요청부터 401을 받게 됩니다. 언제든지 새 토큰을 생성할 수 있습니다.",
+    "revokeConfirmButton": "해지",
+    "revealTitle": "이 토큰을 저장하세요",
+    "revealDescription": "FiestaBoard는 이후 요청을 검증하는 데 필요한 정보만 저장합니다 — 평문 값이 표시되는 것은 지금뿐입니다. 지금 MCP 클라이언트에 복사해 두세요.",
+    "tokenLabel": "토큰",
+    "copyButton": "복사",
+    "copiedButton": "복사됨",
+    "configSnippetLabel": "Claude Desktop 설정 스니펫",
+    "configSnippetDescription": "{configPath}에 이 내용을 붙여넣어 기존 내용과 병합한 다음, Claude Desktop을 완전히 종료했다가 다시 실행하세요(⌘Q — 창을 닫는 것만으로는 부족합니다). Claude Desktop은 stdio MCP 서버만 지원하므로 이 스니펫은 {npx}를 통해 {mcpRemoteLink}를 프록시로 실행합니다 — Node 18 이상이 설치되어 있어야 하고 Claude Desktop의 PATH에서 {npx}에 접근할 수 있어야 합니다. {commandNotFound} 오류가 발생하면 {npxQuoted}를 {whichNpx}로 확인한 절대 경로로 바꾸세요.",
+    "claudeCodeDescription": "<label>Claude Code (CLI):</label> HTTP로 직접 통신하므로 프록시가 필요 없습니다.",
+    "claudeWebDescription": "<label>claude.ai 웹 (Connectors):</label> 자체 호스팅 FiestaBoard에서는 지원되지 않습니다. Connectors 방식은 공개 HTTPS URL과 OAuth 2.1 동적 클라이언트 등록을 요구하는데, LAN 호스트는 둘 다 제공할 수 없습니다. 대신 Desktop이나 Code를 사용하세요.",
+    "savedItButton": "저장했습니다",
+    "toastTokenRevoked": "MCP 토큰이 해지되었습니다",
+    "toastCopyFailed": "클립보드에 복사하지 못했습니다"
   }
 }

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -50,7 +50,8 @@
     "pageCount": "{count, plural, one {# pagina} other {# pagina's}}",
     "unknownError": "Onbekende fout",
     "opensInNewTab": "(opent in een nieuw tabblad)",
-    "notificationsRegionLabel": "Meldingen"
+    "notificationsRegionLabel": "Meldingen",
+    "versionShort": "v{version}"
   },
   "metadata": {
     "appTitle": "FiestaBoard-bediening",
@@ -81,7 +82,8 @@
     "boardSelector": "Te beheren board selecteren",
     "selectBoard": "Board selecteren",
     "unnamedBoard": "Naamloos board",
-    "transitions": "Transitielab"
+    "transitions": "Transitielab",
+    "prideCelebration": "Fijne Pride!"
   },
   "network": {
     "title": "Wi-Fi",
@@ -330,7 +332,11 @@
       "validationOneOffDateRequired": "Please pick a date",
       "validationEndDateBeforeStart": "End date must be on or after start date",
       "collectionSizeWarning": "{count} van de {total} pagina's in deze collectie passen niet bij het formaat van dit bord en worden overgeslagen.",
-      "incompatiblePageWarning": "Deze pagina past niet bij het formaat van dit bord en wordt mogelijk niet correct weergegeven."
+      "incompatiblePageWarning": "Deze pagina past niet bij het formaat van dit bord en wordt mogelijk niet correct weergegeven.",
+      "monthAriaLabel": "Maand",
+      "dayAriaLabel": "Dag",
+      "endMonthAriaLabel": "Eindmaand",
+      "endDayAriaLabel": "Einddag"
     },
     "descriptionWithTimezone": "Automatiseer paginarotatie op tijd en dag · {timezone}",
     "gapDefaultPlaceholder": "Standaard bij gat…",
@@ -472,7 +478,37 @@
     "toastNoUpdates": "Alle plugins zijn up-to-date",
     "toastCheckFailed": "Updates controleren mislukt: {error}",
     "installAction": "Installeren",
-    "installedBadge": "Geïnstalleerd"
+    "installedBadge": "Geïnstalleerd",
+    "valueUnavailable": "Niet beschikbaar",
+    "enablePluginForLiveValues": "Schakel de plugin in om live waarden te zien.",
+    "liveValuesUnavailable": "Live waarden zijn niet beschikbaar.",
+    "liveValuesUnavailableWithError": "Live waarden zijn niet beschikbaar: {error}",
+    "currentValueColumn": "Huidige waarde",
+    "refreshingValues": "vernieuwen…",
+    "sourceCoreBadge": "Kern",
+    "sourceMarketplaceBadge": "Marketplace",
+    "sourceExternalBadge": "Extern",
+    "updateAvailableBadge": "Update",
+    "moreOptionsAriaLabel": "Meer opties",
+    "addInstanceAction": "Instantie toevoegen",
+    "instanceNameInlineLabel": "Instantienaam:",
+    "addInstanceInlineHelp": "Maakt een nieuwe onafhankelijke instantie van deze plugin met een eigen configuratie. Gebruik alfanumerieke tekens, koppeltekens of underscores (1–40 tekens).",
+    "deleteInstanceConfirmTitle": "Instantie \"{label}\" verwijderen?",
+    "deletePluginConfirmTitle": "\"{name}\" verwijderen?",
+    "deleteInstanceConfirmDescription": "Hiermee worden deze instantie en de bijbehorende configuratie definitief verwijderd. Deze actie kan niet ongedaan worden gemaakt.",
+    "deletePluginConfirmDescription": "Hiermee worden de plugin en al zijn instanties definitief verwijderd. Deze actie kan niet ongedaan worden gemaakt.",
+    "demoPage": {
+      "title": "Demopagina",
+      "alreadyExists": "Er bestaat al een demopagina voor deze plugin.",
+      "createDescription": "Maak een direct bruikbare pagina die deze plugin laat zien.",
+      "recreateButton": "Opnieuw aanmaken",
+      "recreateConfirmTitle": "Demopagina opnieuw aanmaken?",
+      "recreateConfirmDescription": "Hiermee wordt de bestaande demopagina verwijderd en een nieuwe met standaardinstellingen aangemaakt. Deze actie kan niet ongedaan worden gemaakt.",
+      "creating": "Maken...",
+      "createAction": "Demopagina aanmaken",
+      "recreateAction": "Demopagina opnieuw aanmaken",
+      "requirementsWarning": "Configureer hieronder de vereiste instellingen voordat je een demopagina aanmaakt."
+    }
   },
   "settings": {
     "title": "Instellingen",
@@ -496,7 +532,43 @@
     "sectionAccount": "Account",
     "sectionAccountDescription": "Gebruikersnaam, wachtwoord en uitloggen",
     "sectionNetwork": "Netwerk",
-    "sectionNetworkDescription": "Wi-Fi en verbinding beheren"
+    "sectionNetworkDescription": "Wi-Fi en verbinding beheren",
+    "ai": {
+      "removeProviderAriaLabel": "Provider verwijderen",
+      "cardTitle": "AI-providers",
+      "cardDescription": "Configureer OpenAI-compatibele LLM's voor de paginagenerator \"Gen AI\". BYO-LLM: FiestaBoard levert nooit een sleutel mee.",
+      "privacyNotice": "Je prompts en de variabelenlijst van je ingeschakelde plugins worden rechtstreeks naar de provider verzonden die je configureert. API-sleutels worden op dit apparaat opgeslagen en nooit ergens anders naartoe gestuurd.",
+      "emptyState": "Nog geen providers geconfigureerd.",
+      "addProviderButton": "Provider toevoegen",
+      "discardButton": "Verwerpen",
+      "saveChangesButton": "Wijzigingen opslaan",
+      "defaultBadge": "Standaard",
+      "anthropicBadge": "Anthropic",
+      "makeDefaultButton": "Als standaard instellen",
+      "nameLabel": "Naam",
+      "protocolLabel": "Protocol",
+      "protocolOpenaiOption": "OpenAI-compatibel (OpenAI, OpenRouter, Groq, DeepSeek, Mistral, Together, Fireworks, Ollama, LM Studio, vLLM, …)",
+      "protocolAnthropicOption": "Anthropic (Messages API)",
+      "baseUrlLabel": "Basis-URL",
+      "quickPresetsLabel": "Snelle presets",
+      "apiKeyLabel": "API-sleutel",
+      "modelsLabel": "Modellen",
+      "defaultModelLabel": "Standaardmodel",
+      "testConnectionButton": "Verbinding testen"
+    },
+    "backup": {
+      "cardTitle": "Back-up & herstel",
+      "cardDescription": "Exporteer je volledige FiestaBoard-configuratie — bordinstellingen, pagina's, carrousels, planningen en pluginconfiguratie — als één JSON-bestand. Upload dat bestand op een nieuwe instantie om te migreren of te herstellen na een upgrade.",
+      "exportButton": "Back-up exporteren",
+      "importButton": "Back-up importeren…",
+      "reinstallPluginsLabel": "Externe plugins opnieuw installeren na import",
+      "reinstallPluginsDescription": "Indien ingeschakeld probeert FiestaBoard alle externe plugins uit de back-up te klonen die nog niet op deze instantie zijn geïnstalleerd. Hun configuratie wordt hoe dan ook uit de back-up hersteld.",
+      "sensitiveNote": "Let op: back-ups bevatten gevoelige waarden zoals API-sleutels en bordgegevens in platte tekst. Bewaar het bestand veilig en deel het niet publiekelijk.",
+      "confirmTitle": "Huidige configuratie vervangen?",
+      "confirmDescription": "Je staat op het punt <file></file> terug te zetten. Je bestaande pagina's, carrousels, planningen en configuratie worden overschreven. Van elk bestaand bestand wordt een kopie met tijdstempel bewaard naast het nieuwe, zodat je zo nodig handmatig kunt terugdraaien.",
+      "restoringButton": "Terugzetten…",
+      "restoreButton": "Back-up terugzetten"
+    }
   },
   "offline": {
     "youreOffline": "Je bent offline",
@@ -581,7 +653,10 @@
       "passwordPlaceholder": "JeWachtwoord",
       "wifiPreview": "WIFI: {ssid}",
       "passPreview": "PASS: {password}",
-      "noPassword": "(geen wachtwoord)"
+      "noPassword": "(geen wachtwoord)",
+      "addMoreHint": "Je kunt er altijd meer toevoegen via de pagina <link>Integraties</link>.",
+      "builtInBadge": "Ingebouwd",
+      "previewLabel": "Voorbeeld:"
     },
     "welcome": {
       "setupComplete": "Installatie voltooid!",
@@ -639,7 +714,9 @@
     "changeModeDisableTitle": "Roostermodus uitschakelen",
     "changeModeDisableDescription": "Schakel het rooster uit en bedien het board handmatig.",
     "changeModeDisableSuccess": "Roostermodus uitgeschakeld",
-    "collectionSizeWarning": "{count} van de {total} pagina's in deze collectie passen niet bij het formaat van dit bord en worden overgeslagen."
+    "collectionSizeWarning": "{count} van de {total} pagina's in deze collectie passen niet bij het formaat van dit bord en worden overgeslagen.",
+    "turnOffLiveModeAriaLabel": "Live-modus uitschakelen",
+    "liveModeBadge": "Live-modus"
   },
   "forceSetDialog": {
     "title": "Board forceren",
@@ -882,7 +959,10 @@
     "updateNow": "Nu bijwerken",
     "oneClickHint": "Wil je hier een één-klik \"Nu bijwerken\"-knop? Stel <profile></profile> in je <envFile></envFile> in en voer dan <command></command> uit.",
     "dialogTitle": "FiestaBoard bijwerken?",
-    "dialogDescription": "Dit haalt <version></version> op en herstart FiestaBoard. De board-weergave pauzeert ongeveer 30 seconden en deze pagina laadt automatisch opnieuw."
+    "dialogDescription": "Dit haalt <version></version> op en herstart FiestaBoard. De board-weergave pauzeert ongeveer 30 seconden en deze pagina laadt automatisch opnieuw.",
+    "intervalSelectAriaLabel": "Frequentie van updatecontrole",
+    "intervalCardDescription": "Hoe vaak FiestaBoard op de achtergrond naar een nieuwe release moet zoeken. Je ziet hier een banner zodra er een is gevonden.",
+    "lastChecked": "Laatst gecontroleerd: {time}"
   },
   "transitionSettings": {
     "title": "Bordovergangen",
@@ -1008,7 +1088,8 @@
       "Numbers": "Cijfers",
       "Symbols": "Symbolen",
       "Colors": "Kleuren"
-    }
+    },
+    "latencyMs": "{ms} ms"
   },
   "generalSettings": {
     "title": "Algemene instellingen",
@@ -1375,7 +1456,8 @@
     "flapSpeed_relaxedHint": "{ms} ms — een traag, bedachtzaam omklappen voor sfeerschermen.",
     "flapSpeedPreviewLabel": "Voorbeeld",
     "flapSpeedInactive": "Board-animaties staan uit, dus de omklapsnelheid heeft geen effect.",
-    "flapSpeedScreenOnlyNote": "Dit wijzigt alleen het board-voorbeeld op het scherm. Het tempo van de overgangen op je fysieke Vestaboard stel je apart in, onder Gedrag → Board-overgangen."
+    "flapSpeedScreenOnlyNote": "Dit wijzigt alleen het board-voorbeeld op het scherm. Het tempo van de overgangen op je fysieke Vestaboard stel je apart in, onder Gedrag → Board-overgangen.",
+    "updateAvailableBadge": "v{version} beschikbaar"
   },
   "monitor": {
     "title": "Monitor",
@@ -1647,7 +1729,8 @@
     "whiteBoard": "Wit bord",
     "deviceFlagship": "Flagship",
     "deviceNote": "Note",
-    "deviceNoteArray": "Note-array {w}×{h}"
+    "deviceNoteArray": "Note-array {w}×{h}",
+    "githubLink": "GitHub"
   },
   "boardDisplay": {
     "loading": "Board-weergave laden",
@@ -1736,7 +1819,12 @@
     "remoteOptionsSearchPlaceholder": "Zoeken…",
     "remoteOptionsCustomLabel": "Aangepaste waarde",
     "remoteOptionsCustomPlaceholder": "Voer een waarde in die niet in de lijst staat",
-    "remoteOptionsCustomAdd": "Aangepaste waarde toevoegen"
+    "remoteOptionsCustomAdd": "Aangepaste waarde toevoegen",
+    "addItemLabel": "{label} toevoegen",
+    "unknownType": "Onbekend type: {type}",
+    "pagePickerNone": "Geen (geen override)",
+    "pagePickerLoading": "Pagina's laden…",
+    "pagePickerPlaceholder": "Kies een pagina…"
   },
   "filterPicker": {
     "noFiltersAvailable": "Geen filters beschikbaar",
@@ -1744,7 +1832,8 @@
     "filterDescWrap": "Laat lange tekst over meerdere regels lopen",
     "filterDescPad": "Vult tekst aan tot de opgegeven breedte",
     "filterDescTruncate": "Kapt tekst af tot de opgegeven lengte",
-    "wrapInstruction": "|wrap: Laat lange tekst doorlopen. Laat lege regels eronder zodat tekst erin kan stromen."
+    "wrapInstruction": "Laat lange tekst doorlopen. Laat lege regels eronder zodat tekst erin kan stromen.",
+    "exampleLabel": "Voorbeeld: {example}"
   },
   "formattingPicker": {
     "noFormattingAvailable": "Geen opmaakopties beschikbaar",
@@ -1805,7 +1894,25 @@
     "alignRight": "Rechts uitlijnen",
     "syncFromBoardTooltip": "Vul sjabloon in vanaf wat momenteel op het board wordt getoond",
     "syncFromBoard": "Synchroniseren vanaf huidige board-weergave",
-    "alignment": "Uitlijning:"
+    "alignment": "Uitlijning:",
+    "undoAriaLabel": "Ongedaan maken",
+    "redoAriaLabel": "Opnieuw",
+    "cutAriaLabel": "Knippen",
+    "copyAriaLabel": "Kopiëren",
+    "pasteAriaLabel": "Plakken",
+    "removeWrappedTextAriaLabel": "Omgeslagen tekst verwijderen",
+    "colorPickerAriaLabel": "Kleurkiezer",
+    "heartCharacterAriaLabel": "Hartteken",
+    "lineCount": "{used} / {max} regels",
+    "overLineLimit": " — overschrijdt de bordlimiet van {max} regels",
+    "currentLine": "(Regel {line})",
+    "heartLabel": "hart",
+    "insertHeartTooltip": "Hartteken invoegen (alleen Note)",
+    "colorTileTooltip": "{color}-tegel (code {code}) - sleep om te verplaatsen, backspace om te verwijderen",
+    "fillSpaceTooltip": "Vulruimte - vult de resterende regelbreedte",
+    "fillSpaceRepeatTooltip": "Vulruimte herhaalt: {char}",
+    "variableFilterTooltip": "Filter: {filter}",
+    "variableMaxLengthTooltip": "Maximale lengte: {maxLength} tekens"
   },
   "variablePicker": {
     "noVariablesAvailable": "Geen variabelen beschikbaar",
@@ -1815,7 +1922,8 @@
     "searchPlaceholder": "Variabelen zoeken...",
     "indexLabel": "Index: {index}",
     "configureHint": "Configureer {arrayName} in Instellingen om geïndexeerde variabelen hier te zien.",
-    "configureExample": "Voorbeeld:"
+    "configureExample": "Voorbeeld:",
+    "noMatchingVariables": "Geen overeenkomende variabelen gevonden."
   },
   "login": {
     "signInTitle": "Inloggen bij FiestaBoard",
@@ -1873,11 +1981,62 @@
     "taskStatusAriaLabel": "Taakvoortgang",
     "taskProgressAriaLabel": "Voortgang AI-taken",
     "clearConversationAriaLabel": "Gesprek wissen",
-    "closePanelAriaLabel": "FiestaBot (Beta) sluiten"
+    "closePanelAriaLabel": "FiestaBot (Beta) sluiten",
+    "providerSelectAriaLabel": "Provider",
+    "modelSelectAriaLabel": "Model",
+    "showBoardTooltip": "Board-voorbeeld tonen",
+    "hideBoardTooltip": "Board-voorbeeld verbergen",
+    "undoTooltip": "Laatste AI-wijziging ongedaan maken",
+    "panelTitle": "FiestaBot (Beta)",
+    "retryButton": "Opnieuw proberen",
+    "messageLabel": "Bericht",
+    "stopButton": "Stoppen",
+    "sendButton": "Verzenden",
+    "tasksHeading": "Taken ({done}/{total})",
+    "emptyStateTitle": "Waarmee kan ik helpen?",
+    "emptyStateDescription": "Beschrijf wat je wilt bouwen of wijzigen.",
+    "showBoardButton": "Board tonen",
+    "undoButton": "Ongedaan maken",
+    "renameSummary": "→ hernoemen naar \"{name}\"",
+    "previewUnavailable": "(voorbeeld niet beschikbaar)"
   },
   "boardSizeIndicator": {
     "custom": "Aangepast",
     "ariaLabel": "{rows} rijen bij {cols} kolommen",
     "ariaLabelWithLayout": "{rows} rijen bij {cols} kolommen, {layout}"
+  },
+  "mcpSettings": {
+    "title": "MCP / externe clients",
+    "description": "Een vooraf gedeeld token waarmee Claude Desktop, Claude Code en andere MCP-clients met deze FiestaBoard kunnen communiceren. Het token authenticeert als één principal — alleen met toegang tot het {endpoint}-eindpunt — en kan dus geen pagina's of andere instellingen bewerken. Zie <link>MCP-client instellen</link> voor client-specifieke eigenaardigheden (Desktop heeft een stdio-proxy nodig; Connectors op claude.ai web vereisen publieke HTTPS en OAuth en bereiken dus geen host in het LAN).",
+    "statusLabel": "Status:",
+    "pinnedByEnvBadge": "Vastgezet door {envVar}",
+    "configuredBadge": "Geconfigureerd",
+    "pinnedByEnvDescription": "Het actieve token wordt ingesteld door de omgevingsvariabele {envVar}. Verwijder deze uit je {envFile} en herstart de container voordat je het token via deze interface beheert.",
+    "noTokenDescription": "Er is geen token geconfigureerd. Externe MCP-clients vallen terug op cookie-authenticatie, die Claude Desktop / Claude Code niet ondersteunen — hun registratie mislukt dan met een nietszeggende foutmelding. Genereer een token om ze te deblokkeren.",
+    "activeTokenDescription": "Er is een token geconfigureerd en actief. Roteer het om het vorige ongeldig te maken (elke client die het oude token nog gebruikt, krijgt vanaf dan 401), of trek het volledig in om terug te vallen op alleen cookie-authenticatie.",
+    "rotateTokenButton": "Token roteren",
+    "generateTokenButton": "Token genereren",
+    "revokeTokenButton": "Token intrekken",
+    "rotateConfirmTitle": "MCP-token roteren?",
+    "generateConfirmTitle": "MCP-token genereren?",
+    "rotateConfirmDescription": "Elke client die het vorige token nog gebruikt, wordt bij zijn volgende verzoek geweigerd met 401 + Bearer-challenge. Je ziet het nieuwe token één keer — bewaar het op een veilige plek (het is later niet meer uit te lezen via de interface).",
+    "generateConfirmDescription": "Je ziet het token één keer — bewaar het op een veilige plek (het is later niet meer uit te lezen via de interface). Externe MCP-clients gebruiken het om zich te authenticeren bij {endpoint}.",
+    "rotateConfirmButton": "Roteren",
+    "generateConfirmButton": "Genereren",
+    "revokeConfirmTitle": "MCP-token intrekken?",
+    "revokeConfirmDescription": "Externe MCP-clients krijgen bij hun volgende verzoek 401. Je kunt later altijd een nieuw token genereren.",
+    "revokeConfirmButton": "Intrekken",
+    "revealTitle": "Bewaar dit token",
+    "revealDescription": "FiestaBoard slaat alleen op wat nodig is om toekomstige verzoeken te verifiëren — dit is de enige keer dat de waarde in platte tekst wordt getoond. Kopieer hem nu naar je MCP-client.",
+    "tokenLabel": "Token",
+    "copyButton": "Kopiëren",
+    "copiedButton": "Gekopieerd",
+    "configSnippetLabel": "Claude Desktop-configuratiefragment",
+    "configSnippetDescription": "Plak dit in {configPath} en voeg het samen met wat er al staat. Sluit Claude Desktop daarna volledig af en start het opnieuw (⌘Q — het venster sluiten is niet genoeg). Claude Desktop ondersteunt alleen stdio-MCP-servers, dus dit fragment roept {mcpRemoteLink} aan via {npx} als proxy — Node 18+ moet geïnstalleerd zijn en {npx} bereikbaar via het PATH van Claude Desktop. Krijg je {commandNotFound}, vervang dan {npxQuoted} door het absolute pad uit {whichNpx}.",
+    "claudeCodeDescription": "<label>Claude Code (CLI):</label> communiceert rechtstreeks via HTTP — geen proxy nodig.",
+    "claudeWebDescription": "<label>claude.ai web (Connectors):</label> wordt niet ondersteund voor een zelf gehoste FiestaBoard. De Connectors-flow vereist een publieke HTTPS-URL en dynamische OAuth 2.1-clientregistratie, en geen van beide kan een host in het LAN bieden. Gebruik in plaats daarvan Desktop of Code.",
+    "savedItButton": "Ik heb het opgeslagen",
+    "toastTokenRevoked": "MCP-token ingetrokken",
+    "toastCopyFailed": "Kopiëren naar klembord mislukt"
   }
 }

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -50,7 +50,8 @@
     "pageCount": "{count, plural, one {# strona} few {# strony} many {# stron} other {# stron}}",
     "unknownError": "Nieznany błąd",
     "opensInNewTab": "(otwiera się w nowej karcie)",
-    "notificationsRegionLabel": "Powiadomienia"
+    "notificationsRegionLabel": "Powiadomienia",
+    "versionShort": "v{version}"
   },
   "metadata": {
     "appTitle": "Panel FiestaBoard",
@@ -81,7 +82,8 @@
     "boardSelector": "Wybierz tablicę do zarządzania",
     "selectBoard": "Wybierz tablicę",
     "unnamedBoard": "Tablica bez nazwy",
-    "transitions": "Laboratorium przejść"
+    "transitions": "Laboratorium przejść",
+    "prideCelebration": "Szczęśliwego Miesiąca Dumy!"
   },
   "network": {
     "title": "Wi-Fi",
@@ -330,7 +332,11 @@
       "validationOneOffDateRequired": "Please pick a date",
       "validationEndDateBeforeStart": "End date must be on or after start date",
       "collectionSizeWarning": "{count} z {total} stron w tej kolekcji nie pasuje do rozmiaru tej tablicy i zostaną pominięte.",
-      "incompatiblePageWarning": "Ta strona nie pasuje do rozmiaru tej tablicy i może nie wyświetlać się poprawnie."
+      "incompatiblePageWarning": "Ta strona nie pasuje do rozmiaru tej tablicy i może nie wyświetlać się poprawnie.",
+      "monthAriaLabel": "Miesiąc",
+      "dayAriaLabel": "Dzień",
+      "endMonthAriaLabel": "Miesiąc końcowy",
+      "endDayAriaLabel": "Dzień końcowy"
     },
     "descriptionWithTimezone": "Automatyzuj rotację stron według czasu i dnia · {timezone}",
     "gapDefaultPlaceholder": "Domyślna dla luki…",
@@ -472,7 +478,37 @@
     "toastNoUpdates": "Wszystkie wtyczki są aktualne",
     "toastCheckFailed": "Nie udało się sprawdzić aktualizacji: {error}",
     "installAction": "Zainstaluj",
-    "installedBadge": "Zainstalowano"
+    "installedBadge": "Zainstalowano",
+    "valueUnavailable": "Niedostępne",
+    "enablePluginForLiveValues": "Włącz wtyczkę, aby zobaczyć wartości na żywo.",
+    "liveValuesUnavailable": "Wartości na żywo są niedostępne.",
+    "liveValuesUnavailableWithError": "Wartości na żywo są niedostępne: {error}",
+    "currentValueColumn": "Bieżąca wartość",
+    "refreshingValues": "odświeżanie…",
+    "sourceCoreBadge": "Wbudowana",
+    "sourceMarketplaceBadge": "Marketplace",
+    "sourceExternalBadge": "Zewnętrzna",
+    "updateAvailableBadge": "Aktualizacja",
+    "moreOptionsAriaLabel": "Więcej opcji",
+    "addInstanceAction": "Dodaj instancję",
+    "instanceNameInlineLabel": "Nazwa instancji:",
+    "addInstanceInlineHelp": "Tworzy nową, niezależną instancję tej wtyczki z własną konfiguracją. Użyj znaków alfanumerycznych, myślników lub podkreśleń (1-40 znaków).",
+    "deleteInstanceConfirmTitle": "Usunąć instancję „{label}”?",
+    "deletePluginConfirmTitle": "Usunąć „{name}”?",
+    "deleteInstanceConfirmDescription": "Spowoduje to trwałe usunięcie tej instancji i jej konfiguracji. Tej operacji nie można cofnąć.",
+    "deletePluginConfirmDescription": "Spowoduje to trwałe usunięcie wtyczki i wszystkich jej instancji. Tej operacji nie można cofnąć.",
+    "demoPage": {
+      "title": "Strona demo",
+      "alreadyExists": "Dla tej wtyczki istnieje już strona demonstracyjna.",
+      "createDescription": "Utwórz gotową do użycia stronę prezentującą tę wtyczkę.",
+      "recreateButton": "Utwórz ponownie",
+      "recreateConfirmTitle": "Utworzyć stronę demo ponownie?",
+      "recreateConfirmDescription": "Spowoduje to usunięcie istniejącej strony demo i utworzenie nowej z ustawieniami domyślnymi. Tej operacji nie można cofnąć.",
+      "creating": "Tworzenie...",
+      "createAction": "Utwórz stronę demo",
+      "recreateAction": "Utwórz stronę demo ponownie",
+      "requirementsWarning": "Przed utworzeniem strony demo skonfiguruj wymagane ustawienia poniżej."
+    }
   },
   "settings": {
     "title": "Ustawienia",
@@ -496,7 +532,43 @@
     "sectionAccount": "Konto",
     "sectionAccountDescription": "Nazwa użytkownika, hasło i wylogowanie",
     "sectionNetwork": "Sieć",
-    "sectionNetworkDescription": "Zarządzaj Wi-Fi i łącznością"
+    "sectionNetworkDescription": "Zarządzaj Wi-Fi i łącznością",
+    "ai": {
+      "removeProviderAriaLabel": "Usuń dostawcę",
+      "cardTitle": "Dostawcy AI",
+      "cardDescription": "Skonfiguruj modele LLM zgodne z OpenAI dla generatora stron „Gen AI”. BYO-LLM: FiestaBoard nigdy nie dołącza własnego klucza.",
+      "privacyNotice": "Twoje prompty i lista zmiennych włączonych wtyczek są wysyłane bezpośrednio do skonfigurowanego przez ciebie dostawcy. Klucze API są przechowywane na tym urządzeniu i nigdy nie są wysyłane nigdzie indziej.",
+      "emptyState": "Nie skonfigurowano jeszcze żadnych dostawców.",
+      "addProviderButton": "Dodaj dostawcę",
+      "discardButton": "Odrzuć",
+      "saveChangesButton": "Zapisz zmiany",
+      "defaultBadge": "Domyślny",
+      "anthropicBadge": "Anthropic",
+      "makeDefaultButton": "Ustaw jako domyślny",
+      "nameLabel": "Nazwa",
+      "protocolLabel": "Protokół",
+      "protocolOpenaiOption": "Zgodne z OpenAI (OpenAI, OpenRouter, Groq, DeepSeek, Mistral, Together, Fireworks, Ollama, LM Studio, vLLM, …)",
+      "protocolAnthropicOption": "Anthropic (Messages API)",
+      "baseUrlLabel": "Bazowy URL",
+      "quickPresetsLabel": "Szybkie ustawienia",
+      "apiKeyLabel": "Klucz API",
+      "modelsLabel": "Modele",
+      "defaultModelLabel": "Model domyślny",
+      "testConnectionButton": "Testuj połączenie"
+    },
+    "backup": {
+      "cardTitle": "Kopia zapasowa i przywracanie",
+      "cardDescription": "Wyeksportuj całą konfigurację FiestaBoard — ustawienia boarda, strony, karuzele, harmonogramy i konfigurację wtyczek — do jednego pliku JSON. Wgraj ten plik w nowej instancji, aby przenieść dane lub odzyskać je po aktualizacji.",
+      "exportButton": "Eksportuj kopię zapasową",
+      "importButton": "Importuj kopię zapasową…",
+      "reinstallPluginsLabel": "Zainstaluj ponownie zewnętrzne wtyczki po imporcie",
+      "reinstallPluginsDescription": "Gdy ta opcja jest włączona, FiestaBoard spróbuje sklonować zewnętrzne wtyczki zapisane w kopii zapasowej, które nie są jeszcze zainstalowane w tej instancji. Ich konfiguracja i tak jest przywracana z kopii zapasowej.",
+      "sensitiveNote": "Uwaga: kopie zapasowe zawierają wrażliwe wartości, takie jak klucze API i dane dostępowe boarda, zapisane jawnym tekstem. Przechowuj plik bezpiecznie i nie udostępniaj go publicznie.",
+      "confirmTitle": "Zastąpić bieżącą konfigurację?",
+      "confirmDescription": "Zaraz przywrócisz plik <file></file>. Twoje istniejące strony, karuzele, harmonogramy i konfiguracja zostaną nadpisane. Obok każdego nowego pliku zachowywana jest kopia istniejącego z sygnaturą czasową, więc w razie potrzeby możesz ręcznie cofnąć zmiany.",
+      "restoringButton": "Przywracanie…",
+      "restoreButton": "Przywróć kopię zapasową"
+    }
   },
   "offline": {
     "youreOffline": "Jesteś offline",
@@ -581,7 +653,10 @@
       "passwordPlaceholder": "TwojeHaslo",
       "wifiPreview": "WIFI: {ssid}",
       "passPreview": "HASLO: {password}",
-      "noPassword": "(brak hasła)"
+      "noPassword": "(brak hasła)",
+      "addMoreHint": "W każdej chwili możesz dodać więcej na stronie <link>Integracje</link>.",
+      "builtInBadge": "Wbudowane",
+      "previewLabel": "Podgląd:"
     },
     "welcome": {
       "setupComplete": "Konfiguracja zakończona!",
@@ -639,7 +714,9 @@
     "changeModeDisableTitle": "Wyłącz tryb harmonogramu",
     "changeModeDisableDescription": "Wyłącz harmonogram i steruj boardem ręcznie.",
     "changeModeDisableSuccess": "Tryb harmonogramu wyłączony",
-    "collectionSizeWarning": "{count} z {total} stron w tej kolekcji nie pasuje do rozmiaru tej tablicy i zostaną pominięte."
+    "collectionSizeWarning": "{count} z {total} stron w tej kolekcji nie pasuje do rozmiaru tej tablicy i zostaną pominięte.",
+    "turnOffLiveModeAriaLabel": "Wyłącz tryb na żywo",
+    "liveModeBadge": "Tryb na żywo"
   },
   "forceSetDialog": {
     "title": "Wymuś ustawienie boarda",
@@ -882,7 +959,10 @@
     "updateNow": "Aktualizuj teraz",
     "oneClickHint": "Chcesz tu mieć przycisk jednoklikowej „Aktualizuj teraz\"? Ustaw <profile></profile> w swoim <envFile></envFile>, a następnie uruchom <command></command>.",
     "dialogTitle": "Zaktualizować FiestaBoard?",
-    "dialogDescription": "Pobrane zostanie <version></version> i FiestaBoard zostanie zrestartowany. Wyświetlacz boarda zatrzyma się na około 30 sekund, a strona przeładuje się automatycznie."
+    "dialogDescription": "Pobrane zostanie <version></version> i FiestaBoard zostanie zrestartowany. Wyświetlacz boarda zatrzyma się na około 30 sekund, a strona przeładuje się automatycznie.",
+    "intervalSelectAriaLabel": "Częstotliwość sprawdzania aktualizacji",
+    "intervalCardDescription": "Jak często FiestaBoard ma w tle sprawdzać dostępność nowego wydania. Gdy je znajdzie, zobaczysz tutaj baner.",
+    "lastChecked": "Ostatnie sprawdzenie: {time}"
   },
   "transitionSettings": {
     "title": "Przejścia tablicy",
@@ -1008,7 +1088,8 @@
       "Numbers": "Cyfry",
       "Symbols": "Symbole",
       "Colors": "Kolory"
-    }
+    },
+    "latencyMs": "{ms} ms"
   },
   "generalSettings": {
     "title": "Ustawienia ogólne",
@@ -1375,7 +1456,8 @@
     "flapSpeed_relaxedHint": "{ms} ms — powolny, wyważony obrót dla wyświetlaczy w tle.",
     "flapSpeedPreviewLabel": "Podgląd",
     "flapSpeedInactive": "Animacje boarda są wyłączone, więc szybkość obrotu nie ma znaczenia.",
-    "flapSpeedScreenOnlyNote": "To zmienia wyłącznie podgląd boarda na ekranie. Tempo przejść fizycznego Vestaboard ustawia się osobno, w Zachowanie → Przejścia boarda."
+    "flapSpeedScreenOnlyNote": "To zmienia wyłącznie podgląd boarda na ekranie. Tempo przejść fizycznego Vestaboard ustawia się osobno, w Zachowanie → Przejścia boarda.",
+    "updateAvailableBadge": "Dostępna v{version}"
   },
   "monitor": {
     "title": "Monitor",
@@ -1647,7 +1729,8 @@
     "whiteBoard": "Biała tablica",
     "deviceFlagship": "Flagship",
     "deviceNote": "Note",
-    "deviceNoteArray": "Macierz Note {w}×{h}"
+    "deviceNoteArray": "Macierz Note {w}×{h}",
+    "githubLink": "GitHub"
   },
   "boardDisplay": {
     "loading": "Ładowanie wyświetlacza boarda",
@@ -1736,7 +1819,12 @@
     "remoteOptionsSearchPlaceholder": "Szukaj…",
     "remoteOptionsCustomLabel": "Wartość niestandardowa",
     "remoteOptionsCustomPlaceholder": "Wpisz wartość spoza listy",
-    "remoteOptionsCustomAdd": "Dodaj wartość niestandardową"
+    "remoteOptionsCustomAdd": "Dodaj wartość niestandardową",
+    "addItemLabel": "Dodaj {label}",
+    "unknownType": "Nieznany typ: {type}",
+    "pagePickerNone": "Brak (bez nadpisania)",
+    "pagePickerLoading": "Ładowanie stron…",
+    "pagePickerPlaceholder": "Wybierz stronę…"
   },
   "filterPicker": {
     "noFiltersAvailable": "Brak dostępnych filtrów",
@@ -1744,7 +1832,8 @@
     "filterDescWrap": "Zawija długi tekst w wiele wierszy",
     "filterDescPad": "Dopełnia tekst do określonej szerokości",
     "filterDescTruncate": "Skraca tekst do określonej długości",
-    "wrapInstruction": "|wrap: Zawija długi tekst. Pozostaw puste wiersze poniżej, aby tekst mógł do nich płynąć."
+    "wrapInstruction": "Zawija długi tekst. Pozostaw puste wiersze poniżej, aby tekst mógł do nich płynąć.",
+    "exampleLabel": "Przykład: {example}"
   },
   "formattingPicker": {
     "noFormattingAvailable": "Brak dostępnych opcji formatowania",
@@ -1805,7 +1894,25 @@
     "alignRight": "Wyrównaj do prawej",
     "syncFromBoardTooltip": "Wypełnij szablon na podstawie tego, co aktualnie wyświetlane na boardzie",
     "syncFromBoard": "Synchronizuj z aktualnego wyświetlacza boarda",
-    "alignment": "Wyrównanie:"
+    "alignment": "Wyrównanie:",
+    "undoAriaLabel": "Cofnij",
+    "redoAriaLabel": "Ponów",
+    "cutAriaLabel": "Wytnij",
+    "copyAriaLabel": "Kopiuj",
+    "pasteAriaLabel": "Wklej",
+    "removeWrappedTextAriaLabel": "Usuń zawinięty tekst",
+    "colorPickerAriaLabel": "Wybór koloru",
+    "heartCharacterAriaLabel": "Znak serca",
+    "lineCount": "{used} / {max} linii",
+    "overLineLimit": " — przekracza limit {max} linii boarda",
+    "currentLine": "(Wiersz {line})",
+    "heartLabel": "serce",
+    "insertHeartTooltip": "Wstaw znak serca (tylko Note)",
+    "colorTileTooltip": "Kafelek {color} (kod {code}) — przeciągnij, aby przenieść, backspace, aby usunąć",
+    "fillSpaceTooltip": "Wypełnij przestrzeń — rozszerza się na pozostałą szerokość wiersza",
+    "fillSpaceRepeatTooltip": "Wypełnij przestrzeń, powtarzając: {char}",
+    "variableFilterTooltip": "Filtr: {filter}",
+    "variableMaxLengthTooltip": "Maksymalna długość: {maxLength} znaków"
   },
   "variablePicker": {
     "noVariablesAvailable": "Brak dostępnych zmiennych",
@@ -1815,7 +1922,8 @@
     "searchPlaceholder": "Szukaj zmiennych...",
     "indexLabel": "Indeks: {index}",
     "configureHint": "Skonfiguruj {arrayName} w Ustawieniach, aby zobaczyć tu indeksowane zmienne.",
-    "configureExample": "Przykład:"
+    "configureExample": "Przykład:",
+    "noMatchingVariables": "Nie znaleziono pasujących zmiennych."
   },
   "login": {
     "signInTitle": "Zaloguj się do FiestaBoard",
@@ -1873,11 +1981,62 @@
     "taskStatusAriaLabel": "Postęp zadań",
     "taskProgressAriaLabel": "Postęp zadań AI",
     "clearConversationAriaLabel": "Wyczyść rozmowę",
-    "closePanelAriaLabel": "Zamknij FiestaBot (Beta)"
+    "closePanelAriaLabel": "Zamknij FiestaBot (Beta)",
+    "providerSelectAriaLabel": "Dostawca",
+    "modelSelectAriaLabel": "Model",
+    "showBoardTooltip": "Pokaż podgląd boarda",
+    "hideBoardTooltip": "Ukryj podgląd boarda",
+    "undoTooltip": "Cofnij ostatnią zmianę AI",
+    "panelTitle": "FiestaBot (Beta)",
+    "retryButton": "Ponów",
+    "messageLabel": "Wiadomość",
+    "stopButton": "Zatrzymaj",
+    "sendButton": "Wyślij",
+    "tasksHeading": "Zadania ({done}/{total})",
+    "emptyStateTitle": "W czym mogę pomóc?",
+    "emptyStateDescription": "Opisz, co chcesz zbudować lub zmienić.",
+    "showBoardButton": "Pokaż board",
+    "undoButton": "Cofnij",
+    "renameSummary": "→ zmień nazwę na „{name}”",
+    "previewUnavailable": "(podgląd niedostępny)"
   },
   "boardSizeIndicator": {
     "custom": "Niestandardowy",
     "ariaLabel": "{rows} wierszy na {cols} kolumn",
     "ariaLabelWithLayout": "{rows} wierszy na {cols} kolumn, {layout}"
+  },
+  "mcpSettings": {
+    "title": "MCP / klienci zewnętrzni",
+    "description": "Wstępnie współdzielony token, który pozwala Claude Desktop, Claude Code i innym klientom MCP komunikować się z tym FiestaBoard. Token uwierzytelnia się jako pojedynczy podmiot — z dostępem wyłącznie do endpointu {endpoint} — więc nie może edytować stron ani innych ustawień. Zobacz <link>konfigurację klientów MCP</link>, aby poznać osobliwości poszczególnych klientów (Desktop wymaga proxy stdio; Connectors w claude.ai web wymagają publicznego HTTPS i OAuth, więc nie dotrą do hosta w sieci LAN).",
+    "statusLabel": "Status:",
+    "pinnedByEnvBadge": "Ustalony przez {envVar}",
+    "configuredBadge": "Skonfigurowano",
+    "pinnedByEnvDescription": "Aktywny token jest ustawiany przez zmienną środowiskową {envVar}. Usuń ją z pliku {envFile} i zrestartuj kontener, zanim zaczniesz zarządzać tokenem z tego interfejsu.",
+    "noTokenDescription": "Nie skonfigurowano żadnego tokenu. Zewnętrzni klienci MCP wrócą do uwierzytelniania przez cookie, którego Claude Desktop / Claude Code nie obsługują — rejestracja zakończy się niejasnym błędem. Wygeneruj token, aby je odblokować.",
+    "activeTokenDescription": "Token jest skonfigurowany i aktywny. Wymień go, aby unieważnić poprzedni (każdy klient wciąż używający starego tokenu zacznie otrzymywać 401), albo odwołaj go całkowicie, by wrócić do uwierzytelniania wyłącznie przez cookie.",
+    "rotateTokenButton": "Wymień token",
+    "generateTokenButton": "Wygeneruj token",
+    "revokeTokenButton": "Odwołaj token",
+    "rotateConfirmTitle": "Wymienić token MCP?",
+    "generateConfirmTitle": "Wygenerować token MCP?",
+    "rotateConfirmDescription": "Każdy klient wciąż używający poprzedniego tokenu przy następnym żądaniu otrzyma odmowę z kodem 401 i wyzwaniem Bearer. Nowy token zobaczysz tylko raz — zapisz go w bezpiecznym miejscu (nie da się go ponownie odczytać w interfejsie).",
+    "generateConfirmDescription": "Token zobaczysz tylko raz — zapisz go w bezpiecznym miejscu (nie da się go ponownie odczytać w interfejsie). Zewnętrzni klienci MCP użyją go do uwierzytelnienia w {endpoint}.",
+    "rotateConfirmButton": "Wymień",
+    "generateConfirmButton": "Wygeneruj",
+    "revokeConfirmTitle": "Odwołać token MCP?",
+    "revokeConfirmDescription": "Zewnętrzni klienci MCP zaczną otrzymywać 401 przy następnym żądaniu. Zawsze możesz później wygenerować nowy token.",
+    "revokeConfirmButton": "Odwołaj",
+    "revealTitle": "Zapisz ten token",
+    "revealDescription": "FiestaBoard przechowuje tylko to, co jest potrzebne do weryfikacji przyszłych żądań — to jedyny raz, kiedy wartość jest pokazywana jawnym tekstem. Skopiuj ją teraz do swojego klienta MCP.",
+    "tokenLabel": "Token",
+    "copyButton": "Kopiuj",
+    "copiedButton": "Skopiowano",
+    "configSnippetLabel": "Fragment konfiguracji Claude Desktop",
+    "configSnippetDescription": "Wklej to do {configPath}, łącząc z tym, co już tam jest, a następnie całkowicie zamknij i uruchom ponownie Claude Desktop (⌘Q — zamknięcie okna nie wystarczy). Claude Desktop obsługuje tylko serwery MCP w trybie stdio, więc ten fragment uruchamia {mcpRemoteLink} przez {npx} jako proxy — musisz mieć zainstalowany Node 18+, a {npx} musi być dostępny w PATH Claude Desktop. Jeśli pojawi się błąd {commandNotFound}, zastąp {npxQuoted} bezwzględną ścieżką z {whichNpx}.",
+    "claudeCodeDescription": "<label>Claude Code (CLI):</label> komunikuje się bezpośrednio przez HTTP — proxy nie jest potrzebne.",
+    "claudeWebDescription": "<label>claude.ai web (Connectors):</label> nieobsługiwane w samodzielnie hostowanym FiestaBoard. Przepływ Connectors wymaga publicznego adresu HTTPS i dynamicznej rejestracji klienta OAuth 2.1, a host w sieci LAN nie zapewnia żadnej z tych rzeczy. Użyj zamiast tego Desktop lub Code.",
+    "savedItButton": "Zapisane",
+    "toastTokenRevoked": "Token MCP odwołany",
+    "toastCopyFailed": "Nie udało się skopiować do schowka"
   }
 }

--- a/web/messages/pt.json
+++ b/web/messages/pt.json
@@ -50,7 +50,8 @@
     "pageCount": "{count, plural, one {# página} other {# páginas}}",
     "unknownError": "Erro desconhecido",
     "opensInNewTab": "(abre numa nova aba)",
-    "notificationsRegionLabel": "Notificações"
+    "notificationsRegionLabel": "Notificações",
+    "versionShort": "v{version}"
   },
   "metadata": {
     "appTitle": "Painel FiestaBoard",
@@ -81,7 +82,8 @@
     "boardSelector": "Selecionar quadro a gerir",
     "selectBoard": "Selecionar quadro",
     "unnamedBoard": "Quadro sem nome",
-    "transitions": "Laboratório de transições"
+    "transitions": "Laboratório de transições",
+    "prideCelebration": "Feliz Orgulho!"
   },
   "network": {
     "title": "Wi-Fi",
@@ -330,7 +332,11 @@
       "validationOneOffDateRequired": "Please pick a date",
       "validationEndDateBeforeStart": "End date must be on or after start date",
       "collectionSizeWarning": "{count} de {total} páginas desta coleção não se ajustam ao tamanho deste quadro e serão ignoradas.",
-      "incompatiblePageWarning": "Esta página não corresponde ao tamanho deste quadro e pode não ser exibida corretamente."
+      "incompatiblePageWarning": "Esta página não corresponde ao tamanho deste quadro e pode não ser exibida corretamente.",
+      "monthAriaLabel": "Mês",
+      "dayAriaLabel": "Dia",
+      "endMonthAriaLabel": "Mês de fim",
+      "endDayAriaLabel": "Dia de fim"
     },
     "descriptionWithTimezone": "Automatize a rotação de páginas por hora e dia · {timezone}",
     "gapDefaultPlaceholder": "Predefinida para intervalo…",
@@ -472,7 +478,37 @@
     "toastNoUpdates": "Todos os plugins estão atualizados",
     "toastCheckFailed": "Falha ao procurar atualizações: {error}",
     "installAction": "Instalar",
-    "installedBadge": "Instalado"
+    "installedBadge": "Instalado",
+    "valueUnavailable": "Indisponível",
+    "enablePluginForLiveValues": "Ative o plugin para ver valores em tempo real.",
+    "liveValuesUnavailable": "Os valores em tempo real estão indisponíveis.",
+    "liveValuesUnavailableWithError": "Os valores em tempo real estão indisponíveis: {error}",
+    "currentValueColumn": "Valor atual",
+    "refreshingValues": "a atualizar…",
+    "sourceCoreBadge": "Integrado",
+    "sourceMarketplaceBadge": "Marketplace",
+    "sourceExternalBadge": "Externo",
+    "updateAvailableBadge": "Atualização",
+    "moreOptionsAriaLabel": "Mais opções",
+    "addInstanceAction": "Adicionar instância",
+    "instanceNameInlineLabel": "Nome da instância:",
+    "addInstanceInlineHelp": "Cria uma nova instância independente deste plugin, com a sua própria configuração. Use caracteres alfanuméricos, hífenes ou underscores (1-40 caracteres).",
+    "deleteInstanceConfirmTitle": "Eliminar a instância «{label}»?",
+    "deletePluginConfirmTitle": "Eliminar «{name}»?",
+    "deleteInstanceConfirmDescription": "Isto irá remover permanentemente esta instância e a sua configuração. Esta ação não pode ser anulada.",
+    "deletePluginConfirmDescription": "Isto irá remover permanentemente o plugin e todas as suas instâncias. Esta ação não pode ser anulada.",
+    "demoPage": {
+      "title": "Página de demonstração",
+      "alreadyExists": "Já existe uma página de demonstração para este plugin.",
+      "createDescription": "Crie uma página pronta a usar que mostra este plugin.",
+      "recreateButton": "Recriar",
+      "recreateConfirmTitle": "Recriar a página de demonstração?",
+      "recreateConfirmDescription": "Isto irá eliminar a página de demonstração existente e criar uma nova com as definições predefinidas. Esta ação não pode ser anulada.",
+      "creating": "A criar...",
+      "createAction": "Criar página de demonstração",
+      "recreateAction": "Recriar página de demonstração",
+      "requirementsWarning": "Configure as definições obrigatórias abaixo antes de criar uma página de demonstração."
+    }
   },
   "settings": {
     "title": "Configurações",
@@ -496,7 +532,43 @@
     "sectionAccount": "Conta",
     "sectionAccountDescription": "Nome de usuário, senha e sair",
     "sectionNetwork": "Rede",
-    "sectionNetworkDescription": "Gerenciar Wi-Fi e conectividade"
+    "sectionNetworkDescription": "Gerenciar Wi-Fi e conectividade",
+    "ai": {
+      "removeProviderAriaLabel": "Remover fornecedor",
+      "cardTitle": "Fornecedores de IA",
+      "cardDescription": "Configure LLMs compatíveis com a OpenAI para o gerador de páginas «Gen AI». BYO-LLM: o FiestaBoard nunca inclui uma chave.",
+      "privacyNotice": "Os seus prompts e a lista de variáveis dos plugins ativados são enviados diretamente para o fornecedor que configurar. As chaves API são guardadas neste dispositivo e nunca são enviadas para mais lado nenhum.",
+      "emptyState": "Ainda não há fornecedores configurados.",
+      "addProviderButton": "Adicionar fornecedor",
+      "discardButton": "Descartar",
+      "saveChangesButton": "Guardar alterações",
+      "defaultBadge": "Predefinido",
+      "anthropicBadge": "Anthropic",
+      "makeDefaultButton": "Tornar predefinido",
+      "nameLabel": "Nome",
+      "protocolLabel": "Protocolo",
+      "protocolOpenaiOption": "Compatível com OpenAI (OpenAI, OpenRouter, Groq, DeepSeek, Mistral, Together, Fireworks, Ollama, LM Studio, vLLM, …)",
+      "protocolAnthropicOption": "Anthropic (Messages API)",
+      "baseUrlLabel": "URL base",
+      "quickPresetsLabel": "Predefinições rápidas",
+      "apiKeyLabel": "Chave API",
+      "modelsLabel": "Modelos",
+      "defaultModelLabel": "Modelo predefinido",
+      "testConnectionButton": "Testar ligação"
+    },
+    "backup": {
+      "cardTitle": "Backup e restauro",
+      "cardDescription": "Exporte toda a configuração do seu FiestaBoard — definições do board, páginas, carrosséis, agendamentos e configuração de plugins — num único ficheiro JSON. Carregue esse ficheiro noutra instância para migrar ou recuperar depois de uma atualização.",
+      "exportButton": "Exportar backup",
+      "importButton": "Importar backup…",
+      "reinstallPluginsLabel": "Reinstalar plugins externos após a importação",
+      "reinstallPluginsDescription": "Quando ativado, o FiestaBoard tentará clonar os plugins externos registados no backup que ainda não estejam instalados nesta instância. A configuração deles é restaurada a partir do backup em qualquer dos casos.",
+      "sensitiveNote": "Nota: os backups contêm valores sensíveis, como chaves API e credenciais do board, em texto simples. Guarde o ficheiro em segurança e não o partilhe publicamente.",
+      "confirmTitle": "Substituir a configuração atual?",
+      "confirmDescription": "Está prestes a restaurar <file></file>. As suas páginas, carrosséis, agendamentos e configuração existentes serão substituídos. É guardada uma cópia com data e hora de cada ficheiro existente junto ao novo, para poder reverter manualmente se for necessário.",
+      "restoringButton": "A restaurar…",
+      "restoreButton": "Restaurar backup"
+    }
   },
   "offline": {
     "youreOffline": "Você Está Offline",
@@ -581,7 +653,10 @@
       "passwordPlaceholder": "SuaSenha",
       "wifiPreview": "WIFI: {ssid}",
       "passPreview": "SENHA: {password}",
-      "noPassword": "(sem senha)"
+      "noPassword": "(sem senha)",
+      "addMoreHint": "Pode adicionar mais a qualquer momento na página <link>Integrações</link>.",
+      "builtInBadge": "Integrado",
+      "previewLabel": "Pré-visualização:"
     },
     "welcome": {
       "setupComplete": "Configuração Concluída!",
@@ -639,7 +714,9 @@
     "changeModeDisableTitle": "Desativar modo de agendamento",
     "changeModeDisableDescription": "Desativar o agendamento e controlar o board manualmente.",
     "changeModeDisableSuccess": "Modo de agendamento desativado",
-    "collectionSizeWarning": "{count} de {total} páginas desta coleção não se ajustam ao tamanho deste quadro e serão ignoradas."
+    "collectionSizeWarning": "{count} de {total} páginas desta coleção não se ajustam ao tamanho deste quadro e serão ignoradas.",
+    "turnOffLiveModeAriaLabel": "Desativar o modo ao vivo",
+    "liveModeBadge": "Modo ao vivo"
   },
   "forceSetDialog": {
     "title": "Forçar board",
@@ -882,7 +959,10 @@
     "updateNow": "Atualizar agora",
     "oneClickHint": "Quer aqui um botão de «Atualizar agora» com um clique? Defina <profile></profile> no seu <envFile></envFile>, depois execute <command></command>.",
     "dialogTitle": "Atualizar FiestaBoard?",
-    "dialogDescription": "Isto irá obter <version></version> e reiniciar o FiestaBoard. O ecrã do board ficará em pausa cerca de 30 segundos e esta página será recarregada automaticamente."
+    "dialogDescription": "Isto irá obter <version></version> e reiniciar o FiestaBoard. O ecrã do board ficará em pausa cerca de 30 segundos e esta página será recarregada automaticamente.",
+    "intervalSelectAriaLabel": "Frequência de verificação de atualizações",
+    "intervalCardDescription": "Com que frequência o FiestaBoard deve procurar uma nova versão em segundo plano. Verá aqui um aviso quando for encontrada.",
+    "lastChecked": "Última verificação: {time}"
   },
   "transitionSettings": {
     "title": "Transições do Painel",
@@ -1008,7 +1088,8 @@
       "Numbers": "Números",
       "Symbols": "Símbolos",
       "Colors": "Cores"
-    }
+    },
+    "latencyMs": "{ms} ms"
   },
   "generalSettings": {
     "title": "Configurações Gerais",
@@ -1375,7 +1456,8 @@
     "flapSpeed_relaxedHint": "{ms} ms — uma viragem lenta e deliberada para ecrãs de ambiente.",
     "flapSpeedPreviewLabel": "Pré-visualização",
     "flapSpeedInactive": "As animações do board estão desligadas, por isso a velocidade de viragem não tem efeito.",
-    "flapSpeedScreenOnlyNote": "Isto altera apenas a pré-visualização do board no ecrã. O ritmo das transições do seu Vestaboard físico define-se à parte, em Comportamento → Transições do board."
+    "flapSpeedScreenOnlyNote": "Isto altera apenas a pré-visualização do board no ecrã. O ritmo das transições do seu Vestaboard físico define-se à parte, em Comportamento → Transições do board.",
+    "updateAvailableBadge": "v{version} disponível"
   },
   "monitor": {
     "title": "Monitor",
@@ -1647,7 +1729,8 @@
     "whiteBoard": "Painel branco",
     "deviceFlagship": "Flagship",
     "deviceNote": "Note",
-    "deviceNoteArray": "Matriz Note {w}×{h}"
+    "deviceNoteArray": "Matriz Note {w}×{h}",
+    "githubLink": "GitHub"
   },
   "boardDisplay": {
     "loading": "A carregar visualização do board",
@@ -1736,7 +1819,12 @@
     "remoteOptionsSearchPlaceholder": "Pesquisar…",
     "remoteOptionsCustomLabel": "Valor personalizado",
     "remoteOptionsCustomPlaceholder": "Introduza um valor que não esteja na lista",
-    "remoteOptionsCustomAdd": "Adicionar valor personalizado"
+    "remoteOptionsCustomAdd": "Adicionar valor personalizado",
+    "addItemLabel": "Adicionar {label}",
+    "unknownType": "Tipo desconhecido: {type}",
+    "pagePickerNone": "Nenhuma (sem substituição)",
+    "pagePickerLoading": "A carregar páginas…",
+    "pagePickerPlaceholder": "Escolha uma página…"
   },
   "filterPicker": {
     "noFiltersAvailable": "Nenhum filtro disponível",
@@ -1744,7 +1832,8 @@
     "filterDescWrap": "Quebra texto longo em várias linhas",
     "filterDescPad": "Preenche texto até à largura especificada",
     "filterDescTruncate": "Trunca o texto ao comprimento especificado",
-    "wrapInstruction": "|wrap: Quebra texto longo. Deixe linhas vazias abaixo para o texto fluir."
+    "wrapInstruction": "Quebra texto longo. Deixe linhas vazias abaixo para o texto fluir.",
+    "exampleLabel": "Exemplo: {example}"
   },
   "formattingPicker": {
     "noFormattingAvailable": "Nenhuma opção de formatação disponível",
@@ -1805,7 +1894,25 @@
     "alignRight": "Alinhar à direita",
     "syncFromBoardTooltip": "Preencher o modelo com o que está atualmente no board",
     "syncFromBoard": "Sincronizar do ecrã atual do board",
-    "alignment": "Alinhamento:"
+    "alignment": "Alinhamento:",
+    "undoAriaLabel": "Anular",
+    "redoAriaLabel": "Refazer",
+    "cutAriaLabel": "Cortar",
+    "copyAriaLabel": "Copiar",
+    "pasteAriaLabel": "Colar",
+    "removeWrappedTextAriaLabel": "Remover texto quebrado",
+    "colorPickerAriaLabel": "Seletor de cores",
+    "heartCharacterAriaLabel": "Carácter de coração",
+    "lineCount": "{used} / {max} linhas",
+    "overLineLimit": " — excede o limite de {max} linhas do board",
+    "currentLine": "(Linha {line})",
+    "heartLabel": "coração",
+    "insertHeartTooltip": "Inserir carácter de coração (apenas Note)",
+    "colorTileTooltip": "Bloco {color} (código {code}) - arraste para mover, backspace para eliminar",
+    "fillSpaceTooltip": "Preencher espaço - expande-se para ocupar a largura restante da linha",
+    "fillSpaceRepeatTooltip": "Preencher espaço repetindo: {char}",
+    "variableFilterTooltip": "Filtro: {filter}",
+    "variableMaxLengthTooltip": "Comprimento máximo: {maxLength} caracteres"
   },
   "variablePicker": {
     "noVariablesAvailable": "Nenhuma variável disponível",
@@ -1815,7 +1922,8 @@
     "searchPlaceholder": "Pesquisar variáveis...",
     "indexLabel": "Índice: {index}",
     "configureHint": "Configure {arrayName} em Definições para ver aqui variáveis indexadas.",
-    "configureExample": "Exemplo:"
+    "configureExample": "Exemplo:",
+    "noMatchingVariables": "Não foram encontradas variáveis correspondentes."
   },
   "login": {
     "signInTitle": "Entrar no FiestaBoard",
@@ -1873,11 +1981,62 @@
     "taskStatusAriaLabel": "Progresso das tarefas",
     "taskProgressAriaLabel": "Progresso das tarefas de IA",
     "clearConversationAriaLabel": "Limpar conversa",
-    "closePanelAriaLabel": "Fechar FiestaBot (Beta)"
+    "closePanelAriaLabel": "Fechar FiestaBot (Beta)",
+    "providerSelectAriaLabel": "Fornecedor",
+    "modelSelectAriaLabel": "Modelo",
+    "showBoardTooltip": "Mostrar pré-visualização do board",
+    "hideBoardTooltip": "Ocultar pré-visualização do board",
+    "undoTooltip": "Anular a última alteração da IA",
+    "panelTitle": "FiestaBot (Beta)",
+    "retryButton": "Tentar novamente",
+    "messageLabel": "Mensagem",
+    "stopButton": "Parar",
+    "sendButton": "Enviar",
+    "tasksHeading": "Tarefas ({done}/{total})",
+    "emptyStateTitle": "Como posso ajudar?",
+    "emptyStateDescription": "Descreva o que quer criar ou alterar.",
+    "showBoardButton": "Mostrar board",
+    "undoButton": "Anular",
+    "renameSummary": "→ renomear para «{name}»",
+    "previewUnavailable": "(pré-visualização indisponível)"
   },
   "boardSizeIndicator": {
     "custom": "Personalizado",
     "ariaLabel": "{rows} linhas por {cols} colunas",
     "ariaLabelWithLayout": "{rows} linhas por {cols} colunas, {layout}"
+  },
+  "mcpSettings": {
+    "title": "MCP / clientes externos",
+    "description": "Um token pré-partilhado que permite ao Claude Desktop, ao Claude Code e a outros clientes MCP comunicar com este FiestaBoard. O token autentica-se como uma única identidade — limitada apenas ao endpoint {endpoint} — pelo que não pode editar páginas nem outras definições. Consulte a <link>configuração de clientes MCP</link> para conhecer as particularidades de cada cliente (o Desktop precisa de um proxy stdio; os Connectors do claude.ai web exigem HTTPS público e OAuth, por isso não chegam a um host na LAN).",
+    "statusLabel": "Estado:",
+    "pinnedByEnvBadge": "Fixado por {envVar}",
+    "configuredBadge": "Configurado",
+    "pinnedByEnvDescription": "O token ativo é definido pela variável de ambiente {envVar}. Remova-a do seu {envFile} e reinicie o contentor antes de gerir o token a partir desta interface.",
+    "noTokenDescription": "Não há nenhum token configurado. Os clientes MCP externos recorrerão à autenticação por cookie, que o Claude Desktop / Claude Code não suportam — o registo falhará com um erro pouco claro. Gere um token para os desbloquear.",
+    "activeTokenDescription": "Existe um token configurado e ativo. Renove-o para invalidar o anterior (qualquer cliente que continue a usar o token antigo começará a receber 401) ou revogue-o por completo para voltar à autenticação apenas por cookie.",
+    "rotateTokenButton": "Renovar token",
+    "generateTokenButton": "Gerar token",
+    "revokeTokenButton": "Revogar token",
+    "rotateConfirmTitle": "Renovar o token MCP?",
+    "generateConfirmTitle": "Gerar token MCP?",
+    "rotateConfirmDescription": "Qualquer cliente que continue a usar o token anterior será recusado com um 401 + desafio Bearer no próximo pedido. Verá o novo token apenas uma vez — guarde-o num local seguro (não é possível voltar a lê-lo na interface).",
+    "generateConfirmDescription": "Verá o token apenas uma vez — guarde-o num local seguro (não é possível voltar a lê-lo na interface). Os clientes MCP externos vão usá-lo para se autenticarem em {endpoint}.",
+    "rotateConfirmButton": "Renovar",
+    "generateConfirmButton": "Gerar",
+    "revokeConfirmTitle": "Revogar o token MCP?",
+    "revokeConfirmDescription": "Os clientes MCP externos começarão a receber 401 no próximo pedido. Pode sempre gerar um novo token mais tarde.",
+    "revokeConfirmButton": "Revogar",
+    "revealTitle": "Guarde este token",
+    "revealDescription": "O FiestaBoard guarda apenas o necessário para verificar pedidos futuros — esta é a única vez que o valor é mostrado em texto simples. Copie-o agora para o seu cliente MCP.",
+    "tokenLabel": "Token",
+    "copyButton": "Copiar",
+    "copiedButton": "Copiado",
+    "configSnippetLabel": "Excerto de configuração do Claude Desktop",
+    "configSnippetDescription": "Cole isto em {configPath}, juntando ao que já lá estiver, e depois saia por completo do Claude Desktop e volte a abri-lo (⌘Q — fechar a janela não chega). O Claude Desktop só suporta servidores MCP stdio, por isso este excerto invoca {mcpRemoteLink} através de {npx} como proxy — tem de ter o Node 18+ instalado e o {npx} acessível a partir do PATH do Claude Desktop. Se der o erro {commandNotFound}, substitua {npxQuoted} pelo caminho absoluto indicado por {whichNpx}.",
+    "claudeCodeDescription": "<label>Claude Code (CLI):</label> comunica diretamente por HTTP — não é preciso proxy.",
+    "claudeWebDescription": "<label>claude.ai web (Connectors):</label> não é suportado num FiestaBoard alojado por si. O fluxo dos Connectors exige um URL HTTPS público e registo dinâmico de clientes OAuth 2.1, e um host na LAN não fornece nenhum dos dois. Use antes o Desktop ou o Code.",
+    "savedItButton": "Já o guardei",
+    "toastTokenRevoked": "Token MCP revogado",
+    "toastCopyFailed": "Não foi possível copiar para a área de transferência"
   }
 }

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -50,7 +50,8 @@
     "pageCount": "{count, plural, one {# страница} few {# страницы} many {# страниц} other {# страниц}}",
     "unknownError": "Неизвестная ошибка",
     "opensInNewTab": "(откроется в новой вкладке)",
-    "notificationsRegionLabel": "Уведомления"
+    "notificationsRegionLabel": "Уведомления",
+    "versionShort": "v{version}"
   },
   "metadata": {
     "appTitle": "Управление FiestaBoard",
@@ -81,7 +82,8 @@
     "boardSelector": "Выберите доску для управления",
     "selectBoard": "Выберите доску",
     "unnamedBoard": "Доска без названия",
-    "transitions": "Лаборатория переходов"
+    "transitions": "Лаборатория переходов",
+    "prideCelebration": "С месяцем гордости!"
   },
   "network": {
     "title": "Wi-Fi",
@@ -330,7 +332,11 @@
       "validationOneOffDateRequired": "Please pick a date",
       "validationEndDateBeforeStart": "End date must be on or after start date",
       "collectionSizeWarning": "{count} из {total} страниц в этой коллекции не подходят под размер этой доски и будут пропущены.",
-      "incompatiblePageWarning": "Эта страница не подходит под размер этой доски и может отображаться некорректно."
+      "incompatiblePageWarning": "Эта страница не подходит под размер этой доски и может отображаться некорректно.",
+      "monthAriaLabel": "Месяц",
+      "dayAriaLabel": "День",
+      "endMonthAriaLabel": "Месяц окончания",
+      "endDayAriaLabel": "День окончания"
     },
     "descriptionWithTimezone": "Автоматизация смены страниц по времени и дню · {timezone}",
     "gapDefaultPlaceholder": "По умолчанию для пропуска…",
@@ -472,7 +478,37 @@
     "toastNoUpdates": "Все плагины актуальны",
     "toastCheckFailed": "Не удалось проверить обновления: {error}",
     "installAction": "Установить",
-    "installedBadge": "Установлено"
+    "installedBadge": "Установлено",
+    "valueUnavailable": "Недоступно",
+    "enablePluginForLiveValues": "Включите плагин, чтобы видеть текущие значения.",
+    "liveValuesUnavailable": "Текущие значения недоступны.",
+    "liveValuesUnavailableWithError": "Текущие значения недоступны: {error}",
+    "currentValueColumn": "Текущее значение",
+    "refreshingValues": "обновление…",
+    "sourceCoreBadge": "Базовый",
+    "sourceMarketplaceBadge": "Marketplace",
+    "sourceExternalBadge": "Внешний",
+    "updateAvailableBadge": "Обновление",
+    "moreOptionsAriaLabel": "Другие параметры",
+    "addInstanceAction": "Добавить экземпляр",
+    "instanceNameInlineLabel": "Имя экземпляра:",
+    "addInstanceInlineHelp": "Создаёт новый независимый экземпляр этого плагина с собственной конфигурацией. Используйте буквенно-цифровые символы, дефисы или подчёркивания (1–40 символов).",
+    "deleteInstanceConfirmTitle": "Удалить экземпляр «{label}»?",
+    "deletePluginConfirmTitle": "Удалить «{name}»?",
+    "deleteInstanceConfirmDescription": "Этот экземпляр и его конфигурация будут безвозвратно удалены. Это действие нельзя отменить.",
+    "deletePluginConfirmDescription": "Плагин и все его экземпляры будут безвозвратно удалены. Это действие нельзя отменить.",
+    "demoPage": {
+      "title": "Демо-страница",
+      "alreadyExists": "Для этого плагина уже есть демо-страница.",
+      "createDescription": "Создайте готовую страницу, которая демонстрирует этот плагин.",
+      "recreateButton": "Пересоздать",
+      "recreateConfirmTitle": "Пересоздать демо-страницу?",
+      "recreateConfirmDescription": "Существующая демо-страница будет удалена, а вместо неё создана новая с настройками по умолчанию. Это действие нельзя отменить.",
+      "creating": "Создание...",
+      "createAction": "Создать демо-страницу",
+      "recreateAction": "Пересоздать демо-страницу",
+      "requirementsWarning": "Настройте обязательные параметры ниже, прежде чем создавать демо-страницу."
+    }
   },
   "settings": {
     "title": "Настройки",
@@ -496,7 +532,43 @@
     "sectionAccount": "Учётная запись",
     "sectionAccountDescription": "Имя пользователя, пароль и выход",
     "sectionNetwork": "Сеть",
-    "sectionNetworkDescription": "Управление Wi-Fi и подключением"
+    "sectionNetworkDescription": "Управление Wi-Fi и подключением",
+    "ai": {
+      "removeProviderAriaLabel": "Удалить провайдера",
+      "cardTitle": "ИИ-провайдеры",
+      "cardDescription": "Настройте OpenAI-совместимые LLM для генератора страниц «Gen AI». BYO-LLM: FiestaBoard никогда не поставляется с ключом.",
+      "privacyNotice": "Ваши запросы и список переменных включённых плагинов отправляются напрямую тому провайдеру, которого вы настроили. API-ключи хранятся на этом устройстве и никуда больше не отправляются.",
+      "emptyState": "Провайдеры ещё не настроены.",
+      "addProviderButton": "Добавить провайдера",
+      "discardButton": "Отменить",
+      "saveChangesButton": "Сохранить изменения",
+      "defaultBadge": "По умолчанию",
+      "anthropicBadge": "Anthropic",
+      "makeDefaultButton": "Сделать основным",
+      "nameLabel": "Название",
+      "protocolLabel": "Протокол",
+      "protocolOpenaiOption": "OpenAI-совместимый (OpenAI, OpenRouter, Groq, DeepSeek, Mistral, Together, Fireworks, Ollama, LM Studio, vLLM, …)",
+      "protocolAnthropicOption": "Anthropic (Messages API)",
+      "baseUrlLabel": "Базовый URL",
+      "quickPresetsLabel": "Быстрые пресеты",
+      "apiKeyLabel": "API-ключ",
+      "modelsLabel": "Модели",
+      "defaultModelLabel": "Модель по умолчанию",
+      "testConnectionButton": "Проверить подключение"
+    },
+    "backup": {
+      "cardTitle": "Резервное копирование и восстановление",
+      "cardDescription": "Экспортируйте всю конфигурацию FiestaBoard — настройки доски, страницы, карусели, расписания и конфигурацию плагинов — в один файл JSON. Загрузите этот файл на новом экземпляре, чтобы перенести данные или восстановить их после обновления.",
+      "exportButton": "Экспортировать резервную копию",
+      "importButton": "Импортировать резервную копию…",
+      "reinstallPluginsLabel": "Переустановить внешние плагины после импорта",
+      "reinstallPluginsDescription": "Если включено, FiestaBoard попытается клонировать те внешние плагины из резервной копии, которые ещё не установлены в этом экземпляре. Их конфигурация восстанавливается из резервной копии в любом случае.",
+      "sensitiveNote": "Примечание: резервные копии содержат конфиденциальные данные, такие как API-ключи и учётные данные доски, в открытом виде. Храните файл в надёжном месте и не публикуйте его.",
+      "confirmTitle": "Заменить текущую конфигурацию?",
+      "confirmDescription": "Сейчас будет восстановлен файл <file></file>. Ваши текущие страницы, карусели, расписания и конфигурация будут перезаписаны. Рядом с новым файлом сохраняется копия каждого существующего файла с меткой времени, чтобы при необходимости вы могли откатиться вручную.",
+      "restoringButton": "Восстановление…",
+      "restoreButton": "Восстановить из резервной копии"
+    }
   },
   "offline": {
     "youreOffline": "Вы не в сети",
@@ -581,7 +653,10 @@
       "passwordPlaceholder": "ВашПароль",
       "wifiPreview": "WIFI: {ssid}",
       "passPreview": "PASS: {password}",
-      "noPassword": "(без пароля)"
+      "noPassword": "(без пароля)",
+      "addMoreHint": "Вы можете в любой момент добавить ещё на странице <link>Интеграции</link>.",
+      "builtInBadge": "Встроенный",
+      "previewLabel": "Предпросмотр:"
     },
     "welcome": {
       "setupComplete": "Настройка завершена!",
@@ -639,7 +714,9 @@
     "changeModeDisableTitle": "Отключить режим расписания",
     "changeModeDisableDescription": "Отключите расписание и управляйте board вручную.",
     "changeModeDisableSuccess": "Режим расписания отключён",
-    "collectionSizeWarning": "{count} из {total} страниц в этой коллекции не подходят под размер этой доски и будут пропущены."
+    "collectionSizeWarning": "{count} из {total} страниц в этой коллекции не подходят под размер этой доски и будут пропущены.",
+    "turnOffLiveModeAriaLabel": "Отключить живой режим",
+    "liveModeBadge": "Живой режим"
   },
   "forceSetDialog": {
     "title": "Принудительно установить board",
@@ -882,7 +959,10 @@
     "updateNow": "Обновить сейчас",
     "oneClickHint": "Хотите кнопку «Обновить сейчас» одним нажатием? Установите <profile></profile> в вашем <envFile></envFile>, затем выполните <command></command>.",
     "dialogTitle": "Обновить FiestaBoard?",
-    "dialogDescription": "Это загрузит <version></version> и перезапустит FiestaBoard. Дисплей board остановится примерно на 30 секунд, и эта страница автоматически перезагрузится."
+    "dialogDescription": "Это загрузит <version></version> и перезапустит FiestaBoard. Дисплей board остановится примерно на 30 секунд, и эта страница автоматически перезагрузится.",
+    "intervalSelectAriaLabel": "Частота проверки обновлений",
+    "intervalCardDescription": "Как часто FiestaBoard должен искать новый релиз в фоновом режиме. Когда релиз найдётся, здесь появится баннер.",
+    "lastChecked": "Последняя проверка: {time}"
   },
   "transitionSettings": {
     "title": "Переходы доски",
@@ -1008,7 +1088,8 @@
       "Numbers": "Цифры",
       "Symbols": "Символы",
       "Colors": "Цвета"
-    }
+    },
+    "latencyMs": "{ms} мс"
   },
   "generalSettings": {
     "title": "Общие настройки",
@@ -1375,7 +1456,8 @@
     "flapSpeed_relaxedHint": "{ms} мс — медленный, размеренный переворот для фоновых дисплеев.",
     "flapSpeedPreviewLabel": "Предпросмотр",
     "flapSpeedInactive": "Анимации board отключены, поэтому скорость переворота ни на что не влияет.",
-    "flapSpeedScreenOnlyNote": "Это меняет только предпросмотр board на экране. Темп переходов физического Vestaboard настраивается отдельно, в разделе «Поведение → Переходы board»."
+    "flapSpeedScreenOnlyNote": "Это меняет только предпросмотр board на экране. Темп переходов физического Vestaboard настраивается отдельно, в разделе «Поведение → Переходы board».",
+    "updateAvailableBadge": "Доступна v{version}"
   },
   "monitor": {
     "title": "Монитор",
@@ -1647,7 +1729,8 @@
     "whiteBoard": "Белое табло",
     "deviceFlagship": "Flagship",
     "deviceNote": "Note",
-    "deviceNoteArray": "Массив Note {w}×{h}"
+    "deviceNoteArray": "Массив Note {w}×{h}",
+    "githubLink": "GitHub"
   },
   "boardDisplay": {
     "loading": "Загрузка дисплея board",
@@ -1736,7 +1819,12 @@
     "remoteOptionsSearchPlaceholder": "Поиск…",
     "remoteOptionsCustomLabel": "Своё значение",
     "remoteOptionsCustomPlaceholder": "Введите значение, которого нет в списке",
-    "remoteOptionsCustomAdd": "Добавить своё значение"
+    "remoteOptionsCustomAdd": "Добавить своё значение",
+    "addItemLabel": "Добавить {label}",
+    "unknownType": "Неизвестный тип: {type}",
+    "pagePickerNone": "Нет (без переопределения)",
+    "pagePickerLoading": "Загрузка страниц…",
+    "pagePickerPlaceholder": "Выберите страницу…"
   },
   "filterPicker": {
     "noFiltersAvailable": "Нет доступных фильтров",
@@ -1744,7 +1832,8 @@
     "filterDescWrap": "Переносит длинный текст на несколько строк",
     "filterDescPad": "Дополняет текст до заданной ширины",
     "filterDescTruncate": "Обрезает текст до заданной длины",
-    "wrapInstruction": "|wrap: Переносит длинный текст. Оставьте пустые строки ниже, чтобы текст мог в них перетекать."
+    "wrapInstruction": "Переносит длинный текст. Оставьте пустые строки ниже, чтобы текст мог в них перетекать.",
+    "exampleLabel": "Пример: {example}"
   },
   "formattingPicker": {
     "noFormattingAvailable": "Нет доступных опций форматирования",
@@ -1805,7 +1894,25 @@
     "alignRight": "Выровнять по правому краю",
     "syncFromBoardTooltip": "Заполнить шаблон из того, что сейчас отображается на board",
     "syncFromBoard": "Синхронизировать из текущего дисплея board",
-    "alignment": "Выравнивание:"
+    "alignment": "Выравнивание:",
+    "undoAriaLabel": "Отменить",
+    "redoAriaLabel": "Повторить",
+    "cutAriaLabel": "Вырезать",
+    "copyAriaLabel": "Копировать",
+    "pasteAriaLabel": "Вставить",
+    "removeWrappedTextAriaLabel": "Удалить перенесённый текст",
+    "colorPickerAriaLabel": "Выбор цвета",
+    "heartCharacterAriaLabel": "Символ сердца",
+    "lineCount": "{used} / {max} строк",
+    "overLineLimit": " — превышает лимит доски в {max} строк",
+    "currentLine": "(Строка {line})",
+    "heartLabel": "сердце",
+    "insertHeartTooltip": "Вставить символ сердца (только Note)",
+    "colorTileTooltip": "Плитка «{color}» (код {code}) — перетащите, чтобы переместить, backspace, чтобы удалить",
+    "fillSpaceTooltip": "Заполнение пробела — растягивается на оставшуюся ширину строки",
+    "fillSpaceRepeatTooltip": "Заполнение пробела повторением: {char}",
+    "variableFilterTooltip": "Фильтр: {filter}",
+    "variableMaxLengthTooltip": "Максимальная длина: {maxLength} символов"
   },
   "variablePicker": {
     "noVariablesAvailable": "Нет доступных переменных",
@@ -1815,7 +1922,8 @@
     "searchPlaceholder": "Поиск переменных...",
     "indexLabel": "Индекс: {index}",
     "configureHint": "Настройте {arrayName} в Настройках, чтобы видеть здесь индексированные переменные.",
-    "configureExample": "Пример:"
+    "configureExample": "Пример:",
+    "noMatchingVariables": "Подходящих переменных не найдено."
   },
   "login": {
     "signInTitle": "Войти в FiestaBoard",
@@ -1873,11 +1981,62 @@
     "taskStatusAriaLabel": "Ход выполнения задач",
     "taskProgressAriaLabel": "Прогресс задач ИИ",
     "clearConversationAriaLabel": "Очистить разговор",
-    "closePanelAriaLabel": "Закрыть FiestaBot (Beta)"
+    "closePanelAriaLabel": "Закрыть FiestaBot (Beta)",
+    "providerSelectAriaLabel": "Провайдер",
+    "modelSelectAriaLabel": "Модель",
+    "showBoardTooltip": "Показать предпросмотр доски",
+    "hideBoardTooltip": "Скрыть предпросмотр доски",
+    "undoTooltip": "Отменить последнее изменение ИИ",
+    "panelTitle": "FiestaBot (Beta)",
+    "retryButton": "Повторить",
+    "messageLabel": "Сообщение",
+    "stopButton": "Остановить",
+    "sendButton": "Отправить",
+    "tasksHeading": "Задачи ({done}/{total})",
+    "emptyStateTitle": "Чем я могу помочь?",
+    "emptyStateDescription": "Опишите, что вы хотите создать или изменить.",
+    "showBoardButton": "Показать доску",
+    "undoButton": "Отменить",
+    "renameSummary": "→ переименовать в «{name}»",
+    "previewUnavailable": "(предпросмотр недоступен)"
   },
   "boardSizeIndicator": {
     "custom": "Пользовательский",
     "ariaLabel": "{rows} строк на {cols} столбцов",
     "ariaLabelWithLayout": "{rows} строк на {cols} столбцов, {layout}"
+  },
+  "mcpSettings": {
+    "title": "MCP / внешние клиенты",
+    "description": "Предварительно выданный токен, который позволяет Claude Desktop, Claude Code и другим клиентам MCP обращаться к этому FiestaBoard. Токен аутентифицируется как единый субъект — только в рамках конечной точки {endpoint} — поэтому он не может изменять страницы или другие настройки. См. <link>настройку клиента MCP</link>, чтобы узнать об особенностях конкретных клиентов (Desktop требует stdio-прокси; Connectors в claude.ai web требуют публичного HTTPS и OAuth, поэтому не смогут подключиться к хосту в LAN).",
+    "statusLabel": "Статус:",
+    "pinnedByEnvBadge": "Задан через {envVar}",
+    "configuredBadge": "Настроено",
+    "pinnedByEnvDescription": "Активный токен задан переменной окружения {envVar}. Удалите её из {envFile} и перезапустите контейнер, прежде чем управлять токеном из этого интерфейса.",
+    "noTokenDescription": "Токен не настроен. Внешние клиенты MCP перейдут к аутентификации по cookie, которую Claude Desktop и Claude Code не поддерживают — их регистрация завершится непонятной ошибкой. Сгенерируйте токен, чтобы разблокировать их.",
+    "activeTokenDescription": "Токен настроен и активен. Смените его, чтобы аннулировать предыдущий (любой клиент, всё ещё использующий старый токен, начнёт получать 401), либо отзовите его полностью, чтобы вернуться к аутентификации только по cookie.",
+    "rotateTokenButton": "Сменить токен",
+    "generateTokenButton": "Сгенерировать токен",
+    "revokeTokenButton": "Отозвать токен",
+    "rotateConfirmTitle": "Сменить токен MCP?",
+    "generateConfirmTitle": "Сгенерировать токен MCP?",
+    "rotateConfirmDescription": "Любому клиенту, всё ещё использующему предыдущий токен, при следующем запросе будет отказано с ответом 401 и запросом Bearer. Новый токен будет показан только один раз — сохраните его в надёжном месте (прочитать его в интерфейсе повторно не получится).",
+    "generateConfirmDescription": "Токен будет показан только один раз — сохраните его в надёжном месте (прочитать его в интерфейсе повторно не получится). Внешние клиенты MCP будут использовать его для аутентификации в {endpoint}.",
+    "rotateConfirmButton": "Сменить",
+    "generateConfirmButton": "Сгенерировать",
+    "revokeConfirmTitle": "Отозвать токен MCP?",
+    "revokeConfirmDescription": "Внешние клиенты MCP начнут получать 401 при следующем запросе. Вы всегда сможете сгенерировать новый токен позже.",
+    "revokeConfirmButton": "Отозвать",
+    "revealTitle": "Сохраните этот токен",
+    "revealDescription": "FiestaBoard хранит только то, что нужно для проверки будущих запросов, — значение в открытом виде показывается только сейчас. Скопируйте его в свой клиент MCP.",
+    "tokenLabel": "Токен",
+    "copyButton": "Копировать",
+    "copiedButton": "Скопировано",
+    "configSnippetLabel": "Фрагмент конфигурации Claude Desktop",
+    "configSnippetDescription": "Вставьте это в {configPath}, объединив с тем, что там уже есть, затем полностью закройте и заново запустите Claude Desktop (⌘Q — закрыть окно недостаточно). Claude Desktop поддерживает только stdio-серверы MCP, поэтому этот фрагмент запускает {mcpRemoteLink} через {npx} в качестве прокси — необходимо установить Node 18+, а {npx} должен быть доступен в PATH Claude Desktop. Если возникает ошибка {commandNotFound}, замените {npxQuoted} на абсолютный путь из {whichNpx}.",
+    "claudeCodeDescription": "<label>Claude Code (CLI):</label> общается по HTTP напрямую — прокси не нужен.",
+    "claudeWebDescription": "<label>claude.ai web (Connectors):</label> не поддерживается для самостоятельно размещённого FiestaBoard. Процесс Connectors требует публичного HTTPS-адреса и динамической регистрации клиента OAuth 2.1, а хост в LAN не может обеспечить ни того, ни другого. Используйте вместо этого Desktop или Code.",
+    "savedItButton": "Я сохранил его",
+    "toastTokenRevoked": "Токен MCP отозван",
+    "toastCopyFailed": "Не удалось скопировать в буфер обмена"
   }
 }

--- a/web/messages/sv.json
+++ b/web/messages/sv.json
@@ -50,7 +50,8 @@
     "pageCount": "{count, plural, one {# sida} other {# sidor}}",
     "unknownError": "Okänt fel",
     "opensInNewTab": "(öppnas i en ny flik)",
-    "notificationsRegionLabel": "Aviseringar"
+    "notificationsRegionLabel": "Aviseringar",
+    "versionShort": "v{version}"
   },
   "metadata": {
     "appTitle": "FiestaBoard-styrning",
@@ -81,7 +82,8 @@
     "boardSelector": "Välj tavla att hantera",
     "selectBoard": "Välj tavla",
     "unnamedBoard": "Namnlös tavla",
-    "transitions": "Övergångslabb"
+    "transitions": "Övergångslabb",
+    "prideCelebration": "Glad Pride!"
   },
   "network": {
     "title": "Wi-Fi",
@@ -330,7 +332,11 @@
       "validationOneOffDateRequired": "Please pick a date",
       "validationEndDateBeforeStart": "End date must be on or after start date",
       "collectionSizeWarning": "{count} av {total} sidor i den här samlingen passar inte den här tavlans storlek och hoppas över.",
-      "incompatiblePageWarning": "Den här sidan matchar inte den här tavlans storlek och kanske inte visas korrekt."
+      "incompatiblePageWarning": "Den här sidan matchar inte den här tavlans storlek och kanske inte visas korrekt.",
+      "monthAriaLabel": "Månad",
+      "dayAriaLabel": "Dag",
+      "endMonthAriaLabel": "Slutmånad",
+      "endDayAriaLabel": "Slutdag"
     },
     "descriptionWithTimezone": "Automatisera sidrotation efter tid och dag · {timezone}",
     "gapDefaultPlaceholder": "Standard för lucka…",
@@ -472,7 +478,37 @@
     "toastNoUpdates": "Alla plugins är uppdaterade",
     "toastCheckFailed": "Kunde inte söka efter uppdateringar: {error}",
     "installAction": "Installera",
-    "installedBadge": "Installerad"
+    "installedBadge": "Installerad",
+    "valueUnavailable": "Ej tillgängligt",
+    "enablePluginForLiveValues": "Aktivera pluginen för att se livevärden.",
+    "liveValuesUnavailable": "Livevärden är inte tillgängliga.",
+    "liveValuesUnavailableWithError": "Livevärden är inte tillgängliga: {error}",
+    "currentValueColumn": "Aktuellt värde",
+    "refreshingValues": "uppdaterar…",
+    "sourceCoreBadge": "Kärna",
+    "sourceMarketplaceBadge": "Marketplace",
+    "sourceExternalBadge": "Extern",
+    "updateAvailableBadge": "Uppdatering",
+    "moreOptionsAriaLabel": "Fler alternativ",
+    "addInstanceAction": "Lägg till instans",
+    "instanceNameInlineLabel": "Instansnamn:",
+    "addInstanceInlineHelp": "Skapar en ny oberoende instans av denna plugin med egen konfiguration. Använd alfanumeriska tecken, bindestreck eller understreck (1–40 tecken).",
+    "deleteInstanceConfirmTitle": "Ta bort instansen ”{label}”?",
+    "deletePluginConfirmTitle": "Ta bort ”{name}”?",
+    "deleteInstanceConfirmDescription": "Detta tar bort denna instans och dess konfiguration permanent. Denna åtgärd kan inte ångras.",
+    "deletePluginConfirmDescription": "Detta tar bort pluginen och alla dess instanser permanent. Denna åtgärd kan inte ångras.",
+    "demoPage": {
+      "title": "Demosida",
+      "alreadyExists": "Det finns redan en demosida för denna plugin.",
+      "createDescription": "Skapa en färdig sida som visar upp denna plugin.",
+      "recreateButton": "Skapa om",
+      "recreateConfirmTitle": "Skapa om demosidan?",
+      "recreateConfirmDescription": "Detta tar bort den befintliga demosidan och skapar en ny med standardinställningar. Denna åtgärd kan inte ångras.",
+      "creating": "Skapar...",
+      "createAction": "Skapa demosida",
+      "recreateAction": "Skapa om demosidan",
+      "requirementsWarning": "Konfigurera de obligatoriska inställningarna nedan innan du skapar en demosida."
+    }
   },
   "settings": {
     "title": "Inställningar",
@@ -496,7 +532,43 @@
     "sectionAccount": "Konto",
     "sectionAccountDescription": "Användarnamn, lösenord och logga ut",
     "sectionNetwork": "Nätverk",
-    "sectionNetworkDescription": "Hantera Wi-Fi och anslutning"
+    "sectionNetworkDescription": "Hantera Wi-Fi och anslutning",
+    "ai": {
+      "removeProviderAriaLabel": "Ta bort leverantör",
+      "cardTitle": "AI-leverantörer",
+      "cardDescription": "Konfigurera OpenAI-kompatibla LLM:er för sidgeneratorn ”Gen AI”. BYO-LLM: FiestaBoard levererar aldrig med en nyckel.",
+      "privacyNotice": "Dina prompts och variabellistan för dina aktiverade plugins skickas direkt till leverantören du konfigurerar. API-nycklar lagras på den här enheten och skickas aldrig någon annanstans.",
+      "emptyState": "Inga leverantörer konfigurerade än.",
+      "addProviderButton": "Lägg till leverantör",
+      "discardButton": "Förkasta",
+      "saveChangesButton": "Spara ändringar",
+      "defaultBadge": "Standard",
+      "anthropicBadge": "Anthropic",
+      "makeDefaultButton": "Gör till standard",
+      "nameLabel": "Namn",
+      "protocolLabel": "Protokoll",
+      "protocolOpenaiOption": "OpenAI-kompatibel (OpenAI, OpenRouter, Groq, DeepSeek, Mistral, Together, Fireworks, Ollama, LM Studio, vLLM, …)",
+      "protocolAnthropicOption": "Anthropic (Messages API)",
+      "baseUrlLabel": "Bas-URL",
+      "quickPresetsLabel": "Snabbval",
+      "apiKeyLabel": "API-nyckel",
+      "modelsLabel": "Modeller",
+      "defaultModelLabel": "Standardmodell",
+      "testConnectionButton": "Testa anslutning"
+    },
+    "backup": {
+      "cardTitle": "Säkerhetskopiering & återställning",
+      "cardDescription": "Exportera hela din FiestaBoard-konfiguration — tavelinställningar, sidor, karuseller, scheman och pluginkonfiguration — som en enda JSON-fil. Ladda upp filen igen på en ny instans för att migrera eller återställa efter en uppgradering.",
+      "exportButton": "Exportera säkerhetskopia",
+      "importButton": "Importera säkerhetskopia…",
+      "reinstallPluginsLabel": "Installera om externa plugins efter import",
+      "reinstallPluginsDescription": "När detta är aktiverat försöker FiestaBoard klona alla externa plugins i säkerhetskopian som inte redan är installerade på denna instans. Deras konfiguration återställs från säkerhetskopian oavsett.",
+      "sensitiveNote": "Obs: säkerhetskopior innehåller känsliga värden som API-nycklar och inloggningsuppgifter till tavlan i klartext. Förvara filen säkert och dela den inte offentligt.",
+      "confirmTitle": "Ersätta nuvarande konfiguration?",
+      "confirmDescription": "Du håller på att återställa <file></file>. Dina befintliga sidor, karuseller, scheman och din konfiguration skrivs över. En kopia med tidsstämpel av varje befintlig fil sparas bredvid den nya, så att du kan rulla tillbaka manuellt vid behov.",
+      "restoringButton": "Återställer…",
+      "restoreButton": "Återställ säkerhetskopia"
+    }
   },
   "offline": {
     "youreOffline": "Du är offline",
@@ -581,7 +653,10 @@
       "passwordPlaceholder": "DittLösenord",
       "wifiPreview": "WIFI: {ssid}",
       "passPreview": "PASS: {password}",
-      "noPassword": "(inget lösenord)"
+      "noPassword": "(inget lösenord)",
+      "addMoreHint": "Du kan lägga till fler när som helst från sidan <link>Integrationer</link>.",
+      "builtInBadge": "Inbyggd",
+      "previewLabel": "Förhandsvisning:"
     },
     "welcome": {
       "setupComplete": "Installationen är klar!",
@@ -639,7 +714,9 @@
     "changeModeDisableTitle": "Stäng av schemaläge",
     "changeModeDisableDescription": "Inaktivera schemat och styr board manuellt.",
     "changeModeDisableSuccess": "Schemaläge inaktiverat",
-    "collectionSizeWarning": "{count} av {total} sidor i den här samlingen passar inte den här tavlans storlek och hoppas över."
+    "collectionSizeWarning": "{count} av {total} sidor i den här samlingen passar inte den här tavlans storlek och hoppas över.",
+    "turnOffLiveModeAriaLabel": "Stäng av liveläge",
+    "liveModeBadge": "Liveläge"
   },
   "forceSetDialog": {
     "title": "Tvinga inställning av board",
@@ -882,7 +959,10 @@
     "updateNow": "Uppdatera nu",
     "oneClickHint": "Vill du ha en ett-klicks ”Uppdatera nu”-knapp här? Ange <profile></profile> i din <envFile></envFile> och kör sedan <command></command>.",
     "dialogTitle": "Uppdatera FiestaBoard?",
-    "dialogDescription": "Detta hämtar <version></version> och startar om FiestaBoard. Board-displayen pausar i cirka 30 sekunder och denna sida laddas om automatiskt."
+    "dialogDescription": "Detta hämtar <version></version> och startar om FiestaBoard. Board-displayen pausar i cirka 30 sekunder och denna sida laddas om automatiskt.",
+    "intervalSelectAriaLabel": "Frekvens för uppdateringssökning",
+    "intervalCardDescription": "Hur ofta FiestaBoard ska leta efter en ny version i bakgrunden. Du ser en banner här när en hittas.",
+    "lastChecked": "Senast kontrollerad: {time}"
   },
   "transitionSettings": {
     "title": "Tavlans övergångar",
@@ -1008,7 +1088,8 @@
       "Numbers": "Siffror",
       "Symbols": "Symboler",
       "Colors": "Färger"
-    }
+    },
+    "latencyMs": "{ms} ms"
   },
   "generalSettings": {
     "title": "Allmänna inställningar",
@@ -1375,7 +1456,8 @@
     "flapSpeed_relaxedHint": "{ms} ms — en långsam, medveten vändning för stämningsskärmar.",
     "flapSpeedPreviewLabel": "Förhandsvisning",
     "flapSpeedInactive": "Board-animationer är avstängda, så vändhastigheten spelar ingen roll.",
-    "flapSpeedScreenOnlyNote": "Detta ändrar bara board-förhandsvisningen på skärmen. Takten för din fysiska Vestaboards egna övergångar ställs in separat, under Beteende → Board-övergångar."
+    "flapSpeedScreenOnlyNote": "Detta ändrar bara board-förhandsvisningen på skärmen. Takten för din fysiska Vestaboards egna övergångar ställs in separat, under Beteende → Board-övergångar.",
+    "updateAvailableBadge": "v{version} tillgänglig"
   },
   "monitor": {
     "title": "Monitor",
@@ -1647,7 +1729,8 @@
     "whiteBoard": "Vit tavla",
     "deviceFlagship": "Flagship",
     "deviceNote": "Note",
-    "deviceNoteArray": "Note-matris {w}×{h}"
+    "deviceNoteArray": "Note-matris {w}×{h}",
+    "githubLink": "GitHub"
   },
   "boardDisplay": {
     "loading": "Laddar board-display",
@@ -1736,7 +1819,12 @@
     "remoteOptionsSearchPlaceholder": "Sök…",
     "remoteOptionsCustomLabel": "Eget värde",
     "remoteOptionsCustomPlaceholder": "Ange ett värde som inte finns i listan",
-    "remoteOptionsCustomAdd": "Lägg till eget värde"
+    "remoteOptionsCustomAdd": "Lägg till eget värde",
+    "addItemLabel": "Lägg till {label}",
+    "unknownType": "Okänd typ: {type}",
+    "pagePickerNone": "Ingen (ingen åsidosättning)",
+    "pagePickerLoading": "Laddar sidor…",
+    "pagePickerPlaceholder": "Välj en sida…"
   },
   "filterPicker": {
     "noFiltersAvailable": "Inga filter tillgängliga",
@@ -1744,7 +1832,8 @@
     "filterDescWrap": "Bryter lång text över flera rader",
     "filterDescPad": "Fyller text till angiven bredd",
     "filterDescTruncate": "Trunkerar text till angiven längd",
-    "wrapInstruction": "|wrap: Bryter lång text. Lämna tomma rader nedan så text kan flöda in."
+    "wrapInstruction": "Bryter lång text. Lämna tomma rader nedan så text kan flöda in.",
+    "exampleLabel": "Exempel: {example}"
   },
   "formattingPicker": {
     "noFormattingAvailable": "Inga formateringsalternativ tillgängliga",
@@ -1805,7 +1894,25 @@
     "alignRight": "Högerjustera",
     "syncFromBoardTooltip": "Fyll mall från det som visas på board just nu",
     "syncFromBoard": "Synka från aktuell board-display",
-    "alignment": "Justering:"
+    "alignment": "Justering:",
+    "undoAriaLabel": "Ångra",
+    "redoAriaLabel": "Gör om",
+    "cutAriaLabel": "Klipp ut",
+    "copyAriaLabel": "Kopiera",
+    "pasteAriaLabel": "Klistra in",
+    "removeWrappedTextAriaLabel": "Ta bort radbruten text",
+    "colorPickerAriaLabel": "Färgväljare",
+    "heartCharacterAriaLabel": "Hjärttecken",
+    "lineCount": "{used} / {max} rader",
+    "overLineLimit": " — överskrider tavlans gräns på {max} rader",
+    "currentLine": "(Rad {line})",
+    "heartLabel": "hjärta",
+    "insertHeartTooltip": "Infoga hjärttecken (endast Note)",
+    "colorTileTooltip": "{color}-ruta (kod {code}) - dra för att flytta, backsteg för att ta bort",
+    "fillSpaceTooltip": "Fyllutrymme - expanderar för att fylla resten av radens bredd",
+    "fillSpaceRepeatTooltip": "Fyllutrymme upprepar: {char}",
+    "variableFilterTooltip": "Filter: {filter}",
+    "variableMaxLengthTooltip": "Maxlängd: {maxLength} tecken"
   },
   "variablePicker": {
     "noVariablesAvailable": "Inga variabler tillgängliga",
@@ -1815,7 +1922,8 @@
     "searchPlaceholder": "Sök variabler...",
     "indexLabel": "Index: {index}",
     "configureHint": "Konfigurera {arrayName} i Inställningar för att se indexerade variabler här.",
-    "configureExample": "Exempel:"
+    "configureExample": "Exempel:",
+    "noMatchingVariables": "Inga matchande variabler hittades."
   },
   "login": {
     "signInTitle": "Logga in på FiestaBoard",
@@ -1873,11 +1981,62 @@
     "taskStatusAriaLabel": "Uppgiftsförlopp",
     "taskProgressAriaLabel": "AI-uppgifters förlopp",
     "clearConversationAriaLabel": "Rensa konversation",
-    "closePanelAriaLabel": "Stäng FiestaBot (Beta)"
+    "closePanelAriaLabel": "Stäng FiestaBot (Beta)",
+    "providerSelectAriaLabel": "Leverantör",
+    "modelSelectAriaLabel": "Modell",
+    "showBoardTooltip": "Visa board-förhandsvisning",
+    "hideBoardTooltip": "Dölj board-förhandsvisning",
+    "undoTooltip": "Ångra senaste AI-ändringen",
+    "panelTitle": "FiestaBot (Beta)",
+    "retryButton": "Försök igen",
+    "messageLabel": "Meddelande",
+    "stopButton": "Stoppa",
+    "sendButton": "Skicka",
+    "tasksHeading": "Uppgifter ({done}/{total})",
+    "emptyStateTitle": "Hur kan jag hjälpa till?",
+    "emptyStateDescription": "Beskriv vad du vill bygga eller ändra.",
+    "showBoardButton": "Visa board",
+    "undoButton": "Ångra",
+    "renameSummary": "→ byt namn till ”{name}”",
+    "previewUnavailable": "(förhandsvisning inte tillgänglig)"
   },
   "boardSizeIndicator": {
     "custom": "Anpassad",
     "ariaLabel": "{rows} rader gånger {cols} kolumner",
     "ariaLabelWithLayout": "{rows} rader gånger {cols} kolumner, {layout}"
+  },
+  "mcpSettings": {
+    "title": "MCP / externa klienter",
+    "description": "En fördelad token som låter Claude Desktop, Claude Code och andra MCP-klienter prata med denna FiestaBoard. Token autentiserar som en enda principal — begränsad till enbart slutpunkten {endpoint} — så den kan inte redigera sidor eller andra inställningar. Se <link>Konfigurera MCP-klienter</link> för klientspecifika egenheter (Desktop behöver en stdio-proxy; Connectors i claude.ai-webben kräver publik HTTPS och OAuth och når därför inte en värd i LAN).",
+    "statusLabel": "Status:",
+    "pinnedByEnvBadge": "Låst av {envVar}",
+    "configuredBadge": "Konfigurerad",
+    "pinnedByEnvDescription": "Den aktiva token sätts av miljövariabeln {envVar}. Ta bort den från din {envFile} och starta om containern innan du hanterar token från detta gränssnitt.",
+    "noTokenDescription": "Ingen token är konfigurerad. Externa MCP-klienter faller tillbaka på cookie-autentisering, som Claude Desktop / Claude Code inte stöder — deras registrering misslyckas då med ett intetsägande fel. Generera en token för att låsa upp dem.",
+    "activeTokenDescription": "En token är konfigurerad och aktiv. Rotera den för att ogiltigförklara den föregående (klienter som fortfarande använder den gamla token börjar få 401), eller återkalla den helt för att falla tillbaka på enbart cookie-autentisering.",
+    "rotateTokenButton": "Rotera token",
+    "generateTokenButton": "Generera token",
+    "revokeTokenButton": "Återkalla token",
+    "rotateConfirmTitle": "Rotera MCP-token?",
+    "generateConfirmTitle": "Generera MCP-token?",
+    "rotateConfirmDescription": "Alla klienter som fortfarande använder den föregående token nekas med 401 + Bearer-challenge vid nästa förfrågan. Du ser den nya token en enda gång — spara den på ett säkert ställe (den går inte att läsa från gränssnittet igen).",
+    "generateConfirmDescription": "Du ser token en enda gång — spara den på ett säkert ställe (den går inte att läsa från gränssnittet igen). Externa MCP-klienter använder den för att autentisera mot {endpoint}.",
+    "rotateConfirmButton": "Rotera",
+    "generateConfirmButton": "Generera",
+    "revokeConfirmTitle": "Återkalla MCP-token?",
+    "revokeConfirmDescription": "Externa MCP-klienter börjar få 401 vid nästa förfrågan. Du kan alltid generera en ny token senare.",
+    "revokeConfirmButton": "Återkalla",
+    "revealTitle": "Spara denna token",
+    "revealDescription": "FiestaBoard sparar bara det som behövs för att verifiera framtida förfrågningar — det här är enda gången värdet visas i klartext. Kopiera det till din MCP-klient nu.",
+    "tokenLabel": "Token",
+    "copyButton": "Kopiera",
+    "copiedButton": "Kopierad",
+    "configSnippetLabel": "Claude Desktop-konfigurationsutdrag",
+    "configSnippetDescription": "Klistra in detta i {configPath} och slå ihop det med det som redan finns där. Avsluta sedan Claude Desktop helt och starta om det (⌘Q — att stänga fönstret räcker inte). Claude Desktop stöder bara stdio-MCP-servrar, så det här utdraget anropar {mcpRemoteLink} via {npx} som proxy — Node 18+ måste vara installerat och {npx} nåbart från Claude Desktops PATH. Om det ger felet {commandNotFound}, ersätt {npxQuoted} med den absoluta sökvägen från {whichNpx}.",
+    "claudeCodeDescription": "<label>Claude Code (CLI):</label> pratar HTTP direkt — ingen proxy behövs.",
+    "claudeWebDescription": "<label>claude.ai web (Connectors):</label> stöds inte för självhostad FiestaBoard. Connectors-flödet kräver en publik HTTPS-URL och dynamisk OAuth 2.1-klientregistrering, och en värd i LAN kan inte tillhandahålla något av detta. Använd Desktop eller Code i stället.",
+    "savedItButton": "Jag har sparat den",
+    "toastTokenRevoked": "MCP-token återkallad",
+    "toastCopyFailed": "Kunde inte kopiera till urklipp"
   }
 }

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -50,7 +50,8 @@
     "pageCount": "{count, plural, one {# sayfa} other {# sayfa}}",
     "unknownError": "Bilinmeyen hata",
     "opensInNewTab": "(yeni sekmede açılır)",
-    "notificationsRegionLabel": "Bildirimler"
+    "notificationsRegionLabel": "Bildirimler",
+    "versionShort": "v{version}"
   },
   "metadata": {
     "appTitle": "FiestaBoard Kontrol",
@@ -81,7 +82,8 @@
     "boardSelector": "Yönetilecek panoyu seçin",
     "selectBoard": "Pano seçin",
     "unnamedBoard": "Adsız pano",
-    "transitions": "Geçiş Laboratuvarı"
+    "transitions": "Geçiş Laboratuvarı",
+    "prideCelebration": "Mutlu Onurlar!"
   },
   "network": {
     "title": "Wi-Fi",
@@ -330,7 +332,11 @@
       "validationOneOffDateRequired": "Please pick a date",
       "validationEndDateBeforeStart": "End date must be on or after start date",
       "collectionSizeWarning": "Bu koleksiyondaki {total} sayfadan {count} tanesi bu panonun boyutuna uymuyor ve atlanacak.",
-      "incompatiblePageWarning": "Bu sayfa bu panonun boyutuyla eşleşmiyor ve doğru görüntülenmeyebilir."
+      "incompatiblePageWarning": "Bu sayfa bu panonun boyutuyla eşleşmiyor ve doğru görüntülenmeyebilir.",
+      "monthAriaLabel": "Ay",
+      "dayAriaLabel": "Gün",
+      "endMonthAriaLabel": "Bitiş ayı",
+      "endDayAriaLabel": "Bitiş günü"
     },
     "descriptionWithTimezone": "Sayfa rotasyonunu saat ve güne göre otomatikleştir · {timezone}",
     "gapDefaultPlaceholder": "Boşluk varsayılanı…",
@@ -472,7 +478,37 @@
     "toastNoUpdates": "Tüm eklentiler güncel",
     "toastCheckFailed": "Güncellemeler kontrol edilemedi: {error}",
     "installAction": "Kur",
-    "installedBadge": "Kuruldu"
+    "installedBadge": "Kuruldu",
+    "valueUnavailable": "Kullanılamıyor",
+    "enablePluginForLiveValues": "Canlı değerleri görmek için eklentiyi etkinleştirin.",
+    "liveValuesUnavailable": "Canlı değerler kullanılamıyor.",
+    "liveValuesUnavailableWithError": "Canlı değerler kullanılamıyor: {error}",
+    "currentValueColumn": "Mevcut Değer",
+    "refreshingValues": "yenileniyor…",
+    "sourceCoreBadge": "Yerleşik",
+    "sourceMarketplaceBadge": "Marketplace",
+    "sourceExternalBadge": "Harici",
+    "updateAvailableBadge": "Güncelleme",
+    "moreOptionsAriaLabel": "Diğer seçenekler",
+    "addInstanceAction": "Örnek Ekle",
+    "instanceNameInlineLabel": "Örnek adı:",
+    "addInstanceInlineHelp": "Bu eklentinin kendi yapılandırmasına sahip yeni ve bağımsız bir örneğini oluşturur. Alfasayısal karakterler, tireler veya alt çizgiler kullanın (1-40 karakter).",
+    "deleteInstanceConfirmTitle": "\"{label}\" örneği silinsin mi?",
+    "deletePluginConfirmTitle": "\"{name}\" silinsin mi?",
+    "deleteInstanceConfirmDescription": "Bu, bu örneği ve yapılandırmasını kalıcı olarak kaldırır. Bu işlem geri alınamaz.",
+    "deletePluginConfirmDescription": "Bu, eklentiyi ve tüm örneklerini kalıcı olarak kaldırır. Bu işlem geri alınamaz.",
+    "demoPage": {
+      "title": "Demo Sayfası",
+      "alreadyExists": "Bu eklenti için zaten bir demo sayfası var.",
+      "createDescription": "Bu eklentiyi tanıtan, kullanıma hazır bir sayfa oluşturun.",
+      "recreateButton": "Yeniden oluştur",
+      "recreateConfirmTitle": "Demo sayfası yeniden oluşturulsun mu?",
+      "recreateConfirmDescription": "Bu, mevcut demo sayfasını silip varsayılan ayarlarla yenisini oluşturur. Bu işlem geri alınamaz.",
+      "creating": "Oluşturuluyor...",
+      "createAction": "Demo Sayfası Oluştur",
+      "recreateAction": "Demo Sayfasını Yeniden Oluştur",
+      "requirementsWarning": "Demo sayfası oluşturmadan önce aşağıdaki zorunlu ayarları yapılandırın."
+    }
   },
   "settings": {
     "title": "Ayarlar",
@@ -496,7 +532,43 @@
     "sectionAccount": "Hesap",
     "sectionAccountDescription": "Kullanıcı adı, şifre ve çıkış",
     "sectionNetwork": "Ağ",
-    "sectionNetworkDescription": "Wi-Fi ve bağlantıyı yönet"
+    "sectionNetworkDescription": "Wi-Fi ve bağlantıyı yönet",
+    "ai": {
+      "removeProviderAriaLabel": "Sağlayıcıyı kaldır",
+      "cardTitle": "Yapay Zeka Sağlayıcıları",
+      "cardDescription": "\"Gen AI\" sayfa oluşturucusu için OpenAI uyumlu LLM'leri yapılandırın. BYO-LLM: FiestaBoard hiçbir zaman hazır anahtar içermez.",
+      "privacyNotice": "İstemleriniz ve etkin eklentilerinizin değişken listesi doğrudan yapılandırdığınız sağlayıcıya gönderilir. API anahtarları bu cihazda saklanır ve başka hiçbir yere gönderilmez.",
+      "emptyState": "Henüz sağlayıcı yapılandırılmadı.",
+      "addProviderButton": "Sağlayıcı ekle",
+      "discardButton": "Vazgeç",
+      "saveChangesButton": "Değişiklikleri kaydet",
+      "defaultBadge": "Varsayılan",
+      "anthropicBadge": "Anthropic",
+      "makeDefaultButton": "Varsayılan yap",
+      "nameLabel": "Ad",
+      "protocolLabel": "Protokol",
+      "protocolOpenaiOption": "OpenAI uyumlu (OpenAI, OpenRouter, Groq, DeepSeek, Mistral, Together, Fireworks, Ollama, LM Studio, vLLM, …)",
+      "protocolAnthropicOption": "Anthropic (Messages API)",
+      "baseUrlLabel": "Temel URL",
+      "quickPresetsLabel": "Hızlı önayarlar",
+      "apiKeyLabel": "API Anahtarı",
+      "modelsLabel": "Modeller",
+      "defaultModelLabel": "Varsayılan model",
+      "testConnectionButton": "Bağlantıyı test et"
+    },
+    "backup": {
+      "cardTitle": "Yedekleme ve Geri Yükleme",
+      "cardDescription": "FiestaBoard yapılandırmanızın tamamını — board ayarları, sayfalar, döngüler, zamanlamalar ve eklenti yapılandırması — tek bir JSON dosyası olarak dışa aktarın. Taşımak veya bir yükseltmeden sonra kurtarmak için bu dosyayı yeni bir örneğe yeniden yükleyin.",
+      "exportButton": "Yedeği dışa aktar",
+      "importButton": "Yedeği içe aktar…",
+      "reinstallPluginsLabel": "İçe aktarmadan sonra harici eklentileri yeniden kur",
+      "reinstallPluginsDescription": "Etkinleştirildiğinde FiestaBoard, yedekte kayıtlı olup bu örneğe henüz kurulmamış harici eklentileri klonlamayı dener. Yapılandırmaları her durumda yedekten geri yüklenir.",
+      "sensitiveNote": "Not: yedekler, API anahtarları ve board kimlik bilgileri gibi hassas değerleri düz metin olarak içerir. Dosyayı güvenli bir yerde saklayın ve herkese açık şekilde paylaşmayın.",
+      "confirmTitle": "Mevcut yapılandırma değiştirilsin mi?",
+      "confirmDescription": "<file></file> dosyasını geri yüklemek üzeresiniz. Mevcut sayfalarınızın, döngülerinizin, zamanlamalarınızın ve yapılandırmanızın üzerine yazılacak. Gerekirse elle geri dönebilmeniz için her mevcut dosyanın zaman damgalı bir kopyası yenisinin yanında saklanır.",
+      "restoringButton": "Geri yükleniyor…",
+      "restoreButton": "Yedeği geri yükle"
+    }
   },
   "offline": {
     "youreOffline": "Çevrimdışısınız",
@@ -581,7 +653,10 @@
       "passwordPlaceholder": "SifrenizBurada",
       "wifiPreview": "WIFI: {ssid}",
       "passPreview": "ŞİFRE: {password}",
-      "noPassword": "(şifresiz)"
+      "noPassword": "(şifresiz)",
+      "addMoreHint": "Dilediğiniz zaman <link>Entegrasyonlar</link> sayfasından daha fazlasını ekleyebilirsiniz.",
+      "builtInBadge": "Yerleşik",
+      "previewLabel": "Önizleme:"
     },
     "welcome": {
       "setupComplete": "Kurulum Tamamlandı!",
@@ -639,7 +714,9 @@
     "changeModeDisableTitle": "Zamanlama modunu kapat",
     "changeModeDisableDescription": "Zamanlamayı devre dışı bırakıp board'u manuel olarak kontrol edin.",
     "changeModeDisableSuccess": "Zamanlama modu devre dışı bırakıldı",
-    "collectionSizeWarning": "Bu koleksiyondaki {total} sayfadan {count} tanesi bu panonun boyutuna uymuyor ve atlanacak."
+    "collectionSizeWarning": "Bu koleksiyondaki {total} sayfadan {count} tanesi bu panonun boyutuna uymuyor ve atlanacak.",
+    "turnOffLiveModeAriaLabel": "Canlı Modu kapat",
+    "liveModeBadge": "Canlı Mod"
   },
   "forceSetDialog": {
     "title": "Board'u Zorla Ayarla",
@@ -882,7 +959,10 @@
     "updateNow": "Şimdi Güncelle",
     "oneClickHint": "Burada tek tıkla \"Şimdi Güncelle\" düğmesi mi istiyorsunuz? <envFile></envFile> dosyanızda <profile></profile> ayarlayın, ardından <command></command> komutunu çalıştırın.",
     "dialogTitle": "FiestaBoard güncellensin mi?",
-    "dialogDescription": "Bu, <version></version> sürümünü çekip FiestaBoard'u yeniden başlatır. Board ekranı yaklaşık 30 saniye duraklar ve bu sayfa otomatik olarak yeniden yüklenir."
+    "dialogDescription": "Bu, <version></version> sürümünü çekip FiestaBoard'u yeniden başlatır. Board ekranı yaklaşık 30 saniye duraklar ve bu sayfa otomatik olarak yeniden yüklenir.",
+    "intervalSelectAriaLabel": "Güncelleme kontrol sıklığı",
+    "intervalCardDescription": "FiestaBoard'un arka planda ne sıklıkla yeni sürüm arayacağı. Bir sürüm bulunduğunda burada bir bildirim şeridi görürsünüz.",
+    "lastChecked": "Son kontrol: {time}"
   },
   "transitionSettings": {
     "title": "Pano Geçişleri",
@@ -1008,7 +1088,8 @@
       "Numbers": "Sayılar",
       "Symbols": "Semboller",
       "Colors": "Renkler"
-    }
+    },
+    "latencyMs": "{ms} ms"
   },
   "generalSettings": {
     "title": "Genel Ayarlar",
@@ -1375,7 +1456,8 @@
     "flapSpeed_relaxedHint": "{ms} ms — ortam ekranları için yavaş, ölçülü bir çevirme.",
     "flapSpeedPreviewLabel": "Önizleme",
     "flapSpeedInactive": "Board animasyonları kapalı, bu yüzden çevirme hızının etkisi yok.",
-    "flapSpeedScreenOnlyNote": "Bu yalnızca ekrandaki board önizlemesini değiştirir. Fiziksel Vestaboard'unuzun kendi geçiş hızı ayrı olarak Davranış → Board geçişleri altında ayarlanır."
+    "flapSpeedScreenOnlyNote": "Bu yalnızca ekrandaki board önizlemesini değiştirir. Fiziksel Vestaboard'unuzun kendi geçiş hızı ayrı olarak Davranış → Board geçişleri altında ayarlanır.",
+    "updateAvailableBadge": "v{version} mevcut"
   },
   "monitor": {
     "title": "Monitör",
@@ -1647,7 +1729,8 @@
     "whiteBoard": "Beyaz pano",
     "deviceFlagship": "Flagship",
     "deviceNote": "Note",
-    "deviceNoteArray": "Note dizisi {w}×{h}"
+    "deviceNoteArray": "Note dizisi {w}×{h}",
+    "githubLink": "GitHub"
   },
   "boardDisplay": {
     "loading": "Board ekranı yükleniyor",
@@ -1736,7 +1819,12 @@
     "remoteOptionsSearchPlaceholder": "Ara…",
     "remoteOptionsCustomLabel": "Özel değer",
     "remoteOptionsCustomPlaceholder": "Listede olmayan bir değer girin",
-    "remoteOptionsCustomAdd": "Özel değer ekle"
+    "remoteOptionsCustomAdd": "Özel değer ekle",
+    "addItemLabel": "{label} ekle",
+    "unknownType": "Bilinmeyen tür: {type}",
+    "pagePickerNone": "Yok (geçersiz kılma yok)",
+    "pagePickerLoading": "Sayfalar yükleniyor…",
+    "pagePickerPlaceholder": "Bir sayfa seçin…"
   },
   "filterPicker": {
     "noFiltersAvailable": "Kullanılabilir filtre yok",
@@ -1744,7 +1832,8 @@
     "filterDescWrap": "Uzun metni birden çok satıra kaydırır",
     "filterDescPad": "Metni belirtilen genişliğe doldurur",
     "filterDescTruncate": "Metni belirtilen uzunluğa kırpar",
-    "wrapInstruction": "|wrap: Uzun metni kaydırır. Metnin akabilmesi için aşağıda boş satırlar bırakın."
+    "wrapInstruction": "Uzun metni kaydırır. Metnin akabilmesi için aşağıda boş satırlar bırakın.",
+    "exampleLabel": "Örnek: {example}"
   },
   "formattingPicker": {
     "noFormattingAvailable": "Kullanılabilir biçimlendirme seçeneği yok",
@@ -1805,7 +1894,25 @@
     "alignRight": "Sağa hizala",
     "syncFromBoardTooltip": "Şablonu şu anda board'da gösterilenden doldur",
     "syncFromBoard": "Mevcut board ekranından senkronize et",
-    "alignment": "Hizalama:"
+    "alignment": "Hizalama:",
+    "undoAriaLabel": "Geri al",
+    "redoAriaLabel": "Yinele",
+    "cutAriaLabel": "Kes",
+    "copyAriaLabel": "Kopyala",
+    "pasteAriaLabel": "Yapıştır",
+    "removeWrappedTextAriaLabel": "Kaydırılan metni kaldır",
+    "colorPickerAriaLabel": "Renk seçici",
+    "heartCharacterAriaLabel": "Kalp karakteri",
+    "lineCount": "{used} / {max} satır",
+    "overLineLimit": " — {max} satırlık board sınırını aşıyor",
+    "currentLine": "(Satır {line})",
+    "heartLabel": "kalp",
+    "insertHeartTooltip": "Kalp karakteri ekle (yalnızca Note)",
+    "colorTileTooltip": "{color} karesi (kod {code}) - taşımak için sürükleyin, silmek için backspace",
+    "fillSpaceTooltip": "Boşluğu doldur - satırın kalan genişliğini dolduracak şekilde genişler",
+    "fillSpaceRepeatTooltip": "Boşluğu doldur, tekrarlanan: {char}",
+    "variableFilterTooltip": "Filtre: {filter}",
+    "variableMaxLengthTooltip": "Maksimum uzunluk: {maxLength} karakter"
   },
   "variablePicker": {
     "noVariablesAvailable": "Kullanılabilir değişken yok",
@@ -1815,7 +1922,8 @@
     "searchPlaceholder": "Değişken ara...",
     "indexLabel": "Dizin: {index}",
     "configureHint": "Burada dizinlenmiş değişkenleri görmek için Ayarlar'da {arrayName} öğesini yapılandırın.",
-    "configureExample": "Örnek:"
+    "configureExample": "Örnek:",
+    "noMatchingVariables": "Eşleşen değişken bulunamadı."
   },
   "login": {
     "signInTitle": "FiestaBoard'a giriş yap",
@@ -1873,11 +1981,62 @@
     "taskStatusAriaLabel": "Görev ilerlemesi",
     "taskProgressAriaLabel": "AI görev ilerlemesi",
     "clearConversationAriaLabel": "Konuşmayı temizle",
-    "closePanelAriaLabel": "FiestaBot (Beta)'yı kapat"
+    "closePanelAriaLabel": "FiestaBot (Beta)'yı kapat",
+    "providerSelectAriaLabel": "Sağlayıcı",
+    "modelSelectAriaLabel": "Model",
+    "showBoardTooltip": "Board önizlemesini göster",
+    "hideBoardTooltip": "Board önizlemesini gizle",
+    "undoTooltip": "Son yapay zeka değişikliğini geri al",
+    "panelTitle": "FiestaBot (Beta)",
+    "retryButton": "Yeniden dene",
+    "messageLabel": "Mesaj",
+    "stopButton": "Durdur",
+    "sendButton": "Gönder",
+    "tasksHeading": "Görevler ({done}/{total})",
+    "emptyStateTitle": "Nasıl yardımcı olabilirim?",
+    "emptyStateDescription": "Ne oluşturmak veya değiştirmek istediğinizi anlatın.",
+    "showBoardButton": "Board'u göster",
+    "undoButton": "Geri al",
+    "renameSummary": "→ \"{name}\" olarak yeniden adlandır",
+    "previewUnavailable": "(önizleme kullanılamıyor)"
   },
   "boardSizeIndicator": {
     "custom": "Özel",
     "ariaLabel": "{rows} satır {cols} sütun",
     "ariaLabelWithLayout": "{rows} satır {cols} sütun, {layout}"
+  },
+  "mcpSettings": {
+    "title": "MCP / harici istemciler",
+    "description": "Claude Desktop, Claude Code ve diğer MCP istemcilerinin bu FiestaBoard ile konuşmasını sağlayan, önceden paylaşılmış bir token. Token tek bir kimlik olarak doğrulanır — yalnızca {endpoint} uç noktasıyla sınırlıdır — bu yüzden sayfaları veya diğer ayarları düzenleyemez. İstemciye özgü ayrıntılar için <link>MCP istemci kurulumu</link> bölümüne bakın (Desktop bir stdio proxy'si ister; claude.ai web Connectors herkese açık HTTPS ve OAuth gerektirdiğinden bir LAN sunucusuna ulaşamaz).",
+    "statusLabel": "Durum:",
+    "pinnedByEnvBadge": "{envVar} ile sabitlendi",
+    "configuredBadge": "Yapılandırıldı",
+    "pinnedByEnvDescription": "Etkin token, {envVar} ortam değişkeni tarafından belirleniyor. Token'ı bu arayüzden yönetmeden önce {envFile} dosyanızdaki bu değişkeni kaldırın ve container'ı yeniden başlatın.",
+    "noTokenDescription": "Yapılandırılmış token yok. Harici MCP istemcileri çerez tabanlı kimlik doğrulamaya geri döner; Claude Desktop / Claude Code bunu desteklemediği için kayıt anlaşılmaz bir hatayla başarısız olur. Onların çalışabilmesi için bir token oluşturun.",
+    "activeTokenDescription": "Yapılandırılmış ve etkin bir token var. Öncekini geçersiz kılmak için yenileyin (eski token'ı hâlâ kullanan istemciler 401 almaya başlar) veya yalnızca çerez tabanlı kimlik doğrulamaya dönmek için tamamen iptal edin.",
+    "rotateTokenButton": "Token'ı yenile",
+    "generateTokenButton": "Token oluştur",
+    "revokeTokenButton": "Token'ı iptal et",
+    "rotateConfirmTitle": "MCP token'ı yenilensin mi?",
+    "generateConfirmTitle": "MCP token'ı oluşturulsun mu?",
+    "rotateConfirmDescription": "Önceki token'ı hâlâ kullanan istemciler bir sonraki isteklerinde 401 + Bearer sorgusuyla reddedilir. Yeni token'ı yalnızca bir kez göreceksiniz — güvenli bir yerde saklayın (arayüzden tekrar okunamaz).",
+    "generateConfirmDescription": "Token'ı yalnızca bir kez göreceksiniz — güvenli bir yerde saklayın (arayüzden tekrar okunamaz). Harici MCP istemcileri {endpoint} adresinde kimlik doğrulamak için bunu kullanır.",
+    "rotateConfirmButton": "Yenile",
+    "generateConfirmButton": "Oluştur",
+    "revokeConfirmTitle": "MCP token'ı iptal edilsin mi?",
+    "revokeConfirmDescription": "Harici MCP istemcileri bir sonraki isteklerinde 401 almaya başlar. Daha sonra istediğiniz zaman yeni bir token oluşturabilirsiniz.",
+    "revokeConfirmButton": "İptal et",
+    "revealTitle": "Bu token'ı kaydedin",
+    "revealDescription": "FiestaBoard yalnızca gelecekteki istekleri doğrulamak için gerekli olanı saklar — düz metin değer yalnızca bu bir kez gösterilir. Şimdi MCP istemcinize kopyalayın.",
+    "tokenLabel": "Token",
+    "copyButton": "Kopyala",
+    "copiedButton": "Kopyalandı",
+    "configSnippetLabel": "Claude Desktop yapılandırma parçacığı",
+    "configSnippetDescription": "Bunu {configPath} dosyasına, orada zaten bulunanlarla birleştirerek yapıştırın, ardından Claude Desktop'tan tamamen çıkıp yeniden başlatın (⌘Q — pencereyi kapatmak yeterli değildir). Claude Desktop yalnızca stdio MCP sunucularını desteklediğinden bu parçacık, proxy olarak {npx} aracılığıyla {mcpRemoteLink} çağırır — Node 18+ kurulu olmalı ve {npx}, Claude Desktop'ın PATH'inden erişilebilir olmalıdır. {commandNotFound} hatası verirse {npxQuoted} yerine {whichNpx} çıktısındaki mutlak yolu yazın.",
+    "claudeCodeDescription": "<label>Claude Code (CLI):</label> doğrudan HTTP konuşur — proxy gerekmez.",
+    "claudeWebDescription": "<label>claude.ai web (Connectors):</label> kendi barındırdığınız FiestaBoard için desteklenmez. Connectors akışı herkese açık bir HTTPS adresi ve OAuth 2.1 dinamik istemci kaydı gerektirir; bir LAN sunucusu bunların ikisini de sağlayamaz. Bunun yerine Desktop veya Code kullanın.",
+    "savedItButton": "Kaydettim",
+    "toastTokenRevoked": "MCP token'ı iptal edildi",
+    "toastCopyFailed": "Kopyalanamadı"
   }
 }

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -50,7 +50,8 @@
     "pageCount": "{count, plural, one {# 个页面} other {# 个页面}}",
     "unknownError": "未知错误",
     "opensInNewTab": "（在新标签页中打开）",
-    "notificationsRegionLabel": "通知"
+    "notificationsRegionLabel": "通知",
+    "versionShort": "v{version}"
   },
   "metadata": {
     "appTitle": "FiestaBoard 控制台",
@@ -81,7 +82,8 @@
     "boardSelector": "选择要管理的板",
     "selectBoard": "选择板",
     "unnamedBoard": "未命名的板",
-    "transitions": "过渡实验室"
+    "transitions": "过渡实验室",
+    "prideCelebration": "骄傲月快乐！"
   },
   "network": {
     "title": "Wi-Fi",
@@ -330,7 +332,11 @@
       "validationOneOffDateRequired": "Please pick a date",
       "validationEndDateBeforeStart": "End date must be on or after start date",
       "collectionSizeWarning": "此合集中的 {total} 个页面中有 {count} 个不适合此板的尺寸，将被跳过。",
-      "incompatiblePageWarning": "此页面与此板的尺寸不匹配，可能无法正确显示。"
+      "incompatiblePageWarning": "此页面与此板的尺寸不匹配，可能无法正确显示。",
+      "monthAriaLabel": "月",
+      "dayAriaLabel": "日",
+      "endMonthAriaLabel": "结束月",
+      "endDayAriaLabel": "结束日"
     },
     "descriptionWithTimezone": "按时间和日期自动轮换页面 · {timezone}",
     "gapDefaultPlaceholder": "空隙默认…",
@@ -472,7 +478,37 @@
     "toastNoUpdates": "所有插件均为最新",
     "toastCheckFailed": "无法检查更新:{error}",
     "installAction": "安装",
-    "installedBadge": "已安装"
+    "installedBadge": "已安装",
+    "valueUnavailable": "不可用",
+    "enablePluginForLiveValues": "启用该插件以查看实时值。",
+    "liveValuesUnavailable": "实时值不可用。",
+    "liveValuesUnavailableWithError": "实时值不可用：{error}",
+    "currentValueColumn": "当前值",
+    "refreshingValues": "刷新中…",
+    "sourceCoreBadge": "核心",
+    "sourceMarketplaceBadge": "Marketplace",
+    "sourceExternalBadge": "外部",
+    "updateAvailableBadge": "更新",
+    "moreOptionsAriaLabel": "更多选项",
+    "addInstanceAction": "添加实例",
+    "instanceNameInlineLabel": "实例名称：",
+    "addInstanceInlineHelp": "创建此插件的一个新的独立实例，它拥有自己的配置。使用字母数字字符、连字符或下划线（1-40 个字符）。",
+    "deleteInstanceConfirmTitle": "删除实例“{label}”？",
+    "deletePluginConfirmTitle": "删除“{name}”？",
+    "deleteInstanceConfirmDescription": "这将永久移除此实例及其配置。此操作无法撤销。",
+    "deletePluginConfirmDescription": "这将永久移除该插件及其所有实例。此操作无法撤销。",
+    "demoPage": {
+      "title": "演示页面",
+      "alreadyExists": "此插件已存在演示页面。",
+      "createDescription": "创建一个可直接使用的页面来展示此插件。",
+      "recreateButton": "重新创建",
+      "recreateConfirmTitle": "重新创建演示页面？",
+      "recreateConfirmDescription": "这将删除现有的演示页面，并使用默认设置创建一个新的。此操作无法撤销。",
+      "creating": "创建中...",
+      "createAction": "创建演示页面",
+      "recreateAction": "重新创建演示页面",
+      "requirementsWarning": "创建演示页面前，请先配置下方的必填设置。"
+    }
   },
   "settings": {
     "title": "设置",
@@ -496,7 +532,43 @@
     "sectionAccount": "账户",
     "sectionAccountDescription": "用户名、密码和退出登录",
     "sectionNetwork": "网络",
-    "sectionNetworkDescription": "管理 Wi-Fi 和连接"
+    "sectionNetworkDescription": "管理 Wi-Fi 和连接",
+    "ai": {
+      "removeProviderAriaLabel": "移除提供商",
+      "cardTitle": "AI 提供商",
+      "cardDescription": "为“Gen AI”页面生成器配置兼容 OpenAI 的 LLM。自带 LLM：FiestaBoard 从不内置密钥。",
+      "privacyNotice": "您的提示词以及已启用插件的变量列表会直接发送给您所配置的提供商。API 密钥保存在本设备上，绝不会发送到其他任何地方。",
+      "emptyState": "尚未配置任何提供商。",
+      "addProviderButton": "添加提供商",
+      "discardButton": "放弃更改",
+      "saveChangesButton": "保存更改",
+      "defaultBadge": "默认",
+      "anthropicBadge": "Anthropic",
+      "makeDefaultButton": "设为默认",
+      "nameLabel": "名称",
+      "protocolLabel": "协议",
+      "protocolOpenaiOption": "兼容 OpenAI（OpenAI、OpenRouter、Groq、DeepSeek、Mistral、Together、Fireworks、Ollama、LM Studio、vLLM、…）",
+      "protocolAnthropicOption": "Anthropic (Messages API)",
+      "baseUrlLabel": "基础 URL",
+      "quickPresetsLabel": "快速预设",
+      "apiKeyLabel": "API 密钥",
+      "modelsLabel": "模型",
+      "defaultModelLabel": "默认模型",
+      "testConnectionButton": "测试连接"
+    },
+    "backup": {
+      "cardTitle": "备份与恢复",
+      "cardDescription": "将您全部的 FiestaBoard 配置 — 看板设置、页面、轮播、日程和插件配置 — 导出为单个 JSON 文件。在新实例上重新上传该文件即可迁移，或在升级后恢复。",
+      "exportButton": "导出备份",
+      "importButton": "导入备份…",
+      "reinstallPluginsLabel": "导入后重新安装外部插件",
+      "reinstallPluginsDescription": "启用后，FiestaBoard 会尝试克隆备份中记录、但此实例上尚未安装的外部插件。无论是否启用，它们的配置都会从备份中恢复。",
+      "sensitiveNote": "注意：备份中以明文形式包含 API 密钥和看板凭据等敏感值。请妥善保管该文件，不要公开分享。",
+      "confirmTitle": "替换当前配置？",
+      "confirmDescription": "您即将恢复 <file></file>。您现有的页面、轮播、日程和配置将被覆盖。每个现有文件都会保留一份带时间戳的副本，与新文件放在一起，必要时可手动回滚。",
+      "restoringButton": "恢复中…",
+      "restoreButton": "恢复备份"
+    }
   },
   "offline": {
     "youreOffline": "您已离线",
@@ -581,7 +653,10 @@
       "passwordPlaceholder": "YourPassword",
       "wifiPreview": "WIFI：{ssid}",
       "passPreview": "密码：{password}",
-      "noPassword": "（无密码）"
+      "noPassword": "（无密码）",
+      "addMoreHint": "您随时可以从<link>集成</link>页面添加更多。",
+      "builtInBadge": "内置",
+      "previewLabel": "预览："
     },
     "welcome": {
       "setupComplete": "设置完成！",
@@ -639,7 +714,9 @@
     "changeModeDisableTitle": "关闭计划模式",
     "changeModeDisableDescription": "禁用计划并手动控制 board。",
     "changeModeDisableSuccess": "计划模式已禁用",
-    "collectionSizeWarning": "此合集中的 {total} 个页面中有 {count} 个不适合此板的尺寸，将被跳过。"
+    "collectionSizeWarning": "此合集中的 {total} 个页面中有 {count} 个不适合此板的尺寸，将被跳过。",
+    "turnOffLiveModeAriaLabel": "关闭实时模式",
+    "liveModeBadge": "实时模式"
   },
   "forceSetDialog": {
     "title": "强制设置 Board",
@@ -882,7 +959,10 @@
     "updateNow": "立即更新",
     "oneClickHint": "想在这里有一个一键 \"立即更新\" 按钮吗?在您的 <envFile></envFile> 中设置 <profile></profile>,然后运行 <command></command>。",
     "dialogTitle": "更新 FiestaBoard?",
-    "dialogDescription": "这将拉取 <version></version> 并重启 FiestaBoard。Board 显示将暂停约 30 秒,此页面将自动重新加载。"
+    "dialogDescription": "这将拉取 <version></version> 并重启 FiestaBoard。Board 显示将暂停约 30 秒,此页面将自动重新加载。",
+    "intervalSelectAriaLabel": "更新检查频率",
+    "intervalCardDescription": "FiestaBoard 在后台检查新版本的频率。发现新版本时，这里会显示横幅。",
+    "lastChecked": "上次检查：{time}"
   },
   "transitionSettings": {
     "title": "看板过渡效果",
@@ -1008,7 +1088,8 @@
       "Numbers": "数字",
       "Symbols": "符号",
       "Colors": "颜色"
-    }
+    },
+    "latencyMs": "{ms} 毫秒"
   },
   "generalSettings": {
     "title": "通用设置",
@@ -1375,7 +1456,8 @@
     "flapSpeed_relaxedHint": "{ms} 毫秒 — 缓慢而从容的翻转，适合氛围展示。",
     "flapSpeedPreviewLabel": "预览",
     "flapSpeedInactive": "board 动画已关闭，因此翻转速度不起作用。",
-    "flapSpeedScreenOnlyNote": "这只会改变屏幕上的 board 预览。实体 Vestaboard 自身的过渡节奏另在「行为 → Board 过渡」中设置。"
+    "flapSpeedScreenOnlyNote": "这只会改变屏幕上的 board 预览。实体 Vestaboard 自身的过渡节奏另在「行为 → Board 过渡」中设置。",
+    "updateAvailableBadge": "v{version} 可用"
   },
   "monitor": {
     "title": "监视器",
@@ -1647,7 +1729,8 @@
     "whiteBoard": "白色显示屏",
     "deviceFlagship": "Flagship",
     "deviceNote": "Note",
-    "deviceNoteArray": "Note 阵列 {w}×{h}"
+    "deviceNoteArray": "Note 阵列 {w}×{h}",
+    "githubLink": "GitHub"
   },
   "boardDisplay": {
     "loading": "加载 board 显示中",
@@ -1736,7 +1819,12 @@
     "remoteOptionsSearchPlaceholder": "搜索…",
     "remoteOptionsCustomLabel": "自定义值",
     "remoteOptionsCustomPlaceholder": "输入列表中没有的值",
-    "remoteOptionsCustomAdd": "添加自定义值"
+    "remoteOptionsCustomAdd": "添加自定义值",
+    "addItemLabel": "添加{label}",
+    "unknownType": "未知类型：{type}",
+    "pagePickerNone": "无（不覆盖）",
+    "pagePickerLoading": "正在加载页面…",
+    "pagePickerPlaceholder": "选择页面…"
   },
   "filterPicker": {
     "noFiltersAvailable": "没有可用的筛选器",
@@ -1744,7 +1832,8 @@
     "filterDescWrap": "将长文本换行到多行",
     "filterDescPad": "将文本填充到指定宽度",
     "filterDescTruncate": "将文本截断到指定长度",
-    "wrapInstruction": "|wrap:换行长文本。在下方留空行,以便文本流入。"
+    "wrapInstruction": "换行长文本。在下方留空行,以便文本流入。",
+    "exampleLabel": "示例：{example}"
   },
   "formattingPicker": {
     "noFormattingAvailable": "没有可用的格式化选项",
@@ -1805,7 +1894,25 @@
     "alignRight": "右对齐",
     "syncFromBoardTooltip": "从当前 board 上显示的内容填充模板",
     "syncFromBoard": "从当前 board 显示同步",
-    "alignment": "对齐:"
+    "alignment": "对齐:",
+    "undoAriaLabel": "撤销",
+    "redoAriaLabel": "重做",
+    "cutAriaLabel": "剪切",
+    "copyAriaLabel": "复制",
+    "pasteAriaLabel": "粘贴",
+    "removeWrappedTextAriaLabel": "移除换行文本",
+    "colorPickerAriaLabel": "颜色选择器",
+    "heartCharacterAriaLabel": "心形字符",
+    "lineCount": "{used} / {max} 行",
+    "overLineLimit": " — 超出 {max} 行的看板上限",
+    "currentLine": "（第 {line} 行）",
+    "heartLabel": "心形",
+    "insertHeartTooltip": "插入心形字符（仅限 Note）",
+    "colorTileTooltip": "{color} 色块（代码 {code}）- 拖动可移动，按 backspace 删除",
+    "fillSpaceTooltip": "填充空间 - 扩展以填满该行剩余宽度",
+    "fillSpaceRepeatTooltip": "重复填充空间：{char}",
+    "variableFilterTooltip": "筛选器：{filter}",
+    "variableMaxLengthTooltip": "最大长度：{maxLength} 个字符"
   },
   "variablePicker": {
     "noVariablesAvailable": "没有可用的变量",
@@ -1815,7 +1922,8 @@
     "searchPlaceholder": "搜索变量...",
     "indexLabel": "索引:{index}",
     "configureHint": "在设置中配置 {arrayName} 以在此查看索引变量。",
-    "configureExample": "示例:"
+    "configureExample": "示例:",
+    "noMatchingVariables": "未找到匹配的变量。"
   },
   "login": {
     "signInTitle": "登录 FiestaBoard",
@@ -1873,11 +1981,62 @@
     "taskStatusAriaLabel": "任务进度",
     "taskProgressAriaLabel": "AI 任务进度",
     "clearConversationAriaLabel": "清除对话",
-    "closePanelAriaLabel": "关闭 FiestaBot (Beta)"
+    "closePanelAriaLabel": "关闭 FiestaBot (Beta)",
+    "providerSelectAriaLabel": "提供商",
+    "modelSelectAriaLabel": "模型",
+    "showBoardTooltip": "显示看板预览",
+    "hideBoardTooltip": "隐藏看板预览",
+    "undoTooltip": "撤销上一次 AI 更改",
+    "panelTitle": "FiestaBot (Beta)",
+    "retryButton": "重试",
+    "messageLabel": "消息",
+    "stopButton": "停止",
+    "sendButton": "发送",
+    "tasksHeading": "任务（{done}/{total}）",
+    "emptyStateTitle": "需要什么帮助？",
+    "emptyStateDescription": "描述您想要构建或更改的内容。",
+    "showBoardButton": "显示看板",
+    "undoButton": "撤销",
+    "renameSummary": "→ 重命名为“{name}”",
+    "previewUnavailable": "（预览不可用）"
   },
   "boardSizeIndicator": {
     "custom": "自定义",
     "ariaLabel": "{rows}行×{cols}列",
     "ariaLabelWithLayout": "{rows}行×{cols}列，{layout}"
+  },
+  "mcpSettings": {
+    "title": "MCP / 外部客户端",
+    "description": "一个预共享令牌，让 Claude Desktop、Claude Code 及其他 MCP 客户端能够与此 FiestaBoard 通信。该令牌以单一主体身份认证 — 仅限 {endpoint} 端点 — 因此无法编辑页面或其他设置。客户端相关的注意事项请参阅 <link>MCP 客户端设置</link>（Desktop 需要 stdio 代理；claude.ai 网页版 Connectors 需要公网 HTTPS 和 OAuth，因此无法访问 LAN 主机）。",
+    "statusLabel": "状态：",
+    "pinnedByEnvBadge": "由 {envVar} 固定",
+    "configuredBadge": "已配置",
+    "pinnedByEnvDescription": "当前令牌由 {envVar} 环境变量设置。请先在 {envFile} 中取消设置该变量并重启容器，然后再从此界面管理令牌。",
+    "noTokenDescription": "尚未配置令牌。外部 MCP 客户端将退回到 Cookie 认证，而 Claude Desktop / Claude Code 并不支持它 — 它们会以一个含义不明的错误注册失败。生成一个令牌即可解除阻塞。",
+    "activeTokenDescription": "已配置并启用令牌。轮换令牌会使上一个令牌失效（仍在使用旧令牌的客户端将开始收到 401），也可以将其完全吊销，退回到仅 Cookie 认证。",
+    "rotateTokenButton": "轮换令牌",
+    "generateTokenButton": "生成令牌",
+    "revokeTokenButton": "吊销令牌",
+    "rotateConfirmTitle": "轮换 MCP 令牌？",
+    "generateConfirmTitle": "生成 MCP 令牌？",
+    "rotateConfirmDescription": "仍在使用旧令牌的客户端在下一次请求时会被拒绝，并收到 401 + Bearer 质询。新令牌只会显示一次 — 请妥善保管（之后无法再从界面中查看）。",
+    "generateConfirmDescription": "令牌只会显示一次 — 请妥善保管（之后无法再从界面中查看）。外部 MCP 客户端将使用它向 {endpoint} 认证。",
+    "rotateConfirmButton": "轮换",
+    "generateConfirmButton": "生成",
+    "revokeConfirmTitle": "吊销 MCP 令牌？",
+    "revokeConfirmDescription": "外部 MCP 客户端在下一次请求时将开始收到 401。您随时可以再生成新的令牌。",
+    "revokeConfirmButton": "吊销",
+    "revealTitle": "保存此令牌",
+    "revealDescription": "FiestaBoard 只保存验证后续请求所需的内容 — 这是唯一一次显示明文值。请立即将它复制到您的 MCP 客户端。",
+    "tokenLabel": "令牌",
+    "copyButton": "复制",
+    "copiedButton": "已复制",
+    "configSnippetLabel": "Claude Desktop 配置代码片段",
+    "configSnippetDescription": "将此内容粘贴到 {configPath}，与已有内容合并，然后完全退出并重新启动 Claude Desktop（⌘Q — 仅关闭窗口是不够的）。Claude Desktop 仅支持 stdio MCP 服务器，因此此代码片段会通过 {npx} 调用 {mcpRemoteLink} 作为代理 — 必须安装 Node 18+，并且能从 Claude Desktop 的 PATH 中访问到 {npx}。如果报错 {commandNotFound}，请将 {npxQuoted} 替换为 {whichNpx} 输出的绝对路径。",
+    "claudeCodeDescription": "<label>Claude Code (CLI)：</label>直接使用 HTTP 通信 — 无需代理。",
+    "claudeWebDescription": "<label>claude.ai 网页版（Connectors）：</label>自托管的 FiestaBoard 不支持。Connectors 流程需要公网 HTTPS URL 和 OAuth 2.1 动态客户端注册，而 LAN 主机两者都无法提供。请改用 Desktop 或 Code。",
+    "savedItButton": "我已保存",
+    "toastTokenRevoked": "MCP 令牌已吊销",
+    "toastCopyFailed": "无法复制到剪贴板"
   }
 }

--- a/web/src/components/active-page-display.tsx
+++ b/web/src/components/active-page-display.tsx
@@ -539,12 +539,12 @@ export function ActivePageDisplay() {
                 className="text-xs gap-1 animate-pulse pr-1 cursor-pointer hover:opacity-90 focus-within:ring-2 focus-within:ring-ring"
               >
                 <Radio className="h-3 w-3" aria-hidden="true" />
-                Live Mode
+                {t("liveModeBadge")}
                 <button
                   type="button"
                   onClick={handleDisableLiveMode}
-                  aria-label="Turn off Live Mode"
-                  title="Turn off Live Mode"
+                  aria-label={t("turnOffLiveModeAriaLabel")}
+                  title={t("turnOffLiveModeAriaLabel")}
                   className="ml-0.5 inline-flex items-center justify-center rounded-sm hover:bg-black/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                 >
                   <X className="h-3 w-3" aria-hidden="true" />

--- a/web/src/components/ai-chat-panel.tsx
+++ b/web/src/components/ai-chat-panel.tsx
@@ -201,7 +201,7 @@ export function AiChatPanel({
           <Flex align="center" gap="2" className="min-w-0">
             <Sparkles className="h-4 w-4 shrink-0 text-brand-emphasis" />
             <Text as="span" size="sm" weight="semibold" className="truncate">
-              FiestaBot (Beta)
+              {t("panelTitle")}
             </Text>
             {status === "streaming" && <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />}
           </Flex>
@@ -271,7 +271,7 @@ export function AiChatPanel({
                   <Box className="mt-1.5">
                     <Button size="sm" variant="outline" className="h-7 text-xs" onClick={retryLast}>
                       <RotateCcw className="mr-1 h-3 w-3" />
-                      Retry
+                      {t("retryButton")}
                     </Button>
                   </Box>
                 </AlertDescription>
@@ -288,7 +288,7 @@ export function AiChatPanel({
          *  well in narrow chat-pane widths. */}
         <Flex direction="col" gap="2" className="flex-shrink-0 border-t bg-card px-4 py-4">
           <Label htmlFor="ai-chat-input" className="sr-only">
-            Message
+            {t("messageLabel")}
           </Label>
           <Textarea
             id="ai-chat-input"
@@ -317,14 +317,14 @@ export function AiChatPanel({
                 model={effectiveModel}
                 onModelChange={setModel}
               />
-              <Text as="span" tone="muted" className="text-[10px]">
-                ⌘/Ctrl+Enter
-              </Text>
+              {/* Keyboard shortcut glyphs are never translated. `Code` keeps them
+                  exempt from i18next/no-literal-string without a disable comment. */}
+              <Code className="bg-transparent px-0 py-0 text-[10px] text-muted-foreground">⌘/Ctrl+Enter</Code>
             </Flex>
             {status === "streaming" ? (
               <Button type="button" size="sm" variant="outline" className="h-7 gap-1 text-xs" onClick={cancel}>
                 <Square className="h-3 w-3" />
-                Stop
+                {t("stopButton")}
               </Button>
             ) : (
               <Button
@@ -336,7 +336,7 @@ export function AiChatPanel({
                 disabled={!draft.trim() || blocked}
               >
                 <Send className="h-3 w-3" />
-                Send
+                {t("sendButton")}
               </Button>
             )}
           </Flex>
@@ -392,7 +392,7 @@ function TaskListPanel({ tasks }: { tasks: TaskItem[] }) {
     >
       <Flex align="center" justify="between" className="mb-1.5">
         <Text as="span" weight="medium" tone="muted" className="text-[10px] uppercase tracking-wide">
-          Tasks ({doneCount}/{tasks.length})
+          {t("tasksHeading", { done: doneCount, total: tasks.length })}
         </Text>
         <Box
           role="progressbar"
@@ -459,6 +459,7 @@ function GradientSparkles({ className }: { className?: string }) {
 }
 
 function EmptyState({ blocked, aiDisabled }: { blocked: boolean; aiDisabled: boolean }) {
+  const t = useTranslations("aiChatPanel");
   if (blocked) {
     return (
       <Alert variant="destructive" className="text-xs">
@@ -475,9 +476,9 @@ function EmptyState({ blocked, aiDisabled }: { blocked: boolean; aiDisabled: boo
     <Flex direction="col" align="center" gap="5" className="px-2 py-6 text-center">
       <GradientSparkles className="h-8 w-8" />
       <Box>
-        <Text weight="medium">How can I help?</Text>
+        <Text weight="medium">{t("emptyStateTitle")}</Text>
         <Text size="xs" tone="muted" className="mt-1">
-          Describe what you&apos;d like to build or change.
+          {t("emptyStateDescription")}
         </Text>
       </Box>
       <Stack gap="2" className="w-full text-left text-xs">
@@ -520,6 +521,7 @@ function ModelPill({
   model: string;
   onModelChange: (m: string) => void;
 }) {
+  const t = useTranslations("aiChatPanel");
   const onlyOneProvider = providers.length <= 1;
   const shortModel = model ? model.split("/").slice(-1)[0] || model : "Default";
   return (
@@ -528,7 +530,7 @@ function ModelPill({
         <Select value={providerId} onValueChange={onProviderChange}>
           <SelectTrigger
             className="h-6 gap-1 rounded-full border-border/60 bg-muted/40 px-2 text-[11px] shadow-none hover:bg-muted/70"
-            aria-label="Provider"
+            aria-label={t("providerSelectAriaLabel")}
           >
             <SelectValue placeholder="Default" />
           </SelectTrigger>
@@ -544,7 +546,7 @@ function ModelPill({
       <Select value={model} onValueChange={onModelChange} disabled={models.length === 0}>
         <SelectTrigger
           className="h-6 max-w-[180px] gap-1 truncate rounded-full border-border/60 bg-muted/40 px-2 font-mono text-[11px] shadow-none hover:bg-muted/70"
-          aria-label="Model"
+          aria-label={t("modelSelectAriaLabel")}
           title={model}
         >
           <SelectValue>
@@ -676,6 +678,7 @@ function ToolCallCard({
   boardVisible: boolean;
   onToggleBoard: () => void;
 }) {
+  const t = useTranslations("aiChatPanel");
   const deviceType = call.deviceType ?? "flagship";
   const hasBoard = !!call.appliedSnapshot;
   return (
@@ -692,10 +695,10 @@ function ToolCallCard({
               variant="ghost"
               className="h-6 gap-1 px-1.5 text-[11px] text-muted-foreground"
               onClick={onToggleBoard}
-              title="Show board preview"
+              title={t("showBoardTooltip")}
             >
               <Eye className="h-3 w-3" />
-              Show board
+              {t("showBoardButton")}
             </Button>
           )}
           {hasBoard && boardVisible && !showUndo && (
@@ -705,7 +708,7 @@ function ToolCallCard({
               variant="ghost"
               className="h-6 gap-1 px-1.5 text-[11px] text-muted-foreground"
               onClick={onToggleBoard}
-              title="Hide board preview"
+              title={t("hideBoardTooltip")}
             >
               <EyeOff className="h-3 w-3" />
             </Button>
@@ -717,10 +720,10 @@ function ToolCallCard({
               variant="ghost"
               className="h-6 gap-1 px-1.5 text-[11px]"
               onClick={onUndo}
-              title="Undo last AI change"
+              title={t("undoTooltip")}
             >
               <Undo2 className="h-3 w-3" />
-              Undo
+              {t("undoButton")}
             </Button>
           )}
         </Flex>
@@ -775,6 +778,7 @@ function labelFor(call: ToolCall): string {
 }
 
 function ToolCallSummary({ call }: { call: ToolCall }) {
+  const t = useTranslations("aiChatPanel");
   // `replace_page` is fully described by the inline board preview
   // above; rendering a JSON line-dump here would just duplicate the
   // visual. Keep the card lean.
@@ -796,7 +800,7 @@ function ToolCallSummary({ call }: { call: ToolCall }) {
             </ListItem>
           ))}
           {call.args.rename && (
-            <ListItem className="break-all font-mono">→ rename to &quot;{call.args.rename}&quot;</ListItem>
+            <ListItem className="break-all font-mono">{t("renameSummary", { name: call.args.rename })}</ListItem>
           )}
         </List>
       </PatchDetailDisclosure>

--- a/web/src/components/inline-board-preview.tsx
+++ b/web/src/components/inline-board-preview.tsx
@@ -4,6 +4,7 @@ import { Box, Text } from "@fiestaboard/ui";
 import { useQuery } from "@tanstack/react-query";
 
 import { ScaledBoardDisplay } from "@/components/scaled-board-display";
+import { useTranslations } from "@/i18n/translations";
 import type { CurrentPageSnapshot } from "@/lib/ai-chat-types";
 import { api, type DeviceType } from "@/lib/api";
 
@@ -41,6 +42,7 @@ export interface InlineBoardPreviewProps {
  * snapshots dedupe across multiple tool calls in the same session.
  */
 export function InlineBoardPreview({ snapshot, deviceType, size = "sm", className }: InlineBoardPreviewProps) {
+  const t = useTranslations("aiChatPanel");
   const { data, isLoading, isError } = useQuery({
     queryKey: ["inline-preview-render", deviceType, snapshot.template, snapshot.line_metadata],
     queryFn: () => api.renderTemplate(snapshot.template, snapshot.line_metadata, deviceType),
@@ -56,7 +58,7 @@ export function InlineBoardPreview({ snapshot, deviceType, size = "sm", classNam
     // back to a quiet hint. The card still has a useful summary.
     return (
       <Text tone="muted" className="text-[10px] italic">
-        (preview unavailable)
+        {t("previewUnavailable")}
       </Text>
     );
   }

--- a/web/src/components/navigation-sidebar.tsx
+++ b/web/src/components/navigation-sidebar.tsx
@@ -64,6 +64,39 @@ const secondaryItems: NavItemDef[] = [
 ];
 
 /**
+ * Toast body for the seasonal celebration burst.
+ *
+ * Kept as its own component (rather than inline JSX in `fireCelebration`)
+ * so the translation hook lives here instead of being captured by the
+ * `useCallback` closure — `t` in a dependency array is the infinite-render
+ * trap from issue #1570.
+ */
+function PrideCelebrationToast() {
+  const t = useTranslations("navigation");
+  return (
+    <Flex
+      align="center"
+      gap="2"
+      className="rounded-full border border-white/10 bg-[#111] px-5 py-2.5 text-[15px] font-bold shadow-xl"
+    >
+      <Text
+        as="span"
+        className="text-[15px] font-bold"
+        style={{
+          background: "linear-gradient(90deg, #e40303, #ff8c00, #ffed00, #008026, #004dff, #750787)",
+          WebkitBackgroundClip: "text",
+          WebkitTextFillColor: "transparent",
+          backgroundClip: "text",
+        }}
+      >
+        {t("prideCelebration")}
+      </Text>{" "}
+      🏳️‍🌈
+    </Flex>
+  );
+}
+
+/**
  * App wiring around the design system's presentational <Sidebar> — routes,
  * i18n labels, board context, collapse persistence, AI/beta feature flags,
  * and the seasonal celebration all live here; every pixel lives in
@@ -83,27 +116,7 @@ export function NavigationSidebar() {
     (e: React.MouseEvent) => {
       if (!season) return;
       fireSeasonBurst(e, season.colors);
-      toast.custom(() => (
-        <Flex
-          align="center"
-          gap="2"
-          className="rounded-full border border-white/10 bg-[#111] px-5 py-2.5 text-[15px] font-bold shadow-xl"
-        >
-          <Text
-            as="span"
-            className="text-[15px] font-bold"
-            style={{
-              background: "linear-gradient(90deg, #e40303, #ff8c00, #ffed00, #008026, #004dff, #750787)",
-              WebkitBackgroundClip: "text",
-              WebkitTextFillColor: "transparent",
-              backgroundClip: "text",
-            }}
-          >
-            Happy Pride!
-          </Text>{" "}
-          🏳️‍🌈
-        </Flex>
-      ));
+      toast.custom(() => <PrideCelebrationToast />);
     },
     [season],
   );

--- a/web/src/components/plugin-settings/json-tree.tsx
+++ b/web/src/components/plugin-settings/json-tree.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Box, Flex, Stack, Text } from "@fiestaboard/ui";
+import { Box, Code, Flex, Stack, Text } from "@fiestaboard/ui";
 import { Check, ChevronDown, ChevronRight, Copy } from "lucide-react";
 import React, { useState } from "react";
 
@@ -31,9 +31,9 @@ export function JsonTree({ data, path, onSelect, defaultExpanded = false }: Json
 
   if (data === null || data === undefined) {
     return (
-      <Text as="span" size="xs" tone="muted" className="italic">
-        null
-      </Text>
+      // `null` is the JSON value itself, not copy — rendered through Code so it
+      // stays verbatim in every locale.
+      <Code className="bg-transparent px-0 py-0 text-xs italic text-muted-foreground">null</Code>
     );
   }
 

--- a/web/src/components/plugin-settings/page-picker-field.tsx
+++ b/web/src/components/plugin-settings/page-picker-field.tsx
@@ -3,6 +3,7 @@
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@fiestaboard/ui";
 import { useQuery } from "@tanstack/react-query";
 
+import { useTranslations } from "@/i18n/translations";
 import { api } from "@/lib/api";
 
 interface PagePickerFieldProps {
@@ -17,6 +18,7 @@ interface PagePickerFieldProps {
 const NONE_VALUE = "__none__";
 
 export function PagePickerField({ id, value, onChange, disabled }: PagePickerFieldProps) {
+  const t = useTranslations("schemaForm");
   const { data: pagesData, isLoading } = useQuery({
     queryKey: ["pages"],
     queryFn: api.getPages,
@@ -33,10 +35,10 @@ export function PagePickerField({ id, value, onChange, disabled }: PagePickerFie
       modal={false}
     >
       <SelectTrigger id={id}>
-        <SelectValue placeholder={isLoading ? "Loading pages…" : "Choose a page…"} />
+        <SelectValue placeholder={isLoading ? t("pagePickerLoading") : t("pagePickerPlaceholder")} />
       </SelectTrigger>
       <SelectContent className="max-h-[300px] z-[120]">
-        <SelectItem value={NONE_VALUE}>None (no override)</SelectItem>
+        <SelectItem value={NONE_VALUE}>{t("pagePickerNone")}</SelectItem>
         {pages.map((page) => (
           <SelectItem key={page.id} value={page.id}>
             {page.name}

--- a/web/src/components/plugin-settings/schema-form.tsx
+++ b/web/src/components/plugin-settings/schema-form.tsx
@@ -710,7 +710,7 @@ function ArrayField({ name, property, value, onChange, disabled, itemSchema }: A
       {canAdd && (
         <Button type="button" variant="outline" size="sm" onClick={handleAdd} disabled={disabled} className="w-full">
           <Plus className="h-4 w-4 mr-2" />
-          Add {property.title || name}
+          {t("addItemLabel", { label: property.title || name })}
         </Button>
       )}
     </Stack>
@@ -861,7 +861,7 @@ function FormField({
       }
       return <Text tone="muted">{t("objectTypeNoProperties")}</Text>;
     default:
-      return <Text tone="muted">Unknown type: {property.type}</Text>;
+      return <Text tone="muted">{t("unknownType", { type: property.type })}</Text>;
   }
 }
 

--- a/web/src/components/schedule-entry-form.tsx
+++ b/web/src/components/schedule-entry-form.tsx
@@ -575,7 +575,7 @@ export function ScheduleEntryForm({
             <Label>{t("scheduleEntryForm.annualDateLabel")}</Label>
             <Flex gap="2">
               <Select value={annualMonth} onValueChange={setAnnualMonth}>
-                <SelectTrigger className="flex-1" aria-label="Month">
+                <SelectTrigger className="flex-1" aria-label={t("scheduleEntryForm.monthAriaLabel")}>
                   <SelectValue placeholder="MM" />
                 </SelectTrigger>
                 <SelectContent className="max-h-60">
@@ -587,7 +587,7 @@ export function ScheduleEntryForm({
                 </SelectContent>
               </Select>
               <Select value={annualDay} onValueChange={setAnnualDay}>
-                <SelectTrigger className="flex-1" aria-label="Day">
+                <SelectTrigger className="flex-1" aria-label={t("scheduleEntryForm.dayAriaLabel")}>
                   <SelectValue placeholder="DD" />
                 </SelectTrigger>
                 <SelectContent className="max-h-60">
@@ -613,7 +613,7 @@ export function ScheduleEntryForm({
               <Label>{t("scheduleEntryForm.annualEndDateLabel")}</Label>
               <Flex gap="2">
                 <Select value={annualEndMonth} onValueChange={setAnnualEndMonth}>
-                  <SelectTrigger className="flex-1" aria-label="End month">
+                  <SelectTrigger className="flex-1" aria-label={t("scheduleEntryForm.endMonthAriaLabel")}>
                     <SelectValue placeholder="MM" />
                   </SelectTrigger>
                   <SelectContent className="max-h-60">
@@ -625,7 +625,7 @@ export function ScheduleEntryForm({
                   </SelectContent>
                 </Select>
                 <Select value={annualEndDay} onValueChange={setAnnualEndDay}>
-                  <SelectTrigger className="flex-1" aria-label="End day">
+                  <SelectTrigger className="flex-1" aria-label={t("scheduleEntryForm.endDayAriaLabel")}>
                     <SelectValue placeholder="DD" />
                   </SelectTrigger>
                   <SelectContent className="max-h-60">
@@ -687,9 +687,9 @@ export function ScheduleEntryForm({
       <Flex align="center" justify="between" className="rounded-lg border p-4">
         <Stack gap="0.5">
           <Label htmlFor="enabled" className="text-base">
-            Enabled
+            {t("scheduleEntryForm.enabledLabel")}
           </Label>
-          <Text tone="muted">Schedule will be active when enabled</Text>
+          <Text tone="muted">{t("scheduleEntryForm.enabledDescription")}</Text>
         </Stack>
         <Switch id="enabled" checked={enabled} onCheckedChange={setEnabled} />
       </Flex>

--- a/web/src/components/schedule/schedule-event.tsx
+++ b/web/src/components/schedule/schedule-event.tsx
@@ -30,6 +30,7 @@ export function ScheduleEvent({ event }: ScheduleEventProps) {
 }
 
 function RegularScheduleEvent({ event }: { event: ScheduleCalendarEvent }) {
+  const tCommon = useTranslations("common");
   const { resource } = event;
 
   // Generate consistent color based on schedule ID (so each schedule entry has unique color)
@@ -106,7 +107,7 @@ function RegularScheduleEvent({ event }: { event: ScheduleCalendarEvent }) {
         )}
         {!resource.enabled && (
           <Badge variant="secondary" className="w-fit text-[10px] px-1 py-0 h-3.5">
-            Off
+            {tCommon("off")}
           </Badge>
         )}
         {resource.dayPattern !== "all" && (

--- a/web/src/components/settings/about-card.tsx
+++ b/web/src/components/settings/about-card.tsx
@@ -24,6 +24,7 @@ import { cn } from "@/lib/utils";
 
 export function AboutCard() {
   const t = useTranslations("profile");
+  const tCommon = useTranslations("common");
 
   const { data: versionData, isLoading: isLoadingVersion } = useQuery({
     queryKey: ["version"],
@@ -92,7 +93,7 @@ export function AboutCard() {
                 <Flex align="center" gap="2">
                   <Package className="h-3.5 w-3.5 text-muted-foreground" />
                   <Text as="span" className="font-mono tabular-nums">
-                    v{versionData.package_version}
+                    {tCommon("versionShort", { version: versionData.package_version })}
                   </Text>
                   {versionData.is_dev && (
                     <Badge variant="secondary" className="text-xs">
@@ -101,7 +102,7 @@ export function AboutCard() {
                   )}
                   {!managedExternally && updateCheck?.update_available && (
                     <Badge variant="outline" className="text-xs text-warning border-warning/50">
-                      v{updateCheck.latest_version} available
+                      {t("updateAvailableBadge", { version: updateCheck.latest_version })}
                     </Badge>
                   )}
                 </Flex>

--- a/web/src/components/settings/ai-settings.tsx
+++ b/web/src/components/settings/ai-settings.tsx
@@ -43,6 +43,7 @@ import {
 import { useState } from "react";
 import { toast } from "sonner";
 
+import { useTranslations } from "@/i18n/translations";
 import type { AIProvider, AISettings } from "@/lib/api";
 import { api } from "@/lib/api";
 
@@ -108,6 +109,7 @@ function ProviderRow({
   onRemove,
   onMakeDefault,
 }: ProviderRowProps) {
+  const t = useTranslations("settings.ai");
   const [showKey, setShowKey] = useState(false);
   const [modelInput, setModelInput] = useState("");
   const [testing, setTesting] = useState(false);
@@ -175,12 +177,12 @@ function ProviderRow({
           </Text>
           {isDefault && (
             <Badge variant="default" className="h-5 text-[10px] shrink-0">
-              Default
+              {t("defaultBadge")}
             </Badge>
           )}
           {provider.protocol === "anthropic" && (
             <Badge variant="outline" className="h-5 text-[10px] shrink-0">
-              Anthropic
+              {t("anthropicBadge")}
             </Badge>
           )}
           <Text as="span" tone="muted" className="text-[11px] shrink-0">
@@ -198,7 +200,7 @@ function ProviderRow({
               disabled={provider.models.length === 0}
               title={provider.models.length === 0 ? "Add at least one model first" : "Make this the default provider"}
             >
-              Make default
+              {t("makeDefaultButton")}
             </Button>
           )}
           <Button
@@ -207,7 +209,7 @@ function ProviderRow({
             variant="ghost"
             className="h-7 w-7 text-destructive hover:text-destructive hover:bg-destructive/10"
             onClick={onRemove}
-            aria-label="Remove provider"
+            aria-label={t("removeProviderAriaLabel")}
           >
             <Trash2 className="h-3.5 w-3.5" />
           </Button>
@@ -218,7 +220,7 @@ function ProviderRow({
         <Stack gap="3" className="border-t p-3">
           <Stack gap="1.5">
             <Label htmlFor={`name-${provider.id}`} className="text-xs">
-              Name
+              {t("nameLabel")}
             </Label>
             <Input
               id={`name-${provider.id}`}
@@ -231,7 +233,7 @@ function ProviderRow({
 
           <Stack gap="1.5">
             <Label htmlFor={`protocol-${provider.id}`} className="text-xs">
-              Protocol
+              {t("protocolLabel")}
             </Label>
             <Select
               value={provider.protocol ?? "openai"}
@@ -246,18 +248,15 @@ function ProviderRow({
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="openai">
-                  OpenAI-compatible (OpenAI, OpenRouter, Groq, DeepSeek, Mistral, Together, Fireworks, Ollama, LM
-                  Studio, vLLM, …)
-                </SelectItem>
-                <SelectItem value="anthropic">Anthropic (Messages API)</SelectItem>
+                <SelectItem value="openai">{t("protocolOpenaiOption")}</SelectItem>
+                <SelectItem value="anthropic">{t("protocolAnthropicOption")}</SelectItem>
               </SelectContent>
             </Select>
           </Stack>
 
           <Stack gap="1.5">
             <Label htmlFor={`url-${provider.id}`} className="text-xs">
-              Base URL
+              {t("baseUrlLabel")}
             </Label>
             <Input
               id={`url-${provider.id}`}
@@ -268,7 +267,7 @@ function ProviderRow({
             />
             <Stack gap="1" className="rounded-md border border-dashed bg-muted/30 p-2">
               <Text weight="medium" tone="muted" className="text-[10px] uppercase tracking-wide">
-                Quick presets
+                {t("quickPresetsLabel")}
               </Text>
               {(["cloud", "local"] as const).map((group) => {
                 const presets = PROVIDER_PRESETS.filter((p) => p.group === group);
@@ -306,7 +305,7 @@ function ProviderRow({
 
           <Stack gap="1.5">
             <Label htmlFor={`key-${provider.id}`} className="text-xs">
-              API Key
+              {t("apiKeyLabel")}
             </Label>
             <Box className="relative">
               <KeyRound className="pointer-events-none absolute left-2 top-2 h-3.5 w-3.5 text-muted-foreground" />
@@ -332,7 +331,7 @@ function ProviderRow({
           </Stack>
 
           <Stack gap="1.5">
-            <Label className="text-xs">Models</Label>
+            <Label className="text-xs">{t("modelsLabel")}</Label>
             <Flex gap="1.5">
               <Input
                 value={modelInput}
@@ -373,7 +372,7 @@ function ProviderRow({
           {provider.models.length > 0 && (
             <Stack gap="1.5">
               <Label htmlFor={`default-${provider.id}`} className="text-xs">
-                Default model
+                {t("defaultModelLabel")}
               </Label>
               <Select
                 value={provider.default_model || provider.models[0]}
@@ -404,7 +403,7 @@ function ProviderRow({
             >
               {testing ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Sparkles className="h-3.5 w-3.5" />}
               <Text as="span" size="xs">
-                Test connection
+                {t("testConnectionButton")}
               </Text>
             </Button>
             {testResult && (
@@ -423,6 +422,8 @@ function ProviderRow({
 }
 
 export function AiSettings() {
+  const t = useTranslations("settings.ai");
+  const tCommon = useTranslations("common");
   const queryClient = useQueryClient();
 
   const { data, isLoading } = useQuery<AISettings>({
@@ -517,16 +518,13 @@ export function AiSettings() {
           <Box>
             <CardTitle className="text-base flex items-center gap-2">
               <Sparkles className="h-4 w-4" />
-              AI Providers
+              {t("cardTitle")}
             </CardTitle>
-            <CardDescription>
-              Configure OpenAI-compatible LLMs for the &ldquo;Gen AI&rdquo; page generator. BYO-LLM: FiestaBoard never
-              bundles a key.
-            </CardDescription>
+            <CardDescription>{t("cardDescription")}</CardDescription>
           </Box>
           <Flex align="center" gap="2" className="pt-1">
             <Label htmlFor="ai-enabled" className="text-xs">
-              {current.enabled ? "Enabled" : "Disabled"}
+              {current.enabled ? tCommon("enabled") : tCommon("disabled")}
             </Label>
             <Switch
               id="ai-enabled"
@@ -539,15 +537,12 @@ export function AiSettings() {
       </CardHeader>
       <CardContent className="space-y-3">
         <Alert>
-          <AlertDescription className="text-xs">
-            Your prompts and the variable list of your enabled plugins are sent directly to the provider you configure.
-            API keys are stored on this device and never sent anywhere else.
-          </AlertDescription>
+          <AlertDescription className="text-xs">{t("privacyNotice")}</AlertDescription>
         </Alert>
 
         {current.providers.length === 0 ? (
           <Text tone="muted" className="rounded-md border border-dashed p-6 text-center">
-            No providers configured yet.
+            {t("emptyState")}
           </Text>
         ) : (
           <Stack gap="3">
@@ -569,12 +564,12 @@ export function AiSettings() {
         <Flex wrap align="center" justify="between" gap="2" className="pt-1">
           <Button type="button" variant="outline" size="sm" className="gap-1.5" onClick={addProvider}>
             <Plus className="h-3.5 w-3.5" />
-            Add provider
+            {t("addProviderButton")}
           </Button>
           {hasDraft && (
             <Flex gap="2">
               <Button type="button" variant="ghost" size="sm" onClick={() => setDraft(null)}>
-                Discard
+                {t("discardButton")}
               </Button>
               <Button
                 type="button"
@@ -583,7 +578,7 @@ export function AiSettings() {
                 onClick={() => saveMutation.mutate(current)}
                 disabled={saveMutation.isPending}
               >
-                {saveMutation.isPending ? "Saving..." : "Save changes"}
+                {saveMutation.isPending ? tCommon("saving") : t("saveChangesButton")}
               </Button>
             </Flex>
           )}

--- a/web/src/components/settings/auto-update-interval.tsx
+++ b/web/src/components/settings/auto-update-interval.tsx
@@ -122,10 +122,7 @@ export function AutoUpdateIntervalCard() {
           <CalendarClock className="h-4 w-4" />
           {t("checkForUpdates")}
         </CardTitle>
-        <CardDescription>
-          How often FiestaBoard should look for a new release in the background. You&apos;ll see a banner here when one
-          is found.
-        </CardDescription>
+        <CardDescription>{t("intervalCardDescription")}</CardDescription>
       </CardHeader>
       <CardContent className="space-y-3">
         <Flex wrap align="center" gap="3">
@@ -134,7 +131,7 @@ export function AutoUpdateIntervalCard() {
             onValueChange={(v) => mutation.mutate(v as AutoUpdateInterval)}
             disabled={mutation.isPending}
           >
-            <SelectTrigger className="w-[180px]" aria-label="Update check frequency">
+            <SelectTrigger className="w-[180px]" aria-label={t("intervalSelectAriaLabel")}>
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
@@ -146,7 +143,7 @@ export function AutoUpdateIntervalCard() {
             </SelectContent>
           </Select>
           <Text as="span" size="xs" tone="muted">
-            Last checked: {formatLastCheck(status.last_check)}
+            {t("lastChecked", { time: formatLastCheck(status.last_check) })}
           </Text>
           <Button
             variant="outline"

--- a/web/src/components/settings/backup-settings.tsx
+++ b/web/src/components/settings/backup-settings.tsx
@@ -26,6 +26,7 @@ import { AlertTriangle, Database, Download, Loader2, Upload } from "lucide-react
 import { useRef, useState } from "react";
 import { toast } from "sonner";
 
+import { useTranslations } from "@/i18n/translations";
 import { api } from "@/lib/api";
 
 interface PendingImport {
@@ -34,6 +35,8 @@ interface PendingImport {
 }
 
 export function BackupSettings() {
+  const t = useTranslations("settings.backup");
+  const tCommon = useTranslations("common");
   const queryClient = useQueryClient();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [reinstallPlugins, setReinstallPlugins] = useState(true);
@@ -131,19 +134,15 @@ export function BackupSettings() {
         <CardHeader>
           <CardTitle className="text-base flex items-center gap-2">
             <Database className="h-4 w-4" />
-            Backup &amp; Restore
+            {t("cardTitle")}
           </CardTitle>
-          <CardDescription>
-            Export all of your FiestaBoard configuration — board settings, pages, collections, schedules and plugin
-            configuration — as a single JSON file. Re-upload that file on a new instance to migrate or recover after an
-            upgrade.
-          </CardDescription>
+          <CardDescription>{t("cardDescription")}</CardDescription>
         </CardHeader>
         <CardContent className="space-y-6">
           <Flex direction="col" gap="3" className="sm:flex-row">
             <Button variant="default" className="gap-2" onClick={handleExport} disabled={importMutation.isPending}>
               <Download className="h-4 w-4" />
-              Export backup
+              {t("exportButton")}
             </Button>
             <Button
               variant="outline"
@@ -152,7 +151,7 @@ export function BackupSettings() {
               disabled={importMutation.isPending}
             >
               {importMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Upload className="h-4 w-4" />}
-              Import backup…
+              {t("importButton")}
             </Button>
             <input
               ref={fileInputRef}
@@ -167,18 +166,16 @@ export function BackupSettings() {
             <Switch id="backup-reinstall-plugins" checked={reinstallPlugins} onCheckedChange={setReinstallPlugins} />
             <Stack gap="1">
               <Label htmlFor="backup-reinstall-plugins" className="cursor-pointer">
-                Reinstall external plugins after import
+                {t("reinstallPluginsLabel")}
               </Label>
               <Text size="xs" tone="muted">
-                When enabled, FiestaBoard will attempt to clone any external plugins recorded in the backup that are not
-                yet installed on this instance. Their configuration is restored from the backup either way.
+                {t("reinstallPluginsDescription")}
               </Text>
             </Stack>
           </Flex>
 
           <Text size="xs" tone="muted">
-            Note: backups contain sensitive values such as API keys and board credentials in plain text. Store the file
-            securely and do not share it publicly.
+            {t("sensitiveNote")}
           </Text>
         </CardContent>
       </Card>
@@ -193,27 +190,28 @@ export function BackupSettings() {
           <AlertDialogHeader>
             <AlertDialogTitle className="flex items-center gap-2">
               <AlertTriangle className="h-5 w-5 text-amber-500" />
-              Replace current configuration?
+              {t("confirmTitle")}
             </AlertDialogTitle>
             <AlertDialogDescription>
-              You are about to restore{" "}
-              <Text as="span" weight="medium" tone="muted">
-                {pending?.fileName}
-              </Text>
-              . Your existing pages, collections, schedules and configuration will be overwritten. A timestamped copy of
-              each existing file is kept alongside the new one so you can roll back manually if needed.
+              {t.rich("confirmDescription", {
+                file: () => (
+                  <Text as="span" weight="medium" tone="muted">
+                    {pending?.fileName}
+                  </Text>
+                ),
+              })}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel disabled={importMutation.isPending}>Cancel</AlertDialogCancel>
+            <AlertDialogCancel disabled={importMutation.isPending}>{tCommon("cancel")}</AlertDialogCancel>
             <AlertDialogAction onClick={handleConfirmImport} disabled={importMutation.isPending}>
               {importMutation.isPending ? (
                 <>
                   <Loader2 className="h-4 w-4 animate-spin mr-2" />
-                  Restoring…
+                  {t("restoringButton")}
                 </>
               ) : (
-                "Restore backup"
+                t("restoreButton")
               )}
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/web/src/components/settings/debug-settings.tsx
+++ b/web/src/components/settings/debug-settings.tsx
@@ -426,7 +426,7 @@ export function DebugSettings() {
                   ) : (
                     <Info className="h-4 w-4" />
                   )}
-                  Show Debug Info on Board
+                  {t("showDebugInfoOnBoard")}
                 </Button>
                 <Text size="xs" tone="muted">
                   {t("showDebugInfoDescription")}
@@ -450,7 +450,7 @@ export function DebugSettings() {
                   ) : (
                     <Database className="h-4 w-4" />
                   )}
-                  Clear Message Cache
+                  {t("clearMessageCache")}
                 </Button>
                 <Text size="xs" tone="muted">
                   {t("clearCacheDescription")}
@@ -510,7 +510,7 @@ export function DebugSettings() {
                             {t("versionLabel")}
                           </Text>
                           <Text size="xs" className="font-mono">
-                            v{systemInfo.version}
+                            {tCommon("versionShort", { version: systemInfo.version })}
                           </Text>
 
                           <Text size="xs" weight="medium" tone="muted">
@@ -639,6 +639,7 @@ function DiagnosticRow({
   result: { ok: boolean; latency_ms?: number };
   detail: string;
 }) {
+  const t = useTranslations("debugSettings");
   return (
     <Flex align="start" gap="2" className="p-2.5 text-xs">
       <DiagnosticStatusIcon ok={result.ok} />
@@ -648,7 +649,7 @@ function DiagnosticRow({
           {label}
           {result.latency_ms != null && (
             <Badge variant="secondary" className="text-[10px] px-1.5 py-0 h-4 font-mono">
-              {result.latency_ms}ms
+              {t("latencyMs", { ms: result.latency_ms })}
             </Badge>
           )}
         </Flex>
@@ -709,7 +710,7 @@ function VestaboardDiagnosticRow({
             {t("vestaboardCloudApiLabel")}
             {cloud?.latency_ms != null && (
               <Badge variant="secondary" className="text-[10px] px-1.5 py-0 h-4 font-mono">
-                {cloud.latency_ms}ms
+                {t("latencyMs", { ms: cloud.latency_ms })}
               </Badge>
             )}
           </Flex>
@@ -768,7 +769,7 @@ function VestaboardDiagnosticRow({
                 </Text>
                 {step.latency_ms != null && (
                   <Badge variant="secondary" className="ml-1 text-[10px] px-1 py-0 h-3.5 font-mono">
-                    {step.latency_ms}ms
+                    {t("latencyMs", { ms: step.latency_ms })}
                   </Badge>
                 )}
                 {step.ok ? (

--- a/web/src/components/settings/mcp-settings.tsx
+++ b/web/src/components/settings/mcp-settings.tsx
@@ -32,10 +32,20 @@ import {
 } from "@fiestaboard/ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { AlertTriangle, Bot, Check, Copy, KeyRound, Loader2, RefreshCw, Trash2 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { type ReactNode, useMemo, useState } from "react";
 import { toast } from "sonner";
 
+import { useTranslations } from "@/i18n/translations";
 import { api } from "@/lib/api";
+
+/** Env var that pins the MCP token when set — never translated. */
+const MCP_TOKEN_ENV_VAR = "FIESTABOARD_MCP_TOKEN";
+
+/** MCP endpoint path — never translated. */
+const MCP_ENDPOINT = "/api/mcp";
+
+/** npm package name of the stdio proxy Claude Desktop shells out to — never translated. */
+const MCP_REMOTE_PACKAGE = "mcp-remote";
 
 /**
  * Build the Claude Desktop config snippet the user will paste into
@@ -74,6 +84,8 @@ function buildClaudeDesktopConfig(token: string): string {
 }
 
 export function McpSettings() {
+  const t = useTranslations("mcpSettings");
+  const tCommon = useTranslations("common");
   const queryClient = useQueryClient();
   const [revealedToken, setRevealedToken] = useState<string | null>(null);
   const [confirmingRotate, setConfirmingRotate] = useState(false);
@@ -101,7 +113,7 @@ export function McpSettings() {
   const clearMutation = useMutation({
     mutationFn: () => api.clearMcpToken(),
     onSuccess: () => {
-      toast.success("MCP token revoked");
+      toast.success(t("toastTokenRevoked"));
       setConfirmingClear(false);
       queryClient.invalidateQueries({ queryKey: ["mcp-token-status"] });
     },
@@ -117,7 +129,7 @@ export function McpSettings() {
       setCopied(which);
       setTimeout(() => setCopied(null), 1500);
     } catch {
-      toast.error("Couldn't copy to clipboard");
+      toast.error(t("toastCopyFailed"));
     }
   };
 
@@ -136,7 +148,7 @@ export function McpSettings() {
 
   const isPinnedByEnv = status.source === "env";
   const hasToken = status.configured;
-  const rotateLabel = hasToken ? "Rotate token" : "Generate token";
+  const rotateLabel = hasToken ? t("rotateTokenButton") : t("generateTokenButton");
 
   return (
     <>
@@ -144,67 +156,56 @@ export function McpSettings() {
         <CardHeader>
           <CardTitle className="flex items-center gap-2 text-base">
             <Bot className="h-4 w-4" />
-            MCP / external clients
+            {t("title")}
           </CardTitle>
           <CardDescription>
-            A pre-shared token that lets Claude Desktop, Claude Code, and other MCP clients talk to this FiestaBoard.
-            The token authenticates as a single principal — scoped to the{" "}
-            <Code className="font-mono text-xs">/api/mcp</Code> endpoint only — so it can&apos;t edit pages or other
-            settings. See{" "}
-            <TextLink
-              href="https://github.com/Fiestaboard/FiestaBoard/blob/main/docs/setup/MCP_CLIENTS.md"
-              target="_blank"
-              rel="noreferrer"
-              className="underline underline-offset-2"
-            >
-              MCP client setup
-            </TextLink>{" "}
-            for client-specific quirks (Desktop needs an stdio proxy; claude.ai web Connectors require public HTTPS and
-            OAuth, so they won&apos;t reach a LAN host).
+            {t.rich("description", {
+              endpoint: () => <Code className="font-mono text-xs">{MCP_ENDPOINT}</Code>,
+              link: (chunks: ReactNode) => (
+                <TextLink
+                  href="https://github.com/Fiestaboard/FiestaBoard/blob/main/docs/setup/MCP_CLIENTS.md"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="underline underline-offset-2"
+                >
+                  {chunks}
+                </TextLink>
+              ),
+            })}
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
           <Flex align="center" gap="2">
             <Text as="span" size="sm" weight="medium">
-              Status:
+              {t("statusLabel")}
             </Text>
             {isPinnedByEnv ? (
               <Badge variant="secondary" className="gap-1.5">
                 <KeyRound className="h-3 w-3" />
-                Pinned by FIESTABOARD_MCP_TOKEN
+                {t("pinnedByEnvBadge", { envVar: MCP_TOKEN_ENV_VAR })}
               </Badge>
             ) : hasToken ? (
               <Badge variant="default" className="gap-1.5 bg-emerald-600 hover:bg-emerald-600">
                 <Check className="h-3 w-3" />
-                Configured
+                {t("configuredBadge")}
               </Badge>
             ) : (
-              <Badge variant="outline">Not configured</Badge>
+              <Badge variant="outline">{tCommon("notConfigured")}</Badge>
             )}
           </Flex>
 
           {isPinnedByEnv && (
             <Text tone="muted">
-              The active token is set by the <Code className="font-mono text-xs">FIESTABOARD_MCP_TOKEN</Code>{" "}
-              environment variable. Unset it in your <Code className="font-mono text-xs">.env</Code> and restart the
-              container before managing the token from this UI.
+              {t.rich("pinnedByEnvDescription", {
+                envVar: () => <Code className="font-mono text-xs">{MCP_TOKEN_ENV_VAR}</Code>,
+                envFile: () => <Code className="font-mono text-xs">.env</Code>,
+              })}
             </Text>
           )}
 
-          {!isPinnedByEnv && !hasToken && (
-            <Text tone="muted">
-              No token is configured. External MCP clients will fall back to cookie auth, which Claude Desktop / Claude
-              Code don&apos;t support — they&apos;ll fail registration with an opaque error. Generate a token to unblock
-              them.
-            </Text>
-          )}
+          {!isPinnedByEnv && !hasToken && <Text tone="muted">{t("noTokenDescription")}</Text>}
 
-          {!isPinnedByEnv && hasToken && (
-            <Text tone="muted">
-              A token is configured and active. Rotate it to invalidate the previous one (any client still using the old
-              token will start receiving 401), or revoke it entirely to fall back to cookie-only auth.
-            </Text>
-          )}
+          {!isPinnedByEnv && hasToken && <Text tone="muted">{t("activeTokenDescription")}</Text>}
 
           {!isPinnedByEnv && (
             <Flex wrap gap="2">
@@ -233,7 +234,7 @@ export function McpSettings() {
                   ) : (
                     <Trash2 className="h-4 w-4" />
                   )}
-                  Revoke token
+                  {t("revokeTokenButton")}
                 </Button>
               )}
             </Flex>
@@ -246,18 +247,16 @@ export function McpSettings() {
       <AlertDialog open={confirmingRotate} onOpenChange={(open) => !open && setConfirmingRotate(false)}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>{hasToken ? "Rotate MCP token?" : "Generate MCP token?"}</AlertDialogTitle>
+            <AlertDialogTitle>{hasToken ? t("rotateConfirmTitle") : t("generateConfirmTitle")}</AlertDialogTitle>
             <AlertDialogDescription>
-              {hasToken
-                ? "Any client still using the previous token will be denied with a 401 + Bearer challenge on its next request. You'll see the new token once — store it somewhere safe (it's not readable from the UI again)."
-                : "You'll see the token once — store it somewhere safe (it's not readable from the UI again). External MCP clients will use it to authenticate to /api/mcp."}
+              {hasToken ? t("rotateConfirmDescription") : t("generateConfirmDescription", { endpoint: MCP_ENDPOINT })}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel disabled={rotateMutation.isPending}>Cancel</AlertDialogCancel>
+            <AlertDialogCancel disabled={rotateMutation.isPending}>{tCommon("cancel")}</AlertDialogCancel>
             <AlertDialogAction onClick={() => rotateMutation.mutate()} disabled={rotateMutation.isPending}>
               {rotateMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
-              {hasToken ? "Rotate" : "Generate"}
+              {hasToken ? t("rotateConfirmButton") : t("generateConfirmButton")}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -266,21 +265,18 @@ export function McpSettings() {
       <AlertDialog open={confirmingClear} onOpenChange={(open) => !open && setConfirmingClear(false)}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Revoke MCP token?</AlertDialogTitle>
-            <AlertDialogDescription>
-              External MCP clients will start receiving 401 on their next request. You can always generate a new token
-              later.
-            </AlertDialogDescription>
+            <AlertDialogTitle>{t("revokeConfirmTitle")}</AlertDialogTitle>
+            <AlertDialogDescription>{t("revokeConfirmDescription")}</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel disabled={clearMutation.isPending}>Cancel</AlertDialogCancel>
+            <AlertDialogCancel disabled={clearMutation.isPending}>{tCommon("cancel")}</AlertDialogCancel>
             <AlertDialogAction
               onClick={() => clearMutation.mutate()}
               disabled={clearMutation.isPending}
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             >
               {clearMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
-              Revoke
+              {t("revokeConfirmButton")}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -296,12 +292,11 @@ export function McpSettings() {
       >
         <DialogContent className="sm:max-w-xl">
           <DialogHeader>
-            <DialogTitle>Save this token</DialogTitle>
+            <DialogTitle>{t("revealTitle")}</DialogTitle>
             <DialogDescription className="flex items-start gap-2">
               <AlertTriangle className="h-4 w-4 mt-0.5 flex-shrink-0 text-amber-500" />
               <Text as="span" size="sm" tone="muted">
-                FiestaBoard stores only what&apos;s needed to verify future requests — this is the only time the
-                plaintext value is shown. Copy it into your MCP client now.
+                {t("revealDescription")}
               </Text>
             </DialogDescription>
           </DialogHeader>
@@ -310,7 +305,7 @@ export function McpSettings() {
             <Box>
               <Flex align="center" justify="between" className="mb-1.5">
                 <Text as="span" size="sm" weight="medium">
-                  Token
+                  {t("tokenLabel")}
                 </Text>
                 <Button
                   size="sm"
@@ -319,7 +314,7 @@ export function McpSettings() {
                   className="h-7 gap-1.5"
                 >
                   {copied === "token" ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
-                  {copied === "token" ? "Copied" : "Copy"}
+                  {copied === "token" ? t("copiedButton") : t("copyButton")}
                 </Button>
               </Flex>
               <Code className="block w-full break-all rounded bg-muted px-3 py-2 font-mono text-xs">
@@ -330,7 +325,7 @@ export function McpSettings() {
             <Box>
               <Flex align="center" justify="between" className="mb-1.5">
                 <Text as="span" size="sm" weight="medium">
-                  Claude Desktop config snippet
+                  {t("configSnippetLabel")}
                 </Text>
                 <Button
                   size="sm"
@@ -339,37 +334,41 @@ export function McpSettings() {
                   className="h-7 gap-1.5"
                 >
                   {copied === "config" ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
-                  {copied === "config" ? "Copied" : "Copy"}
+                  {copied === "config" ? t("copiedButton") : t("copyButton")}
                 </Button>
               </Flex>
               <Text size="xs" tone="muted" className="mb-2">
-                Paste this into{" "}
-                <Code className="font-mono">~/Library/Application Support/Claude/claude_desktop_config.json</Code>,
-                merging with anything that&apos;s already there, then fully quit and relaunch Claude Desktop (⌘Q —
-                closing the window isn&apos;t enough). Claude Desktop only supports stdio MCP servers, so this snippet
-                shells out to{" "}
-                <TextLink
-                  href="https://www.npmjs.com/package/mcp-remote"
-                  target="_blank"
-                  rel="noreferrer"
-                  className="underline underline-offset-2"
-                >
-                  mcp-remote
-                </TextLink>{" "}
-                via <Code className="font-mono">npx</Code> as a proxy — Node 18+ must be installed and{" "}
-                <Code className="font-mono">npx</Code> reachable from Claude Desktop&apos;s PATH. If it errors with{" "}
-                <Code className="font-mono">command not found</Code>, replace{" "}
-                <Code className="font-mono">&quot;npx&quot;</Code> with the absolute path from{" "}
-                <Code className="font-mono">which npx</Code>.
+                {t.rich("configSnippetDescription", {
+                  configPath: () => (
+                    <Code className="font-mono">~/Library/Application Support/Claude/claude_desktop_config.json</Code>
+                  ),
+                  mcpRemoteLink: () => (
+                    <TextLink
+                      href="https://www.npmjs.com/package/mcp-remote"
+                      target="_blank"
+                      rel="noreferrer"
+                      className="underline underline-offset-2"
+                    >
+                      {MCP_REMOTE_PACKAGE}
+                    </TextLink>
+                  ),
+                  npx: () => <Code className="font-mono">npx</Code>,
+                  commandNotFound: () => <Code className="font-mono">command not found</Code>,
+                  npxQuoted: () => <Code className="font-mono">&quot;npx&quot;</Code>,
+                  whichNpx: () => <Code className="font-mono">which npx</Code>,
+                })}
               </Text>
               <pre className="max-h-64 overflow-auto rounded bg-muted px-3 py-2 font-mono text-xs">{configSnippet}</pre>
             </Box>
 
             <Text size="xs" tone="muted">
-              <Text as="span" size="xs" weight="semibold" tone="muted">
-                Claude Code (CLI):
-              </Text>{" "}
-              talks HTTP directly — no proxy needed.
+              {t.rich("claudeCodeDescription", {
+                label: (chunks: ReactNode) => (
+                  <Text as="span" size="xs" weight="semibold" tone="muted">
+                    {chunks}
+                  </Text>
+                ),
+              })}
               <br />
               <Code className="font-mono">
                 claude mcp add fiestaboard --transport http --url{" "}
@@ -380,16 +379,18 @@ export function McpSettings() {
               </Code>
             </Text>
             <Text size="xs" tone="muted">
-              <Text as="span" size="xs" weight="semibold" tone="muted">
-                claude.ai web (Connectors):
-              </Text>{" "}
-              not supported for self-hosted FiestaBoard. The Connectors flow requires a public HTTPS URL and OAuth 2.1
-              dynamic client registration, neither of which a LAN host can provide. Use Desktop or Code instead.
+              {t.rich("claudeWebDescription", {
+                label: (chunks: ReactNode) => (
+                  <Text as="span" size="xs" weight="semibold" tone="muted">
+                    {chunks}
+                  </Text>
+                ),
+              })}
             </Text>
           </Stack>
 
           <DialogFooter>
-            <Button onClick={() => setRevealedToken(null)}>I&apos;ve saved it</Button>
+            <Button onClick={() => setRevealedToken(null)}>{t("savedItButton")}</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/web/src/components/settings/network-settings.tsx
+++ b/web/src/components/settings/network-settings.tsx
@@ -180,7 +180,6 @@ export function NetworkSettings() {
               {status?.signal != null && (
                 <>
                   <dt className="text-muted-foreground">{t("signalLabel")}</dt>
-                  {/* eslint-disable-next-line i18next/no-literal-string */}
                   <dd>{status.signal}%</dd>
                 </>
               )}

--- a/web/src/components/settings/system-update.tsx
+++ b/web/src/components/settings/system-update.tsx
@@ -94,7 +94,7 @@ export function SystemUpdate() {
               {t("updateAvailable")}
             </Text>
             <Badge variant="secondary" className="text-xs">
-              v{updateCheck.latest_version}
+              {tCommon("versionShort", { version: updateCheck.latest_version })}
             </Badge>
             <Text as="span" tone="muted">
               {t("youAreRunning", { currentVersion: updateCheck.current_version })}
@@ -143,11 +143,7 @@ export function SystemUpdate() {
       {!sidecarReady && (
         <Text size="xs" tone="muted" className="mt-2 ml-1">
           {t.rich("oneClickHint", {
-            profile: () => (
-              <Text as="span" size="xs" tone="muted" className="font-mono">
-                COMPOSE_PROFILES=fiestaupdater
-              </Text>
-            ),
+            profile: () => <Code>COMPOSE_PROFILES=fiestaupdater</Code>,
             envFile: () => <Code>.env</Code>,
             command: () => <Code>docker compose up -d</Code>,
           })}
@@ -162,7 +158,7 @@ export function SystemUpdate() {
               {t.rich("dialogDescription", {
                 version: () => (
                   <Text as="span" weight="semibold" tone="muted">
-                    v{updateCheck.latest_version}
+                    {tCommon("versionShort", { version: updateCheck.latest_version })}
                   </Text>
                 ),
               })}

--- a/web/src/components/sidebar-account.tsx
+++ b/web/src/components/sidebar-account.tsx
@@ -14,6 +14,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { LogOut } from "lucide-react";
 
 import { useRouter } from "@/hooks/use-router";
+import { useTranslations } from "@/i18n/translations";
 import { api } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
@@ -25,6 +26,7 @@ interface SidebarAccountProps {
 }
 
 export function SidebarAccount({ collapsed = false, variant = "desktop" }: SidebarAccountProps) {
+  const t = useTranslations("accountSection");
   const router = useRouter();
   const queryClient = useQueryClient();
 
@@ -60,7 +62,7 @@ export function SidebarAccount({ collapsed = false, variant = "desktop" }: Sideb
   );
 
   const button = (
-    <button type="button" onClick={handleSignOut} aria-label="Sign out" className={className}>
+    <button type="button" onClick={handleSignOut} aria-label={t("signOut.button")} className={className}>
       <LogOut className="h-5 w-5 flex-shrink-0" />
       <Text
         as="span"
@@ -71,7 +73,7 @@ export function SidebarAccount({ collapsed = false, variant = "desktop" }: Sideb
           collapsed ? "opacity-0 max-w-0" : "opacity-100 max-w-48 delay-150",
         )}
       >
-        Sign out
+        {t("signOut.button")}
       </Text>
     </button>
   );
@@ -82,7 +84,7 @@ export function SidebarAccount({ collapsed = false, variant = "desktop" }: Sideb
     <Tooltip>
       <TooltipTrigger asChild>{button}</TooltipTrigger>
       <TooltipContent side="right" className="font-medium">
-        Sign out
+        {t("signOut.button")}
       </TooltipContent>
     </Tooltip>
   );

--- a/web/src/components/tiptap-template-editor/TipTapTemplateEditor.tsx
+++ b/web/src/components/tiptap-template-editor/TipTapTemplateEditor.tsx
@@ -1313,8 +1313,8 @@ export const TipTapTemplateEditor = forwardRef<TipTapTemplateEditorHandle, TipTa
             size="xs"
             className={cn("mt-1", isOverLineLimit ? "text-warning font-medium" : "text-muted-foreground")}
           >
-            {editorLineCount} / {boardLines} lines
-            {isOverLineLimit && ` — exceeds the ${boardLines}-line board limit`}
+            {t("lineCount", { used: editorLineCount, max: boardLines })}
+            {isOverLineLimit && t("overLineLimit", { max: boardLines })}
           </Text>
 
           {/* Alignment controls - only show if toolbar is hidden */}
@@ -1379,7 +1379,7 @@ export const TipTapTemplateEditor = forwardRef<TipTapTemplateEditorHandle, TipTa
                 </Flex>
                 {currentLineIndex !== null && (
                   <Text as="span" size="xs" tone="muted">
-                    (Line {currentLineIndex + 1})
+                    {t("currentLine", { line: currentLineIndex + 1 })}
                   </Text>
                 )}
               </Flex>

--- a/web/src/components/tiptap-template-editor/components/ColorPickerContent.tsx
+++ b/web/src/components/tiptap-template-editor/components/ColorPickerContent.tsx
@@ -7,6 +7,7 @@ import { Box, Grid, Text, Tooltip, TooltipContent, TooltipProvider, TooltipTrigg
 import { Heart } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
+import { useTranslations } from "@/i18n/translations";
 import type { DeviceType } from "@/lib/api";
 import { FIESTABOARD_COLORS } from "@/lib/board-colors";
 import { cn } from "@/lib/utils";
@@ -30,6 +31,7 @@ const COLOR_MAP: Record<string, { bg: string; needsDarkText: boolean }> = {
 const COLOR_ORDER = ["red", "orange", "yellow", "green", "blue", "violet", "white", "black"] as const;
 
 export function ColorPickerContent({ onInsert, deviceType }: ColorPickerContentProps) {
+  const t = useTranslations("templateEditor");
   const isNote = deviceType === "note";
   const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const containerRef = useRef<HTMLElement>(null);
@@ -155,7 +157,7 @@ export function ColorPickerContent({ onInsert, deviceType }: ColorPickerContentP
         className={cn("p-2", !isNote && "pb-1")}
         tabIndex={0}
         role="listbox"
-        aria-label="Color picker"
+        aria-label={t("colorPickerAriaLabel")}
       >
         <Grid cols="4" gap="2" className="w-64">
           {COLOR_ORDER.map((colorName, index) => {
@@ -207,18 +209,18 @@ export function ColorPickerContent({ onInsert, deviceType }: ColorPickerContentP
                     "flex items-center justify-center gap-1.5 focus:outline-none",
                     "bg-red-500/10 text-red-500 border border-red-500/20 hover:bg-red-500/20",
                   )}
-                  aria-label="Heart character"
+                  aria-label={t("heartCharacterAriaLabel")}
                   role="option"
                   aria-selected={false}
                 >
                   <Heart className="w-4 h-4 fill-current" />
                   <Text as="span" weight="medium" className="text-red-500">
-                    heart
+                    {t("heartLabel")}
                   </Text>
                 </button>
               </TooltipTrigger>
               <TooltipContent>
-                <Text>Insert heart character (Note only)</Text>
+                <Text>{t("insertHeartTooltip")}</Text>
               </TooltipContent>
             </Tooltip>
           </Box>

--- a/web/src/components/tiptap-template-editor/components/FilterPickerContent.tsx
+++ b/web/src/components/tiptap-template-editor/components/FilterPickerContent.tsx
@@ -4,7 +4,7 @@
  */
 "use client";
 
-import { Badge, Box, Flex, Stack, Text } from "@fiestaboard/ui";
+import { Badge, Box, Code, Flex, Stack, Text } from "@fiestaboard/ui";
 import type { Editor } from "@tiptap/react";
 import { AlertCircle } from "lucide-react";
 
@@ -198,13 +198,13 @@ export function FilterPickerContent({ filters, editor, onInsert }: FilterPickerC
       </Stack>
       <Stack gap="1" className="mt-3 pt-3 border-t text-xs text-muted-foreground">
         <Text size="xs" tone="muted">
-          Example: {"{{weather.temperature|pad:3}}"}
+          {/* The template snippet is syntax — it stays verbatim in every locale. */}
+          {t("exampleLabel", { example: "{{weather.temperature|pad:3}}" })}
         </Text>
         <Text tone="muted" className="text-[10px]">
-          <Text as="span" weight="semibold" tone="muted" className="text-[10px]">
-            |wrap
-          </Text>
-          : {t("wrapInstruction")}
+          {/* Filter name, not copy. */}
+          <Code className="bg-transparent px-0 py-0 text-[10px] font-semibold text-muted-foreground">|wrap</Code>:{" "}
+          {t("wrapInstruction")}
         </Text>
       </Stack>
     </Box>

--- a/web/src/components/tiptap-template-editor/components/TemplateEditorToolbar.tsx
+++ b/web/src/components/tiptap-template-editor/components/TemplateEditorToolbar.tsx
@@ -338,7 +338,7 @@ export function TemplateEditorToolbar({
                   canUndo ? "hover:bg-muted/50" : "opacity-60 cursor-not-allowed",
                   "border-r border-border",
                 )}
-                aria-label="Undo"
+                aria-label={t("undoAriaLabel")}
               >
                 <Undo2 className="w-4 h-4" />
               </button>
@@ -358,7 +358,7 @@ export function TemplateEditorToolbar({
                   "px-2 py-1.5 transition-colors",
                   canRedo ? "hover:bg-muted/50" : "opacity-60 cursor-not-allowed",
                 )}
-                aria-label="Redo"
+                aria-label={t("redoAriaLabel")}
               >
                 <Redo2 className="w-4 h-4" />
               </button>
@@ -478,7 +478,7 @@ export function TemplateEditorToolbar({
                       hasSelection ? "hover:bg-muted/50" : "opacity-60 cursor-not-allowed",
                       "border-r border-border",
                     )}
-                    aria-label="Cut"
+                    aria-label={t("cutAriaLabel")}
                   >
                     <Scissors className="w-4 h-4" />
                   </button>
@@ -499,7 +499,7 @@ export function TemplateEditorToolbar({
                       hasSelection ? "hover:bg-muted/50" : "opacity-60 cursor-not-allowed",
                       "border-r border-border",
                     )}
-                    aria-label="Copy"
+                    aria-label={t("copyAriaLabel")}
                   >
                     <Copy className="w-4 h-4" />
                   </button>
@@ -519,7 +519,7 @@ export function TemplateEditorToolbar({
                       "px-2 py-1.5 transition-colors",
                       hasClipboardContent ? "hover:bg-muted/50" : "opacity-60 cursor-not-allowed",
                     )}
-                    aria-label="Paste"
+                    aria-label={t("pasteAriaLabel")}
                   >
                     <ClipboardPaste className="w-4 h-4" />
                   </button>

--- a/web/src/components/tiptap-template-editor/components/VariablePickerContent.tsx
+++ b/web/src/components/tiptap-template-editor/components/VariablePickerContent.tsx
@@ -276,7 +276,7 @@ function renderArraySection(
     return (
       <Box className="p-3 bg-muted/30 rounded-lg text-xs text-muted-foreground">
         <Text size="xs" tone="muted">
-          No matching variables found.
+          {t ? t("noMatchingVariables") : "No matching variables found."}
         </Text>
       </Box>
     );

--- a/web/src/components/tiptap-template-editor/node-views/ColorTileNodeView.tsx
+++ b/web/src/components/tiptap-template-editor/node-views/ColorTileNodeView.tsx
@@ -7,6 +7,7 @@ import { Box, Text, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } f
 import { NodeViewWrapper } from "@tiptap/react";
 import React from "react";
 
+import { useTranslations } from "@/i18n/translations";
 import { FIESTABOARD_COLORS } from "@/lib/board-colors";
 import { cn } from "@/lib/utils";
 
@@ -21,6 +22,7 @@ interface ColorTileNodeViewProps {
 }
 
 export function ColorTileNodeView({ node, deleteNode: _deleteNode }: ColorTileNodeViewProps) {
+  const t = useTranslations("templateEditor");
   const { color, code } = node.attrs;
   const colorKey = color.toLowerCase() as keyof typeof FIESTABOARD_COLORS;
   const bgColor = FIESTABOARD_COLORS[colorKey] || FIESTABOARD_COLORS.red;
@@ -97,9 +99,7 @@ export function ColorTileNodeView({ node, deleteNode: _deleteNode }: ColorTileNo
           </NodeViewWrapper>
         </TooltipTrigger>
         <TooltipContent>
-          <Text>
-            {color} tile (code {code}) - drag to move, backspace to delete
-          </Text>
+          <Text>{t("colorTileTooltip", { color, code })}</Text>
         </TooltipContent>
       </Tooltip>
     </TooltipProvider>

--- a/web/src/components/tiptap-template-editor/node-views/FillSpaceNodeView.tsx
+++ b/web/src/components/tiptap-template-editor/node-views/FillSpaceNodeView.tsx
@@ -6,6 +6,8 @@ import { Badge, Text, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger }
 import { NodeViewWrapper } from "@tiptap/react";
 import React from "react";
 
+import { useTranslations } from "@/i18n/translations";
+
 interface FillSpaceNodeViewProps {
   node: {
     attrs: {
@@ -17,6 +19,7 @@ interface FillSpaceNodeViewProps {
 }
 
 export function FillSpaceNodeView({ node, deleteNode: _deleteNode }: FillSpaceNodeViewProps) {
+  const t = useTranslations("templateEditor");
   const { repeatChar } = node.attrs;
   const hasRepeatChar = repeatChar && repeatChar !== " ";
 
@@ -41,18 +44,14 @@ export function FillSpaceNodeView({ node, deleteNode: _deleteNode }: FillSpaceNo
                   contentEditable. <Text as="span"> would emit text-foreground,
                   overriding the Badge's inherited success tint, and text-[11px]
                   is sub-xs grid geometry. Kept raw for correctness. */}
-              {/* eslint-disable-next-line react/forbid-elements -- span inside a colored Badge in TipTap contentEditable; Text as="span" would override the Badge's inherited tint and text-[11px] is sub-xs grid geometry */}
+              {/* eslint-disable-next-line react/forbid-elements, i18next/no-literal-string -- span inside a colored Badge in TipTap contentEditable; Text as="span" would override the Badge's inherited tint and text-[11px] is sub-xs grid geometry, and Code would add its own bg/padding/size. The text is the `fill_space` template token, which is syntax and stays verbatim in every locale. */}
               <span className="font-mono text-[11px] leading-none">
                 fill_space{hasRepeatChar && `_repeat:${repeatChar}`}
               </span>
             </Badge>
           </TooltipTrigger>
           <TooltipContent>
-            <Text>
-              {hasRepeatChar
-                ? `Fill space repeating: ${repeatChar}`
-                : "Fill space - expands to fill remaining line width"}
-            </Text>
+            <Text>{hasRepeatChar ? t("fillSpaceRepeatTooltip", { char: repeatChar }) : t("fillSpaceTooltip")}</Text>
           </TooltipContent>
         </Tooltip>
       </TooltipProvider>

--- a/web/src/components/tiptap-template-editor/node-views/VariableNodeView.tsx
+++ b/web/src/components/tiptap-template-editor/node-views/VariableNodeView.tsx
@@ -6,6 +6,8 @@ import { Badge, Text, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger }
 import { NodeViewWrapper } from "@tiptap/react";
 import React from "react";
 
+import { useTranslations } from "@/i18n/translations";
+
 interface VariableNodeViewProps {
   node: {
     attrs: {
@@ -19,6 +21,7 @@ interface VariableNodeViewProps {
 }
 
 export function VariableNodeView({ node, deleteNode: _deleteNode }: VariableNodeViewProps) {
+  const t = useTranslations("templateEditor");
   const { pluginId, field, filters, maxLength } = node.attrs;
 
   return (
@@ -60,8 +63,9 @@ export function VariableNodeView({ node, deleteNode: _deleteNode }: VariableNode
                   </TooltipTrigger>
                   <TooltipContent>
                     <Text>
-                      Filter: {filter.name}
-                      {filter.arg ? `:${filter.arg}` : ""}
+                      {t("variableFilterTooltip", {
+                        filter: `${filter.name}${filter.arg ? `:${filter.arg}` : ""}`,
+                      })}
                     </Text>
                   </TooltipContent>
                 </Tooltip>
@@ -76,7 +80,7 @@ export function VariableNodeView({ node, deleteNode: _deleteNode }: VariableNode
                 <span className="hidden group-hover:inline text-[10px] leading-none">~{maxLength}</span>
               </TooltipTrigger>
               <TooltipContent>
-                <Text>Max length: {maxLength} characters</Text>
+                <Text>{t("variableMaxLengthTooltip", { maxLength })}</Text>
               </TooltipContent>
             </Tooltip>
           )}

--- a/web/src/components/tiptap-template-editor/node-views/WrappedTextView.tsx
+++ b/web/src/components/tiptap-template-editor/node-views/WrappedTextView.tsx
@@ -6,6 +6,7 @@ import { NodeViewWrapper } from "@tiptap/react";
 import { WrapText, X } from "lucide-react";
 import React from "react";
 
+import { useTranslations } from "@/i18n/translations";
 import { cn } from "@/lib/utils";
 
 interface WrappedTextViewProps {
@@ -19,6 +20,7 @@ interface WrappedTextViewProps {
 
 export function WrappedTextView({ node, deleteNode }: WrappedTextViewProps) {
   const { text } = node.attrs;
+  const t = useTranslations("templateEditor");
 
   return (
     <NodeViewWrapper
@@ -59,7 +61,7 @@ export function WrappedTextView({ node, deleteNode }: WrappedTextViewProps) {
         }}
         className="rounded-full hover:bg-black/10 dark:hover:bg-white/10 p-0.5 -mr-1 ml-0.5 transition-colors"
         tabIndex={-1}
-        aria-label="Remove wrapped text"
+        aria-label={t("removeWrappedTextAriaLabel")}
       >
         <X className="w-3 h-3" />
       </button>

--- a/web/src/components/variable-rule-row.tsx
+++ b/web/src/components/variable-rule-row.tsx
@@ -4,6 +4,7 @@ import {
   Badge,
   Box,
   Button,
+  Code,
   Flex,
   Select,
   SelectContent,
@@ -168,16 +169,22 @@ export function VariableRuleRow({
                 <Text size="xs" weight="medium" className="mb-1">
                   {t("variableRuleHelpOperatorsTitle")}
                 </Text>
+                {/* Operator cheat-sheet: formula syntax, identical in every locale. */}
                 <Text size="xs" tone="muted" className="font-mono">
-                  ==, =, !=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;= · AND OR NOT (or &amp;&amp; || !) · + - * / %
+                  <Code className="bg-transparent px-0 py-0 text-xs text-muted-foreground">
+                    ==, =, !=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;= · AND OR NOT (or &amp;&amp; || !) · + - * / %
+                  </Code>
                 </Text>
               </Box>
               <Box>
                 <Text size="xs" weight="medium" className="mb-1">
                   {t("variableRuleHelpFunctionsTitle")}
                 </Text>
+                {/* Function cheat-sheet: formula syntax, identical in every locale. */}
                 <Text size="xs" tone="muted" className="font-mono">
-                  IF(cond, then, else) · AND(a, b) · OR(a, b) · CONTAINS(s, sub) · STARTSWITH · LEN · UPPER · LOWER
+                  <Code className="bg-transparent px-0 py-0 text-xs text-muted-foreground">
+                    IF(cond, then, else) · AND(a, b) · OR(a, b) · CONTAINS(s, sub) · STARTSWITH · LEN · UPPER · LOWER
+                  </Code>
                 </Text>
               </Box>
               <Box>

--- a/web/src/components/version-display.tsx
+++ b/web/src/components/version-display.tsx
@@ -10,6 +10,7 @@ import { api } from "@/lib/api";
 
 export function VersionDisplay() {
   const t = useTranslations("versionDisplay");
+  const tCommon = useTranslations("common");
   const managedExternally = useIsManagedExternally();
   const { data: version } = useQuery({
     queryKey: ["version"],
@@ -31,7 +32,7 @@ export function VersionDisplay() {
     <Flex align="center" gap="2" className="text-xs text-muted-foreground">
       <Package className="h-3 w-3" />
       <Text as="span" size="xs" tone="muted" suppressHydrationWarning>
-        v{version.package_version}
+        {tCommon("versionShort", { version: version.package_version })}
         {version.is_dev && ` ${t("devSuffix")}`}
       </Text>
       {!managedExternally && updateCheck?.update_available && (

--- a/web/src/components/wizard/step-easy-plugins.tsx
+++ b/web/src/components/wizard/step-easy-plugins.tsx
@@ -188,11 +188,13 @@ export function StepEasyPlugins({ config, onConfigChange, onValidChange }: StepE
         {t("description")}
       </Text>
       <Text size="xs" tone="muted" className="mb-4">
-        You can add more from the{" "}
-        <Link href="/integrations" className="underline hover:text-foreground">
-          Integrations
-        </Link>{" "}
-        page at any time.
+        {t.rich("addMoreHint", {
+          link: (chunks: string) => (
+            <Link href="/integrations" className="underline hover:text-foreground">
+              {chunks}
+            </Link>
+          ),
+        })}
       </Text>
 
       <Stack gap="3">
@@ -221,7 +223,7 @@ export function StepEasyPlugins({ config, onConfigChange, onValidChange }: StepE
                         )}
                         {plugin.builtin && (
                           <Badge variant="outline" className="text-[10px] px-1.5 py-0 h-4 text-muted-foreground">
-                            Built-in
+                            {t("builtInBadge")}
                           </Badge>
                         )}
                       </CardTitle>
@@ -256,7 +258,7 @@ export function StepEasyPlugins({ config, onConfigChange, onValidChange }: StepE
                     />
                   </Stack>
                   <Text tone="muted" className="bg-muted/50 p-2 rounded">
-                    Preview:{" "}
+                    {t("previewLabel")}{" "}
                     <Text as="span" tone="muted" className="font-mono">
                       {currentTime}
                     </Text>


### PR DESCRIPTION
Closes #1567.

`i18next/no-literal-string` is now **zero and enforced as an `error`** — the full outcome, not the partial one.

## The three counts

Measured with `npx eslint . -f json` on this branch's parent (`d87a6ce1`), counting `ruleId === "i18next/no-literal-string"` messages. The exemptions were applied one at a time so each one's contribution is attributable rather than asserted:

| Config | Findings |
| --- | ---: |
| **Baseline** (`origin/main`) | **336** |
| + plugin default `words.exclude` restored, + Unicode punctuation/emoji patterns | 268 |
| + **`Code` / `CodeChip` children exempt** | **254** |
| + `*.stories.tsx` and test files ignored | 179 |
| **After the sweep** | **0** |

The single biggest cause of the inflated number was not `Code`. The rule shallow-merges its options over its own defaults, so the pre-existing `words: { exclude: ["FiestaBoard", "Vestaboard", "•", "&middot;"] }` **replaced** the plugin's default excludes rather than extending them. Every punctuation-only literal — `*`, `(`, `)`, `:`, `—`, `·`, `×`, `→`, `⌘↵` — was being reported as untranslated copy. 68 of the 336 were that.

`*.stories.tsx` and `__tests__` accounted for 75 more. Those are developer-facing fixtures that never render to an end user, and they are already exempt from the other app-only rules in this config (`react/forbid-elements`, `no-console`).

That left **179 real gaps across 31 files**, all of which are fixed here.

## What the sweep did

**151 new keys**, added to `en.json` and translated into all 13 other locales — no key drift, no English left in a non-English file.

Translations were written against each locale file's existing terminology and register, not machine-defaulted:

- German is `Sie` in settings/integrations/wizard (93 keys vs 41 in the file) but `du` in the AI panel, matching its `aiActionConfirmation` sibling
- Japanese です・ます, 「…」, ASCII colons; Korean 합쇼체; zh-CN 看板 / 集成 / 色块 with fullwidth punctuation
- Existing domain vocabulary reused verbatim: de Karussell/Kachel/Marktplatz, fr tableau/tuile/carrousel, ru доска/плитка/карусель, pl wtyczka/karuzela/kafelek
- Loanwords kept where the file already uses them — `Marketplace` stays untranslated in it/nl/sv/pt/pl/tr/zh because `integrations.tabMarketplace` already does; `Token` in de/nl/sv/es/it/pt/pl/tr; fr translates it as "Jeton" because `boardSettings.hideToken` already says "Masquer le jeton"

**Existing keys were reused rather than duplicated:** `common.cancel`, `common.delete`, `common.off`, `common.loading`, `common.pageCount`, `integrations.configuredBadge`, `integrations.requiredBadge`, `schedule.scheduleEntryForm.enabledLabel`/`enabledDescription`, `accountSection.signOut.button`, `pluginDetail.addInstanceOfTitle`. Three keys already existed in `en.json` but were never wired up — `integrations.colorRules.fieldPlaceholder`, `debugSettings.showDebugInfoOnBoard`, `debugSettings.clearMessageCache` — and are now.

**Sentences were kept whole.** Anything with an embedded value became one key with an ICU placeholder, not concatenated fragments, so word order can differ per language: `"{used} / {max} lines"`, `"Last checked: {time}"`, `"Delete instance “{label}”?"`. `collections.tsx` rendered `{n} page{n !== 1 ? "s" : ""}` — English-only pluralisation, now the existing `common.pageCount` ICU plural. Prose with inline markup uses a single `t.rich(...)` call (MCP card description, the Claude Desktop config paragraph, the backup restore confirmation, the wizard's `add more from <link>Integrations</link>` hint).

**Code was not translated.** Shell commands, file paths, env var names, template and formula syntax are wrapped in `Code`/`CodeChip` (exempt) or passed into `t.rich` as render functions: `COMPOSE_PROFILES=fiestaupdater`, `.env`, `npx`, `which npx`, `/api/mcp`, `|wrap`, `{{weather.temperature|pad:3}}`, and the operator/function cheat-sheets in `variable-rule-row.tsx`.

**English wording is byte-identical to what rendered before**, so the existing unit and Playwright assertions that match on it keep passing without any assertion being weakened.

### Two things swept beyond the lint count

- **21 literal `aria-label` / `title` attributes.** `mode: "jsx-text-only"` only visits literals whose direct parent is a JSX element, so it never reaches attribute values — the rule's `jsx-attributes.include` list has been inert this whole time. Those 21 were translated by hand anyway (screen-reader text is user-visible text). A comment in the config records why the include list is kept and what widening it would cost.
- **A rendering bug in `FilterPickerContent`.** `filterPicker.wrapInstruction` carried a `|wrap: ` prefix in all 14 locales while the JSX renders `<Code>|wrap</Code>:` right next to it, so the line read `|wrap: |wrap: Wraps long text…`. The prefix is dropped from the message value in every locale.

## TDD / non-vacuity

A key-parity test already existed (`src/__tests__/i18n-config.test.ts` → "every locale has exactly the same key paths as English"), so the job was to prove it is not vacuous rather than to write it.

**Observed failure, at the real scale of this change** — `en.json` populated with all 151 keys, locale files untouched:

```
 ✓ translation files > every locale file is valid JSON 9ms
 ✓ translation files > every locale has the same top-level namespaces as English 9ms
 × translation files > every locale has the same number of leaf keys as English
   → es has 1675 keys, English has 1826: expected 1675 to be 1826
 × translation files > every locale has exactly the same key paths as English
   → es is missing keys: activeDisplay.liveModeBadge, activeDisplay.turnOffLiveModeAriaLabel,
     aiChatPanel.emptyStateDescription, … (151 keys) …, wizard.easyPlugins.previewLabel:
     expected [ …(151) ] to deeply equal []
 Test Files  1 failed | ... 
```

Adding a single key to `en.json` alone reproduces it at minimum scale:

```
 × translation files > every locale has the same number of leaf keys as English
   → es has 1675 keys, English has 1676: expected 1675 to be 1676
 × translation files > every locale has exactly the same key paths as English
   → es is missing keys: common.__paritySmokeKey: expected [ 'common.__paritySmokeKey' ] to deeply equal []
 Tests  2 failed | 8 passed (10)
```

Both go green once the locale files are populated. Also verified: the test's third assertion (`no translation value is empty string`) still passes, and a `namespaces` mismatch is caught separately — the new `mcpSettings` namespace had to be created in all 14 files.

**Component-level non-vacuity.** Broke two swept lookups in `en.json` and confirmed the tests that cover them fail for the right reason:

```
 FAIL  live-output-home-sync.test.tsx > shows Live Mode badge when liveOutputMessage is set
   TestingLibraryElementError: Unable to find an element with the text: Live Mode.
 FAIL  live-output-home-sync.test.tsx > clicking the Live Mode turn-off button clears live output state
   TestingLibraryElementError: Unable to find an element with the text: Live Mode.
 FAIL  schema-form.test.tsx > renders a Select trigger (not a raw text input) for ui:widget: page-picker
   TestingLibraryElementError: Unable to find an element with the text: /none \(no override\)/i.
 Test Files  2 failed (2)   Tests  3 failed | 34 passed (37)
```

Restored → `Test Files 2 passed (2) / Tests 37 passed (37)`. The same negative control was run independently against `ai-settings.test.tsx` (11 failures without the keys, 0 with).

A separate script also confirmed **every `t("…")` / `t.rich("…")` call in the 34 changed TSX files resolves to a key that exists in `en.json`** — `checked 34 files, 0 missing keys`. Lint cannot catch a typo'd key; this can.

## Verification

```
$ docker run --rm -v "$PWD/web:/app" -v wf1567-nm:/app/node_modules -w /app -e CI=true node:24-alpine \
    sh -c 'npm run lint > /tmp/lint.txt 2>&1; echo "LINT_EXIT=$?"; grep -c "no-literal-string" /tmp/lint.txt; tail -3 /tmp/lint.txt'
LINT_EXIT=0
no-literal-string occurrences: 0

✖ 42 problems (0 errors, 42 warnings)
```

The 42 remaining warnings are the pre-existing `react-hooks/set-state-in-effect` baseline, unchanged by this PR. **`npm run lint` exits 0 with the rule at `error`** — verified, not assumed.

```
$ ... sh -c 'npx vitest run --reporter=dot --maxWorkers=3; echo "VITEST_EXIT=$?"'
 Test Files  121 passed (121)
      Tests  1499 passed | 13 skipped (1512)
VITEST_EXIT=0
```

121 of 121 files actually ran — no crashed workers hiding behind the pass count. (At default parallelism this container OOM-kills one worker and `active-page-display-multi-board.test.tsx` flakes; both reproduce identically on `origin/main`, and `--maxWorkers=3` clears them.)

```
$ ... sh -c 'npm run format:check; echo "FMT_EXIT=$?"'
Checking formatting...
All matched files use Prettier code style!
FMT_EXIT=0
```

```
$ ... sh -c 'npx react-router typegen; npx tsc --noEmit 2>&1 | grep -c "error TS"'
136
```

Same 136 as `origin/main` (87 unique file+message pairs, identical set — diffed against a clean extract of the parent commit). **No new TypeScript errors**, which matters because a `npm run typecheck` CI gate is landing separately.

## Inline disables

One added, one removed. Net zero, and no file-level disables anywhere.

**Added** — `FillSpaceNodeView.tsx:47`, merged into the existing `react/forbid-elements` disable because `eslint-disable-next-line` applies to line N+1 unconditionally and a stacked second comment would disable nothing:

> `react/forbid-elements, i18next/no-literal-string -- span inside a colored Badge in TipTap contentEditable; Text as="span" would override the Badge's inherited tint and text-[11px] is sub-xs grid geometry, and Code would add its own bg/padding/size. The text is the` `fill_space` `template token, which is syntax and stays verbatim in every locale.`

**Removed** — `network-settings.tsx:183` carried a bare `eslint-disable-next-line i18next/no-literal-string` with no reason, for the `%` in `{status.signal}%`. The restored punctuation exclude covers it, and ESLint now reports the directive as unused, so it is gone.

## Known follow-ups (not in scope here, no regression risk)

`mode: "jsx-text-only"` means literals inside JSX **expression containers** are still invisible to the rule — ternaries like `{isCreating ? "Creating..." : "Create"}`, `toast.success("…")`, and module-level label maps such as `INTERVAL_LABELS` in `auto-update-interval.tsx`. Widening to `jsx-only` would catch those and the attribute values in one go, but it is a materially larger sweep and belongs in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
