### PR TITLE
fix(tests): strip docs captures through the DOM, not with regexes (CodeQL #75/#76/#77)

### DIFF
--- a/web/src/__tests__/dom-capture.test.ts
+++ b/web/src/__tests__/dom-capture.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Regression tests for the docs-capture sanitiser.
+ *
+ * `stripInertMarkup` used to be four regexes over serialised markup, and
+ * CodeQL flagged three of them (`js/bad-tag-filter`,
+ * `js/incomplete-multi-character-sanitization`).
+ *
+ * Two cases here are the guards that would have caught those: a script whose
+ * own text carries an end tag, and an attribute value that reads as markup.
+ * Both fail against the regexes and pass against a parser. The rest pin down
+ * behaviour the capture output depends on — what must go, and what must
+ * survive — so a future rewrite cannot quietly change either.
+ *
+ * Vitest runs under jsdom, so `stripInertMarkup` gets a real parsed tree here
+ * exactly as it gets Chrome's in the capture path.
+ */
+import { describe, expect, it } from "vitest";
+
+import { normaliseVolatileIds, stripInertMarkup } from "../../tests/lib/dom-capture";
+
+/** Parse a fragment the way a browser would, and return its root element. */
+function parse(html: string): Element {
+  const host = document.createElement("div");
+  host.innerHTML = html;
+  return host;
+}
+
+describe("stripInertMarkup", () => {
+  it("removes a script whose own text contains an end tag", () => {
+    // Script text is serialised verbatim by both Chrome and jsdom, so a
+    // script carrying `</script>` in its body serialises as
+    // `<script></script></script>`. The old `<script\b[^>]*>[\s\S]*?<\/script>`
+    // stopped at the first end tag and left the trailing one behind, which is
+    // the `js/bad-tag-filter` finding. Removing the element cannot half-match.
+    const host = document.createElement("div");
+    const script = document.createElement("script");
+    script.textContent = "</script>";
+    host.append(document.createElement("p"), script);
+    host.querySelector("p")!.textContent = "keep me";
+
+    const out = stripInertMarkup(host);
+
+    expect(out.toLowerCase()).not.toContain("script");
+    expect(out).toContain("keep me");
+  });
+
+  it("removes inline handlers whatever their quoting or case", () => {
+    // Serialisation normalises quoting, so this pins the contract rather than
+    // reproducing a past failure: handlers go, and the elements stay.
+    const out = stripInertMarkup(parse(`<b ONCLICK="a()">x</b><i onmouseover='b()'>y</i><u onfocus=c()>z</u>`));
+
+    expect(out.toLowerCase()).not.toContain("onclick");
+    expect(out.toLowerCase()).not.toContain("onmouseover");
+    expect(out.toLowerCase()).not.toContain("onfocus");
+    expect(out).toContain(">x<");
+    expect(out).toContain(">y<");
+    expect(out).toContain(">z<");
+  });
+
+  it("leaves markup after a '>' inside an attribute value untouched", () => {
+    // Tailwind arbitrary variants put a bare '>' in class names. Chrome
+    // escapes it on the way out and jsdom does not, so this is the shape of
+    // input where `[^>]*` would end a tag match early.
+    const html = `<div class="has-[>svg]:px-2"><span onclick="x()" data-slot="label">keep me</span></div>`;
+    const out = stripInertMarkup(parse(html));
+
+    expect(out).toContain("keep me");
+    expect(out).toContain('data-slot="label"');
+    expect(out.toLowerCase()).not.toContain("onclick");
+  });
+
+  it("does not treat attribute text that looks like markup as markup", () => {
+    // A regex over serialised markup cannot tell an attribute value from an
+    // element, so the old sanitiser deleted the tags out of the middle of
+    // this title (`js/incomplete-multi-character-sanitization`).
+    const el = document.createElement("i");
+    el.setAttribute("title", "<script>zap</script>");
+    el.setAttribute("data-slot", "label");
+    el.textContent = "keep me";
+    const host = document.createElement("div");
+    host.append(el);
+
+    const out = stripInertMarkup(host);
+
+    expect(out).toContain("keep me");
+    expect(host.querySelector("i")!.getAttribute("title")).toBe("<script>zap</script>");
+    expect(out).toContain("zap");
+  });
+
+  it("removes tabindex, toasts, and caller-supplied attributes only", () => {
+    const html =
+      `<div tabindex="-1" data-slot="root" data-noise="1">` +
+      `<ol data-sonner-toaster><li>toast</li></ol>` +
+      `<span data-current-char="A">A</span></div>`;
+    const out = stripInertMarkup(parse(html), ["data-noise"]);
+
+    expect(out).not.toContain("tabindex");
+    expect(out).not.toContain("data-noise");
+    expect(out).not.toContain("toast");
+    // Attributes the render depends on must survive.
+    expect(out).toContain('data-slot="root"');
+    expect(out).toContain('data-current-char="A"');
+  });
+
+  it("leaves attributes that merely contain 'on' alone", () => {
+    const out = stripInertMarkup(parse(`<div data-online="yes" aria-orientation="vertical">x</div>`));
+
+    expect(out).toContain('data-online="yes"');
+    expect(out).toContain('aria-orientation="vertical"');
+  });
+});
+
+describe("normaliseVolatileIds", () => {
+  it("renumbers seeded UUIDs in first-appearance order, keeping them distinct", () => {
+    const html =
+      `<i id="a-3f2504e0-4f89-41d3-9a0c-0305e82c3301"></i>` +
+      `<i id="b-6ba7b810-9dad-11d1-80b4-00c04fd430c8"></i>` +
+      `<i id="c-3f2504e0-4f89-41d3-9a0c-0305e82c3301"></i>`;
+    const out = normaliseVolatileIds(html);
+
+    expect(out).not.toContain("3f2504e0");
+    expect(out).toContain("00000000-0000-4000-8000-000000000000");
+    expect(out).toContain("00000000-0000-4000-8000-000000000001");
+    // Same source id renumbers to the same target; different ids stay different.
+    expect(out.match(/00000000-0000-4000-8000-000000000000/g)).toHaveLength(2);
+  });
+
+  it("renumbers base-ui generated ids", () => {
+    const out = normaliseVolatileIds(`<i id="base-ui-_r_1a_"></i><i for="base-ui-_r_2b_"></i>`);
+
+    expect(out).not.toContain("base-ui-_r_");
+    expect(out).toContain("fb-c0");
+    expect(out).toContain("fb-c1");
+  });
+});

--- a/web/tests/lib/dom-capture.ts
+++ b/web/tests/lib/dom-capture.ts
@@ -63,44 +63,78 @@ export interface CaptureEntry {
 }
 
 /**
- * Strip what is provably inert, and normalise what is provably unstable.
+ * Strip what is provably inert, then serialise the subtree.
  *
- * Deliberately conservative. Measured against a real Settings capture, removing
- * every attribute that renders identically saves ~1% of the gzipped bytes — not
- * worth the risk of stripping something a Tailwind selector depends on. Note
- * that `data-slot` and `data-current-char`/`data-target-char` DO change the
- * render (they drive component styling and the split-flap tiles) and must
- * survive; so must `data-orientation` and `data-[state]`, which style tabs.
+ * Operates on a real parsed DOM — never on serialised markup. An earlier
+ * version did all four removals with regexes over the `outerHTML` string, and
+ * every one of them was wrong in the way HTML-stripping regexes always are:
+ * `/<script\b[^>]*>[\s\S]*?<\/script>/` does not match the perfectly legal
+ * `</script >`, `\son[a-z]+="[^"]*"` sees only double-quoted handlers, and a
+ * `>` inside an attribute value (Chrome serialises Tailwind's `has-[>svg]:`
+ * arbitrary variants literally) ends `[^>]*` early and lets the match run on
+ * through unrelated markup. CodeQL flagged all three as `js/bad-tag-filter`
+ * and `js/incomplete-multi-character-sanitization`; a parser has none of those
+ * failure modes, and `removeAttribute` cannot corrupt neighbouring markup.
+ *
+ * The same function runs in two places, which is the point: the capture path
+ * hands it a cloned subtree inside the browser (so serialisation stays
+ * Chrome's, byte-for-byte), and the unit tests hand it a jsdom tree. It must
+ * therefore stay self-contained — Playwright ships it to the page by source,
+ * so it may reference only DOM globals, never module scope.
+ *
+ * Deliberately conservative about what goes. Measured against a real Settings
+ * capture, removing every attribute that renders identically saves ~1% of the
+ * gzipped bytes — not worth the risk of stripping something a Tailwind
+ * selector depends on. Note that `data-slot` and
+ * `data-current-char`/`data-target-char` DO change the render (they drive
+ * component styling and the split-flap tiles) and must survive; so must
+ * `data-orientation` and `data-[state]`, which style tabs.
  *
  * `stripAttrs` may be extended per-screen by `verifyStripsAreSafe`, which
  * proves a candidate is neutral by re-rendering and comparing pixels.
  */
-export function sanitize(html: string, stripAttrs: readonly string[] = []): string {
-  let out = html;
-
+export function stripInertMarkup(root: Element, stripAttrs: readonly string[] = []): string {
   // React Router's streaming-hydration scripts come along with outerHTML and
   // throw ("Cannot read properties of undefined (reading 'streamController')")
   // in every docs page that embeds the capture. They can never do useful work
   // outside the app, so they always go.
-  out = out.replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, "");
+  root.querySelectorAll("script").forEach((el) => el.remove());
 
   // Toasts are transient by definition — one run caught a Sonner toast that
   // the next had already dismissed, so the capture differed by a whole
   // subtree. A notification that has already faded has no place in a docs
-  // screenshot regardless.
-  out = out.replace(/<ol\b[^>]*data-sonner-toaster[\s\S]*?<\/ol>/gi, "");
+  // screenshot regardless. `removeVolatileUi` already takes these out of the
+  // live page; this is the belt to that pair of braces.
+  root.querySelectorAll("[data-sonner-toaster], [data-sonner-toast]").forEach((el) => el.remove());
 
-  // Inline event handlers cannot fire (the capture is inert) but should not be
-  // shipped either.
-  out = out.replace(/\son[a-z]+="[^"]*"/gi, "");
+  const extra = new Set(stripAttrs.map((a) => a.toLowerCase()));
+  const scrub = (el: Element) => {
+    for (const name of el.getAttributeNames()) {
+      const lower = name.toLowerCase();
+      // Inline event handlers cannot fire (the capture is inert) but should
+      // not be shipped either. Nothing in a capture should be focusable
+      // (`inert` on the wrapper already enforces that; dropping `tabindex`
+      // keeps the markup honest).
+      if (/^on[a-z]+$/.test(lower) || lower === "tabindex" || extra.has(lower)) {
+        el.removeAttribute(name);
+      }
+    }
+    for (const child of Array.from(el.children)) scrub(child);
+  };
+  scrub(root);
 
-  // Nothing in a capture should be focusable; `inert` on the wrapper already
-  // enforces that, this keeps the markup honest.
-  out = out.replace(/\stabindex="[^"]*"/gi, "");
+  return root.outerHTML;
+}
 
-  for (const attr of stripAttrs) {
-    out = out.replace(new RegExp(`\\s${attr}="[^"]*"`, "gi"), "");
-  }
+/**
+ * Normalise the ids that churn between two identical runs.
+ *
+ * Pure string rewriting over already-serialised markup — no HTML parsing, and
+ * nothing here decides what is safe to ship. Structural removal is
+ * `stripInertMarkup`'s job and happens before serialisation.
+ */
+export function normaliseVolatileIds(html: string): string {
+  let out = html;
 
   // Entity ids are minted by the server every time the fixtures are seeded, so
   // the same page created by two runs carries two different UUIDs and every
@@ -201,11 +235,11 @@ async function settleBoards(page: Page, timeoutMs = 12_000) {
  * silently — it retries, then marks the entry `unstable` and warns, rather
  * than quietly committing churn.
  */
-async function readStable(page: Page) {
-  let last = await readScreen(page);
+async function readStable(page: Page, stripAttrs: readonly string[] = []) {
+  let last = await readScreen(page, stripAttrs);
   for (let attempt = 0; attempt < 3; attempt++) {
     await page.waitForTimeout(800);
-    const next = await readScreen(page);
+    const next = await readScreen(page, stripAttrs);
     if (next.html === last.html) return { ...next, unstable: false };
     last = next;
   }
@@ -242,25 +276,39 @@ async function fittedHeight(page: Page, width: number, fallback: number): Promis
   return Math.min(900, Math.max(600, natural));
 }
 
-/** Read the wrapper class + runtime vars + markup for the current viewport. */
-async function readScreen(page: Page) {
-  return page.evaluate(
+/**
+ * Read the wrapper class + runtime vars + markup for the current viewport.
+ *
+ * The subtree is CLONED before it is stripped, so the live page is never
+ * mutated — a test may take further shots after a capture — and serialisation
+ * stays Chrome's own, which is what keeps the committed captures free of
+ * re-serialisation churn.
+ */
+async function readScreen(page: Page, stripAttrs: readonly string[] = []) {
+  const meta = await page.evaluate(
     (vars: readonly string[]) => {
-      const root = document.querySelector("#root") ?? document.body;
       const cs = getComputedStyle(document.documentElement);
       const collected: Record<string, string> = {};
       for (const v of vars) {
         const value = cs.getPropertyValue(v).trim();
         if (value) collected[v] = value;
       }
-      return {
-        html: root.outerHTML,
-        wrapperClass: document.body.className,
-        vars: collected,
-      };
+      return { wrapperClass: document.body.className, vars: collected };
     },
     RUNTIME_VARS as unknown as string[],
   );
+
+  const clone = await page.evaluateHandle(
+    () => (document.querySelector("#root") ?? document.body).cloneNode(true) as Element,
+  );
+  try {
+    // `JSHandle.evaluate` calls the function in the page with the handle as its
+    // first argument, so `stripInertMarkup` runs against a real Chrome DOM.
+    const html = await clone.evaluate(stripInertMarkup, [...stripAttrs]);
+    return { html, ...meta };
+  } finally {
+    await clone.dispose();
+  }
 }
 
 /**
@@ -300,7 +348,7 @@ export async function captureScreen(
   // Prove the screen is settled BEFORE freezing the clock. Checking afterwards
   // is worthless — a paused clock makes anything look stable, including a demo
   // board frozen halfway through a flip.
-  const settled = await readStable(page);
+  const settled = await readStable(page, opts.stripAttrs);
 
   // Then stop the clock so timer-driven UI cannot change mid-capture. Paused
   // only for the duration of the capture — the PNG for this screen has already
@@ -340,13 +388,13 @@ export async function captureScreen(
     }
     // Let the breakpoint change settle before reading layout-derived vars.
     await page.waitForTimeout(400);
-    byViewport[label] = { ...(await readStable(page)), unstable: settled.unstable };
+    byViewport[label] = { ...(await readStable(page, opts.stripAttrs)), unstable: settled.unstable };
   }
   await page.setViewportSize(original);
   await page.clock.resume();
 
   const labels = Object.keys(CAPTURE_VIEWPORTS);
-  const sanitised = Object.fromEntries(labels.map((l) => [l, sanitize(byViewport[l].html, opts.stripAttrs)]));
+  const sanitised = Object.fromEntries(labels.map((l) => [l, normaliseVolatileIds(byViewport[l].html)]));
   const identical = labels.every((l) => sanitised[l] === sanitised[labels[0]]);
 
   fs.mkdirSync(outDir, { recursive: true });


### PR DESCRIPTION
Closes CodeQL alerts **#75**, **#76** (`js/incomplete-multi-character-sanitization`)
and **#77** (`js/bad-tag-filter`), all high, all opened 22 Aug with the DOM-capture work.

## Verdict: real defects, not reachable in context — fixed anyway because it is cheap

`sanitize()` did four removals with regexes over serialised markup:

```js
out = out.replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, "");
out = out.replace(/<ol\b[^>]*data-sonner-toaster[\s\S]*?<\/ol>/gi, "");
out = out.replace(/\son[a-z]+="[^"]*"/gi, "");
out = out.replace(/\stabindex="[^"]*"/gi, "");
```

Every finding is correct about the pattern:

- `<\/script>` does not match `</script >`, which is a legal end tag.
- Neither removal is idempotent, so a crafted input can leave `<script` behind.
- `[^>]*` assumes no `>` inside an attribute value.

What CodeQL cannot see is the input. This helper only ever receives Chrome's
`outerHTML` of the app's own DOM, captured in CI against seeded fixtures, and
Chrome escapes `<`, `>`, `&` and `"` in attribute values and `<`/`>` in text
(verified in Chromium, and visible in the committed captures as
`class="has-[&gt;svg]:px-2.5"`). So none of the three is reachable today, and
there is no attacker on this path — a test helper, fixtures, and a
human-reviewed capture PR.

That makes them low-risk, not wrong. The correct answer to a regex parsing HTML
is a parser, and there was one available the whole time.

## The fix

- `stripInertMarkup(root, stripAttrs)` does the removals on a real tree —
  `querySelectorAll("script")`, `querySelectorAll("[data-sonner-toaster], [data-sonner-toast]")`,
  `removeAttribute` for `on*` / `tabindex` / caller-supplied attributes — and returns
  `root.outerHTML`.
- `readScreen` clones the subtree **inside the page** and hands the clone to it. The
  live DOM is never mutated (a spec may take further shots after a capture), and
  serialisation stays Chrome's own.
- The remaining string work — UUID and base-ui id renumbering, which never parsed HTML —
  keeps its own name: `normaliseVolatileIds`.
- One implementation, two call sites: Playwright ships the function into the page via
  `JSHandle.evaluate`, and the unit tests call it against jsdom.

No query was suppressed and no alert was dismissed.

## Captures do not churn

The output is Chrome's serialisation of the same tree minus the same nodes, so the
committed captures are unaffected. Confirmed two ways: the current
`assets/docs-captures/*.html` contain no `<script`, no `on*=` handler, no `tabindex`
and no `sonner` residue for the new code to remove; and a Chromium run reproduces
`has-[&gt;svg]` escaping byte-for-byte. (For contrast, re-serialising the captures
through jsdom rewrites every one of them — parse5 does not escape `>` in attributes.
That is why the strip happens in the browser rather than in Node.)

## Regression test

`web/src/__tests__/dom-capture.test.ts` (vitest, jsdom). Two cases are the guards for
the flagged behaviour; proven non-vacuous by restoring the old regexes:

```
 × removes a script whose own text contains an end tag
   AssertionError: expected '<div><p>keep me</p></script></div>' not to contain 'script'
 × does not treat attribute text that looks like markup as markup
   AssertionError: expected '<div><i title="" data-slot="label">ke…' to contain 'zap'
 Tests  2 failed | 6 passed (8)
```

With the DOM implementation: `8 passed`, and `1547 passed | 7 skipped` across the full
`vitest run --coverage` suite. ESLint, Prettier and `tsc --noEmit` clean.

`clone.evaluate(stripInertMarkup, …)` was additionally exercised against real Chromium
through Playwright's own TypeScript loader, confirming the function ships to the page
intact and leaves the live page untouched — the one thing a jsdom unit test cannot show.

## Notes

- Touches only `web/`, so it cannot conflict with the FiestaPanel stack (#1775 / #1776).
- `docs-captures.yml` triggers on `web/tests/lib/dom-capture.ts`, so a capture run will
  fire on merge; it is expected to report "captures unchanged — nothing to open".