### PR TITLE
feat(plugins): sweep installed plugins for config-independent breakage

### DIFF
--- a/.github/workflows/scheduled-maintenance.yml
+++ b/.github/workflows/scheduled-maintenance.yml
@@ -15,6 +15,12 @@ name: 'Scheduled: Maintenance'
 #   - security-scan   : weekly bandit + pip-audit sweep of plugin-registry
 #                       repos, opens/updates an issue on findings
 #                       (was .github/workflows/registry-scan.yml)
+#   - plugin-health   : daily install-and-load sweep of every registry
+#                       plugin, opens/updates an issue on findings. Catches
+#                       breakage that per-plugin CI structurally cannot see,
+#                       because each plugin repo tests itself in the bundled
+#                       plugins/<id>/ layout rather than the installed
+#                       data/external_plugins/<id>/ one.
 #
 # Note: the Claude-driven docs audit lives in its own workflow
 # (.github/workflows/claude-docs-audit.yml) so it surfaces independently
@@ -26,6 +32,7 @@ on:
     # Each job filters on the resolved schedule via `github.event.schedule`.
     - cron: '0 4 * * *'    # plugin previews (04:00 UTC daily)
     - cron: '0 0 * * 0'    # security scan (Sun 00:00 UTC)
+    - cron: '0 5 * * *'    # plugin health sweep (05:00 UTC daily)
   workflow_dispatch:
     inputs:
       job:
@@ -33,7 +40,7 @@ on:
         required: true
         default: 'all'
         type: choice
-        options: [all, plugin-previews, security-scan]
+        options: [all, plugin-previews, security-scan, plugin-health]
 
 permissions:
   contents: read
@@ -176,4 +183,136 @@ jobs:
               labels: ['security']
             });
             console.log('Created new security scan issue');
+          }
+
+  plugin-health:
+    name: Sweep installed plugins
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Daily cron OR explicit dispatch.
+    if: |
+      (github.event_name == 'schedule' && github.event.schedule == '0 5 * * *') ||
+      (github.event_name == 'workflow_dispatch' &&
+        (inputs.job == 'all' || inputs.job == 'plugin-health'))
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v7
+
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v7
+      with:
+        python-version: "3.11"
+        cache: 'pip'
+
+    - name: Install platform dependencies
+      # Deliberately ONLY the platform's own requirements. A plugin's
+      # requirements.txt is never installed on a real box either (#1671),
+      # so installing it here would hide exactly what we are sweeping for.
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Install every registry plugin
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Clone each plugin into the directory the app actually installs to,
+      # so __file__-relative paths resolve the way they do for a user.
+      run: |
+        mkdir -p data/external_plugins
+        failed=0
+        while IFS=$'\t' read -r id repo; do
+          [ -n "$id" ] || continue
+          if git clone --depth 1 --quiet "$repo" "data/external_plugins/$id"; then
+            echo "cloned $id"
+          else
+            echo "::warning::could not clone $id from $repo"
+            failed=$((failed + 1))
+          fi
+        done < <(python -c "
+        import json
+        for p in json.load(open('plugin-registry.json'))['plugins']:
+            print(p['id'], p['repository'], sep='\t')
+        ")
+        echo "installed $(find data/external_plugins -maxdepth 1 -mindepth 1 -type d | wc -l) plugins ($failed clone failures)"
+
+    - name: Sweep installed plugins
+      id: sweep
+      # Exit 1 means findings; that is a reportable result, not a crash.
+      # --no-fetch keeps the run hermetic: fetch_data() would hit dozens of
+      # third-party APIs and make a scheduled job flaky for reasons that
+      # have nothing to do with plugin health.
+      run: |
+        set +e
+        python scripts/plugin_health_sweep.py \
+          --external-dir=data/external_plugins \
+          --no-fetch \
+          --verbose \
+          --json=plugin-health.json \
+          --markdown=plugin-health.md
+        code=$?
+        set -e
+        if [ "$code" = "0" ] || [ "$code" = "1" ]; then
+          exit 0
+        fi
+        echo "::error::plugin_health_sweep.py crashed with exit code $code"
+        exit "$code"
+
+    - name: Upload sweep results
+      if: always()
+      uses: actions/upload-artifact@v7
+      with:
+        name: plugin-health-results
+        path: |
+          plugin-health.json
+          plugin-health.md
+        retention-days: 90
+
+    - name: Create or update issue on findings
+      if: steps.sweep.outputs.has_findings == 'true'
+      uses: actions/github-script@v9
+      with:
+        script: |
+          const fs = require('fs');
+          const report = fs.readFileSync('plugin-health.md', 'utf8');
+          const title = '🔌 Plugin Health Sweep: Broken Plugins Found';
+
+          const { data: issues } = await github.rest.issues.listForRepo({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            state: 'open',
+            labels: 'plugin',
+            per_page: 100
+          });
+
+          const existing = issues.find(i => i.title === title);
+          const body = [
+            report,
+            '',
+            '---',
+            '_Automatically created by the daily plugin health sweep._',
+            `_Run: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}_`,
+            `_Last updated: ${new Date().toISOString()}_`
+          ].join('\n');
+
+          if (existing) {
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: existing.number,
+              body
+            });
+            console.log(`Updated existing issue #${existing.number}`);
+          } else {
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ['plugin']
+            });
+            console.log('Created new plugin health issue');
           }

