### PR TITLE
fix(plugins): never persist the "***" mask sentinel over a real secret

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -9093,15 +9093,25 @@ async def update_plugin_config(plugin_id: str, request: PluginConfigRequest):
     if not registry.get_plugin(plugin_id):
         raise HTTPException(status_code=404, detail=f"Plugin not found: {plugin_id}")
 
+    # Resolve the "***" placeholders before anything sees the payload. Config
+    # goes out masked, so any client that echoes back what it read — the
+    # settings form, or an MCP client working from list_installed_plugins() —
+    # posts the sentinel where the secret used to be. Un-masking here rather
+    # than only inside ConfigManager keeps the mask out of the live plugin as
+    # well, whose validate_config()/on_config_change() would otherwise run
+    # against three asterisks (issue #1743).
+    config_manager = get_config_manager()
+    stored_config = config_manager.get_plugin_config(plugin_id) or {}
+    config = unmask_sensitive_values(request.config, stored_config)
+
     # Validate configuration against manifest schema
-    errors = registry.set_plugin_config(plugin_id, request.config)
+    errors = registry.set_plugin_config(plugin_id, config)
     if errors:
         logger.error(f"Plugin '{plugin_id}' config validation failed: {errors}")
         raise HTTPException(status_code=400, detail={"errors": errors})
 
     # Save to config file
-    config_manager = get_config_manager()
-    config_manager.set_plugin_config(plugin_id, request.config)
+    config_manager.set_plugin_config(plugin_id, config)
 
     # Reset services to pick up new config
     reset_display_service()

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -322,16 +322,21 @@ def unmask_sensitive_values(values: dict[str, Any], stored: dict[str, Any]) -> d
     through — or handing it to a plugin — replaces a working credential with
     three asterisks.
 
-    A masked key with nothing stored resolves to ``""`` rather than being
-    dropped, matching the persisted-config behaviour this was extracted from:
-    the field was explicitly submitted, so it should end up present and empty
-    rather than silently absent.
+    A masked key at a path that *does* exist in *stored* but holds nothing
+    resolves to ``""`` rather than being dropped, matching the persisted-config
+    behaviour this was extracted from: the field was explicitly submitted, so
+    it should end up present and empty rather than silently absent. That is a
+    key with no secret behind it, not a secret being erased.
 
     Nested dicts and lists are walked too, mirroring
     :meth:`ConfigManager._mask_sensitive`, which masks at any depth. A flat
     un-mask left every nested secret — a plugin's ``sources[0].api_key``, say —
     reading ``"***"`` on the way out and persisting ``"***"`` on the way back
