### PR TITLE
fix(silence): per-board silence schedules

### DIFF
--- a/docs/features/home-assistant-control.md
+++ b/docs/features/home-assistant-control.md
@@ -128,7 +128,7 @@ is never rewritten.
 |--------|------|-------------|
 | **Current Page** | Sensor | Name of the page currently displayed. *Includes JSON attributes (page_id, page_index).* |
 | **Board Message** | Sensor | Summary of what's currently on the board |
-| **Silence Mode** | Binary Sensor | Whether silence/quiet hours are active |
+| **Silence Mode** | Binary Sensor | Whether quiet hours are active on the **primary** board (silence is per board — see [Silence Schedule](./silence-schedule.md)) |
 | **Page Count** | Sensor | Number of pages configured *(state_class: measurement)* |
 
 ### Diagnostics (device health and info, grouped separately in HA)

--- a/docs/features/silence-schedule.md
+++ b/docs/features/silence-schedule.md
@@ -19,20 +19,33 @@ Split-flap displays can be noisy when updating. The silence schedule ensures you
 ### Via the Web UI
 
 1. Open the FiestaBoard Web UI at `http://localhost:4420`
-2. Go to **Settings**
+2. Go to **Settings** → **Behavior**
 3. Find the **Silence Schedule** section
 4. Set your **Start Time** and **End Time**
 5. Save your settings
 
-### Via Environment Variables
+Settings save automatically a second after you stop typing.
 
-You can also configure silence hours in your `.env` file:
+## Multiple Boards
 
-```bash
-# Silence Schedule
-SILENCE_SCHEDULE_START_TIME=22:00    # 10:00 PM
-SILENCE_SCHEDULE_END_TIME=07:00      # 7:00 AM
-```
+Silence settings are **per board**. If you run a Flagship in the living room
+and a Note on your desk, each keeps its own quiet hours, its own silence mode,
+and its own silence page — the Flagship can go quiet at 10 PM while the Note
+stays live, and each can show a page sized for its own display.
+
+Pick the board you want with the board selector in the sidebar, then edit the
+Silence Schedule card; you are editing that board's settings.
+
+A few things follow from this:
+
+- **A board you have not configured inherits the install-wide schedule.** That
+  is the schedule you had before you ever touched a second board, so upgrading
+  changes nothing: every existing board keeps the quiet hours it already had.
+  A board you add later starts out quiet during the same window rather than
+  flipping at 3 AM.
+- **The silence page picker only offers pages that fit that board.** A 22×6
+  Flagship page cannot be chosen for a 15×3 Note.
+- **Single-board installs see no difference.** There is just the one schedule.
 
 ## How It Works
 
@@ -45,11 +58,14 @@ how to handle the board based on the configured **silence mode**:
 | **Leave board unchanged** | The board is left exactly as it was — no further updates are sent until silence ends. |
 | **Show a specific page** | A page you choose is rendered once when silence begins and frozen on the board. Template variables are not refreshed until silence ends. |
 
+The mode is chosen per board, and so is the page: the silence page is always
+rendered at the size of the board it is being sent to.
+
 Regardless of which mode you pick:
 
-- The display service stops sending refresh updates while silenced
+- The display service stops sending refresh updates to that board while it is silenced
 - The web UI and API continue to function normally
-- Scheduled pages are skipped during silence hours
+- Scheduled pages are skipped during that board's silence hours
 
 When the silence window ends:
 
@@ -62,19 +78,17 @@ The silence schedule uses your configured timezone (`TIMEZONE` in `.env`). Make 
 
 ## Example Configurations
 
-### Nighttime Quiet Hours
+| Goal | Start Time | End Time |
+| --- | --- | --- |
+| Nighttime quiet hours | `22:00` (10 PM) | `07:00` (7 AM) |
+| Quiet outside office hours | `18:00` (6 PM) | `08:00` (8 AM) |
 
-```bash
-SILENCE_SCHEDULE_START_TIME=22:00    # Board goes quiet at 10 PM
-SILENCE_SCHEDULE_END_TIME=07:00      # Board resumes at 7 AM
-```
-
-### Office Hours Only
-
-```bash
-SILENCE_SCHEDULE_START_TIME=18:00    # Quiet after 6 PM
-SILENCE_SCHEDULE_END_TIME=08:00      # Resume at 8 AM
-```
+:::caution
+`SILENCE_SCHEDULE_START_TIME` and `SILENCE_SCHEDULE_END_TIME` appear in
+`env.example`, but the display service does not read them — they are written
+to a config key nothing consumes. Set your quiet hours in the Web UI (or via
+`PUT /settings/silence-schedule`) instead.
+:::
 
 ## Next Steps
 

--- a/docs/features/silence-schedule.md
+++ b/docs/features/silence-schedule.md
@@ -53,7 +53,8 @@ A few things follow from this:
   say it should be asleep.
 - **The Home Assistant `silence_mode` sensor reports the primary board.** Like
   the other entities in that payload (active page, transition style), it
-  describes the primary board rather than the install as a whole.
+  describes the primary board rather than the install as a whole. The same is
+  true of `GET /silence-status` when you do not name a board.
 
 ## How It Works
 

--- a/docs/features/silence-schedule.md
+++ b/docs/features/silence-schedule.md
@@ -45,7 +45,15 @@ A few things follow from this:
   flipping at 3 AM.
 - **The silence page picker only offers pages that fit that board.** A 22×6
   Flagship page cannot be chosen for a 15×3 Note.
-- **Single-board installs see no difference.** There is just the one schedule.
+- **Single-board installs see no difference.** There is just the one board, so
+  its schedule is the schedule.
+- **Manual sends respect the target board's window.** Sending a message or a
+  page from the Web UI, the API, or Home Assistant is blocked while *that*
+  board is silenced, so a 2 AM send cannot wake a board whose own quiet hours
+  say it should be asleep.
+- **The Home Assistant `silence_mode` sensor reports the primary board.** Like
+  the other entities in that payload (active page, transition style), it
+  describes the primary board rather than the install as a whole.
 
 ## How It Works
 

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -152,7 +152,7 @@ pickers filter to the boards they're compatible with (see
 | `end_time` | string | Window end, UTC ISO |
 | `mode` | string | `"freeze"` (default), `"indicator"`, or `"page"` |
 | `page_id` | string \| null | Page shown when `mode` is `"page"`. Required in that mode, and validated against the target board's size |
-| `indicator_text` | string \| null | Text shown when `mode` is `"indicator"`. Uppercased; defaults to `SNOOZING` |
+| `indicator_text` | string \| null | Text shown when `mode` is `"indicator"`. Trimmed and forced to uppercase; defaults to `SNOOZING` |
 | `indicator_position` | string \| null | `"center"` (default), `"top-left"`, `"top-right"`, `"bottom-left"`, `"bottom-right"` |
 | `board_id` | string | Optional. Unknown board → `404`. **Note the exception below** |
 

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -156,13 +156,23 @@ pickers filter to the boards they're compatible with (see
 | `indicator_position` | string \| null | `"center"` (default), `"top-left"`, `"top-right"`, `"bottom-left"`, `"bottom-right"` |
 | `board_id` | string | Optional. Unknown board → `404`. **Note the exception below** |
 
-Silence is the one per-board setting where omitting `board_id` does *not*
-mean "the primary board": it writes the **install-wide** schedule, which every
-board without its own override resolves to. That way an existing install keeps
-one set of quiet hours until you deliberately give a board its own, and a board
-you add later inherits the install's quiet hours rather than staying loud.
-`GET /silence-status?board_id=` returns the resolved values for that board and
-echoes `board_id` back.
+Reads and writes here use `board_id` differently, on purpose:
+
+- **`PUT /settings/silence-schedule` without `board_id`** writes the
+  **install-wide** schedule — the default every board without its own override
+  resolves to. That is how an existing install keeps one set of quiet hours
+  until you deliberately give a board its own, and how a board you add later
+  inherits the install's quiet hours rather than staying loud. On an install
+  with exactly one board there is no such distinction, so the write also drops
+  that board's override rather than leaving it to shadow what you just saved.
+- **`GET /silence-status` without `board_id`** reports the **primary** board,
+  like every other status and send guard. It answers "is silence on right
+  now?", so it has to describe a board rather than a config layer. The response
+  echoes the board it describes. To read the install-wide layer itself, use
+  `GET /settings/all` → `silence_schedule.config`, which includes `by_board`.
+
+With `board_id`, both resolve that board: its own entry wins key by key, and
+anything it does not define falls back to the install-wide values.
 
 #### Board Instance Fields
 

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -123,6 +123,8 @@ pickers filter to the boards they're compatible with (see
 | `DELETE` | `/settings/board/{id}` | Remove a board instance |
 | `GET` | `/settings/active-page` | Get a board's active page id (`?board_id=`) |
 | `PUT` | `/settings/active-page` | Set a board's active page (renders and sends immediately) |
+| `GET` | `/silence-status` | Get a board's silence schedule status (`?board_id=`) |
+| `PUT` | `/settings/silence-schedule` | Set a board's silence schedule (`board_id` in the body) |
 | `POST` | `/pages/{id}/send` | Send a page (`?target=board&board_id=`) |
 | `GET` | `/board/current-message` | Read a board's current display (`?board_id=`) |
 
@@ -140,6 +142,27 @@ pickers filter to the boards they're compatible with (see
 |-------|------|-------------|
 | `page_id` | string \| null | Page (or collection) id to activate, or `null` to clear |
 | `board_id` | string | Optional. Omitted → primary board (legacy behavior) |
+
+#### `PUT /settings/silence-schedule` — request body fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `enabled` | boolean | Whether silence is on for this board |
+| `start_time` | string | Window start, UTC ISO (e.g. `"04:00+00:00"`) |
+| `end_time` | string | Window end, UTC ISO |
+| `mode` | string | `"freeze"` (default), `"indicator"`, or `"page"` |
+| `page_id` | string \| null | Page shown when `mode` is `"page"`. Required in that mode, and validated against the target board's size |
+| `indicator_text` | string \| null | Text shown when `mode` is `"indicator"`. Uppercased; defaults to `SNOOZING` |
+| `indicator_position` | string \| null | `"center"` (default), `"top-left"`, `"top-right"`, `"bottom-left"`, `"bottom-right"` |
+| `board_id` | string | Optional. Unknown board → `404`. **Note the exception below** |
+
+Silence is the one per-board setting where omitting `board_id` does *not*
+mean "the primary board": it writes the **install-wide** schedule, which every
+board without its own override resolves to. That way an existing install keeps
+one set of quiet hours until you deliberately give a board its own, and a board
+you add later inherits the install's quiet hours rather than staying loud.
+`GET /silence-status?board_id=` returns the resolved values for that board and
+echoes `board_id` back.
 
 #### Board Instance Fields
 

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -3450,8 +3450,10 @@ async def send_message(request: MessageRequest):
     if not service:
         raise HTTPException(status_code=503, detail="Service not initialized")
 
