### PR TITLE
perf(plugins): fetch only referenced + trigger plugins; one persistent bounded executor

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -909,6 +909,15 @@ async def lifespan(app: FastAPI):
     except Exception:
         logger.debug("Failed to stop mDNS during shutdown", exc_info=True)
 
+    # Stop the shared plugin-fetch pool (issue #1751). wait=False: a wedged
+    # plugin fetch must not stall process shutdown.
+    try:
+        from .plugins.registry import shutdown_plugin_fetch_executor
+
+        shutdown_plugin_fetch_executor()
+    except Exception:
+        logger.debug("Failed to stop plugin-fetch executor during shutdown", exc_info=True)
+
 
 # Create FastAPI app
 app = FastAPI(

--- a/src/pages/service.py
+++ b/src/pages/service.py
@@ -419,7 +419,11 @@ class PageService:
                 return context
 
             board = board_context_for(device_type, notes_wide, notes_tall)
-            context.update(registry.build_template_context(board, plugin_ids=missing))
+            # Widening fetches EXACTLY the missing ids: the first build for
+            # this size already fetched the trigger plugins (they are in
+            # ``fetched``), so re-unioning them here would fetch each trigger
+            # plugin once per widening consumer (#1862 review).
+            context.update(registry.build_template_context(board, plugin_ids=missing, include_trigger_plugins=False))
             if plugin_ids is None:
                 contexts.pop(coverage_key, None)  # widened to full coverage
             else:

--- a/src/pages/service.py
+++ b/src/pages/service.py
@@ -5,6 +5,7 @@ Provides high-level operations on pages including preview and send.
 
 import logging
 import time
+from collections.abc import Collection
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 
@@ -19,7 +20,7 @@ from src.devices import (
 from src.displays.service import DisplayResult, get_display_service
 from src.plugins.manifest import DemoPageSchema
 from src.settings.service import get_settings_service
-from src.templates.engine import get_template_engine
+from src.templates.engine import extract_template_plugin_ids, get_template_engine
 
 from .models import LineMetadata, Page, PageCreate, PageUpdate
 from .storage import PageStorage
@@ -30,6 +31,13 @@ logger = logging.getLogger(__name__)
 # Cache TTL in seconds for non-polling preview requests (e.g. UI preview list).
 # The background polling loop bypasses this cache via force_refresh=True.
 PREVIEW_CACHE_TTL = 120
+
+# Prefix for the per-size coverage entries `shared_context_for` keeps inside
+# the per-tick ``contexts`` cache (issue #1751): ``coverage_key -> set of
+# plugin ids the cached context was fetched for``. A size key never starts
+# with NUL, so these companion entries can share the dict without colliding.
+# A size WITHOUT a coverage entry was built with fetch-all (full coverage).
+_CONTEXT_COVERAGE_PREFIX = "\x00fetched:"
 
 
 # Default welcome page templates per device type
@@ -354,15 +362,26 @@ class PageService:
         device_type: str,
         notes_wide: int = 1,
         notes_tall: int = 1,
+        plugin_ids: Collection[str] | None = None,
     ) -> dict | None:
         """Get-or-build the per-tick shared template context for one board size.
 
         ``contexts`` is a per-pass cache keyed by :func:`src.devices.size_key`
         (the display loop creates one dict per tick, issue #1752). The first
-        consumer of a size pays the full plugin fan-out; every later consumer
-        of the same size — collection resolution, other boards' renders —
+        consumer of a size pays the plugin fan-out; every later consumer of
+        the same size — collection resolution, other boards' renders —
         reuses the same dict, exactly as ``preview_pages_batch`` already
         shares contexts per board size.
+
+        ``plugin_ids`` narrows that fan-out to the plugins the consumer will
+        actually read (issue #1751): a filtered build fetches only those ids
+        (plus trigger plugins — the registry enforces that), and the cache
+        remembers WHICH ids each size's context covers (a companion
+        ``\\x00``-prefixed entry, invisible to templates). A later consumer
+        needing more — another page's variables, or a fetch-all consumer like
+        variable-mode collection resolution (``plugin_ids=None``) — widens
+        the cached context by fetching only what it lacks, so no plugin is
+        fetched twice in one pass.
 
         Returns None (caller falls back to building its own context, the
         pre-#1752 behavior) when ``contexts`` is None or the build fails.
@@ -370,18 +389,45 @@ class PageService:
         if contexts is None:
             return None
         key = size_key(device_type or DEFAULT_DEVICE_TYPE, notes_wide or 1, notes_tall or 1)
-        context = contexts.get(key)
-        if context is None:
-            try:
-                from src.plugins.registry import get_plugin_registry
+        coverage_key = _CONTEXT_COVERAGE_PREFIX + key
+        try:
+            from src.plugins.registry import get_plugin_registry
 
+            registry = get_plugin_registry()
+            context = contexts.get(key)
+            if context is None:
                 board = board_context_for(device_type, notes_wide, notes_tall)
-                context = get_plugin_registry().build_template_context(board)
-            except Exception as e:
-                logger.error(f"Failed to build shared template context: {e}")
-                return None
-            contexts[key] = context
-        return context
+                if plugin_ids is None:
+                    context = registry.build_template_context(board)
+                    # No coverage entry: a fetch-all context covers everything.
+                else:
+                    context = registry.build_template_context(board, plugin_ids=plugin_ids)
+                    contexts[coverage_key] = set(plugin_ids) | set(getattr(registry, "trigger_plugins", {}) or {})
+                contexts[key] = context
+                return context
+
+            fetched = contexts.get(coverage_key)
+            if fetched is None:
+                return context  # built with fetch-all — covers every consumer
+
+            if plugin_ids is not None:
+                needed = set(plugin_ids)
+            else:
+                needed = set(getattr(registry, "enabled_plugins", {}) or {})
+            missing = needed - fetched
+            if not missing:
+                return context
+
+            board = board_context_for(device_type, notes_wide, notes_tall)
+            context.update(registry.build_template_context(board, plugin_ids=missing))
+            if plugin_ids is None:
+                contexts.pop(coverage_key, None)  # widened to full coverage
+            else:
+                contexts[coverage_key] = fetched | missing
+            return context
+        except Exception as e:
+            logger.error(f"Failed to build shared template context: {e}")
+            return None
 
     def render_page(
         self, page: Page, context: dict | None = None, contexts: dict[str, dict] | None = None
@@ -399,7 +445,16 @@ class PageService:
             DisplayResult with formatted text
         """
         if context is None and contexts is not None and page.type == "template":
-            context = self.shared_context_for(contexts, page.device_type, page.notes_wide, page.notes_tall)
+            context = self.shared_context_for(
+                contexts,
+                page.device_type,
+                page.notes_wide,
+                page.notes_tall,
+                # Demand-driven fetch (issue #1751): only the plugins this
+                # page's template references. None (a formula page) keeps
+                # the fetch-all fallback.
+                plugin_ids=extract_template_plugin_ids(page.template),
+            )
         if page.type == "single":
             return self._render_single(page)
         if page.type == "composite":
@@ -650,17 +705,26 @@ class PageService:
         # different sizes are distinct boards (see _board_key).
         contexts_by_board: dict[str, dict] = {}
         boards: dict[str, BoardContext] = {}
+        # Per-size fetch filters (issue #1751): the union of every batched
+        # template page's referenced plugins for that size, or None (fetch
+        # all) as soon as any page's references cannot be determined.
+        ids_by_board: dict[str, Collection[str] | None] = {}
         for _, p in pages_to_render:
             if p.type != "template":
                 continue
             key = self._board_key(p)
             if key not in boards:
                 boards[key] = board_context_for(p.device_type, p.notes_wide, p.notes_tall)
+            refs = extract_template_plugin_ids(p.template)
+            if key not in ids_by_board:
+                ids_by_board[key] = set(refs) if refs is not None else None
+            elif ids_by_board[key] is not None:
+                ids_by_board[key] = ids_by_board[key] | refs if refs is not None else None
         if boards:
             try:
                 from src.plugins.registry import get_plugin_registry
 
-                contexts_by_board = get_plugin_registry().build_template_contexts_for(boards)
+                contexts_by_board = get_plugin_registry().build_template_contexts_for(boards, plugin_ids=ids_by_board)
             except Exception as e:
                 logger.error(f"Failed to build shared template context: {e}")
 

--- a/src/plugins/registry.py
+++ b/src/plugins/registry.py
@@ -135,6 +135,15 @@ class PluginRegistry:
         # Auto-discovery cache: maps plugin_id -> discovered variable names
         self._discovered_vars: dict[str, list[str]] = {}
 
+        # In-flight fetch registry (issue #1862 review): maps
+        # (plugin_id, board key) -> the pending Future for that fetch.
+        # While a fetch is pending, later context builds JOIN it within
+        # their own wait budget instead of submitting a duplicate, so a
+        # wedged plugin occupies at most ONE shared-pool worker per board
+        # key instead of one more per tick until the pool starves.
+        self._inflight_fetches: dict[tuple, Any] = {}
+        self._inflight_lock = threading.Lock()
+
         # Set once initialize() has loaded the plugin set. Guards against a
         # repeat call rebuilding every live plugin (issue #1753).
         self._initialized = False
@@ -1572,8 +1581,25 @@ class PluginRegistry:
             if self._enabled.get(pid, False) and plugin.supports_triggers
         }
 
