### PR TITLE
ci: give Lint Markdown room to install before it lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1267,7 +1267,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: detect-changes
     if: needs.detect-changes.outputs.markdown == 'true' || needs.detect-changes.outputs.shared == 'true'
-    timeout-minutes: 5
+    # 5 minutes covered the lint steps but not `npm ci` ahead of them. On a cold
+    # cache the install alone repeatedly hit 5m00s, so the job was killed after
+    # installing and before linting anything -- a red "Lint Markdown" that had
+    # examined zero files. 15 matches the other Node jobs here.
+    timeout-minutes: 15
 
     steps:
     - uses: actions/checkout@v7


### PR DESCRIPTION
## The failure mode

`lint-markdown` had `timeout-minutes: 5`, and that budget covers `npm ci` as well as the four lint steps that follow it. On a cold npm cache the install alone repeatedly took the full 5m00s, so the runner killed the job **after installing and before linting anything**.

In the checks UI that is indistinguishable from a real lint failure — a red `Lint Markdown` that had examined zero files.

## Evidence

It hit three PRs tonight (#1803 once, #1805 twice) and cost a rerun each time. Confirmed not content-related: all four docs-lint steps were run locally against both branches — `frontmatter`, `contract`, `markdownlint-cli2`, and `cspell` — **100 files, 0 issues**.

## The change

`timeout-minutes: 5` → `15`, matching the other Node jobs in this workflow (`lint-web`, `test-ui` and the E2E lanes all sit at 10–15). A comment records the failure mode, because the next person to see a red `Lint Markdown` deserves to know it might not be about markdown.

No lint rule, config, or content changed.