### PR TITLE
ci: allow zeroconf's LGPL-2.1 in Dependency Review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,16 @@ jobs:
           #   by Google Fonts; the JS wrapper / package metadata is MIT.
           #   Self-hosted (HA-Ingress-safe) via @fiestaboard/ui, which
           #   replaced Geist with these faces in v5.0.0.
+          # - zeroconf is LGPL-2.1-only. It has shipped in requirements.txt
+          #   since well before this allow-list existed; Dependency Review
+          #   only flags it when the pin moves, because a version change
+          #   reads as a newly-introduced dependency. FiestaBoard imports it
+          #   as an unmodified library from a separate PyPI wheel and does
+          #   not link it statically or modify it, which is the LGPL's
+          #   dynamic-linking case. Listing it records a decision already
+          #   made in practice rather than granting anything new.
           allow-dependencies-licenses: >-
+            pkg:pypi/zeroconf,
             pkg:npm/caniuse-lite,
             pkg:npm/%40fontsource-variable/archivo,
             pkg:npm/%40fontsource-variable/spline-sans-mono


### PR DESCRIPTION
## Why

**#1796** (bump the pip-dependencies group) fails `Dependency Review` on a license, not a vulnerability:

```
requirements.txt » zeroconf@>=0.151.2 — LGPL-2.1-only
```

The important detail: **zeroconf already ships on `main`** as `zeroconf>=0.150.0`, and has for a long time. #1796 only raises the floor to `>=0.151.2`. Dependency Review surfaces it because it treats a *version change* as a newly-introduced dependency — so the gate is failing on a dependency the product already distributes, not on something new entering the tree.

That makes this an inconsistency between the allow-list and what FiestaBoard actually ships, rather than a new permission grant.

## The licensing position

FiestaBoard imports zeroconf as an unmodified library from a separate PyPI wheel. It is not statically linked and not modified — the LGPL's dynamic-linking case, where the obligation is that users can substitute their own build of the library, which a separately-installed wheel satisfies.

Recording it as a per-package exception keeps the workflow's existing rule intact:

> Add to this list if a future dep needs an unlisted license; do NOT silently allow all licenses.

`LGPL-2.1-only` is **not** added to the general `allow-licenses` list. Only this one reviewed package is excepted, alongside the existing `caniuse-lite` (CC-BY-4.0 data) and the two `@fontsource-variable` packages (OFL-1.1 fonts).

## Verification

`ci.yml` parses (`yaml.safe_load` in a container — 17 jobs), and the `dependency-review-action` step's `allow-dependencies-licenses` resolves to:

```
pkg:pypi/zeroconf, pkg:npm/caniuse-lite, pkg:npm/%40fontsource-variable/archivo, pkg:npm/%40fontsource-variable/spline-sans-mono
```

Only real CI can confirm the gate now passes on #1796.

## Note for whoever reviews #1796

Two other bumps in that group deserve a look independently of this fix:

- **`ruff==0.16.4` → `0.16.5`.** This file's own comment explains ruff is pinned exactly because formatter output changes between releases and can turn `format --check` red. That bump should be taken deliberately, with a reformat pass if needed.
- **`mcp>=2.0.0` → `>=2.1.1`.** An unbounded `mcp` floor has previously broken `main` via a fresh-install major bump.

Neither is addressed here — this PR is scoped to the license gate.