### PR TITLE
test(date_time): patch the imported module object so mocks survive loader reloads

### DIFF
--- a/plugins/date_time/tests/test_plugin.py
+++ b/plugins/date_time/tests/test_plugin.py
@@ -8,8 +8,15 @@ from zoneinfo import ZoneInfo
 
 import pytest
 
+import plugins.date_time as date_time_module
 from plugins.date_time import DateTimePlugin, _time_to_english
 from src.devices import BoardContext
+
+# Patch the module object captured at import time rather than the
+# "plugins.date_time" dotted path. The plugin loader replaces the
+# sys.modules entry when it loads plugins (src/plugins/loader.py), so in a
+# full-suite run the dotted path resolves to a different module object than
+# the one DateTimePlugin above was defined in — and the mock never applies.
 
 
 class TestDateTimePlugin:
@@ -55,7 +62,7 @@ class TestDateTimePlugin:
         # Should use default and be valid
         assert len(errors) == 0
 
-    @patch("plugins.date_time.datetime")
+    @patch.object(date_time_module, "datetime")
     def test_fetch_data_all_variables(self, mock_datetime, sample_manifest, sample_config):
         """Test fetch_data returns all expected variables."""
         # Mock datetime to return a specific date/time
@@ -101,7 +108,7 @@ class TestDateTimePlugin:
         assert "month_abbr" in data
         assert "timezone" in data
 
-    @patch("plugins.date_time.datetime")
+    @patch.object(date_time_module, "datetime")
     def test_fetch_data_time_formats(self, mock_datetime, sample_manifest, sample_config):
         """Test time format variables."""
         # Test at 2:30 PM (14:30)
@@ -118,7 +125,7 @@ class TestDateTimePlugin:
         assert result.data["time"] == "14:30"  # Should match time_24h
         assert result.data["time_12h"] == "2:30 PM"  # Leading zero removed
 
-    @patch("plugins.date_time.datetime")
+    @patch.object(date_time_module, "datetime")
     def test_fetch_data_time_formats_midnight(self, mock_datetime, sample_manifest, sample_config):
         """Test time formats at midnight (12:00 AM)."""
         mock_now = datetime(2025, 1, 15, 0, 0, 0)
@@ -133,7 +140,7 @@ class TestDateTimePlugin:
         assert result.data["time_24h"] == "00:00"
         assert result.data["time_12h"] == "12:00 AM"
 
-    @patch("plugins.date_time.datetime")
+    @patch.object(date_time_module, "datetime")
     def test_fetch_data_time_formats_noon(self, mock_datetime, sample_manifest, sample_config):
         """Test time formats at noon (12:00 PM)."""
         mock_now = datetime(2025, 1, 15, 12, 0, 0)
@@ -148,7 +155,7 @@ class TestDateTimePlugin:
         assert result.data["time_24h"] == "12:00"
         assert result.data["time_12h"] == "12:00 PM"
 
-    @patch("plugins.date_time.datetime")
+    @patch.object(date_time_module, "datetime")
     def test_fetch_data_date_formats(self, mock_datetime, sample_manifest, sample_config):
         """Test US date format variables."""
         mock_now = datetime(2025, 1, 15, 14, 30, 0)
@@ -164,7 +171,7 @@ class TestDateTimePlugin:
         assert result.data["date_us"] == "01/15/2025"
         assert result.data["date_us_short"] == "01/15/25"
 
-    @patch("plugins.date_time.datetime")
+    @patch.object(date_time_module, "datetime")
     def test_fetch_data_month_formats(self, mock_datetime, sample_manifest, sample_config):
         """Test month format variables."""
         # Test January (month 1)
@@ -193,7 +200,7 @@ class TestDateTimePlugin:
         assert result.data["month_number_padded"] == "12"
         assert result.data["month_abbr"] == "Dec"
 
-    @patch("plugins.date_time.datetime")
+    @patch.object(date_time_module, "datetime")
     def test_fetch_data_timezone_info(self, mock_datetime, sample_manifest, sample_config):
         """Test timezone-related variables."""
         mock_now = datetime(2025, 1, 15, 14, 30, 0)
