### PR TITLE
test(ci): route-inventory golden test + make never-running specs a CI failure

### DIFF
--- a/.claude/ux-coverage.json
+++ b/.claude/ux-coverage.json
@@ -1,4 +1,12 @@
 {
+  "_provenance": {
+    "status": "historical",
+    "audited_at": "2026-06-04T05:34:34Z",
+    "stale_as_of": "2026-09-03",
+    "why_stale": "This audit is the INPUT that produced web/tests/regression/ (26 specs, ~240 tests). Its audited_specs list predates that suite, so the 8.8% headline in `summary` describes coverage BEFORE the gap tests it generated were written. Do not quote it as current coverage.",
+    "superseded_by": "web/tests/regression/*.spec.ts and web/tests/COVERAGE.md",
+    "regenerate_with": "/audit-ux-coverage (qa-auditor agent) - rewrites this file in place"
+  },
   "ux_tree": "ux-tree.json",
   "generated_at": "2026-06-04T05:34:34Z",
   "scope": "pages,schedule,dashboard,integrations,settings,carousels,picks,profile,login,offline,debug",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       shared: ${{ steps.filter.outputs.shared }}
       docs: ${{ steps.filter.outputs.docs }}
       markdown: ${{ steps.filter.outputs.markdown }}
+      e2e_wiring: ${{ steps.filter.outputs.e2e_wiring }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -61,6 +62,18 @@ jobs:
               - 'start-dev.sh'
             plugins:
               - 'plugins/**'
+            e2e_wiring:
+              # The inputs to tests/test_e2e_spec_reachability.py, which
+              # proves no Playwright spec is unreachable by every workflow
+              # and that the merge queue gates on all of them (#1737).
+              # A new workflow, a new `RUN_*` gate in the Playwright config,
+              # or a new spec can each create a never-run test, so the guard
+              # has to re-run whenever one of them changes. Deliberately NOT
+              # folded into `shared` — that would rebuild the Docker image
+              # and run the whole E2E fleet for an unrelated workflow edit.
+              - '.github/workflows/**'
+              - 'web/playwright.config.ts'
+              - 'web/tests/**'
             shared:
               # Files that genuinely affect every test surface (Platform,
               # UI, Plugins, A11y, E2E, Build). Keep this list as an
@@ -147,7 +160,12 @@ jobs:
     name: Platform Tests
     runs-on: ubuntu-latest
     needs: detect-changes
-    if: needs.detect-changes.outputs.api == 'true' || needs.detect-changes.outputs.shared == 'true'
+    # `e2e_wiring` is here so the spec-reachability guard runs when a workflow
+    # or the Playwright config changes, even though no Python changed (#1737).
+    if: >-
+      needs.detect-changes.outputs.api == 'true'
+      || needs.detect-changes.outputs.shared == 'true'
+      || needs.detect-changes.outputs.e2e_wiring == 'true'
     timeout-minutes: 10
     
     steps:

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,7 +9,34 @@ This directory contains shared test infrastructure to reduce boilerplate and imp
 - `conftest.py` — Shared pytest fixtures for mocks and sample data
 - `factories.py` — Factory functions for creating test objects
 - `helpers.py` — Helper assertions for common test patterns
+- `golden/` — Reviewed snapshots that tests compare against (see below)
 - `__init__.py` — Public API exports for test helpers
+
+## Golden files
+
+### `golden/api_routes.json` — API route inventory
+
+`test_route_inventory.py` snapshots every route on `src.api_server.app`
+(path + sorted methods + endpoint name + route class) and fails on any drift.
+It exists so that refactors which move routes between modules cannot silently
+drop, re-path, or rename an endpoint — the change has to show up as a diff in
+the golden file that a reviewer reads.
+
+**Adding or changing a route is expected to fail this test once.** That is the
+point: regenerate the golden file deliberately, then read the diff.
+
+```bash
+docker compose -f docker-compose.dev.yml exec fiestaboard \
+    env UPDATE_ROUTE_INVENTORY=1 pytest tests/test_route_inventory.py
+git diff tests/golden/api_routes.json
+```
+
+Never regenerate to "make CI green" without reading that diff — a removed line
+is a broken client.
+
+Note that the inventory includes the `/mcp` mount, which only exists when the
+`mcp` package is installed. If that dependency ever goes missing the golden
+test fails rather than the MCP surface disappearing quietly.
 
 ## Usage
 

--- a/tests/golden/api_routes.json
+++ b/tests/golden/api_routes.json
@@ -1,0 +1,1639 @@
+{
+  "_comment": "Golden snapshot of src.api_server.app route table (issue #1731). Do not hand-edit: regenerate with `UPDATE_ROUTE_INVENTORY=1 pytest tests/test_route_inventory.py` and review the diff.",
+  "routes": [
+    {
+      "path": "/",
+      "methods": [
+        "GET"
+      ],
+      "name": "root",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/auth/change-password",
+      "methods": [
+        "POST"
+      ],
+      "name": "auth_change_password",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/auth/change-username",
+      "methods": [
+        "POST"
+      ],
+      "name": "auth_change_username",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/auth/disable",
+      "methods": [
+        "POST"
+      ],
+      "name": "auth_disable",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/auth/login",
+      "methods": [
+        "POST"
+      ],
+      "name": "auth_login",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/auth/logout",
+      "methods": [
+        "POST"
+      ],
+      "name": "auth_logout",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/auth/mcp-token",
+      "methods": [
+        "DELETE"
+      ],
+      "name": "auth_mcp_token_clear",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/auth/mcp-token",
+      "methods": [
+        "GET"
+      ],
+      "name": "auth_mcp_token_status",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/auth/mcp-token",
+      "methods": [
+        "POST"
+      ],
+      "name": "auth_mcp_token_rotate",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/auth/preference",
+      "methods": [
+        "POST"
+      ],
+      "name": "auth_preference",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/auth/setup",
+      "methods": [
+        "POST"
+      ],
+      "name": "auth_setup",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/auth/status",
+      "methods": [
+        "GET"
+      ],
+      "name": "auth_status",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/backup/export",
+      "methods": [
+        "GET"
+      ],
+      "name": "export_backup",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/backup/import",
+      "methods": [
+        "POST"
+      ],
+      "name": "import_backup",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/baywheels/stations",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_all_baywheels_stations",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/baywheels/stations/nearby",
+      "methods": [
+        "GET"
+      ],
+      "name": "find_nearby_baywheels_stations",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/baywheels/stations/search",
+      "methods": [
+        "GET"
+      ],
+      "name": "search_baywheels_stations_by_address",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/board/current-message",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_board_current_message",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/cache-status",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_cache_status",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/clear-cache",
+      "methods": [
+        "POST"
+      ],
+      "name": "clear_cache",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/collections",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_collections",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/collections",
+      "methods": [
+        "POST"
+      ],
+      "name": "create_collection",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/collections/{collection_id}",
+      "methods": [
+        "DELETE"
+      ],
+      "name": "delete_collection",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/collections/{collection_id}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_collection",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/collections/{collection_id}",
+      "methods": [
+        "PUT"
+      ],
+      "name": "update_collection",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/config",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_config",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/config/board",
+      "methods": [
+        "DELETE"
+      ],
+      "name": "reset_board_config",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/config/board",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_board_config",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/config/board",
+      "methods": [
+        "PUT"
+      ],
+      "name": "update_board_config",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/config/board/enable-local-api",
+      "methods": [
+        "POST"
+      ],
+      "name": "enable_local_api",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/config/board/scan",
+      "methods": [
+        "POST"
+      ],
+      "name": "scan_for_boards",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/config/board/test",
+      "methods": [
+        "POST"
+      ],
+      "name": "test_board_connection",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/config/full",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_full_config",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/config/general",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_general_config",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/config/general",
+      "methods": [
+        "PUT"
+      ],
+      "name": "update_general_config",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/config/validate",
+      "methods": [
+        "GET"
+      ],
+      "name": "validate_config",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/debug/blank",
+      "methods": [
+        "POST"
+      ],
+      "name": "debug_blank_board",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/debug/cache-status",
+      "methods": [
+        "GET"
+      ],
+      "name": "debug_get_cache_status",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/debug/clear-cache",
+      "methods": [
+        "POST"
+      ],
+      "name": "debug_clear_cache",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/debug/fill",
+      "methods": [
+        "POST"
+      ],
+      "name": "debug_fill_board",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/debug/info",
+      "methods": [
+        "POST"
+      ],
+      "name": "debug_show_info",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/debug/network-diagnostics",
+      "methods": [
+        "GET"
+      ],
+      "name": "debug_network_diagnostics",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/debug/system-info",
+      "methods": [
+        "GET"
+      ],
+      "name": "debug_get_system_info",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/debug/test-connection",
+      "methods": [
+        "POST"
+      ],
+      "name": "debug_test_connection",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/displays",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_displays",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/displays/raw/batch",
+      "methods": [
+        "POST"
+      ],
+      "name": "get_displays_raw_batch",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/displays/{display_type}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_display",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/displays/{display_type}/raw",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_display_raw",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/displays/{display_type}/send",
+      "methods": [
+        "POST"
+      ],
+      "name": "send_display",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/docs",
+      "methods": [
+        "GET",
+        "HEAD"
+      ],
+      "name": "swagger_ui_html",
+      "kind": "Route"
+    },
+    {
+      "path": "/docs/oauth2-redirect",
+      "methods": [
+        "GET",
+        "HEAD"
+      ],
+      "name": "swagger_ui_redirect",
+      "kind": "Route"
+    },
+    {
+      "path": "/force-refresh",
+      "methods": [
+        "POST"
+      ],
+      "name": "force_refresh",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/generic-data/test-fetch",
+      "methods": [
+        "POST"
+      ],
+      "name": "generic_data_test_fetch",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/health",
+      "methods": [
+        "GET"
+      ],
+      "name": "health",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/health",
+      "methods": [
+        "HEAD"
+      ],
+      "name": "health_head",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/home-assistant/entities",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_home_assistant_entities",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/logs",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_logs",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/mcp",
+      "methods": [],
+      "name": null,
+      "kind": "Mount"
+    },
+    {
+      "path": "/mqtt/republish-discovery",
+      "methods": [
+        "POST"
+      ],
+      "name": "mqtt_republish_discovery",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/mqtt/status",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_mqtt_status",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/muni/stops",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_all_muni_stops",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/muni/stops/nearby",
+      "methods": [
+        "GET"
+      ],
+      "name": "find_nearby_muni_stops",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/muni/stops/search",
+      "methods": [
+        "GET"
+      ],
+      "name": "search_muni_stops_by_address",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/network/wifi/capability",
+      "methods": [
+        "GET"
+      ],
+      "name": "wifi_capability",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/network/wifi/connect",
+      "methods": [
+        "POST"
+      ],
+      "name": "wifi_connect",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/network/wifi/disconnect",
+      "methods": [
+        "POST"
+      ],
+      "name": "wifi_disconnect",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/network/wifi/saved",
+      "methods": [
+        "GET"
+      ],
+      "name": "wifi_saved",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/network/wifi/saved/{con_name}",
+      "methods": [
+        "DELETE"
+      ],
+      "name": "wifi_forget",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/network/wifi/scan",
+      "methods": [
+        "POST"
+      ],
+      "name": "wifi_scan",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/network/wifi/status",
+      "methods": [
+        "GET"
+      ],
+      "name": "wifi_status",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/openapi.json",
+      "methods": [
+        "GET",
+        "HEAD"
+      ],
+      "name": "openapi",
+      "kind": "Route"
+    },
+    {
+      "path": "/pages",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_pages",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/pages",
+      "methods": [
+        "POST"
+      ],
+      "name": "create_page",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/pages/ai/chat",
+      "methods": [
+        "POST"
+      ],
+      "name": "chat_ai_page",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/pages/ai/context",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_ai_context",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/pages/ai/generate",
+      "methods": [
+        "POST"
+      ],
+      "name": "generate_ai_page",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/pages/cache/clear",
+      "methods": [
+        "POST"
+      ],
+      "name": "clear_page_cache",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/pages/cache/stats",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_page_cache_stats",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/pages/current-display",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_current_display",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/pages/import",
+      "methods": [
+        "POST"
+      ],
+      "name": "import_page",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/pages/import/preview",
+      "methods": [
+        "POST"
+      ],
+      "name": "preview_page_import",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/pages/preview/batch",
+      "methods": [
+        "POST"
+      ],
+      "name": "preview_pages_batch",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/pages/{page_id}",
+      "methods": [
+        "DELETE"
+      ],
+      "name": "delete_page",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/pages/{page_id}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_page",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/pages/{page_id}",
+      "methods": [
+        "PUT"
+      ],
+      "name": "update_page",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/pages/{page_id}/preview",
+      "methods": [
+        "POST"
+      ],
+      "name": "preview_page",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/pages/{page_id}/send",
+      "methods": [
+        "POST"
+      ],
+      "name": "send_page",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/pages/{page_id}/share",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_page_share_string",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/panel/{panel_id}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_panel_public",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/panel/{panel_id}/frame",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_panel_frame",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/panels",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_panels",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/panels",
+      "methods": [
+        "POST"
+      ],
+      "name": "create_panel",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/panels/{panel_id}",
+      "methods": [
+        "DELETE"
+      ],
+      "name": "delete_panel",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/panels/{panel_id}",
+      "methods": [
+        "PATCH"
+      ],
+      "name": "update_panel",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/plugins",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_plugins",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/plugins/errors",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_plugin_errors",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/plugins/install",
+      "methods": [
+        "POST"
+      ],
+      "name": "install_external_plugin",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/plugins/registry",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_registry_plugins",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/plugins/registry/{plugin_id}/install",
+      "methods": [
+        "POST"
+      ],
+      "name": "install_registry_plugin",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/plugins/updates",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_plugin_updates",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/plugins/updates/apply",
+      "methods": [
+        "POST"
+      ],
+      "name": "apply_all_plugin_updates",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/plugins/updates/check",
+      "methods": [
+        "POST"
+      ],
+      "name": "trigger_plugin_update_check",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/plugins/variables/all",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_all_plugin_variables",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/plugins/{plugin_id}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_plugin",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/plugins/{plugin_id}/config",
+      "methods": [
+        "PUT"
+      ],
+      "name": "update_plugin_config",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/plugins/{plugin_id}/data",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_plugin_data",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/plugins/{plugin_id}/demo-page",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_plugin_demo_page",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/plugins/{plugin_id}/demo-page",
+      "methods": [
+        "POST"
+      ],
+      "name": "create_plugin_demo_page",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/plugins/{plugin_id}/disable",
+      "methods": [
+        "POST"
+      ],
+      "name": "disable_plugin",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/plugins/{plugin_id}/enable",
+      "methods": [
+        "POST"
+      ],
+      "name": "enable_plugin",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/plugins/{plugin_id}/instances",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_plugin_instances",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/plugins/{plugin_id}/instances",
+      "methods": [
+        "POST"
+      ],
+      "name": "create_plugin_instance",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/plugins/{plugin_id}/instances/{instance_label}",
+      "methods": [
+        "DELETE"
+      ],
+      "name": "delete_plugin_instance",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/plugins/{plugin_id}/manifest",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_plugin_manifest",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/plugins/{plugin_id}/options/{options_id}",
+      "methods": [
+        "POST"
+      ],
+      "name": "get_plugin_options_endpoint",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/plugins/{plugin_id}/receive",
+      "methods": [
+        "POST"
+      ],
+      "name": "receive_plugin_payload",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/plugins/{plugin_id}/uninstall",
+      "methods": [
+        "DELETE"
+      ],
+      "name": "uninstall_external_plugin",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/plugins/{plugin_id}/update",
+      "methods": [
+        "POST"
+      ],
+      "name": "update_plugin",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/plugins/{plugin_id}/variables",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_plugin_variables",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/redoc",
+      "methods": [
+        "GET",
+        "HEAD"
+      ],
+      "name": "redoc_html",
+      "kind": "Route"
+    },
+    {
+      "path": "/refresh",
+      "methods": [
+        "POST"
+      ],
+      "name": "refresh_display",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/schedules",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_schedules",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/schedules",
+      "methods": [
+        "POST"
+      ],
+      "name": "create_schedule",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/schedules/active/page",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_active_schedule",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/schedules/default-page",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_default_page",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/schedules/default-page",
+      "methods": [
+        "PUT"
+      ],
+      "name": "set_default_page",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/schedules/enabled",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_schedule_enabled",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/schedules/enabled",
+      "methods": [
+        "PUT"
+      ],
+      "name": "set_schedule_enabled",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/schedules/validate",
+      "methods": [
+        "POST"
+      ],
+      "name": "validate_schedules",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/schedules/{schedule_id}",
+      "methods": [
+        "DELETE"
+      ],
+      "name": "delete_schedule",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/schedules/{schedule_id}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_schedule",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/schedules/{schedule_id}",
+      "methods": [
+        "PUT"
+      ],
+      "name": "update_schedule",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/send-message",
+      "methods": [
+        "POST"
+      ],
+      "name": "send_message",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/send-welcome-message",
+      "methods": [
+        "POST"
+      ],
+      "name": "send_welcome_message",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/settings/active-page",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_active_page",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/settings/active-page",
+      "methods": [
+        "PUT"
+      ],
+      "name": "set_active_page",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/settings/ai",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_ai_settings",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/settings/ai",
+      "methods": [
+        "PUT"
+      ],
+      "name": "update_ai_settings",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/settings/ai/test",
+      "methods": [
+        "POST"
+      ],
+      "name": "test_ai_provider",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/settings/all",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_all_settings",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/settings/beta",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_beta_settings",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/settings/beta",
+      "methods": [
+        "PUT"
+      ],
+      "name": "update_beta_settings",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/settings/board",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_board_settings",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/settings/board",
+      "methods": [
+        "PUT"
+      ],
+      "name": "update_board_settings",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/settings/board/add",
+      "methods": [
+        "POST"
+      ],
+      "name": "add_board_instance",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/settings/board/{board_id}",
+      "methods": [
+        "DELETE"
+      ],
+      "name": "remove_board_instance",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/settings/board/{board_id}/detect-size",
+      "methods": [
+        "POST"
+      ],
+      "name": "detect_board_size",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/settings/board/{board_id}/identify",
+      "methods": [
+        "POST"
+      ],
+      "name": "identify_board_tiles",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/settings/board/{board_id}/pause",
+      "methods": [
+        "POST"
+      ],
+      "name": "set_board_paused",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/settings/display",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_display_settings",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/settings/display",
+      "methods": [
+        "PUT"
+      ],
+      "name": "update_display_settings",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/settings/hdmi-kiosk",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_hdmi_kiosk_status",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/settings/hdmi-kiosk",
+      "methods": [
+        "POST"
+      ],
+      "name": "set_hdmi_kiosk",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/settings/location",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_location_settings",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/settings/location",
+      "methods": [
+        "PUT"
+      ],
+      "name": "update_location_settings",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/settings/location/sun-times",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_location_sun_times",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/settings/location/sun-times-week",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_location_sun_times_week",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/settings/mqtt",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_mqtt_settings",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/settings/mqtt",
+      "methods": [
+        "PUT"
+      ],
+      "name": "update_mqtt_settings",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/settings/output",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_output_settings",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/settings/output",
+      "methods": [
+        "PUT"
+      ],
+      "name": "update_output_settings",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/settings/plugins",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_plugin_settings",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/settings/plugins",
+      "methods": [
+        "PUT"
+      ],
+      "name": "update_plugin_settings",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/settings/polling",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_polling_settings",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/settings/polling",
+      "methods": [
+        "PUT"
+      ],
+      "name": "update_polling_settings",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/settings/silence-schedule",
+      "methods": [
+        "PUT"
+      ],
+      "name": "update_silence_schedule",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/settings/temporary-override",
+      "methods": [
+        "DELETE"
+      ],
+      "name": "clear_temporary_override",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/settings/temporary-override",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_temporary_override",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/settings/temporary-override",
+      "methods": [
+        "POST"
+      ],
+      "name": "set_temporary_override",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/settings/transitions",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_transition_settings",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/settings/transitions",
+      "methods": [
+        "PUT"
+      ],
+      "name": "update_transition_settings",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/silence-status",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_silence_status",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/staff-picks",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_staff_picks",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/staff-picks/{pick_id}/share",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_staff_pick_share",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/start",
+      "methods": [
+        "POST"
+      ],
+      "name": "start_service",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/status",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_status",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/stocks/search",
+      "methods": [
+        "GET"
+      ],
+      "name": "search_stock_symbols",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/stocks/validate",
+      "methods": [
+        "POST"
+      ],
+      "name": "validate_stock_symbol",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/stop",
+      "methods": [
+        "POST"
+      ],
+      "name": "stop_service",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/system/restart",
+      "methods": [
+        "POST"
+      ],
+      "name": "system_restart",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/system/shutdown",
+      "methods": [
+        "POST"
+      ],
+      "name": "system_shutdown",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/system/update",
+      "methods": [
+        "POST"
+      ],
+      "name": "system_update_apply",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/system/update-check",
+      "methods": [
+        "GET"
+      ],
+      "name": "system_update_check",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/system/update/auto",
+      "methods": [
+        "POST"
+      ],
+      "name": "system_update_set_auto",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/system/update/rollback",
+      "methods": [
+        "POST"
+      ],
+      "name": "system_update_rollback",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/system/update/status",
+      "methods": [
+        "GET"
+      ],
+      "name": "system_update_status",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/templates/formula-functions",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_formula_functions",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/templates/render",
+      "methods": [
+        "POST"
+      ],
+      "name": "render_template",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/templates/render/live",
+      "methods": [
+        "POST"
+      ],
+      "name": "render_template_live",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/templates/validate",
+      "methods": [
+        "POST"
+      ],
+      "name": "validate_template",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/templates/variables",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_template_variables",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/traffic/routes/geocode",
+      "methods": [
+        "POST"
+      ],
+      "name": "geocode_address",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/traffic/routes/validate",
+      "methods": [
+        "POST"
+      ],
+      "name": "validate_traffic_route",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/transit/cache/status",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_transit_cache_status",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/transitions/plugins",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_transition_plugins",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/transitions/preview",
+      "methods": [
+        "POST"
+      ],
+      "name": "preview_transition",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/transitions/restore",
+      "methods": [
+        "POST"
+      ],
+      "name": "restore_after_transition_test",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/transitions/test-live",
+      "methods": [
+        "POST"
+      ],
+      "name": "run_live_transition_test",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/triggers",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_triggers",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/triggers/active",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_active_trigger",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/triggers/check",
+      "methods": [
+        "POST"
+      ],
+      "name": "check_triggers",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/triggers/clear",
+      "methods": [
+        "POST"
+      ],
+      "name": "clear_triggers",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/triggers/{trigger_id}/dismiss",
+      "methods": [
+        "POST"
+      ],
+      "name": "dismiss_trigger",
+      "kind": "APIRoute"
+    },
+    {
+      "path": "/version",
+      "methods": [
+        "GET"
+      ],
+      "name": "version",
+      "kind": "APIRoute"
+    }
+  ]
+}

--- a/tests/test_e2e_spec_reachability.py
+++ b/tests/test_e2e_spec_reachability.py
@@ -1,0 +1,264 @@
+"""Every Playwright spec must actually be run by some workflow (issue #1737).
+
+A test job that never runs is worse than no job at all: it reads as green
+coverage on the PR page while asserting nothing. This repo has hit that twice
+--- all four E2E jobs were gated on ``pull_request`` so the merge queue skipped
+them 28/28 (#1771), and ``ingress.spec.ts`` sat behind a ``RUN_INGRESS_TESTS``
+flag with no job to set it. Both were found by hand, months later.
+
+These tests close the loop mechanically. They read
+``web/playwright.config.ts`` for the env-gated ignore lists and every
+``npx playwright test`` invocation in ``.github/workflows/``, then assert:
+
+1. every spec in ``web/tests/`` is executed by at least one invocation;
+2. every ``RUN_*`` gate the config defines is actually set by some job;
+3. every spec is reachable by an invocation that can run on ``merge_group``,
+   so the queue --- the last gate before ``main`` --- really tests it.
+
+The parsing is deliberately shallow (regex over the TS config, YAML over the
+workflows). If either file changes shape enough to break the parse, these
+tests fail loudly rather than passing on an empty result set --- see
+``test_parsers_found_something``.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import re
+from pathlib import Path
+from typing import Any, NamedTuple
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+SPEC_DIR = REPO_ROOT / "web" / "tests"
+PLAYWRIGHT_CONFIG = REPO_ROOT / "web" / "playwright.config.ts"
+
+# Specs that are intentionally not run by any CI workflow, with the reason.
+# This allowlist is asserted to be *minimal*: an entry that has since become
+# reachable fails the test, so it can't rot into a blanket exemption.
+INTENTIONALLY_UNREACHABLE = {
+    "generate-screenshots.spec.ts": "Authoring tool — regenerates documentation screenshots on demand, not a test.",
+    "draw-mode-demo.spec.ts": "Authoring tool — records the draw-mode demo GIF, excluded even locally.",
+}
+
+
+class Invocation(NamedTuple):
+    """One ``npx playwright test`` step found in a workflow."""
+
+    workflow: str
+    job: str
+    step: str
+    specs: tuple[str, ...]  # explicit file args; empty means "the whole suite"
+    env: dict[str, str]
+    runs_on_merge_queue: bool
+
+
+# --------------------------------------------------------------------------
+# playwright.config.ts
+# --------------------------------------------------------------------------
+
+
+def _quoted_strings(fragment: str) -> list[str]:
+    return re.findall(r'"([^"]+)"', fragment)
+
+
+def parse_ignore_rules() -> tuple[list[str], dict[str, list[str]], list[str]]:
+    """Return (always-in-CI ignores, {env gate: globs}, always ignores).
+
+    * *always-in-CI ignores* come from the initial ``const ciIgnore = [...]``.
+    * *env gates* are the ``if (!process.env.X) { ciIgnore.push(...) }`` blocks:
+      those globs are ignored unless ``X`` is set.
+    * *always ignores* are the literal globs in ``testIgnore``, applied
+      regardless of ``CI``.
+    """
+    source = PLAYWRIGHT_CONFIG.read_text(encoding="utf-8")
+
+    base_match = re.search(r"const ciIgnore\s*=\s*\[([^\]]*)\]", source)
+    base = _quoted_strings(base_match.group(1)) if base_match else []
+
+    gates: dict[str, list[str]] = {}
+    for env_var, pushed in re.findall(
+        r"if\s*\(!process\.env\.(\w+)\)\s*\{\s*ciIgnore\.push\(([^)]*)\)",
+        source,
+    ):
+        gates.setdefault(env_var, []).extend(_quoted_strings(pushed))
+
+    ignore_match = re.search(r"testIgnore:\s*\[(.*?)\]\s*,", source, re.DOTALL)
+    always = _quoted_strings(ignore_match.group(1)) if ignore_match else []
+
+    return base, gates, always
+
+
+def _matches(spec_path: str, glob: str) -> bool:
+    """Match a repo-relative spec path against a playwright ignore glob."""
+    return fnmatch.fnmatch(spec_path, glob.removeprefix("**/")) or fnmatch.fnmatch(
+        Path(spec_path).name, glob.removeprefix("**/")
+    )
+
+
+# --------------------------------------------------------------------------
+# .github/workflows/*.yml
+# --------------------------------------------------------------------------
+
+
+def _admits_merge_group(condition: Any) -> bool:
+    """Whether a job/step ``if:`` can be true for a ``merge_group`` event.
+
+    Conservative on purpose: no condition means it always runs; a condition
+    that mentions ``merge_group`` is assumed to admit it; anything else (say
+    ``github.event_name == 'pull_request'``) is assumed not to. A wrong guess
+    here fails the test rather than passing it silently.
+    """
+    if condition is None:
+        return True
+    return "merge_group" in str(condition)
+
+
+def _spec_args(command: str) -> tuple[str, ...]:
+    """Extract explicit spec-file arguments from a playwright command line."""
+    match = re.search(r"playwright\s+test\b(?P<rest>[^\n]*)", command)
+    if not match:
+        return ()
+    args = []
+    for token in match.group("rest").split():
+        if token.startswith("-"):
+            continue
+        args.append(token)
+    return tuple(args)
+
+
+def collect_invocations() -> list[Invocation]:
+    invocations: list[Invocation] = []
+    for workflow_path in sorted(WORKFLOW_DIR.glob("*.yml")):
+        data = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            continue
+        # PyYAML parses the bare key `on:` as the boolean True.
+        triggers = data.get("on", data.get(True)) or {}
+        workflow_has_merge_group = "merge_group" in (triggers if isinstance(triggers, dict) else {triggers: None})
+
+        for job_name, job in (data.get("jobs") or {}).items():
+            if not isinstance(job, dict):
+                continue
+            job_admits = workflow_has_merge_group and _admits_merge_group(job.get("if"))
+            job_env = {str(k): str(v) for k, v in (job.get("env") or {}).items()}
+
+            for step in job.get("steps") or []:
+                command = str(step.get("run") or "")
+                if "playwright test" not in command:
+                    continue
+                env = dict(job_env)
+                env.update({str(k): str(v) for k, v in (step.get("env") or {}).items()})
+                invocations.append(
+                    Invocation(
+                        workflow=workflow_path.name,
+                        job=str(job_name),
+                        step=str(step.get("name") or command),
+                        specs=_spec_args(command),
+                        env=env,
+                        runs_on_merge_queue=job_admits and _admits_merge_group(step.get("if")),
+                    )
+                )
+    return invocations
+
+
+# --------------------------------------------------------------------------
+# reachability
+# --------------------------------------------------------------------------
+
+
+def _ignored_globs_for(invocation: Invocation) -> list[str]:
+    base, gates, always = parse_ignore_rules()
+    ignored = list(always)
+    # Workflow steps always run with CI set, so the CI-only list applies.
+    ignored += base
+    for env_var, globs in gates.items():
+        if not invocation.env.get(env_var):
+            ignored += globs
+    return ignored
+
+
+def _runs(spec_rel: str, invocation: Invocation) -> bool:
+    if any(_matches(spec_rel, glob) for glob in _ignored_globs_for(invocation)):
+        return False
+    if not invocation.specs:
+        return True  # whole-suite run
+    # Bare playwright args are path substring filters.
+    return any(arg in spec_rel for arg in invocation.specs)
+
+
+def all_specs() -> list[str]:
+    return sorted(str(p.relative_to(SPEC_DIR)) for p in SPEC_DIR.rglob("*.spec.ts"))
+
+
+def _reachability_map() -> dict[str, list[Invocation]]:
+    invocations = collect_invocations()
+    return {spec: [inv for inv in invocations if _runs(spec, inv)] for spec in all_specs()}
+
+
+# --------------------------------------------------------------------------
+# tests
+# --------------------------------------------------------------------------
+
+
+def test_parsers_found_something():
+    """A broken parse must fail here, not silently pass every other test."""
+    base, gates, always = parse_ignore_rules()
+    assert gates, f"No `if (!process.env.X) ciIgnore.push(...)` gates parsed from {PLAYWRIGHT_CONFIG}"
+    assert base or always, f"No testIgnore globs parsed from {PLAYWRIGHT_CONFIG}"
+    assert len(all_specs()) > 40, "Spec discovery found suspiciously few files"
+    assert len(collect_invocations()) >= 4, "Found fewer `playwright test` workflow steps than the four E2E jobs"
+
+
+def test_every_spec_is_run_by_some_workflow():
+    """No spec sits in the tree unreachable by every workflow."""
+    unreachable = sorted(spec for spec, invs in _reachability_map().items() if not invs)
+    unexpected = [spec for spec in unreachable if Path(spec).name not in INTENTIONALLY_UNREACHABLE]
+    assert not unexpected, (
+        "These specs are not executed by any workflow — they read as coverage but assert nothing:\n  "
+        + "\n  ".join(unexpected)
+        + "\n\nEither wire them into a CI job or delete them. If a spec is an authoring "
+        "tool rather than a test, add it to INTENTIONALLY_UNREACHABLE with a reason."
+    )
+
+
+def test_unreachable_allowlist_is_minimal():
+    """An allowlisted spec that CI now runs must leave the allowlist."""
+    reachable = {Path(spec).name for spec, invs in _reachability_map().items() if invs}
+    stale = sorted(reachable & set(INTENTIONALLY_UNREACHABLE))
+    assert not stale, (
+        "These specs are listed in INTENTIONALLY_UNREACHABLE but a workflow does run them; "
+        f"drop them from the allowlist: {stale}"
+    )
+
+
+def test_every_env_gate_is_set_by_some_job():
+    """Every `RUN_*` opt-in in playwright.config.ts has a job that sets it."""
+    _, gates, _ = parse_ignore_rules()
+    invocations = collect_invocations()
+    orphans = sorted(env_var for env_var in gates if not any(inv.env.get(env_var) for inv in invocations))
+    assert not orphans, (
+        "These env gates hide specs from every CI run because no workflow sets them: "
+        f"{orphans}. Wire a job that sets the flag, or remove the gate and the specs behind it."
+    )
+
+
+def test_every_spec_is_gated_on_the_merge_queue():
+    """The queue is the last gate before main; it must run every spec.
+
+    A PR-only E2E job tests the PR head, never the merged result — two
+    individually-green PRs can then land a semantic conflict that surfaces as
+    an "unrelated" failure on whatever branch rebases next. This is the
+    regression guard for #1771 and #1737.
+    """
+    gaps = sorted(
+        spec for spec, invs in _reachability_map().items() if invs and not any(inv.runs_on_merge_queue for inv in invs)
+    )
+    assert not gaps, (
+        "These specs run on pull_request but not in the merge queue, so the queue "
+        "cannot gate on them:\n  "
+        + "\n  ".join(gaps)
+        + "\n\nAdd `merge_group` to the owning workflow's `on:` and to the job's `if:`."
+    )

--- a/tests/test_route_inventory.py
+++ b/tests/test_route_inventory.py
@@ -1,0 +1,181 @@
+"""Golden test over the FastAPI route inventory (issue #1731).
+
+``src/api_server.py`` declares ~200 routes inline. Epic #1730 extracts them
+into routers, and the classic failure mode of that refactor is a route that
+silently changes path, loses a method, or disappears entirely — nothing in
+the suite notices, because every *other* test only asserts on the endpoints
+it happens to exercise.
+
+This test snapshots the whole route table (path + sorted methods + endpoint
+name) into ``tests/golden/api_routes.json`` and fails on any drift. Adding a
+route is not forbidden — it just has to be a deliberate, reviewable change to
+the golden file rather than an invisible side effect of a refactor.
+
+Regenerating the golden file
+----------------------------
+Only ever do this when the route change is intentional, and read the diff::
+
+    docker compose -f docker-compose.dev.yml exec fiestaboard \\
+        env UPDATE_ROUTE_INVENTORY=1 pytest tests/test_route_inventory.py
+
+Then ``git diff tests/golden/api_routes.json`` and confirm every line is a
+change you meant to make.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from src.api_server import app
+
+GOLDEN_PATH = Path(__file__).parent / "golden" / "api_routes.json"
+
+REGENERATE_HINT = (
+    "If this change is intentional, regenerate the golden file with:\n"
+    "    UPDATE_ROUTE_INVENTORY=1 pytest tests/test_route_inventory.py\n"
+    "then review `git diff tests/golden/api_routes.json` line by line."
+)
+
+
+def _describe(route: Any, prefix: str) -> dict[str, Any]:
+    """Render a single route as a stable, JSON-serializable record."""
+    return {
+        "path": prefix + getattr(route, "path", ""),
+        "methods": sorted(getattr(route, "methods", None) or []),
+        "name": getattr(route, "name", None),
+        "kind": type(route).__name__,
+    }
+
+
+def _walk(routes: Any, prefix: str = "") -> list[dict[str, Any]]:
+    """Flatten a Starlette/FastAPI route list into inventory records.
+
+    Two node types need special handling:
+
+    * ``Mount`` wraps a foreign ASGI app (the MCP server). Its internal
+      routes belong to that app, not to us, so the mount point is recorded
+      as a single entry and not descended into.
+    * FastAPI >= 0.130 wraps ``include_router()`` results in an internal
+      ``_IncludedRouter`` node that exposes no ``path``. The real routes
+      hang off ``include_context``, so recurse through that with the
+      router's prefix applied.
+    """
+    collected: list[dict[str, Any]] = []
+    for route in routes:
+        include_context = getattr(route, "include_context", None)
+        if include_context is not None:
+            collected.extend(
+                _walk(
+                    include_context.included_router.routes,
+                    prefix + (include_context.prefix or ""),
+                )
+            )
+            continue
+        collected.append(_describe(route, prefix))
+    return collected
+
+
+def build_route_inventory() -> list[dict[str, Any]]:
+    """Return the app's full route table, sorted deterministically."""
+    records = _walk(app.routes)
+    return sorted(records, key=lambda r: (r["path"], r["methods"], r["name"] or "", r["kind"]))
+
+
+def _key(record: dict[str, Any]) -> str:
+    """Identity of a route for diffing: what it answers, not how it's named."""
+    methods = ",".join(record["methods"]) or "-"
+    return f"{record['path']} [{methods}]"
+
+
+def _load_golden() -> list[dict[str, Any]]:
+    with GOLDEN_PATH.open(encoding="utf-8") as fh:
+        return json.load(fh)["routes"]
+
+
+def _write_golden(routes: list[dict[str, Any]]) -> None:
+    GOLDEN_PATH.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "_comment": (
+            "Golden snapshot of src.api_server.app route table (issue #1731). "
+            "Do not hand-edit: regenerate with "
+            "`UPDATE_ROUTE_INVENTORY=1 pytest tests/test_route_inventory.py` "
+            "and review the diff."
+        ),
+        "routes": routes,
+    }
+    with GOLDEN_PATH.open("w", encoding="utf-8") as fh:
+        json.dump(payload, fh, indent=2, ensure_ascii=False)
+        fh.write("\n")
+
+
+def _format_drift(current: list[dict[str, Any]], golden: list[dict[str, Any]]) -> str:
+    current_by_key = {_key(r): r for r in current}
+    golden_by_key = {_key(r): r for r in golden}
+
+    added = sorted(set(current_by_key) - set(golden_by_key))
+    removed = sorted(set(golden_by_key) - set(current_by_key))
+    renamed = sorted(
+        key
+        for key in set(current_by_key) & set(golden_by_key)
+        if current_by_key[key]["name"] != golden_by_key[key]["name"]
+        or current_by_key[key]["kind"] != golden_by_key[key]["kind"]
+    )
+
+    lines = ["Route inventory drifted from tests/golden/api_routes.json.", ""]
+    if added:
+        lines.append(f"ADDED ({len(added)}) — routes the app serves but the golden file doesn't list:")
+        lines.extend(f"  + {key} -> {current_by_key[key]['name']}" for key in added)
+        lines.append("")
+    if removed:
+        lines.append(f"REMOVED ({len(removed)}) — routes the golden file lists but the app no longer serves:")
+        lines.extend(f"  - {key} -> {golden_by_key[key]['name']}" for key in removed)
+        lines.append("")
+    if renamed:
+        lines.append(f"CHANGED ({len(renamed)}) — same path+methods, different endpoint name or route class:")
+        for key in renamed:
+            before, after = golden_by_key[key], current_by_key[key]
+            lines.append(f"  ~ {key}: {before['name']} ({before['kind']}) -> {after['name']} ({after['kind']})")
+        lines.append("")
+    lines.append(REGENERATE_HINT)
+    return "\n".join(lines)
+
+
+def test_route_inventory_matches_golden():
+    """The live route table equals the reviewed golden snapshot."""
+    current = build_route_inventory()
+
+    if os.environ.get("UPDATE_ROUTE_INVENTORY"):
+        _write_golden(current)
+        return
+
+    golden = _load_golden()
+    assert current == golden, _format_drift(current, golden)
+
+
+def test_route_inventory_is_not_trivially_empty():
+    """Guard the guard: an import failure must not read as 'no drift'.
+
+    If ``app`` ever came back with a handful of routes (a broken import, a
+    conditional mount that silently no-ops), the comparison above would
+    still be a meaningful assertion — but a golden file regenerated in that
+    state would lock in the damage. Assert the table is the size we expect
+    a real app to have.
+    """
+    assert len(build_route_inventory()) > 150
+
+
+def test_route_inventory_has_no_duplicate_path_method_pairs():
+    """No two routes claim the same path+method — the second is unreachable."""
+    seen: dict[str, str] = {}
+    duplicates: list[str] = []
+    for record in build_route_inventory():
+        for method in record["methods"]:
+            key = f"{method} {record['path']}"
+            if key in seen:
+                duplicates.append(f"{key}: {seen[key]} then {record['name']}")
+            else:
+                seen[key] = record["name"] or "<unnamed>"
+    assert not duplicates, "Shadowed routes (only the first is ever reached):\n  " + "\n  ".join(duplicates)

--- a/web/tests/COVERAGE.md
+++ b/web/tests/COVERAGE.md
@@ -1,126 +1,158 @@
 # Test Coverage
 
-This document describes the full test suite for the FiestaBoard web layer,
-covering both Playwright E2E tests and Vitest unit tests.
+This document describes the test suite for the FiestaBoard web layer, covering
+both Playwright E2E tests and Vitest unit tests.
+
+> **Counts refreshed 2026-09-03** — 74 Playwright spec files (48 top-level,
+> 26 under `regression/`), 134 Vitest files. Counts drift; the invariants
+> below are enforced by `tests/test_e2e_spec_reachability.py`, which fails CI
+> if any spec is unreachable by every workflow.
 
 ---
 
 ## E2E Tests (Playwright)
 
-Tests exercise the full stack:
+Tests exercise the full stack against the unified container:
 
 ```
-Playwright browser → Next.js UI → FastAPI backend → Mock Vestaboard API
+Playwright browser → nginx → React Router v7 + Vite UI
+                           → FastAPI backend → mock Vestaboard Local/Cloud API
 ```
 
-### Playwright Spec Files (29 files)
+### Which CI job runs which specs
 
-| File                               | Area                      | What's Covered                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| ---------------------------------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ai.spec.ts`                       | AI providers + generation | `/settings/ai` round-trip + api_key masking, `/settings/ai/test` against a mock OpenAI server (happy path + draft override + auth error), `/pages/ai/context` debug payload, `/pages/ai/generate` happy path / disabled / bad JSON / missing template / upstream auth error, Settings → Integrations tab renders AI Settings. Gated behind `RUN_AI_TESTS=1`; runs in the `ai-mcp-e2e-tests` CI job against `integration-tests/mock-llm/server.py`. |
-| `api.spec.ts`                      | Backend API               | Core endpoint contracts: version, config, settings CRUD, pages CRUD, schedules CRUD, plugins, template validation, displays, debug                                                                                                                                                                                                                                                                                                                 |
-| `api-extended.spec.ts`             | Backend API               | Deeper API coverage: full config, board config test, page preview/send/batch, schedule active/validate/default/enable, plugin config/variables, settings transitions/active-page/board, template render, service start/stop                                                                                                                                                                                                                        |
-| `auth.spec.ts`                     | Authentication            | First-run setup form, sign-in form (valid + invalid creds), remember-me cookie behavior, logout, protected-route 401 / 409 setup-required, `/profile` redirect, `redirect=` query param. Gated behind `RUN_AUTH_TESTS=1` because it requires a container booted with `FIESTABOARD_AUTH_ENABLED=true`. Runs in its own CI job (`auth-e2e-tests`); the main e2e job runs with auth disabled.                                                         |
-| `mcp.spec.ts`                      | MCP HTTP                  | Smoke that `/api/mcp/` is mounted, MCP Streamable-HTTP initialize handshake, `tools/list` returns the expected FiestaBoard tool catalog, `tools/call list_pages` returns valid JSON, unknown-tool error path. Catches "MCP broke at the HTTP boundary" regressions that `tests/test_mcp_server.py` can't see. Gated behind `RUN_AI_TESTS=1`.                                                                                                       |
-| `board-discovery-offline.spec.ts`  | Board discovery & offline | Board scan/discovery endpoint, connection test (online/offline/missing creds), per-board schedule active page resolution, per-board schedule enable/disable independence, Note template rendering dimensions, offline board send handling, multi-board state independence                                                                                                                                                                          |
-| `calendar-alignment.spec.ts`       | Schedule UI               | Time gutter label alignment with hour grid, desktop + mobile viewports                                                                                                                                                                                                                                                                                                                                                                             |
-| `dashboard.spec.ts`                | Dashboard                 | Board display visible, active page name, manual mode badge                                                                                                                                                                                                                                                                                                                                                                                         |
-| `error-handling.spec.ts`           | Error handling            | 404 for missing page/schedule, invalid POST/template data, API error states, invalid routes, graceful degradation                                                                                                                                                                                                                                                                                                                                  |
-| `generate-screenshots.spec.ts`     | Docs                      | Screenshot generation for documentation (skipped in CI)                                                                                                                                                                                                                                                                                                                                                                                            |
-| `home-assistant-controls.spec.ts`  | HA integration            | HA REST API round-trips: schedule switch, active page select, refresh display/blank board buttons, send message, refresh interval, sensor state reads, transition style select                                                                                                                                                                                                                                                                     |
-| `home-assistant-discovery.spec.ts` | HA integration            | FiestaBoard entities discoverable in Home Assistant via MQTT                                                                                                                                                                                                                                                                                                                                                                                       |
-| `integration.spec.ts`              | Core flows                | Setup wizard, navigation, page creation, schedule creation                                                                                                                                                                                                                                                                                                                                                                                         |
-| `integrations.spec.ts`             | Plugin UI                 | Installed + Marketplace tabs, plugin cards, "Add from Git" dialog (open/URL entry/cancel/disabled state validation)                                                                                                                                                                                                                                                                                                                                |
-| `localization.spec.ts`             | i18n                      | Default English, switching to Spanish/French/German/Japanese, locale persistence across navigation + reload, mobile menu                                                                                                                                                                                                                                                                                                                           |
-| `mock-board.spec.ts`               | Mock server               | Accepts valid 6×22 and 3×15 arrays, rejects codes >71, validates dimensions                                                                                                                                                                                                                                                                                                                                                                        |
-| `multi-board.spec.ts`              | Multi-board               | Board card display, board CRUD (add/rename/type/color/toggle/delete), wizard board type/color picker, cross-feature config                                                                                                                                                                                                                                                                                                                         |
-| `multi-board-schedule.spec.ts`     | Multi-board scheduling    | Single-board schedule page, two-board board selector, schedule mode toggle, per-board CRUD, filtering by board_id                                                                                                                                                                                                                                                                                                                                  |
-| `multi-board-output.spec.ts`       | Multi-board output        | Two boards with real mock connections (ports 7000/7001): manual send + scheduled send land on the right board's hardware, cross-board leak checks, per-board pause isolation, per-board schedule list consistency, board-deletion consistency, board-selector UI clarity (name shown, view fully swaps, per-board toggle). Known gaps as fixme: board 2 driving (epic #1241), client reinit on board mutations                                     |
-| `multi-board-mixed.spec.ts`        | Mixed-device fleet        | Flagship (6×22) + Note (3×15) boards side by side: one refresh delivers correctly-sized content to each device's hardware (dimension + token asserts, no cross-device leakage), and the board selector switches cleanly between device types on /schedule                                                                                                                                                                                          |
-| `note-array-output.spec.ts`        | Note-array output         | Note arrays at the Cloud-API hardware layer: solo array installs (scheduled + manual send), every geometry class (all five presets, 1×1, 8-wide/8-tall/8×8 extremes, a non-preset size) validated against a size-strict mock, flagship+array mixed fleet driven in one refresh, array pause isolation                                                                                                                                              |
-| `page-device-switch.spec.ts`       | Page creator              | Board-size switching in the editor: a page started from the Flagship tab can be switched to Note (3×15) before saving and persists device_type=note; existing pages offer no switcher (size locked once saved)                                                                                                                                                                                                                                     |
-| `navigation.spec.ts`               | Navigation                | Mobile hamburger menu, sidebar links, theme toggle, version display, sidebar gradient                                                                                                                                                                                                                                                                                                                                                              |
-| `note-pages.spec.ts`               | Note pages                | Note (3×15) API CRUD, UI creation, 3-line editor, preview dimensions, pages list tabs, send to board with encoding verification                                                                                                                                                                                                                                                                                                                    |
-| `note-multiboard-extended.spec.ts` | Note & multi-board        | Device type mismatch (Flagship↔Note), Note 3×15 grid enforcement, one board offline handling, per-board schedule isolation, multi-board UI switching, Note display rendering                                                                                                                                                                                                                                                                       |
-| `page-builder.spec.ts`             | Page builder              | Create/edit pages through the visual page builder UI                                                                                                                                                                                                                                                                                                                                                                                               |
-| `pages-crud.spec.ts`               | Page management           | Create, edit, delete pages via UI                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| `plugin-detail.spec.ts`            | Plugin detail             | `/integrations/[pluginId]` route: navigation from Marketplace, plugin name/category visible, Install/Installed button, Back to Marketplace link, README section present, unknown plugin error state, GitHub link                                                                                                                                                                                                                                   |
-| `plugin-management.spec.ts`        | Plugin management         | Plugin listing by category, enable/disable via API+UI, config sheet open, API key password field, status badge                                                                                                                                                                                                                                                                                                                                     |
-| `schedule-crud.spec.ts`            | Schedules                 | Create with page/time/day selection, delete via UI                                                                                                                                                                                                                                                                                                                                                                                                 |
-| `schedule-management.spec.ts`      | Schedules                 | Toggle, form interactions, validation, calendar/list view modes, day patterns                                                                                                                                                                                                                                                                                                                                                                      |
-| `settings.spec.ts`                 | Settings                  | Settings page loads with all sections (General, Boards, Advanced/Debug/Wizard), navigate to integrations                                                                                                                                                                                                                                                                                                                                           |
-| `settings-full.spec.ts`            | Settings                  | Timezone picker, refresh interval, output target, board type, service control, silence schedule, wizard rerun, debug tools, system info                                                                                                                                                                                                                                                                                                            |
+This is the part that matters most: a spec no job runs reads as coverage while
+asserting nothing. Every one of these jobs runs on **`pull_request` and
+`merge_group`**, so the merge queue gates on the merged result, not just the PR
+head.
 
-> Note: `generate-screenshots.spec.ts` is excluded from CI runs via playwright config.
+| Job                                                     | Specs                                              | Why it's separate                                                                                |
+| ------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `e2e-tests` (ci.yml)                                    | whole suite except the opt-in specs below           | 4 workers, 4 isolated backends                                                                     |
+| `ai-mcp-e2e-tests` (ci.yml)                             | `ai.spec.ts`, `mcp.spec.ts` — `RUN_AI_TESTS=1`      | Needs the `mock-llm` sidecar; `ai.spec.ts` writes global `/settings/ai` state                      |
+| `auth-e2e-tests` (ci.yml)                               | `auth.spec.ts` — `RUN_AUTH_TESTS=1`                 | Needs a container booted with `FIESTABOARD_AUTH_ENABLED=true`                                      |
+| `ingress-e2e-tests` (ci.yml)                            | `ingress.spec.ts` — `RUN_INGRESS_TESTS=1`           | Needs the HA Ingress nginx simulator in front of a production bundle                               |
+| `integration-tests` (integration-tests.yml)             | `integration.spec.ts` on PRs, whole suite in the queue | Smoke subset early, full suite as the last gate                                                 |
+| _not run in CI_                                         | `generate-screenshots.spec.ts`, `draw-mode-demo.spec.ts` | Authoring tools that produce docs assets, not tests — allowlisted in the reachability guard |
 
----
+The opt-in `RUN_*` flags live in `web/playwright.config.ts`. Adding a new flag
+without a job that sets it fails `tests/test_e2e_spec_reachability.py`.
 
-### App Routes Covered by E2E Tests
+### Core flows and API
 
-| Route                      | Spec File(s)                                                                         |
-| -------------------------- | ------------------------------------------------------------------------------------ |
-| `/` (Dashboard)            | `dashboard.spec.ts`, `integration.spec.ts`                                           |
-| `/pages`                   | `pages-crud.spec.ts`, `integration.spec.ts`                                          |
-| `/pages/new`               | `pages-crud.spec.ts`, `page-builder.spec.ts`                                         |
-| `/pages/edit/[id]`         | `pages-crud.spec.ts`, `page-builder.spec.ts`                                         |
-| `/carousels`               | `api.spec.ts` (API only)                                                             |
-| `/schedule`                | `schedule-crud.spec.ts`, `schedule-management.spec.ts`, `calendar-alignment.spec.ts` |
-| `/integrations`            | `integrations.spec.ts`, `plugin-management.spec.ts`                                  |
-| `/integrations/[pluginId]` | `plugin-detail.spec.ts`                                                              |
-| `/settings`                | `settings.spec.ts`, `settings-full.spec.ts`                                          |
-| `/debug`                   | `settings-full.spec.ts` (debug tools section)                                        |
-| `/login`                   | `auth.spec.ts` (setup + sign-in forms)                                               |
-| `/profile`                 | `auth.spec.ts` (redirects to `/settings`)                                            |
+| File                        | Area                | What's covered                                                                                          |
+| --------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------- |
+| `integration.spec.ts`       | Core flows          | Infrastructure health, setup wizard, navigation, page and schedule management                            |
+| `api.spec.ts`               | Backend API         | Version/config, settings, pages, schedules, plugins, templates, displays, debug                          |
+| `api-extended.spec.ts`      | Backend API         | Deeper config/pages/schedules/plugins/settings/templates coverage                                        |
+| `navigation.spec.ts`        | Navigation          | Mobile hamburger menu, sidebar links, theme toggle, version display                                      |
+| `dashboard.spec.ts`         | Dashboard           | Board display, active page name, manual-mode badge                                                       |
+| `a11y.spec.ts`              | Accessibility       | axe-core scans of the main routes                                                                        |
+| `localization.spec.ts`      | i18n                | Locale switching, persistence across navigation and reload, mobile menu                                  |
+| `error-handling.spec.ts`    | Error handling      | 404s, invalid POST/template data, API error states, graceful degradation                                 |
+| `error-recovery.spec.ts`    | Error recovery      | Board unreachable, config reset, invalid data, network simulation                                        |
+| `mobile-critical-flows.spec.ts` | Mobile          | Navigation, dashboard, pages, integrations, schedule at phone viewports                                  |
+
+### Pages, schedules and the editor
+
+| File                          | Area           | What's covered                                                                             |
+| ----------------------------- | -------------- | -------------------------------------------------------------------------------------------- |
+| `pages-crud.spec.ts`          | Pages          | Create, edit, delete via the UI                                                               |
+| `page-builder.spec.ts`        | Page builder   | Visual builder create/edit, Sync from Board                                                   |
+| `page-device-switch.spec.ts`  | Page creator   | Flagship → Note switching before save; size locked once saved                                 |
+| `draw-mode.spec.ts`           | Page builder   | Pencil draw mode strokes and template round-trip                                              |
+| `transition-pickers.spec.ts`  | Transitions    | Transition picker UI on pages and settings                                                    |
+| `schedule-crud.spec.ts`       | Schedules      | Create with page/time/day selection, delete                                                   |
+| `schedule-management.spec.ts` | Schedules      | Toggle, form interactions, validation, calendar/list views, day patterns                      |
+| `schedule-midnight.spec.ts`   | Schedules      | Midnight-rollover boundary behavior                                                           |
+| `calendar-alignment.spec.ts`  | Schedule UI    | Time-gutter alignment with the hour grid, desktop and mobile                                  |
+
+### Boards, devices and output
+
+| File                               | Area                   | What's covered                                                                                                                                                                     |
+| ---------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `multi-board.spec.ts`              | Multi-board            | Board card display, board CRUD, wizard board type/color picker, cross-feature config                                                                                                   |
+| `multi-board-schedule.spec.ts`     | Multi-board scheduling | Board selector, schedule mode toggle, per-board CRUD, filtering by `board_id`                                                                                                          |
+| `multi-board-output.spec.ts`       | Multi-board output     | Two boards on real mock connections (ports 7000/7001): manual and scheduled sends land on the right hardware, cross-board leak checks, per-board pause and schedule-mode isolation      |
+| `multi-board-mixed.spec.ts`        | Mixed-device fleet     | Flagship (6×22) + Note (3×15) in one refresh, correctly sized per device, no cross-device leakage                                                                                       |
+| `board-switch-ux.spec.ts`          | Board selector         | Switching boards fully swaps the view                                                                                                                                                  |
+| `board-send-path.spec.ts`          | Send path              | End-to-end send path from UI action to board hardware                                                                                                                                  |
+| `board-discovery-offline.spec.ts`  | Discovery & offline    | Board scan, connection test online/offline/missing creds, per-board active-page resolution, offline send handling                                                                       |
+| `mock-board.spec.ts`               | Mock server            | Character-code validation, text-mode encoding, mock state                                                                                                                              |
+| `code62-glyph.spec.ts`             | Character code 62      | Per-board heart/degree glyph setting, including the setup wizard                                                                                                                       |
+| `note-pages.spec.ts`               | Note pages             | Note (3×15) API CRUD, UI creation, 3-line editor, preview dimensions, send with encoding verification, heart/degree handling                                                            |
+| `note-multiboard-extended.spec.ts` | Note & multi-board     | Device-type mismatch, 3×15 grid enforcement, one board offline, per-board schedule isolation                                                                                            |
+| `note-array-output.spec.ts`        | Note-array output      | Cloud-API hardware layer: solo array installs, every geometry class, mixed fleet in one refresh, array pause isolation                                                                  |
+| `note-array-local.spec.ts`         | Note-array output      | Local-API per-tile fan-out for arrays                                                                                                                                                  |
+| `note-array-add-ux.spec.ts`        | Note arrays            | Adding a Note Array board through the UI                                                                                                                                               |
+| `panel.spec.ts`                    | FiestaPanel            | The public read-only `/panel/{id}` viewer surface                                                                                                                                      |
+
+### Plugins and integrations
+
+| File                            | Area                | What's covered                                                                                        |
+| ------------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------- |
+| `integrations.spec.ts`          | Plugin UI           | Installed + Marketplace tabs, plugin cards, Add-from-Git dialog, Check for Updates                       |
+| `plugin-management.spec.ts`     | Plugin management   | Listing by category, enable/disable via API + UI, config sheet, API-key field, status badge               |
+| `plugin-detail.spec.ts`         | Plugin detail       | `/integrations/[pluginId]` navigation, metadata, install button, README, unknown-plugin error state       |
+| `plugin-board-previews.spec.ts` | Plugin previews     | Manifest `teaser`/`previews` rendering as live split-flap boards                                         |
+| `home-assistant-controls.spec.ts` | HA integration    | HA REST round-trips: schedule switch, active page, refresh/blank, send message, sensors, transition style  |
+| `home-assistant-discovery.spec.ts` | HA integration   | FiestaBoard entities discoverable in Home Assistant via MQTT                                             |
+
+### Settings, auth, AI and infrastructure
+
+| File                   | Area          | What's covered                                                                                                                       |
+| ---------------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `settings.spec.ts`     | Settings      | Settings page loads with all sections; navigation to integrations                                                                       |
+| `settings-full.spec.ts`| Settings      | Timezone picker, refresh interval, output target, board type, service control, silence schedule, wizard rerun, debug tools, system info  |
+| `auth.spec.ts`         | Auth          | First-run setup, sign-in valid/invalid, remember-me cookie, logout, 401/409 protected routes, `redirect=` param. `RUN_AUTH_TESTS=1`      |
+| `ai.spec.ts`           | AI            | `/settings/ai` round-trip + key masking, `/settings/ai/test`, `/pages/ai/context`, `/pages/ai/generate` happy and error paths. `RUN_AI_TESTS=1` |
+| `mcp.spec.ts`          | MCP HTTP      | `/api/mcp/` mount smoke, Streamable-HTTP initialize handshake, `tools/list` catalog, `tools/call list_pages`, prompts, resources, unknown-tool error. `RUN_AI_TESTS=1` |
+| `ingress.spec.ts`      | HA Ingress    | The production bundle behind the HA Ingress path-rewrite proxy. `RUN_INGRESS_TESTS=1`                                                    |
+
+### `regression/` — UX-tree gap suite
+
+26 specs generated from `.claude/ux-tree.json` and then filled in with real
+assertions. They are named for the UX node they cover
+(`regression: pages.edit`, `regression: settings.hardware`, …) and run in the
+main `e2e-tests` job alongside everything else:
+
+`board-preview-fit`, `collections`, `dashboard`, `debug`,
+`integrations-installed`, `integrations-marketplace-detail`,
+`integrations-plugin-config`, `login`, `multi-board-e2e`, `note-arrays`,
+`offline`, `pages-edit`, `pages-import-dialog`, `pages-list`, `pages-new`,
+`picks`, `schedule-calendar`, `schedule-delete-confirm`, `schedule-form`,
+`schedule-list`, `schedule-toolbar`, `settings-advanced`,
+`settings-behavior-integrations`, `settings-general-account`,
+`settings-hardware-network`, `settings-system`.
+
+A handful of individual cases are still `test.fixme` where the UI affordance
+does not exist yet (for example a Factory Reset card in `settings-system`).
+Grep for `test.fixme` for the current list — that grep is the source of truth,
+not this document.
+
+### Authoring tools (not tests)
+
+| File                           | What it does                                                     |
+| ------------------------------ | ------------------------------------------------------------------ |
+| `generate-screenshots.spec.ts` | Regenerates documentation screenshots on demand                    |
+| `draw-mode-demo.spec.ts`       | Records the draw-mode demo asset; excluded even in local runs      |
 
 ---
 
 ## Unit Tests (Vitest)
 
-Unit tests run in Node with jsdom + MSW mocks for API calls.
+Unit tests run in Node with jsdom + MSW mocks for API calls. There are 134
+files under `web/src/__tests__/`. An exhaustive table here rotted within a
+release and is not worth maintaining by hand — list them with:
 
-### Vitest Test Files
+```bash
+ls web/src/__tests__
+```
 
-| File                                      | What's Covered                                                                                                                  |
-| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `api.test.ts`                             | `lib/api.ts` function contracts (rotation, page, settings API calls)                                                            |
-| `api-extended.test.ts`                    | Extended `lib/api.ts` coverage: plugin API, schedule API, carousel API                                                          |
-| `active-page-display.test.tsx`            | `ActivePageDisplay` component states (loading, active page, no page)                                                            |
-| `board-colors-extended.test.ts`           | `lib/board-colors.ts` — extended color mapping edge cases                                                                       |
-| `board-display-colors.test.tsx`           | Board display component color rendering                                                                                         |
-| `board-display-transition.test.tsx`       | Board display component transition logic                                                                                        |
-| `carousel-integration.test.tsx`           | Carousel integration component                                                                                                  |
-| `carousels.test.ts`                       | `lib/carousels` utility functions                                                                                               |
-| `components.test.tsx`                     | Miscellaneous UI components                                                                                                     |
-| `general-settings.test.tsx`               | `GeneralSettings` component                                                                                                     |
-| `general-settings-extended.test.tsx`      | `GeneralSettings` extended coverage                                                                                             |
-| `github.test.ts`                          | `lib/github.ts` — GitHub raw/README helpers (`fetchPluginReadme`, `rewriteMarkdownImageUrls`, `rewriteMarkdownRepoLinks`, etc.) |
-| `home-page-banner.test.tsx`               | Home page banner component                                                                                                      |
-| `hooks.test.ts`                           | Custom React hooks (useStatus, useConfig, useActivePage, usePages)                                                              |
-| `hooks-extended.test.ts`                  | Custom React hooks extended coverage                                                                                            |
-| `i18n-config.test.ts`                     | i18n configuration                                                                                                              |
-| `language-selector.test.tsx`              | `LanguageSelector` component                                                                                                    |
-| `live-output.test.tsx`                    | Live output display component                                                                                                   |
-| `mqtt-settings.test.tsx`                  | MQTT settings component                                                                                                         |
-| `navigation-sidebar.test.tsx`             | `NavigationSidebar` active state, mobile menu, links                                                                            |
-| `new-components.test.tsx`                 | Additional UI components                                                                                                        |
-| `page-grid-selector.test.tsx`             | `PageGridSelector` component                                                                                                    |
-| `preview-cache.test.ts`                   | `lib/preview-cache.ts`                                                                                                          |
-| `schedule-calendar.test.ts`               | `lib/schedule-calendar.ts`                                                                                                      |
-| `schedule-calendar-extended.test.ts`      | `lib/schedule-calendar.ts` extended                                                                                             |
-| `schedule-components.test.tsx`            | Schedule form components                                                                                                        |
-| `schedule-entry-form-validation.test.tsx` | Schedule entry form validation                                                                                                  |
-| `service-controls.test.tsx`               | `ServiceControls`: loading state, running/stopped badge                                                                         |
-| `setup-detection.test.ts`                 | `lib/setup-detection.ts`                                                                                                        |
-| `system-update.test.tsx`                  | `SystemUpdate` component                                                                                                        |
-| `theme-toggle.test.tsx`                   | Theme toggle component                                                                                                          |
-| `time-picker.test.tsx`                    | `TimePicker` UI component                                                                                                       |
-| `timezone-picker.test.tsx`                | Timezone picker component                                                                                                       |
-| `timezone-utils.test.ts`                  | Timezone utility functions                                                                                                      |
-| `tiptap-length-calculator.test.ts`        | TipTap editor character length calculation                                                                                      |
-| `tiptap-serialization.test.ts`            | TipTap editor serialization                                                                                                     |
-| `tiptap-template-editor-enter.test.ts`    | TipTap editor Enter key behavior                                                                                                |
-| `transition-settings.test.tsx`            | Transition settings component                                                                                                   |
-| `variable-picker-content.test.tsx`        | Variable picker in TipTap toolbar                                                                                               |
+They cover `lib/` contracts (`api.ts`, `board-colors.ts`, `schedule-calendar.ts`,
+`github.ts`, `preview-cache.ts`, `setup-detection.ts`, timezone and TipTap
+helpers) and component behavior (board display, settings sections, schedule
+forms, navigation sidebar, pickers, theme and locale switching).
 
 ---
 
@@ -129,27 +161,23 @@ Unit tests run in Node with jsdom + MSW mocks for API calls.
 ### E2E Tests (Playwright)
 
 ```bash
-# Start Docker services
+# Start the dev container
 docker compose -f docker-compose.dev.yml up -d
 
-# Run all E2E tests
-cd web && MOCK_BOARD_HOST=fiestaboard-mock-board npm run test:integration
+# Run the suite against it
+cd web && npx playwright test
 
-# Run a specific spec file
+# Run a single spec
 cd web && npx playwright test tests/integrations.spec.ts
 
-# Run with headed browser for debugging
-cd web && npx playwright test --headed
+# Run an opt-in spec (needs the matching sidecar — see the CI job table)
+cd web && RUN_AI_TESTS=1 npx playwright test tests/mcp.spec.ts
 ```
 
 ### Unit Tests (Vitest)
 
 ```bash
-# Run unit tests (inside Docker)
 docker compose -f docker-compose.dev.yml run --rm --profile test web sh -c "npm ci && npm test"
-
-# Run with coverage
-cd web && npm run test:coverage
 ```
 
 ---
@@ -157,11 +185,13 @@ cd web && npm run test:coverage
 ## Architecture
 
 ```
-┌─────────────┐     ┌──────────────────┐     ┌──────────────┐     ┌──────────────┐
-│  Playwright  │────▶│  Next.js UI      │────▶│   FastAPI    │────▶│  Mock Board  │
-│  (browser)   │     │  (host:4420)     │     │  (internal)  │     │ (host:17000) │
-└─────────────┘     └──────────────────┘     └──────────────┘     └──────────────┘
+┌────────────┐    ┌───────────────────────────────┐    ┌──────────────────┐
+│ Playwright │───▶│ FiestaBoard container         │───▶│ mock Vestaboard  │
+│ (browser)  │    │ nginx → RRv7/Vite UI + FastAPI│    │ Local/Cloud API  │
+└────────────┘    └───────────────────────────────┘    └──────────────────┘
 ```
 
-The mock board server simulates the Vestaboard Local API so no real hardware
-is needed for any test in this suite.
+The mock servers (`integration-tests/mock-board`, `integration-tests/mock-cloud`,
+`integration-tests/mock-llm`) simulate the Vestaboard Local API, the Vestaboard
+Cloud API, and an OpenAI-compatible LLM, so no real hardware or API key is
+needed for any test in this suite.

--- a/web/tests/COVERAGE.md
+++ b/web/tests/COVERAGE.md
@@ -26,88 +26,88 @@ asserting nothing. Every one of these jobs runs on **`pull_request` and
 `merge_group`**, so the merge queue gates on the merged result, not just the PR
 head.
 
-| Job                                                     | Specs                                              | Why it's separate                                                                                |
-| ------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| `e2e-tests` (ci.yml)                                    | whole suite except the opt-in specs below           | 4 workers, 4 isolated backends                                                                     |
-| `ai-mcp-e2e-tests` (ci.yml)                             | `ai.spec.ts`, `mcp.spec.ts` — `RUN_AI_TESTS=1`      | Needs the `mock-llm` sidecar; `ai.spec.ts` writes global `/settings/ai` state                      |
-| `auth-e2e-tests` (ci.yml)                               | `auth.spec.ts` — `RUN_AUTH_TESTS=1`                 | Needs a container booted with `FIESTABOARD_AUTH_ENABLED=true`                                      |
-| `ingress-e2e-tests` (ci.yml)                            | `ingress.spec.ts` — `RUN_INGRESS_TESTS=1`           | Needs the HA Ingress nginx simulator in front of a production bundle                               |
-| `integration-tests` (integration-tests.yml)             | `integration.spec.ts` on PRs, whole suite in the queue | Smoke subset early, full suite as the last gate                                                 |
-| _not run in CI_                                         | `generate-screenshots.spec.ts`, `draw-mode-demo.spec.ts` | Authoring tools that produce docs assets, not tests — allowlisted in the reachability guard |
+| Job                                         | Specs                                                    | Why it's separate                                                                           |
+| ------------------------------------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `e2e-tests` (ci.yml)                        | whole suite except the opt-in specs below                | 4 workers, 4 isolated backends                                                              |
+| `ai-mcp-e2e-tests` (ci.yml)                 | `ai.spec.ts`, `mcp.spec.ts` — `RUN_AI_TESTS=1`           | Needs the `mock-llm` sidecar; `ai.spec.ts` writes global `/settings/ai` state               |
+| `auth-e2e-tests` (ci.yml)                   | `auth.spec.ts` — `RUN_AUTH_TESTS=1`                      | Needs a container booted with `FIESTABOARD_AUTH_ENABLED=true`                               |
+| `ingress-e2e-tests` (ci.yml)                | `ingress.spec.ts` — `RUN_INGRESS_TESTS=1`                | Needs the HA Ingress nginx simulator in front of a production bundle                        |
+| `integration-tests` (integration-tests.yml) | `integration.spec.ts` on PRs, whole suite in the queue   | Smoke subset early, full suite as the last gate                                             |
+| _not run in CI_                             | `generate-screenshots.spec.ts`, `draw-mode-demo.spec.ts` | Authoring tools that produce docs assets, not tests — allowlisted in the reachability guard |
 
 The opt-in `RUN_*` flags live in `web/playwright.config.ts`. Adding a new flag
 without a job that sets it fails `tests/test_e2e_spec_reachability.py`.
 
 ### Core flows and API
 
-| File                        | Area                | What's covered                                                                                          |
-| --------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------- |
-| `integration.spec.ts`       | Core flows          | Infrastructure health, setup wizard, navigation, page and schedule management                            |
-| `api.spec.ts`               | Backend API         | Version/config, settings, pages, schedules, plugins, templates, displays, debug                          |
-| `api-extended.spec.ts`      | Backend API         | Deeper config/pages/schedules/plugins/settings/templates coverage                                        |
-| `navigation.spec.ts`        | Navigation          | Mobile hamburger menu, sidebar links, theme toggle, version display                                      |
-| `dashboard.spec.ts`         | Dashboard           | Board display, active page name, manual-mode badge                                                       |
-| `a11y.spec.ts`              | Accessibility       | axe-core scans of the main routes                                                                        |
-| `localization.spec.ts`      | i18n                | Locale switching, persistence across navigation and reload, mobile menu                                  |
-| `error-handling.spec.ts`    | Error handling      | 404s, invalid POST/template data, API error states, graceful degradation                                 |
-| `error-recovery.spec.ts`    | Error recovery      | Board unreachable, config reset, invalid data, network simulation                                        |
-| `mobile-critical-flows.spec.ts` | Mobile          | Navigation, dashboard, pages, integrations, schedule at phone viewports                                  |
+| File                            | Area           | What's covered                                                                  |
+| ------------------------------- | -------------- | ------------------------------------------------------------------------------- |
+| `integration.spec.ts`           | Core flows     | Infrastructure health, setup wizard, navigation, page and schedule management   |
+| `api.spec.ts`                   | Backend API    | Version/config, settings, pages, schedules, plugins, templates, displays, debug |
+| `api-extended.spec.ts`          | Backend API    | Deeper config/pages/schedules/plugins/settings/templates coverage               |
+| `navigation.spec.ts`            | Navigation     | Mobile hamburger menu, sidebar links, theme toggle, version display             |
+| `dashboard.spec.ts`             | Dashboard      | Board display, active page name, manual-mode badge                              |
+| `a11y.spec.ts`                  | Accessibility  | axe-core scans of the main routes                                               |
+| `localization.spec.ts`          | i18n           | Locale switching, persistence across navigation and reload, mobile menu         |
+| `error-handling.spec.ts`        | Error handling | 404s, invalid POST/template data, API error states, graceful degradation        |
+| `error-recovery.spec.ts`        | Error recovery | Board unreachable, config reset, invalid data, network simulation               |
+| `mobile-critical-flows.spec.ts` | Mobile         | Navigation, dashboard, pages, integrations, schedule at phone viewports         |
 
 ### Pages, schedules and the editor
 
-| File                          | Area           | What's covered                                                                             |
-| ----------------------------- | -------------- | -------------------------------------------------------------------------------------------- |
-| `pages-crud.spec.ts`          | Pages          | Create, edit, delete via the UI                                                               |
-| `page-builder.spec.ts`        | Page builder   | Visual builder create/edit, Sync from Board                                                   |
-| `page-device-switch.spec.ts`  | Page creator   | Flagship → Note switching before save; size locked once saved                                 |
-| `draw-mode.spec.ts`           | Page builder   | Pencil draw mode strokes and template round-trip                                              |
-| `transition-pickers.spec.ts`  | Transitions    | Transition picker UI on pages and settings                                                    |
-| `schedule-crud.spec.ts`       | Schedules      | Create with page/time/day selection, delete                                                   |
-| `schedule-management.spec.ts` | Schedules      | Toggle, form interactions, validation, calendar/list views, day patterns                      |
-| `schedule-midnight.spec.ts`   | Schedules      | Midnight-rollover boundary behavior                                                           |
-| `calendar-alignment.spec.ts`  | Schedule UI    | Time-gutter alignment with the hour grid, desktop and mobile                                  |
+| File                          | Area         | What's covered                                                           |
+| ----------------------------- | ------------ | ------------------------------------------------------------------------ |
+| `pages-crud.spec.ts`          | Pages        | Create, edit, delete via the UI                                          |
+| `page-builder.spec.ts`        | Page builder | Visual builder create/edit, Sync from Board                              |
+| `page-device-switch.spec.ts`  | Page creator | Flagship → Note switching before save; size locked once saved            |
+| `draw-mode.spec.ts`           | Page builder | Pencil draw mode strokes and template round-trip                         |
+| `transition-pickers.spec.ts`  | Transitions  | Transition picker UI on pages and settings                               |
+| `schedule-crud.spec.ts`       | Schedules    | Create with page/time/day selection, delete                              |
+| `schedule-management.spec.ts` | Schedules    | Toggle, form interactions, validation, calendar/list views, day patterns |
+| `schedule-midnight.spec.ts`   | Schedules    | Midnight-rollover boundary behavior                                      |
+| `calendar-alignment.spec.ts`  | Schedule UI  | Time-gutter alignment with the hour grid, desktop and mobile             |
 
 ### Boards, devices and output
 
 | File                               | Area                   | What's covered                                                                                                                                                                     |
-| ---------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `multi-board.spec.ts`              | Multi-board            | Board card display, board CRUD, wizard board type/color picker, cross-feature config                                                                                                   |
-| `multi-board-schedule.spec.ts`     | Multi-board scheduling | Board selector, schedule mode toggle, per-board CRUD, filtering by `board_id`                                                                                                          |
-| `multi-board-output.spec.ts`       | Multi-board output     | Two boards on real mock connections (ports 7000/7001): manual and scheduled sends land on the right hardware, cross-board leak checks, per-board pause and schedule-mode isolation      |
-| `multi-board-mixed.spec.ts`        | Mixed-device fleet     | Flagship (6×22) + Note (3×15) in one refresh, correctly sized per device, no cross-device leakage                                                                                       |
-| `board-switch-ux.spec.ts`          | Board selector         | Switching boards fully swaps the view                                                                                                                                                  |
-| `board-send-path.spec.ts`          | Send path              | End-to-end send path from UI action to board hardware                                                                                                                                  |
-| `board-discovery-offline.spec.ts`  | Discovery & offline    | Board scan, connection test online/offline/missing creds, per-board active-page resolution, offline send handling                                                                       |
-| `mock-board.spec.ts`               | Mock server            | Character-code validation, text-mode encoding, mock state                                                                                                                              |
-| `code62-glyph.spec.ts`             | Character code 62      | Per-board heart/degree glyph setting, including the setup wizard                                                                                                                       |
-| `note-pages.spec.ts`               | Note pages             | Note (3×15) API CRUD, UI creation, 3-line editor, preview dimensions, send with encoding verification, heart/degree handling                                                            |
-| `note-multiboard-extended.spec.ts` | Note & multi-board     | Device-type mismatch, 3×15 grid enforcement, one board offline, per-board schedule isolation                                                                                            |
-| `note-array-output.spec.ts`        | Note-array output      | Cloud-API hardware layer: solo array installs, every geometry class, mixed fleet in one refresh, array pause isolation                                                                  |
-| `note-array-local.spec.ts`         | Note-array output      | Local-API per-tile fan-out for arrays                                                                                                                                                  |
-| `note-array-add-ux.spec.ts`        | Note arrays            | Adding a Note Array board through the UI                                                                                                                                               |
-| `panel.spec.ts`                    | FiestaPanel            | The public read-only `/panel/{id}` viewer surface                                                                                                                                      |
+| ---------------------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `multi-board.spec.ts`              | Multi-board            | Board card display, board CRUD, wizard board type/color picker, cross-feature config                                                                                               |
+| `multi-board-schedule.spec.ts`     | Multi-board scheduling | Board selector, schedule mode toggle, per-board CRUD, filtering by `board_id`                                                                                                      |
+| `multi-board-output.spec.ts`       | Multi-board output     | Two boards on real mock connections (ports 7000/7001): manual and scheduled sends land on the right hardware, cross-board leak checks, per-board pause and schedule-mode isolation |
+| `multi-board-mixed.spec.ts`        | Mixed-device fleet     | Flagship (6×22) + Note (3×15) in one refresh, correctly sized per device, no cross-device leakage                                                                                  |
+| `board-switch-ux.spec.ts`          | Board selector         | Switching boards fully swaps the view                                                                                                                                              |
+| `board-send-path.spec.ts`          | Send path              | End-to-end send path from UI action to board hardware                                                                                                                              |
+| `board-discovery-offline.spec.ts`  | Discovery & offline    | Board scan, connection test online/offline/missing creds, per-board active-page resolution, offline send handling                                                                  |
+| `mock-board.spec.ts`               | Mock server            | Character-code validation, text-mode encoding, mock state                                                                                                                          |
+| `code62-glyph.spec.ts`             | Character code 62      | Per-board heart/degree glyph setting, including the setup wizard                                                                                                                   |
+| `note-pages.spec.ts`               | Note pages             | Note (3×15) API CRUD, UI creation, 3-line editor, preview dimensions, send with encoding verification, heart/degree handling                                                       |
+| `note-multiboard-extended.spec.ts` | Note & multi-board     | Device-type mismatch, 3×15 grid enforcement, one board offline, per-board schedule isolation                                                                                       |
+| `note-array-output.spec.ts`        | Note-array output      | Cloud-API hardware layer: solo array installs, every geometry class, mixed fleet in one refresh, array pause isolation                                                             |
+| `note-array-local.spec.ts`         | Note-array output      | Local-API per-tile fan-out for arrays                                                                                                                                              |
+| `note-array-add-ux.spec.ts`        | Note arrays            | Adding a Note Array board through the UI                                                                                                                                           |
+| `panel.spec.ts`                    | FiestaPanel            | The public read-only `/panel/{id}` viewer surface                                                                                                                                  |
 
 ### Plugins and integrations
 
-| File                            | Area                | What's covered                                                                                        |
-| ------------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------- |
-| `integrations.spec.ts`          | Plugin UI           | Installed + Marketplace tabs, plugin cards, Add-from-Git dialog, Check for Updates                       |
-| `plugin-management.spec.ts`     | Plugin management   | Listing by category, enable/disable via API + UI, config sheet, API-key field, status badge               |
-| `plugin-detail.spec.ts`         | Plugin detail       | `/integrations/[pluginId]` navigation, metadata, install button, README, unknown-plugin error state       |
-| `plugin-board-previews.spec.ts` | Plugin previews     | Manifest `teaser`/`previews` rendering as live split-flap boards                                         |
-| `home-assistant-controls.spec.ts` | HA integration    | HA REST round-trips: schedule switch, active page, refresh/blank, send message, sensors, transition style  |
-| `home-assistant-discovery.spec.ts` | HA integration   | FiestaBoard entities discoverable in Home Assistant via MQTT                                             |
+| File                               | Area              | What's covered                                                                                            |
+| ---------------------------------- | ----------------- | --------------------------------------------------------------------------------------------------------- |
+| `integrations.spec.ts`             | Plugin UI         | Installed + Marketplace tabs, plugin cards, Add-from-Git dialog, Check for Updates                        |
+| `plugin-management.spec.ts`        | Plugin management | Listing by category, enable/disable via API + UI, config sheet, API-key field, status badge               |
+| `plugin-detail.spec.ts`            | Plugin detail     | `/integrations/[pluginId]` navigation, metadata, install button, README, unknown-plugin error state       |
+| `plugin-board-previews.spec.ts`    | Plugin previews   | Manifest `teaser`/`previews` rendering as live split-flap boards                                          |
+| `home-assistant-controls.spec.ts`  | HA integration    | HA REST round-trips: schedule switch, active page, refresh/blank, send message, sensors, transition style |
+| `home-assistant-discovery.spec.ts` | HA integration    | FiestaBoard entities discoverable in Home Assistant via MQTT                                              |
 
 ### Settings, auth, AI and infrastructure
 
-| File                   | Area          | What's covered                                                                                                                       |
-| ---------------------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `settings.spec.ts`     | Settings      | Settings page loads with all sections; navigation to integrations                                                                       |
-| `settings-full.spec.ts`| Settings      | Timezone picker, refresh interval, output target, board type, service control, silence schedule, wizard rerun, debug tools, system info  |
-| `auth.spec.ts`         | Auth          | First-run setup, sign-in valid/invalid, remember-me cookie, logout, 401/409 protected routes, `redirect=` param. `RUN_AUTH_TESTS=1`      |
-| `ai.spec.ts`           | AI            | `/settings/ai` round-trip + key masking, `/settings/ai/test`, `/pages/ai/context`, `/pages/ai/generate` happy and error paths. `RUN_AI_TESTS=1` |
-| `mcp.spec.ts`          | MCP HTTP      | `/api/mcp/` mount smoke, Streamable-HTTP initialize handshake, `tools/list` catalog, `tools/call list_pages`, prompts, resources, unknown-tool error. `RUN_AI_TESTS=1` |
-| `ingress.spec.ts`      | HA Ingress    | The production bundle behind the HA Ingress path-rewrite proxy. `RUN_INGRESS_TESTS=1`                                                    |
+| File                    | Area       | What's covered                                                                                                                                                         |
+| ----------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `settings.spec.ts`      | Settings   | Settings page loads with all sections; navigation to integrations                                                                                                      |
+| `settings-full.spec.ts` | Settings   | Timezone picker, refresh interval, output target, board type, service control, silence schedule, wizard rerun, debug tools, system info                                |
+| `auth.spec.ts`          | Auth       | First-run setup, sign-in valid/invalid, remember-me cookie, logout, 401/409 protected routes, `redirect=` param. `RUN_AUTH_TESTS=1`                                    |
+| `ai.spec.ts`            | AI         | `/settings/ai` round-trip + key masking, `/settings/ai/test`, `/pages/ai/context`, `/pages/ai/generate` happy and error paths. `RUN_AI_TESTS=1`                        |
+| `mcp.spec.ts`           | MCP HTTP   | `/api/mcp/` mount smoke, Streamable-HTTP initialize handshake, `tools/list` catalog, `tools/call list_pages`, prompts, resources, unknown-tool error. `RUN_AI_TESTS=1` |
+| `ingress.spec.ts`       | HA Ingress | The production bundle behind the HA Ingress path-rewrite proxy. `RUN_INGRESS_TESTS=1`                                                                                  |
 
 ### `regression/` — UX-tree gap suite
 
@@ -132,10 +132,10 @@ not this document.
 
 ### Authoring tools (not tests)
 
-| File                           | What it does                                                     |
-| ------------------------------ | ------------------------------------------------------------------ |
-| `generate-screenshots.spec.ts` | Regenerates documentation screenshots on demand                    |
-| `draw-mode-demo.spec.ts`       | Records the draw-mode demo asset; excluded even in local runs      |
+| File                           | What it does                                                  |
+| ------------------------------ | ------------------------------------------------------------- |
+| `generate-screenshots.spec.ts` | Regenerates documentation screenshots on demand               |
+| `draw-mode-demo.spec.ts`       | Records the draw-mode demo asset; excluded even in local runs |
 
 ---
 


### PR DESCRIPTION
Two Phase 0 items from the engine-cleanup epic, both about making CI notice things it currently can't.

Closes #1731
Closes #1737

---

## #1731 — Route-inventory golden test

Phase 3 (#1756) moves ~200 inline routes out of `src/api_server.py` into routers. The classic failure of that refactor is a route that quietly changes path, loses a method, or disappears — and nothing in the suite notices, because every other test only asserts on the handful of endpoints it happens to call.

`tests/test_route_inventory.py` snapshots the whole table (path + sorted methods + endpoint name + route class) into `tests/golden/api_routes.json` — **204 routes** — and fails on drift with an added/removed/changed summary plus regeneration instructions.

Two wrinkles the walker handles:

- **`Mount`** — the `/mcp` sub-app is recorded as one entry, not descended into; its routes belong to a foreign ASGI app. It also means the golden test fails loudly if the `mcp` package ever goes missing, instead of the MCP surface disappearing quietly.
- **`_IncludedRouter`** — FastAPI ≥ 0.130 wraps `include_router()` results in an internal node with no `path`; the real routes hang off `include_context`. Without that recursion all eleven `/auth/*` endpoints would be silently absent from the snapshot.

Two companion tests keep the golden honest: one asserts the table isn't trivially small (so a broken import can't be frozen in as "no drift"), one asserts no two routes claim the same path+method.

Regenerate deliberately, then read the diff:

```bash
docker compose -f docker-compose.dev.yml exec fiestaboard \
    env UPDATE_ROUTE_INVENTORY=1 pytest tests/test_route_inventory.py
git diff tests/golden/api_routes.json
```

Documented in `tests/README.md`.

---

## #1737 — MCP E2E on the merge queue, and stale metadata

### Audit first: two of the three asks are already fixed on main

The issue predates #1771. I checked rather than re-fixing:

| Issue claim | Actual state |
| --- | --- |
| `ai-mcp-e2e-tests` runs only on `pull_request` | **Fixed by #1771.** Its `if:` is now `(pull_request \|\| merge_group) && (api \|\| ui \|\| plugins \|\| shared)`. |
| `RUN_INGRESS_TESTS` set nowhere | **Fixed by #1467**, which added `ingress-e2e-tests` in the same PR as the spec. |
| `COVERAGE.md` and `ux-coverage.json` stale | **Still true.** |

Note #1771 solved it differently from the issue's plan — it gated the *dedicated* job on `merge_group` rather than teaching the merge_group integration job to start `mock-llm`. That's the better shape: `ai.spec.ts` writes global `/settings/ai` state, which is exactly why it was pulled out of the main matrix.

What was missing is that **nothing stops either regression from recurring.**

### `tests/test_e2e_spec_reachability.py`

Parses the `RUN_*` ignore gates out of `web/playwright.config.ts` and every `npx playwright test` step out of `.github/workflows/`, then asserts:

1. every spec under `web/tests/` is executed by at least one invocation;
2. every `RUN_*` gate has a job that sets it;
3. every spec is reachable by an invocation that can run on `merge_group`.

Authoring tools (`generate-screenshots`, `draw-mode-demo`) sit in a documented allowlist, and a companion test fails if an allowlisted spec *becomes* reachable — so the allowlist can't rot into a blanket exemption. A fourth test fails if either parser returns an empty result, so a reshaped config can't make the whole file vacuous.

A guard only helps if it runs, so `detect-changes` gains an `e2e_wiring` filter (`.github/workflows/**`, `web/playwright.config.ts`, `web/tests/**`) that `test-platform` opts into. Deliberately **not** folded into `shared`, which would rebuild the Docker image and run the whole E2E fleet for an unrelated workflow edit.

### Metadata

- **`web/tests/COVERAGE.md`** claimed 29 spec files (there are 74: 48 top-level + 26 regression), 39 Vitest files (there are 134), described the UI as Next.js, and listed board-2 driving as an open `fixme` when `multi-board-output.spec.ts` has asserted it for months. It now leads with a *which CI job runs which specs* table — the thing that actually determines whether coverage is real — and drops the hand-maintained Vitest enumeration that rotted, since `ls web/src/__tests__` is the honest answer.
- **`.claude/ux-coverage.json`**'s 8.8% headline is the *input* that generated `web/tests/regression/`, so it describes coverage before those 26 specs existed. Rather than fabricate a current number, it gains a `_provenance` block saying so, naming what supersedes it, and giving the regeneration command. (8-line diff; the data is untouched.)

---

## Test evidence

### Route-inventory golden test fails on a deliberately-added route

Added `@app.get("/dummy-drift-probe")` to `src/api_server.py`:

```
tests/test_route_inventory.py F..                                        [100%]
=================================== FAILURES ===================================
_____________________ test_route_inventory_matches_golden ______________________
E   AssertionError: Route inventory drifted from tests/golden/api_routes.json.
E
E     ADDED (1) — routes the app serves but the golden file doesn't list:
E       + /dummy-drift-probe [GET] -> dummy_drift_probe
E
E     If this change is intentional, regenerate the golden file with:
E         UPDATE_ROUTE_INVENTORY=1 pytest tests/test_route_inventory.py
E     then review `git diff tests/golden/api_routes.json` line by line.
========================= 1 failed, 2 passed in 0.49s ==========================
```

Second probe — re-pathed `/version` → `/version-renamed` and renamed the `root` endpoint function, on top of the dummy route, to exercise all three drift categories:

```
E   AssertionError: Route inventory drifted from tests/golden/api_routes.json.
E
E     ADDED (2) — routes the app serves but the golden file doesn't list:
E       + /dummy-drift-probe [GET] -> dummy_drift_probe
E       + /version-renamed [GET] -> version
E
E     REMOVED (1) — routes the golden file lists but the app no longer serves:
E       - /version [GET] -> version
E
E     CHANGED (1) — same path+methods, different endpoint name or route class:
E       ~ / [GET]: root (APIRoute) -> root_renamed (APIRoute)
```

All probes reverted (`git checkout -- src/api_server.py`); green afterwards.

### Reachability guard fails on both historical CI bugs

Probe 1 — reverted `ai-mcp-e2e-tests` to `github.event_name == 'pull_request'`, i.e. the exact state #1737 was filed about:

```
tests/test_e2e_spec_reachability.py ....F                                [100%]
_________________ test_every_spec_is_gated_on_the_merge_queue __________________
E   AssertionError: These specs run on pull_request but not in the merge queue, so the queue cannot gate on them:
E       ai.spec.ts
E       mcp.spec.ts
E
E     Add `merge_group` to the owning workflow's `on:` and to the job's `if:`.
========================= 1 failed, 4 passed in 0.76s ==========================
```

Probe 2 — deleted `RUN_INGRESS_TESTS: "1"` from the ingress job's env, i.e. the other half of the issue:

```
tests/test_e2e_spec_reachability.py .F.F.                                [100%]
___________________ test_every_spec_is_run_by_some_workflow ____________________
E   AssertionError: These specs are not executed by any workflow — they read as coverage but assert nothing:
E       ingress.spec.ts
____________________ test_every_env_gate_is_set_by_some_job ____________________
E   AssertionError: These env gates hide specs from every CI run because no workflow sets them: ['RUN_INGRESS_TESTS']. Wire a job that sets the flag, or remove the gate and the specs behind it.
========================= 2 failed, 3 passed in 0.81s ==========================
```

Probe 3 — added `api.spec.ts` to `INTENTIONALLY_UNREACHABLE` to prove the allowlist-minimality test isn't decorative:

```
____________________ test_unreachable_allowlist_is_minimal _____________________
E   AssertionError: These specs are listed in INTENTIONALLY_UNREACHABLE but a workflow does run them; drop them from the allowlist: ['api.spec.ts']
```

All probes reverted; suite green.

### Green state

```
$ docker run --rm -e PYTHONPATH=/app -v "$PWD":/app -w /app fb-test:latest \
    python -m pytest tests/test_e2e_spec_reachability.py tests/test_route_inventory.py \
                     tests/test_api_docs.py tests/test_docker_compose.py -q --no-header
31 passed in 1.84s
```

`ruff check` + `ruff format --check` clean across `tests/` (150 files).

---

## Verified locally vs. needs real CI

**Verified locally**

- Both test files pass, and fail for the right reason on five deliberate probes (above).
- `ci.yml` and `integration-tests.yml` parse under `yaml.safe_load` after the edit.
- `act -l merge_group -W .github/workflows/ci.yml` lists `test-platform`, `e2e-tests`, `ai-mcp-e2e-tests`, `auth-e2e-tests`, `ingress-e2e-tests` for the `merge_group` event.
- `act merge_group -n -W .github/workflows/ci.yml` builds a full execution plan without error.
- Empirically confirmed the *old* behaviour on real history: merge_group run `33320195247` shows `AI + MCP E2E Tests` as `skipped` — that one was a legitimate path-filter skip, but it's the run shape #1771 was fixing.

**Only real CI can confirm**

- That `dorny/paths-filter` populates the new `e2e_wiring` output on a `merge_group` event. Filters demonstrably work there (#1771 relies on it), but `act` stubs the action out, so this PR's own CI run is the first proof — and since this PR touches `.github/workflows/**`, `web/tests/**`, *and* `tests/**`, `Platform Tests` should run on it either way. The narrow proof is a later PR that touches **only** a workflow file and still runs Platform Tests.
- That `ai-mcp-e2e-tests` reports as a real merge-queue check on a queue entry whose diff matches the path filter. Nothing here changed that job; it's the state #1771 established and this PR now pins with a test.
- Whether `ci-success` is configured as a required check in branch protection — not visible from the repo, and unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ndXRi5v57yB5sXXhQswjp