+    def _clear_inflight_entry(self, key: tuple):
+        """A done-callback that removes *key* from the in-flight registry.
+
+        Identity-guarded: only the future currently registered under the key
+        removes itself, so a fresh fetch registered after (e.g.) a cancelled
+        one is never clobbered by the old future's late callback.
+        """
+
+        def _done(future) -> None:
+            with self._inflight_lock:
+                if self._inflight_fetches.get(key) is future:
+                    del self._inflight_fetches[key]
+
+        return _done
+
     def build_template_context(
-        self, board: BoardContext | None = None, plugin_ids: Collection[str] | None = None
+        self,
+        board: BoardContext | None = None,
+        plugin_ids: Collection[str] | None = None,
     ) -> dict[str, Any]:
         """Build context dictionary for template rendering.
 
@@ -1618,7 +1644,30 @@ class PluginRegistry:
         # not_done futures that never started, so a saturated pool's backlog
         # cannot grow without bound; running fetches ignore cancel().
         executor = _get_fetch_executor()
-        futures = {executor.submit(self.fetch_plugin_data, plugin_id, board): plugin_id for plugin_id in to_fetch}
+        # In-flight dedupe (#1862 review): a fetch still pending from an
+        # earlier build (same plugin, same board key) is JOINED — awaited
+        # within this build's own wait budget — never resubmitted. Without
+        # this, a wedged plugin gains one duplicate worker per tick until
+        # the shared pool starves and every plugin's data dies board-wide.
+        # A done future means the previous fetch finished; submit a fresh
+        # one (fetch_plugin_data's own caching decides how fresh the data
+        # actually is, exactly as before).
+        board_key = None if board is None else (board.device_type, board.rows, board.cols)
+        futures: dict[Any, str] = {}
+        submitted: list[tuple[tuple, Any]] = []
+        with self._inflight_lock:
+            for plugin_id in to_fetch:
+                key = (plugin_id, board_key)
+                future = self._inflight_fetches.get(key)
+                if future is None or future.done():
+                    future = executor.submit(self.fetch_plugin_data, plugin_id, board)
+                    self._inflight_fetches[key] = future
+                    submitted.append((key, future))
+                futures[future] = plugin_id
+        # Register cleanup callbacks OUTSIDE the lock: an already-completed
+        # future runs its callback inline, which itself takes the lock.
+        for key, future in submitted:
+            future.add_done_callback(self._clear_inflight_entry(key))
         done, not_done = futures_wait(futures, timeout=CONTEXT_BUILD_TIMEOUT_SECONDS)
 
         if not_done:

--- a/src/plugins/registry.py
+++ b/src/plugins/registry.py
@@ -1600,6 +1600,7 @@ class PluginRegistry:
         self,
         board: BoardContext | None = None,
         plugin_ids: Collection[str] | None = None,
+        include_trigger_plugins: bool = True,
     ) -> dict[str, Any]:
         """Build context dictionary for template rendering.
 
