### PR TITLE
feat(web): surface per-board init errors in the UI

### DIFF
--- a/web/app/routes/home.tsx
+++ b/web/app/routes/home.tsx
@@ -13,6 +13,7 @@ import { Home as HomeIcon, Info } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { ActivePageDisplay } from "@/components/active-page-display";
+import { BoardInitErrorBanner } from "@/components/board-init-error-banner";
 import { SilenceImminentBanner } from "@/components/silence-imminent-banner";
 import { useWizard } from "@/components/wizard-provider";
 import { useTranslations } from "@/i18n/translations";
@@ -61,6 +62,7 @@ export default function Home() {
         )}
 
         <PageSection>
+          <BoardInitErrorBanner />
           <SilenceImminentBanner />
           <ActivePageDisplay />
         </PageSection>

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -132,6 +132,9 @@
     "description": "Überwachen Sie die Anzeige Ihres Boards und die Systemaktivität",
     "noBoardConfigured": "Kein Board konfiguriert",
     "noBoardDescription": "Ihr Board ist noch nicht eingerichtet. Verbinden Sie Ihr Board, um Inhalte anzuzeigen.",
+    "boardInitErrorTitle": "{boardName} ist nicht verfügbar",
+    "boardInitErrorTitleUnnamed": "Ein Board ist nicht verfügbar",
+    "boardInitErrorOpenSettings": "Board-Einstellungen öffnen",
     "runSetupWizard": "Einrichtungsassistent starten",
     "silenceImminentTitle": "Silence starts in {minutes, plural, =0 {less than a minute} one {# minute} other {# minutes}}",
     "silenceImminentDescription": "Switch to “{pageName}” now so you don't have to wait for the schedule to catch up.",
@@ -935,6 +938,11 @@
       "resumeToggle": "Resume sends",
       "badge": "Paused",
       "tooltip": "When paused, FiestaBoard does not push anything to this board — scheduled pages, manual sends, plugin triggers, and MQTT commands are all blocked until you resume."
+    },
+    "initError": {
+      "badge": "Nicht verfügbar",
+      "title": "Dieses Board konnte nicht initialisiert werden",
+      "hint": "Korrigieren Sie die Verbindungsdaten unten — beim Speichern wird die Verbindung erneut versucht."
     },
     "deviceTypeAriaLabel": "Boardtyp und Größe",
     "deviceGroupLabel": "Geräte",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -88,6 +88,9 @@
     "description": "Monitor your board display and system activity",
     "noBoardConfigured": "No board configured",
     "noBoardDescription": "Your board is not set up yet. Connect your board to start displaying content.",
+    "boardInitErrorTitle": "{boardName} is unavailable",
+    "boardInitErrorTitleUnnamed": "A board is unavailable",
+    "boardInitErrorOpenSettings": "Open board settings",
     "runSetupWizard": "Run Setup Wizard",
     "silenceImminentTitle": "Silence starts in {minutes, plural, =0 {less than a minute} one {# minute} other {# minutes}}",
     "silenceImminentDescription": "Switch to “{pageName}” now so you don't have to wait for the schedule to catch up.",
@@ -883,6 +886,11 @@
       "resumeToggle": "Resume sends",
       "badge": "Paused",
       "tooltip": "When paused, FiestaBoard does not push anything to this board — scheduled pages, manual sends, plugin triggers, and MQTT commands are all blocked until you resume."
+    },
+    "initError": {
+      "badge": "Unavailable",
+      "title": "This board failed to initialize",
+      "hint": "Fix the connection details below — saving retries the connection."
     },
     "blackAriaLabel": "Black",
     "whiteAriaLabel": "White",

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -132,6 +132,9 @@
     "description": "Supervisa la pantalla de tu tablero y la actividad del sistema",
     "noBoardConfigured": "Ningún tablero configurado",
     "noBoardDescription": "Tu tablero aún no está configurado. Conecta tu tablero para comenzar a mostrar contenido.",
+    "boardInitErrorTitle": "{boardName} no está disponible",
+    "boardInitErrorTitleUnnamed": "Un tablero no está disponible",
+    "boardInitErrorOpenSettings": "Abrir configuración del tablero",
     "runSetupWizard": "Ejecutar asistente de configuración",
     "silenceImminentTitle": "Silence starts in {minutes, plural, =0 {less than a minute} one {# minute} other {# minutes}}",
     "silenceImminentDescription": "Switch to “{pageName}” now so you don't have to wait for the schedule to catch up.",
@@ -935,6 +938,11 @@
       "resumeToggle": "Resume sends",
       "badge": "Paused",
       "tooltip": "When paused, FiestaBoard does not push anything to this board — scheduled pages, manual sends, plugin triggers, and MQTT commands are all blocked until you resume."
