### PR TITLE
fix(system): atomic .system-update.json writes and correct migration lock

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -31,6 +31,7 @@ from pydantic import BaseModel, Field
 load_dotenv()
 
 from . import __version__  # noqa: E402
+from .atomic_io import write_json_atomic  # noqa: E402
 from .auth import is_auth_enabled  # noqa: E402
 from .auth.middleware import AuthMiddleware  # noqa: E402
 from .auth.routes import router as auth_router  # noqa: E402
@@ -645,6 +646,20 @@ class WiFiConnectResponse(BaseModel):
     message: str
 
 
+def _run_startup_migrations() -> None:
+    """Run the one-shot config migrations that used to fire from read paths.
+
+    ``migrate_silence_schedule_to_utc`` converts pre-UTC ``HH:MM`` silence
+    times.  It is idempotent, so running it once per boot is enough; doing it
+    here keeps ``GET /silence-status`` a pure read (#1746).  Failures are
+    logged, never fatal — a migration must not stop the API from booting.
+    """
+    try:
+        get_config_manager().migrate_silence_schedule_to_utc()
+    except Exception:
+        logger.warning("Silence-schedule UTC migration failed on startup", exc_info=True)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Lifespan context manager for startup and shutdown events.
@@ -693,6 +708,9 @@ async def lifespan(app: FastAPI):
     except Exception:  # pragma: no cover - safety net must never block boot
         logger.debug("Post-upgrade auto-restore failed", exc_info=True)
     _log_config_boot_snapshot("post-restore")
+
+    # One-shot config migrations, before anything reads the migrated values.
+    _run_startup_migrations()
 
     # If the most recent settings snapshot looks materially richer than the
     # live config (more enabled plugins, etc.), tell the user loudly on
@@ -1768,9 +1786,7 @@ async def _perform_update_check() -> "UpdateCheckResponse":
         if latest_version:
             update_available = _is_newer_version(latest_version, __version__)
             try:
