### PR TITLE
feat(settings): unify board credentials on settings.json

### DIFF
--- a/src/api_server.py
+++ b/src/api_server.py
@@ -3768,9 +3768,7 @@ async def send_welcome_message():
         logger.error(f"Failed to create board client: {e}")
         raise HTTPException(status_code=503, detail=f"Board not configured: {str(e)}") from e
     if board_client is None:
-        raise HTTPException(
-            status_code=503, detail="Board not configured: no board with a usable connection"
-        )
+        raise HTTPException(status_code=503, detail="Board not configured: no board with a usable connection")
     board_client.skip_unchanged = False  # Always send the welcome message
 
     try:
@@ -4034,6 +4032,7 @@ async def validate_config():
     # first-run. Board-related validation errors/missing_fields from the
     # legacy config are dropped in that case.
     has_configured_board_instance = False
+    has_connection_attempt = False
     try:
         from .devices import BoardInstance
 
@@ -4043,11 +4042,23 @@ async def validate_config():
                 instance = BoardInstance.from_dict(b)
             except Exception:  # pragma: no cover - defensive
                 continue
+            if instance.has_connection_attempt:
+                has_connection_attempt = True
             if instance.is_connection_configured:
                 has_configured_board_instance = True
                 break
     except Exception:  # pragma: no cover - defensive
         logger.exception("Failed to inspect multi-board settings during validate_config")
+
+    # A board with SOME connection detail but not a working set is
+    # *misconfigured*, not first-run: it must surface as a per-board error
+    # (#1813), never bounce an existing install back into the setup wizard.
+    # Before #1760 the legacy config.json copy masked this case; with
+    # settings as the single credential source the distinction is load-
+    # bearing (a token-less note array replacing the only board used to
+    # keep the wizard away purely via the stale legacy copy).
+    if has_connection_attempt and not has_configured_board_instance:
+        is_first_run = False
 
     if has_configured_board_instance:
         is_first_run = False

--- a/src/api_server.py
+++ b/src/api_server.py
@@ -3744,11 +3744,9 @@ async def send_welcome_message():
     Used by the setup wizard to confirm the board is working.
     Sends "HIYA FROM FIESTABOARD" with colorful borders.
 
-    Note: This creates a fresh BoardClient with current config values
-    to ensure any recent config changes (e.g., from the setup wizard) are used.
+    Note: This creates a fresh board client from the settings boards store
+    so any recent credential changes (setup wizard or Settings) are used.
     """
-    from .board_client import BoardClient
-
     # Check silence mode for the board this actually writes to (the primary
     # board — the wizard has no board picker).
     if _silence_active():
@@ -3760,19 +3758,20 @@ async def send_welcome_message():
         logger.info("Board is paused - blocking welcome message")
         return _paused_response()
 
-    # Create a fresh board client with current config values
-    # This ensures any config changes from the setup wizard are used
+    # Create a fresh board client from the primary settings board so recent
+    # credential edits are always used. Board credentials are unified on
+    # settings.json (issue #1760): the legacy config.json copy is never read.
+    board = _primary_board_entry()
     try:
-        use_cloud = Config.BOARD_API_MODE.lower() == "cloud"
-        board_client = BoardClient(
-            api_key=Config.get_board_api_key(),
-            host=Config.BOARD_HOST if not use_cloud else None,
-            use_cloud=use_cloud,
-            skip_unchanged=False,  # Always send the welcome message
-        )
+        board_client = board_client_from_board_dict(board) if board is not None else None
     except ValueError as e:
         logger.error(f"Failed to create board client: {e}")
         raise HTTPException(status_code=503, detail=f"Board not configured: {str(e)}") from e
+    if board_client is None:
+        raise HTTPException(
+            status_code=503, detail="Board not configured: no board with a usable connection"
+        )
+    board_client.skip_unchanged = False  # Always send the welcome message
 
     try:
         # Use custom welcome message if set, otherwise use the default
@@ -3853,20 +3852,64 @@ async def get_full_config():
     return config_manager.get_all_masked()
 
 
-@app.get("/config/board")
-async def get_board_config():
-    """Get board connection configuration (keys masked)."""
-    config_manager = get_config_manager()
-    board_config = config_manager.get_board()
-    masked = config_manager._mask_sensitive(board_config)
+# Deprecated /config/board shim (issue #1760): board credentials are unified
+# on the settings boards store. These endpoints keep their legacy wire shapes
+# during deprecation but read from and write through the settings service —
+# the config.json board block is left on disk untouched as a rollback copy
+# for older versions and is never read at runtime.
+_CONFIG_BOARD_SUCCESSOR_LINK = '</settings/board>; rel="successor-version"'
+_LEGACY_BOARD_CONNECTION_FIELDS = ("api_mode", "local_api_key", "cloud_key", "note_array_token", "host")
+_LEGACY_BOARD_SENSITIVE_FIELDS = ("local_api_key", "cloud_key", "note_array_token")
 
-    return {"config": masked, "api_modes": ["local", "cloud"]}
 
+def _legacy_board_config_view() -> dict:
+    """Project the primary settings board into the legacy config.json board
+    shape (the recorded ``GET/PUT /config/board`` wire contract).
 