+    },
+    "initError": {
+      "badge": "No disponible",
+      "title": "Este tablero no se pudo inicializar",
+      "hint": "Corrige los datos de conexión abajo; al guardar se reintenta la conexión."
     },
     "deviceTypeAriaLabel": "Tipo y tamaño del tablero",
     "deviceGroupLabel": "Dispositivos",

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -132,6 +132,9 @@
     "description": "Surveillez l'affichage de votre tableau et l'activité du système",
     "noBoardConfigured": "Aucun tableau configuré",
     "noBoardDescription": "Votre tableau n'est pas encore configuré. Connectez votre tableau pour commencer à afficher du contenu.",
+    "boardInitErrorTitle": "{boardName} est indisponible",
+    "boardInitErrorTitleUnnamed": "Un tableau est indisponible",
+    "boardInitErrorOpenSettings": "Ouvrir les paramètres du tableau",
     "runSetupWizard": "Lancer l'assistant de configuration",
     "silenceImminentTitle": "Silence starts in {minutes, plural, =0 {less than a minute} one {# minute} other {# minutes}}",
     "silenceImminentDescription": "Switch to “{pageName}” now so you don't have to wait for the schedule to catch up.",
@@ -935,6 +938,11 @@
       "resumeToggle": "Resume sends",
       "badge": "Paused",
       "tooltip": "When paused, FiestaBoard does not push anything to this board — scheduled pages, manual sends, plugin triggers, and MQTT commands are all blocked until you resume."
+    },
+    "initError": {
+      "badge": "Indisponible",
+      "title": "Ce tableau n'a pas pu être initialisé",
+      "hint": "Corrigez les informations de connexion ci-dessous — l'enregistrement relance la connexion."
     },
     "deviceTypeAriaLabel": "Type et taille du tableau",
     "deviceGroupLabel": "Appareils",

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -132,6 +132,9 @@
     "description": "Monitora la visualizzazione della bacheca e l'attività del sistema",
     "noBoardConfigured": "Nessuna bacheca configurata",
     "noBoardDescription": "La tua bacheca non è ancora configurata. Collega la tua bacheca per iniziare a mostrare contenuti.",
+    "boardInitErrorTitle": "{boardName} non è disponibile",
+    "boardInitErrorTitleUnnamed": "Una bacheca non è disponibile",
+    "boardInitErrorOpenSettings": "Apri le impostazioni della bacheca",
     "runSetupWizard": "Avvia procedura guidata",
     "silenceImminentTitle": "Silence starts in {minutes, plural, =0 {less than a minute} one {# minute} other {# minutes}}",
     "silenceImminentDescription": "Switch to “{pageName}” now so you don't have to wait for the schedule to catch up.",
@@ -935,6 +938,11 @@
       "resumeToggle": "Resume sends",
       "badge": "Paused",
       "tooltip": "When paused, FiestaBoard does not push anything to this board — scheduled pages, manual sends, plugin triggers, and MQTT commands are all blocked until you resume."
+    },
+    "initError": {
+      "badge": "Non disponibile",
+      "title": "Questa bacheca non è stata inizializzata",
+      "hint": "Correggi i dati di connessione qui sotto: al salvataggio la connessione viene ritentata."
     },
     "deviceTypeAriaLabel": "Tipo e dimensione del tabellone",
     "deviceGroupLabel": "Dispositivi",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -132,6 +132,9 @@
     "description": "ボードの表示状態とシステムアクティビティを確認できます",
     "noBoardConfigured": "ボードが未設定です",
     "noBoardDescription": "ボードがまだセットアップされていません。ボードを接続してコンテンツの表示を開始しましょう。",
+    "boardInitErrorTitle": "{boardName}は利用できません",
+    "boardInitErrorTitleUnnamed": "利用できないボードがあります",
+    "boardInitErrorOpenSettings": "ボード設定を開く",
     "runSetupWizard": "セットアップウィザードを実行",
     "silenceImminentTitle": "Silence starts in {minutes, plural, =0 {less than a minute} one {# minute} other {# minutes}}",
     "silenceImminentDescription": "Switch to “{pageName}” now so you don't have to wait for the schedule to catch up.",
@@ -935,6 +938,11 @@
       "resumeToggle": "Resume sends",
       "badge": "Paused",
       "tooltip": "When paused, FiestaBoard does not push anything to this board — scheduled pages, manual sends, plugin triggers, and MQTT commands are all blocked until you resume."
