### PR TITLE
ci: run the docs quality gate on documentation changes (and fix the typo it let through)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
       plugins: ${{ steps.filter.outputs.plugins }}
       shared: ${{ steps.filter.outputs.shared }}
       docs: ${{ steps.filter.outputs.docs }}
+      markdown: ${{ steps.filter.outputs.markdown }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7

--- a/docs/development/PLUGIN_DEVELOPMENT.md
+++ b/docs/development/PLUGIN_DEVELOPMENT.md
@@ -679,7 +679,7 @@ the plugin whose settings are open, not from a fixed name.
 
 ### What is rejected
 
-The left-hand side of both blocks is *core's* vocabulary, so an unrecognised
+The left-hand side of both blocks is *core's* vocabulary, so an unrecognized
 entry there cannot be grammar from a newer core — it is a typo, and the field
 would silently probe with that part missing. These fail the whole manifest:
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -22,8 +22,16 @@
 # otherwise make the check flaky.
 accept = ["200..=299", "403", "429"]
 
-max_retries = 2
-retry_wait_time = 2
+# Transport-level failures need a bigger retry budget than HTTP statuses do.
+# GitHub-hosted runners intermittently fail github.com requests with
+# "HTTP/2 protocol error. Server may not support HTTP/2 properly" — not a
+# status code, so no `accept` entry can cover it (same shape as the
+# docs.vestaboard.com timeout excluded below). Observed transient: the same
+# six github.com URLs passed on a PR run and failed in the merge-queue run of
+# the identical commit ~20 minutes later. lychee exposes no flag to force
+# HTTP/1.1, so retries are the only lever.
+max_retries = 5
+retry_wait_time = 5
 timeout = 20
 no_progress = true
 


### PR DESCRIPTION
## The real defect: the docs quality gate has never run on docs changes

`detect-changes` defines a `markdown` filter, but **never exports it**:

```yaml
outputs:
  api: ${{ steps.filter.outputs.api }}
  ui: ${{ steps.filter.outputs.ui }}
  plugins: ${{ steps.filter.outputs.plugins }}
  shared: ${{ steps.filter.outputs.shared }}
  docs: ${{ steps.filter.outputs.docs }}
  # markdown: <- missing
```

So `needs.detect-changes.outputs.markdown` has always evaluated to `''`, and both consumers collapse to a single live term:

```yaml
if: needs.detect-changes.outputs.markdown == 'true'   # always '' -> false
 || needs.detect-changes.outputs.shared == 'true'     # the only test that ever fires
```

**`Lint Markdown`** (spell check + markdownlint + frontmatter validation) and **`Check Markdown Links`** have therefore never run for a documentation-only change since they were added in #1238 (2026-06-19). They fire only when a PR incidentally touches a *shared* file.

That inverts the gate: prose changes — the thing it exists to check — skip it, while unrelated PRs inherit whatever has accumulated on `main`.

## How this was found

#1599 adds a typecheck step to `.github/workflows/ci.yml`. It touches **no markdown at all**, but that made `shared` true, which linted all 99 markdown files and failed on a word from someone else's PR:

```
docs/development/PLUGIN_DEVELOPMENT.md:682:65 - Unknown word (unrecognised)
CSpell: Files checked: 99, Issues found: 1 in 1 file.
```

Tracing it back: #1557 introduced `unrecognised` while changing `docs/development/PLUGIN_DEVELOPMENT.md` (+78 lines). The `markdown` filter pattern is `**/*.md`, so that file matches — but `Lint Markdown` on #1557 is recorded as **`skipping`**, because the output it keys on does not exist. `cspell` uses the `en_US` dictionary, so the British spelling is flagged.

## The fix

Two commits, deliberately in one PR:

1. **`docs:`** correct `unrecognised` -> `unrecognized`.
2. **`ci:`** export `markdown: ${{ steps.filter.outputs.markdown }}`.

They have to ship together. Wiring the output up without fixing the typo would turn every subsequent markdown PR red on a defect it did not introduce — reproducing the exact problem this PR removes.

## Verification

Full gate in a `node:24-alpine` container after `npm ci` (`NPM_CI_EXIT=0`):

| Step | Exit | Result |
| --- | --- | --- |
| `docs:lint:frontmatter` | 0 | clean |
| `docs:lint:markdown` | 0 | `Linting: 99 files` / `Summary: 0 issues in 0 files` |
| `docs:lint:spell` | 0 | `Files checked: 99, Issues found: 0 in 0 files` |

cspell before the typo fix: `Issues found: 1 in 1 file`, exit 1. After: `0 in 0 files`, exit 0.

`ci.yml` parses (`js-yaml`, exit 0).

## Expected effect on this PR

This PR touches markdown *and* `ci.yml`, so `Lint Markdown` and `Check Markdown Links` both run — and with the export in place they will now also run on future docs-only PRs, which is the point.

One thing I could not verify locally: `Check Markdown Links` (lychee) makes live network requests, so it may surface pre-existing broken links that have been invisible for the same reason. If it does, those are pre-existing on `main` and want their own fix rather than reverting this export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)