### PR TITLE
ci: move every workflow to Node 24 and gate out image-size's DoS image formats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,7 +365,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v7
       with:
-        node-version: '20'
+        node-version: '24'
         cache: 'npm'
         cache-dependency-path: docs-site/package-lock.json
 
@@ -1155,7 +1155,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v7
       with:
-        node-version: '20'
+        node-version: '24'
         cache: 'npm'
         cache-dependency-path: docs-site/package-lock.json
 
@@ -1219,7 +1219,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v7
       with:
-        node-version: '22'
+        node-version: '24'
         cache: 'npm'
         cache-dependency-path: package-lock.json
 
@@ -1262,10 +1262,30 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  # `@docusaurus/mdx-loader` sizes every Markdown-referenced image with
+  # `image-size`, whose ICNS/JXL/HEIF parsers have two high-severity
+  # infinite-loop advisories and no patched version — the project was
+  # archived with the affected 2.0.2 as its final release. A crafted image
+  # would hang the docs build rather than fail it, so those formats are
+  # refused at the gate instead. See issue #1578.
+  #
+  # Deliberately unconditional: an image can be added under any path filter
+  # (docs/, docs-site/, plugins/*/docs/), and the check is a few seconds.
+  check-image-formats:
+    name: Check Image Formats
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Reject ICNS/HEIF/JXL content
+      run: python3 scripts/check_image_formats.py
+
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [detect-changes, dependency-review, test-platform, test-plugins, lint-web, lint-docs, test-ui, a11y-tests, build-test-image, e2e-tests, ai-mcp-e2e-tests, auth-e2e-tests, ingress-e2e-tests, build, build-docs, lint-markdown, link-check]
+    needs: [detect-changes, dependency-review, test-platform, test-plugins, lint-web, lint-docs, test-ui, a11y-tests, build-test-image, e2e-tests, ai-mcp-e2e-tests, auth-e2e-tests, ingress-e2e-tests, build, build-docs, lint-markdown, link-check, check-image-formats]
     if: always()
     steps:
       - name: Check all jobs passed or were skipped
@@ -1291,6 +1311,7 @@ jobs:
             build-docs
             lint-markdown
             link-check
+            check-image-formats
           RESULTS: ${{ toJSON(needs.*.result) }}
         run: |
           python3 - <<'PY'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
           cache: npm
           cache-dependency-path: docs-site/package-lock.json
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -484,9 +484,27 @@ jobs:
       # publish step below already tolerates a missing summary file, so any
       # transient API failure just ships the release without AI bullets
       # instead of blocking the release entirely.
+      #
+      # Pinned to a SHA rather than @beta: the `beta` tag still points at
+      # e8132bc, whose nested `actions/setup-node@v4.4.0` and
+      # `oven-sh/setup-bun@v2.0.2` both declare `runs.using: node20`. The
+      # runner now executes those on Node 24 anyway and prints a deprecation
+      # notice; the only opt-out is literally named
+      # ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION. The mirror has not cut a tag
+      # since v0.0.63 (Aug 2025) but `main` still syncs daily, and this SHA
+      # pins setup-node v6.4.0 + setup-bun v2.2.0 — both node24. Re-point at
+      # an immutable tag if upstream ever tags again. See issue #1577.
+      #
+      # This also fixes a silent no-op: e8132bc predates `claude_args`, so
+      # every release since logged "Unexpected input(s) 'claude_args'" and
+      # ran without the --model and --allowed-tools below.
       - name: Generate AI summary with Claude
         continue-on-error: true
-        uses: anthropics/claude-code-base-action@beta
+        uses: anthropics/claude-code-base-action@f1b5c5c49125f0e6adc48c1203ebd77f83ea9adb
+        env:
+          # The action defaults the CLI's runtime to 18.x; align it with the
+          # Node 24 the rest of this repo's workflows use.
+          NODE_VERSION: '24'
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: '--model claude-sonnet-4-6 --allowed-tools "Read,Write"'