+    },
+    "initError": {
+      "badge": "利用不可",
+      "title": "このボードは初期化に失敗しました",
+      "hint": "以下の接続設定を修正してください。保存すると接続を再試行します。"
     },
     "deviceTypeAriaLabel": "ボードの種類とサイズ",
     "deviceGroupLabel": "デバイス",

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -132,6 +132,9 @@
     "description": "보드 표시 상태 및 시스템 활동을 모니터링하세요",
     "noBoardConfigured": "보드가 설정되지 않았습니다",
     "noBoardDescription": "보드가 아직 설정되지 않았습니다. 보드를 연결하여 콘텐츠 표시를 시작하세요.",
+    "boardInitErrorTitle": "{boardName}을(를) 사용할 수 없습니다",
+    "boardInitErrorTitleUnnamed": "사용할 수 없는 보드가 있습니다",
+    "boardInitErrorOpenSettings": "보드 설정 열기",
     "runSetupWizard": "설정 마법사 실행",
     "silenceImminentTitle": "Silence starts in {minutes, plural, =0 {less than a minute} one {# minute} other {# minutes}}",
     "silenceImminentDescription": "Switch to “{pageName}” now so you don't have to wait for the schedule to catch up.",
@@ -935,6 +938,11 @@
       "resumeToggle": "Resume sends",
       "badge": "Paused",
       "tooltip": "When paused, FiestaBoard does not push anything to this board — scheduled pages, manual sends, plugin triggers, and MQTT commands are all blocked until you resume."
+    },
+    "initError": {
+      "badge": "사용 불가",
+      "title": "이 보드를 초기화하지 못했습니다",
+      "hint": "아래 연결 정보를 수정하세요. 저장하면 연결을 다시 시도합니다."
     },
     "deviceTypeAriaLabel": "보드 유형 및 크기",
     "deviceGroupLabel": "기기",

--- a/web/messages/nl.json
+++ b/web/messages/nl.json
@@ -132,6 +132,9 @@
     "description": "Bekijk je bordweergave en systeemactiviteit",
     "noBoardConfigured": "Geen bord geconfigureerd",
     "noBoardDescription": "Je bord is nog niet ingesteld. Verbind je bord om inhoud weer te geven.",
+    "boardInitErrorTitle": "{boardName} is niet beschikbaar",
+    "boardInitErrorTitleUnnamed": "Een bord is niet beschikbaar",
+    "boardInitErrorOpenSettings": "Bordinstellingen openen",
     "runSetupWizard": "Installatiewizard starten",
     "silenceImminentTitle": "Silence starts in {minutes, plural, =0 {less than a minute} one {# minute} other {# minutes}}",
     "silenceImminentDescription": "Switch to “{pageName}” now so you don't have to wait for the schedule to catch up.",
@@ -935,6 +938,11 @@
       "resumeToggle": "Resume sends",
       "badge": "Paused",
       "tooltip": "When paused, FiestaBoard does not push anything to this board — scheduled pages, manual sends, plugin triggers, and MQTT commands are all blocked until you resume."
+    },
+    "initError": {
+      "badge": "Niet beschikbaar",
+      "title": "Dit bord kon niet worden geïnitialiseerd",
+      "hint": "Corrigeer de verbindingsgegevens hieronder — bij het opslaan wordt de verbinding opnieuw geprobeerd."
     },
     "deviceTypeAriaLabel": "Bordtype en -grootte",
     "deviceGroupLabel": "Apparaten",

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -132,6 +132,9 @@
     "description": "Monitoruj wyświetlacz tablicy i aktywność systemu",
     "noBoardConfigured": "Tablica nie skonfigurowana",
     "noBoardDescription": "Twoja tablica nie jest jeszcze skonfigurowana. Połącz tablicę, aby zacząć wyświetlać treści.",
+    "boardInitErrorTitle": "{boardName} jest niedostępna",
+    "boardInitErrorTitleUnnamed": "Jedna z tablic jest niedostępna",
+    "boardInitErrorOpenSettings": "Otwórz ustawienia tablicy",
     "runSetupWizard": "Uruchom kreator konfiguracji",
     "silenceImminentTitle": "Silence starts in {minutes, plural, =0 {less than a minute} one {# minute} other {# minutes}}",
     "silenceImminentDescription": "Switch to “{pageName}” now so you don't have to wait for the schedule to catch up.",
@@ -935,6 +938,11 @@
       "resumeToggle": "Resume sends",
       "badge": "Paused",
       "tooltip": "When paused, FiestaBoard does not push anything to this board — scheduled pages, manual sends, plugin triggers, and MQTT commands are all blocked until you resume."
