### PR TITLE
fix(api): run plugin install and update off the event loop

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -9979,12 +9979,16 @@ class ExternalPluginInstallRequest(BaseModel):
 async def install_registry_plugin(plugin_id: str):
     """
     Install a plugin from the curated registry by its id.
+
+    The install shells out to ``git`` (up to 120 s) and then imports the
+    plugin package, so it runs in a worker thread — inline it would seize the
+    event loop and freeze every other request for the whole clone (#1750).
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
         raise HTTPException(status_code=503, detail="Plugin system is not available.")
 
     registry = get_plugin_registry()
-    errors = registry.install_from_registry(plugin_id)
+    errors = await asyncio.to_thread(registry.install_from_registry, plugin_id)
 
     if errors:
         raise HTTPException(status_code=400, detail="; ".join(errors))
@@ -10003,6 +10007,9 @@ async def install_external_plugin(request: ExternalPluginInstallRequest):
 
     The repository does not need to follow the ``fiestaboard-plugin--``
     naming convention (that requirement only applies to registry plugins).
+
+    The clone runs in a worker thread so a slow or unreachable remote cannot
+    block the event loop (#1750).
     """
     if not PLUGIN_SYSTEM_AVAILABLE:
         raise HTTPException(status_code=503, detail="Plugin system is not available.")
@@ -10018,7 +10025,8 @@ async def install_external_plugin(request: ExternalPluginInstallRequest):
     safe_plugin_id = _sanitize_optional_plugin_id(request.plugin_id)
 
     registry = get_plugin_registry()
