### PR TITLE
test(engine): Phase 0 safety net — silence at the board layer + display-loop timing under a fake clock

### DIFF
--- a/tests/fake_clock.py
+++ b/tests/fake_clock.py
@@ -1,0 +1,133 @@
+"""Deterministic clock control for the display engine's timing tests.
+
+Phase 0 of the engine-cleanup epic (#1730) needs tests that cross real time
+boundaries — a silence window opening, a schedule entry taking over, a
+collection rotating — without any ``sleep``. Everything here exists so a test
+can *state* what time it is and drive production code at that instant.
+
+Three seams are covered:
+
+``FakeClock``
+    The single source of "now" for a test. Holds one timezone-aware UTC
+    instant and moves only when a test moves it.
+
+``FakeTimeService``
+    A real :class:`~src.time_service.TimeService` with only the two
+    "what time is it" primitives overridden. Every piece of production logic
+    (ISO parsing, silence-window math, timezone conversion) is inherited, so
+    a test asserts against the real implementation at a controlled instant.
+
+``FakeTimeModule`` / ``fake_schedule_datetime``
+    Stand-ins for the ``time`` module and the ``schedule`` library's clock, so
+    ``DisplayService.run()`` can be driven through simulated seconds. The fake
+    ``sleep`` is where a test advances the clock — the suite never blocks.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from datetime import time as dt_time
+from types import SimpleNamespace
+
+from src.time_service import TimeService, _resolve_timezone
+
+
+class FakeClock:
+    """A movable "now", stored as a timezone-aware UTC datetime."""
+
+    def __init__(self, start: datetime):
+        if start.tzinfo is None:
+            raise ValueError("FakeClock needs a timezone-aware start instant")
+        self.utc = start.astimezone(UTC)
+
+    @property
+    def epoch(self) -> float:
+        """Unix timestamp, for the ``time.time()``-shaped call sites."""
+        return self.utc.timestamp()
+
+    def advance(self, seconds: float) -> datetime:
+        self.utc = self.utc + timedelta(seconds=seconds)
+        return self.utc
+
+    def set(self, when: datetime) -> datetime:
+        self.utc = when.astimezone(UTC)
+        return self.utc
+
+
+class FakeTimeService(TimeService):
+    """A ``TimeService`` that reads its "now" from a :class:`FakeClock`."""
+
+    def __init__(self, clock: FakeClock, default_timezone: str = "UTC"):
+        super().__init__(default_timezone=default_timezone)
+        self.clock = clock
+
+    def get_current_utc(self) -> datetime:
+        return self.clock.utc
+
+    def get_current_time(self, timezone: str | None = None) -> datetime:
+        if timezone is None:
+            tz = self._default_tz
+        else:
+            tz, ok = _resolve_timezone(timezone)
+            if not ok:
+                tz = self._default_tz
+        return self.clock.utc.astimezone(tz)
+
+
+def install_fake_time_service(monkeypatch, clock: FakeClock, timezone: str = "UTC") -> FakeTimeService:
+    """Point the process-wide ``get_time_service()`` singleton at ``clock``.
+
+    Every production caller goes through that singleton, so this is the one
+    seam needed to make silence windows and schedule lookups deterministic.
+    """
+    service = FakeTimeService(clock, default_timezone=timezone)
+    monkeypatch.setattr("src.time_service._time_service", service)
+    return service
+
+
+class FakeTimeModule:
+    """Drop-in for the ``time`` module, backed by a :class:`FakeClock`.
+
+    ``sleep`` does not sleep: it hands the requested duration to ``on_sleep``,
+    which is where the driving test advances the clock and decides when the
+    loop under test should stop.
+    """
+
+    def __init__(self, clock: FakeClock, on_sleep=None):
+        self.clock = clock
+        self._on_sleep = on_sleep
+
+    def time(self) -> float:
+        return self.clock.epoch
+
+    def monotonic(self) -> float:
+        return self.clock.epoch
+
+    def sleep(self, seconds: float) -> None:
+        if self._on_sleep is None:
+            self.clock.advance(seconds)
+        else:
+            self._on_sleep(seconds)
+
+
+def fake_schedule_datetime(clock: FakeClock) -> SimpleNamespace:
+    """A stand-in for the ``datetime`` module as the ``schedule`` library sees it.
+
+    ``schedule`` decides whether a job is due with naive ``datetime.now()``
+    comparisons. Swapping the module reference it holds lets a test move a
+    real ``schedule.Scheduler`` through simulated time — the cadence logic
+    under test stays the library's own, not a mock's.
+    """
+
+    class _Datetime:
+        @staticmethod
+        def now(tz=None):
+            if tz is None:
+                return clock.utc.replace(tzinfo=None)
+            return clock.utc.astimezone(tz)
+
+        @staticmethod
+        def combine(*args, **kwargs):
+            return datetime.combine(*args, **kwargs)
+
+    return SimpleNamespace(datetime=_Datetime, timedelta=timedelta, time=dt_time)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -50,3 +50,37 @@ def validate_template_variables(template, variables):
     if missing:
         raise AssertionError(f"Template missing variable values: {missing}")
     return True
+
+
+# --- Board frame decoding -------------------------------------------------
+#
+# Board clients receive grids of Vestaboard character codes. Tests that assert
+# on what actually reached the hardware read much better against the words on
+# the flaps than against arrays of integers.
+
+_BOARD_CHAR_BY_CODE = {0: " "}
+for _i, _ch in enumerate("ABCDEFGHIJKLMNOPQRSTUVWXYZ", start=1):
+    _BOARD_CHAR_BY_CODE[_i] = _ch
+for _i, _ch in enumerate("123456789", start=27):
+    _BOARD_CHAR_BY_CODE[_i] = _ch
+_BOARD_CHAR_BY_CODE[36] = "0"
+
+
+def decode_board_rows(board_array):
+    """Board character grid -> one string per row, padding preserved.
+
+    Use this when *placement* on the board is the thing under test. Codes
+    outside the letters/digits/blank set decode to "?" — deliberately loud, so
+    a test never silently asserts against a character it did not mean.
+    """
+    return ["".join(_BOARD_CHAR_BY_CODE.get(code, "?") for code in row) for row in board_array]
+
+
+def decode_board_text(board_array):
+    """Board character grid -> the text an owner would read off the flaps.
+
+    Blank rows and padding are dropped, so an assertion reads as words rather
+    than as a fixed-width grid. Use :func:`decode_board_rows` when the exact
+    row/column placement matters.
+    """
+    return "\n".join(line.strip() for line in decode_board_rows(board_array) if line.strip())

--- a/tests/test_display_loop_timing.py
+++ b/tests/test_display_loop_timing.py
@@ -1,0 +1,404 @@
+"""Display-loop timing under a fake clock (issue #1734, epic #1730 Phase 0).
+
+``DisplayService.run()`` is the heartbeat of the whole product — tick cadence,
+schedule-boundary detection, collection rotation — and until now it was only
+ever exercised for crash resilience. Every hardware E2E forces a single tick.
+Nothing crossed a real time boundary, and nothing asserted that a rotating
+collection actually changes what is on the flaps. Phase 2 rewrites this loop.
+
+So these tests run the real ``run()`` — the real ``schedule`` jobs, the real
+collection resolution math — through *simulated* seconds, and assert on the
+frames a stub board client receives and the (fake) instant each one arrived.
+Nothing sleeps: the loop's own ``time.sleep(1)`` is the hook the harness uses
+to advance the clock, so the suite stays instantaneous and fully deterministic.
+
+What is deliberately NOT asserted: how often the loop wakes up internally.
+The 1 Hz wake-up is an implementation detail that issue #1740 is changing.
+These tests pin the *observable* contract instead — the board is redriven at
+the polling interval, a schedule boundary reaches the flaps within one polling
+interval of the boundary, and a collection advances on its own cadence.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from datetime import time as clock_time
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import schedule
+
+from src.collections.models import Collection, TimeModeConfig
+from src.collections.service import CollectionService
+from src.main import BoardRuntime, DisplayService
+from tests.fake_clock import FakeClock, FakeTimeModule, fake_schedule_datetime, install_fake_time_service
+from tests.helpers import decode_board_text
+
+BOARD = {
+    "id": "board-1",
+    "name": "Living Room",
+    "device_type": "flagship",
+    "enabled": True,
+    "paused": False,
+    "api_mode": "local",
+    "host": "mock-host",
+    "port": 7000,
+    "local_api_key": "test-key",
+}
+
+TRANSITIONS = SimpleNamespace(strategy="instant", step_interval_ms=0, step_size=1)
+
+# 2026-07-15 is a Wednesday. 09:00:00Z is the schedule boundary these tests
+# cross, and it also lands exactly on a 30-second collection slice boundary
+# whose slice index is even — so a two-page time-mode collection with a 30s
+# interval shows page_ids[0] from 09:00:00 and page_ids[1] from 09:00:30.
+SCHEDULE_BOUNDARY = datetime(2026, 7, 15, 9, 0, tzinfo=UTC)
+TEN_SECONDS_BEFORE = datetime(2026, 7, 15, 8, 59, 50, tzinfo=UTC)
+TWENTY_SECONDS_IN = datetime(2026, 7, 15, 9, 0, 20, tzinfo=UTC)
+THIRTY_SECONDS_IN = datetime(2026, 7, 15, 9, 0, 30, tzinfo=UTC)
+FORTY_SECONDS_IN = datetime(2026, 7, 15, 9, 0, 40, tzinfo=UTC)
+ONE_MINUTE_LATER = datetime(2026, 7, 15, 9, 1, tzinfo=UTC)
+TWO_MINUTES_LATER = datetime(2026, 7, 15, 9, 2, tzinfo=UTC)
+FIVE_MINUTES_LATER = datetime(2026, 7, 15, 9, 5, tzinfo=UTC)
+
+COLLECTION_ID = "collection:11111111-2222-3333-4444-555555555555"
+
+
+class RecordingBoardClient:
+    """Stub board client recording every frame and the instant it arrived."""
+
+    def __init__(self, clock: FakeClock):
+        self.clock = clock
+        self.sends: list[tuple[datetime, list[list[int]]]] = []
+        self._last_characters = None
+        self.use_cloud = False
+
+    def render(self, board_array, **_kwargs):
+        self.sends.append((self.clock.utc, [row[:] for row in board_array]))
+        self._last_characters = [row[:] for row in board_array]
+        return True, True
+
+    def read_current_message(self, sync_cache: bool = False):
+        return None
+
+    def clear_cache(self):
+        self._last_characters = None
+
+    @property
+    def timeline(self) -> list[tuple[datetime, str]]:
+        """(when it was sent, what it said) for every frame the board got."""
+        return [(when, decode_board_text(frame)) for when, frame in self.sends]
+
+    @property
+    def texts(self) -> list[str]:
+        return [text for _when, text in self.timeline]
+
+    @property
+    def times(self) -> list[datetime]:
+        return [when for when, _text in self.timeline]
+
+    def first_sent_at(self, text: str) -> datetime:
+        """When the board first showed ``text``. Fails loudly if it never did."""
+        for when, sent in self.timeline:
+            if sent == text:
+                return when
+        raise AssertionError(f"{text!r} never reached the board; got {self.texts}")
+
+
+class SilenceOffConfigManager:
+    """Config store with silence disabled — this suite is about the loop only.
+
+    Kept real (rather than mocking ``Config``) so the loop's per-second silence
+    boundary check runs its production code path and is proven not to disturb
+    the cadence under test.
+    """
+
+    def get_feature(self, name: str) -> dict:
+        if name == "silence_schedule":
+            return {"enabled": False, "by_board": {}}
+        return {}
+
+    def get_general(self) -> dict:
+        return {}
+
+    def get_board(self) -> dict:
+        return {}
+
+    def migrate_silence_schedule_to_utc(self) -> bool:
+        return False
+
+    def migrate_silence_schedule_to_per_board(self) -> int:
+        return 0
+
+
+def settings_service(*, polling_interval: int, schedule_enabled: bool, active_page_id: str | None = None) -> MagicMock:
+    svc = MagicMock()
+    svc.get_board_settings.return_value = SimpleNamespace(boards=[BOARD])
+    svc.get_primary_board_id.return_value = BOARD["id"]
+    svc.is_paused.return_value = False
+    svc.is_schedule_enabled.return_value = schedule_enabled
+    svc.get_active_page_id.return_value = active_page_id
+    svc.get_transition_settings.return_value = TRANSITIONS
+    svc.consume_temporary_override.return_value = None
+    svc.get_polling_interval.return_value = polling_interval
+    return svc
+
+
+def page_service(specs) -> MagicMock:
+    """``specs`` maps page id -> content, or page id -> callable returning it."""
+
+    def _page(page_id):
+        if page_id not in specs:
+            return None
+        return SimpleNamespace(
+            id=page_id,
+            device_type="flagship",
+            notes_wide=1,
+            notes_tall=1,
+            transition_strategy=None,
+            transition_interval_ms=None,
+            transition_step_size=None,
+        )
+
+    def _content(page_id):
+        value = specs[page_id]
+        return value() if callable(value) else value
+
+    svc = MagicMock()
+    svc.get_page.side_effect = _page
+    svc.preview_page.side_effect = lambda pid, force_refresh=False: SimpleNamespace(
+        available=pid in specs, formatted=_content(pid) if pid in specs else "", error=None
+    )
+    svc.list_pages.return_value = [_page(pid) for pid in specs]
+    return svc
+
+
+class LoopHarness:
+    """Drives ``DisplayService.run()`` through simulated time.
+
+    The loop's ``time.sleep`` is redirected here: each call advances the clock
+    by the requested amount and, once the clock has passed ``run_until``, flips
+    the service's ``running`` flag so the loop exits on its own terms.
+    ``run_until`` is inclusive — the work scheduled for that exact instant runs
+    before the loop stops. ``max_ticks`` is a safety net: a loop that stopped
+    sleeping would otherwise hang the suite.
+    """
+
+    def __init__(self, service: DisplayService, clock: FakeClock, run_until: datetime, max_ticks: int = 5000):
+        self.service = service
+        self.clock = clock
+        self.run_until = run_until
+        self.max_ticks = max_ticks
+        self.ticks = 0
+
+    def _on_sleep(self, seconds: float) -> None:
+        self.ticks += 1
+        if self.ticks > self.max_ticks:
+            raise AssertionError(f"run() slept {self.ticks} times without reaching {self.run_until}")
+        self.clock.advance(seconds)
+        if self.clock.utc > self.run_until:
+            self.service.running = False
+
+
+@pytest.fixture(autouse=True)
+def _clear_schedule():
+    """``run()`` registers jobs on the library's global scheduler."""
+    schedule.clear()
+    yield
+    schedule.clear()
+
+
+@pytest.fixture
+def loop(monkeypatch):
+    """Factory that runs ``DisplayService.run()`` over a simulated window."""
+
+    def _run(
+        *,
+        start: datetime,
+        run_until: datetime,
+        settings,
+        pages,
+        schedules=None,
+        collections=None,
+    ) -> RecordingBoardClient:
+        clock = FakeClock(start)
+        service = DisplayService()
+        client = RecordingBoardClient(clock)
+        service.runtimes = {BOARD["id"]: BoardRuntime(client=client, board_id=BOARD["id"])}
+        service._primary_board_id = BOARD["id"]
+
+        harness = LoopHarness(service, clock, run_until)
+        fake_time = FakeTimeModule(clock, on_sleep=harness._on_sleep)
+
+        install_fake_time_service(monkeypatch, clock)
+        monkeypatch.setattr("src.config.get_config_manager", SilenceOffConfigManager)
+        monkeypatch.setattr("src.config_manager.get_config_manager", SilenceOffConfigManager)
+        # The loop's own clock, the schedule library's clock, and the clock the
+        # collection resolver reads — all three point at the same fake instant.
+        monkeypatch.setattr("src.main.time", fake_time)
+        monkeypatch.setattr("src.collections.service.time", FakeTimeModule(clock))
+        monkeypatch.setattr(schedule, "datetime", fake_schedule_datetime(clock))
+
+        with (
+            patch("src.main.get_settings_service", return_value=settings),
+            patch("src.main.get_page_service", return_value=pages),
+            patch("src.main.get_schedule_service", return_value=schedules or MagicMock()),
+            patch("src.main.get_collection_service", return_value=collections or MagicMock()),
+            patch.object(service, "_check_trigger_override", return_value=None),
+            patch.object(service, "request_board_refresh"),
+        ):
+            service.run()
+
+        return client
+
+    return _run
+
+
+class TestScheduleBoundary:
+    """A schedule entry taking over must reach the board, and reach it soon."""
+
+    @staticmethod
+    def _schedule_service():
+        """Morning page until 09:00, day page from 09:00 — by wall-clock time."""
+        svc = MagicMock()
+        svc.get_active_page_id.side_effect = lambda t, day, board_id=None: (
+            "page-day" if t >= clock_time(9, 0) else "page-morning"
+        )
+        return svc
+
+    def test_board_switches_pages_when_the_clock_crosses_a_schedule_boundary(self, loop):
+        client = loop(
+            start=TEN_SECONDS_BEFORE,
+            run_until=THIRTY_SECONDS_IN,
+            settings=settings_service(polling_interval=15, schedule_enabled=True),
+            pages=page_service({"page-morning": "MORNING", "page-day": "DAY"}),
+            schedules=self._schedule_service(),
+        )
+
+        assert client.texts == ["MORNING", "DAY"]
+
+    def test_the_new_page_reaches_the_board_within_one_polling_interval(self, loop):
+        polling_interval = 15
+        client = loop(
+            start=TEN_SECONDS_BEFORE,
+            run_until=TWO_MINUTES_LATER,
+            settings=settings_service(polling_interval=polling_interval, schedule_enabled=True),
+            pages=page_service({"page-morning": "MORNING", "page-day": "DAY"}),
+            schedules=self._schedule_service(),
+        )
+
+        lag = (client.first_sent_at("DAY") - SCHEDULE_BOUNDARY).total_seconds()
+        assert 0 <= lag <= polling_interval
+
+    def test_no_further_sends_once_the_schedule_settles_on_a_page(self, loop):
+        """Unchanged content is not re-pushed tick after tick."""
+        client = loop(
+            start=SCHEDULE_BOUNDARY,
+            run_until=FIVE_MINUTES_LATER,
+            settings=settings_service(polling_interval=15, schedule_enabled=True),
+            pages=page_service({"page-morning": "MORNING", "page-day": "DAY"}),
+            schedules=self._schedule_service(),
+        )
+
+        assert client.texts == ["DAY"]
+
+
+class TestCollectionRotation:
+    """A time-mode collection must advance what is on the board on its own."""
+
+    @staticmethod
+    def _collection_service():
+        """A real CollectionService over one in-memory two-page collection."""
+        collection = Collection(
+            id=COLLECTION_ID,
+            name="Rotation",
+            page_ids=["page-a", "page-b"],
+            selection_mode="time",
+            time=TimeModeConfig(interval_seconds=30),
+        )
+        storage = MagicMock()
+        storage.get.side_effect = lambda cid: collection if cid == COLLECTION_ID else None
+        return CollectionService(storage=storage)
+
+    def test_collection_advances_to_its_next_page_at_the_interval_boundary(self, loop):
+        """The polling interval is 5 minutes, so only rotation can drive this."""
+        client = loop(
+            start=TWENTY_SECONDS_IN,
+            run_until=FORTY_SECONDS_IN,
+            settings=settings_service(polling_interval=300, schedule_enabled=False, active_page_id=COLLECTION_ID),
+            pages=page_service({"page-a": "ALPHA", "page-b": "BETA"}),
+            collections=self._collection_service(),
+        )
+
+        assert client.texts == ["ALPHA", "BETA"]
+
+    def test_the_next_page_arrives_on_the_interval_boundary_not_at_the_next_poll(self, loop):
+        client = loop(
+            start=TWENTY_SECONDS_IN,
+            run_until=ONE_MINUTE_LATER,
+            settings=settings_service(polling_interval=300, schedule_enabled=False, active_page_id=COLLECTION_ID),
+            pages=page_service({"page-a": "ALPHA", "page-b": "BETA"}),
+            collections=self._collection_service(),
+        )
+
+        assert (client.first_sent_at("BETA") - THIRTY_SECONDS_IN).total_seconds() <= 1
+
+    def test_collection_keeps_rotating_across_several_intervals(self, loop):
+        client = loop(
+            start=TWENTY_SECONDS_IN,
+            run_until=TWO_MINUTES_LATER,
+            settings=settings_service(polling_interval=300, schedule_enabled=False, active_page_id=COLLECTION_ID),
+            pages=page_service({"page-a": "ALPHA", "page-b": "BETA"}),
+            collections=self._collection_service(),
+        )
+
+        # 09:00:20 -> 09:02:00 crosses a 30s boundary at :30, 1:00, 1:30 and 2:00.
+        assert client.texts == ["ALPHA", "BETA", "ALPHA", "BETA", "ALPHA"]
+
+
+def always_changing_page() -> MagicMock:
+    """A page that renders differently every time it is asked.
+
+    With this, a frame is missing from the board only because the loop did not
+    poll — never because the dedupe cache swallowed an unchanged render. That
+    makes the send timeline a direct readout of the loop's cadence.
+    """
+    counter = {"n": 0}
+
+    def _content():
+        counter["n"] += 1
+        return f"FRAME {counter['n']}"
+
+    return page_service({"page-x": _content})
+
+
+class TestPollingCadence:
+    """Board work happens at the configured polling interval."""
+
+    def test_the_board_is_redriven_once_per_polling_interval(self, loop):
+        start = SCHEDULE_BOUNDARY
+        client = loop(
+            start=start,
+            run_until=ONE_MINUTE_LATER,
+            settings=settings_service(polling_interval=15, schedule_enabled=False, active_page_id="page-x"),
+            pages=always_changing_page(),
+        )
+
+        # 60 simulated seconds at a 15s interval: the initial send plus one per
+        # interval. A board driven at 1 Hz would show ~60 frames instead.
+        offsets = [(when - start).total_seconds() for when in client.times]
+        assert offsets == [0, 15, 30, 45, 60]
+
+    def test_raising_the_polling_interval_slows_the_board_down(self, loop):
+        """Same simulated window, double the interval, half the frames."""
+        start = SCHEDULE_BOUNDARY
+        client = loop(
+            start=start,
+            run_until=ONE_MINUTE_LATER,
+            settings=settings_service(polling_interval=30, schedule_enabled=False, active_page_id="page-x"),
+            pages=always_changing_page(),
+        )
+
+        offsets = [(when - start).total_seconds() for when in client.times]
+        assert offsets == [0, 30, 60]

--- a/tests/test_silence_board_layer.py
+++ b/tests/test_silence_board_layer.py
@@ -1,0 +1,344 @@
+"""Silence mode verified at the board layer (issue #1733, epic #1730 Phase 0).
+
+Silence mode has plenty of unit coverage, but all of it stops at settings
+shapes and internal flags. Nothing asserted the thing an owner actually
+observes: that the board **stops receiving their content** when the window
+opens, shows whatever the silence mode calls for, and gets their content back
+when the window closes.
+
+These tests drive ``DisplayService`` the way the run loop does — one tick at a
+time — and assert only on the frames a stub board client receives. The only
+thing that changes between ticks is the clock: the silence window is crossed
+by time passing, never by rewriting config mid-test, so what is locked down is
+the real boundary behaviour that Phase 1 is about to refactor.
+
+Real production code stays in the loop on purpose: ``Config.silence_config_for``
+/ ``Config.is_silence_mode_active``, the UTC window math in ``TimeService``, and
+the whole ``check_and_send_for_board`` dispatch. Only the clock, the config
+store, and the board client are substituted.
+
+Per-board silence (#1788 / PR #1801): the silence schedule is configured here
+on the **install-wide** layer with an empty ``by_board``, which is exactly the
+"board with no override of its own" case. That resolves identically before and
+after per-board silence lands, so these assertions hold either way.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.main import BoardRuntime, DisplayService
+from tests.fake_clock import FakeClock, install_fake_time_service
+from tests.helpers import decode_board_rows, decode_board_text
+
+# A single flagship board. Silence geometry resolves from the first configured
+# board both before and after PR #1801, so a 6x22 grid is expected either way.
+BOARD = {
+    "id": "board-1",
+    "name": "Living Room",
+    "device_type": "flagship",
+    "enabled": True,
+    "paused": False,
+    "api_mode": "local",
+    "host": "mock-host",
+    "port": 7000,
+    "local_api_key": "test-key",
+}
+
+PAGE_TEXT = "GOOD MORNING"
+
+# Quiet hours 22:00-07:00 UTC, stored in the UTC ISO format the config carries
+# once migrated. Spans midnight, which is the interesting case for the window
+# math.
+SILENCE_START = "22:00+00:00"
+SILENCE_END = "07:00+00:00"
+
+BEFORE_WINDOW = datetime(2026, 7, 15, 21, 59, tzinfo=UTC)
+INSIDE_WINDOW = datetime(2026, 7, 15, 23, 30, tzinfo=UTC)
+AFTER_WINDOW = datetime(2026, 7, 16, 7, 30, tzinfo=UTC)
+
+TRANSITIONS = SimpleNamespace(strategy="instant", step_interval_ms=0, step_size=1)
+
+
+class RecordingBoardClient:
+    """Stub board client that records every frame handed to the hardware."""
+
+    def __init__(self):
+        self.frames: list[list[list[int]]] = []
+        self._last_characters = None
+        self.use_cloud = False
+
+    def render(self, board_array, **_kwargs):
+        self.frames.append([row[:] for row in board_array])
+        self._last_characters = [row[:] for row in board_array]
+        return True, True
+
+    def read_current_message(self, sync_cache: bool = False):
+        return None
+
+    def clear_cache(self):
+        self._last_characters = None
+
+    @property
+    def texts(self) -> list[str]:
+        return [decode_board_text(frame) for frame in self.frames]
+
+
+class StubConfigManager:
+    """Config store holding just the silence feature, so nothing touches disk.
+
+    The migration hooks are no-ops: the window is already in UTC ISO form, and
+    per-board seeding (#1788) has nothing to do for an install-wide schedule.
+    """
+
+    def __init__(self, silence: dict):
+        self.silence = silence
+
+    def get_feature(self, name: str) -> dict:
+        return dict(self.silence) if name == "silence_schedule" else {}
+
+    def get_general(self) -> dict:
+        return {}
+
+    def get_board(self) -> dict:
+        return {}
+
+    def migrate_silence_schedule_to_utc(self) -> bool:
+        return False
+
+    def migrate_silence_schedule_to_per_board(self) -> int:
+        return 0
+
+
+def silence_feature(*, enabled=True, mode="indicator", **overrides) -> dict:
+    """An install-wide silence schedule with no per-board overrides."""
+    feature = {
+        "enabled": enabled,
+        "start_time": SILENCE_START,
+        "end_time": SILENCE_END,
+        "mode": mode,
+        "page_id": None,
+        "indicator_text": "SNOOZING",
+        "indicator_position": "center",
+        # Empty per-board layer (#1788): board-1 has no override, so it
+        # resolves to the install-wide values above.
+        "by_board": {},
+    }
+    feature.update(overrides)
+    return feature
+
+
+@pytest.fixture
+def clock():
+    return FakeClock(BEFORE_WINDOW)
+
+
+@pytest.fixture
+def board():
+    """A DisplayService wired to one recording client, plus that client."""
+    service = DisplayService()
+    client = RecordingBoardClient()
+    service.runtimes = {BOARD["id"]: BoardRuntime(client=client, board_id=BOARD["id"])}
+    service._primary_board_id = BOARD["id"]
+    return service, client
+
+
+@pytest.fixture
+def settings_service():
+    svc = MagicMock()
+    svc.get_board_settings.return_value = SimpleNamespace(boards=[BOARD])
+    svc.get_primary_board_id.return_value = BOARD["id"]
+    svc.is_paused.return_value = False
+    svc.is_schedule_enabled.return_value = False
+    svc.get_active_page_id.return_value = "page-morning"
+    svc.get_transition_settings.return_value = TRANSITIONS
+    svc.consume_temporary_override.return_value = None
+    return svc
+
+
+def page_service(specs: dict[str, str]) -> MagicMock:
+    def _page(page_id):
+        if page_id not in specs:
+            return None
+        return SimpleNamespace(
+            id=page_id,
+            device_type="flagship",
+            notes_wide=1,
+            notes_tall=1,
+            transition_strategy=None,
+            transition_interval_ms=None,
+            transition_step_size=None,
+        )
+
+    svc = MagicMock()
+    svc.get_page.side_effect = _page
+    svc.preview_page.side_effect = lambda pid, force_refresh=False: SimpleNamespace(
+        available=pid in specs, formatted=specs.get(pid, ""), error=None
+    )
+    svc.list_pages.return_value = [_page(pid) for pid in specs]
+    return svc
+
+
+class Ticker:
+    """Runs single display ticks against a fixed set of stubbed services."""
+
+    def __init__(self, service, settings, pages, config_manager, monkeypatch, clock):
+        self.service = service
+        self.settings = settings
+        self.pages = pages
+        self.clock = clock
+        install_fake_time_service(monkeypatch, clock)
+        monkeypatch.setattr("src.config.get_config_manager", lambda: config_manager)
+        monkeypatch.setattr("src.config_manager.get_config_manager", lambda: config_manager)
+
+    def tick(self, at: datetime | None = None) -> bool:
+        """Run one display cycle, optionally moving the clock there first."""
+        if at is not None:
+            self.clock.set(at)
+        with (
+            patch("src.main.get_settings_service", return_value=self.settings),
+            patch("src.main.get_page_service", return_value=self.pages),
+            patch("src.main.get_schedule_service", return_value=MagicMock()),
+            patch("src.main.get_collection_service", return_value=MagicMock()),
+            patch.object(self.service, "_check_trigger_override", return_value=None),
+            patch.object(self.service, "request_board_refresh"),
+        ):
+            return self.service.check_and_send_active_page()
+
+
+@pytest.fixture
+def ticker(board, settings_service, monkeypatch, clock):
+    """Factory: build a Ticker for a given silence feature configuration."""
+
+    def _build(feature: dict, pages: dict[str, str] | None = None) -> Ticker:
+        return Ticker(
+            service=board[0],
+            settings=settings_service,
+            pages=page_service(pages if pages is not None else {"page-morning": PAGE_TEXT}),
+            config_manager=StubConfigManager(feature),
+            monkeypatch=monkeypatch,
+            clock=clock,
+        )
+
+    return _build
+
+
+class TestSilenceWindowAtTheBoardLayer:
+    def test_board_shows_page_content_before_the_window_opens(self, board, ticker):
+        _service, client = board
+        ticker(silence_feature()).tick(BEFORE_WINDOW)
+
+        assert client.texts == [PAGE_TEXT]
+
+    def test_crossing_into_the_window_replaces_page_content_with_the_indicator(self, board, ticker):
+        _service, client = board
+        tick = ticker(silence_feature()).tick
+
+        tick(BEFORE_WINDOW)
+        tick(INSIDE_WINDOW)
+
+        assert client.texts == [PAGE_TEXT, "SNOOZING"]
+
+    def test_page_content_is_never_sent_while_the_window_is_open(self, board, ticker):
+        """Repeated ticks inside the window must not put content back on the board."""
+        _service, client = board
+        tick = ticker(silence_feature()).tick
+
+        tick(INSIDE_WINDOW)
+        tick(datetime(2026, 7, 16, 1, 0, tzinfo=UTC))
+        tick(datetime(2026, 7, 16, 4, 0, tzinfo=UTC))
+
+        assert client.texts == ["SNOOZING"]
+
+    def test_crossing_out_of_the_window_restores_page_content(self, board, ticker):
+        _service, client = board
+        tick = ticker(silence_feature()).tick
+
+        tick(BEFORE_WINDOW)
+        tick(INSIDE_WINDOW)
+        tick(AFTER_WINDOW)
+
+        assert client.texts == [PAGE_TEXT, "SNOOZING", PAGE_TEXT]
+
+    def test_freeze_mode_leaves_the_board_untouched_for_the_whole_window(self, board, ticker):
+        """Freeze sends nothing at all — the pre-silence frame stays on the flaps."""
+        _service, client = board
+        tick = ticker(silence_feature(mode="freeze")).tick
+
+        tick(BEFORE_WINDOW)
+        frames_before = len(client.frames)
+        tick(INSIDE_WINDOW)
+        tick(datetime(2026, 7, 16, 3, 0, tzinfo=UTC))
+
+        assert client.texts == [PAGE_TEXT]
+        assert len(client.frames) == frames_before
+
+    def test_freeze_mode_resumes_driving_the_board_after_the_window(self, board, ticker):
+        _service, client = board
+        tick = ticker(silence_feature(mode="freeze")).tick
+
+        tick(BEFORE_WINDOW)
+        tick(INSIDE_WINDOW)
+        tick(AFTER_WINDOW)
+
+        assert client.texts == [PAGE_TEXT, PAGE_TEXT]
+
+    def test_page_mode_freezes_the_configured_silence_page_on_the_board(self, board, ticker):
+        _service, client = board
+        pages = {"page-morning": PAGE_TEXT, "page-night": "SLEEP WELL"}
+        tick = ticker(silence_feature(mode="page", page_id="page-night"), pages=pages).tick
+
+        tick(BEFORE_WINDOW)
+        tick(INSIDE_WINDOW)
+        tick(datetime(2026, 7, 16, 2, 0, tzinfo=UTC))
+
+        assert client.texts == [PAGE_TEXT, "SLEEP WELL"]
+
+    def test_indicator_frame_is_a_clean_board_sized_to_the_device(self, board, ticker):
+        """The indicator replaces the content; it is not overlaid on it."""
+        _service, client = board
+        ticker(silence_feature()).tick(INSIDE_WINDOW)
+
+        (frame,) = client.frames
+        assert len(frame) == 6
+        assert all(len(row) == 22 for row in frame)
+        # Centered on a 6x22 flagship, every other flap blank.
+        assert decode_board_rows(frame) == [
+            " " * 22,
+            " " * 22,
+            " " * 22,
+            "       SNOOZING       ",
+            " " * 22,
+            " " * 22,
+        ]
+
+    def test_a_disabled_schedule_never_silences_the_board(self, board, ticker):
+        """Same clock, same window — only ``enabled`` differs."""
+        _service, client = board
+        tick = ticker(silence_feature(enabled=False)).tick
+
+        tick(BEFORE_WINDOW)
+        tick(INSIDE_WINDOW)
+
+        assert client.texts == [PAGE_TEXT]
+
+    def test_board_without_its_own_override_inherits_the_install_wide_window(self, board, ticker):
+        """The #1788 inheritance rule, asserted at the board layer.
+
+        ``by_board`` carries an entry for some *other* board and none for the
+        board being driven, so the only way the indicator reaches this board is
+        by resolving to the install-wide schedule.
+        """
+        _service, client = board
+        feature = silence_feature()
+        feature["by_board"] = {"some-other-board": {"enabled": False}}
+        tick = ticker(feature).tick
+
+        tick(BEFORE_WINDOW)
+        tick(INSIDE_WINDOW)
+
+        assert client.texts == [PAGE_TEXT, "SNOOZING"]


### PR DESCRIPTION
Closes #1733
Closes #1734

Two Phase 0 safety-net tests for epic #1730. Both drive the engine under a
**fake clock** and assert only on what reaches the board client — never on
internal flags or call counts. No `sleep` anywhere; both files together run in
about 0.2 seconds.

## What each test file locks down

### `tests/test_silence_board_layer.py` — #1733 (10 tests)

Silence mode had six pytest files and none of them looked at the board. They
asserted settings shapes and internal flags, so the thing an owner actually
observes was uncovered. These tests tick `DisplayService` the way the run loop
does and assert on the frames a stub board client receives. **The window is
crossed by moving the clock, never by rewriting config mid-test** — so what is
pinned is the real boundary behaviour Phase 1 refactors.

| Behaviour |
| --- |
| Page content reaches the board before the window opens |
| Crossing into the window replaces page content with the indicator |
| Page content is never sent again while the window stays open |
| Crossing out of the window restores page content |
| `freeze` mode leaves the board untouched for the whole window |
| `freeze` mode resumes driving the board after the window |
| `page` mode freezes the configured silence page on the board |
| The indicator frame is a clean 6×22 board, centred — not overlaid on content |
| A disabled schedule never silences the board (same clock, same window) |
| A board with no override of its own inherits the install-wide window |

Production code kept in the loop on purpose: `Config.is_silence_mode_active`,
the UTC window math in `TimeService`, and the whole `check_and_send_for_board`
dispatch. Only the clock, the config store, and the board client are
substituted.

### `tests/test_display_loop_timing.py` — #1734 (8 tests)

The real `run()` — the real `schedule` jobs, the real collection resolution
math — driven through *simulated* seconds. The loop's own `time.sleep(1)` is
the hook the harness uses to advance the clock, so it is deterministic and
instantaneous.

| Behaviour |
| --- |
| The board switches pages when the clock crosses a schedule boundary |
| The new page reaches the board within one polling interval of the boundary |
| A settled schedule stops re-pushing identical content |
| A time-mode collection advances to its next page at the interval boundary |
| That next page arrives on the interval boundary, not at the next poll |
| The collection keeps rotating across several intervals |
| The board is redriven once per polling interval |
| Raising the polling interval slows the board down |

The collection tests run with a **5-minute** polling interval, so only the
collection cadence gate can possibly drive them.

### Shared scaffolding

- `tests/fake_clock.py` — `FakeClock`, a `FakeTimeService` that subclasses the
  real `TimeService` (only the two "what time is it" primitives are
  overridden, so all production window/timezone math is exercised), a
  `time`-module stand-in, and a `datetime`-module stand-in for the `schedule`
  library's clock.
- `tests/helpers.py` — `decode_board_rows` / `decode_board_text`, so board
  assertions read as the words on the flaps rather than integer arrays.

## Interaction with PR #1801 (per-board silence, #1788)

Branched from `origin/main`, but written against the **per-board** model.

The silence schedule in these tests is configured on the **install-wide** layer
with an empty `by_board` — which is exactly #1801's "a board with no override
of its own inherits the install-wide schedule" case. That resolves identically
before and after #1801 lands, so nothing here needs rewriting at merge time.
One test (`test_board_without_its_own_override_inherits_the_install_wide_window`)
puts an entry for a *different* board in `by_board` and asserts the driven board
still silences, which encodes the inheritance rule explicitly.

**Verified both ways.** The two new files were exported onto a checkout of
`pull/1801/head` and run there:

```
$ docker run --rm -v <pr1801-tree>:/app -w /app fb-test:latest \
    python -m pytest tests/test_display_loop_timing.py tests/test_silence_board_layer.py -q --no-header
18 passed, 3 warnings in 0.17s
```

**#1740 (silence boundary detector no longer busy-polling at 1 Hz):** no test
here asserts a 1-second poll. The cadence test asserts the *observable*
contract — the board is redriven at `polling_interval` — which holds however
often the loop wakes up internally. This is called out in the module docstring
so a future reader does not "restore" a 1 Hz assertion.

Nothing else required a one-way-or-the-other choice.

## Test evidence (non-vacuity)

Per CLAUDE.md, each test was proven to fail when the production behaviour it
covers is broken. Seven breakages, verbatim output below. `src/main.py` was
restored after each (`git diff --stat src/` is empty on this branch).

<details>
<summary><b>#1733 — Breakage A: <code>silence_mode_active = False</code> (silence gate neutered) → 7 failed</b></summary>

```
============================= test session starts ==============================
collected 10 items

tests/test_silence_board_layer.py .FFF.FFF.F                             [100%]

=================================== FAILURES ===================================
_ TestSilenceWindowAtTheBoardLayer.test_crossing_into_the_window_replaces_page_content_with_the_indicator _
    assert client.texts == [PAGE_TEXT, "SNOOZING"]
E   AssertionError: assert ['GOOD MORNING'] == ['GOOD MORNING', 'SNOOZING']
E     Right contains one more item: 'SNOOZING'
_ TestSilenceWindowAtTheBoardLayer.test_page_content_is_never_sent_while_the_window_is_open _
    assert client.texts == ["SNOOZING"]
E   AssertionError: assert ['GOOD MORNING'] == ['SNOOZING']
E     At index 0 diff: 'GOOD MORNING' != 'SNOOZING'
_ TestSilenceWindowAtTheBoardLayer.test_crossing_out_of_the_window_restores_page_content _
    assert client.texts == [PAGE_TEXT, "SNOOZING", PAGE_TEXT]
E   AssertionError: assert ['GOOD MORNING'] == ['GOOD MORNIN...GOOD MORNING']
E     Right contains 2 more items, first extra item: 'SNOOZING'
_ TestSilenceWindowAtTheBoardLayer.test_freeze_mode_resumes_driving_the_board_after_the_window _
    assert client.texts == [PAGE_TEXT, PAGE_TEXT]
E   AssertionError: assert ['GOOD MORNING'] == ['GOOD MORNIN...GOOD MORNING']
E     Right contains one more item: 'GOOD MORNING'
_ TestSilenceWindowAtTheBoardLayer.test_page_mode_freezes_the_configured_silence_page_on_the_board _
    assert client.texts == [PAGE_TEXT, "SLEEP WELL"]
E   AssertionError: assert ['GOOD MORNING'] == ['GOOD MORNING', 'SLEEP WELL']
E     Right contains one more item: 'SLEEP WELL'
_ TestSilenceWindowAtTheBoardLayer.test_indicator_frame_is_a_clean_board_sized_to_the_device _
    assert decode_board_rows(frame) == [
E   AssertionError: assert ['GOOD MORNIN...            '] == ['           ...            ']
E     At index 0 diff: 'GOOD MORNING          ' != '                      '
_ TestSilenceWindowAtTheBoardLayer.test_board_without_its_own_override_inherits_the_install_wide_window _
    assert client.texts == [PAGE_TEXT, "SNOOZING"]
E   AssertionError: assert ['GOOD MORNING'] == ['GOOD MORNING', 'SNOOZING']
E     Right contains one more item: 'SNOOZING'
========================= 7 failed, 3 passed in 0.16s ==========================
```
</details>

<details>
<summary><b>#1733 — Breakage B: <code>if silence_mode == "freeze"</code> → <code>if False</code> (freeze no longer freezes) → 2 failed</b></summary>

```
============================= test session starts ==============================
collected 10 items

tests/test_silence_board_layer.py ....FF....                             [100%]

=================================== FAILURES ===================================
_ TestSilenceWindowAtTheBoardLayer.test_freeze_mode_leaves_the_board_untouched_for_the_whole_window _
    assert client.texts == [PAGE_TEXT]
E   AssertionError: assert ['GOOD MORNING', 'SNOOZING'] == ['GOOD MORNING']
E     Left contains one more item: 'SNOOZING'
_ TestSilenceWindowAtTheBoardLayer.test_freeze_mode_resumes_driving_the_board_after_the_window _
    assert client.texts == [PAGE_TEXT, PAGE_TEXT]
E   AssertionError: assert ['GOOD MORNIN...GOOD MORNING'] == ['GOOD MORNIN...GOOD MORNING']
E     At index 1 diff: 'SNOOZING' != 'GOOD MORNING'
E     Left contains one more item: 'GOOD MORNING'
========================= 2 failed, 8 passed in 0.14s ==========================
```
</details>

<details>
<summary><b>#1733 — Breakage C: drop <code>rt.last_active_page_content = None</code> on silence exit → 1 failed</b></summary>

```
============================= test session starts ==============================
collected 10 items

tests/test_silence_board_layer.py .....F....                             [100%]

=================================== FAILURES ===================================
_ TestSilenceWindowAtTheBoardLayer.test_freeze_mode_resumes_driving_the_board_after_the_window _
    assert client.texts == [PAGE_TEXT, PAGE_TEXT]
E   AssertionError: assert ['GOOD MORNING'] == ['GOOD MORNIN...GOOD MORNING']
E     Right contains one more item: 'GOOD MORNING'
========================= 1 failed, 9 passed in 0.15s ==========================
```

This is the exact bug the comment in `check_and_send_for_board` warns about
("otherwise 'content unchanged, skipping send' leaves the indicator stuck") and
nothing covered it at the board layer before.
</details>

<details>
<summary><b>#1733 — Breakage D: <code>silence_mode_active = True</code> (always silenced) → 8 failed</b></summary>

```
tests/test_silence_board_layer.py FFFFFF.FF.

_ TestSilenceWindowAtTheBoardLayer.test_a_disabled_schedule_never_silences_the_board _
    assert client.texts == [PAGE_TEXT]
E   AssertionError: assert ['SNOOZING'] == ['GOOD MORNING']
E     At index 0 diff: 'SNOOZING' != 'GOOD MORNING'
_ TestSilenceWindowAtTheBoardLayer.test_board_without_its_own_override_inherits_the_install_wide_window _
    assert client.texts == [PAGE_TEXT, "SNOOZING"]
E   AssertionError: assert ['SNOOZING'] == ['GOOD MORNING', 'SNOOZING']
E     At index 0 diff: 'SNOOZING' != 'GOOD MORNING'
=========================== short test summary info ============================
FAILED tests/test_silence_board_layer.py::TestSilenceWindowAtTheBoardLayer::test_board_shows_page_content_before_the_window_opens
FAILED tests/test_silence_board_layer.py::TestSilenceWindowAtTheBoardLayer::test_crossing_into_the_window_replaces_page_content_with_the_indicator
FAILED tests/test_silence_board_layer.py::TestSilenceWindowAtTheBoardLayer::test_crossing_out_of_the_window_restores_page_content
FAILED tests/test_silence_board_layer.py::TestSilenceWindowAtTheBoardLayer::test_freeze_mode_leaves_the_board_untouched_for_the_whole_window
FAILED tests/test_silence_board_layer.py::TestSilenceWindowAtTheBoardLayer::test_freeze_mode_resumes_driving_the_board_after_the_window
FAILED tests/test_silence_board_layer.py::TestSilenceWindowAtTheBoardLayer::test_page_mode_freezes_the_configured_silence_page_on_the_board
FAILED tests/test_silence_board_layer.py::TestSilenceWindowAtTheBoardLayer::test_a_disabled_schedule_never_silences_the_board
FAILED tests/test_silence_board_layer.py::TestSilenceWindowAtTheBoardLayer::test_board_without_its_own_override_inherits_the_install_wide_window
========================= 8 failed, 2 passed in 0.16s ==========================
```

Breakages A–D together cover all 10 tests in the file.
</details>

<details>
<summary><b>#1734 — Breakage E1: remove <code>schedule.run_pending()</code> from the loop → 4 failed</b></summary>

```
=================================== FAILURES ===================================
_ TestScheduleBoundary.test_board_switches_pages_when_the_clock_crosses_a_schedule_boundary _
    assert client.texts == ["MORNING", "DAY"]
E   AssertionError: assert ['MORNING'] == ['MORNING', 'DAY']
E     Right contains one more item: 'DAY'
_ TestScheduleBoundary.test_the_new_page_reaches_the_board_within_one_polling_interval _
    lag = (client.first_sent_at("DAY") - SCHEDULE_BOUNDARY).total_seconds()
E   AssertionError: 'DAY' never reached the board; got ['MORNING']
___ TestPollingCadence.test_the_board_is_redriven_once_per_polling_interval ____
    assert offsets == [0, 15, 30, 45, 60]
E   assert [0.0] == [0, 15, 30, 45, 60]
E     Right contains 4 more items, first extra item: 15
__ TestPollingCadence.test_raising_the_polling_interval_slows_the_board_down ___
    assert offsets == [0, 30, 60]
E   assert [0.0] == [0, 30, 60]
E     Right contains 2 more items, first extra item: 30
=================== 4 failed, 4 passed, 3 warnings in 0.17s ====================
```

(The `first_sent_at` message shown is from the current code; at the time of the
run this assertion read `KeyError: 'DAY'` before the helper was introduced.)
</details>

<details>
<summary><b>#1734 — Breakage E2: collection gate uses <code>polling_interval</code> instead of <code>seconds_until_next_check</code> → 3 failed</b></summary>

```
============================= test session starts ==============================
collected 8 items

tests/test_display_loop_timing.py ...FFF..                               [100%]

=================================== FAILURES ===================================
_ TestCollectionRotation.test_collection_advances_to_its_next_page_at_the_interval_boundary _
    assert client.texts == ["ALPHA", "BETA"]
E   AssertionError: assert ['ALPHA'] == ['ALPHA', 'BETA']
E     Right contains one more item: 'BETA'
_ TestCollectionRotation.test_the_next_page_arrives_on_the_interval_boundary_not_at_the_next_poll _
E   KeyError: 'BETA'
_ TestCollectionRotation.test_collection_keeps_rotating_across_several_intervals _
    assert client.texts == ["ALPHA", "BETA", "ALPHA", "BETA", "ALPHA"]
E   AssertionError: assert ['ALPHA'] == ['ALPHA', 'BE...ETA', 'ALPHA']
E     Right contains 4 more items, first extra item: 'BETA'
=================== 3 failed, 5 passed, 3 warnings in 0.16s ====================
```
</details>

<details>
<summary><b>#1734 — Breakage E3: add <code>self.check_and_send_active_page()</code> to every 1-second iteration → 2 failed</b></summary>

```
============================= test session starts ==============================
collected 8 items

tests/test_display_loop_timing.py ......FF                               [100%]

=================================== FAILURES ===================================
___ TestPollingCadence.test_the_board_is_redriven_once_per_polling_interval ____
    assert offsets == [0, 15, 30, 45, 60]
E   assert [0.0, 0.0, 1....3.0, 4.0, ...] == [0, 15, 30, 45, 60]
E     At index 1 diff: 0.0 != 15
E     Left contains 61 more items, first extra item: 4.0
__ TestPollingCadence.test_raising_the_polling_interval_slows_the_board_down ___
    assert offsets == [0, 30, 60]
E   assert [0.0, 0.0, 1....3.0, 4.0, ...] == [0, 30, 60]
E     At index 1 diff: 0.0 != 30
E     Left contains 61 more items, first extra item: 2.0
=================== 2 failed, 6 passed, 3 warnings in 0.22s ====================
```

This is the exact regression the cadence tests exist to catch: a 1 Hz drive
produces 61 board sends where 5 are correct.
</details>

<details>
<summary><b>#1734 — Breakage E4: remove the unchanged-content dedupe → 6 failed</b></summary>

```
============================= test session starts ==============================
collected 8 items

tests/test_display_loop_timing.py FFFF.F..                               [100%]

=================================== FAILURES ===================================
_ TestScheduleBoundary.test_board_switches_pages_when_the_clock_crosses_a_schedule_boundary _
    assert client.texts == ["MORNING", "DAY"]
E   AssertionError: assert ['MORNING', 'DAY', 'DAY'] == ['MORNING', 'DAY']
E     Left contains one more item: 'DAY'
_ TestScheduleBoundary.test_the_new_page_reaches_the_board_within_one_polling_interval _
    assert 0 <= lag <= polling_interval
E   assert 110.0 <= 15
_ TestScheduleBoundary.test_no_further_sends_once_the_schedule_settles_on_a_page _
    assert client.texts == ["DAY"]
E   AssertionError: assert ['DAY', 'DAY'...', 'DAY', ...] == ['DAY']
E     Left contains 20 more items, first extra item: 'DAY'
```

Breakages E1–E4 together cover all 8 tests in the file.
</details>

## Status

```
$ python -m pytest tests/test_display_loop_timing.py tests/test_silence_board_layer.py -q --no-header
18 passed, 3 warnings in 0.20s
```

Surrounding suites, no regressions:

```
$ python -m pytest tests/test_adaptive_board_refresh.py tests/test_board_paused.py \
    tests/test_display_loop_timing.py tests/test_integration_multi_features.py tests/test_logs.py \
    tests/test_multi_board_driving.py tests/test_per_board_engine.py tests/test_schedule_board_id_bug.py \
    tests/test_silence_board_layer.py tests/test_silence_mode_display.py tests/test_service_lifecycle.py \
    tests/test_silence_indicator_rendering.py tests/test_silence_schedule_polling.py \
    tests/test_trigger_render_path.py -q --no-header
161 passed, 3 warnings in 7.12s

$ python -m pytest tests/test_silence_schedule_endpoint.py tests/test_silence_config_properties.py \
    tests/test_displays.py tests/test_displays_batch.py tests/test_collections.py ... -q --no-header
267 passed, 88 warnings in 1.03s
```

The three `DeprecationWarning`s are pre-existing `datetime.utcnow()` calls in
`src/collections/`, surfaced because these tests construct a real `Collection`.

Ruff (`check` + `format --check`) clean on all touched files.

No production code is modified by this PR.
