### PR TITLE
fix(plugins): make the context-build timeout actually bound the render

### DIFF
--- a/src/plugins/registry.py
+++ b/src/plugins/registry.py
@@ -45,6 +45,11 @@ INSTANCE_SEPARATOR = ":"
 # Valid instance label pattern: alphanumeric, underscores, and hyphens, 1-40 chars.
 _INSTANCE_LABEL_RE = re.compile(r"^[a-zA-Z0-9_-]{1,40}$")
 
+# How long build_template_context() waits for the slowest enabled plugin before
+# rendering without it. A board that is a little stale beats a board that never
+# updates because one data source is wedged.
+CONTEXT_BUILD_TIMEOUT_SECONDS = 15
+
 
 def _config_in_use(plugin_id: str, stored_configs: dict[str, dict[str, Any]]) -> bool:
     """Return True when a stored config, or any of its instance configs
@@ -1528,9 +1533,10 @@ class PluginRegistry:
         # Fetch every plugin concurrently; cap the pool to avoid spawning an
         # unbounded number of threads when many plugins are enabled.
         max_workers = min(len(enabled), 8)
-        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        executor = ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="plugin-fetch")
+        try:
             futures = {executor.submit(self.fetch_plugin_data, plugin_id, board): plugin_id for plugin_id in enabled}
-            done, not_done = futures_wait(futures, timeout=15)
+            done, not_done = futures_wait(futures, timeout=CONTEXT_BUILD_TIMEOUT_SECONDS)
 
             if not_done:
                 slow_ids = [futures[f] for f in not_done]
@@ -1547,6 +1553,19 @@ class PluginRegistry:
                         context[plugin_id] = result.data
                 except Exception:
                     logger.exception(f"Plugin {plugin_id} raised an error during context build")
+        finally:
+            # Deliberately not a `with` block. ThreadPoolExecutor.__exit__ calls
+            # shutdown(wait=True), which would block here until the slowest
+            # plugin returned -- so the timeout above would decide only whether
+            # a result is *used*, never how long the render takes. A plugin
+            # wedged on a 60s network call would stall every board render for
+            # the full 60s and then have its answer thrown away.
+            #
+            # wait=False lets an abandoned fetch finish on its own thread
+            # (harmlessly -- nothing reads its result, and PluginBase caches it
+            # for the next tick); cancel_futures drops the ones that never
+            # started.
+            executor.shutdown(wait=False, cancel_futures=True)
 
         return context
 

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -1,5 +1,7 @@
 """Tests for PluginRegistry - manages loaded plugins."""
 
+import threading
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -2098,3 +2100,53 @@ def test_migration_still_installs_untombstoned_orphan(registry):
         registry._auto_migrate_v2_plugins(stored)
 
     registry.install_from_registry.assert_called_once_with("weather")
+
+
+def test_build_template_context_returns_without_waiting_for_a_slow_plugin(
+    registry, mock_loader, mock_plugin, mock_manifest
+):
+    """A plugin that blows the timeout must not delay the render.
+
+    ``futures_wait(timeout=...)`` only decides whether a result is *used*.
+    Leaving the executor to a ``with`` block undoes that: ``__exit__`` calls
+    ``shutdown(wait=True)``, so the call still blocks for the full duration of
+    the slowest plugin and then throws its answer away.
+    """
+    slow_plugin = MagicMock(spec=PluginBase)
+    slow_plugin.plugin_id = "slow_plugin"
+    slow_plugin.validate_config.return_value = []
+    slow_plugin._validate_refresh_seconds.return_value = []
+    slow_plugin.enabled = False
+    slow_plugin.config = {}
+
+    released = threading.Event()
+
+    def never_finishes_in_time(board=None):
+        released.wait(timeout=30)
+        return PluginResult(available=True, data={"key": "too late"})
+
+    slow_plugin.get_data.side_effect = never_finishes_in_time
+
+    mock_loader.load_all_plugins.return_value = {
+        "test_plugin": mock_plugin,
+        "slow_plugin": slow_plugin,
+    }
+    mock_loader.get_manifest.side_effect = lambda pid: mock_manifest
+    with patch("src.config_manager.get_config_manager") as mock_cm:
+        mock_cm.return_value.get_all_plugin_configs.return_value = {
+            "test_plugin": {"enabled": True},
+            "slow_plugin": {"enabled": True},
+        }
+        registry.initialize()
+
+    try:
+        with patch("src.plugins.registry.CONTEXT_BUILD_TIMEOUT_SECONDS", 0.5):
+            started = time.monotonic()
+            context = registry.build_template_context()
+            elapsed = time.monotonic() - started
+
+        assert elapsed < 3, f"build_template_context blocked {elapsed:.1f}s on a plugin it had already abandoned"
+        assert "test_plugin" in context, "the responsive plugin's data was lost"
+        assert "slow_plugin" not in context
+    finally:
+        released.set()


### PR DESCRIPTION
Found while investigating #1690.

## The bug

`build_template_context()` fans plugin fetches out across a `ThreadPoolExecutor` and waits 15s for them:

```python
with ThreadPoolExecutor(max_workers=max_workers) as executor:
    futures = {...}
    done, not_done = futures_wait(futures, timeout=15)
    if not_done:
        logger.warning(f"... will be skipped: {slow_ids}")
    ...
# <- __exit__ calls shutdown(wait=True)
```

`ThreadPoolExecutor.__exit__` calls `shutdown(wait=True)`. So the `with` block blocks until the *slowest* plugin returns — and only then throws its result away. The timeout decided whether a slow plugin's data was **used**, never how long a render **took**.

Minimal demonstration of the semantics:

```
wait returned at 1.0s, not_done=1
with-block exited at 5.1s
```

One plugin wedged on a long network call stalled every board render for its full duration, logged "will be skipped", and discarded the answer at the end.

This is not hypothetical — it is exactly what `network_speed` (#1690) does. A real `speedtest-cli` run measured 20.5s here, i.e. every refresh would have frozen the render for 20s to produce nothing.

## The fix

Hold the executor explicitly and shut it down with `wait=False, cancel_futures=True`:

- abandoned fetches finish harmlessly on their own threads — nothing reads the result, and `PluginBase` caches it for the next tick, so the slow plugin actually *recovers* on a later render instead of being permanently late
- queued fetches that never started are cancelled
- the render proceeds at the timeout, as intended

The 15s literal becomes `CONTEXT_BUILD_TIMEOUT_SECONDS` so the behaviour is testable without a 15-second test.

## Non-vacuity

Per the test quality bar, the test was written first and observed failing against the unfixed code:

```
tests/test_plugin_registry.py:2148: in test_build_template_context_returns_without_waiting_for_a_slow_plugin
    assert elapsed < 3, f"build_template_context blocked {elapsed:.1f}s on a plugin it had already abandoned"
E   AssertionError: build_template_context blocked 30.0s on a plugin it had already abandoned
E   assert 30.015190930018434 < 3
------------------------------ Captured log call -------------------------------
WARNING  src.plugins.registry:registry.py:1542 1 plugin(s) did not complete within the context-build timeout and will be skipped: ['slow_plugin']
```

The captured log is the point: it says "will be skipped" and then waits 30s anyway.

After the fix, `test_plugin_registry.py` goes from 30.18s for that one test to **112 passed in 0.73s**.

## Verification

Run against this branch's tree:

```
tests/test_plugin_registry.py tests/test_plugin_instances.py
tests/test_plugin_board_context.py tests/test_plugin_install_check.py
268 passed in 1.76s
```

`ruff==0.16.3` (the pinned version) — `All checks passed! / 2 files already formatted`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)