### PR TITLE
ci: point docs sync at the site repo main

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -33,7 +33,7 @@ jobs:
           # RELEASE_PAT: PAT with push access to Fiestaboard/fiestaboard.github.io
           # (GITHUB_TOKEN cannot push cross-repo).
           RELEASE_PAT: ${{ secrets.RELEASE_PAT }}
-          # Default target branch is sync-test until the sync is promoted;
-          # override here (e.g. to "source") when cutting over.
-          SYNC_TARGET_BRANCH: sync-test
+          # main is the production source branch on the site repo; pushes to it
+          # trigger build-deploy.yml, which builds and deploys fiestaboard.app.
+          SYNC_TARGET_BRANCH: main
         run: scripts/publish-docs.sh


### PR DESCRIPTION
## Summary

Cutover: the site repo (Fiestaboard/fiestaboard.github.io) `main` branch is now the production source — pushes to it trigger `build-deploy.yml`, which builds and deploys fiestaboard.app via Actions.

This promotes the docs sync in `publish-docs.yml` from the `sync-test` staging branch to `main`. The sync push uses `RELEASE_PAT` (a real PAT, not `GITHUB_TOKEN`), so the push will natively trigger the site repo's build-deploy workflow.

One-line change: `SYNC_TARGET_BRANCH: sync-test` → `SYNC_TARGET_BRANCH: main` (plus updated comment).

## Test plan

- [ ] CI checks green on this PR
- [ ] After merge: canary docs change on `main` round-trips to the site repo `main` and deploys to fiestaboard.app

🤖 Generated with [Claude Code](https://claude.com/claude-code)