### PR TITLE
fix(boards): isolate per-board init so a misconfigured primary can't down the fleet

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -3025,6 +3025,11 @@ async def get_status():
     # boards list must never break the legacy top-level status fields.
     try:
         boards = settings_service.get_board_settings().boards or []
+        # Why each board failed to get a client, when it failed (issue #1749).
+        # A board skipped at startup is visible here instead of only in the log.
+        init_errors = getattr(service, "board_init_errors", None)
+        if not isinstance(init_errors, dict):
+            init_errors = {}
         for board in boards:
             if not isinstance(board, dict) or not board.get("id"):
                 continue
@@ -3036,10 +3041,14 @@ async def get_status():
             active_page_id = settings_service.get_active_page_id(board_id=bid)
             if not isinstance(active_page_id, str):
                 active_page_id = None
+            init_error = init_errors.get(bid)
+            if not isinstance(init_error, str):
+                init_error = None
             status.boards[bid] = {
                 "configured": configured,
                 "paused": _board_is_paused(bid),
                 "active_page_id": active_page_id,
+                "error": init_error,
             }
     except Exception as e:
         logger.debug(f"Per-board status unavailable: {e}")

--- a/src/main.py
+++ b/src/main.py
@@ -90,6 +90,12 @@ class DisplayService:
         self.runtimes: dict[str, BoardRuntime] = {}
         self._primary_board_id = None
 
+        # Why each configured board failed to get a client, keyed by board id
+        # (issue #1749). Rebuilt on every ``_build_board_clients`` pass so a
+        # fixed board clears its entry. Surfaced per board on ``GET /status``
+        # so a skipped board is visible in the UI instead of only in the log.
+        self.board_init_errors: dict[str, str] = {}
+
         # Board state polling (background thread reads actual board state).
         self._poll_thread: threading.Thread | None = None
 
