### PR TITLE
feat(countdown): add count-up mode for days-since events

### DIFF
--- a/docs/plugins/countdown.md
+++ b/docs/plugins/countdown.md
@@ -13,6 +13,7 @@ Display the remaining days, hours, minutes, and seconds until any target date. *
 The Countdown plugin shows the remaining time until a target date and time you set:
 
 - Days, hours, minutes, and seconds remaining
+- Optional **Count Up (Days Since)** mode counts upward from a past date instead — anniversaries, "days since launch", streaks
 - Automatically detects when the event has passed
 - Timezone-aware — configure any IANA timezone
 - Values update on every board refresh
@@ -23,7 +24,8 @@ The Countdown plugin shows the remaining time until a target date and time you s
 2. Go to the **Integrations** page
 3. Toggle **Countdown** on
 4. Click **Configure** and set the event name, target date/time, and timezone
-5. Click **Save Changes**
+5. Optionally toggle **Count Up (Days Since)** to count upward from a past date. A target still in the future counts down until it arrives, then counts up
+6. Click **Save Changes**
 
 :::tip
 Countdown requires no external service or API key. All values are computed locally.
@@ -35,13 +37,14 @@ Countdown requires no external service or API key. All values are computed local
 |----------|-------------|---------|
 | `{{countdown.event_name}}` | Configured event name | `Last Day of School` |
 | `{{countdown.target_datetime}}` | Target datetime (ISO 8601) | `2027-01-01T00:00:00` |
-| `{{countdown.days}}` | Whole days remaining | `86` |
-| `{{countdown.hours}}` | Hours remaining (0–23) | `14` |
-| `{{countdown.minutes}}` | Minutes remaining (0–59) | `30` |
-| `{{countdown.seconds}}` | Seconds remaining (0–59) | `45` |
-| `{{countdown.total_seconds}}` | Total seconds until target | `7473045` |
+| `{{countdown.days}}` | Whole days remaining (or elapsed in count-up mode) | `86` |
+| `{{countdown.hours}}` | Hours remaining or elapsed (0–23) | `14` |
+| `{{countdown.minutes}}` | Minutes remaining or elapsed (0–59) | `30` |
+| `{{countdown.seconds}}` | Seconds remaining or elapsed (0–59) | `45` |
+| `{{countdown.total_seconds}}` | Total seconds until (or since) the target | `7473045` |
 | `{{countdown.formatted}}` | Pre-formatted summary | `86D 14H 30M` |
 | `{{countdown.is_expired}}` | `"true"` once the target has passed | `false` |
+| `{{countdown.is_count_up}}` | `"true"` when values are counting up (count-up mode, past target) | `false` |
 
 ## Example Templates
 
@@ -67,6 +70,13 @@ Countdown requires no external service or API key. All values are computed local
 
 ```jinja
 {center}{{countdown.days}} DAYS UNTIL
+{{countdown.event_name}}
+```
+
+**Days since (count-up mode):**
+
+```jinja
+{center}{{countdown.days}} DAYS SINCE
 {{countdown.event_name}}
 ```
 

--- a/plugins/countdown/README.md
+++ b/plugins/countdown/README.md
@@ -1,6 +1,6 @@
 # Countdown Plugin
 
-Display the remaining time to an event in real time on your board.
+Display the time until an event — or, in count-up mode, the time since it — in real time on your board.
 
 ![Countdown Display](./docs/board-display.png)
 
@@ -8,7 +8,7 @@ Display the remaining time to an event in real time on your board.
 
 ## Overview
 
-The Countdown plugin shows the remaining days, hours, minutes, and seconds until a target date/time. Values recompute on every board refresh — useful for the last day of school, a wedding, a product launch, or any date you want to watch tick down.
+The Countdown plugin shows the remaining days, hours, minutes, and seconds until a target date/time. Values recompute on every board refresh — useful for the last day of school, a wedding, a product launch, or any date you want to watch tick down. With **Count Up (Days Since)** enabled, the same counters run upward from a past target instead — for anniversaries, "days since launch", streaks, and the like.
 
 ## Template Variables
 
