### PR TITLE
chore(deps): pin nanoid >=3.3.18 to clear GHSA-2v37-7h3g-55p8

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "8.27.28",
+  "version": "8.27.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "8.27.28",
+      "version": "8.27.31",
       "dependencies": {
         "@codemirror/commands": "^6.10.4",
         "@codemirror/language": "^6.12.4",
@@ -16782,9 +16782,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/web/package.json
+++ b/web/package.json
@@ -63,7 +63,8 @@
     "serialize-javascript": ">=7.0.3",
     "uuid": ">=14.0.0",
     "postcss": ">=8.5.10",
-    "esbuild": ">=0.28.1"
+    "esbuild": ">=0.28.1",
+    "nanoid": "^3.3.18"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
## Why

`nanoid@3.3.16` is already on `main` (pulled in by `postcss`, which declares `^3.3.16`) and is vulnerable to [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) — **high severity**, "custom generators can loop indefinitely when size is zero". Patched in **3.3.18** for the v3 line.

This is what fails Dependency Review on the npm dependabot group PR #1655:

```
web/package-lock.json » nanoid@3.3.16 – nanoid: custom generators can loop
indefinitely when size is zero (high severity)
##[error]Dependency review detected vulnerable packages.
```

The advisory is not introduced by #1655 — it is pre-existing on `main`. Fixing it here unblocks that PR and removes the vulnerability from the tree.

## What changed

Added `"nanoid": "^3.3.18"` to `web/package.json` `overrides`, matching the pattern already used there for `serialize-javascript`, `uuid`, `postcss`, and `esbuild`.

## Why `^3.3.18` and not `>=3.3.18`

I tried the open range first, matching the style of the neighbouring entries. It resolves to **nanoid 6.0.1**, which is ESM-only and declares `"node": "^22 || ^24 || >=26"`:

```
-      "version": "3.3.16",
+      "version": "6.0.1",
-        "nanoid": "bin/nanoid.cjs"
+        "nanoid": "bin/nanoid.js"
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+        "node": "^22 || ^24 || >=26"
```

An `overrides` entry forces the version regardless of the consumer's declared range, so that would have handed postcss a package it cannot `require()` — postcss uses CommonJS `require('nanoid/non-secure')`. `^3.3.18` keeps the v3 major that postcss's own `^3.3.16` range expects.

## Resulting diff

```
web/package-lock.json | 10 +++++-----
web/package.json      |  3 ++-
```

Substantive lockfile changes are only:

```
-      "version": "3.3.16",
+      "version": "3.3.18",
```

plus the lockfile's stale top-level `version` field catching up (`8.27.28` -> `8.27.31`). That is incidental: `scripts/version-sync.js` updates `package.json` but not the lockfile, so any `npm install` re-syncs it.

Lockfile regenerated with `npm install --package-lock-only --legacy-peer-deps` on node:24 in a container. Verified afterwards that `postcss` still resolves to `8.5.23` (unchanged) and `nanoid` to `3.3.18`.

## Follow-up

Once this lands, #1655 needs a rebase to pick up the override.

Co-Authored-By: Claude <noreply@anthropic.com>