### PR TITLE
feat(registry): add Price List plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ FiestaBoard has a catalog of **50+ plugins** covering weather, finance, transit,
 | [On This Day](https://github.com/Fiestaboard/fiestaboard-plugin--on-this-day) | Historical event from today's date | No |
 | [Pet Facts](https://github.com/Fiestaboard/fiestaboard-plugin--pet-facts) | Random cat or dog fact | No |
 | [Pi-hole Stats](https://github.com/Fiestaboard/fiestaboard-plugin--pihole) | DNS query stats from local Pi-hole | No |
+| [Price List](https://github.com/Fiestaboard/fiestaboard-plugin--price-list) | Styled price list or menu sign with page rotation | No |
 | [Quote of the Day](https://github.com/Fiestaboard/fiestaboard-plugin--quote-of-day) | Daily inspirational quote | No |
 | [Random](./plugins/random/README.md) | Randomly selected values from a custom list, coin flip, or board color | No |
 | [Reddit Hot](https://github.com/Fiestaboard/fiestaboard-plugin--reddit-hot) | Top post from any subreddit | No |

--- a/plugin-registry.json
+++ b/plugin-registry.json
@@ -115,7 +115,8 @@
       "icon": "database",
       "category": "data"
     },
-    {      "id": "generative_ai_art",
+    {
+      "id": "generative_ai_art",
       "name": "Generative AI Art",
       "description": "Generate full-screen abstract art for your split-flap display using an LLM. Each piece is a unique, thought-out composition using the board's 8-color palette.",
       "repository": "https://github.com/Fiestaboard/fiestaboard-plugin--generative-ai-art",
@@ -124,7 +125,8 @@
       "icon": "palette",
       "category": "art"
     },
-    {      "id": "guest_wifi",
+    {
+      "id": "guest_wifi",
       "name": "Guest WiFi",
       "description": "Display guest WiFi credentials on your board",
       "repository": "https://github.com/Fiestaboard/fiestaboard-plugin--guest-wifi",
@@ -271,6 +273,16 @@
       "author": "FiestaBoard Team",
       "fiestaboard_version": ">=4.2.0",
       "icon": "shield",
+      "category": "utility"
+    },
+    {
+      "id": "price_list",
+      "name": "Price List",
+      "description": "Display a styled price list or menu sign with your own items, prices, and colors, plus automatic page rotation for longer menus.",
+      "repository": "https://github.com/Fiestaboard/fiestaboard-plugin--price-list",
+      "author": "FiestaBoard Team",
+      "fiestaboard_version": ">=4.2.0",
+      "icon": "tags",
       "category": "utility"
     },
     {


### PR DESCRIPTION
## Summary

Adds the new **Price List** plugin to the registry and the README plugin table (alphabetical).

- Repo: https://github.com/Fiestaboard/fiestaboard-plugin--price-list (CI green, v1.0.0 released)
- Config-driven price/menu sign for restaurants, coffee shops, breweries: items with per-item color bullets, three line styles, currency symbol placement, accented title, automatic page rotation for longer menus
- 35 tests, 96% coverage; manifest includes `teaser`/`previews` (Coffee Shop, Brewery Tap List, Happy Hour, Note) and flagship + note demo pages
- Real board-render hero image captured from the app
- `python scripts/validate_plugins.py --registry --verbose` passes locally (0 errors)

## Test plan
- [x] Registry validation passes in the dev container
- [x] Plugin installs from the repo via `POST /api/plugins/install` and serves data end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)