### PR TITLE
fix(ai): sanitise tool-block validation errors before streaming them (CodeQL #51)

### DIFF
--- a/src/ai/chat.py
+++ b/src/ai/chat.py
@@ -959,10 +959,19 @@ class _FenceParser:
         try:
             tool = parse_tool_call(parsed)
         except ToolCallValidationError as exc:
+            # ``parse_tool_call`` wraps *any* exception raised by
+            # ``model_validate``, so ``exc`` can carry a multi-line Pydantic
+            # report — or, if validation ever fails for an unexpected reason,
+            # internal detail that has no business on the wire. This handler
+            # is the source CodeQL traces into the SSE stream
+            # (``py/stack-trace-exposure``): keep the full text in the server
+            # log and send the client a bounded, single-line copy.
+            logger.warning("Invalid fiestaboard tool block: %s", exc)
+            detail = _user_safe_error_message(exc, fallback="schema validation failed")
             return [
                 {
                     "event": "warning",
-                    "data": {"message": f"Invalid fiestaboard tool block: {exc}"},
+                    "data": {"message": f"Invalid fiestaboard tool block: {detail}"},
                 }
             ]
 

--- a/src/ai/generator.py
+++ b/src/ai/generator.py
@@ -61,13 +61,19 @@ class AIGenerationError(Exception):
 _SAFE_ERROR_MESSAGE_RE = re.compile(r"[ -~]{1,500}")
 
 
-def _user_safe_error_message(exc: BaseException) -> str:
+def _user_safe_error_message(exc: BaseException, fallback: str = "AI provider error") -> str:
     """Return a curated, user-safe message from ``exc``.
 
     ``AIGenerationError`` instances carry curated single-line strings that
     are safe to show to API consumers.  This helper strips control
     characters / multi-line traceback fragments and bounds the length so
     static analysis sees a sanitized string flow, not raw exception data.
+
+    Args:
+        exc: The exception to derive a message from.
+        fallback: Returned when ``exc`` carries nothing usable.  Callers
+            outside the provider path pass their own wording so the
+            fallback still describes what actually failed.
     """
     raw = exc.args[0] if exc.args else ""
     candidate = raw if isinstance(raw, str) else ""
@@ -75,7 +81,7 @@ def _user_safe_error_message(exc: BaseException) -> str:
     candidate = candidate.replace("\n", " ").replace("\r", " ").replace("\t", " ").strip()
     match = _SAFE_ERROR_MESSAGE_RE.match(candidate)
     if not match:
-        return "AI provider error"
+        return fallback
     return match.group(0)
 
 

--- a/tests/ai/test_chat.py
+++ b/tests/ai/test_chat.py
@@ -466,6 +466,41 @@ def test_fence_parser_invalid_op_emits_warning():
     assert "Unknown tool op" in warnings[0]["data"]["message"]
 
 
+def test_fence_parser_schema_failure_does_not_leak_raw_exception_text():
+    """A validation failure reaches the client sanitized, not verbatim.
+
+    ``parse_tool_call`` wraps whatever ``model_validate`` raises, so the
+    exception text is a multi-line Pydantic report (and, for an unexpected
+    failure, could be arbitrary internal detail). The warning event is
+    streamed straight to the browser over SSE, so it must be a single
+    bounded line of printable ASCII — this is CodeQL's
+    ``py/stack-trace-exposure`` sink.
+    """
+    p = _FenceParser()
+    body = json.dumps(
+        {
+            "op": "apply_patch",
+            "args": {
+                "changes": [
+                    {"type": "replace_line", "index": "not-an-int", "text": "HI"},
+                    {"type": "replace_line", "index": -5, "text": 42},
+                ]
+            },
+        }
+    )
+    events = _events(p, f"```fiestaboard\n{body}\n```")
+
+    warnings = [e for e in events if e["event"] == "warning"]
+    assert len(warnings) == 1
+    message = warnings[0]["data"]["message"]
+    assert message.startswith("Invalid fiestaboard tool block: ")
+    # Single line, printable ASCII, bounded length. The raw Pydantic report
+    # is multi-line and unbounded; none of it may survive as-is.
+    assert "\n" not in message and "\r" not in message
+    assert all(" " <= ch <= "~" for ch in message)
+    assert len(message) <= len("Invalid fiestaboard tool block: ") + 500
+
+
 def test_fence_parser_unterminated_fence():
     p = _FenceParser()
     events = _events(p, "```fiestaboard\nstart of json...")


### PR DESCRIPTION
Closes CodeQL alert **#51** — `py/stack-trace-exposure` (medium), open since 11 May.

## What CodeQL actually found

The SARIF flow is unambiguous:

```
src/ai/chat.py:961   except ToolCallValidationError as exc     <- source
src/ai/chat.py:965   f"Invalid fiestaboard tool block: {exc}"
...                  -> warning event -> yielded from stream_chat
src/api_server.py:1490 _format_sse_event(...)
src/api_server.py:1501 event_source()                          <- sink (SSE body)
```

So the exposure is not a traceback — it is the exception's *text*. But
`parse_tool_call` does `except Exception as exc: raise ToolCallValidationError(str(exc))`,
so that text is whatever Pydantic (or anything else that goes wrong inside
`model_validate`) produced. Today that is a multi-line validation report echoing
the model's input values and a `errors.pydantic.dev` URL; tomorrow it is whatever
an unexpected failure inside validation says. None of it should be on the wire.

**Verdict: real, but low severity in context** — the content reaching the client
today is a schema report about the model's own output, not server internals. The
fix is cheap, so it is fixed rather than documented.

## The fix

- `src/ai/chat.py` — log the full report with `logger.warning`, and send the client
  `_user_safe_error_message(exc)`: a single bounded line of printable ASCII. This is
  the same barrier `stream_chat` already uses for `AIGenerationError` (which is why
  that path was never flagged).
- `src/ai/generator.py` — `_user_safe_error_message` grows an optional `fallback`
  so a non-provider caller does not have to say "AI provider error" for a schema
  failure.

No query was suppressed and no alert was dismissed.

## Regression test

`tests/ai/test_chat.py::test_fence_parser_schema_failure_does_not_leak_raw_exception_text`
feeds a tool block that fails schema validation and asserts the streamed warning is
single-line, printable ASCII, and length-bounded.

Proven non-vacuous — reverting only the `chat.py` handler and re-running:

```
tests/ai/test_chat.py:499: in test_fence_parser_schema_failure_does_not_leak_raw_exception_text
    assert "\n" not in message and "\r" not in message
E   AssertionError: assert ('\n' not in 'Invalid fie...r_than_equal'
E     '\n' is contained here:
E       args.changes.0.ReplaceLineOp.index
E         Input should be a valid integer, unable to parse string as an integer
E           [type=int_parsing, input_value='not-an-int', input_type=str]
E     ...Full output truncated (45 lines hidden)
FAILED tests/ai/test_chat.py::test_fence_parser_schema_failure_does_not_leak_raw_exception_text
1 failed, 46 deselected
```

With the fix restored: `223 passed` across `tests/ai/`, plus `ruff check` and
`ruff format --check` clean.

## Notes

- Deliberately does **not** touch `src/api_server.py`, so it cannot conflict with the
  FiestaPanel stack (#1775 / #1776).
- The existing wording `Unknown tool op: ...` is plain ASCII and passes through the
  barrier unchanged, so `test_fence_parser_invalid_op_emits_warning` still holds.