@@ -278,6 +284,13 @@ class DisplayService:
         board without a usable connection. A pre-filter on local/cloud keys
         silently dropped note-array boards (issue #1243 item 3).
 
+        Per-board failure isolation (issue #1749): each board's client build
+        is independent, so one bad board — the primary included — is skipped
+        with its reason recorded in ``self.board_init_errors`` while every
+        other board still comes up. The legacy Config fallback only runs when
+        *no* configured board produced a client, so a misconfigured primary
+        can no longer drag the whole fleet through it.
+
         Args:
             sync_cache: read the primary board's current message to seed the
                 skip-unchanged cache. Startup wants this; reinitialization
@@ -288,6 +301,7 @@ class DisplayService:
         boards = settings_service.get_board_settings().boards or []
 
         new_runtimes: dict[str, BoardRuntime] = {}
+        init_errors: dict[str, str] = {}
         for board in boards:
             if not isinstance(board, dict):
                 continue
@@ -300,8 +314,17 @@ class DisplayService:
                 # Unchanged connection: keep the runtime so its caches survive.
                 new_runtimes[bid] = existing
                 continue
-            client = board_client_from_board_dict(board)
+            try:
+                client = board_client_from_board_dict(board)
+            except Exception as e:
+                # One board's bad config must never abort the loop for the
+                # rest of the fleet (issue #1749).
+                init_errors[bid] = str(e) or e.__class__.__name__
+                logger.error(f"Board {bid}: could not build client ({e}) - skipping this board")
+                continue
             if client is None:
+                init_errors[bid] = "Board is not fully configured (missing host, API key, or token)"
+                logger.error(f"Board {bid}: {init_errors[bid]} - skipping this board")
                 continue
             self._attach_transition_runner(client)
             rt = BoardRuntime(client=client, board_id=bid)
@@ -309,22 +332,43 @@ class DisplayService:
             new_runtimes[bid] = rt
 
         self.runtimes = new_runtimes
+        self.board_init_errors = init_errors
 
-        if boards and isinstance(boards[0], dict) and boards[0].get("id") in new_runtimes:
-            self._primary_board_id = boards[0]["id"]
+        primary_id = boards[0].get("id") if (boards and isinstance(boards[0], dict)) else None
+        if primary_id and primary_id in new_runtimes:
+            self._primary_board_id = primary_id
+        elif new_runtimes:
+            # The primary is misconfigured but other boards came up. Keep the
+            # primary id pointing at the configured primary (its clientless
+            # runtime is created lazily by ``_ensure_primary_runtime``) rather
+            # than dropping into the legacy Config fallback, which would raise
+            # on an install with no legacy credential and take every board
+            # down with it (issue #1749).
+            self._primary_board_id = primary_id
+            logger.error(
+                f"Primary board {primary_id or '(unidentified)'} is unavailable "
+                f"({init_errors.get(primary_id, 'no usable connection')}); "
+                f"continuing with {len(new_runtimes)} other board(s)"
+            )
         else:
             # Legacy single-board Config path: no usable settings.boards entry.
-            use_cloud = Config.BOARD_API_MODE.lower() == "cloud"
-            client = BoardClient(
-                api_key=Config.get_board_api_key(),
-                host=Config.BOARD_HOST if not use_cloud else None,
-                use_cloud=use_cloud,
-                skip_unchanged=True,
-            )
-            self._attach_transition_runner(client)
-            key = self._PRIMARY_FALLBACK_KEY
-            self.runtimes[key] = BoardRuntime(client=client, board_id=key)
-            self._primary_board_id = key
+            # Its own failure is recorded rather than raised so callers see an
+            # empty fleet instead of an exception out of the whole build.
+            try:
+                use_cloud = Config.BOARD_API_MODE.lower() == "cloud"
+                client = BoardClient(
+                    api_key=Config.get_board_api_key(),
+                    host=Config.BOARD_HOST if not use_cloud else None,
+                    use_cloud=use_cloud,
+                    skip_unchanged=True,
+                )
+                self._attach_transition_runner(client)
+                key = self._PRIMARY_FALLBACK_KEY
+                self.runtimes[key] = BoardRuntime(client=client, board_id=key)
+                self._primary_board_id = key
+            except Exception as e:
+                self._primary_board_id = primary_id
+                logger.error(f"No board connection available: legacy config client could not be built ({e})")
 
         if sync_cache:
             rt = self._primary_runtime()
@@ -371,9 +415,12 @@ class DisplayService:
                 # thread repopulates it on its next iteration.
                 rt.polled_characters = None
                 rt.polled_at = None
-                logger.info(f"Board clients rebuilt successfully ({len(self.runtimes)} runtime(s))")
-                return True
-            return False
+            # Success means *some* board is drivable — a misconfigured primary
+            # alongside healthy secondaries is still a usable rebuild (#1749).
+            if not self.board_clients:
+                return False
+            logger.info(f"Board clients rebuilt successfully ({len(self.runtimes)} runtime(s))")
+            return True
         except Exception as e:
             logger.error(f"Failed to rebuild board clients: {e}")
             return False
@@ -511,9 +558,17 @@ class DisplayService:
         # Initialize board runtimes from settings.boards (all boards) or Config
         try:
             self._build_board_clients()
-            if not self.vb_client:
+            # Gate on the FLEET, not on the primary board (issue #1749): a
+            # misconfigured primary used to fail initialization outright,
+            # which made ``run()`` bail and left every other board dark.
+            if not self.board_clients:
                 logger.error("No board connection configured (settings.boards or config)")
                 return False
+            if not self.vb_client:
+                logger.warning(
+                    "Primary board has no connection - it will be skipped until its "
+                    "configuration is fixed; other boards keep running"
+                )
             logger.info("Syncing cache with current board state...")
             # Log transition settings if configured
             transition = Config.get_transition_settings()

--- a/src/main.py
+++ b/src/main.py
@@ -580,11 +580,19 @@ class DisplayService:
             logger.error(f"Failed to initialize board client: {e}")
             return False
 
-        # Start background thread that reads the actual board state periodically
-        self._poll_thread = threading.Thread(target=self._board_poll_loop, daemon=True, name="board-state-poll")
-        self._poll_thread.start()
-        interval = self._get_board_read_interval()
-        logger.info(f"Board state poll started (interval={interval}s)")
+        # Start background thread that reads the actual board state periodically.
+        # This must be idempotent: with a clientless primary ``vb_client`` stays
+        # None for the life of the process, so every startup gate that tests it
+        # re-enters initialize() -- ``get_service()``, ``run_service_background()``
+        # and ``run()`` -- and the backoff loop repeats that on each restart.
+        # Starting a thread per pass would leak them without bound.
+        if self._poll_thread is not None and self._poll_thread.is_alive():
+            logger.debug("Board state poll already running - reusing the existing thread")
+        else:
+            self._poll_thread = threading.Thread(target=self._board_poll_loop, daemon=True, name="board-state-poll")
+            self._poll_thread.start()
+            interval = self._get_board_read_interval()
+            logger.info(f"Board state poll started (interval={interval}s)")
 
         # Log configuration summary
         summary = Config.get_summary()

--- a/tests/test_api_extended.py
+++ b/tests/test_api_extended.py
@@ -2200,9 +2200,25 @@ class TestStatusPerBoard:
 
         assert response.status_code == 200
         boards = response.json()["boards"]
-        assert boards["b1"] == {"configured": True, "paused": False, "active_page_id": "page1"}
+        assert boards["b1"] == {"configured": True, "paused": False, "active_page_id": "page1", "error": None}
         assert boards["b2"]["configured"] is False
         assert boards["b2"]["paused"] is True
+
+    def test_status_surfaces_why_a_board_has_no_client(self, client, mock_service, mock_settings_service):
+        """A board skipped at startup must be observable, not just logged
+        (issue #1749)."""
+        _configure_boards(mock_settings_service)
+        mock_settings_service.get_active_page_id.return_value = "page1"
+        mock_service.get_board_client = Mock(side_effect=lambda bid: None if bid == "b1" else Mock())
+        mock_service.board_init_errors = {"b1": "api_key is required"}
+
+        with patch("src.api_server._service_running", True):
+            response = client.get("/status")
+
+        assert response.status_code == 200
+        boards = response.json()["boards"]
+        assert boards["b1"]["error"] == "api_key is required"
+        assert boards["b2"]["error"] is None
 
     def test_status_keeps_top_level_fields(self, client, mock_service, mock_settings_service):
         _configure_boards(mock_settings_service)

--- a/tests/test_multi_board_driving.py
+++ b/tests/test_multi_board_driving.py
@@ -13,6 +13,7 @@ per-board caches) is covered by ``tests/test_per_board_engine.py``, which
 exercises the unified ``check_and_send_for_board`` path.
 """
 
+import threading
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -332,6 +333,52 @@ class TestPrimaryBoardFailureIsolation:
 
         assert "host is required for Local API" in service.board_init_errors["b1"]
         assert "b2" not in service.board_init_errors
+
+    def test_repeated_initialize_reuses_the_live_board_state_poll_thread(self, service):
+        """``initialize()`` must not stack a second ``board-state-poll`` thread.
+
+        With the primary clientless, ``vb_client`` stays ``None`` for the life
+        of the process, so every startup gate that tests it re-enters
+        ``initialize()``: ``get_service()``, ``run_service_background()``'s
+        ``if not service.vb_client`` guard, and ``run()``'s
+        ``if not self.vb_client and not self.initialize()``. Each pass used to
+        start another poll thread, and ``run_service_background``'s backoff
+        loop repeated two of them on every auto-restart — an unbounded leak.
+        """
+        boards = [_board("b1", "Broken", local_api_key="", cloud_key=""), _board("b2", "Good", port=7001)]
+        pre_existing = {t.ident for t in threading.enumerate()}
+        release = threading.Event()
+
+        def _park(_self):
+            release.wait(10)
+
+        with (
+            patch("src.main.get_settings_service", return_value=_settings_service(boards)),
+            patch(
+                "src.main.board_client_from_board_dict",
+                side_effect=lambda b: None if b["id"] == "b1" else MagicMock(),
+            ),
+            patch("src.main.Config.validate", return_value=True),
+            patch("src.main.Config.get_summary", return_value={}),
+            patch("src.main.Config.get_transition_settings", return_value={"strategy": None}),
+            patch.object(DisplayService, "_board_poll_loop", _park),
+        ):
+            try:
+                for _ in range(3):
+                    assert service.initialize() is True
+                # The condition all three startup gates re-test.
+                assert service.vb_client is None
+                started = [
+                    t
+                    for t in threading.enumerate()
+                    if t.name == "board-state-poll" and t.is_alive() and t.ident not in pre_existing
+                ]
+                assert len(started) == 1, f"expected 1 live poll thread, found {len(started)}"
+            finally:
+                release.set()
+                for t in threading.enumerate():
+                    if t.name == "board-state-poll" and t.ident not in pre_existing:
+                        t.join(timeout=5)
 
     def test_a_recovered_board_clears_its_recorded_error(self, service):
         boards = [_board("b1", "One")]

--- a/tests/test_multi_board_driving.py
+++ b/tests/test_multi_board_driving.py
@@ -196,3 +196,152 @@ class TestInvalidateBoardContent:
 
         assert service._last_active_page_content is None
         client.clear_cache.assert_called_once()
+
+
+class TestPrimaryBoardFailureIsolation:
+    """A misconfigured primary board must not take down the rest of the fleet
+    (issue #1749).
+
+    Before the fix, ``boards[0]`` failing to yield a client dropped the build
+    into the legacy single-board ``Config`` fallback, which raises when no
+    legacy credential is configured — aborting ``_build_board_clients`` for
+    every board and making ``initialize()`` return False, so ``run()`` bailed
+    and no board was driven at all.
+    """
+
+    def test_secondary_board_gets_a_runtime_when_the_primary_client_raises(self, service):
+        boards = [_board("b1", "Broken"), _board("b2", "Good", port=7001)]
+        good = MagicMock()
+
+        def factory(board):
+            if board["id"] == "b1":
+                raise ValueError("api_key is required")
+            return good
+
+        with (
+            patch("src.main.get_settings_service", return_value=_settings_service(boards)),
+            patch("src.main.board_client_from_board_dict", side_effect=factory),
+        ):
+            service._build_board_clients(sync_cache=False)
+
+        assert service.get_board_client("b2") is good
+
+    def test_secondary_board_gets_a_runtime_when_the_primary_is_unconfigured(self, service):
+        """The primary has no usable credential (factory returns None). The
+        legacy Config fallback must not hijack the build."""
+        boards = [_board("b1", "Broken", local_api_key="", cloud_key=""), _board("b2", "Good", port=7001)]
+        good = MagicMock()
+
+        with (
+            patch("src.main.get_settings_service", return_value=_settings_service(boards)),
+            patch(
+                "src.main.board_client_from_board_dict",
+                side_effect=lambda b: None if b["id"] == "b1" else good,
+            ),
+        ):
+            service._build_board_clients(sync_cache=False)
+
+        assert service.get_board_client("b2") is good
+
+    def test_misconfigured_primary_does_not_build_the_legacy_config_client(self, service):
+        """With another board up, the legacy single-board fallback must stay
+        out of the way — it would claim the primary slot with a client built
+        from whatever is left in the legacy env config."""
+        boards = [_board("b1", "Broken", local_api_key="", cloud_key=""), _board("b2", "Good", port=7001)]
+
+        with (
+            patch("src.main.get_settings_service", return_value=_settings_service(boards)),
+            patch(
+                "src.main.board_client_from_board_dict",
+                side_effect=lambda b: None if b["id"] == "b1" else MagicMock(),
+            ),
+            patch("src.main.BoardClient") as legacy_client,
+        ):
+            service._build_board_clients(sync_cache=False)
+
+        legacy_client.assert_not_called()
+        assert service._PRIMARY_FALLBACK_KEY not in service.runtimes
+
+    def test_secondary_board_is_still_driven_when_the_primary_is_misconfigured(self, service):
+        """Acceptance (issue #1749): primary invalid + secondary valid ->
+        the secondary is still driven on the update tick."""
+        boards = [_board("b1", "Broken", local_api_key="", cloud_key=""), _board("b2", "Good", port=7001)]
+        driven = []
+
+        with (
+            patch("src.main.get_settings_service", return_value=_settings_service(boards)),
+            patch(
+                "src.main.board_client_from_board_dict",
+                side_effect=lambda b: None if b["id"] == "b1" else MagicMock(),
+            ),
+        ):
+            service._build_board_clients(sync_cache=False)
+            with patch.object(
+                service,
+                "check_and_send_for_board",
+                side_effect=lambda board_id, rt, **kw: driven.append(board_id) or True,
+            ):
+                service.check_and_send_active_page()
+
+        assert "b2" in driven
+
+    def test_initialize_succeeds_when_only_the_primary_board_is_misconfigured(self, service):
+        boards = [_board("b1", "Broken", local_api_key="", cloud_key=""), _board("b2", "Good", port=7001)]
+
+        with (
+            patch("src.main.get_settings_service", return_value=_settings_service(boards)),
+            patch(
+                "src.main.board_client_from_board_dict",
+                side_effect=lambda b: None if b["id"] == "b1" else MagicMock(),
+            ),
+            patch("src.main.Config.validate", return_value=True),
+            patch("src.main.Config.get_summary", return_value={}),
+            patch("src.main.Config.get_transition_settings", return_value={"strategy": None}),
+            patch("src.main.threading.Thread"),
+        ):
+            assert service.initialize() is True
+
+    def test_initialize_fails_when_no_board_has_a_connection(self, service):
+        """The all-boards-down case must still be a hard failure — the fix
+        must not turn a fully unconfigured install into a silent success."""
+        boards = [_board("b1", "Broken", local_api_key="", cloud_key="")]
+
+        with (
+            patch("src.main.get_settings_service", return_value=_settings_service(boards)),
+            patch("src.main.board_client_from_board_dict", return_value=None),
+            patch("src.main.Config.validate", return_value=True),
+            patch("src.main.BoardClient", side_effect=ValueError("api_key is required")),
+        ):
+            assert service.initialize() is False
+
+    def test_primary_failure_reason_is_recorded_for_surfacing(self, service):
+        """The skipped board's reason must be observable, not swallowed —
+        /status exposes it per board."""
+        boards = [_board("b1", "Broken"), _board("b2", "Good", port=7001)]
+
+        def factory(board):
+            if board["id"] == "b1":
+                raise ValueError("host is required for Local API")
+            return MagicMock()
+
+        with (
+            patch("src.main.get_settings_service", return_value=_settings_service(boards)),
+            patch("src.main.board_client_from_board_dict", side_effect=factory),
+        ):
+            service._build_board_clients(sync_cache=False)
+
+        assert "host is required for Local API" in service.board_init_errors["b1"]
+        assert "b2" not in service.board_init_errors
+
+    def test_a_recovered_board_clears_its_recorded_error(self, service):
+        boards = [_board("b1", "One")]
+
+        with patch("src.main.get_settings_service", return_value=_settings_service(boards)):
+            with patch("src.main.board_client_from_board_dict", side_effect=ValueError("boom")):
+                service._build_board_clients(sync_cache=False)
+            assert "b1" in service.board_init_errors
+
+            with patch("src.main.board_client_from_board_dict", return_value=MagicMock()):
+                service._build_board_clients(sync_cache=False)
+
+        assert service.board_init_errors == {}

--- a/tests/test_silence_schedule_polling.py
+++ b/tests/test_silence_schedule_polling.py
@@ -272,3 +272,29 @@ class TestSilenceBoundaryDetector:
 
         # One initial update + exactly one forced update at the boundary.
         assert drive.call_count == 2
+
+    def test_clientless_primary_does_not_force_an_update_every_second_during_silence(self, service_factory):
+        """A primary board with a runtime but no client is a normal running
+        state since #1749/#1813 — the fleet keeps going while that one board is
+        skipped. Its silence flag must still be latched, or the 1 Hz boundary
+        detector sees a permanent mismatch and re-drives every board once per
+        second for the whole silence window (issue #1740).
+        """
+        svc, mocks, page_service = service_factory(is_silence=True)
+        svc.vb_client = None
+        assert svc._ensure_primary_runtime().client is None
+        mocks["settings"].return_value.is_paused.return_value = False
+
+        with (
+            # The fleet came up; only the primary lacks a client (issue #1749).
+            patch.object(svc, "initialize", return_value=True),
+            patch.object(svc, "check_and_send_active_page", wraps=svc.check_and_send_active_page) as drive,
+            patch.object(svc, "_check_trigger_override", return_value=None),
+            patch("src.main.schedule"),
+            patch("src.main.time.sleep", _sleep_that_stops_after(svc, 5)),
+        ):
+            svc.run()
+
+        # Only the initial update before the loop — not one per simulated second.
+        assert drive.call_count == 1
+        assert page_service.preview_page.call_count == 1

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -20,6 +20,12 @@ export interface BoardStatus {
   configured: boolean;
   paused: boolean;
   active_page_id: string | null;
+  /**
+   * Why this board has no client, when it has none (issue #1749). A board
+   * skipped at startup because of a bad config is surfaced here; the rest of
+   * the fleet keeps running.
+   */
+  error?: string | null;
 }
 
 export interface ConfigSummary {


### PR DESCRIPTION
Closes #1749

## Root cause

`DisplayService._build_board_clients` (`src/main.py`) built every board's client
inside one unguarded loop, so an exception from `board_client_from_board_dict`
on *any* board — the primary included — aborted the loop for all of them.

Worse, when `boards[0]` merely produced **no** client (returned `None` because
its credential/host is missing), the build fell through to the legacy
single-board `Config` path:

```python
if boards and isinstance(boards[0], dict) and boards[0].get("id") in new_runtimes:
    self._primary_board_id = boards[0]["id"]
else:
    # Legacy single-board Config path
    client = BoardClient(api_key=Config.get_board_api_key(), ...)
```

On a multi-board install with no legacy env credential, `BoardClient.__init__`
raises `ValueError: api_key is required` (`src/board_client.py:345`). That
exception escaped `_build_board_clients`, so `initialize()` logged
`Failed to initialize board client` and returned `False`, and `run()` bailed
(`src/main.py:1165`). One bad board config left the entire fleet dark.

## The fix

- **Per-board isolation.** Each board's client build is wrapped individually;
  a raising or `None`-returning board is skipped with its reason recorded, and
  the loop continues for every other board.
- **Legacy fallback is last-resort only.** It now runs when *no* configured
  board produced a client, instead of whenever `boards[0]` specifically failed.
  A legacy single-board install still has exactly one board, so its migration
  path is unchanged — only multi-board fleets see different behaviour. The
  fallback's own failure is caught and logged rather than raised, so
  `_build_board_clients` no longer explodes on an unconfigured install.
- **Primary id stays honest.** When the primary is down but secondaries are up,
  `_primary_board_id` keeps pointing at the configured primary (its clientless
  runtime is created lazily by `_ensure_primary_runtime`), so
  `check_and_send_active_page` never drives board B's hardware with board A's
  id. `_drive_secondary_boards` then drives the healthy boards as normal.
- **Fleet-level gating.** `initialize()` and `rebuild_board_clients()` now
  succeed when *some* board is drivable (`self.board_clients`) rather than
  requiring the primary. A fully unconfigured install is still a hard failure —
  covered by `test_initialize_fails_when_no_board_has_a_connection`, which
  passed before the fix too and must keep passing.

## How the failure is surfaced

The codebase had no existing `last_send_error`-style field, so this follows the
nearest existing convention — the per-board `/status` map added in #1244.

- `DisplayService.board_init_errors: dict[board_id, str]` records why each board
  was skipped. It is rebuilt on every `_build_board_clients` pass, so a board
  whose config is fixed clears its own entry.
- Every skip is logged at **ERROR** (`Board b1: could not build client (...) -
  skipping this board`), plus a summary line naming the unavailable primary and
  how many boards are still running.
- `GET /status` exposes it per board as `boards[<id>].error` alongside the
  existing `configured` / `paused` / `active_page_id`, with a matching
  `BoardStatus.error` field in `web/src/lib/api.ts`.

Nothing is swallowed: a skipped board reads `configured: false` **with** the
reason attached.

## Test evidence

Eight tests were written first, in `tests/test_multi_board_driving.py`
(`TestPrimaryBoardFailureIsolation`). Seven fail on `main` for exactly the
mechanism described above; the eighth
(`test_initialize_fails_when_no_board_has_a_connection`) passes before and after
as a guard that the fix does not turn an unconfigured install into a silent
success.

Verbatim pre-fix run:

```
$ docker run --rm -v "$PWD":/app -w /app fb-test:latest \
    python -m pytest tests/test_multi_board_driving.py -q --no-header -p no:cacheprovider

============================= test session starts ==============================
collected 17 items

tests/test_multi_board_driving.py .........FFFFF.FF                      [100%]

=================================== FAILURES ===================================
_ TestPrimaryBoardFailureIsolation.test_secondary_board_gets_a_runtime_when_the_primary_client_raises _
tests/test_multi_board_driving.py:225: in test_secondary_board_gets_a_runtime_when_the_primary_client_raises
    service._build_board_clients(sync_cache=False)
src/main.py:303: in _build_board_clients
    client = board_client_from_board_dict(board)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/local/lib/python3.14/unittest/mock.py:1176: in __call__
    return self._mock_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/local/lib/python3.14/unittest/mock.py:1180: in _mock_call
    return self._execute_mock_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/local/lib/python3.14/unittest/mock.py:1247: in _execute_mock_call
    result = effect(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^
tests/test_multi_board_driving.py:218: in factory
    raise ValueError("api_key is required")
E   ValueError: api_key is required
_ TestPrimaryBoardFailureIsolation.test_secondary_board_gets_a_runtime_when_the_primary_is_unconfigured _
tests/test_multi_board_driving.py:242: in test_secondary_board_gets_a_runtime_when_the_primary_is_unconfigured
    service._build_board_clients(sync_cache=False)
src/main.py:318: in _build_board_clients
    client = BoardClient(
src/board_client.py:345: in __init__
    raise ValueError("api_key is required")
E   ValueError: api_key is required
_ TestPrimaryBoardFailureIsolation.test_misconfigured_primary_does_not_build_the_legacy_config_client _
tests/test_multi_board_driving.py:262: in test_misconfigured_primary_does_not_build_the_legacy_config_client
    legacy_client.assert_not_called()
/usr/local/lib/python3.14/unittest/mock.py:947: in assert_not_called
    raise AssertionError(msg)
E   AssertionError: Expected 'BoardClient' to not have been called. Called 1 times.
E   Calls: [call(api_key='', host='', use_cloud=False, skip_unchanged=True),
E    call().set_transition_runner(<src.transitions.runner.TransitionRunner object at 0xffffb2759e50>)].
_ TestPrimaryBoardFailureIsolation.test_secondary_board_is_still_driven_when_the_primary_is_misconfigured _
tests/test_multi_board_driving.py:278: in test_secondary_board_is_still_driven_when_the_primary_is_misconfigured
    service._build_board_clients(sync_cache=False)
src/main.py:318: in _build_board_clients
    client = BoardClient(
src/board_client.py:345: in __init__
    raise ValueError("api_key is required")
E   ValueError: api_key is required
_ TestPrimaryBoardFailureIsolation.test_initialize_succeeds_when_only_the_primary_board_is_misconfigured _
tests/test_multi_board_driving.py:302: in test_initialize_succeeds_when_only_the_primary_board_is_misconfigured
    assert service.initialize() is True
E   assert False is True
E    +  where False = initialize()
E    +    where initialize = <src.main.DisplayService object at 0xffffb23dc750>.initialize
------------------------------ Captured log call -------------------------------
ERROR    src.main:main.py:525 Failed to initialize board client: api_key is required
_ TestPrimaryBoardFailureIsolation.test_primary_failure_reason_is_recorded_for_surfacing _
tests/test_multi_board_driving.py:331: in test_primary_failure_reason_is_recorded_for_surfacing
    service._build_board_clients(sync_cache=False)
src/main.py:303: in _build_board_clients
    client = board_client_from_board_dict(board)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/local/lib/python3.14/unittest/mock.py:1176: in __call__
    return self._mock_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/local/lib/python3.14/unittest/mock.py:1180: in _mock_call
    return self._execute_mock_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/local/lib/python3.14/unittest/mock.py:1247: in _execute_mock_call
    result = effect(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^
tests/test_multi_board_driving.py:324: in factory
    raise ValueError("host is required for Local API")
E   ValueError: host is required for Local API
_ TestPrimaryBoardFailureIsolation.test_a_recovered_board_clears_its_recorded_error _
tests/test_multi_board_driving.py:341: in test_a_recovered_board_clears_its_recorded_error
    service._build_board_clients(sync_cache=False)
src/main.py:303: in _build_board_clients
    client = board_client_from_board_dict(board)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/local/lib/python3.14/unittest/mock.py:1176: in __call__
    return self._mock_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/local/lib/python3.14/unittest/mock.py:1180: in _mock_call
    return self._execute_mock_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/local/lib/python3.14/unittest/mock.py:1241: in _execute_mock_call
    raise effect
E   ValueError: boom
=========================== short test summary info ============================
FAILED tests/test_multi_board_driving.py::TestPrimaryBoardFailureIsolation::test_secondary_board_gets_a_runtime_when_the_primary_client_raises
FAILED tests/test_multi_board_driving.py::TestPrimaryBoardFailureIsolation::test_secondary_board_gets_a_runtime_when_the_primary_is_unconfigured
FAILED tests/test_multi_board_driving.py::TestPrimaryBoardFailureIsolation::test_misconfigured_primary_does_not_build_the_legacy_config_client
FAILED tests/test_multi_board_driving.py::TestPrimaryBoardFailureIsolation::test_secondary_board_is_still_driven_when_the_primary_is_misconfigured
FAILED tests/test_multi_board_driving.py::TestPrimaryBoardFailureIsolation::test_initialize_succeeds_when_only_the_primary_board_is_misconfigured
FAILED tests/test_multi_board_driving.py::TestPrimaryBoardFailureIsolation::test_primary_failure_reason_is_recorded_for_surfacing
FAILED tests/test_multi_board_driving.py::TestPrimaryBoardFailureIsolation::test_a_recovered_board_clears_its_recorded_error
========================= 7 failed, 10 passed in 0.40s =========================
```

Post-fix, same command plus the per-board engine suite:

```
tests/test_multi_board_driving.py .................                      [ 51%]
tests/test_per_board_engine.py ................                          [100%]

============================== 33 passed in 0.18s ==============================
```

### Regression sweep

All suites that touch `src.main` or `/status`, run in `fb-test:latest`:

```
tests/test_board_paused.py tests/test_settings_per_board.py
tests/test_adaptive_board_refresh.py tests/test_board_client.py
tests/test_board_connection_test.py tests/test_schedule_board_id_bug.py
tests/test_virtual_board_client.py                       -> 208 passed
tests/test_silence_mode_display.py tests/test_integration_multi_features.py
tests/test_trigger_render_path.py tests/test_silence_indicator_rendering.py
tests/test_silence_schedule_polling.py tests/test_logs.py
tests/test_service_lifecycle.py                          ->  99 passed
tests/test_api_coverage.py tests/test_api_extended.py tests/test_api_wifi.py
tests/test_hdmi_kiosk_api.py tests/test_mqtt_client.py
tests/test_mqtt_discovery.py tests/test_system_endpoints.py
tests/test_multi_board_driving.py tests/test_per_board_engine.py -> 599 passed
```

`ruff check src tests` and `ruff format --check` are clean.

One existing assertion was updated rather than weakened:
`TestStatusPerBoard::test_status_reports_per_board_state` compared the per-board
status dict by exact equality, so the additive `error` key is now part of the
expected dict. A new test,
`test_status_surfaces_why_a_board_has_no_client`, asserts the reason actually
reaches the API response.


---

## Review round 2

### Thread leak: `initialize()` is now idempotent w.r.t. the poll thread

Making a clientless primary a *survivable* state has a second-order effect this
PR originally missed. `service.vb_client` is a property over the primary
runtime's client, so with the primary skipped it stays `None` for the life of
the process — and three startup gates test exactly that value and re-enter
`initialize()` when it is falsy:

| gate | site |
| --- | --- |
| `get_service()` | `src/api_server.py:946` |
| `run_service_background()` — `if not service.vb_client: service.initialize()` | `src/api_server.py:973-976` |
| `DisplayService.run()` — `if not self.vb_client and not self.initialize()` | `src/main.py:1110` |

`initialize()` started a `board-state-poll` thread unconditionally, so each pass
started another. Three at startup, plus **two more on every auto-restart cycle**
of `run_service_background`'s backoff loop — an unbounded leak. On `main` this
is unreachable: a healthy primary makes `vb_client` truthy, and a broken one
makes `initialize()` return `False`. This PR is what makes it reachable.

Observed before the fix:

```
initialize() -> True
vb_client after initialize: None
board_clients: ['b2']
run_service_background would re-initialize: True
run() would re-initialize: True
board-state-poll threads alive: 3
```

The thread is now started only when there is no live one. Polling is
primary-only by design (a thread per board would break the single-threaded send
invariant the note-array >=15s throttle relies on), so exactly one thread is the
correct steady state.

Test written first —
`TestPrimaryBoardFailureIsolation::test_repeated_initialize_reuses_the_live_board_state_poll_thread`
calls `initialize()` three times with a clientless primary and counts live
threads named `board-state-poll` that did not exist before the test. Verbatim
pre-fix failure:

```
tests/test_multi_board_driving.py F                                      [100%]

=================================== FAILURES ===================================
_ TestPrimaryBoardFailureIsolation.test_repeated_initialize_reuses_the_live_board_state_poll_thread _
tests/test_multi_board_driving.py:376: in test_repeated_initialize_reuses_the_live_board_state_poll_thread
    assert len(started) == 1, f"expected 1 live poll thread, found {len(started)}"
E   AssertionError: expected 1 live poll thread, found 3
E   assert 3 == 1
E    +  where 3 = len([<Thread(board-state-poll, started daemon 281473006145888)>, <Thread(board-state-poll, started daemon 281472997691744)>, <Thread(board-state-poll, started daemon 281472989237600)>])
=========================== short test summary info ============================
FAILED tests/test_multi_board_driving.py::TestPrimaryBoardFailureIsolation::test_repeated_initialize_reuses_the_live_board_state_poll_thread
============================== 1 failed in 0.15s ===============================
```

### Rebased onto #1817 (silence-detector busy-loop)

Rebased from `d17a27b9f` onto `c0f4969a2`, which contains #1817 (`cf6995e58`).
That rebase is load-bearing, not housekeeping.

This PR makes "primary board has a runtime but no client" a normal running
state. Under the pre-#1817 code that state left `rt.last_silence_mode_active`
stale on the no-client early return, so the 1 Hz silence-boundary detector in
`run()` saw a permanent mismatch and re-drove the entire fleet — a full forced
plugin fan-out — once per second for the whole silence window. #1817 hoists the
silence evaluation above the pause short-circuit and latches the flag on every
exit path, which fixes it.

New regression test pinning the interaction:
`TestSilenceBoundaryDetector::test_clientless_primary_does_not_force_an_update_every_second_during_silence`.
It uses the deterministic `_sleep_that_stops_after` harness from #1817 (no real
clock, no sleeps), walks 5 simulated seconds of the run loop with a clientless
primary inside an active silence window, and asserts one drive and one
`preview_page` call.

Proved non-vacuous by reverting #1817's hunk in `check_and_send_for_board` and
re-running:

```
E   AssertionError: assert 6 == 1
E    +  where 6 = <MagicMock name='check_and_send_active_page'>.call_count
WARNING  src.main:main.py:982 Board client not initialized   (x6)
```

6 fleet-wide drives per 5 simulated seconds without #1817, 1 with it. The hunk
was then restored.

### Known degradation: `/status` is fleet-aware, the "Active Display" UI is not

**This belongs in the release note.** With the primary board down but
secondaries healthy, the fleet keeps rendering — but roughly 20 endpoints still
gate on `service.vb_client` and return **503** for the whole install
(`src/api_server.py:3261`, `:3358`, `:4575`, `:5651`, `:8748`, `:8763`, among
others). Concretely: the boards keep updating, while the app's Active Display
surfaces — current board content, manual send, force refresh — report the
service as unavailable until the primary's configuration is fixed.

That is strictly better than the status quo, where *no* board rendered at all,
but it is a partial fix and users should be told which half works. Narrowing
those gates to the specific board being addressed is engine-cleanup work beyond
this PR's scope.

### Deliberately not done

- **No periodic retry.** A board that failed for a transient reason (unplugged,
  DHCP not settled, Local API still booting) stays down until
  `rebuild_board_clients()` runs, which today only happens on the board-settings
  mutation paths — i.e. the user re-saving that board. Recovery works; it just
  needs a human who has no reason to suspect a save is the fix. Adding retry is
  a behaviour change with its own design surface (cadence, backoff, thread
  ownership, racing the send path) and its own tests, so it is filed as #1827
  rather than bolted on here.
- **No UI for the new `error` field.** There is nowhere to put it yet: nothing
  in the web app reads `status.boards` at all — the only `useStatus()` consumers
  are `service-controls.tsx` and `about-card.tsx`, and neither touches the
  per-board map (which has been on `/status` since #1244). Wiring the reason in
  means choosing a surface, adding i18n keys across 14 locales, and testing it.
  Filed as #1829.

### Test status after the rebase

```
tests/test_multi_board_driving.py ..................                     [ 41%]
tests/test_per_board_engine.py ................                          [ 79%]
tests/test_silence_schedule_polling.py .........                         [100%]

============================== 43 passed in 0.26s ==============================
```

Regression sweep over the suites that touch `src.main`, `/status` and service
lifecycle — `test_service_lifecycle`, `test_board_paused`,
`test_settings_per_board`, `test_adaptive_board_refresh`,
`test_silence_mode_display`, `test_trigger_render_path`,
`test_silence_indicator_rendering`, `test_system_endpoints`,
`test_api_coverage`, `test_integration_multi_features` — **308 passed**.

`ruff 0.16.4`: `ruff check src tests` → *All checks passed!*;
`ruff format --check src tests` → *245 files already formatted*.

_Part of #1730 (Phase 1)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ndXRi5v57yB5sXXhQswjp

