### PR TITLE
fix(security): linear-time wrap-filter detection in template engine (CodeQL py/polynomial-redos)

### DIFF
--- a/src/templates/engine.py
+++ b/src/templates/engine.py
@@ -419,6 +419,49 @@ class TemplateEngine:
 
         return "\n".join(rendered)
 
+    @staticmethod
+    def _find_wrap_expression(template: str) -> tuple[int, int, str] | None:
+        """Find the first ``{{...}}`` whose filter chain contains ``|wrap``.
+
+        Linear-time replacement for the former regex
+        ``\\{\\{([^}]+\\|wrap(?:\\|[^}]*)?)\\}\\}``, which backtracked
+        polynomially on adversarial user-authored templates (CodeQL alert
+        #65, py/polynomial-redos). The matching semantics are preserved
+        exactly: the expression is everything between ``{{`` and the first
+        following ``}`` (which must itself be followed by another ``}``),
+        and it qualifies when splitting on ``|`` yields a segment equal to
+        ``wrap`` (lowercase, unstripped — same as the old regex) that is
+        preceded by at least one character.
+
+        Args:
+            template: Template string to scan
+
+        Returns:
+            ``(start, end, expr)`` for the first qualifying ``{{expr}}``
+            (``start``/``end`` span the braces), or ``None``.
+        """
+        pos = 0
+        while True:
+            start = template.find("{{", pos)
+            if start == -1:
+                return None
+            close = template.find("}", start + 2)
+            if close == -1:
+                return None
+            if template[close + 1 : close + 2] != "}":
+                # "{{...}" without a second "}": nothing can match at or
+                # before this "}", so resume scanning right after it.
+                pos = close + 1
+                continue
+            expr = template[start + 2 : close]
+            segments = expr.split("|")
+            for idx in range(1, len(segments)):
+                # idx > 1 or a non-empty first segment mirrors the old
+                # regex's [^}]+ requirement of ≥1 char before "|wrap".
+                if segments[idx] == "wrap" and (idx > 1 or segments[0]):
+                    return (start, close + 2, expr)
+            pos = close + 2
+
     def _render_with_wrap(
         self, template: str, context: dict[str, Any], max_lines: int = 1, board_width: int = 22
     ) -> list[str]:
@@ -438,13 +481,12 @@ class TemplateEngine:
             List of rendered lines (up to max_lines)
         """
         # First, check if there's a variable with |wrap filter (variable-level wrap)
-        wrap_pattern = re.compile(r"\{\{([^}]+\|wrap(?:\|[^}]*)?)\}\}")
-        match = wrap_pattern.search(template)
+        wrap_match = self._find_wrap_expression(template)
 
-        if match:
+        if wrap_match:
             # Variable-level wrap: wrap only the variable with |wrap filter
             # Get the variable expression (without |wrap)
-            expr = match.group(1)
+            match_start, match_end, expr = wrap_match
             # Remove |wrap from the filter chain
             parts = expr.split("|")
             var_part = parts[0].strip()
@@ -458,8 +500,8 @@ class TemplateEngine:
                 value = self._apply_filter(value, f)
 
             # Get prefix and suffix around the variable
-            prefix = template[: match.start()]
-            suffix = template[match.end() :]
+            prefix = template[:match_start]
+            suffix = template[match_end:]
 
             # Render prefix and suffix (they may have other variables)
             prefix = self.render(prefix, context)

--- a/tests/test_templates_extended.py
+++ b/tests/test_templates_extended.py
@@ -340,26 +340,66 @@ class TestWrapDetectionLinearTime:
     CodeQL alert #65 (py/polynomial-redos): the former detection regex
     ``\\{\\{([^}]+\\|wrap(?:\\|[^}]*)?)\\}\\}`` was quadratic on unclosed
     ``{{`` runs. Templates are user-authored (pages/API), so these inputs
-    are reachable. At the committed sizes the old code took tens of
-    seconds; the linear scanner finishes in milliseconds.
+    are reachable.
+
+    Rather than an absolute wall-clock bound (flaky on slow shared CI
+    runners), these assert the growth property itself: a 4x larger input
+    may not take quadratically (~16x) longer. Quadratic code fails at any
+    machine speed; linear code passes at any machine speed — on a fast
+    machine via the FAST_ENOUGH short-circuit, on a slow one via the
+    ratio. Measured on the old regex (repo test container): the "||wrap|"
+    shape grew 1.28s -> 20.63s (16.1x) end to end, and the "{{|" shape
+    grew 1.17s -> 18.74s (16.1x) at the detection step; the linear
+    scanner handles both large inputs in milliseconds.
+
+    The "{{|" brace-flood shape is asserted at the detection level only:
+    the downstream ``_split_into_tokens``/``_count_tiles`` tile scan does
+    ``text.find("}", i)`` per "{" and is therefore quadratic on "}"-free
+    brace floods — a pre-existing issue independent of alert #65, so
+    end-to-end growth cannot be asserted on that shape.
     """
 
