### PR TITLE
fix(mcp): correct template-variable shape, update_plugin, and delete guards

### DIFF
--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -403,20 +403,34 @@ def _build_mcp_server() -> Any:
         )
 
     @mcp.tool()
-    def update_plugin(plugin_id: str) -> dict[str, Any]:
-        """Update an installed plugin to its latest registry version.
+    async def update_plugin(plugin_id: str) -> dict[str, Any]:
+        """Update an installed plugin to its latest version from its git remote.
+
+        Built-in plugins cannot be updated this way.
 
         Args:
             plugin_id: The plugin identifier (from list_installed_plugins()).
         """
-        try:
-            from .plugins import get_plugin_registry
+        from fastapi import HTTPException
 
-            registry = get_plugin_registry()
-            registry.reload_plugin(plugin_id)
-            return _ok(f"Plugin '{plugin_id}' updated successfully.", plugin_id=plugin_id)
+        from .api_server import update_plugin as _rest_update_plugin
+
+        # #1741: this used to call ``registry.reload_plugin()`` and nothing
+        # else — re-importing the code already on disk and reporting
+        # "updated successfully" without ever fetching anything, for any
+        # id at all. It also skipped every guard the REST handler applies
+        # (built-in rejection, realpath containment of the plugin's
+        # local_path inside the external plugins directory, and the .git
+        # check) before it lets a path near ``git``. Same lesson as #1588:
+        # go through the REST handler, do not re-derive its checks here.
+        try:
+            await _rest_update_plugin(plugin_id)
+        except HTTPException as exc:
+            return _err(f"Error updating plugin '{plugin_id}': {_rest_detail(exc)}")
         except Exception as exc:
             return _err(f"Error updating plugin '{plugin_id}': {exc}")
+
+        return _ok(f"Plugin '{plugin_id}' updated successfully.", plugin_id=plugin_id)
 
     @mcp.tool()
     def get_template_variables() -> dict[str, Any]:
@@ -431,7 +445,10 @@ def _build_mcp_server() -> Any:
             from .plugins import get_plugin_registry
 
             registry = get_plugin_registry()
-            return _serialize(registry.get_all_variables())
+            # #1739: get_all_variables() returns {plugin: [name, ...]}, not the
+            # nested metadata this tool documents. GET /templates/variables
+            # already uses the *_with_metadata variant; this call site drifted.
+            return _serialize(registry.get_all_variables_with_metadata())
         except Exception as exc:
             return _err(str(exc))
 
@@ -793,7 +810,12 @@ def _build_mcp_server() -> Any:
             from .schedules.service import get_schedule_service
 
             svc = get_schedule_service()
-            svc.delete_schedule(schedule_id)
+            # #1742: delete_schedule() returns False when the id does not
+            # exist. Discarding it made every delete look successful, so a
+            # typo'd id read back as "deleted" — DELETE /schedules/{id} 404s
+            # in the same case. Same drift delete_page was fixed for.
+            if not svc.delete_schedule(schedule_id):
+                return _err(f"Schedule '{schedule_id}' not found.")
             return _ok(f"Schedule '{schedule_id}' deleted successfully.", schedule_id=schedule_id)
         except Exception as exc:
             return _err(f"Error deleting schedule '{schedule_id}': {exc}")
@@ -965,7 +987,9 @@ def _build_mcp_server() -> Any:
             from .collections.service import get_collection_service
 
             svc = get_collection_service()
-            svc.delete_collection(collection_id)
+            # #1742: same as delete_schedule above — the boolean was dropped.
+            if not svc.delete_collection(collection_id):
+                return _err(f"Collection '{collection_id}' not found.")
             return _ok(
                 f"Collection '{collection_id}' deleted successfully.",
                 collection_id=collection_id,
@@ -1153,7 +1177,11 @@ def _build_mcp_server() -> Any:
             from .plugins import get_plugin_registry
 
             registry = get_plugin_registry()
-            variables = registry.get_all_variables()
+            # #1739: the loop below reads `meta.get("description")`, so it needs
+            # the metadata mapping. Against get_all_variables()'s list payload
+            # `.items()` raised AttributeError, and this handler returned that
+            # as the resource body on every install with an enabled plugin.
+            variables = registry.get_all_variables_with_metadata()
             lines = ["# Available Template Variables\n", "Use these in page templates as `{{plugin.variable}}`.\n"]
             for plugin_id, vars_dict in variables.items():
                 lines.append(f"\n## {plugin_id}")

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -88,7 +88,12 @@ def mock_registry():
         {"id": "openweather", "name": "OpenWeather", "description": "Weather data", "installed": True},
         {"id": "stocks", "name": "Stocks", "description": "Stock prices", "installed": False},
     ]
-    registry.get_all_variables.return_value = {
+    # #1739: these two return *different* shapes, and this mock used to give
+    # the metadata payload to `get_all_variables`. That made the drift
+    # invisible — the tool called the name-list method and the mock handed it
+    # metadata anyway. Each stub now matches its real signature.
+    registry.get_all_variables.return_value = {"openweather": ["temperature", "condition"]}
+    registry.get_all_variables_with_metadata.return_value = {
         "openweather": {
             "temperature": {"description": "Current temperature", "example": "72°F"},
             "condition": {"description": "Weather condition", "example": "Sunny"},

--- a/tests/test_mcp_state_effects.py
+++ b/tests/test_mcp_state_effects.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 import asyncio
 import json
 import shutil
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -85,12 +86,12 @@ COVERED = {
     "uninstall_plugin",
     "configure_plugin",
     "get_plugin_data",
+    "update_plugin",
 }
 
 #: Tools not yet covered here, each with the reason. Not an exemption list.
 UNCOVERED = {
     "list_registry_plugins": "hits the network-backed registry; needs a fixture",
-    "update_plugin": "reload_plugin() re-clones from git; needs a local git fixture",
     "set_active_page": "delegates to the REST handler; needs board render wiring",
     "set_schedule_mode": "routes through SettingsService; needs settings wiring",
 }
@@ -144,11 +145,11 @@ PLUGIN_ID = "harness_tide"
 UNINSTALLED_PLUGIN_ID = "harness_surf"
 
 
-def _manifest(plugin_id: str) -> dict[str, Any]:
+def _manifest(plugin_id: str, version: str = "1.0.0") -> dict[str, Any]:
     return {
         "id": plugin_id,
         "name": plugin_id.replace("_", " ").title(),
-        "version": "1.0.0",
+        "version": version,
         "description": "Fixture plugin for MCP state-effect tests.",
         "author": "FiestaBoard Tests",
         "icon": "puzzle",
@@ -198,10 +199,10 @@ class HarnessPlugin(PluginBase):
 '''
 
 
-def _write_plugin(directory: Path, plugin_id: str) -> None:
+def _write_plugin(directory: Path, plugin_id: str, version: str = "1.0.0") -> None:
     """Write a real, loadable plugin package to *directory*."""
     directory.mkdir(parents=True, exist_ok=True)
-    (directory / "manifest.json").write_text(json.dumps(_manifest(plugin_id)), encoding="utf-8")
+    (directory / "manifest.json").write_text(json.dumps(_manifest(plugin_id, version)), encoding="utf-8")
     (directory / "__init__.py").write_text(_PLUGIN_SOURCE.format(plugin_id=plugin_id), encoding="utf-8")
 
 
@@ -821,3 +822,197 @@ def test_plugin_configured_over_mcp_survives_a_container_recreate(mcp, plugins):
         "the plugin came back unconfigured after a restart"
     )
     assert PLUGIN_ID in restarted.get_all_variables(), "the plugin's template variables did not come back"
+
+
+# ---------------------------------------------------------------------------
+# Deleting something that is not there — #1742
+#
+# Both services return a boolean; both tools threw it away and reported
+# success. REST 404s in the same case, and ``delete_page`` was already fixed
+# for exactly this. The assertions below are on the tool's own envelope,
+# because there is no state to re-read — that is the whole point.
+# ---------------------------------------------------------------------------
+
+
+def test_delete_schedule_reports_an_error_for_an_unknown_id(mcp, services):
+    result = call(mcp, "delete_schedule", schedule_id="no-such-schedule")
+    assert result.get("status") == "error", f"deleting a schedule that does not exist reported success: {result}"
+
+
+def test_delete_collection_reports_an_error_for_an_unknown_id(mcp, services):
+    result = call(mcp, "delete_collection", collection_id="no-such-collection")
+    assert result.get("status") == "error", f"deleting a collection that does not exist reported success: {result}"
+
+
+# ---------------------------------------------------------------------------
+# Template variables — #1739
+#
+# ``get_template_variables`` documents ``{plugin: {var: {description, ...}}}``
+# but called ``get_all_variables()``, which returns ``{plugin: [name, ...]}``.
+# The existing shape test above passes vacuously: its fixture enables no
+# plugin, so the payload is ``{}`` and every nested assertion is skipped.
+# These enable one.
+# ---------------------------------------------------------------------------
+
+
+def call_resource(mcp: Any, uri: str) -> Any:
+    """Read a registered MCP resource by URI, awaiting it if it is async."""
+    resource = mcp._resource_manager._resources.get(uri)
+    if resource is None:
+        raise KeyError(f"resource {uri!r} is not registered; have: {sorted(mcp._resource_manager._resources)}")
+    result = resource.fn()
+    if asyncio.iscoroutine(result):
+        result = asyncio.run(result)
+    return result
+
+
+def _enable_harness_plugin(mcp: Any) -> None:
+    assert_ok(
+        call(mcp, "configure_plugin", plugin_id=PLUGIN_ID, config={"station_id": "9447427"}),
+        "configure_plugin",
+    )
+    assert_ok(call(mcp, "enable_plugin", plugin_id=PLUGIN_ID), "enable_plugin")
+
+
+def test_get_template_variables_describes_each_variable_with_metadata(mcp, plugins):
+    _enable_harness_plugin(mcp)
+
+    result = assert_ok(call(mcp, "get_template_variables"), "get_template_variables")
+
+    assert PLUGIN_ID in result, f"an enabled plugin's variables are missing entirely: {result}"
+    variables = result[PLUGIN_ID]
+    assert isinstance(variables, dict), (
+        f"the documented shape is {{variable: {{description, ...}}}}, got {type(variables).__name__}: {variables}"
+    )
+    assert variables["next_high"]["description"] == "Time of the next high tide"
+
+
+def test_variables_resource_renders_for_an_enabled_plugin(mcp, plugins):
+    """The resource calls ``.items()`` on each plugin's entry.
+
+    Against a list that is an AttributeError, which the resource caught and
+    returned as its whole body — so every install with at least one enabled
+    plugin got an error string instead of its variables.
+    """
+    _enable_harness_plugin(mcp)
+
+    content = call_resource(mcp, "fiestaboard://variables")
+
+    assert not content.lstrip().startswith("Error:"), f"the variables resource failed to render: {content}"
+    assert f"{{{{{PLUGIN_ID}.next_high}}}}" in content, (
+        f"an enabled plugin's variable is not listed in the resource: {content}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# update_plugin — #1741
+#
+# The tool called ``registry.reload_plugin()`` and nothing else: no git
+# fetch, so it re-imported the code already on disk and reported "updated
+# successfully" without any new code existing. It also skipped every guard
+# ``POST /plugins/{id}/update`` applies — built-in rejection, realpath
+# containment of ``local_path`` inside the external plugins directory, and
+# the ``.git`` check — so it would happily "update" a built-in plugin or a
+# directory that is not a checkout at all.
+#
+# The fixture below is a real local git remote, so the version change is
+# observed rather than mocked.
+# ---------------------------------------------------------------------------
+
+#: External plugin cloned from a real git remote, so it can actually update.
+GIT_PLUGIN_ID = "harness_git"
+
+#: Built-in plugin — must be rejected by update_plugin, never reloaded.
+BUILTIN_PLUGIN_ID = "harness_builtin"
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-c", "user.name=FiestaBoard Tests", "-c", "user.email=tests@example.com", *args],
+        cwd=str(cwd),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.fixture
+def updatable_plugins(plugins, tmp_path, monkeypatch):
+    """A git-backed external plugin, a built-in plugin, and a plain directory.
+
+    ``publish(version)`` commits a new manifest version to the remote. Nothing
+    in the update path is stubbed: the tool has to run a real ``git fetch``
+    against a real remote for the version to change.
+    """
+    external_dir = tmp_path / "external_plugins"
+    builtin_dir = tmp_path / "builtin_plugins"
+
+    remote = tmp_path / "remote" / GIT_PLUGIN_ID
+    _write_plugin(remote, GIT_PLUGIN_ID, version="1.0.0")
+    _git(remote, "init", "--quiet", "--initial-branch=main")
+    _git(remote, "add", "-A")
+    _git(remote, "commit", "--quiet", "-m", "v1.0.0")
+
+    _git(tmp_path, "clone", "--quiet", f"file://{remote}", str(external_dir / GIT_PLUGIN_ID))
+
+    _write_plugin(builtin_dir / BUILTIN_PLUGIN_ID, BUILTIN_PLUGIN_ID)
+
+    monkeypatch.setattr("src.plugins.sources.get_external_plugins_dir", lambda *a, **k: external_dir)
+
+    registry = plugins["restart"]()
+    assert registry.get_manifest(GIT_PLUGIN_ID) is not None, "fixture failed to load the git-backed plugin"
+    assert registry.get_manifest(BUILTIN_PLUGIN_ID) is not None, "fixture failed to load the built-in plugin"
+
+    def publish(version: str) -> None:
+        _write_plugin(remote, GIT_PLUGIN_ID, version=version)
+        _git(remote, "add", "-A")
+        _git(remote, "commit", "--quiet", "-m", f"v{version}")
+
+    yield {"registry": registry, "publish": publish, "external_dir": external_dir}
+
+
+def test_update_plugin_fetches_the_new_version_from_the_remote(mcp, updatable_plugins):
+    """The state effect: the manifest on disk and in the registry both move."""
+    registry = updatable_plugins["registry"]
+    assert registry.get_manifest(GIT_PLUGIN_ID).version == "1.0.0"
+
+    updatable_plugins["publish"]("2.0.0")
+
+    assert_ok(call(mcp, "update_plugin", plugin_id=GIT_PLUGIN_ID), "update_plugin")
+
+    on_disk = json.loads(
+        (updatable_plugins["external_dir"] / GIT_PLUGIN_ID / "manifest.json").read_text(encoding="utf-8")
+    )
+    assert on_disk["version"] == "2.0.0", "update_plugin reported success but never fetched the new code"
+    assert registry.get_manifest(GIT_PLUGIN_ID).version == "2.0.0", (
+        "the new version was fetched but the registry still serves the old manifest"
+    )
+
+
+def test_update_plugin_refuses_a_builtin_plugin(mcp, updatable_plugins):
+    """``POST /plugins/{id}/update`` 400s here; the MCP tool reloaded it."""
+    result = call(mcp, "update_plugin", plugin_id=BUILTIN_PLUGIN_ID)
+
+    assert result.get("status") == "error", f"a built-in plugin was reported as updated: {result}"
+    assert "built-in" in str(result.get("error", "")).lower(), (
+        f"the rejection did not say why a built-in cannot be updated: {result}"
+    )
+
+
+def test_update_plugin_refuses_a_plugin_that_is_not_a_git_checkout(mcp, updatable_plugins):
+    """``harness_tide`` was copied into place, not cloned — there is no remote.
+
+    Without the REST path's ``.git`` check the tool reports success for a
+    directory it has no way to update.
+    """
+    result = call(mcp, "update_plugin", plugin_id=PLUGIN_ID)
+
+    assert result.get("status") == "error", f"a plugin with no git checkout was reported as updated: {result}"
+    assert "git" in str(result.get("error", "")).lower(), (
+        f"the rejection did not name the missing git checkout: {result}"
+    )
+
+
+def test_update_plugin_reports_an_error_for_an_unknown_plugin(mcp, updatable_plugins):
+    result = call(mcp, "update_plugin", plugin_id="not_a_plugin")
+    assert result.get("status") == "error", f"updating a plugin that does not exist reported success: {result}"

--- a/tests/test_service_wiring.py
+++ b/tests/test_service_wiring.py
@@ -51,9 +51,12 @@ SCANNED_MODULES = [
 MIN_RESOLVED_CALLS = {
     # Dropped 35 -> 34 in #1588: the mutating plugin tools now delegate to the
     # REST handlers instead of calling PluginRegistry themselves, so there is
-    # one fewer directly-resolvable service call in this module. Lower this
-    # only alongside a change that genuinely removes a direct service call.
-    "src/mcp_server.py": 34,
+    # one fewer directly-resolvable service call in this module. Dropped
+    # 34 -> 33 in #1741 for the same reason: update_plugin no longer calls
+    # registry.reload_plugin() itself, it awaits the REST handler so the
+    # built-in / realpath-containment / .git guards run. Lower this only
+    # alongside a change that genuinely removes a direct service call.
+    "src/mcp_server.py": 33,
     "src/mqtt/commands.py": 15,
 }
 


### PR DESCRIPTION
Three independent correctness defects on the MCP surface. They all live in
`src/mcp_server.py` and share a test file, so they ship together rather than
as three racing branches.

Closes #1739
Closes #1741
Closes #1742

## Root causes

### #1739 — template-variable shape

`get_template_variables()` and the `fiestaboard://variables` resource both
called `registry.get_all_variables()`, which returns
`{plugin_id: [name, ...]}`. The tool's docstring promises — and clients
consume — the nested `{plugin_id: {var: {description, example, max_length,
...}}}` payload, and the resource calls `.items()` on each plugin's entry.
Against a list that is an `AttributeError`, which the handler caught and
returned as the resource's entire body, so every install with at least one
enabled plugin read `Error: 'list' object has no attribute 'items'` instead
of its variables. `GET /templates/variables` has always used
`get_all_variables_with_metadata()`; these two call sites drifted. Both now
call it too.

The existing test passed vacuously: its fixture enables no plugins, so the
payload was `{}` and the loop body never ran.

### #1741 — `update_plugin` (security)

`update_plugin()` called `registry.reload_plugin()` and nothing else. No git
fetch ran, so it re-imported the code already on disk and reported "updated
successfully" without any new version existing — for any plugin id at all,
including ones that are not installed. It also skipped every guard
`POST /plugins/{id}/update` applies before letting a path anywhere near
`git`:

- built-in plugins are rejected (they have no remote to fetch from)
- the plugin's `local_path` is `realpath`'d and required to sit strictly
  inside the external plugins directory — the path-traversal defence
- the directory is required to contain `.git`

None of that ran on the MCP path. The fix routes the tool through the REST
handler and flattens its `HTTPException` into the standard error envelope,
the same pattern the file's own #1588 comment mandates for the other mutating
plugin tools. The tool becomes `async` to await it.

### #1742 — delete tools

`delete_schedule()` and `delete_collection()` both discarded the boolean
their services return, so deleting an id that does not exist reported
`status: success`. `DELETE /schedules/{id}` and `DELETE /collections/{id}`
404 in the same case, and `delete_page` was already fixed for exactly this
drift (its inline comment names #1559/#1561); the two siblings were missed.
Both now propagate the boolean into an error result.

## Test evidence

Eight new cases in `tests/test_mcp_state_effects.py`, written first and each
confirmed failing against the unmodified code. Verbatim pre-fix output:

### #1739

```
______ test_get_template_variables_describes_each_variable_with_metadata _______
tests/test_mcp_state_effects.py:883: in test_get_template_variables_describes_each_variable_with_metadata
    assert isinstance(variables, dict), (
E   AssertionError: the documented shape is {variable: {description, ...}}, got list: ['next_high']
E   assert False
E    +  where False = isinstance(['next_high'], dict)
____________ test_variables_resource_renders_for_an_enabled_plugin _____________
tests/test_mcp_state_effects.py:901: in test_variables_resource_renders_for_an_enabled_plugin
    assert not content.lstrip().startswith("Error:"), f"the variables resource failed to render: {content}"
E   AssertionError: the variables resource failed to render: Error: 'list' object has no attribute 'items'
E   assert not True
E    +  where True = <built-in method startswith of str object at 0xffffacfc2670>('Error:')
E    +    where <built-in method startswith of str object at 0xffffacfc2670> = "Error: 'list' object has no attribute 'items'".startswith
E    +      where "Error: 'list' object has no attribute 'items'" = <built-in method lstrip of str object at 0xffffacfc2670>()
E    +        where <built-in method lstrip of str object at 0xffffacfc2670> = "Error: 'list' object has no attribute 'items'".lstrip
```

### #1741

```
__________ test_update_plugin_fetches_the_new_version_from_the_remote __________
tests/test_mcp_state_effects.py:987: in test_update_plugin_fetches_the_new_version_from_the_remote
    assert on_disk["version"] == "2.0.0", "update_plugin reported success but never fetched the new code"
E   AssertionError: update_plugin reported success but never fetched the new code
E   assert '1.0.0' == '2.0.0'
E     
E     - 2.0.0
E     ? ^
E     + 1.0.0
E     ? ^
_________________ test_update_plugin_refuses_a_builtin_plugin __________________
tests/test_mcp_state_effects.py:997: in test_update_plugin_refuses_a_builtin_plugin
    assert result.get("status") == "error", f"a built-in plugin was reported as updated: {result}"
E   AssertionError: a built-in plugin was reported as updated: {'status': 'success', 'message': "Plugin 'harness_builtin' updated successfully.", 'plugin_id': 'harness_builtin'}
E   assert 'success' == 'error'
E     
E     - error
E     + success
________ test_update_plugin_refuses_a_plugin_that_is_not_a_git_checkout ________
tests/test_mcp_state_effects.py:1011: in test_update_plugin_refuses_a_plugin_that_is_not_a_git_checkout
    assert result.get("status") == "error", f"a plugin with no git checkout was reported as updated: {result}"
E   AssertionError: a plugin with no git checkout was reported as updated: {'status': 'success', 'message': "Plugin 'harness_tide' updated successfully.", 'plugin_id': 'harness_tide'}
E   assert 'success' == 'error'
E     
E     - error
E     + success
__________ test_update_plugin_reports_an_error_for_an_unknown_plugin ___________
tests/test_mcp_state_effects.py:1019: in test_update_plugin_reports_an_error_for_an_unknown_plugin
    assert result.get("status") == "error", f"updating a plugin that does not exist reported success: {result}"
E   AssertionError: updating a plugin that does not exist reported success: {'status': 'success', 'message': "Plugin 'not_a_plugin' updated successfully.", 'plugin_id': 'not_a_plugin'}
E   assert 'success' == 'error'
E     
E     - error
E     + success
```

### #1742

```
___________ test_delete_schedule_reports_an_error_for_an_unknown_id ____________
tests/test_mcp_state_effects.py:838: in test_delete_schedule_reports_an_error_for_an_unknown_id
    assert result.get("status") == "error", f"deleting a schedule that does not exist reported success: {result}"
E   AssertionError: deleting a schedule that does not exist reported success: {'status': 'success', 'message': "Schedule 'no-such-schedule' deleted successfully.", 'schedule_id': 'no-such-schedule'}
E   assert 'success' == 'error'
E     
E     - error
E     + success
__________ test_delete_collection_reports_an_error_for_an_unknown_id ___________
tests/test_mcp_state_effects.py:843: in test_delete_collection_reports_an_error_for_an_unknown_id
    assert result.get("status") == "error", f"deleting a collection that does not exist reported success: {result}"
E   AssertionError: deleting a collection that does not exist reported success: {'status': 'success', 'message': "Collection 'no-such-collection' deleted successfully.", 'collection_id': 'no-such-collection'}
E   assert 'success' == 'error'
E     
E     - error
E     + success
```

### After the fix

```
tests/test_mcp_server.py ............................................... [ 23%]
....................................................                     [ 48%]
tests/test_mcp_prompts_and_resources.py .....................            [ 59%]
tests/test_mcp_skill_quality.py .............                            [ 65%]
tests/test_auth_mcp_bearer.py ........                                   [ 69%]
tests/test_auth_mcp_token_routes.py ................                     [ 77%]
tests/test_mcp_state_effects.py ........................................ [ 97%]
......                                                                   [100%]
======================= 203 passed, 4 warnings in 4.15s ========================
```

Plus 547 selected schedule/collection/plugin/template tests across `tests/`,
all passing. `ruff==0.16.2` format + check clean on all three files.

## Notes on the test changes

- `update_plugin` moves from the `UNCOVERED` ledger to `COVERED`. Its old
  reason — "needs a local git fixture" — is now satisfied: the
  `updatable_plugins` fixture builds a real git remote, clones it into the
  external plugins dir, and publishes a v2.0.0 commit. Nothing about the
  update path is stubbed, so the version change is observed on disk and in
  the registry rather than inferred from a call record.
- `mock_registry` in `tests/test_mcp_server.py` stubbed `get_all_variables`
  with the *metadata* shape. That is what let the #1739 drift stay invisible:
  the tool called the name-list method and the mock handed it metadata
  anyway. Each stub now returns what its real counterpart returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ndXRi5v57yB5sXXhQswjp
