### PR TITLE
fix(debug): report real connection mode and surface silent send failures

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -3209,24 +3209,29 @@ async def stop_service():
     return {"status": "stopped", "message": "Service stopped successfully"}
 
 
-def _service_send_error(service, board_id: str | None = None) -> str | None:
-    """The failure reason recorded by the service's last send attempt, or None.
+def _send_with_status(service, method: str, fallback: str, *args, **kwargs) -> tuple[bool, str | None]:
+    """Run a ``check_and_send_*`` pass and return ``(sent, failure reason)``.
 
     ``check_and_send_*`` swallow exceptions and return a bool that conflates
-    "failed" with benign skips; the recorded ``last_send_error`` is what lets
-    endpoints report real failures (issue #1791). Only a non-empty ``str``
-    counts — Mock services from older test fixtures return Mock attributes,
-    which must not read as failures (same convention as ``_board_is_paused``).
+    "failed" with benign skips, so endpoints reported silent failures as
+    success (issue #1791). The ``*_with_status`` wrappers capture the reason
+    for *this* call in a thread-local, which is why the reason must come back
+    from the call rather than be read off the runtime afterwards — the engine
+    thread rewrites ``last_send_error`` on its own cadence.
+
+    Falls back to the plain method (and no reason) when the service does not
+    expose the wrapper, so Mock services from older test fixtures still work.
+    Only a non-empty ``str`` counts as a reason, for the same Mock reason
+    (same convention as ``_board_is_paused``).
     """
-    getter = getattr(service, "get_last_send_error", None)
-    if not callable(getter):
-        return None
-    try:
-        error = getter(board_id) if board_id is not None else getter()
-    except Exception as exc:  # pragma: no cover - defensive
-        logger.debug("Could not read last send error: %s", exc)
-        return None
-    return error if isinstance(error, str) and error else None
+    wrapper = getattr(service, method, None)
+    if callable(wrapper):
+        result = wrapper(*args, **kwargs)
+        if isinstance(result, tuple) and len(result) == 2:
+            sent, error = result
+            return sent is True, (error if isinstance(error, str) and error else None)
+    sent = getattr(service, fallback)(*args, **kwargs)
+    return sent is True, None
 
 
 @app.post("/refresh")
@@ -3247,15 +3252,18 @@ async def refresh_display(board_id: str | None = None, payload: dict | None = Bo
 
     try:
         if board_id is None:
-            sent = service.check_and_send_active_page()
-            error = _service_send_error(service)
+            # Every board is driven here, so a failing secondary must surface
+            # too — the wrapper aggregates across the whole pass (issue #1791).
+            sent, error = _send_with_status(
+                service, "check_and_send_active_page_with_status", "check_and_send_active_page"
+            )
             if error:
                 raise HTTPException(status_code=500, detail=f"Failed to refresh display: {error}")
             return {
                 "status": "success",
                 "message": "Display refreshed successfully",
                 "board_id": None,
-                "sent": sent is True,
+                "sent": sent,
             }
 
         board = _find_board(board_id)
@@ -3265,15 +3273,22 @@ async def refresh_display(board_id: str | None = None, payload: dict | None = Bo
         if rt is None:
             raise HTTPException(status_code=503, detail=f"Board client not initialized: {board_id}")
         is_primary = board_id == get_settings_service().get_primary_board_id()
-        sent = service.check_and_send_for_board(board_id, rt, is_primary=is_primary, board=board)
-        error = _service_send_error(service, board_id)
+        sent, error = _send_with_status(
+            service,
+            "check_and_send_for_board_with_status",
+            "check_and_send_for_board",
+            board_id,
+            rt,
+            is_primary=is_primary,
+            board=board,
+        )
         if error:
             raise HTTPException(status_code=500, detail=f"Failed to refresh board {board_id}: {error}")
         return {
             "status": "success",
             "message": f"Board {board_id} refreshed successfully",
             "board_id": board_id,
-            "sent": sent is True,
+            "sent": sent,
         }
     except HTTPException:
         raise
@@ -9218,14 +9233,15 @@ async def force_refresh():
         client.clear_cache()
 
     try:
-        sent = service.check_and_send_active_page()
-        error = _service_send_error(service)
+        sent, error = _send_with_status(
+            service, "check_and_send_active_page_with_status", "check_and_send_active_page"
+        )
         if error:
             raise HTTPException(status_code=500, detail=f"Failed to force refresh: {error}")
         return {
             "status": "success",
             "message": "Display force-refreshed successfully",
-            "sent": sent is True,
+            "sent": sent,
         }
     except HTTPException:
         raise

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -3209,6 +3209,26 @@ async def stop_service():
     return {"status": "stopped", "message": "Service stopped successfully"}
 
 
+def _service_send_error(service, board_id: str | None = None) -> str | None:
+    """The failure reason recorded by the service's last send attempt, or None.
+
+    ``check_and_send_*`` swallow exceptions and return a bool that conflates
+    "failed" with benign skips; the recorded ``last_send_error`` is what lets
+    endpoints report real failures (issue #1791). Only a non-empty ``str``
+    counts — Mock services from older test fixtures return Mock attributes,
+    which must not read as failures (same convention as ``_board_is_paused``).
+    """
+    getter = getattr(service, "get_last_send_error", None)
+    if not callable(getter):
+        return None
+    try:
+        error = getter(board_id) if board_id is not None else getter()
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("Could not read last send error: %s", exc)
+        return None
+    return error if isinstance(error, str) and error else None
+
+
 @app.post("/refresh")
 async def refresh_display(board_id: str | None = None, payload: dict | None = Body(None)):
     """Manually trigger a display refresh.
@@ -3227,8 +3247,16 @@ async def refresh_display(board_id: str | None = None, payload: dict | None = Bo
 
     try:
         if board_id is None:
-            service.check_and_send_active_page()
-            return {"status": "success", "message": "Display refreshed successfully", "board_id": None}
+            sent = service.check_and_send_active_page()
+            error = _service_send_error(service)
+            if error:
+                raise HTTPException(status_code=500, detail=f"Failed to refresh display: {error}")
+            return {
+                "status": "success",
+                "message": "Display refreshed successfully",
+                "board_id": None,
+                "sent": sent is True,
+            }
 
         board = _find_board(board_id)
         if board is None:
@@ -3237,8 +3265,16 @@ async def refresh_display(board_id: str | None = None, payload: dict | None = Bo
         if rt is None:
             raise HTTPException(status_code=503, detail=f"Board client not initialized: {board_id}")
         is_primary = board_id == get_settings_service().get_primary_board_id()
-        service.check_and_send_for_board(board_id, rt, is_primary=is_primary, board=board)
-        return {"status": "success", "message": f"Board {board_id} refreshed successfully", "board_id": board_id}
+        sent = service.check_and_send_for_board(board_id, rt, is_primary=is_primary, board=board)
+        error = _service_send_error(service, board_id)
+        if error:
+            raise HTTPException(status_code=500, detail=f"Failed to refresh board {board_id}: {error}")
+        return {
+            "status": "success",
+            "message": f"Board {board_id} refreshed successfully",
+            "board_id": board_id,
+            "sent": sent is True,
+        }
     except HTTPException:
         raise
     except Exception as e:
@@ -6171,6 +6207,11 @@ async def set_active_page(request: dict):
       legacy behavior (issue #1244).
 
     When a page is set, it will be immediately rendered and sent to the board.
+
+    Response: ``sent_to_board`` reports whether content actually reached the
+    board, and ``error`` carries the render/send failure reason (null when the
+    send succeeded or was skipped benignly — paused board, UI-only output,
+    unchanged content). The page selection itself is persisted either way.
     """
     settings_service = get_settings_service()
     page_service = get_page_service()
@@ -6234,9 +6275,12 @@ async def set_active_page(request: dict):
     if service:
         send_client = service.get_board_client(board_id) if board_id is not None else service.vb_client
 
-    # Immediately send to board if a page is set
+    # Immediately send to board if a page is set. The page selection is
+    # persisted either way; a failed render/send is a partial failure that
+    # must be reported, not silently swallowed (issue #1791).
     sent_to_board = False
     paused = False
+    send_error: str | None = None
     if render_page_id and page and send_client and settings_service.should_send_to_board():
         # Skip immediate send when the board is paused (issue #970). The
         # active-page selection is still persisted so it takes effect when
@@ -6274,17 +6318,28 @@ async def set_active_page(request: dict):
                 )
                 sent_to_board = was_sent
                 if not success:
+                    send_error = f"Failed to send page to board: {page_id}"
                     logger.warning(f"Failed to send active page to board: {page_id}")
                 elif was_sent and (board_id is None or board_id == settings_service.get_primary_board_id()):
                     # Adaptive post-send refresh polls the primary board only.
                     service.request_board_refresh()
+            else:
+                # A network/plugin failure surfaces here as an unavailable
+                # render — report it instead of skipping silently (#1791).
+                render_error = getattr(result, "error", None) if result else None
+                send_error = render_error or f"Failed to render page: {render_page_id}"
+                logger.warning(f"Active page set but render unavailable, not sent: {render_page_id}")
 
+    # status stays "success" (the page selection itself was persisted); a
+    # render/send problem is reported via error + sent_to_board=False, the
+    # same partial-failure contract page-builder already consumes.
     response = {
         "status": "success",
         "page_id": page_id,
         "sent_to_board": sent_to_board,
         "paused": paused,
         "board_id": board_id,
+        "error": send_error,
     }
     if compat_warnings:
         response["warnings"] = compat_warnings
@@ -7195,6 +7250,47 @@ def _get_board_client():
     return None
 
 
+def _primary_board_entry() -> dict | None:
+    """First entry of the settings.boards store, or None when it is empty.
+
+    Safe to call from any endpoint — never raises (mirrors
+    ``_get_first_board_dims``).
+    """
+    try:
+        boards = get_settings_service().get_board_settings().boards or []
+        if isinstance(boards, list) and boards and isinstance(boards[0], dict):
+            return boards[0]
+    except Exception as exc:
+        logger.debug("Could not read boards list: %s", exc)
+    return None
+
+
+def _primary_connection_info() -> tuple[str, str]:
+    """Return ``(connection_mode, board_host)`` for the primary board.
+
+    Reads the boards[] store — the source the live clients are built from
+    and what Settings → Boards displays — then falls back to the live
+    primary client, and only then to legacy ``Config`` (config.json), which
+    only the setup wizard writes and therefore goes stale as soon as the
+    board is edited in Settings (issue #1791).
+    """
+    board = _primary_board_entry()
+    if board is not None:
+        mode = board.get("api_mode") or "local"
+        host = board.get("host") or ""
+        return (mode.lower() if isinstance(mode, str) else "local", host if isinstance(host, str) else "")
+
+    client = _get_board_client()
+    if client is not None:
+        # Strict-True guard so Mock clients from older test fixtures don't
+        # read as cloud (same convention as _board_is_paused).
+        mode = "cloud" if getattr(client, "use_cloud", False) is True else "local"
+        host = getattr(client, "host", "")
+        return mode, host if isinstance(host, str) else ""
+
+    return (Config.BOARD_API_MODE or "local").lower(), Config.BOARD_HOST or ""
+
+
 def _get_first_board_dims():
     """Return resolved dimensions for the first configured board.
 
@@ -7388,12 +7484,14 @@ async def debug_show_info():
     settings_service = get_settings_service()
     send_to_board = settings_service.should_send_to_board()
 
-    # Gather system info
-    board_ip = Config.BOARD_HOST or "not set"
+    # Gather system info. Mode/IP come from the boards[] store / live client,
+    # not wizard-era config.json (issue #1791).
+    connection_mode, board_ip = _primary_connection_info()
+    board_ip = board_ip or "not set"
+    connection_mode = connection_mode.upper()
     server_ip = _get_server_ip()
     uptime = _get_service_uptime()
     uptime_str = _format_uptime(uptime)
-    connection_mode = Config.BOARD_API_MODE.upper()
     version = __version__
 
     # Get current timestamp
@@ -7504,12 +7602,13 @@ async def debug_get_cache_status():
 @app.get("/debug/system-info")
 async def debug_get_system_info():
     """Get system information without sending to board."""
-    # Gather all system info
-    board_ip = Config.BOARD_HOST or ""
+    # Gather all system info. Connection mode and board IP come from the
+    # boards[] store / live client — the values the send path actually uses —
+    # not from wizard-era config.json (issue #1791).
+    connection_mode, board_ip = _primary_connection_info()
     server_ip = _get_server_ip()
     uptime_seconds = _get_service_uptime()
     uptime_formatted = _format_uptime(uptime_seconds)
-    connection_mode = Config.BOARD_API_MODE
     version = __version__
 
     # Get current timestamp
@@ -7522,14 +7621,24 @@ async def debug_get_system_info():
     client = _get_board_client()
     cache_status = client.get_cache_status() if client else None
 
-    # Check if board is configured
-    board_configured = bool(
-        board_ip
-        and (
-            (connection_mode == "local" and Config.BOARD_LOCAL_API_KEY)
-            or (connection_mode == "cloud" and Config.BOARD_READ_WRITE_KEY)
+    # Check if board is configured: for a boards[] entry the client factory is
+    # the authority on "has a usable connection"; legacy Config installs keep
+    # the old credential check.
+    board = _primary_board_entry()
+    if board is not None:
+        try:
+            board_configured = board_client_from_board_dict(board) is not None
+        except Exception as exc:
+            logger.debug("Could not evaluate board connection config: %s", exc)
+            board_configured = False
+    else:
+        board_configured = bool(
+            board_ip
+            and (
+                (connection_mode == "local" and Config.BOARD_LOCAL_API_KEY)
+                or (connection_mode == "cloud" and Config.BOARD_READ_WRITE_KEY)
+            )
         )
-    )
 
     return {
         "board_ip": board_ip,
@@ -7553,11 +7662,22 @@ async def debug_network_diagnostics():
     """
     from .network_diagnostics import run_full_diagnostics
 
-    board_host = Config.BOARD_HOST or None
-    board_port = 7000
-    board_api_key = Config.BOARD_LOCAL_API_KEY or None
-    use_cloud = (Config.BOARD_API_MODE or "local").lower() == "cloud"
-    cloud_key = Config.BOARD_READ_WRITE_KEY or None
+    # Diagnose the connection the send path actually uses: the boards[] store
+    # first, legacy Config (wizard-era config.json) only when no board is
+    # configured there (issue #1791).
+    board = _primary_board_entry()
+    if board is not None:
+        board_host = board.get("host") or None
+        board_port = board.get("port") or 7000
+        board_api_key = board.get("local_api_key") or None
+        use_cloud = (board.get("api_mode") or "local").lower() == "cloud"
+        cloud_key = board.get("cloud_key") or None
+    else:
+        board_host = Config.BOARD_HOST or None
+        board_port = 7000
+        board_api_key = Config.BOARD_LOCAL_API_KEY or None
+        use_cloud = (Config.BOARD_API_MODE or "local").lower() == "cloud"
+        cloud_key = Config.BOARD_READ_WRITE_KEY or None
 
     try:
         results = run_full_diagnostics(
@@ -9098,8 +9218,17 @@ async def force_refresh():
         client.clear_cache()
 
     try:
-        service.check_and_send_active_page()
-        return {"status": "success", "message": "Display force-refreshed successfully"}
+        sent = service.check_and_send_active_page()
+        error = _service_send_error(service)
+        if error:
+            raise HTTPException(status_code=500, detail=f"Failed to force refresh: {error}")
+        return {
+            "status": "success",
+            "message": "Display force-refreshed successfully",
+            "sent": sent is True,
+        }
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Error force-refreshing display: {e}")
         raise HTTPException(status_code=500, detail=f"Failed to force refresh: {str(e)}") from e

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -884,13 +884,8 @@ class ConfigManager:
     def _apply_env_overrides(self) -> None:
         """Apply environment variable overrides to config.
 
-        An env var applies when the stored value is empty OR still the schema
-        default; a user-customized (non-default) value — e.g. set via the UI —
-        is preserved. The default-equality case matters because
-        ``_load_or_create`` merges defaults BEFORE this runs, so keys with a
-        truthy default (``board.api_mode`` = "local") are never empty and a
-        falsy-only guard made env vars like ``BOARD_API_MODE`` dead code
-        (issue #1791).
+        Only sets values if they're empty in config (allows env vars to provide defaults).
+        Environment variables take precedence for initial setup but UI changes are preserved.
         Placeholder values from .env (e.g. ``your_api_key_here``) are ignored.
         """
         changed = False
@@ -909,66 +904,51 @@ class ConfigManager:
                 self._config["features"][name] = {}
             return self._config["features"][name]
 
-        # Helper to apply string env var. ``default`` is the schema default
-        # for keys the defaults merge fills with a truthy value: a stored
-        # value still equal to it was never customized, so the env var wins.
-        def apply_str(config: dict, key: str, env_var: str, alt_env_var: str | None = None, default=None) -> bool:
+        # Helper to apply string env var
+        def apply_str(config: dict, key: str, env_var: str, alt_env_var: str | None = None) -> bool:
             value = os.getenv(env_var, "").strip()
             if not value and alt_env_var:
                 value = os.getenv(alt_env_var, "").strip()
             if value and ConfigManager._is_placeholder(value):
                 logger.debug(f"Ignoring placeholder value for {env_var}")
                 return False
-            current = config.get(key)
-            if value and (not current or current == default) and value != current:
+            if value and not config.get(key):
                 config[key] = value
                 logger.info(f"Applied {env_var} from environment variable")
                 return True
             return False
 
-        # Helper to apply int env var (same default-equality rule as apply_str)
-        def apply_int(config: dict, key: str, env_var: str, alt_env_var: str | None = None, default=None) -> bool:
+        # Helper to apply int env var
+        def apply_int(config: dict, key: str, env_var: str, alt_env_var: str | None = None) -> bool:
             value = os.getenv(env_var, "").strip()
             if not value and alt_env_var:
                 value = os.getenv(alt_env_var, "").strip()
-            current = config.get(key)
-            if value and (current is None or current == default):
+            if value and config.get(key) is None:
                 try:
-                    parsed = int(value)
-                except ValueError:
-                    logger.warning(f"Invalid {env_var} value: {value}")
-                    return False
-                if parsed != current:
-                    config[key] = parsed
+                    config[key] = int(value)
                     logger.info(f"Applied {env_var} from environment variable")
                     return True
+                except ValueError:
+                    logger.warning(f"Invalid {env_var} value: {value}")
             return False
 
-        # Helper to apply float env var (same default-equality rule as apply_str)
-        def apply_float(config: dict, key: str, env_var: str, default=None) -> bool:
+        # Helper to apply float env var
+        def apply_float(config: dict, key: str, env_var: str) -> bool:
             value = os.getenv(env_var, "").strip()
-            current = config.get(key)
-            if value and (current is None or current == default):
+            if value and config.get(key) is None:
                 try:
-                    parsed = float(value)
-                except ValueError:
-                    logger.warning(f"Invalid {env_var} value: {value}")
-                    return False
-                if parsed != current:
-                    config[key] = parsed
+                    config[key] = float(value)
                     logger.info(f"Applied {env_var} from environment variable")
                     return True
+                except ValueError:
+                    logger.warning(f"Invalid {env_var} value: {value}")
             return False
 
         board_config = self._config["board"]
         general_config = self._config["general"]
 
         # ==================== Board Configuration ====================
-        # api_mode has a truthy schema default ("local"), so its default must
-        # be passed for the env var to apply at all (see docstring / #1791).
-        changed |= apply_str(
-            board_config, "api_mode", "BOARD_API_MODE", "FB_API_MODE", default=DEFAULT_CONFIG["board"]["api_mode"]
-        )
+        changed |= apply_str(board_config, "api_mode", "BOARD_API_MODE", "FB_API_MODE")
         changed |= apply_str(board_config, "local_api_key", "BOARD_LOCAL_API_KEY", "FB_LOCAL_API_KEY")
         changed |= apply_str(board_config, "host", "BOARD_HOST", "FB_HOST")
         changed |= apply_str(board_config, "cloud_key", "BOARD_READ_WRITE_KEY", "FB_READ_WRITE_KEY")
@@ -982,17 +962,9 @@ class ConfigManager:
         )
 
         # ==================== General Configuration ====================
-        general_defaults = DEFAULT_CONFIG["general"]
-        changed |= apply_str(general_config, "timezone", "TIMEZONE", default=general_defaults["timezone"])
-        changed |= apply_int(
-            general_config,
-            "refresh_interval_seconds",
-            "REFRESH_INTERVAL_SECONDS",
-            default=general_defaults["refresh_interval_seconds"],
-        )
-        changed |= apply_str(
-            general_config, "output_target", "OUTPUT_TARGET", default=general_defaults["output_target"]
-        )
+        changed |= apply_str(general_config, "timezone", "TIMEZONE")
+        changed |= apply_int(general_config, "refresh_interval_seconds", "REFRESH_INTERVAL_SECONDS")
+        changed |= apply_str(general_config, "output_target", "OUTPUT_TARGET")
 
         # Silence schedule start/end times (enabling via env var is no longer supported;
         # use the UI or config.json to set silence_schedule.enabled)
@@ -1001,10 +973,9 @@ class ConfigManager:
 
         # ==================== Weather Feature ====================
         weather = get_feature("weather")
-        weather_defaults = DEFAULT_CONFIG["features"]["weather"]
         changed |= apply_str(weather, "api_key", "WEATHER_API_KEY")
-        changed |= apply_str(weather, "provider", "WEATHER_PROVIDER", default=weather_defaults["provider"])
-        changed |= apply_str(weather, "location", "WEATHER_LOCATION", default=weather_defaults["location"])
+        changed |= apply_str(weather, "provider", "WEATHER_PROVIDER")
+        changed |= apply_str(weather, "location", "WEATHER_LOCATION")
 
         # ==================== Guest WiFi Feature ====================
         guest_wifi = get_feature("guest_wifi")

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -884,8 +884,13 @@ class ConfigManager:
     def _apply_env_overrides(self) -> None:
         """Apply environment variable overrides to config.
 
-        Only sets values if they're empty in config (allows env vars to provide defaults).
-        Environment variables take precedence for initial setup but UI changes are preserved.
+        An env var applies when the stored value is empty OR still the schema
+        default; a user-customized (non-default) value — e.g. set via the UI —
+        is preserved. The default-equality case matters because
+        ``_load_or_create`` merges defaults BEFORE this runs, so keys with a
+        truthy default (``board.api_mode`` = "local") are never empty and a
+        falsy-only guard made env vars like ``BOARD_API_MODE`` dead code
+        (issue #1791).
         Placeholder values from .env (e.g. ``your_api_key_here``) are ignored.
         """
         changed = False
@@ -904,51 +909,66 @@ class ConfigManager:
                 self._config["features"][name] = {}
             return self._config["features"][name]
 
-        # Helper to apply string env var
-        def apply_str(config: dict, key: str, env_var: str, alt_env_var: str | None = None) -> bool:
+        # Helper to apply string env var. ``default`` is the schema default
+        # for keys the defaults merge fills with a truthy value: a stored
+        # value still equal to it was never customized, so the env var wins.
+        def apply_str(config: dict, key: str, env_var: str, alt_env_var: str | None = None, default=None) -> bool:
             value = os.getenv(env_var, "").strip()
             if not value and alt_env_var:
                 value = os.getenv(alt_env_var, "").strip()
             if value and ConfigManager._is_placeholder(value):
                 logger.debug(f"Ignoring placeholder value for {env_var}")
                 return False
-            if value and not config.get(key):
+            current = config.get(key)
+            if value and (not current or current == default) and value != current:
                 config[key] = value
                 logger.info(f"Applied {env_var} from environment variable")
                 return True
             return False
 
-        # Helper to apply int env var
-        def apply_int(config: dict, key: str, env_var: str, alt_env_var: str | None = None) -> bool:
+        # Helper to apply int env var (same default-equality rule as apply_str)
+        def apply_int(config: dict, key: str, env_var: str, alt_env_var: str | None = None, default=None) -> bool:
             value = os.getenv(env_var, "").strip()
             if not value and alt_env_var:
                 value = os.getenv(alt_env_var, "").strip()
-            if value and config.get(key) is None:
+            current = config.get(key)
+            if value and (current is None or current == default):
                 try:
-                    config[key] = int(value)
-                    logger.info(f"Applied {env_var} from environment variable")
-                    return True
+                    parsed = int(value)
                 except ValueError:
                     logger.warning(f"Invalid {env_var} value: {value}")
+                    return False
+                if parsed != current:
+                    config[key] = parsed
+                    logger.info(f"Applied {env_var} from environment variable")
+                    return True
             return False
 
-        # Helper to apply float env var
-        def apply_float(config: dict, key: str, env_var: str) -> bool:
+        # Helper to apply float env var (same default-equality rule as apply_str)
+        def apply_float(config: dict, key: str, env_var: str, default=None) -> bool:
             value = os.getenv(env_var, "").strip()
-            if value and config.get(key) is None:
+            current = config.get(key)
+            if value and (current is None or current == default):
                 try:
-                    config[key] = float(value)
-                    logger.info(f"Applied {env_var} from environment variable")
-                    return True
+                    parsed = float(value)
                 except ValueError:
                     logger.warning(f"Invalid {env_var} value: {value}")
+                    return False
+                if parsed != current:
+                    config[key] = parsed
+                    logger.info(f"Applied {env_var} from environment variable")
+                    return True
             return False
 
         board_config = self._config["board"]
         general_config = self._config["general"]
 
         # ==================== Board Configuration ====================
-        changed |= apply_str(board_config, "api_mode", "BOARD_API_MODE", "FB_API_MODE")
+        # api_mode has a truthy schema default ("local"), so its default must
+        # be passed for the env var to apply at all (see docstring / #1791).
+        changed |= apply_str(
+            board_config, "api_mode", "BOARD_API_MODE", "FB_API_MODE", default=DEFAULT_CONFIG["board"]["api_mode"]
+        )
         changed |= apply_str(board_config, "local_api_key", "BOARD_LOCAL_API_KEY", "FB_LOCAL_API_KEY")
         changed |= apply_str(board_config, "host", "BOARD_HOST", "FB_HOST")
         changed |= apply_str(board_config, "cloud_key", "BOARD_READ_WRITE_KEY", "FB_READ_WRITE_KEY")
@@ -962,9 +982,17 @@ class ConfigManager:
         )
 
         # ==================== General Configuration ====================
-        changed |= apply_str(general_config, "timezone", "TIMEZONE")
-        changed |= apply_int(general_config, "refresh_interval_seconds", "REFRESH_INTERVAL_SECONDS")
-        changed |= apply_str(general_config, "output_target", "OUTPUT_TARGET")
+        general_defaults = DEFAULT_CONFIG["general"]
+        changed |= apply_str(general_config, "timezone", "TIMEZONE", default=general_defaults["timezone"])
+        changed |= apply_int(
+            general_config,
+            "refresh_interval_seconds",
+            "REFRESH_INTERVAL_SECONDS",
+            default=general_defaults["refresh_interval_seconds"],
+        )
+        changed |= apply_str(
+            general_config, "output_target", "OUTPUT_TARGET", default=general_defaults["output_target"]
+        )
 
         # Silence schedule start/end times (enabling via env var is no longer supported;
         # use the UI or config.json to set silence_schedule.enabled)
@@ -973,9 +1001,10 @@ class ConfigManager:
 
         # ==================== Weather Feature ====================
         weather = get_feature("weather")
+        weather_defaults = DEFAULT_CONFIG["features"]["weather"]
         changed |= apply_str(weather, "api_key", "WEATHER_API_KEY")
-        changed |= apply_str(weather, "provider", "WEATHER_PROVIDER")
-        changed |= apply_str(weather, "location", "WEATHER_LOCATION")
+        changed |= apply_str(weather, "provider", "WEATHER_PROVIDER", default=weather_defaults["provider"])
+        changed |= apply_str(weather, "location", "WEATHER_LOCATION", default=weather_defaults["location"])
 
         # ==================== Guest WiFi Feature ====================
         guest_wifi = get_feature("guest_wifi")

--- a/src/main.py
+++ b/src/main.py
@@ -81,6 +81,13 @@ class BoardRuntime:
         self.last_silence_mode_active: bool = False
         self.snoozing_message_sent: bool = False
 
+        # Why the most recent check_and_send_for_board pass failed for this
+        # board, or None when it succeeded or skipped benignly (paused,
+        # silence, unchanged content, no active page). Lets API endpoints
+        # report real send failures instead of silently claiming success
+        # (issue #1791).
+        self.last_send_error: str | None = None
+
         # Board-state read cache (populated by the poll thread / adaptive
         # refresh). Board-state polling stays primary-only (see
         # ``_board_poll_loop``), but the cache lives on the runtime so a
@@ -200,6 +207,16 @@ class DisplayService:
     def get_runtime(self, board_id) -> BoardRuntime | None:
         """Return the runtime for a board id, or None."""
         return self.runtimes.get(board_id)
+
+    def get_last_send_error(self, board_id=None) -> str | None:
+        """Failure reason for a board's most recent active-page send attempt.
+
+        None means the last ``check_and_send_for_board`` pass either sent
+        successfully or skipped benignly (paused, silence, unchanged content,
+        no active page). ``board_id`` omitted → the primary board.
+        """
+        rt = self.runtimes.get(board_id) if board_id is not None else self._primary_runtime()
+        return rt.last_send_error if rt is not None else None
 
     # -- State shims aliasing the primary runtime (read + write). --------- #
 
@@ -723,6 +740,10 @@ class DisplayService:
             True if content was sent to this board, False otherwise.
         """
         try:
+            # Each pass starts clean: a benign skip must not leave a stale
+            # failure reason behind (issue #1791).
+            rt.last_send_error = None
+
             settings_service = get_settings_service()
             page_service = get_page_service()
             schedule_service = get_schedule_service()
@@ -901,6 +922,8 @@ class DisplayService:
                 # so template variables (weather, time, stocks, etc.) are current.
                 result = page_service.preview_page(active_page_id, force_refresh=True)
                 if not result or not result.available:
+                    render_error = getattr(result, "error", None) if result else None
+                    rt.last_send_error = render_error or f"Failed to render active page: {active_page_id}"
                     logger.warning(f"Failed to render active page: {active_page_id}")
                     return False
 
@@ -966,6 +989,7 @@ class DisplayService:
             logger.info(f"Board {board_id}: active page content changed, sending: {active_page_id}")
 
             if not rt.client:
+                rt.last_send_error = "Board client not initialized"
                 logger.warning("Board client not initialized")
                 return False
 
@@ -1008,10 +1032,12 @@ class DisplayService:
                 else:
                     logger.debug("Active page unchanged at board level")
                 return was_sent
+            rt.last_send_error = f"Failed to send active page to board: {active_page_id}"
             logger.error(f"Board {board_id}: failed to send active page: {active_page_id}")
             return False
 
         except Exception as e:
+            rt.last_send_error = str(e) or e.__class__.__name__
             logger.error(f"Error checking active page for board {board_id}: {e}")
             return False
 

--- a/src/main.py
+++ b/src/main.py
@@ -4,6 +4,7 @@ import logging
 import signal
 import threading
 import time
+from contextlib import contextmanager
 
 import schedule
 
@@ -138,6 +139,15 @@ class DisplayService:
         # Board state polling (background thread reads actual board state).
         self._poll_thread: threading.Thread | None = None
 
+        # Per-thread capture of send failures for the pass currently running
+        # on THIS thread. ``rt.last_send_error`` is shared state that the
+        # engine thread rewrites on its own cadence, so an API endpoint that
+        # read it after ``check_and_send_*`` returned could see the engine's
+        # value instead of its own (issue #1791). The ``*_with_status``
+        # wrappers below read this instead, so a caller only ever sees the
+        # failures its own call produced.
+        self._send_capture = threading.local()
+
     # ------------------------------------------------------------------ #
     # Primary-runtime resolution + back-compat property shims
     # ------------------------------------------------------------------ #
@@ -214,9 +224,68 @@ class DisplayService:
         None means the last ``check_and_send_for_board`` pass either sent
         successfully or skipped benignly (paused, silence, unchanged content,
         no active page). ``board_id`` omitted → the primary board.
+
+        This is shared state the engine thread also writes; callers that need
+        the reason for *their own* send should use the ``*_with_status``
+        wrappers instead of reading this after the fact.
         """
         rt = self.runtimes.get(board_id) if board_id is not None else self._primary_runtime()
         return rt.last_send_error if rt is not None else None
+
+    def _record_send_error(self, rt: BoardRuntime, board_id, message: str) -> None:
+        """Record a send failure on the runtime and in this thread's capture."""
+        rt.last_send_error = message
+        errors = getattr(self._send_capture, "errors", None)
+        if errors is not None:
+            errors.append((board_id, message))
+
+    @contextmanager
+    def _capture_send_errors(self):
+        """Collect send failures recorded on this thread for the enclosed pass.
+
+        Nesting is a no-op for the inner block: the outermost capture owns the
+        list so ``check_and_send_active_page_with_status`` still sees failures
+        raised while driving secondary boards.
+        """
+        if getattr(self._send_capture, "errors", None) is not None:
+            yield None
+            return
+        errors: list[tuple] = []
+        self._send_capture.errors = errors
+        try:
+            yield errors
+        finally:
+            self._send_capture.errors = None
+
+    def check_and_send_for_board_with_status(
+        self, board_id, rt: BoardRuntime, *, is_primary: bool, board: dict | None = None
+    ) -> tuple[bool, str | None]:
+        """``check_and_send_for_board`` plus the reason THIS call failed.
+
+        Reading ``rt.last_send_error`` after the call returns races the engine
+        thread, which can clear or overwrite it in between and so produce a
+        false success or a spurious 500 (issue #1791).
+        """
+        with self._capture_send_errors() as errors:
+            sent = self.check_and_send_for_board(board_id, rt, is_primary=is_primary, board=board)
+            reason = errors[0][1] if errors else None
+        return sent, reason
+
+    def check_and_send_active_page_with_status(self) -> tuple[bool, str | None]:
+        """``check_and_send_active_page`` plus the first failure across ALL boards.
+
+        The pass drives the primary board and then every secondary; a failing
+        secondary must not read as an unqualified success, so the reason is
+        prefixed with the board id when it came from a non-primary board.
+        """
+        primary_id = self._get_first_board_id()
+        with self._capture_send_errors() as errors:
+            sent = self.check_and_send_active_page()
+            reason = None
+            if errors:
+                failed_board_id, message = errors[0]
+                reason = message if failed_board_id == primary_id else f"board {failed_board_id}: {message}"
+        return sent, reason
 
     # -- State shims aliasing the primary runtime (read + write). --------- #
 
@@ -723,6 +792,7 @@ class DisplayService:
             try:
                 self.check_and_send_for_board(board_id, rt, is_primary=False, board=board)
             except Exception as e:  # partial-failure isolation
+                self._record_send_error(rt, board_id, str(e) or e.__class__.__name__)
                 logger.error(f"Board {board_id}: update failed: {e}")
 
     def check_and_send_for_board(
@@ -899,6 +969,8 @@ class DisplayService:
                 page = inline_page
                 result = page_service.render_page(inline_page)
                 if not result or not result.available:
+                    render_error = getattr(result, "error", None) if result else None
+                    self._record_send_error(rt, board_id, render_error or "Failed to render one-off override content")
                     logger.warning("Failed to render one-off override content")
                     return False
             else:
@@ -923,7 +995,9 @@ class DisplayService:
                 result = page_service.preview_page(active_page_id, force_refresh=True)
                 if not result or not result.available:
                     render_error = getattr(result, "error", None) if result else None
-                    rt.last_send_error = render_error or f"Failed to render active page: {active_page_id}"
+                    self._record_send_error(
+                        rt, board_id, render_error or f"Failed to render active page: {active_page_id}"
+                    )
                     logger.warning(f"Failed to render active page: {active_page_id}")
                     return False
 
@@ -989,7 +1063,7 @@ class DisplayService:
             logger.info(f"Board {board_id}: active page content changed, sending: {active_page_id}")
 
             if not rt.client:
-                rt.last_send_error = "Board client not initialized"
+                self._record_send_error(rt, board_id, "Board client not initialized")
                 logger.warning("Board client not initialized")
                 return False
 
@@ -1032,12 +1106,12 @@ class DisplayService:
                 else:
                     logger.debug("Active page unchanged at board level")
                 return was_sent
-            rt.last_send_error = f"Failed to send active page to board: {active_page_id}"
+            self._record_send_error(rt, board_id, f"Failed to send active page to board: {active_page_id}")
             logger.error(f"Board {board_id}: failed to send active page: {active_page_id}")
             return False
 
         except Exception as e:
-            rt.last_send_error = str(e) or e.__class__.__name__
+            self._record_send_error(rt, board_id, str(e) or e.__class__.__name__)
             logger.error(f"Error checking active page for board {board_id}: {e}")
             return False
 

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -1027,18 +1027,35 @@ class TestSetActivePage:
 
 class TestRefreshFailureReporting:
     """POST /refresh and /force-refresh must report send failures instead of
-    unconditionally claiming success (issue #1791)."""
+    unconditionally claiming success (issue #1791).
 
-    def test_refresh_reports_primary_send_failure(self, client, mock_service):
-        mock_service.check_and_send_active_page.return_value = False
-        mock_service.get_last_send_error.return_value = "Failed to render active page: p1"
+    The reason comes back from the ``*_with_status`` call itself, never from a
+    follow-up read of ``last_send_error`` — that attribute is shared with the
+    engine thread, which can clear or overwrite it in between.
+    """
+
+    def test_refresh_reports_send_failure(self, client, mock_service):
+        mock_service.check_and_send_active_page_with_status.return_value = (
+            False,
+            "Failed to render active page: p1",
+        )
         response = client.post("/refresh")
         assert response.status_code == 500
         assert "Failed to render active page: p1" in response.json()["detail"]
 
+    def test_refresh_reports_a_secondary_boards_failure(self, client, mock_service):
+        """/refresh drives every board, so a failing secondary must not return
+        success even though the primary was fine."""
+        mock_service.check_and_send_active_page_with_status.return_value = (
+            True,
+            "board b2: Failed to send active page to board: p2",
+        )
+        response = client.post("/refresh")
+        assert response.status_code == 500
+        assert "board b2" in response.json()["detail"]
+
     def test_refresh_success_reports_sent_flag(self, client, mock_service):
-        mock_service.check_and_send_active_page.return_value = True
-        mock_service.get_last_send_error.return_value = None
+        mock_service.check_and_send_active_page_with_status.return_value = (True, None)
         response = client.post("/refresh")
         assert response.status_code == 200
         data = response.json()
@@ -1047,32 +1064,40 @@ class TestRefreshFailureReporting:
 
     def test_refresh_benign_skip_is_still_success(self, client, mock_service):
         """Not sending because nothing changed (or paused) is not a failure."""
-        mock_service.check_and_send_active_page.return_value = False
-        mock_service.get_last_send_error.return_value = None
+        mock_service.check_and_send_active_page_with_status.return_value = (False, None)
         response = client.post("/refresh")
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == "success"
         assert data["sent"] is False
 
+    def test_refresh_does_not_read_last_send_error_after_the_call(self, client, mock_service):
+        """Guard against reintroducing the race: a stale/concurrent
+        ``last_send_error`` must not turn a clean pass into a 500."""
+        mock_service.check_and_send_active_page_with_status.return_value = (True, None)
+        mock_service.get_last_send_error.return_value = "engine thread failure from another tick"
+        response = client.post("/refresh")
+        assert response.status_code == 200
+        assert response.json()["sent"] is True
+
     def test_refresh_board_id_reports_that_boards_failure(self, client, mock_service, mock_settings_service):
         mock_settings_service.get_primary_board_id.return_value = "b1"
-        mock_service.check_and_send_for_board.return_value = False
-        mock_service.get_last_send_error.side_effect = lambda board_id=None: "send failed" if board_id == "b1" else None
+        mock_service.check_and_send_for_board_with_status.return_value = (False, "send failed")
         response = client.post("/refresh?board_id=b1")
         assert response.status_code == 500
         assert "send failed" in response.json()["detail"]
 
     def test_force_refresh_reports_send_failure(self, client, mock_service):
-        mock_service.check_and_send_active_page.return_value = False
-        mock_service.get_last_send_error.return_value = "Failed to send active page to board: p1"
+        mock_service.check_and_send_active_page_with_status.return_value = (
+            False,
+            "Failed to send active page to board: p1",
+        )
         response = client.post("/force-refresh")
         assert response.status_code == 500
         assert "Failed to send active page to board: p1" in response.json()["detail"]
 
     def test_force_refresh_success_reports_sent_flag(self, client, mock_service):
-        mock_service.check_and_send_active_page.return_value = True
-        mock_service.get_last_send_error.return_value = None
+        mock_service.check_and_send_active_page_with_status.return_value = (True, None)
         response = client.post("/force-refresh")
         assert response.status_code == 200
         assert response.json()["sent"] is True

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -972,6 +972,111 @@ class TestSetActivePage:
             # send_characters returns (False, False), the endpoint logs a warning
             assert response.status_code == 200
 
+    def test_set_active_page_render_unavailable_reports_error(
+        self, client, mock_settings_service, mock_page_service, mock_service, mock_collection_service
+    ):
+        """A page whose render is unavailable (e.g. plugin/network failure) must
+        surface an explicit error instead of silently reporting success (#1791)."""
+        mock_settings_service.should_send_to_board.return_value = True
+        preview = Mock()
+        preview.available = False
+        preview.formatted = ""
+        preview.error = "Weather API unreachable"
+        mock_page_service.preview_page.return_value = preview
+        response = client.put("/settings/active-page", json={"page_id": "page1"})
+        assert response.status_code == 200
+        data = response.json()
+        assert data["sent_to_board"] is False
+        assert "Weather API unreachable" in data["error"]
+
+    def test_set_active_page_board_write_failure_reports_error(
+        self, client, mock_settings_service, mock_page_service, mock_service, mock_collection_service
+    ):
+        """A failed board write must surface an explicit error field (#1791)."""
+        mock_settings_service.should_send_to_board.return_value = True
+        mock_service.vb_client.render.return_value = (False, False)
+        with (
+            patch("src.api_server.resolve_dimensions") as mock_dims,
+            patch("src.api_server.text_to_board_array") as mock_ttba,
+        ):
+            mock_dims.return_value = Mock(rows=6, cols=22)
+            mock_ttba.return_value = [[0] * 22 for _ in range(6)]
+            response = client.put("/settings/active-page", json={"page_id": "page1"})
+        assert response.status_code == 200
+        data = response.json()
+        assert data["sent_to_board"] is False
+        assert data["error"]
+
+    def test_set_active_page_successful_send_has_no_error(
+        self, client, mock_settings_service, mock_page_service, mock_service, mock_collection_service
+    ):
+        """A successful send must not carry an error field."""
+        mock_settings_service.should_send_to_board.return_value = True
+        with (
+            patch("src.api_server.resolve_dimensions") as mock_dims,
+            patch("src.api_server.text_to_board_array") as mock_ttba,
+        ):
+            mock_dims.return_value = Mock(rows=6, cols=22)
+            mock_ttba.return_value = [[0] * 22 for _ in range(6)]
+            response = client.put("/settings/active-page", json={"page_id": "page1"})
+        assert response.status_code == 200
+        data = response.json()
+        assert data["sent_to_board"] is True
+        assert data.get("error") is None
+
+
+class TestRefreshFailureReporting:
+    """POST /refresh and /force-refresh must report send failures instead of
+    unconditionally claiming success (issue #1791)."""
+
+    def test_refresh_reports_primary_send_failure(self, client, mock_service):
+        mock_service.check_and_send_active_page.return_value = False
+        mock_service.get_last_send_error.return_value = "Failed to render active page: p1"
+        response = client.post("/refresh")
+        assert response.status_code == 500
+        assert "Failed to render active page: p1" in response.json()["detail"]
+
+    def test_refresh_success_reports_sent_flag(self, client, mock_service):
+        mock_service.check_and_send_active_page.return_value = True
+        mock_service.get_last_send_error.return_value = None
+        response = client.post("/refresh")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "success"
+        assert data["sent"] is True
+
+    def test_refresh_benign_skip_is_still_success(self, client, mock_service):
+        """Not sending because nothing changed (or paused) is not a failure."""
+        mock_service.check_and_send_active_page.return_value = False
+        mock_service.get_last_send_error.return_value = None
+        response = client.post("/refresh")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "success"
+        assert data["sent"] is False
+
+    def test_refresh_board_id_reports_that_boards_failure(self, client, mock_service, mock_settings_service):
+        mock_settings_service.get_primary_board_id.return_value = "b1"
+        mock_service.check_and_send_for_board.return_value = False
+        mock_service.get_last_send_error.side_effect = lambda board_id=None: "send failed" if board_id == "b1" else None
+        response = client.post("/refresh?board_id=b1")
+        assert response.status_code == 500
+        assert "send failed" in response.json()["detail"]
+
+    def test_force_refresh_reports_send_failure(self, client, mock_service):
+        mock_service.check_and_send_active_page.return_value = False
+        mock_service.get_last_send_error.return_value = "Failed to send active page to board: p1"
+        response = client.post("/force-refresh")
+        assert response.status_code == 500
+        assert "Failed to send active page to board: p1" in response.json()["detail"]
+
+    def test_force_refresh_success_reports_sent_flag(self, client, mock_service):
+        mock_service.check_and_send_active_page.return_value = True
+        mock_service.get_last_send_error.return_value = None
+        response = client.post("/force-refresh")
+        assert response.status_code == 200
+        assert response.json()["sent"] is True
+
 
 class TestDisplaySettings:
     """Tests for PUT /settings/display."""

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -329,6 +329,41 @@ def test_apply_env_overrides_does_not_override_existing_note_array_token(monkeyp
     assert cm.get_board()["note_array_token"] == "ui-stored-token"
 
 
+def test_apply_env_overrides_board_api_mode_takes_effect_over_merged_default(monkeypatch, tmp_path):
+    """BOARD_API_MODE from the environment must take effect (issue #1791).
+
+    The defaults merge fills board.api_mode with "local" before
+    ``_apply_env_overrides`` runs, so a falsy-only guard silently ignored
+    the env var forever (dead code). An env var must win over a value that
+    is still the schema default.
+    """
+    monkeypatch.setenv("BOARD_API_MODE", "cloud")
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"board": {}, "features": {}, "general": {}}))
+    cm = ConfigManager(config_path=str(config_path))
+    assert cm.get_board()["api_mode"] == "cloud"
+
+
+def test_apply_env_overrides_board_api_mode_persisted_default_still_overridden(monkeypatch, tmp_path):
+    """A previously persisted default (written back by the defaults merge on an
+    earlier boot) is still overridable — only a user-customized value wins."""
+    monkeypatch.setenv("BOARD_API_MODE", "cloud")
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"board": {"api_mode": "local"}, "features": {}, "general": {}}))
+    cm = ConfigManager(config_path=str(config_path))
+    assert cm.get_board()["api_mode"] == "cloud"
+
+
+def test_apply_env_overrides_preserves_user_customized_api_mode(monkeypatch, tmp_path):
+    """A non-default api_mode stored in config (set via the wizard/UI) is not
+    clobbered by an env var — UI changes are preserved."""
+    monkeypatch.setenv("BOARD_API_MODE", "local")
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"board": {"api_mode": "cloud"}, "features": {}, "general": {}}))
+    cm = ConfigManager(config_path=str(config_path))
+    assert cm.get_board()["api_mode"] == "cloud"
+
+
 def test_apply_env_overrides_invalid_int_value(monkeypatch, tmp_path):
     """Handles invalid int env var values."""
     monkeypatch.setenv("BOARD_TRANSITION_INTERVAL_MS", "not_a_number")

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -329,31 +329,6 @@ def test_apply_env_overrides_does_not_override_existing_note_array_token(monkeyp
     assert cm.get_board()["note_array_token"] == "ui-stored-token"
 
 
-def test_apply_env_overrides_board_api_mode_takes_effect_over_merged_default(monkeypatch, tmp_path):
-    """BOARD_API_MODE from the environment must take effect (issue #1791).
-
-    The defaults merge fills board.api_mode with "local" before
-    ``_apply_env_overrides`` runs, so a falsy-only guard silently ignored
-    the env var forever (dead code). An env var must win over a value that
-    is still the schema default.
-    """
-    monkeypatch.setenv("BOARD_API_MODE", "cloud")
-    config_path = tmp_path / "config.json"
-    config_path.write_text(json.dumps({"board": {}, "features": {}, "general": {}}))
-    cm = ConfigManager(config_path=str(config_path))
-    assert cm.get_board()["api_mode"] == "cloud"
-
-
-def test_apply_env_overrides_board_api_mode_persisted_default_still_overridden(monkeypatch, tmp_path):
-    """A previously persisted default (written back by the defaults merge on an
-    earlier boot) is still overridable — only a user-customized value wins."""
-    monkeypatch.setenv("BOARD_API_MODE", "cloud")
-    config_path = tmp_path / "config.json"
-    config_path.write_text(json.dumps({"board": {"api_mode": "local"}, "features": {}, "general": {}}))
-    cm = ConfigManager(config_path=str(config_path))
-    assert cm.get_board()["api_mode"] == "cloud"
-
-
 def test_apply_env_overrides_preserves_user_customized_api_mode(monkeypatch, tmp_path):
     """A non-default api_mode stored in config (set via the wizard/UI) is not
     clobbered by an env var — UI changes are preserved."""
@@ -362,6 +337,52 @@ def test_apply_env_overrides_preserves_user_customized_api_mode(monkeypatch, tmp
     config_path.write_text(json.dumps({"board": {"api_mode": "cloud"}, "features": {}, "general": {}}))
     cm = ConfigManager(config_path=str(config_path))
     assert cm.get_board()["api_mode"] == "cloud"
+
+
+def test_apply_env_overrides_preserves_user_chosen_value_equal_to_default(monkeypatch, tmp_path):
+    """A stored value that happens to equal the schema default is still the
+    user's choice and must not be replaced by an env var.
+
+    ``_apply_env_overrides`` cannot distinguish "user deliberately selected
+    the default" from "never configured", so it must never override a
+    present value. ``board.api_mode`` defaults to "local"; a user who picks
+    Local API in Settings or the setup wizard stores exactly that string,
+    and ``BOARD_API_MODE=cloud`` in the compose-loaded ``.env`` must not
+    silently flip it back.
+    """
+    monkeypatch.setenv("BOARD_API_MODE", "cloud")
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"board": {"api_mode": "local"}, "features": {}, "general": {}}))
+    cm = ConfigManager(config_path=str(config_path))
+    assert cm.get_board()["api_mode"] == "local"
+
+
+def test_reload_does_not_revert_user_saved_board_api_mode(monkeypatch, tmp_path):
+    """``PUT /config/board`` calls ``Config.reload()`` inline, which re-runs
+    ``_apply_env_overrides``. A just-saved default-equal value must survive
+    that round-trip instead of reverting inside the same request.
+    """
+    monkeypatch.setenv("BOARD_API_MODE", "cloud")
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"board": {"api_mode": "cloud"}, "features": {}, "general": {}}))
+    cm = ConfigManager(config_path=str(config_path))
+
+    cm.set_board({"api_mode": "local"})
+    assert cm.get_board()["api_mode"] == "local"
+
+    cm.reload()
+    assert cm.get_board()["api_mode"] == "local"
+
+
+def test_apply_env_overrides_preserves_user_chosen_default_timezone(monkeypatch, tmp_path):
+    """The same rule for ``general.timezone``, which feeds schedule rotations
+    and sunrise/sunset: a stored value equal to the default is not replaced.
+    """
+    monkeypatch.setenv("TIMEZONE", "Europe/Berlin")
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"board": {}, "features": {}, "general": {"timezone": "America/Los_Angeles"}}))
+    cm = ConfigManager(config_path=str(config_path))
+    assert cm.get_general()["timezone"] == "America/Los_Angeles"
 
 
 def test_apply_env_overrides_invalid_int_value(monkeypatch, tmp_path):

