### PR TITLE
feat(settings): allow renaming boards

### DIFF
--- a/docs/features/home-assistant-control.md
+++ b/docs/features/home-assistant-control.md
@@ -444,7 +444,7 @@ breaks every automation that targets it by the old name — FiestaBoard cannot
 rewrite payloads that live in your Home Assistant config. When this happens
 the log records:
 
-```
+```text
 MQTT: resolved board by name 'Kitchen'; renaming this board will break it. Target the board id 'b1' instead.
 ```
 

--- a/docs/features/home-assistant-control.md
+++ b/docs/features/home-assistant-control.md
@@ -430,6 +430,28 @@ FiestaBoard properly categorizes entities using Home Assistant's `entity_categor
 - Check that HA's MQTT integration is configured with the correct broker credentials
 - Check FiestaBoard logs for command processing errors
 
+### A Command Stopped Working After Renaming a Board
+
+Command payloads can target a specific board with a `board` field, which
+accepts either the board's id or its display name:
+
+```json
+{ "board": "Kitchen", "page_id": "weather" }
+```
+
+Display names are editable in **Settings → Boards**, so renaming a board
+breaks every automation that targets it by the old name — FiestaBoard cannot
+rewrite payloads that live in your Home Assistant config. When this happens
+the log records:
+
+```
+MQTT: resolved board by name 'Kitchen'; renaming this board will break it. Target the board id 'b1' instead.
+```
+
+Target the board **id** instead. Ids never change, and they are what the
+discovery topics already use, so renaming a board never orphans its HA
+entities — only name-based `board` refs in your own automations.
+
 ## Branding
 
 ### Entity Icons

--- a/src/devices.py
+++ b/src/devices.py
@@ -31,6 +31,12 @@ NOTE_ROWS: int = 3
 NOTE_COLS: int = 15
 MAX_NOTES_PER_AXIS: int = 8
 
