### PR TITLE
chore: extraction cleanup — README logo URLs + docs SLA

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,7 +211,7 @@ GitHub Actions.
 - Never edit site code (Docusaurus config, theme, components) here — that
   all belongs to the site repo. Edit only the markdown under `docs/`.
 - Docs merge-to-live SLA: a docs change merged to `main` here is live on
-  fiestaboard.app after the sync + site build (measured at cutover: ~N min).
+  fiestaboard.app after the sync + site build (measured at cutover: ~4 min).
 
 ### Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,8 @@
 <h1 align="center">
   <picture>
-    <!-- TODO(docs-extraction): flip these three srcset/src paths to
-         https://fiestaboard.app/img/branding/... once the branding sync
-         (publish-docs.sh, path fixed in PR 9) has landed on the site
-         repo's main — the URLs 404 until then. -->
-    <source media="(prefers-color-scheme: dark)" srcset="assets/img/branding/logo-lockup-dark.png">
-    <source media="(prefers-color-scheme: light)" srcset="assets/img/branding/logo-lockup-light.png">
-    <img alt="FiestaBoard" src="assets/img/branding/logo-lockup-light.png" width="320">
+    <source media="(prefers-color-scheme: dark)" srcset="https://fiestaboard.app/img/branding/logo-lockup-dark.png">
+    <source media="(prefers-color-scheme: light)" srcset="https://fiestaboard.app/img/branding/logo-lockup-light.png">
+    <img alt="FiestaBoard" src="https://fiestaboard.app/img/branding/logo-lockup-light.png" width="320">
   </picture>
 </h1>
 


### PR DESCRIPTION
Final cleanup after the docs-site extraction (#1619).

## Changes

**README.md** — the `<picture>` logo block still pointed at local `assets/img/branding/*` paths with a `TODO(docs-extraction)` comment, left because `https://fiestaboard.app/img/branding/*` 404'd at the time of the removal PR. Those URLs now serve `200 image/png` (verified with curl, filenames confirmed against `static/img/branding/` on `Fiestaboard/fiestaboard.github.io` main). All three sources repointed and the TODO removed:

- dark: `https://fiestaboard.app/img/branding/logo-lockup-dark.png` (`prefers-color-scheme: dark`)
- light: `https://fiestaboard.app/img/branding/logo-lockup-light.png` (`prefers-color-scheme: light`)
- `<img>` fallback: light variant

**CLAUDE.md** — filled in the docs merge-to-live SLA placeholder (`~N min` → `~4 min`), measured at cutover on 2026-08-15: docs commit 19:41:19Z → live build-info 19:45:26Z.

## Verification

- Both branding URLs curl-verified `200` with `content-type: image/png`
- `npx markdownlint-cli2` clean on the repo (0 issues in 99 files)
- CI link check (lychee) will validate the new URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)