--- a/tests/test_debug_endpoints.py
+++ b/tests/test_debug_endpoints.py
@@ -477,3 +477,97 @@ class TestGetFirstBoardDims:
         with patch("src.api_server.get_settings_service", return_value=ss):
             dims = _get_first_board_dims()
         assert (dims.rows, dims.cols) == (6, 22)
+
+
+class TestConnectionInfoSource:
+    """/debug/system-info and /debug/info must report the connection mode and
+    board IP the live send path actually uses — the boards[] store — not the
+    wizard-era legacy config.json values (issue #1791)."""
+
+    @staticmethod
+    def _ss_with_board(board, send_to_board=False):
+        ss = Mock()
+        ss.should_send_to_board.return_value = send_to_board
+        ss.is_paused.return_value = False
+        board_settings = Mock()
+        board_settings.boards = [board] if board is not None else []
+        ss.get_board_settings.return_value = board_settings
+        return ss
+
+    def test_system_info_uses_boards_store_not_legacy_config(self, client):
+        """boards[0] says cloud; stale config.json says local → report cloud."""
+        board = {
+            "id": "b1",
+            "api_mode": "cloud",
+            "host": "10.0.0.42",
+            "cloud_key": "test-rw-key",
+            "device_type": "flagship",
+        }
+        with (
+            patch("src.api_server.get_settings_service", return_value=self._ss_with_board(board)),
+            patch("src.api_server.Config") as mock_config,
+        ):
+            mock_config.BOARD_API_MODE = "local"
+            mock_config.BOARD_HOST = "192.168.1.99"
+            response = client.get("/debug/system-info")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["connection_mode"] == "cloud"
+        assert data["board_ip"] == "10.0.0.42"
+        assert data["board_configured"] is True
+
+    def test_system_info_unusable_board_entry_not_configured(self, client):
+        """A boards[0] entry without usable credentials reports board_configured False."""
+        board = {"id": "b1", "api_mode": "cloud", "host": "", "cloud_key": "", "device_type": "flagship"}
+        with (
+            patch("src.api_server.get_settings_service", return_value=self._ss_with_board(board)),
+            patch("src.api_server.Config") as mock_config,
+        ):
+            mock_config.BOARD_API_MODE = "local"
+            mock_config.BOARD_HOST = "192.168.1.99"
+            mock_config.BOARD_LOCAL_API_KEY = "legacy-key"
+            mock_config.BOARD_READ_WRITE_KEY = ""
+            response = client.get("/debug/system-info")
+        assert response.status_code == 200
+        assert response.json()["board_configured"] is False
+
+    def test_system_info_falls_back_to_legacy_config_without_boards(self, client):
+        """No boards[] entries → legacy Config keeps working (pre-boards installs)."""
+        with (
+            patch("src.api_server.get_settings_service", return_value=self._ss_with_board(None)),
+            patch("src.api_server._get_board_client", return_value=None),
+            patch("src.api_server.Config") as mock_config,
+        ):
+            mock_config.BOARD_API_MODE = "local"
+            mock_config.BOARD_HOST = "192.168.1.50"
+            mock_config.BOARD_LOCAL_API_KEY = "legacy-key"
+            mock_config.BOARD_READ_WRITE_KEY = ""
+            response = client.get("/debug/system-info")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["connection_mode"] == "local"
+        assert data["board_ip"] == "192.168.1.50"
+        assert data["board_configured"] is True
+
+    def test_debug_info_board_text_uses_boards_store(self, client, mock_board_client):
+        """The on-board debug text reports the boards[] mode/host, not legacy Config."""
+        board = {
+            "id": "b1",
+            "api_mode": "cloud",
+            "host": "10.0.0.42",
+            "cloud_key": "test-rw-key",
+            "device_type": "flagship",
+        }
+        ss = self._ss_with_board(board, send_to_board=False)
+        with (
+            patch("src.api_server.get_settings_service", return_value=ss),
+            patch("src.api_server.Config") as mock_config,
+        ):
+            mock_config.BOARD_API_MODE = "local"
+            mock_config.BOARD_HOST = "192.168.1.99"
+            response = client.post("/debug/info")
+        assert response.status_code == 200
+        debug_info = response.json()["debug_info"]
+        assert "CLOUD API" in debug_info
+        assert "10.0.0.42" in debug_info
+        assert "192.168.1.99" not in debug_info