--- a/docs/internal/development/PLUGIN_DEVELOPMENT.md
+++ b/docs/internal/development/PLUGIN_DEVELOPMENT.md
@@ -717,6 +717,54 @@ plugins/my_plugin/
     └── test_plugin.py
 ```
 
+### A plugin must be self-contained
+
+Ship every data file your plugin reads, and never resolve a path outside your
+own plugin directory.
+
+The tree above is the **development** layout. Installed from the registry, your
+plugin lives one directory deeper:
+
+```text
+data/external_plugins/my_plugin/     # where users actually run it
+plugins/my_plugin/                   # bundled/dev layout only
+```
+
+So a path written against the bundled layout silently resolves somewhere else
+once installed:
+
+```python
+# WRONG — reaches into the platform. Resolves to data/src/utils/ on a real
+# install, so the file is never found and every variable renders "???".
+data = Path(__file__).parent.parent.parent / "src" / "utils" / "data.json"
+
+# RIGHT — relative to the plugin, valid in both layouts.
+data = Path(__file__).parent / "data.json"
+```
+
+This is not hypothetical: the Star Trek Quotes plugin shipped this way for
+months, serving `???` to every user, because its data file was never committed
+and its fallback pointed at the platform copy.
+
+Two rules follow:
+
+- **Commit your data files.** Do not generate or symlink them in CI. If your
+  test workflow creates a file the shipped plugin lacks, your suite is testing
+  a tree no user has.
+- **Do not rely on third-party packages.** The platform does not install a
+  plugin's `requirements.txt` (see
+  [#1671](https://github.com/Fiestaboard/FiestaBoard/issues/1671)); anything
+  beyond the standard library plus the platform's own dependencies will be
+  missing at runtime. Vendor it or do without.
+
+`scripts/plugin_health_sweep.py` enforces all of this against every registry
+plugin daily. Run it locally before publishing:
+
+```bash
+docker compose -f docker-compose.dev.yml exec fiestaboard \
+  python scripts/plugin_health_sweep.py --plugin=my_plugin --no-fetch
+```
+
 ## Documentation Standards
 
 Each plugin has two documentation layers you are responsible for:

--- a/scripts/plugin_health_sweep.py
+++ b/scripts/plugin_health_sweep.py
@@ -1,0 +1,543 @@
+#!/usr/bin/env python3
+"""Sweep every installed plugin for breakage that no amount of config can fix.
+
+Per-plugin CI runs each plugin in a tree it never actually ships in: the repo
+is checked out into the *bundled* ``plugins/<id>/`` layout, and some workflows
+even synthesise data files before running the suite.  A plugin can therefore be
+green in its own repo and completely dead once installed to
+``data/external_plugins/<id>/``.  That is how the Star Trek Quotes plugin
+shipped for months serving ``???`` for every variable
+(Fiestaboard/fiestaboard-plugin--star-trek-quotes#10).
+
+This sweep loads plugins the way the running app does and asserts the things
+that must hold for *any* install, regardless of user configuration:
+
+1. ``load``          - the plugin imports and instantiates
+2. ``data_files``    - every ``__file__``-relative data file it reads exists
+3. ``self_contained``- no ``__file__`` path escapes the plugin directory
+4. ``dependencies``  - everything in requirements.txt is importable
+5. ``fetch_contract``- fetch_data() does not raise, and an unavailable result
+                       carries a non-empty error the user can act on
+
+Checks 1-4 are hermetic.  Check 5 calls fetch_data(), which may touch the
+network; a plugin that is merely unconfigured or whose upstream API is down is
+reported but never fails the sweep.  Only a raised exception or a silent
+failure counts against it.
+
+Usage:
+    python scripts/plugin_health_sweep.py [OPTIONS]
+
+Options:
+    --external-dir=PATH  Directory of installed plugins
+                         (default: data/external_plugins)
+    --plugin=ID          Sweep a single plugin
+    --no-fetch           Skip check 5; run only the hermetic checks
+    --json=PATH          Write the full report as JSON
+    --markdown=PATH      Write a report suitable for a GitHub issue body
+    --verbose            Show passing checks too
+
+Sets ``has_findings=true|false`` on $GITHUB_OUTPUT when running in Actions.
+
+Exit codes:
+    0 - No breakage found
+    1 - At least one plugin is broken
+    2 - Configuration/setup error
+"""
+
+import argparse
+import importlib.util
+import json
+import os
+import re
+import sys
+import traceback
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent
+PROJECT_ROOT = SCRIPT_DIR.parent
+PLUGINS_DIR = PROJECT_ROOT / "plugins"
+DEFAULT_EXTERNAL_DIR = PROJECT_ROOT / "data" / "external_plugins"
+
+sys.path.insert(0, str(PROJECT_ROOT))
+
+DATA_SUFFIXES = ("json", "csv", "txt", "yaml", "yml", "ndjson", "tsv")
+
+# A __file__-anchored path expression, capturing the .parent hops and the
+# quoted segments joined onto it. Matches both pathlib and os.path styles:
+#   Path(__file__).parent / "quotes.json"
+#   Path(__file__).parent.parent / "src" / "utils" / "x.json"
+#   os.path.join(os.path.dirname(__file__), "data", "x.json")
+FILE_ANCHORED = re.compile(
+    r"""
+    (?P<anchor>
+        Path\(\s*__file__\s*\)(?P<hops>(?:\s*\.\s*parent)*)
+        | os\.path\.dirname\(\s*__file__\s*\)
+    )
+    (?P<tail>(?:\s*[/,]\s*(?:["'][^"']+["']|\w+\s*\(\s*\))|\s*\)\s*)*)
+    """,
+    re.VERBOSE,
+)
+QUOTED = re.compile(r"""["']([^"']+)["']""")
+
+# Plugins commonly stash the anchor first and join onto it later:
+#   plugin_dir = Path(__file__).parent
+#   quotes_file = plugin_dir / "quotes.json"
+# Without this the data_files check misses the most idiomatic spelling.
+ANCHOR_ASSIGN = re.compile(
+    r"""^[ \t]*(?P<name>\w+)[ \t]*=[ \t]*
+        (?:Path\(\s*__file__\s*\)(?P<hops>(?:\s*\.\s*parent)*)
+         | os\.path\.dirname\(\s*__file__\s*\))
+        [ \t]*$""",
+    re.VERBOSE | re.MULTILINE,
+)
+
+# Distributions whose import name differs from the package name.
+IMPORT_NAME_OVERRIDES = {
+    "speedtest-cli": "speedtest",
+    "beautifulsoup4": "bs4",
+    "pillow": "PIL",
+    "python-dateutil": "dateutil",
+    "pyyaml": "yaml",
+    "python-dotenv": "dotenv",
+    "msgpack-python": "msgpack",
+    "attrs": "attr",
+}
+
+
+class Finding:
+    """One failed check against one plugin."""
+
+    def __init__(self, plugin_id: str, check: str, detail: str, fatal: bool = True):
+        self.plugin_id = plugin_id
+        self.check = check
+        self.detail = detail
+        self.fatal = fatal
+
+    def to_dict(self) -> dict:
+        return {
+            "plugin": self.plugin_id,
+            "check": self.check,
+            "detail": self.detail,
+            "fatal": self.fatal,
+        }
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return f"<Finding {self.plugin_id}/{self.check}>"
+
+
+def python_sources(plugin_dir: Path) -> list[Path]:
+    """Runtime .py files for a plugin (tests and caches excluded)."""
+    skip = {"tests", "test", "docs", "__pycache__", ".git", ".github"}
+    return [p for p in plugin_dir.rglob("*.py") if not any(part in skip for part in p.relative_to(plugin_dir).parts)]
+
+
+def referenced_data_paths(source: str) -> list[tuple[int, list[str]]]:
+    """Extract ``__file__``-anchored data-file references from source text.
+
+    Returns ``(parent_hops, path_segments)`` per reference.  ``parent_hops`` is
+    how many ``.parent`` steps the expression takes, which is what tells us
+    whether the path escapes the plugin's own directory.
+    """
+    refs = []
+    for match in FILE_ANCHORED.finditer(source):
+        segments = QUOTED.findall(match.group("tail") or "")
+        if not segments:
+            continue
+        if not segments[-1].lower().endswith(DATA_SUFFIXES):
+            continue
+        hops = len(re.findall(r"\.\s*parent", match.group("hops") or ""))
+        if match.group("anchor").startswith("os.path.dirname"):
+            hops = 1
+        refs.append((hops, segments))
+
+    # Second pass: joins onto a variable that holds a __file__ anchor.
+    for assign in ANCHOR_ASSIGN.finditer(source):
+        name = assign.group("name")
+        hops = len(re.findall(r"\.\s*parent", assign.group("hops") or "")) or 1
+        joined = re.compile(
+            rf"""(?:\b{re.escape(name)}\b(?P<tail>(?:\s*/\s*["'][^"']+["'])+)
+                 | os\.path\.join\(\s*{re.escape(name)}\s*(?P<jtail>(?:,\s*["'][^"']+["'])+)\s*\))""",
+            re.VERBOSE,
+        )
+        for use in joined.finditer(source):
+            segments = QUOTED.findall(use.group("tail") or use.group("jtail") or "")
+            if not segments:
+                continue
+            if not segments[-1].lower().endswith(DATA_SUFFIXES):
+                continue
+            refs.append((hops, segments))
+
+    # Same file referenced both inline and via a variable -> report once.
+    deduped = dict.fromkeys((hops, tuple(segs)) for hops, segs in refs)
+    return [(hops, list(segs)) for hops, segs in deduped]
+
+
+def check_data_files(plugin_id: str, plugin_dir: Path) -> list[Finding]:
+    """Every data file the plugin reads relative to itself must exist."""
+    findings = []
+    for src in python_sources(plugin_dir):
+        try:
+            text = src.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if "__file__" not in text:
+            continue
+        for hops, segments in referenced_data_paths(text):
+            if segments[-1] == "manifest.json":
+                continue
+            # hops==1 means Path(__file__).parent -> the plugin dir itself.
+            base = src.parent
+            for _ in range(max(hops - 1, 0)):
+                base = base.parent
+            target = base.joinpath(*segments)
+            if target.exists():
+                continue
+            rel = src.relative_to(plugin_dir)
+            findings.append(
+                Finding(
+                    plugin_id,
+                    "data_files",
+                    f"{rel} reads {'/'.join(segments)!r} but no such file ships with the plugin (looked for {target})",
+                )
+            )
+    return findings
+
+
+def check_self_contained(plugin_id: str, plugin_dir: Path) -> list[Finding]:
+    """A plugin must not reach outside its own directory for data.
+
+    This is the exact shape of the Star Trek Quotes regression: a path written
+    for the bundled ``plugins/<id>/`` layout silently resolves somewhere else
+    once the plugin is installed one directory deeper.
+    """
+    findings = []
+    for src in python_sources(plugin_dir):
+        try:
+            text = src.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if "__file__" not in text:
+            continue
+        depth = len(src.relative_to(plugin_dir).parts)  # 1 == plugin root
+        for hops, segments in referenced_data_paths(text):
+            # hops-1 directories above the file's own directory.
+            if hops - 1 < depth:
+                continue
+            rel = src.relative_to(plugin_dir)
+            findings.append(
+                Finding(
+                    plugin_id,
+                    "self_contained",
+                    f"{rel} walks {hops - 1} directories up to reach "
+                    f"{'/'.join(segments)!r}, escaping the plugin directory. "
+                    f"Such a path only resolves in the bundled layout and "
+                    f"breaks once the plugin is installed.",
+                )
+            )
+    return findings
+
+
+def declared_requirements(plugin_dir: Path) -> list[str]:
+    """Distribution names from any requirements.txt the plugin ships."""
+    names = []
+    for req in plugin_dir.rglob("requirements.txt"):
+        if "dev" in req.name:
+            continue
+        for line in req.read_text(encoding="utf-8", errors="replace").splitlines():
+            line = line.split("#")[0].strip()
+            if not line or line.startswith("-"):
+                continue
+            name = re.split(r"[<>=!~\[; ]", line, maxsplit=1)[0].strip()
+            if name:
+                names.append(name)
+    return sorted(set(names))
+
+
+def check_dependencies(plugin_id: str, plugin_dir: Path) -> list[Finding]:
+    """Declared dependencies must be importable in this runtime.
+
+    The platform never installs a plugin's requirements.txt (Fiestaboard/
+    FiestaBoard#1671), so anything declared there is missing at runtime.
+    """
+    findings = []
+    for dist in declared_requirements(plugin_dir):
+        module = IMPORT_NAME_OVERRIDES.get(dist.lower(), dist.replace("-", "_"))
+        try:
+            found = importlib.util.find_spec(module) is not None
+        except (ImportError, ValueError):
+            found = False
+        if not found:
+            findings.append(
+                Finding(
+                    plugin_id,
+                    "dependencies",
+                    f"requires {dist!r} (import {module!r}) which is not "
+                    f"installed in the runtime; the plugin cannot work on a "
+                    f"real install",
+                )
+            )
+    return findings
+
+
+def schema_defaults(plugin) -> dict:
+    """Config a plugin gets with nothing configured but 'enabled'."""
+    try:
+        schema = plugin.get_settings_schema() or {}
+    except Exception:
+        schema = {}
+    config = {
+        name: spec["default"]
+        for name, spec in (schema.get("properties") or {}).items()
+        if isinstance(spec, dict) and "default" in spec
+    }
+    config["enabled"] = True
+    return config
+
+
+def check_fetch_contract(plugin_id: str, plugin) -> tuple[list[Finding], str]:
+    """fetch_data() must not raise, and must explain itself when unavailable."""
+    try:
+        plugin.config = schema_defaults(plugin)
+    except Exception as exc:
+        return (
+            [
+                Finding(
+                    plugin_id,
+                    "fetch_contract",
+                    f"applying default config raised {type(exc).__name__}: {exc}",
+                )
+            ],
+            "CONFIG_RAISED",
+        )
+
+    try:
+        result = plugin.fetch_data()
+    except Exception as exc:
+        return (
+            [
+                Finding(
+                    plugin_id,
+                    "fetch_contract",
+                    f"fetch_data() raised {type(exc).__name__}: {exc}\n{traceback.format_exc(limit=3)}",
+                )
+            ],
+            "FETCH_RAISED",
+        )
+
+    if result is None:
+        return (
+            [
+                Finding(
+                    plugin_id,
+                    "fetch_contract",
+                    "fetch_data() returned None instead of a PluginResult",
+                )
+            ],
+            "RETURNED_NONE",
+        )
+
+    if result.available:
+        return [], "OK"
+
+    if not (result.error or "").strip():
+        return (
+            [
+                Finding(
+                    plugin_id,
+                    "fetch_contract",
+                    "unavailable with no error message; the UI can only render "
+                    "'???' with no way for the user to learn why",
+                )
+            ],
+            "SILENT_UNAVAILABLE",
+        )
+
+    # Unavailable-with-a-reason is the normal state for an unconfigured
+    # plugin. Reported, never fatal.
+    return [], "UNAVAILABLE"
+
+
+def sweep(external_dir: Path, only: str | None, do_fetch: bool) -> tuple[list, list]:
+    """Run every check against every discoverable plugin."""
+    from src.plugins.loader import PluginLoader
+
+    loader = PluginLoader(plugins_dir=PLUGINS_DIR, external_dirs=[external_dir])
+    plugin_ids = loader.discover_plugins()
+    if only:
+        plugin_ids = [p for p in plugin_ids if p == only]
+        if not plugin_ids:
+            raise SystemExit(f"error: plugin {only!r} not found")
+
+    findings: list[Finding] = []
+    report = []
+
+    for plugin_id in sorted(plugin_ids):
+        plugin_dir = loader._resolve_plugin_dir(plugin_id)
+        row = {"plugin": plugin_id, "dir": str(plugin_dir), "status": "?"}
+
+        if plugin_dir is not None:
+            findings.extend(check_data_files(plugin_id, plugin_dir))
+            findings.extend(check_self_contained(plugin_id, plugin_dir))
+            findings.extend(check_dependencies(plugin_id, plugin_dir))
+
+        try:
+            plugin = loader.load_plugin(plugin_id)
+        except Exception as exc:
+            findings.append(
+                Finding(
+                    plugin_id,
+                    "load",
+                    f"loading raised {type(exc).__name__}: {exc}",
+                )
+            )
+            row["status"] = "LOAD_RAISED"
+            report.append(row)
+            continue
+
+        if plugin is None:
+            errors = "; ".join(str(e) for e in loader.load_errors.get(plugin_id, []))
+            findings.append(Finding(plugin_id, "load", errors or "plugin failed to load"))
+            row["status"] = "LOAD_FAILED"
+            report.append(row)
+            continue
+
+        manifest = loader.get_manifest(plugin_id)
+        if (getattr(manifest, "plugin_type", None) or "data") == "transition":
+            row["status"] = "TRANSITION"
+            report.append(row)
+            continue
+
+        if not do_fetch:
+            row["status"] = "LOADED"
+            report.append(row)
+            continue
+
+        fetch_findings, status = check_fetch_contract(plugin_id, plugin)
+        findings.extend(fetch_findings)
+        row["status"] = status
+        report.append(row)
+
+    return findings, report
+
+
+CHECK_EXPLANATIONS = {
+    "load": "The plugin does not load at all, so it is invisible to users.",
+    "data_files": (
+        "The plugin reads a data file that is not shipped with it. Every variable it exposes will render as `???`."
+    ),
+    "self_contained": (
+        "The plugin reaches outside its own directory for data. Such a path "
+        "only resolves in the bundled `plugins/<id>/` layout and breaks once "
+        "the plugin is installed to `data/external_plugins/<id>/`."
+    ),
+    "dependencies": ("The plugin declares a dependency the platform never installs (see #1671)."),
+    "fetch_contract": ("`fetch_data()` raised, returned nothing, or failed without telling the user why."),
+}
+
+
+def render_markdown(findings: list, report: list, external_dir: Path) -> str:
+    """Build an issue body describing the sweep results."""
+    lines = [
+        "## Plugin health sweep",
+        "",
+        f"Swept **{len(report)}** plugins installed to `{external_dir}`.",
+        "",
+    ]
+    if not findings:
+        lines += ["No breakage found. ✅", ""]
+        return "\n".join(lines)
+
+    by_plugin: dict[str, list] = {}
+    for finding in findings:
+        by_plugin.setdefault(finding.plugin_id, []).append(finding)
+
+    lines += [
+        f"Found **{len(findings)}** issue(s) across **{len(by_plugin)}** "
+        f"plugin(s). These are failures no user configuration can fix.",
+        "",
+    ]
+    for plugin_id in sorted(by_plugin):
+        lines.append(f"### `{plugin_id}`")
+        lines.append("")
+        for finding in by_plugin[plugin_id]:
+            lines.append(f"- **{finding.check}** — {finding.detail}")
+        lines.append("")
+
+    checks_seen = sorted({f.check for f in findings})
+    lines += ["<details><summary>What these checks mean</summary>", ""]
+    for check in checks_seen:
+        lines.append(f"- **{check}**: {CHECK_EXPLANATIONS.get(check, '')}")
+    lines += ["", "</details>", ""]
+    return "\n".join(lines)
+
+
+def set_output(name: str, value: str) -> None:
+    """Publish a step output when running inside GitHub Actions."""
+    output_file = os.environ.get("GITHUB_OUTPUT")
+    if not output_file:
+        return
+    with Path(output_file).open("a", encoding="utf-8") as handle:
+        handle.write(f"{name}={value}\n")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--external-dir", default=str(DEFAULT_EXTERNAL_DIR))
+    parser.add_argument("--plugin", default=None)
+    parser.add_argument("--no-fetch", action="store_true")
+    parser.add_argument("--json", dest="json_path", default=None)
+    parser.add_argument("--markdown", dest="markdown_path", default=None)
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args()
+
+    external_dir = Path(args.external_dir)
+    if not external_dir.exists():
+        print(f"error: external plugin dir not found: {external_dir}", file=sys.stderr)
+        return 2
+
+    findings, report = sweep(external_dir, args.plugin, not args.no_fetch)
+
+    print(f"Swept {len(report)} plugins from {external_dir}\n")
+    if args.verbose:
+        print(f"{'plugin':28} status")
+        print("-" * 50)
+        for row in report:
+            print(f"{row['plugin']:28} {row['status']}")
+        print()
+
+    if args.json_path:
+        Path(args.json_path).write_text(
+            json.dumps(
+                {
+                    "findings": [f.to_dict() for f in findings],
+                    "plugins": report,
+                },
+                indent=2,
+            )
+        )
+
+    if args.markdown_path:
+        Path(args.markdown_path).write_text(render_markdown(findings, report, external_dir))
+
+    set_output("has_findings", "true" if findings else "false")
+
+    if not findings:
+        print("No breakage found. Every plugin loads, ships its data files,")
+        print("has its dependencies available, and honours the fetch contract.")
+        return 0
+
+    by_plugin: dict[str, list[Finding]] = {}
+    for finding in findings:
+        by_plugin.setdefault(finding.plugin_id, []).append(finding)
+
+    print(f"BROKEN: {len(findings)} finding(s) across {len(by_plugin)} plugin(s)\n")
+    for plugin_id in sorted(by_plugin):
+        print(f"  {plugin_id}")
+        for finding in by_plugin[plugin_id]:
+            print(f"    [{finding.check}] {finding.detail}")
+        print()
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_plugin_health_sweep.py
+++ b/tests/test_plugin_health_sweep.py
@@ -1,0 +1,366 @@
+"""Tests for scripts/plugin_health_sweep.py.
+
+Each test builds a synthetic plugin directory exhibiting one real failure
+mode and asserts the sweep catches it -- and, just as importantly, that a
+healthy plugin produces no findings, so the checks cannot pass by flagging
+everything.
+"""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+SWEEP_PATH = PROJECT_ROOT / "scripts" / "plugin_health_sweep.py"
+
+
+def _load_sweep_module():
+    spec = importlib.util.spec_from_file_location("plugin_health_sweep", SWEEP_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["plugin_health_sweep"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+sweep_mod = _load_sweep_module()
+
+
+HEALTHY_SOURCE = """
+import json
+from pathlib import Path
+
+
+class Plugin:
+    def __init__(self, manifest):
+        self.manifest = manifest
+        data_file = Path(__file__).parent / "data.json"
+        self._data = json.loads(data_file.read_text())
+"""
+
+# The Star Trek Quotes shape: reads a file that does not ship, then reaches
+# back out of the plugin directory for a platform-owned copy.
+ESCAPING_SOURCE = """
+import json
+from pathlib import Path
+
+
+class Plugin:
+    def __init__(self, manifest):
+        quotes_file = Path(__file__).parent / "quotes.json"
+        if not quotes_file.exists():
+            quotes_file = Path(__file__).parent.parent.parent / "src" / "utils" / "quotes.json"
+        self._data = json.loads(quotes_file.read_text())
+"""
+
+
+def make_plugin(tmp_path: Path, plugin_id: str, source: str, files: dict | None = None):
+    """Create a plugin directory on disk."""
+    plugin_dir = tmp_path / plugin_id
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "__init__.py").write_text(source)
+    (plugin_dir / "manifest.json").write_text(json.dumps({"id": plugin_id, "name": plugin_id, "version": "1.0.0"}))
+    for name, content in (files or {}).items():
+        target = plugin_dir / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content)
+    return plugin_dir
+
+
+class TestDataFileCheck:
+    def test_flags_data_file_that_does_not_ship(self, tmp_path):
+        plugin_dir = make_plugin(tmp_path, "brokenplug", HEALTHY_SOURCE)
+        findings = sweep_mod.check_data_files("brokenplug", plugin_dir)
+        assert len(findings) == 1
+        assert findings[0].check == "data_files"
+        assert "data.json" in findings[0].detail
+
+    def test_flags_a_missing_file_reached_through_a_variable(self, tmp_path):
+        """Exactly how star_trek_quotes spells it, and how most plugins do."""
+        source = (
+            'from pathlib import Path\n\nplugin_dir = Path(__file__).parent\nquotes_file = plugin_dir / "quotes.json"\n'
+        )
+        plugin_dir = make_plugin(tmp_path, "varplug", source)
+        findings = sweep_mod.check_data_files("varplug", plugin_dir)
+        assert len(findings) == 1
+        assert "quotes.json" in findings[0].detail
+
+    def test_passes_when_the_data_file_ships(self, tmp_path):
+        plugin_dir = make_plugin(tmp_path, "goodplug", HEALTHY_SOURCE, {"data.json": "{}"})
+        assert sweep_mod.check_data_files("goodplug", plugin_dir) == []
+
+    def test_ignores_manifest_json(self, tmp_path):
+        source = 'from pathlib import Path\np = Path(__file__).parent / "manifest.json"\n'
+        plugin_dir = make_plugin(tmp_path, "manifestonly", source)
+        assert sweep_mod.check_data_files("manifestonly", plugin_dir) == []
+
+    def test_ignores_plugins_without_file_references(self, tmp_path):
+        source = "import requests\n\n\nclass Plugin:\n    pass\n"
+        plugin_dir = make_plugin(tmp_path, "netplug", source)
+        assert sweep_mod.check_data_files("netplug", plugin_dir) == []
+
+    def test_does_not_scan_test_files(self, tmp_path):
+        plugin_dir = make_plugin(tmp_path, "withtests", HEALTHY_SOURCE, {"data.json": "{}"})
+        tests_dir = plugin_dir / "tests"
+        tests_dir.mkdir()
+        (tests_dir / "test_x.py").write_text(
+            'from pathlib import Path\nfixture = Path(__file__).parent / "fixture.json"\n'
+        )
+        assert sweep_mod.check_data_files("withtests", plugin_dir) == []
+
+
+class TestSelfContainedCheck:
+    def test_flags_path_escaping_the_plugin_directory(self, tmp_path):
+        """The exact Star Trek Quotes regression."""
+        plugin_dir = make_plugin(tmp_path, "escaper", ESCAPING_SOURCE)
+        findings = sweep_mod.check_self_contained("escaper", plugin_dir)
+        assert len(findings) == 1
+        assert findings[0].check == "self_contained"
+        assert "escaping the plugin directory" in findings[0].detail
+
+    def test_escape_is_flagged_even_when_the_file_happens_to_exist(self, tmp_path):
+        """A path that resolves on this box still breaks on a real install."""
+        plugin_dir = make_plugin(tmp_path, "luckyescaper", ESCAPING_SOURCE)
+        stray = tmp_path.parent / "src" / "utils"
+        stray.mkdir(parents=True, exist_ok=True)
+        (stray / "quotes.json").write_text("{}")
+        findings = sweep_mod.check_self_contained("luckyescaper", plugin_dir)
+        assert len(findings) == 1
+
+    def test_allows_paths_inside_the_plugin_directory(self, tmp_path):
+        plugin_dir = make_plugin(tmp_path, "selfcontained", HEALTHY_SOURCE, {"data.json": "{}"})
+        assert sweep_mod.check_self_contained("selfcontained", plugin_dir) == []
+
+    def test_allows_a_nested_module_reaching_its_own_package_root(self, tmp_path):
+        """plugins/<id>/lib/loader.py reading ../data.json is fine."""
+        plugin_dir = make_plugin(tmp_path, "nested", "class Plugin:\n    pass\n", {"data.json": "{}"})
+        lib = plugin_dir / "lib"
+        lib.mkdir()
+        (lib / "loader.py").write_text('from pathlib import Path\nDATA = Path(__file__).parent.parent / "data.json"\n')
+        assert sweep_mod.check_self_contained("nested", plugin_dir) == []
+
+
+class TestDependencyCheck:
+    def test_flags_a_dependency_that_is_not_installed(self, tmp_path):
+        plugin_dir = make_plugin(
+            tmp_path,
+            "needsdep",
+            HEALTHY_SOURCE,
+            {"data.json": "{}", "requirements.txt": "definitely-not-installed>=1.0\n"},
+        )
+        findings = sweep_mod.check_dependencies("needsdep", plugin_dir)
+        assert len(findings) == 1
+        assert findings[0].check == "dependencies"
+        assert "definitely-not-installed" in findings[0].detail
+
+    def test_passes_for_a_dependency_the_platform_ships(self, tmp_path):
+        plugin_dir = make_plugin(
+            tmp_path,
+            "usesrequests",
+            HEALTHY_SOURCE,
+            {"data.json": "{}", "requirements.txt": "requests>=2.0\n"},
+        )
+        assert sweep_mod.check_dependencies("usesrequests", plugin_dir) == []
+
+    def test_ignores_comments_and_blank_lines(self, tmp_path):
+        plugin_dir = make_plugin(
+            tmp_path,
+            "commented",
+            HEALTHY_SOURCE,
+            {
+                "data.json": "{}",
+                "requirements.txt": "# a comment\n\n  \nrequests>=2.0  # inline\n",
+            },
+        )
+        assert sweep_mod.check_dependencies("commented", plugin_dir) == []
+
+    def test_maps_distribution_names_to_import_names(self, tmp_path):
+        """speedtest-cli imports as 'speedtest', not 'speedtest_cli'."""
+        assert sweep_mod.IMPORT_NAME_OVERRIDES["speedtest-cli"] == "speedtest"
+        plugin_dir = make_plugin(
+            tmp_path,
+            "speedy",
+            HEALTHY_SOURCE,
+            {"data.json": "{}", "requirements.txt": "speedtest-cli\n"},
+        )
+        findings = sweep_mod.check_dependencies("speedy", plugin_dir)
+        assert len(findings) == 1
+        assert "'speedtest'" in findings[0].detail
+
+    def test_skips_dev_requirements(self, tmp_path):
+        plugin_dir = make_plugin(
+            tmp_path,
+            "devonly",
+            HEALTHY_SOURCE,
+            {"data.json": "{}", "requirements-dev.txt": "definitely-not-installed\n"},
+        )
+        assert sweep_mod.check_dependencies("devonly", plugin_dir) == []
+
+
+class TestFetchContract:
+    class _Result:
+        def __init__(self, available, error=None, data=None):
+            self.available = available
+            self.error = error
+            self.data = data
+
+    class _Plugin:
+        def __init__(self, behaviour):
+            self.behaviour = behaviour
+            self.config = {}
+
+        def get_settings_schema(self):
+            return {"properties": {"refresh_seconds": {"default": 300}}}
+
+        def fetch_data(self):
+            return self.behaviour()
+
+    def test_raising_fetch_is_a_finding(self):
+        def boom():
+            raise RuntimeError("upstream exploded")
+
+        findings, status = sweep_mod.check_fetch_contract("p", self._Plugin(boom))
+        assert status == "FETCH_RAISED"
+        assert len(findings) == 1
+        assert "upstream exploded" in findings[0].detail
+
+    def test_returning_none_is_a_finding(self):
+        findings, status = sweep_mod.check_fetch_contract("p", self._Plugin(lambda: None))
+        assert status == "RETURNED_NONE"
+        assert len(findings) == 1
+
+    def test_unavailable_without_a_reason_is_a_finding(self):
+        plugin = self._Plugin(lambda: self._Result(False, error="  "))
+        findings, status = sweep_mod.check_fetch_contract("p", plugin)
+        assert status == "SILENT_UNAVAILABLE"
+        assert len(findings) == 1
+
+    def test_unavailable_with_a_reason_is_reported_but_not_a_finding(self):
+        """An unconfigured plugin is normal and must not fail the sweep."""
+        plugin = self._Plugin(lambda: self._Result(False, error="Not configured"))
+        findings, status = sweep_mod.check_fetch_contract("p", plugin)
+        assert status == "UNAVAILABLE"
+        assert findings == []
+
+    def test_available_is_clean(self):
+        plugin = self._Plugin(lambda: self._Result(True, data={"x": 1}))
+        findings, status = sweep_mod.check_fetch_contract("p", plugin)
+        assert status == "OK"
+        assert findings == []
+
+    def test_schema_defaults_always_enable_the_plugin(self):
+        plugin = self._Plugin(lambda: self._Result(True))
+        config = sweep_mod.schema_defaults(plugin)
+        assert config["enabled"] is True
+        assert config["refresh_seconds"] == 300
+
+
+class TestReferencedDataPaths:
+    def test_counts_parent_hops(self):
+        refs = sweep_mod.referenced_data_paths('p = Path(__file__).parent.parent.parent / "src" / "x.json"')
+        assert refs == [(3, ["src", "x.json"])]
+
+    def test_handles_os_path_join(self):
+        refs = sweep_mod.referenced_data_paths('p = os.path.join(os.path.dirname(__file__), "data.json")')
+        assert refs == [(1, ["data.json"])]
+
+    def test_ignores_non_data_suffixes(self):
+        refs = sweep_mod.referenced_data_paths('p = Path(__file__).parent / "helper.py"')
+        assert refs == []
+
+    def test_ignores_paths_not_anchored_to_file(self):
+        refs = sweep_mod.referenced_data_paths('p = Path("/etc/config.json")')
+        assert refs == []
+
+    def test_follows_an_anchor_held_in_a_variable(self):
+        """The idiomatic two-line spelling must not slip past the check."""
+        refs = sweep_mod.referenced_data_paths(
+            'plugin_dir = Path(__file__).parent\nquotes = plugin_dir / "quotes.json"\n'
+        )
+        assert refs == [(1, ["quotes.json"])]
+
+    def test_follows_a_variable_anchor_with_parent_hops(self):
+        refs = sweep_mod.referenced_data_paths(
+            'root = Path(__file__).parent.parent.parent\ndata = root / "src" / "utils" / "x.json"\n'
+        )
+        assert refs == [(3, ["src", "utils", "x.json"])]
+
+    def test_follows_a_variable_anchor_through_os_path_join(self):
+        refs = sweep_mod.referenced_data_paths(
+            'here = os.path.dirname(__file__)\ndata = os.path.join(here, "data.json")\n'
+        )
+        assert refs == [(1, ["data.json"])]
+
+    def test_reports_a_file_referenced_twice_only_once(self):
+        refs = sweep_mod.referenced_data_paths(
+            "plugin_dir = Path(__file__).parent\n"
+            'a = plugin_dir / "data.json"\n'
+            'b = Path(__file__).parent / "data.json"\n'
+        )
+        assert refs == [(1, ["data.json"])]
+
+
+class TestFindingSerialisation:
+    def test_to_dict_round_trips(self):
+        finding = sweep_mod.Finding("plug", "data_files", "missing x.json")
+        assert finding.to_dict() == {
+            "plugin": "plug",
+            "check": "data_files",
+            "detail": "missing x.json",
+            "fatal": True,
+        }
+
+
+class TestMarkdownReport:
+    def test_clean_sweep_says_so(self):
+        body = sweep_mod.render_markdown([], [{"plugin": "a"}], Path("/ext"))
+        assert "No breakage found" in body
+        assert "Swept **1** plugins" in body
+
+    def test_findings_are_grouped_by_plugin(self):
+        findings = [
+            sweep_mod.Finding("alpha", "data_files", "missing a.json"),
+            sweep_mod.Finding("alpha", "self_contained", "escapes dir"),
+            sweep_mod.Finding("beta", "dependencies", "needs feedparser"),
+        ]
+        body = sweep_mod.render_markdown(findings, [{}, {}], Path("/ext"))
+        assert "### `alpha`" in body
+        assert "### `beta`" in body
+        assert body.index("### `alpha`") < body.index("### `beta`")
+        assert "**3** issue(s) across **2** plugin(s)" in body
+
+    def test_explains_only_the_checks_that_fired(self):
+        findings = [sweep_mod.Finding("alpha", "dependencies", "needs x")]
+        body = sweep_mod.render_markdown(findings, [{}], Path("/ext"))
+        assert "**dependencies**:" in body
+        assert "**self_contained**:" not in body
+
+
+class TestSetOutput:
+    def test_writes_to_github_output_when_present(self, tmp_path, monkeypatch):
+        output = tmp_path / "gh_output"
+        monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+        sweep_mod.set_output("has_findings", "true")
+        assert output.read_text() == "has_findings=true\n"
+
+    def test_is_a_noop_outside_actions(self, monkeypatch):
+        monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+        sweep_mod.set_output("has_findings", "true")  # must not raise
+
+
+class TestAgainstRealBundledPlugins:
+    """The sweep must find nothing wrong with the plugins we actually ship."""
+
+    @pytest.mark.parametrize("plugin_id", ["date_time", "countdown", "random", "typewriter"])
+    def test_bundled_plugin_is_clean(self, plugin_id):
+        plugin_dir = PROJECT_ROOT / "plugins" / plugin_id
+        if not plugin_dir.exists():
+            pytest.skip(f"{plugin_id} not present")
+        findings = (
+            sweep_mod.check_data_files(plugin_id, plugin_dir)
+            + sweep_mod.check_self_contained(plugin_id, plugin_dir)
+            + sweep_mod.check_dependencies(plugin_id, plugin_dir)
+        )
+        assert findings == [], [f.detail for f in findings]


### PR DESCRIPTION
## Why

A Discord report that Star Trek Quotes rendered `???` turned out to be a plugin that had been dead for months while its own CI stayed green (fixed in [fiestaboard-plugin--star-trek-quotes#10](https://github.com/Fiestaboard/fiestaboard-plugin--star-trek-quotes/pull/10)).

Per-plugin CI **structurally cannot** catch that class of bug. Each plugin repo checks itself out into the bundled layout:

```
plugins/<id>/                  # what CI tests
data/external_plugins/<id>/    # what users actually run — one level deeper
```

Any `__file__`-relative path that reaches back toward the project root resolves differently between the two. Worse, some plugin workflows *manufacture* missing files before running the suite — Star Trek's did exactly that:

```yaml
ln -sf fiestaboard-core/src/utils/star_trek_quotes.json quotes.json
```

So the suite asserted `available is True` against a tree no user has ever had.

## What this adds

`scripts/plugin_health_sweep.py` loads plugins through the real `PluginLoader` and asserts what must hold for **any** install, regardless of user configuration:

| check | catches |
|---|---|
| `load` | plugin doesn't import/instantiate |
| `data_files` | reads a data file that isn't shipped |
| `self_contained` | `__file__` path escapes the plugin directory |
| `dependencies` | `requirements.txt` entry not importable (#1671) |
| `fetch_contract` | `fetch_data()` raises, returns `None`, or fails silently |

Checks 1–4 are hermetic. `fetch_data()` runs only on demand, and an unconfigured plugin — or one whose upstream API is down — is **reported but never fails the sweep**. Without that distinction the job would be flaky for reasons that have nothing to do with plugin health.

Wired into `scheduled-maintenance.yml` as a daily job that clones every registry plugin into the real install directory, sweeps them, and opens/updates a single issue on findings. It deliberately installs **only** the platform's `requirements.txt`, because that is what a user's box has — installing plugin requirements there would hide the very thing being swept for.

## Validation

Run against all 51 published plugin repos plus the 7 bundled ones:

**Catches the bug it was built for**, naming the exact offending path:

```
star_trek_quotes
  [data_files] __init__.py reads 'quotes.json' but no such file ships with the
    plugin (looked for /app/data/external_plugins/star_trek_quotes/quotes.json)
  [data_files] __init__.py reads 'src/utils/star_trek_quotes.json' but no such
    file ships (looked for /app/data/src/utils/star_trek_quotes.json)
  [self_contained] __init__.py walks 2 directories up to reach
    'src/utils/star_trek_quotes.json', escaping the plugin directory.
