### PR TITLE
ci(a11y): stop fetching the Storybook static server at job time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -474,8 +474,23 @@ jobs:
     - name: Start Storybook static server
       working-directory: web
       run: |
-        npx http-server storybook-static --port 6006 --silent &
-        sleep 5
+        npx --yes http-server storybook-static --port 6006 --silent &
+        # `http-server` is not a dependency, so npx has to fetch it before
+        # the server can bind. A fixed `sleep 5` raced that download: on a
+        # busy runner the port was still closed when the next step ran and
+        # the test runner bailed out with "It seems that your Storybook
+        # instance is not running at: http://localhost:6006", which reads
+        # like an a11y failure but is really a startup race. Poll the port
+        # instead, and fail loudly with a real message if it never opens.
+        for _ in $(seq 1 60); do
+          if curl -sfo /dev/null http://localhost:6006; then
+            echo "Storybook static server is serving on port 6006"
+            exit 0
+          fi
+          sleep 1
+        done
+        echo "::error::Storybook static server never started listening on port 6006"
+        exit 1
 
     - name: Run Storybook a11y tests
       working-directory: web

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -474,14 +474,17 @@ jobs:
     - name: Start Storybook static server
       working-directory: web
       run: |
-        npx --yes http-server storybook-static --port 6006 --silent &
-        # `http-server` is not a dependency, so npx has to fetch it before
-        # the server can bind. A fixed `sleep 5` raced that download: on a
-        # busy runner the port was still closed when the next step ran and
-        # the test runner bailed out with "It seems that your Storybook
-        # instance is not running at: http://localhost:6006", which reads
-        # like an a11y failure but is really a startup race. Poll the port
-        # instead, and fail loudly with a real message if it never opens.
+        # `http-server` is a devDependency, so the `npm ci` step above has
+        # already put it in node_modules and this runs the local binary
+        # without touching the registry. It used to be fetched on demand by
+        # `npx`; when that fetch stalled the server never bound, and the
+        # a11y step then failed with "It seems that your Storybook instance
+        # is not running at: http://localhost:6006" — which reads like an
+        # accessibility violation but means no story was ever visited.
+        npx http-server storybook-static --port 6006 --silent \
+          > /tmp/storybook-server.log 2>&1 &
+        # Poll rather than `sleep 5`: a fixed guess either wastes time or
+        # loses the race, and it hides why the server is missing.
         for _ in $(seq 1 60); do
           if curl -sfo /dev/null http://localhost:6006; then
             echo "Storybook static server is serving on port 6006"
@@ -490,6 +493,7 @@ jobs:
           sleep 1
         done
         echo "::error::Storybook static server never started listening on port 6006"
+        cat /tmp/storybook-server.log
         exit 1
 
     - name: Run Storybook a11y tests

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -65,6 +65,7 @@
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-simple-import-sort": "^14.0.0",
+        "http-server": "^14.1.1",
         "jsdom": "^30.0.1",
         "msw": "^2.15.0",
         "prettier": "^3.9.6",
@@ -9961,6 +9962,16 @@
         "url": "https://opencollective.com/core-js"
       }
     },
+    "node_modules/corser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+      "integrity": "sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/crelt": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
@@ -11367,6 +11378,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -12503,6 +12521,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
     "node_modules/headers-polyfill": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-5.0.1.tgz",
@@ -12616,6 +12644,62 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-proxy": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/http-server": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
+      "integrity": "sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-auth": "^2.0.1",
+        "chalk": "^4.1.2",
+        "corser": "^2.0.1",
+        "he": "^1.2.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy": "^1.18.1",
+        "mime": "^1.6.0",
+        "minimist": "^1.2.6",
+        "opener": "^1.5.1",
+        "portfinder": "^1.0.28",
+        "secure-compare": "3.0.1",
+        "union": "~0.5.0",
+        "url-join": "^4.0.1"
+      },
+      "bin": {
+        "http-server": "bin/http-server"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/http-server/node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -16564,6 +16648,19 @@
       ],
       "license": "MIT"
     },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -17434,6 +17531,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -17989,6 +18096,20 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/portfinder": {
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.38.tgz",
+      "integrity": "sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^3.2.6",
+        "debug": "^4.3.6"
+      },
+      "engines": {
+        "node": ">= 10.12"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -18945,6 +19066,13 @@
         "node": ">=0.10.5"
       }
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/reselect": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
@@ -19492,6 +19620,13 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/secure-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
+      "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -21157,6 +21292,18 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/union": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
+      "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
+      "dev": true,
+      "dependencies": {
+        "qs": "^6.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/unique-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
@@ -21372,6 +21519,13 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
@@ -22133,6 +22287,33 @@
       "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/whatwg-mimetype": {
       "version": "5.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -93,6 +93,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-simple-import-sort": "^14.0.0",
+    "http-server": "^14.1.1",
     "jsdom": "^30.0.1",
     "msw": "^2.15.0",
     "prettier": "^3.9.6",


### PR DESCRIPTION
## Problem

`Accessibility Tests` failed on four unrelated PRs tonight — ten jobs
counting reruns, none of which ran axe at all:

```
[test-storybook] It seems that your Storybook instance is not running at: http://localhost:6006. Are you sure it's running?
```

| PR | jobs | what the diff touches |
|----|------|-----------------------|
| #1801 | dark + light | per-board silence |
| #1802 | dark + light | connection mode reporting |
| #1803 | dark + light | board rename |
| #1807 | dark + light | `web/package-lock.json` only — a browserslist bump |

#1807 settles it: a lockfile-only diff cannot introduce an accessibility
violation, and its log carries the identical message. The test runner's
preflight `fetch` was refused, so it exited before visiting a single
story. These were never a11y failures, and none of the four PRs caused
them.

## Root cause

The `Start Storybook static server` step was:

```yaml
npx http-server storybook-static --port 6006 --silent &
sleep 5
```

`http-server` is not a dependency of `web/`, so npx fetched it from the
registry on every run. The registry was badly degraded for roughly an
hour — the same window pushed the `Lint Markdown` job's `npm ci` from its
usual 1m13s to 5m, tripping that job's 5-minute timeout. While it lasted,
the fetch outran any fixed sleep and the server never bound.

The first commit here replaced the `sleep 5` with a 60s readiness poll,
which is how the cause got pinned down: this PR's own
`Accessibility Tests (dark)` waited the full minute and the port still
never opened, with the log stopping right after npm began resolving
http-server's dependency tree. A `sleep` long enough to cover that is not
a thing worth guessing at — the fetch should not be on this path at all.

## Fix

- `http-server` becomes a devDependency, so the `npm ci` step already in
  this job installs it from the setup-node cache and starting the server
  no longer touches the registry. Verified with the network disabled:
  `npx http-server --version` resolves the local binary and exits 0.
- Keep the readiness poll instead of a fixed sleep, so a slow start waits
  rather than fails.
- Dump the server's captured output on failure, so a future occurrence
  names its own cause rather than masquerading as an axe violation.

Both `Accessibility Tests` legs on this PR exercise the new step and pass
— 17 suites, 104 tests, after `Storybook static server is serving on port
6006`.