### PR TITLE
ci(e2e): gate the merge queue on E2E, surface retry-masked flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -491,7 +491,20 @@ jobs:
     name: Build Test Image
     runs-on: ubuntu-latest
     needs: detect-changes
-    if: github.event_name == 'pull_request' && (needs.detect-changes.outputs.api == 'true' || needs.detect-changes.outputs.ui == 'true' || needs.detect-changes.outputs.shared == 'true')
+    # Runs on PRs *and* in the merge queue. The queue is the last gate before
+    # code reaches main and it tests the merged result, not the PR head; a
+    # PR-only gate lets two individually-green PRs land a semantic conflict
+    # that then surfaces as an "unrelated" E2E failure on the next branch to
+    # rebase. `plugins` is in the filter because plugin manifests drive the
+    # Integrations routes that integrations.spec.ts covers. Keep this gate
+    # identical across build-test-image and all four E2E jobs — the image
+    # build must be a superset of everything that consumes it.
+    if: >-
+      (github.event_name == 'pull_request' || github.event_name == 'merge_group')
+      && (needs.detect-changes.outputs.api == 'true'
+          || needs.detect-changes.outputs.ui == 'true'
+          || needs.detect-changes.outputs.plugins == 'true'
+          || needs.detect-changes.outputs.shared == 'true')
     timeout-minutes: 10
 
     # Builds the test Docker image once and warms the `build-test` GHA
@@ -541,7 +554,20 @@ jobs:
     name: E2E Tests
     runs-on: ubuntu-latest
     needs: [detect-changes, build-test-image]
-    if: github.event_name == 'pull_request' && (needs.detect-changes.outputs.api == 'true' || needs.detect-changes.outputs.ui == 'true' || needs.detect-changes.outputs.shared == 'true')
+    # Runs on PRs *and* in the merge queue. The queue is the last gate before
+    # code reaches main and it tests the merged result, not the PR head; a
+    # PR-only gate lets two individually-green PRs land a semantic conflict
+    # that then surfaces as an "unrelated" E2E failure on the next branch to
+    # rebase. `plugins` is in the filter because plugin manifests drive the
+    # Integrations routes that integrations.spec.ts covers. Keep this gate
+    # identical across build-test-image and all four E2E jobs — the image
+    # build must be a superset of everything that consumes it.
+    if: >-
+      (github.event_name == 'pull_request' || github.event_name == 'merge_group')
+      && (needs.detect-changes.outputs.api == 'true'
+          || needs.detect-changes.outputs.ui == 'true'
+          || needs.detect-changes.outputs.plugins == 'true'
+          || needs.detect-changes.outputs.shared == 'true')
     timeout-minutes: 15
 
     steps:
@@ -672,7 +698,7 @@ jobs:
       - name: Run E2E tests
         working-directory: web
         timeout-minutes: 10
-        run: npx playwright test --reporter=github
+        run: npx playwright test
         env:
           CI: true
           WORKER_URLS: ${{ env.WORKER_URLS }}
@@ -687,19 +713,40 @@ jobs:
             docker rm -f fiestaboard-$i mock-board-$i mock-cloud-$i 2>/dev/null || true
           done
 
+      - name: Report flaky tests
+        # Runs even when the suite failed: a run can have both a real failure
+        # and a retry-masked flake, and the flake is the one nothing else says.
+        if: ${{ !cancelled() }}
+        run: node scripts/summarize-playwright-flakes.mjs web/playwright-report.json e2e
+
       - name: Upload test results
         uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
           name: playwright-results
-          path: web/playwright-test-results/
+          path: |
+            web/playwright-test-results/
+            web/playwright-report.json
           retention-days: 7
 
   ai-mcp-e2e-tests:
     name: AI + MCP E2E Tests
     runs-on: ubuntu-latest
     needs: [detect-changes, build-test-image]