-@app.put("/config/board")
-async def update_board_config(request: dict):
+    Transition fields come from the settings transitions section — the copy
+    the runtime actually uses.
     """
-    Update board configuration.
+    board = _primary_board_entry() or {}
+    transitions = get_settings_service().get_transition_settings()
+    return {
+        "api_mode": board.get("api_mode") or "local",
+        "local_api_key": board.get("local_api_key") or "",
+        "cloud_key": board.get("cloud_key") or "",
+        "note_array_token": board.get("note_array_token") or "",
+        "host": board.get("host") or "",
+        "transition_strategy": transitions.strategy,
+        "transition_interval_ms": transitions.step_interval_ms,
+        "transition_step_size": transitions.step_size,
+    }
+
+
+def _mask_legacy_board_view(view: dict) -> dict:
+    """Mask non-empty sensitive fields with '***' (legacy masking contract)."""
+    return {key: ("***" if key in _LEGACY_BOARD_SENSITIVE_FIELDS and value else value) for key, value in view.items()}
+
+
+# Deprecated: use GET /settings/board instead
+@app.get("/config/board")
+async def get_board_config(response: Response):
+    """Deprecated: use GET /settings/board instead (issue #1760).
+
+    Get board connection configuration (keys masked). Served from the
+    settings boards store — the single source of truth for board credentials.
+    """
+    response.headers["Deprecation"] = "true"
+    response.headers["Link"] = _CONFIG_BOARD_SUCCESSOR_LINK
+
+    return {"config": _mask_legacy_board_view(_legacy_board_config_view()), "api_modes": ["local", "cloud"]}
+
+
+# Deprecated: use PUT /settings/board instead
+@app.put("/config/board")
+async def update_board_config(request: dict, response: Response):
+    """Deprecated: use PUT /settings/board instead (issue #1760).
+
+    Update board connection configuration. Writes go to the primary board in
+    the settings boards store ONLY — the legacy config.json board block is no
+    longer written (it stays on disk as a rollback copy for older versions).
 
     Example body:
     {
@@ -3875,24 +3918,27 @@ async def update_board_config(request: dict):
         "host": "192.168.1.100"
     }
     """
-    config_manager = get_config_manager()
+    response.headers["Deprecation"] = "true"
+    response.headers["Link"] = _CONFIG_BOARD_SUCCESSOR_LINK
 
-    # Update board config
-    config_manager.set_board(request)
+    settings_service = get_settings_service()
+    boards = [dict(b) for b in (settings_service.get_board_settings().boards or []) if isinstance(b, dict)]
+    if not boards:
+        from .devices import BoardInstance
 
-    # Reload config in the Config class
-    Config.reload()
+        boards = [BoardInstance(name="My Board", device_type="flagship", board_color="black").to_dict()]
 
-    # Reinitialize the board client with new config
-    service = get_service()
-    if service:
-        service.reinitialize_board_client()
+    updates = {key: request[key] for key in _LEGACY_BOARD_CONNECTION_FIELDS if key in request}
+    boards[0].update(updates)
+    try:
+        settings_service.set_boards(boards)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
 
-    # Get updated config (masked)
-    updated = config_manager.get_board()
-    masked = config_manager._mask_sensitive(updated)
+    # Reinitialize the board clients with the new connection
+    _reinitialize_board_clients()
 
-    return {"status": "success", "config": masked}
+    return {"status": "success", "config": _mask_legacy_board_view(_legacy_board_config_view())}
 
 
 @app.delete("/config/board")
@@ -7378,9 +7424,9 @@ def _primary_connection_info() -> tuple[str, str]:
 
     Reads the boards[] store — the source the live clients are built from
     and what Settings → Boards displays — then falls back to the live
-    primary client, and only then to legacy ``Config`` (config.json), which
-    only the setup wizard writes and therefore goes stale as soon as the
-    board is edited in Settings (issue #1791).
+    primary client. The legacy config.json copy is never consulted: board
+    credentials are unified on settings.json (issue #1760), so with no
+    boards entry and no live client the install is simply unconfigured.
     """
     board = _primary_board_entry()
     if board is not None:
@@ -7396,7 +7442,7 @@ def _primary_connection_info() -> tuple[str, str]:
         host = getattr(client, "host", "")
         return mode, host if isinstance(host, str) else ""
 
-    return (Config.BOARD_API_MODE or "local").lower(), Config.BOARD_HOST or ""
+    return "local", ""
 
 
 def _get_first_board_dims():
@@ -7732,9 +7778,9 @@ async def debug_get_system_info():
     client = _get_board_client()
     cache_status = client.get_cache_status() if client else None
 
-    # Check if board is configured: for a boards[] entry the client factory is
-    # the authority on "has a usable connection"; legacy Config installs keep
-    # the old credential check.
+    # Check if board is configured: the client factory is the authority on
+    # "has a usable connection". No boards[] entry means unconfigured — the
+    # legacy config.json copy is never consulted (issue #1760).
     board = _primary_board_entry()
     if board is not None:
         try:
@@ -7743,13 +7789,7 @@ async def debug_get_system_info():
             logger.debug("Could not evaluate board connection config: %s", exc)
             board_configured = False
     else:
-        board_configured = bool(
-            board_ip
-            and (
-                (connection_mode == "local" and Config.BOARD_LOCAL_API_KEY)
-                or (connection_mode == "cloud" and Config.BOARD_READ_WRITE_KEY)
-            )
-        )
+        board_configured = False
 
     return {
         "board_ip": board_ip,
@@ -7773,22 +7813,15 @@ async def debug_network_diagnostics():
     """
     from .network_diagnostics import run_full_diagnostics
 
-    # Diagnose the connection the send path actually uses: the boards[] store
-    # first, legacy Config (wizard-era config.json) only when no board is
-    # configured there (issue #1791).
-    board = _primary_board_entry()
-    if board is not None:
-        board_host = board.get("host") or None
-        board_port = board.get("port") or 7000
-        board_api_key = board.get("local_api_key") or None
-        use_cloud = (board.get("api_mode") or "local").lower() == "cloud"
-        cloud_key = board.get("cloud_key") or None
-    else:
-        board_host = Config.BOARD_HOST or None
-        board_port = 7000
-        board_api_key = Config.BOARD_LOCAL_API_KEY or None
-        use_cloud = (Config.BOARD_API_MODE or "local").lower() == "cloud"
-        cloud_key = Config.BOARD_READ_WRITE_KEY or None
+    # Diagnose the connection the send path actually uses: the boards[]
+    # store. The legacy config.json copy is never consulted (issue #1760) —
+    # with no boards entry the diagnostics run without board credentials.
+    board = _primary_board_entry() or {}
+    board_host = board.get("host") or None
+    board_port = board.get("port") or 7000
+    board_api_key = board.get("local_api_key") or None
+    use_cloud = (board.get("api_mode") or "local").lower() == "cloud"
+    cloud_key = board.get("cloud_key") or None
 
     try:
         results = run_full_diagnostics(

--- a/src/config.py
+++ b/src/config.py
@@ -363,9 +363,15 @@ class Config:
         (``plugins.*``), not the retired legacy ``features.*`` blocks. The
         key set is unchanged so existing consumers keep working; the
         ``*_enabled`` flags now report plugin enablement.
+
+        Since #1760 the board connection fields report the primary settings
+        board — the connection the runtime actually uses — not the vestigial
+        config.json board block.
         """
         cm = cls._get_cm()
         weather = cm.get_plugin_config("weather") or {}
+        board = cls._primary_settings_board()
+        board_api_mode = (board.get("api_mode") or "local").lower() if board else "local"
         return {
             "weather_provider": weather.get("provider", "weatherapi"),
             "weather_location": weather.get("location", ""),
@@ -383,15 +389,32 @@ class Config:
             "baywheels_enabled": cm.is_plugin_enabled("lyft_bike_share"),
             "traffic_enabled": cm.is_plugin_enabled("traffic"),
             "stocks_enabled": cm.is_plugin_enabled("stocks"),
-            # Board config
-            "board_api_mode": cls.BOARD_API_MODE,
-            "board_host": cls.BOARD_HOST if cls.BOARD_API_MODE.lower() == "local" else "cloud",
-            "board_key_set": bool(cls.get_board_api_key()),
+            # Board config (from the primary settings board, issue #1760)
+            "board_api_mode": board_api_mode,
+            "board_host": (board.get("host") or "") if board_api_mode == "local" else "cloud",
+            "board_key_set": bool(board.get("cloud_key") if board_api_mode == "cloud" else board.get("local_api_key")),
             "weather_key_set": bool(weather.get("api_key")),
             # Transition settings (only available in Local API mode)
-            "transition_strategy": cls.BOARD_TRANSITION_STRATEGY if cls.BOARD_API_MODE.lower() == "local" else None,
-            "transition_interval_ms": cls.BOARD_TRANSITION_INTERVAL_MS
-            if cls.BOARD_API_MODE.lower() == "local"
-            else None,
-            "transition_step_size": cls.BOARD_TRANSITION_STEP_SIZE if cls.BOARD_API_MODE.lower() == "local" else None,
+            "transition_strategy": cls.BOARD_TRANSITION_STRATEGY if board_api_mode == "local" else None,
+            "transition_interval_ms": cls.BOARD_TRANSITION_INTERVAL_MS if board_api_mode == "local" else None,
+            "transition_step_size": cls.BOARD_TRANSITION_STEP_SIZE if board_api_mode == "local" else None,
         }
+
+    @staticmethod
+    def _primary_settings_board() -> dict:
+        """Connection fields of the primary settings board (issue #1760).
+
+        Board credentials are unified on settings.json; summaries must report
+        the connection the runtime actually uses, not the vestigial
+        config.json board block. Returns {} when the settings service is
+        unavailable (early startup, broken store).
+        """
+        try:
+            from .settings.service import get_settings_service
+
+            boards = get_settings_service().get_board_settings().boards or []
+            if boards and isinstance(boards[0], dict):
+                return boards[0]
+        except Exception:  # pragma: no cover - defensive
+            pass
+        return {}

--- a/src/devices.py
+++ b/src/devices.py
@@ -238,6 +238,21 @@ class BoardInstance:
             return bool(self.cloud_key)
         return bool(self.local_api_key and self.host)
 
+    @property
+    def has_connection_attempt(self) -> bool:
+        """True when the user has entered ANY connection detail for this board.
+
+        Deliberately weaker than :attr:`is_connection_configured`: a board
+        with a host but no key (or a note array missing its token) is
+        *misconfigured*, not *unconfigured*. First-run detection must use
+        this, not the strict check — a misconfigured board should surface
+        as a per-board error (#1813), never flip a working install back
+        into the setup wizard (#1760).
+        """
+        if self.api_mode == "virtual":
+            return True
+        return bool(self.host or self.local_api_key or self.cloud_key or self.note_array_token or self.tiles)
+
     def configured_tiles(self) -> list[dict]:
         """Return tiles that are in-range for the current W×H, enabled, and credentialed.
 

--- a/src/main.py
+++ b/src/main.py
@@ -120,8 +120,7 @@ class DisplayService:
     """Main service for displaying information on the board."""
 
     # Runtime key for the primary board when no board id is available
-    # (legacy single-board Config installs, or tests that set ``vb_client``
-    # directly without a boards list).
+    # (tests that set ``vb_client`` directly without a boards list).
     _PRIMARY_FALLBACK_KEY = "__primary__"
 
     def __init__(self):
@@ -433,7 +432,7 @@ class DisplayService:
         )
 
     def _build_board_clients(self, sync_cache: bool = True):
-        """Build one runtime per configured board (settings.boards) or fall back to Config.
+        """Build one runtime per configured board (settings.boards).
 
         Populates ``self.runtimes`` (board_id -> BoardRuntime for every board
         with a usable connection) and ``self._primary_board_id`` (the first
@@ -450,9 +449,9 @@ class DisplayService:
         Per-board failure isolation (issue #1749): each board's client build
         is independent, so one bad board — the primary included — is skipped
         with its reason recorded in ``self.board_init_errors`` while every
-        other board still comes up. The legacy Config fallback only runs when
-        *no* configured board produced a client, so a misconfigured primary
-        can no longer drag the whole fleet through it.
+        other board still comes up. Board credentials are unified on
+        settings.boards (issue #1760): the legacy config.json copy is never
+        read here, so no client is ever built from stale credentials.
 
         Args:
             sync_cache: read the primary board's current message to seed the
@@ -514,24 +513,14 @@ class DisplayService:
                 f"continuing with {len(new_runtimes)} other board(s)"
             )
         else:
-            # Legacy single-board Config path: no usable settings.boards entry.
-            # Its own failure is recorded rather than raised so callers see an
-            # empty fleet instead of an exception out of the whole build.
-            try:
-                use_cloud = Config.BOARD_API_MODE.lower() == "cloud"
-                client = BoardClient(
-                    api_key=Config.get_board_api_key(),
-                    host=Config.BOARD_HOST if not use_cloud else None,
-                    use_cloud=use_cloud,
-                    skip_unchanged=True,
-                )
-                self._attach_transition_runner(client)
-                key = self._PRIMARY_FALLBACK_KEY
-                self.runtimes[key] = BoardRuntime(client=client, board_id=key)
-                self._primary_board_id = key
-            except Exception as e:
-                self._primary_board_id = primary_id
-                logger.error(f"No board connection available: legacy config client could not be built ({e})")
+            # No board produced a client. Board credentials are unified on
+            # settings.boards (issue #1760): the legacy config.json copy is
+            # never read here anymore, so a credential-less settings board
+            # means the install is genuinely unconfigured — building a ghost
+            # client from a stale config.json key silently drove the wrong
+            # credentials (the #948/#1102 family).
+            self._primary_board_id = primary_id
+            logger.error("No board connection available: no configured board produced a client")
 
         if sync_cache:
             rt = self._primary_runtime()
@@ -561,8 +550,8 @@ class DisplayService:
     def rebuild_board_clients(self) -> bool:
         """Rebuild runtimes from current config (diff-based, keyed by board id).
 
-        Prefers settings.boards (one runtime per board with a connection);
-        falls back to Config for the primary. Unchanged boards keep their
+        Builds from settings.boards (one runtime per board with a
+        connection). Unchanged boards keep their
         runtime + caches; removed/disabled boards are pruned. Must be called
         after any boards-list mutation, otherwise sends keep targeting the old
         connections (issue: content delivered to a removed board).
@@ -728,7 +717,7 @@ class DisplayService:
             logger.error("Configuration validation failed")
             return False
 
-        # Initialize board runtimes from settings.boards (all boards) or Config
+        # Initialize board runtimes from settings.boards (all boards)
         try:
             self._build_board_clients()
             # Gate on the FLEET, not on the primary board (issue #1749): a

--- a/src/settings/service.py
+++ b/src/settings/service.py
@@ -718,10 +718,16 @@ def _board_dict_has_credentials(board: dict) -> bool:
     """True when a raw board dict already carries any connection credential.
 
     Credentials are the local API key, the cloud read/write key, the
-    note-array token, or configured local-array tiles. A board with any of
+    note-array token, or configured local-array tiles. A virtual board
+    (FiestaPanel) counts too: carrying no credential fields is its nature,
+    not an unconfigured state — mirroring
+    ``BoardInstance.has_connection_attempt`` — so stale physical credentials
+    never flip its ``api_mode`` (#1866 review). A board matching any of
     these is a *maintained* copy and must never be overwritten by the legacy
     config.json block (issue #1760 precedence rule).
     """
+    if board.get("api_mode") == "virtual":
+        return True
     if board.get("local_api_key") or board.get("cloud_key") or board.get("note_array_token"):
         return True
     tiles = board.get("tiles")
@@ -732,16 +738,17 @@ def _read_legacy_board_connection() -> dict | None:
     """Read the legacy ``config.json -> board.*`` connection block.
 
     Returns a dict of :data:`_LEGACY_CONNECTION_FIELDS`, or None when the
-    legacy block is unreadable or carries no credential worth importing.
+    legacy block carries no credential worth importing. A *failure* to read
+    it propagates instead of masquerading as "no credentials": swallowing it
+    let a transient config read failure stamp the new schema version with
+    nothing imported (#1866 review). The migration runner aborts the run so
+    schema_version stays pre-migration and the import retries next boot.
     This is the ONLY remaining read of board credentials from config.json;
     everything at runtime goes through the settings store (issue #1760).
     """
-    try:
-        from src.config_manager import get_config_manager
+    from src.config_manager import get_config_manager
 
-        legacy = get_config_manager().get_board()
-    except Exception:
-        return None
+    legacy = get_config_manager().get_board()
     if not (legacy.get("local_api_key") or legacy.get("cloud_key") or legacy.get("note_array_token")):
         return None
     return {
@@ -751,6 +758,27 @@ def _read_legacy_board_connection() -> dict | None:
         "cloud_key": legacy.get("cloud_key", "") or "",
         "note_array_token": legacy.get("note_array_token", "") or "",
     }
+
+
+def _connection_fields_for_board(legacy: dict, board: dict) -> dict | None:
+    """Restrict an imported legacy connection to fields the target board can use.
+
+    A note-array token only ever drives a note-array board. Importing it onto
+    a flagship/note primary satisfied ``has_connection_attempt`` — the setup
+    wizard never appeared — while no client could ever be built from it
+    (#1866 review). For non-array targets the token is dropped; if no real
+    credential remains, nothing imports and the wizard shows as it did
+    pre-#1760.
+    """
+    from src.devices import is_note_array
+
+    if is_note_array(board.get("device_type", "flagship")):
+        return legacy
+    fields = dict(legacy)
+    fields["note_array_token"] = ""
+    if not (fields.get("local_api_key") or fields.get("cloud_key")):
+        return None
+    return fields
 
 
 def _migrate_v2_to_v3(data: dict) -> int:
@@ -775,15 +803,32 @@ def _migrate_v2_to_v3(data: dict) -> int:
     if not isinstance(board, dict):
         return 0
     boards = board.get("boards")
+    materialize = False
     if not isinstance(boards, list) or not boards or not isinstance(boards[0], dict):
-        return 0
+        # Devices-era file: a raw ``board`` dict without a ``boards`` list
+        # (e.g. {"board_type": "black", "devices": ["flagship"]}) — a shape
+        # BoardSettings.from_dict still parses. Gating only on a raw
+        # boards[0] let these installs slip between the migration and the
+        # first-boot seed: schema stamped v3 with the credentials stranded
+        # in config.json (#1866 review). Run the import against the
+        # POST-PARSE board list instead, and materialize it on import.
+        parsed = BoardSettings.from_dict(board)
+        boards = [b for b in parsed.boards if isinstance(b, dict)]
+        if not boards:
+            return 0
+        materialize = True
     first = boards[0]
     if _board_dict_has_credentials(first):
         return 0
     legacy = _read_legacy_board_connection()
     if legacy is None:
         return 0
-    first.update(legacy)
+    importable = _connection_fields_for_board(legacy, first)
+    if importable is None:
+        return 0
+    first.update(importable)
+    if materialize:
+        board["boards"] = boards
     logger.info("Imported legacy config.json board connection into the primary settings board")
     return 1
 
@@ -910,12 +955,25 @@ class SettingsService:
             except OSError as e:
                 logger.warning(f"Could not create settings backup: {e}")
 
-        for target_version, migrate_fn in MIGRATIONS:
-            if current_version >= target_version:
-                continue
-            count = migrate_fn(data)
-            logger.info(f"Settings schema migration v{current_version}->v{target_version}: {count} change(s) applied")
-            current_version = target_version
+        try:
+            for target_version, migrate_fn in MIGRATIONS:
+                if current_version >= target_version:
+                    continue
+                count = migrate_fn(data)
+                logger.info(
+                    f"Settings schema migration v{current_version}->v{target_version}: {count} change(s) applied"
+                )
+                current_version = target_version
+        except Exception:
+            # Abort the whole run without saving: schema_version on disk stays
+            # pre-migration (no half-stamp — nothing mutated reaches disk) and
+            # every pending migration re-runs on the next boot. Migrations are
+            # idempotent by contract, so the retry is safe (#1866 review).
+            logger.exception(
+                f"Settings schema migration to v{CURRENT_SETTINGS_SCHEMA_VERSION} failed — "
+                "leaving schema_version unstamped; will retry next boot"
+            )
+            return
 
         data["schema_version"] = CURRENT_SETTINGS_SCHEMA_VERSION
 
@@ -1046,10 +1104,19 @@ class SettingsService:
         first = settings.boards[0]
         if _board_dict_has_credentials(first):
             return False
-        legacy = _read_legacy_board_connection()
+        try:
+            legacy = _read_legacy_board_connection()
+        except Exception:
+            # First boot has no schema-version retry lever; skip the seed and
+            # leave the board section unsaved so the next boot tries again.
+            logger.warning("Could not read legacy board connection for first-boot seed", exc_info=True)
+            return False
         if legacy is None:
             return False
-        first.update(legacy)
+        importable = _connection_fields_for_board(legacy, first)
+        if importable is None:
+            return False
+        first.update(importable)
         logger.info("Seeded first-boot board connection from legacy config.json")
         return True
 

--- a/src/settings/service.py
+++ b/src/settings/service.py
@@ -581,7 +581,7 @@ class MQTTSettings:
 # pre-migration file is written to ``settings.json.v{N}_backup`` before the
 # first migration runs.
 
-CURRENT_SETTINGS_SCHEMA_VERSION = 2
+CURRENT_SETTINGS_SCHEMA_VERSION = 3
 
 _LEGACY_CAROUSEL_PREFIX = "carousel:"
 _COLLECTION_PREFIX = "collection:"
@@ -709,9 +709,89 @@ def _migrate_v1_to_v2(data: dict) -> int:
     return 1
 
 
+# Board-connection fields copied from the legacy config.json board block into
+# a credential-less settings board (v2 -> v3 migration and first-boot seed).
+_LEGACY_CONNECTION_FIELDS = ("api_mode", "host", "local_api_key", "cloud_key", "note_array_token")
+
+
+def _board_dict_has_credentials(board: dict) -> bool:
+    """True when a raw board dict already carries any connection credential.
+
+    Credentials are the local API key, the cloud read/write key, the
+    note-array token, or configured local-array tiles. A board with any of
+    these is a *maintained* copy and must never be overwritten by the legacy
+    config.json block (issue #1760 precedence rule).
+    """
+    if board.get("local_api_key") or board.get("cloud_key") or board.get("note_array_token"):
+        return True
+    tiles = board.get("tiles")
+    return isinstance(tiles, list) and len(tiles) > 0
+
+
+def _read_legacy_board_connection() -> dict | None:
+    """Read the legacy ``config.json -> board.*`` connection block.
+
+    Returns a dict of :data:`_LEGACY_CONNECTION_FIELDS`, or None when the
+    legacy block is unreadable or carries no credential worth importing.
+    This is the ONLY remaining read of board credentials from config.json;
+    everything at runtime goes through the settings store (issue #1760).
+    """
+    try:
+        from src.config_manager import get_config_manager
+
+        legacy = get_config_manager().get_board()
+    except Exception:
+        return None
+    if not (legacy.get("local_api_key") or legacy.get("cloud_key") or legacy.get("note_array_token")):
+        return None
+    return {
+        "api_mode": legacy.get("api_mode", "local") or "local",
+        "host": legacy.get("host", "") or "",
+        "local_api_key": legacy.get("local_api_key", "") or "",
+        "cloud_key": legacy.get("cloud_key", "") or "",
+        "note_array_token": legacy.get("note_array_token", "") or "",
+    }
+
+
+def _migrate_v2_to_v3(data: dict) -> int:
+    """Migration 2 -> 3 (idempotent; operates on the raw settings dict).
+
+    Unify board credentials on settings.json (issue #1760): import the legacy
+    ``config.json -> board.*`` connection block into the primary settings
+    board — once, gated on schema_version, replacing the old copy-on-every-boot
+    seam that kept resurrecting stale config.json keys (#948/#1102).
+
+    Precedence: settings is the maintained copy. Only a credential-less
+    primary board inherits from config.json; a board that already carries any
+    credential (local key, cloud key, note-array token, or local-array tiles)
+    is left untouched. config.json itself is not modified — its board block
+    stays on disk as a rollback copy for older versions but is no longer read
+    at runtime.
+
+    Returns 1 when the primary board inherited the legacy connection,
+    0 otherwise.
+    """
+    board = data.get("board")
+    if not isinstance(board, dict):
+        return 0
+    boards = board.get("boards")
+    if not isinstance(boards, list) or not boards or not isinstance(boards[0], dict):
+        return 0
+    first = boards[0]
+    if _board_dict_has_credentials(first):
+        return 0
+    legacy = _read_legacy_board_connection()
+    if legacy is None:
+        return 0
+    first.update(legacy)
+    logger.info("Imported legacy config.json board connection into the primary settings board")
+    return 1
+
+
 MIGRATIONS: list[tuple[int, Callable[[dict], int]]] = [
     (1, _migrate_v0_to_v1),
     (2, _migrate_v1_to_v2),
+    (3, _migrate_v2_to_v3),
 ]
 
 
@@ -778,9 +858,9 @@ class SettingsService:
         self._plugins = self._load_plugin_settings()
         self._temporary_override: TemporaryOverride | None = self._load_temporary_override()
 
-        if getattr(self, "_needs_migration_save", False):
+        if getattr(self, "_needs_seed_save", False):
             self._save_to_file()
-            self._needs_migration_save = False
+            self._needs_seed_save = False
 
         logger.info(f"SettingsService initialized (file: {self.settings_file})")
 
@@ -935,47 +1015,42 @@ class SettingsService:
     def _load_board_settings(self) -> BoardSettings:
         """Load board settings from file.
 
-        If the first board has no connection settings, migrate them from
-        the global board config (config.json) so existing setups keep working.
-        Migration is deferred -- _migrate_global_connection sets a flag,
-        and the actual save happens after all settings are fully initialized.
+        Existing files: the schema migrations (run before any ``_load_*``)
+        already imported the legacy config.json connection where appropriate,
+        so the section is used as-is — a maintained board is never re-seeded
+        from config.json (issue #1760).
+
+        First boot only (no board section on disk yet): the freshly created
+        default board inherits the legacy ``config.json -> board.*``
+        connection, which is where env vars like ``BOARD_READ_WRITE_KEY``
+        seed credentials. The seed is persisted after init via
+        ``_needs_seed_save``.
         """
         file_data = self._load_from_file()
         if "board" in file_data:
-            settings = BoardSettings.from_dict(file_data["board"])
-        else:
-            settings = BoardSettings()
+            return BoardSettings.from_dict(file_data["board"])
 
-        self._needs_migration_save = self._apply_global_connection(settings)
+        settings = BoardSettings()
+        self._needs_seed_save = self._seed_connection_from_legacy_config(settings)
         return settings
 
-    def _apply_global_connection(self, settings: BoardSettings) -> bool:
-        """Copy global board connection config into board instances that lack one.
+    @staticmethod
+    def _seed_connection_from_legacy_config(settings: BoardSettings) -> bool:
+        """First-boot seed: copy the legacy config.json connection into the
+        default board when it carries no credential of its own.
 
         Returns True if settings were modified and need saving.
         """
         if not settings.boards:
             return False
-
         first = settings.boards[0]
-        if first.get("local_api_key") or first.get("cloud_key"):
+        if _board_dict_has_credentials(first):
             return False
-
-        try:
-            from src.config_manager import get_config_manager
-
-            global_cfg = get_config_manager().get_board()
-        except Exception:
+        legacy = _read_legacy_board_connection()
+        if legacy is None:
             return False
-
-        if not global_cfg.get("local_api_key") and not global_cfg.get("cloud_key"):
-            return False
-
-        first["api_mode"] = global_cfg.get("api_mode", "local")
-        first["host"] = global_cfg.get("host", "")
-        first["local_api_key"] = global_cfg.get("local_api_key", "")
-        first["cloud_key"] = global_cfg.get("cloud_key", "")
-        logger.info("Migrated global board connection to first board instance")
+        first.update(legacy)
+        logger.info("Seeded first-boot board connection from legacy config.json")
         return True
 
     def _load_schedule_settings(self) -> ScheduleSettings:

--- a/tests/golden/storage/settings.json
+++ b/tests/golden/storage/settings.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "transitions": {
     "strategy": null,
     "step_interval_ms": null,

--- a/tests/test_api_coverage.py
+++ b/tests/test_api_coverage.py
@@ -280,6 +280,17 @@ class TestSendWelcomeMessage:
             transition.step_interval_ms = 100
             transition.step_size = 1
             ss.get_transition_settings.return_value = transition
+            board_settings = Mock()
+            board_settings.boards = [
+                {
+                    "id": "b1",
+                    "device_type": "flagship",
+                    "api_mode": "local",
+                    "host": "192.168.1.100",
+                    "local_api_key": "test_key_12345",
+                }
+            ]
+            ss.get_board_settings.return_value = board_settings
             mock_ss.return_value = ss
 
             response = client.post("/send-welcome-message")
@@ -312,6 +323,17 @@ class TestSendWelcomeMessage:
             transition.step_interval_ms = 100
             transition.step_size = 1
             ss.get_transition_settings.return_value = transition
+            board_settings = Mock()
+            board_settings.boards = [
+                {
+                    "id": "b1",
+                    "device_type": "flagship",
+                    "api_mode": "local",
+                    "host": "192.168.1.100",
+                    "local_api_key": "test_key_12345",
+                }
+            ]
+            ss.get_board_settings.return_value = board_settings
             mock_ss.return_value = ss
 
             response = client.post("/send-welcome-message")
@@ -343,6 +365,16 @@ class TestSendWelcomeMessage:
             transition.step_interval_ms = 100
             transition.step_size = 1
             ss.get_transition_settings.return_value = transition
+            board_settings = Mock()
+            board_settings.boards = [
+                {
+                    "id": "b1",
+                    "device_type": "flagship",
+                    "api_mode": "cloud",
+                    "cloud_key": "test_cloud_key",
+                }
+            ]
+            ss.get_board_settings.return_value = board_settings
             mock_ss.return_value = ss
 
             response = client.post("/send-welcome-message")
@@ -378,7 +410,14 @@ class TestSendWelcomeMessage:
             transition.step_size = 1
             ss.get_transition_settings.return_value = transition
             board_settings = Mock()
-            board_settings.boards = [{"device_type": "note"}]
+            board_settings.boards = [
+                {
+                    "device_type": "note",
+                    "api_mode": "local",
+                    "host": "192.168.1.100",
+                    "local_api_key": "test_key_12345",
+                }
+            ]
             ss.get_board_settings.return_value = board_settings
             mock_ss.return_value = ss
 
@@ -428,7 +467,14 @@ class TestSendWelcomeMessage:
             transition.step_size = 1
             ss.get_transition_settings.return_value = transition
             board_settings = Mock()
-            board_settings.boards = [{"device_type": "flagship"}]
+            board_settings.boards = [
+                {
+                    "device_type": "flagship",
+                    "api_mode": "local",
+                    "host": "192.168.1.100",
+                    "local_api_key": "test_key_12345",
+                }
+            ]
             ss.get_board_settings.return_value = board_settings
             mock_ss.return_value = ss
 
@@ -469,7 +515,15 @@ class TestSendWelcomeMessage:
             transition.step_size = 1
             ss.get_transition_settings.return_value = transition
             board_settings = Mock()
-            board_settings.boards = [{"device_type": "note_array", "notes_wide": 2, "notes_tall": 1}]
+            board_settings.boards = [
+                {
+                    "device_type": "note_array",
+                    "notes_wide": 2,
+                    "notes_tall": 1,
+                    "api_mode": "cloud",
+                    "note_array_token": "test-token",
+                }
+            ]
             ss.get_board_settings.return_value = board_settings
             mock_ss.return_value = ss
 
@@ -508,7 +562,15 @@ class TestSendWelcomeMessage:
             transition.step_size = 1
             ss.get_transition_settings.return_value = transition
             board_settings = Mock()
-            board_settings.boards = [{"device_type": "note_array", "notes_wide": 1, "notes_tall": 2}]
+            board_settings.boards = [
+                {
+                    "device_type": "note_array",
+                    "notes_wide": 1,
+                    "notes_tall": 2,
+                    "api_mode": "cloud",
+                    "note_array_token": "test-token",
+                }
+            ]
             ss.get_board_settings.return_value = board_settings
             mock_ss.return_value = ss
 

--- a/tests/test_api_extended.py
+++ b/tests/test_api_extended.py
@@ -394,11 +394,14 @@ class TestConfigEndpoints:
         assert "api_modes" in data
 
     def test_update_board_config(self, client, mock_config_manager, mock_service):
+        """PUT /config/board is a shim over settings (issue #1760): it writes
+        the settings boards store and never the config.json board block."""
         response = client.put("/config/board", json={"api_mode": "local", "host": "10.0.0.1"})
         assert response.status_code == 200
         data = response.json()
         assert data["status"] == "success"
-        mock_config_manager.set_board.assert_called_once()
+        assert data["config"]["host"] == "10.0.0.1"
+        mock_config_manager.set_board.assert_not_called()
 
     def test_validate_config_valid(self, client, mock_config_manager):
         response = client.get("/config/validate")

--- a/tests/test_board_credentials_unification.py
+++ b/tests/test_board_credentials_unification.py
@@ -205,6 +205,108 @@ class TestLegacyCredentialMigration:
         first = svc.get_board_settings().boards[0]
         assert first["cloud_key"] == "test_key"
 
+    def test_devices_era_settings_still_import_legacy_credentials(self, data_dir):
+        """Devices-era fixture: a raw ``board`` dict with ``devices`` and NO
+        ``boards`` list — a shape ``BoardSettings.from_dict`` still parses.
+
+        This shape used to slip between the migration gate (which needed a
+        raw ``boards[0]``) and the first-boot seed (which needs ``board``
+        absent): schema stamped v3 with the credentials stranded in
+        config.json forever — dark board, and no wizard to recover with. The
+        migration must run the legacy import against the POST-PARSE board
+        list (#1866 review).
+        """
+        from src.settings.service import CURRENT_SETTINGS_SCHEMA_VERSION
+
+        _write_config(data_dir, local_api_key=STALE_KEY, host=STALE_HOST)
+        payload = {
+            "schema_version": 2,
+            "board": {"board_type": "black", "devices": ["flagship"]},
+        }
+        (data_dir / "settings.json").write_text(json.dumps(payload))
+
+        svc = _new_settings_service()
+
+        first = svc.get_board_settings().boards[0]
+        assert first["local_api_key"] == STALE_KEY, "devices-era install stranded its credentials in config.json"
+        assert first["host"] == STALE_HOST
+
+        on_disk = _settings_on_disk(data_dir)
+        assert on_disk["schema_version"] == CURRENT_SETTINGS_SCHEMA_VERSION
+        assert on_disk["board"]["boards"][0]["local_api_key"] == STALE_KEY
+
+    def test_virtual_primary_is_never_clobbered_by_stale_credentials(self, data_dir):
+        """A FiestaPanel primary (api_mode="virtual") carries no credential
+        fields by nature — that is configured, not credential-less. The
+        migration must not import stale physical credentials over it
+        (flipping api_mode and creating a ghost client); mirror
+        ``BoardInstance.has_connection_attempt``, which counts virtual as a
+        connection attempt (#1866 review).
+        """
+        _write_config(data_dir, local_api_key=STALE_KEY, host=STALE_HOST, api_mode="local")
+        _write_settings(data_dir, [_board(api_mode="virtual")], schema_version=2)
+
+        svc = _new_settings_service()
+
+        first = svc.get_board_settings().boards[0]
+        assert first["api_mode"] == "virtual", "stale physical credentials flipped a virtual primary"
+        assert first.get("local_api_key", "") == ""
+        assert first.get("host", "") == ""
+
+    def test_transient_config_read_failure_aborts_migration_for_retry(self, data_dir):
+        """A transient failure reading config.json must not stamp the new
+        schema version with nothing imported. The migration run aborts —
+        schema_version stays pre-migration, nothing half-stamped — and the
+        next (healthy) boot completes the import (#1866 review).
+        """
+        _write_config(data_dir, local_api_key=STALE_KEY, host=STALE_HOST)
+        _write_settings(data_dir, [_board()], schema_version=2)
+
+        with patch(
+            "src.config_manager.get_config_manager",
+            side_effect=RuntimeError("transient config read failure"),
+        ):
+            _new_settings_service()
+
+        assert _settings_on_disk(data_dir)["schema_version"] == 2, (
+            "migration stamped the new schema version despite the failed legacy read"
+        )
+
+        svc = _new_settings_service()
+        assert svc.get_board_settings().boards[0]["local_api_key"] == STALE_KEY
+        from src.settings.service import CURRENT_SETTINGS_SCHEMA_VERSION
+
+        assert _settings_on_disk(data_dir)["schema_version"] == CURRENT_SETTINGS_SCHEMA_VERSION
+
+    def test_token_only_install_does_not_seed_a_flagship_board(self, data_dir):
+        """BOARD_NOTE_ARRAY_TOKEN-only fresh install: a note-array token can
+        never drive the default flagship board. Seeding it anyway satisfied
+        has_connection_attempt — wizard suppressed, no client possible.
+        Nothing imports, so the wizard appears (pre-#1760 behavior)
+        (#1866 review).
+        """
+        from src.devices import BoardInstance
+
+        _write_config(data_dir, note_array_token="test_na_token")
+
+        svc = _new_settings_service()
+
+        first = svc.get_board_settings().boards[0]
+        assert first.get("note_array_token", "") == "", "a note-array token was seeded onto a flagship board"
+        assert not BoardInstance.from_dict(first).has_connection_attempt, (
+            "token-only seed suppressed the setup wizard with no buildable client"
+        )
+
+    def test_token_still_imports_into_a_note_array_primary(self, data_dir):
+        """The counterpart guard: when the primary IS a note array, the legacy
+        token imports exactly as before."""
+        _write_config(data_dir, note_array_token="test_na_token")
+        _write_settings(data_dir, [_board(device_type="note_array")], schema_version=2)
+
+        svc = _new_settings_service()
+
+        assert svc.get_board_settings().boards[0]["note_array_token"] == "test_na_token"
+
     def test_migrated_credentials_drive_client_construction(self, data_dir):
         """Upgrade acceptance: after the migration, the board runtime is built
         from the migrated settings credentials (under the board's own id, not

--- a/tests/test_board_credentials_unification.py
+++ b/tests/test_board_credentials_unification.py
@@ -1,0 +1,425 @@
+"""Board credentials unification (issue #1760).
+
+Board connection credentials historically lived in TWO places: the legacy
+``config.json -> board.*`` block (written by the setup wizard and env-var
+seeding) and the maintained ``settings.json -> board.boards[]`` store
+(written by Settings). They were copied once at first boot and then
+diverged — the structural root of the #948/#1102 "board went offline after
+I changed a key" family.
+
+These tests pin the unified contract:
+
+* A schema-versioned settings migration imports the legacy config.json
+  credentials exactly once (gated on ``schema_version``, never heuristics),
+  and never overwrites a maintained settings credential.
+* Every runtime reader of board credentials goes through the settings
+  store; nothing silently falls back to the stale config.json copy.
+* ``GET/PUT /config/board`` is a deprecated shim over settings — the wire
+  shapes are unchanged, ``Deprecation``/``Link`` successor headers are set,
+  and writes land in settings.json only. The config.json board block stays
+  on disk untouched as a rollback copy for older versions.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+# Clearly-fake test credentials (never real keys).
+LIVE_KEY = "test_live_settings_key"
+STALE_KEY = "test_stale_config_key"
+LIVE_HOST = "192.0.2.20"
+STALE_HOST = "192.0.2.99"
+
+_BOARD_ENV_VARS = (
+    "BOARD_API_MODE",
+    "BOARD_LOCAL_API_KEY",
+    "BOARD_HOST",
+    "BOARD_READ_WRITE_KEY",
+    "BOARD_NOTE_ARRAY_TOKEN",
+    "FB_API_MODE",
+    "FB_LOCAL_API_KEY",
+    "FB_HOST",
+    "FB_READ_WRITE_KEY",
+)
+
+
+@pytest.fixture
+def data_dir(_isolated_data_dir: Path, monkeypatch) -> Path:
+    """The isolated data dir, with board env vars cleared for determinism."""
+    for var in _BOARD_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    _isolated_data_dir.mkdir(parents=True, exist_ok=True)
+    return _isolated_data_dir
+
+
+@pytest.fixture
+def client(data_dir) -> TestClient:
+    """A TestClient whose services resolve from the isolated data dir."""
+    from src.api_server import app
+
+    return TestClient(app)
+
+
+def _write_config(data_dir: Path, **board) -> None:
+    """Write a legacy config.json with the given board block fields."""
+    block = {
+        "api_mode": "local",
+        "local_api_key": "",
+        "cloud_key": "",
+        "note_array_token": "",
+        "host": "",
+        "transition_strategy": None,
+        "transition_interval_ms": None,
+        "transition_step_size": None,
+    }
+    block.update(board)
+    (data_dir / "config.json").write_text(json.dumps({"board": block}))
+
+
+def _board(**overrides) -> dict:
+    board = {
+        "id": "b1",
+        "name": "My Board",
+        "device_type": "flagship",
+        "board_color": "black",
+        "enabled": True,
+        "paused": False,
+        "api_mode": "local",
+        "host": "",
+        "port": 7000,
+        "local_api_key": "",
+        "cloud_key": "",
+    }
+    board.update(overrides)
+    return board
+
+
+def _write_settings(data_dir: Path, boards: list[dict], schema_version: int = 2) -> None:
+    payload = {
+        "schema_version": schema_version,
+        "board": {"board_type": "black", "boards": boards},
+    }
+    (data_dir / "settings.json").write_text(json.dumps(payload))
+
+
+def _settings_on_disk(data_dir: Path) -> dict:
+    return json.loads((data_dir / "settings.json").read_text())
+
+
+def _new_settings_service():
+    from src.settings.service import SettingsService
+
+    return SettingsService()
+
+
+# ── 1. schema-versioned migration ───────────────────────────────────────────
+
+
+class TestLegacyCredentialMigration:
+    """The legacy config.json board block is imported via a settings schema
+    migration — run once, gated on schema_version, idempotent."""
+
+    def test_upgrade_imports_config_credentials_into_settings(self, data_dir):
+        """Legacy install: config.json has the credentials, settings.json has
+        a credential-less board at a pre-migration schema version. After boot
+        the settings store carries the credentials and is stamped with the
+        new schema version."""
+        from src.settings.service import CURRENT_SETTINGS_SCHEMA_VERSION
+
+        _write_config(data_dir, local_api_key=STALE_KEY, host=STALE_HOST, api_mode="local")
+        _write_settings(data_dir, [_board()], schema_version=2)
+
+        svc = _new_settings_service()
+
+        first = svc.get_board_settings().boards[0]
+        assert first["local_api_key"] == STALE_KEY
+        assert first["host"] == STALE_HOST
+
+        on_disk = _settings_on_disk(data_dir)
+        assert CURRENT_SETTINGS_SCHEMA_VERSION >= 3, "board-credential migration must bump the settings schema"
+        assert on_disk["schema_version"] == CURRENT_SETTINGS_SCHEMA_VERSION
+        assert on_disk["board"]["boards"][0]["local_api_key"] == STALE_KEY
+
+    def test_migration_is_gated_on_schema_version_not_heuristics(self, data_dir):
+        """A settings file already at the current schema version is never
+        re-seeded from config.json — even when its board has no credentials.
+
+        This is the root #948 fix: a user who cleared or changed credentials
+        in Settings must never have the stale config.json copy resurrected by
+        a boot-time heuristic ("board has no key, copy it over again")."""
+        from src.settings.service import CURRENT_SETTINGS_SCHEMA_VERSION
+
+        _write_config(data_dir, local_api_key=STALE_KEY, host=STALE_HOST)
+        _write_settings(data_dir, [_board()], schema_version=CURRENT_SETTINGS_SCHEMA_VERSION)
+
+        svc = _new_settings_service()
+
+        first = svc.get_board_settings().boards[0]
+        assert first.get("local_api_key", "") == "", "stale config.json credentials were re-copied heuristically"
+        assert first.get("host", "") == ""
+
+    def test_migration_never_overwrites_maintained_settings_credentials(self, data_dir):
+        """Precedence: settings is the maintained copy. A board that already
+        carries a credential keeps it through the migration, and re-running
+        the boot (idempotence) changes nothing."""
+        from src.settings.service import CURRENT_SETTINGS_SCHEMA_VERSION
+
+        _write_config(data_dir, local_api_key=STALE_KEY, host=STALE_HOST)
+        _write_settings(data_dir, [_board(local_api_key=LIVE_KEY, host=LIVE_HOST)], schema_version=2)
+
+        svc = _new_settings_service()
+        first = svc.get_board_settings().boards[0]
+        assert first["local_api_key"] == LIVE_KEY
+        assert first["host"] == LIVE_HOST
+
+        # Idempotent re-run: a second boot leaves everything as-is.
+        svc2 = _new_settings_service()
+        first2 = svc2.get_board_settings().boards[0]
+        assert first2["local_api_key"] == LIVE_KEY
+        assert first2["host"] == LIVE_HOST
+        assert _settings_on_disk(data_dir)["schema_version"] == CURRENT_SETTINGS_SCHEMA_VERSION
+
+    def test_fresh_install_seeds_credentials_from_config(self, data_dir):
+        """First boot ever (no settings.json): the default board inherits the
+        config.json credentials (which env vars may have seeded there)."""
+        _write_config(data_dir, local_api_key=STALE_KEY, host=STALE_HOST)
+
+        svc = _new_settings_service()
+
+        first = svc.get_board_settings().boards[0]
+        assert first["local_api_key"] == STALE_KEY
+        assert first["host"] == STALE_HOST
+
+    def test_env_cloud_key_flows_into_settings_on_first_boot(self, data_dir, monkeypatch):
+        """CI-style env flow: BOARD_READ_WRITE_KEY seeds config.json via the
+        ConfigManager, and the settings store picks it up on first boot."""
+        monkeypatch.setenv("BOARD_READ_WRITE_KEY", "test_key")
+
+        svc = _new_settings_service()
+
+        first = svc.get_board_settings().boards[0]
+        assert first["cloud_key"] == "test_key"
+
+    def test_migrated_credentials_drive_client_construction(self, data_dir):
+        """Upgrade acceptance: after the migration, the board runtime is built
+        from the migrated settings credentials (under the board's own id, not
+        a legacy fallback slot)."""
+        from src.main import DisplayService
+
+        _write_config(data_dir, local_api_key=STALE_KEY, host=STALE_HOST)
+        _write_settings(data_dir, [_board()], schema_version=2)
+
+        service = DisplayService()
+        service._build_board_clients(sync_cache=False)
+
+        assert "b1" in service.runtimes
+        client = service.runtimes["b1"].client
+        assert client.api_key == STALE_KEY
+
+
+# ── 2. divergence: every reader sees the settings copy ──────────────────────
+
+
+@pytest.fixture
+def diverged(data_dir) -> Path:
+    """The #948 repro state: settings carries the live key A (user changed it
+    in the UI), config.json still holds the stale key B."""
+    from src.settings.service import CURRENT_SETTINGS_SCHEMA_VERSION
+
+    _write_config(data_dir, local_api_key=STALE_KEY, host=STALE_HOST)
+    _write_settings(
+        data_dir,
+        [_board(local_api_key=LIVE_KEY, host=LIVE_HOST)],
+        schema_version=CURRENT_SETTINGS_SCHEMA_VERSION,
+    )
+    return data_dir
+
+
+class TestDivergedReadersSeeSettings:
+    """With settings key A and stale config.json key B, every repointed
+    reader must see A."""
+
+    def test_welcome_message_uses_settings_credentials(self, diverged, client):
+        with patch("src.board_client.BoardClient") as mock_bc:
+            instance = MagicMock()
+            instance.render.return_value = (True, True)
+            mock_bc.return_value = instance
+            response = client.post("/send-welcome-message")
+
+        assert response.status_code == 200
+        kwargs = mock_bc.call_args.kwargs
+        assert kwargs["api_key"] == LIVE_KEY
+        assert kwargs["host"] == LIVE_HOST
+
+    def test_board_client_build_uses_settings_credentials(self, diverged):
+        from src.main import DisplayService
+
+        service = DisplayService()
+        service._build_board_clients(sync_cache=False)
+
+        assert "b1" in service.runtimes
+        client = service.runtimes["b1"].client
+        assert client.api_key == LIVE_KEY
+        assert STALE_KEY not in {getattr(rt.client, "api_key", None) for rt in service.runtimes.values()}
+
+    def test_get_config_board_returns_settings_view(self, diverged, client):
+        response = client.get("/config/board")
+        assert response.status_code == 200
+        config = response.json()["config"]
+        assert config["host"] == LIVE_HOST
+        assert config["api_mode"] == "local"
+        # Non-empty credential is masked, proving it is set (and came from
+        # settings — the stale config.json copy has a different host).
+        assert config["local_api_key"] == "***"
+
+    def test_system_info_reports_settings_connection(self, diverged, client):
+        response = client.get("/debug/system-info")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["board_ip"] == LIVE_HOST
+        assert data["connection_mode"] == "local"
+
+    def test_network_diagnostics_uses_settings_credentials(self, diverged, client):
+        with patch("src.network_diagnostics.run_full_diagnostics", return_value={}) as diag:
+            response = client.get("/debug/network-diagnostics")
+        assert response.status_code == 200
+        kwargs = diag.call_args.kwargs
+        assert kwargs["board_host"] == LIVE_HOST
+        assert kwargs["board_api_key"] == LIVE_KEY
+
+
+class TestNoStaleConfigFallback:
+    """A credential-less settings board must read as unconfigured — never
+    silently served by the stale config.json copy."""
+
+    def _cleared(self, data_dir):
+        from src.settings.service import CURRENT_SETTINGS_SCHEMA_VERSION
+
+        _write_config(data_dir, local_api_key=STALE_KEY, host=STALE_HOST)
+        _write_settings(data_dir, [_board()], schema_version=CURRENT_SETTINGS_SCHEMA_VERSION)
+
+    def test_client_build_never_falls_back_to_stale_config(self, data_dir):
+        """User cleared the credentials in Settings: no ghost client is built
+        from whatever is left in config.json."""
+        from src.main import DisplayService
+
+        self._cleared(data_dir)
+        service = DisplayService()
+        with patch("src.main.BoardClient") as legacy_client:
+            service._build_board_clients(sync_cache=False)
+
+        legacy_client.assert_not_called()
+        assert service.board_clients == {}
+
+    def test_system_info_without_boards_never_reads_stale_config(self, client):
+        """Even with no boards[] entries at all, the stale config.json values
+        must not be reported as the live connection."""
+        ss = Mock()
+        board_settings = Mock()
+        board_settings.boards = []
+        ss.get_board_settings.return_value = board_settings
+        ss.should_send_to_board.return_value = False
+        with (
+            patch("src.api_server.get_settings_service", return_value=ss),
+            patch("src.api_server._get_board_client", return_value=None),
+            patch("src.api_server.Config") as mock_config,
+        ):
+            mock_config.BOARD_API_MODE = "local"
+            mock_config.BOARD_HOST = STALE_HOST
+            mock_config.BOARD_LOCAL_API_KEY = STALE_KEY
+            mock_config.BOARD_READ_WRITE_KEY = ""
+            response = client.get("/debug/system-info")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["board_ip"] == ""
+        assert data["board_configured"] is False
+
+
+# ── 3. /config/board deprecation shim ───────────────────────────────────────
+
+
+class TestConfigBoardShim:
+    """GET/PUT /config/board keep their recorded wire shapes, carry the
+    deprecation headers, and write through settings only."""
+
+    # Recorded response shapes of the pre-#1760 endpoints (golden).
+    GET_SHAPE = {"config", "api_modes"}
+    CONFIG_KEYS = {
+        "api_mode",
+        "local_api_key",
+        "cloud_key",
+        "note_array_token",
+        "host",
+        "transition_strategy",
+        "transition_interval_ms",
+        "transition_step_size",
+    }
+    PUT_SHAPE = {"status", "config"}
+
+    def test_get_config_board_shape_is_stable(self, diverged, client):
+        response = client.get("/config/board")
+        assert response.status_code == 200
+        data = response.json()
+        assert set(data.keys()) == self.GET_SHAPE
+        assert data["api_modes"] == ["local", "cloud"]
+        assert set(data["config"].keys()) == self.CONFIG_KEYS
+
+    def test_put_config_board_shape_is_stable(self, diverged, client):
+        response = client.put("/config/board", json={"api_mode": "local", "host": "192.0.2.50"})
+        assert response.status_code == 200
+        data = response.json()
+        assert set(data.keys()) == self.PUT_SHAPE
+        assert data["status"] == "success"
+        assert set(data["config"].keys()) == self.CONFIG_KEYS
+
+    def test_config_board_shim_sends_deprecation_headers(self, diverged, client):
+        for response in (
+            client.get("/config/board"),
+            client.put("/config/board", json={"host": "192.0.2.50"}),
+        ):
+            assert response.headers.get("Deprecation") == "true"
+            link = response.headers.get("Link", "")
+            assert "/settings/board" in link
+            assert 'rel="successor-version"' in link
+
+    def test_put_config_board_writes_settings_not_config(self, diverged, client):
+        # Warm the config manager first: its constructor normalizes
+        # config.json (defaults merge / version snapshot) on first load,
+        # which is unrelated to the PUT under test.
+        assert client.get("/config/full").status_code == 200
+        board_block_before = json.loads((diverged / "config.json").read_text())["board"]
+
+        response = client.put(
+            "/config/board",
+            json={"api_mode": "local", "host": "192.0.2.50", "local_api_key": "test_new_key"},
+        )
+        assert response.status_code == 200
+        assert response.json()["status"] == "success"
+
+        # The write landed in settings.json (visible through the settings API)…
+        settings_view = client.get("/settings/board").json()
+        assert settings_view["boards"][0]["host"] == "192.0.2.50"
+        on_disk = _settings_on_disk(diverged)
+        assert on_disk["board"]["boards"][0]["local_api_key"] == "test_new_key"
+        assert on_disk["board"]["boards"][0]["host"] == "192.0.2.50"
+
+        # …and the config.json board block was not touched: it keeps the
+        # stale values as a vestigial rollback copy for older versions.
+        board_block_after = json.loads((diverged / "config.json").read_text())["board"]
+        assert board_block_after == board_block_before
+        assert board_block_after["local_api_key"] == STALE_KEY
+        assert board_block_after["host"] == STALE_HOST
+
+    def test_put_config_board_preserves_masked_credentials(self, diverged, client):
+        """A masked '***' credential in the PUT body keeps the stored value —
+        the same contract the legacy config writer had."""
+        response = client.put("/config/board", json={"host": "192.0.2.50", "local_api_key": "***"})
+        assert response.status_code == 200
+        on_disk = _settings_on_disk(diverged)
+        assert on_disk["board"]["boards"][0]["local_api_key"] == LIVE_KEY

--- a/tests/test_board_credentials_unification.py
+++ b/tests/test_board_credentials_unification.py
@@ -423,3 +423,70 @@ class TestConfigBoardShim:
         assert response.status_code == 200
         on_disk = _settings_on_disk(diverged)
         assert on_disk["board"]["boards"][0]["local_api_key"] == LIVE_KEY
+
+
+class TestFirstRunDetectionAfterUnification:
+    """First-run must mean *never configured*, not *misconfigured* (#1760).
+
+    Before the unification, ``configureBoard()``-style writes through
+    ``PUT /config/board`` left credentials in config.json forever, so the
+    wizard gate never re-armed. With settings as the single source, a board
+    whose credentials are incomplete (e.g. a note array missing its token)
+    must surface as a per-board error — not flip the install back into the
+    setup wizard.
+    """
+
+    def test_incomplete_note_array_is_not_first_run(self, client):
+        client.put(
+            "/settings/board",
+            json={
+                "boards": [
+                    {
+                        "name": "My Board",
+                        "device_type": "note_array",
+                        "notes_wide": 4,
+                        "notes_tall": 1,
+                        "enabled": True,
+                        "api_mode": "local",
+                        "host": "localhost",
+                        "local_api_key": "test-key",
+                    }
+                ]
+            },
+        )
+        result = client.get("/config/validate").json()
+        assert result["is_first_run"] is False
+
+    def test_partial_host_only_board_is_not_first_run(self, client):
+        client.put(
+            "/settings/board",
+            json={
+                "boards": [{"name": "My Board", "device_type": "flagship", "api_mode": "local", "host": "192.0.2.9"}]
+            },
+        )
+        result = client.get("/config/validate").json()
+        assert result["is_first_run"] is False
+
+    def test_truly_blank_board_still_first_run(self, client):
+        client.put(
+            "/settings/board",
+            json={
+                "boards": [
+                    {
+                        "name": "My Board",
+                        "device_type": "flagship",
+                        "api_mode": "local",
+                        "host": "",
+                        "local_api_key": "",
+                    }
+                ]
+            },
+        )
+        result = client.get("/config/validate").json()
+        assert result["is_first_run"] is True
+
+    def test_wizard_reset_still_first_run(self, client):
+        client.put("/config/board", json={"host": "192.0.2.9", "local_api_key": "test-key"})
+        assert client.get("/config/validate").json()["is_first_run"] is False
+        client.delete("/config/board")
+        assert client.get("/config/validate").json()["is_first_run"] is True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -346,22 +346,40 @@ class TestGetSummary:
         assert "transition_interval_ms" in result
         assert "transition_step_size" in result
 
+    @staticmethod
+    def _patch_settings_board(board):
+        """Patch the settings service get_summary reads its board fields from
+        (issue #1760: the summary reports settings.boards, not config.json)."""
+        ss = MagicMock()
+        ss.get_board_settings.return_value = MagicMock(boards=[board])
+        return patch("src.settings.service.get_settings_service", return_value=ss)
+
     def test_get_summary_board_host_cloud_when_cloud_mode(self, mock_config_manager):
-        mock_config_manager.get_board.return_value = {"api_mode": "cloud", "host": ""}
-        result = Config.get_summary()
+        with self._patch_settings_board({"api_mode": "cloud", "host": "", "cloud_key": "test-rw"}):
+            result = Config.get_summary()
         assert result["board_host"] == "cloud"
 
     def test_get_summary_board_host_actual_when_local_mode(self, mock_config_manager):
-        mock_config_manager.get_board.return_value = {
-            "api_mode": "local",
-            "host": "192.168.1.100",
-        }
-        result = Config.get_summary()
+        with self._patch_settings_board({"api_mode": "local", "host": "192.168.1.100", "local_api_key": "test-key"}):
+            result = Config.get_summary()
         assert result["board_host"] == "192.168.1.100"
 
+    def test_get_summary_board_fields_ignore_stale_config_json(self, mock_config_manager):
+        """Divergence (#948/#1760): config.json says one host, settings says
+        another — the summary reports the settings copy."""
+        mock_config_manager.get_board.return_value = {
+            "api_mode": "local",
+            "host": "192.0.2.99",
+            "local_api_key": "test_stale_config_key",
+        }
+        with self._patch_settings_board({"api_mode": "local", "host": "192.0.2.20", "local_api_key": ""}):
+            result = Config.get_summary()
+        assert result["board_host"] == "192.0.2.20"
+        assert result["board_key_set"] is False
+
     def test_get_summary_transition_keys_none_when_cloud_mode(self, mock_config_manager):
-        mock_config_manager.get_board.return_value = {"api_mode": "cloud"}
-        result = Config.get_summary()
+        with self._patch_settings_board({"api_mode": "cloud", "cloud_key": "test-rw"}):
+            result = Config.get_summary()
         assert result["transition_strategy"] is None
         assert result["transition_interval_ms"] is None
         assert result["transition_step_size"] is None

--- a/tests/test_debug_endpoints.py
+++ b/tests/test_debug_endpoints.py
@@ -531,8 +531,11 @@ class TestConnectionInfoSource:
         assert response.status_code == 200
         assert response.json()["board_configured"] is False
 
-    def test_system_info_falls_back_to_legacy_config_without_boards(self, client):
-        """No boards[] entries → legacy Config keeps working (pre-boards installs)."""
+    def test_system_info_without_boards_never_reads_legacy_config(self, client):
+        """No boards[] entries → unconfigured. Board credentials are unified
+        on settings.json (issue #1760): the migration imports pre-boards
+        installs at boot, so at runtime the legacy config.json values must
+        never be reported as the live connection."""
         with (
             patch("src.api_server.get_settings_service", return_value=self._ss_with_board(None)),
             patch("src.api_server._get_board_client", return_value=None),
@@ -546,8 +549,8 @@ class TestConnectionInfoSource:
         assert response.status_code == 200
         data = response.json()
         assert data["connection_mode"] == "local"
-        assert data["board_ip"] == "192.168.1.50"
-        assert data["board_configured"] is True
+        assert data["board_ip"] == ""
+        assert data["board_configured"] is False
 
     def test_debug_info_board_text_uses_boards_store(self, client, mock_board_client):
         """The on-board debug text reports the boards[] mode/host, not legacy Config."""

--- a/tests/test_settings_service.py
+++ b/tests/test_settings_service.py
@@ -587,9 +587,17 @@ class TestSettingsServiceLoadFromFile:
 
 
 class TestSettingsServiceMigration:
-    """Test _apply_global_connection migration."""
+    """Legacy config.json board connection import (schema migration v2 -> v3).
 
-    def test_apply_global_connection_migrates_when_first_board_empty(self, settings_file, mock_config):
+    Issue #1760: the copy-on-every-boot ``_apply_global_connection`` seam was
+    replaced by a one-time, schema-versioned migration (plus a first-boot
+    seed when no board section exists yet). These tests exercise the
+    migration path: pre-versioned settings files with a credential-less
+    board. tests/test_board_credentials_unification.py covers version
+    gating, precedence, and the divergence contract.
+    """
+
+    def test_migration_imports_legacy_connection_when_first_board_empty(self, settings_file, mock_config):
         Path(settings_file).write_text(
             json.dumps(
                 {
@@ -611,7 +619,7 @@ class TestSettingsServiceMigration:
             svc = SettingsService(settings_file=settings_file)
         assert svc._board.boards[0]["local_api_key"] == "migrated-key"
 
-    def test_apply_global_connection_skips_when_board_has_keys(self, settings_file, mock_config):
+    def test_migration_skips_when_board_has_keys(self, settings_file, mock_config):
         Path(settings_file).write_text(
             json.dumps(
                 {
@@ -625,7 +633,7 @@ class TestSettingsServiceMigration:
             SettingsService(settings_file=settings_file)
             mock_get.assert_not_called()
 
-    def test_apply_global_connection_skips_when_global_empty(self, settings_file, mock_config):
+    def test_migration_skips_when_legacy_config_empty(self, settings_file, mock_config):
         Path(settings_file).write_text(json.dumps({"board": {"boards": [{"name": "B", "device_type": "flagship"}]}}))
         mock_cm = MagicMock()
         mock_cm.get_board.return_value = {"local_api_key": "", "cloud_key": ""}
@@ -633,7 +641,7 @@ class TestSettingsServiceMigration:
             svc = SettingsService(settings_file=settings_file)
         assert svc._board.boards[0].get("local_api_key", "") == ""
 
-    def test_apply_global_connection_handles_exception(self, settings_file, mock_config):
+    def test_migration_handles_config_manager_exception(self, settings_file, mock_config):
         Path(settings_file).write_text(json.dumps({"board": {"boards": [{"name": "B", "device_type": "flagship"}]}}))
         with patch("src.config_manager.get_config_manager", side_effect=Exception("err")):
             svc = SettingsService(settings_file=settings_file)


### PR DESCRIPTION
Closes #1760. **Track A**, stacked on #1864 (chain: #1855 → #1860 → #1864 → this).

## Why

Board credentials lived in `config.json → board.*` AND `settings.json → boards[]`, synced once at first boot then diverging — the structural root of the #948/#1102 "board went offline after I changed a key" family. Six legacy readers (the audit predicted five; `Config.get_summary` was a sixth) still read the stale config.json copy.

## What

- **Schema-versioned settings migration (v2→v3)**, on the #1848 kernel machinery: a fully credential-less primary board inherits the legacy `config.json` block; a board with **any** credential is never touched (settings is the maintained copy — precedence proven idempotent). The copy-once seam is deleted; its sole descendant is a first-boot seed when settings has no boards at all. Exactly one function still reads the legacy block: `_read_legacy_board_connection()`, used only by the migration.
- **Six readers repointed** to the settings store (welcome-message send, system-info, connection-info fallback, network diagnostics, `_build_board_clients`' legacy fallback — removed outright so a stale config key can't produce a ghost client — and `Config.get_summary`). `GET /config/validate` deliberately keeps its dual-source boolean first-run probe (documented).
- **`GET/PUT /config/board` is now a deprecation shim**: shapes pinned by golden-style tests, `Deprecation` + successor `Link` headers (existing repo pattern), PUT writes the primary settings board only (masked secrets preserved) and provably does **not** touch config.json. The on-disk legacy block stays as a rollback copy for older versions — never read at runtime.
- Env-var seeding (`BOARD_READ_WRITE_KEY` et al.) unchanged; it reaches settings via the migration/first-boot seed — pinned by a dedicated test and the CI env-var flow.

## Zero-regression evidence

- **Fail-first**: 8/18 new tests fail pre-fix on the exact bug shapes (stale key B served while settings has key A; ghost legacy client; PUT persisting to config.json), plus a revert-to-HEAD non-vacuity proof for the divergence test.
- `tests/test_persistence_round_trip.py` (#1736 gate) green **unmodified**, including under `BOARD_READ_WRITE_KEY=test_key`.
- Full suite: baseline `5498 passed / 1 failed` → `5517 passed / same 1 environmental failure`. Storage golden: the only byte changed is `schema_version` 2→3 (the intentional format change; the credentialed golden board untouched). Old-contract tests re-encoded with renames that say what changed (e.g. `..._falls_back_to_legacy_config` → `..._never_reads_legacy_config`). ruff clean.

(The base branch got a CI fix in the same push: the workflow's verify-imports step hardcoded two modules #1761 deleted.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Par2E2Nh65PyDF1q9TARJP