### PR TITLE
fix(plugins): lock registry/loader shared state; serialize per-directory git ops

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -2137,7 +2137,7 @@ async def _auto_apply_plugin_updates(registry: Any, plugin_ids: list) -> None:
             failed.append(plugin_id)
             continue
 
-        registry._update_status.pop(plugin_id, None)
+        registry.clear_update_status(plugin_id)
         updated.append(plugin_id)
 
     if updated:
@@ -5727,7 +5727,9 @@ async def list_transition_plugins():
 
     registry = get_plugin_registry()
     out = []
-    for plugin_id, plugin in registry._plugins.items():  # noqa: SLF001 - registry is in-process
+    # registry.plugins copies under the registry lock, so a concurrent
+    # install/uninstall can't mutate the dict mid-iteration (#1828).
+    for plugin_id, plugin in registry.plugins.items():
         if not isinstance(plugin, TransitionPluginBase):
             continue
         manifest = registry.get_manifest(plugin_id)
@@ -10751,7 +10753,7 @@ async def update_plugin(plugin_id: str):
         detail = "; ".join(errors) if errors else "Plugin failed to reload after update."
         raise HTTPException(status_code=500, detail=detail)
 
-    registry._update_status.pop(plugin_id, None)
+    registry.clear_update_status(plugin_id)
 
     return {
         "status": "success",
@@ -10823,7 +10825,7 @@ async def apply_all_plugin_updates():
             failed[plugin_id] = "; ".join(errors) if errors else "Reload failed."
             continue
 
-        registry._update_status.pop(plugin_id, None)
+        registry.clear_update_status(plugin_id)
         updated.append(plugin_id)
         logger.info("Bulk update: applied update for plugin '%s'", plugin_id)
 

--- a/src/plugins/loader.py
+++ b/src/plugins/loader.py
@@ -649,11 +649,12 @@ class PluginLoader:
             Reloaded plugin instance, or None if failed
         """
         with self._lock:
-            # Unload if loaded
+            # Unload if loaded.  cleanup() is plugin-authored and unbounded,
+            # so it is retired to a daemon thread instead of running under
+            # the shared registry/loader lock (#1854).
             if plugin_id in self._loaded_plugins:
-                old_plugin, _ = self._loaded_plugins[plugin_id]
-                old_plugin.cleanup()
-                del self._loaded_plugins[plugin_id]
+                old_plugin, _ = self._loaded_plugins.pop(plugin_id)
+                self._retire_instance(plugin_id, old_plugin)
 
                 # Remove from sys.modules to force reimport
                 module_name = f"plugins.{plugin_id}"
@@ -676,9 +677,9 @@ class PluginLoader:
             if plugin_id not in self._loaded_plugins:
                 return False
 
-            plugin, _ = self._loaded_plugins[plugin_id]
-            plugin.cleanup()
-            del self._loaded_plugins[plugin_id]
+            # Plugin-authored cleanup() off the shared lock (#1854).
+            plugin, _ = self._loaded_plugins.pop(plugin_id)
+            self._retire_instance(plugin_id, plugin)
 
             # Remove from sys.modules
             module_name = f"plugins.{plugin_id}"

--- a/src/plugins/loader.py
+++ b/src/plugins/loader.py
@@ -116,6 +116,7 @@ class PluginLoader:
         self,
         plugins_dir: Path | None = None,
         external_dirs: list[Path] | None = None,
+        lock: "threading.RLock | None" = None,
     ):
         """Initialize the plugin loader.
 
@@ -126,6 +127,10 @@ class PluginLoader:
             external_dirs: Additional directories to scan for plugins
                 (e.g. ``external_plugins/``).  When *None* the default
                 external directory is included automatically.
+            lock: Re-entrant lock guarding the loader's mutable state.
+                The registry passes its own lock so registry->loader call
+                chains re-enter one lock instead of ordering two (#1828).
+                When *None* a private lock is created.
         """
         if plugins_dir is None:
             project_root = Path(__file__).parent.parent.parent
@@ -140,6 +145,7 @@ class PluginLoader:
         else:
             self._external_dirs = list(external_dirs)
 
+        self._lock = lock or threading.RLock()
         self._loaded_plugins: dict[str, tuple[AnyPlugin, PluginManifest]] = {}
         self._plugin_classes: dict[str, type[AnyPlugin]] = {}
         self._load_errors: dict[str, list[str]] = {}
@@ -154,23 +160,27 @@ class PluginLoader:
     @property
     def loaded_plugins(self) -> dict[str, tuple[AnyPlugin, PluginManifest]]:
         """Return all successfully loaded plugins (data + transition)."""
-        return self._loaded_plugins.copy()
+        with self._lock:
+            return self._loaded_plugins.copy()
 
     @property
     def data_plugins(self) -> dict[str, tuple[PluginBase, PluginManifest]]:
         """Return only loaded *data* plugins (PluginBase subclasses)."""
-        return {pid: (inst, m) for pid, (inst, m) in self._loaded_plugins.items() if isinstance(inst, PluginBase)}
+        with self._lock:
+            items = list(self._loaded_plugins.items())
+        return {pid: (inst, m) for pid, (inst, m) in items if isinstance(inst, PluginBase)}
 
     @property
     def transition_plugins(self) -> dict[str, tuple[TransitionPluginBase, PluginManifest]]:
         """Return only loaded *transition* plugins."""
-        return {
-            pid: (inst, m) for pid, (inst, m) in self._loaded_plugins.items() if isinstance(inst, TransitionPluginBase)
-        }
+        with self._lock:
+            items = list(self._loaded_plugins.items())
+        return {pid: (inst, m) for pid, (inst, m) in items if isinstance(inst, TransitionPluginBase)}
 
     def get_transition_plugin(self, plugin_id: str) -> TransitionPluginBase | None:
         """Return a loaded transition plugin instance, or None."""
-        entry = self._loaded_plugins.get(plugin_id)
+        with self._lock:
+            entry = self._loaded_plugins.get(plugin_id)
         if entry is None:
             return None
         instance, _ = entry
@@ -181,12 +191,14 @@ class PluginLoader:
     @property
     def load_errors(self) -> dict[str, list[str]]:
         """Return load errors by plugin directory name."""
-        return self._load_errors.copy()
+        with self._lock:
+            return self._load_errors.copy()
 
     @property
     def plugin_sources(self) -> dict[str, PluginSource]:
         """Return source information for every loaded plugin."""
-        return self._plugin_sources.copy()
+        with self._lock:
+            return self._plugin_sources.copy()
 
     # ── discovery ────────────────────────────────────────────────────────
 
@@ -288,6 +300,16 @@ class PluginLoader:
         Returns:
             Loaded plugin instance, or None if loading failed
         """
+        # The whole load runs under the shared lock: it is a multi-step
+        # read-modify-write of _load_errors / _loaded_plugins /
+        # _plugin_classes / _plugin_sources plus sys.modules, and nothing in
+        # it shells out (importlib and file reads only), so holding the lock
+        # for the duration is safe.
+        with self._lock:
+            return self._load_plugin_locked(plugin_name)
+
+    def _load_plugin_locked(self, plugin_name: str) -> AnyPlugin | None:
+        """Body of :meth:`load_plugin`; the caller holds ``self._lock``."""
         plugin_dir = self._resolve_plugin_dir(plugin_name)
         errors: list[str] = []
 
@@ -546,9 +568,8 @@ class PluginLoader:
 
         logger.info(f"Loaded {len(loaded)}/{len(plugin_dirs)} plugins")
 
-        if self._load_errors:
-            for name, errors in self._load_errors.items():
-                logger.warning(f"Plugin {name} had errors: {errors}")
+        for name, errors in self.load_errors.items():
+            logger.warning(f"Plugin {name} had errors: {errors}")
 
         return loaded
 
@@ -577,7 +598,8 @@ class PluginLoader:
         Returns:
             Directory names that were removed (empty when nothing was stale).
         """
-        loaded_ids = set(self._loaded_plugins.keys())
+        with self._lock:
+            loaded_ids = set(self._loaded_plugins.keys())
         removed: list[str] = []
 
         for ext_dir in self._external_dirs:
@@ -606,7 +628,8 @@ class PluginLoader:
                     continue
 
                 if remove_external_plugin(item):
-                    self._load_errors.pop(item.name, None)
+                    with self._lock:
+                        self._load_errors.pop(item.name, None)
                     removed.append(item.name)
                     logger.info(
                         "Removed orphaned renamed plugin directory '%s' (manifest id '%s' installed elsewhere)",
@@ -625,19 +648,20 @@ class PluginLoader:
         Returns:
             Reloaded plugin instance, or None if failed
         """
-        # Unload if loaded
-        if plugin_id in self._loaded_plugins:
-            old_plugin, _ = self._loaded_plugins[plugin_id]
-            old_plugin.cleanup()
-            del self._loaded_plugins[plugin_id]
+        with self._lock:
+            # Unload if loaded
+            if plugin_id in self._loaded_plugins:
+                old_plugin, _ = self._loaded_plugins[plugin_id]
+                old_plugin.cleanup()
+                del self._loaded_plugins[plugin_id]
 
-            # Remove from sys.modules to force reimport
-            module_name = f"plugins.{plugin_id}"
-            if module_name in sys.modules:
-                del sys.modules[module_name]
+                # Remove from sys.modules to force reimport
+                module_name = f"plugins.{plugin_id}"
+                if module_name in sys.modules:
+                    del sys.modules[module_name]
 
-        # Load again
-        return self.load_plugin(plugin_id)
+            # Load again
+            return self.load_plugin(plugin_id)
 
     def unload_plugin(self, plugin_id: str) -> bool:
         """Unload a plugin.
@@ -648,17 +672,18 @@ class PluginLoader:
         Returns:
             True if unloaded, False if not loaded
         """
-        if plugin_id not in self._loaded_plugins:
-            return False
+        with self._lock:
+            if plugin_id not in self._loaded_plugins:
+                return False
 
-        plugin, _ = self._loaded_plugins[plugin_id]
-        plugin.cleanup()
-        del self._loaded_plugins[plugin_id]
+            plugin, _ = self._loaded_plugins[plugin_id]
+            plugin.cleanup()
+            del self._loaded_plugins[plugin_id]
 
-        # Remove from sys.modules
-        module_name = f"plugins.{plugin_id}"
-        if module_name in sys.modules:
-            del sys.modules[module_name]
+            # Remove from sys.modules
+            module_name = f"plugins.{plugin_id}"
+            if module_name in sys.modules:
+                del sys.modules[module_name]
 
         logger.info(f"Unloaded plugin: {plugin_id}")
         return True
@@ -672,8 +697,10 @@ class PluginLoader:
         Returns:
             PluginManifest or None if not loaded
         """
-        if plugin_id in self._loaded_plugins:
-            _, manifest = self._loaded_plugins[plugin_id]
+        with self._lock:
+            entry = self._loaded_plugins.get(plugin_id)
+        if entry is not None:
+            _, manifest = entry
             return manifest
         return None
 
@@ -715,16 +742,19 @@ class PluginLoader:
         Returns:
             A new PluginBase instance, or None if the plugin is not loaded.
         """
-        plugin_class = self._plugin_classes.get(plugin_id)
+        with self._lock:
+            plugin_class = self._plugin_classes.get(plugin_id)
+            entry = self._loaded_plugins.get(plugin_id)
+
         if plugin_class is None:
             logger.warning("Cannot create instance: plugin class not found for %s", plugin_id)
             return None
 
-        if plugin_id not in self._loaded_plugins:
+        if entry is None:
             logger.warning("Cannot create instance: plugin not loaded: %s", plugin_id)
             return None
 
-        _, manifest = self._loaded_plugins[plugin_id]
+        _, manifest = entry
 
         try:
             return plugin_class(manifest.raw)

--- a/src/plugins/registry.py
+++ b/src/plugins/registry.py
@@ -10,6 +10,7 @@ The PluginRegistry is the central point for:
 
 import logging
 import re
+import threading
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import wait as futures_wait
 from dataclasses import replace
@@ -77,7 +78,16 @@ class PluginRegistry:
         Args:
             plugins_dir: Path to plugins directory
         """
-        self._loader = PluginLoader(plugins_dir)
+        # One re-entrant lock guards every mutable dict on the registry AND
+        # the loader's internal state (the loader is handed the same lock, so
+        # a registry->loader call chain re-enters one lock instead of having
+        # to order two).  Install/update endpoints run on worker threads since
+        # #1809, so these dicts mutate concurrently with request handlers that
+        # iterate them (#1828).  Iterating callers snapshot under the lock and
+        # iterate the snapshot; nothing slow — git, plugin ``get_data``, the
+        # context-build thread pool — ever runs while it is held.
+        self._lock = threading.RLock()
+        self._loader = PluginLoader(plugins_dir, lock=self._lock)
         self._plugins: dict[str, PluginBase] = {}
         self._manifests: dict[str, PluginManifest] = {}
         self._configs: dict[str, dict[str, Any]] = {}
@@ -167,27 +177,28 @@ class PluginRegistry:
             ]
         instance_label = instance_label.lower()
 
-        # Base plugin must exist
-        if plugin_id not in self._plugins:
-            return [f"Plugin not found: {plugin_id}"]
+        with self._lock:
+            # Base plugin must exist
+            if plugin_id not in self._plugins:
+                return [f"Plugin not found: {plugin_id}"]
 
-        compound_key = self.make_instance_key(plugin_id, instance_label)
+            compound_key = self.make_instance_key(plugin_id, instance_label)
 
-        # Must not already exist
-        if compound_key in self._plugins:
-            return [f"Instance already exists: {compound_key}"]
+            # Must not already exist
+            if compound_key in self._plugins:
+                return [f"Instance already exists: {compound_key}"]
 
-        # Create a fresh plugin object
-        new_plugin = self._loader.create_instance(plugin_id)
-        if new_plugin is None:
-            return [f"Failed to create instance of {plugin_id}"]
+            # Create a fresh plugin object
+            new_plugin = self._loader.create_instance(plugin_id)
+            if new_plugin is None:
+                return [f"Failed to create instance of {plugin_id}"]
 
-        # Register under compound key
-        base_manifest = self._manifests[plugin_id]
-        self._plugins[compound_key] = new_plugin
-        self._manifests[compound_key] = base_manifest
-        self._enabled[compound_key] = False
-        self._configs[compound_key] = {}
+            # Register under compound key
+            base_manifest = self._manifests[plugin_id]
+            self._plugins[compound_key] = new_plugin
+            self._manifests[compound_key] = base_manifest
+            self._enabled[compound_key] = False
+            self._configs[compound_key] = {}
 
         logger.info("Created plugin instance: %s", compound_key)
         return []
@@ -206,16 +217,17 @@ class PluginRegistry:
         """
         compound_key = self.make_instance_key(plugin_id, instance_label)
 
-        if compound_key not in self._plugins:
-            return [f"Instance not found: {compound_key}"]
+        with self._lock:
+            if compound_key not in self._plugins:
+                return [f"Instance not found: {compound_key}"]
 
-        # Clean up the plugin
-        self._plugins[compound_key].cleanup()
-        del self._plugins[compound_key]
-        self._manifests.pop(compound_key, None)
-        self._enabled.pop(compound_key, None)
-        self._configs.pop(compound_key, None)
-        self._discovered_vars.pop(compound_key, None)
+            # Clean up the plugin
+            self._plugins[compound_key].cleanup()
+            del self._plugins[compound_key]
+            self._manifests.pop(compound_key, None)
+            self._enabled.pop(compound_key, None)
+            self._configs.pop(compound_key, None)
+            self._discovered_vars.pop(compound_key, None)
 
         logger.info("Deleted plugin instance: %s", compound_key)
         return []
@@ -233,29 +245,33 @@ class PluginRegistry:
         instances: list[dict[str, Any]] = []
         prefix = f"{plugin_id}{INSTANCE_SEPARATOR}"
 
-        for key in sorted(self._plugins):
-            if key.startswith(prefix):
-                label = key[len(prefix) :]
-                instances.append(
-                    {
-                        "label": label,
-                        "key": key,
-                        "enabled": self._enabled.get(key, False),
-                        "has_config": bool(self._configs.get(key)),
-                    }
-                )
+        with self._lock:
+            for key in sorted(self._plugins):
+                if key.startswith(prefix):
+                    label = key[len(prefix) :]
+                    instances.append(
+                        {
+                            "label": label,
+                            "key": key,
+                            "enabled": self._enabled.get(key, False),
+                            "has_config": bool(self._configs.get(key)),
+                        }
+                    )
 
         return instances
 
     @property
     def plugins(self) -> dict[str, PluginBase]:
         """Return all loaded plugins."""
-        return self._plugins.copy()
+        with self._lock:
+            return self._plugins.copy()
 
     @property
     def enabled_plugins(self) -> dict[str, PluginBase]:
         """Return only enabled plugins."""
-        return {pid: plugin for pid, plugin in self._plugins.items() if self._enabled.get(pid, False)}
+        with self._lock:
+            items = list(self._plugins.items())
+            return {pid: plugin for pid, plugin in items if self._enabled.get(pid, False)}
 
     def initialize(self, force: bool = False) -> None:
         """Load all discovered plugins.
@@ -309,28 +325,29 @@ class PluginRegistry:
             # that their integrations "turned themselves off".
             logger.exception("Could not load stored plugin configs — all plugins will start disabled")
 
-        for plugin_id, plugin in loaded.items():
-            manifest = self._loader.get_manifest(plugin_id)
-            if manifest:
-                self._plugins[plugin_id] = plugin
-                self._manifests[plugin_id] = manifest
+        with self._lock:
+            for plugin_id, plugin in loaded.items():
+                manifest = self._loader.get_manifest(plugin_id)
+                if manifest:
+                    self._plugins[plugin_id] = plugin
+                    self._manifests[plugin_id] = manifest
 
-                # Check if plugin has stored config with enabled=true
-                plugin_config = stored_configs.get(plugin_id, {})
-                is_enabled = plugin_config.get("enabled", False)
+                    # Check if plugin has stored config with enabled=true
+                    plugin_config = stored_configs.get(plugin_id, {})
+                    is_enabled = plugin_config.get("enabled", False)
 
-                self._enabled[plugin_id] = is_enabled
+                    self._enabled[plugin_id] = is_enabled
 
-                # Apply stored config to the plugin
-                if plugin_config:
-                    self._configs[plugin_id] = plugin_config
-                    plugin.config = plugin_config
-                    plugin.enabled = is_enabled
+                    # Apply stored config to the plugin
+                    if plugin_config:
+                        self._configs[plugin_id] = plugin_config
+                        plugin.config = plugin_config
+                        plugin.enabled = is_enabled
 
-                if is_enabled:
-                    logger.info(f"Loaded and enabled plugin: {plugin_id}")
-                else:
-                    logger.debug(f"Loaded plugin (disabled): {plugin_id}")
+                    if is_enabled:
+                        logger.info(f"Loaded and enabled plugin: {plugin_id}")
+                    else:
+                        logger.debug(f"Loaded plugin (disabled): {plugin_id}")
 
         # Auto-install any plugins that were configured in V2 but are no longer
         # built-in (extracted to external repos in V3).
@@ -340,10 +357,10 @@ class PluginRegistry:
         # Instance configs have compound keys like "weather:sf".
         self._restore_instances(stored_configs)
 
-        self._initialized = True
-
-        enabled_count = sum(1 for e in self._enabled.values() if e)
-        logger.info(f"Initialized {len(self._plugins)} plugins ({enabled_count} enabled)")
+        with self._lock:
+            self._initialized = True
+            enabled_count = sum(1 for e in self._enabled.values() if e)
+            logger.info(f"Initialized {len(self._plugins)} plugins ({enabled_count} enabled)")
 
     def _restore_instances(self, stored_configs: dict[str, dict[str, Any]]) -> None:
         """Restore plugin instances from stored configuration.
@@ -467,7 +484,8 @@ class PluginRegistry:
             return
 
         first_run = not cm.is_v2_plugin_migration_done()
-        loaded_ids = set(self._plugins.keys())
+        with self._lock:
+            loaded_ids = set(self._plugins.keys())
 
         if first_run or cm.version_changed_on_load:
             # Full reconcile: (re)install every orphaned config — one that is
@@ -529,7 +547,8 @@ class PluginRegistry:
         we can retry just those on the next boot.
         """
         if loaded_ids is None:
-            loaded_ids = set(self._plugins.keys())
+            with self._lock:
+                loaded_ids = set(self._plugins.keys())
         # Instance keys (e.g. "countdown:fijiaustralia") are restored separately
         # by ``_restore_instances`` and must not be treated as orphaned base
         # plugins — their base ID is what gets installed from the registry.
@@ -621,16 +640,17 @@ class PluginRegistry:
 
             # install_from_registry() registers the plugin with enabled=False and
             # no config applied.  Restore the full stored config and enabled state.
-            plugin = self._plugins.get(plugin_id)
-            if plugin:
-                cfg = stored_configs[plugin_id]
-                is_enabled = cfg.get("enabled", False)
-                self._enabled[plugin_id] = is_enabled
-                self._configs[plugin_id] = cfg
-                plugin.config = cfg
-                plugin.enabled = is_enabled
-                migrated.append(plugin_id)
-                logger.info("V3 migration: restored '%s' (enabled=%s)", plugin_id, is_enabled)
+            with self._lock:
+                plugin = self._plugins.get(plugin_id)
+                if plugin:
+                    cfg = stored_configs[plugin_id]
+                    is_enabled = cfg.get("enabled", False)
+                    self._enabled[plugin_id] = is_enabled
+                    self._configs[plugin_id] = cfg
+                    plugin.config = cfg
+                    plugin.enabled = is_enabled
+                    migrated.append(plugin_id)
+                    logger.info("V3 migration: restored '%s' (enabled=%s)", plugin_id, is_enabled)
 
         if migrated:
             logger.info(
@@ -694,10 +714,12 @@ class PluginRegistry:
 
     def _plugin_in_use(self, plugin_id: str) -> bool:
         """Return True when the plugin or any of its instances is enabled."""
-        if self._enabled.get(plugin_id, False):
-            return True
-        prefix = f"{plugin_id}{INSTANCE_SEPARATOR}"
-        return any(key.startswith(prefix) and enabled for key, enabled in self._enabled.items())
+        with self._lock:
+            if self._enabled.get(plugin_id, False):
+                return True
+            prefix = f"{plugin_id}{INSTANCE_SEPARATOR}"
+            enabled_items = list(self._enabled.items())
+        return any(key.startswith(prefix) and enabled for key, enabled in enabled_items)
 
     def enable_plugin(self, plugin_id: str) -> bool:
         """Enable a plugin.
@@ -727,17 +749,18 @@ class PluginRegistry:
                 if errors:
                     logger.warning("On-demand install of '%s' failed: %s", plugin_id, errors)
 
-        if plugin_id not in self._plugins:
-            logger.warning(f"Cannot enable unknown plugin: {plugin_id}")
-            return False
+        with self._lock:
+            if plugin_id not in self._plugins:
+                logger.warning(f"Cannot enable unknown plugin: {plugin_id}")
+                return False
 
-        plugin = self._plugins[plugin_id]
-        plugin.enabled = True
-        self._enabled[plugin_id] = True
+            plugin = self._plugins[plugin_id]
+            plugin.enabled = True
+            self._enabled[plugin_id] = True
 
-        # Apply stored config
-        if plugin_id in self._configs:
-            plugin.config = self._configs[plugin_id]
+            # Apply stored config
+            if plugin_id in self._configs:
+                plugin.config = self._configs[plugin_id]
 
         logger.info(f"Enabled plugin: {plugin_id}")
         return True
@@ -751,12 +774,13 @@ class PluginRegistry:
         Returns:
             True if disabled successfully, False if plugin not found
         """
-        if plugin_id not in self._plugins:
-            return False
+        with self._lock:
+            if plugin_id not in self._plugins:
+                return False
 
-        plugin = self._plugins[plugin_id]
-        plugin.enabled = False
-        self._enabled[plugin_id] = False
+            plugin = self._plugins[plugin_id]
+            plugin.enabled = False
+            self._enabled[plugin_id] = False
 
         logger.info(f"Disabled plugin: {plugin_id}")
         return True
@@ -771,20 +795,21 @@ class PluginRegistry:
         Returns:
             List of validation errors (empty if valid)
         """
-        if plugin_id not in self._plugins:
-            return [f"Plugin not found: {plugin_id}"]
+        with self._lock:
+            if plugin_id not in self._plugins:
+                return [f"Plugin not found: {plugin_id}"]
 
-        plugin = self._plugins[plugin_id]
+            plugin = self._plugins[plugin_id]
 
-        # Validate config (base refresh_seconds + plugin-specific)
-        errors = plugin._validate_refresh_seconds(config)
-        errors.extend(plugin.validate_config(config))
-        if errors:
-            return errors
+            # Validate config (base refresh_seconds + plugin-specific)
+            errors = plugin._validate_refresh_seconds(config)
+            errors.extend(plugin.validate_config(config))
+            if errors:
+                return errors
 
-        # Store and apply config
-        self._configs[plugin_id] = config
-        plugin.config = config
+            # Store and apply config
+            self._configs[plugin_id] = config
+            plugin.config = config
 
         logger.debug(f"Updated config for {plugin_id}")
         return []
@@ -806,10 +831,11 @@ class PluginRegistry:
             List of validation errors. Non-empty means the config was applied
             anyway and the caller should log it.
         """
-        errors = self.set_plugin_config(plugin_id, config)
-        if errors and plugin_id in self._plugins:
-            self._configs[plugin_id] = config
-            self._plugins[plugin_id].config = config
+        with self._lock:
+            errors = self.set_plugin_config(plugin_id, config)
+            if errors and plugin_id in self._plugins:
+                self._configs[plugin_id] = config
+                self._plugins[plugin_id].config = config
         return errors
 
     def get_plugin_config(self, plugin_id: str) -> dict[str, Any] | None:
@@ -834,13 +860,18 @@ class PluginRegistry:
         Returns:
             PluginResult with data or error
         """
-        if plugin_id not in self._plugins:
+        # Lookups only under the lock; the fetch itself runs unlocked because
+        # ``get_data`` is plugin code that may block on the network, and this
+        # method runs on build_template_context's worker threads.
+        with self._lock:
+            plugin = self._plugins.get(plugin_id)
+            enabled = self._enabled.get(plugin_id, False)
+
+        if plugin is None:
             return PluginResult(available=False, error=f"Plugin not found: {plugin_id}")
 
-        if not self._enabled.get(plugin_id, False):
+        if not enabled:
             return PluginResult(available=False, error=f"Plugin not enabled: {plugin_id}")
-
-        plugin = self._plugins[plugin_id]
 
         # Transition plugins animate sends; they have no data or template
         # variables.  Data-oriented callers (variable discovery, display
@@ -940,27 +971,34 @@ class PluginRegistry:
         Results are cached so the discovery fetch only happens once per
         plugin lifecycle.
         """
-        if plugin_id in self._discovered_vars:
-            return self._discovered_vars[plugin_id]
+        with self._lock:
+            cached = self._discovered_vars.get(plugin_id)
+        if cached is not None:
+            return cached
 
+        # The discovery fetch runs unlocked — it calls plugin code that may
+        # block on the network.
         try:
             result = self.fetch_plugin_data(plugin_id)
             if result.available and result.data:
                 discovered = [key for key, val in result.data.items() if isinstance(val, str | int | float | bool)]
-                self._discovered_vars[plugin_id] = discovered
+                with self._lock:
+                    self._discovered_vars[plugin_id] = discovered
                 return discovered
         except Exception:
             logger.debug("Auto-discovery fetch failed for %s", plugin_id)
 
-        self._discovered_vars[plugin_id] = []
+        with self._lock:
+            self._discovered_vars[plugin_id] = []
         return []
 
     def clear_discovered_cache(self, plugin_id: str | None = None) -> None:
         """Clear auto-discovery cache for one or all plugins."""
-        if plugin_id:
-            self._discovered_vars.pop(plugin_id, None)
-        else:
-            self._discovered_vars.clear()
+        with self._lock:
+            if plugin_id:
+                self._discovered_vars.pop(plugin_id, None)
+            else:
+                self._discovered_vars.clear()
 
     def get_all_variables(self) -> dict[str, list[str]]:
         """Get all template variables from enabled plugins.
@@ -974,11 +1012,17 @@ class PluginRegistry:
         """
         variables: dict[str, list[str]] = {}
 
-        for plugin_id, _plugin in self._plugins.items():
-            if not self._enabled.get(plugin_id, False):
-                continue
+        # Snapshot under the lock, iterate the snapshot: _discover_variables
+        # below may call plugin code, which must never run while the lock is
+        # held.
+        with self._lock:
+            snapshot = [
+                (plugin_id, self._manifests.get(plugin_id))
+                for plugin_id in list(self._plugins)
+                if self._enabled.get(plugin_id, False)
+            ]
 
-            manifest = self._manifests.get(plugin_id)
+        for plugin_id, manifest in snapshot:
             if not manifest:
                 continue
 
@@ -1048,12 +1092,13 @@ class PluginRegistry:
             ``{plugin_id: {group_id: {"label": "..."}}}``
         """
         result: dict[str, dict[str, dict[str, str]]] = {}
-        for plugin_id in self._plugins:
-            if not self._enabled.get(plugin_id, False):
-                continue
-            manifest = self._manifests.get(plugin_id)
-            if manifest and manifest.variables.groups:
-                result[plugin_id] = {gid: {"label": g.label} for gid, g in manifest.variables.groups.items()}
+        with self._lock:
+            for plugin_id in list(self._plugins):
+                if not self._enabled.get(plugin_id, False):
+                    continue
+                manifest = self._manifests.get(plugin_id)
+                if manifest and manifest.variables.groups:
+                    result[plugin_id] = {gid: {"label": g.label} for gid, g in manifest.variables.groups.items()}
         return result
 
     def get_all_max_lengths(self) -> dict[str, int]:
@@ -1064,18 +1109,19 @@ class PluginRegistry:
         """
         max_lengths: dict[str, int] = {}
 
-        for plugin_id in self._plugins:
-            if not self._enabled.get(plugin_id, False):
-                continue
+        with self._lock:
+            for plugin_id in list(self._plugins):
+                if not self._enabled.get(plugin_id, False):
+                    continue
 
-            manifest = self._manifests.get(plugin_id)
-            if not manifest:
-                continue
+                manifest = self._manifests.get(plugin_id)
+                if not manifest:
+                    continue
 
-            # Prefix variable names with plugin_id
-            for var_name, max_len in manifest.max_lengths.items():
-                full_name = f"{plugin_id}.{var_name}"
-                max_lengths[full_name] = max_len
+                # Prefix variable names with plugin_id
+                for var_name, max_len in manifest.max_lengths.items():
+                    full_name = f"{plugin_id}.{var_name}"
+                    max_lengths[full_name] = max_len
 
         return max_lengths
 
@@ -1103,7 +1149,10 @@ class PluginRegistry:
         """
         plugins = []
 
-        for plugin_id, _plugin in self._plugins.items():
+        with self._lock:
+            snapshot = list(self._plugins.items())
+
+        for plugin_id, _plugin in snapshot:
             manifest = self._manifests.get(plugin_id)
             base_id, instance_label = self.parse_instance_key(plugin_id)
             source = self._loader.get_source(base_id)
@@ -1145,48 +1194,54 @@ class PluginRegistry:
         Returns:
             Reloaded plugin instance or None if failed
         """
-        # Remember enabled state and config
-        was_enabled = self._enabled.get(plugin_id, False)
-        config = self._configs.get(plugin_id, {})
+        # The whole reload runs under the lock: between the unload and the
+        # re-add the id is absent from _plugins, and readers must never
+        # observe that window.  Nothing in here shells out — the loader's
+        # reload is importlib + file reads, and enable_plugin cannot hit its
+        # install-on-demand path because the plugin is present again by then.
+        with self._lock:
+            # Remember enabled state and config
+            was_enabled = self._enabled.get(plugin_id, False)
+            config = self._configs.get(plugin_id, {})
 
-        # Unload
-        if plugin_id in self._plugins:
-            self._plugins[plugin_id].cleanup()
-            del self._plugins[plugin_id]
-        if plugin_id in self._manifests:
-            del self._manifests[plugin_id]
+            # Unload
+            if plugin_id in self._plugins:
+                self._plugins[plugin_id].cleanup()
+                del self._plugins[plugin_id]
+            if plugin_id in self._manifests:
+                del self._manifests[plugin_id]
 
-        # Reload
-        plugin = self._loader.reload_plugin(plugin_id)
-        if plugin:
-            manifest = self._loader.get_manifest(plugin_id)
-            if manifest:
-                self._plugins[plugin_id] = plugin
-                self._manifests[plugin_id] = manifest
-                self.clear_discovered_cache(plugin_id)
+            # Reload
+            plugin = self._loader.reload_plugin(plugin_id)
+            if plugin:
+                manifest = self._loader.get_manifest(plugin_id)
+                if manifest:
+                    self._plugins[plugin_id] = plugin
+                    self._manifests[plugin_id] = manifest
+                    self.clear_discovered_cache(plugin_id)
 
-                # Restore state
-                if was_enabled:
-                    self.enable_plugin(plugin_id)
-                if config:
-                    errors = self.set_plugin_config(plugin_id, config)
-                    if errors:
-                        # New version's validate_config rejected the old config
-                        # (e.g. a required field was added/renamed).  Apply the
-                        # config directly so the user's data isn't silently lost.
-                        # The user can re-save through the UI to normalise it.
-                        logger.warning(
-                            "Config validation failed after reload for '%s': %s"
-                            " — applying raw config to avoid data loss",
-                            plugin_id,
-                            errors,
-                        )
-                        self._configs[plugin_id] = config
-                        plugin.config = config
+                    # Restore state
+                    if was_enabled:
+                        self.enable_plugin(plugin_id)
+                    if config:
+                        errors = self.set_plugin_config(plugin_id, config)
+                        if errors:
+                            # New version's validate_config rejected the old config
+                            # (e.g. a required field was added/renamed).  Apply the
+                            # config directly so the user's data isn't silently lost.
+                            # The user can re-save through the UI to normalise it.
+                            logger.warning(
+                                "Config validation failed after reload for '%s': %s"
+                                " — applying raw config to avoid data loss",
+                                plugin_id,
+                                errors,
+                            )
+                            self._configs[plugin_id] = config
+                            plugin.config = config
 
-                self._rebuild_instances(plugin_id, manifest)
+                    self._rebuild_instances(plugin_id, manifest)
 
-                return plugin
+                    return plugin
 
         return None
 
@@ -1203,39 +1258,41 @@ class PluginRegistry:
         being torn down.
         """
         prefix = f"{plugin_id}{INSTANCE_SEPARATOR}"
-        for compound_key in [k for k in self._plugins if k.startswith(prefix)]:
-            new_instance = self._loader.create_instance(plugin_id)
-            if new_instance is None:
-                logger.warning(
-                    "Failed to rebuild instance '%s' after reload — keeping the old instance",
-                    compound_key,
-                )
-                continue
-
-            old_instance = self._plugins[compound_key]
-            try:
-                old_instance.cleanup()
-            except Exception:
-                logger.exception("Error cleaning up old instance '%s'", compound_key)
-
-            self._plugins[compound_key] = new_instance
-            self._manifests[compound_key] = manifest
-            self.clear_discovered_cache(compound_key)
-
-            # Restore state (mirrors the base-plugin restore above)
-            if self._enabled.get(compound_key, False):
-                self.enable_plugin(compound_key)
-            instance_config = self._configs.get(compound_key, {})
-            if instance_config:
-                errors = self.apply_stored_config(compound_key, instance_config)
-                if errors:
+        with self._lock:
+            for compound_key in [k for k in list(self._plugins) if k.startswith(prefix)]:
+                new_instance = self._loader.create_instance(plugin_id)
+                if new_instance is None:
                     logger.warning(
-                        "Config validation failed after reload for '%s': %s — applying raw config to avoid data loss",
+                        "Failed to rebuild instance '%s' after reload — keeping the old instance",
                         compound_key,
-                        errors,
                     )
+                    continue
 
-            logger.info("Rebuilt plugin instance after reload: %s", compound_key)
+                old_instance = self._plugins[compound_key]
+                try:
+                    old_instance.cleanup()
+                except Exception:
+                    logger.exception("Error cleaning up old instance '%s'", compound_key)
+
+                self._plugins[compound_key] = new_instance
+                self._manifests[compound_key] = manifest
+                self.clear_discovered_cache(compound_key)
+
+                # Restore state (mirrors the base-plugin restore above)
+                if self._enabled.get(compound_key, False):
+                    self.enable_plugin(compound_key)
+                instance_config = self._configs.get(compound_key, {})
+                if instance_config:
+                    errors = self.apply_stored_config(compound_key, instance_config)
+                    if errors:
+                        logger.warning(
+                            "Config validation failed after reload for '%s': %s"
+                            " — applying raw config to avoid data loss",
+                            compound_key,
+                            errors,
+                        )
+
+                logger.info("Rebuilt plugin instance after reload: %s", compound_key)
 
     def get_load_errors(self) -> dict[str, list[str]]:
         """Get plugin load errors.
@@ -1285,13 +1342,15 @@ class PluginRegistry:
                     check.blocked_reason,
                 )
 
-        self._update_status = results
-        self._update_blocked = blocked
+        with self._lock:
+            self._update_status = results
+            self._update_blocked = blocked
         return results
 
     def get_update_status(self) -> dict[str, bool]:
         """Return cached update status from the last check_for_updates() call."""
-        return self._update_status.copy()
+        with self._lock:
+            return self._update_status.copy()
 
     def get_update_blocked_reasons(self) -> dict[str, str]:
         """Return why held-back updates were held back, by plugin id.
@@ -1299,7 +1358,18 @@ class PluginRegistry:
         Only contains plugins that have an upstream commit which the running
         core cannot run.  Empty for every plugin that is simply up to date.
         """
-        return self._update_blocked.copy()
+        with self._lock:
+            return self._update_blocked.copy()
+
+    def clear_update_status(self, plugin_id: str) -> None:
+        """Drop the cached update flag for one plugin.
+
+        Called after an update has been applied so ``/plugins/updates`` stops
+        advertising it.  Public so the API layer never mutates the cache
+        directly (it must go through the registry lock).
+        """
+        with self._lock:
+            self._update_status.pop(plugin_id, None)
 
     def get_plugin_source(self, plugin_id: str) -> PluginSource | None:
         """Get the source information for a loaded plugin.
@@ -1328,9 +1398,12 @@ class PluginRegistry:
         entries = load_registry()
         seed = load_preview_seed()
 
+        with self._lock:
+            installed_ids = set(self._plugins)
+
         result: list[dict[str, Any]] = []
         for e in entries:
-            installed = e.plugin_id in self._plugins
+            installed = e.plugin_id in installed_ids
             teaser, previews = self._board_previews_for(e.plugin_id, seed)
             result.append(
                 {
@@ -1399,23 +1472,26 @@ class PluginRegistry:
         if entry is None:
             return [f"Plugin '{plugin_id}' not found in the registry"]
 
+        # The clone runs unlocked — it is a network git operation, serialized
+        # per plugin directory inside sources.py.
         ok, err = install_registry_plugin(entry)
         if not ok:
             return [err]
 
-        # Reload external dirs and load the new plugin
-        self._loader._external_dirs = [get_external_plugins_dir()]
-        plugin = self._loader.load_plugin(plugin_id)
-        if plugin is None:
-            errors = self._loader.load_errors.get(plugin_id, [])
-            return errors or [f"Failed to load plugin after install: {plugin_id}"]
+        with self._lock:
+            # Reload external dirs and load the new plugin
+            self._loader._external_dirs = [get_external_plugins_dir()]
+            plugin = self._loader.load_plugin(plugin_id)
+            if plugin is None:
+                errors = self._loader.load_errors.get(plugin_id, [])
+                return errors or [f"Failed to load plugin after install: {plugin_id}"]
 
-        manifest = self._loader.get_manifest(plugin_id)
-        if manifest:
-            self._plugins[plugin_id] = plugin
-            self._manifests[plugin_id] = manifest
-            self._enabled[plugin_id] = False
-            logger.info("Installed registry plugin: %s", plugin_id)
+            manifest = self._loader.get_manifest(plugin_id)
+            if manifest:
+                self._plugins[plugin_id] = plugin
+                self._manifests[plugin_id] = manifest
+                self._enabled[plugin_id] = False
+                logger.info("Installed registry plugin: %s", plugin_id)
 
         self._clear_removed_tombstone(plugin_id)
         return []
@@ -1445,19 +1521,20 @@ class PluginRegistry:
             repo_name = repo_name_from_url(repo_url)
             plugin_id = plugin_id_from_repo_name(repo_name)
 
-        # Reload external dirs and load the new plugin
-        self._loader._external_dirs = [get_external_plugins_dir()]
-        plugin = self._loader.load_plugin(plugin_id)
-        if plugin is None:
-            errors = self._loader.load_errors.get(plugin_id, [])
-            return errors or [f"Failed to load plugin after install: {plugin_id}"]
+        with self._lock:
+            # Reload external dirs and load the new plugin
+            self._loader._external_dirs = [get_external_plugins_dir()]
+            plugin = self._loader.load_plugin(plugin_id)
+            if plugin is None:
+                errors = self._loader.load_errors.get(plugin_id, [])
+                return errors or [f"Failed to load plugin after install: {plugin_id}"]
 
-        manifest = self._loader.get_manifest(plugin_id)
-        if manifest:
-            self._plugins[plugin_id] = plugin
-            self._manifests[plugin_id] = manifest
-            self._enabled[plugin_id] = False
-            logger.info("Installed git plugin: %s from %s", plugin_id, repo_url)
+            manifest = self._loader.get_manifest(plugin_id)
+            if manifest:
+                self._plugins[plugin_id] = plugin
+                self._manifests[plugin_id] = manifest
+                self._enabled[plugin_id] = False
+                logger.info("Installed git plugin: %s from %s", plugin_id, repo_url)
 
         self._clear_removed_tombstone(plugin_id)
         return []
@@ -1479,26 +1556,27 @@ class PluginRegistry:
         if source.source_type == "builtin":
             return ["Cannot uninstall a built-in plugin"]
 
-        # Cascade-delete all named instances first
         instance_prefix = f"{plugin_id}{INSTANCE_SEPARATOR}"
-        for compound_key in [k for k in list(self._plugins) if k.startswith(instance_prefix)]:
-            self._plugins[compound_key].cleanup()
-            del self._plugins[compound_key]
-            self._manifests.pop(compound_key, None)
-            self._enabled.pop(compound_key, None)
-            self._configs.pop(compound_key, None)
-            self._discovered_vars.pop(compound_key, None)
-            logger.info("Removed instance on uninstall: %s", compound_key)
+        with self._lock:
+            # Cascade-delete all named instances first
+            for compound_key in [k for k in list(self._plugins) if k.startswith(instance_prefix)]:
+                self._plugins[compound_key].cleanup()
+                del self._plugins[compound_key]
+                self._manifests.pop(compound_key, None)
+                self._enabled.pop(compound_key, None)
+                self._configs.pop(compound_key, None)
+                self._discovered_vars.pop(compound_key, None)
+                logger.info("Removed instance on uninstall: %s", compound_key)
 
-        # Disable and unload base plugin
-        if plugin_id in self._plugins:
-            self._plugins[plugin_id].cleanup()
-            del self._plugins[plugin_id]
-        self._manifests.pop(plugin_id, None)
-        self._enabled.pop(plugin_id, None)
-        self._configs.pop(plugin_id, None)
+            # Disable and unload base plugin
+            if plugin_id in self._plugins:
+                self._plugins[plugin_id].cleanup()
+                del self._plugins[plugin_id]
+            self._manifests.pop(plugin_id, None)
+            self._enabled.pop(plugin_id, None)
+            self._configs.pop(plugin_id, None)
 
-        self._loader.unload_plugin(plugin_id)
+            self._loader.unload_plugin(plugin_id)
 
         # Remove the directory
         local_path = Path(source.local_path)
@@ -1527,11 +1605,9 @@ class PluginRegistry:
     @property
     def trigger_plugins(self) -> dict[str, PluginBase]:
         """Return enabled plugins that support event-based triggers."""
-        return {
-            pid: plugin
-            for pid, plugin in self._plugins.items()
-            if self._enabled.get(pid, False) and plugin.supports_triggers
-        }
+        with self._lock:
+            items = list(self._plugins.items())
+            return {pid: plugin for pid, plugin in items if self._enabled.get(pid, False) and plugin.supports_triggers}
 
     def build_template_context(self, board: BoardContext | None = None) -> dict[str, Any]:
         """Build context dictionary for template rendering.
@@ -1548,6 +1624,11 @@ class PluginRegistry:
             Dictionary mapping plugin_id to plugin data
         """
         context: dict[str, Any] = {}
+        # Snapshot-then-release: enabled_plugins copies under the registry
+        # lock and returns.  The lock must NEVER be held across the
+        # submit/wait below — the workers call fetch_plugin_data on other
+        # threads, which takes the lock for its lookups, so a held lock
+        # would deadlock the pool.
         enabled = list(self.enabled_plugins)
 
         if not enabled:

--- a/src/plugins/registry.py
+++ b/src/plugins/registry.py
@@ -25,6 +25,7 @@ from .manifest import PluginManifest, VariableMetadata
 from .previews import load_preview_seed
 from .sources import (
     PluginSource,
+    _dir_lock,
     check_plugin_update_available,
     get_external_plugins_dir,
     install_git_plugin,
@@ -203,6 +204,23 @@ class PluginRegistry:
         logger.info("Created plugin instance: %s", compound_key)
         return []
 
+    def _retire_plugin_object(self, plugin_id: str, plugin: PluginBase) -> None:
+        """Run a removed plugin's ``cleanup()`` on a short-lived daemon thread.
+
+        Mirrors :meth:`PluginLoader._retire_instance` (#1854): ``cleanup()``
+        is plugin-authored code that may join threads or close sockets, and
+        nothing bounds how long that takes — so it must never run under the
+        registry lock, where a wedged plugin would stall every reader.
+        """
+
+        def _run() -> None:
+            try:
+                plugin.cleanup()
+            except Exception:
+                logger.exception("Error cleaning up removed plugin '%s'", plugin_id)
+
+        threading.Thread(target=_run, name=f"plugin-cleanup-{plugin_id}", daemon=True).start()
+
     def delete_instance(self, plugin_id: str, instance_label: str) -> list[str]:
         """Delete a plugin instance.
 
@@ -221,13 +239,14 @@ class PluginRegistry:
             if compound_key not in self._plugins:
                 return [f"Instance not found: {compound_key}"]
 
-            # Clean up the plugin
-            self._plugins[compound_key].cleanup()
-            del self._plugins[compound_key]
+            # State swap under the lock; plugin-authored cleanup() off it.
+            instance = self._plugins.pop(compound_key)
             self._manifests.pop(compound_key, None)
             self._enabled.pop(compound_key, None)
             self._configs.pop(compound_key, None)
             self._discovered_vars.pop(compound_key, None)
+
+        self._retire_plugin_object(compound_key, instance)
 
         logger.info("Deleted plugin instance: %s", compound_key)
         return []
@@ -670,7 +689,10 @@ class PluginRegistry:
         Returns:
             Plugin instance or None if not loaded
         """
-        return self._plugins.get(plugin_id)
+        # Under the lock so a reader can never observe the transient window
+        # inside reload_plugin where the id is absent from _plugins (#1854).
+        with self._lock:
+            return self._plugins.get(plugin_id)
 
     def get_transition_plugin(self, plugin_id: str):
         """Return a loaded *transition* plugin instance, or None.
@@ -685,7 +707,8 @@ class PluginRegistry:
         """
         from .base import TransitionPluginBase  # local import to avoid cycles
 
-        plugin = self._plugins.get(plugin_id)
+        with self._lock:
+            plugin = self._plugins.get(plugin_id)
         if plugin is None or not isinstance(plugin, TransitionPluginBase):
             return None
         return plugin
@@ -699,7 +722,8 @@ class PluginRegistry:
         Returns:
             PluginManifest or None if not loaded
         """
-        return self._manifests.get(plugin_id)
+        with self._lock:
+            return self._manifests.get(plugin_id)
 
     def is_enabled(self, plugin_id: str) -> bool:
         """Check if a plugin is enabled.
@@ -710,7 +734,8 @@ class PluginRegistry:
         Returns:
             True if enabled, False otherwise
         """
-        return self._enabled.get(plugin_id, False)
+        with self._lock:
+            return self._enabled.get(plugin_id, False)
 
     def _plugin_in_use(self, plugin_id: str) -> bool:
         """Return True when the plugin or any of its instances is enabled."""
@@ -757,10 +782,13 @@ class PluginRegistry:
             plugin = self._plugins[plugin_id]
             plugin.enabled = True
             self._enabled[plugin_id] = True
+            stored_config = self._configs.get(plugin_id)
 
-            # Apply stored config
-            if plugin_id in self._configs:
-                plugin.config = self._configs[plugin_id]
+        # Apply stored config with the lock released: the config setter fires
+        # clear_cache()/on_config_change() — plugin-authored code that may
+        # tear down live listeners and take arbitrarily long (#1854).
+        if stored_config is not None:
+            plugin.config = stored_config
 
         logger.info(f"Enabled plugin: {plugin_id}")
         return True
@@ -807,9 +835,12 @@ class PluginRegistry:
             if errors:
                 return errors
 
-            # Store and apply config
+            # Store config under the lock; apply it below with the lock
+            # released — the config setter fires clear_cache() and
+            # on_config_change(), plugin-authored code that may block (#1854).
             self._configs[plugin_id] = config
-            plugin.config = config
+
+        plugin.config = config
 
         logger.debug(f"Updated config for {plugin_id}")
         return []
@@ -831,11 +862,15 @@ class PluginRegistry:
             List of validation errors. Non-empty means the config was applied
             anyway and the caller should log it.
         """
-        with self._lock:
-            errors = self.set_plugin_config(plugin_id, config)
-            if errors and plugin_id in self._plugins:
+        errors = self.set_plugin_config(plugin_id, config)
+        if errors:
+            with self._lock:
+                plugin = self._plugins.get(plugin_id)
+                if plugin is None:
+                    return errors
                 self._configs[plugin_id] = config
-                self._plugins[plugin_id].config = config
+            # Setter fires plugin-authored callbacks — run it unlocked (#1854).
+            plugin.config = config
         return errors
 
     def get_plugin_config(self, plugin_id: str) -> dict[str, Any] | None:
@@ -847,7 +882,8 @@ class PluginRegistry:
         Returns:
             Configuration dictionary or None if not found
         """
-        return self._configs.get(plugin_id)
+        with self._lock:
+            return self._configs.get(plugin_id)
 
     def fetch_plugin_data(self, plugin_id: str, board: BoardContext | None = None) -> PluginResult:
         """Fetch data from a plugin.
@@ -928,7 +964,9 @@ class PluginRegistry:
         """
         base_id, _instance_label = self.parse_instance_key(plugin_id)
 
-        live = self._plugins.get(plugin_id)
+        with self._lock:
+            live = self._plugins.get(plugin_id)
+            stored_config = self._configs.get(plugin_id)
         if live is None:
             raise KeyError(f"Plugin not found: {plugin_id}")
 
@@ -937,7 +975,7 @@ class PluginRegistry:
             raise NotImplementedError(f"Plugin {plugin_id} is a transition plugin (no options)")
 
         # Config comes from the full instance key, the class from the base id.
-        effective_config = dict(self._configs.get(plugin_id) or {})
+        effective_config = dict(stored_config or {})
         # Unsaved form values win: the user is browsing the catalog *in order
         # to* fill the form in, so the credentials they just typed are the ones
         # that matter. The HTTP layer un-masks the redacted secrets the form
@@ -1194,56 +1232,61 @@ class PluginRegistry:
         Returns:
             Reloaded plugin instance or None if failed
         """
-        # The whole reload runs under the lock: between the unload and the
-        # re-add the id is absent from _plugins, and readers must never
-        # observe that window.  Nothing in here shells out — the loader's
-        # reload is importlib + file reads, and enable_plugin cannot hit its
-        # install-on-demand path because the plugin is present again by then.
+        # The unload -> re-add window runs under the lock: between them the
+        # id is absent from _plugins, and readers must never observe that
+        # window.  Nothing under the lock shells out — the loader's reload is
+        # importlib + file reads.  Plugin-authored code stays OFF the lock
+        # (#1854): the old instance's cleanup() is retired to a daemon
+        # thread, and the state restore below (whose config setter fires
+        # on_config_change) runs after the plugin is present again and the
+        # lock is released.  enable_plugin cannot hit its install-on-demand
+        # path because the plugin is present again by then.
         with self._lock:
             # Remember enabled state and config
             was_enabled = self._enabled.get(plugin_id, False)
             config = self._configs.get(plugin_id, {})
 
             # Unload
-            if plugin_id in self._plugins:
-                self._plugins[plugin_id].cleanup()
-                del self._plugins[plugin_id]
+            old_plugin = self._plugins.pop(plugin_id, None)
+            if old_plugin is not None:
+                self._retire_plugin_object(plugin_id, old_plugin)
             if plugin_id in self._manifests:
                 del self._manifests[plugin_id]
 
             # Reload
             plugin = self._loader.reload_plugin(plugin_id)
-            if plugin:
-                manifest = self._loader.get_manifest(plugin_id)
-                if manifest:
-                    self._plugins[plugin_id] = plugin
-                    self._manifests[plugin_id] = manifest
-                    self.clear_discovered_cache(plugin_id)
+            manifest = self._loader.get_manifest(plugin_id) if plugin else None
+            if not plugin or not manifest:
+                return None
 
-                    # Restore state
-                    if was_enabled:
-                        self.enable_plugin(plugin_id)
-                    if config:
-                        errors = self.set_plugin_config(plugin_id, config)
-                        if errors:
-                            # New version's validate_config rejected the old config
-                            # (e.g. a required field was added/renamed).  Apply the
-                            # config directly so the user's data isn't silently lost.
-                            # The user can re-save through the UI to normalise it.
-                            logger.warning(
-                                "Config validation failed after reload for '%s': %s"
-                                " — applying raw config to avoid data loss",
-                                plugin_id,
-                                errors,
-                            )
-                            self._configs[plugin_id] = config
-                            plugin.config = config
+            self._plugins[plugin_id] = plugin
+            self._manifests[plugin_id] = manifest
+            self.clear_discovered_cache(plugin_id)
 
-                    self._rebuild_instances(plugin_id, manifest)
+        # Restore state — the plugin is visible again, so this can (and
+        # must) run without the lock: both paths apply the config through
+        # the plugin-authored setter.
+        if was_enabled:
+            self.enable_plugin(plugin_id)
+        if config:
+            errors = self.set_plugin_config(plugin_id, config)
+            if errors:
+                # New version's validate_config rejected the old config
+                # (e.g. a required field was added/renamed).  Apply the
+                # config directly so the user's data isn't silently lost.
+                # The user can re-save through the UI to normalise it.
+                logger.warning(
+                    "Config validation failed after reload for '%s': %s — applying raw config to avoid data loss",
+                    plugin_id,
+                    errors,
+                )
+                with self._lock:
+                    self._configs[plugin_id] = config
+                plugin.config = config
 
-                    return plugin
+        self._rebuild_instances(plugin_id, manifest)
 
-        return None
+        return plugin
 
     def _rebuild_instances(self, plugin_id: str, manifest: PluginManifest) -> None:
         """Recreate all named instances of *plugin_id* after a base reload.
@@ -1259,40 +1302,47 @@ class PluginRegistry:
         """
         prefix = f"{plugin_id}{INSTANCE_SEPARATOR}"
         with self._lock:
-            for compound_key in [k for k in list(self._plugins) if k.startswith(prefix)]:
-                new_instance = self._loader.create_instance(plugin_id)
-                if new_instance is None:
-                    logger.warning(
-                        "Failed to rebuild instance '%s' after reload — keeping the old instance",
-                        compound_key,
-                    )
-                    continue
+            compound_keys = [k for k in list(self._plugins) if k.startswith(prefix)]
 
-                old_instance = self._plugins[compound_key]
-                try:
-                    old_instance.cleanup()
-                except Exception:
-                    logger.exception("Error cleaning up old instance '%s'", compound_key)
+        for compound_key in compound_keys:
+            new_instance = self._loader.create_instance(plugin_id)
+            if new_instance is None:
+                logger.warning(
+                    "Failed to rebuild instance '%s' after reload — keeping the old instance",
+                    compound_key,
+                )
+                continue
+
+            with self._lock:
+                old_instance = self._plugins.get(compound_key)
+                if old_instance is None:
+                    # Deleted concurrently — nothing to replace.
+                    continue
 
                 self._plugins[compound_key] = new_instance
                 self._manifests[compound_key] = manifest
                 self.clear_discovered_cache(compound_key)
-
-                # Restore state (mirrors the base-plugin restore above)
-                if self._enabled.get(compound_key, False):
-                    self.enable_plugin(compound_key)
+                was_enabled = self._enabled.get(compound_key, False)
                 instance_config = self._configs.get(compound_key, {})
-                if instance_config:
-                    errors = self.apply_stored_config(compound_key, instance_config)
-                    if errors:
-                        logger.warning(
-                            "Config validation failed after reload for '%s': %s"
-                            " — applying raw config to avoid data loss",
-                            compound_key,
-                            errors,
-                        )
 
-                logger.info("Rebuilt plugin instance after reload: %s", compound_key)
+            # Plugin-authored code off the lock (#1854): old instance's
+            # cleanup() on a daemon thread; enable/config restore fires the
+            # config setter (clear_cache/on_config_change) unlocked.
+            self._retire_plugin_object(compound_key, old_instance)
+
+            # Restore state (mirrors the base-plugin restore above)
+            if was_enabled:
+                self.enable_plugin(compound_key)
+            if instance_config:
+                errors = self.apply_stored_config(compound_key, instance_config)
+                if errors:
+                    logger.warning(
+                        "Config validation failed after reload for '%s': %s — applying raw config to avoid data loss",
+                        compound_key,
+                        errors,
+                    )
+
+            logger.info("Rebuilt plugin instance after reload: %s", compound_key)
 
     def get_load_errors(self) -> dict[str, list[str]]:
         """Get plugin load errors.
@@ -1557,11 +1607,12 @@ class PluginRegistry:
             return ["Cannot uninstall a built-in plugin"]
 
         instance_prefix = f"{plugin_id}{INSTANCE_SEPARATOR}"
+        retired: list[tuple[str, PluginBase]] = []
         with self._lock:
-            # Cascade-delete all named instances first
+            # Cascade-delete all named instances first.  State swap only —
+            # plugin-authored cleanup() is retired off the lock below (#1854).
             for compound_key in [k for k in list(self._plugins) if k.startswith(instance_prefix)]:
-                self._plugins[compound_key].cleanup()
-                del self._plugins[compound_key]
+                retired.append((compound_key, self._plugins.pop(compound_key)))
                 self._manifests.pop(compound_key, None)
                 self._enabled.pop(compound_key, None)
                 self._configs.pop(compound_key, None)
@@ -1570,17 +1621,22 @@ class PluginRegistry:
 
             # Disable and unload base plugin
             if plugin_id in self._plugins:
-                self._plugins[plugin_id].cleanup()
-                del self._plugins[plugin_id]
+                retired.append((plugin_id, self._plugins.pop(plugin_id)))
             self._manifests.pop(plugin_id, None)
             self._enabled.pop(plugin_id, None)
             self._configs.pop(plugin_id, None)
 
             self._loader.unload_plugin(plugin_id)
 
-        # Remove the directory
+        for retired_key, retired_plugin in retired:
+            self._retire_plugin_object(retired_key, retired_plugin)
+
+        # Remove the directory — under the same per-directory lock the
+        # install/update path takes (#1854), so an overlapping update and
+        # uninstall of one plugin serialize instead of racing git vs rmtree.
         local_path = Path(source.local_path)
-        remove_external_plugin(local_path)
+        with _dir_lock(plugin_id):
+            remove_external_plugin(local_path)
 
         # Persist the deliberate removal (#1394): purge the stored configs for
         # the base plugin and every named instance, then tombstone the id so

--- a/src/plugins/sources.py
+++ b/src/plugins/sources.py
@@ -17,6 +17,7 @@ import os
 import re
 import shutil
 import subprocess
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -57,6 +58,24 @@ _ALLOWED_SCHEMES = ("https://",)
 
 # Where the plugin code lives inside a cloned repo (root by default)
 _PLUGIN_SUBDIR = ""
+
+# One lock per plugin directory (#1828): two concurrent clone_or_update_repo
+# calls for the same plugin would run ``git fetch``/``git reset --hard`` in the
+# same working tree at once and trip over each other's index.lock.  Keyed by
+# plugin id so operations on *different* plugins still run in parallel.
+_repo_dir_locks: dict[str, threading.Lock] = {}
+_repo_dir_locks_guard = threading.Lock()
+
+
+def _dir_lock(plugin_id: str) -> threading.Lock:
+    """Return the lock serializing git operations in *plugin_id*'s directory."""
+    with _repo_dir_locks_guard:
+        lock = _repo_dir_locks.get(plugin_id)
+        if lock is None:
+            lock = threading.Lock()
+            _repo_dir_locks[plugin_id] = lock
+        return lock
+
 
 # ── data classes ─────────────────────────────────────────────────────────────
 
@@ -376,11 +395,73 @@ def clone_or_update_repo(
     if _candidate == _ext_root:
         return False, "Refusing to install plugin at root directory"
 
-    # ── Update path (no URL required) ─────────────────────────────────────────
-    if os.path.isdir(os.path.join(_candidate, ".git")):
+    # Everything that touches the plugin's directory — the install/update
+    # branch decision included — runs under its per-directory lock (#1828), so
+    # concurrent operations on the same plugin serialize instead of corrupting
+    # the working tree.  Operations on other plugins take other locks.
+    with _dir_lock(plugin_id):
+        # ── Update path (no URL required) ─────────────────────────────────────
+        if os.path.isdir(os.path.join(_candidate, ".git")):
+            try:
+                subprocess.run(
+                    ["git", "fetch", "--depth=1", "origin", "HEAD"],
+                    cwd=_candidate,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    timeout=120,
+                    env=env,
+                )
+                subprocess.run(
+                    ["git", "reset", "--hard", "FETCH_HEAD"],
+                    cwd=_candidate,
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                    env=env,
+                )
+                logger.info("Updated existing plugin clone at %s", _candidate)
+                return True, ""
+            except subprocess.SubprocessError as exc:
+                stderr = (getattr(exc, "stderr", None) or "").strip()
+                msg = f"git fetch/reset failed: {stderr}" if stderr else f"git fetch/reset failed: {exc}"
+                return False, msg
+
+        # ── Fresh install — validate URL and optional branch ──────────────────
+        ok, err = _validate_git_url(repo_url)
+        if not ok:
+            return False, err
+
+        if branch:
+            ok, err = _validate_git_ref(branch)
+            if not ok:
+                return False, err
+
+        # ── git init + write remote URL to config + git fetch ─────────────────
+        # Writing repo_url to .git/config (a normal file write) avoids passing a
+        # user-controlled value as a subprocess argument (py/command-line-injection).
+        os.makedirs(_candidate, exist_ok=True)
         try:
             subprocess.run(
-                ["git", "fetch", "--depth=1", "origin", "HEAD"],
+                ["git", "init", "--quiet"],
+                cwd=_candidate,
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                env=env,
+            )
+            _git_config_path = os.path.join(_candidate, ".git", "config")
+            with open(_git_config_path, "a") as _cfg:
+                _cfg.write(f'[remote "origin"]\n\turl = {repo_url}\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n')
+            _fetch_cmd = ["git", "fetch", "--depth=1", "origin"]
+            if branch:
+                _fetch_cmd.append(branch)
+            else:
+                _fetch_cmd.append("HEAD")
+            subprocess.run(
+                _fetch_cmd,
                 cwd=_candidate,
                 check=True,
                 capture_output=True,
@@ -397,73 +478,16 @@ def clone_or_update_repo(
                 timeout=30,
                 env=env,
             )
-            logger.info("Updated existing plugin clone at %s", _candidate)
+            logger.info("Installed external plugin repository to %s", _candidate)
             return True, ""
         except subprocess.SubprocessError as exc:
+            shutil.rmtree(_candidate, ignore_errors=True)
             stderr = (getattr(exc, "stderr", None) or "").strip()
-            msg = f"git fetch/reset failed: {stderr}" if stderr else f"git fetch/reset failed: {exc}"
+            msg = f"git clone failed: {stderr}" if stderr else f"git clone failed: {exc}"
             return False, msg
-
-    # ── Fresh install — validate URL and optional branch ──────────────────────
-    ok, err = _validate_git_url(repo_url)
-    if not ok:
-        return False, err
-
-    if branch:
-        ok, err = _validate_git_ref(branch)
-        if not ok:
-            return False, err
-
-    # ── git init + write remote URL to config + git fetch ─────────────────────
-    # Writing repo_url to .git/config (a normal file write) avoids passing a
-    # user-controlled value as a subprocess argument (py/command-line-injection).
-    os.makedirs(_candidate, exist_ok=True)
-    try:
-        subprocess.run(
-            ["git", "init", "--quiet"],
-            cwd=_candidate,
-            check=True,
-            capture_output=True,
-            text=True,
-            timeout=30,
-            env=env,
-        )
-        _git_config_path = os.path.join(_candidate, ".git", "config")
-        with open(_git_config_path, "a") as _cfg:
-            _cfg.write(f'[remote "origin"]\n\turl = {repo_url}\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n')
-        _fetch_cmd = ["git", "fetch", "--depth=1", "origin"]
-        if branch:
-            _fetch_cmd.append(branch)
-        else:
-            _fetch_cmd.append("HEAD")
-        subprocess.run(
-            _fetch_cmd,
-            cwd=_candidate,
-            check=True,
-            capture_output=True,
-            text=True,
-            timeout=120,
-            env=env,
-        )
-        subprocess.run(
-            ["git", "reset", "--hard", "FETCH_HEAD"],
-            cwd=_candidate,
-            check=True,
-            capture_output=True,
-            text=True,
-            timeout=30,
-            env=env,
-        )
-        logger.info("Installed external plugin repository to %s", _candidate)
-        return True, ""
-    except subprocess.SubprocessError as exc:
-        shutil.rmtree(_candidate, ignore_errors=True)
-        stderr = (getattr(exc, "stderr", None) or "").strip()
-        msg = f"git clone failed: {stderr}" if stderr else f"git clone failed: {exc}"
-        return False, msg
-    except OSError as exc:
-        shutil.rmtree(_candidate, ignore_errors=True)
-        return False, f"git clone failed (I/O error): {exc}"
+        except OSError as exc:
+            shutil.rmtree(_candidate, ignore_errors=True)
+            return False, f"git clone failed (I/O error): {exc}"
 
 
 def get_remote_head_sha(dest_dir: Path) -> str | None:

--- a/src/templates/engine.py
+++ b/src/templates/engine.py
@@ -1568,7 +1568,9 @@ class TemplateEngine:
             return {}
 
         max_lengths: dict[str, int] = {}
-        for plugin_id, manifest in self._plugin_registry._manifests.items():
+        # list() snapshots atomically, so a concurrent plugin install can't
+        # mutate the manifests dict mid-iteration (#1828).
+        for plugin_id, manifest in list(self._plugin_registry._manifests.items()):
             for var_name, max_len in manifest.max_lengths.items():
                 full_name = f"{plugin_id}.{var_name}"
                 max_lengths[full_name] = max_len

--- a/tests/test_plugin_registry_locking.py
+++ b/tests/test_plugin_registry_locking.py
@@ -225,3 +225,162 @@ def test_clear_update_status_removes_cached_flag(registry):
     assert registry.get_update_status() == {}
     # Clearing an id with no cached status is a no-op, not an error.
     registry.clear_update_status("missing")
+
+
+# ── #1854 review follow-ups ──────────────────────────────────────────────────
+#
+# Bounded-time concurrency probes.  Each test drives a deterministic
+# interleaving with Events; the only timing involved is a generous upper
+# bound on operations that must not block.
+
+
+def _call_on_thread(fn):
+    """Run *fn* on a daemon thread; return (thread, done_event, results)."""
+    done = threading.Event()
+    result: list = []
+
+    def _run():
+        result.append(fn())
+        done.set()
+
+    t = threading.Thread(target=_run, daemon=True)
+    t.start()
+    return t, done, result
+
+
+def test_blocking_instance_cleanup_does_not_stall_readers(registry):
+    """delete_instance must not run plugin-authored cleanup() under the
+    registry lock: a wedged cleanup (e.g. HA MQTT loop_stop joining a network
+    thread) would otherwise stall every render and plugin listing."""
+    cleanup_entered = threading.Event()
+    cleanup_release = threading.Event()
+
+    stub = _plugin_stub("wedge")
+
+    def _wedged_cleanup():
+        cleanup_entered.set()
+        assert cleanup_release.wait(timeout=30)
+
+    stub.cleanup.side_effect = _wedged_cleanup
+
+    key = registry.make_instance_key("wedge", "inst")
+    registry._plugins["wedge"] = _plugin_stub("wedge")
+    registry._plugins[key] = stub
+    registry._enabled[key] = True
+    registry._configs[key] = {}
+
+    try:
+        _del_thread, del_done, _ = _call_on_thread(lambda: registry.delete_instance("wedge", "inst"))
+        assert cleanup_entered.wait(timeout=5), "cleanup() was never invoked"
+
+        _read_thread, read_done, read_result = _call_on_thread(registry.list_plugins)
+        assert read_done.wait(timeout=2), (
+            "list_plugins blocked behind a wedged plugin cleanup — cleanup ran under the registry lock"
+        )
+        assert isinstance(read_result[0], list)
+    finally:
+        cleanup_release.set()
+    assert del_done.wait(timeout=5)
+
+
+def test_uninstall_directory_removal_holds_the_plugin_dir_lock(registry, mock_loader, tmp_path):
+    """uninstall must take the same per-directory lock as clone_or_update_repo
+    so an overlapping update + uninstall of one plugin serialize instead of
+    racing rmtree against git."""
+    source = MagicMock()
+    source.source_type = "external"
+    source.local_path = str(tmp_path / "victim")
+    mock_loader.get_source.return_value = source
+
+    remove_called = threading.Event()
+
+    with (
+        patch("src.plugins.registry.remove_external_plugin") as remove_mock,
+        patch("src.config_manager.get_config_manager", return_value=MagicMock()),
+    ):
+        remove_mock.side_effect = lambda path: (remove_called.set(), True)[1]
+
+        # Simulate an in-flight update of the same plugin holding its lock.
+        dir_lock = sources._dir_lock("victim")
+        dir_lock.acquire()
+        try:
+            _t, done, result = _call_on_thread(lambda: registry.uninstall_external_plugin("victim"))
+            assert not remove_called.wait(timeout=0.3), (
+                "remove_external_plugin ran while another thread held the plugin's directory lock"
+            )
+        finally:
+            dir_lock.release()
+
+        assert done.wait(timeout=5)
+        assert remove_called.is_set()
+        assert result[0] == []
+
+
+def test_registry_lock_blocks_readers_while_a_mutator_holds_it(registry):
+    """Mutual exclusion, proven end-to-end: a mutator paused inside the lock
+    (validate_config runs under it) blocks list_plugins until it releases."""
+    entered = threading.Event()
+    release = threading.Event()
+
+    stub = _plugin_stub("gate")
+
+    def _paused_validate(config):
+        entered.set()
+        assert release.wait(timeout=30)
+        return []
+
+    stub.validate_config.side_effect = _paused_validate
+    stub._validate_refresh_seconds.return_value = []
+    registry._plugins["gate"] = stub
+
+    _writer, writer_done, _ = _call_on_thread(lambda: registry.set_plugin_config("gate", {"a": 1}))
+    assert entered.wait(timeout=5)
+
+    _reader, reader_done, _ = _call_on_thread(registry.list_plugins)
+    assert not reader_done.wait(timeout=0.3), (
+        "list_plugins completed while a mutator held the registry lock — no mutual exclusion"
+    )
+
+    release.set()
+    assert writer_done.wait(timeout=5)
+    assert reader_done.wait(timeout=5)
+
+
+@pytest.mark.parametrize(
+    "reader_name",
+    ["get_plugin", "get_transition_plugin", "get_manifest", "is_enabled", "get_plugin_config"],
+)
+def test_point_readers_cannot_observe_the_reload_window(registry, mock_loader, reader_name):
+    """The point readers must take the registry lock: during reload_plugin the
+    id is briefly absent from _plugins/_manifests, and an unlocked reader
+    could observe that window (the documented invariant forbids it)."""
+    in_window = threading.Event()
+    release = threading.Event()
+
+    new_plugin = _plugin_stub("rw")
+    manifest = MagicMock()
+    manifest.id = "rw"
+    registry._plugins["rw"] = _plugin_stub("rw")
+    registry._manifests["rw"] = manifest
+    registry._enabled["rw"] = False
+
+    def _paused_reload(plugin_id):
+        in_window.set()
+        assert release.wait(timeout=30)
+        return new_plugin
+
+    mock_loader.reload_plugin.side_effect = _paused_reload
+    mock_loader.get_manifest.return_value = manifest
+
+    _writer, writer_done, _ = _call_on_thread(lambda: registry.reload_plugin("rw"))
+    assert in_window.wait(timeout=5)
+
+    reader_fn = getattr(registry, reader_name)
+    _reader, reader_done, reader_result = _call_on_thread(lambda: reader_fn("rw"))
+    assert not reader_done.wait(timeout=0.3), f"{reader_name} returned mid-reload — it does not take the registry lock"
+
+    release.set()
+    assert writer_done.wait(timeout=5)
+    assert reader_done.wait(timeout=5)
+    if reader_name == "get_plugin":
+        assert reader_result[0] is new_plugin

--- a/tests/test_plugin_registry_locking.py
+++ b/tests/test_plugin_registry_locking.py
@@ -1,0 +1,227 @@
+"""Concurrency tests for PluginRegistry/PluginLoader shared state (#1828).
+
+PR #1809 moved plugin install/update work off the event loop and onto worker
+threads (``asyncio.to_thread``), which removed the accidental serialization
+the loop provided.  Registry mutations now run concurrently with request
+handlers that iterate the same dicts, and two updates of the same plugin can
+run git in the same directory at once.  These tests drive those exact
+interleavings.
+"""
+
+import sys
+import threading
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import src.plugins.sources as sources
+from src.plugins.base import PluginBase
+from src.plugins.registry import PluginRegistry
+from src.plugins.sources import clone_or_update_repo
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def mock_loader():
+    """Create a mock PluginLoader (same shape as tests/test_plugin_registry.py)."""
+    loader = MagicMock()
+    loader.load_all_plugins.return_value = {}
+    loader.load_errors = {}
+    loader.get_manifest.return_value = None
+    loader.reload_plugin.return_value = None
+    return loader
+
+
+@pytest.fixture
+def registry(mock_loader):
+    """Create a PluginRegistry with a mocked loader."""
+    with patch("src.plugins.registry.PluginLoader", return_value=mock_loader):
+        return PluginRegistry(plugins_dir=Path("/fake/plugins"))
+
+
+def _plugin_stub(plugin_id: str, supports_triggers: bool = True) -> MagicMock:
+    """A PluginBase-shaped stub with the attributes the read paths touch."""
+    plugin = MagicMock(spec=PluginBase)
+    plugin.plugin_id = plugin_id
+    plugin.supports_triggers = supports_triggers
+    plugin.enabled = True
+    return plugin
+
+
+def _run_concurrently(*fns, join_timeout: float = 60.0) -> list[BaseException]:
+    """Run each callable on its own thread, released together by a barrier.
+
+    Returns every exception raised in any thread (empty list = clean run).
+    """
+    errors: list[BaseException] = []
+    errors_lock = threading.Lock()
+    start = threading.Barrier(len(fns))
+
+    def _wrap(fn):
+        def _inner():
+            try:
+                start.wait(timeout=10)
+                fn()
+            except BaseException as exc:
+                with errors_lock:
+                    errors.append(exc)
+
+        return _inner
+
+    threads = [threading.Thread(target=_wrap(fn)) for fn in fns]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=join_timeout)
+    return errors
+
+
+@pytest.fixture
+def fast_thread_switching():
+    """Force very frequent thread switches so races interleave reliably."""
+    previous = sys.getswitchinterval()
+    sys.setswitchinterval(1e-6)
+    yield
+    sys.setswitchinterval(previous)
+
+
+def _seed_plugins(registry: PluginRegistry, count: int = 400) -> None:
+    for i in range(count):
+        pid = f"seed_{i}"
+        registry._plugins[pid] = _plugin_stub(pid)
+        registry._enabled[pid] = True
+
+
+# ── registry iteration vs concurrent mutation ────────────────────────────────
+
+
+def _churn_until(registry: PluginRegistry, stop: threading.Event) -> None:
+    """Mutate ``registry._plugins`` for as long as the reader is running.
+
+    Same dict operations install_from_registry/uninstall perform, driven
+    directly so the interleaving does not depend on git or the loader.  Keys
+    are added in a batch before being removed so the dict's size actually
+    differs from the reader's snapshot for a meaningful window.
+    """
+    stub = _plugin_stub("churn")
+    while not stop.is_set():
+        for i in range(10):
+            registry._plugins[f"x_{i}"] = stub
+        for i in range(10):
+            del registry._plugins[f"x_{i}"]
+
+
+def test_list_plugins_survives_concurrent_mutation(registry, fast_thread_switching):
+    """GET /plugins iterating while an install registers a plugin must not
+    raise ``RuntimeError: dictionary changed size during iteration``."""
+    _seed_plugins(registry)
+    stop = threading.Event()
+
+    def reader():
+        try:
+            for _ in range(300):
+                registry.list_plugins()
+        finally:
+            stop.set()
+
+    errors = _run_concurrently(reader, lambda: _churn_until(registry, stop))
+    assert errors == [], f"concurrent list_plugins/mutation raised: {errors!r}"
+
+
+def test_trigger_plugins_survives_concurrent_mutation(registry, fast_thread_switching):
+    """The trigger_plugins property must tolerate a concurrent install/uninstall."""
+    _seed_plugins(registry)
+    stop = threading.Event()
+
+    def reader():
+        try:
+            for _ in range(300):
+                _ = registry.trigger_plugins
+        finally:
+            stop.set()
+
+    errors = _run_concurrently(reader, lambda: _churn_until(registry, stop))
+    assert errors == [], f"concurrent trigger_plugins/mutation raised: {errors!r}"
+
+
+# ── per-plugin-directory git serialization ───────────────────────────────────
+
+
+class _ConcurrencyProbe:
+    """subprocess.run stand-in that records how many calls overlap in time."""
+
+    def __init__(self, hold_seconds: float):
+        self.hold_seconds = hold_seconds
+        self._lock = threading.Lock()
+        self.current = 0
+        self.max_seen = 0
+
+    def __call__(self, *args, **kwargs):
+        with self._lock:
+            self.current += 1
+            self.max_seen = max(self.max_seen, self.current)
+        time.sleep(self.hold_seconds)
+        with self._lock:
+            self.current -= 1
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = ""
+        result.stderr = ""
+        return result
+
+
+def _run_repo_ops(plugin_ids: list[str], external_dir: Path, probe) -> list:
+    """Call clone_or_update_repo for each id on its own thread, simultaneously."""
+    results = []
+    results_lock = threading.Lock()
+
+    def _op(plugin_id):
+        def _call():
+            outcome = clone_or_update_repo("", plugin_id, external_dir=external_dir)
+            with results_lock:
+                results.append(outcome)
+
+        return _call
+
+    with patch.object(sources.subprocess, "run", probe):
+        errors = _run_concurrently(*[_op(pid) for pid in plugin_ids])
+    assert errors == [], f"clone_or_update_repo raised: {errors!r}"
+    return results
+
+
+def test_concurrent_same_plugin_repo_ops_serialize(tmp_path):
+    """Two updates of the same plugin must never run git in its directory at
+    the same time (index.lock contention -> 500s)."""
+    (tmp_path / "sameplugin" / ".git").mkdir(parents=True)
+    probe = _ConcurrencyProbe(hold_seconds=0.2)
+
+    results = _run_repo_ops(["sameplugin", "sameplugin"], tmp_path, probe)
+
+    assert results == [(True, ""), (True, "")]
+    assert probe.max_seen == 1, f"same-directory git ops overlapped (max concurrency {probe.max_seen})"
+
+
+def test_different_plugin_repo_ops_parallel(tmp_path):
+    """Serialization is per plugin directory: distinct plugins stay parallel."""
+    (tmp_path / "aaa" / ".git").mkdir(parents=True)
+    (tmp_path / "bbb" / ".git").mkdir(parents=True)
+    probe = _ConcurrencyProbe(hold_seconds=0.3)
+
+    results = _run_repo_ops(["aaa", "bbb"], tmp_path, probe)
+
+    assert results == [(True, ""), (True, "")]
+    assert probe.max_seen == 2, "different-plugin git ops were over-serialized"
+
+
+# ── public replacement for api_server's direct _update_status.pop ────────────
+
+
+def test_clear_update_status_removes_cached_flag(registry):
+    registry._update_status["foo"] = True
+    registry.clear_update_status("foo")
+    assert registry.get_update_status() == {}
+    # Clearing an id with no cached status is a no-op, not an error.
+    registry.clear_update_status("missing")

--- a/tests/test_settings_plugins.py
+++ b/tests/test_settings_plugins.py
@@ -165,6 +165,9 @@ def test_auto_apply_updates_external_plugin(tmp_path):
     registry.get_plugin_source.return_value = source
     registry.reload_plugin.return_value = MagicMock()
     registry._update_status = {plugin_id: True}
+    # The auto-apply loop clears the flag through the public locked method
+    # (#1828); mirror the real registry's behavior on this mock.
+    registry.clear_update_status.side_effect = lambda pid: registry._update_status.pop(pid, None)
 
     with (
         patch("src.plugins.sources.get_external_plugins_dir", return_value=tmp_path),
@@ -235,6 +238,7 @@ def test_auto_apply_handles_git_fetch_failure(tmp_path):
     source.local_path = str(plugin_dir)
     registry.get_plugin_source.return_value = source
     registry._update_status = {plugin_id: True}
+    registry.clear_update_status.side_effect = lambda pid: registry._update_status.pop(pid, None)
 
     with (
         patch("src.plugins.sources.get_external_plugins_dir", return_value=tmp_path),
@@ -258,6 +262,7 @@ def test_auto_apply_handles_reload_failure(tmp_path):
     registry.get_plugin_source.return_value = source
     registry.reload_plugin.return_value = None  # reload failed
     registry._update_status = {plugin_id: True}
+    registry.clear_update_status.side_effect = lambda pid: registry._update_status.pop(pid, None)
 
     with (
         patch("src.plugins.sources.get_external_plugins_dir", return_value=tmp_path),
@@ -290,6 +295,7 @@ def test_auto_apply_multiple_plugins_partial_success(tmp_path):
     registry.get_plugin_source.side_effect = get_source
     registry.reload_plugin.return_value = MagicMock()
     registry._update_status = {good_id: True, bad_id: True}
+    registry.clear_update_status.side_effect = lambda pid: registry._update_status.pop(pid, None)
 
     def fake_clone(url, pid, external_dir):
         return (True, "") if pid == good_id else (False, "fetch error")


### PR DESCRIPTION
Closes #1828. Backend-rework **Stack 0**, stacked on #1853 (chain: #1851 → #1853 → this). Prerequisite for moving the remaining blocking I/O off the event loop (#1826).

## Why

PR #1809 moved plugin install/update to `asyncio.to_thread`, which traded away the serialization the single event loop provided for free. `PluginRegistry`/`PluginLoader` mutable state was entirely unlocked (`threading` wasn't even imported in registry.py): `GET /plugins` iterating `_plugins` during a concurrent install raises `RuntimeError: dictionary changed size during iteration`, and two overlapping updates of the same plugin could both run `git fetch`/`git reset --hard` in one working tree (opaque `index.lock` 500s).

## Design

- **One shared `threading.RLock`** created by `PluginRegistry`, passed into its `PluginLoader` — a single lock across both objects because the registry reaches into loader state on the install paths; no ordering deadlocks possible.
- **Snapshot-under-lock iteration** at every iteration site (list_plugins, enabled_plugins, trigger_plugins, variable maps, …); mutations guarded end-to-end.
- **The deadlock rule**: `build_template_context` snapshots `enabled_plugins` under the lock and *releases before* the fetch fan-out — workers re-acquire briefly inside `fetch_plugin_data`. The deliberate `shutdown(wait=False, cancel_futures=True)` executor pattern is untouched.
- **Never held across git**: install paths do the 120 s git work *before* taking the registry lock; the state swap alone is locked.
- **Per-plugin-directory lock** in `sources.py` around `clone_or_update_repo`'s git/rmtree body — same-plugin ops serialize, different plugins stay parallel; the CodeQL path-injection barrier block is wrapped, not restructured.
- New public `registry.clear_update_status()` replaces api_server's three direct `_update_status.pop()` reaches; two extra unlocked iteration sites found while sweeping (api_server transition listing, template engine `_manifests`) hardened the same way.

## Zero-regression evidence

**Fail-first** (first race-test draft was vacuous — writer finished before the reader overlapped; rebuilt with sustained churn + `sys.setswitchinterval(1e-6)`, then deterministic 6/6 pre-fix failures):
```
E   AssertionError: concurrent list_plugins/mutation raised: [RuntimeError('dictionary changed size during iteration')]
E   AssertionError: same-directory git ops overlapped (max concurrency 2)
```
Post-fix: new suite **5/5** (incl. an over-serialization guard proving different plugins still clone in parallel), stable across repeated runs.

**Regression**: 1566 passed across every plugin/registry/loader/engine/template/transition suite + `test_plugin_install_event_loop` + `test_plugin_lifecycle_round_trip` + route-inventory golden. The only 2 failures are the pre-existing `generative_dashboard` seed gap, fixed by #1852 (verified pre-existing via stash on the unmodified tree). Two `test_settings_plugins.py` assertions were re-wired to the new `clear_update_status` contract without weakening (the mock's side_effect still performs the pop so the same ids are verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Par2E2Nh65PyDF1q9TARJP