### PR TITLE
fix(ci): stop cancelling capture runs before they can finish

### DIFF
--- a/.github/workflows/docs-captures.yml
+++ b/.github/workflows/docs-captures.yml
@@ -22,9 +22,17 @@ on:
       - ".github/workflows/docs-captures.yml"
   workflow_dispatch: {}
 
+# Queue runs, never cancel them. This job takes ~11 minutes — build the image,
+# boot the app, capture every screen twice — and it triggers on any web/**
+# change. With cancel-in-progress the first four real runs were all killed by
+# the next merge landing before they finished, so the capture PR was never
+# refreshed and sat there as a rollback of everything merged after it.
+#
+# Queueing wastes some runner time when merges cluster. Cancelling wasted the
+# entire mechanism.
 concurrency:
   group: docs-captures
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 permissions:
   contents: write


### PR DESCRIPTION
## The workflow could never complete

Four consecutive runs, all cancelled:

```
cancelled  chore(deps): bump @fiestaboard/ui (#1679)
cancelled  fix(ci): show which commit a capture PR was generated from (#1687)
cancelled  fix(ui): put bare body content on the page content column (#1683)
cancelled  feat(docs): capture the AI settings and chat panel screens (#1684)
```

The job takes **~11 minutes** — build the image, boot the app, capture every screen twice — and triggers on any `web/**` change. Merges have been landing every ~5 minutes. With `cancel-in-progress: true`, each run was killed by the next merge before it could push anything.

The visible symptom: capture PR #1685 has sat at its original 00:26 commit through four merges, which makes it a **rollback** of everything landed since — the content-fitting fix and the two AI captures. My own doing, in the concurrency block.

## The fix

Queue instead of cancel. Runs serialize on the same group and each one finishes; the last to complete force-pushes the branch, so the PR ends up reflecting the most recent `main`.

Queueing wastes some runner time when merges cluster. Cancelling wasted the entire mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)