### PR TITLE
feat(storage): one JSON kernel — atomic writes, real locks, schema migrations — under every store

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -31,7 +31,7 @@ from pydantic import BaseModel, Field
 load_dotenv()
 
 from . import __version__  # noqa: E402
-from .atomic_io import write_json_atomic  # noqa: E402
+from .atomic_io import write_json_atomic, write_text_atomic  # noqa: E402
 from .auth import is_auth_enabled  # noqa: E402
 from .auth.middleware import AuthMiddleware  # noqa: E402
 from .auth.routes import router as auth_router  # noqa: E402
@@ -2311,11 +2311,10 @@ def _take_settings_snapshot(
         else:  # pragma: no cover - effectively unreachable
             logger.warning("Could not find a free snapshot filename")
             return None
-        # Use a temp file + atomic rename so a crash mid-write can't leave a
-        # truncated snapshot in place.
-        tmp = target.with_suffix(target.suffix + ".tmp")
-        tmp.write_text(document, encoding="utf-8")
-        tmp.replace(target)
+        # Atomic staged write (process-scoped staging name) so a crash
+        # mid-write can't leave a truncated snapshot, and a concurrent
+        # process can't collide on a fixed .tmp name.
+        write_text_atomic(target, document)
     except OSError:
         logger.exception("Failed to write pre-update settings snapshot")
         return None

--- a/src/atomic_io.py
+++ b/src/atomic_io.py
@@ -1,28 +1,33 @@
-"""Naming for the staging files used by FiestaBoard's atomic JSON writes.
+"""Atomic file writes for FiestaBoard's JSON stores.
 
 Every long-lived store under ``data/`` (config, settings, pages, schedules,
-collections, auth) writes by staging a temp file next to the target and then
-``os.replace``-ing it into place, so a mid-write crash never truncates the
+collections, panels, auth) writes by staging a temp file next to the target and
+then ``os.replace``-ing it into place, so a mid-write crash never truncates the
 real file (see #1304).
 
-That pattern is only safe if each writer owns its staging file. The in-process
-locks guarding these stores are ``threading.Lock``, so they serialise threads
-and nothing else — and ``data/`` is routinely shared by more than one process:
-every ``pytest -n auto`` xdist worker, the API server alongside a CLI script or
-the MQTT bridge. With one fixed ``<file>.tmp`` name, the process that renames
-second finds its source already renamed away and ``os.replace`` fails with
-``ENOENT``, taking the save (and, in tests, an unrelated request) down with it.
+That pattern is only safe if each writer owns its staging file, and writers
+come from more than one process: every ``pytest -n auto`` xdist worker, the API
+server alongside a CLI script or the MQTT bridge. With one fixed
+``<file>.tmp`` name, the process that renames second finds its source already
+renamed away and ``os.replace`` fails with ``ENOENT``, taking the save (and, in
+tests, an unrelated request) down with it. Scoping the staging name to the
+process removes that collision while keeping staging file and target siblings,
+so the rename stays a same-filesystem rename.
 
-Scoping the staging name to the process removes the collision. The write stays
-atomic: staging file and target are still siblings, so the rename is still a
-same-filesystem rename.
+Within one process the staging name is shared by every thread, so writers must
+also serialise their saves. The stores built on
+:class:`src.storage.json_store.JsonStore` do this with the store's ``RLock``;
+stores with their own locking (``ConfigManager``) hold that lock across the
+write. This module itself is lock-free — it provides the atomic write, not the
+serialisation.
 """
 
 import contextlib
 import json
 import os
+import stat
 from pathlib import Path
-from typing import Any
+from typing import Any, TextIO
 
 
 def staging_path(target: Path) -> Path:
@@ -33,22 +38,71 @@ def staging_path(target: Path) -> Path:
     return target.with_suffix(f"{target.suffix}.{os.getpid()}.tmp")
 
 
-def write_json_atomic(target: Path, data: Any, *, indent: int | None = 2) -> None:
+def _open_staging(tmp_path: Path, private: bool) -> TextIO:
+    """Open *tmp_path* for writing.
+
+    ``private=True`` creates the file with owner-only (0600) permissions via
+    ``os.open`` so a credential store is never world-readable, even briefly.
+    The default path uses builtins ``open`` — deliberately, so existing tests
+    that patch ``builtins.open`` to inject I/O errors keep working.
+    """
+    if private:
+        fd = os.open(
+            str(tmp_path),
+            os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+            stat.S_IRUSR | stat.S_IWUSR,
+        )
+        return os.fdopen(fd, "w", encoding="utf-8")
+    return open(tmp_path, "w", encoding="utf-8")  # noqa: PTH123
+
+
+def write_json_atomic(
+    target: Path,
+    data: Any,
+    *,
+    indent: int | None = 2,
+    private: bool = False,
+) -> None:
     """Serialise *data* as JSON onto *target* without ever truncating it.
 
-    Stages the JSON in the process-scoped sibling from :func:`staging_path` and
-    ``os.replace``s it into place. A crash (OOM, SIGKILL, power loss) partway
-    through the write leaves the previous contents of *target* fully intact, and
-    the partial staging file is removed on any failure rather than leaked.
+    Stages the JSON in the process-scoped sibling from :func:`staging_path`,
+    fsyncs, and ``os.replace``s it into place. A crash (OOM, SIGKILL, power
+    loss) partway through the write leaves the previous contents of *target*
+    fully intact, and the partial staging file is removed on any failure
+    rather than leaked.
 
-    Parent directories are created if missing. Exceptions propagate — the caller
-    decides whether a failed save is fatal.
+    Parent directories are created if missing. ``private=True`` creates the
+    file owner-only (0600). Exceptions propagate — the caller decides whether
+    a failed save is fatal.
     """
     target.parent.mkdir(parents=True, exist_ok=True)
     tmp_path = staging_path(target)
     try:
-        with tmp_path.open("w", encoding="utf-8") as fh:
+        with _open_staging(tmp_path, private) as fh:
             json.dump(data, fh, indent=indent)
+            fh.flush()
+            os.fsync(fh.fileno())
+        tmp_path.replace(target)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def write_text_atomic(target: Path, text: str, *, private: bool = False) -> None:
+    """Write pre-serialised *text* onto *target* with the same guarantees as
+    :func:`write_json_atomic` (staging sibling, fsync, ``os.replace``).
+
+    For callers that already hold serialised content (e.g. an annotated
+    settings snapshot) and only need the atomic install.
+    """
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = staging_path(target)
+    try:
+        with _open_staging(tmp_path, private) as fh:
+            fh.write(text)
+            fh.flush()
+            os.fsync(fh.fileno())
         tmp_path.replace(target)
     except BaseException:
         with contextlib.suppress(OSError):

--- a/src/atomic_io.py
+++ b/src/atomic_io.py
@@ -11,31 +11,45 @@ server alongside a CLI script or the MQTT bridge. With one fixed
 ``<file>.tmp`` name, the process that renames second finds its source already
 renamed away and ``os.replace`` fails with ``ENOENT``, taking the save (and, in
 tests, an unrelated request) down with it. Scoping the staging name to the
-process removes that collision while keeping staging file and target siblings,
-so the rename stays a same-filesystem rename.
+process — plus a per-process monotonic counter — removes that collision while
+keeping staging file and target siblings, so the rename stays a
+same-filesystem rename.
 
-Within one process the staging name is shared by every thread, so writers must
-also serialise their saves. The stores built on
-:class:`src.storage.json_store.JsonStore` do this with the store's ``RLock``;
-stores with their own locking (``ConfigManager``) hold that lock across the
-write. This module itself is lock-free — it provides the atomic write, not the
-serialisation.
+The counter matters within one process too: two threads writing the same
+target (a settings PUT racing a backup restore, #1860) each get their own
+staging file, so neither can truncate or adopt the other's half-written temp.
+Unique staging names make the *rename* safe, not the *data*: last rename still
+wins, so writers that must not lose each other's updates still serialise their
+saves. The stores built on :class:`src.storage.json_store.JsonStore` do this
+with the store's ``RLock``; stores with their own locking (``ConfigManager``)
+hold that lock across the write. This module itself is lock-free — it provides
+the atomic write, not the serialisation.
 """
 
 import contextlib
+import itertools
 import json
 import os
 import stat
 from pathlib import Path
 from typing import Any, TextIO
 
+#: Per-process monotonic counter folded into every staging name so that no two
+#: calls — even from different threads staging the same target — ever share a
+#: staging file (#1860).
+_staging_counter = itertools.count()
+
 
 def staging_path(target: Path) -> Path:
-    """Return the process-scoped staging path to write before renaming onto *target*.
+    """Return a unique staging path to write before renaming onto *target*.
 
-    ``data/pages.json`` becomes ``data/pages.json.<pid>.tmp``.
+    ``data/pages.json`` becomes ``data/pages.json.<pid>.<n>.tmp`` where
+    ``<n>`` is a per-process monotonic counter. Every call returns a fresh
+    path: unique across processes (the pid) and across calls within one
+    process (the counter), so concurrent writers can never open, truncate,
+    or rename each other's staging file.
     """
-    return target.with_suffix(f"{target.suffix}.{os.getpid()}.tmp")
+    return target.with_suffix(f"{target.suffix}.{os.getpid()}.{next(_staging_counter)}.tmp")
 
 
 def _open_staging(tmp_path: Path, private: bool) -> TextIO:

--- a/src/auth/service.py
+++ b/src/auth/service.py
@@ -19,7 +19,6 @@ Design notes
 from __future__ import annotations
 
 import base64
-import contextlib
 import hashlib
 import hmac
 import json
@@ -33,7 +32,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from src.atomic_io import staging_path
+from src.atomic_io import write_json_atomic
 from src.paths import get_data_dir
 
 logger = logging.getLogger(__name__)
@@ -402,27 +401,10 @@ class AuthService:
         # (``"enabled"`` / ``"disabled"``). Absent => undecided.
 
     def _save(self) -> None:
-        self._path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = staging_path(self._path)
-        # Restrictive perms on the temp file before fdopen writes to it.
-        fd = os.open(
-            str(tmp),
-            os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
-            stat.S_IRUSR | stat.S_IWUSR,
-        )
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as fh:
-                json.dump(self._data, fh, indent=2)
-                fh.flush()
-                os.fsync(fh.fileno())
-            Path(tmp).replace(self._path)
-        except Exception:
-            # Cleanup of a cleanup failure — nothing useful we can do;
-            # the original exception below is the one that matters and
-            # we don't want to mask it.
-            with contextlib.suppress(OSError):
-                tmp.unlink(missing_ok=True)
-            raise
+        # private=True keeps the credential store owner-only (0600) from the
+        # moment the staging file is created; the kernel helper also fsyncs
+        # and cleans up the staging file on any failure.
+        write_json_atomic(self._path, self._data, private=True)
 
     # -- queries -----------------------------------------------------------
 

--- a/src/backup/service.py
+++ b/src/backup/service.py
@@ -30,6 +30,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from src.atomic_io import write_json_atomic
 from src.paths import get_data_dir
 
 #: Strict allowlist for repository URLs read from a backup file.  We only
@@ -224,9 +225,11 @@ class BackupService:
         """Write *payload* to *path*, preserving any existing file.
 
         The old file (if any) is moved to ``<path>.pre-restore-<timestamp>``
-        before the new content is written.  Writes are atomic via
-        ``os.replace`` so a crash mid-restore can never leave a partially
-        written JSON file in place.
+        before the new content is written.  Writes go through
+        :func:`src.atomic_io.write_json_atomic` (process-scoped staging file +
+        ``os.replace``) so a crash mid-restore can never leave a partially
+        written JSON file in place and a concurrent process can never collide
+        on the staging name.
         """
         path.parent.mkdir(parents=True, exist_ok=True)
         if path.exists():
@@ -237,10 +240,7 @@ class BackupService:
             except OSError as exc:
                 logger.warning("Could not write pre-restore backup %s: %s", backup_path, exc)
 
-        tmp_path = path.with_suffix(path.suffix + ".tmp")
-        with tmp_path.open("w", encoding="utf-8") as fh:
-            json.dump(payload, fh, indent=2)
-        tmp_path.replace(path)
+        write_json_atomic(path, payload)
 
     @staticmethod
     def _validate_backup(backup: Any) -> None:

--- a/src/backup/service.py
+++ b/src/backup/service.py
@@ -21,6 +21,7 @@ sources rather than being shipped inside the user's backup file.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import re
@@ -161,13 +162,15 @@ class BackupService:
                     # first-run import migrates it into collections.json.
                     legacy = data_section.get("carousels")
                     if legacy is not None:
+                        # No live store owns carousels.json — plain write.
                         self._write_json_with_backup(self.data_dir / "carousels.json", legacy, timestamp)
                         restored.append("carousels.json (legacy)")
                         continue
                 if payload is None:
                     skipped.append(filename)
                     continue
-                self._write_json_with_backup(self.data_dir / filename, payload, timestamp)
+                with self._owning_lock(filename):
+                    self._write_json_with_backup(self.data_dir / filename, payload, timestamp)
                 restored.append(filename)
 
         plugin_results: dict[str, Any] = {
@@ -221,15 +224,64 @@ class BackupService:
             return None
 
     @staticmethod
+    def _owning_lock(filename: str) -> contextlib.AbstractContextManager:
+        """Return the lock of the live singleton that normally writes *filename*.
+
+        A restore rewrites files that JsonStore-backed services (settings,
+        pages, collections, schedules, panels) and the ConfigManager also
+        write from other threads. Even with per-call staging names a
+        concurrent save could still interleave with the restore (last rename
+        wins mid-restore), so each file is written under its owner's lock
+        (#1860).
+
+        Lock ordering: the restore loop takes exactly ONE of these locks at a
+        time — acquire, write the one file, release, move on — and never
+        nests them, so it cannot deadlock against writers that each hold only
+        their own lock.
+
+        Falls back to a no-op context when the owning subsystem cannot be
+        loaded (a restore must still succeed in a minimal environment).
+        """
+        try:
+            if filename == "config.json":
+                from src.config_manager import get_config_manager
+
+                return get_config_manager().lock
+            if filename == "settings.json":
+                from src.settings.service import get_settings_service
+
+                return get_settings_service().lock
+            if filename == "pages.json":
+                from src.pages.service import get_page_service
+
+                return get_page_service().storage.lock
+            if filename == "collections.json":
+                from src.collections.service import get_collection_service
+
+                return get_collection_service().storage.lock
+            if filename == "schedules.json":
+                from src.schedules.service import get_schedule_service
+
+                return get_schedule_service().storage.lock
+            if filename == "panels.json":
+                from src.panels.service import get_panel_service
+
+                return get_panel_service().storage.lock
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("No owning lock for %s during restore: %s", filename, exc)
+        return contextlib.nullcontext()
+
+    @staticmethod
     def _write_json_with_backup(path: Path, payload: Any, timestamp: str) -> None:
         """Write *payload* to *path*, preserving any existing file.
 
         The old file (if any) is moved to ``<path>.pre-restore-<timestamp>``
         before the new content is written.  Writes go through
-        :func:`src.atomic_io.write_json_atomic` (process-scoped staging file +
-        ``os.replace``) so a crash mid-restore can never leave a partially
-        written JSON file in place and a concurrent process can never collide
-        on the staging name.
+        :func:`src.atomic_io.write_json_atomic` (unique per-call staging file
+        + ``os.replace``) so a crash mid-restore can never leave a partially
+        written JSON file in place and no concurrent writer can collide on
+        the staging name. Callers restoring a file owned by a live store must
+        additionally hold that store's lock (see :meth:`_owning_lock`).
         """
         path.parent.mkdir(parents=True, exist_ok=True)
         if path.exists():

--- a/src/collections/storage.py
+++ b/src/collections/storage.py
@@ -6,16 +6,12 @@ legacy ``data/carousels.json`` file (carousel: prefixed IDs, flat
 ``interval_seconds``) into the new collection format on first run.
 """
 
-import contextlib
 import json
 import logging
-import shutil
 from collections.abc import Callable
 from datetime import datetime
-from pathlib import Path
 
-from src.atomic_io import staging_path
-from src.paths import get_data_dir
+from src.storage.json_store import JsonStore
 
 from .models import COLLECTION_ID_PREFIX, Collection
 
@@ -63,14 +59,22 @@ def import_legacy_carousels(raw_carousels: list[dict]) -> list[dict]:
 MIGRATIONS: list[tuple[int, Callable[[list[dict]], int]]] = []
 
 
+def _adapt_migration(fn: Callable[[list[dict]], int]) -> Callable[[dict], int]:
+    """Adapt a records-list migration to the kernel's whole-document signature."""
+    return lambda data: fn(data.get("collections", []))
+
+
 class CollectionStorage:
     """JSON file-based storage for collections."""
 
     def __init__(self, storage_file: str | None = None):
-        if storage_file is None:
-            self.storage_file = get_data_dir() / "collections.json"
-        else:
-            self.storage_file = Path(storage_file)
+        self._store = JsonStore(
+            "collections.json" if storage_file is None else storage_file,
+            current_schema_version=CURRENT_SCHEMA_VERSION,
+            migrations=[(version, _adapt_migration(fn)) for version, fn in MIGRATIONS],
+            label="Collections",
+        )
+        self.storage_file = self._store.path
 
         self._collections: dict[str, Collection] = {}
         # Raw entries (post-migration) that failed Pydantic validation on load.
@@ -81,40 +85,6 @@ class CollectionStorage:
         self._load()
 
         logger.info(f"CollectionStorage initialized (file: {self.storage_file}, collections: {len(self._collections)})")
-
-    # --- migrations ------------------------------------------------------
-
-    def _run_migrations(self, data: dict) -> bool:
-        """Run any pending schema migrations on raw JSON data.
-
-        Returns True if any migrations were applied (caller should resave).
-        """
-        current_version = data.get("schema_version", 0)
-        if current_version >= CURRENT_SCHEMA_VERSION:
-            return False
-
-        records = data.get("collections", [])
-
-        if self.storage_file.exists():
-            backup_path = self.storage_file.with_suffix(f".json.v{current_version}_backup")
-            if not backup_path.exists():
-                try:
-                    shutil.copy2(self.storage_file, backup_path)
-                    logger.info(f"Created pre-migration backup at {backup_path}")
-                except Exception as e:
-                    logger.warning(f"Could not create backup: {e}")
-
-        for target_version, migrate_fn in MIGRATIONS:
-            if current_version >= target_version:
-                continue
-            count = migrate_fn(records)
-            logger.info(
-                f"Collections schema migration v{current_version}->v{target_version}: {count} record(s) processed"
-            )
-            current_version = target_version
-
-        data["schema_version"] = CURRENT_SCHEMA_VERSION
-        return True
 
     def _import_legacy_carousels_if_needed(self) -> bool:
         """If no collections file exists but a legacy carousels.json does,
@@ -191,21 +161,20 @@ class CollectionStorage:
             self._save()
             return
 
-        if not self.storage_file.exists():
-            self._collections = {}
-            self._failed_entries = []
-            return
-
         try:
-            with open(self.storage_file) as f:  # noqa: PTH123
-                data = json.load(f)
+            data = self._store.load()
         except (OSError, json.JSONDecodeError) as e:
             logger.warning(f"Failed to load collections file: {e}")
             self._collections = {}
             self._failed_entries = []
             return
 
-        needs_save = self._run_migrations(data)
+        if data is None:
+            self._collections = {}
+            self._failed_entries = []
+            return
+
+        needs_save = self._store.migrated
 
         self._collections = {}
         self._failed_entries = []
@@ -238,12 +207,7 @@ class CollectionStorage:
             logger.info("Saved migrated collections to storage")
 
     def _save(self) -> None:
-        """Save collections to storage file.
-
-        Writes to a sibling ``<file>.tmp`` and ``os.replace``s it into place so
-        a mid-write crash (OOM, SIGKILL, power loss) never leaves a truncated
-        file that would wipe in-memory state on reload (see #1304).
-        """
+        """Save collections to storage file atomically via the storage kernel."""
         try:
             records = []
             for c in self._collections.values():
@@ -263,17 +227,7 @@ class CollectionStorage:
                 "collections": records,
             }
 
-            tmp_path = staging_path(self.storage_file)
-            try:
-                with open(tmp_path, "w") as f:  # noqa: PTH123
-                    json.dump(data, f, indent=2)
-                tmp_path.replace(self.storage_file)
-            except BaseException:
-                # Clean up the partial tmp file on any failure so we don't leak
-                # it; the original storage file stays untouched.
-                with contextlib.suppress(OSError):
-                    tmp_path.unlink(missing_ok=True)
-                raise
+            self._store.save(data)
 
             logger.debug(f"Saved {len(self._collections)} collections to storage")
         except OSError as e:
@@ -291,17 +245,22 @@ class CollectionStorage:
         return self._collections.get(collection_id)
 
     def create(self, collection: Collection) -> Collection:
-        if collection.id in self._collections:
-            raise ValueError(f"Collection with ID {collection.id} already exists")
-        errors = collection.validate_config()
-        if errors:
-            raise ValueError(f"Invalid collection configuration: {errors}")
-        self._collections[collection.id] = collection
-        self._save()
+        with self._store.lock:
+            if collection.id in self._collections:
+                raise ValueError(f"Collection with ID {collection.id} already exists")
+            errors = collection.validate_config()
+            if errors:
+                raise ValueError(f"Invalid collection configuration: {errors}")
+            self._collections[collection.id] = collection
+            self._save()
         logger.info(f"Created collection: {collection.id} ({collection.name})")
         return collection
 
     def update(self, collection_id: str, updates: dict) -> Collection | None:
+        with self._store.lock:
+            return self._update_locked(collection_id, updates)
+
+    def _update_locked(self, collection_id: str, updates: dict) -> Collection | None:
         if collection_id not in self._collections:
             return None
 
@@ -324,10 +283,11 @@ class CollectionStorage:
         return updated
 
     def delete(self, collection_id: str) -> bool:
-        if collection_id not in self._collections:
-            return False
-        del self._collections[collection_id]
-        self._save()
+        with self._store.lock:
+            if collection_id not in self._collections:
+                return False
+            del self._collections[collection_id]
+            self._save()
         logger.info(f"Deleted collection: {collection_id}")
         return True
 

--- a/src/collections/storage.py
+++ b/src/collections/storage.py
@@ -8,6 +8,7 @@ legacy ``data/carousels.json`` file (carousel: prefixed IDs, flat
 
 import json
 import logging
+import threading
 from collections.abc import Callable
 from datetime import datetime
 
@@ -154,6 +155,12 @@ class CollectionStorage:
         self._collections[collection.id] = collection
 
     # --- load / save -----------------------------------------------------
+
+    @property
+    def lock(self) -> threading.RLock:
+        """The kernel store's lock, for out-of-band writers of this file
+        (the backup restore, #1860) to serialise against normal saves."""
+        return self._store.lock
 
     def _load(self) -> None:
         # First-run path: import legacy carousels.json if present.

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -1045,6 +1045,13 @@ class ConfigManager:
         logger.info("Configuration reloaded from file")
 
     @property
+    def lock(self) -> threading.RLock:
+        """The manager's file lock, for callers that write ``config.json``
+        out-of-band (the backup restore) and must not interleave with a
+        concurrent ``_save_internal`` (#1860)."""
+        return self._file_lock
+
+    @property
     def version_changed_on_load(self) -> bool:
         """True if this process loaded an existing config from an older app version.
 

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -8,7 +8,6 @@ Supports:
 - Plugin system (config.plugins.*) for data source integrations
 """
 
-import contextlib
 import json
 import logging
 import os
@@ -20,7 +19,7 @@ from typing import Any, Optional
 from src.paths import get_data_dir
 
 # Import TimeService for migration
-from .atomic_io import staging_path
+from .atomic_io import write_json_atomic
 from .time_service import get_time_service
 
 logger = logging.getLogger(__name__)
@@ -658,9 +657,7 @@ class ConfigManager:
                 ts = now.strftime("%Y%m%dT%H%M%S") + f".{ms:03d}Z"
                 target = snapshot_dir / f"pre-update-{ts}.json"
 
-            tmp = target.with_suffix(target.suffix + ".tmp")
-            tmp.write_text(json.dumps(doc, indent=2), encoding="utf-8")
-            tmp.replace(target)
+            write_json_atomic(target, doc)
 
             logger.info(
                 "Version change detected (%s -> %s); pre-init snapshot written to %s",
@@ -843,23 +840,13 @@ class ConfigManager:
     def _save_internal(self) -> None:
         """Internal save without acquiring lock (called from locked context).
 
-        Writes to a process-scoped sibling staging file and ``os.replace``s it
-        into place so a mid-write crash (OOM, SIGKILL, power loss) never leaves
-        a truncated config file (see #1304). See :mod:`src.atomic_io` for why
-        the staging name has to be per-process.
+        Writes go through :func:`src.atomic_io.write_json_atomic` (process-
+        scoped staging file + ``os.replace``) so a mid-write crash (OOM,
+        SIGKILL, power loss) never leaves a truncated config file (see #1304)
+        and concurrent processes never collide on a fixed staging name.
         """
         try:
-            tmp_path = staging_path(self._config_path)
-            try:
-                with tmp_path.open("w") as f:
-                    json.dump(self._config, f, indent=2)
-                tmp_path.replace(self._config_path)
-            except BaseException:
-                # Clean up the partial tmp file on any failure so we don't leak
-                # it; the original config file stays untouched.
-                with contextlib.suppress(OSError):
-                    tmp_path.unlink(missing_ok=True)
-                raise
+            write_json_atomic(self._config_path, self._config)
             logger.debug(f"Saved config to {self._config_path}")
         except OSError as e:
             logger.error(f"Failed to save config: {e}")

--- a/src/pages/storage.py
+++ b/src/pages/storage.py
@@ -4,17 +4,13 @@ Provides simple persistence for page configurations that survives restarts.
 Includes schema versioning and automatic migration on startup.
 """
 
-import contextlib
 import json
 import logging
 import re
-import shutil
 from collections.abc import Callable
 from datetime import UTC, datetime
-from pathlib import Path
 
-from src.atomic_io import staging_path
-from src.paths import get_data_dir
+from src.storage.json_store import JsonStore
 from src.text_utils import extract_alignment_from_line as _extract_alignment_from_line
 
 from .models import Page
@@ -207,6 +203,15 @@ MIGRATIONS: list[tuple[int, Callable[[list[dict]], int]]] = [
 ]
 
 
+def _adapt_migration(fn: Callable[[list[dict]], int]) -> Callable[[dict], int]:
+    """Adapt a pages-list migration to the kernel's whole-document signature.
+
+    The kernel hands migrations the raw top-level dict; pages migrations
+    operate on the wrapped ``pages`` list, exactly as before.
+    """
+    return lambda data: fn(data.get("pages", []))
+
+
 class PageStorage:
     """JSON file-based storage for pages.
 
@@ -220,10 +225,13 @@ class PageStorage:
         Args:
             storage_file: Path to JSON storage file. Defaults to data/pages.json
         """
-        if storage_file is None:
-            self.storage_file = get_data_dir() / "pages.json"
-        else:
-            self.storage_file = Path(storage_file)
+        self._store = JsonStore(
+            "pages.json" if storage_file is None else storage_file,
+            current_schema_version=CURRENT_SCHEMA_VERSION,
+            migrations=[(version, _adapt_migration(fn)) for version, fn in MIGRATIONS],
+            label="Pages",
+        )
+        self.storage_file = self._store.path
 
         # In-memory cache
         self._pages: dict[str, Page] = {}
@@ -238,50 +246,16 @@ class PageStorage:
 
         logger.info(f"PageStorage initialized (file: {self.storage_file}, pages: {len(self._pages)})")
 
-    def _run_migrations(self, data: dict) -> bool:
-        """Run any pending schema migrations on raw JSON data.
-
-        Returns True if any migrations were applied (caller should resave).
-        """
-        current_version = data.get("schema_version", 0)
-
-        if current_version >= CURRENT_SCHEMA_VERSION:
-            return False
-
-        pages_list = data.get("pages", [])
-
-        # Back up before first migration
-        if self.storage_file.exists():
-            backup_path = self.storage_file.with_suffix(f".json.v{current_version}_backup")
-            if not backup_path.exists():
-                try:
-                    shutil.copy2(self.storage_file, backup_path)
-                    logger.info(f"Created pre-migration backup at {backup_path}")
-                except Exception as e:
-                    logger.warning(f"Could not create backup: {e}")
-
-        for target_version, migrate_fn in MIGRATIONS:
-            if current_version >= target_version:
-                continue
-            count = migrate_fn(pages_list)
-            logger.info(f"Pages schema migration v{current_version}->v{target_version}: {count} page(s) processed")
-            current_version = target_version
-
-        data["schema_version"] = CURRENT_SCHEMA_VERSION
-        return True
-
     def _load(self) -> None:
         """Load pages from storage file, running migrations if needed."""
-        if not self.storage_file.exists():
-            self._pages = {}
-            self._failed_entries = []
-            return
-
         try:
-            with self.storage_file.open() as f:
-                data = json.load(f)
+            data = self._store.load()
+            if data is None:
+                self._pages = {}
+                self._failed_entries = []
+                return
 
-            needs_save = self._run_migrations(data)
+            needs_save = self._store.migrated
 
             self._pages = {}
             self._failed_entries = []
@@ -326,12 +300,7 @@ class PageStorage:
             self._failed_entries = []
 
     def _save(self) -> None:
-        """Save pages to storage file.
-
-        Writes to a sibling ``<file>.tmp`` and ``os.replace``s it into place
-        so a mid-write crash (OOM, SIGKILL, power loss) never leaves a
-        truncated file that would wipe in-memory state on reload (see #1304).
-        """
+        """Save pages to storage file atomically via the storage kernel."""
         try:
             pages_out: list[dict] = []
             for page in self._pages.values():
@@ -355,17 +324,7 @@ class PageStorage:
             # Datetimes are already coerced to ISO strings while building
             # pages_out above (covers both parsed pages and preserved
             # _failed_entries), so write data straight out — atomically.
-            tmp_path = staging_path(self.storage_file)
-            try:
-                with tmp_path.open("w") as f:
-                    json.dump(data, f, indent=2)
-                tmp_path.replace(self.storage_file)
-            except BaseException:
-                # Clean up the partial tmp file on any failure so we don't
-                # leak it; the original storage file stays untouched.
-                with contextlib.suppress(OSError):
-                    tmp_path.unlink(missing_ok=True)
-                raise
+            self._store.save(data)
 
             logger.debug(f"Saved {len(self._pages)} pages to storage")
 
@@ -406,16 +365,17 @@ class PageStorage:
         Raises:
             ValueError: If page with same ID already exists
         """
-        if page.id in self._pages:
-            raise ValueError(f"Page with ID {page.id} already exists")
+        with self._store.lock:
+            if page.id in self._pages:
+                raise ValueError(f"Page with ID {page.id} already exists")
 
-        # Validate
-        errors = page.validate_config()
-        if errors:
-            raise ValueError(f"Invalid page configuration: {errors}")
+            # Validate
+            errors = page.validate_config()
+            if errors:
+                raise ValueError(f"Invalid page configuration: {errors}")
 
-        self._pages[page.id] = page
-        self._save()
+            self._pages[page.id] = page
+            self._save()
 
         logger.info(f"Created page: {page.id} ({page.name})")
         return page
@@ -430,6 +390,10 @@ class PageStorage:
         Returns:
             Updated page if found, None otherwise
         """
+        with self._store.lock:
+            return self._update_locked(page_id, updates)
+
+    def _update_locked(self, page_id: str, updates: dict) -> Page | None:
         if page_id not in self._pages:
             return None
 
@@ -482,11 +446,12 @@ class PageStorage:
         Returns:
             True if deleted, False if not found
         """
-        if page_id not in self._pages:
-            return False
+        with self._store.lock:
+            if page_id not in self._pages:
+                return False
 
-        del self._pages[page_id]
-        self._save()
+            del self._pages[page_id]
+            self._save()
 
         logger.info(f"Deleted page: {page_id}")
         return True

--- a/src/pages/storage.py
+++ b/src/pages/storage.py
@@ -7,6 +7,7 @@ Includes schema versioning and automatic migration on startup.
 import json
 import logging
 import re
+import threading
 from collections.abc import Callable
 from datetime import UTC, datetime
 
@@ -245,6 +246,12 @@ class PageStorage:
         self._load()
 
         logger.info(f"PageStorage initialized (file: {self.storage_file}, pages: {len(self._pages)})")
+
+    @property
+    def lock(self) -> threading.RLock:
+        """The kernel store's lock, for out-of-band writers of this file
+        (the backup restore, #1860) to serialise against normal saves."""
+        return self._store.lock
 
     def _load(self) -> None:
         """Load pages from storage file, running migrations if needed."""

--- a/src/panels/storage.py
+++ b/src/panels/storage.py
@@ -7,6 +7,7 @@ that fail validation on load.
 
 import json
 import logging
+import threading
 from collections.abc import Callable
 from datetime import UTC, datetime
 
@@ -122,6 +123,12 @@ class PanelStorage:
         self._load()
 
         logger.info(f"PanelStorage initialized (file: {self.storage_file}, panels: {len(self._panels)})")
+
+    @property
+    def lock(self) -> threading.RLock:
+        """The kernel store's lock, for out-of-band writers of this file
+        (the backup restore, #1860) to serialise against normal saves."""
+        return self._store.lock
 
     def _load(self) -> None:
         """Load panels from storage file, running migrations if needed."""

--- a/src/panels/storage.py
+++ b/src/panels/storage.py
@@ -5,16 +5,12 @@ migrations, atomic writes via a staging file, and preservation of entries
 that fail validation on load.
 """
 
-import contextlib
 import json
 import logging
-import shutil
 from collections.abc import Callable
 from datetime import UTC, datetime
-from pathlib import Path
 
-from src.atomic_io import staging_path
-from src.paths import get_data_dir
+from src.storage.json_store import JsonStore
 
 from .models import Panel
 
@@ -95,6 +91,11 @@ MIGRATIONS: list[tuple[int, Callable[[list[dict]], int]]] = [
 ]
 
 
+def _adapt_migration(fn: Callable[[list[dict]], int]) -> Callable[[dict], int]:
+    """Adapt a panels-list migration to the kernel's whole-document signature."""
+    return lambda data: fn(data.get("panels", []))
+
+
 class PanelStorage:
     """JSON file-based storage for panels. Thread-safe for basic operations."""
 
@@ -104,10 +105,13 @@ class PanelStorage:
         Args:
             storage_file: Path to JSON storage file. Defaults to data/panels.json
         """
-        if storage_file is None:
-            self.storage_file = get_data_dir() / "panels.json"
-        else:
-            self.storage_file = Path(storage_file)
+        self._store = JsonStore(
+            "panels.json" if storage_file is None else storage_file,
+            current_schema_version=CURRENT_SCHEMA_VERSION,
+            migrations=[(version, _adapt_migration(fn)) for version, fn in MIGRATIONS],
+            label="Panels",
+        )
+        self.storage_file = self._store.path
 
         self._panels: dict[str, Panel] = {}
         # Raw entries (post-migration) that failed Pydantic validation on load.
@@ -119,50 +123,16 @@ class PanelStorage:
 
         logger.info(f"PanelStorage initialized (file: {self.storage_file}, panels: {len(self._panels)})")
 
-    def _run_migrations(self, data: dict) -> bool:
-        """Run any pending schema migrations on raw JSON data.
-
-        Returns True if any migrations were applied (caller should resave).
-        """
-        current_version = data.get("schema_version", 0)
-
-        if current_version >= CURRENT_SCHEMA_VERSION:
-            return False
-
-        panels_list = data.get("panels", [])
-
-        # Back up before first migration
-        if self.storage_file.exists():
-            backup_path = self.storage_file.with_suffix(f".json.v{current_version}_backup")
-            if not backup_path.exists():
-                try:
-                    shutil.copy2(self.storage_file, backup_path)
-                    logger.info(f"Created pre-migration backup at {backup_path}")
-                except Exception as e:
-                    logger.warning(f"Could not create backup: {e}")
-
-        for target_version, migrate_fn in MIGRATIONS:
-            if current_version >= target_version:
-                continue
-            count = migrate_fn(panels_list)
-            logger.info(f"Panels schema migration v{current_version}->v{target_version}: {count} panel(s) processed")
-            current_version = target_version
-
-        data["schema_version"] = CURRENT_SCHEMA_VERSION
-        return True
-
     def _load(self) -> None:
         """Load panels from storage file, running migrations if needed."""
-        if not self.storage_file.exists():
-            self._panels = {}
-            self._failed_entries = []
-            return
-
         try:
-            with self.storage_file.open() as f:
-                data = json.load(f)
+            data = self._store.load()
+            if data is None:
+                self._panels = {}
+                self._failed_entries = []
+                return
 
-            needs_save = self._run_migrations(data)
+            needs_save = self._store.migrated
 
             self._panels = {}
             self._failed_entries = []
@@ -204,7 +174,7 @@ class PanelStorage:
             self._failed_entries = []
 
     def _save(self) -> None:
-        """Save panels to storage file atomically (staging file + replace)."""
+        """Save panels to storage file atomically via the storage kernel."""
         try:
             panels_out: list[dict] = []
             for panel in self._panels.values():
@@ -223,15 +193,7 @@ class PanelStorage:
                 "panels": panels_out,
             }
 
-            tmp_path = staging_path(self.storage_file)
-            try:
-                with tmp_path.open("w") as f:
-                    json.dump(data, f, indent=2)
-                tmp_path.replace(self.storage_file)
-            except BaseException:
-                with contextlib.suppress(OSError):
-                    tmp_path.unlink(missing_ok=True)
-                raise
+            self._store.save(data)
 
             logger.debug(f"Saved {len(self._panels)} panels to storage")
 
@@ -286,14 +248,15 @@ class PanelStorage:
         Raises:
             ValueError: If a panel with the same ID already exists.
         """
-        if panel.id in self._panels:
-            raise ValueError(f"Panel with ID {panel.id} already exists")
+        with self._store.lock:
+            if panel.id in self._panels:
+                raise ValueError(f"Panel with ID {panel.id} already exists")
 
-        if panel.short_code <= 0:
-            panel = panel.model_copy(update={"short_code": self._next_short_code()})
+            if panel.short_code <= 0:
+                panel = panel.model_copy(update={"short_code": self._next_short_code()})
 
-        self._panels[panel.id] = panel
-        self._save()
+            self._panels[panel.id] = panel
+            self._save()
 
         logger.info(f"Created panel: {panel.id} ({panel.name})")
         return panel
@@ -303,30 +266,32 @@ class PanelStorage:
 
         Returns the updated panel, or None when the id is unknown.
         """
-        if panel_id not in self._panels:
-            return None
+        with self._store.lock:
+            if panel_id not in self._panels:
+                return None
 
-        panel_dict = self._panels[panel_id].model_dump()
-        for key, value in updates.items():
-            if key in panel_dict and value is not None:
-                panel_dict[key] = value
+            panel_dict = self._panels[panel_id].model_dump()
+            for key, value in updates.items():
+                if key in panel_dict and value is not None:
+                    panel_dict[key] = value
 
-        panel_dict["updated_at"] = datetime.now(UTC)
+            panel_dict["updated_at"] = datetime.now(UTC)
 
-        updated_panel = Panel(**panel_dict)
-        self._panels[panel_id] = updated_panel
-        self._save()
+            updated_panel = Panel(**panel_dict)
+            self._panels[panel_id] = updated_panel
+            self._save()
 
         logger.info(f"Updated panel: {panel_id}")
         return updated_panel
 
     def delete(self, panel_id: str) -> bool:
         """Delete a panel. Returns True if it existed."""
-        if panel_id not in self._panels:
-            return False
+        with self._store.lock:
+            if panel_id not in self._panels:
+                return False
 
-        del self._panels[panel_id]
-        self._save()
+            del self._panels[panel_id]
+            self._save()
 
         logger.info(f"Deleted panel: {panel_id}")
         return True

--- a/src/schedules/storage.py
+++ b/src/schedules/storage.py
@@ -4,16 +4,12 @@ Provides simple persistence for schedule configurations that survives restarts.
 Includes schema versioning and automatic migration on startup.
 """
 
-import contextlib
 import json
 import logging
-import shutil
 from collections.abc import Callable
 from datetime import UTC, datetime
-from pathlib import Path
 
-from src.atomic_io import staging_path
-from src.paths import get_data_dir
+from src.storage.json_store import JsonStore
 
 from .models import DEFAULT_BOARD_ID, ScheduleEntry
 
@@ -101,10 +97,13 @@ class ScheduleStorage:
         Args:
             storage_file: Path to JSON storage file. Defaults to data/schedules.json
         """
-        if storage_file is None:
-            self.storage_file = get_data_dir() / "schedules.json"
-        else:
-            self.storage_file = Path(storage_file)
+        self._store = JsonStore(
+            "schedules.json" if storage_file is None else storage_file,
+            current_schema_version=CURRENT_SCHEMA_VERSION,
+            migrations=MIGRATIONS,
+            label="Schedules",
+        )
+        self.storage_file = self._store.path
 
         # In-memory cache
         self._schedules: dict[str, ScheduleEntry] = {}
@@ -121,51 +120,18 @@ class ScheduleStorage:
 
         logger.info(f"ScheduleStorage initialized (file: {self.storage_file}, schedules: {len(self._schedules)})")
 
-    def _run_migrations(self, data: dict) -> bool:
-        """Run any pending schema migrations on raw JSON data.
-
-        Returns True if any migrations were applied (caller should resave).
-        """
-        current_version = data.get("schema_version", 0)
-
-        if current_version >= CURRENT_SCHEMA_VERSION:
-            return False
-
-        if self.storage_file.exists():
-            backup_path = self.storage_file.with_suffix(f".json.v{current_version}_backup")
-            if not backup_path.exists():
-                try:
-                    shutil.copy2(self.storage_file, backup_path)
-                    logger.info(f"Created pre-migration backup at {backup_path}")
-                except Exception as e:
-                    logger.warning(f"Could not create backup: {e}")
-
-        for target_version, migrate_fn in MIGRATIONS:
-            if current_version >= target_version:
-                continue
-            count = migrate_fn(data)
-            logger.info(f"Schedules schema migration v{current_version}->v{target_version}: {count} change(s) applied")
-            current_version = target_version
-
-        data["schema_version"] = CURRENT_SCHEMA_VERSION
-        return True
-
     def _load(self) -> None:
         """Load schedules from storage file, running migrations if needed."""
-        if not self.storage_file.exists():
-            self._schedules = {}
-            self._default_page_id = None
-            self._default_page_by_board = {}
-            self._failed_entries = []
-            return
-
         try:
-            # Use builtins.open (not Path.open) so existing tests can
-            # patch builtins.open to inject I/O errors.
-            with open(self.storage_file) as f:  # noqa: PTH123
-                data = json.load(f)
+            data = self._store.load()
+            if data is None:
+                self._schedules = {}
+                self._default_page_id = None
+                self._default_page_by_board = {}
+                self._failed_entries = []
+                return
 
-            needs_save = self._run_migrations(data)
+            needs_save = self._store.migrated
 
             self._schedules = {}
             self._failed_entries = []
@@ -217,12 +183,7 @@ class ScheduleStorage:
             self._failed_entries = []
 
     def _save(self) -> None:
-        """Save schedules to storage file.
-
-        Writes to a sibling ``<file>.tmp`` and ``os.replace``s it into place
-        so a mid-write crash (OOM, SIGKILL, power loss) never leaves a
-        truncated file that would wipe in-memory state on reload (see #1304).
-        """
+        """Save schedules to storage file atomically via the storage kernel."""
         try:
             schedules_out: list[dict] = []
             for schedule in self._schedules.values():
@@ -248,19 +209,7 @@ class ScheduleStorage:
             # Datetimes are already coerced to ISO strings while building
             # schedules_out above (covers both parsed schedules and preserved
             # _failed_entries), so write data straight out — atomically.
-            tmp_path = staging_path(self.storage_file)
-            try:
-                # Use builtins.open (not Path.open) on the tmp path so existing
-                # tests can patch builtins.open to inject I/O errors.
-                with open(tmp_path, "w") as f:  # noqa: PTH123
-                    json.dump(data, f, indent=2)
-                tmp_path.replace(self.storage_file)
-            except BaseException:
-                # Clean up the partial tmp file on any failure so we don't
-                # leak it; the original storage file stays untouched.
-                with contextlib.suppress(OSError):
-                    tmp_path.unlink(missing_ok=True)
-                raise
+            self._store.save(data)
 
             logger.debug(f"Saved {len(self._schedules)} schedules to storage")
 
@@ -302,15 +251,16 @@ class ScheduleStorage:
 
     def create(self, schedule: ScheduleEntry) -> ScheduleEntry:
         """Create a new schedule entry."""
-        if schedule.id in self._schedules:
-            raise ValueError(f"Schedule with ID {schedule.id} already exists")
-        if not schedule.board_id:
-            schedule.board_id = DEFAULT_BOARD_ID
-        errors = schedule.validate_config()
-        if errors:
-            raise ValueError(f"Invalid schedule configuration: {errors}")
-        self._schedules[schedule.id] = schedule
-        self._save()
+        with self._store.lock:
+            if schedule.id in self._schedules:
+                raise ValueError(f"Schedule with ID {schedule.id} already exists")
+            if not schedule.board_id:
+                schedule.board_id = DEFAULT_BOARD_ID
+            errors = schedule.validate_config()
+            if errors:
+                raise ValueError(f"Invalid schedule configuration: {errors}")
+            self._schedules[schedule.id] = schedule
+            self._save()
         logger.info(f"Created schedule: {schedule.id} (board_id={schedule.board_id})")
         return schedule
 
@@ -324,6 +274,10 @@ class ScheduleStorage:
         Returns:
             Updated schedule if found, None otherwise
         """
+        with self._store.lock:
+            return self._update_locked(schedule_id, updates)
+
+    def _update_locked(self, schedule_id: str, updates: dict) -> ScheduleEntry | None:
         if schedule_id not in self._schedules:
             return None
 
@@ -369,11 +323,12 @@ class ScheduleStorage:
         Returns:
             True if deleted, False if not found
         """
-        if schedule_id not in self._schedules:
-            return False
+        with self._store.lock:
+            if schedule_id not in self._schedules:
+                return False
 
-        del self._schedules[schedule_id]
-        self._save()
+            del self._schedules[schedule_id]
+            self._save()
 
         logger.info(f"Deleted schedule: {schedule_id}")
         return True
@@ -403,13 +358,14 @@ class ScheduleStorage:
     def set_default_page_id(self, page_id: str | None, board_id: str | None = None) -> None:
         """Set the default page ID for schedule gaps for the given board."""
         bid = board_id or DEFAULT_BOARD_ID
-        if bid == DEFAULT_BOARD_ID:
-            self._default_page_id = page_id
-        if page_id:
-            self._default_page_by_board[bid] = page_id
-        else:
-            self._default_page_by_board.pop(bid, None)
+        with self._store.lock:
             if bid == DEFAULT_BOARD_ID:
-                self._default_page_id = None
-        self._save()
+                self._default_page_id = page_id
+            if page_id:
+                self._default_page_by_board[bid] = page_id
+            else:
+                self._default_page_by_board.pop(bid, None)
+                if bid == DEFAULT_BOARD_ID:
+                    self._default_page_id = None
+            self._save()
         logger.info(f"Set default page ID for board {bid!r} to: {page_id}")

--- a/src/schedules/storage.py
+++ b/src/schedules/storage.py
@@ -6,6 +6,7 @@ Includes schema versioning and automatic migration on startup.
 
 import json
 import logging
+import threading
 from collections.abc import Callable
 from datetime import UTC, datetime
 
@@ -119,6 +120,12 @@ class ScheduleStorage:
         self._load()
 
         logger.info(f"ScheduleStorage initialized (file: {self.storage_file}, schedules: {len(self._schedules)})")
+
+    @property
+    def lock(self) -> threading.RLock:
+        """The kernel store's lock, for out-of-band writers of this file
+        (the backup restore, #1860) to serialise against normal saves."""
+        return self._store.lock
 
     def _load(self) -> None:
         """Load schedules from storage file, running migrations if needed."""

--- a/src/settings/service.py
+++ b/src/settings/service.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 import shutil
+import threading
 from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
@@ -782,6 +783,12 @@ class SettingsService:
             self._needs_migration_save = False
 
         logger.info(f"SettingsService initialized (file: {self.settings_file})")
+
+    @property
+    def lock(self) -> threading.RLock:
+        """The kernel store's lock, for out-of-band writers of settings.json
+        (the backup restore, #1860) to serialise against normal saves."""
+        return self._store.lock
 
     @_locked
     def _run_migrations(self) -> None:

--- a/src/settings/service.py
+++ b/src/settings/service.py
@@ -4,7 +4,7 @@ This service allows runtime modification of settings like transition
 animations and output targets, which can be controlled from the UI.
 """
 
-import contextlib
+import functools
 import json
 import logging
 import os
@@ -12,11 +12,9 @@ import shutil
 from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
-from pathlib import Path
 from typing import Literal, Optional
 
-from src.atomic_io import staging_path
-from src.paths import get_data_dir
+from src.storage.json_store import JsonStore
 
 logger = logging.getLogger(__name__)
 
@@ -716,6 +714,24 @@ MIGRATIONS: list[tuple[int, Callable[[dict], int]]] = [
 ]
 
 
+def _locked(method):
+    """Run *method* under the settings store lock.
+
+    Every mutating method is a read-modify-write over the shared in-memory
+    sections followed by a full-file save; without one lock around the whole
+    thing, two concurrent PUTs race the save and one silently overwrites the
+    other's section with a stale snapshot (#1848). The lock is the JsonStore's
+    RLock, so nested ``_save_to_file`` calls re-enter cleanly.
+    """
+
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+        with self._store.lock:
+            return method(self, *args, **kwargs)
+
+    return wrapper
+
+
 class SettingsService:
     """Service for managing runtime settings.
 
@@ -729,11 +745,17 @@ class SettingsService:
         Args:
             settings_file: Path to settings JSON file. Defaults to data/settings.json
         """
-        if settings_file is None:
-            # Default to the central data directory (src/paths.py seam)
-            self.settings_file = get_data_dir() / "settings.json"
-        else:
-            self.settings_file = Path(settings_file)
+        # The storage kernel owns the lock and the atomic write. Migrations
+        # stay domain-run in _run_migrations below (they must execute before
+        # any _load_* reads sections, and settings' error semantics — swallow
+        # unreadable files, skip non-dict payloads — predate the kernel), so
+        # no migrations are handed to the store.
+        self._store = JsonStore(
+            "settings.json" if settings_file is None else settings_file,
+            current_schema_version=CURRENT_SETTINGS_SCHEMA_VERSION,
+            label="Settings",
+        )
+        self.settings_file = self._store.path
 
         # Run ordered schema migrations on the raw settings file BEFORE any
         # subsystem reads, so every _load_* sees fully migrated values. This
@@ -761,6 +783,7 @@ class SettingsService:
 
         logger.info(f"SettingsService initialized (file: {self.settings_file})")
 
+    @_locked
     def _run_migrations(self) -> None:
         """Run pending settings schema migrations on the raw settings file.
 
@@ -816,22 +839,13 @@ class SettingsService:
             logger.warning(f"Could not write migrated settings: {e}")
 
     def _atomic_write_json(self, data: dict) -> None:
-        """Write *data* to ``settings_file`` atomically (tmp + os.replace).
+        """Write *data* to ``settings_file`` atomically via the storage kernel.
 
         A mid-write crash (OOM, SIGKILL, power loss) never truncates the real
-        file — it stays untouched until the temp file is fully written and
-        renamed over it (see #1304). Uses builtins.open on the tmp path so
-        existing tests can patch builtins.open to inject write errors.
+        file — it stays untouched until the staged file is fully written and
+        renamed over it (see #1304).
         """
-        tmp_path = staging_path(self.settings_file)
-        try:
-            with open(tmp_path, "w") as f:  # noqa: PTH123
-                json.dump(data, f, indent=2)
-            tmp_path.replace(self.settings_file)
-        except BaseException:
-            with contextlib.suppress(OSError):
-                tmp_path.unlink(missing_ok=True)
-            raise
+        self._store.save(data)
 
     def _load_from_file(self) -> dict:
         """Load settings from JSON file."""
@@ -845,6 +859,7 @@ class SettingsService:
                 logger.warning(f"Failed to load settings file: {e}")
         return {}
 
+    @_locked
     def _save_to_file(self) -> None:
         """Save current settings to JSON file."""
         try:
@@ -1026,6 +1041,7 @@ class SettingsService:
         """Get current transition settings."""
         return self._transition
 
+    @_locked
     def update_transition_settings(
         self, strategy: str | None = ..., step_interval_ms: int | None = ..., step_size: int | None = ...
     ) -> TransitionSettings:
@@ -1071,6 +1087,7 @@ class SettingsService:
         """Get current output settings."""
         return self._output
 
+    @_locked
     def set_output_target(self, target: OutputTarget) -> OutputSettings:
         """Set the output target.
 
@@ -1120,6 +1137,7 @@ class SettingsService:
             return self._active_page.page_id
         return None
 
+    @_locked
     def set_active_page_id(self, page_id: str | None, board_id: str | None = None) -> ActivePageSettings:
         """Set the active (manual) page ID for a board.
 
@@ -1168,6 +1186,7 @@ class SettingsService:
         """
         return self._polling.interval_seconds
 
+    @_locked
     def set_polling_interval(self, interval_seconds: int) -> PollingSettings:
         """Set the polling interval.
 
@@ -1185,6 +1204,7 @@ class SettingsService:
         logger.info(f"Polling interval set to: {interval_seconds} seconds")
         return self._polling
 
+    @_locked
     def set_board_read_intervals(
         self,
         local_seconds: int | None = None,
@@ -1241,6 +1261,7 @@ class SettingsService:
             return bid if bid else None
         return None
 
+    @_locked
     def set_board_type(self, board_type: Literal["black", "white"] | None) -> BoardSettings:
         """Set the board type for UI rendering.
 
@@ -1258,6 +1279,7 @@ class SettingsService:
         logger.info(f"Board type set to: {board_type}")
         return self._board
 
+    @_locked
     def set_devices(self, devices: list[str]) -> BoardSettings:
         """Set the configured device types (backward-compatible).
 
@@ -1307,6 +1329,7 @@ class SettingsService:
         logger.info(f"Configured devices set to: {valid_devices}")
         return self._board
 
+    @_locked
     def set_boards(self, boards: list[dict]) -> BoardSettings:
         """Set the configured board instances.
 
@@ -1370,6 +1393,7 @@ class SettingsService:
         logger.info(f"Configured boards set to: {[b.get('name') for b in validated]}")
         return self._board
 
+    @_locked
     def add_board(self, board: dict) -> BoardSettings:
         """Add a new board instance.
 
@@ -1399,6 +1423,7 @@ class SettingsService:
             n += 1
         return f"My Board {n}"
 
+    @_locked
     def remove_board(self, board_id: str) -> BoardSettings:
         """Remove a board instance by ID.
 
@@ -1453,6 +1478,7 @@ class SettingsService:
             return bool(self._board.boards[0].get("paused", False))
         return False
 
+    @_locked
     def set_paused(self, paused: bool, board_id: str | None = None) -> bool:
         """Pause or resume a board (or the first board when board_id is None).
 
@@ -1502,6 +1528,7 @@ class SettingsService:
         # No boards configured: fall back to the deprecated global mirror.
         return self._schedule.enabled
 
+    @_locked
     def set_schedule_enabled(self, enabled: bool, board_id: str | None = None) -> ScheduleSettings:
         """Enable or disable schedule mode for a board.
 
@@ -1534,6 +1561,7 @@ class SettingsService:
         """Return current MQTT integration settings."""
         return self._mqtt
 
+    @_locked
     def set_mqtt_settings(self, updates: dict) -> "MQTTSettings":
         """Persist MQTT settings and return updated object.
 
@@ -1560,6 +1588,7 @@ class SettingsService:
         """Return current web UI display settings."""
         return self._display
 
+    @_locked
     def update_display_settings(self, updates: dict) -> "DisplaySettings":
         """Update display settings and persist.
 
@@ -1581,6 +1610,7 @@ class SettingsService:
         """Return current location settings for sun-based schedules."""
         return self._location
 
+    @_locked
     def update_location_settings(self, updates: dict) -> "LocationSettings":
         """Update location settings and persist.
 
@@ -1600,6 +1630,7 @@ class SettingsService:
         """Return current beta-feature settings."""
         return self._beta
 
+    @_locked
     def update_beta_settings(self, updates: dict) -> "BetaSettings":
         """Update beta-feature settings and persist.
 
@@ -1620,6 +1651,7 @@ class SettingsService:
         """Return current plugin system settings."""
         return self._plugins
 
+    @_locked
     def update_plugin_settings(self, updates: dict) -> "PluginSettings":
         """Update plugin settings and persist. Only keys present in *updates* are changed."""
         if "auto_update" in updates:
@@ -1629,6 +1661,7 @@ class SettingsService:
         return self._plugins
 
     # Temporary override
+    @_locked
     def get_temporary_override(self) -> TemporaryOverride | None:
         """Return the active temporary override, or None if absent or expired.
 
@@ -1643,6 +1676,7 @@ class SettingsService:
             return None
         return self._temporary_override
 
+    @_locked
     def consume_temporary_override(self) -> TemporaryOverride | None:
         """Return the current temporary override (live or expired) and clear it if expired.
 
@@ -1659,6 +1693,7 @@ class SettingsService:
             self._save_to_file()
         return raw
 
+    @_locked
     def set_temporary_override(self, override: TemporaryOverride) -> TemporaryOverride:
         """Persist a new temporary override, replacing any existing one."""
         self._temporary_override = override
@@ -1671,6 +1706,7 @@ class SettingsService:
         )
         return override
 
+    @_locked
     def clear_temporary_override(self) -> None:
         """Remove the temporary override without applying any revert logic."""
         if self._temporary_override is not None:

--- a/src/storage/__init__.py
+++ b/src/storage/__init__.py
@@ -1,0 +1,10 @@
+"""Storage kernel: the one atomic, locked, schema-versioned JSON store.
+
+Every JSON-file store (pages, schedules, collections, panels, settings) is
+built on :class:`src.storage.json_store.JsonStore` instead of open-coding the
+staging-file write, the lock, and the migration runner.
+"""
+
+from .json_store import JsonStore
+
+__all__ = ["JsonStore"]

--- a/src/storage/json_store.py
+++ b/src/storage/json_store.py
@@ -140,6 +140,15 @@ class JsonStore:
         fresh ``{}`` when the file is missing) → ``fn(data)`` → save.
 
         ``fn`` mutates the data in place; its return value is passed through.
+
+        Assumes this store instance is the only writer of its file: once
+        ``self._data`` is populated it is trusted as-is — the file is never
+        re-read, so changes written by another JsonStore instance or another
+        process are silently overwritten. The missing-file path starts from a
+        bare ``{}`` without running migrations (``load()`` on an existing
+        file is where migrations happen). Use the process-wide singleton
+        store for a given file, and single-process deployment, for this to
+        hold.
         """
         with self._lock:
             data = self._data

--- a/src/storage/json_store.py
+++ b/src/storage/json_store.py
@@ -1,0 +1,184 @@
+"""The storage kernel: one atomic, locked, schema-versioned JSON file store.
+
+``JsonStore`` owns the three things every FiestaBoard store used to open-code
+(and drift on):
+
+* **Atomic writes** — every save goes through
+  :func:`src.atomic_io.write_json_atomic` (process-scoped staging file, fsync,
+  ``os.replace``), so a mid-write crash never truncates the real file (#1304)
+  and two processes never collide on a fixed ``.tmp`` name.
+
+* **In-process locking** — a ``threading.RLock`` serialises ``load``/``save``/
+  ``mutate``. The lock is public (:attr:`lock`) so a composing service can
+  extend the critical section around its own read-modify-write (the fix for
+  lost concurrent settings PUTs, #1848).
+
+* **Schema migrations** — the ordered ``(target_version, fn)`` machinery from
+  ``src/pages/storage.py``, generalised. Migration functions receive the raw
+  top-level object (usually a dict; stores whose payload is a wrapped list
+  adapt with a small lambda) and are run in order on ``load()`` when the
+  file's ``schema_version`` is behind. A backup of the pre-migration file is
+  written once as ``<file>.v{N}_backup``. The kernel does **not** write the
+  migrated data back itself — it sets :attr:`migrated` and the domain store
+  persists via its own ``save`` path, so the on-disk bytes keep coming from
+  the domain's serialisation exactly as before.
+
+Domain rules stay in the domain: each store keeps its own
+``CURRENT_SCHEMA_VERSION`` and ``MIGRATIONS`` list (per CLAUDE.md, never
+heuristic detection) and hands them to the kernel to run.
+"""
+
+import json
+import logging
+import shutil
+import threading
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import Any
+
+from src.atomic_io import write_json_atomic
+from src.paths import get_data_dir
+
+logger = logging.getLogger(__name__)
+
+# A migration: (target_version, fn). ``fn`` mutates the raw top-level data in
+# place and returns the number of records/changes it touched (for logging).
+Migration = tuple[int, Callable[[Any], int]]
+
+
+class JsonStore:
+    """Atomic, locked, schema-versioned persistence for one JSON file."""
+
+    def __init__(
+        self,
+        filename_or_path: str | Path,
+        *,
+        current_schema_version: int = 0,
+        migrations: Sequence[Migration] = (),
+        label: str | None = None,
+    ):
+        """Create a store for one JSON file.
+
+        Args:
+            filename_or_path: A bare filename (``"pages.json"``) resolves into
+                the central data directory via ``get_data_dir()``; anything
+                with a directory component is used as given (explicit path
+                wins).
+            current_schema_version: The version ``save()`` stamps on dict
+                payloads and ``load()`` migrates files up to. ``0`` disables
+                schema versioning entirely.
+            migrations: Ordered ``(target_version, fn)`` pairs; each ``fn``
+                mutates the raw loaded object in place and returns a count.
+            label: Name used in migration log lines (defaults to the file
+                stem).
+        """
+        path = Path(filename_or_path)
+        if len(path.parts) == 1:
+            path = get_data_dir() / path
+        self._path = path
+        self._version = current_schema_version
+        self._migrations = list(migrations)
+        self._label = label or path.stem
+        self._lock = threading.RLock()
+        self._data: Any = None
+        #: True when the most recent ``load()`` applied migrations; the caller
+        #: should persist (``mutate()`` does so automatically).
+        self.migrated = False
+
+    @property
+    def path(self) -> Path:
+        """The resolved on-disk path of this store."""
+        return self._path
+
+    @property
+    def lock(self) -> threading.RLock:
+        """The store's re-entrant lock, for composing services that need to
+        extend the critical section around their own read-modify-write."""
+        return self._lock
+
+    def exists(self) -> bool:
+        """True when the backing file exists on disk."""
+        return self._path.exists()
+
+    # ── core operations ────────────────────────────────────────────────
+
+    def load(self) -> Any:
+        """Read the file, run any pending migrations, and return the data.
+
+        Returns ``None`` when the file does not exist. Read/parse errors
+        propagate — the domain store decides whether a broken file is fatal.
+        Sets :attr:`migrated` when migrations ran; the migrated data is NOT
+        written back here (see module docstring).
+        """
+        with self._lock:
+            self.migrated = False
+            if not self._path.exists():
+                self._data = None
+                return None
+            # builtins.open (not Path.open) so existing tests can patch
+            # builtins.open to inject I/O errors.
+            with open(self._path) as f:  # noqa: PTH123
+                data = json.load(f)
+            if self._migrations_pending(data):
+                self._backup_before_migration(data)
+                self._run_migrations(data)
+                self.migrated = True
+            self._data = data
+            return data
+
+    def save(self, data: Any) -> None:
+        """Atomically persist *data*, stamping ``schema_version`` on
+        versioned dict payloads. Write errors propagate."""
+        with self._lock:
+            if self._version and isinstance(data, dict):
+                data["schema_version"] = self._version
+            write_json_atomic(self._path, data)
+            self._data = data
+
+    def mutate(self, fn: Callable[[Any], Any]) -> Any:
+        """The read-modify-write primitive: lock → load (or cached data, or a
+        fresh ``{}`` when the file is missing) → ``fn(data)`` → save.
+
+        ``fn`` mutates the data in place; its return value is passed through.
+        """
+        with self._lock:
+            data = self._data
+            if data is None:
+                data = self.load()
+            if data is None:
+                data = {}
+            result = fn(data)
+            self.save(data)
+            return result
+
+    # ── schema migrations ──────────────────────────────────────────────
+
+    def _migrations_pending(self, data: Any) -> bool:
+        return self._version > 0 and isinstance(data, dict) and self._file_version(data) < self._version
+
+    @staticmethod
+    def _file_version(data: dict) -> int:
+        version = data.get("schema_version", 0)
+        return version if isinstance(version, int) else 0
+
+    def _backup_before_migration(self, data: dict) -> None:
+        """Copy the pre-migration file to ``<file>.v{N}_backup``, once."""
+        version = self._file_version(data)
+        backup_path = self._path.with_suffix(f"{self._path.suffix}.v{version}_backup")
+        if backup_path.exists():
+            return
+        try:
+            shutil.copy2(self._path, backup_path)
+            logger.info(f"Created pre-migration backup at {backup_path}")
+        except Exception as e:
+            logger.warning(f"Could not create backup: {e}")
+
+    def _run_migrations(self, data: dict) -> None:
+        version = self._file_version(data)
+        for target_version, migrate_fn in self._migrations:
+            if version >= target_version:
+                continue
+            count = migrate_fn(data)
+            logger.info(f"{self._label} schema migration v{version}->v{target_version}: {count} change(s) applied")
+            version = target_version
+        data["schema_version"] = self._version

--- a/tests/golden/storage/collections.json
+++ b/tests/golden/storage/collections.json
@@ -1,0 +1,21 @@
+{
+  "schema_version": 1,
+  "collections": [
+    {
+      "id": "collection:golden-1",
+      "name": "Golden Collection",
+      "page_ids": [
+        "page-golden-1",
+        "page-golden-2"
+      ],
+      "selection_mode": "time",
+      "time": {
+        "interval_seconds": 30
+      },
+      "variable": null,
+      "random": null,
+      "created_at": "2026-01-02T03:04:05+00:00",
+      "updated_at": "2026-01-02T03:04:05+00:00"
+    }
+  ]
+}

--- a/tests/golden/storage/pages.json
+++ b/tests/golden/storage/pages.json
@@ -1,0 +1,82 @@
+{
+  "schema_version": 4,
+  "pages": [
+    {
+      "id": "page-golden-1",
+      "name": "Golden Page",
+      "type": "template",
+      "device_type": "flagship",
+      "display_type": null,
+      "rows": null,
+      "template": [
+        "HELLO WORLD",
+        "",
+        "{{date_time.time}}",
+        "",
+        "",
+        ""
+      ],
+      "line_metadata": [
+        {
+          "alignment": "center",
+          "wrap": false
+        },
+        {
+          "alignment": "center",
+          "wrap": false
+        },
+        {
+          "alignment": "center",
+          "wrap": false
+        },
+        {
+          "alignment": "center",
+          "wrap": false
+        },
+        {
+          "alignment": "center",
+          "wrap": false
+        },
+        {
+          "alignment": "center",
+          "wrap": false
+        }
+      ],
+      "duration_seconds": 300,
+      "transition_strategy": null,
+      "transition_interval_ms": null,
+      "transition_step_size": null,
+      "demo_plugin_id": null,
+      "notes_wide": 1,
+      "notes_tall": 1,
+      "created_at": "2026-01-02T03:04:05+00:00",
+      "updated_at": "2026-01-02T03:04:05+00:00"
+    },
+    {
+      "id": "page-golden-2",
+      "name": "Another Page",
+      "type": "template",
+      "device_type": "flagship",
+      "display_type": null,
+      "rows": null,
+      "template": [
+        "SECOND",
+        "",
+        "",
+        "",
+        "",
+        ""
+      ],
+      "line_metadata": null,
+      "duration_seconds": 300,
+      "transition_strategy": null,
+      "transition_interval_ms": null,
+      "transition_step_size": null,
+      "demo_plugin_id": null,
+      "notes_wide": 1,
+      "notes_tall": 1,
+      "created_at": "2026-01-03T06:07:08+00:00",
+      "updated_at": "2026-01-03T06:07:08+00:00"
+    }
+  ]
+}

--- a/tests/golden/storage/panels.json
+++ b/tests/golden/storage/panels.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 5,
+  "panels": [
+    {
+      "id": "panel-golden-1",
+      "short_code": 1,
+      "name": "Golden Panel",
+      "board_id": "board-golden-1",
+      "screen_diagonal_inches": 55.0,
+      "screen_aspect_w": 16.0,
+      "screen_aspect_h": 9.0,
+      "calibration_scale": 1.0,
+      "animations_enabled": false,
+      "is_display": false,
+      "backdrop": "wall",
+      "auto_dim": {
+        "enabled": false,
+        "start": "22:00",
+        "end": "07:00"
+      },
+      "created_at": "2026-01-02T03:04:05+00:00",
+      "updated_at": "2026-01-02T03:04:05+00:00"
+    }
+  ]
+}

--- a/tests/golden/storage/schedules.json
+++ b/tests/golden/storage/schedules.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": 2,
+  "schedules": [
+    {
+      "id": "sched-golden-1",
+      "board_id": "",
+      "page_id": "page-golden-1",
+      "start_time": "08:00",
+      "end_time": "10:00",
+      "day_pattern": "all",
+      "custom_days": null,
+      "enabled": true,
+      "recurrence_type": "weekly",
+      "annual_date": null,
+      "annual_end_date": null,
+      "one_off_date": null,
+      "one_off_end_date": null,
+      "start_type": "fixed",
+      "start_sun_offset": 0,
+      "end_type": "fixed",
+      "end_sun_offset": 0,
+      "created_at": "2026-01-02T03:04:05+00:00",
+      "updated_at": "2026-01-02T03:04:05+00:00"
+    }
+  ],
+  "default_page_id": null,
+  "default_page_by_board": {}
+}

--- a/tests/golden/storage/settings.json
+++ b/tests/golden/storage/settings.json
@@ -1,0 +1,78 @@
+{
+  "schema_version": 2,
+  "transitions": {
+    "strategy": null,
+    "step_interval_ms": null,
+    "step_size": null
+  },
+  "output": {
+    "target": "board"
+  },
+  "active_page": {
+    "page_id": "page-golden-1",
+    "by_board": {
+      "board-golden-1": "page-golden-1"
+    }
+  },
+  "polling": {
+    "interval_seconds": 15,
+    "board_read_interval_local": 30,
+    "board_read_interval_cloud": 180
+  },
+  "board": {
+    "board_type": "black",
+    "boards": [
+      {
+        "id": "board-golden-1",
+        "name": "Golden Board",
+        "device_type": "flagship",
+        "board_color": "black",
+        "code62_glyph": "degree",
+        "enabled": true,
+        "paused": false,
+        "schedule_enabled": false,
+        "api_mode": "local",
+        "host": "192.0.2.10",
+        "port": 7000,
+        "local_api_key": "test_key_golden",
+        "cloud_key": "",
+        "note_array_token": "",
+        "notes_wide": 1,
+        "notes_tall": 1,
+        "tiles": []
+      }
+    ],
+    "devices": [
+      "flagship"
+    ]
+  },
+  "schedule": {
+    "enabled": false
+  },
+  "mqtt": {
+    "enabled": false,
+    "broker_host": "localhost",
+    "broker_port": 1883,
+    "username": "",
+    "password": "",
+    "external_url": ""
+  },
+  "display": {
+    "reduce_motion": false,
+    "board_animations": "on",
+    "site_animations": "on",
+    "board_flap_speed": "standard"
+  },
+  "location": {
+    "latitude": null,
+    "longitude": null
+  },
+  "beta": {
+    "https_enabled": false,
+    "transition_plugins_enabled": false
+  },
+  "plugins": {
+    "auto_update": true
+  },
+  "temporary_override": null
+}

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -48,11 +48,23 @@ def competing_writer(monkeypatch):
     monkeypatch.undo()
 
 
-def test_staging_path_is_scoped_to_the_process():
-    """Two processes must never pick the same staging filename."""
-    import os
+def test_staging_path_is_unique_per_call_and_scoped_to_the_process():
+    """No two writers — across processes or within one — may share a staging name.
 
-    assert staging_path(Path("/data/pages.json")) == Path(f"/data/pages.json.{os.getpid()}.tmp")
+    The name carries the pid (cross-process uniqueness) plus a per-process
+    monotonic counter, so two threads staging the same target in the same
+    process (a settings PUT racing a restore, #1860) can never open each
+    other's staging file.
+    """
+    import os
+    import re
+
+    first = staging_path(Path("/data/pages.json"))
+    second = staging_path(Path("/data/pages.json"))
+
+    assert re.fullmatch(rf"/data/pages\.json\.{os.getpid()}\.\d+\.tmp", str(first))
+    assert first != second, "two calls shared a staging name"
+    assert first.parent == Path("/data"), "staging file must stay a sibling of the target"
 
 
 def _saved_without_error(save, target: Path, competing_writer) -> dict:

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -480,3 +480,84 @@ def test_import_endpoint_does_not_leak_plugin_install_errors(client_with_data_di
     assert "SECRET_INTERNAL_XYZ" not in response.text
     body = response.json()
     assert body["plugins"]["failed"] and body["plugins"]["failed"][0]["plugin_id"] == "weather"
+
+
+# ── restore vs. concurrent store writes (#1860) ─────────────────────────────
+
+
+def test_restore_survives_a_concurrent_settings_save(monkeypatch):
+    """A restore and an in-flight settings save must both land coherently.
+
+    Repro from review of #1860: a settings PUT is paused inside ``json.dump``
+    (holding the settings store's lock) while a restore rewrites
+    ``settings.json``. With both writers staging at the same
+    ``<file>.<pid>.tmp`` name and the restore taking no store lock, the
+    restore's rename adopts the paused writer's inode; the resumed save then
+    scribbles over the restored file in place and its own final rename dies
+    with FileNotFoundError — a corrupted or silently reverted restore.
+    """
+    import threading
+
+    from src.paths import get_data_dir
+    from src.settings.service import get_settings_service
+
+    data_dir = get_data_dir()
+    settings_file = data_dir / "settings.json"
+    svc = get_settings_service()  # the live singleton — owns the settings lock
+
+    restore_payload = {
+        "transitions": {"strategy": "column"},
+        "padding_so_the_restore_is_longer_than_the_settings_dump": "x" * 512,
+    }
+    backup = {
+        BACKUP_FILE_MARKER: True,
+        "schema_version": BACKUP_SCHEMA_VERSION,
+        "data": {"settings": restore_payload},
+    }
+
+    real_dump = json.dump
+    settings_ident: list[int] = []
+    paused_in_dump = threading.Event()
+    resume_dump = threading.Event()
+    errors: list[BaseException] = []
+
+    def pausing_dump(obj, fh, **kwargs):
+        if settings_ident and threading.get_ident() == settings_ident[0]:
+            paused_in_dump.set()
+            assert resume_dump.wait(15), "orchestration stalled: dump never resumed"
+        return real_dump(obj, fh, **kwargs)
+
+    monkeypatch.setattr("src.atomic_io.json.dump", pausing_dump)
+
+    def settings_save():
+        settings_ident.append(threading.get_ident())
+        try:
+            svc._atomic_write_json({"display": {"reduce_motion": True}})
+        except BaseException as exc:
+            errors.append(exc)
+
+    def run_restore():
+        try:
+            with patch("src.backup.service._reload_services", return_value=[]):
+                BackupService(data_dir=data_dir).import_from_dict(backup, reinstall_plugins=False)
+        except BaseException as exc:
+            errors.append(exc)
+
+    saver = threading.Thread(target=settings_save)
+    saver.start()
+    assert paused_in_dump.wait(15), "settings save never reached json.dump"
+
+    restorer = threading.Thread(target=run_restore)
+    restorer.start()
+    # Post-fix the restore blocks on the settings store lock, so this join
+    # times out; pre-fix it sails through and clobbers the paused writer.
+    restorer.join(timeout=1.5)
+
+    resume_dump.set()
+    saver.join(timeout=15)
+    restorer.join(timeout=15)
+    assert not saver.is_alive() and not restorer.is_alive(), "writer threads wedged"
+
+    assert errors == [], f"a writer blew up: {errors!r}"
+    on_disk = json.loads(settings_file.read_text())  # corrupt pre-fix
+    assert on_disk == restore_payload, "restore was silently reverted by the concurrent save"

--- a/tests/test_silence_per_board_composition.py
+++ b/tests/test_silence_per_board_composition.py
@@ -175,6 +175,7 @@ class TestBoardRemovalPrunesOverrides:
     def test_remove_board_prunes_its_silence_override(self, real_config, tmp_path):
         """Removing a board deletes its ``by_board`` entry (issue #1788 review)."""
         from src.settings.service import SettingsService
+        from src.storage.json_store import JsonStore
 
         real_config.set_silence_schedule_for_board(
             "board-1", {"enabled": True, "start_time": "01:00+00:00", "end_time": "02:00+00:00"}
@@ -186,6 +187,9 @@ class TestBoardRemovalPrunesOverrides:
         service = SettingsService.__new__(SettingsService)
         service._board = Mock(boards=[dict(BOARD_1), dict(BOARD_2)])
         service._save_to_file = Mock()
+        # #1848: every mutator runs under the storage-kernel lock, so a
+        # __new__-constructed service needs the store the lock lives on.
+        service._store = JsonStore(tmp_path / "settings.json")
 
         service.remove_board("board-2")
 

--- a/tests/test_storage_kernel.py
+++ b/tests/test_storage_kernel.py
@@ -18,6 +18,7 @@ Three sections:
    blow up on the shared process-scoped staging file.
 """
 
+import contextlib
 import json
 import shutil
 import stat
@@ -313,3 +314,68 @@ class TestGoldenOnDiskFormat:
         path, golden = _pin(tmp_path, "settings.json")
         SettingsService(settings_file=str(path))._save_to_file()
         assert path.read_bytes() == golden
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 3. Concurrent writers
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def _force_write_overlap(monkeypatch):
+    """Patch ``json.dump`` so two concurrent saves are forced to overlap.
+
+    Both writers rendezvous on a barrier inside the serialisation step; with
+    no store lock they then race the shared PID-scoped staging file (second
+    ``os.replace`` dies ENOENT, or one write lands on the already-renamed
+    inode). With the store lock the second writer never reaches ``json.dump``
+    until the first is done, the barrier times out, and both proceed serially.
+    """
+    barrier = threading.Barrier(2, timeout=0.3)
+    real_dump = json.dump
+
+    def overlapping_dump(obj, fh, *args, **kwargs):
+        with contextlib.suppress(threading.BrokenBarrierError):
+            barrier.wait()
+        return real_dump(obj, fh, *args, **kwargs)
+
+    monkeypatch.setattr(json, "dump", overlapping_dump)
+
+
+def _run_pair(fn_a, fn_b):
+    """Run two callables on two threads; return the exceptions they raised."""
+    errors = []
+
+    def wrap(fn):
+        try:
+            fn()
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=wrap, args=(f,)) for f in (fn_a, fn_b)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    return errors
+
+
+class TestConcurrentWriters:
+    def test_pages_two_threads_updating_disjoint_pages_both_survive(self, tmp_path, monkeypatch):
+        from src.pages.models import Page
+        from src.pages.storage import PageStorage
+
+        storage = PageStorage(storage_file=str(tmp_path / "pages.json"))
+        for pid in ("p1", "p2"):
+            storage.create(Page(id=pid, name=pid.upper(), type="template", template=["x", "", "", "", "", ""]))
+
+        _force_write_overlap(monkeypatch)
+        errors = _run_pair(
+            lambda: storage.update("p1", {"name": "First Updated"}),
+            lambda: storage.update("p2", {"name": "Second Updated"}),
+        )
+        monkeypatch.undo()
+
+        assert errors == []
+        reloaded = PageStorage(storage_file=str(tmp_path / "pages.json"))
+        assert reloaded.get("p1").name == "First Updated"
+        assert reloaded.get("p2").name == "Second Updated"

--- a/tests/test_storage_kernel.py
+++ b/tests/test_storage_kernel.py
@@ -386,9 +386,7 @@ class TestConcurrentWriters:
 
         storage = ScheduleStorage(storage_file=str(tmp_path / "schedules.json"))
         for sid in ("s1", "s2"):
-            storage.create(
-                ScheduleEntry(id=sid, page_id="p1", start_time="08:00", end_time="10:00", day_pattern="all")
-            )
+            storage.create(ScheduleEntry(id=sid, page_id="p1", start_time="08:00", end_time="10:00", day_pattern="all"))
 
         _force_write_overlap(monkeypatch)
         errors = _run_pair(

--- a/tests/test_storage_kernel.py
+++ b/tests/test_storage_kernel.py
@@ -441,3 +441,51 @@ class TestConcurrentWriters:
         reloaded = PanelStorage(storage_file=str(tmp_path / "panels.json"))
         assert reloaded.get("panel-1").name == "First Updated"
         assert reloaded.get("panel-2").name == "Second Updated"
+
+    def test_settings_two_concurrent_puts_to_different_sections_both_survive(self, tmp_path, monkeypatch):
+        """The #1848 headline bug: SettingsService rewrites ALL sections from
+        memory on every mutation with no lock, so a PUT whose save is paused
+        mid-serialisation gets lapped by a second PUT — the slow writer then
+        finishes onto the already-renamed inode and overwrites the fast
+        writer's section with its own stale snapshot (its rename dies ENOENT,
+        which ``_save_to_file`` swallows, so nobody even notices). The
+        interleaving is forced deterministically: writer A blocks inside
+        ``json.dump`` until writer B's whole PUT has completed (with a
+        timeout so the post-fix lock, which makes B wait for A, cannot
+        deadlock). Written before the fix — the pre-fix failure is recorded
+        verbatim in .fail-first-1848.txt."""
+        from src.settings.service import SettingsService
+
+        path = tmp_path / "settings.json"
+        svc = SettingsService(settings_file=str(path))
+        svc._save_to_file()
+
+        a_in_dump = threading.Event()
+        b_done = threading.Event()
+        real_dump = json.dump
+        first_call = threading.Event()
+
+        def sequenced_dump(obj, fh, *args, **kwargs):
+            if not first_call.is_set():
+                first_call.set()
+                a_in_dump.set()
+                b_done.wait(timeout=0.5)  # times out post-fix (B waits on the lock)
+            return real_dump(obj, fh, *args, **kwargs)
+
+        monkeypatch.setattr(json, "dump", sequenced_dump)
+
+        def writer_a():
+            svc.update_display_settings({"reduce_motion": True})
+
+        def writer_b():
+            a_in_dump.wait(timeout=1.0)
+            svc.update_location_settings({"latitude": 40.7128, "longitude": -74.0060})
+            b_done.set()
+
+        errors = _run_pair(writer_a, writer_b)
+        monkeypatch.undo()
+
+        assert errors == []
+        on_disk = json.loads(path.read_text())
+        assert on_disk["display"]["reduce_motion"] is True, "display PUT lost"
+        assert on_disk["location"]["latitude"] == 40.7128, "location PUT lost"

--- a/tests/test_storage_kernel.py
+++ b/tests/test_storage_kernel.py
@@ -421,3 +421,23 @@ class TestConcurrentWriters:
         reloaded = CollectionStorage(storage_file=str(tmp_path / "collections.json"))
         assert reloaded.get("collection:c1").name == "First Updated"
         assert reloaded.get("collection:c2").name == "Second Updated"
+
+    def test_panels_two_threads_updating_disjoint_panels_both_survive(self, tmp_path, monkeypatch):
+        from src.panels.models import Panel
+        from src.panels.storage import PanelStorage
+
+        storage = PanelStorage(storage_file=str(tmp_path / "panels.json"))
+        for pid in ("panel-1", "panel-2"):
+            storage.create(Panel(id=pid, name=pid, board_id="board-1"))
+
+        _force_write_overlap(monkeypatch)
+        errors = _run_pair(
+            lambda: storage.update("panel-1", {"name": "First Updated"}),
+            lambda: storage.update("panel-2", {"name": "Second Updated"}),
+        )
+        monkeypatch.undo()
+
+        assert errors == []
+        reloaded = PanelStorage(storage_file=str(tmp_path / "panels.json"))
+        assert reloaded.get("panel-1").name == "First Updated"
+        assert reloaded.get("panel-2").name == "Second Updated"

--- a/tests/test_storage_kernel.py
+++ b/tests/test_storage_kernel.py
@@ -401,3 +401,23 @@ class TestConcurrentWriters:
         reloaded = ScheduleStorage(storage_file=str(tmp_path / "schedules.json"))
         assert reloaded.get("s1").start_time == "09:00"
         assert reloaded.get("s2").start_time == "11:00"
+
+    def test_collections_two_threads_updating_disjoint_collections_both_survive(self, tmp_path, monkeypatch):
+        from src.collections.models import Collection
+        from src.collections.storage import CollectionStorage
+
+        storage = CollectionStorage(storage_file=str(tmp_path / "collections.json"))
+        for cid in ("collection:c1", "collection:c2"):
+            storage.create(Collection(id=cid, name=cid[-2:], page_ids=["p1"]))
+
+        _force_write_overlap(monkeypatch)
+        errors = _run_pair(
+            lambda: storage.update("collection:c1", {"name": "First Updated"}),
+            lambda: storage.update("collection:c2", {"name": "Second Updated"}),
+        )
+        monkeypatch.undo()
+
+        assert errors == []
+        reloaded = CollectionStorage(storage_file=str(tmp_path / "collections.json"))
+        assert reloaded.get("collection:c1").name == "First Updated"
+        assert reloaded.get("collection:c2").name == "Second Updated"

--- a/tests/test_storage_kernel.py
+++ b/tests/test_storage_kernel.py
@@ -1,0 +1,315 @@
+"""Storage kernel tests (#1848, absorbing #1759).
+
+Three sections:
+
+1. Kernel unit tests — ``src.atomic_io.write_json_atomic`` /
+   ``write_text_atomic`` and ``src.storage.json_store.JsonStore`` (locking,
+   load/save/mutate, schema-migration running, backup-before-first-migration,
+   crash atomicity).
+
+2. Golden on-disk format pins — each store loads a committed fixture, saves
+   it back, and the file must be byte-identical. Written BEFORE the stores
+   were rebuilt on the kernel; they passed on the old open-coded stores and
+   must keep passing identically afterwards. The fixtures under
+   ``tests/golden/storage/`` were produced by the pre-kernel code.
+
+3. Concurrent-writer tests — added per-store as each store adopts the
+   kernel; each reproduces the interleaving that used to lose an update or
+   blow up on the shared process-scoped staging file.
+"""
+
+import json
+import shutil
+import stat
+import threading
+from pathlib import Path
+
+import pytest
+
+GOLDEN = Path(__file__).parent / "golden" / "storage"
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 1. Kernel unit tests
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestWriteJsonAtomic:
+    def test_writes_indent2_json(self, tmp_path):
+        from src.atomic_io import write_json_atomic
+
+        target = tmp_path / "x.json"
+        write_json_atomic(target, {"a": 1})
+        assert target.read_text() == json.dumps({"a": 1}, indent=2)
+
+    def test_crash_mid_serialize_leaves_target_intact_and_no_staging_leak(self, tmp_path, monkeypatch):
+        from src import atomic_io
+
+        target = tmp_path / "x.json"
+        atomic_io.write_json_atomic(target, {"a": 1})
+        original = target.read_bytes()
+
+        def crashing_dump(obj, fh, *args, **kwargs):
+            fh.write('{"a": ')
+            fh.flush()
+            raise OSError("simulated crash mid-write")
+
+        monkeypatch.setattr(atomic_io.json, "dump", crashing_dump)
+        with pytest.raises(OSError):
+            atomic_io.write_json_atomic(target, {"a": 2})
+
+        assert target.read_bytes() == original
+        assert not list(tmp_path.glob("x.json*.tmp")), "partial staging file leaked"
+
+    def test_orphaned_staging_file_from_a_crashed_writer_never_corrupts_target(self, tmp_path):
+        from src.atomic_io import staging_path, write_json_atomic
+
+        target = tmp_path / "x.json"
+        write_json_atomic(target, {"a": 1})
+        staging_path(target).write_text("{ truncated by a SIGKILLed writer")
+
+        write_json_atomic(target, {"a": 2})
+        assert json.loads(target.read_text()) == {"a": 2}
+
+    def test_private_mode_creates_owner_only_file(self, tmp_path):
+        from src.atomic_io import write_json_atomic
+
+        target = tmp_path / "secrets.json"
+        write_json_atomic(target, {"key": "test_key_123"}, private=True)
+        mode = stat.S_IMODE(target.stat().st_mode)
+        assert mode & (stat.S_IRWXG | stat.S_IRWXO) == 0, f"file is group/world accessible: {mode:o}"
+
+    def test_write_text_atomic_replaces_content_atomically(self, tmp_path):
+        from src.atomic_io import write_text_atomic
+
+        target = tmp_path / "snap.json"
+        write_text_atomic(target, '{"doc": 1}')
+        assert target.read_text() == '{"doc": 1}'
+        assert not list(tmp_path.glob("snap.json*.tmp"))
+
+
+class TestJsonStoreBasics:
+    def _store(self, path, **kw):
+        from src.storage.json_store import JsonStore
+
+        return JsonStore(path, **kw)
+
+    def test_bare_filename_resolves_into_the_data_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("FIESTABOARD_DATA_DIR", str(tmp_path))
+        store = self._store("things.json")
+        assert store.path == tmp_path / "things.json"
+
+    def test_explicit_path_wins_over_data_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("FIESTABOARD_DATA_DIR", str(tmp_path / "elsewhere"))
+        explicit = tmp_path / "here" / "things.json"
+        store = self._store(explicit)
+        assert store.path == explicit
+
+    def test_load_returns_none_when_file_missing(self, tmp_path):
+        store = self._store(tmp_path / "missing.json")
+        assert store.load() is None
+
+    def test_save_then_load_round_trips(self, tmp_path):
+        store = self._store(tmp_path / "x.json")
+        store.save({"k": "v"})
+        assert store.load() == {"k": "v"}
+
+    def test_save_stamps_schema_version_on_versioned_dict_payloads(self, tmp_path):
+        store = self._store(tmp_path / "x.json", current_schema_version=3)
+        store.save({"items": []})
+        assert json.loads((tmp_path / "x.json").read_text())["schema_version"] == 3
+
+    def test_save_does_not_invent_schema_version_on_unversioned_stores(self, tmp_path):
+        store = self._store(tmp_path / "x.json")
+        store.save({"items": []})
+        assert "schema_version" not in json.loads((tmp_path / "x.json").read_text())
+
+    def test_lock_is_reentrant_and_shared_with_composers(self, tmp_path):
+        store = self._store(tmp_path / "x.json")
+        with store.lock:
+            with store.lock:  # re-entrant
+                store.save({"k": 1})
+        assert store.load() == {"k": 1}
+
+
+class TestJsonStoreMigrations:
+    def _versioned_store(self, path, migrations, version=2):
+        from src.storage.json_store import JsonStore
+
+        return JsonStore(path, current_schema_version=version, migrations=migrations)
+
+    def test_pending_migrations_run_in_order_and_version_bumps_once(self, tmp_path):
+        calls = []
+
+        def m1(data):
+            calls.append(1)
+            data["a"] = True
+            return 1
+
+        def m2(data):
+            calls.append(2)
+            data["b"] = True
+            return 1
+
+        path = tmp_path / "x.json"
+        path.write_text(json.dumps({"schema_version": 0, "items": []}))
+        store = self._versioned_store(path, [(1, m1), (2, m2)])
+
+        data = store.load()
+        assert calls == [1, 2]
+        assert data["a"] and data["b"]
+        assert data["schema_version"] == 2
+        assert store.migrated is True
+
+    def test_migrations_at_current_version_do_not_run(self, tmp_path):
+        def boom(data):
+            raise AssertionError("migration ran on an up-to-date file")
+
+        path = tmp_path / "x.json"
+        path.write_text(json.dumps({"schema_version": 2, "items": []}))
+        store = self._versioned_store(path, [(1, boom), (2, boom)])
+        store.load()
+        assert store.migrated is False
+
+    def test_only_migrations_newer_than_file_version_run(self, tmp_path):
+        calls = []
+        path = tmp_path / "x.json"
+        path.write_text(json.dumps({"schema_version": 1}))
+        store = self._versioned_store(path, [(1, lambda d: calls.append(1)), (2, lambda d: calls.append(2) or 0)])
+        store.load()
+        assert calls == [2]
+
+    def test_backup_written_before_first_migration_and_only_once(self, tmp_path):
+        path = tmp_path / "x.json"
+        original = json.dumps({"schema_version": 0, "items": ["keep"]})
+        path.write_text(original)
+        store = self._versioned_store(path, [(1, lambda d: 0), (2, lambda d: 0)])
+        store.load()
+
+        backup = tmp_path / "x.json.v0_backup"
+        assert backup.exists(), "no pre-migration backup written"
+        assert backup.read_text() == original, "backup must hold the PRE-migration bytes"
+
+        # A second store at the same version must not overwrite the backup.
+        backup_bytes = backup.read_bytes()
+        path.write_text(json.dumps({"schema_version": 0, "items": ["changed"]}))
+        self._versioned_store(path, [(1, lambda d: 0), (2, lambda d: 0)]).load()
+        assert backup.read_bytes() == backup_bytes
+
+    def test_load_does_not_write_migrated_data_itself(self, tmp_path):
+        """The domain owns the resave (pages re-serializes via its models);
+        the kernel only flags that one is needed."""
+        path = tmp_path / "x.json"
+        original = json.dumps({"schema_version": 0})
+        path.write_text(original)
+        store = self._versioned_store(path, [(1, lambda d: 0), (2, lambda d: 0)])
+        store.load()
+        assert path.read_text() == original
+
+
+class TestJsonStoreMutate:
+    def test_mutate_is_a_locked_read_modify_write(self, tmp_path):
+        from src.storage.json_store import JsonStore
+
+        store = JsonStore(tmp_path / "x.json")
+        store.save({"n": 0})
+
+        import time
+
+        def bump(data):
+            n = data.get("n", 0)
+            time.sleep(0.001)  # widen the stale-read window
+            data["n"] = n + 1
+            return data["n"]
+
+        threads = [threading.Thread(target=lambda: [store.mutate(bump) for _ in range(25)]) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert store.load() == {"n": 100}, "concurrent mutate() lost updates"
+
+    def test_mutate_on_missing_file_starts_from_empty_dict(self, tmp_path):
+        from src.storage.json_store import JsonStore
+
+        store = JsonStore(tmp_path / "x.json")
+        result = store.mutate(lambda d: d.setdefault("created", True))
+        assert result is True
+        assert json.loads((tmp_path / "x.json").read_text()) == {"created": True}
+
+    def test_concurrent_saves_never_collide_on_the_staging_file(self, tmp_path):
+        """Two same-process threads saving at once share one PID-scoped
+        staging name; without the store lock the second rename dies ENOENT."""
+        from src.storage.json_store import JsonStore
+
+        store = JsonStore(tmp_path / "x.json")
+        errors = []
+
+        def save_many(tag):
+            try:
+                for i in range(50):
+                    store.save({"tag": tag, "i": i})
+            except Exception as exc:  # pragma: no cover - the failure we assert against
+                errors.append(exc)
+
+        threads = [threading.Thread(target=save_many, args=(t,)) for t in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == []
+        assert not list(tmp_path.glob("x.json*.tmp"))
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# 2. Golden on-disk format pins (written before the kernel rework)
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def _pin(tmp_path, fixture_name):
+    src = GOLDEN / fixture_name
+    dst = tmp_path / fixture_name
+    shutil.copyfile(src, dst)
+    return dst, src.read_bytes()
+
+
+class TestGoldenOnDiskFormat:
+    """Load a committed fixture, save it back, byte-identical. Pins the
+    on-disk format across the kernel rework — any drift is a regression."""
+
+    def test_pages_json_round_trips_byte_identical(self, tmp_path):
+        from src.pages.storage import PageStorage
+
+        path, golden = _pin(tmp_path, "pages.json")
+        PageStorage(storage_file=str(path))._save()
+        assert path.read_bytes() == golden
+
+    def test_schedules_json_round_trips_byte_identical(self, tmp_path):
+        from src.schedules.storage import ScheduleStorage
+
+        path, golden = _pin(tmp_path, "schedules.json")
+        ScheduleStorage(storage_file=str(path))._save()
+        assert path.read_bytes() == golden
+
+    def test_collections_json_round_trips_byte_identical(self, tmp_path):
+        from src.collections.storage import CollectionStorage
+
+        path, golden = _pin(tmp_path, "collections.json")
+        CollectionStorage(storage_file=str(path))._save()
+        assert path.read_bytes() == golden
+
+    def test_panels_json_round_trips_byte_identical(self, tmp_path):
+        from src.panels.storage import PanelStorage
+
+        path, golden = _pin(tmp_path, "panels.json")
+        PanelStorage(storage_file=str(path))._save()
+        assert path.read_bytes() == golden
+
+    def test_settings_json_round_trips_byte_identical(self, tmp_path):
+        from src.settings.service import SettingsService
+
+        path, golden = _pin(tmp_path, "settings.json")
+        SettingsService(settings_file=str(path))._save_to_file()
+        assert path.read_bytes() == golden

--- a/tests/test_storage_kernel.py
+++ b/tests/test_storage_kernel.py
@@ -379,3 +379,25 @@ class TestConcurrentWriters:
         reloaded = PageStorage(storage_file=str(tmp_path / "pages.json"))
         assert reloaded.get("p1").name == "First Updated"
         assert reloaded.get("p2").name == "Second Updated"
+
+    def test_schedules_two_threads_updating_disjoint_schedules_both_survive(self, tmp_path, monkeypatch):
+        from src.schedules.models import ScheduleEntry
+        from src.schedules.storage import ScheduleStorage
+
+        storage = ScheduleStorage(storage_file=str(tmp_path / "schedules.json"))
+        for sid in ("s1", "s2"):
+            storage.create(
+                ScheduleEntry(id=sid, page_id="p1", start_time="08:00", end_time="10:00", day_pattern="all")
+            )
+
+        _force_write_overlap(monkeypatch)
+        errors = _run_pair(
+            lambda: storage.update("s1", {"start_time": "09:00"}),
+            lambda: storage.update("s2", {"start_time": "11:00"}),
+        )
+        monkeypatch.undo()
+
+        assert errors == []
+        reloaded = ScheduleStorage(storage_file=str(tmp_path / "schedules.json"))
+        assert reloaded.get("s1").start_time == "09:00"
+        assert reloaded.get("s2").start_time == "11:00"


### PR DESCRIPTION
Closes #1848 (umbrella; absorbs #1759, folds the #1745 pattern). **Track A**, stacked on #1855. Nine commits, one per store, each independently green.

## Why

The 12-line atomic-write block was copy-pasted ~5×, and the writers that didn't copy it regressed to the fixed-`.tmp` collision it prevents (backup, ConfigManager's boot snapshot, plus a third found in api_server's pre-update snapshot). `atomic_io.py`'s docstring claimed every store holds a lock; **five stores had none** — `SettingsService` rewrites all 12 sections from memory on every mutation, so concurrent PUTs lost each other wholesale.

## What

- **Kernel**: `src/storage/json_store.py` — `JsonStore` with default paths via the #1762 seam, an RLock (`lock` exposed for composed critical sections), `load()/save()/mutate(fn)`, and pages-style ordered schema migrations with backup-before-first-migration. `load()` migrates in memory and lets the domain resave through its own serialization — that's what makes byte-compatibility achievable. `write_json_atomic` (fsync + rename, `private=True` for 0600) and `write_text_atomic` in `atomic_io.py`; docstring lie fixed.
- **Adopted**: pages, schedules, collections, panels (domain keeps its own `MIGRATIONS`; kernel runs them), SettingsService (all 21 mutators under the store lock — the lost-PUT fix), ConfigManager + backup + api_server snapshot + auth (atomic-write adoption). Registry verified to persist only through ConfigManager — nothing to adopt. `.system-update.json` already correct from #1745 — untouched.

## Zero-regression evidence

- **Pin-first**: golden on-disk fixtures for all five formats, generated from the pre-kernel code and verified round-trip-stable on it *before* any store was touched; byte-for-byte after.
- **Fail-first**, deterministic (event-sequenced, not barrier-raced): a PUT paused mid-dump gets lapped, then corrupts `settings.json` with its stale snapshot while its own rename ENOENT is swallowed —
```
E   json.decoder.JSONDecodeError: Extra data: line 76 column 2 (char 1535)
FAILED ...test_settings_two_concurrent_puts_to_different_sections_both_survive
```
The four storage-class concurrency tests were each proven non-vacuous by swapping the old store back in.
- **Full suite**: baseline `1 failed, 5617 passed` (known worktree-env failure) → `1 failed, 5647 passed` — identical failure set, +30 kernel tests. One test file adapted (it built `SettingsService` via `__new__`, bypassing `__init__`) with in-place justification; no assertion weakened. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Par2E2Nh65PyDF1q9TARJP