### PR TITLE
fix(sync): protect the site repo's generated docs/README.md banner

### DIFF
--- a/scripts/publish-docs.sh
+++ b/scripts/publish-docs.sh
@@ -111,10 +111,12 @@ copy_file() {
 
 echo "==> syncing allowlisted content"
 # docs/** minus docs/internal/**. Excluded paths are protected from --delete,
-# so .source-sha (rewritten below) and any stray target-side internal/ are
-# never copied; internal/ is additionally purged in case it ever leaked.
+# so .source-sha (rewritten below), the site repo's generated /README.md
+# banner (no such file exists on the source side), and any stray target-side
+# internal/ are never copied; internal/ is additionally purged in case it
+# ever leaked.
 mirror_dir "$SRC_ROOT/docs" "$TARGET_DIR/docs" \
-  --exclude='/internal/' --exclude='/.source-sha'
+  --exclude='/internal/' --exclude='/.source-sha' --exclude='/README.md'
 rm -rf "$TARGET_DIR/docs/internal"
 
 copy_file "$SRC_ROOT/plugin-registry.json" "$TARGET_DIR/data/plugin-registry.json"


### PR DESCRIPTION
The publish-docs mirror's `--delete` would remove the target-side generated banner README on every sync, since no `docs/README.md` exists on the source side. Exclude it the same way as `.source-sha`.

Found during Phase 1 rehearsals of the docs-site extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)