### PR TITLE
feat(plugins): validate plugins at install time instead of after the fact

### DIFF
--- a/docs/internal/development/PLUGIN_DEVELOPMENT.md
+++ b/docs/internal/development/PLUGIN_DEVELOPMENT.md
@@ -746,7 +746,20 @@ This is not hypothetical: the Star Trek Quotes plugin shipped this way for
 months, serving `???` to every user, because its data file was never committed
 and its fallback pointed at the platform copy.
 
-Two rules follow:
+Three rules follow:
+
+- **Declare your data files** in `manifest.json`, so a broken install is
+  rejected before the plugin ever runs:
+
+  ```json
+  {
+    "id": "star_trek_quotes",
+    "data_files": ["quotes.json"]
+  }
+  ```
+
+  Paths are relative to your plugin directory. Absolute paths and `..`
+  segments are rejected — a plugin may only declare files it ships.
 
 - **Commit your data files.** Do not generate or symlink them in CI. If your
   test workflow creates a file the shipped plugin lacks, your suite is testing
@@ -757,8 +770,17 @@ Two rules follow:
   beyond the standard library plus the platform's own dependencies will be
   missing at runtime. Vendor it or do without.
 
-`scripts/plugin_health_sweep.py` enforces all of this against every registry
-plugin daily. Run it locally before publishing:
+### How this is enforced
+
+| when | what happens |
+|------|--------------|
+| **Install** | A plugin that declares a file it does not ship, reads a file that is missing, or needs a package FiestaBoard lacks is **refused**, and the clone is removed. |
+| **Update** | The same failure is reported through `GET /plugins/errors` and the Integrations page, but the plugin is **left installed** — an update should not silently pull a working board out from under someone. |
+| **Startup** | Every installed plugin is re-checked; findings appear in `GET /plugins/errors`. |
+| **Registry review** | `validate_plugins.py --strict` escalates the advisory "reads a file it does not declare" into a failure. |
+| **Daily** | `scripts/plugin_health_sweep.py` sweeps every registry plugin and files an issue. |
+
+Run the checks locally before publishing:
 
 ```bash
 docker compose -f docker-compose.dev.yml exec fiestaboard \

--- a/scripts/plugin_health_sweep.py
+++ b/scripts/plugin_health_sweep.py
@@ -45,10 +45,8 @@ Exit codes:
 """
 
 import argparse
-import importlib.util
 import json
 import os
-import re
 import sys
 import traceback
 from pathlib import Path
@@ -59,49 +57,6 @@ PLUGINS_DIR = PROJECT_ROOT / "plugins"
 DEFAULT_EXTERNAL_DIR = PROJECT_ROOT / "data" / "external_plugins"
 
 sys.path.insert(0, str(PROJECT_ROOT))
-
-DATA_SUFFIXES = ("json", "csv", "txt", "yaml", "yml", "ndjson", "tsv")
-
-# A __file__-anchored path expression, capturing the .parent hops and the
-# quoted segments joined onto it. Matches both pathlib and os.path styles:
-#   Path(__file__).parent / "quotes.json"
-#   Path(__file__).parent.parent / "src" / "utils" / "x.json"
-#   os.path.join(os.path.dirname(__file__), "data", "x.json")
-FILE_ANCHORED = re.compile(
-    r"""
-    (?P<anchor>
-        Path\(\s*__file__\s*\)(?P<hops>(?:\s*\.\s*parent)*)
-        | os\.path\.dirname\(\s*__file__\s*\)
-    )
-    (?P<tail>(?:\s*[/,]\s*(?:["'][^"']+["']|\w+\s*\(\s*\))|\s*\)\s*)*)
-    """,
-    re.VERBOSE,
-)
-QUOTED = re.compile(r"""["']([^"']+)["']""")
-
-# Plugins commonly stash the anchor first and join onto it later:
-#   plugin_dir = Path(__file__).parent
-#   quotes_file = plugin_dir / "quotes.json"
-# Without this the data_files check misses the most idiomatic spelling.
-ANCHOR_ASSIGN = re.compile(
-    r"""^[ \t]*(?P<name>\w+)[ \t]*=[ \t]*
-        (?:Path\(\s*__file__\s*\)(?P<hops>(?:\s*\.\s*parent)*)
-         | os\.path\.dirname\(\s*__file__\s*\))
-        [ \t]*$""",
-    re.VERBOSE | re.MULTILINE,
-)
-
-# Distributions whose import name differs from the package name.
-IMPORT_NAME_OVERRIDES = {
-    "speedtest-cli": "speedtest",
-    "beautifulsoup4": "bs4",
-    "pillow": "PIL",
-    "python-dateutil": "dateutil",
-    "pyyaml": "yaml",
-    "python-dotenv": "dotenv",
-    "msgpack-python": "msgpack",
-    "attrs": "attr",
-}
 
 
 class Finding:
@@ -123,160 +78,6 @@ class Finding:
 
     def __repr__(self) -> str:  # pragma: no cover - debugging aid
         return f"<Finding {self.plugin_id}/{self.check}>"
-
-
-def python_sources(plugin_dir: Path) -> list[Path]:
-    """Runtime .py files for a plugin (tests and caches excluded)."""
-    skip = {"tests", "test", "docs", "__pycache__", ".git", ".github"}
-    return [p for p in plugin_dir.rglob("*.py") if not any(part in skip for part in p.relative_to(plugin_dir).parts)]
-
-
-def referenced_data_paths(source: str) -> list[tuple[int, list[str]]]:
-    """Extract ``__file__``-anchored data-file references from source text.
-
-    Returns ``(parent_hops, path_segments)`` per reference.  ``parent_hops`` is
-    how many ``.parent`` steps the expression takes, which is what tells us
-    whether the path escapes the plugin's own directory.
-    """
-    refs = []
-    for match in FILE_ANCHORED.finditer(source):
-        segments = QUOTED.findall(match.group("tail") or "")
-        if not segments:
-            continue
-        if not segments[-1].lower().endswith(DATA_SUFFIXES):
-            continue
-        hops = len(re.findall(r"\.\s*parent", match.group("hops") or ""))
-        if match.group("anchor").startswith("os.path.dirname"):
-            hops = 1
-        refs.append((hops, segments))
-
-    # Second pass: joins onto a variable that holds a __file__ anchor.
-    for assign in ANCHOR_ASSIGN.finditer(source):
-        name = assign.group("name")
-        hops = len(re.findall(r"\.\s*parent", assign.group("hops") or "")) or 1
-        joined = re.compile(
-            rf"""(?:\b{re.escape(name)}\b(?P<tail>(?:\s*/\s*["'][^"']+["'])+)
-                 | os\.path\.join\(\s*{re.escape(name)}\s*(?P<jtail>(?:,\s*["'][^"']+["'])+)\s*\))""",
-            re.VERBOSE,
-        )
-        for use in joined.finditer(source):
-            segments = QUOTED.findall(use.group("tail") or use.group("jtail") or "")
-            if not segments:
-                continue
-            if not segments[-1].lower().endswith(DATA_SUFFIXES):
-                continue
-            refs.append((hops, segments))
-
-    # Same file referenced both inline and via a variable -> report once.
-    deduped = dict.fromkeys((hops, tuple(segs)) for hops, segs in refs)
-    return [(hops, list(segs)) for hops, segs in deduped]
-
-
-def check_data_files(plugin_id: str, plugin_dir: Path) -> list[Finding]:
-    """Every data file the plugin reads relative to itself must exist."""
-    findings = []
-    for src in python_sources(plugin_dir):
-        try:
-            text = src.read_text(encoding="utf-8", errors="replace")
-        except OSError:
-            continue
-        if "__file__" not in text:
-            continue
-        for hops, segments in referenced_data_paths(text):
-            if segments[-1] == "manifest.json":
-                continue
-            # hops==1 means Path(__file__).parent -> the plugin dir itself.
-            base = src.parent
-            for _ in range(max(hops - 1, 0)):
-                base = base.parent
-            target = base.joinpath(*segments)
-            if target.exists():
-                continue
-            rel = src.relative_to(plugin_dir)
-            findings.append(
-                Finding(
-                    plugin_id,
-                    "data_files",
-                    f"{rel} reads {'/'.join(segments)!r} but no such file ships with the plugin (looked for {target})",
-                )
-            )
-    return findings
-
-
-def check_self_contained(plugin_id: str, plugin_dir: Path) -> list[Finding]:
-    """A plugin must not reach outside its own directory for data.
-
-    This is the exact shape of the Star Trek Quotes regression: a path written
-    for the bundled ``plugins/<id>/`` layout silently resolves somewhere else
-    once the plugin is installed one directory deeper.
-    """
-    findings = []
-    for src in python_sources(plugin_dir):
-        try:
-            text = src.read_text(encoding="utf-8", errors="replace")
-        except OSError:
-            continue
-        if "__file__" not in text:
-            continue
-        depth = len(src.relative_to(plugin_dir).parts)  # 1 == plugin root
-        for hops, segments in referenced_data_paths(text):
-            # hops-1 directories above the file's own directory.
-            if hops - 1 < depth:
-                continue
-            rel = src.relative_to(plugin_dir)
-            findings.append(
-                Finding(
-                    plugin_id,
-                    "self_contained",
-                    f"{rel} walks {hops - 1} directories up to reach "
-                    f"{'/'.join(segments)!r}, escaping the plugin directory. "
-                    f"Such a path only resolves in the bundled layout and "
-                    f"breaks once the plugin is installed.",
-                )
-            )
-    return findings
-
-
-def declared_requirements(plugin_dir: Path) -> list[str]:
-    """Distribution names from any requirements.txt the plugin ships."""
-    names = []
-    for req in plugin_dir.rglob("requirements.txt"):
-        if "dev" in req.name:
-            continue
-        for line in req.read_text(encoding="utf-8", errors="replace").splitlines():
-            line = line.split("#")[0].strip()
-            if not line or line.startswith("-"):
-                continue
-            name = re.split(r"[<>=!~\[; ]", line, maxsplit=1)[0].strip()
-            if name:
-                names.append(name)
-    return sorted(set(names))
-
-
-def check_dependencies(plugin_id: str, plugin_dir: Path) -> list[Finding]:
-    """Declared dependencies must be importable in this runtime.
-
-    The platform never installs a plugin's requirements.txt (Fiestaboard/
-    FiestaBoard#1671), so anything declared there is missing at runtime.
-    """
-    findings = []
-    for dist in declared_requirements(plugin_dir):
-        module = IMPORT_NAME_OVERRIDES.get(dist.lower(), dist.replace("-", "_"))
-        try:
-            found = importlib.util.find_spec(module) is not None
-        except (ImportError, ValueError):
-            found = False
-        if not found:
-            findings.append(
-                Finding(
-                    plugin_id,
-                    "dependencies",
-                    f"requires {dist!r} (import {module!r}) which is not "
-                    f"installed in the runtime; the plugin cannot work on a "
-                    f"real install",
-                )
-            )
-    return findings
 
 
 def schema_defaults(plugin) -> dict:
@@ -359,7 +160,9 @@ def check_fetch_contract(plugin_id: str, plugin) -> tuple[list[Finding], str]:
 
 def sweep(external_dir: Path, only: str | None, do_fetch: bool) -> tuple[list, list]:
     """Run every check against every discoverable plugin."""
+    from src.plugins.install_check import validate_install
     from src.plugins.loader import PluginLoader
+    from src.plugins.manifest import load_manifest
 
     loader = PluginLoader(plugins_dir=PLUGINS_DIR, external_dirs=[external_dir])
     plugin_ids = loader.discover_plugins()
@@ -376,9 +179,12 @@ def sweep(external_dir: Path, only: str | None, do_fetch: bool) -> tuple[list, l
         row = {"plugin": plugin_id, "dir": str(plugin_dir), "status": "?"}
 
         if plugin_dir is not None:
-            findings.extend(check_data_files(plugin_id, plugin_dir))
-            findings.extend(check_self_contained(plugin_id, plugin_dir))
-            findings.extend(check_dependencies(plugin_id, plugin_dir))
+            manifest_for_checks, _ = load_manifest(plugin_dir / "manifest.json")
+            install_result = validate_install(plugin_id, plugin_dir, manifest_for_checks)
+            for message in install_result.errors:
+                findings.append(Finding(plugin_id, "install", message))
+            for message in install_result.warnings:
+                findings.append(Finding(plugin_id, "undeclared", message, fatal=False))
 
         try:
             plugin = loader.load_plugin(plugin_id)
@@ -422,6 +228,15 @@ def sweep(external_dir: Path, only: str | None, do_fetch: bool) -> tuple[list, l
 
 CHECK_EXPLANATIONS = {
     "load": "The plugin does not load at all, so it is invisible to users.",
+    "install": (
+        "The plugin cannot work as installed -- a declared data file is "
+        "missing, or it needs a package FiestaBoard does not ship."
+    ),
+    "undeclared": (
+        "Advisory. The plugin reads a data file it does not declare in "
+        "`manifest.json`, so a missing copy would not be caught at install "
+        "time. Declare it under `data_files`."
+    ),
     "data_files": (
         "The plugin reads a data file that is not shipped with it. Every variable it exposes will render as `???`."
     ),
@@ -519,7 +334,8 @@ def main() -> int:
     if args.markdown_path:
         Path(args.markdown_path).write_text(render_markdown(findings, report, external_dir))
 
-    set_output("has_findings", "true" if findings else "false")
+    fatal = [f for f in findings if f.fatal]
+    set_output("has_findings", "true" if fatal else "false")
 
     if not findings:
         print("No breakage found. Every plugin loads, ships its data files,")
@@ -530,13 +346,18 @@ def main() -> int:
     for finding in findings:
         by_plugin.setdefault(finding.plugin_id, []).append(finding)
 
-    print(f"BROKEN: {len(findings)} finding(s) across {len(by_plugin)} plugin(s)\n")
+    print(f"{len(fatal)} blocking, {len(findings) - len(fatal)} advisory across {len(by_plugin)} plugin(s)\n")
     for plugin_id in sorted(by_plugin):
         print(f"  {plugin_id}")
         for finding in by_plugin[plugin_id]:
-            print(f"    [{finding.check}] {finding.detail}")
+            mark = "" if finding.fatal else " (advisory)"
+            print(f"    [{finding.check}]{mark} {finding.detail}")
         print()
-    return 1
+
+    # Advisory findings -- an undeclared data file that is nonetheless
+    # present -- must not fail a scheduled job, or every plugin published
+    # before data_files existed turns the run red forever.
+    return 1 if fatal else 0
 
 
 if __name__ == "__main__":

--- a/scripts/validate_plugins.py
+++ b/scripts/validate_plugins.py
@@ -306,7 +306,43 @@ def validate_plugin(plugin_dir: Path) -> ValidationResult:
     for warning in validate_preview_presence(manifest):
         result.add_warning(warning)
 
+    # Can this plugin actually work once installed? A declared data file that
+    # never shipped, or a Python package FiestaBoard does not provide, means
+    # the plugin renders "???" for every variable no matter how it is
+    # configured. Errors here are hard errors; the advisory "reads a file it
+    # does not declare" is a warning that --strict escalates, which is what
+    # the registry submission lane wants.
+    for error, warning in _install_findings(plugin_dir, manifest):
+        if error:
+            result.add_error(error)
+        else:
+            result.add_warning(warning)
+
     return result
+
+
+def _install_findings(plugin_dir: Path, manifest: dict):
+    """Yield ``(error, warning)`` pairs from the shared install checks.
+
+    Imported lazily so this script keeps working (minus these checks) if it is
+    ever run somewhere the platform package is not importable.
+    """
+    try:
+        from src.plugins.install_check import validate_install
+        from src.plugins.manifest import PluginManifest
+    except ImportError:  # pragma: no cover - defensive
+        return
+
+    try:
+        parsed = PluginManifest.from_dict(manifest)
+    except Exception:
+        return
+
+    outcome = validate_install(manifest.get("id", plugin_dir.name), plugin_dir, parsed)
+    for message in outcome.errors:
+        yield message, None
+    for message in outcome.warnings:
+        yield None, message
 
 
 def validate_unique_ids(plugins: list[Path]) -> list[str]:

--- a/src/plugins/install_check.py
+++ b/src/plugins/install_check.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import importlib.util
 import re
 from dataclasses import dataclass, field
+from importlib import metadata as importlib_metadata
 from pathlib import Path
 
 # Distributions whose import name differs from the name pip installs under.
@@ -233,6 +234,32 @@ def _declared_requirements(plugin_dir: Path) -> list[str]:
 
 
 def _is_importable(distribution: str) -> bool:
+    """True when this runtime provides *distribution*.
+
+    Installed metadata is asked first, because it is keyed by the name pip
+    installs under (PEP 503 normalised) and so needs no guess about the import
+    name.  Guessing is what makes this dangerous: a wrong guess here is a
+    blocking error that *refuses the install*, and FiestaBoard ships two
+    packages whose import name differs from their distribution name without
+    appearing in the override table below -- ``finnhub-python`` (imports as
+    ``finnhub``) and ``paho-mqtt`` (imports as ``paho.mqtt``).  A plugin
+    declaring either would have been rejected for a dependency that is in
+    fact present.
+
+    ``find_spec`` remains as a fallback for a module that is importable
+    without installed metadata -- vendored, or provided under a different
+    distribution name.
+    """
+    try:
+        importlib_metadata.distribution(distribution)
+        return True
+    except importlib_metadata.PackageNotFoundError:
+        pass
+    except (ValueError, OSError):
+        # Malformed name or unreadable metadata: fall through to the import
+        # probe rather than treating the dependency as missing.
+        pass
+
     module = IMPORT_NAME_OVERRIDES.get(distribution.lower(), distribution.replace("-", "_"))
     try:
         return importlib.util.find_spec(module) is not None

--- a/src/plugins/install_check.py
+++ b/src/plugins/install_check.py
@@ -1,0 +1,351 @@
+"""Install-time validation: is this plugin actually usable on this box?
+
+A plugin's own CI runs it from the *bundled* ``plugins/<id>/`` layout, one
+directory shallower than the ``data/external_plugins/<id>/`` layout it
+installs to, and with the plugin repo's dev dependencies present.  Neither
+holds for a user.  The Star Trek Quotes plugin passed its own suite for
+months while serving ``???`` to everyone, because the data file it read was
+created by CI and never shipped.
+
+These checks run at install time, against the tree that actually landed, and
+answer one question: *can this plugin possibly work here?*  They deliberately
+do not ask whether it is configured -- that is the user's business and comes
+later.
+
+Policy (see ``validate_install``):
+
+* A **new install** that fails is rejected.  Nothing is worse than a plugin
+  that installs cleanly and then renders ``???`` with no explanation.
+* An **already-installed** plugin that starts failing (say, an upgrade drops
+  a data file) is reported loudly via ``/api/plugins/errors`` and the
+  Integrations UI, but never auto-disabled -- yanking a working board out
+  from under someone is a worse failure than a stale one.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Distributions whose import name differs from the name pip installs under.
+IMPORT_NAME_OVERRIDES = {
+    "attrs": "attr",
+    "beautifulsoup4": "bs4",
+    "msgpack-python": "msgpack",
+    "pillow": "PIL",
+    "python-dateutil": "dateutil",
+    "python-dotenv": "dotenv",
+    "pyyaml": "yaml",
+    "speedtest-cli": "speedtest",
+}
+
+_REQUIREMENT_NAME = re.compile(r"^[A-Za-z0-9._-]+")
+
+# ── heuristic: does the source read a data file it never declared? ──────────
+#
+# The declaration is authoritative, but it is opt-in, and the plugin that
+# started all this did not declare anything. This scan is the backstop: it
+# reads the source for __file__-relative data paths and reports ones the
+# manifest does not cover. It is a *warning* everywhere except the registry
+# submission lane -- a regex over source is a guess, and a guess must never
+# block an install.
+
+DATA_SUFFIXES = ("json", "csv", "txt", "yaml", "yml", "ndjson", "tsv")
+
+#   Path(__file__).parent / "quotes.json"
+#   Path(__file__).parent.parent / "src" / "utils" / "x.json"
+#   os.path.join(os.path.dirname(__file__), "data", "x.json")
+_FILE_ANCHORED = re.compile(
+    r"""
+    (?P<anchor>
+        Path\(\s*__file__\s*\)(?P<hops>(?:\s*\.\s*parent)*)
+        | os\.path\.dirname\(\s*__file__\s*\)
+    )
+    (?P<tail>(?:\s*[/,]\s*(?:["'][^"']+["']|\w+\s*\(\s*\))|\s*\)\s*)*)
+    """,
+    re.VERBOSE,
+)
+
+#   plugin_dir = Path(__file__).parent
+#   quotes_file = plugin_dir / "quotes.json"
+_ANCHOR_ASSIGN = re.compile(
+    r"""^[ \t]*(?P<name>\w+)[ \t]*=[ \t]*
+        (?:Path\(\s*__file__\s*\)(?P<hops>(?:\s*\.\s*parent)*)
+         | os\.path\.dirname\(\s*__file__\s*\))
+        [ \t]*$""",
+    re.VERBOSE | re.MULTILINE,
+)
+
+_QUOTED = re.compile(r"""["']([^"']+)["']""")
+
+_NON_RUNTIME_PARTS = {"tests", "test", "docs", "__pycache__", ".git", ".github"}
+
+
+def python_sources(plugin_dir: Path) -> list[Path]:
+    """Runtime .py files for a plugin (tests, docs and caches excluded)."""
+    return [
+        p
+        for p in sorted(plugin_dir.rglob("*.py"))
+        if not any(part in _NON_RUNTIME_PARTS for part in p.relative_to(plugin_dir).parts)
+    ]
+
+
+def referenced_data_paths(source: str) -> list[tuple[int, list[str]]]:
+    """Find ``__file__``-anchored data-file references in source text.
+
+    Returns ``(parent_hops, path_segments)`` per distinct reference.
+    ``parent_hops`` counts ``.parent`` steps, which is what reveals a path
+    reaching outside the plugin's own directory.
+    """
+    refs: list[tuple[int, list[str]]] = []
+
+    for match in _FILE_ANCHORED.finditer(source):
+        segments = _QUOTED.findall(match.group("tail") or "")
+        if not segments or not segments[-1].lower().endswith(DATA_SUFFIXES):
+            continue
+        hops = len(re.findall(r"\.\s*parent", match.group("hops") or ""))
+        if match.group("anchor").startswith("os.path.dirname"):
+            hops = 1
+        refs.append((hops, segments))
+
+    for assign in _ANCHOR_ASSIGN.finditer(source):
+        name = assign.group("name")
+        hops = len(re.findall(r"\.\s*parent", assign.group("hops") or "")) or 1
+        joined = re.compile(
+            rf"""(?:\b{re.escape(name)}\b(?P<tail>(?:\s*/\s*["'][^"']+["'])+)
+                 | os\.path\.join\(\s*{re.escape(name)}\s*(?P<jtail>(?:,\s*["'][^"']+["'])+)\s*\))""",
+            re.VERBOSE,
+        )
+        for use in joined.finditer(source):
+            segments = _QUOTED.findall(use.group("tail") or use.group("jtail") or "")
+            if not segments or not segments[-1].lower().endswith(DATA_SUFFIXES):
+                continue
+            refs.append((hops, segments))
+
+    deduped = dict.fromkeys((hops, tuple(segs)) for hops, segs in refs)
+    return [(hops, list(segs)) for hops, segs in deduped]
+
+
+def detect_data_file_problems(plugin_dir: Path, declared: list[str]) -> tuple[list[str], list[str]]:
+    """Scan source for data-file reads the declaration does not cover.
+
+    Returns ``(errors, warnings)``.  Severity follows whether the plugin can
+    actually work, **not** whether the author remembered to declare anything:
+
+    * a path that escapes the plugin directory -> error (can never resolve
+      once installed, no matter what is on disk)
+    * a file that is read but absent -> error (the plugin is broken right now;
+      this is the Star Trek case, which declared nothing)
+    * a file that is read, present, but undeclared -> warning (works today,
+      but nothing would catch it going missing at install time)
+    """
+    declared_set = set(declared)
+    errors: list[str] = []
+    warnings: list[str] = []
+    seen: set[str] = set()
+
+    for src in python_sources(plugin_dir):
+        try:
+            text = src.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if "__file__" not in text:
+            continue
+        rel_src = src.relative_to(plugin_dir)
+        depth = len(rel_src.parts)  # 1 == plugin root
+
+        for hops, segments in referenced_data_paths(text):
+            joined = "/".join(segments)
+            if joined == "manifest.json":
+                continue
+            key = f"{rel_src}:{joined}"
+            if key in seen:
+                continue
+            seen.add(key)
+
+            if hops - 1 >= depth:
+                errors.append(
+                    f"{rel_src} reads {joined!r} from outside the plugin "
+                    f"directory ({hops - 1} levels up). That path only "
+                    f"resolves in the bundled plugins/<id>/ layout and breaks "
+                    f"once the plugin is installed."
+                )
+                continue
+
+            base = src.parent
+            for _ in range(max(hops - 1, 0)):
+                base = base.parent
+            if not base.joinpath(*segments).exists():
+                errors.append(
+                    f"{rel_src} reads {joined!r} but no such file ships with "
+                    f"the plugin. Every variable it provides will render "
+                    f"'???'."
+                )
+            elif joined not in declared_set:
+                warnings.append(
+                    f"{rel_src} reads {joined!r} but manifest data_files does "
+                    f"not declare it, so a missing copy would not be caught "
+                    f"at install time"
+                )
+    return errors, warnings
+
+
+@dataclass
+class InstallCheckResult:
+    """Outcome of validating one plugin directory."""
+
+    plugin_id: str
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        """True when nothing would stop this plugin from working."""
+        return not self.errors
+
+    def to_dict(self) -> dict[str, list[str]]:
+        return {"errors": list(self.errors), "warnings": list(self.warnings)}
+
+
+def _declared_requirements(plugin_dir: Path) -> list[str]:
+    """Distribution names from the plugin's runtime requirements.txt."""
+    names: list[str] = []
+    for req in sorted(plugin_dir.rglob("requirements.txt")):
+        if "dev" in req.name:
+            continue
+        if any(part in {".git", "__pycache__", "tests"} for part in req.parts):
+            continue
+        try:
+            content = req.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for line in content.splitlines():
+            line = line.split("#")[0].strip()
+            if not line or line.startswith("-"):
+                continue
+            match = _REQUIREMENT_NAME.match(line)
+            if match:
+                names.append(match.group(0))
+    # dedupe, order-stable
+    return list(dict.fromkeys(names))
+
+
+def _is_importable(distribution: str) -> bool:
+    module = IMPORT_NAME_OVERRIDES.get(distribution.lower(), distribution.replace("-", "_"))
+    try:
+        return importlib.util.find_spec(module) is not None
+    except (ImportError, ValueError):
+        return False
+
+
+def check_declared_data_files(plugin_dir: Path, declared: list[str]) -> list[str]:
+    """Every file the manifest promises must actually be present."""
+    errors = []
+    for rel in declared:
+        target = plugin_dir / rel
+        if not target.exists():
+            errors.append(
+                f"manifest declares data file {rel!r} but it is missing from the plugin. The install is incomplete."
+            )
+        elif not target.is_file():
+            errors.append(f"manifest declares data file {rel!r} but it is not a file.")
+    return errors
+
+
+def check_declaration_is_well_formed(raw_manifest: dict, declared: list[str]) -> list[str]:
+    """Catch entries parse_data_files() dropped for escaping the plugin dir."""
+    raw = raw_manifest.get("data_files")
+    if not isinstance(raw, list):
+        return []
+    kept = set(declared)
+    errors = []
+    for entry in raw:
+        if not isinstance(entry, str):
+            errors.append(f"data_files entry {entry!r} is not a string")
+            continue
+        normalised = entry.strip().replace("\\", "/")
+        parts = [p for p in normalised.split("/") if p not in ("", ".")]
+        if "/".join(parts) in kept:
+            continue
+        errors.append(
+            f"data_files entry {entry!r} is not a path inside the plugin "
+            f"directory. Plugins must ship their own data; reaching outside "
+            f"the plugin directory only works in the bundled layout and "
+            f"breaks once installed."
+        )
+    return errors
+
+
+def check_dependencies(plugin_dir: Path) -> list[str]:
+    """Declared third-party packages must be importable in this runtime.
+
+    The platform does not install a plugin's requirements.txt, so anything
+    listed there is missing at runtime unless the platform happens to ship it.
+    """
+    errors = []
+    for dist in _declared_requirements(plugin_dir):
+        if not _is_importable(dist):
+            errors.append(
+                f"requires Python package {dist!r}, which is not available. "
+                f"FiestaBoard does not install plugin dependencies; the plugin "
+                f"must rely only on the standard library and the packages "
+                f"FiestaBoard already ships."
+            )
+    return errors
+
+
+def check_required_files(plugin_dir: Path) -> list[str]:
+    """The files every plugin needs regardless of what it declares."""
+    errors = []
+    for required in ("__init__.py", "manifest.json"):
+        if not (plugin_dir / required).is_file():
+            errors.append(f"missing required file {required!r}")
+    return errors
+
+
+def validate_install(
+    plugin_id: str,
+    plugin_dir: Path,
+    manifest,
+) -> InstallCheckResult:
+    """Validate a plugin directory that has just been installed or loaded.
+
+    Args:
+        plugin_id: The plugin's id.
+        plugin_dir: Directory the plugin was installed into.
+        manifest: A parsed ``PluginManifest`` (or None if it would not parse).
+
+    Returns:
+        An :class:`InstallCheckResult`. ``result.ok`` is False when the plugin
+        cannot work here, whatever the user configures.
+    """
+    result = InstallCheckResult(plugin_id=plugin_id)
+
+    if not plugin_dir.is_dir():
+        result.errors.append(f"plugin directory {plugin_dir} does not exist")
+        return result
+
+    result.errors.extend(check_required_files(plugin_dir))
+
+    if manifest is None:
+        result.errors.append("manifest.json could not be parsed")
+        return result
+
+    declared = list(getattr(manifest, "data_files", []) or [])
+    raw_manifest = getattr(manifest, "raw", {}) or {}
+
+    result.errors.extend(check_declaration_is_well_formed(raw_manifest, declared))
+    result.errors.extend(check_declared_data_files(plugin_dir, declared))
+    result.errors.extend(check_dependencies(plugin_dir))
+
+    # Backstop for the plugin that declares nothing -- which is every plugin
+    # published before data_files existed, including the one that prompted it.
+    # A genuinely missing file is an error even when undeclared; merely
+    # failing to declare a file that is present is advisory.
+    scan_errors, scan_warnings = detect_data_file_problems(plugin_dir, declared)
+    result.errors.extend(scan_errors)
+    result.warnings.extend(scan_warnings)
+
+    return result

--- a/src/plugins/loader.py
+++ b/src/plugins/loader.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from .base import PluginBase, TransitionPluginBase
+from .install_check import validate_install
 from .manifest import PluginManifest, collect_options_ids, load_manifest, settings_schema_ui_warnings
 from .sources import (
     PluginSource,
@@ -321,6 +322,24 @@ class PluginLoader:
         # ignored key is invisible from the settings dialog, so surface it
         # through GET /plugins/errors rather than only in the container log.
         for message in settings_schema_ui_warnings(manifest.settings_schema):
+            self._load_errors.setdefault(plugin_name, []).append(message)
+
+        # Structural problems that make the plugin unusable no matter how the
+        # user configures it: a declared data file that never shipped, a
+        # Python package the platform does not provide. A *fresh* install
+        # carrying these is rejected outright (see sources._install_and_verify);
+        # here we are looking at something already on disk, which may be
+        # driving a board, so surface it through GET /plugins/errors and let
+        # it load rather than silently serving "???" for every variable.
+        install_result = validate_install(plugin_name, plugin_dir, manifest)
+        for message in install_result.errors:
+            self._load_errors.setdefault(plugin_name, []).append(message)
+            logger.error("Plugin %s is installed but cannot work: %s", plugin_name, message)
+        # Warnings are heuristic (a regex over the plugin's source), so they
+        # never stop a load -- but they share the same surface, because an
+        # undeclared data file is precisely the case the declaration cannot
+        # catch on its own.
+        for message in install_result.warnings:
             self._load_errors.setdefault(plugin_name, []).append(message)
 
         # Check FiestaBoard version compatibility (soft failure -- warn but still load)

--- a/src/plugins/manifest.py
+++ b/src/plugins/manifest.py
@@ -95,6 +95,37 @@ UI_OPTIONS_KEYS = (
 MIN_OPTIONS_CACHE_SECONDS = 0
 MAX_OPTIONS_CACHE_SECONDS = 3600
 
+
+def parse_data_files(raw: Any) -> list[str]:
+    """Normalise the manifest's ``data_files`` declaration.
+
+    Entries are paths relative to the plugin's own directory.  Anything that
+    could escape that directory -- absolute paths, ``..`` segments, drive
+    letters, backslashes -- is dropped rather than raising, because
+    ``load_manifest()`` returns None on error and rejecting the manifest would
+    uninstall a working plugin over a bad declaration.  ``validate_install()``
+    reports the dropped entry.
+    """
+    if not isinstance(raw, list):
+        return []
+    cleaned: list[str] = []
+    for entry in raw:
+        if not isinstance(entry, str):
+            continue
+        candidate = entry.strip().replace("\\", "/")
+        if not candidate:
+            continue
+        if candidate.startswith("/") or ":" in candidate:
+            continue
+        parts = [p for p in candidate.split("/") if p not in ("", ".")]
+        if any(p == ".." for p in parts):
+            continue
+        normalised = "/".join(parts)
+        if normalised and normalised not in cleaned:
+            cleaned.append(normalised)
+    return cleaned
+
+
 # ``ui:widget`` values the settings form knows how to render. An unrecognised
 # value is a *warning*, never an error: several installed plugins declare
 # picker widgets core never implemented, and load_manifest() returns None on
@@ -522,6 +553,11 @@ class PluginManifest:
     previews: list[BoardPreview] = field(default_factory=list)
     plugin_type: str = "data"  # "data" or "transition"
     transition_settings: dict[str, Any] = field(default_factory=dict)
+    # Data files the plugin must be able to read, relative to its own
+    # directory. Declared so an install can be rejected before the plugin
+    # ever runs, rather than serving "???" for every variable. See
+    # validate_install() in src/plugins/install_check.py.
+    data_files: list[str] = field(default_factory=list)
     raw: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
@@ -685,6 +721,7 @@ class PluginManifest:
             previews=parse_previews(data.get("previews")),
             plugin_type=data.get("plugin_type", "data"),
             transition_settings=dict(data.get("transition_settings", {})),
+            data_files=parse_data_files(data.get("data_files")),
             raw=raw,
         )
 

--- a/src/plugins/sources.py
+++ b/src/plugins/sources.py
@@ -39,9 +39,7 @@ EXTERNAL_PLUGINS_DIR = "external_plugins"
 # UI can distinguish them by repo name alone before any cloning happens.
 REGISTRY_PREFIX = "fiestaboard-plugin--"
 REGISTRY_TRANSITION_PREFIX = "fiestaboard-transition--"
-REGISTRY_NAME_RE = re.compile(
-    r"^(?:fiestaboard-plugin--|fiestaboard-transition--)[a-z][a-z0-9-]*$"
-)
+REGISTRY_NAME_RE = re.compile(r"^(?:fiestaboard-plugin--|fiestaboard-transition--)[a-z][a-z0-9-]*$")
 
 # Plugin id must be a safe single-segment identifier so it can be used as a
 # directory name without enabling path traversal.  Same character set as a
@@ -238,7 +236,7 @@ def plugin_id_from_repo_name(repo_name: str) -> str:
     """
     for prefix in (REGISTRY_PREFIX, REGISTRY_TRANSITION_PREFIX):
         if repo_name.startswith(prefix):
-            return repo_name[len(prefix):].replace("-", "_")
+            return repo_name[len(prefix) :].replace("-", "_")
     return repo_name.replace("-", "_")
 
 
@@ -296,10 +294,7 @@ def _validate_git_url(url: str) -> tuple[bool, str]:
 def _validate_plugin_id(plugin_id: str) -> tuple[bool, str]:
     """Validate that *plugin_id* is safe to use as a single path segment."""
     if not isinstance(plugin_id, str) or not PLUGIN_ID_RE.match(plugin_id):
-        return False, (
-            f"Invalid plugin id {plugin_id!r}: must match "
-            f"{PLUGIN_ID_RE.pattern}"
-        )
+        return False, (f"Invalid plugin id {plugin_id!r}: must match {PLUGIN_ID_RE.pattern}")
     return True, ""
 
 
@@ -308,9 +303,7 @@ def _validate_git_ref(ref: str) -> tuple[bool, str]:
     if not isinstance(ref, str):
         return False, "Invalid branch/tag: must be a string"
     if not GIT_REF_RE.fullmatch(ref):
-        return False, (
-            f"Invalid branch/tag {ref!r}: must match {GIT_REF_RE.pattern}"
-        )
+        return False, (f"Invalid branch/tag {ref!r}: must match {GIT_REF_RE.pattern}")
     return True, ""
 
 
@@ -389,14 +382,20 @@ def clone_or_update_repo(
             subprocess.run(
                 ["git", "fetch", "--depth=1", "origin", "HEAD"],
                 cwd=_candidate,
-                check=True, capture_output=True, text=True,
-                timeout=120, env=env,
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=120,
+                env=env,
             )
             subprocess.run(
                 ["git", "reset", "--hard", "FETCH_HEAD"],
                 cwd=_candidate,
-                check=True, capture_output=True, text=True,
-                timeout=30, env=env,
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                env=env,
             )
             logger.info("Updated existing plugin clone at %s", _candidate)
             return True, ""
@@ -423,16 +422,15 @@ def clone_or_update_repo(
         subprocess.run(
             ["git", "init", "--quiet"],
             cwd=_candidate,
-            check=True, capture_output=True, text=True,
-            timeout=30, env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
         )
         _git_config_path = os.path.join(_candidate, ".git", "config")
         with open(_git_config_path, "a") as _cfg:
-            _cfg.write(
-                '[remote "origin"]\n'
-                f"\turl = {repo_url}\n"
-                "\tfetch = +refs/heads/*:refs/remotes/origin/*\n"
-            )
+            _cfg.write(f'[remote "origin"]\n\turl = {repo_url}\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n')
         _fetch_cmd = ["git", "fetch", "--depth=1", "origin"]
         if branch:
             _fetch_cmd.append(branch)
@@ -441,14 +439,20 @@ def clone_or_update_repo(
         subprocess.run(
             _fetch_cmd,
             cwd=_candidate,
-            check=True, capture_output=True, text=True,
-            timeout=120, env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=120,
+            env=env,
         )
         subprocess.run(
             ["git", "reset", "--hard", "FETCH_HEAD"],
             cwd=_candidate,
-            check=True, capture_output=True, text=True,
-            timeout=30, env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
         )
         logger.info("Installed external plugin repository to %s", _candidate)
         return True, ""
@@ -475,7 +479,9 @@ def get_remote_head_sha(dest_dir: Path) -> str | None:
         # Get the remote URL from the local clone
         result = subprocess.run(
             ["git", "-C", str(dest_dir), "remote", "get-url", "origin"],
-            capture_output=True, text=True, timeout=30,
+            capture_output=True,
+            text=True,
+            timeout=30,
         )
         if result.returncode != 0:
             return None
@@ -495,14 +501,16 @@ def get_remote_head_sha(dest_dir: Path) -> str | None:
         # Determine the default branch name tracked locally
         branch_result = subprocess.run(
             ["git", "-C", str(dest_dir), "rev-parse", "--abbrev-ref", "HEAD"],
-            capture_output=True, text=True, timeout=10,
+            capture_output=True,
+            text=True,
+            timeout=10,
         )
         branch = branch_result.stdout.strip() or "main"
         # Allow only characters that are legal in git branch names and safe
         # as subprocess arguments (prevents argument injection).
         # Re-derive branch from the match result so the subprocess sink
         # does not see it as tainted (CodeQL py/command-line-injection).
-        _branch_m = re.match(r'^[A-Za-z0-9_./-]+$', branch)
+        _branch_m = re.match(r"^[A-Za-z0-9_./-]+$", branch)
         if not _branch_m:
             return None
         branch = _branch_m.group(0)
@@ -510,7 +518,9 @@ def get_remote_head_sha(dest_dir: Path) -> str | None:
         # Query the remote for the latest SHA
         ls_result = subprocess.run(
             ["git", "ls-remote", "--heads", remote_url, branch],
-            capture_output=True, text=True, timeout=30,
+            capture_output=True,
+            text=True,
+            timeout=30,
             env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
         )
         if ls_result.returncode == 0 and ls_result.stdout.strip():
@@ -524,7 +534,9 @@ def get_remote_head_sha(dest_dir: Path) -> str | None:
         # detected correctly regardless of local/remote branch name mismatch.
         ls_result = subprocess.run(
             ["git", "ls-remote", remote_url, "HEAD"],
-            capture_output=True, text=True, timeout=30,
+            capture_output=True,
+            text=True,
+            timeout=30,
             env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
         )
         if ls_result.returncode != 0 or not ls_result.stdout.strip():
@@ -541,7 +553,9 @@ def get_local_head_sha(dest_dir: Path) -> str | None:
     try:
         result = subprocess.run(
             ["git", "-C", str(dest_dir), "rev-parse", "HEAD"],
-            capture_output=True, text=True, timeout=10,
+            capture_output=True,
+            text=True,
+            timeout=10,
         )
         return result.stdout.strip() if result.returncode == 0 else None
     except (subprocess.SubprocessError, OSError):
@@ -573,7 +587,10 @@ def _read_remote_manifest_version(dest_dir: Path) -> str:
         # while most plugin repos publish "main".
         branch_result = subprocess.run(
             ["git", "-C", str(dest_dir), "rev-parse", "--abbrev-ref", "HEAD"],
-            capture_output=True, text=True, timeout=10, env=env,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env=env,
         )
         refs: list[str] = []
         branch = branch_result.stdout.strip()
@@ -588,7 +605,10 @@ def _read_remote_manifest_version(dest_dir: Path) -> str:
         for ref in refs:
             fetch_result = subprocess.run(
                 ["git", "-C", str(dest_dir), "fetch", "--quiet", "--depth=1", "origin", ref],
-                capture_output=True, text=True, timeout=120, env=env,
+                capture_output=True,
+                text=True,
+                timeout=120,
+                env=env,
             )
             if fetch_result.returncode == 0:
                 fetched = True
@@ -598,7 +618,10 @@ def _read_remote_manifest_version(dest_dir: Path) -> str:
 
         show_result = subprocess.run(
             ["git", "-C", str(dest_dir), "show", "FETCH_HEAD:manifest.json"],
-            capture_output=True, text=True, timeout=30, env=env,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
         )
         if show_result.returncode != 0:
             return ""
@@ -752,9 +775,7 @@ def get_external_plugins_dir(project_root: Path | None = None) -> Path:
     return ext_dir
 
 
-def _safe_external_dest(
-    external_dir: Path, plugin_id: str
-) -> tuple[Path | None, str]:
+def _safe_external_dest(external_dir: Path, plugin_id: str) -> tuple[Path | None, str]:
     """Compute a safe destination path inside `external_dir` for a plugin.
 
     The plugin id flows through three independent CodeQL-recognized
@@ -838,30 +859,56 @@ def _install_and_verify(
     out is a worse outcome than leaving it broken and loudly reported. The
     failure surfaces through the loader's error list instead.
     """
-    plugin_dir = external_dir / plugin_id
-    was_installed = plugin_dir.exists()
+    # ── Validate plugin_id ────────────────────────────────────────────────────
+    if not PLUGIN_ID_RE.fullmatch(plugin_id):
+        return False, f"Invalid plugin id {plugin_id!r}"
+    # Rebuild from the literal allowed-character set so the value is sourced
+    # from a constant, not from the user-provided parameter.
+    _safe_id = "".join(c for c in plugin_id if c in _PLUGIN_ID_ALLOWED)
+    if _safe_id != plugin_id:
+        return False, f"Invalid plugin id {plugin_id!r}"
+
+    # ── Inline canonical CodeQL py/path-injection barrier ─────────────────────
+    # Same pattern as clone_or_update_repo: realpath + containment check, with
+    # the check and every filesystem sink in this one scope so the taint
+    # tracker treats ``_candidate`` as sanitised.  This matters more here than
+    # most places -- the rejection path below *deletes* the directory.
+    #
+    # The containment check duplicates the identical one in
+    # clone_or_update_repo, deliberately.  It cannot be reached independently
+    # (that function refuses the same paths first, with the same message), so
+    # removing it changes no test.  It stays because CodeQL only treats the
+    # rmtree below as sanitised when the barrier is in the *same* function,
+    # and because a delete deserves the second layer regardless.
+    _ext_root = os.path.realpath(str(external_dir))
+    _ext_root_prefix = _ext_root + os.sep
+    _candidate = os.path.realpath(os.path.join(_ext_root, _safe_id))
+    if not _candidate.startswith(_ext_root_prefix):
+        return False, "Plugin path is outside the external plugins directory"
+    if _candidate == _ext_root:
+        return False, "Refusing to install plugin at root directory"
+
+    was_installed = os.path.isdir(_candidate)
 
     ok, err = clone_or_update_repo(repo_url, plugin_id, branch, external_dir=external_dir)
     if not ok:
         return ok, err
 
-    verified, reason = verify_installed_plugin(plugin_id, plugin_dir)
+    verified, reason = verify_installed_plugin(_safe_id, Path(_candidate))
     if verified:
         return True, ""
 
     if was_installed:
         logger.error(
             "Plugin %s failed validation after update but was left installed: %s",
-            plugin_id,
+            _safe_id,
             reason,
         )
         return True, ""
 
-    logger.error("Rejecting install of %s: %s", plugin_id, reason)
-    shutil.rmtree(plugin_dir, ignore_errors=True)
-    return False, (
-        f"This plugin cannot run on FiestaBoard as published and was not installed. {reason}"
-    )
+    logger.error("Rejecting install of %s: %s", _safe_id, reason)
+    shutil.rmtree(_candidate, ignore_errors=True)
+    return False, (f"This plugin cannot run on FiestaBoard as published and was not installed. {reason}")
 
 
 def install_registry_plugin(

--- a/src/plugins/sources.py
+++ b/src/plugins/sources.py
@@ -801,6 +801,69 @@ def _safe_external_dest(
     return Path(candidate_real), ""
 
 
+def verify_installed_plugin(plugin_id: str, plugin_dir: Path) -> tuple[bool, str]:
+    """Check that a freshly-cloned plugin can actually work on this box.
+
+    Returns ``(True, "")`` when usable, ``(False, reason)`` otherwise.  The
+    reason is written for the person installing the plugin, not for a log.
+    """
+    # Imported here: manifest/install_check pull in the plugin package, and
+    # sources is imported during its initialisation.
+    from .install_check import validate_install
+    from .manifest import load_manifest
+
+    manifest, manifest_errors = load_manifest(plugin_dir / "manifest.json")
+    if manifest is None:
+        detail = "; ".join(manifest_errors) or "manifest.json could not be read"
+        return False, f"{plugin_id}: {detail}"
+
+    result = validate_install(plugin_id, plugin_dir, manifest)
+    for warning in result.warnings:
+        logger.warning("Plugin %s: %s", plugin_id, warning)
+    if result.ok:
+        return True, ""
+    return False, f"{plugin_id}: " + "; ".join(result.errors)
+
+
+def _install_and_verify(
+    repo_url: str,
+    plugin_id: str,
+    branch: str,
+    external_dir: Path,
+) -> tuple[bool, str]:
+    """Clone/update a plugin, then refuse a *fresh* install that cannot work.
+
+    An update that fails validation is left in place and only logged: the
+    plugin was already installed and may be driving a board, so tearing it
+    out is a worse outcome than leaving it broken and loudly reported. The
+    failure surfaces through the loader's error list instead.
+    """
+    plugin_dir = external_dir / plugin_id
+    was_installed = plugin_dir.exists()
+
+    ok, err = clone_or_update_repo(repo_url, plugin_id, branch, external_dir=external_dir)
+    if not ok:
+        return ok, err
+
+    verified, reason = verify_installed_plugin(plugin_id, plugin_dir)
+    if verified:
+        return True, ""
+
+    if was_installed:
+        logger.error(
+            "Plugin %s failed validation after update but was left installed: %s",
+            plugin_id,
+            reason,
+        )
+        return True, ""
+
+    logger.error("Rejecting install of %s: %s", plugin_id, reason)
+    shutil.rmtree(plugin_dir, ignore_errors=True)
+    return False, (
+        f"This plugin cannot run on FiestaBoard as published and was not installed. {reason}"
+    )
+
+
 def install_registry_plugin(
     entry: RegistryEntry,
     external_dir: Path | None = None,
@@ -823,7 +886,7 @@ def install_registry_plugin(
     if external_dir is None:
         external_dir = get_external_plugins_dir()
 
-    return clone_or_update_repo(entry.repository, entry.plugin_id, entry.branch, external_dir=external_dir)
+    return _install_and_verify(entry.repository, entry.plugin_id, entry.branch, external_dir)
 
 
 def install_git_plugin(
@@ -867,4 +930,4 @@ def install_git_plugin(
     if not ok:
         return False, err
 
-    return clone_or_update_repo(repo_url, plugin_id, branch, external_dir=external_dir)
+    return _install_and_verify(repo_url, plugin_id, branch, external_dir)

--- a/tests/test_plugin_health_sweep.py
+++ b/tests/test_plugin_health_sweep.py
@@ -69,136 +69,6 @@ def make_plugin(tmp_path: Path, plugin_id: str, source: str, files: dict | None 
     return plugin_dir
 
 
-class TestDataFileCheck:
-    def test_flags_data_file_that_does_not_ship(self, tmp_path):
-        plugin_dir = make_plugin(tmp_path, "brokenplug", HEALTHY_SOURCE)
-        findings = sweep_mod.check_data_files("brokenplug", plugin_dir)
-        assert len(findings) == 1
-        assert findings[0].check == "data_files"
-        assert "data.json" in findings[0].detail
-
-    def test_flags_a_missing_file_reached_through_a_variable(self, tmp_path):
-        """Exactly how star_trek_quotes spells it, and how most plugins do."""
-        source = (
-            'from pathlib import Path\n\nplugin_dir = Path(__file__).parent\nquotes_file = plugin_dir / "quotes.json"\n'
-        )
-        plugin_dir = make_plugin(tmp_path, "varplug", source)
-        findings = sweep_mod.check_data_files("varplug", plugin_dir)
-        assert len(findings) == 1
-        assert "quotes.json" in findings[0].detail
-
-    def test_passes_when_the_data_file_ships(self, tmp_path):
-        plugin_dir = make_plugin(tmp_path, "goodplug", HEALTHY_SOURCE, {"data.json": "{}"})
-        assert sweep_mod.check_data_files("goodplug", plugin_dir) == []
-
-    def test_ignores_manifest_json(self, tmp_path):
-        source = 'from pathlib import Path\np = Path(__file__).parent / "manifest.json"\n'
-        plugin_dir = make_plugin(tmp_path, "manifestonly", source)
-        assert sweep_mod.check_data_files("manifestonly", plugin_dir) == []
-
-    def test_ignores_plugins_without_file_references(self, tmp_path):
-        source = "import requests\n\n\nclass Plugin:\n    pass\n"
-        plugin_dir = make_plugin(tmp_path, "netplug", source)
-        assert sweep_mod.check_data_files("netplug", plugin_dir) == []
-
-    def test_does_not_scan_test_files(self, tmp_path):
-        plugin_dir = make_plugin(tmp_path, "withtests", HEALTHY_SOURCE, {"data.json": "{}"})
-        tests_dir = plugin_dir / "tests"
-        tests_dir.mkdir()
-        (tests_dir / "test_x.py").write_text(
-            'from pathlib import Path\nfixture = Path(__file__).parent / "fixture.json"\n'
-        )
-        assert sweep_mod.check_data_files("withtests", plugin_dir) == []
-
-
-class TestSelfContainedCheck:
-    def test_flags_path_escaping_the_plugin_directory(self, tmp_path):
-        """The exact Star Trek Quotes regression."""
-        plugin_dir = make_plugin(tmp_path, "escaper", ESCAPING_SOURCE)
-        findings = sweep_mod.check_self_contained("escaper", plugin_dir)
-        assert len(findings) == 1
-        assert findings[0].check == "self_contained"
-        assert "escaping the plugin directory" in findings[0].detail
-
-    def test_escape_is_flagged_even_when_the_file_happens_to_exist(self, tmp_path):
-        """A path that resolves on this box still breaks on a real install."""
-        plugin_dir = make_plugin(tmp_path, "luckyescaper", ESCAPING_SOURCE)
-        stray = tmp_path.parent / "src" / "utils"
-        stray.mkdir(parents=True, exist_ok=True)
-        (stray / "quotes.json").write_text("{}")
-        findings = sweep_mod.check_self_contained("luckyescaper", plugin_dir)
-        assert len(findings) == 1
-
-    def test_allows_paths_inside_the_plugin_directory(self, tmp_path):
-        plugin_dir = make_plugin(tmp_path, "selfcontained", HEALTHY_SOURCE, {"data.json": "{}"})
-        assert sweep_mod.check_self_contained("selfcontained", plugin_dir) == []
-
-    def test_allows_a_nested_module_reaching_its_own_package_root(self, tmp_path):
-        """plugins/<id>/lib/loader.py reading ../data.json is fine."""
-        plugin_dir = make_plugin(tmp_path, "nested", "class Plugin:\n    pass\n", {"data.json": "{}"})
-        lib = plugin_dir / "lib"
-        lib.mkdir()
-        (lib / "loader.py").write_text('from pathlib import Path\nDATA = Path(__file__).parent.parent / "data.json"\n')
-        assert sweep_mod.check_self_contained("nested", plugin_dir) == []
-
-
-class TestDependencyCheck:
-    def test_flags_a_dependency_that_is_not_installed(self, tmp_path):
-        plugin_dir = make_plugin(
-            tmp_path,
-            "needsdep",
-            HEALTHY_SOURCE,
-            {"data.json": "{}", "requirements.txt": "definitely-not-installed>=1.0\n"},
-        )
-        findings = sweep_mod.check_dependencies("needsdep", plugin_dir)
-        assert len(findings) == 1
-        assert findings[0].check == "dependencies"
-        assert "definitely-not-installed" in findings[0].detail
-
-    def test_passes_for_a_dependency_the_platform_ships(self, tmp_path):
-        plugin_dir = make_plugin(
-            tmp_path,
-            "usesrequests",
-            HEALTHY_SOURCE,
-            {"data.json": "{}", "requirements.txt": "requests>=2.0\n"},
-        )
-        assert sweep_mod.check_dependencies("usesrequests", plugin_dir) == []
-
-    def test_ignores_comments_and_blank_lines(self, tmp_path):
-        plugin_dir = make_plugin(
-            tmp_path,
-            "commented",
-            HEALTHY_SOURCE,
-            {
-                "data.json": "{}",
-                "requirements.txt": "# a comment\n\n  \nrequests>=2.0  # inline\n",
-            },
-        )
-        assert sweep_mod.check_dependencies("commented", plugin_dir) == []
-
-    def test_maps_distribution_names_to_import_names(self, tmp_path):
-        """speedtest-cli imports as 'speedtest', not 'speedtest_cli'."""
-        assert sweep_mod.IMPORT_NAME_OVERRIDES["speedtest-cli"] == "speedtest"
-        plugin_dir = make_plugin(
-            tmp_path,
-            "speedy",
-            HEALTHY_SOURCE,
-            {"data.json": "{}", "requirements.txt": "speedtest-cli\n"},
-        )
-        findings = sweep_mod.check_dependencies("speedy", plugin_dir)
-        assert len(findings) == 1
-        assert "'speedtest'" in findings[0].detail
-
-    def test_skips_dev_requirements(self, tmp_path):
-        plugin_dir = make_plugin(
-            tmp_path,
-            "devonly",
-            HEALTHY_SOURCE,
-            {"data.json": "{}", "requirements-dev.txt": "definitely-not-installed\n"},
-        )
-        assert sweep_mod.check_dependencies("devonly", plugin_dir) == []
-
-
 class TestFetchContract:
     class _Result:
         def __init__(self, available, error=None, data=None):
@@ -257,51 +127,6 @@ class TestFetchContract:
         assert config["refresh_seconds"] == 300
 
 
-class TestReferencedDataPaths:
-    def test_counts_parent_hops(self):
-        refs = sweep_mod.referenced_data_paths('p = Path(__file__).parent.parent.parent / "src" / "x.json"')
-        assert refs == [(3, ["src", "x.json"])]
-
-    def test_handles_os_path_join(self):
-        refs = sweep_mod.referenced_data_paths('p = os.path.join(os.path.dirname(__file__), "data.json")')
-        assert refs == [(1, ["data.json"])]
-
-    def test_ignores_non_data_suffixes(self):
-        refs = sweep_mod.referenced_data_paths('p = Path(__file__).parent / "helper.py"')
-        assert refs == []
-
-    def test_ignores_paths_not_anchored_to_file(self):
-        refs = sweep_mod.referenced_data_paths('p = Path("/etc/config.json")')
-        assert refs == []
-
-    def test_follows_an_anchor_held_in_a_variable(self):
-        """The idiomatic two-line spelling must not slip past the check."""
-        refs = sweep_mod.referenced_data_paths(
-            'plugin_dir = Path(__file__).parent\nquotes = plugin_dir / "quotes.json"\n'
-        )
-        assert refs == [(1, ["quotes.json"])]
-
-    def test_follows_a_variable_anchor_with_parent_hops(self):
-        refs = sweep_mod.referenced_data_paths(
-            'root = Path(__file__).parent.parent.parent\ndata = root / "src" / "utils" / "x.json"\n'
-        )
-        assert refs == [(3, ["src", "utils", "x.json"])]
-
-    def test_follows_a_variable_anchor_through_os_path_join(self):
-        refs = sweep_mod.referenced_data_paths(
-            'here = os.path.dirname(__file__)\ndata = os.path.join(here, "data.json")\n'
-        )
-        assert refs == [(1, ["data.json"])]
-
-    def test_reports_a_file_referenced_twice_only_once(self):
-        refs = sweep_mod.referenced_data_paths(
-            "plugin_dir = Path(__file__).parent\n"
-            'a = plugin_dir / "data.json"\n'
-            'b = Path(__file__).parent / "data.json"\n'
-        )
-        assert refs == [(1, ["data.json"])]
-
-
 class TestFindingSerialisation:
     def test_to_dict_round_trips(self):
         finding = sweep_mod.Finding("plug", "data_files", "missing x.json")
@@ -350,17 +175,28 @@ class TestSetOutput:
         sweep_mod.set_output("has_findings", "true")  # must not raise
 
 
-class TestAgainstRealBundledPlugins:
-    """The sweep must find nothing wrong with the plugins we actually ship."""
+class TestFatalVsAdvisory:
+    """Advisory findings must not turn a scheduled run red."""
 
-    @pytest.mark.parametrize("plugin_id", ["date_time", "countdown", "random", "typewriter"])
-    def test_bundled_plugin_is_clean(self, plugin_id):
-        plugin_dir = PROJECT_ROOT / "plugins" / plugin_id
-        if not plugin_dir.exists():
-            pytest.skip(f"{plugin_id} not present")
-        findings = (
-            sweep_mod.check_data_files(plugin_id, plugin_dir)
-            + sweep_mod.check_self_contained(plugin_id, plugin_dir)
-            + sweep_mod.check_dependencies(plugin_id, plugin_dir)
-        )
-        assert findings == [], [f.detail for f in findings]
+    def test_fatal_defaults_true(self):
+        assert sweep_mod.Finding("p", "install", "x").fatal is True
+
+    def test_advisory_finding_can_be_marked_non_fatal(self):
+        assert sweep_mod.Finding("p", "undeclared", "x", fatal=False).fatal is False
+
+    def test_to_dict_carries_the_flag(self):
+        assert sweep_mod.Finding("p", "undeclared", "x", fatal=False).to_dict()["fatal"] is False
+
+
+class TestAgainstRealBundledPlugins:
+    """The sweep must find nothing blocking in the plugins we ship."""
+
+    def test_bundled_plugins_sweep_clean(self):
+
+        bundled = PROJECT_ROOT / "plugins"
+        if not bundled.exists():
+            pytest.skip("bundled plugins not present")
+        findings, report = sweep_mod.sweep(bundled, None, do_fetch=False)
+        blocking = [f for f in findings if f.fatal]
+        assert blocking == [], [f"{f.plugin_id}: {f.detail}" for f in blocking]
+        assert report, "sweep discovered no plugins at all"

--- a/tests/test_plugin_install_check.py
+++ b/tests/test_plugin_install_check.py
@@ -1,0 +1,376 @@
+"""Tests for install-time plugin validation.
+
+The anchor case is the Star Trek Quotes regression: a plugin whose data file
+was never shipped, which passed its own CI because CI created the file, and
+served "???" to every user. `test_catches_the_star_trek_regression` encodes
+that exact shape.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from src.plugins.install_check import (
+    InstallCheckResult,
+    check_declaration_is_well_formed,
+    check_declared_data_files,
+    check_dependencies,
+    check_required_files,
+    detect_data_file_problems,
+    validate_install,
+)
+from src.plugins.manifest import PluginManifest, parse_data_files
+
+
+def make_plugin_dir(tmp_path: Path, plugin_id: str, manifest_extra: dict | None = None, files: dict | None = None):
+    """Create a plugin directory and return (dir, parsed manifest)."""
+    plugin_dir = tmp_path / plugin_id
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "__init__.py").write_text("class Plugin:\n    pass\n")
+    manifest_data = {
+        "id": plugin_id,
+        "name": plugin_id,
+        "version": "1.0.0",
+        **(manifest_extra or {}),
+    }
+    (plugin_dir / "manifest.json").write_text(json.dumps(manifest_data))
+    for name, content in (files or {}).items():
+        target = plugin_dir / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content)
+    return plugin_dir, PluginManifest.from_dict(manifest_data)
+
+
+class TestParseDataFiles:
+    def test_keeps_plain_relative_paths(self):
+        assert parse_data_files(["quotes.json", "data/extra.csv"]) == [
+            "quotes.json",
+            "data/extra.csv",
+        ]
+
+    def test_drops_absolute_paths(self):
+        assert parse_data_files(["/etc/passwd"]) == []
+
+    def test_drops_parent_traversal(self):
+        assert parse_data_files(["../../src/utils/quotes.json"]) == []
+
+    def test_drops_windows_style_escapes(self):
+        assert parse_data_files(["..\\..\\secrets.json", "C:/data.json"]) == []
+
+    def test_normalises_leading_dot_slash(self):
+        assert parse_data_files(["./quotes.json"]) == ["quotes.json"]
+
+    def test_dedupes(self):
+        assert parse_data_files(["quotes.json", "./quotes.json"]) == ["quotes.json"]
+
+    def test_ignores_non_list_and_non_string(self):
+        assert parse_data_files("quotes.json") == []
+        assert parse_data_files(None) == []
+        assert parse_data_files([1, None, {}]) == []
+
+    def test_manifest_exposes_parsed_declaration(self):
+        m = PluginManifest.from_dict({"id": "p", "name": "p", "version": "1.0.0", "data_files": ["quotes.json"]})
+        assert m.data_files == ["quotes.json"]
+
+    def test_manifest_without_declaration_defaults_empty(self):
+        m = PluginManifest.from_dict({"id": "p", "name": "p", "version": "1.0.0"})
+        assert m.data_files == []
+
+
+class TestDeclaredDataFiles:
+    def test_missing_declared_file_is_an_error(self, tmp_path):
+        plugin_dir, _ = make_plugin_dir(tmp_path, "p")
+        errors = check_declared_data_files(plugin_dir, ["quotes.json"])
+        assert len(errors) == 1
+        assert "quotes.json" in errors[0]
+
+    def test_present_declared_file_is_clean(self, tmp_path):
+        plugin_dir, _ = make_plugin_dir(tmp_path, "p", files={"quotes.json": "{}"})
+        assert check_declared_data_files(plugin_dir, ["quotes.json"]) == []
+
+    def test_nested_declared_file_is_supported(self, tmp_path):
+        plugin_dir, _ = make_plugin_dir(tmp_path, "p", files={"data/quotes.json": "{}"})
+        assert check_declared_data_files(plugin_dir, ["data/quotes.json"]) == []
+
+    def test_directory_where_a_file_was_declared_is_an_error(self, tmp_path):
+        plugin_dir, _ = make_plugin_dir(tmp_path, "p")
+        (plugin_dir / "quotes.json").mkdir()
+        errors = check_declared_data_files(plugin_dir, ["quotes.json"])
+        assert len(errors) == 1
+        assert "not a file" in errors[0]
+
+
+class TestDeclarationWellFormed:
+    def test_escaping_entry_is_reported(self):
+        raw = {"data_files": ["../../src/utils/quotes.json"]}
+        errors = check_declaration_is_well_formed(raw, parse_data_files(raw["data_files"]))
+        assert len(errors) == 1
+        assert "inside the plugin directory" in errors[0]
+
+    def test_valid_entries_are_silent(self):
+        raw = {"data_files": ["quotes.json"]}
+        assert check_declaration_is_well_formed(raw, parse_data_files(raw["data_files"])) == []
+
+    def test_non_string_entry_is_reported(self):
+        raw = {"data_files": [123]}
+        errors = check_declaration_is_well_formed(raw, parse_data_files(raw["data_files"]))
+        assert len(errors) == 1
+        assert "not a string" in errors[0]
+
+    def test_absent_declaration_is_silent(self):
+        assert check_declaration_is_well_formed({}, []) == []
+
+
+class TestDependencies:
+    def test_uninstallable_dependency_is_an_error(self, tmp_path):
+        plugin_dir, _ = make_plugin_dir(tmp_path, "p", files={"requirements.txt": "definitely-not-a-real-package\n"})
+        errors = check_dependencies(plugin_dir)
+        assert len(errors) == 1
+        assert "definitely-not-a-real-package" in errors[0]
+
+    def test_platform_provided_dependency_is_clean(self, tmp_path):
+        plugin_dir, _ = make_plugin_dir(tmp_path, "p", files={"requirements.txt": "requests>=2.0\n"})
+        assert check_dependencies(plugin_dir) == []
+
+    def test_dev_requirements_are_ignored(self, tmp_path):
+        plugin_dir, _ = make_plugin_dir(
+            tmp_path, "p", files={"requirements-dev.txt": "definitely-not-a-real-package\n"}
+        )
+        assert check_dependencies(plugin_dir) == []
+
+    def test_comments_and_blanks_are_ignored(self, tmp_path):
+        plugin_dir, _ = make_plugin_dir(
+            tmp_path,
+            "p",
+            files={"requirements.txt": "# comment\n\n   \nrequests  # inline\n"},
+        )
+        assert check_dependencies(plugin_dir) == []
+
+    def test_distribution_name_is_mapped_to_import_name(self, tmp_path):
+        """speedtest-cli imports as 'speedtest'; a naive guess would say speedtest_cli."""
+        plugin_dir, _ = make_plugin_dir(tmp_path, "p", files={"requirements.txt": "speedtest-cli\n"})
+        errors = check_dependencies(plugin_dir)
+        assert len(errors) == 1
+        assert "speedtest-cli" in errors[0]
+
+    def test_no_requirements_file_is_clean(self, tmp_path):
+        plugin_dir, _ = make_plugin_dir(tmp_path, "p")
+        assert check_dependencies(plugin_dir) == []
+
+
+class TestRequiredFiles:
+    def test_missing_init_is_an_error(self, tmp_path):
+        plugin_dir = tmp_path / "p"
+        plugin_dir.mkdir()
+        (plugin_dir / "manifest.json").write_text("{}")
+        errors = check_required_files(plugin_dir)
+        assert any("__init__.py" in e for e in errors)
+
+    def test_complete_plugin_is_clean(self, tmp_path):
+        plugin_dir, _ = make_plugin_dir(tmp_path, "p")
+        assert check_required_files(plugin_dir) == []
+
+
+class TestValidateInstall:
+    def test_catches_the_star_trek_regression(self, tmp_path):
+        """A plugin declaring a data file it does not ship must be rejected."""
+        plugin_dir, manifest = make_plugin_dir(
+            tmp_path, "star_trek_quotes", manifest_extra={"data_files": ["quotes.json"]}
+        )
+        result = validate_install("star_trek_quotes", plugin_dir, manifest)
+        assert result.ok is False
+        assert any("quotes.json" in e for e in result.errors)
+
+    def test_same_plugin_passes_once_the_file_ships(self, tmp_path):
+        plugin_dir, manifest = make_plugin_dir(
+            tmp_path,
+            "star_trek_quotes",
+            manifest_extra={"data_files": ["quotes.json"]},
+            files={"quotes.json": '{"tng": []}'},
+        )
+        result = validate_install("star_trek_quotes", plugin_dir, manifest)
+        assert result.ok is True, result.errors
+        assert result.errors == []
+
+    def test_plugin_reading_no_files_is_clean_and_silent(self, tmp_path):
+        """Most plugins read nothing off disk; they must not be nagged."""
+        plugin_dir, manifest = make_plugin_dir(tmp_path, "weather")
+        result = validate_install("weather", plugin_dir, manifest)
+        assert result.ok is True
+        assert result.warnings == []
+
+    def test_undeclared_but_present_read_warns_without_blocking(self, tmp_path):
+        """Reads a file, declares nothing, but the file does ship."""
+        plugin_dir, manifest = make_plugin_dir(tmp_path, "legacy", files={"quotes.json": "{}"})
+        (plugin_dir / "__init__.py").write_text('from pathlib import Path\nD = Path(__file__).parent / "quotes.json"\n')
+        result = validate_install("legacy", plugin_dir, manifest)
+        assert result.ok is True, "a present file must not block an install"
+        assert any("does not declare it" in w for w in result.warnings)
+
+    def test_undeclared_and_missing_read_is_blocking(self, tmp_path):
+        """The Star Trek case, which declared nothing: must still be caught."""
+        plugin_dir, manifest = make_plugin_dir(tmp_path, "star_trek_quotes")
+        (plugin_dir / "__init__.py").write_text(
+            'from pathlib import Path\nplugin_dir = Path(__file__).parent\nquotes = plugin_dir / "quotes.json"\n'
+        )
+        result = validate_install("star_trek_quotes", plugin_dir, manifest)
+        assert result.ok is False, "an undeclared missing file is still broken"
+        assert any("quotes.json" in e for e in result.errors)
+
+    def test_declared_read_produces_no_warning(self, tmp_path):
+        plugin_dir, manifest = make_plugin_dir(
+            tmp_path,
+            "tidy",
+            manifest_extra={"data_files": ["quotes.json"]},
+            files={"quotes.json": "{}"},
+        )
+        (plugin_dir / "__init__.py").write_text('from pathlib import Path\nD = Path(__file__).parent / "quotes.json"\n')
+        result = validate_install("tidy", plugin_dir, manifest)
+        assert result.ok is True
+        assert result.warnings == []
+
+    def test_transition_plugin_is_not_nagged_about_data_files(self, tmp_path):
+        plugin_dir, manifest = make_plugin_dir(tmp_path, "typewriter", manifest_extra={"plugin_type": "transition"})
+        result = validate_install("typewriter", plugin_dir, manifest)
+        assert result.ok is True
+        assert result.warnings == []
+
+    def test_missing_directory_is_an_error(self, tmp_path):
+        result = validate_install("ghost", tmp_path / "nope", None)
+        assert result.ok is False
+        assert "does not exist" in result.errors[0]
+
+    def test_unparseable_manifest_is_an_error(self, tmp_path):
+        plugin_dir, _ = make_plugin_dir(tmp_path, "p")
+        result = validate_install("p", plugin_dir, None)
+        assert result.ok is False
+        assert any("could not be parsed" in e for e in result.errors)
+
+    def test_errors_accumulate_rather_than_short_circuit(self, tmp_path):
+        """One run should tell the author everything that is wrong."""
+        plugin_dir, manifest = make_plugin_dir(
+            tmp_path,
+            "messy",
+            manifest_extra={"data_files": ["a.json", "b.json"]},
+            files={"requirements.txt": "definitely-not-a-real-package\n"},
+        )
+        result = validate_install("messy", plugin_dir, manifest)
+        assert result.ok is False
+        assert len(result.errors) == 3  # two missing files + one missing dep
+
+    def test_result_serialises(self, tmp_path):
+        plugin_dir, manifest = make_plugin_dir(tmp_path, "p", files={"quotes.json": "{}"})
+        result = validate_install("p", plugin_dir, manifest)
+        assert set(result.to_dict()) == {"errors", "warnings"}
+
+
+class TestDataFileProblemSeverity:
+    """Severity tracks whether the plugin can work, not whether it declared.
+
+    This is the rule the first refactor got wrong: moving detection under the
+    declaration downgraded the Star Trek case (which declared nothing) from
+    broken to advisory.
+    """
+
+    def _plugin_with_source(self, tmp_path, source, files=None):
+        plugin_dir, _ = make_plugin_dir(tmp_path, "p", files=files)
+        (plugin_dir / "__init__.py").write_text(source)
+        return plugin_dir
+
+    READS_DATA = 'from pathlib import Path\nD = Path(__file__).parent / "data.json"\n'
+    READS_VIA_VAR = (
+        'from pathlib import Path\nplugin_dir = Path(__file__).parent\nquotes = plugin_dir / "quotes.json"\n'
+    )
+    ESCAPES = 'from pathlib import Path\nD = Path(__file__).parent.parent.parent / "src" / "utils" / "q.json"\n'
+
+    def test_missing_and_undeclared_is_an_error(self, tmp_path):
+        """The exact Star Trek shape: reads it, declares nothing, ships nothing."""
+        d = self._plugin_with_source(tmp_path, self.READS_VIA_VAR)
+        errors, warnings = detect_data_file_problems(d, [])
+        assert len(errors) == 1, warnings
+        assert "quotes.json" in errors[0]
+        assert warnings == []
+
+    def test_missing_and_declared_is_an_error(self, tmp_path):
+        d = self._plugin_with_source(tmp_path, self.READS_DATA)
+        errors, _ = detect_data_file_problems(d, ["data.json"])
+        assert len(errors) == 1
+
+    def test_present_but_undeclared_is_only_a_warning(self, tmp_path):
+        d = self._plugin_with_source(tmp_path, self.READS_DATA, files={"data.json": "{}"})
+        errors, warnings = detect_data_file_problems(d, [])
+        assert errors == []
+        assert len(warnings) == 1
+        assert "does not declare it" in warnings[0]
+
+    def test_present_and_declared_is_silent(self, tmp_path):
+        d = self._plugin_with_source(tmp_path, self.READS_DATA, files={"data.json": "{}"})
+        assert detect_data_file_problems(d, ["data.json"]) == ([], [])
+
+    def test_escaping_path_is_an_error(self, tmp_path):
+        d = self._plugin_with_source(tmp_path, self.ESCAPES)
+        errors, _ = detect_data_file_problems(d, [])
+        assert len(errors) == 1
+        assert "outside the plugin directory" in errors[0]
+
+    def test_escape_cannot_be_silenced_by_declaring_it(self, tmp_path):
+        d = self._plugin_with_source(tmp_path, self.ESCAPES)
+        errors, warnings = detect_data_file_problems(d, ["src/utils/q.json"])
+        assert len(errors) == 1
+        assert warnings == []
+
+    def test_manifest_json_is_never_reported(self, tmp_path):
+        d = self._plugin_with_source(
+            tmp_path, 'from pathlib import Path\nM = Path(__file__).parent / "manifest.json"\n'
+        )
+        assert detect_data_file_problems(d, []) == ([], [])
+
+    def test_nested_module_reaching_its_package_root_is_allowed(self, tmp_path):
+        plugin_dir, _ = make_plugin_dir(tmp_path, "p", files={"data.json": "{}"})
+        lib = plugin_dir / "lib"
+        lib.mkdir()
+        (lib / "loader.py").write_text('from pathlib import Path\nD = Path(__file__).parent.parent / "data.json"\n')
+        assert detect_data_file_problems(plugin_dir, ["data.json"]) == ([], [])
+
+    def test_test_files_are_not_scanned(self, tmp_path):
+        plugin_dir, _ = make_plugin_dir(tmp_path, "p")
+        tests = plugin_dir / "tests"
+        tests.mkdir()
+        (tests / "test_x.py").write_text('from pathlib import Path\nF = Path(__file__).parent / "fixture.json"\n')
+        assert detect_data_file_problems(plugin_dir, []) == ([], [])
+
+    def test_same_file_reported_once(self, tmp_path):
+        d = self._plugin_with_source(
+            tmp_path,
+            "from pathlib import Path\n"
+            "plugin_dir = Path(__file__).parent\n"
+            'a = plugin_dir / "data.json"\n'
+            'b = Path(__file__).parent / "data.json"\n',
+        )
+        errors, warnings = detect_data_file_problems(d, [])
+        assert len(errors) + len(warnings) == 1
+
+
+class TestAgainstRealBundledPlugins:
+    """Shipped plugins must pass their own gate."""
+
+    @pytest.mark.parametrize("plugin_id", ["date_time", "countdown", "random", "typewriter"])
+    def test_bundled_plugin_installs_clean(self, plugin_id):
+        from src.plugins.manifest import load_manifest
+
+        plugin_dir = Path(__file__).resolve().parent.parent / "plugins" / plugin_id
+        if not plugin_dir.exists():
+            pytest.skip(f"{plugin_id} not present")
+        manifest, manifest_errors = load_manifest(plugin_dir / "manifest.json")
+        assert manifest is not None, manifest_errors
+        result = validate_install(plugin_id, plugin_dir, manifest)
+        assert result.ok is True, result.errors
+
+
+class TestInstallCheckResult:
+    def test_ok_is_false_only_for_errors(self):
+        r = InstallCheckResult("p", warnings=["just a note"])
+        assert r.ok is True
+        r.errors.append("real problem")
+        assert r.ok is False

--- a/tests/test_plugin_install_check.py
+++ b/tests/test_plugin_install_check.py
@@ -154,6 +154,21 @@ class TestDependencies:
         assert len(errors) == 1
         assert "speedtest-cli" in errors[0]
 
+    @pytest.mark.parametrize("dist", ["finnhub-python", "paho-mqtt"])
+    def test_shipped_dist_with_a_different_import_name_is_clean(self, tmp_path, dist):
+        """A package FiestaBoard ships must never be reported as missing.
+
+        Both of these are in the platform's own requirements.txt and both
+        import under a name that is not their distribution name
+        (``finnhub``, ``paho.mqtt``). Resolving them by guessing the import
+        name reports them absent, which at install time is not a warning --
+        it refuses the install of a plugin whose dependency is in fact
+        present. Neither appears in IMPORT_NAME_OVERRIDES, so the guess is
+        the only thing standing between them and a false rejection.
+        """
+        plugin_dir, _ = make_plugin_dir(tmp_path, "p", files={"requirements.txt": f"{dist}\n"})
+        assert check_dependencies(plugin_dir) == []
+
     def test_no_requirements_file_is_clean(self, tmp_path):
         plugin_dir, _ = make_plugin_dir(tmp_path, "p")
         assert check_dependencies(plugin_dir) == []

--- a/tests/test_plugin_install_gate.py
+++ b/tests/test_plugin_install_gate.py
@@ -104,6 +104,82 @@ class TestFreshInstallIsBlocked:
         assert err == "network down"
 
 
+class TestPathSafety:
+    """The rejection path deletes a directory, so the id must be sanitised.
+
+    CodeQL flagged these sinks as py/path-injection (2 high) on the first
+    version of this change; these encode the barrier that resolved it.
+    """
+
+    def test_traversal_in_the_plugin_id_is_refused(self, tmp_path):
+        external = tmp_path / "external"
+        external.mkdir()
+        victim = tmp_path / "victim"
+        victim.mkdir()
+        (victim / "keepme.txt").write_text("do not delete")
+
+        ok, err = sources._install_and_verify("https://x/y", "../victim", "", external)
+
+        assert ok is False
+        assert "Invalid plugin id" in err
+        assert (victim / "keepme.txt").exists(), "traversal must never reach a delete"
+
+    def test_absolute_path_in_the_plugin_id_is_refused(self, tmp_path):
+        external = tmp_path / "external"
+        external.mkdir()
+        ok, err = sources._install_and_verify("https://x/y", "/etc", "", external)
+        assert ok is False
+        assert "Invalid plugin id" in err
+
+    def test_id_with_separators_is_refused(self, tmp_path):
+        external = tmp_path / "external"
+        external.mkdir()
+        ok, err = sources._install_and_verify("https://x/y", "a/b", "", external)
+        assert ok is False
+        assert "Invalid plugin id" in err
+
+    def test_the_clone_is_never_attempted_for_a_bad_id(self, tmp_path):
+        """Reject before doing any work, not after."""
+        external = tmp_path / "external"
+        external.mkdir()
+        with patch.object(sources, "clone_or_update_repo") as mock_clone:
+            ok, _err = sources._install_and_verify("https://x/y", "../evil", "", external)
+        assert ok is False
+        mock_clone.assert_not_called()
+
+    def test_a_symlinked_plugin_dir_escaping_the_root_is_refused(self, tmp_path):
+        """Covers the realpath containment check, not the id allow-list.
+
+        A valid id can still resolve outside the plugins directory if the
+        directory it names is a symlink. Without the containment check the
+        rejection path would rmtree the symlink's *target*.
+        """
+        external = tmp_path / "external"
+        external.mkdir()
+        victim = tmp_path / "victim"
+        victim.mkdir()
+        (victim / "keepme.txt").write_text("do not delete")
+        (external / "evil_plugin").symlink_to(victim, target_is_directory=True)
+
+        ok, err = sources._install_and_verify("https://x/y", "evil_plugin", "", external)
+
+        assert ok is False
+        assert "outside the external plugins directory" in err
+        assert (victim / "keepme.txt").exists(), "must not delete a symlink target"
+
+    def test_a_normal_id_still_passes_the_barrier(self, tmp_path):
+        external = tmp_path / "external"
+        external.mkdir()
+
+        def fake_clone(repo_url, plugin_id, branch, external_dir):
+            write_plugin(external_dir / plugin_id, data_files=["d.json"], ships={"d.json": "{}"})
+            return True, ""
+
+        with patch.object(sources, "clone_or_update_repo", side_effect=fake_clone):
+            ok, err = sources._install_and_verify("https://x/y", "good_plugin", "", external)
+        assert ok is True, err
+
+
 class TestUpdateIsNotBlocked:
     def test_update_that_breaks_a_plugin_leaves_it_installed(self, tmp_path):
         """An installed plugin may be driving a board; do not tear it out."""

--- a/tests/test_plugin_install_gate.py
+++ b/tests/test_plugin_install_gate.py
@@ -1,0 +1,141 @@
+"""Tests for the install-time gate in src/plugins/sources.py.
+
+Policy under test:
+  * a FRESH install that cannot work is rejected and cleaned up
+  * an UPDATE that breaks an already-installed plugin is left in place and
+    reported, because removing a plugin that may be driving a board is worse
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from src.plugins import sources
+
+
+def write_plugin(plugin_dir: Path, *, data_files=None, ships=None, requirements=None):
+    """Materialise a plugin directory as a clone would leave it."""
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    (plugin_dir / "__init__.py").write_text("class Plugin:\n    pass\n")
+    manifest = {"id": plugin_dir.name, "name": plugin_dir.name, "version": "1.0.0"}
+    if data_files is not None:
+        manifest["data_files"] = data_files
+    (plugin_dir / "manifest.json").write_text(json.dumps(manifest))
+    for name, content in (ships or {}).items():
+        (plugin_dir / name).write_text(content)
+    if requirements:
+        (plugin_dir / "requirements.txt").write_text(requirements)
+
+
+class TestVerifyInstalledPlugin:
+    def test_rejects_a_plugin_missing_its_declared_data(self, tmp_path):
+        plugin_dir = tmp_path / "star_trek_quotes"
+        write_plugin(plugin_dir, data_files=["quotes.json"])
+        ok, reason = sources.verify_installed_plugin("star_trek_quotes", plugin_dir)
+        assert ok is False
+        assert "quotes.json" in reason
+
+    def test_accepts_the_same_plugin_once_it_ships_the_file(self, tmp_path):
+        plugin_dir = tmp_path / "star_trek_quotes"
+        write_plugin(plugin_dir, data_files=["quotes.json"], ships={"quotes.json": "{}"})
+        ok, reason = sources.verify_installed_plugin("star_trek_quotes", plugin_dir)
+        assert ok is True, reason
+
+    def test_rejects_a_plugin_needing_an_absent_package(self, tmp_path):
+        plugin_dir = tmp_path / "volcano"
+        write_plugin(plugin_dir, requirements="definitely-not-a-real-package\n")
+        ok, reason = sources.verify_installed_plugin("volcano", plugin_dir)
+        assert ok is False
+        assert "definitely-not-a-real-package" in reason
+
+    def test_rejects_an_unreadable_manifest(self, tmp_path):
+        plugin_dir = tmp_path / "broken"
+        plugin_dir.mkdir()
+        (plugin_dir / "__init__.py").write_text("")
+        (plugin_dir / "manifest.json").write_text("{ not json")
+        ok, _reason = sources.verify_installed_plugin("broken", plugin_dir)
+        assert ok is False
+
+    def test_a_warning_alone_does_not_reject(self, tmp_path):
+        """No data_files declaration warns, but must still install."""
+        plugin_dir = tmp_path / "weather"
+        write_plugin(plugin_dir)
+        ok, reason = sources.verify_installed_plugin("weather", plugin_dir)
+        assert ok is True, reason
+
+
+class TestFreshInstallIsBlocked:
+    def test_broken_fresh_install_is_rejected_and_removed(self, tmp_path):
+        external = tmp_path / "external"
+        external.mkdir()
+
+        def fake_clone(repo_url, plugin_id, branch, external_dir):
+            write_plugin(external_dir / plugin_id, data_files=["quotes.json"])
+            return True, ""
+
+        with patch.object(sources, "clone_or_update_repo", side_effect=fake_clone):
+            ok, err = sources._install_and_verify("https://x/y", "star_trek_quotes", "", external)
+
+        assert ok is False
+        assert "was not installed" in err
+        assert "quotes.json" in err
+        assert not (external / "star_trek_quotes").exists(), "broken clone must be cleaned up"
+
+    def test_healthy_fresh_install_succeeds_and_remains(self, tmp_path):
+        external = tmp_path / "external"
+        external.mkdir()
+
+        def fake_clone(repo_url, plugin_id, branch, external_dir):
+            write_plugin(external_dir / plugin_id, data_files=["quotes.json"], ships={"quotes.json": "{}"})
+            return True, ""
+
+        with patch.object(sources, "clone_or_update_repo", side_effect=fake_clone):
+            ok, err = sources._install_and_verify("https://x/y", "star_trek_quotes", "", external)
+
+        assert ok is True, err
+        assert (external / "star_trek_quotes" / "quotes.json").exists()
+
+    def test_a_clone_failure_is_returned_unchanged(self, tmp_path):
+        external = tmp_path / "external"
+        external.mkdir()
+        with patch.object(sources, "clone_or_update_repo", return_value=(False, "network down")):
+            ok, err = sources._install_and_verify("https://x/y", "p", "", external)
+        assert ok is False
+        assert err == "network down"
+
+
+class TestUpdateIsNotBlocked:
+    def test_update_that_breaks_a_plugin_leaves_it_installed(self, tmp_path):
+        """An installed plugin may be driving a board; do not tear it out."""
+        external = tmp_path / "external"
+        external.mkdir()
+        # Already installed and healthy.
+        write_plugin(external / "star_trek_quotes", data_files=["quotes.json"], ships={"quotes.json": "{}"})
+
+        def fake_clone_drops_the_file(repo_url, plugin_id, branch, external_dir):
+            (external_dir / plugin_id / "quotes.json").unlink()
+            return True, ""
+
+        with patch.object(sources, "clone_or_update_repo", side_effect=fake_clone_drops_the_file):
+            ok, err = sources._install_and_verify("https://x/y", "star_trek_quotes", "", external)
+
+        assert ok is True, "an update must not fail the caller"
+        assert err == ""
+        assert (external / "star_trek_quotes").exists(), "must not be removed"
+
+    def test_the_broken_update_is_logged_as_an_error(self, tmp_path, caplog):
+        external = tmp_path / "external"
+        external.mkdir()
+        write_plugin(external / "p", data_files=["d.json"], ships={"d.json": "{}"})
+
+        def fake_clone(repo_url, plugin_id, branch, external_dir):
+            (external_dir / plugin_id / "d.json").unlink()
+            return True, ""
+
+        with (
+            patch.object(sources, "clone_or_update_repo", side_effect=fake_clone),
+            caplog.at_level("ERROR"),
+        ):
+            sources._install_and_verify("https://x/y", "p", "", external)
+
+        assert any("left installed" in r.message or "left installed" in r.getMessage() for r in caplog.records)

--- a/tests/test_plugin_sources.py
+++ b/tests/test_plugin_sources.py
@@ -440,8 +440,26 @@ class TestCloneOrUpdateRepoErrorMessages:
 # ── install helpers ──────────────────────────────────────────────────────────
 
 
+def _fake_clone_producing_a_plugin(repo_url, plugin_id, branch, external_dir):
+    """Stand in for a real clone by leaving a usable plugin behind.
+
+    A clone that reports success but writes nothing is not a state git can
+    produce, and since install now verifies what actually landed
+    (sources._install_and_verify), returning (True, "") alone would have the
+    install correctly rejected.
+    """
+    plugin_dir = Path(external_dir) / plugin_id
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    (plugin_dir / "__init__.py").write_text("class Plugin:\n    pass\n")
+    (plugin_dir / "manifest.json").write_text(json.dumps({"id": plugin_id, "name": plugin_id, "version": "1.0.0"}))
+    return True, ""
+
+
 class TestInstallRegistryPlugin:
-    @mock.patch("src.plugins.sources.clone_or_update_repo", return_value=(True, ""))
+    @mock.patch(
+        "src.plugins.sources.clone_or_update_repo",
+        side_effect=_fake_clone_producing_a_plugin,
+    )
     def test_valid_install(self, mock_clone, tmp_path):
         entry = RegistryEntry(
             plugin_id="ext_weather",
@@ -452,6 +470,18 @@ class TestInstallRegistryPlugin:
         assert ok
         assert err == ""
         mock_clone.assert_called_once()
+
+    @mock.patch("src.plugins.sources.clone_or_update_repo", return_value=(True, ""))
+    def test_clone_that_produces_nothing_usable_is_rejected(self, mock_clone, tmp_path):
+        """A "successful" clone leaving no plugin behind must not install."""
+        entry = RegistryEntry(
+            plugin_id="ext_weather",
+            name="Weather",
+            repository="https://github.com/FiestaBoard/fiestaboard-plugin--ext-weather",
+        )
+        ok, err = install_registry_plugin(entry, external_dir=tmp_path)
+        assert ok is False
+        assert "was not installed" in err
 
     def test_rejects_bad_name(self, tmp_path):
         entry = RegistryEntry(
@@ -465,7 +495,10 @@ class TestInstallRegistryPlugin:
 
 
 class TestInstallGitPlugin:
-    @mock.patch("src.plugins.sources.clone_or_update_repo", return_value=(True, ""))
+    @mock.patch(
+        "src.plugins.sources.clone_or_update_repo",
+        side_effect=_fake_clone_producing_a_plugin,
+    )
     def test_install_custom(self, mock_clone, tmp_path):
         ok, err = install_git_plugin(
             "https://github.com/someone/my-cool-plugin",
@@ -474,7 +507,10 @@ class TestInstallGitPlugin:
         assert ok
         assert err == ""
 
-    @mock.patch("src.plugins.sources.clone_or_update_repo", return_value=(True, ""))
+    @mock.patch(
+        "src.plugins.sources.clone_or_update_repo",
+        side_effect=_fake_clone_producing_a_plugin,
+    )
     def test_install_with_override_id(self, mock_clone, tmp_path):
         ok, _err = install_git_plugin(
             "https://github.com/someone/repo",


### PR DESCRIPTION
Follow-up to #1675. That PR added a daily sweep, which finds a broken plugin a day late and infers severity from a regex over source. This moves the check to the boundary: a plugin that cannot work is never installed in the first place.

## The declaration

`manifest.json` gains an optional `data_files`:

```json
{
  "id": "star_trek_quotes",
  "data_files": ["quotes.json"]
}
```

Paths are relative to the plugin directory. Absolute paths and `..` segments are rejected — a plugin reaching outside its own directory only resolves in the bundled `plugins/<id>/` layout and breaks once installed to `data/external_plugins/<id>/`. That is exactly the Star Trek Quotes regression ([plugin#10](https://github.com/Fiestaboard/fiestaboard-plugin--star-trek-quotes/pull/10)).

## The checks

New `src/plugins/install_check.py` answers one question — *can this plugin possibly work here?* It deliberately does not ask whether it is **configured**; that is the user's business and comes later.

- declared data files are present
- the declaration is well-formed and stays inside the plugin directory
- `requirements.txt` entries are importable (#1671)
- `__init__.py` / `manifest.json` exist

**Severity tracks whether the plugin can work, not whether the author remembered to declare anything.** This is the subtle part, and my first cut got it wrong: I initially made all undeclared-file findings warnings, which downgraded the Star Trek case — *which declared nothing* — from broken to advisory. The rule that survives:

| situation | severity |
|---|---|
| path escapes the plugin directory | **error** (can never resolve once installed) |
| file is read but missing | **error** (broken now, declared or not) |
| file is read, present, undeclared | advisory (works, but unprotected) |

## Enforcement

| when | what happens |
|---|---|
| **install** | a fresh install that fails is **refused** and the clone removed |
| **update** | reported via `GET /plugins/errors`, but **left installed** — an update must not pull a working board out from under someone |
| **startup** | re-checked; findings surface in `GET /plugins/errors` |
| **registry** | `validate_plugins.py --strict` escalates the advisory |
| **daily** | the sweep from #1675 now delegates here instead of carrying its own copy (net −233 lines in that script) |

## Verification

Against the **real instance**, the installed `star_trek_quotes` — which declares nothing — is now reported through `/plugins/errors`:

```
star_trek_quotes:
  - __init__.py reads 'src/utils/star_trek_quotes.json' from outside the plugin
    directory (2 levels up). That path only resolves in the bundled
    plugins/<id>/ layout and breaks once the plugin is installed.
  - __init__.py reads 'quotes.json' but no such file ships with the plugin.
    Every variable it provides will render '???'.
