### PR TITLE
test(plugins): pin the git-ref allow-list behind CodeQL #56

### DIFF
--- a/tests/test_plugin_sources.py
+++ b/tests/test_plugin_sources.py
@@ -208,6 +208,60 @@ class TestGitUrlValidation:
         assert ok
 
 
+# ── _validate_git_ref ────────────────────────────────────────────────────────
+
+
+class TestValidateGitRef:
+    """The allow-list that keeps a user-supplied branch safe as a git argument.
+
+    ``POST /plugins/install`` lets a caller name a branch, and that value ends
+    up as the last element of ``["git", "fetch", "--depth=1", "origin", ...]``.
+    Nothing is escaped anywhere, and nothing needs to be: ``subprocess.run``
+    gets a list with ``shell=False``, so there is no shell to inject into, and
+    this allow-list is what stops the value being read as an *option* instead.
+
+    CodeQL reports the fetch as ``py/command-line-injection`` (alert #56)
+    because it cannot see this guard. These tests pin the properties that make
+    that a false positive, so it cannot quietly stop being one.
+    """
+
+    def test_rejects_option_like_ref(self):
+        """A leading '-' would make git parse the branch as a flag."""
+        from src.plugins.sources import _validate_git_ref
+
+        for ref in ("--upload-pack=touch /tmp/pwned", "-o", "--exec=sh"):
+            ok, _ = _validate_git_ref(ref)
+            assert not ok, f"option-like ref {ref!r} must be rejected"
+
+    def test_rejects_shell_metacharacters_and_whitespace(self):
+        from src.plugins.sources import _validate_git_ref
+
+        for ref in ("main; rm -rf /", "main && id", "main|id", "$(id)", "`id`", "main branch", "main\nx"):
+            ok, _ = _validate_git_ref(ref)
+            assert not ok, f"ref {ref!r} must be rejected"
+
+    def test_rejects_traversal_and_refspec_punctuation(self):
+        from src.plugins.sources import _validate_git_ref
+
+        for ref in ("../../etc/passwd", "refs/heads/a..b", "a//b", "main:refs/heads/hijack"):
+            ok, _ = _validate_git_ref(ref)
+            assert not ok, f"ref {ref!r} must be rejected"
+
+    def test_rejects_non_strings_and_empty(self):
+        from src.plugins.sources import _validate_git_ref
+
+        assert not _validate_git_ref(None)[0]
+        assert not _validate_git_ref(["main"])[0]
+        assert not _validate_git_ref("")[0]
+
+    def test_accepts_ordinary_branch_and_tag_names(self):
+        from src.plugins.sources import _validate_git_ref
+
+        for ref in ("main", "develop", "release/1.2.3", "v8.32.16", "feat_x-1"):
+            ok, err = _validate_git_ref(ref)
+            assert ok, f"ref {ref!r} should be accepted, got {err!r}"
+
+
 # ── clone_or_update_repo ─────────────────────────────────────────────────────
 
 
@@ -253,6 +307,24 @@ class TestCloneOrUpdateRepo:
         fetch_cmd = mock_run.call_args_list[1][0][0]
         assert "fetch" in fetch_cmd
         assert fetch_cmd[-1] == "develop", "Explicit branch should be the final fetch argument"
+
+    @mock.patch("src.plugins.sources.subprocess.run")
+    def test_rejects_option_like_branch_before_running_git(self, mock_run, tmp_path):
+        """A branch git could read as an option never reaches a subprocess.
+
+        This is the sink CodeQL flags as py/command-line-injection (#56). The
+        argv is a list and there is no shell, so the only real risk is option
+        injection — and the branch is refused before any git runs at all.
+        """
+        ok, err = clone_or_update_repo(
+            "https://github.com/Org/repo",
+            "my_plugin",
+            branch="--upload-pack=touch /tmp/pwned",
+            external_dir=tmp_path,
+        )
+        assert not ok
+        assert "Invalid branch/tag" in err
+        mock_run.assert_not_called()
 
     @mock.patch("src.plugins.sources.subprocess.run")
     def test_fetch_reset_existing(self, mock_run, tmp_path):