+    },
+    "initError": {
+      "badge": "Niedostępna",
+      "title": "Nie udało się zainicjować tej tablicy",
+      "hint": "Popraw dane połączenia poniżej — zapisanie ponawia próbę połączenia."
     },
     "deviceTypeAriaLabel": "Typ i rozmiar tablicy",
     "deviceGroupLabel": "Urządzenia",

--- a/web/messages/pt.json
+++ b/web/messages/pt.json
@@ -132,6 +132,9 @@
     "description": "Monitore a exibição do seu painel e a atividade do sistema",
     "noBoardConfigured": "Nenhum painel configurado",
     "noBoardDescription": "Seu painel ainda não foi configurado. Conecte seu painel para começar a exibir conteúdo.",
+    "boardInitErrorTitle": "{boardName} está indisponível",
+    "boardInitErrorTitleUnnamed": "Um painel está indisponível",
+    "boardInitErrorOpenSettings": "Abrir configurações do painel",
     "runSetupWizard": "Iniciar Assistente de Configuração",
     "silenceImminentTitle": "Silence starts in {minutes, plural, =0 {less than a minute} one {# minute} other {# minutes}}",
     "silenceImminentDescription": "Switch to “{pageName}” now so you don't have to wait for the schedule to catch up.",
@@ -935,6 +938,11 @@
       "resumeToggle": "Resume sends",
       "badge": "Paused",
       "tooltip": "When paused, FiestaBoard does not push anything to this board — scheduled pages, manual sends, plugin triggers, and MQTT commands are all blocked until you resume."
+    },
+    "initError": {
+      "badge": "Indisponível",
+      "title": "Não foi possível inicializar este painel",
+      "hint": "Corrija os dados de conexão abaixo — ao salvar, a conexão será tentada novamente."
     },
     "deviceTypeAriaLabel": "Tipo e tamanho do quadro",
     "deviceGroupLabel": "Dispositivos",

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -132,6 +132,9 @@
     "description": "Отслеживайте отображение доски и активность системы",
     "noBoardConfigured": "Доска не настроена",
     "noBoardDescription": "Ваша доска ещё не настроена. Подключите доску, чтобы начать отображать контент.",
+    "boardInitErrorTitle": "{boardName} недоступна",
+    "boardInitErrorTitleUnnamed": "Одна из досок недоступна",
+    "boardInitErrorOpenSettings": "Открыть настройки доски",
     "runSetupWizard": "Запустить мастер настройки",
     "silenceImminentTitle": "Silence starts in {minutes, plural, =0 {less than a minute} one {# minute} other {# minutes}}",
     "silenceImminentDescription": "Switch to “{pageName}” now so you don't have to wait for the schedule to catch up.",
@@ -935,6 +938,11 @@
       "resumeToggle": "Resume sends",
       "badge": "Paused",
       "tooltip": "When paused, FiestaBoard does not push anything to this board — scheduled pages, manual sends, plugin triggers, and MQTT commands are all blocked until you resume."
+    },
+    "initError": {
+      "badge": "Недоступна",
+      "title": "Не удалось инициализировать эту доску",
+      "hint": "Исправьте данные подключения ниже — при сохранении подключение будет выполнено повторно."
     },
     "deviceTypeAriaLabel": "Тип и размер табло",
     "deviceGroupLabel": "Устройства",

--- a/web/messages/sv.json
+++ b/web/messages/sv.json
@@ -132,6 +132,9 @@
     "description": "Övervaka din tavlas visning och systemaktivitet",
     "noBoardConfigured": "Ingen tavla konfigurerad",
     "noBoardDescription": "Din tavla är inte inställd ännu. Anslut din tavla för att börja visa innehåll.",
+    "boardInitErrorTitle": "{boardName} är inte tillgänglig",
+    "boardInitErrorTitleUnnamed": "En tavla är inte tillgänglig",
+    "boardInitErrorOpenSettings": "Öppna tavlans inställningar",
     "runSetupWizard": "Kör installationsguiden",
     "silenceImminentTitle": "Silence starts in {minutes, plural, =0 {less than a minute} one {# minute} other {# minutes}}",
     "silenceImminentDescription": "Switch to “{pageName}” now so you don't have to wait for the schedule to catch up.",
@@ -935,6 +938,11 @@
       "resumeToggle": "Resume sends",
       "badge": "Paused",
       "tooltip": "When paused, FiestaBoard does not push anything to this board — scheduled pages, manual sends, plugin triggers, and MQTT commands are all blocked until you resume."
