### PR TITLE
chore(web): bump @fiestaboard/ui to ^3.0.0

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -27,7 +27,7 @@
     "@codemirror/language": "^6.12.4",
     "@codemirror/state": "^6.7.1",
     "@codemirror/view": "^6.43.8",
-    "@fiestaboard/ui": "2.2.6",
+    "@fiestaboard/ui": "^3.0.0",
     "@lezer/highlight": "^1.2.3",
     "@microsoft/fetch-event-source": "^2.0.1",
     "@react-router/fs-routes": "^8.3.0",


### PR DESCRIPTION
## Summary

Adopts FiestaUI 3.0.0 (Fiestaboard/FiestaUI#213), which reorganizes component files into functional group folders and restructures the Storybook taxonomy.

**No code changes needed**: all `web/` imports use the root barrel export of `@fiestaboard/ui`, which is unchanged in 3.0.0. Only deep-import subpaths moved, and `web/` uses none. `docs-site/` is unaffected — it vendors its own pinned tarball (`vendor/fiestaboard-ui-1.5.0.tgz`) and upgrades on its own cadence.

## Blocked on

- [ ] Fiestaboard/FiestaUI#213 merging and v3.0.0 publishing to npm
- [ ] After publish: run `npm install` in `web/` to refresh `package-lock.json`, then mark ready for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)