```

**Passes the fixed version** (exit 0).

**Finds the other two real problems**, already filed:

```
network_speed  [dependencies] requires 'speedtest-cli' (import 'speedtest') — #1671
volcano        [dependencies] requires 'feedparser' — #1671
baywheels      [load] Manifest id 'lyft_bike_share' does not match directory name — #1672
```

**Zero false positives** across the remaining 54 plugins. That mattered more than sensitivity here — a gate that cries wolf gets ignored.

## Tests

`tests/test_plugin_health_sweep.py` — 39 cases, all passing. Each builds a synthetic plugin exhibiting one real failure mode; each check also has a negative case asserting a healthy plugin produces **no** findings, so the checks cannot pass by flagging everything. Notable cases:

- `test_flags_a_missing_file_reached_through_a_variable` — the idiomatic two-line spelling (`d = Path(__file__).parent` then `d / "x.json"`). My first cut missed this and only caught the inline form; caught it by running against the real plugin corpus, which is why that second pass exists.
- `test_escape_is_flagged_even_when_the_file_happens_to_exist` — an escaping path that resolves on *this* box still breaks on a real install, so it must be flagged regardless.
- `test_allows_a_nested_module_reaching_its_own_package_root` — `<id>/lib/loader.py` reading `../data.json` is legitimate and must not be flagged.
- `test_unavailable_with_a_reason_is_reported_but_not_a_finding` — guards the unconfigured-vs-broken distinction the whole design rests on.
- `TestAgainstRealBundledPlugins` — sweeps `date_time`, `countdown`, `random`, `typewriter` live.

Verified locally in the dev container: `39 passed`. `ruff check` and `ruff format --check` clean; full `npm run docs:lint` (frontmatter, contract, markdownlint, cspell) clean.

## Docs

`PLUGIN_DEVELOPMENT.md` gains a "plugin must be self-contained" section showing the wrong and right path shapes, plus the two rules that would have prevented this: commit your data files (don't generate them in CI), and don't rely on third-party packages.

## Caveats

- The container available locally has `ruff 0.16.1`; the repo pins `0.16.3`. Formatting was applied with 0.16.1 — CI will confirm.
- The dependency check uses a small distribution→import name map for the cases where they differ. Unknown distributions fall back to `name.replace("-", "_")`, which is right the vast majority of the time; a wrong guess produces a false positive that the map can absorb.
- The path checks are regex-based rather than AST-based. That is why they are backed by the real-corpus run above rather than by confidence alone. An AST pass would be more rigorous if this ever needs to get stricter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