@@ -18,17 +18,18 @@ The Countdown plugin shows the remaining days, hours, minutes, and seconds until
 |----------|-------------|---------|
 | `{{countdown.event_name}}` | Name of the event | `Last Day of School` |
 | `{{countdown.target_datetime}}` | Target datetime string | `2027-01-01T00:00:00` |
-| `{{countdown.is_expired}}` | `"true"` if the event has passed, `"false"` otherwise | `"false"` |
+| `{{countdown.is_expired}}` | `"true"` if the target datetime has passed, `"false"` otherwise | `"false"` |
+| `{{countdown.is_count_up}}` | `"true"` when values are counting up (count-up mode, past target) | `"false"` |
 
 ### Countdown Values
 
 | Variable | Description | Example |
 |----------|-------------|---------|
-| `{{countdown.days}}` | Remaining days | `22` |
-| `{{countdown.hours}}` | Remaining hours (0–23) | `3` |
-| `{{countdown.minutes}}` | Remaining minutes (0–59) | `10` |
-| `{{countdown.seconds}}` | Remaining seconds (0–59) | `45` |
-| `{{countdown.total_seconds}}` | Total remaining seconds | `1912245` |
+| `{{countdown.days}}` | Remaining days (or elapsed in count-up mode) | `22` |
+| `{{countdown.hours}}` | Remaining or elapsed hours (0–23) | `3` |
+| `{{countdown.minutes}}` | Remaining or elapsed minutes (0–59) | `10` |
+| `{{countdown.seconds}}` | Remaining or elapsed seconds (0–59) | `45` |
+| `{{countdown.total_seconds}}` | Total seconds until (or since) the target | `1912245` |
 | `{{countdown.formatted}}` | Pre-formatted string | `22D 3H 10M` |
 
 ## Example Templates
@@ -58,6 +59,13 @@ The Countdown plugin shows the remaining days, hours, minutes, and seconds until
 {{countdown.event_name}}
 ```
 
+### Days Since (Count-Up Mode)
+
+```jinja
+{center}{{countdown.days}} DAYS SINCE
+{{countdown.event_name}}
+```
+
 ### Full Countdown with Seconds
 
 ```jinja
@@ -74,10 +82,12 @@ The Countdown plugin shows the remaining days, hours, minutes, and seconds until
 | event_name | string | "Event" | Name of the event to count down to |
 | target_datetime | string | *(required)* | Target date/time in ISO format (e.g., `2027-01-01T00:00:00`) |
 | timezone | string | "America/Los_Angeles" | IANA timezone name |
+| count_up | boolean | false | Count up from the target instead of down to it. While the target is still in the future, the plugin counts down to it, then counts up once it passes |
 
 ## Features
 
 - **Real-time Countdown**: Days, hours, minutes, and seconds remaining
+- **Count-Up Mode**: Track "days since" a past date — anniversaries, launches, streaks
 - **Timezone-aware**: Configurable timezone with autocomplete picker
 - **Expired Detection**: Automatically detects when the event has passed
 - **Flexible Formatting**: Use individual components or the pre-formatted string

--- a/plugins/countdown/__init__.py
+++ b/plugins/countdown/__init__.py
@@ -87,7 +87,16 @@ class CountdownPlugin(PluginBase):
             delta = target.astimezone(UTC) - now.astimezone(UTC)
             total_seconds = int(delta.total_seconds())
 
-            if total_seconds <= 0:
+            # Count-up ("days since") mode: once the target has passed, count
+            # upward from it instead of freezing at zero (#1795). While the
+            # target is still in the future, count down to it as usual.
+            count_up = bool(self.config.get("count_up", False))
+            counting_up = count_up and total_seconds <= 0
+
+            if counting_up:
+                total_seconds = -total_seconds
+
+            if total_seconds <= 0 and not counting_up:
                 data = {
                     "event_name": event_name,
                     "target_datetime": target_str,
@@ -97,6 +106,7 @@ class CountdownPlugin(PluginBase):
                     "seconds": "0",
                     "total_seconds": "0",
                     "is_expired": "true",
+                    "is_count_up": "false",
                     "formatted": "Event has passed",
                 }
             else:
@@ -113,7 +123,8 @@ class CountdownPlugin(PluginBase):
                     "minutes": str(minutes),
                     "seconds": str(seconds),
                     "total_seconds": str(total_seconds),
