### PR TITLE
test: E2E safety net for plugin lifecycle and persistence round-trips

### DIFF
--- a/tests/test_persistence_round_trip.py
+++ b/tests/test_persistence_round_trip.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import functools
 import json
+import uuid
 from pathlib import Path
 
 import pytest
@@ -403,7 +404,64 @@ def test_backup_import_restores_every_data_file_byte_for_byte(client, isolated_d
     assert client.post("/backup/import?reinstall_plugins=false", json=backup).status_code == 200
 
     after = {name: json.loads((isolated_data_dir / name).read_text()) for name in DATA_FILES}
+
+    # `config.json` legitimately gains one key the export did not carry, and
+    # only that one. #1817 made the restore path call
+    # `PluginRegistry.initialize(force=True)` (`_reload_services`) so restored
+    # plugin configs reach the live plugin objects. That reload runs the v2->v3
+    # plugin migration, which stamps `plugin_migrations.v2_completed` to record
+    # that it has now run for *this* config.
+    #
+    # This is derived state about the installation, not user data, and
+    # re-deriving it is what makes a v2-era backup restore correctly onto a v3
+    # instance: the migration is what re-installs plugin configs whose code was
+    # extracted out of the app, and the flag is what stops it resurrecting a
+    # deliberately-uninstalled plugin on the next boot (#937/#948/#1102/#1301).
+    # `_reload_services` reloads ConfigManager from disk *before* the registry
+    # reload, so the migration reads what the backup wrote rather than a stale
+    # in-memory copy — pinned by
+    # `test_backup_import_is_not_clobbered_by_the_pre_restore_config_manager`.
+    #
+    # So the contract is "restore loses nothing and alters nothing", not
+    # "restore reproduces the file byte for byte". Asserted as exactly that,
+    # which is stricter than ignoring the key: nothing else may be added, the
+    # added value must be the completed flag, and every exported byte must
+    # still come back unchanged.
+    added = set(after["config.json"]) - set(before["config.json"])
+    assert added == {"plugin_migrations"}, f"restore added unexpected config.json keys: {sorted(added)}"
+    assert after["config.json"].pop("plugin_migrations") == {"v2_completed": True}
     assert after == before
+
+
+def test_backup_import_is_not_clobbered_by_the_pre_restore_config_manager(client, isolated_data_dir):
+    """The plugin-registry reload that follows a restore must read the restored config.
+
+    `src.backup.service._reload_services` reloads ConfigManager from disk
+    *before* it calls `PluginRegistry.initialize(force=True)` (#1817). That
+    order is load-bearing and easy to lose: the registry reload runs the v2->v3
+    plugin migration, which writes back through ConfigManager. Run it against
+    the pre-restore in-memory config and the write lands on top of the file the
+    restore just produced — the "an upgrade stranded my plugin configs" failure
+    shape of #948/#1102/#1301, reached this time through a restore.
+
+    It is also the reason `test_backup_import_restores_every_data_file_byte_for_byte`
+    tolerates a re-derived `plugin_migrations` key: the migration is *supposed*
+    to run here, over restored data.
+    """
+    assert client.put("/settings/ai", json={"enabled": True, "providers": [_AI_PROVIDER]}).status_code == 200
+    backup = client.get("/backup/export").json()
+
+    # Diverge the live config (and the live ConfigManager) from the backup.
+    assert client.put("/settings/ai", json={"enabled": False, "providers": []}).status_code == 200
+    assert json.loads((isolated_data_dir / "config.json").read_text())["ai_providers"]["enabled"] is False
+
+    assert client.post("/backup/import?reinstall_plugins=false", json=backup).status_code == 200
+
+    on_disk = json.loads((isolated_data_dir / "config.json").read_text())
+    assert on_disk["ai_providers"]["enabled"] is True, (
+        "the post-restore reload wrote the pre-restore config back over the restored one"
+    )
+    assert [p["id"] for p in on_disk["ai_providers"]["providers"]] == [_AI_PROVIDER["id"]]
 
 
 def test_restored_state_survives_a_restart(client, isolated_data_dir):
@@ -436,18 +494,49 @@ def test_import_rejects_a_document_that_is_not_a_backup(client, isolated_data_di
 def test_the_isolation_fixture_keeps_writes_out_of_the_repo_data_dir(client, isolated_data_dir):
     """Guard for #1762: these tests must never touch the developer's data/.
 
-    If the fixture stops covering a store, that store writes into the repo and
-    this assertion is the thing that notices.
+    Every store is written with a marker unique to this run, then the repo's
+    ``data/`` is searched for it. Looking for *our own* content is what makes
+    this order-independent, the way the sibling guard in
+    ``test_plugin_lifecycle_round_trip.py`` does it.
+
+    A wholesale comparison of the repo's files — of mtimes or of bytes — would
+    be a cross-worker race instead of a guard: other suites in the same
+    ``-n auto`` run legitimately write ``<repo>/data/config.json``
+    (``test_config_manager.py`` does), so it would fail on their writes, not on
+    a leak from here. Verified: swapping this for a byte comparison fails 5 runs
+    in 6 alongside ``tests/test_config_manager.py``.
     """
+    from src.backup.service import DATA_FILES
+
+    marker = f"isolation-guard-{uuid.uuid4().hex}"
     repo_data = Path(__file__).resolve().parent.parent / "data"
-    before = {p.name: p.stat().st_mtime_ns for p in repo_data.glob("*.json")} if repo_data.exists() else {}
 
-    page = _create_page(client)
-    _create_schedule(client, page["id"])
-    _create_collection(client, page["id"])
-    assert client.put("/settings/display", json={"reduce_motion": True}).status_code == 200
-    assert client.put("/settings/ai", json={"enabled": True, "providers": [_AI_PROVIDER]}).status_code == 200
+    page = _create_page(client, name=marker)  # pages.json
+    _create_schedule(client, page["id"])  # schedules.json
+    _create_collection(client, page["id"])  # collections.json
+    assert client.put("/settings/mqtt", json={"broker_host": marker}).status_code == 200  # settings.json
+    ai = client.put("/settings/ai", json={"enabled": True, "providers": [{**_AI_PROVIDER, "name": marker}]})
+    assert ai.status_code == 200, ai.text  # config.json
 
-    assert (isolated_data_dir / "pages.json").exists(), "the fixture never redirected pages.json"
-    after = {p.name: p.stat().st_mtime_ns for p in repo_data.glob("*.json")} if repo_data.exists() else {}
-    assert after == before
+    # Both tokens are unique to this run: the marker string this test chose,
+    # and the id the API minted for its page.
+    written_token = {
+        "pages.json": marker,
+        "schedules.json": page["id"],
+        "collections.json": page["id"],
+        "settings.json": marker,
+        "config.json": marker,
+    }
+    assert set(written_token) == set(DATA_FILES), "DATA_FILES changed — give the new file a token"
+
+    for name, token in written_token.items():
+        written = isolated_data_dir / name
+        assert written.exists(), f"the fixture never redirected {name}"
+        assert token in written.read_text(), f"{name} did not receive this test's write"
+
+    for name in DATA_FILES:
+        leaked = repo_data / name
+        if leaked.exists():
+            text = leaked.read_text()
+            assert marker not in text, f"this test's data leaked into <repo>/data/{name}"
+            assert page["id"] not in text, f"this test's page leaked into <repo>/data/{name}"

--- a/tests/test_persistence_round_trip.py
+++ b/tests/test_persistence_round_trip.py
@@ -1,0 +1,438 @@
+"""Persistence round-trips: state written through the API survives a restart.
+
+Part of #1730 Phase 0 (issue #1736). Every existing persistence test writes and
+re-reads inside one process, with the service singletons still holding their
+in-memory copy of the data — so a store that never actually flushed to disk, or
+one whose loader silently drops a field, still passes. These tests close that
+gap: they write through HTTP, throw every singleton away (which is what a
+container restart does to on-disk-backed state), and read the same values back
+through HTTP off the JSON files alone.
+
+Two things are deliberate:
+
+* **Everything goes through the API.** The point is the whole write path —
+  route handler, service, storage, JSON encoder — not one store's `_save`.
+* **Nothing hand-writes `pages.json`.** The schema-version machinery in
+  ``src/pages/storage.py`` stamps ``CURRENT_SCHEMA_VERSION`` on save and runs
+  migrations on load; seeding a file by hand would bypass exactly the code the
+  restart is supposed to exercise.
+
+Data isolation (see #1762): the app has no single data-directory seam. Each
+store resolves its own path from ``Path(__file__)`` at construction time, so
+``isolated_data_dir`` has to rebind five different constructors to keep the
+suite off the developer's real ``data/`` directory. That fixture is the
+workaround, not the fix.
+"""
+
+from __future__ import annotations
+
+import functools
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.config_manager import ConfigManager
+
+# ── isolation ───────────────────────────────────────────────────────────────
+
+#: Module path + attribute name of every service singleton that caches
+#: on-disk state. This is the same list ``src.backup.service._reload_services``
+#: drops after a restore — i.e. the app's own definition of "re-read from disk".
+_SINGLETONS: tuple[tuple[str, str], ...] = (
+    ("src.settings.service", "_settings_service"),
+    ("src.pages.service", "_page_service"),
+    ("src.collections.service", "_collection_service"),
+    ("src.schedules.service", "_schedule_service"),
+    ("src.backup.service", "_backup_service"),
+)
+
+
+def _drop_singletons() -> None:
+    """Forget every cached service instance, as a process restart would.
+
+    ``ConfigManager`` is cleared through the class imported at module scope,
+    never through ``src.config_manager.ConfigManager``: the isolation fixture
+    rebinds that name to a ``functools.partial``, and assigning ``_instance``
+    on the partial leaves the class-level singleton — pointing at the repo's
+    real ``data/config.json`` — very much alive.
+    """
+    import importlib
+
+    ConfigManager._instance = None  # type: ignore[attr-defined]
+    for module_path, attr in _SINGLETONS:
+        setattr(importlib.import_module(module_path), attr, None)
+
+
+def _bind_backup_service(data_dir: Path) -> None:
+    """Rebuild the backup singleton against *data_dir*."""
+    import src.backup.service as backup_module
+
+    backup_module._backup_service = backup_module.BackupService(data_dir=data_dir)
+
+
+@pytest.fixture
+def isolated_data_dir(tmp_path, monkeypatch):
+    """Point every on-disk store at *tmp_path* and hand back that path.
+
+    Rebinds the class each singleton factory instantiates, so the *next*
+    construction — including the ones that happen after a simulated restart —
+    lands in the temp directory rather than the repo's ``data/``.
+    """
+    from src.collections.storage import CollectionStorage
+    from src.pages.storage import PageStorage
+    from src.schedules.storage import ScheduleStorage
+    from src.settings.service import SettingsService
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+
+    bindings = (
+        ("src.config_manager.ConfigManager", ConfigManager, {"config_path": str(data_dir / "config.json")}),
+        ("src.settings.service.SettingsService", SettingsService, {"settings_file": str(data_dir / "settings.json")}),
+        ("src.pages.service.PageStorage", PageStorage, {"storage_file": str(data_dir / "pages.json")}),
+        (
+            "src.schedules.service.ScheduleStorage",
+            ScheduleStorage,
+            {"storage_file": str(data_dir / "schedules.json")},
+        ),
+        (
+            "src.collections.service.CollectionStorage",
+            CollectionStorage,
+            {"storage_file": str(data_dir / "collections.json")},
+        ),
+    )
+    for target, cls, kwargs in bindings:
+        monkeypatch.setattr(target, functools.partial(cls, **kwargs))
+
+    _drop_singletons()
+    # BackupService takes its data dir up front, so the *instance* is bound
+    # rather than the class; _drop_singletons has to run first or it clears it.
+    _bind_backup_service(data_dir)
+    try:
+        yield data_dir
+    finally:
+        _drop_singletons()
+
+
+@pytest.fixture
+def client(isolated_data_dir):
+    """A TestClient whose every request resolves services from the temp dir."""
+    from src.api_server import app
+
+    return TestClient(app)
+
+
+def _restart(data_dir: Path) -> TestClient:
+    """Throw away all in-memory state and return a client reading from disk.
+
+    Route handlers resolve their services per request through the singleton
+    getters, so dropping the singletons is precisely what a container restart
+    does: the next request rebuilds each store by parsing the JSON files.
+    """
+    from src.api_server import app
+
+    _drop_singletons()
+    _bind_backup_service(data_dir)
+    return TestClient(app)
+
+
+# ── seed helpers ────────────────────────────────────────────────────────────
+
+#: A throwaway AI provider. Its api_key is a placeholder, never a real key.
+_AI_PROVIDER = {
+    "id": "test-provider",
+    "name": "Test Provider",
+    "base_url": "https://llm.example.test/v1",
+    "api_key": "test_api_key_placeholder",
+    "models": ["test-model"],
+    "default_model": "test-model",
+}
+
+
+def _create_page(client: TestClient, name: str = "Restart Survivor") -> dict:
+    response = client.post(
+        "/pages",
+        json={
+            "name": name,
+            "type": "template",
+            "template": ["HELLO", "FROM DISK", "", "", "", ""],
+            "duration_seconds": 42,
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["page"]
+
+
+def _create_schedule(client: TestClient, page_id: str) -> dict:
+    response = client.post(
+        "/schedules",
+        json={"page_id": page_id, "start_time": "07:30", "end_time": "09:15", "day_pattern": "weekdays"},
+    )
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+def _create_collection(client: TestClient, page_id: str) -> dict:
+    response = client.post(
+        "/collections",
+        json={"name": "Mornings", "page_ids": [page_id]},
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["collection"]
+
+
+# ── restart round-trips ─────────────────────────────────────────────────────
+
+
+def test_page_survives_a_restart(client, isolated_data_dir):
+    """A page created through the API is byte-identical after a restart."""
+    created = _create_page(client)
+
+    after = _restart(isolated_data_dir).get(f"/pages/{created['id']}")
+
+    assert after.status_code == 200, after.text
+    assert after.json() == created
+
+
+def test_schedule_survives_a_restart(client, isolated_data_dir):
+    """A schedule entry keeps every field across a restart."""
+    page = _create_page(client)
+    created = _create_schedule(client, page["id"])
+
+    after = _restart(isolated_data_dir).get(f"/schedules/{created['id']}")
+
+    assert after.status_code == 200, after.text
+    assert after.json()["start_time"] == created["start_time"]
+    assert after.json()["end_time"] == created["end_time"]
+    assert after.json()["day_pattern"] == created["day_pattern"]
+    assert after.json()["page_id"] == page["id"]
+
+
+def test_collection_survives_a_restart(client, isolated_data_dir):
+    """A collection keeps its member pages across a restart."""
+    page = _create_page(client)
+    created = _create_collection(client, page["id"])
+
+    after = _restart(isolated_data_dir).get(f"/collections/{created['id']}")
+
+    assert after.status_code == 200, after.text
+    assert after.json()["name"] == "Mornings"
+    assert after.json()["page_ids"] == [page["id"]]
+
+
+def test_display_settings_survive_a_restart(client, isolated_data_dir):
+    """settings.json values written through the API reload from disk."""
+    written = client.put(
+        "/settings/display",
+        json={"reduce_motion": True, "board_animations": "off", "site_animations": "off"},
+    )
+    assert written.status_code == 200, written.text
+
+    after = _restart(isolated_data_dir).get("/settings/display")
+
+    assert after.status_code == 200, after.text
+    assert after.json()["reduce_motion"] is True
+    assert after.json()["board_animations"] == "off"
+    assert after.json()["site_animations"] == "off"
+
+
+def test_polling_settings_survive_a_restart(client, isolated_data_dir):
+    """A numeric settings field round-trips without being coerced or reset."""
+    written = client.put("/settings/polling", json={"interval_seconds": 37})
+    assert written.status_code == 200, written.text
+
+    after = _restart(isolated_data_dir).get("/settings/polling")
+
+    assert after.status_code == 200, after.text
+    assert after.json()["interval_seconds"] == 37
+
+
+def test_board_type_survives_a_restart(client, isolated_data_dir):
+    """The board settings block reloads from settings.json."""
+    written = client.put("/settings/board", json={"board_type": "white"})
+    assert written.status_code == 200, written.text
+
+    after = _restart(isolated_data_dir).get("/settings/board")
+
+    assert after.status_code == 200, after.text
+    assert after.json()["board_type"] == "white"
+
+
+def test_config_json_survives_a_restart(client, isolated_data_dir):
+    """config.json is a different store from settings.json and also reloads.
+
+    ``/settings/ai`` is the AI-provider block in ``config.json``, written
+    through ``ConfigManager`` rather than ``SettingsService``.
+    """
+    written = client.put("/settings/ai", json={"enabled": True, "providers": [_AI_PROVIDER]})
+    assert written.status_code == 200, written.text
+
+    after = _restart(isolated_data_dir).get("/settings/ai")
+
+    assert after.status_code == 200, after.text
+    assert after.json()["enabled"] is True
+    assert [p["id"] for p in after.json()["providers"]] == [_AI_PROVIDER["id"]]
+
+
+def test_a_secret_in_config_json_survives_a_restart_unmasked_on_disk(client, isolated_data_dir):
+    """The stored secret must be the real key, not the mask the API returns.
+
+    A restart re-reads ``config.json``; if the mask had been persisted the
+    credential would be gone for good.
+    """
+    assert client.put("/settings/ai", json={"enabled": True, "providers": [_AI_PROVIDER]}).status_code == 200
+
+    _restart(isolated_data_dir)
+
+    stored = json.loads((isolated_data_dir / "config.json").read_text())
+    assert stored["ai_providers"]["providers"][0]["api_key"] == _AI_PROVIDER["api_key"]
+
+
+def test_pages_file_is_stamped_with_the_current_schema_version(client, isolated_data_dir):
+    """Saving through the API stamps the version the migration ladder expects.
+
+    Without the stamp every subsequent load re-runs the whole ladder from 0.
+    """
+    from src.pages.storage import CURRENT_SCHEMA_VERSION
+
+    _create_page(client)
+
+    on_disk = json.loads((isolated_data_dir / "pages.json").read_text())
+    assert on_disk["schema_version"] == CURRENT_SCHEMA_VERSION
+
+
+def test_restart_does_not_re_migrate_an_already_current_pages_file(client, isolated_data_dir):
+    """A restart must not treat current data as un-migrated.
+
+    ``PageStorage._load`` snapshots the file to ``pages.json.v<n>_backup``
+    before the first migration runs. If that backup appears on a plain restart,
+    the version gate is being ignored and every restart is rewriting user data.
+    """
+    _create_page(client)
+
+    restarted = _restart(isolated_data_dir)
+    assert restarted.get("/pages").status_code == 200
+
+    assert not list(isolated_data_dir.glob("pages.json.v*_backup"))
+
+
+# ── backup export → import round-trips ──────────────────────────────────────
+
+
+def test_backup_export_is_a_recognisable_backup_document(client):
+    """The exported payload carries the marker its own importer requires."""
+    from src.backup.service import BACKUP_FILE_MARKER, BACKUP_SCHEMA_VERSION
+
+    exported = client.get("/backup/export")
+
+    assert exported.status_code == 200, exported.text
+    payload = exported.json()
+    assert payload[BACKUP_FILE_MARKER] is True
+    assert payload["schema_version"] == BACKUP_SCHEMA_VERSION
+
+
+def test_backup_import_restores_a_deleted_page(client, isolated_data_dir):
+    """Export, delete the page, import — the page comes back unchanged."""
+    page = _create_page(client)
+    backup = client.get("/backup/export").json()
+
+    assert client.delete(f"/pages/{page['id']}").status_code == 200
+    assert client.get(f"/pages/{page['id']}").status_code == 404
+
+    imported = client.post("/backup/import?reinstall_plugins=false", json=backup)
+    assert imported.status_code == 200, imported.text
+
+    restored = client.get(f"/pages/{page['id']}")
+    assert restored.status_code == 200, restored.text
+    assert restored.json() == page
+
+
+def test_backup_import_restores_overwritten_settings(client):
+    """A settings value changed after the export is rolled back by the import."""
+    assert client.put("/settings/display", json={"reduce_motion": True}).status_code == 200
+    backup = client.get("/backup/export").json()
+
+    assert client.put("/settings/display", json={"reduce_motion": False}).status_code == 200
+    assert client.get("/settings/display").json()["reduce_motion"] is False
+
+    assert client.post("/backup/import?reinstall_plugins=false", json=backup).status_code == 200
+
+    assert client.get("/settings/display").json()["reduce_motion"] is True
+
+
+def test_backup_import_restores_every_data_file_byte_for_byte(client, isolated_data_dir):
+    """Every file the backup format covers is restored to its exported content.
+
+    Model-level checks can hide a field the encoder drops on the way out. This
+    compares the parsed JSON of all five ``DATA_FILES`` before and after.
+    """
+    from src.backup.service import DATA_FILES
+
+    page = _create_page(client)
+    _create_schedule(client, page["id"])
+    _create_collection(client, page["id"])
+    assert client.put("/settings/display", json={"reduce_motion": True}).status_code == 200
+    assert client.put("/settings/ai", json={"enabled": True, "providers": [_AI_PROVIDER]}).status_code == 200
+
+    before = {name: json.loads((isolated_data_dir / name).read_text()) for name in DATA_FILES}
+    backup = client.get("/backup/export").json()
+
+    # Mutate every store so a no-op import cannot pass.
+    assert client.delete(f"/pages/{page['id']}").status_code == 200
+    assert client.put("/settings/display", json={"reduce_motion": False}).status_code == 200
+    after_mutation = {name: json.loads((isolated_data_dir / name).read_text()) for name in DATA_FILES}
+    assert after_mutation != before, "the mutation step changed nothing — the test proves nothing"
+
+    assert client.post("/backup/import?reinstall_plugins=false", json=backup).status_code == 200
+
+    after = {name: json.loads((isolated_data_dir / name).read_text()) for name in DATA_FILES}
+    assert after == before
+
+
+def test_restored_state_survives_a_restart(client, isolated_data_dir):
+    """An import writes to disk, not just to the in-memory singletons."""
+    page = _create_page(client)
+    backup = client.get("/backup/export").json()
+
+    assert client.delete(f"/pages/{page['id']}").status_code == 200
+    assert client.post("/backup/import?reinstall_plugins=false", json=backup).status_code == 200
+
+    after = _restart(isolated_data_dir).get(f"/pages/{page['id']}")
+
+    assert after.status_code == 200, after.text
+    assert after.json() == page
+
+
+def test_import_rejects_a_document_that_is_not_a_backup(client, isolated_data_dir):
+    """An arbitrary JSON upload must not be written over the data directory."""
+    page = _create_page(client)
+
+    response = client.post("/backup/import?reinstall_plugins=false", json={"pages": {"pages": []}})
+
+    assert response.status_code == 400
+    assert client.get(f"/pages/{page['id']}").status_code == 200, "a rejected upload still overwrote pages.json"
+
+
+# ── isolation guard ─────────────────────────────────────────────────────────
+
+
+def test_the_isolation_fixture_keeps_writes_out_of_the_repo_data_dir(client, isolated_data_dir):
+    """Guard for #1762: these tests must never touch the developer's data/.
+
+    If the fixture stops covering a store, that store writes into the repo and
+    this assertion is the thing that notices.
+    """
+    repo_data = Path(__file__).resolve().parent.parent / "data"
+    before = {p.name: p.stat().st_mtime_ns for p in repo_data.glob("*.json")} if repo_data.exists() else {}
+
+    page = _create_page(client)
+    _create_schedule(client, page["id"])
+    _create_collection(client, page["id"])
+    assert client.put("/settings/display", json={"reduce_motion": True}).status_code == 200
+    assert client.put("/settings/ai", json={"enabled": True, "providers": [_AI_PROVIDER]}).status_code == 200
+
+    assert (isolated_data_dir / "pages.json").exists(), "the fixture never redirected pages.json"
+    after = {p.name: p.stat().st_mtime_ns for p in repo_data.glob("*.json")} if repo_data.exists() else {}
+    assert after == before

--- a/tests/test_persistence_round_trip.py
+++ b/tests/test_persistence_round_trip.py
@@ -50,14 +50,7 @@ _SINGLETONS: tuple[tuple[str, str], ...] = (
 
 
 def _drop_singletons() -> None:
-    """Forget every cached service instance, as a process restart would.
-
-    ``ConfigManager`` is cleared through the class imported at module scope,
-    never through ``src.config_manager.ConfigManager``: the isolation fixture
-    rebinds that name to a ``functools.partial``, and assigning ``_instance``
-    on the partial leaves the class-level singleton — pointing at the repo's
-    real ``data/config.json`` — very much alive.
-    """
+    """Forget every cached service instance, as a process restart would."""
     import importlib
 
     ConfigManager._instance = None  # type: ignore[attr-defined]
@@ -70,6 +63,26 @@ def _bind_backup_service(data_dir: Path) -> None:
     import src.backup.service as backup_module
 
     backup_module._backup_service = backup_module.BackupService(data_dir=data_dir)
+
+
+def _bind_config_manager(data_dir: Path) -> None:
+    """Rebuild the ConfigManager singleton against *data_dir*.
+
+    ``ConfigManager`` cannot be redirected the way the storage classes are,
+    by rebinding ``src.config_manager.ConfigManager`` to a pre-bound
+    constructor: ``_apply_env_overrides`` reaches the *class* through that
+    same module global (``ConfigManager._is_placeholder``, config_manager.py),
+    and a constructor stand-in carries no class attributes. That path only
+    runs when a board env var is set — which CI does (``BOARD_READ_WRITE_KEY``)
+    and a bare local shell does not — so the rebind raised ``AttributeError``
+    on CI only.
+
+    Constructing the singleton directly is also the more faithful restart:
+    it is what ``_bind_backup_service`` already does, and it re-reads
+    ``config.json`` off disk exactly as a fresh process would.
+    """
+    ConfigManager._instance = None  # type: ignore[attr-defined]
+    ConfigManager(config_path=str(data_dir / "config.json"))
 
 
 @pytest.fixture
@@ -89,7 +102,6 @@ def isolated_data_dir(tmp_path, monkeypatch):
     data_dir.mkdir()
 
     bindings = (
-        ("src.config_manager.ConfigManager", ConfigManager, {"config_path": str(data_dir / "config.json")}),
         ("src.settings.service.SettingsService", SettingsService, {"settings_file": str(data_dir / "settings.json")}),
         ("src.pages.service.PageStorage", PageStorage, {"storage_file": str(data_dir / "pages.json")}),
         (
@@ -107,9 +119,11 @@ def isolated_data_dir(tmp_path, monkeypatch):
         monkeypatch.setattr(target, functools.partial(cls, **kwargs))
 
     _drop_singletons()
-    # BackupService takes its data dir up front, so the *instance* is bound
-    # rather than the class; _drop_singletons has to run first or it clears it.
+    # BackupService and ConfigManager take their path up front, so the
+    # *instance* is bound rather than the class; _drop_singletons has to run
+    # first or it clears them.
     _bind_backup_service(data_dir)
+    _bind_config_manager(data_dir)
     try:
         yield data_dir
     finally:
@@ -135,6 +149,7 @@ def _restart(data_dir: Path) -> TestClient:
 
     _drop_singletons()
     _bind_backup_service(data_dir)
+    _bind_config_manager(data_dir)
     return TestClient(app)
 
 

--- a/tests/test_plugin_lifecycle_round_trip.py
+++ b/tests/test_plugin_lifecycle_round_trip.py
@@ -1,0 +1,530 @@
+"""Plugin lifecycle round-trips driven through the HTTP API.
+
+Part of #1730 Phase 0 (issue #1735). The existing plugin suite is either
+registry-level (`test_plugin_instances.py`) or mocks the registry away at the
+route boundary (`test_plugin_detail_plugin_type.py`), and the browser specs
+stub the network. So three things nothing currently pins:
+
+* **Fan-out isolation** — one plugin raising in ``fetch_data`` must not take
+  the render down with it, and must not leak its exception text onto a board.
+* **Secret masking** — reading a config back gives ``"***"``; writing that
+  same document back must leave the stored credential intact. This is the
+  round-trip #1743 exists to protect; the assertions below hold on today's
+  code and are here so the Phase-1 rework of the config-write path cannot
+  quietly regress them.
+* **Instances** — configs keyed by ``INSTANCE_SEPARATOR`` are independent of
+  the base plugin's, render under their own namespace, and are purged when the
+  instance (or the whole plugin) goes away.
+
+Nothing is mocked. Two stub plugins are written to disk and loaded by the real
+``PluginLoader``; a real ``ConfigManager`` writes a real ``config.json``. Only
+the git clone is replaced, by a copy from a local staging directory, so
+install works without the network.
+
+Data isolation (see #1762): ``PluginLoader`` with no ``external_dirs``
+resolves — and *creates* — ``<repo>/data/external_plugins``, and
+``ConfigManager`` defaults to ``<repo>/data/config.json``. The fixture below
+has to override both by hand; there is no data-directory seam to point at
+a temp path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+import src.plugins.registry as registry_module
+import src.templates.engine as engine_module
+from src.config_manager import ConfigManager
+from src.plugins.loader import PluginLoader
+from src.plugins.registry import INSTANCE_SEPARATOR, PluginRegistry
+
+# ── stub plugins ────────────────────────────────────────────────────────────
+
+HEALTHY = "stub_ok"
+RAISING = "stub_broken"
+EXTERNAL = "stub_external"
+
+#: What the healthy stub reports. Distinctive enough to spot in board output.
+HEALTHY_VALUE = "OKDATA"
+
+#: The message the raising stub blows up with. Must never reach a board.
+BOOM = "STUBBOOM"
+
+#: A placeholder credential — never a real key.
+SECRET = "test_secret_key_abcd"
+
+#: What the API substitutes for a stored secret on the way out.
+MASK = "***"
+
+
+def _manifest(plugin_id: str) -> dict[str, Any]:
+    return {
+        "id": plugin_id,
+        "name": plugin_id.replace("_", " ").title(),
+        "version": "1.0.0",
+        "description": "Fixture plugin for tests/test_plugin_lifecycle_round_trip.py.",
+        "author": "FiestaBoard Tests",
+        "icon": "puzzle",
+        "category": "utility",
+        "settings_schema": {
+            "type": "object",
+            "properties": {
+                "label": {"type": "string", "title": "Label"},
+                "api_key": {"type": "string", "title": "API Key", "ui:widget": "password"},
+                "enabled": {"type": "boolean", "title": "Enabled", "default": False},
+            },
+        },
+        "variables": {
+            "simple": {
+                "value": {"description": "A constant", "type": "string", "max_length": 12, "example": HEALTHY_VALUE},
+                "key_tail": {
+                    "description": "Last 4 chars of the live api_key",
+                    "type": "string",
+                    "max_length": 8,
+                    "example": "abcd",
+                },
+            }
+        },
+    }
+
+
+#: ``key_tail`` is the only HTTP-observable window onto the credential the
+#: *live* plugin object is holding — which is the half of the masking contract
+#: that a config.json assertion cannot see.
+#:
+#: Placeholders are substituted with ``str.replace``, not ``str.format``: the
+#: plugin bodies are full of braces and every one of them would have to be
+#: doubled.
+_HEALTHY_SOURCE = """\
+\"\"\"Fixture plugin: always succeeds.\"\"\"
+
+from src.plugins.base import PluginBase, PluginResult
+
+
+class HealthyStub(PluginBase):
+    @property
+    def plugin_id(self) -> str:
+        return "__PLUGIN_ID__"
+
+    def fetch_data(self) -> PluginResult:
+        key = self.config.get("api_key") or ""
+        return PluginResult(available=True, data={"value": "__HEALTHY_VALUE__", "key_tail": key[-4:]})
+"""
+
+_RAISING_SOURCE = """\
+\"\"\"Fixture plugin: always raises.\"\"\"
+
+from src.plugins.base import PluginBase, PluginResult
+
+
+class RaisingStub(PluginBase):
+    @property
+    def plugin_id(self) -> str:
+        return "__PLUGIN_ID__"
+
+    def fetch_data(self) -> PluginResult:
+        raise RuntimeError("__BOOM__")
+"""
+
+
+def _write_plugin(directory: Path, plugin_id: str, source: str) -> None:
+    """Write a real, loadable plugin package to *directory*."""
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "manifest.json").write_text(json.dumps(_manifest(plugin_id)), encoding="utf-8")
+    body = source.replace("__PLUGIN_ID__", plugin_id).replace("__HEALTHY_VALUE__", HEALTHY_VALUE)
+    (directory / "__init__.py").write_text(body.replace("__BOOM__", BOOM), encoding="utf-8")
+
+
+class _LocalRegistry(PluginRegistry):
+    """A real registry whose "registry install" copies from a local directory.
+
+    Everything after the copy is production code — the real loader imports the
+    package and the real bookkeeping runs. Only the network fetch is replaced.
+    """
+
+    def __init__(self, plugins_dir: Path, external_dir: Path, staging_dir: Path):
+        super().__init__(plugins_dir=plugins_dir)
+        self._loader = PluginLoader(plugins_dir=plugins_dir, external_dirs=[external_dir])
+        self._external_dir = external_dir
+        self._staging_dir = staging_dir
+
+    def install_from_registry(self, plugin_id: str) -> list[str]:
+        staged = self._staging_dir / plugin_id
+        if not staged.is_dir():
+            return [f"Plugin '{plugin_id}' not found in the registry"]
+
+        shutil.copytree(staged, self._external_dir / plugin_id, dirs_exist_ok=True)
+
+        plugin = self._loader.load_plugin(plugin_id)
+        if plugin is None:
+            return self._loader.load_errors.get(plugin_id, []) or [f"Failed to load plugin: {plugin_id}"]
+
+        manifest = self._loader.get_manifest(plugin_id)
+        assert manifest is not None
+        self._plugins[plugin_id] = plugin
+        self._manifests[plugin_id] = manifest
+        self._enabled[plugin_id] = False
+        self._clear_removed_tombstone(plugin_id)
+        return []
+
+
+# ── fixtures ────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def plugin_env(tmp_path, monkeypatch):
+    """A real registry over stub plugins, wired to the app singletons.
+
+    Teardown order matters and is hand-rolled. The plugin routes call
+    ``reset_template_engine()``, which binds ``get_plugin_registry()`` onto the
+    long-lived engine singleton — so the engine is dropped *after* the registry
+    is put back, or every later test in the session inherits an engine that has
+    never heard of ``date_time``.
+    """
+    builtin_dir = tmp_path / "builtin_plugins"
+    builtin_dir.mkdir()
+    external_dir = tmp_path / "external_plugins"
+    external_dir.mkdir()
+    staging_dir = tmp_path / "staged_plugins"
+
+    _write_plugin(builtin_dir / HEALTHY, HEALTHY, _HEALTHY_SOURCE)
+    _write_plugin(builtin_dir / RAISING, RAISING, _RAISING_SOURCE)
+    _write_plugin(staging_dir / EXTERNAL, EXTERNAL, _HEALTHY_SOURCE)
+
+    config_path = tmp_path / "config.json"
+    ConfigManager._instance = None  # type: ignore[attr-defined]
+    config_manager = ConfigManager(config_path=str(config_path))
+    monkeypatch.setattr("src.config_manager.ConfigManager._instance", config_manager, raising=False)
+
+    original_registry = registry_module._registry
+    original_engine = engine_module._template_engine
+
+    registry = _LocalRegistry(builtin_dir, external_dir, staging_dir)
+    registry.initialize()
+    registry_module._registry = registry
+    engine_module._template_engine = None
+
+    try:
+        yield {
+            "registry": registry,
+            "config_path": config_path,
+            "external_dir": external_dir,
+        }
+    finally:
+        registry_module._registry = original_registry
+        engine_module._template_engine = original_engine
+        ConfigManager._instance = None  # type: ignore[attr-defined]
+
+
+@pytest.fixture
+def client(plugin_env):
+    from src.api_server import app
+
+    return TestClient(app)
+
+
+# ── helpers ─────────────────────────────────────────────────────────────────
+
+
+def _stored_config(config_path: Path, plugin_id: str) -> dict[str, Any] | None:
+    """Read a plugin's config straight out of ``config.json``.
+
+    Deliberately bypasses ConfigManager: the in-memory copy looking right
+    while the file holds the mask is exactly the failure mode under test.
+    """
+    raw = json.loads(config_path.read_text(encoding="utf-8"))
+    return raw.get("plugins", {}).get(plugin_id)
+
+
+def _enable(client: TestClient, plugin_id: str) -> None:
+    response = client.post(f"/plugins/{plugin_id}/enable")
+    assert response.status_code == 200, response.text
+
+
+def _put_config(client: TestClient, plugin_id: str, config: dict[str, Any]) -> dict[str, Any]:
+    response = client.put(f"/plugins/{plugin_id}/config", json={"config": config})
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
+def _render(client: TestClient, line: str) -> str:
+    response = client.post("/templates/render", json={"template": [line, "", "", "", "", ""]})
+    assert response.status_code == 200, response.text
+    return response.json()["rendered"]
+
+
+def _plugin_entry(client: TestClient, plugin_id: str) -> dict[str, Any]:
+    response = client.get("/plugins")
+    assert response.status_code == 200, response.text
+    for entry in response.json()["plugins"]:
+        if entry["id"] == plugin_id:
+            return entry
+    raise AssertionError(f"{plugin_id} is missing from GET /plugins")
+
+
+# ── fan-out isolation ───────────────────────────────────────────────────────
+
+
+def test_a_raising_plugin_does_not_block_a_healthy_plugins_variable(client):
+    """One plugin exploding must not cost the others their data."""
+    _enable(client, HEALTHY)
+    _enable(client, RAISING)
+
+    rendered = _render(client, f"{{{{{HEALTHY}.value}}}}")
+
+    assert HEALTHY_VALUE in rendered
+
+
+def test_a_raising_plugins_error_text_never_reaches_the_board(client):
+    """An exception message is not board content."""
+    _enable(client, HEALTHY)
+    _enable(client, RAISING)
+
+    rendered = _render(client, f"{{{{{RAISING}.value}}}}")
+
+    assert BOOM not in rendered
+
+
+def test_a_raising_plugin_is_reported_unavailable_on_its_own_data_endpoint(client):
+    """The failure is surfaced where it belongs, not silently reported OK."""
+    _enable(client, RAISING)
+
+    response = client.get(f"/plugins/{RAISING}/data")
+
+    assert response.status_code == 503, response.text
+
+
+def test_a_healthy_plugin_still_serves_its_own_data_endpoint_alongside_a_raising_one(client):
+    """A sibling's failure must not be mistaken for this plugin's own."""
+    _enable(client, HEALTHY)
+    _enable(client, RAISING)
+
+    response = client.get(f"/plugins/{HEALTHY}/data")
+
+    assert response.status_code == 200, response.text
+    assert response.json()["data"]["value"] == HEALTHY_VALUE
+
+
+# ── secret masking round-trip ───────────────────────────────────────────────
+
+
+def test_a_stored_api_key_is_masked_when_the_plugin_list_is_read_back(client):
+    """The browser must never hold the real credential."""
+    _put_config(client, HEALTHY, {"label": "primary", "api_key": SECRET})
+
+    assert _plugin_entry(client, HEALTHY)["config"]["api_key"] == MASK
+
+
+def test_a_stored_api_key_is_masked_on_the_plugin_detail_endpoint(client):
+    """The single-plugin route masks too — not just the list."""
+    _put_config(client, HEALTHY, {"label": "primary", "api_key": SECRET})
+
+    response = client.get(f"/plugins/{HEALTHY}")
+
+    assert response.status_code == 200, response.text
+    assert response.json()["config"]["api_key"] == MASK
+
+
+def test_writing_the_masked_api_key_back_preserves_the_stored_secret(client, plugin_env):
+    """The #1743 contract: a form re-save must not destroy the credential."""
+    _put_config(client, HEALTHY, {"label": "primary", "api_key": SECRET})
+
+    _put_config(client, HEALTHY, {"label": "renamed", "api_key": MASK})
+
+    stored = _stored_config(plugin_env["config_path"], HEALTHY)
+    assert stored is not None
+    assert stored["api_key"] == SECRET
+    assert stored["label"] == "renamed", "the non-secret edit was dropped"
+
+
+def test_writing_the_masked_api_key_back_leaves_the_live_plugin_using_the_real_secret(client):
+    """Persisting the key is not enough — the running plugin needs it too."""
+    _enable(client, HEALTHY)
+    _put_config(client, HEALTHY, {"label": "primary", "api_key": SECRET})
+
+    _put_config(client, HEALTHY, {"label": "renamed", "api_key": MASK})
+
+    assert SECRET[-4:] in _render(client, f"{{{{{HEALTHY}.key_tail}}}}")
+
+
+def test_writing_a_new_api_key_replaces_the_stored_secret(client, plugin_env):
+    """Preserving masked values must not also freeze real ones."""
+    _put_config(client, HEALTHY, {"label": "primary", "api_key": SECRET})
+
+    _put_config(client, HEALTHY, {"label": "primary", "api_key": "test_rotated_key_wxyz"})
+
+    assert _stored_config(plugin_env["config_path"], HEALTHY)["api_key"] == "test_rotated_key_wxyz"
+
+
+def test_writing_the_masked_api_key_back_over_mcp_preserves_the_stored_secret(client, plugin_env):
+    """The MCP tool round-trips the masked config it just handed the model."""
+    pytest.importorskip("mcp", reason="mcp package not installed")
+
+    from src.mcp_server import _build_mcp_server
+
+    _put_config(client, HEALTHY, {"label": "primary", "api_key": SECRET})
+
+    mcp = _build_mcp_server()
+    assert mcp is not None, "mcp installed but _build_mcp_server() returned None"
+    tool = mcp._tool_manager._tools["configure_plugin"]
+    result = tool.fn(plugin_id=HEALTHY, config={"label": "renamed", "api_key": MASK})
+    if asyncio.iscoroutine(result):
+        result = asyncio.run(result)
+    assert not result.get("error"), result
+
+    assert _stored_config(plugin_env["config_path"], HEALTHY)["api_key"] == SECRET
+
+
+# ── instances ───────────────────────────────────────────────────────────────
+
+
+def test_creating_an_instance_registers_it_under_the_compound_key(client):
+    """The instance is addressable as ``<base><SEPARATOR><label>``."""
+    created = client.post(f"/plugins/{HEALTHY}/instances", json={"label": "sf"})
+    assert created.status_code == 200, created.text
+
+    listed = client.get(f"/plugins/{HEALTHY}/instances")
+    assert listed.status_code == 200, listed.text
+    assert [i["key"] for i in listed.json()["instances"]] == [f"{HEALTHY}{INSTANCE_SEPARATOR}sf"]
+
+
+def test_an_instance_config_is_independent_of_the_base_plugin_config(client, plugin_env):
+    """Configuring one must not overwrite the other."""
+    instance = f"{HEALTHY}{INSTANCE_SEPARATOR}sf"
+    assert client.post(f"/plugins/{HEALTHY}/instances", json={"label": "sf"}).status_code == 200
+
+    _put_config(client, HEALTHY, {"label": "base"})
+    _put_config(client, instance, {"label": "san francisco"})
+
+    assert _stored_config(plugin_env["config_path"], HEALTHY)["label"] == "base"
+    assert _stored_config(plugin_env["config_path"], instance)["label"] == "san francisco"
+
+
+def test_an_instance_secret_is_masked_independently_of_the_base(client):
+    """Masking follows the compound key, not the base id."""
+    instance = f"{HEALTHY}{INSTANCE_SEPARATOR}sf"
+    assert client.post(f"/plugins/{HEALTHY}/instances", json={"label": "sf"}).status_code == 200
+    _put_config(client, instance, {"api_key": SECRET})
+
+    response = client.get(f"/plugins/{instance}")
+
+    assert response.status_code == 200, response.text
+    assert response.json()["config"]["api_key"] == MASK
+
+
+def test_an_instance_renders_under_its_own_template_namespace(client):
+    """``{{base:label.var}}`` resolves to the instance's own data."""
+    instance = f"{HEALTHY}{INSTANCE_SEPARATOR}sf"
+    assert client.post(f"/plugins/{HEALTHY}/instances", json={"label": "sf"}).status_code == 200
+    _put_config(client, instance, {"api_key": SECRET})
+    _enable(client, instance)
+
+    assert SECRET[-4:] in _render(client, f"{{{{{instance}.key_tail}}}}")
+
+
+def test_deleting_an_instance_purges_its_stored_config(client, plugin_env):
+    """A deleted instance must not leave configuration behind to be adopted."""
+    instance = f"{HEALTHY}{INSTANCE_SEPARATOR}sf"
+    assert client.post(f"/plugins/{HEALTHY}/instances", json={"label": "sf"}).status_code == 200
+    _put_config(client, instance, {"api_key": SECRET})
+
+    deleted = client.delete(f"/plugins/{HEALTHY}/instances/sf")
+    assert deleted.status_code == 200, deleted.text
+
+    assert _stored_config(plugin_env["config_path"], instance) is None
+
+
+def test_deleting_an_instance_leaves_the_base_plugin_config_alone(client, plugin_env):
+    """Prefix-based purging must not swallow the base plugin's own entry."""
+    assert client.post(f"/plugins/{HEALTHY}/instances", json={"label": "sf"}).status_code == 200
+    _put_config(client, HEALTHY, {"label": "base"})
+
+    assert client.delete(f"/plugins/{HEALTHY}/instances/sf").status_code == 200
+
+    assert _stored_config(plugin_env["config_path"], HEALTHY)["label"] == "base"
+
+
+# ── install → configure → uninstall ─────────────────────────────────────────
+
+
+def test_installing_from_the_registry_makes_the_plugin_configurable(client, plugin_env):
+    """The freshly installed plugin accepts and stores a config."""
+    installed = client.post(f"/plugins/registry/{EXTERNAL}/install")
+    assert installed.status_code == 200, installed.text
+
+    _put_config(client, EXTERNAL, {"label": "fresh", "api_key": SECRET})
+
+    assert _stored_config(plugin_env["config_path"], EXTERNAL)["api_key"] == SECRET
+
+
+def test_uninstalling_removes_the_plugin_from_the_listing(client):
+    assert client.post(f"/plugins/registry/{EXTERNAL}/install").status_code == 200
+
+    uninstalled = client.delete(f"/plugins/{EXTERNAL}/uninstall")
+    assert uninstalled.status_code == 200, uninstalled.text
+
+    assert client.get(f"/plugins/{EXTERNAL}").status_code == 404
+
+
+def test_uninstalling_purges_the_plugin_config(client, plugin_env):
+    """#948/#1102: a stale config resurrects the plugin on the next upgrade."""
+    assert client.post(f"/plugins/registry/{EXTERNAL}/install").status_code == 200
+    _put_config(client, EXTERNAL, {"label": "fresh", "api_key": SECRET})
+
+    assert client.delete(f"/plugins/{EXTERNAL}/uninstall").status_code == 200
+
+    assert _stored_config(plugin_env["config_path"], EXTERNAL) is None
+
+
+def test_uninstalling_purges_the_configs_of_its_instances_too(client, plugin_env):
+    """Instance keys are separate config entries and must go with the base."""
+    instance = f"{EXTERNAL}{INSTANCE_SEPARATOR}sf"
+    assert client.post(f"/plugins/registry/{EXTERNAL}/install").status_code == 200
+    assert client.post(f"/plugins/{EXTERNAL}/instances", json={"label": "sf"}).status_code == 200
+    _put_config(client, instance, {"api_key": SECRET})
+
+    assert client.delete(f"/plugins/{EXTERNAL}/uninstall").status_code == 200
+
+    assert _stored_config(plugin_env["config_path"], instance) is None
+
+
+def test_uninstalling_removes_the_plugin_directory_from_disk(client, plugin_env):
+    assert client.post(f"/plugins/registry/{EXTERNAL}/install").status_code == 200
+    assert (plugin_env["external_dir"] / EXTERNAL).is_dir()
+
+    assert client.delete(f"/plugins/{EXTERNAL}/uninstall").status_code == 200
+
+    assert not (plugin_env["external_dir"] / EXTERNAL).exists()
+
+
+def test_uninstalling_a_builtin_plugin_is_refused(client, plugin_env):
+    """Refusal must also leave the config untouched."""
+    _put_config(client, HEALTHY, {"label": "base"})
+
+    refused = client.delete(f"/plugins/{HEALTHY}/uninstall")
+
+    assert refused.status_code == 400
+    assert _stored_config(plugin_env["config_path"], HEALTHY)["label"] == "base"
+
+
+# ── isolation guard ─────────────────────────────────────────────────────────
+
+
+def test_the_fixture_keeps_plugin_writes_out_of_the_repo_data_dir(client, plugin_env):
+    """Guard for #1762: no stub plugin may land in the developer's data/."""
+    repo_data = Path(__file__).resolve().parent.parent / "data"
+    assert client.post(f"/plugins/registry/{EXTERNAL}/install").status_code == 200
+    _put_config(client, HEALTHY, {"label": "base", "api_key": SECRET})
+
+    assert (plugin_env["external_dir"] / EXTERNAL).is_dir(), "the fixture never redirected the external dir"
+    assert plugin_env["config_path"].exists(), "the fixture never redirected config.json"
+    assert not (repo_data / "external_plugins" / EXTERNAL).exists()
+    if (repo_data / "config.json").exists():
+        assert HEALTHY not in json.loads((repo_data / "config.json").read_text()).get("plugins", {})

--- a/tests/test_plugin_lifecycle_round_trip.py
+++ b/tests/test_plugin_lifecycle_round_trip.py
@@ -178,8 +178,33 @@ class _LocalRegistry(PluginRegistry):
 # ── fixtures ────────────────────────────────────────────────────────────────
 
 
+#: Every ConfigManager ``plugin_env`` has constructed. The leak guard below
+#: is scoped to these so an unrelated singleton leak elsewhere in the suite
+#: (there are known ones — see #1730) cannot make this module fail.
+_MANAGERS_CREATED_HERE: list[ConfigManager] = []
+
+
+@pytest.fixture(autouse=True)
+def _config_manager_leak_guard():
+    """Fail if a previous test left ``plugin_env``'s ConfigManager installed.
+
+    Checked at *setup*, not teardown, because the leak is not observable from
+    inside the test that causes it: ``monkeypatch.undo()`` runs after every
+    fixture finalizer, so a singleton it restores only becomes visible to the
+    next test in the same xdist worker. That is exactly why the leak survived
+    ``plugin_env``'s ``finally``.
+    """
+    installed = ConfigManager._instance  # type: ignore[attr-defined]
+    assert installed is None or installed not in _MANAGERS_CREATED_HERE, (
+        "a previous test leaked plugin_env's ConfigManager "
+        f"({getattr(installed, '_config_path', '?')}); it points at a deleted "
+        "temp dir and every later test in this worker inherits it"
+    )
+    yield
+
+
 @pytest.fixture
-def plugin_env(tmp_path, monkeypatch):
+def plugin_env(tmp_path):
     """A real registry over stub plugins, wired to the app singletons.
 
     Teardown order matters and is hand-rolled. The plugin routes call
@@ -200,8 +225,15 @@ def plugin_env(tmp_path, monkeypatch):
 
     config_path = tmp_path / "config.json"
     ConfigManager._instance = None  # type: ignore[attr-defined]
+    # Constructing it installs it: ``ConfigManager.__new__`` assigns
+    # ``cls._instance``. Do NOT also pin it with ``monkeypatch.setattr`` —
+    # ``monkeypatch.undo()`` runs after every fixture finalizer in this test,
+    # so it would restore this temp-dir instance *after* the ``finally`` below
+    # cleared it, handing every later test in this xdist worker a
+    # ConfigManager pointing at a deleted ``tmp_path/config.json``. See
+    # ``test_monkeypatching_the_config_manager_singleton_outlives_a_fixture``.
     config_manager = ConfigManager(config_path=str(config_path))
-    monkeypatch.setattr("src.config_manager.ConfigManager._instance", config_manager, raising=False)
+    _MANAGERS_CREATED_HERE.append(config_manager)
 
     original_registry = registry_module._registry
     original_engine = engine_module._template_engine
@@ -528,3 +560,34 @@ def test_the_fixture_keeps_plugin_writes_out_of_the_repo_data_dir(client, plugin
     assert not (repo_data / "external_plugins" / EXTERNAL).exists()
     if (repo_data / "config.json").exists():
         assert HEALTHY not in json.loads((repo_data / "config.json").read_text()).get("plugins", {})
+
+
+def test_monkeypatching_the_config_manager_singleton_outlives_a_fixture(tmp_path):
+    """``monkeypatch.undo()`` runs after a fixture's own teardown, not before.
+
+    Deterministic reproduction of the hazard ``plugin_env`` used to have: it
+    both constructed the temp ConfigManager (which installs it) *and* pinned it
+    with ``monkeypatch.setattr``. The undo restored the pinned value after the
+    ``finally`` had cleared it, so the temp-dir singleton escaped the fixture.
+    ``_config_manager_leak_guard`` above catches a live regression; this pins
+    the mechanism so the comment in ``plugin_env`` cannot rot into folklore.
+    """
+    from _pytest.monkeypatch import MonkeyPatch
+
+    original = ConfigManager._instance  # type: ignore[attr-defined]
+    monkeypatch = MonkeyPatch()
+    try:
+        ConfigManager._instance = None  # type: ignore[attr-defined]
+        temp_manager = ConfigManager(config_path=str(tmp_path / "config.json"))
+        monkeypatch.setattr("src.config_manager.ConfigManager._instance", temp_manager, raising=False)
+
+        ConfigManager._instance = None  # type: ignore[attr-defined]  # the fixture's own teardown
+        monkeypatch.undo()  # ...which pytest runs afterwards, not before
+
+        assert ConfigManager._instance is temp_manager, (
+            "monkeypatch.undo() no longer resurrects the value — if pytest changed "
+            "this ordering, plugin_env's hand-rolled teardown can be simplified"
+        )
+    finally:
+        monkeypatch.undo()
+        ConfigManager._instance = original  # type: ignore[attr-defined]


### PR DESCRIPTION
Closes #1735
Closes #1736

Phase 0 of #1730 is a safety net, not a refactor: it pins today's *correct*
behaviour so the epic's later phases cannot break it quietly. Two new pytest
files, 40 tests, no production code touched.

| File | Tests | Locks down |
|---|---|---|
| `tests/test_plugin_lifecycle_round_trip.py` | 23 | fan-out isolation, secret masking round-trip, instances, install→configure→uninstall |
| `tests/test_persistence_round_trip.py` | 17 | settings/pages/schedules/collections/config survive a restart, backup export→import |

Both drive the real thing. Stub plugins are written to disk and loaded by the
real `PluginLoader`; a real `ConfigManager` writes a real `config.json`; every
assertion goes through an HTTP route. The only substitution is the git clone,
replaced by a copy from a local staging directory so install works offline.

---

## What each file pins

### `test_plugin_lifecycle_round_trip.py` (#1735)

**Fan-out isolation** — `build_template_context` fans out to every enabled
plugin on a thread pool. Nothing asserted that one plugin raising leaves the
others intact.

- `test_a_raising_plugin_does_not_block_a_healthy_plugins_variable`
- `test_a_raising_plugins_error_text_never_reaches_the_board` — an exception
  message is not board content
- `test_a_raising_plugin_is_reported_unavailable_on_its_own_data_endpoint` — the
  failure is surfaced (503), not swallowed into a green response
- `test_a_healthy_plugin_still_serves_its_own_data_endpoint_alongside_a_raising_one`

**Secret masking** — the round-trip #1743 exists to protect.

- masked on `GET /plugins` and on `GET /plugins/{id}`, and for instance keys
- `test_writing_the_masked_api_key_back_preserves_the_stored_secret` — REST
- `test_writing_the_masked_api_key_back_over_mcp_preserves_the_stored_secret` — MCP
- `test_writing_the_masked_api_key_back_leaves_the_live_plugin_using_the_real_secret`
  — persisting the key is not enough; the *running* plugin object needs it too.
  The stub exposes `key_tail` (last 4 chars of its live `api_key`) so this is
  observable through `POST /templates/render` rather than through registry
  internals.
- `test_writing_a_new_api_key_replaces_the_stored_secret` — preserving masked
  values must not also freeze real ones

**Instances** (`INSTANCE_SEPARATOR`) — compound-key registration, config
independence from the base, independent masking, rendering under
`{{base:label.var}}`, purge on instance delete, and *not* taking the base
plugin's config down with it.

**Install → configure → uninstall** against a local fixture registry — the
plugin becomes configurable, disappears from the listing, its directory is
removed, its config and its instances' configs are purged (#948/#937), and a
built-in plugin is refused without its config being touched.

### `test_persistence_round_trip.py` (#1736)

`_restart()` drops exactly the singletons `src.backup.service._reload_services`
drops — the app's own definition of "re-read from disk" — then reads state back
through HTTP off the JSON files alone.

- pages / schedules / collections / `settings.json` / `config.json` each survive
- `test_a_secret_in_config_json_survives_a_restart_unmasked_on_disk` — the
  stored value must be the real key, not the mask the API returns
- `test_pages_file_is_stamped_with_the_current_schema_version` and
  `test_restart_does_not_re_migrate_an_already_current_pages_file` — the second
  asserts the *absence* of the `pages.json.v<n>_backup` snapshot that
  `PageStorage._load` writes before its first migration, so the
  `schema_version` gate itself is under test rather than bypassed
- backup export → mutate → import restores all five `DATA_FILES` to their
  exported content (parsed-JSON equality, not a model spot-check), survives a
  further restart, and a non-backup upload is refused **without** overwriting
  the data directory

Nothing hand-writes `pages.json`: every fixture is seeded through the API, so
the schema-version machinery produces the files it later reads back.

---

## Coordination with work in flight

- **#1743** (mask sentinel over real secrets) — the three
  `writing_the_masked_api_key_back_*` tests encode the *fixed* contract: a
  masked value written back preserves the stored secret. They **pass on
  `origin/main` today** via `ConfigManager.set_plugin_config`'s
  `unmask_sensitive_values` call, over both REST and MCP. So this PR is a
  regression lock, not a red test: #1743's rework of the shared config-write
  path must keep them green. If #1743 moves the strip earlier (e.g. before
  `registry.set_plugin_config`, which today receives the masked dict and is only
  rescued because `set_plugin_config` mutates the same dict object in place),
  these tests are the ones that say whether the move was safe.
  Nothing here needs changing whichever order the PRs land in.
- **#1753** (`cleanup()` on reset; reload only the affected plugin) — the
  lifecycle tests exercise enable/disable/config-save, which all currently call
  `reset_display_service()`. They assert on *observable* state (config on disk,
  live plugin data through a render), never on how many times the world was
  reset, so narrowing the reset to one plugin will not disturb them.
- **#1745** (`.system-update.json` atomic writes) — no overlap; that file is not
  one of the backup `DATA_FILES`.

---

## Data isolation (evidence for #1762)

There is **no data-directory seam** in the app. Each store resolves its own path
from `Path(__file__)` at construction time, so both fixtures have to rebind
constructors by hand:

- `ConfigManager` → `<repo>/data/config.json`
- `SettingsService` → `<repo>/data/settings.json`
- `PageStorage` / `ScheduleStorage` / `CollectionStorage` → `<repo>/data/*.json`
- `BackupService` → `<repo>/data`
- `PluginLoader` with no `external_dirs` **creates** `<repo>/data/external_plugins`

Verified directly:

```
$ docker run --rm -v "$PWD":/app -w /app fb-test:latest python -c "
from src.pages.storage import PageStorage; print(PageStorage().storage_file)"
/app/data/pages.json
```

Two traps found while building the fixtures, both worth recording on #1762:

1. **Patching the class hides the singleton.** `isolated_data_dir` rebinds
   `src.config_manager.ConfigManager` to a `functools.partial`. Clearing
   `_instance` through *that* name sets an attribute on the partial and leaves
   the real class-level singleton — still pointing at `<repo>/data/config.json`
   — very much alive. The first draft did exactly this and silently reused the
   previous test's ConfigManager. `_drop_singletons()` now clears the class
   imported at module scope, with a comment saying why.
2. **The container hides the leak.** The `Dockerfile` declares `VOLUME /app/data`
   (line 151), so `docker run -v "$PWD":/app` shadows the bind mount at that
   path — a test that writes to the default `data/` writes into an anonymous
   volume and the developer never sees it. CI runs pytest natively on the runner
   host, where there is no such shadow. So the docker workflow masks #1762 and
   the CI/host workflow does not.

Each file therefore carries a guard test —
`test_the_isolation_fixture_keeps_writes_out_of_the_repo_data_dir` and
`test_the_fixture_keeps_plugin_writes_out_of_the_repo_data_dir` — that fails if
the fixture ever stops covering a store. Both were verified to trip (evidence
below). Neither new file writes into the repository's `data/`.

---

## Test evidence (non-vacuity)

CLAUDE.md requires proof for tests written after the code they cover. For every
one of the 40 tests, the production behaviour it covers was broken, the failure
observed, and the break reverted. Output is verbatim.

<details>
<summary><b>#1735 — fan-out isolation</b></summary>

**Break:** `PluginRegistry.fetch_plugin_data`'s `except` re-raises instead of
returning `PluginResult(available=False, ...)`, and the per-future `except` in
`build_template_context` re-raises.

```
tests/test_plugin_lifecycle_round_trip.py:271: in test_a_raising_plugin_does_not_block_a_healthy_plugins_variable
    rendered = _render(client, f"{{{{{HEALTHY}.value}}}}")
tests/test_plugin_lifecycle_round_trip.py:259: in _render
    assert response.status_code == 200, response.text
E   AssertionError: {"detail":"Template rendering failed: STUBBOOM"}
E   assert 400 == 200
FAILED tests/test_plugin_lifecycle_round_trip.py::test_a_raising_plugin_does_not_block_a_healthy_plugins_variable
======================= 1 failed, 22 deselected in 0.49s =======================
```

**Break:** `fetch_plugin_data` returns the exception text as plugin data.

```
E     'STUBBOOM              \n                      \n ... '
FAILED tests/test_plugin_lifecycle_round_trip.py::test_a_raising_plugins_error_text_never_reaches_the_board
======================= 1 failed, 22 deselected in 0.50s =======================
```

**Break:** `GET /plugins/{id}/data` stops raising 503 when `result.available` is
False.

```
E   assert 200 == 503
FAILED tests/test_plugin_lifecycle_round_trip.py::test_a_raising_plugin_is_reported_unavailable_on_its_own_data_endpoint
======================= 1 failed, 22 deselected in 0.52s =======================
```

**Break:** `GET /plugins/{id}/data` returns `"data": {}` instead of `result.data`.

```
tests/test_plugin_lifecycle_round_trip.py:312: in test_a_healthy_plugin_still_serves_its_own_data_endpoint_alongside_a_raising_one
    assert response.json()["data"]["value"] == HEALTHY_VALUE
E   KeyError: 'value'
FAILED tests/test_plugin_lifecycle_round_trip.py::test_a_healthy_plugin_still_serves_its_own_data_endpoint_alongside_a_raising_one
======================= 1 failed, 22 deselected in 0.51s =======================
```

</details>

<details>
<summary><b>#1735 — secret masking (this is the #1743 bug, reproduced)</b></summary>

**Break:** delete the `config.update(unmask_sensitive_values(config, existing))`
line from `ConfigManager.set_plugin_config` — i.e. exactly the mask-sentinel bug
#1743 describes.

```
============================= test session starts ==============================
collected 23 items / 20 deselected / 3 selected

tests/test_plugin_lifecycle_round_trip.py FFF                            [100%]

=================================== FAILURES ===================================
_______ test_writing_the_masked_api_key_back_preserves_the_stored_secret _______
tests/test_plugin_lifecycle_round_trip.py:343: in test_writing_the_masked_api_key_back_preserves_the_stored_secret
    assert stored["api_key"] == SECRET
E   AssertionError: assert '***' == 'test_secret_key_abcd'
E     - test_secret_key_abcd
E     + ***
_ test_writing_the_masked_api_key_back_leaves_the_live_plugin_using_the_real_secret _
tests/test_plugin_lifecycle_round_trip.py:354: in test_writing_the_masked_api_key_back_leaves_the_live_plugin_using_the_real_secret
    assert SECRET[-4:] in _render(client, f"{{{{{HEALTHY}.key_tail}}}}")
E   AssertionError: assert 'abcd' in '***                   \n ... '
__ test_writing_the_masked_api_key_back_over_mcp_preserves_the_stored_secret ___
tests/test_plugin_lifecycle_round_trip.py:382: in test_writing_the_masked_api_key_back_over_mcp_preserves_the_stored_secret
    assert _stored_config(plugin_env["config_path"], HEALTHY)["api_key"] == SECRET
E   AssertionError: assert '***' == 'test_secret_key_abcd'
E     - test_secret_key_abcd
E     + ***
======================= 3 failed, 20 deselected in 0.56s =======================
```

**Break:** `ConfigManager._mask_sensitive` returns the value unchanged.

```
E   AssertionError: assert 'test_secret_key_abcd' == '***'
FAILED tests/test_plugin_lifecycle_round_trip.py::test_a_stored_api_key_is_masked_when_the_plugin_list_is_read_back
FAILED tests/test_plugin_lifecycle_round_trip.py::test_a_stored_api_key_is_masked_on_the_plugin_detail_endpoint
FAILED tests/test_plugin_lifecycle_round_trip.py::test_an_instance_secret_is_masked_independently_of_the_base
======================= 3 failed, 20 deselected in 0.63s =======================
```

**Break:** `unmask_sensitive_values` drops the `and value == MASKED_VALUE` guard,
so a real new key is also treated as a mask.

```
tests/test_plugin_lifecycle_round_trip.py:363: in test_writing_a_new_api_key_replaces_the_stored_secret
    assert _stored_config(plugin_env["config_path"], HEALTHY)["api_key"] == "test_rotated_key_wxyz"
E   AssertionError: assert '' == 'test_rotated_key_wxyz'
======================= 1 failed, 22 deselected in 0.59s =======================
```

</details>

<details>
<summary><b>#1735 — instances</b></summary>

**Break:** `PluginRegistry.list_instances` reports the base id as each
instance's `key`.

```
tests/test_plugin_lifecycle_round_trip.py:395: in test_creating_an_instance_registers_it_under_the_compound_key
    assert [i["key"] for i in listed.json()["instances"]] == [f"{HEALTHY}{INSTANCE_SEPARATOR}sf"]
E   AssertionError: assert ['stub_ok'] == ['stub_ok:sf']
======================= 1 failed, 22 deselected in 0.48s =======================
```

**Break:** `ConfigManager.set_plugin_config` collapses instance keys to the base id.

```
tests/test_plugin_lifecycle_round_trip.py:406: in test_an_instance_config_is_independent_of_the_base_plugin_config
    assert _stored_config(plugin_env["config_path"], HEALTHY)["label"] == "base"
E   AssertionError: assert 'san francisco' == 'base'
======================= 1 failed, 22 deselected in 0.49s =======================
```

**Break:** `build_template_context` keys the context by base id rather than the
compound key.

```
tests/test_plugin_lifecycle_round_trip.py:429: in test_an_instance_renders_under_its_own_template_namespace
    assert SECRET[-4:] in _render(client, f"{{{{{instance}.key_tail}}}}")
E   AssertionError: assert 'abcd' in '???                   \n ... '
======================= 1 failed, 22 deselected in 0.49s =======================
```

**Break:** `DELETE /plugins/{id}/instances/{label}` stops calling
`config_manager.delete_plugin_config(compound_key)`.

```
tests/test_plugin_lifecycle_round_trip.py:441: in test_deleting_an_instance_purges_its_stored_config
    assert _stored_config(plugin_env["config_path"], instance) is None
E   AssertionError: assert {'api_key': 'test_secret_key_abcd'} is None
======================= 1 failed, 22 deselected in 0.51s =======================
```

**Break:** the same route also deletes the base id's config.

```
tests/test_plugin_lifecycle_round_trip.py:451: in test_deleting_an_instance_leaves_the_base_plugin_config_alone
    assert _stored_config(plugin_env["config_path"], HEALTHY)["label"] == "base"
E   TypeError: 'NoneType' object is not subscriptable
======================= 1 failed, 22 deselected in 0.53s =======================
```

</details>

<details>
<summary><b>#1735 — install / uninstall</b></summary>

**Break:** `POST /plugins/registry/{id}/install` skips the install and reports
success.

```
tests/test_plugin_lifecycle_round_trip.py:253: in _put_config
    assert response.status_code == 200, response.text
E   AssertionError: {"detail":"Plugin not found: stub_external"}
E   assert 404 == 200
======================= 1 failed, 22 deselected in 0.56s =======================
```

**Break:** `PluginRegistry.uninstall_external_plugin` returns success without
doing anything.

```
tests/test_plugin_lifecycle_round_trip.py:473: in test_uninstalling_removes_the_plugin_from_the_listing
    assert client.get(f"/plugins/{EXTERNAL}").status_code == 404
E   AssertionError: assert 200 == 404
tests/test_plugin_lifecycle_round_trip.py:504: in test_uninstalling_removes_the_plugin_directory_from_disk
    assert not (plugin_env["external_dir"] / EXTERNAL).exists()
E   AssertionError: assert not True
======================= 2 failed, 21 deselected in 0.52s =======================
```

**Break:** the config purge is removed from both
`uninstall_external_plugin` and the uninstall route (the #937 regression).

```
tests/test_plugin_lifecycle_round_trip.py:483: in test_uninstalling_purges_the_plugin_config
    assert _stored_config(plugin_env["config_path"], EXTERNAL) is None
E   AssertionError: assert {'label': 'fresh', 'api_key': 'test_secret_key_abcd'} is None
tests/test_plugin_lifecycle_round_trip.py:495: in test_uninstalling_purges_the_configs_of_its_instances_too
    assert _stored_config(plugin_env["config_path"], instance) is None
E   AssertionError: assert {'api_key': 'test_secret_key_abcd'} is None
======================= 2 failed, 21 deselected in 0.53s =======================
```

**Break:** the `source_type == "builtin"` guard is removed.

```
tests/test_plugin_lifecycle_round_trip.py:513: in test_uninstalling_a_builtin_plugin_is_refused
    assert refused.status_code == 400
E   assert 200 == 400
======================= 1 failed, 22 deselected in 0.47s =======================
```

**Break (fixture):** `_LocalRegistry` stops overriding `external_dirs`, so the
loader falls back to `<repo>/data/external_plugins`.

```
tests/test_plugin_lifecycle_round_trip.py:522: in test_the_fixture_keeps_plugin_writes_out_of_the_repo_data_dir
    assert client.post(f"/plugins/registry/{EXTERNAL}/install").status_code == 200
E   AssertionError: assert 400 == 200
======================= 1 failed, 22 deselected in 0.49s =======================
```

</details>

<details>
<summary><b>#1736 — restart round-trips</b></summary>

**Break:** `PageStorage._save` becomes a no-op.

```
tests/test_persistence_round_trip.py:195: in test_page_survives_a_restart
    assert after.status_code == 200, after.text
E   AssertionError: {"detail":"Page not found: 08a89390-2b2b-409e-8e7b-de818b732ebc"}
E   assert 404 == 200
======================= 1 failed, 16 deselected in 0.64s =======================
```

**Break:** `ScheduleStorage._save` becomes a no-op.

```
E   AssertionError: {"detail":"Schedule not found: 0429f9d0-427f-4159-891c-1a0b3ab01020"}
FAILED tests/test_persistence_round_trip.py::test_schedule_survives_a_restart
======================= 1 failed, 16 deselected in 0.47s =======================
```

**Break:** `CollectionStorage._save` becomes a no-op.

```
E   AssertionError: {"detail":"Collection not found: collection:271121c8-551c-4c10-849d-c7cc6482e269"}
FAILED tests/test_persistence_round_trip.py::test_collection_survives_a_restart
================= 1 failed, 16 deselected, 1 warning in 0.49s ==================
```

**Break:** `SettingsService._atomic_write_json` becomes a no-op.

```
E   AssertionError: assert 'black' == 'white'
FAILED tests/test_persistence_round_trip.py::test_display_settings_survive_a_restart
FAILED tests/test_persistence_round_trip.py::test_polling_settings_survive_a_restart
FAILED tests/test_persistence_round_trip.py::test_board_type_survives_a_restart
======================= 3 failed, 14 deselected in 0.49s =======================
```

**Break:** `ConfigManager._save_internal` becomes a no-op.

```
FAILED tests/test_persistence_round_trip.py::test_config_json_survives_a_restart
======================= 1 failed, 16 deselected in 0.49s =======================
```

**Break:** `set_ai_providers` persists the mask instead of preserving the stored key.

```
E   AssertionError: assert '***' == 'test_api_key_placeholder'
FAILED tests/test_persistence_round_trip.py::test_a_secret_in_config_json_survives_a_restart_unmasked_on_disk
======================= 1 failed, 16 deselected in 0.48s =======================
```

</details>

<details>
<summary><b>#1736 — schema_version machinery</b></summary>

**Break:** `PageStorage._save` writes `schema_version: 0`.

```
tests/test_persistence_round_trip.py:303: in test_pages_file_is_stamped_with_the_current_schema_version
    assert on_disk["schema_version"] == CURRENT_SCHEMA_VERSION
E   assert 0 == 4
======================= 1 failed, 16 deselected in 0.47s =======================
```

**Break:** `_run_migrations` ignores the stored `schema_version` and always
starts from 0.

```
tests/test_persistence_round_trip.py:318: in test_restart_does_not_re_migrate_an_already_current_pages_file
    assert not list(isolated_data_dir.glob("pages.json.v*_backup"))
E   AssertionError: assert not [PosixPath('.../data/pages.json.v0_backup')]
======================= 1 failed, 16 deselected in 0.49s =======================
```

</details>

<details>
<summary><b>#1736 — backup export / import</b></summary>

**Break:** the export writes `BACKUP_FILE_MARKER: False`.

```
FAILED tests/test_persistence_round_trip.py::test_backup_export_is_a_recognisable_backup_document
======================= 1 failed, 16 deselected in 0.50s =======================
```

**Break:** `BackupService._write_json_with_backup` becomes a no-op.

```
E   AssertionError: {"detail":"Page not found: 8753d12d-be29-4418-a6c2-a3abc5ae5e22"}
E   AssertionError: assert {'config.json..., ...}]}, ...} == {'config.json..., ...}]}, ...}
E   AssertionError: {"detail":"Page not found: d75b1aff-b813-4d78-8c42-02c770f6751d"}
FAILED tests/test_persistence_round_trip.py::test_backup_import_restores_a_deleted_page
FAILED tests/test_persistence_round_trip.py::test_backup_import_restores_overwritten_settings
FAILED tests/test_persistence_round_trip.py::test_backup_import_restores_every_data_file_byte_for_byte
FAILED tests/test_persistence_round_trip.py::test_restored_state_survives_a_restart
================= 4 failed, 13 deselected, 1 warning in 0.54s ==================
```

**Break:** `BackupService._validate_backup` becomes a no-op.

```
tests/test_persistence_round_trip.py:414: in test_import_rejects_a_document_that_is_not_a_backup
    assert response.status_code == 400
E   assert 200 == 400
======================= 1 failed, 16 deselected in 0.49s =======================
```

Note: the earlier draft of this test asserted only the status code and still
passed when the `BACKUP_FILE_MARKER` check alone was removed — the
`schema_version` check caught it. The test was renamed and strengthened to also
assert the rejected upload left `pages.json` intact, and re-proved above against
a fully neutered validator.

**Break (fixture):** `isolated_data_dir` stops rebinding `PageStorage`.

```
tests/test_persistence_round_trip.py:432: in test_the_isolation_fixture_keeps_writes_out_of_the_repo_data_dir
    assert (isolated_data_dir / "pages.json").exists(), "the fixture never redirected pages.json"
E   AssertionError: the fixture never redirected pages.json
E   assert False
================= 1 failed, 16 deselected, 1 warning in 0.49s ==================
```

</details>

---

## Test status

```
$ docker run --rm -v "$PWD":/app -w /app fb-test:latest python -m pytest \
    tests/test_persistence_round_trip.py tests/test_plugin_lifecycle_round_trip.py \
    -q --no-header -p no:cacheprovider
40 passed, 3 warnings in 0.74s
```

Full Python suite on this branch:

```
$ ... python -m pytest tests/ -q --no-header -p no:cacheprovider
1 failed, 5246 passed, 1 skipped, 140 warnings in 28.44s
```

The single failure is
`test_check_image_formats.py::TestRepositoryIsClean::test_no_tracked_file_in_this_repo_reaches_a_vulnerable_parser`,
which shells out to `git ls-files` and exits 128 because the container mounts a
git *worktree* whose `.git` file points outside the mount. Environmental, not
related to this change.

Lint clean with the pinned formatter:

```
$ ruff 0.16.4
All checks passed!
2 files already formatted
```


---

# Rebase onto current `main` + review fixes

`main` moved a lot; rebased, and three things needed handling.

## 1. `config.json` gains `plugin_migrations.v2_completed` after a restore — **decision: (a) acceptable bookkeeping**, with a stricter assertion, not a relaxed one

`test_backup_import_restores_every_data_file_byte_for_byte` went red after **#1817** landed:

```
tests/test_persistence_round_trip.py:406: in test_backup_import_restores_every_data_file_byte_for_byte
    assert after == before
E   AssertionError: assert {'config.json..., ...}]}, ...} == {'config.json..., ...}]}, ...}
E     + 'plugin_migrations': {'v2_completed': True},
```

The diff is exactly one added key, and it is purely additive — every other key in all five `DATA_FILES` is byte-identical.

**Why this is bookkeeping and not a data-loss bug.** #1817 made the restore path call `PluginRegistry.initialize(force=True)` in `_reload_services`, deliberately, so a restore's plugin configs reach the live plugin objects. That reload runs the v2→v3 plugin migration, which stamps the completion flag.

The flag is derived state about *this installation*, not user data, and re-deriving it after a restore is the desired behaviour in both directions:

* Restoring a **v2-era backup** (no flag) onto a v3 instance leaves every extracted plugin's config orphaned. `first_run` is true, the migration re-installs them, and the flag records that it has now run. That is the whole point of the migration.
* Restoring a backup that **already carries** `v2_completed: True` leaves `first_run` false, so nothing is re-installed and a deliberately-uninstalled plugin is not resurrected — the #937/#948/#1102/#1301 invariant, preserved.

Given this repo's history of upgrade bugs stranding plugin configs, the thing actually worth checking was the **ordering**, and it holds: `_reload_services` calls `get_config_manager().reload()` *before* `get_plugin_registry().initialize(force=True)`, so the migration reads what the backup wrote rather than a stale in-memory copy.

**The assertion got stricter, not looser.** It does not ignore the key:

```python
added = set(after["config.json"]) - set(before["config.json"])
assert added == {"plugin_migrations"}, f"restore added unexpected config.json keys: {sorted(added)}"
assert after["config.json"].pop("plugin_migrations") == {"v2_completed": True}
assert after == before
```

Nothing else may be added, the added value must be the completed flag, and every exported byte must still come back unchanged. It now *pins* #1817's behaviour instead of merely tolerating it — reverting `initialize(force=True)` fails it:

```
tests/test_persistence_round_trip.py:430: in test_backup_import_restores_every_data_file_byte_for_byte
    assert added == {"plugin_migrations"}, f"restore added unexpected config.json keys: {sorted(added)}"
E   AssertionError: restore added unexpected config.json keys: []
E   assert set() == {'plugin_migrations'}
```

**New test for the ordering the tolerance rests on.** `test_backup_import_is_not_clobbered_by_the_pre_restore_config_manager`. Removing `get_config_manager().reload()` from `_reload_services` makes the post-restore migration write the stale in-memory config straight over the file the restore just produced — the "upgrade stranded my plugin configs" shape, reached through a restore:

```
tests/test_persistence_round_trip.py:460: in test_backup_import_is_not_clobbered_by_the_pre_restore_config_manager
    assert on_disk["ai_providers"]["enabled"] is True, (
E   AssertionError: the post-restore reload wrote the pre-restore config back over the restored one
E   assert False is True
=================== 1 failed, 17 passed, 3 warnings in 0.70s ===================
```

Note the byte-for-byte test **passes** under that break. The new test covers a gap the old assertion never did, which is the real reason relaxing it is safe.

## 2. `plugin_env` leaked a stale `ConfigManager` singleton

The fixture both constructed the temp-dir manager — which installs it, `ConfigManager.__new__` assigns `cls._instance` — and pinned it with `monkeypatch.setattr`. `monkeypatch` is set up *before* `plugin_env`, so `monkeypatch.undo()` ran *after* the `finally` and put the instance back.

Confirmed by direct observation. A guard fixture requested before `plugin_env` sees nothing wrong at its own teardown; the **next test** inherits the leak:

```
ORDER test body:          <ConfigManager object> path=/tmp/pytest-of-root/pytest-0/test_probe0/config.json
ORDER outer_guard teardown: None
ORDER at-report:          <ConfigManager object> path=/tmp/pytest-of-root/pytest-0/test_probe0/config.json
```

`monkeypatch.undo()` runs after *every* fixture finalizer, so the leak is not observable from inside the test that causes it.

**Fix:** the `monkeypatch.setattr` line is gone (the constructor already installs the singleton), and `plugin_env` no longer requests `monkeypatch` at all.

**Two guards replace it:**

* `_config_manager_leak_guard`, an autouse fixture that checks at **setup** — the only point where the leak is visible — that no previous test left one of this module's managers installed. Scoped to instances `plugin_env` itself created, so the repo's known unrelated singleton leaks cannot make it flake. Reinstating the `monkeypatch.setattr` line turns 23 of 24 tests into setup errors:

  ```
  tests/test_plugin_lifecycle_round_trip.py:198: in _config_manager_leak_guard
      assert installed is None or installed not in _MANAGERS_CREATED_HERE, (
  E   AssertionError: a previous test leaked plugin_env's ConfigManager
  E   (/tmp/pytest-of-root/pytest-0/test_a_raising_plugin_does_not0/config.json);
  E   it points at a deleted temp dir and every later test in this worker inherits it
  ========================== 1 passed, 23 errors in 0.58s ==========================
  ```

* `test_monkeypatching_the_config_manager_singleton_outlives_a_fixture`, which reproduces the undo-outlives-teardown mechanism deterministically, so the reasoning in the fixture comment cannot rot into folklore.

**Measured effect.** These two files alongside `test_config_manager.py`, `test_backup.py` and `test_config_migration.py` under `-n 4 --cov`, 8 runs, total failures per run:

```
before:  6  5  6  9  2  7  8  7
after:   3  0  1  6  1  2  1  1
```

## 3. The isolation guard was a cross-worker race

`test_the_isolation_fixture_keeps_writes_out_of_the_repo_data_dir` compared `st_mtime_ns` across `<repo>/data/*.json` while other xdist workers ran free. The review flagged this as a race waiting for its first writer — it already has one: `test_config_manager.py` legitimately writes `<repo>/data/config.json`. Switching mtimes for bytes does not help, because the *content* is what another worker changes:

```
tests/test_persistence_round_trip.py:527: in test_the_isolation_fixture_keeps_writes_out_of_the_repo_data_dir
    assert snapshot() == before
E   assert {'config.json...de": null\n}'} == {'config.json...de": null\n}'}
E     {'config.json': b'... "baywheels": {... "gbfs_url": "...gbfs/en"} ...'}
E                  != {'config.json': b'... "baywheels": {... "refresh_seconds": 60} ...'}
```

That failed **5 runs in 6** alongside `test_config_manager.py`.

Rewritten to look for *its own* data, the way the sibling guard in `test_plugin_lifecycle_round_trip.py` already does: a per-run marker is written into all five `DATA_FILES`, each temp file is asserted to have received it, and the repo's copies are asserted to contain neither the marker nor the minted page id. Order-independent, and 0 failures in 8 runs against the same suites. It still trips when the fixture stops redirecting a store:

```
tests/test_persistence_round_trip.py:535: in test_the_isolation_fixture_keeps_writes_out_of_the_repo_data_dir
    assert written.exists(), f"the fixture never redirected {name}"
E   AssertionError: the fixture never redirected pages.json
```

As a side benefit it no longer has to reason about `Path.glob("*.json")` matching the `.system-update.json` dotfile — it does, verified.

## Test status after the rebase

```
$ docker run --rm -v "$PWD":/app -w /app fb-test:latest python -m pytest \
    tests/test_persistence_round_trip.py tests/test_plugin_lifecycle_round_trip.py \
    -q --no-header -p no:cacheprovider
42 passed, 3 warnings in 0.83s
```

Full suite on **Python 3.11** (CI's version, not the container's 3.14) with CI's exact flags, 5 runs — 5298 passed every time:

```
run 1: 1 failed, 5298 passed, 1 skipped
run 2: 1 failed, 5298 passed, 1 skipped
run 3: 2 failed, 5297 passed, 1 skipped   (+ test_apply_env_overrides_invalid_int_value)
run 4: 1 failed, 5298 passed, 1 skipped
run 5: 1 failed, 5298 passed, 1 skipped
```

The constant failure is `test_check_image_formats.py::TestRepositoryIsClean`, which shells out to `git ls-files` and cannot run from a mounted git worktree — environmental.

The run-3 extra is the known `test_config_manager.py` / `test_config_migration.py` family losing to `ConfigManager._instance` ordering under `-n auto`. **Pre-existing, and worse on `main`** — 6 runs of the same command on `main`:

```
run 1: 13 failed   (test_config_manager + test_config_migration)
run 2:  3 failed
run 3:  1 failed   (environmental only)
run 4:  1 failed   (environmental only)
run 5: 13 failed
run 6:  1 failed   (environmental only)
```

3 of 6 runs on `main` versus 1 of 5 here.

`ruff 0.16.4`: `All checks passed! / 2 files already formatted`.
