### PR TITLE
fix(editor): stop dropping filter arguments when saving a template

### DIFF
--- a/web/src/__tests__/tiptap-serialization.test.ts
+++ b/web/src/__tests__/tiptap-serialization.test.ts
@@ -84,3 +84,52 @@ describe("Simple serialization – 3-line mode (Note)", () => {
     });
   });
 });
+
+describe("Variable filter arguments survive the round-trip", () => {
+  it("preserves a single filter argument (|pad:3)", () => {
+    const doc = parseTemplateSimple("{{weather.temp|pad:3}}", 3);
+    const firstLine = serializeTemplateSimple(doc, 3).split("\n")[0];
+    expect(firstLine).toBe("{{weather.temp|pad:3}}");
+  });
+
+  it("preserves arguments on every filter in a chain", () => {
+    const doc = parseTemplateSimple("{{weather.temp|pad:3|truncate:5}}", 3);
+    const firstLine = serializeTemplateSimple(doc, 3).split("\n")[0];
+    expect(firstLine).toBe("{{weather.temp|pad:3|truncate:5}}");
+  });
+
+  it("preserves a filter argument on a variable surrounded by text", () => {
+    const doc = parseTemplateSimple("A {{weather.temp|pad:3}} B", 3);
+    const firstLine = serializeTemplateSimple(doc, 3).split("\n")[0];
+    expect(firstLine).toBe("A {{weather.temp|pad:3}} B");
+  });
+
+  // Guards against a wrong fix, not the bug itself: this passes before and
+  // after. It fails if someone writes an unconditional `:${f.arg}`.
+  it("emits no colon for an argument-less filter", () => {
+    const doc = parseTemplateSimple("{{weather.temp|wrap}}", 3);
+    const firstLine = serializeTemplateSimple(doc, 3).split("\n")[0];
+    expect(firstLine).toBe("{{weather.temp|wrap}}");
+  });
+
+  // Also passes before and after: it pins the legacy plural branch so a future
+  // "fix" that merely renames args -> arg cannot silently drop it.
+  it("still serializes a legacy plural-args filter attribute", () => {
+    const doc = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "variable",
+              attrs: { pluginId: "weather", field: "temp", filters: [{ name: "pad", args: ["3"] }] },
+            },
+          ],
+        },
+      ],
+    };
+    const firstLine = serializeTemplateSimple(doc, 3).split("\n")[0];
+    expect(firstLine).toBe("{{weather.temp|pad:3}}");
+  });
+});

--- a/web/src/components/tiptap-template-editor/utils/serialization.ts
+++ b/web/src/components/tiptap-template-editor/utils/serialization.ts
@@ -124,11 +124,7 @@ function serializeNodeContent(node: JSONContent): string {
     case "variable":
       const filters = node.attrs?.filters || [];
       const filterStr =
-        filters.length > 0
-          ? filters
-              .map((f: { name: string; args?: string[] }) => `|${f.name}${f.args ? ":" + f.args.join(",") : ""}`)
-              .join("")
-          : "";
+        filters.length > 0 ? filters.map((f: TemplateFilter) => `|${f.name}${serializeFilterArg(f)}`).join("") : "";
       return `{{${node.attrs?.pluginId}.${node.attrs?.field}${filterStr}}}`;
 
     case "colorTile":
@@ -150,6 +146,36 @@ function serializeNodeContent(node: JSONContent): string {
     default:
       return "";
   }
+}
+
+/**
+ * A parsed variable filter, e.g. `|pad:3` → `{ name: "pad", arg: "3" }`.
+ *
+ * `arg` (singular string) is the contract: it is what {@link parseVariable}
+ * produces, what the filter picker produces, and what VariableNode declares as
+ * its `filters` attribute. `args` is tolerated on read only — see below.
+ */
+export interface TemplateFilter {
+  name: string;
+  arg?: string;
+  /** @deprecated Legacy plural form; accepted on read, never written. */
+  args?: string[];
+}
+
+/**
+ * Render a filter's argument suffix (`":3"`, or `""` when it takes none).
+ *
+ * This serializer used to read `f.args` (a plural string ARRAY) while every
+ * producer writes `f.arg` (a singular string), so the branch never fired and
+ * every filter argument was silently dropped on save. `{{t.temp|pad:3}}`
+ * round-tripped to `{{t.temp|pad}}`, changing what the board renders. Read the
+ * canonical `arg` first; still accept the legacy `args` array so this stays a
+ * character-for-character match with @fiestaboard/ui's serializer.
+ */
+function serializeFilterArg(filter: TemplateFilter): string {
+  if (filter.arg !== undefined && filter.arg !== "") return `:${filter.arg}`;
+  if (filter.args && filter.args.length > 0) return `:${filter.args.join(",")}`;
+  return "";
 }
 
 /** Node types that are inline atoms (cursor can't sit inside them). */


