### PR TITLE
test: CI drill (must fail)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,3 +146,5 @@ If you discover a security issue, do **not** open a public issue. See [SECURITY.
 - For bugs or feature ideas, use the issue tracker and keep one topic per issue.
 
 Thanks for contributing.
+
+* CI drill: deliberate MD004 violation (asterisk bullet where config requires dash)


### PR DESCRIPTION
Deliberate failure drill: verifies the required `CI Success` context can actually go red after the docs-site removal. Contains an intentional MD004 markdownlint violation in CONTRIBUTING.md. **Do not merge** — will be closed once the check-set is recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)