@@ -1616,6 +1617,12 @@ class PluginRegistry:
                 freshly cached data a fetch produces, so a filtered engine
                 tick must never starve them (issue #1751). ``None`` keeps
                 the fetch-everything behavior.
+            include_trigger_plugins: Set False by cache-WIDENING callers
+                (``PageService.shared_context_for``) whose per-tick shared
+                context already holds the trigger plugins from its first
+                build — otherwise every widening would re-fetch them, up to
+                N times per tick (#1862 review). Only meaningful when
+                ``plugin_ids`` is given.
 
         Returns:
             Dictionary mapping plugin_id to plugin data
@@ -1629,7 +1636,7 @@ class PluginRegistry:
             # Demand-driven fetch (issue #1751): only the plugins a template
             # actually references... plus trigger plugins, unconditionally.
             requested = {str(pid).lower() for pid in plugin_ids}
-            triggers = set(self.trigger_plugins)
+            triggers = set(self.trigger_plugins) if include_trigger_plugins else set()
             to_fetch = [pid for pid in enabled if pid.lower() in requested or pid in triggers]
 
         if not to_fetch:

--- a/src/plugins/registry.py
+++ b/src/plugins/registry.py
@@ -10,6 +10,8 @@ The PluginRegistry is the central point for:
 
 import logging
 import re
+import threading
+from collections.abc import Collection
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import wait as futures_wait
 from dataclasses import replace
@@ -49,6 +51,43 @@ _INSTANCE_LABEL_RE = re.compile(r"^[a-zA-Z0-9_-]{1,40}$")
 # rendering without it. A board that is a little stale beats a board that never
 # updates because one data source is wedged.
 CONTEXT_BUILD_TIMEOUT_SECONDS = 15
+
+# One persistent, bounded pool serves every plugin fetch (issue #1751). The
+# previous design built a fresh ThreadPoolExecutor per render and abandoned it
+# with shutdown(wait=False), which leaked one live thread per tick for every
+# hung plugin. With a shared pool a wedged fetch OCCUPIES a worker until it
+# returns (bounded occupancy) instead of leaking a thread (unbounded growth).
+# The pool is module-level and independent of registry instances so tests
+# that reset the registry singleton never accumulate pools.
+PLUGIN_FETCH_MAX_WORKERS = 8
+
+_fetch_executor: ThreadPoolExecutor | None = None
+_fetch_executor_lock = threading.Lock()
+
+
+def _get_fetch_executor() -> ThreadPoolExecutor:
+    """Lazily create (once) the shared plugin-fetch pool."""
+    global _fetch_executor
+    with _fetch_executor_lock:
+        if _fetch_executor is None:
+            _fetch_executor = ThreadPoolExecutor(
+                max_workers=PLUGIN_FETCH_MAX_WORKERS, thread_name_prefix="plugin-fetch"
+            )
+        return _fetch_executor
+
+
+def shutdown_plugin_fetch_executor() -> None:
+    """Shut down the shared plugin-fetch pool (process teardown only).
+
+    Safe to call repeatedly; a later fetch lazily creates a fresh pool.
+    ``wait=False`` so a wedged plugin cannot stall shutdown; its worker
+    thread dies with the process.
+    """
+    global _fetch_executor
+    with _fetch_executor_lock:
+        if _fetch_executor is not None:
+            _fetch_executor.shutdown(wait=False, cancel_futures=True)
+            _fetch_executor = None
 
 
 def _config_in_use(plugin_id: str, stored_configs: dict[str, dict[str, Any]]) -> bool:
@@ -1533,66 +1572,85 @@ class PluginRegistry:
             if self._enabled.get(pid, False) and plugin.supports_triggers
         }
 
-    def build_template_context(self, board: BoardContext | None = None) -> dict[str, Any]:
+    def build_template_context(
+        self, board: BoardContext | None = None, plugin_ids: Collection[str] | None = None
+    ) -> dict[str, Any]:
         """Build context dictionary for template rendering.
 
-        Fetches data from all enabled plugins in parallel so that slow or
-        unresponsive external data sources do not block each other.
+        Fetches plugin data in parallel so that slow or unresponsive external
+        data sources do not block each other.
 
         Args:
             board: Board being rendered on, forwarded to every plugin so
                 board-aware plugins can adapt their data. ``None`` keeps the
                 board-agnostic behavior.
+            plugin_ids: When given, fetch only these plugins (intersected
+                with the enabled set) PLUS every enabled trigger-capable
+                plugin — their ``check_triggers`` path may rely on the
+                freshly cached data a fetch produces, so a filtered engine
+                tick must never starve them (issue #1751). ``None`` keeps
+                the fetch-everything behavior.
 
         Returns:
             Dictionary mapping plugin_id to plugin data
         """
         context: dict[str, Any] = {}
-        enabled = list(self.enabled_plugins)
+        enabled = self.enabled_plugins
 
-        if not enabled:
+        if plugin_ids is None:
+            to_fetch = list(enabled)
+        else:
+            # Demand-driven fetch (issue #1751): only the plugins a template
+            # actually references... plus trigger plugins, unconditionally.
+            requested = {str(pid).lower() for pid in plugin_ids}
+            triggers = set(self.trigger_plugins)
+            to_fetch = [pid for pid in enabled if pid.lower() in requested or pid in triggers]
+
+        if not to_fetch:
             return context
 
-        # Fetch every plugin concurrently; cap the pool to avoid spawning an
-        # unbounded number of threads when many plugins are enabled.
-        max_workers = min(len(enabled), 8)
-        executor = ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="plugin-fetch")
-        try:
-            futures = {executor.submit(self.fetch_plugin_data, plugin_id, board): plugin_id for plugin_id in enabled}
-            done, not_done = futures_wait(futures, timeout=CONTEXT_BUILD_TIMEOUT_SECONDS)
+        # One persistent bounded pool for every render (issue #1751); see the
+        # module-level notes on PLUGIN_FETCH_MAX_WORKERS. The timeout below
+        # still solely bounds how long a render waits — never how long a
+        # plugin runs: an abandoned fetch finishes harmlessly on its worker
+        # (nothing reads its result, and PluginBase caches it for the next
+        # tick), occupying that worker until it returns. cancel() drops the
+        # not_done futures that never started, so a saturated pool's backlog
+        # cannot grow without bound; running fetches ignore cancel().
+        executor = _get_fetch_executor()
+        futures = {executor.submit(self.fetch_plugin_data, plugin_id, board): plugin_id for plugin_id in to_fetch}
+        done, not_done = futures_wait(futures, timeout=CONTEXT_BUILD_TIMEOUT_SECONDS)
 