### PR DESCRIPTION
Fixes #1629

## What changed

`web/src/components/tiptap-template-editor/utils/serialization.ts` read a **plural `f.args`** (a string *array*) when serializing a variable's filters, while every producer in the editor writes a **singular `f.arg`** (a string):

- `parseVariable` (same file, line 353) emits `{ name, arg }`
- `FilterPickerContent.tsx:80` emits `{ name, arg }`
- `VariableNodeView.tsx:58` renders `filter.arg`

The `args` branch therefore never fired, and every filter argument was silently dropped the moment a template was saved.

Round-trip (`parseTemplateSimple` → `serializeTemplateSimple`, `maxLines=3`, first line):

| input | before | after |
|---|---|---|
| `{{weather.temp\|pad:3}}` | `{{weather.temp\|pad}}` | `{{weather.temp\|pad:3}}` |
| `{{weather.temp\|pad:3\|truncate:5}}` | `{{weather.temp\|pad\|truncate}}` | `{{weather.temp\|pad:3\|truncate:5}}` |
| `A {{weather.temp\|pad:3}} B` | `A {{weather.temp\|pad}} B` | `A {{weather.temp\|pad:3}} B` |

This is real data loss, not cosmetic. `src/templates/engine.py::_apply_filter` (line 1211) honors `pad:N`, `truncate:N` and `zeropad:N`, so a dropped argument turns those filters into no-ops and the physical board renders unpadded / untruncated text. The editor's own variable badge renders `filter.arg` correctly, which is why the bug is invisible until you save and reload.

The fix ports `TemplateFilter` and `serializeFilterArg` from `@fiestaboard/ui`'s serializer (`src/components/editor/utils/serialization.ts`) so the two copies converge rather than diverging a third time. The helper reads the canonical `arg` first and still accepts the legacy `args` array. Logic is character-for-character identical to the package; only the doc-comment wording differs (first person for this side of the port).

Two files, +80/−5. No new dependencies, no `package.json` change, no `@fiestaboard/ui` imports added.

## Verification — honest accounting

**No vitest run. I could not produce one.** This is a Docker-only repo, I did not start Docker, and the worktree has no `node_modules`. CI is the verification of record for this branch. Nothing below should be read as a test-suite run.

What I *did* run, as reviewer, independently of the implementer's own report:

**1. A differential probe of the real module.** I copied the post-fix `serialization.ts` and `origin/main`'s pre-fix `serialization.ts` (plus `constants.ts`) into a scratch dir and executed both under Node v26.7.0's native type stripping. The only edits to either file were replacing the type-only `import type { JSONContent } from "@tiptap/react"` with a local `type JSONContent = any` and appending `.ts` to the `./constants` specifier — verified by `diff` against `git show origin/main:...`. The runner mirrors all five new test cases verbatim. Observed:

```
--- before ---
FAIL :: preserves a single filter argument (|pad:3) :: got="{{weather.temp|pad}}" expected="{{weather.temp|pad:3}}"
FAIL :: preserves arguments on every filter in a chain :: got="{{weather.temp|pad|truncate}}" expected="{{weather.temp|pad:3|truncate:5}}"
FAIL :: preserves a filter argument on a variable surrounded by text :: got="A {{weather.temp|pad}} B" expected="A {{weather.temp|pad:3}} B"
PASS :: emits no colon for an argument-less filter
PASS :: legacy plural-args
--- after ---
PASS :: preserves a single filter argument (|pad:3)
PASS :: preserves arguments on every filter in a chain
PASS :: preserves a filter argument on a variable surrounded by text
PASS :: emits no colon for an argument-less filter
PASS :: legacy plural-args
```

So three of the five new cases are genuine, non-vacuous regression tests: they fail on `main` with exactly the `before` values in the table. The other two pass both before and after and are **not** bug-regression tests; they are labelled as such in comments in the test file, and they exist to fence off two plausible wrong fixes (an unconditional `:${f.arg}`, and a "fix" that merely renames `args` → `arg` and deletes the legacy branch).

I also probed that the pre-existing round-trips are byte-identical before and after (`{{weather.temp}}\n{{red}}\n` and `A{{fill_space}}B\n\n`).

**2. `prettier --check`** on both changed files with the repo's `.prettierrc.json`, using the already-installed binary — read-only, nothing installed. Clean.

**3. Static review** of `@tiptap/core`'s `JSONContent` (`index.d.ts:1491`) to confirm the plain object literal in the legacy-shape test is structurally assignable — it has an `[key: string]: any` index signature, so it is. Not verified by `tsc`; `tsc --noEmit` was **not** run (path aliases and `@tiptap/react` are unresolvable from this worktree). If CI disagrees the fix is `as unknown as JSONContent`.

**Not run:** vitest, `tsc --noEmit`, eslint, any Python test (no Python touched).

## Review notes

Reviewed adversarially. No blocking problems found. No existing test was touched — the test diff is a pure append (`@@ -84,3 +84,52 @@`); no assertion was weakened or rewritten. Commit trailer is exactly `Co-Authored-By: Claude <noreply@anthropic.com>`, once. Branch is off `origin/main` (`b9fef7e5`), 0 behind, no conflicts, nothing on `main`. No stray markdown.

Non-blocking, for the record:

1. **Behavior change on the legacy path that the implementation notes did not call out.** An empty `args: []` array used to serialize a dangling colon — `{{w.t|pad:}}` — because `f.args ? … : ""` is truthy for `[]`. It now serializes `{{w.t|pad}}`. Strict improvement, matches `@fiestaboard/ui` exactly, and unreachable here (nothing in this repo writes `args`). Left as is.
2. A multi-element legacy `args` still joins with a comma (`pad:3,4`), which `_apply_filter` cannot parse as an int and silently returns unfiltered. Pre-existing, unreachable, kept for package parity.
3. **This PR does not repair already-corrupted templates.** A template whose `pad:3` was stripped by a previous save is stored without the argument; the user must retype it. There is no migration, and there should not be — the stored string is the source of truth and we cannot know the original argument. Correspondingly, nothing about what the board renders *today* changes; only future saves stop corrupting.
4. `{{weather.temp|pad:}}` (trailing colon, empty arg) still normalizes to `{{weather.temp|pad}}`, before and after, via the `arg !== ""` guard. Intended; no test asserts otherwise.
5. `serializeFilterArg` is module-private, matching `@fiestaboard/ui`. Unifying the third site (below) later would require exporting it.

## Deliberately skipped

`TipTapTemplateEditor.tsx:95` — the clipboard/slice serializer. I verified it by hand: it already reads singular `f.arg` and is correct, so it is not part of this bug. Routing it through the shared helper is a consistency refactor with no behavior change, and this PR is deliberately kept to two files. I grepped the whole of `web/src` and `web/app` for other filter-serialization sites; those two are the only ones, and `VariableNodeView.tsx` / `FilterPickerContent.tsx` both use the correct singular `arg`.

This file is slated for deletion when the app adopts the extracted editor from FiestaUI PR #220. This is a targeted fix to stop live data loss now, not the long-term shape.
