### PR TITLE
fix(send-message): wrap to real board width and honor newlines

### DIFF
--- a/docs/features/home-assistant-control.md
+++ b/docs/features/home-assistant-control.md
@@ -106,6 +106,13 @@ Once connected, FiestaBoard appears as a device with **24 entities** — control
 | **Previous Page** | Button | Navigate to the previous page in the page list (wraps around) |
 | **Refresh Interval** | Number | Set how often the board refreshes (30–3600 seconds). *Categorized as config.* |
 
+**Send Message formatting:** text longer than the board width word-wraps onto
+the following rows automatically, sized to your board's real geometry (6 rows ×
+22 columns on Flagship, 3 × 15 on Note). The text entity is single-line, so to
+force a line break type the literal two-character sequence `\n` where you want
+the break (e.g. `TACO\nTUESDAY`) — wrapping still fills within those breaks.
+Lines beyond the board's row count are dropped.
+
 ### Sensors (read-only status from FiestaBoard)
 
 | Entity | Type | Description |

--- a/docs/features/home-assistant-control.md
+++ b/docs/features/home-assistant-control.md
@@ -108,10 +108,19 @@ Once connected, FiestaBoard appears as a device with **24 entities** — control
 
 **Send Message formatting:** text longer than the board width word-wraps onto
 the following rows automatically, sized to your board's real geometry (6 rows ×
-22 columns on Flagship, 3 × 15 on Note). The text entity is single-line, so to
-force a line break type the literal two-character sequence `\n` where you want
-the break (e.g. `TACO\nTUESDAY`) — wrapping still fills within those breaks.
-Lines beyond the board's row count are dropped.
+22 columns on Flagship, 3 × 15 on Note). Width is counted in flaps, so a colour
+marker like `{red}` costs one tile, not five characters. A word wider than the
+board is split across rows rather than cut off. Lines beyond the board's row
+count are dropped.
+
+The text entity is single-line, so to force a line break type the literal
+two-character sequence `\n` where you want the break (e.g. `TACO\nTUESDAY`) —
+wrapping still fills within those breaks. If your text needs a real backslash
+before an `n`, double it: `C:\\new` renders as `C:\new`. Any other backslash
+(`C:\temp`) is left alone. This escape applies only to the plain-string
+payload the text entity publishes; a JSON payload such as
+`{"message": "TACO\nTUESDAY", "board": "Kitchen"}` can carry a real newline and
+is never rewritten.
 
 ### Sensors (read-only status from FiestaBoard)
 

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -208,8 +208,15 @@ curl http://localhost:4420/api/status
 ```bash
 curl -X POST http://localhost:4420/api/send-message \
   -H "Content-Type: application/json" \
-  -d '{"message": "Hello World!"}'
+  -d '{"text": "Hello World!"}'
 ```
+
+Message formatting: text longer than the board width is word-wrapped onto
+the following rows automatically, sized to your board's real geometry
+(6 rows × 22 columns on Flagship, 3 × 15 on Note). A newline (`\n`) — or the
+literal two-character sequence `\n` typed in a single-line field — starts a
+new row, and wrapping fills within those explicit breaks. Lines beyond the
+board's row count are dropped.
 
 ### List Plugins
 

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -213,10 +213,17 @@ curl -X POST http://localhost:4420/api/send-message \
 
 Message formatting: text longer than the board width is word-wrapped onto
 the following rows automatically, sized to your board's real geometry
-(6 rows × 22 columns on Flagship, 3 × 15 on Note). A newline (`\n`) — or the
-literal two-character sequence `\n` typed in a single-line field — starts a
-new row, and wrapping fills within those explicit breaks. Lines beyond the
-board's row count are dropped.
+(6 rows × 22 columns on Flagship, 3 × 15 on Note). Width is counted in flaps,
+so a colour marker like `{red}` costs one tile, not five characters, and a word
+wider than the board is split across rows rather than cut off. A newline in the
+JSON body starts a new row, and wrapping fills within those explicit breaks.
+Lines beyond the board's row count are dropped (and logged).
+
+Backslashes are never reinterpreted here — JSON can already carry a real
+newline, so `{"text": "C:\\new"}` renders `C:\new` verbatim. The
+`\n`-as-line-break shorthand exists only on the MQTT plain-string
+`send_message` payload, for single-line clients that cannot type a newline;
+see [Home Assistant control](../features/home-assistant-control.md).
 
 ### List Plugins
 

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -53,7 +53,7 @@ from .schedules.service import get_schedule_service  # noqa: E402
 from .settings.service import VALID_OUTPUT_TARGETS, VALID_STRATEGIES, get_settings_service  # noqa: E402
 from .templates.engine import get_template_engine, reset_template_engine  # noqa: E402
 from .templates.expressions import function_signatures  # noqa: E402
-from .text_to_board import text_to_board_array  # noqa: E402
+from .text_to_board import text_to_board_array, wrap_message_text  # noqa: E402
 from .time_service import reset_time_service  # noqa: E402
 
 logger = logging.getLogger(__name__)
@@ -3373,8 +3373,11 @@ async def send_message(request: MessageRequest):
             notes_wide = primary_board.get("notes_wide", 1)
             notes_tall = primary_board.get("notes_tall", 1)
         dims = resolve_dimensions(device_type, notes_wide, notes_tall)
