### PR TITLE
fix(security): enforce MCP token in every auth mode; drop CORS wildcard+credentials

### DIFF
--- a/docs/internal/setup/MCP_CLIENTS.md
+++ b/docs/internal/setup/MCP_CLIENTS.md
@@ -44,6 +44,14 @@ client config — it replaces `<YOUR_TOKEN>` in the examples below.
 > in **Settings → Integrations** are disabled. To manage the token from the UI
 > again, unset the variable and restart the container.
 
+> **Once a token exists, `/api/mcp/` requires it** — in every auth mode,
+> including `FIESTABOARD_AUTH_ENABLED=false`. Turning off the browser login
+> is a UI convenience; it does not switch off a credential you configured on
+> purpose. Requests without a valid `Authorization: Bearer` header get a 401,
+> so every client needs the token in its config. If you have no token
+> configured, nothing changes: `/api/mcp/` follows whatever the auth mode
+> says.
+
 ## Why local hosting makes this awkward
 
 The MCP ecosystem is converging on three transports — stdio, HTTP, and

--- a/docs/internal/setup/MCP_CLIENTS.md
+++ b/docs/internal/setup/MCP_CLIENTS.md
@@ -52,6 +52,23 @@ client config — it replaces `<YOUR_TOKEN>` in the examples below.
 > configured, nothing changes: `/api/mcp/` follows whatever the auth mode
 > says.
 
+> **With the login disabled, pin the token with the env var.** The paragraph
+> above is about the `/api/mcp/` data path only. The *token management*
+> routes are not gated the same way: `_require_admin` in
+> `src/auth/routes.py` deliberately returns an `"anonymous"` sentinel when
+> `auth_mode()` is `disabled`, so that **Settings → Integrations** doesn't
+> bounce off a 401 into a login-redirect loop. The consequence is that on an
+> install with the login off, an unauthenticated caller who can reach the
+> port can `POST /auth/mcp-token` to mint a valid token, or
+> `DELETE /auth/mcp-token` to revoke the stored one and re-open `/api/mcp/`
+> outright. A token stored from the Settings page is therefore a guard
+> against accidental clients on such an install, **not** a boundary against
+> an attacker who can already reach FiestaBoard. Setting
+> `FIESTABOARD_MCP_TOKEN` is the configuration that holds: while it is set,
+> both management routes refuse with `409`, so the token cannot be rotated
+> or revoked over the network. Enabling the browser login also closes it.
+> Tracked in Fiestaboard/FiestaBoard#1825.
+
 ## Why local hosting makes this awkward
 
 The MCP ecosystem is converging on three transports — stdio, HTTP, and

--- a/docs/setup/authentication.md
+++ b/docs/setup/authentication.md
@@ -78,6 +78,8 @@ future request.
 | `FIESTABOARD_AUTH_ENABLED` | *(unset, first-run picker)* | `true`/`1`/`yes`/`on` force-enables, `false`/`0`/`no`/`off` force-disables. Unset = use stored preference; if none, show the first-run picker. |
 | `FIESTABOARD_SESSION_TTL_SECONDS` | `604800` (7d) | Lifetime for a normal sign-in (without "Keep me logged in"), in seconds. Caps the session-cookie token. |
 | `FIESTABOARD_REMEMBER_ME_TTL_SECONDS` | `2592000` (30d) | Lifetime when "Keep me logged in" is checked, in seconds. Sets both the persistent cookie's `Max-Age` and the token expiry. |