--- a/tests/test_per_board_engine.py
+++ b/tests/test_per_board_engine.py
@@ -600,3 +600,62 @@ class TestSilencePageGeometryValidation:
         secondary_rows = clients["b2"].render.call_args.args[0]
         assert len(secondary_rows) == 3 and len(secondary_rows[0]) == 15
         assert svc.runtimes["b2"].last_active_page_id != "__silence_page__:sil"
+
+
+class TestSendFailureTracking:
+    """check_and_send_for_board records why a send attempt failed on the
+    runtime (issue #1791) so API endpoints can report it instead of
+    conflating 'failed' with benign skips."""
+
+    def test_render_unavailable_records_error(self):
+        boards = [_board("b1", "One")]
+        svc, _clients = _service_with_runtimes(boards)
+        pages = _page_service({"pA": {"content": "ALPHA"}})
+        pages.preview_page.side_effect = lambda pid, force_refresh=False: SimpleNamespace(
+            available=False, formatted="", error="plugin data unavailable"
+        )
+        schedule = _schedule_service({"b1": "pA"})
+
+        sent = _drive(svc, boards, pages=pages, schedule=schedule)
+
+        assert sent is False
+        assert svc.get_last_send_error("b1") == "plugin data unavailable"
+        assert svc.get_last_send_error() == "plugin data unavailable"  # default → primary
+
+    def test_board_write_failure_records_error(self):
+        boards = [_board("b1", "One")]
+        svc, clients = _service_with_runtimes(boards)
+        clients["b1"].render.return_value = (False, False)
+        pages = _page_service({"pA": {"content": "ALPHA"}})
+        schedule = _schedule_service({"b1": "pA"})
+
+        sent = _drive(svc, boards, pages=pages, schedule=schedule)
+
+        assert sent is False
+        assert "pA" in (svc.get_last_send_error("b1") or "")
+
+    def test_successful_send_clears_previous_error(self):
+        boards = [_board("b1", "One")]
+        svc, _clients = _service_with_runtimes(boards)
+        svc.runtimes["b1"].last_send_error = "stale error from an earlier tick"
+        pages = _page_service({"pA": {"content": "ALPHA"}})
+        schedule = _schedule_service({"b1": "pA"})
+
+        sent = _drive(svc, boards, pages=pages, schedule=schedule)
+
+        assert sent is True
+        assert svc.get_last_send_error("b1") is None
+
+    def test_unchanged_content_skip_is_not_an_error(self):
+        boards = [_board("b1", "One")]
+        svc, clients = _service_with_runtimes(boards)
+        pages = _page_service({"pA": {"content": "ALPHA"}})
+        schedule = _schedule_service({"b1": "pA"})
+
+        _drive(svc, boards, pages=pages, schedule=schedule)
+        clients["b1"].render.reset_mock()
+        sent = _drive(svc, boards, pages=pages, schedule=schedule)
+
+        assert sent is False
+        clients["b1"].render.assert_not_called()
+        assert svc.get_last_send_error("b1") is None