--- a/scripts/check_image_formats.py
+++ b/scripts/check_image_formats.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Refuse image formats that reach ``image-size``'s unpatchable DoS parsers.
+
+The docs site builds with Docusaurus, and ``@docusaurus/mdx-loader`` hands
+every Markdown-referenced image to ``image-size`` at build time::
+
+    const size = await imageSizeFromFile(imagePath)
+
+Two high-severity advisories against ``image-size`` have no patched version,
+and never will: the project was archived on 2026-06-03 with ``2.0.2`` -- the
+affected release -- as its last.
+
+  GHSA-w3rx-r6r6-pgpr  ICNS parser hangs on a zero-valued entry-length field
+  GHSA-5p2g-fcmc-qvqq  JXL and HEIF parsers hang on a zero-sized box
+
+Both are infinite loops that block the Node event loop permanently, so a
+single crafted image committed here would wedge the docs build forever rather
+than fail it. Exposure is build-time only -- the deployed site is static HTML
+and ``image-size`` never sees runtime input -- so the realistic threat is a
+malicious image reaching the repo. Those three parsers are the only way in,
+which makes refusing their formats at the gate a complete mitigation for the
+path we actually have. Tracked as issue #1578; drop this once Docusaurus ships
+facebook/docusaurus#12235, which replaces the dependency outright.
+
+``image-size`` dispatches on magic bytes and ignores file extensions, so this
+matches on content exactly the way its own ``validate()`` functions do -- a
+crafted ICNS renamed to ``.png`` is still parsed as ICNS.
+
+Usage::
+
+    python scripts/check_image_formats.py            # every tracked file
+    python scripts/check_image_formats.py a.png b.icns
+"""
+
+import subprocess
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+
+# `brandMap` in image-size's lib/types/heif.ts. A file is only routed to the
+# HEIF parser when its `ftyp` brand is one of these, which is what keeps MP4
+# and MOV -- same `ftyp` header, different brand -- out of scope.
+HEIF_BRANDS = frozenset({b"avif", b"mif1", b"msf1", b"heic", b"heix", b"hevc", b"hevx"})
+
+# Enough to cover the `ftyp` box, which is the first or second box in every
+# ISO-BMFF variant. Nothing here needs the rest of the file.
+HEAD_BYTES = 4096
+
+# A malformed file can declare boxes that advance the offset by the 8-byte
+# minimum forever; image-size's own walker is what the advisory is about, so
+# this one is explicitly bounded.
+MAX_BOXES = 32
+
+
+def _walk_boxes(data: bytes) -> Iterable[tuple[bytes, int, int]]:
+    """Yield ``(name, offset, size)`` for each ISO-BMFF box in ``data``.
+
+    Mirrors ``findBox`` in image-size, including its ``size > 0 ? size : 8``
+    fallback, so that this agrees with the parser it is protecting.
+    """
+    offset = 0
+    for _ in range(MAX_BOXES):
+        if offset < 0 or offset + 8 > len(data):
+            return
+        size = int.from_bytes(data[offset : offset + 4], "big")
+        name = data[offset + 4 : offset + 8]
+        yield name, offset, size
+        offset += size if size > 0 else 8
+
+
+def _ftyp_brand(data: bytes) -> bytes | None:
+    """The brand of the first ``ftyp`` box, or ``None`` if there isn't one."""
+    for name, offset, _size in _walk_boxes(data):
+        if name == b"ftyp":
+            brand = data[offset + 8 : offset + 12]
+            return brand if len(brand) == 4 else None
+    return None
+
+
+def detect_blocked_format(data: bytes) -> str | None:
+    """Return the vulnerable parser ``data`` would reach, or ``None``.
+
+    ``data`` may be a truncated head of the file; only the first few bytes
+    matter to any of these checks.
+    """
+    # ICNS: toUTF8String(input, 0, 4) === "icns"
+    if data[:4] == b"icns":
+        return "ICNS"
+
+    # JXL, naked codestream: toHexString(input, 0, 2) === "ff0a"
+    if data[:2] == b"\xff\x0a":
+        return "JXL"
+
+    # JXL, container: a "JXL " box, then an ftyp box branded "jxl "
+    if data[4:8] == b"JXL " and _ftyp_brand(data) == b"jxl ":
+        return "JXL"
+
+    # HEIF (and AVIF): an ftyp box whose brand is in image-size's brandMap
+    if data[4:8] == b"ftyp" and _ftyp_brand(data) in HEIF_BRANDS:
+        return "HEIF"
+
+    return None
+
+
+def scan_paths(paths: Iterable[Path]) -> list[tuple[Path, str]]:
+    """Return ``(path, format)`` for every path that would hit a bad parser.
+
+    Paths that are missing, unreadable, or directories are skipped -- this is
+    a content check, not a filesystem audit.
+    """
+    findings: list[tuple[Path, str]] = []
+    for path in paths:
+        try:
+            with open(path, "rb") as fh:
+                head = fh.read(HEAD_BYTES)
+        except (OSError, ValueError):
+            continue
+
+        blocked = detect_blocked_format(head)
+        if blocked:
+            findings.append((path, blocked))
+    return findings
+
+
+def tracked_files(root: Path) -> list[Path]:
+    """Every file git tracks under ``root``."""
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=root,
+        capture_output=True,
+        check=True,
+    )
+    return [root / name.decode() for name in result.stdout.split(b"\0") if name]
+
+
+def main(argv: list[str]) -> int:
+    root = Path(__file__).parent.parent
+    paths = [Path(a) for a in argv] if argv else tracked_files(root)
+
+    findings = scan_paths(paths)
+    if not findings:
+        print(f"OK: no ICNS/HEIF/JXL content in {len(paths)} files checked.")
+        return 0
+
+    for path, blocked in findings:
+        try:
+            shown = path.relative_to(root)
+        except ValueError:
+            shown = path
+        print(
+            f"::error file={shown}::{shown} is {blocked} content, which "
+            f"@docusaurus/mdx-loader parses with image-size -- a parser with "
+            f"two unpatchable infinite-loop advisories "
+            f"(GHSA-w3rx-r6r6-pgpr, GHSA-5p2g-fcmc-qvqq) that would hang the "
+            f"docs build. Convert it to PNG, JPEG, WebP or SVG. See issue "
+            f"#1578."
+        )
+
+    print(
+        f"\nFAIL: {len(findings)} file(s) use an image format that reaches an unpatched image-size parser.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/test_check_image_formats.py
+++ b/tests/test_check_image_formats.py
@@ -1,0 +1,135 @@
+"""The gate that keeps ``image-size``'s unpatchable DoS parsers unreachable.
+
+``scripts/check_image_formats.py`` refuses to let ICNS, HEIF or JXL files into
+the repo, because ``@docusaurus/mdx-loader`` hands every Markdown-referenced
+image to ``image-size``, whose ICNS/JXL/HEIF parsers hang the Node event loop
+forever on crafted input and will never be patched (see issue #1578).
+
+``image-size`` dispatches on magic bytes, not on file extension, so the two
+things worth guarding are that the checker matches on content the same way
+``image-size``'s own ``validate()`` does, and that it does not fire on the
+formats the repo actually uses -- including ISO-BMFF containers such as MP4,
+which share HEIF's ``ftyp`` header and differ only by brand.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.check_image_formats import (
+    MAX_BOXES,
+    _walk_boxes,
+    detect_blocked_format,
+    scan_paths,
+)
+
+REPO_ROOT = Path(__file__).parent.parent
+
+PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 64
+JPEG = b"\xff\xd8\xff\xe0" + b"\x00" * 64
+GIF = b"GIF89a" + b"\x00" * 64
+SVG = b'<svg xmlns="http://www.w3.org/2000/svg"></svg>'
+
+
+def _ftyp(brand: bytes, *, size: int = 32) -> bytes:
+    """An ISO-BMFF file whose first box is ``ftyp`` carrying ``brand``."""
+    box = size.to_bytes(4, "big") + b"ftyp" + brand + b"\x00" * 4
+    return box.ljust(size, b"\x00")
+
+
+def _jxl_container() -> bytes:
+    """The JXL box format: a 12-byte ``JXL `` signature, then ``ftyp jxl ``."""
+    signature = (12).to_bytes(4, "big") + b"JXL " + b"\x0d\x0a\x87\x0a"
+    ftyp = (20).to_bytes(4, "big") + b"ftyp" + b"jxl " + b"\x00" * 8
+    return signature + ftyp
+
+
+class TestBlockedFormatsAreDetected:
+    def test_icns_magic_is_blocked(self):
+        assert detect_blocked_format(b"icns" + b"\x00" * 64) == "ICNS"
+
+    def test_naked_jxl_codestream_is_blocked(self):
+        assert detect_blocked_format(b"\xff\x0a" + b"\x00" * 64) == "JXL"
+
+    def test_jxl_container_is_blocked(self):
+        assert detect_blocked_format(_jxl_container()) == "JXL"
+
+    def test_zero_sized_signature_box_does_not_hide_the_jxl_brand(self):
+        """A box declaring size 0 -- the shape both advisories turn on.
+
+        ``image-size``'s ``findBox`` advances by 8 rather than by the declared
+        0, so an attacker who declares 0 and puts a valid ``ftyp`` at offset 8
+        still gets the file routed to the JXL parser. Trusting the declared
+        size instead would walk in place and let that payload past the gate.
+        """
+        payload = (0).to_bytes(4, "big") + b"JXL " + (20).to_bytes(4, "big") + b"ftyp" + b"jxl " + b"\x00" * 32
+
+        assert detect_blocked_format(payload) == "JXL"
+
+    @pytest.mark.parametrize("brand", [b"avif", b"mif1", b"msf1", b"heic", b"heix", b"hevc", b"hevx"])
+    def test_every_heif_brand_image_size_recognises_is_blocked(self, brand):
+        assert detect_blocked_format(_ftyp(brand)) == "HEIF"
+
+
+class TestSupportedFormatsAreNotBlocked:
+    @pytest.mark.parametrize("data", [PNG, JPEG, GIF, SVG], ids=["png", "jpeg", "gif", "svg"])
+    def test_formats_the_docs_actually_use_pass(self, data):
+        assert detect_blocked_format(data) is None
+
+    @pytest.mark.parametrize("brand", [b"isom", b"mp42", b"qt  "], ids=["mp4", "mp4v2", "mov"])
+    def test_iso_bmff_video_shares_the_ftyp_header_but_is_not_blocked(self, brand):
+        """MP4/MOV also start with an ``ftyp`` box; only the brand separates them."""
+        assert detect_blocked_format(_ftyp(brand)) is None
+
+    def test_empty_file_is_not_blocked(self):
+        assert detect_blocked_format(b"") is None
+
+    def test_file_shorter_than_the_magic_bytes_does_not_crash(self):
+        assert detect_blocked_format(b"ic") is None
+
+    def test_zero_sized_boxes_without_a_known_brand_are_not_blocked(self):
+        payload = (0).to_bytes(4, "big") + b"free" + b"\x00" * 256
+        assert detect_blocked_format(payload) is None
+
+
+class TestBoxWalkerIsBounded:
+    def test_walker_stops_after_max_boxes(self):
+        """Unbounded, this walker would be the very bug it is guarding against."""
+        pathological = ((0).to_bytes(4, "big") + b"free") * 512
+
+        assert len(list(_walk_boxes(pathological))) == MAX_BOXES
+
+
+class TestScanPaths:
+    def test_offending_file_is_reported_with_its_format(self, tmp_path):
+        bad = tmp_path / "logo.png"  # extension lies; content is what matters
+        bad.write_bytes(b"icns" + b"\x00" * 64)
+
+        assert scan_paths([bad]) == [(bad, "ICNS")]
+
+    def test_clean_file_produces_no_findings(self, tmp_path):
+        good = tmp_path / "logo.png"
+        good.write_bytes(PNG)
+
+        assert scan_paths([good]) == []
+
+    def test_unreadable_path_is_skipped_rather_than_raising(self, tmp_path):
+        assert scan_paths([tmp_path / "does-not-exist.png"]) == []
+
+    def test_directories_are_skipped(self, tmp_path):
+        assert scan_paths([tmp_path]) == []
+
+
+class TestRepositoryIsClean:
+    def test_no_tracked_file_in_this_repo_reaches_a_vulnerable_parser(self):
+        """The check the CI job runs. Failing here means a bad image landed."""
+        result = subprocess.run(
+            [sys.executable, "scripts/check_image_formats.py"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
Fixes #1577. Fixes #1578.

Two issues that both reduce to *the runtime under the docs build is not the one we think it is*.

## #1577 — Node 20 deprecation

The Release workflow's `Generate AI summary with Claude` step prints a Node 20 deprecation notice on every run. The cause is upstream: `claude-code-base-action@beta` still points at `e8132bc`, whose nested `actions/setup-node@v4.4.0` and `oven-sh/setup-bun@v2.0.2` both declare `runs.using: node20`. The runner executes them on Node 24 anyway, and the documented opt-out is literally named `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION`.

`claude-code-action@v1` is node24-clean but rejects `push` events — that's what broke every release after v7.3.0, so it isn't the escape hatch. The mirror hasn't cut a tag since `v0.0.63`, but `main` still syncs daily and now pins `setup-node@v6.4.0` + `setup-bun@v2.2.0`, both node24. Pinned to that SHA (`f1b5c5c`), with `NODE_VERSION: '24'` so the CLI runtime matches the rest of the repo rather than the action's `18.x` default. Re-point at an immutable tag if upstream ever tags again.

**The pin also fixes a silent no-op.** `e8132bc` predates the `claude_args` input, so every release has been logging:

```
##[warning]Unexpected input(s) 'claude_args', valid inputs are ['prompt', 'prompt_file', 'allowed_tools', ...]
  claude_args: --model claude-sonnet-4-6 --allowed-tools "Read,Write"
```

— i.e. the release summary has been running without `--model` or `--allowed-tools` for a while. `continue-on-error: true` kept it invisible. ([run 31671602901](https://github.com/Fiestaboard/FiestaBoard/actions/runs/31671602901))

**Our own workflows**, separately: three jobs still asked for Node 20 (EOL 2026-04-30) and one for Node 22, while everything else used 24. All four now use 24 — no `node-version` in the repo is off 24.

I re-audited every third-party action at its pinned ref; `claude-code-base-action` was the only node20 left, so this closes the issue rather than deferring it.

## #1578 — `image-size` DoS advisories

There is no dependency bump that fixes this, and there never will be: **`image-size` was archived on 2026-06-03** with the affected `2.0.2` as its final release. `@docusaurus/mdx-loader@3.10.2` — and even `@canary` — still declare `^2.0.2`, and aliasing to `image-dimensions` breaks the build because mdx-loader imports `image-size/fromFile`, which that package doesn't export.

Both advisories are **infinite loops**, so a crafted image doesn't fail the docs build — it hangs it forever. I confirmed that rather than assuming it, with the payload described in GHSA-w3rx-r6r6-pgpr (valid `icns` magic, zero-valued entry length) against real `image-size@2.0.2`:

```
$ timeout 10 node -e 'imageSizeFromFile("/w/evil.icns").then(...)'
HUNG — killed by timeout (exit 124). Advisory reproduced.
```

Those three parsers are the *only* way to reach the bug, so this refuses their formats at the gate, which makes the vulnerable code unreachable via the path we actually have. `scripts/check_image_formats.py` matches on **magic bytes**, mirroring `image-size`'s own `validate()` functions — extension-based blocking would be trivially bypassed, since `image-size` ignores extensions entirely:

```
$ python scripts/check_image_formats.py /w/innocent-looking.png
::error file=...::... is ICNS content, which @docusaurus/mdx-loader parses with image-size ...
exit=1
```

It runs as a new unconditional `Check Image Formats` CI job — deliberately not path-filtered, since an image can land under `docs/`, `docs-site/`, or `plugins/*/docs/`, and the check takes seconds. Zero tracked files currently trip it.

Remove the whole thing once Docusaurus ships facebook/docusaurus#12235, which drops the dependency outright.

## Verification

**Non-vacuity.** Tests were written first and watched fail (`ModuleNotFoundError`). Then each guard was individually broken in the production code to confirm the suite catches it:

| Mutation | Result |
|---|---|
| drop the ICNS magic check | 2 failed |
| accept any `ftyp` brand as HEIF | 3 failed |
| trust the declared box size (drop the zero-size fallback) | 1 failed |
| drop the naked-JXL codestream check | 1 failed |
| unbound the box walker | 1 failed |

The first pass surfaced a genuinely vacuous test of my own: `test_zero_sized_box_does_not_hang_the_walker` survived removing the zero-size fallback, because `MAX_BOXES` masked it. Replaced with `test_zero_sized_signature_box_does_not_hide_the_jxl_brand`, which uses the attacker-reachable shape — a `JXL ` box declaring size 0 whose follow-on bytes are crafted into a valid `ftyp` at offset 8, exactly where `image-size`'s `findBox` lands. That one does fail when the fallback is removed.

27 tests pass. Coverage includes the false-positive direction: MP4/MOV share HEIF's `ftyp` header and are separated only by brand, so they're asserted *not* blocked.

**Node 24 bump**, run in throwaway containers rather than assumed:

- `docs-site`: `npm ci && npm run typecheck && npm run lint && npm run build` on `node:24` → clean, exit 0. Only the known pre-existing postcss-calc `infinity * 1px` warning.
- root docs tooling: `docs:lint:frontmatter` (63 files), `docs:lint:markdown` (99 files, 0 issues), `docs:lint:spell` (99 files, 0 issues) on `node:24` → all pass.
- `ruff==0.16.2` (the pinned version) `check` + `format --check` over `src/ plugins/ tests/ scripts/` → clean, 294 files.

**`ci-success` bookkeeping.** That job pairs `NAMES` with `needs.*.result` positionally. I verified against a real run that `needs.*` follows *declaration* order, not alphabetical (alphabetical mismatches at position 3), so the new job is appended to both lists.

## Note on scope

#1578 was filed as track-don't-fix, and that assessment was right about the dependency — nothing to bump. This doesn't upgrade anything; it closes the reachable path instead, which is why I think it's closable rather than perpetually open. If you'd rather keep it open to track facebook/docusaurus#12235, drop the `Fixes #1578` and the guard still stands on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
