### PR TITLE
chore(deps): resolve npm install deprecation warnings

### DIFF
--- a/docs-site/package-lock.json
+++ b/docs-site/package-lock.json
@@ -9870,28 +9870,36 @@
       }
     },
     "node_modules/encoding-sniffer": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
-      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-1.0.2.tgz",
+      "integrity": "sha512-dlQ0jlnDJ2ElE1Ky4crYX0pPEPxQY9F2j+ZMIXlBedLJToEfDed9pvPqXg4fZnuu4qVBbcIrZVeg3S4aibTYGw==",
       "license": "MIT",
       "dependencies": {
-        "iconv-lite": "^0.6.3",
-        "whatwg-encoding": "^3.1.1"
+        "@exodus/bytes": "^1.15.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       },
       "funding": {
+        "type": "github",
         "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
       }
     },
-    "node_modules/encoding-sniffer/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+    "node_modules/encoding-sniffer/node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
       "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
       "engines": {
-        "node": ">=0.10.0"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/enhanced-resolve": {
@@ -22241,31 +22249,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.8.0"
-      }
-    },
-    "node_modules/whatwg-encoding": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
-      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "0.6.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/whatwg-mimetype": {

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -53,7 +53,8 @@
     "js-yaml@^4.0.0": "^4.3.1",
     "nanoid@^3.0.0": "^3.3.17",
     "http-proxy-middleware@^2.0.0": "^2.0.10",
-    "@babel/core": "^7.29.7"
+    "@babel/core": "^7.29.7",
+    "encoding-sniffer": "^1.0.2"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.9.2",


### PR DESCRIPTION
Fixes #1576

Reproduced the warning block fresh in all three packages (root, `web/`, `docs-site/`, Node 26 / npm 11) and traced every warning to its direct parent. One turned out to be actionable — and it was hiding in `docs-site/`, which the previous investigation passes (which ran in `web/`) never covered.

| Deprecated dep | Where | Parent chain | Action |
| --- | --- | --- | --- |
| `whatwg-encoding@3.1.1` | docs-site | `@easyops-cn/docusaurus-search-local` → `cheerio@1.2.0` → `encoding-sniffer@0.2.1` | **Fixed**: override `encoding-sniffer` → `^1.0.2`, which swaps `whatwg-encoding` + `iconv-lite` for `@exodus/bytes` (the exact replacement the deprecation notice recommends) |
| `expect-playwright@0.8.0` | web | `@storybook/test-runner@0.24.4` (direct dep) | Blocked upstream — re-verified today: latest is still 0.24.4 (2026-05-14); both `0.24.4` and `0.24.5-next.0` tarballs still list it |
| `jest-process-manager@0.4.0` | web | `@storybook/test-runner@0.24.4` (direct dep) | Blocked upstream — storybookjs/test-runner#598 still open/unreviewed; no release removes it |
| `glob@7.2.3` + `inflight@1.0.6` + `rimraf@3.0.2` | web | `@storybook/test-runner` → `nyc@15.1.0` (latest) + its own `rimraf ^3` | Not safely overridable: nyc needs glob v7's callback API; rimraf v4 changed its API |
| `glob@10.5.0` (×3) | web | `@storybook/test-runner` → jest 30 internals (`jest-runtime`, `@jest/reporters`, `jest-config` pin `^10.3.10`) | Not safely overridable inside jest internals (a11y CI critical path) |
| `glob@11.1.0`, `source-map@0.8.0-beta.0` | web | `vite-plugin-pwa@1.3.0` → `workbox-build@7.4.1` (both latest) | workbox-build deliberately pins both; no non-deprecated in-range replacement for the source-map beta; overriding inside the service-worker bundler is not worth the risk |

The `web/` rows match the standing decision already recorded in #1576 (accepted noise / wait for upstream) — re-verified against the registry today rather than assumed. Trigger to revisit: a published `@storybook/test-runner` whose `dependencies` no longer list `jest-process-manager`.

## Safety of the override

`encoding-sniffer` 0.2.1 → 1.0.2 keeps the exact API cheerio consumes — `decodeBuffer(buffer, options?)` and `new DecodeStream(options?)` (verified against both packages' published typings and cheerio 1.2.0's compiled output). Only the decoding backend changes. Note: `encoding-sniffer@1.0.2` declares `engines.node >=20.19.0`; docs-site CI runs Node 24.

## Verification (all run locally on this branch)

- `docs-site`: fresh `npm ci` — **zero deprecation warnings**; `npm ls whatwg-encoding` → empty; lockfile diff is tightly scoped (encoding-sniffer bump, `whatwg-encoding` + nested `iconv-lite` removed, `@exodus/bytes` added)
- `docs-site`: `npm run lint`, `npm run typecheck`, `npm run format:check` — all pass
- `docs-site`: `DOCS_PR_MODE=1 npm run build` — succeeds, `search-index.json` generated (exercises the search-local → cheerio path)
- root: `npm ci` already emitted no deprecation warnings (unchanged)
- `web/`: unchanged in this PR; `npm ci --legacy-peer-deps` still emits the storybook-test-runner/workbox block documented above

🤖 Generated with [Claude Code](https://claude.com/claude-code)