-            if not_done:
-                slow_ids = [futures[f] for f in not_done]
+        if not_done:
+            slow_ids = [futures[f] for f in not_done]
+            logger.warning(
+                f"{len(not_done)} plugin(s) did not complete within the "
+                f"context-build timeout and will be skipped: {slow_ids}"
+            )
+            never_started = [futures[f] for f in not_done if f.cancel()]
+            if never_started:
                 logger.warning(
-                    f"{len(not_done)} plugin(s) did not complete within the "
-                    f"context-build timeout and will be skipped: {slow_ids}"
+                    f"plugin-fetch pool saturated: {len(never_started)} fetch(es) never started "
+                    f"({never_started}) — all {PLUGIN_FETCH_MAX_WORKERS} workers are occupied by "
+                    f"slow or wedged plugin fetches"
                 )
 
-            for future in done:
-                plugin_id = futures[future]
-                try:
-                    result = future.result()
-                    if result.available and result.data:
-                        context[plugin_id] = result.data
-                except Exception:
-                    logger.exception(f"Plugin {plugin_id} raised an error during context build")
-        finally:
-            # Deliberately not a `with` block. ThreadPoolExecutor.__exit__ calls
-            # shutdown(wait=True), which would block here until the slowest
-            # plugin returned -- so the timeout above would decide only whether
-            # a result is *used*, never how long the render takes. A plugin
-            # wedged on a 60s network call would stall every board render for
-            # the full 60s and then have its answer thrown away.
-            #
-            # wait=False lets an abandoned fetch finish on its own thread
-            # (harmlessly -- nothing reads its result, and PluginBase caches it
-            # for the next tick); cancel_futures drops the ones that never
-            # started.
-            executor.shutdown(wait=False, cancel_futures=True)
+        for future in done:
+            plugin_id = futures[future]
+            try:
+                result = future.result()
+                if result.available and result.data:
+                    context[plugin_id] = result.data
+            except Exception:
+                logger.exception(f"Plugin {plugin_id} raised an error during context build")
 
         return context
 