--- a/tests/test_per_board_engine.py
+++ b/tests/test_per_board_engine.py
@@ -736,6 +736,35 @@ class TestSendStatusReporting:
         # which is exactly why the endpoint must not read it back.
         assert rt.last_send_error == "engine tick failure"
 
+    def test_one_off_override_render_failure_is_reported(self):
+        """The one-off send path (#1789) is a second render that can fail. It
+        must report too, or /refresh on a failing one-off returns success."""
+        boards = [_board("b1", "One")]
+        svc, _clients = _service_with_runtimes(boards)
+        override = SimpleNamespace(
+            is_inline=True,
+            is_expired=lambda: False,
+            template=["ONE OFF"],
+            line_metadata=None,
+            device_type="flagship",
+            notes_wide=1,
+            notes_tall=1,
+            revert_mode="schedule",
+            revert_page_id=None,
+            page_id=None,
+        )
+        settings = _settings_service(boards, override=override)
+        pages = _page_service({"pA": {"content": "ALPHA"}})
+        pages.render_page.side_effect = lambda page: SimpleNamespace(
+            available=False, formatted="", error="one-off render failed"
+        )
+        schedule = _schedule_service({"b1": "pA"})
+
+        sent, error = _drive(svc, boards, settings=settings, pages=pages, schedule=schedule, with_status=True)
+
+        assert sent is False
+        assert error == "one-off render failed"
+
     def test_successful_pass_reports_no_reason(self):
         boards = [_board("b1", "One")]
         svc, _clients = _service_with_runtimes(boards)