+| `FIESTABOARD_MCP_TOKEN` | *(unset)* | Pre-shared bearer token for `/api/mcp/`. Takes precedence over a token stored from **Settings → Integrations**, and disables the UI's rotate/revoke buttons. See [MCP clients and the bearer token](#mcp-clients-and-the-bearer-token). |
+| `FIESTABOARD_CORS_ORIGINS` | *(unset, no credentialed cross-origin access)* | Comma-separated list of exact origins allowed to send credentials on cross-origin browser requests. See [Cross-origin browser access](#cross-origin-browser-access-cors). |
 
 ## Public endpoints
 
@@ -90,6 +92,68 @@ page itself, and the OpenAPI docs keep working:
 
 Everything else (status, config, pages, plugins, etc.) requires a valid
 session cookie.
+
+## MCP clients and the bearer token
+
+External MCP clients — Claude Desktop, Claude Code — can't drive a
+cookie-based login, so they authenticate to `/api/mcp/` with a pre-shared
+bearer token instead of a session cookie. Configure one in
+**Settings → Integrations**, or by setting `FIESTABOARD_MCP_TOKEN`.
+
+:::warning Behaviour change: a configured token is now enforced in every auth mode
+
+If a token is configured, `/api/mcp/` **requires** it — including when you
+chose *Continue without login*. Previously the token was ignored whenever
+auth was disabled, so a client could reach `/api/mcp/` without sending it.
+
+If an MCP client that used to work starts returning `401`, put the token in
+its config so it sends `Authorization: Bearer <your-token>`. Alternatively,
+clear the token in **Settings → Integrations** if you want `/api/mcp/` to
+stay open.
+
+**Installs with no token configured are unaffected** — they behave exactly
+as before.
+:::
+
+On an install where you chose *Continue without login*, prefer
+`FIESTABOARD_MCP_TOKEN` over a token generated on the Settings page. Token
+management is part of the API (`POST` / `DELETE /auth/mcp-token`), and with
+the login disabled there is no session for those routes to check — so
+anyone who can reach the port can rotate or revoke a Settings-stored token
+and re-open `/api/mcp/`. A Settings-stored token protects against accidents
+there, not against an attacker who can already reach FiestaBoard. While
+`FIESTABOARD_MCP_TOKEN` is set, both routes refuse with `409` and the token
+cannot be changed over the network.
+
+## Cross-origin browser access (CORS)
+
+The web UI and the API are served from the same origin (nginx fronts both),
+so CORS only affects third-party callers — for example a dashboard of your
+own, on a different host or port, calling the FiestaBoard API from a
+browser.
+
+:::warning Behaviour change: credentialed cross-origin requests need an allowlist
+
+Any origin may still make **anonymous** cross-origin requests, exactly as
+before. What changed is that **no** origin may send credentials (cookies,
+TLS client certificates) unless you list it. Previously every origin on the
+internet held a credentialed grant to the whole API, so any page you
+visited could drive your board.
+
+If your own page calls the API with `credentials: "include"`, list its
+origin in `FIESTABOARD_CORS_ORIGINS`:
+
+```bash
+FIESTABOARD_CORS_ORIGINS=https://dashboard.example,http://192.0.2.10:8080
+```
+
+Origins must match exactly — scheme, host, and port. A `*` in the list is
+accepted, but drops credentials again: the wildcard and credentials cannot
+be combined.
+:::
+
+MCP clients such as Claude Desktop and Claude Code are not browsers, so
+CORS never applies to them.
 
 ## Managing your account
 

--- a/env.example
+++ b/env.example
@@ -216,19 +216,37 @@ FIESTABOARD_AUTH_ENABLED=
 # =============================================================================
 # MCP (Model Context Protocol) bearer token
 # =============================================================================
-# When FIESTABOARD_AUTH_ENABLED is on, external MCP clients (Claude Desktop,
-# Claude Code, etc.) can't drive the cookie-based login flow. Set a token
-# here and FiestaBoard's /mcp endpoint will accept it as
+# External MCP clients (Claude Desktop, Claude Code, etc.) can't drive the
+# cookie-based login flow. Set a token here and FiestaBoard's /mcp endpoint
+# will accept it as
 #     Authorization: Bearer <token>
 # instead of a session cookie. A 401 from /mcp will include
 #     WWW-Authenticate: Bearer realm="FiestaBoard MCP"
 # so clients know to send a pre-shared token rather than attempting OAuth.
+#
+# Once a token is set, /mcp REQUIRES it — in every auth mode, including
+# FIESTABOARD_AUTH_ENABLED=false. Turning off the browser login does not
+# turn off this token, so clients must be configured with it.
 #
 # Generate a value with:
 #     python -c "import secrets; print(secrets.token_urlsafe(32))"
 #
 # Leave empty to disable token auth on /mcp (cookie auth still works).
 FIESTABOARD_MCP_TOKEN=
+
+# =============================================================================
+# CORS (cross-origin browser access)
+# =============================================================================
+# The web UI and the API are served from the same origin, so CORS only
+# affects third-party callers. By default any origin may make anonymous
+# cross-origin requests, but none may send credentials (cookies, TLS client
+# certs, etc.) — a wildcard origin and credentials cannot be combined
+# safely.
+#
+# Set a comma-separated list of exact origins to allow credentialed
+# cross-origin requests from those origins only, e.g.
+#     FIESTABOARD_CORS_ORIGINS=https://dashboard.example,http://192.0.2.10:8080
+FIESTABOARD_CORS_ORIGINS=
 
 # =============================================================================
 # Secret encryption at rest

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -891,14 +891,65 @@ app = FastAPI(
     root_path="/api",
 )
 
+CORS_ORIGINS_ENV = "FIESTABOARD_CORS_ORIGINS"
+
+
+def cors_settings() -> dict:
+    """Resolve the CORS policy from the environment.
+
+    The UI is served from the same origin as the API (nginx fronts both),
+    so CORS only ever matters for third-party callers. Two regimes:
+
+    * ``FIESTABOARD_CORS_ORIGINS`` unset (the default) — allow any origin
+      but **without** credentials. Anonymous cross-origin reads keep
+      working exactly as before; what stops working is a browser sending
+      the session cookie (or any other credential) on behalf of a page
+      the operator never allow-listed.
+    * ``FIESTABOARD_CORS_ORIGINS`` set to a comma-separated list of
+      origins — only those origins are allowed, and they may send
+      credentials.
+
+    ``allow_origins=["*"]`` together with ``allow_credentials=True`` is
+    never emitted: browsers reject that pairing, and Starlette "helpfully"
+    works around it by echoing back whatever ``Origin`` the caller sent —
+    which is how every site on the internet ended up holding a
+    credentialed grant to a LAN board (#1744).
+    """
+    raw = os.environ.get(CORS_ORIGINS_ENV, "")
+    origins = [o.strip().rstrip("/") for o in raw.split(",") if o.strip()]
+
+    if not origins:
+        return {
+            "allow_origins": ["*"],
+            "allow_credentials": False,
+            "allow_methods": ["*"],
+            "allow_headers": ["*"],
+        }
+
+    if "*" in origins:
+        logger.warning(
+            "%s contains '*'; credentials disabled for CORS because a wildcard "
+            "origin cannot be combined with credentials. List explicit origins "
+            "to allow credentialed cross-origin requests.",
+            CORS_ORIGINS_ENV,
+        )
+        return {
+            "allow_origins": ["*"],
+            "allow_credentials": False,
+            "allow_methods": ["*"],
+            "allow_headers": ["*"],
+        }
+
+    return {
+        "allow_origins": origins,
+        "allow_credentials": True,
+        "allow_methods": ["*"],
+        "allow_headers": ["*"],
+    }
+
+
 # Add CORS middleware
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],  # In production, restrict this to your UI domain
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+app.add_middleware(CORSMiddleware, **cors_settings())
 
 # Mount the MCP server at /mcp (accessible at /api/mcp via nginx).
 # Gracefully skipped if the mcp package is not installed.

