### PR TITLE
fix(ui): float the AI panel as its own card, and sweep design-audit polish

### DIFF
--- a/web/app/routes/pages._index.tsx
+++ b/web/app/routes/pages._index.tsx
@@ -256,6 +256,7 @@ export default function PagesPage() {
                 <TabsContent value="flagship">
                   <PageGridSelector
                     onSelectPage={handleSelectPage}
+                    label={null}
                     showActiveIndicator={false}
                     showCollections={false}
                     deviceTypeFilter="flagship"
@@ -267,6 +268,7 @@ export default function PagesPage() {
                 <TabsContent value="note">
                   <PageGridSelector
                     onSelectPage={handleSelectPage}
+                    label={null}
                     showActiveIndicator={false}
                     showCollections={false}
                     deviceTypeFilter="note"
@@ -278,6 +280,7 @@ export default function PagesPage() {
                 <TabsContent value="note_array">
                   <PageGridSelector
                     onSelectPage={handleSelectPage}
+                    label={null}
                     showActiveIndicator={false}
                     showCollections={false}
                     deviceTypeFilter="note_array"
@@ -289,6 +292,7 @@ export default function PagesPage() {
           ) : (
             <PageGridSelector
               onSelectPage={handleSelectPage}
+              label={null}
               showActiveIndicator={false}
               showCollections={false}
               deviceTypeFilter={(availableDevices[0] ?? configuredDevices[0]) as DeviceType}

--- a/web/app/routes/schedule.tsx
+++ b/web/app/routes/schedule.tsx
@@ -634,7 +634,12 @@ export default function SchedulePage() {
                           <Button
                             variant="ghost"
                             size="sm"
-                            className={`relative h-8 w-8 p-0 ${hasOverlaps ? "text-destructive hover:text-destructive" : "text-yellow-500 hover:text-yellow-500"}`}
+                            aria-label={
+                              hasOverlaps
+                                ? t("conflictsCountTooltip", { count: issueCount })
+                                : t("gapsCountTooltip", { count: issueCount })
+                            }
+                            className={`relative h-8 w-8 p-0 ${hasOverlaps ? "text-destructive hover:text-destructive" : "text-warning hover:text-warning"}`}
                           >
                             {hasOverlaps ? <AlertCircle className="h-4 w-4" /> : <AlertTriangle className="h-4 w-4" />}
                             <Flex
@@ -642,8 +647,10 @@ export default function SchedulePage() {
                               justify="center"
                               inline
                               className={cn(
-                                "absolute -top-1 -right-1 h-4 min-w-4 px-0.5 text-xs font-bold rounded-full text-white",
-                                hasOverlaps ? "bg-destructive" : "bg-yellow-500",
+                                "absolute -top-1 -right-1 h-4 min-w-4 px-0.5 text-xs font-bold rounded-full",
+                                hasOverlaps
+                                  ? "bg-destructive text-destructive-foreground"
+                                  : "bg-warning text-warning-foreground",
                               )}
                             >
                               {issueCount}
@@ -658,9 +665,7 @@ export default function SchedulePage() {
                       </TooltipContent>
                     </Tooltip>
                     <DropdownMenuContent align="end" className="w-80">
-                      <DropdownMenuLabel
-                        className={hasOverlaps ? "text-destructive" : "text-yellow-600 dark:text-yellow-400"}
-                      >
+                      <DropdownMenuLabel className={hasOverlaps ? "text-destructive" : "text-warning"}>
                         {hasOverlaps ? t("scheduleConflictsLabel") : t("scheduleGapsLabel")}
                       </DropdownMenuLabel>
                       <DropdownMenuSeparator />

--- a/web/src/components/active-page-display.tsx
+++ b/web/src/components/active-page-display.tsx
@@ -6,9 +6,6 @@ import {
   Badge,
   Box,
   Button,
-  Card,
-  CardContent,
-  CardHeader,
   CardTitle,
   Dialog,
   DialogContent,
@@ -469,8 +466,13 @@ export function ActivePageDisplay() {
 
   return (
     <>
-      <Card className="card-interactive">
-        <CardHeader className="pb-4">
+      {/* A block inside the route's PageCard, not a card of its own: home.tsx
+          wraps this in a PageSection, which owns the inset and the top rule.
+          Keeping a bordered Card here drew a second frame inside the page card
+          for a region that is not a click target (see PageCard's "what keeps
+          its border inside" note in @fiestaboard/ui). */}
+      <Box>
+        <Stack gap="2" className="pb-4">
           <Flex align="center" justify="between">
             <Flex align="baseline" gap="2" className="min-w-0">
               <CardTitle className="text-lg">{t("title")}</CardTitle>
@@ -638,9 +640,9 @@ export function ActivePageDisplay() {
               </Badge>
             ))}
           </Flex>
-        </CardHeader>
+        </Stack>
 
-        <CardContent className="space-y-4">
+        <Box className="space-y-4">
           {/* Schedule gap warning */}
           {scheduleEnabled && !activePageId && (
             <Alert variant="default" className="border-warning/50 bg-warning/10">
@@ -700,8 +702,8 @@ export function ActivePageDisplay() {
               )}
             />
           </Flex>
-        </CardContent>
-      </Card>
+        </Box>
+      </Box>
 
       {/* Pre-render grid in background (hidden) to warm up cache */}
       {shouldPreRender && !isSheetOpen && (

--- a/web/src/components/ai-chat-panel.tsx
+++ b/web/src/components/ai-chat-panel.tsx
@@ -196,7 +196,7 @@ export function AiChatPanel({
 
   return (
     <Flex direction="col" className="h-full min-h-0 w-full">
-      <Card className="flex flex-1 min-h-0 w-full flex-col gap-0 overflow-hidden rounded-none border-0 py-0 shadow-none">
+      <Card className="flex flex-1 min-h-0 w-full flex-col gap-0 overflow-hidden py-0">
         {/* Header */}
         <Flex align="center" justify="between" gap="2" className="flex-shrink-0 border-b px-4 py-3">
           <Flex align="center" gap="2" className="min-w-0">

--- a/web/src/components/global-ai-chat-drawer.tsx
+++ b/web/src/components/global-ai-chat-drawer.tsx
@@ -826,10 +826,23 @@ export function GlobalAiChatDrawer() {
       aria-label={t("panelAriaLabel")}
       tabIndex={-1}
       className={cn(
-        "fixed right-0 top-0 bottom-0 z-40 w-96 flex flex-col bg-background overflow-hidden",
+        // A floating card on the same 12px inset the rail sits on — MainContent
+        // already reserves 396px (384 panel + 12 inset) for exactly this
+        // geometry. The card chrome itself (bg, border, radius, shadow) lives
+        // on AiChatPanel's Card; this Box only places and slides it.
+        // Below lg it clears the floating mobile header the same way the nav
+        // menu does, and the maxWidth clamp keeps the card inside a phone
+        // viewport (384 + the 12px inset overflows a 390px screen).
+        "fixed right-3 bottom-3 top-[calc(var(--mobile-header-height,56px)+16px)] lg:top-3 z-40 w-96 flex flex-col overflow-hidden",
         "transition-transform duration-300 ease-in-out sidebar-transition",
-        isOpen ? "translate-x-0" : "translate-x-full",
       )}
+      // Inline rather than a Tailwind arbitrary class: translate-x-full alone
+      // would leave the 12px inset's worth of card (plus its shadow) peeking
+      // at the screen edge, so the closed offset is 100% + the inset.
+      style={{
+        maxWidth: "calc(100vw - 1.5rem)",
+        transform: isOpen ? "translateX(0)" : "translateX(calc(100% + 0.75rem))",
+      }}
       aria-hidden={!isOpen}
     >
       <AiChatPanel

--- a/web/src/components/page-builder.tsx
+++ b/web/src/components/page-builder.tsx
@@ -1788,7 +1788,10 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
             <ScrollArea className="flex-1 min-h-0 space-y-4">
               {/* Draft restored notification */}
               {draftRestored && (
-                <Alert className="bg-info/10 border-info/20">
+                // mb-4 by hand: the parent ScrollArea's space-y-4 spaces its
+                // viewport wrapper, not the content siblings inside it, so
+                // without this the banner sat flush against the name field.
+                <Alert className="bg-info/10 border-info/20 mb-4">
                   <AlertDescription className="text-sm">{t("draftRestored")}</AlertDescription>
                 </Alert>
               )}
@@ -1822,7 +1825,7 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
                       size="sm"
                       variant="ghost"
                       onClick={() => handleEditorModeChange("rich")}
-                      className={`h-7 px-3 text-[11px] rounded-none ${editorMode === "rich" ? "bg-brand-emphasis text-brand-foreground hover:bg-brand-emphasis/85 hover:text-brand-foreground" : ""}`}
+                      className={`h-7 px-3 text-[11px] rounded-none ${editorMode === "rich" ? "bg-primary text-primary-foreground hover:bg-primary/85 hover:text-primary-foreground" : ""}`}
                       aria-label={t("richEditorAriaLabel")}
                       aria-pressed={editorMode === "rich"}
                     >
@@ -1832,7 +1835,7 @@ export const PageBuilder = forwardRef<PageBuilderHandle, PageBuilderProps>(funct
                       size="sm"
                       variant="ghost"
                       onClick={() => handleEditorModeChange("plain")}
-                      className={`h-7 px-3 text-[11px] rounded-none ${editorMode === "plain" ? "bg-brand-emphasis text-brand-foreground hover:bg-brand-emphasis/85 hover:text-brand-foreground" : ""}`}
+                      className={`h-7 px-3 text-[11px] rounded-none ${editorMode === "plain" ? "bg-primary text-primary-foreground hover:bg-primary/85 hover:text-primary-foreground" : ""}`}
                       aria-label={t("plainTextAriaLabel")}
                       aria-pressed={editorMode === "plain"}
                     >

--- a/web/src/components/page-grid-selector.tsx
+++ b/web/src/components/page-grid-selector.tsx
@@ -517,8 +517,8 @@ export interface PageGridSelectorProps {
   isPending?: boolean;
   /** Whether to show the active indicator line */
   showActiveIndicator?: boolean;
-  /** Label text above the grid */
-  label?: string;
+  /** Label text above the grid; null suppresses it (undefined falls back to "SELECT PAGE") */
+  label?: string | null;
   /** Filter pages by device type */
   deviceTypeFilter?: DeviceType;
   /** View mode: "grid" shows previews, "list" shows compact list */

--- a/web/src/components/schedule/schedule-list-view.tsx
+++ b/web/src/components/schedule/schedule-list-view.tsx
@@ -1,17 +1,4 @@
-import {
-  Badge,
-  Box,
-  Button,
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-  Flex,
-  Label,
-  Stack,
-  Switch,
-  Text,
-} from "@fiestaboard/ui";
+import { Badge, Box, Button, CardTitle, Flex, Label, Stack, Switch, Text } from "@fiestaboard/ui";
 import { EmptyState } from "@fiestaboard/ui/components/feedback/empty-state";
 import { format } from "date-fns";
 import { Calendar, ChevronRight, Edit, GalleryHorizontalEnd, Moon, Trash2 } from "lucide-react";
@@ -178,11 +165,15 @@ export function ScheduleListView({
   };
 
   return (
-    <Card className="mb-6">
-      <CardHeader>
-        <CardTitle className="text-lg">{t("scheduleEntriesTitle")}</CardTitle>
-      </CardHeader>
-      <CardContent>
+    // A block inside the route's PageCard: the PageSection wrapping this in
+    // schedule.tsx owns the inset and the top rule, so the list draws no card
+    // of its own — mirroring the calendar view, whose border was already
+    // traded for the page card. The heading matches its size="base" title.
+    <Box>
+      <CardTitle size="base" className="pb-3">
+        {t("scheduleEntriesTitle")}
+      </CardTitle>
+      <Box>
         {schedules.length === 0 && !showSilenceRow ? (
           <EmptyState
             icon={Calendar}
@@ -268,7 +259,7 @@ export function ScheduleListView({
             })}
           </Stack>
         )}
-      </CardContent>
-    </Card>
+      </Box>
+    </Box>
   );
 }

--- a/web/tests/regression/schedule-toolbar.spec.ts
+++ b/web/tests/regression/schedule-toolbar.spec.ts
@@ -140,9 +140,11 @@ test.describe("regression: schedule.toolbar", () => {
     await createSchedule(pageId, "10:00", "12:00", "weekdays");
     await page.goto("/schedule");
     await page.waitForLoadState("networkidle");
-    // The validation indicator is an icon button with a destructive-colored badge.
-    // Click it to open the dropdown, then assert the conflicts label.
-    const indicator = page.locator("button.text-destructive").first();
+    // The validation indicator is an icon-only button whose accessible name
+    // carries the conflict count ("2 schedule conflicts"). Locate it by role,
+    // not by its color classes — those are presentation, and moving them onto
+    // tokens must not break this test.
+    const indicator = page.getByRole("button", { name: /schedule conflicts?$/i }).first();
     await expect(indicator).toBeVisible({ timeout: 15_000 });
     await indicator.click();
     await expect(page.getByText(/Schedule Conflicts/i)).toBeVisible({ timeout: 5_000 });
@@ -154,8 +156,9 @@ test.describe("regression: schedule.toolbar", () => {
     await createSchedule(pageId, "09:00", "10:00", "weekdays");
     await page.goto("/schedule");
     await page.waitForLoadState("networkidle");
-    // The gap indicator is yellow-colored when there are gaps and no overlaps.
-    const indicator = page.locator("button.text-yellow-500").first();
+    // With gaps and no overlaps the same button's accessible name carries the
+    // gap count instead ("1 schedule gap").
+    const indicator = page.getByRole("button", { name: /schedule gaps?$/i }).first();
     await expect(indicator).toBeVisible({ timeout: 15_000 });
     await indicator.click();
     await expect(page.getByText(/Schedule Gaps/i)).toBeVisible({ timeout: 5_000 });


### PR DESCRIPTION
## What

Fixes from a visual design/alignment/polish audit of the app running against `@fiestaboard/ui` 5.12.1 (main + #1701's bump), walked in light + dark at desktop and 390px.

### AI panel → floating card
The assistant drawer was the last attached, squared, full-bleed surface in an app of floating cards. It now sits on the same 12px inset as the rail — the geometry `MainContent`'s `lg:pr-[396px]` (384 panel + 12 inset) has reserved since the page card landed:
- `AiChatPanel`'s internal Card gets its border/radius/shadow back (it was stripped with `rounded-none border-0 shadow-none` for the flush look).
- Below `lg` the card clears the floating mobile header exactly like the nav menu (`top-[calc(var(--mobile-header-height,56px)+16px)]`), and a `maxWidth: calc(100vw - 1.5rem)` clamp keeps it inside a phone viewport — `384 + 12` overflowed a 390px screen.
- The closed slide is `translateX(calc(100% + 0.75rem))` (inline — Tailwind can't see a runtime-composed arbitrary calc), so no 12px sliver stays parked at the screen edge.

### One card per route, finished
- **Home / Active Display** and **Schedule / Schedule Entries** still drew nested bordered Cards inside the route's `PageCard`. Both flatten into plain blocks — the sections aren't click targets, so per PageCard's own doctrine they don't keep a border. The schedule calendar view had already made this trade; the list view now matches it (`CardTitle size="base"`).

### Smaller polish
- **Editor Rich/Plain toggle**: dropped deprecated `bg-brand-emphasis` (the *ink* orange — rendered as a dark brown chip) for the `bg-primary` selected state every other toolbar control uses.
- **Schedule validation indicator**: icon-only button gains an `aria-label`; raw `yellow-500`s move to `--warning` tokens (badge text pairs `*-foreground` with its fill).
- **Pages route**: suppresses `PageGridSelector`'s "SELECT PAGE" eyebrow (`label` now accepts `null`) — that copy belongs to the dashboard's picker sheet, not a screen already titled Pages.
- **Page builder**: "draft restored" banner gets `mb-4` — the ScrollArea's `space-y-4` spaces its viewport wrapper, not the content siblings, so the banner sat flush against the name field.

## Verification

In the dev container against ui 5.12.1: vitest **1499 passed** (128 files), `typecheck` clean, eslint clean on changed files, prettier clean. Visually walked home, pages, editor, schedule (list + calendar), integrations and the drawer open/closed at 1440px and 390px, light and dark; confirmed drawer geometry (open: 12px inset on three sides; closed: fully off-screen).

Companion PR: Fiestaboard/FiestaUI#297 fixes the collapsed rail clipping the version footer to "v8.32.1" (library-side; independent of this one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)