### PR TITLE
feat(triggers): TimeService clock + persisted dismissals; trigger check as a named engine stage

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1303,6 +1303,11 @@ class DisplayService:
         feature set (locked epic decision); silence is resolved and delivered
         per board (issue #1788). All state reads/writes go through ``rt``.
 
+        The pass runs a fixed sequence of stages: silence evaluation, the
+        pause short-circuit, the output-target short-circuit, the TRIGGER
+        INPUT stage (#1850 — see the stage comment below), the temporary
+        override, then schedule/manual page resolution and the send.
+
         ``contexts`` is the pass-wide shared template-context cache (issue
         #1752): one dict per ``check_and_send_active_page`` pass, keyed by
         board size, so N boards of one size cost one plugin fan-out per tick.
@@ -1419,7 +1424,20 @@ class DisplayService:
                 # unchanged, skipping send" leaves the indicator stuck.
                 rt.last_active_page_content = None
 
-            # --- Triggers (PRIMARY only; suppressed during silence) ---
+            # --- Stage: trigger input (PRIMARY only; suppressed during silence) ---
+            # Triggers are a first-class engine input (#1850, per the #1767
+            # decision: the plugin contract — supports_triggers /
+            # check_triggers() / trigger_page_id — is unchanged because live
+            # plugins depend on it). The stage evaluates every enabled
+            # trigger-capable plugin through the REAL TriggerService and,
+            # when one is active, overrides this board's page for the tick.
+            #
+            # Data freshness: check_triggers() implementations read their
+            # plugin's own cached fetch data. The engine fetch already unions
+            # trigger-capable plugins into every tick's fetch set (#1751) and
+            # the pass-wide shared context (#1752) reuses that same fetch, so
+            # this stage performs no plugin fetch of its own and consumes
+            # nothing from ``contexts``.
             if is_primary and not silence_mode_active:
                 trigger_content = self._check_trigger_override()
                 if trigger_content is not None:
@@ -2122,7 +2140,15 @@ class DisplayService:
         )
 
     def _check_trigger_override(self) -> str | None:
-        """Check all trigger-capable plugins and return content if a trigger is active.
+        """The trigger-input stage: evaluate trigger plugins, return override content.
+
+        Evaluates ``check_triggers()`` for every enabled trigger-capable
+        plugin via the TriggerService and resolves the highest-priority
+        active trigger to board content (the plugin's configured
+        trigger_page_id rendered with the trigger's data, else its built-in
+        formatted display). ``check_triggers()`` reads the plugin's own
+        cached fetch data — kept fresh because #1751 unions trigger plugins
+        into every engine fetch — so this stage itself fetches nothing.
 
         Returns:
             Formatted text content from the highest-priority active trigger,

--- a/src/triggers/service.py
+++ b/src/triggers/service.py
@@ -136,7 +136,14 @@ class TriggerService:
         if dismissals_file is None:
             dismissals_file = _default_dismissals_file()
         self._dismissals_file = Path(dismissals_file)
-        self._dismissals_lock = threading.Lock()
+        # Guards BOTH the in-memory trigger state (_active_triggers /
+        # _suppressed_until / _dismissed_at) and the dismissal-store write
+        # (#1871 review): the engine tick prunes these dicts while API
+        # threads dismiss/activate, so an unguarded snapshot or iteration
+        # races a concurrent mutation (RuntimeError into the caller), and
+        # two unserialized saves could persist the staler snapshot.
+        # Reentrant: dismiss/clear paths hold it across mutation + save.
+        self._state_lock = threading.RLock()
         # When each persisted suppression was created (metadata only; the
         # behavioral horizon lives in ``_suppressed_until``).
         self._dismissed_at: dict[str, datetime] = {}
@@ -162,45 +169,46 @@ class TriggerService:
         A corrupt or unreadable store degrades to the pre-#1850 behavior
         (empty suppressions) rather than blocking service startup.
         """
-        try:
-            if not self._dismissals_file.exists():
+        with self._state_lock:  # mutations guarded (#1871 review)
+            try:
+                if not self._dismissals_file.exists():
+                    return
+                data = json.loads(self._dismissals_file.read_text(encoding="utf-8"))
+            except Exception as e:
+                logger.warning("Could not load trigger dismissals from %s: %s", self._dismissals_file, e)
                 return
-            data = json.loads(self._dismissals_file.read_text(encoding="utf-8"))
-        except Exception as e:
-            logger.warning("Could not load trigger dismissals from %s: %s", self._dismissals_file, e)
-            return
-        if not isinstance(data, dict) or data.get("schema_version") != DISMISSALS_SCHEMA_VERSION:
-            logger.warning(
-                "Trigger dismissal store %s has unsupported schema_version %r - ignoring it",
-                self._dismissals_file,
-                data.get("schema_version") if isinstance(data, dict) else None,
-            )
-            return
-        now = _now()
-        entries = data.get("dismissals")
-        pruned = 0
-        for trigger_id, entry in (entries or {}).items():
-            if not isinstance(entry, dict):
-                pruned += 1
-                continue
-            until = self._parse_instant(entry.get("suppressed_until"))
-            if until is None or until <= now:
-                pruned += 1
-                continue
-            self._suppressed_until[trigger_id] = until
-            dismissed_at = self._parse_instant(entry.get("dismissed_at"))
-            if dismissed_at is not None:
-                self._dismissed_at[trigger_id] = dismissed_at
-        if self._suppressed_until:
-            logger.info(
-                "Restored %d persisted trigger dismissal(s): %s",
-                len(self._suppressed_until),
-                ", ".join(sorted(self._suppressed_until)),
-            )
-        if pruned:
-            # Keep the on-disk store pruned too (best-effort; the next
-            # write-through rewrites it from memory anyway).
-            self._save_dismissals()
+            if not isinstance(data, dict) or data.get("schema_version") != DISMISSALS_SCHEMA_VERSION:
+                logger.warning(
+                    "Trigger dismissal store %s has unsupported schema_version %r - ignoring it",
+                    self._dismissals_file,
+                    data.get("schema_version") if isinstance(data, dict) else None,
+                )
+                return
+            now = _now()
+            entries = data.get("dismissals")
+            pruned = 0
+            for trigger_id, entry in (entries or {}).items():
+                if not isinstance(entry, dict):
+                    pruned += 1
+                    continue
+                until = self._parse_instant(entry.get("suppressed_until"))
+                if until is None or until <= now:
+                    pruned += 1
+                    continue
+                self._suppressed_until[trigger_id] = until
+                dismissed_at = self._parse_instant(entry.get("dismissed_at"))
+                if dismissed_at is not None:
+                    self._dismissed_at[trigger_id] = dismissed_at
+            if self._suppressed_until:
+                logger.info(
+                    "Restored %d persisted trigger dismissal(s): %s",
+                    len(self._suppressed_until),
+                    ", ".join(sorted(self._suppressed_until)),
+                )
+            if pruned:
+                # Keep the on-disk store pruned too (best-effort; the next
+                # write-through rewrites it from memory anyway).
+                self._save_dismissals()
 
     def _save_dismissals(self) -> None:
         """Write-through of the in-memory suppressions (pruned of lapsed entries).
@@ -209,19 +217,26 @@ class TriggerService:
         leaves no state behind today, and persisting one would change that
         contract. A failed write logs and degrades to in-memory behavior —
         dismissing a trigger must never raise into the caller.
+
+        Snapshot AND write run under ``_state_lock``, inside the try
+        (#1871 review): unlocked, an engine-tick prune could mutate
+        ``_suppressed_until`` mid-comprehension (RuntimeError into the API
+        caller — a 500 on the user's page change), and two concurrent saves
+        could persist the staler snapshot, dropping a just-written
+        dismissal.
         """
-        now = _now()
-        dismissals = {
-            trigger_id: {
-                "suppressed_until": until.isoformat(),
-                "dismissed_at": (self._dismissed_at.get(trigger_id) or now).isoformat(),
-            }
-            for trigger_id, until in sorted(self._suppressed_until.items())
-            if until > now
-        }
-        payload = {"schema_version": DISMISSALS_SCHEMA_VERSION, "dismissals": dismissals}
         try:
-            with self._dismissals_lock:
+            with self._state_lock:
+                now = _now()
+                dismissals = {
+                    trigger_id: {
+                        "suppressed_until": until.isoformat(),
+                        "dismissed_at": (self._dismissed_at.get(trigger_id) or now).isoformat(),
+                    }
+                    for trigger_id, until in sorted(self._suppressed_until.items())
+                    if until > now
+                }
+                payload = {"schema_version": DISMISSALS_SCHEMA_VERSION, "dismissals": dismissals}
                 if not dismissals and not self._dismissals_file.exists():
                     return  # nothing durable and nothing on disk to clear
                 write_json_atomic(self._dismissals_file, payload)
@@ -238,56 +253,59 @@ class TriggerService:
         it won't show on the board until the suppression entry expires (or
         a new trigger fires with a different ``trigger_id``).
         """
-        suppressed_until = self._suppressed_until.get(trigger.trigger_id)
-        if suppressed_until is not None:
-            if _now() < suppressed_until:
-                logger.debug(
-                    "Trigger %s is user-suppressed until %s — not activating",
-                    trigger.trigger_id,
-                    suppressed_until.isoformat(),
-                )
-                return
-            # Suppression has lapsed; drop the entry and fall through.
-            del self._suppressed_until[trigger.trigger_id]
-            self._dismissed_at.pop(trigger.trigger_id, None)
+        with self._state_lock:  # serialized with prune/dismiss (#1871 review)
+            suppressed_until = self._suppressed_until.get(trigger.trigger_id)
+            if suppressed_until is not None:
+                if _now() < suppressed_until:
+                    logger.debug(
+                        "Trigger %s is user-suppressed until %s — not activating",
+                        trigger.trigger_id,
+                        suppressed_until.isoformat(),
+                    )
+                    return
+                # Suppression has lapsed; drop the entry and fall through.
+                del self._suppressed_until[trigger.trigger_id]
+                self._dismissed_at.pop(trigger.trigger_id, None)
 
-        active = ActiveTrigger(
-            trigger_id=trigger.trigger_id,
-            plugin_id=plugin_id,
-            message=trigger.message,
-            formatted_lines=trigger.formatted_lines,
-            data=trigger.data,
-            priority=trigger.priority,
-            duration_seconds=trigger.duration_seconds,
-            activated_at=_now(),
-        )
-        self._active_triggers[trigger.trigger_id] = active
-        logger.info(
-            "Trigger activated: %s (plugin=%s, priority=%d, duration=%ds)",
-            trigger.trigger_id,
-            plugin_id,
-            trigger.priority,
-            trigger.duration_seconds,
-        )
+            active = ActiveTrigger(
+                trigger_id=trigger.trigger_id,
+                plugin_id=plugin_id,
+                message=trigger.message,
+                formatted_lines=trigger.formatted_lines,
+                data=trigger.data,
+                priority=trigger.priority,
+                duration_seconds=trigger.duration_seconds,
+                activated_at=_now(),
+            )
+            self._active_triggers[trigger.trigger_id] = active
+            logger.info(
+                "Trigger activated: %s (plugin=%s, priority=%d, duration=%ds)",
+                trigger.trigger_id,
+                plugin_id,
+                trigger.priority,
+                trigger.duration_seconds,
+            )
 
     def get_active_trigger(self) -> ActiveTrigger | None:
         """Return the highest-priority non-expired trigger, or None.
 
         Automatically clears expired triggers before selecting.
         """
-        self.clear_expired()
-        if not self._active_triggers:
-            return None
-        return max(self._active_triggers.values(), key=lambda t: t.priority)
+        with self._state_lock:  # iteration races the prune unguarded (#1871)
+            self.clear_expired()
+            if not self._active_triggers:
+                return None
+            return max(self._active_triggers.values(), key=lambda t: t.priority)
 
     def list_active_triggers(self) -> list[ActiveTrigger]:
         """Return all active (non-expired) triggers sorted by priority desc."""
-        self.clear_expired()
-        return sorted(
-            self._active_triggers.values(),
-            key=lambda t: t.priority,
-            reverse=True,
-        )
+        with self._state_lock:
+            self.clear_expired()
+            return sorted(
+                self._active_triggers.values(),
+                key=lambda t: t.priority,
+                reverse=True,
+            )
 
     def dismiss_trigger(self, trigger_id: str, suppress: bool = False) -> bool:
         """Dismiss (remove) a trigger by its id.
@@ -301,31 +319,32 @@ class TriggerService:
 
         Returns True if the trigger existed and was removed.
         """
-        active = self._active_triggers.get(trigger_id)
-        if active is None:
-            return False
+        with self._state_lock:  # held across mutation + save (#1871 review)
+            active = self._active_triggers.get(trigger_id)
+            if active is None:
+                return False
 
-        if suppress:
-            # Suppress for whatever was left of the trigger's natural duration,
-            # not the full duration — once that window passes, the underlying
-            # condition (e.g. "event happening soon") should be gone, and any
-            # new trigger from the plugin is a fresh signal worth honoring.
-            # Written through to the dismissal store so the suppression
-            # survives a restart (#1850); an unsuppressed dismissal stays
-            # transient, exactly as before.
-            self._suppressed_until[trigger_id] = active.activated_at + timedelta(seconds=active.duration_seconds)
-            self._dismissed_at[trigger_id] = _now()
-            self._save_dismissals()
-            logger.info(
-                "Trigger dismissed + suppressed: %s (until %s)",
-                trigger_id,
-                self._suppressed_until[trigger_id].isoformat(),
-            )
-        else:
-            logger.info("Trigger dismissed: %s", trigger_id)
+            if suppress:
+                # Suppress for whatever was left of the trigger's natural duration,
+                # not the full duration — once that window passes, the underlying
+                # condition (e.g. "event happening soon") should be gone, and any
+                # new trigger from the plugin is a fresh signal worth honoring.
+                # Written through to the dismissal store so the suppression
+                # survives a restart (#1850); an unsuppressed dismissal stays
+                # transient, exactly as before.
+                self._suppressed_until[trigger_id] = active.activated_at + timedelta(seconds=active.duration_seconds)
+                self._dismissed_at[trigger_id] = _now()
+                self._save_dismissals()
+                logger.info(
+                    "Trigger dismissed + suppressed: %s (until %s)",
+                    trigger_id,
+                    self._suppressed_until[trigger_id].isoformat(),
+                )
+            else:
+                logger.info("Trigger dismissed: %s", trigger_id)
 
-        del self._active_triggers[trigger_id]
-        return True
+            del self._active_triggers[trigger_id]
+            return True
 
     def dismiss_active_for_user_override(self) -> int:
         """Dismiss every currently-active trigger and suppress re-firing.
@@ -334,41 +353,44 @@ class TriggerService:
         (e.g. via "Change Page" on the Home screen). Returns the number of
         triggers dismissed.
         """
-        # Snapshot keys first because dismiss_trigger mutates the dict.
-        ids = list(self._active_triggers.keys())
-        for tid in ids:
-            self.dismiss_trigger(tid, suppress=True)
-        if ids:
-            logger.info(
-                "Dismissed %d trigger(s) for user override; suppressed: %s",
-                len(ids),
-                ", ".join(ids),
-            )
-        return len(ids)
+        with self._state_lock:
+            # Snapshot keys first because dismiss_trigger mutates the dict.
+            ids = list(self._active_triggers.keys())
+            for tid in ids:
+                self.dismiss_trigger(tid, suppress=True)
+            if ids:
+                logger.info(
+                    "Dismissed %d trigger(s) for user override; suppressed: %s",
+                    len(ids),
+                    ", ".join(ids),
+                )
+            return len(ids)
 
     def clear_expired(self) -> None:
         """Remove all triggers that have exceeded their duration."""
-        expired = [tid for tid, t in self._active_triggers.items() if t.is_expired()]
-        for tid in expired:
-            del self._active_triggers[tid]
-            logger.debug("Trigger expired and removed: %s", tid)
+        with self._state_lock:  # the engine tick's prune (#1871 review)
+            expired = [tid for tid, t in self._active_triggers.items() if t.is_expired()]
+            for tid in expired:
+                del self._active_triggers[tid]
+                logger.debug("Trigger expired and removed: %s", tid)
 
-        # Garbage-collect lapsed suppression entries so the dict doesn't
-        # grow without bound. Memory-only: the store prunes lapsed entries
-        # itself on every load and write.
-        now = _now()
-        lapsed = [tid for tid, until in self._suppressed_until.items() if now >= until]
-        for tid in lapsed:
-            del self._suppressed_until[tid]
-            self._dismissed_at.pop(tid, None)
+            # Garbage-collect lapsed suppression entries so the dict doesn't
+            # grow without bound. Memory-only: the store prunes lapsed entries
+            # itself on every load and write.
+            now = _now()
+            lapsed = [tid for tid, until in self._suppressed_until.items() if now >= until]
+            for tid in lapsed:
+                del self._suppressed_until[tid]
+                self._dismissed_at.pop(tid, None)
 
     def clear_all(self) -> None:
         """Remove all active triggers and suppressions (persisted ones too)."""
-        self._active_triggers.clear()
-        self._suppressed_until.clear()
-        self._dismissed_at.clear()
-        self._save_dismissals()
-        logger.info("All triggers cleared")
+        with self._state_lock:
+            self._active_triggers.clear()
+            self._suppressed_until.clear()
+            self._dismissed_at.clear()
+            self._save_dismissals()
+            logger.info("All triggers cleared")
 
     def check_plugin_triggers(self, plugin: PluginBase) -> None:
         """Evaluate a plugin's triggers and activate any that fired.

--- a/src/triggers/service.py
+++ b/src/triggers/service.py
@@ -7,14 +7,46 @@ set of *active* triggers, and exposes the highest-priority one so the
 display loop can override the normal schedule/manual page.
 """
 
+import json
 import logging
+import threading
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
 from typing import Any
 
+from src.atomic_io import write_json_atomic
 from src.plugins.base import PluginBase, TriggerResult
+from src.time_service import get_time_service
 
 logger = logging.getLogger(__name__)
+
+# Version of the on-disk dismissal store (see ``TriggerService`` below).
+DISMISSALS_SCHEMA_VERSION = 1
+
+
+def _default_dismissals_file() -> Path:
+    """Default location of the dismissal store (repo-root ``data/``).
+
+    A module-level seam so tests that exercise the trigger-service
+    *singleton* can point it at a temp directory. See the adapter note in
+    ``TriggerService.__init__`` for the A-track storage-kernel merge.
+    """
+    project_root = Path(__file__).parent.parent.parent
+    return project_root / "data" / "trigger_dismissals.json"
+
+
+def _now() -> datetime:
+    """The trigger clock: aware UTC from the app's TimeService (#1850).
+
+    All trigger timing — activation stamps, expiry math, suppression
+    horizons — goes through the TimeService rather than module-level
+    ``datetime.now()``, so triggers follow the app's clock discipline and
+    a fake TimeService is the only seam tests need. Aware UTC throughout:
+    every stored/compared instant carries tzinfo, so naive-vs-aware mixing
+    cannot occur internally and persisted ISO stamps are unambiguous.
+    """
+    return get_time_service().get_current_utc()
 
 
 @dataclass
@@ -39,16 +71,16 @@ class ActiveTrigger:
     data: dict[str, Any] | None
     priority: int
     duration_seconds: int
-    activated_at: datetime = field(default_factory=datetime.now)
+    activated_at: datetime = field(default_factory=_now)
 
     def is_expired(self) -> bool:
         """Return True when the trigger has exceeded its duration."""
-        age = (datetime.now() - self.activated_at).total_seconds()
+        age = (_now() - self.activated_at).total_seconds()
         return age >= self.duration_seconds
 
     def remaining_seconds(self) -> float:
         """Return the number of seconds left before expiry."""
-        age = (datetime.now() - self.activated_at).total_seconds()
+        age = (_now() - self.activated_at).total_seconds()
         return max(0.0, self.duration_seconds - age)
 
     def to_dict(self) -> dict[str, Any]:
@@ -72,13 +104,14 @@ class TriggerService:
     * ``activate_trigger`` — record a fired trigger.
     * ``get_active_trigger`` — return the highest-priority non-expired
       trigger (or ``None``).
-    * ``dismiss_trigger`` — manually dismiss a trigger by id.
+    * ``dismiss_trigger`` — manually dismiss a trigger by id; with
+      ``suppress=True`` the suppression is persisted across restarts.
     * ``clear_expired`` — remove triggers past their duration.
     * ``check_plugin_triggers`` — evaluate a single plugin and activate
       any fired triggers.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, dismissals_file: Path | None = None) -> None:
         self._active_triggers: dict[str, ActiveTrigger] = {}
         # Triggers the user has explicitly dismissed (typically via a manual
         # "Change Page" action). Each entry maps a trigger_id to the time at
@@ -87,7 +120,113 @@ class TriggerService:
         # display loop tick would silently overwrite the user's choice
         # (see issue #856 — manual page change blocked by active trigger).
         self._suppressed_until: dict[str, datetime] = {}
+
+        # Suppressed dismissals persist across restarts (#1850): before this,
+        # a reboot brought every dismissed trigger straight back — the one
+        # real restart loss in the trigger platform. The store is a minimal
+        # schema-versioned JSON file written atomically (src.atomic_io).
+        #
+        # NOTE for the A-track storage-kernel merge: the file location is
+        # resolved the way this branch's stores do (repo-root ``data/``,
+        # mirroring pages/settings storage). When the kernel lands
+        # (src/storage/json_store.py + src/paths.py), swap this block for
+        # ``get_data_dir() / "trigger_dismissals.json"`` behind a JsonStore —
+        # the payload is already schema-versioned, so that swap is a trivial
+        # adapter change, not a migration.
+        if dismissals_file is None:
+            dismissals_file = _default_dismissals_file()
+        self._dismissals_file = Path(dismissals_file)
+        self._dismissals_lock = threading.Lock()
+        # When each persisted suppression was created (metadata only; the
+        # behavioral horizon lives in ``_suppressed_until``).
+        self._dismissed_at: dict[str, datetime] = {}
+        self._load_dismissals()
         logger.info("TriggerService initialized")
+
+    # -- dismissal persistence ---------------------------------------------
+
+    @staticmethod
+    def _parse_instant(raw: object) -> datetime | None:
+        """Parse a persisted ISO instant; naive values are taken as UTC."""
+        if not isinstance(raw, str):
+            return None
+        try:
+            parsed = datetime.fromisoformat(raw)
+        except ValueError:
+            return None
+        return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
+
+    def _load_dismissals(self) -> None:
+        """Restore persisted suppressions, pruning any that already lapsed.
+
+        A corrupt or unreadable store degrades to the pre-#1850 behavior
+        (empty suppressions) rather than blocking service startup.
+        """
+        try:
+            if not self._dismissals_file.exists():
+                return
+            data = json.loads(self._dismissals_file.read_text(encoding="utf-8"))
+        except Exception as e:
+            logger.warning("Could not load trigger dismissals from %s: %s", self._dismissals_file, e)
+            return
+        if not isinstance(data, dict) or data.get("schema_version") != DISMISSALS_SCHEMA_VERSION:
+            logger.warning(
+                "Trigger dismissal store %s has unsupported schema_version %r - ignoring it",
+                self._dismissals_file,
+                data.get("schema_version") if isinstance(data, dict) else None,
+            )
+            return
+        now = _now()
+        entries = data.get("dismissals")
+        pruned = 0
+        for trigger_id, entry in (entries or {}).items():
+            if not isinstance(entry, dict):
+                pruned += 1
+                continue
+            until = self._parse_instant(entry.get("suppressed_until"))
+            if until is None or until <= now:
+                pruned += 1
+                continue
+            self._suppressed_until[trigger_id] = until
+            dismissed_at = self._parse_instant(entry.get("dismissed_at"))
+            if dismissed_at is not None:
+                self._dismissed_at[trigger_id] = dismissed_at
+        if self._suppressed_until:
+            logger.info(
+                "Restored %d persisted trigger dismissal(s): %s",
+                len(self._suppressed_until),
+                ", ".join(sorted(self._suppressed_until)),
+            )
+        if pruned:
+            # Keep the on-disk store pruned too (best-effort; the next
+            # write-through rewrites it from memory anyway).
+            self._save_dismissals()
+
+    def _save_dismissals(self) -> None:
+        """Write-through of the in-memory suppressions (pruned of lapsed entries).
+
+        Only suppressed dismissals are durable: an unsuppressed dismissal
+        leaves no state behind today, and persisting one would change that
+        contract. A failed write logs and degrades to in-memory behavior —
+        dismissing a trigger must never raise into the caller.
+        """
+        now = _now()
+        dismissals = {
+            trigger_id: {
+                "suppressed_until": until.isoformat(),
+                "dismissed_at": (self._dismissed_at.get(trigger_id) or now).isoformat(),
+            }
+            for trigger_id, until in sorted(self._suppressed_until.items())
+            if until > now
+        }
+        payload = {"schema_version": DISMISSALS_SCHEMA_VERSION, "dismissals": dismissals}
+        try:
+            with self._dismissals_lock:
+                if not dismissals and not self._dismissals_file.exists():
+                    return  # nothing durable and nothing on disk to clear
+                write_json_atomic(self._dismissals_file, payload)
+        except Exception as e:
+            logger.error("Could not persist trigger dismissals to %s: %s", self._dismissals_file, e)
 
     # -- public API --------------------------------------------------------
 
@@ -101,7 +240,7 @@ class TriggerService:
         """
         suppressed_until = self._suppressed_until.get(trigger.trigger_id)
         if suppressed_until is not None:
-            if datetime.now() < suppressed_until:
+            if _now() < suppressed_until:
                 logger.debug(
                     "Trigger %s is user-suppressed until %s — not activating",
                     trigger.trigger_id,
@@ -110,6 +249,7 @@ class TriggerService:
                 return
             # Suppression has lapsed; drop the entry and fall through.
             del self._suppressed_until[trigger.trigger_id]
+            self._dismissed_at.pop(trigger.trigger_id, None)
 
         active = ActiveTrigger(
             trigger_id=trigger.trigger_id,
@@ -119,7 +259,7 @@ class TriggerService:
             data=trigger.data,
             priority=trigger.priority,
             duration_seconds=trigger.duration_seconds,
-            activated_at=datetime.now(),
+            activated_at=_now(),
         )
         self._active_triggers[trigger.trigger_id] = active
         logger.info(
@@ -170,7 +310,12 @@ class TriggerService:
             # not the full duration — once that window passes, the underlying
             # condition (e.g. "event happening soon") should be gone, and any
             # new trigger from the plugin is a fresh signal worth honoring.
+            # Written through to the dismissal store so the suppression
+            # survives a restart (#1850); an unsuppressed dismissal stays
+            # transient, exactly as before.
             self._suppressed_until[trigger_id] = active.activated_at + timedelta(seconds=active.duration_seconds)
+            self._dismissed_at[trigger_id] = _now()
+            self._save_dismissals()
             logger.info(
                 "Trigger dismissed + suppressed: %s (until %s)",
                 trigger_id,
@@ -209,16 +354,20 @@ class TriggerService:
             logger.debug("Trigger expired and removed: %s", tid)
 
         # Garbage-collect lapsed suppression entries so the dict doesn't
-        # grow without bound.
-        now = datetime.now()
+        # grow without bound. Memory-only: the store prunes lapsed entries
+        # itself on every load and write.
+        now = _now()
         lapsed = [tid for tid, until in self._suppressed_until.items() if now >= until]
         for tid in lapsed:
             del self._suppressed_until[tid]
+            self._dismissed_at.pop(tid, None)
 
     def clear_all(self) -> None:
-        """Remove all active triggers."""
+        """Remove all active triggers and suppressions (persisted ones too)."""
         self._active_triggers.clear()
         self._suppressed_until.clear()
+        self._dismissed_at.clear()
+        self._save_dismissals()
         logger.info("All triggers cleared")
 
     def check_plugin_triggers(self, plugin: PluginBase) -> None:

--- a/tests/engine_harness.py
+++ b/tests/engine_harness.py
@@ -23,9 +23,9 @@ on wall-clock time and the goldens stop being deterministic:
 3. ``src.collections.service.time`` — collection slice math.
 4. ``schedule.datetime`` — the schedule library's job-due decisions.
 
-Scenarios that exercise the REAL ``TriggerService`` patch a fifth seam,
-``src.triggers.service.datetime``, because trigger activation/expiry math
-calls ``datetime.now()`` at module scope.
+(Scenarios exercising the REAL ``TriggerService`` used to patch a fifth
+seam, ``src.triggers.service.datetime``; since #1850 the service reads the
+TimeService, so seam 1 covers trigger activation/expiry math too.)
 
 What the goldens pin is ONLY the send sequence — the (simulated time, board,
 frame) triples handed to each board client. The run loop may evaluate
@@ -315,27 +315,6 @@ class StubPluginRegistry:
         return self.trigger_plugins.get(plugin_id)
 
 
-def fake_trigger_datetime(clock: FakeClock):
-    """Stand-in for ``datetime`` as ``src.triggers.service`` sees it.
-
-    ``TriggerService`` stamps/compares activation with naive
-    ``datetime.now()`` at module scope; this pins those calls to the fake
-    clock so trigger expiry is simulated-time math, not wall-clock math.
-    (``ActiveTrigger``'s ``default_factory`` captured the real ``datetime.now``
-    at import time, but ``activate_trigger`` always passes ``activated_at``
-    explicitly, so the module-attribute patch covers every live call site.)
-    """
-
-    class _Datetime:
-        @staticmethod
-        def now(tz=None):
-            if tz is None:
-                return clock.utc.replace(tzinfo=None)
-            return clock.utc.astimezone(tz)
-
-    return _Datetime
-
-
 # --------------------------------------------------------------------------
 # Scenario runner
 # --------------------------------------------------------------------------
@@ -437,9 +416,10 @@ def run_engine_scenario(
     ``trigger_registry_factory`` chooses the trigger seam: ``None`` stubs
     ``_check_trigger_override`` out entirely (the model suites' default);
     a factory (called with the scenario's clock) instead builds a
-    ``StubPluginRegistry`` and patches ``get_plugin_registry`` plus the
-    trigger clock so the REAL ``TriggerService`` runs. Callers using triggers
-    must reset the trigger-service singleton around the test.
+    ``StubPluginRegistry`` and patches ``get_plugin_registry`` so the REAL
+    ``TriggerService`` runs (its clock is the TimeService — seam 1 — since
+    #1850). Callers using triggers must reset the trigger-service singleton
+    around the test.
 
     ``fail_when`` maps board id -> predicate for injected render failures.
 
@@ -488,7 +468,6 @@ def run_engine_scenario(
     else:
         trigger_registry = trigger_registry_factory(clock)
         monkeypatch.setattr("src.plugins.registry.get_plugin_registry", lambda: trigger_registry)
-        monkeypatch.setattr("src.triggers.service.datetime", fake_trigger_datetime(clock))
 
     service.run()
     # One final settle: the loop exits from inside its last sleep, so any

--- a/tests/test_engine_equivalence.py
+++ b/tests/test_engine_equivalence.py
@@ -87,8 +87,17 @@ def _clear_schedule():
 
 
 @pytest.fixture(autouse=True)
-def _reset_triggers():
-    """The trigger-service singleton must never leak state across scenarios."""
+def _reset_triggers(tmp_path, monkeypatch):
+    """The trigger-service singleton must never leak state across scenarios —
+    and must never touch the real data/trigger_dismissals.json on a dev
+    machine (#1871 review): scenarios exercising the REAL TriggerService
+    would otherwise read (and prune) the developer's live dismissal store.
+    The ``_default_dismissals_file`` seam points the singleton at a
+    per-test tmp file instead."""
+    monkeypatch.setattr(
+        "src.triggers.service._default_dismissals_file",
+        lambda: tmp_path / "trigger_dismissals.json",
+    )
     reset_trigger_service()
     yield
     reset_trigger_service()
@@ -455,3 +464,16 @@ def test_temporary_override_inline(monkeypatch):
         pages=make_page_service({"page-home": "HELLO HOME"}),
     )
     check_golden("temporary_override_inline", result.sends)
+
+
+def test_trigger_scenarios_use_a_tmp_dismissals_store(tmp_path):
+    """#1871 review: the real-TriggerService scenarios ran the singleton on
+    its DEFAULT dismissals path — on a dev machine they read (and pruned)
+    the real data/trigger_dismissals.json. The suite must point the seam at
+    a per-test tmp file."""
+    from src.triggers.service import get_trigger_service
+
+    service = get_trigger_service()
+    assert str(service._dismissals_file).startswith(str(tmp_path)), (
+        f"trigger scenarios must not touch the real dismissals store: {service._dismissals_file}"
+    )

--- a/tests/test_plugin_triggers.py
+++ b/tests/test_plugin_triggers.py
@@ -4,7 +4,7 @@ Tests the ability for plugins to trigger messages based on events,
 rather than pre-scheduled time slots.
 """
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
@@ -225,10 +225,10 @@ class TestTriggerService:
     """Tests for the TriggerService that manages trigger lifecycle."""
 
     @pytest.fixture
-    def trigger_service(self):
+    def trigger_service(self, tmp_path):
         from src.triggers.service import TriggerService
 
-        return TriggerService()
+        return TriggerService(dismissals_file=tmp_path / "trigger_dismissals.json")
 
     def test_no_active_triggers_initially(self, trigger_service):
         assert trigger_service.get_active_trigger() is None
@@ -363,7 +363,7 @@ class TestTriggerService:
         trigger_service.dismiss_trigger("lapsing", suppress=True)
 
         # Rewind suppression entry into the past.
-        trigger_service._suppressed_until["lapsing"] = datetime.now() - timedelta(seconds=1)
+        trigger_service._suppressed_until["lapsing"] = datetime.now(UTC) - timedelta(seconds=1)
 
         trigger_service.activate_trigger("plugin", trigger)
         assert trigger_service.get_active_trigger() is not None
@@ -428,7 +428,7 @@ class TestTriggerService:
         trigger_service.activate_trigger("plugin_a", trigger)
 
         # Manually set activation time to the past
-        trigger_service._active_triggers["expires_soon"].activated_at = datetime.now() - timedelta(seconds=10)
+        trigger_service._active_triggers["expires_soon"].activated_at = datetime.now(UTC) - timedelta(seconds=10)
 
         trigger_service.clear_expired()
         assert trigger_service.get_active_trigger() is None
@@ -532,7 +532,7 @@ class TestTriggerService:
             duration_seconds=1,
         )
         trigger_service.activate_trigger("p1", trigger)
-        trigger_service._active_triggers["temp"].activated_at = datetime.now() - timedelta(seconds=10)
+        trigger_service._active_triggers["temp"].activated_at = datetime.now(UTC) - timedelta(seconds=10)
         # get_active_trigger should auto-clear expired
         assert trigger_service.get_active_trigger() is None
 
@@ -552,7 +552,7 @@ class TestActiveTrigger:
             data=None,
             priority=1,
             duration_seconds=60,
-            activated_at=datetime.now() - timedelta(seconds=120),
+            activated_at=datetime.now(UTC) - timedelta(seconds=120),
         )
         assert trigger.is_expired() is True
 
@@ -567,7 +567,7 @@ class TestActiveTrigger:
             data=None,
             priority=1,
             duration_seconds=3600,
-            activated_at=datetime.now(),
+            activated_at=datetime.now(UTC),
         )
         assert trigger.is_expired() is False
 
@@ -582,7 +582,7 @@ class TestActiveTrigger:
             data=None,
             priority=1,
             duration_seconds=60,
-            activated_at=datetime.now() - timedelta(seconds=30),
+            activated_at=datetime.now(UTC) - timedelta(seconds=30),
         )
         remaining = trigger.remaining_seconds()
         assert 25 <= remaining <= 35  # ~30 seconds remaining
