### PR TITLE
feat(engine): backoff retry for boards that failed to initialize

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -244,14 +244,26 @@ class DisplayService:
         return bid if bid else self._PRIMARY_FALLBACK_KEY
 
     def _ensure_primary_runtime(self) -> BoardRuntime:
-        """Return the primary runtime, creating an empty one if needed."""
+        """Return the primary runtime, creating an empty one if needed.
+
+        The placeholder insert runs under ``_runtimes_lock`` with a
+        double-checked read (#1870 review): unlocked, the insert raced the
+        recovery pass's copy-swap of ``self.runtimes`` — the placeholder
+        could land in the pre-swap dict (and be lost), or land after the
+        swap and clobber the freshly recovered runtime whose init error was
+        already cleared, silently re-stranding the board. The common case
+        (runtime already exists) stays lock-free.
+        """
         rt = self._primary_runtime()
         if rt is None:
             key = self._resolve_primary_key()
-            rt = self.runtimes.get(key)
+            rt = self.runtimes.get(key)  # unlocked fast path
             if rt is None:
-                rt = BoardRuntime(client=None, board_id=key)
-                self.runtimes[key] = rt
+                with self._runtimes_lock:
+                    rt = self.runtimes.get(key)  # double-check under the lock
+                    if rt is None:
+                        rt = BoardRuntime(client=None, board_id=key)
+                        self.runtimes[key] = rt
             self._primary_board_id = key
         return rt
 

--- a/src/main.py
+++ b/src/main.py
@@ -65,6 +65,14 @@ ADHOC_PAGE_ID = "__adhoc__"
 # the 120s cap and the executing job is budgeted at that full cap.)
 SEND_WAIT_TIMEOUT = 240.0
 
+# Backoff schedule for re-attempting boards that failed to initialize
+# (issue #1827). First retry ~60s after the failure, doubling per failed
+# attempt up to a 15-minute cap. The poll thread's cadence (the board-read
+# interval) is the timing granularity, so attempts land on the first poll
+# iteration at or after each deadline.
+BOARD_RETRY_INITIAL_BACKOFF = 60.0
+BOARD_RETRY_MAX_BACKOFF = 900.0
+
 
 def _board_size_key(board: dict) -> str:
     """Canonical size key ("flagship:6x22", "note_array:6x30", ...) for a board dict."""
@@ -180,6 +188,22 @@ class DisplayService:
 
         # Board state polling (background thread reads actual board state).
         self._poll_thread: threading.Thread | None = None
+
+        # Guards every copy-and-replace of ``self.runtimes`` /
+        # ``board_init_errors``: the rebuild path (API threads) and the poll
+        # thread's failed-board recovery pass (#1827) both perform
+        # read-modify-write swaps, and without a common critical section one
+        # side's update could be lost. Readers (the tick thread, /status) stay
+        # lock-free: the dicts are only ever replaced atomically, never
+        # mutated in place while shared.
+        self._runtimes_lock = threading.RLock()
+
+        # Per-board retry schedule for boards stuck in ``board_init_errors``
+        # (#1827): board_id -> {"backoff": current delay s, "next_attempt":
+        # time.monotonic() deadline}. Seeded by the poll thread's first
+        # recovery pass after a failure; cleared wholesale on every
+        # ``_build_board_clients`` (a full rebuild restarts the schedule).
+        self._board_retry_state: dict[str, dict[str, float]] = {}
 
         # Per-thread capture of send failures for the pass currently running
         # on THIS thread. ``rt.last_send_error`` is shared state that the