-    def build_template_contexts_for(self, boards: dict[str, BoardContext]) -> dict[str, dict[str, Any]]:
+    def build_template_contexts_for(
+        self,
+        boards: dict[str, BoardContext],
+        plugin_ids: dict[str, Collection[str] | None] | None = None,
+    ) -> dict[str, dict[str, Any]]:
         """Build one template context per distinct board.
 
         Used by batch rendering (e.g. the page-grid preview) where pages
@@ -1603,12 +1661,17 @@ class PluginRegistry:
         Args:
             boards: Mapping of a key (typically ``device_type``) to the
                 :class:`BoardContext` to build a context for.
+            plugin_ids: Optional per-key fetch filters (issue #1751): the
+                value for a key is forwarded to
+                :meth:`build_template_context`, so ``None`` (or a missing
+                key) keeps fetch-all for that board.
 
         Returns:
             Mapping of the same keys to their rendered ``{plugin_id: data}``
             context dictionaries.
         """
-        return {key: self.build_template_context(board) for key, board in boards.items()}
+        filters = plugin_ids or {}
+        return {key: self.build_template_context(board, plugin_ids=filters.get(key)) for key, board in boards.items()}
 
 
 def get_plugin_registry() -> PluginRegistry:

--- a/src/templates/engine.py
+++ b/src/templates/engine.py
@@ -84,6 +84,49 @@ FILL_SPACE_REPEAT_PATTERN = re.compile(r"\{\{fill_space_repeat:(.+?)\}\}", re.IG
 FILLED_PATTERN = re.compile(r"\{\{filled:(.+?)\}\}", re.IGNORECASE)
 
 
+def extract_template_plugin_ids(template_lines: "list[str] | str | None") -> set[str] | None:
+    """Statically extract the plugin ids a template's variables reference.
+
+    A plain ``{{source.field...}}`` variable resolves against the template
+    context by its root: ``source`` is the plugin id (or instance key like
+    ``weather:sf``), exactly as ``_get_variable_value`` looks it up. That
+    makes the fetch set of a template statically computable, so a render
+    can fetch only the plugins it will actually read (issue #1751).
+
+    Returns ``None`` when the set CANNOT be determined statically — today
+    that is any ``{{= ... }}`` formula expression, whose variable references
+    live inside an expression grammar this scan does not parse. ``None``
+    tells the caller to fall back to fetching every enabled plugin, which
+    is always safe (it is the pre-#1751 behavior).
+
+    Expressions that never read plugin data are skipped: color markers
+    (``{{red}}``), ``fill_space`` / ``filled:`` / ``fill_space_repeat:``
+    specials, and dotless or empty roots (all of which render without a
+    context lookup). Roots that don't name an enabled plugin are harmless
+    to include — the registry intersects with the enabled set.
+    """
+    if template_lines is None:
+        return set()
+    lines = [template_lines] if isinstance(template_lines, str) else list(template_lines)
+
+    refs: set[str] = set()
+    for line in lines:
+        if not line:
+            continue
+        for match in VAR_PATTERN.finditer(line):
+            expr = match.group(1).strip()
+            if expr.startswith("="):
+                return None  # formula: variable owners are not statically known
+            var_part = expr.split("|", 1)[0].strip().lower()
+            if var_part == "fill_space" or var_part.startswith(("filled:", "fill_space_repeat:")):
+                continue
+            root, sep, rest = var_part.partition(".")
+            if not sep or not root or not rest:
+                continue  # colors, invalid or dotless expressions: no context lookup
+            refs.add(root)
+    return refs
+
+
 @dataclass
 class TemplateError:
     """Template validation error."""

--- a/tests/test_demand_driven_fetch.py
+++ b/tests/test_demand_driven_fetch.py
@@ -261,3 +261,26 @@ class TestInFlightFetchDedupe:
             "in-flight dedupe should hold it to exactly one"
         )
 