-    if: github.event_name == 'pull_request' && (needs.detect-changes.outputs.api == 'true' || needs.detect-changes.outputs.ui == 'true' || needs.detect-changes.outputs.shared == 'true')
+    # Runs on PRs *and* in the merge queue. The queue is the last gate before
+    # code reaches main and it tests the merged result, not the PR head; a
+    # PR-only gate lets two individually-green PRs land a semantic conflict
+    # that then surfaces as an "unrelated" E2E failure on the next branch to
+    # rebase. `plugins` is in the filter because plugin manifests drive the
+    # Integrations routes that integrations.spec.ts covers. Keep this gate
+    # identical across build-test-image and all four E2E jobs — the image
+    # build must be a superset of everything that consumes it.
+    if: >-
+      (github.event_name == 'pull_request' || github.event_name == 'merge_group')
+      && (needs.detect-changes.outputs.api == 'true'
+          || needs.detect-changes.outputs.ui == 'true'
+          || needs.detect-changes.outputs.plugins == 'true'
+          || needs.detect-changes.outputs.shared == 'true')
     timeout-minutes: 12
 
     steps:
@@ -822,7 +869,7 @@ jobs:
       - name: Run AI + MCP E2E tests
         working-directory: web
         timeout-minutes: 8
-        run: npx playwright test ai.spec.ts mcp.spec.ts --reporter=github --workers=1
+        run: npx playwright test ai.spec.ts mcp.spec.ts --workers=1
         env:
           CI: true
           RUN_AI_TESTS: "1"
@@ -843,19 +890,40 @@ jobs:
         run: |
           docker rm -f fiestaboard-ai mock-llm 2>/dev/null || true
 
+      - name: Report flaky tests
+        # Runs even when the suite failed: a run can have both a real failure
+        # and a retry-masked flake, and the flake is the one nothing else says.
+        if: ${{ !cancelled() }}
+        run: node scripts/summarize-playwright-flakes.mjs web/playwright-report.json ai-mcp
+
       - name: Upload test results
         uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
           name: playwright-ai-mcp-results
-          path: web/playwright-test-results/
+          path: |
+            web/playwright-test-results/
+            web/playwright-report.json
           retention-days: 7
 
   auth-e2e-tests:
     name: Auth E2E Tests
     runs-on: ubuntu-latest
     needs: [detect-changes, build-test-image]
-    if: github.event_name == 'pull_request' && (needs.detect-changes.outputs.api == 'true' || needs.detect-changes.outputs.ui == 'true' || needs.detect-changes.outputs.shared == 'true')
+    # Runs on PRs *and* in the merge queue. The queue is the last gate before
+    # code reaches main and it tests the merged result, not the PR head; a
+    # PR-only gate lets two individually-green PRs land a semantic conflict
+    # that then surfaces as an "unrelated" E2E failure on the next branch to
+    # rebase. `plugins` is in the filter because plugin manifests drive the
+    # Integrations routes that integrations.spec.ts covers. Keep this gate
+    # identical across build-test-image and all four E2E jobs — the image
+    # build must be a superset of everything that consumes it.
+    if: >-
+      (github.event_name == 'pull_request' || github.event_name == 'merge_group')
+      && (needs.detect-changes.outputs.api == 'true'
+          || needs.detect-changes.outputs.ui == 'true'
+          || needs.detect-changes.outputs.plugins == 'true'
+          || needs.detect-changes.outputs.shared == 'true')
     timeout-minutes: 10
 
     steps:
@@ -941,7 +1009,7 @@ jobs:
       - name: Run auth E2E tests
         working-directory: web
         timeout-minutes: 5
-        run: npx playwright test auth.spec.ts --reporter=github --workers=1
+        run: npx playwright test auth.spec.ts --workers=1
         env:
           CI: true
           RUN_AUTH_TESTS: "1"
@@ -955,19 +1023,40 @@ jobs:
         if: always()
         run: docker rm -f fiestaboard-auth 2>/dev/null || true
 
+      - name: Report flaky tests
+        # Runs even when the suite failed: a run can have both a real failure
+        # and a retry-masked flake, and the flake is the one nothing else says.
+        if: ${{ !cancelled() }}
+        run: node scripts/summarize-playwright-flakes.mjs web/playwright-report.json auth
+
       - name: Upload test results
         uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
           name: playwright-auth-results
-          path: web/playwright-test-results/
+          path: |
+            web/playwright-test-results/
+            web/playwright-report.json
           retention-days: 7
 
   ingress-e2e-tests:
     name: HA Ingress E2E Tests
     runs-on: ubuntu-latest
     needs: [detect-changes, build-test-image]
