### PR TITLE
Update README to remove license and CI badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@
 </h1>
 
 <p align="center">
-  <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
-  <a href="https://github.com/Fiestaboard/FiestaBoard/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/Fiestaboard/FiestaBoard/ci.yml?label=CI" alt="CI"></a>
   <a href="https://hub.docker.com/r/fiestaboard/fiestaboard"><img src="https://img.shields.io/badge/docker-fiestaboard-blue?logo=docker" alt="Docker"></a>
   <a href="https://fiestaboard.app"><img src="https://img.shields.io/badge/docs-fiestaboard.app-orange" alt="Documentation"></a>
   <a href="https://discord.gg/2GAqKnRF6h"><img src="https://img.shields.io/badge/Discord-Join%20us-7289da?logo=discord&logoColor=white" alt="Discord"></a>


### PR DESCRIPTION
Removed MIT license and CI badge links from README.

## Description

Brief description of what this PR does.

## Related Issue

Closes #

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] New plugin
- [ ] Documentation update
- [ ] Refactor / maintenance

## Checklist

- [ ] I have tested my changes locally
- [ ] I have added/updated tests where applicable
- [ ] I have updated documentation where applicable
- [ ] My code follows the project's coding standards
