### PR TITLE
fix(ci): rebase and retry when pushing regenerated captures

### DIFF
--- a/.github/workflows/docs-captures.yml
+++ b/.github/workflows/docs-captures.yml
@@ -146,7 +146,21 @@ jobs:
           # what carries the captures to the site repo. It cannot retrigger
           # this workflow — that one only watches web/**.
           git commit -m "chore(docs): regenerate app captures"
-          git push
+
+          # main moves while this job runs — it takes ~10 minutes to build the
+          # image and capture every screen twice, and a release version bump
+          # landing in that window is enough to make the push a stale-ref
+          # rejection. Rebase and retry rather than losing the captures.
+          for attempt in 1 2 3; do
+            if git push; then
+              echo "captures pushed on attempt $attempt"
+              exit 0
+            fi
+            echo "push rejected, rebasing onto latest main (attempt $attempt)"
+            git pull --rebase --autostash origin main || exit 1
+          done
+          echo "::error::Could not push captures after 3 attempts."
+          exit 1
 
       - name: Collect diagnostics on failure
         if: failure()


### PR DESCRIPTION
Follow-up to #1678.

The first real run of `Docs: regenerate app captures` did everything right and then lost the result:

```
✓ Generate captures
✓ Verify captures are reproducible
X Commit captures
    ! [rejected]  main -> main (fetch first)
```

The job takes ~10 minutes — build the image, boot the app, capture every screen twice — and `main` moved in that window (`chore: bump version to 8.29.0`). The push was a stale-ref rejection, so 36 regenerated captures were discarded.

Rebase onto latest `main` and retry, up to three times.

Worth noting from that run: **the reproducibility check passed on the first real CI run.** Two full passes in a fresh container produced byte-identical captures — which is the environment the nine determinism fixes were actually aimed at, and cleaner than local runs where the dev container auto-updates plugins underneath the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)