### PR TITLE
fix(web): resolve all 42 React Compiler setState-in-effect warnings (#1568)

### DIFF
--- a/web/app/routes/integrations._index.tsx
+++ b/web/app/routes/integrations._index.tsx
@@ -269,6 +269,7 @@ import { toast } from "sonner";
 
 import { SchemaForm } from "@/components/plugin-settings";
 import Link from "@/components/smart-link";
+import { useDepsChanged } from "@/hooks/use-deps-changed";
 import { useEffectiveBoardColor } from "@/hooks/use-effective-board-color";
 import { useSearchParams } from "@/hooks/use-router";
 import { useTranslations } from "@/i18n/translations";
@@ -1051,8 +1052,10 @@ function InstalledPluginRow({
   // for any keys the saved config doesn't already set, so fields with a
   // declared `default` (e.g. refresh_seconds) show their value instead of
   // appearing blank. Saved config always wins over defaults.
-  useEffect(() => {
-    if (!pluginDetails) return;
+  // Done during render rather than in an effect, so the config dialog's fields
+  // are populated in its first commit instead of flashing empty
+  // (react-hooks/set-state-in-effect, issue #1568).
+  if (useDepsChanged([pluginDetails]) && pluginDetails) {
     const schema = pluginDetails.settings_schema as { properties?: Record<string, { default?: unknown }> } | undefined;
     const defaults: Record<string, unknown> = {};
     for (const [key, prop] of Object.entries(schema?.properties ?? {})) {
@@ -1061,7 +1064,7 @@ function InstalledPluginRow({
       }
     }
     setConfigValues({ ...defaults, ...(pluginDetails.config ?? {}) });
-  }, [pluginDetails]);
+  }
 
   const handleSaveConfig = async () => {
     setIsSaving(true);

--- a/web/app/routes/offline.tsx
+++ b/web/app/routes/offline.tsx
@@ -1,29 +1,29 @@
 import { Box, Flex, List, ListItem, Stack, Text } from "@fiestaboard/ui";
 import { RefreshCw, WifiOff } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useSyncExternalStore } from "react";
 
 import { useTranslations } from "@/i18n/translations";
 
+/** `navigator.onLine` is an external store — subscribe to it as one. */
+function subscribeToOnlineStatus(onChange: () => void) {
+  window.addEventListener("online", onChange);
+  window.addEventListener("offline", onChange);
+  return () => {
+    window.removeEventListener("online", onChange);
+    window.removeEventListener("offline", onChange);
+  };
+}
+
 export default function OfflinePage() {
-  const [isOnline, setIsOnline] = useState(false);
+  // Was a mount effect that called setIsOnline(navigator.onLine), i.e. always
+  // one render of "offline" before the truth arrived
+  // (react-hooks/set-state-in-effect, issue #1568).
+  const isOnline = useSyncExternalStore(
+    subscribeToOnlineStatus,
+    () => navigator.onLine,
+    () => false,
+  );
   const t = useTranslations("offline");
-
-  useEffect(() => {
-    // Check initial online status
-    setIsOnline(navigator.onLine);
-
-    // Listen for online/offline events
-    const handleOnline = () => setIsOnline(true);
-    const handleOffline = () => setIsOnline(false);
-
-    window.addEventListener("online", handleOnline);
-    window.addEventListener("offline", handleOffline);
-
-    return () => {
-      window.removeEventListener("online", handleOnline);
-      window.removeEventListener("offline", handleOffline);
-    };
-  }, []);
 
   const handleRetry = () => {
     if (navigator.onLine) {

--- a/web/app/routes/pages._index.tsx
+++ b/web/app/routes/pages._index.tsx
@@ -26,6 +26,7 @@ import { toast } from "sonner";
 import type { ViewMode } from "@/components/page-grid-selector";
 import { useBoardSettings, usePages } from "@/hooks/use-board";
 import { queryKeys } from "@/hooks/use-board";
+import { useDepsChanged } from "@/hooks/use-deps-changed";
 import { useViewTransition } from "@/hooks/use-view-transition";
 import { useTranslations } from "@/i18n/translations";
 import type { DeviceType } from "@/lib/api";
@@ -71,9 +72,12 @@ export function ImportPageDialog({ open, onOpenChange }: { open: boolean; onOpen
   const [shareString, setShareString] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  useEffect(() => {
-    if (!open) setShareString("");
-  }, [open]);
+  // Clear the pasted share string when the dialog closes. Done during render
+  // so a reopen can never flash the previous paste
+  // (react-hooks/set-state-in-effect, issue #1568).
+  if (useDepsChanged([open]) && !open) {
+    setShareString("");
+  }
 
   const importMutation = useMutation({
     mutationFn: () => api.importPage(shareString.trim()),
@@ -147,13 +151,22 @@ export default function PagesPage() {
   // demo pages on a note-only setup) are still reachable via the secondary
   // tab. After the user has chosen a tab we only override if their pick
   // is no longer available.
+  //
+  // Done during render rather than in an effect, so the tab strip renders on
+  // the right device the first time instead of switching under the user
+  // (react-hooks/set-state-in-effect, issue #1568). `activeTab` is not a dep:
+  // the user picking a tab can never invalidate it, so re-running on that
+  // would only ever be a no-op.
   const settingsLoaded = boardSettings !== undefined;
-  useEffect(() => {
-    if (!settingsLoaded || availableDevices.length === 0) return;
-    if (activeTab && availableDevices.includes(activeTab)) return;
+  if (
+    useDepsChanged([settingsLoaded, availableDevices, configuredDevices]) &&
+    settingsLoaded &&
+    availableDevices.length > 0 &&
+    !(activeTab && availableDevices.includes(activeTab))
+  ) {
     const preferred = configuredDevices.find((d) => availableDevices.includes(d));
     setActiveTab(preferred ?? availableDevices[0]);
-  }, [settingsLoaded, availableDevices, configuredDevices, activeTab]);
+  }
 
   const handleViewModeChange = useCallback((mode: ViewMode) => {
     setViewMode(mode);

--- a/web/app/routes/pages.edit._index.tsx
+++ b/web/app/routes/pages.edit._index.tsx
@@ -4,23 +4,26 @@ import { useEffect, useState } from "react";
 import { PageBuilder } from "@/components/page-builder";
 import { useViewTransition } from "@/hooks/use-view-transition";
 
+/** Read the `?id` query parameter (works with the static SPA build). */
+function readPageIdFromUrl(): string | null {
+  if (typeof window === "undefined") return null;
+  return new URLSearchParams(window.location.search).get("id");
+}
+
 export default function EditPage() {
   const { push } = useViewTransition();
-  const [pageId, setPageId] = useState<string | null>(null);
+
+  // Read the id in the state initializer, not a mount effect: the effect
+  // version always rendered "Loading…" once even when the id was right there
+  // in the URL (react-hooks/set-state-in-effect, issue #1568). The redirect
+  // stays in an effect — navigating during render is not allowed.
+  const [pageId] = useState(readPageIdFromUrl);
 
   useEffect(() => {
-    // Read query parameter from URL (works with static export)
-    if (typeof window !== "undefined") {
-      const params = new URLSearchParams(window.location.search);
-      const id = params.get("id");
-      if (!id) {
-        // Redirect to pages list if no ID provided
-        push("/pages", { transitionType: "slide-down" });
-      } else {
-        setPageId(id);
-      }
+    if (!pageId) {
+      push("/pages", { transitionType: "slide-down" });
     }
-  }, [push]);
+  }, [pageId, push]);
 
   const handleClose = () => {
     push("/pages", { transitionType: "slide-down" });

--- a/web/app/routes/schedule.tsx
+++ b/web/app/routes/schedule.tsx
@@ -99,6 +99,41 @@ function ScheduleCalendarView(props: React.ComponentProps<typeof ScheduleCalenda
 type ViewMode = "list" | "calendar";
 
 const SCHEDULE_VIEW_MODE_KEY = "schedule-view-mode";
+
+/** Pre-fill for the entry form, from a calendar slot, the AI drawer, or the URL. */
+interface PrefillData {
+  startTime?: string;
+  endTime?: string;
+  dayPattern?: DayPattern;
+  customDays?: string[];
+  pageId?: string;
+}
+
+/**
+ * Read the `prefill_*` query params the AI drawer sets when it navigates here
+ * from another page. Returns null when there is nothing to prefill.
+ */
+function readUrlPrefill(searchParams: URLSearchParams): PrefillData | null {
+  const pageId = searchParams.get("prefill_page_id");
+  const startTime = searchParams.get("prefill_start");
+  if (!pageId && !startTime) return null;
+
+  const rawDayPattern = searchParams.get("prefill_days");
+  const dayPattern: DayPattern | undefined =
+    rawDayPattern === "all" ||
+    rawDayPattern === "weekdays" ||
+    rawDayPattern === "weekends" ||
+    rawDayPattern === "custom"
+      ? rawDayPattern
+      : undefined;
+
+  return {
+    pageId: pageId ?? undefined,
+    startTime: startTime ?? undefined,
+    endTime: searchParams.get("prefill_end") ?? undefined,
+    dayPattern,
+  };
+}
 const NO_DEFAULT_PAGE = "__none__";
 
 export default function SchedulePage() {
@@ -121,7 +156,15 @@ export default function SchedulePage() {
   useEffect(() => {
     localStorage.setItem(SCHEDULE_VIEW_MODE_KEY, viewMode);
   }, [viewMode]);
-  const [showForm, setShowForm] = useState(false);
+  // Handle URL params set by the AI drawer when navigating from outside. Read
+  // once, in a state initializer rather than a mount effect: the effect version
+  // rendered the page without the form and then popped it open
+  // (react-hooks/set-state-in-effect, issue #1568).
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [urlPrefill] = useState(() => readUrlPrefill(searchParams));
+
+  const [showForm, setShowForm] = useState(urlPrefill !== null);
   const [editingSchedule, setEditingSchedule] = useState<ScheduleEntry | null>(null);
   const [deleteScheduleId, setDeleteScheduleId] = useState<string | null>(null);
 
@@ -133,13 +176,7 @@ export default function SchedulePage() {
   const effectiveBoardId = boards.length > 1 ? currentBoardId || undefined : undefined;
 
   // Pre-fill data when creating from calendar slot selection or AI navigation
-  const [prefillData, setPrefillData] = useState<{
-    startTime?: string;
-    endTime?: string;
-    dayPattern?: DayPattern;
-    customDays?: string[];
-    pageId?: string;
-  } | null>(null);
+  const [prefillData, setPrefillData] = useState<PrefillData | null>(urlPrefill);
 
   // Register with the schedule editor bridge so the AI drawer can open the
   // form directly when the user is already on this page.
@@ -163,35 +200,15 @@ export default function SchedulePage() {
     return () => unregister();
   }, [register, unregister]);
 
-  // Handle URL params set by the AI drawer when navigating from outside.
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const urlParamsHandled = useRef(false);
+  // The AI drawer navigates here with prefill_* query params. `urlPrefill` was
+  // read in the state initializer above; all that is left is scrubbing the
+  // params from the URL, which has to stay in an effect because navigating
+  // during render is not allowed.
   useEffect(() => {
-    if (urlParamsHandled.current) return;
-    const pageId = searchParams.get("prefill_page_id");
-    const startTime = searchParams.get("prefill_start");
-    const endTime = searchParams.get("prefill_end");
-    const rawDayPattern = searchParams.get("prefill_days");
-    const dayPattern: DayPattern | undefined =
-      rawDayPattern === "all" ||
-      rawDayPattern === "weekdays" ||
-      rawDayPattern === "weekends" ||
-      rawDayPattern === "custom"
-        ? rawDayPattern
-        : undefined;
-    if (pageId || startTime) {
-      urlParamsHandled.current = true;
-      setPrefillData({
-        pageId: pageId ?? undefined,
-        startTime: startTime ?? undefined,
-        endTime: endTime ?? undefined,
-        dayPattern,
-      });
-      setShowForm(true);
+    if (urlPrefill) {
       router.replace("/schedule", { scroll: false });
     }
-  }, [searchParams, router]);
+  }, [urlPrefill, router]);
 
   // Fetch schedules (scoped by board when multi-board). keepPreviousData holds
   // the outgoing board's list on screen while the new board's loads, so

--- a/web/app/routes/transitions.tsx
+++ b/web/app/routes/transitions.tsx
@@ -43,6 +43,7 @@ import { Cast, FlaskConical, Pause, Play, RotateCcw, SkipBack, SkipForward, Undo
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { TransitionGridDisplay } from "@/components/transitions/transition-grid-display";
+import { useDepsChanged } from "@/hooks/use-deps-changed";
 import { useRouter } from "@/hooks/use-router";
 import { useTranslations } from "@/i18n/translations";
 import type { DeviceType, TransitionPreviewResponse } from "@/lib/api";
@@ -99,23 +100,22 @@ export default function TransitionsLabPage() {
 
   const pages = useMemo(() => pagesQuery.data?.pages ?? [], [pagesQuery.data]);
 
-  // Pick the first plugin once loaded so the page isn't empty.
-  useEffect(() => {
-    if (!selectedPluginId && plugins.length > 0) {
-      setSelectedPluginId(plugins[0].id);
-    }
-  }, [plugins, selectedPluginId]);
+  // Pick the first plugin once loaded so the page isn't empty. Done during
+  // render rather than in an effect, so the pickers are populated in the same
+  // commit the lists arrive (react-hooks/set-state-in-effect, issue #1568).
+  if (useDepsChanged([plugins]) && !selectedPluginId && plugins.length > 0) {
+    setSelectedPluginId(plugins[0].id);
+  }
 
   // Default the from/to pickers to the first two pages once loaded.
-  useEffect(() => {
-    if (pages.length === 0) return;
+  if (useDepsChanged([pages]) && pages.length > 0) {
     if (!fromPageId) {
       setFromPageId(pages[0].id);
     }
     if (!toPageId) {
       setToPageId((pages[1] ?? pages[0]).id);
     }
-  }, [pages, fromPageId, toPageId]);
+  }
 
   const selectedPlugin = useMemo(
     () => plugins.find((p) => p.id === selectedPluginId) ?? null,
@@ -125,25 +125,22 @@ export default function TransitionsLabPage() {
   // Seed the config editor with the plugin's current config when the
   // selection changes, so authors aren't staring at an empty `{}` when
   // a plugin already has defaults.
-  useEffect(() => {
-    if (selectedPlugin) {
-      setConfigJson(JSON.stringify(selectedPlugin.config ?? {}, null, 2));
-    }
-  }, [selectedPlugin]);
+  if (useDepsChanged([selectedPlugin]) && selectedPlugin) {
+    setConfigJson(JSON.stringify(selectedPlugin.config ?? {}, null, 2));
+  }
 
   const toPage = useMemo(() => pages.find((p) => p.id === toPageId) ?? null, [pages, toPageId]);
 
   // Match the preview canvas to the target page's geometry — a transition
   // on a real board always runs at the dimensions of the page being shown.
   // The device picker stays editable so authors can still experiment.
-  useEffect(() => {
-    if (!toPage) return;
+  if (useDepsChanged([toPage]) && toPage) {
     setDeviceType(toPage.device_type);
     if (toPage.device_type === "note_array") {
       setNotesWide(toPage.notes_wide ?? 1);
       setNotesTall(toPage.notes_tall ?? 1);
     }
-  }, [toPage]);
+  }
 
   const stopPlayback = useCallback(() => {
     if (playTimerRef.current) {
@@ -155,12 +152,17 @@ export default function TransitionsLabPage() {
 
   // Drive playback: each frame schedules the next based on its delay_ms
   // (clamped so a long per-frame step delay doesn't stall the preview).
+  // Reaching the last frame stops playback. Done during render so the play
+  // button flips back in the same commit the last frame is shown
+  // (react-hooks/set-state-in-effect, issue #1568).
+  const atLastFrame = preview !== null && frameIdx >= preview.frames.length - 1;
+  if (useDepsChanged([isPlaying, frameIdx, preview]) && isPlaying && atLastFrame) {
+    setIsPlaying(false);
+  }
+
   useEffect(() => {
     if (!isPlaying || !preview) return;
-    if (frameIdx >= preview.frames.length - 1) {
-      setIsPlaying(false);
-      return;
-    }
+    if (frameIdx >= preview.frames.length - 1) return;
     const rawDelay = preview.frames[frameIdx]?.delay_ms ?? 100;
     const playbackDelay = Math.min(rawDelay, 2000);
     playTimerRef.current = setTimeout(() => {
@@ -174,14 +176,14 @@ export default function TransitionsLabPage() {
     };
   }, [isPlaying, frameIdx, preview]);
 
-  // When a new preview lands, reset playback to the first frame and
-  // autoplay if it has frames.  Autoplay must happen HERE, not in
-  // runPreview — this effect runs after the setPreview render, so a
-  // setIsPlaying(true) in runPreview would be immediately reverted.
-  useEffect(() => {
+  // When a new preview lands, reset playback to the first frame and autoplay
+  // if it has frames. This has to run off `preview` rather than inside
+  // runPreview: it must win over the "stop at the last frame" reset above,
+  // which is evaluated in the same render, and it must not be undone by it.
+  if (useDepsChanged([preview])) {
     setFrameIdx(0);
     setIsPlaying(Boolean(preview && preview.frames.length > 0));
-  }, [preview]);
+  }
 
   const runPreview = useCallback(async () => {
     if (!selectedPluginId || !fromPageId || !toPageId) return;

--- a/web/src/__tests__/board-settings-form-seed.test.tsx
+++ b/web/src/__tests__/board-settings-form-seed.test.tsx
@@ -1,0 +1,70 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import React from "react";
+import { describe, expect, it } from "vitest";
+
+import { BoardSettings } from "@/components/settings/board-settings";
+
+import { server } from "./mocks/server";
+
+const API_BASE = "/api";
+
+function TestWrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+function withBoardConfig(config: Record<string, unknown>) {
+  server.use(http.get(`${API_BASE}/config/board`, () => HttpResponse.json({ config, api_modes: ["local", "cloud"] })));
+}
+
+/**
+ * BoardSettings seeded its form from GET /config/board in a useEffect — one of
+ * the 42 `react-hooks/set-state-in-effect` warnings in #1568. It is now seeded
+ * during render. The seeding is load-bearing beyond cosmetics: the card
+ * auto-saves `formData` one second after `hasChanges` flips, so a form that
+ * seeds late (or seeds and marks itself dirty) can PUT the wrong config back.
+ */
+describe("BoardSettings form seeding", () => {
+  it("shows the saved board host once the config loads", async () => {
+    withBoardConfig({ api_mode: "local", host: "192.168.1.100", local_api_key: "***" });
+    render(<BoardSettings />, { wrapper: TestWrapper });
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("192.168.1.100")).toHaveValue("192.168.1.100");
+    });
+  });
+
+  it("selects the saved connection mode once the config loads", async () => {
+    withBoardConfig({ api_mode: "cloud", cloud_key: "***" });
+    render(<BoardSettings />, { wrapper: TestWrapper });
+
+    // The cloud-only field is what proves api_mode came from the server: the
+    // component's own default for a missing api_mode is "local".
+    expect(await screen.findByText("Read/Write API Key")).toBeInTheDocument();
+  });
+
+  it("does not mark the freshly seeded form as changed", async () => {
+    // hasChanges drives a 1s debounced auto-save. Seeding must leave it false
+    // or merely opening the card would PUT the config straight back.
+    const puts: unknown[] = [];
+    withBoardConfig({ api_mode: "local", host: "192.168.1.100", local_api_key: "***" });
+    server.use(
+      http.put(`${API_BASE}/config/board`, async ({ request }) => {
+        puts.push(await request.json());
+        return HttpResponse.json({ status: "success", config: {} });
+      }),
+    );
+
+    render(<BoardSettings />, { wrapper: TestWrapper });
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("192.168.1.100")).toHaveValue("192.168.1.100");
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 1300));
+    expect(puts).toEqual([]);
+  });
+});

--- a/web/src/__tests__/festive-months-settings.test.tsx
+++ b/web/src/__tests__/festive-months-settings.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { FestiveMonthsSettings } from "@/components/settings/festive-months-settings";
+import { HIDE_FESTIVE_COOKIE } from "@/lib/pride";
+
+function clearCookie() {
+  document.cookie = `${HIDE_FESTIVE_COOKIE}=; path=/; max-age=0`;
+}
+
+/**
+ * The switch reflects a browser cookie, which used to be read in a mount
+ * effect — one of the 42 `react-hooks/set-state-in-effect` warnings in #1568.
+ * That made the control render OFF and then visibly flip ON for users who had
+ * opted out. It now reads the cookie in the state initializer.
+ */
+describe("FestiveMonthsSettings", () => {
+  beforeEach(clearCookie);
+  afterEach(clearCookie);
+
+  it("shows the switch on when the hide_festive_months cookie is set", () => {
+    document.cookie = `${HIDE_FESTIVE_COOKIE}=true; path=/`;
+    render(<FestiveMonthsSettings />);
+
+    expect(screen.getByRole("switch", { name: "Hide festive months" })).toBeChecked();
+  });
+
+  it("shows the switch off when the cookie is absent", () => {
+    render(<FestiveMonthsSettings />);
+
+    expect(screen.getByRole("switch", { name: "Hide festive months" })).not.toBeChecked();
+  });
+
+  it("reads the cookie before the first paint, with no off-then-on flip", () => {
+    // The effect version committed `false` first. Asserting on the very first
+    // committed value is what distinguishes the two implementations.
+    document.cookie = `${HIDE_FESTIVE_COOKIE}=true; path=/`;
+    const { container } = render(<FestiveMonthsSettings />);
+
+    // No await, no waitFor: the initial synchronous render must already be on.
+    expect(container.querySelector('[role="switch"]')).toHaveAttribute("aria-checked", "true");
+  });
+});

--- a/web/src/__tests__/first-commit-state.test.tsx
+++ b/web/src/__tests__/first-commit-state.test.tsx
@@ -1,0 +1,108 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { BootGate } from "@/components/boot-gate";
+import { TemplateEditorToolbar } from "@/components/tiptap-template-editor/components/TemplateEditorToolbar";
+import { UpdateProvider } from "@/components/update-context";
+
+import { server } from "./mocks/server";
+
+const API_BASE = "/api";
+
+function TestWrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <UpdateProvider>{children}</UpdateProvider>
+    </QueryClientProvider>
+  );
+}
+
+/**
+ * The last two of the #1568 fixes that had no coverage of their own.
+ */
+describe("state that must land in the first commit", () => {
+  describe("BootGate", () => {
+    beforeEach(() => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      window.localStorage.clear();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+      window.localStorage.clear();
+    });
+
+    it("reveals the app once the health check answers", async () => {
+      server.use(http.get(`${API_BASE}/health`, () => HttpResponse.json({ status: "ok" })));
+
+      render(
+        <BootGate>
+          <output data-testid="app">app</output>
+        </BootGate>,
+        { wrapper: TestWrapper },
+      );
+
+      expect(await screen.findByTestId("app")).toBeInTheDocument();
+    });
+
+    it("holds the splash while the health check is failing", async () => {
+      server.use(http.get(`${API_BASE}/health`, () => new HttpResponse(null, { status: 503 })));
+
+      render(
+        <BootGate>
+          <output data-testid="app">app</output>
+        </BootGate>,
+        { wrapper: TestWrapper },
+      );
+
+      // Past the no-flash delay, the gate is showing the waiting splash and
+      // the children are still gated.
+      await vi.advanceTimersByTimeAsync(1000);
+      await waitFor(() => expect(screen.queryByTestId("app")).not.toBeInTheDocument());
+      expect(screen.getByRole("status")).toBeInTheDocument();
+    });
+  });
+
+  describe("TemplateEditorToolbar", () => {
+    /** Undo/redo available and a live selection — everything would be enabled. */
+    function fakeEditor() {
+      return {
+        can: () => ({ undo: () => true, redo: () => true }),
+        state: { selection: { from: 0, to: 3 }, doc: { textBetween: () => "abc" } },
+        on: vi.fn(),
+        off: vi.fn(),
+      };
+    }
+
+    function renderToolbar(editor: unknown) {
+      const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      return render(
+        <QueryClientProvider client={queryClient}>
+          {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+          <TemplateEditorToolbar editor={editor as any} deviceType="flagship" />
+        </QueryClientProvider>,
+      );
+    }
+
+    it("disables undo once the editor it acts on is gone", async () => {
+      const { rerender } = renderToolbar(fakeEditor());
+      await waitFor(() => expect(screen.getByRole("button", { name: "Undo" })).not.toBeDisabled());
+
+      const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+      rerender(
+        <QueryClientProvider client={queryClient}>
+          <TemplateEditorToolbar editor={null} deviceType="flagship" />
+        </QueryClientProvider>,
+      );
+
+      // No waitFor: an editor that has gone away must disable the buttons in
+      // the same commit, not a frame later.
+      expect(screen.getByRole("button", { name: "Undo" })).toBeDisabled();
+    });
+  });
+});

--- a/web/src/__tests__/mount-state-initializers.test.tsx
+++ b/web/src/__tests__/mount-state-initializers.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { InstallPrompt } from "@/components/install-prompt";
+import { SidebarProvider, useSidebar } from "@/components/sidebar-context";
+
+const pushSpy = vi.fn();
+vi.mock("@/hooks/use-view-transition", () => ({
+  useViewTransition: () => ({ push: pushSpy }),
+}));
+vi.mock("@/components/page-builder", () => ({
+  PageBuilder: ({ pageId }: { pageId: string }) => <div data-testid="page-builder">{pageId}</div>,
+}));
+
+// Imported after the mocks so the route picks them up.
+const { default: EditPage } = await import("../../app/routes/pages.edit._index");
+const { default: OfflinePage } = await import("../../app/routes/offline");
+
+/**
+ * These five all read a browser API on mount and pushed the result into state
+ * from a `useEffect` — the `react-hooks/set-state-in-effect` shape in issue
+ * #1568, and a guaranteed extra render of the wrong thing. They now read it in
+ * the `useState` initializer (safe: the app is a static SPA, `ssr: false`).
+ *
+ * The assertions deliberately look at the FIRST synchronous render, with no
+ * `waitFor` — that is the difference between the two implementations.
+ */
+describe("browser state read on the first render", () => {
+  describe("SidebarProvider", () => {
+    function ShowsCollapsed() {
+      const { collapsed } = useSidebar();
+      return <output data-testid="collapsed">{String(collapsed)}</output>;
+    }
+
+    beforeEach(() => window.localStorage.clear());
+    afterEach(() => window.localStorage.clear());
+
+    it("renders collapsed on the first render when that is the stored preference", () => {
+      window.localStorage.setItem("fiestaboard_sidebar_collapsed", "true");
+
+      render(
+        <SidebarProvider>
+          <ShowsCollapsed />
+        </SidebarProvider>,
+      );
+
+      expect(screen.getByTestId("collapsed").textContent).toBe("true");
+    });
+
+    it("renders expanded when nothing is stored", () => {
+      render(
+        <SidebarProvider>
+          <ShowsCollapsed />
+        </SidebarProvider>,
+      );
+
+      expect(screen.getByTestId("collapsed").textContent).toBe("false");
+    });
+  });
+
+  describe("OfflinePage", () => {
+    afterEach(() => vi.restoreAllMocks());
+
+    it("shows the reconnecting state on the first render when the browser is online", () => {
+      vi.spyOn(navigator, "onLine", "get").mockReturnValue(true);
+
+      render(<OfflinePage />);
+
+      expect(screen.getByRole("heading", { level: 1 }).textContent).toBe("Reconnecting...");
+    });
+
+    it("shows the offline state on the first render when the browser is offline", () => {
+      vi.spyOn(navigator, "onLine", "get").mockReturnValue(false);
+
+      render(<OfflinePage />);
+
+      expect(screen.getByRole("heading", { level: 1 }).textContent).toBe("You're Offline");
+    });
+  });
+
+  describe("EditPage", () => {
+    afterEach(() => {
+      pushSpy.mockClear();
+      window.history.replaceState({}, "", "/");
+    });
+
+    it("mounts the page builder on the first render when ?id is in the URL", () => {
+      window.history.replaceState({}, "", "/pages/edit?id=abc123");
+
+      render(<EditPage />);
+
+      // Never the "Loading..." placeholder — the id was in the URL all along.
+      expect(screen.getByTestId("page-builder").textContent).toBe("abc123");
+    });
+
+    it("redirects to the pages list when ?id is missing", () => {
+      window.history.replaceState({}, "", "/pages/edit");
+
+      render(<EditPage />);
+
+      expect(pushSpy).toHaveBeenCalledWith("/pages", { transitionType: "slide-down" });
+    });
+  });
+
+  describe("InstallPrompt", () => {
+    afterEach(() => vi.restoreAllMocks());
+
+    it("renders nothing when the app is already running standalone", () => {
+      vi.spyOn(window, "matchMedia").mockImplementation(
+        (query: string) => ({ matches: query === "(display-mode: standalone)" }) as MediaQueryList,
+      );
+
+      const { container } = render(<InstallPrompt />);
+
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+});

--- a/web/src/__tests__/prop-sync-during-render.test.tsx
+++ b/web/src/__tests__/prop-sync-during-render.test.tsx
@@ -1,0 +1,144 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { DaySelector } from "@/components/day-selector";
+import { ForceSetDialog } from "@/components/force-set-dialog";
+import { SchemaForm } from "@/components/plugin-settings/schema-form";
+import { VariableRuleRow } from "@/components/variable-rule-row";
+import type { VariableRule } from "@/lib/api";
+
+function QueryWrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+/**
+ * Each of these components used to copy a prop into local state from a
+ * useEffect — the `react-hooks/set-state-in-effect` shape in issue #1568. They
+ * now do it during render. These are the behaviours that would silently break
+ * if a sync were dropped or fired on the wrong renders; none of them had a
+ * test before.
+ */
+describe("prop-driven state syncs", () => {
+  describe("DaySelector", () => {
+    it("checks the days named by a changed customDays prop", () => {
+      const { rerender } = render(<DaySelector value="custom" customDays={["monday"]} onChange={vi.fn()} />);
+      expect(screen.getByLabelText("Monday")).toBeChecked();
+
+      rerender(<DaySelector value="custom" customDays={["tuesday"]} onChange={vi.fn()} />);
+
+      expect(screen.getByLabelText("Tuesday")).toBeChecked();
+      expect(screen.getByLabelText("Monday")).not.toBeChecked();
+    });
+
+    it("keeps a day the user just ticked when the parent re-renders with the same prop", () => {
+      const customDays = ["monday"];
+      const { rerender } = render(<DaySelector value="custom" customDays={customDays} onChange={vi.fn()} />);
+
+      fireEvent.click(screen.getByLabelText("Friday"));
+      expect(screen.getByLabelText("Friday")).toBeChecked();
+
+      rerender(<DaySelector value="custom" customDays={customDays} onChange={vi.fn()} />);
+      expect(screen.getByLabelText("Friday")).toBeChecked();
+    });
+  });
+
+  describe("ForceSetDialog", () => {
+    it("resets the duration to the 5 min default each time it reopens", async () => {
+      const user = userEvent.setup();
+      const { rerender } = render(<ForceSetDialog open onOpenChange={vi.fn()} pageId="p1" pageName="Weather" />, {
+        wrapper: QueryWrapper,
+      });
+
+      await user.click(await screen.findByRole("button", { name: "30 min" }));
+      // Selected presets get the primary background.
+      expect(screen.getByRole("button", { name: "30 min" }).className).toContain("bg-primary");
+
+      rerender(<ForceSetDialog open={false} onOpenChange={vi.fn()} pageId="p1" pageName="Weather" />);
+      rerender(<ForceSetDialog open onOpenChange={vi.fn()} pageId="p1" pageName="Weather" />);
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: "5 min" }).className).toContain("bg-primary");
+      });
+      expect(screen.getByRole("button", { name: "30 min" }).className).not.toContain("bg-primary");
+    });
+  });
+
+  describe("VariableRuleRow", () => {
+    const t = (key: string) => key;
+
+    function row(rule: VariableRule, isEditing: boolean) {
+      return (
+        <VariableRuleRow
+          rule={rule}
+          index={0}
+          pages={[{ id: "p1", name: "Evening" }]}
+          selectablePageIds={["p1"]}
+          isEditing={isEditing}
+          isDragging={false}
+          onRequestEdit={() => true}
+          onSave={vi.fn()}
+          onCancelEdit={vi.fn()}
+          onRemove={vi.fn()}
+          onDirtyChange={vi.fn()}
+          onDragStart={vi.fn()}
+          onDragOver={vi.fn()}
+          onDragEnd={vi.fn()}
+          t={t}
+        />
+      );
+    }
+
+    it("opens the editor on the rule's current expression, not the one it mounted with", () => {
+      // The row is a long-lived component: its rule can be replaced (a save
+      // elsewhere in the list, a reorder) while it is collapsed. Entering edit
+      // mode must snapshot the rule it has NOW.
+      const original: VariableRule = { expression: "date_time.hour >= 17", page_id: "p1" };
+      const replaced: VariableRule = { expression: "weather.temp > 80", page_id: "p1" };
+
+      const { rerender } = render(row(original, false), { wrapper: QueryWrapper });
+      rerender(row(replaced, false));
+      rerender(row(replaced, true));
+
+      expect(screen.getByRole("textbox")).toHaveValue("weather.temp > 80");
+    });
+  });
+
+  describe("SchemaForm number field", () => {
+    const schema = {
+      type: "object" as const,
+      properties: { latitude: { type: "number" as const, title: "Latitude" } },
+    };
+
+    it("shows a value written from outside the field while it is not focused", () => {
+      // This is the "use my location" button path: the parent replaces the
+      // value and the input has to follow.
+      const { rerender } = render(<SchemaForm schema={schema} values={{ latitude: 1 }} onChange={vi.fn()} />);
+      expect((screen.getByLabelText(/Latitude/) as HTMLInputElement).value).toBe("1");
+
+      rerender(<SchemaForm schema={schema} values={{ latitude: 40.7128 }} onChange={vi.fn()} />);
+      expect((screen.getByLabelText(/Latitude/) as HTMLInputElement).value).toBe("40.7128");
+    });
+
+    it("does not overwrite the number the user is typing", async () => {
+      const user = userEvent.setup();
+      const values = { latitude: 1 };
+      const { rerender } = render(<SchemaForm schema={schema} values={values} onChange={vi.fn()} />);
+
+      const input = screen.getByLabelText(/Latitude/);
+      await user.click(input);
+      await user.clear(input);
+      await user.type(input, "-12");
+
+      // A parent re-render with the same stored value must not snap the
+      // half-typed "-12" back to "1".
+      rerender(<SchemaForm schema={schema} values={values} onChange={vi.fn()} />);
+      expect((input as HTMLInputElement).value).toBe("-12");
+    });
+  });
+});

--- a/web/src/__tests__/settings-cards-server-sync.test.tsx
+++ b/web/src/__tests__/settings-cards-server-sync.test.tsx
@@ -1,0 +1,98 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import React from "react";
+import { describe, expect, it } from "vitest";
+
+import { AccessibilitySettings } from "@/components/settings/accessibility-settings";
+import { InstanceNameCard } from "@/components/settings/instance-name";
+import { TimeAndDateCard } from "@/components/settings/time-and-date";
+
+import { server } from "./mocks/server";
+
+const API_BASE = "/api";
+
+function TestWrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+function withAllSettings(payload: Record<string, unknown>) {
+  server.use(http.get(`${API_BASE}/settings/all`, () => HttpResponse.json(payload)));
+}
+
+/**
+ * These cards used to mirror the `/settings/all` response into local form
+ * state from a `useEffect`, which is the "cascading render" shape
+ * `react-hooks/set-state-in-effect` flags (issue #1568). They now adjust that
+ * state during render via `useDepsChanged`. The observable contract that must
+ * survive the swap: the server value reaches the control, and a local edit is
+ * not clobbered by a re-render that carries the same server data.
+ */
+describe("settings cards mirror server values without an effect", () => {
+  describe("AccessibilitySettings", () => {
+    it("shows the stored reduce-motion value once settings load", async () => {
+      withAllSettings({ display: { reduce_motion: true } });
+      render(<AccessibilitySettings />, { wrapper: TestWrapper });
+
+      const toggle = await screen.findByRole("switch", { name: /reduce motion/i });
+      await waitFor(() => expect(toggle).toBeChecked());
+    });
+
+    it("leaves the toggle off when the server has reduce motion disabled", async () => {
+      withAllSettings({ display: { reduce_motion: false } });
+      render(<AccessibilitySettings />, { wrapper: TestWrapper });
+
+      const toggle = await screen.findByRole("switch", { name: /reduce motion/i });
+      await waitFor(() => expect(toggle).not.toBeChecked());
+    });
+  });
+
+  describe("InstanceNameCard", () => {
+    it("shows the stored instance name once settings load", async () => {
+      withAllSettings({ general: { instance_name: "Living Room" } });
+      render(<InstanceNameCard />, { wrapper: TestWrapper });
+
+      const input = await screen.findByLabelText("Instance Name");
+      await waitFor(() => expect(input).toHaveValue("Living Room"));
+    });
+
+    it("keeps what the user typed when the same settings payload re-renders the card", async () => {
+      // The refetch after a save re-delivers identical data; the sync must not
+      // fire for it, or the field would snap back mid-edit.
+      withAllSettings({ general: { instance_name: "Living Room" } });
+      const user = userEvent.setup();
+      const { rerender } = render(<InstanceNameCard />, { wrapper: TestWrapper });
+
+      const input = await screen.findByLabelText("Instance Name");
+      await waitFor(() => expect(input).toHaveValue("Living Room"));
+
+      await user.clear(input);
+      await user.type(input, "Kitchen");
+      rerender(<InstanceNameCard />);
+
+      expect(await screen.findByLabelText("Instance Name")).toHaveValue("Kitchen");
+    });
+  });
+
+  describe("TimeAndDateCard", () => {
+    it("shows the stored time format once settings load", async () => {
+      withAllSettings({ general: { timezone: "America/New_York", time_format: "24h", date_format: "YYYY-MM-DD" } });
+      render(<TimeAndDateCard />, { wrapper: TestWrapper });
+
+      const trigger = await screen.findByLabelText("Time format");
+      await waitFor(() => expect(trigger).toHaveTextContent("24-hour (14:30)"));
+    });
+
+    it("shows the stored date format once settings load", async () => {
+      withAllSettings({ general: { timezone: "America/New_York", time_format: "24h", date_format: "YYYY-MM-DD" } });
+      render(<TimeAndDateCard />, { wrapper: TestWrapper });
+
+      const trigger = await screen.findByLabelText("Date format");
+      await waitFor(() => expect(trigger).toHaveTextContent("YYYY-MM-DD"));
+    });
+  });
+});

--- a/web/src/__tests__/transitions-lab-defaults.test.tsx
+++ b/web/src/__tests__/transitions-lab-defaults.test.tsx
@@ -1,0 +1,114 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { server } from "./mocks/server";
+
+vi.mock("@/hooks/use-router", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+}));
+
+const { default: TransitionsLabPage } = await import("../../app/routes/transitions");
+
+const API_BASE = "/api";
+
+function TestWrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+const PLUGIN = {
+  id: "wipe",
+  name: "Wipe",
+  description: "Wipes across",
+  version: "1.0.0",
+  enabled: true,
+  config: { direction: "left" },
+  config_schema: {},
+};
+
+const PAGES = [
+  { id: "p1", name: "Weather", device_type: "note", type: "template", duration_seconds: 60 },
+  { id: "p2", name: "Transit", device_type: "note", type: "template", duration_seconds: 60 },
+];
+
+/** Two frames so playback has somewhere to go, then somewhere to stop. */
+const FRAMES = [
+  { grid: [[0]], delay_ms: 10 },
+  { grid: [[1]], delay_ms: 10 },
+];
+
+function mockLab() {
+  server.use(
+    http.get(`${API_BASE}/settings/beta`, () =>
+      HttpResponse.json({ settings: { transition_plugins_enabled: true }, available: [] }),
+    ),
+    http.get(`${API_BASE}/transitions/plugins`, () => HttpResponse.json({ plugins: [PLUGIN] })),
+    http.get(`${API_BASE}/pages`, () => HttpResponse.json({ pages: PAGES })),
+    http.post(`${API_BASE}/transitions/preview`, () =>
+      HttpResponse.json({ frames: FRAMES, frame_count: FRAMES.length, capped: false }),
+    ),
+  );
+}
+
+/**
+ * The Transition Lab drove six separate `useEffect`s that wrote state — every
+ * default on the page plus the whole playback state machine (6 of the 42
+ * `react-hooks/set-state-in-effect` warnings in #1568). They are all
+ * render-phase now, and none of them had a test.
+ */
+describe("Transition Lab defaults and playback", () => {
+  beforeEach(mockLab);
+
+  it("selects the first plugin once the plugin list loads", async () => {
+    render(<TransitionsLabPage />, { wrapper: TestWrapper });
+
+    const trigger = await screen.findByLabelText("Transition plugin");
+    await waitFor(() => expect(trigger).toHaveTextContent("Wipe"));
+  });
+
+  it("defaults the from and to pickers to the first two pages", async () => {
+    render(<TransitionsLabPage />, { wrapper: TestWrapper });
+
+    const from = await screen.findByLabelText("From page");
+    const to = await screen.findByLabelText("To page");
+    await waitFor(() => expect(from).toHaveTextContent("Weather"));
+    expect(to).toHaveTextContent("Transit");
+  });
+
+  it("seeds the config editor from the selected plugin's saved config", async () => {
+    render(<TransitionsLabPage />, { wrapper: TestWrapper });
+
+    const config = await screen.findByLabelText("Plugin config (JSON)");
+    await waitFor(() => {
+      expect((config as HTMLTextAreaElement).value).toBe(JSON.stringify({ direction: "left" }, null, 2));
+    });
+  });
+
+  it("matches the preview canvas to the target page's device type", async () => {
+    // Both pages are notes, so the device picker must follow rather than stay
+    // on its "flagship" default.
+    render(<TransitionsLabPage />, { wrapper: TestWrapper });
+
+    const device = await screen.findByLabelText("Device");
+    await waitFor(() => expect(device).toHaveTextContent("Note (3×15)"));
+  });
+
+  it("starts on frame 1 and stops on the last frame when a preview lands", async () => {
+    const user = userEvent.setup();
+    render(<TransitionsLabPage />, { wrapper: TestWrapper });
+
+    await waitFor(() => expect(screen.getByLabelText("From page")).toHaveTextContent("Weather"));
+    await user.click(screen.getByRole("button", { name: "Run preview" }));
+
+    // Autoplay runs to the end, then stops: the toggle is back to "Play" and
+    // the counter is parked on the last frame.
+    await waitFor(() => expect(screen.getByText("Frame 2 / 2")).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole("button", { name: "Play" })).toBeInTheDocument());
+  });
+});

--- a/web/src/__tests__/use-deps-changed.test.tsx
+++ b/web/src/__tests__/use-deps-changed.test.tsx
@@ -1,0 +1,106 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useLayoutEffect, useState } from "react";
+import { describe, expect, it } from "vitest";
+
+import { useDepsChanged } from "@/hooks/use-deps-changed";
+
+/**
+ * `useDepsChanged` is the render-phase replacement for the
+ * "mirror an external value into local state" effect that
+ * `react-hooks/set-state-in-effect` flags (issue #1568). It has to fire on
+ * exactly the renders `useEffect(fn, deps)` would have fired on — the first
+ * one, plus every dep-identity change — or the components ported onto it
+ * silently stop syncing.
+ */
+describe("useDepsChanged", () => {
+  /** Renders `value`, mirrored into state via useDepsChanged. */
+  function Mirror({ value }: { value: string }) {
+    const [mirrored, setMirrored] = useState("unsynced");
+    const changed = useDepsChanged([value]);
+    if (changed) setMirrored(value);
+    return <output data-testid="mirror">{mirrored}</output>;
+  }
+
+  it("fires on the first render, so mount-time syncing still happens", () => {
+    render(<Mirror value="from-server" />);
+    expect(screen.getByTestId("mirror").textContent).toBe("from-server");
+  });
+
+  it("fires again when a dep changes identity", () => {
+    const { rerender } = render(<Mirror value="from-server" />);
+    rerender(<Mirror value="refetched" />);
+    expect(screen.getByTestId("mirror").textContent).toBe("refetched");
+  });
+
+  it("does not fire when the deps are unchanged, so local edits survive re-renders", () => {
+    function EditableMirror({ value }: { value: string }) {
+      const [mirrored, setMirrored] = useState("unsynced");
+      const changed = useDepsChanged([value]);
+      if (changed) setMirrored(value);
+      return (
+        <>
+          <output data-testid="mirror">{mirrored}</output>
+          <button data-testid="edit" onClick={() => setMirrored("typed-by-user")} />
+        </>
+      );
+    }
+
+    const { rerender } = render(<EditableMirror value="from-server" />);
+    fireEvent.click(screen.getByTestId("edit"));
+    expect(screen.getByTestId("mirror").textContent).toBe("typed-by-user");
+
+    // Same dep identity — a parent re-render must not clobber the local edit.
+    rerender(<EditableMirror value="from-server" />);
+    expect(screen.getByTestId("mirror").textContent).toBe("typed-by-user");
+  });
+
+  it("compares deps by identity, not by value, so equal-looking objects still re-sync", () => {
+    function ObjectMirror({ obj }: { obj: { n: number } }) {
+      const [seen, setSeen] = useState(0);
+      const changed = useDepsChanged([obj]);
+      if (changed) setSeen((s) => s + 1);
+      return <output data-testid="seen">{seen}</output>;
+    }
+
+    const { rerender } = render(<ObjectMirror obj={{ n: 1 }} />);
+    expect(screen.getByTestId("seen")).toHaveTextContent("1");
+    rerender(<ObjectMirror obj={{ n: 1 }} />);
+    expect(screen.getByTestId("seen")).toHaveTextContent("2");
+  });
+
+  it("treats a dep list of a different length as changed", () => {
+    function VariadicMirror({ deps }: { deps: unknown[] }) {
+      const [count, setCount] = useState(0);
+      const changed = useDepsChanged(deps);
+      if (changed) setCount((c) => c + 1);
+      return <output data-testid="count">{count}</output>;
+    }
+
+    const { rerender } = render(<VariadicMirror deps={["a"]} />);
+    expect(screen.getByTestId("count")).toHaveTextContent("1");
+    rerender(<VariadicMirror deps={["a", "b"]} />);
+    expect(screen.getByTestId("count")).toHaveTextContent("2");
+  });
+
+  it("mirrors the value before the first commit, not after it", () => {
+    // This is the point of the refactor. The effect version committed
+    // "unsynced", then re-rendered with "a" — so a layout effect (which runs
+    // synchronously with each commit) would observe both. The render-phase
+    // version restarts the render before committing, so the only value that
+    // ever reaches the DOM is "a".
+    const commits: string[] = [];
+
+    function Recording({ value }: { value: string }) {
+      const [mirrored, setMirrored] = useState("unsynced");
+      const changed = useDepsChanged([value]);
+      if (changed) setMirrored(value);
+      useLayoutEffect(() => {
+        commits.push(mirrored);
+      });
+      return <output>{mirrored}</output>;
+    }
+
+    render(<Recording value="a" />);
+    expect(commits).toEqual(["a"]);
+  });
+});

--- a/web/src/components/active-page-display.tsx
+++ b/web/src/components/active-page-display.tsx
@@ -63,6 +63,7 @@ import {
   usePages,
   useSetActivePage,
 } from "@/hooks/use-board";
+import { useDepsChanged } from "@/hooks/use-deps-changed";
 import { useTranslations } from "@/i18n/translations";
 import type { BoardCurrentMessageResponse, Collection, SilenceStatus } from "@/lib/api";
 import { api, isCollectionId } from "@/lib/api";
@@ -117,18 +118,22 @@ export function ActivePageDisplay() {
     return () => clearTimeout(timer);
   }, []);
 
-  // Handle showing content after animation completes
+  // Handle showing content after animation completes. Hiding on close is a
+  // render-phase reset, not a setState in the effect body
+  // (react-hooks/set-state-in-effect, issue #1568) — and it stays synchronous
+  // with the close, where an effect would have let the content linger for a
+  // frame.
+  if (useDepsChanged([isSheetOpen]) && !isSheetOpen) {
+    setShowSheetContent(false);
+  }
+
   useEffect(() => {
-    if (isSheetOpen) {
-      // Wait for slide animation to complete (400ms) before revealing content
-      const timer = setTimeout(() => {
-        setShowSheetContent(true);
-      }, 420); // Slightly after animation (400ms + buffer)
-      return () => clearTimeout(timer);
-    } else {
-      // Hide immediately when closing
-      setShowSheetContent(false);
-    }
+    if (!isSheetOpen) return;
+    // Wait for slide animation to complete (400ms) before revealing content
+    const timer = setTimeout(() => {
+      setShowSheetContent(true);
+    }, 420); // Slightly after animation (400ms + buffer)
+    return () => clearTimeout(timer);
   }, [isSheetOpen]);
 
   // Fetch schedule status and active page in a single request.

--- a/web/src/components/ai-chat-panel.tsx
+++ b/web/src/components/ai-chat-panel.tsx
@@ -48,6 +48,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ChainingModePicker } from "@/components/chaining-mode-picker";
 import { ChatMarkdown } from "@/components/chat-markdown";
 import { InlineBoardPreview } from "@/components/inline-board-preview";
+import { useDepsChanged } from "@/hooks/use-deps-changed";
 import { useTranslations } from "@/i18n/translations";
 import type {
   ChainingMode,
@@ -367,18 +368,22 @@ function TaskListPanel({ tasks }: { tasks: TaskItem[] }) {
   const t = useTranslations("aiChatPanel");
   const allDone = tasks.length > 0 && tasks.every((task) => task.status === "done" || task.status === "failed");
   const doneCount = tasks.filter((task) => task.status === "done").length;
-  const [visible, setVisible] = useState(true);
+  // The panel auto-hides 3s after everything finishes, and comes back when new
+  // work starts. Only the hide is a timer; the un-hide is a render-phase reset
+  // rather than a setState in the effect body
+  // (react-hooks/set-state-in-effect, issue #1568).
+  const [hidden, setHidden] = useState(false);
+  if (useDepsChanged([allDone]) && !allDone) {
+    setHidden(false);
+  }
 
   useEffect(() => {
-    if (allDone) {
-      const timer = setTimeout(() => setVisible(false), 3000);
-      return () => clearTimeout(timer);
-    } else {
-      setVisible(true);
-    }
+    if (!allDone) return;
+    const timer = setTimeout(() => setHidden(true), 3000);
+    return () => clearTimeout(timer);
   }, [allDone]);
 
-  if (!visible) return null;
+  if (hidden) return null;
 
   const pct = tasks.length > 0 ? (doneCount / tasks.length) * 100 : 0;
 

--- a/web/src/components/boot-gate.tsx
+++ b/web/src/components/boot-gate.tsx
@@ -6,6 +6,7 @@ import { WifiOff } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { useUpdate } from "@/components/update-context";
+import { useDepsChanged } from "@/hooks/use-deps-changed";
 import { useTranslations } from "@/i18n/translations";
 import { apiUrl } from "@/lib/base-path";
 
@@ -60,11 +61,17 @@ export function BootGate({ children }: { children: React.ReactNode }) {
     enabled: !hasConnected,
   });
 
-  // Mark connected on first successful response. This is also what retires a
-  // post-update marker: the new container answered, so the update is over.
+  // Mark connected on first successful response. Done during render so the
+  // splash clears in the same commit the health check lands
+  // (react-hooks/set-state-in-effect, issue #1568).
+  if (useDepsChanged([data]) && data) {
+    setHasConnected(true);
+  }
+
+  // Retiring the post-update marker touches the UpdateProvider's state, which
+  // is a different component — that has to stay in an effect.
   useEffect(() => {
     if (!data) return;
-    setHasConnected(true);
     markPostUpdateBootComplete();
   }, [data, markPostUpdateBootComplete]);
 

--- a/web/src/components/current-board-context.tsx
+++ b/web/src/components/current-board-context.tsx
@@ -4,6 +4,7 @@ import { createContext, useCallback, useContext, useEffect, useLayoutEffect, use
 import { flushSync } from "react-dom";
 
 import { useBoardSettings } from "@/hooks/use-board";
+import { useDepsChanged } from "@/hooks/use-deps-changed";
 import type { BoardInstance } from "@/lib/api";
 
 const STORAGE_KEY = "fiestaboard_current_board";
@@ -95,8 +96,12 @@ export function CurrentBoardProvider({ children }: { children: React.ReactNode }
   // Reconcile the selected board against the live board list. The default is
   // the PRIMARY board (boards[0]); a stored id is honored only if it still
   // maps to an existing board, otherwise it's dropped in favor of the primary.
-  useEffect(() => {
-    if (boards.length === 0) return;
+  //
+  // Done during render rather than in an effect (react-hooks/set-state-in-effect,
+  // issue #1568): the reconciled id is then in the same commit as the board
+  // list it was reconciled against, so consumers never see the empty-string
+  // placeholder alongside a populated `boards`.
+  if (useDepsChanged([boards]) && boards.length > 0) {
     const primaryId = boards[0].id;
 
     setCurrentBoardIdState((prev) => {
@@ -108,7 +113,7 @@ export function CurrentBoardProvider({ children }: { children: React.ReactNode }
 
       return primaryId;
     });
-  }, [boards]);
+  }
 
   // Refs so setCurrentBoardId can compute the switch direction without
   // changing identity every time the selection or board list updates.

--- a/web/src/components/day-selector.tsx
+++ b/web/src/components/day-selector.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { Badge, Box, Flex, Text } from "@fiestaboard/ui";
-import { type KeyboardEvent, useEffect, useRef, useState } from "react";
+import { type KeyboardEvent, useRef, useState } from "react";
 
+import { useDepsChanged } from "@/hooks/use-deps-changed";
 import { useTranslations } from "@/i18n/translations";
 import type { DayPattern } from "@/lib/api";
 import { cn } from "@/lib/utils";
@@ -16,6 +17,10 @@ interface DaySelectorProps {
   className?: string;
 }
 
+// Stable identity for the default: the customDays sync compares by identity,
+// and a fresh `[]` literal per render would re-fire it every render.
+const NO_CUSTOM_DAYS: string[] = [];
+
 const WEEKDAYS = ["monday", "tuesday", "wednesday", "thursday", "friday"];
 const WEEKENDS = ["saturday", "sunday"];
 const ALL_DAYS = [...WEEKDAYS, ...WEEKENDS];
@@ -24,7 +29,7 @@ const ALL_DAYS = [...WEEKDAYS, ...WEEKENDS];
 // (Flex layout via <Flex wrap justify="end" gap="1"> at each usage.)
 const CHIP_ROW_CLASS = "ml-auto min-w-0";
 
-export function DaySelector({ value, customDays = [], onChange, className }: DaySelectorProps) {
+export function DaySelector({ value, customDays = NO_CUSTOM_DAYS, onChange, className }: DaySelectorProps) {
   const t = useTranslations("daySelector");
   const dayLabels = t.raw("dayLabels") as Record<string, string>;
   const [selectedCustomDays, setSelectedCustomDays] = useState<string[]>(customDays);
@@ -56,10 +61,12 @@ export function DaySelector({ value, customDays = [], onChange, className }: Day
     radioRefs.current[nextPattern]?.focus();
   };
 
-  // Update selectedCustomDays when customDays prop changes
-  useEffect(() => {
+  // Update selectedCustomDays when the customDays prop changes. Done during
+  // render so the checkboxes are right in the first commit
+  // (react-hooks/set-state-in-effect, issue #1568).
+  if (useDepsChanged([customDays])) {
     setSelectedCustomDays(customDays);
-  }, [customDays]);
+  }
 
   const handlePatternChange = (pattern: DayPattern) => {
     if (pattern === "custom") {

--- a/web/src/components/force-set-dialog.tsx
+++ b/web/src/components/force-set-dialog.tsx
@@ -17,9 +17,10 @@ import {
 } from "@fiestaboard/ui";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Timer } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { toast } from "sonner";
 
+import { useDepsChanged } from "@/hooks/use-deps-changed";
 import { useTranslations } from "@/i18n/translations";
 import type { SetTemporaryOverrideRequest } from "@/lib/api";
 import { api } from "@/lib/api";
@@ -46,13 +47,14 @@ export function ForceSetDialog({ open, onOpenChange, pageId, pageName }: ForceSe
   const [customMinutes, setCustomMinutes] = useState<string>("");
   const [isCustom, setIsCustom] = useState(false);
 
-  useEffect(() => {
-    if (open) {
-      setDurationMinutes(5);
-      setCustomMinutes("");
-      setIsCustom(false);
-    }
-  }, [open]);
+  // Reset the duration picker each time the dialog opens. Done during render
+  // so the dialog's first painted frame already shows the defaults instead of
+  // last time's selection (react-hooks/set-state-in-effect, issue #1568).
+  if (useDepsChanged([open]) && open) {
+    setDurationMinutes(5);
+    setCustomMinutes("");
+    setIsCustom(false);
+  }
 
   const effectiveDuration = isCustom ? Math.max(1, Math.min(480, parseInt(customMinutes, 10) || 1)) : durationMinutes;
 

--- a/web/src/components/install-prompt.tsx
+++ b/web/src/components/install-prompt.tsx
@@ -11,16 +11,23 @@ interface BeforeInstallPromptEvent extends Event {
   userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
 }
 
+function isRunningStandalone(): boolean {
+  return typeof window !== "undefined" && window.matchMedia("(display-mode: standalone)").matches;
+}
+
 export function InstallPrompt() {
   const t = useTranslations("installPrompt");
   const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
   const [isVisible, setIsVisible] = useState(false);
-  const [isInstalled, setIsInstalled] = useState(false);
+  // Read display-mode in the initializer rather than a mount effect, so an
+  // installed app never renders the "not installed" branch first
+  // (react-hooks/set-state-in-effect, issue #1568). Safe because the app is a
+  // static SPA (`ssr: false`) — there is no server render to mismatch.
+  const [isInstalled, setIsInstalled] = useState(isRunningStandalone);
 
   useEffect(() => {
-    // Check if app is already installed
-    if (window.matchMedia("(display-mode: standalone)").matches) {
-      setIsInstalled(true);
+    // Already installed: nothing to listen for.
+    if (isInstalled) {
       return;
     }
 
@@ -62,7 +69,7 @@ export function InstallPrompt() {
       window.removeEventListener("beforeinstallprompt", handleBeforeInstallPrompt);
       window.removeEventListener("appinstalled", handleAppInstalled);
     };
-  }, []);
+  }, [isInstalled]);
 
   const handleInstallClick = async () => {
     if (!deferredPrompt) {

--- a/web/src/components/page-grid-selector.tsx
+++ b/web/src/components/page-grid-selector.tsx
@@ -110,13 +110,16 @@ const PageButtonPreview = memo(
   }) {
     const t = useTranslations("pageGridSelector");
     const ref = useRef<HTMLDivElement>(null);
-    const [isVisible, setIsVisible] = useState(false);
+    // Environments without IntersectionObserver (jsdom, very old browsers)
+    // render everything eagerly. Decided in the initializer rather than a
+    // mount effect, which cost a whole extra render pass per tile there
+    // (react-hooks/set-state-in-effect, issue #1568).
+    const [isVisible, setIsVisible] = useState(() => typeof IntersectionObserver === "undefined");
 
     useEffect(() => {
       const el = ref.current;
       if (!el) return;
       if (typeof IntersectionObserver === "undefined") {
-        setIsVisible(true);
         return;
       }
       const observer = new IntersectionObserver(
@@ -552,88 +555,89 @@ export function PageGridSelector({
     return result;
   }, [allPages, deviceTypeFilter, filterByCurrentBoardSize, currentBoard]);
 
-  // State for batch preview data
-  const [previews, setPreviews] = useState<Record<string, PagePreviewResponse>>({});
-  const [loadingPreviews, setLoadingPreviews] = useState(true);
+  // State for batch preview data — only what the network produced.
+  const [fetchedPreviews, setFetchedPreviews] = useState<Record<string, PagePreviewResponse>>({});
+  const [fetchFailed, setFetchFailed] = useState(false);
 
-  // Fetch batch previews when pages change (only in grid mode)
-  useEffect(() => {
+  // Splitting the cache lookup out of the effect is what removes the
+  // set-state-in-effect warnings here (issue #1568): reading localStorage is
+  // synchronous, so the cached previews and the "which ones must we fetch"
+  // list are plain derived values. Only the network result — which arrives in
+  // an async callback, where setState is fine — still needs state.
+  const { cachedPreviews, initialPreviews, pagesToFetch } = useMemo(() => {
     if (viewMode === "list" || pages.length === 0) {
-      setLoadingPreviews(false);
+      return { cachedPreviews: {}, initialPreviews: {}, pagesToFetch: [] as string[] };
+    }
+    const cached = getCachedPreviews();
+    const initial: Record<string, PagePreviewResponse> = {};
+    const toFetch: string[] = [];
+    for (const page of pages) {
+      const entry = cached[page.id];
+      if (isCacheValid(entry, page.updated_at || "")) {
+        initial[page.id] = entry.preview;
+      } else {
+        toFetch.push(page.id);
+      }
+    }
+    return { cachedPreviews: cached, initialPreviews: initial, pagesToFetch: toFetch };
+  }, [pages, viewMode]);
+
+  // Cache hits render instantly; anything fetched since layers on top.
+  const previews = useMemo(() => ({ ...initialPreviews, ...fetchedPreviews }), [initialPreviews, fetchedPreviews]);
+
+  // Still waiting only while a page we need has neither a cache hit nor a
+  // fetched result, and the fetch hasn't given up.
+  const previewsPending = pagesToFetch.some((id) => !(id in fetchedPreviews)) && !fetchFailed;
+
+  // Fetch missing previews in batch
+  useEffect(() => {
+    if (pagesToFetch.length === 0) {
       return;
     }
 
-    // Check cache first for instant render
-    const cachedPreviews = getCachedPreviews();
-    const initialPreviews: Record<string, PagePreviewResponse> = {};
-    const pagesToFetch: string[] = [];
+    let mounted = true;
 
-    for (const page of pages) {
-      const cached = cachedPreviews[page.id];
-      const pageUpdatedAt = page.updated_at || "";
+    const fetchBatchPreviews = async () => {
+      try {
+        const result = await api.previewPagesBatch(pagesToFetch);
 
-      if (isCacheValid(cached, pageUpdatedAt)) {
-        initialPreviews[page.id] = cached.preview;
-      } else {
-        pagesToFetch.push(page.id);
-      }
-    }
+        if (mounted && result.previews) {
+          const newCachedPreviews = { ...cachedPreviews };
 
-    // Set cached previews immediately for instant render
-    if (Object.keys(initialPreviews).length > 0) {
-      setPreviews(initialPreviews);
-      setLoadingPreviews(pagesToFetch.length > 0);
-    }
-
-    // Fetch missing previews in batch
-    if (pagesToFetch.length > 0) {
-      let mounted = true;
-
-      const fetchBatchPreviews = async () => {
-        try {
-          const result = await api.previewPagesBatch(pagesToFetch);
-
-          if (mounted && result.previews) {
-            const newCachedPreviews = { ...cachedPreviews };
-
-            for (const [pageId, preview] of Object.entries(result.previews)) {
-              if (preview.available) {
-                const page = pages.find((p) => p.id === pageId);
-                if (page) {
-                  newCachedPreviews[pageId] = {
-                    preview,
-                    pageUpdatedAt: page.updated_at || "",
-                    cachedAt: new Date().toISOString(),
-                  };
-                }
+          for (const [pageId, preview] of Object.entries(result.previews)) {
+            if (preview.available) {
+              const page = pages.find((p) => p.id === pageId);
+              if (page) {
+                newCachedPreviews[pageId] = {
+                  preview,
+                  pageUpdatedAt: page.updated_at || "",
+                  cachedAt: new Date().toISOString(),
+                };
               }
             }
-
-            setCachedPreviews(newCachedPreviews);
-
-            setPreviews((prev) => ({
-              ...prev,
-              ...result.previews,
-            }));
-            setLoadingPreviews(false);
           }
-        } catch (error) {
-          console.error("Failed to fetch batch previews:", error);
-          if (mounted) {
-            setLoadingPreviews(false);
-          }
+
+          setCachedPreviews(newCachedPreviews);
+
+          setFetchedPreviews((prev) => ({
+            ...prev,
+            ...result.previews,
+          }));
         }
-      };
+      } catch (error) {
+        console.error("Failed to fetch batch previews:", error);
+        if (mounted) {
+          setFetchFailed(true);
+        }
+      }
+    };
 
-      fetchBatchPreviews();
+    fetchBatchPreviews();
 
-      return () => {
-        mounted = false;
-      };
-    } else {
-      setLoadingPreviews(false);
-    }
-  }, [pages, viewMode]);
+    return () => {
+      mounted = false;
+    };
+  }, [pagesToFetch, cachedPreviews, pages]);
 
   if (isLoadingPages) {
     return (
@@ -747,7 +751,7 @@ export function PageGridSelector({
             key={page.id}
             page={page}
             preview={previews[page.id] || null}
-            isLoadingPreview={loadingPreviews}
+            isLoadingPreview={previewsPending}
             isActive={page.id === activePageId}
             isPending={isPending}
             onSelect={onSelectPage}
@@ -766,7 +770,7 @@ export function PageGridSelector({
           collection={collection}
           pages={allPages}
           previews={previews}
-          loadingPreviews={loadingPreviews}
+          loadingPreviews={previewsPending}
           isActive={collection.id === activePageId}
           isPending={isPending}
           onSelect={onSelectPage}

--- a/web/src/components/plugin-settings/schema-form.tsx
+++ b/web/src/components/plugin-settings/schema-form.tsx
@@ -21,6 +21,7 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { TimezonePicker } from "@/components/ui/timezone-picker";
+import { useDepsChanged } from "@/hooks/use-deps-changed";
 import { useTranslations } from "@/i18n/translations";
 import { cn } from "@/lib/utils";
 
@@ -364,12 +365,13 @@ function NumberField(props: NumberFieldProps) {
   const [isFocused, setIsFocused] = useState(false);
 
   // Keep the local text in sync with external value changes (e.g. the
-  // "use my location" button) when the user is not actively editing.
-  useEffect(() => {
-    if (!isFocused) {
-      setText(value !== undefined && value !== null ? String(value) : "");
-    }
-  }, [value, isFocused]);
+  // "use my location" button) when the user is not actively editing. Done
+  // during render so the new value is in the first commit rather than
+  // replacing the old one a render later
+  // (react-hooks/set-state-in-effect, issue #1568).
+  if (useDepsChanged([value, isFocused]) && !isFocused) {
+    setText(value !== undefined && value !== null ? String(value) : "");
+  }
 
   if (hasNumericEnum) {
     return <NumberEnumField {...props} />;

--- a/web/src/components/schedule-entry-form.tsx
+++ b/web/src/components/schedule-entry-form.tsx
@@ -198,10 +198,11 @@ export function ScheduleEntryForm({
     return null;
   }, [currentBoard, pageId, collections, pages, t]);
 
-  // Validation
-  const [validationErrors, setValidationErrors] = useState<string[]>([]);
-
-  useEffect(() => {
+  // Validation. Computed during render rather than pushed into state from an
+  // effect: the errors are a pure function of the form fields, and the effect
+  // version left the submit button enabled for one render after an edit made
+  // the form invalid (react-hooks/set-state-in-effect, issue #1568).
+  const validationErrors = useMemo(() => {
     const errors: string[] = [];
 
     if (!pageId) {
@@ -245,7 +246,7 @@ export function ScheduleEntryForm({
       }
     }
 
-    setValidationErrors(errors);
+    return errors;
   }, [
     pageId,
     startTime,

--- a/web/src/components/settings/accessibility-settings.tsx
+++ b/web/src/components/settings/accessibility-settings.tsx
@@ -14,9 +14,10 @@ import {
 } from "@fiestaboard/ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Accessibility } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { toast } from "sonner";
 
+import { useDepsChanged } from "@/hooks/use-deps-changed";
 import { useTranslations } from "@/i18n/translations";
 import { api } from "@/lib/api";
 
@@ -31,10 +32,13 @@ export function AccessibilitySettings() {
     queryFn: api.getAllSettings,
   });
 
-  useEffect(() => {
-    const display = allSettings?.display;
-    if (display) setReduceMotion(display.reduce_motion ?? false);
-  }, [allSettings?.display]);
+  // Mirror the server value into the switch during render, not in an effect:
+  // an effect would commit the default `false` first and flip the switch in a
+  // second render (react-hooks/set-state-in-effect, issue #1568).
+  const display = allSettings?.display;
+  if (useDepsChanged([display]) && display) {
+    setReduceMotion(display.reduce_motion ?? false);
+  }
 
   const updateDisplayMutation = useMutation({
     mutationFn: (settings: { reduce_motion: boolean }) => api.updateDisplaySettings(settings),

--- a/web/src/components/settings/animation-settings.tsx
+++ b/web/src/components/settings/animation-settings.tsx
@@ -22,6 +22,7 @@ import { toast } from "sonner";
 
 import { BoardDisplay } from "@/components/board-display";
 import { useBoardAnimationsEnabled } from "@/hooks/use-board-animations";
+import { useDepsChanged } from "@/hooks/use-deps-changed";
 import { useTranslations } from "@/i18n/translations";
 import { api, type BoardAnimationsMode, type DisplaySettings, type SiteAnimationsMode } from "@/lib/api";
 
@@ -101,19 +102,20 @@ export function AnimationSettings() {
   const [siteMode, setSiteMode] = useState<SiteAnimationsMode>("on");
   const [flapSpeed, setFlapSpeed] = useState<FlapSpeedPreset>("standard");
 
-  useEffect(() => {
-    const display = allSettings?.display;
-    if (display) {
-      setBoardMode(display.board_animations ?? "on");
-      setSiteMode(display.site_animations ?? "on");
-      const stored = display.board_flap_speed;
-      // A raw millisecond count (the API's escape hatch) has no radio to
-      // select; leave the group showing the default rather than inventing one.
-      if (typeof stored === "string" && stored in FLAP_SPEED_PRESETS) {
-        setFlapSpeed(stored as FlapSpeedPreset);
-      }
+  // Mirror the stored values into the radio groups during render rather than
+  // from an effect, so the right option is checked in the first commit
+  // (react-hooks/set-state-in-effect, issue #1568).
+  const display = allSettings?.display;
+  if (useDepsChanged([display]) && display) {
+    setBoardMode(display.board_animations ?? "on");
+    setSiteMode(display.site_animations ?? "on");
+    const stored = display.board_flap_speed;
+    // A raw millisecond count (the API's escape hatch) has no radio to
+    // select; leave the group showing the default rather than inventing one.
+    if (typeof stored === "string" && stored in FLAP_SPEED_PRESETS) {
+      setFlapSpeed(stored as FlapSpeedPreset);
     }
-  }, [allSettings?.display]);
+  }
 
   const updateMutation = useMutation({
     mutationFn: (settings: Partial<DisplaySettings>) => api.updateDisplaySettings(settings),

--- a/web/src/components/settings/board-settings.tsx
+++ b/web/src/components/settings/board-settings.tsx
@@ -25,6 +25,7 @@ import { AlertCircle, Check, Eye, EyeOff, Key, KeyRound, Loader2, Monitor, Searc
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
+import { useDepsChanged } from "@/hooks/use-deps-changed";
 import { useTranslations } from "@/i18n/translations";
 import type { BoardConfig, DiscoveredBoard } from "@/lib/api";
 import { api } from "@/lib/api";
@@ -50,13 +51,14 @@ export function BoardSettings() {
     queryFn: api.getBoardConfig,
   });
 
-  // Initialize form
-  useEffect(() => {
-    if (configData?.config) {
-      setFormData(configData.config);
-      setHasChanges(false);
-    }
-  }, [configData]);
+  // Initialize form. Done during render rather than in an effect so the saved
+  // connection details are in the first commit, and so the auto-save effect
+  // below never observes an intermediate empty formData
+  // (react-hooks/set-state-in-effect, issue #1568).
+  if (useDepsChanged([configData]) && configData?.config) {
+    setFormData(configData.config);
+    setHasChanges(false);
+  }
 
   // Update mutation
   const updateMutation = useMutation({

--- a/web/src/components/settings/festive-months-settings.tsx
+++ b/web/src/components/settings/festive-months-settings.tsx
@@ -2,7 +2,7 @@
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle, Flex, Stack, Switch, Text } from "@fiestaboard/ui";
 import { Sparkles } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import { useTranslations } from "@/i18n/translations";
 import { HIDE_FESTIVE_COOKIE } from "@/lib/pride";
@@ -35,11 +35,12 @@ function writeCookie(hide: boolean) {
  */
 export function FestiveMonthsSettings() {
   const t = useTranslations("festiveMonthsSettings");
-  const [hide, setHide] = useState(false);
-
-  useEffect(() => {
-    setHide(readCookie());
-  }, []);
+  // Read the cookie in the state initializer, not a mount effect: an effect
+  // would render the switch off and flip it a render later
+  // (react-hooks/set-state-in-effect, issue #1568). This mirrors what
+  // `app/root.tsx::Layout` already does with the same cookie, and `readCookie`
+  // is SSR-safe on its own.
+  const [hide, setHide] = useState(readCookie);
 
   const onToggle = (checked: boolean) => {
     setHide(checked);

--- a/web/src/components/settings/instance-name.tsx
+++ b/web/src/components/settings/instance-name.tsx
@@ -13,9 +13,10 @@ import {
 } from "@fiestaboard/ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Tag } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { toast } from "sonner";
 
+import { useDepsChanged } from "@/hooks/use-deps-changed";
 import { useTranslations } from "@/i18n/translations";
 import { api } from "@/lib/api";
 
@@ -30,10 +31,13 @@ export function InstanceNameCard() {
     queryFn: api.getAllSettings,
   });
 
-  useEffect(() => {
-    const general = allSettings?.general;
-    if (general) setInstanceName(general.instance_name ?? "");
-  }, [allSettings?.general]);
+  // Mirror the server value into the input during render rather than from an
+  // effect, so the field is populated in the first commit instead of the
+  // second (react-hooks/set-state-in-effect, issue #1568).
+  const general = allSettings?.general;
+  if (useDepsChanged([general]) && general) {
+    setInstanceName(general.instance_name ?? "");
+  }
 
   const updateGeneralMutation = useMutation({
     mutationFn: api.updateGeneralConfig,

--- a/web/src/components/settings/location-settings.tsx
+++ b/web/src/components/settings/location-settings.tsx
@@ -17,10 +17,11 @@ import {
 } from "@fiestaboard/ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Loader2, LocateFixed, MapPin } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { toast } from "sonner";
 
 import { queryKeys } from "@/hooks/use-board";
+import { useDepsChanged } from "@/hooks/use-deps-changed";
 import { useTranslations } from "@/i18n/translations";
 import type { LocationSettings } from "@/lib/api";
 import { api } from "@/lib/api";
@@ -40,13 +41,14 @@ export function LocationSettingsCard() {
   const [isDirty, setIsDirty] = useState(false);
   const [isGeolocating, setIsGeolocating] = useState(false);
 
-  useEffect(() => {
-    if (location) {
-      setLatitude(location.latitude != null ? String(location.latitude) : "");
-      setLongitude(location.longitude != null ? String(location.longitude) : "");
-      setIsDirty(false);
-    }
-  }, [location]);
+  // Mirror the stored coordinates into the inputs during render rather than
+  // from an effect, so they are populated in the first commit
+  // (react-hooks/set-state-in-effect, issue #1568).
+  if (useDepsChanged([location]) && location) {
+    setLatitude(location.latitude != null ? String(location.latitude) : "");
+    setLongitude(location.longitude != null ? String(location.longitude) : "");
+    setIsDirty(false);
+  }
 
   const mutation = useMutation({
     mutationFn: (settings: Partial<LocationSettings>) => api.updateLocationSettings(settings),

--- a/web/src/components/settings/silence-schedule.tsx
+++ b/web/src/components/settings/silence-schedule.tsx
@@ -23,11 +23,12 @@ import {
 } from "@fiestaboard/ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Moon } from "lucide-react";
-import { useDeferredValue, useEffect, useRef, useState } from "react";
+import { useDeferredValue, useEffect, useState } from "react";
 import { toast } from "sonner";
 
 import { TimePicker } from "@/components/ui/time-picker";
 import { usePages } from "@/hooks/use-board";
+import { useDepsChanged } from "@/hooks/use-deps-changed";
 import { useTranslations } from "@/i18n/translations";
 import { api } from "@/lib/api";
 import { localTimeToUTC, utcToLocalTime } from "@/lib/timezone-utils";
@@ -56,10 +57,15 @@ export function SilenceSchedule() {
   const generalConfig = allSettings?.general;
   const silenceConfig = allSettings?.silence_schedule;
   const deferredSilenceConfig = useDeferredValue(silenceConfig);
-  const initializedRef = useRef(false);
+  // Seed the form from the saved schedule exactly once, during render rather
+  // than from an effect, so the stored times are in the first commit instead
+  // of replacing 20:00/07:00 a render later (react-hooks/set-state-in-effect,
+  // issue #1568). The "once" guard is state, not a ref, because refs must not
+  // be read during render either.
+  const [initialized, setInitialized] = useState(false);
+  const configChanged = useDepsChanged([deferredSilenceConfig, generalConfig?.timezone]);
 
-  useEffect(() => {
-    if (initializedRef.current) return;
+  if (configChanged && !initialized) {
     const rawConfig = (deferredSilenceConfig as { config?: Record<string, unknown> } | undefined)?.config;
     if (rawConfig && generalConfig?.timezone) {
       const userTimezone = generalConfig.timezone ?? "America/Los_Angeles";
@@ -81,9 +87,9 @@ export function SilenceSchedule() {
       setSilenceIndicatorPosition(((config.indicator_position as string) ?? "") || "center");
 
       setHasChanges(false);
-      initializedRef.current = true;
+      setInitialized(true);
     }
-  }, [deferredSilenceConfig, generalConfig?.timezone]);
+  }
 
   const updateSilenceMutation = useMutation({
     mutationFn: (data: Parameters<typeof api.updateSilenceSchedule>[0]) => api.updateSilenceSchedule(data),

--- a/web/src/components/settings/time-and-date.tsx
+++ b/web/src/components/settings/time-and-date.tsx
@@ -20,10 +20,11 @@ import {
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { formatInTimeZone } from "date-fns-tz";
 import { Clock } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { toast } from "sonner";
 
 import { TimezonePicker } from "@/components/ui/timezone-picker";
+import { useDepsChanged } from "@/hooks/use-deps-changed";
 import { useTranslations } from "@/i18n/translations";
 import { api } from "@/lib/api";
 
@@ -43,14 +44,15 @@ export function TimeAndDateCard() {
     queryFn: api.getAllSettings,
   });
 
-  useEffect(() => {
-    const general = allSettings?.general;
-    if (general) {
-      setTimezone(general.timezone ?? "America/Los_Angeles");
-      setTimeFormat((general.time_format as TimeFormat) ?? "12h");
-      setDateFormat((general.date_format as DateFormat) ?? "MM/DD/YYYY");
-    }
-  }, [allSettings?.general]);
+  // Mirror the server values into the three controls during render rather than
+  // from an effect, so they are correct in the first commit instead of
+  // flashing defaults (react-hooks/set-state-in-effect, issue #1568).
+  const general = allSettings?.general;
+  if (useDepsChanged([general]) && general) {
+    setTimezone(general.timezone ?? "America/Los_Angeles");
+    setTimeFormat((general.time_format as TimeFormat) ?? "12h");
+    setDateFormat((general.date_format as DateFormat) ?? "MM/DD/YYYY");
+  }
 
   const updateMutation = useMutation({
     mutationFn: api.updateGeneralConfig,

--- a/web/src/components/settings/transition-settings.tsx
+++ b/web/src/components/settings/transition-settings.tsx
@@ -21,6 +21,7 @@ import { Info, Sparkles } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
+import { useDepsChanged } from "@/hooks/use-deps-changed";
 import { useTranslations } from "@/i18n/translations";
 import type { TransitionSettings as TransitionSettingsType } from "@/lib/api";
 import { api } from "@/lib/api";
@@ -78,15 +79,15 @@ export function TransitionSettings() {
   const [stepSize, setStepSize] = useState<number | "">("");
   const [hasChanges, setHasChanges] = useState(false);
 
-  // Sync local state when settings load
-  useEffect(() => {
-    if (transitions) {
-      setStrategy(transitions.strategy);
-      setStepIntervalMs(transitions.step_interval_ms ?? "");
-      setStepSize(transitions.step_size ?? "");
-      setHasChanges(false);
-    }
-  }, [transitions]);
+  // Sync local state when settings load. Done during render rather than in an
+  // effect so the stored strategy is selected in the first commit
+  // (react-hooks/set-state-in-effect, issue #1568).
+  if (useDepsChanged([transitions]) && transitions) {
+    setStrategy(transitions.strategy);
+    setStepIntervalMs(transitions.step_interval_ms ?? "");
+    setStepSize(transitions.step_size ?? "");
+    setHasChanges(false);
+  }
 
   const updateMutation = useMutation({
     mutationFn: (settings: Partial<TransitionSettingsType>) => api.updateTransitionSettings(settings),

--- a/web/src/components/sidebar-context.tsx
+++ b/web/src/components/sidebar-context.tsx
@@ -1,8 +1,16 @@
 "use client";
 
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { createContext, useCallback, useContext, useMemo, useState } from "react";
 
 const STORAGE_KEY = "fiestaboard_sidebar_collapsed";
+
+function readStoredCollapsed(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
 
 interface SidebarContextValue {
   collapsed: boolean;
@@ -27,15 +35,12 @@ const SidebarContext = createContext<SidebarContextValue>({
 });
 
 export function SidebarProvider({ children }: { children: React.ReactNode }) {
-  const [collapsed, setCollapsedState] = useState(false);
+  // Read the stored preference in the initializer, not a mount effect: an
+  // effect renders the sidebar expanded and then snaps it closed
+  // (react-hooks/set-state-in-effect, issue #1568). Safe here because the app
+  // is a static SPA (`ssr: false`) — there is no server render to mismatch.
+  const [collapsed, setCollapsedState] = useState(readStoredCollapsed);
   const [transitioning, setTransitioning] = useState(false);
-
-  useEffect(() => {
-    try {
-      const stored = localStorage.getItem(STORAGE_KEY);
-      if (stored === "true") setCollapsedState(true);
-    } catch {}
-  }, []);
 
   const setCollapsed = useCallback((value: boolean, opts?: { persist?: boolean }) => {
     setCollapsedState((prev) => {

--- a/web/src/components/tiptap-template-editor/components/FormulaEditorPanel.tsx
+++ b/web/src/components/tiptap-template-editor/components/FormulaEditorPanel.tsx
@@ -284,19 +284,15 @@ export function FormulaEditorPanel({ initialExpr = "", mode, onConfirm, onCancel
 
   // ─── Debounced validation ─────────────────────────────────────────────────
 
-  const validate = useCallback((expression: string) => {
+  /**
+   * Schedule the debounced round-trip to the validator. Contains no
+   * synchronous state update, so it is safe to call from an effect.
+   */
+  const scheduleValidation = useCallback((expression: string) => {
     if (debounceRef.current) clearTimeout(debounceRef.current);
 
     const trimmed = expression.trim();
-    if (!trimmed) {
-      lastValidExprRef.current = null;
-      setLastValidExpr(null);
-      setValidationState("idle");
-      setErrors([]);
-      return;
-    }
-
-    setValidationState("validating");
+    if (!trimmed) return;
 
     debounceRef.current = setTimeout(async () => {
       if (latestExprRef.current.trim() !== trimmed) return;
@@ -323,12 +319,37 @@ export function FormulaEditorPanel({ initialExpr = "", mode, onConfirm, onCancel
     }, 300);
   }, []);
 
+  /**
+   * Full validation pass for a new expression: flip the indicator immediately,
+   * then schedule the network check. Called from the CodeMirror update
+   * handler — the single funnel every doc change goes through — instead of
+   * from an effect on `expr` (react-hooks/set-state-in-effect, issue #1568).
+   */
+  const validate = useCallback(
+    (expression: string) => {
+      if (!expression.trim()) {
+        if (debounceRef.current) clearTimeout(debounceRef.current);
+        lastValidExprRef.current = null;
+        setLastValidExpr(null);
+        setValidationState("idle");
+        setErrors([]);
+        return;
+      }
+      setValidationState("validating");
+      scheduleValidation(expression);
+    },
+    [scheduleValidation],
+  );
+
+  // Validate whatever the panel opened with. `validationState` already starts
+  // at "validating" for a non-empty initialExpr, so only the network half is
+  // needed here — no synchronous state update in the effect body.
   useEffect(() => {
-    validate(expr);
+    scheduleValidation(initialExpr);
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, [expr, validate]);
+  }, [initialExpr, scheduleValidation]);
 
   // ─── CodeMirror initialisation ────────────────────────────────────────────
 
@@ -362,6 +383,10 @@ export function FormulaEditorPanel({ initialExpr = "", mode, onConfirm, onCancel
             if (!update.docChanged) return;
             const raw = unformatFormula(update.state.doc.toString());
             setExpr(raw);
+            // Every path that changes the document — typing, the function
+            // scaffold button, the variable picker — dispatches through here,
+            // so this is the one place validation has to be kicked from.
+            validate(raw);
           }),
           EditorView.domEventHandlers({
             // Prevent clicks inside the editor from bubbling up to the pill/editor

--- a/web/src/components/tiptap-template-editor/components/TemplateEditorToolbar.tsx
+++ b/web/src/components/tiptap-template-editor/components/TemplateEditorToolbar.tsx
@@ -29,6 +29,7 @@ import {
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from "react";
 
 import { HomeAssistantEntityPicker } from "@/components/home-assistant-entity-picker";
+import { useDepsChanged } from "@/hooks/use-deps-changed";
 import { useTranslations } from "@/i18n/translations";
 import type { DeviceType } from "@/lib/api";
 import { api } from "@/lib/api";
@@ -147,11 +148,18 @@ export function TemplateEditorToolbar({
     [],
   );
 
+  // Clearing the toolbar when the editor goes away is a render-phase reset,
+  // not a setState in the effect body (react-hooks/set-state-in-effect,
+  // issue #1568) — so the buttons can never stay enabled for a frame after the
+  // editor they act on has been torn down.
+  if (useDepsChanged([editor]) && !editor) {
+    setCanUndo(false);
+    setCanRedo(false);
+    setHasSelection(false);
+  }
+
   useEffect(() => {
     if (!editor) {
-      setCanUndo(false);
-      setCanRedo(false);
-      setHasSelection(false);
       return;
     }
 

--- a/web/src/components/tiptap-template-editor/components/ToolbarDropdown.tsx
+++ b/web/src/components/tiptap-template-editor/components/ToolbarDropdown.tsx
@@ -40,9 +40,14 @@ export function ToolbarDropdown({
   // so a wide picker anchored to a right-side toolbar button runs off narrow
   // (mobile) viewports. Measure after open/content changes and shift it back
   // into view.
+  // The reset on close used to live in this effect. It is redundant: the panel
+  // is only rendered while open, and `clamp()` below runs synchronously in the
+  // same layout effect that opening triggers — before paint — so a shift left
+  // over from the previous open is always overwritten before it can be seen.
+  // Dropping it removes a setState from the effect body
+  // (react-hooks/set-state-in-effect, issue #1568).
   useLayoutEffect(() => {
     if (!isOpen) {
-      setPanelShift(0);
       return;
     }
     const clamp = () => {

--- a/web/src/components/ui/time-picker.tsx
+++ b/web/src/components/ui/time-picker.tsx
@@ -6,6 +6,7 @@ import type { CSSProperties } from "react";
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
+import { useDepsChanged } from "@/hooks/use-deps-changed";
 import { useTranslations } from "@/i18n/translations";
 import { cn } from "@/lib/utils";
 
@@ -37,8 +38,10 @@ export function TimePicker({
   const containerRef = useRef<HTMLElement>(null);
   const dropdownRef = useRef<HTMLElement>(null);
 
-  // Parse value on mount and when value changes
-  useEffect(() => {
+  // Parse `value` on mount and whenever it changes. Done during render rather
+  // than in an effect so the picker never commits 00:00 before the real time
+  // (react-hooks/set-state-in-effect, issue #1568).
+  if (useDepsChanged([value])) {
     if (value) {
       const [h, m] = value.split(":");
       if (h && m) {
@@ -49,7 +52,7 @@ export function TimePicker({
       setHours("00");
       setMinutes("00");
     }
-  }, [value]);
+  }
 
   // Close on outside click
   useEffect(() => {

--- a/web/src/components/ui/timezone-picker.tsx
+++ b/web/src/components/ui/timezone-picker.tsx
@@ -6,6 +6,7 @@ import type { CSSProperties } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
+import { useDepsChanged } from "@/hooks/use-deps-changed";
 import { useTranslations } from "@/i18n/translations";
 import { ALL_TIMEZONES } from "@/lib/timezone-utils";
 import { cn } from "@/lib/utils";
@@ -51,10 +52,17 @@ export function TimezonePicker({ value, onChange, className, disabled, onValidat
     );
   }, [searchQuery]);
 
-  // Reset highlighted index when filtered results change
-  useEffect(() => {
+  // Reset highlighted index when filtered results change. Done during render
+  // so the highlight can never point at a row from the previous result set
+  // for a frame (react-hooks/set-state-in-effect, issue #1568).
+  //
+  // No dedicated test: every user-reachable path that changes the filter also
+  // resets the highlight inline already (`handleInputChange`, the outside-click
+  // handler, `handleSelect`, Escape), so this reset is unobservable and the
+  // conversion is behaviour-identical by construction.
+  if (useDepsChanged([filteredTimezones])) {
     setHighlightedIndex(-1);
-  }, [filteredTimezones]);
+  }
 
   // Check if current value is valid
   const isValid = useMemo(() => {
@@ -67,17 +75,14 @@ export function TimezonePicker({ value, onChange, className, disabled, onValidat
     onValidationChange?.(isValid);
   }, [isValid, onValidationChange]);
 
-  // Update search query when value changes externally
-  useEffect(() => {
-    if (value && !isOpen) {
-      const tz = ALL_TIMEZONES.find((t) => t.value === value);
-      if (tz) {
-        setSearchQuery(tz.label);
-      } else {
-        setSearchQuery(value);
-      }
-    }
-  }, [value, isOpen]);
+  // Update search query when value changes externally. Done during render so
+  // the closed input shows the selected zone's label in the first commit
+  // rather than briefly showing the previous one
+  // (react-hooks/set-state-in-effect, issue #1568).
+  if (useDepsChanged([value, isOpen]) && value && !isOpen) {
+    const tz = ALL_TIMEZONES.find((t) => t.value === value);
+    setSearchQuery(tz ? tz.label : value);
+  }
 
   // Close dropdown when clicking outside
   useEffect(() => {

--- a/web/src/components/update-context.tsx
+++ b/web/src/components/update-context.tsx
@@ -105,21 +105,17 @@ function markAwaitingBoot(fromVersion?: string) {
 // ---------------------------------------------------------------------------
 
 export function UpdateProvider({ children }: { children: React.ReactNode }) {
-  const [isUpdating, setIsUpdating] = useState(false);
-  const [currentVersion, setCurrentVersion] = useState<string | undefined>(undefined);
-  const [awaitingPostUpdateBoot, setAwaitingPostUpdateBoot] = useState(false);
-
-  // On mount: pick up whatever the previous page life left behind.
-  useEffect(() => {
-    const persisted = readPersisted();
-    if (!persisted) return;
-    setCurrentVersion(persisted.fromVersion);
-    if (persisted.awaitingBoot) {
-      setAwaitingPostUpdateBoot(true);
-    } else {
-      setIsUpdating(true);
-    }
-  }, []);
+  // Pick up whatever the previous page life left behind, in the state
+  // initializers rather than a mount effect. The effect version rendered the
+  // whole app once in the "no update in progress" state before the update
+  // overlay appeared (react-hooks/set-state-in-effect, issue #1568). Safe
+  // because the app is a static SPA (`ssr: false`) — no server render to
+  // mismatch. `useState(readPersisted)` reads localStorage exactly once, on
+  // the first render, which is what the mount effect did.
+  const [persisted] = useState(readPersisted);
+  const [isUpdating, setIsUpdating] = useState(() => persisted !== null && !persisted.awaitingBoot);
+  const [currentVersion, setCurrentVersion] = useState<string | undefined>(() => persisted?.fromVersion);
+  const [awaitingPostUpdateBoot, setAwaitingPostUpdateBoot] = useState(() => persisted?.awaitingBoot === true);
 
   const startUpdate = useCallback((version?: string) => {
     writePersisted({ fromVersion: version, startedAt: Date.now() });

--- a/web/src/components/variable-rule-row.tsx
+++ b/web/src/components/variable-rule-row.tsx
@@ -16,6 +16,7 @@ import {
 import { AlertCircle, Check, GripVertical, HelpCircle, Pencil, Sparkles, Trash2, X } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 
+import { useDepsChanged } from "@/hooks/use-deps-changed";
 import type { VariableRule } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
@@ -76,10 +77,12 @@ export function VariableRuleRow({
   const [knownVariables, setKnownVariables] = useState<Set<string>>(new Set());
   const [helpOpen, setHelpOpen] = useState(false);
 
-  // When entering edit mode, snapshot the rule into the draft.
-  useEffect(() => {
-    if (isEditing) setDraft(rule);
-  }, [isEditing, rule]);
+  // When entering edit mode, snapshot the rule into the draft. Done during
+  // render so the editor opens on the rule's values instead of the previous
+  // row's for a frame (react-hooks/set-state-in-effect, issue #1568).
+  if (useDepsChanged([isEditing, rule]) && isEditing) {
+    setDraft(rule);
+  }
 
   // Report dirty state to parent so it can prompt before switching rules.
   useEffect(() => {

--- a/web/src/components/wizard/setup-wizard.tsx
+++ b/web/src/components/wizard/setup-wizard.tsx
@@ -27,7 +27,15 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
   const router = useRouter();
   const t = useTranslations("wizard");
   const tc = useTranslations("common");
-  const [currentStep, setCurrentStep] = useState(1);
+  // Restore saved progress in the state initializers rather than a mount
+  // effect. The effect version rendered step 1 with empty fields and then
+  // jumped to the saved step, which also made the "save progress" effect below
+  // fire once with the empty defaults (react-hooks/set-state-in-effect, issue
+  // #1568). Safe because the app is a static SPA (`ssr: false`).
+  // `useState(getWizardProgress)` reads localStorage exactly once.
+  const [saved] = useState(getWizardProgress);
+
+  const [currentStep, setCurrentStep] = useState(() => saved?.currentStep ?? 1);
   const [isLoading, setIsLoading] = useState(false);
   const [canProceed, setCanProceed] = useState(false);
 
@@ -40,46 +48,22 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
     connectionVerified: boolean;
     device_type: "flagship" | "note";
     board_color: "black" | "white";
-  }>({
-    api_mode: "cloud",
-    local_api_key: "",
-    cloud_key: "",
-    host: "",
+  }>(() => ({
+    api_mode: saved?.boardConfig?.api_mode ?? "cloud",
+    local_api_key: saved?.boardConfig?.local_api_key || "",
+    cloud_key: saved?.boardConfig?.cloud_key || "",
+    host: saved?.boardConfig?.host || "",
     connectionVerified: false,
-    device_type: "flagship",
-    board_color: "black",
-  });
+    device_type: saved?.boardConfig?.device_type || "flagship",
+    board_color: saved?.boardConfig?.board_color || "black",
+  }));
 
   // Plugin config state
-  const [pluginConfig, setPluginConfig] = useState<WizardPluginConfig>({
+  const [pluginConfig, setPluginConfig] = useState<WizardPluginConfig>(() => ({
     date_time: { enabled: true, timezone: "America/Los_Angeles" },
     registry_selected: [],
-  });
-
-  // Restore progress on mount
-  useEffect(() => {
-    const saved = getWizardProgress();
-    if (saved) {
-      setCurrentStep(saved.currentStep);
-      if (saved.boardConfig) {
-        setBoardConfig((prev) => ({
-          ...prev,
-          api_mode: saved.boardConfig!.api_mode,
-          local_api_key: saved.boardConfig!.local_api_key || "",
-          cloud_key: saved.boardConfig!.cloud_key || "",
-          host: saved.boardConfig!.host || "",
-          device_type: saved.boardConfig!.device_type || "flagship",
-          board_color: saved.boardConfig!.board_color || "black",
-        }));
-      }
-      if (saved.plugins) {
-        setPluginConfig((prev) => ({
-          ...prev,
-          ...saved.plugins,
-        }));
-      }
-    }
-  }, []);
+    ...saved?.plugins,
+  }));
 
   // Save progress on change
   useEffect(() => {

--- a/web/src/hooks/use-deps-changed.ts
+++ b/web/src/hooks/use-deps-changed.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useState } from "react";
+
+/**
+ * Render-phase equivalent of `useEffect(fn, deps)` for the specific job of
+ * mirroring an external value (a query result, a prop) into local state.
+ *
+ * Returns `true` on the first render, and on any later render where one of
+ * `deps` changed identity — i.e. exactly the renders after which
+ * `useEffect(fn, deps)` would have fired. Callers do their `setState` calls
+ * inside that branch, during render, instead of in an effect:
+ *
+ * ```tsx
+ * const settingsChanged = useDepsChanged([data?.general]);
+ * if (settingsChanged && data?.general) {
+ *   setTimezone(data.general.timezone ?? DEFAULT_TZ);
+ * }
+ * ```
+ *
+ * Why this is better than the effect it replaces: React restarts the render
+ * immediately when a component sets its own state during render, *before*
+ * committing — so the mirrored value is on screen in the first commit. The
+ * effect version commits the stale value, paints, then re-renders, which is
+ * the cascading render that `react-hooks/set-state-in-effect` warns about
+ * (and, per the React docs, a state update during render of the *same*
+ * component is the supported way to adjust state when a prop changes:
+ * https://react.dev/reference/react/useState#storing-information-from-previous-renders).
+ *
+ * Constraints, same as any render-phase update:
+ * - Only call `setState` for THIS component inside the branch. Calling a
+ *   parent's setter (or a router/toast side effect) during render is illegal;
+ *   those must stay in an effect.
+ * - The branch must be idempotent. It runs once per change because the deps
+ *   snapshot is taken as soon as it fires.
+ */
+export function useDepsChanged(deps: readonly unknown[]): boolean {
+  const [prev, setPrev] = useState<readonly unknown[] | null>(null);
+
+  if (prev === null || prev.length !== deps.length || deps.some((dep, i) => !Object.is(dep, prev[i]))) {
+    setPrev(deps);
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
Closes #1568

## Warning count

| | `react-hooks/set-state-in-effect` |
|---|---|
| before (`origin/main`) | **42** |
| after | **0** |

No `eslint-disable` was used anywhere in this PR.

## Approach

Most instances were the same shape — an effect that mirrors an external value (a react-query result, a prop) into local state. Rather than repeat the same six-line dance 20 times, this adds one primitive:

```ts
// web/src/hooks/use-deps-changed.ts
export function useDepsChanged(deps: readonly unknown[]): boolean;
```

It returns `true` on exactly the renders `useEffect(fn, deps)` would have fired on — the first, plus every dep-identity change — so callers put their `setState` calls in that branch, during render. React restarts the render immediately when a component sets its own state during render, *before* committing, so the mirrored value is in the first commit instead of a second one. This is React's documented ["storing information from previous renders"](https://react.dev/reference/react/useState#storing-information-from-previous-renders) pattern, not a lint dodge.

Constraints are documented on the hook: only this component's setters may be called in that branch (a parent setter, a router navigation, or a toast during render is illegal), and the branch must be idempotent.

## Per-file summary

Fix shapes: **D** = derive during render · **M** = move the read/update out of the effect · **E** = move into the event handler · **S** = `useSyncExternalStore` · **X** = delete as redundant

| File | # | Shape | What |
|---|---|---|---|
| `src/hooks/use-deps-changed.ts` | — | — | new primitive + unit test |
| `settings/accessibility-settings.tsx` | 1 | D | mirror `reduce_motion` |
| `settings/instance-name.tsx` | 1 | D | mirror `instance_name` |
| `settings/time-and-date.tsx` | 1 | D | mirror timezone / time / date format |
| `settings/animation-settings.tsx` | 1 | D | mirror animation + flap-speed presets |
| `settings/board-settings.tsx` | 1 | D | seed the connection form |
| `settings/location-settings.tsx` | 1 | D | mirror lat/lon |
| `settings/transition-settings.tsx` | 1 | D | mirror strategy / step settings |
| `settings/silence-schedule.tsx` | 1 | D | seed-once; `initializedRef` → state (refs mustn't be read in render either) |
| `settings/festive-months-settings.tsx` | 1 | M | cookie read → `useState` initializer |
| `ui/time-picker.tsx` | 1 | D | parse the `HH:MM` value prop |
| `ui/timezone-picker.tsx` | 2 | D | mirror `value` into the search box; reset the keyboard highlight |
| `day-selector.tsx` | 1 | D | mirror `customDays` (+ pins the `= []` default to a module constant — a fresh literal per render is a latent infinite loop in the effect version too) |
| `force-set-dialog.tsx` | 1 | D | reset the duration picker on open |
| `variable-rule-row.tsx` | 1 | D | snapshot the rule into the draft on edit |
| `plugin-settings/schema-form.tsx` | 1 | D | mirror external number writes while unfocused |
| `app/routes/offline.tsx` | 1 | S | `navigator.onLine` is an external store |
| `app/routes/pages.edit._index.tsx` | 1 | M | read `?id` in the initializer; redirect stays in an effect |
| `sidebar-context.tsx` | 1 | M | localStorage read → initializer |
| `install-prompt.tsx` | 1 | M | `matchMedia` read → initializer |
| `update-context.tsx` | 1 | M | persisted-update read → initializers |
| `wizard/setup-wizard.tsx` | 1 | M | saved wizard progress → initializers |
| `page-grid-selector.tsx` | 2 | M + D | IntersectionObserver fallback → initializer; the batch-preview effect's synchronous half (localStorage cache lookup + "what must we fetch") lifted into a `useMemo`, leaving only the async network callback in the effect; `loadingPreviews` → derived `previewsPending` |
| `ai-chat-panel.tsx` | 1 | D | task list reappearing when work restarts |
| `active-page-display.tsx` | 1 | D | hide the sheet's content on close |
| `boot-gate.tsx` | 1 | D | mark connected (retiring the post-update marker touches the *UpdateProvider's* state, so that half stays in an effect) |
| `current-board-context.tsx` | 1 | D | reconcile the selected board against the live list |
| `TemplateEditorToolbar.tsx` | 1 | D | clear undo/redo/selection when the editor unmounts |
| `schedule-entry-form.tsx` | 1 | D (`useMemo`) | `validationErrors` is a pure function of the form fields |
| `FormulaEditorPanel.tsx` | 1 | E | validation now runs from the CodeMirror update listener — the single funnel every doc change dispatches through — instead of an effect on `expr` |
| `ToolbarDropdown.tsx` | 1 | X | `setPanelShift(0)` on close; see below |
| `app/routes/transitions.tsx` | 6 | D | plugin default, from/to page defaults, config-editor seed, canvas geometry, stop-at-last-frame, reset+autoplay on new preview |
| `app/routes/pages._index.tsx` | 2 | D | clear the import dialog on close; default the device tab |
| `app/routes/integrations._index.tsx` | 1 | D | seed the plugin config dialog |
| `app/routes/schedule.tsx` | 1 | M | AI-drawer `prefill_*` params → `readUrlPrefill` in an initializer; URL scrub stays in an effect |

One deletion instead of a conversion: **`ToolbarDropdown`**'s `setPanelShift(0)` on close. The panel only renders while open, and `clamp()` runs synchronously in the same layout effect that opening triggers — before paint — so a shift left over from the previous open is always overwritten before it can be seen.

## Non-vacuity evidence

Per CLAUDE.md, every new test was proven to fail when the production change it covers is reverted. The technique for the render-phase syncs is `if (useDepsChanged([…]) && false && …)` — the hook is still *called*, so hook order is unchanged and the failure is the behaviour, not a crash.

**`useDepsChanged`** — initialising the internal snapshot to `deps` instead of `null` (so it never fires on mount) fails 4 of 6:

```
FAIL src/__tests__/use-deps-changed.test.tsx > useDepsChanged > fires on the first render, so mount-time syncing still happens
AssertionError: expected 'unsynced' to be 'from-server' // Object.is equality

FAIL … > mirrors the value before the first commit, not after it
AssertionError: expected [ 'unsynced' ] to deeply equal [ 'a' ]
- Expected      + Received
-   "a",        +   "unsynced",

Tests  4 failed | 2 passed (6)
```

**Settings cards** — replacing each mirrored value with the hard-coded default fails 5 of 6:

```
FAIL … settings-cards-server-sync.test.tsx > AccessibilitySettings > shows the stored reduce-motion value once settings load
Error: expect(element).toBeChecked()
Received element is not checked: <button aria-checked="false" role="switch" id="reduce-motion" />

FAIL … > InstanceNameCard > shows the stored instance name once settings load
FAIL … > InstanceNameCard > keeps what the user typed when the same settings payload re-renders the card
FAIL … > TimeAndDateCard > shows the stored time format once settings load
FAIL … > TimeAndDateCard > shows the stored date format once settings load
Tests  5 failed | 1 passed (6)
```

**`BoardSettings`** — seeding with `setHasChanges(true)`:

```
FAIL … board-settings-form-seed.test.tsx > does not mark the freshly seeded form as changed
AssertionError: expected [ { api_mode: 'local', …(2) } ] to deeply equal []
```

(i.e. merely opening the card auto-PUTs the config straight back.)

**`FestiveMonthsSettings`** — `useState(false)` instead of `useState(readCookie)`:

```
FAIL … festive-months-settings.test.tsx > shows the switch on when the hide_festive_months cookie is set
Received element is not checked
FAIL … > reads the cookie before the first paint, with no off-then-on flip
Tests  2 failed | 1 passed (3)
```

**Prop-driven syncs** — neutralising all five fails 4 of 7:

```
FAIL … prop-sync-during-render.test.tsx > DaySelector > checks the days named by a changed customDays prop
Received element is not checked: <input aria-label="Tuesday" class="sr-only" type="checkbox" />
FAIL … > ForceSetDialog > resets the duration to the 5 min default each time it reopens
FAIL … > VariableRuleRow > opens the editor on the rule's current expression, not the one it mounted with
FAIL … > SchemaForm number field > shows a value written from outside the field while it is not focused
Tests  4 failed | 3 passed (7)
```

The other two assert the *no-op* half of the contract (a re-render with unchanged deps must not clobber a local edit), so they pass by construction under this break.

**Browser-state initializers** — restoring the old defaults (`useState(false)`, `useState<string|null>(null)`, a `() => false` snapshot) fails 3 of 7:

```
FAIL … mount-state-initializers.test.tsx > SidebarProvider > renders collapsed on the first render when that is the stored preference
AssertionError: expected 'false' to be 'true' // Object.is equality
FAIL … > OfflinePage > shows the reconnecting state on the first render when the browser is online
AssertionError: expected 'You\'re Offline' to be 'Reconnecting...' // Object.is equality
FAIL … > EditPage > mounts the page builder on the first render when ?id is in the URL
Tests  3 failed | 4 passed (7)
```

**Transition Lab** — neutralising all six fails all five:

```
FAIL … transitions-lab-defaults.test.tsx > seeds the config editor from the selected plugin's saved config
AssertionError: expected '{}' to be '{\n  "direction": "left"\n}' // Object.is equality
FAIL … > selects the first plugin once the plugin list loads
FAIL … > defaults the from and to pickers to the first two pages
FAIL … > matches the preview canvas to the target page's device type
FAIL … > starts on frame 1 and stops on the last frame when a preview lands
Tests  5 failed | 0 passed (5)
```

**BootGate / TemplateEditorToolbar**:

```
FAIL … first-commit-state.test.tsx > BootGate > reveals the app once the health check answers
FAIL … first-commit-state.test.tsx > TemplateEditorToolbar > disables undo once the editor it acts on is gone
Received element is not disabled
```

**Existing suites as the regression net.** Neutralising the component batch (five render-phase syncs + making the validation memo return `[]`) fails **25 tests across 7 files** that were already in the repo:

```
FAIL src/__tests__/current-board-context.test.tsx  (13 tests, incl. "defaults to the primary board when nothing is stored",
                                                    "restores a valid stored board id from localStorage",
                                                    "drops a stale stored id and falls back to the primary board")
FAIL src/__tests__/current-board-context-ref-sync.test.tsx  (1)
FAIL src/__tests__/active-page-display-multi-board.test.tsx (5)
FAIL src/__tests__/navigation-sidebar.test.tsx > restores the persisted board selection across reloads
FAIL src/__tests__/schedule-entry-form-locale-switch.test.tsx > recomputes validation error messages when the language changes
FAIL src/__tests__/schedule-entry-form-recurrence.test.tsx  (3)
FAIL src/__tests__/schedule-entry-form-validation.test.tsx > should still show validation error for zero-duration schedule
Tests  25 failed | 1505 passed | 13 skipped (1543)
```

And neutralising the `pages._index` pair:

```
FAIL src/__tests__/import-page-dialog.test.tsx > clears textarea when dialog is closed via onOpenChange
FAIL src/__tests__/pages-index-device-tabs.test.tsx > defaults to the user's configured device tab even when an orphan tab exists
FAIL src/__tests__/pages-index-device-tabs.test.tsx > shows the note-array tab and its page on a note-array-only setup
```

Existing `time-picker.test.tsx` ("calls onChange when minute is selected") and `timezone-picker.test.tsx` ("renders with default value") likewise fail when those two syncs are neutralised, and `update-context.test.tsx`'s "does not re-show the overlay after the post-update reload" / "ignores a stale awaiting-boot marker" both depend on the persisted restore that moved into the initializers.

## What is NOT covered by a dedicated test, and why

Four instances are behaviour-preserving by construction and have no test of their own. None of them is silenced — all four are converted or removed, and the count is still 0.

1. **`ui/timezone-picker` highlight reset.** Every user-reachable path that changes the filtered list already resets `highlightedIndex` inline (`handleInputChange` line 158, the outside-click handler, `handleSelect`, Escape). I wrote two candidate tests for it and both passed against a neutralised implementation, i.e. they were vacuous — so I deleted them rather than ship a green test that proves nothing. The reason is recorded as a comment at the call site.
2. **`ToolbarDropdown` panel-shift reset** (the deletion). The assertion would be about `getBoundingClientRect`, which jsdom reports as all-zero, so the clamping logic can't be exercised there at all. Argument for safety is in the code comment; a Playwright check would be the honest way to cover it.
3. **`FormulaEditorPanel`** validation move. The panel is a CodeMirror host with no existing test in the repo, and standing one up is a project of its own. The change is structural: `validate` was split so the effect only schedules the debounced network call (`validationState` already starts at `"validating"` for a non-empty `initialExpr`), and the synchronous half now runs from the update listener that *all three* mutation paths dispatch through.
4. **`InstallPrompt`.** Its test ("renders nothing when the app is already running standalone") passes with or without the change, because the banner is hidden for other reasons too. The change is a straight early-return-to-guard rewrite.

Also not individually covered, though the components themselves are exercised by the suite: `integrations._index`'s config-dialog seed and `schedule.tsx`'s URL prefill.

## Verification

Run in `node:24-alpine` (the host `web/node_modules` is unusable and node 20 breaks vitest's jsdom→undici path).

```
$ npm ci --legacy-peer-deps --no-audit
added 1393 packages
NPM_EXIT=0

$ npm run lint ; grep -c "warning  Error: Calling setState synchronously within an effect"
LINT_EXIT=0
0                       # was 42 on origin/main

$ npx vitest run --reporter=dot
 Test Files  129 passed (129)
      Tests  1538 passed | 13 skipped (1551)
VITEST_EXIT=0

$ npm run format:check
FMT_EXIT=0
```

`npx tsc --noEmit` reports the same pre-existing errors as `origin/main` — none new. (Confirmed by diffing the two runs; the only `page-grid-selector.tsx` entries are the four that were already there, shifted by a line.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