@@ -679,89 +703,98 @@ class DisplayService:
                 from an API request must NOT block on board I/O (an
                 unreachable board would stall the request), so it skips it.
         """
-        settings_service = get_settings_service()
-        boards = settings_service.get_board_settings().boards or []
+        # Serialized with the poll thread's failed-board recovery pass
+        # (#1827): both mutate ``self.runtimes``/``board_init_errors`` via
+        # copy-and-replace, and interleaved rebuild/retry writes would lose
+        # one side's update without a common critical section.
+        with self._runtimes_lock:
+            settings_service = get_settings_service()
+            boards = settings_service.get_board_settings().boards or []
 
-        new_runtimes: dict[str, BoardRuntime] = {}
-        init_errors: dict[str, str] = {}
-        for board in boards:
-            if not isinstance(board, dict):
-                continue
-            bid = board.get("id")
-            if not bid:
-                continue
-            sig = self._config_signature(board)
-            existing = self.runtimes.get(bid)
-            if existing is not None and existing.config_signature == sig and existing.client is not None:
-                # Unchanged connection: keep the runtime so its caches survive.
-                new_runtimes[bid] = existing
-                continue
-            try:
-                client = board_client_from_board_dict(board)
-            except Exception as e:
-                # One board's bad config must never abort the loop for the
-                # rest of the fleet (issue #1749).
-                init_errors[bid] = str(e) or e.__class__.__name__
-                logger.error(f"Board {bid}: could not build client ({e}) - skipping this board")
-                continue
-            if client is None:
-                init_errors[bid] = "Board is not fully configured (missing host, API key, or token)"
-                logger.error(f"Board {bid}: {init_errors[bid]} - skipping this board")
-                continue
-            self._attach_transition_runner(client)
-            rt = BoardRuntime(client=client, board_id=bid)
-            rt.config_signature = sig
-            new_runtimes[bid] = rt
-
-        # Runtimes not carried over are dead: stop their send workers so a
-        # queued job for a removed/reconfigured board is failed rather than
-        # delivered to a stale connection. Bounded join — a wedged send must
-        # not stall a rebuild (the runtime-epoch guard in _dispatch_send
-        # already keeps its late bookkeeping from touching live state).
-        for old_id, old_rt in self.runtimes.items():
-            if new_runtimes.get(old_id) is old_rt:
-                continue
-            if old_rt.send_worker is not None:
-                old_rt.send_worker.stop(timeout=1.0)
-
-        self.runtimes = new_runtimes
-        self.board_init_errors = init_errors
-
-        primary_id = boards[0].get("id") if (boards and isinstance(boards[0], dict)) else None
-        if primary_id and primary_id in new_runtimes:
-            self._primary_board_id = primary_id
-        elif new_runtimes:
-            # The primary is misconfigured but other boards came up. Keep the
-            # primary id pointing at the configured primary (its clientless
-            # runtime is created lazily by ``_ensure_primary_runtime``) rather
-            # than dropping into the legacy Config fallback, which would raise
-            # on an install with no legacy credential and take every board
-            # down with it (issue #1749).
-            self._primary_board_id = primary_id
-            logger.error(
-                f"Primary board {primary_id or '(unidentified)'} is unavailable "
-                f"({init_errors.get(primary_id, 'no usable connection')}); "
-                f"continuing with {len(new_runtimes)} other board(s)"
-            )
-        else:
-            # Legacy single-board Config path: no usable settings.boards entry.
-            # Its own failure is recorded rather than raised so callers see an
-            # empty fleet instead of an exception out of the whole build.
-            try:
-                use_cloud = Config.BOARD_API_MODE.lower() == "cloud"
-                client = BoardClient(
-                    api_key=Config.get_board_api_key(),
-                    host=Config.BOARD_HOST if not use_cloud else None,
-                    use_cloud=use_cloud,
-                    skip_unchanged=True,
-                )
+            new_runtimes: dict[str, BoardRuntime] = {}
+            init_errors: dict[str, str] = {}
+            for board in boards:
+                if not isinstance(board, dict):
+                    continue
+                bid = board.get("id")
+                if not bid:
+                    continue
+                sig = self._config_signature(board)
+                existing = self.runtimes.get(bid)
+                if existing is not None and existing.config_signature == sig and existing.client is not None:
+                    # Unchanged connection: keep the runtime so its caches survive.
+                    new_runtimes[bid] = existing
+                    continue
+                try:
+                    client = board_client_from_board_dict(board)
+                except Exception as e:
+                    # One board's bad config must never abort the loop for the
+                    # rest of the fleet (issue #1749).
+                    init_errors[bid] = str(e) or e.__class__.__name__
+                    logger.error(f"Board {bid}: could not build client ({e}) - skipping this board")
+                    continue
+                if client is None:
+                    init_errors[bid] = "Board is not fully configured (missing host, API key, or token)"
+                    logger.error(f"Board {bid}: {init_errors[bid]} - skipping this board")
+                    continue
                 self._attach_transition_runner(client)
-                key = self._PRIMARY_FALLBACK_KEY
-                self.runtimes[key] = BoardRuntime(client=client, board_id=key)
-                self._primary_board_id = key
-            except Exception as e:
+                rt = BoardRuntime(client=client, board_id=bid)
+                rt.config_signature = sig
+                new_runtimes[bid] = rt
+
+            # Runtimes not carried over are dead: stop their send workers so a
+            # queued job for a removed/reconfigured board is failed rather than
+            # delivered to a stale connection. Bounded join — a wedged send must
+            # not stall a rebuild (the runtime-epoch guard in _dispatch_send
+            # already keeps its late bookkeeping from touching live state).
+            for old_id, old_rt in self.runtimes.items():
+                if new_runtimes.get(old_id) is old_rt:
+                    continue
+                if old_rt.send_worker is not None:
+                    old_rt.send_worker.stop(timeout=1.0)
+
+            self.runtimes = new_runtimes
+            self.board_init_errors = init_errors
+            # Every failure recorded here is fresh (a full build re-attempted
+            # every board), so the poll thread's recovery pass restarts each
+            # failed board's backoff from the initial delay (#1827).
+            self._board_retry_state.clear()
+
+            primary_id = boards[0].get("id") if (boards and isinstance(boards[0], dict)) else None
+            if primary_id and primary_id in new_runtimes:
                 self._primary_board_id = primary_id
-                logger.error(f"No board connection available: legacy config client could not be built ({e})")
+            elif new_runtimes:
+                # The primary is misconfigured but other boards came up. Keep the
+                # primary id pointing at the configured primary (its clientless
+                # runtime is created lazily by ``_ensure_primary_runtime``) rather
+                # than dropping into the legacy Config fallback, which would raise
+                # on an install with no legacy credential and take every board
+                # down with it (issue #1749).
+                self._primary_board_id = primary_id
+                logger.error(
+                    f"Primary board {primary_id or '(unidentified)'} is unavailable "
+                    f"({init_errors.get(primary_id, 'no usable connection')}); "
+                    f"continuing with {len(new_runtimes)} other board(s)"
+                )
+            else:
+                # Legacy single-board Config path: no usable settings.boards entry.
+                # Its own failure is recorded rather than raised so callers see an
+                # empty fleet instead of an exception out of the whole build.
+                try:
+                    use_cloud = Config.BOARD_API_MODE.lower() == "cloud"
+                    client = BoardClient(
+                        api_key=Config.get_board_api_key(),
+                        host=Config.BOARD_HOST if not use_cloud else None,
+                        use_cloud=use_cloud,
+                        skip_unchanged=True,
+                    )
+                    self._attach_transition_runner(client)
+                    key = self._PRIMARY_FALLBACK_KEY
+                    self.runtimes[key] = BoardRuntime(client=client, board_id=key)
+                    self._primary_board_id = key
+                except Exception as e:
+                    self._primary_board_id = primary_id
+                    logger.error(f"No board connection available: legacy config client could not be built ({e})")
 
         if sync_cache:
             rt = self._primary_runtime()
@@ -873,9 +906,19 @@ class DisplayService:
         Polling stays primary-only (single board-read thread — a thread per
         board would break the single-threaded send invariant the note-array
         >=15s throttle relies on). The cache lives on the primary runtime.
+
+        This thread also hosts the failed-board recovery pass (#1827):
+        ``initialize()`` is already idempotent w.r.t. this thread, so
+        piggybacking the low-frequency retry here avoids a second background
+        thread. The pass is a cheap no-op while ``board_init_errors`` is
+        empty.
         """
         while self.running:
             interval = self._get_board_read_interval()