+    },
+    "initError": {
+      "badge": "Otillgänglig",
+      "title": "Den här tavlan kunde inte initieras",
+      "hint": "Rätta till anslutningsuppgifterna nedan — när du sparar görs ett nytt anslutningsförsök."
     },
     "deviceTypeAriaLabel": "Tavlans typ och storlek",
     "deviceGroupLabel": "Enheter",

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -132,6 +132,9 @@
     "description": "Pano ekranınızı ve sistem etkinliğini izleyin",
     "noBoardConfigured": "Pano yapılandırılmadı",
     "noBoardDescription": "Panonuz henüz kurulmadı. İçerik görüntülemeye başlamak için panonuzu bağlayın.",
+    "boardInitErrorTitle": "{boardName} kullanılamıyor",
+    "boardInitErrorTitleUnnamed": "Bir pano kullanılamıyor",
+    "boardInitErrorOpenSettings": "Pano ayarlarını aç",
     "runSetupWizard": "Kurulum Sihirbazını Çalıştır",
     "silenceImminentTitle": "Silence starts in {minutes, plural, =0 {less than a minute} one {# minute} other {# minutes}}",
     "silenceImminentDescription": "Switch to “{pageName}” now so you don't have to wait for the schedule to catch up.",
@@ -935,6 +938,11 @@
       "resumeToggle": "Resume sends",
       "badge": "Paused",
       "tooltip": "When paused, FiestaBoard does not push anything to this board — scheduled pages, manual sends, plugin triggers, and MQTT commands are all blocked until you resume."
+    },
+    "initError": {
+      "badge": "Kullanılamıyor",
+      "title": "Bu pano başlatılamadı",
+      "hint": "Aşağıdaki bağlantı bilgilerini düzeltin — kaydettiğinizde bağlantı yeniden denenir."
     },
     "deviceTypeAriaLabel": "Pano türü ve boyutu",
     "deviceGroupLabel": "Cihazlar",

--- a/web/messages/zh.json
+++ b/web/messages/zh.json
@@ -132,6 +132,9 @@
     "description": "监控看板显示和系统活动",
     "noBoardConfigured": "未配置看板",
     "noBoardDescription": "您的看板尚未设置。连接看板以开始显示内容。",
+    "boardInitErrorTitle": "{boardName}不可用",
+    "boardInitErrorTitleUnnamed": "有看板不可用",
+    "boardInitErrorOpenSettings": "打开看板设置",
     "runSetupWizard": "运行设置向导",
     "silenceImminentTitle": "Silence starts in {minutes, plural, =0 {less than a minute} one {# minute} other {# minutes}}",
     "silenceImminentDescription": "Switch to “{pageName}” now so you don't have to wait for the schedule to catch up.",
@@ -935,6 +938,11 @@
       "resumeToggle": "Resume sends",
       "badge": "Paused",
       "tooltip": "When paused, FiestaBoard does not push anything to this board — scheduled pages, manual sends, plugin triggers, and MQTT commands are all blocked until you resume."
+    },
+    "initError": {
+      "badge": "不可用",
+      "title": "此看板初始化失败",
+      "hint": "请修正下方的连接信息，保存后将重试连接。"
     },
     "deviceTypeAriaLabel": "板子类型和尺寸",
     "deviceGroupLabel": "设备",