### PR DESCRIPTION
Support for dismissing CodeQL alert **#56** — `py/command-line-injection`, critical,
open since 5 June. **No production code changes.**

## Why the alert is a false positive

The SARIF flow is:

```
src/api_server.py:9710   request                       <- POST /plugins/install body
src/api_server.py:9720   safe_branch
src/plugins/registry.py:1414 branch
src/plugins/sources.py:942 -> 852 -> 313
src/plugins/sources.py:436  _fetch_cmd.append(branch)
src/plugins/sources.py:440  subprocess.run(_fetch_cmd)  <- sink
```

So the tainted value is `branch`, and it is the *only* tainted element in that
argv — `repo_url` is deliberately kept out of every subprocess call by writing it
to `.git/config` instead.

Two things make the sink safe, neither of which CodeQL can see:

1. **No shell.** `subprocess.run(["git", "fetch", "--depth=1", "origin", branch], ...)`
   is a list with `shell=False`, so metacharacters have no meaning. Escaping would
   be the wrong fix here; there is nothing to escape *for*.
2. **No option injection.** The residual risk with an argv is a value git reads as
   a flag (`--upload-pack=...` is the classic plugin-fetch RCE). `GIT_REF_RE` is
   `^(?!-)(?!.*\.\.)(?!.*//)[A-Za-z0-9._/-]{1,255}$` — anchored, `fullmatch`, no
   leading `-`, no whitespace, no shell metacharacters, no `..`, no `//`, and no
   `:` so a refspec cannot be smuggled in either.

`branch` is validated twice: at the endpoint (`install_external_plugin`, which 400s
before calling the registry) and again in `clone_or_update_repo` before the fetch
command is built. The registry path (`entry.branch`, read from the in-repo
`plugin-registry.json`) goes through the same guard.

## What this PR adds

The argument above rests entirely on one regex that a future edit could loosen
without a single test noticing — which is exactly how a dismissed alert becomes a
real one. So the properties are now pinned:

- `TestValidateGitRef` — option-like refs, shell metacharacters, whitespace,
  `..`, `//` and refspec `:` are rejected; ordinary branch/tag names
  (`main`, `release/1.2.3`, `v8.32.16`) are accepted; non-strings and `""` are rejected.
- `TestCloneOrUpdateRepo::test_rejects_option_like_branch_before_running_git` —
  `clone_or_update_repo(..., branch="--upload-pack=touch /tmp/pwned")` returns
  `Invalid branch/tag` and `subprocess.run` is never called.

Proven non-vacuous. Relaxing `GIT_REF_RE` to `^[^\s]{1,255}$` fails 5 of the 6:

```
FAILED tests/test_plugin_sources.py::TestValidateGitRef::test_rejects_option_like_ref
FAILED tests/test_plugin_sources.py::TestValidateGitRef::test_rejects_shell_metacharacters_and_whitespace
FAILED tests/test_plugin_sources.py::TestValidateGitRef::test_rejects_traversal_and_refspec_punctuation
FAILED tests/test_plugin_sources.py::TestValidateGitRef::test_accepts_ordinary_branch_and_tag_names
FAILED tests/test_plugin_sources.py::TestCloneOrUpdateRepo::test_rejects_option_like_branch_before_running_git
5 failed, 1 passed
```

(The sixth, `test_rejects_non_strings_and_empty`, guards the `isinstance` check
rather than the pattern, so it correctly survives that mutation.)

With the real pattern: all 6 pass, `ruff check` and `ruff format --check` clean, and
`tests/test_plugin_sources.py` goes from 83 to 89 passing with no change to the
pre-existing failure set.

Alert #56 is dismissed as a false positive once this lands.