-    BOUND_SECONDS = 2.0
+    GROWTH_LIMIT = 8.0  # quadratic growth is ~16x for a 4x input
+    FAST_ENOUGH = 1.0  # seconds; below this, growth rate is irrelevant
+    NOISE_FLOOR = 0.05  # seconds; keeps the ratio denominator meaningful
 
-    def _assert_fast(self, engine, template):
+    @staticmethod
+    def _timed(fn):
         start = time.perf_counter()
-        engine._render_with_wrap(template, {}, max_lines=1)
-        elapsed = time.perf_counter() - start
-        assert elapsed < self.BOUND_SECONDS, f"wrap detection took {elapsed:.2f}s (bound {self.BOUND_SECONDS}s)"
+        fn()
+        return time.perf_counter() - start
 
-    def test_unclosed_brace_pipe_runs_are_linear(self, engine):
-        self._assert_fast(engine, "{{" + "{{|" * 100_000)
+    def _assert_linear_growth(self, run, make_template, n):
+        small = self._timed(lambda: run(make_template(n)))
+        large = self._timed(lambda: run(make_template(4 * n)))
+        if large < self.FAST_ENOUGH:
+            return
+        ratio = large / max(small, self.NOISE_FLOOR)
+        assert ratio < self.GROWTH_LIMIT, (
+            f"4x input grew {ratio:.1f}x ({small:.2f}s -> {large:.2f}s); "
+            f"expected < {self.GROWTH_LIMIT}x for linear-time wrap detection"
+        )
 
-    def test_unclosed_wrap_pipe_runs_are_linear(self, engine):
-        self._assert_fast(engine, "{{||wrap|" + "||wrap|" * 30_000)
+    def test_wrap_pipe_flood_renders_in_linear_time(self, engine):
+        self._assert_linear_growth(
+            lambda t: engine._render_with_wrap(t, {}, max_lines=1),
+            lambda n: "{{||wrap|" + "||wrap|" * n,
+            7_500,
+        )
 