@@ -211,7 +218,7 @@ class TestDateTimePlugin:
         assert result.data["timezone"] == "America/New_York"
         assert "timezone_abbr" in result.data  # Should have abbreviation like "EST" or "EDT"
 
-    @patch("plugins.date_time.datetime")
+    @patch.object(date_time_module, "datetime")
     def test_fetch_data_day_of_week(self, mock_datetime, sample_manifest, sample_config):
         """Test day of week variable."""
         # Wednesday
@@ -233,7 +240,7 @@ class TestDateTimePlugin:
         assert result.data["quarter"] == "1"
         assert result.data["year"] == "2025"
 
-    @patch("plugins.date_time.datetime")
+    @patch.object(date_time_module, "datetime")
     def test_fetch_data_variables_match_manifest(self, mock_datetime, sample_manifest, sample_config):
         """Test that fetch_data() output keys match the manifest-declared variables."""
         mock_now = datetime(2025, 1, 15, 14, 30, 0)
@@ -290,7 +297,7 @@ class TestDateTimePlugin:
         assert result.data is not None
         assert result.data["timezone"] == "America/Denver"
 
-    @patch("plugins.date_time.datetime")
+    @patch.object(date_time_module, "datetime")
     def test_get_formatted_display(self, mock_datetime, sample_manifest, sample_config):
         """Test formatted display output."""
         mock_now = datetime(2025, 1, 15, 14, 30, 0)
@@ -308,7 +315,7 @@ class TestDateTimePlugin:
         assert "2025-01-15" in lines[2]  # Date should be centered
         assert "14:30" in lines[3]  # Time should be centered
 
-    @patch("plugins.date_time.datetime")
+    @patch.object(date_time_module, "datetime")
     def test_get_formatted_display_fetch_fails(self, mock_datetime, sample_manifest):
         """Test formatted display when fetch_data fails."""
         mock_datetime.now.side_effect = Exception("Test error")
@@ -487,7 +494,7 @@ class TestTimeToEnglish:
 class TestDateTimeBoardAwareness:
     """Date & Time adapts its content to the board it renders on."""
 
-    @patch("plugins.date_time.datetime")
+    @patch.object(date_time_module, "datetime")
     def test_date_pretty_full_on_flagship(self, mock_datetime, sample_manifest, sample_config):
         """On a wide board, date_pretty spells the weekday and month out fully."""
         tz = ZoneInfo("America/Los_Angeles")
@@ -501,7 +508,7 @@ class TestDateTimeBoardAwareness:
         assert data["month_adaptive"] == "August"
         assert data["date_pretty"] == "Wednesday, August 27"
 
-    @patch("plugins.date_time.datetime")
+    @patch.object(date_time_module, "datetime")
     def test_date_pretty_abbreviated_on_note(self, mock_datetime, sample_manifest, sample_config):
         """On a narrow board (Note), date_pretty uses abbreviated forms that fit."""
         tz = ZoneInfo("America/Los_Angeles")
@@ -516,7 +523,7 @@ class TestDateTimeBoardAwareness:
         assert data["date_pretty"] == "Wed, Aug 27"
         assert len(data["date_pretty"]) <= 15
 
-    @patch("plugins.date_time.datetime")
+    @patch.object(date_time_module, "datetime")
     def test_no_board_defaults_to_full(self, mock_datetime, sample_manifest, sample_config):
         """With no board bound, the long form is used (backward compatible)."""
         tz = ZoneInfo("America/Los_Angeles")
@@ -528,7 +535,7 @@ class TestDateTimeBoardAwareness:
 
         assert data["date_pretty"] == "Wednesday, August 27"
 
-    @patch("plugins.date_time.datetime")
+    @patch.object(date_time_module, "datetime")
     def test_formatted_display_note_is_compact(self, mock_datetime, sample_manifest, sample_config):
         """get_formatted_display drops to 3 lines that fit 15 cols on a Note."""
         tz = ZoneInfo("America/Los_Angeles")
