### PR TITLE
chore(ui): adopt FiestaUI SecretInput for credential fields

### DIFF
--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -1825,7 +1825,9 @@
     "unknownType": "Unbekannter Typ: {type}",
     "pagePickerNone": "Keine (keine Übersteuerung)",
     "pagePickerLoading": "Seiten werden geladen…",
-    "pagePickerPlaceholder": "Seite auswählen…"
+    "pagePickerPlaceholder": "Seite auswählen…",
+    "showSecret": "Wert anzeigen",
+    "hideSecret": "Wert verbergen"
   },
   "filterPicker": {
     "noFiltersAvailable": "Keine Filter verfügbar",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1782,7 +1782,9 @@
     "unknownType": "Unknown type: {type}",
     "pagePickerNone": "None (no override)",
     "pagePickerLoading": "Loading pages…",
-    "pagePickerPlaceholder": "Choose a page…"
+    "pagePickerPlaceholder": "Choose a page…",
+    "showSecret": "Show value",
+    "hideSecret": "Hide value"
   },
   "filterPicker": {
     "noFiltersAvailable": "No filters available",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -1825,7 +1825,9 @@
     "unknownType": "Tipo desconocido: {type}",
     "pagePickerNone": "Ninguna (sin anulación)",
     "pagePickerLoading": "Cargando páginas…",
-    "pagePickerPlaceholder": "Elige una página…"
+    "pagePickerPlaceholder": "Elige una página…",
+    "showSecret": "Mostrar valor",
+    "hideSecret": "Ocultar valor"
   },
   "filterPicker": {
     "noFiltersAvailable": "No hay filtros disponibles",

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -1825,7 +1825,9 @@
     "unknownType": "Type inconnu : {type}",
     "pagePickerNone": "Aucune (pas de remplacement)",
     "pagePickerLoading": "Chargement des pages…",
-    "pagePickerPlaceholder": "Choisissez une page…"
+    "pagePickerPlaceholder": "Choisissez une page…",
+    "showSecret": "Afficher la valeur",
+    "hideSecret": "Masquer la valeur"
   },
   "filterPicker": {
     "noFiltersAvailable": "Aucun filtre disponible",

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -1825,7 +1825,9 @@
     "unknownType": "Tipo sconosciuto: {type}",
     "pagePickerNone": "Nessuna (nessuna sostituzione)",
     "pagePickerLoading": "Caricamento pagine…",
-    "pagePickerPlaceholder": "Scegli una pagina…"
+    "pagePickerPlaceholder": "Scegli una pagina…",
+    "showSecret": "Mostra valore",
+    "hideSecret": "Nascondi valore"
   },
   "filterPicker": {
     "noFiltersAvailable": "Nessun filtro disponibile",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -1825,7 +1825,9 @@
     "unknownType": "不明な型: {type}",
     "pagePickerNone": "なし（上書きなし）",
     "pagePickerLoading": "ページを読み込み中…",
-    "pagePickerPlaceholder": "ページを選択…"
+    "pagePickerPlaceholder": "ページを選択…",
+    "showSecret": "値を表示",
+    "hideSecret": "値を非表示"
   },
   "filterPicker": {
     "noFiltersAvailable": "利用可能なフィルターがありません",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -1825,7 +1825,9 @@
     "unknownType": "알 수 없는 타입: {type}",
     "pagePickerNone": "없음 (재정의 안 함)",
     "pagePickerLoading": "페이지를 불러오는 중…",
-    "pagePickerPlaceholder": "페이지 선택…"
+    "pagePickerPlaceholder": "페이지 선택…",
+    "showSecret": "값 표시",
+    "hideSecret": "값 숨기기"
   },
   "filterPicker": {
     "noFiltersAvailable": "사용 가능한 필터가 없습니다",

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -1825,7 +1825,9 @@
     "unknownType": "Onbekend type: {type}",
     "pagePickerNone": "Geen (geen override)",
     "pagePickerLoading": "Pagina's laden…",
-    "pagePickerPlaceholder": "Kies een pagina…"
+    "pagePickerPlaceholder": "Kies een pagina…",
+    "showSecret": "Waarde tonen",
+    "hideSecret": "Waarde verbergen"
   },
   "filterPicker": {
     "noFiltersAvailable": "Geen filters beschikbaar",

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -1825,7 +1825,9 @@
     "unknownType": "Nieznany typ: {type}",
     "pagePickerNone": "Brak (bez nadpisania)",
     "pagePickerLoading": "Ładowanie stron…",
-    "pagePickerPlaceholder": "Wybierz stronę…"
+    "pagePickerPlaceholder": "Wybierz stronę…",
+    "showSecret": "Pokaż wartość",
+    "hideSecret": "Ukryj wartość"
   },
   "filterPicker": {
     "noFiltersAvailable": "Brak dostępnych filtrów",

--- a/web/messages/pt.json
+++ b/web/messages/pt.json
@@ -1825,7 +1825,9 @@
     "unknownType": "Tipo desconhecido: {type}",
     "pagePickerNone": "Nenhuma (sem substituição)",
     "pagePickerLoading": "A carregar páginas…",
-    "pagePickerPlaceholder": "Escolha uma página…"
+    "pagePickerPlaceholder": "Escolha uma página…",
+    "showSecret": "Mostrar valor",
+    "hideSecret": "Ocultar valor"
   },
   "filterPicker": {
     "noFiltersAvailable": "Nenhum filtro disponível",

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -1825,7 +1825,9 @@
     "unknownType": "Неизвестный тип: {type}",
     "pagePickerNone": "Нет (без переопределения)",
     "pagePickerLoading": "Загрузка страниц…",
-    "pagePickerPlaceholder": "Выберите страницу…"
+    "pagePickerPlaceholder": "Выберите страницу…",
+    "showSecret": "Показать значение",
+    "hideSecret": "Скрыть значение"
   },
   "filterPicker": {
     "noFiltersAvailable": "Нет доступных фильтров",

--- a/web/messages/sv.json
+++ b/web/messages/sv.json
@@ -1825,7 +1825,9 @@
     "unknownType": "Okänd typ: {type}",
     "pagePickerNone": "Ingen (ingen åsidosättning)",
     "pagePickerLoading": "Laddar sidor…",
-    "pagePickerPlaceholder": "Välj en sida…"
+    "pagePickerPlaceholder": "Välj en sida…",
+    "showSecret": "Visa värde",
+    "hideSecret": "Dölj värde"
   },
   "filterPicker": {
     "noFiltersAvailable": "Inga filter tillgängliga",

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -1825,7 +1825,9 @@
     "unknownType": "Bilinmeyen tür: {type}",
     "pagePickerNone": "Yok (geçersiz kılma yok)",
     "pagePickerLoading": "Sayfalar yükleniyor…",
-    "pagePickerPlaceholder": "Bir sayfa seçin…"
+    "pagePickerPlaceholder": "Bir sayfa seçin…",
+    "showSecret": "Değeri göster",
+    "hideSecret": "Değeri gizle"
   },
   "filterPicker": {
     "noFiltersAvailable": "Kullanılabilir filtre yok",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -1825,7 +1825,9 @@
     "unknownType": "未知类型：{type}",
     "pagePickerNone": "无（不覆盖）",
     "pagePickerLoading": "正在加载页面…",
-    "pagePickerPlaceholder": "选择页面…"
+    "pagePickerPlaceholder": "选择页面…",
+    "showSecret": "显示值",
+    "hideSecret": "隐藏值"
   },
   "filterPicker": {
     "noFiltersAvailable": "没有可用的筛选器",

--- a/web/src/components/plugin-settings/schema-form.tsx
+++ b/web/src/components/plugin-settings/schema-form.tsx
@@ -17,7 +17,8 @@ import {
   Text,
   Textarea,
 } from "@fiestaboard/ui";
-import { Eye, EyeOff, Loader2, MapPin, Plus, Trash2 } from "lucide-react";
+import { SecretInput } from "@fiestaboard/ui/components/forms/secret-input";
+import { Loader2, MapPin, Plus, Trash2 } from "lucide-react";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
@@ -189,7 +190,7 @@ function EnumSelectField({
 }
 
 function StringField({ name, property, value, onChange, required, disabled }: FieldProps) {
-  const [showPassword, setShowPassword] = useState(false);
+  const tSecret = useTranslations("schemaForm");
   const [_timezoneValid, setTimezoneValid] = useState(true);
   const isPassword = property["ui:widget"] === "password";
   const isTextarea = property["ui:widget"] === "textarea";
@@ -288,35 +289,31 @@ function StringField({ name, property, value, onChange, required, disabled }: Fi
     return <PagePickerField id={name} value={String(value || "")} onChange={onChange} disabled={disabled} />;
   }
 
-  return (
-    <Box className="relative">
-      <Input
+  if (isPassword) {
+    return (
+      <SecretInput
         id={name}
-        type={isPassword && !showPassword ? "password" : "text"}
         value={String(value || "")}
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChange(e.target.value)}
         placeholder={property["ui:placeholder"] || property.description}
         disabled={disabled}
         required={required}
-        className={isPassword ? "pr-10" : undefined}
+        showLabel={tSecret("showSecret")}
+        hideLabel={tSecret("hideSecret")}
       />
-      {isPassword && (
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
-          onClick={() => setShowPassword(!showPassword)}
-          tabIndex={-1}
-        >
-          {showPassword ? (
-            <EyeOff className="h-4 w-4 text-muted-foreground" />
-          ) : (
-            <Eye className="h-4 w-4 text-muted-foreground" />
-          )}
-        </Button>
-      )}
-    </Box>
+    );
+  }
+
+  return (
+    <Input
+      id={name}
+      type="text"
+      value={String(value || "")}
+      onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChange(e.target.value)}
+      placeholder={property["ui:placeholder"] || property.description}
+      disabled={disabled}
+      required={required}
+    />
   );
 }
 

--- a/web/src/components/settings/ai-settings.tsx
+++ b/web/src/components/settings/ai-settings.tsx
@@ -27,19 +27,9 @@ import {
   Switch,
   Text,
 } from "@fiestaboard/ui";
+import { SecretInput } from "@fiestaboard/ui/components/forms/secret-input";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import {
-  CheckCircle2,
-  ChevronDown,
-  Eye,
-  EyeOff,
-  KeyRound,
-  Loader2,
-  Plus,
-  Sparkles,
-  Trash2,
-  XCircle,
-} from "lucide-react";
+import { CheckCircle2, ChevronDown, KeyRound, Loader2, Plus, Sparkles, Trash2, XCircle } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 
@@ -110,7 +100,6 @@ function ProviderRow({
   onMakeDefault,
 }: ProviderRowProps) {
   const t = useTranslations("settings.ai");
-  const [showKey, setShowKey] = useState(false);
   const [modelInput, setModelInput] = useState("");
   const [testing, setTesting] = useState(false);
   const [testResult, setTestResult] = useState<{ ok: boolean; message: string } | null>(null);
@@ -309,24 +298,15 @@ function ProviderRow({
             </Label>
             <Box className="relative">
               <KeyRound className="pointer-events-none absolute left-2 top-2 h-3.5 w-3.5 text-muted-foreground" />
-              <Input
+              <SecretInput
                 id={`key-${provider.id}`}
-                type={showKey ? "text" : "password"}
                 value={provider.api_key}
                 onChange={(e) => onChange({ ...provider, api_key: e.target.value })}
                 placeholder="sk-..."
-                className="h-8 pl-7 pr-8 font-mono text-xs"
+                showLabel="Show API key"
+                hideLabel="Hide API key"
+                className="h-8 pl-7 text-xs"
               />
-              <Button
-                type="button"
-                size="icon"
-                variant="ghost"
-                className="absolute right-0 top-0 h-8 w-8"
-                onClick={() => setShowKey((v) => !v)}
-                aria-label={showKey ? "Hide API key" : "Show API key"}
-              >
-                {showKey ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
-              </Button>
             </Box>
           </Stack>
 

--- a/web/src/components/settings/board-settings.tsx
+++ b/web/src/components/settings/board-settings.tsx
@@ -15,14 +15,12 @@ import {
   Stack,
   Text,
   TextLink,
-  Tooltip,
-  TooltipContent,
   TooltipProvider,
-  TooltipTrigger,
 } from "@fiestaboard/ui";
 import { Spinner } from "@fiestaboard/ui/components/feedback/spinner";
+import { SecretInput } from "@fiestaboard/ui/components/forms/secret-input";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { AlertCircle, Check, Eye, EyeOff, Key, KeyRound, Loader2, Monitor, Search } from "lucide-react";
+import { AlertCircle, Check, Key, KeyRound, Loader2, Monitor, Search } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
@@ -38,7 +36,6 @@ export function BoardSettings() {
   const tCommon = useTranslations("common");
   const queryClient = useQueryClient();
   const [formData, setFormData] = useState<Partial<BoardConfig>>({});
-  const [showSecrets, setShowSecrets] = useState<Record<string, boolean>>({});
   const [hasChanges, setHasChanges] = useState(false);
   const [localKeyMode, setLocalKeyMode] = useState<LocalKeyMode>("api_key");
   const [enablementToken, setEnablementToken] = useState("");
@@ -343,44 +340,24 @@ export function BoardSettings() {
 
               {localKeyMode === "api_key" ? (
                 <Stack gap="1.5">
-                  <label className="text-xs font-medium">
+                  <label className="text-xs font-medium" htmlFor="board-local-api-key">
                     {t("localApiKey")}{" "}
                     <Text as="span" size="xs" tone="destructive">
                       *
                     </Text>
                   </label>
-                  <Flex gap="2">
-                    <input
-                      type={showSecrets.local_api_key ? "text" : "password"}
-                      value={formData.local_api_key === "***" ? "" : (formData.local_api_key ?? "")}
-                      onChange={(e) => handleChange("local_api_key", e.target.value)}
-                      placeholder={hasLocalKey ? t("localApiKeySetPlaceholder") : t("localApiKeyPlaceholder")}
-                      className="flex-1 h-9 px-3 text-sm rounded-md border bg-background font-mono"
-                    />
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Button
-                          type="button"
-                          variant="outline"
-                          size="sm"
-                          aria-label={showSecrets.local_api_key ? t("hideApiKey") : t("showApiKey")}
-                          onClick={() =>
-                            setShowSecrets((prev) => ({
-                              ...prev,
-                              local_api_key: !prev.local_api_key,
-                            }))
-                          }
-                          className="h-9 w-9 p-0"
-                          disabled={formData.local_api_key === "***"}
-                        >
-                          {showSecrets.local_api_key ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        <Text>{formData.local_api_key === "***" ? t("cannotReveal") : t("toggleVisibility")}</Text>
-                      </TooltipContent>
-                    </Tooltip>
-                  </Flex>
+                  <SecretInput
+                    id="board-local-api-key"
+                    value={formData.local_api_key === "***" ? "" : (formData.local_api_key ?? "")}
+                    onChange={(e) => handleChange("local_api_key", e.target.value)}
+                    placeholder={hasLocalKey ? t("localApiKeySetPlaceholder") : t("localApiKeyPlaceholder")}
+                    revealDisabled={formData.local_api_key === "***"}
+                    // The old Tooltip explaining why a server-stored value cannot be
+                    // revealed has nowhere to attach now that the toggle is internal,
+                    // so that copy becomes the disabled toggle's accessible name.
+                    showLabel={formData.local_api_key === "***" ? t("cannotReveal") : t("showApiKey")}
+                    hideLabel={t("hideApiKey")}
+                  />
                   <Text size="xs" tone="muted">
                     {t.rich("localApiSetupGuideHint", {
                       link: (chunks) => (
@@ -399,31 +376,17 @@ export function BoardSettings() {
               ) : (
                 <Stack gap="2">
                   <Stack gap="1.5">
-                    <label className="text-xs font-medium">{t("enablementToken")}</label>
-                    <Flex gap="2">
-                      <input
-                        type={showSecrets.enablement_token ? "text" : "password"}
-                        value={enablementToken}
-                        onChange={(e) => setEnablementToken(e.target.value)}
-                        placeholder={t("enablementTokenPlaceholder")}
-                        className="flex-1 h-9 px-3 text-sm rounded-md border bg-background font-mono"
-                      />
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        aria-label={showSecrets.enablement_token ? t("hideToken") : t("showToken")}
-                        onClick={() =>
-                          setShowSecrets((prev) => ({
-                            ...prev,
-                            enablement_token: !prev.enablement_token,
-                          }))
-                        }
-                        className="h-9 w-9 p-0"
-                      >
-                        {showSecrets.enablement_token ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                      </Button>
-                    </Flex>
+                    <label className="text-xs font-medium" htmlFor="board-enablement-token">
+                      {t("enablementToken")}
+                    </label>
+                    <SecretInput
+                      id="board-enablement-token"
+                      value={enablementToken}
+                      onChange={(e) => setEnablementToken(e.target.value)}
+                      placeholder={t("enablementTokenPlaceholder")}
+                      showLabel={t("showToken")}
+                      hideLabel={t("hideToken")}
+                    />
                     <Text size="xs" tone="muted">
                       {t.rich("enablementTokenHint", {
                         link: (chunks) => (
@@ -464,44 +427,21 @@ export function BoardSettings() {
           {/* Cloud API Fields */}
           {apiMode === "cloud" && (
             <Stack gap="1.5">
-              <label className="text-xs font-medium">
+              <label className="text-xs font-medium" htmlFor="board-cloud-key">
                 {t("readWriteApiKey")}{" "}
                 <Text as="span" size="xs" tone="destructive">
                   *
                 </Text>
               </label>
-              <Flex gap="2">
-                <input
-                  type={showSecrets.cloud_key ? "text" : "password"}
-                  value={formData.cloud_key === "***" ? "" : (formData.cloud_key ?? "")}
-                  onChange={(e) => handleChange("cloud_key", e.target.value)}
-                  placeholder={hasCloudKey ? t("cloudKeySetPlaceholder") : t("cloudKeyPlaceholder")}
-                  className="flex-1 h-9 px-3 text-sm rounded-md border bg-background font-mono"
-                />
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      aria-label={showSecrets.cloud_key ? t("hideCloudKey") : t("showCloudKey")}
-                      onClick={() =>
-                        setShowSecrets((prev) => ({
-                          ...prev,
-                          cloud_key: !prev.cloud_key,
-                        }))
-                      }
-                      className="h-9 w-9 p-0"
-                      disabled={formData.cloud_key === "***"}
-                    >
-                      {showSecrets.cloud_key ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>
-                    <Text>{formData.cloud_key === "***" ? t("cannotReveal") : t("toggleVisibility")}</Text>
-                  </TooltipContent>
-                </Tooltip>
-              </Flex>
+              <SecretInput
+                id="board-cloud-key"
+                value={formData.cloud_key === "***" ? "" : (formData.cloud_key ?? "")}
+                onChange={(e) => handleChange("cloud_key", e.target.value)}
+                placeholder={hasCloudKey ? t("cloudKeySetPlaceholder") : t("cloudKeyPlaceholder")}
+                revealDisabled={formData.cloud_key === "***"}
+                showLabel={formData.cloud_key === "***" ? t("cannotReveal") : t("showCloudKey")}
+                hideLabel={t("hideCloudKey")}
+              />
               <Text size="xs" tone="muted">
                 {t("cloudKeyHint")}
               </Text>

--- a/web/src/components/settings/display-settings.tsx
+++ b/web/src/components/settings/display-settings.tsx
@@ -269,7 +269,7 @@ function BoardConnectionForm({
                 revealDisabled={board.local_api_key === "***"}
                 showLabel={t("showSecretAriaLabel")}
                 hideLabel={t("hideSecretAriaLabel")}
-                className="h-8 px-2 text-xs"
+                className="h-8 pl-2 text-xs"
               />
               <Text tone="muted" className="text-[10px]">
                 {t.rich("localApiKeyHelp", {
@@ -298,7 +298,7 @@ function BoardConnectionForm({
                 placeholder={t("enablementTokenPlaceholder")}
                 showLabel={t("showSecretAriaLabel")}
                 hideLabel={t("hideSecretAriaLabel")}
-                className="h-8 px-2 text-xs"
+                className="h-8 pl-2 text-xs"
               />
               <Button
                 type="button"
@@ -344,7 +344,7 @@ function BoardConnectionForm({
             revealDisabled={board.cloud_key === "***"}
             showLabel={t("showSecretAriaLabel")}
             hideLabel={t("hideSecretAriaLabel")}
-            className="h-8 px-2 text-xs"
+            className="h-8 pl-2 text-xs"
           />
           <Text tone="muted" className="text-[10px]">
             {t("cloudKeyHelp")}
@@ -371,7 +371,7 @@ function BoardConnectionForm({
             revealDisabled={board.note_array_token === "***"}
             showLabel={t("showSecretAriaLabel")}
             hideLabel={t("hideSecretAriaLabel")}
-            className="h-8 px-2 text-xs"
+            className="h-8 pl-2 text-xs"
           />
           <Text tone="muted" className="text-[10px]">
             {t("noteArrayTokenHelp")}

--- a/web/src/components/settings/display-settings.tsx
+++ b/web/src/components/settings/display-settings.tsx
@@ -28,14 +28,13 @@ import {
   Text,
   TextLink,
 } from "@fiestaboard/ui";
+import { SecretInput } from "@fiestaboard/ui/components/forms/secret-input";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   AlertCircle,
   Check,
   ChevronDown,
   ChevronRight,
-  Eye,
-  EyeOff,
   Key,
   KeyRound,
   LayoutGrid,
@@ -100,7 +99,6 @@ function BoardConnectionForm({
   onUpdate: (boardId: string, updates: Partial<BoardInstance>) => void;
 }) {
   const t = useTranslations("displaySettings");
-  const [showSecrets, setShowSecrets] = useState<Record<string, boolean>>({});
   const [localKeyMode, setLocalKeyMode] = useState<"api_key" | "enablement_token">("api_key");
   const [enablementToken, setEnablementToken] = useState("");
   const [isEnabling, setIsEnabling] = useState(false);
@@ -252,37 +250,27 @@ function BoardConnectionForm({
 
           {localKeyMode === "api_key" ? (
             <Stack gap="1">
-              <label className="text-xs font-medium">
+              <label className="text-xs font-medium" htmlFor={`local-api-key-${board.id}`}>
                 {t("localApiKeyLabel")}{" "}
                 <Text as="span" size="xs" tone="destructive">
                   *
                 </Text>
               </label>
-              <Flex gap="1.5">
-                <input
-                  type={showSecrets.local_api_key ? "text" : "password"}
-                  defaultValue={board.local_api_key === "***" ? "" : (board.local_api_key ?? "")}
-                  onBlur={(e) => {
-                    const val = e.target.value;
-                    if (val && val !== "***" && val !== board.local_api_key) {
-                      onUpdate(board.id, { local_api_key: val });
-                    }
-                  }}
-                  placeholder={hasLocalKey ? t("localApiKeySetPlaceholder") : t("localApiKeyPlaceholder")}
-                  className="flex-1 h-8 px-2 text-xs rounded-md border bg-background font-mono"
-                />
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={() => setShowSecrets((prev) => ({ ...prev, local_api_key: !prev.local_api_key }))}
-                  aria-label={showSecrets.local_api_key ? t("hideSecretAriaLabel") : t("showSecretAriaLabel")}
-                  className="h-8 w-8 p-0"
-                  disabled={board.local_api_key === "***"}
-                >
-                  {showSecrets.local_api_key ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
-                </Button>
-              </Flex>
+              <SecretInput
+                id={`local-api-key-${board.id}`}
+                defaultValue={board.local_api_key === "***" ? "" : (board.local_api_key ?? "")}
+                onBlur={(e) => {
+                  const val = e.target.value;
+                  if (val && val !== "***" && val !== board.local_api_key) {
+                    onUpdate(board.id, { local_api_key: val });
+                  }
+                }}
+                placeholder={hasLocalKey ? t("localApiKeySetPlaceholder") : t("localApiKeyPlaceholder")}
+                revealDisabled={board.local_api_key === "***"}
+                showLabel={t("showSecretAriaLabel")}
+                hideLabel={t("hideSecretAriaLabel")}
+                className="h-8 px-2 text-xs"
+              />
               <Text tone="muted" className="text-[10px]">
                 {t.rich("localApiKeyHelp", {
                   link: (chunks) => (
@@ -300,26 +288,18 @@ function BoardConnectionForm({
             </Stack>
           ) : (
             <Stack gap="1.5">
-              <label className="text-xs font-medium">{t("enablementTokenLabel")}</label>
-              <Flex gap="1.5">
-                <input
-                  type={showSecrets.enablement_token ? "text" : "password"}
-                  value={enablementToken}
-                  onChange={(e) => setEnablementToken(e.target.value)}
-                  placeholder={t("enablementTokenPlaceholder")}
-                  className="flex-1 h-8 px-2 text-xs rounded-md border bg-background font-mono"
-                />
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={() => setShowSecrets((prev) => ({ ...prev, enablement_token: !prev.enablement_token }))}
-                  aria-label={showSecrets.enablement_token ? t("hideSecretAriaLabel") : t("showSecretAriaLabel")}
-                  className="h-8 w-8 p-0"
-                >
-                  {showSecrets.enablement_token ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
-                </Button>
-              </Flex>
+              <label className="text-xs font-medium" htmlFor={`enablement-token-${board.id}`}>
+                {t("enablementTokenLabel")}
+              </label>
+              <SecretInput
+                id={`enablement-token-${board.id}`}
+                value={enablementToken}
+                onChange={(e) => setEnablementToken(e.target.value)}
+                placeholder={t("enablementTokenPlaceholder")}
+                showLabel={t("showSecretAriaLabel")}
+                hideLabel={t("hideSecretAriaLabel")}
+                className="h-8 px-2 text-xs"
+              />
               <Button
                 type="button"
                 variant="secondary"
@@ -345,37 +325,27 @@ function BoardConnectionForm({
       {/* Cloud API Fields (single boards — arrays use the token below) */}
       {apiMode === "cloud" && !isArray && (
         <Stack gap="1">
-          <label className="text-xs font-medium">
+          <label className="text-xs font-medium" htmlFor={`cloud-key-${board.id}`}>
             {t("cloudKeyLabel")}{" "}
             <Text as="span" size="xs" tone="destructive">
               *
             </Text>
           </label>
-          <Flex gap="1.5">
-            <input
-              type={showSecrets.cloud_key ? "text" : "password"}
-              defaultValue={board.cloud_key === "***" ? "" : (board.cloud_key ?? "")}
-              onBlur={(e) => {
-                const val = e.target.value;
-                if (val && val !== "***" && val !== board.cloud_key) {
-                  onUpdate(board.id, { cloud_key: val });
-                }
-              }}
-              placeholder={hasCloudKey ? t("cloudKeySetPlaceholder") : t("cloudKeyPlaceholder")}
-              className="flex-1 h-8 px-2 text-xs rounded-md border bg-background font-mono"
-            />
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => setShowSecrets((prev) => ({ ...prev, cloud_key: !prev.cloud_key }))}
-              aria-label={showSecrets.cloud_key ? t("hideSecretAriaLabel") : t("showSecretAriaLabel")}
-              className="h-8 w-8 p-0"
-              disabled={board.cloud_key === "***"}
-            >
-              {showSecrets.cloud_key ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
-            </Button>
-          </Flex>
+          <SecretInput
+            id={`cloud-key-${board.id}`}
+            defaultValue={board.cloud_key === "***" ? "" : (board.cloud_key ?? "")}
+            onBlur={(e) => {
+              const val = e.target.value;
+              if (val && val !== "***" && val !== board.cloud_key) {
+                onUpdate(board.id, { cloud_key: val });
+              }
+            }}
+            placeholder={hasCloudKey ? t("cloudKeySetPlaceholder") : t("cloudKeyPlaceholder")}
+            revealDisabled={board.cloud_key === "***"}
+            showLabel={t("showSecretAriaLabel")}
+            hideLabel={t("hideSecretAriaLabel")}
+            className="h-8 px-2 text-xs"
+          />
           <Text tone="muted" className="text-[10px]">
             {t("cloudKeyHelp")}
           </Text>
@@ -388,32 +358,21 @@ function BoardConnectionForm({
           <label className="text-xs font-medium" htmlFor={`note-array-token-${board.id}`}>
             {t("noteArrayTokenLabel")}
           </label>
-          <Flex gap="1.5">
-            <input
-              id={`note-array-token-${board.id}`}
-              type={showSecrets.note_array_token ? "text" : "password"}
-              defaultValue={board.note_array_token === "***" ? "" : (board.note_array_token ?? "")}
-              onBlur={(e) => {
-                const val = e.target.value;
-                if (val && val !== "***" && val !== board.note_array_token) {
-                  onUpdate(board.id, { note_array_token: val });
-                }
-              }}
-              placeholder={hasNoteArrayToken ? t("noteArrayTokenSetPlaceholder") : t("noteArrayTokenPlaceholder")}
-              className="flex-1 h-8 px-2 text-xs rounded-md border bg-background font-mono"
-            />
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => setShowSecrets((prev) => ({ ...prev, note_array_token: !prev.note_array_token }))}
-              aria-label={showSecrets.note_array_token ? t("hideSecretAriaLabel") : t("showSecretAriaLabel")}
-              className="h-8 w-8 p-0"
-              disabled={board.note_array_token === "***"}
-            >
-              {showSecrets.note_array_token ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
-            </Button>
-          </Flex>
+          <SecretInput
+            id={`note-array-token-${board.id}`}
+            defaultValue={board.note_array_token === "***" ? "" : (board.note_array_token ?? "")}
+            onBlur={(e) => {
+              const val = e.target.value;
+              if (val && val !== "***" && val !== board.note_array_token) {
+                onUpdate(board.id, { note_array_token: val });
+              }
+            }}
+            placeholder={hasNoteArrayToken ? t("noteArrayTokenSetPlaceholder") : t("noteArrayTokenPlaceholder")}
+            revealDisabled={board.note_array_token === "***"}
+            showLabel={t("showSecretAriaLabel")}
+            hideLabel={t("hideSecretAriaLabel")}
+            className="h-8 px-2 text-xs"
+          />
           <Text tone="muted" className="text-[10px]">
             {t("noteArrayTokenHelp")}
           </Text>

--- a/web/src/components/settings/mqtt-settings.tsx
+++ b/web/src/components/settings/mqtt-settings.tsx
@@ -20,8 +20,9 @@ import {
   Switch,
   Text,
 } from "@fiestaboard/ui";
+import { SecretInput } from "@fiestaboard/ui/components/forms/secret-input";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { CheckCircle2, ChevronDown, Eye, EyeOff, Radio, XCircle } from "lucide-react";
+import { CheckCircle2, ChevronDown, Radio, XCircle } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 
@@ -34,7 +35,6 @@ export function MqttSettingsCard() {
   const tCommon = useTranslations("common");
   const queryClient = useQueryClient();
   const [expanded, setExpanded] = useState(false);
-  const [showPassword, setShowPassword] = useState(false);
   const [draft, setDraft] = useState<Partial<MqttSettings>>({});
 
   const { data: settings, isLoading } = useQuery({
@@ -178,26 +178,16 @@ export function MqttSettingsCard() {
                 <Label htmlFor="mqtt-password" className="text-xs">
                   {t("password")}
                 </Label>
-                <Flex gap="1.5">
-                  <Input
-                    id="mqtt-password"
-                    type={showPassword ? "text" : "password"}
-                    value={merged.password === "***" ? "" : merged.password}
-                    onChange={(e) => setDraft((d) => ({ ...d, password: e.target.value }))}
-                    placeholder={settings?.password === "***" ? t("passwordSet") : t("optional")}
-                    className="h-8 text-xs font-mono flex-1"
-                  />
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={() => setShowPassword((p) => !p)}
-                    className="h-8 w-8 p-0 flex-shrink-0"
-                    aria-label={showPassword ? t("hidePassword") : t("showPassword")}
-                  >
-                    {showPassword ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
-                  </Button>
-                </Flex>
+                <SecretInput
+                  id="mqtt-password"
+                  value={merged.password === "***" ? "" : merged.password}
+                  onChange={(e) => setDraft((d) => ({ ...d, password: e.target.value }))}
+                  placeholder={settings?.password === "***" ? t("passwordSet") : t("optional")}
+                  revealDisabled={merged.password === "***"}
+                  showLabel={t("showPassword")}
+                  hideLabel={t("hidePassword")}
+                  className="h-8 text-xs"
+                />
               </Stack>
             </Grid>
 

--- a/web/src/components/settings/tile-grid-assignment.tsx
+++ b/web/src/components/settings/tile-grid-assignment.tsx
@@ -20,6 +20,7 @@ import {
   Stack,
   Text,
 } from "@fiestaboard/ui";
+import { SecretInput } from "@fiestaboard/ui/components/forms/secret-input";
 import { AlertCircle, Check, Key, KeyRound, Loader2, Plus, Radar, ScanSearch, Trash2, Wifi } from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
@@ -562,9 +563,8 @@ export function TileGridAssignment({
                     *
                   </Text>
                 </label>
-                <input
+                <SecretInput
                   id={`tile-key-${board.id}`}
-                  type="password"
                   value={form.localApiKey === MASKED ? "" : form.localApiKey}
                   onChange={(e) => setForm((prev) => ({ ...prev, localApiKey: e.target.value }))}
                   placeholder={
@@ -572,7 +572,10 @@ export function TileGridAssignment({
                       ? t("localApiKeySetPlaceholder")
                       : t("localApiKeyPlaceholder")
                   }
-                  className="w-full h-8 px-2 text-xs rounded-md border bg-background font-mono"
+                  revealDisabled={form.localApiKey === MASKED}
+                  showLabel={t("showSecretAriaLabel")}
+                  hideLabel={t("hideSecretAriaLabel")}
+                  className="h-8 px-2 text-xs"
                 />
               </Stack>
             ) : (
@@ -580,13 +583,14 @@ export function TileGridAssignment({
                 <label className="text-xs font-medium" htmlFor={`tile-token-${board.id}`}>
                   {t("enablementTokenLabel")}
                 </label>
-                <input
+                <SecretInput
                   id={`tile-token-${board.id}`}
-                  type="password"
                   value={form.enablementToken}
                   onChange={(e) => setForm((prev) => ({ ...prev, enablementToken: e.target.value }))}
                   placeholder={t("enablementTokenPlaceholder")}
-                  className="w-full h-8 px-2 text-xs rounded-md border bg-background font-mono"
+                  showLabel={t("showSecretAriaLabel")}
+                  hideLabel={t("hideSecretAriaLabel")}
+                  className="h-8 px-2 text-xs"
                 />
                 <Button
                   type="button"

--- a/web/src/components/settings/tile-grid-assignment.tsx
+++ b/web/src/components/settings/tile-grid-assignment.tsx
@@ -575,7 +575,7 @@ export function TileGridAssignment({
                   revealDisabled={form.localApiKey === MASKED}
                   showLabel={t("showSecretAriaLabel")}
                   hideLabel={t("hideSecretAriaLabel")}
-                  className="h-8 px-2 text-xs"
+                  className="h-8 pl-2 text-xs"
                 />
               </Stack>
             ) : (
@@ -590,7 +590,7 @@ export function TileGridAssignment({
                   placeholder={t("enablementTokenPlaceholder")}
                   showLabel={t("showSecretAriaLabel")}
                   hideLabel={t("hideSecretAriaLabel")}
-                  className="h-8 px-2 text-xs"
+                  className="h-8 pl-2 text-xs"
                 />
                 <Button
                   type="button"

--- a/web/src/components/wizard/step-board-setup.tsx
+++ b/web/src/components/wizard/step-board-setup.tsx
@@ -1,20 +1,9 @@
 "use client";
 
-import { Box, Button, Flex, Grid, Input, Label, List, ListItem, Stack, Text } from "@fiestaboard/ui";
+import { Button, Flex, Grid, Input, Label, List, ListItem, Stack, Text } from "@fiestaboard/ui";
 import { Spinner } from "@fiestaboard/ui/components/feedback/spinner";
-import {
-  CheckCircle,
-  Cloud,
-  Eye,
-  EyeOff,
-  HelpCircle,
-  Key,
-  KeyRound,
-  Loader2,
-  Search,
-  Wifi,
-  XCircle,
-} from "lucide-react";
+import { SecretInput } from "@fiestaboard/ui/components/forms/secret-input";
+import { CheckCircle, Cloud, HelpCircle, Key, KeyRound, Loader2, Search, Wifi, XCircle } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { ScaledBoardDisplay } from "@/components/scaled-board-display";
@@ -65,7 +54,6 @@ export function StepBoardSetup({
   const [testStatus, setTestStatus] = useState<"idle" | "testing" | "success" | "error">("idle");
   const [testMessage, setTestMessage] = useState("");
   const [troubleshootingSteps, setTroubleshootingSteps] = useState<string[]>([]);
-  const [showApiKey, setShowApiKey] = useState(false);
   const [localKeyMode, setLocalKeyMode] = useState<LocalKeyMode>("api_key");
   const [enablementToken, setEnablementToken] = useState("");
   const [enablementStatus, setEnablementStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
@@ -277,31 +265,21 @@ export function StepBoardSetup({
         <Stack gap="4">
           <Stack gap="2">
             <Label htmlFor="cloud_key">{t("readWriteApiKey")}</Label>
-            <Box className="relative">
-              <Input
-                id="cloud_key"
-                type={showApiKey ? "text" : "password"}
-                placeholder={t("cloudKeyPlaceholder")}
-                value={config.cloud_key}
-                onChange={(e) => {
-                  onConfigChange({
-                    ...config,
-                    cloud_key: e.target.value,
-                    connectionVerified: false,
-                  });
-                  setTestStatus("idle");
-                }}
-                className="pr-10"
-              />
-              <button
-                type="button"
-                onClick={() => setShowApiKey(!showApiKey)}
-                aria-label={showApiKey ? tbs("hideApiKey") : tbs("showApiKey")}
-                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
-              >
-                {showApiKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-              </button>
-            </Box>
+            <SecretInput
+              id="cloud_key"
+              placeholder={t("cloudKeyPlaceholder")}
+              value={config.cloud_key}
+              onChange={(e) => {
+                onConfigChange({
+                  ...config,
+                  cloud_key: e.target.value,
+                  connectionVerified: false,
+                });
+                setTestStatus("idle");
+              }}
+              showLabel={tbs("showApiKey")}
+              hideLabel={tbs("hideApiKey")}
+            />
             <Text size="xs" tone="muted" className="flex items-center gap-1">
               <HelpCircle className="h-3 w-3" />
               {t("cloudKeyHelp")}
@@ -441,31 +419,21 @@ export function StepBoardSetup({
           {localKeyMode === "api_key" ? (
             <Stack gap="2">
               <Label htmlFor="local_api_key">{t("localApiKey")}</Label>
-              <Box className="relative">
-                <Input
-                  id="local_api_key"
-                  type={showApiKey ? "text" : "password"}
-                  placeholder={t("localApiKeyPlaceholder")}
-                  value={config.local_api_key}
-                  onChange={(e) => {
-                    onConfigChange({
-                      ...config,
-                      local_api_key: e.target.value,
-                      connectionVerified: false,
-                    });
-                    setTestStatus("idle");
-                  }}
-                  className="pr-10"
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowApiKey(!showApiKey)}
-                  aria-label={showApiKey ? tbs("hideApiKey") : tbs("showApiKey")}
-                  className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
-                >
-                  {showApiKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                </button>
-              </Box>
+              <SecretInput
+                id="local_api_key"
+                placeholder={t("localApiKeyPlaceholder")}
+                value={config.local_api_key}
+                onChange={(e) => {
+                  onConfigChange({
+                    ...config,
+                    local_api_key: e.target.value,
+                    connectionVerified: false,
+                  });
+                  setTestStatus("idle");
+                }}
+                showLabel={tbs("showApiKey")}
+                hideLabel={tbs("hideApiKey")}
+              />
               <Text size="xs" tone="muted" className="flex items-center gap-1">
                 <HelpCircle className="h-3 w-3" />
                 {t("localApiKeyHelp")}
@@ -475,27 +443,17 @@ export function StepBoardSetup({
             <Stack gap="3">
               <Stack gap="2">
                 <Label htmlFor="enablement_token">{t("enablementToken")}</Label>
-                <Box className="relative">
-                  <Input
-                    id="enablement_token"
-                    type={showApiKey ? "text" : "password"}
-                    placeholder={t("enablementTokenPlaceholder")}
-                    value={enablementToken}
-                    onChange={(e) => {
-                      setEnablementToken(e.target.value);
-                      setEnablementStatus("idle");
-                    }}
-                    className="pr-10"
-                  />
-                  <button
-                    type="button"
-                    onClick={() => setShowApiKey(!showApiKey)}
-                    aria-label={showApiKey ? tbs("hideToken") : tbs("showToken")}
-                    className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded"
-                  >
-                    {showApiKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                  </button>
-                </Box>
+                <SecretInput
+                  id="enablement_token"
+                  placeholder={t("enablementTokenPlaceholder")}
+                  value={enablementToken}
+                  onChange={(e) => {
+                    setEnablementToken(e.target.value);
+                    setEnablementStatus("idle");
+                  }}
+                  showLabel={tbs("showToken")}
+                  hideLabel={tbs("hideToken")}
+                />
                 <Text size="xs" tone="muted" className="flex items-center gap-1">
                   <HelpCircle className="h-3 w-3" />
                   {t("enablementTokenHelp")}


### PR DESCRIPTION
## What changed

Replaces 15 hand-rolled credential fields across 7 files with `SecretInput`, the primitive promoted into `@fiestaboard/ui` v3.1.0. Three divergent shapes had accumulated — a sibling toggle in a `Flex` row, an absolutely-positioned overlay button, and no toggle at all — and all three collapse into one component.

| File | Fields |
| --- | --- |
| `web/src/components/settings/board-settings.tsx` | 3 |
| `web/src/components/settings/display-settings.tsx` | 4 |
| `web/src/components/settings/tile-grid-assignment.tsx` | 2 |
| `web/src/components/wizard/step-board-setup.tsx` | 3 |
| `web/src/components/settings/ai-settings.tsx` | 1 |
| `web/src/components/settings/mqtt-settings.tsx` | 1 |
| `web/src/components/plugin-settings/schema-form.tsx` | 1 |

No `package.json` change — `origin/main` already carries `@fiestaboard/ui` 3.2.0 via #1628 (merged 2026-08-16). This PR has no dependency on anything unlanded.

### Why — two real accessibility defects, not just deduplication

1. **`tile-grid-assignment.tsx`** — the per-tile local API key and enablement token were raw `<input type="password">` with **no reveal control of any kind**. Users typing a long key into the note-array tile dialog could not verify what they had entered.
2. **`schema-form.tsx`** — the plugin-settings password toggle carried `tabIndex={-1}` **and** had no accessible name (no `aria-label`, no text child, only an `<Eye>` svg). It was simultaneously keyboard-unreachable and unnamed to assistive tech — two WCAG failures. `SecretInput` is natively focusable and names the toggle after the action it performs.

Also fixes six credential inputs whose `<label>` had no `htmlFor` over an input with no `id`, leaving them programmatically unlabelled (board-settings ×3, display-settings ×3).

### Behaviour that improves as a side effect

- `revealDisabled` replaces the hand-coded `disabled={x === "***"}` on the server-masked fields. Unlike the old code, `SecretInput` computes `effectivelyVisible = visible && !revealDisabled`, so a field that is revealed and *then* flips to write-only re-masks itself. The old code left the secret on screen behind a dead toggle.
- The wizard's three fields shared a single `showApiKey` state — revealing one revealed all three. Each `SecretInput` now owns its own visibility.
- `SecretInput` sets `spellCheck={false}` / `autoCapitalize="none"` / `autoCorrect="off"`, which none of the hand-rolled fields did.

### i18n

Adds `schemaForm.showSecret` / `schemaForm.hideSecret` to all 14 locales, each string copied from the already-reviewed `displaySettings.showSecretAriaLabel` / `hideSecretAriaLabel` in the same locale (identical English: "Show value" / "Hide value"). Nothing is machine-guessed. +2 lines per locale, no formatting churn.

---

## Review findings

An adversarial review of the implementation diff ran before this PR was opened. It found **one blocking defect**, fixed in `0c4e914d`.

### BLOCKING (fixed): the reveal button's icon gutter was being deleted by tailwind-merge

Six compact fields passed `className="h-8 px-2 text-xs"`. `SecretInput` merges its own classes as `cn("pr-9 font-mono", className)`, and tailwind-merge treats `px-*` as conflicting with `pr-*` — so the later `px-2` removed `pr-9` entirely. Verified empirically against the repo's own tailwind-merge:

```
twMerge("pr-9 font-mono", "h-8 px-2 text-xs")  ->  "font-mono h-8 px-2 text-xs"
twMerge("pr-9 font-mono", "h-8 pl-2 text-xs")  ->  "pr-9 font-mono h-8 pl-2 text-xs"
```

That leaves 8px of right padding under a `size-8` (32px) reveal button, so the value renders underneath the toggle. The markup this replaced put the button in a sibling `Flex` cell, so nothing ever overlapped — this would have been a regression *introduced* by the migration, on 4 fields in `display-settings` and 2 in `tile-grid-assignment`. Changed to `pl-2`, which sets the same left padding without touching the `pr` group. `ai-settings` (`pl-7`) and `mqtt-settings` (no padding class) were already correct.

### Checked and clean

- **No test file is touched by this diff** (`git diff --name-only` over the whole branch returns zero test paths). No assertion was weakened, reworded, or deleted.
- **No root-barrel `@fiestaboard/ui` import was added.** All 7 `SecretInput` imports are deep subpaths. The single added root-barrel line in `step-board-setup.tsx` is an existing import with `Box` and two icons *removed*.
- **The deep subpath actually resolves** — not assumed. At the `v3.2.0` tag the file is `src/components/forms/secret-input.tsx`; `vite.config.ts` builds with `preserveModules: true, preserveModulesRoot: "src"`; `package.json` exposes `"./*": { types: "./dist/*.d.ts", import: "./dist/*.js" }`. Confirmed against an actually-installed published tarball (2.2.3 in a sibling checkout) that the package really does emit 72 per-module `.js` + `.d.ts` files mirroring `src/`, rather than a single bundle.
- **`font-mono` dropped from every call site is correct** — `SecretInput` applies `font-mono` itself by default.
- **No unused imports** introduced. Every symbol in every touched import block is still referenced (checked mechanically across all 7 files); `Box` correctly dropped from `step-board-setup`, `Tooltip`/`TooltipContent`/`TooltipTrigger` from `board-settings`, `Eye`/`EyeOff` everywhere.
- **All translation keys resolve in the namespace they are called from.** `tile-grid-assignment` calls `t("showSecretAriaLabel")` under `useTranslations("displaySettings")` — the key exists there.
- **No test couples to a changed accessible name.** The only test that clicks a reveal toggle by name is `ai-settings.test.tsx` (`/show api key/i`); those labels were kept verbatim as literals rather than swapped to translation keys, and `id={\`key-${provider.id}\`}` is preserved so the existing `<Label htmlFor>` still associates.
- **`board-settings` is the only place a reveal button's accessible name changes** (to `cannotReveal` while masked) and nothing asserts on it.
- **The `e2e` selector survives**: `tests/plugin-management.spec.ts` locates `input[type="password"]`, and `SecretInput` renders `type="password"` while masked.
- **`display-settings.test.tsx`'s structural query survives.** It reaches the token input via `label.parentElement.querySelector("input")`. The input moved from a `<Flex>` into `<div data-slot="secret-input">`, but both are children of the same `Stack`, and the toggle is a `<button>` — the query still resolves to the same element.
- **`board-settings-form-seed.test.tsx`** asserts the 1.3s debounced autosave fires no PUTs; `SecretInput` does not emit `onChange` on mount.
- **`schema-form`'s new `useTranslations` hook** sits above every early return, so hook order stays unconditional. `StringField` is rendered as JSX, so the hook is legal.
- **Rules**: commit trailer is exactly `Co-Authored-By: Claude <noreply@anthropic.com>` on both commits; branched off `origin/main`, nothing on `main`; no stray markdown; no `package.json` or lockfile edit; no new dependency; no forbidden `clsx`/`tailwind-merge`/`cva`/`@base-ui/react`/`ogl`; nothing recreated in `web/src/components/ui/`.
- **i18n gate re-verified independently** (not taken from the implementer): all 14 locales have identical leaf-key sets (1829 each) and identical top-level namespace counts (65 each), no empty values, and both new keys present and non-empty everywhere. Spot-checked `ja`/`zh`/`de` to confirm the new strings are genuinely localized rather than English fallbacks.

---

## Verification — honest account

This repo is Docker-only and no worktree on this host has `@fiestaboard/ui` 3.2.0 installed (the nearest is 2.2.3, a version with no `SecretInput` at all). **Nothing here is type-checked, lint-checked, or test-run.** GitHub Actions is the real gate.

**Actually executed:**
- `prettier --check` with the repo's pinned Prettier 3.9.6 across all 21 changed files — *All matched files use Prettier code style!* (This proves every file parses.)
- The tailwind-merge experiment quoted above, run against the exact `extendTailwindMerge({ cacheSize: 8000 })` config FiestaUI's `cn` uses.
- An independent re-implementation of what `i18n-config.test.ts` asserts, over all 14 locale files — passes.
- Read `secret-input.tsx`, `input.tsx`, `button.tsx`, and `lib/utils.ts` at the `v3.2.0` **tag** (confirmed the local checkout is `v3.2.0-5-g…` and that none of those four files differ from the tag) rather than trusting an API summary.
- `gh pr view 1628 --json state` → `MERGED`; confirmed `90866898` (the 3.2.0 bump) is in `origin/main`.
- Grep sweeps: zero `type="password"` and zero `Eye`/`EyeOff` remain in the three touched directories; exactly 15 `<SecretInput` call sites, matching the audit's count.

**Deliberately not run:** `tsc`, ESLint, and Vitest. ESLint aborts with `ERR_MODULE_NOT_FOUND` in a worktree with no `node_modules`, and running either against the sibling checkout's 2.2.3 install would emit confident-looking but entirely fabricated "module not found" errors for `SecretInput`. Symlinking `node_modules` in to force a green-looking check was rejected. **Type errors and lint violations remain possible.**

**No new tests were added.** Both accessibility defects this PR fixes are still uncovered. A follow-up should assert that the schema-form toggle is keyboard-reachable and has an accessible name, and that the tile-grid toggle exists and is disabled when the value is masked.

---

## Non-blocking concerns — please accept or reject

1. **Tooltip copy lost for sighted mouse users (`board-settings`).** The local/cloud key toggles were wrapped in a `Tooltip` reading `t("cannotReveal")` ("Cannot reveal server-stored values"). `SecretInput` renders its toggle internally, so there is no node for `TooltipTrigger asChild`. That copy is folded into the disabled toggle's accessible name via `showLabel={masked ? t("cannotReveal") : t("showApiKey")}` — a disabled `<button>` stays in the accessibility tree, so screen readers still receive it, but sighted mouse users lose the hover text and fall back on the "(set)" placeholder. Reviewer's call.
2. **`mqtt-settings` gains `revealDisabled` where none existed.** Previously the toggle was enabled even when the field rendered empty — a no-op reveal. This makes it consistent with the other five masked fields, but it *is* a behaviour change and is called out rather than slipped in. Trivial to drop.
3. **`board-settings`' `TooltipProvider` now wraps zero `Tooltip`s.** Confirmed dead (only the import and the open/close tags remain). Left in place because removing it would re-indent ~265 lines and drown the real diff. Harmless — it renders no DOM. Worth a follow-up.
4. **`boardSettings.toggleVisibility` is now an orphaned key in all 14 locales.** Left in place. Verified this is not a CI risk: `i18n-config.test.ts` only compares each locale against English (`extraInLocale`), and has no unused-key check.
5. **`ai-settings`' toggle labels are hardcoded English** (`"Show API key"` / `"Hide API key"`). This is pre-existing — the old `aria-label` was hardcoded too — and it was kept verbatim on purpose so `ai-settings.test.tsx` keeps passing untouched. It should be moved to a translation key in a separate PR, together with fixing the existing test.

### Deliberately out of scope

- **`account-section.tsx` (5 fields) and `app/routes/login.tsx` (3 fields)** — auth passwords that are typed and discarded, not stored credentials. Adding a reveal affordance to sign-in and change-password forms is a security/UX policy decision, not a refactor.
- **`ai-chat-panel.tsx`** — its `Eye` icons are a board show/hide affordance, not a secret.
- **`app/routes/integrations._index.tsx`** — its `Eye`/`EyeOff` are entries in the plugin-manifest icon-name registry.

### Note on scope

This branch contains only the `SecretInput` adoption. It carries no fix for #1629 and adds no tests, so the "does the new test fail without the production change" check does not apply here — there is no new test to trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