--- a/web/src/__tests__/board-init-error-banner.test.tsx
+++ b/web/src/__tests__/board-init-error-banner.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * Dashboard banner for boards that failed to initialize (issue #1829).
+ *
+ * `GET /status` → `boards[<id>].error` (issue #1749) names the boards the
+ * backend skipped at startup. The home dashboard renders one alert per
+ * failed board — with the board's name, the verbatim reason, and a jump to
+ * hardware settings — and renders nothing at all for a healthy fleet.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { BoardInitErrorBanner } from "@/components/board-init-error-banner";
+import { CurrentBoardProvider } from "@/components/current-board-context";
+
+import { server } from "./mocks/server";
+
+const API_BASE = "/api";
+
+const INIT_ERROR = "Cloud API key rejected (HTTP 401)";
+
+const mockPush = vi.fn();
+vi.mock("@/hooks/use-router", () => ({
+  useRouter: () => ({
+    push: mockPush,
+    replace: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+  }),
+}));
+
+function setupHandlers({ boardsStatus }: { boardsStatus?: Record<string, unknown> } = {}) {
+  server.use(
+    http.get(`${API_BASE}/settings/board`, () =>
+      HttpResponse.json({
+        board_type: "black",
+        boards: [
+          { id: "board-1", name: "Kitchen", device_type: "flagship", board_color: "black" },
+          { id: "board-2", name: "Office", device_type: "note", board_color: "white" },
+        ],
+        devices: ["flagship", "note"],
+      }),
+    ),
+    http.get(`${API_BASE}/status`, () =>
+      HttpResponse.json({
+        running: true,
+        initialized: true,
+        config_summary: {},
+        ...(boardsStatus !== undefined ? { boards: boardsStatus } : {}),
+      }),
+    ),
+  );
+}
+
+function TestWrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <CurrentBoardProvider>{children}</CurrentBoardProvider>
+    </QueryClientProvider>
+  );
+}
+
+describe("BoardInitErrorBanner", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders an alert naming the failed board with the translated message and verbatim reason", async () => {
+    setupHandlers({
+      boardsStatus: {
+        "board-1": { configured: true, paused: false, active_page_id: null },
+        "board-2": { configured: false, paused: false, active_page_id: null, error: INIT_ERROR },
+      },
+    });
+    render(<BoardInitErrorBanner />, { wrapper: TestWrapper });
+
+    const banner = await screen.findByTestId("board-init-error-banner");
+    expect(banner).toHaveTextContent("Office is unavailable");
+    expect(banner).toHaveTextContent(INIT_ERROR);
+  });
+
+  it("renders nothing when no board reports an init error", async () => {
+    setupHandlers({
+      boardsStatus: {
+        "board-1": { configured: true, paused: false, active_page_id: null, error: null },
+        "board-2": { configured: true, paused: false, active_page_id: null },
+      },
+    });
+    const { container } = render(<BoardInitErrorBanner />, { wrapper: TestWrapper });
+
+    // Let the status query resolve, then assert the banner never appeared.
+    await expect(
+      waitFor(() => expect(screen.getByTestId("board-init-error-banner")).toBeInTheDocument(), { timeout: 300 }),
+    ).rejects.toThrow();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("navigates to hardware settings from the alert's action", async () => {
+    const user = userEvent.setup();
+    setupHandlers({
+      boardsStatus: {
+        "board-1": { configured: false, paused: false, active_page_id: null, error: INIT_ERROR },
+      },
+    });
+    render(<BoardInitErrorBanner />, { wrapper: TestWrapper });
+
+    await screen.findByTestId("board-init-error-banner");
+    await user.click(screen.getByRole("button", { name: "Open board settings" }));
+
+    expect(mockPush).toHaveBeenCalledWith("/settings?section=hardware");
+  });
+});