-    # CRITICAL: Block ALL manual sends during silence mode to prevent wake-ups
-    if Config.is_silence_mode_active():
+    # CRITICAL: Block ALL manual sends during silence mode to prevent wake-ups.
+    # This path drives the primary board's client, so it must resolve the
+    # primary board's window (issue #1788).
+    if _silence_active():
         logger.info("Silence mode is active - blocking manual message send to prevent wake-up")
         return {
             "status": "blocked",
@@ -3603,8 +3605,9 @@ async def send_welcome_message():
     """
     from .board_client import BoardClient
 
-    # Check silence mode
-    if Config.is_silence_mode_active():
+    # Check silence mode for the board this actually writes to (the primary
+    # board — the wizard has no board picker).
+    if _silence_active():
         logger.info("Silence mode is active - blocking welcome message to prevent wake-up")
         return {"status": "blocked", "message": "Welcome message blocked during silence mode", "silence_mode": True}
 
@@ -5877,7 +5880,7 @@ async def run_live_transition_test(request: dict):
 
     board, board_client = _resolve_live_board_client(board_id)
 
-    if Config.is_silence_mode_active():
+    if _silence_active(board_id):
         raise HTTPException(status_code=409, detail="Silence mode is active - live test blocked")
     if _board_is_paused(board_id):
         raise HTTPException(status_code=409, detail="Board is paused - live test blocked")
@@ -5971,7 +5974,7 @@ async def restore_after_transition_test(request: dict | None = None):
 
     board, board_client = _resolve_live_board_client(board_id)
 
-    if Config.is_silence_mode_active():
+    if _silence_active(board_id):
         raise HTTPException(status_code=409, detail="Silence mode is active - restore blocked")
     if _board_is_paused(board_id):
         raise HTTPException(status_code=409, detail="Board is paused - restore blocked")
@@ -7144,6 +7147,27 @@ def _board_is_paused(board_id: str | None = None) -> bool:
     return result is True
 
 
+def _silence_active(board_id: str | None = None) -> bool:
+    """Return True when the target board (or the primary board) is silenced.
+
+    Mirrors :func:`_board_is_paused`: silence is per board since issue #1788,
+    so every send guard must resolve the window of the board it is about to
+    touch. ``Config.is_silence_mode_active(None)`` deliberately keeps its
+    legacy install-wide meaning for the ~20 fixtures that call it zero-arg, so
+    the primary board is resolved here instead — without this an override on
+    the bedroom Note was ignored by every manual-send path and a 2am send from
+    the web UI or Home Assistant woke the board up.
+    """
+    resolved = board_id
+    if resolved is None:
+        try:
+            resolved = get_settings_service().get_primary_board_id()
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug("Could not resolve primary board for silence check: %s", e)
+            resolved = None
+    return Config.is_silence_mode_active(resolved)
+
+
 def _paused_response(board_id: str | None = None) -> dict:
     """Standard payload returned by API endpoints that skip a send because
     the target board is paused."""
@@ -8167,8 +8191,9 @@ async def send_page(
     sent_to_board = False
     paused = False
     if send_to_board:
-        # CRITICAL: Block ALL manual sends during silence mode to prevent wake-ups
-        if Config.is_silence_mode_active():
+        # CRITICAL: Block ALL manual sends during silence mode to prevent
+        # wake-ups — for the board this send targets (issue #1788).
+        if _silence_active(board_id):
             logger.info("Silence mode is active - blocking manual page send to prevent wake-up")
             sent_to_board = False
             # Don't raise error, just skip sending

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -4374,7 +4374,15 @@ async def get_silence_status(board_id: str | None = None):
 
     Args:
         board_id: Optional board to read (query param). Omitted → the
-            install-wide schedule, legacy behavior (issue #1788).
+            **primary** board (issue #1788), matching ``_silence_active`` and
+            ``_board_is_paused``. This is a runtime status endpoint, not a
+            config dump: "is silence on?" with no board means "on the board
+            you drive by default". Returning the install-wide layer instead
+            made the dashboard overlay, the silence-imminent banner and
+            ``GET /silence-status`` all report the pre-save window on a
+            single-board install, because the settings form writes the board
+            layer. The install-wide layer is still readable as raw config via
+            ``GET /settings/all``.
 
     Returns:
     - enabled: Whether silence schedule is enabled
@@ -4383,13 +4391,23 @@ async def get_silence_status(board_id: str | None = None):
     - end_time_utc: End time in UTC ISO format
     - current_time_utc: Current UTC time
     - next_change_utc: Time of next status change
-    - board_id: Echo of the requested board (null when unscoped)
+    - board_id: The board this status describes (the primary board when the
+      query param was omitted; null only when no board is configured)
     """
     from .config import resolve_silence_schedule
     from .time_service import get_time_service
 
     time_service = get_time_service()
     config_manager = get_config_manager()
+
+    if board_id is None:
+        try:
+            primary = get_settings_service().get_primary_board_id()
+        except Exception as e:  # pragma: no cover - defensive
+            logger.debug("Could not resolve primary board for silence status: %s", e)
+            primary = None
+        # Coerce: an id that is not a string would land in the JSON response.
+        board_id = str(primary) if isinstance(primary, str) and primary else None
 
     # No migration here: this is a read the UI polls on a timer, and the
     # migration is a config write.  It runs once at startup instead

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -4530,6 +4530,22 @@ async def update_silence_schedule(request: SilenceScheduleRequest):
         success = config_manager.set_silence_schedule_for_board(board_id, updated)
     else:
         success = config_manager.set_feature("silence_schedule", updated)
+        # The engine resolves silence per board on every install
+        # (``check_and_send_for_board(primary_id, ...)``), so an install-wide
+        # write that leaves a board-scoped copy in place is shadowed key by
+        # key: the user turns silence off, the API says 200, and the board
+        # keeps snoozing at the old time. On a single-board install there is
+        # no meaningful difference between "the install default" and "this
+        # board", so drop the override rather than let it win (issue #1788
+        # review). Multi-board installs are untouched — there the overrides
+        # are the whole point.
+        if success:
+            try:
+                boards = get_settings_service().get_board_settings().boards or []
+            except Exception:  # pragma: no cover - defensive: never fail the save
+                boards = []
+            if len(boards) == 1 and isinstance(boards[0], dict) and boards[0].get("id"):
+                config_manager.prune_silence_schedule_for_board(str(boards[0]["id"]))
     if not success:
         raise HTTPException(
             status_code=500,

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -649,11 +649,19 @@ class WiFiConnectResponse(BaseModel):
 def _run_startup_migrations() -> None:
     """Run the one-shot config migrations that used to fire from read paths.
 
+    ``migrate_silence_schedule_to_per_board`` seeds each configured board's
+    silence override from the install-wide window, and
     ``migrate_silence_schedule_to_utc`` converts pre-UTC ``HH:MM`` silence
-    times.  It is idempotent, so running it once per boot is enough; doing it
-    here keeps ``GET /silence-status`` a pure read (#1746).  Failures are
-    logged, never fatal — a migration must not stop the API from booting.
+    times.  Seeding runs first so the UTC pass converts the per-board windows
+    in the same boot.  Both are idempotent, so running them once per boot is
+    enough; doing it here keeps ``GET /silence-status`` a pure read (#1746).
+    Failures are logged, never fatal — a migration must not stop the API from
+    booting.
     """
+    try:
+        get_config_manager().migrate_silence_schedule_to_per_board()
+    except Exception:
+        logger.warning("Silence-schedule per-board migration failed on startup", exc_info=True)
     try:
         get_config_manager().migrate_silence_schedule_to_utc()
     except Exception:
@@ -4357,9 +4365,13 @@ async def update_general_config(request: dict):
 
 
 @app.get("/silence-status")
-async def get_silence_status():
+async def get_silence_status(board_id: str | None = None):
     """
     Get current silence mode status with UTC times.
+
+    Args:
+        board_id: Optional board to read (query param). Omitted → the
+            install-wide schedule, legacy behavior (issue #1788).
 
     Returns:
     - enabled: Whether silence schedule is enabled
@@ -4368,7 +4380,9 @@ async def get_silence_status():
     - end_time_utc: End time in UTC ISO format
     - current_time_utc: Current UTC time
     - next_change_utc: Time of next status change
+    - board_id: Echo of the requested board (null when unscoped)
     """
+    from .config import resolve_silence_schedule
     from .time_service import get_time_service
 
     time_service = get_time_service()
@@ -4377,14 +4391,12 @@ async def get_silence_status():
     # No migration here: this is a read the UI polls on a timer, and the
     # migration is a config write.  It runs once at startup instead
     # (``_run_startup_migrations``) — see #1746.
-    silence_config = config_manager.get_feature("silence_schedule")
-    enabled = silence_config.get("enabled", False)
-    start_time = silence_config.get("start_time", "20:00+00:00")
-    end_time = silence_config.get("end_time", "07:00+00:00")
-    mode = silence_config.get("mode", "freeze")
-    if mode not in ("indicator", "freeze", "page"):
-        mode = "freeze"
-    page_id = silence_config.get("page_id")
+    silence_config = resolve_silence_schedule(config_manager.get_feature("silence_schedule"), board_id)
+    enabled = silence_config["enabled"]
+    start_time = silence_config["start_time"]
+    end_time = silence_config["end_time"]
+    mode = silence_config["mode"]
+    page_id = silence_config["page_id"]
 
     # Check if currently active
     active = False
@@ -4423,8 +4435,9 @@ async def get_silence_status():
         "seconds_until_next_change": seconds_until_next_change,
         "mode": mode,
         "page_id": page_id,
-        "indicator_text": silence_config.get("indicator_text", "SNOOZING"),
-        "indicator_position": silence_config.get("indicator_position", "center"),
+        "indicator_text": silence_config["indicator_text"],
+        "indicator_position": silence_config["indicator_position"],
+        "board_id": board_id,
     }
 
 
@@ -4438,6 +4451,9 @@ class SilenceScheduleRequest(BaseModel):
     page_id: str | None = None  # Page id to display when mode == "page"
     indicator_text: str | None = None  # Custom text to display when mode == "indicator"
     indicator_position: str | None = None  # Position: center, top-left, top-right, bottom-left, bottom-right
+    # Board to target (issue #1788). Omitted → the install-wide schedule.
+    # Deliberately in the BODY, not the URL, so the endpoint path is unchanged.
+    board_id: str | None = None
 
 
 @app.put("/settings/silence-schedule")
@@ -4453,8 +4469,17 @@ async def update_silence_schedule(request: SilenceScheduleRequest):
       - "indicator" (default) - show a clean "SNOOZING" message sized to the device
       - "freeze" - leave whatever is on the board, stop sending updates
       - "page" - display the page identified by `page_id` and freeze it
+
+    `board_id` (optional, issue #1788) targets one board: the write lands in
+    `features.silence_schedule.by_board[board_id]` and the install-wide layer
+    is left alone. Omitted → the install-wide layer is written, which is what
+    every board without its own override resolves to.
     """
     config_manager = get_config_manager()
+
+    board_id = request.board_id
+    if board_id is not None and _find_board(board_id) is None:
+        raise HTTPException(status_code=404, detail=f"Board not found: {board_id}")
 
     # Validate mode and page_id together
     mode = request.mode if request.mode in ("indicator", "freeze", "page") else "freeze"
@@ -4482,6 +4507,15 @@ async def update_silence_schedule(request: SilenceScheduleRequest):
     _valid_positions = ("center", "top-left", "top-right", "bottom-left", "bottom-right")
     indicator_position = request.indicator_position if request.indicator_position in _valid_positions else "center"
 
+    # Enforce page<->board size compatibility (issue #1788, mirroring #1245's
+    # rule on PUT /settings/active-page). Without this a 22x6 Flagship page
+    # could be selected as the silence page of a 15x3 Note board. There is no
+    # board to validate against on an install-wide write.
+    if board_id is not None and page_id:
+        compat = check_ref_board_compatibility(page_id, board_id)
+        if not compat.ok:
+            raise HTTPException(status_code=400, detail=compat.error)
+
     updated = {
         "enabled": request.enabled,
         "start_time": request.start_time,
@@ -4492,7 +4526,10 @@ async def update_silence_schedule(request: SilenceScheduleRequest):
         "indicator_position": indicator_position,
     }
 
-    success = config_manager.set_feature("silence_schedule", updated)
+    if board_id is not None:
+        success = config_manager.set_silence_schedule_for_board(board_id, updated)
+    else:
+        success = config_manager.set_feature("silence_schedule", updated)
     if not success:
         raise HTTPException(
             status_code=500,
@@ -4500,7 +4537,9 @@ async def update_silence_schedule(request: SilenceScheduleRequest):
         )
 
     logger.info(
-        "Silence schedule updated: enabled=%s, start=%s, end=%s, mode=%s, page_id=%s, indicator_text=%s, indicator_position=%s",
+        "Silence schedule updated for board=%s: enabled=%s, start=%s, end=%s, mode=%s, page_id=%s, "
+        "indicator_text=%s, indicator_position=%s",
+        board_id or "(install-wide)",
         request.enabled,
         request.start_time,
         request.end_time,
@@ -4510,9 +4549,17 @@ async def update_silence_schedule(request: SilenceScheduleRequest):
         indicator_position,
     )
 
+    if board_id is not None:
+        from .config import resolve_silence_schedule
+
+        config = resolve_silence_schedule(config_manager.get_feature("silence_schedule"), board_id)
+    else:
+        config = config_manager.get_feature("silence_schedule") or updated
+
     return {
         "status": "success",
-        "config": config_manager.get_feature("silence_schedule") or updated,
+        "config": config,
+        "board_id": board_id,
     }
 
 

--- a/src/config.py
+++ b/src/config.py
@@ -21,6 +21,60 @@ _SILENCE_KEYS = (
     "indicator_position",
 )
 
+SILENCE_INDICATOR_POSITIONS = ("center", "top-left", "top-right", "bottom-left", "bottom-right")
+SILENCE_MODES = ("indicator", "freeze", "page")
+
+
+def resolve_silence_schedule(feature: dict | None, board_id: str | None = None) -> dict:
+    """Resolve a ``silence_schedule`` feature dict for one board (issue #1788).
+
+    Shared by :meth:`Config.silence_config_for` and the ``/silence-status``
+    endpoint so both apply exactly the same layering and normalization.
+
+    Args:
+        feature: The raw ``features.silence_schedule`` dict (may be None).
+        board_id: Board to resolve, or None for the install-wide layer.
+
+    Returns:
+        A normalized dict with exactly the seven silence keys — never
+        ``by_board``.
+    """
+    feature = feature or {}
+    layer = dict(feature)
+    layer.pop("by_board", None)
+
+    if board_id:
+        by_board = feature.get("by_board")
+        if isinstance(by_board, dict):
+            entry = by_board.get(board_id)
+            if isinstance(entry, dict):
+                layer.update({k: v for k, v in entry.items() if k in _SILENCE_KEYS})
+
+    mode = layer.get("mode", "freeze")
+    if mode not in SILENCE_MODES:
+        mode = "freeze"
+
+    page_id = layer.get("page_id")
+    if not (isinstance(page_id, str) and page_id.strip()):
+        page_id = None
+
+    text = layer.get("indicator_text", "SNOOZING")
+    indicator_text = text.strip().upper() if isinstance(text, str) and text.strip() else "SNOOZING"
+
+    position = layer.get("indicator_position", "center")
+    if position not in SILENCE_INDICATOR_POSITIONS:
+        position = "center"
+
+    return {
+        "enabled": bool(layer.get("enabled", False)),
+        "start_time": layer.get("start_time", "20:00"),
+        "end_time": layer.get("end_time", "07:00"),
+        "mode": mode,
+        "page_id": page_id,
+        "indicator_text": indicator_text,
+        "indicator_position": position,
+    }
+
 
 class classproperty:
     """Descriptor that acts like @property but on the class itself.
@@ -552,41 +606,7 @@ class Config:
             A normalized dict with exactly the seven silence keys. Never
             contains ``by_board``.
         """
-        feature = cls._get_feature("silence_schedule") or {}
-        layer = dict(feature)
-        layer.pop("by_board", None)
-
-        if board_id:
-            by_board = feature.get("by_board")
-            if isinstance(by_board, dict):
-                entry = by_board.get(board_id)
-                if isinstance(entry, dict):
-                    layer.update({k: v for k, v in entry.items() if k in _SILENCE_KEYS})
-
-        mode = layer.get("mode", "freeze")
-        if mode not in ("indicator", "freeze", "page"):
-            mode = "freeze"
-
-        page_id = layer.get("page_id")
-        if not (isinstance(page_id, str) and page_id.strip()):
-            page_id = None
-
-        text = layer.get("indicator_text", "SNOOZING")
-        indicator_text = text.strip().upper() if isinstance(text, str) and text.strip() else "SNOOZING"
-
-        position = layer.get("indicator_position", "center")
-        if position not in ("center", "top-left", "top-right", "bottom-left", "bottom-right"):
-            position = "center"
-
-        return {
-            "enabled": bool(layer.get("enabled", False)),
-            "start_time": layer.get("start_time", "20:00"),
-            "end_time": layer.get("end_time", "07:00"),
-            "mode": mode,
-            "page_id": page_id,
-            "indicator_text": indicator_text,
-            "indicator_position": position,
-        }
+        return resolve_silence_schedule(cls._get_feature("silence_schedule"), board_id)
 
     @classproperty
     def SILENCE_SCHEDULE_ENABLED(cls) -> bool:

--- a/src/config.py
+++ b/src/config.py
@@ -10,6 +10,17 @@ from .config_manager import get_config_manager
 
 logger = logging.getLogger(__name__)
 
+# Silence-schedule keys a per-board override may carry (issue #1788).
+_SILENCE_KEYS = (
+    "enabled",
+    "start_time",
+    "end_time",
+    "mode",
+    "page_id",
+    "indicator_text",
+    "indicator_position",
+)
+
 
 class classproperty:
     """Descriptor that acts like @property but on the class itself.
@@ -517,64 +528,119 @@ class Config:
 
     # ==================== Silence Schedule Configuration ====================
 
+    @classmethod
+    def silence_config_for(cls, board_id: str | None = None) -> dict:
+        """Resolve the effective silence schedule for one board (issue #1788).
+
+        Silence settings are stored per board under
+        ``features.silence_schedule.by_board[board_id]``; the top-level keys of
+        the feature are the **install-wide default**.
+
+        Resolution rule: a board's own entry wins key-by-key; anything it does
+        not define — including a board with no entry at all — falls back to the
+        install-wide values. This deliberately differs from
+        :class:`~src.settings.service.ActivePageSettings`, where the legacy
+        mirror is only consulted for the *primary* board. Here a newly added
+        board should inherit the install's quiet hours rather than be
+        unexpectedly loud at 3am.
+
+        Args:
+            board_id: Board to resolve. ``None`` returns the install-wide layer
+                (what the seven ``SILENCE_SCHEDULE_*`` classproperties read).
+
+        Returns:
+            A normalized dict with exactly the seven silence keys. Never
+            contains ``by_board``.
+        """
+        feature = cls._get_feature("silence_schedule") or {}
+        layer = dict(feature)
+        layer.pop("by_board", None)
+
+        if board_id:
+            by_board = feature.get("by_board")
+            if isinstance(by_board, dict):
+                entry = by_board.get(board_id)
+                if isinstance(entry, dict):
+                    layer.update({k: v for k, v in entry.items() if k in _SILENCE_KEYS})
+
+        mode = layer.get("mode", "freeze")
+        if mode not in ("indicator", "freeze", "page"):
+            mode = "freeze"
+
+        page_id = layer.get("page_id")
+        if not (isinstance(page_id, str) and page_id.strip()):
+            page_id = None
+
+        text = layer.get("indicator_text", "SNOOZING")
+        indicator_text = text.strip().upper() if isinstance(text, str) and text.strip() else "SNOOZING"
+
+        position = layer.get("indicator_position", "center")
+        if position not in ("center", "top-left", "top-right", "bottom-left", "bottom-right"):
+            position = "center"
+
+        return {
+            "enabled": bool(layer.get("enabled", False)),
+            "start_time": layer.get("start_time", "20:00"),
+            "end_time": layer.get("end_time", "07:00"),
+            "mode": mode,
+            "page_id": page_id,
+            "indicator_text": indicator_text,
+            "indicator_position": position,
+        }
+
     @classproperty
     def SILENCE_SCHEDULE_ENABLED(cls) -> bool:
-        """Whether silence schedule is enabled."""
-        return cls._get_feature("silence_schedule").get("enabled", False)
+        """Whether the install-wide silence schedule is enabled."""
+        return cls.silence_config_for()["enabled"]
 
     @classproperty
     def SILENCE_SCHEDULE_START_TIME(cls) -> str:
-        """Silence schedule start time (HH:MM format)."""
-        return cls._get_feature("silence_schedule").get("start_time", "20:00")
+        """Install-wide silence schedule start time (HH:MM format)."""
+        return cls.silence_config_for()["start_time"]
 
     @classproperty
     def SILENCE_SCHEDULE_END_TIME(cls) -> str:
-        """Silence schedule end time (HH:MM format)."""
-        return cls._get_feature("silence_schedule").get("end_time", "07:00")
+        """Install-wide silence schedule end time (HH:MM format)."""
+        return cls.silence_config_for()["end_time"]
 
     @classproperty
-    def SILENCE_SCHEDULE_MODE(self) -> str:
+    def SILENCE_SCHEDULE_MODE(cls) -> str:
         """Silence behaviour: 'freeze' (default), 'indicator', or 'page'."""
-        mode = self._get_feature("silence_schedule").get("mode", "freeze")
-        if mode not in ("indicator", "freeze", "page"):
-            return "freeze"
-        return mode
+        return cls.silence_config_for()["mode"]
 
     @classproperty
-    def SILENCE_SCHEDULE_PAGE_ID(self):
+    def SILENCE_SCHEDULE_PAGE_ID(cls):
         """Page id to display when SILENCE_SCHEDULE_MODE == 'page'."""
-        page_id = self._get_feature("silence_schedule").get("page_id")
-        if isinstance(page_id, str) and page_id.strip():
-            return page_id
-        return None
+        return cls.silence_config_for()["page_id"]
 
     @classproperty
-    def SILENCE_SCHEDULE_INDICATOR_TEXT(self) -> str:
+    def SILENCE_SCHEDULE_INDICATOR_TEXT(cls) -> str:
         """Custom text to display when SILENCE_SCHEDULE_MODE == 'indicator'. Defaults to 'SNOOZING'."""
-        text = self._get_feature("silence_schedule").get("indicator_text", "SNOOZING")
-        if isinstance(text, str) and text.strip():
-            return text.strip().upper()
-        return "SNOOZING"
+        return cls.silence_config_for()["indicator_text"]
 
     @classproperty
-    def SILENCE_SCHEDULE_INDICATOR_POSITION(self) -> str:
+    def SILENCE_SCHEDULE_INDICATOR_POSITION(cls) -> str:
         """Position of indicator text: 'center' (default), 'top-left', 'top-right', 'bottom-left', 'bottom-right'."""
-        pos = self._get_feature("silence_schedule").get("indicator_position", "center")
-        if pos not in ("center", "top-left", "top-right", "bottom-left", "bottom-right"):
-            return "center"
-        return pos
+        return cls.silence_config_for()["indicator_position"]
 
     @classmethod
-    def is_silence_mode_active(cls) -> bool:
-        """Check if we're currently in silence mode.
+    def is_silence_mode_active(cls, board_id: str | None = None) -> bool:
+        """Check if a board is currently in silence mode.
 
-        Uses TimeService to check if current UTC time is within the configured
-        silence window. Times are stored in UTC ISO format.
+        Uses TimeService to check if current UTC time is within that board's
+        configured silence window. Times are stored in UTC ISO format.
+
+        Args:
+            board_id: Board to check. ``None`` keeps the legacy meaning — the
+                install-wide window — so existing zero-arg callers (MQTT state,
+                the AI chat surfaces, manual-send guards) are unchanged.
 
         Returns:
-            True if silence schedule is enabled and current time is within the silence window.
+            True if silence is enabled for that board and the current time is
+            within its silence window.
         """
-        if not cls.SILENCE_SCHEDULE_ENABLED:
+        silence = cls.silence_config_for(board_id)
+        if not silence["enabled"]:
             return False
 
         try:
@@ -582,18 +648,21 @@ class Config:
             from .config_manager import get_config_manager
 
             config_manager = get_config_manager()
+            # Seed per-board overrides first (issue #1788) so the UTC migration
+            # below converts them in the same pass. Both are cheap no-ops once
+            # they have run.
+            config_manager.migrate_silence_schedule_to_per_board()
             config_manager.migrate_silence_schedule_to_utc()
 
-            # Get times (should now be in UTC ISO format)
-            start_time = cls.SILENCE_SCHEDULE_START_TIME
-            end_time = cls.SILENCE_SCHEDULE_END_TIME
+            # Re-resolve: the migration may have rewritten the window in place.
+            silence = cls.silence_config_for(board_id)
 
             # Use TimeService to check if we're in the window
             from .time_service import get_time_service
 
             time_service = get_time_service()
 
-            return time_service.is_time_in_window(start_time, end_time)
+            return time_service.is_time_in_window(silence["start_time"], silence["end_time"])
 
         except (ValueError, AttributeError) as e:
             logger.warning(f"Invalid silence schedule time format: {e}")

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -27,6 +27,19 @@ logger = logging.getLogger(__name__)
 # config. Used by the boot-time snapshot guard below.
 APP_VERSION_SEEN_KEY = "app_version_seen"
 
+# The silence-schedule keys that can be overridden per board (issue #1788).
+# Anything outside this tuple (notably ``by_board`` itself) is never copied
+# into a per-board entry.
+SILENCE_SCHEDULE_KEYS = (
+    "enabled",
+    "start_time",
+    "end_time",
+    "mode",
+    "page_id",
+    "indicator_text",
+    "indicator_position",
+)
+
 # Mapping from legacy feature keys to plugin IDs.
 # silence_schedule is a system feature and is NOT migrated here.
 FEATURE_TO_PLUGIN_MAP = {
@@ -253,6 +266,12 @@ DEFAULT_CONFIG: dict[str, Any] = {
             "indicator_position": "center",
             # Page id to display when mode == "page" (variables are frozen at silence-start)
             "page_id": None,
+            # Per-board overrides (issue #1788): board_id -> partial dict of the
+            # seven keys above. A board with no entry inherits the values above,
+            # which act as the install-wide default. MUST stay in DEFAULT_CONFIG:
+            # set_feature() whitelists keys against it and would otherwise drop
+            # this one silently.
+            "by_board": {},
         },
         "stocks": {
             "enabled": False,
@@ -1405,10 +1424,25 @@ class ConfigManager:
                 return True
         return False
 
+    @staticmethod
+    def _needs_utc_migration(start_time: Any, end_time: Any) -> bool:
+        """True when a window pair is still in the legacy local "HH:MM" format.
+
+        Old format: "20:00" (5 chars). New format: "20:00+00:00" (11 chars).
+        """
+        return (
+            isinstance(start_time, str)
+            and isinstance(end_time, str)
+            and len(start_time) == 5
+            and ":" in start_time
+            and len(end_time) == 5
+            and ":" in end_time
+        )
+
     def migrate_silence_schedule_to_utc(self) -> bool:
         """Migrate silence_schedule times from old HH:MM format to UTC ISO format.
 
-        This method detects if the silence_schedule is using the old local time format
+        This method detects if a silence window is using the old local time format
         (e.g., "20:00") and converts it to the new UTC ISO format (e.g., "04:00+00:00").
 
         Held under ``_file_lock`` — the lock that guards config data — for the
@@ -1417,22 +1451,33 @@ class ConfigManager:
         read racing other config writers and stalled every thread calling
         ``ConfigManager()`` for the duration of the disk I/O (#1746).
 
+        The 5-char heuristic is applied **per window** — to the install-wide
+        default and to every ``by_board`` entry independently (issue #1788).
+        Applying it once for the whole feature would strand every per-board
+        window in local time as soon as the global one had been migrated.
+
+        Idempotent: a window already in UTC ISO format is left untouched.
+
         Returns:
-            True if migration was performed, False if no migration needed
+            True if any window was migrated, False if no migration was needed.
         """
         with self._file_lock:
             silence_config = self.get_feature("silence_schedule")
-            start_time = silence_config.get("start_time", "")
-            end_time = silence_config.get("end_time", "")
+            by_board = silence_config.get("by_board")
+            if not isinstance(by_board, dict):
+                by_board = {}
 
-            # Check if migration is needed (old format is just HH:MM, 5 chars)
-            if not start_time or not end_time:
-                return False
+            global_needs = self._needs_utc_migration(
+                silence_config.get("start_time", ""), silence_config.get("end_time", "")
+            )
+            board_needs = [
+                board_id
+                for board_id, entry in by_board.items()
+                if isinstance(entry, dict)
+                and self._needs_utc_migration(entry.get("start_time", ""), entry.get("end_time", ""))
+            ]
 
-            # Old format: "20:00" (5 chars), New format: "20:00-08:00" (11+ chars)
-            needs_migration = len(start_time) == 5 and ":" in start_time and len(end_time) == 5 and ":" in end_time
-
-            if not needs_migration:
+            if not global_needs and not board_needs:
                 logger.debug("Silence schedule already in UTC format, no migration needed")
                 return False
 
@@ -1447,25 +1492,124 @@ class ConfigManager:
 
             logger.info(f"Migrating silence schedule from local time to UTC using timezone: {timezone}")
 
-            # Convert times to UTC
             time_service = get_time_service()
-            start_utc = time_service.local_to_utc_iso(start_time, timezone)
-            end_utc = time_service.local_to_utc_iso(end_time, timezone)
 
-            # Update the config
-            silence_config["start_time"] = start_utc
-            silence_config["end_time"] = end_utc
+            if global_needs:
+                start_time = silence_config["start_time"]
+                end_time = silence_config["end_time"]
+                silence_config["start_time"] = time_service.local_to_utc_iso(start_time, timezone)
+                silence_config["end_time"] = time_service.local_to_utc_iso(end_time, timezone)
+                logger.info(
+                    "Migrating install-wide silence window: %s → %s, %s → %s",
+                    start_time,
+                    silence_config["start_time"],
+                    end_time,
+                    silence_config["end_time"],
+                )
+
+            for board_id in board_needs:
+                entry = by_board[board_id]
+                entry["start_time"] = time_service.local_to_utc_iso(entry["start_time"], timezone)
+                entry["end_time"] = time_service.local_to_utc_iso(entry["end_time"], timezone)
+            if board_needs:
+                silence_config["by_board"] = by_board
+                logger.info("Migrated %d per-board silence window(s) to UTC", len(board_needs))
 
             success = self.set_feature("silence_schedule", silence_config)
 
             if success:
-                logger.info(
-                    f"Successfully migrated silence schedule: {start_time} → {start_utc}, {end_time} → {end_utc}"
-                )
+                logger.info("Successfully migrated silence schedule to UTC")
             else:
                 logger.error("Failed to save migrated silence schedule")
 
             return success
+
+    def set_silence_schedule_for_board(self, board_id: str, values: dict[str, Any]) -> bool:
+        """Write one board's silence-schedule override (issue #1788).
+
+        Only ``features.silence_schedule.by_board[board_id]`` is touched — the
+        install-wide default (the top-level keys) is left alone so other boards
+        keep resolving to it.
+
+        Args:
+            board_id: Board whose override to write.
+            values: Full or partial dict of the seven silence keys.
+
+        Returns:
+            True if the write was persisted.
+        """
+        with self._file_lock:
+            features = self._config.setdefault("features", {})
+            silence = features.setdefault("silence_schedule", self._deep_copy(DEFAULT_CONFIG["features"]["silence_schedule"]))
+            by_board = silence.get("by_board")
+            if not isinstance(by_board, dict):
+                by_board = {}
+            entry = dict(by_board.get(board_id) or {}) if isinstance(by_board.get(board_id), dict) else {}
+            entry.update({k: v for k, v in values.items() if k in SILENCE_SCHEDULE_KEYS})
+            by_board[board_id] = entry
+            silence["by_board"] = by_board
+            self._save_internal()
+        logger.info("Silence schedule for board %s updated", board_id)
+        return True
+
+    def migrate_silence_schedule_to_per_board(self) -> int:
+        """Seed per-board silence overrides from the install-wide values (issue #1788).
+
+        Before #1788 the silence schedule was a single global window. On the
+        first boot after upgrading, every configured board is given an explicit
+        copy of it so nothing changes behaviourally.
+
+        ``config.json`` has no integer schema_version runner, so the guard is
+        structural and reads ``self._raw_features`` — the features section as it
+        existed **on disk before** the defaults merge (which would otherwise
+        supply an empty ``by_board`` and make every install look migrated). A
+        ``by_board`` key in the stored file means this install has already been
+        migrated. That cannot double-apply, and it also means a user who
+        deliberately deletes a board's override does not get it silently
+        re-seeded on the next boot (the resolution rule already falls back to
+        the install-wide values for them).
+
+        Returns:
+            Number of boards seeded (0 when nothing needed migrating).
+        """
+        with self._file_lock:
+            stored = self._raw_features.get("silence_schedule")
+            if isinstance(stored, dict) and isinstance(stored.get("by_board"), dict):
+                logger.debug("Silence schedule already per-board, no migration needed")
+                return 0
+
+            features = self._config.setdefault("features", {})
+            silence = features.setdefault(
+                "silence_schedule", self._deep_copy(DEFAULT_CONFIG["features"]["silence_schedule"])
+            )
+            legacy = {k: silence[k] for k in SILENCE_SCHEDULE_KEYS if k in silence}
+            board_ids = self._configured_board_ids()
+            silence["by_board"] = {board_id: dict(legacy) for board_id in board_ids}
+            # Mark the stored snapshot as migrated too, so a second call in the
+            # same process short-circuits without re-reading the file.
+            self._raw_features.setdefault("silence_schedule", {})["by_board"] = self._deep_copy(silence["by_board"])
+            self._save_internal()
+
+        if board_ids:
+            logger.info(
+                "Migrated silence schedule to per-board: seeded %d board(s) from the install-wide window",
+                len(board_ids),
+            )
+        else:
+            logger.info("Migrated silence schedule to per-board: seeded 0 board(s) (none configured)")
+        return len(board_ids)
+
+    @staticmethod
+    def _configured_board_ids() -> list[str]:
+        """Board ids from the multi-board settings service (empty on any failure)."""
+        try:
+            from .settings.service import get_settings_service
+
+            boards = get_settings_service().get_board_settings().boards or []
+        except Exception:  # pragma: no cover - defensive: never break boot
+            logger.warning("Could not read board settings for silence migration", exc_info=True)
+            return []
+        return [str(b["id"]) for b in boards if isinstance(b, dict) and b.get("id")]
 
     # ==================== Plugin Configuration Methods ====================
 

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -1554,6 +1554,40 @@ class ConfigManager:
         logger.info("Silence schedule for board %s updated", board_id)
         return True
 
+    def prune_silence_schedule_for_board(self, board_id: str) -> bool:
+        """Drop one board's silence-schedule override (issue #1788 review).
+
+        Used in two places:
+
+        * ``SettingsService.remove_board`` — a removed board must not leave an
+          orphan entry behind. Harmless on its own (``resolve_silence_schedule``
+          falls back cleanly for an unknown id) but the orphans accumulate.
+        * The install-wide write path — see
+          ``PUT /settings/silence-schedule``. A single-board install has no
+          meaningful distinction between "the install default" and "this
+          board", so a lingering override there can only shadow the value the
+          user just saved.
+
+        Returns:
+            True if an entry was removed (and the config resaved).
+        """
+        with self._file_lock:
+            silence = self._config.get("features", {}).get("silence_schedule")
+            if not isinstance(silence, dict):
+                return False
+            by_board = silence.get("by_board")
+            if not isinstance(by_board, dict) or board_id not in by_board:
+                return False
+            by_board.pop(board_id)
+            # Keep the on-disk snapshot in step so the structural migration
+            # guard still sees this install as migrated.
+            raw = self._raw_features.get("silence_schedule")
+            if isinstance(raw, dict) and isinstance(raw.get("by_board"), dict):
+                raw["by_board"].pop(board_id, None)
+            self._save_internal()
+        logger.info("Pruned silence schedule override for board %s", board_id)
+        return True
+
     def migrate_silence_schedule_to_per_board(self) -> int:
         """Seed per-board silence overrides from the install-wide values (issue #1788).
 
@@ -1574,6 +1608,18 @@ class ConfigManager:
         Returns:
             Number of boards seeded (0 when nothing needed migrating).
         """
+        # Resolve the board list BEFORE taking the file lock. ``_file_lock`` is
+        # a plain (non-reentrant) ``threading.Lock`` and
+        # ``get_settings_service()`` constructs a ``SettingsService`` whose
+        # ``__init__`` reads ``FB_TRANSITION_STRATEGY`` ->
+        # ``Config._get_board()`` -> ``ConfigManager.get_board()``, which takes
+        # that same lock. Calling it from inside the ``with`` block deadlocks
+        # the whole process: the lock is never released, so every config read
+        # blocks forever with no exception and no timeout. Every production
+        # caller happens to warm the settings service first, which is the only
+        # reason this was latent rather than a hang on boot.
+        board_ids = self._configured_board_ids()
+
         with self._file_lock:
             stored = self._raw_features.get("silence_schedule")
             if isinstance(stored, dict) and isinstance(stored.get("by_board"), dict):
@@ -1585,7 +1631,6 @@ class ConfigManager:
                 "silence_schedule", self._deep_copy(DEFAULT_CONFIG["features"]["silence_schedule"])
             )
             legacy = {k: silence[k] for k in SILENCE_SCHEDULE_KEYS if k in silence}
-            board_ids = self._configured_board_ids()
             silence["by_board"] = {board_id: dict(legacy) for board_id in board_ids}
             # Mark the stored snapshot as migrated too, so a second call in the
             # same process short-circuits without re-reading the file.

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -1540,7 +1540,9 @@ class ConfigManager:
         """
         with self._file_lock:
             features = self._config.setdefault("features", {})
-            silence = features.setdefault("silence_schedule", self._deep_copy(DEFAULT_CONFIG["features"]["silence_schedule"]))
+            silence = features.setdefault(
+                "silence_schedule", self._deep_copy(DEFAULT_CONFIG["features"]["silence_schedule"])
+            )
             by_board = silence.get("by_board")
             if not isinstance(by_board, dict):
                 by_board = {}

--- a/src/main.py
+++ b/src/main.py
@@ -97,8 +97,8 @@ class DisplayService:
         self.board_init_errors: dict[str, str] = {}
 
         # board_id -> silence-active, as of the last run()-loop boundary check
-        # (issue #1788). Empty on the first pass, so the first tick after boot
-        # only reports a change if some board is already silenced.
+        # (issue #1788). Empty until the first check; see _silence_baseline for
+        # what a board that is not in it yet compares against.
         self._last_silence_snapshot: dict[str, bool] = {}
 
         # Board state polling (background thread reads actual board state).
@@ -669,8 +669,8 @@ class DisplayService:
         Respects schedule mode (per board) - uses schedule-based page selection
         when that board's schedule is enabled, otherwise the board's manual
         active page. Triggers and temporary overrides are the PRIMARY board's
-        feature set (locked epic decision); silence is a global decision with
-        per-board delivery. All state reads/writes go through ``rt``.
+        feature set (locked epic decision); silence is resolved and delivered
+        per board (issue #1788). All state reads/writes go through ``rt``.
 
         Returns:
             True if content was sent to this board, False otherwise.
@@ -952,6 +952,25 @@ class DisplayService:
             logger.warning("Could not determine device type from board settings: %s", e)
         return "flagship"
 
+    def _silence_baseline(self, key: str, board_id=None) -> bool:
+        """What the boundary detector last knew about one board's silence.
+
+        Prefers the detector's own snapshot, then the board runtime's
+        ``last_silence_mode_active`` latch — the flag
+        ``check_and_send_for_board`` writes on *every* exit path, including the
+        pause short-circuit and every render failure (issue #1740). Without the
+        latch fallback, an install that boots **inside** its silence window
+        reports a boundary on the detector's very first pass and forces one
+        spurious extra update, because the initial
+        ``check_and_send_active_page()`` has already handled it.
+        """
+        if key in self._last_silence_snapshot:
+            return self._last_silence_snapshot[key]
+        # Runtimes are keyed by the raw board id, which is not always a string
+        # (the primary fallback key, or a test double).
+        rt = self.runtimes.get(board_id if board_id is not None else key)
+        return bool(rt.last_silence_mode_active) if rt is not None else False
+
     def _silence_state_changed(self) -> bool:
         """True when any board's silence state flipped since the last check.
 
@@ -959,7 +978,9 @@ class DisplayService:
         are per board (issue #1788), so watching only the primary would leave a
         secondary board's transition waiting for the next poll tick.
 
-        Records the new snapshot, so a change is reported exactly once.
+        Records the new snapshot, so a change is reported exactly once — a
+        board the drive path never touches (a disabled secondary, say) must not
+        re-trigger a forced update every second for the whole window.
         """
         snapshot: dict[str, bool] = {}
         try:
@@ -971,16 +992,15 @@ class DisplayService:
             board_ids = [self._primary_board_id]
 
         for board_id in board_ids:
+            key = str(board_id)
             try:
-                snapshot[str(board_id)] = bool(Config.is_silence_mode_active(board_id))
+                snapshot[key] = bool(Config.is_silence_mode_active(board_id))
             except Exception as e:
                 logger.debug(f"Silence boundary check failed for board {board_id}: {e}")
-                snapshot[str(board_id)] = self._last_silence_snapshot.get(str(board_id), False)
+                snapshot[key] = self._silence_baseline(key, board_id)
 
-        # A board not seen before defaults to "not silenced", matching the
-        # runtime's own initial state — so a quiet install does not report a
-        # change on its very first pass.
-        changed = any(active != self._last_silence_snapshot.get(bid, False) for bid, active in snapshot.items())
+        baselines = {str(bid): self._silence_baseline(str(bid), bid) for bid in board_ids}
+        changed = any(active != baselines[bid] for bid, active in snapshot.items())
         if changed:
             logger.debug(
                 "Silence boundary crossed (now=%s, was=%s) - forcing immediate update",

--- a/src/main.py
+++ b/src/main.py
@@ -96,6 +96,11 @@ class DisplayService:
         # so a skipped board is visible in the UI instead of only in the log.
         self.board_init_errors: dict[str, str] = {}
 
+        # board_id -> silence-active, as of the last run()-loop boundary check
+        # (issue #1788). Empty on the first pass, so the first tick after boot
+        # only reports a change if some board is already silenced.
+        self._last_silence_snapshot: dict[str, bool] = {}
+
         # Board state polling (background thread reads actual board state).
         self._poll_thread: threading.Thread | None = None
 
@@ -683,10 +688,12 @@ class DisplayService:
             # This runs BEFORE the pause short-circuit so that even a fully
             # hands-off board records where the silence window stands: the 1 Hz
             # boundary detector in ``run()`` compares this flag against
-            # ``Config.is_silence_mode_active()``, so any exit path that leaves
-            # it stale makes the detector see a permanent mismatch and re-drive
-            # every board once per second for the whole window (issue #1740).
-            silence_mode_active = Config.is_silence_mode_active()
+            # ``Config.is_silence_mode_active(board_id)``, so any exit path that
+            # leaves it stale makes the detector see a permanent mismatch and
+            # re-drive every board once per second for the whole window
+            # (issue #1740).
+            silence_config = Config.silence_config_for(board_id)
+            silence_mode_active = Config.is_silence_mode_active(board_id)
             entering_silence_mode = silence_mode_active and not rt.last_silence_mode_active
             exiting_silence_mode = not silence_mode_active and rt.last_silence_mode_active
 
@@ -815,14 +822,8 @@ class DisplayService:
             # A user-initiated temporary override (primary only) wins over
             # silence (issue #949); everything else is silenced.
             if silence_mode_active and not override_active:
-                silence_mode = Config.SILENCE_SCHEDULE_MODE
-                if is_primary:
-                    silence_dt = self._silence_device_type()
-                    silence_nw = silence_nt = 1
-                else:
-                    silence_dt = (board or {}).get("device_type") or "flagship"
-                    silence_nw = (board or {}).get("notes_wide", 1) or 1
-                    silence_nt = (board or {}).get("notes_tall", 1) or 1
+                silence_mode = silence_config["mode"]
+                silence_dt, silence_nw, silence_nt = self._silence_geometry(board, is_primary=is_primary)
                 if silence_mode == "freeze":
                     if entering_silence_mode:
                         logger.info("⏸️  Entering silence mode (freeze) - leaving board untouched")
@@ -832,8 +833,10 @@ class DisplayService:
                     rt.snoozing_message_sent = True
                     return False
                 if silence_mode == "page":
-                    return self._send_silence_page(rt)
-                return self._send_silence_indicator(silence_dt, rt, silence_nw, silence_nt)
+                    return self._send_silence_page(rt, silence_config, silence_dt, silence_nw, silence_nt)
+                return self._send_silence_indicator(
+                    silence_dt, rt, silence_nw, silence_nt, silence_config=silence_config
+                )
 
             # --- Normal send (content changed) ---
             current_content = result.formatted
@@ -949,20 +952,91 @@ class DisplayService:
             logger.warning("Could not determine device type from board settings: %s", e)
         return "flagship"
 
-    def _build_silence_indicator_array(self, device_type: str, notes_wide: int = 1, notes_tall: int = 1):
-        """Build a clean board array with 'SNOOZING' centered.
+    def _silence_state_changed(self) -> bool:
+        """True when any board's silence state flipped since the last check.
+
+        Backs the ``run()`` loop's 1-second boundary detector. Silence windows
+        are per board (issue #1788), so watching only the primary would leave a
+        secondary board's transition waiting for the next poll tick.
+
+        Records the new snapshot, so a change is reported exactly once.
+        """
+        snapshot: dict[str, bool] = {}
+        try:
+            board_ids = [b.get("id") for b in (get_settings_service().get_board_settings().boards or []) if b.get("id")]
+        except Exception as e:
+            logger.debug(f"Silence boundary check failed to read boards: {e}")
+            board_ids = []
+        if not board_ids:
+            board_ids = [self._primary_board_id]
+
+        for board_id in board_ids:
+            try:
+                snapshot[str(board_id)] = bool(Config.is_silence_mode_active(board_id))
+            except Exception as e:
+                logger.debug(f"Silence boundary check failed for board {board_id}: {e}")
+                snapshot[str(board_id)] = self._last_silence_snapshot.get(str(board_id), False)
+
+        # A board not seen before defaults to "not silenced", matching the
+        # runtime's own initial state — so a quiet install does not report a
+        # change on its very first pass.
+        changed = any(active != self._last_silence_snapshot.get(bid, False) for bid, active in snapshot.items())
+        if changed:
+            logger.debug(
+                "Silence boundary crossed (now=%s, was=%s) - forcing immediate update",
+                snapshot,
+                self._last_silence_snapshot,
+            )
+        self._last_silence_snapshot = snapshot
+        return changed
+
+    def _silence_geometry(self, board: dict | None, *, is_primary: bool) -> tuple[str, int, int]:
+        """Resolve (device_type, notes_wide, notes_tall) for a board's silence display.
+
+        Secondary boards carry their own settings dict. The primary is driven
+        with ``board=None``, so its geometry comes from the first configured
+        board — including its note-array grid, which the old primary path
+        hardcoded to 1x1 (issue #1788).
+        """
+        if board is None and is_primary:
+            try:
+                boards = get_settings_service().get_board_settings().boards or []
+                if boards and isinstance(boards[0], dict):
+                    board = boards[0]
+            except Exception as e:
+                logger.warning("Could not determine device type from board settings: %s", e)
+        if not isinstance(board, dict):
+            return "flagship", 1, 1
+        device_type = board.get("device_type")
+        if device_type not in ("flagship", "note", "note_array"):
+            device_type = "flagship"
+        return device_type, board.get("notes_wide", 1) or 1, board.get("notes_tall", 1) or 1
+
+    def _build_silence_indicator_array(
+        self,
+        device_type: str,
+        notes_wide: int = 1,
+        notes_tall: int = 1,
+        silence_config: dict | None = None,
+    ):
+        """Build a clean board array with the silence indicator text centered.
 
         Sized via resolve_dimensions so it fits the Note (15 cols), the
         Flagship (22 cols), and any note-array grid without overlaying content.
+
+        ``silence_config`` is the target board's resolved silence settings
+        (issue #1788); omitted falls back to the install-wide values.
         """
+        if silence_config is None:
+            silence_config = Config.silence_config_for()
         dims = resolve_dimensions(device_type, notes_wide, notes_tall)
         board_array = [[BoardChars.SPACE] * dims.cols for _ in range(dims.rows)]
 
-        indicator = Config.SILENCE_SCHEDULE_INDICATOR_TEXT
+        indicator = silence_config["indicator_text"]
         # Truncate to fit if a future device is narrower.
         text = indicator[: dims.cols]
 
-        position = Config.SILENCE_SCHEDULE_INDICATOR_POSITION
+        position = silence_config["indicator_position"]
         if position == "top-left":
             row, start_col = 0, 0
         elif position == "top-right":
@@ -981,25 +1055,29 @@ class DisplayService:
         return board_array
 
     def _send_silence_indicator(
-        self, page_device_type: str, rt: BoardRuntime | None = None, notes_wide: int = 1, notes_tall: int = 1
+        self,
+        page_device_type: str,
+        rt: BoardRuntime | None = None,
+        notes_wide: int = 1,
+        notes_tall: int = 1,
+        silence_config: dict | None = None,
     ) -> bool:
-        """Send a clean SNOOZING-only board sized for the device."""
+        """Send a clean indicator-only board sized for the device."""
         rt = rt if rt is not None else self._ensure_primary_runtime()
         if rt is None or rt.client is None:
             logger.warning("Board client not initialized")
             return False
 
-        # Primary board: prefer the first configured board's device type
-        # (legacy behavior). Secondary boards pass their own resolved geometry.
-        if rt.board_id == self._primary_board_id:
-            device_type = self._silence_device_type() or page_device_type
-        else:
-            device_type = page_device_type
-        logger.info(f"⏸️  Entering silence mode (indicator) - displaying SNOOZING for {device_type}")
+        # Every caller now resolves the TARGET BOARD's geometry via
+        # _silence_geometry (issue #1788), so it is used verbatim. The old
+        # primary-only override through _silence_device_type() collapsed a
+        # note-array primary down to "flagship".
+        device_type = page_device_type
+        logger.info(f"⏸️  Entering silence mode (indicator) - displaying indicator for {device_type}")
 
         settings_service = get_settings_service()
         system_transition = settings_service.get_transition_settings()
-        board_array = self._build_silence_indicator_array(device_type, notes_wide, notes_tall)
+        board_array = self._build_silence_indicator_array(device_type, notes_wide, notes_tall, silence_config)
 
         success, was_sent = rt.client.render(
             board_array,
@@ -1020,18 +1098,36 @@ class DisplayService:
         logger.error("Failed to send silence indicator to board")
         return False
 
-    def _send_silence_page(self, rt: BoardRuntime | None = None) -> bool:
-        """Render the configured silence page once and freeze it on the board.
+    def _send_silence_page(
+        self,
+        rt: BoardRuntime | None = None,
+        silence_config: dict | None = None,
+        device_type: str | None = None,
+        notes_wide: int = 1,
+        notes_tall: int = 1,
+    ) -> bool:
+        """Render the target board's silence page once and freeze it there.
 
         Variables in the page are rendered with the values present at the
         moment silence begins; the board is not refreshed afterwards.
+
+        The array is sized to the **board**, never to the page's own declared
+        device type (issue #1788): a 22x6 Flagship page used to be handed to a
+        15x3 Note client verbatim. ``device_type``/``notes_wide``/``notes_tall``
+        come from :meth:`_silence_geometry`; omitted, they fall back to the
+        primary board's geometry.
         """
         rt = rt if rt is not None else self._ensure_primary_runtime()
         if rt is None or rt.client is None:
             logger.warning("Board client not initialized")
             return False
 
-        page_id = Config.SILENCE_SCHEDULE_PAGE_ID
+        if silence_config is None:
+            silence_config = Config.silence_config_for(rt.board_id)
+        if device_type is None:
+            device_type, notes_wide, notes_tall = self._silence_geometry(None, is_primary=True)
+
+        page_id = silence_config["page_id"]
         page_service = get_page_service()
         page = page_service.get_page(page_id) if page_id else None
 
@@ -1040,14 +1136,14 @@ class DisplayService:
                 "Silence mode 'page' selected but page %r not found - falling back to indicator",
                 page_id,
             )
-            return self._send_silence_indicator(self._silence_device_type(), rt)
+            return self._send_silence_indicator(device_type, rt, notes_wide, notes_tall, silence_config)
 
         logger.info(f"⏸️  Entering silence mode (page) - displaying {page.id}")
 
         result = page_service.preview_page(page.id, force_refresh=True)
         if not result or not result.available:
             logger.warning("Silence page %s could not be rendered - falling back to indicator", page.id)
-            return self._send_silence_indicator(page.device_type, rt)
+            return self._send_silence_indicator(device_type, rt, notes_wide, notes_tall, silence_config)
 
         settings_service = get_settings_service()
         system_transition = settings_service.get_transition_settings()
@@ -1059,7 +1155,7 @@ class DisplayService:
         )
         step_size = page.transition_step_size if page.transition_step_size is not None else system_transition.step_size
 
-        dims = resolve_dimensions(page.device_type, page.notes_wide, page.notes_tall)
+        dims = resolve_dimensions(device_type, notes_wide, notes_tall)
         board_array = text_to_board_array(result.formatted, rows=dims.rows, cols=dims.cols)
 
         success, was_sent = rt.client.render(
@@ -1067,7 +1163,7 @@ class DisplayService:
             strategy=strategy,
             step_interval_ms=interval_ms,
             step_size=step_size,
-            device_type=page.device_type,
+            device_type=device_type,
         )
 
         if success:
@@ -1208,19 +1304,10 @@ class DisplayService:
                 # fires check_and_send_active_page every polling_interval seconds,
                 # so without this the silence page could appear up to ~15s after
                 # the configured start time (longer if the user raised the poll
-                # interval). A cheap is_silence_mode_active() call each second
-                # lets us catch the transition within ~1s.
-                try:
-                    silence_now = Config.is_silence_mode_active()
-                except Exception as e:
-                    logger.debug(f"Silence boundary check failed: {e}")
-                    silence_now = self._last_silence_mode_active
-                if silence_now != self._last_silence_mode_active:
-                    logger.debug(
-                        "Silence boundary crossed (now=%s, was=%s) - forcing immediate update",
-                        silence_now,
-                        self._last_silence_mode_active,
-                    )
+                # interval). A cheap per-board silence check each second lets us
+                # catch the transition within ~1s. Windows are per board
+                # (issue #1788), so ANY board flipping forces the update.
+                if self._silence_state_changed():
                     self.check_and_send_active_page()
 
                 # When a collection is active, poll at its mode-specific cadence:

--- a/src/mqtt/commands.py
+++ b/src/mqtt/commands.py
@@ -307,7 +307,19 @@ class CommandHandler:
                 return
         from src.config import Config
 
-        if Config.is_silence_mode_active():
+        # Silence is per board (issue #1788): resolve the window of the board
+        # this message targets, falling back to the primary board for a plain
+        # -string payload. Without this a Home Assistant send at 2am woke a
+        # board whose own override said it should be quiet.
+        from src.settings.service import get_settings_service
+
+        silence_board_id = board_id
+        if silence_board_id is None:
+            try:
+                silence_board_id = get_settings_service().get_primary_board_id()
+            except Exception:  # pragma: no cover - defensive
+                silence_board_id = None
+        if Config.is_silence_mode_active(silence_board_id):
             logger.info("MQTT send_message blocked by silence mode")
             return
         from src.api_server import get_service

--- a/src/mqtt/state.py
+++ b/src/mqtt/state.py
@@ -97,8 +97,14 @@ class StatePublisher:
             # current_message
             out["current_message"] = self._get_current_message()
 
-            # silence_mode
-            silence_active = Config.is_silence_mode_active()
+            # silence_mode — scoped to the primary board (issue #1788).
+            # Every other field in this payload is primary-board scoped
+            # (active_page, transition_style, ...), so publishing the
+            # install-wide layer here made the Home Assistant sensor report
+            # OFF while the board it describes was snoozing. A per-board
+            # sensor set is a separate feature; this keeps the single entity
+            # honest about the board it already describes.
+            silence_active = Config.is_silence_mode_active(settings.get_primary_board_id())
             out["silence_mode"] = "ON" if silence_active else "OFF"
 
             # version

--- a/src/pages/service.py
+++ b/src/pages/service.py
@@ -779,17 +779,35 @@ def _board_geometry(board: dict) -> tuple[str, int, int]:
     )
 
 
-def find_incompatible_references(page: Page) -> list[dict]:
-    """Find schedule/active-page references the page no longer fits (issue #1250).
+def silence_page_id_for_board(board_id: str | None) -> str | None:
+    """The page ref a board shows during silence, or None (issue #1788).
 
-    After a device/size retarget, existing references may point the page at
-    boards whose size no longer matches. This scans, for every board the page
-    is now incompatible with:
+    Only meaningful when that board's silence mode is ``page``. Never raises —
+    a failure here must not break a page save.
+    """
+    try:
+        from src.config import Config
+
+        silence = Config.silence_config_for(board_id)
+        return silence["page_id"] if silence["mode"] == "page" else None
+    except Exception:  # pragma: no cover - defensive
+        logger.exception("Could not resolve silence page for board %s", board_id)
+        return None
+
+
+def find_incompatible_references(page: Page) -> list[dict]:
+    """Find schedule/active-page/silence references the page no longer fits.
+
+    Issue #1250, extended by #1788. After a device/size retarget, existing
+    references may point the page at boards whose size no longer matches. This
+    scans, for every board the page is now incompatible with:
 
       - schedule entries referencing the page directly or via a collection
         that contains it (``surface: "schedule"``, with ``schedule_id``)
       - the board's manual active page, direct or via a containing collection
         (``surface: "active_page"``)
+      - the board's silence page when its silence mode is ``page``
+        (``surface: "silence"``)
 
     Warn-only by design: nothing is mutated or auto-fixed — callers surface
     the returned refs to the user. Returns
@@ -843,6 +861,15 @@ def find_incompatible_references(page: Page) -> list[dict]:
                         "board_id": board_id,
                         "board_name": board_name,
                         "surface": "active_page",
+                        "schedule_id": None,
+                    }
+                )
+            if references_page(silence_page_id_for_board(board_id)):
+                refs.append(
+                    {
+                        "board_id": board_id,
+                        "board_name": board_name,
+                        "surface": "silence",
                         "schedule_id": None,
                     }
                 )

--- a/src/settings/service.py
+++ b/src/settings/service.py
@@ -1349,6 +1349,16 @@ class SettingsService:
 
         self._board.boards = new_boards
         self._save_to_file()
+        # Drop the board's silence-schedule override too (issue #1788 review):
+        # nothing else ever removes it, so orphans accumulate in
+        # ``features.silence_schedule.by_board`` for boards that no longer
+        # exist.
+        try:
+            from src.config_manager import get_config_manager
+
+            get_config_manager().prune_silence_schedule_for_board(board_id)
+        except Exception:  # pragma: no cover - never block board removal
+            logger.warning("Could not prune silence override for %s", board_id, exc_info=True)
         logger.info(f"Removed board: {board_id}")
         return self._board
 

--- a/tests/test_page_retarget.py
+++ b/tests/test_page_retarget.py
@@ -171,6 +171,43 @@ class TestFindIncompatibleReferences:
             "schedule_id": schedule.id,
         } in refs
 
+    def test_silence_page_reference_reported(self, env, monkeypatch):
+        """A board's silence page is a third surface that can go stale (#1788)."""
+        page = env["flagship_page"]
+        monkeypatch.setattr(
+            "src.pages.service.silence_page_id_for_board",
+            lambda board_id: page.id if board_id == "board-flagship" else None,
+        )
+        retargeted = env["page_service"].update_page(page.id, PageUpdate(device_type="note"))
+        refs = find_incompatible_references(retargeted)
+        assert refs == [
+            {
+                "board_id": "board-flagship",
+                "board_name": "Kitchen",
+                "surface": "silence",
+                "schedule_id": None,
+            }
+        ]
+
+    def test_silence_page_reference_via_collection_reported(self, env, monkeypatch):
+        page = env["flagship_page"]
+        other = env["page_service"].create_page(PageCreate(name="Other Flag", type="template", template=["b"]))
+        collection = env["collection_service"].create_collection(
+            CollectionCreate(name="Mixed", page_ids=[page.id, other.id])
+        )
+        monkeypatch.setattr(
+            "src.pages.service.silence_page_id_for_board",
+            lambda board_id: collection.id if board_id == "board-flagship" else None,
+        )
+        retargeted = env["page_service"].update_page(page.id, PageUpdate(device_type="note"))
+        refs = find_incompatible_references(retargeted)
+        assert {
+            "board_id": "board-flagship",
+            "board_name": "Kitchen",
+            "surface": "silence",
+            "schedule_id": None,
+        } in refs
+
     def test_no_references_when_still_compatible(self, env):
         page = env["flagship_page"]
         _schedule(env, page.id)

--- a/tests/test_per_board_engine.py
+++ b/tests/test_per_board_engine.py
@@ -156,6 +156,17 @@ def _drive(svc, boards, *, settings=None, pages=None, schedule=None, silence=Fal
         cfg.SILENCE_SCHEDULE_INDICATOR_TEXT = "SNOOZING"
         cfg.SILENCE_SCHEDULE_INDICATOR_POSITION = "center"
         cfg.SILENCE_SCHEDULE_PAGE_ID = None
+        # Silence is resolved per board since issue #1788; every board here
+        # shares the same window, which is what `silence=` toggles.
+        cfg.silence_config_for.return_value = {
+            "enabled": True,
+            "start_time": "04:00+00:00",
+            "end_time": "15:00+00:00",
+            "mode": "indicator",
+            "page_id": None,
+            "indicator_text": "SNOOZING",
+            "indicator_position": "center",
+        }
         return svc.check_and_send_active_page()
 
 

--- a/tests/test_silence_mode_display.py
+++ b/tests/test_silence_mode_display.py
@@ -26,6 +26,41 @@ def service():
     return svc
 
 
+def _silence_config_mock(
+    *,
+    silence_active=True,
+    mode="indicator",
+    page_id=None,
+    indicator_text="SNOOZING",
+    indicator_position="center",
+):
+    """A ``Config`` stand-in for the silence path.
+
+    Since issue #1788 the display engine reads a board's resolved silence
+    settings through ``Config.silence_config_for(board_id)`` instead of the
+    seven install-wide ``SILENCE_SCHEDULE_*`` classproperties, so a Mock that
+    only sets the classproperties no longer drives the engine. The
+    classproperties are still set here: they remain the install-wide mirror.
+    """
+    resolved = {
+        "enabled": True,
+        "start_time": "04:00+00:00",
+        "end_time": "15:00+00:00",
+        "mode": mode,
+        "page_id": page_id,
+        "indicator_text": indicator_text,
+        "indicator_position": indicator_position,
+    }
+    config = Mock()
+    config.is_silence_mode_active.return_value = silence_active
+    config.silence_config_for.return_value = resolved
+    config.SILENCE_SCHEDULE_MODE = mode
+    config.SILENCE_SCHEDULE_PAGE_ID = page_id
+    config.SILENCE_SCHEDULE_INDICATOR_TEXT = indicator_text
+    config.SILENCE_SCHEDULE_INDICATOR_POSITION = indicator_position
+    return config
+
+
 def _decode_board_text(board_array):
     """Turn a board character array back into a flat string for assertions."""
     # Build a reverse map from BoardChars constants. We only need letters,
@@ -114,12 +149,11 @@ class TestSilenceModeDispatch:
         settings.get_board_settings.return_value = Mock(boards=[{"device_type": "note"}])
         settings.get_transition_settings.return_value = Mock(strategy=None, step_interval_ms=500, step_size=1)
 
-        config = Mock()
-        config.is_silence_mode_active.return_value = silence_active
-        config.SILENCE_SCHEDULE_MODE = mode
-        config.SILENCE_SCHEDULE_PAGE_ID = page_id
-        config.SILENCE_SCHEDULE_INDICATOR_TEXT = "SNOOZING"
-        config.SILENCE_SCHEDULE_INDICATOR_POSITION = "center"
+        config = _silence_config_mock(
+            silence_active=silence_active,
+            mode=mode,
+            page_id=page_id,
+        )
 
         return page, page_service, settings, config
 
@@ -266,12 +300,12 @@ class TestCustomIndicatorTextAndPosition:
         settings.get_board_settings.return_value = Mock(boards=[{"device_type": "flagship"}])
         settings.get_transition_settings.return_value = Mock(strategy=None, step_interval_ms=500, step_size=1)
 
-        config = Mock()
-        config.is_silence_mode_active.return_value = True
-        config.SILENCE_SCHEDULE_MODE = "indicator"
-        config.SILENCE_SCHEDULE_PAGE_ID = None
-        config.SILENCE_SCHEDULE_INDICATOR_TEXT = indicator_text
-        config.SILENCE_SCHEDULE_INDICATOR_POSITION = indicator_position
+        config = _silence_config_mock(
+            silence_active=True,
+            mode="indicator",
+            indicator_text=indicator_text,
+            indicator_position=indicator_position,
+        )
         return page_service, settings, config
 
     def test_indicator_uses_custom_text(self, service):
@@ -320,6 +354,7 @@ class TestCustomIndicatorTextAndPosition:
         """If config provides no mode (so Config.SILENCE_SCHEDULE_MODE == 'freeze'), no send."""
         page_service, settings, config = self._patch_common()
         config.SILENCE_SCHEDULE_MODE = "freeze"
+        config.silence_config_for.return_value = {**config.silence_config_for.return_value, "mode": "freeze"}
         with (
             patch("src.main.get_page_service", return_value=page_service),
             patch("src.main.get_settings_service", return_value=settings),
@@ -394,12 +429,7 @@ class TestTemporaryOverrideDuringSilence:
         settings.get_transition_settings.return_value = Mock(strategy=None, step_interval_ms=500, step_size=1)
         settings.consume_temporary_override.return_value = override
 
-        config = Mock()
-        config.is_silence_mode_active.return_value = silence_active
-        config.SILENCE_SCHEDULE_MODE = silence_mode
-        config.SILENCE_SCHEDULE_PAGE_ID = None
-        config.SILENCE_SCHEDULE_INDICATOR_TEXT = "SNOOZING"
-        config.SILENCE_SCHEDULE_INDICATOR_POSITION = "center"
+        config = _silence_config_mock(silence_active=silence_active, mode=silence_mode)
 
         return page_service, settings, config
 

--- a/tests/test_silence_per_board.py
+++ b/tests/test_silence_per_board.py
@@ -1,0 +1,376 @@
+"""Per-board silence schedule resolution, storage and migrations (issue #1788).
+
+Silence used to be a single global window shared by every board, which made a
+Note and a Flagship share one quiet period *and* one silence page (the page
+could only ever be one size). Silence settings are now stored per board under
+``features.silence_schedule.by_board`` with the legacy top-level keys retained
+as the install-wide default.
+
+Covers:
+  - the resolution rule (per-board entry wins, unconfigured board falls back
+    to the global values, partial entries merge over the global layer)
+  - ``Config.is_silence_mode_active(board_id)`` honoring per-board windows
+    while the zero-arg call keeps its legacy primary/global meaning
+  - per-board round-trip through ``ConfigManager`` (``set_feature`` must not
+    silently drop ``by_board``)
+  - the structural per-board migration: idempotent, logs the count
+  - the UTC migration fanning out across every per-board window
+"""
+
+import json
+import logging
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.config import Config
+from src.config_manager import ConfigManager
+
+
+def _patch_feature(feature_dict):
+    """Patch Config._get_feature to return the given silence_schedule dict."""
+    return patch.object(Config, "_get_feature", classmethod(lambda cls, name: feature_dict))
+
+
+GLOBAL = {
+    "enabled": True,
+    "start_time": "04:00+00:00",
+    "end_time": "15:00+00:00",
+    "mode": "freeze",
+    "page_id": None,
+    "indicator_text": "SNOOZING",
+    "indicator_position": "center",
+}
+
+
+# ==================== Resolution rule ====================
+
+
+class TestSilenceConfigResolution:
+    def test_board_with_own_entry_wins_over_global(self):
+        feature = {
+            **GLOBAL,
+            "by_board": {
+                "note-1": {
+                    "enabled": True,
+                    "start_time": "06:00+00:00",
+                    "end_time": "12:00+00:00",
+                    "mode": "page",
+                    "page_id": "note-night",
+                    "indicator_text": "HUSH",
+                    "indicator_position": "top-left",
+                }
+            },
+        }
+        with _patch_feature(feature):
+            resolved = Config.silence_config_for("note-1")
+
+        assert resolved["start_time"] == "06:00+00:00"
+        assert resolved["end_time"] == "12:00+00:00"
+        assert resolved["mode"] == "page"
+        assert resolved["page_id"] == "note-night"
+        assert resolved["indicator_text"] == "HUSH"
+        assert resolved["indicator_position"] == "top-left"
+
+    def test_unconfigured_board_falls_back_to_global(self):
+        """A board that was never configured inherits the install-wide window.
+
+        Deliberately different from ActivePageSettings (where the legacy mirror
+        is only consulted for the primary board): a newly added board should
+        inherit the existing quiet hours rather than be unexpectedly loud.
+        """
+        feature = {**GLOBAL, "by_board": {"note-1": {"start_time": "06:00+00:00"}}}
+        with _patch_feature(feature):
+            resolved = Config.silence_config_for("brand-new-board")
+
+        assert resolved["enabled"] is True
+        assert resolved["start_time"] == "04:00+00:00"
+        assert resolved["end_time"] == "15:00+00:00"
+
+    def test_partial_entry_merges_over_global(self):
+        feature = {**GLOBAL, "by_board": {"b1": {"mode": "indicator", "indicator_text": "shhh"}}}
+        with _patch_feature(feature):
+            resolved = Config.silence_config_for("b1")
+
+        assert resolved["mode"] == "indicator"
+        assert resolved["indicator_text"] == "SHHH"  # normalized like the global path
+        assert resolved["start_time"] == "04:00+00:00"  # inherited
+
+    def test_none_board_id_returns_global_layer(self):
+        feature = {**GLOBAL, "by_board": {"b1": {"start_time": "23:00+00:00"}}}
+        with _patch_feature(feature):
+            resolved = Config.silence_config_for(None)
+
+        assert resolved["start_time"] == "04:00+00:00"
+
+    def test_resolved_dict_never_leaks_by_board(self):
+        feature = {**GLOBAL, "by_board": {"b1": {"start_time": "23:00+00:00"}}}
+        with _patch_feature(feature):
+            assert "by_board" not in Config.silence_config_for("b1")
+
+    def test_missing_feature_yields_documented_defaults(self):
+        with _patch_feature({}):
+            resolved = Config.silence_config_for("b1")
+
+        assert resolved == {
+            "enabled": False,
+            "start_time": "20:00",
+            "end_time": "07:00",
+            "mode": "freeze",
+            "page_id": None,
+            "indicator_text": "SNOOZING",
+            "indicator_position": "center",
+        }
+
+    def test_malformed_by_board_is_ignored(self):
+        for bad in ("nope", 42, ["b1"], None):
+            with _patch_feature({**GLOBAL, "by_board": bad}):
+                assert Config.silence_config_for("b1")["start_time"] == "04:00+00:00"
+
+    def test_malformed_board_entry_is_ignored(self):
+        with _patch_feature({**GLOBAL, "by_board": {"b1": "garbage"}}):
+            assert Config.silence_config_for("b1")["start_time"] == "04:00+00:00"
+
+    def test_per_board_values_are_normalized(self):
+        feature = {
+            **GLOBAL,
+            "by_board": {"b1": {"mode": "GARBAGE", "indicator_position": "sideways", "page_id": "   "}},
+        }
+        with _patch_feature(feature):
+            resolved = Config.silence_config_for("b1")
+
+        assert resolved["mode"] == "freeze"
+        assert resolved["indicator_position"] == "center"
+        assert resolved["page_id"] is None
+
+
+class TestClassPropertiesStayGlobal:
+    """The seven classproperties keep meaning "the install-wide default"."""
+
+    def test_classproperties_ignore_by_board(self):
+        feature = {
+            **GLOBAL,
+            "by_board": {"b1": {"enabled": False, "start_time": "23:00+00:00", "mode": "indicator"}},
+        }
+        with _patch_feature(feature):
+            assert Config.SILENCE_SCHEDULE_ENABLED is True
+            assert Config.SILENCE_SCHEDULE_START_TIME == "04:00+00:00"
+            assert Config.SILENCE_SCHEDULE_MODE == "freeze"
+
+
+# ==================== is_silence_mode_active(board_id) ====================
+
+
+class TestIsSilenceModeActivePerBoard:
+    def _run(self, feature, board_id, *, in_window):
+        time_service = patch("src.time_service.get_time_service")
+        with _patch_feature(feature), time_service as get_ts:
+            get_ts.return_value.is_time_in_window.side_effect = lambda s, e: in_window.get((s, e), False)
+            with patch("src.config_manager.get_config_manager"):
+                return Config.is_silence_mode_active(board_id)
+
+    def test_board_uses_its_own_window(self):
+        feature = {
+            **GLOBAL,
+            "by_board": {"b1": {"start_time": "06:00+00:00", "end_time": "12:00+00:00"}},
+        }
+        in_window = {("06:00+00:00", "12:00+00:00"): True, ("04:00+00:00", "15:00+00:00"): False}
+        assert self._run(feature, "b1", in_window=in_window) is True
+
+    def test_other_board_uses_global_window(self):
+        feature = {
+            **GLOBAL,
+            "by_board": {"b1": {"start_time": "06:00+00:00", "end_time": "12:00+00:00"}},
+        }
+        in_window = {("06:00+00:00", "12:00+00:00"): True, ("04:00+00:00", "15:00+00:00"): False}
+        assert self._run(feature, "b2", in_window=in_window) is False
+
+    def test_zero_arg_call_keeps_global_meaning(self):
+        """Back-compat: ~20 existing fixtures call this with no arguments."""
+        feature = {
+            **GLOBAL,
+            "by_board": {"b1": {"start_time": "06:00+00:00", "end_time": "12:00+00:00"}},
+        }
+        in_window = {("06:00+00:00", "12:00+00:00"): True, ("04:00+00:00", "15:00+00:00"): False}
+        assert self._run(feature, None, in_window=in_window) is False
+
+    def test_board_can_disable_silence_independently(self):
+        feature = {**GLOBAL, "by_board": {"b1": {"enabled": False}}}
+        in_window = {("04:00+00:00", "15:00+00:00"): True}
+        assert self._run(feature, "b1", in_window=in_window) is False
+        assert self._run(feature, "b2", in_window=in_window) is True
+
+
+# ==================== ConfigManager storage ====================
+
+
+@pytest.fixture
+def cm(tmp_path: Path):
+    ConfigManager._instance = None
+    path = tmp_path / "config.json"
+    manager = ConfigManager(config_path=str(path))
+    yield manager
+    ConfigManager._instance = None
+
+
+class TestPerBoardStorageRoundTrip:
+    def test_by_board_is_not_dropped_by_set_feature(self, cm):
+        """set_feature whitelists against DEFAULT_CONFIG - by_board must be in it."""
+        cfg = cm.get_feature("silence_schedule")
+        cfg["by_board"] = {"b1": {"enabled": True, "start_time": "01:00+00:00", "end_time": "02:00+00:00"}}
+        assert cm.set_feature("silence_schedule", cfg) is True
+
+        assert cm.get_feature("silence_schedule")["by_board"]["b1"]["start_time"] == "01:00+00:00"
+
+    def test_set_silence_schedule_for_board_writes_only_that_board(self, cm):
+        cm.set_silence_schedule_for_board(
+            "b1", {"enabled": True, "start_time": "01:00+00:00", "end_time": "02:00+00:00", "mode": "freeze"}
+        )
+        cm.set_silence_schedule_for_board(
+            "b2", {"enabled": False, "start_time": "03:00+00:00", "end_time": "04:00+00:00", "mode": "indicator"}
+        )
+
+        stored = cm.get_feature("silence_schedule")
+        assert stored["by_board"]["b1"]["start_time"] == "01:00+00:00"
+        assert stored["by_board"]["b2"]["start_time"] == "03:00+00:00"
+        # The global layer is untouched by a per-board write.
+        assert stored["start_time"] == "20:00"
+
+    def test_per_board_write_survives_reload(self, cm, tmp_path):
+        cm.set_silence_schedule_for_board(
+            "b1", {"enabled": True, "start_time": "01:00+00:00", "end_time": "02:00+00:00", "mode": "freeze"}
+        )
+        ConfigManager._instance = None
+        reloaded = ConfigManager(config_path=str(tmp_path / "config.json"))
+        assert reloaded.get_feature("silence_schedule")["by_board"]["b1"]["enabled"] is True
+
+
+# ==================== Per-board migration ====================
+
+
+def _write_config(path: Path, silence: dict):
+    path.write_text(json.dumps({"features": {"silence_schedule": silence}}))
+
+
+class TestPerBoardMigration:
+    def _boards(self, *ids):
+        return patch(
+            "src.settings.service.get_settings_service",
+            **{"return_value.get_board_settings.return_value.boards": [{"id": i} for i in ids]},
+        )
+
+    def test_seeds_every_configured_board_from_the_global_values(self, tmp_path, caplog):
+        path = tmp_path / "config.json"
+        _write_config(path, dict(GLOBAL))
+        ConfigManager._instance = None
+        manager = ConfigManager(config_path=str(path))
+
+        with self._boards("b1", "b2"), caplog.at_level(logging.INFO):
+            changed = manager.migrate_silence_schedule_to_per_board()
+
+        assert changed == 2
+        by_board = manager.get_feature("silence_schedule")["by_board"]
+        assert by_board["b1"]["start_time"] == "04:00+00:00"
+        assert by_board["b2"]["end_time"] == "15:00+00:00"
+        assert "2" in caplog.text
+
+    def test_is_idempotent(self, tmp_path):
+        path = tmp_path / "config.json"
+        _write_config(path, dict(GLOBAL))
+        ConfigManager._instance = None
+        manager = ConfigManager(config_path=str(path))
+
+        with self._boards("b1", "b2"):
+            assert manager.migrate_silence_schedule_to_per_board() == 2
+            assert manager.migrate_silence_schedule_to_per_board() == 0
+
+    def test_never_overwrites_an_existing_per_board_entry(self, tmp_path):
+        path = tmp_path / "config.json"
+        _write_config(path, {**GLOBAL, "by_board": {"b1": {"start_time": "23:00+00:00"}}})
+        ConfigManager._instance = None
+        manager = ConfigManager(config_path=str(path))
+
+        with self._boards("b1", "b2"):
+            manager.migrate_silence_schedule_to_per_board()
+
+        by_board = manager.get_feature("silence_schedule")["by_board"]
+        assert by_board["b1"]["start_time"] == "23:00+00:00"
+
+    def test_already_migrated_install_is_left_alone(self, tmp_path):
+        """The structural guard is the presence of by_board, so a user who
+        deleted a board's entry does not get it silently re-seeded."""
+        path = tmp_path / "config.json"
+        _write_config(path, {**GLOBAL, "by_board": {}})
+        ConfigManager._instance = None
+        manager = ConfigManager(config_path=str(path))
+
+        with self._boards("b1", "b2"):
+            assert manager.migrate_silence_schedule_to_per_board() == 0
+        assert manager.get_feature("silence_schedule")["by_board"] == {}
+
+
+# ==================== UTC migration fan-out ====================
+
+
+class TestUtcMigrationFansOut:
+    def test_converts_every_per_board_window(self, tmp_path):
+        path = tmp_path / "config.json"
+        _write_config(
+            path,
+            {
+                **GLOBAL,
+                "start_time": "20:00",
+                "end_time": "07:00",
+                "by_board": {
+                    "b1": {"start_time": "21:00", "end_time": "06:00"},
+                    "b2": {"start_time": "22:00", "end_time": "05:00"},
+                },
+            },
+        )
+        ConfigManager._instance = None
+        manager = ConfigManager(config_path=str(path))
+        manager.set_general({"timezone": "UTC"})
+
+        assert manager.migrate_silence_schedule_to_utc() is True
+
+        stored = manager.get_feature("silence_schedule")
+        assert stored["start_time"] == "20:00+00:00"
+        assert stored["by_board"]["b1"]["start_time"] == "21:00+00:00"
+        assert stored["by_board"]["b1"]["end_time"] == "06:00+00:00"
+        assert stored["by_board"]["b2"]["start_time"] == "22:00+00:00"
+
+    def test_is_idempotent(self, tmp_path):
+        path = tmp_path / "config.json"
+        _write_config(
+            path,
+            {**GLOBAL, "start_time": "20:00", "end_time": "07:00", "by_board": {"b1": {"start_time": "21:00", "end_time": "06:00"}}},
+        )
+        ConfigManager._instance = None
+        manager = ConfigManager(config_path=str(path))
+        manager.set_general({"timezone": "UTC"})
+
+        manager.migrate_silence_schedule_to_utc()
+        assert manager.migrate_silence_schedule_to_utc() is False
+        assert manager.get_feature("silence_schedule")["by_board"]["b1"]["start_time"] == "21:00+00:00"
+
+    def test_converts_per_board_windows_even_when_global_is_already_utc(self, tmp_path):
+        """Regression: the 5-char heuristic must be applied per entry, not once
+        for the whole feature - otherwise an already-migrated global window
+        strands every per-board window in local time."""
+        path = tmp_path / "config.json"
+        _write_config(
+            path,
+            {
+                **GLOBAL,
+                "start_time": "04:00+00:00",
+                "end_time": "15:00+00:00",
+                "by_board": {"b1": {"start_time": "21:00", "end_time": "06:00"}},
+            },
+        )
+        ConfigManager._instance = None
+        manager = ConfigManager(config_path=str(path))
+        manager.set_general({"timezone": "UTC"})
+
+        assert manager.migrate_silence_schedule_to_utc() is True
+        assert manager.get_feature("silence_schedule")["by_board"]["b1"]["start_time"] == "21:00+00:00"

--- a/tests/test_silence_per_board.py
+++ b/tests/test_silence_per_board.py
@@ -344,7 +344,12 @@ class TestUtcMigrationFansOut:
         path = tmp_path / "config.json"
         _write_config(
             path,
-            {**GLOBAL, "start_time": "20:00", "end_time": "07:00", "by_board": {"b1": {"start_time": "21:00", "end_time": "06:00"}}},
+            {
+                **GLOBAL,
+                "start_time": "20:00",
+                "end_time": "07:00",
+                "by_board": {"b1": {"start_time": "21:00", "end_time": "06:00"}},
+            },
         )
         ConfigManager._instance = None
         manager = ConfigManager(config_path=str(path))

--- a/tests/test_silence_per_board_call_sites.py
+++ b/tests/test_silence_per_board_call_sites.py
@@ -1,0 +1,211 @@
+"""Every send guard must resolve silence for the board it is about to touch.
+
+Issue #1788 made the silence schedule per board, but the manual-send guards
+kept calling ``Config.is_silence_mode_active()`` with no board.  Scenario the
+review caught: install-wide silence disabled, the bedroom Note overridden to
+22:00-07:00 — at 2am a manual send from the web UI or Home Assistant went
+straight through to the bedroom board.
+
+Each test pins one guard.  ``is_silence_mode_active`` is replaced by a
+board-aware stub so a guard that still passes ``None`` sees "not silent" and
+lets the send through, which is exactly the production bug.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.api_server import app
+from src.config import Config
+from src.mqtt.client import MQTTClient
+from src.mqtt.commands import CommandHandler
+from src.mqtt.config import MQTTConfig
+from src.mqtt.state import StatePublisher
+
+SILENCED_BOARD = "bedroom-note"
+LOUD_BOARD = "kitchen-flagship"
+
+BOARDS = [
+    {"id": SILENCED_BOARD, "name": "Bedroom", "device_type": "note", "enabled": True},
+    {"id": LOUD_BOARD, "name": "Kitchen", "device_type": "flagship", "enabled": True},
+]
+
+
+def _board_aware_silence(silenced: str = SILENCED_BOARD):
+    """Patch ``Config.is_silence_mode_active`` so only ``silenced`` is quiet.
+
+    The install-wide layer (``board_id=None``) is explicitly NOT silent, which
+    is what makes a guard that forgets to pass a board fail this test.
+    """
+    return patch.object(
+        Config,
+        "is_silence_mode_active",
+        classmethod(lambda cls, board_id=None: board_id == silenced),
+    )
+
+
+def _settings(primary: str = SILENCED_BOARD):
+    settings = MagicMock()
+    settings.get_board_settings.return_value = MagicMock(boards=BOARDS)
+    settings.get_primary_board_id.return_value = primary
+    settings.is_paused.return_value = False
+    settings.should_send_to_board.return_value = True
+    settings.get_transition_settings.return_value = MagicMock(strategy="column", step_interval_ms=100, step_size=1)
+    settings.get_active_page_id.return_value = "page-1"
+    settings.is_schedule_enabled.return_value = False
+    settings.get_polling_interval.return_value = 300
+    settings.get_output_settings.return_value = MagicMock(target="both")
+    return settings
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+# ==================== api_server manual-send guards ====================
+
+
+class TestApiSendGuards:
+    def test_send_message_respects_the_primary_boards_window(self, client):
+        """POST /send-message drives the primary board's client (issue #1788)."""
+        service = MagicMock()
+        service.vb_client.render.return_value = (True, True)
+        with (
+            _board_aware_silence(),
+            patch("src.api_server.get_service", return_value=service),
+            patch("src.api_server.get_settings_service", return_value=_settings()),
+        ):
+            response = client.post("/send-message", json={"text": "HELLO"})
+
+        assert response.status_code == 200, response.text
+        assert response.json()["status"] == "blocked"
+        assert response.json()["silence_mode"] is True
+        service.vb_client.render.assert_not_called()
+
+    def test_send_welcome_message_respects_the_primary_boards_window(self, client):
+        with (
+            _board_aware_silence(),
+            patch("src.api_server.get_settings_service", return_value=_settings()),
+            patch("src.board_client.BoardClient") as board_client,
+        ):
+            board_client.return_value.render.return_value = (True, True)
+            response = client.post("/send-welcome-message")
+
+        assert response.status_code == 200, response.text
+        assert response.json()["status"] == "blocked"
+        board_client.return_value.render.assert_not_called()
+
+    def test_page_send_respects_the_target_boards_window(self, client):
+        """POST /pages/{id}/send?board_id= must use that board's window."""
+        page = MagicMock(transition_strategy=None, transition_interval_ms=None, transition_step_size=None)
+        page_service = MagicMock()
+        page_service.get_page.return_value = page
+        page_service.preview_page.return_value = MagicMock(available=True, error=None)
+        service = MagicMock()
+        board_client = MagicMock()
+        board_client.render.return_value = (True, True)
+        service.get_board_client.return_value = board_client
+
+        with (
+            _board_aware_silence(),
+            patch("src.api_server.get_page_service", return_value=page_service),
+            patch("src.api_server.get_settings_service", return_value=_settings(primary=LOUD_BOARD)),
+            patch("src.api_server.get_service", return_value=service),
+            patch("src.api_server._find_board", return_value=BOARDS[0]),
+        ):
+            response = client.post(f"/pages/page-1/send?board_id={SILENCED_BOARD}")
+
+        assert response.status_code == 200, response.text
+        assert response.json()["sent_to_board"] is False
+        board_client.render.assert_not_called()
+
+    def test_live_transition_test_respects_the_target_boards_window(self, client):
+        registry = MagicMock()
+        registry.get_transition_plugin.return_value = MagicMock()
+
+        with (
+            _board_aware_silence(),
+            patch("src.api_server._ensure_transition_plugins_beta"),
+            patch("src.plugins.registry.get_plugin_registry", return_value=registry),
+            patch("src.api_server._resolve_live_board_client", return_value=(BOARDS[0], MagicMock())),
+            patch("src.api_server.get_settings_service", return_value=_settings(primary=LOUD_BOARD)),
+        ):
+            response = client.post(
+                "/transitions/test-live",
+                json={"plugin_id": "wipe", "to_page_id": "page-1", "board_id": SILENCED_BOARD},
+            )
+
+        # The silence guard is the first thing after the board client is
+        # resolved, so any other status means it did not fire.
+        assert response.status_code == 409, response.text
+        assert "Silence" in response.json()["detail"]
+
+    def test_transition_restore_respects_the_target_boards_window(self, client):
+        with (
+            _board_aware_silence(),
+            patch("src.api_server._ensure_transition_plugins_beta"),
+            patch("src.api_server._resolve_live_board_client", return_value=(BOARDS[0], MagicMock())),
+            patch("src.api_server.get_settings_service", return_value=_settings(primary=LOUD_BOARD)),
+        ):
+            response = client.post("/transitions/restore", json={"board_id": SILENCED_BOARD})
+
+        # Same ordering as /transitions/test-live: anything but 409 means the
+        # guard resolved the wrong board and let the restore through.
+        assert response.status_code == 409, response.text
+        assert "Silence" in response.json()["detail"]
+
+
+# ==================== MQTT / Home Assistant ====================
+
+
+class TestMqttSilenceIsPerBoard:
+    def test_state_publisher_reports_the_primary_boards_silence(self):
+        """The HA ``silence_mode`` sensor mirrors the rest of the payload.
+
+        Every other field in ``_gather_state`` is primary-board scoped
+        (``get_active_page_id()``, ``get_transition_settings()``), so the
+        silence sensor must be too — publishing the install-wide layer makes
+        it report OFF while the board it describes is snoozing.
+        """
+        page_service = MagicMock()
+        page_service.get_page.return_value = MagicMock(name="Weather")
+        page_service.list_pages.return_value = []
+
+        mock_client = MagicMock(spec=MQTTClient)
+        mock_client.config = MQTTConfig(enabled=True, base_topic="fiestaboard")
+
+        with (
+            _board_aware_silence(),
+            patch("src.settings.service.get_settings_service", return_value=_settings()),
+            patch("src.pages.service.get_page_service", return_value=page_service),
+            patch("src.api_server._get_board_client", return_value=None),
+            patch("src.config_manager.ConfigManager") as mock_cm,
+        ):
+            mock_cm.return_value._config = {"plugins": {}}
+            publisher = StatePublisher(mock_client)
+            state = publisher._gather_state()
+
+        assert state["silence_mode"] == "ON"
+
+    def test_mqtt_send_message_respects_the_target_boards_window(self):
+        """A Home Assistant send to a silenced board must be dropped."""
+        mock_client = MagicMock(spec=MQTTClient)
+        mock_client._state_publisher = None
+        mock_client.config = MQTTConfig(enabled=True, base_topic="fiestaboard")
+        handler = CommandHandler(mock_client)
+
+        service = MagicMock()
+        target_client = MagicMock()
+        service.get_board_client.return_value = target_client
+
+        with (
+            _board_aware_silence(),
+            patch("src.api_server.get_service", return_value=service),
+            patch("src.settings.service.get_settings_service", return_value=_settings(primary=LOUD_BOARD)),
+        ):
+            handler.handle("send_message", '{"message": "HELLO", "board": "Bedroom"}')
+
+        target_client.send_characters.assert_not_called()
+        service.vb_client.send_characters.assert_not_called()

--- a/tests/test_silence_per_board_composition.py
+++ b/tests/test_silence_per_board_composition.py
@@ -260,3 +260,59 @@ class TestMigrationLockSafety:
             "that call reads config through ConfigManager.get_board()"
         )
         assert result["seeded"] == 1
+
+
+# ==================== /silence-status read layer ====================
+
+
+class TestSilenceStatusReadsTheBoardTheUiWrote:
+    """``GET /silence-status`` with no board must describe the primary board.
+
+    The dashboard SNOOZING overlay, the silence-imminent banner and the E2E
+    regression for #597 all poll this endpoint unscoped on a single-board
+    install. If it keeps returning the install-wide layer while the form
+    writes the board layer, the user toggles silence off and every one of
+    those surfaces still says it is on — the same disagreement as BLOCKER 1,
+    one layer up.
+    """
+
+    def test_unscoped_status_reports_the_primary_boards_window(self, real_config):
+        service = _boards(BOARD_1)
+        p1, p2 = _patch_settings(service)
+        with p1, p2:
+            real_config.migrate_silence_schedule_to_per_board()
+            client = TestClient(app)
+
+            # What the settings form now sends: a board-scoped save.
+            _save_via_api(
+                client,
+                {
+                    "enabled": False,
+                    "start_time": "22:30+00:00",
+                    "end_time": "07:00+00:00",
+                    "mode": "indicator",
+                    "board_id": "board-1",
+                },
+            )
+
+            status = client.get("/silence-status")
+
+        assert status.status_code == 200, status.text
+        body = status.json()
+        assert body["enabled"] is False
+        assert body["start_time_utc"] == "22:30+00:00"
+        assert body["board_id"] == "board-1"
+
+    def test_explicit_board_id_still_wins_over_the_primary(self, real_config):
+        service = _boards(BOARD_1, BOARD_2)
+        p1, p2 = _patch_settings(service)
+        with p1, p2:
+            real_config.set_silence_schedule_for_board(
+                "board-2", {"enabled": True, "start_time": "03:00+00:00", "end_time": "04:00+00:00"}
+            )
+            client = TestClient(app)
+            status = client.get("/silence-status?board_id=board-2")
+
+        assert status.status_code == 200, status.text
+        assert status.json()["start_time_utc"] == "03:00+00:00"
+        assert status.json()["board_id"] == "board-2"

--- a/tests/test_silence_per_board_composition.py
+++ b/tests/test_silence_per_board_composition.py
@@ -200,20 +200,36 @@ class TestBoardRemovalPrunesOverrides:
 
 
 class TestMigrationLockSafety:
-    def test_seeding_migration_does_not_reenter_the_config_file_lock(self, real_config):
-        """``_configured_board_ids()`` must not be called while holding ``_file_lock``.
+    def test_seeding_migration_does_not_hold_the_config_lock_across_the_board_lookup(self, real_config):
+        """``_configured_board_ids()`` must run OUTSIDE ``_file_lock``.
 
         ``get_settings_service()`` constructs a ``SettingsService`` whose
         ``__init__`` reads ``FB_TRANSITION_STRATEGY`` -> ``Config._get_board()``
-        -> ``ConfigManager.get_board()``, which takes the same non-reentrant
-        ``threading.Lock``.  Held forever, every config read in the process
-        blocks: total freeze, no exception, no timeout.
+        -> ``ConfigManager.get_board()``, which takes ``_file_lock``. Calling it
+        from inside the migration's ``with`` block self-deadlocked the whole
+        process while ``_file_lock`` was a plain ``threading.Lock``: held
+        forever, every config read blocked, no exception and no timeout.
 
-        Run on a worker thread with a join timeout so the failure is a red
-        test rather than a hung suite.
+        #1746 has since made ``_file_lock`` an ``RLock``, so the same-thread
+        re-entry no longer hangs — but that is an implementation detail of the
+        lock, not a property of this code. The invariant pinned here is the
+        durable one: the config lock is free while the settings service is
+        being built. A probe thread proves it, so this fails whether the lock
+        is reentrant or not.
         """
+        lock_was_free: dict[str, bool] = {}
 
         def _settings_service_that_reads_config():
+            # Another thread must be able to touch config while this runs.
+            def _probe():
+                acquired = real_config._file_lock.acquire(timeout=2)
+                lock_was_free["free"] = acquired
+                if acquired:
+                    real_config._file_lock.release()
+
+            probe = threading.Thread(target=_probe, daemon=True)
+            probe.start()
+            probe.join(timeout=5)
             # Exactly what SettingsService.__init__ does today.
             real_config.get_board()
             return _boards(BOARD_1)
@@ -232,11 +248,15 @@ class TestMigrationLockSafety:
 
         worker = threading.Thread(target=_run, daemon=True)
         worker.start()
-        worker.join(timeout=10)
+        worker.join(timeout=15)
 
         assert not worker.is_alive(), (
             "migrate_silence_schedule_to_per_board() deadlocked: it called "
             "get_settings_service() while holding ConfigManager._file_lock"
         )
         assert "error" not in result, result.get("error")
+        assert lock_was_free.get("free") is True, (
+            "ConfigManager._file_lock was held across get_settings_service(); "
+            "that call reads config through ConfigManager.get_board()"
+        )
         assert result["seeded"] == 1

--- a/tests/test_silence_per_board_composition.py
+++ b/tests/test_silence_per_board_composition.py
@@ -1,0 +1,242 @@
+"""Composition of the per-board silence layers (issue #1788, PR #1801 review).
+
+The per-board silence PR shipped a correct write path, a correct read path and
+a correct migration — and the three did not agree.  The migration seeded
+``features.silence_schedule.by_board[<board>]`` for **every** configured board
+(single-board installs included), the engine always resolves per board, and the
+UI wrote the *install-wide* layer whenever there was only one board.  The
+board-scoped copy then shadowed every subsequent save: the user turned silence
+off, the UI said off, and the board kept snoozing at the old time forever.
+
+These tests pin the composition rather than the pieces:
+
+  - a single-board install's save is what the engine resolves, whichever layer
+    the client writes
+  - the same holds after a 2-board install is reduced to 1 (the surviving
+    board keeps its seeded override while the client flips back to
+    install-wide writes)
+  - removing a board prunes its override instead of leaving an orphan
+  - seeding the migration never re-enters ``ConfigManager._file_lock``
+"""
+
+import json
+import threading
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.api_server import app
+from src.config import Config
+from src.config_manager import ConfigManager
+
+LEGACY_INSTALL_WIDE = {
+    "enabled": True,
+    "start_time": "20:00+00:00",
+    "end_time": "07:00+00:00",
+    "mode": "indicator",
+    "page_id": None,
+    "indicator_text": "SNOOZING",
+    "indicator_position": "center",
+}
+
+BOARD_1 = {"id": "board-1", "name": "Kitchen", "device_type": "flagship", "enabled": True}
+BOARD_2 = {"id": "board-2", "name": "Desk", "device_type": "note", "enabled": True}
+
+
+def _write_config(path: Path, silence: dict) -> None:
+    path.write_text(json.dumps({"features": {"silence_schedule": silence}}))
+
+
+@pytest.fixture
+def real_config(tmp_path: Path):
+    """A real ConfigManager singleton backed by a legacy (pre-#1788) config."""
+    ConfigManager._instance = None
+    path = tmp_path / "config.json"
+    _write_config(path, dict(LEGACY_INSTALL_WIDE))
+    manager = ConfigManager(config_path=str(path))
+    yield manager
+    ConfigManager._instance = None
+
+
+def _boards(*boards):
+    """Patch every settings-service lookup used by the silence paths."""
+    service = Mock()
+    service.get_board_settings.return_value = Mock(boards=list(boards))
+    service.get_primary_board_id.return_value = boards[0]["id"] if boards else None
+    return service
+
+
+def _patch_settings(service):
+    return (
+        patch("src.settings.service.get_settings_service", return_value=service),
+        patch("src.api_server.get_settings_service", return_value=service),
+    )
+
+
+def _save_via_api(client, body: dict) -> None:
+    response = client.put("/settings/silence-schedule", json=body)
+    assert response.status_code == 200, response.text
+
+
+# ==================== single-board composition ====================
+
+
+class TestSingleBoardComposition:
+    """The layer the client writes must be the layer the engine reads."""
+
+    def test_single_board_install_save_is_honored_by_the_engine(self, real_config):
+        """A single-board install turns silence off; the engine must see it off.
+
+        The migration seeds ``by_board["board-1"]`` from the install-wide
+        window, so an install-wide save is shadowed key-by-key unless the two
+        layers are reconciled.
+        """
+        service = _boards(BOARD_1)
+        p1, p2 = _patch_settings(service)
+        with p1, p2:
+            assert real_config.migrate_silence_schedule_to_per_board() >= 0
+
+            client = TestClient(app)
+            _save_via_api(
+                client,
+                {
+                    "enabled": False,
+                    "start_time": "22:30+00:00",
+                    "end_time": "07:00+00:00",
+                    "mode": "indicator",
+                },
+            )
+
+            resolved = Config.silence_config_for("board-1")
+
+        assert resolved["enabled"] is False
+        assert resolved["start_time"] == "22:30+00:00"
+
+    def test_board_scoped_save_is_honored_by_the_engine(self, real_config):
+        """The board-scoped write path resolves for the board the engine drives."""
+        service = _boards(BOARD_1)
+        p1, p2 = _patch_settings(service)
+        with p1, p2:
+            real_config.migrate_silence_schedule_to_per_board()
+
+            client = TestClient(app)
+            _save_via_api(
+                client,
+                {
+                    "enabled": False,
+                    "start_time": "23:15+00:00",
+                    "end_time": "06:00+00:00",
+                    "mode": "indicator",
+                    "board_id": "board-1",
+                },
+            )
+
+            resolved = Config.silence_config_for(service.get_primary_board_id())
+
+        assert resolved["enabled"] is False
+        assert resolved["start_time"] == "23:15+00:00"
+
+    def test_save_after_dropping_from_two_boards_to_one_is_honored(self, real_config):
+        """2 -> 1 board deletion must not strand the survivor's seeded override.
+
+        Reachable without the migration ever running on a single-board install:
+        the client flips back to install-wide writes as soon as only one board
+        is left, while the survivor still carries a board-scoped copy.
+        """
+        two = _boards(BOARD_1, BOARD_2)
+        p1, p2 = _patch_settings(two)
+        with p1, p2:
+            real_config.migrate_silence_schedule_to_per_board()
+
+        one = _boards(BOARD_1)
+        p1, p2 = _patch_settings(one)
+        with p1, p2:
+            client = TestClient(app)
+            _save_via_api(
+                client,
+                {
+                    "enabled": False,
+                    "start_time": "21:45+00:00",
+                    "end_time": "05:30+00:00",
+                    "mode": "indicator",
+                },
+            )
+
+            resolved = Config.silence_config_for("board-1")
+
+        assert resolved["enabled"] is False
+        assert resolved["start_time"] == "21:45+00:00"
+
+
+# ==================== orphan pruning ====================
+
+
+class TestBoardRemovalPrunesOverrides:
+    def test_remove_board_prunes_its_silence_override(self, real_config, tmp_path):
+        """Removing a board deletes its ``by_board`` entry (issue #1788 review)."""
+        from src.settings.service import SettingsService
+
+        real_config.set_silence_schedule_for_board(
+            "board-1", {"enabled": True, "start_time": "01:00+00:00", "end_time": "02:00+00:00"}
+        )
+        real_config.set_silence_schedule_for_board(
+            "board-2", {"enabled": True, "start_time": "03:00+00:00", "end_time": "04:00+00:00"}
+        )
+
+        service = SettingsService.__new__(SettingsService)
+        service._board = Mock(boards=[dict(BOARD_1), dict(BOARD_2)])
+        service._save_to_file = Mock()
+
+        service.remove_board("board-2")
+
+        by_board = real_config.get_feature("silence_schedule")["by_board"]
+        assert "board-2" not in by_board
+        assert by_board["board-1"]["start_time"] == "01:00+00:00"
+
+
+# ==================== lock re-entrancy ====================
+
+
+class TestMigrationLockSafety:
+    def test_seeding_migration_does_not_reenter_the_config_file_lock(self, real_config):
+        """``_configured_board_ids()`` must not be called while holding ``_file_lock``.
+
+        ``get_settings_service()`` constructs a ``SettingsService`` whose
+        ``__init__`` reads ``FB_TRANSITION_STRATEGY`` -> ``Config._get_board()``
+        -> ``ConfigManager.get_board()``, which takes the same non-reentrant
+        ``threading.Lock``.  Held forever, every config read in the process
+        blocks: total freeze, no exception, no timeout.
+
+        Run on a worker thread with a join timeout so the failure is a red
+        test rather than a hung suite.
+        """
+
+        def _settings_service_that_reads_config():
+            # Exactly what SettingsService.__init__ does today.
+            real_config.get_board()
+            return _boards(BOARD_1)
+
+        result: dict[str, object] = {}
+
+        def _run():
+            try:
+                with patch(
+                    "src.settings.service.get_settings_service",
+                    side_effect=_settings_service_that_reads_config,
+                ):
+                    result["seeded"] = real_config.migrate_silence_schedule_to_per_board()
+            except BaseException as exc:  # pragma: no cover - surfaced via result
+                result["error"] = exc
+
+        worker = threading.Thread(target=_run, daemon=True)
+        worker.start()
+        worker.join(timeout=10)
+
+        assert not worker.is_alive(), (
+            "migrate_silence_schedule_to_per_board() deadlocked: it called "
+            "get_settings_service() while holding ConfigManager._file_lock"
+        )
+        assert "error" not in result, result.get("error")
+        assert result["seeded"] == 1

--- a/tests/test_silence_per_board_engine.py
+++ b/tests/test_silence_per_board_engine.py
@@ -1,0 +1,321 @@
+"""Per-board silence delivery through the display engine (issue #1788).
+
+Silence used to be one global decision applied to every board. Now each board
+resolves its own window, mode, page and indicator, so:
+
+  - two boards with different windows go quiet independently
+  - each board's silence page is sized to **that board**, not to the page's
+    own declared device type (the second half of the issue: a Flagship-sized
+    page silently mis-rendered onto a Note)
+  - the 1-second boundary detector in ``run()`` fires when ANY board's silence
+    state flips, not just the primary's
+"""
+
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from src.config import resolve_silence_schedule
+from src.main import BoardRuntime, DisplayService
+
+TRANSITIONS = SimpleNamespace(strategy="instant", step_interval_ms=0, step_size=1)
+
+
+def _board(board_id: str, name: str, **overrides) -> dict:
+    board = {
+        "id": board_id,
+        "name": name,
+        "device_type": "flagship",
+        "board_color": "black",
+        "enabled": True,
+        "paused": False,
+        "api_mode": "local",
+        "host": "mock-host",
+        "port": 7000,
+        "local_api_key": "test-key",
+        "schedule_enabled": True,
+    }
+    board.update(overrides)
+    return board
+
+
+def _page(page_id, device_type="flagship", notes_wide=1, notes_tall=1):
+    return SimpleNamespace(
+        id=page_id,
+        device_type=device_type,
+        notes_wide=notes_wide,
+        notes_tall=notes_tall,
+        transition_strategy=None,
+        transition_interval_ms=None,
+        transition_step_size=None,
+    )
+
+
+def _page_service(specs):
+    svc = MagicMock()
+
+    def _get_page(pid):
+        spec = specs.get(pid)
+        if spec is None:
+            return None
+        return _page(pid, spec.get("device_type", "flagship"), spec.get("notes_wide", 1), spec.get("notes_tall", 1))
+
+    def _preview(pid, force_refresh=False):
+        spec = specs.get(pid)
+        if spec is None:
+            return SimpleNamespace(available=False, formatted="", error="missing")
+        return SimpleNamespace(available=True, formatted=spec["content"], error=None)
+
+    svc.get_page.side_effect = _get_page
+    svc.preview_page.side_effect = _preview
+    svc.list_pages.return_value = [_page(pid) for pid in specs]
+    return svc
+
+
+def _settings_service(boards):
+    svc = MagicMock()
+    svc.get_board_settings.return_value = SimpleNamespace(boards=boards)
+    svc.get_primary_board_id.return_value = boards[0]["id"] if boards else None
+    svc.is_paused.side_effect = lambda board_id=None: False
+    svc.is_schedule_enabled.side_effect = lambda board_id=None: True
+    svc.get_active_page_id.side_effect = lambda board_id=None: None
+    svc.get_transition_settings.return_value = TRANSITIONS
+    svc.consume_temporary_override.return_value = None
+    return svc
+
+
+def _schedule_service(active_by_board):
+    svc = MagicMock()
+    svc.get_active_page_id.side_effect = lambda t, d, board_id=None: active_by_board.get(board_id)
+    return svc
+
+
+def _service_with_runtimes(boards):
+    svc = DisplayService()
+    runtimes = {}
+    clients = {}
+    for board in boards:
+        client = MagicMock()
+        client.render.return_value = (True, True)
+        client._last_characters = None
+        clients[board["id"]] = client
+        runtimes[board["id"]] = BoardRuntime(client=client, board_id=board["id"])
+    svc.runtimes = runtimes
+    svc._primary_board_id = boards[0]["id"] if boards else None
+    return svc, clients
+
+
+class _FakeConfig:
+    """A stand-in for ``Config`` driven by one silence_schedule feature dict.
+
+    Resolution goes through the real :func:`resolve_silence_schedule`, and
+    ``is_silence_mode_active`` consults ``active_boards`` so a test can put one
+    board inside its window and another outside it.
+    """
+
+    def __init__(self, feature, active_boards):
+        self._feature = feature
+        self._active = set(active_boards)
+
+    def silence_config_for(self, board_id=None):
+        return resolve_silence_schedule(self._feature, board_id)
+
+    def is_silence_mode_active(self, board_id=None):
+        return board_id in self._active
+
+
+def _drive(svc, boards, *, config, pages=None, schedule=None, settings=None):
+    settings = settings if settings is not None else _settings_service(boards)
+    pages = pages if pages is not None else _page_service({})
+    schedule = schedule if schedule is not None else _schedule_service({})
+    with (
+        patch("src.main.get_settings_service", return_value=settings),
+        patch("src.main.get_page_service", return_value=pages),
+        patch("src.main.get_schedule_service", return_value=schedule),
+        patch("src.main.get_collection_service", return_value=MagicMock()),
+        patch("src.time_service.get_time_service", return_value=_time_service()),
+        patch("src.main.Config", config),
+        patch.object(svc, "_check_trigger_override", return_value=None),
+        patch.object(svc, "request_board_refresh"),
+    ):
+        return svc.check_and_send_active_page()
+
+
+def _time_service():
+    ts = MagicMock()
+    ts.get_current_time.return_value = datetime(2026, 7, 15, 12, 0, 0)
+    return ts
+
+
+def _decode(board_array):
+    """Turn a board character array back into text for assertions."""
+    rev = {0: " "}
+    for i, ch in enumerate("ABCDEFGHIJKLMNOPQRSTUVWXYZ", start=1):
+        rev[i] = ch
+    for i, ch in enumerate("123456789", start=27):
+        rev[i] = ch
+    rev[36] = "0"
+    out = [("".join(rev.get(code, "?") for code in row)).rstrip() for row in board_array]
+    return "\n".join(line for line in out if line)
+
+
+BASE = {
+    "enabled": True,
+    "start_time": "04:00+00:00",
+    "end_time": "15:00+00:00",
+    "mode": "indicator",
+    "page_id": None,
+    "indicator_text": "SNOOZING",
+    "indicator_position": "center",
+}
+
+
+class TestIndependentSilenceWindows:
+    def test_one_board_silences_while_the_other_keeps_updating(self):
+        boards = [_board("b1", "One"), _board("b2", "Two", port=7001)]
+        svc, clients = _service_with_runtimes(boards)
+        pages = _page_service({"pA": {"content": "ALPHA"}, "pB": {"content": "BETA"}})
+        schedule = _schedule_service({"b1": "pA", "b2": "pB"})
+        config = _FakeConfig(BASE, active_boards={"b1"})
+
+        _drive(svc, boards, config=config, pages=pages, schedule=schedule)
+
+        assert _decode(clients["b1"].render.call_args.args[0]).strip() == "SNOOZING"
+        assert "BETA" in _decode(clients["b2"].render.call_args.args[0])
+        assert svc.runtimes["b1"].snoozing_message_sent is True
+        assert svc.runtimes["b2"].snoozing_message_sent is False
+
+    def test_each_board_uses_its_own_indicator_text_and_position(self):
+        boards = [_board("b1", "One"), _board("b2", "Two", port=7001)]
+        svc, clients = _service_with_runtimes(boards)
+        pages = _page_service({"pA": {"content": "ALPHA"}, "pB": {"content": "BETA"}})
+        schedule = _schedule_service({"b1": "pA", "b2": "pB"})
+        feature = {
+            **BASE,
+            "by_board": {
+                "b1": {"indicator_text": "bedtime", "indicator_position": "top-left"},
+                "b2": {"indicator_text": "quiet"},
+            },
+        }
+        config = _FakeConfig(feature, active_boards={"b1", "b2"})
+
+        _drive(svc, boards, config=config, pages=pages, schedule=schedule)
+
+        rows1 = clients["b1"].render.call_args.args[0]
+        assert _decode(rows1).splitlines()[0].startswith("BEDTIME")
+        rows2 = clients["b2"].render.call_args.args[0]
+        assert _decode(rows2).strip() == "QUIET"
+
+    def test_a_board_can_freeze_while_another_shows_an_indicator(self):
+        boards = [_board("b1", "One"), _board("b2", "Two", port=7001)]
+        svc, clients = _service_with_runtimes(boards)
+        pages = _page_service({"pA": {"content": "ALPHA"}, "pB": {"content": "BETA"}})
+        schedule = _schedule_service({"b1": "pA", "b2": "pB"})
+        feature = {**BASE, "by_board": {"b1": {"mode": "freeze"}}}
+        config = _FakeConfig(feature, active_boards={"b1", "b2"})
+
+        _drive(svc, boards, config=config, pages=pages, schedule=schedule)
+
+        clients["b1"].render.assert_not_called()
+        assert _decode(clients["b2"].render.call_args.args[0]).strip() == "SNOOZING"
+
+
+class TestSilencePageIsSizedToTheBoard:
+    """Issue #1788 bug 2: _send_silence_page ignored the board's geometry."""
+
+    def test_note_board_renders_its_own_note_sized_silence_page(self):
+        boards = [_board("b1", "Flag"), _board("b2", "Desk", device_type="note", port=7001)]
+        svc, clients = _service_with_runtimes(boards)
+        pages = _page_service(
+            {
+                "pA": {"content": "ALPHA"},
+                "pB": {"content": "BETA", "device_type": "note"},
+                "night-big": {"content": "GOOD NIGHT", "device_type": "flagship"},
+                "night-small": {"content": "NIGHT", "device_type": "note"},
+            }
+        )
+        schedule = _schedule_service({"b1": "pA", "b2": "pB"})
+        feature = {
+            **BASE,
+            "mode": "page",
+            "by_board": {
+                "b1": {"mode": "page", "page_id": "night-big"},
+                "b2": {"mode": "page", "page_id": "night-small"},
+            },
+        }
+        config = _FakeConfig(feature, active_boards={"b1", "b2"})
+
+        _drive(svc, boards, config=config, pages=pages, schedule=schedule)
+
+        rows1 = clients["b1"].render.call_args.args[0]
+        assert (len(rows1), len(rows1[0])) == (6, 22)
+        assert "GOOD NIGHT" in _decode(rows1)
+
+        rows2 = clients["b2"].render.call_args.args[0]
+        assert (len(rows2), len(rows2[0])) == (3, 15)
+        assert "NIGHT" in _decode(rows2)
+
+    def test_page_wider_than_the_board_is_rendered_at_board_size(self):
+        """Regression: a Flagship-sized page used to be rendered at 22 cols
+        onto a 15-col Note, so the array handed to the client did not match
+        the hardware."""
+        boards = [_board("b1", "Desk", device_type="note")]
+        svc, clients = _service_with_runtimes(boards)
+        pages = _page_service(
+            {
+                "pA": {"content": "ALPHA", "device_type": "note"},
+                "wide": {"content": "GOOD NIGHT EVERYBODY", "device_type": "flagship"},
+            }
+        )
+        schedule = _schedule_service({"b1": "pA"})
+        feature = {**BASE, "mode": "page", "page_id": "wide"}
+        config = _FakeConfig(feature, active_boards={"b1"})
+
+        _drive(svc, boards, config=config, pages=pages, schedule=schedule)
+
+        rows = clients["b1"].render.call_args.args[0]
+        assert (len(rows), len(rows[0])) == (3, 15)
+        assert clients["b1"].render.call_args.kwargs["device_type"] == "note"
+
+    def test_missing_silence_page_falls_back_to_a_board_sized_indicator(self):
+        boards = [_board("b1", "Desk", device_type="note")]
+        svc, clients = _service_with_runtimes(boards)
+        pages = _page_service({"pA": {"content": "ALPHA", "device_type": "note"}})
+        schedule = _schedule_service({"b1": "pA"})
+        feature = {**BASE, "mode": "page", "page_id": "gone"}
+        config = _FakeConfig(feature, active_boards={"b1"})
+
+        _drive(svc, boards, config=config, pages=pages, schedule=schedule)
+
+        rows = clients["b1"].render.call_args.args[0]
+        assert (len(rows), len(rows[0])) == (3, 15)
+        assert _decode(rows).strip() == "SNOOZING"
+
+
+class TestBoundaryDetector:
+    """The run() loop's 1s detector must watch every board, not just primary."""
+
+    def test_reports_a_change_when_a_secondary_board_crosses_its_boundary(self):
+        boards = [_board("b1", "One"), _board("b2", "Two", port=7001)]
+        svc, _clients = _service_with_runtimes(boards)
+        settings = _settings_service(boards)
+
+        with patch("src.main.get_settings_service", return_value=settings):
+            with patch("src.main.Config", _FakeConfig(BASE, active_boards=set())):
+                assert svc._silence_state_changed() is False
+            with patch("src.main.Config", _FakeConfig(BASE, active_boards={"b2"})):
+                assert svc._silence_state_changed() is True
+            # Sticky: no further change until the state flips again.
+            with patch("src.main.Config", _FakeConfig(BASE, active_boards={"b2"})):
+                assert svc._silence_state_changed() is False
+
+    def test_reports_a_change_when_the_primary_crosses_its_boundary(self):
+        boards = [_board("b1", "One")]
+        svc, _clients = _service_with_runtimes(boards)
+        settings = _settings_service(boards)
+
+        with patch("src.main.get_settings_service", return_value=settings):
+            with patch("src.main.Config", _FakeConfig(BASE, active_boards=set())):
+                assert svc._silence_state_changed() is False
+            with patch("src.main.Config", _FakeConfig(BASE, active_boards={"b1"})):
+                assert svc._silence_state_changed() is True

--- a/tests/test_silence_schedule_per_board_api.py
+++ b/tests/test_silence_schedule_per_board_api.py
@@ -73,6 +73,7 @@ def boards():
     with patch("src.api_server.get_settings_service") as mock_get:
         svc = Mock()
         svc.get_board_settings.return_value = Mock(boards=[FLAGSHIP, NOTE])
+        svc.get_primary_board_id.return_value = FLAGSHIP["id"]
         mock_get.return_value = svc
         yield svc
 
@@ -94,14 +95,34 @@ class TestGetSilenceStatusPerBoard:
         assert data["start_time_utc"] == "04:00+00:00"
         assert data["board_id"] == "flag-1"
 
-    def test_omitting_board_id_keeps_legacy_global_reading(self, client, silence_store, boards):
+    def test_omitting_board_id_reports_the_primary_board(self, client, silence_store, boards):
+        """Runtime status, not a config dump: no board means the primary board.
+
+        This replaces an assertion that omitting ``board_id`` returns the
+        install-wide layer. That contract broke the single-board install: the
+        settings form writes the board layer, so the dashboard overlay, the
+        silence-imminent banner and this endpoint all kept reporting the
+        pre-save window (PR #1801 review). The install-wide layer is still
+        readable as raw config through ``GET /settings/all``.
+        """
+        _cm, store = silence_store
+        store["by_board"]["flag-1"] = {"start_time": "06:00+00:00", "end_time": "12:00+00:00"}
+
+        data = client.get("/silence-status").json()
+
+        assert data["start_time_utc"] == "06:00+00:00"
+        assert data["end_time_utc"] == "12:00+00:00"
+        assert data["board_id"] == "flag-1"
+
+    def test_a_board_without_its_own_entry_still_reads_the_install_wide_window(self, client, silence_store, boards):
+        """The primary board with no override inherits the install-wide values."""
         _cm, store = silence_store
         store["by_board"]["note-1"] = {"start_time": "06:00+00:00", "end_time": "12:00+00:00"}
 
         data = client.get("/silence-status").json()
 
         assert data["start_time_utc"] == "04:00+00:00"
-        assert data["board_id"] is None
+        assert data["board_id"] == "flag-1"
 
     def test_per_board_mode_and_page_are_reported(self, client, silence_store, boards):
         _cm, store = silence_store

--- a/tests/test_silence_schedule_per_board_api.py
+++ b/tests/test_silence_schedule_per_board_api.py
@@ -1,0 +1,233 @@
+"""Board-scoped silence schedule API (issue #1788).
+
+``GET /silence-status`` takes an optional ``board_id`` query param and
+``PUT /settings/silence-schedule`` takes an optional ``board_id`` in the
+**body** (mirroring ``PUT /settings/active-page``; the path must not change
+because the web client asserts it).
+
+Also covers the second half of the issue: the silence page must be validated
+against the *target board's* size, so a 22x6 Flagship page can no longer be
+selected for a 15x3 Note.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.api_server import app
+
+FLAGSHIP = {"id": "flag-1", "name": "Kitchen", "device_type": "flagship"}
+NOTE = {"id": "note-1", "name": "Desk", "device_type": "note"}
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def silence_store():
+    """Config manager backed by a real dict, with per-board write support."""
+    with patch("src.api_server.get_config_manager") as mock_get:
+        cm = Mock()
+        store = {
+            "enabled": True,
+            "start_time": "04:00+00:00",
+            "end_time": "15:00+00:00",
+            "mode": "freeze",
+            "page_id": None,
+            "indicator_text": "SNOOZING",
+            "indicator_position": "center",
+            "by_board": {},
+        }
+
+        def _get_feature(name):
+            return dict(store) if name == "silence_schedule" else {}
+
+        def _set_feature(name, value):
+            if name != "silence_schedule":
+                return False
+            by_board = store.get("by_board", {})
+            store.clear()
+            store.update(value)
+            store.setdefault("by_board", by_board)
+            return True
+
+        def _set_for_board(board_id, values):
+            store.setdefault("by_board", {})[board_id] = dict(values)
+            return True
+
+        cm.get_feature.side_effect = _get_feature
+        cm.set_feature.side_effect = _set_feature
+        cm.set_silence_schedule_for_board.side_effect = _set_for_board
+        cm.migrate_silence_schedule_to_utc.return_value = False
+        cm.migrate_silence_schedule_to_per_board.return_value = 0
+        mock_get.return_value = cm
+        yield cm, store
+
+
+@pytest.fixture
+def boards():
+    """Two boards of different sizes registered with the settings service."""
+    with patch("src.api_server.get_settings_service") as mock_get:
+        svc = Mock()
+        svc.get_board_settings.return_value = Mock(boards=[FLAGSHIP, NOTE])
+        mock_get.return_value = svc
+        yield svc
+
+
+class TestGetSilenceStatusPerBoard:
+    def test_board_id_returns_that_boards_window(self, client, silence_store, boards):
+        _cm, store = silence_store
+        store["by_board"]["note-1"] = {"start_time": "06:00+00:00", "end_time": "12:00+00:00"}
+
+        data = client.get("/silence-status?board_id=note-1").json()
+
+        assert data["start_time_utc"] == "06:00+00:00"
+        assert data["end_time_utc"] == "12:00+00:00"
+        assert data["board_id"] == "note-1"
+
+    def test_unconfigured_board_falls_back_to_install_wide_window(self, client, silence_store, boards):
+        data = client.get("/silence-status?board_id=flag-1").json()
+
+        assert data["start_time_utc"] == "04:00+00:00"
+        assert data["board_id"] == "flag-1"
+
+    def test_omitting_board_id_keeps_legacy_global_reading(self, client, silence_store, boards):
+        _cm, store = silence_store
+        store["by_board"]["note-1"] = {"start_time": "06:00+00:00", "end_time": "12:00+00:00"}
+
+        data = client.get("/silence-status").json()
+
+        assert data["start_time_utc"] == "04:00+00:00"
+        assert data["board_id"] is None
+
+    def test_per_board_mode_and_page_are_reported(self, client, silence_store, boards):
+        _cm, store = silence_store
+        store["by_board"]["note-1"] = {"mode": "page", "page_id": "note-night"}
+
+        data = client.get("/silence-status?board_id=note-1").json()
+
+        assert data["mode"] == "page"
+        assert data["page_id"] == "note-night"
+
+    def test_status_never_leaks_by_board(self, client, silence_store, boards):
+        assert "by_board" not in client.get("/silence-status").json()
+
+
+class TestPutSilenceSchedulePerBoard:
+    def _body(self, **overrides):
+        body = {"enabled": True, "start_time": "06:00+00:00", "end_time": "12:00+00:00"}
+        body.update(overrides)
+        return body
+
+    def test_board_id_in_body_writes_only_that_board(self, client, silence_store, boards):
+        cm, store = silence_store
+
+        response = client.put("/settings/silence-schedule", json=self._body(board_id="note-1"))
+
+        assert response.status_code == 200
+        assert response.json()["board_id"] == "note-1"
+        cm.set_feature.assert_not_called()
+        assert store["by_board"]["note-1"]["start_time"] == "06:00+00:00"
+        # The install-wide layer is untouched.
+        assert store["start_time"] == "04:00+00:00"
+
+    def test_omitting_board_id_still_writes_the_install_wide_layer(self, client, silence_store, boards):
+        cm, store = silence_store
+
+        response = client.put("/settings/silence-schedule", json=self._body())
+
+        assert response.status_code == 200
+        assert response.json()["board_id"] is None
+        cm.set_feature.assert_called_once()
+        assert store["start_time"] == "06:00+00:00"
+
+    def test_unknown_board_returns_404(self, client, silence_store, boards):
+        response = client.put("/settings/silence-schedule", json=self._body(board_id="ghost"))
+
+        assert response.status_code == 404
+        assert "ghost" in response.json()["detail"]
+
+    def test_response_config_is_the_resolved_board_config(self, client, silence_store, boards):
+        client.put(
+            "/settings/silence-schedule",
+            json=self._body(board_id="note-1", mode="indicator", indicator_text="hush"),
+        )
+        data = client.put("/settings/silence-schedule", json=self._body(board_id="note-1")).json()
+
+        assert data["config"]["start_time"] == "06:00+00:00"
+        assert "by_board" not in data["config"]
+
+    def test_normalisation_rules_still_apply_per_board(self, client, silence_store, boards):
+        data = client.put(
+            "/settings/silence-schedule",
+            json=self._body(board_id="note-1", mode="garbage", indicator_text="  hush  ", indicator_position="up"),
+        ).json()
+
+        assert data["config"]["mode"] == "freeze"
+        assert data["config"]["indicator_text"] == "HUSH"
+        assert data["config"]["indicator_position"] == "center"
+
+    def test_page_mode_without_page_id_still_400s_per_board(self, client, silence_store, boards):
+        response = client.put("/settings/silence-schedule", json=self._body(board_id="note-1", mode="page"))
+        assert response.status_code == 400
+
+
+class TestSilencePageBoardCompatibility:
+    """Issue #1788 bug 2: the silence page must fit the target board."""
+
+    def _compat(self, ok, error=None):
+        return patch("src.api_server.check_ref_board_compatibility", return_value=Mock(ok=ok, error=error, warnings=[]))
+
+    def test_flagship_page_is_rejected_for_a_note_board(self, client, silence_store, boards):
+        with self._compat(False, "Page 'Big' (flagship) is not compatible with board 'Desk' (note)") as spy:
+            response = client.put(
+                "/settings/silence-schedule",
+                json={
+                    "enabled": True,
+                    "start_time": "06:00+00:00",
+                    "end_time": "12:00+00:00",
+                    "mode": "page",
+                    "page_id": "big-page",
+                    "board_id": "note-1",
+                },
+            )
+
+        assert response.status_code == 400
+        assert "not compatible" in response.json()["detail"]
+        spy.assert_called_once_with("big-page", "note-1")
+
+    def test_compatible_page_is_accepted(self, client, silence_store, boards):
+        with self._compat(True):
+            response = client.put(
+                "/settings/silence-schedule",
+                json={
+                    "enabled": True,
+                    "start_time": "06:00+00:00",
+                    "end_time": "12:00+00:00",
+                    "mode": "page",
+                    "page_id": "small-page",
+                    "board_id": "note-1",
+                },
+            )
+
+        assert response.status_code == 200
+
+    def test_no_board_id_skips_the_board_check(self, client, silence_store, boards):
+        """Legacy install-wide writes have no board to validate against."""
+        with self._compat(False, "nope") as spy:
+            response = client.put(
+                "/settings/silence-schedule",
+                json={
+                    "enabled": True,
+                    "start_time": "06:00+00:00",
+                    "end_time": "12:00+00:00",
+                    "mode": "page",
+                    "page_id": "big-page",
+                },
+            )
+
+        assert response.status_code == 200
+        spy.assert_not_called()

--- a/tests/test_silence_schedule_polling.py
+++ b/tests/test_silence_schedule_polling.py
@@ -269,7 +269,10 @@ class TestSilenceBoundaryDetector:
         mocks["settings"].return_value.is_paused.return_value = True
 
         silence = {"active": False}
-        mocks["config"].is_silence_mode_active.side_effect = lambda: silence["active"]
+        # Since issue #1788 the engine resolves silence per board, so the stub
+        # has to accept the board_id the drive path and the boundary detector
+        # both pass.
+        mocks["config"].is_silence_mode_active.side_effect = lambda board_id=None: silence["active"]
 
         def _flip_at_tick_3(tick):
             if tick == 3:

--- a/tests/test_silence_schedule_polling.py
+++ b/tests/test_silence_schedule_polling.py
@@ -42,6 +42,18 @@ def service_factory():
         mocks["config"].SILENCE_SCHEDULE_INDICATOR_TEXT = "SNOOZING"
         mocks["config"].SILENCE_SCHEDULE_INDICATOR_POSITION = "center"
         mocks["config"].SILENCE_SCHEDULE_PAGE_ID = None
+        # Since issue #1788 the engine resolves a board's silence settings via
+        # Config.silence_config_for(board_id); the classproperties above are
+        # only the install-wide mirror.
+        mocks["config"].silence_config_for.return_value = {
+            "enabled": True,
+            "start_time": "04:00+00:00",
+            "end_time": "15:00+00:00",
+            "mode": "indicator",
+            "page_id": None,
+            "indicator_text": "SNOOZING",
+            "indicator_position": "center",
+        }
 
         settings_service = Mock()
         settings_service.is_schedule_enabled.return_value = False

--- a/tests/test_transitions_api.py
+++ b/tests/test_transitions_api.py
@@ -340,7 +340,8 @@ def live_env(monkeypatch, patched_registry):
     fake_service = SimpleNamespace(vb_client=board_client, get_board_client=lambda board_id: board_client)
     monkeypatch.setattr(api_server, "get_service", lambda: fake_service)
     monkeypatch.setattr(api_server, "get_page_service", _FakePageService)
-    monkeypatch.setattr(api_server.Config, "is_silence_mode_active", staticmethod(lambda: False))
+    # Since issue #1788 the guard resolves the target board, so the stub takes a board_id.
+    monkeypatch.setattr(api_server.Config, "is_silence_mode_active", staticmethod(lambda board_id=None: False))
     monkeypatch.setattr(api_server, "_board_is_paused", lambda board_id=None: False)
     monkeypatch.setattr(api_server, "LIVE_TEST_FROM_HOLD_SECONDS", 0)
     return board_client
@@ -398,7 +399,7 @@ def test_live_without_from_page_skips_snap(live_env):
 
 
 def test_live_blocked_by_silence_mode(live_env, monkeypatch):
-    monkeypatch.setattr(api_server.Config, "is_silence_mode_active", staticmethod(lambda: True))
+    monkeypatch.setattr(api_server.Config, "is_silence_mode_active", staticmethod(lambda board_id=None: True))
     with pytest.raises(HTTPException) as exc:
         _run(run_live_transition_test({"plugin_id": "fake_typewriter", "to_page_id": "page-to"}))
     assert exc.value.status_code == 409

--- a/web/src/__tests__/mocks/handlers.ts
+++ b/web/src/__tests__/mocks/handlers.ts
@@ -847,9 +847,11 @@ export const handlers = [
     });
   }),
 
-  // Silence status endpoint
-  http.get(`${API_BASE}/silence-status`, () => {
-    return HttpResponse.json(mockSilenceStatus);
+  // Silence status endpoint. Echoes board_id back like the real endpoint
+  // (issue #1788); the window itself is the install-wide one.
+  http.get(`${API_BASE}/silence-status`, ({ request }) => {
+    const boardId = new URL(request.url).searchParams.get("board_id");
+    return HttpResponse.json({ ...mockSilenceStatus, board_id: boardId });
   }),
 
   // Silence schedule update endpoint (system feature, not a plugin)
@@ -858,10 +860,12 @@ export const handlers = [
       enabled: boolean;
       start_time: string;
       end_time: string;
+      board_id?: string;
     };
     return HttpResponse.json({
       status: "success",
       config: body,
+      board_id: body.board_id ?? null,
     });
   }),
 

--- a/web/src/__tests__/silence-schedule-per-board.test.tsx
+++ b/web/src/__tests__/silence-schedule-per-board.test.tsx
@@ -7,8 +7,10 @@
 //
 // Covers:
 // - resolveSilenceConfig: per-board entry wins, unconfigured board falls back
-// - multi-board: the form seeds from the selected board's entry
-// - multi-board: PUT carries board_id; single-board: it does not (byte-identical)
+// - the form seeds from the selected board's entry
+// - PUT always carries board_id, single-board installs included: the engine
+//   resolves per board on every install, so the layer the form writes has to
+//   be the layer the engine reads (PR #1801 review, BLOCKER 1)
 // - the page picker only offers pages that fit the selected board
 // - saving invalidates the silenceStatus query key the consumers actually use
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -139,9 +141,15 @@ describe("SilenceSchedule - board scoping", () => {
   beforeEach(() => vi.clearAllMocks());
   afterEach(() => server.resetHandlers());
 
-  it("sends no board_id on a single-board install", async () => {
-    const puts: unknown[] = [];
-    stub({ boards: [FLAGSHIP], onPut: (b) => puts.push(b) });
+  // This replaces an assertion that encoded the wrong contract
+  // (`expect(puts[0]).not.toHaveProperty("board_id")`). Omitting board_id on a
+  // single-board install writes the install-wide layer, but the engine always
+  // resolves per board (`check_and_send_for_board(primary_id, ...)`), so a
+  // seeded `by_board` entry shadowed the save key-by-key and the board kept
+  // snoozing at the old time forever.
+  it("sends the board_id on a single-board install so the save reaches the engine", async () => {
+    const puts: Array<Record<string, unknown>> = [];
+    stub({ boards: [FLAGSHIP], onPut: (b) => puts.push(b as Record<string, unknown>) });
     const user = userEvent.setup();
     const { Wrapper } = makeWrapper();
     render(<SilenceSchedule />, { wrapper: Wrapper });
@@ -151,7 +159,7 @@ describe("SilenceSchedule - board scoping", () => {
     await user.type(textInput, "ZZZZ");
 
     await waitFor(() => expect(puts.length).toBeGreaterThan(0), { timeout: 5000 });
-    expect(puts[0]).not.toHaveProperty("board_id");
+    expect(puts[0].board_id).toBe("flag-1");
   });
 
   it("sends the selected board_id on a multi-board install", async () => {
@@ -172,6 +180,22 @@ describe("SilenceSchedule - board scoping", () => {
   it("seeds the form from the selected board's own entry", async () => {
     stub({
       boards: [FLAGSHIP, NOTE],
+      silence: { by_board: { "flag-1": { indicator_text: "BEDTIME" } } },
+    });
+    const { Wrapper } = makeWrapper();
+    render(<SilenceSchedule />, { wrapper: Wrapper });
+
+    const text = await screen.findByLabelText(/message text/i);
+    await waitFor(() => expect((text as HTMLInputElement).value).toBe("BEDTIME"));
+  });
+
+  // The read half of the same bug: a single-board install that has a
+  // `by_board` entry (every upgraded install does — the seeding migration
+  // writes one) showed the install-wide values while the engine used the
+  // board entry, so the form and the board disagreed with no feedback.
+  it("seeds the form from the board's own entry on a single-board install", async () => {
+    stub({
+      boards: [FLAGSHIP],
       silence: { by_board: { "flag-1": { indicator_text: "BEDTIME" } } },
     });
     const { Wrapper } = makeWrapper();

--- a/web/src/__tests__/silence-schedule-per-board.test.tsx
+++ b/web/src/__tests__/silence-schedule-per-board.test.tsx
@@ -1,0 +1,228 @@
+// Per-board silence schedule UI (issue #1788)
+//
+// Silence settings used to be global: every board shared one quiet period and
+// one silence page, so a Note and a Flagship could not both have a valid page.
+// The form now scopes to the selected board in multi-board installs and
+// filters the page picker to pages that fit that board.
+//
+// Covers:
+// - resolveSilenceConfig: per-board entry wins, unconfigured board falls back
+// - multi-board: the form seeds from the selected board's entry
+// - multi-board: PUT carries board_id; single-board: it does not (byte-identical)
+// - the page picker only offers pages that fit the selected board
+// - saving invalidates the silenceStatus query key the consumers actually use
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CurrentBoardProvider } from "@/components/current-board-context";
+import { SilenceSchedule } from "@/components/settings/silence-schedule";
+import { queryKeys } from "@/hooks/use-board";
+import { ThemeProvider } from "@/hooks/use-theme";
+import { resolveSilenceConfig } from "@/lib/silence-config";
+
+import { mockOutputSettings, mockTransitionSettings } from "./mocks/handlers";
+import { server } from "./mocks/server";
+
+vi.mock("@/hooks/use-router", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn(), back: vi.fn(), forward: vi.fn() }),
+  usePathname: () => "/settings",
+}));
+
+const API_BASE = "/api";
+
+const FLAGSHIP = { id: "flag-1", name: "Kitchen", device_type: "flagship", board_color: "black" };
+const NOTE = { id: "note-1", name: "Desk", device_type: "note", board_color: "white" };
+
+const PAGES = [
+  { id: "big", name: "Big Page", device_type: "flagship", notes_wide: 1, notes_tall: 1 },
+  { id: "small", name: "Small Page", device_type: "note", notes_wide: 1, notes_tall: 1 },
+];
+
+function allSettingsResponse(silenceOverrides: Record<string, unknown> = {}, boards = [FLAGSHIP]) {
+  return {
+    general: { timezone: "UTC", refresh_interval_seconds: 300, output_target: "board" },
+    silence_schedule: {
+      config: {
+        enabled: true,
+        start_time: "04:00+00:00",
+        end_time: "15:00+00:00",
+        mode: "indicator",
+        page_id: null,
+        indicator_text: "SNOOZING",
+        indicator_position: "center",
+        ...silenceOverrides,
+      },
+    },
+    polling: { interval_seconds: 15 },
+    transitions: mockTransitionSettings,
+    output: mockOutputSettings,
+    board: { board_type: "black", boards, devices: ["flagship"] },
+    mqtt: { enabled: false, broker_host: "localhost", broker_port: 1883, username: "", password: "", external_url: "" },
+    status: { running: true, config_summary: {} },
+  };
+}
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider attribute="class" defaultTheme="light">
+          <CurrentBoardProvider>{children}</CurrentBoardProvider>
+        </ThemeProvider>
+      </QueryClientProvider>
+    );
+  }
+  return { Wrapper, queryClient };
+}
+
+function stub({ boards = [FLAGSHIP], silence = {} as Record<string, unknown>, onPut = (_body: unknown) => {} }) {
+  server.use(
+    http.get(`${API_BASE}/settings/all`, () => HttpResponse.json(allSettingsResponse(silence, boards))),
+    http.get(`${API_BASE}/settings/board`, () =>
+      HttpResponse.json({ board_type: "black", boards, devices: ["flagship"] }),
+    ),
+    http.get(`${API_BASE}/pages`, () => HttpResponse.json({ pages: PAGES, total: PAGES.length })),
+    http.put(`${API_BASE}/settings/silence-schedule`, async ({ request }) => {
+      const body = await request.json();
+      onPut(body);
+      return HttpResponse.json({ status: "success", config: body, board_id: null });
+    }),
+  );
+}
+
+describe("resolveSilenceConfig", () => {
+  const base = {
+    enabled: true,
+    start_time: "04:00+00:00",
+    end_time: "15:00+00:00",
+    mode: "freeze" as const,
+    page_id: null,
+    indicator_text: "SNOOZING",
+    indicator_position: "center",
+  };
+
+  it("returns the install-wide layer when no board is given", () => {
+    const resolved = resolveSilenceConfig({ ...base, by_board: { "note-1": { start_time: "06:00+00:00" } } });
+    expect(resolved.start_time).toBe("04:00+00:00");
+  });
+
+  it("lets a board's own entry win key by key", () => {
+    const resolved = resolveSilenceConfig(
+      { ...base, by_board: { "note-1": { start_time: "06:00+00:00", mode: "page", page_id: "small" } } },
+      "note-1",
+    );
+    expect(resolved.start_time).toBe("06:00+00:00");
+    expect(resolved.mode).toBe("page");
+    expect(resolved.page_id).toBe("small");
+    // Not overridden -> inherited from the install-wide layer.
+    expect(resolved.end_time).toBe("15:00+00:00");
+  });
+
+  it("falls back to the install-wide layer for a board with no entry", () => {
+    const resolved = resolveSilenceConfig({ ...base, by_board: { "note-1": { start_time: "06:00+00:00" } } }, "flag-1");
+    expect(resolved.start_time).toBe("04:00+00:00");
+  });
+
+  it("never leaks by_board into the resolved config", () => {
+    const resolved = resolveSilenceConfig({ ...base, by_board: { "note-1": {} } }, "note-1");
+    expect(resolved).not.toHaveProperty("by_board");
+  });
+});
+
+describe("SilenceSchedule - board scoping", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => server.resetHandlers());
+
+  it("sends no board_id on a single-board install", async () => {
+    const puts: unknown[] = [];
+    stub({ boards: [FLAGSHIP], onPut: (b) => puts.push(b) });
+    const user = userEvent.setup();
+    const { Wrapper } = makeWrapper();
+    render(<SilenceSchedule />, { wrapper: Wrapper });
+
+    const textInput = await screen.findByLabelText(/message text/i);
+    await user.clear(textInput);
+    await user.type(textInput, "ZZZZ");
+
+    await waitFor(() => expect(puts.length).toBeGreaterThan(0), { timeout: 5000 });
+    expect(puts[0]).not.toHaveProperty("board_id");
+  });
+
+  it("sends the selected board_id on a multi-board install", async () => {
+    const puts: Array<Record<string, unknown>> = [];
+    stub({ boards: [FLAGSHIP, NOTE], onPut: (b) => puts.push(b as Record<string, unknown>) });
+    const user = userEvent.setup();
+    const { Wrapper } = makeWrapper();
+    render(<SilenceSchedule />, { wrapper: Wrapper });
+
+    const textInput = await screen.findByLabelText(/message text/i);
+    await user.clear(textInput);
+    await user.type(textInput, "ZZZZ");
+
+    await waitFor(() => expect(puts.length).toBeGreaterThan(0), { timeout: 5000 });
+    expect(puts[0].board_id).toBe("flag-1");
+  });
+
+  it("seeds the form from the selected board's own entry", async () => {
+    stub({
+      boards: [FLAGSHIP, NOTE],
+      silence: { by_board: { "flag-1": { indicator_text: "BEDTIME" } } },
+    });
+    const { Wrapper } = makeWrapper();
+    render(<SilenceSchedule />, { wrapper: Wrapper });
+
+    const text = await screen.findByLabelText(/message text/i);
+    await waitFor(() => expect((text as HTMLInputElement).value).toBe("BEDTIME"));
+  });
+});
+
+describe("SilenceSchedule - page picker board compatibility", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => server.resetHandlers());
+
+  it("only offers pages that fit the selected board", async () => {
+    stub({ boards: [FLAGSHIP, NOTE], silence: { mode: "page", page_id: "big" } });
+    const user = userEvent.setup();
+    const { Wrapper } = makeWrapper();
+    render(<SilenceSchedule />, { wrapper: Wrapper });
+
+    const picker = await screen.findByRole("combobox", { name: /silence page/i });
+    await user.click(picker);
+
+    // Current board is the flagship: the Note page must not be offered.
+    // "Big Page" appears twice (trigger label + option), hence findAllByText.
+    expect((await screen.findAllByText("Big Page")).length).toBeGreaterThan(0);
+    expect(screen.queryByText("Small Page")).not.toBeInTheDocument();
+  });
+});
+
+describe("SilenceSchedule - cache invalidation", () => {
+  beforeEach(() => vi.clearAllMocks());
+  afterEach(() => server.resetHandlers());
+
+  it("invalidates the silenceStatus key the consumers actually read", async () => {
+    // Regression: the mutation invalidated ["silence-status"] (hyphenated)
+    // while SilenceImminentBanner / ActivePageDisplay read ["silenceStatus"],
+    // so the banner kept showing a stale window after a save.
+    stub({ boards: [FLAGSHIP] });
+    const user = userEvent.setup();
+    const { Wrapper, queryClient } = makeWrapper();
+    const spy = vi.spyOn(queryClient, "invalidateQueries");
+    render(<SilenceSchedule />, { wrapper: Wrapper });
+
+    const textInput = await screen.findByLabelText(/message text/i);
+    await user.clear(textInput);
+    await user.type(textInput, "ZZZZ");
+
+    await waitFor(
+      () => expect(spy).toHaveBeenCalledWith(expect.objectContaining({ queryKey: queryKeys.silenceStatus() })),
+      { timeout: 5000 },
+    );
+  });
+});

--- a/web/src/components/active-page-display.tsx
+++ b/web/src/components/active-page-display.tsx
@@ -165,8 +165,8 @@ export function ActivePageDisplay() {
 
   // Fetch silence mode status to show snoozing indicator
   const { data: silenceStatus } = useQuery<SilenceStatus>({
-    queryKey: ["silenceStatus"],
-    queryFn: api.getSilenceStatus,
+    queryKey: queryKeys.silenceStatus(scopedBoardId),
+    queryFn: () => api.getSilenceStatus(scopedBoardId),
   });
 
   // Fetch live board state so the Home display reflects what was last sent

--- a/web/src/components/settings/silence-schedule.tsx
+++ b/web/src/components/settings/silence-schedule.tsx
@@ -19,14 +19,17 @@ import {
 import { Spinner } from "@fiestaboard/ui/components/feedback/spinner";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Moon } from "lucide-react";
-import { useDeferredValue, useEffect, useState } from "react";
+import { useDeferredValue, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
+import { useCurrentBoard } from "@/components/current-board-context";
 import { TimePicker } from "@/components/ui/time-picker";
-import { usePages } from "@/hooks/use-board";
+import { queryKeys, usePages } from "@/hooks/use-board";
 import { useDepsChanged } from "@/hooks/use-deps-changed";
 import { useTranslations } from "@/i18n/translations";
 import { api } from "@/lib/api";
+import { pagesCompatibleWithBoard } from "@/lib/board-dimensions";
+import { resolveSilenceConfig } from "@/lib/silence-config";
 import { localTimeToUTC, utcToLocalTime } from "@/lib/timezone-utils";
 
 type SilenceMode = "indicator" | "freeze" | "page";
@@ -35,6 +38,12 @@ export function SilenceSchedule() {
   const t = useTranslations("generalSettings");
   const tc = useTranslations("common");
   const queryClient = useQueryClient();
+
+  // Silence settings are per board (issue #1788). Scope only in multi-board
+  // installs so a single-board install behaves exactly as before.
+  const { currentBoardId, currentBoard, boards } = useCurrentBoard();
+  const isMultiBoard = boards.length > 1;
+  const scopedBoardId = isMultiBoard && currentBoardId ? currentBoardId : undefined;
 
   const [hasChanges, setHasChanges] = useState(false);
   const [silenceEnabled, setSilenceEnabled] = useState(false);
@@ -58,14 +67,17 @@ export function SilenceSchedule() {
   // of replacing 20:00/07:00 a render later (react-hooks/set-state-in-effect,
   // issue #1568). The "once" guard is state, not a ref, because refs must not
   // be read during render either.
-  const [initialized, setInitialized] = useState(false);
-  const configChanged = useDepsChanged([deferredSilenceConfig, generalConfig?.timezone]);
+  // Keyed by board rather than a bare boolean: switching boards must re-seed
+  // the form from that board's own settings (issue #1788).
+  const [initializedFor, setInitializedFor] = useState<string | null>(null);
+  const seedKey = scopedBoardId ?? "";
+  const configChanged = useDepsChanged([deferredSilenceConfig, generalConfig?.timezone, seedKey]);
 
-  if (configChanged && !initialized) {
+  if (configChanged && initializedFor !== seedKey) {
     const rawConfig = (deferredSilenceConfig as { config?: Record<string, unknown> } | undefined)?.config;
     if (rawConfig && generalConfig?.timezone) {
       const userTimezone = generalConfig.timezone ?? "America/Los_Angeles";
-      const config = rawConfig;
+      const config = resolveSilenceConfig(rawConfig as never, scopedBoardId) as Record<string, unknown>;
 
       setSilenceEnabled((config.enabled as boolean) ?? false);
 
@@ -83,7 +95,7 @@ export function SilenceSchedule() {
       setSilenceIndicatorPosition(((config.indicator_position as string) ?? "") || "center");
 
       setHasChanges(false);
-      setInitialized(true);
+      setInitializedFor(seedKey);
     }
   }
 
@@ -91,7 +103,11 @@ export function SilenceSchedule() {
     mutationFn: (data: Parameters<typeof api.updateSilenceSchedule>[0]) => api.updateSilenceSchedule(data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["all-settings"], refetchType: "active" });
-      queryClient.invalidateQueries({ queryKey: ["silence-status"], refetchType: "active" });
+      // Unscoped key = prefix match, so every board-scoped variant refetches
+      // too. This used to invalidate ["silence-status"] (hyphenated) while the
+      // consumers read ["silenceStatus"] (camelCase), so the invalidation
+      // silently missed and the banner kept a stale window.
+      queryClient.invalidateQueries({ queryKey: queryKeys.silenceStatus(), refetchType: "active" });
       toast.success(t("toastSettingsSaved"));
     },
     onError: (error: Error) => {
@@ -100,7 +116,15 @@ export function SilenceSchedule() {
   });
 
   const { data: pagesData } = usePages();
-  const availablePages = pagesData?.pages ?? [];
+  // Only offer pages that fit this board (issue #1788): a 22x6 Flagship page
+  // used to be selectable as a 15x3 Note board's silence page and then
+  // silently mis-rendered. The current selection is always kept so an
+  // existing (possibly stale) choice stays visible instead of vanishing.
+  const availablePages = useMemo(() => {
+    const pages = pagesData?.pages ?? [];
+    if (!currentBoard) return pages;
+    return pages.filter((p) => p.id === silencePageId || pagesCompatibleWithBoard(p, currentBoard));
+  }, [pagesData?.pages, currentBoard, silencePageId]);
 
   const isSaving = updateSilenceMutation.isPending;
 
@@ -152,6 +176,9 @@ export function SilenceSchedule() {
         page_id: silencePageId || null,
         indicator_text: silenceIndicatorText || null,
         indicator_position: silenceIndicatorPosition || null,
+        // Multi-board installs target the selected board; single-board
+        // installs send exactly the body they always did.
+        ...(scopedBoardId ? { board_id: scopedBoardId } : {}),
       });
     }
     setHasChanges(false);

--- a/web/src/components/settings/silence-schedule.tsx
+++ b/web/src/components/settings/silence-schedule.tsx
@@ -39,11 +39,17 @@ export function SilenceSchedule() {
   const tc = useTranslations("common");
   const queryClient = useQueryClient();
 
-  // Silence settings are per board (issue #1788). Scope only in multi-board
-  // installs so a single-board install behaves exactly as before.
-  const { currentBoardId, currentBoard, boards } = useCurrentBoard();
-  const isMultiBoard = boards.length > 1;
-  const scopedBoardId = isMultiBoard && currentBoardId ? currentBoardId : undefined;
+  // Silence settings are per board (issue #1788), and the display engine
+  // resolves them per board on EVERY install — check_and_send_for_board() is
+  // always called with the primary board's id, never with null. So this form
+  // must always read and write the board-scoped layer too: scoping only in
+  // multi-board installs made a single-board install write the install-wide
+  // layer while the engine kept reading the board's own (migration-seeded)
+  // entry, and the entry won key by key. Silence looked off in the UI and
+  // stayed on for the board, with no feedback and no recovery short of
+  // hand-editing config.json (PR #1801 review, BLOCKER 1).
+  const { currentBoardId, currentBoard } = useCurrentBoard();
+  const scopedBoardId = currentBoardId ?? undefined;
 
   const [hasChanges, setHasChanges] = useState(false);
   const [silenceEnabled, setSilenceEnabled] = useState(false);
@@ -176,8 +182,9 @@ export function SilenceSchedule() {
         page_id: silencePageId || null,
         indicator_text: silenceIndicatorText || null,
         indicator_position: silenceIndicatorPosition || null,
-        // Multi-board installs target the selected board; single-board
-        // installs send exactly the body they always did.
+        // Always target the selected board so the layer written here is the
+        // layer the engine reads. Only an install with no board at all (the
+        // context has not resolved one yet) falls back to install-wide.
         ...(scopedBoardId ? { board_id: scopedBoardId } : {}),
       });
     }

--- a/web/src/components/silence-imminent-banner.tsx
+++ b/web/src/components/silence-imminent-banner.tsx
@@ -6,7 +6,8 @@ import { Moon } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
-import { useActivePage, usePages } from "@/hooks/use-board";
+import { useCurrentBoard } from "@/components/current-board-context";
+import { queryKeys, useActivePage, usePages } from "@/hooks/use-board";
 import { useTranslations } from "@/i18n/translations";
 import type { ActiveScheduleResponse, SilenceStatus } from "@/lib/api";
 import { api } from "@/lib/api";
@@ -29,9 +30,14 @@ export function SilenceImminentBanner() {
     return () => clearInterval(id);
   }, []);
 
+  // Silence windows are per board (issue #1788). Scope only in multi-board
+  // installs so single-board behavior is completely unchanged.
+  const { currentBoardId, boards } = useCurrentBoard();
+  const scopedBoardId = boards.length > 1 && currentBoardId ? currentBoardId : undefined;
+
   const { data: silenceStatus } = useQuery<SilenceStatus>({
-    queryKey: ["silenceStatus"],
-    queryFn: api.getSilenceStatus,
+    queryKey: queryKeys.silenceStatus(scopedBoardId),
+    queryFn: () => api.getSilenceStatus(scopedBoardId),
     refetchInterval: 30_000,
   });
 

--- a/web/src/hooks/use-board.ts
+++ b/web/src/hooks/use-board.ts
@@ -20,6 +20,10 @@ export const queryKeys = {
   boardSettings: ["boardSettings"] as const,
   collections: ["collections"] as const,
   schedules: (boardId: string) => ["schedules", boardId] as const,
+  // Silence windows are per board (issue #1788). Calling this without a
+  // boardId yields the legacy unscoped key, which also works as an
+  // invalidation prefix matching every board-scoped variant.
+  silenceStatus: (boardId?: string) => (boardId ? (["silenceStatus", boardId] as const) : (["silenceStatus"] as const)),
 };
 
 // Pair with the backend's adaptive post-send refresh (max ~3s). Early tick

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -618,6 +618,8 @@ export interface SilenceStatus {
   page_id?: string | null;
   indicator_text?: string;
   indicator_position?: string;
+  /** Echo of the requested board (issue #1788); null when unscoped. */
+  board_id?: string | null;
 }
 
 export interface PollingSettings {
@@ -1084,6 +1086,12 @@ export interface SilenceScheduleConfig {
   page_id: string | null;
   indicator_text: string | null;
   indicator_position: string | null;
+  /**
+   * Per-board overrides (issue #1788): board_id -> partial override. The keys
+   * above are the install-wide default every board without an entry resolves
+   * to. Read it through `resolveSilenceConfig` rather than indexing directly.
+   */
+  by_board?: Record<string, Partial<Omit<SilenceScheduleConfig, "by_board">>>;
 }
 
 export interface SilenceScheduleSettings {
@@ -2106,10 +2114,20 @@ export const api = {
       body: JSON.stringify(config),
     }),
 
-  // Silence mode status
-  getSilenceStatus: () => fetchApi<SilenceStatus>("/silence-status"),
+  // Silence mode status (optional boardId reads that board's window).
+  // boardId is only honored when it's a non-empty string: this wrapper is
+  // handed to TanStack Query as a bare reference, which would otherwise pass
+  // the query context as boardId (issue #1244).
+  getSilenceStatus: (boardId?: string) =>
+    fetchApi<SilenceStatus>(
+      typeof boardId === "string" && boardId
+        ? `/silence-status?board_id=${encodeURIComponent(boardId)}`
+        : "/silence-status",
+    ),
 
-  // Silence schedule (system feature, not a plugin)
+  // Silence schedule (system feature, not a plugin).
+  // board_id targets one board (issue #1788); omitted writes the install-wide
+  // layer. It goes in the BODY, mirroring PUT /settings/active-page.
   updateSilenceSchedule: (data: {
     enabled: boolean;
     start_time: string;
@@ -2118,6 +2136,7 @@ export const api = {
     page_id?: string | null;
     indicator_text?: string | null;
     indicator_position?: string | null;
+    board_id?: string;
   }) =>
     fetchApi<{ status: string; config: Record<string, unknown> }>("/settings/silence-schedule", {
       method: "PUT",

--- a/web/src/lib/silence-config.ts
+++ b/web/src/lib/silence-config.ts
@@ -1,0 +1,43 @@
+import type { SilenceScheduleConfig } from "@/lib/api";
+
+/** The seven keys a per-board silence override may carry. */
+const SILENCE_KEYS = [
+  "enabled",
+  "start_time",
+  "end_time",
+  "mode",
+  "page_id",
+  "indicator_text",
+  "indicator_position",
+] as const;
+
+type SilenceLayer = Partial<SilenceScheduleConfig> & { by_board?: Record<string, Partial<SilenceScheduleConfig>> };
+
+/**
+ * Resolve the effective silence schedule for one board (issue #1788).
+ *
+ * Mirrors `resolve_silence_schedule()` in `src/config.py`: the top-level keys
+ * of `features.silence_schedule` are the install-wide default, and
+ * `by_board[boardId]` overrides them key by key. A board with no entry — or no
+ * board at all — resolves to the install-wide values, so a newly added board
+ * inherits the install's quiet hours instead of being unexpectedly loud.
+ *
+ * Normalization stays on the server; this only does the layering, so the form
+ * shows exactly what was stored.
+ */
+export function resolveSilenceConfig(
+  config: SilenceLayer | undefined | null,
+  boardId?: string,
+): Partial<SilenceScheduleConfig> {
+  const { by_board: byBoard, ...base } = config ?? {};
+  if (!boardId) return base;
+
+  const entry = byBoard?.[boardId];
+  if (!entry || typeof entry !== "object") return base;
+
+  const resolved: Record<string, unknown> = { ...base };
+  for (const key of SILENCE_KEYS) {
+    if (key in entry) resolved[key] = entry[key];
+  }
+  return resolved as Partial<SilenceScheduleConfig>;
+}

--- a/web/tests/regression/settings-behavior-integrations.spec.ts
+++ b/web/tests/regression/settings-behavior-integrations.spec.ts
@@ -135,6 +135,90 @@ test.describe("regression: settings.behavior", () => {
       }),
     });
   });
+
+  /**
+   * UX node: settings.behavior.silence-per-board
+   * Route: /settings (Behavior tab)
+   * Issue #1788: silence settings used to be global, so a Note and a Flagship
+   * were forced to share one quiet period and one (single-sized) silence page.
+   * A per-board write must land on the targeted board only and leave the other
+   * board resolving to the install-wide window.
+   */
+  test("settings.behavior.silence-per-board — a per-board write does not move the other board's window", async ({
+    page,
+  }) => {
+    // Snapshot the install-wide window so we can put it back.
+    const originalRes = await fetch(`${API_URL}/silence-status`, { headers: authHeaders() });
+    const original = await originalRes.json();
+
+    // Resolve the primary board id from the boards list.
+    const boardsRes = await fetch(`${API_URL}/settings/board`, { headers: authHeaders() });
+    const boards = (await boardsRes.json()).boards ?? [];
+    const primaryId: string | undefined = boards[0]?.id;
+    expect(primaryId, "at least one board must be configured").toBeTruthy();
+
+    // Write a distinctive window for the primary board only.
+    const putRes = await fetch(`${API_URL}/settings/silence-schedule`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...authHeaders() },
+      body: JSON.stringify({
+        enabled: true,
+        start_time: "01:11+00:00",
+        end_time: "02:22+00:00",
+        mode: "freeze",
+        board_id: primaryId,
+      }),
+    });
+    expect(putRes.status).toBe(200);
+    expect((await putRes.json()).board_id).toBe(primaryId);
+
+    // That board reads back its own window...
+    const scopedRes = await fetch(`${API_URL}/silence-status?board_id=${encodeURIComponent(primaryId!)}`, {
+      headers: authHeaders(),
+    });
+    const scoped = await scopedRes.json();
+    expect(scoped.start_time_utc).toBe("01:11+00:00");
+    expect(scoped.board_id).toBe(primaryId);
+
+    // ...while the install-wide layer is untouched.
+    const globalRes = await fetch(`${API_URL}/silence-status`, { headers: authHeaders() });
+    const globalStatus = await globalRes.json();
+    expect(globalStatus.start_time_utc).toBe(original.start_time_utc);
+    expect(globalStatus.board_id).toBeNull();
+
+    // An unknown board is a 404, not a silent global write.
+    const ghostRes = await fetch(`${API_URL}/settings/silence-schedule`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...authHeaders() },
+      body: JSON.stringify({
+        enabled: true,
+        start_time: "03:33+00:00",
+        end_time: "04:44+00:00",
+        board_id: "no-such-board",
+      }),
+    });
+    expect(ghostRes.status).toBe(404);
+
+    // The Behavior tab still renders the silence card for the current board.
+    await page.goto("/settings");
+    await expect(page.getByRole("heading", { name: "Settings", exact: true })).toBeVisible({ timeout: 15_000 });
+    await page.getByRole("tab", { name: "Behavior", exact: true }).click();
+    await expect(page.getByLabel("Silence Schedule")).toBeVisible({ timeout: 10_000 });
+
+    // Restore: clear the per-board override by writing the original window
+    // back to that board, then re-assert the install-wide layer.
+    await fetch(`${API_URL}/settings/silence-schedule`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json", ...authHeaders() },
+      body: JSON.stringify({
+        enabled: original.enabled,
+        start_time: original.start_time_utc,
+        end_time: original.end_time_utc,
+        mode: original.mode,
+        board_id: primaryId,
+      }),
+    });
+  });
 });
 
 test.describe("regression: settings.integrations (AI / MCP / MQTT)", () => {

--- a/web/tests/regression/settings-behavior-integrations.spec.ts
+++ b/web/tests/regression/settings-behavior-integrations.spec.ts
@@ -142,14 +142,21 @@ test.describe("regression: settings.behavior", () => {
    * Issue #1788: silence settings used to be global, so a Note and a Flagship
    * were forced to share one quiet period and one (single-sized) silence page.
    * A per-board write must land on the targeted board only and leave the other
-   * board resolving to the install-wide window.
+   * board resolving to the install-wide window. `/silence-status` without a
+   * board_id describes the PRIMARY board (PR #1801 review) — it is a runtime
+   * status endpoint, so the install-wide layer is read from the stored config.
    */
   test("settings.behavior.silence-per-board — a per-board write does not move the other board's window", async ({
     page,
   }) => {
-    // Snapshot the install-wide window so we can put it back.
-    const originalRes = await fetch(`${API_URL}/silence-status`, { headers: authHeaders() });
-    const original = await originalRes.json();
+    // Snapshot the raw stored config: `/silence-status` reports the PRIMARY
+    // board (issue #1788), so the install-wide layer has to be read from the
+    // config itself, not from the status endpoint.
+    const readStored = async () => {
+      const res = await fetch(`${API_URL}/settings/all`, { headers: authHeaders() });
+      return (await res.json()).silence_schedule?.config ?? {};
+    };
+    const originalStored = await readStored();
 
     // Resolve the primary board id from the boards list.
     const boardsRes = await fetch(`${API_URL}/settings/board`, { headers: authHeaders() });
@@ -180,11 +187,18 @@ test.describe("regression: settings.behavior", () => {
     expect(scoped.start_time_utc).toBe("01:11+00:00");
     expect(scoped.board_id).toBe(primaryId);
 
-    // ...while the install-wide layer is untouched.
-    const globalRes = await fetch(`${API_URL}/silence-status`, { headers: authHeaders() });
-    const globalStatus = await globalRes.json();
-    expect(globalStatus.start_time_utc).toBe(original.start_time_utc);
-    expect(globalStatus.board_id).toBeNull();
+    // ...while the install-wide layer in the stored config is untouched, so a
+    // board with no override of its own still resolves to it.
+    const storedAfter = await readStored();
+    expect(storedAfter.start_time).toBe(originalStored.start_time);
+    expect(storedAfter.end_time).toBe(originalStored.end_time);
+    expect(storedAfter.by_board?.[primaryId!]?.start_time).toBe("01:11+00:00");
+
+    // Unscoped status describes the primary board, not the install-wide layer.
+    const unscopedRes = await fetch(`${API_URL}/silence-status`, { headers: authHeaders() });
+    const unscoped = await unscopedRes.json();
+    expect(unscoped.start_time_utc).toBe("01:11+00:00");
+    expect(unscoped.board_id).toBe(primaryId);
 
     // An unknown board is a 404, not a silent global write.
     const ghostRes = await fetch(`${API_URL}/settings/silence-schedule`, {
@@ -205,16 +219,15 @@ test.describe("regression: settings.behavior", () => {
     await page.getByRole("tab", { name: "Behavior", exact: true }).click();
     await expect(page.getByLabel("Silence Schedule")).toBeVisible({ timeout: 10_000 });
 
-    // Restore: clear the per-board override by writing the original window
-    // back to that board, then re-assert the install-wide layer.
+    // Restore: write the original window back to that board.
     await fetch(`${API_URL}/settings/silence-schedule`, {
       method: "PUT",
       headers: { "Content-Type": "application/json", ...authHeaders() },
       body: JSON.stringify({
-        enabled: original.enabled,
-        start_time: original.start_time_utc,
-        end_time: original.end_time_utc,
-        mode: original.mode,
+        enabled: originalStored.enabled ?? false,
+        start_time: originalStored.start_time,
+        end_time: originalStored.end_time,
+        mode: originalStored.mode ?? "freeze",
         board_id: primaryId,
       }),
     });


### PR DESCRIPTION
Closes #1788.

Silence settings were install-wide, so a mixed Note + Flagship setup could not be configured correctly.

- Resolve the silence schedule per board in the config layer; an unconfigured board inherits the install-wide schedule
- Board-scoped silence API with page/board size validation
- Per-board silence delivery in the display engine
- Scope the silence settings UI to the selected board (`useCurrentBoard()`)
- Filter the silence page picker with `pagesCompatibleWithBoard` — it previously offered pages of any size
- Docs: per-board resolution rule and `GET /silence-status?board_id=`

Also flags the dead `SILENCE_SCHEDULE_START_TIME` / `_END_TIME` env vars — they write `general.silence_schedule_*`, which nothing in `src/` or `web/` reads, so the documented examples were a no-op.

Rebased onto current `main`. Two of the merges it picked up matter here:

- **#1817** rewrote `check_and_send_for_board` (silence evaluated above the pause check, `rt.last_silence_mode_active` latched on every exit path). Kept intact, and it is now what the per-board boundary detector compares against.
- **#1746** moved the silence migrations off `GET /silence-status` into `_run_startup_migrations`, and made `ConfigManager._file_lock` an `RLock`. The per-board seeding migration is added to the startup runner (before the UTC pass, so it converts the seeded windows in the same boot) and `GET /silence-status` stays a pure read. The `RLock` change also affects BLOCKER 2 below.
- **#1813** added `DisplayService.board_init_errors`; the per-board silence snapshot sits alongside it.

---

## Review fixes

Four defects found in code review. Every piece of the original PR was correct in isolation; the composition was not, and 24 green tests said nothing about it.

### BLOCKER 1 — single-board installs could not change silence settings at all

The seeding migration gave **every** configured board an explicit copy of the install-wide window, single-board installs included. The engine always resolves per board (`check_and_send_for_board` is called with the primary board's id, never `None`). But the UI wrote the **install-wide** layer whenever `boards.length === 1`. The seeded copy then shadowed every later save key by key:

```
by_board after migration: {"board-1": {"enabled": true, "start_time": "20:00+00:00", ...}}
--- user turns silence OFF and moves the window to 22:30 in the UI ---
install-wide layer after save : enabled=False start=22:30+00:00
what the ENGINE resolves      : enabled=True  start=20:00+00:00 end=07:00+00:00
what the UI form shows        : enabled=False start=22:30+00:00
```

Also reachable without the migration: delete a board from a 2-board install and `isMultiBoard` flips false while the survivor keeps its `by_board` entry.

**Design choice: (b) — the writer always targets the board layer.**

The reader is board-scoped on every install and cannot be anything else: `check_and_send_active_page()` resolves `get_primary_board_id()` and hands it to `check_and_send_for_board`. So the only way to make the write layer and the read layer agree *in every case* is to make the writer board-scoped too, unconditionally.

Why not the others:

- **(a) don't seed `by_board` for single-board installs** does not fix the 2 → 1 deletion path: pruning the *removed* board still leaves the *survivor's* entry, `isMultiBoard` still flips false, and the shadowing returns. It also depends on an invariant ("a single-board install never has a `by_board` entry") that any board-scoped write from MCP or curl silently breaks.
- **(c) make resolution prefer the install-wide layer when there is exactly one board** puts board-count logic on the *read* side, so adding a second board would silently change board 1's effective schedule. It also forces `resolve_silence_schedule` — today a pure function of the feature dict — to read board settings, which is exactly the re-entrancy that produced BLOCKER 2.

Implemented on both sides of the wire, because a client-side convention alone cannot guarantee "in every case":

- `web/src/components/settings/silence-schedule.tsx` drops the `isMultiBoard` conditional and reads **and** writes `by_board[currentBoardId]` unconditionally.
- `PUT /settings/silence-schedule` enforces the same invariant for clients that are not our UI: an install-wide write on a single-board install prunes that board's override instead of letting it win. On one board there is no meaningful difference between "the install default" and "this board", so a divergent override there can only shadow the save. Multi-board installs are untouched — there the overrides are the whole point.

#### Follow-on, caught by E2E: `GET /silence-status` was still the wrong layer

Making the form write the board layer fixed the engine, but the status endpoint with no `board_id` still returned the install-wide layer — so on a single-board install the user toggled silence off and every surface polling it unscoped kept saying on:

```
  1) [chromium] › tests/settings-full.spec.ts:158:3 › Settings – Full Coverage › toggling silence schedule saves without 404 (regression: #597)
    Error: expect(received).toBe(expected) // Object.is equality
    Expected: true
    Received: false
    Call Log:
    - Timeout 5000ms exceeded while waiting on the predicate
    > 196 |       .toBe(!originalEnabled);
```

Not just that endpoint: `SilenceImminentBanner` and `ActivePageDisplay` both scope with `boards.length > 1 ? currentBoardId : undefined`, so a single-board install read the install-wide layer for the dashboard SNOOZING overlay and the countdown banner too.

`/silence-status` is a runtime status endpoint — it returns `active`, `current_time_utc`, `next_change_utc`, `seconds_until_next_change` — so "is silence on?" with no board named has to mean "on the board you drive by default", the same rule as `_silence_active(None)`, `_board_is_paused(None)` and `SettingsService.is_paused(None)`. It now resolves the primary board and echoes the board it describes. That fixes the unscoped consumers for free. The install-wide layer is still readable as raw config via `GET /settings/all` → `silence_schedule.config`, which includes `by_board`.

`test_omitting_board_id_keeps_legacy_global_reading` encoded the contract this replaces and is rewritten as `test_omitting_board_id_reports_the_primary_board`, with a companion asserting a board with no override of its own still reads the install-wide values. The per-board E2E now reads the install-wide layer from the stored config instead of from the status endpoint — which is what it actually meant to assert.

### BLOCKER 2 — latent self-deadlock that froze the whole process

`migrate_silence_schedule_to_per_board` held `self._file_lock` across a call into `get_settings_service()`, whose constructor reads `FB_TRANSITION_STRATEGY` → `Config._get_board()` → `ConfigManager.get_board()` — the same lock. Held forever, every config read in the process blocks: total freeze, no exception, no timeout. `_configured_board_ids()` is hoisted above the `with self._file_lock`.

**Caveat, found on the second rebase:** #1746 landed mid-review and made `_file_lock` an `RLock`, so the same-thread re-entry no longer hangs and the original timeout-based test passed with the fix reverted. That test was vacuous on current `main` and has been replaced. The invariant now pinned is the durable one — *the config lock must be free while the settings service is being constructed* — proved by a probe thread that tries to acquire it from inside the callback. That fails whether the lock is reentrant or not. The hoist is kept regardless: building a service that reads config under the config lock is a deadlock waiting on `RLock` staying an `RLock`, and it also holds the lock across unrelated disk I/O.

### MAJOR 3 — eight call sites still resolved install-wide

Install-wide silence disabled, bedroom Note overridden to 22:00–07:00 — at 2am a manual send from the web UI or Home Assistant went straight through. New `_silence_active(board_id)` mirrors `_board_is_paused`: an explicit board is used as given, `None` resolves to the **primary** board rather than the install-wide layer. `Config.is_silence_mode_active(None)` keeps its legacy install-wide meaning for the ~20 fixtures that call it zero-arg.

| Call site | Board threaded through | Note |
| --- | --- | --- |
| `POST /send-message` (`api_server.py:3345`) | primary board | No board parameter exists; the endpoint drives `service.vb_client` |
| `POST /send-welcome-message` (`api_server.py:3493`) | primary board | Setup wizard; builds a fresh primary client from `Config` |
| `POST /transitions/test-live` (`api_server.py:5751`) | `request["board_id"]` | Already resolved for the client |
| `POST /transitions/restore` (`api_server.py:5845`) | `body["board_id"]` | Already resolved for the client |
| `POST /pages/{id}/send` (`api_server.py:8042`) | `board_id` param | Already routes the client with it |
| `src/mqtt/commands.py:297` | board from the MQTT payload | Falls back to primary for a plain-string payload |
| `src/mqtt/state.py:101` | primary board | See below |

Two sites genuinely have no board context: `/send-message` and `/send-welcome-message`. Neither takes a board — both write the primary board's client — so both resolve the primary board, which is the board they are about to touch.

`src/mqtt/state.py` now publishes the **primary** board's silence to Home Assistant. Every other field in that payload is primary-scoped (`active_page`, `transition_style`, `current_message`), so publishing the install-wide layer made the sensor report OFF while the board it describes was snoozing. A per-board sensor set is a separate feature; documented in `docs/features/home-assistant-control.md`.

### MINOR 4 — orphan `by_board` entries

`SettingsService.remove_board` now prunes the removed board's override via the new `ConfigManager.prune_silence_schedule_for_board`.

---

## Verbatim pre-fix failures

Every test below was written first and run against the rebased branch before any fix.

**Composition, deadlock and prune** (`tests/test_silence_per_board_composition.py`), captured against the branch as reviewed (before the second rebase, when `_file_lock` was still a plain `Lock`):

```
============================= test session starts ==============================
collected 5 items

tests/test_silence_per_board_composition.py F.FFF                        [100%]

=================================== FAILURES ===================================
_ TestSingleBoardComposition.test_single_board_install_save_is_honored_by_the_engine _
tests/test_silence_per_board_composition.py:114: in test_single_board_install_save_is_honored_by_the_engine
    assert resolved["enabled"] is False
E   assert True is False
_ TestSingleBoardComposition.test_save_after_dropping_from_two_boards_to_one_is_honored _
tests/test_silence_per_board_composition.py:169: in test_save_after_dropping_from_two_boards_to_one_is_honored
    assert resolved["enabled"] is False
E   assert True is False
_ TestBoardRemovalPrunesOverrides.test_remove_board_prunes_its_silence_override _
tests/test_silence_per_board_composition.py:195: in test_remove_board_prunes_its_silence_override
    assert "board-2" not in by_board
E   AssertionError: assert 'board-2' not in {'board-1': {'enabled': True, 'start_time': '01:00+00:00', 'end_time': '02:00+00:00'}, 'board-2': {'enabled': True, 'start_time': '03:00+00:00', 'end_time': '04:00+00:00'}}
_ TestMigrationLockSafety.test_seeding_migration_does_not_reenter_the_config_file_lock _
tests/test_silence_per_board_composition.py:237: in test_seeding_migration_does_not_reenter_the_config_file_lock
    assert not worker.is_alive(), (
E   AssertionError: migrate_silence_schedule_to_per_board() deadlocked: it called get_settings_service() while holding ConfigManager._file_lock
E   assert not True
E    +  where True = is_alive()
E    +    where is_alive = <Thread(Thread-4 (_run), started daemon 281473271460192)>.is_alive
=========================== short test summary info ============================
FAILED tests/test_silence_per_board_composition.py::TestSingleBoardComposition::test_single_board_install_save_is_honored_by_the_engine
FAILED tests/test_silence_per_board_composition.py::TestSingleBoardComposition::test_save_after_dropping_from_two_boards_to_one_is_honored
FAILED tests/test_silence_per_board_composition.py::TestBoardRemovalPrunesOverrides::test_remove_board_prunes_its_silence_override
FAILED tests/test_silence_per_board_composition.py::TestMigrationLockSafety::test_seeding_migration_does_not_reenter_the_config_file_lock
========================= 4 failed, 1 passed in 10.52s =========================
```

The deadlock test runs the migration on a worker thread with a join timeout, so it fails red instead of hanging the suite. After the rebase onto #1746's `RLock` it no longer reproduced (see the caveat above) and was rewritten around the lock-holding probe; here it is failing against the fix reverted on the **current** base:

```
=================================== FAILURES ===================================
_ TestMigrationLockSafety.test_seeding_migration_does_not_hold_the_config_lock_across_the_board_lookup _
tests/test_silence_per_board_composition.py:258: in test_seeding_migration_does_not_hold_the_config_lock_across_the_board_lookup
    assert lock_was_free.get("free") is True, (
E   AssertionError: ConfigManager._file_lock was held across get_settings_service(); that call reads config through ConfigManager.get_board()
E   assert False is True
E    +  where False = <built-in method get of dict object at 0xffffb0041380>('free')
E    +    where <built-in method get of dict object at 0xffffb0041380> = {'free': False}.get
=========================== short test summary info ============================
FAILED tests/test_silence_per_board_composition.py::TestMigrationLockSafety::test_seeding_migration_does_not_hold_the_config_lock_across_the_board_lookup
============================== 1 failed in 2.60s ===============================
```

**Send guards** (`tests/test_silence_per_board_call_sites.py`) — each guard let the send through:

```
E   AssertionError: assert 'success' == 'blocked'
/app/tests/test_silence_per_board_call_sites.py:83: AssertionError: assert 'success' == 'blocked'
E   AssertionError: assert 'success' == 'blocked'
/app/tests/test_silence_per_board_call_sites.py:97: AssertionError: assert 'success' == 'blocked'
E   assert True is False
/app/tests/test_silence_per_board_call_sites.py:121: assert True is False
E   AssertionError: {"detail":"Page not found: page-1"}
    assert 404 == 409
/app/tests/test_silence_per_board_call_sites.py:142: AssertionError: {"detail":"Page not found: page-1"}
E   AssertionError: {"detail":"Active page not found"}
    assert 404 == 409
/app/tests/test_silence_per_board_call_sites.py:156: AssertionError: {"detail":"Active page not found"}
E   AssertionError: assert 'OFF' == 'ON'
/app/tests/test_silence_per_board_call_sites.py:190: AssertionError: assert 'OFF' == 'ON'
E   AssertionError: Expected 'send_characters' to not have been called. Called 1 times.
/usr/local/lib/python3.14/unittest/mock.py:947: AssertionError: Expected 'send_characters' to not have been called. Called 1 times.
=========================== short test summary info ============================
FAILED tests/test_silence_per_board_call_sites.py::TestApiSendGuards::test_send_message_respects_the_primary_boards_window
FAILED tests/test_silence_per_board_call_sites.py::TestApiSendGuards::test_send_welcome_message_respects_the_primary_boards_window
FAILED tests/test_silence_per_board_call_sites.py::TestApiSendGuards::test_page_send_respects_the_target_boards_window
FAILED tests/test_silence_per_board_call_sites.py::TestApiSendGuards::test_live_transition_test_respects_the_target_boards_window
FAILED tests/test_silence_per_board_call_sites.py::TestApiSendGuards::test_transition_restore_respects_the_target_boards_window
FAILED tests/test_silence_per_board_call_sites.py::TestMqttSilenceIsPerBoard::test_state_publisher_reports_the_primary_boards_silence
FAILED tests/test_silence_per_board_call_sites.py::TestMqttSilenceIsPerBoard::test_mqtt_send_message_respects_the_target_boards_window
```

`is_silence_mode_active` is replaced by a board-aware stub whose install-wide layer is explicitly **not** silent, so a guard that still passes `None` sees "not silent" and lets the send through — which is the production bug. The two 404s are proof the guard did not fire: the silence check is the first thing after the board client is resolved, so anything downstream of it (page lookup) means the request got past it.

**UI write and read halves** (`web/src/__tests__/silence-schedule-per-board.test.tsx`):

```
 ❯ src/__tests__/silence-schedule-per-board.test.tsx (10 tests | 2 failed) 8476ms
     × sends the board_id on a single-board install so the save reaches the engine 1166ms
     × seeds the form from the board's own entry on a single-board install 5030ms

 FAIL  src/__tests__/silence-schedule-per-board.test.tsx > SilenceSchedule - board scoping > sends the board_id on a single-board install so the save reaches the engine
AssertionError: expected undefined to be 'flag-1' // Object.is equality

- Expected:
"flag-1"

+ Received:
undefined

 FAIL  src/__tests__/silence-schedule-per-board.test.tsx > SilenceSchedule - board scoping > seeds the form from the board's own entry on a single-board install
AssertionError: expected 'SNOOZING' to be 'BEDTIME' // Object.is equality
```

The first replaces `expect(puts[0]).not.toHaveProperty("board_id")`, an assertion that encoded the wrong contract — "single-board installs send a byte-identical PUT body" was the safety guarantee that turned out to be the bug. This is a corrected contract, not a weakened assertion.

## Test-fixture updates (signature, not assertion)

- `tests/test_transitions_api.py` stubbed `is_silence_mode_active` with `staticmethod(lambda: False)`; the guard now passes a board, so the stubs take `board_id=None`.
- `tests/test_silence_schedule_polling.py` had one `side_effect = lambda: silence["active"]` for the same reason.
- `_silence_state_changed` now falls back to the runtime's `last_silence_mode_active` latch for a board its snapshot has not seen. Without that, an install booting **inside** its silence window reported a boundary the initial `check_and_send_active_page()` had already handled and forced one spurious extra update — #1817's `test_paused_board_does_not_force_an_update_every_second_during_silence` and `test_render_failure_...` caught it after the rebase. The snapshot is still recorded, so a board the drive path never touches (a disabled secondary) cannot re-trigger a forced update every second.

## Status

- Python: `5415 passed, 1 skipped` (full suite, in the CI image; `test_check_image_formats.py` excluded — it shells out to `git ls-files`, which cannot resolve a worktree `.git` file from inside the container). `ruff==0.16.4` check + format clean.
- Web: `121 passed` across the silence unit suites (`silence-schedule-per-board`, `silence-schedule-extended`, `silence-imminent-banner`, `active-page-display-silence`, `api-extended`); prettier + eslint clean on the touched files.
- Docs: cspell 0 issues, markdownlint 0 issues.
- E2E: the first CI run was `579 passed, 1 failed` — that one failure is the `/silence-status` layer bug documented above, now fixed.