-                _state = _system_update_state_load()
-                _state["last_check"] = datetime.now(UTC).isoformat()
-                _system_update_state_save(_state)
+                _system_update_state_update(last_check=datetime.now(UTC).isoformat())
             except Exception as e:
                 logger.debug("Could not persist update-check result (non-fatal): %s", e, exc_info=True)
             return UpdateCheckResponse(
@@ -1821,28 +1837,49 @@ def _is_newer_version(latest: str, current: str) -> bool:
 # because this state is system-level, not display-level.
 SYSTEM_UPDATE_STATE_FILE = Path("data/.system-update.json")
 
+# Serialises the read-modify-write of the state file.  Three writers share it —
+# the hourly auto-update loop, ``POST /system/update`` and
+# ``POST /system/update/auto`` — and each does load -> mutate -> save.  Without
+# this lock a writer's read goes stale and the other writer's field is lost
+# (#1745).  Re-entrant so a guarded update can call load/save directly.
+_SYSTEM_UPDATE_STATE_LOCK = threading.RLock()
+
 
 def _system_update_state_load() -> dict[str, Any]:
     """Read the system-update state file.  Returns a fresh dict on any error."""
-    try:
-        if SYSTEM_UPDATE_STATE_FILE.exists():
-            with SYSTEM_UPDATE_STATE_FILE.open("r", encoding="utf-8") as f:
-                data = json.load(f)
-                if isinstance(data, dict):
-                    return data
-    except Exception as e:
-        logger.debug(f"Failed to read {SYSTEM_UPDATE_STATE_FILE}: {e}")
-    return {}
+    with _SYSTEM_UPDATE_STATE_LOCK:
+        try:
+            if SYSTEM_UPDATE_STATE_FILE.exists():
+                with SYSTEM_UPDATE_STATE_FILE.open("r", encoding="utf-8") as f:
+                    data = json.load(f)
+                    if isinstance(data, dict):
+                        return data
+        except Exception as e:
+            logger.debug(f"Failed to read {SYSTEM_UPDATE_STATE_FILE}: {e}")
+        return {}
 
 
 def _system_update_state_save(state: dict[str, Any]) -> None:
-    """Persist the system-update state file."""
-    try:
-        SYSTEM_UPDATE_STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
-        with SYSTEM_UPDATE_STATE_FILE.open("w", encoding="utf-8") as f:
-            json.dump(state, f, indent=2)
-    except Exception as e:
-        logger.warning(f"Failed to write {SYSTEM_UPDATE_STATE_FILE}: {e}")
+    """Persist the system-update state file atomically.
+
+    A truncating ``open("w")`` here used to leave a half-written file behind on
+    a crash; the loader swallows the resulting JSON error and returns ``{}``,
+    which silently resets the auto-update toggle to its default (#1745).
+    """
+    with _SYSTEM_UPDATE_STATE_LOCK:
+        try:
+            write_json_atomic(SYSTEM_UPDATE_STATE_FILE, state)
+        except Exception as e:
+            logger.warning(f"Failed to write {SYSTEM_UPDATE_STATE_FILE}: {e}")
+
+
+def _system_update_state_update(**changes: Any) -> dict[str, Any]:
+    """Merge *changes* into the state file as one locked read-modify-write."""
+    with _SYSTEM_UPDATE_STATE_LOCK:
+        state = _system_update_state_load()
+        state.update(changes)
+        _system_update_state_save(state)
+        return state
 
 
 def _is_update_check_due(state: dict[str, Any], period_days: int) -> bool:
@@ -2557,9 +2594,7 @@ async def system_update_apply():
     except ValueError as e:
         # fiestaupdater may return a non-JSON body (e.g. plain-text on error); fall back to empty dict.
         logger.debug("fiestaupdater response is not JSON, using empty body (non-fatal): %s", e)
-    state = _system_update_state_load()
-    state["last_update"] = datetime.now(UTC).isoformat()
-    _system_update_state_save(state)
+    _system_update_state_update(last_update=datetime.now(UTC).isoformat())
 
     return UpdateApplyResponse(
         status="queued",
@@ -2761,12 +2796,12 @@ async def system_update_set_auto(req: AutoUpdateRequest):
             detail="Request must include either 'interval' or 'enabled'.",
         )
 
-    state = _system_update_state_load()
-    state["auto_update_interval"] = interval
-    # Keep the legacy bool in sync so older clients reading the file see a
-    # consistent picture.
-    state["auto_update_enabled"] = interval != "manual"
-    _system_update_state_save(state)
+    _system_update_state_update(
+        auto_update_interval=interval,
+        # Keep the legacy bool in sync so older clients reading the file see a
+        # consistent picture.
+        auto_update_enabled=interval != "manual",
+    )
     return AutoUpdateResponse(enabled=interval != "manual", interval=interval)
 
 
@@ -4268,9 +4303,9 @@ async def get_silence_status():
     time_service = get_time_service()
     config_manager = get_config_manager()
 
-    # Trigger migration if needed
-    config_manager.migrate_silence_schedule_to_utc()
-
+    # No migration here: this is a read the UI polls on a timer, and the
+    # migration is a config write.  It runs once at startup instead
+    # (``_run_startup_migrations``) — see #1746.
     silence_config = config_manager.get_feature("silence_schedule")
     enabled = silence_config.get("enabled", False)
     start_time = silence_config.get("start_time", "20:00+00:00")

--- a/src/atomic_io.py
+++ b/src/atomic_io.py
@@ -18,8 +18,11 @@ atomic: staging file and target are still siblings, so the rename is still a
 same-filesystem rename.
 """
 
+import contextlib
+import json
 import os
 from pathlib import Path
+from typing import Any
 
 
 def staging_path(target: Path) -> Path:
@@ -28,3 +31,26 @@ def staging_path(target: Path) -> Path:
     ``data/pages.json`` becomes ``data/pages.json.<pid>.tmp``.
     """
     return target.with_suffix(f"{target.suffix}.{os.getpid()}.tmp")
+
+
+def write_json_atomic(target: Path, data: Any, *, indent: int | None = 2) -> None:
+    """Serialise *data* as JSON onto *target* without ever truncating it.
+
+    Stages the JSON in the process-scoped sibling from :func:`staging_path` and
+    ``os.replace``s it into place. A crash (OOM, SIGKILL, power loss) partway
+    through the write leaves the previous contents of *target* fully intact, and
+    the partial staging file is removed on any failure rather than leaked.
+
+    Parent directories are created if missing. Exceptions propagate — the caller
+    decides whether a failed save is fatal.
+    """
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = staging_path(target)
+    try:
+        with tmp_path.open("w", encoding="utf-8") as fh:
+            json.dump(data, fh, indent=indent)
+        tmp_path.replace(target)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            tmp_path.unlink(missing_ok=True)
+        raise

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -373,7 +373,12 @@ class ConfigManager:
         if self._initialized:
             return
 
-        self._file_lock = threading.Lock()
+        # Re-entrant so a method that needs the whole read-modify-write to be
+        # atomic (``migrate_silence_schedule_to_utc``) can hold it across the
+        # public accessors, which take it again.  A plain Lock would deadlock
+        # there, which is why that migration reached for the class-level
+        # singleton lock instead and blocked ConfigManager() everywhere (#1746).
+        self._file_lock = threading.RLock()
 
         # Determine config file path
         if config_path:
@@ -1332,10 +1337,16 @@ class ConfigManager:
         This method detects if the silence_schedule is using the old local time format
         (e.g., "20:00") and converts it to the new UTC ISO format (e.g., "04:00+00:00").
 
+        Held under ``_file_lock`` — the lock that guards config data — for the
+        whole read-modify-write.  It previously took the class-level ``_lock``,
+        which only guards singleton construction: that both left the migration's
+        read racing other config writers and stalled every thread calling
+        ``ConfigManager()`` for the duration of the disk I/O (#1746).
+
         Returns:
             True if migration was performed, False if no migration needed
         """
-        with self._lock:
+        with self._file_lock:
             silence_config = self.get_feature("silence_schedule")
             start_time = silence_config.get("start_time", "")
             end_time = silence_config.get("end_time", "")

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -1451,3 +1451,76 @@ def test_get_removed_plugins_tolerates_garbage(tmp_path):
     )
     cm = ConfigManager(config_path=str(config_path))
     assert cm.get_removed_plugins() == ["stocks"]
+
+
+# ---------------------------------------------------------------------------
+# migrate_silence_schedule_to_utc takes the right lock (issue #1746)
+# ---------------------------------------------------------------------------
+
+
+def _config_needing_silence_migration() -> dict:
+    """Config whose silence times are still in the pre-UTC ``HH:MM`` format."""
+    return {
+        "board": {},
+        "features": {"silence_schedule": {"enabled": True, "start_time": "20:00", "end_time": "07:00"}},
+        "general": {"timezone": "America/Los_Angeles"},
+    }
+
+
+def _acquired_from_another_thread(lock, timeout: float = 0.25) -> bool:
+    """Whether a *different* thread can take ``lock`` right now."""
+    result: list[bool] = []
+
+    def attempt():
+        if lock.acquire(timeout=timeout):
+            result.append(True)
+            lock.release()
+        else:
+            result.append(False)
+
+    thread = threading.Thread(target=attempt)
+    thread.start()
+    thread.join()
+    return result[0]
+
+
+def _migrate_with_a_lock_probe(tmp_path, mock_time_service, lock_of) -> list[bool]:
+    """Run the silence migration, probing a lock from another thread mid-flight."""
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps(_config_needing_silence_migration()))
+    cm = ConfigManager(config_path=str(config_path))
+
+    probes: list[bool] = []
+
+    def probe_then_convert(local_time, timezone):
+        probes.append(_acquired_from_another_thread(lock_of(cm)))
+        return local_time
+
+    mock_time_service.local_to_utc_iso.side_effect = probe_then_convert
+
+    assert cm.migrate_silence_schedule_to_utc() is True, "the migration never ran — the test proves nothing"
+    assert probes, "the migration never reached the conversion step"
+    return probes
+
+
+def test_silence_migration_holds_the_config_file_lock(tmp_path, mock_time_service):
+    """#1746: the migration read-modify-writes config, so it must hold ``_file_lock``.
+
+    Without it another thread can write config between the migration's read
+    and its save, and lose that write.
+    """
+    probes = _migrate_with_a_lock_probe(tmp_path, mock_time_service, lambda cm: cm._file_lock)
+
+    assert not any(probes), "another thread took the config file lock while the migration was mid-flight"
+
+
+def test_silence_migration_does_not_hold_the_singleton_construction_lock(tmp_path, mock_time_service):
+    """#1746: holding the class-level ``_lock`` blocks ``ConfigManager()`` everywhere.
+
+    ``_lock`` guards singleton construction, not config data. Taking it for the
+    duration of a disk-writing migration stalls every other thread that merely
+    wants a ConfigManager handle.
+    """
+    probes = _migrate_with_a_lock_probe(tmp_path, mock_time_service, lambda cm: ConfigManager._lock)
+
+    assert all(probes), "the migration held the singleton construction lock while doing disk I/O"

--- a/tests/test_silence_schedule_endpoint.py
+++ b/tests/test_silence_schedule_endpoint.py
@@ -419,3 +419,41 @@ class TestSilenceStatusSecondsUntilNextChange:
         # we count down to end_time (10:00 tomorrow = 21h away).
         assert data["active"] is True
         assert data["seconds_until_next_change"] == 21 * 3600
+
+
+def test_silence_status_performs_no_config_writes(client, mock_config_manager_for_silence):
+    """GET /silence-status is a read; it must not write config (#1746).
+
+    The handler used to call ``migrate_silence_schedule_to_utc()``, turning a
+    plain status poll — which the UI polls on a timer — into a config
+    read-modify-write. The migration belongs at startup instead.
+    """
+    cm, _store = mock_config_manager_for_silence
+
+    response = client.get("/silence-status")
+
+    assert response.status_code == 200
+    cm.migrate_silence_schedule_to_utc.assert_not_called()
+    cm.set_feature.assert_not_called()
+
+
+def test_startup_runs_the_silence_migration():
+    """#1746: the migration moves to startup, so it runs once per boot."""
+    from src import api_server
+
+    cm = Mock()
+    cm.migrate_silence_schedule_to_utc.return_value = True
+    with patch("src.api_server.get_config_manager", return_value=cm):
+        api_server._run_startup_migrations()
+
+    cm.migrate_silence_schedule_to_utc.assert_called_once_with()
+
+
+def test_startup_migration_failure_does_not_block_boot():
+    """A broken migration must not take the API down on startup."""
+    from src import api_server
+
+    cm = Mock()
+    cm.migrate_silence_schedule_to_utc.side_effect = RuntimeError("disk on fire")
+    with patch("src.api_server.get_config_manager", return_value=cm):
+        api_server._run_startup_migrations()  # must not raise

--- a/tests/test_system_endpoints.py
+++ b/tests/test_system_endpoints.py
@@ -1189,3 +1189,99 @@ class TestUpdaterLastUpdateHelper:
 
         with patch("src.api_server.requests.get", return_value=Mock(status_code=500)):
             assert api._updater_last_update() == {}
+
+
+def _writes_to(fh, target) -> bool:
+    """True if the open file handle ``fh`` is writing ``target`` or its staging file."""
+    name = getattr(fh, "name", "")
+    return isinstance(name, str) and name.startswith(str(target))
+
+
+class TestSystemUpdateStateFileDurability:
+    """Durability of ``data/.system-update.json`` (issue #1745).
+
+    The file is read-modify-written from three places (the hourly auto-update
+    loop, ``POST /system/update`` and ``POST /system/update/auto``).  A
+    truncating ``open("w")`` with no lock around the read-modify-write can lose
+    the auto-update toggle outright.
+    """
+
+    def test_save_leaves_the_existing_file_intact_when_the_write_crashes(self):
+        """A crash mid-write must not truncate the state file.
+
+        The loader swallows a JSON error and returns ``{}``, so a truncated
+        file silently resets the auto-update toggle to its default.
+        """
+        from src import api_server
+
+        state_file = api_server.SYSTEM_UPDATE_STATE_FILE
+        api_server._system_update_state_save({"auto_update_interval": "weekly", "auto_update_enabled": True})
+        original_bytes = state_file.read_bytes()
+
+        real_dump = api_server.json.dump
+        crashed = []
+
+        def crashing_dump(obj, fh, *args, **kwargs):
+            # ``json`` is shared with every other store, so only sabotage the
+            # write that targets the system-update state file (or its staging
+            # sibling).
+            if not _writes_to(fh, state_file):
+                return real_dump(obj, fh, *args, **kwargs)
+            crashed.append(True)
+            fh.write('{"auto_update_interval"')
+            fh.flush()
+            raise OSError("Simulated crash mid-write")
+
+        with patch.object(api_server.json, "dump", crashing_dump):
+            api_server._system_update_state_save({"auto_update_interval": "monthly"})
+
+        assert crashed, "the sabotaged write never ran — the test proves nothing"
+        assert state_file.read_bytes() == original_bytes
+
+    def test_concurrent_updates_do_not_lose_each_others_fields(self, client, monkeypatch):
+        """Two writers racing on the state file must both survive.
+
+        ``POST /system/update/auto`` writes ``auto_update_interval`` while the
+        hourly loop writes ``last_check``; both do load -> mutate -> save.  With
+        no lock around that sequence the second writer's read is stale and one
+        of the two fields is lost.
+        """
+        import threading
+
+        from src import api_server
+
+        monkeypatch.setenv("FIESTABOARD_PROFILE", "docker")
+        state_file = api_server.SYSTEM_UPDATE_STATE_FILE
+        api_server._system_update_state_save({"auto_update_interval": "manual", "last_check": "stale"})
+
+        real_dump = api_server.json.dump
+        competitor: list = []
+
+        def dump_with_a_competing_update(obj, fh, *args, **kwargs):
+            # Interleave one full competing read-modify-write in the middle of
+            # the handler's own write.
+            if not competitor and _writes_to(fh, state_file):
+
+                def compete():
+                    state = api_server._system_update_state_load()
+                    state["last_check"] = "2026-01-01T00:00:00+00:00"
+                    api_server._system_update_state_save(state)
+
+                thread = threading.Thread(target=compete)
+                competitor.append(thread)
+                thread.start()
+                # A correctly locked writer blocks here; an unlocked one races.
+                thread.join(timeout=0.5)
+            return real_dump(obj, fh, *args, **kwargs)
+
+        with patch.object(api_server.json, "dump", dump_with_a_competing_update):
+            response = client.post("/system/update/auto", json={"interval": "weekly"})
+        assert response.status_code == 200
+
+        assert competitor, "the competing update never ran — the test proves nothing"
+        competitor[0].join(timeout=5)
+        assert not competitor[0].is_alive()
+
+        persisted = json.loads(state_file.read_text())
+        assert persisted["auto_update_interval"] == "weekly"
+        assert persisted["last_check"] == "2026-01-01T00:00:00+00:00"


### PR DESCRIPTION
Closes #1745
Closes #1746

Two data-integrity bugs on adjacent persistence paths, fixed together because
one of them needed a helper the other one wanted anyway.

## #1745 — `.system-update.json` written non-atomically with no lock

**Root cause.** `_system_update_state_save` wrote the file with a truncating
`open("w")` + `json.dump`:

```python
with SYSTEM_UPDATE_STATE_FILE.open("w", encoding="utf-8") as f:
    json.dump(state, f, indent=2)
```

`open("w")` truncates before a byte is written, so a crash anywhere in the dump
(OOM, SIGKILL, power loss) leaves a partial file. `_system_update_state_load`
swallows the resulting `JSONDecodeError` and returns `{}` — so the corruption
is invisible and presents as the auto-update toggle silently resetting to its
default. Exactly the #1304 bug class, missed in this one spot.

Second, orthogonal half: three callers each do an unguarded
load → mutate → save on this file — the hourly auto-update loop
(`last_check`), `POST /system/update` (`last_update`), and
`POST /system/update/auto` (`auto_update_interval` + `auto_update_enabled`).
With no lock spanning that sequence, one writer's read goes stale and the
other's field is dropped.

**Fix.** Writes go through `write_json_atomic` (staging file + `os.replace`).
A module-level `threading.RLock` guards load and save, and a new
`_system_update_state_update(**changes)` performs the whole read-modify-write
under it; all three call sites now use it.

## #1746 — `GET /silence-status` runs a data migration under the wrong lock

**Root cause, part 1.** The GET handler called
`config_manager.migrate_silence_schedule_to_utc()`, making a status poll — one
the UI runs on a timer — perform a config write.

**Root cause, part 2.** That migration guarded itself with `self._lock`
(`src/config_manager.py:1338`). `_lock` is the *class-level* lock used only by
`__new__` to guard singleton construction; the lock that actually guards config
data is the per-instance `_file_lock`. So the migration's read-modify-write
raced every real config writer, *and* it blocked `ConfigManager()` in every
other thread while it did disk I/O.

**Fix.** The migration takes `_file_lock` and runs once per boot from a new
`_run_startup_migrations()` in the lifespan; the GET is now a pure read. Taking
`_file_lock` across the migration requires re-entrancy — the migration calls
`get_feature`/`get_general`/`set_feature`, which take it again — so
`_file_lock` becomes a `threading.RLock`. (Avoiding that re-entrancy is
presumably why the original reached for the wrong lock in the first place.)

## Atomic-write helper: reused, not reinvented

`src/atomic_io.py` already existed with `staging_path()`, but the actual
tmp-write + `os.replace` + cleanup block was copy-pasted into six stores
(config, settings, pages, schedules, collections, auth, panels). Rather than
add a seventh copy, this PR **extends `src/atomic_io.py`** with
`write_json_atomic(target, data)` and uses it for the one new path. The
existing stores are left alone — migrating them is #1759's job, and it now has
the helper waiting for it.

## Out of scope

`Config.is_silence_mode_active()` (`src/config.py:585`) also triggers the
silence migration from a read path. It's not part of #1746 and changing it
would alter service-loop behavior, so it stays — but it now benefits from the
lock half of the fix.

## Test evidence

Seven tests, written first, each confirmed failing against `main` for the
expected reason. Verbatim pre-fix output (log noise trimmed):

### #1745

```
$ pytest tests/test_system_endpoints.py::TestSystemUpdateStateFileDurability

FF                                                                       [100%]
=================================== FAILURES ===================================
_ TestSystemUpdateStateFileDurability.test_save_leaves_the_existing_file_intact_when_the_write_crashes _
tests/test_system_endpoints.py:1235: in test_save_leaves_the_existing_file_intact_when_the_write_crashes
    assert state_file.read_bytes() == original_bytes
E   assert b'{"auto_update_interval"' == b'{\n  "auto_...led": true\n}'
E
E     At index 1 diff: b'"' != b'\n'
E     Use -v to get more diff
_ TestSystemUpdateStateFileDurability.test_concurrent_updates_do_not_lose_each_others_fields _
tests/test_system_endpoints.py:1283: in test_concurrent_updates_do_not_lose_each_others_fields
    assert persisted["last_check"] == "2026-01-01T00:00:00+00:00"
E   AssertionError: assert 'stale' == '2026-01-01T00:00:00+00:00'
E
E     - 2026-01-01T00:00:00+00:00
E     + stale
=========================== short test summary info ============================
FAILED ...::test_save_leaves_the_existing_file_intact_when_the_write_crashes
FAILED ...::test_concurrent_updates_do_not_lose_each_others_fields
2 failed in 0.53s
```

The first shows the file left holding the 23-byte truncated fragment instead of
its previous contents. The second shows the handler's stale read clobbering the
competing writer's `last_check`.

### #1746 — wrong lock

```
$ pytest tests/test_config_manager.py -k silence_migration

FF                                                                       [100%]
=================================== FAILURES ===================================
______________ test_silence_migration_holds_the_config_file_lock _______________
tests/test_config_manager.py:1514: in test_silence_migration_holds_the_config_file_lock
    assert not any(probes), "another thread took the config file lock while the migration was mid-flight"
E   AssertionError: another thread took the config file lock while the migration was mid-flight
E   assert not True
E    +  where True = any([True, True])
_____ test_silence_migration_does_not_hold_the_singleton_construction_lock _____
tests/test_config_manager.py:1526: in test_silence_migration_does_not_hold_the_singleton_construction_lock
    assert all(probes), "the migration held the singleton construction lock while doing disk I/O"
E   AssertionError: the migration held the singleton construction lock while doing disk I/O
E   assert False
E    +  where False = all([False, False])
=========================== short test summary info ============================
2 failed, 97 deselected in 0.63s
```

Both probe from a second thread mid-migration: `_file_lock` was acquirable when
it should not have been, and `ConfigManager._lock` was not when it should have
been. Together they pin "the migration holds the config lock, not the singleton
lock".

### #1746 — impure GET / startup migration

```
$ pytest tests/test_silence_schedule_endpoint.py -k "no_config_writes or startup"

FFF                                                                      [100%]
=================================== FAILURES ===================================
________________ test_silence_status_performs_no_config_writes _________________
tests/test_silence_schedule_endpoint.py:436: in test_silence_status_performs_no_config_writes
    cm.migrate_silence_schedule_to_utc.assert_not_called()
E   AssertionError: Expected 'migrate_silence_schedule_to_utc' to not have been called. Called 1 times.
E   Calls: [call()].
___________________ test_startup_runs_the_silence_migration ____________________
tests/test_silence_schedule_endpoint.py:447: in test_startup_runs_the_silence_migration
    api_server._run_startup_migrations()
E   AttributeError: module 'src.api_server' has no attribute '_run_startup_migrations'
______________ test_startup_migration_failure_does_not_block_boot ______________
tests/test_silence_schedule_endpoint.py:459: in test_startup_migration_failure_does_not_block_boot
    api_server._run_startup_migrations()  # must not raise
E   AttributeError: module 'src.api_server' has no attribute '_run_startup_migrations'
=========================== short test summary info ============================
3 failed, 29 deselected in 0.52s
```

The two `AttributeError`s are the honest red for "startup does not run this
migration yet"; the first failure is the substantive one.

### After the fix

- All 7 new tests pass.
- `tests/test_system_endpoints.py`, `test_silence_schedule_endpoint.py`,
  `test_config_manager.py`, `test_atomic_io.py`, `test_api_coverage.py`,
  `test_api_extended.py`, `test_config.py` — **700 passed**.
- Broader sweep across every config/settings/storage/auth/pages/schedules/
  collections/backup/panels/plugin suite — **2836 passed**.
- `ruff check` and `ruff format --check` clean.

### Non-vacuity spot-check

Reverting only the atomic write in `_system_update_state_save` back to
`open("w")` + `json.dump`, with everything else in place, reproduces the
failure:

```
/app/tests/test_system_endpoints.py:1239: assert b'{"auto_update_interval"' == b'{\n  "auto_...led": true\n}'
FAILED ...::test_save_leaves_the_existing_file_intact_when_the_write_crashes
1 failed, 1 passed in 1.02s
```

The crash test also asserts the sabotaged write actually ran
(`assert crashed, "the sabotaged write never ran"`), and the concurrency test
asserts the competing writer actually ran, so neither can pass by doing nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ndXRi5v57yB5sXXhQswjp