-    if: github.event_name == 'pull_request' && (needs.detect-changes.outputs.api == 'true' || needs.detect-changes.outputs.ui == 'true' || needs.detect-changes.outputs.shared == 'true')
+    # Runs on PRs *and* in the merge queue. The queue is the last gate before
+    # code reaches main and it tests the merged result, not the PR head; a
+    # PR-only gate lets two individually-green PRs land a semantic conflict
+    # that then surfaces as an "unrelated" E2E failure on the next branch to
+    # rebase. `plugins` is in the filter because plugin manifests drive the
+    # Integrations routes that integrations.spec.ts covers. Keep this gate
+    # identical across build-test-image and all four E2E jobs — the image
+    # build must be a superset of everything that consumes it.
+    if: >-
+      (github.event_name == 'pull_request' || github.event_name == 'merge_group')
+      && (needs.detect-changes.outputs.api == 'true'
+          || needs.detect-changes.outputs.ui == 'true'
+          || needs.detect-changes.outputs.plugins == 'true'
+          || needs.detect-changes.outputs.shared == 'true')
     timeout-minutes: 10
 
     steps:
@@ -1054,7 +1143,7 @@ jobs:
       - name: Run ingress E2E tests
         working-directory: web
         timeout-minutes: 5
-        run: npx playwright test ingress.spec.ts --reporter=github --workers=1
+        run: npx playwright test ingress.spec.ts --workers=1
         env:
           CI: true
           RUN_INGRESS_TESTS: "1"
@@ -1070,12 +1159,20 @@ jobs:
         if: always()
         run: docker rm -f fiestaboard ha-ingress-proxy 2>/dev/null || true; docker network rm ingress-net 2>/dev/null || true
 
+      - name: Report flaky tests
+        # Runs even when the suite failed: a run can have both a real failure
+        # and a retry-masked flake, and the flake is the one nothing else says.
+        if: ${{ !cancelled() }}
+        run: node scripts/summarize-playwright-flakes.mjs web/playwright-report.json ingress
+
       - name: Upload test results
         uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
           name: playwright-ingress-results
-          path: web/playwright-test-results/
+          path: |
+            web/playwright-test-results/
+            web/playwright-report.json
           retention-days: 7
 
   build:

