### PR TITLE
fix(integrations): draw plugin previews with the board's own code-62 flap

### DIFF
--- a/web/app/routes/integrations.$pluginId.tsx
+++ b/web/app/routes/integrations.$pluginId.tsx
@@ -36,6 +36,7 @@ import { toast } from "sonner";
 
 import Link from "@/components/smart-link";
 import { useEffectiveBoardColor } from "@/hooks/use-effective-board-color";
+import { useEffectiveCode62Glyph } from "@/hooks/use-effective-code62-glyph";
 import { useParams, useRouter } from "@/hooks/use-router";
 import { useTranslations } from "@/i18n/translations";
 import { api } from "@/lib/api";
@@ -49,6 +50,7 @@ export default function PluginDetailPage() {
   const router = useRouter();
   const queryClient = useQueryClient();
   const boardColor = useEffectiveBoardColor();
+  const code62Glyph = useEffectiveCode62Glyph();
   const pluginId = params.pluginId as string;
   const [addInstanceOpen, setAddInstanceOpen] = useState(false);
   const [instanceLabel, setInstanceLabel] = useState("");
@@ -158,6 +160,7 @@ export default function PluginDetailPage() {
             previews={previews}
             previewLabel={t("boardPreviewLabel", { name: entry?.name ?? pluginId })}
             defaultBoardType={boardColor}
+            code62Glyph={code62Glyph}
             labels={{
               flagship: t("deviceFlagship"),
               note: t("deviceNote"),

--- a/web/app/routes/integrations._index.tsx
+++ b/web/app/routes/integrations._index.tsx
@@ -277,6 +277,7 @@ import { asJSONSchema, SchemaForm } from "@/components/plugin-settings";
 import Link from "@/components/smart-link";
 import { useDepsChanged } from "@/hooks/use-deps-changed";
 import { useEffectiveBoardColor } from "@/hooks/use-effective-board-color";
+import { useEffectiveCode62Glyph } from "@/hooks/use-effective-code62-glyph";
 import { useSearchParams } from "@/hooks/use-router";
 import { useTranslations } from "@/i18n/translations";
 import type { PluginInfo, RegistryEntry } from "@/lib/api";
@@ -1822,6 +1823,7 @@ function RegistryPluginCard({
 }) {
   const t = useTranslations("integrations");
   const boardColor = useEffectiveBoardColor();
+  const code62Glyph = useEffectiveCode62Glyph();
 
   return (
     <PluginCard
@@ -1832,6 +1834,7 @@ function RegistryPluginCard({
       authorLabel={t("byAuthor", { author: entry.author })}
       teaser={entry.teaser}
       boardType={boardColor}
+      code62Glyph={code62Glyph}
       renderLink={({ className, children }) => (
         <Link href={`/integrations/${entry.id}`} className={className}>
           {children}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "web",
-  "version": "8.27.39",
+  "version": "8.27.40",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "8.27.39",
+      "version": "8.27.40",
       "dependencies": {
         "@codemirror/commands": "^6.11.0",
         "@codemirror/language": "^6.12.4",
         "@codemirror/state": "^6.7.1",
         "@codemirror/view": "^6.43.9",
-        "@fiestaboard/ui": "5.4.0",
+        "@fiestaboard/ui": "5.4.2",
         "@lezer/highlight": "^1.2.3",
         "@microsoft/fetch-event-source": "^2.0.1",
         "@react-router/fs-routes": "^8.3.0",
@@ -2973,9 +2973,9 @@
       }
     },
     "node_modules/@fiestaboard/ui": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@fiestaboard/ui/-/ui-5.4.0.tgz",
-      "integrity": "sha512-efxI2sxWvW6qWJXKurWHGgCSSUNwd5MpDCirKMWM+6lE1vsagapT4ur55KIRdrNuMAOkAgDaiLzseXaE2VNcGQ==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/@fiestaboard/ui/-/ui-5.4.2.tgz",
+      "integrity": "sha512-m326CA3ua4J9OfV9CkQURwiTZkUESXnk7Ol5tFF1Z+u6PyUlPlilGBftHLT/gYoJxLqKdMNamj4VggGDCiZYdg==",
       "license": "MIT",
       "dependencies": {
         "@base-ui/react": "^1.6.0",

--- a/web/package.json
+++ b/web/package.json
@@ -27,7 +27,7 @@
     "@codemirror/language": "^6.12.4",
     "@codemirror/state": "^6.7.1",
     "@codemirror/view": "^6.43.9",
-    "@fiestaboard/ui": "5.4.0",
+    "@fiestaboard/ui": "5.4.2",
     "@lezer/highlight": "^1.2.3",
     "@microsoft/fetch-event-source": "^2.0.1",
     "@react-router/fs-routes": "^8.3.0",

--- a/web/src/__tests__/integrations-plugin-preview-code62.test.tsx
+++ b/web/src/__tests__/integrations-plugin-preview-code62.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * Plugin previews honor the board's code-62 flap (issue #1666).
+ *
+ * `BoardInstance.code62_glyph` says whether a Flagship's character-code-62 flap
+ * carries a degree sign or a heart (issue #1657), and the dashboard, editor and
+ * wizard all pass it down. The Integrations surfaces did not: the marketplace
+ * card's teaser strip and the detail page's hero showcase were handed
+ * `boardType` and nothing else, so a plugin whose teaser puts a temperature on
+ * the board advertised a `°` to owners whose board physically draws a `♥`.
+ *
+ * The registry fixtures below are the manifest fixture the issue asks for — no
+ * shipped manifest puts code 62 in a `teaser` or `previews` yet, which is the
+ * only reason the gap was latent rather than visible.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it, vi } from "vitest";
+
+import type { Code62Glyph } from "@/lib/api";
+
+import IntegrationsPage from "../../app/routes/integrations._index";
+import PluginDetailPage from "../../app/routes/integrations.$pluginId";
+import { server } from "./mocks/server";
+
+const API_BASE = "/api";
+
+// Only `useParams` is faked — the detail route reads the plugin id from it and
+// there is no router around these renders. The rest of the module (notably
+// `useSearchParams`, which the Integrations page reads its tab from) stays real.
+vi.mock("@/hooks/use-router", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/hooks/use-router")>()),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn(), back: vi.fn() }),
+  useParams: () => ({ pluginId: "weather" }),
+}));
+
+vi.mock("@/components/smart-link", () => ({
+  default: ({ children, href, ...rest }: { children: React.ReactNode; href: string }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+/** A board whose code-62 flap carries `glyph`; omit for a board saved before the setting existed. */
+function mockBoard(glyph?: Code62Glyph) {
+  server.use(
+    http.get(`${API_BASE}/settings/board`, () =>
+      HttpResponse.json({
+        board_type: "black",
+        boards: [
+          {
+            id: "default",
+            name: "Flagship",
+            device_type: "flagship",
+            board_color: "black",
+            ...(glyph ? { code62_glyph: glyph } : {}),
+            enabled: true,
+          },
+        ],
+        devices: ["flagship"],
+      }),
+    ),
+  );
+}
+
+/** One uninstalled registry plugin whose teaser and previews put code 62 on the board. */
+function mockWeatherRegistry() {
+  server.use(
+    http.get(`${API_BASE}/plugins`, () =>
+      HttpResponse.json({ plugins: [], plugin_system_enabled: true, total: 0, enabled_count: 0 }),
+    ),
+    http.get(`${API_BASE}/plugins/registry`, () =>
+      HttpResponse.json({
+        entries: [
+          {
+            id: "weather",
+            name: "Weather",
+            description: "Current conditions on your board",
+            category: "weather",
+            repository: "https://example.com/weather",
+            branch: "main",
+            author: "FiestaBoard",
+            fiestaboard_version: ">=8.0.0",
+            icon: "puzzle",
+            installed: false,
+            teaser: "52 °F CLEAR",
+            previews: [{ device_type: "flagship", rows: ["52 °F CLEAR"] }],
+          },
+        ],
+      }),
+    ),
+  );
+}
+
+function renderWithQueryClient(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+}
+
+/** Marketplace tab, card view — where a registry entry renders its teaser strip. */
+async function openMarketplaceCards() {
+  const user = userEvent.setup();
+  await user.click(await screen.findByRole("tab", { name: /marketplace/i }));
+}
+
+describe("Integrations plugin previews — code-62 flap", () => {
+  it("draws a heart in the marketplace teaser when the board's flap carries one", async () => {
+    mockBoard("heart");
+    mockWeatherRegistry();
+    renderWithQueryClient(<IntegrationsPage />);
+
+    await openMarketplaceCards();
+
+    // The strip hides its tiles from assistive tech, so its role="img" name is
+    // the derivation of what the tiles drew — tiles and name come from the same
+    // substitution and cannot disagree.
+    expect(await screen.findByRole("img", { name: /52 ♥F CLEAR/ })).toBeInTheDocument();
+  });
+
+  it("keeps the degree in the marketplace teaser for a board saved before the setting", async () => {
+    mockBoard();
+    mockWeatherRegistry();
+    renderWithQueryClient(<IntegrationsPage />);
+
+    await openMarketplaceCards();
+
+    expect(await screen.findByRole("img", { name: /52 °F CLEAR/ })).toBeInTheDocument();
+  });
+
+  it("draws a heart in the plugin detail showcase when the board's flap carries one", async () => {
+    mockBoard("heart");
+    mockWeatherRegistry();
+    renderWithQueryClient(<PluginDetailPage />);
+
+    // Blank tiles draw nothing, so the board's text is the glyphs with the
+    // padding squeezed out.
+    const board = await screen.findByRole("img", { name: /split-flap board/i });
+    expect(board).toHaveTextContent("52♥FCLEAR");
+  });
+
+  it("keeps the degree in the plugin detail showcase for a board saved before the setting", async () => {
+    mockBoard();
+    mockWeatherRegistry();
+    renderWithQueryClient(<PluginDetailPage />);
+
+    const board = await screen.findByRole("img", { name: /split-flap board/i });
+    expect(board).toHaveTextContent("52°FCLEAR");
+  });
+});

--- a/web/src/hooks/use-effective-code62-glyph.ts
+++ b/web/src/hooks/use-effective-code62-glyph.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { useCurrentBoard } from "@/components/current-board-context";
+import { getEffectiveCode62Glyph, resolveCode62Glyph, useBoardSettings } from "@/hooks/use-board";
+import type { Code62Glyph } from "@/lib/api";
+
+/**
+ * The glyph a plugin preview should draw for character code 62: the board the
+ * user is currently managing, falling back to the effective glyph from board
+ * settings while that is still loading (issue #1666).
+ *
+ * The device is resolved alongside the preference, not after it — a Note is
+ * heart hardware whatever a stale Flagship preference says.
+ *
+ * Lives beside `use-effective-board-color` rather than in `use-board` for the
+ * same reason it does: `current-board-context` imports from there, and joining
+ * the two would close an import cycle.
+ */
+export function useEffectiveCode62Glyph(): Code62Glyph {
+  const { currentBoard } = useCurrentBoard();
+  const { data: boardSettings } = useBoardSettings();
+  if (currentBoard) return resolveCode62Glyph(currentBoard.device_type, currentBoard.code62_glyph);
+  return getEffectiveCode62Glyph(boardSettings);
+}


### PR DESCRIPTION
Fixes #1666.

## What

`BoardInstance.code62_glyph` lets an owner say whether their Flagship's character-code-62 flap carries a degree sign or a heart (#1657), and the dashboard, editor preview and wizard all honor it. The Integrations page did not — `PluginCard` and `BoardShowcase` were handed `boardType` and nothing else, so every marketplace teaser and every hero preview drew `°` regardless of the board's setting, on exactly the boards #1657 was about.

- **Package half** (Fiestaboard/FiestaUI#264, released in `@fiestaboard/ui` 5.4.1): `code62Glyph` threaded through `PluginCard` → `ScaledBoardTeaser` → `BoardTeaser` and through `BoardShowcase` → `StaticBoardDisplay`
- **Here**: bump to 5.4.2 (5.4.1 carries the fix; 5.4.2 adds the unrelated perf work released since — this replaces the bot's bump PR #1668) and pass the resolved glyph from both Integrations routes, the same way `boardType` already is

New `useEffectiveCode62Glyph()` sits beside `useEffectiveBoardColor()` (same import-cycle reason for its own module): it reads the board being managed and falls back to board settings while that is still loading, resolving the device alongside the preference — a Note is heart hardware whatever a stale Flagship preference says.

A `note` / `note_array` preview in the showcase still draws its own heart: `StaticBoardDisplay` resolves that from the preview's `device_type`, not from this prop.

## Tests

`web/src/__tests__/integrations-plugin-preview-code62.test.tsx` mounts both routes against MSW fixtures. The registry entry it mocks is the **manifest fixture the issue asks for** — no shipped manifest puts code 62 in a `teaser` or `previews`, which is the only reason this was latent, so the test supplies one (`teaser: "52 °F CLEAR"`).

Written first and watched fail — the two heart cases failed, the two degree guards passed:

```
× draws a heart in the marketplace teaser when the board's flap carries one
  → Unable to find role="img" and name `/52 ♥F CLEAR/`
✓ keeps the degree in the marketplace teaser for a board saved before the setting
× draws a heart in the plugin detail showcase when the board's flap carries one
  → Expected element to have text content: 52♥FCLEAR / Received: 52°FCLEAR
✓ keeps the degree in the plugin detail showcase for a board saved before the setting
```

The marketplace assertion reads the strip's `role="img"` name rather than its tiles: the tiles are `aria-hidden`, so the name is all a screen reader gets, and it comes from the same substitution — a strip drawing ♥ while announcing "degree" would be a text alternative for a different image (WCAG 1.1.1).

After the fix: 4/4 pass. Full web suite on this branch with 5.4.2 installed: **128 files, 1498 passed, 7 skipped**. `typecheck`, `eslint` and `prettier --check` clean.

FiestaUI side: 8 new mounted tests (5 of which failed before that fix), `release:test` 242/242, vitest 131/131.

## Housekeeping

- Supersedes #1669 (same commit; that branch conflicted with main after #1667 landed, which is why GitHub never dispatched its `pull_request` CI run).
- Supersedes the release bot's #1668 — this carries the `@fiestaboard/ui` bump it wanted, plus the app change that needs it.