+            try:
+                self._retry_failed_board_inits()
+            except Exception as e:  # a retry bug must never kill board polling
+                logger.error(f"Failed-board recovery pass crashed: {e}")
             try:
                 rt = self._primary_runtime()
                 if rt is not None and rt.client is not None:
@@ -887,6 +930,104 @@ class DisplayService:
             except Exception as e:
                 logger.debug(f"Board state poll failed: {e}")
             time.sleep(interval)
+
+    def _retry_failed_board_inits(self) -> None:
+        """Low-frequency recovery pass for boards stuck in ``board_init_errors`` (#1827).
+
+        Runs on the board-poll thread. Re-attempts ONLY the failed boards —
+        never a full ``rebuild_board_clients()``, so healthy boards' runtimes
+        (and caches) are untouched — with per-board exponential backoff:
+        first retry ``BOARD_RETRY_INITIAL_BACKOFF`` seconds after the
+        failure, doubling per failed attempt to the
+        ``BOARD_RETRY_MAX_BACKOFF`` cap.
+
+        Log discipline: every attempt logs at debug; error-level lines are
+        emitted only while the backoff step is still increasing (the first
+        few attempts), so a permanently misconfigured board settles into one
+        debug line per 15 minutes instead of an error per poll iteration.
+        """
+        if not self.board_init_errors and not self._board_retry_state:
+            return
+        now = time.monotonic()
+        with self._runtimes_lock:
+            # Boards no longer failed (fixed via rebuild, or removed) drop
+            # their schedule; ``_build_board_clients`` also clears wholesale.
+            for board_id in list(self._board_retry_state):
+                if board_id not in self.board_init_errors:
+                    del self._board_retry_state[board_id]
+            for board_id in sorted(self.board_init_errors):
+                state = self._board_retry_state.get(board_id)
+                if state is None:
+                    # First sighting of this failure: the failed build already
+                    # logged at error, so just schedule the first retry.
+                    self._board_retry_state[board_id] = {
+                        "backoff": BOARD_RETRY_INITIAL_BACKOFF,
+                        "next_attempt": now + BOARD_RETRY_INITIAL_BACKOFF,
+                    }
+                    continue
+                if now < state["next_attempt"]:
+                    continue
+                self._attempt_board_init_recovery(board_id, state, now)
+
+    def _attempt_board_init_recovery(self, board_id: str, state: dict[str, float], now: float) -> bool:
+        """One retry for one failed board. Caller holds ``_runtimes_lock``.
+
+        On success the new runtime is swapped in exactly the way
+        ``_build_board_clients`` swaps: an atomic replace of ``self.runtimes``
+        (copy, insert, reassign) so the tick thread — which reads the dict
+        lock-free — sees either the old mapping or the new one, never a
+        half-mutated dict; a replaced runtime's send worker (a clientless
+        primary placeholder from ``_ensure_primary_runtime`` can hold one) is
+        stopped with the same bounded join, and the runtime-epoch guard in
+        ``_dispatch_send`` keeps any of its late bookkeeping off live state.
+        Other boards' runtimes are never touched, so their in-flight sends
+        proceed undisturbed.
+
+        Returns True when the board recovered.
+        """
+        board = self._board_dict_for(board_id)
+        if board is None:
+            # The board is no longer configured; its failure record is stale.
+            self.board_init_errors.pop(board_id, None)
+            self._board_retry_state.pop(board_id, None)
+            logger.debug("Board %s: no longer configured - dropping init-retry state", board_id)
+            return False
+
+        logger.debug("Board %s: retrying client init (current backoff %.0fs)", board_id, state["backoff"])
+        error: str | None = None
+        client = None
+        try:
+            client = board_client_from_board_dict(board)
+        except Exception as e:
+            error = str(e) or e.__class__.__name__
+        if client is None and error is None:
+            error = "Board is not fully configured (missing host, API key, or token)"
+
+        if error is not None:
+            self.board_init_errors[board_id] = error
+            previous = state["backoff"]
+            state["backoff"] = min(previous * 2, BOARD_RETRY_MAX_BACKOFF)
+            state["next_attempt"] = now + state["backoff"]
+            message = "Board %s: init retry failed (%s); next attempt in %.0fs"
+            if state["backoff"] > previous:
+                logger.error(message, board_id, error, state["backoff"])
+            else:
+                logger.debug(message, board_id, error, state["backoff"])
+            return False
+
+        self._attach_transition_runner(client)
+        rt = BoardRuntime(client=client, board_id=board_id)
+        rt.config_signature = self._config_signature(board)
+        runtimes = dict(self.runtimes)
+        old_rt = runtimes.get(board_id)
+        runtimes[board_id] = rt
+        self.runtimes = runtimes
+        if old_rt is not None and old_rt.send_worker is not None:
+            old_rt.send_worker.stop(timeout=1.0)
+        self.board_init_errors.pop(board_id, None)
+        self._board_retry_state.pop(board_id, None)
+        logger.info("Board %s: recovered - client initialized on retry; the board rejoins the fleet", board_id)
+        return True
 
     def request_board_refresh(
         self,

--- a/tests/test_board_init_retry.py
+++ b/tests/test_board_init_retry.py
@@ -1,0 +1,250 @@
+"""Fake-clock tests for the failed-board-init retry loop (issue #1827).
+
+A board whose client cannot be built at startup lands in
+``DisplayService.board_init_errors`` (#1813) — and, before #1827, stayed
+there until a human re-saved board settings. These tests pin the recovery
+behavior: the board-poll thread re-attempts ONLY the failed boards, on a
+per-board exponential backoff (60s doubling to a 900s cap), swaps a
+successful client in without disturbing other boards' in-flight sends, and
+clears the board's ``board_init_errors`` entry so GET /status shows it
+healthy again.
+
+The engine equivalence harness never starts the poll thread (its runtimes are
+hand-set), so there is no run()-level golden scenario for recovery; these
+tests drive ``_board_poll_loop`` itself on the test thread through a
+``FakeTimeModule`` whose ``sleep`` advances the clock — deterministic,
+single-threaded, no real waiting.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+from src.main import DisplayService
+from tests.engine_harness import (
+    GoldenRecordingClient,
+    SilenceOffConfigManager,
+    make_board,
+    make_page_service,
+    make_settings_service,
+)
+from tests.fake_clock import FakeClock, FakeTimeModule, install_fake_time_service
+
+T0 = datetime(2026, 7, 15, 9, 0, tzinfo=UTC)
+
+
+class _NoLegacyBoardClient:
+    """Stand-in for the legacy-Config BoardClient constructor: always fails.
+
+    Keeps the all-boards-failed startup path deterministic regardless of any
+    BOARD_* env vars present in the environment running the tests.
+    """
+
+    def __init__(self, *args, **kwargs):
+        raise RuntimeError("no legacy board credentials in tests")
+
+
+def _make_service(monkeypatch, clock, boards, factory, *, poll_interval=30, active_page_ids=None):
+    """A DisplayService wired to stubs, with ``board_client_from_board_dict``
+    replaced by ``factory`` and every clock seam on ``clock``."""
+    service = DisplayService()
+    settings = make_settings_service(
+        boards=boards,
+        polling_interval=15,
+        active_page_ids=active_page_ids or {},
+    )
+    settings.get_polling_settings.return_value = SimpleNamespace(
+        board_read_interval_local=poll_interval, board_read_interval_cloud=poll_interval
+    )
+    cm = SilenceOffConfigManager()
+    install_fake_time_service(monkeypatch, clock)
+    monkeypatch.setattr("src.config.get_config_manager", lambda: cm)
+    monkeypatch.setattr("src.config_manager.get_config_manager", lambda: cm)
+    monkeypatch.setattr("src.main.get_settings_service", lambda: settings)
+    monkeypatch.setattr("src.main.board_client_from_board_dict", factory)
+    monkeypatch.setattr("src.main.BoardClient", _NoLegacyBoardClient)
+    monkeypatch.setattr(DisplayService, "_attach_transition_runner", staticmethod(lambda client: None))
+    monkeypatch.setattr(service, "request_board_refresh", lambda *a, **k: None)
+    return service, settings
+
+
+def _run_poll_loop(monkeypatch, service, clock, *, until):
+    """Run ``_board_poll_loop`` on this thread until the clock passes ``until``.
+
+    The loop's ``time.sleep`` advances the fake clock; past the horizon it
+    flips ``service.running`` so the loop exits on its own check.
+    """
+    ticks = {"n": 0}
+
+    def on_sleep(seconds: float) -> None:
+        ticks["n"] += 1
+        if ticks["n"] > 10_000:
+            raise AssertionError("poll loop never reached the horizon")
+        clock.advance(seconds)
+        if clock.utc > until:
+            service.running = False
+
+    monkeypatch.setattr("src.main.time", FakeTimeModule(clock, on_sleep=on_sleep))
+    service.running = True
+    service._board_poll_loop()
+
+
+def test_transiently_failed_board_recovers_after_first_retry(monkeypatch):
+    """A board that fails at init is retried ~60s later and rejoins the fleet.
+
+    The stub factory raises (board unplugged) until t+45s, then succeeds. The
+    poll loop (30s cadence) must re-attempt at t+60, build the client, clear
+    ``board_init_errors`` and install a live runtime — after which a normal
+    engine pass drives the board.
+    """
+    clock = FakeClock(T0)
+    sink: list[dict] = []
+    boards = [make_board("board-1")]
+
+    def factory(board_dict):
+        if clock.utc < T0 + timedelta(seconds=45):
+            raise ConnectionError("board unplugged")
+        return GoldenRecordingClient(clock, board_dict["id"], sink)
+
+    service, _settings = _make_service(monkeypatch, clock, boards, factory, active_page_ids={"board-1": "page-static"})
+    service._build_board_clients(sync_cache=False)
+    assert service.board_init_errors == {"board-1": "board unplugged"}
+    assert service.get_board_client("board-1") is None
+
+    _run_poll_loop(monkeypatch, service, clock, until=T0 + timedelta(seconds=90))
+
+    assert "board-1" not in service.board_init_errors, "recovery must clear the GET /status error"
+    rt = service.runtimes.get("board-1")
+    assert rt is not None and rt.client is not None, "recovered board must have a live runtime"
+
+    # And the recovered board is drivable by a normal engine pass.
+    pages = make_page_service({"page-static": "HELLO AGAIN"})
+    monkeypatch.setattr("src.main.get_page_service", lambda: pages)
+    monkeypatch.setattr("src.main.get_schedule_service", lambda: SimpleNamespace())
+    monkeypatch.setattr(service, "_check_trigger_override", lambda: None)
+    assert service.check_and_send_active_page(wait=True) is True
+    assert [s["board"] for s in sink] == ["board-1"]
+    assert sink[0]["rows"][0].rstrip() == "HELLO AGAIN"
+
+
+def test_retry_backoff_doubles_to_cap_and_logs_quietly(monkeypatch, caplog):
+    """A permanently failed board backs off 60/120/240/480/900(cap)s.
+
+    Over one simulated hour that is exactly 7 attempts (t+60, 180, 420, 900,
+    1800, 2700, 3600) — and error-level log lines only where the backoff step
+    increased (4), NOT one per poll iteration (~120).
+    """
+    clock = FakeClock(T0)
+    attempts: list[float] = []
+
+    def factory(board_dict):
+        attempts.append((clock.utc - T0).total_seconds())
+        raise ConnectionError("still unplugged")
+
+    service, _settings = _make_service(monkeypatch, clock, [make_board("board-1")], factory)
+    service._build_board_clients(sync_cache=False)
+    assert attempts == [0.0]  # the initial (failed) build
+
+    with caplog.at_level(logging.DEBUG, logger="src.main"):
+        _run_poll_loop(monkeypatch, service, clock, until=T0 + timedelta(seconds=3600))
+
+    assert attempts[1:] == [60.0, 180.0, 420.0, 900.0, 1800.0, 2700.0, 3600.0]
+    assert service.board_init_errors == {"board-1": "still unplugged"}
+
+    retry_errors = [r for r in caplog.records if r.levelno == logging.ERROR and "retry" in r.getMessage().lower()]
+    assert len(retry_errors) == 4, (
+        "error-level retry noise must be bounded by backoff-step increases "
+        f"(60->120->240->480->900), got {len(retry_errors)}: "
+        f"{[r.getMessage() for r in retry_errors]}"
+    )
+
+
+def test_recovery_swap_does_not_disturb_other_boards_inflight_send(monkeypatch):
+    """A retry landing while another board is mid-send must not touch it.
+
+    Board-2's send worker is blocked inside a long send (Event) when board-1's
+    recovery swaps a new runtime in. Board-2's runtime object and worker must
+    be exactly the ones already in flight — same no-race property scenario 10
+    pins for rebuilds (#1755).
+    """
+    clock = FakeClock(T0)
+    sink: list[dict] = []
+    boards = [make_board("board-1"), make_board("board-2")]
+    allow_board_1 = {"ok": False}
+
+    def factory(board_dict):
+        if board_dict["id"] == "board-1" and not allow_board_1["ok"]:
+            raise ConnectionError("board unplugged")
+        return GoldenRecordingClient(clock, board_dict["id"], sink)
+
+    service, _settings = _make_service(monkeypatch, clock, boards, factory)
+    monkeypatch.setattr("src.main.time", FakeTimeModule(clock))
+    service._build_board_clients(sync_cache=False)
+    assert set(service.runtimes) == {"board-2"}
+    assert "board-1" in service.board_init_errors
+
+    # Seed the retry schedule (first pass), then make the retry due.
+    service._retry_failed_board_inits()
+    clock.advance(60)
+
+    rt2 = service.runtimes["board-2"]
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_send():
+        started.set()
+        if not release.wait(timeout=10):
+            return False, False
+        return True, True
+
+    try:
+        service._dispatch_send(
+            rt2,
+            "board-2",
+            key=("page", "page-x", "content"),
+            send=blocking_send,
+            on_complete=lambda success, was_sent, exc: was_sent,
+            wait=False,
+            sink=None,
+        )
+        assert started.wait(timeout=5), "board-2's worker never started the blocked send"
+        worker2 = rt2.send_worker
+
+        allow_board_1["ok"] = True
+        service._retry_failed_board_inits()
+
+        assert "board-1" in service.runtimes and service.runtimes["board-1"].client is not None
+        assert "board-1" not in service.board_init_errors
+        assert service.runtimes["board-2"] is rt2, "recovery must not replace an unrelated runtime"
+        assert rt2.send_worker is worker2 and not worker2.stopped, (
+            "recovery must not stop another board's in-flight worker"
+        )
+    finally:
+        release.set()
+    assert service.wait_until_idle(timeout=10.0, board_ids=["board-2"])
+
+
+def test_retry_drops_board_removed_from_settings(monkeypatch):
+    """A failed board deleted from settings stops being retried (state pruned)."""
+    clock = FakeClock(T0)
+
+    def factory(board_dict):
+        raise ConnectionError("board unplugged")
+
+    boards = [make_board("board-1"), make_board("board-2")]
+    service, settings = _make_service(monkeypatch, clock, boards, factory)
+    monkeypatch.setattr("src.main.time", FakeTimeModule(clock))
+    service._build_board_clients(sync_cache=False)
+    assert set(service.board_init_errors) == {"board-1", "board-2"}
+
+    # board-2 disappears from settings before its first retry comes due.
+    settings.get_board_settings.return_value = SimpleNamespace(boards=[boards[0]])
+    service._retry_failed_board_inits()  # seeds schedules
+    clock.advance(61)
+    service._retry_failed_board_inits()
+
+    assert "board-2" not in service.board_init_errors, "a deconfigured board must not report an init error"
+    assert "board-2" not in service._board_retry_state

--- a/tests/test_board_init_retry.py
+++ b/tests/test_board_init_retry.py
@@ -248,3 +248,51 @@ def test_retry_drops_board_removed_from_settings(monkeypatch):
 
     assert "board-2" not in service.board_init_errors, "a deconfigured board must not report an init error"
     assert "board-2" not in service._board_retry_state
+
+
+class TestEnsurePrimaryRuntimeLockRace:
+    """#1870 review: _ensure_primary_runtime inserted its clientless
+    placeholder into ``self.runtimes`` OUTSIDE ``_runtimes_lock``,
+    contradicting the lock's copy-and-replace invariant. Interleaved with a
+    recovery copy-swap, either the insert was lost (it landed in the pre-swap
+    dict) or — worse — the placeholder landed AFTER the swap and clobbered
+    the freshly recovered runtime, whose init error was already cleared:
+    the board was silently re-stranded with /status showing it healthy."""
+
+    def test_placeholder_insert_cannot_clobber_a_concurrent_recovery_swap(self, monkeypatch):
+        from src.main import BoardRuntime
+
+        service = DisplayService()
+        service._primary_board_id = None
+        monkeypatch.setattr(
+            "src.main.get_settings_service",
+            lambda: SimpleNamespace(get_primary_board_id=lambda: "b-1"),
+        )
+
+        recovered = BoardRuntime(client=object(), board_id="b-1")
+
+        class RacingRuntimes(dict):
+            """Fires a deterministic recovery copy-swap inside the unlocked
+            read window: the first miss for "b-1" atomically replaces
+            service.runtimes with a dict holding the recovered runtime —
+            exactly what _attempt_board_init_recovery does concurrently."""
+
+            fired = False
+
+            def get(self, key, default=None):
+                result = dict.get(self, key, default)
+                if not RacingRuntimes.fired and key == "b-1" and result is None:
+                    RacingRuntimes.fired = True
+                    swapped = dict(service.runtimes)
+                    swapped["b-1"] = recovered
+                    service.runtimes = swapped
+                return result
+
+        service.runtimes = RacingRuntimes()
+
+        rt = service._ensure_primary_runtime()
+
+        assert service.runtimes["b-1"] is recovered, (
+            "the clientless placeholder clobbered the freshly recovered runtime"
+        )
+        assert rt is recovered


### PR DESCRIPTION
Closes #1827. **Track B**, stacked on #1868.

## What

#1813 isolated per-board init failures but left recovery manual — a board that failed for a transient reason (unplugged, DHCP late, Local API booting) stayed down until a human re-saved its settings. Now the existing poll thread (no new thread) runs `_retry_failed_board_inits()`: only boards in `board_init_errors` are re-attempted (never a full rebuild), with 60s backoff doubling to a 900s cap. Log discipline per the issue: debug per attempt, error only when the backoff step increases, info on recovery — a permanently misconfigured board does not spam the log for the life of the process.

Race safety: recovery swaps runtimes via the same atomic copy-insert-replace the rebuild uses, stops a replaced worker with the bounded join, and a new `_runtimes_lock` guards the two writers' read-modify-write swaps (the rebuild path had no synchronization to reuse — two concurrent swaps could lose each other's updates); readers stay lock-free. A board-settings rebuild clears the retry schedule so a fresh save restarts at 60s.

## Zero-regression evidence

- **Fail-first: 4/4 new tests fail pre-fix** (no retry exists; zero attempts recorded; method absent). Backoff test pins the exact schedule (60/180/420/900/1800/2700/3600 over a simulated hour) *and* asserts error-log count == backoff steps, not poll cycles.
- All 10 engine goldens byte-identical (the harness never starts the poll thread; recovery is pinned at poll-loop/method level on the fake clock). No-race test: recovery lands while another board's worker is blocked mid-send.
- Full suite: strict subset of baseline (known environmental + pollution-class flakes only, verified present at baseline). ruff clean.

Known pre-existing limitation, documented not changed: if *every* board fails at startup, `initialize()` still returns False before the poll thread exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Par2E2Nh65PyDF1q9TARJP