```

Swept across all 51 published plugin repos: **2 blocking** (`volcano`, `network_speed` — both #1671), **2 advisory** (present-but-undeclared reads, incl. one in `national_day`), **zero false positives**.

## Tests

87 cases across three files, every check with a matching negative case.

**Mutation-tested** — each of these turns tests red:

| mutation | tests failed |
|---|---|
| don't clean up a rejected install | 1 |
| block updates too (violates the policy) | 2 |
| skip the data-file check | 5 |
| skip the dependency check | 2 |
| allow `..` traversal in declarations | 3 |

**Three existing tests changed, deliberately.** `test_plugin_sources.py` mocked `clone_or_update_repo` to return `(True, "")` while writing nothing — encoding "a successful clone is sufficient to install." That contract is now false on purpose. Their fake clone leaves a plausible plugin behind, which is what a real clone does, and a **new** test covers the rejection path they used to occupy. This is a corrected contract, not a weakened assertion.

**A/B against `origin/main`** on the same test selection, same container: 1155 → 1194 passing, error set byte-identical, no regressions. (The 78 errors in both are pre-existing artifacts of the isolated test dir, not of either branch.)

`ruff check` / `ruff format --check` clean; full `npm run docs:lint` clean.

## Known limitation

The declaration is opt-in, so it does nothing for the existing fleet until plugins adopt it — I verified this rather than assuming: the installed `star_trek_quotes` produced **zero** findings from the declaration path alone. The source scan is what covers those plugins, and it is a regex, not an AST pass. That is why it can only ever *warn* about a file that is present, and why the real-corpus run above matters more than the unit tests for judging its precision.

Phase 2 (a typed `unconfigured` vs `error` reason on `PluginResult`) removes the remaining guesswork and fixes the `???`-means-three-things ambiguity in the UI. Separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