@@ -544,7 +551,7 @@ class TestDateTimeBoardAwareness:
         assert all(len(line) <= 15 for line in lines)
         assert "WED" in lines[0].upper()
 
-    @patch("plugins.date_time.datetime")
+    @patch.object(date_time_module, "datetime")
     def test_per_board_cache_isolation(self, mock_datetime, sample_manifest, sample_config):
         """Flagship and Note variables cache independently."""
         tz = ZoneInfo("America/Los_Angeles")
@@ -565,7 +572,7 @@ class TestDateTimeBoardAwareness:
 class TestDateTimeCacheFreshness:
     """The clock plugin must never be served from a stale cache (#1738)."""
 
-    @patch("plugins.date_time.datetime")
+    @patch.object(date_time_module, "datetime")
     def test_get_data_reflects_advanced_clock(self, mock_datetime, sample_manifest, sample_config):
         """A get_data() call after the wall clock moves reports the new time."""
         tz = ZoneInfo("America/Los_Angeles")


### PR DESCRIPTION
## Summary

Converts all 17 `@patch("plugins.date_time.datetime")` decorators in `plugins/date_time/tests/test_plugin.py` to `@patch.object(date_time_module, "datetime")`, patching the module object captured at import time. Test-only change; no production code touched.

## Root cause

`src/plugins/loader.py` replaces the `sys.modules["plugins.date_time"]` entry with a freshly exec'd module when it (re)loads plugins. In a full-suite run, any loader test that runs first leaves the swapped entry behind, so `@patch("plugins.date_time.datetime")` resolves the dotted path to the *new* module object — while this test file's `DateTimePlugin` was defined in the *original* one. The mock never applies and every datetime-mocking test silently runs against the real wall clock.

This is the same root cause fixed for `plugins/countdown` in 1528b9a6 (#1806); this PR applies the identical conversion to date_time.

## Before / after

Baseline (3086c3f8c, v8.34.8), full suite serial `.venv/bin/pytest -q`:

```
14 failed, 5768 passed, 1 skipped   — all 14 in plugins/date_time/tests/test_plugin.py
```

Baseline under `-n auto` (3 runs): the same 14 date_time failures every run.

After the fix:

- `pytest -q plugins/date_time` (isolation): **48 passed**
- `pytest -q` (full serial): **5782 passed, 1 skipped**
- `pytest -q -n auto` x3: **5782 passed, 1 skipped** in each clean run

Note: an unrelated, pre-existing `-n auto` flake exists in `tests/test_config_migration.py` / `tests/test_config_manager.py` (10-test cluster, order-dependent). It reproduces at the baseline commit with this change reverted (baseline `-n auto` runs showed `24 failed` = 14 date_time + the 10-test cluster) and is untouched by this PR.

## Non-vacuity proof

Temporarily reverted the single conversion on `test_fetch_data_time_formats` back to the dotted-path patch and re-ran the full suite serially:

```
FAILED plugins/date_time/tests/test_plugin.py::TestDateTimePlugin::test_fetch_data_time_formats
1 failed, 5781 passed, 1 skipped
```

Exactly the reverted test fails; restored the conversion afterwards.

## Date-boundary sensitivity

The near-midnight flakiness reported in the issue is a symptom of the same bug, not a separate one: with the mock inert, 14 tests asserted frozen expected values (e.g. `"time_24h" == "14:30"`, `"WEDNESDAY" in lines[1]`) against the real clock, so exactly which tests failed varied with local date and time of day. After the conversion every datetime-dependent test is frozen via the mock. The four remaining unpatched tests that touch the real clock (`test_fetch_data_invalid_timezone`, `test_fetch_data_default_timezone`, `test_fetch_data_uses_general_timezone`, `test_time_english_in_fetch_data`) assert only clock-independent facts (timezone names, availability, the `IT'S ` prefix), so no time-of-day-dependent expectation computation remains.

`ruff check` and `ruff format --check` pass on the changed file.

Closes #1840

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLYErjB6rt3vgQXYFykRNw