--- a/src/auth/middleware.py
+++ b/src/auth/middleware.py
@@ -10,12 +10,18 @@ Public paths (no auth required):
     * CORS preflight (``OPTIONS``) requests
 
 MCP endpoint (``/mcp/*``):
-    If ``FIESTABOARD_MCP_TOKEN`` is set, the MCP endpoint accepts an
-    ``Authorization: Bearer <token>`` header instead of (or in addition to)
-    the session cookie. This lets external MCP clients (Claude Desktop,
-    Claude Code) connect without needing to drive a browser login flow.
-    A 401 from this endpoint includes ``WWW-Authenticate: Bearer`` so the
-    client knows to send a pre-shared token rather than attempting OAuth.
+    If an MCP token is configured (``FIESTABOARD_MCP_TOKEN`` or the value
+    stored via Settings), the MCP endpoint requires an
+    ``Authorization: Bearer <token>`` header instead of the session
+    cookie. This lets external MCP clients (Claude Desktop, Claude Code)
+    connect without needing to drive a browser login flow. A 401 from
+    this endpoint includes ``WWW-Authenticate: Bearer`` so the client
+    knows to send a pre-shared token rather than attempting OAuth.
+
+    That check runs in **every** auth mode, ``disabled`` included — a
+    configured token is a credential the operator asked for, not a
+    formality that the UI login toggle can switch off. With no token
+    configured, nothing changes for anyone.
 """
 
 from __future__ import annotations
@@ -109,35 +115,43 @@ class AuthMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next):
         mode = auth_mode()
-        if mode == "disabled":
-            return await call_next(request)
 
-        # Always allow CORS preflight.
+        # Always allow CORS preflight (browsers never attach credentials
+        # to it, so there is nothing to check).
         if request.method == "OPTIONS":
             return await call_next(request)
 
         path = request.url.path
+
+        # MCP endpoint: a *configured* bearer token is enforced in every
+        # auth mode, including "disabled". Auth mode governs the browser
+        # login flow; setting FIESTABOARD_MCP_TOKEN (or storing one via
+        # Settings) is a separate, deliberate act that must not be undone
+        # by opting out of the UI login. Without this, every mutating MCP
+        # tool is open to anything that can reach the port.
+        #
+        # When no token is configured there is nothing to enforce, so we
+        # fall through: auth-disabled installs stay open and cookie-auth
+        # installs keep using the session cookie.
+        if _is_mcp_path(path) and mcp_token() is not None:
+            supplied = _bearer_from(request)
+            # No Authorization header, or a bad one -> challenge. We skip
+            # the session-cookie fallback because Claude/etc. will never
+            # have a cookie, and a 401 with WWW-Authenticate is exactly
+            # the signal such a client needs.
+            if supplied is None or not verify_mcp_bearer(supplied):
+                return _mcp_unauthorized()
+            request.scope["auth_user"] = "mcp-client"
+            return await call_next(request)
+
+        if mode == "disabled":
+            return await call_next(request)
+
         if _is_public_path(path):
             return await call_next(request)
         for extra in self._extra_public:
             if path == extra or path.startswith(extra.rstrip("/") + "/"):
                 return await call_next(request)
-
-        # MCP endpoint: accept a Bearer token if one is configured. Falls
-        # through to cookie auth when no token env var is set so the UI's
-        # own MCP usage (and existing installs) keep working.
-        if _is_mcp_path(path) and mcp_token() is not None:
-            supplied = _bearer_from(request)
-            if supplied is not None:
-                if verify_mcp_bearer(supplied):
-                    request.scope["auth_user"] = "mcp-client"
-                    return await call_next(request)
-                return _mcp_unauthorized()
-            # No Authorization header — challenge the client. We skip the
-            # session-cookie fallback here because Claude/etc. will never
-            # have a cookie, and emitting a 401 with WWW-Authenticate is
-            # exactly the signal it needs.
-            return _mcp_unauthorized()
 
         svc = get_auth_service()
 

--- a/tests/test_auth_mcp_bearer.py
+++ b/tests/test_auth_mcp_bearer.py
@@ -146,12 +146,45 @@ def test_bearer_does_not_grant_access_to_non_mcp_paths(client, setup_user, with_
     assert not r.headers.get("WWW-Authenticate", "").startswith("Bearer")
 
 
-# --- Auth disabled -> token irrelevant -----------------------------------
+# --- Auth disabled -> a *configured* token is still enforced --------------
+#
+# The previous version of this section asserted the opposite
+# ("test_token_irrelevant_when_auth_disabled"): with auth mode "disabled"
+# a cookie-less request to /mcp/ was expected NOT to 401 even when a token
+# was configured. That encoded the wrong contract — it made
+# FIESTABOARD_MCP_TOKEN pure decoration on the exact deployments that set
+# it (Fiestaboard/FiestaBoard#1744). Auth mode governs the browser login
+# flow; it is not an instruction to ignore a credential the operator
+# deliberately configured.
 
 
-def test_token_irrelevant_when_auth_disabled(client, monkeypatch, with_token):
+@pytest.fixture
+def auth_disabled(monkeypatch):
+    """Pin the app's auth mode to ``disabled``."""
     monkeypatch.setenv("FIESTABOARD_AUTH_ENABLED", "false")
+    yield
+    monkeypatch.delenv("FIESTABOARD_AUTH_ENABLED", raising=False)
+
+
+def test_mcp_rejects_missing_bearer_when_auth_disabled(client, auth_disabled, with_token):
+    """Auth mode ``disabled`` must not silently disable a configured token."""
     r = client.get("/mcp/")
-    # No auth means the middleware is a no-op; downstream may 404 or 405
-    # but should not 401.
+    assert r.status_code == 401
+    assert r.headers.get("WWW-Authenticate", "").startswith("Bearer")
+
+
+def test_mcp_rejects_wrong_bearer_when_auth_disabled(client, auth_disabled, with_token):
+    r = client.get("/mcp/", headers={"Authorization": "Bearer not-the-real-token"})
+    assert r.status_code == 401
+
+
+def test_mcp_accepts_valid_bearer_when_auth_disabled(client, auth_disabled, with_token):
+    """The token is the credential — presenting it must still work."""
+    r = client.get("/mcp/", headers={"Authorization": f"Bearer {with_token}"})
+    assert r.status_code != 401
+
+
+def test_mcp_open_when_auth_disabled_and_no_token(client, auth_disabled, no_token):
+    """Backward compatibility: no token configured -> nothing to enforce."""
+    r = client.get("/mcp/")
     assert r.status_code != 401

--- a/tests/test_cors_policy.py
+++ b/tests/test_cors_policy.py
@@ -1,0 +1,92 @@
+"""Tests for the API's CORS policy.
+
+The API is normally same-origin with the UI (nginx serves both), so CORS
+exists only for third-party callers. Two invariants matter:
+
+* A credentialed cross-origin grant must never be handed to an arbitrary
+  origin — that turns any web page the operator visits into a client of
+  their LAN board (Fiestaboard/FiestaBoard#1744).
+* ``Access-Control-Allow-Origin: *`` must never be paired with
+  ``Access-Control-Allow-Credentials: true``; browsers reject the
+  combination outright, so it is a footgun even where it is not a hole.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.api_server import app, cors_settings
+
+# A third-party origin the operator never configured.
+EVIL = "https://evil.example"
+
+
+@pytest.fixture
+def client():
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _headers(response):
+    return (
+        response.headers.get("access-control-allow-origin"),
+        response.headers.get("access-control-allow-credentials"),
+    )
+
+
+# --- Emitted headers on the real app --------------------------------------
+
+
+def test_arbitrary_origin_is_not_granted_credentialed_access(client):
+    """An unconfigured origin must not get an origin echo + credentials."""
+    r = client.get("/health", headers={"Origin": EVIL})
+    allow_origin, allow_credentials = _headers(r)
+    assert not (allow_origin == EVIL and allow_credentials == "true"), (
+        f"reflected {EVIL} with credentials — any site could drive this board"
+    )
+
+
+def test_wildcard_origin_is_never_paired_with_credentials(client):
+    """``*`` + credentials is invalid per the CORS spec."""
+    r = client.get("/health", headers={"Origin": EVIL})
+    allow_origin, allow_credentials = _headers(r)
+    assert not (allow_origin == "*" and allow_credentials == "true")
+
+
+def test_preflight_from_arbitrary_origin_is_not_credentialed(client):
+    """The preflight for an unconfigured origin must not promise credentials."""
+    r = client.options(
+        "/health",
+        headers={"Origin": EVIL, "Access-Control-Request-Method": "POST"},
+    )
+    assert r.headers.get("access-control-allow-credentials") != "true"
+
+
+def test_anonymous_cross_origin_reads_still_allowed_by_default(client):
+    """Backward compatibility: the default stays open to anonymous callers."""
+    r = client.get("/health", headers={"Origin": EVIL})
+    assert r.headers.get("access-control-allow-origin") == "*"
+
+
+# --- cors_settings() ------------------------------------------------------
+
+
+def test_default_config_does_not_allow_credentials(monkeypatch):
+    monkeypatch.delenv("FIESTABOARD_CORS_ORIGINS", raising=False)
+    settings = cors_settings()
+    assert settings["allow_origins"] == ["*"]
+    assert settings["allow_credentials"] is False
+
+
+def test_explicit_allowlist_enables_credentials(monkeypatch):
+    monkeypatch.setenv("FIESTABOARD_CORS_ORIGINS", "https://board.example, https://other.example/")
+    settings = cors_settings()
+    assert settings["allow_origins"] == ["https://board.example", "https://other.example"]
+    assert settings["allow_credentials"] is True
+
+
+def test_wildcard_in_allowlist_drops_credentials(monkeypatch):
+    """An operator writing ``*`` must not resurrect the invalid pairing."""
+    monkeypatch.setenv("FIESTABOARD_CORS_ORIGINS", "*")
+    settings = cors_settings()
+    assert settings["allow_credentials"] is False

--- a/tests/test_cors_policy.py
+++ b/tests/test_cors_policy.py
@@ -14,17 +14,51 @@ exists only for third-party callers. Two invariants matter:
 from __future__ import annotations
 
 import pytest
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.testclient import TestClient
+from starlette.middleware import Middleware
 
-from src.api_server import app, cors_settings
+from src.api_server import CORS_ORIGINS_ENV, app, cors_settings
 
 # A third-party origin the operator never configured.
 EVIL = "https://evil.example"
 
 
 @pytest.fixture
-def client():
-    return TestClient(app, raise_server_exceptions=False)
+def client(monkeypatch):
+    """``app`` with its CORS middleware rebuilt from a scrubbed environment.
+
+    ``src.api_server`` calls ``load_dotenv()`` and evaluates
+    ``cors_settings()`` at *import* time, so the policy baked into ``app``
+    reflects whatever ``FIESTABOARD_CORS_ORIGINS`` the developer's ``.env``
+    (or the CI runner's environment) happened to hold. A plain
+    ``monkeypatch.delenv`` is too late to undo that. Swap in a middleware
+    entry built from the clean environment and drop the cached stack so the
+    next request rebuilds it, so the assertions below describe the shipped
+    *default* policy rather than the ambient operator config.
+
+    The real ``app`` — real routes, real middleware ordering — is still what
+    gets exercised; only the one env-derived argument is normalised.
+    """
+    monkeypatch.delenv(CORS_ORIGINS_ENV, raising=False)
+
+    original = list(app.user_middleware)
+    assert any(m.cls is CORSMiddleware for m in original), (
+        "app no longer installs CORSMiddleware — these tests would be vacuous"
+    )
+
+    def with_default_cors(entry):
+        if entry.cls is CORSMiddleware:
+            return Middleware(CORSMiddleware, **cors_settings())
+        return entry
+
+    app.user_middleware = [with_default_cors(m) for m in original]
+    app.middleware_stack = None  # force a rebuild on the next request
+    try:
+        yield TestClient(app, raise_server_exceptions=False)
+    finally:
+        app.user_middleware = original
+        app.middleware_stack = None
 
 
 def _headers(response):


### PR DESCRIPTION
Closes #1744

Two independent security holes on any LAN-reachable instance, both in the request-entry layer.

## Root cause

**1. MCP bearer token unenforced when auth mode is `disabled`.**
`AuthMiddleware.dispatch()` returned early for `auth_mode() == "disabled"` *before* reaching the MCP bearer branch (`src/auth/middleware.py`). A configured `FIESTABOARD_MCP_TOKEN` — or a token generated in Settings → Integrations — was therefore never checked on exactly the installs most likely to set one (auth off, but MCP exposed). Since `/api/mcp/` serves mutating tools with DNS-rebinding protection deliberately off, the token was decoration: anything that could reach the port could drive the board.

**2. CORS wildcard + credentials.**
`src/api_server.py` configured `allow_origins=["*"]` together with `allow_credentials=True`. That pairing is invalid per spec, and Starlette 1.4.1 "resolves" it by echoing back whatever `Origin` the caller sent alongside `Access-Control-Allow-Credentials: true` (see `CORSMiddleware.send`). The practical effect is worse than a literal `*`: **every origin on the internet held a credentialed cross-origin grant to the entire API**, MCP mount included. `SameSite=lax` on the session cookie limits — but does not define — the blast radius, and it does nothing for auth-disabled installs.

## The fix

- The MCP bearer check now runs whenever a token is configured, in **every** auth mode. The `mode == "disabled"` early return moved below it. `OPTIONS` preflight still short-circuits first (browsers never attach credentials to a preflight).
- CORS config is derived from a new `cors_settings()` helper reading `FIESTABOARD_CORS_ORIGINS`:
  - **unset (default)** → `allow_origins=["*"]`, `allow_credentials=False`
  - **comma-separated origin list** → those origins only, `allow_credentials=True`
  - `*` inside that list → credentials dropped and a warning logged, so the invalid pairing can't be reintroduced by config

Documented in `env.example`, `docs/internal/setup/MCP_CLIENTS.md`, and — because
those two are never published — `docs/setup/authentication.md`, the page that
syncs to fiestaboard.app. The published page carries both breaking changes as
admonitions plus the two new env vars in its configuration reference, so a user
whose instance auto-updates and whose MCP client starts returning `401` can find
the answer on the site.

## Scope of the guarantee (read this)

The claim "once a token exists, `/api/mcp/` requires it — in every auth mode" is
true of the **data path**, and that is what this PR fixes. It is *not* a claim
that a token protects an auth-disabled install against an attacker.

`_require_admin()` in `src/auth/routes.py` deliberately returns the sentinel
`"anonymous"` when `auth_mode() == "disabled"`, so that Settings → Integrations
doesn't hit a 401 and bounce into a login-redirect loop. Every MCP
token-management route is gated by that helper. So on an install with the login
off and a token stored via the Settings page:

```text
anon GET    /mcp/                   -> 401   (this PR working as intended)
anon POST   /auth/mcp-token         -> 201 {"token":"xkIfsZl0eRJBSVPIZe9kiRQ9bWizrsWw-AAHGHiodIo"}
anon DELETE /auth/mcp-token         -> 200 {"status":"ok","username":null}
token source after revoke: none
anon GET    /mcp/ after revoke      -> 404   (past the auth layer, into the MCP mount — open)
```

An attacker who can reach the port can mint a valid token, or revoke the stored
one and re-open all 28 mutating tools. A Settings-stored token is therefore a
guard against accidental clients on such an install, not a security boundary.

**Pinning `FIESTABOARD_MCP_TOKEN` is the configuration that holds** — while it
is set, `mcp_token_source() == "env"` short-circuits both management routes
before any state change:

```text
--- with FIESTABOARD_MCP_TOKEN pinned ---
anon POST   /auth/mcp-token         -> 409
anon DELETE /auth/mcp-token         -> 409
```

That `_require_admin` gap is **pre-existing and deliberately out of scope here**
— this PR does not touch it. Filed as #1825. Both docs pages now state the
limitation rather than the unqualified guarantee.

## Backward-compatibility impact

**Read this before merging — two user-visible behaviour changes.**

1. **Installs with auth disabled *and* an MCP token configured** now get `401` on `/api/mcp/` unless the client sends `Authorization: Bearer <token>`. This is the point of the fix, but it is a break for anyone whose MCP client was connecting to such an instance *without* the token (which worked by accident). Remedy: put the token in the client config, or clear the token to return to an open endpoint. **Installs with no token configured are completely unaffected** — auth-disabled instances stay open, cookie-auth instances keep using the session cookie. Note the scope limit above: on an auth-disabled install, this `401` is only as durable as the token, which an unauthenticated caller can rotate or revoke unless it is pinned with `FIESTABOARD_MCP_TOKEN` (#1825).

2. **Credentialed cross-origin requests now fail by default.** Any browser code calling this API from a *different* origin with `credentials: "include"` will stop working until the operator lists its origin in `FIESTABOARD_CORS_ORIGINS`. In practice the shipped stack is unaffected: nginx serves the UI and the API from the same origin (CORS never applies), the FiestaPanel viewer is same-origin, and no app code calls `/api/mcp/` from a browser. MCP clients such as Claude Desktop / Claude Code are not browsers, so CORS is irrelevant to them. The exposure is to **third-party browser dashboards** users may have built against the old wildcard — those keep working for anonymous requests (the wildcard is retained without credentials), and only break if they send credentials.

Not fixed here (deliberately out of scope for a targeted security patch): the default still allows *anonymous* cross-origin requests from any origin. Locking that down would break third-party integrations without a deprecation path; operators who want it can set `FIESTABOARD_CORS_ORIGINS` today.

## Test evidence

Tests were written first and run against unmodified `main`.

### 1. MCP token unenforced when auth is disabled — verbatim pre-fix output

```
$ docker run --rm -v "$PWD":/app -w /app fb-test:latest \
    python -m pytest tests/test_auth_mcp_bearer.py -q --no-header -p no:cacheprovider

============================= test session starts ==============================
collected 11 items

tests/test_auth_mcp_bearer.py .......FF..                                [100%]

=================================== FAILURES ===================================
______________ test_mcp_rejects_missing_bearer_when_auth_disabled ______________
tests/test_auth_mcp_bearer.py:172: in test_mcp_rejects_missing_bearer_when_auth_disabled
    assert r.status_code == 401
E   assert 404 == 401
E    +  where 404 = <Response [404 Not Found]>.status_code
_______________ test_mcp_rejects_wrong_bearer_when_auth_disabled _______________
tests/test_auth_mcp_bearer.py:178: in test_mcp_rejects_wrong_bearer_when_auth_disabled
    assert r.status_code == 401
E   assert 404 == 401
E    +  where 404 = <Response [404 Not Found]>.status_code
=========================== short test summary info ============================
FAILED tests/test_auth_mcp_bearer.py::test_mcp_rejects_missing_bearer_when_auth_disabled
FAILED tests/test_auth_mcp_bearer.py::test_mcp_rejects_wrong_bearer_when_auth_disabled
========================= 2 failed, 9 passed in 1.78s ==========================
```

`404` is the request sailing straight past the auth layer into the MCP mount — the failure mode described in the issue, not a test typo.

### 2. CORS — verbatim pre-fix output

Run with the `cors_settings` import temporarily dropped (the helper does not exist on `main`), selecting the four header-emission tests:

```
$ docker run --rm -v "$PWD":/app -w /app fb-test:latest \
    python -m pytest tests/test_cors_policy.py -q --no-header -p no:cacheprovider \
      -k "not cors_settings and not allowlist and not default_config"

============================= test session starts ==============================
collected 7 items / 3 deselected / 4 selected

tests/test_cors_policy.py F.FF                                           [100%]

=================================== FAILURES ===================================
___________ test_arbitrary_origin_is_not_granted_credentialed_access ___________
tests/test_cors_policy.py:44: in test_arbitrary_origin_is_not_granted_credentialed_access
    assert not (allow_origin == EVIL and allow_credentials == "true"), (
E   AssertionError: reflected https://evil.example with credentials — any site could drive this board
E   assert not ('https://evil.example' == 'https://evil.example'
E
E       https://evil.example and 'true' == 'true'
E
E       true)
___________ test_preflight_from_arbitrary_origin_is_not_credentialed ___________
tests/test_cors_policy.py:62: in test_preflight_from_arbitrary_origin_is_not_credentialed
    assert r.headers.get("access-control-allow-credentials") != "true"
E   AssertionError: assert 'true' != 'true'
E    +  where 'true' = get('access-control-allow-credentials')
E    +    where get = Headers({'vary': 'Origin', 'access-control-allow-methods': 'DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT', 'access-con...ess-control-allow-origin': 'https://evil.example', 'content-length': '2', 'content-type': 'text/plain; charset=utf-8'}).get
E    +      where Headers({'vary': 'Origin', 'access-control-allow-methods': 'DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT', 'access-con...ess-control-allow-origin': 'https://evil.example', 'content-length': '2', 'content-type': 'text/plain; charset=utf-8'}) = <Response [200 OK]>.headers
__________ test_anonymous_cross_origin_reads_still_allowed_by_default __________
tests/test_cors_policy.py:68: in test_anonymous_cross_origin_reads_still_allowed_by_default
    assert r.headers.get("access-control-allow-origin") == "*"
E   AssertionError: assert 'https://evil.example' == '*'
E     - *
E     + https://evil.example
=========================== short test summary info ============================
FAILED tests/test_cors_policy.py::test_arbitrary_origin_is_not_granted_credentialed_access
FAILED tests/test_cors_policy.py::test_preflight_from_arbitrary_origin_is_not_credentialed
FAILED tests/test_cors_policy.py::test_anonymous_cross_origin_reads_still_allowed_by_default
================== 3 failed, 1 passed, 3 deselected in 0.57s ===================
```

**Honest note on the one that passed:** `test_wildcard_origin_is_never_paired_with_credentials` — the literal invariant from the issue's acceptance criteria — passes on `main` too, because Starlette 1.4.1 substitutes the echoed origin for `*` before the header is written. It is kept as a regression guard against an older/different Starlette, but it is *not* the test that catches this bug; the three above are.

`test_wildcard_in_allowlist_drops_credentials` was proven non-vacuous by mutation (`if "*" in origins:` → `if False:`):

```
E   assert True is False
FAILED tests/test_cors_policy.py::test_wildcard_in_allowlist_drops_credentials
```

### 3. A pre-existing test asserted the vulnerable behaviour

`test_token_irrelevant_when_auth_disabled` explicitly asserted that a cookie-less request to `/mcp/` with a token configured must **not** 401 when auth is disabled. That encoded the wrong contract — it is what made the hole look intentional — and has been replaced by four tests covering: missing bearer → 401, wrong bearer → 401, valid bearer → passes, and no token configured → still open.

### 4. Post-fix

```
tests/test_cors_policy.py .......                                        [ 38%]
tests/test_auth_mcp_bearer.py ...........                                [100%]
============================== 18 passed in 1.32s ==============================
```

Regression suites, all green:

```
tests/test_auth_routes.py, tests/test_auth_service.py, tests/test_auth_mcp_token_routes.py,
tests/test_mcp_server.py, tests/test_mcp_state_effects.py,
tests/test_mcp_prompts_and_resources.py, tests/test_panels_api.py
  -> 259 passed

tests/test_api_coverage.py, tests/test_api_extended.py, tests/test_api_docs.py,
tests/test_nginx_error_semantics.py
  -> 354 passed
```

`ruff check` and `ruff format --check` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ndXRi5v57yB5sXXhQswjp

