### PR TITLE
fix(registry): seed board preview for generative_dashboard (unblocks all PR CI)

### DIFF
--- a/plugin-previews.json
+++ b/plugin-previews.json
@@ -273,6 +273,30 @@
         }
       ]
     },
+    "generative_dashboard": {
+      "teaser": "NIGHT WALK 58F",
+      "previews": [
+        {
+          "device_type": "flagship",
+          "rows": [
+            "   {blue}{blue} NIGHT WALK {blue}{blue}",
+            "CLEAR AND BRISK IN SF",
+            "NOW   58F{green} LIKE   53F{green}",
+            "WI 9.6MPH{green} FOG  CLEAR{green}",
+            "HUMID 88%{green} AQI     53{yellow}",
+            "MOON  31%  VIS  6.2MI"
+          ]
+        },
+        {
+          "device_type": "note",
+          "rows": [
+            " {blue} NIGHT WALK {blue}",
+            "NOW        58F{green}",
+            "AQI         53{yellow}"
+          ]
+        }
+      ]
+    },
     "generic_data": {
       "teaser": "3 FEEDS ACTIVE",
       "previews": [


### PR DESCRIPTION
PR #1844 added Generative Dashboard to `plugin-registry.json` without the matching `plugin-previews.json` seed entry. The seed-integrity tests (`test_shipped_seed_covers_the_registry`, `test_every_registry_plugin_has_an_entry`) run in every PR's Platform Tests job and now fail for **every open PR** (first seen on #1851, whose diff is unrelated); pushes to main skip them, so main looks green.

The entry is copied verbatim from the plugin's own manifest `teaser`/`previews` — exactly what `scripts/sync_plugin_previews.py` would produce on its next scheduled run (manifest values win at render time; the seed is the required fallback per the contract in the file's `_comment`).

Verification: `tests/test_plugin_previews.py` + `tests/test_sync_plugin_previews.py` — **84 passed** locally (both failed before the fix, reproducing the PR-CI failure).

This should merge ahead of other open PRs since it unblocks their CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Par2E2Nh65PyDF1q9TARJP