### PR TITLE
chore(ui): adopt FiestaUI EmptyState across remaining routes

### DIFF
--- a/web/app/routes/collections.tsx
+++ b/web/app/routes/collections.tsx
@@ -35,6 +35,7 @@ import {
   Stack,
   Text,
 } from "@fiestaboard/ui";
+import { EmptyState } from "@fiestaboard/ui/components/feedback/empty-state";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   Clock,
@@ -765,25 +766,25 @@ export default function CollectionsPage() {
       {/* Collections list */}
       {collections.length === 0 ? (
         <Card>
-          <CardContent className="py-12 text-center">
-            <GalleryHorizontalEnd className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
-            <Text tone="muted" size="base" className="mb-2">
-              {t("noCollectionsTitle")}
-            </Text>
-            <Text tone="muted" className="mb-4">
-              {t("noCollectionsDescription")}
-            </Text>
-            <Button
-              variant="brand"
-              onClick={() => {
-                setEditingCollection(null);
-                setShowForm(true);
-              }}
-              className="btn-lift"
-            >
-              <Plus className="h-4 w-4 mr-1" />
-              {t("createFirstCollection")}
-            </Button>
+          <CardContent className="py-12">
+            <EmptyState
+              icon={GalleryHorizontalEnd}
+              title={t("noCollectionsTitle")}
+              description={t("noCollectionsDescription")}
+              action={
+                <Button
+                  variant="brand"
+                  onClick={() => {
+                    setEditingCollection(null);
+                    setShowForm(true);
+                  }}
+                  className="btn-lift"
+                >
+                  <Plus className="h-4 w-4 mr-1" />
+                  {t("createFirstCollection")}
+                </Button>
+              }
+            />
           </CardContent>
         </Card>
       ) : (

--- a/web/app/routes/integrations._index.tsx
+++ b/web/app/routes/integrations._index.tsx
@@ -72,6 +72,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@fiestaboard/ui";
+import { EmptyState } from "@fiestaboard/ui/components/feedback/empty-state";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import type { LucideIcon } from "lucide-react";
 import {
@@ -2446,27 +2447,21 @@ export default function IntegrationsPage() {
               </CardContent>
             </Card>
           ) : filteredInstalled.length === 0 ? (
-            <Box className="text-center py-16">
-              {query ? (
-                <>
-                  <Search className="h-10 w-10 text-muted-foreground mx-auto mb-3" />
-                  <Text tone="muted">{t("noInstalledMatch", { query: searchQuery })}</Text>
-                </>
-              ) : (
-                <>
-                  <Puzzle className="h-10 w-10 text-muted-foreground mx-auto mb-3" />
-                  <Text size="base" weight="medium" className="mb-1">
-                    {t("noPluginsInstalled")}
-                  </Text>
-                  <Text tone="muted" className="mb-4">
-                    {t("headToMarketplace")}
-                  </Text>
+            query ? (
+              <EmptyState icon={Search} title={t("noInstalledMatch", { query: searchQuery })} className="py-16" />
+            ) : (
+              <EmptyState
+                icon={Puzzle}
+                title={t("noPluginsInstalled")}
+                description={t("headToMarketplace")}
+                action={
                   <Button variant="outline" onClick={() => setActiveTab("marketplace")}>
                     {t("browseMarketplace")}
                   </Button>
-                </>
-              )}
-            </Box>
+                }
+                className="py-16"
+              />
+            )
           ) : (
             <Stack gap="3">
               {updatesAvailableCount > 0 && (
@@ -2551,22 +2546,16 @@ export default function IntegrationsPage() {
         {/* ── Marketplace Tab ── */}
         <TabsContent value="marketplace" className="mt-0">
           {filteredRegistry.length === 0 ? (
-            <Box className="text-center py-16">
-              {query ? (
-                <>
-                  <Search className="h-10 w-10 text-muted-foreground mx-auto mb-3" />
-                  <Text tone="muted">{t("noPluginsMatch", { query: searchQuery })}</Text>
-                </>
-              ) : (
-                <>
-                  <Puzzle className="h-10 w-10 text-muted-foreground mx-auto mb-3" />
-                  <Text size="base" weight="medium" className="mb-1">
-                    {t("noRegistryPluginsFound")}
-                  </Text>
-                  <Text tone="muted">{t("canInstallCustomGitDescription")}</Text>
-                </>
-              )}
-            </Box>
+            query ? (
+              <EmptyState icon={Search} title={t("noPluginsMatch", { query: searchQuery })} className="py-16" />
+            ) : (
+              <EmptyState
+                icon={Puzzle}
+                title={t("noRegistryPluginsFound")}
+                description={t("canInstallCustomGitDescription")}
+                className="py-16"
+              />
+            )
           ) : marketplaceView === "card" ? (
             <Stack gap="6" className="animate-card-fade-in">
               {(() => {

--- a/web/src/components/schedule/schedule-list-view.tsx
+++ b/web/src/components/schedule/schedule-list-view.tsx
@@ -12,6 +12,7 @@ import {
   Switch,
   Text,
 } from "@fiestaboard/ui";
+import { EmptyState } from "@fiestaboard/ui/components/feedback/empty-state";
 import { format } from "date-fns";
 import { Calendar, ChevronRight, Edit, GalleryHorizontalEnd, Moon, Trash2 } from "lucide-react";
 import { useMemo } from "react";
@@ -183,13 +184,12 @@ export function ScheduleListView({
       </CardHeader>
       <CardContent>
         {schedules.length === 0 && !showSilenceRow ? (
-          <Box className="text-center py-12 text-muted-foreground">
-            <Calendar className="h-12 w-12 mx-auto mb-4" />
-            <Text tone="muted">{t("noSchedulesCreated")}</Text>
-            <Text tone="muted" className="mt-1">
-              {t("useToolbarToAdd")}
-            </Text>
-          </Box>
+          <EmptyState
+            icon={Calendar}
+            title={t("noSchedulesCreated")}
+            description={t("useToolbarToAdd")}
+            className="py-12"
+          />
         ) : (
           <Stack gap="3">
             {renderSilenceRow()}


### PR DESCRIPTION
## What changed

Replaces the last hand-rolled empty states in the web app with FiestaUI's shared `EmptyState`
primitive, so list/grid empties render consistently and each one gains a real heading plus a
labelled region for assistive tech.

**6 empty-state branches across 4 wrapper sites in 3 files** (50 insertions / 60 deletions):

| File | Site |
| --- | --- |
| `web/app/routes/collections.tsx` | no-collections state — keeps the `Card`/`CardContent` shell, drops `text-center` (EmptyState centers itself), moves the "Create Your First Collection" CTA into `action` |
| `web/src/components/schedule/schedule-list-view.tsx` | no-schedules state — `className="py-12"` preserves the original rhythm over EmptyState's built-in `py-8` |
| `web/app/routes/integrations._index.tsx` | Installed tab: search-no-match + no-plugins-installed (the latter keeps its Browse Marketplace CTA) |
| `web/app/routes/integrations._index.tsx` | Marketplace tab: search-no-match + no-registry-plugins-found |

Each `<Box className="text-center py-16">` wrapper in `integrations._index.tsx` collapses into a
bare ternary of two `EmptyState`s. The conditional structure is logically identical to before —
same `query` guard, same `filteredInstalled.length === 0` / `filteredRegistry.length === 0` outer
branches.

**No new strings, no locale files touched.** All 12 reused i18n keys were verified present in
`web/messages/en.json`. The two search-no-match branches only ever had a single key each
(`noInstalledMatch`, `noPluginsMatch`); those map to EmptyState's required `title`, and
`description` is optional, so nothing had to be invented.

No `package.json` change, no new dependencies, no version bump — `@fiestaboard/ui` is already
`3.2.0` on `main` (#1628).

## Review caught a blocking bug — wrong deep-subpath, would have failed CI

The implementer wrote the import as:

```ts
import { EmptyState } from "@fiestaboard/ui/components/ui/empty-state";
```

**That path does not exist in `@fiestaboard/ui@3.2.0`.** FiestaUI reorganised its component
taxonomy in 3.0.0: `src/components/ui/` was dissolved into `board / chrome / containment / editor /
effects / feedback / forms / layout / overlays / plugin / seasons / typography`, and `EmptyState`
now lives under `feedback/`. The build uses `preserveModules: true` with
`preserveModulesRoot: "src"`, so `dist/` mirrors `src/` one-for-one.

Evidence, not inference:

* `git ls-tree -r v3.2.0 -- src/components/ui/` in the FiestaUI repo returns **0 paths**;
  `src/components/feedback/empty-state.tsx` is the real source.
* Extracting the published tarball from the local npm cache
  (`registry.npmjs.org/@fiestaboard/ui/-/ui-3.0.1.tgz`, same 3.x taxonomy) shows
  `package/dist/components/feedback/empty-state.{js,d.ts,js.map}` and **no**
  `package/dist/components/ui/` directory at all.

Why it wasn't caught locally: every `node_modules` on this machine is stale. The FiestaBoard
checkout has `@fiestaboard/ui@2.2.3` installed against a `package.json` that asks for `3.2.0`, and
2.2.3 *does* ship `dist/components/ui/empty-state.js`. Verifying the import against the installed
tree gave a false pass. On CI, `npm ci` installs a real 3.2.0 and the subpath export
(`"./*": { types: "./dist/*.d.ts", import: "./dist/*.js" }`) has nothing to resolve — this would
have failed typecheck and the production build in all three files.

Fixed on the branch (commit amended):

```ts
import { EmptyState } from "@fiestaboard/ui/components/feedback/empty-state";
```

The v3.2.0 `EmptyStateProps` interface is byte-identical to 2.2.3's, so only the path was wrong;
no call-site props needed changing.

## Verification — honest account

**I could not run `tsc`, `eslint`, `vitest`, or Playwright.** This repo is Docker-only and
`CLAUDE.md` forbids `npm install` / `npm ci` on the host; the worktree has no `web/node_modules`,
and the repo-root copy is stale (2.2.3, see above), so running against it would have been actively
misleading. **CI is the real verification for this PR.**

What was actually executed:

* `prettier --check` on all three edited files (already-installed binary, no install, no network) —
  *"All matched files use Prettier code style!"* This doubles as a parse check: prettier's TS/JSX
  parser accepted the new nested ternaries in `integrations._index.tsx`.
* Extracted the cached `@fiestaboard/ui` 3.x tarball and enumerated its `dist/` layout — this is
  what surfaced the blocking import bug.
* Read the v3.2.0 `EmptyState` source out of the FiestaUI repo at the tag (not from stale
  `node_modules`) to confirm the prop shape and the rendered DOM.
* Post-edit identifier counts for every symbol whose only use might have been removed —
  `integrations._index.tsx` `Box` 13 JSX / `Text` 24 / `Search` / `Puzzle`; `collections.tsx`
  `Text` 16 / `GalleryHorizontalEnd` / `Plus` / `Button`; `schedule-list-view.tsx` `Box` 2 /
  `Text` 4 / `Calendar`. All non-zero, so no import became unused.
* All 12 i18n keys resolved against `web/messages/en.json`.
* `git diff` confirms exactly 3 files, no test files, no markdown files, no `package.json`.
* Commit trailer is byte-exact and appears exactly once.

Reasoned about but **not executed**:

* **Typecheck.** `t()` is typed `(key: string, params?: Record<string, unknown>) => string` in
  `web/src/i18n/translations.tsx`, so every `title` / `description` satisfies EmptyState's `string`
  props. In the old code these were JSX children, which tolerate any `ReactNode` — this was the
  highest-risk difference and it checks out by source reading, not by a compiler run.
* **Lint.** `web/eslint.config.mjs` has no `no-nested-ternary` rule (the `integrations` edit adds a
  nesting level), and its `no-restricted-imports` config bans `clsx` / `tailwind-merge` /
  `class-variance-authority` / `ogl` / `react-resizable-panels` / `@base-ui/react` — it does **not**
  restrict `@fiestaboard/ui` subpaths, so the deep import is allowed. Import order under
  `simple-import-sort` was hand-checked:
  `"@fiestaboard/ui"` < `"@fiestaboard/ui/components/feedback/empty-state"` < `"@tanstack/react-query"`,
  and `"@f…"` < `"date-fns"`.
* **Playwright.** No test file was modified and no assertion was weakened — the diff contains zero
  test files. Five existing specs assert on affected copy
  (`tests/regression/collections.spec.ts:164,170`, `tests/schedule-management.spec.ts:33`,
  `tests/regression/schedule-list.spec.ts:52`,
  `tests/regression/integrations-installed.spec.ts:145,148,167`). They should still pass: the
  strings move from a `<p>` (`Text`) to EmptyState's `<h3>`, and Playwright's text engine resolves
  to the innermost element owning the text node either way; the `Browse Marketplace` and
  `Create Your First Collection` buttons are rendered verbatim inside `action`, so the
  `getByRole("button")` assertions are unaffected. Not observed running.
* **a11y.** `tests/a11y.spec.ts` audits `/schedule` (:107) and `/integrations` (:112). The new
  `role="region"` can only touch `region`, `landmark-unique` and `heading-order`, all
  **moderate**-impact; `FAIL_IMPACTS` (`tests/a11y.spec.ts:31`) only fails on critical/serious.

## Deliberate changes to call out

* Icons shrink from `h-12`/`h-10` muted grey to `h-8` brand-coloured inside a `bg-brand/10` pill.
* Titles move from a muted `<Text>` to a foreground `<h3 class="text-sm font-medium">` — smaller in
  `collections.tsx` (was `size="base"`) and in the integrations no-plugins states (were
  `size="base" weight="medium"`), but higher contrast and now real headings.
* Each empty state gains `role="region"` + `aria-labelledby`.
* `announce` is deliberately **not** passed anywhere. All of these render on load rather than as
  the result of a data change, and the two search branches interpolate the live query — a
  `role="status"` region would re-announce on every keystroke.

## Non-blocking concerns for a human eye

1. **`collections.tsx` gains ~32px of vertical padding.** `CardContent` keeps its `className="py-12"`
   and `EmptyState` adds its own `py-8` on top (no `className` override there, unlike the other
   sites). The empty card gets taller. Left alone rather than guessed at, since I can't render it.
2. **Two titles get visually smaller.** `collections.tsx` (`size="base"` → `text-sm`) and both
   integrations no-plugins states (`size="base" weight="medium"` → `text-sm font-medium`). Intended
   by the adoption, but these are the places where the shared component is smaller than what it
   replaced.
3. **Deep subpath vs. root barrel — a real local inconsistency.** These are the *first three* deep
   subpath imports anywhere in `web/`; the other ~131 `@fiestaboard/ui` imports all use the root
   barrel, and `web/eslint.config.mjs` has no barrel ban. In these three files it buys nothing
   today — each already imports the root barrel for other primitives, so the Tiptap editor is in
   their module graph either way. Kept because it's the direction the docs site went in
   `fiestaboard.github.io#17` and it's the right default for new imports; happy to switch to the
   existing barrel block if the reviewer prefers local consistency. **Note that this convention is
   exactly what produced the blocking bug above** — a root-barrel import would have been immune to
   the 3.0.0 path reshuffle. If deep subpaths are to become the house style, a
   `no-restricted-imports` rule banning the root barrel should land alongside, so the paths are
   lint-checked rather than hand-typed.
4. **`heading-order`.** The `<h3>` may not always follow an `<h2>` on these routes. Moderate impact,
   so it won't fail the a11y suite, but it's a real (pre-existing-style) nit the shared component
   now makes uniform.

## Deliberately skipped

* `app/routes/debug.tsx` — its description is a `ReactNode`
  (`{t("monitoringRemovedDescription")} <Code>docker logs fiestaboard</Code>`), but EmptyState types
  `description?: string`. Its title is also a `Heading level={2}` that EmptyState would demote to
  `h3`.
* `app/routes/picks.tsx` — the whole empty state is a single `<Text>`; EmptyState's `icon` is
  required, so adopting it would mean inventing a glyph.
* `app/routes/transitions.tsx` (2 sites) — these are inline form-field hints under a `Select`, not
  route-level empty states. Wrapping a field hint in a `role="region"` landmark with an `h3` would
  be a regression. (An earlier audit justified this exclusion with "no icon to supply", which is
  factually wrong for line 343 — it does have a `<Wand2>`. The exclusion stands on the field-hint
  grounds, not that one.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