+
+class TestTriggerFetchedOncePerTick:
+    def test_trigger_plugin_fetched_once_across_three_consumers_in_one_tick(self, registry, page_service):
+        """Cache widening fetches exactly the missing ids: the trigger plugin
+        rides along on the FIRST build of a size only, not on every widening."""
+        _install_plugin(registry, "alpha")
+        _install_plugin(registry, "beta")
+        _install_plugin(registry, "gamma")
+        _install_plugin(registry, "trig", supports_triggers=True)
+
+        contexts: dict[str, dict] = {}
+        first = page_service.render_page(_template_page("p-1", ["{{alpha.value}}"]), contexts=contexts)
+        second = page_service.render_page(_template_page("p-2", ["{{beta.value}}"]), contexts=contexts)
+        third = page_service.render_page(_template_page("p-3", ["{{gamma.value}}"]), contexts=contexts)
+
+        # Non-vacuity: all three renders resolved their variable, and the
+        # trigger plugin's data is in the shared context.
+        assert first.available and "ALPHA" in first.formatted
+        assert second.available and "BETA" in second.formatted
+        assert third.available and "GAMMA" in third.formatted
+        assert contexts[next(k for k in contexts if not k.startswith("\x00"))].get("trig") == {"value": "TRIG"}
+
+        assert _fetched_ids(registry) == {"alpha": 1, "beta": 1, "gamma": 1, "trig": 1}

--- a/tests/test_demand_driven_fetch.py
+++ b/tests/test_demand_driven_fetch.py
@@ -209,3 +209,55 @@ class TestPersistentBoundedExecutor:
             release.set()
 
         assert "saturated" in caplog.text
+
+
+@pytest.fixture
+def fresh_pool():
+    """A private shared-pool lifetime for occupancy-counting tests."""
+    registry_module.shutdown_plugin_fetch_executor()
+    yield
+    registry_module.shutdown_plugin_fetch_executor()
+
+
+class TestInFlightFetchDedupe:
+    def test_wedged_plugin_occupies_one_worker_and_never_starves_healthy_plugins(
+        self, registry, monkeypatch, fresh_pool
+    ):
+        """12 ticks with one wedged plugin: its pending fetch is JOINED, not
+        resubmitted — so it occupies exactly ONE pool worker, and the healthy
+        plugin's data is present in the context on every tick.
+
+        (Pre-dedupe, every tick submitted a duplicate wedged fetch; by ~tick 8
+        all 8 shared workers were occupied and the healthy plugin's fetch
+        could no longer start, killing ALL plugin data board-wide.)
+        """
+        monkeypatch.setattr(registry_module, "CONTEXT_BUILD_TIMEOUT_SECONDS", 0.1)
+        release = threading.Event()
+        workers_entered: list[str] = []
+
+        def hang(board=None):
+            workers_entered.append(threading.current_thread().name)
+            release.wait(timeout=30)
+            return PluginResult(available=False, error="released")
+
+        _install_plugin(registry, "wedged", get_data=hang)
+        healthy = _install_plugin(registry, "healthy")
+
+        try:
+            for tick in range(12):
+                context = registry.build_template_context()
+                assert context.get("healthy") == {"value": "HEALTHY"}, (
+                    f"healthy plugin dropped from the context at tick {tick} "
+                    f"(wedged fetch occupies {len(workers_entered)} workers)"
+                )
+        finally:
+            release.set()
+
+        # The healthy plugin really was re-fetched every tick (dedupe joins
+        # only PENDING fetches; completed ones are re-submitted as before).
+        assert healthy.get_data.call_count == 12
+        assert len(workers_entered) == 1, (
+            f"wedged fetch occupied {len(workers_entered)} pool workers across 12 ticks; "
+            "in-flight dedupe should hold it to exactly one"
+        )
+

