### PR TITLE
chore(ui): adopt FiestaUI Spinner and Button loading state

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -196,6 +196,27 @@
   scroll-behavior: auto !important;
 }
 
+/* Bridge FiestaUI's Spinner to the app's own motion kill switches. The
+   component swaps its animated three-quarter arc for a complete static ring
+   under `motion-reduce:`, which compiles to the OS-level
+   `prefers-reduced-motion` media query only. `.reduce-motion` and
+   `.site-animations-off` are settings-driven classes that media query never
+   sees, and the rules above merely zero the animation — which would freeze the
+   arc mid-rotation and read as a rendering glitch. Drive the same swap from
+   them instead. `data-slot` is the component's stable public hook.
+
+   The `.site-animations-off` arm carries the same `[data-board-preview]`
+   exclusion as the rule above it, so a spinner inside the board preview keeps
+   the behaviour that kill switch deliberately leaves alone. */
+.reduce-motion [data-slot="spinner-mark"],
+.site-animations-off [data-slot="spinner-mark"]:not([data-board-preview] *) {
+  display: none;
+}
+.reduce-motion [data-slot="spinner-mark-static"],
+.site-animations-off [data-slot="spinner-mark-static"]:not([data-board-preview] *) {
+  display: block;
+}
+
 /* Board animation kill switch. The board flap structure (4 layers) is
    already gated in JS so the extra DOM never renders when this is set,
    but the CSS belt-and-braces guarantees no leftover transforms animate

--- a/web/app/routes/collections.tsx
+++ b/web/app/routes/collections.tsx
@@ -41,7 +41,6 @@ import {
   FileText,
   GalleryHorizontalEnd,
   GripVertical,
-  Loader2,
   Pencil,
   Plus,
   Shuffle,
@@ -629,8 +628,7 @@ function CollectionForm({ collection, pages, onSubmit, onCancel, onDelete }: Col
           <Button type="button" variant="outline" onClick={onCancel} disabled={isSubmitting}>
             {tc("cancel")}
           </Button>
-          <Button type="submit" disabled={!canSubmit || isSubmitting}>
-            {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          <Button type="submit" loading={isSubmitting} disabled={!canSubmit || isSubmitting}>
             {isEdit ? t("updateCollection") : t("createCollection")}
           </Button>
         </Flex>

--- a/web/app/routes/login.tsx
+++ b/web/app/routes/login.tsx
@@ -43,6 +43,7 @@ import {
   Text,
   TextLink,
 } from "@fiestaboard/ui";
+import { Spinner } from "@fiestaboard/ui/components/feedback/spinner";
 import { Loader2, Lock, ShieldAlert, ShieldCheck, ShieldQuestion } from "lucide-react";
 import { type FormEvent, useCallback, useEffect, useRef, useState } from "react";
 
@@ -269,7 +270,11 @@ export default function LoginPage() {
 
   if (!status) {
     return (
-      <CenteredCard tCommon={tCommon} icon={<Loader2 className="h-6 w-6 animate-spin" />} title={t("loadingTitle")}>
+      <CenteredCard
+        tCommon={tCommon}
+        icon={<Spinner size="lg" className="size-6" label={null} />}
+        title={t("loadingTitle")}
+      >
         <Text tone="muted">{t("loadingDescription")}</Text>
       </CenteredCard>
     );
@@ -278,7 +283,11 @@ export default function LoginPage() {
   // While redirecting we render a placeholder rather than flashing the form.
   if (!status.enabled || status.authenticated) {
     return (
-      <CenteredCard tCommon={tCommon} icon={<Loader2 className="h-6 w-6 animate-spin" />} title={t("redirectingTitle")}>
+      <CenteredCard
+        tCommon={tCommon}
+        icon={<Spinner size="lg" className="size-6" label={null} />}
+        title={t("redirectingTitle")}
+      >
         <Text tone="muted">{t("redirectingDescription")}</Text>
       </CenteredCard>
     );

--- a/web/app/routes/offline.tsx
+++ b/web/app/routes/offline.tsx
@@ -1,4 +1,5 @@
 import { Box, Flex, List, ListItem, Stack, Text } from "@fiestaboard/ui";
+import { Spinner } from "@fiestaboard/ui/components/feedback/spinner";
 import { RefreshCw, WifiOff } from "lucide-react";
 import { useEffect, useSyncExternalStore } from "react";
 
@@ -80,7 +81,7 @@ export default function OfflinePage() {
 
         {isOnline && (
           <Flex justify="center">
-            <Box className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></Box>
+            <Spinner size="lg" className="size-8 text-primary" label={t("reconnecting")} />
           </Flex>
         )}
       </Stack>

--- a/web/src/components/active-page-display.tsx
+++ b/web/src/components/active-page-display.tsx
@@ -27,6 +27,7 @@ import {
   Stack,
   Text,
 } from "@fiestaboard/ui";
+import { Spinner } from "@fiestaboard/ui/components/feedback/spinner";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   AlertTriangle,
@@ -780,7 +781,7 @@ export function ActivePageDisplay() {
                 className="h-10 w-10 rounded-full bg-muted flex-shrink-0 group-hover:bg-muted/80 transition-colors"
               >
                 {disableScheduleMutation.isPending ? (
-                  <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+                  <Spinner size="lg" className="text-muted-foreground" label={null} />
                 ) : (
                   <CalendarOff className="h-5 w-5 text-muted-foreground" />
                 )}

--- a/web/src/components/ai-chat-panel.tsx
+++ b/web/src/components/ai-chat-panel.tsx
@@ -25,6 +25,7 @@ import {
   Text,
   Textarea,
 } from "@fiestaboard/ui";
+import { Spinner } from "@fiestaboard/ui/components/feedback/spinner";
 import { useQuery } from "@tanstack/react-query";
 import {
   AlertCircle,
@@ -33,7 +34,6 @@ import {
   Circle,
   Eye,
   EyeOff,
-  Loader2,
   RotateCcw,
   Send,
   Sparkles,
@@ -204,7 +204,7 @@ export function AiChatPanel({
             <Text as="span" size="sm" weight="semibold" className="truncate">
               {t("panelTitle")}
             </Text>
-            {status === "streaming" && <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />}
+            {status === "streaming" && <Spinner size="sm" className="text-muted-foreground" label={null} />}
           </Flex>
           <Flex align="center" gap="1">
             {onChainingModeChange && <ChainingModePicker mode={chainingMode} onChange={onChainingModeChange} />}
@@ -358,7 +358,7 @@ function TaskStatusIcon({ status }: { status: TaskStatus }) {
     case "failed":
       return <XCircle className="h-3 w-3 shrink-0 text-destructive" aria-hidden="true" />;
     case "in_progress":
-      return <Loader2 className="h-3 w-3 shrink-0 animate-spin text-brand-emphasis" aria-hidden="true" />;
+      return <Spinner size="sm" className="size-3 shrink-0 text-brand-emphasis" label={null} />;
     case "pending":
       return <Circle className="h-3 w-3 shrink-0 text-muted-foreground/50" aria-hidden="true" />;
   }
@@ -633,7 +633,7 @@ function MessageBubble({
         <Text as="span" weight="medium" tone="muted" className="text-[10px] uppercase tracking-wide">
           AI
         </Text>
-        {message.pending && <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />}
+        {message.pending && <Spinner size="sm" className="size-3 text-muted-foreground" label={null} />}
       </Flex>
       {message.content && (
         <Box className="break-words text-sm">

--- a/web/src/components/boot-gate.tsx
+++ b/web/src/components/boot-gate.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Box, FiestaIcon, FiestaLogo, Flex, Stack, Text } from "@fiestaboard/ui";
+import { FiestaIcon, FiestaLogo, Flex, Stack, Text } from "@fiestaboard/ui";
+import { Spinner } from "@fiestaboard/ui/components/feedback/spinner";
 import { useQuery } from "@tanstack/react-query";
 import { WifiOff } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -137,10 +138,7 @@ export function BootGate({ children }: { children: React.ReactNode }) {
         ) : (
           /* ── Waiting state ── */
           <>
