### PR TITLE
test: code-only drill

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -10249,3 +10249,5 @@ if __name__ == "__main__":
     import uvicorn
 
     uvicorn.run(app, host="0.0.0.0", port=8000)
+
+# CI drill: no-op comment to exercise the code-path check-set. Safe to remove.


### PR DESCRIPTION
Code-only check-set drill after the docs-site removal: no-op comment appended to `src/api_server.py` only. Verifies Platform Tests run and pass while docs jobs skip, and CI Success passes. **Do not merge** — will be closed after recording checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)