--- a/tests/test_demand_driven_fetch.py
+++ b/tests/test_demand_driven_fetch.py
@@ -1,0 +1,211 @@
+"""Instrumentation tests for demand-driven plugin fetch (issue #1751).
+
+Two audited wastes are pinned here by COUNTING, not by timing:
+
+1. Render fan-out — a template page render fetched EVERY enabled plugin,
+   whether or not the template referenced it. After the fix, a render
+   fetches only the plugins its template references (plus trigger-capable
+   plugins, whose ``check_triggers`` path may rely on fresh data), with a
+   safe fetch-all fallback for pages whose variable owners cannot be
+   determined statically (formula expressions).
+2. Executor churn — every render built a fresh ``ThreadPoolExecutor`` and
+   abandoned it with ``shutdown(wait=False)``, leaking one live thread per
+   tick per hung plugin. After the fix, one persistent bounded pool serves
+   every render: a hung fetch OCCUPIES a worker (bounded) instead of
+   leaking a thread (unbounded).
+
+Send behavior itself is pinned elsewhere (tests/test_engine_equivalence.py);
+these tests must pass WITHOUT any golden changing.
+"""
+
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import src.plugins.registry as registry_module
+from src.pages.models import Page
+from src.pages.service import PageService
+from src.pages.storage import PageStorage
+from src.plugins.base import PluginBase, PluginResult
+from src.plugins.registry import PluginRegistry
+from src.templates.engine import TemplateEngine
+
+
+def _make_registry() -> PluginRegistry:
+    loader = MagicMock()
+    loader.load_all_plugins.return_value = {}
+    loader.load_errors = {}
+    loader.get_manifest.return_value = None
+    with patch("src.plugins.registry.PluginLoader", return_value=loader):
+        return PluginRegistry(plugins_dir=Path("/fake/plugins"))
+
+
+def _install_plugin(
+    registry: PluginRegistry,
+    plugin_id: str,
+    *,
+    supports_triggers: bool = False,
+    get_data=None,
+):
+    """Register an enabled mock plugin directly on the registry internals."""
+    plugin = MagicMock(spec=PluginBase)
+    plugin.plugin_id = plugin_id
+    plugin.supports_triggers = supports_triggers
+    if get_data is not None:
+        plugin.get_data.side_effect = get_data
+    else:
+        plugin.get_data.return_value = PluginResult(available=True, data={"value": plugin_id.upper()})
+    registry._plugins[plugin_id] = plugin
+    registry._enabled[plugin_id] = True
+    return plugin
+
+
+def _fetched_ids(registry: PluginRegistry) -> dict[str, int]:
+    """Map of plugin_id -> how many times its data was fetched."""
+    return {pid: p.get_data.call_count for pid, p in registry._plugins.items() if p.get_data.call_count}
+
+
+def _engine_with(registry) -> TemplateEngine:
+    """A TemplateEngine wired to the given registry, skipping real plugin init."""
+    engine = TemplateEngine.__new__(TemplateEngine)
+    engine._display_service = None
+    cm = MagicMock()
+    cm.get_color_rules.return_value = []
+    engine._config_manager = cm
+    engine._plugin_registry = registry
+    return engine
+
+
+def _template_page(page_id: str, lines: list[str]) -> Page:
+    return Page(id=page_id, name=page_id, type="template", device_type="flagship", template=lines)
+
+
+@pytest.fixture
+def registry(monkeypatch):
+    reg = _make_registry()
+    monkeypatch.setattr("src.plugins.registry.get_plugin_registry", lambda: reg)
+    return reg
+
+
+@pytest.fixture
+def page_service(monkeypatch, tmp_path, registry):
+    storage = PageStorage(storage_file=str(tmp_path / "pages.json"))
+    service = PageService(storage=storage)
+    monkeypatch.setattr("src.pages.service.get_template_engine", lambda: _engine_with(registry))
+    return service
+
+
+class TestReferencedPluginFiltering:
+    def test_render_fetches_only_the_referenced_plugin(self, registry, page_service):
+        """A page referencing 1 of 3 enabled plugins fetches exactly that 1."""
+        _install_plugin(registry, "alpha")
+        _install_plugin(registry, "beta")
+        _install_plugin(registry, "gamma")
+
+        page = _template_page("p-1", ["TEMP {{alpha.value}}"])
+        result = page_service.render_page(page, contexts={})
+
+        # Non-vacuity: the referenced variable really resolved from plugin data.
+        assert result.available
+        assert "ALPHA" in result.formatted
+        assert _fetched_ids(registry) == {"alpha": 1}
+
+    def test_trigger_capable_plugin_is_fetched_even_when_unreferenced(self, registry, page_service):
+        """The engine-tick fetch set is referenced plugins PLUS trigger plugins."""
+        _install_plugin(registry, "alpha")
+        _install_plugin(registry, "beta")
+        _install_plugin(registry, "trig", supports_triggers=True)
+
+        page = _template_page("p-1", ["{{alpha.value}}"])
+        result = page_service.render_page(page, contexts={})
+
+        assert result.available
+        assert _fetched_ids(registry) == {"alpha": 1, "trig": 1}
+
+    def test_formula_page_falls_back_to_fetching_all_plugins(self, registry, page_service):
+        """A {{= ...}} formula's variable owners are not statically known: fetch all."""
+        _install_plugin(registry, "alpha")
+        _install_plugin(registry, "beta")
+        _install_plugin(registry, "gamma")
+
+        page = _template_page("p-1", ["{{= alpha.value & beta.value }}"])
+        result = page_service.render_page(page, contexts={})
+
+        assert result.available
+        assert "ALPHABETA" in result.formatted
+        assert _fetched_ids(registry) == {"alpha": 1, "beta": 1, "gamma": 1}
+
+    def test_second_page_of_same_size_fetches_only_its_missing_plugin(self, registry, page_service):
+        """The per-tick shared context widens by fetching only what it lacks."""
+        _install_plugin(registry, "alpha")
+        _install_plugin(registry, "beta")
+        _install_plugin(registry, "gamma")
+
+        contexts: dict[str, dict] = {}
+        first = page_service.render_page(_template_page("p-1", ["{{alpha.value}}"]), contexts=contexts)
+        second = page_service.render_page(_template_page("p-2", ["{{beta.value}}"]), contexts=contexts)
+
+        assert first.available and "ALPHA" in first.formatted
+        assert second.available and "BETA" in second.formatted
+        assert _fetched_ids(registry) == {"alpha": 1, "beta": 1}
+
+    def test_fetch_all_consumer_widens_a_filtered_shared_context(self, registry, page_service):
+        """A fetch-all consumer (collection resolution) after a filtered render
+        fetches only the plugins the shared context does not already hold."""
+        _install_plugin(registry, "alpha")
+        _install_plugin(registry, "beta")
+
+        contexts: dict[str, dict] = {}
+        page_service.render_page(_template_page("p-1", ["{{alpha.value}}"]), contexts=contexts)
+        context = page_service.shared_context_for(contexts, "flagship")
+
+        assert context is not None
+        assert context.get("alpha") == {"value": "ALPHA"}
+        assert context.get("beta") == {"value": "BETA"}
+        assert _fetched_ids(registry) == {"alpha": 1, "beta": 1}
+
+
+class TestPersistentBoundedExecutor:
+    def test_thread_count_is_bounded_across_100_ticks_with_a_hanging_plugin(self, registry, monkeypatch):
+        """100 renders with a wedged plugin occupy pool workers, not +1 thread/tick."""
+        monkeypatch.setattr(registry_module, "CONTEXT_BUILD_TIMEOUT_SECONDS", 0.02)
+        release = threading.Event()
+
+        def hang(board=None):
+            release.wait(timeout=30)
+            return PluginResult(available=False, error="released")
+
+        _install_plugin(registry, "wedged", get_data=hang)
+        baseline = threading.active_count()
+        try:
+            for _ in range(100):
+                context = registry.build_template_context()
+                assert context == {}  # the wedged plugin never lands in the context
+            grown = threading.active_count() - baseline
+        finally:
+            release.set()
+
+        assert grown <= 8 + 2, f"thread count grew by {grown} across 100 ticks (bounded pool expected)"
+
+    def test_saturated_fetch_pool_logs_a_warning(self, registry, monkeypatch, caplog):
+        """When every worker is wedged and a fetch cannot even start, say so."""
+        monkeypatch.setattr(registry_module, "CONTEXT_BUILD_TIMEOUT_SECONDS", 0.02)
+        release = threading.Event()
+
+        def hang(board=None):
+            release.wait(timeout=30)
+            return PluginResult(available=False, error="released")
+
+        for i in range(12):  # more wedged plugins than the pool has workers
+            _install_plugin(registry, f"wedged_{i}", get_data=hang)
+
+        try:
+            with caplog.at_level("WARNING", logger="src.plugins.registry"):
+                registry.build_template_context()
+                registry.build_template_context()
+        finally:
+            release.set()
+
+        assert "saturated" in caplog.text