-    def test_long_unclosed_variable_is_linear(self, engine):
-        self._assert_fast(engine, "{{" + "a" * 50_000)
+    def test_long_unclosed_variable_renders_in_linear_time(self, engine):
+        self._assert_linear_growth(
+            lambda t: engine._render_with_wrap(t, {}, max_lines=1),
+            lambda n: "{{" + "a" * n,
+            12_500,
+        )
+
+    def test_brace_pipe_flood_detection_is_linear(self, engine):
+        self._assert_linear_growth(
+            engine._find_wrap_expression,
+            lambda n: "{{" + "{{|" * n,
+            25_000,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_templates_extended.py
+++ b/tests/test_templates_extended.py
@@ -1,5 +1,6 @@
 """Extended tests for template engine - covering additional code paths."""
 
+import time
 from unittest.mock import Mock, patch
 
 import pytest
@@ -259,6 +260,106 @@ class TestRenderWithWrap:
         context = {"test": {"val": "SHORT"}}
         result = engine._render_with_wrap("{{test.val}} some extra text here now", context, max_lines=2)
         assert len(result) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Wrap-filter detection: parity + linear time (CodeQL alert #65)
+# ---------------------------------------------------------------------------
+
+
+class TestWrapDetectionParity:
+    """Pin the exact matching semantics of the |wrap detection.
+
+    These lock in which ``{{...}}`` expression triggers variable-level wrap
+    (and which spellings do NOT), so the linear-time replacement for the
+    former backtracking regex (CodeQL alert #65, py/polynomial-redos)
+    cannot drift from the original behavior. The variable-wrap path keeps
+    the suffix on the FIRST line; the line-level path wraps the fully
+    rendered template so the suffix lands on the LAST line — that
+    difference makes each assertion sensitive to the detection outcome.
+    """
+
+    CTX = {"test": {"val": "AAAA BBBB CCCC DDDD EEEE", "plain": "HI"}}
+
+    def test_variable_wrap_exact_output(self, engine):
+        result = engine._render_with_wrap("{{test.val|wrap}}", self.CTX, max_lines=3)
+        assert result == ["AAAA BBBB CCCC DDDD", "EEEE"]
+
+    def test_wrap_followed_by_another_filter(self, engine):
+        result = engine._render_with_wrap("{{test.val|wrap|upper}}", self.CTX, max_lines=3)
+        assert result == ["AAAA BBBB CCCC DDDD", "EEEE"]
+
+    def test_another_filter_before_wrap(self, engine):
+        result = engine._render_with_wrap("{{test.val|upper|wrap}}", self.CTX, max_lines=3)
+        assert result == ["AAAA BBBB CCCC DDDD", "EEEE"]
+
+    def test_prefix_suffix_take_variable_wrap_path(self, engine):
+        result = engine._render_with_wrap("X:{{test.val|wrap}}:Y", self.CTX, max_lines=3)
+        assert result == ["X:AAAA BBBB CCCC:Y", "DDDD EEEE"]
+
+    def test_whitespace_around_wrap_is_line_level(self, engine):
+        # "{{ x | wrap }}" never matched the old regex (space between the
+        # pipe and "wrap"), so it must keep taking the line-level path.
+        result = engine._render_with_wrap("X:{{ test.val | wrap }}:Y", self.CTX, max_lines=3)
+        assert result == ["X:AAAA BBBB CCCC DDDD", "EEEE:Y"]
+
+    def test_uppercase_wrap_is_line_level(self, engine):
+        # Detection was case-sensitive in the old regex.
+        result = engine._render_with_wrap("X:{{test.val|WRAP}}:Y", self.CTX, max_lines=3)
+        assert result == ["X:AAAA BBBB CCCC DDDD", "EEEE:Y"]
+
+    def test_wrap_prefixed_filter_name_is_line_level(self, engine):
+        # "wrapx" is not the wrap filter.
+        result = engine._render_with_wrap("X:{{test.val|wrapx}}:Y", self.CTX, max_lines=3)
+        assert result == ["X:AAAA BBBB CCCC DDDD", "EEEE:Y"]
+
+    def test_template_without_wrap_is_line_level(self, engine):
+        result = engine._render_with_wrap("NO WRAP {{test.plain}} HERE", self.CTX, max_lines=2)
+        assert result == ["NO WRAP HI HERE"]
+
+    def test_plain_variable_before_wrap_variable(self, engine):
+        # The first {{...}} has no |wrap; detection must skip it and pick
+        # {{test.val|wrap}}, leaving the rendered plain variable as prefix.
+        result = engine._render_with_wrap("{{test.plain}} {{test.val|wrap}}", self.CTX, max_lines=3)
+        assert result == ["HI AAAA BBBB CCCC DDDD", "EEEE"]
+
+    def test_render_lines_wrap_prefix_exact_rows(self, engine):
+        lines = ["{wrap}{{test.val}}", "", "", "", "", ""]
+        result = engine.render_lines(lines, self.CTX).split("\n")
+        assert [row.rstrip() for row in result] == ["AAAA BBBB CCCC DDDD", "EEEE", "", "", "", ""]
+
+    def test_render_lines_pipe_wrap_exact_rows(self, engine):
+        lines = ["{{test.val|wrap}}", "", "", "", "", ""]
+        result = engine.render_lines(lines, self.CTX).split("\n")
+        assert [row.rstrip() for row in result] == ["AAAA BBBB CCCC DDDD", "EEEE", "", "", "", ""]
+
+
+class TestWrapDetectionLinearTime:
+    """Adversarial templates must not trigger polynomial backtracking.
+
+    CodeQL alert #65 (py/polynomial-redos): the former detection regex
+    ``\\{\\{([^}]+\\|wrap(?:\\|[^}]*)?)\\}\\}`` was quadratic on unclosed
+    ``{{`` runs. Templates are user-authored (pages/API), so these inputs
+    are reachable. At the committed sizes the old code took tens of
+    seconds; the linear scanner finishes in milliseconds.
+    """
+
+    BOUND_SECONDS = 2.0
+
+    def _assert_fast(self, engine, template):
+        start = time.perf_counter()
+        engine._render_with_wrap(template, {}, max_lines=1)
+        elapsed = time.perf_counter() - start
+        assert elapsed < self.BOUND_SECONDS, f"wrap detection took {elapsed:.2f}s (bound {self.BOUND_SECONDS}s)"
+
+    def test_unclosed_brace_pipe_runs_are_linear(self, engine):
+        self._assert_fast(engine, "{{" + "{{|" * 100_000)
+
+    def test_unclosed_wrap_pipe_runs_are_linear(self, engine):
+        self._assert_fast(engine, "{{||wrap|" + "||wrap|" * 30_000)
+
+    def test_long_unclosed_variable_is_linear(self, engine):
+        self._assert_fast(engine, "{{" + "a" * 50_000)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes CodeQL alert #65 (`py/polynomial-redos`, HIGH): https://github.com/Fiestaboard/FiestaBoard/security/code-scanning/65

## What

`TemplateEngine._render_with_wrap` detected the `|wrap` filter with

```python
wrap_pattern = re.compile(r"\{\{([^}]+\|wrap(?:\|[^}]*)?)\}\}")
```

`[^}]+` followed by `\|wrap` is ambiguous, so the regex backtracks polynomially on unclosed-brace inputs — and templates are user-authored content (pages/API, see the alert's taint sources in `src/api_server.py`), so the input is uncontrolled. This PR replaces the regex with a `str.find`-based linear scanner, `TemplateEngine._find_wrap_expression` (`src/templates/engine.py`): find each `{{...}}` (content up to the first `}`, which must be followed by a second `}`), split the content on `|`, and pick the first expression with a segment exactly equal to `wrap` (lowercase, unstripped — identical to the old regex) preceded by at least one character.

Note: the alert-recommended one-line swap to `\{\{([^}]*)\}\}` + `finditer` was measured and rejected — it is still quadratic on `"{{" + "{{|"*n` (0.02s → 0.09s → 0.37s → 1.58s for n = 2k/4k/8k/16k), because every position of an all-brace input is a viable match start. The `str.find` scanner is truly O(n).

## Adversarial tests: growth-ratio assertions (machine-speed independent)

The tests originally used a 2.0s wall-clock bound; that failed on GitHub's slower shared runners (3.68s). They now assert the property itself: the same operation is timed at input size N and 4N, and growth must stay under **8x** (quadratic code grows ~16x for a 4x input), with a 1s fast-path short-circuit so fast machines never even compute the ratio. Quadratic code fails at any runner speed; linear code passes at any runner speed.

Evidence against the **old** regex (repo test container):

```
FAILED TestWrapDetectionLinearTime::test_wrap_pipe_flood_renders_in_linear_time
  AssertionError: 4x input grew 16.1x (1.28s -> 20.63s)   # "{{||wrap|" + "||wrap|" * n, n=7.5k vs 30k, end to end
FAILED TestWrapDetectionLinearTime::test_brace_pipe_flood_detection_is_linear
  # with detection swapped back to the old regex (sabotage run):
  AssertionError: 4x input grew 16.1x (1.17s -> 18.74s)   # "{{" + "{{|" * n, n=25k vs 100k, detection step
```

With the fix, all three template test modules pass in full:

```
436 passed in 0.70s     # the timed adversarial tests cost <= 30ms each
```

**Discovery from the ratio rework:** end-to-end growth on the `"{{" + "{{|"*n` brace-flood shape is *still* quadratic after this fix — but not in the detection. `_split_into_tokens`/`_count_tiles` do `text.find("}", i)` for every `{`, which is O(n²) on `}`-free brace floods (measured 0.08s → 1.10s for a 4x input; this, not runner speed alone, dominated the original CI failure). That is a pre-existing issue independent of alert #65, so that shape is asserted at the detection level (`_find_wrap_expression`) and the tile-scan quadratic is documented in the test docstring as a follow-up candidate rather than fixed here (minimal scope).

## Parity guarantee (end-user output is unchanged)

- **Fuzz/exhaustive equivalence:** the scanner was verified against the old regex on 200,000 random strings over the hostile alphabet `{}|wrapWRAP aX` (lengths 0–24) plus exhaustive enumeration of all token sequences up to length 5 — 0 mismatches in match start/end/expression.
- **Parity tests** (all pass on the old code and on the fix; each is sensitive to the detection outcome because the variable-wrap path keeps the suffix on the *first* line while the line-level path puts it on the *last*):
  - `{{x|wrap}}`, `{{x|wrap|upper}}`, `{{x|upper|wrap}}` — exact wrapped output
  - `X:{{x|wrap}}:Y` — prefix/suffix stay on the first line (variable-wrap path)
  - `{{ x | wrap }}` — whitespace never matched the old regex → stays line-level
  - `{{x|WRAP}}` — detection stays case-sensitive → stays line-level
  - `{{x|wrapx}}` — prefix-named filter is not wrap → stays line-level
  - no-wrap template → line-level
  - `{{plain}} {{y|wrap}}` — earlier plain variable is skipped; the wrap-bearing one is picked
  - `{wrap}`-prefix line path and `|wrap`-in-`render_lines` path — exact 6-row output
- **Non-vacuity:** deliberate sabotages of the new scanner were each caught — "always return None" fails `test_prefix_suffix_take_variable_wrap_path`; "strip().lower() matching" fails `test_whitespace_around_wrap_is_line_level` and `test_uppercase_wrap_is_line_level`; "old regex as detection" fails `test_brace_pipe_flood_detection_is_linear` at 16.1x; and reverting `src/templates/engine.py` to main fails both flood tests.

## Similar-shaped regexes in the same file (reported only — out of scope)

- `FILL_SPACE_REPEAT_PATTERN` / `FILLED_PATTERN` (lines 83–84) and the `\x00FILL_SPACE(?:_REPEAT:(.+?))?\x00` placeholder pattern (`_restore_fill_space`): `(.+?)\}\}`-style lazy dot before the closer; mitigated by long literal prefixes/anchors and not flagged by CodeQL.
- `strip_formatting` (`re.sub(r"\{\{[^}]*\}\}", ...)` / `re.sub(r"\{[^}]*\}", ...)`): unambiguous per-attempt but quadratic across start positions on all-`{` inputs, same class as the rejected one-line swap above; not flagged by CodeQL.
- Non-regex but same DoS class: the `_split_into_tokens`/`_count_tiles` per-`{` brace scan described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