--- a/web/src/__tests__/display-settings-init-error.test.tsx
+++ b/web/src/__tests__/display-settings-init-error.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * Per-board init errors in DisplaySettings (issue #1829).
+ *
+ * The backend records why a board failed to initialize (issue #1749) and
+ * exposes it as `GET /status` → `boards[<id>].error`. The board card in
+ * hardware settings must surface it: an "Unavailable" badge on the collapsed
+ * header, and the verbatim reason string inside the expanded card.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DisplaySettings } from "@/components/settings/display-settings";
+
+import { server } from "./mocks/server";
+
+const API_BASE = "/api";
+
+const INIT_ERROR = "Local API key rejected by board at 192.0.2.55";
+
+function setupHandlers({ error }: { error?: string | null } = {}) {
+  server.use(
+    http.get(`${API_BASE}/settings/board`, () =>
+      HttpResponse.json({
+        board_type: "black",
+        boards: [
+          {
+            id: "default",
+            name: "My Board",
+            device_type: "flagship",
+            board_color: "black",
+            api_mode: "cloud",
+            cloud_key: "***",
+          },
+        ],
+        devices: ["flagship"],
+      }),
+    ),
+    http.get(`${API_BASE}/status`, () =>
+      HttpResponse.json({
+        running: true,
+        initialized: true,
+        config_summary: {},
+        boards: {
+          default: {
+            configured: !error,
+            paused: false,
+            active_page_id: null,
+            ...(error !== undefined ? { error } : {}),
+          },
+        },
+      }),
+    ),
+  );
+}
+
+function TestWrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+describe("DisplaySettings — board init error surfacing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows an Unavailable badge on the board card when status reports an init error", async () => {
+    setupHandlers({ error: INIT_ERROR });
+    render(<DisplaySettings />, { wrapper: TestWrapper });
+
+    const badge = await screen.findByTestId("board-init-error-badge");
+    expect(badge).toHaveTextContent("Unavailable");
+  });
+
+  it("shows the verbatim reason string inside the expanded card", async () => {
+    const user = userEvent.setup();
+    setupHandlers({ error: INIT_ERROR });
+    render(<DisplaySettings />, { wrapper: TestWrapper });
+
+    await user.click(await screen.findByText("My Board"));
+
+    const detail = await screen.findByTestId("board-init-error-detail");
+    expect(detail).toHaveTextContent("This board failed to initialize");
+    expect(detail).toHaveTextContent(INIT_ERROR);
+  });
+
+  it("renders no badge and no detail when the board has no init error", async () => {
+    const user = userEvent.setup();
+    setupHandlers({ error: null });
+    render(<DisplaySettings />, { wrapper: TestWrapper });
+
+    await user.click(await screen.findByText("My Board"));
+    await screen.findByTestId("board-card");
+
+    expect(screen.queryByTestId("board-init-error-badge")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("board-init-error-detail")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/board-init-error-banner.tsx
+++ b/web/src/components/board-init-error-banner.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { Alert, AlertDescription, AlertTitle, Box, Button, Flex, Stack } from "@fiestaboard/ui";
+import { AlertTriangle } from "lucide-react";
+
+import { useCurrentBoard } from "@/components/current-board-context";
+import { useStatus } from "@/hooks/use-board";
+import { useRouter } from "@/hooks/use-router";
+import { useTranslations } from "@/i18n/translations";
+
+/**
+ * Dashboard callout for boards that failed to initialize (issue #1829).
+ *
+ * The backend records why each board has no client (issue #1749) and exposes
+ * it as `GET /status` → `boards[<id>].error`; until now nothing in the UI
+ * read it, so a board dark from a bad credential looked identical to a
+ * healthy one. One alert per failed board — a failed board is often NOT the
+ * currently selected one, so this reads the whole fleet rather than scoping
+ * to the current board. Rides the shared 15s status poll (useStatus); no new
+ * polling loop.
+ */
+export function BoardInitErrorBanner() {
+  const t = useTranslations("home");
+  const router = useRouter();
+  const { data: status } = useStatus();
+  const { boards } = useCurrentBoard();
+
+  const failedBoards = Object.entries(status?.boards ?? {}).flatMap(([id, boardStatus]) =>
+    boardStatus.error ? [{ id, error: boardStatus.error, name: boards.find((b) => b.id === id)?.name ?? "" }] : [],
+  );
+
+  if (failedBoards.length === 0) return null;
+
+  return (
+    <Stack gap="2" className="mb-6" data-testid="board-init-error-banner">
+      {failedBoards.map((board) => (
+        <Alert
+          key={board.id}
+          variant="destructive"
+          className="flex flex-col sm:flex-row sm:items-center sm:gap-4 [&>svg]:static [&>svg]:shrink-0 [&>svg+div]:translate-y-0 [&>svg~*]:pl-3"
+        >
+          <AlertTriangle className="h-4 w-4" />
+          <Box className="flex-1 min-w-0">
+            <AlertTitle>
+              {board.name ? t("boardInitErrorTitle", { boardName: board.name }) : t("boardInitErrorTitleUnnamed")}
+            </AlertTitle>
+            <AlertDescription>{board.error}</AlertDescription>
+          </Box>
+          <Flex align="center" className="self-center shrink-0">
+            <Button variant="outline" size="sm" onClick={() => router.push("/settings?section=hardware")}>
+              {t("boardInitErrorOpenSettings")}
+            </Button>
+          </Flex>
+        </Alert>
+      ))}
+    </Stack>
+  );
+}

--- a/web/src/components/settings/display-settings.tsx
+++ b/web/src/components/settings/display-settings.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
   Badge as BadgeUI,
   Box,
   Button,
@@ -30,6 +33,7 @@ import { SecretInput } from "@fiestaboard/ui/components/forms/secret-input";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   AlertCircle,
+  AlertTriangle,
   Check,
   ChevronDown,
   ChevronRight,
@@ -48,7 +52,7 @@ import { useState } from "react";
 import { toast } from "sonner";
 
 import { BoardSizeIndicator } from "@/components/board-size-indicator";
-import { queryKeys, useBoardSettings } from "@/hooks/use-board";
+import { queryKeys, useBoardSettings, useStatus } from "@/hooks/use-board";
 import { useTranslations } from "@/i18n/translations";
 import type { BoardInstance, Code62Glyph, DeviceType } from "@/lib/api";
 import { api } from "@/lib/api";
@@ -464,6 +468,10 @@ export function DisplaySettings() {
   const tCommon = useTranslations("common");
   const queryClient = useQueryClient();
   const { data: boardSettings, isLoading } = useBoardSettings();
+  // Per-board init errors from the shared 15s status poll (issue #1829):
+  // a board the backend skipped at startup (issue #1749) carries the reason
+  // in `boards[<id>].error`, surfaced on its card below.
+  const { data: statusData } = useStatus();
   const [showTypePicker, setShowTypePicker] = useState(false);
   // Per-board UI state for the note-array selector / custom inputs / auto-detect.
   const [customOpen, setCustomOpen] = useState<Record<string, boolean>>({});
@@ -676,6 +684,9 @@ export function DisplaySettings() {
             : isNoteArray(board.device_type)
               ? isArrayConfigured(board)
               : (apiMode === "local" && hasLocalKey && hasHost) || (apiMode === "cloud" && hasCloudKey);
+          // Why this board has no client, when the backend skipped it at
+          // startup (issues #1749/#1829). Verbatim backend reason string.
+          const initError = statusData?.boards?.[board.id]?.error ?? null;
 
           return (
             <Collapsible
@@ -720,6 +731,17 @@ export function DisplaySettings() {
                   </Flex>
                 </Box>
                 <Flex align="center" gap="1.5" className="flex-shrink-0">
+                  {initError && (
+                    <BadgeUI
+                      variant="destructive"
+                      className="text-[10px] h-5"
+                      data-testid="board-init-error-badge"
+                      title={initError}
+                    >
+                      <AlertTriangle className="h-2.5 w-2.5 mr-0.5" />
+                      {t("initError.badge")}
+                    </BadgeUI>
+                  )}
                   {isPaused && (
                     <BadgeUI
                       variant="default"
@@ -752,6 +774,26 @@ export function DisplaySettings() {
 
               <CollapsibleContent>
                 <Stack gap="3" className="border-t px-4 pb-4 pt-3">
+                  {/* Why the backend skipped this board at startup (issue
+                      #1829) — verbatim reason, fixed via the form below
+                      (saving re-initializes the board's client). */}
+                  {initError && (
+                    <Alert variant="destructive" data-testid="board-init-error-detail">
+                      <AlertTriangle className="h-4 w-4" />
+                      <AlertTitle>{t("initError.title")}</AlertTitle>
+                      <AlertDescription>
+                        <Stack gap="1">
+                          <Text size="xs" className="break-words">
+                            {initError}
+                          </Text>
+                          <Text size="xs" tone="muted">
+                            {t("initError.hint")}
+                          </Text>
+                        </Stack>
+                      </AlertDescription>
+                    </Alert>
+                  )}
+
                   {/* Board name (issue #1792). Trimmed on save; clearing it
                       saves "" and the backend restores its default name. */}
                   <BoardNameField board={board} onRename={(name) => handleUpdateBoard(board.id, { name })} />

--- a/web/src/components/settings/display-settings.tsx
+++ b/web/src/components/settings/display-settings.tsx
@@ -513,6 +513,10 @@ export function DisplaySettings() {
     mutationFn: (boardId: string) => api.removeBoard(boardId),
     onSuccess: () => {
       invalidate();
+      // The per-board init errors ride the 15s ["status"] poll — refetch it
+      // now so deleting a failed board doesn't leave a ghost error banner
+      // until the next poll tick (#1829 review).
+      queryClient.invalidateQueries({ queryKey: ["status"] });
       toast.success(t("boardRemoved"));
     },
     onError: (error: Error) => {


### PR DESCRIPTION
Closes #1829. Backend-rework **frontend tail**, stacked on Stack 0 (#1857). Sibling of #1858 (disjoint files; `api.ts` untouched here — verified).

## What

#1813 records why each board failed to initialize (`GET /status` → `boards[id].error`), but nothing in the UI read it — a board dark from a bad credential had no explanation anywhere. Now:

1. **Hardware settings, board card**: a destructive "Unavailable" badge on the collapsed card header (tooltip = the reason) and a destructive Alert in the expanded card with the verbatim backend reason plus a hint that saving the connection form retries initialization (which it genuinely does — every PUT re-runs `_reinitialize_board_clients()`).
2. **Dashboard banner**: one Alert per failed board, fleet-wide (the failed board is usually not the selected one), with an "Open board settings" action.

Both read the existing shared `useStatus()` query — no new polling. i18n keys added and translated across all 14 locales.

## The sidebar-selector finding

The issue's first-choice surface was a badge on the sidebar `BoardSelector` — but that component lives in `@fiestaboard/ui` and its published props (`6.0.3` d.ts) offer **no per-item adornment/status/slot of any kind**, so the wiring side can't attach one. Per the repo rule (presentation changes go in FiestaUI), this PR uses the app-owned surfaces above; the upstream prop gap is filed as a FiestaUI issue (linked below).

## Zero-regression evidence

- **Fail-first**: 6 tests written against a null-stub first — `4 failed | 2 passed` (all positive assertions failed on missing testids; the two absence tests' non-vacuity is covered by their positive twins). After: **6/6**.
- node:24 container: baseline 1611 passed / 0 failed → **1617 passed / 0 failed** (exactly the +6 new). `tsc`, prettier, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Par2E2Nh65PyDF1q9TARJP