### PR TITLE
fix(release): keep web/package-lock.json's version with the manifest's

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,7 +153,7 @@ jobs:
       - name: Commit version bump
         id: commit
         run: |
-          git add package.json web/package.json src/__init__.py
+          git add package.json web/package.json web/package-lock.json src/__init__.py
           git commit -m "chore: bump version to ${{ steps.version.outputs.version }} [skip ci]"
 
           # Push with retry to handle transient failures or rare race conditions

--- a/scripts/version-sync.js
+++ b/scripts/version-sync.js
@@ -6,6 +6,7 @@
  * Synchronizes version across multiple files:
  * - package.json (root)
  * - web/package.json
+ * - web/package-lock.json (root version fields only)
  * - src/__init__.py
  * 
  * Usage:
@@ -22,6 +23,7 @@ const path = require('path');
 const ROOT_DIR = path.join(__dirname, '..');
 const ROOT_PACKAGE_JSON = path.join(ROOT_DIR, 'package.json');
 const WEB_PACKAGE_JSON = path.join(ROOT_DIR, 'web', 'package.json');
+const WEB_PACKAGE_LOCK = path.join(ROOT_DIR, 'web', 'package-lock.json');
 const PYTHON_INIT_FILE = path.join(ROOT_DIR, 'src', '__init__.py');
 
 /**
@@ -86,6 +88,29 @@ function readJsonFile(filePath) {
 function writeJsonFile(filePath, data) {
   const content = JSON.stringify(data, null, 2) + '\n';
   fs.writeFileSync(filePath, content, 'utf8');
+}
+
+/**
+ * Update the root version fields in web/package-lock.json.
+ *
+ * npm records the manifest's own version twice in the lockfile — at the top
+ * level and again under packages[""] — and leaving them behind makes the
+ * lockfile disagree with the manifest it was generated from. Only those two
+ * fields are touched; the dependency tree is npm's to write, so this never
+ * needs an install.
+ */
+function updateLockVersion(filePath, newVersion) {
+  const lock = readJsonFile(filePath);
+  const oldVersion = lock.version;
+
+  lock.version = newVersion;
+  if (lock.packages && lock.packages['']) {
+    lock.packages[''].version = newVersion;
+  }
+
+  writeJsonFile(filePath, lock);
+
+  return oldVersion;
 }
 
 /**
@@ -158,6 +183,15 @@ function main() {
     console.log(`✅ Updated ${path.relative(ROOT_DIR, WEB_PACKAGE_JSON)}: ${oldWebVersion} → ${newVersion}`);
   } else {
     console.log(`✓  ${path.relative(ROOT_DIR, WEB_PACKAGE_JSON)}: ${newVersion} (unchanged)`);
+  }
+
+  // Update web/package-lock.json
+  const oldLockVersion = updateLockVersion(WEB_PACKAGE_LOCK, newVersion);
+
+  if (oldLockVersion !== newVersion) {
+    console.log(`✅ Updated ${path.relative(ROOT_DIR, WEB_PACKAGE_LOCK)}: ${oldLockVersion} → ${newVersion}`);
+  } else {
+    console.log(`✓  ${path.relative(ROOT_DIR, WEB_PACKAGE_LOCK)}: ${newVersion} (unchanged)`);
   }
   
   // Update src/__init__.py

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "8.33.0",
+  "version": "8.33.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "8.33.0",
+      "version": "8.33.2",
       "dependencies": {
         "@codemirror/commands": "^6.11.0",
         "@codemirror/language": "^6.12.4",


### PR DESCRIPTION
## The bug

The release job bumps `package.json`, `web/package.json` and `src/__init__.py`, then stages exactly those three:

```
git add package.json web/package.json src/__init__.py
```

Nothing writes the version npm records in `web/package-lock.json` — once at the top level, once under `packages[""]`. So the lockfile drifts behind every release, and only snapped back whenever Dependabot happened to regenerate it. It had reached **8.33.0 against a manifest at 8.33.2** on `main`, widening with each release cut tonight.

## The fix

`version-sync.js` now writes those two fields, and `release.yml` stages the lockfile alongside the files it already bumps. Only the version fields are touched — the dependency tree stays npm's to write, so this needs no install and the rest of the 20k-line file is byte-identical (the lockfile diff below is 2 lines each way).

The lockfile change in this PR heals the drift standing on `main` today.

## Verified

- `node scripts/version-sync.js` with no bump heals existing drift; the lockfile diff is exactly the two version fields.
- `node scripts/version-sync.js patch` moves all four files together (8.33.2 → 8.33.3).
- `npm ci --legacy-peer-deps --no-audit --dry-run` in `web/` resolves clean against the edited lockfile — the same flags CI installs with.

> Plain `npm ci` in `web/` fails on an ERESOLVE, but that is pre-existing and unrelated to this change: `eslint@^10` is installed while `eslint-plugin-jsx-a11y@6.10.2` and `eslint-plugin-react@7.37.5` both cap at eslint 9. CI already works around it with `--legacy-peer-deps`, as the comment at `ci.yml:339` anticipates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VX138nCzUMdFV51WM5Hz4E