### PR TITLE
fix(ui): put bare body content on the page content column

### DIFF
--- a/web/app/routes/integrations._index.tsx
+++ b/web/app/routes/integrations._index.tsx
@@ -38,6 +38,7 @@ import {
   Label,
   PageHeader,
   PageLayout,
+  PageToolbar,
   PluginCard,
   PluginCategoryBadge,
   Select,
@@ -2325,71 +2326,79 @@ export default function IntegrationsPage() {
 
       {/* Tabs */}
       <Tabs value={activeTab} onValueChange={setActiveTab}>
-        <Box
-          className={
-            activeTab === "marketplace"
-              ? "mb-4 grid grid-cols-1 gap-3 items-center md:grid-cols-[auto_minmax(12rem,1fr)_auto]"
-              : "mb-4 grid grid-cols-1 gap-3 items-center sm:grid-cols-[auto_minmax(0,1fr)]"
-          }
-        >
-          <TabsList className="w-fit">
-            <TabsTrigger value="installed">
-              {t("tabInstalled")}
-              {data && (
-                <Badge variant="secondary" className="ml-1.5 text-[10px] px-1.5 py-0 h-4">
-                  {data.total}
-                </Badge>
-              )}
-            </TabsTrigger>
-            <TabsTrigger value="marketplace">
-              {t("tabMarketplace")}
-              {availableCount > 0 && (
-                <Badge variant="outline" className="ml-1.5 text-[10px] px-1.5 py-0 h-4">
-                  {availableCount}
-                </Badge>
-              )}
-            </TabsTrigger>
-          </TabsList>
-          <Box className="relative min-w-0 w-full">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
-            <Input
-              placeholder={
-                activeTab === "installed" ? t("searchInstalledPlaceholder") : t("searchAvailablePlaceholder")
-              }
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              className="pl-9 w-full"
-            />
-          </Box>
-          {activeTab === "marketplace" && (
-            <Flex align="center" gap="2" className="shrink-0 md:justify-self-end">
-              <Flex className="rounded-md border overflow-hidden">
-                <Button
-                  variant={marketplaceView === "card" ? "secondary" : "ghost"}
-                  size="icon"
-                  className="h-9 w-9 rounded-none border-0"
-                  onClick={() => setMarketplaceView("card")}
-                  aria-label={t("cardViewAriaLabel")}
-                >
-                  <LayoutGrid className="h-4 w-4" />
-                </Button>
-                <Button
-                  variant={marketplaceView === "list" ? "secondary" : "ghost"}
-                  size="icon"
-                  className="h-9 w-9 rounded-none border-0"
-                  onClick={() => setMarketplaceView("list")}
-                  aria-label={t("listViewAriaLabel")}
-                >
-                  <LayoutList className="h-4 w-4" />
+        {/* PageToolbar via its children escape hatch, not its left/right slots:
+            the search field has to take whatever track the tab strip leaves,
+            and a flex split cannot express "fill the rest". The toolbar
+            contributes only the inset, which is what puts this row on the
+            content column with the page title above it. `mb-4` moves off the
+            grid because PageToolbar already carries it. */}
+        <PageToolbar>
+          <Box
+            className={
+              activeTab === "marketplace"
+                ? "grid grid-cols-1 gap-3 items-center md:grid-cols-[auto_minmax(12rem,1fr)_auto]"
+                : "grid grid-cols-1 gap-3 items-center sm:grid-cols-[auto_minmax(0,1fr)]"
+            }
+          >
+            <TabsList className="w-fit">
+              <TabsTrigger value="installed">
+                {t("tabInstalled")}
+                {data && (
+                  <Badge variant="secondary" className="ml-1.5 text-[10px] px-1.5 py-0 h-4">
+                    {data.total}
+                  </Badge>
+                )}
+              </TabsTrigger>
+              <TabsTrigger value="marketplace">
+                {t("tabMarketplace")}
+                {availableCount > 0 && (
+                  <Badge variant="outline" className="ml-1.5 text-[10px] px-1.5 py-0 h-4">
+                    {availableCount}
+                  </Badge>
+                )}
+              </TabsTrigger>
+            </TabsList>
+            <Box className="relative min-w-0 w-full">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
+              <Input
+                placeholder={
+                  activeTab === "installed" ? t("searchInstalledPlaceholder") : t("searchAvailablePlaceholder")
+                }
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="pl-9 w-full"
+              />
+            </Box>
+            {activeTab === "marketplace" && (
+              <Flex align="center" gap="2" className="shrink-0 md:justify-self-end">
+                <Flex className="rounded-md border overflow-hidden">
+                  <Button
+                    variant={marketplaceView === "card" ? "secondary" : "ghost"}
+                    size="icon"
+                    className="h-9 w-9 rounded-none border-0"
+                    onClick={() => setMarketplaceView("card")}
+                    aria-label={t("cardViewAriaLabel")}
+                  >
+                    <LayoutGrid className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    variant={marketplaceView === "list" ? "secondary" : "ghost"}
+                    size="icon"
+                    className="h-9 w-9 rounded-none border-0"
+                    onClick={() => setMarketplaceView("list")}
+                    aria-label={t("listViewAriaLabel")}
+                  >
+                    <LayoutList className="h-4 w-4" />
+                  </Button>
+                </Flex>
+                <Button variant="outline" className="gap-2" onClick={() => setGitDialogOpen(true)}>
+                  <GitBranch className="h-4 w-4" />
+                  {t("addFromGit")}
                 </Button>
               </Flex>
-              <Button variant="outline" className="gap-2" onClick={() => setGitDialogOpen(true)}>
-                <GitBranch className="h-4 w-4" />
-                {t("addFromGit")}
-              </Button>
-            </Flex>
-          )}
-        </Box>
+            )}
+          </Box>
+        </PageToolbar>
 
         {/* ── Installed Tab ── */}
         <TabsContent value="installed" className="mt-0">

--- a/web/app/routes/pages._index.tsx
+++ b/web/app/routes/pages._index.tsx
@@ -10,6 +10,7 @@ import {
   Flex,
   Grid,
   PageHeader,
+  PageInset,
   PageLayout,
   PageToolbar,
   Skeleton,
@@ -238,13 +239,20 @@ export default function PagesPage() {
       <Box className="animate-card-fade-in" style={{ animationDelay: "150ms" }}>
         {hasMultipleDevices ? (
           <Tabs value={activeTab ?? availableDevices[0]} onValueChange={(v) => setActiveTab(v as DeviceType)}>
-            <TabsList className="mb-5">
-              {availableDevices.includes("flagship") && <TabsTrigger value="flagship">{t("flagshipTab")}</TabsTrigger>}
-              {availableDevices.includes("note") && <TabsTrigger value="note">{t("noteTab")}</TabsTrigger>}
-              {availableDevices.includes("note_array") && (
-                <TabsTrigger value="note_array">{t("noteArrayTab")}</TabsTrigger>
-              )}
-            </TabsList>
+            {/* Inset: a tab strip is bare controls, so it belongs on the
+                content column with the toolbar above it, not on the gutter
+                the tiles' borders use. */}
+            <PageInset>
+              <TabsList className="mb-5">
+                {availableDevices.includes("flagship") && (
+                  <TabsTrigger value="flagship">{t("flagshipTab")}</TabsTrigger>
+                )}
+                {availableDevices.includes("note") && <TabsTrigger value="note">{t("noteTab")}</TabsTrigger>}
+                {availableDevices.includes("note_array") && (
+                  <TabsTrigger value="note_array">{t("noteArrayTab")}</TabsTrigger>
+                )}
+              </TabsList>
+            </PageInset>
             {availableDevices.includes("flagship") && (
               <TabsContent value="flagship">
                 <PageGridSelector

--- a/web/app/routes/picks.tsx
+++ b/web/app/routes/picks.tsx
@@ -6,6 +6,7 @@ import {
   Grid,
   Heading,
   PageHeader,
+  PageInset,
   PageLayout,
   Skeleton,
   Stack,
@@ -241,18 +242,22 @@ export default function PicksPage() {
     <PageLayout>
       <PageHeader icon={Sparkles} title={t("title")} description={t("description")} />
 
-      <Flex align="center" gap="2" className="mb-6 -mt-2">
-        <Text as="span" size="xs" tone="muted" className="italic">
-          {t("byline")}
-        </Text>
-      </Flex>
+      <PageInset>
+        <Flex align="center" gap="2" className="mb-6 -mt-2">
+          <Text as="span" size="xs" tone="muted" className="italic">
+            {t("byline")}
+          </Text>
+        </Flex>
+      </PageInset>
 
       {hasMultipleDevices ? (
         <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as DeviceType)}>
-          <TabsList className="mb-6">
-            {configuredDevices.includes("flagship") && <TabsTrigger value="flagship">{t("flagshipTab")}</TabsTrigger>}
-            {configuredDevices.includes("note") && <TabsTrigger value="note">{t("noteTab")}</TabsTrigger>}
-          </TabsList>
+          <PageInset>
+            <TabsList className="mb-6">
+              {configuredDevices.includes("flagship") && <TabsTrigger value="flagship">{t("flagshipTab")}</TabsTrigger>}
+              {configuredDevices.includes("note") && <TabsTrigger value="note">{t("noteTab")}</TabsTrigger>}
+            </TabsList>
+          </PageInset>
           {configuredDevices.includes("flagship") && (
             <TabsContent value="flagship">
               <PicksGrid deviceType="flagship" />

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "web",
-  "version": "8.28.1",
+  "version": "8.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "8.28.1",
+      "version": "8.30.0",
       "dependencies": {
         "@codemirror/commands": "^6.11.0",
         "@codemirror/language": "^6.12.4",
         "@codemirror/state": "^6.7.1",
         "@codemirror/view": "^6.43.9",
-        "@fiestaboard/ui": "5.4.3",
+        "@fiestaboard/ui": "5.5.0",
         "@lezer/highlight": "^1.2.3",
         "@microsoft/fetch-event-source": "^2.0.1",
         "@react-router/fs-routes": "^8.3.0",
@@ -2973,9 +2973,9 @@
       }
     },
     "node_modules/@fiestaboard/ui": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/@fiestaboard/ui/-/ui-5.4.3.tgz",
-      "integrity": "sha512-0Z+DXTTfn5+O7SKQME2iSRAV/F1pEsQCuqnc/ZgoD1iqvEkEHLxSH+ESmGIKZs99JvG/GQ1k4mkcTnfH8Zznsg==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@fiestaboard/ui/-/ui-5.5.0.tgz",
+      "integrity": "sha512-jp3XXxPgSlme+PNsSGNvGJcXl0yAQLKYo7cDRDocwyNSZgXDAGcjHqk36TZUeUzgVsLnM8AVp9+FqtMttzwgNQ==",
       "license": "MIT",
       "dependencies": {
         "@base-ui/react": "^1.6.0",

--- a/web/package.json
+++ b/web/package.json
@@ -27,7 +27,7 @@
     "@codemirror/language": "^6.12.4",
     "@codemirror/state": "^6.7.1",
     "@codemirror/view": "^6.43.9",
-    "@fiestaboard/ui": "5.4.3",
+    "@fiestaboard/ui": "5.5.0",
     "@lezer/highlight": "^1.2.3",
     "@microsoft/fetch-event-source": "^2.0.1",
     "@react-router/fs-routes": "^8.3.0",


### PR DESCRIPTION
**Draft — blocked on Fiestaboard/FiestaUI#272.** This uses `PageInset`, which does not exist in the pinned `@fiestaboard/ui` 5.4.3, so CI will fail typecheck until that PR releases and the evergreen upgrade PR carries the new version in. Undraft then.

## Why

FiestaUI #270 moved `PageHeader` and `PageToolbar` onto the card **content column** — the container gutter plus the 24 that `Card` pads its own contents by. It did not move the bare body content under them.

So a tab strip is now the last thing on a route still sitting on the gutter, 24px outboard of the toolbar one row above it. On **Pages** the device strip starts left of the view-mode buttons directly over it, which reads as outdented rather than as full-bleed.

## What moves

| Route | Change |
|---|---|
| **Pages** | device tab strip → `PageInset` |
| **Picks** | byline and device tab strip → `PageInset` |
| **Integrations** | tabs/search/view-toggle row → `PageToolbar` |

Integrations had never been converted at all — that row is a hand-rolled grid predating `PageToolbar`. It uses the `children` escape hatch, since the search field has to take whatever track the tab strip leaves and a left/right flex split cannot express "fill the rest". `mb-4` moves off the grid because the toolbar already carries it.

## What deliberately does NOT move

The page tiles on Pages, the pick cards on Picks, and every `Card` and `Alert` on every route. Those draw a border, and **a border is chrome** — it belongs on the gutter. Wrapping them would indent them past every card on every other route. Home, Settings, Collections, Schedule, Transitions and Debug have all-bordered bodies and are untouched.

One incidental behaviour change: the Integrations row now picks up `PageToolbar`'s 50ms fade-in, matching every other route that has one.

## Verification

Run against a local build of FiestaUI #272 swapped into `node_modules`, not assumed:

- `npm run typecheck` ✅
- `eslint` + `prettier --check` on all three routes ✅
- `npm run test:run` — **128 files, 1498 passed**, 7 skipped ✅

Including `pages-index-device-tabs.test.tsx`, whose two tests click a device tab and assert the panel swaps. That matters here specifically: the wrapper puts a `<div>` between `Tabs` and `TabsList`, and those tests confirm Base UI's context still resolves through it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)