### PR TITLE
fix(previews): seed board previews for price_list registry plugin

### DIFF
--- a/plugin-previews.json
+++ b/plugin-previews.json
@@ -677,6 +677,56 @@
         }
       ]
     },
+    "price_list": {
+      "teaser": "LATTE ... $4.50",
+      "previews": [
+        {
+          "label": "Coffee Shop",
+          "device_type": "flagship",
+          "rows": [
+            "    {65} DAILY BREW {65}",
+            "",
+            "LATTE............$4.50",
+            "CAPPUCCINO.......$4.25",
+            "DRIP COFFEE......$3.00",
+            "{66} COLD BREW......$4.75"
+          ]
+        },
+        {
+          "label": "Brewery Tap List",
+          "device_type": "flagship",
+          "rows": [
+            "  {64} TAPROOM DRAFTS {64}",
+            "{65} HAZY IPA.......$7.00",
+            "WEST COAST IPA...$6.50",
+            "{63} AMBER ALE......$6.00",
+            "PILSNER..........$5.50",
+            "STOUT NITRO......$7.50"
+          ]
+        },
+        {
+          "label": "Happy Hour",
+          "device_type": "flagship",
+          "rows": [
+            "    {68} HAPPY HOUR {68}",
+            "",
+            "{63} HOUSE RED      $6.00",
+            "{65} DRAFT PINT     $4.00",
+            "WELL DRINKS      $5.00",
+            "{64} WINGS          $7.50"
+          ]
+        },
+        {
+          "label": "Note",
+          "device_type": "note",
+          "rows": [
+            "DAILY BREW",
+            "LATTE.....$4.50",
+            "DRIP......$3.00"
+          ]
+        }
+      ]
+    },
     "quote_of_day": {
       "teaser": "DAILY QUOTE",
       "previews": [


### PR DESCRIPTION
## What

Adds the missing `plugin-previews.json` seed entry for `price_list`, generated by `scripts/sync_plugin_previews.py` from the plugin's own manifest (teaser + 3 flagship previews + 1 note preview). No hand-authored content.

## Why

#1602 added `price_list` to `plugin-registry.json` without seeding `plugin-previews.json`. The seed-integrity tests fail on every full Platform Tests run since:

```
FAILED tests/test_plugin_previews.py::TestLoadPreviewSeed::test_shipped_seed_covers_the_registry - AssertionError: registry plugins with no seeded preview: ['price_list']
FAILED tests/test_sync_plugin_previews.py::TestSeedIntegrity::test_every_registry_plugin_has_an_entry - AssertionError: registry plugins missing from plugin-previews.json: ['price_list']
```

Main's CI path filters skipped Platform Tests on the registry-only push, so the breakage is latent on `main` and currently fails CI on unrelated PRs (#1604, #1605 — see their Platform Tests runs, which double as the failing-first evidence for these tests).

## Verification

`tests/test_plugin_previews.py` + `tests/test_sync_plugin_previews.py`: **84 passed** in the app container against this branch. Diff is a single 50-line entry insertion; nothing else in the seed changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)