### PR TITLE
fix(security): validate plugin ids before path resolution (CodeQL py/path-injection)

### DIFF
--- a/src/plugins/loader.py
+++ b/src/plugins/loader.py
@@ -26,6 +26,20 @@ logger = logging.getLogger(__name__)
 # Default plugins directory (relative to project root)
 DEFAULT_PLUGINS_DIR = "plugins"
 
+# Plugin directory names are plugin ids: a single path segment of lowercase
+# letters, digits, and underscores (the manifest contract).  Anything else --
+# ``..``, path separators, absolute paths, empty strings -- can never name a
+# plugin and must not reach a filesystem path expression.  Plugin names arrive
+# from user-controlled API input (settings / install / reload endpoints), so
+# this is a security barrier, not just hygiene (CodeQL py/path-injection).
+_SAFE_PLUGIN_NAME_RE = re.compile(r"^[a-z0-9_]+$")
+
+
+def is_safe_plugin_dir_name(plugin_name: str) -> bool:
+    """Return True when *plugin_name* is safe to use as a single path segment."""
+    return isinstance(plugin_name, str) and _SAFE_PLUGIN_NAME_RE.fullmatch(plugin_name) is not None
+
+
 # ---------------------------------------------------------------------------
 # FiestaBoard version compatibility helpers
 # ---------------------------------------------------------------------------
@@ -218,14 +232,27 @@ class PluginLoader:
         """Find the on-disk directory for *plugin_name*.
 
         Checks built-in first, then external directories.
-        """
-        # Built-in takes precedence
-        candidate = self.plugins_dir / plugin_name
-        if candidate.is_dir():
-            return candidate
 
