### PR TITLE
fix(auth): possession-gate MCP token management when auth is disabled

### DIFF
--- a/docs/internal/setup/MCP_CLIENTS.md
+++ b/docs/internal/setup/MCP_CLIENTS.md
@@ -64,8 +64,15 @@ client config — it replaces `<YOUR_TOKEN>` in the examples below.
 > login-redirect loop. (Earlier releases left these routes fully anonymous
 > on such installs, so anyone who could reach the port could mint or
 > revoke the token — fixed in Fiestaboard/FiestaBoard#1825.)
-> `FIESTABOARD_MCP_TOKEN` is still the strongest configuration: while it
-> is set, the mutating routes refuse with `409` even for a caller
+> Even so, the possession gate is **not a boundary against an attacker
+> who can already reach the port**: on an install where the login is
+> merely *disabled by preference*, the preference itself is part of the
+> open API, so such an attacker can `POST /auth/preference` to enable the
+> login, register the first admin via `POST /auth/setup`, and manage the
+> token with that session. Treat the gate as protection against casual or
+> accidental mint-and-read and revocation.
+> `FIESTABOARD_MCP_TOKEN` is the configuration that actually holds: while
+> it is set, the mutating routes refuse with `409` even for a caller
 > presenting the token, so it cannot be rotated or revoked over the
 > network at all. Enabling the browser login gates management behind the
 > admin session as usual.

--- a/docs/internal/setup/MCP_CLIENTS.md
+++ b/docs/internal/setup/MCP_CLIENTS.md
@@ -52,22 +52,23 @@ client config — it replaces `<YOUR_TOKEN>` in the examples below.
 > configured, nothing changes: `/api/mcp/` follows whatever the auth mode
 > says.
 
-> **With the login disabled, pin the token with the env var.** The paragraph
-> above is about the `/api/mcp/` data path only. The *token management*
-> routes are not gated the same way: `_require_admin` in
-> `src/auth/routes.py` deliberately returns an `"anonymous"` sentinel when
-> `auth_mode()` is `disabled`, so that **Settings → Integrations** doesn't
-> bounce off a 401 into a login-redirect loop. The consequence is that on an
-> install with the login off, an unauthenticated caller who can reach the
-> port can `POST /auth/mcp-token` to mint a valid token, or
-> `DELETE /auth/mcp-token` to revoke the stored one and re-open `/api/mcp/`
-> outright. A token stored from the Settings page is therefore a guard
-> against accidental clients on such an install, **not** a boundary against
-> an attacker who can already reach FiestaBoard. Setting
-> `FIESTABOARD_MCP_TOKEN` is the configuration that holds: while it is set,
-> both management routes refuse with `409`, so the token cannot be rotated
-> or revoked over the network. Enabling the browser login also closes it.
-> Tracked in Fiestaboard/FiestaBoard#1825.
+> **With the login disabled, the token guards its own management.** The
+> paragraph above is about the `/api/mcp/` data path. The *token
+> management* routes (`GET` / `POST` / `DELETE /auth/mcp-token`) have no
+> session to check when the login is off, so they check possession
+> instead: once a token is configured, managing it requires presenting the
+> current token as an `Authorization: Bearer` header, and anonymous
+> requests get a 401. Only the first mint stays open, by design — until a
+> token exists the whole REST surface is open, so gating it would protect
+> nothing, and it keeps **Settings → Integrations** rendering without a
+> login-redirect loop. (Earlier releases left these routes fully anonymous
+> on such installs, so anyone who could reach the port could mint or
+> revoke the token — fixed in Fiestaboard/FiestaBoard#1825.)
+> `FIESTABOARD_MCP_TOKEN` is still the strongest configuration: while it
+> is set, the mutating routes refuse with `409` even for a caller
+> presenting the token, so it cannot be rotated or revoked over the
+> network at all. Enabling the browser login gates management behind the
+> admin session as usual.
 
 ## Why local hosting makes this awkward
 

--- a/docs/setup/authentication.md
+++ b/docs/setup/authentication.md
@@ -124,9 +124,14 @@ the first mint is open — until a token exists the whole API is open anyway,
 so gating it would protect nothing. (Earlier releases left these routes
 fully open on such installs, so anyone who could reach the port could
 rotate or revoke a Settings-stored token — fixed in
-Fiestaboard/FiestaBoard#1825.) `FIESTABOARD_MCP_TOKEN` is still the
-strongest option: while it is set, both mutating routes refuse with `409`
-and the token cannot be changed over the network at all.
+Fiestaboard/FiestaBoard#1825.) The gate protects against casual or
+accidental mint-and-read and revocation, but it is not a boundary against
+an attacker who can already reach the port: with the login disabled by
+preference, that attacker can re-enable it (`POST /auth/preference`),
+register the first admin (`POST /auth/setup`), and manage the token with
+that session. `FIESTABOARD_MCP_TOKEN` is the option that actually holds:
+while it is set, both mutating routes refuse with `409` and the token
+cannot be changed over the network at all.
 
 ## Cross-origin browser access (CORS)
 

--- a/docs/setup/authentication.md
+++ b/docs/setup/authentication.md
@@ -115,15 +115,18 @@ stay open.
 as before.
 :::
 
-On an install where you chose *Continue without login*, prefer
-`FIESTABOARD_MCP_TOKEN` over a token generated on the Settings page. Token
-management is part of the API (`POST` / `DELETE /auth/mcp-token`), and with
-the login disabled there is no session for those routes to check — so
-anyone who can reach the port can rotate or revoke a Settings-stored token
-and re-open `/api/mcp/`. A Settings-stored token protects against accidents
-there, not against an attacker who can already reach FiestaBoard. While
-`FIESTABOARD_MCP_TOKEN` is set, both routes refuse with `409` and the token
-cannot be changed over the network.
+On an install where you chose *Continue without login* there is no session
+for the token-management routes (`GET` / `POST` / `DELETE
+/auth/mcp-token`) to check, so possession of the current token stands in
+for one: once a token exists, managing it requires sending that token as an
+`Authorization: Bearer` header, and requests without it get a `401`. Only
+the first mint is open — until a token exists the whole API is open anyway,
+so gating it would protect nothing. (Earlier releases left these routes
+fully open on such installs, so anyone who could reach the port could
+rotate or revoke a Settings-stored token — fixed in
+Fiestaboard/FiestaBoard#1825.) `FIESTABOARD_MCP_TOKEN` is still the
+strongest option: while it is set, both mutating routes refuse with `409`
+and the token cannot be changed over the network at all.
 
 ## Cross-origin browser access (CORS)
 

--- a/src/auth/routes.py
+++ b/src/auth/routes.py
@@ -8,6 +8,7 @@ import time
 from fastapi import APIRouter, HTTPException, Request, Response, status
 from pydantic import BaseModel, Field
 
+from .middleware import _bearer_from
 from .service import (
     SESSION_COOKIE_NAME,
     AlreadySetup,
@@ -19,6 +20,7 @@ from .service import (
     generate_mcp_token,
     get_auth_service,
     mcp_token_source,
+    verify_mcp_bearer,
 )
 
 logger = logging.getLogger(__name__)
@@ -372,7 +374,12 @@ async def auth_disable(payload: DisableAuthRequest, request: Request, response: 
 # pre-shared bearer token that external MCP clients (Claude Desktop, Claude
 # Code) use to authenticate. The plaintext token is only returned by
 # ``POST /auth/mcp-token`` and never read back — the UI is responsible for
-# showing it to the user at rotation time.
+# showing it to the user at rotation time. When auth is disabled there is
+# no session; once a token is configured, every management route (status
+# included — it leaks the token's source) requires presenting the *current*
+# token as a Bearer (possession is the credential — #1825). Only the first
+# mint stays open, so Settings → Integrations can still bootstrap a token
+# on an install with the login off.
 
 
 def _require_admin(request: Request) -> str:
@@ -380,12 +387,14 @@ def _require_admin(request: Request) -> str:
 
     When auth is explicitly *disabled* (``FIESTABOARD_AUTH_ENABLED=0`` or the
     persisted preference is ``disabled``) there is no admin concept and no
-    session cookie ever gets issued — return a sentinel so MCP token
-    management remains reachable. Without this the Settings → Integrations
-    page hits a 401, the web client redirects to ``/login``, the login page
-    sees auth is disabled and bounces back, and the user is stuck in an
-    infinite reload loop. ``undecided`` mode (first-run, secure-by-default)
-    still requires a session.
+    session cookie ever gets issued — return a sentinel instead of a 401.
+    Without this the Settings → Integrations page hits a 401, the web client
+    redirects to ``/login``, the login page sees auth is disabled and bounces
+    back, and the user is stuck in an infinite reload loop. The MCP token
+    routes reach this only through :func:`_require_admin_or_mcp_token`, which
+    limits the sentinel to the no-token-configured case — once a token
+    exists, management demands it (#1825). ``undecided`` mode (first-run,
+    secure-by-default) still requires a session.
     """
     if auth_mode() == "disabled":
         return "anonymous"
@@ -397,10 +406,35 @@ def _require_admin(request: Request) -> str:
     return username
 
 
+def _require_admin_or_mcp_token(request: Request) -> str:
+    """Gate for MCP-token management.
+
+    In ``enabled`` / ``undecided`` modes this is :func:`_require_admin`.
+    When auth is disabled there is no session concept, so possession of
+    the *current* token is the credential: if a token is configured
+    (stored or env-pinned), the caller must present it as a Bearer; if
+    none is configured yet, management stays open — with auth disabled the
+    whole REST surface is open, so gating the first mint would protect
+    nothing (#1825).
+    """
+    if auth_mode() != "disabled":
+        return _require_admin(request)
+    if mcp_token_source() == "none":
+        return "anonymous"
+    supplied = _bearer_from(request)
+    if supplied and verify_mcp_bearer(supplied):
+        return "mcp-token-holder"
+    raise HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="MCP token management requires the current token when auth is disabled",
+        headers={"WWW-Authenticate": 'Bearer realm="FiestaBoard MCP token management"'},
+    )
+
+
 @router.get("/mcp-token", response_model=McpTokenStatusResponse)
 async def auth_mcp_token_status(request: Request) -> McpTokenStatusResponse:
     """Report whether an MCP bearer token is configured, and from where."""
-    _require_admin(request)
+    _require_admin_or_mcp_token(request)
     source = mcp_token_source()
     return McpTokenStatusResponse(configured=source != "none", source=source)
 
@@ -417,7 +451,7 @@ async def auth_mcp_token_rotate(request: Request) -> McpTokenRotateResponse:
     in :func:`~src.auth.service.mcp_token` resolution — a UI rotation
     would silently have no effect and confuse the admin.
     """
-    username = _require_admin(request)
+    username = _require_admin_or_mcp_token(request)
     if mcp_token_source() == "env":
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -440,7 +474,7 @@ async def auth_mcp_token_clear(request: Request) -> SimpleResponse:
     their next request. (If ``FIESTABOARD_MCP_TOKEN`` is set, this only
     clears the stored fallback — the env var continues to be active.)
     """
-    username = _require_admin(request)
+    username = _require_admin_or_mcp_token(request)
     if mcp_token_source() == "env":
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,

--- a/tests/test_auth_mcp_token_routes.py
+++ b/tests/test_auth_mcp_token_routes.py
@@ -169,11 +169,22 @@ def test_clear_blocked_when_env_var_pins_the_token(signed_in, client, monkeypatc
     assert r.status_code == 409
 
 
-# --- Auth-disabled mode (issue #857) --------------------------------------
+# --- Auth-disabled mode (issues #857 / #1825) ------------------------------
 #
 # When the install opted out of login, there's no session cookie to send.
-# The mcp-token endpoints must still respond so Settings → Integrations can
-# render. Before the fix these 401s triggered an infinite /login bounce.
+# While no token exists the mcp-token endpoints must still respond so
+# Settings → Integrations can render — before the #857 fix these 401s
+# triggered an infinite /login bounce. But once a token IS configured,
+# managing it requires presenting the current token as a Bearer (#1825):
+# with no session concept, possession of the credential is the credential.
+
+# Obviously-fake token used to seed the store directly in tests.
+FAKE_STORED_TOKEN = "test-stored-mcp-token-000000000000000000"
+
+
+def _store_token():
+    auth_service.get_auth_service().set_stored_mcp_token(FAKE_STORED_TOKEN)
+    return FAKE_STORED_TOKEN
 
 
 def test_status_accessible_when_auth_disabled(client, auth_disabled):
@@ -182,27 +193,93 @@ def test_status_accessible_when_auth_disabled(client, auth_disabled):
     assert r.json() == {"configured": False, "source": "none"}
 
 
-def test_rotate_accessible_when_auth_disabled(client, auth_disabled):
+def test_first_mint_open_when_auth_disabled(client, auth_disabled):
+    # With no token configured the whole REST surface is already open, so
+    # gating the first mint would protect nothing — it stays anonymous.
     r = client.post("/auth/mcp-token")
     assert r.status_code == 201
     token = r.json()["token"]
     assert len(token) >= 32
-    assert client.get("/auth/mcp-token").json() == {
-        "configured": True,
-        "source": "stored",
-    }
     bare = TestClient(app, raise_server_exceptions=False)
     assert bare.get("/mcp/", headers={"Authorization": f"Bearer {token}"}).status_code != 401
+    # The mint is a one-shot: now that a token exists, an anonymous second
+    # POST must be refused (#1825).
+    assert client.post("/auth/mcp-token").status_code == 401
 
 
-def test_clear_accessible_when_auth_disabled(client, auth_disabled):
-    client.post("/auth/mcp-token")
+def test_clear_requires_current_token_when_auth_disabled(client, auth_disabled):
+    # The previous version of this test ("test_clear_accessible_when_auth_
+    # disabled") asserted the opposite: an anonymous DELETE was expected to
+    # revoke a stored token. That encoded the vulnerability itself — anyone
+    # who could reach the port could revoke the token and re-open /mcp/
+    # outright (Fiestaboard/FiestaBoard#1825). Now revocation requires
+    # presenting the current token.
+    token = _store_token()
     r = client.delete("/auth/mcp-token")
-    assert r.status_code == 200
+    assert r.status_code == 401
+    # The token is still stored and still enforced.
+    assert auth_service.mcp_token_source() == "stored"
+    # With the current token, revocation works…
+    r2 = client.delete("/auth/mcp-token", headers={"Authorization": f"Bearer {token}"})
+    assert r2.status_code == 200
+    # …and with no token configured, management is open again.
     assert client.get("/auth/mcp-token").json() == {
         "configured": False,
         "source": "none",
     }
+
+
+def test_status_requires_token_when_auth_disabled_and_token_stored(client, auth_disabled):
+    _store_token()
+    r = client.get("/auth/mcp-token")
+    assert r.status_code == 401
+    assert r.headers.get("WWW-Authenticate", "").startswith("Bearer")
+
+
+def test_rotate_requires_token_when_auth_disabled_and_token_stored(client, auth_disabled):
+    _store_token()
+    r = client.post("/auth/mcp-token")
+    assert r.status_code == 401
+
+
+def test_management_accepts_current_token_when_auth_disabled(client, auth_disabled):
+    old = _store_token()
+    headers = {"Authorization": f"Bearer {old}"}
+    assert client.get("/auth/mcp-token", headers=headers).status_code == 200
+    rotate = client.post("/auth/mcp-token", headers=headers)
+    assert rotate.status_code == 201
+    new = rotate.json()["token"]
+    assert new != old
+    # After rotation the OLD token no longer manages…
+    assert client.get("/auth/mcp-token", headers=headers).status_code == 401
+    # …and the NEW one does.
+    new_headers = {"Authorization": f"Bearer {new}"}
+    assert client.get("/auth/mcp-token", headers=new_headers).status_code == 200
+    assert client.delete("/auth/mcp-token", headers=new_headers).status_code == 200
+
+
+def test_wrong_bearer_rejected_when_auth_disabled(client, auth_disabled):
+    _store_token()
+    r = client.get(
+        "/auth/mcp-token",
+        headers={"Authorization": "Bearer test-not-the-right-token"},
+    )
+    assert r.status_code == 401
+
+
+def test_env_pin_still_wins_when_auth_disabled(client, auth_disabled, monkeypatch):
+    # An env-pinned token counts as "configured": the possession gate
+    # applies first (anonymous callers get 401), and a caller holding the
+    # env token still hits the 409 pin on mutation.
+    monkeypatch.setenv("FIESTABOARD_MCP_TOKEN", "test-pinned-by-ops-token")
+    assert client.post("/auth/mcp-token").status_code == 401
+    headers = {"Authorization": "Bearer test-pinned-by-ops-token"}
+    assert client.post("/auth/mcp-token", headers=headers).status_code == 409
+    assert client.delete("/auth/mcp-token", headers=headers).status_code == 409
+    # Status with the env token still reports the source.
+    r = client.get("/auth/mcp-token", headers=headers)
+    assert r.status_code == 200
+    assert r.json() == {"configured": True, "source": "env"}
 
 
 def test_undecided_mode_still_requires_auth(client, monkeypatch):

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -2088,7 +2088,11 @@
     "claudeWebDescription": "<label>claude.ai web (Connectors):</label> wird für selbst gehostete FiestaBoards nicht unterstützt. Der Connectors-Ablauf erfordert eine öffentliche HTTPS-URL und dynamische OAuth-2.1-Client-Registrierung — beides kann ein Host im LAN nicht bereitstellen. Verwenden Sie stattdessen Desktop oder Code.",
     "savedItButton": "Ich habe es gespeichert",
     "toastTokenRevoked": "MCP-Token widerrufen",
-    "toastCopyFailed": "Kopieren in die Zwischenablage fehlgeschlagen"
+    "toastCopyFailed": "Kopieren in die Zwischenablage fehlgeschlagen",
+    "lockedDescription": "Die Anmeldung ist auf dieser Installation deaktiviert, daher dient das aktuelle MCP-Token selbst als Nachweis für die Token-Verwaltung. Geben Sie es unten ein, um Rotieren und Widerrufen freizuschalten.",
+    "lockedTokenLabel": "Aktuelles MCP-Token",
+    "unlockButton": "Entsperren",
+    "unlockFailedToast": "Dieses Token stimmt nicht mit dem konfigurierten MCP-Token überein."
   },
   "fiestaPanels": {
     "title": "FiestaPanel",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -2088,7 +2088,11 @@
     "claudeWebDescription": "<label>claude.ai web (Connectors):</label> not supported for self-hosted FiestaBoard. The Connectors flow requires a public HTTPS URL and OAuth 2.1 dynamic client registration, neither of which a LAN host can provide. Use Desktop or Code instead.",
     "savedItButton": "I've saved it",
     "toastTokenRevoked": "MCP token revoked",
-    "toastCopyFailed": "Couldn't copy to clipboard"
+    "toastCopyFailed": "Couldn't copy to clipboard",
+    "lockedDescription": "Login is turned off on this install, so the current MCP token is itself the credential for managing tokens. Enter it below to unlock rotating or revoking.",
+    "lockedTokenLabel": "Current MCP token",
+    "unlockButton": "Unlock",
+    "unlockFailedToast": "That token doesn't match the configured MCP token."
   },
   "fiestaPanels": {
     "title": "FiestaPanel",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -2088,7 +2088,11 @@
     "claudeWebDescription": "<label>claude.ai web (Connectors):</label> no es compatible con un FiestaBoard autoalojado. El flujo de Connectors requiere una URL HTTPS pública y registro dinámico de clientes OAuth 2.1, y un host en la LAN no puede ofrecer ninguna de las dos cosas. Usa Desktop o Code en su lugar.",
     "savedItButton": "Ya lo he guardado",
     "toastTokenRevoked": "Token MCP revocado",
-    "toastCopyFailed": "No se pudo copiar al portapapeles"
+    "toastCopyFailed": "No se pudo copiar al portapapeles",
+    "lockedDescription": "El inicio de sesión está desactivado en esta instalación, así que el propio token MCP actual es la credencial para gestionar tokens. Introdúcelo abajo para desbloquear la rotación o revocación.",
+    "lockedTokenLabel": "Token MCP actual",
+    "unlockButton": "Desbloquear",
+    "unlockFailedToast": "Ese token no coincide con el token MCP configurado."
   },
   "fiestaPanels": {
     "title": "FiestaPanel",

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -2088,7 +2088,11 @@
     "claudeWebDescription": "<label>claude.ai web (Connectors) :</label> non pris en charge pour un FiestaBoard auto-hébergé. Le flux Connectors exige une URL HTTPS publique et l'enregistrement dynamique de clients OAuth 2.1, or un hôte du LAN ne peut fournir ni l'un ni l'autre. Utilisez plutôt Desktop ou Code.",
     "savedItButton": "Je l'ai enregistré",
     "toastTokenRevoked": "Jeton MCP révoqué",
-    "toastCopyFailed": "Impossible de copier dans le presse-papiers"
+    "toastCopyFailed": "Impossible de copier dans le presse-papiers",
+    "lockedDescription": "La connexion est désactivée sur cette installation : le jeton MCP actuel sert donc lui-même d'identifiant pour gérer les jetons. Saisissez-le ci-dessous pour débloquer le renouvellement ou la révocation.",
+    "lockedTokenLabel": "Jeton MCP actuel",
+    "unlockButton": "Déverrouiller",
+    "unlockFailedToast": "Ce jeton ne correspond pas au jeton MCP configuré."
   },
   "fiestaPanels": {
     "title": "FiestaPanel",

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -2088,7 +2088,11 @@
     "claudeWebDescription": "<label>claude.ai web (Connectors):</label> non supportato per un FiestaBoard self-hosted. Il flusso Connectors richiede un URL HTTPS pubblico e la registrazione dinamica dei client OAuth 2.1, e un host sulla LAN non può fornire né l'uno né l'altro. Usa invece Desktop o Code.",
     "savedItButton": "L'ho salvato",
     "toastTokenRevoked": "Token MCP revocato",
-    "toastCopyFailed": "Impossibile copiare negli appunti"
+    "toastCopyFailed": "Impossibile copiare negli appunti",
+    "lockedDescription": "L'accesso è disattivato su questa installazione, quindi il token MCP attuale è esso stesso la credenziale per gestire i token. Inseriscilo qui sotto per sbloccare rotazione e revoca.",
+    "lockedTokenLabel": "Token MCP attuale",
+    "unlockButton": "Sblocca",
+    "unlockFailedToast": "Quel token non corrisponde al token MCP configurato."
   },
   "fiestaPanels": {
     "title": "FiestaPanel",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -2088,7 +2088,11 @@
     "claudeWebDescription": "<label>claude.ai web (Connectors):</label> セルフホストの FiestaBoard ではサポートされていません。Connectors のフローには公開 HTTPS の URL と OAuth 2.1 の動的クライアント登録が必要ですが、LAN 上のホストはどちらも提供できません。代わりに Desktop または Code をご利用ください。",
     "savedItButton": "保存しました",
     "toastTokenRevoked": "MCP トークンを失効しました",
-    "toastCopyFailed": "クリップボードにコピーできませんでした"
+    "toastCopyFailed": "クリップボードにコピーできませんでした",
+    "lockedDescription": "このインストールではログインが無効になっているため、現在の MCP トークン自体がトークン管理の資格情報になります。ローテーションや失効を行うには、下に入力してロックを解除してください。",
+    "lockedTokenLabel": "現在の MCP トークン",
+    "unlockButton": "ロック解除",
+    "unlockFailedToast": "そのトークンは設定済みの MCP トークンと一致しません。"
   },
   "fiestaPanels": {
     "title": "FiestaPanel",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -2088,7 +2088,11 @@
     "claudeWebDescription": "<label>claude.ai 웹 (Connectors):</label> 자체 호스팅 FiestaBoard에서는 지원되지 않습니다. Connectors 방식은 공개 HTTPS URL과 OAuth 2.1 동적 클라이언트 등록을 요구하는데, LAN 호스트는 둘 다 제공할 수 없습니다. 대신 Desktop이나 Code를 사용하세요.",
     "savedItButton": "저장했습니다",
     "toastTokenRevoked": "MCP 토큰이 해지되었습니다",
-    "toastCopyFailed": "클립보드에 복사하지 못했습니다"
+    "toastCopyFailed": "클립보드에 복사하지 못했습니다",
+    "lockedDescription": "이 설치에서는 로그인이 꺼져 있어 현재 MCP 토큰 자체가 토큰 관리를 위한 자격 증명입니다. 교체와 해지를 잠금 해제하려면 아래에 입력하세요.",
+    "lockedTokenLabel": "현재 MCP 토큰",
+    "unlockButton": "잠금 해제",
+    "unlockFailedToast": "해당 토큰이 설정된 MCP 토큰과 일치하지 않습니다."
   },
   "fiestaPanels": {
     "title": "FiestaPanel",

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -2088,7 +2088,11 @@
     "claudeWebDescription": "<label>claude.ai web (Connectors):</label> wordt niet ondersteund voor een zelf gehoste FiestaBoard. De Connectors-flow vereist een publieke HTTPS-URL en dynamische OAuth 2.1-clientregistratie, en geen van beide kan een host in het LAN bieden. Gebruik in plaats daarvan Desktop of Code.",
     "savedItButton": "Ik heb het opgeslagen",
     "toastTokenRevoked": "MCP-token ingetrokken",
-    "toastCopyFailed": "Kopiëren naar klembord mislukt"
+    "toastCopyFailed": "Kopiëren naar klembord mislukt",
+    "lockedDescription": "Inloggen is uitgeschakeld op deze installatie, dus het huidige MCP-token is zelf het bewijs om tokens te beheren. Voer het hieronder in om roteren en intrekken te ontgrendelen.",
+    "lockedTokenLabel": "Huidig MCP-token",
+    "unlockButton": "Ontgrendelen",
+    "unlockFailedToast": "Dat token komt niet overeen met het geconfigureerde MCP-token."
   },
   "fiestaPanels": {
     "title": "FiestaPanel",

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -2088,7 +2088,11 @@
     "claudeWebDescription": "<label>claude.ai web (Connectors):</label> nieobsługiwane w samodzielnie hostowanym FiestaBoard. Przepływ Connectors wymaga publicznego adresu HTTPS i dynamicznej rejestracji klienta OAuth 2.1, a host w sieci LAN nie zapewnia żadnej z tych rzeczy. Użyj zamiast tego Desktop lub Code.",
     "savedItButton": "Zapisane",
     "toastTokenRevoked": "Token MCP odwołany",
-    "toastCopyFailed": "Nie udało się skopiować do schowka"
+    "toastCopyFailed": "Nie udało się skopiować do schowka",
+    "lockedDescription": "Logowanie jest wyłączone w tej instalacji, więc bieżący token MCP sam w sobie jest poświadczeniem do zarządzania tokenami. Wpisz go poniżej, aby odblokować wymianę i odwoływanie.",
+    "lockedTokenLabel": "Bieżący token MCP",
+    "unlockButton": "Odblokuj",
+    "unlockFailedToast": "Ten token nie zgadza się ze skonfigurowanym tokenem MCP."
   },
   "fiestaPanels": {
     "title": "FiestaPanel",

--- a/web/messages/pt.json
+++ b/web/messages/pt.json
@@ -2088,7 +2088,11 @@
     "claudeWebDescription": "<label>claude.ai web (Connectors):</label> não é suportado num FiestaBoard alojado por si. O fluxo dos Connectors exige um URL HTTPS público e registo dinâmico de clientes OAuth 2.1, e um host na LAN não fornece nenhum dos dois. Use antes o Desktop ou o Code.",
     "savedItButton": "Já o guardei",
     "toastTokenRevoked": "Token MCP revogado",
-    "toastCopyFailed": "Não foi possível copiar para a área de transferência"
+    "toastCopyFailed": "Não foi possível copiar para a área de transferência",
+    "lockedDescription": "O início de sessão está desativado nesta instalação, pelo que o próprio token MCP atual é a credencial para gerir tokens. Introduza-o abaixo para desbloquear a renovação ou revogação.",
+    "lockedTokenLabel": "Token MCP atual",
+    "unlockButton": "Desbloquear",
+    "unlockFailedToast": "Esse token não corresponde ao token MCP configurado."
   },
   "fiestaPanels": {
     "title": "FiestaPanel",

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -2088,7 +2088,11 @@
     "claudeWebDescription": "<label>claude.ai web (Connectors):</label> не поддерживается для самостоятельно размещённого FiestaBoard. Процесс Connectors требует публичного HTTPS-адреса и динамической регистрации клиента OAuth 2.1, а хост в LAN не может обеспечить ни того, ни другого. Используйте вместо этого Desktop или Code.",
     "savedItButton": "Я сохранил его",
     "toastTokenRevoked": "Токен MCP отозван",
-    "toastCopyFailed": "Не удалось скопировать в буфер обмена"
+    "toastCopyFailed": "Не удалось скопировать в буфер обмена",
+    "lockedDescription": "Вход отключён в этой установке, поэтому текущий токен MCP сам служит учётными данными для управления токенами. Введите его ниже, чтобы разблокировать смену и отзыв токена.",
+    "lockedTokenLabel": "Текущий токен MCP",
+    "unlockButton": "Разблокировать",
+    "unlockFailedToast": "Этот токен не совпадает с настроенным токеном MCP."
   },
   "fiestaPanels": {
     "title": "FiestaPanel",

--- a/web/messages/sv.json
+++ b/web/messages/sv.json
@@ -2088,7 +2088,11 @@
     "claudeWebDescription": "<label>claude.ai web (Connectors):</label> stöds inte för självhostad FiestaBoard. Connectors-flödet kräver en publik HTTPS-URL och dynamisk OAuth 2.1-klientregistrering, och en värd i LAN kan inte tillhandahålla något av detta. Använd Desktop eller Code i stället.",
     "savedItButton": "Jag har sparat den",
     "toastTokenRevoked": "MCP-token återkallad",
-    "toastCopyFailed": "Kunde inte kopiera till urklipp"
+    "toastCopyFailed": "Kunde inte kopiera till urklipp",
+    "lockedDescription": "Inloggning är avstängd på den här installationen, så den aktuella MCP-token är i sig behörigheten för att hantera tokens. Ange den nedan för att låsa upp rotation och återkallelse.",
+    "lockedTokenLabel": "Aktuell MCP-token",
+    "unlockButton": "Lås upp",
+    "unlockFailedToast": "Den token matchar inte den konfigurerade MCP-token."
   },
   "fiestaPanels": {
     "title": "FiestaPanel",

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -2088,7 +2088,11 @@
     "claudeWebDescription": "<label>claude.ai web (Connectors):</label> kendi barındırdığınız FiestaBoard için desteklenmez. Connectors akışı herkese açık bir HTTPS adresi ve OAuth 2.1 dinamik istemci kaydı gerektirir; bir LAN sunucusu bunların ikisini de sağlayamaz. Bunun yerine Desktop veya Code kullanın.",
     "savedItButton": "Kaydettim",
     "toastTokenRevoked": "MCP token'ı iptal edildi",
-    "toastCopyFailed": "Kopyalanamadı"
+    "toastCopyFailed": "Kopyalanamadı",
+    "lockedDescription": "Bu kurulumda oturum açma kapalı olduğundan, token yönetiminin kimlik bilgisi mevcut MCP token'ının kendisidir. Yenileme ve iptal işlemlerinin kilidini açmak için aşağıya girin.",
+    "lockedTokenLabel": "Mevcut MCP token'ı",
+    "unlockButton": "Kilidi aç",
+    "unlockFailedToast": "Bu token, yapılandırılmış MCP token'ıyla eşleşmiyor."
   },
   "fiestaPanels": {
     "title": "FiestaPanel",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -2088,7 +2088,11 @@
     "claudeWebDescription": "<label>claude.ai 网页版（Connectors）：</label>自托管的 FiestaBoard 不支持。Connectors 流程需要公网 HTTPS URL 和 OAuth 2.1 动态客户端注册，而 LAN 主机两者都无法提供。请改用 Desktop 或 Code。",
     "savedItButton": "我已保存",
     "toastTokenRevoked": "MCP 令牌已吊销",
-    "toastCopyFailed": "无法复制到剪贴板"
+    "toastCopyFailed": "无法复制到剪贴板",
+    "lockedDescription": "此安装已关闭登录，因此当前 MCP 令牌本身就是管理令牌的凭据。在下方输入它即可解锁轮换和吊销操作。",
+    "lockedTokenLabel": "当前 MCP 令牌",
+    "unlockButton": "解锁",
+    "unlockFailedToast": "该令牌与已配置的 MCP 令牌不匹配。"
   },
   "fiestaPanels": {
     "title": "FiestaPanel",

--- a/web/src/__tests__/mcp-settings-first-mint.test.tsx
+++ b/web/src/__tests__/mcp-settings-first-mint.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * Regressions from the #1853 review.
+ *
+ * 1. First mint on an auth-disabled install: rotate's onSuccess must hold
+ *    the freshly minted token unconditionally. If it only holds it when a
+ *    previous unlock populated the ref, the post-mint status refetch goes
+ *    out with no bearer, 401s, flips the component into the locked view,
+ *    and unmounts the reveal dialog before the user can copy the token.
+ *
+ * 2. Auth-enabled installs: the MCP token calls skip fetchApi's automatic
+ *    login redirect (a 401 means "locked" on auth-disabled installs), so
+ *    when the *session* expires the component itself must send the user
+ *    to /login instead of rendering a perpetual skeleton.
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { McpSettings } from "@/components/settings/mcp-settings";
+
+import { server } from "./mocks/server";
+
+const MINTED_TOKEN = "test_first_minted_mcp_token";
+
+function TestWrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+describe("McpSettings first mint and expired-session handling", () => {
+  let originalLocation: Location;
+  let assignMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    assignMock = vi.fn();
+    originalLocation = window.location;
+    // Mimic a settings route (not /login) so a login redirect is
+    // observable via window.location.assign.
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        ...originalLocation,
+        pathname: "/settings",
+        search: "",
+        assign: assignMock,
+      },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
+  it("first mint on an auth-disabled install keeps the reveal open and holds the new token", async () => {
+    // Backend state machine: no token at first (open management), then
+    // once POST mints one, GET is gated behind the new token — exactly
+    // the #1825 backend behavior on auth-disabled installs.
+    let minted = false;
+    const seenAuth: string[] = [];
+    server.use(
+      http.get("/api/auth/mcp-token", ({ request }) => {
+        const auth = request.headers.get("authorization") ?? "";
+        seenAuth.push(auth);
+        if (!minted) {
+          return HttpResponse.json({ configured: false, source: "none" });
+        }
+        if (auth === `Bearer ${MINTED_TOKEN}`) {
+          return HttpResponse.json({ configured: true, source: "stored" });
+        }
+        return HttpResponse.json(
+          { detail: "MCP token management requires the current token when auth is disabled" },
+          { status: 401, headers: { "WWW-Authenticate": 'Bearer realm="FiestaBoard MCP token management"' } },
+        );
+      }),
+      http.post("/api/auth/mcp-token", () => {
+        minted = true;
+        return HttpResponse.json({ token: MINTED_TOKEN }, { status: 201 });
+      }),
+    );
+    const user = userEvent.setup();
+
+    render(<McpSettings />, { wrapper: TestWrapper });
+
+    // No token configured yet — mint the first one.
+    await user.click(await screen.findByRole("button", { name: "Generate token" }));
+    await user.click(await screen.findByRole("button", { name: "Generate" }));
+
+    // The reveal dialog shows the new token once.
+    expect(await screen.findByText(MINTED_TOKEN)).toBeInTheDocument();
+
+    // The post-mint status refetch must carry the new bearer (the held
+    // token was set even though nothing was held before the mint).
+    await waitFor(() => {
+      expect(seenAuth[seenAuth.length - 1]).toBe(`Bearer ${MINTED_TOKEN}`);
+    });
+
+    // The reveal must STAY mounted — flipping into the locked view here
+    // would unmount it before the user can copy the token.
+    expect(screen.getByText(MINTED_TOKEN)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Unlock" })).not.toBeInTheDocument();
+    expect(assignMock).not.toHaveBeenCalled();
+  });
+
+  it("redirects to /login when the session is expired and auth is enabled", async () => {
+    server.use(
+      http.get("/api/auth/status", () => {
+        return HttpResponse.json({
+          enabled: true,
+          setup_required: false,
+          authenticated: false,
+          username: null,
+          mode: "enabled",
+          first_run: false,
+        });
+      }),
+      // Session cookie expired: every management call 401s.
+      http.get("/api/auth/mcp-token", () => {
+        return HttpResponse.json({ detail: "Not authenticated" }, { status: 401 });
+      }),
+    );
+
+    render(<McpSettings />, { wrapper: TestWrapper });
+
+    await waitFor(() => {
+      expect(assignMock).toHaveBeenCalledTimes(1);
+    });
+    expect(String(assignMock.mock.calls[0][0])).toContain("/login?redirect=");
+    // Never the locked view — that's an auth-disabled concept.
+    expect(screen.queryByRole("button", { name: "Unlock" })).not.toBeInTheDocument();
+  });
+});

--- a/web/src/__tests__/mcp-settings-locked.test.tsx
+++ b/web/src/__tests__/mcp-settings-locked.test.tsx
@@ -1,0 +1,176 @@
+/**
+ * Locked-state flow for MCP token management on auth-disabled installs
+ * (#1825). When auth mode is "disabled" and a token is already
+ * configured, the backend answers 401 (Bearer challenge) on
+ * GET/POST/DELETE /auth/mcp-token unless the caller presents the
+ * current token. The UI must treat that 401 as "locked" — never as
+ * "not logged in" — and offer an unlock form instead of bouncing to
+ * /login.
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { McpSettings } from "@/components/settings/mcp-settings";
+
+import { server } from "./mocks/server";
+
+const CORRECT_TOKEN = "test_current_mcp_token";
+const ROTATED_TOKEN = "test_rotated_mcp_token";
+
+function TestWrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+/**
+ * Install a GET /api/auth/mcp-token handler that mimics the backend
+ * gate: 401 + Bearer challenge unless the request carries
+ * `Authorization: Bearer <expected>`.
+ */
+function useLockedStatusHandler(expected: string, seenAuth: string[] = []) {
+  server.use(
+    http.get("/api/auth/mcp-token", ({ request }) => {
+      const auth = request.headers.get("authorization") ?? "";
+      seenAuth.push(auth);
+      if (auth === `Bearer ${expected}`) {
+        return HttpResponse.json({ configured: true, source: "stored" });
+      }
+      return HttpResponse.json(
+        { detail: "MCP token management requires the current token when auth is disabled" },
+        { status: 401, headers: { "WWW-Authenticate": 'Bearer realm="FiestaBoard MCP token management"' } },
+      );
+    }),
+  );
+  return seenAuth;
+}
+
+describe("McpSettings locked state (auth disabled + token configured)", () => {
+  let originalLocation: Location;
+  let assignMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    assignMock = vi.fn();
+    originalLocation = window.location;
+    // Mimic a settings route (not /login) so a login redirect, if one
+    // were wrongly triggered, would actually fire and be observable.
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: {
+        ...originalLocation,
+        pathname: "/settings",
+        search: "",
+        assign: assignMock,
+      },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+
+  it("renders the locked state on 401 without redirecting to /login", async () => {
+    useLockedStatusHandler(CORRECT_TOKEN);
+
+    render(<McpSettings />, { wrapper: TestWrapper });
+
+    expect(await screen.findByLabelText("Current MCP token")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Unlock" })).toBeInTheDocument();
+    expect(assignMock).not.toHaveBeenCalled();
+  });
+
+  it("unlocking with the correct token shows the token status", async () => {
+    useLockedStatusHandler(CORRECT_TOKEN);
+    const user = userEvent.setup();
+
+    render(<McpSettings />, { wrapper: TestWrapper });
+
+    await user.type(await screen.findByLabelText("Current MCP token"), CORRECT_TOKEN);
+    await user.click(screen.getByRole("button", { name: "Unlock" }));
+
+    expect(await screen.findByText("Configured")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Unlock" })).not.toBeInTheDocument();
+    expect(assignMock).not.toHaveBeenCalled();
+  });
+
+  it("rotating while unlocked sends the bearer and updates the held token", async () => {
+    const seenAuth = useLockedStatusHandler(CORRECT_TOKEN);
+    const rotateAuth: string[] = [];
+    server.use(
+      http.post("/api/auth/mcp-token", ({ request }) => {
+        const auth = request.headers.get("authorization") ?? "";
+        rotateAuth.push(auth);
+        if (auth !== `Bearer ${CORRECT_TOKEN}`) {
+          return HttpResponse.json({ detail: "Bad token" }, { status: 401 });
+        }
+        return HttpResponse.json({ token: ROTATED_TOKEN }, { status: 201 });
+      }),
+    );
+    const user = userEvent.setup();
+
+    render(<McpSettings />, { wrapper: TestWrapper });
+
+    // Unlock first.
+    await user.type(await screen.findByLabelText("Current MCP token"), CORRECT_TOKEN);
+    await user.click(screen.getByRole("button", { name: "Unlock" }));
+    expect(await screen.findByText("Configured")).toBeInTheDocument();
+
+    // Rotation invalidates the old token: from now on the status
+    // endpoint only accepts the NEW one, mimicking the backend.
+    server.use(
+      http.get("/api/auth/mcp-token", ({ request }) => {
+        const auth = request.headers.get("authorization") ?? "";
+        seenAuth.push(auth);
+        if (auth === `Bearer ${ROTATED_TOKEN}`) {
+          return HttpResponse.json({ configured: true, source: "stored" });
+        }
+        return HttpResponse.json({ detail: "stale token" }, { status: 401 });
+      }),
+    );
+
+    // Rotate: open the confirm dialog, then confirm.
+    await user.click(screen.getByRole("button", { name: "Rotate token" }));
+    await user.click(await screen.findByRole("button", { name: "Rotate" }));
+
+    // The reveal dialog shows the new token once.
+    expect(await screen.findByText(ROTATED_TOKEN)).toBeInTheDocument();
+    // The rotate call itself carried the (then-current) bearer.
+    expect(rotateAuth).toEqual([`Bearer ${CORRECT_TOKEN}`]);
+
+    // The post-rotate status refetch must use the NEW token — i.e. the
+    // held token was updated — and management must stay unlocked.
+    await waitFor(() => {
+      expect(seenAuth[seenAuth.length - 1]).toBe(`Bearer ${ROTATED_TOKEN}`);
+    });
+    expect(screen.queryByRole("button", { name: "Unlock" })).not.toBeInTheDocument();
+    expect(assignMock).not.toHaveBeenCalled();
+  });
+
+  it("shows an inline error toast when the unlock token is wrong", async () => {
+    useLockedStatusHandler(CORRECT_TOKEN);
+    const user = userEvent.setup();
+
+    render(<McpSettings />, { wrapper: TestWrapper });
+
+    await user.type(await screen.findByLabelText("Current MCP token"), "wrong-token");
+    await user.click(screen.getByRole("button", { name: "Unlock" }));
+
+    // Still locked, no redirect.
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Unlock" })).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Configured")).not.toBeInTheDocument();
+    expect(assignMock).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/settings/mcp-settings.tsx
+++ b/web/src/components/settings/mcp-settings.tsx
@@ -30,11 +30,13 @@ import {
 } from "@fiestaboard/ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { AlertTriangle, Bot, Check, Copy, KeyRound, Loader2, Lock, RefreshCw, Trash2 } from "lucide-react";
-import { type ReactNode, useMemo, useRef, useState } from "react";
+import { type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { useTranslations } from "@/i18n/translations";
 import { api, ApiError } from "@/lib/api";
+import { appUrl, stripBasePath } from "@/lib/base-path";
+import { isPanelPath } from "@/lib/chromeless";
 
 /** Env var that pins the MCP token when set — never translated. */
 const MCP_TOKEN_ENV_VAR = "FIESTABOARD_MCP_TOKEN";
@@ -128,6 +130,21 @@ export function McpSettings() {
 
   const isLocked = authStatus?.mode === "disabled" && isLockedError(statusError);
 
+  // The token calls skip fetchApi's automatic login redirect because a
+  // 401 means "locked" on auth-disabled installs. When auth is ENABLED,
+  // though, a 401 here is a plain expired session — without this the
+  // component would sit on a skeleton forever. Mirror the shared
+  // redirect helper in @/lib/api (same guards, same redirect target).
+  const sessionExpired = authStatus !== undefined && authStatus.mode !== "disabled" && isLockedError(statusError);
+  useEffect(() => {
+    if (!sessionExpired) return;
+    if (typeof window === "undefined") return;
+    if (stripBasePath(window.location.pathname).startsWith("/login")) return;
+    if (isPanelPath(window.location.pathname)) return;
+    const target = encodeURIComponent(stripBasePath(window.location.pathname) + window.location.search);
+    window.location.assign(appUrl(`/login?redirect=${target}`));
+  }, [sessionExpired]);
+
   const unlockMutation = useMutation({
     mutationFn: (token: string) => api.getMcpTokenStatus(token),
     onSuccess: (data, token) => {
@@ -145,11 +162,13 @@ export function McpSettings() {
     onSuccess: ({ token }) => {
       setRevealedToken(token);
       setConfirmingRotate(false);
-      // In the locked flow the old bearer just became invalid — hold the
-      // new token so management (and the refetch below) keeps working.
-      if (heldTokenRef.current !== null) {
-        heldTokenRef.current = token;
-      }
+      // Hold the fresh token unconditionally. In the locked flow the old
+      // bearer just became invalid; on a FIRST mint (auth disabled, no
+      // token yet, nothing held) the status refetch below would 401 and
+      // flip into the locked view — unmounting the reveal dialog before
+      // the user can copy the token. When session auth is doing the work
+      // the extra bearer is simply ignored by the backend.
+      heldTokenRef.current = token;
       queryClient.invalidateQueries({ queryKey: ["mcp-token-status"] });
     },
     onError: (err: Error) => {

--- a/web/src/components/settings/mcp-settings.tsx
+++ b/web/src/components/settings/mcp-settings.tsx
@@ -20,6 +20,8 @@ import {
   DialogHeader,
   DialogTitle,
   Flex,
+  Input,
+  Label,
   PageSection,
   Skeleton,
   Stack,
@@ -27,12 +29,12 @@ import {
   TextLink,
 } from "@fiestaboard/ui";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { AlertTriangle, Bot, Check, Copy, KeyRound, Loader2, RefreshCw, Trash2 } from "lucide-react";
-import { type ReactNode, useMemo, useState } from "react";
+import { AlertTriangle, Bot, Check, Copy, KeyRound, Loader2, Lock, RefreshCw, Trash2 } from "lucide-react";
+import { type ReactNode, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { useTranslations } from "@/i18n/translations";
-import { api } from "@/lib/api";
+import { api, ApiError } from "@/lib/api";
 
 /** Env var that pins the MCP token when set — never translated. */
 const MCP_TOKEN_ENV_VAR = "FIESTABOARD_MCP_TOKEN";
@@ -79,6 +81,15 @@ function buildClaudeDesktopConfig(token: string): string {
   return JSON.stringify(config, null, 2);
 }
 
+/**
+ * True when an error is the backend's "present the current MCP token"
+ * 401 challenge (#1825) — auth-disabled installs answer it on every
+ * /auth/mcp-token call once a token is configured.
+ */
+function isLockedError(err: unknown): boolean {
+  return err instanceof ApiError && err.status === 401;
+}
+
 export function McpSettings() {
   const t = useTranslations("mcpSettings");
   const tCommon = useTranslations("common");
@@ -87,17 +98,58 @@ export function McpSettings() {
   const [confirmingRotate, setConfirmingRotate] = useState(false);
   const [confirmingClear, setConfirmingClear] = useState(false);
   const [copied, setCopied] = useState<"token" | "config" | null>(null);
+  const [tokenInput, setTokenInput] = useState("");
 
-  const { data: status, isLoading } = useQuery({
+  // On auth-disabled installs the backend gates token management behind
+  // the *current* token once one exists (#1825). After a successful
+  // unlock the token is held here and passed as a bearer on every
+  // management call. A ref (not state) so the invalidation-triggered
+  // refetch inside mutation callbacks always sees the freshest value —
+  // a state closure would still hold the pre-rotate token.
+  const heldTokenRef = useRef<string | null>(null);
+
+  const { data: authStatus } = useQuery({
+    queryKey: ["auth-status"],
+    queryFn: api.getAuthStatus,
+    staleTime: 30_000,
+    retry: false,
+  });
+
+  const {
+    data: status,
+    isLoading,
+    error: statusError,
+  } = useQuery({
     queryKey: ["mcp-token-status"],
-    queryFn: () => api.getMcpTokenStatus(),
+    queryFn: () => api.getMcpTokenStatus(heldTokenRef.current ?? undefined),
+    // 401 means "locked" here, not a transient failure — don't retry it.
+    retry: (failureCount, err) => !isLockedError(err) && failureCount < 3,
+  });
+
+  const isLocked = authStatus?.mode === "disabled" && isLockedError(statusError);
+
+  const unlockMutation = useMutation({
+    mutationFn: (token: string) => api.getMcpTokenStatus(token),
+    onSuccess: (data, token) => {
+      heldTokenRef.current = token;
+      setTokenInput("");
+      queryClient.setQueryData(["mcp-token-status"], data);
+    },
+    onError: (err: Error) => {
+      toast.error(isLockedError(err) ? t("unlockFailedToast") : err.message);
+    },
   });
 
   const rotateMutation = useMutation({
-    mutationFn: () => api.rotateMcpToken(),
+    mutationFn: () => api.rotateMcpToken(heldTokenRef.current ?? undefined),
     onSuccess: ({ token }) => {
       setRevealedToken(token);
       setConfirmingRotate(false);
+      // In the locked flow the old bearer just became invalid — hold the
+      // new token so management (and the refetch below) keeps working.
+      if (heldTokenRef.current !== null) {
+        heldTokenRef.current = token;
+      }
       queryClient.invalidateQueries({ queryKey: ["mcp-token-status"] });
     },
     onError: (err: Error) => {
@@ -107,10 +159,12 @@ export function McpSettings() {
   });
 
   const clearMutation = useMutation({
-    mutationFn: () => api.clearMcpToken(),
+    mutationFn: () => api.clearMcpToken(heldTokenRef.current ?? undefined),
     onSuccess: () => {
       toast.success(t("toastTokenRevoked"));
       setConfirmingClear(false);
+      // No token configured any more — management is open again.
+      heldTokenRef.current = null;
       queryClient.invalidateQueries({ queryKey: ["mcp-token-status"] });
     },
     onError: (err: Error) => {
@@ -130,6 +184,34 @@ export function McpSettings() {
   };
 
   const configSnippet = useMemo(() => (revealedToken ? buildClaudeDesktopConfig(revealedToken) : ""), [revealedToken]);
+
+  if (isLocked) {
+    return (
+      <PageSection icon={<Lock />} title={t("title")} description={t("lockedDescription")} className="space-y-4">
+        <Stack gap="2" className="max-w-md">
+          <Label htmlFor="mcp-current-token">{t("lockedTokenLabel")}</Label>
+          <Flex gap="2">
+            <Input
+              id="mcp-current-token"
+              type="password"
+              autoComplete="off"
+              value={tokenInput}
+              onChange={(e) => setTokenInput(e.target.value)}
+              disabled={unlockMutation.isPending}
+            />
+            <Button
+              onClick={() => unlockMutation.mutate(tokenInput.trim())}
+              disabled={unlockMutation.isPending || !tokenInput.trim()}
+              className="gap-2"
+            >
+              {unlockMutation.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+              {t("unlockButton")}
+            </Button>
+          </Flex>
+        </Stack>
+      </PageSection>
+    );
+  }
 
   if (isLoading || !status) {
     return (

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1700,8 +1700,27 @@ function loginRedirectTarget(): string {
   return encodeURIComponent(stripBasePath(window.location.pathname) + window.location.search);
 }
 
-async function fetchApi<T>(path: string, options?: RequestInit & { timeoutMs?: number }): Promise<T> {
-  const { timeoutMs = DEFAULT_TIMEOUT_MS, ...fetchOptions } = options ?? {};
+/**
+ * Error thrown by fetchApi for non-2xx responses. Carries the HTTP
+ * status so callers can branch on it — e.g. a 401 from /auth/mcp-token
+ * on an auth-disabled install means "management is locked behind the
+ * current token" (#1825), not "not signed in".
+ */
+export class ApiError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+  }
+}
+
+async function fetchApi<T>(
+  path: string,
+  options?: RequestInit & { timeoutMs?: number; skipAuthRedirect?: boolean },
+): Promise<T> {
+  const { timeoutMs = DEFAULT_TIMEOUT_MS, skipAuthRedirect = false, ...fetchOptions } = options ?? {};
   const timeoutSignal = AbortSignal.timeout(timeoutMs);
   const signal = fetchOptions.signal ? AbortSignal.any([fetchOptions.signal, timeoutSignal]) : timeoutSignal;
 
@@ -1724,7 +1743,9 @@ async function fetchApi<T>(path: string, options?: RequestInit & { timeoutMs?: n
     throw err;
   }
   if (!res.ok) {
-    redirectToLoginIfNeeded(res);
+    if (!skipAuthRedirect) {
+      redirectToLoginIfNeeded(res);
+    }
     let detail = `API error: ${res.status} ${res.statusText}`;
     try {
       const body = await res.json();
@@ -1734,7 +1755,7 @@ async function fetchApi<T>(path: string, options?: RequestInit & { timeoutMs?: n
     } catch {
       // ignore JSON parse errors; use status text fallback
     }
-    throw new Error(detail);
+    throw new ApiError(detail, res.status);
   }
   return res.json();
 }
@@ -2735,16 +2756,35 @@ export const api = {
   // pasting a one-time-shown token into their connector config instead
   // of editing FIESTABOARD_MCP_TOKEN in .env. See src/auth/routes.py.
 
-  getMcpTokenStatus: () => fetchApi<McpTokenStatus>("/auth/mcp-token"),
+  // On auth-disabled installs the backend gates these routes behind the
+  // *current* token once one exists (#1825): a 401 here means "locked",
+  // not "not signed in", so all three skip the login redirect and accept
+  // an optional bearer to pass through as `Authorization`.
+
+  getMcpTokenStatus: (currentToken?: string) =>
+    fetchApi<McpTokenStatus>("/auth/mcp-token", {
+      skipAuthRedirect: true,
+      headers: currentToken ? { Authorization: `Bearer ${currentToken}` } : undefined,
+    }),
 
   /**
    * Generate a fresh token, persist it server-side, and return the
    * plaintext value ONCE. The caller is responsible for showing it to
    * the user immediately — it can't be read back after this response.
    */
-  rotateMcpToken: () => fetchApi<{ token: string }>("/auth/mcp-token", { method: "POST" }),
+  rotateMcpToken: (currentToken?: string) =>
+    fetchApi<{ token: string }>("/auth/mcp-token", {
+      method: "POST",
+      skipAuthRedirect: true,
+      headers: currentToken ? { Authorization: `Bearer ${currentToken}` } : undefined,
+    }),
 
-  clearMcpToken: () => fetchApi<{ status: string }>("/auth/mcp-token", { method: "DELETE" }),
+  clearMcpToken: (currentToken?: string) =>
+    fetchApi<{ status: string }>("/auth/mcp-token", {
+      method: "DELETE",
+      skipAuthRedirect: true,
+      headers: currentToken ? { Authorization: `Bearer ${currentToken}` } : undefined,
+    }),
 
   // ── WiFi (FiestaPi only) ────────────────────────────────────────────────
   getWifiCapability: () => fetchApi<WifiCapability>("/network/wifi/capability"),


### PR DESCRIPTION
Closes #1825. Backend-rework **Stack 0** (stacked on #1851; retarget to main as the stack merges).

## The vulnerability

`_require_admin()` returns the `"anonymous"` sentinel when auth mode is disabled, so on an auth-disabled, LAN-reachable install **anyone who can reach the port** could `POST /auth/mcp-token` (mint and read a valid token) or `DELETE` it (revoke, re-opening `/api/mcp` entirely) — the exact management-path asymmetry #1810 left open after gating the data path.

## The fix: possession-based management

New `_require_admin_or_mcp_token()` gate on all three `/auth/mcp-token` routes:
- enabled/undecided modes: unchanged (session auth)
- disabled + **no token configured**: open — first mint stays anonymous by design (with auth disabled the whole REST surface is open; gating the first mint protects nothing)
- disabled + token configured (stored **or** env): caller must present the *current* token as `Authorization: Bearer`; otherwise 401 + `WWW-Authenticate` challenge. Status included — it leaks the token's source.
- env-pinned installs: possession gate first (anon → 401), then the existing 409 pin on mutation

No login-redirect loop (the #857 regression this sentinel guarded against): the web client now treats 401 on this route as "locked", not "sign in" — a password input in Settings → Integrations unlocks management with the current token, and a rotate hands the UI the new token so management continues.

`_require_admin` audit: zero other callers repo-wide (grep evidence in the commit); every other auth route is deliberately public or re-verifies the password inline.

## Zero-regression evidence

**Fail-first (backend)** — the new tests reproduce the issue's exact repro before the fix:
```
tests/test_auth_mcp_token_routes.py .............FFFFFFF.
E   AssertionError: assert 201 == 401   (anon second POST)
E   assert 200 == 401                   (anon DELETE with stored token)
E   assert 200 == 401                   (anon GET with stored token)
========================= 7 failed, 14 passed =========================
```
The three tests that previously **pinned the vulnerability** are rewritten with in-place justification (repo precedent: the #1744 contract reversal in `test_auth_mcp_bearer.py`). No other assertion weakened.

**After:** auth suites + CORS + route-inventory golden: **110 passed**. Web: new locked-state tests **4/4** (non-vacuity proven by reverting the redirect-skip → 4/4 fail, and the held-token update → 1 fails on the exact assertion); full web suite **1611 passed / 0 failed**; `tsc`, eslint, prettier clean.

Docs (`docs/setup/authentication.md`, `docs/internal/setup/MCP_CLIENTS.md`) updated from "known hole + workaround" to the new contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Par2E2Nh65PyDF1q9TARJP