-    errors = registry.install_from_git(
+    errors = await asyncio.to_thread(
+        registry.install_from_git,
         request.repository,
         plugin_id=safe_plugin_id,
         branch=safe_branch,
@@ -10152,11 +10160,13 @@ async def update_plugin(plugin_id: str):
 
     # Pass the validated plugin_id — clone_or_update_repo resolves the path
     # internally so no user-controlled Path flows into subprocess sinks.
-    ok, err = clone_or_update_repo("", plugin_id, external_dir=_ext_dir)
+    # Both the git fetch and the module reimport go to a worker thread so the
+    # event loop keeps serving other requests during the update (#1750).
+    ok, err = await asyncio.to_thread(clone_or_update_repo, "", plugin_id, external_dir=_ext_dir)
     if not ok:
         raise HTTPException(status_code=500, detail=f"Update failed: {err}")
 
-    reloaded = registry.reload_plugin(plugin_id)
+    reloaded = await asyncio.to_thread(registry.reload_plugin, plugin_id)
     if reloaded is None:
         errors = registry.get_load_errors().get(plugin_id, [])
         detail = "; ".join(errors) if errors else "Plugin failed to reload after update."
@@ -10221,12 +10231,14 @@ async def apply_all_plugin_updates():
 
         # Pass the validated plugin_id — clone_or_update_repo resolves the path
         # internally so no user-controlled Path flows into subprocess sinks.
-        ok, err = clone_or_update_repo("", plugin_id, external_dir=_ext_dir)
+        # A bulk update is N sequential git fetches; keeping them on the loop
+        # would freeze the API for the sum of all of them (#1750).
+        ok, err = await asyncio.to_thread(clone_or_update_repo, "", plugin_id, external_dir=_ext_dir)
         if not ok:
             failed[plugin_id] = f"git fetch failed: {err}"
             continue
 
-        reloaded = registry.reload_plugin(plugin_id)
+        reloaded = await asyncio.to_thread(registry.reload_plugin, plugin_id)
         if reloaded is None:
             errors = registry.get_load_errors().get(plugin_id, [])
             failed[plugin_id] = "; ".join(errors) if errors else "Reload failed."

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -1938,7 +1938,13 @@ def _resolve_auto_update_interval(state: dict[str, Any]) -> str:
 
 
 async def _auto_apply_plugin_updates(registry: Any, plugin_ids: list) -> None:
-    """Silently apply pending plugin updates in the background update loop."""
+    """Silently apply pending plugin updates in the background update loop.
+
+    Runs unattended from ``_plugin_update_check_loop`` once an hour, so the git
+    fetch and the module reimport go to worker threads: inline they would seize
+    the event loop for up to 120 s per plugin with nobody having asked for
+    anything, and the board would simply stop updating (#1750).
+    """
     import os as _os
     from pathlib import Path as _Path
 
@@ -1968,13 +1974,13 @@ async def _auto_apply_plugin_updates(registry: Any, plugin_ids: list) -> None:
             failed.append(plugin_id)
             continue
 
-        ok, err = clone_or_update_repo("", plugin_id, external_dir=_ext_dir)
+        ok, err = await asyncio.to_thread(clone_or_update_repo, "", plugin_id, external_dir=_ext_dir)
         if not ok:
             logger.warning("Auto-update: git fetch failed for %s: %s", plugin_id, err)
             failed.append(plugin_id)
             continue
 
-        reloaded = registry.reload_plugin(plugin_id)
+        reloaded = await asyncio.to_thread(registry.reload_plugin, plugin_id)
         if reloaded is None:
             logger.warning("Auto-update: reload failed for %s", plugin_id)
             failed.append(plugin_id)

--- a/tests/test_plugin_install_event_loop.py
+++ b/tests/test_plugin_install_event_loop.py
@@ -21,7 +21,7 @@ from unittest.mock import Mock, patch
 import httpx
 import pytest
 
-from src.api_server import app
+from src.api_server import _auto_apply_plugin_updates, app
 
 # Wall-clock cap on every blocking stub.  The worker keeps running after the
 # request that started it, so an uncapped stub would wedge the suite; the cap
@@ -157,3 +157,29 @@ async def test_a_slow_bulk_update_does_not_block_the_event_loop():
 
     health, waited, still_running = await _health_while_in_flight(_apply)
     _assert_loop_stayed_free(health, waited, still_running, "bulk update")
+
+
+@pytest.mark.asyncio
+async def test_a_slow_auto_update_does_not_block_the_event_loop():
+    """The hourly auto-update loop fetches and reimports with no user watching.
+
+    ``_auto_apply_plugin_updates`` is driven by ``_plugin_update_check_loop``
+    every hour.  Blocking there is the worst of the set: nobody pressed a
+    button, so an unattended two-minute freeze just looks like the board
+    having died.
+    """
+
+    async def _auto_update(_ac, release):
+        registry = Mock()
+        registry.get_plugin_source.return_value = Mock(source_type="external", local_path="/fake/path")
+        registry.reload_plugin.return_value = Mock()
+        registry._update_status = {"plugin_a": True}
+        with (
+            patch("pathlib.Path.is_dir", return_value=True),
+            patch("src.plugins.sources.get_external_plugins_dir", return_value=Path("/fake")),
+            patch("src.plugins.sources.clone_or_update_repo", _blocking(release, (True, ""))),
+        ):
+            return await _auto_apply_plugin_updates(registry, ["plugin_a"])
+
+    health, waited, still_running = await _health_while_in_flight(_auto_update)
+    _assert_loop_stayed_free(health, waited, still_running, "auto-update")

--- a/tests/test_plugin_install_event_loop.py
+++ b/tests/test_plugin_install_event_loop.py
@@ -1,0 +1,159 @@
+"""Watchdog tests: installing or updating a plugin must not freeze the API.
+
+The plugin install/update endpoints shell out to ``git`` with timeouts of up
+to 120 s.  Every one of them is an ``async def``, so running that subprocess
+inline seizes the single asyncio event loop for its whole duration and the
+entire web UI — every board, every page, every poll — stops answering until
+the clone finishes (#1750).
+
+These tests assert the *symptom* rather than the mechanism: a cheap endpoint
+(``GET /health``) must answer while a slow install is still in flight.  Any
+correct fix (``asyncio.to_thread``, ``run_in_executor``, a plain ``def``
+handler) satisfies them; no particular one is required.
+"""
+
+import asyncio
+import threading
+import time
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import httpx
+import pytest
+
+from src.api_server import app
+
+# Wall-clock cap on every blocking stub.  The worker keeps running after the
+# request that started it, so an uncapped stub would wedge the suite; the cap
+# is a safety valve, not the thing under test — the assertions below fire on
+# ordering and latency, both of which resolve long before it.
+_BLOCK_SECONDS = 5.0
+
+# A blocked event loop cannot serve /health at all, so the bar only has to
+# separate "answered immediately" from "answered after the git subprocess".
+_HEALTH_BUDGET_SECONDS = 0.5
+
+
+def _blocking(release: threading.Event, result):
+    """Return a callable that hangs until *release* is set, then returns *result*."""
+
+    def _stub(*_args, **_kwargs):
+        release.wait(_BLOCK_SECONDS)
+        return result
+
+    return _stub
+
+
+async def _health_while_in_flight(request_factory):
+    """Fire *request_factory* then race ``GET /health`` against it.
+
+    Returns ``(health_response, seconds_waited, still_running)``.
+    """
+    release = threading.Event()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as ac:
+        # The stopwatch starts *before* the yield that lets the install reach
+        # its handler: a blocking handler seizes the loop during that yield, so
+        # timing only the /health await would measure the world after the block
+        # had already ended and would pass either way.
+        started = time.monotonic()
+        in_flight = asyncio.create_task(request_factory(ac, release))
+        await asyncio.sleep(0.05)
+
+        health = await ac.get("/health")
+        waited = time.monotonic() - started
+        still_running = not in_flight.done()
+
+        release.set()
+        await in_flight
+
+    return health, waited, still_running
+
+
+def _assert_loop_stayed_free(health, waited, still_running, what: str):
+    assert health.status_code == 200
+    assert waited < _HEALTH_BUDGET_SECONDS, (
+        f"/health waited {waited:.2f}s behind the {what} — the event loop was blocked"
+    )
+    assert still_running, f"the {what} finished too early to prove anything"
+
+
+@pytest.mark.asyncio
+async def test_a_slow_registry_install_does_not_block_the_event_loop():
+    """POST /plugins/registry/{id}/install runs ``git fetch`` with a 120 s timeout."""
+
+    async def _install(ac, release):
+        registry = Mock()
+        registry.install_from_registry = _blocking(release, [])
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_plugin_registry", return_value=registry),
+        ):
+            return await ac.post("/plugins/registry/dad_jokes/install")
+
+    health, waited, still_running = await _health_while_in_flight(_install)
+    _assert_loop_stayed_free(health, waited, still_running, "registry install")
+
+
+@pytest.mark.asyncio
+async def test_a_slow_git_install_does_not_block_the_event_loop():
+    """POST /plugins/install clones an arbitrary repository over the network."""
+
+    async def _install(ac, release):
+        registry = Mock()
+        registry.install_from_git = _blocking(release, [])
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_plugin_registry", return_value=registry),
+            patch("src.plugins.sources.repo_name_from_url", return_value="fiestaboard-plugin--x"),
+            patch("src.plugins.sources.plugin_id_from_repo_name", return_value="x"),
+        ):
+            return await ac.post("/plugins/install", json={"repository": "https://github.com/example/repo"})
+
+    health, waited, still_running = await _health_while_in_flight(_install)
+    _assert_loop_stayed_free(health, waited, still_running, "git install")
+
+
+@pytest.mark.asyncio
+async def test_a_slow_plugin_update_does_not_block_the_event_loop():
+    """POST /plugins/{id}/update calls the same 120 s ``git fetch``."""
+
+    async def _update(ac, release):
+        registry = Mock()
+        registry.get_plugin_source.return_value = Mock(source_type="external", local_path="/fake/path")
+        registry.reload_plugin.return_value = Mock()
+        registry._update_status = {}
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_plugin_registry", return_value=registry),
+            patch("pathlib.Path.is_dir", return_value=True),
+            patch("src.plugins.sources.get_external_plugins_dir", return_value=Path("/fake")),
+            patch("src.plugins.sources.clone_or_update_repo", _blocking(release, (True, ""))),
+        ):
+            return await ac.post("/plugins/test_plugin/update")
+
+    health, waited, still_running = await _health_while_in_flight(_update)
+    _assert_loop_stayed_free(health, waited, still_running, "plugin update")
+
+
+@pytest.mark.asyncio
+async def test_a_slow_bulk_update_does_not_block_the_event_loop():
+    """POST /plugins/updates/apply fetches every pending plugin in a loop."""
+
+    async def _apply(ac, release):
+        registry = Mock()
+        registry.get_update_status.return_value = {"plugin_a": True}
+        registry.get_plugin_source.return_value = Mock(source_type="external", local_path="/fake/path")
+        registry.reload_plugin.return_value = Mock()
+        registry._update_status = {"plugin_a": True}
+        with (
+            patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.api_server.get_plugin_registry", return_value=registry),
+            patch("pathlib.Path.is_dir", return_value=True),
+            patch("src.plugins.sources.get_external_plugins_dir", return_value=Path("/fake")),
+            patch("src.plugins.sources.clone_or_update_repo", _blocking(release, (True, ""))),
+        ):
+            return await ac.post("/plugins/updates/apply")
+
+    health, waited, still_running = await _health_while_in_flight(_apply)
+    _assert_loop_stayed_free(health, waited, still_running, "bulk update")