--- a/tests/test_per_board_engine.py
+++ b/tests/test_per_board_engine.py
@@ -14,6 +14,7 @@ each other's caches. Covers:
   - the note-array send routes through its own client at its own size
 """
 
+import threading
 from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -150,7 +151,10 @@ def _drive(
     silence=False,
     silence_mode="indicator",
     silence_page_id=None,
+    with_status=False,
 ):
+    """Run one full pass. ``with_status`` uses the wrapper the API endpoints
+    call, returning ``(sent, failure reason)`` instead of just ``sent``."""
     settings = settings if settings is not None else _settings_service(boards)
     pages = pages if pages is not None else _page_service({})
     schedule = schedule if schedule is not None else _schedule_service({})
@@ -183,6 +187,8 @@ def _drive(
             "indicator_text": "SNOOZING",
             "indicator_position": "center",
         }
+        if with_status:
+            return svc.check_and_send_active_page_with_status()
         return svc.check_and_send_active_page()
 
 
@@ -659,3 +665,84 @@ class TestSendFailureTracking:
         assert sent is False
         clients["b1"].render.assert_not_called()
         assert svc.get_last_send_error("b1") is None
+
+
+class TestSendStatusReporting:
+    """``check_and_send_active_page_with_status`` is what /refresh and
+    /force-refresh call, so it must report the failure THIS pass produced —
+    across every board, and without picking up the engine thread's writes
+    (issue #1791)."""
+
+    def test_secondary_board_failure_is_reported_by_the_aggregate_status(self):
+        """A failing secondary must not read as an unqualified success. Reading
+        only the primary runtime's error (as the endpoint used to) returned
+        None here, so /refresh reported success while board 2 went stale."""
+        boards = [_board("b1", "One"), _board("b2", "Two")]
+        svc, _clients = _service_with_runtimes(boards)
+        pages = _page_service({"pA": {"content": "ALPHA"}, "pB": {"content": "BETA"}})
+
+        def _preview(pid, force_refresh=False):
+            if pid == "pB":
+                return SimpleNamespace(available=False, formatted="", error="secondary board render failed")
+            return SimpleNamespace(available=True, formatted="ALPHA", error=None)
+
+        pages.preview_page.side_effect = _preview
+        schedule = _schedule_service({"b1": "pA", "b2": "pB"})
+
+        sent, error = _drive(svc, boards, pages=pages, schedule=schedule, with_status=True)
+
+        assert sent is True  # the primary board was driven fine
+        assert error == "board b2: secondary board render failed"
+
+    def test_primary_failure_reason_is_reported_unprefixed(self):
+        boards = [_board("b1", "One")]
+        svc, _clients = _service_with_runtimes(boards)
+        pages = _page_service({"pA": {"content": "ALPHA"}})
+        pages.preview_page.side_effect = lambda pid, force_refresh=False: SimpleNamespace(
+            available=False, formatted="", error="plugin data unavailable"
+        )
+        schedule = _schedule_service({"b1": "pA"})
+
+        sent, error = _drive(svc, boards, pages=pages, schedule=schedule, with_status=True)
+
+        assert sent is False
+        assert error == "plugin data unavailable"
+
+    def test_status_ignores_a_concurrent_write_from_another_thread(self):
+        """``rt.last_send_error`` is shared with the engine thread, which can
+        set it between this pass returning and the endpoint reading it. The
+        status wrapper captures per-thread, so only this call's failures count.
+        """
+        boards = [_board("b1", "One")]
+        svc, clients = _service_with_runtimes(boards)
+        rt = svc.runtimes["b1"]
+
+        def _render(*args, **kwargs):
+            # Stand-in for the engine thread ticking mid-request.
+            t = threading.Thread(target=svc._record_send_error, args=(rt, "b1", "engine tick failure"))
+            t.start()
+            t.join()
+            return (True, True)
+
+        clients["b1"].render.side_effect = _render
+        pages = _page_service({"pA": {"content": "ALPHA"}})
+        schedule = _schedule_service({"b1": "pA"})
+
+        sent, error = _drive(svc, boards, pages=pages, schedule=schedule, with_status=True)
+
+        assert sent is True
+        assert error is None
+        # The other thread's write did land on the shared runtime attribute —
+        # which is exactly why the endpoint must not read it back.
+        assert rt.last_send_error == "engine tick failure"
+
+    def test_successful_pass_reports_no_reason(self):
+        boards = [_board("b1", "One")]
+        svc, _clients = _service_with_runtimes(boards)
+        pages = _page_service({"pA": {"content": "ALPHA"}})
+        schedule = _schedule_service({"b1": "pA"})
+
+        sent, error = _drive(svc, boards, pages=pages, schedule=schedule, with_status=True)
+
+        assert sent is True
+        assert error is None

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -718,6 +718,7 @@
     "toastSetDefaultFailed": "Standardseite konnte nicht festgelegt werden",
     "toastSwitchSuccess": "Zur aktiven Seite gewechselt",
     "toastSwitchFailed": "Seitenwechsel fehlgeschlagen",
+    "toastSwitchNotSent": "Seite gewechselt, aber Senden an das Board fehlgeschlagen",
     "updatedExternally": "Board wurde von einer anderen App geändert",
     "resendToBoard": "Wiederherstellen",
     "toastResendSuccess": "Board wiederhergestellt",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -674,6 +674,7 @@
     "toastSetDefaultFailed": "Failed to set default page",
     "toastSwitchSuccess": "Switched to active page",
     "toastSwitchFailed": "Failed to switch page",
+    "toastSwitchNotSent": "Page switched, but sending to the board failed",
     "updatedExternally": "Board was changed by another app",
     "resendToBoard": "Restore",
     "toastResendSuccess": "Board restored",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -718,6 +718,7 @@
     "toastSetDefaultFailed": "Error al establecer la página predeterminada",
     "toastSwitchSuccess": "Se cambió a la página activa",
     "toastSwitchFailed": "Error al cambiar la página",
+    "toastSwitchNotSent": "Página cambiada, pero falló el envío al tablero",
     "updatedExternally": "La pantalla fue cambiada por otra aplicación",
     "resendToBoard": "Restaurar",
     "toastResendSuccess": "Pantalla restaurada",

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -718,6 +718,7 @@
     "toastSetDefaultFailed": "Échec de la définition de la page par défaut",
     "toastSwitchSuccess": "Page active changée",
     "toastSwitchFailed": "Échec du changement de page",
+    "toastSwitchNotSent": "Page changée, mais l'envoi vers le tableau a échoué",
     "updatedExternally": "Le board a été modifié par une autre application",
     "resendToBoard": "Restaurer",
     "toastResendSuccess": "Board restauré",

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -718,6 +718,7 @@
     "toastSetDefaultFailed": "Impossibile impostare la pagina predefinita",
     "toastSwitchSuccess": "Passato alla pagina attiva",
     "toastSwitchFailed": "Impossibile cambiare pagina",
+    "toastSwitchNotSent": "Pagina cambiata, ma invio alla bacheca non riuscito",
     "updatedExternally": "Il board è stato modificato da un'altra app",
     "resendToBoard": "Ripristina",
     "toastResendSuccess": "Board ripristinato",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -718,6 +718,7 @@
     "toastSetDefaultFailed": "デフォルトページの設定に失敗しました",
     "toastSwitchSuccess": "アクティブページに切り替えました",
     "toastSwitchFailed": "ページの切り替えに失敗しました",
+    "toastSwitchNotSent": "ページを切り替えましたが、ボードへの送信に失敗しました",
     "updatedExternally": "ボードが別のアプリで変更されました",
     "resendToBoard": "復元",
     "toastResendSuccess": "ボードを復元しました",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -718,6 +718,7 @@
     "toastSetDefaultFailed": "기본 페이지 설정에 실패했습니다",
     "toastSwitchSuccess": "활성 페이지로 전환되었습니다",
     "toastSwitchFailed": "페이지 전환에 실패했습니다",
+    "toastSwitchNotSent": "페이지를 전환했지만 보드 전송에 실패했습니다",
     "updatedExternally": "다른 앱에서 보드가 변경되었습니다",
     "resendToBoard": "복원",
     "toastResendSuccess": "보드 복원됨",

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -718,6 +718,7 @@
     "toastSetDefaultFailed": "Standaardpagina instellen mislukt",
     "toastSwitchSuccess": "Gewisseld naar actieve pagina",
     "toastSwitchFailed": "Pagina wisselen mislukt",
+    "toastSwitchNotSent": "Pagina gewisseld, maar verzenden naar bord mislukt",
     "updatedExternally": "Board is gewijzigd door een andere app",
     "resendToBoard": "Herstellen",
     "toastResendSuccess": "Board hersteld",

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -718,6 +718,7 @@
     "toastSetDefaultFailed": "Nie udało się ustawić domyślnej strony",
     "toastSwitchSuccess": "Przełączono na aktywną stronę",
     "toastSwitchFailed": "Nie udało się przełączyć strony",
+    "toastSwitchNotSent": "Przełączono stronę, ale nie udało się wysłać na tablicę",
     "updatedExternally": "Board został zmieniony przez inną aplikację",
     "resendToBoard": "Przywróć",
     "toastResendSuccess": "Board przywrócony",

--- a/web/messages/pt.json
+++ b/web/messages/pt.json
@@ -718,6 +718,7 @@
     "toastSetDefaultFailed": "Falha ao definir página padrão",
     "toastSwitchSuccess": "Página ativa alterada",
     "toastSwitchFailed": "Falha ao trocar de página",
+    "toastSwitchNotSent": "Página trocada, mas falha ao enviar para o painel",
     "updatedExternally": "O board foi alterado por outra aplicação",
     "resendToBoard": "Restaurar",
     "toastResendSuccess": "Board restaurado",

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -718,6 +718,7 @@
     "toastSetDefaultFailed": "Не удалось установить страницу по умолчанию",
     "toastSwitchSuccess": "Переключено на активную страницу",
     "toastSwitchFailed": "Не удалось переключить страницу",
+    "toastSwitchNotSent": "Страница переключена, но не удалось отправить на доску",
     "updatedExternally": "Board был изменён другим приложением",
     "resendToBoard": "Восстановить",
     "toastResendSuccess": "Board восстановлен",

--- a/web/messages/sv.json
+++ b/web/messages/sv.json
@@ -718,6 +718,7 @@
     "toastSetDefaultFailed": "Kunde inte ställa in standardsida",
     "toastSwitchSuccess": "Bytte till aktiv sida",
     "toastSwitchFailed": "Kunde inte byta sida",
+    "toastSwitchNotSent": "Sidan byttes, men det gick inte att skicka till tavlan",
     "updatedExternally": "Board ändrades av en annan app",
     "resendToBoard": "Återställ",
     "toastResendSuccess": "Board återställd",

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -718,6 +718,7 @@
     "toastSetDefaultFailed": "Varsayılan sayfa ayarlanamadı",
     "toastSwitchSuccess": "Aktif sayfaya geçildi",
     "toastSwitchFailed": "Sayfa değiştirilemedi",
+    "toastSwitchNotSent": "Sayfa değiştirildi ancak panoya gönderilemedi",
     "updatedExternally": "Board başka bir uygulama tarafından değiştirildi",
     "resendToBoard": "Geri Yükle",
     "toastResendSuccess": "Board geri yüklendi",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -718,6 +718,7 @@
     "toastSetDefaultFailed": "设置默认页面失败",
     "toastSwitchSuccess": "已切换到活跃页面",
     "toastSwitchFailed": "切换页面失败",
+    "toastSwitchNotSent": "页面已切换，但发送到看板失败",
     "updatedExternally": "Board 已被另一个应用更改",
     "resendToBoard": "恢复",
     "toastResendSuccess": "Board 已恢复",

--- a/web/src/__tests__/active-page-display.test.tsx
+++ b/web/src/__tests__/active-page-display.test.tsx
@@ -521,4 +521,57 @@ describe("ActivePageDisplay", () => {
 
     toastSpy.mockRestore();
   });
+
+  it("shows an error toast when the page switches but the board send fails", async () => {
+    // Issue #1791: the backend persists the page but reports the render/send
+    // failure via error + sent_to_board=false on a 200 response. That must
+    // NOT be toasted as a success.
+    const errorToastSpy = vi.spyOn((await import("sonner")).toast, "error");
+    const successToastSpy = vi.spyOn((await import("sonner")).toast, "success");
+    server.use(
+      http.put(`${API_BASE}/settings/active-page`, () =>
+        HttpResponse.json({
+          status: "success",
+          page_id: "page-2",
+          sent_to_board: false,
+          paused: false,
+          board_id: null,
+          error: "Weather API unreachable",
+        }),
+      ),
+    );
+
+    const user = userEvent.setup();
+    render(<ActivePageDisplay />, { wrapper: TestWrapper });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Change Page/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /Change Page/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Select Page")).toBeInTheDocument();
+    });
+
+    await waitFor(
+      () => {
+        expect(screen.queryByText("Custom Template")).toBeInTheDocument();
+      },
+      { timeout: 3000 },
+    );
+
+    await user.click(screen.getByText("Custom Template"));
+
+    await waitFor(
+      () => {
+        expect(errorToastSpy).toHaveBeenCalledWith("Page switched, but sending to the board failed");
+      },
+      { timeout: 3000 },
+    );
+    expect(successToastSpy).not.toHaveBeenCalledWith("Switched to active page");
+
+    errorToastSpy.mockRestore();
+    successToastSpy.mockRestore();
+  });
 });

