### PR TITLE
fix(engine): silence detector busy-loop (#1740) and plugin lifecycle on reset (#1753)

### DIFF
--- a/docs/internal/development/PLUGIN_DEVELOPMENT.md
+++ b/docs/internal/development/PLUGIN_DEVELOPMENT.md
@@ -1107,7 +1107,7 @@ Your plugin must inherit from `PluginBase`:
 | `validate_config(config)` | No | Return a list of error strings; empty list means valid |
 | `on_config_change(old, new)` | No | Hook called after settings are updated |
 | `get_formatted_display()` | No | Legacy hook — not called by the platform; see note below |
-| `cleanup()` | No | Release resources when the plugin is disabled |
+| `cleanup()` | No | Release resources the instance owns (threads, connections). Called when the plugin is unloaded, deleted, or replaced by a reload — on a background thread, so it may overlap the replacement instance and must not block |
 | `check_triggers()` | No | Return a list of `TriggerResult` if `supports_triggers` is set |
 | `receive_payload(payload, headers, raw_body)` | No | Handle inbound webhooks (raise `PermissionError` → 403, `ValueError` → 400) |
 

--- a/src/backup/service.py
+++ b/src/backup/service.py
@@ -437,6 +437,19 @@ def _reload_services() -> list[str]:
             logger.exception("Failed to reset %s.%s", module_path, attr)
             errors.append(f"{module_path}: reset failed (see server logs)")
 
+    # Plugin registry: live plugin objects still hold the pre-restore
+    # configuration. A restore rewrites config.json wholesale, so this is one
+    # of the few places that genuinely must rebuild the whole plugin set —
+    # everywhere else a single plugin's config change reaches only that plugin
+    # (issue #1753).
+    try:
+        from src.plugins import get_plugin_registry
+
+        get_plugin_registry().initialize(force=True)
+    except Exception:  # pragma: no cover - defensive
+        logger.exception("Failed to reload plugin registry")
+        errors.append("plugins: reload failed (see server logs)")
+
     # Display service has its own reset helper.
     try:
         from src.displays.service import reset_display_service

--- a/src/displays/service.py
+++ b/src/displays/service.py
@@ -54,6 +54,9 @@ class DisplayService:
         if PLUGIN_SYSTEM_AVAILABLE:
             try:
                 self._plugin_registry = get_plugin_registry()
+                # No-op once the registry has loaded (issue #1753): this
+                # singleton is rebuilt on every config change, and rebuilding
+                # the live plugin set here would wipe every plugin's cache.
                 self._plugin_registry.initialize()
                 logger.info("DisplayService initialized with plugin system")
             except Exception as e:

--- a/src/main.py
+++ b/src/main.py
@@ -612,22 +612,36 @@ class DisplayService:
             page_service = get_page_service()
             schedule_service = get_schedule_service()
 
-            # --- Pause short-circuit (issue #970) ---
-            # A paused board is completely hands-off: no rotation, no silence
-            # indicator, no trigger overrides, no override revert. Evaluate
-            # this BEFORE silence. Only a strict ``True`` counts as paused
-            # (guards against Mock returns from older fixtures).
-            if settings_service.is_paused(board_id=board_id) is True:
-                logger.debug("Board %s is paused - skipping update", board_id or "(default)")
-                return False
-
-            # --- Silence mode short-circuit (global decision, per-board state) ---
+            # --- Silence mode evaluation (global decision, per-board state) ---
             # Evaluate silence before any plugin/API work so a snoozed board
             # doesn't hit weather/transit/stocks APIs on every poll. We send
             # exactly one update on entering silence, then go quiet.
+            #
+            # This runs BEFORE the pause short-circuit so that even a fully
+            # hands-off board records where the silence window stands: the 1 Hz
+            # boundary detector in ``run()`` compares this flag against
+            # ``Config.is_silence_mode_active()``, so any exit path that leaves
+            # it stale makes the detector see a permanent mismatch and re-drive
+            # every board once per second for the whole window (issue #1740).
             silence_mode_active = Config.is_silence_mode_active()
             entering_silence_mode = silence_mode_active and not rt.last_silence_mode_active
             exiting_silence_mode = not silence_mode_active and rt.last_silence_mode_active
+
+            # --- Pause short-circuit (issue #970) ---
+            # A paused board is completely hands-off: no rotation, no silence
+            # indicator, no trigger overrides, no override revert. Evaluate
+            # this BEFORE acting on silence. Only a strict ``True`` counts as
+            # paused (guards against Mock returns from older fixtures).
+            if settings_service.is_paused(board_id=board_id) is True:
+                logger.debug("Board %s is paused - skipping update", board_id or "(default)")
+                rt.last_silence_mode_active = silence_mode_active
+                return False
+
+            # Record the boundary now, not on the success path: every early
+            # return below (no page, render failure, no client) would otherwise
+            # leave the flag stale and busy-loop the detector (issue #1740).
+            # The entering/exiting decisions above are already latched.
+            rt.last_silence_mode_active = silence_mode_active
 
             if silence_mode_active and rt.snoozing_message_sent:
                 # Steady-state silence: indicator is already on this board.

--- a/src/plugins/loader.py
+++ b/src/plugins/loader.py
@@ -8,6 +8,7 @@ import importlib.util
 import logging
 import re
 import sys
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -459,7 +460,13 @@ class PluginLoader:
                 logger.warning("Plugin '%s': %s", plugin_name, message)
                 self._load_errors.setdefault(plugin_name, []).append(message)
 
-            # Store loaded plugin and class
+            # Store loaded plugin and class. A plugin loaded over a live one
+            # (re-install, forced rescan) replaces an object that may own a
+            # background thread or an open connection, so retire it first.
+            previous = self._loaded_plugins.get(manifest.id)
+            if previous is not None and previous[0] is not plugin_instance:
+                self._retire_instance(manifest.id, previous[0])
+
             self._loaded_plugins[manifest.id] = (plugin_instance, manifest)
             self._plugin_classes[manifest.id] = plugin_class
             self._plugin_sources[manifest.id] = self._source_for_dir(plugin_dir)
@@ -472,6 +479,31 @@ class PluginLoader:
             self._load_errors[plugin_name] = errors
             logger.exception(f"Error instantiating plugin {plugin_name}")
             return None
+
+    def _retire_instance(self, plugin_id: str, plugin: AnyPlugin) -> None:
+        """Run a replaced plugin instance's ``cleanup()`` off the caller's thread.
+
+        ``cleanup()`` is plugin code: it may close a socket, stop an MQTT
+        listener, or join a thread of its own, and nothing bounds how long that
+        takes. A replacement can happen behind a board render (the render path
+        builds the display service, which touches the registry), so the call is
+        handed to a short-lived daemon thread and never joined — a plugin wedged
+        in teardown must not stall a render or an API request.
+
+        The old object is left to finish whatever it is still doing: the
+        registry deliberately lets an abandoned fetch complete on its own thread
+        (see ``PluginRegistry.build_template_context``), and that thread holds
+        the only other reference to this instance. Nothing here cancels or
+        interrupts it; cleanup simply releases the resources the instance owns.
+        """
+
+        def _run() -> None:
+            try:
+                plugin.cleanup()
+            except Exception:
+                logger.exception("Error cleaning up replaced instance of plugin '%s'", plugin_id)
+
+        threading.Thread(target=_run, name=f"plugin-cleanup-{plugin_id}", daemon=True).start()
 
     def _find_plugin_class(self, module: Any, expected_type: str = "data") -> type[AnyPlugin] | None:
         """Find a plugin class in *module* matching *expected_type*.

--- a/src/plugins/registry.py
+++ b/src/plugins/registry.py
@@ -96,6 +96,10 @@ class PluginRegistry:
         # Auto-discovery cache: maps plugin_id -> discovered variable names
         self._discovered_vars: dict[str, list[str]] = {}
 
+        # Set once initialize() has loaded the plugin set. Guards against a
+        # repeat call rebuilding every live plugin (issue #1753).
+        self._initialized = False
+
         logger.info("PluginRegistry initialized")
 
     # ── instance key helpers ────────────────────────────────────────────
@@ -253,14 +257,31 @@ class PluginRegistry:
         """Return only enabled plugins."""
         return {pid: plugin for pid, plugin in self._plugins.items() if self._enabled.get(pid, False)}
 
-    def initialize(self) -> None:
+    def initialize(self, force: bool = False) -> None:
         """Load all discovered plugins.
 
         This should be called once at startup. It will:
         1. Load all plugin modules from the plugins directory
         2. Read stored configurations from config manager
         3. Enable plugins that have enabled=true in their config
+
+        Repeat calls are a no-op. The registry is a singleton holding *live*
+        plugin objects: their data caches, and any thread or connection they
+        own, belong to the instance. Re-running the full load would swap in
+        cold replacements for every plugin, so one plugin's config save would
+        wipe every other plugin's cache (a refetch storm across the whole
+        board) and orphan their background resources (issue #1753). Config
+        changes reach the affected plugin through ``set_plugin_config`` /
+        ``reload_plugin``, which touch that plugin only.
+
+        Args:
+            force: Rescan and rebuild the plugin set even when already
+                initialized. Only for a genuine reload of what is on disk.
         """
+        if self._initialized and not force:
+            logger.debug("Plugin registry already initialized - skipping reload (pass force=True to rescan)")
+            return
+
         loaded = self._loader.load_all_plugins()
 
         # Self-heal directories left orphaned by a plugin rename: an update
@@ -318,6 +339,8 @@ class PluginRegistry:
         # Restore plugin instances from stored configs.
         # Instance configs have compound keys like "weather:sf".
         self._restore_instances(stored_configs)
+
+        self._initialized = True
 
         enabled_count = sum(1 for e in self._enabled.values() if e)
         logger.info(f"Initialized {len(self._plugins)} plugins ({enabled_count} enabled)")

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -176,6 +176,18 @@ def test_import_from_json_rejects_invalid_json(tmp_path):
         service.import_from_json("{not valid json")
 
 
+def test_restore_forces_a_full_plugin_registry_reload():
+    """A restore rewrites every plugin's stored config, so the live plugin
+    objects — which still hold the pre-restore config — must be rebuilt."""
+    from src.backup.service import _reload_services
+
+    fake_registry = MagicMock()
+    with patch("src.plugins.get_plugin_registry", return_value=fake_registry, create=True):
+        _reload_services()
+
+    fake_registry.initialize.assert_called_once_with(force=True)
+
+
 def test_collect_installed_plugins_skips_builtins(tmp_path):
     fake_source_builtin = MagicMock(source_type="builtin", repository_url="")
     fake_source_external = MagicMock(

--- a/tests/test_plugin_loader.py
+++ b/tests/test_plugin_loader.py
@@ -1,6 +1,7 @@
 """Tests for PluginLoader - discovers and loads plugin modules."""
 
 import sys
+import threading
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -437,6 +438,25 @@ def test_reload_plugin_loads_if_not_loaded(tmp_path):
     plugin = loader.reload_plugin("test_plugin")
     assert plugin is not None
     assert plugin.plugin_id == "test_plugin"
+
+
+def test_loading_over_a_live_plugin_cleans_up_the_replaced_instance(tmp_path):
+    """Replacing a loaded instance must run cleanup() on the one it drops.
+
+    Without it, whatever the old instance owns — a listener thread, an open
+    connection — is leaked for the lifetime of the process (issue #1753).
+    """
+    create_valid_plugin_dir(tmp_path, "test_plugin")
+    loader = _loader_for_tests(tmp_path)
+    first = loader.load_plugin("test_plugin")
+
+    cleaned_up = threading.Event()
+    first.cleanup = cleaned_up.set
+
+    second = loader.load_plugin("test_plugin")
+
+    assert second is not first
+    assert cleaned_up.wait(timeout=5), "the replaced plugin instance was dropped without cleanup()"
 
 
 # --- unload_plugin ---

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -2150,3 +2150,87 @@ def test_build_template_context_returns_without_waiting_for_a_slow_plugin(
         assert "slow_plugin" not in context
     finally:
         released.set()
+
+
+# --- plugin lifecycle on reset (issue #1753) ---
+
+
+class _LifecyclePlugin(PluginBase):
+    """Real PluginBase subclass that records every fetch it performs.
+
+    The counter is shared across instances of the same plugin id so a test can
+    tell "the warm instance served its cache" from "a fresh instance refetched".
+    """
+
+    def __init__(self, manifest, fetches):
+        super().__init__(manifest)
+        self._fetches = fetches
+
+    @property
+    def plugin_id(self):
+        return self._manifest["id"]
+
+    def fetch_data(self):
+        self._fetches.append(self.plugin_id)
+        return PluginResult(available=True, data={"n": len(self._fetches)})
+
+
+def _lifecycle_manifest(plugin_id):
+    return {
+        "id": plugin_id,
+        "name": plugin_id.title(),
+        "version": "1.0.0",
+        "description": "",
+        "author": "",
+        "variables": {"simple": ["var1"]},
+        "max_lengths": {},
+    }
+
+
+def _two_generations(plugin_id, fetches):
+    """A live plugin instance plus the replacement a full reload would build."""
+    manifest = _lifecycle_manifest(plugin_id)
+    return _LifecyclePlugin(manifest, fetches), _LifecyclePlugin(manifest, fetches)
+
+
+def test_repeat_initialize_keeps_plugin_data_cached(registry, mock_loader, mock_manifest):
+    """A second initialize() must not swap in cold instances and refetch."""
+    fetches = []
+    live, replacement = _two_generations("beta", fetches)
+    mock_loader.load_all_plugins.side_effect = [{"beta": live}, {"beta": replacement}]
+    mock_loader.get_manifest.side_effect = lambda pid: mock_manifest
+
+    with patch("src.config_manager.get_config_manager") as mock_cm:
+        mock_cm.return_value.get_all_plugin_configs.return_value = {"beta": {"enabled": True}}
+        registry.initialize()
+        registry.get_plugin("beta").get_data()
+
+        # What a plugin config save triggers today: reset_display_service()
+        # drops the DisplayService singleton, and rebuilding it re-initializes
+        # the already-initialized registry.
+        registry.initialize()
+        registry.get_plugin("beta").get_data()
+
+    assert fetches == ["beta"], "plugin beta refetched after an unrelated reset — its cache was thrown away"
+
+
+def test_recreating_the_display_service_keeps_the_live_plugin_instance(registry, mock_loader, mock_manifest):
+    """Rebuilding DisplayService must not re-instantiate the whole plugin set."""
+    from src.displays.service import DisplayService
+
+    fetches = []
+    live, replacement = _two_generations("beta", fetches)
+    mock_loader.load_all_plugins.side_effect = [{"beta": live}, {"beta": replacement}]
+    mock_loader.get_manifest.side_effect = lambda pid: mock_manifest
+
+    with patch("src.config_manager.get_config_manager") as mock_cm:
+        mock_cm.return_value.get_all_plugin_configs.return_value = {"beta": {"enabled": True}}
+        registry.initialize()
+
+        with (
+            patch("src.displays.service.PLUGIN_SYSTEM_AVAILABLE", True),
+            patch("src.displays.service.get_plugin_registry", return_value=registry),
+        ):
+            DisplayService()
+
+    assert registry.get_plugin("beta") is live

--- a/tests/test_silence_schedule_polling.py
+++ b/tests/test_silence_schedule_polling.py
@@ -197,3 +197,78 @@ class TestExitingSilence:
         sent_array = svc.vb_client.render.call_args.args[0]
         last_row_text = "".join(chr(c + 64) if 1 <= c <= 26 else "?" for c in sent_array[-1])
         assert "SNOOZING" not in last_row_text
+
+
+def _sleep_that_stops_after(svc, iterations, on_iteration=None):
+    """Fake ``time.sleep`` that drives the run loop for a fixed number of ticks.
+
+    Replaces the wall clock entirely: each call is one simulated second, so a
+    silence window can be walked tick by tick without any real waiting.
+    """
+    state = {"ticks": 0}
+
+    def _fake_sleep(_seconds):
+        state["ticks"] += 1
+        if on_iteration is not None:
+            on_iteration(state["ticks"])
+        if state["ticks"] >= iterations:
+            svc.running = False
+
+    return _fake_sleep
+
+
+class TestSilenceBoundaryDetector:
+    """The 1 Hz boundary detector must fire once per boundary, not once per
+    second, even when the board's update path returns early (issue #1740)."""
+
+    def test_paused_board_does_not_force_an_update_every_second_during_silence(self, service_factory):
+        svc, mocks, _page_service = service_factory(is_silence=True)
+        mocks["settings"].return_value.is_paused.return_value = True
+
+        with (
+            patch.object(svc, "check_and_send_active_page", wraps=svc.check_and_send_active_page) as drive,
+            patch("src.main.schedule"),
+            patch("src.main.time.sleep", _sleep_that_stops_after(svc, 5)),
+        ):
+            svc.run()
+
+        # Only the initial update before the loop; the detector must stay quiet.
+        assert drive.call_count == 1
+
+    def test_render_failure_does_not_force_an_update_every_second_during_silence(self, service_factory):
+        svc, mocks, page_service = service_factory(is_silence=True)
+        failed_preview = Mock()
+        failed_preview.available = False
+        page_service.preview_page.return_value = failed_preview
+        mocks["settings"].return_value.is_paused.return_value = False
+
+        with (
+            patch.object(svc, "check_and_send_active_page", wraps=svc.check_and_send_active_page) as drive,
+            patch.object(svc, "_check_trigger_override", return_value=None),
+            patch("src.main.schedule"),
+            patch("src.main.time.sleep", _sleep_that_stops_after(svc, 5)),
+        ):
+            svc.run()
+
+        assert drive.call_count == 1
+
+    def test_crossing_into_silence_forces_exactly_one_update(self, service_factory):
+        svc, mocks, _page_service = service_factory(is_silence=False)
+        mocks["settings"].return_value.is_paused.return_value = True
+
+        silence = {"active": False}
+        mocks["config"].is_silence_mode_active.side_effect = lambda: silence["active"]
+
+        def _flip_at_tick_3(tick):
+            if tick == 3:
+                silence["active"] = True
+
+        with (
+            patch.object(svc, "check_and_send_active_page", wraps=svc.check_and_send_active_page) as drive,
+            patch("src.main.schedule"),
+            patch("src.main.time.sleep", _sleep_that_stops_after(svc, 6, _flip_at_tick_3)),
+        ):
+            svc.run()
+
+        # One initial update + exactly one forced update at the boundary.
+        assert drive.call_count == 2


### PR DESCRIPTION
Two independent engine/plugin-lifecycle bugs, one commit each.

Closes #1740
Closes #1753

## #1740 — silence detector busy-loops at 1 Hz

**Root cause.** The 1 Hz boundary detector in `DisplayService.run()` compares
`Config.is_silence_mode_active()` against the primary runtime's
`last_silence_mode_active`, but that flag was only written on the *successful
send* path of `check_and_send_for_board`. Every early return — paused board, no
active page, render failure, no client — left it stale, so throughout a silence
window the detector saw a permanent mismatch and re-drove **every configured
board once per second** for the whole window.

**Fix.** Silence is evaluated before the pause short-circuit, and the flag is
latched immediately after the entering/exiting decisions are taken, so every
exit path leaves it consistent. The paused branch records it explicitly before
returning. Crossing a boundary still forces exactly one update.

## #1753 — plugin reset rebuilds the world and leaks resources

**Root cause.** Saving, enabling, or disabling any plugin calls
`reset_display_service()`. The next board render rebuilds `DisplayService`,
whose constructor calls `PluginRegistry.initialize()` on the already-initialized
singleton — a full `load_all_plugins()` that instantiates a cold replacement for
every plugin. Toggling one plugin therefore discarded every *other* plugin's data
cache (a refetch storm across the whole board) and orphaned whatever the replaced
instances owned — listener threads, connections, an MQTT subscription — because
nothing called `cleanup()` on them.

**Fix.**
- `PluginRegistry.initialize()` is a no-op once the plugin set is loaded. A
  config change reaches only the plugin it names (`set_plugin_config` clears just
  that plugin's cache). `initialize(force=True)` remains for a genuine rescan.
- Backup restore now calls `initialize(force=True)` explicitly: a restore
  rewrites every stored config, so it is the one place that must rebuild the
  world. Without this it would silently stop applying restored plugin configs —
  covered by a new test.
- Where the loader *does* replace a live instance, the old one's `cleanup()` runs
  on a short-lived daemon thread. `cleanup()` is plugin code with no time bound
  and a replacement can happen behind a board render, so the caller must not
  inherit a wedged teardown. The old object is never cancelled or joined, so a
  fetch the registry deliberately abandoned to its own thread
  (`build_template_context`) still finishes undisturbed.

## Test evidence

Each test was written first and observed failing. Verbatim pre-fix output:

### #1740 — `tests/test_silence_schedule_polling.py`

```
tests/test_silence_schedule_polling.py .....FFF                          [100%]

=================================== FAILURES ===================================
_ TestSilenceBoundaryDetector.test_paused_board_does_not_force_an_update_every_second_during_silence _
tests/test_silence_schedule_polling.py:236: in test_paused_board_does_not_force_an_update_every_second_during_silence
    assert drive.call_count == 1
E   AssertionError: assert 6 == 1
E    +  where 6 = <MagicMock name='check_and_send_active_page' id='281473566639504'>.call_count
_ TestSilenceBoundaryDetector.test_render_failure_does_not_force_an_update_every_second_during_silence _
tests/test_silence_schedule_polling.py:253: in test_render_failure_does_not_force_an_update_every_second_during_silence
    assert drive.call_count == 1
E   AssertionError: assert 6 == 1
E    +  where 6 = <MagicMock name='check_and_send_active_page' id='281473566650256'>.call_count
------------------------------ Captured log call -------------------------------
WARNING  src.main:main.py:734 Failed to render active page: page-1
WARNING  src.main:main.py:734 Failed to render active page: page-1
WARNING  src.main:main.py:734 Failed to render active page: page-1
WARNING  src.main:main.py:734 Failed to render active page: page-1
WARNING  src.main:main.py:734 Failed to render active page: page-1
WARNING  src.main:main.py:734 Failed to render active page: page-1
_ TestSilenceBoundaryDetector.test_crossing_into_silence_forces_exactly_one_update _
tests/test_silence_schedule_polling.py:274: in test_crossing_into_silence_forces_exactly_one_update
    assert drive.call_count == 2
E   AssertionError: assert 4 == 2
E    +  where 4 = <MagicMock name='check_and_send_active_page' id='281473566462640'>.call_count
=========================== short test summary info ============================
FAILED tests/test_silence_schedule_polling.py::TestSilenceBoundaryDetector::test_paused_board_does_not_force_an_update_every_second_during_silence
FAILED tests/test_silence_schedule_polling.py::TestSilenceBoundaryDetector::test_render_failure_does_not_force_an_update_every_second_during_silence
FAILED tests/test_silence_schedule_polling.py::TestSilenceBoundaryDetector::test_crossing_into_silence_forces_exactly_one_update
========================= 3 failed, 5 passed in 0.23s ==========================
```

6 drives instead of 1 = the initial update plus one per simulated second (the
loop runs on a fake clock: `time.sleep` is replaced by a counter, nothing waits).

### #1753 — replaced instance is dropped without `cleanup()`

```
_______ test_loading_over_a_live_plugin_cleans_up_the_replaced_instance ________
tests/test_plugin_loader.py:459: in test_loading_over_a_live_plugin_cleans_up_the_replaced_instance
    assert cleaned_up.wait(timeout=5), "the replaced plugin instance was dropped without cleanup()"
E   AssertionError: the replaced plugin instance was dropped without cleanup()
E   assert False
E    +  where False = wait(timeout=5)
E    +    where wait = <threading.Event at 0xffff7cf72350: unset>.wait
```

### #1753 — reset throws away an unrelated plugin's cache

```
_______________ test_repeat_initialize_keeps_plugin_data_cached ________________
tests/test_plugin_registry.py:2214: in test_repeat_initialize_keeps_plugin_data_cached
    assert fetches == ["beta"], "plugin beta refetched after an unrelated reset — its cache was thrown away"
E   AssertionError: plugin beta refetched after an unrelated reset — its cache was thrown away
E   assert ['beta', 'beta'] == ['beta']
E
E     Left contains one more item: 'beta'
E     Use -v to get more diff
______ test_recreating_the_display_service_keeps_the_live_plugin_instance ______
tests/test_plugin_registry.py:2236: in test_recreating_the_display_service_keeps_the_live_plugin_instance
    assert registry.get_plugin("beta") is live
E   AssertionError: assert <tests.test_plugin_registry._LifecyclePlugin object at 0xffffb20da780> is <tests.test_plugin_registry._LifecyclePlugin object at 0xffffb206e0d0>
E    +  where <tests.test_plugin_registry._LifecyclePlugin object at 0xffffb20da780> = get_plugin('beta')
E    +    where get_plugin = <src.plugins.registry.PluginRegistry object at 0xffffb218fc50>.get_plugin
```

### #1753 — restore must still force a full reload (regression guard)

Non-vacuity checked by reverting just that call in `src/backup/service.py`:

```
______________ test_restore_forces_a_full_plugin_registry_reload _______________
tests/test_backup.py:188: in test_restore_forces_a_full_plugin_registry_reload
    fake_registry.initialize.assert_called_once_with(force=True)
/usr/local/lib/python3.14/unittest/mock.py:997: in assert_called_once_with
    raise AssertionError(msg)
E   AssertionError: Expected 'initialize' to be called once. Called 0 times.
```

### After the fixes

Full Python suite in the test container:

```
5213 passed, 1 skipped, 1 deselected, 137 warnings in 30.35s
```

(The deselection is `test_check_image_formats.py::TestRepositoryIsClean`, which
shells out to `git ls-files`; it cannot run inside the container from a git
worktree. `ruff check` and `ruff format --check` are clean across `src` and
`tests`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ndXRi5v57yB5sXXhQswjp