--- a/scripts/summarize-playwright-flakes.mjs
+++ b/scripts/summarize-playwright-flakes.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+/**
+ * Surface Playwright tests that only passed because of a retry.
+ *
+ * `retries: 1` means a flaky test reports "1 flaky" in the log and the job
+ * still goes green, so nobody sees it. This reads the JSON reporter's output
+ * and turns each flaky spec into a GitHub annotation plus a row in the job
+ * summary, giving flakes a durable, greppable record before the suite grows.
+ *
+ * Usage: node scripts/summarize-playwright-flakes.mjs <report.json> [label]
+ *
+ * Always exits 0 — a flake is a signal to act on, not a reason to fail a job
+ * that Playwright already decided had passed.
+ */
+import { appendFileSync, readFileSync } from "node:fs";
+import { isAbsolute, relative } from "node:path";
+
+const [reportPath, label = "e2e"] = process.argv.slice(2);
+
+if (!reportPath) {
+  console.error("usage: summarize-playwright-flakes.mjs <report.json> [label]");
+  process.exit(0);
+}
+
+let report;
+try {
+  report = JSON.parse(readFileSync(reportPath, "utf8"));
+} catch (err) {
+  // A missing report means the run died before the reporter flushed (container
+  // never came up, step timeout). That is already loud elsewhere; don't add
+  // a second confusing failure here.
+  console.log(`[flakes] no readable report at ${reportPath}: ${err.message}`);
+  process.exit(0);
+}
+
+/**
+ * Spec `file` paths in the report are relative to `config.rootDir` (the
+ * resolved testDir), so they need a prefix before a GitHub annotation can
+ * anchor to them. In CI this step runs from the repo root and the relative
+ * path resolves exactly.
+ */
+function repoRelativeTestDir(rootDir) {
+  if (!rootDir) return "web/tests";
+  const rel = relative(process.cwd(), rootDir);
+  if (rel && !rel.startsWith("..") && !isAbsolute(rel)) return rel;
+  // Path mismatch — e.g. Playwright ran inside a container with the repo
+  // mounted at a different root. Recover the tail from the last `web/`.
+  const m = rootDir.match(/(?:^|\/)(web\/.*)$/);
+  return m ? m[1] : "web/tests";
+}
+
+/**
+ * Playwright puts ANSI colour codes in error messages; they are noise in an
+ * annotation. The ESC byte has to be part of the pattern — matching only
+ * `\[[0-9;]*m` leaves the ESC behind (invisible in a terminal, still in the
+ * string) and eats plain text like `array[2m]`.
+ */
+// eslint-disable-next-line no-control-regex
+const ANSI = /\u001b\[[0-9;]*m/g;
+
+/** Walk the nested suite tree and yield every spec with its owning file. */
+function* walkSpecs(suite, file) {
+  const currentFile = suite.file || file;
+  for (const spec of suite.specs ?? []) {
+    yield { spec, file: spec.file || currentFile };
+  }
+  for (const child of suite.suites ?? []) {
+    yield* walkSpecs(child, currentFile);
+  }
+}
+
+const testDir = repoRelativeTestDir(report.config?.rootDir);
+
+const flaky = [];
+for (const suite of report.suites ?? []) {
+  for (const { spec, file } of walkSpecs(suite)) {
+    for (const test of spec.tests ?? []) {
+      if (test.status !== "flaky") continue;
+      const failed = (test.results ?? []).find((r) => r.status !== "passed");
+      flaky.push({
+        title: spec.title,
+        file: file ? `${testDir}/${file}` : testDir,
+        line: spec.line,
+        attempts: (test.results ?? []).length,
+        error: (failed?.error?.message ?? "")
+          .replace(ANSI, "")
+          .split("\n")[0]
+          .slice(0, 200)
+          .trim(),
+      });
+    }
+  }
+}
+
+if (flaky.length === 0) {
+  console.log(`[flakes] ${label}: none`);
+  process.exit(0);
+}
+
+for (const f of flaky) {
+  // `::warning file=…` puts the flake on the PR diff next to the test.
+  console.log(`::warning file=${f.file},line=${f.line}::Flaky (${label}): ${f.title} — ${f.error}`);
+}
+
+const summary = process.env.GITHUB_STEP_SUMMARY;
+if (summary) {
+  // A `|` anywhere in a cell splits the markdown row, and test titles contain
+  // them at least as often as error messages do. Backslashes have to be
+  // escaped *first*: escaping only the pipe turns an input `\|` into `\\|`,
+  // an escaped backslash followed by a live pipe, which still breaks the row.
+  // A newline ends the row outright, so flatten those too.
+  const cell = (s) =>
+    String(s)
+      .replace(/\\/g, "\\\\")
+      .replace(/\|/g, "\\|")
+      .replace(/\r?\n/g, " ");
+  const rows = flaky
+    .map((f) => `| \`${cell(f.file)}:${f.line}\` | ${cell(f.title)} | ${f.attempts} | ${cell(f.error)} |`)
+    .join("\n");
+  appendFileSync(
+    summary,
+    `\n### ⚠️ Flaky tests (${label}): ${flaky.length}\n\n` +
+      `These passed only on retry. The job is green; the flake is not.\n\n` +
+      `| Spec | Test | Attempts | First failure |\n|---|---|---|---|\n${rows}\n`,
+  );
+}
+
+console.log(`[flakes] ${label}: ${flaky.length} test(s) passed only on retry`);

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -50,3 +50,4 @@ yarn-error.log*
 /playwright/.cache/
 /screenshot-results/
 /draw-mode-demo-results/
+/playwright-report.json

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -40,13 +40,18 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   workers: process.env.CI ? 4 : 1,
-  reporter: process.env.CI ? "github" : "list",
+  // `github` annotates the diff; the JSON report is what makes retried-and-
+  // passed tests visible. Without it a flake reports "1 flaky", the job goes
+  // green, and nothing durable records which test it was.
+  reporter: process.env.CI ? [["github"], ["json", { outputFile: "playwright-report.json" }]] : [["list"]],
   timeout: 30_000,
   globalSetup: "./tests/global-setup.ts",
 
   use: {
     baseURL: process.env.BASE_URL || "http://localhost:4420",
-    trace: "off",
+    // Only the retry carries a trace, so passing runs pay nothing and every
+    // CI failure arrives with a timeline instead of a lone screenshot.
+    trace: "on-first-retry",
     screenshot: "only-on-failure",
   },
 

--- a/web/tests/a11y.spec.ts
+++ b/web/tests/a11y.spec.ts
@@ -2,9 +2,11 @@
  * Accessibility regression tests.
  *
  * Runs axe-core against the main pages and fails on critical+serious
- * WCAG violations. Moderate/minor findings are reported but don't fail
- * CI so the test stays useful as a regression guard without blocking on
- * known cosmetic issues. To debug, set DEBUG_A11Y=1 to log every finding.
+ * WCAG violations. Moderate/minor findings never fail CI, so the test
+ * stays useful as a regression guard without blocking on known cosmetic
+ * issues — and they are not logged either, because printing the same
+ * never-actioned `heading-order` finding on every run drowned the E2E
+ * log. Set DEBUG_A11Y=1 to log every finding at every impact level.
  *
  * Pages covered:
  *   - /          Dashboard (with and without pages configured)
@@ -66,11 +68,24 @@ async function auditPage(page: Page, path: string, waitForSelector?: string) {
     sample: v.nodes.slice(0, 3).map((n) => n.target),
   }));
 
