### PR TITLE
registry: add Generative Dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ FiestaBoard has a catalog of **50+ plugins** covering weather, finance, transit,
 | [Earthquake Monitor](https://github.com/Fiestaboard/fiestaboard-plugin--earthquake) | Recent USGS earthquake data | No |
 | [Element of the Day](https://github.com/Fiestaboard/fiestaboard-plugin--element-of-day) | Periodic table element of the day | No |
 | [Generative AI Art](https://github.com/Fiestaboard/fiestaboard-plugin--generative-ai-art) | LLM-generated abstract art using the board's 8-color palette | Yes |
+| [Generative Dashboard](https://github.com/Fiestaboard/fiestaboard-plugin--generative-dashboard) | AI-curated dashboard from your other plugins' data | Yes |
 | [Generic Data](https://github.com/Fiestaboard/fiestaboard-plugin--generic-data) | Custom data from any JSON/XML URL | No |
 | [Guest WiFi](https://github.com/Fiestaboard/fiestaboard-plugin--guest-wifi) | WiFi credentials for guests | No |
 | [Hacker News](https://github.com/Fiestaboard/fiestaboard-plugin--hacker-news) | Top Hacker News story title and score | No |

--- a/plugin-registry.json
+++ b/plugin-registry.json
@@ -126,6 +126,16 @@
       "category": "art"
     },
     {
+      "id": "generative_dashboard",
+      "name": "Generative Dashboard",
+      "description": "AI-curated dashboard composed from your other plugins' variables \u2014 live values, range-driven status lights, grid or prose",
+      "repository": "https://github.com/Fiestaboard/fiestaboard-plugin--generative-dashboard",
+      "author": "FiestaBoard Team",
+      "fiestaboard_version": ">=2.10.0",
+      "icon": "layout-dashboard",
+      "category": "data"
+    },
+    {
       "id": "guest_wifi",
       "name": "Guest WiFi",
       "description": "Display guest WiFi credentials on your board",


### PR DESCRIPTION
## Description

Adds [`fiestaboard-plugin--generative-dashboard`](https://github.com/Fiestaboard/fiestaboard-plugin--generative-dashboard) to `plugin-registry.json` and to the plugin table in `README.md` — an AI editor for the board. Point it at any OpenAI-compatible model and it composes the board from every variable your enabled plugins expose: live values inside stable layouts (the model places variables, never numbers), range-driven status lights via compiled formula rules, and an auto-chosen grid or prose form. Curated by an audience brief, the local clock, a self-written journal, and awareness of what the rest of the rotation already covers.

## Registry checklist

- [x] Canonical README with hero `docs/board-display.png`, canonical `docs/SETUP.md`
- [x] `teaser` + flagship/note `previews` (literal board text), primary screenshot in manifest
- [x] `scripts/validate_plugins.py --strict`: passed, 0 errors, 0 warnings
- [x] 450 tests, 95% coverage (bar: 80%), 14/14 mutation checks
- [x] CI (org template) green on main; PR-policy ruleset + taco-admins CODEOWNERS active
- [x] Exercised on a live board through ~30 versions; docs are explicit that output quality depends on model choice and tuning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DD3TtK4aRG5RaoTZ5zHkC6