--- a/tests/test_tick_shared_context.py
+++ b/tests/test_tick_shared_context.py
@@ -46,12 +46,12 @@ class CountingRegistry:
         # differs between board=None and board-aware builds override this.
         self.payload = lambda board: {}
 
-    def build_template_context(self, board=None):
+    def build_template_context(self, board=None, plugin_ids=None):
         self.build_calls += 1
         self.boards_seen.append(board)
         return self.payload(board)
 
-    def build_template_contexts_for(self, boards):
+    def build_template_contexts_for(self, boards, plugin_ids=None):
         return {key: self.build_template_context(b) for key, b in boards.items()}
 
     def get_manifest(self, plugin_id):


### PR DESCRIPTION
Closes #1751. **Track B**, stacked on #1861 (chain: #1856 → #1861 → this).

## What

1. **Demand-driven fetch**: new `extract_template_plugin_ids()` scans a template's `{{...}}` roots (instance keys included, colors/specials skipped) and the fan-out fetches only those plugins — falling back to fetch-all the moment a `{{= ...}}` formula appears (owners aren't statically parseable; safety first). The per-tick shared context (#1861) records which ids it covers, so a later consumer needing more fetches **only the missing ids** and merges — variable-mode collections still see everything, nothing is fetched twice per pass.
2. **Trigger freshness is un-bypassable**: the union with trigger-capable plugins happens inside `build_template_context` itself, so no caller can starve `check_triggers` of fresh data.
3. **One persistent bounded executor** (module-level, 8 workers, lazy, shut down in the API lifespan) replaces the per-render pool. Timeout semantics preserved exactly: `futures_wait` still solely bounds the render; abandoned fetches finish harmlessly — now as **bounded occupancy instead of a leaked thread per tick per hung plugin**; saturation logs a warning.

## Zero-regression evidence

**Fail-first instrumentation** (verbatim in the test evidence):
- 1-of-3 referenced → fetches **3 → 1**
- unreferenced trigger plugin: pre-fix dropped (`{alpha,beta,trig} != {alpha,trig}`) → always fetched
- 100 ticks with a hanging plugin: **+100 threads → ≤ 10** (observed `100 <= 10` failure pre-fix)
- fetch-all fallback + cache-widening proven non-vacuous by mutation (`#REF` output / missing plugin observed, restored)

**Goldens**: all 9 engine equivalence scenarios byte-identical, zero re-records; the #1861 instrumentation suite green. Targeted suites: 887 passed across engine/templates/pages/collections/silence/triggers. Full suite: **5634 passed** ×3 consecutive clean runs (sole failure = known worktree-env image-formats test). ruff clean.

Merge-order note: `build_template_context` is also touched by #1854 (registry locks) on Stack 0 — the rebase resolution is planned (snapshot-then-release + filter compose cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Par2E2Nh65PyDF1q9TARJP