-                    "is_expired": "false",
+                    "is_expired": "true" if counting_up else "false",
+                    "is_count_up": "true" if counting_up else "false",
                     "formatted": f"{days}D {hours}H {minutes}M",
                 }
 
@@ -151,9 +162,18 @@ class CountdownPlugin(PluginBase):
 
         event_name = data.get("event_name", "Event")
         is_expired = data.get("is_expired") == "true"
+        is_count_up = data.get("is_count_up") == "true"
 
         if height <= 3:
             # Compact layout for short boards (e.g. Note).
+            if is_count_up:
+                days = data.get("days", "0")
+                hours = data.get("hours", "0")
+                return [
+                    event_name[:width].upper().center(width),
+                    f"{days}D {hours}H".center(width),
+                    "SINCE".center(width),
+                ]
             if is_expired:
                 return [
                     event_name[:width].upper().center(width),
@@ -168,7 +188,7 @@ class CountdownPlugin(PluginBase):
                 "TO GO".center(width),
             ]
 
-        if is_expired:
+        if is_expired and not is_count_up:
             lines = [
                 "COUNTDOWN",
                 event_name[:width].upper().center(width),
@@ -182,8 +202,9 @@ class CountdownPlugin(PluginBase):
             hours = data.get("hours", "0")
             minutes = data.get("minutes", "0")
 
+            header = "TIME SINCE" if is_count_up else "COUNTDOWN UNTIL"
             lines = [
-                "COUNTDOWN UNTIL".center(width),
+                header.center(width),
                 event_name[:width].upper().center(width),
                 "",
                 f"{days} DAYS".center(width),

--- a/plugins/countdown/docs/SETUP.md
+++ b/plugins/countdown/docs/SETUP.md
@@ -7,8 +7,9 @@ Configure a target date and time, then watch the days, hours, and minutes tick d
 **What it does:**
 
 - Counts down to a target date and time in days, hours, minutes, and seconds
+- Optionally counts up from a past target instead ("days since" mode) — for anniversaries, launches, and streaks
 - Updates on every board refresh
-- Switches to "Event has passed" once the target is reached
+- Switches to "Event has passed" once the target is reached (unless count-up mode is on, in which case it keeps counting upward)
 - Respects an IANA timezone of your choice
 
 **Prerequisites:**
@@ -30,7 +31,8 @@ In the FiestaBoard web UI:
 2. Set the **Event Name** — for example, `Last Day of School`.
 3. Set the **Target Date & Time** in ISO 8601 format — for example, `2027-01-01T00:00:00`.
 4. Set the **Timezone** (defaults to `America/Los_Angeles`). The picker autocompletes IANA names.
-5. Click **Save Changes**.
+5. Optionally toggle **Count Up (Days Since)** to count upward from a past date — for example, an anniversary or "days since launch". If the target is still in the future, the plugin counts down to it, then counts up once it passes.
+6. Click **Save Changes**.
 
 ### 3. Add countdown variables to a page
 
@@ -57,15 +59,16 @@ Save the page. On the next refresh, your board will show the countdown.
 |----------|-------------|---------|
 | `{{countdown.event_name}}` | Configured event name | `Last Day of School` |
 | `{{countdown.target_datetime}}` | Target datetime (ISO 8601) | `2027-01-01T00:00:00` |
-| `{{countdown.days}}` | Whole days remaining | `86` |
-| `{{countdown.hours}}` | Hours remaining (0–23) | `14` |
-| `{{countdown.minutes}}` | Minutes remaining (0–59) | `30` |
-| `{{countdown.seconds}}` | Seconds remaining (0–59) | `45` |
-| `{{countdown.total_seconds}}` | Total seconds until target | `7482645` |
+| `{{countdown.days}}` | Whole days remaining (or elapsed in count-up mode) | `86` |
+| `{{countdown.hours}}` | Hours remaining or elapsed (0–23) | `14` |
+| `{{countdown.minutes}}` | Minutes remaining or elapsed (0–59) | `30` |
+| `{{countdown.seconds}}` | Seconds remaining or elapsed (0–59) | `45` |
+| `{{countdown.total_seconds}}` | Total seconds until (or since) the target | `7482645` |
 | `{{countdown.is_expired}}` | `"true"` once the target has passed | `"false"` |
+| `{{countdown.is_count_up}}` | `"true"` when values are counting up (count-up mode, past target) | `"false"` |
 | `{{countdown.formatted}}` | Pre-formatted summary | `86D 14H 30M` |
 
-> **Note:** When `is_expired` is `"true"`, `formatted` becomes `Event has passed` and the day/hour/minute counters are `0`.
+> **Note:** When `is_expired` is `"true"` and count-up mode is off, `formatted` becomes `Event has passed` and the day/hour/minute counters are `0`. With count-up mode on, the counters keep running upward instead.
 
 ## Configuration Reference
 
@@ -77,6 +80,7 @@ Save the page. On the next refresh, your board will show the countdown.
 | `event_name` | string | No | `Event` | Name shown via `{{countdown.event_name}}` |
 | `target_datetime` | string | Yes | — | Target date/time in ISO 8601 format (e.g. `2027-01-01T00:00:00`) |
 | `timezone` | string | No | `America/Los_Angeles` | IANA timezone name |
+| `count_up` | boolean | No | `false` | Count up from the target instead of down to it. A future target counts down until it arrives, then counts up |
 
 ### Environment variables
 
@@ -98,7 +102,7 @@ The target date/time is missing. Set `target_datetime` in the UI or `COUNTDOWN_T
 The configured timezone does not match the timezone you intended for the target. Verify the IANA name (for example, `America/Los_Angeles`, not `PST`).
 
 **Board shows "Event has passed".**
-The target datetime is in the past. Update it to a future date and time.
+The target datetime is in the past. Update it to a future date and time — or, if you want to track time *since* that date, enable **Count Up (Days Since)** instead.
 
 **Configuration save fails with "Invalid target datetime format".**
 The value must be ISO 8601 — `YYYY-MM-DDTHH:MM:SS`. For example, `2027-01-01T00:00:00`.

--- a/plugins/countdown/manifest.json
+++ b/plugins/countdown/manifest.json
@@ -1,8 +1,8 @@
 {
   "id": "countdown",
   "name": "Countdown",
-  "version": "1.2.0",
-  "description": "Display the remaining time to an event in real time",
+  "version": "1.3.0",
+  "description": "Display the time until an event — or, in count-up mode, the time since it — in real time",
   "author": "FiestaBoard Team",
   "repository": "https://github.com/FiestaBoard/FiestaBoard",
   "documentation": "README.md",
@@ -34,6 +34,12 @@
         "description": "IANA timezone name (e.g., America/Los_Angeles)",
         "default": "America/Los_Angeles",
         "ui:widget": "timezone"
+      },
+      "count_up": {
+        "type": "boolean",
+        "title": "Count Up (Days Since)",
+        "description": "Count up from the target instead of down to it — for anniversaries and 'days since' events. While the target is still in the future, the plugin counts down to it, then counts up once it passes.",
+        "default": false
       }
     },
     "required": [
@@ -75,42 +81,49 @@
         "example": "2030-01-01T00:00:00"
       },
       "is_expired": {
-        "description": "Whether the countdown has reached zero",
+        "description": "Whether the target datetime has passed",
+        "type": "string",
+        "group": "event",
+        "max_length": 5,
+        "example": "false"
+      },
+      "is_count_up": {
+        "description": "Whether values are counting up (time since a past target in count-up mode)",
         "type": "string",
         "group": "event",
         "max_length": 5,
         "example": "false"
       },
       "days": {
-        "description": "Days remaining",
+        "description": "Days remaining (or elapsed in count-up mode)",
         "type": "number",
         "group": "countdown",
         "max_length": 5,
         "example": "86"
       },
       "hours": {
-        "description": "Hours remaining (0-23)",
+        "description": "Hours remaining or elapsed (0-23)",
         "type": "number",
         "group": "countdown",
         "max_length": 2,
         "example": "14"
       },
       "minutes": {
-        "description": "Minutes remaining (0-59)",
+        "description": "Minutes remaining or elapsed (0-59)",
         "type": "number",
         "group": "countdown",
         "max_length": 2,
         "example": "30"
       },
       "seconds": {
-        "description": "Seconds remaining (0-59)",
+        "description": "Seconds remaining or elapsed (0-59)",
         "type": "number",
         "group": "countdown",
         "max_length": 2,
         "example": "45"
       },
       "total_seconds": {
-        "description": "Total seconds until target",
+        "description": "Total seconds until the target (or since it in count-up mode)",
         "type": "number",
         "group": "countdown",
         "max_length": 10,

--- a/plugins/countdown/tests/test_plugin.py
+++ b/plugins/countdown/tests/test_plugin.py
@@ -328,6 +328,114 @@ class TestCountdownPlugin:
         assert result.data["event_name"] == "Event"
 
 
+class TestCountdownCountUp:
+    """Count-up ("days since") mode — #1795."""
+
+    @patch("plugins.countdown.datetime")
+    def test_count_up_past_target_counts_elapsed_time(self, mock_datetime, sample_manifest, sample_config):
+        """With count_up on and a past target, values count upward from it."""
+        tz = ZoneInfo("America/Los_Angeles")
+        # 30 days, 20 hours, 50 minutes after the 2025-06-15T00:00:00 target.
+        mock_datetime.now.return_value = datetime(2025, 7, 15, 20, 50, 0, tzinfo=tz)
+        mock_datetime.fromisoformat = datetime.fromisoformat
+
+        plugin = CountdownPlugin(sample_manifest)
+        plugin.config = {**sample_config, "count_up": True}
+        result = plugin.fetch_data()
+
+        assert result.available is True
+        data = result.data
+        assert data["days"] == "30"
+        assert data["hours"] == "20"
+        assert data["minutes"] == "50"
+        assert data["seconds"] == "0"
+        assert data["total_seconds"] == "2667000"
+        assert data["is_expired"] == "true"
+        assert data["is_count_up"] == "true"
+        assert data["formatted"] == "30D 20H 50M"
+
+    @patch("plugins.countdown.datetime")
+    def test_count_up_flagship_display_says_since(self, mock_datetime, sample_manifest, sample_config):
+        """Flagship display announces time SINCE the event, not a passed event."""
+        tz = ZoneInfo("America/Los_Angeles")
+        mock_datetime.now.return_value = datetime(2025, 7, 15, 20, 50, 0, tzinfo=tz)
+        mock_datetime.fromisoformat = datetime.fromisoformat
+
+        plugin = CountdownPlugin(sample_manifest)
+        plugin.config = {**sample_config, "count_up": True}
+        lines = plugin.get_data(BoardContext.from_device_type("flagship")).formatted_lines
+
+        assert lines is not None
+        assert len(lines) == 6
+        assert all(len(line) <= 22 for line in lines)
+        assert "SINCE" in lines[0].upper()
+        assert not any("PASSED" in line.upper() for line in lines)
+        assert "30 DAYS" in lines[3].upper()
+
+    @patch("plugins.countdown.datetime")
+    def test_count_up_note_compact_says_since(self, mock_datetime, sample_manifest, sample_config):
+        """Note (15x3) count-up layout fits and says SINCE instead of TO GO."""
+        tz = ZoneInfo("America/Los_Angeles")
+        mock_datetime.now.return_value = datetime(2025, 7, 15, 20, 50, 0, tzinfo=tz)
+        mock_datetime.fromisoformat = datetime.fromisoformat
+
+        plugin = CountdownPlugin(sample_manifest)
+        plugin.config = {**sample_config, "count_up": True}
+        lines = plugin.get_data(BoardContext.from_device_type("note")).formatted_lines
+
+        assert lines is not None
+        assert len(lines) == 3
+        assert all(len(line) <= 15 for line in lines)
+        assert any("SINCE" in line.upper() for line in lines)
+        assert not any("TO GO" in line.upper() for line in lines)
+
+    @patch("plugins.countdown.datetime")
+    def test_count_up_future_target_counts_down_until_it_arrives(self, mock_datetime, sample_manifest, sample_config):
+        """count_up with a future target counts down to it (then up after)."""
+        tz = ZoneInfo("America/Los_Angeles")
+        # 21 days, 3 hours, 10 minutes before the target.
+        mock_datetime.now.return_value = datetime(2025, 5, 24, 20, 50, 0, tzinfo=tz)
+        mock_datetime.fromisoformat = datetime.fromisoformat
+
+        plugin = CountdownPlugin(sample_manifest)
+        plugin.config = {**sample_config, "count_up": True}
+        result = plugin.fetch_data()
+
+        data = result.data
+        assert data["days"] == "21"
+        assert data["hours"] == "3"
+        assert data["minutes"] == "10"
+        assert data["is_expired"] == "false"
+        assert data["is_count_up"] == "false"
+        assert data["formatted"] == "21D 3H 10M"
+
+    @patch("plugins.countdown.datetime")
+    def test_count_up_off_past_target_still_reports_expired_zeros(self, mock_datetime, sample_manifest, sample_config):
+        """Default (count_up off) keeps the historical expired behavior exactly."""
+        tz = ZoneInfo("America/Los_Angeles")
+        mock_datetime.now.return_value = datetime(2025, 7, 1, 0, 0, 0, tzinfo=tz)
+        mock_datetime.fromisoformat = datetime.fromisoformat
+
+        plugin = CountdownPlugin(sample_manifest)
+        plugin.config = sample_config
+        data = plugin.fetch_data().data
+
+        assert data["is_expired"] == "true"
+        assert data["is_count_up"] == "false"
+        assert data["total_seconds"] == "0"
+        assert data["formatted"] == "Event has passed"
+
+    def test_manifest_declares_count_up_boolean_default_off(self):
+        """count_up is a boolean setting defaulting to false in the schema."""
+        manifest_path = Path(__file__).parent.parent / "manifest.json"
+        with open(manifest_path) as f:
+            manifest = json.load(f)
+
+        prop = manifest["settings_schema"]["properties"]["count_up"]
+        assert prop["type"] == "boolean"
+        assert prop["default"] is False
+
+
 class TestCountdownManifestMetadata:
     """Tests for the rich metadata format in the countdown manifest."""
 

--- a/plugins/countdown/tests/test_plugin.py
+++ b/plugins/countdown/tests/test_plugin.py
@@ -6,8 +6,15 @@ from pathlib import Path
 from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
+import plugins.countdown as countdown_module
 from plugins.countdown import CountdownPlugin
 from src.devices import BoardContext
+
+# Patch the module object captured at import time rather than the
+# "plugins.countdown" dotted path. The plugin loader replaces the
+# sys.modules entry when it loads plugins (src/plugins/loader.py), so in a
+# full-suite run the dotted path resolves to a different module object than
+# the one CountdownPlugin above was defined in — and the mock never applies.
 
 
 class TestCountdownPlugin:
@@ -63,7 +70,7 @@ class TestCountdownPlugin:
         errors = plugin.validate_config(config)
         assert len(errors) == 0
 
-    @patch("plugins.countdown.datetime")
+    @patch.object(countdown_module, "datetime")
     def test_fetch_data_future_event(self, mock_datetime, sample_manifest, sample_config):
         """Test fetch_data with a future target date."""
         tz = ZoneInfo("America/Los_Angeles")
@@ -88,7 +95,7 @@ class TestCountdownPlugin:
         assert int(data["seconds"]) >= 0
         assert int(data["total_seconds"]) > 0
 
-    @patch("plugins.countdown.datetime")
+    @patch.object(countdown_module, "datetime")
     def test_fetch_data_exact_values(self, mock_datetime, sample_manifest, sample_config):
         """Test fetch_data returns correct countdown values."""
         tz = ZoneInfo("America/Los_Angeles")
@@ -107,7 +114,7 @@ class TestCountdownPlugin:
         assert data["minutes"] == "10"
         assert data["seconds"] == "0"
 
-    @patch("plugins.countdown.datetime")
+    @patch.object(countdown_module, "datetime")
     def test_fetch_data_expired_event(self, mock_datetime, sample_manifest, sample_config):
         """Test fetch_data when the event has already passed."""
         tz = ZoneInfo("America/Los_Angeles")
@@ -159,7 +166,7 @@ class TestCountdownPlugin:
         assert result.available is False
         assert result.error is not None
 
-    @patch("plugins.countdown.datetime")
+    @patch.object(countdown_module, "datetime")
     def test_fetch_data_all_variables(self, mock_datetime, sample_manifest, sample_config):
         """Test fetch_data returns all expected variables from manifest."""
         tz = ZoneInfo("America/Los_Angeles")
@@ -183,7 +190,7 @@ class TestCountdownPlugin:
         for var in var_names:
             assert var in data, f"Variable '{var}' declared in manifest but not in data"
 
-    @patch("plugins.countdown.datetime")
+    @patch.object(countdown_module, "datetime")
     def test_fetch_data_formatted_lines(self, mock_datetime, sample_manifest, sample_config):
         """Test fetch_data returns formatted lines for the board."""
         tz = ZoneInfo("America/Los_Angeles")
@@ -198,7 +205,7 @@ class TestCountdownPlugin:
         assert result.formatted_lines is not None
         assert len(result.formatted_lines) == 6
 
-    @patch("plugins.countdown.datetime")
+    @patch.object(countdown_module, "datetime")
     def test_get_formatted_display(self, mock_datetime, sample_manifest, sample_config):
         """Test get_formatted_display returns 6 lines."""
         tz = ZoneInfo("America/Los_Angeles")
@@ -217,7 +224,7 @@ class TestCountdownPlugin:
         assert "HOURS" in lines[4].upper()
         assert "MINUTES" in lines[5].upper()
 
-    @patch("plugins.countdown.datetime")
+    @patch.object(countdown_module, "datetime")
     def test_get_formatted_display_expired(self, mock_datetime, sample_manifest, sample_config):
         """Test formatted display when event has passed."""
         tz = ZoneInfo("America/Los_Angeles")
@@ -241,7 +248,7 @@ class TestCountdownPlugin:
 
         assert lines is None
 
-    @patch("plugins.countdown.datetime")
+    @patch.object(countdown_module, "datetime")
     def test_fetch_data_formatted_string(self, mock_datetime, sample_manifest, sample_config):
         """Test the formatted countdown string."""
         tz = ZoneInfo("America/Los_Angeles")
@@ -255,7 +262,7 @@ class TestCountdownPlugin:
 
         assert result.data["formatted"] == "21D 3H 10M"
 
-    @patch("plugins.countdown.datetime")
+    @patch.object(countdown_module, "datetime")
     def test_fetch_data_dst_spring_forward(self, mock_datetime, sample_manifest):
         """Countdown across the DST spring-forward boundary loses an hour (#926).
 
@@ -286,7 +293,7 @@ class TestCountdownPlugin:
         assert data["hours"] == "23"
         assert data["total_seconds"] == "82800"
 
-    @patch("plugins.countdown.datetime")
+    @patch.object(countdown_module, "datetime")
     def test_fetch_data_dst_fall_back(self, mock_datetime, sample_manifest):
         """Countdown across the DST fall-back boundary gains an hour (#926)."""
         tz = ZoneInfo("America/Los_Angeles")
@@ -310,7 +317,7 @@ class TestCountdownPlugin:
         assert data["hours"] == "1"
         assert data["total_seconds"] == "90000"
 
-    @patch("plugins.countdown.datetime")
+    @patch.object(countdown_module, "datetime")
     def test_fetch_data_default_event_name(self, mock_datetime, sample_manifest):
         """Test default event name when not configured."""
         tz = ZoneInfo("America/Los_Angeles")
@@ -331,7 +338,7 @@ class TestCountdownPlugin:
 class TestCountdownCountUp:
     """Count-up ("days since") mode — #1795."""
 
-    @patch("plugins.countdown.datetime")
+    @patch.object(countdown_module, "datetime")
     def test_count_up_past_target_counts_elapsed_time(self, mock_datetime, sample_manifest, sample_config):
         """With count_up on and a past target, values count upward from it."""
         tz = ZoneInfo("America/Los_Angeles")
@@ -354,7 +361,7 @@ class TestCountdownCountUp:
         assert data["is_count_up"] == "true"
         assert data["formatted"] == "30D 20H 50M"
 
-    @patch("plugins.countdown.datetime")
+    @patch.object(countdown_module, "datetime")
     def test_count_up_flagship_display_says_since(self, mock_datetime, sample_manifest, sample_config):
         """Flagship display announces time SINCE the event, not a passed event."""
         tz = ZoneInfo("America/Los_Angeles")
@@ -372,7 +379,7 @@ class TestCountdownCountUp:
         assert not any("PASSED" in line.upper() for line in lines)
         assert "30 DAYS" in lines[3].upper()
 
-    @patch("plugins.countdown.datetime")
+    @patch.object(countdown_module, "datetime")
     def test_count_up_note_compact_says_since(self, mock_datetime, sample_manifest, sample_config):
         """Note (15x3) count-up layout fits and says SINCE instead of TO GO."""
         tz = ZoneInfo("America/Los_Angeles")
@@ -389,7 +396,7 @@ class TestCountdownCountUp:
         assert any("SINCE" in line.upper() for line in lines)
         assert not any("TO GO" in line.upper() for line in lines)
 
-    @patch("plugins.countdown.datetime")
+    @patch.object(countdown_module, "datetime")
     def test_count_up_future_target_counts_down_until_it_arrives(self, mock_datetime, sample_manifest, sample_config):
         """count_up with a future target counts down to it (then up after)."""
         tz = ZoneInfo("America/Los_Angeles")
@@ -409,7 +416,7 @@ class TestCountdownCountUp:
         assert data["is_count_up"] == "false"
         assert data["formatted"] == "21D 3H 10M"
 
-    @patch("plugins.countdown.datetime")
+    @patch.object(countdown_module, "datetime")
     def test_count_up_off_past_target_still_reports_expired_zeros(self, mock_datetime, sample_manifest, sample_config):
         """Default (count_up off) keeps the historical expired behavior exactly."""
         tz = ZoneInfo("America/Los_Angeles")
@@ -486,7 +493,7 @@ class TestCountdownManifestMetadata:
 class TestCountdownBoardAwareness:
     """The countdown display adapts to the board it renders on."""
 
-    @patch("plugins.countdown.datetime")
+    @patch.object(countdown_module, "datetime")
     def test_flagship_unchanged_six_lines(self, mock_datetime, sample_manifest, sample_config):
         """Flagship (22x6) keeps the full six-line labelled layout."""
         tz = ZoneInfo("America/Los_Angeles")
@@ -503,7 +510,7 @@ class TestCountdownBoardAwareness:
         assert all(len(line) <= 22 for line in lines)
         assert "COUNTDOWN" in lines[0].upper()
 
-    @patch("plugins.countdown.datetime")
+    @patch.object(countdown_module, "datetime")
     def test_note_compact_three_lines(self, mock_datetime, sample_manifest, sample_config):
         """Note (15x3) drops to a compact three-line layout that fits 15 cols."""
         tz = ZoneInfo("America/Los_Angeles")
@@ -519,7 +526,7 @@ class TestCountdownBoardAwareness:
         assert len(lines) == 3
         assert all(len(line) <= 15 for line in lines)
 
-    @patch("plugins.countdown.datetime")
+    @patch.object(countdown_module, "datetime")
     def test_note_compact_expired(self, mock_datetime, sample_manifest, sample_config):
         """An expired event on a Note still fits the compact three-line layout."""
         tz = ZoneInfo("America/Los_Angeles")
@@ -535,7 +542,7 @@ class TestCountdownBoardAwareness:
         assert all(len(line) <= 15 for line in lines)
         assert any("PASSED" in line.upper() for line in lines)
 
-    @patch("plugins.countdown.datetime")
+    @patch.object(countdown_module, "datetime")
     def test_per_board_cache_isolation(self, mock_datetime, sample_manifest, sample_config):
         """Flagship and Note renders cache independently (no cross-contamination)."""
         tz = ZoneInfo("America/Los_Angeles")
@@ -554,7 +561,7 @@ class TestCountdownBoardAwareness:
         # not the 3-line note variant that was cached afterwards.
         assert len(plugin.get_data(BoardContext.from_device_type("flagship")).formatted_lines) == 6
 
-    @patch("plugins.countdown.datetime")
+    @patch.object(countdown_module, "datetime")
     def test_no_board_defaults_to_flagship(self, mock_datetime, sample_manifest, sample_config):
         """With no board bound, output matches the historical 22x6 layout."""
         tz = ZoneInfo("America/Los_Angeles")


### PR DESCRIPTION
Closes #1795.

Adds a count-up mode to the countdown plugin for days-since events, alongside the existing countdown behavior.

Includes a test fix: patch the imported module object so mocks survive loader reloads.

Authored earlier in a local worktree and never pushed; surfacing now for CI verification.