-        for ext_dir in self._external_dirs:
-            candidate = ext_dir / plugin_name
+        ``plugin_name`` is user-controlled (plugin ids arrive through the
+        HTTP API), so it must pass :func:`is_safe_plugin_dir_name` and the
+        joined path is resolved and confirmed to still live inside the base
+        directory before any filesystem access.  Names failing either check
+        behave exactly like a nonexistent plugin (returns ``None``).
+        """
+        if not is_safe_plugin_dir_name(plugin_name):
+            return None
+
+        # Built-in takes precedence over external directories.
+        for base in (self.plugins_dir, *self._external_dirs):
+            base_resolved = base.resolve()
+            # Containment barrier: resolve the joined path and reject
+            # anything that escapes the base directory (e.g. a symlinked
+            # plugin dir pointing outside it).  Defense in depth on top of
+            # the name allow-list above, and the sanitizer CodeQL
+            # recognises for py/path-injection.
+            candidate = (base_resolved / plugin_name).resolve()
+            if not candidate.is_relative_to(base_resolved):
+                continue
             if candidate.is_dir():
                 return candidate
 
@@ -234,14 +261,17 @@ class PluginLoader:
     def _source_for_dir(self, plugin_dir: Path) -> PluginSource:
         """Determine the :class:`PluginSource` for a plugin directory."""
         for ext_dir in self._external_dirs:
-            try:
-                plugin_dir.relative_to(ext_dir)
-                return PluginSource(
-                    source_type="external",
-                    local_path=str(plugin_dir),
-                )
-            except ValueError:
-                continue
+            # _resolve_plugin_dir returns fully resolved paths, so compare
+            # against both the raw and the resolved external dir.
+            for ext_base in (ext_dir, ext_dir.resolve()):
+                try:
+                    plugin_dir.relative_to(ext_base)
+                    return PluginSource(
+                        source_type="external",
+                        local_path=str(plugin_dir),
+                    )
+                except ValueError:
+                    continue
         return PluginSource(source_type="builtin", local_path=str(plugin_dir))
 
     # ── loading ──────────────────────────────────────────────────────────
@@ -307,7 +337,11 @@ class PluginLoader:
         #   2. Package layout: <plugin_dir>/plugins/<id>/__init__.py        (newer repos)
         init_path = plugin_dir / "__init__.py"
         if not init_path.exists():
-            subdir_path = plugin_dir / "plugins" / plugin_name / "__init__.py"
+            # plugin_dir was resolved from the validated plugin name, so its
+            # final component equals that name.  Derive the package-layout
+            # path from the sanitized plugin_dir instead of re-joining the
+            # user-provided plugin_name into a path expression.
+            subdir_path = plugin_dir / "plugins" / plugin_dir.name / "__init__.py"
             if subdir_path.exists():
                 init_path = subdir_path
                 logger.debug("Using package layout for plugin %s: %s", plugin_name, init_path)

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -559,3 +559,161 @@ def test_default_external_dir_uses_data_location(tmp_path):
 
     mock_dir.assert_called_once()
     assert loader._external_dirs == [tmp_path]
+
+
+# --- path traversal hardening (CodeQL py/path-injection, alerts #66-#71) ---
+#
+# Plugin names reach load_plugin() from user-controlled API input (plugin
+# settings / install / reload endpoints).  A crafted name must never resolve
+# to a directory outside the plugins root, and must fail through the exact
+# same error path as a nonexistent plugin.
+
+
+def _plugins_root_with_outside_decoy(tmp_path: Path, decoy_id: str = "outside_plugin"):
+    """A plugins root plus a fully valid decoy plugin OUTSIDE that root."""
+    plugins_root = tmp_path / "plugins_root"
+    plugins_root.mkdir()
+    decoy_dir = create_valid_plugin_dir(tmp_path, decoy_id)
+    return plugins_root, decoy_dir
+
+
+def test_load_plugin_rejects_parent_traversal_name(tmp_path):
+    """load_plugin('../x') must not open files outside the plugins root.
+
+    The decoy manifest outside the root contains invalid JSON: on vulnerable
+    code the loader reports "Invalid JSON in manifest" — proof it opened the
+    outside file via load_manifest().  Fixed code must never touch it and
+    must report the standard not-found error instead.
+    """
+    plugins_root = tmp_path / "plugins_root"
+    plugins_root.mkdir()
+    decoy_dir = tmp_path / "outside_plugin"
+    decoy_dir.mkdir()
+    (decoy_dir / "manifest.json").write_text("{ invalid json — reading me proves traversal")
+
+    loader = _loader_for_tests(plugins_root)
+    plugin = loader.load_plugin("../outside_plugin")
+
+    assert plugin is None
+    assert loader.load_errors["../outside_plugin"] == ["Plugin directory not found: ../outside_plugin"]
+
+
+def test_load_plugin_rejects_absolute_path_name(tmp_path):
+    """load_plugin('/abs/path') must not resolve a directory outside the root."""
+    plugins_root, decoy_dir = _plugins_root_with_outside_decoy(tmp_path)
+
+    loader = _loader_for_tests(plugins_root)
+    abs_name = str(decoy_dir)
+    plugin = loader.load_plugin(abs_name)
+
+    assert plugin is None
+    assert loader.load_errors[abs_name] == [f"Plugin directory not found: {abs_name}"]
+
+
+def test_load_plugin_rejects_intermediate_traversal_name(tmp_path):
+    """load_plugin('foo/../bar') must be rejected even when it resolves inside the root."""
+    plugins_root = tmp_path / "plugins_root"
+    plugins_root.mkdir()
+    (plugins_root / "foo").mkdir()
+    create_valid_plugin_dir(plugins_root, "bar")
+
+    loader = _loader_for_tests(plugins_root)
+    plugin = loader.load_plugin("foo/../bar")
+
+    assert plugin is None
+    assert loader.load_errors["foo/../bar"] == ["Plugin directory not found: foo/../bar"]
+    assert "bar" not in loader.loaded_plugins
+
+
+def test_load_plugin_rejects_empty_name(tmp_path):
+    """load_plugin('') must not treat the plugins root itself as a plugin dir."""
+    plugins_root = tmp_path / "plugins_root"
+    plugins_root.mkdir()
+
+    loader = _loader_for_tests(plugins_root)
+    plugin = loader.load_plugin("")
+
+    assert plugin is None
+    assert loader.load_errors[""] == ["Plugin directory not found: "]
+
+
+def test_load_plugin_rejects_symlink_escaping_plugins_root(tmp_path):
+    """A symlinked plugin dir pointing outside the plugins root must not load.
+
+    On vulnerable code this decoy actually LOADS (manifest id matches the
+    requested name), executing code from outside the plugins root.
+    """
+    plugins_root, decoy_dir = _plugins_root_with_outside_decoy(tmp_path, decoy_id="evil")
+    (plugins_root / "evil").symlink_to(decoy_dir)
+
+    loader = _loader_for_tests(plugins_root)
+    plugin = loader.load_plugin("evil")
+
+    assert plugin is None
+    assert loader.load_errors["evil"] == ["Plugin directory not found: evil"]
+    assert "evil" not in loader.loaded_plugins
+
+
+def test_load_plugin_rejects_traversal_out_of_external_dir(tmp_path):
+    """Traversal names must be rejected for external plugin dirs too."""
+    builtin_root = tmp_path / "builtin_root"
+    builtin_root.mkdir()
+    external_root = tmp_path / "external_root"
+    external_root.mkdir()
+    create_valid_plugin_dir(tmp_path, "outside_plugin")
+
+    loader = PluginLoader(plugins_dir=builtin_root, external_dirs=[external_root])
+    plugin = loader.load_plugin("../outside_plugin")
+
+    assert plugin is None
+    assert loader.load_errors["../outside_plugin"] == ["Plugin directory not found: ../outside_plugin"]
+
+
+def test_load_plugin_valid_id_with_digits_and_underscores_still_loads(tmp_path):
+    """A normal plugin id (letters, digits, underscores) loads exactly as before."""
+    create_valid_plugin_dir(tmp_path, "clock_v2")
+    loader = _loader_for_tests(tmp_path)
+
+    plugin = loader.load_plugin("clock_v2")
+
+    assert plugin is not None
+    assert plugin.plugin_id == "clock_v2"
+    source = loader.get_source("clock_v2")
+    assert source is not None
+    assert source.source_type == "builtin"
+    assert Path(source.local_path).name == "clock_v2"
+
+
+def test_load_plugin_builtin_still_wins_over_external(tmp_path):
+    """Builtin dir precedence over external dirs is unchanged by the barrier."""
+    builtin_root = tmp_path / "builtin_root"
+    builtin_root.mkdir()
+    external_root = tmp_path / "external_root"
+    external_root.mkdir()
+    create_valid_plugin_dir(builtin_root, "dup_plugin")
+    create_valid_plugin_dir(external_root, "dup_plugin")
+
+    loader = PluginLoader(plugins_dir=builtin_root, external_dirs=[external_root])
+    plugin = loader.load_plugin("dup_plugin")
+
+    assert plugin is not None
+    source = loader.get_source("dup_plugin")
+    assert source is not None
+    assert source.source_type == "builtin"
+
+
+def test_load_plugin_external_plugin_still_reports_external_source(tmp_path):
+    """A plugin that only exists in an external dir still loads with source 'external'."""
+    builtin_root = tmp_path / "builtin_root"
+    builtin_root.mkdir()
+    external_root = tmp_path / "external_root"
+    external_root.mkdir()
+    create_valid_plugin_dir(external_root, "ext_only")
+
+    loader = PluginLoader(plugins_dir=builtin_root, external_dirs=[external_root])
+    plugin = loader.load_plugin("ext_only")
+
+    assert plugin is not None
+    source = loader.get_source("ext_only")
+    assert source is not None
+    assert source.source_type == "external"


### PR DESCRIPTION
## What

Fixes 6 HIGH-severity CodeQL `py/path-injection` alerts (**#66, #67, #68, #69** in `src/plugins/loader.py`; **#70, #71** in `src/plugins/manifest.py`): user-controlled plugin ids (plugin settings/options/install/reload API endpoints) flowed unvalidated into path expressions. A crafted id like `../../etc`, an absolute path, or a symlinked plugin directory could escape the plugins root — letting the loader open arbitrary `manifest.json`-shaped files and, via a symlink, execute plugin code from outside the plugins directory.

## How

Two-layer barrier at the single resolution point, `PluginLoader._resolve_plugin_dir()`:

1. **Allow-list validation** — new `is_safe_plugin_dir_name()` requires a single path segment matching `^[a-z0-9_]+$` (the manifest id contract).
2. **Containment barrier** — the joined candidate is `resolve()`d and rejected unless `candidate.is_relative_to(base.resolve())`. This is the sanitizer CodeQL recognises for `py/path-injection`, and it also rejects symlinked plugin dirs pointing outside the plugins root.

The package-layout fallback (`plugins/<id>/plugins/<id>/__init__.py`) now derives its path from the sanitized `plugin_dir.name` instead of re-joining the user-provided name, so **all six flagged sinks** — the loader's `is_dir`/`exists` checks and the `manifest_path` passed into `load_manifest()` — sit behind the barrier. The `builtins.open` patchability note in `manifest.py` is untouched (no changes to that file were needed; its sinks only receive sanitized paths).

## Behavior compatibility

- **Valid plugin ids resolve exactly as before**: builtin dir precedence over external dirs, package-layout fallback, `load_errors` semantics — all covered by new regression tests plus the 36 pre-existing loader tests (all green).
- **Invalid/malicious names flow into the existing error path**: `"Plugin directory not found: <name>"` in `load_errors`, `load_plugin()` returns `None` — same API status codes and response shapes as a nonexistent plugin today.
- `_source_for_dir()` additionally compares against the *resolved* external dir so source classification (`builtin`/`external`) is unchanged now that resolved paths are returned.
- Only intentional change: a plugin directory that is a **symlink escaping the plugins root** no longer loads (that was the exploit vector).

## Test evidence (non-vacuity proof)

Tests were written first and run against unfixed code in the container. All 6 traversal tests failed for exactly the vulnerable reasons — including proof the outside file was **opened** (`Invalid JSON in manifest` from the decoy planted outside the root) and that a symlinked decoy **actually loaded**:

```
FAILED test_load_plugin_rejects_parent_traversal_name
  At index 0 diff: 'Invalid JSON in manifest: Expecting property name enclosed in
  double quotes: line 1 column 3 (char 2)' != 'Plugin directory not found: ../outside_plugin'
FAILED test_load_plugin_rejects_absolute_path_name
  "Manifest id 'outside_plugin' does not match directory name
  '/tmp/pytest-of-root/pytest-0/test_load_plugin_rejects_absol0/outside_plugin'"
  != 'Plugin directory not found: /tmp/.../outside_plugin'
FAILED test_load_plugin_rejects_intermediate_traversal_name
  "Manifest id 'bar' does not match directory name 'foo/../bar'" != 'Plugin directory not found: foo/../bar'
FAILED test_load_plugin_rejects_empty_name
  'Manifest not found: /tmp/.../plugins_root/manifest.json' != 'Plugin directory not found: '
FAILED test_load_plugin_rejects_symlink_escaping_plugins_root
  assert <plugins.evil.TestPlugin object at 0xffffaeafe660> is None
FAILED test_load_plugin_rejects_traversal_out_of_external_dir
  "Manifest id 'outside_plugin' does not match directory name '../outside_plugin'"
  != 'Plugin directory not found: ../outside_plugin'
================== 6 failed, 3 passed, 36 deselected in 0.11s ==================
```

After the fix (all run per-module in the container):

```
tests/test_plugin_loader.py                 45 passed
tests/test_plugin_registry.py              111 passed
tests/test_plugin_system_security.py        39 passed
tests/test_plugin_install_integration.py    13 passed
tests/test_manifest_previews.py             18 passed
tests/test_plugin_validation.py             73 passed
tests/test_plugin_sources.py                95 passed
tests/test_plugin_instances.py              91 passed
tests/test_extract_plugin.py                 3 passed
tests/test_settings_plugins.py              23 passed
tests/test_plugin_options_route.py          38 passed
```

`ruff check` and `ruff format --check` pass on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
