### PR TITLE
fix(security): stop leaking exception details in API error responses (CodeQL py/stack-trace-exposure)

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -6738,9 +6738,11 @@ async def update_beta_settings(request: dict):
             # persisting the user's preference, but we surface the error.
             try:
                 await asyncio.to_thread(https_certs.generate_cert)
-            except Exception as e:  # noqa: BLE001 - report to caller
-                logger.error("Failed to generate HTTPS certificate: %s", e)
-                cert_error = str(e)
+            except Exception:  # noqa: BLE001 - report to caller
+                # Full detail stays in the server log; the raw exception can
+                # carry paths/config internals (CodeQL py/stack-trace-exposure).
+                logger.exception("Failed to generate HTTPS certificate")
+                cert_error = "Certificate generation failed — check the server logs for details."
         elif previous and not requested:
             # User just turned HTTPS off -> remove the cert so nginx
             # falls back to HTTP on next restart.
@@ -9330,11 +9332,14 @@ async def get_plugin_options_endpoint(plugin_id: str, options_id: str, body: Plu
         # inline next to the field instead of a failed-request toast.
         return _envelope(error=str(e))
     except Exception as e:
+        # The traceback (with the plugin's raw error text) is already in the
+        # server log; the client gets a static message so plugin exceptions
+        # cannot leak keys/URLs/paths (CodeQL py/stack-trace-exposure).
         logger.exception("Options provider '%s' failed for plugin '%s'", options_id, plugin_id)
-        stale = _stale_options_payload(cache_key, reason=f"Options provider failed: {e}")
+        stale = _stale_options_payload(cache_key, reason="Options provider failed")
         if stale is not None:
             return stale
-        raise HTTPException(status_code=502, detail=f"Options provider failed: {e}") from e
+        raise HTTPException(status_code=502, detail="Options provider failed") from e
 
     options, truncated = _serialise_options(result.options, limit, plugin_id, options_id)
     payload = _fit_options_payload(

--- a/src/backup/service.py
+++ b/src/backup/service.py
@@ -373,7 +373,11 @@ class BackupService:
                 continue
 
             if errors:
-                result["failed"].append({"plugin_id": safe_plugin_id, "error": "; ".join(errors)})
+                # Install errors embed git/loader exception text (URLs, paths,
+                # stderr) — keep the detail in the server log and return a
+                # static message (CodeQL py/stack-trace-exposure).
+                logger.warning("Plugin reinstall for '%s' failed: %s", safe_plugin_id, "; ".join(errors))
+                result["failed"].append({"plugin_id": safe_plugin_id, "error": "install failed (see server logs)"})
             else:
                 result["installed"].append(safe_plugin_id)
 

--- a/src/network_diagnostics.py
+++ b/src/network_diagnostics.py
@@ -23,6 +23,33 @@ _CONNECT_TIMEOUT = 5
 _HTTP_TIMEOUT = 10
 
 
+def _describe_socket_error(exc: OSError) -> str:
+    """Classify a socket-level failure into a static, user-facing message.
+
+    The diagnostics dict is returned verbatim to the browser, so error text
+    must never echo the raw exception (CodeQL py/stack-trace-exposure) — the
+    full detail is logged server-side at each call site instead.
+    """
+    if isinstance(exc, socket.gaierror):
+        return "DNS lookup failed"
+    if isinstance(exc, TimeoutError):
+        return "Connection timed out"
+    if isinstance(exc, ConnectionRefusedError):
+        return "Connection refused"
+    return "Connection failed"
+
+
+def _describe_request_error(exc: requests.exceptions.RequestException) -> str:
+    """Classify a requests-level failure into a static, user-facing message."""
+    if isinstance(exc, requests.exceptions.SSLError):
+        return "SSL/TLS error"
+    if isinstance(exc, requests.exceptions.Timeout):
+        return "Connection timed out"
+    if isinstance(exc, requests.exceptions.ConnectionError):
+        return "Could not connect"
+    return "Request failed"
+
+
 def check_dns_resolution(hostname: str = "google.com", timeout: float = _DNS_TIMEOUT) -> dict:
     """Check if DNS resolution is working.
 
@@ -39,9 +66,11 @@ def check_dns_resolution(hostname: str = "google.com", timeout: float = _DNS_TIM
         ip = socket.gethostbyname(hostname)
         return {"ok": True, "hostname": hostname, "ip": ip}
     except socket.gaierror as exc:
-        return {"ok": False, "hostname": hostname, "ip": None, "error": str(exc)}
+        logger.warning("DNS resolution for %s failed: %s", hostname, exc)
+        return {"ok": False, "hostname": hostname, "ip": None, "error": "DNS lookup failed"}
     except Exception as exc:
-        return {"ok": False, "hostname": hostname, "ip": None, "error": str(exc)}
+        logger.warning("DNS check for %s failed: %s", hostname, exc)
+        return {"ok": False, "hostname": hostname, "ip": None, "error": "DNS check failed"}
     finally:
         socket.setdefaulttimeout(old_timeout)
 
@@ -71,12 +100,13 @@ def check_internet_connectivity(
         }
     except requests.exceptions.RequestException as exc:
         latency_ms = round((time.time() - start) * 1000)
+        logger.warning("Internet connectivity check against %s failed: %s", url, exc)
         return {
             "ok": False,
             "url": url,
             "status_code": None,
             "latency_ms": latency_ms,
-            "error": str(exc),
+            "error": _describe_request_error(exc),
         }
 
 
@@ -99,7 +129,8 @@ def check_port_reachable(host: str, port: int, timeout: float = _CONNECT_TIMEOUT
         return {"ok": True, "host": host, "port": port, "latency_ms": latency_ms}
     except OSError as exc:
         latency_ms = round((time.time() - start) * 1000)
-        return {"ok": False, "host": host, "port": port, "latency_ms": latency_ms, "error": str(exc)}
+        logger.warning("Port check for %s:%s failed: %s", host, port, exc)
+        return {"ok": False, "host": host, "port": port, "latency_ms": latency_ms, "error": _describe_socket_error(exc)}
 
 
 def check_vestaboard_connection(
@@ -149,11 +180,12 @@ def check_vestaboard_connection(
             }
         except requests.exceptions.RequestException as exc:
             latency_ms = round((time.time() - start) * 1000)
+            logger.warning("Vestaboard cloud API check failed: %s", exc)
             steps["cloud_api"] = {
                 "ok": False,
                 "status_code": None,
                 "latency_ms": latency_ms,
-                "error": str(exc),
+                "error": _describe_request_error(exc),
             }
 
         overall = steps.get("cloud_api", {}).get("ok", False)
@@ -190,11 +222,12 @@ def check_vestaboard_connection(
         }
     except requests.exceptions.RequestException as exc:
         latency_ms = round((time.time() - start) * 1000)
+        logger.warning("Vestaboard local API check for %s failed: %s", host, exc)
         steps["api"] = {
             "ok": False,
             "status_code": None,
             "latency_ms": latency_ms,
-            "error": str(exc),
+            "error": _describe_request_error(exc),
         }
 
     overall = all(step.get("ok", False) for step in steps.values())

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -242,6 +242,30 @@ def test_reinstall_plugins_records_failures(tmp_path):
     assert result["failed"] and result["failed"][0]["plugin_id"] == "weather"
 
 
+def test_reinstall_plugins_does_not_leak_install_error_text(tmp_path):
+    """Install errors embed git/loader exception text (URLs, paths, stderr).
+    They belong in the server log, not in the API response (CodeQL
+    py/stack-trace-exposure, alert #64)."""
+    fake_registry = MagicMock()
+    fake_registry.get_plugin.return_value = None
+    fake_registry.install_from_registry.return_value = ["git clone failed: SECRET_INTERNAL_XYZ /root/.ssh detail"]
+
+    with patch("src.plugins.get_plugin_registry", return_value=fake_registry, create=True):
+        result = BackupService._reinstall_plugins(
+            [
+                {
+                    "plugin_id": "weather",
+                    "source_type": "registry",
+                    "repository_url": "https://example.com/p.git",
+                }
+            ]
+        )
+
+    assert result["failed"] and result["failed"][0]["plugin_id"] == "weather"
+    assert "SECRET_INTERNAL_XYZ" not in repr(result)
+    assert result["failed"][0]["error"] == "install failed (see server logs)"
+
+
 def test_reinstall_plugins_installs_registry_plugin(tmp_path):
     """A registry plugin not yet present should be installed and appear in
     the 'installed' list."""
@@ -388,3 +412,31 @@ def test_import_endpoint_rejects_invalid_payload(client_with_data_dir):
 
     assert response.status_code == 400
     assert "marker" in response.json()["detail"].lower()
+
+
+def test_import_endpoint_does_not_leak_plugin_install_errors(client_with_data_dir):
+    """The import summary is returned verbatim to the browser, so a failed
+    plugin reinstall must not carry raw git/loader exception text (CodeQL
+    py/stack-trace-exposure, alert #64)."""
+    client, _ = client_with_data_dir
+
+    backup = client.get("/backup/export").json()
+    backup["installed_plugins"] = [
+        {
+            "plugin_id": "weather",
+            "source_type": "registry",
+            "repository_url": "https://example.com/p.git",
+        }
+    ]
+
+    fake_registry = MagicMock()
+    fake_registry.get_plugin.return_value = None
+    fake_registry.install_from_registry.return_value = ["git clone failed: SECRET_INTERNAL_XYZ /root/.ssh detail"]
+
+    with patch("src.plugins.get_plugin_registry", return_value=fake_registry, create=True):
+        response = client.post("/backup/import", json=backup)
+
+    assert response.status_code == 200
+    assert "SECRET_INTERNAL_XYZ" not in response.text
+    body = response.json()
+    assert body["plugins"]["failed"] and body["plugins"]["failed"][0]["plugin_id"] == "weather"

--- a/tests/test_network_diagnostics.py
+++ b/tests/test_network_diagnostics.py
@@ -591,3 +591,102 @@ class TestRunFullDiagnostics:
 
         assert result["overall_ok"] is False
         assert len(result["recommendations"]) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Error-text sanitization (CodeQL py/stack-trace-exposure, alert #63)
+#
+# The diagnostics dict is returned verbatim by /debug/network-diagnostics, so
+# no ``error`` field may carry raw exception text — only a static, classified
+# description. Full details go to the server log instead.
+# ---------------------------------------------------------------------------
+
+
+class TestErrorTextSanitization:
+    """Every ``error`` field is a static classification, never str(exc)."""
+
+    SENTINEL = "SECRET_INTERNAL_XYZ"
+
+    @patch("src.network_diagnostics.socket.gethostbyname")
+    def test_dns_gaierror_text_is_sanitized(self, mock_resolve):
+        mock_resolve.side_effect = socket.gaierror(self.SENTINEL)
+
+        result = check_dns_resolution()
+
+        assert result["ok"] is False
+        assert self.SENTINEL not in repr(result)
+        assert result["error"] == "DNS lookup failed"
+
+    @patch("src.network_diagnostics.socket.gethostbyname")
+    def test_dns_generic_error_text_is_sanitized(self, mock_resolve):
+        mock_resolve.side_effect = RuntimeError(self.SENTINEL)
+
+        result = check_dns_resolution()
+
+        assert result["ok"] is False
+        assert self.SENTINEL not in repr(result)
+        assert result["error"] == "DNS check failed"
+
+    @patch("src.network_diagnostics.requests.head")
+    def test_internet_timeout_text_is_sanitized(self, mock_head):
+        mock_head.side_effect = requests.exceptions.Timeout(self.SENTINEL)
+
+        result = check_internet_connectivity()
+
+        assert result["ok"] is False
+        assert self.SENTINEL not in repr(result)
+        assert result["error"] == "Connection timed out"
+
+    @patch("src.network_diagnostics.requests.head")
+    def test_internet_connection_error_text_is_sanitized(self, mock_head):
+        mock_head.side_effect = requests.exceptions.ConnectionError(self.SENTINEL)
+
+        result = check_internet_connectivity()
+
+        assert result["ok"] is False
+        assert self.SENTINEL not in repr(result)
+        assert result["error"] == "Could not connect"
+
+    @patch("src.network_diagnostics.socket.create_connection")
+    def test_port_refused_text_is_sanitized(self, mock_conn):
+        mock_conn.side_effect = ConnectionRefusedError(self.SENTINEL)
+
+        result = check_port_reachable("192.0.2.10", 7000)
+
+        assert result["ok"] is False
+        assert self.SENTINEL not in repr(result)
+        assert result["error"] == "Connection refused"
+
+    @patch("src.network_diagnostics.socket.create_connection")
+    def test_port_generic_oserror_text_is_sanitized(self, mock_conn):
+        mock_conn.side_effect = OSError(self.SENTINEL)
+
+        result = check_port_reachable("192.0.2.10", 7000)
+
+        assert result["ok"] is False
+        assert self.SENTINEL not in repr(result)
+        assert result["error"] == "Connection failed"
+
+    @patch("src.network_diagnostics.requests.get")
+    def test_cloud_api_error_text_is_sanitized(self, mock_get):
+        mock_get.side_effect = requests.exceptions.ConnectionError(self.SENTINEL)
+
+        result = check_vestaboard_connection(host="", use_cloud=True, cloud_key="rw-key")
+
+        assert result["ok"] is False
+        assert self.SENTINEL not in repr(result)
+        assert result["steps"]["cloud_api"]["error"] == "Could not connect"
+
+    @patch("src.network_diagnostics.requests.get")
+    @patch("src.network_diagnostics.check_port_reachable")
+    @patch("src.network_diagnostics.check_dns_resolution")
+    def test_local_api_error_text_is_sanitized(self, mock_dns, mock_port, mock_get):
+        mock_dns.return_value = {"ok": True, "hostname": "192.0.2.10", "ip": "192.0.2.10"}
+        mock_port.return_value = {"ok": True, "host": "192.0.2.10", "port": 7000, "latency_ms": 5}
+        mock_get.side_effect = requests.exceptions.Timeout(self.SENTINEL)
+
+        result = check_vestaboard_connection(host="192.0.2.10", api_key="key")
+
+        assert result["ok"] is False
+        assert self.SENTINEL not in repr(result)
+        assert result["steps"]["api"]["error"] == "Connection timed out"

--- a/tests/test_network_diagnostics_endpoint.py
+++ b/tests/test_network_diagnostics_endpoint.py
@@ -68,3 +68,25 @@ class TestNetworkDiagnosticsEndpoint:
         assert response.status_code == 500
         data = response.json()
         assert data["detail"] == "Network diagnostics failed"
+
+    @patch("src.network_diagnostics.requests.get")
+    @patch("src.network_diagnostics.requests.head")
+    @patch("src.network_diagnostics.socket.gethostbyname")
+    def test_check_failures_do_not_leak_exception_text(self, mock_resolve, mock_head, mock_get, client):
+        """Raw exception text from failed checks must never reach the HTTP
+        response (CodeQL py/stack-trace-exposure, alert #63)."""
+        import socket
+
+        import requests as req
+
+        mock_resolve.side_effect = socket.gaierror("SECRET_INTERNAL_XYZ resolver detail")
+        mock_head.side_effect = req.exceptions.ConnectionError("SECRET_INTERNAL_XYZ proxy detail")
+        mock_get.side_effect = req.exceptions.ConnectionError("SECRET_INTERNAL_XYZ api detail")
+
+        response = client.get("/debug/network-diagnostics")
+
+        assert response.status_code == 200
+        assert "SECRET_INTERNAL_XYZ" not in response.text
+        data = response.json()["diagnostics"]
+        assert data["dns"]["error"] == "DNS lookup failed"
+        assert data["internet"]["error"] == "Could not connect"

--- a/tests/test_plugin_options_route.py
+++ b/tests/test_plugin_options_route.py
@@ -216,6 +216,35 @@ def test_an_unexpected_plugin_exception_is_a_502(registry, client):
     assert response.status_code == 502
 
 
+def test_an_unexpected_plugin_exception_does_not_leak_its_text(registry, client):
+    """Plugin tracebacks carry keys/URLs/paths. The 502 detail is a static
+    message; the real exception goes to the server log only (CodeQL
+    py/stack-trace-exposure, alert #72)."""
+    registry.result = _raises(RuntimeError("SECRET_INTERNAL_XYZ token=abc123"))
+
+    response = _post(client)
+
+    assert response.status_code == 502
+    assert "SECRET_INTERNAL_XYZ" not in response.text
+    assert response.json()["detail"] == "Options provider failed"
+
+
+def test_a_stale_fallback_does_not_leak_the_new_failures_text(registry, client):
+    """The stale payload's ``error`` field is shown inline in the widget — it
+    must describe the failure without echoing the raw exception (CodeQL
+    py/stack-trace-exposure, alert #72)."""
+    _post(client)
+    registry.result = _raises(RuntimeError("SECRET_INTERNAL_XYZ token=abc123"))
+
+    response = _post(client, refresh=True)
+
+    assert response.status_code == 200
+    assert "SECRET_INTERNAL_XYZ" not in response.text
+    payload = response.json()
+    assert payload["stale"] is True
+    assert payload["error"] == "Options provider failed"
+
+
 def _blocking_provider(release: threading.Event, seconds: float = 1.0):
     """A plugin behaviour that hangs until *release* is set (or *seconds* pass).
 

--- a/tests/test_settings_beta.py
+++ b/tests/test_settings_beta.py
@@ -123,10 +123,34 @@ def test_put_beta_cert_generation_failure_returns_warning(tmp_path, monkeypatch)
     assert response.status_code == 200
     body = response.json()
     # The setting still toggles (we don't hide the user's intent), but
-    # we surface the cert error so the UI can show it.
+    # we surface a cert error so the UI can show it.
     assert body["status"] == "warning"
     assert body["settings"]["https_enabled"] is True
-    assert "openssl exploded" in body["cert_error"]
+    assert body["cert_error"]
+    _reset_beta_state()
+
+
+def test_put_beta_cert_generation_failure_does_not_leak_exception_text(tmp_path, monkeypatch):
+    """The raw exception may carry paths/config internals (CodeQL
+    py/stack-trace-exposure, alert #62) — the client gets a static message."""
+    _reset_beta_state()
+    monkeypatch.setenv("FIESTABOARD_CERT_DIR", str(tmp_path))
+
+    with (
+        patch(
+            "src.system.https_certs.generate_cert",
+            side_effect=RuntimeError("SECRET_INTERNAL_XYZ /etc/ssl/private/key.pem"),
+        ),
+        patch("src.api_server._updater_token", return_value=""),
+        patch("src.api_server._updater_probe", return_value=False),
+    ):
+        response = client.put("/settings/beta", json={"https_enabled": True})
+
+    assert response.status_code == 200
+    assert "SECRET_INTERNAL_XYZ" not in response.text
+    body = response.json()
+    assert body["status"] == "warning"
+    assert body["cert_error"] == "Certificate generation failed — check the server logs for details."
     _reset_beta_state()
 
 


### PR DESCRIPTION
## What / why

Fixes the four MEDIUM CodeQL `py/stack-trace-exposure` alerts (#62, #63, #64, #72), all rooted in `src/api_server.py` handlers that echoed raw exception text to HTTP clients. Exception messages can carry filesystem paths, upstream URLs, credentials embedded in connection strings, and stderr from subprocesses.

Pattern applied everywhere: **full detail server-side** (`logger.exception(...)` / `logger.warning(...)` at the catch site) + **static, human-meaningful message client-side**. Status codes, response shapes, and JSON keys are unchanged.

## Per-endpoint before/after

| Alert | Endpoint | Field | Before (leaked) | After |
|---|---|---|---|---|
| #62 | `PUT /settings/beta` | `cert_error` | `str(e)` from cert generation | `Certificate generation failed — check the server logs for details.` |
| #63 | `GET /debug/network-diagnostics` | `diagnostics.*.error` (6 sites in `src/network_diagnostics.py`) | `str(exc)` from socket/requests | Classified by exception type: `DNS lookup failed`, `DNS check failed`, `Connection timed out`, `Connection refused`, `Connection failed`, `Could not connect`, `SSL/TLS error`, `Request failed` |
| #64 | `POST /backup/import` | `plugins.failed[].error` | `"; ".join(errors)` — git/loader errors embedding `{exc}` (e.g. `git clone failed: <exc>`, `Failed to import plugin module: <e>`) | `install failed (see server logs)` |
| #72 | `POST /plugins/{id}/options/{options_id}` | 502 `detail` + stale-fallback `error` | `Options provider failed: {e}` | `Options provider failed` |

## Preserved user-facing messages (deliberate)

- **`BackupError` → 400 `detail=str(exc)` is kept.** Every `BackupError` raise site reachable from `/backup/import` (`src/backup/service.py::_validate_backup`) is a hand-written validation string ("Backup file must be a JSON object.", "missing 'schema_version'", …). The one message that embeds exception data (`import_from_json`, JSON parse) is never called by the endpoint — FastAPI parses the body itself.
- **`OptionsUnavailable` → 200 `error=str(e)` is kept.** It is the documented domain error for "plugin not configured yet" with plugin-crafted reasons; not flagged by CodeQL.
- **Marketplace install errors untouched.** #64 is sanitized at the backup path's join (`_reinstall_plugins`), not in `loader.py`/`sources.py`, so the Integrations install flow keeps its detailed errors.
- Checked `web/src` for string-matching on these responses: `beta-settings.tsx` toasts `cert_error` verbatim, `debug-settings.tsx` renders diagnostics `error` fields verbatim, `remote-options-field.tsx` renders `data.error` verbatim, and `backup-settings.tsx` only counts `plugins.failed.length` — no UI string-matching anywhere, and all replacement messages remain informative. The `Options provider failed` prefix is preserved.

## Test evidence (TDD — tests written first, failed pre-fix)

14 new tests, each mocking the underlying service to raise with sentinel `SECRET_INTERNAL_XYZ` and asserting (a) status code, (b) sentinel absent, (c) expected static message present. Pre-fix run:

```
FAILED tests/test_settings_beta.py::test_put_beta_cert_generation_failure_does_not_leak_exception_text
  assert 'SECRET_INTERNAL_XYZ' not in '{"status":"...te/key.pem"}'
  'SECRET_INTERNAL_XYZ' is contained here: t_error":"SECRET_INTERNAL_XYZ /etc/ssl/private/key.pem"}
FAILED tests/test_network_diagnostics.py::TestErrorTextSanitization::test_dns_gaierror_text_is_sanitized
FAILED tests/test_network_diagnostics.py::TestErrorTextSanitization::test_dns_generic_error_text_is_sanitized
FAILED tests/test_network_diagnostics.py::TestErrorTextSanitization::test_internet_timeout_text_is_sanitized
FAILED tests/test_network_diagnostics.py::TestErrorTextSanitization::test_internet_connection_error_text_is_sanitized
FAILED tests/test_network_diagnostics.py::TestErrorTextSanitization::test_port_refused_text_is_sanitized
FAILED tests/test_network_diagnostics.py::TestErrorTextSanitization::test_port_generic_oserror_text_is_sanitized
FAILED tests/test_network_diagnostics.py::TestErrorTextSanitization::test_cloud_api_error_text_is_sanitized
FAILED tests/test_network_diagnostics.py::TestErrorTextSanitization::test_local_api_error_text_is_sanitized
FAILED tests/test_network_diagnostics_endpoint.py::TestNetworkDiagnosticsEndpoint::test_check_failures_do_not_leak_exception_text
  assert 'SECRET_INTERNAL_XYZ' not in ... ,"error":"SECRET_INTERNAL_XYZ resolver detail"},"internet":{...,"error":"SECRET_INTERNAL_XYZ proxy detail"}
FAILED tests/test_plugin_options_route.py::test_an_unexpected_plugin_exception_does_not_leak_its_text
  {"detail":"Options provider failed: SECRET_INTERNAL_XYZ token=abc123"}
FAILED tests/test_plugin_options_route.py::test_a_stale_fallback_does_not_leak_the_new_failures_text
  ...r failed: SECRET_INTERNAL_XYZ token=abc123","cached":true,"stale":true...
FAILED tests/test_backup.py::test_reinstall_plugins_does_not_leak_install_error_text
  ...e failed: SECRET_INTERNAL_XYZ /root/.ssh detail'}], 'manual_reinstall_required': []}
FAILED tests/test_backup.py::test_import_endpoint_does_not_leak_plugin_install_errors
  ...e failed: SECRET_INTERNAL_XYZ /root/.ssh detail"}],"manual_reinstall_required":[]}
== 14 failed pre-fix ==
```

One existing test (`test_put_beta_cert_generation_failure_returns_warning`) asserted the leak itself (`"openssl exploded" in body["cert_error"]`) — it encoded the wrong contract and now asserts that a cert error is surfaced without pinning it to the exception text.

Post-fix (in Docker, per-module):

```
tests/test_settings_beta.py tests/test_network_diagnostics.py tests/test_network_diagnostics_endpoint.py — 60 passed
tests/test_plugin_options_route.py tests/test_backup.py — 61 passed
tests/test_plugin_options.py tests/test_debug_endpoints.py tests/test_post_upgrade_restore.py tests/test_https_certs.py tests/test_settings_all.py — 148 passed (collateral check)
ruff check <changed files> — All checks passed!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