@@ -590,7 +590,7 @@ class TestActiveTrigger:
     def test_to_dict(self):
         from src.triggers.service import ActiveTrigger
 
-        now = datetime.now()
+        now = datetime.now(UTC)
         trigger = ActiveTrigger(
             trigger_id="t1",
             plugin_id="p1",

--- a/tests/test_trigger_dismissal_persistence.py
+++ b/tests/test_trigger_dismissal_persistence.py
@@ -1,0 +1,177 @@
+"""Persisted trigger dismissals + TimeService clock (issue #1850, Track B7).
+
+Two platform gaps closed per the #1767 decision (triggers stay a live
+plugin-facing feature; the plugin contract — ``supports_triggers`` /
+``check_triggers()`` / ``trigger_page_id`` — is unchanged):
+
+1. Dismissals were in-memory only, so a dismissed trigger came back after a
+   restart. Suppressed dismissals now persist to a schema-versioned JSON
+   store and are honored by a fresh ``TriggerService`` instance.
+2. ``TriggerService`` told time with module-level naive ``datetime.now()``
+   instead of the app's TimeService, so trigger timing ignored the app's
+   clock discipline.
+
+Every test here drives the service through the fake TimeService ONLY — the
+engine harness's old fifth clock seam (``src.triggers.service.datetime``)
+is gone, and no test patches it — proving trigger timing is deterministic
+through the app's one clock.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+from src.plugins.base import TriggerResult
+from src.triggers.service import TriggerService
+from tests.fake_clock import FakeClock, install_fake_time_service
+
+T0 = datetime(2026, 7, 15, 9, 0, tzinfo=UTC)
+
+
+def _result(trigger_id: str = "door-open", duration: int = 3600, priority: int = 5) -> TriggerResult:
+    return TriggerResult(
+        triggered=True,
+        trigger_id=trigger_id,
+        message="DOOR OPEN",
+        priority=priority,
+        duration_seconds=duration,
+    )
+
+
+def test_suppressed_dismissal_survives_restart(monkeypatch, tmp_path):
+    """Dismiss with suppress=True, restart, plugin re-emits: still suppressed.
+
+    "Restart" is a fresh TriggerService instance reading the same store file
+    — exactly what process restart does through get_trigger_service().
+    """
+    clock = FakeClock(T0)
+    install_fake_time_service(monkeypatch, clock)
+    store = tmp_path / "trigger_dismissals.json"
+
+    svc = TriggerService(dismissals_file=store)
+    svc.activate_trigger("stub_plugin", _result())
+    assert svc.dismiss_trigger("door-open", suppress=True) is True
+    assert svc.get_active_trigger() is None
+
+    svc2 = TriggerService(dismissals_file=store)
+    svc2.activate_trigger("stub_plugin", _result())  # plugin re-emits after reboot
+    assert svc2.get_active_trigger() is None, "a suppressed dismissal must survive a restart"
+
+
+def test_suppression_expires_after_suppressed_until(monkeypatch, tmp_path):
+    """Past the persisted suppressed_until horizon the trigger fires again.
+
+    Suppression covers what was left of the trigger's natural duration
+    (activated_at + duration_seconds) — the pre-existing semantics, now
+    surviving a restart.
+    """
+    clock = FakeClock(T0)
+    install_fake_time_service(monkeypatch, clock)
+    store = tmp_path / "trigger_dismissals.json"
+
+    svc = TriggerService(dismissals_file=store)
+    svc.activate_trigger("stub_plugin", _result(duration=60))
+    svc.dismiss_trigger("door-open", suppress=True)
+
+    clock.advance(61)  # past the suppression horizon
+    svc2 = TriggerService(dismissals_file=store)
+    svc2.activate_trigger("stub_plugin", _result(duration=60))
+    active = svc2.get_active_trigger()
+    assert active is not None and active.trigger_id == "door-open"
+
+
+def test_store_is_schema_versioned_with_suppression_horizon(monkeypatch, tmp_path):
+    """The store carries schema_version 1 and per-trigger horizon + stamp."""
+    clock = FakeClock(T0)
+    install_fake_time_service(monkeypatch, clock)
+    store = tmp_path / "trigger_dismissals.json"
+
+    svc = TriggerService(dismissals_file=store)
+    svc.activate_trigger("stub_plugin", _result(duration=120))
+    svc.dismiss_trigger("door-open", suppress=True)
+
+    data = json.loads(store.read_text())
+    assert data["schema_version"] == 1
+    entry = data["dismissals"]["door-open"]
+    assert entry["suppressed_until"] == (T0 + timedelta(seconds=120)).isoformat()
+    assert entry["dismissed_at"] == T0.isoformat()
+
+
+def test_expired_entries_are_pruned_on_load(monkeypatch, tmp_path):
+    """Loading drops entries whose suppression already lapsed (and junk)."""
+    clock = FakeClock(T0)
+    install_fake_time_service(monkeypatch, clock)
+    store = tmp_path / "trigger_dismissals.json"
+    store.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "dismissals": {
+                    "live": {
+                        "suppressed_until": (T0 + timedelta(seconds=300)).isoformat(),
+                        "dismissed_at": (T0 - timedelta(seconds=60)).isoformat(),
+                    },
+                    "lapsed": {
+                        "suppressed_until": (T0 - timedelta(seconds=1)).isoformat(),
+                        "dismissed_at": (T0 - timedelta(seconds=600)).isoformat(),
+                    },
+                    "junk": {"suppressed_until": None, "dismissed_at": None},
+                },
+            }
+        )
+    )
+
+    svc = TriggerService(dismissals_file=store)
+    assert set(svc._suppressed_until) == {"live"}
+    svc.activate_trigger("stub_plugin", _result(trigger_id="lapsed"))
+    assert svc.get_active_trigger() is not None, "a lapsed suppression must not block re-activation"
+
+
+def test_unsuppressed_dismissal_leaves_no_durable_state(monkeypatch, tmp_path):
+    """suppress=False keeps today's semantics: nothing survives the dismissal."""
+    clock = FakeClock(T0)
+    install_fake_time_service(monkeypatch, clock)
+    store = tmp_path / "trigger_dismissals.json"
+
+    svc = TriggerService(dismissals_file=store)
+    svc.activate_trigger("stub_plugin", _result())
+    svc.dismiss_trigger("door-open", suppress=False)
+
+    svc2 = TriggerService(dismissals_file=store)
+    svc2.activate_trigger("stub_plugin", _result())
+    assert svc2.get_active_trigger() is not None
+
+
+def test_trigger_expiry_honors_time_service_without_datetime_seam(monkeypatch, tmp_path):
+    """Expiry follows the fake TimeService — no datetime-module patch anywhere.
+
+    Pre-#1850 this fails: the service read wall-clock ``datetime.now()``, so
+    advancing the fake clock never expired the trigger.
+    """
+    clock = FakeClock(T0)
+    install_fake_time_service(monkeypatch, clock)
+
+    svc = TriggerService(dismissals_file=tmp_path / "trigger_dismissals.json")
+    svc.activate_trigger("stub_plugin", _result(duration=30))
+    clock.advance(29)
+    assert svc.get_active_trigger() is not None
+    clock.advance(2)
+    assert svc.get_active_trigger() is None, "trigger expiry must follow the app's TimeService clock"
+
+
+def test_suppression_lapse_honors_time_service_without_datetime_seam(monkeypatch, tmp_path):
+    """Suppression lapse also runs on the TimeService clock (same instance)."""
+    clock = FakeClock(T0)
+    install_fake_time_service(monkeypatch, clock)
+
+    svc = TriggerService(dismissals_file=tmp_path / "trigger_dismissals.json")
+    svc.activate_trigger("stub_plugin", _result(duration=60))
+    svc.dismiss_trigger("door-open", suppress=True)
+
+    svc.activate_trigger("stub_plugin", _result(duration=60))
+    assert svc.get_active_trigger() is None, "still inside the suppression window"
+
+    clock.advance(61)
+    svc.activate_trigger("stub_plugin", _result(duration=60))
+    assert svc.get_active_trigger() is not None

--- a/tests/test_trigger_dismissal_persistence.py
+++ b/tests/test_trigger_dismissal_persistence.py
@@ -175,3 +175,63 @@ def test_suppression_lapse_honors_time_service_without_datetime_seam(monkeypatch
     clock.advance(61)
     svc.activate_trigger("stub_plugin", _result(duration=60))
     assert svc.get_active_trigger() is not None
+
+
+def test_engine_prune_during_dismissal_save_neither_raises_nor_loses_the_write(monkeypatch, tmp_path):
+    """#1871 review: _save_dismissals built its snapshot of _suppressed_until
+    OUTSIDE the lock and outside the try — an engine-tick prune
+    (clear_expired) mutating the dict mid-comprehension raised RuntimeError
+    INTO the API caller, aborting the user's page change with a 500.
+
+    Event-sequenced repro: the snapshot's first item spawns the engine's
+    prune on another thread and gives it a beat to run. Unserialized, the
+    prune deletes a lapsed entry from the dict the snapshot is iterating
+    (RuntimeError escapes dismiss_trigger); serialized under the state lock,
+    the prune waits, the dismissal persists, and the prune lands after.
+    """
+    import threading
+
+    clock = FakeClock(T0)
+    install_fake_time_service(monkeypatch, clock)
+    store = tmp_path / "trigger_dismissals.json"
+    svc = TriggerService(dismissals_file=store)
+
+    # A lapsed suppression for the engine's prune to collect (inserted first,
+    # so the snapshot yields it before the hook fires)...
+    svc._suppressed_until["aa-lapsed"] = T0 - timedelta(seconds=1)
+    # ...and the trigger the user is dismissing.
+    svc.activate_trigger("stub_plugin", _result("zz-dismissed"))
+
+    prune_threads: list = []
+
+    class RacingSuppressions(dict):
+        """items() whose first snapshot fires a concurrent engine prune."""
+
+        fired = False
+
+        def items(self):
+            iterator = iter(dict.items(self))
+
+            def gen():
+                if not RacingSuppressions.fired and len(self) > 1:
+                    RacingSuppressions.fired = True
+                    yield next(iterator)
+                    prune = threading.Thread(target=svc.clear_expired)
+                    prune.start()
+                    prune_threads.append(prune)
+                    prune.join(timeout=0.2)  # unserialized: completes (mutating us); locked: still waiting
+                yield from iterator
+
+            return gen()
+
+    svc._suppressed_until = RacingSuppressions(svc._suppressed_until)
+
+    assert svc.dismiss_trigger("zz-dismissed", suppress=True) is True
+
+    for prune in prune_threads:
+        prune.join(timeout=5)
+        assert not prune.is_alive()
+
+    data = json.loads(store.read_text(encoding="utf-8"))
+    assert "zz-dismissed" in data["dismissals"], "the user's dismissal must be persisted, not lost to the race"
+    assert "aa-lapsed" not in svc._suppressed_until  # the prune still landed

--- a/tests/test_trigger_platform_plumbing.py
+++ b/tests/test_trigger_platform_plumbing.py
@@ -67,8 +67,16 @@ def _make_manifest(
 
 
 @pytest.fixture(autouse=True)
-def _reset_singleton():
-    """Each test runs with a clean TriggerService singleton."""
+def _reset_singleton(monkeypatch, tmp_path):
+    """Each test runs with a clean TriggerService singleton.
+
+    The dismissal store (#1850) is pointed at a temp dir so singleton-based
+    suppress-dismiss tests never touch the repo's real ``data/`` state.
+    """
+    monkeypatch.setattr(
+        "src.triggers.service._default_dismissals_file",
+        lambda: tmp_path / "trigger_dismissals.json",
+    )
     reset_trigger_service()
     yield
     reset_trigger_service()
@@ -311,8 +319,8 @@ class TestTriggerPriority:
         assert trigger.priority == 80
         assert int(trigger.priority) == 80
 
-    def test_higher_priority_wins_in_trigger_service(self):
-        svc = TriggerService()
+    def test_higher_priority_wins_in_trigger_service(self, tmp_path):
+        svc = TriggerService(dismissals_file=tmp_path / "trigger_dismissals.json")
         svc.activate_trigger(
             "p1",
             TriggerResult(

--- a/tests/test_trigger_render_path.py
+++ b/tests/test_trigger_render_path.py
@@ -94,9 +94,9 @@ class _FakeRegistry:
 
 
 @pytest.fixture
-def trigger_service():
+def trigger_service(tmp_path):
     """Fresh, isolated TriggerService for each test."""
-    return TriggerService()
+    return TriggerService(dismissals_file=tmp_path / "trigger_dismissals.json")
 
 
 @pytest.fixture


### PR DESCRIPTION
Part of #1850 (final Track B item); implements the #1767 disposition. Stacked on #1870 — the full Track B chain: #1856 → #1861 → #1862 → #1867 → #1868 → #1870 → this.

## What

The plugin trigger contract (`supports_triggers`, `check_triggers()`, `trigger_page_id`) is untouched — calendar-sub keeps working. Three gaps closed:

1. **Clock unification**: `TriggerService` ran on module-level naive `datetime.now()` — outside the app's clock discipline entirely (discovered building the harness, which had to patch it as a fifth clock seam). All trigger timing now goes through `get_time_service()`, aware-UTC throughout. **The fifth seam is deleted from the harness** — and the fail-first evidence proves it was load-bearing: with the seam removed pre-fix, golden scenario 7 diverged (the trigger never expired on wall clock); post-fix the golden is byte-identical with no seam.
2. **Persisted dismissals** — the one real restart loss: a dismissed trigger came back after restart. Suppressions now persist (`schema_version: 1`, atomic writes, pruned on load/write); semantics are exactly today's, just durable. The A-track merge adapter is a single documented seam (`_default_dismissals_file()` → `get_data_dir()` + JsonStore, no migration needed — the payload is already schema-versioned).
3. **Named engine stage**: the tick's trigger check is now a documented "trigger input" stage; verified `check_triggers()` reads plugin-cached data that #1862's fetch-union keeps fresh — no behavior change, now it's written down.

## Zero-regression evidence

- **Fail-first: 8 failures pre-fix** — 7 new tests (persistence, clock) plus the golden divergence above. Non-vacuity probe: disabling the write-through fails the restart-survival test behaviorally.
- `git diff tests/golden/` empty across both commits; equivalence suite (10 scenarios), send-worker, timing, silence, and trigger suites all green; full suite failure set identical to baseline. Trigger stores in tests are now tmp-isolated (no repo `data/` pollution). ruff clean.

One disclosed shape change: `ActiveTrigger.to_dict()["activated_at"]` now carries a `+00:00` offset (aware-UTC consistency); nothing pins the naive form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Par2E2Nh65PyDF1q9TARJP