--- a/web/tests/multi-board.spec.ts
+++ b/web/tests/multi-board.spec.ts
@@ -586,6 +586,16 @@ test.describe("Cross-Feature – Board Config affects Pages", () => {
     await resetToSingleBoard();
     await suppressWizard(page);
     await deleteAllPages();
+    // deleteAllPages() cannot actually empty the store: deleting the *last*
+    // page regenerates a Welcome carrying that page's device_type (issue
+    // #1307, src/pages/service.py). If a note page happened to be deleted
+    // last — which an earlier spec on this worker's backend decides, not this
+    // one — the store is left holding a note-typed Welcome, and a note-typed
+    // PAGE keeps the Note tab alive on its own (issue #943). The state is
+    // self-perpetuating, so a retry sees it too. Anchor a flagship page so
+    // the store never empties, then clear the note pages.
+    await createPage(`Flagship Anchor ${Date.now() % 1_000_000}`);
+    await deletePagesByDevice("note");
   });
 
   test.afterEach(async () => {


### PR DESCRIPTION
Refs #1750

Deliberately **not** `Closes` — #1750 names four families of blocking calls and this PR fixes one of them plus a fifth path the issue missed. See [Scope](#scope-what-this-pr-does-not-fix) below.

## Root cause

The plugin install/update endpoints are all `async def`, but they call `git` through `subprocess.run` inline on the event loop. `clone_or_update_repo` (`src/plugins/sources.py:382`, `:391`, `:422`) runs `git fetch --depth=1` with a **120 second** timeout, followed by `git reset --hard`; the registry then does an `importlib` load of the freshly cloned package. FiestaBoard is a single-process ASGI app with one event loop, so for the entire duration of that clone nothing else runs — the board stops being driven, every page in the web UI hangs, `/health` does not answer. Four other handlers in the same file already use `asyncio.to_thread`; the pattern existed but was not applied here.

## What moved off-loop

Each blocking section is now dispatched with `asyncio.to_thread`:

| Path | Call moved |
| --- | --- |
| `POST /plugins/registry/{plugin_id}/install` | `registry.install_from_registry` (git fetch/reset + plugin import) |
| `POST /plugins/install` | `registry.install_from_git` (git init/fetch/reset + plugin import) |
| `POST /plugins/{plugin_id}/update` | `clone_or_update_repo`, `registry.reload_plugin` |
| `POST /plugins/updates/apply` | `clone_or_update_repo`, `registry.reload_plugin` — per plugin, so a bulk update no longer freezes the API for the sum of N fetches |
| `_auto_apply_plugin_updates` (`src/api_server.py:1971`) | `clone_or_update_repo`, `registry.reload_plugin` — per plugin |

The last row is not named in #1750 and is arguably the most impactful of the set. `_plugin_update_check_loop` (`src/api_server.py:782`) calls it **once an hour, unattended**, on every install that has auto-update on. Nobody pressed a button, so the up-to-120s-per-plugin freeze doesn't read as a slow request — the user's board just stops updating for two minutes every hour whenever an update is available.

No executor is created: `asyncio.to_thread` uses the loop's default threadpool, so there is no shutdown semantics question and the deliberate `shutdown(wait=False, cancel_futures=True)` pattern in `src/plugins/registry.py` is untouched. The path-validation and CodeQL sanitiser scopes in the handlers are unchanged — only the call site of the already-validated arguments moved.

<a name="scope-what-this-pr-does-not-fix"></a>
## Scope: what this PR does not fix

#1750 names four families. This PR fixes one of them (install/update) and adds the auto-update loop. Three remain, so the issue must stay open:

| Named in #1750 | Fixed here? | Still blocking |
| --- | --- | --- |
| `POST /plugins/registry/{id}/install` | ✅ | — |
| `POST /refresh` (`src/api_server.py:3109`) | ❌ | full render + 10 s board POST + up to 120 s transition |
| `POST /force-refresh` (`src/api_server.py:8776`) | ❌ | same render + board POST path |
| page preview (`src/api_server.py:7804`, `:7828`) | ❌ | `page_service.preview_page()` runs the full plugin fan-out inline |

Tracked in **#1826**, which also records that the preview surface is wider than #1750 knew: `set_active_page` (`:6047`), `get_current_display` (`:7619`), `preview_pages_batch` (`:7873`), and `send_page` (`:7990`) all fan out to plugins inline too.

## Known trade-off: this widens a concurrency window

Moving install off the loop removes serialization the event loop was providing for free. While install ran inline, nothing else could touch the registry — not because anything was locked, but because there was one thread of control. `PluginRegistry` / `PluginLoader` state (`_plugins`, `_loaded_plugins`, `_plugin_classes`, `sys.modules`) is unlocked.

Concretely: `GET /plugins` → `registry.list_plugins()` (`src/plugins/registry.py:1096`) iterates `self._plugins` while `install_from_registry` (`:1415`) does `self._plugins[plugin_id] = plugin` → `RuntimeError: dictionary changed size during iteration`. Separately, two concurrent `POST /plugins/{id}/update` can now both run `git fetch` / `git reset --hard` in one directory (`clone_or_update_repo`, `src/plugins/sources.py:310`) and surface as confusing `index.lock` 500s.

The display thread already raced the registry this way, so this is the **same class** of bug rather than a new one — but this PR widens the window from "one background thread" to "every API request." The correct fix is a registry mutex, which is a refactor and not a two-line change, so it is deliberately **not** attempted here. Tracked in **#1828**.

## Why an E2E spec change is in a Python PR

`web/tests/multi-board.spec.ts` gets a `beforeEach` change that is unrelated to the event loop: it anchors a flagship page so `deleteAllPages()` cannot leave a note-typed Welcome page behind. That is a pre-existing E2E flake, but it is load-bearing for this PR's CI — without it the suite is red for reasons that have nothing to do with these changes. It is correct and small, so it rides along rather than blocking on a separate PR.

## Test evidence

New file `tests/test_plugin_install_event_loop.py` — five watchdog tests that fire a slow install and race `GET /health` against it, asserting health is served *while* the install is still in flight. They assert the symptom (loop responsiveness), not the mechanism, so `run_in_executor` or a plain `def` handler would satisfy them equally. The blocking stub hangs on a `threading.Event` with a wall-clock cap as a safety valve rather than sleeping for a fixed duration.

### Before the fix (verbatim)

The original four:

```
============================= test session starts ==============================
collected 4 items

tests/test_plugin_install_event_loop.py FFFF                             [100%]

=================================== FAILURES ===================================
__________ test_a_slow_registry_install_does_not_block_the_event_loop __________
tests/test_plugin_install_event_loop.py:95: in test_a_slow_registry_install_does_not_block_the_event_loop
    _assert_loop_stayed_free(health, waited, still_running, "registry install")
tests/test_plugin_install_event_loop.py:75: in _assert_loop_stayed_free
    assert waited < _HEALTH_BUDGET_SECONDS, (
E   AssertionError: /health waited 5.03s behind the registry install — the event loop was blocked
E   assert 5.026920668024104 < 0.5
____________ test_a_slow_git_install_does_not_block_the_event_loop _____________
tests/test_plugin_install_event_loop.py:114: in test_a_slow_git_install_does_not_block_the_event_loop
    _assert_loop_stayed_free(health, waited, still_running, "git install")
tests/test_plugin_install_event_loop.py:75: in _assert_loop_stayed_free
    assert waited < _HEALTH_BUDGET_SECONDS, (
E   AssertionError: /health waited 5.02s behind the git install — the event loop was blocked
E   assert 5.015404334990308 < 0.5
___________ test_a_slow_plugin_update_does_not_block_the_event_loop ____________
tests/test_plugin_install_event_loop.py:136: in test_a_slow_plugin_update_does_not_block_the_event_loop
    _assert_loop_stayed_free(health, waited, still_running, "plugin update")
tests/test_plugin_install_event_loop.py:75: in _assert_loop_stayed_free
    assert waited < _HEALTH_BUDGET_SECONDS, (
E   AssertionError: /health waited 5.01s behind the plugin update — the event loop was blocked
E   assert 5.005474210949615 < 0.5
____________ test_a_slow_bulk_update_does_not_block_the_event_loop _____________
tests/test_plugin_install_event_loop.py:159: in test_a_slow_bulk_update_does_not_block_the_event_loop
    _assert_loop_stayed_free(health, waited, still_running, "bulk update")
tests/test_plugin_install_event_loop.py:75: in _assert_loop_stayed_free
    assert waited < _HEALTH_BUDGET_SECONDS, (
E   AssertionError: /health waited 5.01s behind the bulk update — the event loop was blocked
E   assert 5.005315419984981 < 0.5
=========================== short test summary info ============================
FAILED tests/test_plugin_install_event_loop.py::test_a_slow_registry_install_does_not_block_the_event_loop
FAILED tests/test_plugin_install_event_loop.py::test_a_slow_git_install_does_not_block_the_event_loop
FAILED tests/test_plugin_install_event_loop.py::test_a_slow_plugin_update_does_not_block_the_event_loop
FAILED tests/test_plugin_install_event_loop.py::test_a_slow_bulk_update_does_not_block_the_event_loop
============================== 4 failed in 21.24s ==============================
```

And the auto-update test, run against the tree with its two-line fix not yet applied:

```
============================= test session starts ==============================
collected 1 item

tests/test_plugin_install_event_loop.py F                                [100%]

=================================== FAILURES ===================================
____________ test_a_slow_auto_update_does_not_block_the_event_loop _____________
tests/test_plugin_install_event_loop.py:185: in test_a_slow_auto_update_does_not_block_the_event_loop
    _assert_loop_stayed_free(health, waited, still_running, "auto-update")
tests/test_plugin_install_event_loop.py:75: in _assert_loop_stayed_free
    assert waited < _HEALTH_BUDGET_SECONDS, (
E   AssertionError: /health waited 5.01s behind the auto-update — the event loop was blocked
E   assert 5.0125927940243855 < 0.5
=========================== short test summary info ============================
FAILED tests/test_plugin_install_event_loop.py::test_a_slow_auto_update_does_not_block_the_event_loop
============================== 1 failed in 5.70s ===============================
```

Every one waits the full stub duration, which is exactly the acceptance criterion in the issue inverted: health latency was 5.0 s, not <100 ms.

### After the fix

```
tests/test_plugin_install_event_loop.py .....                            [100%]
============================== 5 passed in 1.03s ===============================
```

1.03 s instead of 26 s — health now returns immediately in all five cases instead of queueing behind the install.

### Regressions

```
tests/test_api_coverage_extended.py tests/test_plugin_registry.py tests/test_plugin_sources.py
tests/test_plugin_options_route.py tests/test_plugin_install_gate.py tests/test_plugin_install_check.py
tests/test_settings_plugins.py                    416 passed in 4.94s

tests/test_api_coverage.py tests/test_api_extended.py tests/test_plugin_instances.py
tests/test_extract_plugin.py tests/test_plugin_system_security.py    476 passed in 2.69s
```

`ruff 0.16.4` — `ruff check` and `ruff format --check` clean on both changed files.

Rebased onto `main` at `c0f4969a2` (picks up #1817 and #1812).

## Follow-ups filed

- **#1826** — `/refresh`, `/force-refresh`, and page preview still block the loop (the rest of #1750)
- **#1828** — plugin registry state is unlocked; off-loop install races every API request

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ndXRi5v57yB5sXXhQswjp