-        # Convert text to board array for proper character/color support
-        board_array = text_to_board_array(request.text, rows=dims.rows, cols=dims.cols)
+        # Word-wrap to the board width and honor \n / literal "\n" line
+        # breaks (issue #1793), then convert to a board array for proper
+        # character/color support.
+        wrapped = wrap_message_text(request.text, rows=dims.rows, cols=dims.cols)
+        board_array = text_to_board_array(wrapped, rows=dims.rows, cols=dims.cols)
 
         success, was_sent = service.vb_client.render(
             board_array,

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -3373,9 +3373,11 @@ async def send_message(request: MessageRequest):
             notes_wide = primary_board.get("notes_wide", 1)
             notes_tall = primary_board.get("notes_tall", 1)
         dims = resolve_dimensions(device_type, notes_wide, notes_tall)
-        # Word-wrap to the board width and honor \n / literal "\n" line
-        # breaks (issue #1793), then convert to a board array for proper
-        # character/color support.
+        # Word-wrap to the board width (in tiles) and honor real newlines
+        # (issue #1793), then convert to a board array for proper
+        # character/color support. Backslashes are left alone: a JSON body
+        # can carry a real newline, so rewriting "\n" here would only corrupt
+        # legitimate text like C:\new.
         wrapped = wrap_message_text(request.text, rows=dims.rows, cols=dims.cols)
         board_array = text_to_board_array(wrapped, rows=dims.rows, cols=dims.cols)
 

--- a/src/formatters/message_formatter.py
+++ b/src/formatters/message_formatter.py
@@ -11,6 +11,7 @@ Use them as decorative indicators followed by a space, e.g., "{green} SSID: netw
 import logging
 
 from src.board_chars import get_weather_symbol
+from src.text_to_board import count_tiles, take_tiles
 
 logger = logging.getLogger(__name__)
 
@@ -357,41 +358,69 @@ class MessageFormatter:
 
     def split_into_lines(self, text: str, max_lines: int = MAX_ROWS) -> list[str]:
         """
-        Split text into lines, respecting max length.
+        Split text into lines that each fit the board width.
+
+        Width is measured in *flaps*, not characters: a colour marker such as
+        ``{red}`` writes five characters but occupies one tile, and a closing
+        tag such as ``{/green}`` occupies none. Measuring characters wrapped
+        text that actually fit and wasted the rest of the row (issue #1793).
+
+        A word wider than the board is hard-broken across rows rather than
+        left to be truncated at the column limit downstream, and a
+        whitespace-only line still yields the (blank) row it asked for.
 
         Args:
             text: Text to split
             max_lines: Maximum number of lines
 
         Returns:
-            List of lines (each at most self._cols characters)
+            List of lines (each at most self._cols tiles wide)
         """
-        lines = text.split("\n")
-        result = []
+        result: list[str] = []
 
-        for line in lines[:max_lines]:
-            # If line is too long, try to split on spaces
-            if len(line) > self._cols:
-                words = line.split()
-                current_line = ""
-
-                for word in words:
-                    if len(current_line) + len(word) + 1 <= self._cols:
-                        if current_line:
-                            current_line += " " + word
-                        else:
-                            current_line = word
-                    else:
-                        if current_line:
-                            result.append(current_line)
-                        current_line = word
-
-                if current_line:
-                    result.append(current_line)
-            else:
+        for line in text.split("\n")[:max_lines]:
+            if count_tiles(line) <= self._cols:
                 result.append(line)
+            else:
+                result.extend(self._wrap_line(line))
 
         return result[:max_lines]
+
+    def _wrap_line(self, line: str) -> list[str]:
+        """Greedy word-wrap one over-wide line into board-width rows."""
+        words = line.split()
+        if not words:
+            # Whitespace-only line: keep the blank row instead of returning
+            # nothing and silently shifting everything below it up.
+            return [""]
+
+        wrapped: list[str] = []
+        current = ""
+        current_tiles = 0
+
+        for word in words:
+            word_tiles = count_tiles(word)
+            if current and current_tiles + 1 + word_tiles <= self._cols:
+                current = f"{current} {word}"
+                current_tiles += 1 + word_tiles
+                continue
+            if current:
+                wrapped.append(current)
+                current, current_tiles = "", 0
+            # A single word wider than the board flows onto further rows
+            # instead of vanishing past the column limit.
+            while word_tiles > self._cols:
+                head, word = take_tiles(word, self._cols)
+                if not head:  # defensive: never loop forever on a 0-wide board
+                    break
+                wrapped.append(head)
+                word_tiles = count_tiles(word)
+            if word:
+                current, current_tiles = word, word_tiles
+
+        if current:
+            wrapped.append(current)
+        return wrapped
 
     def format_muni(self, muni_data: dict) -> str:
         """

--- a/src/mqtt/client.py
+++ b/src/mqtt/client.py
@@ -167,11 +167,28 @@ class MQTTClient:
             page_names = [p.name for p in pages]
         except Exception:
             logger.debug("Could not retrieve page names for MQTT discovery")
+        max_message_length = None
+        try:
+            from src.devices import resolve_dimensions
+            from src.settings.service import get_settings_service
+
+            boards = get_settings_service().get_board_settings().boards or []
+            primary = next((b for b in boards if isinstance(b, dict) and b.get("id")), None)
+            if primary:
+                dims = resolve_dimensions(
+                    primary.get("device_type") or "flagship",
+                    primary.get("notes_wide") or 1,
+                    primary.get("notes_tall") or 1,
+                )
+                max_message_length = dims.rows * dims.cols
+        except Exception:
+            logger.debug("Could not resolve board capacity for MQTT discovery")
         messages = build_all_discovery_messages(
             self.config,
             sw_version=sw_version,
             configuration_url=configuration_url,
             page_names=page_names or [],
+            max_message_length=max_message_length,
         )
         for msg in messages:
             self._client.publish(

--- a/src/mqtt/commands.py
+++ b/src/mqtt/commands.py
@@ -298,7 +298,7 @@ class CommandHandler:
             logger.info("MQTT send_message blocked by silence mode")
             return
         from src.api_server import get_service
-        from src.text_to_board import text_to_board_array
+        from src.text_to_board import text_to_board_array, wrap_message_text
 
         service = get_service()
         if not service or (board_id is None and not service.vb_client):
@@ -319,11 +319,15 @@ class CommandHandler:
             logger.info("MQTT send_message blocked: board is paused")
             return
         transition = settings.get_transition_settings()
-        if board is not None:
-            dims = self._board_dims(board)
-            board_array = text_to_board_array(message, rows=dims.rows, cols=dims.cols)
-        else:
-            board_array = text_to_board_array(message)
+        # Grid sized to the target board (issue #1793): the named board when
+        # given, else the primary board, else the flagship 6x22 default.
+        # Plain-string payloads (what HA's text entity sends) used to fall
+        # back to 6x22 even on a Note, so columns 16+ went nowhere.
+        dims = self._board_dims(board if board is not None else self._resolve_board(None)[1])
+        # Word-wrap to the board width and honor \n / literal "\n" line
+        # breaks instead of truncating everything past the first row.
+        wrapped = wrap_message_text(message, rows=dims.rows, cols=dims.cols)
+        board_array = text_to_board_array(wrapped, rows=dims.rows, cols=dims.cols)
         client.send_characters(
             board_array,
             strategy=transition.strategy,

--- a/src/mqtt/commands.py
+++ b/src/mqtt/commands.py
@@ -93,20 +93,33 @@ class CommandHandler:
         ``value_keys`` — e.g. ``{"message": "HI", "board": "Kitchen"}``.
         """
         text = payload or ""
-        if text.startswith("{") and text.endswith("}"):
-            try:
-                data = json.loads(text)
-            except ValueError:
-                return text, None
-            if isinstance(data, dict):
-                board_ref = data.get("board_id") or data.get("board")
-                value = ""
-                for key in value_keys:
-                    if data.get(key) not in (None, ""):
-                        value = str(data[key])
-                        break
-                return value, (str(board_ref) if board_ref not in (None, "") else None)
-        return text, None
+        data = CommandHandler._json_object(text)
+        if data is None:
+            return text, None
+        board_ref = data.get("board_id") or data.get("board")
+        value = ""
+        for key in value_keys:
+            if data.get(key) not in (None, ""):
+                value = str(data[key])
+                break
+        return value, (str(board_ref) if board_ref not in (None, "") else None)
+
+    @staticmethod
+    def _json_object(payload: str) -> dict | None:
+        """Parse *payload* as a JSON object, or ``None`` for a plain string.
+
+        Handlers use the ``None`` case to tell the legacy plain-string format
+        (what Home Assistant's single-line text entity publishes) from a
+        structured JSON payload, which can carry a real newline of its own.
+        """
+        text = payload or ""
+        if not (text.startswith("{") and text.endswith("}")):
+            return None
+        try:
+            data = json.loads(text)
+        except ValueError:
+            return None
+        return data if isinstance(data, dict) else None
 
     @staticmethod
     def _resolve_board(board_ref: str | None) -> tuple[str | None, dict | None]:
@@ -324,9 +337,17 @@ class CommandHandler:
         # Plain-string payloads (what HA's text entity sends) used to fall
         # back to 6x22 even on a Note, so columns 16+ went nowhere.
         dims = self._board_dims(board if board is not None else self._resolve_board(None)[1])
-        # Word-wrap to the board width and honor \n / literal "\n" line
-        # breaks instead of truncating everything past the first row.
-        wrapped = wrap_message_text(message, rows=dims.rows, cols=dims.cols)
+        # Word-wrap to the board width instead of truncating everything past
+        # the first row. Only the legacy plain-string payload gets the literal
+        # "\n" line-break escape: that is the single-line HA text entity that
+        # cannot type a real newline, whereas a JSON payload can carry one, so
+        # confining the substitution keeps backslashes intact everywhere else.
+        wrapped = wrap_message_text(
+            message,
+            rows=dims.rows,
+            cols=dims.cols,
+            unescape_newlines=self._json_object(payload) is None,
+        )
         board_array = text_to_board_array(wrapped, rows=dims.rows, cols=dims.cols)
         client.send_characters(
             board_array,

--- a/src/mqtt/discovery.py
+++ b/src/mqtt/discovery.py
@@ -173,6 +173,8 @@ ENTITY_DEFINITIONS: list[EntityDefinition] = [
         icon="mdi:send",
         has_command=True,
         min_length=1,
+        # Flagship capacity (6x22). Overridden per install from the primary
+        # board's real geometry by build_all_discovery_messages (issue #1793).
         max_length=132,
     ),
     # Number
@@ -411,6 +413,7 @@ def build_all_discovery_messages(
     sw_version: str = "1.0.0",
     configuration_url: str | None = None,
     page_names: list[str] | None = None,
+    max_message_length: int | None = None,
 ) -> list[dict[str, Any]]:
     """Build all discovery messages for FiestaBoard.
 
@@ -423,6 +426,9 @@ def build_all_discovery_messages(
         sw_version: FiestaBoard software version.
         configuration_url: URL to FiestaBoard web UI.
         page_names: Current list of page names (for active_page select options).
+        max_message_length: Characters the board can actually hold
+            (rows x cols). Advertised to HA as the Send Message text limit;
+            ``None`` keeps the flagship 132 default.
 
     Returns:
         List of dicts, each with 'topic' and 'payload' keys.
@@ -434,6 +440,11 @@ def build_all_discovery_messages(
         # Inject dynamic page list into active_page entity
         if entity.object_id == "active_page" and page_names is not None:
             entity = replace(entity, options=page_names)
+
+        # Advertise the board's real capacity, not the flagship default, so a
+        # Note owner is not offered 132 characters for a 45-tile board.
+        if entity.object_id == "send_message" and max_message_length is not None:
+            entity = replace(entity, max_length=max_message_length)
 
         topic = build_discovery_topic(config, entity)
         payload = build_discovery_payload(config, entity, device_info)

--- a/src/plugins/previews.py
+++ b/src/plugins/previews.py
@@ -32,7 +32,10 @@ from typing import Any
 
 from src.board_chars import BoardChars
 from src.devices import DEVICE_DIMENSIONS, DeviceDimensions, resolve_dimensions
-from src.text_to_board import COLOR_MARKER_PATTERN, text_to_board_array
+
+# count_tiles lives beside COLOR_MARKER_PATTERN in text_to_board and is
+# re-exported here, where it was originally defined, for existing importers.
+from src.text_to_board import COLOR_MARKER_PATTERN, count_tiles, text_to_board_array
 
 logger = logging.getLogger(__name__)
 
@@ -108,28 +111,6 @@ def load_preview_seed(seed_path: Path | None = None) -> dict[str, dict[str, Any]
 
     logger.debug("Loaded previews for %d plugins from the seed", len(seeded))
     return seeded
-
-
-def count_tiles(text: str) -> int:
-    """Count how many flaps *text* occupies.
-
-    A colour marker (``{66}``, ``{green}``) is one tile regardless of how many
-    characters it takes to write. Closing tags (``{/green}``, ``{/}``) are
-    formatting artefacts and occupy none — matching ``text_to_board_array``,
-    which skips them without advancing ``col_idx``.
-    """
-    tiles = 0
-    pos = 0
-    while pos < len(text):
-        match = COLOR_MARKER_PATTERN.match(text, pos)
-        if match:
-            if not match.group(3):  # group(3) is the closing-tag alternative
-                tiles += 1
-            pos = match.end()
-            continue
-        tiles += 1
-        pos += 1
-    return tiles
 
 
 def _unmappable_characters(text: str) -> list[str]:

--- a/src/text_to_board.py
+++ b/src/text_to_board.py
@@ -37,35 +37,128 @@ COLOR_MARKER_PATTERN = re.compile(
 )
 
 
-def wrap_message_text(text: str, rows: int = 6, cols: int = 22) -> str:
-    """Prepare free-form user text for ``text_to_board_array`` (issue #1793).
+def count_tiles(text: str) -> int:
+    """Count how many flaps *text* occupies.
 
-    - Converts the literal two-character sequence backslash-n (``"\\\\n"``)
-      into a real newline, so single-line clients (e.g. Home Assistant text
-      entities) can request a line break.
-    - Word-wraps to ``cols`` characters (greedy, at word boundaries) so text
-      longer than the board width flows onto the next row instead of being
-      silently truncated. Explicit newlines are respected; wrapping fills
-      within them.
-    - Truncates to ``rows`` lines.
+    A colour marker (``{66}``, ``{green}``) is one tile regardless of how many
+    characters it takes to write. Closing tags (``{/green}``, ``{/}``) are
+    formatting artefacts and occupy none — matching :func:`text_to_board_array`,
+    which skips them without advancing ``col_idx``.
+    """
+    tiles = 0
+    pos = 0
+    while pos < len(text):
+        match = COLOR_MARKER_PATTERN.match(text, pos)
+        if match:
+            if not match.group(3):  # group(3) is the closing-tag alternative
+                tiles += 1
+            pos = match.end()
+            continue
+        tiles += 1
+        pos += 1
+    return tiles
 
-    ``text_to_board_array`` itself keeps its contract of truncating each line
-    at the column limit — wrapping happens here, upstream.
+
+def take_tiles(text: str, limit: int) -> tuple[str, str]:
+    """Split *text* into ``(head, tail)``, ``head`` at most *limit* tiles wide.
+
+    The split never lands inside a colour marker: a marker is taken whole or
+    left for the tail. Trailing closing tags cost no tiles, so they ride along
+    with ``head``.
+    """
+    if limit <= 0:
+        return "", text
+    tiles = 0
+    pos = 0
+    while pos < len(text):
+        match = COLOR_MARKER_PATTERN.match(text, pos)
+        cost = 1
+        end = pos + 1
+        if match:
+            cost = 0 if match.group(3) else 1
+            end = match.end()
+        if tiles + cost > limit:
+            break
+        tiles += cost
+        pos = end
+    return text[:pos], text[pos:]
+
+
+# Backslash escapes understood by ``unescape_message_newlines``. Only "\n"
+# and "\\" mean anything; every other sequence is passed through untouched.
+MESSAGE_ESCAPE_PATTERN = re.compile(r"\\(.)", re.DOTALL)
+
+
+def unescape_message_newlines(text: str) -> str:
+    r"""Interpret backslash escapes in a *single-line* message payload.
+
+    Home Assistant's ``text`` entity cannot type a real newline, so the
+    literal two-character sequence ``\n`` is how an MQTT plain-string
+    payload asks for a line break (issue #1793).
+
+    That substitution is destructive for text that legitimately contains a
+    backslash, so ``\\`` is the escape hatch: it collapses to one literal
+    backslash and the next character is left alone, making ``C:\\new``
+    render as ``C:\new``. Any other backslash sequence (``C:\temp``) is
+    passed through verbatim.
+
+    This is deliberately *not* applied to the HTTP ``/send-message`` body or
+    to JSON MQTT payloads — both can carry a real newline already, so they
+    keep their exact pre-#1793 rendering.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        escaped = match.group(1)
+        if escaped == "n":
+            return "\n"
+        if escaped == "\\":
+            return "\\"
+        return match.group(0)
+
+    return MESSAGE_ESCAPE_PATTERN.sub(_replace, text)
+
+
+def wrap_message_text(text: str, rows: int = 6, cols: int = 22, unescape_newlines: bool = False) -> str:
+    r"""Prepare free-form user text for :func:`text_to_board_array` (issue #1793).
+
+    - Word-wraps to ``cols`` *tiles* (not characters — a colour marker like
+      ``{red}`` is one flap) so text longer than the board width flows onto
+      the next row instead of being silently truncated. Explicit newlines are
+      respected; wrapping fills within them.
+    - Truncates to ``rows`` lines, logging a warning when content is dropped.
+    - With ``unescape_newlines``, first turns the literal two-character
+      sequence ``\n`` into a real line break. Off by default because it
+      corrupts text that legitimately contains a backslash; see
+      :func:`unescape_message_newlines`.
+
+    :func:`text_to_board_array` itself keeps its contract of truncating each
+    line at the column limit — wrapping happens here, upstream.
 
     Args:
         text: Raw user message.
         rows: Target board rows (default 6 for flagship, 3 for note).
         cols: Target board columns (default 22 for flagship, 15 for note).
+        unescape_newlines: Treat ``\n`` as a line break (single-line clients).
 
     Returns:
-        Newline-separated text that fits within rows x cols at word
-        boundaries (a single word longer than ``cols`` still gets truncated
-        downstream).
+        Newline-separated text that fits within rows x cols.
     """
     from src.formatters.message_formatter import MessageFormatter
 
-    unescaped = text.replace("\\n", "\n")
-    lines = MessageFormatter(rows=rows, cols=cols).split_into_lines(unescaped, max_lines=rows)
+    if unescape_newlines:
+        text = unescape_message_newlines(text)
+
+    # Ask for one row more than fits so overflow is detectable rather than
+    # silently swallowed.
+    lines = MessageFormatter(rows=rows, cols=cols).split_into_lines(text, max_lines=rows + 1)
+    if len(lines) > rows:
+        logger.warning(
+            "Message too long for a %dx%d board: dropping everything past row %d",
+            rows,
+            cols,
+            rows,
+        )
+        lines = lines[:rows]
     return "\n".join(lines)
 
 

--- a/src/text_to_board.py
+++ b/src/text_to_board.py
@@ -37,6 +37,38 @@ COLOR_MARKER_PATTERN = re.compile(
 )
 
 
+def wrap_message_text(text: str, rows: int = 6, cols: int = 22) -> str:
+    """Prepare free-form user text for ``text_to_board_array`` (issue #1793).
+
+    - Converts the literal two-character sequence backslash-n (``"\\\\n"``)
+      into a real newline, so single-line clients (e.g. Home Assistant text
+      entities) can request a line break.
+    - Word-wraps to ``cols`` characters (greedy, at word boundaries) so text
+      longer than the board width flows onto the next row instead of being
+      silently truncated. Explicit newlines are respected; wrapping fills
+      within them.
+    - Truncates to ``rows`` lines.
+
+    ``text_to_board_array`` itself keeps its contract of truncating each line
+    at the column limit — wrapping happens here, upstream.
+
+    Args:
+        text: Raw user message.
+        rows: Target board rows (default 6 for flagship, 3 for note).
+        cols: Target board columns (default 22 for flagship, 15 for note).
+
+    Returns:
+        Newline-separated text that fits within rows x cols at word
+        boundaries (a single word longer than ``cols`` still gets truncated
+        downstream).
+    """
+    from src.formatters.message_formatter import MessageFormatter
+
+    unescaped = text.replace("\\n", "\n")
+    lines = MessageFormatter(rows=rows, cols=cols).split_into_lines(unescaped, max_lines=rows)
+    return "\n".join(lines)
+
+
 def text_to_board_array(text: str, use_color_tiles: bool = True, rows: int = 6, cols: int = 22) -> list[list[int]]:
     """
     Convert formatted text to board character array.

--- a/tests/test_api_extended.py
+++ b/tests/test_api_extended.py
@@ -1477,10 +1477,24 @@ class TestSendMessageWrapping:
         assert self._row_text(board_array[0]) == "TACO TUESDAY"
         assert self._row_text(board_array[1]) == "PARTY TIME"
 
-    def test_literal_backslash_n_breaks_line(self, client, mock_service, mock_settings_service):
+    def test_backslash_text_renders_exactly_as_before(self, client, mock_service, mock_settings_service):
+        """HTTP JSON bodies can carry a real newline, so /send-message must NOT
+        reinterpret a backslash. ``C:\\new`` keeps its N (issue #1793 review)."""
+        from src.text_to_board import text_to_board_array
+
+        board_array = self._sent_array(client, mock_service, "C:\\new")
+        assert board_array == text_to_board_array("C:\\new", rows=6, cols=22)
+
+    def test_literal_backslash_n_is_not_a_line_break(self, client, mock_service, mock_settings_service):
         board_array = self._sent_array(client, mock_service, "HI\\nTHERE")
-        assert self._row_text(board_array[0]) == "HI"
-        assert self._row_text(board_array[1]) == "THERE"
+        assert self._row_text(board_array[0]) == "HI NTHERE"
+        assert self._row_text(board_array[1]) == ""
+
+    def test_long_word_hard_breaks_instead_of_vanishing(self, client, mock_service, mock_settings_service):
+        board_array = self._sent_array(client, mock_service, "SEE SUPERCALIFRAGILISTICEXPIALIDOCIOUS")
+        assert self._row_text(board_array[0]) == "SEE"
+        assert self._row_text(board_array[1]) == "SUPERCALIFRAGILISTICEX"
+        assert self._row_text(board_array[2]) == "PIALIDOCIOUS"
 
     def test_explicit_newline_breaks_line(self, client, mock_service, mock_settings_service):
         board_array = self._sent_array(client, mock_service, "HI\nTHERE")

--- a/tests/test_api_extended.py
+++ b/tests/test_api_extended.py
@@ -1453,6 +1453,49 @@ class TestServiceLifecycle:
         assert response.status_code == 500
 
 
+class TestSendMessageWrapping:
+    """Issue #1793: /send-message wraps long text to the board's geometry."""
+
+    @staticmethod
+    def _row_text(row):
+        """Decode a board row of character codes back to letters/spaces."""
+        return "".join(chr(ord("A") + code - 1) if 1 <= code <= 26 else " " for code in row).rstrip()
+
+    def _sent_array(self, client, mock_service, text):
+        with patch("src.api_server.Config.is_silence_mode_active", return_value=False):
+            response = client.post("/send-message", json={"text": text})
+        assert response.status_code == 200
+        return mock_service.vb_client.render.call_args[0][0]
+
+    def test_long_message_wraps_at_word_boundaries_on_note(self, client, mock_service, mock_settings_service):
+        mock_settings_service.get_board_settings.return_value.boards = [
+            {"id": "b1", "device_type": "note", "notes_wide": 1, "notes_tall": 1},
+        ]
+        board_array = self._sent_array(client, mock_service, "TACO TUESDAY PARTY TIME")
+        assert len(board_array) == 3
+        assert len(board_array[0]) == 15
+        assert self._row_text(board_array[0]) == "TACO TUESDAY"
+        assert self._row_text(board_array[1]) == "PARTY TIME"
+
+    def test_literal_backslash_n_breaks_line(self, client, mock_service, mock_settings_service):
+        board_array = self._sent_array(client, mock_service, "HI\\nTHERE")
+        assert self._row_text(board_array[0]) == "HI"
+        assert self._row_text(board_array[1]) == "THERE"
+
+    def test_explicit_newline_breaks_line(self, client, mock_service, mock_settings_service):
+        board_array = self._sent_array(client, mock_service, "HI\nTHERE")
+        assert self._row_text(board_array[0]) == "HI"
+        assert self._row_text(board_array[1]) == "THERE"
+
+    def test_text_beyond_rows_truncates_predictably(self, client, mock_service, mock_settings_service):
+        mock_settings_service.get_board_settings.return_value.boards = [
+            {"id": "b1", "device_type": "note", "notes_wide": 1, "notes_tall": 1},
+        ]
+        board_array = self._sent_array(client, mock_service, "AAAA BBBB CCCC DDDD EEEE FFFF GGGG HHHH IIII JJJJ")
+        assert len(board_array) == 3
+        assert self._row_text(board_array[2]) == "GGGG HHHH IIII"
+
+
 # ============================================================
 # Board Current Message
 # ============================================================

--- a/tests/test_message_formatter.py
+++ b/tests/test_message_formatter.py
@@ -7,6 +7,7 @@ MessageFormatter contains pure formatting logic that is highly testable
 import pytest
 
 from src.formatters.message_formatter import MessageFormatter, get_message_formatter
+from src.text_to_board import count_tiles
 
 
 @pytest.fixture
@@ -212,6 +213,50 @@ class TestSplitIntoLines:
     def test_empty_string(self, fmt):
         lines = fmt.split_into_lines("")
         assert lines == [""]
+
+
+class TestSplitIntoLinesTileWidth:
+    """Width is measured in flaps, not characters (issue #1793 review)."""
+
+    def test_colour_marker_costs_one_tile_not_five_characters(self):
+        fmt = MessageFormatter(rows=3, cols=15)
+        # 18 characters, 14 tiles — fits one Note row.
+        assert fmt.split_into_lines("{red} TACO TUESDAY") == ["{red} TACO TUESDAY"]
+
+    def test_closing_tag_costs_no_tiles(self):
+        fmt = MessageFormatter(rows=3, cols=15)
+        assert fmt.split_into_lines("{green}HI{/green} TACO TUESDAY") == [
+            "{green}HI{/green} TACO",
+            "TUESDAY",
+        ]
+
+
+class TestSplitIntoLinesLongWords:
+    """A word wider than the board is broken across rows, not cut off."""
+
+    def test_over_long_word_is_hard_broken(self):
+        fmt = MessageFormatter(rows=6, cols=22)
+        assert fmt.split_into_lines("SEE HTTPS://EXAMPLE.COM/VERYLONGPATH") == [
+            "SEE",
+            "HTTPS://EXAMPLE.COM/VE",
+            "RYLONGPATH",
+        ]
+
+    def test_hard_break_does_not_split_a_colour_marker(self):
+        fmt = MessageFormatter(rows=6, cols=22)
+        assert fmt.split_into_lines("A" * 21 + "{red}" + "B" * 4) == ["A" * 21 + "{red}", "B" * 4]
+
+    def test_every_returned_line_fits_the_board(self):
+        fmt = MessageFormatter(rows=6, cols=22)
+        for line in fmt.split_into_lines("X" * 100):
+            assert count_tiles(line) <= 22
+
+
+class TestSplitIntoLinesWhitespaceOnly:
+    def test_long_whitespace_line_still_yields_a_row(self):
+        fmt = MessageFormatter(rows=6, cols=22)
+        # Used to return [] and silently eat the row (issue #1793 review).
+        assert fmt.split_into_lines("TOP\n" + " " * 40 + "\nBOTTOM") == ["TOP", "", "BOTTOM"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mqtt_commands.py
+++ b/tests/test_mqtt_commands.py
@@ -633,3 +633,51 @@ class TestCommandHandlerSendMessageWrapping:
         board_array = b1_client.send_characters.call_args[0][0]
         assert _row_text(board_array[0]) == "TACO TUESDAY"
         assert _row_text(board_array[1]) == "PARTY TIME"
+
+    @patch("src.api_server.get_service")
+    @patch("src.settings.service.get_settings_service")
+    @patch("src.config.Config")
+    def test_colour_marker_costs_one_tile_when_wrapping(self, mock_config, get_settings, get_service, handler):
+        """Wrapping counts flaps: "{red} TACO TUESDAY" is 14 tiles and fits
+        one 15-wide Note row even though it is 18 characters."""
+        board_array = self._send(handler, get_settings, get_service, mock_config, "{red} TACO TUESDAY")
+        assert board_array[0][0] == 63  # red tile
+        assert _row_text(board_array[0]) == "  TACO TUESDAY"
+        assert _row_text(board_array[1]) == ""
+
+    @patch("src.api_server.get_service")
+    @patch("src.settings.service.get_settings_service")
+    @patch("src.config.Config")
+    def test_escaped_backslash_n_stays_literal(self, mock_config, get_settings, get_service, handler):
+        """``\\\\n`` is the escape hatch for text that really contains a
+        backslash before an N (issue #1793 review)."""
+        board_array = self._send(handler, get_settings, get_service, mock_config, "C:\\\\new")
+        # One row: "C:" + an unmappable backslash (space) + "NEW" — the N survives.
+        assert _row_text(board_array[0]) == "C  NEW"
+        assert _row_text(board_array[1]) == ""
+
+    @patch("src.api_server.get_service")
+    @patch("src.settings.service.get_settings_service")
+    @patch("src.config.Config")
+    def test_json_payload_does_not_unescape_backslash_n(self, mock_config, get_settings, get_service, handler):
+        """JSON payloads can already carry a real newline, so the escape
+        substitution is confined to the plain-string (HA text entity) path."""
+        mock_config.is_silence_mode_active.return_value = False
+        get_settings.return_value = self._settings_with_note_primary()
+        service = MagicMock()
+        b1_client = MagicMock()
+        service.get_board_client.return_value = b1_client
+        get_service.return_value = service
+        # Raw MQTT payload: {"message": "HI\\nTHERE", "board": "Desk"}
+        handler.handle("send_message", '{"message": "HI\\\\nTHERE", "board": "Desk"}')
+        board_array = b1_client.send_characters.call_args[0][0]
+        assert _row_text(board_array[0]) == "HI NTHERE"
+        assert _row_text(board_array[1]) == ""
+
+    @patch("src.api_server.get_service")
+    @patch("src.settings.service.get_settings_service")
+    @patch("src.config.Config")
+    def test_long_word_hard_breaks_instead_of_vanishing(self, mock_config, get_settings, get_service, handler):
+        board_array = self._send(handler, get_settings, get_service, mock_config, "SUPERCALIFRAGILISTIC")
+        assert _row_text(board_array[0]) == "SUPERCALIFRAGIL"
+        assert _row_text(board_array[1]) == "ISTIC"

--- a/tests/test_mqtt_commands.py
+++ b/tests/test_mqtt_commands.py
@@ -537,3 +537,99 @@ class TestCommandHandlerPerBoardRouting:
         handler.handle("active_page", "Weather")
 
         settings.set_active_page_id.assert_called_once_with("page-weather-id")
+
+
+def _row_text(row):
+    """Decode a board row of character codes back to letters/spaces."""
+    return "".join(chr(ord("A") + code - 1) if 1 <= code <= 26 else " " for code in row).rstrip()
+
+
+class TestCommandHandlerSendMessageWrapping:
+    """Issue #1793: send_message must use the target board's real geometry
+    and word-wrap long text instead of running off the first row."""
+
+    @staticmethod
+    def _settings_with_note_primary():
+        settings = MagicMock()
+        board_settings = MagicMock()
+        board_settings.boards = [
+            {"id": "b1", "name": "Desk", "device_type": "note", "notes_wide": 1, "notes_tall": 1},
+        ]
+        settings.get_board_settings.return_value = board_settings
+        settings.get_primary_board_id.return_value = "b1"
+        settings.should_send_to_board.return_value = True
+        settings.is_paused.return_value = False
+        settings.get_transition_settings.return_value = MagicMock(strategy="column", step_interval_ms=100, step_size=1)
+        return settings
+
+    def _send(self, handler, get_settings, get_service, mock_config, payload):
+        mock_config.is_silence_mode_active.return_value = False
+        get_settings.return_value = self._settings_with_note_primary()
+        service = MagicMock()
+        get_service.return_value = service
+        handler.handle("send_message", payload)
+        service.vb_client.send_characters.assert_called_once()
+        return service.vb_client.send_characters.call_args[0][0]
+
+    @patch("src.api_server.get_service")
+    @patch("src.settings.service.get_settings_service")
+    @patch("src.config.Config")
+    def test_plain_payload_sized_to_primary_note_board(self, mock_config, get_settings, get_service, handler):
+        """A plain-string payload gets a 3x15 grid on a Note, not flagship 6x22."""
+        board_array = self._send(handler, get_settings, get_service, mock_config, "HELLO")
+        assert len(board_array) == 3
+        assert len(board_array[0]) == 15
+
+    @patch("src.api_server.get_service")
+    @patch("src.settings.service.get_settings_service")
+    @patch("src.config.Config")
+    def test_long_message_wraps_at_word_boundaries(self, mock_config, get_settings, get_service, handler):
+        board_array = self._send(handler, get_settings, get_service, mock_config, "TACO TUESDAY PARTY TIME")
+        assert _row_text(board_array[0]) == "TACO TUESDAY"
+        assert _row_text(board_array[1]) == "PARTY TIME"
+
+    @patch("src.api_server.get_service")
+    @patch("src.settings.service.get_settings_service")
+    @patch("src.config.Config")
+    def test_explicit_newline_breaks_line(self, mock_config, get_settings, get_service, handler):
+        board_array = self._send(handler, get_settings, get_service, mock_config, "HI\nTHERE")
+        assert _row_text(board_array[0]) == "HI"
+        assert _row_text(board_array[1]) == "THERE"
+
+    @patch("src.api_server.get_service")
+    @patch("src.settings.service.get_settings_service")
+    @patch("src.config.Config")
+    def test_literal_backslash_n_breaks_line(self, mock_config, get_settings, get_service, handler):
+        """The two-character sequence backslash-n acts as a line break so
+        single-line clients (HA text entities) can request one."""
+        board_array = self._send(handler, get_settings, get_service, mock_config, "HI\\nTHERE")
+        assert _row_text(board_array[0]) == "HI"
+        assert _row_text(board_array[1]) == "THERE"
+
+    @patch("src.api_server.get_service")
+    @patch("src.settings.service.get_settings_service")
+    @patch("src.config.Config")
+    def test_text_beyond_rows_truncates_predictably(self, mock_config, get_settings, get_service, handler):
+        board_array = self._send(
+            handler, get_settings, get_service, mock_config, "AAAA BBBB CCCC DDDD EEEE FFFF GGGG HHHH IIII JJJJ"
+        )
+        assert len(board_array) == 3
+        assert _row_text(board_array[0]) == "AAAA BBBB CCCC"
+        assert _row_text(board_array[1]) == "DDDD EEEE FFFF"
+        assert _row_text(board_array[2]) == "GGGG HHHH IIII"
+
+    @patch("src.api_server.get_service")
+    @patch("src.settings.service.get_settings_service")
+    @patch("src.config.Config")
+    def test_json_payload_to_named_board_also_wraps(self, mock_config, get_settings, get_service, handler):
+        """The board-targeted JSON path wraps too, at that board's width."""
+        mock_config.is_silence_mode_active.return_value = False
+        get_settings.return_value = self._settings_with_note_primary()
+        service = MagicMock()
+        b1_client = MagicMock()
+        service.get_board_client.return_value = b1_client
+        get_service.return_value = service
+        handler.handle("send_message", '{"message": "TACO TUESDAY PARTY TIME", "board": "Desk"}')
+        board_array = b1_client.send_characters.call_args[0][0]
+        assert _row_text(board_array[0]) == "TACO TUESDAY"
+        assert _row_text(board_array[1]) == "PARTY TIME"

--- a/tests/test_mqtt_discovery.py
+++ b/tests/test_mqtt_discovery.py
@@ -522,6 +522,24 @@ class TestBuildAllDiscoveryMessages:
         topics = [msg["topic"] for msg in messages]
         assert len(topics) == len(set(topics)), "Duplicate topics found"
 
+    @staticmethod
+    def _send_message_payload(messages):
+        for msg in messages:
+            payload = json.loads(msg["payload"])
+            if payload.get("unique_id", "").endswith("_send_message"):
+                return payload
+        raise AssertionError("no send_message discovery message")
+
+    def test_send_message_max_length_defaults_to_flagship_capacity(self, mqtt_config):
+        """Without a resolved board, keep the historical 6x22 = 132 default."""
+        messages = build_all_discovery_messages(mqtt_config)
+        assert self._send_message_payload(messages)["max"] == 132
+
+    def test_send_message_max_length_follows_the_board(self, mqtt_config):
+        """A Note holds 3x15 = 45 characters, not 132 (issue #1793 review)."""
+        messages = build_all_discovery_messages(mqtt_config, max_message_length=45)
+        assert self._send_message_payload(messages)["max"] == 45
+
     def test_custom_instance_id(self):
         """Custom instance ID should be reflected in all payloads."""
         config = MQTTConfig(

--- a/tests/test_text_to_board.py
+++ b/tests/test_text_to_board.py
@@ -4,6 +4,8 @@ text_to_board contains pure, deterministic conversion logic — character
 mapping and board array construction. This addresses issue #505.
 """
 
+import logging
+
 from src.board_chars import BoardChars
 from src.text_to_board import (
     COLOR_CODES,
@@ -444,10 +446,6 @@ class TestWrapMessageText:
         result = wrap_message_text("HI\nTACO TUESDAY PARTY TIME", rows=6, cols=15)
         assert result == "HI\nTACO TUESDAY\nPARTY TIME"
 
-    def test_literal_backslash_n_becomes_line_break(self):
-        result = wrap_message_text("HI\\nTHERE", rows=3, cols=15)
-        assert result == "HI\nTHERE"
-
     def test_truncates_wrapped_output_to_rows(self):
         result = wrap_message_text("AAAA BBBB CCCC DDDD EEEE FFFF GGGG HHHH IIII JJJJ", rows=3, cols=15)
         assert result == "AAAA BBBB CCCC\nDDDD EEEE FFFF\nGGGG HHHH IIII"
@@ -455,3 +453,85 @@ class TestWrapMessageText:
     def test_truncates_explicit_lines_to_rows(self):
         result = wrap_message_text("A\nB\nC\nD", rows=3, cols=15)
         assert result == "A\nB\nC"
+
+
+class TestWrapMessageTextMeasuresTilesNotCharacters:
+    """Wrapping must count flaps. ``{red}`` writes five characters but
+    occupies one tile, and ``{/green}`` occupies none (issue #1793 review)."""
+
+    def test_colour_marker_line_that_fits_stays_on_one_row(self):
+        # "{red} TACO TUESDAY" is 18 characters but only 14 tiles, so it
+        # fits a 15-wide Note row without wrapping.
+        assert wrap_message_text("{red} TACO TUESDAY", rows=3, cols=15) == "{red} TACO TUESDAY"
+
+    def test_closing_tag_costs_no_flaps_so_the_row_is_filled(self):
+        # "{green}HI{/green} TACO" is 8 tiles; "TUESDAY" pushes it to 16,
+        # so only TUESDAY moves down.
+        result = wrap_message_text("{green}HI{/green} TACO TUESDAY", rows=3, cols=15)
+        assert result == "{green}HI{/green} TACO\nTUESDAY"
+
+    def test_numeric_marker_counted_as_one_tile(self):
+        assert wrap_message_text("{63}{64}{65} HELLO WORLD", rows=3, cols=15) == "{63}{64}{65} HELLO WORLD"
+
+
+class TestWrapMessageTextLongWords:
+    """A word wider than the board is hard-broken across rows instead of
+    being silently cut mid-word (issue #1793 review)."""
+
+    def test_long_word_hard_breaks_onto_the_next_row(self):
+        result = wrap_message_text("SEE HTTPS://EXAMPLE.COM/VERYLONGPATH", rows=6, cols=22)
+        assert result == "SEE\nHTTPS://EXAMPLE.COM/VE\nRYLONGPATH"
+
+    def test_hard_break_never_splits_a_colour_marker(self):
+        # 21 tiles of A, then a marker: the marker cannot straddle the break.
+        result = wrap_message_text("A" * 21 + "{red}" + "B" * 4, rows=6, cols=22)
+        assert result == "A" * 21 + "{red}\n" + "B" * 4
+
+    def test_word_exactly_board_width_is_not_broken(self):
+        assert wrap_message_text("A" * 22, rows=6, cols=22) == "A" * 22
+
+
+class TestWrapMessageTextWhitespaceLines:
+    def test_whitespace_only_long_line_keeps_its_row(self):
+        # A blank spacer line longer than the board used to yield zero lines
+        # and eat a row (issue #1793 review).
+        result = wrap_message_text("TOP\n" + " " * 40 + "\nBOTTOM", rows=6, cols=22)
+        assert result == "TOP\n\nBOTTOM"
+
+
+class TestWrapMessageTextBackslashes:
+    """``\\n`` unescaping is opt-in, and has an escape hatch when on."""
+
+    def test_backslash_text_is_untouched_by_default(self):
+        assert wrap_message_text("C:\\new", rows=6, cols=22) == "C:\\new"
+
+    def test_backslash_text_is_untouched_by_default_mid_sentence(self):
+        assert wrap_message_text("GO \\north 5 MILES", rows=6, cols=22) == "GO \\north 5 MILES"
+
+    def test_opt_in_unescape_turns_backslash_n_into_a_line_break(self):
+        result = wrap_message_text("HI\\nTHERE", rows=3, cols=15, unescape_newlines=True)
+        assert result == "HI\nTHERE"
+
+    def test_doubled_backslash_is_the_escape_hatch_for_a_literal(self):
+        # Typing C:\\new asks for the literal text C:\new.
+        result = wrap_message_text("C:\\\\new", rows=6, cols=22, unescape_newlines=True)
+        assert result == "C:\\new"
+
+    def test_other_backslash_sequences_pass_through_when_unescaping(self):
+        result = wrap_message_text("C:\\temp", rows=6, cols=22, unescape_newlines=True)
+        assert result == "C:\\temp"
+
+
+class TestWrapMessageTextOverflowIsLogged:
+    """Content that does not fit is dropped, but no longer silently."""
+
+    def test_dropped_rows_are_logged(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="src.text_to_board"):
+            wrap_message_text("A\nB\nC\nD", rows=3, cols=15)
+        warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+        assert any("too long" in msg.lower() for msg in warnings), warnings
+
+    def test_no_warning_when_everything_fits(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="src.text_to_board"):
+            wrap_message_text("A\nB\nC", rows=3, cols=15)
+        assert [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING] == []

--- a/tests/test_text_to_board.py
+++ b/tests/test_text_to_board.py
@@ -10,6 +10,7 @@ from src.text_to_board import (
     format_board_array_preview,
     text_to_board_array,
     validate_board_array,
+    wrap_message_text,
 )
 
 # ---------------------------------------------------------------------------
@@ -424,3 +425,33 @@ class TestNoteFillSpaceEndToEnd:
         assert board[0][0] == 1  # A
         assert board[0][1] == 71  # filled
         assert board[0][2] == 2  # B
+
+
+# ---------------------------------------------------------------------------
+# wrap_message_text — free-form message preparation (issue #1793)
+# ---------------------------------------------------------------------------
+
+
+class TestWrapMessageText:
+    def test_short_text_unchanged(self):
+        assert wrap_message_text("HELLO", rows=3, cols=15) == "HELLO"
+
+    def test_wraps_long_line_at_word_boundaries(self):
+        result = wrap_message_text("TACO TUESDAY PARTY TIME", rows=3, cols=15)
+        assert result == "TACO TUESDAY\nPARTY TIME"
+
+    def test_explicit_newlines_preserved_and_wrapping_fills_within(self):
+        result = wrap_message_text("HI\nTACO TUESDAY PARTY TIME", rows=6, cols=15)
+        assert result == "HI\nTACO TUESDAY\nPARTY TIME"
+
+    def test_literal_backslash_n_becomes_line_break(self):
+        result = wrap_message_text("HI\\nTHERE", rows=3, cols=15)
+        assert result == "HI\nTHERE"
+
+    def test_truncates_wrapped_output_to_rows(self):
+        result = wrap_message_text("AAAA BBBB CCCC DDDD EEEE FFFF GGGG HHHH IIII JJJJ", rows=3, cols=15)
+        assert result == "AAAA BBBB CCCC\nDDDD EEEE FFFF\nGGGG HHHH IIII"
+
+    def test_truncates_explicit_lines_to_rows(self):
+        result = wrap_message_text("A\nB\nC\nD", rows=3, cols=15)
+        assert result == "A\nB\nC"


### PR DESCRIPTION
Closes #1793.

A plain-string `send_message` payload (what Home Assistant's text entity publishes) fell back to the Flagship 6x22 grid even on a Note, so columns 16+ vanished. Neither send path wrapped long text — everything past the board width was silently truncated on row 1.

- MQTT `_handle_send_message` resolves the target board's real dimensions for plain payloads
- New shared `wrap_message_text()` in `src/text_to_board.py`, used by both the MQTT and HTTP paths
- `text_to_board_array`'s contract is unchanged (its body is untouched vs `main`)
- Docs: corrects the `/send-message` example field name (`message` → `text`) and documents wrap/line-break behavior

## Review follow-up (second commit)

### 1. Wrapping now measures tiles, not characters

Counting characters spent five flaps of budget on `{red}` and eight on `{/green}`, so text that fit was wrapped anyway. `count_tiles()` and a new `take_tiles()` moved from `src/plugins/previews.py` to sit beside `COLOR_MARKER_PATTERN` in `src/text_to_board.py` (re-exported from `previews` for existing importers), and `MessageFormatter.split_into_lines` measures in tiles.

<details><summary>Pre-fix failures</summary>

```
_ TestWrapMessageTextMeasuresTilesNotCharacters.test_colour_marker_line_that_fits_stays_on_one_row _
    assert wrap_message_text("{red} TACO TUESDAY", rows=3, cols=15) == "{red} TACO TUESDAY"
E   AssertionError: assert '{red} TACO\nTUESDAY' == '{red} TACO TUESDAY'
E     - {red} TACO TUESDAY
E     + {red} TACO
E     + TUESDAY
_ TestWrapMessageTextMeasuresTilesNotCharacters.test_closing_tag_costs_no_flaps_so_the_row_is_filled _
    assert result == "{green}HI{/green} TACO\nTUESDAY"
E   AssertionError: assert '{green}HI{/g...nTACO TUESDAY' == '{green}HI{/g...TACO\nTUESDAY'
E     - {green}HI{/green} TACO
E     + {green}HI{/green}
E     - TUESDAY
E     + TACO TUESDAY
_ TestWrapMessageTextMeasuresTilesNotCharacters.test_numeric_marker_counted_as_one_tile _
    assert wrap_message_text("{63}{64}{65} HELLO WORLD", rows=3, cols=15) == "{63}{64}{65} HELLO WORLD"
E   AssertionError: assert '{63}{64}{65}\nHELLO WORLD' == '{63}{64}{65} HELLO WORLD'
_ TestSplitIntoLinesTileWidth.test_colour_marker_costs_one_tile_not_five_characters _
E   AssertionError: assert ['{red} TACO', 'TUESDAY'] == ['{red} TACO TUESDAY']
_ TestSplitIntoLinesTileWidth.test_closing_tag_costs_no_tiles _
E   AssertionError: At index 0 diff: '{green}HI{/green}' != '{green}HI{/green} TACO'
```
</details>

### 2. `\n` unescaping is now opt-in and confined to the MQTT plain-string path

**Decision.** The unconditional `text.replace("\\n", "\n")` deleted the `N` out of legitimate text (`C:\new` → `C:` / `EW`, plus an injected row break) across all of `/send-message`, with no escape hatch. Two things changed:

- **Blast radius.** The substitution now applies only to the *legacy plain-string* MQTT `send_message` payload — the single-line HA text entity that cannot type a newline, which is exactly what #1793 reported. The HTTP JSON body and JSON MQTT payloads can carry a real newline already, so they need no shorthand and keep their **exact pre-#1793 rendering** (asserted by comparing the sent array against `text_to_board_array("C:\\new", ...)`).
- **Escape hatch.** On the one path that does unescape, `\\n` collapses to a literal backslash-n, and every other backslash sequence (`C:\temp`) passes through untouched.

`GO \north 5 MILES` typed into the HA text entity still breaks — that is the unavoidable cost of a `\n` shorthand — but it is now escapable as `GO \\north 5 MILES`, and it no longer affects any other caller.

<details><summary>Pre-fix failures</summary>

```
_ TestWrapMessageTextBackslashes.test_backslash_text_is_untouched_by_default _
    assert wrap_message_text("C:\\new", rows=6, cols=22) == "C:\\new"
E   AssertionError: assert 'C:\new' == 'C:\\new'
_ TestWrapMessageTextBackslashes.test_backslash_text_is_untouched_by_default_mid_sentence _
    assert wrap_message_text("GO \\north 5 MILES", rows=6, cols=22) == "GO \\north 5 MILES"
E   AssertionError: assert 'GO \north 5 MILES' == 'GO \\north 5 MILES'
E     + GO
E     + orth 5 MILES
_ TestWrapMessageTextBackslashes.test_doubled_backslash_is_the_escape_hatch_for_a_literal _
E   TypeError: wrap_message_text() got an unexpected keyword argument 'unescape_newlines'
```

Non-vacuity of the gate — flipping `unescape_newlines=self._json_object(payload) is None` to `True`:

```
_ TestCommandHandlerSendMessageWrapping.test_json_payload_does_not_unescape_backslash_n _
    assert _row_text(board_array[0]) == "HI NTHERE"
E   AssertionError: assert 'HI' == 'HI NTHERE'
```
</details>

### 3. Long words hard-break instead of vanishing

`.COM/VERYLONGPATH` used to disappear past the column limit while a later row sat empty, contradicting the "wraps automatically" docs this PR adds. `split_into_lines` now flows an over-wide word onto further rows, and `take_tiles` guarantees the break never lands inside a colour marker.

<details><summary>Pre-fix failures</summary>

```
_ TestSplitIntoLinesLongWords.test_over_long_word_is_hard_broken _
E   AssertionError: At index 1 diff: 'HTTPS://EXAMPLE.COM/VERYLONGPATH' != 'HTTPS://EXAMPLE.COM/VE'
E     Right contains one more item: 'RYLONGPATH'
_ TestSplitIntoLinesLongWords.test_hard_break_does_not_split_a_colour_marker _
E   AssertionError: At index 0 diff: 'AAAAAAAAAAAAAAAAAAAAA{red}BBBB' != 'AAAAAAAAAAAAAAAAAAAAA{red}'
_ TestSplitIntoLinesLongWords.test_every_returned_line_fits_the_board _
E   AssertionError: assert 100 <= 22
E    +  where 100 = count_tiles('XXXX...')
```
</details>

### 4. A whitespace-only over-wide line no longer eats a row

`line.split()` returned no words, so the branch appended nothing and everything below shifted up.

```
_ TestSplitIntoLinesWhitespaceOnly.test_long_whitespace_line_still_yields_a_row _
    assert fmt.split_into_lines("TOP\n" + " " * 40 + "\nBOTTOM") == ["TOP", "", "BOTTOM"]
E   AssertionError: assert ['TOP', 'BOTTOM'] == ['TOP', '', 'BOTTOM']
```

### 5. Overflow is signalled; discovery advertises the real capacity

`wrap_message_text` logs a warning naming the board geometry and the row it truncated at. `build_all_discovery_messages` takes `max_message_length` and `MQTTClient._publish_discovery` derives it from the primary board (`rows * cols`), so a Note owner sees 45 instead of the hardcoded flagship 132.

```
_ TestBuildAllDiscoveryMessages.test_send_message_max_length_follows_the_board _
    messages = build_all_discovery_messages(mqtt_config, max_message_length=45)
E   TypeError: build_all_discovery_messages() got an unexpected keyword argument 'max_message_length'
_ TestWrapMessageTextOverflowIsLogged.test_dropped_rows_are_logged _
    assert any("too long" in msg.lower() for msg in warnings), warnings
E   AssertionError: []
```

## Status

Rebased on current `main`. `5264 passed, 1 skipped` (`tests/test_check_image_formats.py::TestRepositoryIsClean` deselected — it shells out to `git ls-files`, which cannot run inside the test container). `ruff 0.16.4` check + format clean.

19 new/changed tests went red → green; the verbatim pre-fix output for each is above.
