### PR TITLE
chore(deps): bump js-yaml lockfile entries to patched versions (Dependabot)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fiestaboard",
-  "version": "8.1.0",
+  "version": "8.27.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fiestaboard",
-      "version": "8.1.0",
+      "version": "8.27.2",
       "license": "MIT",
       "devDependencies": {
         "cspell": "^10.0.1",
@@ -1268,9 +1268,9 @@
       }
     },
     "node_modules/globby": {
-      "version": "16.2.1",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.1.tgz",
-      "integrity": "sha512-JmsqJalahxxgW8V2ecSQ2G7UjPlI9cpKdrkG9KoNiXhd/YslXOTEB0cViENWUznuovIuNT+FkMbraDGjr4FCUg==",
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.2.tgz",
+      "integrity": "sha512-NLvV9ubZ6NDsJaOpKPy3cQeJpKi9DcWiyCiFUpJPA0YihRqiE6RWaLUmgNNPr8MgPpLZjnBjSmou7uZBRJv9wA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1440,9 +1440,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
-      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
+      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
       "dev": true,
       "funding": [
         {
@@ -1579,14 +1579,14 @@
       }
     },
     "node_modules/markdownlint-cli2": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.23.1.tgz",
-      "integrity": "sha512-20JPI5W+HpV1OA+pUM712wgvL4GzYNUvbmhLU8KlEYJ1kCDx4soZ4/Xqd+WkLrPTOKMAn8SfO3zYFrK8GLlwQg==",
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.23.2.tgz",
+      "integrity": "sha512-eUhcnkSpzURo/o4htSqc7LPDszgOOTknhU4eY/sPHvMCLxnTCYscv1gw1/js/idmaZPisv9ECVEIORcllqjTUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "globby": "16.2.1",
-        "js-yaml": "5.2.1",
+        "globby": "16.2.2",
+        "js-yaml": "5.2.2",
         "jsonc-parser": "3.3.1",
         "jsonpointer": "5.0.1",
         "markdown-it": "14.3.0",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "8.25.9",
+  "version": "8.27.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "8.25.9",
+      "version": "8.27.2",
       "dependencies": {
         "@codemirror/commands": "^6.10.4",
         "@codemirror/language": "^6.12.4",
@@ -3371,9 +3371,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14808,9 +14808,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Resolves 5 of the 7 open Dependabot alerts by bumping `js-yaml` lockfile entries to patched versions. The two `image-size` alerts (docs-site) cannot be fixed because **no patched release exists** — details below.

## Alert resolution table

| Alert | Package | Lockfile | Old | New | Advisory |
|---|---|---|---|---|---|
| #169 | js-yaml | `package-lock.json` | 5.2.1 | 5.2.2 | GHSA-pm4m-ph32-ghv5 (exponential parse time in flow collections) |
| #192 | js-yaml | `web/package-lock.json` | 4.3.0 | 4.3.1 | GHSA-5p4m-2wfm-xmqj (quadratic CPU in `!!omap` resolution) |
| #193 | js-yaml (nested under `@istanbuljs/load-nyc-config`) | `web/package-lock.json` | 3.14.2 | 3.15.1 | GHSA-5p4m-2wfm-xmqj |
| #155 | js-yaml (same nested copy) | `web/package-lock.json` | 3.14.2 | 3.15.1 | GHSA-52cp-r559-cp3m (quadratic CPU via merge-key chains) |
| #146 | js-yaml (same nested copy) | `web/package-lock.json` | 3.14.2 | 3.15.1 | GHSA-h67p-54hq-rp68 (quadratic DoS via repeated merge aliases) |
| #195 | image-size | `docs-site/package-lock.json` | 2.0.2 | **not fixed — no patched release exists** | GHSA-5p2g-fcmc-qvqq |
| #196 | image-size | `docs-site/package-lock.json` | 2.0.2 | **not fixed — no patched release exists** | GHSA-w3rx-r6r6-pgpr |

## How the bumps were made

- **Root**: `npm update js-yaml` alone was a no-op because `markdownlint-cli2` 0.23.1 pins `js-yaml` **exactly** at `5.2.1`. Bumping the parent to 0.23.2 (inside the existing `^0.23.1` range, no `package.json` change) pulls `js-yaml 5.2.2`; its other exact pin drags `globby 16.2.1 → 16.2.2` along. This was preferred over an `overrides` block as the narrower long-term mechanism.
- **Web**: `npm update js-yaml --package-lock-only --legacy-peer-deps` reached both copies in one pass — the top-level 4.x entry and the nested 3.x copy under `@istanbuljs/load-nyc-config`. No overrides needed.
- The `"version"` field syncs in both lockfiles (8.1.0/8.25.9 → 8.27.2) are npm's automatic reconciliation with the current `package.json` versions — unavoidable side effect of any `--package-lock-only` operation.

## Runtime risk: none (dev-only graphs)

Every touched `js-yaml` entry carries `"dev": true` in its lockfile:

- Root: `markdownlint-cli2` → docs lint tooling (`npm run docs:lint:markdown`)
- Web: top-level 4.x copy and the `@istanbuljs/load-nyc-config` 3.x copy are both vitest/istanbul coverage tooling

Neither appears in a production dependency graph; nothing shipped in the app image changes.

## image-size investigation (alerts #195/#196 left open on purpose)

- Both advisories report vulnerable range `<= 2.0.2` with **no `first_patched_version`**.
- npm registry: latest published versions are `2.0.2` and `1.2.1`, both released 2025-04-02 — nothing newer exists on any dist-tag.
- GitHub repo (`image-size/image-size`): latest release tag is `v2.0.2`; the only commits since that release are two README updates (May/June 2026). The last substantive commit was the *partial* DoS fix ("fix potential Denial of Service via specially crafted payloads", #436) that shipped **in** 2.0.2 — the ICNS/JXL/HEIF infinite loops remain unfixed upstream.
- It reaches docs-site transitively via `@docusaurus/mdx-loader → ^2.0.2` (build-time image dimension probing of repo-local images, not user-supplied input), so exposure is limited to the docs build.
- Per scope of this PR, the alerts were **not dismissed** and `docs-site/package-lock.json` is untouched; dismissal (e.g. as "no fix available / build-time only") is a separate decision.

## Validation

- `git diff` audited per lockfile — only the entries listed above (plus integrity hashes and the version-field syncs) changed.
- `npm ci --dry-run` exits 0 for the root lockfile and `npm ci --dry-run --legacy-peer-deps` exits 0 for `web/`, both in a clean `node:24` container (metadata resolution only; no `node_modules` created in the repo).
- Verified final lockfile state: root `js-yaml 5.2.2`; web `js-yaml 4.3.1` + nested `3.15.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