--- a/web/src/components/active-page-display.tsx
+++ b/web/src/components/active-page-display.tsx
@@ -372,8 +372,16 @@ export function ActivePageDisplay() {
       // Manual mode (or after the user chose to disable schedule): switch immediately.
       setOpenSheetAsManual(false);
       setActivePageMutation.mutate(pageId, {
-        onSuccess: (_result) => {
+        onSuccess: (result) => {
           setIsSheetOpen(false);
+          // The page selection persisted, but the render/send to the board
+          // can still fail (e.g. plugin/network outage) — the backend reports
+          // that via error + sent_to_board=false on a 200 response, same
+          // contract page-builder consumes (issue #1791).
+          if (result.error) {
+            toast.error(t("toastSwitchNotSent"));
+            return;
+          }
           startTransition(() => {
             toast.success(t("toastSwitchSuccess"));
           });

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -293,7 +293,12 @@ export interface SetActivePageResponse {
   status: string;
   page_id: string | null;
   sent_to_board: boolean;
+  paused?: boolean;
   board_id?: string | null;
+  // Render/send failure reason when the page was persisted but never reached
+  // the board (issue #1791). Null/absent when the send succeeded or was
+  // skipped benignly (paused board, UI-only output, unchanged content).
+  error?: string | null;
 }
 
 // Page types


### PR DESCRIPTION
Debug endpoints read wizard-era `config.json` rather than the `boards[]` store, so they disagreed with both Settings → Boards and the actual send path: System Info could say `CLOUD API` while Board settings said Local API. Send failures were also reported as success.

Issue #1791 is already closed, so this does not close anything — it lands the fix on its own terms.

## What changed

- `/debug/system-info`, `/debug/info`, `/debug/network-diagnostics` derive connection mode / board IP / credentials from `boards[]`, with live-client and legacy-`Config` fallbacks
- `PUT /settings/active-page` reports failures via an `error` field and `sent_to_board=false` instead of silently succeeding
- `/refresh` and `/force-refresh` propagate the send result and return 500 with the recorded reason
- `check_and_send_for_board` records `last_send_error` so endpoints can distinguish real failures from unchanged-content skips
- web: toast when the page switched but the board send failed (`toastSwitchNotSent`, all 14 locales)

## Review follow-ups

**Reverted the `_apply_env_overrides` change entirely.** Letting an env var override a value that merely *equals* the schema default is unsound: the code cannot distinguish "user deliberately chose the default" from "never configured". `_apply_env_overrides()` runs on every `ConfigManager.__init__` **and every `reload()`**, and `docker-compose.yml` loads the user's whole `.env`. Because `PUT /config/board` calls `Config.reload()` inline, a user who picked Local API in Settings — or in the setup wizard — had it silently reverted to `BOARD_API_MODE` within the same request. The same held for `general.timezone`, which feeds `time_service` and `schedules/sun_times`, so schedule rotations and sunrise/sunset would fire at the wrong time.

`src/config_manager.py` is now byte-identical to `main`. Two tests that encoded the unsound contract are gone; three that pin the correct one are new:

- a stored value equal to the schema default survives `_apply_env_overrides`
- it also survives a `set_board` + `reload()` round-trip (the `PUT /config/board` path)
- the same for `general.timezone`

The pre-existing `test_apply_env_overrides_preserves_user_customized_api_mode` only proved a *non-default* value survives, which is why the change looked correct.

**Closed the send-status race.** `rt.last_send_error` is shared with the engine thread, which could set or clear it between `check_and_send_for_board` returning and the endpoint reading it — giving a false success or a spurious 500. `check_and_send_for_board_with_status` / `check_and_send_active_page_with_status` now capture the reason for the calling thread only (a `threading.local`), and the endpoints take the reason from the call's return value rather than reading the runtime afterwards.

**`/refresh` no longer hides a failing secondary board.** With `board_id=None` the pass drives every board, but only the primary runtime's error was read, so a failing secondary returned success. The aggregate status now reports the first failure across all boards, prefixed with its board id.

## Tests

`tests/test_per_board_engine.py` gains a `TestSendStatusReporting` class covering the aggregate across boards, the unprefixed primary reason, and a concurrent write from another thread being ignored. `tests/test_api_coverage.py` pins that a stale `last_send_error` cannot turn a clean pass into a 500.

Verified non-vacuous: expressed against the pre-fix read strategy (drive, then read `service.get_last_send_error()`), both defects reproduce —

```
E   AssertionError: assert None == 'board b2: secondary board render failed'
E   AssertionError: engine thread's error leaked into this call: 'engine tick failure'
```

and the reverted env-override tests failed against the branch code before the revert:

```
E   AssertionError: assert 'cloud' == 'local'      # board.api_mode after reload()
E   AssertionError: assert 'Europe/Berlin' == 'America/Los_Angeles'
```

592 Python tests pass across the engine / API / config / settings suites; `ruff 0.16.4` check + format clean; web prettier clean.