-    in (issue #1743). List elements are matched to *stored* by position.
+    in (issue #1743).
+
+    Inside a list, a secret is restored only into the element it belongs to.
+    See :func:`_match_stored_element` for how an element is identified and what
+    happens when it cannot be.
 
     Args:
         values: Incoming settings, possibly carrying masked placeholders.
@@ -343,23 +348,70 @@ def unmask_sensitive_values(values: dict[str, Any], stored: dict[str, Any]) -> d
     return _unmask_node(values, stored)
 
 
+# Sentinel for "no stored counterpart could be identified for this node", as
+# distinct from "the stored counterpart is known and holds nothing". The first
+# means guessing; the second is an ordinary absent value.
+_UNMATCHED = object()
+
+# Fields that identify a list element across an edit, most specific first.
+IDENTITY_FIELDS = ("id", "name", "key")
+
+
+def _match_stored_element(item: Any, stored_list: list[Any]) -> Any:
+    """Return the stored element *item* is confidently the same as, or ``_UNMATCHED``.
+
+    Positional matching is not safe here: deleting, reordering, or inserting a
+    list element shifts every later index, and the secret restored into an
+    element would then be its neighbour's. A wrong-but-plausible credential is
+    worse than a visibly broken one — it fails as an auth error the user blames
+    on the provider, whereas ``"***"`` fails loudly and locally.
+
+    So an element is matched only on evidence: a unique hit on the first
+    :data:`IDENTITY_FIELDS` key it carries, or — when it carries none — a
+    unique stored element whose non-sensitive keys are all equal to its own.
+    Anything else (no candidate, several candidates, a renamed identity) is
+    ``_UNMATCHED``, and every masked field below it keeps the sentinel for the
+    schema layer to reject.
+    """
+    if not isinstance(item, dict):
+        return _UNMATCHED
+
+    candidates = [element for element in stored_list if isinstance(element, dict)]
+
+    for field in IDENTITY_FIELDS:
+        if field in item and isinstance(item[field], (str, int)) and not isinstance(item[field], bool):
+            matches = [element for element in candidates if element.get(field) == item[field]]
+            return matches[0] if len(matches) == 1 else _UNMATCHED
+
+    signature = _non_sensitive_keys(item)
+    matches = [element for element in candidates if _non_sensitive_keys(element) == signature]
+    return matches[0] if len(matches) == 1 else _UNMATCHED
+
+
+def _non_sensitive_keys(element: dict[str, Any]) -> dict[str, Any]:
+    """The part of *element* a client can echo back unchanged: everything unmasked."""
+    return {key: value for key, value in element.items() if key not in SENSITIVE_FIELDS}
+
+
 def _unmask_node(value: Any, stored: Any) -> Any:
     """Recursive worker for :func:`unmask_sensitive_values`."""
     if isinstance(value, dict):
+        unmatched = stored is _UNMATCHED
         stored_dict = stored if isinstance(stored, dict) else {}
         merged: dict[str, Any] = {}
         for key, item in value.items():
             if key in SENSITIVE_FIELDS and item == MASKED_VALUE:
-                merged[key] = stored_dict.get(key, "")
+                # Under an unmatched element there is nothing to restore from,
+                # and "" would destroy a secret just as surely as "***" did.
+                merged[key] = MASKED_VALUE if unmatched else stored_dict.get(key, "")
             else:
-                merged[key] = _unmask_node(item, stored_dict.get(key))
+                merged[key] = _unmask_node(item, _UNMATCHED if unmatched else stored_dict.get(key))
         return merged
     if isinstance(value, list):
+        if stored is _UNMATCHED:
+            return [_unmask_node(item, _UNMATCHED) for item in value]
         stored_list = stored if isinstance(stored, list) else []
-        return [
-            _unmask_node(item, stored_list[index] if index < len(stored_list) else None)
-            for index, item in enumerate(value)
-        ]
+        return [_unmask_node(item, _match_stored_element(item, stored_list)) for item in value]
     return value
 
 
@@ -1462,12 +1514,13 @@ class ConfigManager:
             if plugin_id not in self._config["plugins"]:
                 self._config["plugins"][plugin_id] = {}
 
-            # Merge updates, preserving masked sensitive fields
-            for key, value in updates.items():
-                if key in SENSITIVE_FIELDS and value == "***":
-                    logger.debug(f"Preserving existing value for masked field: plugins.{plugin_id}.{key}")
-                    continue
-                self._config["plugins"][plugin_id][key] = value
+            # Merge updates, restoring masked sensitive fields from what is
+            # already stored. Shares unmask_sensitive_values with
+            # set_plugin_config: a flat top-level check here would go on
+            # persisting "***" over secrets nested in dicts and lists, which is
+            # exactly the drift that produced #1743.
+            existing = self._config["plugins"][plugin_id]
+            existing.update(unmask_sensitive_values(updates, existing))
 
             self._save_internal()
 

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -327,6 +327,12 @@ def unmask_sensitive_values(values: dict[str, Any], stored: dict[str, Any]) -> d
     the field was explicitly submitted, so it should end up present and empty
     rather than silently absent.
 
+    Nested dicts and lists are walked too, mirroring
+    :meth:`ConfigManager._mask_sensitive`, which masks at any depth. A flat
+    un-mask left every nested secret — a plugin's ``sources[0].api_key``, say —
+    reading ``"***"`` on the way out and persisting ``"***"`` on the way back
+    in (issue #1743). List elements are matched to *stored* by position.
+
     Args:
         values: Incoming settings, possibly carrying masked placeholders.
         stored: The currently persisted settings to restore secrets from.
@@ -334,11 +340,27 @@ def unmask_sensitive_values(values: dict[str, Any], stored: dict[str, Any]) -> d
     Returns:
         A new dict; *values* is not mutated.
     """
-    merged = dict(values)
-    for key, value in values.items():
-        if key in SENSITIVE_FIELDS and value == MASKED_VALUE:
-            merged[key] = stored.get(key, "")
-    return merged
+    return _unmask_node(values, stored)
+
+
+def _unmask_node(value: Any, stored: Any) -> Any:
+    """Recursive worker for :func:`unmask_sensitive_values`."""
+    if isinstance(value, dict):
+        stored_dict = stored if isinstance(stored, dict) else {}
+        merged: dict[str, Any] = {}
+        for key, item in value.items():
+            if key in SENSITIVE_FIELDS and item == MASKED_VALUE:
+                merged[key] = stored_dict.get(key, "")
+            else:
+                merged[key] = _unmask_node(item, stored_dict.get(key))
+        return merged
+    if isinstance(value, list):
+        stored_list = stored if isinstance(stored, list) else []
+        return [
+            _unmask_node(item, stored_list[index] if index < len(stored_list) else None)
+            for index, item in enumerate(value)
+        ]
+    return value
 
 
 class ConfigManager:

--- a/tests/test_plugin_config_mask_roundtrip.py
+++ b/tests/test_plugin_config_mask_roundtrip.py
@@ -20,7 +20,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from src.api_server import app
-from src.config_manager import ConfigManager
+from src.config_manager import ConfigManager, unmask_sensitive_values
 
 REAL_SECRET = "super-secret-key-abc123"
 NESTED_SECRET = "nested-secret-key-xyz789"
@@ -176,3 +176,112 @@ class TestMcpConfigurePluginMaskSentinel:
         assert result.get("success") is not False, result
         assert _applied_config(applied)["api_key"] == REAL_SECRET
         assert cm.get_plugin_config("test_plugin")["api_key"] == REAL_SECRET
+
+
+KEY_A = "key-for-source-a"
+KEY_B = "key-for-source-b"
+
+
+def _stored_two_sources() -> dict:
+    return {
+        "sources": [
+            {"name": "a", "api_key": KEY_A},
+            {"name": "b", "api_key": KEY_B},
+        ]
+    }
+
+
+class TestUnmaskListIdentity:
+    """Secrets inside a list must follow their element, not its index.
+
+    ``unmask_sensitive_values`` used to pair incoming list elements with stored
+    ones by position. Any edit that changes a list's shape — a delete, a
+    reorder, an insert — then restored the wrong element's secret, or wrote an
+    empty string where a secret belonged.
+    """
+
+    def test_deleting_an_earlier_source_does_not_hand_its_key_to_a_later_one(self):
+        stored = _stored_two_sources()
+        incoming = {"sources": [{"name": "b", "api_key": MASK}]}
+
+        result = unmask_sensitive_values(incoming, stored)
+
+        assert result["sources"] == [{"name": "b", "api_key": KEY_B}]
+
+    def test_reordering_sources_keeps_each_key_with_its_own_source(self):
+        stored = _stored_two_sources()
+        incoming = {"sources": [{"name": "b", "api_key": MASK}, {"name": "a", "api_key": MASK}]}
+
+        result = unmask_sensitive_values(incoming, stored)
+
+        assert result["sources"] == [
+            {"name": "b", "api_key": KEY_B},
+            {"name": "a", "api_key": KEY_A},
+        ]
+
+    def test_inserting_a_source_neither_cross_wires_nor_destroys_the_others(self):
+        stored = _stored_two_sources()
+        incoming = {
+            "sources": [
+                {"name": "c", "api_key": "brand-new-key-c"},
+                {"name": "a", "api_key": MASK},
+                {"name": "b", "api_key": MASK},
+            ]
+        }
+
+        result = unmask_sensitive_values(incoming, stored)
+
+        assert result["sources"] == [
+            {"name": "c", "api_key": "brand-new-key-c"},
+            {"name": "a", "api_key": KEY_A},
+            {"name": "b", "api_key": KEY_B},
+        ]
+
+    def test_an_unidentifiable_element_keeps_the_mask_rather_than_guessing(self):
+        stored = {"sources": [{"url": "https://example.com/one", "api_key": KEY_A}]}
+        incoming = {"sources": [{"url": "https://example.com/two", "api_key": MASK}]}
+
+        result = unmask_sensitive_values(incoming, stored)
+
+        # No stable identity ties the incoming element to the stored one, so
+        # the sentinel survives for the schema layer to reject. Restoring
+        # KEY_A here would authenticate the new URL with the old URL's key;
+        # writing "" would destroy a working credential.
+        assert result["sources"] == [{"url": "https://example.com/two", "api_key": MASK}]
+
+    def test_elements_without_an_id_field_match_on_their_other_keys(self):
+        stored = {
+            "sources": [
+                {"url": "https://example.com/one", "api_key": KEY_A},
+                {"url": "https://example.com/two", "api_key": KEY_B},
+            ]
+        }
+        incoming = {
+            "sources": [
+                {"url": "https://example.com/two", "api_key": MASK},
+                {"url": "https://example.com/one", "api_key": MASK},
+            ]
+        }
+
+        result = unmask_sensitive_values(incoming, stored)
+
+        assert result["sources"] == [
+            {"url": "https://example.com/two", "api_key": KEY_B},
+            {"url": "https://example.com/one", "api_key": KEY_A},
+        ]
+
+    def test_update_plugin_config_preserves_a_secret_nested_in_a_list(self, tmp_path):
+        """update_plugin_config must un-mask at depth, like set_plugin_config."""
+        saved_instance = ConfigManager._instance
+        ConfigManager._instance = None
+        ConfigManager._lock = threading.Lock()
+        try:
+            cm = ConfigManager(config_path=str(tmp_path / "config.json"))
+            cm.set_plugin_config("test_plugin", {"enabled": True, "sources": [{"name": "a", "api_key": KEY_A}]})
+
+            cm.update_plugin_config("test_plugin", {"sources": [{"name": "a", "api_key": MASK}]})
+
+            assert cm.get_plugin_config("test_plugin")["sources"] == [{"name": "a", "api_key": KEY_A}]
+        finally:
+            ConfigManager._instance = saved_instance
+            ConfigManager._lock = threading.Lock()

--- a/tests/test_plugin_config_mask_roundtrip.py
+++ b/tests/test_plugin_config_mask_roundtrip.py
@@ -1,0 +1,178 @@
+"""Mask-sentinel round-trip tests for plugin configuration writes (issue #1743).
+
+Plugin config leaves the process with every sensitive field replaced by the
+``"***"`` sentinel (``ConfigManager._mask_sensitive``). Any client that reads a
+config and writes it straight back — the settings form, or an MCP client that
+called ``list_installed_plugins()`` — therefore posts the sentinel where the
+real secret used to be. Writing that through replaces a working credential with
+three asterisks, both in the live plugin instance the registry holds and (for
+values nested below the top level) on disk.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import threading
+from unittest.mock import Mock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.api_server import app
+from src.config_manager import ConfigManager
+
+REAL_SECRET = "super-secret-key-abc123"
+NESTED_SECRET = "nested-secret-key-xyz789"
+MASK = "***"
+
+
+@pytest.fixture
+def client():
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def mask_env(tmp_path):
+    """Real ConfigManager holding stored secrets, plus a mock plugin registry.
+
+    The ConfigManager is real (pinned at a tmp ``config.json``) so the disk
+    assertions are about what actually gets persisted, not about a mock's
+    call log.
+    """
+    saved_instance = ConfigManager._instance
+    ConfigManager._instance = None
+    ConfigManager._lock = threading.Lock()
+
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"board": {}, "features": {}, "general": {}, "plugins": {}}))
+    cm = ConfigManager(config_path=str(config_path))
+    cm.set_plugin_config(
+        "test_plugin",
+        {
+            "enabled": True,
+            "api_key": REAL_SECRET,
+            "location": "New York",
+            "sources": [{"name": "primary", "api_key": NESTED_SECRET}],
+        },
+    )
+    cm.set_plugin_config("test_plugin:office", {"enabled": True, "api_key": REAL_SECRET, "location": "Boston"})
+
+    # The endpoint hands the *same dict object* to the registry and then to the
+    # ConfigManager, which un-masks in place — so a plain call-args assertion
+    # would inspect the already-repaired dict and pass no matter what. Snapshot
+    # the config at the moment the live plugin receives it.
+    applied: list[dict] = []
+
+    registry = Mock()
+    registry.get_plugin.return_value = Mock()
+    registry.set_plugin_config.side_effect = lambda _pid, config: applied.append(copy.deepcopy(config)) or []
+
+    with (
+        patch("src.api_server.get_plugin_registry", return_value=registry),
+        patch("src.api_server.PLUGIN_SYSTEM_AVAILABLE", True),
+        patch("src.api_server.reset_display_service"),
+        patch("src.api_server.reset_template_engine"),
+    ):
+        yield applied, cm
+
+    ConfigManager._instance = saved_instance
+    ConfigManager._lock = threading.Lock()
+
+
+def _masked_body(cm: ConfigManager, plugin_id: str, **overrides) -> dict:
+    """The request body a client builds by echoing back a masked GET."""
+    masked = cm._mask_sensitive(cm.get_plugin_config(plugin_id))
+    masked.update(overrides)
+    return {"config": masked}
+
+
+def _applied_config(applied: list[dict]) -> dict:
+    """The config the endpoint handed to the live plugin registry."""
+    assert applied, "registry.set_plugin_config was never called"
+    return applied[-1]
+
+
+class TestRestPluginConfigMaskSentinel:
+    """PUT /plugins/{plugin_id}/config must never write the mask sentinel."""
+
+    def test_masked_api_key_is_not_applied_to_the_live_plugin(self, client, mask_env):
+        applied, cm = mask_env
+
+        response = client.put("/plugins/test_plugin/config", json=_masked_body(cm, "test_plugin", location="Chicago"))
+
+        assert response.status_code == 200
+        assert _applied_config(applied)["api_key"] == REAL_SECRET
+
+    def test_masked_api_key_leaves_the_stored_secret_intact(self, client, mask_env):
+        _applied, cm = mask_env
+
+        response = client.put("/plugins/test_plugin/config", json=_masked_body(cm, "test_plugin", location="Chicago"))
+
+        assert response.status_code == 200
+        assert cm.get_plugin_config("test_plugin")["api_key"] == REAL_SECRET
+
+    def test_masked_secret_nested_in_a_list_leaves_the_stored_secret_intact(self, client, mask_env):
+        _applied, cm = mask_env
+
+        response = client.put("/plugins/test_plugin/config", json=_masked_body(cm, "test_plugin"))
+
+        assert response.status_code == 200
+        assert cm.get_plugin_config("test_plugin")["sources"][0]["api_key"] == NESTED_SECRET
+
+    def test_masked_api_key_on_an_instance_key_resolves_against_that_instance(self, client, mask_env):
+        applied, cm = mask_env
+
+        response = client.put("/plugins/test_plugin:office/config", json=_masked_body(cm, "test_plugin:office"))
+
+        assert response.status_code == 200
+        assert _applied_config(applied)["api_key"] == REAL_SECRET
+        assert cm.get_plugin_config("test_plugin:office")["api_key"] == REAL_SECRET
+
+    def test_a_real_new_api_key_still_replaces_the_stored_secret(self, client, mask_env):
+        applied, cm = mask_env
+
+        response = client.put(
+            "/plugins/test_plugin/config",
+            json=_masked_body(cm, "test_plugin", api_key="brand-new-key"),
+        )
+
+        assert response.status_code == 200
+        assert _applied_config(applied)["api_key"] == "brand-new-key"
+        assert cm.get_plugin_config("test_plugin")["api_key"] == "brand-new-key"
+
+    def test_a_masked_api_key_with_nothing_stored_is_not_persisted(self, client, mask_env):
+        _applied, cm = mask_env
+        cm.set_plugin_config("test_plugin", {"enabled": True, "location": "New York"})
+
+        response = client.put(
+            "/plugins/test_plugin/config",
+            json={"config": {"enabled": True, "api_key": MASK, "location": "New York"}},
+        )
+
+        assert response.status_code == 200
+        assert cm.get_plugin_config("test_plugin")["api_key"] == ""
+
+
+class TestMcpConfigurePluginMaskSentinel:
+    """The MCP configure_plugin tool must not write back what it read masked."""
+
+    def test_masked_api_key_from_list_installed_plugins_is_not_written_back(self, mask_env):
+        pytest.importorskip("mcp", reason="mcp package not installed")
+
+        from src.mcp_server import _build_mcp_server
+        from tests.test_mcp_server import _call_tool
+
+        applied, cm = mask_env
+        mcp = _build_mcp_server()
+        assert mcp is not None
+
+        # What an MCP client sees from list_installed_plugins(): the mask.
+        masked = cm._mask_sensitive(cm.get_plugin_config("test_plugin"))
+        assert masked["api_key"] == MASK
+
+        result = _call_tool(mcp, "configure_plugin", plugin_id="test_plugin", config=masked)
+
+        assert result.get("success") is not False, result
+        assert _applied_config(applied)["api_key"] == REAL_SECRET
+        assert cm.get_plugin_config("test_plugin")["api_key"] == REAL_SECRET


### PR DESCRIPTION
Closes #1743

## Root cause

Plugin config leaves the process with every `SENSITIVE_FIELDS` entry replaced by the `"***"` sentinel (`ConfigManager._mask_sensitive`). Any client that reads a config and writes it straight back — the settings form, or an MCP client working from `list_installed_plugins()` — therefore posts the sentinel where the real secret used to be. Two gaps let it through:

1. **`PUT /plugins/{plugin_id}/config` handed the raw request body to `registry.set_plugin_config()`** before `ConfigManager` did its un-masking. The live plugin's `validate_config()` and `on_config_change()` therefore ran against three asterisks — for something like the Home Assistant plugin that means tearing down a working connection and re-establishing it with `***` as the token.
2. **`unmask_sensitive_values()` only walked the top level, while `_mask_sensitive()` masks at any depth.** A secret nested below the top level (a plugin's `sources[0].api_key`, say) was masked on the way out and then persisted as the literal string `"***"` on the way back in. That one is a real on-disk credential destruction, not just a live-state problem.

## Fix

- `src/api_server.py` — un-mask `request.config` against the stored config once, at the top of the handler, and use that dict for **both** `registry.set_plugin_config()` and `config_manager.set_plugin_config()`. Instance keys (`weather:sf`) resolve against their own stored entry because the handler already uses the compound key for both lookups. MCP's `configure_plugin` delegates to this REST handler, so it inherits the fix.
- `src/config_manager.py` — `unmask_sensitive_values()` now recurses through dicts and lists, mirroring `_mask_sensitive()`. List elements are matched to the stored list by position. Top-level semantics are unchanged: a masked key with nothing stored still resolves to `""` rather than being dropped.

## Test evidence

New file `tests/test_plugin_config_mask_roundtrip.py` drives the real `ConfigManager` (pinned at a tmp `config.json`) through the real endpoint, so the disk assertions are about what actually gets persisted rather than about a mock's call log.

One trap worth calling out: the endpoint hands the *same dict object* to the registry and then to the `ConfigManager`, which un-masks it **in place**. A plain `call_args` assertion on the registry mock would inspect the already-repaired dict and pass no matter what the code does. The fixture snapshots the config with `copy.deepcopy` inside a `side_effect` instead.

Verbatim failure output on the pre-fix tree (test written first, fix not yet applied):

```
============================= test session starts ==============================
collected 7 items

tests/test_plugin_config_mask_roundtrip.py F.FF..F                       [100%]

=================================== FAILURES ===================================
_ TestRestPluginConfigMaskSentinel.test_masked_api_key_is_not_applied_to_the_live_plugin _
tests/test_plugin_config_mask_roundtrip.py:105: in test_masked_api_key_is_not_applied_to_the_live_plugin
    assert _applied_config(applied)["api_key"] == REAL_SECRET
E   AssertionError: assert '***' == 'super-secret-key-abc123'
E     
E     - super-secret-key-abc123
E     + ***
_ TestRestPluginConfigMaskSentinel.test_masked_secret_nested_in_a_list_leaves_the_stored_secret_intact _
tests/test_plugin_config_mask_roundtrip.py:121: in test_masked_secret_nested_in_a_list_leaves_the_stored_secret_intact
    assert cm.get_plugin_config("test_plugin")["sources"][0]["api_key"] == NESTED_SECRET
E   AssertionError: assert '***' == 'nested-secret-key-xyz789'
E     
E     - nested-secret-key-xyz789
E     + ***
_ TestRestPluginConfigMaskSentinel.test_masked_api_key_on_an_instance_key_resolves_against_that_instance _
tests/test_plugin_config_mask_roundtrip.py:129: in test_masked_api_key_on_an_instance_key_resolves_against_that_instance
    assert _applied_config(applied)["api_key"] == REAL_SECRET
E   AssertionError: assert '***' == 'super-secret-key-abc123'
E     
E     - super-secret-key-abc123
E     + ***
_ TestMcpConfigurePluginMaskSentinel.test_masked_api_key_from_list_installed_plugins_is_not_written_back _
tests/test_plugin_config_mask_roundtrip.py:177: in test_masked_api_key_from_list_installed_plugins_is_not_written_back
    assert _applied_config(applied)["api_key"] == REAL_SECRET
E   AssertionError: assert '***' == 'super-secret-key-abc123'
E     
E     - super-secret-key-abc123
E     + ***
=========================== short test summary info ============================
FAILED tests/test_plugin_config_mask_roundtrip.py::TestRestPluginConfigMaskSentinel::test_masked_api_key_is_not_applied_to_the_live_plugin
FAILED tests/test_plugin_config_mask_roundtrip.py::TestRestPluginConfigMaskSentinel::test_masked_secret_nested_in_a_list_leaves_the_stored_secret_intact
FAILED tests/test_plugin_config_mask_roundtrip.py::TestRestPluginConfigMaskSentinel::test_masked_api_key_on_an_instance_key_resolves_against_that_instance
FAILED tests/test_plugin_config_mask_roundtrip.py::TestMcpConfigurePluginMaskSentinel::test_masked_api_key_from_list_installed_plugins_is_not_written_back
========================= 4 failed, 3 passed in 0.54s ==========================
```

Each failing test covers a different half of the fix: the three `_applied_config` failures are the endpoint change, the nested-list failure is the recursive `unmask_sensitive_values`. The three tests that passed before the fix are the guard rails — a real new key still overwrites the stored secret, a masked key with nothing stored still resolves to `""`, and the top-level disk write was already defended.

After the fix, all 7 pass.

## Regression runs

All in `fb-test:latest`:

- `tests/test_config_manager.py tests/test_security.py tests/test_plugin_registry.py tests/test_plugin_instances.py tests/test_plugin_options_route.py tests/test_mcp_server.py tests/test_mcp_state_effects.py tests/test_settings_service.py tests/test_settings_all.py` — **677 passed**
- `tests/test_api_extended.py tests/test_api_coverage.py tests/test_api_coverage_extended.py tests/test_config.py tests/test_config_migration.py tests/test_plugin_system_security.py tests/test_post_upgrade_restore.py tests/test_secrets_encryption.py tests/test_settings_per_board.py` — **668 passed**
- `tests/test_plugin_options.py tests/test_plugin_config_interpolation.py tests/test_plugin_loader.py tests/test_plugin_triggers.py tests/test_plugin_detail_plugin_type.py tests/test_plugin_health_sweep.py tests/test_mcp_prompts_and_resources.py tests/test_auth_mcp_bearer.py` — **270 passed**
- `ruff check` and `ruff format --check` over `src tests` — clean

## Review follow-up: list elements are matched by identity, not by index

The first cut of the recursive `unmask_sensitive_values` matched incoming list
elements to stored ones **by position**. Code review caught that this is not
safe: any edit that changes a list's shape shifts every later index, and the
secret restored into an element is then its neighbour's. Reproduced against the
branch, with `sources=[{name: a, api_key: KEY_A}, {name: b, api_key: KEY_B}]`
stored:

| Edit | Positional result |
| --- | --- |
| delete source `a`, post `[{name: b, api_key: "***"}]` | `[{'name': 'b', 'api_key': 'KEY_A'}]` — `b` authenticates with `a`'s key |
| reorder to `[b, a]`, both masked | keys swapped |
| prepend a new source `c`, `a` and `b` masked | `a` gets `b`'s key, **and `b`'s key becomes `''`** |

The third case is a regression in kind — an empty string is as destroyed as
`"***"` was, which is the exact bug this PR exists to fix. The first two are
arguably worse than the status quo: `"***"` fails loudly at the provider,
whereas a wrong-but-valid-looking key fails as an auth error the user blames on
the provider.

### Fix

`_match_stored_element` restores a stored secret into an incoming element only
on evidence that the two are the *same* element:

1. a unique hit on the first of `id` / `name` / `key` the element carries, or
2. when it carries none of those, a unique stored element whose **non-sensitive
   keys are all equal** to the incoming element's.

Anything else — no candidate, several candidates, or a renamed identity — is
`_UNMATCHED`, and every masked field below it **keeps the `"***"` sentinel**
for the schema/validation layer to reject.

### The trade-off, chosen deliberately

Leaving `"***"` means a user who renames a list element while its key is masked
gets a visible validation error instead of a silently working save. That is the
correct trade: the alternatives are cross-wiring one source's credential into
another (fails later, at the provider, and looks like the provider's fault) or
writing `""` (destroys a working credential outright). A loud, local failure the
user can act on beats a quiet, remote one they cannot diagnose. Nothing is
guessed, and no secret is ever replaced with an empty string.

Note that a masked key at a path that *does* exist in `stored` but holds nothing
still resolves to `""` — that is a key with no secret behind it, not a secret
being erased, and it is the pre-existing top-level contract.

Severity is low in practice: no bundled plugin in `plugins/*/manifest.json`
declares an array-typed setting containing a `SENSITIVE_FIELDS` key, so this is
latent for bundled plugins and reachable only by third-party/external plugins.
The fix is deliberately kept proportionate — ~40 lines, no schema awareness, no
new configuration.

## Review follow-up: `update_plugin_config` shares the helper

**Unified — yes.** `ConfigManager.update_plugin_config` still did a flat
top-level `if key in SENSITIVE_FIELDS and value == "***": continue`, so it
disagreed with `set_plugin_config` about depth. Its only live callers pass
`{"enabled": bool}`, so there was no active gap — but that inconsistency is the
same drift class that produced #1743 in the first place, and leaving it means
the next caller that passes a nested config re-opens the bug. Both methods now
route through `unmask_sensitive_values`.

One intentional semantic change comes with it: a masked key with nothing stored
used to be *skipped* by `update_plugin_config` (leaving the key absent) and now
resolves to `""`, matching `set_plugin_config` and the REST handler. The
existing `test_update_plugin_config_merges_preserves_masked` still passes.

### Test evidence (tests written first, verbatim pre-fix output)

`tests/test_plugin_config_mask_roundtrip.py::TestUnmaskListIdentity` — six new
tests, all failing on the pre-fix tree:

```
============================= test session starts ==============================
collected 6 items

tests/test_plugin_config_mask_roundtrip.py FFFFFF                        [100%]

=================================== FAILURES ===================================
_ TestUnmaskListIdentity.test_deleting_an_earlier_source_does_not_hand_its_key_to_a_later_one _
tests/test_plugin_config_mask_roundtrip.py:209: in test_deleting_an_earlier_source_does_not_hand_its_key_to_a_later_one
    assert result["sources"] == [{"name": "b", "api_key": KEY_B}]
E   AssertionError: assert [{'name': 'b'...or-source-a'}] == [{'name': 'b'...or-source-b'}]
E     
E     At index 0 diff: {'name': 'b', 'api_key': 'key-for-source-a'} != {'name': 'b', 'api_key': 'key-for-source-b'}
E     Use -v to get more diff
_ TestUnmaskListIdentity.test_reordering_sources_keeps_each_key_with_its_own_source _
tests/test_plugin_config_mask_roundtrip.py:217: in test_reordering_sources_keeps_each_key_with_its_own_source
    assert result["sources"] == [
E   AssertionError: assert [{'name': 'b'...or-source-b'}] == [{'name': 'b'...or-source-a'}]
E     
E     At index 0 diff: {'name': 'b', 'api_key': 'key-for-source-a'} != {'name': 'b', 'api_key': 'key-for-source-b'}
E     Use -v to get more diff
_ TestUnmaskListIdentity.test_inserting_a_source_neither_cross_wires_nor_destroys_the_others _
tests/test_plugin_config_mask_roundtrip.py:234: in test_inserting_a_source_neither_cross_wires_nor_destroys_the_others
    assert result["sources"] == [
E   AssertionError: assert [{'name': 'c'...api_key': ''}] == [{'name': 'c'...or-source-b'}]
E     
E     At index 1 diff: {'name': 'a', 'api_key': 'key-for-source-b'} != {'name': 'a', 'api_key': 'key-for-source-a'}
E     Use -v to get more diff
_ TestUnmaskListIdentity.test_an_unidentifiable_element_keeps_the_mask_rather_than_guessing _
tests/test_plugin_config_mask_roundtrip.py:250: in test_an_unidentifiable_element_keeps_the_mask_rather_than_guessing
    assert result["sources"] == [{"url": "https://example.com/two", "api_key": MASK}]
E   AssertionError: assert [{'url': 'htt...or-source-a'}] == [{'url': 'htt..._key': '***'}]
E     
E     At index 0 diff: {'url': 'https://example.com/two', 'api_key': 'key-for-source-a'} != {'url': 'https://example.com/two', 'api_key': '***'}
E     Use -v to get more diff
_ TestUnmaskListIdentity.test_elements_without_an_id_field_match_on_their_other_keys _
tests/test_plugin_config_mask_roundtrip.py:268: in test_elements_without_an_id_field_match_on_their_other_keys
    assert result["sources"] == [
E   AssertionError: assert [{'url': 'htt...or-source-b'}] == [{'url': 'htt...or-source-a'}]
E     
E     At index 0 diff: {'url': 'https://example.com/two', 'api_key': 'key-for-source-a'} != {'url': 'https://example.com/two', 'api_key': 'key-for-source-b'}
E     Use -v to get more diff
_ TestUnmaskListIdentity.test_update_plugin_config_preserves_a_secret_nested_in_a_list _
tests/test_plugin_config_mask_roundtrip.py:284: in test_update_plugin_config_preserves_a_secret_nested_in_a_list
    assert cm.get_plugin_config("test_plugin")["sources"] == [{"name": "a", "api_key": KEY_A}]
E   AssertionError: assert [{'name': 'a'..._key': '***'}] == [{'name': 'a'...or-source-a'}]
E     
E     At index 0 diff: {'name': 'a', 'api_key': '***'} != {'name': 'a', 'api_key': 'key-for-source-a'}
E     Use -v to get more diff
=========================== short test summary info ============================
FAILED tests/test_plugin_config_mask_roundtrip.py::TestUnmaskListIdentity::test_deleting_an_earlier_source_does_not_hand_its_key_to_a_later_one
FAILED tests/test_plugin_config_mask_roundtrip.py::TestUnmaskListIdentity::test_reordering_sources_keeps_each_key_with_its_own_source
FAILED tests/test_plugin_config_mask_roundtrip.py::TestUnmaskListIdentity::test_inserting_a_source_neither_cross_wires_nor_destroys_the_others
FAILED tests/test_plugin_config_mask_roundtrip.py::TestUnmaskListIdentity::test_an_unidentifiable_element_keeps_the_mask_rather_than_guessing
FAILED tests/test_plugin_config_mask_roundtrip.py::TestUnmaskListIdentity::test_elements_without_an_id_field_match_on_their_other_keys
FAILED tests/test_plugin_config_mask_roundtrip.py::TestUnmaskListIdentity::test_update_plugin_config_preserves_a_secret_nested_in_a_list
============================== 6 failed in 0.65s ===============================
```

Each failure is the defect itself, not a typo: index 0/1 diffs showing another
element's key, and — in the insert case and the `update_plugin_config` case —
the destroyed value (`''` and `'***'`).

### Regression runs after the fix

All in `fb-test:latest`:

- `tests/test_config_manager.py tests/test_plugin_config_mask_roundtrip.py` — **110 passed**
- `tests/test_security.py tests/test_plugin_registry.py tests/test_plugin_instances.py tests/test_plugin_options_route.py tests/test_mcp_server.py tests/test_mcp_state_effects.py tests/test_settings_service.py tests/test_settings_all.py tests/test_api_extended.py tests/test_config.py tests/test_config_migration.py tests/test_plugin_system_security.py tests/test_post_upgrade_restore.py tests/test_secrets_encryption.py tests/test_settings_per_board.py tests/test_plugin_config_interpolation.py tests/ai` — **1360 passed**
- `ruff check` + `ruff format --check` over `src tests` with the pinned `ruff==0.16.4` — clean

_Part of #1730 (Phase 1)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ndXRi5v57yB5sXXhQswjp

