### PR TITLE
fix(settings): stop drawing an empty band when there is no update

### DIFF
--- a/web/app/routes/settings.tsx
+++ b/web/app/routes/settings.tsx
@@ -172,9 +172,11 @@ export default function SettingsPage() {
         <PageCard>
           <PageHeader icon={Settings} title={t("title")} description={t("description")} />
 
-          <PageSection>
-            <SystemUpdate />
-          </PageSection>
+          {/* Unwrapped on purpose: SystemUpdate brings its own PageSection
+              when it has something to announce and renders nothing when it
+              does not. A section here would draw an empty band on every
+              up-to-date install — see the note on its return. */}
+          <SystemUpdate />
 
           <PageSection>
             <Box className="-mx-6 overflow-x-auto px-6">

--- a/web/src/__tests__/system-update.test.tsx
+++ b/web/src/__tests__/system-update.test.tsx
@@ -138,6 +138,65 @@ describe("SystemUpdate", () => {
     expect(screen.queryByText("Update Available")).not.toBeInTheDocument();
   });
 
+  /*
+   * The banner owns its `PageSection`, and these two are the pair that keeps
+   * it that way.
+   *
+   * The settings route is one `PageCard` whose blocks are `PageSection`s, and
+   * a section pads itself 24px top and bottom and draws a divider whether or
+   * not anything is inside it. So when the route wrapped this component —
+   * `<PageSection><SystemUpdate /></PageSection>` — every install with no
+   * update pending, which is nearly all of them nearly all of the time, drew
+   * an empty 49px band and a rule under the settings header. Only this
+   * component can know whether it has anything to say; the route cannot,
+   * because the answer lives in a query this component owns.
+   */
+  it("draws no section when there is nothing to announce", async () => {
+    server.use(
+      http.get(`${API_BASE}/system/update-check`, () => {
+        return HttpResponse.json({
+          current_version: "2.0.1",
+          latest_version: "2.0.1",
+          update_available: false,
+          package_url: "https://github.com/Fiestaboard/FiestaBoard/releases/latest",
+          error: null,
+          is_production: true,
+        });
+      }),
+    );
+
+    render(<SystemUpdate />, { wrapper: TestWrapper });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+    expect(document.querySelector('[data-slot="page-section"]')).toBeNull();
+  });
+
+  it("draws its own section when it has an update to announce", async () => {
+    server.use(
+      http.get(`${API_BASE}/system/update-check`, () => {
+        return HttpResponse.json({
+          current_version: "2.0.1",
+          latest_version: "2.0.2",
+          update_available: true,
+          package_url: "https://github.com/Fiestaboard/FiestaBoard/releases/latest",
+          error: null,
+          is_production: true,
+        });
+      }),
+    );
+
+    render(<SystemUpdate />, { wrapper: TestWrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("Update Available")).toBeInTheDocument();
+    });
+    const section = document.querySelector('[data-slot="page-section"]');
+    expect(section).not.toBeNull();
+    expect(section).toContainElement(screen.getByRole("alert"));
+  });
+
   it("renders nothing in non-production mode with no update", async () => {
     server.use(
       http.get(`${API_BASE}/system/update-check`, () => {

--- a/web/src/components/settings/system-update.tsx
+++ b/web/src/components/settings/system-update.tsx
@@ -13,6 +13,7 @@ import {
   DialogHeader,
   DialogTitle,
   Flex,
+  PageSection,
   Text,
   Tooltip,
   TooltipContent,
@@ -85,101 +86,110 @@ export function SystemUpdate() {
   const sidecarReady = !!status?.updater_available;
 
   return (
-    <TooltipProvider>
-      <Alert className="border-warning/50 bg-warning/10">
-        <ArrowUpCircle className="h-4 w-4 text-warning" />
-        <AlertDescription className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
-          <Flex align="center" gap="2" wrap>
-            <Text as="span" weight="medium">
-              {t("updateAvailable")}
-            </Text>
-            <Badge variant="secondary" className="text-xs">
-              {tCommon("versionShort", { version: updateCheck.latest_version })}
-            </Badge>
-            <Text as="span" tone="muted">
-              {t("youAreRunning", { currentVersion: updateCheck.current_version })}
-            </Text>
-          </Flex>
-          <Flex align="center" gap="2">
-            <Button variant="outline" size="sm" asChild>
-              {/* Plain <a> stays raw: it is the single Slot child of Button asChild,
+    // The section belongs to the banner, not to the route. Every `return
+    // null` above is a case where the settings card must show no block at
+    // all, and a `PageSection` wrapped around this component in settings.tsx
+    // could not honour that — it pads itself 24px top and bottom and draws a
+    // divider whether or not its child renders anything, so an install with
+    // no update pending (the usual case) got an empty band under the page
+    // header. Only this component can know; the answer is in its own query.
+    <PageSection>
+      <TooltipProvider>
+        <Alert className="border-warning/50 bg-warning/10">
+          <ArrowUpCircle className="h-4 w-4 text-warning" />
+          <AlertDescription className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
+            <Flex align="center" gap="2" wrap>
+              <Text as="span" weight="medium">
+                {t("updateAvailable")}
+              </Text>
+              <Badge variant="secondary" className="text-xs">
+                {tCommon("versionShort", { version: updateCheck.latest_version })}
+              </Badge>
+              <Text as="span" tone="muted">
+                {t("youAreRunning", { currentVersion: updateCheck.current_version })}
+              </Text>
+            </Flex>
+            <Flex align="center" gap="2">
+              <Button variant="outline" size="sm" asChild>
+                {/* Plain <a> stays raw: it is the single Slot child of Button asChild,
                   which merges button styling onto it; TextLink would layer conflicting
                   link/underline treatment on top. */}
-              {/* eslint-disable-next-line react/forbid-elements -- single Slot child of Button asChild; the Button merges its chrome onto this anchor and TextLink would layer conflicting link styling */}
-              <a href={updateCheck.package_url} target="_blank" rel="noopener noreferrer">
-                <ExternalLink className="h-4 w-4 mr-2" />
-                {t("viewRelease")}
-              </a>
-            </Button>
-            {sidecarReady && (
-              <Button size="sm" onClick={() => setConfirmOpen(true)} disabled={applyMutation.isPending}>
+                {/* eslint-disable-next-line react/forbid-elements -- single Slot child of Button asChild; the Button merges its chrome onto this anchor and TextLink would layer conflicting link styling */}
+                <a href={updateCheck.package_url} target="_blank" rel="noopener noreferrer">
+                  <ExternalLink className="h-4 w-4 mr-2" />
+                  {t("viewRelease")}
+                </a>
+              </Button>
+              {sidecarReady && (
+                <Button size="sm" onClick={() => setConfirmOpen(true)} disabled={applyMutation.isPending}>
+                  <ArrowUpCircle className="h-4 w-4 mr-2" />
+                  {t("updateNow")}
+                </Button>
+              )}
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8"
+                    onClick={() => {
+                      queryClient.invalidateQueries({ queryKey: ["update-check"] });
+                      queryClient.invalidateQueries({ queryKey: ["update-status"] });
+                    }}
+                    aria-label={t("checkForUpdates")}
+                  >
+                    <RefreshCw className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <Text>{t("checkForUpdates")}</Text>
+                </TooltipContent>
+              </Tooltip>
+            </Flex>
+          </AlertDescription>
+        </Alert>
+
+        {!sidecarReady && (
+          <Text size="xs" tone="muted" className="mt-2 ml-1">
+            {t.rich("oneClickHint", {
+              profile: () => <Code>COMPOSE_PROFILES=fiestaupdater</Code>,
+              envFile: () => <Code>.env</Code>,
+              command: () => <Code>docker compose up -d</Code>,
+            })}
+          </Text>
+        )}
+
+        <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>{t("dialogTitle")}</DialogTitle>
+              <DialogDescription>
+                {t.rich("dialogDescription", {
+                  version: () => (
+                    <Text as="span" weight="semibold" tone="muted">
+                      {tCommon("versionShort", { version: updateCheck.latest_version })}
+                    </Text>
+                  ),
+                })}
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setConfirmOpen(false)}>
+                {tCommon("cancel")}
+              </Button>
+              <Button
+                onClick={() => {
+                  setConfirmOpen(false);
+                  applyMutation.mutate();
+                }}
+              >
                 <ArrowUpCircle className="h-4 w-4 mr-2" />
                 {t("updateNow")}
               </Button>
-            )}
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-8 w-8"
-                  onClick={() => {
-                    queryClient.invalidateQueries({ queryKey: ["update-check"] });
-                    queryClient.invalidateQueries({ queryKey: ["update-status"] });
-                  }}
-                  aria-label={t("checkForUpdates")}
-                >
-                  <RefreshCw className="h-4 w-4" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                <Text>{t("checkForUpdates")}</Text>
-              </TooltipContent>
-            </Tooltip>
-          </Flex>
-        </AlertDescription>
-      </Alert>
-
-      {!sidecarReady && (
-        <Text size="xs" tone="muted" className="mt-2 ml-1">
-          {t.rich("oneClickHint", {
-            profile: () => <Code>COMPOSE_PROFILES=fiestaupdater</Code>,
-            envFile: () => <Code>.env</Code>,
-            command: () => <Code>docker compose up -d</Code>,
-          })}
-        </Text>
-      )}
-
-      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>{t("dialogTitle")}</DialogTitle>
-            <DialogDescription>
-              {t.rich("dialogDescription", {
-                version: () => (
-                  <Text as="span" weight="semibold" tone="muted">
-                    {tCommon("versionShort", { version: updateCheck.latest_version })}
-                  </Text>
-                ),
-              })}
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setConfirmOpen(false)}>
-              {tCommon("cancel")}
-            </Button>
-            <Button
-              onClick={() => {
-                setConfirmOpen(false);
-                applyMutation.mutate();
-              }}
-            >
-              <ArrowUpCircle className="h-4 w-4 mr-2" />
-              {t("updateNow")}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </TooltipProvider>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </TooltipProvider>
+    </PageSection>
   );
 }


### PR DESCRIPTION
## The bug

Every install with no update pending draws a 49px strip of nothing, plus a divider, directly under the `/settings` page header.

Measured on `/settings` at 1440px, the children of the page card before this change:

| block | top | height |
| --- | --- | --- |
| `page-header` | 29 | 114 |
| **`page-section`** | **143** | **49** ← empty |
| `page-section` (tab strip) | 192 | 89 |
| `tabs-content` | 281 | … |

## Why

`PageSection` pads itself 24px top and bottom and draws a divider whether or not its child renders anything — that is its job inside a `PageCard`. `SystemUpdate` returns `null` in four of its five states: up to date, still loading, check failed, and updates managed by the Home Assistant supervisor. `#1698` wrapped it at the call site:

```tsx
<PageSection>
  <SystemUpdate />
</PageSection>
```

so the section drew itself around nothing.

The route cannot decide this. Whether the banner has anything to say lives in a react-query result `SystemUpdate` owns and nothing else can see. So the section moves inside the component and the route renders `<SystemUpdate />` bare — its documented contract ("if up to date, render nothing") is true again.

## Test

Two, and they are a pair:

- `draws no section when there is nothing to announce` — guards the regression coming back
- `draws its own section when it has an update to announce` — the one that had to be written first

**Non-vacuity, as required by CLAUDE.md.** The second test was written before the fix and failed for the right reason:

```
FAIL  src/__tests__/system-update.test.tsx > SystemUpdate > draws its own section when it has an update to announce
AssertionError: expected null not to be null
 ❯ src/__tests__/system-update.test.tsx:196:25
     195|     const section = document.querySelector('[data-slot="page-section"]…
     196|     expect(section).not.toBeNull();
Tests  1 failed | 6 passed (7)
```

Re-confirmed after the fix by reverting `system-update.tsx` to `origin/main` with the tests in place — same failure, `1 failed | 6 passed`. Restoring it gives `7 passed`.

## Verification

All in the dev container:

- `npx vitest run src/__tests__/system-update.test.tsx` — 7 passed
- `npx tsc --noEmit` — clean
- `npx eslint` + `npx prettier --check` on the three touched files — clean
- In a browser on `/settings` at 1440px, the page card's children are now `page-header` → tab-strip `page-section` → `tabs-content`. The empty block is gone.

## Not in this PR

The page card's top edge still sits 16px below the sidebar rail's — that is a `PageLayout` bug, fixed in Fiestaboard/FiestaUI#296 and landing here in a follow-up.

Co-Authored-By: Claude <noreply@anthropic.com>
