### PR TITLE
fix(mqtt): sync active-page state after out-of-band board writes

### DIFF
--- a/docs/features/home-assistant-control.md
+++ b/docs/features/home-assistant-control.md
@@ -112,7 +112,7 @@ will not paint over them on its next cycle. Put the active page back with
 **Refresh Display**, by selecting a page, or by letting that page's content
 change on its own. (The Active Page and Current Page entities still report the
 configured page, not the manual message — tracked separately in
-[#1794](https://github.com/Fiestaboard/FiestaBoard/issues/1794).)
+[#1831](https://github.com/Fiestaboard/FiestaBoard/issues/1831).)
 
 **Send Message formatting:** text longer than the board width word-wraps onto
 the following rows automatically, sized to your board's real geometry (6 rows ×

--- a/docs/features/home-assistant-control.md
+++ b/docs/features/home-assistant-control.md
@@ -97,14 +97,22 @@ Once connected, FiestaBoard appears as a device with **24 entities** — control
 |--------|------|-------------|
 | **Schedule** | Switch | Turn the FiestaBoard schedule on/off |
 | **Display Service** | Switch | Start/stop the FiestaBoard display service |
-| **Active Page** | Select | Choose which page to display (dynamically populated from your pages) |
+| **Active Page** | Select | Choose which page to display (dynamically populated from your pages). Selecting a page always re-sends it, even if it is already the active page — that is how you put the page back after a manual message. The list also carries a `None` option so "no page is active" is a state HA can show; as a *command* it only applies to secondary boards, since the primary board never goes dark. |
 | **Transition Style** | Select | Board transition animation (column, reverse-column, edges-to-center, row, diagonal, random) |
 | **Send Message** | Text | Send a text message to the board (up to 132 characters) |
-| **Refresh Display** | Button | Force a display refresh |
+| **Refresh Display** | Button | Force a display refresh. This is a *force* refresh: unchanged content is re-sent, so it restores the active page after something else wrote to the board. |
 | **Blank Board** | Button | Clear the board display (all blank) |
 | **Next Page** | Button | Navigate to the next page in the page list (wraps around) |
 | **Previous Page** | Button | Navigate to the previous page in the page list (wraps around) |
 | **Refresh Interval** | Number | Set how often the board refreshes (30–3600 seconds). *Categorized as config.* |
+
+**Manual writes stay on the board.** Send Message, Blank Board and the debug
+endpoints write straight to the board and are left there — the display loop
+will not paint over them on its next cycle. Put the active page back with
+**Refresh Display**, by selecting a page, or by letting that page's content
+change on its own. (The Active Page and Current Page entities still report the
+configured page, not the manual message — tracked separately in
+[#1794](https://github.com/Fiestaboard/FiestaBoard/issues/1794).)
 
 **Send Message formatting:** text longer than the board width word-wraps onto
 the following rows automatically, sized to your board's real geometry (6 rows ×

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -1069,24 +1069,6 @@ def _publish_mqtt_state_update() -> None:
         logger.debug(f"MQTT state publish after board write failed: {e}")
 
 
-def _invalidate_primary_board_content() -> None:
-    """Clear the display loop's dedupe caches after an out-of-band write to
-    the primary board (issue #1794), so the next cycle restores the active
-    page instead of skipping at the content-unchanged guard.
-    """
-    service = peek_service()
-    if service is None:
-        return
-    try:
-        board_id = get_settings_service().get_primary_board_id()
-    except Exception:
-        board_id = None
-    try:
-        service.invalidate_board_content(board_id)
-    except Exception as e:
-        logger.debug(f"Board content invalidation failed: {e}")
-
-
 def run_service_background():
     """Run the service in a background thread with auto-restart on failure."""
     global _service_running, _service_start_time
@@ -3605,13 +3587,12 @@ async def send_message(request: MessageRequest):
         )
         if success:
             if was_sent:
-                # Out-of-band write (issue #1794): clear the display loop's
-                # dedupe caches so the active page can be restored, and push
-                # fresh MQTT state so HA reflects the update.
-                try:
-                    service.invalidate_board_content(settings_service.get_primary_board_id())
-                except Exception as e:
-                    logger.debug(f"Board content invalidation failed: {e}")
+                # Push fresh MQTT state so HA reflects the update. The
+                # display loop's dedupe cache is deliberately left alone:
+                # invalidating it here made the message self-destruct on the
+                # next engine tick (<=15s). Restoring the active page is a
+                # pull — /force-refresh, MQTT Refresh Display, re-selecting
+                # a page, or an actual content change (issue #1794).
                 _publish_mqtt_state_update()
                 service.request_board_refresh()
                 return {"status": "success", "message": "Message sent successfully"}
@@ -7516,9 +7497,6 @@ async def debug_blank_board():
         success, was_sent = client.send_characters(blank_array, force=True)
 
         if success:
-            # Out-of-band write (issue #1794): let the display loop restore
-            # the active page on its next cycle.
-            _invalidate_primary_board_content()
             return {"status": "success", "message": "Board blanked successfully"}
         else:
             raise HTTPException(status_code=500, detail="Failed to blank board")
@@ -7563,9 +7541,6 @@ async def debug_fill_board(request: dict):
         success, was_sent = client.send_characters(fill_array, force=True)
 
         if success:
-            # Out-of-band write (issue #1794): let the display loop restore
-            # the active page on its next cycle.
-            _invalidate_primary_board_content()
             return {"status": "success", "message": f"Board filled with character {character_code}"}
         else:
             raise HTTPException(status_code=500, detail="Failed to fill board")
@@ -7635,9 +7610,6 @@ V{version[:7]} {timestamp}"""
         success, was_sent = client.send_characters(board_array, force=True)
 
         if success:
-            # Out-of-band write (issue #1794): let the display loop restore
-            # the active page on its next cycle.
-            _invalidate_primary_board_content()
             return {"status": "success", "message": "Debug info sent to board", "debug_info": debug_text}
         else:
             raise HTTPException(status_code=500, detail="Failed to send debug info")
@@ -9358,6 +9330,13 @@ async def force_refresh():
         service.vb_client.clear_cache()
     for client in service.board_clients.values():
         client.clear_cache()
+    # The board clients are only half of it: the display loop skips at its
+    # own per-runtime content-dedupe guard, so clearing the client caches
+    # alone left "Resend to board" doing nothing (issue #1794).
+    try:
+        service.invalidate_all_board_content()
+    except Exception as e:
+        logger.debug(f"Board content invalidation failed: {e}")
 
     try:
         sent, error = _send_with_status(

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -1039,6 +1039,54 @@ def get_service() -> DisplayService | None:
     return _service
 
 
+def peek_service() -> DisplayService | None:
+    """Return the existing DisplayService instance without creating one.
+
+    For callers that only need to touch state that already exists (e.g.
+    invalidating dedupe caches after an out-of-band board write, issue
+    #1794): when no service exists there is nothing to invalidate, and
+    building one as a side effect would be wrong.
+    """
+    return _service
+
+
+def _publish_mqtt_state_update() -> None:
+    """Push fresh MQTT state after an out-of-band board write (issue #1794).
+
+    No-op when the MQTT integration isn't wired. Errors are swallowed —
+    MQTT reporting must never fail the board write that triggered it.
+    """
+    try:
+        from .mqtt import get_mqtt_client
+
+        client = get_mqtt_client()
+        publisher = getattr(client, "_state_publisher", None) if client else None
+        if publisher is None:
+            return
+        publisher.mark_display_updated()
+        publisher.gather_and_publish()
+    except Exception as e:
+        logger.debug(f"MQTT state publish after board write failed: {e}")
+
+
+def _invalidate_primary_board_content() -> None:
+    """Clear the display loop's dedupe caches after an out-of-band write to
+    the primary board (issue #1794), so the next cycle restores the active
+    page instead of skipping at the content-unchanged guard.
+    """
+    service = peek_service()
+    if service is None:
+        return
+    try:
+        board_id = get_settings_service().get_primary_board_id()
+    except Exception:
+        board_id = None
+    try:
+        service.invalidate_board_content(board_id)
+    except Exception as e:
+        logger.debug(f"Board content invalidation failed: {e}")
+
+
 def run_service_background():
     """Run the service in a background thread with auto-restart on failure."""
     global _service_running, _service_start_time
@@ -3557,6 +3605,14 @@ async def send_message(request: MessageRequest):
         )
         if success:
             if was_sent:
+                # Out-of-band write (issue #1794): clear the display loop's
+                # dedupe caches so the active page can be restored, and push
+                # fresh MQTT state so HA reflects the update.
+                try:
+                    service.invalidate_board_content(settings_service.get_primary_board_id())
+                except Exception as e:
+                    logger.debug(f"Board content invalidation failed: {e}")
+                _publish_mqtt_state_update()
                 service.request_board_refresh()
                 return {"status": "success", "message": "Message sent successfully"}
             else:
@@ -7460,6 +7516,9 @@ async def debug_blank_board():
         success, was_sent = client.send_characters(blank_array, force=True)
 
         if success:
+            # Out-of-band write (issue #1794): let the display loop restore
+            # the active page on its next cycle.
+            _invalidate_primary_board_content()
             return {"status": "success", "message": "Board blanked successfully"}
         else:
             raise HTTPException(status_code=500, detail="Failed to blank board")
@@ -7504,6 +7563,9 @@ async def debug_fill_board(request: dict):
         success, was_sent = client.send_characters(fill_array, force=True)
 
         if success:
+            # Out-of-band write (issue #1794): let the display loop restore
+            # the active page on its next cycle.
+            _invalidate_primary_board_content()
             return {"status": "success", "message": f"Board filled with character {character_code}"}
         else:
             raise HTTPException(status_code=500, detail="Failed to fill board")
@@ -7573,6 +7635,9 @@ V{version[:7]} {timestamp}"""
         success, was_sent = client.send_characters(board_array, force=True)
 
         if success:
+            # Out-of-band write (issue #1794): let the display loop restore
+            # the active page on its next cycle.
+            _invalidate_primary_board_content()
             return {"status": "success", "message": "Debug info sent to board", "debug_info": debug_text}
         else:
             raise HTTPException(status_code=500, detail="Failed to send debug info")

--- a/src/board_client.py
+++ b/src/board_client.py
@@ -381,9 +381,25 @@ class BoardClient(TransitionRenderMixin):
         self._is_note_array: bool = bool(note_array_token)
         # Injectable monotonic clock for the note-array send throttle (tests).
         self._time_func: Callable[[], float] = _time_func if _time_func is not None else _time_module.monotonic
+        # Whether the most recent send_characters call was dropped by the
+        # note-array rate limit (see the last_send_throttled property).
+        self._last_send_throttled: bool = False
 
         # Transition-plugin render state (lock, cancel event, runner slot).
         self._init_transition_state()
+
+    @property
+    def last_send_throttled(self) -> bool:
+        """True when the most recent send was dropped by the note-array rate limit.
+
+        That drop reports ``(True, False)`` — byte-identical to the
+        unchanged-content skip — but the two mean opposite things: after an
+        unchanged-content skip the frame IS on the board, whereas after a
+        throttle it never left. Callers that cache "what the board is
+        showing" must not do so on a throttle, or the board stays stale
+        forever because nothing re-attempts unchanged content (issue #1794).
+        """
+        return self._last_send_throttled
 
     @property
     def min_send_interval_ms(self) -> int:
@@ -513,6 +529,8 @@ class BoardClient(TransitionRenderMixin):
             step_interval_ms = None
             step_size = None
 
+        self._last_send_throttled = False
+
         # Rate-limit note-array sends to >= NOTE_ARRAY_MIN_SEND_INTERVAL seconds.
         # Read the clock once and reuse it for the success-path timestamp below.
         # The check+update below is not locked: FiestaBoard's send paths run on a
@@ -529,6 +547,7 @@ class BoardClient(TransitionRenderMixin):
                         elapsed,
                         NOTE_ARRAY_MIN_SEND_INTERVAL,
                     )
+                    self._last_send_throttled = True
                     return (True, False)
 
         # Check if characters have changed (client-side caching)

--- a/src/main.py
+++ b/src/main.py
@@ -572,6 +572,16 @@ class DisplayService:
         if rt.client is not None:
             rt.client.clear_cache()
 
+    def invalidate_all_board_content(self) -> None:
+        """Invalidate every board's dedupe + client caches (issue #1794).
+
+        Used by force-refresh paths (e.g. the MQTT "Refresh Display" button)
+        so the next check-and-send cycle unconditionally re-sends each
+        board's content instead of skipping at the content-dedupe guard.
+        """
+        for board_id in list(self.runtimes):
+            self.invalidate_board_content(board_id)
+
     # ------------------------------------------------------------------ #
     # Board-state polling (primary board only; state lives on the runtime)
     # ------------------------------------------------------------------ #

--- a/src/main.py
+++ b/src/main.py
@@ -1103,9 +1103,24 @@ class DisplayService:
             )
 
             if success:
+                # A note-array send dropped by NOTE_ARRAY_MIN_SEND_INTERVAL
+                # reports success with was_sent=False, exactly like an
+                # unchanged-content skip — but the content never reached the
+                # board. Caching it here would strand the board on the
+                # previous frame permanently, because no later tick
+                # re-attempts unchanged content (issue #1794). Keep the
+                # silence latch (#1817) either way, then leave the dedupe
+                # cache clear so the next tick retries.
+                rt.last_silence_mode_active = silence_mode_active
+                if getattr(rt.client, "last_send_throttled", False) is True:
+                    logger.warning(
+                        "Board %s: send throttled and did not reach the board; "
+                        "leaving dedupe cache clear so the next tick retries",
+                        board_id,
+                    )
+                    return False
                 rt.last_active_page_content = current_content
                 rt.last_active_page_id = active_page_id
-                rt.last_silence_mode_active = silence_mode_active
                 if was_sent:
                     logger.info(f"Board {board_id}: active page sent: {active_page_id}")
                     # Board-state adaptive refresh is primary-only (see

--- a/src/mqtt/commands.py
+++ b/src/mqtt/commands.py
@@ -289,13 +289,28 @@ class CommandHandler:
         from .discovery import NO_ACTIVE_PAGE_OPTION
 
         if payload_lower == NO_ACTIVE_PAGE_OPTION.lower():
-            # The HA select's stable no-page option (issue #1794): clear the
-            # board's manual active page. (A real page named like the option
-            # wins — the name match above runs first.)
-            if board_id is not None:
-                get_settings_service().set_active_page_id(None, board_id=board_id)
+            # The HA select's stable no-page option (issue #1794). It exists
+            # so an empty active page is a *representable state* — HA rejects
+            # published states that aren't in the options list.
+            #
+            # As a command it only works on a secondary board, which goes
+            # dark when no page is set. The primary never goes dark:
+            # check_and_send_for_board re-defaults it to pages[0] and
+            # persists that on the next tick, so accepting the selection here
+            # would just make the select bounce back within one polling
+            # interval. Refuse it instead; handle()'s trailing
+            # gather_and_publish re-publishes the real state, so the select
+            # snaps back immediately rather than lying for 15 seconds.
+            # (A real page named like the option wins — the name match above
+            # runs first.)
+            settings_service = get_settings_service()
+            if board_id is not None and board_id != settings_service.get_primary_board_id():
+                settings_service.set_active_page_id(None, board_id=board_id)
             else:
-                get_settings_service().set_active_page_id(None)
+                logger.info(
+                    "MQTT active_page: %r ignored on the primary board, which never goes dark",
+                    NO_ACTIVE_PAGE_OPTION,
+                )
             return
         logger.warning("MQTT active_page: no page named %r", page_name)
 
@@ -395,9 +410,11 @@ class CommandHandler:
         dims = self._board_dims(board if board is not None else self._resolve_board(None)[1])
         blank_array = [[0] * dims.cols for _ in range(dims.rows)]
         client.send_characters(blank_array, force=True)
-        # Out-of-band write (issue #1794): let the display loop restore the
-        # active page on its next cycle.
-        self._invalidate_board_content(board_id)
+        # NOTE: deliberately does NOT invalidate the display loop's dedupe
+        # cache. Doing so made the blank self-destruct on the next engine
+        # tick (<=15s), breaking the "Blank the Board at Bedtime" automation
+        # in our own HA docs. Restoring the page is a pull: Refresh Display,
+        # re-selecting a page, or an actual content change.
         self._mark_display_updated()
         self._publish_event("display_updated", "board_blanked")
 
@@ -477,9 +494,9 @@ class CommandHandler:
             step_interval_ms=transition.step_interval_ms,
             step_size=transition.step_size,
         )
-        # Out-of-band write (issue #1794): let the display loop restore the
-        # active page on its next cycle.
-        self._invalidate_board_content(board_id)
+        # NOTE: deliberately does NOT invalidate the display loop's dedupe
+        # cache — see _handle_blank_board. The message must outlive the next
+        # engine tick, or "Welcome Home John!" lasts 15 seconds.
         self._mark_display_updated()
         self._publish_event("display_updated", "message_sent")
 

--- a/src/mqtt/commands.py
+++ b/src/mqtt/commands.py
@@ -80,6 +80,66 @@ class CommandHandler:
                 logger.debug("Mark display updated failed: %s", e)
 
     # ------------------------------------------------------------------ #
+    # Out-of-band write / force-send helpers (issue #1794)
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _display_service():
+        """The existing DisplayService instance, or None (never creates one)."""
+        from src.api_server import peek_service
+
+        return peek_service()
+
+    def _invalidate_board_content(self, board_id: str | None) -> None:
+        """Clear a board's display-loop dedupe + client caches after an
+        out-of-band board write, so the next check-and-send cycle restores
+        the active page instead of skipping at the content-unchanged guard.
+        ``None`` targets the primary board.
+        """
+        service = self._display_service()
+        if service is None or not hasattr(service, "invalidate_board_content"):
+            return
+        try:
+            if board_id is None:
+                from src.settings.service import get_settings_service
+
+                board_id = get_settings_service().get_primary_board_id()
+            service.invalidate_board_content(board_id)
+        except Exception as e:
+            logger.debug("Board content invalidation failed: %s", e)
+
+    def _force_send_active_page(self, board_id: str | None) -> None:
+        """Invalidate dedupe state and immediately push the active page.
+
+        Mirrors what PUT /settings/active-page does for the web UI. The
+        display loop alone would skip at its content-dedupe guard, so
+        re-selecting the currently-set page over MQTT would never restore
+        it after an out-of-band write (issue #1794).
+        """
+        service = self._display_service()
+        if service is None:
+            return
+        try:
+            self._invalidate_board_content(board_id)
+            if board_id is not None and hasattr(service, "check_and_send_for_board"):
+                rt = service.get_runtime(board_id) if hasattr(service, "get_runtime") else None
+                if rt is not None:
+                    is_primary = False
+                    try:
+                        from src.settings.service import get_settings_service
+
+                        is_primary = get_settings_service().get_primary_board_id() == board_id
+                    except Exception as e:
+                        logger.debug("Primary board lookup failed: %s", e)
+                    _bid, board = self._resolve_board(board_id)
+                    service.check_and_send_for_board(board_id, rt, is_primary=is_primary, board=board)
+                    return
+            if hasattr(service, "check_and_send_active_page"):
+                service.check_and_send_active_page()
+        except Exception as e:
+            logger.warning("MQTT active_page: immediate send failed: %s", e)
+
+    # ------------------------------------------------------------------ #
     # Per-board routing helpers (issue #1244)
     # ------------------------------------------------------------------ #
 
@@ -221,7 +281,22 @@ class CommandHandler:
                 else:
                     get_settings_service().set_active_page_id(page.id)
                     self._publish_event("page_changed", "page_switched", {"page_name": page.name})
+                # Push the page immediately (issue #1794): re-selecting the
+                # currently-set page must still restore it to the board after
+                # an out-of-band write.
+                self._force_send_active_page(board_id)
                 return
+        from .discovery import NO_ACTIVE_PAGE_OPTION
+
+        if payload_lower == NO_ACTIVE_PAGE_OPTION.lower():
+            # The HA select's stable no-page option (issue #1794): clear the
+            # board's manual active page. (A real page named like the option
+            # wins — the name match above runs first.)
+            if board_id is not None:
+                get_settings_service().set_active_page_id(None, board_id=board_id)
+            else:
+                get_settings_service().set_active_page_id(None)
+            return
         logger.warning("MQTT active_page: no page named %r", page_name)
 
     def _handle_transition_style(self, payload: str) -> None:
@@ -241,8 +316,14 @@ class CommandHandler:
         # JSON payloads may target a specific board (issue #1244):
         # {"board_id": "..."} or {"board": "Kitchen"}. Anything else (e.g.
         # the HA button's "PRESS") keeps the legacy all-boards refresh.
+        #
+        # This is a FORCE refresh (issue #1794): dedupe caches are dropped
+        # first so unchanged content is re-sent (restoring the active page
+        # after an out-of-band write), and display_updated only fires when
+        # something was actually sent.
         _, board_ref = self._parse_board_payload(payload)
         service = get_service()
+        sent = False
         if service and board_ref:
             board_id, board = self._resolve_board(board_ref)
             rt = service.get_runtime(board_id) if (board_id and hasattr(service, "get_runtime")) else None
@@ -254,13 +335,28 @@ class CommandHandler:
                     is_primary = get_settings_service().get_primary_board_id() == board_id
                 except Exception as e:
                     logger.debug("Primary board lookup failed: %s", e)
-                service.check_and_send_for_board(board_id, rt, is_primary=is_primary, board=board)
+                self._invalidate_service_boards(service, board_id)
+                sent = service.check_and_send_for_board(board_id, rt, is_primary=is_primary, board=board)
             elif hasattr(service, "check_and_send_active_page"):
-                service.check_and_send_active_page()
+                self._invalidate_service_boards(service)
+                sent = service.check_and_send_active_page()
         elif service and hasattr(service, "check_and_send_active_page"):
-            service.check_and_send_active_page()
-        self._mark_display_updated()
-        self._publish_event("display_updated", "page_refreshed")
+            self._invalidate_service_boards(service)
+            sent = service.check_and_send_active_page()
+        if sent:
+            self._mark_display_updated()
+            self._publish_event("display_updated", "page_refreshed")
+
+    @staticmethod
+    def _invalidate_service_boards(service, board_id: str | None = None) -> None:
+        """Drop the dedupe caches for one board (or all) ahead of a force refresh."""
+        try:
+            if board_id is not None and hasattr(service, "invalidate_board_content"):
+                service.invalidate_board_content(board_id)
+            elif board_id is None and hasattr(service, "invalidate_all_board_content"):
+                service.invalidate_all_board_content()
+        except Exception as e:
+            logger.debug("Board content invalidation failed: %s", e)
 
     def _handle_blank_board(self, payload: str = "") -> None:
         # JSON payloads may target a specific board (issue #1244); the
@@ -299,6 +395,9 @@ class CommandHandler:
         dims = self._board_dims(board if board is not None else self._resolve_board(None)[1])
         blank_array = [[0] * dims.cols for _ in range(dims.rows)]
         client.send_characters(blank_array, force=True)
+        # Out-of-band write (issue #1794): let the display loop restore the
+        # active page on its next cycle.
+        self._invalidate_board_content(board_id)
         self._mark_display_updated()
         self._publish_event("display_updated", "board_blanked")
 
@@ -378,6 +477,9 @@ class CommandHandler:
             step_interval_ms=transition.step_interval_ms,
             step_size=transition.step_size,
         )
+        # Out-of-band write (issue #1794): let the display loop restore the
+        # active page on its next cycle.
+        self._invalidate_board_content(board_id)
         self._mark_display_updated()
         self._publish_event("display_updated", "message_sent")
 

--- a/src/mqtt/discovery.py
+++ b/src/mqtt/discovery.py
@@ -26,6 +26,12 @@ from src.mqtt.config import MQTTConfig
 # Valid entity types supported by HA MQTT Discovery
 VALID_ENTITY_TYPES = ["switch", "select", "sensor", "binary_sensor", "button", "text", "number", "event"]
 
+# Stable option representing "no page is active" in the Active Page select
+# (issue #1794). It must be a member of the select's options list — HA
+# rejects published states that aren't — so it is injected ahead of the
+# page names at discovery time and published whenever no page is active.
+NO_ACTIVE_PAGE_OPTION = "None"
+
 
 @dataclass
 class EntityDefinition:
@@ -437,9 +443,11 @@ def build_all_discovery_messages(
     messages = []
 
     for entity in ENTITY_DEFINITIONS:
-        # Inject dynamic page list into active_page entity
+        # Inject dynamic page list into active_page entity, prefixed with the
+        # stable no-page option so an empty active page is representable
+        # (issue #1794).
         if entity.object_id == "active_page" and page_names is not None:
-            entity = replace(entity, options=page_names)
+            entity = replace(entity, options=[NO_ACTIVE_PAGE_OPTION, *page_names])
 
         # Advertise the board's real capacity, not the flagship default, so a
         # Note owner is not offered 132 characters for a 45-tile board.

--- a/src/mqtt/state.py
+++ b/src/mqtt/state.py
@@ -77,9 +77,13 @@ class StatePublisher:
             display_running = self._get_display_running()
             out["display_service"] = "ON" if display_running else "OFF"
 
-            # active_page, current_page: page name
+            # active_page, current_page: page name. With no active page,
+            # publish the select's stable no-page option — HA rejects
+            # states that aren't in the options list (issue #1794).
+            from .discovery import NO_ACTIVE_PAGE_OPTION
+
             active_id = settings.get_active_page_id()
-            page_name = "—"
+            page_name = NO_ACTIVE_PAGE_OPTION
             if active_id:
                 page = page_service.get_page(active_id)
                 if page:

--- a/tests/test_api_extended.py
+++ b/tests/test_api_extended.py
@@ -1379,6 +1379,14 @@ class TestCacheEndpoints:
         response = client.post("/force-refresh")
         assert response.status_code == 500
 
+    def test_force_refresh_invalidates_the_display_loop_dedupe_state(self, client, mock_service):
+        """Clearing only the board clients' caches is not enough: the display
+        loop skips at its own content-dedupe guard, so "Resend to board" did
+        nothing when the content had not changed (issue #1794 review)."""
+        response = client.post("/force-refresh")
+        assert response.status_code == 200
+        mock_service.invalidate_all_board_content.assert_called_once_with()
+
 
 # ============================================================
 # Service Start / Stop / Refresh / Send Message
@@ -1452,21 +1460,15 @@ class TestServiceLifecycle:
             response = client.post("/send-message", json={"text": "Hello"})
         assert response.status_code == 500
 
-    def test_send_message_success_invalidates_display_dedupe(self, client, mock_service, mock_settings_service):
-        """Issue #1794: a manual send is an out-of-band write — the display
-        loop's dedupe caches must be cleared so the active page is restored."""
-        with patch("src.api_server.Config.is_silence_mode_active", return_value=False):
-            response = client.post("/send-message", json={"text": "Hello"})
-        assert response.status_code == 200
-        mock_service.invalidate_board_content.assert_called_once()
-
-    def test_send_message_skipped_does_not_invalidate(self, client, mock_service, mock_settings_service):
-        """A skipped (unchanged) send wrote nothing, so nothing to invalidate."""
-        mock_service.vb_client.render.return_value = (True, False)
+    def test_send_message_leaves_the_display_dedupe_state_alone(self, client, mock_service, mock_settings_service):
+        """Issue #1794: a manual send is an out-of-band write, and must survive
+        the next display-loop tick. Invalidating the dedupe cache here made the
+        engine repaint the active page over it within one polling interval."""
         with patch("src.api_server.Config.is_silence_mode_active", return_value=False):
             response = client.post("/send-message", json={"text": "Hello"})
         assert response.status_code == 200
         mock_service.invalidate_board_content.assert_not_called()
+        mock_service.invalidate_all_board_content.assert_not_called()
 
     def test_send_message_success_publishes_mqtt_state(self, client, mock_service, mock_settings_service):
         """Issue #1794: after a manual send, push fresh MQTT state so HA's

--- a/tests/test_api_extended.py
+++ b/tests/test_api_extended.py
@@ -1452,6 +1452,54 @@ class TestServiceLifecycle:
             response = client.post("/send-message", json={"text": "Hello"})
         assert response.status_code == 500
 
+    def test_send_message_success_invalidates_display_dedupe(self, client, mock_service, mock_settings_service):
+        """Issue #1794: a manual send is an out-of-band write — the display
+        loop's dedupe caches must be cleared so the active page is restored."""
+        with patch("src.api_server.Config.is_silence_mode_active", return_value=False):
+            response = client.post("/send-message", json={"text": "Hello"})
+        assert response.status_code == 200
+        mock_service.invalidate_board_content.assert_called_once()
+
+    def test_send_message_skipped_does_not_invalidate(self, client, mock_service, mock_settings_service):
+        """A skipped (unchanged) send wrote nothing, so nothing to invalidate."""
+        mock_service.vb_client.render.return_value = (True, False)
+        with patch("src.api_server.Config.is_silence_mode_active", return_value=False):
+            response = client.post("/send-message", json={"text": "Hello"})
+        assert response.status_code == 200
+        mock_service.invalidate_board_content.assert_not_called()
+
+    def test_send_message_success_publishes_mqtt_state(self, client, mock_service, mock_settings_service):
+        """Issue #1794: after a manual send, push fresh MQTT state so HA's
+        last-update sensor reflects the out-of-band write."""
+        mqtt_client = Mock()
+        publisher = Mock()
+        mqtt_client._state_publisher = publisher
+        with (
+            patch("src.api_server.Config.is_silence_mode_active", return_value=False),
+            patch("src.mqtt.get_mqtt_client", return_value=mqtt_client),
+        ):
+            response = client.post("/send-message", json={"text": "Hello"})
+        assert response.status_code == 200
+        publisher.mark_display_updated.assert_called_once()
+        publisher.gather_and_publish.assert_called_once()
+
+    def test_send_message_no_mqtt_client_is_safe(self, client, mock_service, mock_settings_service):
+        """No MQTT client wired: the send still succeeds."""
+        with (
+            patch("src.api_server.Config.is_silence_mode_active", return_value=False),
+            patch("src.mqtt.get_mqtt_client", return_value=None),
+        ):
+            response = client.post("/send-message", json={"text": "Hello"})
+        assert response.status_code == 200
+        assert response.json()["status"] == "success"
+
+    def test_peek_service_does_not_create_service(self):
+        """peek_service returns the existing instance only — never creates one."""
+        from src import api_server
+
+        with patch.object(api_server, "_service", None):
+            assert api_server.peek_service() is None
+
 
 class TestSendMessageWrapping:
     """Issue #1793: /send-message wraps long text to the board's geometry."""

--- a/tests/test_board_client.py
+++ b/tests/test_board_client.py
@@ -1184,6 +1184,34 @@ class TestNoteArrayConstraints:
         assert mock_post.call_count == 2
 
     @patch("src.board_client.requests.post")
+    def test_throttled_send_is_reported_via_last_send_throttled(
+        self, mock_post, note_array_client_with_clock, valid_3x60_grid, other_3x60_grid
+    ):
+        """A throttled send and an unchanged-content skip both return
+        ``(True, False)``, but only the first means the board never got the
+        content. Callers need to tell them apart (issue #1794 review)."""
+        mock_post.return_value.raise_for_status = Mock()
+        client = note_array_client_with_clock(_clock(0.0, 10.0), "na-throttle-flag")
+
+        client.send_characters(valid_3x60_grid)
+        assert client.last_send_throttled is False
+
+        assert client.send_characters(other_3x60_grid) == (True, False)
+        assert client.last_send_throttled is True
+
+    @patch("src.board_client.requests.post")
+    def test_unchanged_content_skip_is_not_reported_as_throttled(
+        self, mock_post, note_array_client_with_clock, valid_3x60_grid
+    ):
+        """Re-sending identical content skips, but the frame IS on the board."""
+        mock_post.return_value.raise_for_status = Mock()
+        client = note_array_client_with_clock(_clock(0.0, 100.0), "na-unchanged-flag")
+
+        client.send_characters(valid_3x60_grid)
+        assert client.send_characters(valid_3x60_grid) == (True, False)
+        assert client.last_send_throttled is False
+
+    @patch("src.board_client.requests.post")
     def test_note_array_first_send_always_goes_through(self, mock_post, note_array_client_with_clock, valid_3x60_grid):
         mock_post.return_value.raise_for_status = Mock()
         # Token never previously seen in _note_array_last_send.

--- a/tests/test_debug_endpoints.py
+++ b/tests/test_debug_endpoints.py
@@ -573,9 +573,10 @@ class TestConnectionInfoSource:
         assert "192.168.1.99" not in debug_info
 
 
-class TestDebugOutOfBandInvalidation:
-    """Issue #1794: debug board writes are out-of-band — they must clear the
-    display loop's dedupe caches so the active page is restored next cycle."""
+class TestDebugOutOfBandWritesSurviveTheDisplayLoop:
+    """Issue #1794: debug board writes are out-of-band, and must NOT clear the
+    display loop's dedupe caches — that would make the next engine tick
+    (<=15s) paint the active page straight over the debug output."""
 
     @staticmethod
     def _ss():
@@ -583,7 +584,7 @@ class TestDebugOutOfBandInvalidation:
         ss.get_primary_board_id.return_value = "b1"
         return ss
 
-    def test_blank_invalidates_display_dedupe(self, client, mock_board_client):
+    def test_blank_leaves_the_dedupe_state_alone(self, client, mock_board_client):
         service = Mock()
         with (
             patch("src.api_server.get_settings_service", return_value=self._ss()),
@@ -591,9 +592,9 @@ class TestDebugOutOfBandInvalidation:
         ):
             response = client.post("/debug/blank")
         assert response.status_code == 200
-        service.invalidate_board_content.assert_called_once_with("b1")
+        service.invalidate_board_content.assert_not_called()
 
-    def test_fill_invalidates_display_dedupe(self, client, mock_board_client):
+    def test_fill_leaves_the_dedupe_state_alone(self, client, mock_board_client):
         service = Mock()
         with (
             patch("src.api_server.get_settings_service", return_value=self._ss()),
@@ -601,9 +602,9 @@ class TestDebugOutOfBandInvalidation:
         ):
             response = client.post("/debug/fill", json={"character_code": 63})
         assert response.status_code == 200
-        service.invalidate_board_content.assert_called_once_with("b1")
+        service.invalidate_board_content.assert_not_called()
 
-    def test_info_invalidates_display_dedupe(self, client, mock_board_client):
+    def test_info_leaves_the_dedupe_state_alone(self, client, mock_board_client):
         service = Mock()
         with (
             patch("src.api_server.get_settings_service", return_value=self._ss()),
@@ -611,7 +612,7 @@ class TestDebugOutOfBandInvalidation:
         ):
             response = client.post("/debug/info")
         assert response.status_code == 200
-        service.invalidate_board_content.assert_called_once_with("b1")
+        service.invalidate_board_content.assert_not_called()
 
     def test_blank_without_service_instance_is_safe(self, client, mock_board_client):
         """No display service yet → nothing to invalidate, blank still succeeds."""

--- a/tests/test_debug_endpoints.py
+++ b/tests/test_debug_endpoints.py
@@ -571,3 +571,53 @@ class TestConnectionInfoSource:
         assert "CLOUD API" in debug_info
         assert "10.0.0.42" in debug_info
         assert "192.168.1.99" not in debug_info
+
+
+class TestDebugOutOfBandInvalidation:
+    """Issue #1794: debug board writes are out-of-band — they must clear the
+    display loop's dedupe caches so the active page is restored next cycle."""
+
+    @staticmethod
+    def _ss():
+        ss = _mock_ss("flagship")
+        ss.get_primary_board_id.return_value = "b1"
+        return ss
+
+    def test_blank_invalidates_display_dedupe(self, client, mock_board_client):
+        service = Mock()
+        with (
+            patch("src.api_server.get_settings_service", return_value=self._ss()),
+            patch("src.api_server.peek_service", return_value=service),
+        ):
+            response = client.post("/debug/blank")
+        assert response.status_code == 200
+        service.invalidate_board_content.assert_called_once_with("b1")
+
+    def test_fill_invalidates_display_dedupe(self, client, mock_board_client):
+        service = Mock()
+        with (
+            patch("src.api_server.get_settings_service", return_value=self._ss()),
+            patch("src.api_server.peek_service", return_value=service),
+        ):
+            response = client.post("/debug/fill", json={"character_code": 63})
+        assert response.status_code == 200
+        service.invalidate_board_content.assert_called_once_with("b1")
+
+    def test_info_invalidates_display_dedupe(self, client, mock_board_client):
+        service = Mock()
+        with (
+            patch("src.api_server.get_settings_service", return_value=self._ss()),
+            patch("src.api_server.peek_service", return_value=service),
+        ):
+            response = client.post("/debug/info")
+        assert response.status_code == 200
+        service.invalidate_board_content.assert_called_once_with("b1")
+
+    def test_blank_without_service_instance_is_safe(self, client, mock_board_client):
+        """No display service yet → nothing to invalidate, blank still succeeds."""
+        with (
+            patch("src.api_server.get_settings_service", return_value=self._ss()),
+            patch("src.api_server.peek_service", return_value=None),
+        ):
+            response = client.post("/debug/blank")
+        assert response.status_code == 200

--- a/tests/test_mqtt_commands.py
+++ b/tests/test_mqtt_commands.py
@@ -1,5 +1,6 @@
 """Tests for MQTT command handler."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -7,6 +8,16 @@ import pytest
 from src.mqtt.client import MQTTClient
 from src.mqtt.commands import CommandHandler
 from src.mqtt.config import MQTTConfig
+
+
+@pytest.fixture(autouse=True)
+def _no_display_service():
+    """Command handlers resolve the display service via peek_service (issue
+    #1794). Default it to None so unit tests never touch a DisplayService
+    instance leaked into the process by other tests; tests that need one
+    patch peek_service themselves (their patch wins while active)."""
+    with patch("src.api_server.peek_service", return_value=None):
+        yield
 
 
 @pytest.fixture
@@ -188,8 +199,16 @@ class TestCommandHandlerEventPublishing:
 
     @patch("src.api_server.get_service")
     def test_refresh_display_fires_display_updated_event(self, get_service, handler_with_publisher):
+        """When the refresh actually sent content, a page_refreshed event fires.
+
+        Contract change for issue #1794: the event used to fire
+        unconditionally (even with no service at all); it now reports a real
+        board update, so this test drives a service whose refresh sends.
+        """
         handler, publisher = handler_with_publisher
-        get_service.return_value = None
+        service = MagicMock()
+        service.check_and_send_active_page.return_value = True
+        get_service.return_value = service
         handler.handle("refresh_display", "")
         publisher.publish_event.assert_called_once()
         args = publisher.publish_event.call_args[0]
@@ -199,9 +218,11 @@ class TestCommandHandlerEventPublishing:
 
     @patch("src.api_server.get_service")
     def test_refresh_display_marks_last_update(self, get_service, handler_with_publisher):
-        """Refresh display should call mark_display_updated."""
+        """A refresh that sent content should call mark_display_updated."""
         handler, publisher = handler_with_publisher
-        get_service.return_value = None
+        service = MagicMock()
+        service.check_and_send_active_page.return_value = True
+        get_service.return_value = service
         handler.handle("refresh_display", "")
         publisher.mark_display_updated.assert_called_once()
 
@@ -718,3 +739,330 @@ class TestResolveBoardByName:
             with caplog.at_level("WARNING"):
                 assert CommandHandler._resolve_board("b1")[0] == "b1"
         assert caplog.records == []
+
+
+def _page_service_with(name="Weather", page_id="page-weather-id"):
+    """Page service mock exposing one named page."""
+    page_svc = MagicMock()
+    page = MagicMock()
+    page.name = name
+    page.id = page_id
+    page_svc.list_pages.return_value = [page]
+    return page_svc
+
+
+class TestActivePageRestore:
+    """Issue #1794: (re)selecting a page over MQTT must invalidate dedupe
+    state and push the page immediately, so re-selecting the currently-set
+    page restores it after an out-of-band board write."""
+
+    @patch("src.api_server.peek_service")
+    @patch("src.settings.service.get_settings_service")
+    @patch("src.pages.service.get_page_service")
+    def test_active_page_invalidates_and_sends_immediately(self, get_page, get_settings, peek, handler):
+        get_page.return_value = _page_service_with()
+        settings = MagicMock()
+        settings.get_primary_board_id.return_value = "b1"
+        get_settings.return_value = settings
+        service = MagicMock()
+        peek.return_value = service
+
+        handler.handle("active_page", "Weather")
+
+        settings.set_active_page_id.assert_called_once_with("page-weather-id")
+        service.invalidate_board_content.assert_called_once_with("b1")
+        service.check_and_send_active_page.assert_called_once()
+
+    @patch("src.api_server.peek_service")
+    @patch("src.settings.service.get_settings_service")
+    @patch("src.pages.service.get_page_service")
+    def test_active_page_board_targeted_sends_to_that_board(self, get_page, get_settings, peek, handler):
+        get_page.return_value = _page_service_with()
+        settings = TestCommandHandlerPerBoardRouting._settings_with_boards()
+        get_settings.return_value = settings
+        service = MagicMock()
+        rt = MagicMock()
+        service.get_runtime.return_value = rt
+        peek.return_value = service
+
+        handler.handle("active_page", '{"page": "Weather", "board": "Kitchen"}')
+
+        service.invalidate_board_content.assert_called_once_with("b2")
+        service.check_and_send_for_board.assert_called_once()
+        args, kwargs = service.check_and_send_for_board.call_args
+        assert args[0] == "b2"
+        assert args[1] is rt
+        assert kwargs["is_primary"] is False
+        service.check_and_send_active_page.assert_not_called()
+
+    @patch("src.api_server.peek_service")
+    @patch("src.settings.service.get_settings_service")
+    @patch("src.pages.service.get_page_service")
+    def test_active_page_none_option_clears_active_page(self, get_page, get_settings, peek, handler):
+        """Selecting the HA select's no-page option clears the active page."""
+        page_svc = MagicMock()
+        page_svc.list_pages.return_value = []
+        get_page.return_value = page_svc
+        settings = MagicMock()
+        get_settings.return_value = settings
+        peek.return_value = None
+
+        handler.handle("active_page", "None")
+
+        settings.set_active_page_id.assert_called_once_with(None)
+
+    @patch("src.api_server.peek_service")
+    @patch("src.settings.service.get_settings_service")
+    @patch("src.pages.service.get_page_service")
+    def test_active_page_no_service_still_persists_selection(self, get_page, get_settings, peek, handler):
+        """Without a display service the selection is persisted and no send is attempted."""
+        get_page.return_value = _page_service_with()
+        settings = MagicMock()
+        get_settings.return_value = settings
+        peek.return_value = None
+
+        handler.handle("active_page", "Weather")
+
+        settings.set_active_page_id.assert_called_once_with("page-weather-id")
+
+
+class TestRefreshDisplayForce:
+    """Issue #1794: refresh_display is a force refresh — dedupe caches are
+    invalidated first, and display_updated only fires when content was sent."""
+
+    @patch("src.api_server.get_service")
+    def test_refresh_display_invalidates_all_boards_first(self, get_service, handler):
+        service = MagicMock()
+        service.check_and_send_active_page.return_value = True
+        get_service.return_value = service
+
+        handler.handle("refresh_display", "PRESS")
+
+        service.invalidate_all_board_content.assert_called_once()
+        service.check_and_send_active_page.assert_called_once()
+
+    @patch("src.settings.service.get_settings_service")
+    @patch("src.api_server.get_service")
+    def test_refresh_display_board_targeted_invalidates_that_board(self, get_service, get_settings, handler):
+        get_settings.return_value = TestCommandHandlerPerBoardRouting._settings_with_boards()
+        service = MagicMock()
+        service.get_runtime.return_value = MagicMock()
+        service.check_and_send_for_board.return_value = True
+        get_service.return_value = service
+
+        handler.handle("refresh_display", '{"board_id": "b2"}')
+
+        service.invalidate_board_content.assert_called_once_with("b2")
+        service.check_and_send_for_board.assert_called_once()
+
+    @patch("src.api_server.get_service")
+    def test_refresh_display_no_event_when_nothing_sent(self, get_service, handler_with_publisher):
+        handler, publisher = handler_with_publisher
+        service = MagicMock()
+        service.check_and_send_active_page.return_value = False
+        get_service.return_value = service
+
+        handler.handle("refresh_display", "")
+
+        publisher.publish_event.assert_not_called()
+        publisher.mark_display_updated.assert_not_called()
+
+    @patch("src.api_server.get_service")
+    def test_refresh_display_no_service_publishes_no_event(self, get_service, handler_with_publisher):
+        handler, publisher = handler_with_publisher
+        get_service.return_value = None
+
+        handler.handle("refresh_display", "")
+
+        publisher.publish_event.assert_not_called()
+        publisher.mark_display_updated.assert_not_called()
+
+
+class TestOutOfBandInvalidation:
+    """Issue #1794: MQTT board writes must invalidate the display loop's
+    dedupe state so the active page can be restored afterwards."""
+
+    @patch("src.api_server.peek_service")
+    @patch("src.settings.service.get_settings_service")
+    @patch("src.text_to_board.text_to_board_array")
+    @patch("src.api_server.get_service")
+    @patch("src.config.Config")
+    def test_send_message_invalidates_board_content(
+        self, mock_config, get_service, text_to_board, get_settings, peek, handler
+    ):
+        mock_config.is_silence_mode_active.return_value = False
+        service = MagicMock()
+        service.vb_client = MagicMock()
+        get_service.return_value = service
+        peek.return_value = service
+        text_to_board.return_value = [[0] * 22 for _ in range(6)]
+        settings = MagicMock()
+        settings.get_primary_board_id.return_value = "b1"
+        settings.is_paused.return_value = False
+        settings.get_transition_settings.return_value = MagicMock(strategy="column", step_interval_ms=100, step_size=1)
+        get_settings.return_value = settings
+
+        handler.handle("send_message", "Hello World")
+
+        service.vb_client.send_characters.assert_called_once()
+        service.invalidate_board_content.assert_called_once_with("b1")
+
+    @patch("src.api_server.peek_service")
+    @patch("src.api_server.get_service")
+    @patch("src.settings.service.get_settings_service")
+    @patch("src.config.Config")
+    def test_send_message_board_targeted_invalidates_that_board(
+        self, mock_config, get_settings, get_service, peek, handler
+    ):
+        mock_config.is_silence_mode_active.return_value = False
+        get_settings.return_value = TestCommandHandlerPerBoardRouting._settings_with_boards()
+        service = MagicMock()
+        service.get_board_client.return_value = MagicMock()
+        get_service.return_value = service
+        peek.return_value = service
+
+        handler.handle("send_message", '{"message": "HELLO", "board": "Kitchen"}')
+
+        service.invalidate_board_content.assert_called_once_with("b2")
+
+    @patch("src.api_server.peek_service")
+    @patch("src.settings.service.get_settings_service")
+    @patch("src.api_server._get_board_client")
+    def test_blank_board_invalidates_board_content(self, get_board, get_settings, peek, handler):
+        board_client = MagicMock()
+        get_board.return_value = board_client
+        settings = MagicMock()
+        settings.should_send_to_board.return_value = True
+        settings.is_paused.return_value = False
+        settings.get_primary_board_id.return_value = "b1"
+        get_settings.return_value = settings
+        service = MagicMock()
+        peek.return_value = service
+
+        handler.handle("blank_board", "")
+
+        board_client.send_characters.assert_called_once()
+        service.invalidate_board_content.assert_called_once_with("b1")
+
+
+class TestDisplayServiceGuardIntegration:
+    """Issue #1794: drive MQTT commands against a REAL DisplayService so the
+    content-dedupe guard in check_and_send_for_board is actually exercised
+    (the unit tests above mock the service, which bypasses the guard)."""
+
+    @staticmethod
+    def _make_env(pages=None, active_page_id="pA"):
+        from src.main import BoardRuntime, DisplayService
+
+        board = {
+            "id": "b1",
+            "name": "Lobby",
+            "device_type": "flagship",
+            "enabled": True,
+            "notes_wide": 1,
+            "notes_tall": 1,
+        }
+        svc = DisplayService()
+        client = MagicMock()
+        client.render.return_value = (True, True)
+        client.send_characters.return_value = (True, True)
+        svc.runtimes = {"b1": BoardRuntime(client=client, board_id="b1")}
+        svc._primary_board_id = "b1"
+
+        settings = MagicMock()
+        settings.get_board_settings.return_value = SimpleNamespace(boards=[board])
+        settings.get_primary_board_id.return_value = "b1"
+        settings.is_paused.return_value = False
+        settings.is_schedule_enabled.return_value = False
+        settings.get_active_page_id.return_value = active_page_id
+        settings.get_transition_settings.return_value = SimpleNamespace(
+            strategy=None, step_interval_ms=None, step_size=None
+        )
+        settings.consume_temporary_override.return_value = None
+        settings.should_send_to_board.return_value = True
+
+        pages = pages if pages is not None else {"pA": ("Alpha", "ALPHA CONTENT")}
+        page_objs = [
+            SimpleNamespace(
+                id=pid,
+                name=name,
+                device_type="flagship",
+                notes_wide=1,
+                notes_tall=1,
+                transition_strategy=None,
+                transition_interval_ms=None,
+                transition_step_size=None,
+            )
+            for pid, (name, _content) in pages.items()
+        ]
+        page_svc = MagicMock()
+        page_svc.list_pages.return_value = page_objs
+        page_svc.get_page.side_effect = lambda pid: next((p for p in page_objs if p.id == pid), None)
+        page_svc.preview_page.side_effect = lambda pid, force_refresh=False: (
+            SimpleNamespace(available=True, formatted=pages[pid][1], error=None)
+            if pid in pages
+            else SimpleNamespace(available=False, formatted="", error="missing")
+        )
+        return svc, client, settings, page_svc
+
+    @staticmethod
+    def _env_patches(svc, settings, page_svc):
+        from contextlib import ExitStack
+
+        stack = ExitStack()
+        stack.enter_context(patch("src.main.get_settings_service", return_value=settings))
+        stack.enter_context(patch("src.main.get_page_service", return_value=page_svc))
+        stack.enter_context(patch("src.main.get_schedule_service", return_value=MagicMock()))
+        stack.enter_context(patch("src.main.get_collection_service", return_value=MagicMock()))
+        stack.enter_context(patch("src.settings.service.get_settings_service", return_value=settings))
+        stack.enter_context(patch("src.pages.service.get_page_service", return_value=page_svc))
+        stack.enter_context(patch("src.api_server.get_service", return_value=svc))
+        stack.enter_context(patch("src.api_server.peek_service", return_value=svc))
+        cfg_main = stack.enter_context(patch("src.main.Config"))
+        cfg_main.is_silence_mode_active.return_value = False
+        cfg = stack.enter_context(patch("src.config.Config"))
+        cfg.is_silence_mode_active.return_value = False
+        stack.enter_context(patch.object(svc, "_check_trigger_override", return_value=None))
+        stack.enter_context(patch.object(svc, "request_board_refresh"))
+        return stack
+
+    def test_reselecting_current_page_restores_it_after_out_of_band_write(self, handler):
+        svc, client, settings, page_svc = self._make_env()
+        with self._env_patches(svc, settings, page_svc):
+            assert svc.check_and_send_active_page() is True
+            assert client.render.call_count == 1
+            # Second tick dedupes: content and page id unchanged.
+            assert svc.check_and_send_active_page() is False
+            assert client.render.call_count == 1
+
+            # Out-of-band write: MQTT custom message replaces the page frame.
+            handler.handle("send_message", "HELLO")
+            client.send_characters.assert_called_once()
+
+            # Re-selecting the SAME page must re-send it to the board.
+            handler.handle("active_page", "Alpha")
+            assert client.render.call_count == 2
+
+    def test_refresh_display_resends_after_out_of_band_write(self, handler_with_publisher):
+        handler, publisher = handler_with_publisher
+        svc, client, settings, page_svc = self._make_env()
+        with self._env_patches(svc, settings, page_svc):
+            assert svc.check_and_send_active_page() is True
+            handler.handle("send_message", "HELLO")
+            publisher.reset_mock()
+
+            handler.handle("refresh_display", "PRESS")
+
+            assert client.render.call_count == 2
+            refreshed = [c for c in publisher.publish_event.call_args_list if c[0][1] == "page_refreshed"]
+            assert len(refreshed) == 1
+
+    def test_refresh_display_without_send_publishes_no_event(self, handler_with_publisher):
+        handler, publisher = handler_with_publisher
+        svc, client, settings, page_svc = self._make_env(pages={}, active_page_id=None)
+        with self._env_patches(svc, settings, page_svc):
+            handler.handle("refresh_display", "PRESS")
+
+            client.render.assert_not_called()
+            publisher.publish_event.assert_not_called()
+            publisher.mark_display_updated.assert_not_called()

--- a/tests/test_mqtt_commands.py
+++ b/tests/test_mqtt_commands.py
@@ -798,18 +798,74 @@ class TestActivePageRestore:
     @patch("src.api_server.peek_service")
     @patch("src.settings.service.get_settings_service")
     @patch("src.pages.service.get_page_service")
-    def test_active_page_none_option_clears_active_page(self, get_page, get_settings, peek, handler):
-        """Selecting the HA select's no-page option clears the active page."""
+    def test_active_page_none_option_clears_a_secondary_board(self, get_page, get_settings, peek, handler):
+        """Secondary boards go dark when no page is set, so the no-page option
+        is real there."""
+        page_svc = MagicMock()
+        page_svc.list_pages.return_value = []
+        get_page.return_value = page_svc
+        settings = TestCommandHandlerPerBoardRouting._settings_with_boards()
+        get_settings.return_value = settings
+        peek.return_value = None
+
+        handler.handle("active_page", '{"page": "None", "board": "Kitchen"}')
+
+        settings.set_active_page_id.assert_called_once_with(None, board_id="b2")
+
+    @patch("src.api_server.peek_service")
+    @patch("src.settings.service.get_settings_service")
+    @patch("src.pages.service.get_page_service")
+    def test_active_page_none_option_is_refused_on_the_primary_board(self, get_page, get_settings, peek, handler):
+        """The primary board never goes dark — check_and_send_for_board
+        re-defaults it to pages[0] and persists that within one polling
+        interval, so accepting the selection here would only make the HA
+        select bounce back 15s later (issue #1794 review).
+        """
         page_svc = MagicMock()
         page_svc.list_pages.return_value = []
         get_page.return_value = page_svc
         settings = MagicMock()
+        settings.get_primary_board_id.return_value = "b1"
         get_settings.return_value = settings
         peek.return_value = None
 
         handler.handle("active_page", "None")
 
-        settings.set_active_page_id.assert_called_once_with(None)
+        settings.set_active_page_id.assert_not_called()
+
+    @patch("src.api_server.peek_service")
+    @patch("src.settings.service.get_settings_service")
+    @patch("src.pages.service.get_page_service")
+    def test_active_page_none_option_republishes_so_the_select_snaps_back(
+        self, get_page, get_settings, peek, handler_with_publisher
+    ):
+        """Refusing the selection must not leave HA showing the wrong state."""
+        handler, publisher = handler_with_publisher
+        page_svc = MagicMock()
+        page_svc.list_pages.return_value = []
+        get_page.return_value = page_svc
+        settings = MagicMock()
+        settings.get_primary_board_id.return_value = "b1"
+        get_settings.return_value = settings
+        peek.return_value = None
+
+        handler.handle("active_page", "None")
+
+        publisher.gather_and_publish.assert_called()
+
+    @patch("src.api_server.peek_service")
+    @patch("src.settings.service.get_settings_service")
+    @patch("src.pages.service.get_page_service")
+    def test_a_real_page_named_none_still_wins(self, get_page, get_settings, peek, handler):
+        get_page.return_value = _page_service_with(name="None", page_id="page-none-id")
+        settings = MagicMock()
+        settings.get_primary_board_id.return_value = "b1"
+        get_settings.return_value = settings
+        peek.return_value = None
+
+        handler.handle("active_page", "None")
+
+        settings.set_active_page_id.assert_called_once_with("page-none-id")
 
     @patch("src.api_server.peek_service")
     @patch("src.settings.service.get_settings_service")
@@ -878,16 +934,18 @@ class TestRefreshDisplayForce:
         publisher.mark_display_updated.assert_not_called()
 
 
-class TestOutOfBandInvalidation:
-    """Issue #1794: MQTT board writes must invalidate the display loop's
-    dedupe state so the active page can be restored afterwards."""
+class TestOutOfBandWritesSurviveTheDisplayLoop:
+    """Issue #1794: MQTT board writes must NOT invalidate the display loop's
+    dedupe state. Doing so made every message self-destruct on the next
+    engine tick (<=15s). Restoring the active page is a pull — Refresh
+    Display, re-selecting a page, or a real content change."""
 
     @patch("src.api_server.peek_service")
     @patch("src.settings.service.get_settings_service")
     @patch("src.text_to_board.text_to_board_array")
     @patch("src.api_server.get_service")
     @patch("src.config.Config")
-    def test_send_message_invalidates_board_content(
+    def test_send_message_leaves_the_dedupe_state_alone(
         self, mock_config, get_service, text_to_board, get_settings, peek, handler
     ):
         mock_config.is_silence_mode_active.return_value = False
@@ -905,13 +963,14 @@ class TestOutOfBandInvalidation:
         handler.handle("send_message", "Hello World")
 
         service.vb_client.send_characters.assert_called_once()
-        service.invalidate_board_content.assert_called_once_with("b1")
+        service.invalidate_board_content.assert_not_called()
+        service.invalidate_all_board_content.assert_not_called()
 
     @patch("src.api_server.peek_service")
     @patch("src.api_server.get_service")
     @patch("src.settings.service.get_settings_service")
     @patch("src.config.Config")
-    def test_send_message_board_targeted_invalidates_that_board(
+    def test_send_message_board_targeted_leaves_the_dedupe_state_alone(
         self, mock_config, get_settings, get_service, peek, handler
     ):
         mock_config.is_silence_mode_active.return_value = False
@@ -923,12 +982,12 @@ class TestOutOfBandInvalidation:
 
         handler.handle("send_message", '{"message": "HELLO", "board": "Kitchen"}')
 
-        service.invalidate_board_content.assert_called_once_with("b2")
+        service.invalidate_board_content.assert_not_called()
 
     @patch("src.api_server.peek_service")
     @patch("src.settings.service.get_settings_service")
     @patch("src.api_server._get_board_client")
-    def test_blank_board_invalidates_board_content(self, get_board, get_settings, peek, handler):
+    def test_blank_board_leaves_the_dedupe_state_alone(self, get_board, get_settings, peek, handler):
         board_client = MagicMock()
         get_board.return_value = board_client
         settings = MagicMock()
@@ -942,7 +1001,7 @@ class TestOutOfBandInvalidation:
         handler.handle("blank_board", "")
 
         board_client.send_characters.assert_called_once()
-        service.invalidate_board_content.assert_called_once_with("b1")
+        service.invalidate_board_content.assert_not_called()
 
 
 class TestDisplayServiceGuardIntegration:
@@ -1043,12 +1102,40 @@ class TestDisplayServiceGuardIntegration:
             handler.handle("active_page", "Alpha")
             assert client.render.call_count == 2
 
-    def test_refresh_display_resends_after_out_of_band_write(self, handler_with_publisher):
+    def test_refresh_display_breaks_the_content_dedupe_guard(self, handler_with_publisher):
+        """The force refresh itself must drop the dedupe state.
+
+        The previous version of this test let its own ``send_message`` step do
+        the invalidating, so it passed with every ``_invalidate_service_boards``
+        call deleted. Here nothing else touches the caches: the second tick is
+        asserted to dedupe first, so the third render can only come from
+        refresh_display invalidating.
+        """
+        handler, publisher = handler_with_publisher
+        svc, client, settings, page_svc = self._make_env()
+        with self._env_patches(svc, settings, page_svc):
+            assert svc.check_and_send_active_page() is True
+            assert client.render.call_count == 1
+            # Guard is armed: unchanged content is skipped.
+            assert svc.check_and_send_active_page() is False
+            assert client.render.call_count == 1
+            publisher.reset_mock()
+
+            handler.handle("refresh_display", "PRESS")
+
+            assert client.render.call_count == 2, "refresh_display did not break the dedupe guard"
+            refreshed = [c for c in publisher.publish_event.call_args_list if c[0][1] == "page_refreshed"]
+            assert len(refreshed) == 1
+
+    def test_refresh_display_restores_the_page_after_an_out_of_band_write(self, handler_with_publisher):
+        """End to end: a custom message is on the board, Refresh Display puts
+        the active page back."""
         handler, publisher = handler_with_publisher
         svc, client, settings, page_svc = self._make_env()
         with self._env_patches(svc, settings, page_svc):
             assert svc.check_and_send_active_page() is True
             handler.handle("send_message", "HELLO")
+            client.send_characters.assert_called_once()
             publisher.reset_mock()
 
             handler.handle("refresh_display", "PRESS")
@@ -1056,6 +1143,38 @@ class TestDisplayServiceGuardIntegration:
             assert client.render.call_count == 2
             refreshed = [c for c in publisher.publish_event.call_args_list if c[0][1] == "page_refreshed"]
             assert len(refreshed) == 1
+
+    def test_engine_tick_does_not_overwrite_an_out_of_band_message(self, handler):
+        """An MQTT/HA message must survive the next display-loop tick.
+
+        Invalidating the dedupe cache on the *write* made the message
+        self-destruct within one polling interval (15s by default), which
+        breaks the "Welcome Home" automation in our own HA docs.
+        """
+        svc, client, settings, page_svc = self._make_env()
+        with self._env_patches(svc, settings, page_svc):
+            assert svc.check_and_send_active_page() is True
+            handler.handle("send_message", "HELLO")
+            client.send_characters.assert_called_once()
+
+            resent = svc.check_and_send_active_page()
+
+            assert resent is False, "the next display-loop tick re-sent the active page over the user's message"
+            assert client.render.call_count == 1
+
+    def test_engine_tick_does_not_relight_a_blanked_board(self, handler):
+        """ "Blank the Board at Bedtime" must stay blank, not re-light in 15s."""
+        svc, client, settings, page_svc = self._make_env()
+        with self._env_patches(svc, settings, page_svc):
+            assert svc.check_and_send_active_page() is True
+            with patch("src.api_server._get_board_client", return_value=client):
+                handler.handle("blank_board", "")
+            assert client.send_characters.called
+
+            resent = svc.check_and_send_active_page()
+
+            assert resent is False, "the next display-loop tick re-lit the board after a blank"
+            assert client.render.call_count == 1
 
     def test_refresh_display_without_send_publishes_no_event(self, handler_with_publisher):
         handler, publisher = handler_with_publisher

--- a/tests/test_mqtt_discovery.py
+++ b/tests/test_mqtt_discovery.py
@@ -479,7 +479,8 @@ class TestBuildAllDiscoveryMessages:
             assert msg["topic"].endswith("/config")
 
     def test_dynamic_page_names_injected(self, mqtt_config):
-        """Active page entity should include provided page names as options."""
+        """Active page entity includes the page names as options, preceded by
+        the stable no-page option (contract change for issue #1794)."""
         page_names = ["Weather Dashboard", "Sports Scores", "Welcome Message"]
         messages = build_all_discovery_messages(mqtt_config, page_names=page_names)
 
@@ -492,7 +493,22 @@ class TestBuildAllDiscoveryMessages:
                 break
 
         assert active_page_msg is not None
-        assert active_page_msg["options"] == page_names
+        assert active_page_msg["options"] == ["None", *page_names]
+
+    def test_active_page_options_start_with_no_page_sentinel(self, mqtt_config):
+        """Issue #1794: the select always offers a representable no-page state."""
+        from src.mqtt.discovery import NO_ACTIVE_PAGE_OPTION
+
+        messages = build_all_discovery_messages(mqtt_config, page_names=["Weather"])
+        active_page_msg = None
+        for msg in messages:
+            payload = json.loads(msg["payload"])
+            if payload.get("unique_id", "").endswith("_active_page"):
+                active_page_msg = payload
+                break
+
+        assert active_page_msg is not None
+        assert active_page_msg["options"][0] == NO_ACTIVE_PAGE_OPTION
 
     def test_sw_version_included(self, mqtt_config):
         """Software version should appear in device info."""

--- a/tests/test_mqtt_state.py
+++ b/tests/test_mqtt_state.py
@@ -115,6 +115,40 @@ class TestStatePublisherGather:
         assert second_state_count == first_state_count
         assert second_attrs_count == first_attrs_count
 
+    @patch("src.config_manager.ConfigManager")
+    @patch("src.api_server._get_board_client")
+    @patch("src.api_server._service_start_time", 1000000.0)
+    @patch("src.pages.service.get_page_service")
+    @patch("src.settings.service.get_settings_service")
+    @patch("src.config.Config")
+    def test_no_active_page_publishes_none_option(
+        self, mock_config, get_settings, get_page, mock_board, mock_cm, mock_client
+    ):
+        """Issue #1794: with no active page, publish the select's stable
+        no-page option (not an em dash HA rejects as an unknown option)."""
+        from src.mqtt.discovery import NO_ACTIVE_PAGE_OPTION
+
+        mock_config.is_silence_mode_active.return_value = False
+        settings = MagicMock()
+        settings.is_schedule_enabled.return_value = False
+        settings.get_active_page_id.return_value = None
+        settings.get_transition_settings.return_value = MagicMock(strategy="")
+        settings.get_polling_interval.return_value = 60
+        settings.get_output_settings.return_value = MagicMock(target="both")
+        get_settings.return_value = settings
+        page_svc = MagicMock()
+        page_svc.get_page.return_value = None
+        page_svc.list_pages.return_value = []
+        get_page.return_value = page_svc
+        mock_board.return_value = None
+        mock_cm.return_value._config = {"plugins": {}}
+        pub = StatePublisher(mock_client)
+        pub.gather_and_publish()
+        state = {c[0][0]: c[0][1] for c in mock_client.publish_state.call_args_list}
+        assert state["active_page"] == NO_ACTIVE_PAGE_OPTION
+        assert state["current_page"] == NO_ACTIVE_PAGE_OPTION
+        assert NO_ACTIVE_PAGE_OPTION == "None"
+
     @patch("src.pages.service.get_page_service")
     @patch("src.settings.service.get_settings_service")
     def test_gather_handles_exception(self, get_settings, get_page, mock_client):

--- a/tests/test_per_board_engine.py
+++ b/tests/test_per_board_engine.py
@@ -775,3 +775,58 @@ class TestSendStatusReporting:
 
         assert sent is True
         assert error is None
+
+
+class TestThrottledSendDoesNotPrimeDedupeCache:
+    """Issue #1794 review: a note-array send skipped by
+    ``NOTE_ARRAY_MIN_SEND_INTERVAL`` returns ``(True, False)`` — success, but
+    the content never reached the board. Priming the dedupe cache with it
+    strands the board on the previous frame forever, because no later tick
+    re-attempts unchanged content."""
+
+    @staticmethod
+    def _throttled_env():
+        boards = [_note_array_board("b1", "Notes", notes_wide=2, notes_tall=2)]
+        svc, clients = _service_with_runtimes(boards)
+        client = clients["b1"]
+        client.render.return_value = (True, False)
+        client.last_send_throttled = True
+        pages = _page_service(
+            {"pA": {"content": "ALPHA", "device_type": "note_array", "notes_wide": 2, "notes_tall": 2}}
+        )
+        schedule = _schedule_service({"b1": "pA"})
+        return svc, boards, client, pages, schedule
+
+    def test_throttled_send_leaves_the_dedupe_cache_clear(self):
+        svc, boards, _client, pages, schedule = self._throttled_env()
+
+        _drive(svc, boards, pages=pages, schedule=schedule)
+
+        rt = svc.runtimes["b1"]
+        assert rt.last_active_page_content is None, "cached content the board never received"
+        assert rt.last_active_page_id is None
+
+    def test_a_later_tick_retries_a_throttled_send(self):
+        svc, boards, client, pages, schedule = self._throttled_env()
+
+        _drive(svc, boards, pages=pages, schedule=schedule)
+        # Throttle window has passed; this send lands.
+        client.render.return_value = (True, True)
+        client.last_send_throttled = False
+        _drive(svc, boards, pages=pages, schedule=schedule)
+
+        assert client.render.call_count == 2, "board left permanently stale after a throttled send"
+        assert svc.runtimes["b1"].last_active_page_content == "ALPHA"
+
+    def test_a_delivered_send_still_primes_the_cache(self):
+        """Regression guard: the unchanged-content skip (also (True, False))
+        means the frame IS on the board, so it must still prime."""
+        boards = [_board("b1", "One")]
+        svc, clients = _service_with_runtimes(boards)
+        clients["b1"].render.return_value = (True, False)
+        clients["b1"].last_send_throttled = False
+        pages = _page_service({"pA": {"content": "ALPHA"}})
+
+        _drive(svc, boards, pages=pages, schedule=_schedule_service({"b1": "pA"}))
+
+        assert svc.runtimes["b1"].last_active_page_content == "ALPHA"


### PR DESCRIPTION
Refs #1794 (closes sub-complaints (b) and (c); (a) split out as #1831).

Out-of-band writes to the physical board left the display loop's content-dedupe state stale, so the active page could never be restored: re-selecting the same page via MQTT no-oped at the dedupe guard, and MQTT "Refresh Display" hit the same guard while still publishing a `display_updated` success event.

## Review follow-up (second commit)

### BLOCKER — the push-invalidation made every MQTT/debug write self-destruct

The first commit invalidated the dedupe cache on the *write*, so the next engine tick re-sent the active page straight over it — within one polling interval (15s, `settings/service.py`). That breaks two automations from our own docs (`docs/features/home-assistant-control.md`): "Blank the Board at Bedtime" re-lit within 15s and "Welcome Home John!" lasted 15s. It also broke the MQTT `send_message` feature #1804 is fixing, for the same reporter.

**Fix: keep the pull half, drop the push half.** `_force_send_active_page` and `invalidate_all_board_content` on the refresh paths stay. The invalidation on `send_message` / `blank_board` / `debug/*` is gone from both `src/mqtt/commands.py` and `src/api_server.py`.

The seven tests that asserted the removed behavior now assert the opposite, and two new integration tests do what none of them did: tick a real `DisplayService` after the write.

<details><summary>Pre-fix failure (the new regression tests, against the first commit)</summary>

```
_ TestDisplayServiceGuardIntegration.test_engine_tick_does_not_overwrite_an_out_of_band_message _
tests/test_mqtt_commands.py:922: in test_engine_tick_does_not_overwrite_an_out_of_band_message
    assert resent is False, "the next display-loop tick re-sent the active page over the user's message"
E   AssertionError: the next display-loop tick re-sent the active page over the user's message
E   assert True is False
_ TestDisplayServiceGuardIntegration.test_engine_tick_does_not_relight_a_blanked_board _
tests/test_mqtt_commands.py:936: in test_engine_tick_does_not_relight_a_blanked_board
    assert resent is False, "the next display-loop tick re-lit the board after a blank"
E   AssertionError: the next display-loop tick re-lit the board after a blank
E   assert True is False
```
</details>

### The vacuous refresh test

`test_refresh_display_resends_after_out_of_band_write` still passed with all three `_invalidate_service_boards` calls deleted, because its own `send_message` step did the invalidating. Replaced by `test_refresh_display_breaks_the_content_dedupe_guard`, which asserts the guard is armed (second tick dedupes) *before* pressing refresh, so the extra render can only come from the refresh. A separate end-to-end test keeps the out-of-band-write scenario.

<details><summary>Non-vacuity proof — all three <code>_invalidate_service_boards</code> calls deleted, old test re-added alongside the new one</summary>

```
collected 50 items / 48 deselected / 2 selected

tests/test_mqtt_commands.py .F                                           [100%]

=================================== FAILURES ===================================
_ TestDisplayServiceGuardIntegration.test_refresh_display_breaks_the_content_dedupe_guard _
tests/test_mqtt_commands.py:900: in test_refresh_display_breaks_the_content_dedupe_guard
    assert client.render.call_count == 2, "refresh_display did not break the dedupe guard"
E   AssertionError: refresh_display did not break the dedupe guard
E   assert 1 == 2

================== 1 failed, 1 passed, 48 deselected in 1.48s ==================
```

The `.` is `test_OLD_refresh_display_resends_after_out_of_band_write` — green with the fix fully removed.
</details>

### Stuck board on note arrays (`src/main.py`)

A note-array send dropped by `NOTE_ARRAY_MIN_SEND_INTERVAL` returns `(True, False)` — byte-identical to an unchanged-content skip, but the content never left the process. `check_and_send_for_board` branched on `success` and primed the dedupe cache with it, so no later tick ever retried and the board stayed on the previous frame permanently.

`BoardClient` now exposes `last_send_throttled`, which separates the two `(True, False)` cases. The engine keeps #1817's `rt.last_silence_mode_active` latch either way, then returns early on a throttle, leaving the dedupe cache clear.

<details><summary>Pre-fix failures</summary>

```
_ TestThrottledSendDoesNotPrimeDedupeCache.test_throttled_send_leaves_the_dedupe_cache_clear _
    assert rt.last_active_page_content is None, "cached content the board never received"
E   AssertionError: cached content the board never received
E   assert 'ALPHA' is None
_ TestThrottledSendDoesNotPrimeDedupeCache.test_a_later_tick_retries_a_throttled_send _
    assert client.render.call_count == 2, "board left permanently stale after a throttled send"
E   AssertionError: board left permanently stale after a throttled send
E   assert 1 == 2
_ TestNoteArrayConstraints.test_throttled_send_is_reported_via_last_send_throttled _
E   AttributeError: 'BoardClient' object has no attribute 'last_send_throttled'
```

`test_a_delivered_send_still_primes_the_cache` guards the other direction: an unchanged-content skip means the frame *is* on the board, so it must still prime.
</details>

### HTTP `/force-refresh` was left broken

It cleared the board clients' caches but not the display loop's per-runtime guard, so the web UI's "Resend to board" button — right next to the reporter's "Board was changed by another app" banner — did nothing when content had not changed. Same one-line root fix.

```
_ TestCacheEndpoints.test_force_refresh_invalidates_the_display_loop_dedupe_state _
    mock_service.invalidate_all_board_content.assert_called_once_with()
E   AssertionError: Expected 'invalidate_all_board_content' to be called once. Called 0 times.
```

### The HA `None` option

Non-functional on the primary board: `check_and_send_for_board` re-defaults it to `pages[0]` and persists that, so the select visibly bounced back within 15s. It is now refused there (and `handle()`'s trailing `gather_and_publish` snaps the select back immediately rather than lying for 15 seconds), and honoured on secondary boards, which genuinely do go dark. The options-list membership change is untouched — the option still exists so "no page is active" is a *representable state*, which is the half that was correct.

```
_ TestActivePageRestore.test_active_page_none_option_is_refused_on_the_primary_board _
    settings.set_active_page_id.assert_not_called()
E   AssertionError: Expected 'set_active_page_id' to not have been called. Called 1 times.
E   Calls: [call(None)].
```

### Scope honesty

`Closes #1794` → `Refs #1794`. Of the issue's three sub-complaints: **(b)** re-selecting the same page and **(c)** MQTT Refresh Display are fixed here; **(a)** the select reflecting non-page content is not, and is filed as #1831. Dropping the push-invalidation makes (a) *more* visible, not less, so it is called out in the docs too.

### Docs

`docs/features/home-assistant-control.md` now states that manual writes stay on the board, that Refresh Display is a force refresh, and what the `None` option does and does not do.

## Status

Rebased on current `main`. `5305 passed, 1 skipped` (`tests/test_check_image_formats.py::TestRepositoryIsClean` deselected — it shells out to `git ls-files`, which cannot run inside the test container). `ruff 0.16.4` check + format clean.