-  if (process.env.DEBUG_A11Y || summarised.length > 0) {
-    console.log(`[a11y] ${path}:`, JSON.stringify(summarised, null, 2));
-  }
-
   const failing = violations.filter((v) => FAIL_IMPACTS.has(v.impact || ""));
+
+  // Only speak up when the finding is one this test actually fails on, or when
+  // someone asked for everything. Logging every moderate violation on every
+  // run buried the E2E log in the same handful of never-actioned warnings and
+  // made real failures expensive to find.
+  if (process.env.DEBUG_A11Y) {
+    console.log(`[a11y] ${path}:`, JSON.stringify(summarised, null, 2));
+  } else if (failing.length > 0) {
+    console.log(
+      `[a11y] ${path}:`,
+      JSON.stringify(
+        summarised.filter((v) => FAIL_IMPACTS.has(v.impact || "")),
+        null,
+        2,
+      ),
+    );
+  }
   return { violations, failing };
 }
 

--- a/web/tests/helpers.ts
+++ b/web/tests/helpers.ts
@@ -561,6 +561,24 @@ export async function deleteAllSchedules(): Promise<void> {
   }
 }
 
+/**
+ * Turn schedule mode on or off for the primary board.
+ *
+ * Useful for pinning "no active page" deterministically: the render loop's
+ * "primary never goes dark" rule (src/main.py) auto-promotes the first page
+ * whenever the active page is null *in manual mode*, so a test that needs a
+ * genuinely empty active display should enable schedule mode with no matching
+ * schedules rather than race the loop's ~15s tick.
+ */
+export async function setScheduleEnabled(enabled: boolean): Promise<void> {
+  const res = await fetch(`${API_URL}/schedules/enabled`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json", ...authHeaders() },
+    body: JSON.stringify({ enabled }),
+  });
+  if (!res.ok) throw new Error(`setScheduleEnabled(${enabled}) failed: ${res.status}`);
+}
+
 /** Enable a plugin via the API. */
 export async function enablePlugin(id: string): Promise<void> {
   const res = await fetch(`${API_URL}/plugins/${id}/enable`, {

--- a/web/tests/mobile-critical-flows.spec.ts
+++ b/web/tests/mobile-critical-flows.spec.ts
@@ -181,27 +181,32 @@ test.describe("Mobile — Board preview fits viewport", () => {
     await page.goto("/");
     const firstTile = page.getByTestId("char-tile-0-0");
     await expect(firstTile).toBeVisible({ timeout: 15_000 });
-    // Let ScaledBoardDisplay's measure + rAF scale pass settle
-    await page.waitForTimeout(500);
 
-    const geometry = await page.evaluate(() => {
-      const t0 = document.querySelector('[data-testid="char-tile-0-0"]');
-      const t21 = document.querySelector('[data-testid="char-tile-0-21"]');
-      if (!t0 || !t21) return null;
-      const frame = t0.closest('[class*="border-["]');
-      if (!frame) return null;
-      const fr = frame.getBoundingClientRect();
-      const r0 = t0.getBoundingClientRect();
-      const r21 = t21.getBoundingClientRect();
-      return {
-        frameInViewport: fr.left >= 0 && fr.right <= window.innerWidth,
-        tilesInsideFrame: r0.left >= fr.left - 0.5 && r21.right <= fr.right + 0.5,
-      };
-    });
+    // ScaledBoardDisplay measures, then applies its scale on a rAF. A fixed
+    // sleep followed by a single measurement samples whatever the layout
+    // happened to be at that instant, which is what made this flaky on a
+    // loaded CI runner. Poll the measurement instead so a late scale pass is
+    // waited out rather than caught mid-flight.
+    const readGeometry = () =>
+      page.evaluate(() => {
+        const t0 = document.querySelector('[data-testid="char-tile-0-0"]');
+        const t21 = document.querySelector('[data-testid="char-tile-0-21"]');
+        if (!t0 || !t21) return null;
+        const frame = t0.closest('[class*="border-["]');
+        if (!frame) return null;
+        const fr = frame.getBoundingClientRect();
+        const r0 = t0.getBoundingClientRect();
+        const r21 = t21.getBoundingClientRect();
+        // A frame with no width means the scale pass has not run yet; report
+        // it as not-ready so the poll retries instead of asserting on zeroes.
+        if (fr.width === 0) return null;
+        return {
+          frameInViewport: fr.left >= 0 && fr.right <= window.innerWidth,
+          tilesInsideFrame: r0.left >= fr.left - 0.5 && r21.right <= fr.right + 0.5,
+        };
+      });
 
-    expect(geometry).not.toBeNull();
-    expect(geometry?.frameInViewport).toBe(true);
-    expect(geometry?.tilesInsideFrame).toBe(true);
+    await expect.poll(readGeometry, { timeout: 10_000 }).toEqual({ frameInViewport: true, tilesInsideFrame: true });
   });
 });
 

--- a/web/tests/page-builder.spec.ts
+++ b/web/tests/page-builder.spec.ts
@@ -9,9 +9,11 @@ import {
   configureBoard,
   createPage,
   deleteAllPages,
+  deleteAllSchedules,
   deletePage,
   expect,
   setActivePage,
+  setScheduleEnabled,
   suppressWizard,
   test,
   waitForNoActiveDisplay,
@@ -245,45 +247,54 @@ test.describe("Sync from Board", () => {
   });
 
   test("shows error when no active page is set", async ({ page }) => {
-    // Delete all pages and clear the active page. The backend auto-creates a
-    // default welcome page when the last page is deleted, so we cannot reach
-    // a truly empty state. Instead we clear active_page_id again immediately
-    // before clicking sync to collapse the window where the main loop (polling
-    // every ~15 s) could auto-promote the default page back to active.
+    // Reaching "no active display" is the whole setup cost of this test, and
+    // it used to be a race: deleting the last page makes the backend
+    // auto-create a Welcome page, and the render loop's "primary never goes
+    // dark" rule (src/main.py) re-promotes the first page to active on every
+    // ~15s tick whenever the active page is null. Clearing active_page_id and
+    // clicking fast enough to beat the next tick is what made this the single
+    // flakiest test in the suite.
+    //
+    // The loop's rule is guarded on manual mode, and GET /pages/current-display
+    // resolves through the schedule when schedule mode is on. So schedule mode
+    // with zero schedules is a *stable* no-active-display state that neither
+    // side will promote out from under us.
     await deleteAllPages();
-    await setActivePage(null);
+    await deleteAllSchedules();
+    await setScheduleEnabled(true);
 
-    await page.goto("/pages/new");
-    await expect(page.getByText("Create Page").first()).toBeVisible({
-      timeout: 15_000,
-    });
+    try {
+      await setActivePage(null);
+      // Now a cheap assertion rather than a race we hope to win.
+      await waitForNoActiveDisplay();
 
-    const syncBtn = page.getByRole("button", {
-      name: "Sync from current board display",
-    });
-    await expect(syncBtn).toBeVisible({ timeout: 10_000 });
+      await page.goto("/pages/new");
+      await expect(page.getByText("Create Page").first()).toBeVisible({
+        timeout: 15_000,
+      });
 
-    // Re-arm null active page immediately before clicking to prevent the main
-    // loop from auto-promoting the default page during the page-load wait above.
-    await setActivePage(null);
+      const syncBtn = page.getByRole("button", {
+        name: "Sync from current board display",
+      });
+      await expect(syncBtn).toBeVisible({ timeout: 10_000 });
 
-    // Block on confirmation that there is no active display server-side. This
-    // closes the race where the polling loop auto-promotes the Welcome page
-    // between the setActivePage(null) write and the click below.
-    await waitForNoActiveDisplay();
+      // Wait for the sync API response, then verify the error toast.
+      // We match on URL only (not status) so a 200 produces an assertion
+      // failure rather than a cryptic timeout.
+      const [response] = await Promise.all([
+        page.waitForResponse((res) => res.url().includes("/api/pages/current-display"), { timeout: 10_000 }),
+        syncBtn.click(),
+      ]);
+      expect(response.status()).toBe(404);
 
-    // Wait for the sync API response, then verify the error toast.
-    // We match on URL only (not status) so a 200 produces an assertion
-    // failure rather than a cryptic timeout.
-    const [response] = await Promise.all([
-      page.waitForResponse((res) => res.url().includes("/api/pages/current-display"), { timeout: 10_000 }),
-      syncBtn.click(),
-    ]);
-    expect(response.status()).toBe(404);
-
-    // An error toast should be visible — use text-based detection since Sonner
-    // toast attribute structure can vary between versions/configurations.
-    await expect(page.getByText("No active display to sync from").first()).toBeVisible({ timeout: 5_000 });
+      // An error toast should be visible — use text-based detection since Sonner
+      // toast attribute structure can vary between versions/configurations.
+      await expect(page.getByText("No active display to sync from").first()).toBeVisible({ timeout: 5_000 });
+    } finally {
+      // Specs in a file run serially against one backend; leaving schedule
+      // mode on would change what every later test in this file sees.
+      await setScheduleEnabled(false);
+    }
   });
 
   test("populates template lines from active page on successful sync", async ({ page }) => {


### PR DESCRIPTION
Prep work before the E2E suite expands, from eight days of CI history (200 runs, Aug 16–24).

The headline is that **the suite itself is honest** — all 7 E2E failures in the window traced to real breakage on the PR branch (`fix-code-62-glyph` ×4, `fiestaui-upgrade` ×2, `fix/design-polish` ×1), not noise. The problems are around it.

## 1. The merge queue never ran E2E

All four E2E jobs were gated on `github.event_name == 'pull_request'`. Measured over the window:

| Event | E2E Tests result |
| --- | --- |
| `merge_group` | skipped 28/28 |
| `push` (main) | skipped 56/56 |
| `pull_request` | 54 pass / 7 fail / 10 cancelled / 41 path-skipped |

And `ci-success` counts `skipped` as pass. So E2E only ever tested the **PR head**, never the merged result. Two individually-green PRs can land a semantic conflict whose first symptom is an "unrelated" E2E failure on the next branch to rebase — which reads as "flaky, rerun it."

`dorny/paths-filter` works correctly on `merge_group` (it diffs the queue head against the base — verified in run `32669959334`, which set `ui = true`), so the event gate was the only blocker.

The gate now admits `merge_group`, and also picks up `plugins`: plugin manifests drive the Integrations routes that `integrations.spec.ts`, `plugin-management.spec.ts` and `plugin-board-previews.spec.ts` cover, and a plugins-only PR previously skipped E2E entirely.

**Cost:** the merge queue gains ~7 min of wall clock on PRs that touch api/ui/plugins/shared. That is the price of the queue actually gating on E2E.

## 2. Flakes were invisible

`retries: 1` means a test that passes on retry reports `1 flaky` and the job goes green. That happened in **6 of 61 runs (9.8%)**, across four distinct tests:

| Test | Runs |
| --- | --- |
| `page-builder.spec.ts:247` — error when no active page | 2 |
| `mobile-critical-flows.spec.ts:180` — preview fits viewport | 2 |
| `note-pages.spec.ts:479` — centered 3×15 array | 1 |
| `multi-board.spec.ts:595` — Note board enables Note tab | 1 |

The reporter was `github` only and the uploaded artifact was screenshots, so there was no machine-readable record of which test flaked. At 570 tests you can spot it by eye; at 1200 you can't.

Now: a JSON reporter runs alongside `github`, and `scripts/summarize-playwright-flakes.mjs` turns each retry-masked pass into a `::warning` annotation on the test line plus a job-summary table. The JSON report is uploaded with the artifacts.

> **Note for reviewers:** `--reporter=github` had to come off all four CLI invocations. It *overrides* the config's reporter list rather than adding to it, so the JSON reporter would never have run.

## 3. Failures arrived as a lone screenshot

`trace: "off"` → `on-first-retry`. Passing runs pay nothing; every CI failure now arrives with a timeline. Confirmed working — the mutation run below produced `trace.zip` in the retry directory.

## 4. The two worst flakes, fixed at the cause

**`page-builder` "shows error when no active page is set"** raced the render loop. `src/main.py`'s *primary never goes dark* rule re-promotes `pages[0]` whenever the active page is null **in manual mode**, and the test tried to out-run the ~15s tick with three separate mitigations and still lost. That branch is guarded on manual mode, and `GET /pages/current-display` resolves through the schedule when schedule mode is on — so the test now uses **schedule mode with zero schedules**, a stable no-active-display state rather than a race. Restored in `finally` so it can't leak to later tests in the file.

**`mobile` "board preview stays inside its frame"** slept 500ms for `ScaledBoardDisplay`'s rAF scale pass and then measured once. Now polled with `expect.poll`, so a late scale pass is waited out instead of caught mid-flight. (748ms vs. the old mandatory 500ms sleep.)

## 5. `a11y.spec.ts` stopped shouting

It logged every moderate violation on every run, flooding each E2E log with the same never-actioned `heading-order` finding. It now logs only what it actually fails on. `DEBUG_A11Y=1` still shows everything.

---

## Verification

All against an isolated container stack (prod image built from this branch, mock board + mock cloud, port 4488), Playwright run from `mcr.microsoft.com/playwright:v1.62.1-noble`.

- **35 tests across the three touched specs pass serially.** `page-builder`'s full 11 pass, confirming the schedule-mode toggle is restored and does not leak.
- **The race, demonstrated directly.** With pages present and the service running:

  ```
  === MANUAL MODE (what the test used to rely on) ===
    t=10s  status=200  <-- active page was promoted back

  === SCHEDULE MODE, NO SCHEDULES (what the test does now) ===
    stayed 404 for the whole 60s
  ```

- **Non-vacuity, `page-builder`.** Mutating the container's `api_server.py` to return `200` instead of `404` for "No active page set":

  ```
  > 790 |   throw new Error("waitForNoActiveDisplay: an active display kept getting promoted");
    1 failed
      [chromium] › tests/page-builder.spec.ts:249:3 › Sync from Board › shows error when no active page is set
  ```

  Restored and re-run green.

- **Non-vacuity, `mobile`.** A throwaway spec defeating the inline scale transform — the #1397 regression this test exists to guard:

  ```
  -   "frameInViewport": true,
  +   "frameInViewport": false,
  ```

  Worth noting: my *first* mutation attempt (widening the tiles) correctly **passed**, because `ScaledBoardDisplay` scales to compensate. The component was doing its job; the mutation was wrong, not the test.

- **Non-vacuity, a11y logging.** 0 `[a11y]` lines by default, 6 with `DEBUG_A11Y=1`.

- **`summarize-playwright-flakes.mjs`** checked against a real flaky report and synthetic fixtures — nested suites, `regression/` subpaths, pipes in titles, real failures not miscounted as flaky, missing report exits 0. Two of its own bugs were found this way and fixed:
  - spec `file` paths are relative to `config.rootDir`, so the annotation pointed at a nonexistent path (`web/mobile-critical-flows.spec.ts`);
  - the ANSI strip matched `\[[0-9;]*m` without the ESC byte, leaving the raw ESC in the string (invisible in a terminal) and eating plain text like `array[2m]`.

- `tsc --noEmit` clean, `eslint` clean, `prettier --check` clean. `actionlint` reports **21 shellcheck findings on this branch and 21 on main** — no new ones.

## Not included

**Sharding.** At 572 tests the suite runs 3.7–6.7 min against a 10-minute step timeout — roughly 1.5× headroom. `.claude/ux-coverage.json` lists 147 uncovered + 48 partial UX nodes, so a serious expansion will hit that ceiling and want `--shard=i/N`. That is its own change, best done when the expansion actually approaches the limit.

Also unaddressed and worth knowing about: **89 `waitForTimeout` calls** across the suite (29 of them 3000ms) — each is either dead time or a future flake, and `resetBackend` only resets the mock board, leaving pages/schedules/board config to ad-hoc per-spec `beforeEach` cleanup. Both are fine at 30 spec files and will not be at 60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
