### PR TITLE
fix(mqtt): report out-of-band content in Active/Current Page entities (#1831)

### DIFF
--- a/docs/features/home-assistant-control.md
+++ b/docs/features/home-assistant-control.md
@@ -108,11 +108,13 @@ Once connected, FiestaBoard appears as a device with **24 entities** — control
 
 **Manual writes stay on the board.** Send Message, Blank Board and the debug
 endpoints write straight to the board and are left there — the display loop
-will not paint over them on its next cycle. Put the active page back with
-**Refresh Display**, by selecting a page, or by letting that page's content
-change on its own. (The Active Page and Current Page entities still report the
-configured page, not the manual message — tracked separately in
-[#1831](https://github.com/Fiestaboard/FiestaBoard/issues/1831).)
+will not paint over them on its next cycle. While manual content is displayed,
+the Active Page select and Current Page sensor report `None` rather than the
+configured page, so Home Assistant shows that the board is not on a page. The
+configured page itself is kept as the restore target: put it back with
+**Refresh Display**, by selecting a page (re-selecting the same page works),
+or by letting that page's content change on its own — the entities switch back
+to the page name as soon as the page lands on the board.
 
 **Send Message formatting:** text longer than the board width word-wraps onto
 the following rows automatically, sized to your board's real geometry (6 rows ×

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -1069,6 +1069,25 @@ def _publish_mqtt_state_update() -> None:
         logger.debug(f"MQTT state publish after board write failed: {e}")
 
 
+def _note_out_of_band_write() -> None:
+    """Record a successful out-of-band write to the primary board and push
+    fresh MQTT state (issue #1831).
+
+    The write bypassed the display loop and persists (issue #1794), so the
+    board no longer shows the configured page; flagging it lets the state
+    publisher report that instead of the page name. Peek only — with no
+    DisplayService there is nothing to flag, and reporting must never fail
+    the board write that triggered it.
+    """
+    service = peek_service()
+    if service is not None:
+        try:
+            service.mark_showing_out_of_band()
+        except Exception as e:
+            logger.debug(f"Out-of-band mark failed: {e}")
+    _publish_mqtt_state_update()
+
+
 def run_service_background():
     """Run the service in a background thread with auto-restart on failure."""
     global _service_running, _service_start_time
@@ -3587,13 +3606,14 @@ async def send_message(request: MessageRequest):
         )
         if success:
             if was_sent:
-                # Push fresh MQTT state so HA reflects the update. The
-                # display loop's dedupe cache is deliberately left alone:
+                # Flag the out-of-band write and push fresh MQTT state so HA
+                # reflects the update (issues #1794/#1831). The display
+                # loop's dedupe cache is deliberately left alone:
                 # invalidating it here made the message self-destruct on the
                 # next engine tick (<=15s). Restoring the active page is a
                 # pull — /force-refresh, MQTT Refresh Display, re-selecting
                 # a page, or an actual content change (issue #1794).
-                _publish_mqtt_state_update()
+                _note_out_of_band_write()
                 service.request_board_refresh()
                 return {"status": "success", "message": "Message sent successfully"}
             else:
@@ -7497,6 +7517,7 @@ async def debug_blank_board():
         success, was_sent = client.send_characters(blank_array, force=True)
 
         if success:
+            _note_out_of_band_write()
             return {"status": "success", "message": "Board blanked successfully"}
         else:
             raise HTTPException(status_code=500, detail="Failed to blank board")
@@ -7541,6 +7562,7 @@ async def debug_fill_board(request: dict):
         success, was_sent = client.send_characters(fill_array, force=True)
 
         if success:
+            _note_out_of_band_write()
             return {"status": "success", "message": f"Board filled with character {character_code}"}
         else:
             raise HTTPException(status_code=500, detail="Failed to fill board")
@@ -7610,6 +7632,7 @@ V{version[:7]} {timestamp}"""
         success, was_sent = client.send_characters(board_array, force=True)
 
         if success:
+            _note_out_of_band_write()
             return {"status": "success", "message": "Debug info sent to board", "debug_info": debug_text}
         else:
             raise HTTPException(status_code=500, detail="Failed to send debug info")

--- a/src/main.py
+++ b/src/main.py
@@ -73,6 +73,16 @@ class BoardRuntime:
         self.last_active_page_content: str | None = None
         self.last_active_page_id: str | None = None
 
+        # True while the board shows out-of-band content — a manual write
+        # that bypassed the display loop (MQTT send_message/blank_board,
+        # POST /send-message, the /debug/* writes). Out-of-band writes
+        # deliberately persist (issue #1794), so this flag is what lets the
+        # MQTT state publisher stop reporting the configured page while the
+        # board actually shows something else (issue #1831). Cleared whenever
+        # the engine delivers real content to this board. The stored active
+        # page id is never touched: it remains the restore target.
+        self.showing_out_of_band: bool = False
+
         # Last page/board geometry mismatch reported for this board, so the
         # send-time validation warns once per distinct mismatch instead of
         # every poll tick (issue #1748).
@@ -231,6 +241,41 @@ class DisplayService:
         """
         rt = self.runtimes.get(board_id) if board_id is not None else self._primary_runtime()
         return rt.last_send_error if rt is not None else None
+
+    def is_showing_out_of_band(self, board_id=None) -> bool:
+        """True while a board shows out-of-band content (issue #1831).
+
+        Out-of-band content is a manual write that bypassed the display loop
+        (MQTT send_message/blank_board, POST /send-message, /debug/* writes)
+        and deliberately persists (issue #1794). ``board_id`` omitted → the
+        primary board.
+        """
+        rt = self.runtimes.get(board_id) if board_id is not None else self._primary_runtime()
+        return rt.showing_out_of_band if rt is not None else False
+
+    def mark_showing_out_of_band(self, board_id=None) -> None:
+        """Record that a board now shows out-of-band content (issue #1831).
+
+        Called by the out-of-band write paths after a successful board write.
+        ``board_id`` omitted → the primary board. The flag is cleared when
+        ``check_and_send_for_board`` next delivers real content to the board.
+        """
+        if board_id is None:
+            self._ensure_primary_runtime().showing_out_of_band = True
+            return
+        rt = self.runtimes.get(board_id)
+        if rt is None:
+            # Legacy installs may key the primary runtime under the fallback
+            # sentinel rather than its settings board id (mirrors
+            # invalidate_board_content).
+            try:
+                primary_id = get_settings_service().get_primary_board_id()
+            except Exception:
+                primary_id = None
+            if board_id == primary_id:
+                rt = self._primary_runtime()
+        if rt is not None:
+            rt.showing_out_of_band = True
 
     def _record_send_error(self, rt: BoardRuntime, board_id, message: str) -> None:
         """Record a send failure on the runtime and in this thread's capture."""
@@ -1140,6 +1185,9 @@ class DisplayService:
                     return False
                 rt.last_active_page_content = current_content
                 rt.last_active_page_id = active_page_id
+                # The engine just painted the page over whatever was on the
+                # board, so any out-of-band content is gone (issue #1831).
+                rt.showing_out_of_band = False
                 if was_sent:
                     logger.info(f"Board {board_id}: active page sent: {active_page_id}")
                     # Board-state adaptive refresh is primary-only (see
@@ -1215,6 +1263,9 @@ class DisplayService:
         if success:
             rt.last_active_page_content = None
             rt.last_active_page_id = None
+            # Engine-owned write: the board no longer shows out-of-band
+            # content (issue #1831).
+            rt.showing_out_of_band = False
             logger.info("Temporary override expired (blank) - board cleared")
             if was_sent:
                 self.request_board_refresh()
@@ -1401,6 +1452,8 @@ class DisplayService:
         if success:
             rt.last_active_page_content = "snoozing"
             rt.last_active_page_id = "__silence__"
+            # Engine-owned write (issue #1831).
+            rt.showing_out_of_band = False
             rt.last_silence_mode_active = True
             rt.snoozing_message_sent = True
             logger.info("🔇 Silence mode active - further updates blocked until silence ends")
@@ -1505,6 +1558,8 @@ class DisplayService:
         if success:
             rt.last_active_page_content = result.formatted
             rt.last_active_page_id = f"__silence_page__:{page.id}"
+            # Engine-owned write (issue #1831).
+            rt.showing_out_of_band = False
             rt.last_silence_mode_active = True
             rt.snoozing_message_sent = True
             logger.info("🔇 Silence page sent - further updates blocked until silence ends")
@@ -1593,6 +1648,8 @@ class DisplayService:
         if success:
             rt.last_active_page_content = content
             rt.last_active_page_id = "__trigger__"
+            # Engine-owned write (issue #1831).
+            rt.showing_out_of_band = False
             if was_sent:
                 logger.info("Triggered message sent to board")
             return was_sent

--- a/src/mqtt/commands.py
+++ b/src/mqtt/commands.py
@@ -108,6 +108,33 @@ class CommandHandler:
         except Exception as e:
             logger.debug("Board content invalidation failed: %s", e)
 
+    def _mark_out_of_band(self, board_id: str | None) -> None:
+        """Record that a board now shows out-of-band content (issue #1831).
+
+        Out-of-band writes persist (issue #1794), so this is what lets the
+        state publisher report the no-page option instead of the configured
+        page while the manual content is on the board. ``None`` targets the
+        primary board. No-op when no DisplayService exists yet.
+        """
+        service = self._display_service()
+        if service is None or not hasattr(service, "mark_showing_out_of_band"):
+            return
+        try:
+            service.mark_showing_out_of_band(board_id)
+        except Exception as e:
+            logger.debug("Out-of-band mark failed: %s", e)
+
+    @staticmethod
+    def _send_succeeded(result) -> bool:
+        """True when a client write reported success.
+
+        ``send_characters`` returns ``(success, was_sent)``; older fakes may
+        return a bare truthy value.
+        """
+        if isinstance(result, tuple):
+            return bool(result[0])
+        return bool(result)
+
     def _force_send_active_page(self, board_id: str | None) -> None:
         """Invalidate dedupe state and immediately push the active page.
 
@@ -409,12 +436,16 @@ class CommandHandler:
         # when given, else the primary board, else the flagship 6x22 default.
         dims = self._board_dims(board if board is not None else self._resolve_board(None)[1])
         blank_array = [[0] * dims.cols for _ in range(dims.rows)]
-        client.send_characters(blank_array, force=True)
+        result = client.send_characters(blank_array, force=True)
         # NOTE: deliberately does NOT invalidate the display loop's dedupe
         # cache. Doing so made the blank self-destruct on the next engine
         # tick (<=15s), breaking the "Blank the Board at Bedtime" automation
         # in our own HA docs. Restoring the page is a pull: Refresh Display,
         # re-selecting a page, or an actual content change.
+        if self._send_succeeded(result):
+            # The board now shows out-of-band content (issue #1831); the
+            # trailing gather_and_publish in handle() reports it to HA.
+            self._mark_out_of_band(board_id)
         self._mark_display_updated()
         self._publish_event("display_updated", "board_blanked")
 
@@ -488,7 +519,7 @@ class CommandHandler:
             unescape_newlines=self._json_object(payload) is None,
         )
         board_array = text_to_board_array(wrapped, rows=dims.rows, cols=dims.cols)
-        client.send_characters(
+        result = client.send_characters(
             board_array,
             strategy=transition.strategy,
             step_interval_ms=transition.step_interval_ms,
@@ -497,6 +528,10 @@ class CommandHandler:
         # NOTE: deliberately does NOT invalidate the display loop's dedupe
         # cache — see _handle_blank_board. The message must outlive the next
         # engine tick, or "Welcome Home John!" lasts 15 seconds.
+        if self._send_succeeded(result):
+            # The board now shows out-of-band content (issue #1831); the
+            # trailing gather_and_publish in handle() reports it to HA.
+            self._mark_out_of_band(board_id)
         self._mark_display_updated()
         self._publish_event("display_updated", "message_sent")
 

--- a/src/mqtt/state.py
+++ b/src/mqtt/state.py
@@ -88,6 +88,14 @@ class StatePublisher:
                 page = page_service.get_page(active_id)
                 if page:
                     page_name = page.name
+            # While the primary board shows out-of-band content (a manual
+            # MQTT/HTTP write, which persists per issue #1794), the board is
+            # NOT showing the configured page — report the same stable
+            # no-page option instead of lying (issue #1831). The stored
+            # active page id is untouched: selecting any page in HA still
+            # force-sends it (issue #1794), which is the restore path.
+            if self._primary_board_showing_out_of_band():
+                page_name = NO_ACTIVE_PAGE_OPTION
             out["active_page"] = page_name
             out["current_page"] = page_name
 
@@ -229,6 +237,23 @@ class StatePublisher:
         except Exception as e:
             logger.debug("Attributes gather error: %s", e)
         return out
+
+    @staticmethod
+    def _primary_board_showing_out_of_band() -> bool:
+        """True while the primary board shows out-of-band content (issue #1831).
+
+        Reads the existing DisplayService only (peek, never create): with no
+        service there has been no board write, so nothing is out of band.
+        """
+        try:
+            from src.api_server import peek_service
+
+            service = peek_service()
+            if service is not None and hasattr(service, "is_showing_out_of_band"):
+                return service.is_showing_out_of_band() is True
+        except Exception:
+            logger.debug("Could not read out-of-band display state")
+        return False
 
     @staticmethod
     def _get_uptime() -> str:

--- a/tests/test_api_extended.py
+++ b/tests/test_api_extended.py
@@ -1502,6 +1502,30 @@ class TestServiceLifecycle:
         with patch.object(api_server, "_service", None):
             assert api_server.peek_service() is None
 
+    def test_send_message_marks_the_board_as_out_of_band(self, client, mock_service, mock_settings_service):
+        """Issue #1831: a manual send replaces the page on the board, so the
+        board must be flagged as showing out-of-band content — that is what
+        makes the HA Active/Current Page entities stop reporting the page."""
+        with (
+            patch("src.api_server.Config.is_silence_mode_active", return_value=False),
+            patch("src.api_server.peek_service", return_value=mock_service),
+        ):
+            response = client.post("/send-message", json={"text": "Hello"})
+        assert response.status_code == 200
+        mock_service.mark_showing_out_of_band.assert_called_once_with()
+
+    def test_skipped_send_message_does_not_mark_out_of_band(self, client, mock_service, mock_settings_service):
+        """was_sent=False means the board already showed this content — nothing
+        was written, so the out-of-band state must not change."""
+        mock_service.vb_client.render.return_value = (True, False)
+        with (
+            patch("src.api_server.Config.is_silence_mode_active", return_value=False),
+            patch("src.api_server.peek_service", return_value=mock_service),
+        ):
+            response = client.post("/send-message", json={"text": "Hello"})
+        assert response.status_code == 200
+        mock_service.mark_showing_out_of_band.assert_not_called()
+
 
 class TestSendMessageWrapping:
     """Issue #1793: /send-message wraps long text to the board's geometry."""

--- a/tests/test_debug_endpoints.py
+++ b/tests/test_debug_endpoints.py
@@ -622,3 +622,68 @@ class TestDebugOutOfBandWritesSurviveTheDisplayLoop:
         ):
             response = client.post("/debug/blank")
         assert response.status_code == 200
+
+
+class TestDebugWritesReportOutOfBand:
+    """Issue #1831: the /debug/* board writes must mark the primary board as
+    showing out-of-band content and push fresh MQTT state, so Home Assistant
+    stops reporting the configured page while debug content is displayed."""
+
+    def test_debug_blank_marks_out_of_band_and_publishes(self, client, mock_board_client):
+        service = Mock()
+        with (
+            patch("src.api_server.get_settings_service", return_value=_mock_ss("flagship")),
+            patch("src.api_server.peek_service", return_value=service),
+            patch("src.api_server._publish_mqtt_state_update") as publish,
+        ):
+            response = client.post("/debug/blank")
+        assert response.status_code == 200
+        service.mark_showing_out_of_band.assert_called_once_with()
+        publish.assert_called_once_with()
+
+    def test_debug_fill_marks_out_of_band_and_publishes(self, client, mock_board_client):
+        service = Mock()
+        with (
+            patch("src.api_server.get_settings_service", return_value=_mock_ss("flagship")),
+            patch("src.api_server.peek_service", return_value=service),
+            patch("src.api_server._publish_mqtt_state_update") as publish,
+        ):
+            response = client.post("/debug/fill", json={"character_code": 63})
+        assert response.status_code == 200
+        service.mark_showing_out_of_band.assert_called_once_with()
+        publish.assert_called_once_with()
+
+    def test_debug_info_marks_out_of_band_and_publishes(self, client, mock_board_client):
+        service = Mock()
+        with (
+            patch("src.api_server.get_settings_service", return_value=_mock_ss("flagship")),
+            patch("src.api_server.peek_service", return_value=service),
+            patch("src.api_server._publish_mqtt_state_update") as publish,
+        ):
+            response = client.post("/debug/info")
+        assert response.status_code == 200
+        service.mark_showing_out_of_band.assert_called_once_with()
+        publish.assert_called_once_with()
+
+    def test_failed_debug_blank_does_not_mark_out_of_band(self, client, mock_board_client):
+        mock_board_client.send_characters.return_value = (False, False)
+        service = Mock()
+        with (
+            patch("src.api_server.get_settings_service", return_value=_mock_ss("flagship")),
+            patch("src.api_server.peek_service", return_value=service),
+            patch("src.api_server._publish_mqtt_state_update") as publish,
+        ):
+            response = client.post("/debug/blank")
+        assert response.status_code == 500
+        service.mark_showing_out_of_band.assert_not_called()
+        publish.assert_not_called()
+
+    def test_no_display_service_is_safe(self, client, mock_board_client):
+        """peek_service returning None must not fail the debug write."""
+        with (
+            patch("src.api_server.get_settings_service", return_value=_mock_ss("flagship")),
+            patch("src.api_server.peek_service", return_value=None),
+            patch("src.api_server._publish_mqtt_state_update"),
+        ):
+            response = client.post("/debug/blank")
+        assert response.status_code == 200

--- a/tests/test_mqtt_commands.py
+++ b/tests/test_mqtt_commands.py
@@ -1185,3 +1185,214 @@ class TestDisplayServiceGuardIntegration:
             client.render.assert_not_called()
             publisher.publish_event.assert_not_called()
             publisher.mark_display_updated.assert_not_called()
+
+
+class TestOutOfBandFlagMarking:
+    """Issue #1831: the MQTT board-write commands must record that the board
+    now shows out-of-band content, so the state publisher stops reporting the
+    configured page while a manual message/blank is on the board."""
+
+    @patch("src.api_server.peek_service")
+    @patch("src.settings.service.get_settings_service")
+    @patch("src.text_to_board.text_to_board_array")
+    @patch("src.api_server.get_service")
+    @patch("src.config.Config")
+    def test_send_message_marks_the_board_as_out_of_band(
+        self, mock_config, get_service, text_to_board, get_settings, peek, handler
+    ):
+        mock_config.is_silence_mode_active.return_value = False
+        service = MagicMock()
+        service.vb_client = MagicMock()
+        service.vb_client.send_characters.return_value = (True, True)
+        get_service.return_value = service
+        peek.return_value = service
+        text_to_board.return_value = [[0] * 22 for _ in range(6)]
+        settings = MagicMock()
+        settings.get_primary_board_id.return_value = "b1"
+        settings.is_paused.return_value = False
+        settings.get_transition_settings.return_value = MagicMock(strategy="column", step_interval_ms=100, step_size=1)
+        get_settings.return_value = settings
+
+        handler.handle("send_message", "Hello World")
+
+        service.mark_showing_out_of_band.assert_called_once_with(None)
+
+    @patch("src.api_server.peek_service")
+    @patch("src.api_server.get_service")
+    @patch("src.settings.service.get_settings_service")
+    @patch("src.config.Config")
+    def test_send_message_board_targeted_marks_that_board(self, mock_config, get_settings, get_service, peek, handler):
+        mock_config.is_silence_mode_active.return_value = False
+        get_settings.return_value = TestCommandHandlerPerBoardRouting._settings_with_boards()
+        service = MagicMock()
+        board_client = MagicMock()
+        board_client.send_characters.return_value = (True, True)
+        service.get_board_client.return_value = board_client
+        get_service.return_value = service
+        peek.return_value = service
+
+        handler.handle("send_message", '{"message": "HELLO", "board": "Kitchen"}')
+
+        service.mark_showing_out_of_band.assert_called_once_with("b2")
+
+    @patch("src.api_server.peek_service")
+    @patch("src.settings.service.get_settings_service")
+    @patch("src.text_to_board.text_to_board_array")
+    @patch("src.api_server.get_service")
+    @patch("src.config.Config")
+    def test_failed_send_message_does_not_mark_out_of_band(
+        self, mock_config, get_service, text_to_board, get_settings, peek, handler
+    ):
+        mock_config.is_silence_mode_active.return_value = False
+        service = MagicMock()
+        service.vb_client = MagicMock()
+        service.vb_client.send_characters.return_value = (False, False)
+        get_service.return_value = service
+        peek.return_value = service
+        text_to_board.return_value = [[0] * 22 for _ in range(6)]
+        settings = MagicMock()
+        settings.get_primary_board_id.return_value = "b1"
+        settings.is_paused.return_value = False
+        settings.get_transition_settings.return_value = MagicMock(strategy="column", step_interval_ms=100, step_size=1)
+        get_settings.return_value = settings
+
+        handler.handle("send_message", "Hello World")
+
+        service.mark_showing_out_of_band.assert_not_called()
+
+    @patch("src.api_server.peek_service")
+    @patch("src.settings.service.get_settings_service")
+    @patch("src.api_server._get_board_client")
+    def test_blank_board_marks_the_board_as_out_of_band(self, get_board, get_settings, peek, handler):
+        board_client = MagicMock()
+        board_client.send_characters.return_value = (True, True)
+        get_board.return_value = board_client
+        settings = MagicMock()
+        settings.should_send_to_board.return_value = True
+        settings.is_paused.return_value = False
+        settings.get_primary_board_id.return_value = "b1"
+        get_settings.return_value = settings
+        service = MagicMock()
+        peek.return_value = service
+
+        handler.handle("blank_board", "")
+
+        service.mark_showing_out_of_band.assert_called_once_with(None)
+
+    @patch("src.api_server.peek_service")
+    @patch("src.settings.service.get_settings_service")
+    @patch("src.api_server._get_board_client")
+    def test_failed_blank_board_does_not_mark_out_of_band(self, get_board, get_settings, peek, handler):
+        board_client = MagicMock()
+        board_client.send_characters.return_value = (False, False)
+        get_board.return_value = board_client
+        settings = MagicMock()
+        settings.should_send_to_board.return_value = True
+        settings.is_paused.return_value = False
+        settings.get_primary_board_id.return_value = "b1"
+        get_settings.return_value = settings
+        service = MagicMock()
+        peek.return_value = service
+
+        handler.handle("blank_board", "")
+
+        service.mark_showing_out_of_band.assert_not_called()
+
+
+class TestOutOfBandStateReporting:
+    """Issue #1831: while a board shows out-of-band content, the Active Page
+    select / Current Page sensor must report the no-page option instead of
+    the configured page. Drives a REAL DisplayService and a REAL
+    StatePublisher so the flag's full lifecycle is exercised, not mocked."""
+
+    @staticmethod
+    def _publisher(mock_client):
+        from src.mqtt.state import StatePublisher
+
+        return StatePublisher(mock_client)
+
+    @staticmethod
+    def _published(mock_client, object_id):
+        """The last value published for an object_id, or None."""
+        values = [c[0][1] for c in mock_client.publish_state.call_args_list if c[0][0] == object_id]
+        return values[-1] if values else None
+
+    def test_out_of_band_write_flips_published_state_to_the_none_option(self, handler, mock_client):
+        from src.mqtt.discovery import NO_ACTIVE_PAGE_OPTION
+
+        env = TestDisplayServiceGuardIntegration
+        svc, _client, settings, page_svc = env._make_env()
+        pub = self._publisher(mock_client)
+        with env._env_patches(svc, settings, page_svc):
+            assert svc.check_and_send_active_page() is True
+            pub.gather_and_publish()
+            assert self._published(mock_client, "active_page") == "Alpha"
+
+            handler.handle("send_message", "HELLO")
+
+            pub.gather_and_publish()
+            assert self._published(mock_client, "active_page") == NO_ACTIVE_PAGE_OPTION
+            assert self._published(mock_client, "current_page") == NO_ACTIVE_PAGE_OPTION
+
+    def test_reselecting_the_page_flips_state_back_and_resends(self, handler, mock_client):
+        from src.mqtt.discovery import NO_ACTIVE_PAGE_OPTION
+
+        env = TestDisplayServiceGuardIntegration
+        svc, client, settings, page_svc = env._make_env()
+        pub = self._publisher(mock_client)
+        with env._env_patches(svc, settings, page_svc):
+            assert svc.check_and_send_active_page() is True
+            handler.handle("send_message", "HELLO")
+            pub.gather_and_publish()
+            assert self._published(mock_client, "active_page") == NO_ACTIVE_PAGE_OPTION
+
+            # Restoring: picking the page (even the one already configured)
+            # force-sends it and flips the reported state back.
+            handler.handle("active_page", "Alpha")
+
+            assert client.render.call_count == 2, "re-selecting the page did not re-send it"
+            pub.gather_and_publish()
+            assert self._published(mock_client, "active_page") == "Alpha"
+            assert self._published(mock_client, "current_page") == "Alpha"
+
+    def test_engine_tick_delivering_the_page_clears_the_flag(self, handler, mock_client):
+        from src.mqtt.discovery import NO_ACTIVE_PAGE_OPTION
+
+        env = TestDisplayServiceGuardIntegration
+        pages = {"pA": ("Alpha", "ALPHA CONTENT")}
+        svc, _client, settings, page_svc = env._make_env(pages=pages)
+        pub = self._publisher(mock_client)
+        with env._env_patches(svc, settings, page_svc):
+            assert svc.check_and_send_active_page() is True
+            handler.handle("send_message", "HELLO")
+            pub.gather_and_publish()
+            assert self._published(mock_client, "active_page") == NO_ACTIVE_PAGE_OPTION
+
+            # The page's content changes on its own -> the engine repaints the
+            # board with the page, so the board is no longer out of band.
+            pages["pA"] = ("Alpha", "NEW ALPHA CONTENT")
+            assert svc.check_and_send_active_page() is True
+
+            pub.gather_and_publish()
+            assert self._published(mock_client, "active_page") == "Alpha"
+
+    def test_sync_loop_does_not_flap_the_published_value(self, handler, mock_client):
+        """Engine ticks that dedupe (content unchanged) must leave the flag
+        set, and the periodic state publish must keep reporting the sentinel
+        without republishing it every cycle."""
+        from src.mqtt.discovery import NO_ACTIVE_PAGE_OPTION
+
+        env = TestDisplayServiceGuardIntegration
+        svc, _client, settings, page_svc = env._make_env()
+        pub = self._publisher(mock_client)
+        with env._env_patches(svc, settings, page_svc):
+            assert svc.check_and_send_active_page() is True
+            pub.gather_and_publish()
+            handler.handle("send_message", "HELLO")
+
+            for _ in range(3):
+                assert svc.check_and_send_active_page() is False, "sync tick repainted over the manual message"
+                pub.gather_and_publish()
+
+            values = [c[0][1] for c in mock_client.publish_state.call_args_list if c[0][0] == "active_page"]
+            assert values == ["Alpha", NO_ACTIVE_PAGE_OPTION], "published Active Page state flapped"

--- a/tests/test_mqtt_state.py
+++ b/tests/test_mqtt_state.py
@@ -479,3 +479,94 @@ class TestStatePublisherPerBoardAttributes:
         attrs = json.loads(attrs_calls[attrs_topics.index("current_page")][0][1])
         assert attrs["by_board"]["b1"] == {"page_id": "page-42", "page_name": "Weather"}
         assert attrs["by_board"]["b2"] == {"page_id": "page-7", "page_name": "Transit"}
+
+
+class TestStatePublisherOutOfBand:
+    """Issue #1831: while the primary board shows out-of-band content (a
+    manual MQTT/HTTP write), active_page/current_page must report the select's
+    stable no-page option instead of the configured page. The stored active
+    page id is untouched — it remains the restore target (issue #1794)."""
+
+    @staticmethod
+    def _wired(get_settings, get_page, mock_config, active_page_id="page-1", page_name="Weather"):
+        mock_config.is_silence_mode_active.return_value = False
+        settings = MagicMock()
+        settings.is_schedule_enabled.return_value = False
+        settings.get_active_page_id.return_value = active_page_id
+        settings.get_transition_settings.return_value = MagicMock(strategy="")
+        settings.get_polling_interval.return_value = 60
+        settings.get_output_settings.return_value = MagicMock(target="both")
+        get_settings.return_value = settings
+        page_svc = MagicMock()
+        page = MagicMock()
+        page.name = page_name
+        page.id = active_page_id
+        page_svc.get_page.return_value = page
+        page_svc.list_pages.return_value = []
+        get_page.return_value = page_svc
+
+    @patch("src.api_server.peek_service")
+    @patch("src.config_manager.ConfigManager")
+    @patch("src.api_server._get_board_client")
+    @patch("src.api_server._service_start_time", 1000000.0)
+    @patch("src.pages.service.get_page_service")
+    @patch("src.settings.service.get_settings_service")
+    @patch("src.config.Config")
+    def test_out_of_band_content_publishes_none_option(
+        self, mock_config, get_settings, get_page, mock_board, mock_cm, peek, mock_client
+    ):
+        from src.mqtt.discovery import NO_ACTIVE_PAGE_OPTION
+
+        self._wired(get_settings, get_page, mock_config)
+        mock_board.return_value = None
+        mock_cm.return_value._config = {"plugins": {}}
+        service = MagicMock()
+        service.is_showing_out_of_band.return_value = True
+        peek.return_value = service
+        pub = StatePublisher(mock_client)
+        pub.gather_and_publish()
+        state = {c[0][0]: c[0][1] for c in mock_client.publish_state.call_args_list}
+        assert state["active_page"] == NO_ACTIVE_PAGE_OPTION
+        assert state["current_page"] == NO_ACTIVE_PAGE_OPTION
+
+    @patch("src.api_server.peek_service")
+    @patch("src.config_manager.ConfigManager")
+    @patch("src.api_server._get_board_client")
+    @patch("src.api_server._service_start_time", 1000000.0)
+    @patch("src.pages.service.get_page_service")
+    @patch("src.settings.service.get_settings_service")
+    @patch("src.config.Config")
+    def test_in_band_content_still_publishes_the_page_name(
+        self, mock_config, get_settings, get_page, mock_board, mock_cm, peek, mock_client
+    ):
+        self._wired(get_settings, get_page, mock_config)
+        mock_board.return_value = None
+        mock_cm.return_value._config = {"plugins": {}}
+        service = MagicMock()
+        service.is_showing_out_of_band.return_value = False
+        peek.return_value = service
+        pub = StatePublisher(mock_client)
+        pub.gather_and_publish()
+        state = {c[0][0]: c[0][1] for c in mock_client.publish_state.call_args_list}
+        assert state["active_page"] == "Weather"
+        assert state["current_page"] == "Weather"
+
+    @patch("src.api_server.peek_service")
+    @patch("src.config_manager.ConfigManager")
+    @patch("src.api_server._get_board_client")
+    @patch("src.api_server._service_start_time", 1000000.0)
+    @patch("src.pages.service.get_page_service")
+    @patch("src.settings.service.get_settings_service")
+    @patch("src.config.Config")
+    def test_no_display_service_reports_the_page_name(
+        self, mock_config, get_settings, get_page, mock_board, mock_cm, peek, mock_client
+    ):
+        """No DisplayService instance -> nothing can be out of band."""
+        self._wired(get_settings, get_page, mock_config)
+        mock_board.return_value = None
+        mock_cm.return_value._config = {"plugins": {}}
+        peek.return_value = None
+        pub = StatePublisher(mock_client)
+        pub.gather_and_publish()
+        state = {c[0][0]: c[0][1] for c in mock_client.publish_state.call_args_list}
+        assert state["active_page"] == "Weather"

--- a/tests/test_per_board_engine.py
+++ b/tests/test_per_board_engine.py
@@ -910,3 +910,81 @@ class TestThrottledSendDoesNotPrimeDedupeCache:
         _drive(svc, boards, pages=pages, schedule=_schedule_service({"b1": "pA"}))
 
         assert svc.runtimes["b1"].last_active_page_content == "ALPHA"
+
+
+class TestOutOfBandContentFlag:
+    """Issue #1831: per-board "showing out-of-band content" state.
+
+    Set by the out-of-band write paths (MQTT send_message/blank_board, POST
+    /send-message, the /debug/* writes), cleared whenever the engine actually
+    delivers a page to that board. The stored active page id is untouched —
+    it remains the restore target (issue #1805)."""
+
+    def test_runtime_defaults_to_in_band(self):
+        rt = BoardRuntime(client=None, board_id="b1")
+        assert rt.showing_out_of_band is False
+
+    def test_mark_and_read_target_the_given_board(self):
+        boards = [_board("b1", "One"), _board("b2", "Two", port=7001)]
+        svc, _clients = _service_with_runtimes(boards)
+
+        svc.mark_showing_out_of_band("b2")
+
+        assert svc.is_showing_out_of_band("b2") is True
+        assert svc.is_showing_out_of_band("b1") is False
+
+    def test_mark_without_board_id_targets_the_primary_board(self):
+        boards = [_board("b1", "One"), _board("b2", "Two", port=7001)]
+        svc, _clients = _service_with_runtimes(boards)
+
+        svc.mark_showing_out_of_band()
+
+        assert svc.is_showing_out_of_band() is True
+        assert svc.is_showing_out_of_band("b1") is True
+        assert svc.is_showing_out_of_band("b2") is False
+
+    def test_unknown_board_reads_as_in_band(self):
+        boards = [_board("b1", "One")]
+        svc, _clients = _service_with_runtimes(boards)
+
+        svc.mark_showing_out_of_band("nope")
+
+        assert svc.is_showing_out_of_band("nope") is False
+        assert svc.is_showing_out_of_band("b1") is False
+
+    def test_delivering_a_page_clears_the_flag(self):
+        boards = [_board("b1", "One")]
+        svc, _clients = _service_with_runtimes(boards)
+        pages = _page_service({"pA": {"content": "ALPHA"}})
+        schedule = _schedule_service({"b1": "pA"})
+        svc.mark_showing_out_of_band("b1")
+
+        _drive(svc, boards, pages=pages, schedule=schedule)
+
+        assert svc.is_showing_out_of_band("b1") is False
+
+    def test_deduped_tick_leaves_the_flag_set(self):
+        """The engine skipping at the content-unchanged guard has NOT painted
+        over the manual content, so the flag must survive the tick."""
+        boards = [_board("b1", "One")]
+        svc, _clients = _service_with_runtimes(boards)
+        pages = _page_service({"pA": {"content": "ALPHA"}})
+        schedule = _schedule_service({"b1": "pA"})
+
+        _drive(svc, boards, pages=pages, schedule=schedule)
+        svc.mark_showing_out_of_band("b1")
+        _drive(svc, boards, pages=pages, schedule=schedule)
+
+        assert svc.is_showing_out_of_band("b1") is True
+
+    def test_failed_send_leaves_the_flag_set(self):
+        boards = [_board("b1", "One")]
+        svc, clients = _service_with_runtimes(boards)
+        clients["b1"].render.return_value = (False, False)
+        pages = _page_service({"pA": {"content": "ALPHA"}})
+        schedule = _schedule_service({"b1": "pA"})
+        svc.mark_showing_out_of_band("b1")
+
+        _drive(svc, boards, pages=pages, schedule=schedule)
+
+        assert svc.is_showing_out_of_band("b1") is True


### PR DESCRIPTION
## Problem

`StatePublisher` publishes `active_page` / `current_page` from `get_active_page_id()`. When something writes to the board out of band — MQTT `send_message` / `blank_board`, `POST /send-message`, the `/debug/*` endpoints — the board shows that content, but Home Assistant keeps reporting the configured page. Since #1805 deliberately makes out-of-band writes persist, the board can sit on "HELLO" indefinitely while HA says "Weather Dashboard".

## Design decision: reuse `None`, not a new "External" option

The issue left open whether to add a distinct select option (e.g. `External`) for "out-of-band content" vs reusing the existing `NO_ACTIVE_PAGE_OPTION` (`None`). This PR **reuses `None`**:

- HA rejects published select states that aren't in the options list, so a distinct option would have to be *selectable* — a second non-command entry in the select that, as a command, can only be refused (like `None` already is on the primary board). One such sentinel in the options list is a wart; two is a pattern.
- Semantically, `None` already means "the board is not showing a configured page", which is exactly the truth here. The distinction "no page configured" vs "manual content displayed" is not actionable from the select — the restore gesture (pick a page, which force-sends since #1805) is identical in both cases.
- Smaller HA-visible surface: no discovery payload change, no new option for existing automations to trip over, nothing new to migrate if a better idea arrives later.

## What changed

- **`BoardRuntime.showing_out_of_band`** (per-board) with `DisplayService.is_showing_out_of_band()` / `mark_showing_out_of_band()` accessors. Set by every out-of-band write path on successful write only; cleared whenever the engine actually delivers content to that board (page send success path, trigger content, silence indicator/page, override-expiry blank). The stored active page id is never touched — it stays the restore target (core of #1805).
- **`StatePublisher`**: while the primary board's flag is set, `active_page` and `current_page` publish `None` instead of the configured page name. Reads the service via `peek_service()` (never creates one).
- **MQTT `send_message` / `blank_board`** mark the target board after a successful `send_characters`; the trailing `gather_and_publish` in `handle()` reports it immediately.
- **HTTP paths**: `POST /send-message` now flags the write via a shared `_note_out_of_band_write()` helper (which also does the #1805 MQTT state push), and the same helper is added to `/debug/blank`, `/debug/fill`, `/debug/info` — these previously published nothing.
- **Docs**: the "Manual writes stay on the board" paragraph in `docs/features/home-assistant-control.md` now documents the `None` reporting and the restore loop, replacing the caveat that pointed at #1831.

### Behavior changes visible to users

- After a manual write, the Active Page select and Current Page sensor show `None` until the page is restored (Refresh Display, selecting a page — including re-selecting the same one — or the page's content changing on its own). They flip back to the page name as soon as the page lands.
- The `/debug/*` write endpoints now push fresh MQTT state after a successful write.
- Deduped engine ticks ("content unchanged") leave the flag alone, so the periodic sync loop does not flap the published value.

Closes #1831
Closes #1794 — #1805 closed sub-complaints (b) and (c); this completes the remaining sub-complaint (a), the select/sensor reflecting non-page content.

## Test evidence

TDD: all new tests were written first and observed failing for the expected reasons, e.g.

```
E   AttributeError: 'BoardRuntime' object has no attribute 'showing_out_of_band'
E   AssertionError: assert 'Alpha' == 'None'
```

New coverage (integration tests drive a REAL `DisplayService` + REAL `StatePublisher`, following the #1805 house style):

- `tests/test_mqtt_commands.py::TestOutOfBandStateReporting` — (a) out-of-band write flips published state to `None`, (b) re-selecting the page flips it back and re-sends, (c) an engine tick delivering changed content clears the flag, (d) the sync loop publishes `["Alpha", "None"]` exactly once each across repeated ticks (no flapping).
- `tests/test_mqtt_commands.py::TestOutOfBandFlagMarking` — MQTT send/blank mark the right board; failed sends don't mark.
- `tests/test_per_board_engine.py::TestOutOfBandContentFlag` — accessor units + delivery clears / dedupe keeps / failed send keeps the flag.
- `tests/test_mqtt_state.py::TestStatePublisherOutOfBand` — publisher branch units (flag set → `None`; flag clear / no service → page name).
- `tests/test_debug_endpoints.py::TestDebugWritesReportOutOfBand` — (e) `/debug/blank|fill|info` mark + publish; failed write does neither; no service is safe.
- `tests/test_api_extended.py` — `/send-message` marks on `was_sent`, not on a skipped send.

Non-vacuity checks (per repo test quality bar) — each negative test that passed pre-implementation was proven against a deliberate mutation:

```
MUTATION _send_succeeded -> True:      FAILED test_failed_send_message_does_not_mark_out_of_band
                                       FAILED test_failed_blank_board_does_not_mark_out_of_band
MUTATION clear flag on dedupe skip:    FAILED test_deduped_tick_leaves_the_flag_set
                                       FAILED test_sync_loop_does_not_flap_the_published_value
MUTATION mark on skipped /send-message: FAILED test_skipped_send_message_does_not_mark_out_of_band
```

Runs (local venv, Python 3.14):

- Touched files: `pytest tests/test_mqtt_commands.py tests/test_mqtt_state.py tests/test_per_board_engine.py tests/test_debug_endpoints.py tests/test_api_extended.py tests/test_mqtt_client.py tests/test_mqtt_discovery.py` → **552 passed**.
- Full suite `pytest -q -n auto`: **5786 passed, 22 failed** — the failures are `plugins/date_time` (known, #1840) plus `tests/test_config_manager.py` / `tests/test_config_migration.py` full-suite-only interaction failures. All of them reproduce **identically at base `3086c3f8c`** (verified in a throwaway detached worktree: full suite there fails the exact same non-date_time test ids; those files pass in isolation on both base and this branch).
- `ruff check` + `ruff format --check` clean on changed files (the two `ruff format` findings in `src/api_server.py` are pre-existing at base, outside this diff, and were left untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TLYErjB6rt3vgQXYFykRNw