-            <Box
-              className="h-8 w-8 rounded-full border-[2.5px] border-muted-foreground/25 border-t-muted-foreground animate-spin"
-              aria-hidden="true"
-            />
+            <Spinner size="lg" className="size-8 text-muted-foreground" label={null} />
             {awaitingPostUpdateBoot ? (
               <Stack gap="1.5">
                 <Text size="base" weight="semibold">

--- a/web/src/components/plugin-settings/remote-options-field.tsx
+++ b/web/src/components/plugin-settings/remote-options-field.tsx
@@ -12,8 +12,9 @@ import {
   Stack,
   Text,
 } from "@fiestaboard/ui";
+import { Spinner } from "@fiestaboard/ui/components/feedback/spinner";
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
-import { ArrowDown, ArrowUp, Loader2, Trash2 } from "lucide-react";
+import { ArrowDown, ArrowUp, Trash2 } from "lucide-react";
 import React, { useEffect, useRef, useState } from "react";
 
 import { useTranslations } from "@/i18n/translations";
@@ -622,7 +623,7 @@ function FieldNotes({
   if (query.isLoading) {
     return (
       <Flex align="center" gap="2" className="text-xs text-muted-foreground">
-        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        <Spinner size="sm" label={null} />
         {t("remoteOptionsLoading")}
       </Flex>
     );

--- a/web/src/components/schedule-entry-form.tsx
+++ b/web/src/components/schedule-entry-form.tsx
@@ -19,7 +19,7 @@ import {
   Switch,
   Text,
 } from "@fiestaboard/ui";
-import { AlertCircle, AlertTriangle, GalleryHorizontalEnd, Loader2, Sunrise, Sunset, Trash2 } from "lucide-react";
+import { AlertCircle, AlertTriangle, GalleryHorizontalEnd, Sunrise, Sunset, Trash2 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 
 import { BoardSizeIndicator } from "@/components/board-size-indicator";
@@ -723,8 +723,7 @@ export function ScheduleEntryForm({
           <Button type="button" variant="outline" onClick={onCancel} disabled={isSubmitting}>
             {tc("cancel")}
           </Button>
-          <Button type="submit" disabled={validationErrors.length > 0 || isSubmitting}>
-            {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          <Button type="submit" loading={isSubmitting} disabled={validationErrors.length > 0 || isSubmitting}>
             {isEdit ? t("scheduleEntryForm.updateSchedule") : t("scheduleEntryForm.createSchedule")}
           </Button>
         </Flex>

--- a/web/src/components/settings/board-settings.tsx
+++ b/web/src/components/settings/board-settings.tsx
@@ -20,6 +20,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@fiestaboard/ui";
+import { Spinner } from "@fiestaboard/ui/components/feedback/spinner";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { AlertCircle, Check, Eye, EyeOff, Key, KeyRound, Loader2, Monitor, Search } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -520,7 +521,7 @@ export function BoardSettings() {
           {/* Auto-save indicator */}
           {updateMutation.isPending && (
             <Flex align="center" justify="center" gap="2" className="pt-2 text-xs text-muted-foreground">
-              <Box className="h-3 w-3 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+              <Spinner size="sm" className="size-3 text-primary" label={null} />
               <Text as="span" size="xs" tone="muted">
                 {tCommon("saving")}
               </Text>

--- a/web/src/components/settings/location-settings.tsx
+++ b/web/src/components/settings/location-settings.tsx
@@ -187,8 +187,12 @@ export function LocationSettingsCard() {
                 )}
                 {isGeolocating ? t("locating") : t("useMyLocation")}
               </Button>
-              <Button onClick={handleSave} disabled={mutation.isPending || !isDirty} size="sm">
-                {mutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              <Button
+                onClick={handleSave}
+                loading={mutation.isPending}
+                disabled={mutation.isPending || !isDirty}
+                size="sm"
+              >
                 {tCommon("save")}
               </Button>
               {isConfigured && (

--- a/web/src/components/settings/mqtt-settings.tsx
+++ b/web/src/components/settings/mqtt-settings.tsx
@@ -21,7 +21,7 @@ import {
   Text,
 } from "@fiestaboard/ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { CheckCircle2, ChevronDown, Eye, EyeOff, Loader2, Radio, XCircle } from "lucide-react";
+import { CheckCircle2, ChevronDown, Eye, EyeOff, Radio, XCircle } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 
@@ -223,10 +223,10 @@ export function MqttSettingsCard() {
                   size="sm"
                   variant="brand"
                   onClick={handleSave}
+                  loading={saveMutation.isPending}
                   disabled={saveMutation.isPending}
                   className="text-xs gap-1.5"
                 >
-                  {saveMutation.isPending && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
                   {tCommon("save")}
                 </Button>
               </Flex>

--- a/web/src/components/settings/network-settings.tsx
+++ b/web/src/components/settings/network-settings.tsx
@@ -23,6 +23,7 @@ import {
   Stack,
   Text,
 } from "@fiestaboard/ui";
+import { Spinner } from "@fiestaboard/ui/components/feedback/spinner";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Check, Loader2, Lock, RefreshCw, Trash2, Unlink, Wifi, WifiOff, X } from "lucide-react";
 import { useState } from "react";
@@ -158,7 +159,7 @@ export function NetworkSettings() {
         </CardHeader>
         <CardContent className="space-y-3">
           {statusQuery.isLoading ? (
-            <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+            <Spinner className="text-muted-foreground" label={tCommon("loading")} />
           ) : !isConnected ? (
             <Text tone="muted">{t("notConnected")}</Text>
           ) : (
@@ -287,7 +288,7 @@ export function NetworkSettings() {
         </CardHeader>
         <CardContent>
           {savedQuery.isLoading ? (
-            <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+            <Spinner className="text-muted-foreground" label={tCommon("loading")} />
           ) : !savedQuery.data || savedQuery.data.length === 0 ? (
             <Text tone="muted">{t("savedEmpty")}</Text>
           ) : (

--- a/web/src/components/settings/silence-schedule.tsx
+++ b/web/src/components/settings/silence-schedule.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import {
-  Box,
   Card,
   CardContent,
   CardDescription,
@@ -21,6 +20,7 @@ import {
   Switch,
   Text,
 } from "@fiestaboard/ui";
+import { Spinner } from "@fiestaboard/ui/components/feedback/spinner";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Moon } from "lucide-react";
 import { useDeferredValue, useEffect, useState } from "react";
@@ -346,7 +346,7 @@ export function SilenceSchedule() {
                 gap="2"
                 className="pt-4 mt-4 border-t text-xs text-muted-foreground"
               >
-                <Box className="h-3 w-3 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+                <Spinner size="sm" className="size-3 text-primary" label={null} />
                 <Text as="span" size="xs" tone="muted">
                   {tc("savingIndicator")}
                 </Text>

--- a/web/src/components/settings/system-controls.tsx
+++ b/web/src/components/settings/system-controls.tsx
@@ -18,6 +18,7 @@ import {
   Stack,
   Text,
 } from "@fiestaboard/ui";
+import { Spinner } from "@fiestaboard/ui/components/feedback/spinner";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { ArrowUpCircle, Cpu, Loader2, Power, RefreshCw } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -314,7 +315,7 @@ function RestartingOverlay({ currentVersion }: { currentVersion?: string }) {
   return (
     <Flex align="center" justify="center" className="fixed inset-0 z-[100] bg-background/95 backdrop-blur-sm">
       <Stack gap="4" className="text-center">
-        <Loader2 className="h-12 w-12 mx-auto animate-spin text-primary" />
+        <Spinner size="lg" className="size-12 mx-auto text-primary" label={null} />
         <Heading level={2} size="xl">
           {phase === "restarting" ? t("restartingFiestaboard") : t("backOnline")}
         </Heading>

--- a/web/src/components/settings/transition-settings.tsx
+++ b/web/src/components/settings/transition-settings.tsx
@@ -2,7 +2,6 @@
 
 import {
   Badge,
-  Box,
   Card,
   CardContent,
   CardDescription,
@@ -16,6 +15,7 @@ import {
   Stack,
   Text,
 } from "@fiestaboard/ui";
+import { Spinner } from "@fiestaboard/ui/components/feedback/spinner";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Info, Sparkles } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
@@ -334,7 +334,7 @@ export function TransitionSettings() {
         {/* Saving indicator */}
         {updateMutation.isPending && (
           <Flex align="center" justify="center" gap="2" className="pt-2 text-xs text-muted-foreground">
-            <Box className="h-3 w-3 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+            <Spinner size="sm" className="size-3 text-primary" label={null} />
             <Text as="span" size="xs" tone="muted">
               {tCommon("saving")}
             </Text>

--- a/web/src/components/tiptap-template-editor/components/FormulaEditorPanel.tsx
+++ b/web/src/components/tiptap-template-editor/components/FormulaEditorPanel.tsx
@@ -32,6 +32,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@fiestaboard/ui";
+import { Spinner } from "@fiestaboard/ui/components/feedback/spinner";
 import { tags } from "@lezer/highlight";
 import { useQuery } from "@tanstack/react-query";
 import type { LucideIcon } from "lucide-react";
@@ -42,7 +43,6 @@ import {
   ChevronRight,
   GitBranch,
   Hash,
-  Loader2,
   Palette,
   Type as TypeIcon,
   XCircle,
@@ -677,7 +677,7 @@ export function FormulaEditorPanel({ initialExpr = "", mode, onConfirm, onCancel
                   ) : validationState === "invalid" ? (
                     <XCircle className="w-3.5 h-3.5 text-destructive" />
                   ) : validationState === "validating" ? (
-                    <Loader2 className="w-3.5 h-3.5 text-muted-foreground/50 animate-spin" />
+                    <Spinner size="sm" className="text-muted-foreground/50" label={null} />
                   ) : null}
                 </Text>
               </Flex>

--- a/web/src/components/ui/sonner.tsx
+++ b/web/src/components/ui/sonner.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { CircleCheckIcon, InfoIcon, Loader2Icon, OctagonXIcon, TriangleAlertIcon } from "lucide-react";
+import { Spinner } from "@fiestaboard/ui/components/feedback/spinner";
+import { CircleCheckIcon, InfoIcon, OctagonXIcon, TriangleAlertIcon } from "lucide-react";
 import { Toaster as Sonner, type ToasterProps } from "sonner";
 
 import { useTheme } from "@/hooks/use-theme";
@@ -40,7 +41,7 @@ const Toaster = ({ containerAriaLabel, ...props }: ToasterProps) => {
         info: <InfoIcon className="size-4" />,
         warning: <TriangleAlertIcon className="size-4" />,
         error: <OctagonXIcon className="size-4" />,
-        loading: <Loader2Icon className="size-4 animate-spin" />,
+        loading: <Spinner label={null} />,
       }}
       style={
         {

--- a/web/src/components/update-context.tsx
+++ b/web/src/components/update-context.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Box, Button, Code, Flex, Heading, Stack, Text } from "@fiestaboard/ui";
+import { Spinner } from "@fiestaboard/ui/components/feedback/spinner";
 import { RefreshCw } from "lucide-react";
 import { createContext, Fragment, useCallback, useContext, useEffect, useRef, useState } from "react";
 
@@ -354,8 +355,7 @@ function UpdateOverlay({ currentVersion, onDone }: { currentVersion?: string; on
   return (
     <Flex align="center" justify="center" className="fixed inset-0 z-[200] bg-black text-white">
       <Stack gap="6" className="text-center max-w-xs mx-auto px-4">
-        {/* Spinner */}
-        <Box className="h-12 w-12 mx-auto rounded-full border-[3px] border-white/20 border-t-white animate-spin" />
+        <Spinner size="lg" className="size-12 mx-auto" label={null} />
 
         {/* Title + current phase message */}
         <Stack gap="2">

--- a/web/src/components/wizard-provider.tsx
+++ b/web/src/components/wizard-provider.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Box, Flex, Text } from "@fiestaboard/ui";
+import { Spinner } from "@fiestaboard/ui/components/feedback/spinner";
 import type { ReactNode } from "react";
 import { createContext, lazy, Suspense, useCallback, useContext, useEffect, useState } from "react";
 
@@ -13,7 +14,7 @@ function WizardLoadingFallback() {
   return (
     <Flex align="center" justify="center" className="fixed inset-0 bg-background">
       <Box className="text-center">
-        <Box className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+        <Spinner size="lg" className="size-8 text-primary" label={null} />
         <Text tone="muted" className="mt-4">
           {t("loadingSetupWizard")}
         </Text>
@@ -113,7 +114,7 @@ export function WizardProvider({ children }: WizardProviderProps) {
     return (
       <Flex align="center" justify="center" className="fixed inset-0 bg-background">
         <Box className="text-center">
-          <Box className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
+          <Spinner size="lg" className="size-8 text-primary" label={null} />
           <Text tone="muted" className="mt-4">
             {t("loading")}
           </Text>

--- a/web/src/components/wizard/step-board-setup.tsx
+++ b/web/src/components/wizard/step-board-setup.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Box, Button, Flex, Grid, Input, Label, List, ListItem, Stack, Text } from "@fiestaboard/ui";
+import { Spinner } from "@fiestaboard/ui/components/feedback/spinner";
 import {
   CheckCircle,
   Cloud,
@@ -352,7 +353,7 @@ export function StepBoardSetup({
           {/* Scan results */}
           {scanStatus === "scanning" && (
             <Flex align="center" gap="2" className="p-3 rounded-lg bg-muted/50 text-sm text-muted-foreground">
-              <Loader2 className="h-4 w-4 animate-spin" />
+              <Spinner label={null} />
               <Text as="span" tone="muted">
                 {t("scanningNetwork")}
               </Text>

--- a/web/tests/regression/collections.spec.ts
+++ b/web/tests/regression/collections.spec.ts
@@ -300,7 +300,7 @@ test.describe("regression: collections.form", () => {
    * UX node: collections.form.creating
    * Route: /collections (sheet)
    * Preconditions: create-mutation:pending
-   * Expected: Submit button shows pending state (disabled + spinner) while mutation in flight
+   * Expected: Submit button shows pending state (disabled, announced busy, spinner) while mutation in flight
    * Source refs: web/src/app/collections/page.tsx (isSubmitting branch)
    */
   test("collections.form.creating — Submit becomes disabled with spinner while POST is in flight", async ({ page }) => {
@@ -329,7 +329,13 @@ test.describe("regression: collections.form", () => {
     await submit.click();
 
     await expect(submit).toBeDisabled({ timeout: 5_000 });
-    await expect(submit.locator("svg.animate-spin")).toBeVisible();
+    // Assert the busy state the user is actually served: announced to assistive
+    // tech, and visibly indicated. Not the CSS animation class that paints it.
+    await expect(submit).toHaveAttribute("aria-busy", "true");
+    await expect(submit.locator("[data-slot='spinner']")).toBeVisible();
+    // The accessible name must survive the transition — the button must not
+    // silently rename itself to "Loading" mid-interaction.
+    await expect(submit).toHaveAccessibleName("Create Collection");
 
     release!();
     await expect(dialog).toBeHidden({ timeout: 10_000 });
@@ -384,7 +390,7 @@ test.describe("regression: collections.form", () => {
    * UX node: collections.form.updating
    * Route: /collections (sheet)
    * Preconditions: update-mutation:pending
-   * Expected: Update Collection button disabled + spinner while PUT in flight
+   * Expected: Update Collection button disabled, announced busy, spinner while PUT in flight
    * Source refs: web/src/app/collections/page.tsx (isSubmitting branch)
    */
   test("collections.form.updating — Update Collection button shows pending state while PUT is in flight", async ({
@@ -415,7 +421,11 @@ test.describe("regression: collections.form", () => {
     await submit.click();
 
     await expect(submit).toBeDisabled({ timeout: 5_000 });
-    await expect(submit.locator("svg.animate-spin")).toBeVisible();
+    // Assert the busy state the user is actually served: announced to assistive
+    // tech, and visibly indicated. Not the CSS animation class that paints it.
+    await expect(submit).toHaveAttribute("aria-busy", "true");
+    await expect(submit.locator("[data-slot='spinner']")).toBeVisible();
+    await expect(submit).toHaveAccessibleName("Update Collection");
 
     release!();
     await expect(dialog).toBeHidden({ timeout: 10_000 });

--- a/web/tests/regression/schedule-form.spec.ts
+++ b/web/tests/regression/schedule-form.spec.ts
@@ -457,7 +457,7 @@ test.describe("regression: schedule.form", () => {
    * Preconditions: create-schedule-mutation:pending
    * Interactions: (none — pending state only)
    * Expected:
-   *   - Create button shows Loader2 spinner and is disabled while mutation pending
+   *   - Create button is disabled and announces itself busy while mutation pending
    *   - Cancel and Delete (in edit) are also disabled
    *   - On success: 'Schedule created' toast, sheet closes, prefillData cleared
    *   - On error: 'Failed to create schedule' (or backend error.message) toast
@@ -486,6 +486,7 @@ test.describe("regression: schedule.form", () => {
     if (await createBtn.isEnabled()) {
       await createBtn.click();
       await expect(createBtn).toBeDisabled({ timeout: 5_000 });
+      await expect(createBtn).toHaveAttribute("aria-busy", "true");
     }
     release();
     void pageId;
@@ -497,7 +498,7 @@ test.describe("regression: schedule.form", () => {
    * Preconditions: update-schedule-mutation:pending
    * Interactions: (none — pending state only)
    * Expected:
-   *   - Update button shows Loader2 spinner, disabled
+   *   - Update button is disabled and announces itself busy while mutation pending
    *   - On success: 'Schedule updated' toast, sheet closes, editingSchedule cleared
    *   - On error: destructive Alert with error.message rendered inside form
    * Source refs: web/src/app/schedule/page.tsx, web/src/components/schedule-entry-form.tsx
@@ -518,6 +519,7 @@ test.describe("regression: schedule.form", () => {
     if (await updateBtn.isEnabled()) {
       await updateBtn.click();
       await expect(updateBtn).toBeDisabled({ timeout: 5_000 });
+      await expect(updateBtn).toHaveAttribute("aria-busy", "true");
     }
     release();
   });


### PR DESCRIPTION
## Description

Replaces 25 hand-rolled loading indicators in the web app with the design system's `Spinner`
(FiestaUI 3.2.0), and converts four submit buttons to `<Button loading>`.

**Why.** The defect is not "motion is ignored" — `globals.css` already zeroes every animation under
reduced motion. It is that the indicators stop *frozen at frame 0*: a three-quarter arc, or a
`border-t-transparent` ring with a visible gap, which reads as a rendering glitch rather than
"pending". FiestaUI's `Spinner` **replaces** the arc with a complete dimmed ring instead of freezing
it, and carries `role="status"` in both states.

### What changed

- **8 hand-drawn `border-*` rings** across 7 files (4 distinct class strings, two byte-identical
  triples) → `Spinner`. Each carries an explicit `text-*` class: the rings encoded colour in
  `border-primary`, while `Spinner` draws with `currentColor`, so a bare swap would have silently
  recoloured the three sites nested in `text-muted-foreground`. Zero hand-drawn rings survive
  (`grep 'animate-spin' | grep 'border-'` → 0 hits).
- **13 standalone `Loader2` indicators** → `Spinner`, size-matched 1:1 (`h-3.5`→`sm`/14px,
  `h-4`→default/16px, `h-5`→`lg`/20px; explicit `size-3`/`size-6`/`size-8`/`size-12` where the old
  markup was off-scale).
- **4 submit buttons** (collections, schedule-entry-form, mqtt-settings, location-settings Save) →
  `<Button loading>`, which adds `aria-busy` / `aria-disabled` and a double-submit click guard.
  Before this the app had **zero** buttons carrying `aria-busy`.
- **`web/app/globals.css`**: bridges the Spinner's arc↔static-ring swap to the app's two
  settings-driven motion kill switches. The component keys that swap off `motion-reduce:`, i.e. the
  OS media query only; `.reduce-motion` and `.site-animations-off` are class-driven and that query
  never sees them, so without the bridge an in-app-toggle user would get exactly the frozen arc this
  change exists to remove. The `.site-animations-off` arm repeats that block's `[data-board-preview]`
  exclusion so a spinner inside the board preview keeps the behaviour that switch deliberately leaves
  running.

`web/package.json` untouched — `@fiestaboard/ui` was already pinned at `3.2.0` on `main` (#1628).
All new imports use **deep subpaths** (`@fiestaboard/ui/components/feedback/spinner`) rather than the
root barrel, per standing instruction; this deviates from the ~120 existing barrel imports in this
app on purpose — please do not "correct" it back.

### Tests

Two assertions in `collections.spec.ts` were coupled to a CSS animation class
(`submit.locator("svg.animate-spin")`). They would still have passed — `Spinner`'s `LoaderCircle`
carries `animate-spin` — so leaving them was the lazy option. They were **retargeted, not weakened**:
each single assertion became three, asserting the user-visible contract instead of the paint detail.

```
- await expect(submit.locator("svg.animate-spin")).toBeVisible();
+ await expect(submit).toHaveAttribute("aria-busy", "true");
+ await expect(submit.locator("[data-slot='spinner']")).toBeVisible();
+ await expect(submit).toHaveAccessibleName("Create Collection");
```

The name assertion guards the specific regression `<Button loading>` could introduce — its label sits
at `opacity-0` rather than being replaced, precisely so the button does not rename itself to
"Loading" mid-interaction. `toBeDisabled()` is untouched, and no assertion was removed without a
strictly stronger replacement. `schedule-form.spec.ts` gains the matching `aria-busy` assertion; its
doc comments named "Loader2 spinner" and would otherwise have become false.

## Related Issue

Closes #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] New plugin
- [ ] Documentation update
- [x] Refactor / maintenance

---

## Verification — honest account

**No test, lint, typecheck, or build was run for this PR.** Not by the implementer, not by the
reviewer. This repo is Docker-only, `web/node_modules` does not exist in the worktree, and Docker was
not started. **CI is the only real gate on this diff** — `lint-web` (eslint + `tsc` + `format:check`),
`test-ui`, `a11y-tests`, and the Playwright `e2e-tests` job that owns `tests/regression/`.

What *was* actually verified, statically:

- **API confirmed against the exact `v3.2.0` tag** of the FiestaUI source (not the stale 2.2.3 copy
  in a local `node_modules`): `Spinner` emits `data-slot="spinner"` / `"spinner-mark"` /
  `"spinner-mark-static"`; `label={null}` ⇒ `aria-hidden` and no `role`; the sm/md/lg scale is
  14/16/20px; `<Button loading>` sets `aria-busy` + `aria-disabled` + `data-loading`, wraps children
  in an `opacity-0` label slot, and injects a `label={null}` spinner sized by
  `SPINNER_SIZE_BY_BUTTON_SIZE`.
- **Deep subpath resolution**: `v3.2.0` ships `src/components/feedback/spinner.tsx`, built with
  `preserveModules: true` / `preserveModulesRoot: "src"`, against an `exports` map of
  `"./*" → "./dist/*.js"`. The path resolves. Confirmed by reading the tag, not by resolving it.
- **CSS bridge cascade**: the new rules sit at brace depth 0 in `globals.css`, i.e. **unlayered**,
  while Tailwind's `hidden` / `motion-reduce:block` live in `@layer utilities` — unlayered wins
  regardless of specificity, so the `display` override lands. Verified by parsing the file, not by
  rendering it.
- **Size parity checked class-by-class** for all 21 spinner sites; `cn` is `extendTailwindMerge`
  (tailwind-merge ^3.5), which resolves the `size-*` group, so `size="lg" + className="size-8"`
  collapses to `size-8` as intended.
- **Import hygiene**: a script parsed every named import in all 23 touched files against its usage
  count. One orphan found — `useEffect` in `schedule-entry-form.tsx` — confirmed pre-existing on
  `origin/main` and left alone. `Box` was correctly dropped from the three files where the ring was
  its last use and kept in the four where it is still used; same for `Loader2`/`Loader2Icon`.
- **Prettier**: `printWidth: 120`. No added line exceeds 110 chars, and the four multi-line JSX
  elements were measured in collapsed form (125 / 129 / 124 / 166) to confirm prettier will not
  fold them back.
- **Blast radius on existing tests**: grepped every selector this diff could break.
  `first-commit-state.test.tsx`'s `getByRole("status")` still resolves to exactly one node
  (boot-gate's Spinner uses `label={null}`, so it adds no `status` role); `offline.spec.ts` matches
  the `h1` by heading role, not by text, so the new sr-only "Reconnecting..." does not create a
  strict-mode ambiguity; the `[aria-busy="true"]` locators in `pages-list.spec.ts` / `pages-edit.spec.ts`
  belong to `page-grid-selector`'s skeleton, and none of the four converted buttons render on those
  routes. No test file references `animate-spin`.

**Not verified, and not verifiable without a browser:** every rendered pixel. Specifically all
colour-inheritance claims, the sonner icon-slot layout, and the visual weight of the three large
spinners listed below.

## Review findings

Reviewed as an adversarial pass over the full diff against `origin/main`. **No blocking problem was
found, and nothing was changed during review.** Rule checks all pass: one commit, none on `main`,
trailer is exactly `Co-Authored-By: Claude <noreply@anthropic.com>`, no stray markdown, no
`package.json` edit, no new dependency, no root-barrel import, and no weakened assertion. Concerns
worth a reviewer's eyes, none of them blocking:

1. **Sonner's loading icon slot is the least-verified swap.** `icons.loading` went from a direct
   `<svg class="size-4">` to a `<span data-slot="spinner">` wrapping two svgs. Sonner's own CSS sizes
   `[data-icon]` and its children; a wrapper element is a different shape than what it expects.
   Worth eyeballing one `toast.loading()`.
2. **Two new screen-reader announcements.** `network-settings` gains two `role="status"` regions
   announcing `common.loading` where there was previously silence, and they can be live
   simultaneously. This is an improvement over an unannounced spinner, but it is new behaviour.
3. **`offline.tsx` announces "Reconnecting..." twice** — once as the `h1` text, once as the
   Spinner's sr-only label. Deliberate (an `h1` swap is not announced, a live region is), but a
   screen-reader user on that screen hears it in both places.
4. **Unscreenshotted visual deltas.** `update-context.tsx` (48px, full-bleed black — loses its dim
   `border-white/20` track ring and becomes a single arc), `boot-gate.tsx` (32px), and the two
   `wizard-provider` fallbacks (32px). The old marks were CSS border-arcs; `LoaderCircle` is a
   stroked arc of different weight. Sizes match; stroke weight does not.
5. **The four converted buttons keep `disabled` alongside `loading`,** so `<Button loading>`'s two
   headline benefits — staying in the tab order while pending, and the double-submit click guard —
   are inert here. That is deliberate: dropping `disabled` changes focus behaviour under six existing
   `toBeDisabled()` assertions and is a separate decision.
6. **Asymmetry in the CSS bridge.** The `.site-animations-off` arm carries `:not([data-board-preview] *)`
   but not the sibling rule's `:not([data-board-preview])` self-match. Harmless — a `spinner-mark`
   can never itself be the board-preview root — but the two rules no longer read identically.
7. **Padding note, in the good direction.** Previously these buttons rendered `<Loader2>` as a direct
   `<svg>` child, so `has-[>svg]:px-3` fired and the button narrowed by 8px the moment it went
   pending. `<Button loading>` moves children into a label slot and the variant's mirror rule only
   looks through it at the *original* children, so the padding — and the width — now stay put.

Deliberately out of scope, for a follow-up: ~30 in-button `Loader2` sites (the `has-[>svg]:px-3`
padding jump, plus `<Button loading>` hides children rather than swapping them, so the ~13 sites
rendering a distinct pending label like "Connecting…" / "Signing in…" would lose it); 6 `RefreshCw`
rotations (the icon identity *is* the message); `AlertDialogAction` sites (no `loading` prop);
`page-grid-selector.tsx`'s skeleton region. 72 → 47 `animate-spin` occurrences; the 47 remaining are
exactly those deferred sites.

## Checklist

- [ ] ~~I have tested my changes locally~~ — **no**, see "Verification" above. Docker-only repo, not started.
- [x] I have added/updated tests where applicable
- [ ] I have updated documentation where applicable — n/a
- [x] My code follows the project's coding standards

🤖 Generated with [Claude Code](https://claude.com/claude-code)