+# Board display names are user-editable (issue #1792) and are rendered in the
+# sidebar board selector, Settings cards and page headers, so cap them at
+# storage time rather than letting every call site truncate.
+MAX_BOARD_NAME_LENGTH: int = 64
+DEFAULT_BOARD_NAME: str = "My Board"
+
 NOTE_ARRAY_PRESETS: list[dict] = [
     {"id": "2_wide", "label": "2 side-by-side", "notes_wide": 2, "notes_tall": 1},  # → 3 rows × 30 cols
     {"id": "4_wide", "label": "4 side-by-side", "notes_wide": 4, "notes_tall": 1},  # → 3 rows × 60 cols
@@ -167,8 +173,12 @@ class BoardInstance:
             self.enabled = bool(self.enabled)
         if not isinstance(self.paused, bool):
             self.paused = bool(self.paused)
+        # Name is user-editable (issue #1792): strip, cap, and fall back to
+        # the default. "   " is truthy, so a falsy-only guard stored
+        # whitespace verbatim and rendered a blank sidebar row.
+        self.name = self.name.strip()[:MAX_BOARD_NAME_LENGTH] if isinstance(self.name, str) else ""
         if not self.name:
-            self.name = "My Board"
+            self.name = DEFAULT_BOARD_NAME
         # Normalize notes_wide / notes_tall: must be positive ints (bool is a
         # subclass of int, so reject it explicitly), clamped to MAX_NOTES_PER_AXIS
         if isinstance(self.notes_wide, bool) or not isinstance(self.notes_wide, int) or self.notes_wide < 1:

--- a/src/mqtt/commands.py
+++ b/src/mqtt/commands.py
@@ -142,10 +142,21 @@ class CommandHandler:
         for board in boards:
             if board.get("id") == board_ref:
                 return board["id"], board
+        # Name matching is kept for back-compat, but board names are
+        # user-editable in Settings -> Boards (issue #1792): a rename silently
+        # breaks any automation publishing {"board": "<name>"}, and nothing can
+        # rewrite those payloads for the user. Warn so the log says why the
+        # automation stopped working, and points at the stable id.
         ref_lower = str(board_ref).lower()
         for board in boards:
             name = board.get("name")
             if isinstance(name, str) and name.lower() == ref_lower:
+                logger.warning(
+                    "MQTT: resolved board by name %r; renaming this board will break it. "
+                    "Target the board id %r instead.",
+                    board_ref,
+                    board["id"],
+                )
                 return board["id"], board
         logger.warning("MQTT: unknown board %r", board_ref)
         return None, None

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -5,6 +5,7 @@ import pytest
 from src.devices import (
     DEVICE_DIMENSIONS,
     DEVICE_TYPES,
+    MAX_BOARD_NAME_LENGTH,
     MAX_NOTES_PER_AXIS,
     NOTE_ARRAY_PRESETS,
     NOTE_COLS,
@@ -1157,3 +1158,36 @@ class TestVirtualApiMode:
         """Arbitrary junk api_mode values keep falling back to local."""
         board = BoardInstance(api_mode="bogus")
         assert board.api_mode == "local"
+
+
+class TestBoardNameNormalization:
+    """``name`` is user-editable in Settings → Boards (issue #1792), so
+    ``__post_init__`` is the single place that normalizes what gets stored."""
+
+    def test_empty_name_falls_back_to_the_default(self):
+        assert BoardInstance(name="").name == "My Board"
+
+    def test_whitespace_only_name_falls_back_to_the_default(self):
+        """A whitespace-only name is truthy, so a falsy-only guard stored it
+        verbatim and the sidebar rendered a blank row."""
+        assert BoardInstance(name="   ").name == "My Board"
+
+    def test_surrounding_whitespace_is_stripped(self):
+        assert BoardInstance(name="  Kitchen Board  ").name == "Kitchen Board"
+
+    def test_overlong_name_is_capped(self):
+        """Names are shown in the sidebar, board selector and card headers;
+        an unbounded string is a layout hazard, so cap it at storage time."""
+        board = BoardInstance(name="K" * 200)
+        assert len(board.name) == MAX_BOARD_NAME_LENGTH
+        assert board.name == "K" * MAX_BOARD_NAME_LENGTH
+
+    def test_a_normal_name_is_left_alone(self):
+        assert BoardInstance(name="Kitchen Board").name == "Kitchen Board"
+
+    def test_non_string_name_falls_back_to_the_default(self):
+        assert BoardInstance(name=None).name == "My Board"
+
+    def test_from_dict_applies_the_same_normalization(self):
+        board = BoardInstance.from_dict({"device_type": "flagship", "name": "  Garage  "})
+        assert board.name == "Garage"

--- a/tests/test_mqtt_commands.py
+++ b/tests/test_mqtt_commands.py
@@ -681,3 +681,40 @@ class TestCommandHandlerSendMessageWrapping:
         board_array = self._send(handler, get_settings, get_service, mock_config, "SUPERCALIFRAGILISTIC")
         assert _row_text(board_array[0]) == "SUPERCALIFRAGIL"
         assert _row_text(board_array[1]) == "ISTIC"
+
+
+class TestResolveBoardByName:
+    """``_resolve_board`` matches a board ref by id first, then by display name.
+
+    Board names became user-editable in Settings → Boards (issue #1792), so a
+    rename silently breaks any automation that targets a board by name. Nothing
+    can migrate those payloads for us, so resolving by name warns.
+    """
+
+    @staticmethod
+    def _settings(boards):
+        settings = MagicMock()
+        settings.get_board_settings.return_value = MagicMock(boards=boards)
+        return settings
+
+    def test_name_match_still_resolves(self):
+        boards = [{"id": "b1", "name": "Kitchen"}, {"id": "b2", "name": "Office"}]
+        with patch("src.settings.service.get_settings_service", return_value=self._settings(boards)):
+            assert CommandHandler._resolve_board("Office")[0] == "b2"
+
+    def test_name_match_warns_that_a_rename_will_break_it(self, caplog):
+        boards = [{"id": "b1", "name": "Kitchen"}]
+        with patch("src.settings.service.get_settings_service", return_value=self._settings(boards)):
+            with caplog.at_level("WARNING"):
+                CommandHandler._resolve_board("Kitchen")
+        messages = [r.getMessage() for r in caplog.records]
+        assert any("renaming this board will break it" in m for m in messages), messages
+        # The warning must name the stable id the user should switch to.
+        assert any("'b1'" in m for m in messages), messages
+
+    def test_id_match_does_not_warn(self, caplog):
+        boards = [{"id": "b1", "name": "Kitchen"}]
+        with patch("src.settings.service.get_settings_service", return_value=self._settings(boards)):
+            with caplog.at_level("WARNING"):
+                assert CommandHandler._resolve_board("b1")[0] == "b1"
+        assert caplog.records == []

--- a/tests/test_settings_service.py
+++ b/tests/test_settings_service.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from src.devices import MAX_BOARD_NAME_LENGTH
 from src.settings.service import (
     VALID_OUTPUT_TARGETS,
     ActivePageSettings,
@@ -465,6 +466,23 @@ class TestSettingsServiceBoard:
         board_id = settings_service.get_board_settings().boards[0]["id"]
         settings_service.set_boards([{"id": board_id, "device_type": "flagship", "name": ""}])
         assert settings_service.get_board_settings().boards[0]["name"] == "My Board"
+
+    def test_set_boards_whitespace_only_name_restores_default(self, settings_service):
+        """A field cleared to spaces must not persist as a blank sidebar row —
+        ``"   "`` is truthy, so this needs the strip in BoardInstance (#1792)."""
+        settings_service.set_boards([{"device_type": "flagship", "name": "Kitchen Board"}])
+        board_id = settings_service.get_board_settings().boards[0]["id"]
+        settings_service.set_boards([{"id": board_id, "device_type": "flagship", "name": "   "}])
+        assert settings_service.get_board_settings().boards[0]["name"] == "My Board"
+
+    def test_set_boards_trims_a_padded_name(self, settings_service):
+        settings_service.set_boards([{"device_type": "flagship", "name": "  Kitchen Board  "}])
+        assert settings_service.get_board_settings().boards[0]["name"] == "Kitchen Board"
+
+    def test_set_boards_caps_an_overlong_name(self, settings_service):
+        settings_service.set_boards([{"device_type": "flagship", "name": "K" * 200}])
+        stored = settings_service.get_board_settings().boards[0]["name"]
+        assert stored == "K" * MAX_BOARD_NAME_LENGTH
 
     def test_add_board(self, settings_service):
         result = settings_service.add_board({"device_type": "note"})

--- a/tests/test_settings_service.py
+++ b/tests/test_settings_service.py
@@ -449,6 +449,23 @@ class TestSettingsServiceBoard:
         with pytest.raises(ValueError, match="At least one board"):
             settings_service.set_boards([])
 
+    def test_set_boards_roundtrips_renamed_board(self, settings_service):
+        """A custom name saved via the boards[] round-trip persists (issue #1792)."""
+        settings_service.set_boards([{"device_type": "flagship", "name": "Kitchen Board"}])
+        board = settings_service.get_board_settings().boards[0]
+        assert board["name"] == "Kitchen Board"
+
+        # Rename the same board (matched by id) and read it back.
+        settings_service.set_boards([{"id": board["id"], "device_type": "flagship", "name": "Garage Board"}])
+        assert settings_service.get_board_settings().boards[0]["name"] == "Garage Board"
+
+    def test_set_boards_empty_name_restores_default(self, settings_service):
+        """Clearing the name falls back to the BoardInstance default (issue #1792)."""
+        settings_service.set_boards([{"device_type": "flagship", "name": "Kitchen Board"}])
+        board_id = settings_service.get_board_settings().boards[0]["id"]
+        settings_service.set_boards([{"id": board_id, "device_type": "flagship", "name": ""}])
+        assert settings_service.get_board_settings().boards[0]["name"] == "My Board"
+
     def test_add_board(self, settings_service):
         result = settings_service.add_board({"device_type": "note"})
         assert len(result.boards) == 2

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -896,6 +896,7 @@
     "disabledLabel": "Deaktiviert",
     "blackAriaLabel": "Schwarz",
     "whiteAriaLabel": "Weiß",
+    "boardNameLabel": "Name",
     "boardNamePlaceholder": "z. B. Küchenboard, Büro Note",
     "flagshipLabel": "Flagship",
     "noteLabel": "Note",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -858,6 +858,7 @@
     },
     "blackAriaLabel": "Black",
     "whiteAriaLabel": "White",
+    "boardNameLabel": "Name",
     "boardNamePlaceholder": "e.g. Kitchen Board, Office Note",
     "flagshipLabel": "Flagship",
     "noteLabel": "Note",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -896,6 +896,7 @@
     "disabledLabel": "Deshabilitado",
     "blackAriaLabel": "Negro",
     "whiteAriaLabel": "Blanco",
+    "boardNameLabel": "Nombre",
     "boardNamePlaceholder": "p. ej. Tablero Cocina, Note Oficina",
     "flagshipLabel": "Flagship",
     "noteLabel": "Note",

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -896,6 +896,7 @@
     "disabledLabel": "Désactivé",
     "blackAriaLabel": "Noir",
     "whiteAriaLabel": "Blanc",
+    "boardNameLabel": "Nom",
     "boardNamePlaceholder": "p. ex. Tableau cuisine, Note bureau",
     "flagshipLabel": "Flagship",
     "noteLabel": "Note",

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -896,6 +896,7 @@
     "disabledLabel": "Disattivato",
     "blackAriaLabel": "Nero",
     "whiteAriaLabel": "Bianco",
+    "boardNameLabel": "Nome",
     "boardNamePlaceholder": "es. Board cucina, Note ufficio",
     "flagshipLabel": "Flagship",
     "noteLabel": "Note",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -896,6 +896,7 @@
     "disabledLabel": "無効",
     "blackAriaLabel": "黒",
     "whiteAriaLabel": "白",
+    "boardNameLabel": "名前",
     "boardNamePlaceholder": "例: キッチンの Board、オフィスの Note",
     "flagshipLabel": "Flagship",
     "noteLabel": "Note",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -896,6 +896,7 @@
     "disabledLabel": "비활성화",
     "blackAriaLabel": "검은색",
     "whiteAriaLabel": "흰색",
+    "boardNameLabel": "이름",
     "boardNamePlaceholder": "예: 주방 Board, 사무실 Note",
     "flagshipLabel": "Flagship",
     "noteLabel": "Note",

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -896,6 +896,7 @@
     "disabledLabel": "Uitgeschakeld",
     "blackAriaLabel": "Zwart",
     "whiteAriaLabel": "Wit",
+    "boardNameLabel": "Naam",
     "boardNamePlaceholder": "bijv. Keuken Board, Kantoor Note",
     "flagshipLabel": "Flagship",
     "noteLabel": "Note",

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -896,6 +896,7 @@
     "disabledLabel": "Wyłączone",
     "blackAriaLabel": "Czarny",
     "whiteAriaLabel": "Biały",
+    "boardNameLabel": "Nazwa",
     "boardNamePlaceholder": "np. Kuchenny Board, Biurowy Note",
     "flagshipLabel": "Flagship",
     "noteLabel": "Note",

--- a/web/messages/pt.json
+++ b/web/messages/pt.json
@@ -896,6 +896,7 @@
     "disabledLabel": "Desativado",
     "blackAriaLabel": "Preto",
     "whiteAriaLabel": "Branco",
+    "boardNameLabel": "Nome",
     "boardNamePlaceholder": "ex. Board cozinha, Note escritório",
     "flagshipLabel": "Flagship",
     "noteLabel": "Note",

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -896,6 +896,7 @@
     "disabledLabel": "Отключено",
     "blackAriaLabel": "Чёрный",
     "whiteAriaLabel": "Белый",
+    "boardNameLabel": "Название",
     "boardNamePlaceholder": "напр. Кухонный Board, Офисный Note",
     "flagshipLabel": "Flagship",
     "noteLabel": "Note",

--- a/web/messages/sv.json
+++ b/web/messages/sv.json
@@ -896,6 +896,7 @@
     "disabledLabel": "Inaktiverad",
     "blackAriaLabel": "Svart",
     "whiteAriaLabel": "Vit",
+    "boardNameLabel": "Namn",
     "boardNamePlaceholder": "t.ex. Köks-Board, Kontors-Note",
     "flagshipLabel": "Flagship",
     "noteLabel": "Note",

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -896,6 +896,7 @@
     "disabledLabel": "Devre dışı",
     "blackAriaLabel": "Siyah",
     "whiteAriaLabel": "Beyaz",
+    "boardNameLabel": "Ad",
     "boardNamePlaceholder": "ör. Mutfak Board, Ofis Note",
     "flagshipLabel": "Flagship",
     "noteLabel": "Note",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -896,6 +896,7 @@
     "disabledLabel": "已禁用",
     "blackAriaLabel": "黑色",
     "whiteAriaLabel": "白色",
+    "boardNameLabel": "名称",
     "boardNamePlaceholder": "例如:厨房 Board、办公室 Note",
     "flagshipLabel": "Flagship",
     "noteLabel": "Note",

--- a/web/src/__tests__/display-settings.test.tsx
+++ b/web/src/__tests__/display-settings.test.tsx
@@ -24,13 +24,26 @@ const API_BASE = "/api";
 type BoardOverride = Record<string, unknown>;
 type BoardRecord = Record<string, unknown>;
 
+/** Mirrors BoardInstance.__post_init__ (src/devices.py): strip, cap, default. */
+const MAX_BOARD_NAME_LENGTH = 64;
+function normalizeBoardName(name: unknown): string {
+  const trimmed = typeof name === "string" ? name.trim().slice(0, MAX_BOARD_NAME_LENGTH) : "";
+  return trimmed || "My Board";
+}
+
 /**
  * Stateful board fixture. GET returns the current board; PUT persists the
  * incoming boards and records the request body — mirroring the real backend
  * so the component's invalidate→refetch cycle reflects each save (the
- * controlled Select reads from the refetched query data, not local state).
+ * controlled Select and the name input read from the refetched query data,
+ * not local state).
  *
- * `put.body` is `null` until a PUT fires; reset it between assertions.
+ * The PUT handler applies the backend's own name normalization, so saving
+ * "" (or whitespace) reads back as "My Board" and the clear→reset round-trip
+ * is actually exercised rather than echoed verbatim (issue #1792).
+ *
+ * `put.body` is `null` until a PUT fires and `put.count` counts them; both are
+ * only meaningful after awaiting the request, since the handler is async.
  */
 function setupBoard(board: BoardOverride) {
   const state: { boards: BoardRecord[] } = {
@@ -45,7 +58,8 @@ function setupBoard(board: BoardOverride) {
       },
     ],
   };
-  const put: { body: { boards?: BoardRecord[] } | null } = { body: null };
+  state.boards = state.boards.map((b) => ({ ...b, name: normalizeBoardName(b.name) }));
+  const put: { body: { boards?: BoardRecord[] } | null; count: number } = { body: null, count: 0 };
 
   server.use(
     http.get(`${API_BASE}/settings/board`, () =>
@@ -58,10 +72,13 @@ function setupBoard(board: BoardOverride) {
     http.put(`${API_BASE}/settings/board`, async ({ request }) => {
       const body = (await request.json()) as { boards?: BoardRecord[] };
       put.body = body;
+      put.count += 1;
       if (body.boards) {
-        // Persist, masking the token like the real backend would on read-back.
+        // Persist the way the real backend does on read-back: mask the token
+        // and normalize the display name.
         state.boards = body.boards.map((b) => ({
           ...b,
+          name: normalizeBoardName(b.name),
           note_array_token: b.note_array_token ? "***" : b.note_array_token,
         }));
       }
@@ -89,6 +106,16 @@ async function renderAndExpand(user: ReturnType<typeof userEvent.setup>) {
   await user.click(trigger);
   const card = await screen.findByTestId("board-card");
   return card;
+}
+
+/**
+ * Assert no PUT lands beyond `expected`. The MSW handler is async, so a
+ * synchronous count check would pass even when a request is in flight; this
+ * waits long enough for one to arrive and fails if it does.
+ */
+async function expectNoFurtherPuts(put: { count: number }, expected: number) {
+  await expect(waitFor(() => expect(put.count).toBeGreaterThan(expected), { timeout: 300 })).rejects.toThrow();
+  expect(put.count).toBe(expected);
 }
 
 describe("DisplaySettings — note-array selector", () => {
@@ -206,7 +233,7 @@ describe("DisplaySettings — board name field (#1792)", () => {
     fireEvent.change(nameInput, { target: { value: "  Kitchen Board  " } });
     fireEvent.blur(nameInput);
 
-    await waitFor(() => expect(put.body).not.toBeNull());
+    await waitFor(() => expect(put.count).toBe(1));
     const saved = put.body!.boards![0];
     // Trimmed before saving; the rest of the board rides along unchanged in
     // the boards[] round-trip.
@@ -222,16 +249,20 @@ describe("DisplaySettings — board name field (#1792)", () => {
     const card = await renderAndExpand(user);
 
     const nameInput = (await within(card).findByLabelText("Name")) as HTMLInputElement;
-    nameInput.focus();
-    nameInput.blur();
+    fireEvent.focus(nameInput);
+    fireEvent.blur(nameInput);
     // Whitespace-only padding around the same name is also not a change.
     fireEvent.change(nameInput, { target: { value: " My Board " } });
     fireEvent.blur(nameInput);
 
+    // The PUT handler is async, so a synchronous assertion here passes whether
+    // or not a request fired. Give any request that WAS made time to land, and
+    // pin the request count rather than only the recorded body.
+    await expectNoFurtherPuts(put, 0);
     expect(put.body).toBeNull();
   });
 
-  it("clearing the name saves an empty string so the backend restores its default", async () => {
+  it("clearing the name saves an empty string and shows the restored default", async () => {
     const user = userEvent.setup();
     const put = setupBoard({ device_type: "flagship", name: "Kitchen Board" });
     render(<DisplaySettings />, { wrapper: TestWrapper });
@@ -242,8 +273,34 @@ describe("DisplaySettings — board name field (#1792)", () => {
     fireEvent.change(nameInput, { target: { value: "   " } });
     fireEvent.blur(nameInput);
 
-    await waitFor(() => expect(put.body).not.toBeNull());
+    await waitFor(() => expect(put.count).toBe(1));
     expect(put.body!.boards![0].name).toBe("");
+    // The backend restores its default, and the field must show what is
+    // actually stored — not the empty string the user left behind.
+    expect(await screen.findByText("My Board")).toBeInTheDocument();
+    await waitFor(() => expect(nameInput.value).toBe("My Board"));
+  });
+
+  it("re-blurring after a clear does not fire a second identical PUT", async () => {
+    const user = userEvent.setup();
+    const put = setupBoard({ device_type: "flagship", name: "Kitchen Board" });
+    render(<DisplaySettings />, { wrapper: TestWrapper });
+    await user.click(await screen.findByText("Kitchen Board"));
+    const card = await screen.findByTestId("board-card");
+
+    const nameInput = (await within(card).findByLabelText("Name")) as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: "" } });
+    fireEvent.blur(nameInput);
+
+    await waitFor(() => expect(put.count).toBe(1));
+    await screen.findByText("My Board");
+
+    // A field left showing "" while the server holds "My Board" reads as
+    // changed on every blur. Each PUT re-runs _reinitialize_board_clients()
+    // and rewrites config.json, so the repeat is not merely cosmetic.
+    fireEvent.focus(nameInput);
+    fireEvent.blur(nameInput);
+    await expectNoFurtherPuts(put, 1);
   });
 });
 

--- a/web/src/__tests__/display-settings.test.tsx
+++ b/web/src/__tests__/display-settings.test.tsx
@@ -194,6 +194,59 @@ describe("DisplaySettings — note-array selector", () => {
   });
 });
 
+describe("DisplaySettings — board name field (#1792)", () => {
+  it("shows the current name and saves an edited, trimmed name on blur", async () => {
+    const user = userEvent.setup();
+    const put = setupBoard({ device_type: "flagship" });
+    const card = await renderAndExpand(user);
+
+    const nameInput = (await within(card).findByLabelText("Name")) as HTMLInputElement;
+    expect(nameInput.value).toBe("My Board");
+
+    fireEvent.change(nameInput, { target: { value: "  Kitchen Board  " } });
+    fireEvent.blur(nameInput);
+
+    await waitFor(() => expect(put.body).not.toBeNull());
+    const saved = put.body!.boards![0];
+    // Trimmed before saving; the rest of the board rides along unchanged in
+    // the boards[] round-trip.
+    expect(saved.name).toBe("Kitchen Board");
+    expect(saved.device_type).toBe("flagship");
+    // The card header picks up the new name after the refetch.
+    expect(await screen.findByText("Kitchen Board")).toBeInTheDocument();
+  });
+
+  it("blurring without changing the name fires no PUT", async () => {
+    const user = userEvent.setup();
+    const put = setupBoard({ device_type: "flagship" });
+    const card = await renderAndExpand(user);
+
+    const nameInput = (await within(card).findByLabelText("Name")) as HTMLInputElement;
+    nameInput.focus();
+    nameInput.blur();
+    // Whitespace-only padding around the same name is also not a change.
+    fireEvent.change(nameInput, { target: { value: " My Board " } });
+    fireEvent.blur(nameInput);
+
+    expect(put.body).toBeNull();
+  });
+
+  it("clearing the name saves an empty string so the backend restores its default", async () => {
+    const user = userEvent.setup();
+    const put = setupBoard({ device_type: "flagship", name: "Kitchen Board" });
+    render(<DisplaySettings />, { wrapper: TestWrapper });
+    await user.click(await screen.findByText("Kitchen Board"));
+    const card = await screen.findByTestId("board-card");
+
+    const nameInput = (await within(card).findByLabelText("Name")) as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: "   " } });
+    fireEvent.blur(nameInput);
+
+    await waitFor(() => expect(put.body).not.toBeNull());
+    expect(put.body!.boards![0].name).toBe("");
+  });
+});
+
 describe("DisplaySettings — custom W×H inputs", () => {
   it("selecting Custom reveals the W×H inputs", async () => {
     const user = userEvent.setup();

--- a/web/src/components/settings/display-settings.tsx
+++ b/web/src/components/settings/display-settings.tsx
@@ -51,7 +51,7 @@ import { queryKeys, useBoardSettings } from "@/hooks/use-board";
 import { useTranslations } from "@/i18n/translations";
 import type { BoardInstance, Code62Glyph, DeviceType } from "@/lib/api";
 import { api } from "@/lib/api";
-import { isNoteArray, MAX_NOTES_PER_AXIS, NOTE_ARRAY_PRESETS } from "@/lib/board-dimensions";
+import { isNoteArray, MAX_BOARD_NAME_LENGTH, MAX_NOTES_PER_AXIS, NOTE_ARRAY_PRESETS } from "@/lib/board-dimensions";
 
 import { TileGridAssignment } from "./tile-grid-assignment";
 
@@ -150,6 +150,9 @@ function BoardNameField({ board, onRename }: { board: BoardInstance; onRename: (
         id={`board-name-${board.id}`}
         type="text"
         value={draft}
+        // Matches the backend cap, so the field never shows more than what
+        // will actually be stored.
+        maxLength={MAX_BOARD_NAME_LENGTH}
         onChange={(e) => setDraft(e.target.value)}
         onBlur={handleBlur}
         placeholder={t("boardNamePlaceholder")}

--- a/web/src/components/settings/display-settings.tsx
+++ b/web/src/components/settings/display-settings.tsx
@@ -672,6 +672,28 @@ export function DisplaySettings() {
 
               <CollapsibleContent>
                 <Stack gap="3" className="border-t px-4 pb-4 pt-3">
+                  {/* Board name (issue #1792). Trimmed on save; clearing it
+                      saves "" and the backend restores its default name. */}
+                  <Stack gap="1">
+                    <label className="text-xs font-medium" htmlFor={`board-name-${board.id}`}>
+                      {t("boardNameLabel")}
+                    </label>
+                    <input
+                      id={`board-name-${board.id}`}
+                      type="text"
+                      defaultValue={board.name ?? ""}
+                      onBlur={(e) => {
+                        const trimmed = e.target.value.trim();
+                        if (trimmed !== (board.name ?? "")) {
+                          handleUpdateBoard(board.id, { name: trimmed });
+                        }
+                      }}
+                      placeholder={t("boardNamePlaceholder")}
+                      className="w-full h-8 px-2 text-xs rounded-md border bg-background"
+                      data-testid="board-name-input"
+                    />
+                  </Stack>
+
                   {/* Pause / Resume row (issue #970) */}
                   <Flex
                     align="center"

--- a/web/src/components/settings/display-settings.tsx
+++ b/web/src/components/settings/display-settings.tsx
@@ -106,6 +106,60 @@ function isArrayConfigured(board: BoardInstance): boolean {
   return board.note_array_token === "***" || Boolean(board.note_array_token);
 }
 
+/**
+ * Controlled board display-name field (issue #1792).
+ *
+ * The stored name is normalized by the backend (trimmed, capped, empty →
+ * "My Board"), so the field cannot be uncontrolled: after clearing the name
+ * the input would keep showing "" while the board is actually called
+ * "My Board". That stale value also makes the blur handler see a change every
+ * time, firing an identical PUT on each focus/blur — and every PUT re-runs
+ * `_reinitialize_board_clients()` and rewrites config.json.
+ *
+ * So: local draft state for typing, re-synced whenever the server's name
+ * changes underneath it.
+ */
+function BoardNameField({ board, onRename }: { board: BoardInstance; onRename: (name: string) => void }) {
+  const t = useTranslations("displaySettings");
+  const storedName = board.name ?? "";
+  const [draft, setDraft] = useState(storedName);
+  const [syncedFrom, setSyncedFrom] = useState(storedName);
+
+  // Adjust state during render rather than in an effect: when the refetch
+  // brings back a different name (the server-normalized one), adopt it.
+  if (storedName !== syncedFrom) {
+    setSyncedFrom(storedName);
+    setDraft(storedName);
+  }
+
+  const handleBlur = () => {
+    const trimmed = draft.trim();
+    // Show what will actually be stored, so re-blurring is a no-op.
+    setDraft(trimmed);
+    if (trimmed !== storedName) {
+      onRename(trimmed);
+    }
+  };
+
+  return (
+    <Stack gap="1">
+      <label className="text-xs font-medium" htmlFor={`board-name-${board.id}`}>
+        {t("boardNameLabel")}
+      </label>
+      <input
+        id={`board-name-${board.id}`}
+        type="text"
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={handleBlur}
+        placeholder={t("boardNamePlaceholder")}
+        className="w-full h-8 px-2 text-xs rounded-md border bg-background"
+        data-testid="board-name-input"
+      />
+    </Stack>
+  );
+}
+
 function BoardConnectionForm({
   board,
   onUpdate,
@@ -674,25 +728,7 @@ export function DisplaySettings() {
                 <Stack gap="3" className="border-t px-4 pb-4 pt-3">
                   {/* Board name (issue #1792). Trimmed on save; clearing it
                       saves "" and the backend restores its default name. */}
-                  <Stack gap="1">
-                    <label className="text-xs font-medium" htmlFor={`board-name-${board.id}`}>
-                      {t("boardNameLabel")}
-                    </label>
-                    <input
-                      id={`board-name-${board.id}`}
-                      type="text"
-                      defaultValue={board.name ?? ""}
-                      onBlur={(e) => {
-                        const trimmed = e.target.value.trim();
-                        if (trimmed !== (board.name ?? "")) {
-                          handleUpdateBoard(board.id, { name: trimmed });
-                        }
-                      }}
-                      placeholder={t("boardNamePlaceholder")}
-                      className="w-full h-8 px-2 text-xs rounded-md border bg-background"
-                      data-testid="board-name-input"
-                    />
-                  </Stack>
+                  <BoardNameField board={board} onRename={(name) => handleUpdateBoard(board.id, { name })} />
 
                   {/* Pause / Resume row (issue #970) */}
                   <Flex

--- a/web/src/components/wizard/step-board-setup.tsx
+++ b/web/src/components/wizard/step-board-setup.tsx
@@ -196,7 +196,8 @@ export function StepBoardSetup({
         await api.updateBoardSettings({
           boards: [
             {
-              name: "My Board",
+              // No name: the backend fills in its default ("My Board");
+              // users rename boards in Settings → Boards (issue #1792).
               device_type: cfg.device_type,
               board_color: cfg.board_color,
               code62_glyph: cfg.code62_glyph,

--- a/web/src/lib/board-dimensions.ts
+++ b/web/src/lib/board-dimensions.ts
@@ -2,6 +2,8 @@
 export const NOTE_ROWS = 3;
 export const NOTE_COLS = 15;
 export const MAX_NOTES_PER_AXIS = 8;
+/** Board display names are capped at storage time by BoardInstance.__post_init__. */
+export const MAX_BOARD_NAME_LENGTH = 64;
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 export interface BoardDimensions {


### PR DESCRIPTION
Closes #1792.

Adds an editable Name field to each board card in Settings → Boards, saved through the existing `PUT /settings/board` round-trip. Trimmed on blur; clearing it saves `""` and the backend restores its default (`My Board`).

The setup wizard no longer hardcodes `name: "My Board"` — it omits the field so the backend default applies, keeping display-name policy out of the wizard.

Adds `boardNameLabel` to all 14 locales.

## Review follow-ups

**The name input is now controlled.** It was `defaultValue`, so the server-normalized name never landed in the field: clearing the name flipped the card header to "My Board" while the input still showed `""`.

```
after save, input           = ""
after collapse+reopen, input = "My Board"
```

Because the field stayed stale, `trimmed !== board.name` was permanently true, so **every subsequent focus/blur fired another identical PUT** — each one running `_reinitialize_board_clients()` and rewriting `config.json` (observed `put count = 2`). A `BoardNameField` component now owns a draft and re-syncs from the query data whenever the stored name changes underneath it, which fixes both.

**Whitespace-only names no longer persist.** `BoardInstance.__post_init__` only had `if not self.name: self.name = "My Board"`, and `"   "` is truthy — so a name of spaces was stored verbatim and rendered as a blank sidebar row. It now strips, caps at `MAX_BOARD_NAME_LENGTH` (64, since the name is rendered in the sidebar, board selector and card headers), then falls back to the default. The input carries a matching `maxLength` so the field never shows more than what will actually be stored.

**A rename breaks name-based MQTT automations.** `CommandHandler._resolve_board` matches by id **then by display name**, so shipping a rename UI silently breaks any Home Assistant automation publishing `{"board": "Kitchen", ...}`. FiestaBoard cannot rewrite payloads that live in the user's HA config, so name resolution now logs a warning naming the stable id, and `docs/features/home-assistant-control.md` gains a troubleshooting entry. HA discovery topics are id-scoped, so entities are never orphaned — only name-based `board` refs in user automations.

## Test fixes

**`blurring without changing the name fires no PUT` was vacuous.** `put.body` is assigned inside an *async* MSW handler and was asserted synchronously, so it read `null` whether or not a request fired. Proven: deleting the production guard left all three new tests green.

```
Test Files  1 passed (1)
     Tests  33 passed (33)      # guard deleted
```

It now awaits and pins a request *count*. With the guard deleted again, it goes red:

```
 ✓ ... shows the current name and saves an edited, trimmed name on blur
 × ... blurring without changing the name fires no PUT
 ✓ ... clearing the name saves an empty string and shows the restored default
 × ... re-blurring after a clear does not fire a second identical PUT
 Test Files  1 failed (1)
      Tests  2 failed | 32 passed (34)
```

**The MSW fixture echoed `name` back verbatim** instead of applying the backend's `name or "My Board"`, so the clear/reset round-trip this PR is *about* was never exercised. It now mirrors `BoardInstance.__post_init__` (strip → cap → default). Against the uncontrolled input the two new tests fail exactly where expected:

```
AssertionError: expected '   ' to be 'My Board' // Object.is equality
Expected: "My Board"
Received: "   "
```

**`test_set_boards_roundtrips_renamed_board` / `test_set_boards_empty_name_restores_default` both passed unchanged against `main`** (the original PR changed no backend code), so they were not evidence of anything. They are joined by whitespace-only, trim, and cap cases that do fail against `main` — 4 red before the `devices.py` change:

```
E   AssertionError: assert '   ' == 'My Board'
E   AssertionError: assert '  Kitchen Board  ' == 'Kitchen Board'
E   AssertionError: assert 200 == 64
E   AssertionError: assert '  Garage  ' == 'Garage'
```

## Verification

- Python: 517 passed (devices / settings / mqtt / api / board suites); `ruff 0.16.4` check + format clean
- Web: 134 files, 1554 passed, 7 skipped; prettier, eslint and `tsc --noEmit` clean
