### PR TITLE
test: docs-only drill

### DIFF
--- a/docs/setup/quick-start.md
+++ b/docs/setup/quick-start.md
@@ -6,7 +6,7 @@ keywords: [FiestaBoard quick start, FiestaPi, Docker setup, getting started, Ves
 
 # Quick Start
 
-Get FiestaBoard running in under 5 minutes. There are two supported paths:
+Get FiestaBoard up and running in under 5 minutes. There are two supported paths:
 
 1. **Flash a Raspberry Pi with FiestaPi** — the easiest route for anyone, technical or not.
 2. **Run with Docker** on a computer or home server you already own.


### PR DESCRIPTION
Docs-only check-set drill after the docs-site removal: trivial wording edit to `docs/setup/quick-start.md` only. Verifies the docs jobs (Lint Docs Site / Build Docs) are gone and Lint Markdown / Check Markdown Links / CI Success run and pass. **Do not merge** — will be closed after recording checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)